### PR TITLE
roachtest: update 22.1 version map to v21.2.7

### DIFF
--- a/pkg/cmd/roachtest/tests/predecessor_version.go
+++ b/pkg/cmd/roachtest/tests/predecessor_version.go
@@ -36,7 +36,7 @@ func PredecessorVersion(buildVersion version.Version) (string, error) {
 	// checkpoint option enabled to create the missing store directory
 	// fixture (see runVersionUpgrade).
 	verMap := map[string]string{
-		"22.1": "21.2.6",
+		"22.1": "21.2.7",
 		"21.2": "21.1.12",
 		"21.1": "20.2.12",
 		"20.2": "20.1.16",


### PR DESCRIPTION
Release note: None
Release justification: non-production code change.