### PR TITLE
release-21.1: sql: scan the system.role_members table using a single scan

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -65,6 +65,7 @@ server.shutdown.query_wait	duration	10s	the server will wait for at least this a
 server.time_until_store_dead	duration	5m0s	the time after which if there is no new gossiped information about a store, it is considered dead
 server.user_login.timeout	duration	10s	timeout after which client authentication times out if some system range is unavailable (0 = no timeout)
 server.web_session_timeout	duration	168h0m0s	the duration that a newly created web session will be valid
+sql.auth.resolve_membership_single_scan.enabled	boolean	false	determines whether to populate the role membership cache with a single scan
 sql.cross_db_fks.enabled	boolean	false	if true, creating foreign key references across databases is allowed
 sql.cross_db_sequence_owners.enabled	boolean	false	if true, creating sequences owned by tables from other databases is allowed
 sql.cross_db_views.enabled	boolean	false	if true, creating views that refer to other databases is allowed

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -67,6 +67,7 @@
 <tr><td><code>server.time_until_store_dead</code></td><td>duration</td><td><code>5m0s</code></td><td>the time after which if there is no new gossiped information about a store, it is considered dead</td></tr>
 <tr><td><code>server.user_login.timeout</code></td><td>duration</td><td><code>10s</code></td><td>timeout after which client authentication times out if some system range is unavailable (0 = no timeout)</td></tr>
 <tr><td><code>server.web_session_timeout</code></td><td>duration</td><td><code>168h0m0s</code></td><td>the duration that a newly created web session will be valid</td></tr>
+<tr><td><code>sql.auth.resolve_membership_single_scan.enabled</code></td><td>boolean</td><td><code>false</code></td><td>determines whether to populate the role membership cache with a single scan</td></tr>
 <tr><td><code>sql.cross_db_fks.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if true, creating foreign key references across databases is allowed</td></tr>
 <tr><td><code>sql.cross_db_sequence_owners.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if true, creating sequences owned by tables from other databases is allowed</td></tr>
 <tr><td><code>sql.cross_db_views.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if true, creating views that refer to other databases is allowed</td></tr>

--- a/pkg/bench/ddl_analysis/testdata/benchmark_expectations
+++ b/pkg/bench/ddl_analysis/testdata/benchmark_expectations
@@ -50,8 +50,8 @@ exp,benchmark
 24,Grant/grant_all_on_1_table
 30,Grant/grant_all_on_2_tables
 36,Grant/grant_all_on_3_tables
-21,GrantRole/grant_1_role
-24,GrantRole/grant_2_roles
+17,GrantRole/grant_1_role
+19,GrantRole/grant_2_roles
 2,ORMQueries/activerecord_type_introspection_query
 2,ORMQueries/django_table_introspection_1_table
 2,ORMQueries/django_table_introspection_4_tables
@@ -63,8 +63,8 @@ exp,benchmark
 24,Revoke/revoke_all_on_1_table
 30,Revoke/revoke_all_on_2_tables
 36,Revoke/revoke_all_on_3_tables
-20,RevokeRole/revoke_1_role
-22,RevokeRole/revoke_2_roles
+17,RevokeRole/revoke_1_role
+19,RevokeRole/revoke_2_roles
 1,SystemDatabaseQueries/select_system.users_with_empty_database_name
 1,SystemDatabaseQueries/select_system.users_with_schema_name
 2,SystemDatabaseQueries/select_system.users_without_schema_name

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -522,7 +522,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		VirtualSchemas:          virtualSchemas,
 		HistogramWindowInterval: cfg.HistogramWindowInterval(),
 		RangeDescriptorCache:    cfg.distSender.RangeDescriptorCache(),
-		RoleMemberCache:         &sql.MembershipCache{},
+		RoleMemberCache:         sql.NewMembershipCache(cfg.stopper),
 		RootMemoryMonitor:       rootSQLMemoryMonitor,
 		TestingKnobs:            sqlExecutorTestingKnobs,
 

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -380,6 +380,7 @@ go_library(
         "//pkg/util/sequence",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
+        "//pkg/util/syncutil/singleflight",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
         "//pkg/util/tracing/tracingpb",

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -31,7 +31,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil/singleflight"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/logtags"
 )
 
 // MembershipCache is a shared cache for role membership information.
