### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/pkg/acceptance/compose_test.go
+++ b/pkg/acceptance/compose_test.go
@@ -13,7 +13,6 @@ package acceptance
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -40,17 +39,11 @@ func TestComposeFlyway(t *testing.T) {
 func testCompose(t *testing.T, path string, exitCodeFrom string) {
 	if bazel.BuiltWithBazel() {
 		// Copy runfiles symlink content to a temporary directory to avoid broken symlinks in docker.
-		tmpComposeDir, err := ioutil.TempDir("", "")
+		tmpComposeDir := t.TempDir()
+		err := copyRunfiles(composeDir, tmpComposeDir)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
-		err = copyRunfiles(composeDir, tmpComposeDir)
-		if err != nil {
-			t.Fatalf(err.Error())
-		}
-		defer func() {
-			_ = os.RemoveAll(tmpComposeDir)
-		}()
 		path = filepath.Join(tmpComposeDir, path)
 		// If running under Bazel, export 2 environment variables that will be interpolated in docker-compose.yml files.
 		cockroachBinary, err := filepath.Abs(*cluster.CockroachBinary)

--- a/pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go
+++ b/pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"strconv"
 	"testing"
@@ -35,8 +34,7 @@ func TestWorkload(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer utilccl.TestingEnableEnterprise()()
 
-	dir, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err)
+	dir := t.TempDir()
 	ctx := context.Background()
 	tc, _, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
 		t,

--- a/pkg/cli/democluster/demo_cluster_test.go
+++ b/pkg/cli/democluster/demo_cluster_test.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
@@ -149,8 +148,7 @@ func TestTransientClusterSimulateLatencies(t *testing.T) {
 	demoCtx.SimulateLatency = true
 	demoCtx.NumNodes = 9
 
-	certsDir, err := ioutil.TempDir("", "cli-demo-test")
-	require.NoError(t, err)
+	certsDir := t.TempDir()
 
 	cleanupFunc := securitytest.CreateTestCerts(certsDir)
 	defer func() {
@@ -273,16 +271,9 @@ func TestTransientClusterMultitenant(t *testing.T) {
 	}
 
 	security.ResetAssetLoader()
-	certsDir, err := ioutil.TempDir("", "cli-demo-mt-test")
-	require.NoError(t, err)
+	certsDir := t.TempDir()
 
 	require.NoError(t, demoCtx.generateCerts(certsDir))
-
-	defer func() {
-		if err := os.RemoveAll(certsDir); err != nil {
-			t.Fatal(err)
-		}
-	}()
 
 	ctx := context.Background()
 

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -16,7 +16,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -233,19 +232,13 @@ func TestClientURLFlagEquivalence(t *testing.T) {
 	defer initCLIDefaults()
 
 	// Prepare a dummy default certificate directory.
-	defCertsDirPath, err := ioutil.TempDir("", "defCerts")
-	if err != nil {
-		t.Fatal(err)
-	}
+	defCertsDirPath := t.TempDir()
 	defCertsDirPath, _ = filepath.Abs(defCertsDirPath)
 	cleanup := securitytest.CreateTestCerts(defCertsDirPath)
 	defer func() { _ = cleanup() }()
 
 	// Prepare a custom certificate directory.
-	testCertsDirPath, err := ioutil.TempDir("", "customCerts")
-	if err != nil {
-		t.Fatal(err)
-	}
+	testCertsDirPath := t.TempDir()
 	testCertsDirPath, _ = filepath.Abs(testCertsDirPath)
 	cleanup2 := securitytest.CreateTestCerts(testCertsDirPath)
 	defer func() { _ = cleanup2() }()

--- a/pkg/cli/gen_test.go
+++ b/pkg/cli/gen_test.go
@@ -11,7 +11,6 @@
 package cli
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,22 +26,14 @@ func TestGenMan(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	// Generate man pages in a temp directory.
-	manpath, err := ioutil.TempDir("", "TestGenMan")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(manpath); err != nil {
-			t.Errorf("couldn't remove temporary directory %s: %s", manpath, err)
-		}
-	}()
+	manpath := t.TempDir()
 	if err := Run([]string{"gen", "man", "--path=" + manpath}); err != nil {
 		t.Fatal(err)
 	}
 
 	// Ensure we have a sane number of man pages.
 	count := 0
-	err = filepath.Walk(manpath, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(manpath, func(path string, info os.FileInfo, err error) error {
 		if strings.HasSuffix(path, ".1") && !info.IsDir() {
 			count++
 		}
@@ -61,15 +52,7 @@ func TestGenAutocomplete(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	// Get a unique path to which we can write our autocomplete files.
-	acdir, err := ioutil.TempDir("", "TestGenAutoComplete")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(acdir); err != nil {
-			t.Errorf("couldn't remove temporary directory %s: %s", acdir, err)
-		}
-	}()
+	acdir := t.TempDir()
 
 	for _, tc := range []struct {
 		shell  string

--- a/pkg/compose/compose_test.go
+++ b/pkg/compose/compose_test.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -72,11 +71,7 @@ func TestComposeCompare(t *testing.T) {
 		// start up docker-compose, but the files themselves will be
 		// Bazel-built symlinks. We want to copy these files to a
 		// different temporary location.
-		composeBinsDir, err := ioutil.TempDir("", "compose-bins")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer func() { _ = os.RemoveAll(composeBinsDir) }()
+		composeBinsDir := t.TempDir()
 		compareDir = composeBinsDir
 		cockroachBin = filepath.Join(composeBinsDir, "cockroach")
 		err = copyBin(*flagCockroach, cockroachBin)
@@ -88,10 +83,7 @@ func TestComposeCompare(t *testing.T) {
 			t.Fatal(err)
 		}
 		if *flagArtifacts == "" {
-			*flagArtifacts, err = ioutil.TempDir("", "compose")
-			if err != nil {
-				t.Fatal(err)
-			}
+			*flagArtifacts = t.TempDir()
 		}
 	} else {
 		if *flagCompare != "" {

--- a/pkg/security/certificate_loader_test.go
+++ b/pkg/security/certificate_loader_test.go
@@ -211,15 +211,7 @@ func TestNamingScheme(t *testing.T) {
 	}
 
 	// Create directory.
-	certsDir, err := ioutil.TempDir("", "certs_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(certsDir); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	certsDir := t.TempDir()
 
 	type testFile struct {
 		name     string

--- a/pkg/security/certificate_manager_test.go
+++ b/pkg/security/certificate_manager_test.go
@@ -12,7 +12,6 @@ package security_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -85,11 +84,7 @@ func TestManagerWithPrincipalMap(t *testing.T) {
 	}()
 	require.NoError(t, os.Setenv("COCKROACH_CERT_NODE_USER", "node.crdb.io"))
 
-	certsDir, err := ioutil.TempDir("", "certs_test")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(certsDir))
-	}()
+	certsDir := t.TempDir()
 
 	caKey := filepath.Join(certsDir, "ca.key")
 	require.NoError(t, security.CreateCAPair(

--- a/pkg/security/certs_rotation_test.go
+++ b/pkg/security/certs_rotation_test.go
@@ -50,15 +50,7 @@ func TestRotateCerts(t *testing.T) {
 	// Do not mock cert access for this test.
 	security.ResetAssetLoader()
 	defer ResetTest()
-	certsDir, err := ioutil.TempDir("", "certs_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(certsDir); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	certsDir := t.TempDir()
 
 	if err := generateBaseCerts(certsDir); err != nil {
 		t.Fatal(err)

--- a/pkg/security/certs_tenant_test.go
+++ b/pkg/security/certs_tenant_test.go
@@ -27,8 +27,8 @@ import (
 	"golang.org/x/exp/rand"
 )
 
-func makeTenantCerts(t *testing.T, tenant uint64) (certsDir string, cleanup func()) {
-	certsDir, cleanup = tempDir(t)
+func makeTenantCerts(t *testing.T, tenant uint64) (certsDir string) {
+	certsDir = t.TempDir()
 
 	// Make certs for the tenant CA (= auth broker). In production, these would be
 	// given to a dedicated service.
@@ -62,7 +62,7 @@ func makeTenantCerts(t *testing.T, tenant uint64) (certsDir string, cleanup func
 
 	// Also check that the tenant signing cert gets created.
 	require.NoError(t, security.CreateTenantSigningPair(certsDir, 500*time.Hour, false /* overwrite */, tenant))
-	return certsDir, cleanup
+	return certsDir
 }
 
 // TestTenantCertificates creates a tenant CA and from it client certificates
@@ -93,9 +93,7 @@ func testTenantCertificatesInner(t *testing.T, embedded bool) {
 		security.ResetAssetLoader()
 		defer ResetTest()
 		tenant = uint64(rand.Int63())
-		var cleanup func()
-		certsDir, cleanup = makeTenantCerts(t, tenant)
-		defer cleanup()
+		certsDir = makeTenantCerts(t, tenant)
 	} else {
 		certsDir = security.EmbeddedCertsDir
 		tenant = security.EmbeddedTenantIDs()[0]

--- a/pkg/security/certs_test.go
+++ b/pkg/security/certs_test.go
@@ -37,27 +37,13 @@ import (
 
 const testKeySize = 1024
 
-// tempDir is like testutils.TempDir but avoids a circular import.
-func tempDir(t *testing.T) (string, func()) {
-	certsDir, err := ioutil.TempDir("", "certs_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	return certsDir, func() {
-		if err := os.RemoveAll(certsDir); err != nil {
-			t.Fatal(err)
-		}
-	}
-}
-
 func TestGenerateCACert(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// Do not mock cert access for this test.
 	security.ResetAssetLoader()
 	defer ResetTest()
 
-	certsDir, cleanup := tempDir(t)
-	defer cleanup()
+	certsDir := t.TempDir()
 
 	cm, err := security.NewCertificateManager(certsDir, security.CommandTLSSettings{})
 	if err != nil {
@@ -126,8 +112,7 @@ func TestGenerateTenantCerts(t *testing.T) {
 	security.ResetAssetLoader()
 	defer ResetTest()
 
-	certsDir, cleanup := tempDir(t)
-	defer cleanup()
+	certsDir := t.TempDir()
 
 	caKeyFile := filepath.Join(certsDir, "name-must-not-matter.key")
 	require.NoError(t, security.CreateTenantCAPair(
@@ -191,15 +176,7 @@ func TestGenerateNodeCerts(t *testing.T) {
 	security.ResetAssetLoader()
 	defer ResetTest()
 
-	certsDir, err := ioutil.TempDir("", "certs_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(certsDir); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	certsDir := t.TempDir()
 
 	// Try generating node certs without CA certs present.
 	if err := security.CreateNodePair(
@@ -340,15 +317,7 @@ func TestUseCerts(t *testing.T) {
 	// Do not mock cert access for this test.
 	security.ResetAssetLoader()
 	defer ResetTest()
-	certsDir, err := ioutil.TempDir("", "certs_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(certsDir); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	certsDir := t.TempDir()
 
 	if err := generateBaseCerts(certsDir); err != nil {
 		t.Fatal(err)
@@ -430,15 +399,7 @@ func TestUseSplitCACerts(t *testing.T) {
 	// Do not mock cert access for this test.
 	security.ResetAssetLoader()
 	defer ResetTest()
-	certsDir, err := ioutil.TempDir("", "certs_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(certsDir); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	certsDir := t.TempDir()
 
 	if err := generateSplitCACerts(certsDir); err != nil {
 		t.Fatal(err)
@@ -547,15 +508,7 @@ func TestUseWrongSplitCACerts(t *testing.T) {
 	// Do not mock cert access for this test.
 	security.ResetAssetLoader()
 	defer ResetTest()
-	certsDir, err := ioutil.TempDir("", "certs_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(certsDir); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	certsDir := t.TempDir()
 
 	if err := generateSplitCACerts(certsDir); err != nil {
 		t.Fatal(err)

--- a/pkg/server/auto_tls_init_test.go
+++ b/pkg/server/auto_tls_init_test.go
@@ -14,7 +14,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -29,17 +28,14 @@ func TestInitializeFromConfig(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	// Create a temp dir for all certificate tests.
-	tempDir, err := ioutil.TempDir("", "auto_tls_init_test")
-	if err != nil {
-		t.Fatalf("failed to create test temp dir: %s", err)
-	}
+	tempDir := t.TempDir()
 
 	certBundle := CertificateBundle{}
 	cfg := base.Config{
 		SSLCertsDir: tempDir,
 	}
 
-	err = certBundle.InitializeFromConfig(context.Background(), cfg)
+	err := certBundle.InitializeFromConfig(context.Background(), cfg)
 	if err != nil {
 		t.Fatalf("expected err=nil, got: %q", err)
 	}
@@ -53,13 +49,6 @@ func TestInitializeFromConfig(t *testing.T) {
 	// Compare each set of certs and keys to those loaded from disk.
 	compareBundleCaCerts(t, bundleFromDisk, certBundle, true)
 	compareBundleServiceCerts(t, bundleFromDisk, certBundle, true)
-
-	// Remove temp directory now that we are done with it.
-	err = os.RemoveAll(tempDir)
-	if err != nil {
-		t.Fatalf("failed to remove test temp dir: %s", err)
-	}
-
 }
 
 func loadAllCertsFromDisk(ctx context.Context, cfg base.Config) (CertificateBundle, error) {
@@ -219,22 +208,14 @@ func TestDummyInitializeNodeFromBundle(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	// Create a temp dir for all certificate tests.
-	tempDir, err := ioutil.TempDir("", "auto_tls_init_test")
-	if err != nil {
-		t.Fatalf("failed to create test temp dir: %s", err)
-	}
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	tempDir := t.TempDir()
 
 	certBundle := CertificateBundle{}
 	cfg := base.Config{
 		SSLCertsDir: tempDir,
 	}
 
-	err = certBundle.InitializeNodeFromBundle(context.Background(), cfg)
+	err := certBundle.InitializeNodeFromBundle(context.Background(), cfg)
 	if err != nil {
 		t.Fatalf("expected err=nil, got: %s", err)
 	}
@@ -259,15 +240,7 @@ func TestRotationOnUnintializedNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	// Create a temp dir for all certificate tests.
-	tempDir, err := ioutil.TempDir("", "auto_tls_init_test")
-	if err != nil {
-		t.Fatalf("failed to create test temp dir: %s", err)
-	}
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	tempDir := t.TempDir()
 
 	cfg := base.Config{
 		SSLCertsDir: tempDir,
@@ -302,15 +275,7 @@ func TestRotationOnIntializedNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	// Create a temp dir for all certificate tests.
-	tempDir, err := ioutil.TempDir("", "auto_tls_init_test")
-	if err != nil {
-		t.Fatalf("failed to create test temp dir: %s", err)
-	}
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	tempDir := t.TempDir()
 
 	cfg := base.Config{
 		SSLCertsDir: tempDir,
@@ -319,7 +284,7 @@ func TestRotationOnIntializedNode(t *testing.T) {
 
 	// Test in the fully provisioned case.
 	certBundle := CertificateBundle{}
-	err = certBundle.InitializeFromConfig(ctx, cfg)
+	err := certBundle.InitializeFromConfig(ctx, cfg)
 	if err != nil {
 		t.Fatalf("expected err=nil, got: %q", err)
 	}
@@ -343,15 +308,7 @@ func TestRotationOnPartialIntializedNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	// Create a temp dir for all certificate tests.
-	tempDir, err := ioutil.TempDir("", "auto_tls_init_test")
-	if err != nil {
-		t.Fatalf("failed to create test temp dir: %s", err)
-	}
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	tempDir := t.TempDir()
 
 	cfg := base.Config{
 		SSLCertsDir: tempDir,
@@ -360,7 +317,7 @@ func TestRotationOnPartialIntializedNode(t *testing.T) {
 
 	// Test in the partially provisioned case (remove the Client and UI CAs).
 	certBundle := CertificateBundle{}
-	err = certBundle.InitializeFromConfig(ctx, cfg)
+	err := certBundle.InitializeFromConfig(ctx, cfg)
 	if err != nil {
 		t.Fatalf("expected err=nil, got: %q", err)
 	}
@@ -407,15 +364,7 @@ func TestRotationOnBrokenIntializedNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	// Create a temp dir for all certificate tests.
-	tempDir, err := ioutil.TempDir("", "auto_tls_init_test")
-	if err != nil {
-		t.Fatalf("failed to create test temp dir: %s", err)
-	}
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	tempDir := t.TempDir()
 
 	cfg := base.Config{
 		SSLCertsDir: tempDir,
@@ -424,7 +373,7 @@ func TestRotationOnBrokenIntializedNode(t *testing.T) {
 
 	cl := security.MakeCertsLocator(cfg.SSLCertsDir)
 	certBundle := CertificateBundle{}
-	err = certBundle.InitializeFromConfig(ctx, cfg)
+	err := certBundle.InitializeFromConfig(ctx, cfg)
 	if err != nil {
 		t.Fatalf("expected err=nil, got: %q", err)
 	}

--- a/pkg/server/dumpstore/dumpstore_test.go
+++ b/pkg/server/dumpstore/dumpstore_test.go
@@ -144,13 +144,7 @@ func TestRemoveOldAndTooBig(t *testing.T) {
 
 	for i, tc := range testData {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			path, err := ioutil.TempDir("", "remove")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer func() { _ = os.RemoveAll(path) }()
-
-			files := populate(t, path, tc.startFiles, tc.sizes)
+			files := populate(t, t.TempDir(), tc.startFiles, tc.sizes)
 
 			cleaned := []string{}
 			cleanupFn := func(s string) error {

--- a/pkg/server/heapprofiler/profilestore_test.go
+++ b/pkg/server/heapprofiler/profilestore_test.go
@@ -197,13 +197,7 @@ func TestCleanupLastRampup(t *testing.T) {
 	s := profileStore{prefix: HeapFileNamePrefix}
 	for i, tc := range testData {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			path, err := ioutil.TempDir("", "cleanup")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer func() { _ = os.RemoveAll(path) }()
-
-			files := populate(t, path, tc.startFiles)
+			files := populate(t, t.TempDir(), tc.startFiles)
 
 			cleaned := []string{}
 			cleanupFn := func(s string) error {

--- a/pkg/storage/disk_map_test.go
+++ b/pkg/storage/disk_map_test.go
@@ -14,9 +14,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
-	"os"
 	"strings"
 	"testing"
 
@@ -309,15 +307,7 @@ func TestPebbleMapClose(t *testing.T) {
 }
 
 func BenchmarkPebbleMapWrite(b *testing.B) {
-	dir, err := ioutil.TempDir("", "BenchmarkPebbleMapWrite")
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			b.Fatal(err)
-		}
-	}()
+	dir := b.TempDir()
 	ctx := context.Background()
 	tempEngine, _, err := NewPebbleTempEngine(ctx, base.TempStorageConfig{Path: dir}, base.DefaultTestStoreSpec)
 	if err != nil {
@@ -355,15 +345,7 @@ func BenchmarkPebbleMapWrite(b *testing.B) {
 
 func BenchmarkPebbleMapIteration(b *testing.B) {
 	skip.UnderShort(b)
-	dir, err := ioutil.TempDir("", "BenchmarkPebbleMapIteration")
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			b.Fatal(err)
-		}
-	}()
+	dir := b.TempDir()
 	ctx := context.Background()
 	tempEngine, _, err := NewPebbleTempEngine(ctx, base.TempStorageConfig{Path: dir}, base.DefaultTestStoreSpec)
 	if err != nil {

--- a/pkg/storage/fs/temp_dir_test.go
+++ b/pkg/storage/fs/temp_dir_test.go
@@ -32,15 +32,7 @@ func TestCreateTempDir(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 	// Temporary parent directory to test this.
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	dir := t.TempDir()
 
 	tempDir, err := CreateTempDir(dir, "test-create-temp", stopper)
 	if err != nil {
@@ -112,17 +104,7 @@ func TestCleanupTempDirs(t *testing.T) {
 	// Generate some temporary directories.
 	var tempDirs []string
 	for i := 0; i < 5; i++ {
-		tempDir, err := ioutil.TempDir("", "temp-dir")
-		if err != nil {
-			t.Fatal(err)
-		}
-		// Not strictly necessary, but good form to clean up temporary
-		// directories independent of test case.
-		defer func() {
-			if err := os.RemoveAll(tempDir); err != nil {
-				t.Fatal(err)
-			}
-		}()
+		tempDir := t.TempDir()
 		tempDirs = append(tempDirs, tempDir)
 		// Record the temporary directories to the file.
 		if _, err = recordFile.Write(append([]byte(tempDir), '\n')); err != nil {

--- a/pkg/util/cgroups/cgroups_test.go
+++ b/pkg/util/cgroups/cgroups_test.go
@@ -106,7 +106,6 @@ func TestCgroupsGetMemoryUsage(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := createFiles(t, tc.paths)
-			defer func() { _ = os.RemoveAll(dir) }()
 
 			limit, warn, err := getCgroupMemUsage(dir)
 			require.True(t, testutils.IsError(err, tc.errMsg),
@@ -203,7 +202,6 @@ func TestCgroupsGetMemoryInactiveFileUsage(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := createFiles(t, tc.paths)
-			defer func() { _ = os.RemoveAll(dir) }()
 			limit, warn, err := getCgroupMemInactiveFileUsage(dir)
 			require.True(t, testutils.IsError(err, tc.errMsg),
 				"%v %v", err, tc.errMsg)
@@ -306,7 +304,6 @@ func TestCgroupsGetMemoryLimit(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := createFiles(t, tc.paths)
-			defer func() { _ = os.RemoveAll(dir) }()
 
 			limit, warn, err := getCgroupMemLimit(dir)
 			require.True(t, testutils.IsError(err, tc.errMsg),
@@ -491,7 +488,6 @@ func TestCgroupsGetCPU(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := createFiles(t, tc.paths)
-			defer func() { _ = os.RemoveAll(dir) }()
 
 			cpuusage, err := getCgroupCPU(dir)
 			require.True(t, testutils.IsError(err, tc.errMsg),
@@ -505,8 +501,7 @@ func TestCgroupsGetCPU(t *testing.T) {
 }
 
 func createFiles(t *testing.T, paths map[string]string) (dir string) {
-	dir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
+	dir = t.TempDir()
 
 	for path, data := range paths {
 		path = filepath.Join(dir, path)

--- a/pkg/util/sysutil/acl_unix_test.go
+++ b/pkg/util/sysutil/acl_unix_test.go
@@ -23,15 +23,7 @@ import (
 )
 
 func TestGetFileACLInfo(t *testing.T) {
-	certsDir, err := ioutil.TempDir("", "acl_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(certsDir); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	certsDir := t.TempDir()
 
 	exampleData := []byte("example")
 

--- a/pkg/util/sysutil/large_file_test.go
+++ b/pkg/util/sysutil/large_file_test.go
@@ -11,23 +11,13 @@
 package sysutil
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
 func TestResizeLargeFile(t *testing.T) {
-	d, err := ioutil.TempDir("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(d); err != nil {
-			t.Fatal(err)
-		}
-	}()
-	fname := filepath.Join(d, "ballast")
+	fname := filepath.Join(t.TempDir(), "ballast")
 
 	lens := []int64{2000, 1000, 64<<20 + 10, 0, 1}
 	for _, n := range lens {


### PR DESCRIPTION
A testing enhancement.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

Release justification: Low risk change to existing tests.

Release note: None.