### PR TITLE
sql: grouping metadata for stmt details

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -4134,9 +4134,7 @@ StatementDetailsRequest requests the details of a Statement, based on its keys.
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
-| key_data | [cockroach.sql.StatementStatisticsKey](#cockroach.server.serverpb.StatementDetailsResponse-cockroach.sql.StatementStatisticsKey) |  |  | [reserved](#support-status) |
-| formatted_query | [string](#cockroach.server.serverpb.StatementDetailsResponse-string) |  | Formatted query is the return of the key_data.query after prettify_statement. The value from the key_data cannot be replaced by the formatted value, because is used as is for diagnostic bundle. | [reserved](#support-status) |
-| app_names | [string](#cockroach.server.serverpb.StatementDetailsResponse-string) | repeated |  | [reserved](#support-status) |
+| metadata | [cockroach.sql.AggregatedStatementMetadata](#cockroach.server.serverpb.StatementDetailsResponse-cockroach.sql.AggregatedStatementMetadata) |  |  | [reserved](#support-status) |
 | stats | [cockroach.sql.StatementStatistics](#cockroach.server.serverpb.StatementDetailsResponse-cockroach.sql.StatementStatistics) |  |  | [reserved](#support-status) |
 | aggregation_interval | [google.protobuf.Duration](#cockroach.server.serverpb.StatementDetailsResponse-google.protobuf.Duration) |  |  | [reserved](#support-status) |
 
@@ -4151,6 +4149,7 @@ StatementDetailsRequest requests the details of a Statement, based on its keys.
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
+| metadata | [cockroach.sql.AggregatedStatementMetadata](#cockroach.server.serverpb.StatementDetailsResponse-cockroach.sql.AggregatedStatementMetadata) |  |  | [reserved](#support-status) |
 | stats | [cockroach.sql.StatementStatistics](#cockroach.server.serverpb.StatementDetailsResponse-cockroach.sql.StatementStatistics) |  |  | [reserved](#support-status) |
 | aggregation_interval | [google.protobuf.Duration](#cockroach.server.serverpb.StatementDetailsResponse-google.protobuf.Duration) |  |  | [reserved](#support-status) |
 | aggregated_ts | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementDetailsResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
@@ -4166,6 +4165,7 @@ StatementDetailsRequest requests the details of a Statement, based on its keys.
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
+| metadata | [cockroach.sql.AggregatedStatementMetadata](#cockroach.server.serverpb.StatementDetailsResponse-cockroach.sql.AggregatedStatementMetadata) |  |  | [reserved](#support-status) |
 | stats | [cockroach.sql.StatementStatistics](#cockroach.server.serverpb.StatementDetailsResponse-cockroach.sql.StatementStatistics) |  |  | [reserved](#support-status) |
 | aggregation_interval | [google.protobuf.Duration](#cockroach.server.serverpb.StatementDetailsResponse-google.protobuf.Duration) |  |  | [reserved](#support-status) |
 | explain_plan | [string](#cockroach.server.serverpb.StatementDetailsResponse-string) |  |  | [reserved](#support-status) |

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -325,6 +325,8 @@
 </span></td></tr>
 <tr><td><a name="crdb_internal.merge_statement_stats"></a><code>crdb_internal.merge_statement_stats(input: jsonb[]) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Merge an array of roachpb.StatementStatistics into a single JSONB object</p>
 </span></td></tr>
+<tr><td><a name="crdb_internal.merge_stats_metadata"></a><code>crdb_internal.merge_stats_metadata(input: jsonb[]) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Merge an array of StmtStatsMetadata into a single JSONB object</p>
+</span></td></tr>
 <tr><td><a name="crdb_internal.merge_transaction_stats"></a><code>crdb_internal.merge_transaction_stats(input: jsonb[]) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Merge an array of roachpb.TransactionStatistics into a single JSONB object</p>
 </span></td></tr>
 <tr><td><a name="string_to_array"></a><code>string_to_array(str: <a href="string.html">string</a>, delimiter: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>Split a string into components on a delimiter.</p>

--- a/pkg/roachpb/app_stats.proto
+++ b/pkg/roachpb/app_stats.proto
@@ -201,6 +201,24 @@ message StatementStatisticsKey {
      (gogoproto.casttype) = "TransactionFingerprintID"];
 }
 
+message AggregatedStatementMetadata {
+  optional string query = 1 [(gogoproto.nullable) = false];
+  // Formatted query is the return of the key_data.query after prettify_statement.
+  // The query above cannot be replaced by the formatted value, because is used as is for
+  // diagnostic bundle.
+  optional string formatted_query = 2 [(gogoproto.nullable) = false];
+  optional string query_summary = 3 [(gogoproto.nullable) = false];
+  optional string stmt_type = 4 [(gogoproto.nullable) = false];
+  repeated string app_names = 5;
+  repeated string databases = 6;
+  optional bool implicit_txn = 7 [(gogoproto.nullable) = false];
+  optional int64 dist_sql_count = 8 [(gogoproto.nullable) = false, (gogoproto.customname) = "DistSQLCount"];
+  optional int64 failed_count = 9 [(gogoproto.nullable) = false];
+  optional int64 full_scan_count = 10 [(gogoproto.nullable) = false];
+  optional int64 vec_count = 11 [(gogoproto.nullable) = false];
+  optional int64 total_count = 12 [(gogoproto.nullable) = false];
+}
+
 // CollectedStatementStatistics wraps collected timings and metadata for some
 // query's execution.
 message CollectedStatementStatistics {

--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -375,6 +375,24 @@ func getStatementDetails(
 		return nil, serverError(ctx, err)
 	}
 
+	// At this point the counts on statementTotal.metadata have the count for how many times we saw that value
+	// as a row, and not the count of executions for each value.
+	// The values on statementStatisticsPerPlanHash.Metadata.*Count have the correct count,
+	// since the metadata is unique per plan hash.
+	// Update the statementTotal.Metadata.*Count with the counts from statementStatisticsPerPlanHash.keyData.
+	statementTotal.Metadata.DistSQLCount = 0
+	statementTotal.Metadata.FailedCount = 0
+	statementTotal.Metadata.FullScanCount = 0
+	statementTotal.Metadata.VecCount = 0
+	statementTotal.Metadata.TotalCount = 0
+	for _, planStats := range statementStatisticsPerPlanHash {
+		statementTotal.Metadata.DistSQLCount += planStats.Metadata.DistSQLCount
+		statementTotal.Metadata.FailedCount += planStats.Metadata.FailedCount
+		statementTotal.Metadata.FullScanCount += planStats.Metadata.FullScanCount
+		statementTotal.Metadata.VecCount += planStats.Metadata.VecCount
+		statementTotal.Metadata.TotalCount += planStats.Metadata.TotalCount
+	}
+
 	response := &serverpb.StatementDetailsResponse{
 		Statement:                          statementTotal,
 		StatementStatisticsPerAggregatedTs: statementStatisticsPerAggregatedTs,
@@ -443,19 +461,17 @@ func getTotalStatementDetails(
 ) (serverpb.StatementDetailsResponse_CollectedStatementSummary, error) {
 	query := fmt.Sprintf(
 		`SELECT
-				metadata,
+				crdb_internal.merge_stats_metadata(array_agg(metadata)) AS metadata,
 				aggregation_interval,
-				prettify_statement(metadata ->> 'query', %d, %d, %d) as query,
 				array_agg(app_name) as app_names,
 				crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics,
 				max(sampled_plan) as sampled_plan
 		FROM crdb_internal.statement_statistics %s
 		GROUP BY
-				metadata,
 				aggregation_interval
-		LIMIT 1`, tree.ConsoleLineWidth, tree.PrettyAlignAndDeindent, tree.UpperCase, whereClause)
+		LIMIT 1`, whereClause)
 
-	const expectedNumDatums = 6
+	const expectedNumDatums = 5
 	var statement serverpb.StatementDetailsResponse_CollectedStatementSummary
 
 	row, err := ie.QueryRowEx(ctx, "combined-stmts-details-total", nil,
@@ -474,36 +490,51 @@ func getTotalStatementDetails(
 	}
 
 	var statistics roachpb.CollectedStatementStatistics
+	var aggregatedMetadata roachpb.AggregatedStatementMetadata
 	metadataJSON := tree.MustBeDJSON(row[0]).JSON
-	if err = sqlstatsutil.DecodeStmtStatsMetadataJSON(metadataJSON, &statistics); err != nil {
+
+	if err = sqlstatsutil.DecodeAggregatedMetadataJSON(metadataJSON, &aggregatedMetadata); err != nil {
 		return statement, serverError(ctx, err)
 	}
 
 	aggInterval := tree.MustBeDInterval(row[1]).Duration
-	queryPrettify := string(tree.MustBeDString(row[2]))
 
-	apps := tree.MustBeDArray(row[3])
+	apps := tree.MustBeDArray(row[2])
 	var appNames []string
 	for _, s := range apps.Array {
 		appNames = util.CombineUniqueString(appNames, []string{string(tree.MustBeDString(s))})
 	}
+	aggregatedMetadata.AppNames = appNames
 
-	statsJSON := tree.MustBeDJSON(row[4]).JSON
+	statsJSON := tree.MustBeDJSON(row[3]).JSON
 	if err = sqlstatsutil.DecodeStmtStatsStatisticsJSON(statsJSON, &statistics.Stats); err != nil {
 		return statement, serverError(ctx, err)
 	}
 
-	planJSON := tree.MustBeDJSON(row[5]).JSON
+	planJSON := tree.MustBeDJSON(row[4]).JSON
 	plan, err := sqlstatsutil.JSONToExplainTreePlanNode(planJSON)
 	if err != nil {
 		return statement, serverError(ctx, err)
 	}
 	statistics.Stats.SensitiveInfo.MostRecentPlanDescription = *plan
 
+	args = []interface{}{}
+	args = append(args, aggregatedMetadata.Query)
+	query = fmt.Sprintf(
+		`SELECT prettify_statement($1, %d, %d, %d)`,
+		tree.ConsoleLineWidth, tree.PrettyAlignAndDeindent, tree.UpperCase)
+	row, err = ie.QueryRowEx(ctx, "combined-stmts-details-format-query", nil,
+		sessiondata.InternalExecutorOverride{
+			User: security.NodeUserName(),
+		}, query, args...)
+
+	if err != nil {
+		return statement, serverError(ctx, err)
+	}
+	aggregatedMetadata.FormattedQuery = string(tree.MustBeDString(row[0]))
+
 	statement = serverpb.StatementDetailsResponse_CollectedStatementSummary{
-		KeyData:             statistics.Key,
-		FormattedQuery:      queryPrettify,
-		AppNames:            appNames,
+		Metadata:            aggregatedMetadata,
 		AggregationInterval: time.Duration(aggInterval.Nanos()),
 		Stats:               statistics.Stats,
 	}
@@ -524,14 +555,13 @@ func getStatementDetailsPerAggregatedTs(
 	query := fmt.Sprintf(
 		`SELECT
 				aggregated_ts,
-				metadata,
+				crdb_internal.merge_stats_metadata(array_agg(metadata)) AS metadata,
 				crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics,
 				max(sampled_plan) as sampled_plan,
 				aggregation_interval
 		FROM crdb_internal.statement_statistics %s
 		GROUP BY
 				aggregated_ts,
-				metadata,
 				aggregation_interval
 		LIMIT $%d`, whereClause, len(args)+1)
 
@@ -569,8 +599,9 @@ func getStatementDetailsPerAggregatedTs(
 		aggregatedTs := tree.MustBeDTimestampTZ(row[0]).Time
 
 		var metadata roachpb.CollectedStatementStatistics
+		var aggregatedMetadata roachpb.AggregatedStatementMetadata
 		metadataJSON := tree.MustBeDJSON(row[1]).JSON
-		if err = sqlstatsutil.DecodeStmtStatsMetadataJSON(metadataJSON, &metadata); err != nil {
+		if err = sqlstatsutil.DecodeAggregatedMetadataJSON(metadataJSON, &aggregatedMetadata); err != nil {
 			return nil, serverError(ctx, err)
 		}
 
@@ -592,6 +623,7 @@ func getStatementDetailsPerAggregatedTs(
 			AggregatedTs:        aggregatedTs,
 			AggregationInterval: time.Duration(aggInterval.Nanos()),
 			Stats:               metadata.Stats,
+			Metadata:            aggregatedMetadata,
 		}
 
 		statements = append(statements, stmt)
@@ -651,7 +683,7 @@ func getStatementDetailsPerPlanHash(
 		`SELECT
 				plan_hash,
 				(statistics -> 'statistics' -> 'planGists'->>0) as plan_gist,
-				metadata,
+				crdb_internal.merge_stats_metadata(array_agg(metadata)) AS metadata,
 				crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics,
 				max(sampled_plan) as sampled_plan,
 				aggregation_interval
@@ -659,7 +691,6 @@ func getStatementDetailsPerPlanHash(
 		GROUP BY
 				plan_hash,
 				plan_gist,
-				metadata,
 				aggregation_interval
 		LIMIT $%d`, whereClause, len(args)+1)
 
@@ -702,8 +733,9 @@ func getStatementDetailsPerPlanHash(
 		explainPlan := getExplainPlanFromGist(ctx, ie, planGist)
 
 		var metadata roachpb.CollectedStatementStatistics
+		var aggregatedMetadata roachpb.AggregatedStatementMetadata
 		metadataJSON := tree.MustBeDJSON(row[2]).JSON
-		if err = sqlstatsutil.DecodeStmtStatsMetadataJSON(metadataJSON, &metadata); err != nil {
+		if err = sqlstatsutil.DecodeAggregatedMetadataJSON(metadataJSON, &aggregatedMetadata); err != nil {
 			return nil, serverError(ctx, err)
 		}
 
@@ -718,14 +750,31 @@ func getStatementDetailsPerPlanHash(
 			return nil, serverError(ctx, err)
 		}
 		metadata.Stats.SensitiveInfo.MostRecentPlanDescription = *plan
-
 		aggInterval := tree.MustBeDInterval(row[5]).Duration
+
+		// A metadata is unique for each plan, meaning if any of the counts are greater than zero,
+		// we can update the value of each count with the execution count of this plan hash to
+		// have the correct count of each metric.
+		if aggregatedMetadata.DistSQLCount > 0 {
+			aggregatedMetadata.DistSQLCount = metadata.Stats.Count
+		}
+		if aggregatedMetadata.FailedCount > 0 {
+			aggregatedMetadata.FailedCount = metadata.Stats.Count
+		}
+		if aggregatedMetadata.FullScanCount > 0 {
+			aggregatedMetadata.FullScanCount = metadata.Stats.Count
+		}
+		if aggregatedMetadata.VecCount > 0 {
+			aggregatedMetadata.VecCount = metadata.Stats.Count
+		}
+		aggregatedMetadata.TotalCount = metadata.Stats.Count
 
 		stmt := serverpb.StatementDetailsResponse_CollectedStatementGroupedByPlanHash{
 			AggregationInterval: time.Duration(aggInterval.Nanos()),
 			ExplainPlan:         explainPlan,
 			PlanHash:            planHash,
 			Stats:               metadata.Stats,
+			Metadata:            aggregatedMetadata,
 		}
 
 		statements = append(statements, stmt)

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1476,27 +1476,24 @@ message StatementDetailsRequest {
 
 message StatementDetailsResponse {
   message CollectedStatementSummary {
-    cockroach.sql.StatementStatisticsKey key_data = 1 [(gogoproto.nullable) = false];
-    // Formatted query is the return of the key_data.query after prettify_statement.
-    // The value from the key_data cannot be replaced by the formatted value, because is used as is for
-    // diagnostic bundle.
-    string formatted_query = 2;
-    repeated string app_names = 3;
-    cockroach.sql.StatementStatistics stats = 4 [(gogoproto.nullable) = false];
-    google.protobuf.Duration aggregation_interval = 5 [(gogoproto.nullable) = false,
+    cockroach.sql.AggregatedStatementMetadata metadata = 1 [(gogoproto.nullable) = false];
+    cockroach.sql.StatementStatistics stats = 2 [(gogoproto.nullable) = false];
+    google.protobuf.Duration aggregation_interval = 3 [(gogoproto.nullable) = false,
       (gogoproto.stdduration) = true];
   }
 
   message CollectedStatementGroupedByAggregatedTs {
-    cockroach.sql.StatementStatistics stats = 1 [(gogoproto.nullable) = false];
-    google.protobuf.Duration aggregation_interval = 2 [(gogoproto.nullable) = false,
+    cockroach.sql.AggregatedStatementMetadata metadata = 1 [(gogoproto.nullable) = false];
+    cockroach.sql.StatementStatistics stats = 2 [(gogoproto.nullable) = false];
+    google.protobuf.Duration aggregation_interval = 3 [(gogoproto.nullable) = false,
       (gogoproto.stdduration) = true];
-    google.protobuf.Timestamp aggregated_ts = 3 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+    google.protobuf.Timestamp aggregated_ts = 4 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
   }
 
   message CollectedStatementGroupedByPlanHash {
-    cockroach.sql.StatementStatistics stats = 1 [(gogoproto.nullable) = false];
-    google.protobuf.Duration aggregation_interval = 2 [(gogoproto.nullable) = false,
+    cockroach.sql.AggregatedStatementMetadata metadata = 1 [(gogoproto.nullable) = false];
+    cockroach.sql.StatementStatistics stats = 2 [(gogoproto.nullable) = false];
+    google.protobuf.Duration aggregation_interval = 3 [(gogoproto.nullable) = false,
       (gogoproto.stdduration) = true];
     string explain_plan = 4;
     uint64 plan_hash = 5;

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -68,6 +68,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
@@ -4152,6 +4153,56 @@ value if you rely on the HLC for accuracy.`,
 				return tree.NewDJSON(aggregatedJSON), nil
 			},
 			Info:       "Merge an array of roachpb.TransactionStatistics into a single JSONB object",
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
+	"crdb_internal.merge_stats_metadata": makeBuiltin(arrayProps(),
+		tree.Overload{
+			Types:      tree.ArgTypes{{"input", types.JSONArray}},
+			ReturnType: tree.FixedReturnType(types.Jsonb),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				arr := tree.MustBeDArray(args[0])
+				metadata := &roachpb.AggregatedStatementMetadata{}
+
+				for _, metadataDatum := range arr.Array {
+					if metadataDatum == tree.DNull {
+						continue
+					}
+
+					var statistics roachpb.CollectedStatementStatistics
+					metadataJSON := tree.MustBeDJSON(metadataDatum).JSON
+					err := sqlstatsutil.DecodeStmtStatsMetadataJSON(metadataJSON, &statistics)
+					if err != nil {
+						return nil, err
+					}
+					metadata.ImplicitTxn = statistics.Key.ImplicitTxn
+					metadata.Query = statistics.Key.Query
+					metadata.QuerySummary = statistics.Key.QuerySummary
+					metadata.StmtType = statistics.Stats.SQLType
+					metadata.Databases = util.CombineUniqueString(metadata.Databases, []string{statistics.Key.Database})
+
+					if statistics.Key.DistSQL {
+						metadata.DistSQLCount++
+					}
+					if statistics.Key.Failed {
+						metadata.FailedCount++
+					}
+					if statistics.Key.FullScan {
+						metadata.FullScanCount++
+					}
+					if statistics.Key.Vec {
+						metadata.VecCount++
+					}
+					metadata.TotalCount++
+				}
+				aggregatedJSON, err := sqlstatsutil.BuildStmtDetailsMetadataJSON(metadata)
+				if err != nil {
+					return nil, err
+				}
+
+				return tree.NewDJSON(aggregatedJSON), nil
+			},
+			Info:       "Merge an array of StmtStatsMetadata into a single JSONB object",
 			Volatility: tree.VolatilityImmutable,
 		},
 	),

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_decoding.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_decoding.go
@@ -43,6 +43,13 @@ func DecodeStmtStatsMetadataJSON(
 	return (*stmtStatsMetadata)(result).jsonFields().decodeJSON(metadata)
 }
 
+// DecodeAggregatedMetadataJSON decodes the 'aggregated metadata' represented by roachpb.AggregatedStatementMetadata.
+func DecodeAggregatedMetadataJSON(
+	metadata json.JSON, result *roachpb.AggregatedStatementMetadata,
+) error {
+	return (*aggregatedMetadata)(result).jsonFields().decodeJSON(metadata)
+}
+
 // DecodeStmtStatsStatisticsJSON decodes the 'statistics' field and the
 // 'execution_statistics' field in the given json into
 // roachpb.StatementStatistics.

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding.go
@@ -247,6 +247,38 @@ func BuildTxnStatisticsJSON(statistics *roachpb.CollectedTransactionStatistics) 
 	return (*txnStats)(&statistics.Stats).encodeJSON()
 }
 
+// BuildStmtDetailsMetadataJSON returns a json.JSON object for the aggregated metadata
+// roachpb.AggregatedStatementMetadata.
+// JSON Schema for statement aggregated metadata:
+//   {
+//     "$schema": "https://json-schema.org/draft/2020-12/schema",
+//     "title": "system.statement_statistics.aggregated_metadata",
+//     "type": "object",
+//
+//     "properties": {
+//       "stmtType":             { "type": "string" },
+//       "query":                { "type": "string" },
+//       "querySummary":         { "type": "string" },
+//       "implicitTxn":          { "type": "boolean" },
+//       "distSQLCount":         { "type": "number" },
+//       "failedCount":          { "type": "number" },
+//       "vecCount":             { "type": "number" },
+//       "fullScanCount":        { "type": "number" },
+//       "totalCount":           { "type": "number" },
+//       "db":                   {
+//      		"type": "array",
+//      		"items": {
+//      		  "type": "string"
+//      		}
+//     	},
+//     }
+//   }
+func BuildStmtDetailsMetadataJSON(
+	metadata *roachpb.AggregatedStatementMetadata,
+) (json.JSON, error) {
+	return (*aggregatedMetadata)(metadata).jsonFields().encodeJSON()
+}
+
 // EncodeUint64ToBytes returns the []byte representation of an uint64 value.
 func EncodeUint64ToBytes(id uint64) []byte {
 	result := make([]byte, 0, 8)

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
@@ -364,6 +364,41 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, input, actualJSONUnmarshalled)
 	})
+
+	t.Run("statement aggregated metadata", func(t *testing.T) {
+		data := genRandomData()
+
+		input := roachpb.AggregatedStatementMetadata{}
+
+		expectedAggregatedMetadataStrTemplate := `
+{
+  "stmtType": "{{.String}}",
+  "query": "{{.String}}",
+  "formattedQuery": "{{.String}}",
+  "querySummary": "{{.String}}",
+  "implicitTxn": {{.Bool}},
+  "distSQLCount": {{.Int64}},
+  "failedCount": {{.Int64}},
+  "vecCount": {{.Int64}},
+  "fullScanCount": {{.Int64}},
+  "totalCount": {{.Int64}},
+  "db": [{{joinStrings .StringArray}}],
+  "appNames": [{{joinStrings .StringArray}}]
+}
+		 `
+		expectedAggregatedMetadataStr := fillTemplate(t, expectedAggregatedMetadataStrTemplate, data)
+		fillObject(t, reflect.ValueOf(&input), &data)
+
+		actualMetadataJSON, err := BuildStmtDetailsMetadataJSON(&input)
+		require.NoError(t, err)
+		jsonTestHelper(t, expectedAggregatedMetadataStr, actualMetadataJSON)
+
+		// Ensure that we get the same protobuf after we decode the JSON.
+		var actualJSONUnmarshalled roachpb.AggregatedStatementMetadata
+		err = DecodeAggregatedMetadataJSON(actualMetadataJSON, &actualJSONUnmarshalled)
+		require.NoError(t, err)
+		require.Equal(t, input, actualJSONUnmarshalled)
+	})
 }
 
 func BenchmarkSQLStatsJson(b *testing.B) {
@@ -439,6 +474,35 @@ func BenchmarkSQLStatsJson(b *testing.B) {
 					b.Fatal(err)
 				}
 				err = DecodeTxnStatsStatisticsJSON(inputTxnStatsJSON, &result.Stats)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	})
+
+	b.Run("statement_metadata", func(b *testing.B) {
+		inputStmtStats := roachpb.CollectedStatementStatistics{}
+		inputStmtMetadata := roachpb.AggregatedStatementMetadata{}
+		b.Run("encoding", func(b *testing.B) {
+			b.SetBytes(int64(inputStmtStats.Size()))
+
+			for i := 0; i < b.N; i++ {
+				_, err := BuildStmtDetailsMetadataJSON(&inputStmtMetadata)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		inputStmtStatsAggregatedMetaJSON, _ := BuildStmtMetadataJSON(&inputStmtStats)
+		result := roachpb.AggregatedStatementMetadata{}
+
+		b.Run("decoding", func(b *testing.B) {
+			b.SetBytes(int64(inputStmtStatsAggregatedMetaJSON.Size()))
+
+			for i := 0; i < b.N; i++ {
+				err := DecodeAggregatedMetadataJSON(inputStmtStatsAggregatedMetaJSON, &result)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
@@ -102,6 +102,25 @@ func (s *stmtStatsMetadata) jsonFields() jsonFields {
 	}
 }
 
+type aggregatedMetadata roachpb.AggregatedStatementMetadata
+
+func (s *aggregatedMetadata) jsonFields() jsonFields {
+	return jsonFields{
+		{"db", (*stringArray)(&s.Databases)},
+		{"appNames", (*stringArray)(&s.AppNames)},
+		{"distSQLCount", (*jsonInt)(&s.DistSQLCount)},
+		{"failedCount", (*jsonInt)(&s.FailedCount)},
+		{"fullScanCount", (*jsonInt)(&s.FullScanCount)},
+		{"implicitTxn", (*jsonBool)(&s.ImplicitTxn)},
+		{"query", (*jsonString)(&s.Query)},
+		{"formattedQuery", (*jsonString)(&s.FormattedQuery)},
+		{"querySummary", (*jsonString)(&s.QuerySummary)},
+		{"stmtType", (*jsonString)(&s.StmtType)},
+		{"vecCount", (*jsonInt)(&s.VecCount)},
+		{"totalCount", (*jsonInt)(&s.TotalCount)},
+	}
+}
+
 type int64Array []int64
 
 func (a *int64Array) decodeJSON(js json.JSON) error {

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
@@ -41,21 +41,20 @@ export const getStatementDetailsPropsFixture = (): StatementDetailsProps => ({
   },
   statementDetails: {
     statement: {
-      key_data: {
+      metadata: {
         query: "SELECT * FROM crdb_internal.node_build_info",
-        app: "",
-        distSQL: false,
-        failed: false,
+        app_names: ["$ cockroach sql", "newname"],
+        dist_sql_count: new Long(2),
+        failed_count: new Long(2),
         implicit_txn: true,
-        vec: true,
-        full_scan: false,
-        database: "defaultdb",
-        plan_hash: new Long(0),
+        vec_count: new Long(2),
+        full_scan_count: new Long(2),
+        databases: ["defaultdb"],
         query_summary: "SELECT * FROM crdb_internal.node_build_info",
-        transaction_fingerprint_id: new Long(0),
+        formatted_query: "SELECT * FROM crdb_internal.node_build_info\n",
+        stmt_type: "DDL",
+        total_count: new Long(3),
       },
-      app_names: ["$ cockroach sql", "newname"],
-      formatted_query: "SELECT * FROM crdb_internal.node_build_info\n",
       stats: {
         count: new Long(5),
         first_attempt_count: new Long(5),

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.spec.tsx
@@ -108,7 +108,7 @@ describe("StatementDetails page", () => {
         .simulate("click");
 
       onDiagnosticsActivateClickSpy.calledOnceWith(
-        statementDetailsProps.statementDetails.statement.key_data.query,
+        statementDetailsProps.statementDetails.statement.metadata.query,
       );
     });
   });

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -211,11 +211,15 @@ function renderTransactionType(implicitTxn: boolean) {
   return "Explicit";
 }
 
-function renderBools(b: boolean) {
-  if (b) {
+function renderCount(yesCount: Long, totalCount: Long) {
+  if (longToInt(yesCount) == 0) {
+    return "No";
+  }
+  if (longToInt(yesCount) == longToInt(totalCount)) {
     return "Yes";
   }
-  return "No";
+  const noCount = longToInt(totalCount) - longToInt(yesCount);
+  return `${longToInt(yesCount)} Yes / ${noCount} No`;
 }
 
 class NumericStatTable extends React.Component<NumericStatTableProps> {
@@ -445,19 +449,18 @@ export class StatementDetails extends React.Component<
     } = this.props;
     const { currentTab } = this.state;
     const { statement_statistics_per_plan_hash } = this.props.statementDetails;
+    const { stats } = this.props.statementDetails.statement;
     const {
-      stats,
       app_names,
       formatted_query,
-    } = this.props.statementDetails.statement;
-    const {
       query,
-      database,
-      distSQL,
-      failed,
-      vec,
+      databases,
+      dist_sql_count,
+      failed_count,
+      vec_count,
+      total_count,
       implicit_txn,
-    } = this.props.statementDetails.statement.key_data;
+    } = this.props.statementDetails.statement.metadata;
 
     if (Number(stats.count) == 0) {
       const sourceApp = queryByName(this.props.location, appAttr);
@@ -525,8 +528,8 @@ export class StatementDetails extends React.Component<
       </Tooltip>
     );
 
-    const db = database ? (
-      <Text>{database}</Text>
+    const db = databases ? (
+      <Text>{databases}</Text>
     ) : (
       <Text className={cx("app-name", "app-name__unset")}>(unset)</Text>
     );
@@ -689,15 +692,15 @@ export class StatementDetails extends React.Component<
                 </div>
                 <div className={summaryCardStylesCx("summary--card__item")}>
                   <Text>Failed?</Text>
-                  <Text>{renderBools(failed)}</Text>
+                  <Text>{renderCount(failed_count, total_count)}</Text>
                 </div>
                 <div className={summaryCardStylesCx("summary--card__item")}>
                   <Text>Distributed execution?</Text>
-                  <Text>{renderBools(distSQL)}</Text>
+                  <Text>{renderCount(dist_sql_count, total_count)}</Text>
                 </div>
                 <div className={summaryCardStylesCx("summary--card__item")}>
                   <Text>Vectorized execution?</Text>
-                  <Text>{renderBools(vec)}</Text>
+                  <Text>{renderCount(vec_count, total_count)}</Text>
                 </div>
                 <div className={summaryCardStylesCx("summary--card__item")}>
                   <Text>Transaction type</Text>

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
@@ -54,7 +54,7 @@ const CancelStatementDiagnosticsReportRequest =
 // diagnostics.
 const mapStateToProps = (state: AppState, props: RouteComponentProps) => {
   const statementDetails = selectStatementDetails(state, props);
-  const statementFingerprint = statementDetails?.statement.key_data.query;
+  const statementFingerprint = statementDetails?.statement.metadata.query;
   return {
     statementDetails,
     statementsError: state.adminUI.sqlStats.lastError,

--- a/pkg/ui/workspaces/cluster-ui/src/store/statementDetails/statementDetails.sagas.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/statementDetails/statementDetails.sagas.spec.ts
@@ -43,21 +43,20 @@ describe("SQLDetailsStats sagas", () => {
   const SQLDetailsStatsResponse = new cockroach.server.serverpb.StatementDetailsResponse(
     {
       statement: {
-        key_data: {
+        metadata: {
           query: "SELECT * FROM crdb_internal.node_build_info",
-          app: "",
-          distSQL: false,
-          failed: false,
+          app_names: ["$ cockroach sql", "newname"],
+          dist_sql_count: new Long(2),
+          failed_count: new Long(2),
           implicit_txn: true,
-          vec: true,
-          full_scan: false,
-          database: "defaultdb",
-          plan_hash: new Long(0),
+          vec_count: new Long(2),
+          full_scan_count: new Long(2),
+          databases: ["defaultdb"],
           query_summary: "SELECT * FROM crdb_internal.node_build_info",
-          transaction_fingerprint_id: new Long(0),
+          formatted_query: "SELECT * FROM crdb_internal.node_build_info\n",
+          stmt_type: "DDL",
+          total_count: new Long(3),
         },
-        app_names: ["$ cockroach sql", "newname"],
-        formatted_query: "SELECT * FROM crdb_internal.node_build_info\n",
         stats: {
           count: new Long(5),
           first_attempt_count: new Long(5),

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
@@ -93,7 +93,7 @@ const mapStateToProps = (
   props: RouteComponentProps,
 ): StatementDetailsStateProps => {
   const statementDetails = selectStatementDetails(state, props);
-  const statementFingerprint = statementDetails?.statement.key_data.query;
+  const statementFingerprint = statementDetails?.statement.metadata.query;
   return {
     statementDetails,
     statementsError: state.cachedData.statements.lastError,

--- a/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
@@ -29,11 +29,17 @@ import ISensitiveInfo = protos.cockroach.sql.ISensitiveInfo;
 import { AdminUIState, createAdminUIStore } from "src/redux/state";
 import { TimeScale, toRoundedDateRange, util } from "@cockroachlabs/cluster-ui";
 
-const { generateStmtDetailsToID } = util;
+const { generateStmtDetailsToID, longToInt } = util;
 
 type CollectedStatementStatistics = util.CollectedStatementStatistics;
 type ExecStats = util.ExecStats;
 type StatementStatistics = util.StatementStatistics;
+type StatementDetails = protos.cockroach.server.serverpb.StatementDetailsResponse;
+
+interface StatementDetailsWithID {
+  details: StatementDetails;
+  id: Long;
+}
 
 const INTERNAL_STATEMENT_PREFIX = "$ internal";
 
@@ -311,47 +317,75 @@ describe("selectStatement", () => {
     const stmtA = makeFingerprint(1);
     const stmtB = makeFingerprint(2, "foobar");
     const stmtC = makeFingerprint(3, "another");
-    const state = makeStateWithStatements([stmtA, stmtB, stmtC], timeScale);
+    const detailsA = makeDetails(stmtA);
+    const detailsB = makeDetails(stmtB);
+    const detailsC = makeDetails(stmtC);
+    const state = makeStateWithStatements([stmtA, stmtB, stmtC], timeScale, [
+      detailsA,
+      detailsB,
+      detailsC,
+    ]);
 
     const stmtAFingerprintID = stmtA.id.toString();
     const props = makeRoutePropsWithStatement(stmtAFingerprintID);
     const result = selectStatementDetails(state, props).statement;
 
-    assert.equal(result.key_data.query, stmtA.key.key_data.query);
+    assert.equal(result.metadata.query, stmtA.key.key_data.query);
     assert.equal(result.stats.count.toNumber(), stmtA.stats.count.toNumber());
-    assert.deepEqual(result.app_names, [stmtA.key.key_data.app]);
-    assert.deepEqual(result.key_data.distSQL, false);
-    assert.deepEqual(result.key_data.vec, false);
-    assert.deepEqual(result.key_data.failed, false);
-    assert.deepEqual(result.stats.nodes, stmtA.stats.nodes);
+    assert.deepEqual(result.metadata.app_names, [stmtA.key.key_data.app]);
+    assert.equal(longToInt(result.metadata.dist_sql_count), 0);
+    assert.equal(longToInt(result.metadata.failed_count), 0);
+    assert.equal(longToInt(result.metadata.full_scan_count), 0);
+    assert.equal(longToInt(result.metadata.vec_count), 0);
+    assert.equal(longToInt(result.metadata.total_count), 1);
   });
 
   it("filters out statements when app param is set", () => {
     const stmtA = makeFingerprint(1, "foo");
+    const stmtB = makeFingerprint(2, "bar");
+    const stmtC = makeFingerprint(3, "baz");
+    const detailsA = makeDetails(stmtA);
+    const detailsB = makeDetails(stmtB);
+    const detailsC = makeDetails(stmtC);
+    const appFilter = "foo";
+
     const state = makeStateWithStatements(
-      [stmtA, makeFingerprint(2, "bar"), makeFingerprint(3, "baz")],
+      [stmtA, stmtB, stmtC],
       timeScale,
+      [detailsA, detailsB, detailsC],
+      appFilter,
     );
     const stmtAFingerprintID = stmtA.id.toString();
-    const props = makeRoutePropsWithStatementAndApp(stmtAFingerprintID, "foo");
+    const props = makeRoutePropsWithStatementAndApp(
+      stmtAFingerprintID,
+      appFilter,
+    );
 
     const result = selectStatementDetails(state, props).statement;
 
-    assert.equal(result.key_data.query, stmtA.key.key_data.query);
+    assert.equal(result.metadata.query, stmtA.key.key_data.query);
     assert.equal(result.stats.count.toNumber(), stmtA.stats.count.toNumber());
-    assert.deepEqual(result.app_names, [stmtA.key.key_data.app]);
-    assert.deepEqual(result.key_data.distSQL, false);
-    assert.deepEqual(result.key_data.vec, false);
-    assert.deepEqual(result.key_data.failed, false);
-    assert.deepEqual(result.stats.nodes, stmtA.stats.nodes);
+    assert.deepEqual(result.metadata.app_names, [stmtA.key.key_data.app]);
+    assert.equal(longToInt(result.metadata.dist_sql_count), 0);
+    assert.equal(longToInt(result.metadata.failed_count), 0);
+    assert.equal(longToInt(result.metadata.full_scan_count), 0);
+    assert.equal(longToInt(result.metadata.vec_count), 0);
+    assert.equal(longToInt(result.metadata.total_count), 1);
   });
 
   it('filters out statements with app set when app param is "(unset)"', () => {
     const stmtA = makeFingerprint(1, "");
-    const state = makeStateWithStatements(
-      [stmtA, makeFingerprint(2, "bar"), makeFingerprint(3, "baz")],
-      timeScale,
-    );
+    const stmtB = makeFingerprint(2, "bar");
+    const stmtC = makeFingerprint(3, "baz");
+    const detailsA = makeDetails(stmtA);
+    const detailsB = makeDetails(stmtB);
+    const detailsC = makeDetails(stmtC);
+
+    const state = makeStateWithStatements([stmtA, stmtB, stmtC], timeScale, [
+      detailsA,
+      detailsB,
+      detailsC,
+    ]);
     const stmtAFingerprintID = stmtA.id.toString();
     const props = makeRoutePropsWithStatementAndApp(
       stmtAFingerprintID,
@@ -360,37 +394,47 @@ describe("selectStatement", () => {
 
     const result = selectStatementDetails(state, props).statement;
 
-    assert.equal(result.key_data.query, stmtA.key.key_data.query);
+    assert.equal(result.metadata.query, stmtA.key.key_data.query);
     assert.equal(result.stats.count.toNumber(), stmtA.stats.count.toNumber());
-    assert.deepEqual(result.app_names, [stmtA.key.key_data.app]);
-    assert.deepEqual(result.key_data.distSQL, false);
-    assert.deepEqual(result.key_data.vec, false);
-    assert.deepEqual(result.key_data.failed, false);
-    assert.deepEqual(result.stats.nodes, stmtA.stats.nodes);
+    assert.deepEqual(result.metadata.app_names, [stmtA.key.key_data.app]);
+    assert.equal(longToInt(result.metadata.dist_sql_count), 0);
+    assert.equal(longToInt(result.metadata.failed_count), 0);
+    assert.equal(longToInt(result.metadata.full_scan_count), 0);
+    assert.equal(longToInt(result.metadata.vec_count), 0);
+    assert.equal(longToInt(result.metadata.total_count), 1);
   });
 
   it('filters out statements with app set when app param is "$ internal"', () => {
     const stmtA = makeFingerprint(1, "$ internal_stmnt_app");
+    const stmtB = makeFingerprint(2, "bar");
+    const stmtC = makeFingerprint(3, "baz");
+    const detailsA = makeDetails(stmtA);
+    const detailsB = makeDetails(stmtB);
+    const detailsC = makeDetails(stmtC);
+    const appFilter = "$ internal";
     const state = makeStateWithStatements(
-      [stmtA, makeFingerprint(2, "bar"), makeFingerprint(3, "baz")],
+      [stmtA, stmtB, stmtC],
       timeScale,
+      [detailsA, detailsB, detailsC],
+      appFilter,
     );
     const stmtAFingerprintID = stmtA.id.toString();
     const props = makeRoutePropsWithStatementAndApp(
       stmtAFingerprintID,
-      "$ internal",
+      appFilter,
     );
 
     const result = selectStatementDetails(state, props)?.statement;
 
-    assert.equal(result.key_data.query, stmtA.key.key_data.query);
+    assert.equal(result.metadata.query, stmtA.key.key_data.query);
     assert.equal(result.stats.count.toNumber(), stmtA.stats.count.toNumber());
     // Statements with internal app prefix should have "$ internal" as app name
-    assert.deepEqual(result.app_names, ["$ internal_stmnt_app"]);
-    assert.deepEqual(result.key_data.distSQL, false);
-    assert.deepEqual(result.key_data.vec, false);
-    assert.deepEqual(result.key_data.failed, false);
-    assert.deepEqual(result.stats.nodes, stmtA.stats.nodes);
+    assert.deepEqual(result.metadata.app_names, ["$ internal_stmnt_app"]);
+    assert.equal(longToInt(result.metadata.dist_sql_count), 0);
+    assert.equal(longToInt(result.metadata.failed_count), 0);
+    assert.equal(longToInt(result.metadata.full_scan_count), 0);
+    assert.equal(longToInt(result.metadata.vec_count), 0);
+    assert.equal(longToInt(result.metadata.total_count), 1);
   });
 });
 
@@ -415,6 +459,38 @@ function makeFingerprint(
     },
     id: Long.fromNumber(id),
     stats: makeStats(),
+  };
+}
+
+function makeDetails(
+  statement: CollectedStatementStatistics,
+): StatementDetailsWithID {
+  return {
+    id: statement.id,
+    details: {
+      statement: {
+        metadata: {
+          query: statement.key.key_data.query,
+          app_names: [statement.key.key_data.app],
+          dist_sql_count: statement.key.key_data.distSQL
+            ? new Long(1)
+            : new Long(0),
+          failed_count: statement.key.key_data.failed
+            ? new Long(1)
+            : new Long(0),
+          full_scan_count: statement.key.key_data.full_scan
+            ? new Long(1)
+            : new Long(0),
+          vec_count: statement.key.key_data.vec ? new Long(1) : new Long(0),
+          total_count: new Long(1),
+        },
+        stats: statement.stats,
+      },
+      statement_statistics_per_aggregated_ts: [],
+      statement_statistics_per_plan_hash: [],
+      internal_app_name_prefix: "$ internal",
+      toJSON: () => ({}),
+    },
   };
 }
 
@@ -493,6 +569,8 @@ function makeStateWithStatementsAndLastReset(
   statements: CollectedStatementStatistics[],
   lastReset: number,
   timeScale: TimeScale,
+  statementsDetails?: StatementDetailsWithID[],
+  appFilter?: string,
 ) {
   const store = createAdminUIStore(H.createMemoryHistory());
   const state = merge(store.getState(), {
@@ -524,31 +602,28 @@ function makeStateWithStatementsAndLastReset(
   const timeStart = Long.fromNumber(start.unix());
   const timeEnd = Long.fromNumber(end.unix());
 
-  for (const stmt of statements) {
-    state.cachedData.statementDetails[
-      generateStmtDetailsToID(
-        stmt.id.toString(),
-        stmt.key.key_data.app,
-        timeStart,
-        timeEnd,
-      )
-    ] = {
-      data: protos.cockroach.server.serverpb.StatementDetailsResponse.fromObject(
-        {
-          statement: {
-            key_data: stmt.key.key_data,
-            formatted_query: stmt.key.key_data.query,
-            app_names: [stmt.key.key_data.app],
-            stats: stmt.stats,
+  if (statementsDetails) {
+    for (const stmt of statementsDetails) {
+      state.cachedData.statementDetails[
+        generateStmtDetailsToID(
+          stmt.id.toString(),
+          appFilter,
+          timeStart,
+          timeEnd,
+        )
+      ] = {
+        data: protos.cockroach.server.serverpb.StatementDetailsResponse.fromObject(
+          {
+            statement: stmt.details.statement,
+            statement_statistics_per_aggregated_ts: [],
+            statement_statistics_per_plan_hash: [],
+            internal_app_name_prefix: "$ internal",
           },
-          statement_statistics_per_aggregated_ts: [],
-          statement_statistics_per_plan_hash: [],
-          internal_app_name_prefix: "$ internal",
-        },
-      ),
-      inFlight: false,
-      valid: true,
-    };
+        ),
+        inFlight: false,
+        valid: true,
+      };
+    }
   }
 
   return state;
@@ -557,8 +632,16 @@ function makeStateWithStatementsAndLastReset(
 function makeStateWithStatements(
   statements: CollectedStatementStatistics[],
   timeScale: TimeScale,
+  statementsDetails?: StatementDetailsWithID[],
+  appFilter?: string,
 ) {
-  return makeStateWithStatementsAndLastReset(statements, 0, timeScale);
+  return makeStateWithStatementsAndLastReset(
+    statements,
+    0,
+    timeScale,
+    statementsDetails,
+    appFilter,
+  );
 }
 
 function makeStateWithLastReset(lastReset: number, timeScale: TimeScale) {


### PR DESCRIPTION
Previously, it was assume the same statement fingerprint id
would have the same metada for all its saved rows.
This commit does a proper grouping of all metadata for the
same fingerprint id.
To make this possible, this commit:
-  introduces the builtin `crdb_internal.merge_stats_metadata`
- Call the new builtin for the grouping on statement details
endpoint
- Update the statement details endpoint to return the new
metadata format with the grouped values.

Partially addresses #77698

Release justification: Bug fix
Release note (sql change): new builtin to group statement
statistics metadata.