### PR TITLE
opt: tweaked formula to combine single- and multi-column stats

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
@@ -1097,16 +1097,16 @@ vectorized: true
     └── • lookup join (anti)
         │ columns: (crdb_internal_email_shard_16_comp, column1, column2, column3)
         │ estimated row count: 0 (missing stats)
-        │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+        │ table: t_unique_hash_sec_key@idx_uniq_hash_email
         │ equality cols are key
-        │ lookup condition: (column1 = id) AND (part IN ('new york', 'seattle'))
+        │ lookup condition: ((column2 = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
         │
         └── • lookup join (anti)
             │ columns: (crdb_internal_email_shard_16_comp, column1, column2, column3)
             │ estimated row count: 0 (missing stats)
-            │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+            │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
             │ equality cols are key
-            │ lookup condition: ((column2 = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+            │ lookup condition: (column1 = id) AND (part IN ('new york', 'seattle'))
             │
             └── • render
                 │ columns: (crdb_internal_email_shard_16_comp, column1, column2, column3)

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
@@ -443,13 +443,13 @@ vectorized: true
             │
             ├── • scan
             │     columns: (id)
-            │     estimated row count: 0 (missing stats)
+            │     estimated row count: 1 (missing stats)
             │     table: t_unique_hash_pk@t_unique_hash_pk_pkey
             │     spans: /"@"/9/4321/0
             │
             └── • scan
                   columns: (id)
-                  estimated row count: 0 (missing stats)
+                  estimated row count: 1 (missing stats)
                   table: t_unique_hash_pk@t_unique_hash_pk_pkey
                   spans: /"\x80"/9/4321/0 /"\xc0"/9/4321/0
                   parallel
@@ -546,13 +546,13 @@ vectorized: true
             │
             ├── • scan
             │     columns: (id)
-            │     estimated row count: 0 (missing stats)
+            │     estimated row count: 1 (missing stats)
             │     table: t_unique_hash_pk@t_unique_hash_pk_pkey
             │     spans: /"@"/9/4321/0
             │
             └── • scan
                   columns: (id)
-                  estimated row count: 0 (missing stats)
+                  estimated row count: 1 (missing stats)
                   table: t_unique_hash_pk@t_unique_hash_pk_pkey
                   spans: /"\x80"/9/4321/0 /"\xc0"/9/4321/0
                   parallel
@@ -676,13 +676,13 @@ vectorized: true
 │                           │
 │                           ├── • scan
 │                           │     columns: (crdb_internal_id_shard_16, id, crdb_region)
-│                           │     estimated row count: 0 (missing stats)
+│                           │     estimated row count: 1 (missing stats)
 │                           │     table: t_unique_hash_pk@t_unique_hash_pk_pkey
 │                           │     spans: /"@"/9/4321/0
 │                           │
 │                           └── • scan
 │                                 columns: (crdb_internal_id_shard_16, id, crdb_region)
-│                                 estimated row count: 0 (missing stats)
+│                                 estimated row count: 1 (missing stats)
 │                                 table: t_unique_hash_pk@t_unique_hash_pk_pkey
 │                                 spans: /"\x80"/9/4321/0 /"\xc0"/9/4321/0
 │                                 parallel
@@ -847,13 +847,13 @@ vectorized: true
             │
             ├── • scan
             │     columns: (crdb_internal_id_shard_16, id, crdb_region)
-            │     estimated row count: 0 (missing stats)
+            │     estimated row count: 1 (missing stats)
             │     table: t_unique_hash_pk@t_unique_hash_pk_pkey
             │     spans: /"@"/9/4321/0
             │
             └── • scan
                   columns: (crdb_internal_id_shard_16, id, crdb_region)
-                  estimated row count: 0 (missing stats)
+                  estimated row count: 1 (missing stats)
                   table: t_unique_hash_pk@t_unique_hash_pk_pkey
                   spans: /"\x80"/9/4321/0 /"\xc0"/9/4321/0
                   parallel
@@ -945,13 +945,13 @@ vectorized: true
 │               │
 │               ├── • scan
 │               │     columns: (crdb_internal_id_shard_16, id, crdb_region)
-│               │     estimated row count: 0 (missing stats)
+│               │     estimated row count: 1 (missing stats)
 │               │     table: t_unique_hash_pk@t_unique_hash_pk_pkey
 │               │     spans: /"@"/9/4321/0
 │               │
 │               └── • scan
 │                     columns: (crdb_internal_id_shard_16, id, crdb_region)
-│                     estimated row count: 0 (missing stats)
+│                     estimated row count: 1 (missing stats)
 │                     table: t_unique_hash_pk@t_unique_hash_pk_pkey
 │                     spans: /"\x80"/9/4321/0 /"\xc0"/9/4321/0
 │                     parallel
@@ -1124,7 +1124,7 @@ vectorized: true
                     │
                     ├── • scan
                     │     columns: (id)
-                    │     estimated row count: 0 (missing stats)
+                    │     estimated row count: 1 (missing stats)
                     │     table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
                     │     spans: /"@"/4321/0
                     │
@@ -1250,13 +1250,13 @@ vectorized: true
 │                       │
 │                       ├── • scan
 │                       │     columns: (email)
-│                       │     estimated row count: 0 (missing stats)
+│                       │     estimated row count: 1 (missing stats)
 │                       │     table: t_unique_hash_sec_key@idx_uniq_hash_email
 │                       │     spans: /"@"/13/"some_email"/0
 │                       │
 │                       └── • scan
 │                             columns: (email)
-│                             estimated row count: 0 (missing stats)
+│                             estimated row count: 1 (missing stats)
 │                             table: t_unique_hash_sec_key@idx_uniq_hash_email
 │                             spans: /"\x80"/13/"some_email"/0 /"\xc0"/13/"some_email"/0
 │                             parallel
@@ -1457,13 +1457,13 @@ vectorized: true
 │                               │
 │                               ├── • scan
 │                               │     columns: (id, email, crdb_region)
-│                               │     estimated row count: 0 (missing stats)
+│                               │     estimated row count: 1 (missing stats)
 │                               │     table: t_unique_hash_sec_key@idx_uniq_hash_email
 │                               │     spans: /"@"/13/"some_email"/0
 │                               │
 │                               └── • scan
 │                                     columns: (id, email, crdb_region)
-│                                     estimated row count: 0 (missing stats)
+│                                     estimated row count: 1 (missing stats)
 │                                     table: t_unique_hash_sec_key@idx_uniq_hash_email
 │                                     spans: /"\x80"/13/"some_email"/0 /"\xc0"/13/"some_email"/0
 │                                     parallel
@@ -1731,7 +1731,7 @@ vectorized: true
 │                           │
 │                           ├── • scan
 │                           │     columns: (id, email, crdb_region)
-│                           │     estimated row count: 0 (missing stats)
+│                           │     estimated row count: 1 (missing stats)
 │                           │     table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
 │                           │     spans: /"@"/1/0
 │                           │
@@ -1907,7 +1907,7 @@ vectorized: true
 │               │
 │               ├── • scan
 │               │     columns: (id, email, crdb_region)
-│               │     estimated row count: 0 (missing stats)
+│               │     estimated row count: 1 (missing stats)
 │               │     table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
 │               │     spans: /"@"/2/0
 │               │

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -714,7 +714,7 @@ vectorized: true
     │
     └── • scan
           columns: (x int, y int, z float)
-          estimated row count: 0 (missing stats)
+          estimated row count: 1 (missing stats)
           table: xyz@zyx
           spans: /3/2-/3/3
           limit: 1
@@ -746,7 +746,7 @@ vectorized: true
     │
     └── • revscan
           columns: (x int, y int, z float)
-          estimated row count: 0 (missing stats)
+          estimated row count: 1 (missing stats)
           table: xyz@zyx
           spans: /3/2-/3/3
           limit: 1
@@ -1448,7 +1448,7 @@ vectorized: true
         └── • filter
             │ columns: (k int, v int)
             │ ordering: +v
-            │ estimated row count: 330 (missing stats)
+            │ estimated row count: 333 (missing stats)
             │ filter: ((k)[int] != (4)[int])[bool]
             │
             └── • scan

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -1219,7 +1219,7 @@ vectorized: true
 ·
 • filter
 │ columns: (x int, y int)
-│ estimated row count: 111 (missing stats)
+│ estimated row count: 311 (missing stats)
 │ filter: ((((x)[int] < (10)[int])[bool]) AND (((y)[int] > (10)[int])[bool]))[bool]
 │
 └── • scan
@@ -1654,11 +1654,11 @@ vectorized: true
 ·
 • project
 │ columns: (attnum)
-│ estimated row count: 0 (missing stats)
+│ estimated row count: 1 (missing stats)
 │
 └── • filter
     │ columns: (attrelid, attname, attnum)
-    │ estimated row count: 0 (missing stats)
+    │ estimated row count: 1 (missing stats)
     │ filter: attname = 'b'
     │
     └── • virtual table

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -1082,7 +1082,7 @@ vectorized: true
 │       │
 │       └── • filter
 │           │ columns: (p, data)
-│           │ estimated row count: 111 (missing stats)
+│           │ estimated row count: 311 (missing stats)
 │           │ filter: data > 0
 │           │
 │           └── • scan

--- a/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
@@ -354,22 +354,22 @@ vectorized: true
 └── • union all
     │ columns: (a)
     │ ordering: +a
-    │ estimated row count: 40 (missing stats)
+    │ estimated row count: 112 (missing stats)
     │
     ├── • union all
     │   │ columns: (a)
     │   │ ordering: +a
-    │   │ estimated row count: 13 (missing stats)
+    │   │ estimated row count: 37 (missing stats)
     │   │
     │   ├── • union all
     │   │   │ columns: (a)
     │   │   │ ordering: +a
-    │   │   │ estimated row count: 7 (missing stats)
+    │   │   │ estimated row count: 19 (missing stats)
     │   │   │
     │   │   ├── • scan
     │   │   │     columns: (a)
     │   │   │     ordering: +a
-    │   │   │     estimated row count: 3 (missing stats)
+    │   │   │     estimated row count: 9 (missing stats)
     │   │   │     table: sharded_secondary@sharded_secondary_a_idx
     │   │   │     spans: /8/101-/9
     │   │   │     limit: 10
@@ -377,7 +377,7 @@ vectorized: true
     │   │   └── • scan
     │   │         columns: (a)
     │   │         ordering: +a
-    │   │         estimated row count: 3 (missing stats)
+    │   │         estimated row count: 9 (missing stats)
     │   │         table: sharded_secondary@sharded_secondary_a_idx
     │   │         spans: /9/101-/10
     │   │         limit: 10
@@ -385,12 +385,12 @@ vectorized: true
     │   └── • union all
     │       │ columns: (a)
     │       │ ordering: +a
-    │       │ estimated row count: 7 (missing stats)
+    │       │ estimated row count: 19 (missing stats)
     │       │
     │       ├── • scan
     │       │     columns: (a)
     │       │     ordering: +a
-    │       │     estimated row count: 3 (missing stats)
+    │       │     estimated row count: 9 (missing stats)
     │       │     table: sharded_secondary@sharded_secondary_a_idx
     │       │     spans: /10/101-/11
     │       │     limit: 10
@@ -398,7 +398,7 @@ vectorized: true
     │       └── • scan
     │             columns: (a)
     │             ordering: +a
-    │             estimated row count: 3 (missing stats)
+    │             estimated row count: 9 (missing stats)
     │             table: sharded_secondary@sharded_secondary_a_idx
     │             spans: /11/101-/12
     │             limit: 10
@@ -406,22 +406,22 @@ vectorized: true
     └── • union all
         │ columns: (a)
         │ ordering: +a
-        │ estimated row count: 27 (missing stats)
+        │ estimated row count: 75 (missing stats)
         │
         ├── • union all
         │   │ columns: (a)
         │   │ ordering: +a
-        │   │ estimated row count: 13 (missing stats)
+        │   │ estimated row count: 37 (missing stats)
         │   │
         │   ├── • union all
         │   │   │ columns: (a)
         │   │   │ ordering: +a
-        │   │   │ estimated row count: 7 (missing stats)
+        │   │   │ estimated row count: 19 (missing stats)
         │   │   │
         │   │   ├── • scan
         │   │   │     columns: (a)
         │   │   │     ordering: +a
-        │   │   │     estimated row count: 3 (missing stats)
+        │   │   │     estimated row count: 9 (missing stats)
         │   │   │     table: sharded_secondary@sharded_secondary_a_idx
         │   │   │     spans: /0/101-/1
         │   │   │     limit: 10
@@ -429,7 +429,7 @@ vectorized: true
         │   │   └── • scan
         │   │         columns: (a)
         │   │         ordering: +a
-        │   │         estimated row count: 3 (missing stats)
+        │   │         estimated row count: 9 (missing stats)
         │   │         table: sharded_secondary@sharded_secondary_a_idx
         │   │         spans: /1/101-/2
         │   │         limit: 10
@@ -437,12 +437,12 @@ vectorized: true
         │   └── • union all
         │       │ columns: (a)
         │       │ ordering: +a
-        │       │ estimated row count: 7 (missing stats)
+        │       │ estimated row count: 19 (missing stats)
         │       │
         │       ├── • scan
         │       │     columns: (a)
         │       │     ordering: +a
-        │       │     estimated row count: 3 (missing stats)
+        │       │     estimated row count: 9 (missing stats)
         │       │     table: sharded_secondary@sharded_secondary_a_idx
         │       │     spans: /2/101-/3
         │       │     limit: 10
@@ -450,7 +450,7 @@ vectorized: true
         │       └── • scan
         │             columns: (a)
         │             ordering: +a
-        │             estimated row count: 3 (missing stats)
+        │             estimated row count: 9 (missing stats)
         │             table: sharded_secondary@sharded_secondary_a_idx
         │             spans: /3/101-/4
         │             limit: 10
@@ -458,17 +458,17 @@ vectorized: true
         └── • union all
             │ columns: (a)
             │ ordering: +a
-            │ estimated row count: 13 (missing stats)
+            │ estimated row count: 37 (missing stats)
             │
             ├── • union all
             │   │ columns: (a)
             │   │ ordering: +a
-            │   │ estimated row count: 7 (missing stats)
+            │   │ estimated row count: 19 (missing stats)
             │   │
             │   ├── • scan
             │   │     columns: (a)
             │   │     ordering: +a
-            │   │     estimated row count: 3 (missing stats)
+            │   │     estimated row count: 9 (missing stats)
             │   │     table: sharded_secondary@sharded_secondary_a_idx
             │   │     spans: /4/101-/5
             │   │     limit: 10
@@ -476,7 +476,7 @@ vectorized: true
             │   └── • scan
             │         columns: (a)
             │         ordering: +a
-            │         estimated row count: 3 (missing stats)
+            │         estimated row count: 9 (missing stats)
             │         table: sharded_secondary@sharded_secondary_a_idx
             │         spans: /5/101-/6
             │         limit: 10
@@ -484,12 +484,12 @@ vectorized: true
             └── • union all
                 │ columns: (a)
                 │ ordering: +a
-                │ estimated row count: 7 (missing stats)
+                │ estimated row count: 19 (missing stats)
                 │
                 ├── • scan
                 │     columns: (a)
                 │     ordering: +a
-                │     estimated row count: 3 (missing stats)
+                │     estimated row count: 9 (missing stats)
                 │     table: sharded_secondary@sharded_secondary_a_idx
                 │     spans: /6/101-/7
                 │     limit: 10
@@ -497,7 +497,7 @@ vectorized: true
                 └── • scan
                       columns: (a)
                       ordering: +a
-                      estimated row count: 3 (missing stats)
+                      estimated row count: 9 (missing stats)
                       table: sharded_secondary@sharded_secondary_a_idx
                       spans: /7/101-/8
                       limit: 10
@@ -547,7 +547,7 @@ vectorized: true
 ·
 • scan
   columns: (i2, i4, i8, f4, f8, s, c, b, dc, ival, oid, tstz, ts, da, inet, vb)
-  estimated row count: 0 (missing stats)
+  estimated row count: 1 (missing stats)
   table: sharded_primary_with_many_column_types@sharded_primary_with_many_column_types_pkey
   spans: /3/1/1/1/1/1/"1"/"1"/"1"/1/00:00:01/1/1970-01-01T00:00:01Z/1970-01-01T00:00:01Z/1/"\x00 \u007f\x00\x00\x01"/B/0
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -758,12 +758,12 @@ vectorized: true
 ·
 • filter
 │ columns: (a, b, n, sq)
-│ estimated row count: 41 (missing stats)
+│ estimated row count: 115 (missing stats)
 │ filter: ((n IS NULL) OR (n > 1)) AND ((n IS NULL) OR (a < sq))
 │
 └── • hash join (left outer)
     │ columns: (a, b, n, sq)
-    │ estimated row count: 370 (missing stats)
+    │ estimated row count: 1,037 (missing stats)
     │ equality: (b) = (sq)
     │ pred: a > 1
     │
@@ -780,7 +780,7 @@ vectorized: true
     │
     └── • filter
         │ columns: (n, sq)
-        │ estimated row count: 111 (missing stats)
+        │ estimated row count: 311 (missing stats)
         │ filter: sq > 1
         │
         └── • scan
@@ -1323,21 +1323,21 @@ vectorized: true
 ·
 • merge join (inner)
 │ columns: (x, y, u, x, y, v)
-│ estimated row count: 3 (missing stats)
+│ estimated row count: 9 (missing stats)
 │ equality: (y, x) = (y, x)
 │ merge ordering: +"(y=y)",+"(x=x)"
 │
 ├── • scan
 │     columns: (x, y, u)
 │     ordering: +y
-│     estimated row count: 3 (missing stats)
+│     estimated row count: 9 (missing stats)
 │     table: xyu@xyu_pkey
 │     spans: /1-/1/10
 │
 └── • scan
       columns: (x, y, v)
       ordering: +y
-      estimated row count: 3 (missing stats)
+      estimated row count: 9 (missing stats)
       table: xyv@xyv_pkey
       spans: /1-/1/10
 
@@ -1349,21 +1349,21 @@ vectorized: true
 ·
 • merge join (inner)
 │ columns: (x, y, u, x, y, v)
-│ estimated row count: 3 (missing stats)
+│ estimated row count: 9 (missing stats)
 │ equality: (y, x) = (y, x)
 │ merge ordering: +"(y=y)",+"(x=x)"
 │
 ├── • scan
 │     columns: (x, y, u)
 │     ordering: +y
-│     estimated row count: 3 (missing stats)
+│     estimated row count: 9 (missing stats)
 │     table: xyu@xyu_pkey
 │     spans: /1-/1/10
 │
 └── • scan
       columns: (x, y, v)
       ordering: +y
-      estimated row count: 3 (missing stats)
+      estimated row count: 9 (missing stats)
       table: xyv@xyv_pkey
       spans: /1-/1/10
 
@@ -1389,7 +1389,7 @@ vectorized: true
 └── • scan
       columns: (x, y, v)
       ordering: +y
-      estimated row count: 3 (missing stats)
+      estimated row count: 9 (missing stats)
       table: xyv@xyv_pkey
       spans: /1-/1/10
 
@@ -1415,7 +1415,7 @@ vectorized: true
 └── • scan
       columns: (x, y, u)
       ordering: +y
-      estimated row count: 3 (missing stats)
+      estimated row count: 9 (missing stats)
       table: xyu@xyu_pkey
       spans: /1-/1/10
 
@@ -1543,7 +1543,7 @@ vectorized: true
 └── • scan
       columns: (x, y, v)
       ordering: +y
-      estimated row count: 3 (missing stats)
+      estimated row count: 9 (missing stats)
       table: xyv@xyv_pkey
       spans: /1-/1/10
 
@@ -1569,7 +1569,7 @@ vectorized: true
 └── • scan
       columns: (x, y, u)
       ordering: +y
-      estimated row count: 3 (missing stats)
+      estimated row count: 9 (missing stats)
       table: xyu@xyu_pkey
       spans: /1-/1/10
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -18,7 +18,7 @@ vectorized: true
 └── • filter
     │ columns: (k, v, w)
     │ ordering: +v
-    │ estimated row count: 10 (missing stats)
+    │ estimated row count: 28 (missing stats)
     │ filter: w > 30
     │
     └── • index join

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -864,11 +864,11 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 108 (missing stats)
+│ estimated row count: 110 (missing stats)
 │
 └── • filter
     │ columns: (a, b, d)
-    │ estimated row count: 108 (missing stats)
+    │ estimated row count: 110 (missing stats)
     │ filter: (a >= b) AND (a <= d)
     │
     └── • scan

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -363,7 +363,7 @@ vectorized: true
 ·
 • filter
 │ columns: (x, y)
-│ estimated row count: 111 (missing stats)
+│ estimated row count: 311 (missing stats)
 │ filter: y < 30
 │
 └── • scan
@@ -871,7 +871,7 @@ vectorized: true
 ·
 • scan
   columns: (d decimal, v decimal)
-  estimated row count: 0 (missing stats)
+  estimated row count: 1 (missing stats)
   table: dec@dec_pkey
   spans: /NaN/NaN/0
 
@@ -888,7 +888,7 @@ vectorized: true
 ·
 • scan
   columns: (d decimal, v decimal)
-  estimated row count: 0 (missing stats)
+  estimated row count: 1 (missing stats)
   table: decfam@decfam_pkey
   spans: /NaN/NaN-/NaN/-Infinity
 
@@ -901,7 +901,7 @@ vectorized: true
 ·
 • scan
   columns: (d decimal, v decimal)
-  estimated row count: 0 (missing stats)
+  estimated row count: 1 (missing stats)
   table: dec@dec_pkey
   spans: /Infinity/Infinity/0
 
@@ -913,7 +913,7 @@ vectorized: true
 ·
 • scan
   columns: (d decimal, v decimal)
-  estimated row count: 0 (missing stats)
+  estimated row count: 1 (missing stats)
   table: dec@dec_pkey
   spans: /-Infinity/-Infinity/0
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -509,11 +509,11 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 111 (missing stats)
+│ estimated row count: 311 (missing stats)
 │
 └── • filter
     │ columns: (a, b, c)
-    │ estimated row count: 111 (missing stats)
+    │ estimated row count: 311 (missing stats)
     │ filter: c < 1
     │
     └── • scan
@@ -572,11 +572,11 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 111 (missing stats)
+│ estimated row count: 311 (missing stats)
 │
 └── • filter
     │ columns: (a, b, c)
-    │ estimated row count: 111 (missing stats)
+    │ estimated row count: 311 (missing stats)
     │ filter: c > 1
     │
     └── • scan
@@ -593,11 +593,11 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 111 (missing stats)
+│ estimated row count: 311 (missing stats)
 │
 └── • filter
     │ columns: (a, b, c)
-    │ estimated row count: 111 (missing stats)
+    │ estimated row count: 311 (missing stats)
     │ filter: c < 1
     │
     └── • scan
@@ -614,11 +614,11 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 0 (missing stats)
+│ estimated row count: 1 (missing stats)
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 0 (missing stats)
+      estimated row count: 1 (missing stats)
       table: t@bc
       spans: /5/1-/5/2
 
@@ -630,11 +630,11 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 0 (missing stats)
+│ estimated row count: 1 (missing stats)
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 0 (missing stats)
+      estimated row count: 1 (missing stats)
       table: t@bc
       spans: /5/1-/5/2
 
@@ -696,11 +696,11 @@ vectorized: true
 ·
 • project
 │ columns: (b)
-│ estimated row count: 0 (missing stats)
+│ estimated row count: 1 (missing stats)
 │
 └── • scan
       columns: (a, b)
-      estimated row count: 0 (missing stats)
+      estimated row count: 1 (missing stats)
       table: abcd@abcd
       spans: /1/4-/1/5
 
@@ -712,11 +712,11 @@ vectorized: true
 ·
 • project
 │ columns: (b)
-│ estimated row count: 0 (missing stats)
+│ estimated row count: 3 (missing stats)
 │
 └── • scan
       columns: (a, b)
-      estimated row count: 0 (missing stats)
+      estimated row count: 3 (missing stats)
       table: abcd@abcd
       spans: /1/4-/1/5 /2/9-/2/10
 
@@ -957,7 +957,7 @@ vectorized: true
 ·
 • scan
   columns: (a, b, c, d)
-  estimated row count: 3 (missing stats)
+  estimated row count: 9 (missing stats)
   table: abcd@abcd
   spans: /NULL/6-/!NULL
 
@@ -969,7 +969,7 @@ vectorized: true
 ·
 • scan
   columns: (a, b, c, d)
-  estimated row count: 3 (missing stats)
+  estimated row count: 9 (missing stats)
   table: abcd@abcd
   spans: /NULL/!NULL-/NULL/5
 
@@ -1012,11 +1012,11 @@ vectorized: true
 ·
 • project
 │ columns: (c)
-│ estimated row count: 0 (missing stats)
+│ estimated row count: 1 (missing stats)
 │
 └── • scan
       columns: (a, c)
-      estimated row count: 0 (missing stats)
+      estimated row count: 1 (missing stats)
       table: abc@abc_c_idx
       spans: /1/3-/1/4
 
@@ -1033,11 +1033,11 @@ vectorized: true
 ·
 • project
 │ columns: (f)
-│ estimated row count: 0 (missing stats)
+│ estimated row count: 1 (missing stats)
 │
 └── • filter
     │ columns: (d, f)
-    │ estimated row count: 0 (missing stats)
+    │ estimated row count: 1 (missing stats)
     │ filter: d = 3
     │
     └── • scan
@@ -1272,7 +1272,7 @@ vectorized: true
 ·
 • scan
   columns: (x, y)
-  estimated row count: 0 (missing stats)
+  estimated row count: 1 (missing stats)
   table: xy@xy_idx
   spans: /1/1-/1/3
 
@@ -1616,13 +1616,13 @@ vectorized: true
 ·
 • index join
 │ columns: (a, b, c, s)
-│ estimated row count: 1
+│ estimated row count: 3
 │ table: t2@t2_pkey
 │ key columns: a
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 1 (1.2% of the table; stats collected <hidden> ago)
+      estimated row count: 3 (3.1% of the table; stats collected <hidden> ago)
       table: t2@bc
       spans: /2/!NULL-/2/2 /2/3-/3
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/stats
@@ -76,7 +76,7 @@ vectorized: true
 ·
 • filter
 │ columns: (u, v)
-│ estimated row count: 0
+│ estimated row count: 1
 │ filter: v = 1
 │
 └── • scan
@@ -148,7 +148,7 @@ vectorized: true
 ·
 • filter
 │ columns: (u, v)
-│ estimated row count: 0
+│ estimated row count: 1
 │ filter: u = 1
 │
 └── • scan

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -270,36 +270,30 @@ vectorized: true
 ·
 • project
 │ columns: (col0)
-│ estimated row count: 111 (missing stats)
+│ estimated row count: 311 (missing stats)
 │
 └── • project
     │ columns: (col0, col3, col4)
-    │ estimated row count: 111 (missing stats)
+    │ estimated row count: 311 (missing stats)
     │
     └── • render
         │ columns: (col0, col3, col4, rowid)
-        │ estimated row count: 111 (missing stats)
+        │ estimated row count: 311 (missing stats)
         │ render col0: col0
         │ render col3: col3
         │ render col4: col4
         │ render rowid: rowid
         │
-        └── • index join
+        └── • filter
             │ columns: (col0, col3, col4, rowid)
-            │ estimated row count: 111 (missing stats)
-            │ table: tab4@tab4_pkey
-            │ key columns: rowid
+            │ estimated row count: 311 (missing stats)
+            │ filter: (col0 <= 0) AND (col4 <= 5.38)
             │
-            └── • filter
-                │ columns: (col0, col4, rowid)
-                │ estimated row count: 111 (missing stats)
-                │ filter: col0 <= 0
-                │
-                └── • scan
-                      columns: (col0, col4, rowid)
-                      estimated row count: 333 (missing stats)
-                      table: tab4@idx_tab4_0
-                      spans: /!NULL-/5.38/1
+            └── • scan
+                  columns: (col0, col3, col4, rowid)
+                  estimated row count: 1,000 (missing stats)
+                  table: tab4@tab4_pkey
+                  spans: FULL SCAN
 
 # ------------------------------------------------------------------------------
 # Correlated subqueries.

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -2147,7 +2147,7 @@ vectorized: true
 │       │
 │       └── • render
 │           │ columns: (r, s, i, j, r_new, s_new, i_new, check1)
-│           │ estimated row count: 3 (missing stats)
+│           │ estimated row count: 9 (missing stats)
 │           │ render check1: r_new IN ('us-east', 'us-west', 'eu-west')
 │           │ render r: r
 │           │ render s: s
@@ -2159,7 +2159,7 @@ vectorized: true
 │           │
 │           └── • render
 │               │ columns: (r_new, s_new, i_new, r, s, i, j)
-│               │ estimated row count: 3 (missing stats)
+│               │ estimated row count: 9 (missing stats)
 │               │ render r_new: CASE (random() * 3.0)::INT8 WHEN 0 THEN 'us-east' WHEN 1 THEN 'us-west' ELSE 'eu-west' END
 │               │ render s_new: 'baz'
 │               │ render i_new: 3
@@ -2170,7 +2170,7 @@ vectorized: true
 │               │
 │               └── • scan
 │                     columns: (r, s, i, j)
-│                     estimated row count: 3 (missing stats)
+│                     estimated row count: 9 (missing stats)
 │                     table: uniq_enum@uniq_enum_pkey
 │                     spans: /"\xc0"/11-/"\xc0"/21
 │                     parallel
@@ -2183,11 +2183,11 @@ vectorized: true
 │       │
 │       └── • project
 │           │ columns: (i_new)
-│           │ estimated row count: 1 (missing stats)
+│           │ estimated row count: 3 (missing stats)
 │           │
 │           └── • project
 │               │ columns: (r_new, i_new)
-│               │ estimated row count: 1 (missing stats)
+│               │ estimated row count: 3 (missing stats)
 │               │
 │               └── • lookup join (semi)
 │                   │ columns: (r_new, i_new, "lookup_join_const_col_@17")
@@ -2198,11 +2198,11 @@ vectorized: true
 │                   │
 │                   └── • cross join (inner)
 │                       │ columns: (r_new, i_new, "lookup_join_const_col_@17")
-│                       │ estimated row count: 10 (missing stats)
+│                       │ estimated row count: 28 (missing stats)
 │                       │
 │                       ├── • project
 │                       │   │ columns: (r_new, i_new)
-│                       │   │ estimated row count: 3 (missing stats)
+│                       │   │ estimated row count: 9 (missing stats)
 │                       │   │
 │                       │   └── • scan buffer
 │                       │         columns: (r, s, i, j, r_new, s_new, i_new, check1)
@@ -2222,11 +2222,11 @@ vectorized: true
         │
         └── • project
             │ columns: (s_new, j)
-            │ estimated row count: 1 (missing stats)
+            │ estimated row count: 3 (missing stats)
             │
             └── • project
                 │ columns: (r_new, s_new, i_new, j)
-                │ estimated row count: 1 (missing stats)
+                │ estimated row count: 3 (missing stats)
                 │
                 └── • lookup join (semi)
                     │ columns: (r_new, s_new, i_new, j, "lookup_join_const_col_@27")
@@ -2237,11 +2237,11 @@ vectorized: true
                     │
                     └── • cross join (inner)
                         │ columns: (r_new, s_new, i_new, j, "lookup_join_const_col_@27")
-                        │ estimated row count: 10 (missing stats)
+                        │ estimated row count: 28 (missing stats)
                         │
                         ├── • project
                         │   │ columns: (r_new, s_new, i_new, j)
-                        │   │ estimated row count: 3 (missing stats)
+                        │   │ estimated row count: 9 (missing stats)
                         │   │
                         │   └── • scan buffer
                         │         columns: (r, s, i, j, r_new, s_new, i_new, check1)

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -627,7 +627,7 @@ vectorized: true
     │
     └── • render
         │ columns: (upsert_b, x, y, z, a, b, c)
-        │ estimated row count: 111 (missing stats)
+        │ estimated row count: 311 (missing stats)
         │ render upsert_b: CASE WHEN a IS NULL THEN y ELSE 5 END
         │ render x: x
         │ render y: y
@@ -636,16 +636,23 @@ vectorized: true
         │ render b: b
         │ render c: c
         │
-        └── • lookup join (left outer)
-            │ columns: (x, y, z, a, b, c)
-            │ estimated row count: 111 (missing stats)
-            │ table: target@target_b_c_key
-            │ equality: (y, z) = (b,c)
-            │ equality cols are key
+        └── • merge join (right outer)
+            │ columns: (a, b, c, x, y, z)
+            │ estimated row count: 311 (missing stats)
+            │ equality: (b, c) = (y, z)
+            │ merge ordering: +"(b=y)",+"(c=z)"
+            │
+            ├── • scan
+            │     columns: (a, b, c)
+            │     ordering: +b,+c
+            │     estimated row count: 1,000 (missing stats)
+            │     table: target@target_b_c_key
+            │     spans: FULL SCAN
             │
             └── • distinct
                 │ columns: (x, y, z)
-                │ estimated row count: 111 (missing stats)
+                │ ordering: +y,+z
+                │ estimated row count: 311 (missing stats)
                 │ distinct on: y, z
                 │ nulls are distinct
                 │ error on duplicate
@@ -654,7 +661,7 @@ vectorized: true
                 └── • filter
                     │ columns: (x, y, z)
                     │ ordering: +y,+z
-                    │ estimated row count: 111 (missing stats)
+                    │ estimated row count: 311 (missing stats)
                     │ filter: x != 1
                     │
                     └── • scan

--- a/pkg/sql/opt/indexrec/testdata/index-candidates-recommendations
+++ b/pkg/sql/opt/indexrec/testdata/index-candidates-recommendations
@@ -200,7 +200,7 @@ index recommendations: 1
 Optimal Plan.
 project
  ├── columns: i:2!null
- ├── cost: 375.181111
+ ├── cost: 377.181111
  └── select
       ├── columns: k:1!null i:2!null
       ├── cost: 374.05
@@ -231,21 +231,21 @@ index recommendations: 2
 Optimal Plan.
 project
  ├── columns: i:2
- ├── cost: 798.18642
+ ├── cost: 816.218448
  └── project
       ├── columns: k:1 i:2 f:3
-      ├── cost: 793.721976
+      ├── cost: 809.754004
       └── distinct-on
            ├── columns: k:1 i:2 f:3 rowid:5!null
            ├── grouping columns: rowid:5!null
-           ├── cost: 789.257531
+           ├── cost: 803.289559
            ├── key: (5)
            ├── fd: (5)-->(1-3)
            ├── union-all
            │    ├── columns: k:1 i:2 f:3 rowid:5!null
            │    ├── left columns: k:8 i:9 f:10 rowid:12
            │    ├── right columns: k:15 i:16 f:17 rowid:19
-           │    ├── cost: 762.534445
+           │    ├── cost: 764.534445
            │    ├── select
            │    │    ├── columns: k:8!null i:9!null f:10 rowid:12!null
            │    │    ├── cost: 380.716667
@@ -641,7 +641,7 @@ inner-join (zigzag t1@_hyp_1 t1@_hyp_2)
  ├── eq columns: [5] = [5]
  ├── left fixed columns: [1] = [1]
  ├── right fixed columns: [2] = [2]
- ├── cost: 10.2550002
+ ├── cost: 11.9982432
  ├── fd: ()-->(1,2)
  └── filters
       ├── k:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
@@ -667,7 +667,7 @@ Optimal Plan.
 scan t1@_hyp_3
  ├── columns: k:1!null i:2 f:3!null s:4
  ├── constraint: /1/3/5: [/1/5e-324 - /1]
- ├── cost: 17.6533334
+ ├── cost: 24.1933333
  └── fd: ()-->(1)
 
 # Multi-column combinations used: EQ, EQ + R.
@@ -696,7 +696,7 @@ inner-join (zigzag t1@_hyp_1 t1@_hyp_2)
  ├── eq columns: [5] = [5]
  ├── left fixed columns: [1] = [1]
  ├── right fixed columns: [2] = [2]
- ├── cost: 10.1220002
+ ├── cost: 10.6474054
  ├── fd: ()-->(1,2)
  └── filters
       ├── k:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
@@ -763,11 +763,11 @@ index recommendations: 2
 Optimal Plan.
 project
  ├── columns: i:2!null s:4!null
- ├── cost: 1098.65445
+ ├── cost: 1111.17702
  ├── fd: ()-->(2,4)
  └── inner-join (cross)
       ├── columns: t1.k:1!null t1.i:2!null t1.s:4!null t2.k:8!null
-      ├── cost: 1098.30775
+      ├── cost: 1108.1814
       ├── fd: ()-->(2,4)
       ├── scan t2
       │    ├── columns: t2.k:8
@@ -777,7 +777,7 @@ project
       │    ├── eq columns: [5] = [5]
       │    ├── left fixed columns: [2] = [2]
       │    ├── right fixed columns: [4] = ['NG']
-      │    ├── cost: 10.2560002
+      │    ├── cost: 12.0073514
       │    ├── fd: ()-->(2,4)
       │    └── filters
       │         ├── t1.i:2 = 2 [outer=(2), constraints=(/2: [/2 - /2]; tight), fd=()-->(2)]
@@ -840,7 +840,7 @@ union-all
  ├── left columns: count_rows:14
  ├── right columns: count_rows:22
  ├── cardinality: [1 - ]
- ├── cost: 25597.9795
+ ├── cost: 25598.0782
  ├── project
  │    ├── columns: count_rows:14!null
  │    ├── cost: 25563.0458
@@ -866,17 +866,17 @@ union-all
  └── scalar-group-by
       ├── columns: count_rows:22!null
       ├── cardinality: [1 - 1]
-      ├── cost: 24.9036701
+      ├── cost: 25.002367
       ├── key: ()
       ├── fd: ()-->(22)
       ├── select
       │    ├── columns: t1.i:16!null f:17!null t1.s:18!null
-      │    ├── cost: 24.8410001
+      │    ├── cost: 24.9391
       │    ├── fd: ()-->(18)
       │    ├── scan t1@_hyp_5
       │    │    ├── columns: t1.i:16 f:17!null t1.s:18!null
       │    │    ├── constraint: /18/17/19: (/'NG'/NULL - /'NG']
-      │    │    ├── cost: 24.7120001
+      │    │    ├── cost: 24.8092
       │    │    └── fd: ()-->(18)
       │    └── filters
       │         └── f:17 > t1.i:16 [outer=(16,17), constraints=(/16: (/NULL - ]; /17: (/NULL - ])]
@@ -920,21 +920,21 @@ index recommendations: 3
 Optimal Plan.
 sort (segmented)
  ├── columns: k:1 i:2 i:9
- ├── cost: 2416.14906
+ ├── cost: 2416.08954
  ├── ordering: +1,+9,-2
  └── project
       ├── columns: t1.k:1 t1.i:2 t2.i:9
-      ├── cost: 2263.46773
+      ├── cost: 2263.40821
       ├── ordering: +1
       └── left-join (merge)
            ├── columns: t1.k:1 t1.i:2 t2.k:8 t2.i:9
            ├── left ordering: +1
            ├── right ordering: +8
-           ├── cost: 2252.14053
+           ├── cost: 2252.08102
            ├── ordering: +1
            ├── select
            │    ├── columns: t1.k:1 t1.i:2
-           │    ├── cost: 1122.12334
+           │    ├── cost: 1122.09358
            │    ├── ordering: +1
            │    ├── scan t1@_hyp_1
            │    │    ├── columns: t1.k:1 t1.i:2
@@ -945,24 +945,24 @@ sort (segmented)
            │              └── limit
            │                   ├── columns: t3.k:14!null t3.i:15 t3.f:16!null
            │                   ├── cardinality: [0 - 1]
-           │                   ├── cost: 17.3733364
+           │                   ├── cost: 17.3435766
            │                   ├── key: ()
            │                   ├── fd: ()-->(14-16)
            │                   ├── select
            │                   │    ├── columns: t3.k:14!null t3.i:15 t3.f:16!null
-           │                   │    ├── cost: 17.3533364
+           │                   │    ├── cost: 17.3235766
            │                   │    ├── limit hint: 1.00
            │                   │    ├── scan t3@_hyp_1
            │                   │    │    ├── columns: t3.k:14 t3.i:15 t3.f:16!null
            │                   │    │    ├── constraint: /16/18: (/NULL - ]
-           │                   │    │    ├── cost: 17.2927273
-           │                   │    │    └── limit hint: 3.03
+           │                   │    │    ├── cost: 17.2632432
+           │                   │    │    └── limit hint: 3.00
            │                   │    └── filters
            │                   │         └── t3.f:16 > t3.k:14 [outer=(14,16), constraints=(/14: (/NULL - ]; /16: (/NULL - ])]
            │                   └── 1
            ├── select
            │    ├── columns: t2.k:8 t2.i:9
-           │    ├── cost: 1112.02334
+           │    ├── cost: 1111.99358
            │    ├── ordering: +8
            │    ├── scan t2@_hyp_2
            │    │    ├── columns: t2.k:8 t2.i:9
@@ -973,18 +973,18 @@ sort (segmented)
            │              └── limit
            │                   ├── columns: t3.k:14!null t3.i:15 t3.f:16!null
            │                   ├── cardinality: [0 - 1]
-           │                   ├── cost: 17.3733364
+           │                   ├── cost: 17.3435766
            │                   ├── key: ()
            │                   ├── fd: ()-->(14-16)
            │                   ├── select
            │                   │    ├── columns: t3.k:14!null t3.i:15 t3.f:16!null
-           │                   │    ├── cost: 17.3533364
+           │                   │    ├── cost: 17.3235766
            │                   │    ├── limit hint: 1.00
            │                   │    ├── scan t3@_hyp_1
            │                   │    │    ├── columns: t3.k:14 t3.i:15 t3.f:16!null
            │                   │    │    ├── constraint: /16/18: (/NULL - ]
-           │                   │    │    ├── cost: 17.2927273
-           │                   │    │    └── limit hint: 3.03
+           │                   │    │    ├── cost: 17.2632432
+           │                   │    │    └── limit hint: 3.00
            │                   │    └── filters
            │                   │         └── t3.f:16 > t3.k:14 [outer=(14,16), constraints=(/14: (/NULL - ]; /16: (/NULL - ])]
            │                   └── 1
@@ -1401,7 +1401,7 @@ Optimal Plan.
 project
  ├── columns: k:1!null f:3
  ├── immutable
- ├── cost: 10.1433334
+ ├── cost: 10.7379279
  ├── fd: ()-->(1)
  └── inner-join (zigzag t4@_hyp_1 t4@_hyp_2)
       ├── columns: t4.k:1!null i:2!null f:3 j:4
@@ -1409,7 +1409,7 @@ project
       ├── left fixed columns: [1] = [1]
       ├── right fixed columns: [2] = [2]
       ├── immutable
-      ├── cost: 10.1230001
+      ├── cost: 10.7148919
       ├── fd: ()-->(1,2)
       └── filters
            ├── j:4 <@ '{"foo": "1"}' [outer=(4), immutable]
@@ -1635,12 +1635,12 @@ No index recommendations.
 Optimal Plan.
 project
  ├── columns: i:2!null
- ├── cost: 17.5400001
+ ├── cost: 23.84
  ├── fd: ()-->(2)
  └── scan t4@partial_idx,partial
       ├── columns: i:2!null rowid:6!null
       ├── constraint: /2/6: [/1 - /1]
-      ├── cost: 17.4866668
+      ├── cost: 23.7266667
       ├── key: (6)
       └── fd: ()-->(2)
 
@@ -1656,11 +1656,11 @@ No index recommendations.
 Optimal Plan.
 project
  ├── columns: f:3!null
- ├── cost: 130.706667
+ ├── cost: 340.706667
  └── scan t4@partial_unique_idx,partial
       ├── columns: f:3!null rowid:6!null
       ├── constraint: /3: [/5.000000000000001 - ]
-      ├── cost: 129.575556
+      ├── cost: 337.575556
       ├── key: (6)
       └── fd: (6)-->(3), (3)-->(6)
 
@@ -1765,12 +1765,12 @@ Optimal Plan.
 project
  ├── columns: k:1!null
  ├── immutable
- ├── cost: 14.1783334
+ ├── cost: 15.0296847
  ├── fd: ()-->(1)
  └── scan t1@expr
       ├── columns: k:1!null rowid:5!null
       ├── constraint: /1/8/5: [/1/'cockroach' - /1/'cockroach']
-      ├── cost: 14.1250001
+      ├── cost: 14.9763514
       ├── key: (5)
       └── fd: ()-->(1)
 

--- a/pkg/sql/opt/memo/testdata/format
+++ b/pkg/sql/opt/memo/testdata/format
@@ -582,7 +582,7 @@ SELECT * FROM zigzag@{FORCE_ZIGZAG} WHERE a = 3 AND b = 7;
 ----
 select
  ├── columns: n:1(int!null) a:2(int!null) b:3(int!null) c:4(string)
- ├── stats: [rows=0.1000001, distinct(2)=0.1, null(2)=0, avgsize(2)=4, distinct(3)=0.1, null(3)=0, avgsize(3)=4]
+ ├── stats: [rows=0.9108108, distinct(2)=0.910811, null(2)=0, avgsize(2)=4, distinct(3)=0.910811, null(3)=0, avgsize(3)=4, distinct(2,3)=0.910811, null(2,3)=0, avgsize(2,3)=8]
  ├── cost: 1e+100
  ├── key: (1)
  ├── fd: ()-->(2,3), (1)-->(4), (3,4)~~>(1)
@@ -612,7 +612,7 @@ SELECT * FROM zigzag@{FORCE_ZIGZAG=a_idx} WHERE a = 3 AND b = 7;
 ----
 select
  ├── columns: n:1(int!null) a:2(int!null) b:3(int!null) c:4(string)
- ├── stats: [rows=0.1000001, distinct(2)=0.1, null(2)=0, avgsize(2)=4, distinct(3)=0.1, null(3)=0, avgsize(3)=4]
+ ├── stats: [rows=0.9108108, distinct(2)=0.910811, null(2)=0, avgsize(2)=4, distinct(3)=0.910811, null(3)=0, avgsize(3)=4, distinct(2,3)=0.910811, null(2,3)=0, avgsize(2,3)=8]
  ├── cost: 1e+100
  ├── key: (1)
  ├── fd: ()-->(2,3), (1)-->(4), (3,4)~~>(1)
@@ -642,7 +642,7 @@ SELECT * FROM zigzag@{FORCE_ZIGZAG=b_idx} WHERE a = 3 AND b = 7;
 ----
 select
  ├── columns: n:1(int!null) a:2(int!null) b:3(int!null) c:4(string)
- ├── stats: [rows=0.1000001, distinct(2)=0.1, null(2)=0, avgsize(2)=4, distinct(3)=0.1, null(3)=0, avgsize(3)=4]
+ ├── stats: [rows=0.9108108, distinct(2)=0.910811, null(2)=0, avgsize(2)=4, distinct(3)=0.910811, null(3)=0, avgsize(3)=4, distinct(2,3)=0.910811, null(2,3)=0, avgsize(2,3)=8]
  ├── cost: 1e+100
  ├── key: (1)
  ├── fd: ()-->(2,3), (1)-->(4), (3,4)~~>(1)
@@ -672,7 +672,7 @@ SELECT * FROM zigzag@{FORCE_ZIGZAG=a_idx,FORCE_ZIGZAG=b_idx} WHERE a = 3 AND b =
 ----
 select
  ├── columns: n:1(int!null) a:2(int!null) b:3(int!null) c:4(string)
- ├── stats: [rows=0.1000001, distinct(2)=0.1, null(2)=0, avgsize(2)=4, distinct(3)=0.1, null(3)=0, avgsize(3)=4]
+ ├── stats: [rows=0.9108108, distinct(2)=0.910811, null(2)=0, avgsize(2)=4, distinct(3)=0.910811, null(3)=0, avgsize(3)=4, distinct(2,3)=0.910811, null(2,3)=0, avgsize(2,3)=8]
  ├── cost: 1e+100
  ├── key: (1)
  ├── fd: ()-->(2,3), (1)-->(4), (3,4)~~>(1)

--- a/pkg/sql/opt/memo/testdata/stats/inverted-geo-multi-column
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-geo-multi-column
@@ -316,7 +316,7 @@ project
       ├── fd: ()-->(4), (1)-->(2,3)
       ├── index-join t
       │    ├── columns: k:1(int!null) g:2(geometry) s:3(string) i:4(int)
-      │    ├── stats: [rows=1.781353]
+      │    ├── stats: [rows=5.512417]
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-4)
       │    └── inverted-filter
@@ -329,7 +329,7 @@ project
       │         │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
       │         ├── pre-filterer expression
       │         │    └── st_intersects('010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F', g:2) [type=bool]
-      │         ├── stats: [rows=1.781353]
+      │         ├── stats: [rows=5.512417]
       │         ├── key: (1)
       │         └── scan t@mp,partial
       │              ├── columns: k:1(int!null) g_inverted_key:10(geometry!null)
@@ -340,12 +340,12 @@ project
       │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x01", "B\xfd\x12\x00\x00\x00\x00\x00\x00\x00")
       │              │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
       │              ├── flags: force-index=mp
-      │              ├── stats: [rows=1.781353, distinct(1)=0.508958, null(1)=0, avgsize(1)=4, distinct(3)=1.78135, null(3)=0, avgsize(3)=4, distinct(4)=1, null(4)=0, avgsize(4)=4, distinct(10)=1.18757, null(10)=0, avgsize(10)=4]
-      │              │   histogram(3)=  0  0.89068   0  0.89068
+      │              ├── stats: [rows=5.512417, distinct(1)=1.57498, null(1)=0, avgsize(1)=4, distinct(3)=2, null(3)=0, avgsize(3)=4, distinct(4)=1, null(4)=0, avgsize(4)=4, distinct(10)=1.18757, null(10)=0, avgsize(10)=4, distinct(3,4,10)=2.36876, null(3,4,10)=0, avgsize(3,4,10)=12]
+      │              │   histogram(3)=  0   2.7562   0   2.7562
       │              │                <--- 'banana' --- 'cherry'
-      │              │   histogram(4)=  0 1.7814
+      │              │   histogram(4)=  0 5.5124
       │              │                <--- 400 -
-      │              │   histogram(10)=  0             0              2.7338e-12            1.5             0.28135             0              0             0
+      │              │   histogram(10)=  0             0              8.4596e-12           4.6418           0.87065             0              0             0
       │              │                 <--- '\x42fd1000000000000001' ------------ '\x42fd1000000100000000' --------- '\x42fd1200000000000000' --- '\x42fd1400000000000001'
       │              ├── key: (1)
       │              └── fd: (1)-->(10)
@@ -372,7 +372,7 @@ project
       ├── fd: (1)-->(2-4)
       ├── index-join t
       │    ├── columns: k:1(int!null) g:2(geometry) s:3(string) i:4(int)
-      │    ├── stats: [rows=3.562706]
+      │    ├── stats: [rows=14.82863]
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-4)
       │    └── inverted-filter
@@ -385,7 +385,7 @@ project
       │         │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
       │         ├── pre-filterer expression
       │         │    └── st_intersects('010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F', g:2) [type=bool]
-      │         ├── stats: [rows=3.562706]
+      │         ├── stats: [rows=14.82863]
       │         ├── key: (1)
       │         └── scan t@mp,partial
       │              ├── columns: k:1(int!null) g_inverted_key:10(geometry!null)
@@ -399,13 +399,13 @@ project
       │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x01", "B\xfd\x12\x00\x00\x00\x00\x00\x00\x00")
       │              │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
       │              ├── flags: force-index=mp
-      │              ├── stats: [rows=3.562706, distinct(1)=1.01792, null(1)=0, avgsize(1)=4, distinct(3)=2, null(3)=0, avgsize(3)=4, distinct(4)=3, null(4)=0, avgsize(4)=4, distinct(10)=1.18757, null(10)=0, avgsize(10)=4]
-      │              │   histogram(3)=  0   1.7814   0   1.7814
+      │              ├── stats: [rows=14.82863, distinct(1)=4.23675, null(1)=0, avgsize(1)=4, distinct(3)=2, null(3)=0, avgsize(3)=4, distinct(4)=3, null(4)=0, avgsize(4)=4, distinct(10)=1.18757, null(10)=0, avgsize(10)=4, distinct(3,4,10)=7.05532, null(3,4,10)=0, avgsize(3,4,10)=12]
+      │              │   histogram(3)=  0   7.4143   0   7.4143
       │              │                <--- 'banana' --- 'cherry'
-      │              │   histogram(4)=  0 0.59378 0 1.1876 0 1.7814
-      │              │                <---- 200 ---- 300 ---- 400 -
-      │              │   histogram(10)=  0             0              5.4675e-12             3              0.56271             0              0             0
-      │              │                 <--- '\x42fd1000000000000001' ------------ '\x42fd1000000100000000' --------- '\x42fd1200000000000000' --- '\x42fd1400000000000001'
+      │              │   histogram(4)=  0 2.4714 0 4.9429 0 7.4143
+      │              │                <--- 200 ---- 300 ---- 400 -
+      │              │   histogram(10)=  0             0              2.2757e-11           12.487           2.3421             0              0             0
+      │              │                 <--- '\x42fd1000000000000001' ------------ '\x42fd1000000100000000' -------- '\x42fd1200000000000000' --- '\x42fd1400000000000001'
       │              ├── key: (1)
       │              └── fd: (1)-->(10)
       └── filters

--- a/pkg/sql/opt/memo/testdata/stats/inverted-join
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-join
@@ -426,7 +426,7 @@ project
       │    ├── prefix key columns: [14 15] = [18 19]
       │    ├── inverted-expr
       │    │    └── t1.j:17 @> t2.j:10 [type=bool]
-      │    ├── stats: [rows=0.3, distinct(14)=0.3, null(14)=0, avgsize(14)=4, distinct(15)=0.3, null(15)=0, avgsize(15)=4, distinct(16)=0.299957, null(16)=0, avgsize(16)=4, distinct(18)=0.3, null(18)=0, avgsize(18)=12, distinct(19)=0.3, null(19)=0, avgsize(19)=2]
+      │    ├── stats: [rows=0.3, distinct(14)=0.3, null(14)=0, avgsize(14)=4, distinct(15)=0.3, null(15)=0, avgsize(15)=4, distinct(16)=0.299957, null(16)=0, avgsize(16)=4, distinct(18)=0.3, null(18)=0, avgsize(18)=12, distinct(19)=0.3, null(19)=0, avgsize(19)=2, distinct(18,19)=0.3, null(18,19)=0, avgsize(18,19)=14]
       │    ├── fd: ()-->(19), (16)-->(18)
       │    ├── project
       │    │    ├── columns: "inverted_join_const_col_@4":15(int!null) t2.j:10(jsonb) "inverted_join_const_col_@3":14(string!null)

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -1650,7 +1650,7 @@ SELECT * FROM xysd, uv WHERE (s = 'foo' AND u = 3 AND v = 4) OR (s = 'bar' AND u
 ----
 inner-join (cross)
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null) u:7(int!null) v:8(int!null)
- ├── stats: [rows=59787.95, distinct(3)=2, null(3)=0, avgsize(3)=9, distinct(7)=2, null(7)=0, avgsize(7)=5, distinct(8)=2, null(8)=0, avgsize(8)=6, distinct(7,8)=2.19139, null(7,8)=0, avgsize(7,8)=8]
+ ├── stats: [rows=59573.61, distinct(3)=2, null(3)=0, avgsize(3)=9, distinct(7)=2, null(7)=0, avgsize(7)=5, distinct(8)=2, null(8)=0, avgsize(8)=6, distinct(7,8)=2.18365, null(7,8)=0, avgsize(7,8)=8]
  ├── fd: (1)-->(2-4), (3,4)-->(1,2)
  ├── scan uv
  │    ├── columns: u:7(int) v:8(int!null)

--- a/pkg/sql/opt/memo/testdata/stats/partial-index-scan
+++ b/pkg/sql/opt/memo/testdata/stats/partial-index-scan
@@ -201,7 +201,7 @@ SELECT * FROM a WHERE s = t AND s LIKE '%foo%' AND t LIKE '%bar%'
 ----
 index-join a
  ├── columns: k:1(int!null) i:2(int) s:3(string!null) t:4(string!null)
- ├── stats: [rows=1.0395, distinct(3)=1.0395, null(3)=0, avgsize(3)=5, distinct(4)=1.0395, null(4)=0, avgsize(4)=6]
+ ├── stats: [rows=1.04895, distinct(3)=1.04895, null(3)=0, avgsize(3)=5, distinct(4)=1.04895, null(4)=0, avgsize(4)=6, distinct(3,4)=1.04895, null(3,4)=0, avgsize(3,4)=11]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)==(4), (4)==(3)
  └── select
@@ -258,13 +258,13 @@ SELECT * FROM a WHERE i > 10 AND i < 20 AND s IN ('foo', 'bar', 'baz')
 ----
 index-join a
  ├── columns: k:1(int!null) i:2(int!null) s:3(string!null) t:4(string)
- ├── stats: [rows=5.207143, distinct(2)=5.20714, null(2)=0, avgsize(2)=2, distinct(3)=3, null(3)=0, avgsize(3)=5]
+ ├── stats: [rows=23.49827, distinct(2)=9, null(2)=0, avgsize(2)=2, distinct(3)=3, null(3)=0, avgsize(3)=5, distinct(2,3)=23.4983, null(2,3)=0, avgsize(2,3)=7]
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  └── scan a@idx,partial
       ├── columns: k:1(int!null) i:2(int!null)
       ├── constraint: /2/1: [/11 - /19]
-      ├── stats: [rows=5.207143, distinct(2)=5.20714, null(2)=0, avgsize(2)=2, distinct(3)=3, null(3)=0, avgsize(3)=5]
+      ├── stats: [rows=23.49827, distinct(2)=9, null(2)=0, avgsize(2)=2, distinct(3)=3, null(3)=0, avgsize(3)=5, distinct(2,3)=23.4983, null(2,3)=0, avgsize(2,3)=7]
       ├── key: (1)
       └── fd: (1)-->(2)
 
@@ -273,18 +273,18 @@ SELECT * FROM a WHERE i > 10 AND i < 20 AND s = 'baz'
 ----
 select
  ├── columns: k:1(int!null) i:2(int!null) s:3(string!null) t:4(string)
- ├── stats: [rows=1.735715, distinct(2)=1.73571, null(2)=0, avgsize(2)=2, distinct(3)=1, null(3)=0, avgsize(3)=5]
+ ├── stats: [rows=8.273571, distinct(2)=8.27357, null(2)=0, avgsize(2)=2, distinct(3)=1, null(3)=0, avgsize(3)=5, distinct(2,3)=8.27357, null(2,3)=0, avgsize(2,3)=7]
  ├── key: (1)
  ├── fd: ()-->(3), (1)-->(2,4)
  ├── index-join a
  │    ├── columns: k:1(int!null) i:2(int) s:3(string) t:4(string)
- │    ├── stats: [rows=5.207143]
+ │    ├── stats: [rows=23.49827]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
  │    └── scan a@idx,partial
  │         ├── columns: k:1(int!null) i:2(int!null)
  │         ├── constraint: /2/1: [/11 - /19]
- │         ├── stats: [rows=5.207143, distinct(2)=5.20714, null(2)=0, avgsize(2)=2, distinct(3)=3, null(3)=0, avgsize(3)=5]
+ │         ├── stats: [rows=23.49827, distinct(2)=9, null(2)=0, avgsize(2)=2, distinct(3)=3, null(3)=0, avgsize(3)=5, distinct(2,3)=23.4983, null(2,3)=0, avgsize(2,3)=7]
  │         ├── key: (1)
  │         └── fd: (1)-->(2)
  └── filters
@@ -295,12 +295,12 @@ SELECT * FROM a WHERE (i = 100 AND s = 'foo') OR (i = 200 AND s = 'bar')
 ----
 select
  ├── columns: k:1(int!null) i:2(int!null) s:3(string!null) t:4(string)
- ├── stats: [rows=0.257143, distinct(2)=0.257143, null(2)=0, avgsize(2)=2, distinct(3)=0.257143, null(3)=0, avgsize(3)=5]
+ ├── stats: [rows=1.176735, distinct(2)=1.17673, null(2)=0, avgsize(2)=2, distinct(3)=1.17673, null(3)=0, avgsize(3)=5, distinct(2,3)=1.17673, null(2,3)=0, avgsize(2,3)=7]
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── index-join a
  │    ├── columns: k:1(int!null) i:2(int) s:3(string) t:4(string)
- │    ├── stats: [rows=1.157143]
+ │    ├── stats: [rows=5.295306]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
  │    └── scan a@idx,partial
@@ -308,7 +308,7 @@ select
  │         ├── constraint: /2/1
  │         │    ├── [/100 - /100]
  │         │    └── [/200 - /200]
- │         ├── stats: [rows=1.157143, distinct(2)=1.15714, null(2)=0, avgsize(2)=2, distinct(3)=1.15714, null(3)=0, avgsize(3)=5]
+ │         ├── stats: [rows=5.295306, distinct(2)=2, null(2)=0, avgsize(2)=2, distinct(3)=3, null(3)=0, avgsize(3)=5, distinct(2,3)=5.29531, null(2,3)=0, avgsize(2,3)=7]
  │         ├── key: (1)
  │         └── fd: (1)-->(2)
  └── filters
@@ -330,13 +330,13 @@ SELECT * FROM a WHERE i > 10 AND i < 20 AND s = 'foo'
 ----
 index-join a
  ├── columns: k:1(int!null) i:2(int!null) s:3(string!null) t:4(string)
- ├── stats: [rows=1.735715, distinct(2)=1.73571, null(2)=0, avgsize(2)=2, distinct(3)=1, null(3)=0, avgsize(3)=5]
+ ├── stats: [rows=8.273571, distinct(2)=8.27357, null(2)=0, avgsize(2)=2, distinct(3)=1, null(3)=0, avgsize(3)=5, distinct(2,3)=8.27357, null(2,3)=0, avgsize(2,3)=7]
  ├── key: (1)
  ├── fd: ()-->(3), (1)-->(2,4)
  └── scan a@idx,partial
       ├── columns: k:1(int!null) i:2(int!null)
       ├── constraint: /2/1: [/11 - /19]
-      ├── stats: [rows=1.735715, distinct(2)=1.73571, null(2)=0, avgsize(2)=2, distinct(3)=1, null(3)=0, avgsize(3)=5]
+      ├── stats: [rows=8.273571, distinct(2)=8.27357, null(2)=0, avgsize(2)=2, distinct(3)=1, null(3)=0, avgsize(3)=5, distinct(2,3)=8.27357, null(2,3)=0, avgsize(2,3)=7]
       ├── key: (1)
       └── fd: (1)-->(2)
 
@@ -356,13 +356,13 @@ SELECT * FROM a WHERE i > 10 AND i < 20 AND s IN ('foo', 'bar', 'baz')
 ----
 index-join a
  ├── columns: k:1(int!null) i:2(int!null) s:3(string!null) t:4(string)
- ├── stats: [rows=5.207143, distinct(2)=5.20714, null(2)=0, avgsize(2)=2, distinct(3)=3, null(3)=0, avgsize(3)=5]
+ ├── stats: [rows=23.49827, distinct(2)=9, null(2)=0, avgsize(2)=2, distinct(3)=3, null(3)=0, avgsize(3)=5, distinct(2,3)=23.4983, null(2,3)=0, avgsize(2,3)=7]
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  └── scan a@idx,partial
       ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
       ├── constraint: /2/3/1: [/11 - /19]
-      ├── stats: [rows=5.207143, distinct(2)=5.20714, null(2)=0, avgsize(2)=2, distinct(3)=3, null(3)=0, avgsize(3)=5]
+      ├── stats: [rows=23.49827, distinct(2)=9, null(2)=0, avgsize(2)=2, distinct(3)=3, null(3)=0, avgsize(3)=5, distinct(2,3)=23.4983, null(2,3)=0, avgsize(2,3)=7]
       ├── key: (1)
       └── fd: (1)-->(2,3)
 
@@ -371,18 +371,18 @@ SELECT * FROM a WHERE i > 10 AND i < 50 AND s = 'baz'
 ----
 index-join a
  ├── columns: k:1(int!null) i:2(int!null) s:3(string!null) t:4(string)
- ├── stats: [rows=7.521429, distinct(2)=7.52143, null(2)=0, avgsize(2)=2, distinct(3)=1, null(3)=0, avgsize(3)=5]
+ ├── stats: [rows=35.85214, distinct(2)=35.8521, null(2)=0, avgsize(2)=2, distinct(3)=1, null(3)=0, avgsize(3)=5, distinct(2,3)=35.8521, null(2,3)=0, avgsize(2,3)=7]
  ├── key: (1)
  ├── fd: ()-->(3), (1)-->(2,4)
  └── select
       ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
-      ├── stats: [rows=7.521429, distinct(3)=1, null(3)=0, avgsize(3)=5]
+      ├── stats: [rows=33.94194, distinct(3)=1, null(3)=0, avgsize(3)=5]
       ├── key: (1)
       ├── fd: ()-->(3), (1)-->(2)
       ├── scan a@idx,partial
       │    ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
       │    ├── constraint: /2/3/1: [/11/'baz' - /49/'baz']
-      │    ├── stats: [rows=22.56429, distinct(1)=22.5643, null(1)=0, avgsize(1)=1, distinct(2)=22.5643, null(2)=0, avgsize(2)=2, distinct(3)=3, null(3)=0, avgsize(3)=5]
+      │    ├── stats: [rows=101.8258, distinct(1)=101.826, null(1)=0, avgsize(1)=1, distinct(2)=39, null(2)=0, avgsize(2)=2, distinct(3)=3, null(3)=0, avgsize(3)=5, distinct(2,3)=101.826, null(2,3)=0, avgsize(2,3)=7]
       │    ├── key: (1)
       │    └── fd: (1)-->(2,3)
       └── filters
@@ -404,13 +404,13 @@ SELECT * FROM a WHERE i > 10 AND i < 20 AND s = 'foo'
 ----
 index-join a
  ├── columns: k:1(int!null) i:2(int!null) s:3(string!null) t:4(string)
- ├── stats: [rows=1.735715, distinct(2)=1.73571, null(2)=0, avgsize(2)=2, distinct(3)=1, null(3)=0, avgsize(3)=5]
+ ├── stats: [rows=8.273571, distinct(2)=8.27357, null(2)=0, avgsize(2)=2, distinct(3)=1, null(3)=0, avgsize(3)=5, distinct(2,3)=8.27357, null(2,3)=0, avgsize(2,3)=7]
  ├── key: (1)
  ├── fd: ()-->(3), (1)-->(2,4)
  └── scan a@idx,partial
       ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
       ├── constraint: /2/3/1: [/11 - /19]
-      ├── stats: [rows=1.735715, distinct(2)=1.73571, null(2)=0, avgsize(2)=2, distinct(3)=1, null(3)=0, avgsize(3)=5]
+      ├── stats: [rows=8.273571, distinct(2)=8.27357, null(2)=0, avgsize(2)=2, distinct(3)=1, null(3)=0, avgsize(3)=5, distinct(2,3)=8.27357, null(2,3)=0, avgsize(2,3)=7]
       ├── key: (1)
       └── fd: ()-->(3), (1)-->(2)
 
@@ -620,20 +620,20 @@ SELECT * FROM hist WHERE i > 125 AND i < 130 AND s IN ('banana', 'cherry', 'mang
 ----
 index-join hist
  ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
- ├── stats: [rows=2.909091, distinct(2)=1.27273, null(2)=0, avgsize(2)=2, distinct(3)=2.90909, null(3)=0, avgsize(3)=3]
- │   histogram(2)=  0   0   2.1818 0.72727
+ ├── stats: [rows=3.114058, distinct(2)=1.27273, null(2)=0, avgsize(2)=2, distinct(3)=3, null(3)=0, avgsize(3)=3, distinct(2,3)=3.11406, null(2,3)=0, avgsize(2,3)=5]
+ │   histogram(2)=  0   0   2.3355 0.77851
  │                <--- 125 --------- 129 -
- │   histogram(3)=  0  0.72727   0  0.72727   0  1.4545
+ │   histogram(3)=  0  0.77851   0  0.77851   0   1.557
  │                <--- 'banana' --- 'cherry' --- 'mango'
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  └── scan hist@idx,partial
       ├── columns: k:1(int!null) i:2(int!null)
       ├── constraint: /2/1: [/126 - /129]
-      ├── stats: [rows=2.909091, distinct(2)=1.27273, null(2)=0, avgsize(2)=2, distinct(3)=2.90909, null(3)=0, avgsize(3)=3]
-      │   histogram(2)=  0   0   2.1818 0.72727
+      ├── stats: [rows=3.114058, distinct(2)=1.27273, null(2)=0, avgsize(2)=2, distinct(3)=3, null(3)=0, avgsize(3)=3, distinct(2,3)=3.11406, null(2,3)=0, avgsize(2,3)=5]
+      │   histogram(2)=  0   0   2.3355 0.77851
       │                <--- 125 --------- 129 -
-      │   histogram(3)=  0  0.72727   0  0.72727   0  1.4545
+      │   histogram(3)=  0  0.77851   0  0.77851   0   1.557
       │                <--- 'banana' --- 'cherry' --- 'mango'
       ├── key: (1)
       └── fd: (1)-->(2)
@@ -643,25 +643,25 @@ SELECT * FROM hist WHERE i > 125 AND i < 130 AND s = 'mango'
 ----
 select
  ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
- ├── stats: [rows=1.454546, distinct(2)=1.27273, null(2)=0, avgsize(2)=2, distinct(3)=1, null(3)=0, avgsize(3)=3]
- │   histogram(2)=  0   0   1.0909 0.36364
+ ├── stats: [rows=1.562854, distinct(2)=1.27273, null(2)=0, avgsize(2)=2, distinct(3)=1, null(3)=0, avgsize(3)=3, distinct(2,3)=1.27273, null(2,3)=0, avgsize(2,3)=5]
+ │   histogram(2)=  0   0   1.1721 0.39071
  │                <--- 125 --------- 129 -
- │   histogram(3)=  0  1.4545
+ │   histogram(3)=  0  1.5629
  │                <--- 'mango'
  ├── key: (1)
  ├── fd: ()-->(3), (1)-->(2)
  ├── index-join hist
  │    ├── columns: k:1(int!null) i:2(int) s:3(string)
- │    ├── stats: [rows=2.909091]
+ │    ├── stats: [rows=3.114058]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3)
  │    └── scan hist@idx,partial
  │         ├── columns: k:1(int!null) i:2(int!null)
  │         ├── constraint: /2/1: [/126 - /129]
- │         ├── stats: [rows=2.909091, distinct(2)=1.27273, null(2)=0, avgsize(2)=2, distinct(3)=2.90909, null(3)=0, avgsize(3)=3]
- │         │   histogram(2)=  0   0   2.1818 0.72727
+ │         ├── stats: [rows=3.114058, distinct(2)=1.27273, null(2)=0, avgsize(2)=2, distinct(3)=3, null(3)=0, avgsize(3)=3, distinct(2,3)=3.11406, null(2,3)=0, avgsize(2,3)=5]
+ │         │   histogram(2)=  0   0   2.3355 0.77851
  │         │                <--- 125 --------- 129 -
- │         │   histogram(3)=  0  0.72727   0  0.72727   0  1.4545
+ │         │   histogram(3)=  0  0.77851   0  0.77851   0   1.557
  │         │                <--- 'banana' --- 'cherry' --- 'mango'
  │         ├── key: (1)
  │         └── fd: (1)-->(2)
@@ -673,12 +673,12 @@ SELECT * FROM hist WHERE (i = 100 AND s = 'banana') OR (i = 200 AND s = 'cherry'
 ----
 select
  ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
- ├── stats: [rows=0.8083334, distinct(2)=0.808333, null(2)=0, avgsize(2)=2, distinct(3)=0.808333, null(3)=0, avgsize(3)=3]
+ ├── stats: [rows=1.270987, distinct(2)=1.27099, null(2)=0, avgsize(2)=2, distinct(3)=1.27099, null(3)=0, avgsize(3)=3, distinct(2,3)=1.27099, null(2,3)=0, avgsize(2,3)=5]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  ├── index-join hist
  │    ├── columns: k:1(int!null) i:2(int) s:3(string)
- │    ├── stats: [rows=8]
+ │    ├── stats: [rows=8.556886]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3)
  │    └── scan hist@idx,partial
@@ -686,10 +686,10 @@ select
  │         ├── constraint: /2/1
  │         │    ├── [/100 - /100]
  │         │    └── [/200 - /200]
- │         ├── stats: [rows=8, distinct(2)=2, null(2)=0, avgsize(2)=2, distinct(3)=3, null(3)=0, avgsize(3)=3]
- │         │   histogram(2)=  0   4   0   4
- │         │                <--- 100 --- 200
- │         │   histogram(3)=  0     2      0     2      0     4
+ │         ├── stats: [rows=8.556886, distinct(2)=2, null(2)=0, avgsize(2)=2, distinct(3)=3, null(3)=0, avgsize(3)=3, distinct(2,3)=5.95077, null(2,3)=0, avgsize(2,3)=5]
+ │         │   histogram(2)=  0 4.2784 0 4.2784
+ │         │                <--- 100 ---- 200 -
+ │         │   histogram(3)=  0   2.1392   0   2.1392   0  4.2784
  │         │                <--- 'banana' --- 'cherry' --- 'mango'
  │         ├── key: (1)
  │         └── fd: (1)-->(2)
@@ -712,20 +712,20 @@ SELECT * FROM hist WHERE i > 125 AND i < 150 AND s = 'banana'
 ----
 project
  ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
- ├── stats: [rows=4.363636, distinct(2)=3.09091, null(2)=0, avgsize(2)=2, distinct(3)=1, null(3)=0, avgsize(3)=3]
- │   histogram(2)=  0   0   4.1818 0.18182
+ ├── stats: [rows=6.223741, distinct(2)=3.09091, null(2)=0, avgsize(2)=2, distinct(3)=1, null(3)=0, avgsize(3)=3, distinct(2,3)=3.09091, null(2,3)=0, avgsize(2,3)=5]
+ │   histogram(2)=  0   0   5.9644 0.25932
  │                <--- 125 --------- 149 -
- │   histogram(3)=  0   4.3636
+ │   histogram(3)=  0   6.2237
  │                <--- 'banana'
  ├── key: (1)
  ├── fd: ()-->(3), (1)-->(2)
  ├── scan hist@idx,partial
  │    ├── columns: k:1(int!null) i:2(int!null)
  │    ├── constraint: /2/1: [/126 - /149]
- │    ├── stats: [rows=4.363636, distinct(2)=3.09091, null(2)=0, avgsize(2)=2, distinct(3)=1, null(3)=0, avgsize(3)=3]
- │    │   histogram(2)=  0   0   4.1818 0.18182
+ │    ├── stats: [rows=6.223741, distinct(2)=3.09091, null(2)=0, avgsize(2)=2, distinct(3)=1, null(3)=0, avgsize(3)=3, distinct(2,3)=3.09091, null(2,3)=0, avgsize(2,3)=5]
+ │    │   histogram(2)=  0   0   5.9644 0.25932
  │    │                <--- 125 --------- 149 -
- │    │   histogram(3)=  0   4.3636
+ │    │   histogram(3)=  0   6.2237
  │    │                <--- 'banana'
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
@@ -749,10 +749,10 @@ SELECT * FROM hist WHERE i > 125 AND i < 130 AND s IN ('banana', 'cherry', 'mang
 scan hist@idx,partial
  ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
  ├── constraint: /2/3/1: [/126 - /129]
- ├── stats: [rows=2.909091, distinct(2)=1.27273, null(2)=0, avgsize(2)=2, distinct(3)=2.90909, null(3)=0, avgsize(3)=3]
- │   histogram(2)=  0   0   2.1818 0.72727
+ ├── stats: [rows=3.114058, distinct(2)=1.27273, null(2)=0, avgsize(2)=2, distinct(3)=3, null(3)=0, avgsize(3)=3, distinct(2,3)=3.11406, null(2,3)=0, avgsize(2,3)=5]
+ │   histogram(2)=  0   0   2.3355 0.77851
  │                <--- 125 --------- 129 -
- │   histogram(3)=  0  0.72727   0  0.72727   0  1.4545
+ │   histogram(3)=  0  0.77851   0  0.77851   0   1.557
  │                <--- 'banana' --- 'cherry' --- 'mango'
  ├── key: (1)
  └── fd: (1)-->(2,3)
@@ -762,20 +762,20 @@ SELECT * FROM hist WHERE i > 125 AND i < 130 AND s = 'mango'
 ----
 select
  ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
- ├── stats: [rows=1.454546, distinct(2)=1.27273, null(2)=0, avgsize(2)=2, distinct(3)=1, null(3)=0, avgsize(3)=3]
- │   histogram(2)=  0   0   1.0909 0.36364
+ ├── stats: [rows=1.562854, distinct(2)=1.27273, null(2)=0, avgsize(2)=2, distinct(3)=1, null(3)=0, avgsize(3)=3, distinct(2,3)=1.27273, null(2,3)=0, avgsize(2,3)=5]
+ │   histogram(2)=  0   0   1.1721 0.39071
  │                <--- 125 --------- 129 -
- │   histogram(3)=  0  1.4545
+ │   histogram(3)=  0  1.5629
  │                <--- 'mango'
  ├── key: (1)
  ├── fd: ()-->(3), (1)-->(2)
  ├── scan hist@idx,partial
  │    ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
  │    ├── constraint: /2/3/1: [/126/'mango' - /129/'mango']
- │    ├── stats: [rows=2.909091, distinct(2)=1.27273, null(2)=0, avgsize(2)=2, distinct(3)=2.90909, null(3)=0, avgsize(3)=3]
- │    │   histogram(2)=  0   0   2.1818 0.72727
+ │    ├── stats: [rows=3.114058, distinct(2)=1.27273, null(2)=0, avgsize(2)=2, distinct(3)=3, null(3)=0, avgsize(3)=3, distinct(2,3)=3.11406, null(2,3)=0, avgsize(2,3)=5]
+ │    │   histogram(2)=  0   0   2.3355 0.77851
  │    │                <--- 125 --------- 129 -
- │    │   histogram(3)=  0  0.72727   0  0.72727   0  1.4545
+ │    │   histogram(3)=  0  0.77851   0  0.77851   0   1.557
  │    │                <--- 'banana' --- 'cherry' --- 'mango'
  │    ├── key: (1)
  │    └── fd: (1)-->(2,3)
@@ -799,10 +799,10 @@ SELECT * FROM hist WHERE i > 125 AND i < 130 AND s = 'banana'
 scan hist@idx,partial
  ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
  ├── constraint: /2/3/1: [/126 - /129]
- ├── stats: [rows=0.7272728, distinct(2)=0.727273, null(2)=0, avgsize(2)=2, distinct(3)=0.727273, null(3)=0, avgsize(3)=3]
- │   histogram(2)=  0   0   0.54545 0.18182
+ ├── stats: [rows=0.8491193, distinct(2)=0.849119, null(2)=0, avgsize(2)=2, distinct(3)=0.849119, null(3)=0, avgsize(3)=3, distinct(2,3)=0.849119, null(2,3)=0, avgsize(2,3)=5]
+ │   histogram(2)=  0   0   0.63684 0.21228
  │                <--- 125 ---------- 129 -
- │   histogram(3)=  0  0.72727
+ │   histogram(3)=  0  0.84912
  │                <--- 'banana'
  ├── key: (1)
  └── fd: ()-->(3), (1)-->(2)
@@ -951,7 +951,7 @@ SELECT * FROM inv@partial WHERE j @> '{"x": "y"}' AND s = 'foo' AND i > 0 AND i 
 select
  ├── columns: k:1(int!null) i:2(int!null) j:3(jsonb!null) s:4(string!null)
  ├── immutable
- ├── stats: [rows=0.01983973, distinct(2)=0.0198397, null(2)=0, avgsize(2)=2, distinct(4)=0.0198397, null(4)=0, avgsize(4)=23]
+ ├── stats: [rows=0.901984, distinct(2)=0.901984, null(2)=0, avgsize(2)=2, distinct(4)=0.901984, null(4)=0, avgsize(4)=23, distinct(2,4)=0.901984, null(2,4)=0, avgsize(2,4)=25]
  ├── key: (1)
  ├── fd: ()-->(4), (1)-->(2,3)
  ├── index-join inv
@@ -1049,10 +1049,10 @@ project
       ├── inverted constraint: /7/1
       │    └── spans: ["7g\x00\x01*\x0e\x00", "7g\x00\x01*\x0e\x00"]
       ├── flags: force-index=partial
-      ├── stats: [rows=20, distinct(4)=2, null(4)=0, avgsize(4)=23, distinct(7)=1, null(7)=0, avgsize(7)=34]
-      │   histogram(4)=  0     10     0     10
+      ├── stats: [rows=46.67789, distinct(4)=2, null(4)=0, avgsize(4)=23, distinct(7)=1, null(7)=0, avgsize(7)=34, distinct(4,7)=2, null(4,7)=0, avgsize(4,7)=57]
+      │   histogram(4)=  0   23.339   0   23.339
       │                <--- 'banana' --- 'cherry'
-      │   histogram(7)=  0          20          1.1895e-16          0
+      │   histogram(7)=  0        46.678        2.7762e-16          0
       │                <--- '\x376700012a0e00' ------------ '\x376700012a0e01'
       └── key: (1)
 
@@ -1072,10 +1072,10 @@ index-join inv_hist
       ├── inverted constraint: /7/1
       │    └── spans: ["7g\x00\x01*\x0e\x00", "7g\x00\x01*\x0e\x00"]
       ├── flags: force-index=partial
-      ├── stats: [rows=20, distinct(4)=2, null(4)=0, avgsize(4)=23, distinct(7)=1, null(7)=0, avgsize(7)=34]
-      │   histogram(4)=  0     10     0     10
+      ├── stats: [rows=46.67789, distinct(4)=2, null(4)=0, avgsize(4)=23, distinct(7)=1, null(7)=0, avgsize(7)=34, distinct(4,7)=2, null(4,7)=0, avgsize(4,7)=57]
+      │   histogram(4)=  0   23.339   0   23.339
       │                <--- 'banana' --- 'cherry'
-      │   histogram(7)=  0          20          1.1895e-16          0
+      │   histogram(7)=  0        46.678        2.7762e-16          0
       │                <--- '\x376700012a0e00' ------------ '\x376700012a0e01'
       └── key: (1)
 
@@ -1097,7 +1097,7 @@ project
       ├── fd: ()-->(4), (1)-->(3)
       ├── index-join inv_hist
       │    ├── columns: k:1(int!null) j:3(jsonb) s:4(string)
-      │    ├── stats: [rows=20]
+      │    ├── stats: [rows=46.67789]
       │    ├── key: (1)
       │    ├── fd: (1)-->(3,4)
       │    └── scan inv_hist@partial,partial
@@ -1105,10 +1105,10 @@ project
       │         ├── inverted constraint: /7/1
       │         │    └── spans: ["7g\x00\x01*\x0e\x00", "7g\x00\x01*\x0e\x00"]
       │         ├── flags: force-index=partial
-      │         ├── stats: [rows=20, distinct(4)=2, null(4)=0, avgsize(4)=23, distinct(7)=1, null(7)=0, avgsize(7)=34]
-      │         │   histogram(4)=  0     10     0     10
+      │         ├── stats: [rows=46.67789, distinct(4)=2, null(4)=0, avgsize(4)=23, distinct(7)=1, null(7)=0, avgsize(7)=34, distinct(4,7)=2, null(4,7)=0, avgsize(4,7)=57]
+      │         │   histogram(4)=  0   23.339   0   23.339
       │         │                <--- 'banana' --- 'cherry'
-      │         │   histogram(7)=  0          20          1.1895e-16          0
+      │         │   histogram(7)=  0        46.678        2.7762e-16          0
       │         │                <--- '\x376700012a0e00' ------------ '\x376700012a0e01'
       │         └── key: (1)
       └── filters
@@ -1127,7 +1127,7 @@ select
  ├── fd: ()-->(4), (1)-->(2,3)
  ├── index-join inv_hist
  │    ├── columns: k:1(int!null) i:2(int) j:3(jsonb) s:4(string)
- │    ├── stats: [rows=20]
+ │    ├── stats: [rows=46.67789]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
  │    └── scan inv_hist@partial,partial
@@ -1135,10 +1135,10 @@ select
  │         ├── inverted constraint: /7/1
  │         │    └── spans: ["7g\x00\x01*\x0e\x00", "7g\x00\x01*\x0e\x00"]
  │         ├── flags: force-index=partial
- │         ├── stats: [rows=20, distinct(4)=2, null(4)=0, avgsize(4)=23, distinct(7)=1, null(7)=0, avgsize(7)=34]
- │         │   histogram(4)=  0     10     0     10
+ │         ├── stats: [rows=46.67789, distinct(4)=2, null(4)=0, avgsize(4)=23, distinct(7)=1, null(7)=0, avgsize(7)=34, distinct(4,7)=2, null(4,7)=0, avgsize(4,7)=57]
+ │         │   histogram(4)=  0   23.339   0   23.339
  │         │                <--- 'banana' --- 'cherry'
- │         │   histogram(7)=  0          20          1.1895e-16          0
+ │         │   histogram(7)=  0        46.678        2.7762e-16          0
  │         │                <--- '\x376700012a0e00' ------------ '\x376700012a0e01'
  │         └── key: (1)
  └── filters
@@ -1150,16 +1150,16 @@ SELECT * FROM inv_hist@partial WHERE j @> '{"g": 7}' AND s IN ('apple', 'banana'
 select
  ├── columns: k:1(int!null) i:2(int!null) j:3(jsonb!null) s:4(string!null)
  ├── immutable
- ├── stats: [rows=1.777778, distinct(2)=1.77778, null(2)=0, avgsize(2)=2, distinct(4)=1.77778, null(4)=0, avgsize(4)=23]
- │   histogram(2)=  0  0  1.6 0.17778
- │                <--- 0 ------ 100 -
- │   histogram(4)=  0  0.88889   0  0.88889
+ ├── stats: [rows=3.080741, distinct(2)=3.08074, null(2)=0, avgsize(2)=2, distinct(4)=2, null(4)=0, avgsize(4)=23, distinct(2,4)=3.08074, null(2,4)=0, avgsize(2,4)=25]
+ │   histogram(2)=  0  0  2.7727 0.30807
+ │                <--- 0 --------- 100 -
+ │   histogram(4)=  0   1.5404   0   1.5404
  │                <--- 'banana' --- 'cherry'
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── index-join inv_hist
  │    ├── columns: k:1(int!null) i:2(int) j:3(jsonb) s:4(string)
- │    ├── stats: [rows=20]
+ │    ├── stats: [rows=46.67789]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
  │    └── scan inv_hist@partial,partial
@@ -1167,10 +1167,10 @@ select
  │         ├── inverted constraint: /7/1
  │         │    └── spans: ["7g\x00\x01*\x0e\x00", "7g\x00\x01*\x0e\x00"]
  │         ├── flags: force-index=partial
- │         ├── stats: [rows=20, distinct(4)=2, null(4)=0, avgsize(4)=23, distinct(7)=1, null(7)=0, avgsize(7)=34]
- │         │   histogram(4)=  0     10     0     10
+ │         ├── stats: [rows=46.67789, distinct(4)=2, null(4)=0, avgsize(4)=23, distinct(7)=1, null(7)=0, avgsize(7)=34, distinct(4,7)=2, null(4,7)=0, avgsize(4,7)=57]
+ │         │   histogram(4)=  0   23.339   0   23.339
  │         │                <--- 'banana' --- 'cherry'
- │         │   histogram(7)=  0          20          1.1895e-16          0
+ │         │   histogram(7)=  0        46.678        2.7762e-16          0
  │         │                <--- '\x376700012a0e00' ------------ '\x376700012a0e01'
  │         └── key: (1)
  └── filters

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -253,7 +253,7 @@ SELECT * FROM a WHERE ((s >= 'bar' AND s <= 'foo') OR (s >= 'foobar')) AND d > 5
 select
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null) b:5(bool)
  ├── immutable
- ├── stats: [rows=500, distinct(3)=1, null(3)=0, avgsize(3)=20, distinct(4)=500, null(4)=0, avgsize(4)=5]
+ ├── stats: [rows=650, distinct(3)=1, null(3)=0, avgsize(3)=20, distinct(4)=650, null(4)=0, avgsize(4)=5, distinct(3,4)=650, null(3,4)=0, avgsize(3,4)=25]
  ├── key: (1)
  ├── fd: (1)-->(2-5), (3,4)-->(1,2,5)
  ├── scan a
@@ -271,7 +271,7 @@ SELECT * FROM a WHERE ((s >= 'bar' AND s <= 'foo') OR (s >= 'foobar')) AND d <= 
 select
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null) b:5(bool)
  ├── immutable
- ├── stats: [rows=500, distinct(3)=1, null(3)=0, avgsize(3)=20, distinct(4)=500, null(4)=0, avgsize(4)=5]
+ ├── stats: [rows=650, distinct(3)=1, null(3)=0, avgsize(3)=20, distinct(4)=650, null(4)=0, avgsize(4)=5, distinct(3,4)=650, null(3,4)=0, avgsize(3,4)=25]
  ├── key: (1)
  ├── fd: (1)-->(2-5), (3,4)-->(1,2,5)
  ├── scan a
@@ -456,13 +456,13 @@ SELECT * FROM abcde WHERE b = 1 AND c LIKE '+1-1000%'
 ----
 index-join abcde
  ├── columns: a:1(int!null) b:2(int!null) c:3(string!null) d:4(int) e:5(int)
- ├── stats: [rows=1.111111, distinct(2)=1, null(2)=0, avgsize(2)=4, distinct(3)=1.11111, null(3)=0, avgsize(3)=4]
+ ├── stats: [rows=9.111111, distinct(2)=1, null(2)=0, avgsize(2)=4, distinct(3)=9.11111, null(3)=0, avgsize(3)=4, distinct(2,3)=9.11111, null(2,3)=0, avgsize(2,3)=8]
  ├── key: (1)
  ├── fd: ()-->(2), (1)-->(3-5)
  └── scan abcde@good
       ├── columns: a:1(int!null) b:2(int!null) c:3(string!null) d:4(int)
       ├── constraint: /2/3/4/1: [/1/'+1-1000' - /1/'+1-1001')
-      ├── stats: [rows=1.111111, distinct(2)=1, null(2)=0, avgsize(2)=4, distinct(3)=1.11111, null(3)=0, avgsize(3)=4]
+      ├── stats: [rows=9.111111, distinct(2)=1, null(2)=0, avgsize(2)=4, distinct(3)=9.11111, null(3)=0, avgsize(3)=4, distinct(2,3)=9.11111, null(2,3)=0, avgsize(2,3)=8]
       ├── key: (1)
       └── fd: ()-->(2), (1)-->(3,4)
 
@@ -901,10 +901,10 @@ SELECT * FROM hist WHERE (a = 10 OR a = 20) AND (b = '2018-08-31'::DATE OR b = '
 ----
 select
  ├── columns: a:1(int!null) b:2(date!null) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
- ├── stats: [rows=1.5, distinct(1)=1.5, null(1)=0, avgsize(1)=2, distinct(2)=1.5, null(2)=0, avgsize(2)=6]
- │   histogram(1)=  0 0.5  0  1
- │                <--- 10 --- 20
- │   histogram(2)=  0      0.6       0      0.9
+ ├── stats: [rows=6.314308, distinct(1)=2, null(1)=0, avgsize(1)=2, distinct(2)=2, null(2)=0, avgsize(2)=6, distinct(1,2)=3.80513, null(1,2)=0, avgsize(1,2)=8]
+ │   histogram(1)=  0 2.1048 0 4.2095
+ │                <---- 10 ----- 20 -
+ │   histogram(2)=  0     2.5257     0     3.7886
  │                <--- '2018-08-31' --- '2018-09-30'
  ├── index-join hist
  │    ├── columns: a:1(int) b:2(date) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
@@ -927,10 +927,10 @@ SELECT * FROM hist WHERE (a = 30 OR a = 40) AND (b = '2018-06-30'::DATE OR b = '
 ----
 select
  ├── columns: a:1(int!null) b:2(date!null) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
- ├── stats: [rows=0.7000001, distinct(1)=0.7, null(1)=0, avgsize(1)=2, distinct(2)=0.7, null(2)=0, avgsize(2)=6]
- │   histogram(1)=  0 0.3  0 0.4
- │                <--- 30 --- 40
- │   histogram(2)=  0      0.7
+ ├── stats: [rows=2.374, distinct(1)=2, null(1)=0, avgsize(1)=2, distinct(2)=1, null(2)=0, avgsize(2)=6, distinct(1,2)=2, null(1,2)=0, avgsize(1,2)=8]
+ │   histogram(1)=  0 1.0174 0 1.3566
+ │                <---- 30 ----- 40 -
+ │   histogram(2)=  0     2.374
  │                <--- '2018-07-31'
  ├── index-join hist
  │    ├── columns: a:1(int) b:2(date) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
@@ -1005,16 +1005,16 @@ SELECT * FROM xyz WHERE x=1 AND z>990
 ----
 index-join xyz
  ├── columns: x:1(int!null) y:2(int!null) z:3(int!null) other:4(int)
- ├── stats: [rows=0.1801802, distinct(1)=0.18018, null(1)=0, avgsize(1)=4, distinct(3)=0.18018, null(3)=0, avgsize(3)=4]
- │   histogram(3)=  0   0   0.18018   0
+ ├── stats: [rows=0.8288288, distinct(1)=0.828829, null(1)=0, avgsize(1)=4, distinct(3)=0.828829, null(3)=0, avgsize(3)=4, distinct(1,3)=0.828829, null(1,3)=0, avgsize(1,3)=8]
+ │   histogram(3)=  0   0   0.82883   0
  │                <--- 990 --------- 1000
  ├── key: (2)
  ├── fd: ()-->(1), (2)-->(3,4), (3)-->(2,4)
  └── scan xyz@xyz_x_z_key
       ├── columns: x:1(int!null) y:2(int!null) z:3(int!null)
       ├── constraint: /1/3: [/1/991 - /1]
-      ├── stats: [rows=0.1801802, distinct(1)=0.18018, null(1)=0, avgsize(1)=4, distinct(3)=0.18018, null(3)=0, avgsize(3)=4]
-      │   histogram(3)=  0   0   0.18018   0
+      ├── stats: [rows=0.8288288, distinct(1)=0.828829, null(1)=0, avgsize(1)=4, distinct(3)=0.828829, null(3)=0, avgsize(3)=4, distinct(1,3)=0.828829, null(1,3)=0, avgsize(1,3)=8]
+      │   histogram(3)=  0   0   0.82883   0
       │                <--- 990 --------- 1000
       ├── key: (2)
       └── fd: ()-->(1), (2)-->(3), (3)-->(2)
@@ -1024,16 +1024,16 @@ SELECT * FROM xyz WHERE x=1 AND z<990 AND (other=11 OR other=13)
 ----
 select
  ├── columns: x:1(int!null) y:2(int!null) z:3(int!null) other:4(int!null)
- ├── stats: [rows=0.395996, distinct(1)=0.395996, null(1)=0, avgsize(1)=4, distinct(3)=0.395996, null(3)=0, avgsize(3)=4, distinct(4)=0.395996, null(4)=0, avgsize(4)=4]
- │   histogram(3)=  0  0  0.3956 0.0004004
+ ├── stats: [rows=1.8396, distinct(1)=1, null(1)=0, avgsize(1)=4, distinct(3)=1.8396, null(3)=0, avgsize(3)=4, distinct(4)=1.8396, null(4)=0, avgsize(4)=4, distinct(1,3,4)=1.8396, null(1,3,4)=0, avgsize(1,3,4)=12]
+ │   histogram(3)=  0  0  1.8377 0.0018601
  │                <--- 0 ---------- 989 --
- │   histogram(4)=  0 0.198 0 0.198
- │                <--- 11 ---- 13 -
+ │   histogram(4)=  0 0.9198 0 0.9198
+ │                <---- 11 ----- 13 -
  ├── key: (2)
  ├── fd: ()-->(1), (2)-->(3,4), (3)-->(2,4)
  ├── index-join xyz
  │    ├── columns: x:1(int!null) y:2(int!null) z:3(int) other:4(int)
- │    ├── stats: [rows=0.4]
+ │    ├── stats: [rows=0.58]
  │    ├── key: (2)
  │    ├── fd: ()-->(1), (2)-->(3,4), (1,3)~~>(2,4)
  │    └── scan xyz@xyz_x_other_z
@@ -1041,8 +1041,8 @@ select
  │         ├── constraint: /1/-4/2
  │         │    ├── [/1/13 - /1/13]
  │         │    └── [/1/11 - /1/11]
- │         ├── stats: [rows=0.4, distinct(1)=0.4, null(1)=0, avgsize(1)=4, distinct(4)=0.4, null(4)=0, avgsize(4)=4]
- │         │   histogram(4)=  0 0.2  0 0.2
+ │         ├── stats: [rows=0.58, distinct(1)=0.58, null(1)=0, avgsize(1)=4, distinct(4)=0.58, null(4)=0, avgsize(4)=4, distinct(1,4)=0.58, null(1,4)=0, avgsize(1,4)=8]
+ │         │   histogram(4)=  0 0.29 0 0.29
  │         │                <--- 11 --- 13
  │         ├── key: (2)
  │         └── fd: ()-->(1), (2)-->(4)
@@ -1134,16 +1134,16 @@ AND f > 0
 ----
 select
  ├── columns: a:1(uuid!null) b:2(bool!null) c:3(int!null) d:4(string!null) e:5(int!null) f:6(float!null)
- ├── stats: [rows=1.66e-05, distinct(1)=1.66e-05, null(1)=0, avgsize(1)=4, distinct(2)=1.66e-05, null(2)=0, avgsize(2)=4, distinct(3)=1.66e-05, null(3)=0, avgsize(3)=4, distinct(4)=1.66e-05, null(4)=0, avgsize(4)=4, distinct(5)=1.66e-05, null(5)=0, avgsize(5)=4, distinct(6)=1.66e-05, null(6)=0, avgsize(6)=4]
+ ├── stats: [rows=0.07568148, distinct(1)=0.0756815, null(1)=0, avgsize(1)=4, distinct(2)=0.0756815, null(2)=0, avgsize(2)=4, distinct(3)=0.0756815, null(3)=0, avgsize(3)=4, distinct(4)=0.0756815, null(4)=0, avgsize(4)=4, distinct(5)=0.0756815, null(5)=0, avgsize(5)=4, distinct(6)=0.0756815, null(6)=0, avgsize(6)=4, distinct(5,6)=0.0756815, null(5,6)=0, avgsize(5,6)=8, distinct(1-4)=0.0756815, null(1-4)=0, avgsize(1-4)=16, distinct(1-6)=0.0756815, null(1-6)=0, avgsize(1-6)=24]
  ├── fd: ()-->(1-4)
  ├── index-join multi_col
  │    ├── columns: a:1(uuid) b:2(bool) c:3(int) d:4(string) e:5(int) f:6(float)
- │    ├── stats: [rows=4.96e-05]
+ │    ├── stats: [rows=0.08109049]
  │    ├── fd: ()-->(1-4)
  │    └── scan multi_col@abcde_idx
  │         ├── columns: a:1(uuid!null) b:2(bool!null) c:3(int!null) d:4(string!null) e:5(int!null) rowid:7(int!null)
  │         ├── constraint: /1/2/-3/4/5/7: [/'37685f26-4b07-40ba-9bbf-42916ed9bc61'/true/5/'foo'/11 - /'37685f26-4b07-40ba-9bbf-42916ed9bc61'/true/5/'foo'/20]
- │         ├── stats: [rows=4.96e-05, distinct(1)=4.96e-05, null(1)=0, avgsize(1)=4, distinct(2)=4.96e-05, null(2)=0, avgsize(2)=4, distinct(3)=4.96e-05, null(3)=0, avgsize(3)=4, distinct(4)=4.96e-05, null(4)=0, avgsize(4)=4, distinct(5)=4.96e-05, null(5)=0, avgsize(5)=4]
+ │         ├── stats: [rows=0.08109049, distinct(1)=0.0810905, null(1)=0, avgsize(1)=4, distinct(2)=0.0810905, null(2)=0, avgsize(2)=4, distinct(3)=0.0810905, null(3)=0, avgsize(3)=4, distinct(4)=0.0810905, null(4)=0, avgsize(4)=4, distinct(5)=0.0810905, null(5)=0, avgsize(5)=4, distinct(1-4)=0.0810905, null(1-4)=0, avgsize(1-4)=16, distinct(1-5)=0.0810905, null(1-5)=0, avgsize(1-5)=20]
  │         ├── key: (7)
  │         └── fd: ()-->(1-4), (7)-->(5)
  └── filters
@@ -1161,17 +1161,17 @@ AND f > 0
 ----
 select
  ├── columns: a:1(uuid!null) b:2(bool!null) c:3(int!null) d:4(string!null) e:5(int!null) f:6(float!null)
- ├── stats: [rows=1.66e-05, distinct(1)=1.66e-05, null(1)=0, avgsize(1)=4, distinct(2)=1.66e-05, null(2)=0, avgsize(2)=4, distinct(3)=1.66e-05, null(3)=0, avgsize(3)=4, distinct(4)=1.66e-05, null(4)=0, avgsize(4)=4, distinct(5)=1.66e-05, null(5)=0, avgsize(5)=4, distinct(6)=1.66e-05, null(6)=0, avgsize(6)=4]
+ ├── stats: [rows=0.07568148, distinct(1)=0.0756815, null(1)=0, avgsize(1)=4, distinct(2)=0.0756815, null(2)=0, avgsize(2)=4, distinct(3)=0.0756815, null(3)=0, avgsize(3)=4, distinct(4)=0.0756815, null(4)=0, avgsize(4)=4, distinct(5)=0.0756815, null(5)=0, avgsize(5)=4, distinct(6)=0.0756815, null(6)=0, avgsize(6)=4, distinct(5,6)=0.0756815, null(5,6)=0, avgsize(5,6)=8, distinct(1-4)=0.0756815, null(1-4)=0, avgsize(1-4)=16, distinct(1-6)=0.0756815, null(1-6)=0, avgsize(1-6)=24]
  ├── fd: ()-->(1-4)
  ├── index-join multi_col
  │    ├── columns: a:1(uuid) b:2(bool) c:3(int) d:4(string) e:5(int) f:6(float)
- │    ├── stats: [rows=1]
+ │    ├── stats: [rows=9.1]
  │    ├── fd: ()-->(3)
  │    └── scan multi_col@ce_idx
  │         ├── columns: c:3(int!null) e:5(int!null) rowid:7(int!null)
  │         ├── constraint: /3/5/7: [/5/11 - /5/20]
  │         ├── flags: force-index=ce_idx
- │         ├── stats: [rows=1, distinct(3)=1, null(3)=0, avgsize(3)=4, distinct(5)=1, null(5)=0, avgsize(5)=4]
+ │         ├── stats: [rows=9.1, distinct(3)=1, null(3)=0, avgsize(3)=4, distinct(5)=9.1, null(5)=0, avgsize(5)=4, distinct(3,5)=9.1, null(3,5)=0, avgsize(3,5)=8]
  │         ├── key: (7)
  │         └── fd: ()-->(3), (7)-->(5)
  └── filters
@@ -1191,17 +1191,17 @@ AND f > 0
 ----
 select
  ├── columns: a:1(uuid!null) b:2(bool!null) c:3(int!null) d:4(string!null) e:5(int!null) f:6(float!null)
- ├── stats: [rows=1.66e-05, distinct(1)=1.66e-05, null(1)=0, avgsize(1)=4, distinct(2)=1.66e-05, null(2)=0, avgsize(2)=4, distinct(3)=1.66e-05, null(3)=0, avgsize(3)=4, distinct(4)=1.66e-05, null(4)=0, avgsize(4)=4, distinct(5)=1.66e-05, null(5)=0, avgsize(5)=4, distinct(6)=1.66e-05, null(6)=0, avgsize(6)=4]
+ ├── stats: [rows=0.07568148, distinct(1)=0.0756815, null(1)=0, avgsize(1)=4, distinct(2)=0.0756815, null(2)=0, avgsize(2)=4, distinct(3)=0.0756815, null(3)=0, avgsize(3)=4, distinct(4)=0.0756815, null(4)=0, avgsize(4)=4, distinct(5)=0.0756815, null(5)=0, avgsize(5)=4, distinct(6)=0.0756815, null(6)=0, avgsize(6)=4, distinct(5,6)=0.0756815, null(5,6)=0, avgsize(5,6)=8, distinct(1-4)=0.0756815, null(1-4)=0, avgsize(1-4)=16, distinct(1-6)=0.0756815, null(1-6)=0, avgsize(1-6)=24]
  ├── fd: ()-->(1-4)
  ├── index-join multi_col
  │    ├── columns: a:1(uuid) b:2(bool) c:3(int) d:4(string) e:5(int) f:6(float)
- │    ├── stats: [rows=0.0495001]
+ │    ├── stats: [rows=0.90585]
  │    ├── fd: ()-->(1,2,4)
  │    └── scan multi_col@bad_idx
  │         ├── columns: a:1(uuid!null) b:2(bool!null) d:4(string!null) rowid:7(int!null)
  │         ├── constraint: /2/-1/4/7: [/true/'37685f26-4b07-40ba-9bbf-42916ed9bc61'/'foo' - /true/'37685f26-4b07-40ba-9bbf-42916ed9bc61'/'foo']
  │         ├── flags: force-index=bad_idx
- │         ├── stats: [rows=0.0495001, distinct(1)=0.0495001, null(1)=0, avgsize(1)=4, distinct(2)=0.0495001, null(2)=0, avgsize(2)=4, distinct(4)=0.0495001, null(4)=0, avgsize(4)=4]
+ │         ├── stats: [rows=0.90585, distinct(1)=0.90585, null(1)=0, avgsize(1)=4, distinct(2)=0.90585, null(2)=0, avgsize(2)=4, distinct(4)=0.90585, null(4)=0, avgsize(4)=4, distinct(1,2,4)=0.90585, null(1,2,4)=0, avgsize(1,2,4)=12]
  │         ├── key: (7)
  │         └── fd: ()-->(1,2,4)
  └── filters
@@ -1220,22 +1220,22 @@ AND f > 0
 ----
 select
  ├── columns: a:1(uuid!null) b:2(bool!null) c:3(int!null) d:4(string!null) e:5(int!null) f:6(float!null)
- ├── stats: [rows=1.66e-05, distinct(1)=1.66e-05, null(1)=0, avgsize(1)=4, distinct(2)=1.66e-05, null(2)=0, avgsize(2)=4, distinct(3)=1.66e-05, null(3)=0, avgsize(3)=4, distinct(4)=1.66e-05, null(4)=0, avgsize(4)=4, distinct(5)=1.66e-05, null(5)=0, avgsize(5)=4, distinct(6)=1.66e-05, null(6)=0, avgsize(6)=4]
+ ├── stats: [rows=0.07568148, distinct(1)=0.0756815, null(1)=0, avgsize(1)=4, distinct(2)=0.0756815, null(2)=0, avgsize(2)=4, distinct(3)=0.0756815, null(3)=0, avgsize(3)=4, distinct(4)=0.0756815, null(4)=0, avgsize(4)=4, distinct(5)=0.0756815, null(5)=0, avgsize(5)=4, distinct(6)=0.0756815, null(6)=0, avgsize(6)=4, distinct(5,6)=0.0756815, null(5,6)=0, avgsize(5,6)=8, distinct(1-4)=0.0756815, null(1-4)=0, avgsize(1-4)=16, distinct(1-6)=0.0756815, null(1-6)=0, avgsize(1-6)=24]
  ├── fd: ()-->(1-4)
  ├── index-join multi_col
  │    ├── columns: a:1(uuid) b:2(bool) c:3(int) d:4(string) e:5(int) f:6(float)
- │    ├── stats: [rows=0.9900001]
+ │    ├── stats: [rows=3.391172]
  │    ├── fd: ()-->(4)
  │    └── select
  │         ├── columns: d:4(string!null) e:5(int!null) f:6(float!null) rowid:7(int!null)
- │         ├── stats: [rows=0.9900001, distinct(6)=0.99, null(6)=0, avgsize(6)=4]
+ │         ├── stats: [rows=3.391172, distinct(6)=2.91209, null(6)=0, avgsize(6)=4]
  │         ├── key: (7)
  │         ├── fd: ()-->(4), (7)-->(5,6)
  │         ├── scan multi_col@def_idx
  │         │    ├── columns: d:4(string!null) e:5(int!null) f:6(float) rowid:7(int!null)
  │         │    ├── constraint: /4/5/6/7: [/'foo'/11/5e-324 - /'foo'/20]
  │         │    ├── flags: force-index=def_idx
- │         │    ├── stats: [rows=1, distinct(4)=1, null(4)=0, avgsize(4)=4, distinct(5)=1, null(5)=0, avgsize(5)=4, distinct(6)=0.995512, null(6)=0.01, avgsize(6)=4, distinct(7)=1, null(7)=0, avgsize(7)=4]
+ │         │    ├── stats: [rows=9.1, distinct(4)=1, null(4)=0, avgsize(4)=4, distinct(5)=9.1, null(5)=0, avgsize(5)=4, distinct(6)=8.73626, null(6)=0.091, avgsize(6)=4, distinct(7)=9.1, null(7)=0, avgsize(7)=4, distinct(4,5)=9.1, null(4,5)=0, avgsize(4,5)=8]
  │         │    ├── key: (7)
  │         │    └── fd: ()-->(4), (7)-->(5,6)
  │         └── filters
@@ -1255,11 +1255,11 @@ AND f > 0
 ----
 select
  ├── columns: a:1(uuid) b:2(bool!null) c:3(int!null) d:4(string) e:5(int!null) f:6(float!null)
- ├── stats: [rows=0.0825001, distinct(2)=0.0825001, null(2)=0, avgsize(2)=4, distinct(3)=0.0825001, null(3)=0, avgsize(3)=4, distinct(5)=0.0825001, null(5)=0, avgsize(5)=4, distinct(6)=0.0825001, null(6)=0, avgsize(6)=4]
+ ├── stats: [rows=0.21615, distinct(2)=0.21615, null(2)=0, avgsize(2)=4, distinct(3)=0.21615, null(3)=0, avgsize(3)=4, distinct(5)=0.21615, null(5)=0, avgsize(5)=4, distinct(6)=0.21615, null(6)=0, avgsize(6)=4, distinct(2,3)=0.21615, null(2,3)=0, avgsize(2,3)=8, distinct(5,6)=0.21615, null(5,6)=0, avgsize(5,6)=8, distinct(2,3,5,6)=0.21615, null(2,3,5,6)=0, avgsize(2,3,5,6)=16]
  ├── fd: ()-->(2,3)
  ├── index-join multi_col
  │    ├── columns: a:1(uuid) b:2(bool) c:3(int) d:4(string) e:5(int) f:6(float)
- │    ├── stats: [rows=0.5000001]
+ │    ├── stats: [rows=4.554054]
  │    ├── fd: ()-->(3)
  │    └── scan multi_col@ce_idx
  │         ├── columns: c:3(int!null) e:5(int!null) rowid:7(int!null)
@@ -1269,7 +1269,7 @@ select
  │         │    ├── [/5/5 - /5/5]
  │         │    ├── [/5/7 - /5/7]
  │         │    └── [/5/9 - /5/9]
- │         ├── stats: [rows=0.5000001, distinct(3)=0.5, null(3)=0, avgsize(3)=4, distinct(5)=0.5, null(5)=0, avgsize(5)=4]
+ │         ├── stats: [rows=4.554054, distinct(3)=1, null(3)=0, avgsize(3)=4, distinct(5)=4.55405, null(5)=0, avgsize(5)=4, distinct(3,5)=4.55405, null(3,5)=0, avgsize(3,5)=8]
  │         ├── key: (7)
  │         └── fd: ()-->(3), (7)-->(5)
  └── filters
@@ -1286,11 +1286,11 @@ AND f > 0
 ----
 select
  ├── columns: a:1(uuid) b:2(bool!null) c:3(int!null) d:4(string) e:5(int!null) f:6(float!null)
- ├── stats: [rows=0.0825001, distinct(2)=0.0825001, null(2)=0, avgsize(2)=4, distinct(3)=0.0825001, null(3)=0, avgsize(3)=4, distinct(5)=0.0825001, null(5)=0, avgsize(5)=4, distinct(6)=0.0825001, null(6)=0, avgsize(6)=4]
+ ├── stats: [rows=0.21615, distinct(2)=0.21615, null(2)=0, avgsize(2)=4, distinct(3)=0.21615, null(3)=0, avgsize(3)=4, distinct(5)=0.21615, null(5)=0, avgsize(5)=4, distinct(6)=0.21615, null(6)=0, avgsize(6)=4, distinct(2,3)=0.21615, null(2,3)=0, avgsize(2,3)=8, distinct(5,6)=0.21615, null(5,6)=0, avgsize(5,6)=8, distinct(2,3,5,6)=0.21615, null(2,3,5,6)=0, avgsize(2,3,5,6)=16]
  ├── fd: ()-->(2,3)
  ├── index-join multi_col
  │    ├── columns: a:1(uuid) b:2(bool) c:3(int) d:4(string) e:5(int) f:6(float)
- │    ├── stats: [rows=8.25]
+ │    ├── stats: [rows=8.250001]
  │    ├── fd: ()-->(2)
  │    └── scan multi_col@bef_idx
  │         ├── columns: b:2(bool!null) e:5(int!null) f:6(float!null) rowid:7(int!null)
@@ -1301,7 +1301,7 @@ select
  │         │    ├── [/true/7/5e-324 - /true/7]
  │         │    └── [/true/9/5e-324 - /true/9]
  │         ├── flags: force-index=bef_idx
- │         ├── stats: [rows=8.25, distinct(2)=1, null(2)=0, avgsize(2)=4, distinct(5)=5, null(5)=0, avgsize(5)=4, distinct(6)=8.25, null(6)=0, avgsize(6)=4]
+ │         ├── stats: [rows=8.250001, distinct(2)=1, null(2)=0, avgsize(2)=4, distinct(5)=5, null(5)=0, avgsize(5)=4, distinct(6)=8.25, null(6)=0, avgsize(6)=4, distinct(2,5,6)=8.25, null(2,5,6)=0, avgsize(2,5,6)=12]
  │         ├── key: (7)
  │         └── fd: ()-->(2), (7)-->(5,6)
  └── filters
@@ -1525,16 +1525,16 @@ AND f > 0
 ----
 select
  ├── columns: a:1(uuid!null) b:2(bool!null) c:3(int!null) d:4(string!null) e:5(int!null) f:6(float!null)
- ├── stats: [rows=7.819546e-06, distinct(1)=7.81955e-06, null(1)=0, avgsize(1)=1, distinct(2)=7.81955e-06, null(2)=0, avgsize(2)=2, distinct(3)=7.81955e-06, null(3)=0, avgsize(3)=3, distinct(4)=7.81955e-06, null(4)=0, avgsize(4)=4, distinct(5)=7.81955e-06, null(5)=0, avgsize(5)=5, distinct(6)=7.81955e-06, null(6)=0, avgsize(6)=6]
+ ├── stats: [rows=0.06870563, distinct(1)=0.0687056, null(1)=0, avgsize(1)=1, distinct(2)=0.0687056, null(2)=0, avgsize(2)=2, distinct(3)=0.0687056, null(3)=0, avgsize(3)=3, distinct(4)=0.0687056, null(4)=0, avgsize(4)=4, distinct(5)=0.0687056, null(5)=0, avgsize(5)=5, distinct(6)=0.0687056, null(6)=0, avgsize(6)=6, distinct(5,6)=0.0687056, null(5,6)=0, avgsize(5,6)=11, distinct(1-4)=0.0687056, null(1-4)=0, avgsize(1-4)=16, distinct(1-6)=0.0687056, null(1-6)=0, avgsize(1-6)=21]
  ├── fd: ()-->(1-4)
  ├── index-join multi_col
  │    ├── columns: a:1(uuid) b:2(bool) c:3(int) d:4(string) e:5(int) f:6(float)
- │    ├── stats: [rows=2.166116e-05]
+ │    ├── stats: [rows=0.07364029]
  │    ├── fd: ()-->(1-4)
  │    └── scan multi_col@abcde_idx
  │         ├── columns: a:1(uuid!null) b:2(bool!null) c:3(int!null) d:4(string!null) e:5(int!null) rowid:7(int!null)
  │         ├── constraint: /1/2/-3/4/5/7: [/'37685f26-4b07-40ba-9bbf-42916ed9bc61'/true/5/'foo'/11 - /'37685f26-4b07-40ba-9bbf-42916ed9bc61'/true/5/'foo'/20]
- │         ├── stats: [rows=2.166116e-05, distinct(1)=2.16612e-05, null(1)=0, avgsize(1)=1, distinct(2)=2.16612e-05, null(2)=0, avgsize(2)=2, distinct(3)=2.16612e-05, null(3)=0, avgsize(3)=3, distinct(4)=2.16612e-05, null(4)=0, avgsize(4)=4, distinct(5)=2.16612e-05, null(5)=0, avgsize(5)=5]
+ │         ├── stats: [rows=0.07364029, distinct(1)=0.0736403, null(1)=0, avgsize(1)=1, distinct(2)=0.0736403, null(2)=0, avgsize(2)=2, distinct(3)=0.0736403, null(3)=0, avgsize(3)=3, distinct(4)=0.0736403, null(4)=0, avgsize(4)=4, distinct(5)=0.0736403, null(5)=0, avgsize(5)=5, distinct(1-4)=0.0736403, null(1-4)=0, avgsize(1-4)=16, distinct(1-5)=0.0736403, null(1-5)=0, avgsize(1-5)=20]
  │         ├── key: (7)
  │         └── fd: ()-->(1-4), (7)-->(5)
  └── filters
@@ -1550,7 +1550,7 @@ AND f > 0
 ----
 select
  ├── columns: a:1(uuid) b:2(bool!null) c:3(int!null) d:4(string) e:5(int!null) f:6(float!null)
- ├── stats: [rows=0.3409783, distinct(2)=0.340978, null(2)=0, avgsize(2)=2, distinct(3)=0.340978, null(3)=0, avgsize(3)=3, distinct(5)=0.340978, null(5)=0, avgsize(5)=5, distinct(6)=0.340978, null(6)=0, avgsize(6)=6]
+ ├── stats: [rows=1.212283, distinct(2)=1, null(2)=0, avgsize(2)=2, distinct(3)=1, null(3)=0, avgsize(3)=3, distinct(5)=1.21228, null(5)=0, avgsize(5)=5, distinct(6)=1.21228, null(6)=0, avgsize(6)=6, distinct(2,3)=1, null(2,3)=0, avgsize(2,3)=5, distinct(5,6)=1.21228, null(5,6)=0, avgsize(5,6)=11, distinct(2,3,5,6)=1.21228, null(2,3,5,6)=0, avgsize(2,3,5,6)=16]
  ├── fd: ()-->(2,3)
  ├── index-join multi_col
  │    ├── columns: a:1(uuid) b:2(bool) c:3(int) d:4(string) e:5(int) f:6(float)
@@ -1581,7 +1581,7 @@ AND f > 0
 ----
 select
  ├── columns: a:1(uuid) b:2(bool!null) c:3(int!null) d:4(string) e:5(int!null) f:6(float!null)
- ├── stats: [rows=0.3409783, distinct(2)=0.340978, null(2)=0, avgsize(2)=2, distinct(3)=0.340978, null(3)=0, avgsize(3)=3, distinct(5)=0.340978, null(5)=0, avgsize(5)=5, distinct(6)=0.340978, null(6)=0, avgsize(6)=6]
+ ├── stats: [rows=1.212283, distinct(2)=1, null(2)=0, avgsize(2)=2, distinct(3)=1, null(3)=0, avgsize(3)=3, distinct(5)=1.21228, null(5)=0, avgsize(5)=5, distinct(6)=1.21228, null(6)=0, avgsize(6)=6, distinct(2,3)=1, null(2,3)=0, avgsize(2,3)=5, distinct(5,6)=1.21228, null(5,6)=0, avgsize(5,6)=11, distinct(2,3,5,6)=1.21228, null(2,3,5,6)=0, avgsize(2,3,5,6)=16]
  ├── fd: ()-->(2,3)
  ├── index-join multi_col
  │    ├── columns: a:1(uuid) b:2(bool) c:3(int) d:4(string) e:5(int) f:6(float)
@@ -1862,24 +1862,24 @@ AND f > 0
 ----
 select
  ├── columns: a:1(uuid!null) b:2(bool!null) c:3(int!null) d:4(string!null) e:5(int!null) f:6(float!null)
- ├── stats: [rows=0.0001372273, distinct(1)=0.000137227, null(1)=0, avgsize(1)=1, distinct(2)=0.000137227, null(2)=0, avgsize(2)=2, distinct(3)=0.000137227, null(3)=0, avgsize(3)=3, distinct(4)=0.000137227, null(4)=0, avgsize(4)=4, distinct(5)=0.000137227, null(5)=0, avgsize(5)=5, distinct(6)=0.000137227, null(6)=0, avgsize(6)=6]
- │   histogram(2)=  0 0.00013723
- │                <----- true --
- │   histogram(4)=  0 0.00013723
- │                <---- 'foo' --
+ ├── stats: [rows=0.06882615, distinct(1)=0.0688261, null(1)=0, avgsize(1)=1, distinct(2)=0.0688261, null(2)=0, avgsize(2)=2, distinct(3)=0.0688261, null(3)=0, avgsize(3)=3, distinct(4)=0.0688261, null(4)=0, avgsize(4)=4, distinct(5)=0.0688261, null(5)=0, avgsize(5)=5, distinct(6)=0.0688261, null(6)=0, avgsize(6)=6, distinct(5,6)=0.0688261, null(5,6)=0, avgsize(5,6)=11, distinct(1-4)=0.0688261, null(1-4)=0, avgsize(1-4)=16, distinct(1-6)=0.0688261, null(1-6)=0, avgsize(1-6)=21]
+ │   histogram(2)=  0 0.068826
+ │                <---- true -
+ │   histogram(4)=  0 0.068826
+ │                <--- 'foo' -
  ├── fd: ()-->(1-4)
  ├── index-join multi_col
  │    ├── columns: a:1(uuid) b:2(bool) c:3(int) d:4(string) e:5(int) f:6(float)
- │    ├── stats: [rows=0.0004137274]
+ │    ├── stats: [rows=0.07400349]
  │    ├── fd: ()-->(1-4)
  │    └── scan multi_col@abcde_idx
  │         ├── columns: a:1(uuid!null) b:2(bool!null) c:3(int!null) d:4(string!null) e:5(int!null) rowid:7(int!null)
  │         ├── constraint: /1/2/-3/4/5/7: [/'37685f26-4b07-40ba-9bbf-42916ed9bc61'/true/5/'foo'/11 - /'37685f26-4b07-40ba-9bbf-42916ed9bc61'/true/5/'foo'/20]
- │         ├── stats: [rows=0.0004137274, distinct(1)=0.000413727, null(1)=0, avgsize(1)=1, distinct(2)=0.000413727, null(2)=0, avgsize(2)=2, distinct(3)=0.000413727, null(3)=0, avgsize(3)=3, distinct(4)=0.000413727, null(4)=0, avgsize(4)=4, distinct(5)=0.000413727, null(5)=0, avgsize(5)=5]
- │         │   histogram(2)=  0 0.00041373
- │         │                <----- true --
- │         │   histogram(4)=  0 0.00041373
- │         │                <---- 'foo' --
+ │         ├── stats: [rows=0.07400349, distinct(1)=0.0740035, null(1)=0, avgsize(1)=1, distinct(2)=0.0740035, null(2)=0, avgsize(2)=2, distinct(3)=0.0740035, null(3)=0, avgsize(3)=3, distinct(4)=0.0740035, null(4)=0, avgsize(4)=4, distinct(5)=0.0740035, null(5)=0, avgsize(5)=5, distinct(1-4)=0.0740035, null(1-4)=0, avgsize(1-4)=16, distinct(1-5)=0.0740035, null(1-5)=0, avgsize(1-5)=20]
+ │         │   histogram(2)=  0 0.074003
+ │         │                <---- true -
+ │         │   histogram(4)=  0 0.074003
+ │         │                <--- 'foo' -
  │         ├── key: (7)
  │         └── fd: ()-->(1-4), (7)-->(5)
  └── filters
@@ -1895,9 +1895,9 @@ AND f > 0
 ----
 select
  ├── columns: a:1(uuid) b:2(bool!null) c:3(int!null) d:4(string) e:5(int!null) f:6(float!null)
- ├── stats: [rows=0.6818192, distinct(2)=0.681819, null(2)=0, avgsize(2)=2, distinct(3)=0.681819, null(3)=0, avgsize(3)=3, distinct(5)=0.681819, null(5)=0, avgsize(5)=5, distinct(6)=0.681819, null(6)=0, avgsize(6)=6]
- │   histogram(2)=  0 0.68182
- │                <--- true -
+ ├── stats: [rows=1.549845, distinct(2)=1, null(2)=0, avgsize(2)=2, distinct(3)=1, null(3)=0, avgsize(3)=3, distinct(5)=1.54985, null(5)=0, avgsize(5)=5, distinct(6)=1.54985, null(6)=0, avgsize(6)=6, distinct(2,3)=1, null(2,3)=0, avgsize(2,3)=5, distinct(5,6)=1.54985, null(5,6)=0, avgsize(5,6)=11, distinct(2,3,5,6)=1.54985, null(2,3,5,6)=0, avgsize(2,3,5,6)=16]
+ │   histogram(2)=  0 1.5498
+ │                <--- true
  ├── fd: ()-->(2,3)
  ├── index-join multi_col
  │    ├── columns: a:1(uuid) b:2(bool) c:3(int) d:4(string) e:5(int) f:6(float)
@@ -1928,13 +1928,13 @@ AND f > 0
 ----
 select
  ├── columns: a:1(uuid) b:2(bool!null) c:3(int!null) d:4(string) e:5(int!null) f:6(float!null)
- ├── stats: [rows=0.6818192, distinct(2)=0.681819, null(2)=0, avgsize(2)=2, distinct(3)=0.681819, null(3)=0, avgsize(3)=3, distinct(5)=0.681819, null(5)=0, avgsize(5)=5, distinct(6)=0.681819, null(6)=0, avgsize(6)=6]
- │   histogram(2)=  0 0.68182
- │                <--- true -
+ ├── stats: [rows=1.549845, distinct(2)=1, null(2)=0, avgsize(2)=2, distinct(3)=1, null(3)=0, avgsize(3)=3, distinct(5)=1.54985, null(5)=0, avgsize(5)=5, distinct(6)=1.54985, null(6)=0, avgsize(6)=6, distinct(2,3)=1, null(2,3)=0, avgsize(2,3)=5, distinct(5,6)=1.54985, null(5,6)=0, avgsize(5,6)=11, distinct(2,3,5,6)=1.54985, null(2,3,5,6)=0, avgsize(2,3,5,6)=16]
+ │   histogram(2)=  0 1.5498
+ │                <--- true
  ├── fd: ()-->(2,3)
  ├── index-join multi_col
  │    ├── columns: a:1(uuid) b:2(bool) c:3(int) d:4(string) e:5(int) f:6(float)
- │    ├── stats: [rows=1872.168]
+ │    ├── stats: [rows=102.3719]
  │    ├── fd: ()-->(2)
  │    └── scan multi_col@bef_idx
  │         ├── columns: b:2(bool!null) e:5(int!null) f:6(float!null) rowid:7(int!null)
@@ -1945,8 +1945,8 @@ select
  │         │    ├── [/true/7/5e-324 - /true/7]
  │         │    └── [/true/9/5e-324 - /true/9]
  │         ├── flags: force-index=bef_idx
- │         ├── stats: [rows=1872.168, distinct(2)=1, null(2)=0, avgsize(2)=2, distinct(5)=5, null(5)=0, avgsize(5)=5, distinct(6)=1666.67, null(6)=0, avgsize(6)=6, distinct(2,5,6)=1872.17, null(2,5,6)=0, avgsize(2,5,6)=12]
- │         │   histogram(2)=  0 1872.2
+ │         ├── stats: [rows=102.3719, distinct(2)=1, null(2)=0, avgsize(2)=2, distinct(5)=5, null(5)=0, avgsize(5)=5, distinct(6)=102.372, null(6)=0, avgsize(6)=6, distinct(2,5,6)=102.372, null(2,5,6)=0, avgsize(2,5,6)=12]
+ │         │   histogram(2)=  0 102.37
  │         │                <--- true
  │         ├── key: (7)
  │         └── fd: ()-->(2), (7)-->(5,6)
@@ -1966,22 +1966,22 @@ AND f = 0
 ----
 select
  ├── columns: a:1(uuid!null) b:2(bool!null) c:3(int) d:4(string!null) e:5(int!null) f:6(float!null)
- ├── stats: [rows=2e-06, distinct(1)=2e-06, null(1)=0, avgsize(1)=1, distinct(2)=2e-06, null(2)=0, avgsize(2)=2, distinct(4)=2e-06, null(4)=0, avgsize(4)=4, distinct(5)=2e-06, null(5)=0, avgsize(5)=5, distinct(6)=2e-06, null(6)=0, avgsize(6)=6]
- │   histogram(2)=  0 2e-06
+ ├── stats: [rows=0.9000001, distinct(1)=0.9, null(1)=0, avgsize(1)=1, distinct(2)=0.9, null(2)=0, avgsize(2)=2, distinct(4)=0.9, null(4)=0, avgsize(4)=4, distinct(5)=0.9, null(5)=0, avgsize(5)=5, distinct(6)=0.9, null(6)=0, avgsize(6)=6, distinct(1,2,4-6)=0.9, null(1,2,4-6)=0, avgsize(1,2,4-6)=18]
+ │   histogram(2)=  0  0.9
  │                <--- true
- │   histogram(4)=  0  2e-06
+ │   histogram(4)=  0   0.9
  │                <--- 'foo'
  ├── fd: ()-->(1,2,4-6)
  ├── index-join multi_col
  │    ├── columns: a:1(uuid) b:2(bool) c:3(int) d:4(string) e:5(int) f:6(float)
- │    ├── stats: [rows=2507.378]
+ │    ├── stats: [rows=0.9978031]
  │    ├── fd: ()-->(2,5,6)
  │    └── scan multi_col@bef_idx
  │         ├── columns: b:2(bool!null) e:5(int!null) f:6(float!null) rowid:7(int!null)
  │         ├── constraint: /2/5/6/7: [/true/5/0.0 - /true/5/0.0]
  │         ├── flags: force-index=bef_idx
- │         ├── stats: [rows=2507.378, distinct(2)=1, null(2)=0, avgsize(2)=2, distinct(5)=1, null(5)=0, avgsize(5)=5, distinct(6)=1, null(6)=0, avgsize(6)=6, distinct(2,5,6)=1, null(2,5,6)=0, avgsize(2,5,6)=12]
- │         │   histogram(2)=  0 2507.4
+ │         ├── stats: [rows=0.9978031, distinct(2)=0.997803, null(2)=0, avgsize(2)=2, distinct(5)=0.997803, null(5)=0, avgsize(5)=5, distinct(6)=0.997803, null(6)=0, avgsize(6)=6, distinct(2,5,6)=0.997803, null(2,5,6)=0, avgsize(2,5,6)=12]
+ │         │   histogram(2)=  0 0.9978
  │         │                <--- true
  │         ├── key: (7)
  │         └── fd: ()-->(2,5,6)
@@ -1997,34 +1997,40 @@ AND d = 'bar'
 AND e = 5
 AND f = 0
 ----
-inner-join (lookup multi_col)
+select
  ├── columns: a:1(uuid!null) b:2(bool!null) c:3(int) d:4(string!null) e:5(int!null) f:6(float!null)
- ├── key columns: [7] = [7]
- ├── lookup columns are key
- ├── stats: [rows=2e-06, distinct(1)=2e-06, null(1)=0, avgsize(1)=1, distinct(2)=2e-06, null(2)=0, avgsize(2)=2, distinct(4)=2e-06, null(4)=0, avgsize(4)=4, distinct(5)=2e-06, null(5)=0, avgsize(5)=5, distinct(6)=2e-06, null(6)=0, avgsize(6)=6]
- │   histogram(2)=  0 2e-06
+ ├── stats: [rows=0.9000001, distinct(1)=0.9, null(1)=0, avgsize(1)=1, distinct(2)=0.9, null(2)=0, avgsize(2)=2, distinct(4)=0.9, null(4)=0, avgsize(4)=4, distinct(5)=0.9, null(5)=0, avgsize(5)=5, distinct(6)=0.9, null(6)=0, avgsize(6)=6, distinct(1,2,4-6)=0.9, null(1,2,4-6)=0, avgsize(1,2,4-6)=18]
+ │   histogram(2)=  0  0.9
  │                <--- true
- │   histogram(4)=  0  2e-06
+ │   histogram(4)=  0   0.9
  │                <--- 'bar'
  ├── fd: ()-->(1,2,4-6)
- ├── inner-join (zigzag multi_col@bad_idx multi_col@bef_idx)
- │    ├── columns: a:1(uuid!null) b:2(bool!null) d:4(string!null) e:5(int!null) f:6(float!null) rowid:7(int!null)
- │    ├── eq columns: [7] = [7]
- │    ├── left fixed columns: [2 1 4] = [true '37685f26-4b07-40ba-9bbf-42916ed9bc61' 'bar']
- │    ├── right fixed columns: [2 5 6] = [true 5 0.0]
- │    ├── stats: [rows=1e-06, distinct(1)=1e-06, null(1)=0, avgsize(1)=1, distinct(2)=1e-06, null(2)=0, avgsize(2)=2, distinct(4)=1e-06, null(4)=0, avgsize(4)=4, distinct(5)=1e-06, null(5)=0, avgsize(5)=5, distinct(6)=1e-06, null(6)=0, avgsize(6)=6]
- │    │   histogram(2)=  0 1e-06
- │    │                <--- true
- │    │   histogram(4)=  0  1e-06
- │    │                <--- 'bar'
- │    ├── fd: ()-->(1,2,4-6)
- │    └── filters
- │         ├── a:1 = '37685f26-4b07-40ba-9bbf-42916ed9bc61' [type=bool, outer=(1), constraints=(/1: [/'37685f26-4b07-40ba-9bbf-42916ed9bc61' - /'37685f26-4b07-40ba-9bbf-42916ed9bc61']; tight), fd=()-->(1)]
- │         ├── b:2 [type=bool, outer=(2), constraints=(/2: [/true - /true]; tight), fd=()-->(2)]
- │         ├── d:4 = 'bar' [type=bool, outer=(4), constraints=(/4: [/'bar' - /'bar']; tight), fd=()-->(4)]
- │         ├── e:5 = 5 [type=bool, outer=(5), constraints=(/5: [/5 - /5]; tight), fd=()-->(5)]
- │         └── f:6 = 0.0 [type=bool, outer=(6), constraints=(/6: [/0.0 - /0.0]; tight), fd=()-->(6)]
- └── filters (true)
+ ├── index-join multi_col
+ │    ├── columns: a:1(uuid) b:2(bool) c:3(int) d:4(string) e:5(int) f:6(float)
+ │    ├── stats: [rows=9.404901e-05]
+ │    ├── fd: ()-->(1,2,4,5)
+ │    └── select
+ │         ├── columns: a:1(uuid!null) b:2(bool!null) c:3(int) d:4(string!null) e:5(int!null) rowid:7(int!null)
+ │         ├── stats: [rows=9.404901e-05, distinct(4)=9.4049e-05, null(4)=0, avgsize(4)=4, distinct(5)=9.4049e-05, null(5)=0, avgsize(5)=5, distinct(4,5)=9.4049e-05, null(4,5)=0, avgsize(4,5)=8]
+ │         │   histogram(4)=  0 9.4049e-05
+ │         │                <---- 'bar' --
+ │         ├── key: (7)
+ │         ├── fd: ()-->(1,2,4,5), (7)-->(3)
+ │         ├── scan multi_col@abcde_idx
+ │         │    ├── columns: a:1(uuid!null) b:2(bool!null) c:3(int) d:4(string) e:5(int) rowid:7(int!null)
+ │         │    ├── constraint: /1/2/-3/4/5/7: [/'37685f26-4b07-40ba-9bbf-42916ed9bc61'/true - /'37685f26-4b07-40ba-9bbf-42916ed9bc61'/true]
+ │         │    ├── stats: [rows=0.94999, distinct(1)=0.94999, null(1)=0, avgsize(1)=1, distinct(2)=0.94999, null(2)=0, avgsize(2)=2, distinct(4)=0.906303, null(4)=0, avgsize(4)=4, distinct(5)=0.945537, null(5)=0.094999, avgsize(5)=5, distinct(7)=0.94999, null(7)=0, avgsize(7)=4, distinct(1,2)=0.94999, null(1,2)=0, avgsize(1,2)=8, distinct(4,5)=0.947782, null(4,5)=0, avgsize(4,5)=8]
+ │         │    │   histogram(2)=  0 0.94999
+ │         │    │                <--- true -
+ │         │    │   histogram(4)=  0 9.4999e-05 0.00019 9.4999e-05 9.4999e-05 9.4999e-05 0.00019 0.94904 9.4999e-05 9.4999e-05
+ │         │    │                <---- 'bar' ------------ 'baz' --------------- 'boo' ----------- 'foo' ------------ 'foobar'
+ │         │    ├── key: (7)
+ │         │    └── fd: ()-->(1,2), (7)-->(3-5)
+ │         └── filters
+ │              ├── d:4 = 'bar' [type=bool, outer=(4), constraints=(/4: [/'bar' - /'bar']; tight), fd=()-->(4)]
+ │              └── e:5 = 5 [type=bool, outer=(5), constraints=(/5: [/5 - /5]; tight), fd=()-->(5)]
+ └── filters
+      └── f:6 = 0.0 [type=bool, outer=(6), constraints=(/6: [/0.0 - /0.0]; tight), fd=()-->(6)]
 
 opt
 SELECT * FROM multi_col
@@ -2034,34 +2040,40 @@ AND d = 'bar'
 AND e = 5
 AND f = 0
 ----
-inner-join (lookup multi_col)
+select
  ├── columns: a:1(uuid!null) b:2(bool!null) c:3(int) d:4(string!null) e:5(int!null) f:6(float!null)
- ├── key columns: [7] = [7]
- ├── lookup columns are key
- ├── stats: [rows=2e-06, distinct(1)=2e-06, null(1)=0, avgsize(1)=1, distinct(2)=2e-06, null(2)=0, avgsize(2)=2, distinct(4)=2e-06, null(4)=0, avgsize(4)=4, distinct(5)=2e-06, null(5)=0, avgsize(5)=5, distinct(6)=2e-06, null(6)=0, avgsize(6)=6]
- │   histogram(2)=  0  2e-06
+ ├── stats: [rows=0.9000001, distinct(1)=0.9, null(1)=0, avgsize(1)=1, distinct(2)=0.9, null(2)=0, avgsize(2)=2, distinct(4)=0.9, null(4)=0, avgsize(4)=4, distinct(5)=0.9, null(5)=0, avgsize(5)=5, distinct(6)=0.9, null(6)=0, avgsize(6)=6, distinct(1,2,4-6)=0.9, null(1,2,4-6)=0, avgsize(1,2,4-6)=18]
+ │   histogram(2)=  0   0.9
  │                <--- false
- │   histogram(4)=  0  2e-06
+ │   histogram(4)=  0   0.9
  │                <--- 'bar'
  ├── fd: ()-->(1,2,4-6)
- ├── inner-join (zigzag multi_col@bad_idx multi_col@bef_idx)
- │    ├── columns: a:1(uuid!null) b:2(bool!null) d:4(string!null) e:5(int!null) f:6(float!null) rowid:7(int!null)
- │    ├── eq columns: [7] = [7]
- │    ├── left fixed columns: [2 1 4] = [false '37685f26-4b07-40ba-9bbf-42916ed9bc61' 'bar']
- │    ├── right fixed columns: [2 5 6] = [false 5 0.0]
- │    ├── stats: [rows=1e-06, distinct(1)=1e-06, null(1)=0, avgsize(1)=1, distinct(2)=1e-06, null(2)=0, avgsize(2)=2, distinct(4)=1e-06, null(4)=0, avgsize(4)=4, distinct(5)=1e-06, null(5)=0, avgsize(5)=5, distinct(6)=1e-06, null(6)=0, avgsize(6)=6]
- │    │   histogram(2)=  0  1e-06
- │    │                <--- false
- │    │   histogram(4)=  0  1e-06
- │    │                <--- 'bar'
- │    ├── fd: ()-->(1,2,4-6)
- │    └── filters
- │         ├── a:1 = '37685f26-4b07-40ba-9bbf-42916ed9bc61' [type=bool, outer=(1), constraints=(/1: [/'37685f26-4b07-40ba-9bbf-42916ed9bc61' - /'37685f26-4b07-40ba-9bbf-42916ed9bc61']; tight), fd=()-->(1)]
- │         ├── NOT b:2 [type=bool, outer=(2), constraints=(/2: [/false - /false]; tight), fd=()-->(2)]
- │         ├── d:4 = 'bar' [type=bool, outer=(4), constraints=(/4: [/'bar' - /'bar']; tight), fd=()-->(4)]
- │         ├── e:5 = 5 [type=bool, outer=(5), constraints=(/5: [/5 - /5]; tight), fd=()-->(5)]
- │         └── f:6 = 0.0 [type=bool, outer=(6), constraints=(/6: [/0.0 - /0.0]; tight), fd=()-->(6)]
- └── filters (true)
+ ├── index-join multi_col
+ │    ├── columns: a:1(uuid) b:2(bool) c:3(int) d:4(string) e:5(int) f:6(float)
+ │    ├── stats: [rows=8.910099e-05]
+ │    ├── fd: ()-->(1,2,4,5)
+ │    └── select
+ │         ├── columns: a:1(uuid!null) b:2(bool!null) c:3(int) d:4(string!null) e:5(int!null) rowid:7(int!null)
+ │         ├── stats: [rows=8.910099e-05, distinct(4)=8.9101e-05, null(4)=0, avgsize(4)=4, distinct(5)=8.9101e-05, null(5)=0, avgsize(5)=5, distinct(4,5)=8.9101e-05, null(4,5)=0, avgsize(4,5)=8]
+ │         │   histogram(4)=  0 8.9101e-05
+ │         │                <---- 'bar' --
+ │         ├── key: (7)
+ │         ├── fd: ()-->(1,2,4,5), (7)-->(3)
+ │         ├── scan multi_col@abcde_idx
+ │         │    ├── columns: a:1(uuid!null) b:2(bool!null) c:3(int) d:4(string) e:5(int) rowid:7(int!null)
+ │         │    ├── constraint: /1/2/-3/4/5/7: [/'37685f26-4b07-40ba-9bbf-42916ed9bc61'/false - /'37685f26-4b07-40ba-9bbf-42916ed9bc61'/false]
+ │         │    ├── stats: [rows=0.90001, distinct(1)=0.90001, null(1)=0, avgsize(1)=1, distinct(2)=0.90001, null(2)=0, avgsize(2)=2, distinct(4)=0.860734, null(4)=0, avgsize(4)=4, distinct(5)=0.896012, null(5)=0.090001, avgsize(5)=5, distinct(7)=0.90001, null(7)=0, avgsize(7)=4, distinct(1,2)=0.90001, null(1,2)=0, avgsize(1,2)=8, distinct(4,5)=0.898028, null(4,5)=0, avgsize(4,5)=8]
+ │         │    │   histogram(2)=  0 0.90001
+ │         │    │                <--- false
+ │         │    │   histogram(4)=  0 9.0001e-05 0.00018 9.0001e-05 9.0001e-05 9.0001e-05 0.00018 0.89911 9.0001e-05 9.0001e-05
+ │         │    │                <---- 'bar' ------------ 'baz' --------------- 'boo' ----------- 'foo' ------------ 'foobar'
+ │         │    ├── key: (7)
+ │         │    └── fd: ()-->(1,2), (7)-->(3-5)
+ │         └── filters
+ │              ├── d:4 = 'bar' [type=bool, outer=(4), constraints=(/4: [/'bar' - /'bar']; tight), fd=()-->(4)]
+ │              └── e:5 = 5 [type=bool, outer=(5), constraints=(/5: [/5 - /5]; tight), fd=()-->(5)]
+ └── filters
+      └── f:6 = 0.0 [type=bool, outer=(6), constraints=(/6: [/0.0 - /0.0]; tight), fd=()-->(6)]
 
 opt
 SELECT * FROM multi_col
@@ -2075,10 +2087,10 @@ inner-join (lookup multi_col)
  ├── columns: a:1(uuid!null) b:2(bool!null) c:3(int) d:4(string!null) e:5(int!null) f:6(float!null)
  ├── key columns: [7] = [7]
  ├── lookup columns are key
- ├── stats: [rows=2e-06, distinct(1)=2e-06, null(1)=0, avgsize(1)=1, distinct(2)=2e-06, null(2)=0, avgsize(2)=2, distinct(4)=2e-06, null(4)=0, avgsize(4)=4, distinct(5)=2e-06, null(5)=0, avgsize(5)=5, distinct(6)=2e-06, null(6)=0, avgsize(6)=6]
- │   histogram(2)=  0  2e-06
+ ├── stats: [rows=0.9000001, distinct(1)=0.9, null(1)=0, avgsize(1)=1, distinct(2)=0.9, null(2)=0, avgsize(2)=2, distinct(4)=0.9, null(4)=0, avgsize(4)=4, distinct(5)=0.9, null(5)=0, avgsize(5)=5, distinct(6)=0.9, null(6)=0, avgsize(6)=6, distinct(1,2,4-6)=0.9, null(1,2,4-6)=0, avgsize(1,2,4-6)=18]
+ │   histogram(2)=  0   0.9
  │                <--- false
- │   histogram(4)=  0  2e-06
+ │   histogram(4)=  0   0.9
  │                <--- 'foo'
  ├── fd: ()-->(1,2,4-6)
  ├── inner-join (zigzag multi_col@bad_idx multi_col@bef_idx)
@@ -2086,10 +2098,10 @@ inner-join (lookup multi_col)
  │    ├── eq columns: [7] = [7]
  │    ├── left fixed columns: [2 1 4] = [false '37685f26-4b07-40ba-9bbf-42916ed9bc61' 'foo']
  │    ├── right fixed columns: [2 5 6] = [false 5 0.0]
- │    ├── stats: [rows=1e-06, distinct(1)=1e-06, null(1)=0, avgsize(1)=1, distinct(2)=1e-06, null(2)=0, avgsize(2)=2, distinct(4)=1e-06, null(4)=0, avgsize(4)=4, distinct(5)=1e-06, null(5)=0, avgsize(5)=5, distinct(6)=1e-06, null(6)=0, avgsize(6)=6]
- │    │   histogram(2)=  0  1e-06
+ │    ├── stats: [rows=0.9000001, distinct(1)=0.9, null(1)=0, avgsize(1)=1, distinct(2)=0.9, null(2)=0, avgsize(2)=2, distinct(4)=0.9, null(4)=0, avgsize(4)=4, distinct(5)=0.9, null(5)=0, avgsize(5)=5, distinct(6)=0.9, null(6)=0, avgsize(6)=6, distinct(1,2,4-6)=0.9, null(1,2,4-6)=0, avgsize(1,2,4-6)=18]
+ │    │   histogram(2)=  0   0.9
  │    │                <--- false
- │    │   histogram(4)=  0  1e-06
+ │    │   histogram(4)=  0   0.9
  │    │                <--- 'foo'
  │    ├── fd: ()-->(1,2,4-6)
  │    └── filters
@@ -2146,7 +2158,7 @@ index-join t
       ├── constraint: /2/1
       │    ├── [/NULL/5 - /NULL/5]
       │    └── [/5 - /5]
-      ├── stats: [rows=1.502004, distinct(1)=1.502, null(1)=0, avgsize(1)=4, distinct(2)=1.502, null(2)=1.502, avgsize(2)=4]
+      ├── stats: [rows=1.952004, distinct(1)=1.952, null(1)=0, avgsize(1)=4, distinct(2)=1.952, null(2)=1.952, avgsize(2)=4]
       ├── key: (1)
       └── fd: (1)-->(2)
 
@@ -2286,8 +2298,8 @@ SELECT * FROM t76485 WHERE a = 20 AND b = 30 AND c < 'foo';
 scan t76485@t76485_a_b_c_idx
  ├── columns: a:1(int!null) b:2(int!null) c:3(string!null)
  ├── constraint: /1/2/3/4: (/20/30/NULL - /20/30/'foo')
- ├── stats: [rows=3.270595, distinct(1)=1, null(1)=0, avgsize(1)=4, distinct(2)=1, null(2)=0, avgsize(2)=4, distinct(3)=3.2706, null(3)=0, avgsize(3)=4]
- │   histogram(1)=  0 3.2706
+ ├── stats: [rows=3.272265, distinct(1)=1, null(1)=0, avgsize(1)=4, distinct(2)=1, null(2)=0, avgsize(2)=4, distinct(3)=3.27226, null(3)=0, avgsize(3)=4, distinct(1,2)=1, null(1,2)=0, avgsize(1,2)=8, distinct(1-3)=3.27226, null(1-3)=0, avgsize(1-3)=12]
+ │   histogram(1)=  0 3.2723
  │                <---- 20 -
  └── fd: ()-->(1,2)
 
@@ -3035,7 +3047,7 @@ top-k
  ├── k: 1000
  ├── cardinality: [0 - 1000]
  ├── immutable
- ├── stats: [rows=0.07759788]
+ ├── stats: [rows=0.1202227]
  ├── key: (6,7)
  ├── fd: ()-->(2,3,5), (6,7)-->(1,4)
  ├── ordering: -1 opt(2,3,5) [actual: -1]
@@ -3059,16 +3071,16 @@ top-k
       │    ├── [/8/4/10/1/NULL/'2022-02-04 19:25:25.356+00:00' - /8/4/10/1/NULL/'2022-02-11 19:25:25.356+00:00']
       │    └── [/8/6/10/1/NULL/'2022-02-04 19:25:25.356+00:00' - /8/6/10/1/NULL/'2022-02-11 19:25:25.356+00:00']
       ├── immutable
-      ├── stats: [rows=0.07759788, distinct(1)=0.0775979, null(1)=0, avgsize(1)=4, distinct(2)=0.0775979, null(2)=0.0775979, avgsize(2)=4, distinct(3)=0.0775979, null(3)=0, avgsize(3)=4, distinct(4)=0.0775979, null(4)=0, avgsize(4)=4, distinct(5)=0.0775979, null(5)=0, avgsize(5)=4, distinct(6)=0.0775979, null(6)=0, avgsize(6)=4]
-      │   histogram(1)=  0                  0                   0.077598             1.283e-16
-      │                <--- '2022-02-04 19:25:25.355999+00:00' ---------- '2022-02-11 19:25:25.356+00:00'
-      │   histogram(3)=  0 0.077598
-      │                <----- 10 --
-      │   histogram(4)=  0 0.0016251 0 0.075973
-      │                <------ 4 -------- 6 ---
-      │   histogram(5)=  0 0.077598
-      │                <----- 1 ---
-      │   histogram(6)=  0 0.077581 0 1.6463e-05
-      │                <----- 3 --------- 5 ----
+      ├── stats: [rows=0.1202227, distinct(1)=0.120223, null(1)=0, avgsize(1)=4, distinct(2)=0.120223, null(2)=0.120223, avgsize(2)=4, distinct(3)=0.120223, null(3)=0, avgsize(3)=4, distinct(4)=0.120223, null(4)=0, avgsize(4)=4, distinct(5)=0.120223, null(5)=0, avgsize(5)=4, distinct(6)=0.120223, null(6)=0, avgsize(6)=4, distinct(1,4)=0.120223, null(1,4)=0, avgsize(1,4)=8, distinct(2,3,5)=0.120223, null(2,3,5)=0, avgsize(2,3,5)=12, distinct(1-5)=0.120223, null(1-5)=0, avgsize(1-5)=20]
+      │   histogram(1)=  0                  0                   0.12022            1.9878e-16
+      │                <--- '2022-02-04 19:25:25.355999+00:00' --------- '2022-02-11 19:25:25.356+00:00'
+      │   histogram(3)=  0 0.12022
+      │                <---- 10 --
+      │   histogram(4)=  0 0.0025178 0 0.1177
+      │                <------ 4 ------- 6 --
+      │   histogram(5)=  0 0.12022
+      │                <----- 1 --
+      │   histogram(6)=  0 0.1202 0 2.5506e-05
+      │                <---- 3 -------- 5 ----
       ├── key: (6,7)
       └── fd: ()-->(2,3,5), (6,7)-->(1,4)

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -72,17 +72,17 @@ SELECT * FROM b WHERE x = 1 AND z = 2 AND rowid >= 5 AND rowid <= 8
 project
  ├── columns: x:1(int!null) z:2(int!null)
  ├── cardinality: [0 - 4]
- ├── stats: [rows=9e-06]
+ ├── stats: [rows=0.00032552]
  ├── fd: ()-->(1,2)
  └── select
       ├── columns: x:1(int!null) z:2(int!null) rowid:3(int!null)
       ├── cardinality: [0 - 4]
-      ├── stats: [rows=9e-06, distinct(1)=9e-06, null(1)=0, avgsize(1)=4, distinct(2)=9e-06, null(2)=0, avgsize(2)=4, distinct(3)=9e-06, null(3)=0, avgsize(3)=4]
+      ├── stats: [rows=0.00032552, distinct(1)=0.00032552, null(1)=0, avgsize(1)=4, distinct(2)=0.00032552, null(2)=0, avgsize(2)=4, distinct(3)=0.00032552, null(3)=0, avgsize(3)=4, distinct(1,2)=0.00032552, null(1,2)=0, avgsize(1,2)=8, distinct(1-3)=0.00032552, null(1-3)=0, avgsize(1-3)=12]
       ├── key: (3)
       ├── fd: ()-->(1,2)
       ├── scan b
       │    ├── columns: x:1(int) z:2(int!null) rowid:3(int!null)
-      │    ├── stats: [rows=10000, distinct(1)=5000, null(1)=0, avgsize(1)=4, distinct(2)=100, null(2)=0, avgsize(2)=4, distinct(3)=10000, null(3)=0, avgsize(3)=4, distinct(1-3)=10000, null(1-3)=0, avgsize(1-3)=12]
+      │    ├── stats: [rows=10000, distinct(1)=5000, null(1)=0, avgsize(1)=4, distinct(2)=100, null(2)=0, avgsize(2)=4, distinct(3)=10000, null(3)=0, avgsize(3)=4, distinct(1,2)=10000, null(1,2)=0, avgsize(1,2)=8, distinct(1-3)=10000, null(1-3)=0, avgsize(1-3)=12]
       │    ├── key: (3)
       │    └── fd: (3)-->(1,2)
       └── filters
@@ -114,7 +114,7 @@ SELECT * FROM a WHERE y = 5 AND x + y < 10
 ----
 select
  ├── columns: x:1(int!null) y:2(int!null)
- ├── stats: [rows=3.333334, distinct(1)=3.33333, null(1)=0, avgsize(1)=4, distinct(2)=1, null(2)=0, avgsize(2)=4]
+ ├── stats: [rows=9.333333, distinct(1)=9.33333, null(1)=0, avgsize(1)=4, distinct(2)=1, null(2)=0, avgsize(2)=4, distinct(1,2)=9.33333, null(1,2)=0, avgsize(1,2)=8]
  ├── key: (1)
  ├── fd: ()-->(2)
  ├── scan a
@@ -179,10 +179,10 @@ SELECT y FROM idx WHERE y < 5 AND z < 10
 ----
 project
  ├── columns: y:2(int!null)
- ├── stats: [rows=111.1111]
+ ├── stats: [rows=311.1111]
  └── select
       ├── columns: y:2(int!null) z:3(int!null)
-      ├── stats: [rows=111.1111, distinct(2)=33.3333, null(2)=0, avgsize(2)=4, distinct(3)=33.3333, null(3)=0, avgsize(3)=4]
+      ├── stats: [rows=311.1111, distinct(2)=33.3333, null(2)=0, avgsize(2)=4, distinct(3)=33.3333, null(3)=0, avgsize(3)=4, distinct(2,3)=311.111, null(2,3)=0, avgsize(2,3)=8]
       ├── scan idx@yz
       │    ├── columns: y:2(int!null) z:3(int)
       │    ├── constraint: /-2/3/1: (/4/NULL - /NULL)
@@ -300,7 +300,7 @@ SELECT * FROM district WHERE d_id = 1 AND d_name='bobs_burgers'
 ----
 select
  ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string!null)
- ├── stats: [rows=0.1, distinct(1)=0.1, null(1)=0, avgsize(1)=4, distinct(3)=0.1, null(3)=0, avgsize(3)=4]
+ ├── stats: [rows=0.91, distinct(1)=0.91, null(1)=0, avgsize(1)=4, distinct(3)=0.91, null(3)=0, avgsize(3)=4, distinct(1,3)=0.91, null(1,3)=0, avgsize(1,3)=8]
  ├── key: (2)
  ├── fd: ()-->(1,3)
  ├── scan district
@@ -317,7 +317,7 @@ SELECT * FROM district WHERE d_id = 1 and d_name LIKE 'bob'
 ----
 select
  ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string!null)
- ├── stats: [rows=0.1, distinct(1)=0.1, null(1)=0, avgsize(1)=4, distinct(3)=0.1, null(3)=0, avgsize(3)=4]
+ ├── stats: [rows=0.91, distinct(1)=0.91, null(1)=0, avgsize(1)=4, distinct(3)=0.91, null(3)=0, avgsize(3)=4, distinct(1,3)=0.91, null(1,3)=0, avgsize(1,3)=8]
  ├── key: (2)
  ├── fd: ()-->(1,3)
  ├── scan district
@@ -340,12 +340,12 @@ SELECT * FROM district WHERE d_id > 1 AND d_id < 10 AND d_w_id=10 AND d_name='bo
 select
  ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string!null)
  ├── cardinality: [0 - 8]