@@ -40,6 +44,17 @@ type MembershipCache struct {
 	tableVersion descpb.DescriptorVersion
 	// userCache is a mapping from username to userRoleMembership.
 	userCache map[security.SQLUsername]userRoleMembership
+	// populateCacheGroup ensures that there is at most one request in-flight
+	// for each key.
+	populateCacheGroup singleflight.Group
+	stopper            *stop.Stopper
+}
+
+// NewMembershipCache initializes a new MembershipCache.
+func NewMembershipCache(stopper *stop.Stopper) *MembershipCache {
+	return &MembershipCache{
+		stopper: stopper,
+	}
 }
 
 // userRoleMembership is a mapping of "rolename" -> "with admin option".
@@ -347,12 +362,33 @@ func (p *planner) MemberOfWithAdminOption(
 			return userMapping, nil
 		}
 
-		// Lookup memberships outside the lock.
-		memberships, err := p.resolveMemberOfWithAdminOption(
-			ctx, member, nil, /* txn */
-			useSingleQueryForRoleMembershipCache.Get(p.ExecCfg().SV()))
-		if err != nil {
-			return nil, err
+		// Lookup memberships outside the lock, with at most one request in-flight
+		// for each user The role_memberships table versions is also part
+		// of the request key so that we don't read data from an old version
+		// of the table.
+		ch, _ := roleMembersCache.populateCacheGroup.DoChan(
+			fmt.Sprintf("%s-%d", member.Normalized(), tableVersion),
+			func() (interface{}, error) {
+				// Use a different context to fetch, so that it isn't possible for
+				// one query to timeout and cause all the goroutines that are waiting
+				// to get a timeout error.
+				loadCtx, cancel := roleMembersCache.stopper.WithCancelOnQuiesce(
+					logtags.WithTags(context.Background(), logtags.FromContext(ctx)))
+				defer cancel()
+				return p.resolveMemberOfWithAdminOption(
+					loadCtx, member, nil, /* txn */
+					useSingleQueryForRoleMembershipCache.Get(p.ExecCfg().SV()))
+			},
+		)
+		var memberships map[security.SQLUsername]bool
+		select {
+		case res := <-ch:
+			if res.Err != nil {
+				return nil, res.Err
+			}
+			memberships = res.Val.(map[security.SQLUsername]bool)
+		case <-ctx.Done():
+			return nil, ctx.Err()
 		}
 
 		// Update membership.

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -29,7 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/roleoption"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/errors"
 )
 
@@ -320,7 +321,10 @@ func (p *planner) MemberOfWithAdminOption(
 	}
 	tableVersion := tableDesc.GetVersion()
 	if tableDesc.IsUncommittedVersion() {
-		return p.resolveMemberOfWithAdminOption(ctx, member, p.txn)
+		return p.resolveMemberOfWithAdminOption(
+			ctx, member, p.txn,
+			useSingleQueryForRoleMembershipCache.Get(p.ExecCfg().SV()),
+		)
 	}
 
 	// We loop in case the table version changes while we're looking up memberships.
@@ -344,7 +348,9 @@ func (p *planner) MemberOfWithAdminOption(
 		}
 
 		// Lookup memberships outside the lock.
-		memberships, err := p.resolveMemberOfWithAdminOption(ctx, member, nil /* txn */)
+		memberships, err := p.resolveMemberOfWithAdminOption(
+			ctx, member, nil, /* txn */
+			useSingleQueryForRoleMembershipCache.Get(p.ExecCfg().SV()))
 		if err != nil {
 			return nil, err
 		}
@@ -365,14 +371,56 @@ func (p *planner) MemberOfWithAdminOption(
 	}
 }
 
