### PR TITLE
ui: change sql box height for Statement Details

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sql/box.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sql/box.tsx
@@ -15,10 +15,16 @@ import classNames from "classnames/bind";
 import styles from "./sqlhighlight.module.scss";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
 
+export enum SqlBoxSize {
+  small = "small",
+  large = "large",
+}
+
 export interface SqlBoxProps {
   value: string;
   zone?: protos.cockroach.server.serverpb.DatabaseDetailsResponse;
   className?: string;
+  size?: SqlBoxSize;
 }
 
 const cx = classNames.bind(styles);
@@ -26,8 +32,9 @@ const cx = classNames.bind(styles);
 export class SqlBox extends React.Component<SqlBoxProps> {
   preNode: React.RefObject<HTMLPreElement> = React.createRef();
   render() {
+    const sizeClass = this.props.size ? this.props.size : "";
     return (
-      <div className={cx("box-highlight", this.props.className)}>
+      <div className={cx("box-highlight", this.props.className, sizeClass)}>
         <Highlight {...this.props} />
       </div>
     );

--- a/pkg/ui/workspaces/cluster-ui/src/sql/sqlhighlight.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sql/sqlhighlight.module.scss
@@ -50,6 +50,14 @@
   }
 }
 
+.small {
+  height: 200px;
+}
+
+.large {
+  height: 400px;
+}
+
 .highlight-divider {
 	width: 100%;
 	height: 1px;

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
@@ -17,7 +17,7 @@ import {
   PlanHashStats,
 } from "./plansTable";
 import { Button } from "../../button";
-import { SqlBox } from "../../sql";
+import { SqlBox, SqlBoxSize } from "../../sql";
 
 interface PlanDetailsProps {
   plans: PlanHashStats[];
@@ -70,7 +70,7 @@ function renderExplainPlan(
       >
         All Plans
       </Button>
-      <SqlBox value={plan.explain_plan} />
+      <SqlBox value={plan.explain_plan} size={SqlBoxSize.large} />
     </div>
   );
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -38,7 +38,7 @@ import {
 } from "src/util";
 import { Loading } from "src/loading";
 import { Button } from "src/button";
-import { SqlBox } from "src/sql";
+import { SqlBox, SqlBoxSize } from "src/sql";
 import { SortSetting } from "src/sortedtable";
 import { Tooltip } from "@cockroachlabs/ui-components";
 import { PlanDetails } from "./planDetails";
@@ -541,7 +541,7 @@ export class StatementDetails extends React.Component<
         <TabPane tab="Overview" key="overview">
           <Row gutter={24}>
             <Col className="gutter-row" span={24}>
-              <SqlBox value={formatted_query} />
+              <SqlBox value={formatted_query} size={SqlBoxSize.small} />
             </Col>
           </Row>
           <Row gutter={24}>
@@ -777,7 +777,7 @@ export class StatementDetails extends React.Component<
         <TabPane tab="Explain Plan" key="explain-plan">
           <Row gutter={24}>
             <Col className="gutter-row" span={24}>
-              <SqlBox value={formatted_query} />
+              <SqlBox value={formatted_query} size={SqlBoxSize.small} />
             </Col>
           </Row>
           <p className={summaryCardStylesCx("summary--card__divider")} />


### PR DESCRIPTION
Change the height of SQL Box on Statement Details,
with the query box smaller (200px) and the Explain Plan
larger (400px);

Release justification: low risk change
Release note: None

<img width="1584" alt="Screen Shot 2022-03-11 at 9 05 08 PM" src="https://user-images.githubusercontent.com/1017486/157999646-b7824634-d030-4aee-b826-75dd03e1037d.png">

