### PR TITLE
sql: backend changes to surface unused index recommendations

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -4672,6 +4672,7 @@ Response object returned by TableIndexStatsResponse.
 | ----- | ---- | ----- | ----------- | -------------- |
 | statistics | [TableIndexStatsResponse.ExtendedCollectedIndexUsageStatistics](#cockroach.server.serverpb.TableIndexStatsResponse-cockroach.server.serverpb.TableIndexStatsResponse.ExtendedCollectedIndexUsageStatistics) | repeated |  | [reserved](#support-status) |
 | last_reset | [google.protobuf.Timestamp](#cockroach.server.serverpb.TableIndexStatsResponse-google.protobuf.Timestamp) |  | Timestamp of the last index usage stats reset. | [reserved](#support-status) |
+| index_recommendations | [cockroach.sql.IndexRecommendation](#cockroach.server.serverpb.TableIndexStatsResponse-cockroach.sql.IndexRecommendation) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -5096,6 +5097,7 @@ zone configuration, and size statistics for a database.
 | range_count | [int64](#cockroach.server.serverpb.DatabaseDetailsResponse-int64) |  | The number of ranges, as determined from a query of range meta keys, across all tables. | [reserved](#support-status) |
 | approximate_disk_bytes | [uint64](#cockroach.server.serverpb.DatabaseDetailsResponse-uint64) |  | An approximation of the disk space (in bytes) used for all replicas of all tables across the cluster. | [reserved](#support-status) |
 | node_ids | [int32](#cockroach.server.serverpb.DatabaseDetailsResponse-int32) | repeated | node_ids is the ordered list of node ids on which data is stored. | [reserved](#support-status) |
+| num_index_recommendations | [int32](#cockroach.server.serverpb.DatabaseDetailsResponse-int32) |  |  | [reserved](#support-status) |
 
 
 
@@ -5165,6 +5167,7 @@ a table.
 | descriptor_id | [int64](#cockroach.server.serverpb.TableDetailsResponse-int64) |  | descriptor_id is an identifier used to uniquely identify this table. It can be used to find events pertaining to this table by filtering on the 'target_id' field of events. | [reserved](#support-status) |
 | configure_zone_statement | [string](#cockroach.server.serverpb.TableDetailsResponse-string) |  | configure_zone_statement is the output of "SHOW ZONE CONFIGURATION FOR TABLE" for this table. It is a SQL statement that would re-configure the table's current zone if executed. | [reserved](#support-status) |
 | stats_last_created_at | [google.protobuf.Timestamp](#cockroach.server.serverpb.TableDetailsResponse-google.protobuf.Timestamp) |  | stats_last_created_at is the time at which statistics were last created. | [reserved](#support-status) |
+| has_index_recommendations | [bool](#cockroach.server.serverpb.TableDetailsResponse-bool) |  | has_index_recommendations notifies if the there are index recommendations on this table. | [reserved](#support-status) |
 
 
 

--- a/docs/generated/swagger/spec.json
+++ b/docs/generated/swagger/spec.json
@@ -1276,6 +1276,11 @@
           },
           "x-go-name": "Grants"
         },
+        "has_index_recommendations": {
+          "description": "has_index_recommendations notifies if the there are index recommendations\non this table.",
+          "type": "boolean",
+          "x-go-name": "HasIndexRecommendations"
+        },
         "indexes": {
           "type": "array",
           "items": {

--- a/pkg/base/testing_knobs.go
+++ b/pkg/base/testing_knobs.go
@@ -49,4 +49,5 @@ type TestingKnobs struct {
 	ProtectedTS                  ModuleTestingKnobs
 	CapturedIndexUsageStatsKnobs ModuleTestingKnobs
 	AdmissionControl             ModuleTestingKnobs
+	UnusedIndexRecommendKnobs    ModuleTestingKnobs
 }

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "addjoin.go",
         "admin.go",
+        "admin_test_utils.go",
         "api_v2.go",
         "api_v2_auth.go",
         "api_v2_error.go",
@@ -388,6 +389,7 @@ go_test(
         "//pkg/sql/catalog/dbdesc",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/execinfrapb",
+        "//pkg/sql/idxusage",
         "//pkg/sql/roleoption",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -510,6 +510,10 @@ func (s *adminServer) databaseDetailsHelper(
 		if err != nil {
 			return nil, err
 		}
+		resp.Stats.NumIndexRecommendations, err = s.getNumDatabaseIndexRecommendations(ctx, req.Database, resp.TableNames)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &resp, nil
@@ -605,6 +609,25 @@ func (s *adminServer) getDatabaseStats(
 	})
 
 	return &stats, nil
+}
+
+func (s *adminServer) getNumDatabaseIndexRecommendations(
+	ctx context.Context, databaseName string, tableNames []string,
+) (int32, error) {
+	var numDatabaseIndexRecommendations int
+	idxUsageStatsProvider := s.server.sqlServer.pgServer.SQLServer.GetLocalIndexStatistics()
+	for _, tableName := range tableNames {
+		tableIndexStatsRequest := &serverpb.TableIndexStatsRequest{
+			Database: databaseName,
+			Table:    tableName,
+		}
+		tableIndexStatsResponse, err := getTableIndexUsageStats(ctx, tableIndexStatsRequest, idxUsageStatsProvider, s.ie, s.server.st, s.server.sqlServer.execCfg)
+		if err != nil {
+			return 0, err
+		}
+		numDatabaseIndexRecommendations += len(tableIndexStatsResponse.IndexRecommendations)
+	}
+	return int32(numDatabaseIndexRecommendations), nil
 }
 
 // getFullyQualifiedTableName, given a database name and a tableName that either
@@ -960,6 +983,16 @@ func (s *adminServer) tableDetailsHelper(
 		resp.RangeCount = rangeCount
 	}
 
+	idxUsageStatsProvider := s.server.sqlServer.pgServer.SQLServer.GetLocalIndexStatistics()
+	tableIndexStatsRequest := &serverpb.TableIndexStatsRequest{
+		Database: req.Database,
+		Table:    req.Table,
+	}
+	tableIndexStatsResponse, err := getTableIndexUsageStats(ctx, tableIndexStatsRequest, idxUsageStatsProvider, s.ie, s.server.st, s.server.sqlServer.execCfg)
+	if err != nil {
+		return nil, err
+	}
+	resp.HasIndexRecommendations = len(tableIndexStatsResponse.IndexRecommendations) > 0
 	return &resp, nil
 }
 

--- a/pkg/server/admin_test_utils.go
+++ b/pkg/server/admin_test_utils.go
@@ -1,0 +1,60 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+type stubUnusedIndexTime struct {
+	syncutil.RWMutex
+	current   time.Time
+	lastRead  time.Time
+	createdAt *time.Time
+}
+
+func (s *stubUnusedIndexTime) setCurrent(t time.Time) {
+	s.RWMutex.Lock()
+	defer s.RWMutex.Unlock()
+	s.current = t
+}
+
+func (s *stubUnusedIndexTime) setLastRead(t time.Time) {
+	s.RWMutex.Lock()
+	defer s.RWMutex.Unlock()
+	s.lastRead = t
+}
+
+func (s *stubUnusedIndexTime) setCreatedAt(t *time.Time) {
+	s.RWMutex.Lock()
+	defer s.RWMutex.Unlock()
+	s.createdAt = t
+}
+
+func (s *stubUnusedIndexTime) getCurrent() time.Time {
+	s.RWMutex.RLock()
+	defer s.RWMutex.RUnlock()
+	return s.current
+}
+
+func (s *stubUnusedIndexTime) getLastRead() time.Time {
+	s.RWMutex.RLock()
+	defer s.RWMutex.RUnlock()
+	return s.lastRead
+}
+
+func (s *stubUnusedIndexTime) getCreatedAt() *time.Time {
+	s.RWMutex.RLock()
+	defer s.RWMutex.RUnlock()
+	return s.createdAt
+}

--- a/pkg/server/index_usage_stats.go
+++ b/pkg/server/index_usage_stats.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/idxusage"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -197,7 +198,7 @@ func (s *statusServer) TableIndexStats(
 		return nil, err
 	}
 	return getTableIndexUsageStats(ctx, req, s.sqlServer.pgServer.SQLServer.GetLocalIndexStatistics(),
-		s.sqlServer.internalExecutor)
+		s.sqlServer.internalExecutor, s.st, s.sqlServer.execCfg)
 }
 
 // getTableIndexUsageStats is a helper function that reads the indexes
@@ -208,6 +209,8 @@ func getTableIndexUsageStats(
 	req *serverpb.TableIndexStatsRequest,
 	idxUsageStatsProvider *idxusage.LocalIndexUsageStats,
 	ie *sql.InternalExecutor,
+	st *cluster.Settings,
+	execConfig *sql.ExecutorConfig,
 ) (*serverpb.TableIndexStatsResponse, error) {
 	userName, err := userFromContext(ctx)
 	if err != nil {
@@ -254,6 +257,7 @@ func getTableIndexUsageStats(
 	}
 
 	var idxUsageStats []*serverpb.TableIndexStatsResponse_ExtendedCollectedIndexUsageStatistics
+	var idxRecommendations []*serverpb.IndexRecommendation
 	var ok bool
 
 	// We have to make sure to close the iterator since we might return from the
@@ -306,14 +310,21 @@ func getTableIndexUsageStats(
 			CreatedAt:       createdAt,
 		}
 
+		statsRow := idxusage.IndexStatsRow{
+			Row:              idxStatsRow,
+			UnusedIndexKnobs: execConfig.UnusedIndexRecommendationsKnobs,
+		}
+		recommendations := statsRow.GetRecommendationsFromIndexStats(st)
+		idxRecommendations = append(idxRecommendations, recommendations...)
 		idxUsageStats = append(idxUsageStats, idxStatsRow)
 	}
 
 	lastReset := idxUsageStatsProvider.GetLastReset()
 
 	resp := &serverpb.TableIndexStatsResponse{
-		Statistics: idxUsageStats,
-		LastReset:  &lastReset,
+		Statistics:           idxUsageStats,
+		LastReset:            &lastReset,
+		IndexRecommendations: idxRecommendations,
 	}
 
 	return resp, nil
@@ -335,7 +346,10 @@ func getTableIDFromDatabaseAndTableName(
 		return 0, err
 	}
 	names := strings.Split(fqtName, ".")
-
+	// Strip quotations marks from db and table names.
+	for idx := range names {
+		names[idx] = strings.Trim(names[idx], "\"")
+	}
 	q := makeSQLQuery()
 	q.Append(`SELECT table_id FROM crdb_internal.tables WHERE database_name = $ `, names[0])
 

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -69,6 +69,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/gcjob/gcjobnotifier"
+	"github.com/cockroachdb/cockroach/pkg/sql/idxusage"
 	"github.com/cockroachdb/cockroach/pkg/sql/optionalnodeliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
 	"github.com/cockroachdb/cockroach/pkg/sql/querycache"
@@ -806,6 +807,10 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	}
 	if capturedIndexUsageStatsKnobs := cfg.TestingKnobs.CapturedIndexUsageStatsKnobs; capturedIndexUsageStatsKnobs != nil {
 		execCfg.CaptureIndexUsageStatsKnobs = capturedIndexUsageStatsKnobs.(*scheduledlogging.CaptureIndexUsageStatsTestingKnobs)
+	}
+
+	if unusedIndexRecommendationsKnobs := cfg.TestingKnobs.UnusedIndexRecommendKnobs; unusedIndexRecommendationsKnobs != nil {
+		execCfg.UnusedIndexRecommendationsKnobs = unusedIndexRecommendationsKnobs.(*idxusage.UnusedIndexRecommendationTestingKnobs)
 	}
 
 	statsRefresher := stats.MakeRefresher(

--- a/pkg/server/serverpb/BUILD.bazel
+++ b/pkg/server/serverpb/BUILD.bazel
@@ -9,6 +9,7 @@ proto_library(
     srcs = [
         "admin.proto",
         "authentication.proto",
+        "index_recommendations.proto",
         "init.proto",
         "migration.proto",
         "status.proto",

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -93,6 +93,8 @@ message DatabaseDetailsResponse {
     // node_ids is the ordered list of node ids on which data is stored.
     repeated int32 node_ids = 4 [(gogoproto.customname) = "NodeIDs",
       (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"];
+
+    int32 num_index_recommendations = 5;
   }
 
   // grants are the results of SHOW GRANTS for this database.
@@ -213,6 +215,9 @@ message TableDetailsResponse {
   string configure_zone_statement = 9;
   // stats_last_created_at is the time at which statistics were last created.
   google.protobuf.Timestamp stats_last_created_at = 10 [(gogoproto.stdtime) = true];
+  // has_index_recommendations notifies if the there are index recommendations
+  // on this table.
+  bool has_index_recommendations = 11;
 }
 
 // TableStatsRequest is a request for detailed, computationally expensive

--- a/pkg/server/serverpb/index_recommendations.proto
+++ b/pkg/server/serverpb/index_recommendations.proto
@@ -1,0 +1,33 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+syntax = "proto2";
+package cockroach.sql;
+option go_package = "serverpb";
+
+import "gogoproto/gogo.proto";
+
+message IndexRecommendation {
+  enum RecommendationType {
+    DROP_UNUSED = 0;
+  }
+  // TableID is the ID of the table this index is created on. This is same as
+  // descpb.TableID and is unique within the cluster.
+  optional uint32 table_id = 1 [(gogoproto.nullable) = false,
+    (gogoproto.customname) = "TableID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.TableID"];
+  // IndexID is the ID of the index within the scope of the given table.
+  optional uint32 index_id = 2 [(gogoproto.nullable) = false,
+    (gogoproto.customname) = "IndexID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.IndexID" ];
+
+  // Type of recommendation for the index.
+  optional RecommendationType type = 3 [(gogoproto.nullable) = false];
+  // Reason for our recommendation type.
+  optional string reason = 4 [(gogoproto.nullable) = false];
+}

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -20,8 +20,7 @@ import "roachpb/data.proto";
 import "roachpb/index_usage_stats.proto";
 import "roachpb/metadata.proto";
 import "server/diagnostics/diagnosticspb/diagnostics.proto";
-import "util/tracing/tracingpb/recorded_span.proto";
-import "util/tracing/tracingpb/tracing.proto";
+import "server/serverpb/index_recommendations.proto";
 import "server/status/statuspb/status.proto";
 import "sql/contentionpb/contention.proto";
 import "sql/execinfrapb/api.proto";
@@ -34,6 +33,8 @@ import "kv/kvserver/liveness/livenesspb/liveness.proto";
 import "util/log/logpb/log.proto";
 import "util/unresolved_addr.proto";
 import "util/hlc/timestamp.proto";
+import "util/tracing/tracingpb/recorded_span.proto";
+import "util/tracing/tracingpb/tracing.proto";
 
 import "etcd/raft/v3/raftpb/raft.proto";
 
@@ -1682,6 +1683,7 @@ message TableIndexStatsResponse {
   repeated ExtendedCollectedIndexUsageStatistics statistics = 1;
   // Timestamp of the last index usage stats reset.
   google.protobuf.Timestamp last_reset = 2 [(gogoproto.stdtime) = true];
+  repeated cockroach.sql.IndexRecommendation index_recommendations = 3;
 }
 
 // Request object for issuing a index usage stats reset request.

--- a/pkg/server/tenant_status.go
+++ b/pkg/server/tenant_status.go
@@ -982,7 +982,7 @@ func (t *tenantStatusServer) TableIndexStats(
 	}
 
 	return getTableIndexUsageStats(ctx, req, t.sqlServer.pgServer.SQLServer.GetLocalIndexStatistics(),
-		t.sqlServer.internalExecutor)
+		t.sqlServer.internalExecutor, t.st, t.sqlServer.execCfg)
 }
 
 // Details returns information for a given instance ID such as

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -64,6 +64,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/gcjob/gcjobnotifier"
+	"github.com/cockroachdb/cockroach/pkg/sql/idxusage"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/optionalnodeliveness"
@@ -1201,6 +1202,8 @@ type ExecutorConfig struct {
 	TelemetryLoggingTestingKnobs         *TelemetryLoggingTestingKnobs
 	SpanConfigTestingKnobs               *spanconfig.TestingKnobs
 	CaptureIndexUsageStatsKnobs          *scheduledlogging.CaptureIndexUsageStatsTestingKnobs
+	UnusedIndexRecommendationsKnobs      *idxusage.UnusedIndexRecommendationTestingKnobs
+
 	// HistogramWindowInterval is (server.Config).HistogramWindowInterval.
 	HistogramWindowInterval time.Duration
 

--- a/pkg/sql/idxusage/BUILD.bazel
+++ b/pkg/sql/idxusage/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "cluster_settings.go",
         "index_usage_stats_controller.go",
+        "index_usage_stats_rec.go",
         "local_idx_usage_stats.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/idxusage",
@@ -22,10 +23,14 @@ go_library(
 
 go_test(
     name = "idxusage_test",
-    srcs = ["local_index_usage_stats_test.go"],
+    srcs = [
+        "index_usage_stats_rec_test.go",
+        "local_index_usage_stats_test.go",
+    ],
     embed = [":idxusage"],
     deps = [
         "//pkg/roachpb",
+        "//pkg/server/serverpb",
         "//pkg/settings/cluster",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/sql/idxusage/index_usage_stats_rec.go
+++ b/pkg/sql/idxusage/index_usage_stats_rec.go
@@ -1,0 +1,129 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package idxusage
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// IndexStatsRow is a wrapper type around
+// serverpb.TableIndexStatsResponse_ExtendedCollectedIndexUsageStatistics that
+// implements additional methods to support unused index recommendations and
+// hold testing knobs.
+type IndexStatsRow struct {
+	Row              *serverpb.TableIndexStatsResponse_ExtendedCollectedIndexUsageStatistics
+	UnusedIndexKnobs *UnusedIndexRecommendationTestingKnobs
+}
+
+// defaultUnusedIndexDuration is a week.
+const defaultUnusedIndexDuration = 7 * 24 * time.Hour
+
+// DropUnusedIndexDuration registers the index unuse duration at which we
+// begin to recommend dropping the index.
+var DropUnusedIndexDuration = settings.RegisterDurationSetting(
+	settings.TenantWritable,
+	"sql.index_recommendation.drop_unused_duration",
+	"the index unuse duration at which we begin to recommend dropping the index",
+	defaultUnusedIndexDuration,
+	settings.NonNegativeDuration,
+)
+
+const indexExceedUsageDurationReasonPlaceholder = "This index has not been used in over %s and can be removed for better write performance."
+const indexNeverUsedReason = "This index has not been used and can be removed for better write performance."
+
+// UnusedIndexRecommendationTestingKnobs provides hooks and knobs for unit tests.
+type UnusedIndexRecommendationTestingKnobs struct {
+	// GetCreatedAt allows tests to override the creation time of the index.
+	GetCreatedAt func() *time.Time
+	// GetLastRead allows tests to override the time the index was last read.
+	GetLastRead func() time.Time
+	// GetCurrentTime allows tests to override the current time.
+	GetCurrentTime func() time.Time
+}
+
+// ModuleTestingKnobs implements base.ModuleTestingKnobs interface.
+func (*UnusedIndexRecommendationTestingKnobs) ModuleTestingKnobs() {}
+
+// GetRecommendationsFromIndexStats gets index recommendations from the given index
+// if applicable.
+func (i IndexStatsRow) GetRecommendationsFromIndexStats(
+	st *cluster.Settings,
+) []*serverpb.IndexRecommendation {
+	var recommendations []*serverpb.IndexRecommendation
+	rec := i.maybeAddUnusedIndexRecommendation(DropUnusedIndexDuration.Get(&st.SV))
+	if rec != nil {
+		recommendations = append(recommendations, rec)
+	}
+	return recommendations
+}
+
+func (i IndexStatsRow) maybeAddUnusedIndexRecommendation(
+	unusedIndexDuration time.Duration,
+) *serverpb.IndexRecommendation {
+	var rec *serverpb.IndexRecommendation
+
+	if i.UnusedIndexKnobs == nil {
+		rec = i.recommendDropUnusedIndex(timeutil.Now(), i.Row.CreatedAt,
+			i.Row.Statistics.Stats.LastRead, unusedIndexDuration)
+	} else {
+		rec = i.recommendDropUnusedIndex(i.UnusedIndexKnobs.GetCurrentTime(),
+			i.UnusedIndexKnobs.GetCreatedAt(), i.UnusedIndexKnobs.GetLastRead(), unusedIndexDuration)
+	}
+	return rec
+}
+
+// recommendDropUnusedIndex checks whether the last usage of an index
+// qualifies the index as unused, if so returns an index recommendation.
+func (i IndexStatsRow) recommendDropUnusedIndex(
+	currentTime time.Time,
+	createdAt *time.Time,
+	lastRead time.Time,
+	unusedIndexDuration time.Duration,
+) *serverpb.IndexRecommendation {
+	lastActive := lastRead
+	if lastActive.Equal(time.Time{}) && createdAt != nil {
+		lastActive = *createdAt
+	}
+	// If we do not have the creation time and index has never been read. Recommend
+	// dropping with a "never used" reason.
+	if lastActive.Equal(time.Time{}) {
+		return &serverpb.IndexRecommendation{
+			TableID: i.Row.Statistics.Key.TableID,
+			IndexID: i.Row.Statistics.Key.IndexID,
+			Type:    serverpb.IndexRecommendation_DROP_UNUSED,
+			Reason:  indexNeverUsedReason,
+		}
+	}
+	// Last usage of the index exceeds the unused index duration.
+	if currentTime.Sub(lastActive) >= unusedIndexDuration {
+		return &serverpb.IndexRecommendation{
+			TableID: i.Row.Statistics.Key.TableID,
+			IndexID: i.Row.Statistics.Key.IndexID,
+			Type:    serverpb.IndexRecommendation_DROP_UNUSED,
+			Reason:  fmt.Sprintf(indexExceedUsageDurationReasonPlaceholder, formatDuration(unusedIndexDuration)),
+		}
+	}
+	return nil
+}
+
+func formatDuration(d time.Duration) string {
+	days := d / (24 * time.Hour)
+	hours := d % (24 * time.Hour)
+	minutes := hours % time.Hour
+
+	return fmt.Sprintf("%dd%dh%dm", days, hours/time.Hour, minutes)
+}

--- a/pkg/sql/idxusage/index_usage_stats_rec_test.go
+++ b/pkg/sql/idxusage/index_usage_stats_rec_test.go
@@ -1,0 +1,120 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package idxusage
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecommendDropUnusedIndex(t *testing.T) {
+
+	var currentTime = timeutil.Now()
+	var anHourBefore = currentTime.Add(-time.Hour)
+	var aMinuteBefore = currentTime.Add(-time.Minute)
+
+	type expectedReturn struct {
+		recommendation *serverpb.IndexRecommendation
+	}
+
+	stubIndexStatsRow := &serverpb.TableIndexStatsResponse_ExtendedCollectedIndexUsageStatistics{
+		Statistics: &roachpb.CollectedIndexUsageStatistics{
+			Key: roachpb.IndexUsageKey{
+				TableID: 1,
+				IndexID: 1,
+			},
+		},
+	}
+
+	indexStatsRow := IndexStatsRow{
+		Row: stubIndexStatsRow,
+	}
+
+	testData := []struct {
+		currentTime         time.Time
+		createdAt           *time.Time
+		lastRead            time.Time
+		unusedIndexDuration time.Duration
+		expectedReturn      expectedReturn
+	}{
+		{
+			currentTime:         currentTime,
+			createdAt:           nil,
+			lastRead:            anHourBefore,
+			unusedIndexDuration: time.Hour,
+			expectedReturn: expectedReturn{
+				recommendation: &serverpb.IndexRecommendation{
+					TableID: 1,
+					IndexID: 1,
+					Type:    serverpb.IndexRecommendation_DROP_UNUSED,
+					Reason:  fmt.Sprintf(indexExceedUsageDurationReasonPlaceholder, formatDuration(time.Hour)),
+				},
+			},
+		},
+		{
+			currentTime:         currentTime,
+			createdAt:           nil,
+			lastRead:            aMinuteBefore,
+			unusedIndexDuration: time.Hour,
+			expectedReturn: expectedReturn{
+				recommendation: nil,
+			},
+		},
+		{
+			currentTime:         currentTime,
+			createdAt:           nil,
+			lastRead:            time.Time{},
+			unusedIndexDuration: time.Hour,
+			expectedReturn: expectedReturn{
+				recommendation: &serverpb.IndexRecommendation{
+					TableID: 1,
+					IndexID: 1,
+					Type:    serverpb.IndexRecommendation_DROP_UNUSED,
+					Reason:  indexNeverUsedReason,
+				},
+			},
+		},
+		{
+			currentTime:         currentTime,
+			createdAt:           &anHourBefore,
+			lastRead:            time.Time{},
+			unusedIndexDuration: time.Hour,
+			expectedReturn: expectedReturn{
+				recommendation: &serverpb.IndexRecommendation{
+					TableID: 1,
+					IndexID: 1,
+					Type:    serverpb.IndexRecommendation_DROP_UNUSED,
+					Reason:  fmt.Sprintf(indexExceedUsageDurationReasonPlaceholder, formatDuration(time.Hour)),
+				},
+			},
+		},
+		{
+			currentTime:         currentTime,
+			createdAt:           &aMinuteBefore,
+			lastRead:            time.Time{},
+			unusedIndexDuration: time.Hour,
+			expectedReturn: expectedReturn{
+				recommendation: nil,
+			},
+		},
+	}
+
+	for _, tc := range testData {
+		actualRecommendation := indexStatsRow.recommendDropUnusedIndex(tc.currentTime, tc.createdAt, tc.lastRead, tc.unusedIndexDuration)
+		require.Equal(t, tc.expectedReturn.recommendation, actualRecommendation)
+	}
+}

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -123,7 +123,7 @@ func (ef *execFactory) ConstructScan(
 		scan.lockingWaitPolicy = descpb.ToScanLockingWaitPolicy(params.Locking.WaitPolicy)
 	}
 	scan.localityOptimized = params.LocalityOptimized
-	if !ef.isExplain {
+	if !ef.isExplain && !ef.planner.isInternalPlanner {
 		idxUsageKey := roachpb.IndexUsageKey{
 			TableID: roachpb.TableID(tabDesc.GetID()),
 			IndexID: roachpb.IndexID(idx.GetID()),


### PR DESCRIPTION
This change introduces backend changes to surface drop index
recommendations for unused indices. As a first iteration, this change
implements a naive approach where we compute index recommendations
ad-hoc on request (for the database details, table details, and index
usage stats requests), and offers no persistence.

Release note (api change): Added logic to support dropping unused index
recommendations.