### PR TITLE
db-console: make all tests run again

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/cachedDataReducer.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/cachedDataReducer.spec.ts
@@ -339,7 +339,7 @@ describe("keyed cachedDataReducer", function() {
   });
 });
 
-describe.only("PaginatedCachedDataReducer", function() {
+describe("PaginatedCachedDataReducer", function() {
   class Request implements WithPaginationRequest {
     constructor(
       public request: string,


### PR DESCRIPTION
A `describe.only` snuck into one of the db-console test files, causing the other tests in that project to be skipped. Remove the `.only` part so all tests run again.

Release justification: Not production-facing.
Release note: None