### PR TITLE
sql/schemachanger: various fix to improve robustness

### DIFF
--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_multiregion
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_multiregion
@@ -22,7 +22,7 @@ begin transaction #1
 ## StatementPhase stage 1 of 1 with 1 MutationType ops
 # end StatementPhase
 # begin PreCommitPhase
-## PreCommitPhase stage 1 of 1 with 15 MutationType ops
+## PreCommitPhase stage 1 of 1 with 12 MutationType ops
 delete object namespace entry {104 106 table_regional_by_row} -> 108
 upsert descriptor #105
    type:
@@ -366,10 +366,7 @@ upsert descriptor #108
      unexposedParentSchemaId: 106
   -  version: "1"
   +  version: "2"
-delete comment for descriptor #108 of type TableCommentType
-delete comment for descriptor #108 of type ColumnCommentType
-delete comment for descriptor #108 of type ColumnCommentType
-delete comment for descriptor #108 of type IndexCommentType
+delete all comments for table descriptors [108]
 create job #1: "schema change job"
   descriptor IDs: [105 107 108]
 # end PreCommitPhase
@@ -738,7 +735,7 @@ begin transaction #1
 ## StatementPhase stage 1 of 1 with 1 MutationType ops
 # end StatementPhase
 # begin PreCommitPhase
-## PreCommitPhase stage 1 of 1 with 10 MutationType ops
+## PreCommitPhase stage 1 of 1 with 8 MutationType ops
 delete object namespace entry {104 106 table_regional_by_table} -> 109
 upsert descriptor #105
    type:
@@ -974,9 +971,7 @@ upsert descriptor #109
      unexposedParentSchemaId: 106
   -  version: "1"
   +  version: "2"
-delete comment for descriptor #109 of type TableCommentType
-delete comment for descriptor #109 of type ColumnCommentType
-delete comment for descriptor #109 of type IndexCommentType
+delete all comments for table descriptors [109]
 create job #1: "schema change job"
   descriptor IDs: [105 109]
 # end PreCommitPhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_multiregion
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_multiregion
@@ -23,12 +23,6 @@ begin transaction #1
 # end StatementPhase
 # begin PreCommitPhase
 ## PreCommitPhase stage 1 of 1 with 15 MutationType ops
-create job #1: "schema change job"
-  descriptor IDs: [105 107 108]
-delete comment for descriptor #108 of type TableCommentType
-delete comment for descriptor #108 of type ColumnCommentType
-delete comment for descriptor #108 of type ColumnCommentType
-delete comment for descriptor #108 of type IndexCommentType
 delete object namespace entry {104 106 table_regional_by_row} -> 108
 upsert descriptor #105
    type:
@@ -372,6 +366,12 @@ upsert descriptor #108
      unexposedParentSchemaId: 106
   -  version: "1"
   +  version: "2"
+delete comment for descriptor #108 of type TableCommentType
+delete comment for descriptor #108 of type ColumnCommentType
+delete comment for descriptor #108 of type ColumnCommentType
+delete comment for descriptor #108 of type IndexCommentType
+create job #1: "schema change job"
+  descriptor IDs: [105 107 108]
 # end PreCommitPhase
 commit transaction #1
 # begin PostCommitPhase
@@ -379,11 +379,6 @@ begin transaction #2
 commit transaction #2
 begin transaction #3
 ## PostCommitNonRevertiblePhase stage 1 of 1 with 8 MutationType ops
-create job #2: "GC for dropping descriptor 108"
-  descriptor IDs: [108]
-write *eventpb.DropTable to event log for descriptor #108: DROP TABLE ‹multi_region_test_db›.‹public›.‹table_regional_by_row›
-update progress of schema change job #1
-set schema change job #1 to non-cancellable
 upsert descriptor #105
    type:
      arrayTypeId: 107
@@ -717,6 +712,11 @@ upsert descriptor #108
      unexposedParentSchemaId: 106
   -  version: "2"
   +  version: "3"
+write *eventpb.DropTable to event log for descriptor #108: DROP TABLE ‹multi_region_test_db›.‹public›.‹table_regional_by_row›
+create job #2: "GC for dropping descriptor 108"
+  descriptor IDs: [108]
+update progress of schema change job #1
+set schema change job #1 to non-cancellable
 commit transaction #3
 # end PostCommitPhase
 
@@ -739,11 +739,6 @@ begin transaction #1
 # end StatementPhase
 # begin PreCommitPhase
 ## PreCommitPhase stage 1 of 1 with 10 MutationType ops
-create job #1: "schema change job"
-  descriptor IDs: [105 109]
-delete comment for descriptor #109 of type TableCommentType
-delete comment for descriptor #109 of type ColumnCommentType
-delete comment for descriptor #109 of type IndexCommentType
 delete object namespace entry {104 106 table_regional_by_table} -> 109
 upsert descriptor #105
    type:
@@ -979,6 +974,11 @@ upsert descriptor #109
      unexposedParentSchemaId: 106
   -  version: "1"
   +  version: "2"
+delete comment for descriptor #109 of type TableCommentType
+delete comment for descriptor #109 of type ColumnCommentType
+delete comment for descriptor #109 of type IndexCommentType
+create job #1: "schema change job"
+  descriptor IDs: [105 109]
 # end PreCommitPhase
 commit transaction #1
 # begin PostCommitPhase
@@ -986,11 +986,6 @@ begin transaction #2
 commit transaction #2
 begin transaction #3
 ## PostCommitNonRevertiblePhase stage 1 of 1 with 6 MutationType ops
-create job #2: "GC for dropping descriptor 109"
-  descriptor IDs: [109]
-write *eventpb.DropTable to event log for descriptor #109: DROP TABLE ‹multi_region_test_db›.‹public›.‹table_regional_by_table› CASCADE
-update progress of schema change job #1
-set schema change job #1 to non-cancellable
 upsert descriptor #105
    type:
      arrayTypeId: 107
@@ -1218,6 +1213,11 @@ upsert descriptor #109
      unexposedParentSchemaId: 106
   -  version: "2"
   +  version: "3"
+write *eventpb.DropTable to event log for descriptor #109: DROP TABLE ‹multi_region_test_db›.‹public›.‹table_regional_by_table› CASCADE
+create job #2: "GC for dropping descriptor 109"
+  descriptor IDs: [109]
+update progress of schema change job #1
+set schema change job #1 to non-cancellable
 commit transaction #3
 # end PostCommitPhase
 
@@ -1232,11 +1232,6 @@ begin transaction #1
 # end StatementPhase
 # begin PreCommitPhase
 ## PreCommitPhase stage 1 of 1 with 18 MutationType ops
-create job #1: "schema change job"
-  descriptor IDs: [104 105 106 107]
-delete comment for descriptor #104 of type DatabaseCommentType
-delete comment for descriptor #106 of type SchemaCommentType
-delete role settings for database on #104
 delete database namespace entry {0 0 multi_region_test_db} -> 104
 delete object namespace entry {104 106 crdb_internal_region} -> 105
 delete schema namespace entry {104 0 public} -> 106
@@ -1667,6 +1662,11 @@ upsert descriptor #107
   -  version: "4"
   +  state: DROP
   +  version: "5"
+delete comment for descriptor #104 of type DatabaseCommentType
+delete comment for descriptor #106 of type SchemaCommentType
+delete role settings for database on #104
+create job #1: "schema change job"
+  descriptor IDs: [104 105 106 107]
 # end PreCommitPhase
 commit transaction #1
 # begin PostCommitPhase
@@ -1674,13 +1674,13 @@ begin transaction #2
 commit transaction #2
 begin transaction #3
 ## PostCommitNonRevertiblePhase stage 1 of 1 with 14 MutationType ops
-write *eventpb.DropDatabase to event log for descriptor #104: DROP DATABASE ‹multi_region_test_db› CASCADE
-update progress of schema change job #1
-set schema change job #1 to non-cancellable
 delete descriptor #104
 delete descriptor #105
 delete descriptor #106
 delete descriptor #107
 deleting zone config for #104
+write *eventpb.DropDatabase to event log for descriptor #104: DROP DATABASE ‹multi_region_test_db› CASCADE
+update progress of schema change job #1
+set schema change job #1 to non-cancellable
 commit transaction #3
 # end PostCommitPhase

--- a/pkg/sql/catalog/descs/txn.go
+++ b/pkg/sql/catalog/descs/txn.go
@@ -176,7 +176,10 @@ func CheckTwoVersionInvariant(
 		return false, err
 	}
 	if count == 0 {
-		return false, nil
+		// This is the last step before committing a transaction which modifies
+		// descriptors. This is a perfect time to refresh the deadline prior to
+		// committing.
+		return false, descsCol.MaybeUpdateDeadline(ctx, txn)
 	}
 
 	// Restart the transaction so that it is able to replay itself at a newer timestamp

--- a/pkg/sql/descmetadata/BUILD.bazel
+++ b/pkg/sql/descmetadata/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/kv",
         "//pkg/security",
         "//pkg/settings",
+        "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/schemachanger/scexec",

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -899,7 +899,7 @@ func (s *TestState) EventLogger() scexec.EventLogger {
 	return s
 }
 
