### PR TITLE
release-21.2: sql: scan the system.role_members table using a single scan

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -74,6 +74,7 @@ server.web_session.purge.max_deletions_per_cycle	integer	10	the maximum number o
 server.web_session.purge.period	duration	1h0m0s	the time until old sessions are deleted
 server.web_session.purge.ttl	duration	1h0m0s	if nonzero, entries in system.web_sessions older than this duration are periodically purged
 server.web_session_timeout	duration	168h0m0s	the duration that a newly created web session will be valid
+sql.auth.resolve_membership_single_scan.enabled	boolean	false	determines whether to populate the role membership cache with a single scan
 sql.cross_db_fks.enabled	boolean	false	if true, creating foreign key references across databases is allowed
 sql.cross_db_sequence_owners.enabled	boolean	false	if true, creating sequences owned by tables from other databases is allowed
 sql.cross_db_views.enabled	boolean	false	if true, creating views that refer to other databases is allowed

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -79,6 +79,7 @@
 <tr><td><code>server.web_session.purge.period</code></td><td>duration</td><td><code>1h0m0s</code></td><td>the time until old sessions are deleted</td></tr>
 <tr><td><code>server.web_session.purge.ttl</code></td><td>duration</td><td><code>1h0m0s</code></td><td>if nonzero, entries in system.web_sessions older than this duration are periodically purged</td></tr>
 <tr><td><code>server.web_session_timeout</code></td><td>duration</td><td><code>168h0m0s</code></td><td>the duration that a newly created web session will be valid</td></tr>
+<tr><td><code>sql.auth.resolve_membership_single_scan.enabled</code></td><td>boolean</td><td><code>false</code></td><td>determines whether to populate the role membership cache with a single scan</td></tr>
 <tr><td><code>sql.cross_db_fks.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if true, creating foreign key references across databases is allowed</td></tr>
 <tr><td><code>sql.cross_db_sequence_owners.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if true, creating sequences owned by tables from other databases is allowed</td></tr>
 <tr><td><code>sql.cross_db_views.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if true, creating views that refer to other databases is allowed</td></tr>

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -1,7 +1,7 @@
 exp,benchmark
-15,AlterRole/alter_role_with_1_option
-16,AlterRole/alter_role_with_2_options
-21,AlterRole/alter_role_with_3_options
+14,AlterRole/alter_role_with_1_option
+15,AlterRole/alter_role_with_2_options
+20,AlterRole/alter_role_with_3_options
 15,AlterTableAddCheckConstraint/alter_table_add_1_check_constraint
 15,AlterTableAddCheckConstraint/alter_table_add_2_check_constraints
 15,AlterTableAddCheckConstraint/alter_table_add_3_check_constraints

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -50,8 +50,8 @@ exp,benchmark
 16,Grant/grant_all_on_1_table
 18,Grant/grant_all_on_2_tables
 20,Grant/grant_all_on_3_tables
-17,GrantRole/grant_1_role
-20,GrantRole/grant_2_roles
+13,GrantRole/grant_1_role
+15,GrantRole/grant_2_roles
 2,ORMQueries/activerecord_type_introspection_query
 2,ORMQueries/django_table_introspection_1_table
 2,ORMQueries/django_table_introspection_4_tables
@@ -72,8 +72,8 @@ exp,benchmark
 16,Revoke/revoke_all_on_1_table
 18,Revoke/revoke_all_on_2_tables
 20,Revoke/revoke_all_on_3_tables
-16,RevokeRole/revoke_1_role
-18,RevokeRole/revoke_2_roles
+13,RevokeRole/revoke_1_role
+15,RevokeRole/revoke_2_roles
 1,SystemDatabaseQueries/select_system.users_with_empty_database_Name
 1,SystemDatabaseQueries/select_system.users_with_schema_Name
 2,SystemDatabaseQueries/select_system.users_without_schema_Name

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -642,7 +642,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		VirtualSchemas:          virtualSchemas,
 		HistogramWindowInterval: cfg.HistogramWindowInterval(),
 		RangeDescriptorCache:    cfg.distSender.RangeDescriptorCache(),
