### PR TITLE
roachtest: stabilize ORM tests

### DIFF
--- a/pkg/cmd/roachtest/tests/activerecord.go
+++ b/pkg/cmd/roachtest/tests/activerecord.go
@@ -28,7 +28,7 @@ import (
 var activerecordResultRegex = regexp.MustCompile(`^(?P<test>[^\s]+#[^\s]+) = (?P<timing>\d+\.\d+ s) = (?P<result>.)$`)
 var railsReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)\.?(?P<subpoint>\d*)$`)
 var supportedRailsVersion = "6.1"
-var activerecordAdapterVersion = "v6.1.6"
+var activerecordAdapterVersion = "v6.1.8"
 
 // This test runs activerecord's full test suite against a single cockroach node.
 

--- a/pkg/cmd/roachtest/tests/pgjdbc_blocklist.go
+++ b/pkg/cmd/roachtest/tests/pgjdbc_blocklist.go
@@ -411,7 +411,6 @@ var pgjdbcBlockList22_1 = blocklist{
 	"org.postgresql.test.jdbc2.ResultSetTest.testRowResultPositioning":                                                                                                         "unknown",
 	"org.postgresql.test.jdbc2.ResultSetTest.testgetBadBoolean":                                                                                                                "32552",
 	"org.postgresql.test.jdbc2.SearchPathLookupTest.testSearchPathNormalLookup":                                                                                                "unknown",
-	"org.postgresql.test.jdbc2.ServerCursorTest.testBasicFetch":                                                                                                                "41412",
 	"org.postgresql.test.jdbc2.ServerCursorTest.testBinaryFetch":                                                                                                               "41412",
 	"org.postgresql.test.jdbc2.ServerErrorTest.testCheckConstraint":                                                                                                            "27796",
 	"org.postgresql.test.jdbc2.ServerErrorTest.testColumn":                                                                                                                     "27796",


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/77213
fixes https://github.com/cockroachdb/cockroach/issues/77522

- Add expected pass to PGJDBC.
- Fix dependency issue in activerecord.

Release justification: test only change
Release note: None