### PR TITLE
cli: debug zip treats version column as string

### DIFF
--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -50,7 +50,7 @@ var customQuery = map[string]string{
 		") SELECT * FROM spans, LATERAL crdb_internal.payloads_for_span(span_id)",
 	"system.jobs":       "SELECT *, to_hex(payload) AS hex_payload, to_hex(progress) AS hex_progress FROM system.jobs",
 	"system.descriptor": "SELECT *, to_hex(descriptor) AS hex_descriptor FROM system.descriptor",
-	"system.settings":   "SELECT *, to_hex(value::bytes) as hex_value FROM system.settings",
+	"system.settings":   "SELECT *, to_hex(value) as hex_value FROM system.settings",
 }
 
 type debugZipContext struct {


### PR DESCRIPTION
Previously, we converted the version column in `system.settings` to
hexadecimal by converting it to bytes first. This led to a problem once
the version got higher than a certain number.

Resolves https://github.com/cockroachdb/cockroach/issues/77579

Release justification: low risk bug fix to debug zip generation
Release note: None