### PR TITLE
changefeedccl: allow changefeeds specifying individual column families

### DIFF
--- a/docs/generated/sql/bnf/create_changefeed_stmt.bnf
+++ b/docs/generated/sql/bnf/create_changefeed_stmt.bnf
@@ -1,11 +1,6 @@
 create_changefeed_stmt ::=
-	'CREATE' 'CHANGEFEED' 'FOR' table_name ( ( ',' table_name ) )* 'INTO' sink 'WITH' option '=' value ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
-	| 'CREATE' 'CHANGEFEED' 'FOR' table_name ( ( ',' table_name ) )* 'INTO' sink 'WITH' option ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
-	| 'CREATE' 'CHANGEFEED' 'FOR' table_name ( ( ',' table_name ) )* 'INTO' sink 'WITH' option '=' value ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
-	| 'CREATE' 'CHANGEFEED' 'FOR' table_name ( ( ',' table_name ) )* 'INTO' sink 'WITH' option ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
-	| 'CREATE' 'CHANGEFEED' 'FOR' table_name ( ( ',' table_name ) )* 'INTO' sink 
-	| 'CREATE' 'CHANGEFEED' 'FOR' 'TABLE' table_name ( ( ',' table_name ) )* 'INTO' sink 'WITH' option '=' value ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
-	| 'CREATE' 'CHANGEFEED' 'FOR' 'TABLE' table_name ( ( ',' table_name ) )* 'INTO' sink 'WITH' option ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
-	| 'CREATE' 'CHANGEFEED' 'FOR' 'TABLE' table_name ( ( ',' table_name ) )* 'INTO' sink 'WITH' option '=' value ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
-	| 'CREATE' 'CHANGEFEED' 'FOR' 'TABLE' table_name ( ( ',' table_name ) )* 'INTO' sink 'WITH' option ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
-	| 'CREATE' 'CHANGEFEED' 'FOR' 'TABLE' table_name ( ( ',' table_name ) )* 'INTO' sink 
+	'CREATE' 'CHANGEFEED' 'FOR' changefeed_target ( ( ',' changefeed_target ) )* 'INTO' sink 'WITH' option '=' value ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
+	| 'CREATE' 'CHANGEFEED' 'FOR' changefeed_target ( ( ',' changefeed_target ) )* 'INTO' sink 'WITH' option ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
+	| 'CREATE' 'CHANGEFEED' 'FOR' changefeed_target ( ( ',' changefeed_target ) )* 'INTO' sink 'WITH' option '=' value ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
+	| 'CREATE' 'CHANGEFEED' 'FOR' changefeed_target ( ( ',' changefeed_target ) )* 'INTO' sink 'WITH' option ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
+	| 'CREATE' 'CHANGEFEED' 'FOR' changefeed_target ( ( ',' changefeed_target ) )* 'INTO' sink 

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1626,8 +1626,7 @@ opt_with_schedule_options ::=
 	| 
 
 changefeed_targets ::=
-	single_table_pattern_list
-	| 'TABLE' single_table_pattern_list
+	( changefeed_target ) ( ( ',' changefeed_target ) )*
 
 opt_changefeed_sink ::=
 	'INTO' string_or_placeholder
@@ -2239,8 +2238,11 @@ opt_sequence_option_list ::=
 	sequence_option_list
 	| 
 
-single_table_pattern_list ::=
-	( table_name ) ( ( ',' table_name ) )*
+changefeed_target ::=
+	'TABLE' table_name
+	| table_name
+	| 'TABLE' table_name 'FAMILY' family_name
+	| table_name 'FAMILY' family_name
 
 replication_options_list ::=
 	( replication_options ) ( ( ',' replication_options ) )*
@@ -2762,6 +2764,9 @@ create_as_table_defs ::=
 
 enum_val_list ::=
 	( 'SCONST' ) ( ( ',' 'SCONST' ) )*
+
+family_name ::=
+	name
 
 replication_options ::=
 	'CURSOR' '=' a_expr
@@ -3460,9 +3465,6 @@ like_table_option ::=
 
 create_as_col_qualification_elem ::=
 	'PRIMARY' 'KEY' opt_with_storage_parameter_list
