### PR TITLE
spanconfig: stop generating split points for views

### DIFF
--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/basic
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/basic
@@ -62,12 +62,17 @@ CREATE TABLE db.t1();
 CREATE TABLE db.t2();
 CREATE SCHEMA db.sc;
 CREATE TYPE typ AS ENUM();
+CREATE VIEW v AS SELECT 1;
+CREATE SEQUENCE db.seq;
+CREATE MATERIALIZED VIEW mv AS SELECT 1;
 ----
 
 mutations
 ----
 upsert /Table/10{6-7}                      range default
 upsert /Table/10{7-8}                      range default
+upsert /Table/11{2-3}                      range default
+upsert /Table/11{3-4}                      range default
 
 exec-sql
 ALTER DATABASE db CONFIGURE ZONE USING num_replicas = 7;
@@ -80,6 +85,8 @@ delete /Table/10{6-7}
 upsert /Table/10{6-7}                      num_replicas=7 num_voters=5
 delete /Table/10{7-8}
 upsert /Table/10{7-8}                      num_replicas=7
+delete /Table/11{2-3}
+upsert /Table/11{2-3}                      num_replicas=7
 
 state offset=47
 ----
@@ -87,6 +94,8 @@ state offset=47
 /Table/5{0-1}                              database system (host)
 /Table/10{6-7}                             num_replicas=7 num_voters=5
 /Table/10{7-8}                             num_replicas=7
+/Table/11{2-3}                             num_replicas=7
+/Table/11{3-4}                             range default
 
 exec-sql
 ALTER DATABASE system CONFIGURE ZONE USING gc.ttlseconds = 100;

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/basic
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/basic
@@ -112,12 +112,19 @@ exec-sql tenant=10
 CREATE DATABASE db;
 CREATE TABLE db.t1();
 CREATE TABLE db.t2();
+CREATE SCHEMA db.sc;
+CREATE TYPE typ AS ENUM();
+CREATE VIEW v AS SELECT 1;
+CREATE SEQUENCE db.seq;
+CREATE MATERIALIZED VIEW mv AS SELECT 1;
 ----
 
 mutations tenant=10
 ----
 upsert /Tenant/10/Table/10{6-7}            range default
 upsert /Tenant/10/Table/10{7-8}            range default
+upsert /Tenant/10/Table/11{2-3}            range default
+upsert /Tenant/10/Table/11{3-4}            range default
 
 state offset=81
 ----
@@ -125,4 +132,6 @@ state offset=81
 /Tenant/10/Table/4{6-7}                    database system (tenant)
 /Tenant/10/Table/10{6-7}                   range default
 /Tenant/10/Table/10{7-8}                   range default
+/Tenant/10/Table/11{2-3}                   range default
+/Tenant/10/Table/11{3-4}                   range default
 /Tenant/11{-"\x00"}                        database system (tenant)

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/full_translate
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/full_translate
@@ -5,7 +5,10 @@ exec-sql
 CREATE DATABASE db;
 CREATE SCHEMA sc;
 CREATE TYPE typ AS ENUM();
+CREATE VIEW v AS SELECT 1;
 CREATE TABLE db.t();
+CREATE SEQUENCE db.seq;
+CREATE MATERIALIZED VIEW mv AS SELECT 1;
 ----
 
 # We expect only the following spans:
@@ -17,7 +20,7 @@ CREATE TABLE db.t();
 # - Timeseries range
 # - All system tables (there should be no entry for pseudo IDs or IDs for which
 #   no table exist)
-# - The user created table
+# - The user created table, sequence, and materialized view.
 full-translate
 ----
 /{Min-System/NodeLiveness}                 ttl_seconds=3600 num_replicas=5
@@ -68,4 +71,6 @@ full-translate
 /Table/4{6-7}                              database system (host)
 /Table/4{7-8}                              database system (host)
 /Table/5{0-1}                              database system (host)
-/Table/109{-/PrefixEnd}                    range default
+/Table/11{0-1}                             range default
+/Table/11{1-2}                             range default
+/Table/11{2-3}                             range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/full_translate
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/full_translate
@@ -5,13 +5,16 @@ exec-sql
 CREATE DATABASE db;
 CREATE SCHEMA sc;
 CREATE TYPE typ AS ENUM();
+CREATE VIEW v AS SELECT 1;
 CREATE TABLE db.t();
+CREATE SEQUENCE db.seq;
+CREATE MATERIALIZED VIEW mv AS SELECT 1;
 ----
 
 # We expect only the following spans:
 # - All system tables (there should be no entry for pseudo IDs or IDs for which
 #   no table exist)
-# - The user created table
+# - The user created table, sequence and materialized view.
 full-translate
 ----
 /Tenant/10{-/Table/4}                      database system (tenant)
@@ -48,7 +51,9 @@ full-translate
 /Tenant/10/Table/4{3-4}                    database system (tenant)
 /Tenant/10/Table/4{4-5}                    database system (tenant)
 /Tenant/10/Table/4{6-7}                    database system (tenant)
-/Tenant/10/Table/109{-/PrefixEnd}          range default
+/Tenant/10/Table/11{0-1}                   range default
+/Tenant/10/Table/11{1-2}                   range default
+/Tenant/10/Table/11{2-3}                   range default
 
 # We should expect the same for RANGE DEFAULT.
 translate named-zone=default
@@ -87,4 +92,6 @@ translate named-zone=default
 /Tenant/10/Table/4{3-4}                    database system (tenant)
 /Tenant/10/Table/4{4-5}                    database system (tenant)
 /Tenant/10/Table/4{6-7}                    database system (tenant)
-/Tenant/10/Table/109{-/PrefixEnd}          range default
+/Tenant/10/Table/11{0-1}                   range default
+/Tenant/10/Table/11{1-2}                   range default
+/Tenant/10/Table/11{2-3}                   range default


### PR DESCRIPTION
The range corresponding to a view's descriptor ID contains no data,
and as such, should not be treated as a split point.

Fixes #77744

Release justification: bug fixes and low-risk updates to new functionality
Release note: None