### PR TITLE
sql: implement SHOW [ALL] CLUSTER SETTINGS FOR TENANT

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2957,11 +2957,15 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.cluster_name"></a><code>crdb_internal.cluster_name() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the cluster name.</p>
 </span></td></tr>
+<tr><td><a name="crdb_internal.cluster_setting_encoded_default"></a><code>crdb_internal.cluster_setting_encoded_default(setting: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the encoded default value of the given cluster setting.</p>
+</span></td></tr>
 <tr><td><a name="crdb_internal.completed_migrations"></a><code>crdb_internal.completed_migrations() &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.create_join_token"></a><code>crdb_internal.create_join_token() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Creates a join token for use when adding a new node to a secure cluster.</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.create_session_revival_token"></a><code>crdb_internal.create_session_revival_token() &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Generate a token that can be used to create a new session for the current user.</p>
+</span></td></tr>
+<tr><td><a name="crdb_internal.decode_cluster_setting"></a><code>crdb_internal.decode_cluster_setting(setting: <a href="string.html">string</a>, value: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Decodes the given encoded value for a cluster setting.</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.deserialize_session"></a><code>crdb_internal.deserialize_session(session: <a href="bytes.html">bytes</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>This function deserializes the serialized variables into the current session.</p>
 </span></td></tr>

--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_settings
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_settings
@@ -10,6 +10,22 @@ user host-cluster-root
 statement ok
 ALTER TENANT 10 SET CLUSTER SETTING sql.notices.enabled = false
 
+query TT
+SELECT value, origin FROM [SHOW CLUSTER SETTINGS FOR TENANT 10] WHERE variable = 'sql.notices.enabled'
+----
+false  per-tenant-override
+
+# Check that subqueries work as tenant ID.
+query TT
+SELECT value, origin FROM [
+  SHOW CLUSTER SETTINGS FOR TENANT (
+     SELECT tenant_id
+     FROM system.tenant_settings
+     WHERE tenant_id = 10)]
+WHERE variable = 'sql.notices.enabled'
+----
+false  per-tenant-override
+
 user root
 
 query B retry
@@ -22,6 +38,11 @@ user host-cluster-root
 
 statement ok
 ALTER TENANT 10 RESET CLUSTER SETTING sql.notices.enabled
+
+query TT
+SELECT value, origin FROM [SHOW CLUSTER SETTINGS FOR TENANT 10] WHERE variable = 'sql.notices.enabled'
+----
+NULL  no-override
 
 user root
 
@@ -36,6 +57,11 @@ user host-cluster-root
 statement ok
 ALTER TENANT ALL SET CLUSTER SETTING sql.notices.enabled = false
 
+query TT
+SELECT value, origin FROM [SHOW CLUSTER SETTINGS FOR TENANT 10] WHERE variable = 'sql.notices.enabled'
+----
+false  all-tenants-override
+
 user root
 
 query B retry
@@ -48,6 +74,11 @@ user host-cluster-root
 # Now set a tenant-specific override which takes precedence.
 statement ok
 ALTER TENANT 10 SET CLUSTER SETTING sql.notices.enabled = true
+
+query TT
+SELECT value, origin FROM [SHOW CLUSTER SETTINGS FOR TENANT 10] WHERE variable = 'sql.notices.enabled'
+----
+true  per-tenant-override
 
 user root
 
@@ -68,6 +99,11 @@ user host-cluster-root
 # Remove the all-tenant override; should make no difference.
 statement ok
 ALTER TENANT ALL RESET CLUSTER SETTING sql.notices.enabled
+
+query TT
+SELECT value, origin FROM [SHOW CLUSTER SETTINGS FOR TENANT 10] WHERE variable = 'sql.notices.enabled'
+----
+true  per-tenant-override
 
 user root
 
@@ -100,6 +136,11 @@ user host-cluster-root
 statement ok
 ALTER TENANT 10 SET CLUSTER SETTING kv.protectedts.reconciliation.interval = '45s'
 
+query TT
+SELECT value, origin FROM [SHOW CLUSTER SETTINGS FOR TENANT 10] WHERE variable = 'kv.protectedts.reconciliation.interval'
+----
+45s  per-tenant-override
+
 user root
 
 query T retry
@@ -128,3 +169,4 @@ query I
 SELECT count(*) FROM system.tenant_settings WHERE tenant_id = 1234
 ----
 0
+

--- a/pkg/settings/bool.go
+++ b/pkg/settings/bool.go
@@ -10,7 +10,10 @@
 
 package settings
 
-import "context"
+import (
+	"context"
+	"strconv"
+)
 
 // BoolSetting is the interface of a setting variable that will be
 // updated automatically when the corresponding cluster-wide setting
@@ -39,6 +42,15 @@ func (b *BoolSetting) Encoded(sv *Values) string {
 // EncodedDefault returns the encoded value of the default value of the setting.
 func (b *BoolSetting) EncodedDefault() string {
 	return EncodeBool(b.defaultValue)
+}
+
+// DecodeToString decodes and renders an encoded value.
+func (b *BoolSetting) DecodeToString(encoded string) (string, error) {
+	bv, err := strconv.ParseBool(encoded)
+	if err != nil {
+		return "", err
+	}
+	return EncodeBool(bv), nil
 }
 
 // Typ returns the short (1 char) string denoting the type of setting.

--- a/pkg/settings/byte_size.go
+++ b/pkg/settings/byte_size.go
@@ -33,6 +33,15 @@ func (b *ByteSizeSetting) String(sv *Values) string {
 	return string(humanizeutil.IBytes(b.Get(sv)))
 }
 
+// DecodeToString decodes and renders an encoded value.
+func (b *ByteSizeSetting) DecodeToString(encoded string) (string, error) {
+	iv, err := b.decodeNum(encoded)
+	if err != nil {
+		return "", err
+	}
+	return string(humanizeutil.IBytes(iv)), nil
+}
+
 // WithPublic sets public visibility and can be chained.
 func (b *ByteSizeSetting) WithPublic() *ByteSizeSetting {
 	b.SetVisibility(Public)

--- a/pkg/settings/common.go
+++ b/pkg/settings/common.go
@@ -127,5 +127,6 @@ type internalSetting interface {
 // numericSetting is used for settings that can be set using an integer value.
 type numericSetting interface {
 	internalSetting
+	decodeNum(value string) (int64, error)
 	set(ctx context.Context, sv *Values, value int64) error
 }

--- a/pkg/settings/duration.go
+++ b/pkg/settings/duration.go
@@ -60,6 +60,15 @@ func (d *DurationSetting) EncodedDefault() string {
 	return EncodeDuration(d.defaultValue)
 }
 
+// DecodeToString decodes and renders an encoded value.
+func (d *DurationSetting) DecodeToString(encoded string) (string, error) {
+	v, err := time.ParseDuration(encoded)
+	if err != nil {
+		return "", err
+	}
+	return EncodeDuration(v), nil
+}
+
 // Typ returns the short (1 char) string denoting the type of setting.
 func (*DurationSetting) Typ() string {
 	return "d"

--- a/pkg/settings/enum.go
+++ b/pkg/settings/enum.go
@@ -43,6 +43,18 @@ func (e *EnumSetting) String(sv *Values) string {
 	return fmt.Sprintf("unknown(%d)", enumID)
 }
 
+// DecodeToString decodes and renders an encoded value.
+func (e *EnumSetting) DecodeToString(encoded string) (string, error) {
+	v, err := e.decodeNum(encoded)
+	if err != nil {
+		return "", err
+	}
+	if str, ok := e.enumValues[v]; ok {
+		return str, nil
+	}
+	return encoded, nil
+}
+
 // ParseEnum returns the enum value, and a boolean that indicates if it was parseable.
 func (e *EnumSetting) ParseEnum(raw string) (int64, bool) {
 	rawLower := strings.ToLower(raw)

--- a/pkg/settings/float.go
+++ b/pkg/settings/float.go
@@ -13,6 +13,7 @@ package settings
 import (
 	"context"
 	"math"
+	"strconv"
 
 	"github.com/cockroachdb/errors"
 )
@@ -45,6 +46,15 @@ func (f *FloatSetting) Encoded(sv *Values) string {
 // EncodedDefault returns the encoded value of the default value of the setting.
 func (f *FloatSetting) EncodedDefault() string {
 	return EncodeFloat(f.defaultValue)
+}
+
+// DecodeToString decodes and renders an encoded value.
+func (f *FloatSetting) DecodeToString(encoded string) (string, error) {
+	fv, err := strconv.ParseFloat(encoded, 64)
+	if err != nil {
+		return "", err
+	}
+	return EncodeFloat(fv), nil
 }
 
 // Typ returns the short (1 char) string denoting the type of setting.

--- a/pkg/settings/int.go
+++ b/pkg/settings/int.go
@@ -12,6 +12,7 @@ package settings
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/cockroachdb/errors"
 )
@@ -44,6 +45,19 @@ func (i *IntSetting) Encoded(sv *Values) string {
 // EncodedDefault returns the encoded value of the default value of the setting.
 func (i *IntSetting) EncodedDefault() string {
 	return EncodeInt(i.defaultValue)
+}
+
+// DecodeToString decodes and renders an encoded value.
+func (i *IntSetting) DecodeToString(encoded string) (string, error) {
+	iv, err := i.decodeNum(encoded)
+	if err != nil {
+		return "", err
+	}
+	return EncodeInt(iv), nil
+}
+
+func (i *IntSetting) decodeNum(value string) (int64, error) {
+	return strconv.ParseInt(value, 10, 64)
 }
 
 // Typ returns the short (1 char) string denoting the type of setting.

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -58,6 +58,14 @@ type NonMaskedSetting interface {
 	// the setting.
 	EncodedDefault() string
 
+	// DecodeToString returns the string representation of the provided
+	// encoded value.
+	// This is analogous to loading the setting from storage and
+	// then calling String() on it, however the setting is not modified.
+	// The string representation of the default value can be obtained
+	// by calling EncodedDefault() and then DecodeToString().
+	DecodeToString(encoded string) (repr string, err error)
+
 	// SetOnChange installs a callback to be called when a setting's value
 	// changes. `fn` should avoid doing long-running or blocking work as it is
 	// called on the goroutine which handles all settings updates.

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -461,7 +461,7 @@ func TestCache(t *testing.T) {
 		if expected, actual := 1, changes.eA; expected != actual {
 			t.Fatalf("expected %d, got %d", expected, actual)
 		}
-		if expected, err := "strconv.Atoi: parsing \"notAValidValue\": invalid syntax",
+		if expected, err := "strconv.ParseInt: parsing \"notAValidValue\": invalid syntax",
 			u.Set(ctx, "e", v("notAValidValue", "e")); !testutils.IsError(err, expected) {
 			t.Fatalf("expected '%s' != actual error '%s'", expected, err)
 		}
@@ -599,7 +599,7 @@ func TestCache(t *testing.T) {
 		{
 			u := settings.NewUpdater(sv)
 			if err := u.Set(ctx, "i.2", v(settings.EncodeBool(false), "i")); !testutils.IsError(err,
-				"strconv.Atoi: parsing \"false\": invalid syntax",
+				"strconv.ParseInt: parsing \"false\": invalid syntax",
 			) {
 				t.Fatal(err)
 			}

--- a/pkg/settings/string.go
+++ b/pkg/settings/string.go
@@ -41,6 +41,11 @@ func (s *StringSetting) EncodedDefault() string {
 	return s.defaultValue
 }
 
+// DecodeToString decodes and renders an encoded value.
+func (s *StringSetting) DecodeToString(encoded string) (string, error) {
+	return encoded, nil
+}
+
 // Typ returns the short (1 char) string denoting the type of setting.
 func (*StringSetting) Typ() string {
 	return "s"

--- a/pkg/settings/updater.go
+++ b/pkg/settings/updater.go
@@ -99,11 +99,11 @@ func (u updater) Set(ctx context.Context, key string, value EncodedValue) error 
 		setting.set(ctx, u.sv, b)
 		return nil
 	case numericSetting:
-		i, err := strconv.Atoi(value.Value)
+		i, err := setting.decodeNum(value.Value)
 		if err != nil {
 			return err
 		}
-		return setting.set(ctx, u.sv, int64(i))
+		return setting.set(ctx, u.sv, i)
 	case *FloatSetting:
 		f, err := strconv.ParseFloat(value.Value, 64)
 		if err != nil {

--- a/pkg/settings/version.go
+++ b/pkg/settings/version.go
@@ -126,7 +126,21 @@ func (v *VersionSetting) Encoded(sv *Values) string {
 
 // EncodedDefault is part of the NonMaskedSetting interface.
 func (v *VersionSetting) EncodedDefault() string {
-	return "unsupported"
+	return encodedDefaultVersion
+}
+
+const encodedDefaultVersion = "unsupported"
+
+// DecodeToString decodes and renders an encoded value.
+func (v *VersionSetting) DecodeToString(encoded string) (string, error) {
+	if encoded == encodedDefaultVersion {
+		return encodedDefaultVersion, nil
+	}
+	cv, err := v.impl.Decode([]byte(encoded))
+	if err != nil {
+		return "", err
+	}
+	return cv.String(), nil
 }
 
 // Get retrieves the encoded value (in string form) in the setting. It panics if

--- a/pkg/sql/logictest/testdata/logic_test/cluster_settings
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_settings
@@ -228,17 +228,31 @@ statement error unimplemented
 SHOW CLUSTER SETTING server.mem_profile.total_dump_size_limit FOR TENANT 10
 
 onlyif config 3node-tenant
-statement error unimplemented
+query error SHOW CLUSTER SETTINGS FOR TENANT can only be called by system operators
 SHOW CLUSTER SETTINGS FOR TENANT 10
 
 skipif config 3node-tenant
-statement error unimplemented
-SHOW CLUSTER SETTINGS FOR TENANT 10
+query error tenant ID must be non-zero
+SHOW CLUSTER SETTINGS FOR TENANT 0
 
 skipif config 3node-tenant
-statement error unimplemented
-SHOW PUBLIC CLUSTER SETTINGS FOR TENANT 10
+query error use SHOW CLUSTER SETTINGS to display settings for the system tenant
+SHOW CLUSTER SETTINGS FOR TENANT 1
 
 skipif config 3node-tenant
-statement error unimplemented
-SHOW ALL CLUSTER SETTINGS FOR TENANT 10
+query error no tenant found with ID 1111
+SHOW CLUSTER SETTINGS FOR TENANT 1111
+
+# The IN clause should contain one public and one hidden cluster setting.
+skipif config 3node-tenant
+query TTT
+SELECT variable, type, origin FROM [SHOW CLUSTER SETTINGS FOR TENANT 10] WHERE variable IN ('jobs.scheduler.enabled', 'jobs.retention_time') ORDER BY 1
+----
+jobs.retention_time  d  no-override
+
+skipif config 3node-tenant
+query TTBT
+SELECT variable, type, public, origin FROM [SHOW ALL CLUSTER SETTINGS FOR TENANT 10] WHERE variable IN ('jobs.scheduler.enabled', 'jobs.retention_time') ORDER BY 1
+----
+jobs.retention_time     d  true   no-override
+jobs.scheduler.enabled  b  false  no-override

--- a/pkg/sql/logictest/testdata/logic_test/cluster_settings
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_settings
@@ -158,6 +158,26 @@ SHOW CLUSTER SETTING kv.snapshot_rebalance.max_rate
 ----
 10 MiB
 
+skipif config 3node-tenant
+query T
+SELECT crdb_internal.cluster_setting_encoded_default('kv.snapshot_rebalance.max_rate')
+----
+33554432
+
+skipif config 3node-tenant
+query T
+SELECT crdb_internal.decode_cluster_setting('kv.snapshot_rebalance.max_rate', '33554432')
+----
+32 MiB
+
+onlyif config 3node-tenant
+query error unknown cluster setting
+SELECT crdb_internal.cluster_setting_encoded_default('kv.snapshot_rebalance.max_rate')
+
+onlyif config 3node-tenant
+query error unknown cluster setting
+SELECT crdb_internal.decode_cluster_setting('kv.snapshot_rebalance.max_rate', '33554432')
+
 onlyif config 3node-tenant
 statement error unknown cluster setting
 SET CLUSTER SETTING kv.snapshot_rebalance.max_rate = '10Mib'

--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/security",
         "//pkg/server/telemetry",
+        "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catalogkeys",

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
@@ -4606,6 +4607,78 @@ value if you rely on the HLC for accuracy.`,
 			},
 			Info:       "Returns the value of the specified locality key.",
 			Volatility: tree.VolatilityStable,
+		},
+	),
+
+	"crdb_internal.cluster_setting_encoded_default": makeBuiltin(
+		tree.FunctionProperties{Category: categorySystemInfo},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"setting", types.String}},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				s, ok := tree.AsDString(args[0])
+				if !ok {
+					return nil, errors.AssertionFailedf("expected string value, got %T", args[0])
+				}
+				name := strings.ToLower(string(s))
+				rawSetting, ok := settings.Lookup(
+					name, settings.LookupForLocalAccess, ctx.Codec.ForSystemTenant(),
+				)
+				if !ok {
+					return nil, errors.Newf("unknown cluster setting '%s'", name)
+				}
+				setting, ok := rawSetting.(settings.NonMaskedSetting)
+				if !ok {
+					// If we arrive here, this means Lookup() did not properly
+					// ignore the masked setting, which is a bug in Lookup().
+					return nil, errors.AssertionFailedf("setting '%s' is masked", name)
+				}
+
+				return tree.NewDString(setting.EncodedDefault()), nil
+			},
+			Info:       "Returns the encoded default value of the given cluster setting.",
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
+
+	"crdb_internal.decode_cluster_setting": makeBuiltin(
+		tree.FunctionProperties{Category: categorySystemInfo},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"setting", types.String},
+				{"value", types.String},
+			},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				s, ok := tree.AsDString(args[0])
+				if !ok {
+					return nil, errors.AssertionFailedf("expected string value, got %T", args[0])
+				}
+				encoded, ok := tree.AsDString(args[1])
+				if !ok {
+					return nil, errors.AssertionFailedf("expected string value, got %T", args[1])
+				}
+				name := strings.ToLower(string(s))
+				rawSetting, ok := settings.Lookup(
+					name, settings.LookupForLocalAccess, ctx.Codec.ForSystemTenant(),
+				)
+				if !ok {
+					return nil, errors.Newf("unknown cluster setting '%s'", name)
+				}
+				setting, ok := rawSetting.(settings.NonMaskedSetting)
+				if !ok {
+					// If we arrive here, this means Lookup() did not properly
+					// ignore the masked setting, which is a bug in Lookup().
+					return nil, errors.AssertionFailedf("setting '%s' is masked", name)
+				}
+				repr, err := setting.DecodeToString(string(encoded))
+				if err != nil {
+					return nil, errors.Wrapf(err, "%v", name)
+				}
+				return tree.NewDString(repr), nil
+			},
+			Info:       "Decodes the given encoded value for a cluster setting.",
+			Volatility: tree.VolatilityImmutable,
 		},
 	),
 


### PR DESCRIPTION
All commits but the last 2 from #77740.
(Reviewers: only the last 2 commits belong to this PR.)

Informs #77471

Release justification: low risk, high benefit changes to existing functionality