### PR TITLE
ui: fix zone config change event details

### DIFF
--- a/pkg/ui/workspaces/db-console/src/util/events.ts
+++ b/pkg/ui/workspaces/db-console/src/util/events.ts
@@ -124,7 +124,12 @@ export function getEventDescription(e: Event$Properties): string {
       }
       return `Cluster Setting Changed: User ${info.User} changed ${info.SettingName}`;
     case eventTypes.SET_ZONE_CONFIG:
-      return `Zone Config Changed: User ${info.User} set the zone config for ${info.Target} to ${info.Config}`;
+      if (info.Options && info.Options.length > 0) {
+        return `Zone Config Changed: User ${
+          info.User
+        } set the zone config for ${info.Target} to ${info.Options.join(", ")}`;
+      }
+      return `Zone Config Changed: User ${info.User} set the zone config for ${info.Target}`;
     case eventTypes.REMOVE_ZONE_CONFIG:
       return `Zone Config Removed: User ${info.User} removed the zone config for ${info.Target}`;
     case eventTypes.CREATE_STATISTICS:
@@ -213,7 +218,6 @@ export function getEventDescription(e: Event$Properties): string {
 // and the `info` field of the `server.serverpb.EventsResponse.Event` proto.
 export interface EventInfo {
   CascadeDroppedViews?: string[];
-  Config?: string;
   DatabaseName?: string;
   DescriptorType?: string;
   DescriptorName?: string;


### PR DESCRIPTION

In the `system.eventlog` table, the `info` blob for a `set_zone_config` event looks like this:
```
{
  "Timestamp": 1647274502768414000,
  "EventType": "set_zone_config",
  "Statement": "ALTER RANGE default CONFIGURE ZONE USING num_replicas = 5",
  "Tag": "CONFIGURE ZONE",
  "User": "root",
  "ApplicationName": "$ cockroach demo",
  "Target": "RANGE default",
  "Options": [
    "num_replicas = 5"
  ]
}
```

Note the presence of the `Options` value instead of a `Config` value.



Release justification: the changes are very localized, and the changes resolve a bug on master.

Release note (bug fix): A zone config change event now includes the correct details of what was changed instead of incorrectly displaying undefined.


