### PR TITLE
kv,bulk: move metamorphic constants out of if statements

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -53,6 +53,8 @@ import (
 // to durable storage.
 var BackupCheckpointInterval = time.Minute
 
+var forceReadBackupManifest = util.ConstantWithMetamorphicTestBool("backup-read-manifest", false)
+
 func countRows(raw roachpb.BulkOpSummary, pkIDs map[uint64]bool) roachpb.RowCount {
 	res := roachpb.RowCount{DataSize: raw.DataSize}
 	for id, count := range raw.EntryCounts {
@@ -499,7 +501,7 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 		}
 	}()
 
-	if backupManifest == nil || util.ConstantWithMetamorphicTestBool("backup-read-manifest", false) {
+	if backupManifest == nil || forceReadBackupManifest {
 		backupManifest, memSize, err = b.readManifestOnResume(ctx, &mem, p.ExecCfg(), defaultStore, details)
 		if err != nil {
 			return err

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -47,6 +47,8 @@ var AddSSTableRewriteConcurrency = settings.RegisterIntSetting(
 	settings.NonNegativeInt,
 )
 
+var forceRewrite = util.ConstantWithMetamorphicTestBool("addsst-rewrite-forced", false)
+
 // EvalAddSSTable evaluates an AddSSTable command. For details, see doc comment
 // on AddSSTableRequest.
 func EvalAddSSTable(
@@ -77,8 +79,7 @@ func EvalAddSSTable(
 	// request timestamp. This ensures the writes comply with the timestamp cache
 	// and closed timestamp, i.e. by not writing to timestamps that have already
 	// been observed or closed.
-	if sstToReqTS.IsSet() && (h.Timestamp != sstToReqTS ||
-		util.ConstantWithMetamorphicTestBool("addsst-rewrite-forced", false)) {
+	if sstToReqTS.IsSet() && (h.Timestamp != sstToReqTS || forceRewrite) {
 		st := cArgs.EvalCtx.ClusterSettings()
 		// TODO(dt): use a quotapool.
 		conc := int(AddSSTableRewriteConcurrency.Get(&cArgs.EvalCtx.ClusterSettings().SV))


### PR DESCRIPTION
As far as I can tell, these are the only calls to the metamorphic
constant functions that aren't setting package level variable.

It wasn't clear to me that this was intentional. It may be interesting
to test this switching back and forth during the course of some
execution, in which case we don't want this change.

But, if we are OK with these metamorphic values being constant
throughout a test run, then moving them to package level vars reduces
the log spam they generate.

Release justification: Low risk change to test-centric code.

Release note: None