### PR TITLE
util/admission: minor cleanups

### DIFF
--- a/pkg/util/admission/doc.go
+++ b/pkg/util/admission/doc.go
@@ -64,7 +64,7 @@
 //   consisting of (multi-tenant) KV nodes and (single-tenant) SQL nodes.
 //
 // The interfaces involved:
-// -  requester: handles all requests for a particular WorkKind. Implemented by
+// - requester: handles all requests for a particular WorkKind. Implemented by
 //   WorkQueue. The requester implementation is responsible for controlling
 //   the admission order within a WorkKind based on tenant fairness,
 //   importance of work etc.

--- a/pkg/util/admission/granter.go
+++ b/pkg/util/admission/granter.go
@@ -877,7 +877,7 @@ func appendMetricStructsForQueues(ms []metric.Struct, coord *GrantCoordinator) [
 // pebbleMetricsTick is called every adjustmentInterval seconds and passes
 // through to the ioLoadListener, so that it can adjust the plan for future IO
 // token allocations.
-func (coord *GrantCoordinator) pebbleMetricsTick(ctx context.Context, m pebble.Metrics) {
+func (coord *GrantCoordinator) pebbleMetricsTick(ctx context.Context, m *pebble.Metrics) {
 	coord.ioLoadListener.pebbleMetricsTick(ctx, m)
 }
 
@@ -1226,7 +1226,7 @@ func (sgc *StoreGrantCoordinators) SetPebbleMetricsProvider(
 	for _, m := range metrics {
 		gc := sgc.initGrantCoordinator(m.StoreID)
 		sgc.gcMap[m.StoreID] = gc
-		gc.pebbleMetricsTick(startupCtx, *m.Metrics)
+		gc.pebbleMetricsTick(startupCtx, m.Metrics)
 		gc.allocateIOTokensTick()
 	}
 
@@ -1249,7 +1249,7 @@ func (sgc *StoreGrantCoordinators) SetPebbleMetricsProvider(
 					}
 					for _, m := range metrics {
 						if gc, ok := sgc.gcMap[m.StoreID]; ok {
-							gc.pebbleMetricsTick(ctx, *m.Metrics)
+							gc.pebbleMetricsTick(ctx, m.Metrics)
 						} else {
 							log.Warningf(ctx,
 								"seeing metrics for unknown storeID %d", m.StoreID)
@@ -1546,7 +1546,7 @@ const adjustmentInterval = 15
 
 // pebbleMetricsTicks is called every adjustmentInterval seconds, and decides
 // the token allocations until the next call.
-func (io *ioLoadListener) pebbleMetricsTick(ctx context.Context, m pebble.Metrics) {
+func (io *ioLoadListener) pebbleMetricsTick(ctx context.Context, m *pebble.Metrics) {
 	if !io.statsInitialized {
 		io.statsInitialized = true
 		// Initialize cumulative stats.
@@ -1595,7 +1595,7 @@ func (io *ioLoadListener) allocateTokensTick() {
 // many bytes are being moved out of L0 via compactions with the average
 // number of bytes being added to L0 per KV work. We want the former to be
 // (significantly) larger so that L0 returns to a healthy state.
-func (io *ioLoadListener) adjustTokens(ctx context.Context, m pebble.Metrics) {
+func (io *ioLoadListener) adjustTokens(ctx context.Context, m *pebble.Metrics) {
 	io.tokensAllocated = 0
 	// Grab the cumulative stats.
 	admittedCount := io.kvRequester.getAdmittedCount()

--- a/pkg/util/admission/granter.go
+++ b/pkg/util/admission/granter.go
@@ -142,6 +142,13 @@ type granter interface {
 	// 5x and shifted ~2s of latency (at p99) from the scheduler into admission
 	// control (which is desirable since the latter is where we can
 	// differentiate between work).
+	//
+	// TODO(sumeer): the "grant chain" concept is subtle and under-documented.
+	// It's easy to go through most of this package thinking it has something to
+	// do with dependent requests (e.g. intent resolution chains on an end txn).
+	// It would help for a top-level comment on grantChainID or continueGrantChain
+	// to spell out what grant chains are, their purpose, and how they work with
+	// an example.
 	continueGrantChain(grantChainID grantChainID)
 }
 

--- a/pkg/util/admission/granter_test.go
+++ b/pkg/util/admission/granter_test.go
@@ -373,7 +373,7 @@ func TestIOLoadListener(t *testing.T) {
 					ioll.mu.Mutex = &syncutil.Mutex{}
 					ioll.mu.kvGranter = kvGranter
 				}
-				ioll.pebbleMetricsTick(ctx, metrics)
+				ioll.pebbleMetricsTick(ctx, &metrics)
 				// Do the ticks until just before next adjustment.
 				var buf strings.Builder
 				fmt.Fprintf(&buf, "admitted: %d, bytes: %d, added-bytes: %d,\nsmoothed-removed: %d, "+
@@ -419,8 +419,8 @@ func TestIOLoadListenerOverflow(t *testing.T) {
 		Sublevels: 100,
 		NumFiles:  10000,
 	}
-	ioll.pebbleMetricsTick(ctx, m)
-	ioll.pebbleMetricsTick(ctx, m)
+	ioll.pebbleMetricsTick(ctx, &m)
+	ioll.pebbleMetricsTick(ctx, &m)
 	ioll.allocateTokensTick()
 }
 
@@ -458,7 +458,7 @@ func TestBadIOLoadListenerStats(t *testing.T) {
 	ioll.mu.kvGranter = kvGranter
 	for i := 0; i < 100; i++ {
 		randomValues()
-		ioll.pebbleMetricsTick(ctx, m)
+		ioll.pebbleMetricsTick(ctx, &m)
 		for j := 0; j < adjustmentInterval; j++ {
 			ioll.allocateTokensTick()
 			require.LessOrEqual(t, int64(0), ioll.totalTokens)


### PR DESCRIPTION
### pass pebble.Metrics struct by reference

The `pebble.Metrics` struct is 1120 bytes large, so it's a little too large to be passing down a nested call stack by value, even if we only do so once per 15 seconds.

### use ctx.Err() for fast-path cancellation check

`Context.Err` is cheaper than calling `Context.Done` and then polling on the returned channel. `Context.Done` lazily allocates a channel and then writes to an atomic variable. The channel read then incurs a mutex lock.

----

I noticed these while finally doing a deep dive on the admission control implementation. One passing suggestion I'd make is that the "grant chain" concept is subtle and under-documented. I went through most of the package thinking it has something to do with dependent requests (e.g. intent resolution chains on an end txn). It would help for a top-level comment on `grantChainID` (or `continueGrantChain` if we want to keep commentary there) to spell out what grant chains are, their purpose, and how they work with an example.

Release justification: None. Wait for v22.2.