+var defaultSingleQueryForRoleMembershipCache = util.ConstantWithMetamorphicTestBool(
+	"resolve-membership-single-scan-enabled",
+	false, /* defaultValue */
+)
+
+var useSingleQueryForRoleMembershipCache = settings.RegisterBoolSetting(
+	"sql.auth.resolve_membership_single_scan.enabled",
+	"determines whether to populate the role membership cache with a single scan",
+	defaultSingleQueryForRoleMembershipCache,
+).WithPublic()
+
 // resolveMemberOfWithAdminOption performs the actual recursive role membership lookup.
 // TODO(mberhault): this is the naive way and performs a full lookup for each user,
 // we could save detailed memberships (as opposed to fully expanded) and reuse them
 // across users. We may then want to lookup more than just this user.
 func (p *planner) resolveMemberOfWithAdminOption(
-	ctx context.Context, member security.SQLUsername, txn *kv.Txn,
+	ctx context.Context, member security.SQLUsername, txn *kv.Txn, singleQuery bool,
 ) (map[security.SQLUsername]bool, error) {
 	ret := map[security.SQLUsername]bool{}
+	if singleQuery {
+		type membership struct {
+			role    security.SQLUsername
+			isAdmin bool
+		}
+		memberToRoles := make(map[security.SQLUsername][]membership)
+		if err := forEachRoleMembership(ctx, p.ExecCfg().InternalExecutor, txn,
+			func(role, member security.SQLUsername, isAdmin bool) error {
+				memberToRoles[member] = append(memberToRoles[member], membership{role, isAdmin})
+				return nil
+			}); err != nil {
+			return nil, err
+		}
+
+		// Recurse through all roles associated with the member.
+		var recurse func(u security.SQLUsername)
+		recurse = func(u security.SQLUsername) {
+			for _, membership := range memberToRoles[u] {
+				// If the parent role was seen before, we still might need to update
+				// the isAdmin flag for that role, but there's no need to recurse
+				// through the role's ancestry again.
+				prev, alreadySeen := ret[membership.role]
+				ret[membership.role] = prev || membership.isAdmin
+				if !alreadySeen {
+					recurse(membership.role)
+				}
+			}
+		}
+		recurse(member)
+		return ret, nil
+	}
 
 	// Keep track of members we looked up.
 	visited := map[security.SQLUsername]struct{}{}

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -20,6 +20,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/cockroachdb/cockroach/pkg/docs"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
@@ -32,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/vtable"
 	"github.com/cockroachdb/errors"
@@ -2258,12 +2260,13 @@ FROM
 }
 
 func forEachRoleMembership(
-	ctx context.Context, p *planner, fn func(role, member security.SQLUsername, isAdmin bool) error,
+	ctx context.Context,
+	ie sqlutil.InternalExecutor,
+	txn *kv.Txn,
+	fn func(role, member security.SQLUsername, isAdmin bool) error,
 ) (retErr error) {
-	query := `SELECT "role", "member", "isAdmin" FROM system.role_members`
-	it, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryIterator(
-		ctx, "read-members", p.txn, query,
-	)
+	const query = `SELECT "role", "member", "isAdmin" FROM system.role_members`
+	it, err := ie.QueryIterator(ctx, "read-members", txn, query)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -181,17 +181,32 @@ user root
 statement ok
 GRANT testrole TO testuser WITH ADMIN OPTION
 
+statement ok
+CREATE ROLE child_role;
+GRANT testrole to child_role;
+GRANT testuser TO child_role;
+
 query TTB colnames
 SELECT * FROM system.role_members
 ----
-role      member    isAdmin
-admin     root      true
-testrole  testuser  true
-
-user testuser
+role      member      isAdmin
+admin     root        true
+testrole  child_role  false
+testrole  testuser    true
+testuser  child_role  false
 
 statement ok
+SET ROLE child_role
+
+# ADMIN OPTION should be inherited, so this should succeed.
+statement ok
 GRANT testrole TO testuser2 WITH ADMIN OPTION
+
+statement ok
+RESET ROLE;
+DROP ROLE child_role
+
+user testuser
 
 query TTT colnames,rowsort
 SELECT * FROM information_schema.administrable_role_authorizations

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -181,32 +181,18 @@ user root
 statement ok
 GRANT testrole TO testuser WITH ADMIN OPTION
 
-statement ok
-CREATE ROLE child_role;
-GRANT testrole to child_role;
-GRANT testuser TO child_role;
-
 query TTB colnames
 SELECT * FROM system.role_members
 ----
-role      member      isAdmin
-admin     root        true
-testrole  child_role  false
-testrole  testuser    true
-testuser  child_role  false
+role      member    isAdmin
+admin     root      true
+testrole  testuser  true
 
-statement ok
-SET ROLE child_role
-
-# ADMIN OPTION should be inherited, so this should succeed.
-statement ok
-GRANT testrole TO testuser2 WITH ADMIN OPTION
-
-statement ok
-RESET ROLE;
-DROP ROLE child_role
 
 user testuser
+
+statement ok
+GRANT testrole TO testuser2 WITH ADMIN OPTION
 
 query TTT colnames,rowsort
 SELECT * FROM information_schema.administrable_role_authorizations

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -552,7 +552,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-auth-members.html`,
 	schema: vtable.PGCatalogAuthMembers,
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
-		return forEachRoleMembership(ctx, p,
+		return forEachRoleMembership(ctx, p.ExecCfg().InternalExecutor, p.Txn(),
 			func(roleName, memberName security.SQLUsername, isAdmin bool) error {
 				return addRow(
 					h.UserOid(roleName),                 // roleid

--- a/pkg/sql/user_test.go
+++ b/pkg/sql/user_test.go
@@ -50,128 +50,137 @@ func TestGetUserHashedPasswordTimeout(t *testing.T) {
 	// race builds are so slow as to trigger this timeout spuriously.
 	skip.UnderRace(t)
 
-	ctx := context.Background()
+	testutils.RunTrueAndFalse(t, "TestGetUserTimeout/single_scan", func(t *testing.T, singleScanEnabled bool) {
 
-	// unavailableCh is used by the replica command filter
-	// to conditionally block requests and simulate unavailability.
-	var unavailableCh atomic.Value
-	closedCh := make(chan struct{})
-	close(closedCh)
-	unavailableCh.Store(closedCh)
-	knobs := &kvserver.StoreTestingKnobs{
-		TestingRequestFilter: func(ctx context.Context, _ roachpb.BatchRequest) *roachpb.Error {
-			select {
-			case <-unavailableCh.Load().(chan struct{}):
-			case <-ctx.Done():
-			}
-			return nil
-		},
-	}
-	params := base.TestServerArgs{Knobs: base.TestingKnobs{Store: knobs}}
-	s, db, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop(ctx)
+		ctx := context.Background()
 
-	// Make a user that must use a password to authenticate.
-	// Default privileges on defaultdb are needed to run simple queries.
-	if _, err := db.Exec(`
+		// unavailableCh is used by the replica command filter
+		// to conditionally block requests and simulate unavailability.
+		var unavailableCh atomic.Value
+		closedCh := make(chan struct{})
+		close(closedCh)
+		unavailableCh.Store(closedCh)
+		knobs := &kvserver.StoreTestingKnobs{
+			TestingRequestFilter: func(ctx context.Context, _ roachpb.BatchRequest) *roachpb.Error {
+				select {
+				case <-unavailableCh.Load().(chan struct{}):
+				case <-ctx.Done():
+				}
+				return nil
+			},
+		}
+		params := base.TestServerArgs{Knobs: base.TestingKnobs{Store: knobs}}
+		s, db, _ := serverutils.StartServer(t, params)
+		defer s.Stopper().Stop(ctx)
+
+		// Make a user that must use a password to authenticate.
+		// Default privileges on defaultdb are needed to run simple queries.
+		if _, err := db.Exec(`
 CREATE USER foo WITH PASSWORD 'testabc';
 GRANT ALL ON DATABASE defaultdb TO foo`); err != nil {
-		t.Fatal(err)
-	}
+			t.Fatal(err)
+		}
 