- ├── stats: [rows=0.08000001, distinct(1)=0.08, null(1)=0, avgsize(1)=4, distinct(2)=0.08, null(2)=0, avgsize(2)=4, distinct(3)=0.08, null(3)=0, avgsize(3)=4]
+ ├── stats: [rows=0.6632, distinct(1)=0.6632, null(1)=0, avgsize(1)=4, distinct(2)=0.6632, null(2)=0, avgsize(2)=4, distinct(3)=0.6632, null(3)=0, avgsize(3)=4, distinct(2,3)=0.6632, null(2,3)=0, avgsize(2,3)=8, distinct(1-3)=0.6632, null(1-3)=0, avgsize(1-3)=12]
  ├── key: (1)
  ├── fd: ()-->(2,3)
  ├── scan district
  │    ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string)
- │    ├── stats: [rows=100, distinct(1)=10, null(1)=0, avgsize(1)=4, distinct(2)=10, null(2)=0, avgsize(2)=4, distinct(3)=100, null(3)=0, avgsize(3)=4, distinct(1-3)=100, null(1-3)=0, avgsize(1-3)=12]
+ │    ├── stats: [rows=100, distinct(1)=10, null(1)=0, avgsize(1)=4, distinct(2)=10, null(2)=0, avgsize(2)=4, distinct(3)=100, null(3)=0, avgsize(3)=4, distinct(2,3)=100, null(2,3)=0, avgsize(2,3)=8, distinct(1-3)=100, null(1-3)=0, avgsize(1-3)=12]
  │    ├── key: (1,2)
  │    └── fd: (1,2)-->(3)
  └── filters
