### PR TITLE
changefeedccl: checkpoint for lagging high-water

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -78,6 +78,17 @@ var FrontierCheckpointFrequency = settings.RegisterDurationSetting(
 	settings.NonNegativeDuration,
 )
 
+// FrontierHighwaterLagCheckpointThreshold controls the amount the high-water
+// mark is allowed to lag behind the leading edge of the frontier before we
+// begin to attempt checkpointing spans above the high-water mark
+var FrontierHighwaterLagCheckpointThreshold = settings.RegisterDurationSetting(
+	settings.TenantWritable,
+	"changefeed.frontier_highwater_lag_checkpoint_threshold",
+	"controls the maximum the high-water mark is allowed to lag behind the leading spans of the frontier before per-span checkpointing is enabled; if 0, checkpointing due to high-water lag is disabled",
+	10*time.Minute,
+	settings.NonNegativeDuration,
+)
+
 // FrontierCheckpointMaxBytes controls the maximum number of key bytes that will be added
 // to the checkpoint record.
 // Checkpoint record could be fairly large.

--- a/pkg/ccl/changefeedccl/changefeeddist/distflow.go
+++ b/pkg/ccl/changefeedccl/changefeeddist/distflow.go
@@ -67,16 +67,24 @@ func StartDistChangefeed(
 	// spans that are assigned to it.
 	// We could compute per-aggregator checkpoint, but that's probably an overkill.
 	aggregatorCheckpoint := execinfrapb.ChangeAggregatorSpec_Checkpoint{
-		Spans: checkpoint.Spans,
+		Spans:     checkpoint.Spans,
+		Timestamp: checkpoint.Timestamp,
 	}
+
+	var checkpointSpanGroup roachpb.SpanGroup
+	checkpointSpanGroup.Add(checkpoint.Spans...)
 
 	aggregatorSpecs := make([]*execinfrapb.ChangeAggregatorSpec, len(spanPartitions))
 	for i, sp := range spanPartitions {
 		watches := make([]execinfrapb.ChangeAggregatorSpec_Watch, len(sp.Spans))
 		for watchIdx, nodeSpan := range sp.Spans {
+			initialResolved := initialHighWater
+			if checkpointSpanGroup.Encloses(nodeSpan) {
+				initialResolved = checkpoint.Timestamp
+			}
 			watches[watchIdx] = execinfrapb.ChangeAggregatorSpec_Watch{
 				Span:            nodeSpan,
-				InitialResolved: initialHighWater,
+				InitialResolved: initialResolved,
 			}
 		}
 

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl/multiregionccltestutils"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/partitionccl"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -770,4 +771,18 @@ func checkS3Credentials(t *testing.T) (bucket string, accessKey string, secretKe
 	}
 
 	return bucket, accessKey, secretKey
+}
+
+func waitForJobStatus(
+	runner *sqlutils.SQLRunner, t *testing.T, id jobspb.JobID, targetStatus jobs.Status,
+) {
+	testutils.SucceedsSoon(t, func() error {
+		var jobStatus string
+		query := `SELECT status FROM [SHOW CHANGEFEED JOB $1]`
+		runner.QueryRow(t, query, id).Scan(&jobStatus)
+		if targetStatus != jobs.Status(jobStatus) {
+			return errors.Errorf("Expected status:%s but found status:%s", targetStatus, jobStatus)
+		}
+		return nil
+	})
 }

--- a/pkg/ccl/changefeedccl/kvfeed/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvfeed/BUILD.bazel
@@ -56,6 +56,7 @@ go_test(
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",
+        "//pkg/kv/kvclient/kvcoord",
         "//pkg/roachpb",
         "//pkg/security",
         "//pkg/security/securitytest",

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -42,7 +42,8 @@ type Config struct {
 	Clock                   *hlc.Clock
 	Gossip                  gossip.OptionalGossip
 	Spans                   []roachpb.Span
-	BackfillCheckpoint      []roachpb.Span
+	CheckpointSpans         []roachpb.Span
+	CheckpointTimestamp     hlc.Timestamp
 	Targets                 []jobspb.ChangefeedTargetSpecification
 	Writer                  kvevent.Writer
 	Metrics                 *kvevent.Metrics
@@ -90,7 +91,7 @@ func Run(ctx context.Context, cfg Config) error {
 	{
 		sender := cfg.DB.NonTransactionalSender()
 		distSender := sender.(*kv.CrossRangeTxnWrapperSender).Wrapped().(*kvcoord.DistSender)
-		pff = rangefeedFactory(distSender.RangeFeed)
+		pff = rangefeedFactory(distSender.RangeFeedSpans)
 	}
 
 	bf := func() kvevent.Buffer {
@@ -99,7 +100,7 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 
 	f := newKVFeed(
-		cfg.Writer, cfg.Spans, cfg.BackfillCheckpoint,
+		cfg.Writer, cfg.Spans, cfg.CheckpointSpans, cfg.CheckpointTimestamp,
 		cfg.SchemaChangeEvents, cfg.SchemaChangePolicy,
 		cfg.NeedsInitialScan, cfg.WithDiff,
 		cfg.InitialHighWater, cfg.EndTime,
@@ -163,6 +164,7 @@ func (e schemaChangeDetectedError) Error() string {
 type kvFeed struct {
 	spans               []roachpb.Span
 	checkpoint          []roachpb.Span
+	checkpointTimestamp hlc.Timestamp
 	withDiff            bool
 	withInitialBackfill bool
 	initialHighWater    hlc.Timestamp
@@ -187,6 +189,7 @@ func newKVFeed(
 	writer kvevent.Writer,
 	spans []roachpb.Span,
 	checkpoint []roachpb.Span,
+	checkpointTimestamp hlc.Timestamp,
 	schemaChangeEvents changefeedbase.SchemaChangeEventClass,
 	schemaChangePolicy changefeedbase.SchemaChangePolicy,
 	withInitialBackfill, withDiff bool,
@@ -203,6 +206,7 @@ func newKVFeed(
 		writer:              writer,
 		spans:               spans,
 		checkpoint:          checkpoint,
+		checkpointTimestamp: checkpointTimestamp,
 		withInitialBackfill: withInitialBackfill,
 		withDiff:            withDiff,
 		initialHighWater:    initialHighWater,
@@ -230,13 +234,26 @@ func (f *kvFeed) run(ctx context.Context) (err error) {
 		return nil
 	}
 
-	// highWater represents the point in time at or before which we know
+	// Frontier initialized to initialHighwater timestamp which
+	// represents the point in time at or before which we know
 	// we've seen all events or is the initial starting time of the feed.
-	highWater := f.initialHighWater
+	rangeFeedResumeFrontier, err := span.MakeFrontierAt(f.initialHighWater, f.spans...)
+	if err != nil {
+		return err
+	}
+
 	for i := 0; ; i++ {
 		initialScan := i == 0
-		if err = f.scanIfShould(ctx, initialScan, highWater); err != nil {
+		scannedSpans, scannedTS, err := f.scanIfShould(ctx, initialScan, rangeFeedResumeFrontier.Frontier())
+		if err != nil {
 			return err
+		}
+		// We have scanned scannedSpans up to and including scannedTS.  Advance frontier
+		// for those spans -- we can start their range feed from scannedTS.Next().
+		for _, sp := range scannedSpans {
+			if _, err := rangeFeedResumeFrontier.Forward(sp, scannedTS.Next()); err != nil {
+				return err
+			}
 		}
 
 		initialScanOnly := f.endTime.EqOrdering(f.initialHighWater)
@@ -247,10 +264,9 @@ func (f *kvFeed) run(ctx context.Context) (err error) {
 			return errChangefeedCompleted
 		}
 
-		highWater, err = f.runUntilTableEvent(ctx, highWater)
-		if err != nil {
+		if err = f.runUntilTableEvent(ctx, rangeFeedResumeFrontier); err != nil {
 			if tErr := (*errEndTimeReached)(nil); errors.As(err, &tErr) {
-				if err := emitResolved(highWater, jobspb.ResolvedSpan_EXIT); err != nil {
+				if err := emitResolved(rangeFeedResumeFrontier.Frontier(), jobspb.ResolvedSpan_EXIT); err != nil {
 					return err
 				}
 				return errChangefeedCompleted
@@ -258,6 +274,13 @@ func (f *kvFeed) run(ctx context.Context) (err error) {
 			return err
 		}
 
+		// Clear out checkpoint after the initial scan or rangefeed.
+		if initialScan {
+			f.checkpoint = nil
+			f.checkpointTimestamp = hlc.Timestamp{}
+		}
+
+		highWater := rangeFeedResumeFrontier.Frontier()
 		boundaryType := jobspb.ResolvedSpan_BACKFILL
 		if f.schemaChangePolicy == changefeedbase.OptSchemaChangePolicyStop {
 			boundaryType = jobspb.ResolvedSpan_EXIT
@@ -302,22 +325,22 @@ func filterCheckpointSpans(spans []roachpb.Span, completed []roachpb.Span) []roa
 
 func (f *kvFeed) scanIfShould(
 	ctx context.Context, initialScan bool, highWater hlc.Timestamp,
-) error {
+) ([]roachpb.Span, hlc.Timestamp, error) {
 	scanTime := highWater.Next()
 
 	events, err := f.tableFeed.Peek(ctx, scanTime)
 	if err != nil {
-		return err
+		return nil, hlc.Timestamp{}, err
 	}
 	// This off-by-one is a little weird. It says that if you create a changefeed
 	// at some statement time then you're going to get the table as of that statement
 	// time with an initial backfill but if you use a cursor then you will get the
 	// updates after that timestamp.
 	isInitialScan := initialScan && f.withInitialBackfill
-	var spansToBackfill []roachpb.Span
+	var spansToScan []roachpb.Span
 	if isInitialScan {
 		scanTime = highWater
-		spansToBackfill = f.spans
+		spansToScan = f.spans
 	} else if len(events) > 0 {
 		// Only backfill for the tables which have events which may not be all
 		// of the targets.
@@ -337,60 +360,60 @@ func (f *kvFeed) scanIfShould(
 			tableSpan := roachpb.Span{Key: tablePrefix, EndKey: tablePrefix.PrefixEnd()}
 			for _, sp := range f.spans {
 				if tableSpan.Overlaps(sp) {
-					spansToBackfill = append(spansToBackfill, sp)
+					spansToScan = append(spansToScan, sp)
 				}
 			}
 			if !scanTime.Equal(ev.After.GetModificationTime()) {
-				return errors.AssertionFailedf("found event in shouldScan which did not occur at the scan time %v: %v",
+				return nil, hlc.Timestamp{}, errors.AssertionFailedf(
+					"found event in shouldScan which did not occur at the scan time %v: %v",
 					scanTime, ev)
 			}
 		}
 	} else {
-		return nil
+		return nil, hlc.Timestamp{}, nil
 	}
 
 	// Consume the events up to scanTime.
 	if _, err := f.tableFeed.Pop(ctx, scanTime); err != nil {
-		return err
+		return nil, hlc.Timestamp{}, err
 	}
 
 	// If we have initial checkpoint information specified, filter out
 	// spans which we no longer need to scan.
-	spansToBackfill = filterCheckpointSpans(spansToBackfill, f.checkpoint)
+	spansToBackfill := filterCheckpointSpans(spansToScan, f.checkpoint)
 
 	if (!isInitialScan && f.schemaChangePolicy == changefeedbase.OptSchemaChangePolicyNoBackfill) ||
 		len(spansToBackfill) == 0 {
-		return nil
+		return spansToScan, scanTime, nil
 	}
 
 	if f.onBackfillCallback != nil {
 		defer f.onBackfillCallback()()
 	}
 
-	if err := f.scanner.Scan(ctx, f.writer, physicalConfig{
+	if err := f.scanner.Scan(ctx, f.writer, scanConfig{
 		Spans:     spansToBackfill,
 		Timestamp: scanTime,
 		WithDiff:  !isInitialScan && f.withDiff,
 		Knobs:     f.knobs,
 	}); err != nil {
-		return err
+		return nil, hlc.Timestamp{}, err
 	}
 
-	f.checkpoint = nil
-
-	// NB: We don't update the highwater even though we've technically seen all
-	// events for all spans at the previous highwater.Next(). We choose not to
-	// because doing so would be wrong once we only backfill some tables.
-	return nil
+	// We return entire set of spans (ignoring possible checkpoint) because all of those
+	// spans have been scanned up to and including scanTime.
+	return spansToScan, scanTime, nil
 }
 
 func (f *kvFeed) runUntilTableEvent(
-	ctx context.Context, startFrom hlc.Timestamp,
-) (resolvedUpTo hlc.Timestamp, err error) {
+	ctx context.Context, resumeFrontier *span.Frontier,
+) (err error) {
+	startFrom := resumeFrontier.Frontier()
+
 	// Determine whether to request the previous value of each update from
 	// RangeFeed based on whether the `diff` option is specified.
 	if _, err := f.tableFeed.Peek(ctx, startFrom); err != nil {
-		return hlc.Timestamp{}, err
+		return err
 	}
 
 	memBuf := f.bufferFactory()
@@ -398,15 +421,31 @@ func (f *kvFeed) runUntilTableEvent(
 		err = errors.CombineErrors(err, memBuf.CloseWithReason(ctx, err))
 	}()
 
-	g := ctxgroup.WithContext(ctx)
-	physicalCfg := physicalConfig{
-		Spans:     f.spans,
-		Timestamp: startFrom,
-		WithDiff:  f.withDiff,
-		Knobs:     f.knobs,
+	// We have catchup scan checkpoint.  Advance frontier.
+	if startFrom.Less(f.checkpointTimestamp) {
+		for _, s := range f.checkpoint {
+			if _, err := resumeFrontier.Forward(s, f.checkpointTimestamp); err != nil {
+				return err
+			}
+		}
 	}
+
+	var stps []kvcoord.SpanTimePair
+	resumeFrontier.Entries(func(s roachpb.Span, ts hlc.Timestamp) (done span.OpResult) {
+		stps = append(stps, kvcoord.SpanTimePair{Span: s, TS: ts})
+		return span.ContinueMatch
+	})
+
+	g := ctxgroup.WithContext(ctx)
+	physicalCfg := rangeFeedConfig{
+		Spans:    stps,
+		Frontier: resumeFrontier.Frontier(),
+		WithDiff: f.withDiff,
+		Knobs:    f.knobs,
+	}
+
 	g.GoCtx(func(ctx context.Context) error {
-		return copyFromSourceToDestUntilTableEvent(ctx, f.writer, memBuf, physicalCfg, f.tableFeed, f.endTime)
+		return copyFromSourceToDestUntilTableEvent(ctx, f.writer, memBuf, resumeFrontier, f.tableFeed, f.endTime)
 	})
 	g.GoCtx(func(ctx context.Context) error {
 		return f.physicalFeed.Run(ctx, memBuf, physicalCfg)
@@ -418,24 +457,22 @@ func (f *kvFeed) runUntilTableEvent(
 	// recreate the rangefeeds.
 	err = g.Wait()
 	if err == nil {
-		return hlc.Timestamp{},
-			errors.AssertionFailedf("feed exited with no error and no scan boundary")
+		return errors.AssertionFailedf("feed exited with no error and no scan boundary")
 	} else if tErr := (*errTableEventReached)(nil); errors.As(err, &tErr) {
 		// TODO(ajwerner): iterate the spans and add a Resolved timestamp.
 		// We'll need to do this to ensure that a resolved timestamp propagates
 		// when we're trying to exit.
-		return tErr.Timestamp().Prev(), nil
+		return nil
 	} else if tErr := (*errEndTimeReached)(nil); errors.As(err, &tErr) {
-		return tErr.endTime.Prev(), err
+		return err
 	} else if kvcoord.IsSendError(err) {
 		// During node shutdown it is possible for all outgoing transports used by
 		// the kvfeed to expire, producing a SendError that the node is still able
 		// to propagate to the frontier. This has been known to happen during
 		// cluster upgrades. This scenario should not fail the changefeed.
-		err = changefeedbase.MarkRetryableError(err)
-		return hlc.Timestamp{}, err
+		return changefeedbase.MarkRetryableError(err)
 	} else {
-		return hlc.Timestamp{}, err
+		return err
 	}
 }
 
@@ -484,21 +521,10 @@ func copyFromSourceToDestUntilTableEvent(
 	ctx context.Context,
 	dest kvevent.Writer,
 	source kvevent.Reader,
-	cfg physicalConfig,
+	frontier *span.Frontier,
 	tables schemafeed.SchemaFeed,
 	endTime hlc.Timestamp,
 ) error {
-	// Maintain a local spanfrontier to tell when all the component rangefeeds
-	// being watched have reached the Scan boundary.
-	frontier, err := span.MakeFrontier(cfg.Spans...)
-	if err != nil {
-		return err
-	}
-	for _, span := range cfg.Spans {
-		if _, err := frontier.Forward(span, cfg.Timestamp); err != nil {
-			return err
-		}
-	}
 	var (
 		scanBoundary         errBoundaryReached
 		checkForScanBoundary = func(ts hlc.Timestamp) error {

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/schemafeed"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/schemafeed/schematestutils"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -108,8 +109,8 @@ func TestKVFeed(t *testing.T) {
 		bufferFactory := func() kvevent.Buffer {
 			return kvevent.NewMemBuffer(mm.MakeBoundAccount(), &st.SV, &metrics)
 		}
-		scans := make(chan physicalConfig)
-		sf := scannerFunc(func(ctx context.Context, sink kvevent.Writer, cfg physicalConfig) error {
+		scans := make(chan scanConfig)
+		sf := scannerFunc(func(ctx context.Context, sink kvevent.Writer, cfg scanConfig) error {
 			select {
 			case scans <- cfg:
 				return nil
@@ -119,7 +120,7 @@ func TestKVFeed(t *testing.T) {
 		})
 		ref := rawEventFeed(tc.events)
 		tf := newRawTableFeed(tc.descs, tc.initialHighWater)
-		f := newKVFeed(buf, tc.spans, tc.checkpoint,
+		f := newKVFeed(buf, tc.spans, tc.checkpoint, hlc.Timestamp{},
 			tc.schemaChangeEvents, tc.schemaChangePolicy,
 			tc.needsInitialScan, tc.withDiff,
 			tc.initialHighWater, tc.endTime,
@@ -265,7 +266,7 @@ func TestKVFeed(t *testing.T) {
 				tableSpan(42),
 			},
 			events: []roachpb.RangeFeedEvent{
-				kvEvent(42, "a", "b", ts(3)),
+				kvEvent(42, "a", "b", ts(3).Next()),
 				checkpointEvent(tableSpan(42), ts(4)),
 				kvEvent(42, "a", "b", ts(5)),
 				checkpointEvent(tableSpan(42), ts(6)),
@@ -312,9 +313,9 @@ func TestKVFeed(t *testing.T) {
 	}
 }
 
-type scannerFunc func(ctx context.Context, sink kvevent.Writer, cfg physicalConfig) error
+type scannerFunc func(ctx context.Context, sink kvevent.Writer, cfg scanConfig) error
 
-func (s scannerFunc) Scan(ctx context.Context, sink kvevent.Writer, cfg physicalConfig) error {
+func (s scannerFunc) Scan(ctx context.Context, sink kvevent.Writer, cfg scanConfig) error {
 	return s(ctx, sink, cfg)
 }
 
@@ -388,18 +389,24 @@ type rawEventFeed []roachpb.RangeFeedEvent
 
 func (f rawEventFeed) run(
 	ctx context.Context,
-	spans []roachpb.Span,
-	startFrom hlc.Timestamp,
+	spans []kvcoord.SpanTimePair,
 	withDiff bool,
 	eventC chan<- *roachpb.RangeFeedEvent,
 ) error {
+	var startFrom hlc.Timestamp
+	for _, s := range spans {
+		if startFrom.IsEmpty() || s.TS.Less(startFrom) {
+			startFrom = s.TS
+		}
+	}
+
 	// We can't use binary search because the errors don't have timestamps.
 	// Instead we just search for the first event which comes after the start time.
 	var i int
 	for i = range f {
 		ev := f[i]
-		if ev.Val != nil && startFrom.Less(ev.Val.Value.Timestamp) ||
-			ev.Checkpoint != nil && startFrom.Less(ev.Checkpoint.ResolvedTS) {
+		if ev.Val != nil && startFrom.LessEq(ev.Val.Value.Timestamp) ||
+			ev.Checkpoint != nil && startFrom.LessEq(ev.Checkpoint.ResolvedTS) {
 			break
 		}
 

--- a/pkg/ccl/changefeedccl/kvfeed/scanner.go
+++ b/pkg/ccl/changefeedccl/kvfeed/scanner.go
@@ -33,10 +33,17 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+type scanConfig struct {
+	Spans     []roachpb.Span
+	Timestamp hlc.Timestamp
+	WithDiff  bool
+	Knobs     TestingKnobs
+}
+
 type kvScanner interface {
 	// Scan will scan all of the KVs in the spans specified by the physical config
 	// at the specified timestamp and write them to the buffer.
-	Scan(ctx context.Context, sink kvevent.Writer, cfg physicalConfig) error
+	Scan(ctx context.Context, sink kvevent.Writer, cfg scanConfig) error
 }
 
 type scanRequestScanner struct {
@@ -48,9 +55,7 @@ type scanRequestScanner struct {
 
 var _ kvScanner = (*scanRequestScanner)(nil)
 
-func (p *scanRequestScanner) Scan(
-	ctx context.Context, sink kvevent.Writer, cfg physicalConfig,
-) error {
+func (p *scanRequestScanner) Scan(ctx context.Context, sink kvevent.Writer, cfg scanConfig) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/pkg/ccl/changefeedccl/kvfeed/scanner_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/scanner_test.go
@@ -66,7 +66,7 @@ INSERT INTO t VALUES (1), (2), (3);
 	span := tableSpan(uint32(descr.GetID()))
 
 	exportTime := kvdb.Clock().Now()
-	cfg := physicalConfig{
+	cfg := scanConfig{
 		Spans:     []roachpb.Span{span},
 		Timestamp: exportTime,
 		Knobs: TestingKnobs{

--- a/pkg/ccl/changefeedccl/kvfeed/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/kvfeed/testing_knobs.go
@@ -10,6 +10,7 @@ package kvfeed
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 )
 
@@ -17,7 +18,14 @@ import (
 type TestingKnobs struct {
 	// BeforeScanRequest is a callback invoked before issuing Scan request.
 	BeforeScanRequest func(b *kv.Batch) error
-	OnRangeFeedValue  func(kv roachpb.KeyValue) error
+	// OnRangeFeedValue invoked when rangefeed receives a value.
+	OnRangeFeedValue func(kv roachpb.KeyValue) error
+	// ShouldSkipCheckpoint invoked when rangefed receives a checkpoint.
+	// Returns true if checkpoint should be skipped.
+	ShouldSkipCheckpoint func(*roachpb.RangeFeedCheckpoint) bool
+	// OnRangeFeedStart invoked when rangefeed starts.  It is given
+	// the list of SpanTimePairs.
+	OnRangeFeedStart func(spans []kvcoord.SpanTimePair)
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
+++ b/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
@@ -23,12 +23,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
-	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,20 +47,6 @@ func (d *fakeResumer) Resume(ctx context.Context, execCtx interface{}) error {
 
 func (d *fakeResumer) OnFailOrCancel(ctx context.Context, _ interface{}) error {
 	return nil
-}
-
-func waitForJobStatus(
-	runner *sqlutils.SQLRunner, t *testing.T, id jobspb.JobID, targetStatus string,
-) {
-	testutils.SucceedsSoon(t, func() error {
-		var jobStatus string
-		query := `SELECT status FROM [SHOW CHANGEFEED JOB $1]`
-		runner.QueryRow(t, query, id).Scan(&jobStatus)
-		if targetStatus != jobStatus {
-			return errors.Errorf("Expected status:%s but found status:%s", targetStatus, jobStatus)
-		}
-		return nil
-	})
 }
 
 func TestShowChangefeedJobsBasic(t *testing.T) {

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -818,13 +818,14 @@ message ResolvedSpans {
 message ChangefeedProgress {
   reserved 1;
 
-  // Checkpoint describes changefeed checkpoint.
-  // Checkpoints are needed when performing certain operations, such as backfill.
-  // When changefeed restarts from previous high water mark timestamp, all
-  // spans in checkpoint fill be filtered out during initial scan.
-  // That is: this checkpoint describes spans that have already advanced to the high water mark.
+  // Checkpoint describes a list of spans that the changefeed has progressed to
+  // at or above the specified timestamp.  This is used for situations where
+  // some spans are significantly behind the rest, such as during backfills or
+  // if specific spans are having issues progressing.  On restart, the
+  // changefeed will forward the specified spans to the specified timestamp.
   message Checkpoint {
     repeated roachpb.Span spans = 1 [(gogoproto.nullable) = false];
+    util.hlc.Timestamp timestamp = 2 [(gogoproto.nullable) = false];
   }
 
   reserved 2;

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -5531,7 +5531,7 @@ CREATE TABLE crdb_internal.active_range_feeds (
 				return addRow(
 					tree.NewDInt(tree.DInt(rfCtx.ID)),
 					tree.NewDString(rfCtx.CtxTags),
-					tree.NewDString(rfCtx.StartFrom.AsOfSystemTime()),
+					tree.NewDString(rf.StartTS.AsOfSystemTime()),
 					tree.MakeDBool(tree.DBool(rfCtx.WithDiff)),
 					tree.NewDInt(tree.DInt(rf.NodeID)),
 					tree.NewDInt(tree.DInt(rf.RangeID)),

--- a/pkg/sql/execinfrapb/processors_changefeeds.proto
+++ b/pkg/sql/execinfrapb/processors_changefeeds.proto
@@ -35,9 +35,8 @@ message ChangeAggregatorSpec {
 
   // Checkpoint enables change aggregators to resume faster on restart.
   message Checkpoint {
-    // The checkpoint is currently applicable only to the spans which have
-    // already been backfilled.
     repeated roachpb.Span spans = 1 [(gogoproto.nullable) = false];
+    optional util.hlc.Timestamp timestamp = 2 [(gogoproto.nullable) = false];
   }
 
   // Change aggregator checkpoint

--- a/pkg/util/span/frontier.go
+++ b/pkg/util/span/frontier.go
@@ -116,7 +116,14 @@ func makeSpan(r interval.Range) (res roachpb.Span) {
 }
 
 // MakeFrontier returns a Frontier that tracks the given set of spans.
+// Each span timestamp initialized at 0.
 func MakeFrontier(spans ...roachpb.Span) (*Frontier, error) {
+	return MakeFrontierAt(hlc.Timestamp{}, spans...)
+}
+
+// MakeFrontierAt returns a Frontier that tracks the given set of spans.
+// Each span timestamp initialized at specified start time.
+func MakeFrontierAt(startAt hlc.Timestamp, spans ...roachpb.Span) (*Frontier, error) {
 	f := &Frontier{tree: interval.NewTree(interval.ExclusiveOverlapper)}
 	for _, s := range spans {
 		span := makeSpan(s.AsRange())
@@ -124,7 +131,7 @@ func MakeFrontier(spans ...roachpb.Span) (*Frontier, error) {
 			id:   f.idAlloc,
 			keys: span.AsRange(),
 			span: span,
-			ts:   hlc.Timestamp{},
+			ts:   startAt,
 		}
 		f.idAlloc++
 		if err := f.tree.Insert(e, true /* fast */); err != nil {


### PR DESCRIPTION
A changefeed's main method of persisting progress is through the
high-water mark, the timestamp at which every tracked span has met or
exceeded.

This meant that if some small set of spans were lagging behind the rest
for example due to nodes becoming transiently unavailable and the
changefeed was to be restarted, it would consider every span to be
at that lagging timestamp and begin re-emitting the other spans. This
would be a pain point for significantly high QPS changefeeds where
restarting even 20 minutes into the past would result in millions of
duplicated events being sent.

In addition, when changefeed starts with the cursor, the changefeeed
performs a catchup scan.  Those catchup scans could be expensive
if the cursor sufficiently back in the past.  Since KV server
limits the number of concurrent catchup scans, some spans will complete
their catchup scan and beging emitting regular (rangefeed) events, while
others would still be waiting to perform catchup scan.  Any transient
error at this time would result in a restart -- and the checkpoint
for the spans that were able to begin rangefeed is important since
it allows changefeed to make forward progress.

This change extends the current per-span checkpointing used in backfills
to also encompass the situation when the high-water mark is sufficiently
lagging behind the latest edge of the frontier.  Once the high-water
mark's delay has exceeded the value of the
frontier_highwater_lag_checkpoint_threshold cluster setting, checkpoints
will be stored at the same frontier_checkpoint_frequency as backfills,
with both a number of spans as well as the minimum timestamp they have
advanced to.  On changefeed resumption, the frontier will advance these
spans to that timestamp.

Fixes #77693 

Release note (performance improvement): per-span checkpointing added to
cases when the high-water mark lags excessively behind the leading edge
of the frontier in order to avoid re-emitting the majority of spans due
to a small minority that is experiencing issues progressing.

Release Justification: Important fix to enable changefeed to operate on
very large tables when performing large catchup scan.