### PR TITLE
sql: track index merging completion in mvcc-compatible backfiller

### DIFF
--- a/pkg/sql/mvcc_backfiller.go
+++ b/pkg/sql/mvcc_backfiller.go
@@ -135,25 +135,52 @@ func (mp *MergeProgress) Copy() *MergeProgress {
 	return newp
 }
 
+// FlatSpans returns all of the TodoSpans being tracked by this merger
+// as a flat slice.
+func (mp *MergeProgress) FlatSpans() []roachpb.Span {
+	spans := []roachpb.Span{}
+	for _, s := range mp.TodoSpans {
+		spans = append(spans, s...)
+	}
+	return spans
+}
+
 // IndexMergeTracker abstracts the infrastructure to read and write merge
 // progress to job state.
 type IndexMergeTracker struct {
 	mu struct {
 		syncutil.Mutex
 		progress *MergeProgress
+
+		hasOrigNRanges bool
+		origNRanges    int
 	}
 
 	jobMu struct {
 		syncutil.Mutex
 		job *jobs.Job
 	}
+
+	rangeCounter   rangeCounter
+	fractionScaler *multiStageFractionScaler
 }
 
 var _ scexec.BackfillProgressFlusher = (*IndexMergeTracker)(nil)
 
+type rangeCounter func(ctx context.Context, spans []roachpb.Span) (int, error)
+
 // NewIndexMergeTracker creates a new IndexMergeTracker
-func NewIndexMergeTracker(progress *MergeProgress, job *jobs.Job) *IndexMergeTracker {
-	imt := IndexMergeTracker{}
+func NewIndexMergeTracker(
+	progress *MergeProgress,
+	job *jobs.Job,
+	rangeCounter rangeCounter,
+	scaler *multiStageFractionScaler,
+) *IndexMergeTracker {
+	imt := IndexMergeTracker{
+		rangeCounter:   rangeCounter,
+		fractionScaler: scaler,
+	}
+	imt.mu.hasOrigNRanges = false
 	imt.mu.progress = progress.Copy()
 	imt.jobMu.job = job
 	return &imt
@@ -185,14 +212,46 @@ func (imt *IndexMergeTracker) FlushCheckpoint(ctx context.Context) error {
 	return imt.jobMu.job.SetDetails(ctx, nil, details)
 }
 
-// FlushFractionCompleted writes out the fraction completed.
+// FlushFractionCompleted writes out the fraction completed based on the number of total
+// ranges completed.
 func (imt *IndexMergeTracker) FlushFractionCompleted(ctx context.Context) error {
-	// TODO(#76365): The backfiller currently doesn't have a good way to report the
-	// total progress of mutations that occur in multiple stages that
-	// independently report progress. So fraction tracking of the merge will be
-	// unimplemented for now and the progress fraction will report only the
-	// progress of the backfilling stage.
+	imt.mu.Lock()
+	spans := imt.mu.progress.FlatSpans()
+	imt.mu.Unlock()
+
+	rangeCount, err := imt.rangeCounter(ctx, spans)
+	if err != nil {
+		return err
+	}
+
+	orig := imt.maybeSetOrigNRanges(rangeCount)
+	if orig >= rangeCount && orig != 0 {
+		fractionRangesFinished := float32(orig-rangeCount) / float32(orig)
+		frac, err := imt.fractionScaler.fractionCompleteFromStageFraction(stageMerge, fractionRangesFinished)
+		if err != nil {
+			return err
+		}
+
+		imt.jobMu.Lock()
+		defer imt.jobMu.Unlock()
+		if err := imt.jobMu.job.FractionProgressed(ctx, nil,
+			jobs.FractionUpdater(frac)); err != nil {
+			return jobs.SimplifyInvalidStatusError(err)
+		}
+	}
 	return nil
+}
+
+// maybeSetOrigNRanges sets the initial range count, if it wasn't
+// previously set. The updated value of the range count is returned.
+func (imt *IndexMergeTracker) maybeSetOrigNRanges(count int) int {
+	imt.mu.Lock()
+	defer imt.mu.Unlock()
+	if !imt.mu.hasOrigNRanges {
+		imt.mu.hasOrigNRanges = true
+		imt.mu.origNRanges = count
+	}
+	return imt.mu.origNRanges
 }
 
 // UpdateMergeProgress allow the caller to modify the current progress with updateFn.

--- a/pkg/sql/mvcc_backfiller_test.go
+++ b/pkg/sql/mvcc_backfiller_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -159,6 +160,94 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 		}
 	})
 	require.True(t, mergeChunk > 3, fmt.Sprintf("mergeChunk: %d", mergeChunk))
