### PR TITLE
sql: re-enable txnidcache by default

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -87,7 +87,7 @@ server.web_session_timeout	duration	168h0m0s	the duration that a newly created w
 sql.auth.resolve_membership_single_scan.enabled	boolean	true	determines whether to populate the role membership cache with a single scan
 sql.contention.event_store.capacity	byte size	64 MiB	the in-memory storage capacity per-node of contention event store
 sql.contention.event_store.duration_threshold	duration	0s	minimum contention duration to cause the contention events to be collected into crdb_internal.transaction_contention_events
-sql.contention.txn_id_cache.max_size	byte size	0 B	the maximum byte size TxnID cache will use (set to 0 to disable)
+sql.contention.txn_id_cache.max_size	byte size	64 MiB	the maximum byte size TxnID cache will use (set to 0 to disable)
 sql.cross_db_fks.enabled	boolean	false	if true, creating foreign key references across databases is allowed
 sql.cross_db_sequence_owners.enabled	boolean	false	if true, creating sequences owned by tables from other databases is allowed
 sql.cross_db_sequence_references.enabled	boolean	false	if true, sequences referenced by tables from other databases are allowed

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -101,7 +101,7 @@
 <tr><td><code>sql.auth.resolve_membership_single_scan.enabled</code></td><td>boolean</td><td><code>true</code></td><td>determines whether to populate the role membership cache with a single scan</td></tr>
 <tr><td><code>sql.contention.event_store.capacity</code></td><td>byte size</td><td><code>64 MiB</code></td><td>the in-memory storage capacity per-node of contention event store</td></tr>
 <tr><td><code>sql.contention.event_store.duration_threshold</code></td><td>duration</td><td><code>0s</code></td><td>minimum contention duration to cause the contention events to be collected into crdb_internal.transaction_contention_events</td></tr>
-<tr><td><code>sql.contention.txn_id_cache.max_size</code></td><td>byte size</td><td><code>0 B</code></td><td>the maximum byte size TxnID cache will use (set to 0 to disable)</td></tr>
+<tr><td><code>sql.contention.txn_id_cache.max_size</code></td><td>byte size</td><td><code>64 MiB</code></td><td>the maximum byte size TxnID cache will use (set to 0 to disable)</td></tr>
 <tr><td><code>sql.cross_db_fks.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if true, creating foreign key references across databases is allowed</td></tr>
 <tr><td><code>sql.cross_db_sequence_owners.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if true, creating sequences owned by tables from other databases is allowed</td></tr>
 <tr><td><code>sql.cross_db_sequence_references.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if true, sequences referenced by tables from other databases are allowed</td></tr>

--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -57,15 +57,6 @@ func TestTenantStatusAPI(t *testing.T) {
 	testHelper := newTestTenantHelper(t, 3 /* tenantClusterSize */, knobs)
 	defer testHelper.cleanup(ctx, t)
 
-	for _, conn := range []*sqlutils.SQLRunner{
-		sqlutils.MakeSQLRunner(testHelper.hostCluster.ServerConn(0)),
-		testHelper.testCluster().tenantConn(0),
-	} {
-		conn.Exec(
-			t, "SET CLUSTER SETTING sql.contention.txn_id_cache.max_size = '10MB'",
-		)
-	}
-
 	t.Run("reset_sql_stats", func(t *testing.T) {
 		testResetSQLStatsRPCForTenant(ctx, t, testHelper)
 	})

--- a/pkg/sql/contention/txnidcache/cluster_settings.go
+++ b/pkg/sql/contention/txnidcache/cluster_settings.go
@@ -17,6 +17,5 @@ var MaxSize = settings.RegisterByteSizeSetting(
 	settings.TenantWritable,
 	`sql.contention.txn_id_cache.max_size`,
 	"the maximum byte size TxnID cache will use (set to 0 to disable)",
-	// See https://github.com/cockroachdb/cockroach/issues/76738.
-	0,
+	64*1024*1024, // 64MiB
 ).WithPublic()


### PR DESCRIPTION
Previously, TxnID cache was disabled by default due to performance
issues. This has since been resolved in #77220.
This commit re-enables TxnID Cache by default.

Release justification: low risk high reward change.
Release note: None