### PR TITLE
dev: `--rewrite` should imply `--ignore-cache`

### DIFF
--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -95,6 +95,9 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 		count         = mustGetFlagInt(cmd, countFlag)
 		vModule       = mustGetFlagString(cmd, vModuleFlag)
 	)
+	if rewrite != "" {
+		ignoreCache = true
+	}
 
 	// Enumerate all tests to run.
 	if len(pkgs) == 0 {

--- a/pkg/cmd/dev/testdata/datadriven/test
+++ b/pkg/cmd/dev/testdata/datadriven/test
@@ -67,7 +67,7 @@ exec
 dev test pkg/cmd/dev -f TestDataDriven/test --rewrite -v
 ----
 bazel info workspace --color=no
-bazel test pkg/cmd/dev:all --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/cmd/dev --test_filter=TestDataDriven/test --test_sharding_strategy=disabled --test_arg -test.v --test_output all
+bazel test pkg/cmd/dev:all --nocache_test_results --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/cmd/dev --test_filter=TestDataDriven/test --test_sharding_strategy=disabled --test_arg -test.v --test_output all
 
 exec
 dev test pkg/server -f=TestSpanStatsResponse -v --count=5 --vmodule=raft=1
@@ -89,4 +89,4 @@ exec
 dev test pkg/ccl/logictestccl -f=TestTenantLogic/3node-tenant/system -v --rewrite
 ----
 bazel info workspace --color=no
-bazel test pkg/ccl/logictestccl:all --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/ccl/logictestccl --sandbox_writable_path=crdb-checkout/pkg/sql/logictest --test_filter=TestTenantLogic/3node-tenant/system --test_sharding_strategy=disabled --test_arg -test.v --test_output all
+bazel test pkg/ccl/logictestccl:all --nocache_test_results --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/ccl/logictestccl --sandbox_writable_path=crdb-checkout/pkg/sql/logictest --test_filter=TestTenantLogic/3node-tenant/system --test_sharding_strategy=disabled --test_arg -test.v --test_output all

--- a/pkg/cmd/dev/testdata/datadriven/testlogic
+++ b/pkg/cmd/dev/testdata/datadriven/testlogic
@@ -1,20 +1,20 @@
 exec
 dev testlogic
 ----
-bazel test --test_env=GOTRACEBACK=all //pkg/sql/logictest:logictest_test --test_filter TestLogic/// --test_output errors
-bazel test --test_env=GOTRACEBACK=all //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic///' --test_output errors
-bazel test --test_env=GOTRACEBACK=all //pkg/sql/opt/exec/execbuilder:execbuilder_test --test_filter TestExecBuild/// --test_output errors
+bazel test --test_env=GOTRACEBACK=all --nocache_test_results //pkg/sql/logictest:logictest_test --test_filter TestLogic/// --test_output errors
+bazel test --test_env=GOTRACEBACK=all --nocache_test_results //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic///' --test_output errors
+bazel test --test_env=GOTRACEBACK=all --nocache_test_results //pkg/sql/opt/exec/execbuilder:execbuilder_test --test_filter TestExecBuild/// --test_output errors
 
 exec
 dev testlogic ccl
 ----
-bazel test --test_env=GOTRACEBACK=all //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic///' --test_output errors
+bazel test --test_env=GOTRACEBACK=all --nocache_test_results //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic///' --test_output errors
 
 exec
 dev testlogic ccl opt
 ----
-bazel test --test_env=GOTRACEBACK=all //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic///' --test_output errors
-bazel test --test_env=GOTRACEBACK=all //pkg/sql/opt/exec/execbuilder:execbuilder_test --test_filter TestExecBuild/// --test_output errors
+bazel test --test_env=GOTRACEBACK=all --nocache_test_results //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic///' --test_output errors
+bazel test --test_env=GOTRACEBACK=all --nocache_test_results //pkg/sql/opt/exec/execbuilder:execbuilder_test --test_filter TestExecBuild/// --test_output errors
 
 exec
 dev testlogic base --ignore-cache 
@@ -24,12 +24,12 @@ bazel test --test_env=GOTRACEBACK=all --nocache_test_results //pkg/sql/logictest
 exec
 dev testlogic base --show-sql
 ----
-bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql //pkg/sql/logictest:logictest_test --test_filter TestLogic/// --test_output errors
+bazel test --test_env=GOTRACEBACK=all --nocache_test_results --test_arg -show-sql //pkg/sql/logictest:logictest_test --test_filter TestLogic/// --test_output errors
 
 exec
 dev testlogic base --files=prepare|fk --subtests=20042 --config=local
 ----
-bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql --test_arg -config --test_arg local //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^prepare|fk$/20042' --test_output errors
+bazel test --test_env=GOTRACEBACK=all --nocache_test_results --test_arg -show-sql --test_arg -config --test_arg local //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^prepare|fk$/20042' --test_output errors
 
 exec
 dev testlogic base --files=auto_span_config_reconciliation --config=local -v --show-logs --timeout=50s --rewrite
@@ -45,17 +45,17 @@ err: cannot combine --stress and --rewrite
 exec
 dev testlogic base --files=auto_span_config_reconciliation --config=local --count 5
 ----
-bazel test --test_env=GOTRACEBACK=all --test_arg -test.count=5 --test_arg -show-sql --test_arg -config --test_arg local //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^auto_span_config_reconciliation$/' --test_output errors
+bazel test --test_env=GOTRACEBACK=all --nocache_test_results --test_arg -test.count=5 --test_arg -show-sql --test_arg -config --test_arg local //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^auto_span_config_reconciliation$/' --test_output errors
 
 exec
 dev testlogic base --files=auto_span_config_reconciliation --stress
 ----
-bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=86400 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' ' //pkg/sql/logictest:logictest_test --test_filter 'TestLogic//^auto_span_config_reconciliation$/' --test_output streamed
+bazel test --test_env=GOTRACEBACK=all --nocache_test_results --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=86400 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' ' //pkg/sql/logictest:logictest_test --test_filter 'TestLogic//^auto_span_config_reconciliation$/' --test_output streamed
 
 exec
 dev testlogic base --files=auto_span_config_reconciliation --stress --timeout 1m --cpus 8
 ----
-bazel test --test_env=GOTRACEBACK=all --local_cpu_resources=8 --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=120 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' -maxtime=1m0s -p=8' //pkg/sql/logictest:logictest_test --test_filter 'TestLogic//^auto_span_config_reconciliation$/' --test_output streamed
+bazel test --test_env=GOTRACEBACK=all --local_cpu_resources=8 --nocache_test_results --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=120 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' -maxtime=1m0s -p=8' //pkg/sql/logictest:logictest_test --test_filter 'TestLogic//^auto_span_config_reconciliation$/' --test_output streamed
 
 exec
 dev testlogic ccl --rewrite --show-logs  -v --files distsql_automatic_stats --config 3node-tenant

--- a/pkg/cmd/dev/testlogic.go
+++ b/pkg/cmd/dev/testlogic.go
@@ -76,6 +76,9 @@ func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 		stressCmdArgs = mustGetFlagString(cmd, stressArgsFlag)
 		testArgs      = mustGetFlagString(cmd, testArgsFlag)
 	)
+	if rewrite == "" {
+		ignoreCache = true
+	}
 
 	validChoices := []string{"base", "ccl", "opt"}
 	if len(choices) == 0 {


### PR DESCRIPTION
If you meant to rewrite again but didn't update any source files, Bazel
can reuse the cached results which is confusing.

Release justification: Non-production code changes
Release note: None