-		RoleMemberCache:         sql.NewMembershipCache(serverCacheMemoryMonitor.MakeBoundAccount()),
+		RoleMemberCache:         sql.NewMembershipCache(serverCacheMemoryMonitor.MakeBoundAccount(), cfg.stopper),
 		SessionInitCache:        sessioninit.NewCache(serverCacheMemoryMonitor.MakeBoundAccount()),
 		RootMemoryMonitor:       rootSQLMemoryMonitor,
 		TestingKnobs:            sqlExecutorTestingKnobs,

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -401,6 +401,7 @@ go_library(
         "//pkg/util/ring",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
+        "//pkg/util/syncutil/singleflight",
         "//pkg/util/timeutil",
         "//pkg/util/timeutil/pgdate",
         "//pkg/util/tracing",

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -37,8 +37,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil/singleflight"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/logtags"
 )
 
 // MembershipCache is a shared cache for role membership information.
@@ -48,12 +51,17 @@ type MembershipCache struct {
 	boundAccount mon.BoundAccount
 	// userCache is a mapping from username to userRoleMembership.
 	userCache map[security.SQLUsername]userRoleMembership
+	// populateCacheGroup ensures that there is at most one request in-flight
+	// for each key.
+	populateCacheGroup singleflight.Group
+	stopper            *stop.Stopper
 }
 
 // NewMembershipCache initializes a new MembershipCache.
