### PR TITLE
worklaod/schemachange: disable schemachange workload

### DIFF
--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -179,6 +179,15 @@ func (s *schemaChange) Ops(
 
 	s.dumpLogsOnce = &sync.Once{}
 
+	// TODO (fqazi): For 21.2 disable the schemahcnage workload, by always forcing
+	// a concurrency of 0. See epic: CRDB-13725
+	// Note: We can't only disable the external workload, since there are other
+	// mixed workloads that require this workload.
+	s.concurrency = 0
+	if artifactsLog != nil {
+		artifactsLog.printLn("schemachanger workload is disabled in 21.2 since it flakes.")
+	}
+
 	for i := 0; i < s.concurrency; i++ {
 
 		opGeneratorParams := operationGeneratorParams{


### PR DESCRIPTION
Previously, the schemachange workload was enabled on 21.2,
but due to a number of test issues could lead to flaky
failures. This was inadequate because it created tons of
noise for developers to investigate. To address this,
this patch will temporarily disable this test in 21.2,
since fixes in the next release will improve the stability
and eliminate noise.

Release note: None