### PR TITLE
storageccl: fix nil ctx

### DIFF
--- a/pkg/ccl/storageccl/external_sst_reader.go
+++ b/pkg/ccl/storageccl/external_sst_reader.go
@@ -140,11 +140,12 @@ type sstReader struct {
 // Close implements io.Closer.
 func (r *sstReader) Close() error {
 	r.pos = 0
-	r.ctx = nil
+	var err error
 	if r.body != nil {
-		return r.body.Close(r.ctx)
+		err = r.body.Close(r.ctx)
 	}
-	return nil
+	r.ctx = nil
+	return err
 }
 
 // Stat returns the size of the file.


### PR DESCRIPTION
A recent patch (#76534) made the sstReader nil-out its captured ctx on
Close, on the argument that it'd be erroneous to use that ctx any more.
Unfortunately, it was nil-ing out the ctx too early, while it was still
used inside Close(). This patch fixes it.

Release note: None
Release justification: bug fix to new code