@@ -361,7 +361,7 @@ SELECT * FROM district WHERE d_id = 1 AND d_w_id=10 AND d_name='hello'
 select
  ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string!null)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=1, distinct(1)=1, null(1)=0, avgsize(1)=4, distinct(2)=1, null(2)=0, avgsize(2)=4, distinct(3)=1, null(3)=0, avgsize(3)=4]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0, avgsize(1)=4, distinct(2)=1, null(2)=0, avgsize(2)=4, distinct(3)=1, null(3)=0, avgsize(3)=4, distinct(1,2)=1, null(1,2)=0, avgsize(1,2)=8]
  ├── key: ()
  ├── fd: ()-->(1-3)
  ├── scan district
@@ -493,7 +493,7 @@ SELECT * FROM order_history WHERE item_id = order_id AND item_id = customer_id A
 ----
 select
  ├── columns: order_id:1(int!null) item_id:2(int!null) customer_id:3(int!null) year:4(int)
- ├── stats: [rows=0.0010001, distinct(1)=0.0010001, null(1)=0, avgsize(1)=4, distinct(2)=0.0010001, null(2)=0, avgsize(2)=4, distinct(3)=0.0010001, null(3)=0, avgsize(3)=4]
+ ├── stats: [rows=0.901, distinct(1)=0.901, null(1)=0, avgsize(1)=4, distinct(2)=0.901, null(2)=0, avgsize(2)=4, distinct(3)=0.901, null(3)=0, avgsize(3)=4, distinct(1-3)=0.901, null(1-3)=0, avgsize(1-3)=12]
  ├── fd: ()-->(1-3)
  ├── scan order_history
  │    ├── columns: order_id:1(int) item_id:2(int) customer_id:3(int) year:4(int)
