### PR TITLE
pkg/server: add pagination fields to TenantRanges/Ranges request/response protos

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -1418,6 +1418,8 @@ Support status: [reserved](#support-status)
 | ----- | ---- | ----- | ----------- | -------------- |
 | node_id | [string](#cockroach.server.serverpb.RangesRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | [reserved](#support-status) |
 | range_ids | [int64](#cockroach.server.serverpb.RangesRequest-int64) | repeated |  | [reserved](#support-status) |
+| limit | [int32](#cockroach.server.serverpb.RangesRequest-int32) |  | The pagination limit to use, if set. NB: Pagination is based on ascending RangeID. | [reserved](#support-status) |
+| offset | [int32](#cockroach.server.serverpb.RangesRequest-int32) |  | The pagination offset to use, if set. NB: Pagination is based on ascending RangeID. | [reserved](#support-status) |
 
 
 
@@ -1436,6 +1438,7 @@ Support status: [reserved](#support-status)
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
 | ranges | [RangeInfo](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeInfo) | repeated |  | [reserved](#support-status) |
+| next | [int32](#cockroach.server.serverpb.RangesResponse-int32) |  | The next pagination offset to use, if any results remain. A value of 0 indicates no more results. NB: Pagination is based on ascending RangeID. | [reserved](#support-status) |
 
 
 

--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -1643,6 +1643,11 @@ Support status: [reserved](#support-status)
 
 
 
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| limit | [int32](#cockroach.server.serverpb.TenantRangesRequest-int32) |  | The pagination limit. This limit will be applied to each node, meaning that if a range is replicated 3 times, 3*limit elements will be returned. NB: Pagination here is based on ascending RangeID. | [reserved](#support-status) |
+| offset | [int32](#cockroach.server.serverpb.TenantRangesRequest-int32) |  | The pagination offset. NB: Pagination here is based on ascending RangeID. | [reserved](#support-status) |
+
 
 
 
@@ -1660,6 +1665,7 @@ Support status: [reserved](#support-status)
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
 | ranges_by_locality | [TenantRangesResponse.RangesByLocalityEntry](#cockroach.server.serverpb.TenantRangesResponse-cockroach.server.serverpb.TenantRangesResponse.RangesByLocalityEntry) | repeated | ranges_by_locality maps each range replica to its specified availability zone, as defined within the replica's locality metadata (default key `az`). Replicas without the default available zone key set will fall under the `locality-unset` key. | [reserved](#support-status) |
+| next | [int32](#cockroach.server.serverpb.TenantRangesResponse-int32) |  | The next offset, if pagination was used. NB: Pagination here is based on ascending RangeID. | [reserved](#support-status) |
 
 
 

--- a/pkg/server/serverpb/status.pb.gw.go
+++ b/pkg/server/serverpb/status.pb.gw.go
@@ -393,9 +393,20 @@ func local_request_Status_Ranges_0(ctx context.Context, marshaler runtime.Marsha
 
 }
 
+var (
+	filter_Status_TenantRanges_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+)
+
 func request_Status_TenantRanges_0(ctx context.Context, marshaler runtime.Marshaler, client StatusClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq TenantRangesRequest
 	var metadata runtime.ServerMetadata
+
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_Status_TenantRanges_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
 
 	msg, err := client.TenantRanges(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
@@ -405,6 +416,13 @@ func request_Status_TenantRanges_0(ctx context.Context, marshaler runtime.Marsha
 func local_request_Status_TenantRanges_0(ctx context.Context, marshaler runtime.Marshaler, server StatusServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq TenantRangesRequest
 	var metadata runtime.ServerMetadata
+
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_Status_TenantRanges_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
 
 	msg, err := server.TenantRanges(ctx, &protoReq)
 	return msg, metadata, err

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -535,7 +535,15 @@ message RangesResponse {
   int32 next = 2;
 }
 
-message TenantRangesRequest {}
+message TenantRangesRequest {
+  // The pagination limit. This limit will be applied to each node, meaning that
+  // if a range is replicated 3 times, 3*limit elements will be returned.
+  // NB: Pagination here is based on ascending RangeID.
+  int32 limit = 1;
+  // The pagination offset.
+  // NB: Pagination here is based on ascending RangeID.
+  int32 offset = 2;
+}
 
 message TenantRangesResponse {
   message TenantRangeList {
@@ -546,6 +554,9 @@ message TenantRangesResponse {
   // Replicas without the default available zone key set will fall under the
   // `locality-unset` key.
   map<string, TenantRangeList> ranges_by_locality = 1 [ (gogoproto.nullable) = false ];
+  // The next offset, if pagination was used.
+  // NB: Pagination here is based on ascending RangeID.
+  int32 next = 2;
 }
 
 message GossipRequest {

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -519,10 +519,20 @@ message RangesRequest {
     (gogoproto.casttype) =
         "github.com/cockroachdb/cockroach/pkg/roachpb.RangeID"
   ];
+  // The pagination limit to use, if set.
+  // NB: Pagination is based on ascending RangeID.
+  int32 limit = 3;
+  // The pagination offset to use, if set.
+  // NB: Pagination is based on ascending RangeID.
+  int32 offset = 4;
 }
 
 message RangesResponse {
   repeated RangeInfo ranges = 1 [ (gogoproto.nullable) = false ];
+  // The next pagination offset to use, if any results remain. A value of 0
+  // indicates no more results.
+  // NB: Pagination is based on ascending RangeID.
+  int32 next = 2;
 }
 
 message TenantRangesRequest {}

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1853,7 +1853,10 @@ func (h varsHandler) handleVars(w http.ResponseWriter, r *http.Request) {
 func (s *statusServer) Ranges(
 	ctx context.Context, req *serverpb.RangesRequest,
 ) (*serverpb.RangesResponse, error) {
-	resp, _, err := s.rangesHelper(ctx, req, 0, 0)
+	resp, next, err := s.rangesHelper(ctx, req, int(req.Limit), int(req.Offset))
+	if resp != nil {
+		resp.Next = int32(next)
+	}
 	return resp, err
 }
 
@@ -2045,7 +2048,7 @@ func (s *statusServer) rangesHelper(
 		return nil, 0, status.Errorf(codes.Internal, err.Error())
 	}
 	var next int
-	if len(req.RangeIDs) > 0 {
+	if limit > 0 {
 		var outputInterface interface{}
 		outputInterface, next = simplePaginate(output.Ranges, limit, offset)
 		output.Ranges = outputInterface.([]serverpb.RangeInfo)


### PR DESCRIPTION
The `(*statusServer).Ranges()` endpoint currently supports pagination
under the hood, but this functionality is not accessible via RPC requests.
Instead, pagination is only currently available via api_v2.

There are multiple callers of the `Ranges()` endpoint outside of api_v2
(e.g. `debug zip`) that could benefit from having this pagination
functionality unlocked. Therefore, this change adds `limit` and `offset`
fields to the associated request object, and a `next` field to the
response object. This allows gRPC callers to leverage the offset
pagination already in place.

Now that `Ranges()` supports pagination for gRPC clients, we can extend
that pagination functionality to the `TenantRanges` endpoint as well.

The pagination for `TenantRanges()` will limit the number of results returned
*by each node*. This means that a `limit = 100` value for a tenant whose
ranges are replicated three times, will return 300 results (100 results for
each node containing a Replica).

Release note: none

Release justification: Low risk, high benefit changes to existing functionality