### PR TITLE
sql: SET CLUSTER SETTING refactors

### DIFF
--- a/pkg/clusterversion/setting.go
+++ b/pkg/clusterversion/setting.go
@@ -158,26 +158,26 @@ func (cv *clusterVersionSetting) Decode(val []byte) (settings.ClusterVersionImpl
 }
 
 // Validate is part of the VersionSettingImpl interface.
-func (cv *clusterVersionSetting) Validate(
+func (cv *clusterVersionSetting) ValidateVersionUpgrade(
 	_ context.Context, sv *settings.Values, curRawProto, newRawProto []byte,
-) ([]byte, error) {
+) error {
 	var newCV ClusterVersion
 	if err := protoutil.Unmarshal(newRawProto, &newCV); err != nil {
-		return nil, err
+		return err
 	}
 
 	if err := cv.validateBinaryVersions(newCV.Version, sv); err != nil {
-		return nil, err
+		return err
 	}
 
 	var oldCV ClusterVersion
 	if err := protoutil.Unmarshal(curRawProto, &oldCV); err != nil {
-		return nil, err
+		return err
 	}
 
 	// Versions cannot be downgraded.
 	if newCV.Version.Less(oldCV.Version) {
-		return nil, errors.Errorf(
+		return errors.Errorf(
 			"versions cannot be downgraded (attempting to downgrade from %s to %s)",
 			oldCV.Version, newCV.Version)
 	}
@@ -185,13 +185,12 @@ func (cv *clusterVersionSetting) Validate(
 	// Prevent cluster version upgrade until cluster.preserve_downgrade_option
 	// is reset.
 	if downgrade := preserveDowngradeVersion.Get(sv); downgrade != "" {
-		return nil, errors.Errorf(
+		return errors.Errorf(
 			"cannot upgrade to %s: cluster.preserve_downgrade_option is set to %s",
 			newCV.Version, downgrade)
 	}
 
-	// Return the serialized form of the new version.
-	return protoutil.Marshal(&newCV)
+	return nil
 }
 
 // ValidateBinaryVersions is part of the VersionSettingImpl interface.

--- a/pkg/settings/version.go
+++ b/pkg/settings/version.go
@@ -46,7 +46,7 @@ type VersionSettingImpl interface {
 	// Validate checks whether an version update is permitted. It takes in the
 	// old and the proposed new value (both in encoded form). This is called by
 	// SET CLUSTER SETTING.
-	Validate(ctx context.Context, sv *Values, oldV, newV []byte) ([]byte, error)
+	ValidateVersionUpgrade(ctx context.Context, sv *Values, oldV, newV []byte) error
 
 	// ValidateBinaryVersions is a subset of Validate. It only checks that the
 	// current binary supports the proposed version. This is called when the
@@ -90,10 +90,8 @@ func (v *VersionSetting) Decode(val []byte) (ClusterVersionImpl, error) {
 // Validate checks whether an version update is permitted. It takes in the
 // old and the proposed new value (both in encoded form). This is called by
 // SET CLUSTER SETTING.
-func (v *VersionSetting) Validate(
-	ctx context.Context, sv *Values, oldV, newV []byte,
-) ([]byte, error) {
-	return v.impl.Validate(ctx, sv, oldV, newV)
+func (v *VersionSetting) Validate(ctx context.Context, sv *Values, oldV, newV []byte) error {
+	return v.impl.ValidateVersionUpgrade(ctx, sv, oldV, newV)
 }
 
 // SettingsListDefault returns the value that should be presented by


### PR DESCRIPTION
This PR paves the way to reusing the individual components
for ALTER TENANT SET CLUSTER SETTING.

Informs #77471

Release justification: low risk, high benefit changes to existing functionality