@@ -583,7 +583,7 @@ SELECT * FROM uvw WHERE u=v AND u=10
 ----
 select
  ├── columns: u:1(int!null) v:2(int!null) w:3(int)
- ├── stats: [rows=0.1000001, distinct(1)=0.1, null(1)=0, avgsize(1)=4, distinct(2)=0.1, null(2)=0, avgsize(2)=4]
+ ├── stats: [rows=0.9108108, distinct(1)=0.910811, null(1)=0, avgsize(1)=4, distinct(2)=0.910811, null(2)=0, avgsize(2)=4, distinct(1,2)=0.910811, null(1,2)=0, avgsize(1,2)=8]
  ├── fd: ()-->(1,2)
  ├── scan uvw
  │    ├── columns: u:1(int) v:2(int) w:3(int)
@@ -726,7 +726,7 @@ inner-join (zigzag lineitem@l_sd lineitem@l_cd)
  ├── eq columns: [1 4] = [1 4]
  ├── left fixed columns: [11] = ['1995-09-01']
  ├── right fixed columns: [12] = ['1995-08-01']
- ├── stats: [rows=0.1000001, distinct(11)=0.1, null(11)=0, avgsize(11)=4, distinct(12)=0.1, null(12)=0, avgsize(12)=4, distinct(11,12)=0.1, null(11,12)=0, avgsize(11,12)=8]
+ ├── stats: [rows=0.91, distinct(11)=0.91, null(11)=0, avgsize(11)=4, distinct(12)=0.91, null(12)=0, avgsize(12)=4, distinct(11,12)=0.91, null(11,12)=0, avgsize(11,12)=8]
  ├── key: (1,4)
  ├── fd: ()-->(11,12)
  └── filters
