### PR TITLE
kvserver/reports: fix `nil` check in `replicationStatsVisitor`

### DIFF
--- a/pkg/kv/kvserver/reports/replication_stats_report.go
+++ b/pkg/kv/kvserver/reports/replication_stats_report.go
@@ -370,7 +370,7 @@ func (v *replicationStatsVisitor) visitNewZone(
 				desiredNumVoters = int(*zone.NumVoters)
 				return true
 			}
-			if *zone.NumReplicas != 0 && desiredNumVoters == 0 {
+			if zone.NumReplicas != nil && desiredNumVoters == 0 {
 				desiredNumVoters = int(*zone.NumReplicas)
 			}
 			// We had already found the zone to report to, but we're haven't found


### PR DESCRIPTION
This fixes a nil pointer dereference in
`replicationStatsVisitor.visitNewZone`.

Resolves #77680.
Touches #76430.

Release justification: bug fixes and low-risk updates to new
functionality.

Release note: None