### PR TITLE
dev: fix --rewrite for logictestccl

### DIFF
--- a/dev
+++ b/dev
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=21
+DEV_VERSION=22
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/datadriven_test.go
+++ b/pkg/cmd/dev/datadriven_test.go
@@ -39,8 +39,8 @@ const (
 // DataDriven divvies up these files as subtests, so individual "files" are
 // runnable through:
 //
-//  		dev test pkg/cmd/dev -f TestDataDrivenDriven/<fname> [--rewrite]
-// 	OR  go test ./pkg/cmd/dev -run TestDataDrivenDriven/<fname> [-rewrite]
+//  		dev test pkg/cmd/dev -f TestDataDriven/<fname> [--rewrite]
+// 	OR  go test ./pkg/cmd/dev -run TestDataDriven/<fname> [-rewrite]
 //
 // NB: See commentary on TestRecorderDriven to see how they compare.
 // TestDataDriven is well suited for exercising flows that don't depend on

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -151,6 +151,12 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 		for _, testTarget := range testTargets {
 			dir := getDirectoryFromTarget(testTarget)
 			args = append(args, fmt.Sprintf("--sandbox_writable_path=%s", filepath.Join(workspace, dir)))
+			if strings.Contains(testTarget, "pkg/ccl/logictestccl") {
+				// The ccl logictest target shares the testdata directory with the base
+				// logictest target -- make an allowance explicitly for that.
+				args = append(args, fmt.Sprintf("--sandbox_writable_path=%s",
+					filepath.Join(workspace, "pkg/sql/logictest")))
+			}
 		}
 	}
 	if timeout > 0 && !stress {

--- a/pkg/cmd/dev/testdata/datadriven/test
+++ b/pkg/cmd/dev/testdata/datadriven/test
@@ -84,3 +84,9 @@ dev test pkg/kv/kvserver -f TestStoreRangeSplitMergeGeneration --test-args '-tes
 ----
 bazel info workspace --color=no
 bazel test pkg/kv/kvserver:all --test_env=GOTRACEBACK=all --test_filter=TestStoreRangeSplitMergeGeneration --test_sharding_strategy=disabled --test_arg -test.outputdir=crdb-checkout --sandbox_writable_path=crdb-checkout --test_arg -test.memprofile=mem.out --test_output errors
+
+exec
+dev test pkg/ccl/logictestccl -f=TestTenantLogic/3node-tenant/system -v --rewrite
+----
+bazel info workspace --color=no
+bazel test pkg/ccl/logictestccl:all --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/ccl/logictestccl --sandbox_writable_path=crdb-checkout/pkg/sql/logictest --test_filter=TestTenantLogic/3node-tenant/system --test_sharding_strategy=disabled --test_arg -test.v --test_output all

--- a/pkg/cmd/dev/testdata/datadriven/testlogic
+++ b/pkg/cmd/dev/testdata/datadriven/testlogic
@@ -56,3 +56,9 @@ exec
 dev testlogic base --files=auto_span_config_reconciliation --stress --timeout 1m --cpus 8
 ----
 bazel test --test_env=GOTRACEBACK=all --local_cpu_resources=8 --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=120 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' -maxtime=1m0s -p=8' //pkg/sql/logictest:logictest_test --test_filter 'TestLogic//^auto_span_config_reconciliation$/' --test_output streamed
+
+exec
+dev testlogic ccl --rewrite --show-logs  -v --files distsql_automatic_stats --config 3node-tenant
+----
+bazel info workspace --color=no
+bazel test --test_env=GOTRACEBACK=all --test_arg -test.v --test_arg -show-logs --test_arg -show-sql --test_arg -config --test_arg 3node-tenant --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/ccl/logictestccl --sandbox_writable_path=crdb-checkout/pkg/sql/logictest //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic/^3node-tenant$/^distsql_automatic_stats$/' --test_output all

--- a/pkg/cmd/dev/testlogic.go
+++ b/pkg/cmd/dev/testlogic.go
@@ -150,6 +150,12 @@ func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 
 			dir := getDirectoryFromTarget(testTarget)
 			args = append(args, fmt.Sprintf("--sandbox_writable_path=%s", filepath.Join(workspace, dir)))
+			if choice == "ccl" {
+				// The ccl logictest target shares the testdata directory with the base
+				// logictest target -- make an allowance explicitly for that.
+				args = append(args, fmt.Sprintf("--sandbox_writable_path=%s",
+					filepath.Join(workspace, "pkg/sql/logictest")))
+			}
 		}
 		if timeout > 0 && !stress {
 			args = append(args, fmt.Sprintf("--test_timeout=%d", int(timeout.Seconds())))


### PR DESCRIPTION
Fixes #76513. The ccl logictest target shares the testdata directory
with the base logictest target. Since dev's --rewrite only makes an
allowance for the testdata/ directory under the package being tested,
this didn't work. This PR accommodates the one test target where
testdata/ is being used from elsewhere.

Release justification: non-production code change
Release note: None