-	// We'll attempt connections on gateway node 0.
-	userURL, cleanupFn := sqlutils.PGUrlWithOptionalClientCerts(t,
-		s.ServingSQLAddr(), t.Name(), url.UserPassword("foo", "testabc"), false /* withClientCerts */)
-	defer cleanupFn()
-	rootURL, rootCleanupFn := sqlutils.PGUrl(t,
-		s.ServingSQLAddr(), t.Name(), url.User(security.RootUser))
-	defer rootCleanupFn()
+		if _, err := db.Exec(
+			`SET CLUSTER SETTING sql.auth.resolve_membership_single_scan.enabled = $1`, singleScanEnabled,
+		); err != nil {
+			t.Fatal(err)
+		}
 
-	// Override the timeout built into pgx so we are only subject to
-	// what the server thinks.
-	userURL.RawQuery += "&connect_timeout=0"
-	rootURL.RawQuery += "&connect_timeout=0"
+		// We'll attempt connections on gateway node 0.
+		userURL, cleanupFn := sqlutils.PGUrlWithOptionalClientCerts(t,
+			s.ServingSQLAddr(), t.Name(), url.UserPassword("foo", "testabc"), false /* withClientCerts */)
+		defer cleanupFn()
+		rootURL, rootCleanupFn := sqlutils.PGUrl(t,
+			s.ServingSQLAddr(), t.Name(), url.User(security.RootUser))
+		defer rootCleanupFn()
 
