### PR TITLE
kvserver: collect metrics for lease transfers during joint config states

### DIFF
--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -138,6 +138,18 @@ var (
 		Measurement: "Replicas",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaLeaseTransfersDuringJointStateSuccesses = metric.Metadata{
+		Name:        "leases.transfers_during_joint_state.success",
+		Help:        "Number of successful lease transfers during joint configurations",
+		Measurement: "Lease Transfer Attempts",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaLeaseTransfersDuringJointStateFailures = metric.Metadata{
+		Name:        "leases.transfers_during_joint_state.failure",
+		Help:        "Number of failed lease transfers during joint configurations",
+		Measurement: "Lease Transfer Attempts",
+		Unit:        metric.Unit_COUNT,
+	}
 
 	// Storage metrics.
 	metaLiveBytes = metric.Metadata{
@@ -1326,12 +1338,14 @@ type StoreMetrics struct {
 	// Lease request metrics for successful and failed lease requests. These
 	// count proposals (i.e. it does not matter how many replicas apply the
 	// lease).
-	LeaseRequestSuccessCount  *metric.Counter
-	LeaseRequestErrorCount    *metric.Counter
-	LeaseTransferSuccessCount *metric.Counter
-	LeaseTransferErrorCount   *metric.Counter
-	LeaseExpirationCount      *metric.Gauge
-	LeaseEpochCount           *metric.Gauge
+	LeaseRequestSuccessCount                *metric.Counter
+	LeaseRequestErrorCount                  *metric.Counter
+	LeaseTransferSuccessCount               *metric.Counter
+	LeaseTransferErrorCount                 *metric.Counter
+	LeaseExpirationCount                    *metric.Gauge
+	LeaseEpochCount                         *metric.Gauge
+	LeaseTransfersDuringJointStateSuccesses *metric.Counter
+	LeaseTransfersDuringJointStateFailures  *metric.Counter
 
 	// Storage metrics.
 	ResolveCommitCount *metric.Counter
@@ -1766,12 +1780,14 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		OverReplicatedRangeCount:  metric.NewGauge(metaOverReplicatedRangeCount),
 
 		// Lease request metrics.
-		LeaseRequestSuccessCount:  metric.NewCounter(metaLeaseRequestSuccessCount),
-		LeaseRequestErrorCount:    metric.NewCounter(metaLeaseRequestErrorCount),
-		LeaseTransferSuccessCount: metric.NewCounter(metaLeaseTransferSuccessCount),
-		LeaseTransferErrorCount:   metric.NewCounter(metaLeaseTransferErrorCount),
-		LeaseExpirationCount:      metric.NewGauge(metaLeaseExpirationCount),
-		LeaseEpochCount:           metric.NewGauge(metaLeaseEpochCount),
+		LeaseRequestSuccessCount:                metric.NewCounter(metaLeaseRequestSuccessCount),
+		LeaseRequestErrorCount:                  metric.NewCounter(metaLeaseRequestErrorCount),
+		LeaseTransferSuccessCount:               metric.NewCounter(metaLeaseTransferSuccessCount),
+		LeaseTransferErrorCount:                 metric.NewCounter(metaLeaseTransferErrorCount),
+		LeaseExpirationCount:                    metric.NewGauge(metaLeaseExpirationCount),
+		LeaseEpochCount:                         metric.NewGauge(metaLeaseEpochCount),
+		LeaseTransfersDuringJointStateSuccesses: metric.NewCounter(metaLeaseTransfersDuringJointStateSuccesses),
+		LeaseTransfersDuringJointStateFailures:  metric.NewCounter(metaLeaseTransfersDuringJointStateFailures),
 
 		// Intent resolution metrics.
 		ResolveCommitCount: metric.NewCounter(metaResolveCommit),

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -1251,15 +1251,18 @@ func (r *Replica) maybeTransferLeaseDuringLeaveJoint(
 		log.VErrEventf(ctx, 5, "%v", err)
 		// Couldn't find a target. Returning nil means we're not exiting the JOINT config, and the
 		// caller will retry. Note that the JOINT config isn't rolled back.
+		r.store.metrics.LeaseTransfersDuringJointStateFailures.Inc(1)
 		return err
 	}
 	log.VEventf(ctx, 5, "current leaseholder %v is being removed through an"+
 		" atomic replication change. Transferring lease to %v", r.String(), target)
 	err := r.store.DB().AdminTransferLease(ctx, r.startKey, target.StoreID)
 	if err != nil {
+		r.store.metrics.LeaseTransfersDuringJointStateFailures.Inc(1)
 		return err
 	}
 	log.VEventf(ctx, 5, "leaseholder transfer to %v complete", target)
+	r.store.metrics.LeaseTransfersDuringJointStateSuccesses.Inc(1)
 	return nil
 }
 

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1315,7 +1315,7 @@ var charts = []sectionDescription{
 				Metrics: []string{"requests.slow.lease"},
 			},
 			{
-				Title: "Succcess Rate",
+				Title: "Success Rate",
 				Metrics: []string{
 					"leases.error",
 					"leases.success",
@@ -1335,6 +1335,13 @@ var charts = []sectionDescription{
 				Metrics: []string{
 					"leases.transfers.error",
 					"leases.transfers.success",
+				},
+			},
+			{
+				Title: "Transfer Success Rate During Joint Configurations",
+				Metrics: []string{
+					"leases.transfers_during_joint_state.success",
+					"leases.transfers_during_joint_state.failure",
 				},
 			},
 		},


### PR DESCRIPTION
This patch adds metrics around lease transfer attempts made when a range is in
a joint configuration.

Release justification: adds observability for new functionality

Release note: none.