-// UpsertDescriptorComment implements scexec.DescriptorMetaDataUpdater.
+// UpsertDescriptorComment implements scexec.DescriptorMetadataUpdater.
 func (s *TestState) UpsertDescriptorComment(
 	id int64, subID int64, commentType keys.CommentType, comment string,
 ) error {
@@ -908,7 +908,13 @@ func (s *TestState) UpsertDescriptorComment(
 	return nil
 }
 
-// DeleteDescriptorComment implements scexec.DescriptorMetaDataUpdater.
+// DeleteAllCommentsForTables implements scexec.DescriptorMetadataUpdater.
+func (s *TestState) DeleteAllCommentsForTables(ids catalog.DescriptorIDSet) error {
+	s.LogSideEffectf("delete all comments for table descriptors %v", ids.Ordered())
+	return nil
+}
+
+// DeleteDescriptorComment implements scexec.DescriptorMetadataUpdater.
 func (s *TestState) DeleteDescriptorComment(
 	id int64, subID int64, commentType keys.CommentType,
 ) error {
@@ -917,7 +923,7 @@ func (s *TestState) DeleteDescriptorComment(
 	return nil
 }
 
-//UpsertConstraintComment implements scexec.DescriptorMetaDataUpdater.
+//UpsertConstraintComment implements scexec.DescriptorMetadataUpdater.
 func (s *TestState) UpsertConstraintComment(
 	tableID descpb.ID, constraintID descpb.ConstraintID, comment string,
 ) error {
@@ -926,7 +932,7 @@ func (s *TestState) UpsertConstraintComment(
 	return nil
 }
 
-//DeleteConstraintComment implements scexec.DescriptorMetaDataUpdater.
+//DeleteConstraintComment implements scexec.DescriptorMetadataUpdater.
 func (s *TestState) DeleteConstraintComment(
 	tableID descpb.ID, constraintID descpb.ConstraintID,
 ) error {
@@ -935,13 +941,13 @@ func (s *TestState) DeleteConstraintComment(
 	return nil
 }
 
-// DeleteDatabaseRoleSettings implements scexec.DescriptorMetaDataUpdater.
+// DeleteDatabaseRoleSettings implements scexec.DescriptorMetadataUpdater.
 func (s *TestState) DeleteDatabaseRoleSettings(_ context.Context, dbID descpb.ID) error {
 	s.LogSideEffectf("delete role settings for database on #%d", dbID)
 	return nil
 }
 
-// SwapDescriptorSubComment implements scexec.DescriptorMetaDataUpdater.
+// SwapDescriptorSubComment implements scexec.DescriptorMetadataUpdater.
 func (s *TestState) SwapDescriptorSubComment(
 	id int64, oldSubID int64, newSubID int64, commentType keys.CommentType,
 ) error {

--- a/pkg/sql/schemachanger/scexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/dependencies.go
@@ -275,6 +275,10 @@ type DescriptorMetadataUpdater interface {
 	// SwapDescriptorSubComment moves a comment from one sub ID to another.
 	SwapDescriptorSubComment(id int64, oldSubID int64, newSubID int64, commentType keys.CommentType) error
 
+	// DeleteAllCommentsForTables deletes all table-bound comments for the tables
+	// with the specified IDs.
+	DeleteAllCommentsForTables(ids catalog.DescriptorIDSet) error
+
 	// DeleteSchedule deletes the given schedule.
 	DeleteSchedule(ctx context.Context, id int64) error
 }

--- a/pkg/sql/schemachanger/scexec/executor_external_test.go
+++ b/pkg/sql/schemachanger/scexec/executor_external_test.go
@@ -539,6 +539,11 @@ func (noopMetadataUpdater) DeleteDescriptorComment(
 	return nil
 }
 
+// DeleteAllCommentsForTables implements scexec.DescriptorMetadataUpdater.
+func (noopMetadataUpdater) DeleteAllCommentsForTables(ids catalog.DescriptorIDSet) error {
+	return nil
+}
+
 //UpsertConstraintComment implements scexec.DescriptorMetadataUpdater.
 func (noopMetadataUpdater) UpsertConstraintComment(
 	tableID descpb.ID, constraintID descpb.ConstraintID, comment string,

--- a/pkg/sql/schemachanger/scexec/scmutationexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/dependencies.go
@@ -72,6 +72,9 @@ type MutationVisitorStateUpdater interface {
 	// DeleteDescriptor adds a descriptor for deletion.
 	DeleteDescriptor(id descpb.ID)
 
+	// DeleteAllTableComments removes all comments for the table with the given id.
+	DeleteAllTableComments(id descpb.ID)
+
 	// DeleteComment removes comments for a descriptor
 	DeleteComment(id descpb.ID, subID int, commentType keys.CommentType)
 

--- a/pkg/sql/schemachanger/scexec/scmutationexec/drop.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/drop.go
@@ -108,6 +108,11 @@ func (m *visitor) DeleteDescriptor(_ context.Context, op scop.DeleteDescriptor) 
 	return nil
 }
 
+func (m *visitor) RemoveAllTableComments(_ context.Context, op scop.RemoveAllTableComments) error {
+	m.s.DeleteAllTableComments(op.TableID)
+	return nil
+}
+
 func (m *visitor) RemoveTableComment(_ context.Context, op scop.RemoveTableComment) error {
 	m.s.DeleteComment(op.TableID, 0, keys.TableCommentType)
 	return nil

--- a/pkg/sql/schemachanger/scop/mutation.go
+++ b/pkg/sql/schemachanger/scop/mutation.go
@@ -405,6 +405,13 @@ type CreateSchemaChangerJob struct {
 	DescriptorIDs []descpb.ID
 }
 
+// RemoveAllTableComments is used to delete all comments associated with a
+// table when dropping a table.
+type RemoveAllTableComments struct {
+	mutationOp
+	TableID descpb.ID
+}
+
 // RemoveTableComment is used to delete a comment associated with a table.
 type RemoveTableComment struct {
 	mutationOp

--- a/pkg/sql/schemachanger/scop/mutation_visitor_generated.go
+++ b/pkg/sql/schemachanger/scop/mutation_visitor_generated.go
@@ -71,6 +71,7 @@ type MutationVisitor interface {
 	SetJobStateOnDescriptor(context.Context, SetJobStateOnDescriptor) error
 	UpdateSchemaChangerJob(context.Context, UpdateSchemaChangerJob) error
 	CreateSchemaChangerJob(context.Context, CreateSchemaChangerJob) error
+	RemoveAllTableComments(context.Context, RemoveAllTableComments) error
 	RemoveTableComment(context.Context, RemoveTableComment) error
 	RemoveDatabaseComment(context.Context, RemoveDatabaseComment) error
 	RemoveSchemaComment(context.Context, RemoveSchemaComment) error
@@ -324,6 +325,11 @@ func (op UpdateSchemaChangerJob) Visit(ctx context.Context, v MutationVisitor) e
 // Visit is part of the MutationOp interface.
 func (op CreateSchemaChangerJob) Visit(ctx context.Context, v MutationVisitor) error {
 	return v.CreateSchemaChangerJob(ctx, op)
+}
+
+// Visit is part of the MutationOp interface.
+func (op RemoveAllTableComments) Visit(ctx context.Context, v MutationVisitor) error {
+	return v.RemoveAllTableComments(ctx, op)
 }
 
 // Visit is part of the MutationOp interface.

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_sequence.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_sequence.go
@@ -44,6 +44,11 @@ func init() {
 						DescID: this.SequenceID,
 					}
 				}),
+				emit(func(this *scpb.Sequence) scop.Op {
+					return &scop.RemoveAllTableComments{
+						TableID: this.SequenceID,
+					}
+				}),
 			),
 			to(scpb.Status_ABSENT,
 				minPhase(scop.PostCommitPhase),

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_table.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_table.go
@@ -44,6 +44,11 @@ func init() {
 						DescID: this.TableID,
 					}
 				}),
+				emit(func(this *scpb.Table) scop.Op {
+					return &scop.RemoveAllTableComments{
+						TableID: this.TableID,
+					}
+				}),
 			),
 			to(scpb.Status_ABSENT,
 				minPhase(scop.PostCommitPhase),

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_view.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_view.go
@@ -62,6 +62,11 @@ func init() {
 						RelationIDs:          this.UsesRelationIDs,
 					}
 				}),
+				emit(func(this *scpb.View) scop.Op {
+					return &scop.RemoveAllTableComments{
+						TableID: this.ViewID,
+					}
+				}),
 			),
 			to(scpb.Status_ABSENT,
 				minPhase(scop.PostCommitPhase),

--- a/pkg/sql/schemachanger/scplan/internal/rules/testdata/oprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/testdata/oprules
@@ -126,3 +126,18 @@ oprules
     - $dep-node[Type] = '*screl.Node'
     - $dep-node[Target] = $dep-target
     - $dep-target[TargetStatus] = ABSENT
+- name: skip table comment removal ops on descriptor drop
+  from: dep-node
+  query:
+    - $desc[Type] IN ['*scpb.Table', '*scpb.View', '*scpb.Sequence']
+    - $dep[Type] IN ['*scpb.ColumnComment', '*scpb.IndexComment', '*scpb.ConstraintComment', '*scpb.TableComment']
+    - $desc[DescID] = $desc-id
+    - $dep[DescID] = $desc-id
+    - $desc-target[Type] = '*scpb.Target'
+    - $desc-target[Element] = $desc
+    - $desc-target[TargetStatus] = ABSENT
+    - $dep-target[Type] = '*scpb.Target'
+    - $dep-target[Element] = $dep
+    - $dep-node[Type] = '*screl.Node'
+    - $dep-node[Target] = $dep-target
+    - $dep-target[TargetStatus] = ABSENT

--- a/pkg/sql/schemachanger/scplan/testdata/drop_database
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_database
@@ -94,7 +94,7 @@ StatementPhase stage 1 of 1 with 14 MutationType ops
       DescID: 116
     *scop.MarkDescriptorAsDroppedSynthetically
       DescID: 117
-PreCommitPhase stage 1 of 1 with 102 MutationType ops
+PreCommitPhase stage 1 of 1 with 84 MutationType ops
   transitions:
     [[Namespace:{DescID: 104, Name: db1, ReferencedDescID: 0}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 104}, ABSENT], PUBLIC] -> ABSENT
@@ -317,26 +317,16 @@ PreCommitPhase stage 1 of 1 with 102 MutationType ops
         DescriptorID: 107
         Name: sq1
         SchemaID: 105
-    *scop.RemoveTableComment
-      TableID: 107
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 104
         DescriptorID: 110
         Name: t1
         SchemaID: 105
-    *scop.RemoveTableComment
-      TableID: 110
     *scop.RemoveDroppedColumnType
       ColumnID: 1
       TableID: 110
-    *scop.RemoveColumnComment
-      ColumnID: 1
-      TableID: 110
     *scop.RemoveDroppedColumnType
-      ColumnID: 2
-      TableID: 110
-    *scop.RemoveColumnComment
       ColumnID: 2
       TableID: 110
     *scop.RemoveColumnDefaultExpression
@@ -347,38 +337,22 @@ PreCommitPhase stage 1 of 1 with 102 MutationType ops
       BackReferencedTableID: 110
       SequenceIDs:
       - 107
-    *scop.RemoveColumnComment
-      ColumnID: 3
-      TableID: 110
-    *scop.RemoveIndexComment
-      IndexID: 1
-      TableID: 110
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 104
         DescriptorID: 108
         Name: sq1
         SchemaID: 106
-    *scop.RemoveTableComment
-      TableID: 108
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 104
         DescriptorID: 109
         Name: t1
         SchemaID: 106
-    *scop.RemoveTableComment
-      TableID: 109
     *scop.RemoveDroppedColumnType
       ColumnID: 1
       TableID: 109
-    *scop.RemoveColumnComment
-      ColumnID: 1
-      TableID: 109
     *scop.RemoveDroppedColumnType
-      ColumnID: 2
-      TableID: 109
-    *scop.RemoveColumnComment
       ColumnID: 2
       TableID: 109
     *scop.RemoveColumnDefaultExpression
@@ -389,24 +363,13 @@ PreCommitPhase stage 1 of 1 with 102 MutationType ops
       BackReferencedTableID: 109
       SequenceIDs:
       - 108
-    *scop.RemoveColumnComment
-      ColumnID: 3
-      TableID: 109
-    *scop.RemoveIndexComment
-      IndexID: 1
-      TableID: 109
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 104
         DescriptorID: 111
         Name: v1
         SchemaID: 106
-    *scop.RemoveTableComment
-      TableID: 111
     *scop.RemoveDroppedColumnType
-      ColumnID: 1
-      TableID: 111
-    *scop.RemoveColumnComment
       ColumnID: 1
       TableID: 111
     *scop.DrainDescriptorName
@@ -415,18 +378,10 @@ PreCommitPhase stage 1 of 1 with 102 MutationType ops
         DescriptorID: 112
         Name: v2
         SchemaID: 106
-    *scop.RemoveTableComment
-      TableID: 112
     *scop.RemoveDroppedColumnType
       ColumnID: 1
       TableID: 112
-    *scop.RemoveColumnComment
-      ColumnID: 1
-      TableID: 112
     *scop.RemoveDroppedColumnType
-      ColumnID: 2
-      TableID: 112
-    *scop.RemoveColumnComment
       ColumnID: 2
       TableID: 112
     *scop.DrainDescriptorName
@@ -435,18 +390,10 @@ PreCommitPhase stage 1 of 1 with 102 MutationType ops
         DescriptorID: 113
         Name: v3
         SchemaID: 106
-    *scop.RemoveTableComment
-      TableID: 113
     *scop.RemoveDroppedColumnType
       ColumnID: 1
       TableID: 113
-    *scop.RemoveColumnComment
-      ColumnID: 1
-      TableID: 113
     *scop.RemoveDroppedColumnType
-      ColumnID: 2
-      TableID: 113
-    *scop.RemoveColumnComment
       ColumnID: 2
       TableID: 113
     *scop.DrainDescriptorName
@@ -455,18 +402,10 @@ PreCommitPhase stage 1 of 1 with 102 MutationType ops
         DescriptorID: 114
         Name: v4
         SchemaID: 106
-    *scop.RemoveTableComment
-      TableID: 114
     *scop.RemoveDroppedColumnType
       ColumnID: 1
       TableID: 114
-    *scop.RemoveColumnComment
-      ColumnID: 1
-      TableID: 114
     *scop.RemoveDroppedColumnType
-      ColumnID: 2
-      TableID: 114
-    *scop.RemoveColumnComment
       ColumnID: 2
       TableID: 114
     *scop.DrainDescriptorName
@@ -487,24 +426,13 @@ PreCommitPhase stage 1 of 1 with 102 MutationType ops
         DescriptorID: 117
         Name: v5
         SchemaID: 106
-    *scop.RemoveTableComment
-      TableID: 117
     *scop.RemoveDroppedColumnType
-      ColumnID: 1
-      TableID: 117
-    *scop.RemoveColumnComment
       ColumnID: 1
       TableID: 117
     *scop.RemoveDroppedColumnType
       ColumnID: 2
       TableID: 117
-    *scop.RemoveColumnComment
-      ColumnID: 2
-      TableID: 117
     *scop.RemoveDroppedColumnType
-      ColumnID: 3
-      TableID: 117
-    *scop.RemoveColumnComment
       ColumnID: 3
       TableID: 117
     *scop.MarkDescriptorAsDropped
@@ -515,13 +443,19 @@ PreCommitPhase stage 1 of 1 with 102 MutationType ops
       DescID: 106
     *scop.MarkDescriptorAsDropped
       DescID: 107
+    *scop.RemoveAllTableComments
+      TableID: 107
     *scop.MarkDescriptorAsDropped
       DescID: 110
+    *scop.RemoveAllTableComments
+      TableID: 110
     *scop.RemoveDroppedColumnType
       ColumnID: 3
       TableID: 110
     *scop.MarkDescriptorAsDropped
       DescID: 108
+    *scop.RemoveAllTableComments
+      TableID: 108
     *scop.RemoveDroppedColumnType
       ColumnID: 3
       TableID: 109
@@ -532,6 +466,8 @@ PreCommitPhase stage 1 of 1 with 102 MutationType ops
       RelationIDs:
       - 111
       - 112
+    *scop.RemoveAllTableComments
+      TableID: 113
     *scop.MarkDescriptorAsDropped
       DescID: 117
     *scop.RemoveBackReferenceInTypes
@@ -543,12 +479,16 @@ PreCommitPhase stage 1 of 1 with 102 MutationType ops
       BackReferencedViewID: 117
       RelationIDs:
       - 114
+    *scop.RemoveAllTableComments
+      TableID: 117
     *scop.MarkDescriptorAsDropped
       DescID: 114
     *scop.RemoveViewBackReferencesInRelations
       BackReferencedViewID: 114
       RelationIDs:
       - 112
+    *scop.RemoveAllTableComments
+      TableID: 114
     *scop.MarkDescriptorAsDropped
       DescID: 116
     *scop.MarkDescriptorAsDropped
@@ -557,6 +497,8 @@ PreCommitPhase stage 1 of 1 with 102 MutationType ops
       BackReferencedViewID: 112
       RelationIDs:
       - 111
+    *scop.RemoveAllTableComments
+      TableID: 112
     *scop.MarkDescriptorAsDropped
       DescID: 115
     *scop.MarkDescriptorAsDropped
@@ -565,8 +507,12 @@ PreCommitPhase stage 1 of 1 with 102 MutationType ops
       BackReferencedViewID: 111
       RelationIDs:
       - 109
+    *scop.RemoveAllTableComments
+      TableID: 111
     *scop.MarkDescriptorAsDropped
       DescID: 109
+    *scop.RemoveAllTableComments
+      TableID: 109
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
       Initialize: true

--- a/pkg/sql/schemachanger/scplan/testdata/drop_schema
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_schema
@@ -930,7 +930,7 @@ StatementPhase stage 1 of 1 with 10 MutationType ops
       DescID: 112
     *scop.MarkDescriptorAsDroppedSynthetically
       DescID: 113
-PreCommitPhase stage 1 of 1 with 76 MutationType ops
+PreCommitPhase stage 1 of 1 with 62 MutationType ops
   transitions:
     [[Namespace:{DescID: 104, Name: sc1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 104}, ABSENT], PUBLIC] -> ABSENT
@@ -1085,26 +1085,16 @@ PreCommitPhase stage 1 of 1 with 76 MutationType ops
         DescriptorID: 105
         Name: sq1
         SchemaID: 104
-    *scop.RemoveTableComment
-      TableID: 105
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 100
         DescriptorID: 106
         Name: t1
         SchemaID: 104
-    *scop.RemoveTableComment
-      TableID: 106
     *scop.RemoveDroppedColumnType
       ColumnID: 1
       TableID: 106
-    *scop.RemoveColumnComment
-      ColumnID: 1
-      TableID: 106
     *scop.RemoveDroppedColumnType
-      ColumnID: 2
-      TableID: 106
-    *scop.RemoveColumnComment
       ColumnID: 2
       TableID: 106
     *scop.RemoveColumnDefaultExpression
@@ -1115,24 +1105,13 @@ PreCommitPhase stage 1 of 1 with 76 MutationType ops
       BackReferencedTableID: 106
       SequenceIDs:
       - 105
-    *scop.RemoveColumnComment
-      ColumnID: 3
-      TableID: 106
-    *scop.RemoveIndexComment
-      IndexID: 1
-      TableID: 106
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 100
         DescriptorID: 107
         Name: v1
         SchemaID: 104
-    *scop.RemoveTableComment
-      TableID: 107
     *scop.RemoveDroppedColumnType
-      ColumnID: 1
-      TableID: 107
-    *scop.RemoveColumnComment
       ColumnID: 1
       TableID: 107
     *scop.DrainDescriptorName
@@ -1141,18 +1120,10 @@ PreCommitPhase stage 1 of 1 with 76 MutationType ops
         DescriptorID: 108
         Name: v2
         SchemaID: 104
-    *scop.RemoveTableComment
-      TableID: 108
     *scop.RemoveDroppedColumnType
       ColumnID: 1
       TableID: 108
-    *scop.RemoveColumnComment
-      ColumnID: 1
-      TableID: 108
     *scop.RemoveDroppedColumnType
-      ColumnID: 2
-      TableID: 108
-    *scop.RemoveColumnComment
       ColumnID: 2
       TableID: 108
     *scop.DrainDescriptorName
@@ -1161,18 +1132,10 @@ PreCommitPhase stage 1 of 1 with 76 MutationType ops
         DescriptorID: 109
         Name: v3
         SchemaID: 104
-    *scop.RemoveTableComment
-      TableID: 109
     *scop.RemoveDroppedColumnType
       ColumnID: 1
       TableID: 109
-    *scop.RemoveColumnComment
-      ColumnID: 1
-      TableID: 109
     *scop.RemoveDroppedColumnType
-      ColumnID: 2
-      TableID: 109
-    *scop.RemoveColumnComment
       ColumnID: 2
       TableID: 109
     *scop.DrainDescriptorName
@@ -1181,18 +1144,10 @@ PreCommitPhase stage 1 of 1 with 76 MutationType ops
         DescriptorID: 110
         Name: v4
         SchemaID: 104
-    *scop.RemoveTableComment
-      TableID: 110
     *scop.RemoveDroppedColumnType
       ColumnID: 1
       TableID: 110
-    *scop.RemoveColumnComment
-      ColumnID: 1
-      TableID: 110
     *scop.RemoveDroppedColumnType
-      ColumnID: 2
-      TableID: 110
-    *scop.RemoveColumnComment
       ColumnID: 2
       TableID: 110
     *scop.DrainDescriptorName
@@ -1213,30 +1168,21 @@ PreCommitPhase stage 1 of 1 with 76 MutationType ops
         DescriptorID: 113
         Name: v5
         SchemaID: 104
-    *scop.RemoveTableComment
-      TableID: 113
     *scop.RemoveDroppedColumnType
-      ColumnID: 1
-      TableID: 113
-    *scop.RemoveColumnComment
       ColumnID: 1
       TableID: 113
     *scop.RemoveDroppedColumnType
       ColumnID: 2
       TableID: 113
-    *scop.RemoveColumnComment
-      ColumnID: 2
-      TableID: 113
     *scop.RemoveDroppedColumnType
-      ColumnID: 3
-      TableID: 113
-    *scop.RemoveColumnComment
       ColumnID: 3
       TableID: 113
     *scop.MarkDescriptorAsDropped
       DescID: 104
     *scop.MarkDescriptorAsDropped
       DescID: 105
+    *scop.RemoveAllTableComments
+      TableID: 105
     *scop.RemoveDroppedColumnType
       ColumnID: 3
       TableID: 106
@@ -1247,6 +1193,8 @@ PreCommitPhase stage 1 of 1 with 76 MutationType ops
       RelationIDs:
       - 107
       - 108
+    *scop.RemoveAllTableComments
+      TableID: 109
     *scop.MarkDescriptorAsDropped
       DescID: 113
     *scop.RemoveBackReferenceInTypes
@@ -1258,12 +1206,16 @@ PreCommitPhase stage 1 of 1 with 76 MutationType ops
       BackReferencedViewID: 113
       RelationIDs:
       - 110
+    *scop.RemoveAllTableComments
+      TableID: 113
     *scop.MarkDescriptorAsDropped
       DescID: 110
     *scop.RemoveViewBackReferencesInRelations
       BackReferencedViewID: 110
       RelationIDs:
       - 108
+    *scop.RemoveAllTableComments
+      TableID: 110
     *scop.MarkDescriptorAsDropped
       DescID: 112
     *scop.MarkDescriptorAsDropped
@@ -1272,6 +1224,8 @@ PreCommitPhase stage 1 of 1 with 76 MutationType ops
       BackReferencedViewID: 108
       RelationIDs:
       - 107
+    *scop.RemoveAllTableComments
+      TableID: 108
     *scop.MarkDescriptorAsDropped
       DescID: 111
     *scop.MarkDescriptorAsDropped
@@ -1280,8 +1234,12 @@ PreCommitPhase stage 1 of 1 with 76 MutationType ops
       BackReferencedViewID: 107
       RelationIDs:
       - 106
+    *scop.RemoveAllTableComments
+      TableID: 107
     *scop.MarkDescriptorAsDropped
       DescID: 106
+    *scop.RemoveAllTableComments
+      TableID: 106
     *scop.SetJobStateOnDescriptor
       DescriptorID: 100
       Initialize: true

--- a/pkg/sql/schemachanger/scplan/testdata/drop_sequence
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_sequence
@@ -28,10 +28,10 @@ PreCommitPhase stage 1 of 1 with 5 MutationType ops
         DescriptorID: 104
         Name: sq1
         SchemaID: 101
-    *scop.RemoveTableComment
-      TableID: 104
     *scop.MarkDescriptorAsDropped
       DescID: 104
+    *scop.RemoveAllTableComments
+      TableID: 104
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
       Initialize: true
@@ -106,8 +106,6 @@ PreCommitPhase stage 1 of 1 with 11 MutationType ops
         DescriptorID: 104
         Name: sq1
         SchemaID: 101
-    *scop.RemoveTableComment
-      TableID: 104
     *scop.RemoveColumnDefaultExpression
       ColumnID: 2
       TableID: 105
@@ -126,6 +124,8 @@ PreCommitPhase stage 1 of 1 with 11 MutationType ops
       - 104
     *scop.MarkDescriptorAsDropped
       DescID: 104
+    *scop.RemoveAllTableComments
+      TableID: 104
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
       Initialize: true

--- a/pkg/sql/schemachanger/scplan/testdata/drop_table
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_table
@@ -50,7 +50,7 @@ StatementPhase stage 1 of 1 with 3 MutationType ops
       DescID: 108
     *scop.MarkDescriptorAsDroppedSynthetically
       DescID: 109
-PreCommitPhase stage 1 of 1 with 43 MutationType ops
+PreCommitPhase stage 1 of 1 with 33 MutationType ops
   transitions:
     [[Namespace:{DescID: 107, Name: shipments, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 107}, ABSENT], PUBLIC] -> ABSENT
@@ -124,16 +124,8 @@ PreCommitPhase stage 1 of 1 with 43 MutationType ops
         DescriptorID: 107
         Name: shipments
         SchemaID: 101
-    *scop.RemoveTableComment
-      TableID: 107
     *scop.RemoveColumnDefaultExpression
       ColumnID: 1
-      TableID: 107
-    *scop.RemoveColumnComment
-      ColumnID: 1
-      TableID: 107
-    *scop.RemoveColumnComment
-      ColumnID: 2
       TableID: 107
     *scop.RemoveSequenceOwner
       ColumnID: 2
@@ -144,13 +136,7 @@ PreCommitPhase stage 1 of 1 with 43 MutationType ops
     *scop.RemoveDroppedColumnType
       ColumnID: 3
       TableID: 107
-    *scop.RemoveColumnComment
-      ColumnID: 3
-      TableID: 107
     *scop.RemoveDroppedColumnType
-      ColumnID: 4
-      TableID: 107
-    *scop.RemoveColumnComment
       ColumnID: 4
       TableID: 107
     *scop.RemoveColumnDefaultExpression
@@ -161,20 +147,11 @@ PreCommitPhase stage 1 of 1 with 43 MutationType ops
       BackReferencedTableID: 107
       SequenceIDs:
       - 106
-    *scop.RemoveColumnComment
-      ColumnID: 5
-      TableID: 107
-    *scop.RemoveIndexComment
-      IndexID: 1
-      TableID: 107
     *scop.RemoveForeignKeyBackReference
       OriginConstraintID: 2
       OriginTableID: 107
       ReferencedTableID: 104
     *scop.RemoveForeignKeyConstraint
-      ConstraintID: 2
-      TableID: 107
-    *scop.RemoveConstraintComment
       ConstraintID: 2
       TableID: 107
     *scop.RemoveForeignKeyBackReference
@@ -184,35 +161,22 @@ PreCommitPhase stage 1 of 1 with 43 MutationType ops
     *scop.RemoveForeignKeyConstraint
       ConstraintID: 3
       TableID: 107
-    *scop.RemoveConstraintComment
-      ConstraintID: 3
-      TableID: 107
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 100
         DescriptorID: 108
         Name: sq1
         SchemaID: 101
-    *scop.RemoveTableComment
-      TableID: 108
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 100
         DescriptorID: 109
         Name: v1
         SchemaID: 101
-    *scop.RemoveTableComment
-      TableID: 109
     *scop.RemoveDroppedColumnType
       ColumnID: 1
       TableID: 109
-    *scop.RemoveColumnComment
-      ColumnID: 1
-      TableID: 109
     *scop.RemoveDroppedColumnType
-      ColumnID: 2
-      TableID: 109
-    *scop.RemoveColumnComment
       ColumnID: 2
       TableID: 109
     *scop.RemoveDroppedColumnType
@@ -226,14 +190,20 @@ PreCommitPhase stage 1 of 1 with 43 MutationType ops
       TableID: 107
     *scop.MarkDescriptorAsDropped
       DescID: 108
+    *scop.RemoveAllTableComments
+      TableID: 108
     *scop.MarkDescriptorAsDropped
       DescID: 109
     *scop.RemoveViewBackReferencesInRelations
       BackReferencedViewID: 109
       RelationIDs:
       - 107
+    *scop.RemoveAllTableComments
+      TableID: 109
     *scop.MarkDescriptorAsDropped
       DescID: 107
+    *scop.RemoveAllTableComments
+      TableID: 107
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
       Initialize: true
@@ -818,7 +788,7 @@ StatementPhase stage 1 of 1 with 1 MutationType ops
   ops:
     *scop.MarkDescriptorAsDroppedSynthetically
       DescID: 112
-PreCommitPhase stage 1 of 1 with 24 MutationType ops
+PreCommitPhase stage 1 of 1 with 18 MutationType ops
   transitions:
     [[Namespace:{DescID: 112, Name: greeter, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 112}, ABSENT], PUBLIC] -> ABSENT
@@ -860,8 +830,6 @@ PreCommitPhase stage 1 of 1 with 24 MutationType ops
         DescriptorID: 112
         Name: greeter
         SchemaID: 101
-    *scop.RemoveTableComment
-      TableID: 112
     *scop.RemoveColumnDefaultExpression
       ColumnID: 1
       TableID: 112
@@ -870,9 +838,6 @@ PreCommitPhase stage 1 of 1 with 24 MutationType ops
       TypeIDs:
       - 110
       - 111
-    *scop.RemoveColumnComment
-      ColumnID: 1
-      TableID: 112
     *scop.RemoveDroppedColumnType
       ColumnID: 2
       TableID: 112
@@ -881,20 +846,8 @@ PreCommitPhase stage 1 of 1 with 24 MutationType ops
       TypeIDs:
       - 110
       - 111
-    *scop.RemoveColumnComment
-      ColumnID: 2
-      TableID: 112
     *scop.RemoveColumnDefaultExpression
       ColumnID: 3
-      TableID: 112
-    *scop.RemoveColumnComment
-      ColumnID: 3
-      TableID: 112
-    *scop.RemoveIndexComment
-      IndexID: 1
-      TableID: 112
-    *scop.RemoveIndexComment
-      IndexID: 2
       TableID: 112
     *scop.RemoveCheckConstraint
       ConstraintID: 2
@@ -904,11 +857,10 @@ PreCommitPhase stage 1 of 1 with 24 MutationType ops
       TypeIDs:
       - 110
       - 111
-    *scop.RemoveConstraintComment
-      ConstraintID: 2
-      TableID: 112
     *scop.MarkDescriptorAsDropped
       DescID: 112
+    *scop.RemoveAllTableComments
+      TableID: 112
     *scop.RemoveDroppedColumnType
       ColumnID: 1
       TableID: 112

--- a/pkg/sql/schemachanger/scplan/testdata/drop_view
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_view
@@ -15,7 +15,7 @@ StatementPhase stage 1 of 1 with 1 MutationType ops
   ops:
     *scop.MarkDescriptorAsDroppedSynthetically
       DescID: 105
-PreCommitPhase stage 1 of 1 with 9 MutationType ops
+PreCommitPhase stage 1 of 1 with 8 MutationType ops
   transitions:
     [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
@@ -36,12 +36,7 @@ PreCommitPhase stage 1 of 1 with 9 MutationType ops
         DescriptorID: 105
         Name: v1
         SchemaID: 101
-    *scop.RemoveTableComment
-      TableID: 105
     *scop.RemoveDroppedColumnType
-      ColumnID: 1
-      TableID: 105
-    *scop.RemoveColumnComment
       ColumnID: 1
       TableID: 105
     *scop.MarkDescriptorAsDropped
@@ -50,6 +45,8 @@ PreCommitPhase stage 1 of 1 with 9 MutationType ops
       BackReferencedViewID: 105
       RelationIDs:
       - 104
+    *scop.RemoveAllTableComments
+      TableID: 105
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
       Initialize: true
@@ -210,7 +207,7 @@ StatementPhase stage 1 of 1 with 5 MutationType ops
       DescID: 108
     *scop.MarkDescriptorAsDroppedSynthetically
       DescID: 111
-PreCommitPhase stage 1 of 1 with 50 MutationType ops
+PreCommitPhase stage 1 of 1 with 40 MutationType ops
   transitions:
     [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
@@ -299,12 +296,7 @@ PreCommitPhase stage 1 of 1 with 50 MutationType ops
         DescriptorID: 105
         Name: v1
         SchemaID: 101
-    *scop.RemoveTableComment
-      TableID: 105
     *scop.RemoveDroppedColumnType
-      ColumnID: 1
-      TableID: 105
-    *scop.RemoveColumnComment
       ColumnID: 1
       TableID: 105
     *scop.DrainDescriptorName
@@ -313,18 +305,10 @@ PreCommitPhase stage 1 of 1 with 50 MutationType ops
         DescriptorID: 106
         Name: v2
         SchemaID: 101
-    *scop.RemoveTableComment
-      TableID: 106
     *scop.RemoveDroppedColumnType
       ColumnID: 1
       TableID: 106
-    *scop.RemoveColumnComment
-      ColumnID: 1
-      TableID: 106
     *scop.RemoveDroppedColumnType
-      ColumnID: 2
-      TableID: 106
-    *scop.RemoveColumnComment
       ColumnID: 2
       TableID: 106
     *scop.DrainDescriptorName
@@ -333,18 +317,10 @@ PreCommitPhase stage 1 of 1 with 50 MutationType ops
         DescriptorID: 107
         Name: v3
         SchemaID: 101
-    *scop.RemoveTableComment
-      TableID: 107
     *scop.RemoveDroppedColumnType
       ColumnID: 1
       TableID: 107
-    *scop.RemoveColumnComment
-      ColumnID: 1
-      TableID: 107
     *scop.RemoveDroppedColumnType
-      ColumnID: 2
-      TableID: 107
-    *scop.RemoveColumnComment
       ColumnID: 2
       TableID: 107
     *scop.DrainDescriptorName
@@ -353,18 +329,10 @@ PreCommitPhase stage 1 of 1 with 50 MutationType ops
         DescriptorID: 108
         Name: v4
         SchemaID: 101
-    *scop.RemoveTableComment
-      TableID: 108
     *scop.RemoveDroppedColumnType
       ColumnID: 1
       TableID: 108
-    *scop.RemoveColumnComment
-      ColumnID: 1
-      TableID: 108
     *scop.RemoveDroppedColumnType
-      ColumnID: 2
-      TableID: 108
-    *scop.RemoveColumnComment
       ColumnID: 2
       TableID: 108
     *scop.DrainDescriptorName
@@ -373,24 +341,13 @@ PreCommitPhase stage 1 of 1 with 50 MutationType ops
         DescriptorID: 111
         Name: v5
         SchemaID: 101
-    *scop.RemoveTableComment
-      TableID: 111
     *scop.RemoveDroppedColumnType
-      ColumnID: 1
-      TableID: 111
-    *scop.RemoveColumnComment
       ColumnID: 1
       TableID: 111
     *scop.RemoveDroppedColumnType
       ColumnID: 2
       TableID: 111
-    *scop.RemoveColumnComment
-      ColumnID: 2
-      TableID: 111
     *scop.RemoveDroppedColumnType
-      ColumnID: 3
-      TableID: 111
-    *scop.RemoveColumnComment
       ColumnID: 3
       TableID: 111
     *scop.MarkDescriptorAsDropped
@@ -400,6 +357,8 @@ PreCommitPhase stage 1 of 1 with 50 MutationType ops
       RelationIDs:
       - 105
       - 106
+    *scop.RemoveAllTableComments
+      TableID: 107
     *scop.MarkDescriptorAsDropped
       DescID: 111
     *scop.RemoveBackReferenceInTypes
@@ -411,24 +370,32 @@ PreCommitPhase stage 1 of 1 with 50 MutationType ops
       BackReferencedViewID: 111
       RelationIDs:
       - 108
+    *scop.RemoveAllTableComments
+      TableID: 111
     *scop.MarkDescriptorAsDropped
       DescID: 108
     *scop.RemoveViewBackReferencesInRelations
       BackReferencedViewID: 108
       RelationIDs:
       - 106
+    *scop.RemoveAllTableComments
+      TableID: 108
     *scop.MarkDescriptorAsDropped
       DescID: 106
     *scop.RemoveViewBackReferencesInRelations
       BackReferencedViewID: 106
       RelationIDs:
       - 105
+    *scop.RemoveAllTableComments
+      TableID: 106
     *scop.MarkDescriptorAsDropped
       DescID: 105
     *scop.RemoveViewBackReferencesInRelations
       BackReferencedViewID: 105
       RelationIDs:
       - 104
+    *scop.RemoveAllTableComments
+      TableID: 105
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
       Initialize: true

--- a/pkg/sql/schemachanger/scrun/BUILD.bazel
+++ b/pkg/sql/schemachanger/scrun/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/jobs/jobspb",
+        "//pkg/roachpb",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/schemachanger/scexec",
@@ -18,6 +19,7 @@ go_library(
         "//pkg/sql/schemachanger/scpb",
         "//pkg/sql/schemachanger/scplan",
         "//pkg/util/log",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/sql/schemachanger/scrun/scrun.go
+++ b/pkg/sql/schemachanger/scrun/scrun.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
@@ -22,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -132,17 +134,31 @@ func executeStage(
 	p scplan.Plan,
 	stageIdx int,
 	stage scplan.Stage,
-) error {
+) (err error) {
 	if knobs != nil && knobs.BeforeStage != nil {
 		if err := knobs.BeforeStage(p, stageIdx); err != nil {
 			return err
 		}
 	}
 
-	log.Infof(ctx, "executing stage %d/%d in phase %v, %d ops of type %s (rollback=%v)",
+	log.Infof(ctx, "executing stage %d/%d in %v, %d ops of type %s (rollback=%v)",
 		stage.Ordinal, stage.StagesInPhase, stage.Phase, len(stage.Ops()), stage.Ops()[0].Type(), p.InRollback)
+	start := timeutil.Now()
+	defer func() {
+		if log.ExpensiveLogEnabled(ctx, 2) {
+			log.Infof(ctx, "executed stage %d/%d in %v, %d ops of type %s (rollback=%v) took %v: err = %v",
+				stage.Ordinal, stage.StagesInPhase, stage.Phase, len(stage.Ops()), stage.Ops()[0].Type(), p.InRollback,
+				timeutil.Since(start), err)
+		}
+	}()
 	if err := scexec.ExecuteStage(ctx, deps, stage.Ops()); err != nil {
-		return errors.Wrapf(p.DecorateErrorWithPlanDetails(err), "error executing %s", stage.String())
+		// Don't go through the effort to wrap the error if it's a retry or it's a
+		// cancelation.
+		if !errors.HasType(err, (*roachpb.TransactionRetryWithProtoRefreshError)(nil)) &&
+			!errors.Is(err, context.Canceled) {
+			err = p.DecorateErrorWithPlanDetails(err)
+		}
+		return errors.Wrapf(err, "error executing %s", stage.String())
 	}
 	return nil
 }

--- a/pkg/sql/schemachanger/testdata/alter_table_add_column
+++ b/pkg/sql/schemachanger/testdata/alter_table_add_column
@@ -18,9 +18,6 @@ begin transaction #1
 # end StatementPhase
 # begin PreCommitPhase
 ## PreCommitPhase stage 1 of 1 with 7 MutationType ops
-create job #1: "schema change job"
-  descriptor IDs: [106]
-write *eventpb.AlterTable to event log for descriptor #106: ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL DEFAULT ‹42›
 upsert descriptor #106
   ...
      createAsOfTime:
@@ -206,6 +203,9 @@ upsert descriptor #106
      unexposedParentSchemaId: 105
   -  version: "1"
   +  version: "2"
+write *eventpb.AlterTable to event log for descriptor #106: ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL DEFAULT ‹42›
+create job #1: "schema change job"
+  descriptor IDs: [106]
 # end PreCommitPhase
 commit transaction #1
 # begin PostCommitPhase
@@ -213,7 +213,6 @@ begin transaction #2
 commit transaction #2
 begin transaction #3
 ## PostCommitPhase stage 1 of 4 with 4 MutationType ops
-update progress of schema change job #1
 upsert descriptor #106
   ...
        - PUBLIC
@@ -246,6 +245,7 @@ upsert descriptor #106
      unexposedParentSchemaId: 105
   -  version: "2"
   +  version: "3"
+update progress of schema change job #1
 commit transaction #3
 begin transaction #4
 ## PostCommitPhase stage 2 of 4 with 1 BackfillType ops
@@ -257,7 +257,6 @@ validate forward indexes [2] in table #106
 commit transaction #5
 begin transaction #6
 ## PostCommitPhase stage 4 of 4 with 8 MutationType ops
-update progress of schema change job #1
 upsert descriptor #106
   ...
          oid: 20
@@ -364,11 +363,10 @@ upsert descriptor #106
      unexposedParentSchemaId: 105
   -  version: "3"
   +  version: "4"
+update progress of schema change job #1
 commit transaction #6
 begin transaction #7
 ## PostCommitNonRevertiblePhase stage 1 of 2 with 3 MutationType ops
-update progress of schema change job #1
-set schema change job #1 to non-cancellable
 upsert descriptor #106
   ...
        authorization: {}
@@ -389,12 +387,11 @@ upsert descriptor #106
      unexposedParentSchemaId: 105
   -  version: "4"
   +  version: "5"
+update progress of schema change job #1
+set schema change job #1 to non-cancellable
 commit transaction #7
 begin transaction #8
 ## PostCommitNonRevertiblePhase stage 2 of 2 with 4 MutationType ops
-create job #2: "GC for dropping table 106 index 1"
-  descriptor IDs: [106]
-update progress of schema change job #1
 upsert descriptor #106
   ...
      createAsOfTime:
@@ -552,5 +549,8 @@ upsert descriptor #106
      unexposedParentSchemaId: 105
   -  version: "5"
   +  version: "6"
+create job #2: "GC for dropping table 106 index 1"
+  descriptor IDs: [106]
+update progress of schema change job #1
 commit transaction #8
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/drop
+++ b/pkg/sql/schemachanger/testdata/drop
@@ -187,7 +187,7 @@ begin transaction #1
 ## StatementPhase stage 1 of 1 with 1 MutationType ops
 # end StatementPhase
 # begin PreCommitPhase
-## PreCommitPhase stage 1 of 1 with 13 MutationType ops
+## PreCommitPhase stage 1 of 1 with 9 MutationType ops
 delete object namespace entry {104 107 t} -> 108
 upsert descriptor #108
   ...
@@ -506,11 +506,7 @@ upsert descriptor #108
      unexposedParentSchemaId: 107
   -  version: "1"
   +  version: "2"
-delete comment for descriptor #108 of type TableCommentType
-delete comment for descriptor #108 of type ColumnCommentType
-delete comment for descriptor #108 of type ColumnCommentType
-delete comment for descriptor #108 of type ColumnCommentType
-delete comment for descriptor #108 of type IndexCommentType
+delete all comments for table descriptors [108]
 create job #1: "schema change job"
   descriptor IDs: [108]
 # end PreCommitPhase
@@ -1496,7 +1492,7 @@ begin transaction #1
 ## StatementPhase stage 1 of 1 with 15 MutationType ops
 # end StatementPhase
 # begin PreCommitPhase
-## PreCommitPhase stage 1 of 1 with 113 MutationType ops
+## PreCommitPhase stage 1 of 1 with 92 MutationType ops
 delete database namespace entry {0 0 db1} -> 111
 delete schema namespace entry {111 0 public} -> 112
 delete schema namespace entry {111 0 sc1} -> 113
@@ -4233,37 +4229,7 @@ upsert descriptor #125
 delete comment for descriptor #111 of type DatabaseCommentType
 delete comment for descriptor #112 of type SchemaCommentType
 delete comment for descriptor #113 of type SchemaCommentType
-delete comment for descriptor #114 of type TableCommentType
-delete comment for descriptor #117 of type TableCommentType
-delete comment for descriptor #117 of type ColumnCommentType
-delete comment for descriptor #117 of type ColumnCommentType
-delete comment for descriptor #117 of type ColumnCommentType
-delete comment for descriptor #117 of type IndexCommentType
-delete comment for descriptor #118 of type TableCommentType
-delete comment for descriptor #118 of type ColumnCommentType
-delete comment for descriptor #118 of type ColumnCommentType
-delete comment for descriptor #118 of type IndexCommentType
-delete comment for descriptor #115 of type TableCommentType
-delete comment for descriptor #116 of type TableCommentType
-delete comment for descriptor #116 of type ColumnCommentType
-delete comment for descriptor #116 of type ColumnCommentType
-delete comment for descriptor #116 of type ColumnCommentType
-delete comment for descriptor #116 of type IndexCommentType
-delete comment for descriptor #119 of type TableCommentType
-delete comment for descriptor #119 of type ColumnCommentType
-delete comment for descriptor #120 of type TableCommentType
-delete comment for descriptor #120 of type ColumnCommentType
-delete comment for descriptor #120 of type ColumnCommentType
-delete comment for descriptor #121 of type TableCommentType
-delete comment for descriptor #121 of type ColumnCommentType
-delete comment for descriptor #121 of type ColumnCommentType
-delete comment for descriptor #122 of type TableCommentType
-delete comment for descriptor #122 of type ColumnCommentType
-delete comment for descriptor #122 of type ColumnCommentType
-delete comment for descriptor #125 of type TableCommentType
-delete comment for descriptor #125 of type ColumnCommentType
-delete comment for descriptor #125 of type ColumnCommentType
-delete comment for descriptor #125 of type ColumnCommentType
+delete all comments for table descriptors [114 115 116 117 118 119 120 121 122 125]
 delete role settings for database on #111
 create job #1: "schema change job"
   descriptor IDs: [111 112 113 114 115 116 117 118 119 120 121 122 123 124 125]

--- a/pkg/sql/schemachanger/testdata/drop
+++ b/pkg/sql/schemachanger/testdata/drop
@@ -19,9 +19,6 @@ begin transaction #1
 # end StatementPhase
 # begin PreCommitPhase
 ## PreCommitPhase stage 1 of 1 with 7 MutationType ops
-create job #1: "schema change job"
-  descriptor IDs: [104 106]
-delete comment for descriptor #106 of type SchemaCommentType
 delete schema namespace entry {104 0 sc} -> 106
 upsert descriptor #104
    database:
@@ -140,6 +137,9 @@ upsert descriptor #106
   -  version: "1"
   +  state: DROP
   +  version: "2"
+delete comment for descriptor #106 of type SchemaCommentType
+create job #1: "schema change job"
+  descriptor IDs: [104 106]
 # end PreCommitPhase
 commit transaction #1
 # begin PostCommitPhase
@@ -147,9 +147,6 @@ begin transaction #2
 commit transaction #2
 begin transaction #3
 ## PostCommitNonRevertiblePhase stage 1 of 1 with 5 MutationType ops
-write *eventpb.DropSchema to event log for descriptor #106: DROP SCHEMA ‹db›.‹sc›
-update progress of schema change job #1
-set schema change job #1 to non-cancellable
 upsert descriptor #104
    database:
   -  declarativeSchemaChangerState:
@@ -163,6 +160,9 @@ upsert descriptor #104
   -  version: "3"
   +  version: "4"
 delete descriptor #106
+write *eventpb.DropSchema to event log for descriptor #106: DROP SCHEMA ‹db›.‹sc›
+update progress of schema change job #1
+set schema change job #1 to non-cancellable
 commit transaction #3
 # end PostCommitPhase
 
@@ -188,13 +188,6 @@ begin transaction #1
 # end StatementPhase
 # begin PreCommitPhase
 ## PreCommitPhase stage 1 of 1 with 13 MutationType ops
-create job #1: "schema change job"
-  descriptor IDs: [108]
-delete comment for descriptor #108 of type TableCommentType
-delete comment for descriptor #108 of type ColumnCommentType
-delete comment for descriptor #108 of type ColumnCommentType
-delete comment for descriptor #108 of type ColumnCommentType
-delete comment for descriptor #108 of type IndexCommentType
 delete object namespace entry {104 107 t} -> 108
 upsert descriptor #108
   ...
@@ -513,6 +506,13 @@ upsert descriptor #108
      unexposedParentSchemaId: 107
   -  version: "1"
   +  version: "2"
+delete comment for descriptor #108 of type TableCommentType
+delete comment for descriptor #108 of type ColumnCommentType
+delete comment for descriptor #108 of type ColumnCommentType
+delete comment for descriptor #108 of type ColumnCommentType
+delete comment for descriptor #108 of type IndexCommentType
+create job #1: "schema change job"
+  descriptor IDs: [108]
 # end PreCommitPhase
 commit transaction #1
 # begin PostCommitPhase
@@ -520,11 +520,6 @@ begin transaction #2
 commit transaction #2
 begin transaction #3
 ## PostCommitNonRevertiblePhase stage 1 of 1 with 7 MutationType ops
-create job #2: "GC for dropping descriptor 108"
-  descriptor IDs: [108]
-write *eventpb.DropTable to event log for descriptor #108: DROP TABLE ‹db›.‹sc›.‹t›
-update progress of schema change job #1
-set schema change job #1 to non-cancellable
 upsert descriptor #108
   ...
      createAsOfTime:
@@ -839,6 +834,11 @@ upsert descriptor #108
      unexposedParentSchemaId: 107
   -  version: "2"
   +  version: "3"
+write *eventpb.DropTable to event log for descriptor #108: DROP TABLE ‹db›.‹sc›.‹t›
+create job #2: "GC for dropping descriptor 108"
+  descriptor IDs: [108]
+update progress of schema change job #1
+set schema change job #1 to non-cancellable
 commit transaction #3
 # end PostCommitPhase
 
@@ -854,9 +854,6 @@ begin transaction #1
 # end StatementPhase
 # begin PreCommitPhase
 ## PreCommitPhase stage 1 of 1 with 13 MutationType ops
-create job #1: "schema change job"
-  descriptor IDs: [104 107 109 110]
-delete comment for descriptor #107 of type SchemaCommentType
 delete schema namespace entry {104 0 sc} -> 107
 delete object namespace entry {104 107 e} -> 109
 delete object namespace entry {104 107 _e} -> 110
@@ -1184,6 +1181,9 @@ upsert descriptor #110
   -  version: "1"
   +  state: DROP
   +  version: "2"
+delete comment for descriptor #107 of type SchemaCommentType
+create job #1: "schema change job"
+  descriptor IDs: [104 107 109 110]
 # end PreCommitPhase
 commit transaction #1
 # begin PostCommitPhase
@@ -1191,9 +1191,6 @@ begin transaction #2
 commit transaction #2
 begin transaction #3
 ## PostCommitNonRevertiblePhase stage 1 of 1 with 11 MutationType ops
-write *eventpb.DropSchema to event log for descriptor #107: DROP SCHEMA ‹db›.‹sc› CASCADE
-update progress of schema change job #1
-set schema change job #1 to non-cancellable
 upsert descriptor #104
    database:
   -  declarativeSchemaChangerState:
@@ -1209,6 +1206,9 @@ upsert descriptor #104
 delete descriptor #107
 delete descriptor #109
 delete descriptor #110
+write *eventpb.DropSchema to event log for descriptor #107: DROP SCHEMA ‹db›.‹sc› CASCADE
+update progress of schema change job #1
+set schema change job #1 to non-cancellable
 commit transaction #3
 # end PostCommitPhase
 
@@ -1223,11 +1223,6 @@ begin transaction #1
 # end StatementPhase
 # begin PreCommitPhase
 ## PreCommitPhase stage 1 of 1 with 11 MutationType ops
-create job #1: "schema change job"
-  descriptor IDs: [104 105]
-delete comment for descriptor #104 of type DatabaseCommentType
-delete comment for descriptor #105 of type SchemaCommentType
-delete role settings for database on #104
 delete database namespace entry {0 0 db} -> 104
 delete schema namespace entry {104 0 public} -> 105
 upsert descriptor #104
@@ -1438,6 +1433,11 @@ upsert descriptor #105
   -  version: "1"
   +  state: DROP
   +  version: "2"
+delete comment for descriptor #104 of type DatabaseCommentType
+delete comment for descriptor #105 of type SchemaCommentType
+delete role settings for database on #104
+create job #1: "schema change job"
+  descriptor IDs: [104 105]
 # end PreCommitPhase
 commit transaction #1
 # begin PostCommitPhase
@@ -1445,12 +1445,12 @@ begin transaction #2
 commit transaction #2
 begin transaction #3
 ## PostCommitNonRevertiblePhase stage 1 of 1 with 8 MutationType ops
-write *eventpb.DropDatabase to event log for descriptor #104: DROP DATABASE ‹db› CASCADE
-update progress of schema change job #1
-set schema change job #1 to non-cancellable
 delete descriptor #104
 delete descriptor #105
 deleting zone config for #104
+write *eventpb.DropDatabase to event log for descriptor #104: DROP DATABASE ‹db› CASCADE
+update progress of schema change job #1
+set schema change job #1 to non-cancellable
 commit transaction #3
 # end PostCommitPhase
 
@@ -1497,43 +1497,6 @@ begin transaction #1
 # end StatementPhase
 # begin PreCommitPhase
 ## PreCommitPhase stage 1 of 1 with 113 MutationType ops
-create job #1: "schema change job"
-  descriptor IDs: [111 112 113 114 115 116 117 118 119 120 121 122 123 124 125]
-delete comment for descriptor #111 of type DatabaseCommentType
-delete comment for descriptor #112 of type SchemaCommentType
-delete comment for descriptor #113 of type SchemaCommentType
-delete comment for descriptor #114 of type TableCommentType
-delete comment for descriptor #117 of type TableCommentType
-delete comment for descriptor #117 of type ColumnCommentType
-delete comment for descriptor #117 of type ColumnCommentType
-delete comment for descriptor #117 of type ColumnCommentType
-delete comment for descriptor #117 of type IndexCommentType
-delete comment for descriptor #118 of type TableCommentType
-delete comment for descriptor #118 of type ColumnCommentType
-delete comment for descriptor #118 of type ColumnCommentType
-delete comment for descriptor #118 of type IndexCommentType
-delete comment for descriptor #115 of type TableCommentType
-delete comment for descriptor #116 of type TableCommentType
-delete comment for descriptor #116 of type ColumnCommentType
-delete comment for descriptor #116 of type ColumnCommentType
-delete comment for descriptor #116 of type ColumnCommentType
-delete comment for descriptor #116 of type IndexCommentType
-delete comment for descriptor #119 of type TableCommentType
-delete comment for descriptor #119 of type ColumnCommentType
-delete comment for descriptor #120 of type TableCommentType
-delete comment for descriptor #120 of type ColumnCommentType
-delete comment for descriptor #120 of type ColumnCommentType
-delete comment for descriptor #121 of type TableCommentType
-delete comment for descriptor #121 of type ColumnCommentType
-delete comment for descriptor #121 of type ColumnCommentType
-delete comment for descriptor #122 of type TableCommentType
-delete comment for descriptor #122 of type ColumnCommentType
-delete comment for descriptor #122 of type ColumnCommentType
-delete comment for descriptor #125 of type TableCommentType
-delete comment for descriptor #125 of type ColumnCommentType
-delete comment for descriptor #125 of type ColumnCommentType
-delete comment for descriptor #125 of type ColumnCommentType
-delete role settings for database on #111
 delete database namespace entry {0 0 db1} -> 111
 delete schema namespace entry {111 0 public} -> 112
 delete schema namespace entry {111 0 sc1} -> 113
@@ -4267,6 +4230,43 @@ upsert descriptor #125
   -  version: "1"
   +  version: "2"
      viewQuery: (SELECT 'a':::sc1.typ::STRING AS k, n2, n1 FROM db1.sc1.v4)
+delete comment for descriptor #111 of type DatabaseCommentType
+delete comment for descriptor #112 of type SchemaCommentType
+delete comment for descriptor #113 of type SchemaCommentType
+delete comment for descriptor #114 of type TableCommentType
+delete comment for descriptor #117 of type TableCommentType
+delete comment for descriptor #117 of type ColumnCommentType
+delete comment for descriptor #117 of type ColumnCommentType
+delete comment for descriptor #117 of type ColumnCommentType
+delete comment for descriptor #117 of type IndexCommentType
+delete comment for descriptor #118 of type TableCommentType
+delete comment for descriptor #118 of type ColumnCommentType
+delete comment for descriptor #118 of type ColumnCommentType
+delete comment for descriptor #118 of type IndexCommentType
+delete comment for descriptor #115 of type TableCommentType
+delete comment for descriptor #116 of type TableCommentType
+delete comment for descriptor #116 of type ColumnCommentType
+delete comment for descriptor #116 of type ColumnCommentType
+delete comment for descriptor #116 of type ColumnCommentType
+delete comment for descriptor #116 of type IndexCommentType
+delete comment for descriptor #119 of type TableCommentType
+delete comment for descriptor #119 of type ColumnCommentType
+delete comment for descriptor #120 of type TableCommentType
+delete comment for descriptor #120 of type ColumnCommentType
+delete comment for descriptor #120 of type ColumnCommentType
+delete comment for descriptor #121 of type TableCommentType
+delete comment for descriptor #121 of type ColumnCommentType
+delete comment for descriptor #121 of type ColumnCommentType
+delete comment for descriptor #122 of type TableCommentType
+delete comment for descriptor #122 of type ColumnCommentType
+delete comment for descriptor #122 of type ColumnCommentType
+delete comment for descriptor #125 of type TableCommentType
+delete comment for descriptor #125 of type ColumnCommentType
+delete comment for descriptor #125 of type ColumnCommentType
+delete comment for descriptor #125 of type ColumnCommentType
+delete role settings for database on #111
+create job #1: "schema change job"
+  descriptor IDs: [111 112 113 114 115 116 117 118 119 120 121 122 123 124 125]
 # end PreCommitPhase
 commit transaction #1
 # begin PostCommitPhase
@@ -4274,12 +4274,6 @@ begin transaction #2
 commit transaction #2
 begin transaction #3
 ## PostCommitNonRevertiblePhase stage 1 of 1 with 66 MutationType ops
-create job #2: "GC for dropping descriptors 111 114 115 116 117 118 119 120 121 122 125"
-  descriptor IDs: [114 115 119 120 121 122 125 117 118 116]
-write *eventpb.DropDatabase to event log for descriptor #111: DROP DATABASE ‹db1› CASCADE
-update progress of schema change job #1
-set schema change job #1 to non-cancellable
-delete scheduleId: <redacted>
 upsert descriptor #114
   ...
      createAsOfTime:
@@ -6458,5 +6452,11 @@ delete descriptor #112
 delete descriptor #113
 delete descriptor #123
 delete descriptor #124
+write *eventpb.DropDatabase to event log for descriptor #111: DROP DATABASE ‹db1› CASCADE
+delete scheduleId: <redacted>
+create job #2: "GC for dropping descriptors 111 114 115 116 117 118 119 120 121 122 125"
+  descriptor IDs: [114 115 119 120 121 122 125 117 118 116]
+update progress of schema change job #1
+set schema change job #1 to non-cancellable
 commit transaction #3
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/index
+++ b/pkg/sql/schemachanger/testdata/index
@@ -13,8 +13,6 @@ begin transaction #1
 # end StatementPhase
 # begin PreCommitPhase
 ## PreCommitPhase stage 1 of 1 with 3 MutationType ops
-create job #1: "schema change job"
-  descriptor IDs: [104]
 upsert descriptor #104
   ...
      createAsOfTime:
@@ -102,6 +100,8 @@ upsert descriptor #104
      unexposedParentSchemaId: 101
   -  version: "1"
   +  version: "2"
+create job #1: "schema change job"
+  descriptor IDs: [104]
 # end PreCommitPhase
 commit transaction #1
 # begin PostCommitPhase
@@ -109,7 +109,6 @@ begin transaction #2
 commit transaction #2
 begin transaction #3
 ## PostCommitPhase stage 1 of 4 with 3 MutationType ops
-update progress of schema change job #1
 upsert descriptor #104
   ...
        authorization: {}
@@ -130,6 +129,7 @@ upsert descriptor #104
      unexposedParentSchemaId: 101
   -  version: "2"
   +  version: "3"
+update progress of schema change job #1
 commit transaction #3
 begin transaction #4
 ## PostCommitPhase stage 2 of 4 with 1 BackfillType ops
@@ -141,7 +141,6 @@ validate forward indexes [2] in table #104
 commit transaction #5
 begin transaction #6
 ## PostCommitPhase stage 4 of 4 with 4 MutationType ops
-update progress of schema change job #1
 upsert descriptor #104
   ...
      createAsOfTime:
@@ -243,5 +242,6 @@ upsert descriptor #104
      unexposedParentSchemaId: 101
   -  version: "3"
   +  version: "4"
+update progress of schema change job #1
 commit transaction #6
 # end PostCommitPhase


### PR DESCRIPTION
See individual commits. In particular, this change:

* Makes sure we bump the deadline for schema changes before committing and after doing all the pre-commit work.
* Drops all table descriptor comments efficiently when dropping the table descriptor.
* Places locks on descriptors before jobs.

This PR does not solve #77601, but it does avoid some transaction restart cases and it avoids some overhead when they occur. There's another PR inbound which will accelerate some internal data structures and algorithms.  

Touches #77601.

Release justification: bug fixes and low-risk updates to new functionality

Release note: None