### PR TITLE
vendor: upgrade to latest `stress`

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -1337,10 +1337,10 @@ def go_deps():
         name = "com_github_cockroachdb_stress",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/stress",
-        sha256 = "a516f84f8e1ad554357b7e60083dddf092d5ac1e80e311de47c46eeac28a4453",
-        strip_prefix = "github.com/cockroachdb/stress@v0.0.0-20220217190341-94cf65c2a29f",
+        sha256 = "ccc4cb7543b7eba12ff82602c85a627a8dba8ecbda67a9a1bf05fb4c56895ba6",
+        strip_prefix = "github.com/cockroachdb/stress@v0.0.0-20220310203902-58fb4627376e",
         urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/stress/com_github_cockroachdb_stress-v0.0.0-20220217190341-94cf65c2a29f.zip",
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/stress/com_github_cockroachdb_stress-v0.0.0-20220310203902-58fb4627376e.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/cockroachdb/pebble v0.0.0-20220310010958-93d472261892
 	github.com/cockroachdb/redact v1.1.3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
-	github.com/cockroachdb/stress v0.0.0-20220217190341-94cf65c2a29f
+	github.com/cockroachdb/stress v0.0.0-20220310203902-58fb4627376e
 	github.com/cockroachdb/tools v0.0.0-20211112185054-642e51449b40
 	github.com/cockroachdb/ttycolor v0.0.0-20210902133924-c7d7dcdde4e8
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd

--- a/go.sum
+++ b/go.sum
@@ -446,8 +446,8 @@ github.com/cockroachdb/redact v1.1.3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZ
 github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd h1:KFOt5I9nEKZgCnOSmy8r4Oykh8BYQO8bFOTgHDS8YZA=
 github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd/go.mod h1:AN708GD2FFeLgUHMbD58YPe4Nw8GG//3rwgyG4L9gR0=
 github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2/go.mod h1:8BT+cPK6xvFOcRlk0R8eg+OTkcqI6baNH4xAkpiYVvQ=
-github.com/cockroachdb/stress v0.0.0-20220217190341-94cf65c2a29f h1:VSTkkFWmwYdiO42v/sBc3u7ioJMuirtXRMGZdelc47Y=
-github.com/cockroachdb/stress v0.0.0-20220217190341-94cf65c2a29f/go.mod h1:oapRqABg5KA/TaAikQH53fpP5nvCe9sftYmYV/F/yVE=
+github.com/cockroachdb/stress v0.0.0-20220310203902-58fb4627376e h1:ylndajQnDQCI6dIPJZmJpQ5i3gt19tijiwXA7BD3KXs=
+github.com/cockroachdb/stress v0.0.0-20220310203902-58fb4627376e/go.mod h1:oapRqABg5KA/TaAikQH53fpP5nvCe9sftYmYV/F/yVE=
 github.com/cockroachdb/tablewriter v0.0.5-0.20200105123400-bd15540e8847 h1:c7yLgqcm/3c9lYtpWeVD9NYqA9cKsKHdpQM62PHtTUM=
 github.com/cockroachdb/tablewriter v0.0.5-0.20200105123400-bd15540e8847/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
 github.com/cockroachdb/teamcity v0.0.0-20180905144921-8ca25c33eb11 h1:UAqRo5xPCyTtZznAJ9iPVpDUFxGI0a6QWtQ8E+zwJRg=


### PR DESCRIPTION
Pull in the change `58fb4627376ead1557e8224bd1a708035c22f56d` to
`stress` to prevent spurious test timeouts under `stress`.

Closes #77351.

Release justification: Fixes bug w/ test running under `stress`
Release note: None