@@ -742,7 +742,7 @@ WHERE
 ----
 select
  ├── columns: l_shipdate:11(date!null) l_commitdate:12(date!null) l_orderkey:1(int!null) l_linenumber:4(int!null)
- ├── stats: [rows=0.1000001, distinct(11)=0.1, null(11)=0, avgsize(11)=4, distinct(12)=0.1, null(12)=0, avgsize(12)=4, distinct(11,12)=0.1, null(11,12)=0, avgsize(11,12)=8]
+ ├── stats: [rows=0.91, distinct(11)=0.91, null(11)=0, avgsize(11)=4, distinct(12)=0.91, null(12)=0, avgsize(12)=4, distinct(11,12)=0.91, null(11,12)=0, avgsize(11,12)=8]
  ├── key: (1,4)
  ├── fd: ()-->(11,12)
  ├── scan lineitem
@@ -771,7 +771,7 @@ inner-join (lookup lineitem)
  ├── columns: l_shipdate:11(date!null) l_commitdate:12(date!null) l_orderkey:1(int!null) l_linenumber:4(int!null) l_quantity:5(float!null)
  ├── key columns: [1 4] = [1 4]
  ├── lookup columns are key
- ├── stats: [rows=0.1000001, distinct(11)=0.1, null(11)=0, avgsize(11)=4, distinct(12)=0.1, null(12)=0, avgsize(12)=4, distinct(11,12)=0.1, null(11,12)=0, avgsize(11,12)=8]
+ ├── stats: [rows=0.91, distinct(11)=0.91, null(11)=0, avgsize(11)=4, distinct(12)=0.91, null(12)=0, avgsize(12)=4, distinct(11,12)=0.91, null(11,12)=0, avgsize(11,12)=8]
  ├── key: (1,4)
  ├── fd: ()-->(11,12), (1,4)-->(5)
  ├── inner-join (zigzag lineitem@l_sd lineitem@l_cd)
@@ -779,7 +779,7 @@ inner-join (lookup lineitem)
  │    ├── eq columns: [1 4] = [1 4]
  │    ├── left fixed columns: [11] = ['1995-09-01']
  │    ├── right fixed columns: [12] = ['1995-08-01']
- │    ├── stats: [rows=0.1, distinct(11)=0.1, null(11)=0, avgsize(11)=4, distinct(12)=0.1, null(12)=0, avgsize(12)=4]
+ │    ├── stats: [rows=0.91, distinct(11)=0.91, null(11)=0, avgsize(11)=4, distinct(12)=0.91, null(12)=0, avgsize(12)=4, distinct(11,12)=0.91, null(11,12)=0, avgsize(11,12)=8]
  │    ├── fd: ()-->(11,12)
  │    └── filters
  │         ├── l_shipdate:11 = '1995-09-01' [type=bool, outer=(11), constraints=(/11: [/'1995-09-01' - /'1995-09-01']; tight), fd=()-->(11)]
@@ -795,7 +795,7 @@ WHERE
 ----
 select
  ├── columns: l_shipdate:11(date!null) l_commitdate:12(date!null) l_orderkey:1(int!null) l_linenumber:4(int!null) l_quantity:5(float!null)
- ├── stats: [rows=0.1000001, distinct(11)=0.1, null(11)=0, avgsize(11)=4, distinct(12)=0.1, null(12)=0, avgsize(12)=4, distinct(11,12)=0.1, null(11,12)=0, avgsize(11,12)=8]
+ ├── stats: [rows=0.91, distinct(11)=0.91, null(11)=0, avgsize(11)=4, distinct(12)=0.91, null(12)=0, avgsize(12)=4, distinct(11,12)=0.91, null(11,12)=0, avgsize(11,12)=8]
  ├── key: (1,4)
  ├── fd: ()-->(11,12), (1,4)-->(5)
  ├── scan lineitem
@@ -1032,17 +1032,17 @@ SELECT * FROM b WHERE x = 1 AND z = 2 AND rowid >= 5 AND rowid <= 8
 project
  ├── columns: x:1(int!null) z:2(int!null)
  ├── cardinality: [0 - 4]
- ├── stats: [rows=7.401281e-06]
+ ├── stats: [rows=0.0003252162]
  ├── fd: ()-->(1,2)
  └── select
       ├── columns: x:1(int!null) z:2(int!null) rowid:3(int!null)
       ├── cardinality: [0 - 4]
-      ├── stats: [rows=7.401281e-06, distinct(1)=7.40128e-06, null(1)=0, avgsize(1)=4, distinct(2)=7.40128e-06, null(2)=0, avgsize(2)=4, distinct(3)=7.40128e-06, null(3)=0, avgsize(3)=4]
+      ├── stats: [rows=0.0003252162, distinct(1)=0.000325216, null(1)=0, avgsize(1)=4, distinct(2)=0.000325216, null(2)=0, avgsize(2)=4, distinct(3)=0.000325216, null(3)=0, avgsize(3)=4, distinct(1,2)=0.000325216, null(1,2)=0, avgsize(1,2)=8, distinct(1-3)=0.000325216, null(1-3)=0, avgsize(1-3)=12]
       ├── key: (3)
       ├── fd: ()-->(1,2)
       ├── scan b
       │    ├── columns: x:1(int) z:2(int!null) rowid:3(int!null)
-      │    ├── stats: [rows=10000, distinct(1)=5000, null(1)=2000, avgsize(1)=4, distinct(2)=100, null(2)=0, avgsize(2)=4, distinct(3)=10000, null(3)=0, avgsize(3)=4, distinct(1-3)=10000, null(1-3)=0, avgsize(1-3)=12]
+      │    ├── stats: [rows=10000, distinct(1)=5000, null(1)=2000, avgsize(1)=4, distinct(2)=100, null(2)=0, avgsize(2)=4, distinct(3)=10000, null(3)=0, avgsize(3)=4, distinct(1,2)=10000, null(1,2)=0, avgsize(1,2)=8, distinct(1-3)=10000, null(1-3)=0, avgsize(1-3)=12]
       │    ├── key: (3)
       │    └── fd: (3)-->(1,2)
       └── filters
@@ -1074,7 +1074,7 @@ SELECT * FROM a WHERE y = 5 AND x + y < 10
 ----
 select
  ├── columns: x:1(int!null) y:2(int!null)
- ├── stats: [rows=3.341688, distinct(1)=3.34169, null(1)=0, avgsize(1)=4, distinct(2)=1, null(2)=0, avgsize(2)=4]
+ ├── stats: [rows=9.356725, distinct(1)=9.35673, null(1)=0, avgsize(1)=4, distinct(2)=1, null(2)=0, avgsize(2)=4, distinct(1,2)=9.35673, null(1,2)=0, avgsize(1,2)=8]
  ├── key: (1)
  ├── fd: ()-->(2)
  ├── scan a
@@ -1673,13 +1673,13 @@ SELECT * FROM hist_and_distinct WHERE a = 10 AND b = 10 AND c = 10 AND d >= 10 A
 ----
 select
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int!null)
- ├── stats: [rows=0.3000001, distinct(1)=0.3, null(1)=0, avgsize(1)=4, distinct(2)=0.3, null(2)=0, avgsize(2)=4, distinct(3)=0.3, null(3)=0, avgsize(3)=4, distinct(4)=0.3, null(4)=0, avgsize(4)=4]
+ ├── stats: [rows=0.3000001, distinct(1)=0.3, null(1)=0, avgsize(1)=4, distinct(2)=0.3, null(2)=0, avgsize(2)=4, distinct(3)=0.3, null(3)=0, avgsize(3)=4, distinct(4)=0.3, null(4)=0, avgsize(4)=4, distinct(1-3)=0.3, null(1-3)=0, avgsize(1-3)=12, distinct(1-4)=0.3, null(1-4)=0, avgsize(1-4)=16]
  │   histogram(1)=  0 0.3
  │                <--- 10
  ├── fd: ()-->(1-3)
  ├── scan hist_and_distinct
  │    ├── columns: a:1(int) b:2(int) c:3(int) d:4(int)
- │    └── stats: [rows=1000, distinct(1)=40, null(1)=0, avgsize(1)=4, distinct(2)=5, null(2)=0, avgsize(2)=4, distinct(3)=5, null(3)=0, avgsize(3)=4, distinct(4)=120, null(4)=0, avgsize(4)=4, distinct(1-4)=1000, null(1-4)=0, avgsize(1-4)=16]
+ │    └── stats: [rows=1000, distinct(1)=40, null(1)=0, avgsize(1)=4, distinct(2)=5, null(2)=0, avgsize(2)=4, distinct(3)=5, null(3)=0, avgsize(3)=4, distinct(4)=120, null(4)=0, avgsize(4)=4, distinct(1-3)=1000, null(1-3)=0, avgsize(1-3)=12, distinct(1-4)=1000, null(1-4)=0, avgsize(1-4)=16]
  │        histogram(1)=  0  0  90  10  180  20  270  30  360  40
  │                     <--- 0 ---- 10 ----- 20 ----- 30 ----- 40
  └── filters
@@ -2482,7 +2482,7 @@ AND c29 = 1 AND c30 = 1 AND c31 = 1 AND c32 = 1 AND c33 = 1
 ----
 select
  ├── columns: c1:1(int!null) c2:2(int!null) c3:3(int!null) c4:4(int!null) c5:5(int!null) c6:6(int!null) c7:7(int!null) c8:8(int!null) c9:9(int!null) c10:10(int!null) c11:11(int!null) c12:12(int!null) c13:13(int!null) c14:14(int!null) c15:15(int!null) c16:16(int!null) c17:17(int!null) c18:18(int!null) c19:19(int!null) c20:20(int!null) c21:21(int!null) c22:22(int!null) c23:23(int!null) c24:24(int!null) c25:25(int!null) c26:26(int!null) c27:27(int!null) c28:28(int!null) c29:29(int!null) c30:30(int!null) c31:31(int!null) c32:32(int!null) c33:33(int!null)
- ├── stats: [rows=2e-10, distinct(1)=2e-10, null(1)=0, avgsize(1)=4, distinct(2)=2e-10, null(2)=0, avgsize(2)=4, distinct(3)=2e-10, null(3)=0, avgsize(3)=4, distinct(4)=2e-10, null(4)=0, avgsize(4)=4, distinct(5)=2e-10, null(5)=0, avgsize(5)=4, distinct(6)=2e-10, null(6)=0, avgsize(6)=4, distinct(7)=2e-10, null(7)=0, avgsize(7)=4, distinct(8)=2e-10, null(8)=0, avgsize(8)=4, distinct(9)=2e-10, null(9)=0, avgsize(9)=4, distinct(10)=2e-10, null(10)=0, avgsize(10)=4, distinct(11)=2e-10, null(11)=0, avgsize(11)=4, distinct(12)=2e-10, null(12)=0, avgsize(12)=4, distinct(13)=2e-10, null(13)=0, avgsize(13)=4, distinct(14)=2e-10, null(14)=0, avgsize(14)=4, distinct(15)=2e-10, null(15)=0, avgsize(15)=4, distinct(16)=2e-10, null(16)=0, avgsize(16)=4, distinct(17)=2e-10, null(17)=0, avgsize(17)=4, distinct(18)=2e-10, null(18)=0, avgsize(18)=4, distinct(19)=2e-10, null(19)=0, avgsize(19)=4, distinct(20)=2e-10, null(20)=0, avgsize(20)=4, distinct(21)=2e-10, null(21)=0, avgsize(21)=4, distinct(22)=2e-10, null(22)=0, avgsize(22)=4, distinct(23)=2e-10, null(23)=0, avgsize(23)=4, distinct(24)=2e-10, null(24)=0, avgsize(24)=4, distinct(25)=2e-10, null(25)=0, avgsize(25)=4, distinct(26)=2e-10, null(26)=0, avgsize(26)=4, distinct(27)=2e-10, null(27)=0, avgsize(27)=4, distinct(28)=2e-10, null(28)=0, avgsize(28)=4, distinct(29)=2e-10, null(29)=0, avgsize(29)=4, distinct(30)=2e-10, null(30)=0, avgsize(30)=4, distinct(31)=2e-10, null(31)=0, avgsize(31)=4, distinct(32)=2e-10, null(32)=0, avgsize(32)=4, distinct(33)=2e-10, null(33)=0, avgsize(33)=4]
+ ├── stats: [rows=2e-10, distinct(1)=2e-10, null(1)=0, avgsize(1)=4, distinct(2)=2e-10, null(2)=0, avgsize(2)=4, distinct(3)=2e-10, null(3)=0, avgsize(3)=4, distinct(4)=2e-10, null(4)=0, avgsize(4)=4, distinct(5)=2e-10, null(5)=0, avgsize(5)=4, distinct(6)=2e-10, null(6)=0, avgsize(6)=4, distinct(7)=2e-10, null(7)=0, avgsize(7)=4, distinct(8)=2e-10, null(8)=0, avgsize(8)=4, distinct(9)=2e-10, null(9)=0, avgsize(9)=4, distinct(10)=2e-10, null(10)=0, avgsize(10)=4, distinct(11)=2e-10, null(11)=0, avgsize(11)=4, distinct(12)=2e-10, null(12)=0, avgsize(12)=4, distinct(13)=2e-10, null(13)=0, avgsize(13)=4, distinct(14)=2e-10, null(14)=0, avgsize(14)=4, distinct(15)=2e-10, null(15)=0, avgsize(15)=4, distinct(16)=2e-10, null(16)=0, avgsize(16)=4, distinct(17)=2e-10, null(17)=0, avgsize(17)=4, distinct(18)=2e-10, null(18)=0, avgsize(18)=4, distinct(19)=2e-10, null(19)=0, avgsize(19)=4, distinct(20)=2e-10, null(20)=0, avgsize(20)=4, distinct(21)=2e-10, null(21)=0, avgsize(21)=4, distinct(22)=2e-10, null(22)=0, avgsize(22)=4, distinct(23)=2e-10, null(23)=0, avgsize(23)=4, distinct(24)=2e-10, null(24)=0, avgsize(24)=4, distinct(25)=2e-10, null(25)=0, avgsize(25)=4, distinct(26)=2e-10, null(26)=0, avgsize(26)=4, distinct(27)=2e-10, null(27)=0, avgsize(27)=4, distinct(28)=2e-10, null(28)=0, avgsize(28)=4, distinct(29)=2e-10, null(29)=0, avgsize(29)=4, distinct(30)=2e-10, null(30)=0, avgsize(30)=4, distinct(31)=2e-10, null(31)=0, avgsize(31)=4, distinct(32)=2e-10, null(32)=0, avgsize(32)=4, distinct(33)=2e-10, null(33)=0, avgsize(33)=4, distinct(1-33)=2e-10, null(1-33)=0, avgsize(1-33)=132]
  ├── fd: ()-->(1-33)
  ├── scan t
  │    ├── columns: c1:1(int) c2:2(int) c3:3(int) c4:4(int) c5:5(int) c6:6(int) c7:7(int) c8:8(int) c9:9(int) c10:10(int) c11:11(int) c12:12(int) c13:13(int) c14:14(int) c15:15(int) c16:16(int) c17:17(int) c18:18(int) c19:19(int) c20:20(int) c21:21(int) c22:22(int) c23:23(int) c24:24(int) c25:25(int) c26:26(int) c27:27(int) c28:28(int) c29:29(int) c30:30(int) c31:31(int) c32:32(int) c33:33(int)
@@ -2721,61 +2721,25 @@ limit
  ├── stats: [rows=0.001]
  ├── key: (1)
  ├── fd: ()-->(4), (1)-->(2,3)
- ├── distinct-on
+ ├── select
  │    ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string!null)
- │    ├── grouping columns: k:1(int!null)
  │    ├── stats: [rows=0.001, distinct(4)=0.001, null(4)=0, avgsize(4)=4]
  │    ├── key: (1)
  │    ├── fd: ()-->(4), (1)-->(2,3)
  │    ├── limit hint: 5.00
- │    ├── union-all
- │    │    ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string!null)
- │    │    ├── left columns: k:7(int) a:8(string) b:9(string) c:10(string)
- │    │    ├── right columns: k:13(int) a:14(string) b:15(string) c:16(string)
- │    │    ├── stats: [rows=0.0010004]
- │    │    ├── inner-join (lookup disjunction)
- │    │    │    ├── columns: k:7(int!null) a:8(string!null) b:9(string) c:10(string!null)
- │    │    │    ├── key columns: [7] = [7]
- │    │    │    ├── lookup columns are key
- │    │    │    ├── stats: [rows=0.0005002, distinct(8)=0.0005002, null(8)=0, avgsize(8)=4, distinct(10)=0.0005002, null(10)=0, avgsize(10)=4]
- │    │    │    ├── key: (7)
- │    │    │    ├── fd: ()-->(8,10), (7)-->(9)
- │    │    │    ├── inner-join (zigzag disjunction@a_idx disjunction@c_idx)
- │    │    │    │    ├── columns: k:7(int!null) a:8(string!null) c:10(string!null)
- │    │    │    │    ├── eq columns: [7] = [7]
- │    │    │    │    ├── left fixed columns: [8] = ['foo']
- │    │    │    │    ├── right fixed columns: [10] = ['foo']
- │    │    │    │    ├── stats: [rows=0.0005, distinct(8)=0.0005, null(8)=0, avgsize(8)=4, distinct(10)=0.0005, null(10)=0, avgsize(10)=4]
- │    │    │    │    ├── fd: ()-->(8,10)
- │    │    │    │    └── filters
- │    │    │    │         ├── a:8 = 'foo' [type=bool, outer=(8), constraints=(/8: [/'foo' - /'foo']; tight), fd=()-->(8)]
- │    │    │    │         └── c:10 = 'foo' [type=bool, outer=(10), constraints=(/10: [/'foo' - /'foo']; tight), fd=()-->(10)]
- │    │    │    └── filters (true)
- │    │    └── inner-join (lookup disjunction)
- │    │         ├── columns: k:13(int!null) a:14(string) b:15(string!null) c:16(string!null)
- │    │         ├── key columns: [13] = [13]
- │    │         ├── lookup columns are key
- │    │         ├── stats: [rows=0.0005002, distinct(15)=0.0005002, null(15)=0, avgsize(15)=4, distinct(16)=0.0005002, null(16)=0, avgsize(16)=4]
- │    │         ├── key: (13)
- │    │         ├── fd: ()-->(15,16), (13)-->(14)
- │    │         ├── inner-join (zigzag disjunction@b_idx disjunction@c_idx)
- │    │         │    ├── columns: k:13(int!null) b:15(string!null) c:16(string!null)
- │    │         │    ├── eq columns: [13] = [13]
- │    │         │    ├── left fixed columns: [15] = ['foo']
- │    │         │    ├── right fixed columns: [16] = ['foo']
- │    │         │    ├── stats: [rows=0.0005, distinct(15)=0.0005, null(15)=0, avgsize(15)=4, distinct(16)=0.0005, null(16)=0, avgsize(16)=4]
- │    │         │    ├── fd: ()-->(15,16)
- │    │         │    └── filters
- │    │         │         ├── b:15 = 'foo' [type=bool, outer=(15), constraints=(/15: [/'foo' - /'foo']; tight), fd=()-->(15)]
- │    │         │         └── c:16 = 'foo' [type=bool, outer=(16), constraints=(/16: [/'foo' - /'foo']; tight), fd=()-->(16)]
- │    │         └── filters (true)
- │    └── aggregations
- │         ├── const-agg [as=a:2, type=string, outer=(2)]
- │         │    └── a:2 [type=string]
- │         ├── const-agg [as=b:3, type=string, outer=(3)]
- │         │    └── b:3 [type=string]
- │         └── const-agg [as=c:4, type=string, outer=(4)]
- │              └── c:4 [type=string]
+ │    ├── index-join disjunction
+ │    │    ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
+ │    │    ├── stats: [rows=1]
+ │    │    ├── key: (1)
+ │    │    ├── fd: ()-->(4), (1)-->(2,3)
+ │    │    └── scan disjunction@c_idx
+ │    │         ├── columns: k:1(int!null) c:4(string!null)
+ │    │         ├── constraint: /4/1: [/'foo' - /'foo']
+ │    │         ├── stats: [rows=1, distinct(4)=1, null(4)=0, avgsize(4)=4]
+ │    │         ├── key: (1)
+ │    │         └── fd: ()-->(4)
+ │    └── filters
+ │         └── (a:2 = 'foo') OR (b:3 = 'foo') [type=bool, outer=(2,3)]
  └── 5 [type=int]
 
 exec-ddl

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpcc
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpcc
@@ -577,7 +577,7 @@ project
       ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_next_o_id:11(int)
       ├── constraint: /2/1: [/4/9 - /4/9]
       ├── cardinality: [0 - 1]
-      ├── stats: [rows=1, distinct(1)=1, null(1)=0, avgsize(1)=1, distinct(2)=1, null(2)=0, avgsize(2)=1, distinct(11)=0.633968, null(11)=0, avgsize(11)=3]
+      ├── stats: [rows=1, distinct(1)=1, null(1)=0, avgsize(1)=1, distinct(2)=1, null(2)=0, avgsize(2)=1, distinct(11)=0.633968, null(11)=0, avgsize(11)=3, distinct(1,2)=1, null(1,2)=0, avgsize(1,2)=2]
       ├── key: ()
       └── fd: ()-->(1,2,11)
 

--- a/pkg/sql/opt/testutils/opttester/testdata/use-multi-col-stats
+++ b/pkg/sql/opt/testutils/opttester/testdata/use-multi-col-stats
@@ -28,7 +28,7 @@ scan rides
  ├── columns: id:1(uuid!null) city:2(varchar!null) vehicle_city:3(varchar) rider_id:4(uuid) vehicle_id:5(uuid) start_address:6(varchar) end_address:7(varchar) start_time:8(timestamp) end_time:9(timestamp) revenue:10(decimal)
  ├── constraint: /2/1: [/'rome'/'17198184-b24f-4aa8-9933-64a72ff6665f' - /'rome'/'17198184-b24f-4aa8-9933-64a72ff6665f']
  ├── cardinality: [0 - 1]
- ├── stats: [rows=0.1111112, distinct(1)=0.111111, null(1)=0, avgsize(1)=1, distinct(2)=0.111111, null(2)=0, avgsize(2)=6]
+ ├── stats: [rows=0.9111111, distinct(1)=0.911111, null(1)=0, avgsize(1)=1, distinct(2)=0.911111, null(2)=0, avgsize(2)=6, distinct(1,2)=0.911111, null(1,2)=0, avgsize(1,2)=8]
  ├── key: ()
  └── fd: ()-->(1-10)
 

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -603,18 +603,18 @@ WHERE w = 'foo' AND x = '2AB23800-06B1-4E19-A3BB-DF3768B808D2' AND (i,j,k,l,m,n)
 ----
 project
  ├── columns: w:1!null x:2!null y:3!null z:4!null
- ├── stats: [rows=0.25]
- ├── cost: 12227.3275
+ ├── stats: [rows=4.504399]
+ ├── cost: 12253.73
  ├── fd: ()-->(1,2)
  └── inner-join (lookup abcde@idx_abcd)
       ├── columns: w:1!null x:2!null y:3!null z:4!null i:5!null j:6!null k:7!null l:8!null m:9!null n:10!null a:14!null b:15!null c:16!null
       ├── key columns: [1 2 3] = [14 15 16]
-      ├── stats: [rows=0.25, distinct(1)=2e-06, null(1)=0, avgsize(1)=4, distinct(2)=2e-06, null(2)=0, avgsize(2)=4, distinct(3)=2e-06, null(3)=0, avgsize(3)=4, distinct(14)=2e-06, null(14)=0, avgsize(14)=4, distinct(15)=2e-06, null(15)=0, avgsize(15)=4, distinct(16)=2e-06, null(16)=0, avgsize(16)=4]
-      ├── cost: 12227.305
+      ├── stats: [rows=4.504399, distinct(1)=0.9, null(1)=0, avgsize(1)=4, distinct(2)=0.9, null(2)=0, avgsize(2)=4, distinct(3)=0.884032, null(3)=0, avgsize(3)=4, distinct(14)=0.9, null(14)=0, avgsize(14)=4, distinct(15)=0.9, null(15)=0, avgsize(15)=4, distinct(16)=0.884032, null(16)=0, avgsize(16)=4]
+      ├── cost: 12253.665
       ├── fd: ()-->(1,2,5-10,14,15), (1)==(14), (14)==(1), (2)==(15), (15)==(2), (3)==(16), (16)==(3)
       ├── select
       │    ├── columns: w:1!null x:2!null y:3!null z:4!null i:5!null j:6!null k:7!null l:8!null m:9!null n:10!null
-      │    ├── stats: [rows=2e-06, distinct(1)=2e-06, null(1)=0, avgsize(1)=4, distinct(2)=2e-06, null(2)=0, avgsize(2)=4, distinct(3)=2e-06, null(3)=0, avgsize(3)=4, distinct(4)=2e-06, null(4)=0, avgsize(4)=4, distinct(5)=2e-06, null(5)=0, avgsize(5)=4, distinct(6)=2e-06, null(6)=0, avgsize(6)=4, distinct(7)=2e-06, null(7)=0, avgsize(7)=4, distinct(8)=2e-06, null(8)=0, avgsize(8)=4, distinct(9)=2e-06, null(9)=0, avgsize(9)=4, distinct(10)=2e-06, null(10)=0, avgsize(10)=4]
+      │    ├── stats: [rows=0.9000001, distinct(1)=0.9, null(1)=0, avgsize(1)=4, distinct(2)=0.9, null(2)=0, avgsize(2)=4, distinct(3)=0.884032, null(3)=0, avgsize(3)=4, distinct(4)=0.899636, null(4)=0, avgsize(4)=4, distinct(5)=0.9, null(5)=0, avgsize(5)=4, distinct(6)=0.9, null(6)=0, avgsize(6)=4, distinct(7)=0.9, null(7)=0, avgsize(7)=4, distinct(8)=0.9, null(8)=0, avgsize(8)=4, distinct(9)=0.9, null(9)=0, avgsize(9)=4, distinct(10)=0.9, null(10)=0, avgsize(10)=4, distinct(5-10)=0.9, null(5-10)=0, avgsize(5-10)=24]
       │    ├── cost: 12226.22
       │    ├── fd: ()-->(1,2,5-10)
       │    ├── scan wxyzijklmn

--- a/pkg/sql/opt/xform/testdata/coster/scan
+++ b/pkg/sql/opt/xform/testdata/coster/scan
@@ -101,13 +101,13 @@ limit
  ├── columns: k:1!null i:2!null s:3 d:4!null
  ├── cardinality: [0 - 20]
  ├── stats: [rows=20]
- ├── cost: 460.259997
+ ├── cost: 173.545714
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── select
  │    ├── columns: k:1!null i:2!null s:3 d:4!null
- │    ├── stats: [rows=1666.667, distinct(1)=1666.67, null(1)=0, avgsize(1)=1, distinct(2)=5, null(2)=0, avgsize(2)=2]
- │    ├── cost: 460.049997
+ │    ├── stats: [rows=4666.667, distinct(1)=4666.67, null(1)=0, avgsize(1)=1, distinct(2)=5, null(2)=0, avgsize(2)=2, distinct(1,2)=4666.67, null(1,2)=0, avgsize(1,2)=3]
+ │    ├── cost: 173.335714
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
  │    ├── limit hint: 20.00
@@ -115,10 +115,10 @@ limit
  │    │    ├── columns: k:1!null i:2 s:3 d:4!null
  │    │    ├── constraint: /1: [/6 - ]
  │    │    ├── stats: [rows=33333.33, distinct(1)=33333.3, null(1)=0, avgsize(1)=1]
- │    │    ├── cost: 448.019998
+ │    │    ├── cost: 169.02
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-4)
- │    │    └── limit hint: 400.00
+ │    │    └── limit hint: 142.86
  │    └── filters
  │         └── i:2 IN (1, 3, 5, 7, 9) [outer=(2), constraints=(/2: [/1 - /1] [/3 - /3] [/5 - /5] [/7 - /7] [/9 - /9]; tight)]
  └── 20
@@ -132,14 +132,14 @@ limit
  ├── columns: k:1!null i:2!null s:3 d:4!null
  ├── cardinality: [0 - 20]
  ├── stats: [rows=20]
- ├── cost: 442.739807
+ ├── cost: 32.7179006
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── select
  │    ├── columns: k:1!null i:2!null s:3 d:4!null
  │    ├── cardinality: [0 - 450]
- │    ├── stats: [rows=22.50001, distinct(1)=22.5, null(1)=0, avgsize(1)=1, distinct(2)=5, null(2)=0, avgsize(2)=2]
- │    ├── cost: 442.529807
+ │    ├── stats: [rows=407.25, distinct(1)=407.25, null(1)=0, avgsize(1)=1, distinct(2)=5, null(2)=0, avgsize(2)=2, distinct(1,2)=407.25, null(1,2)=0, avgsize(1,2)=3]
+ │    ├── cost: 32.5079006
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
  │    ├── limit hint: 20.00
@@ -148,10 +148,10 @@ limit
  │    │    ├── constraint: /1: [/1 - /450]
  │    │    ├── cardinality: [0 - 450]
  │    │    ├── stats: [rows=450, distinct(1)=450, null(1)=0, avgsize(1)=1]
- │    │    ├── cost: 438.009807
+ │    │    ├── cost: 27.9879006
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-4)
- │    │    └── limit hint: 400.00
+ │    │    └── limit hint: 22.10
  │    └── filters
  │         └── i:2 IN (1, 3, 5, 7, 9) [outer=(2), constraints=(/2: [/1 - /1] [/3 - /3] [/5 - /5] [/7 - /7] [/9 - /9]; tight)]
  └── 20
@@ -484,13 +484,13 @@ upsert t64570
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── stats: [rows=0]
- ├── cost: 5.09833333
+ ├── cost: 5.14483333
  └── left-join (cross)
       ├── columns: column1:6!null column2:7!null column3:8!null x:9 y:10 v:11
       ├── cardinality: [1 - 1]
       ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
       ├── stats: [rows=1]
-      ├── cost: 5.08833333
+      ├── cost: 5.13483333
       ├── key: ()
       ├── fd: ()-->(6-11)
       ├── values
@@ -505,8 +505,8 @@ upsert t64570
       │    ├── columns: x:9!null y:10!null v:11
       │    ├── constraint: /9/10: [/10/10 - /10/10]
       │    ├── cardinality: [0 - 1]
-      │    ├── stats: [rows=0.3333333, distinct(9)=0.333333, null(9)=0, avgsize(9)=4, distinct(10)=0.333333, null(10)=0, avgsize(10)=4]
-      │    ├── cost: 5.03
+      │    ├── stats: [rows=0.9333333, distinct(9)=0.933333, null(9)=0, avgsize(9)=4, distinct(10)=0.933333, null(10)=0, avgsize(10)=4, distinct(9,10)=0.933333, null(9,10)=0, avgsize(9,10)=8]
+      │    ├── cost: 5.066
       │    ├── key: ()
       │    └── fd: ()-->(9-11)
       └── filters (true)

