### PR TITLE
ui: fix statement details tests

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/cachedDataReducer.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/cachedDataReducer.spec.ts
@@ -339,7 +339,7 @@ describe("keyed cachedDataReducer", function() {
   });
 });
 
-describe.only("PaginatedCachedDataReducer", function() {
+describe("PaginatedCachedDataReducer", function() {
   class Request implements WithPaginationRequest {
     constructor(
       public request: string,


### PR DESCRIPTION
A few tests under `selectStatement` were failing because
the "fake state" was not setup properly and the tests
were using the default time scale (which meant "now").
This commits adds the timeScale to the fake localStorage
so it can be used on tests.
This commits also removed a `describe.only` that was
stopping all tests to be executed.

Release justification: Non-production facing changes
Release note: None