### PR TITLE
sql: use correct primary index ID in EXPERIMENTAL SCRUB index check

### DIFF
--- a/pkg/sql/scrub_index.go
+++ b/pkg/sql/scrub_index.go
@@ -113,7 +113,7 @@ func (o *indexCheckOperation) Start(params runParams) error {
 	}
 
 	checkQuery := createIndexCheckQuery(
-		colNames(pkColumns), colNames(otherColumns), o.tableDesc.GetID(), o.index.GetID(),
+		colNames(pkColumns), colNames(otherColumns), o.tableDesc.GetID(), o.index.GetID(), o.tableDesc.GetPrimaryIndexID(),
 	)
 
 	rows, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.QueryBuffered(
@@ -245,7 +245,7 @@ func (o *indexCheckOperation) Close(ctx context.Context) {
 //   SELECT pri.k  pri.l, pri.a, pri.b,
 //          sec.k, sec.l, sec.a, sec.b
 //   FROM
-//     (SELECT k, l, a, b FROM [tbl_id AS table_pri]@{FORCE_INDEX=[1]}) AS pri
+//     (SELECT k, l, a, b FROM [tbl_id AS table_pri]@{FORCE_INDEX=[pri_idx_id]}) AS pri
 //   FULL OUTER JOIN
 //     (SELECT k, l, a, b FROM [tbl_id AS table_sec]@{FORCE_INDEX=[idx_id]} AS sec
 //   ON
@@ -278,7 +278,11 @@ func (o *indexCheckOperation) Close(ctx context.Context) {
 //         side row from the primary key had no match in the secondary index.
 //
 func createIndexCheckQuery(
-	pkColumns []string, otherColumns []string, tableID descpb.ID, indexID descpb.IndexID,
+	pkColumns []string,
+	otherColumns []string,
+	tableID descpb.ID,
+	indexID descpb.IndexID,
+	primaryIndexID descpb.IndexID,
 ) string {
 	allColumns := append(pkColumns, otherColumns...)
 	// We need to make sure we can handle the non-public column `rowid`
@@ -287,7 +291,7 @@ func createIndexCheckQuery(
 	const checkIndexQuery = `
     SELECT %[1]s, %[2]s
     FROM
-      (SELECT %[8]s FROM [%[3]d AS table_pri]@{FORCE_INDEX=[1]}) AS pri
+      (SELECT %[8]s FROM [%[3]d AS table_pri]@{FORCE_INDEX=[%[9]d]}) AS pri
     FULL OUTER JOIN
       (SELECT %[8]s FROM [%[3]d AS table_sec]@{FORCE_INDEX=[%[4]d]}) AS sec
     ON %[5]s
@@ -326,5 +330,8 @@ func createIndexCheckQuery(
 
 		// 8: k, l, a, b
 		strings.Join(colRefs("", append(pkColumns, otherColumns...)), ", "),
+
+		// 9
+		primaryIndexID,
 	)
 }


### PR DESCRIPTION
This query assumed that the primary index ID was always 1. But, after
an `ALTER TABLE <table> ALTER PRIMARY KEY` statement, the primary
index ID will no longer be 1.

Release justification: Low risk bug fix to experimental feature

Release note: None