### PR TITLE
ccl/sqlproxyccl: add connection migration-related metrics

### DIFF
--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/base",
         "//pkg/ccl/sqlproxyccl/denylist",
         "//pkg/ccl/sqlproxyccl/idle",
         "//pkg/ccl/sqlproxyccl/interceptor",

--- a/pkg/ccl/sqlproxyccl/conn_migration.go
+++ b/pkg/ccl/sqlproxyccl/conn_migration.go
@@ -170,7 +170,7 @@ func (f *forwarder) runTransfer() (retErr error) {
 
 	// Transfer the connection.
 	clientConn, serverConn := f.getConns()
-	newServerConn, err := transferConnection(ctx, f.connector, clientConn, serverConn)
+	newServerConn, err := transferConnection(ctx, f.connector, f.metrics, clientConn, serverConn)
 	if err != nil {
 		return errors.Wrap(err, "transferring connection")
 	}
@@ -184,7 +184,10 @@ func (f *forwarder) runTransfer() (retErr error) {
 // connection, and returns the a new connection to the server that the
 // connection got transferred to.
 func transferConnection(
-	ctx *transferContext, connector *connector, clientConn, serverConn *interceptor.PGConn,
+	ctx *transferContext,
+	connector *connector,
+	metrics *metrics,
+	clientConn, serverConn *interceptor.PGConn,
 ) (_ *interceptor.PGConn, retErr error) {
 	ctx.markRecoverable(true)
 
@@ -203,7 +206,7 @@ func transferConnection(
 	}
 
 	transferErr, state, revivalToken, err := waitForShowTransferState(
-		ctx, serverConn.ToFrontendConn(), clientConn, transferKey)
+		ctx, serverConn.ToFrontendConn(), clientConn, transferKey, metrics)
 	if err != nil {
 		return nil, errors.Wrap(err, "waiting for transfer state")
 	}
@@ -311,6 +314,9 @@ var runShowTransferState = func(w io.Writer, transferKey string) error {
 // Since ReadyForQuery may be for a previous pipelined query, this handles the
 // forwarding of messages back to the client in case we don't see our state yet.
 //
+// metrics is optional, and if not nil, it will be used to record the transfer
+// response message size in ConnMigrationTransferResponseMessageSize.
+//
 // WARNING: When using this, we assume that no other goroutines are using both
 // serverConn and clientConn. In the context of a transfer, the response
 // processor must be blocked to avoid concurrent reads from serverConn.
@@ -319,6 +325,7 @@ var waitForShowTransferState = func(
 	serverConn *interceptor.FrontendConn,
 	clientConn io.Writer,
 	transferKey string,
+	metrics *metrics,
 ) (transferErr string, state string, revivalToken string, retErr error) {
 	// Wait for a response that looks like the following:
 	//
@@ -363,7 +370,7 @@ var waitForShowTransferState = func(
 	}
 
 	// 2. Read DataRow.
-	if err := expectDataRow(ctx, serverConn, func(msg *pgproto3.DataRow) bool {
+	if err := expectDataRow(ctx, serverConn, func(msg *pgproto3.DataRow, size int) bool {
 		// This has to be 4 since we validated RowDescription earlier.
 		if len(msg.Values) != 4 {
 			return false
@@ -381,6 +388,11 @@ var waitForShowTransferState = func(
 		// referenced in msg will no longer be valid once we read the next pgwire
 		// message.
 		transferErr, state, revivalToken = string(msg.Values[0]), string(msg.Values[1]), string(msg.Values[2])
+
+		// Since the DataRow is valid, record response message size.
+		if metrics != nil {
+			metrics.ConnMigrationTransferResponseMessageSize.RecordValue(int64(size))
+		}
 		return true
 	}); err != nil {
 		return "", "", "", errors.Wrap(err, "expecting DataRow")
@@ -448,7 +460,7 @@ var runAndWaitForDeserializeSession = func(
 	}
 
 	// 2. Read DataRow.
-	if err := expectDataRow(ctx, serverConn, func(msg *pgproto3.DataRow) bool {
+	if err := expectDataRow(ctx, serverConn, func(msg *pgproto3.DataRow, _ int) bool {
 		return len(msg.Values) == 1 && string(msg.Values[0]) == "t"
 	}); err != nil {
 		return errors.Wrap(err, "expecting DataRow")
@@ -565,10 +577,14 @@ func waitForSmallRowDescription(
 func expectDataRow(
 	ctx context.Context,
 	serverConn *interceptor.FrontendConn,
-	validateFn func(*pgproto3.DataRow) bool,
+	validateFn func(*pgproto3.DataRow, int) bool,
 ) error {
 	if ctx.Err() != nil {
 		return ctx.Err()
+	}
+	_, size, err := serverConn.PeekMsg()
+	if err != nil {
+		return errors.Wrap(err, "peeking message")
 	}
 	msg, err := serverConn.ReadMsg()
 	if err != nil {
@@ -578,7 +594,7 @@ func expectDataRow(
 	if !ok {
 		return errors.Newf("unexpected message: %v", jsonOrRaw(msg))
 	}
-	if !validateFn(pgMsg) {
+	if !validateFn(pgMsg, size) {
 		return errors.Newf("validation failed for message: %v", jsonOrRaw(msg))
 	}
 	return nil

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -948,6 +948,8 @@ func TestConnectionMigration(t *testing.T) {
 			require.Equal(t, f.metrics.ConnMigrationAttemptedCount.Count(),
 				f.metrics.ConnMigrationSuccessCount.Count(),
 			)
+			require.Equal(t, f.metrics.ConnMigrationAttemptedCount.Count(),
+				f.metrics.ConnMigrationAttemptedLatency.TotalCount())
 		})
 
 		// Transfers should fail if there is an open transaction. These failed
@@ -995,6 +997,8 @@ func TestConnectionMigration(t *testing.T) {
 			require.NotEqual(t, initAddr, queryAddr(t, tCtx, db))
 			require.Equal(t, prevErrorRecoverableCount, f.metrics.ConnMigrationErrorRecoverableCount.Count())
 			require.Equal(t, int64(0), f.metrics.ConnMigrationErrorFatalCount.Count())
+			require.Equal(t, f.metrics.ConnMigrationAttemptedCount.Count(),
+				f.metrics.ConnMigrationAttemptedLatency.TotalCount())
 
 			// We have already asserted metrics above, so transfer must have
 			// been completed.
@@ -1022,6 +1026,8 @@ func TestConnectionMigration(t *testing.T) {
 			require.Equal(t, initAddr, queryAddr(t, tCtx, db))
 			require.Equal(t, initSuccessCount, f.metrics.ConnMigrationSuccessCount.Count())
 			require.Equal(t, int64(0), f.metrics.ConnMigrationErrorFatalCount.Count())
+			require.Equal(t, f.metrics.ConnMigrationAttemptedCount.Count(),
+				f.metrics.ConnMigrationAttemptedLatency.TotalCount())
 
 			// We have already asserted metrics above, so transfer must have
 			// been completed.
@@ -1125,6 +1131,8 @@ func TestConnectionMigration(t *testing.T) {
 			return f.metrics.ConnMigrationErrorFatalCount.Count() == 1
 		}, 30*time.Second, 100*time.Millisecond)
 		require.NotNil(t, f.ctx.Err())
+		require.Equal(t, f.metrics.ConnMigrationAttemptedCount.Count(),
+			f.metrics.ConnMigrationAttemptedLatency.TotalCount())
 	})
 }
 

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -950,6 +950,8 @@ func TestConnectionMigration(t *testing.T) {
 			)
 			require.Equal(t, f.metrics.ConnMigrationAttemptedCount.Count(),
 				f.metrics.ConnMigrationAttemptedLatency.TotalCount())
+			require.Equal(t, f.metrics.ConnMigrationAttemptedCount.Count(),
+				f.metrics.ConnMigrationTransferResponseMessageSize.TotalCount())
 		})
 
 		// Transfers should fail if there is an open transaction. These failed
@@ -999,6 +1001,8 @@ func TestConnectionMigration(t *testing.T) {
 			require.Equal(t, int64(0), f.metrics.ConnMigrationErrorFatalCount.Count())
 			require.Equal(t, f.metrics.ConnMigrationAttemptedCount.Count(),
 				f.metrics.ConnMigrationAttemptedLatency.TotalCount())
+			require.Equal(t, f.metrics.ConnMigrationAttemptedCount.Count(),
+				f.metrics.ConnMigrationTransferResponseMessageSize.TotalCount())
 
 			// We have already asserted metrics above, so transfer must have
 			// been completed.
@@ -1028,6 +1032,8 @@ func TestConnectionMigration(t *testing.T) {
 			require.Equal(t, int64(0), f.metrics.ConnMigrationErrorFatalCount.Count())
 			require.Equal(t, f.metrics.ConnMigrationAttemptedCount.Count(),
 				f.metrics.ConnMigrationAttemptedLatency.TotalCount())
+			require.Equal(t, f.metrics.ConnMigrationAttemptedCount.Count(),
+				f.metrics.ConnMigrationTransferResponseMessageSize.TotalCount())
 
 			// We have already asserted metrics above, so transfer must have
 			// been completed.
@@ -1133,6 +1139,11 @@ func TestConnectionMigration(t *testing.T) {
 		require.NotNil(t, f.ctx.Err())
 		require.Equal(t, f.metrics.ConnMigrationAttemptedCount.Count(),
 			f.metrics.ConnMigrationAttemptedLatency.TotalCount())
+
+		// Here, we get a transfer timeout in response, so the message size
+		// should not be recorded.
+		require.Equal(t, f.metrics.ConnMigrationAttemptedCount.Count()-1,
+			f.metrics.ConnMigrationTransferResponseMessageSize.TotalCount())
 	})
 }
 


### PR DESCRIPTION
#### ccl/sqlproxyccl: add metric that measures connection migration latency

Previously, we added support for connection migration in https://github.com/cockroachdb/cockroach/pull/76805. This commit
adds a new `proxy.conn_migration.attempted.latency` metric that tracks latency
for attempted connection migrations. Having this metric would be beneficial
as we can now know how long users were blocked during connection migrations.

Release justification: Low-risk metric-only change within sqlproxy.

Release note: None

#### ccl/sqlproxyccl: add metric that records the transfer response message size

Informs #76000, and follow up to #76805.

This commit adds a new proxy.conn_migration.transfer_response.message_size
metric that will track the distribution of the transfer response message size.
This will be used to tune a value for the SQL cluster setting:
sql.session_transfer.max_session_size.

Release justification: Low-risk metric-only change within sqlproxy.

Release note: None