--- a/pkg/sql/opt/xform/testdata/coster/select
+++ b/pkg/sql/opt/xform/testdata/coster/select
@@ -132,7 +132,7 @@ SELECT * FROM zigzag@{FORCE_ZIGZAG=a_idx,FORCE_ZIGZAG=c_idx} WHERE a = 3 AND b =
 ----
 select
  ├── columns: n:1!null a:2!null b:3!null c:4
- ├── stats: [rows=0.1000001, distinct(2)=0.1, null(2)=0, avgsize(2)=4, distinct(3)=0.1, null(3)=0, avgsize(3)=4]
+ ├── stats: [rows=0.9108108, distinct(2)=0.910811, null(2)=0, avgsize(2)=4, distinct(3)=0.910811, null(3)=0, avgsize(3)=4, distinct(2,3)=0.910811, null(2,3)=0, avgsize(2,3)=8]
  ├── cost: 1e+100
  ├── key: (1)
  ├── fd: ()-->(2,3), (1)-->(4), (3,4)~~>(1)
@@ -153,7 +153,7 @@ SELECT * FROM zigzag@{FORCE_ZIGZAG=[2],FORCE_ZIGZAG=c_idx} WHERE a = 3 AND b = 7
 ----
 select
  ├── columns: n:1!null a:2!null b:3!null c:4
- ├── stats: [rows=0.1000001, distinct(2)=0.1, null(2)=0, avgsize(2)=4, distinct(3)=0.1, null(3)=0, avgsize(3)=4]
+ ├── stats: [rows=0.9108108, distinct(2)=0.910811, null(2)=0, avgsize(2)=4, distinct(3)=0.910811, null(3)=0, avgsize(3)=4, distinct(2,3)=0.910811, null(2,3)=0, avgsize(2,3)=8]
  ├── cost: 1e+100
  ├── key: (1)
  ├── fd: ()-->(2,3), (1)-->(4), (3,4)~~>(1)

--- a/pkg/sql/opt/xform/testdata/coster/zone
+++ b/pkg/sql/opt/xform/testdata/coster/zone
@@ -812,7 +812,7 @@ locality-optimized-search
  ├── right columns: t.public.abc_part.r:13(string) t.public.abc_part.a:14(int) t.public.abc_part.b:15(int) t.public.abc_part.c:16(string)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=0.91, distinct(3)=0.91, null(3)=0, avgsize(3)=4, distinct(4)=0.91, null(4)=0, avgsize(4)=4, distinct(3,4)=0.91, null(3,4)=0, avgsize(3,4)=8]
- ├── cost: 3.37254001
+ ├── cost: 3.468444
  ├── key: ()
  ├── fd: ()-->(1-4)
  ├── distribution: east
@@ -821,8 +821,8 @@ locality-optimized-search
  │    ├── columns: t.public.abc_part.r:7(string!null) t.public.abc_part.a:8(int!null) t.public.abc_part.b:9(int!null) t.public.abc_part.c:10(string!null)
  │    ├── constraint: /7/9/10: [/'east'/1/'foo' - /'east'/1/'foo']
  │    ├── cardinality: [0 - 1]
- │    ├── stats: [rows=0.0010001, distinct(7)=0.0010001, null(7)=0, avgsize(7)=4, distinct(9)=0.0010001, null(9)=0, avgsize(9)=4, distinct(10)=0.0010001, null(10)=0, avgsize(10)=4]
- │    ├── cost: 1.67672001
+ │    ├── stats: [rows=0.9001, distinct(7)=0.9001, null(7)=0, avgsize(7)=4, distinct(9)=0.9001, null(9)=0, avgsize(9)=4, distinct(10)=0.9001, null(10)=0, avgsize(10)=4, distinct(7,9,10)=0.9001, null(7,9,10)=0, avgsize(7,9,10)=12]
+ │    ├── cost: 1.724672
  │    ├── key: ()
  │    ├── fd: ()-->(7-10)
  │    └── prune: (7-10)
@@ -830,8 +830,8 @@ locality-optimized-search
       ├── columns: t.public.abc_part.r:13(string!null) t.public.abc_part.a:14(int!null) t.public.abc_part.b:15(int!null) t.public.abc_part.c:16(string!null)
       ├── constraint: /13/15/16: [/'west'/1/'foo' - /'west'/1/'foo']
       ├── cardinality: [0 - 1]
-      ├── stats: [rows=0.0010001, distinct(13)=0.0010001, null(13)=0, avgsize(13)=4, distinct(15)=0.0010001, null(15)=0, avgsize(15)=4, distinct(16)=0.0010001, null(16)=0, avgsize(16)=4]
-      ├── cost: 1.67672001
+      ├── stats: [rows=0.9001, distinct(13)=0.9001, null(13)=0, avgsize(13)=4, distinct(15)=0.9001, null(15)=0, avgsize(15)=4, distinct(16)=0.9001, null(16)=0, avgsize(16)=4, distinct(13,15,16)=0.9001, null(13,15,16)=0, avgsize(13,15,16)=12]
+      ├── cost: 1.724672
       ├── key: ()
       ├── fd: ()-->(13-16)
       └── prune: (13-16)
@@ -850,7 +850,7 @@ anti-join (lookup abc_part@bc_idx [as=a2])
  │         └── a2.r:7 = 'west' [outer=(7), constraints=(/7: [/'west' - /'west']; tight), fd=()-->(7)]
  ├── cardinality: [0 - 1]
  ├── stats: [rows=1e-10]
- ├── cost: 18.0484217
+ ├── cost: 18.1443257
  ├── key: ()
  ├── fd: ()-->(1-4)
  ├── distribution: east
@@ -862,7 +862,7 @@ anti-join (lookup abc_part@bc_idx [as=a2])
  │    │         └── a2.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
  │    ├── cardinality: [0 - 1]
  │    ├── stats: [rows=0.9009, distinct(1)=0.897389, null(1)=0, avgsize(1)=4, distinct(2)=0.9009, null(2)=0, avgsize(2)=4, distinct(3)=0.9009, null(3)=0, avgsize(3)=4, distinct(4)=0.9009, null(4)=0, avgsize(4)=4]
- │    ├── cost: 10.7473047
+ │    ├── cost: 10.8432087
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)
  │    ├── distribution: east
@@ -872,7 +872,7 @@ anti-join (lookup abc_part@bc_idx [as=a2])
  │    │    ├── right columns: a1.r:19 a1.a:20 a1.b:21 a1.c:22
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── stats: [rows=0.91, distinct(1)=0.906283, null(1)=0, avgsize(1)=4, distinct(2)=0.91, null(2)=0, avgsize(2)=4, distinct(3)=0.91, null(3)=0, avgsize(3)=4, distinct(4)=0.91, null(4)=0, avgsize(4)=4, distinct(3,4)=0.91, null(3,4)=0, avgsize(3,4)=8]
- │    │    ├── cost: 3.37254001
+ │    │    ├── cost: 3.468444
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1-4)
  │    │    ├── distribution: east
@@ -880,16 +880,16 @@ anti-join (lookup abc_part@bc_idx [as=a2])
  │    │    │    ├── columns: a1.r:13!null a1.a:14!null a1.b:15!null a1.c:16!null
  │    │    │    ├── constraint: /13/15/16: [/'east'/1/'foo' - /'east'/1/'foo']
  │    │    │    ├── cardinality: [0 - 1]
- │    │    │    ├── stats: [rows=0.0010001, distinct(13)=0.0010001, null(13)=0, avgsize(13)=4, distinct(15)=0.0010001, null(15)=0, avgsize(15)=4, distinct(16)=0.0010001, null(16)=0, avgsize(16)=4]
- │    │    │    ├── cost: 1.67672001
+ │    │    │    ├── stats: [rows=0.9001, distinct(13)=0.9001, null(13)=0, avgsize(13)=4, distinct(15)=0.9001, null(15)=0, avgsize(15)=4, distinct(16)=0.9001, null(16)=0, avgsize(16)=4, distinct(13,15,16)=0.9001, null(13,15,16)=0, avgsize(13,15,16)=12]
+ │    │    │    ├── cost: 1.724672
  │    │    │    ├── key: ()
  │    │    │    └── fd: ()-->(13-16)
  │    │    └── scan abc_part@bc_idx [as=a1]
  │    │         ├── columns: a1.r:19!null a1.a:20!null a1.b:21!null a1.c:22!null
  │    │         ├── constraint: /19/21/22: [/'west'/1/'foo' - /'west'/1/'foo']
  │    │         ├── cardinality: [0 - 1]
- │    │         ├── stats: [rows=0.0010001, distinct(19)=0.0010001, null(19)=0, avgsize(19)=4, distinct(21)=0.0010001, null(21)=0, avgsize(21)=4, distinct(22)=0.0010001, null(22)=0, avgsize(22)=4]
- │    │         ├── cost: 1.67672001
+ │    │         ├── stats: [rows=0.9001, distinct(19)=0.9001, null(19)=0, avgsize(19)=4, distinct(21)=0.9001, null(21)=0, avgsize(21)=4, distinct(22)=0.9001, null(22)=0, avgsize(22)=4, distinct(19,21,22)=0.9001, null(19,21,22)=0, avgsize(19,21,22)=12]
+ │    │         ├── cost: 1.724672
  │    │         ├── key: ()
  │    │         └── fd: ()-->(19-22)
  │    └── filters (true)

--- a/pkg/sql/opt/xform/testdata/external/customer
+++ b/pkg/sql/opt/xform/testdata/external/customer
@@ -182,7 +182,7 @@ limit
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(9)
  │    │    ├── ordering: +1
- │    │    └── limit hint: 10.10
+ │    │    └── limit hint: 5.27
  │    └── filters
  │         └── NOT read:9 [outer=(9), constraints=(/9: [/false - /false]; tight), fd=()-->(9)]
  └── 5

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -2028,9 +2028,10 @@ project
  │    │    │    │    │    └── fd: (18)-->(20)
  │    │    │    │    └── filters
  │    │    │    │         └── li.productid:14 = p.productid:18 [outer=(14,18), constraints=(/14: (/NULL - ]; /18: (/NULL - ]), fd=(14)==(18), (18)==(14)]
- │    │    │    ├── left-join (lookup lineitem [as=lineitems1_])
+ │    │    │    ├── left-join (merge)
  │    │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9
- │    │    │    │    ├── key columns: [1 2] = [6 7]
+ │    │    │    │    ├── left ordering: +1,+2
+ │    │    │    │    ├── right ordering: +6,+7
  │    │    │    │    ├── key: (8)
  │    │    │    │    ├── fd: ()-->(1-3,6,7), (8)-->(9)
  │    │    │    │    ├── scan customerorder [as=order0_]
@@ -2039,9 +2040,12 @@ project
  │    │    │    │    │    ├── cardinality: [0 - 1]
  │    │    │    │    │    ├── key: ()
  │    │    │    │    │    └── fd: ()-->(1-3)
- │    │    │    │    └── filters
- │    │    │    │         ├── lineitems1_.customerid:6 = 'c111' [outer=(6), constraints=(/6: [/'c111' - /'c111']; tight), fd=()-->(6)]
- │    │    │    │         └── lineitems1_.ordernumber:7 = 0 [outer=(7), constraints=(/7: [/0 - /0]; tight), fd=()-->(7)]
+ │    │    │    │    ├── scan lineitem [as=lineitems1_]
+ │    │    │    │    │    ├── columns: lineitems1_.customerid:6!null lineitems1_.ordernumber:7!null lineitems1_.productid:8!null lineitems1_.quantity:9
+ │    │    │    │    │    ├── constraint: /6/7/8: [/'c111'/0 - /'c111'/0]
+ │    │    │    │    │    ├── key: (8)
+ │    │    │    │    │    └── fd: ()-->(6,7), (8)-->(9)
+ │    │    │    │    └── filters (true)
  │    │    │    └── filters
  │    │    │         ├── li.customerid:12 = order0_.customerid:1 [outer=(1,12), constraints=(/1: (/NULL - ]; /12: (/NULL - ]), fd=(1)==(12), (12)==(1)]
  │    │    │         └── li.ordernumber:13 = order0_.ordernumber:2 [outer=(2,13), constraints=(/2: (/NULL - ]; /13: (/NULL - ]), fd=(2)==(13), (13)==(2)]
@@ -2320,9 +2324,10 @@ project
  │    │    │    │    │    └── fd: (18)-->(20)
  │    │    │    │    └── filters
  │    │    │    │         └── li.productid:14 = p.productid:18 [outer=(14,18), constraints=(/14: (/NULL - ]; /18: (/NULL - ]), fd=(14)==(18), (18)==(14)]
- │    │    │    ├── left-join (lookup lineitem [as=lineitems1_])
+ │    │    │    ├── left-join (merge)
  │    │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9
- │    │    │    │    ├── key columns: [1 2] = [6 7]
+ │    │    │    │    ├── left ordering: +1,+2
+ │    │    │    │    ├── right ordering: +6,+7
  │    │    │    │    ├── key: (8)
  │    │    │    │    ├── fd: ()-->(1-3,6,7), (8)-->(9)
  │    │    │    │    ├── scan customerorder [as=order0_]
@@ -2331,9 +2336,12 @@ project
  │    │    │    │    │    ├── cardinality: [0 - 1]
  │    │    │    │    │    ├── key: ()
  │    │    │    │    │    └── fd: ()-->(1-3)
- │    │    │    │    └── filters
- │    │    │    │         ├── lineitems1_.customerid:6 = 'c111' [outer=(6), constraints=(/6: [/'c111' - /'c111']; tight), fd=()-->(6)]
- │    │    │    │         └── lineitems1_.ordernumber:7 = 0 [outer=(7), constraints=(/7: [/0 - /0]; tight), fd=()-->(7)]
+ │    │    │    │    ├── scan lineitem [as=lineitems1_]
+ │    │    │    │    │    ├── columns: lineitems1_.customerid:6!null lineitems1_.ordernumber:7!null lineitems1_.productid:8!null lineitems1_.quantity:9
+ │    │    │    │    │    ├── constraint: /6/7/8: [/'c111'/0 - /'c111'/0]
+ │    │    │    │    │    ├── key: (8)
+ │    │    │    │    │    └── fd: ()-->(6,7), (8)-->(9)
+ │    │    │    │    └── filters (true)
  │    │    │    └── filters
  │    │    │         ├── li.customerid:12 = order0_.customerid:1 [outer=(1,12), constraints=(/1: (/NULL - ]; /12: (/NULL - ]), fd=(1)==(12), (12)==(1)]
  │    │    │         └── li.ordernumber:13 = order0_.ordernumber:2 [outer=(2,13), constraints=(/2: (/NULL - ]; /13: (/NULL - ]), fd=(2)==(13), (13)==(2)]

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -688,22 +688,26 @@ FROM customer
 WHERE c_w_id = 10 AND c_d_id = 100 AND c_last = 'Smith'
 ORDER BY c_first ASC
 ----
-project
+sort
  ├── columns: c_id:1!null c_balance:17 c_first:4 c_middle:5
  ├── key: (1)
  ├── fd: (1)-->(4,5,17)
  ├── ordering: +4
- └── index-join customer
-      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_middle:5 c_last:6!null c_balance:17
+ └── project
+      ├── columns: c_id:1!null c_first:4 c_middle:5 c_balance:17
       ├── key: (1)
-      ├── fd: ()-->(2,3,6), (1)-->(4,5,17)
-      ├── ordering: +4 opt(2,3,6) [actual: +4]
-      └── scan customer@customer_idx
-           ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_last:6!null
-           ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
+      ├── fd: (1)-->(4,5,17)
+      └── select
+           ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_middle:5 c_last:6!null c_balance:17
            ├── key: (1)
-           ├── fd: ()-->(2,3,6), (1)-->(4)
-           └── ordering: +4 opt(2,3,6) [actual: +4]
+           ├── fd: ()-->(2,3,6), (1)-->(4,5,17)
+           ├── scan customer
+           │    ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_middle:5 c_last:6 c_balance:17
+           │    ├── constraint: /3/2/1: [/10/100 - /10/100]
+           │    ├── key: (1)
+           │    └── fd: ()-->(2,3), (1)-->(4-6,17)
+           └── filters
+                └── c_last:6 = 'Smith' [outer=(6), constraints=(/6: [/'Smith' - /'Smith']; tight), fd=()-->(6)]
 
 opt format=hide-qual
 SELECT o_id, o_entry_d, o_carrier_id
@@ -890,23 +894,22 @@ update customer
       ├── immutable
       ├── key: (24,25)
       ├── fd: ()-->(26), (24,25)-->(27-44,49), (43)-->(47)
-      ├── index-join customer
+      ├── scan customer
       │    ├── columns: c_id:24!null c_d_id:25!null c_w_id:26!null c_first:27 c_middle:28 c_last:29 c_street_1:30 c_street_2:31 c_city:32 c_state:33 c_zip:34 c_phone:35 c_since:36 c_credit:37 c_credit_lim:38 c_discount:39 c_balance:40 c_ytd_payment:41 c_payment_cnt:42 c_delivery_cnt:43 c_data:44
+      │    ├── constraint: /26/25/24
+      │    │    ├── [/10/1/1405 - /10/1/1405]
+      │    │    ├── [/10/2/137 - /10/2/137]
+      │    │    ├── [/10/3/309 - /10/3/309]
+      │    │    ├── [/10/4/98 - /10/4/98]
+      │    │    ├── [/10/5/1683 - /10/5/1683]
+      │    │    ├── [/10/6/2807 - /10/6/2807]
+      │    │    ├── [/10/7/2377 - /10/7/2377]
+      │    │    ├── [/10/8/2106 - /10/8/2106]
+      │    │    ├── [/10/9/1412 - /10/9/1412]
+      │    │    └── [/10/10/417 - /10/10/417]
       │    ├── cardinality: [0 - 10]
       │    ├── key: (24,25)
-      │    ├── fd: ()-->(26), (24,25)-->(27-44)
-      │    └── select
-      │         ├── columns: c_id:24!null c_d_id:25!null c_w_id:26!null c_first:27 c_last:29
-      │         ├── cardinality: [0 - 10]
-      │         ├── key: (24,25)
-      │         ├── fd: ()-->(26), (24,25)-->(27,29)
-      │         ├── scan customer@customer_idx
-      │         │    ├── columns: c_id:24!null c_d_id:25!null c_w_id:26!null c_first:27 c_last:29
-      │         │    ├── constraint: /26/25/29/27/24: [/10/1 - /10/10]
-      │         │    ├── key: (24,25)
-      │         │    └── fd: ()-->(26), (24,25)-->(27,29)
-      │         └── filters
-      │              └── (c_d_id:25, c_id:24) IN ((1, 1405), (2, 137), (3, 309), (7, 2377), (8, 2106), (10, 417), (4, 98), (5, 1683), (6, 2807), (9, 1412)) [outer=(24,25), constraints=(/24: [/98 - /98] [/137 - /137] [/309 - /309] [/417 - /417] [/1405 - /1405] [/1412 - /1412] [/1683 - /1683] [/2106 - /2106] [/2377 - /2377] [/2807 - /2807]; /25/24: [/1/1405 - /1/1405] [/2/137 - /2/137] [/3/309 - /3/309] [/4/98 - /4/98] [/5/1683 - /5/1683] [/6/2807 - /6/2807] [/7/2377 - /7/2377] [/8/2106 - /8/2106] [/9/1412 - /9/1412] [/10/417 - /10/417]; tight)]
+      │    └── fd: ()-->(26), (24,25)-->(27-44)
       └── projections
            ├── assignment-cast: DECIMAL(12,2) [as=c_balance_cast:49, outer=(25,40), immutable]
            │    └── c_balance:40::DECIMAL + CASE c_d_id:25 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 ELSE CAST(NULL AS DECIMAL) END

--- a/pkg/sql/opt/xform/testdata/external/tpce
+++ b/pkg/sql/opt/xform/testdata/external/tpce
@@ -5344,31 +5344,33 @@ project
  │    │    │    ├── key: (1)
  │    │    │    ├── fd: ()-->(6,24,27), (1)-->(2,4,5,7,9-11), (18)-->(19), (4)==(18), (18)==(4), (6)==(24), (24)==(6)
  │    │    │    ├── ordering: +2 opt(6,24,27) [actual: +2]
- │    │    │    └── inner-join (merge)
+ │    │    │    └── inner-join (hash)
  │    │    │         ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11 tt_id:18!null tt_name:19!null s_symb:24!null s_name:27!null
- │    │    │         ├── left ordering: +6
- │    │    │         ├── right ordering: +24
+ │    │    │         ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
  │    │    │         ├── key: (1)
  │    │    │         ├── fd: ()-->(6,24,27), (1)-->(2,4,5,7,9-11), (18)-->(19), (4)==(18), (18)==(4), (6)==(24), (24)==(6)
- │    │    │         ├── inner-join (lookup trade_type)
- │    │    │         │    ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11 tt_id:18!null tt_name:19!null
- │    │    │         │    ├── key columns: [4] = [18]
- │    │    │         │    ├── lookup columns are key
+ │    │    │         ├── inner-join (lookup trade@trade_t_s_symb_t_dts_idx)
+ │    │    │         │    ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11 s_symb:24!null s_name:27!null
+ │    │    │         │    ├── lookup expression
+ │    │    │         │    │    └── filters
+ │    │    │         │    │         ├── s_symb:24 = t_s_symb:6 [outer=(6,24), constraints=(/6: (/NULL - ]; /24: (/NULL - ]), fd=(6)==(24), (24)==(6)]
+ │    │    │         │    │         └── (t_dts:2 >= '2020-06-15 22:27:42.148484') AND (t_dts:2 <= '2020-06-20 22:27:42.148484') [outer=(2), constraints=(/2: [/'2020-06-15 22:27:42.148484' - /'2020-06-20 22:27:42.148484']; tight)]
  │    │    │         │    ├── key: (1)
- │    │    │         │    ├── fd: ()-->(6), (1)-->(2,4,5,7,9-11), (18)-->(19), (4)==(18), (18)==(4)
- │    │    │         │    ├── scan trade@trade_t_s_symb_t_dts_idx
- │    │    │         │    │    ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11
- │    │    │         │    │    ├── constraint: /6/2/1: [/'ROACH'/'2020-06-15 22:27:42.148484' - /'ROACH'/'2020-06-20 22:27:42.148484']
- │    │    │         │    │    ├── key: (1)
- │    │    │         │    │    └── fd: ()-->(6), (1)-->(2,4,5,7,9-11)
- │    │    │         │    └── filters (true)
- │    │    │         ├── scan security
- │    │    │         │    ├── columns: s_symb:24!null s_name:27!null
- │    │    │         │    ├── constraint: /24: [/'ROACH' - /'ROACH']
- │    │    │         │    ├── cardinality: [0 - 1]
- │    │    │         │    ├── key: ()
- │    │    │         │    └── fd: ()-->(24,27)
- │    │    │         └── filters (true)
+ │    │    │         │    ├── fd: ()-->(6,24,27), (1)-->(2,4,5,7,9-11), (6)==(24), (24)==(6)
+ │    │    │         │    ├── scan security
+ │    │    │         │    │    ├── columns: s_symb:24!null s_name:27!null
+ │    │    │         │    │    ├── constraint: /24: [/'ROACH' - /'ROACH']
+ │    │    │         │    │    ├── cardinality: [0 - 1]
+ │    │    │         │    │    ├── key: ()
+ │    │    │         │    │    └── fd: ()-->(24,27)
+ │    │    │         │    └── filters
+ │    │    │         │         └── t_s_symb:6 = 'ROACH' [outer=(6), constraints=(/6: [/'ROACH' - /'ROACH']; tight), fd=()-->(6)]
+ │    │    │         ├── scan trade_type
+ │    │    │         │    ├── columns: tt_id:18!null tt_name:19!null
+ │    │    │         │    ├── key: (18)
+ │    │    │         │    └── fd: (18)-->(19)
+ │    │    │         └── filters
+ │    │    │              └── tt_id:18 = t_tt_id:4 [outer=(4,18), constraints=(/4: (/NULL - ]; /18: (/NULL - ]), fd=(4)==(18), (18)==(4)]
  │    │    └── filters (true)
  │    └── filters (true)
  └── projections
@@ -5430,40 +5432,47 @@ project
  │    │    ├── key: (1)
  │    │    ├── fd: ()-->(6,24,27), (1)-->(2,4,5,7,9-11,42-45), (18)-->(19), (4)==(18), (18)==(4), (6)==(24), (24)==(6), (42)-->(43-45)
  │    │    ├── ordering: +2 opt(6,24,27) [actual: +2]
- │    │    ├── top-k
+ │    │    ├── limit
  │    │    │    ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11 tt_id:18!null tt_name:19!null s_symb:24!null s_name:27!null
  │    │    │    ├── internal-ordering: +2 opt(6,24,27)
- │    │    │    ├── k: 50
  │    │    │    ├── cardinality: [0 - 50]
  │    │    │    ├── key: (1)
  │    │    │    ├── fd: ()-->(6,24,27), (1)-->(2,4,5,7,9-11), (18)-->(19), (4)==(18), (18)==(4), (6)==(24), (24)==(6)
  │    │    │    ├── ordering: +2 opt(6,24,27) [actual: +2]
- │    │    │    └── inner-join (lookup security)
- │    │    │         ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11 tt_id:18!null tt_name:19!null s_symb:24!null s_name:27!null
- │    │    │         ├── flags: force lookup join (into right side)
- │    │    │         ├── key columns: [6] = [24]
- │    │    │         ├── lookup columns are key
- │    │    │         ├── key: (1)
- │    │    │         ├── fd: ()-->(6,24,27), (1)-->(2,4,5,7,9-11), (18)-->(19), (4)==(18), (18)==(4), (6)==(24), (24)==(6)
- │    │    │         ├── inner-join (hash)
- │    │    │         │    ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11 tt_id:18!null tt_name:19!null
- │    │    │         │    ├── flags: force hash join (store right side)
- │    │    │         │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
- │    │    │         │    ├── key: (1)
- │    │    │         │    ├── fd: ()-->(6), (1)-->(2,4,5,7,9-11), (18)-->(19), (4)==(18), (18)==(4)
- │    │    │         │    ├── scan trade@trade_t_s_symb_t_dts_idx
- │    │    │         │    │    ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11
- │    │    │         │    │    ├── constraint: /6/2/1: [/'ROACH'/'2020-06-15 22:27:42.148484' - /'ROACH'/'2020-06-20 22:27:42.148484']
- │    │    │         │    │    ├── key: (1)
- │    │    │         │    │    └── fd: ()-->(6), (1)-->(2,4,5,7,9-11)
- │    │    │         │    ├── scan trade_type
- │    │    │         │    │    ├── columns: tt_id:18!null tt_name:19!null
- │    │    │         │    │    ├── key: (18)
- │    │    │         │    │    └── fd: (18)-->(19)
- │    │    │         │    └── filters
- │    │    │         │         └── tt_id:18 = t_tt_id:4 [outer=(4,18), constraints=(/4: (/NULL - ]; /18: (/NULL - ]), fd=(4)==(18), (18)==(4)]
- │    │    │         └── filters
- │    │    │              └── s_symb:24 = 'ROACH' [outer=(24), constraints=(/24: [/'ROACH' - /'ROACH']; tight), fd=()-->(24)]
+ │    │    │    ├── inner-join (lookup security)
+ │    │    │    │    ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11 tt_id:18!null tt_name:19!null s_symb:24!null s_name:27!null
+ │    │    │    │    ├── flags: force lookup join (into right side)
+ │    │    │    │    ├── key columns: [6] = [24]
+ │    │    │    │    ├── lookup columns are key
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    ├── fd: ()-->(6,24,27), (1)-->(2,4,5,7,9-11), (18)-->(19), (4)==(18), (18)==(4), (6)==(24), (24)==(6)
+ │    │    │    │    ├── ordering: +2 opt(6,24,27) [actual: +2]
+ │    │    │    │    ├── limit hint: 50.00
+ │    │    │    │    ├── sort
+ │    │    │    │    │    ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11 tt_id:18!null tt_name:19!null
+ │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    ├── fd: ()-->(6), (1)-->(2,4,5,7,9-11), (18)-->(19), (4)==(18), (18)==(4)
+ │    │    │    │    │    ├── ordering: +2 opt(6) [actual: +2]
+ │    │    │    │    │    └── inner-join (hash)
+ │    │    │    │    │         ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11 tt_id:18!null tt_name:19!null
+ │    │    │    │    │         ├── flags: force hash join (store right side)
+ │    │    │    │    │         ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ │    │    │    │    │         ├── key: (1)
+ │    │    │    │    │         ├── fd: ()-->(6), (1)-->(2,4,5,7,9-11), (18)-->(19), (4)==(18), (18)==(4)
+ │    │    │    │    │         ├── scan trade@trade_t_s_symb_t_dts_idx
+ │    │    │    │    │         │    ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11
+ │    │    │    │    │         │    ├── constraint: /6/2/1: [/'ROACH'/'2020-06-15 22:27:42.148484' - /'ROACH'/'2020-06-20 22:27:42.148484']
+ │    │    │    │    │         │    ├── key: (1)
+ │    │    │    │    │         │    └── fd: ()-->(6), (1)-->(2,4,5,7,9-11)
+ │    │    │    │    │         ├── scan trade_type
+ │    │    │    │    │         │    ├── columns: tt_id:18!null tt_name:19!null
+ │    │    │    │    │         │    ├── key: (18)
+ │    │    │    │    │         │    └── fd: (18)-->(19)
+ │    │    │    │    │         └── filters
+ │    │    │    │    │              └── tt_id:18 = t_tt_id:4 [outer=(4,18), constraints=(/4: (/NULL - ]; /18: (/NULL - ]), fd=(4)==(18), (18)==(4)]
+ │    │    │    │    └── filters
+ │    │    │    │         └── s_symb:24 = 'ROACH' [outer=(24), constraints=(/24: [/'ROACH' - /'ROACH']; tight), fd=()-->(24)]
+ │    │    │    └── 50
  │    │    └── filters (true)
  │    └── filters (true)
  └── projections

--- a/pkg/sql/opt/xform/testdata/external/tpce-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpce-no-stats
@@ -5353,39 +5353,44 @@ project
  │    │    ├── key: (1)
  │    │    ├── fd: ()-->(6,24,27), (1)-->(2,4,5,7,9-11,42-45), (18)-->(19), (4)==(18), (18)==(4), (6)==(24), (24)==(6), (42)-->(43-45)
  │    │    ├── ordering: +2 opt(6,24,27) [actual: +2]
- │    │    ├── top-k
+ │    │    ├── limit
  │    │    │    ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11 tt_id:18!null tt_name:19!null s_symb:24!null s_name:27!null
  │    │    │    ├── internal-ordering: +2 opt(6,24,27)
- │    │    │    ├── k: 50
  │    │    │    ├── cardinality: [0 - 50]
  │    │    │    ├── key: (1)
  │    │    │    ├── fd: ()-->(6,24,27), (1)-->(2,4,5,7,9-11), (18)-->(19), (4)==(18), (18)==(4), (6)==(24), (24)==(6)
  │    │    │    ├── ordering: +2 opt(6,24,27) [actual: +2]
- │    │    │    └── inner-join (merge)
- │    │    │         ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11 tt_id:18!null tt_name:19!null s_symb:24!null s_name:27!null
- │    │    │         ├── left ordering: +6
- │    │    │         ├── right ordering: +24
- │    │    │         ├── key: (1)
- │    │    │         ├── fd: ()-->(6,24,27), (1)-->(2,4,5,7,9-11), (18)-->(19), (4)==(18), (18)==(4), (6)==(24), (24)==(6)
- │    │    │         ├── inner-join (lookup trade_type)
- │    │    │         │    ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11 tt_id:18!null tt_name:19!null
- │    │    │         │    ├── key columns: [4] = [18]
- │    │    │         │    ├── lookup columns are key
- │    │    │         │    ├── key: (1)
- │    │    │         │    ├── fd: ()-->(6), (1)-->(2,4,5,7,9-11), (18)-->(19), (4)==(18), (18)==(4)
- │    │    │         │    ├── scan trade@trade_t_s_symb_t_dts_idx
- │    │    │         │    │    ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11
- │    │    │         │    │    ├── constraint: /6/2/1: [/'ROACH'/'2020-06-15 22:27:42.148484' - /'ROACH'/'2020-06-20 22:27:42.148484']
- │    │    │         │    │    ├── key: (1)
- │    │    │         │    │    └── fd: ()-->(6), (1)-->(2,4,5,7,9-11)
- │    │    │         │    └── filters (true)
- │    │    │         ├── scan security
- │    │    │         │    ├── columns: s_symb:24!null s_name:27!null
- │    │    │         │    ├── constraint: /24: [/'ROACH' - /'ROACH']
- │    │    │         │    ├── cardinality: [0 - 1]
- │    │    │         │    ├── key: ()
- │    │    │         │    └── fd: ()-->(24,27)
- │    │    │         └── filters (true)
+ │    │    │    ├── inner-join (lookup trade_type)
+ │    │    │    │    ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11 tt_id:18!null tt_name:19!null s_symb:24!null s_name:27!null
+ │    │    │    │    ├── key columns: [4] = [18]
+ │    │    │    │    ├── lookup columns are key
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    ├── fd: ()-->(6,24,27), (1)-->(2,4,5,7,9-11), (18)-->(19), (4)==(18), (18)==(4), (6)==(24), (24)==(6)
+ │    │    │    │    ├── ordering: +2 opt(6,24,27) [actual: +2]
+ │    │    │    │    ├── limit hint: 50.00
+ │    │    │    │    ├── sort
+ │    │    │    │    │    ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11 s_symb:24!null s_name:27!null
+ │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    ├── fd: ()-->(6,24,27), (1)-->(2,4,5,7,9-11), (6)==(24), (24)==(6)
+ │    │    │    │    │    ├── ordering: +2 opt(6,24,27) [actual: +2]
+ │    │    │    │    │    └── inner-join (lookup trade@trade_t_s_symb_t_dts_idx)
+ │    │    │    │    │         ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11 s_symb:24!null s_name:27!null
+ │    │    │    │    │         ├── lookup expression
+ │    │    │    │    │         │    └── filters
+ │    │    │    │    │         │         ├── s_symb:24 = t_s_symb:6 [outer=(6,24), constraints=(/6: (/NULL - ]; /24: (/NULL - ]), fd=(6)==(24), (24)==(6)]
+ │    │    │    │    │         │         └── (t_dts:2 >= '2020-06-15 22:27:42.148484') AND (t_dts:2 <= '2020-06-20 22:27:42.148484') [outer=(2), constraints=(/2: [/'2020-06-15 22:27:42.148484' - /'2020-06-20 22:27:42.148484']; tight)]
+ │    │    │    │    │         ├── key: (1)
+ │    │    │    │    │         ├── fd: ()-->(6,24,27), (1)-->(2,4,5,7,9-11), (6)==(24), (24)==(6)
+ │    │    │    │    │         ├── scan security
+ │    │    │    │    │         │    ├── columns: s_symb:24!null s_name:27!null
+ │    │    │    │    │         │    ├── constraint: /24: [/'ROACH' - /'ROACH']
+ │    │    │    │    │         │    ├── cardinality: [0 - 1]
+ │    │    │    │    │         │    ├── key: ()
+ │    │    │    │    │         │    └── fd: ()-->(24,27)
+ │    │    │    │    │         └── filters
+ │    │    │    │    │              └── t_s_symb:6 = 'ROACH' [outer=(6), constraints=(/6: [/'ROACH' - /'ROACH']; tight), fd=()-->(6)]
+ │    │    │    │    └── filters (true)
+ │    │    │    └── 50
  │    │    └── filters (true)
  │    └── filters (true)
  └── projections
@@ -5447,40 +5452,47 @@ project
  │    │    ├── key: (1)
  │    │    ├── fd: ()-->(6,24,27), (1)-->(2,4,5,7,9-11,42-45), (18)-->(19), (4)==(18), (18)==(4), (6)==(24), (24)==(6), (42)-->(43-45)
  │    │    ├── ordering: +2 opt(6,24,27) [actual: +2]
- │    │    ├── top-k
+ │    │    ├── limit
  │    │    │    ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11 tt_id:18!null tt_name:19!null s_symb:24!null s_name:27!null
  │    │    │    ├── internal-ordering: +2 opt(6,24,27)
- │    │    │    ├── k: 50
  │    │    │    ├── cardinality: [0 - 50]
  │    │    │    ├── key: (1)
  │    │    │    ├── fd: ()-->(6,24,27), (1)-->(2,4,5,7,9-11), (18)-->(19), (4)==(18), (18)==(4), (6)==(24), (24)==(6)
  │    │    │    ├── ordering: +2 opt(6,24,27) [actual: +2]