-func NewMembershipCache(account mon.BoundAccount) *MembershipCache {
+func NewMembershipCache(account mon.BoundAccount, stopper *stop.Stopper) *MembershipCache {
 	return &MembershipCache{
 		boundAccount: account,
+		stopper:      stopper,
 	}
 }
 
@@ -383,10 +391,31 @@ func MemberOfWithAdminOption(
 			return userMapping, nil
 		}
 
-		// Lookup memberships outside the lock.
-		memberships, err := resolveMemberOfWithAdminOption(ctx, member, ie, txn, useSingleQueryForRoleMembershipCache.Get(execCfg.SV()))
-		if err != nil {
-			return nil, err
+		// Lookup memberships outside the lock, with at most one request in-flight
+		// for each user The role_memberships table versions is also part
+		// of the request key so that we don't read data from an old version
+		// of the table.
+		ch, _ := roleMembersCache.populateCacheGroup.DoChan(
+			fmt.Sprintf("%s-%d", member.Normalized(), tableVersion),
+			func() (interface{}, error) {
+				// Use a different context to fetch, so that it isn't possible for
+				// one query to timeout and cause all the goroutines that are waiting
+				// to get a timeout error.
+				loadCtx, cancel := roleMembersCache.stopper.WithCancelOnQuiesce(
+					logtags.WithTags(context.Background(), logtags.FromContext(ctx)))
+				defer cancel()
+				return resolveMemberOfWithAdminOption(loadCtx, member, ie, txn, useSingleQueryForRoleMembershipCache.Get(execCfg.SV()))
+			},
+		)
+		var memberships map[security.SQLUsername]bool
+		select {
+		case res := <-ch:
+			if res.Err != nil {
+				return nil, res.Err
+			}
+			memberships = res.Val.(map[security.SQLUsername]bool)
+		case <-ctx.Done():
+			return nil, ctx.Err()
 		}
 
 		finishedLoop := func() bool {

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -33,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessioninit"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -355,7 +357,7 @@ func MemberOfWithAdminOption(
 
 	tableVersion := tableDesc.GetVersion()
 	if tableDesc.IsUncommittedVersion() {
-		return resolveMemberOfWithAdminOption(ctx, member, ie, txn)
+		return resolveMemberOfWithAdminOption(ctx, member, ie, txn, useSingleQueryForRoleMembershipCache.Get(execCfg.SV()))
 	}
 
 	// We loop in case the table version changes while we're looking up memberships.
@@ -382,7 +384,7 @@ func MemberOfWithAdminOption(
 		}
 
 		// Lookup memberships outside the lock.
-		memberships, err := resolveMemberOfWithAdminOption(ctx, member, ie, txn)
+		memberships, err := resolveMemberOfWithAdminOption(ctx, member, ie, txn, useSingleQueryForRoleMembershipCache.Get(execCfg.SV()))
 		if err != nil {
 			return nil, err
 		}
@@ -405,7 +407,7 @@ func MemberOfWithAdminOption(
 			}
 			if err := roleMembersCache.boundAccount.Grow(ctx, sizeOfEntry); err != nil {
 				// If there is no memory available to cache the entry, we can still
-				// proceed so that the query has a chance to succeed..
+				// proceed so that the query has a chance to succeed.
 				log.Ops.Warningf(ctx, "no memory available to cache role membership info: %v", err)
 			} else {
 				roleMembersCache.userCache[member] = memberships
@@ -418,14 +420,56 @@ func MemberOfWithAdminOption(
 	}
 }
 
+var defaultSingleQueryForRoleMembershipCache = util.ConstantWithMetamorphicTestBool(
+	"resolve-membership-single-scan-enabled",
+	false, /* defaultValue */
+)
+
+var useSingleQueryForRoleMembershipCache = settings.RegisterBoolSetting(
+	"sql.auth.resolve_membership_single_scan.enabled",
+	"determines whether to populate the role membership cache with a single scan",
+	defaultSingleQueryForRoleMembershipCache,
+).WithPublic()
+
 // resolveMemberOfWithAdminOption performs the actual recursive role membership lookup.
-// TODO(mberhault): this is the naive way and performs a full lookup for each user,
-// we could save detailed memberships (as opposed to fully expanded) and reuse them
-// across users. We may then want to lookup more than just this user.
 func resolveMemberOfWithAdminOption(
-	ctx context.Context, member security.SQLUsername, ie sqlutil.InternalExecutor, txn *kv.Txn,
+	ctx context.Context,
+	member security.SQLUsername,
+	ie sqlutil.InternalExecutor,
+	txn *kv.Txn,
+	singleQuery bool,
 ) (map[security.SQLUsername]bool, error) {
 	ret := map[security.SQLUsername]bool{}
+	if singleQuery {
+		type membership struct {
+			role    security.SQLUsername
+			isAdmin bool
+		}
+		memberToRoles := make(map[security.SQLUsername][]membership)
+		if err := forEachRoleMembership(ctx, ie, txn, func(role, member security.SQLUsername, isAdmin bool) error {
+			memberToRoles[member] = append(memberToRoles[member], membership{role, isAdmin})
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+
+		// Recurse through all roles associated with the member.
+		var recurse func(u security.SQLUsername)
+		recurse = func(u security.SQLUsername) {
+			for _, membership := range memberToRoles[u] {
+				// If the parent role was seen before, we still might need to update
+				// the isAdmin flag for that role, but there's no need to recurse
+				// through the role's ancestry again.
+				prev, alreadySeen := ret[membership.role]
+				ret[membership.role] = prev || membership.isAdmin
+				if !alreadySeen {
+					recurse(membership.role)
+				}
+			}
+		}
+		recurse(member)
+		return ret, nil
+	}
 
 	// Keep track of members we looked up.
 	visited := map[security.SQLUsername]struct{}{}

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -20,6 +20,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/cockroachdb/cockroach/pkg/docs"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
@@ -30,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/vtable"
 	"github.com/cockroachdb/errors"
@@ -2553,12 +2555,13 @@ FROM
 }
 
 func forEachRoleMembership(
-	ctx context.Context, p *planner, fn func(role, member security.SQLUsername, isAdmin bool) error,
+	ctx context.Context,
+	ie sqlutil.InternalExecutor,
+	txn *kv.Txn,
+	fn func(role, member security.SQLUsername, isAdmin bool) error,
 ) (retErr error) {
-	query := `SELECT "role", "member", "isAdmin" FROM system.role_members`
-	it, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryIterator(
-		ctx, "read-members", p.txn, query,
-	)
+	const query = `SELECT "role", "member", "isAdmin" FROM system.role_members`
+	it, err := ie.QueryIterator(ctx, "read-members", txn, query)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -181,17 +181,32 @@ user root
 statement ok
 GRANT testrole TO testuser WITH ADMIN OPTION
 
+statement ok
+CREATE ROLE child_role;
+GRANT testrole to child_role;
+GRANT testuser TO child_role;
+
 query TTB colnames
 SELECT * FROM system.role_members
 ----
-role      member    isAdmin
-admin     root      true
-testrole  testuser  true
-
-user testuser
+role      member      isAdmin
+admin     root        true
+testrole  child_role  false
+testrole  testuser    true
+testuser  child_role  false
 
 statement ok
+SET ROLE child_role
+
+# ADMIN OPTION should be inherited, so this should succeed.
+statement ok
 GRANT testrole TO testuser2 WITH ADMIN OPTION
+
+statement ok
+RESET ROLE;
+DROP ROLE child_role
+
+user testuser
 
 query TTT colnames,rowsort
 SELECT * FROM information_schema.administrable_role_authorizations

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -528,7 +528,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-auth-members.html`,
 	schema: vtable.PGCatalogAuthMembers,
 	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
-		return forEachRoleMembership(ctx, p,
+		return forEachRoleMembership(ctx, p.ExecCfg().InternalExecutor, p.Txn(),
 			func(roleName, memberName security.SQLUsername, isAdmin bool) error {
 				return addRow(
 					h.UserOid(roleName),                 // roleid

--- a/pkg/sql/user_test.go
+++ b/pkg/sql/user_test.go
@@ -48,190 +48,196 @@ func TestGetUserTimeout(t *testing.T) {
 	// race builds are so slow as to trigger this timeout spuriously.
 	skip.UnderRace(t)
 
-	ctx := context.Background()
+	testutils.RunTrueAndFalse(t, "TestGetUserTimeout/single_scan", func(t *testing.T, singleScanEnabled bool) {
 
-	// unavailableCh is used by the replica command filter
-	// to conditionally block requests and simulate unavailability.
-	var unavailableCh atomic.Value
-	closedCh := make(chan struct{})
-	close(closedCh)
-	unavailableCh.Store(closedCh)
-	knobs := &kvserver.StoreTestingKnobs{
-		TestingRequestFilter: func(ctx context.Context, _ roachpb.BatchRequest) *roachpb.Error {
-			select {
-			case <-unavailableCh.Load().(chan struct{}):
-			case <-ctx.Done():
-			}
-			return nil
-		},
-	}
-	params := base.TestServerArgs{Knobs: base.TestingKnobs{Store: knobs}}
-	s, db, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop(ctx)
+		ctx := context.Background()
 
-	// Make a user that must use a password to authenticate.
-	// Default privileges on defaultdb are needed to run simple queries.
-	if _, err := db.Exec(`
+		// unavailableCh is used by the replica command filter
+		// to conditionally block requests and simulate unavailability.
+		var unavailableCh atomic.Value
+		closedCh := make(chan struct{})
+		close(closedCh)
+		unavailableCh.Store(closedCh)
+		knobs := &kvserver.StoreTestingKnobs{
+			TestingRequestFilter: func(ctx context.Context, _ roachpb.BatchRequest) *roachpb.Error {
+				select {
+				case <-unavailableCh.Load().(chan struct{}):
+				case <-ctx.Done():
+				}
+				return nil
+			},
+		}
+		params := base.TestServerArgs{Knobs: base.TestingKnobs{Store: knobs}}
+		s, db, _ := serverutils.StartServer(t, params)
+		defer s.Stopper().Stop(ctx)
+
+		// Make a user that must use a password to authenticate.
+		// Default privileges on defaultdb are needed to run simple queries.
+		if _, err := db.Exec(`
 CREATE USER foo WITH PASSWORD 'testabc';
 GRANT ALL ON DATABASE defaultdb TO foo;
 GRANT admin TO foo`); err != nil {
-		t.Fatal(err)
-	}
-
-	// We'll attempt connections on gateway node 0.
-	fooURL, fooCleanupFn := sqlutils.PGUrlWithOptionalClientCerts(t,
-		s.ServingSQLAddr(), t.Name(), url.UserPassword("foo", "testabc"), false /* withClientCerts */)
-	defer fooCleanupFn()
-	barURL, barCleanupFn := sqlutils.PGUrlWithOptionalClientCerts(t,
-		s.ServingSQLAddr(), t.Name(), url.UserPassword("bar", "testabc"), false /* withClientCerts */)
-	defer barCleanupFn()
-	rootURL, rootCleanupFn := sqlutils.PGUrl(t,
-		s.ServingSQLAddr(), t.Name(), url.User(security.RootUser))
-	defer rootCleanupFn()
-
-	// Override the timeout built into pgx so we are only subject to
-	// what the server thinks.
-	fooURL.RawQuery += "&connect_timeout=0"
-	barURL.RawQuery += "&connect_timeout=0"
-	rootURL.RawQuery += "&connect_timeout=0"
-
-	t.Log("-- sanity checks --")
-
-	// We use a closure here and below to ensure the defers are run
-	// before the rest of the test.
-
-	func() {
-		// Sanity check: verify that secure mode is enabled: password is
-		// required. If this part fails, this means the test cluster is
-		// not properly configured, and the remainder of the test below
-		// would report false positives.
-		unauthURL := fooURL
-		unauthURL.User = url.User("foo")
-		dbSQL, err := pgxConn(t, unauthURL)
-		if err == nil {
-			defer func() { _ = dbSQL.Close(ctx) }()
-		}
-		if !testutils.IsError(err, "password authentication failed for user foo") {
-			t.Fatalf("expected password error, got %v", err)
-		}
-	}()
-
-	func() {
-		// Sanity check: verify that the new user is able to log in with password.
-		dbSQL, err := pgxConn(t, fooURL)
-		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() { _ = dbSQL.Close(ctx) }()
-		row := dbSQL.QueryRow(ctx, "SELECT current_user")
-		var username string
-		if err := row.Scan(&username); err != nil {
-			t.Fatal(err)
-		}
-		if username != "foo" {
-			t.Fatalf("invalid username: expected foo, got %q", username)
-		}
-	}()
 
-	// Configure the login timeout to just 200ms.
-	if _, err := db.Exec(`SET CLUSTER SETTING server.user_login.timeout = '200ms'`); err != nil {
-		t.Fatal(err)
-	}
+		_, err := db.Exec(`SET CLUSTER SETTING sql.auth.resolve_membership_single_scan.enabled = $1`, singleScanEnabled)
+		require.NoError(t, err)
 
-	func() {
-		t.Log("-- make ranges unavailable --")
+		// We'll attempt connections on gateway node 0.
+		fooURL, fooCleanupFn := sqlutils.PGUrlWithOptionalClientCerts(t,
+			s.ServingSQLAddr(), t.Name(), url.UserPassword("foo", "testabc"), false /* withClientCerts */)
+		defer fooCleanupFn()
+		barURL, barCleanupFn := sqlutils.PGUrlWithOptionalClientCerts(t,
+			s.ServingSQLAddr(), t.Name(), url.UserPassword("bar", "testabc"), false /* withClientCerts */)
+		defer barCleanupFn()
+		rootURL, rootCleanupFn := sqlutils.PGUrl(t,
+			s.ServingSQLAddr(), t.Name(), url.User(security.RootUser))
+		defer rootCleanupFn()
 
-		ch := make(chan struct{})
-		unavailableCh.Store(ch)
-		defer close(ch)
+		// Override the timeout built into pgx so we are only subject to
+		// what the server thinks.
+		fooURL.RawQuery += "&connect_timeout=0"
+		barURL.RawQuery += "&connect_timeout=0"
+		rootURL.RawQuery += "&connect_timeout=0"
 
-		t.Log("-- expect no timeout because of cache --")
+		t.Log("-- sanity checks --")
+
+		// We use a closure here and below to ensure the defers are run
+		// before the rest of the test.
 
 		func() {
-			// Now attempt to connect again. Since a previous authentication attempt
-			// for this user occurred, the auth-related info should be cached, so
-			// authentication should work.
+			// Sanity check: verify that secure mode is enabled: password is
+			// required. If this part fails, this means the test cluster is
+			// not properly configured, and the remainder of the test below
+			// would report false positives.
+			unauthURL := fooURL
+			unauthURL.User = url.User("foo")
+			dbSQL, err := pgxConn(t, unauthURL)
+			if err == nil {
+				defer func() { _ = dbSQL.Close(ctx) }()
+			}
+			if !testutils.IsError(err, "password authentication failed for user foo") {
+				t.Fatalf("expected password error, got %v", err)
+			}
+		}()
+
+		func() {
+			// Sanity check: verify that the new user is able to log in with password.
 			dbSQL, err := pgxConn(t, fooURL)
 			if err != nil {
 				t.Fatal(err)
 			}
 			defer func() { _ = dbSQL.Close(ctx) }()
-			// A simple query must work even without a system range available.
-			if _, err := dbSQL.Exec(ctx, "SELECT 1"); err != nil {
+			row := dbSQL.QueryRow(ctx, "SELECT current_user")
+			var username string
+			if err := row.Scan(&username); err != nil {
 				t.Fatal(err)
 			}
-			var isSuperuser string
-			require.NoError(t, dbSQL.QueryRow(ctx, "SHOW is_superuser").Scan(&isSuperuser))
-			require.Equal(t, "on", isSuperuser)
+			if username != "foo" {
+				t.Fatalf("invalid username: expected foo, got %q", username)
+			}
 		}()
 
-		t.Log("-- expect timeout --")
+		// Configure the login timeout to just 200ms.
+		if _, err := db.Exec(`SET CLUSTER SETTING server.user_login.timeout = '200ms'`); err != nil {
+			t.Fatal(err)
+		}
 
 		func() {
-			// Now attempt to connect with a different user. We're expecting a timeout
-			// within 5 seconds.
-			start := timeutil.Now()
-			dbSQL, err := pgxConn(t, barURL)
-			if err == nil {
+			t.Log("-- make ranges unavailable --")
+
+			ch := make(chan struct{})
+			unavailableCh.Store(ch)
+			defer close(ch)
+
+			t.Log("-- expect no timeout because of cache --")
+
+			func() {
+				// Now attempt to connect again. Since a previous authentication attempt
+				// for this user occurred, the auth-related info should be cached, so
+				// authentication should work.
+				dbSQL, err := pgxConn(t, fooURL)
+				if err != nil {
+					t.Fatal(err)
+				}
 				defer func() { _ = dbSQL.Close(ctx) }()
-			}
-			if !testutils.IsError(err, "internal error while retrieving user account") {
-				t.Fatalf("expected error during connection, got %v", err)
-			}
-			timeoutDur := timeutil.Now().Sub(start)
-			if timeoutDur > 5*time.Second {
-				t.Fatalf("timeout lasted for more than 5 second (%s)", timeoutDur)
-			}
-		}()
+				// A simple query must work even without a system range available.
+				if _, err := dbSQL.Exec(ctx, "SELECT 1"); err != nil {
+					t.Fatal(err)
+				}
+				var isSuperuser string
+				require.NoError(t, dbSQL.QueryRow(ctx, "SHOW is_superuser").Scan(&isSuperuser))
+				require.Equal(t, "on", isSuperuser)
+			}()
 
-		t.Log("-- no timeout for root --")
+			t.Log("-- expect timeout --")
 
-		func() {
-			dbSQL, err := pgxConn(t, rootURL)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer func() { _ = dbSQL.Close(ctx) }()
-			// A simple query must work for 'root' even without a system range available.
-			if _, err := dbSQL.Exec(ctx, "SELECT 1"); err != nil {
-				t.Fatal(err)
-			}
-			var isSuperuser string
-			require.NoError(t, dbSQL.QueryRow(ctx, "SHOW is_superuser").Scan(&isSuperuser))
-			require.Equal(t, "on", isSuperuser)
-		}()
+			func() {
+				// Now attempt to connect with a different user. We're expecting a timeout
+				// within 5 seconds.
+				start := timeutil.Now()
+				dbSQL, err := pgxConn(t, barURL)
+				if err == nil {
+					defer func() { _ = dbSQL.Close(ctx) }()
+				}
+				if !testutils.IsError(err, "internal error while retrieving user account") {
+					t.Fatalf("expected error during connection, got %v", err)
+				}
+				timeoutDur := timeutil.Since(start)
+				if timeoutDur > 5*time.Second {
+					t.Fatalf("timeout lasted for more than 5 second (%s)", timeoutDur)
+				}
+			}()
 
-		t.Log("-- re-enable range, revoke admin for user --")
-	}()
+			t.Log("-- no timeout for root --")
 
-	t.Log("-- removing foo as admin --")
-	_, err := db.Exec(`REVOKE admin FROM foo`)
-	require.NoError(t, err)
-
-	func() {
-		t.Log("-- make ranges unavailable --")
-
-		ch := make(chan struct{})
-		unavailableCh.Store(ch)
-		defer close(ch)
-
-		func() {
-			// Now attempt to connect with foo. We're expecting a timeout within 5
-			// seconds as the membership cache is invalid.
-			start := timeutil.Now()
-			dbSQL, err := pgxConn(t, fooURL)
-			if err == nil {
+			func() {
+				dbSQL, err := pgxConn(t, rootURL)
+				if err != nil {
+					t.Fatal(err)
+				}
 				defer func() { _ = dbSQL.Close(ctx) }()
-			}
-			if !testutils.IsError(err, "internal error while retrieving user account memberships") {
-				t.Fatalf("expected error during connection, got %v", err)
-			}
-			timeoutDur := timeutil.Now().Sub(start)
-			if timeoutDur > 5*time.Second {
-				t.Fatalf("timeout lasted for more than 5 second (%s)", timeoutDur)
-			}
+				// A simple query must work for 'root' even without a system range available.
+				if _, err := dbSQL.Exec(ctx, "SELECT 1"); err != nil {
+					t.Fatal(err)
+				}
+				var isSuperuser string
+				require.NoError(t, dbSQL.QueryRow(ctx, "SHOW is_superuser").Scan(&isSuperuser))
+				require.Equal(t, "on", isSuperuser)
+			}()
+
+			t.Log("-- re-enable range, revoke admin for user --")
 		}()
-	}()
+
+		t.Log("-- removing foo as admin --")
+		_, err = db.Exec(`REVOKE admin FROM foo`)
+		require.NoError(t, err)
+
+		func() {
+			t.Log("-- make ranges unavailable --")
+
+			ch := make(chan struct{})
+			unavailableCh.Store(ch)
+			defer close(ch)
+
+			func() {
+				// Now attempt to connect with foo. We're expecting a timeout within 5
+				// seconds as the membership cache is invalid.
+				start := timeutil.Now()
+				dbSQL, err := pgxConn(t, fooURL)
+				if err == nil {
+					defer func() { _ = dbSQL.Close(ctx) }()
+				}
+				if !testutils.IsError(err, "internal error while retrieving user account memberships") {
+					t.Fatalf("expected error during connection, got %v", err)
+				}
+				timeoutDur := timeutil.Since(start)
+				if timeoutDur > 5*time.Second {
+					t.Fatalf("timeout lasted for more than 5 second (%s)", timeoutDur)
+				}
+			}()
+		}()
+	})
 }
 
 func pgxConn(t *testing.T, connURL url.URL) (*pgx.Conn, error) {


### PR DESCRIPTION
Backport 2/3 commits from #77359.

/cc @cockroachdb/release

An important difference in this backport is that the new cluster setting is
off by default.

---

relates to support case https://github.com/cockroachlabs/support/issues/1463
fixes https://github.com/cockroachdb/cockroach/issues/77452

### sql: use singleflight for role membership lookups

This helps prevent a thundering herd when this cache gets invalidated.

### sql: scan the system.role_members table using a single scan


Release note (sql change): Added a
`sql.auth.resolve_membership_single_scan.enabled` cluster setting, which
changes the query for an internal role membership cache. Previously the
code would recursively look up each role in the membership hierarchy,
leading to multiple queries. With the setting on, it uses a single
query. The setting is *false* by default.

Release justification: high priority bug fix 