-	fmt.Fprintln(os.Stderr, "-- sanity checks --")
+		// Override the timeout built into pgx so we are only subject to
+		// what the server thinks.
+		userURL.RawQuery += "&connect_timeout=0"
+		rootURL.RawQuery += "&connect_timeout=0"
 
-	// We use a closure here and below to ensure the defers are run
-	// before the rest of the test.
+		fmt.Fprintln(os.Stderr, "-- sanity checks --")
 
-	func() {
-		// Sanity check: verify that secure mode is enabled: password is
-		// required. If this part fails, this means the test cluster is
-		// not properly configured, and the remainder of the test below
-		// would report false positives.
-		unauthURL := userURL
-		unauthURL.User = url.User("foo")
-		dbSQL, err := pgxConn(t, unauthURL)
-		if err == nil {
+		// We use a closure here and below to ensure the defers are run
+		// before the rest of the test.
+
+		func() {
+			// Sanity check: verify that secure mode is enabled: password is
+			// required. If this part fails, this means the test cluster is
+			// not properly configured, and the remainder of the test below
+			// would report false positives.
+			unauthURL := userURL
+			unauthURL.User = url.User("foo")
+			dbSQL, err := pgxConn(t, unauthURL)
+			if err == nil {
+				defer func() { _ = dbSQL.Close() }()
+			}
+			if !testutils.IsError(err, "password authentication failed for user foo") {
+				t.Fatalf("expected password error, got %v", err)
+			}
+		}()
+
+		func() {
+			// Sanity check: verify that the new user is able to log in with password.
+			dbSQL, err := pgxConn(t, userURL)
+			if err != nil {
+				t.Fatal(err)
+			}
 			defer func() { _ = dbSQL.Close() }()
-		}
-		if !testutils.IsError(err, "password authentication failed for user foo") {
-			t.Fatalf("expected password error, got %v", err)
-		}
-	}()
+			row := dbSQL.QueryRow("SELECT current_user")
+			var username string
+			if err := row.Scan(&username); err != nil {
+				t.Fatal(err)
+			}
+			if username != "foo" {
+				t.Fatalf("invalid username: expected foo, got %q", username)
+			}
+		}()
 