- │    │    │    └── inner-join (lookup security)
- │    │    │         ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11 tt_id:18!null tt_name:19!null s_symb:24!null s_name:27!null
- │    │    │         ├── flags: force lookup join (into right side)
- │    │    │         ├── key columns: [6] = [24]
- │    │    │         ├── lookup columns are key
- │    │    │         ├── key: (1)
- │    │    │         ├── fd: ()-->(6,24,27), (1)-->(2,4,5,7,9-11), (18)-->(19), (4)==(18), (18)==(4), (6)==(24), (24)==(6)
- │    │    │         ├── inner-join (hash)
- │    │    │         │    ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11 tt_id:18!null tt_name:19!null
- │    │    │         │    ├── flags: force hash join (store right side)
- │    │    │         │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
- │    │    │         │    ├── key: (1)
- │    │    │         │    ├── fd: ()-->(6), (1)-->(2,4,5,7,9-11), (18)-->(19), (4)==(18), (18)==(4)
- │    │    │         │    ├── scan trade@trade_t_s_symb_t_dts_idx
- │    │    │         │    │    ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11
- │    │    │         │    │    ├── constraint: /6/2/1: [/'ROACH'/'2020-06-15 22:27:42.148484' - /'ROACH'/'2020-06-20 22:27:42.148484']
- │    │    │         │    │    ├── key: (1)
- │    │    │         │    │    └── fd: ()-->(6), (1)-->(2,4,5,7,9-11)
- │    │    │         │    ├── scan trade_type
- │    │    │         │    │    ├── columns: tt_id:18!null tt_name:19!null
- │    │    │         │    │    ├── key: (18)
- │    │    │         │    │    └── fd: (18)-->(19)
- │    │    │         │    └── filters
- │    │    │         │         └── tt_id:18 = t_tt_id:4 [outer=(4,18), constraints=(/4: (/NULL - ]; /18: (/NULL - ]), fd=(4)==(18), (18)==(4)]
- │    │    │         └── filters
- │    │    │              └── s_symb:24 = 'ROACH' [outer=(24), constraints=(/24: [/'ROACH' - /'ROACH']; tight), fd=()-->(24)]
+ │    │    │    ├── inner-join (lookup security)
+ │    │    │    │    ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11 tt_id:18!null tt_name:19!null s_symb:24!null s_name:27!null
+ │    │    │    │    ├── flags: force lookup join (into right side)
+ │    │    │    │    ├── key columns: [6] = [24]
+ │    │    │    │    ├── lookup columns are key
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    ├── fd: ()-->(6,24,27), (1)-->(2,4,5,7,9-11), (18)-->(19), (4)==(18), (18)==(4), (6)==(24), (24)==(6)
+ │    │    │    │    ├── ordering: +2 opt(6,24,27) [actual: +2]
+ │    │    │    │    ├── limit hint: 50.00
+ │    │    │    │    ├── sort
+ │    │    │    │    │    ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11 tt_id:18!null tt_name:19!null
+ │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    ├── fd: ()-->(6), (1)-->(2,4,5,7,9-11), (18)-->(19), (4)==(18), (18)==(4)
+ │    │    │    │    │    ├── ordering: +2 opt(6) [actual: +2]
+ │    │    │    │    │    └── inner-join (hash)
+ │    │    │    │    │         ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11 tt_id:18!null tt_name:19!null
+ │    │    │    │    │         ├── flags: force hash join (store right side)
+ │    │    │    │    │         ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ │    │    │    │    │         ├── key: (1)
+ │    │    │    │    │         ├── fd: ()-->(6), (1)-->(2,4,5,7,9-11), (18)-->(19), (4)==(18), (18)==(4)
+ │    │    │    │    │         ├── scan trade@trade_t_s_symb_t_dts_idx
+ │    │    │    │    │         │    ├── columns: t_id:1!null t_dts:2!null t_tt_id:4!null t_is_cash:5!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_trade_price:11
+ │    │    │    │    │         │    ├── constraint: /6/2/1: [/'ROACH'/'2020-06-15 22:27:42.148484' - /'ROACH'/'2020-06-20 22:27:42.148484']
+ │    │    │    │    │         │    ├── key: (1)
+ │    │    │    │    │         │    └── fd: ()-->(6), (1)-->(2,4,5,7,9-11)
+ │    │    │    │    │         ├── scan trade_type
+ │    │    │    │    │         │    ├── columns: tt_id:18!null tt_name:19!null
+ │    │    │    │    │         │    ├── key: (18)
+ │    │    │    │    │         │    └── fd: (18)-->(19)
+ │    │    │    │    │         └── filters
+ │    │    │    │    │              └── tt_id:18 = t_tt_id:4 [outer=(4,18), constraints=(/4: (/NULL - ]; /18: (/NULL - ]), fd=(4)==(18), (18)==(4)]
+ │    │    │    │    └── filters
+ │    │    │    │         └── s_symb:24 = 'ROACH' [outer=(24), constraints=(/24: [/'ROACH' - /'ROACH']; tight), fd=()-->(24)]
+ │    │    │    └── 50
  │    │    └── filters (true)
  │    └── filters (true)
  └── projections

--- a/pkg/sql/opt/xform/testdata/external/tpch-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpch-no-stats
@@ -1657,32 +1657,38 @@ sort
       │    ├── columns: ps_suppkey:2!null p_brand:11!null p_type:12!null p_size:13!null
       │    ├── grouping columns: ps_suppkey:2!null p_brand:11!null p_type:12!null p_size:13!null
       │    ├── key: (2,11-13)
-      │    └── anti-join (lookup supplier)
+      │    └── inner-join (lookup part)
       │         ├── columns: ps_partkey:1!null ps_suppkey:2!null p_partkey:8!null p_brand:11!null p_type:12!null p_size:13!null
-      │         ├── key columns: [2] = [19]
+      │         ├── key columns: [1] = [8]
       │         ├── lookup columns are key
       │         ├── key: (2,8)
       │         ├── fd: (8)-->(11-13), (1)==(8), (8)==(1)
-      │         ├── inner-join (lookup partsupp)
-      │         │    ├── columns: ps_partkey:1!null ps_suppkey:2!null p_partkey:8!null p_brand:11!null p_type:12!null p_size:13!null
-      │         │    ├── key columns: [8] = [1]
-      │         │    ├── key: (2,8)
-      │         │    ├── fd: (8)-->(11-13), (1)==(8), (8)==(1)
+      │         ├── anti-join (merge)
+      │         │    ├── columns: ps_partkey:1!null ps_suppkey:2!null
+      │         │    ├── left ordering: +2
+      │         │    ├── right ordering: +19
+      │         │    ├── key: (1,2)
+      │         │    ├── scan partsupp@ps_sk
+      │         │    │    ├── columns: ps_partkey:1!null ps_suppkey:2!null
+      │         │    │    ├── key: (1,2)
+      │         │    │    └── ordering: +2
       │         │    ├── select
-      │         │    │    ├── columns: p_partkey:8!null p_brand:11!null p_type:12!null p_size:13!null
-      │         │    │    ├── key: (8)
-      │         │    │    ├── fd: (8)-->(11-13)
-      │         │    │    ├── scan part
-      │         │    │    │    ├── columns: p_partkey:8!null p_brand:11!null p_type:12!null p_size:13!null
-      │         │    │    │    ├── key: (8)
-      │         │    │    │    └── fd: (8)-->(11-13)
+      │         │    │    ├── columns: s_suppkey:19!null s_comment:25!null
+      │         │    │    ├── key: (19)
+      │         │    │    ├── fd: (19)-->(25)
+      │         │    │    ├── ordering: +19
+      │         │    │    ├── scan supplier
+      │         │    │    │    ├── columns: s_suppkey:19!null s_comment:25!null
+      │         │    │    │    ├── key: (19)
+      │         │    │    │    ├── fd: (19)-->(25)
+      │         │    │    │    └── ordering: +19
       │         │    │    └── filters
-      │         │    │         ├── p_brand:11 != 'Brand#45' [outer=(11), constraints=(/11: (/NULL - /'Brand#45') [/e'Brand#45\x00' - ]; tight)]
-      │         │    │         ├── p_type:12 NOT LIKE 'MEDIUM POLISHED %' [outer=(12), constraints=(/12: (/NULL - ])]
-      │         │    │         └── p_size:13 IN (3, 9, 14, 19, 23, 36, 45, 49) [outer=(13), constraints=(/13: [/3 - /3] [/9 - /9] [/14 - /14] [/19 - /19] [/23 - /23] [/36 - /36] [/45 - /45] [/49 - /49]; tight)]
+      │         │    │         └── s_comment:25 LIKE '%Customer%Complaints%' [outer=(25), constraints=(/25: (/NULL - ])]
       │         │    └── filters (true)
       │         └── filters
-      │              └── s_comment:25 LIKE '%Customer%Complaints%' [outer=(25), constraints=(/25: (/NULL - ])]
+      │              ├── p_brand:11 != 'Brand#45' [outer=(11), constraints=(/11: (/NULL - /'Brand#45') [/e'Brand#45\x00' - ]; tight)]
+      │              ├── p_type:12 NOT LIKE 'MEDIUM POLISHED %' [outer=(12), constraints=(/12: (/NULL - ])]
+      │              └── p_size:13 IN (3, 9, 14, 19, 23, 36, 45, 49) [outer=(13), constraints=(/13: [/3 - /3] [/9 - /9] [/14 - /14] [/19 - /19] [/23 - /23] [/36 - /36] [/45 - /45] [/49 - /49]; tight)]
       └── aggregations
            └── count-rows [as=count:28]
 

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -558,23 +558,23 @@ project
       ├── key columns: [10] = [1]
       ├── lookup columns are key
       ├── immutable
