### PR TITLE
workload/schemachange: disable schemachange workload

### DIFF
--- a/pkg/cmd/roachtest/tests/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/tests/schemachange_random_load.go
@@ -89,6 +89,10 @@ func registerRandomLoadBenchSpec(r registry.Registry, b randomLoadBenchSpec) {
 		// fix (or bypass) minor schema change bugs that are discovered.
 		NonReleaseBlocker: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			// The schemachange workload is extremely noisy in 21.2, so we are going
+			// leave it disabled until the workload gets fully stabilized in then next
+			// release (via epic: CRDB-13725).
+			t.Skip("disabled in 21.2 since schemachange workload is not stable")
 			runSchemaChangeRandomLoad(ctx, t, c, b.Ops, b.Concurrency)
 		},
 	})


### PR DESCRIPTION
Previously, the schemachange workload was enabled on 21.2,
but due to a number of test issues could lead to flaky
failures. This was inadequate because it created tons of
noise for developers to investigate. To address this,
this patch will temporarily disable this test in 21.2,
since fixes in the next release will improve the stability
and eliminate noise.

Release note: None
Release justification: low only disabling a flaky test