### PR TITLE
sql/contention: introduce contention duration threshold cluster setting

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -86,6 +86,7 @@ server.web_session.purge.ttl	duration	1h0m0s	if nonzero, entries in system.web_s
 server.web_session_timeout	duration	168h0m0s	the duration that a newly created web session will be valid
 sql.auth.resolve_membership_single_scan.enabled	boolean	true	determines whether to populate the role membership cache with a single scan
 sql.contention.event_store.capacity	byte size	64 MiB	the in-memory storage capacity per-node of contention event store
+sql.contention.event_store.duration_threshold	duration	0s	minimum contention duration to cause the contention events to be collected into crdb_internal.transaction_contention_events
 sql.contention.txn_id_cache.max_size	byte size	0 B	the maximum byte size TxnID cache will use (set to 0 to disable)
 sql.cross_db_fks.enabled	boolean	false	if true, creating foreign key references across databases is allowed
 sql.cross_db_sequence_owners.enabled	boolean	false	if true, creating sequences owned by tables from other databases is allowed

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -100,6 +100,7 @@
 <tr><td><code>server.web_session_timeout</code></td><td>duration</td><td><code>168h0m0s</code></td><td>the duration that a newly created web session will be valid</td></tr>
 <tr><td><code>sql.auth.resolve_membership_single_scan.enabled</code></td><td>boolean</td><td><code>true</code></td><td>determines whether to populate the role membership cache with a single scan</td></tr>
 <tr><td><code>sql.contention.event_store.capacity</code></td><td>byte size</td><td><code>64 MiB</code></td><td>the in-memory storage capacity per-node of contention event store</td></tr>
+<tr><td><code>sql.contention.event_store.duration_threshold</code></td><td>duration</td><td><code>0s</code></td><td>minimum contention duration to cause the contention events to be collected into crdb_internal.transaction_contention_events</td></tr>
 <tr><td><code>sql.contention.txn_id_cache.max_size</code></td><td>byte size</td><td><code>0 B</code></td><td>the maximum byte size TxnID cache will use (set to 0 to disable)</td></tr>
 <tr><td><code>sql.cross_db_fks.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if true, creating foreign key references across databases is allowed</td></tr>
 <tr><td><code>sql.cross_db_sequence_owners.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if true, creating sequences owned by tables from other databases is allowed</td></tr>

--- a/pkg/sql/contention/cluster_settings.go
+++ b/pkg/sql/contention/cluster_settings.go
@@ -34,3 +34,14 @@ var StoreCapacity = settings.RegisterByteSizeSetting(
 	"the in-memory storage capacity per-node of contention event store",
 	64*1024*1024, // 64 MB per node.
 ).WithPublic()
+
+// DurationThreshold is the cluster setting for the threshold of
+// contention durations. Only the contention events whose duration exceeds the
+// threshold will be collected into crdb_internal.transaction_contention_events.
+var DurationThreshold = settings.RegisterDurationSetting(
+	settings.TenantWritable,
+	"sql.contention.event_store.duration_threshold",
+	"minimum contention duration to cause the contention events to be collected "+
+		"into crdb_internal.transaction_contention_events",
+	0,
+).WithPublic()


### PR DESCRIPTION
This introduces sql.contention.event_store.duration_threshold cluster
setting. This cluster setting specifies the minimum contention duration
to cause the contention events to be collected into
crdb_internal.transaction_contention_events virtual table. This cluster
setting has the default value of 0.

Release justification: low risk high reward changes
Release note (sql change): introduce
sql.contention.event_store.duration_threshold cluster setting. This
cluster setting specifies the minimum contention duration to cause
the contention events to be collected into
crdb_internal.transaction_contention_events virtual table.