-      ├── stats: [rows=1, distinct(1)=0.00191974, null(1)=0, avgsize(1)=4, distinct(10)=0.00191974, null(10)=0, avgsize(10)=4]
+      ├── stats: [rows=1, distinct(1)=0.0201621, null(1)=0, avgsize(1)=4, distinct(10)=0.0201621, null(10)=0, avgsize(10)=4]
       ├── key: (10)
       ├── fd: ()-->(9), (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(11-17), (17)-->(10-16), (1)==(10), (10)==(1)
       ├── index-join cardsinfo
       │    ├── columns: dealerid:9!null cardid:10!null buyprice:11!null sellprice:12!null discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null version:17!null
       │    ├── immutable
-      │    ├── stats: [rows=0.001919738, distinct(9)=0.00191974, null(9)=0, avgsize(9)=4, distinct(10)=0.00191974, null(10)=0, avgsize(10)=4, distinct(11)=0.00191974, null(11)=0, avgsize(11)=4, distinct(12)=0.00191974, null(12)=0, avgsize(12)=4, distinct(13)=0.00191974, null(13)=0, avgsize(13)=4, distinct(14)=0.00191974, null(14)=0, avgsize(14)=4, distinct(15)=0.00191974, null(15)=0, avgsize(15)=4, distinct(16)=0.00191974, null(16)=0, avgsize(16)=4, distinct(17)=0.00191974, null(17)=0, avgsize(17)=4]
-      │    │   histogram(17)=  0                0                 0.0019197           0
-      │    │                 <--- 1584421773604892000.0000000000 ----------- 1584421778604892000
+      │    ├── stats: [rows=0.02016214, distinct(9)=0.0201621, null(9)=0, avgsize(9)=4, distinct(10)=0.0201621, null(10)=0, avgsize(10)=4, distinct(11)=0.0201621, null(11)=0, avgsize(11)=4, distinct(12)=0.0201621, null(12)=0, avgsize(12)=4, distinct(13)=0.0201621, null(13)=0, avgsize(13)=4, distinct(14)=0.0201621, null(14)=0, avgsize(14)=4, distinct(15)=0.0201621, null(15)=0, avgsize(15)=4, distinct(16)=0.0201621, null(16)=0, avgsize(16)=4, distinct(17)=0.0201621, null(17)=0, avgsize(17)=4, distinct(9,17)=0.0201621, null(9,17)=0, avgsize(9,17)=8]
+      │    │   histogram(17)=  0                0                 0.020162           0
+      │    │                 <--- 1584421773604892000.0000000000 ---------- 1584421778604892000
       │    ├── key: (10)
       │    ├── fd: ()-->(9), (10)-->(11-17), (17)-->(10-16)
       │    └── scan cardsinfo@cardsinfoversionindex
       │         ├── columns: dealerid:9!null cardid:10!null version:17!null
       │         ├── constraint: /9/17: (/1/1584421773604892000.0000000000 - /1]
-      │         ├── stats: [rows=0.001919738, distinct(9)=0.00191974, null(9)=0, avgsize(9)=4, distinct(10)=0.00191974, null(10)=0, avgsize(10)=4, distinct(17)=0.00191974, null(17)=0, avgsize(17)=4]
-      │         │   histogram(17)=  0                0                 0.0019197           0
-      │         │                 <--- 1584421773604892000.0000000000 ----------- 1584421778604892000
+      │         ├── stats: [rows=0.02016214, distinct(9)=0.0201621, null(9)=0, avgsize(9)=4, distinct(10)=0.0201621, null(10)=0, avgsize(10)=4, distinct(17)=0.0201621, null(17)=0, avgsize(17)=4, distinct(9,17)=0.0201621, null(9,17)=0, avgsize(9,17)=8]
+      │         │   histogram(17)=  0                0                 0.020162           0
+      │         │                 <--- 1584421773604892000.0000000000 ---------- 1584421778604892000
       │         ├── key: (10)
       │         └── fd: ()-->(9), (10)-->(17), (17)-->(10)
       └── filters (true)
@@ -825,7 +825,7 @@ project
  │         │    ├── left ordering: +1
  │         │    ├── right ordering: +10
  │         │    ├── immutable
- │         │    ├── stats: [rows=519622.1, distinct(10)=19000, null(10)=0, avgsize(10)=4, distinct(23)=19000, null(23)=0, avgsize(23)=4]
+ │         │    ├── stats: [rows=659920.1, distinct(10)=19000, null(10)=0, avgsize(10)=4, distinct(23)=19000, null(23)=0, avgsize(23)=4]
  │         │    ├── key: (10,22-24)
  │         │    ├── fd: ()-->(9), (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(11-17), (17)-->(10-16), (1)==(10), (10)==(1), (10,22-24)-->(20,21)
  │         │    ├── ordering: +(1|10) opt(9) [actual: +1]
@@ -838,7 +838,7 @@ project
  │         │    │    │         ├── NOT isbuy:21 [outer=(21), constraints=(/21: [/false - /false]; tight), fd=()-->(21)]
  │         │    │    │         └── (transactiondate:22 >= '2020-02-28 00:00:00+00:00') AND (transactiondate:22 <= '2020-03-01 00:00:00+00:00') [outer=(22), constraints=(/22: [/'2020-02-28 00:00:00+00:00' - /'2020-03-01 00:00:00+00:00']; tight)]
  │         │    │    ├── immutable
- │         │    │    ├── stats: [rows=333333.3, distinct(1)=19000, null(1)=0, avgsize(1)=4, distinct(2)=13000, null(2)=0, avgsize(2)=4, distinct(5)=829, null(5)=0, avgsize(5)=4, distinct(6)=5601.15, null(6)=0, avgsize(6)=4, distinct(23)=19000, null(23)=0, avgsize(23)=4]
+ │         │    │    ├── stats: [rows=423333.3, distinct(1)=19000, null(1)=0, avgsize(1)=4, distinct(2)=13000, null(2)=0, avgsize(2)=4, distinct(5)=829, null(5)=0, avgsize(5)=4, distinct(6)=5601.15, null(6)=0, avgsize(6)=4, distinct(23)=19000, null(23)=0, avgsize(23)=4]
  │         │    │    ├── key: (1,22-24)
  │         │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6), (1,22-24)-->(20,21)
  │         │    │    ├── ordering: +1
@@ -945,7 +945,7 @@ ORDER BY extract(day from d.TransactionDate)
 sort
  ├── columns: extract:45 totalsell:40!null totalbuy:42!null totalprofit:44!null
  ├── stable
- ├── stats: [rows=9748.52, distinct(45)=9748.52, null(45)=0, avgsize(45)=4]
+ ├── stats: [rows=82395.87, distinct(45)=82395.9, null(45)=0, avgsize(45)=4]
  ├── key: (45)
  ├── fd: (45)-->(40,42,44)
  ├── ordering: +45
@@ -953,69 +953,70 @@ sort
       ├── columns: sum:40!null sum:42!null sum:44!null column45:45
       ├── grouping columns: column45:45
       ├── stable
-      ├── stats: [rows=9748.52, distinct(45)=9748.52, null(45)=0, avgsize(45)=4]
+      ├── stats: [rows=82395.87, distinct(45)=82395.9, null(45)=0, avgsize(45)=4]
       ├── key: (45)
       ├── fd: (45)-->(40,42,44)
       ├── project
       │    ├── columns: column39:39!null column41:41!null column43:43!null column45:45
       │    ├── stable
-      │    ├── stats: [rows=19245.27, distinct(45)=9748.52, null(45)=0, avgsize(45)=4]
+      │    ├── stats: [rows=139576.9, distinct(45)=82395.9, null(45)=0, avgsize(45)=4]
       │    ├── inner-join (hash)
       │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null transactiondetails.cardid:4!null quantity:5!null transactiondetails.sellprice:6!null transactiondetails.buyprice:7!null transactions.dealerid:11!null transactions.isbuy:12!null date:13!null accountname:14!null customername:15!null id:20!null cardsinfo.dealerid:28!null cardsinfo.cardid:29!null
-      │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
-      │    │    ├── stats: [rows=19245.27, distinct(3)=9748.52, null(3)=0, avgsize(3)=4, distinct(4)=11100.2, null(4)=0, avgsize(4)=4, distinct(20)=11100.2, null(20)=0, avgsize(20)=4]
+      │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+      │    │    ├── stats: [rows=139576.9, distinct(3)=82395.9, null(3)=0, avgsize(3)=4, distinct(4)=37420.4, null(4)=0, avgsize(4)=4, distinct(20)=37420.4, null(20)=0, avgsize(20)=4]
       │    │    ├── key: (5,13,29)
       │    │    ├── fd: ()-->(1,2,11,12,28), (3-5)-->(6,7), (13)-->(14,15), (3)==(13), (13)==(3), (20)==(4,29), (29)==(4,20), (4)==(20,29)
-      │    │    ├── scan cardsinfo@cardsinfoversionindex
-      │    │    │    ├── columns: cardsinfo.dealerid:28!null cardsinfo.cardid:29!null
-      │    │    │    ├── constraint: /28/36: [/1 - /1]
-      │    │    │    ├── stats: [rows=58333.33, distinct(28)=1, null(28)=0, avgsize(28)=4, distinct(29)=37420.4, null(29)=0, avgsize(29)=4]
-      │    │    │    ├── key: (29)
-      │    │    │    └── fd: ()-->(28)
+      │    │    ├── inner-join (merge)
+      │    │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null transactiondetails.cardid:4!null quantity:5!null transactiondetails.sellprice:6!null transactiondetails.buyprice:7!null transactions.dealerid:11!null transactions.isbuy:12!null date:13!null accountname:14!null customername:15!null
+      │    │    │    ├── left ordering: +3
+      │    │    │    ├── right ordering: +13
+      │    │    │    ├── stats: [rows=119679, distinct(1)=1, null(1)=0, avgsize(1)=4, distinct(2)=1, null(2)=0, avgsize(2)=4, distinct(3)=119679, null(3)=0, avgsize(3)=4, distinct(4)=50017.4, null(4)=0, avgsize(4)=4, distinct(5)=114043, null(5)=0, avgsize(5)=4, distinct(6)=114043, null(6)=0, avgsize(6)=4, distinct(7)=114043, null(7)=0, avgsize(7)=4, distinct(11)=1, null(11)=0, avgsize(11)=4, distinct(12)=1, null(12)=0, avgsize(12)=4, distinct(13)=119679, null(13)=0, avgsize(13)=4, distinct(14)=75651.6, null(14)=0, avgsize(14)=4, distinct(15)=75651.6, null(15)=0, avgsize(15)=4]
+      │    │    │    ├── key: (4,5,13)
+      │    │    │    ├── fd: ()-->(1,2,11,12), (3-5)-->(6,7), (13)-->(14,15), (3)==(13), (13)==(3)
+      │    │    │    ├── scan transactiondetails
+      │    │    │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null transactiondetails.cardid:4!null quantity:5!null transactiondetails.sellprice:6!null transactiondetails.buyprice:7!null
+      │    │    │    │    ├── constraint: /1/2/3/4/5: [/1/false/'2020-02-23 00:00:00+00:00' - /1/false/'2020-03-01 00:00:00+00:00']
+      │    │    │    │    ├── stats: [rows=1270000, distinct(1)=1, null(1)=0, avgsize(1)=4, distinct(2)=1, null(2)=0, avgsize(2)=4, distinct(3)=1.27e+06, null(3)=0, avgsize(3)=4, distinct(4)=57000, null(4)=0, avgsize(4)=4, distinct(5)=1.23043e+06, null(5)=0, avgsize(5)=4, distinct(6)=1.23043e+06, null(6)=0, avgsize(6)=4, distinct(7)=1.23043e+06, null(7)=0, avgsize(7)=4, distinct(1,2)=1, null(1,2)=0, avgsize(1,2)=8, distinct(1-3)=1.27e+06, null(1-3)=0, avgsize(1-3)=12]
+      │    │    │    │    ├── key: (3-5)
+      │    │    │    │    ├── fd: ()-->(1,2), (3-5)-->(6,7)
+      │    │    │    │    └── ordering: +3 opt(1,2) [actual: +3]
+      │    │    │    ├── select
+      │    │    │    │    ├── columns: transactions.dealerid:11!null transactions.isbuy:12!null date:13!null accountname:14!null customername:15!null
+      │    │    │    │    ├── stats: [rows=119679, distinct(11)=1, null(11)=0, avgsize(11)=4, distinct(12)=1, null(12)=0, avgsize(12)=4, distinct(13)=119679, null(13)=0, avgsize(13)=4, distinct(14)=119679, null(14)=0, avgsize(14)=4, distinct(15)=119679, null(15)=0, avgsize(15)=4, distinct(11,12)=1, null(11,12)=0, avgsize(11,12)=8, distinct(13-15)=119679, null(13-15)=0, avgsize(13-15)=12, distinct(11-15)=119679, null(11-15)=0, avgsize(11-15)=20]
+      │    │    │    │    ├── key: (13)
+      │    │    │    │    ├── fd: ()-->(11,12), (13)-->(14,15)
+      │    │    │    │    ├── ordering: +13 opt(11,12) [actual: +13]
+      │    │    │    │    ├── scan transactions
+      │    │    │    │    │    ├── columns: transactions.dealerid:11!null transactions.isbuy:12!null date:13!null accountname:14!null customername:15!null
+      │    │    │    │    │    ├── constraint: /11/12/13: [/1/false/'2020-02-23 00:00:00+00:00' - /1/false/'2020-03-01 00:00:00+00:00']
+      │    │    │    │    │    ├── stats: [rows=141111.1, distinct(11)=1, null(11)=0, avgsize(11)=4, distinct(12)=1, null(12)=0, avgsize(12)=4, distinct(13)=141111, null(13)=0, avgsize(13)=4, distinct(11,12)=1, null(11,12)=0, avgsize(11,12)=8, distinct(11-13)=141111, null(11-13)=0, avgsize(11-13)=12]
+      │    │    │    │    │    ├── key: (13)
+      │    │    │    │    │    ├── fd: ()-->(11,12), (13)-->(14,15)
+      │    │    │    │    │    └── ordering: +13 opt(11,12) [actual: +13]
+      │    │    │    │    └── filters
+      │    │    │    │         ├── accountname:14 != 'someaccount' [outer=(14), constraints=(/14: (/NULL - /'someaccount') [/e'someaccount\x00' - ]; tight)]
+      │    │    │    │         └── customername:15 != 'somecustomer' [outer=(15), constraints=(/15: (/NULL - /'somecustomer') [/e'somecustomer\x00' - ]; tight)]
+      │    │    │    └── filters (true)
       │    │    ├── inner-join (hash)
-      │    │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null transactiondetails.cardid:4!null quantity:5!null transactiondetails.sellprice:6!null transactiondetails.buyprice:7!null transactions.dealerid:11!null transactions.isbuy:12!null date:13!null accountname:14!null customername:15!null id:20!null
-      │    │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(exactly-one)
-      │    │    │    ├── stats: [rows=19530.48, distinct(1)=1, null(1)=0, avgsize(1)=4, distinct(2)=1, null(2)=0, avgsize(2)=4, distinct(3)=12345.7, null(3)=0, avgsize(3)=4, distinct(4)=16536.1, null(4)=0, avgsize(4)=4, distinct(5)=19228.7, null(5)=0, avgsize(5)=4, distinct(6)=19228.7, null(6)=0, avgsize(6)=4, distinct(7)=19228.7, null(7)=0, avgsize(7)=4, distinct(11)=1, null(11)=0, avgsize(11)=4, distinct(12)=1, null(12)=0, avgsize(12)=4, distinct(13)=12345.7, null(13)=0, avgsize(13)=4, distinct(14)=9807.78, null(14)=0, avgsize(14)=4, distinct(15)=9807.78, null(15)=0, avgsize(15)=4, distinct(20)=16536.1, null(20)=0, avgsize(20)=4]
-      │    │    │    ├── key: (5,13,20)
-      │    │    │    ├── fd: ()-->(1,2,11,12), (13)-->(14,15), (3-5)-->(6,7), (4)==(20), (20)==(4), (3)==(13), (13)==(3)
+      │    │    │    ├── columns: id:20!null cardsinfo.dealerid:28!null cardsinfo.cardid:29!null
+      │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+      │    │    │    ├── stats: [rows=58333.33, distinct(20)=37420.4, null(20)=0, avgsize(20)=4, distinct(28)=1, null(28)=0, avgsize(28)=4, distinct(29)=37420.4, null(29)=0, avgsize(29)=4]
+      │    │    │    ├── key: (29)
+      │    │    │    ├── fd: ()-->(28), (20)==(29), (29)==(20)
+      │    │    │    ├── scan cardsinfo@cardsinfoversionindex
+      │    │    │    │    ├── columns: cardsinfo.dealerid:28!null cardsinfo.cardid:29!null
+      │    │    │    │    ├── constraint: /28/36: [/1 - /1]
+      │    │    │    │    ├── stats: [rows=58333.33, distinct(28)=1, null(28)=0, avgsize(28)=4, distinct(29)=37420.4, null(29)=0, avgsize(29)=4]
+      │    │    │    │    ├── key: (29)
+      │    │    │    │    └── fd: ()-->(28)
       │    │    │    ├── scan cards@cardsnamesetnumber
       │    │    │    │    ├── columns: id:20!null
       │    │    │    │    ├── stats: [rows=57000, distinct(20)=57000, null(20)=0, avgsize(20)=4]
       │    │    │    │    └── key: (20)
-      │    │    │    ├── inner-join (lookup transactiondetails)
-      │    │    │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null transactiondetails.cardid:4!null quantity:5!null transactiondetails.sellprice:6!null transactiondetails.buyprice:7!null transactions.dealerid:11!null transactions.isbuy:12!null date:13!null accountname:14!null customername:15!null
-      │    │    │    │    ├── key columns: [52 53 13] = [1 2 3]
-      │    │    │    │    ├── stats: [rows=12345.68, distinct(1)=1, null(1)=0, avgsize(1)=4, distinct(2)=1, null(2)=0, avgsize(2)=4, distinct(3)=12345.7, null(3)=0, avgsize(3)=4, distinct(4)=11100.2, null(4)=0, avgsize(4)=4, distinct(5)=12267.9, null(5)=0, avgsize(5)=4, distinct(6)=12267.9, null(6)=0, avgsize(6)=4, distinct(7)=12267.9, null(7)=0, avgsize(7)=4, distinct(11)=1, null(11)=0, avgsize(11)=4, distinct(12)=1, null(12)=0, avgsize(12)=4, distinct(13)=12345.7, null(13)=0, avgsize(13)=4, distinct(14)=7803.96, null(14)=0, avgsize(14)=4, distinct(15)=7803.96, null(15)=0, avgsize(15)=4]
-      │    │    │    │    ├── key: (4,5,13)
-      │    │    │    │    ├── fd: ()-->(1,2,11,12), (3-5)-->(6,7), (13)-->(14,15), (3)==(13), (13)==(3)
-      │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: "lookup_join_const_col_@2":53!null "lookup_join_const_col_@1":52!null transactions.dealerid:11!null transactions.isbuy:12!null date:13!null accountname:14!null customername:15!null
-      │    │    │    │    │    ├── stats: [rows=12345.68, distinct(11)=1, null(11)=0, avgsize(11)=4, distinct(12)=1, null(12)=0, avgsize(12)=4, distinct(13)=12345.7, null(13)=0, avgsize(13)=4, distinct(14)=12345.7, null(14)=0, avgsize(14)=4, distinct(15)=12345.7, null(15)=0, avgsize(15)=4, distinct(52)=1, null(52)=0, avgsize(52)=4, distinct(53)=1, null(53)=0, avgsize(53)=4]
-      │    │    │    │    │    ├── key: (13)
-      │    │    │    │    │    ├── fd: ()-->(11,12,52,53), (13)-->(14,15)
-      │    │    │    │    │    ├── select
-      │    │    │    │    │    │    ├── columns: transactions.dealerid:11!null transactions.isbuy:12!null date:13!null accountname:14!null customername:15!null
-      │    │    │    │    │    │    ├── stats: [rows=12345.68, distinct(11)=1, null(11)=0, avgsize(11)=4, distinct(12)=1, null(12)=0, avgsize(12)=4, distinct(13)=12345.7, null(13)=0, avgsize(13)=4, distinct(14)=12345.7, null(14)=0, avgsize(14)=4, distinct(15)=12345.7, null(15)=0, avgsize(15)=4]
-      │    │    │    │    │    │    ├── key: (13)
-      │    │    │    │    │    │    ├── fd: ()-->(11,12), (13)-->(14,15)
-      │    │    │    │    │    │    ├── scan transactions
-      │    │    │    │    │    │    │    ├── columns: transactions.dealerid:11!null transactions.isbuy:12!null date:13!null accountname:14!null customername:15!null
-      │    │    │    │    │    │    │    ├── constraint: /11/12/13: [/1/false/'2020-02-23 00:00:00+00:00' - /1/false/'2020-03-01 00:00:00+00:00']
-      │    │    │    │    │    │    │    ├── stats: [rows=111111.1, distinct(11)=1, null(11)=0, avgsize(11)=4, distinct(12)=1, null(12)=0, avgsize(12)=4, distinct(13)=111111, null(13)=0, avgsize(13)=4]
-      │    │    │    │    │    │    │    ├── key: (13)
-      │    │    │    │    │    │    │    └── fd: ()-->(11,12), (13)-->(14,15)
-      │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │         ├── accountname:14 != 'someaccount' [outer=(14), constraints=(/14: (/NULL - /'someaccount') [/e'someaccount\x00' - ]; tight)]
-      │    │    │    │    │    │         └── customername:15 != 'somecustomer' [outer=(15), constraints=(/15: (/NULL - /'somecustomer') [/e'somecustomer\x00' - ]; tight)]
-      │    │    │    │    │    └── projections
-      │    │    │    │    │         ├── false [as="lookup_join_const_col_@2":53]
-      │    │    │    │    │         └── 1 [as="lookup_join_const_col_@1":52]
-      │    │    │    │    └── filters
-      │    │    │    │         └── (transactiondate:3 >= '2020-02-23 00:00:00+00:00') AND (transactiondate:3 <= '2020-03-01 00:00:00+00:00') [outer=(3), constraints=(/3: [/'2020-02-23 00:00:00+00:00' - /'2020-03-01 00:00:00+00:00']; tight)]
       │    │    │    └── filters
-      │    │    │         └── id:20 = transactiondetails.cardid:4 [outer=(4,20), constraints=(/4: (/NULL - ]; /20: (/NULL - ]), fd=(4)==(20), (20)==(4)]
+      │    │    │         └── id:20 = cardsinfo.cardid:29 [outer=(20,29), constraints=(/20: (/NULL - ]; /29: (/NULL - ]), fd=(20)==(29), (29)==(20)]
       │    │    └── filters
-      │    │         └── id:20 = cardsinfo.cardid:29 [outer=(20,29), constraints=(/20: (/NULL - ]; /29: (/NULL - ]), fd=(20)==(29), (29)==(20)]
+      │    │         └── id:20 = transactiondetails.cardid:4 [outer=(4,20), constraints=(/4: (/NULL - ]; /20: (/NULL - ]), fd=(4)==(20), (20)==(4)]
       │    └── projections
       │         ├── quantity:5 * transactiondetails.sellprice:6::DECIMAL [as=column39:39, outer=(5,6), immutable]
       │         ├── quantity:5 * transactiondetails.buyprice:7::DECIMAL [as=column41:41, outer=(5,7), immutable]
@@ -1184,38 +1185,46 @@ values
            │         ├── cardinality: [1 - 1]
            │         ├── key: ()
            │         ├── fd: ()-->(20)
-           │         ├── top-k
+           │         ├── limit
            │         │    ├── columns: d.dealerid:1!null d.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null t.dealerid:11!null t.isbuy:12!null date:13!null
            │         │    ├── internal-ordering: -(3|13) opt(4)
-           │         │    ├── k: 100
            │         │    ├── cardinality: [0 - 100]
            │         │    ├── key: (5,11-13)
            │         │    ├── fd: ()-->(4), (1)==(11), (11)==(1), (2)==(12), (12)==(2), (3)==(13), (13)==(3)
-           │         │    └── inner-join (lookup transactions [as=t])
-           │         │         ├── columns: d.dealerid:1!null d.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null t.dealerid:11!null t.isbuy:12!null date:13!null
-           │         │         ├── key columns: [1 2 3] = [11 12 13]
-           │         │         ├── lookup columns are key
-           │         │         ├── key: (5,11-13)
-           │         │         ├── fd: ()-->(4), (1)==(11), (11)==(1), (2)==(12), (12)==(2), (3)==(13), (13)==(3)
-           │         │         ├── scan transactiondetails@detailscardidindex [as=d]
-           │         │         │    ├── columns: d.dealerid:1!null d.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null
-           │         │         │    ├── constraint: /1/2/4/3/5
-           │         │         │    │    ├── [/1/false/19483/'2020-02-28 00:00:00+00:00' - /1/false/19483/'2020-03-01 00:00:00+00:00']
-           │         │         │    │    ├── [/1/true/19483/'2020-02-28 00:00:00+00:00' - /1/true/19483/'2020-03-01 00:00:00+00:00']
-           │         │         │    │    ├── [/2/false/19483/'2020-02-28 00:00:00+00:00' - /2/false/19483/'2020-03-01 00:00:00+00:00']
-           │         │         │    │    ├── [/2/true/19483/'2020-02-28 00:00:00+00:00' - /2/true/19483/'2020-03-01 00:00:00+00:00']
-           │         │         │    │    ├── [/3/false/19483/'2020-02-28 00:00:00+00:00' - /3/false/19483/'2020-03-01 00:00:00+00:00']
-           │         │         │    │    ├── [/3/true/19483/'2020-02-28 00:00:00+00:00' - /3/true/19483/'2020-03-01 00:00:00+00:00']
-           │         │         │    │    ├── [/4/false/19483/'2020-02-28 00:00:00+00:00' - /4/false/19483/'2020-03-01 00:00:00+00:00']
-           │         │         │    │    ├── [/4/true/19483/'2020-02-28 00:00:00+00:00' - /4/true/19483/'2020-03-01 00:00:00+00:00']
-           │         │         │    │    ├── [/5/false/19483/'2020-02-28 00:00:00+00:00' - /5/false/19483/'2020-03-01 00:00:00+00:00']
-           │         │         │    │    └── [/5/true/19483/'2020-02-28 00:00:00+00:00' - /5/true/19483/'2020-03-01 00:00:00+00:00']
-           │         │         │    ├── key: (1-3,5)
-           │         │         │    └── fd: ()-->(4)
-           │         │         └── filters
-           │         │              ├── (date:13 >= '2020-02-28 00:00:00+00:00') AND (date:13 <= '2020-03-01 00:00:00+00:00') [outer=(13), constraints=(/13: [/'2020-02-28 00:00:00+00:00' - /'2020-03-01 00:00:00+00:00']; tight)]
-           │         │              ├── ((((t.dealerid:11 = 1) OR (t.dealerid:11 = 2)) OR (t.dealerid:11 = 3)) OR (t.dealerid:11 = 4)) OR (t.dealerid:11 = 5) [outer=(11), constraints=(/11: [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5]; tight)]
-           │         │              └── t.isbuy:12 IN (false, true) [outer=(12), constraints=(/12: [/false - /false] [/true - /true]; tight)]
+           │         │    ├── inner-join (lookup transactions [as=t])
+           │         │    │    ├── columns: d.dealerid:1!null d.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null t.dealerid:11!null t.isbuy:12!null date:13!null
+           │         │    │    ├── key columns: [1 2 3] = [11 12 13]
+           │         │    │    ├── lookup columns are key
+           │         │    │    ├── key: (5,11-13)
+           │         │    │    ├── fd: ()-->(4), (1)==(11), (11)==(1), (2)==(12), (12)==(2), (3)==(13), (13)==(3)
+           │         │    │    ├── ordering: -(3|13) opt(4) [actual: -3]
+           │         │    │    ├── limit hint: 100.00
+           │         │    │    ├── sort
+           │         │    │    │    ├── columns: d.dealerid:1!null d.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null
+           │         │    │    │    ├── key: (1-3,5)
+           │         │    │    │    ├── fd: ()-->(4)
+           │         │    │    │    ├── ordering: -3 opt(4) [actual: -3]
+           │         │    │    │    ├── limit hint: 1100.00
+           │         │    │    │    └── scan transactiondetails@detailscardidindex [as=d]
+           │         │    │    │         ├── columns: d.dealerid:1!null d.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null
+           │         │    │    │         ├── constraint: /1/2/4/3/5
+           │         │    │    │         │    ├── [/1/false/19483/'2020-02-28 00:00:00+00:00' - /1/false/19483/'2020-03-01 00:00:00+00:00']
+           │         │    │    │         │    ├── [/1/true/19483/'2020-02-28 00:00:00+00:00' - /1/true/19483/'2020-03-01 00:00:00+00:00']
+           │         │    │    │         │    ├── [/2/false/19483/'2020-02-28 00:00:00+00:00' - /2/false/19483/'2020-03-01 00:00:00+00:00']
+           │         │    │    │         │    ├── [/2/true/19483/'2020-02-28 00:00:00+00:00' - /2/true/19483/'2020-03-01 00:00:00+00:00']
+           │         │    │    │         │    ├── [/3/false/19483/'2020-02-28 00:00:00+00:00' - /3/false/19483/'2020-03-01 00:00:00+00:00']
+           │         │    │    │         │    ├── [/3/true/19483/'2020-02-28 00:00:00+00:00' - /3/true/19483/'2020-03-01 00:00:00+00:00']
+           │         │    │    │         │    ├── [/4/false/19483/'2020-02-28 00:00:00+00:00' - /4/false/19483/'2020-03-01 00:00:00+00:00']
+           │         │    │    │         │    ├── [/4/true/19483/'2020-02-28 00:00:00+00:00' - /4/true/19483/'2020-03-01 00:00:00+00:00']
+           │         │    │    │         │    ├── [/5/false/19483/'2020-02-28 00:00:00+00:00' - /5/false/19483/'2020-03-01 00:00:00+00:00']
+           │         │    │    │         │    └── [/5/true/19483/'2020-02-28 00:00:00+00:00' - /5/true/19483/'2020-03-01 00:00:00+00:00']
+           │         │    │    │         ├── key: (1-3,5)
+           │         │    │    │         └── fd: ()-->(4)
+           │         │    │    └── filters
+           │         │    │         ├── (date:13 >= '2020-02-28 00:00:00+00:00') AND (date:13 <= '2020-03-01 00:00:00+00:00') [outer=(13), constraints=(/13: [/'2020-02-28 00:00:00+00:00' - /'2020-03-01 00:00:00+00:00']; tight)]
+           │         │    │         ├── ((((t.dealerid:11 = 1) OR (t.dealerid:11 = 2)) OR (t.dealerid:11 = 3)) OR (t.dealerid:11 = 4)) OR (t.dealerid:11 = 5) [outer=(11), constraints=(/11: [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5]; tight)]
+           │         │    │         └── t.isbuy:12 IN (false, true) [outer=(12), constraints=(/12: [/false - /false] [/true - /true]; tight)]
+           │         │    └── 100
            │         └── aggregations
            │              └── sum [as=sum:20, outer=(5)]
            │                   └── quantity:5

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -572,14 +572,14 @@ project
       ├── index-join cardsinfo
       │    ├── columns: dealerid:9!null cardid:10!null buyprice:11!null sellprice:12!null discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null version:17!null
       │    ├── immutable
-      │    ├── stats: [rows=0.00014, distinct(9)=0.00014, null(9)=0, avgsize(9)=4, distinct(10)=0.00014, null(10)=0, avgsize(10)=4, distinct(11)=0.00014, null(11)=0, avgsize(11)=4, distinct(12)=0.00014, null(12)=0, avgsize(12)=4, distinct(13)=0.00014, null(13)=0, avgsize(13)=4, distinct(14)=0.00014, null(14)=0, avgsize(14)=4, distinct(15)=0.00014, null(15)=0, avgsize(15)=4, distinct(16)=0.00014, null(16)=0, avgsize(16)=4, distinct(17)=0.00014, null(17)=0, avgsize(17)=4]
+      │    ├── stats: [rows=0.00014, distinct(9)=0.00014, null(9)=0, avgsize(9)=4, distinct(10)=0.00014, null(10)=0, avgsize(10)=4, distinct(11)=0.00014, null(11)=0, avgsize(11)=4, distinct(12)=0.00014, null(12)=0, avgsize(12)=4, distinct(13)=0.00014, null(13)=0, avgsize(13)=4, distinct(14)=0.00014, null(14)=0, avgsize(14)=4, distinct(15)=0.00014, null(15)=0, avgsize(15)=4, distinct(16)=0.00014, null(16)=0, avgsize(16)=4, distinct(17)=0.00014, null(17)=0, avgsize(17)=4, distinct(9,17)=0.00014, null(9,17)=0, avgsize(9,17)=8]
       │    │   histogram(17)=
       │    ├── key: (10)
       │    ├── fd: ()-->(9), (10)-->(11-17), (17)-->(10-16)
       │    └── scan cardsinfo@cardsinfoversionindex
       │         ├── columns: dealerid:9!null cardid:10!null version:17!null
       │         ├── constraint: /9/17: (/1/1584421773604892000.0000000000 - /1]
-      │         ├── stats: [rows=0.00014, distinct(9)=0.00014, null(9)=0, avgsize(9)=4, distinct(10)=0.00014, null(10)=0, avgsize(10)=4, distinct(17)=0.00014, null(17)=0, avgsize(17)=4]
+      │         ├── stats: [rows=0.00014, distinct(9)=0.00014, null(9)=0, avgsize(9)=4, distinct(10)=0.00014, null(10)=0, avgsize(10)=4, distinct(17)=0.00014, null(17)=0, avgsize(17)=4, distinct(9,17)=0.00014, null(9,17)=0, avgsize(9,17)=8]
       │         │   histogram(17)=
       │         ├── key: (10)
       │         └── fd: ()-->(9), (10)-->(17), (17)-->(10)
@@ -829,7 +829,7 @@ project
  │         │    ├── left ordering: +1
  │         │    ├── right ordering: +10
  │         │    ├── immutable
- │         │    ├── stats: [rows=519622.1, distinct(10)=19000, null(10)=0, avgsize(10)=4, distinct(27)=19000, null(27)=0, avgsize(27)=4]
+ │         │    ├── stats: [rows=659920.1, distinct(10)=19000, null(10)=0, avgsize(10)=4, distinct(27)=19000, null(27)=0, avgsize(27)=4]
  │         │    ├── key: (10,26-28)
  │         │    ├── fd: ()-->(9), (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(11-17), (17)-->(10-16), (1)==(10), (10)==(1), (10,26-28)-->(24,25)
  │         │    ├── ordering: +(1|10) opt(9) [actual: +1]
@@ -842,7 +842,7 @@ project
  │         │    │    │         ├── NOT isbuy:25 [outer=(25), constraints=(/25: [/false - /false]; tight), fd=()-->(25)]
  │         │    │    │         └── (transactiondate:26 >= '2020-02-28 00:00:00+00:00') AND (transactiondate:26 <= '2020-03-01 00:00:00+00:00') [outer=(26), constraints=(/26: [/'2020-02-28 00:00:00+00:00' - /'2020-03-01 00:00:00+00:00']; tight)]
  │         │    │    ├── immutable
- │         │    │    ├── stats: [rows=333333.3, distinct(1)=19000, null(1)=0, avgsize(1)=4, distinct(2)=13000, null(2)=0, avgsize(2)=4, distinct(5)=829, null(5)=0, avgsize(5)=4, distinct(6)=5601.15, null(6)=0, avgsize(6)=4, distinct(27)=19000, null(27)=0, avgsize(27)=4]
+ │         │    │    ├── stats: [rows=423333.3, distinct(1)=19000, null(1)=0, avgsize(1)=4, distinct(2)=13000, null(2)=0, avgsize(2)=4, distinct(5)=829, null(5)=0, avgsize(5)=4, distinct(6)=5601.15, null(6)=0, avgsize(6)=4, distinct(27)=19000, null(27)=0, avgsize(27)=4]
  │         │    │    ├── key: (1,26-28)
  │         │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6), (1,26-28)-->(24,25)
  │         │    │    ├── ordering: +1
@@ -949,7 +949,7 @@ ORDER BY extract(day from d.TransactionDate)
 sort
  ├── columns: extract:53 totalsell:48!null totalbuy:50!null totalprofit:52!null
  ├── stable
- ├── stats: [rows=9748.52, distinct(53)=9748.52, null(53)=0, avgsize(53)=4]
+ ├── stats: [rows=82395.87, distinct(53)=82395.9, null(53)=0, avgsize(53)=4]
  ├── key: (53)
  ├── fd: (53)-->(48,50,52)
  ├── ordering: +53
@@ -957,69 +957,70 @@ sort
       ├── columns: sum:48!null sum:50!null sum:52!null column53:53
       ├── grouping columns: column53:53
       ├── stable
-      ├── stats: [rows=9748.52, distinct(53)=9748.52, null(53)=0, avgsize(53)=4]
+      ├── stats: [rows=82395.87, distinct(53)=82395.9, null(53)=0, avgsize(53)=4]
       ├── key: (53)
       ├── fd: (53)-->(48,50,52)
       ├── project
       │    ├── columns: column47:47!null column49:49!null column51:51!null column53:53
       │    ├── stable
-      │    ├── stats: [rows=19245.27, distinct(53)=9748.52, null(53)=0, avgsize(53)=4]
+      │    ├── stats: [rows=139576.9, distinct(53)=82395.9, null(53)=0, avgsize(53)=4]
       │    ├── inner-join (hash)
       │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null transactiondetails.cardid:4!null quantity:5!null transactiondetails.sellprice:6!null transactiondetails.buyprice:7!null transactions.dealerid:13!null transactions.isbuy:14!null date:15!null accountname:16!null customername:17!null id:24!null cardsinfo.dealerid:32!null cardsinfo.cardid:33!null
-      │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
-      │    │    ├── stats: [rows=19245.27, distinct(3)=9748.52, null(3)=0, avgsize(3)=4, distinct(4)=11100.2, null(4)=0, avgsize(4)=4, distinct(24)=11100.2, null(24)=0, avgsize(24)=4]
+      │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+      │    │    ├── stats: [rows=139576.9, distinct(3)=82395.9, null(3)=0, avgsize(3)=4, distinct(4)=37420.4, null(4)=0, avgsize(4)=4, distinct(24)=37420.4, null(24)=0, avgsize(24)=4]
       │    │    ├── key: (5,15,33)
       │    │    ├── fd: ()-->(1,2,13,14,32), (3-5)-->(6,7), (15)-->(16,17), (3)==(15), (15)==(3), (24)==(4,33), (33)==(4,24), (4)==(24,33)
-      │    │    ├── scan cardsinfo@cardsinfoversionindex
-      │    │    │    ├── columns: cardsinfo.dealerid:32!null cardsinfo.cardid:33!null
-      │    │    │    ├── constraint: /32/40: [/1 - /1]
-      │    │    │    ├── stats: [rows=58333.33, distinct(32)=1, null(32)=0, avgsize(32)=4, distinct(33)=37420.4, null(33)=0, avgsize(33)=4]
-      │    │    │    ├── key: (33)
-      │    │    │    └── fd: ()-->(32)
+      │    │    ├── inner-join (merge)
+      │    │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null transactiondetails.cardid:4!null quantity:5!null transactiondetails.sellprice:6!null transactiondetails.buyprice:7!null transactions.dealerid:13!null transactions.isbuy:14!null date:15!null accountname:16!null customername:17!null
+      │    │    │    ├── left ordering: +3
+      │    │    │    ├── right ordering: +15
+      │    │    │    ├── stats: [rows=119679, distinct(1)=1, null(1)=0, avgsize(1)=4, distinct(2)=1, null(2)=0, avgsize(2)=4, distinct(3)=119679, null(3)=0, avgsize(3)=4, distinct(4)=50017.4, null(4)=0, avgsize(4)=4, distinct(5)=114043, null(5)=0, avgsize(5)=4, distinct(6)=114043, null(6)=0, avgsize(6)=4, distinct(7)=114043, null(7)=0, avgsize(7)=4, distinct(13)=1, null(13)=0, avgsize(13)=4, distinct(14)=1, null(14)=0, avgsize(14)=4, distinct(15)=119679, null(15)=0, avgsize(15)=4, distinct(16)=75651.6, null(16)=0, avgsize(16)=4, distinct(17)=75651.6, null(17)=0, avgsize(17)=4]
+      │    │    │    ├── key: (4,5,15)
+      │    │    │    ├── fd: ()-->(1,2,13,14), (3-5)-->(6,7), (15)-->(16,17), (3)==(15), (15)==(3)
+      │    │    │    ├── scan transactiondetails
+      │    │    │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null transactiondetails.cardid:4!null quantity:5!null transactiondetails.sellprice:6!null transactiondetails.buyprice:7!null
+      │    │    │    │    ├── constraint: /1/2/3/4/5: [/1/false/'2020-02-23 00:00:00+00:00' - /1/false/'2020-03-01 00:00:00+00:00']
+      │    │    │    │    ├── stats: [rows=1270000, distinct(1)=1, null(1)=0, avgsize(1)=4, distinct(2)=1, null(2)=0, avgsize(2)=4, distinct(3)=1.27e+06, null(3)=0, avgsize(3)=4, distinct(4)=57000, null(4)=0, avgsize(4)=4, distinct(5)=1.23043e+06, null(5)=0, avgsize(5)=4, distinct(6)=1.23043e+06, null(6)=0, avgsize(6)=4, distinct(7)=1.23043e+06, null(7)=0, avgsize(7)=4, distinct(1,2)=1, null(1,2)=0, avgsize(1,2)=8, distinct(1-3)=1.27e+06, null(1-3)=0, avgsize(1-3)=12]
+      │    │    │    │    ├── key: (3-5)
+      │    │    │    │    ├── fd: ()-->(1,2), (3-5)-->(6,7)
+      │    │    │    │    └── ordering: +3 opt(1,2) [actual: +3]
+      │    │    │    ├── select
+      │    │    │    │    ├── columns: transactions.dealerid:13!null transactions.isbuy:14!null date:15!null accountname:16!null customername:17!null
+      │    │    │    │    ├── stats: [rows=119679, distinct(13)=1, null(13)=0, avgsize(13)=4, distinct(14)=1, null(14)=0, avgsize(14)=4, distinct(15)=119679, null(15)=0, avgsize(15)=4, distinct(16)=119679, null(16)=0, avgsize(16)=4, distinct(17)=119679, null(17)=0, avgsize(17)=4, distinct(13,14)=1, null(13,14)=0, avgsize(13,14)=8, distinct(15-17)=119679, null(15-17)=0, avgsize(15-17)=12, distinct(13-17)=119679, null(13-17)=0, avgsize(13-17)=20]
+      │    │    │    │    ├── key: (15)
+      │    │    │    │    ├── fd: ()-->(13,14), (15)-->(16,17)
+      │    │    │    │    ├── ordering: +15 opt(13,14) [actual: +15]
+      │    │    │    │    ├── scan transactions
+      │    │    │    │    │    ├── columns: transactions.dealerid:13!null transactions.isbuy:14!null date:15!null accountname:16!null customername:17!null
+      │    │    │    │    │    ├── constraint: /13/14/15: [/1/false/'2020-02-23 00:00:00+00:00' - /1/false/'2020-03-01 00:00:00+00:00']
+      │    │    │    │    │    ├── stats: [rows=141111.1, distinct(13)=1, null(13)=0, avgsize(13)=4, distinct(14)=1, null(14)=0, avgsize(14)=4, distinct(15)=141111, null(15)=0, avgsize(15)=4, distinct(13,14)=1, null(13,14)=0, avgsize(13,14)=8, distinct(13-15)=141111, null(13-15)=0, avgsize(13-15)=12]
+      │    │    │    │    │    ├── key: (15)
+      │    │    │    │    │    ├── fd: ()-->(13,14), (15)-->(16,17)
+      │    │    │    │    │    └── ordering: +15 opt(13,14) [actual: +15]
+      │    │    │    │    └── filters
+      │    │    │    │         ├── accountname:16 != 'someaccount' [outer=(16), constraints=(/16: (/NULL - /'someaccount') [/e'someaccount\x00' - ]; tight)]
+      │    │    │    │         └── customername:17 != 'somecustomer' [outer=(17), constraints=(/17: (/NULL - /'somecustomer') [/e'somecustomer\x00' - ]; tight)]
+      │    │    │    └── filters (true)
       │    │    ├── inner-join (hash)
-      │    │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null transactiondetails.cardid:4!null quantity:5!null transactiondetails.sellprice:6!null transactiondetails.buyprice:7!null transactions.dealerid:13!null transactions.isbuy:14!null date:15!null accountname:16!null customername:17!null id:24!null
-      │    │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(exactly-one)
-      │    │    │    ├── stats: [rows=19530.48, distinct(1)=1, null(1)=0, avgsize(1)=4, distinct(2)=1, null(2)=0, avgsize(2)=4, distinct(3)=12345.7, null(3)=0, avgsize(3)=4, distinct(4)=16536.1, null(4)=0, avgsize(4)=4, distinct(5)=19228.7, null(5)=0, avgsize(5)=4, distinct(6)=19228.7, null(6)=0, avgsize(6)=4, distinct(7)=19228.7, null(7)=0, avgsize(7)=4, distinct(13)=1, null(13)=0, avgsize(13)=4, distinct(14)=1, null(14)=0, avgsize(14)=4, distinct(15)=12345.7, null(15)=0, avgsize(15)=4, distinct(16)=9807.78, null(16)=0, avgsize(16)=4, distinct(17)=9807.78, null(17)=0, avgsize(17)=4, distinct(24)=16536.1, null(24)=0, avgsize(24)=4]
-      │    │    │    ├── key: (5,15,24)
-      │    │    │    ├── fd: ()-->(1,2,13,14), (15)-->(16,17), (3-5)-->(6,7), (4)==(24), (24)==(4), (3)==(15), (15)==(3)
+      │    │    │    ├── columns: id:24!null cardsinfo.dealerid:32!null cardsinfo.cardid:33!null
+      │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+      │    │    │    ├── stats: [rows=58333.33, distinct(24)=37420.4, null(24)=0, avgsize(24)=4, distinct(32)=1, null(32)=0, avgsize(32)=4, distinct(33)=37420.4, null(33)=0, avgsize(33)=4]
+      │    │    │    ├── key: (33)
+      │    │    │    ├── fd: ()-->(32), (24)==(33), (33)==(24)
+      │    │    │    ├── scan cardsinfo@cardsinfoversionindex
+      │    │    │    │    ├── columns: cardsinfo.dealerid:32!null cardsinfo.cardid:33!null
+      │    │    │    │    ├── constraint: /32/40: [/1 - /1]
+      │    │    │    │    ├── stats: [rows=58333.33, distinct(32)=1, null(32)=0, avgsize(32)=4, distinct(33)=37420.4, null(33)=0, avgsize(33)=4]
+      │    │    │    │    ├── key: (33)
+      │    │    │    │    └── fd: ()-->(32)
       │    │    │    ├── scan cards@cardsnamesetnumber
       │    │    │    │    ├── columns: id:24!null
       │    │    │    │    ├── stats: [rows=57000, distinct(24)=57000, null(24)=0, avgsize(24)=4]
       │    │    │    │    └── key: (24)
-      │    │    │    ├── inner-join (lookup transactiondetails)
-      │    │    │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null transactiondetails.cardid:4!null quantity:5!null transactiondetails.sellprice:6!null transactiondetails.buyprice:7!null transactions.dealerid:13!null transactions.isbuy:14!null date:15!null accountname:16!null customername:17!null
-      │    │    │    │    ├── key columns: [60 61 15] = [1 2 3]
-      │    │    │    │    ├── stats: [rows=12345.68, distinct(1)=1, null(1)=0, avgsize(1)=4, distinct(2)=1, null(2)=0, avgsize(2)=4, distinct(3)=12345.7, null(3)=0, avgsize(3)=4, distinct(4)=11100.2, null(4)=0, avgsize(4)=4, distinct(5)=12267.9, null(5)=0, avgsize(5)=4, distinct(6)=12267.9, null(6)=0, avgsize(6)=4, distinct(7)=12267.9, null(7)=0, avgsize(7)=4, distinct(13)=1, null(13)=0, avgsize(13)=4, distinct(14)=1, null(14)=0, avgsize(14)=4, distinct(15)=12345.7, null(15)=0, avgsize(15)=4, distinct(16)=7803.96, null(16)=0, avgsize(16)=4, distinct(17)=7803.96, null(17)=0, avgsize(17)=4]
-      │    │    │    │    ├── key: (4,5,15)
-      │    │    │    │    ├── fd: ()-->(1,2,13,14), (3-5)-->(6,7), (15)-->(16,17), (3)==(15), (15)==(3)
-      │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: "lookup_join_const_col_@2":61!null "lookup_join_const_col_@1":60!null transactions.dealerid:13!null transactions.isbuy:14!null date:15!null accountname:16!null customername:17!null
-      │    │    │    │    │    ├── stats: [rows=12345.68, distinct(13)=1, null(13)=0, avgsize(13)=4, distinct(14)=1, null(14)=0, avgsize(14)=4, distinct(15)=12345.7, null(15)=0, avgsize(15)=4, distinct(16)=12345.7, null(16)=0, avgsize(16)=4, distinct(17)=12345.7, null(17)=0, avgsize(17)=4, distinct(60)=1, null(60)=0, avgsize(60)=4, distinct(61)=1, null(61)=0, avgsize(61)=4]
-      │    │    │    │    │    ├── key: (15)
-      │    │    │    │    │    ├── fd: ()-->(13,14,60,61), (15)-->(16,17)
-      │    │    │    │    │    ├── select
-      │    │    │    │    │    │    ├── columns: transactions.dealerid:13!null transactions.isbuy:14!null date:15!null accountname:16!null customername:17!null
-      │    │    │    │    │    │    ├── stats: [rows=12345.68, distinct(13)=1, null(13)=0, avgsize(13)=4, distinct(14)=1, null(14)=0, avgsize(14)=4, distinct(15)=12345.7, null(15)=0, avgsize(15)=4, distinct(16)=12345.7, null(16)=0, avgsize(16)=4, distinct(17)=12345.7, null(17)=0, avgsize(17)=4]
-      │    │    │    │    │    │    ├── key: (15)
-      │    │    │    │    │    │    ├── fd: ()-->(13,14), (15)-->(16,17)
-      │    │    │    │    │    │    ├── scan transactions
-      │    │    │    │    │    │    │    ├── columns: transactions.dealerid:13!null transactions.isbuy:14!null date:15!null accountname:16!null customername:17!null
-      │    │    │    │    │    │    │    ├── constraint: /13/14/15: [/1/false/'2020-02-23 00:00:00+00:00' - /1/false/'2020-03-01 00:00:00+00:00']
-      │    │    │    │    │    │    │    ├── stats: [rows=111111.1, distinct(13)=1, null(13)=0, avgsize(13)=4, distinct(14)=1, null(14)=0, avgsize(14)=4, distinct(15)=111111, null(15)=0, avgsize(15)=4]
-      │    │    │    │    │    │    │    ├── key: (15)
-      │    │    │    │    │    │    │    └── fd: ()-->(13,14), (15)-->(16,17)
-      │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │         ├── accountname:16 != 'someaccount' [outer=(16), constraints=(/16: (/NULL - /'someaccount') [/e'someaccount\x00' - ]; tight)]
-      │    │    │    │    │    │         └── customername:17 != 'somecustomer' [outer=(17), constraints=(/17: (/NULL - /'somecustomer') [/e'somecustomer\x00' - ]; tight)]
-      │    │    │    │    │    └── projections
-      │    │    │    │    │         ├── false [as="lookup_join_const_col_@2":61]
-      │    │    │    │    │         └── 1 [as="lookup_join_const_col_@1":60]
-      │    │    │    │    └── filters
-      │    │    │    │         └── (transactiondate:3 >= '2020-02-23 00:00:00+00:00') AND (transactiondate:3 <= '2020-03-01 00:00:00+00:00') [outer=(3), constraints=(/3: [/'2020-02-23 00:00:00+00:00' - /'2020-03-01 00:00:00+00:00']; tight)]
       │    │    │    └── filters
-      │    │    │         └── id:24 = transactiondetails.cardid:4 [outer=(4,24), constraints=(/4: (/NULL - ]; /24: (/NULL - ]), fd=(4)==(24), (24)==(4)]
+      │    │    │         └── id:24 = cardsinfo.cardid:33 [outer=(24,33), constraints=(/24: (/NULL - ]; /33: (/NULL - ]), fd=(24)==(33), (33)==(24)]
       │    │    └── filters
-      │    │         └── id:24 = cardsinfo.cardid:33 [outer=(24,33), constraints=(/24: (/NULL - ]; /33: (/NULL - ]), fd=(24)==(33), (33)==(24)]
+      │    │         └── id:24 = transactiondetails.cardid:4 [outer=(4,24), constraints=(/4: (/NULL - ]; /24: (/NULL - ]), fd=(4)==(24), (24)==(4)]
       │    └── projections
       │         ├── quantity:5 * transactiondetails.sellprice:6::DECIMAL [as=column47:47, outer=(5,6), immutable]
       │         ├── quantity:5 * transactiondetails.buyprice:7::DECIMAL [as=column49:49, outer=(5,7), immutable]
@@ -1188,38 +1189,46 @@ values
            │         ├── cardinality: [1 - 1]
            │         ├── key: ()
            │         ├── fd: ()-->(24)
-           │         ├── top-k
+           │         ├── limit
            │         │    ├── columns: d.dealerid:1!null d.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null t.dealerid:13!null t.isbuy:14!null date:15!null
            │         │    ├── internal-ordering: -(3|15) opt(4)
-           │         │    ├── k: 100
            │         │    ├── cardinality: [0 - 100]
            │         │    ├── key: (5,13-15)
            │         │    ├── fd: ()-->(4), (1)==(13), (13)==(1), (2)==(14), (14)==(2), (3)==(15), (15)==(3)
-           │         │    └── inner-join (lookup transactions [as=t])
-           │         │         ├── columns: d.dealerid:1!null d.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null t.dealerid:13!null t.isbuy:14!null date:15!null
-           │         │         ├── key columns: [1 2 3] = [13 14 15]
-           │         │         ├── lookup columns are key
-           │         │         ├── key: (5,13-15)
-           │         │         ├── fd: ()-->(4), (1)==(13), (13)==(1), (2)==(14), (14)==(2), (3)==(15), (15)==(3)
-           │         │         ├── scan transactiondetails@detailscardidindex [as=d]
-           │         │         │    ├── columns: d.dealerid:1!null d.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null
-           │         │         │    ├── constraint: /1/2/4/3/5
-           │         │         │    │    ├── [/1/false/19483/'2020-02-28 00:00:00+00:00' - /1/false/19483/'2020-03-01 00:00:00+00:00']
-           │         │         │    │    ├── [/1/true/19483/'2020-02-28 00:00:00+00:00' - /1/true/19483/'2020-03-01 00:00:00+00:00']
-           │         │         │    │    ├── [/2/false/19483/'2020-02-28 00:00:00+00:00' - /2/false/19483/'2020-03-01 00:00:00+00:00']
-           │         │         │    │    ├── [/2/true/19483/'2020-02-28 00:00:00+00:00' - /2/true/19483/'2020-03-01 00:00:00+00:00']
-           │         │         │    │    ├── [/3/false/19483/'2020-02-28 00:00:00+00:00' - /3/false/19483/'2020-03-01 00:00:00+00:00']
-           │         │         │    │    ├── [/3/true/19483/'2020-02-28 00:00:00+00:00' - /3/true/19483/'2020-03-01 00:00:00+00:00']
-           │         │         │    │    ├── [/4/false/19483/'2020-02-28 00:00:00+00:00' - /4/false/19483/'2020-03-01 00:00:00+00:00']
-           │         │         │    │    ├── [/4/true/19483/'2020-02-28 00:00:00+00:00' - /4/true/19483/'2020-03-01 00:00:00+00:00']
-           │         │         │    │    ├── [/5/false/19483/'2020-02-28 00:00:00+00:00' - /5/false/19483/'2020-03-01 00:00:00+00:00']
-           │         │         │    │    └── [/5/true/19483/'2020-02-28 00:00:00+00:00' - /5/true/19483/'2020-03-01 00:00:00+00:00']
-           │         │         │    ├── key: (1-3,5)
-           │         │         │    └── fd: ()-->(4)
-           │         │         └── filters
-           │         │              ├── (date:15 >= '2020-02-28 00:00:00+00:00') AND (date:15 <= '2020-03-01 00:00:00+00:00') [outer=(15), constraints=(/15: [/'2020-02-28 00:00:00+00:00' - /'2020-03-01 00:00:00+00:00']; tight)]
-           │         │              ├── ((((t.dealerid:13 = 1) OR (t.dealerid:13 = 2)) OR (t.dealerid:13 = 3)) OR (t.dealerid:13 = 4)) OR (t.dealerid:13 = 5) [outer=(13), constraints=(/13: [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5]; tight)]
-           │         │              └── t.isbuy:14 IN (false, true) [outer=(14), constraints=(/14: [/false - /false] [/true - /true]; tight)]
+           │         │    ├── inner-join (lookup transactions [as=t])
+           │         │    │    ├── columns: d.dealerid:1!null d.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null t.dealerid:13!null t.isbuy:14!null date:15!null
+           │         │    │    ├── key columns: [1 2 3] = [13 14 15]
+           │         │    │    ├── lookup columns are key
+           │         │    │    ├── key: (5,13-15)
+           │         │    │    ├── fd: ()-->(4), (1)==(13), (13)==(1), (2)==(14), (14)==(2), (3)==(15), (15)==(3)
+           │         │    │    ├── ordering: -(3|15) opt(4) [actual: -3]
+           │         │    │    ├── limit hint: 100.00
+           │         │    │    ├── sort
+           │         │    │    │    ├── columns: d.dealerid:1!null d.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null
+           │         │    │    │    ├── key: (1-3,5)
+           │         │    │    │    ├── fd: ()-->(4)
+           │         │    │    │    ├── ordering: -3 opt(4) [actual: -3]
+           │         │    │    │    ├── limit hint: 1100.00
+           │         │    │    │    └── scan transactiondetails@detailscardidindex [as=d]
+           │         │    │    │         ├── columns: d.dealerid:1!null d.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null
+           │         │    │    │         ├── constraint: /1/2/4/3/5
+           │         │    │    │         │    ├── [/1/false/19483/'2020-02-28 00:00:00+00:00' - /1/false/19483/'2020-03-01 00:00:00+00:00']
+           │         │    │    │         │    ├── [/1/true/19483/'2020-02-28 00:00:00+00:00' - /1/true/19483/'2020-03-01 00:00:00+00:00']
+           │         │    │    │         │    ├── [/2/false/19483/'2020-02-28 00:00:00+00:00' - /2/false/19483/'2020-03-01 00:00:00+00:00']
+           │         │    │    │         │    ├── [/2/true/19483/'2020-02-28 00:00:00+00:00' - /2/true/19483/'2020-03-01 00:00:00+00:00']
+           │         │    │    │         │    ├── [/3/false/19483/'2020-02-28 00:00:00+00:00' - /3/false/19483/'2020-03-01 00:00:00+00:00']
+           │         │    │    │         │    ├── [/3/true/19483/'2020-02-28 00:00:00+00:00' - /3/true/19483/'2020-03-01 00:00:00+00:00']
+           │         │    │    │         │    ├── [/4/false/19483/'2020-02-28 00:00:00+00:00' - /4/false/19483/'2020-03-01 00:00:00+00:00']
+           │         │    │    │         │    ├── [/4/true/19483/'2020-02-28 00:00:00+00:00' - /4/true/19483/'2020-03-01 00:00:00+00:00']
+           │         │    │    │         │    ├── [/5/false/19483/'2020-02-28 00:00:00+00:00' - /5/false/19483/'2020-03-01 00:00:00+00:00']
+           │         │    │    │         │    └── [/5/true/19483/'2020-02-28 00:00:00+00:00' - /5/true/19483/'2020-03-01 00:00:00+00:00']
+           │         │    │    │         ├── key: (1-3,5)
+           │         │    │    │         └── fd: ()-->(4)
+           │         │    │    └── filters
+           │         │    │         ├── (date:15 >= '2020-02-28 00:00:00+00:00') AND (date:15 <= '2020-03-01 00:00:00+00:00') [outer=(15), constraints=(/15: [/'2020-02-28 00:00:00+00:00' - /'2020-03-01 00:00:00+00:00']; tight)]
+           │         │    │         ├── ((((t.dealerid:13 = 1) OR (t.dealerid:13 = 2)) OR (t.dealerid:13 = 3)) OR (t.dealerid:13 = 4)) OR (t.dealerid:13 = 5) [outer=(13), constraints=(/13: [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5]; tight)]
+           │         │    │         └── t.isbuy:14 IN (false, true) [outer=(14), constraints=(/14: [/false - /false] [/true - /true]; tight)]
+           │         │    └── 100
            │         └── aggregations
            │              └── sum [as=sum:24, outer=(5)]
            │                   └── quantity:5

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -1336,7 +1336,7 @@ values
       │         │    │    │    ├── columns: y:9 z:10!null
       │         │    │    │    ├── constraint: /10/9/8: (/NULL - ]
       │         │    │    │    ├── ordering: +10
-      │         │    │    │    └── limit hint: 3.00
+      │         │    │    │    └── limit hint: 2.97
       │         │    │    └── filters
       │         │    │         └── y:9 > 0 [outer=(9), constraints=(/9: [/1 - ]; tight)]
       │         │    └── 1
@@ -1403,7 +1403,7 @@ values
       │         │    │    │    ├── columns: y:9 z:10!null
       │         │    │    │    ├── constraint: /10/9/8: (/NULL - ]
       │         │    │    │    ├── ordering: -10
-      │         │    │    │    └── limit hint: 1.01
+      │         │    │    │    └── limit hint: 1.00
       │         │    │    └── filters
       │         │    │         └── y:9 IS NOT NULL [outer=(9), constraints=(/9: (/NULL - ]; tight)]
       │         │    └── 1
@@ -1505,7 +1505,7 @@ values
       │         │    │    │    ├── columns: y:9 z:10!null
       │         │    │    │    ├── constraint: /10/9/8: (/NULL - ]
       │         │    │    │    ├── ordering: -10
-      │         │    │    │    └── limit hint: 1.01
+      │         │    │    │    └── limit hint: 1.00
       │         │    │    └── filters
       │         │    │         └── y:9 IS NOT NULL [outer=(9), constraints=(/9: (/NULL - ]; tight)]
       │         │    └── 1

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -266,8 +266,8 @@ SELECT * FROM p WHERE i > 0 AND s = 'foo'
 memo (optimized, ~17KB, required=[presentation: k:1,i:2,f:3,s:4,b:5])
  ├── G1: (select G2 G3) (index-join G4 p,cols=(1-5)) (index-join G5 p,cols=(1-5)) (index-join G6 p,cols=(1-5)) (index-join G7 p,cols=(1-5))
  │    └── [presentation: k:1,i:2,f:3,s:4,b:5]
- │         ├── best: (index-join G7 p,cols=(1-5))
- │         └── cost: 37.81
+ │         ├── best: (index-join G4 p,cols=(1-5))
+ │         └── cost: 59.03
  ├── G2: (scan p,cols=(1-5))
  │    └── []
  │         ├── best: (scan p,cols=(1-5))
@@ -284,11 +284,11 @@ memo (optimized, ~17KB, required=[presentation: k:1,i:2,f:3,s:4,b:5])
  ├── G6: (scan p@idx,partial,cols=(1-4),constrained)
  │    └── []
  │         ├── best: (scan p@idx,partial,cols=(1-4),constrained)
- │         └── cost: 17.62
+ │         └── cost: 24.10
  ├── G7: (scan p@idx2,partial,cols=(1,4),constrained)
  │    └── []
  │         ├── best: (scan p@idx2,partial,cols=(1,4),constrained)
- │         └── cost: 17.49
+ │         └── cost: 23.73
  ├── G8: (gt G14 G15)
  ├── G9: (eq G16 G17)
  ├── G10: (scan p@idx,partial,cols=(1-4))
@@ -853,7 +853,7 @@ memo (optimized, ~10KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G1: (select G2 G3) (select G4 G5) (index-join G6 b,cols=(1-4))
  │    └── [presentation: k:1,u:2,v:3,j:4]
  │         ├── best: (index-join G6 b,cols=(1-4))
- │         └── cost: 34.77
+ │         └── cost: 47.19
  ├── G2: (scan b,cols=(1-4))
  │    └── []
  │         ├── best: (scan b,cols=(1-4))
@@ -1712,11 +1712,11 @@ memo (optimized, ~21KB, required=[presentation: i:2])
  ├── G1: (project G2 G3 i)
  │    └── [presentation: i:2]
  │         ├── best: (project G2 G3 i)
- │         └── cost: 14.17
+ │         └── cost: 15.03
  ├── G2: (select G4 G5) (select G6 G7) (select G8 G7) (select G9 G7) (project G10 G11 i)
  │    └── []
  │         ├── best: (project G10 G11 i)
- │         └── cost: 14.15
+ │         └── cost: 15.00
  ├── G3: (projections)
  ├── G4: (scan p,cols=(2,4))
  │    └── []
@@ -1735,11 +1735,11 @@ memo (optimized, ~21KB, required=[presentation: i:2])
  ├── G9: (index-join G16 p,cols=(2,4))
  │    └── []
  │         ├── best: (index-join G16 p,cols=(2,4))
- │         └── cost: 37.74
+ │         └── cost: 80.40
  ├── G10: (scan p@idx2,partial,cols=(2),constrained)
  │    └── []
  │         ├── best: (scan p@idx2,partial,cols=(2),constrained)
- │         └── cost: 14.12
+ │         └── cost: 14.96
  ├── G11: (projections G17)
  ├── G12: (eq G18 G19)
  ├── G13: (eq G20 G17)
@@ -1754,7 +1754,7 @@ memo (optimized, ~21KB, required=[presentation: i:2])
  ├── G16: (scan p@idx,partial,cols=(1,4),constrained)
  │    └── []
  │         ├── best: (scan p@idx,partial,cols=(1,4),constrained)
- │         └── cost: 17.49
+ │         └── cost: 23.73
  ├── G17: (const 'foo')
  ├── G18: (variable i)
  ├── G19: (const 3)
@@ -1786,7 +1786,7 @@ memo (optimized, ~9KB, required=[presentation: i:2])
  ├── G1: (project G2 G3 i)
  │    └── [presentation: i:2]
  │         ├── best: (project G2 G3 i)
- │         └── cost: 1104.78
+ │         └── cost: 1104.79
  ├── G2: (select G4 G5)
  │    └── []
  │         ├── best: (select G4 G5)
@@ -5265,7 +5265,7 @@ memo (optimized, ~16KB, required=[presentation: q:2,r:3])
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7) (select G8 G7) (zigzag-join G3 pqr@q pqr@r)
  │    └── [presentation: q:2,r:3]
  │         ├── best: (zigzag-join G3 pqr@q pqr@r)
- │         └── cost: 10.25
+ │         └── cost: 11.94
  ├── G2: (scan pqr,cols=(2,3))
  │    └── []
  │         ├── best: (scan pqr,cols=(2,3))
@@ -5346,7 +5346,7 @@ memo (optimized, ~18KB, required=[presentation: q:2,r:3,s:4])
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7) (select G8 G7) (lookup-join G9 G10 pqr,keyCols=[1],outCols=(2-4))
  │    └── [presentation: q:2,r:3,s:4]
  │         ├── best: (lookup-join G9 G10 pqr,keyCols=[1],outCols=(2-4))
- │         └── cost: 10.87
+ │         └── cost: 17.51
  ├── G2: (scan pqr,cols=(2-4))
  │    └── []
  │         ├── best: (scan pqr,cols=(2-4))
@@ -5369,7 +5369,7 @@ memo (optimized, ~18KB, required=[presentation: q:2,r:3,s:4])
  ├── G9: (zigzag-join G3 pqr@q pqr@r)
  │    └── []
  │         ├── best: (zigzag-join G3 pqr@q pqr@r)
- │         └── cost: 10.25
+ │         └── cost: 11.95
  ├── G10: (filters)
  ├── G11: (eq G16 G17)
  ├── G12: (eq G18 G19)
@@ -5411,7 +5411,7 @@ memo (optimized, ~13KB, required=[presentation: q:2,s:4])
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7) (zigzag-join G3 pqr@q pqr@s)
  │    └── [presentation: q:2,s:4]
  │         ├── best: (zigzag-join G3 pqr@q pqr@s)
- │         └── cost: 12.12
+ │         └── cost: 12.14
  ├── G2: (scan pqr,cols=(2,4))
  │    └── []
  │         ├── best: (scan pqr,cols=(2,4))
@@ -5914,7 +5914,7 @@ memo (optimized, ~37KB, required=[presentation: p:1,q:2,r:3,s:4])
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7) (select G8 G9) (select G10 G9) (lookup-join G11 G12 pqr,keyCols=[1],outCols=(1-4)) (zigzag-join G3 pqr@q pqr@s) (zigzag-join G3 pqr@q pqr@rs) (lookup-join G13 G9 pqr,keyCols=[1],outCols=(1-4))
  │    └── [presentation: p:1,q:2,r:3,s:4]
  │         ├── best: (zigzag-join G3 pqr@q pqr@s)
- │         └── cost: 10.07
+ │         └── cost: 11.96
  ├── G2: (scan pqr,cols=(1-4))
  │    └── []
  │         ├── best: (scan pqr,cols=(1-4))
@@ -5942,7 +5942,7 @@ memo (optimized, ~37KB, required=[presentation: p:1,q:2,r:3,s:4])
  ├── G11: (zigzag-join G21 pqr@q pqr@r)
  │    └── []
  │         ├── best: (zigzag-join G21 pqr@q pqr@r)
- │         └── cost: 10.25
+ │         └── cost: 11.95
  ├── G12: (filters G16)
  ├── G13: (zigzag-join G5 pqr@r pqr@s)
  │    └── []


### PR DESCRIPTION
This commit slightly tweaks the formula to combine single- and
multi-column stats to avoid a sharp change in estimates as the
distinct count approaches the row count. This commit also addresses
remaining feedback on #76786.

Release note: None

Release justification: low risk, high benefit changes to existing
functionality