### PR TITLE
ccl/sqlproxyccl: fix a forwarding race after evaluating a safe transfer point

### DIFF
--- a/pkg/ccl/sqlproxyccl/conn_migration.go
+++ b/pkg/ccl/sqlproxyccl/conn_migration.go
@@ -78,11 +78,22 @@ func (f *forwarder) tryBeginTransfer() (started bool, cleanupFn func()) {
 		return false, nil
 	}
 
-	if !isSafeTransferPoint(f.mu.request, f.mu.response) {
+	request, response := f.mu.request, f.mu.response
+	request.mu.Lock()
+	response.mu.Lock()
+	defer request.mu.Unlock()
+	defer response.mu.Unlock()
+
+	if !isSafeTransferPointLocked(request, response) {
 		return false, nil
 	}
 
+	// Once we mark the forwarder as transferring, attempt to suspend right
+	// away before unlocking, but without blocking. This ensures that no other
+	// messages are forwarded.
 	f.mu.isTransferring = true
+	request.mu.suspendReq = true
+	response.mu.suspendReq = true
 
 	return true, func() {
 		f.mu.Lock()
@@ -249,14 +260,9 @@ func transferConnection(
 	return newServerConn, nil
 }
 
-// isSafeTransferPoint returns true if we're at a point where we're safe to
-// transfer, and false otherwise.
-var isSafeTransferPoint = func(request *processor, response *processor) bool {
-	request.mu.Lock()
-	response.mu.Lock()
-	defer request.mu.Unlock()
-	defer response.mu.Unlock()
-
+// isSafeTransferPointLocked returns true if we're at a point where we're safe
+// to transfer, and false otherwise.
+var isSafeTransferPointLocked = func(request *processor, response *processor) bool {
 	// Three conditions when evaluating a safe transfer point:
 	//   1. The last message sent to the SQL pod was a Sync(S) or SimpleQuery(Q),
 	//      and a ReadyForQuery(Z) has been received after.

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -1043,7 +1043,7 @@ func TestConnectionMigration(t *testing.T) {
 	//
 	// There's no easy way to simulate pipelined queries. pgtest (that allows
 	// us to send individual pgwire messages) does not support authentication,
-	// which is what the proxy needs, so we will stub isSafeTransferPoint
+	// which is what the proxy needs, so we will stub isSafeTransferPointLocked
 	// instead.
 	t.Run("transfer_timeout_in_response", func(t *testing.T) {
 		tCtx, cancel := context.WithCancel(ctx)
@@ -1081,7 +1081,7 @@ func TestConnectionMigration(t *testing.T) {
 			prevTenant1 = true
 			return tenant1.SQLAddr(), nil
 		}
-		defer testutils.TestingHook(&isSafeTransferPoint, func(req *processor, res *processor) bool {
+		defer testutils.TestingHook(&isSafeTransferPointLocked, func(req *processor, res *processor) bool {
 			return true
 		})()
 		// Transfer timeout is 3s, and we'll run pg_sleep for 10s.


### PR DESCRIPTION
Previously, there's a possibility where the forwarder will continue to forward
messages **after** we evaluate a safe transfer point. This isn't a problem in
the old design, and is only present in the updated design. In this bug, there
could be a case where a query gets sent right after evaluating the safe
transfer point because the processors' locks were released, leading to a
possible connection termination.

Consider the following messages sent by the client: Q1 -> Q2 (relies on Q1).
Right before Q1, the forwarder detects that we're in a safe transfer point.
When we release the lock, we forward Q1 to the server before suspending. It is
possible that the connection migration will succeed, but forwarding Q2 through
the new connection will fail. To avoid such protocol errors, we'll ensure that
we set suspendReq = true once we start the transferring process. That way,
there won't be such a race. We want to be sure that when we start sending
the transfer request message, we are in a safe transfer point to minimize
connection terminations.

Release justification: Low-risk sqlproxy only change, high priority bug fix.

Release note: None