+}
+
+func TestIndexBackfillFractionTracking(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	params, _ := tests.CreateTestServerParams()
+
+	const (
+		rowCount  = 2000
+		chunkSize = rowCount / 10
+	)
+
+	var jobID jobspb.JobID
+	var sqlRunner *sqlutils.SQLRunner
+	var kvDB *kv.DB
+	var tc serverutils.TestClusterInterface
+
+	split := func(tableDesc catalog.TableDescriptor, idx catalog.Index) {
+		numSplits := 25
+		var sps []sql.SplitPoint
+		for i := 0; i < numSplits; i++ {
+			sps = append(sps, sql.SplitPoint{TargetNodeIdx: 0, Vals: []interface{}{((rowCount * 2) / numSplits) * i}})
+		}
+		require.NoError(t, splitIndex(tc, tableDesc, idx, sps))
+	}
+
+	var lastPercentage float32
+	assertFractionBetween := func(op string, min float32, max float32) {
+		var fraction float32
+		sqlRunner.QueryRow(t, "SELECT fraction_completed FROM [SHOW JOBS] WHERE job_id = $1", jobID).Scan(&fraction)
+		t.Logf("fraction during %s: %f", op, fraction)
+		assert.True(t, fraction >= min)
+		assert.True(t, fraction <= max)
+		assert.True(t, fraction >= lastPercentage)
+		lastPercentage = fraction
+	}
+
+	params.Knobs = base.TestingKnobs{
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+			BackfillChunkSize: chunkSize,
+			RunBeforeResume: func(id jobspb.JobID) error {
+				jobID = id
+				tableDesc := desctestutils.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "public", "test")
+				split(tableDesc, tableDesc.GetPrimaryIndex())
+				return nil
+			},
+			RunBeforeTempIndexMerge: func() {
+				for i := rowCount + 1; i < (rowCount*2)+1; i++ {
+					sqlRunner.Exec(t, "INSERT INTO t.test VALUES ($1, $1)", i)
+				}
+				tableDesc := desctestutils.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "public", "test")
+				tempIdx, err := findCorrespondingTemporaryIndex(tableDesc, "new_idx")
+				require.NoError(t, err)
+				split(tableDesc, tempIdx)
+			},
+			AlwaysUpdateIndexBackfillDetails:  true,
+			AlwaysUpdateIndexBackfillProgress: true,
+		},
+		DistSQL: &execinfra.TestingKnobs{
+			BulkAdderFlushesEveryBatch: true,
+			RunAfterBackfillChunk:      func() { assertFractionBetween("backfill", 0.0, 0.60) },
+			IndexBackfillMergerTestingKnobs: &backfill.IndexBackfillMergerTestingKnobs{
+				PushesProgressEveryChunk: true,
+				RunBeforeMergeChunk: func(_ roachpb.Key) error {
+					assertFractionBetween("merge", 0.60, 1.00)
+					return nil
+				},
+			},
+		},
+		StartupMigrationManager: &startupmigrations.MigrationManagerTestingKnobs{
+			DisableBackfillMigrations: true,
+		},
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+	}
+
+	tc = serverutils.StartNewTestCluster(t, 1, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+		ServerArgs:      params,
+	})
+	defer tc.Stopper().Stop(context.Background())
+	kvDB = tc.Server(0).DB()
+	sqlDB := tc.ServerConn(0)
+	sqlRunner = sqlutils.MakeSQLRunner(sqlDB)
+	sqlRunner.Exec(t, `CREATE DATABASE t; CREATE TABLE t.test (k INT PRIMARY KEY, v INT)`)
+	sqlRunner.Exec(t, fmt.Sprintf(`SET CLUSTER SETTING bulkio.index_backfill.batch_size = %d;`, chunkSize))
+	require.NoError(t, sqltestutils.BulkInsertIntoTable(sqlDB, rowCount))
+	sqlRunner.Exec(t, "CREATE INDEX new_idx ON t.test(v)")
 }
 
 // Test index backfill merges are not affected by various operations that run

--- a/pkg/sql/schema_changer_helpers_test.go
+++ b/pkg/sql/schema_changer_helpers_test.go
@@ -31,7 +31,8 @@ func (sc *SchemaChanger) TestingDistIndexBackfill(
 	addedIndexes []descpb.IndexID,
 	filter backfill.MutationFilter,
 ) error {
-	err := sc.distIndexBackfill(ctx, version, targetSpans, addedIndexes, true, filter)
+	s := &multiStageFractionScaler{initial: 0.0, stages: backfillStageFractions}
+	err := sc.distIndexBackfill(ctx, version, targetSpans, addedIndexes, true, filter, s)
 	return err
 }
 


### PR DESCRIPTION
This adds a naive basic fraction completion calculation to the merge
phase of the index backfill. The completion fraction of the backfill
and merge are scaled by an arbitrarily chosen guess at what portion of
the total process they account for.

Release justification: Bug fix for newly added feature.
Release note: None