### PR TITLE
validate: check declarative schema changer state target status values

### DIFF
--- a/pkg/sql/catalog/internal/validate/schema_changer_state.go
+++ b/pkg/sql/catalog/internal/validate/schema_changer_state.go
@@ -48,6 +48,14 @@ func validateSchemaChangerState(d catalog.Descriptor, vea catalog.ValidationErro
 			report(errors.Errorf("target %d corresponds to descriptor %d != %d",
 				i, got, d.GetID()))
 		}
+
+		switch t.TargetStatus {
+		case scpb.Status_PUBLIC, scpb.Status_ABSENT, scpb.Status_TRANSIENT:
+			// These are valid target status values.
+		default:
+			report(errors.Errorf("target %d is targeting an invalid status %s",
+				i, t.TargetStatus))
+		}
 	}
 
 	// Validate that the various parallel fields are sound.

--- a/pkg/sql/catalog/internal/validate/schema_changer_state_test.go
+++ b/pkg/sql/catalog/internal/validate/schema_changer_state_test.go
@@ -89,7 +89,7 @@ func TestValidateSchemaChangerState(t *testing.T) {
 			ds: ds{
 				JobID: 1,
 				Targets: []scpb.Target{
-					scpb.MakeTarget(scpb.ToPublic, &scpb.Namespace{
+					scpb.MakeTarget(scpb.InvalidTarget, &scpb.Namespace{
 						DatabaseID:   2,
 						SchemaID:     2,
 						DescriptorID: 3,
@@ -112,6 +112,7 @@ func TestValidateSchemaChangerState(t *testing.T) {
 				},
 			},
 			expectedErrors: []string{
+				prefix + ` target 0 is targeting an invalid status UNKNOWN`,
 				prefix + ` unexpected statement 0 \(ALTER TABLE a RENAME TO b\)`,
 				prefix + ` missing statement for targets \(0\) / \(Namespace:\{DescID: 3, Name: foo, ReferencedDescID: 2\}\)`,
 			},


### PR DESCRIPTION
This commit adds a missing validation check in the descriptor validation
suite for the values of the target statuses in the declarative schema
changer state.

Release justification: low-risk high-benefit correctness check
Release note: None