### PR TITLE
 kv: Limit concurrency of catchup scans.

### DIFF
--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -61,6 +61,7 @@ go_library(
         "//pkg/util/grpcutil",
         "//pkg/util/hlc",
         "//pkg/util/iterutil",
+        "//pkg/util/limit",
         "//pkg/util/log",
         "//pkg/util/metric",
         "//pkg/util/quotapool",

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"sync"
 	"time"
 	"unsafe"
@@ -28,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
+	"github.com/cockroachdb/cockroach/pkg/util/limit"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -50,6 +52,22 @@ var useDedicatedRangefeedConnectionClass = settings.RegisterBoolSetting(
 	util.ConstantWithMetamorphicTestBool(
 		"kv.rangefeed.use_dedicated_connection_class.enabled", false),
 )
+
+var catchupScanConcurrency = settings.RegisterIntSetting(
+	settings.TenantWritable,
+	"kv.rangefeed.catchup_scan_concurrency",
+	"number of catchup scans that a single rangefeed can execute concurrently; 0 implies unlimited",
+	8,
+	settings.NonNegativeInt,
+)
+
+func maxConcurrentCatchupScans(sv *settings.Values) int {
+	l := catchupScanConcurrency.Get(sv)
+	if l == 0 {
+		return math.MaxInt
+	}
+	return int(l)
+}
 
 // RangeFeed divides a RangeFeed request on range boundaries and establishes a
 // RangeFeed to each of the individual ranges. It streams back results on the
@@ -76,6 +94,9 @@ func (ds *DistSender) RangeFeed(
 	ds.activeRangeFeeds.Store(rr, nil)
 	defer ds.activeRangeFeeds.Delete(rr)
 
+	catchupSem := limit.MakeConcurrentRequestLimiter(
+		"distSenderCatchupLimit", maxConcurrentCatchupScans(&ds.st.SV))
+
 	g := ctxgroup.WithContext(ctx)
 	// Goroutine that processes subdivided ranges and creates a rangefeed for
 	// each.
@@ -86,7 +107,7 @@ func (ds *DistSender) RangeFeed(
 			case sri := <-rangeCh:
 				// Spawn a child goroutine to process this feed.
 				g.GoCtx(func(ctx context.Context) error {
-					return ds.partialRangeFeed(ctx, rr, sri.rs, sri.startFrom, sri.token, withDiff, rangeCh, eventCh)
+					return ds.partialRangeFeed(ctx, rr, sri.rs, sri.startFrom, sri.token, withDiff, &catchupSem, rangeCh, eventCh)
 				})
 			case <-ctx.Done():
 				return ctx.Err()
@@ -254,6 +275,7 @@ func (ds *DistSender) partialRangeFeed(
 	startFrom hlc.Timestamp,
 	token rangecache.EvictionToken,
 	withDiff bool,
+	catchupSem *limit.ConcurrentRequestLimiter,
 	rangeCh chan<- singleRangeInfo,
 	eventCh chan<- *roachpb.RangeFeedEvent,
 ) error {
@@ -290,7 +312,8 @@ func (ds *DistSender) partialRangeFeed(
 		}
 
 		// Establish a RangeFeed for a single Range.
-		maxTS, err := ds.singleRangeFeed(ctx, span, startFrom, withDiff, token.Desc(), eventCh, active.onRangeEvent)
+		maxTS, err := ds.singleRangeFeed(ctx, span, startFrom, withDiff, token.Desc(),
+			catchupSem, eventCh, active.onRangeEvent)
 
 		// Forward the timestamp in case we end up sending it again.
 		startFrom.Forward(maxTS)
@@ -361,6 +384,7 @@ func (ds *DistSender) singleRangeFeed(
 	startFrom hlc.Timestamp,
 	withDiff bool,
 	desc *roachpb.RangeDescriptor,
+	catchupSem *limit.ConcurrentRequestLimiter,
 	eventCh chan<- *roachpb.RangeFeedEvent,
 	onRangeEvent onRangeEventCb,
 ) (hlc.Timestamp, error) {
@@ -391,14 +415,31 @@ func (ds *DistSender) singleRangeFeed(
 	}
 	defer transport.Release()
 
-	// checkpointSeen keeps track on whether we've seen range checkpoint.
-	// Initially set to true to avoid erroneously decrementing the counter.
-	checkpointSeen := true
-	defer func() {
-		if !checkpointSeen {
-			ds.metrics.RangefeedCatchupRanges.Dec(1)
+	var catchupRes limit.Reservation
+	startCatchupScan := func() error {
+		if catchupRes != nil {
+			return errors.AssertionFailedf("expected catchup scan reservation to be nil")
 		}
-	}()
+
+		// Indicate catchup scan is starting;  Before potentially blocking on a semaphore, take
+		// opportunity to update semaphore limit.
+		catchupSem.SetLimit(maxConcurrentCatchupScans(&ds.st.SV))
+		res, err := catchupSem.Begin(ctx)
+		if err == nil {
+			catchupRes = res
+			ds.metrics.RangefeedCatchupRanges.Inc(1)
+		}
+		return err
+	}
+	finishCatchupScan := func() {
+		if catchupRes != nil {
+			catchupRes.Release()
+			ds.metrics.RangefeedCatchupRanges.Dec(1)
+			catchupRes = nil
+		}
+	}
+	// cleanup catchup reservation in case of early termination.
+	defer finishCatchupScan()
 
 	for {
 		if transport.IsExhausted() {
@@ -412,6 +453,10 @@ func (ds *DistSender) singleRangeFeed(
 			log.VErrEventf(ctx, 2, "RPC error: %s", err)
 			continue
 		}
+		if err := startCatchupScan(); err != nil {
+			return hlc.Timestamp{}, err
+		}
+
 		log.VEventf(ctx, 3, "attempting to create a RangeFeed over replica %s", args.Replica)
 		stream, err := client.RangeFeed(clientCtx, &args)
 		if err != nil {
@@ -422,12 +467,6 @@ func (ds *DistSender) singleRangeFeed(
 			}
 			continue
 		}
-
-		// Indicate this range is going to performs catchup scan.
-		// Counter decremented when range receive checkpoint event, or
-		// when this function terminates.
-		ds.metrics.RangefeedCatchupRanges.Inc(1)
-		checkpointSeen = false
 
 		for {
 			event, err := stream.Recv()
@@ -440,16 +479,15 @@ func (ds *DistSender) singleRangeFeed(
 			switch t := event.GetValue().(type) {
 			case *roachpb.RangeFeedCheckpoint:
 				if t.Span.Contains(args.Span) {
-					// If we see the first non-empty checkpoint, we know we're done with catchup scan.
-					if !t.ResolvedTS.IsEmpty() && !checkpointSeen {
-						checkpointSeen = true
-						ds.metrics.RangefeedCatchupRanges.Dec(1)
+					// If we see the first non-empty checkpoint, we know we're done with the catchup scan.
+					if !t.ResolvedTS.IsEmpty() && catchupRes != nil {
+						finishCatchupScan()
 					}
 					args.Timestamp.Forward(t.ResolvedTS)
 				}
 			case *roachpb.RangeFeedError:
 				log.VErrEventf(ctx, 2, "RangeFeedError: %s", t.Error.GoError())
-				if !checkpointSeen {
+				if catchupRes != nil {
 					ds.metrics.RangefeedErrorCatchup.Inc(1)
 				}
 				return args.Timestamp, t.Error.GoError()


### PR DESCRIPTION
Limit concurrency of the catchup scans.
Prior to this change, distsender would issue all of the rangefeed
calls immediately, and the the KV server deal with limiting
the number of concurrent catchup scans it can handle.  This has
a potential of using up entirety of the KV server budget by a single
rangefeed client (e.g. changefeed), thus starving all other users.

This PR adds a `kv.rangefeed.catchup_scan_concurrency` setting
to limit the number of catchup scans started by rangefeed client.

Fixes #77690 

Release Notes (enterprise): Limit the number of concurent catchup scan
requests issued by rangefeed client.

Release Justification: Important stability and scalability improvement
to prevent a single rangefeed client from consuming entirety of catchup
scan iterator budget on a KV server.
