### PR TITLE
kvaccessor: implement server-side pagination

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1644,9 +1644,6 @@ func (n *Node) GetSpanConfigs(
 func (n *Node) UpdateSpanConfigs(
 	ctx context.Context, req *roachpb.UpdateSpanConfigsRequest,
 ) (*roachpb.UpdateSpanConfigsResponse, error) {
-	// TODO(irfansharif): We want to protect ourselves from tenants creating
-	// outlandishly large string buffers here and OOM-ing the host cluster. Is
-	// the maximum protobuf message size enough of a safeguard?
 	toUpsert, err := spanconfig.EntriesToRecords(req.ToUpsert)
 	if err != nil {
 		return nil, err

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -557,6 +557,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		scKVAccessor := spanconfigkvaccessor.New(
 			db, internalExecutor, cfg.Settings,
 			systemschema.SpanConfigurationsTableName.FQString(),
+			spanConfigKnobs,
 		)
 		spanConfig.kvAccessor, spanConfig.kvAccessorForTenantRecords = scKVAccessor, scKVAccessor
 	} else {

--- a/pkg/spanconfig/spanconfigkvaccessor/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigkvaccessor/BUILD.bazel
@@ -47,6 +47,8 @@ go_test(
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
+        "//pkg/util/log",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/spanconfig/spanconfigkvaccessor/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigkvaccessor/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/kv",
         "//pkg/roachpb",
         "//pkg/security",
+        "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/spanconfig",
         "//pkg/sql/parser",

--- a/pkg/spanconfig/spanconfigkvaccessor/kvaccessor.go
+++ b/pkg/spanconfig/spanconfigkvaccessor/kvaccessor.go
@@ -353,59 +353,64 @@ func (k *KVAccessor) constructValidationStmtAndArgs(
 	// what we do in GetSpanConfigRecords. For a single upserted span, we
 	// want effectively validate using:
 	//
+	//   -- verify only a single span overlaps with [$start, $end)
 	//   SELECT count(*) = 1 FROM system.span_configurations
 	//    WHERE start_key < $end AND end_key > $start
 	//
-	// Applying the GetSpanConfigRecords treatment, we can arrive at:
+	// With the naive form above that translates to an unbounded index scan on
+	// followed by a filter. Since start_key < end_key, and that spans are
+	// non-overlapping, we can instead do the following:
 	//
-	//   SELECT count(*) = 1 FROM (
-	//    SELECT * FROM span_configurations
-	//     WHERE start_key >= 100 AND start_key < 105
+	//   SELECT bool_and(valid) FROM (
+	//    SELECT bool_and(prev_end_key IS NULL OR start_key >= prev_end_key) AS valid FROM (
+	//     SELECT start_key, lag(end_key, 1) OVER (ORDER BY start_key) AS prev_end_key FROM span_configurations
+	//     WHERE start_key >= $start AND start_key < $end
+	//    )
 	//    UNION ALL
 	//    SELECT * FROM (
-	//      SELECT * FROM span_configurations
-	//      WHERE start_key < 100 ORDER BY start_key DESC LIMIT 1
-	//    ) WHERE end_key > 100
+	//     SELECT $start >= end_key FROM span_configurations
+	//     WHERE start_key < $start ORDER BY start_key DESC LIMIT 1
+	//    )
 	//   )
 	//
-	// To batch multiple query spans into the same statement, we make use of
-	// ALL and UNION ALL.
+	// The idea is to first find all spans that start within the span being
+	// upserted[1], compare each start key to the preceding end key[2] (if any)
+	// and ensure that they're non-overlapping[3]. We also verify the span with
+	// the start key immediately preceding the span being upserted[4]; ensuring
+	// that our upserted span does not overlap with it[5].
 	//
-	//   SELECT true = ALL(
-	//     ( ... validation statement for 1st query span ...),
-	//     UNION ALL
-	//     ( ... validation statement for 2nd query span ...),
-	//     ...
-	//   )
+	// When multiple spans are being upserted, we validate instead the span
+	// straddling all the individual spans being upserted, i.e.
+	// [$smallest-start-key, $largest-end-key).
 	//
-	var validationInnerStmtBuilder strings.Builder
-	validationQueryArgs := make([]interface{}, len(toUpsert)*2)
-	for i, entry := range toUpsert {
-		if i > 0 {
-			validationInnerStmtBuilder.WriteString(`UNION ALL`)
-		}
+	// [1]: WHERE start_key >= $start AND start_key < $end
+	// [2]: lag(end_key, 1) OVER (ORDER BY start_key) AS prev_end_key
+	// [3]: start_key >= prev_end_key
+	// [4]: WHERE start_key < $start ORDER BY start_key DESC LIMIT 1
+	// [5]: $start >= end_key
+	//
+	targetsToUpsert := spanconfig.TargetsFromRecords(toUpsert)
+	sort.Sort(spanconfig.Targets(targetsToUpsert))
 
-		startKeyIdx, endKeyIdx := i*2, (i*2)+1
-		validationQueryArgs[startKeyIdx] = entry.GetTarget().Encode().Key
-		validationQueryArgs[endKeyIdx] = entry.GetTarget().Encode().EndKey
+	validationQueryArgs := make([]interface{}, 2)
+	validationQueryArgs[0] = targetsToUpsert[0].Encode().Key
+	// NB: This is the largest key due to sort above + validation at the caller
+	// than ensures non-overlapping upser spans.
+	validationQueryArgs[1] = targetsToUpsert[len(targetsToUpsert)-1].Encode().EndKey
 
-		fmt.Fprintf(&validationInnerStmtBuilder, `
-SELECT count(*) = 1 FROM (
-  SELECT start_key, end_key, config FROM %[1]s
-   WHERE start_key >= $%[2]d AND start_key < $%[3]d
+	validationStmt := fmt.Sprintf(`
+SELECT bool_and(valid) FROM (
+  SELECT bool_and(prev_end_key IS NULL OR start_key >= prev_end_key) AS valid FROM (
+    SELECT start_key, lag(end_key, 1) OVER (ORDER BY start_key) AS prev_end_key FROM %[1]s
+    WHERE start_key >= $1 AND start_key < $2
+  )
   UNION ALL
-  SELECT start_key, end_key, config FROM (
-    SELECT start_key, end_key, config FROM %[1]s
-    WHERE start_key < $%[2]d ORDER BY start_key DESC LIMIT 1
-  ) WHERE end_key > $%[2]d
-)
-`,
-			k.configurationsTableFQN, // [1]
-			startKeyIdx+1,            // [2] -- prepared statement placeholder (1-indexed)
-			endKeyIdx+1,              // [3] -- prepared statement placeholder (1-indexed)
-		)
-	}
-	validationStmt := fmt.Sprintf("SELECT true = ALL(%s)", validationInnerStmtBuilder.String())
+  SELECT * FROM (
+    SELECT $1 >= end_key FROM %[1]s
+    WHERE start_key < $1 ORDER BY start_key DESC LIMIT 1
+  )
+)`, k.configurationsTableFQN)
+
 	return validationStmt, validationQueryArgs
 }
 
@@ -414,14 +419,7 @@ SELECT count(*) = 1 FROM (
 // expected to be valid and to have non-empty end keys. Spans are also expected
 // to be non-overlapping with other spans in the same list.
 func validateUpdateArgs(toDelete []spanconfig.Target, toUpsert []spanconfig.Record) error {
-	targetsToUpdate := func(recs []spanconfig.Record) []spanconfig.Target {
-		targets := make([]spanconfig.Target, len(recs))
-		for i, ent := range recs {
-			targets[i] = ent.GetTarget()
-		}
-		return targets
-	}(toUpsert)
-
+	targetsToUpdate := spanconfig.TargetsFromRecords(toUpsert)
 	for _, list := range [][]spanconfig.Target{toDelete, targetsToUpdate} {
 		if err := validateSpanTargets(list); err != nil {
 			return err

--- a/pkg/spanconfig/spanconfigkvaccessor/kvaccessor.go
+++ b/pkg/spanconfig/spanconfigkvaccessor/kvaccessor.go
@@ -13,12 +13,14 @@ package spanconfigkvaccessor
 import (
 	"context"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -28,6 +30,16 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
+)
+
+// batchSizeSetting is a hidden cluster setting to control how many span config
+// records we access in a single batch, beyond which we start paginating.
+// No limit enforced if set to zero (or something negative).
+var batchSizeSetting = settings.RegisterIntSetting(
+	settings.SystemOnly,
+	"spanconfig.kvaccessor.batch_size",
+	`number of span config records to access in a single batch`,
+	10000,
 )
 
 // KVAccessor provides read/write access to all the span configurations for a
@@ -45,19 +57,25 @@ type KVAccessor struct {
 	// configurationsTableFQN is typically 'system.public.span_configurations',
 	// but left configurable for ease-of-testing.
 	configurationsTableFQN string
+
+	knobs *spanconfig.TestingKnobs
 }
 
 var _ spanconfig.KVAccessor = &KVAccessor{}
 
 // New constructs a new KVAccessor.
 func New(
-	db *kv.DB, ie sqlutil.InternalExecutor, settings *cluster.Settings, configurationsTableFQN string,
+	db *kv.DB,
+	ie sqlutil.InternalExecutor,
+	settings *cluster.Settings,
+	configurationsTableFQN string,
+	knobs *spanconfig.TestingKnobs,
 ) *KVAccessor {
 	if _, err := parser.ParseQualifiedTableName(configurationsTableFQN); err != nil {
 		panic(fmt.Sprintf("unabled to parse configurations table FQN: %s", configurationsTableFQN))
 	}
 
-	return newKVAccessor(db, ie, settings, configurationsTableFQN, nil /* optionalTxn */)
+	return newKVAccessor(db, ie, settings, configurationsTableFQN, knobs, nil /* optionalTxn */)
 }
 
 // WithTxn is part of the KVAccessor interface.
@@ -65,7 +83,7 @@ func (k *KVAccessor) WithTxn(ctx context.Context, txn *kv.Txn) spanconfig.KVAcce
 	if k.optionalTxn != nil {
 		log.Fatalf(ctx, "KVAccessor already scoped to txn (was .WithTxn(...) chained multiple times?)")
 	}
-	return newKVAccessor(k.db, k.ie, k.settings, k.configurationsTableFQN, txn)
+	return newKVAccessor(k.db, k.ie, k.settings, k.configurationsTableFQN, k.knobs, txn)
 }
 
 // GetSpanConfigRecords is part of the KVAccessor interface.
@@ -106,66 +124,79 @@ func newKVAccessor(
 	ie sqlutil.InternalExecutor,
 	settings *cluster.Settings,
 	configurationsTableFQN string,
+	knobs *spanconfig.TestingKnobs,
 	optionalTxn *kv.Txn,
 ) *KVAccessor {
+	if knobs == nil {
+		knobs = &spanconfig.TestingKnobs{}
+	}
 	return &KVAccessor{
 		db:                     db,
 		ie:                     ie,
 		optionalTxn:            optionalTxn,
 		settings:               settings,
 		configurationsTableFQN: configurationsTableFQN,
+		knobs:                  knobs,
 	}
 }
 
 func (k *KVAccessor) getSpanConfigRecordsWithTxn(
 	ctx context.Context, targets []spanconfig.Target, txn *kv.Txn,
-) (records []spanconfig.Record, retErr error) {
+) ([]spanconfig.Record, error) {
 	if txn == nil {
 		log.Fatalf(ctx, "expected non-nil txn")
 	}
 
 	if len(targets) == 0 {
-		return records, nil
+		return nil, nil
 	}
 	if err := validateSpanTargets(targets); err != nil {
 		return nil, err
 	}
 
-	getStmt, getQueryArgs := k.constructGetStmtAndArgs(targets)
-	it, err := k.ie.QueryIteratorEx(ctx, "get-span-cfgs", txn,
-		sessiondata.InternalExecutorOverride{User: security.RootUserName()},
-		getStmt, getQueryArgs...,
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if closeErr := it.Close(); closeErr != nil {
-			records, retErr = nil, errors.CombineErrors(retErr, closeErr)
-		}
-	}()
-
-	var ok bool
-	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
-		row := it.Cur()
-		span := roachpb.Span{
-			Key:    []byte(*row[0].(*tree.DBytes)),
-			EndKey: []byte(*row[1].(*tree.DBytes)),
-		}
-		var conf roachpb.SpanConfig
-		if err := protoutil.Unmarshal(([]byte)(*row[2].(*tree.DBytes)), &conf); err != nil {
-			return nil, err
-		}
-
-		record, err := spanconfig.MakeRecord(spanconfig.DecodeTarget(span), conf)
+	var records []spanconfig.Record
+	if err := k.paginate(len(targets), func(startIdx, endIdx int) (retErr error) {
+		targetsBatch := targets[startIdx:endIdx]
+		getStmt, getQueryArgs := k.constructGetStmtAndArgs(targetsBatch)
+		it, err := k.ie.QueryIteratorEx(ctx, "get-span-cfgs", txn,
+			sessiondata.InternalExecutorOverride{User: security.RootUserName()},
+			getStmt, getQueryArgs...,
+		)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		records = append(records, record)
-	}
-	if err != nil {
+		defer func() {
+			if closeErr := it.Close(); closeErr != nil {
+				records, retErr = nil, errors.CombineErrors(retErr, closeErr)
+			}
+		}()
+
+		var ok bool
+		for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
+			row := it.Cur()
+			span := roachpb.Span{
+				Key:    []byte(*row[0].(*tree.DBytes)),
+				EndKey: []byte(*row[1].(*tree.DBytes)),
+			}
+			var conf roachpb.SpanConfig
+			if err := protoutil.Unmarshal(([]byte)(*row[2].(*tree.DBytes)), &conf); err != nil {
+				return err
+			}
+
+			record, err := spanconfig.MakeRecord(spanconfig.DecodeTarget(span), conf)
+			if err != nil {
+				return err
+			}
+			records = append(records, record)
+		}
+		if err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
 		return nil, err
 	}
+
 	return records, nil
 }
 
@@ -181,17 +212,22 @@ func (k *KVAccessor) updateSpanConfigRecordsWithTxn(
 	}
 
 	if len(toDelete) > 0 {
-		deleteStmt, deleteQueryArgs := k.constructDeleteStmtAndArgs(toDelete)
-
-		n, err := k.ie.ExecEx(ctx, "delete-span-cfgs", txn,
-			sessiondata.InternalExecutorOverride{User: security.RootUserName()},
-			deleteStmt, deleteQueryArgs...,
-		)
-		if err != nil {
+		if err := k.paginate(len(toDelete), func(startIdx, endIdx int) error {
+			toDeleteBatch := toDelete[startIdx:endIdx]
+			deleteStmt, deleteQueryArgs := k.constructDeleteStmtAndArgs(toDeleteBatch)
+			n, err := k.ie.ExecEx(ctx, "delete-span-cfgs", txn,
+				sessiondata.InternalExecutorOverride{User: security.RootUserName()},
+				deleteStmt, deleteQueryArgs...,
+			)
+			if err != nil {
+				return err
+			}
+			if n != len(toDeleteBatch) {
+				return errors.AssertionFailedf("expected to delete %d row(s), deleted %d", len(toDeleteBatch), n)
+			}
+			return nil
+		}); err != nil {
 			return err
-		}
-		if n != len(toDelete) {
-			return errors.AssertionFailedf("expected to delete %d row(s), deleted %d", len(toDelete), n)
 		}
 	}
 
@@ -199,31 +235,32 @@ func (k *KVAccessor) updateSpanConfigRecordsWithTxn(
 		return nil // nothing left to do
 	}
 
-	upsertStmt, upsertQueryArgs, err := k.constructUpsertStmtAndArgs(toUpsert)
-	if err != nil {
-		return err
-	}
+	return k.paginate(len(toUpsert), func(startIdx, endIdx int) error {
+		toUpsertBatch := toUpsert[startIdx:endIdx]
+		upsertStmt, upsertQueryArgs, err := k.constructUpsertStmtAndArgs(toUpsertBatch)
+		if err != nil {
+			return err
+		}
+		if n, err := k.ie.ExecEx(ctx, "upsert-span-cfgs", txn,
+			sessiondata.InternalExecutorOverride{User: security.RootUserName()},
+			upsertStmt, upsertQueryArgs...,
+		); err != nil {
+			return err
+		} else if n != len(toUpsertBatch) {
+			return errors.AssertionFailedf("expected to upsert %d row(s), upserted %d", len(toUpsertBatch), n)
+		}
 
-	if n, err := k.ie.ExecEx(ctx, "upsert-span-cfgs", txn,
-		sessiondata.InternalExecutorOverride{User: security.RootUserName()},
-		upsertStmt, upsertQueryArgs...,
-	); err != nil {
-		return err
-	} else if n != len(toUpsert) {
-		return errors.AssertionFailedf("expected to upsert %d row(s), upserted %d", len(toUpsert), n)
-	}
-
-	validationStmt, validationQueryArgs := k.constructValidationStmtAndArgs(toUpsert)
-	if datums, err := k.ie.QueryRowEx(ctx, "validate-span-cfgs", txn,
-		sessiondata.InternalExecutorOverride{User: security.RootUserName()},
-		validationStmt, validationQueryArgs...,
-	); err != nil {
-		return err
-	} else if valid := bool(tree.MustBeDBool(datums[0])); !valid {
-		return errors.AssertionFailedf("expected to find single row containing upserted spans")
-	}
-
-	return nil
+		validationStmt, validationQueryArgs := k.constructValidationStmtAndArgs(toUpsertBatch)
+		if datums, err := k.ie.QueryRowEx(ctx, "validate-span-cfgs", txn,
+			sessiondata.InternalExecutorOverride{User: security.RootUserName()},
+			validationStmt, validationQueryArgs...,
+		); err != nil {
+			return err
+		} else if valid := bool(tree.MustBeDBool(datums[0])); !valid {
+			return errors.AssertionFailedf("expected to find single row containing upserted spans")
+		}
+		return nil
+	})
 }
 
 // constructGetStmtAndArgs constructs the statement and query arguments needed
@@ -494,6 +531,36 @@ func validateSpans(spans ...roachpb.Span) error {
 	for _, span := range spans {
 		if !span.Valid() || len(span.EndKey) == 0 {
 			return errors.AssertionFailedf("invalid span: %s", span)
+		}
+	}
+	return nil
+}
+
+// paginate is a helper method to paginate through a list with the batch size
+// controlled by the spanconfig.kvaccessor.batch_size setting. It invokes the
+// provided callback with the [start,end) indexes over the original list.
+func (k *KVAccessor) paginate(totalLen int, f func(startIdx, endIdx int) error) error {
+	batchSize := math.MaxInt32
+	if b := batchSizeSetting.Get(&k.settings.SV); int(b) > 0 {
+		batchSize = int(b) // check for overflow, negative or 0 value
+	}
+
+	if fn := k.knobs.KVAccessorBatchSizeOverrideFn; fn != nil {
+		batchSize = fn()
+	}
+
+	for i := 0; i < totalLen; i += batchSize {
+		j := i + batchSize
+		if j > totalLen {
+			j = totalLen
+		}
+
+		if fn := k.knobs.KVAccessorPaginationInterceptor; fn != nil {
+			fn()
+		}
+
+		if err := f(i, j); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/pkg/spanconfig/spanconfigkvaccessor/kvaccessor.go
+++ b/pkg/spanconfig/spanconfigkvaccessor/kvaccessor.go
@@ -395,7 +395,7 @@ func (k *KVAccessor) constructValidationStmtAndArgs(
 	validationQueryArgs := make([]interface{}, 2)
 	validationQueryArgs[0] = targetsToUpsert[0].Encode().Key
 	// NB: This is the largest key due to sort above + validation at the caller
-	// than ensures non-overlapping upser spans.
+	// than ensures non-overlapping upsert spans.
 	validationQueryArgs[1] = targetsToUpsert[len(targetsToUpsert)-1].Encode().EndKey
 
 	validationStmt := fmt.Sprintf(`

--- a/pkg/spanconfig/spanconfigkvaccessor/testdata/validation_encompass
+++ b/pkg/spanconfig/spanconfigkvaccessor/testdata/validation_encompass
@@ -1,0 +1,60 @@
+# Test a few instances where the kvaccessor validation should prevent us from
+# violating table invariants (installed spans are non-overlapping).
+# Specifically when updates overlap with and/or encompass spans already
+# present.
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state
+# set        [-A)  [-B|-C)  [--D--)
+kvaccessor-update
+upsert [b,c):A
+upsert [d,e):B
+upsert [e,f):C
+upsert [g,i):D
+----
+ok
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-A)  [-B|-C)  [--D--)
+# set     [--------X--------)
+kvaccessor-update
+upsert [a,g):X
+----
+err: expected to find single row containing upserted spans
+
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-A)  [-B|-C)  [--D--)
+# set     [--------X--|----Y---)
+kvaccessor-update
+upsert [a,e):X
+upsert [e,h):Y
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-A)  [-B|-C)  [--D--)
+# set     [--------X-----------)
+kvaccessor-update
+upsert [a,h):X
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-A)  [-B|-C)  [--D--)
+# set     [--------X-----|--Y--)
+kvaccessor-update
+upsert [a,f):X
+upsert [f,h):Y
+----
+err: expected to find single row containing upserted spans
+
+# All of the attempts above should've errored out -- expect to find the actual
+# state unchanged.
+kvaccessor-get
+span [a,j)
+----
+[b,c):A
+[d,e):B
+[e,f):C
+[g,i):D

--- a/pkg/spanconfig/spanconfigkvaccessor/testdata/validation_overlapping
+++ b/pkg/spanconfig/spanconfigkvaccessor/testdata/validation_overlapping
@@ -1,0 +1,159 @@
+# Test a few instances where the kvaccessor validation should prevent us from #
+# violating table invariants (installed spans are non-overlapping).
+# Specifically when updates partially overlap with what's already present.
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state
+# set        [-----X--------)
+# ====================================
+# result     [-----X--------)
+kvaccessor-update
+upsert [b,g):X
+----
+ok
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)
+kvaccessor-update
+upsert [a,c):A
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)              [--B--)
+kvaccessor-update
+upsert [a,c):A
+upsert [h,j):B
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)        [--B--)
+kvaccessor-update
+upsert [a,c):A
+upsert [f,h):B
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)     [--B--)
+kvaccessor-update
+upsert [a,c):A
+upsert [e,g):B
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)  [--B--)
+kvaccessor-update
+upsert [a,c):A
+upsert [d,f):B
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set           [--A--|--B--)
+kvaccessor-update
+upsert [c,e):A
+upsert [e,g):B
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)  [-B)  [--C--)
+kvaccessor-update
+upsert [a,c):A
+upsert [d,e):B
+upsert [f,h):C
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)  [-B)  [-C)
+kvaccessor-update
+upsert [a,c):A
+upsert [d,e):B
+upsert [f,g):C
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set              [-B)
+kvaccessor-update
+upsert [d,e):B
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set                    [-C)
+kvaccessor-update
+upsert [f,g):C
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)  [-B|-C|--D--)
+kvaccessor-update
+upsert [a,c):A
+upsert [d,e):B
+upsert [e,f):C
+upsert [f,h):D
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)              [--B--)
+kvaccessor-update
+upsert [a,c):A
+upsert [h,j):B
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)        [--B--)
+kvaccessor-update
+upsert [a,c):A
+upsert [f,h):B
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)     [--B--)
+# ====================================
+# result         [-X--|--B--)
+kvaccessor-update
+upsert [a,c):A
+upsert [e,g):B
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)  [-B)  [--C--)
+kvaccessor-update
+upsert [a,c):A
+upsert [d,e):B
+upsert [f,h):C
+----
+err: expected to find single row containing upserted spans
+
+# All of the attempts above should've errored out -- expect to find the actual
+# state unchanged.
+kvaccessor-get
+span [a,j)
+----
+[b,g):X

--- a/pkg/spanconfig/spanconfigkvaccessor/testdata/validation_straddle
+++ b/pkg/spanconfig/spanconfigkvaccessor/testdata/validation_straddle
@@ -1,0 +1,96 @@
+# Test a few instances where the kvaccessor validation should prevent us from
+# violating table invariants (installed spans are non-overlapping).
+# Specifically when updates overlap with and/or straddle multiple existing spans.
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state
+# set        [--A--)  [--B--)
+kvaccessor-update
+upsert [b,d):A
+upsert [e,g):B
+----
+ok
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set           [---X----)
+kvaccessor-update
+upsert [c,f):X
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set           [---X-------)
+kvaccessor-update
+upsert [c,g):X
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set           [---X----|xx)
+kvaccessor-update
+upsert [c,f):X
+delete [f,g)
+----
+err: expected to delete 1 row(s), deleted 0
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set           [---X----------)
+kvaccessor-update
+upsert [c,h):X
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set        [---X-------)
+kvaccessor-update
+upsert [b,f):X
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set     [------X-------)
+kvaccessor-update
+upsert [a,f):X
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set           [---X----)
+kvaccessor-update
+upsert [c,f):X
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set     [--X--|---Y----------)
+kvaccessor-update
+upsert [a,c):X
+upsert [c,h):Y
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set        [--X--|--Y--|-Z)
+kvaccessor-update
+upsert [b,d):X
+upsert [d,f):Y
+upsert [f,g):Z
+----
+err: expected to find single row containing upserted spans
+
+# All of the attempts above should've errored out -- expect to find the actual
+# state unchanged.
+kvaccessor-get
+span [a,j)
+----
+[b,d):A
+[e,g):B

--- a/pkg/spanconfig/spanconfigkvsubscriber/datadriven_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/datadriven_test.go
@@ -128,6 +128,7 @@ func TestDataDriven(t *testing.T) {
 			tc.Server(0).InternalExecutor().(sqlutil.InternalExecutor),
 			tc.Server(0).ClusterSettings(),
 			fmt.Sprintf("defaultdb.public.%s", dummyTableName),
+			nil, /* knobs */
 		)
 
 		mu := struct {

--- a/pkg/spanconfig/spanconfigtestutils/utils.go
+++ b/pkg/spanconfig/spanconfigtestutils/utils.go
@@ -45,7 +45,7 @@ var configRe = regexp.MustCompile(`^(FALLBACK)|(^\w)$`)
 
 // ParseSpan is helper function that constructs a roachpb.Span from a string of
 // the form "[start, end)".
-func ParseSpan(t *testing.T, sp string) roachpb.Span {
+func ParseSpan(t testing.TB, sp string) roachpb.Span {
 	if !spanRe.MatchString(sp) {
 		t.Fatalf("expected %s to match span regex", sp)
 	}
@@ -60,7 +60,7 @@ func ParseSpan(t *testing.T, sp string) roachpb.Span {
 
 // parseSystemTarget is a helepr function that constructs a
 // spanconfig.SystemTarget from a string of the form {source=<id>,target=<id>}
-func parseSystemTarget(t *testing.T, systemTarget string) spanconfig.SystemTarget {
+func parseSystemTarget(t testing.TB, systemTarget string) spanconfig.SystemTarget {
 	if !systemTargetRe.MatchString(systemTarget) {
 		t.Fatalf("expected %s to match system target regex", systemTargetRe)
 	}
@@ -86,7 +86,7 @@ func parseSystemTarget(t *testing.T, systemTarget string) spanconfig.SystemTarge
 
 // ParseTarget is a helper function that constructs a spanconfig.Target from a
 // string that conforms to spanRe.
-func ParseTarget(t *testing.T, target string) spanconfig.Target {
+func ParseTarget(t testing.TB, target string) spanconfig.Target {
 	switch {
 	case spanRe.MatchString(target):
 		return spanconfig.MakeTargetFromSpan(ParseSpan(t, target))
@@ -101,7 +101,7 @@ func ParseTarget(t *testing.T, target string) spanconfig.Target {
 // ParseConfig is helper function that constructs a roachpb.SpanConfig that's
 // "tagged" with the given string (i.e. a constraint with the given string a
 // required key).
-func ParseConfig(t *testing.T, conf string) roachpb.SpanConfig {
+func ParseConfig(t testing.TB, conf string) roachpb.SpanConfig {
 	if !configRe.MatchString(conf) {
 		t.Fatalf("expected %s to match config regex", conf)
 	}
@@ -129,7 +129,7 @@ func ParseConfig(t *testing.T, conf string) roachpb.SpanConfig {
 // ParseSpanConfigRecord is helper function that constructs a
 // spanconfig.Target from a string of the form target:config. See
 // ParseTarget and ParseConfig above.
-func ParseSpanConfigRecord(t *testing.T, conf string) spanconfig.Record {
+func ParseSpanConfigRecord(t testing.TB, conf string) spanconfig.Record {
 	parts := strings.Split(conf, ":")
 	if len(parts) != 2 {
 		t.Fatalf("expected single %q separator", ":")
@@ -151,7 +151,7 @@ func ParseSpanConfigRecord(t *testing.T, conf string) spanconfig.Record {
 //		system-target {source=20,target=20}
 //		system-target {source=1,target=20}
 //
-func ParseKVAccessorGetArguments(t *testing.T, input string) []spanconfig.Target {
+func ParseKVAccessorGetArguments(t testing.TB, input string) []spanconfig.Target {
 	var targets []spanconfig.Target
 	for _, line := range strings.Split(input, "\n") {
 		line = strings.TrimSpace(line)
@@ -192,7 +192,7 @@ func ParseKVAccessorGetArguments(t *testing.T, input string) []spanconfig.Target
 // 		delete {source=1,target=20}:D
 //
 func ParseKVAccessorUpdateArguments(
-	t *testing.T, input string,
+	t testing.TB, input string,
 ) ([]spanconfig.Target, []spanconfig.Record) {
 	var toDelete []spanconfig.Target
 	var toUpsert []spanconfig.Record
@@ -225,7 +225,7 @@ func ParseKVAccessorUpdateArguments(
 //      set [c,d):C
 //      set [d,e):D
 //
-func ParseStoreApplyArguments(t *testing.T, input string) (updates []spanconfig.Update) {
+func ParseStoreApplyArguments(t testing.TB, input string) (updates []spanconfig.Update) {
 	for _, line := range strings.Split(input, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -274,7 +274,7 @@ func PrintSpan(sp roachpb.Span) string {
 }
 
 // PrintTarget is a helper function that prints a spanconfig.Target.
-func PrintTarget(t *testing.T, target spanconfig.Target) string {
+func PrintTarget(t testing.TB, target spanconfig.Target) string {
 	switch {
 	case target.IsSpanTarget():
 		return PrintSpan(target.GetSpan())
@@ -311,7 +311,7 @@ func PrintSpanConfig(config roachpb.SpanConfig) string {
 // entry is assumed to either have been constructed using ParseSpanConfigRecord
 // above, or the constituent span and config to have been constructed using the
 // Parse{Span,Config} helpers above.
-func PrintSpanConfigRecord(t *testing.T, record spanconfig.Record) string {
+func PrintSpanConfigRecord(t testing.TB, record spanconfig.Record) string {
 	return fmt.Sprintf("%s:%s", PrintTarget(t, record.GetTarget()), PrintSpanConfig(record.GetConfig()))
 }
 
@@ -478,7 +478,7 @@ func (rs SplitPoints) String() string {
 
 // GetSplitPoints returns a list of range split points as suggested by the given
 // StoreReader.
-func GetSplitPoints(ctx context.Context, t *testing.T, reader spanconfig.StoreReader) SplitPoints {
+func GetSplitPoints(ctx context.Context, t testing.TB, reader spanconfig.StoreReader) SplitPoints {
 	var splitPoints []SplitPoint
 	splitKey := roachpb.RKeyMin
 	for {
@@ -501,7 +501,7 @@ func GetSplitPoints(ctx context.Context, t *testing.T, reader spanconfig.StoreRe
 
 // ParseProtectionTarget returns a ptpb.Target based on the input. This target
 // could either refer to a Cluster, list of Tenants or SchemaObjects.
-func ParseProtectionTarget(t *testing.T, input string) *ptpb.Target {
+func ParseProtectionTarget(t testing.TB, input string) *ptpb.Target {
 	line := strings.Split(input, "\n")
 	if len(line) != 1 {
 		t.Fatal("only one target must be specified per protectedts operation")

--- a/pkg/spanconfig/target.go
+++ b/pkg/spanconfig/target.go
@@ -283,6 +283,16 @@ func TargetsFromProtos(protoTargets []roachpb.SpanConfigTarget) ([]Target, error
 	return targets, nil
 }
 
+// TargetsFromRecords extracts the list of underlying targets from the given
+// list of Records.
+func TargetsFromRecords(records []Record) []Target {
+	targets := make([]Target, len(records))
+	for i, rec := range records {
+		targets[i] = rec.GetTarget()
+	}
+	return targets
+}
+
 // TestingEntireSpanConfigurationStateTargets returns a list of targets which
 // can be used to read the entire span configuration state. This includes all
 // span configurations installed by all tenants and all system span

--- a/pkg/spanconfig/testing_knobs.go
+++ b/pkg/spanconfig/testing_knobs.go
@@ -57,6 +57,14 @@ type TestingKnobs struct {
 	// setting up a new store.
 	StoreKVSubscriberOverride KVSubscriber
 
+	// KVAccessorPaginationInterceptor, if set, is invoked on every pagination
+	// event.
+	KVAccessorPaginationInterceptor func()
+
+	// KVAccessorBatchSizeOverride overrides the batch size KVAccessor makes use
+	// of internally.
+	KVAccessorBatchSizeOverrideFn func() int
+
 	// SQLWatcherOnEventInterceptor, if set, is invoked when the SQLWatcher
 	// receives an event on one of its rangefeeds.
 	SQLWatcherOnEventInterceptor func() error


### PR DESCRIPTION
Fixes #77505. The KVAccessor did not previously paginate -- it was
possible then for large requests (think initial reconciliation with a
large number of descriptors) to generate write batches that could exceed
max raft command size limits. The KVAccessor is also backed by a system
table. In order to function, it dynamically constructed SQL statements
proportional in size to the size of the request. That too was slightly
worrisome -- large enough requests could maybe result in server-side
OOMs.

This commit introduces server-side pagination to mitigate both risks.

Release justification: low risk, high benefit changes
Release note: None