### PR TITLE
ui: fix spelling on hot ranges page

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
@@ -104,15 +104,20 @@ const HotRangesTable = ({
       title: (
         <Tooltip
           placement="bottom"
-          title="The internal ID of the node where the range data is found."
+          title="The ID of each node where the range data is found."
         >
           Nodes
         </Tooltip>
       ),
       cell: val => (
-        <Link to={`/node/${val.replica_node_ids[0]}`}>
-          {val.replica_node_ids.join(", ")}
-        </Link>
+        <>
+          {val.replica_node_ids.map((nodeId, idx, arr) => (
+            <Link to={`/node/${nodeId}`}>
+              {nodeId}
+              {idx < arr.length - 1 && ", "}
+            </Link>
+          ))}
+        </>
       ),
       sort: val => val.replica_node_ids[0],
     },


### PR DESCRIPTION
This change updates tooltip text for "Nodes" column
on Hot Ranges page and fixes links on a list of nodes.

Release note: None

Release justification: bug fixes and low-risk updates to new functionality

Related to: https://cockroachlabs.atlassian.net/browse/DOC-2840?focusedCommentId=93166

<img width="678" alt="Screen Shot 2022-03-11 at 15 10 02" src="https://user-images.githubusercontent.com/3106437/157872635-882b9cb2-20e7-4015-8519-f8cc31639b17.png">
