### PR TITLE
release-21.2: changefeed: fix schema backfill after initial scan checkpoint

### DIFF
--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -343,6 +343,8 @@ func (f *kvFeed) scanIfShould(
 		return err
 	}
 
+	f.checkpoint = nil
+
 	// NB: We don't update the highwater even though we've technically seen all
 	// events for all spans at the previous highwater.Next(). We choose not to
 	// because doing so would be wrong once we only backfill some tables.


### PR DESCRIPTION
Backport 1/1 commits from #77797.

/cc @cockroachdb/release

---

A changefeed that was restarted during a backfill with a checkpoint laid
down would neglect to clear the checkpoint information from aggregator
nodes, causing future backfills triggered by schema changes to reuse the
old checkpoint and skip spans.

This patch clears the kvFeed's checkpoint data upon scan completion

Release justification: low risk bug fix
Release note (bug fix): fix successive schema change backfills from
skipping spans that were checkpointed by an initial backfill that was
restarted