-	func() {
-		// Sanity check: verify that the new user is able to log in with password.
-		dbSQL, err := pgxConn(t, userURL)
-		if err != nil {
+		// Configure the login timeout to just 1s.
+		if _, err := db.Exec(`SET CLUSTER SETTING server.user_login.timeout = '200ms'`); err != nil {
 			t.Fatal(err)
 		}
-		defer func() { _ = dbSQL.Close() }()
-		row := dbSQL.QueryRow("SELECT current_user")
-		var username string
-		if err := row.Scan(&username); err != nil {
-			t.Fatal(err)
-		}
-		if username != "foo" {
-			t.Fatalf("invalid username: expected foo, got %q", username)
-		}
-	}()
 
-	// Configure the login timeout to just 1s.
-	if _, err := db.Exec(`SET CLUSTER SETTING server.user_login.timeout = '200ms'`); err != nil {
-		t.Fatal(err)
-	}
+		fmt.Fprintln(os.Stderr, "-- make ranges unavailable --")
 
-	fmt.Fprintln(os.Stderr, "-- make ranges unavailable --")
+		ch := make(chan struct{})
+		unavailableCh.Store(ch)
+		defer close(ch)
 
-	ch := make(chan struct{})
-	unavailableCh.Store(ch)
-	defer close(ch)
+		fmt.Fprintln(os.Stderr, "-- expect timeout --")
 
-	fmt.Fprintln(os.Stderr, "-- expect timeout --")
+		func() {
+			// Now attempt to connect again. We're expecting a timeout within 5 seconds.
+			start := timeutil.Now()
+			dbSQL, err := pgxConn(t, userURL)
+			if err == nil {
+				defer func() { _ = dbSQL.Close() }()
+			}
+			if !testutils.IsError(err, "internal error while retrieving user account") {
+				t.Fatalf("expected error during connection, got %v", err)
+			}
+			timeoutDur := timeutil.Now().Sub(start)
+			if timeoutDur > 5*time.Second {
+				t.Fatalf("timeout lasted for more than 5 second (%s)", timeoutDur)
+			}
+		}()
 
-	func() {
-		// Now attempt to connect again. We're expecting a timeout within 5 seconds.
-		start := timeutil.Now()
-		dbSQL, err := pgxConn(t, userURL)
-		if err == nil {
+		fmt.Fprintln(os.Stderr, "-- no timeout for root --")
+
+		func() {
+			dbSQL, err := pgxConn(t, rootURL)
+			if err != nil {
+				t.Fatal(err)
+			}
 			defer func() { _ = dbSQL.Close() }()
-		}
-		if !testutils.IsError(err, "internal error while retrieving user account") {
-			t.Fatalf("expected error during connection, got %v", err)
-		}
-		timeoutDur := timeutil.Now().Sub(start)
-		if timeoutDur > 5*time.Second {
-			t.Fatalf("timeout lasted for more than 5 second (%s)", timeoutDur)
-		}
-	}()
-
-	fmt.Fprintln(os.Stderr, "-- no timeout for root --")
-
-	func() {
-		dbSQL, err := pgxConn(t, rootURL)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer func() { _ = dbSQL.Close() }()
-		// A simple query must work for 'root' even without a system range available.
-		if _, err := dbSQL.Exec("SELECT 1"); err != nil {
-			t.Fatal(err)
-		}
-	}()
+			// A simple query must work for 'root' even without a system range available.
+			if _, err := dbSQL.Exec("SELECT 1"); err != nil {
+				t.Fatal(err)
+			}
+		}()
+	})
 }
 
 func pgxConn(t *testing.T, connURL url.URL) (*pgx.Conn, error) {

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -34,6 +34,7 @@ var metamorphicBuild bool
 const (
 	metamorphicBuildProbability = 0.8
 	metamorphicValueProbability = 0.75
+	metamorphicBoolProbability  = 0.5
 )
 
 // ConstantWithMetamorphicTestValue should be used to initialize "magic
@@ -110,6 +111,21 @@ func ConstantWithMetamorphicTestRange(name string, defaultValue, min, max int) i
 	return defaultValue
 }
 
-func logMetamorphicValue(name string, value int) {
+// ConstantWithMetamorphicTestBool is like ConstantWithMetamorphicTestValue except
+// it returns the non-default value half of the time (if running a metamorphic build).
+//
+// The given name is used for logging.
+func ConstantWithMetamorphicTestBool(name string, defaultValue bool) bool {
+	if metamorphicBuild {
+		if rng.Float64() < metamorphicBoolProbability {
+			ret := !defaultValue
+			logMetamorphicValue(name, ret)
+			return ret
+		}
+	}
+	return defaultValue
+}
+
+func logMetamorphicValue(name string, value interface{}) {
 	fmt.Fprintf(os.Stderr, "initialized metamorphic constant %q with value %d\n", name, value)
 }


### PR DESCRIPTION
Backport 2/3 commits from #77359.

/cc @cockroachdb/release

An important difference in this backport is that the new cluster setting is
off by default.

---

relates to support case https://github.com/cockroachlabs/support/issues/1463
fixes https://github.com/cockroachdb/cockroach/issues/77452

### sql: use singleflight for role membership lookups

This helps prevent a thundering herd when this cache gets invalidated.

### sql: scan the system.role_members table using a single scan


Release note (sql change): Added a
`sql.auth.resolve_membership_single_scan.enabled` cluster setting, which
changes the query for an internal role membership cache. Previously the
code would recursively look up each role in the membership hierarchy,
leading to multiple queries. With the setting on, it uses a single
query. The setting is **false** by default.

Release justification: high priority bug fix 