-
-family_name ::=
-	name
 
 create_as_params ::=
 	( create_as_param ) ( ( ',' create_as_param ) )*

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -692,6 +692,7 @@ func newKVEventToRowConsumer(
 		cfg.LeaseManager.(*lease.Manager),
 		cfg.CollectionFactory,
 		cfg.DB,
+		details,
 	)
 
 	return &kvEventToRowConsumer{
@@ -719,6 +720,11 @@ func (c *kvEventToRowConsumer) ConsumeEvent(ctx context.Context, ev kvevent.Even
 
 	r, err := c.eventToRow(ctx, ev)
 	if err != nil {
+		// Column families are stored contiguously, so we'll get
+		// events for each one even if we're not watching them all.
+		if errors.Is(err, ErrUnwatchedFamily) {
+			return nil
+		}
 		return err
 	}
 

--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -600,7 +600,7 @@ var specs = []stmtSpec{
 	},
 	{
 		name:   "create_changefeed_stmt",
-		inline: []string{"changefeed_targets", "single_table_pattern_list", "opt_changefeed_sink", "opt_with_options", "kv_option_list", "kv_option"},
+		inline: []string{"changefeed_targets", "opt_changefeed_sink", "opt_with_options", "kv_option_list", "kv_option"},
 		replace: map[string]string{
 			"table_option":                 "table_name",
 			"'INTO' string_or_placeholder": "'INTO' sink",

--- a/pkg/sql/parser/testdata/alter_changefeed
+++ b/pkg/sql/parser/testdata/alter_changefeed
@@ -1,61 +1,61 @@
 parse
 ALTER CHANGEFEED 123 ADD foo
 ----
-ALTER CHANGEFEED 123 ADD foo
-ALTER CHANGEFEED (123) ADD (foo) -- fully parenthesized
-ALTER CHANGEFEED _ ADD foo -- literals removed
-ALTER CHANGEFEED 123 ADD _ -- identifiers removed
+ALTER CHANGEFEED 123 ADD TABLE foo -- normalized!
+ALTER CHANGEFEED (123) ADD TABLE (foo) -- fully parenthesized
+ALTER CHANGEFEED _ ADD TABLE foo -- literals removed
+ALTER CHANGEFEED 123 ADD TABLE _ -- identifiers removed
 
 
 parse
 ALTER CHANGEFEED 123 DROP foo
 ----
-ALTER CHANGEFEED 123 DROP foo
-ALTER CHANGEFEED (123) DROP (foo) -- fully parenthesized
-ALTER CHANGEFEED _ DROP foo -- literals removed
-ALTER CHANGEFEED 123 DROP _ -- identifiers removed
+ALTER CHANGEFEED 123 DROP TABLE foo -- normalized!
+ALTER CHANGEFEED (123) DROP TABLE (foo) -- fully parenthesized
+ALTER CHANGEFEED _ DROP TABLE foo -- literals removed
+ALTER CHANGEFEED 123 DROP TABLE _ -- identifiers removed
 
 
 parse
 ALTER CHANGEFEED 123 ADD foo DROP bar
 ----
-ALTER CHANGEFEED 123 ADD foo  DROP bar -- normalized!
-ALTER CHANGEFEED (123) ADD (foo)  DROP (bar) -- fully parenthesized
-ALTER CHANGEFEED _ ADD foo  DROP bar -- literals removed
-ALTER CHANGEFEED 123 ADD _  DROP _ -- identifiers removed
+ALTER CHANGEFEED 123 ADD TABLE foo  DROP TABLE bar -- normalized!
+ALTER CHANGEFEED (123) ADD TABLE (foo)  DROP TABLE (bar) -- fully parenthesized
+ALTER CHANGEFEED _ ADD TABLE foo  DROP TABLE bar -- literals removed
+ALTER CHANGEFEED 123 ADD TABLE _  DROP TABLE _ -- identifiers removed
 
 
 parse
 ALTER CHANGEFEED 123 DROP foo ADD bar
 ----
-ALTER CHANGEFEED 123 DROP foo  ADD bar -- normalized!
-ALTER CHANGEFEED (123) DROP (foo)  ADD (bar) -- fully parenthesized
-ALTER CHANGEFEED _ DROP foo  ADD bar -- literals removed
-ALTER CHANGEFEED 123 DROP _  ADD _ -- identifiers removed
+ALTER CHANGEFEED 123 DROP TABLE foo  ADD TABLE bar -- normalized!
+ALTER CHANGEFEED (123) DROP TABLE (foo)  ADD TABLE (bar) -- fully parenthesized
+ALTER CHANGEFEED _ DROP TABLE foo  ADD TABLE bar -- literals removed
+ALTER CHANGEFEED 123 DROP TABLE _  ADD TABLE _ -- identifiers removed
 
 parse
 ALTER CHANGEFEED 123 ADD foo, bar
 ----
-ALTER CHANGEFEED 123 ADD foo, bar
-ALTER CHANGEFEED (123) ADD (foo), (bar) -- fully parenthesized
-ALTER CHANGEFEED _ ADD foo, bar -- literals removed
-ALTER CHANGEFEED 123 ADD _, _ -- identifiers removed
+ALTER CHANGEFEED 123 ADD TABLE foo, TABLE bar -- normalized!
+ALTER CHANGEFEED (123) ADD TABLE (foo), TABLE (bar) -- fully parenthesized
+ALTER CHANGEFEED _ ADD TABLE foo, TABLE bar -- literals removed
+ALTER CHANGEFEED 123 ADD TABLE _, TABLE _ -- identifiers removed
 
 parse
 ALTER CHANGEFEED 123 DROP foo, bar ADD baz, qux
 ----
-ALTER CHANGEFEED 123 DROP foo, bar  ADD baz, qux -- normalized!
-ALTER CHANGEFEED (123) DROP (foo), (bar)  ADD (baz), (qux) -- fully parenthesized
-ALTER CHANGEFEED _ DROP foo, bar  ADD baz, qux -- literals removed
-ALTER CHANGEFEED 123 DROP _, _  ADD _, _ -- identifiers removed
+ALTER CHANGEFEED 123 DROP TABLE foo, TABLE bar  ADD TABLE baz, TABLE qux -- normalized!
+ALTER CHANGEFEED (123) DROP TABLE (foo), TABLE (bar)  ADD TABLE (baz), TABLE (qux) -- fully parenthesized
+ALTER CHANGEFEED _ DROP TABLE foo, TABLE bar  ADD TABLE baz, TABLE qux -- literals removed
+ALTER CHANGEFEED 123 DROP TABLE _, TABLE _  ADD TABLE _, TABLE _ -- identifiers removed
 
 parse
 ALTER CHANGEFEED 123 ADD foo DROP bar ADD baz, qux DROP quux
 ----
-ALTER CHANGEFEED 123 ADD foo  DROP bar  ADD baz, qux  DROP quux -- normalized!
-ALTER CHANGEFEED (123) ADD (foo)  DROP (bar)  ADD (baz), (qux)  DROP (quux) -- fully parenthesized
-ALTER CHANGEFEED _ ADD foo  DROP bar  ADD baz, qux  DROP quux -- literals removed
-ALTER CHANGEFEED 123 ADD _  DROP _  ADD _, _  DROP _ -- identifiers removed
+ALTER CHANGEFEED 123 ADD TABLE foo  DROP TABLE bar  ADD TABLE baz, TABLE qux  DROP TABLE quux -- normalized!
+ALTER CHANGEFEED (123) ADD TABLE (foo)  DROP TABLE (bar)  ADD TABLE (baz), TABLE (qux)  DROP TABLE (quux) -- fully parenthesized
+ALTER CHANGEFEED _ ADD TABLE foo  DROP TABLE bar  ADD TABLE baz, TABLE qux  DROP TABLE quux -- literals removed
+ALTER CHANGEFEED 123 ADD TABLE _  DROP TABLE _  ADD TABLE _, TABLE _  DROP TABLE _ -- identifiers removed
 
 parse
 ALTER CHANGEFEED 123 SET foo = 'bar'
@@ -69,34 +69,34 @@ ALTER CHANGEFEED 123 SET _ = 'bar' -- identifiers removed
 parse
 ALTER CHANGEFEED 123 ADD foo SET bar = 'baz', qux = 'quux'
 ----
-ALTER CHANGEFEED 123 ADD foo  SET bar = 'baz', qux = 'quux' -- normalized!
-ALTER CHANGEFEED (123) ADD (foo)  SET bar = ('baz'), qux = ('quux') -- fully parenthesized
-ALTER CHANGEFEED _ ADD foo  SET bar = '_', qux = '_' -- literals removed
-ALTER CHANGEFEED 123 ADD _  SET _ = 'baz', _ = 'quux' -- identifiers removed
+ALTER CHANGEFEED 123 ADD TABLE foo  SET bar = 'baz', qux = 'quux' -- normalized!
+ALTER CHANGEFEED (123) ADD TABLE (foo)  SET bar = ('baz'), qux = ('quux') -- fully parenthesized
+ALTER CHANGEFEED _ ADD TABLE foo  SET bar = '_', qux = '_' -- literals removed
+ALTER CHANGEFEED 123 ADD TABLE _  SET _ = 'baz', _ = 'quux' -- identifiers removed
 
 parse
 ALTER CHANGEFEED 123 DROP foo SET bar = 'baz', qux = 'quux'
 ----
-ALTER CHANGEFEED 123 DROP foo  SET bar = 'baz', qux = 'quux' -- normalized!
-ALTER CHANGEFEED (123) DROP (foo)  SET bar = ('baz'), qux = ('quux') -- fully parenthesized
-ALTER CHANGEFEED _ DROP foo  SET bar = '_', qux = '_' -- literals removed
-ALTER CHANGEFEED 123 DROP _  SET _ = 'baz', _ = 'quux' -- identifiers removed
+ALTER CHANGEFEED 123 DROP TABLE foo  SET bar = 'baz', qux = 'quux' -- normalized!
+ALTER CHANGEFEED (123) DROP TABLE (foo)  SET bar = ('baz'), qux = ('quux') -- fully parenthesized
+ALTER CHANGEFEED _ DROP TABLE foo  SET bar = '_', qux = '_' -- literals removed
+ALTER CHANGEFEED 123 DROP TABLE _  SET _ = 'baz', _ = 'quux' -- identifiers removed
 
 parse
 ALTER CHANGEFEED 123 SET foo = 'bar' ADD baz DROP qux
 ----
-ALTER CHANGEFEED 123 SET foo = 'bar'  ADD baz  DROP qux -- normalized!
-ALTER CHANGEFEED (123) SET foo = ('bar')  ADD (baz)  DROP (qux) -- fully parenthesized
-ALTER CHANGEFEED _ SET foo = '_'  ADD baz  DROP qux -- literals removed
-ALTER CHANGEFEED 123 SET _ = 'bar'  ADD _  DROP _ -- identifiers removed
+ALTER CHANGEFEED 123 SET foo = 'bar'  ADD TABLE baz  DROP TABLE qux -- normalized!
+ALTER CHANGEFEED (123) SET foo = ('bar')  ADD TABLE (baz)  DROP TABLE (qux) -- fully parenthesized
+ALTER CHANGEFEED _ SET foo = '_'  ADD TABLE baz  DROP TABLE qux -- literals removed
+ALTER CHANGEFEED 123 SET _ = 'bar'  ADD TABLE _  DROP TABLE _ -- identifiers removed
 
 parse
 ALTER CHANGEFEED 123 ADD foo SET bar = 'baz', qux = 'quux' DROP corge
 ----
-ALTER CHANGEFEED 123 ADD foo  SET bar = 'baz', qux = 'quux'  DROP corge -- normalized!
-ALTER CHANGEFEED (123) ADD (foo)  SET bar = ('baz'), qux = ('quux')  DROP (corge) -- fully parenthesized
-ALTER CHANGEFEED _ ADD foo  SET bar = '_', qux = '_'  DROP corge -- literals removed
-ALTER CHANGEFEED 123 ADD _  SET _ = 'baz', _ = 'quux'  DROP _ -- identifiers removed
+ALTER CHANGEFEED 123 ADD TABLE foo  SET bar = 'baz', qux = 'quux'  DROP TABLE corge -- normalized!
+ALTER CHANGEFEED (123) ADD TABLE (foo)  SET bar = ('baz'), qux = ('quux')  DROP TABLE (corge) -- fully parenthesized
+ALTER CHANGEFEED _ ADD TABLE foo  SET bar = '_', qux = '_'  DROP TABLE corge -- literals removed
+ALTER CHANGEFEED 123 ADD TABLE _  SET _ = 'baz', _ = 'quux'  DROP TABLE _ -- identifiers removed
 
 parse
 ALTER CHANGEFEED 123 UNSET foo
@@ -109,55 +109,55 @@ ALTER CHANGEFEED 123 UNSET _ -- identifiers removed
 parse
 ALTER CHANGEFEED 123 ADD foo UNSET bar, baz
 ----
-ALTER CHANGEFEED 123 ADD foo  UNSET bar, baz -- normalized!
-ALTER CHANGEFEED (123) ADD (foo)  UNSET bar, baz -- fully parenthesized
-ALTER CHANGEFEED _ ADD foo  UNSET bar, baz -- literals removed
-ALTER CHANGEFEED 123 ADD _  UNSET _, _ -- identifiers removed
+ALTER CHANGEFEED 123 ADD TABLE foo  UNSET bar, baz -- normalized!
+ALTER CHANGEFEED (123) ADD TABLE (foo)  UNSET bar, baz -- fully parenthesized
+ALTER CHANGEFEED _ ADD TABLE foo  UNSET bar, baz -- literals removed
+ALTER CHANGEFEED 123 ADD TABLE _  UNSET _, _ -- identifiers removed
 
 parse
 ALTER CHANGEFEED 123 UNSET foo, bar ADD baz DROP qux
 ----
-ALTER CHANGEFEED 123 UNSET foo, bar  ADD baz  DROP qux -- normalized!
-ALTER CHANGEFEED (123) UNSET foo, bar  ADD (baz)  DROP (qux) -- fully parenthesized
-ALTER CHANGEFEED _ UNSET foo, bar  ADD baz  DROP qux -- literals removed
-ALTER CHANGEFEED 123 UNSET _, _  ADD _  DROP _ -- identifiers removed
+ALTER CHANGEFEED 123 UNSET foo, bar  ADD TABLE baz  DROP TABLE qux -- normalized!
+ALTER CHANGEFEED (123) UNSET foo, bar  ADD TABLE (baz)  DROP TABLE (qux) -- fully parenthesized
+ALTER CHANGEFEED _ UNSET foo, bar  ADD TABLE baz  DROP TABLE qux -- literals removed
+ALTER CHANGEFEED 123 UNSET _, _  ADD TABLE _  DROP TABLE _ -- identifiers removed
 
 parse
 ALTER CHANGEFEED 123 ADD foo DROP bar SET baz = 'qux' UNSET quux, corge
 ----
-ALTER CHANGEFEED 123 ADD foo  DROP bar  SET baz = 'qux'  UNSET quux, corge -- normalized!
-ALTER CHANGEFEED (123) ADD (foo)  DROP (bar)  SET baz = ('qux')  UNSET quux, corge -- fully parenthesized
-ALTER CHANGEFEED _ ADD foo  DROP bar  SET baz = '_'  UNSET quux, corge -- literals removed
-ALTER CHANGEFEED 123 ADD _  DROP _  SET _ = 'qux'  UNSET _, _ -- identifiers removed
+ALTER CHANGEFEED 123 ADD TABLE foo  DROP TABLE bar  SET baz = 'qux'  UNSET quux, corge -- normalized!
+ALTER CHANGEFEED (123) ADD TABLE (foo)  DROP TABLE (bar)  SET baz = ('qux')  UNSET quux, corge -- fully parenthesized
+ALTER CHANGEFEED _ ADD TABLE foo  DROP TABLE bar  SET baz = '_'  UNSET quux, corge -- literals removed
+ALTER CHANGEFEED 123 ADD TABLE _  DROP TABLE _  SET _ = 'qux'  UNSET _, _ -- identifiers removed
 
 parse
 ALTER CHANGEFEED 123 ADD foo WITH opt
 ----
-ALTER CHANGEFEED 123 ADD foo WITH opt
-ALTER CHANGEFEED (123) ADD (foo) WITH opt -- fully parenthesized
-ALTER CHANGEFEED _ ADD foo WITH opt -- literals removed
-ALTER CHANGEFEED 123 ADD _ WITH _ -- identifiers removed
+ALTER CHANGEFEED 123 ADD TABLE foo WITH opt -- normalized!
+ALTER CHANGEFEED (123) ADD TABLE (foo) WITH opt -- fully parenthesized
+ALTER CHANGEFEED _ ADD TABLE foo WITH opt -- literals removed
+ALTER CHANGEFEED 123 ADD TABLE _ WITH _ -- identifiers removed
 
 parse
 ALTER CHANGEFEED 123 ADD foo, bar, baz WITH opt
 ----
-ALTER CHANGEFEED 123 ADD foo, bar, baz WITH opt
-ALTER CHANGEFEED (123) ADD (foo), (bar), (baz) WITH opt -- fully parenthesized
-ALTER CHANGEFEED _ ADD foo, bar, baz WITH opt -- literals removed
-ALTER CHANGEFEED 123 ADD _, _, _ WITH _ -- identifiers removed
+ALTER CHANGEFEED 123 ADD TABLE foo, TABLE bar, TABLE baz WITH opt -- normalized!
+ALTER CHANGEFEED (123) ADD TABLE (foo), TABLE (bar), TABLE (baz) WITH opt -- fully parenthesized
+ALTER CHANGEFEED _ ADD TABLE foo, TABLE bar, TABLE baz WITH opt -- literals removed
+ALTER CHANGEFEED 123 ADD TABLE _, TABLE _, TABLE _ WITH _ -- identifiers removed
 
 parse
 ALTER CHANGEFEED 123 ADD foo, bar WITH opt ADD baz WITH opt2
 ----
-ALTER CHANGEFEED 123 ADD foo, bar WITH opt  ADD baz WITH opt2 -- normalized!
-ALTER CHANGEFEED (123) ADD (foo), (bar) WITH opt  ADD (baz) WITH opt2 -- fully parenthesized
-ALTER CHANGEFEED _ ADD foo, bar WITH opt  ADD baz WITH opt2 -- literals removed
-ALTER CHANGEFEED 123 ADD _, _ WITH _  ADD _ WITH _ -- identifiers removed
+ALTER CHANGEFEED 123 ADD TABLE foo, TABLE bar WITH opt  ADD TABLE baz WITH opt2 -- normalized!
+ALTER CHANGEFEED (123) ADD TABLE (foo), TABLE (bar) WITH opt  ADD TABLE (baz) WITH opt2 -- fully parenthesized
+ALTER CHANGEFEED _ ADD TABLE foo, TABLE bar WITH opt  ADD TABLE baz WITH opt2 -- literals removed
+ALTER CHANGEFEED 123 ADD TABLE _, TABLE _ WITH _  ADD TABLE _ WITH _ -- identifiers removed
 
 parse
 ALTER CHANGEFEED 123 ADD foo, bar, baz WITH opt SET qux = 'quux' DROP corge
 ----
-ALTER CHANGEFEED 123 ADD foo, bar, baz WITH opt  SET qux = 'quux'  DROP corge -- normalized!
-ALTER CHANGEFEED (123) ADD (foo), (bar), (baz) WITH opt  SET qux = ('quux')  DROP (corge) -- fully parenthesized
-ALTER CHANGEFEED _ ADD foo, bar, baz WITH opt  SET qux = '_'  DROP corge -- literals removed
-ALTER CHANGEFEED 123 ADD _, _, _ WITH _  SET _ = 'quux'  DROP _ -- identifiers removed
+ALTER CHANGEFEED 123 ADD TABLE foo, TABLE bar, TABLE baz WITH opt  SET qux = 'quux'  DROP TABLE corge -- normalized!
+ALTER CHANGEFEED (123) ADD TABLE (foo), TABLE (bar), TABLE (baz) WITH opt  SET qux = ('quux')  DROP TABLE (corge) -- fully parenthesized
+ALTER CHANGEFEED _ ADD TABLE foo, TABLE bar, TABLE baz WITH opt  SET qux = '_'  DROP TABLE corge -- literals removed
+ALTER CHANGEFEED 123 ADD TABLE _, TABLE _, TABLE _ WITH _  SET _ = 'quux'  DROP TABLE _ -- identifiers removed

--- a/pkg/sql/parser/testdata/changefeed
+++ b/pkg/sql/parser/testdata/changefeed
@@ -7,6 +7,14 @@ EXPERIMENTAL CHANGEFEED FOR TABLE foo -- literals removed
 EXPERIMENTAL CHANGEFEED FOR TABLE _ -- identifiers removed
 
 parse
+EXPERIMENTAL CHANGEFEED FOR TABLE foo FAMILY bar
+----
+EXPERIMENTAL CHANGEFEED FOR TABLE foo FAMILY bar
+EXPERIMENTAL CHANGEFEED FOR TABLE (foo) FAMILY bar -- fully parenthesized
+EXPERIMENTAL CHANGEFEED FOR TABLE foo FAMILY bar -- literals removed
+EXPERIMENTAL CHANGEFEED FOR TABLE _ FAMILY _ -- identifiers removed
+
+parse
 EXPLAIN CREATE CHANGEFEED FOR TABLE foo INTO 'sink'
 ----
 EXPLAIN CREATE CHANGEFEED FOR TABLE foo INTO 'sink'
@@ -31,12 +39,12 @@ CREATE CHANGEFEED FOR TABLE foo INTO '_' -- literals removed
 CREATE CHANGEFEED FOR TABLE _ INTO 'sink' -- identifiers removed
 
 parse
-CREATE CHANGEFEED FOR TABLE foo, db.bar, schema.db.foo INTO 'sink'
+CREATE CHANGEFEED FOR TABLE foo, db.bar, foo FAMILY bar, schema.db.foo INTO 'sink'
 ----
-CREATE CHANGEFEED FOR TABLE foo, db.bar, schema.db.foo INTO 'sink'
-CREATE CHANGEFEED FOR TABLE (foo), (db.bar), (schema.db.foo) INTO ('sink') -- fully parenthesized
-CREATE CHANGEFEED FOR TABLE foo, db.bar, schema.db.foo INTO '_' -- literals removed
-CREATE CHANGEFEED FOR TABLE _, _._, _._._ INTO 'sink' -- identifiers removed
+CREATE CHANGEFEED FOR TABLE foo, TABLE db.bar, TABLE foo FAMILY bar, TABLE schema.db.foo INTO 'sink' -- normalized!
+CREATE CHANGEFEED FOR TABLE (foo), TABLE (db.bar), TABLE (foo) FAMILY bar, TABLE (schema.db.foo) INTO ('sink') -- fully parenthesized
+CREATE CHANGEFEED FOR TABLE foo, TABLE db.bar, TABLE foo FAMILY bar, TABLE schema.db.foo INTO '_' -- literals removed
+CREATE CHANGEFEED FOR TABLE _, TABLE _._, TABLE _ FAMILY _, TABLE _._._ INTO 'sink' -- identifiers removed
 
 parse
 CREATE CHANGEFEED FOR TABLE foo INTO 'sink'

--- a/pkg/sql/sem/tree/alter_changefeed.go
+++ b/pkg/sql/sem/tree/alter_changefeed.go
@@ -58,14 +58,14 @@ var _ AlterChangefeedCmd = &AlterChangefeedUnsetOptions{}
 
 // AlterChangefeedAddTarget represents an ADD <targets> command
 type AlterChangefeedAddTarget struct {
-	Targets TargetList
+	Targets ChangefeedTargets
 	Options KVOptions
 }
 
 // Format implements the NodeFormatter interface.
 func (node *AlterChangefeedAddTarget) Format(ctx *FmtCtx) {
 	ctx.WriteString(" ADD ")
-	ctx.FormatNode(&node.Targets.Tables)
+	ctx.FormatNode(&node.Targets)
 	if node.Options != nil {
 		ctx.WriteString(" WITH ")
 		ctx.FormatNode(&node.Options)
@@ -74,13 +74,13 @@ func (node *AlterChangefeedAddTarget) Format(ctx *FmtCtx) {
 
 // AlterChangefeedDropTarget represents an DROP <targets> command
 type AlterChangefeedDropTarget struct {
-	Targets TargetList
+	Targets ChangefeedTargets
 }
 
 // Format implements the NodeFormatter interface.
 func (node *AlterChangefeedDropTarget) Format(ctx *FmtCtx) {
 	ctx.WriteString(" DROP ")
-	ctx.FormatNode(&node.Targets.Tables)
+	ctx.FormatNode(&node.Targets)
 }
 
 // AlterChangefeedSetOptions represents an SET <options> command

--- a/pkg/sql/sem/tree/changefeed.go
+++ b/pkg/sql/sem/tree/changefeed.go
@@ -12,7 +12,7 @@ package tree
 
 // CreateChangefeed represents a CREATE CHANGEFEED statement.
 type CreateChangefeed struct {
-	Targets TargetList
+	Targets ChangefeedTargets
 	SinkURI Expr
 	Options KVOptions
 }
@@ -37,5 +37,34 @@ func (node *CreateChangefeed) Format(ctx *FmtCtx) {
 	if node.Options != nil {
 		ctx.WriteString(" WITH ")
 		ctx.FormatNode(&node.Options)
+	}
+}
+
+// ChangefeedTarget represents a database object to be watched by a changefeed.
+type ChangefeedTarget struct {
+	TableName  TablePattern
+	FamilyName Name
+}
+
+// Format implements the NodeFormatter interface.
+func (ct *ChangefeedTarget) Format(ctx *FmtCtx) {
+	ctx.WriteString("TABLE ")
+	ctx.FormatNode(ct.TableName)
+	if ct.FamilyName != "" {
+		ctx.WriteString(" FAMILY ")
+		ctx.FormatNode(&ct.FamilyName)
+	}
+}
+
+// ChangefeedTargets represents a list of database objects to be watched by a changefeed.
+type ChangefeedTargets []ChangefeedTarget
+
+// Format implements the NodeFormatter interface.
+func (cts *ChangefeedTargets) Format(ctx *FmtCtx) {
+	for i, ct := range *cts {
+		if i > 0 {
+			ctx.WriteString(", ")
+		}
+		ctx.FormatNode(&ct)
 	}
 }


### PR DESCRIPTION
Implements "CREATE CHANGEFEED FOR foo FAMILY bar". `foo FAMILY bar` is
a target, and can be part of a target list. The same table can now appear
multiple times in the same feed. (Fanning out to different topics will
be a separate PR, right now it's still by default a topic per table).

The rangefeed still covers the entire primary key span. I don't think
there's much room for efficiency gain by enabling it to filter by family,
but it's worth looking into. Instead we cache a check by family id in
the changefeed processor.

Release note (enterprise change): Changefeeds can now specify column families to target, using the syntax `[TABLE] foo FAMILY bar`. For example,`CREATE CHANGEFEED FOR TABLE foo FAMILY bar, TABLE foo FAMILY baz, TABLE users` will create a feed that watches the bar and baz column families of foo, as well as the whole table users. A family must exist with that name when the feed is created. If all columns in a watched family are dropped in an ALTER TABLE statement, the feed will fail with an error, similarly to dropping a table. Behavior is otherwise similar to feeds created using split_column_families.

Release note (sql change): Changefeeds can now specify column families to target, using the syntax `[TABLE] foo FAMILY bar`. For example,`EXPERIMENTAL CHANGEFEED FOR TABLE foo FAM
ILY bar, TABLE foo FAMILY baz, TABLE users` will create a feed that watches the bar and baz column families of foo, as well as the whole table users. A family must exist with that
name when the feed is created. If all columns in a watched family are dropped in an ALTER TABLE statement, the feed will fail with an error, similarly to dropping a table. Behavior
 is otherwise similar to feeds created using split_column_families.

Release justification: Additive change that mainly takes advantage of existing plumbing already merged.