### PR TITLE
kv/rangefeed: guarantee non-empty checkpoint before REASON_SLOW_CONSUMER error

### DIFF
--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -32,6 +32,15 @@ const (
 	// defaultPushTxnsAge is the default age at which a Processor will begin to
 	// consider a transaction old enough to push.
 	defaultPushTxnsAge = 10 * time.Second
+	// The size of an event is 72 bytes, so this will result in an allocation on
+	// the order of ~300KB per RangeFeed. That's probably ok given the number of
+	// ranges on a node that we'd like to support with active rangefeeds, but it's
+	// certainly on the upper end of the range.
+	//
+	// TODO(dan): Everyone seems to agree that this memory limit would be better
+	// set at a store-wide level, but there doesn't seem to be an easy way to
+	// accomplish that.
+	defaultEventChanCap = 4096
 	// defaultCheckStreamsInterval is the default interval at which a Processor
 	// will check all streams to make sure they have not been canceled.
 	defaultCheckStreamsInterval = 1 * time.Second
@@ -53,6 +62,10 @@ type Config struct {
 	RangeID roachpb.RangeID
 	Span    roachpb.RSpan
 
+	// InitClosedTS is the initial closed timestamp on the range, at the time
+	// when the rangefeed Processor was started.
+	InitClosedTS hlc.Timestamp
+
 	TxnPusher TxnPusher
 	// PushTxnsInterval specifies the interval at which a Processor will push
 	// all transactions in the unresolvedIntentQueue that are above the age
@@ -73,6 +86,10 @@ type Config struct {
 	// CheckStreamsInterval specifies interval at which a Processor will check
 	// all streams to make sure they have not been canceled.
 	CheckStreamsInterval time.Duration
+
+	// SkipInitResolvedTS is used in testing to disable the processor-wide initial
+	// resolved timestamp scan.
+	SkipInitResolvedTS bool
 
 	// Metrics is for production monitoring of RangeFeeds.
 	Metrics *Metrics
@@ -98,6 +115,9 @@ func (sc *Config) SetDefaults() {
 		if sc.PushTxnsAge == 0 {
 			sc.PushTxnsAge = defaultPushTxnsAge
 		}
+	}
+	if sc.EventChanCap == 0 {
+		sc.EventChanCap = defaultEventChanCap
 	}
 	if sc.CheckStreamsInterval == 0 {
 		sc.CheckStreamsInterval = defaultCheckStreamsInterval
@@ -196,7 +216,7 @@ func NewProcessor(cfg Config) *Processor {
 	p := &Processor{
 		Config: cfg,
 		reg:    makeRegistry(),
-		rts:    makeResolvedTimestamp(),
+		rts:    makeResolvedTimestamp(cfg.InitClosedTS),
 
 		regC:       make(chan registration),
 		unregC:     make(chan *registration),
@@ -215,7 +235,7 @@ func NewProcessor(cfg Config) *Processor {
 // IntentScannerConstructor is used to construct an IntentScanner. It
 // should be called from underneath a stopper task to ensure that the
 // engine has not been closed.
-type IntentScannerConstructor func() IntentScanner
+type IntentScannerConstructor func(roachpb.Span) IntentScanner
 
 // CatchUpIteratorConstructor is used to construct an iterator that can be used
 // for catchup-scans. Takes the key span and exclusive start time to run the
@@ -258,15 +278,18 @@ func (p *Processor) run(
 
 	// Launch an async task to scan over the resolved timestamp iterator and
 	// initialize the unresolvedIntentQueue. Ignore error if quiescing.
-	if rtsIterFunc != nil {
-		rtsIter := rtsIterFunc()
-		initScan := newInitResolvedTSScan(p, rtsIter)
-		err := stopper.RunAsyncTask(ctx, "rangefeed: init resolved ts", initScan.Run)
-		if err != nil {
-			initScan.Cancel()
+	if !p.SkipInitResolvedTS {
+		if rtsIterFunc != nil {
+			sp := p.Span.AsRawSpanWithNoLocals()
+			rtsIter := rtsIterFunc(sp)
+			initScan := newInitResolvedTSScan(rtsIter, sp, (*processorRTSScanConsumer)(p))
+			err := stopper.RunAsyncTask(ctx, "rangefeed: init resolved ts", initScan.Run)
+			if err != nil {
+				initScan.Cancel()
+			}
+		} else {
+			p.initResolvedTS(ctx)
 		}
-	} else {
-		p.initResolvedTS(ctx)
 	}
 
 	// txnPushTicker periodically pushes the transaction record of all
@@ -465,7 +488,9 @@ func (p *Processor) sendStop(pErr *roachpb.Error) {
 func (p *Processor) Register(
 	span roachpb.RSpan,
 	startTS hlc.Timestamp,
+	initClosedTS hlc.Timestamp,
 	catchUpIterConstructor CatchUpIteratorConstructor,
+	rtsIterConstructor IntentScannerConstructor,
 	withDiff bool,
 	stream Stream,
 	errC chan<- *roachpb.Error,
@@ -476,8 +501,8 @@ func (p *Processor) Register(
 	p.syncEventC()
 
 	r := newRegistration(
-		span.AsRawSpanWithNoLocals(), startTS, catchUpIterConstructor, withDiff,
-		p.Config.EventChanCap, p.Metrics, stream, errC,
+		span.AsRawSpanWithNoLocals(), startTS, initClosedTS, catchUpIterConstructor,
+		rtsIterConstructor, withDiff, p.Config.EventChanCap, p.Metrics, stream, errC,
 	)
 	select {
 	case p.regC <- r:

--- a/pkg/kv/kvserver/rangefeed/resolved_timestamp.go
+++ b/pkg/kv/kvserver/rangefeed/resolved_timestamp.go
@@ -82,9 +82,10 @@ type resolvedTimestamp struct {
 	intentQ    unresolvedIntentQueue
 }
 
-func makeResolvedTimestamp() resolvedTimestamp {
+func makeResolvedTimestamp(initClosedTS hlc.Timestamp) resolvedTimestamp {
 	return resolvedTimestamp{
-		intentQ: makeUnresolvedIntentQueue(),
+		closedTS: initClosedTS,
+		intentQ:  makeUnresolvedIntentQueue(),
 	}
 }
 

--- a/pkg/kv/kvserver/rangefeed/task_test.go
+++ b/pkg/kv/kvserver/rangefeed/task_test.go
@@ -129,6 +129,15 @@ func newTestIterator(kvs []storage.MVCCKeyValue, upperBound roachpb.Key) *testIt
 	}
 }
 
+func (s *testIterator) Clone() *testIterator {
+	if s == nil {
+		return nil
+	}
+	c := *s
+	c.done = make(chan struct{})
+	return &c
+}
+
 func (s *testIterator) Close() {
 	s.closed = true
 	close(s.done)
@@ -346,7 +355,7 @@ func TestInitResolvedTSScan(t *testing.T) {
 			}
 			isc, cleanup := tc.intentScanner()
 			defer cleanup()
-			initScan := newInitResolvedTSScan(&p, isc)
+			initScan := newInitResolvedTSScan(isc, p.Span.AsRawSpanWithNoLocals(), (*processorRTSScanConsumer)(&p))
 			initScan.Run(context.Background())
 			// Compare the event channel to the expected events.
 			assert.Equal(t, len(expEvents), len(p.eventC))

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -332,6 +332,12 @@ type StoreTestingKnobs struct {
 	// RangeFeedPushTxnsAge overrides the default value for
 	// rangefeed.Config.PushTxnsAge.
 	RangeFeedPushTxnsAge time.Duration
+	// RangeFeedEventChanCap overrides the default value for
+	// rangefeed.Config.EventChanCap.
+	RangeFeedEventChanCap int
+	// RangeFeedEventChanCap overrides the default value for
+	// rangefeed.Config.SkipInitResolvedTS.
+	RangeFeedSkipInitResolvedTS bool
 	// AllowLeaseProposalWhenNotLeader, if set, makes the proposal buffer allow
 	// lease request proposals even when the replica inserting that proposal is
 	// not the Raft leader. This can be used in tests to allow a replica to


### PR DESCRIPTION
Fixes #77696.

This commit ensures progress of per-range rangefeeds in the presence of large catch-up scans by guaranteeing that a non-empty checkpoint is published before returning a REASON_SLOW_CONSUMER error to the client. This ensures that the client doesn't spin in `DistSender` on the same catch-up span without advancing its frontier. It does so by having rangefeed registrations perform an ad-hoc resolved timestamp computation in cases where the registration's buffer hits a memory limit before it succeeds in publishing a non-empty checkpoint.

In doing so, we can make a loose guarantee (assuming timely closed timestamp progression) that a rangefeed with a client-side retry loop will always be able to catch-up and converge towards a stable connection as long as its rate of consumption is greater than the rate of production on the table. In other words, if `catch_up_scan_rate > new_write_rate`, the retry loop will make forward progress and eventually stop hitting REASON_SLOW_CONSUMER errors.

A nearly viable alternative to this ad-hoc scan is to ensure that the processor-wide resolved timestamp tracker publishes at least one non-zero checkpoint on each registration before the registration is allowed to fail. This runs into the issues described in https://github.com/cockroachdb/cockroach/issues/77696#issuecomment-1065498465. Specifically, because this tracker is shared with other registrations, it continues to advance even after the stream of events has been broken to an overflowing registration. That means that a checkpoint computed after the registration has overflowed cannot be published without violating the ordering contract of rangefeed checkpoints ("all prior events have been seen"). The checkpoint published after the initial catch-up scan needs to be coherent with the state of the range that the catch-up scan saw.

This change should be followed up with system-level testing that exercises a changefeed's ability to be unpaused after a long amount of time on a table with a high rate of writes. That is an example of the kind of situation that this change aims to improve.

Release justification: None. Wait on this.

Release note (enterprise change): Changefeeds are now guaranteed to make forward progress while performing a large catch-up scan on a table with a high rate of writes.