### PR TITLE
testserver: Modify GetHTTPClient to GetUnauthenticatedHTTPClient, GetAdminAuthenticatedHTTPClient to GetAdminHTTPClient

### DIFF
--- a/pkg/ccl/serverccl/server_sql_test.go
+++ b/pkg/ccl/serverccl/server_sql_test.go
@@ -152,7 +152,7 @@ func TestTenantHTTP(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("prometheus", func(t *testing.T) {
-		httpClient, err := tenant.GetHTTPClient()
+		httpClient, err := tenant.GetUnauthenticatedHTTPClient()
 		require.NoError(t, err)
 		defer httpClient.CloseIdleConnections()
 		resp, err := httpClient.Get(tenant.AdminURL() + "/_status/vars")
@@ -163,7 +163,7 @@ func TestTenantHTTP(t *testing.T) {
 		require.Contains(t, string(body), "sql_ddl_started_count_internal")
 	})
 	t.Run("pprof", func(t *testing.T) {
-		httpClient, err := tenant.GetAdminAuthenticatedHTTPClient()
+		httpClient, err := tenant.GetAdminHTTPClient()
 		require.NoError(t, err)
 		defer httpClient.CloseIdleConnections()
 		resp, err := httpClient.Get(tenant.AdminURL() + "/debug/pprof/goroutine?debug=2")

--- a/pkg/ccl/serverccl/statusccl/tenant_grpc_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_grpc_test.go
@@ -73,7 +73,7 @@ func TestTenantGRPCServices(t *testing.T) {
 		require.NotEmpty(t, resp.Statements)
 	})
 
-	httpClient, err := tenant.GetAdminAuthenticatedHTTPClient()
+	httpClient, err := tenant.GetAdminHTTPClient()
 	require.NoError(t, err)
 	defer httpClient.CloseIdleConnections()
 
@@ -114,7 +114,7 @@ func TestTenantGRPCServices(t *testing.T) {
 	defer connTenant3.Close()
 
 	t.Run("fanout of statements endpoint is segregated by tenant", func(t *testing.T) {
-		httpClient3, err := tenant3.GetAdminAuthenticatedHTTPClient()
+		httpClient3, err := tenant3.GetAdminHTTPClient()
 		require.NoError(t, err)
 		defer httpClient3.CloseIdleConnections()
 

--- a/pkg/ccl/serverccl/statusccl/tenant_test_utils.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_test_utils.go
@@ -164,7 +164,13 @@ func (c tenantCluster) tenantConn(idx serverIdx) *sqlutils.SQLRunner {
 }
 
 func (c tenantCluster) tenantHTTPClient(t *testing.T, idx serverIdx, isAdmin bool) *httpClient {
-	client, err := c.tenant(idx).tenant.GetAuthenticatedHTTPClient(isAdmin)
+	var client http.Client
+	var err error
+	if isAdmin {
+		client, err = c.tenant(idx).tenant.GetAdminHTTPClient()
+	} else {
+		client, err = c.tenant(idx).tenant.GetAuthenticatedHTTPClient(false)
+	}
 	require.NoError(t, err)
 	return &httpClient{t: t, client: client, baseURL: c[idx].tenant.AdminURL()}
 }

--- a/pkg/kv/kvserver/client_tenant_test.go
+++ b/pkg/kv/kvserver/client_tenant_test.go
@@ -227,7 +227,7 @@ func TestTenantRateLimiter(t *testing.T) {
 	// Create some tooling to read and verify metrics off of the prometheus
 	// endpoint.
 	runner.Exec(t, `SET CLUSTER SETTING server.child_metrics.enabled = true`)
-	httpClient, err := s.GetHTTPClient()
+	httpClient, err := s.GetUnauthenticatedHTTPClient()
 	require.NoError(t, err)
 	getMetrics := func() string {
 		resp, err := httpClient.Get(s.AdminURL() + "/_status/vars")

--- a/pkg/server/admin_cluster_test.go
+++ b/pkg/server/admin_cluster_test.go
@@ -97,7 +97,7 @@ func TestAdminAPITableStats(t *testing.T) {
 	// Create clients (SQL, HTTP) connected to server 0.
 	db := tc.ServerConn(0)
 
-	client, err := server0.GetAdminAuthenticatedHTTPClient()
+	client, err := server0.GetAdminHTTPClient()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -95,7 +95,7 @@ func postAdminJSONProtoWithAdminOption(
 // getText fetches the HTTP response body as text in the form of a
 // byte slice from the specified URL.
 func getText(ts serverutils.TestServerInterface, url string) ([]byte, error) {
-	httpClient, err := ts.GetAdminAuthenticatedHTTPClient()
+	httpClient, err := ts.GetAdminHTTPClient()
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +223,7 @@ func TestAdminDebugAuth(t *testing.T) {
 	url := debugURL(s)
 
 	// Unauthenticated.
-	client, err := ts.GetHTTPClient()
+	client, err := ts.GetUnauthenticatedHTTPClient()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -278,7 +278,7 @@ func TestAdminDebugRedirect(t *testing.T) {
 	origURL := expURL + "incorrect"
 
 	// Must be admin to access debug endpoints
-	client, err := ts.GetAdminAuthenticatedHTTPClient()
+	client, err := ts.GetAdminHTTPClient()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/api_v2_ranges_test.go
+++ b/pkg/server/api_v2_ranges_test.go
@@ -33,7 +33,7 @@ func TestHotRangesV2(t *testing.T) {
 	defer ts.Stopper().Stop(context.Background())
 
 	var hotRangesResp hotRangesResponse
-	client, err := ts.GetAdminAuthenticatedHTTPClient()
+	client, err := ts.GetAdminHTTPClient()
 	require.NoError(t, err)
 
 	req, err := http.NewRequest("GET", ts.AdminURL()+apiV2Path+"ranges/hot/", nil)
@@ -73,7 +73,7 @@ func TestNodeRangesV2(t *testing.T) {
 	}
 
 	var nodeRangesResp nodeRangesResponse
-	client, err := ts.GetAdminAuthenticatedHTTPClient()
+	client, err := ts.GetAdminHTTPClient()
 	require.NoError(t, err)
 
 	req, err := http.NewRequest("GET", ts.AdminURL()+apiV2Path+"nodes/local/ranges/", nil)
@@ -130,7 +130,7 @@ func TestNodesV2(t *testing.T) {
 	ts1 := testCluster.Server(0)
 
 	var nodesResp nodesResponse
-	client, err := ts1.GetAdminAuthenticatedHTTPClient()
+	client, err := ts1.GetAdminHTTPClient()
 	require.NoError(t, err)
 
 	req, err := http.NewRequest("GET", ts1.AdminURL()+apiV2Path+"nodes/", nil)

--- a/pkg/server/api_v2_sql_schema_test.go
+++ b/pkg/server/api_v2_sql_schema_test.go
@@ -40,7 +40,7 @@ func TestUsersV2(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, conn.Close())
 
-	client, err := ts1.GetAdminAuthenticatedHTTPClient()
+	client, err := ts1.GetAdminHTTPClient()
 	require.NoError(t, err)
 
 	req, err := http.NewRequest("GET", ts1.AdminURL()+apiV2Path+"users/", nil)
@@ -80,7 +80,7 @@ func TestDatabasesTablesV2(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, conn.Close())
 
-	client, err := ts1.GetAdminAuthenticatedHTTPClient()
+	client, err := ts1.GetAdminHTTPClient()
 	require.NoError(t, err)
 	defer client.CloseIdleConnections()
 
@@ -176,7 +176,7 @@ func TestEventsV2(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, conn.Close())
 
-	client, err := ts1.GetAdminAuthenticatedHTTPClient()
+	client, err := ts1.GetAdminHTTPClient()
 	require.NoError(t, err)
 
 	req, err := http.NewRequest("GET", ts1.AdminURL()+apiV2Path+"events/", nil)

--- a/pkg/server/api_v2_test.go
+++ b/pkg/server/api_v2_test.go
@@ -82,7 +82,7 @@ func TestListSessionsV2(t *testing.T) {
 	}
 
 	time.Sleep(500 * time.Millisecond)
-	adminClient, err := ts1.GetAdminAuthenticatedHTTPClient()
+	adminClient, err := ts1.GetAdminHTTPClient()
 	require.NoError(t, err)
 	sessionsResponse := doSessionsRequest(adminClient, 0, "")
 	require.LessOrEqual(t, 15, len(sessionsResponse.Sessions))
@@ -138,7 +138,7 @@ func TestHealthV2(t *testing.T) {
 
 	ts1 := testCluster.Server(0)
 
-	client, err := ts1.GetAdminAuthenticatedHTTPClient()
+	client, err := ts1.GetAdminHTTPClient()
 	require.NoError(t, err)
 
 	req, err := http.NewRequest("GET", ts1.AdminURL()+apiV2Path+"health/", nil)
@@ -166,7 +166,7 @@ func TestRulesV2(t *testing.T) {
 	defer testCluster.Stopper().Stop(ctx)
 
 	ts := testCluster.Server(0)
-	client, err := ts.GetHTTPClient()
+	client, err := ts.GetUnauthenticatedHTTPClient()
 	require.NoError(t, err)
 
 	req, err := http.NewRequest("GET", ts.AdminURL()+apiV2Path+"rules/", nil)

--- a/pkg/server/authentication_test.go
+++ b/pkg/server/authentication_test.go
@@ -486,7 +486,7 @@ func TestAuthenticationAPIUserLogin(t *testing.T) {
 	tryLogin := func(username, password string) (*http.Response, error) {
 		// We need to instantiate our own HTTP Request, because we must inspect
 		// the returned headers.
-		httpClient, err := ts.GetHTTPClient()
+		httpClient, err := ts.GetUnauthenticatedHTTPClient()
 		if util.RaceEnabled {
 			httpClient.Timeout += 30 * time.Second
 		}
@@ -611,7 +611,7 @@ func TestLogout(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	invalidAuthClient, err := s.GetHTTPClient()
+	invalidAuthClient, err := s.GetUnauthenticatedHTTPClient()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -647,11 +647,11 @@ func TestAuthenticationMux(t *testing.T) {
 	tsrv := s.(*TestServer)
 
 	// Both the normal and authenticated client will be used for each test.
-	normalClient, err := tsrv.GetHTTPClient()
+	normalClient, err := tsrv.GetUnauthenticatedHTTPClient()
 	if err != nil {
 		t.Fatal(err)
 	}
-	authClient, err := tsrv.GetAdminAuthenticatedHTTPClient()
+	authClient, err := tsrv.GetAdminHTTPClient()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/node_http_router_test.go
+++ b/pkg/server/node_http_router_test.go
@@ -135,7 +135,7 @@ func TestRouteToNode(t *testing.T) {
 		t.Run(rt.name, func(t *testing.T) {
 			s := tc.Server(rt.sourceServerID)
 			require.Equal(t, rt.sourceServerID+1, int(s.NodeID()))
-			client, err := s.GetHTTPClient()
+			client, err := s.GetUnauthenticatedHTTPClient()
 			if rt.requireAuth {
 				client, err = s.GetAuthenticatedHTTPClient(rt.requireAdmin)
 			}
@@ -178,7 +178,7 @@ func TestRouteToNode(t *testing.T) {
 	t.Run("route to shutdown node should fail with error status", func(t *testing.T) {
 		tc.Server(1).Stopper().Stop(context.Background())
 		s := tc.Server(0)
-		client, err := s.GetHTTPClient()
+		client, err := s.GetUnauthenticatedHTTPClient()
 		require.NoError(t, err)
 
 		resp, err := client.Get(s.AdminURL() + fmt.Sprintf("/_status/vars?%s=%s", RemoteNodeID, "2"))

--- a/pkg/server/server_http_test.go
+++ b/pkg/server/server_http_test.go
@@ -30,7 +30,7 @@ func TestHSTS(t *testing.T) {
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
-	httpClient, err := s.GetHTTPClient()
+	httpClient, err := s.GetUnauthenticatedHTTPClient()
 	require.NoError(t, err)
 	defer httpClient.CloseIdleConnections()
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -296,7 +296,7 @@ func TestSecureHTTPRedirect(t *testing.T) {
 	defer s.Stopper().Stop(context.Background())
 	ts := s.(*TestServer)
 
-	httpClient, err := s.GetHTTPClient()
+	httpClient, err := s.GetUnauthenticatedHTTPClient()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -345,7 +345,7 @@ func TestAcceptEncoding(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
-	client, err := s.GetAdminAuthenticatedHTTPClient()
+	client, err := s.GetAdminHTTPClient()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -856,7 +856,7 @@ func TestServeIndexHTML(t *testing.T) {
 		defer s.Stopper().Stop(ctx)
 		tsrv := s.(*TestServer)
 
-		client, err := tsrv.GetHTTPClient()
+		client, err := tsrv.GetUnauthenticatedHTTPClient()
 		require.NoError(t, err)
 
 		t.Run("short build", func(t *testing.T) {
@@ -910,9 +910,9 @@ Binary built without web UI.
 		defer s.Stopper().Stop(ctx)
 		tsrv := s.(*TestServer)
 
-		loggedInClient, err := tsrv.GetAdminAuthenticatedHTTPClient()
+		loggedInClient, err := tsrv.GetAdminHTTPClient()
 		require.NoError(t, err)
-		loggedOutClient, err := tsrv.GetHTTPClient()
+		loggedOutClient, err := tsrv.GetUnauthenticatedHTTPClient()
 		require.NoError(t, err)
 
 		cases := []struct {

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -1308,7 +1308,7 @@ func TestSpanStatsResponse(t *testing.T) {
 	ts := startServer(t)
 	defer ts.Stopper().Stop(context.Background())
 
-	httpClient, err := ts.GetAdminAuthenticatedHTTPClient()
+	httpClient, err := ts.GetAdminHTTPClient()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/testserver_http.go
+++ b/pkg/server/testserver_http.go
@@ -50,13 +50,13 @@ func (ts *httpTestServer) AdminURL() string {
 	return ts.t.sqlServer.execCfg.RPCContext.Config.AdminURL().String()
 }
 
-// GetHTTPClient implements TestServerInterface.
-func (ts *httpTestServer) GetHTTPClient() (http.Client, error) {
+// GetUnauthenticatedHTTPClient implements TestServerInterface.
+func (ts *httpTestServer) GetUnauthenticatedHTTPClient() (http.Client, error) {
 	return ts.t.sqlServer.execCfg.RPCContext.GetHTTPClient()
 }
 
-// GetAdminAuthenticatedHTTPClient implements the TestServerInterface.
-func (ts *httpTestServer) GetAdminAuthenticatedHTTPClient() (http.Client, error) {
+// GetAdminHTTPClient implements the TestServerInterface.
+func (ts *httpTestServer) GetAdminHTTPClient() (http.Client, error) {
 	httpClient, _, err := ts.getAuthenticatedHTTPClientAndCookie(authenticatedUserName(), true)
 	return httpClient, err
 }

--- a/pkg/sql/pgwire/auth_test.go
+++ b/pkg/sql/pgwire/auth_test.go
@@ -210,7 +210,7 @@ func hbaRunTest(t *testing.T, insecure bool) {
 		pgServer.TestingEnableConnLogging()
 		pgServer.TestingEnableAuthLogging()
 
-		httpClient, err := s.GetAdminAuthenticatedHTTPClient()
+		httpClient, err := s.GetAdminHTTPClient()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/testutils/serverutils/test_tenant_shim.go
+++ b/pkg/testutils/serverutils/test_tenant_shim.go
@@ -117,13 +117,15 @@ type TestTenantInterface interface {
 
 	// AdminURL returns the URL for the admin UI.
 	AdminURL() string
-	// GetHTTPClient returns an http client configured with the client TLS
+	// GetUnauthenticatedHTTPClient returns an http client configured with the client TLS
 	// config required by the TestServer's configuration.
-	GetHTTPClient() (http.Client, error)
-	// GetAdminAuthenticatedHTTPClient returns an http client which has been
+	// Discourages implementer from using unauthenticated http connections
+	// with verbose method name.
+	GetUnauthenticatedHTTPClient() (http.Client, error)
+	// GetAdminHTTPClient returns an http client which has been
 	// authenticated to access Admin API methods (via a cookie).
 	// The user has admin privileges.
-	GetAdminAuthenticatedHTTPClient() (http.Client, error)
+	GetAdminHTTPClient() (http.Client, error)
 	// GetAuthenticatedHTTPClient returns an http client which has been
 	// authenticated to access Admin API methods (via a cookie).
 	GetAuthenticatedHTTPClient(isAdmin bool) (http.Client, error)

--- a/pkg/testutils/testcluster/testcluster_test.go
+++ b/pkg/testutils/testcluster/testcluster_test.go
@@ -197,7 +197,7 @@ func TestStopServer(t *testing.T) {
 	server1 := tc.Server(1)
 	var response serverpb.JSONResponse
 
-	httpClient1, err := server1.GetHTTPClient()
+	httpClient1, err := server1.GetUnauthenticatedHTTPClient()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -256,7 +256,7 @@ func TestStopServer(t *testing.T) {
 	}
 
 	// Verify that request to Server 0 still works.
-	httpClient1, err = tc.Server(0).GetHTTPClient()
+	httpClient1, err = tc.Server(0).GetUnauthenticatedHTTPClient()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
fixes #76241.
See commit message.

Release justification: Low impact, rename refactoring of testserver methods