### PR TITLE
kvserver: transfer lease in JOINT config directly to a VOTER_INCOMING…

### DIFF
--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -593,46 +593,14 @@ func TestLeasePreferencesRebalance(t *testing.T) {
 	})
 }
 
-// Tests that when leaseholder is relocated, the lease can be transferred directly to a new node.
-// This verifies https://github.com/cockroachdb/cockroach/issues/67740
-func TestLeaseholderRelocatePreferred(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-	testLeaseholderRelocateInternal(t, "us")
-}
-
-// Tests that when leaseholder is relocated, the lease will transfer to a node in a preferred
-// location, even if another node is being added.
-// This verifies https://github.com/cockroachdb/cockroach/issues/67740
-func TestLeaseholderRelocateNonPreferred(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-	testLeaseholderRelocateInternal(t, "eu")
-}
-
-// Tests that when leaseholder is relocated, the lease will transfer to some node,
-// even if nodes in the preferred region aren't available.
-// This verifies https://github.com/cockroachdb/cockroach/issues/67740
-func TestLeaseholderRelocateNonExistent(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-	testLeaseholderRelocateInternal(t, "au")
-}
-
 // Tests that when leaseholder is relocated, the lease can be transferred directly to new node
-func testLeaseholderRelocateInternal(t *testing.T, preferredRegion string) {
+func TestLeaseholderRelocate(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 	stickyRegistry := server.NewStickyInMemEnginesRegistry()
 	defer stickyRegistry.CloseAllStickyInMemEngines()
 	ctx := context.Background()
 	manualClock := hlc.NewHybridManualClock()
-	zcfg := zonepb.DefaultZoneConfig()
-	zcfg.LeasePreferences = []zonepb.LeasePreference{
-		{
-			Constraints: []zonepb.Constraint{
-				{Type: zonepb.Constraint_REQUIRED, Key: "region", Value: preferredRegion},
-			},
-		},
-	}
 
 	serverArgs := make(map[int]base.TestServerArgs)
 	locality := func(region string) roachpb.Locality {
@@ -647,7 +615,6 @@ func testLeaseholderRelocateInternal(t *testing.T, preferredRegion string) {
 		locality("eu"),
 		locality("us"),
 		locality("us"),
-		locality("au"),
 	}
 
 	const numNodes = 4
@@ -656,9 +623,8 @@ func testLeaseholderRelocateInternal(t *testing.T, preferredRegion string) {
 			Locality: localities[i],
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					ClockSource:               manualClock.UnixNano,
-					DefaultZoneConfigOverride: &zcfg,
-					StickyEngineRegistry:      stickyRegistry,
+					ClockSource:          manualClock.UnixNano,
+					StickyEngineRegistry: stickyRegistry,
 				},
 			},
 			StoreSpecs: []base.StoreSpec{
@@ -698,7 +664,6 @@ func testLeaseholderRelocateInternal(t *testing.T, preferredRegion string) {
 				context.Background(), rhsDesc.StartKey.AsRawKey(),
 				tc.Targets(0, 1, 3), nil, false)
 		if err != nil {
-			require.True(t, kvserver.IsTransientLeaseholderError(err), "%v", err)
 			return err
 		}
 		leaseHolder, err = tc.FindRangeLeaseHolder(rhsDesc, nil)
@@ -711,34 +676,13 @@ func testLeaseholderRelocateInternal(t *testing.T, preferredRegion string) {
 		return nil
 	})
 
-	// The only node with "au" locality is down, the lease can move anywhere.
-	if preferredRegion == "au" {
-		return
-	}
-
 	// Make sure lease moved to the preferred region, if .
 	leaseHolder, err = tc.FindRangeLeaseHolder(rhsDesc, nil)
 	require.NoError(t, err)
-	require.Equal(t, locality(preferredRegion),
-		localities[leaseHolder.NodeID-1])
-
-	var leaseholderNodeId int
-	if preferredRegion == "us" {
-		require.Equal(t, tc.Target(3).NodeID,
-			leaseHolder.NodeID)
-		leaseholderNodeId = 3
-	} else {
-		if leaseHolder.NodeID == tc.Target(0).NodeID {
-			leaseholderNodeId = 0
-		} else {
-			require.Equal(t, tc.Target(1).NodeID,
-				leaseHolder.NodeID)
-			leaseholderNodeId = 1
-		}
-	}
+	require.Equal(t, tc.Target(3), leaseHolder)
 
 	// Double check that lease moved directly.
-	repl := tc.GetFirstStoreFromServer(t, leaseholderNodeId).
+	repl := tc.GetFirstStoreFromServer(t, 3).
 		LookupReplica(roachpb.RKey(rhsDesc.StartKey.AsRawKey()))
 	history := repl.GetLeaseHistory()
 	require.Equal(t, leaseHolder.NodeID,
@@ -793,7 +737,7 @@ func TestLeasePreferencesDuringOutage(t *testing.T) {
 			},
 		},
 	}
-	numNodes := 6
+	numNodes := 5
 	serverArgs := make(map[int]base.TestServerArgs)
 	locality := func(region string, dc string) roachpb.Locality {
 		return roachpb.Locality{
@@ -804,7 +748,6 @@ func TestLeasePreferencesDuringOutage(t *testing.T) {
 		}
 	}
 	localities := []roachpb.Locality{
-		locality("eu", "tr"),
 		locality("eu", "tr"),
 		locality("us", "sf"),
 		locality("us", "sf"),
@@ -834,25 +777,26 @@ func TestLeasePreferencesDuringOutage(t *testing.T) {
 			ReplicationMode:   base.ReplicationManual,
 			ServerArgsPerNode: serverArgs,
 		})
+
 	defer tc.Stopper().Stop(ctx)
 
 	key := bootstrap.TestingUserTableDataMin()
 	tc.SplitRangeOrFatal(t, key)
-	tc.AddVotersOrFatal(t, key, tc.Targets(2, 4)...)
+	tc.AddVotersOrFatal(t, key, tc.Targets(1, 3)...)
 	repl := tc.GetFirstStoreFromServer(t, 0).LookupReplica(roachpb.RKey(key))
-	require.NoError(t, tc.WaitForVoters(key, tc.Targets(2, 4)...))
-	tc.TransferRangeLeaseOrFatal(t, *repl.Desc(), tc.Target(2))
+	require.NoError(t, tc.WaitForVoters(key, tc.Targets(1, 3)...))
+	tc.TransferRangeLeaseOrFatal(t, *repl.Desc(), tc.Target(1))
 
 	// Shutdown the sf datacenter, which is going to kill the node with the lease.
+	tc.StopServer(1)
 	tc.StopServer(2)
-	tc.StopServer(3)
 
 	wait := func(duration int64) {
 		manualClock.Increment(duration)
 		// Gossip and heartbeat all the live stores, we do this manually otherwise the
 		// allocator on server 0 may see everyone as temporarily dead due to the
 		// clock move above.
-		for _, i := range []int{0, 1, 4, 5} {
+		for _, i := range []int{0, 3, 4} {
 			require.NoError(t, tc.Servers[i].HeartbeatNodeLiveness())
 			require.NoError(t, tc.GetFirstStoreFromServer(t, i).GossipStore(ctx, true))
 		}
@@ -879,18 +823,18 @@ func TestLeasePreferencesDuringOutage(t *testing.T) {
 	testutils.SucceedsSoon(t, func() error {
 		store := tc.GetFirstStoreFromServer(t, 0)
 		sl, _, _ := store.GetStoreConfig().StorePool.GetStoreList()
-		if len(sl.Stores()) != 4 {
-			return errors.Errorf("expected all 4 remaining stores to be live, but only got %v", sl.Stores())
+		if len(sl.Stores()) != 3 {
+			return errors.Errorf("expected all 3 remaining stores to be live, but only got %v",
+				sl.Stores())
+		}
+		if err := checkDead(store, 1); err != nil {
+			return err
 		}
 		if err := checkDead(store, 2); err != nil {
 			return err
 		}
-		if err := checkDead(store, 3); err != nil {
-			return err
-		}
 		return nil
 	})
-
 	_, _, enqueueError := tc.GetFirstStoreFromServer(t, 0).
 		ManuallyEnqueue(ctx, "replicate", repl, true)
 
@@ -903,26 +847,22 @@ func TestLeasePreferencesDuringOutage(t *testing.T) {
 		return err
 	})
 
-	// Check that the leaseholder is in the US
 	srv, err := tc.FindMemberServer(newLeaseHolder.StoreID)
 	require.NoError(t, err)
 	region, ok := srv.Locality().Find("region")
 	require.True(t, ok)
 	require.Equal(t, "us", region)
-
+	require.Equal(t, 3, len(repl.Desc().Replicas().Voters().VoterDescriptors()))
 	// Validate that we upreplicated outside of SF.
-	replicas := repl.Desc().Replicas().Voters().VoterDescriptors()
-	require.Equal(t, 3, len(replicas))
-	for _, replDesc := range replicas {
+	for _, replDesc := range repl.Desc().Replicas().Voters().VoterDescriptors() {
 		serv, err := tc.FindMemberServer(replDesc.StoreID)
 		require.NoError(t, err)
 		dc, ok := serv.Locality().Find("dc")
 		require.True(t, ok)
 		require.NotEqual(t, "sf", dc)
 	}
-
-	// make sure we see the eu node as a lease holder in the second to last position.
 	history := repl.GetLeaseHistory()
+	// make sure we see the eu node as a lease holder in the second to last position.
 	require.Equal(t, tc.Target(0).NodeID, history[len(history)-2].Replica.NodeID)
 }
 
@@ -1001,7 +941,7 @@ func TestLeasesDontThrashWhenNodeBecomesSuspect(t *testing.T) {
 
 	_, rhsDesc := tc.SplitRangeOrFatal(t, bootstrap.TestingUserTableDataMin())
 	tc.AddVotersOrFatal(t, rhsDesc.StartKey.AsRawKey(), tc.Targets(1, 2, 3)...)
-	tc.RemoveLeaseHolderOrFatal(t, rhsDesc, tc.Target(0))
+	tc.RemoveLeaseHolderOrFatal(t, rhsDesc, tc.Target(0), tc.Target(1))
 
 	startKeys := make([]roachpb.Key, 20)
 	startKeys[0] = rhsDesc.StartKey.AsRawKey()

--- a/pkg/kv/kvserver/client_metrics_test.go
+++ b/pkg/kv/kvserver/client_metrics_test.go
@@ -337,7 +337,7 @@ func TestStoreMetrics(t *testing.T) {
 	// Verify stats after addition.
 	verifyStats(t, tc, 1, 2)
 	checkGauge(t, "store 0", tc.GetFirstStoreFromServer(t, 0).Metrics().ReplicaCount, initialCount+1)
-	tc.RemoveLeaseHolderOrFatal(t, desc, tc.Target(0))
+	tc.RemoveLeaseHolderOrFatal(t, desc, tc.Target(0), tc.Target(1))
 	testutils.SucceedsSoon(t, func() error {
 		_, err := tc.GetFirstStoreFromServer(t, 0).GetReplica(desc.RangeID)
 		if err == nil {

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -3841,25 +3841,16 @@ func TestLeaseHolderRemoveSelf(t *testing.T) {
 		})
 	defer tc.Stopper().Stop(ctx)
 
-	_, desc := tc.SplitRangeOrFatal(t, bootstrap.TestingUserTableDataMin())
-	key := desc.StartKey.AsRawKey()
-	tc.AddVotersOrFatal(t, key, tc.Targets(1)...)
+	leaseHolder := tc.GetFirstStoreFromServer(t, 0)
+	key := []byte("a")
+	tc.SplitRangeOrFatal(t, key)
+	tc.AddVotersOrFatal(t, key, tc.Target(1))
 
-	// Remove the replica from first store.
-	tc.RemoveLeaseHolderOrFatal(t, desc, tc.Target(0))
-
-	// Check that lease moved to server 2.
-	leaseInfo := getLeaseInfoOrFatal(t, context.Background(), tc.Servers[1].DB(), key)
-	rangeDesc, err := tc.LookupRange(key)
-	if err != nil {
-		t.Fatal(err)
+	// Attempt to remove the replica from first store.
+	expectedErr := "invalid ChangeReplicasTrigger"
+	if _, err := tc.RemoveVoters(key, tc.Target(0)); !testutils.IsError(err, expectedErr) {
+		t.Fatalf("expected %q error trying to remove leaseholder replica; got %v", expectedErr, err)
 	}
-	replica, ok := rangeDesc.GetReplicaDescriptor(tc.Servers[1].GetFirstStoreID())
-	if !ok {
-		t.Fatalf("expected to find replica in server 2")
-	}
-	require.Equal(t, leaseInfo.Lease.Replica, replica)
-	leaseHolder := tc.GetFirstStoreFromServer(t, 1)
 
 	// Expect that we can still successfully do a get on the range.
 	getArgs := getArgs(key)

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -1871,7 +1871,7 @@ func TestRemoveLeaseholder(t *testing.T) {
 	require.Equal(t, tc.Target(0), leaseHolder)
 
 	// Remove server 1.
-	tc.RemoveLeaseHolderOrFatal(t, rhsDesc, tc.Target(0))
+	tc.RemoveLeaseHolderOrFatal(t, rhsDesc, tc.Target(0), tc.Target(1))
 
 	// Check that the lease moved away from 1.
 	leaseHolder, err = tc.FindRangeLeaseHolder(rhsDesc, nil)

--- a/pkg/kv/kvserver/markers.go
+++ b/pkg/kv/kvserver/markers.go
@@ -78,13 +78,3 @@ var errMarkInvalidReplicationChange = errors.New("invalid replication change")
 func IsIllegalReplicationChangeError(err error) bool {
 	return errors.Is(err, errMarkInvalidReplicationChange)
 }
-
-var errLeaseholderNotRaftLeader = errors.New(
-	"removing leaseholder not allowed since it isn't the Raft leader")
-
-// IsTransientLeaseholderError can happen when a reconfiguration is invoked,
-// if the Raft leader is not collocated with the leaseholder.
-// This is temporary, and indicates that the operation should be retried.
-func IsTransientLeaseholderError(err error) bool {
-	return errors.Is(err, errLeaseholderNotRaftLeader)
-}

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -1058,21 +1058,6 @@ func (r *Replica) changeReplicasImpl(
 		}
 	}
 
-	// Before we initialize learners, check that we're not removing the leaseholder.
-	// Or if we are, ensure that leaseholder is collocated with the Raft leader.
-	// A leaseholder that isn't the Raft leader doesn't know whether other replicas
-	// are sufficiently up-to-date (have the latest snapshot), and so choosing a
-	// target for lease transfer is riskier as it may result in temporary unavailability.
-	for _, target := range targets.voterRemovals {
-		if r.NodeID() == target.NodeID && r.StoreID() == target.StoreID {
-			raftStatus := r.RaftStatus()
-			if raftStatus == nil || len(raftStatus.Progress) == 0 {
-				log.VErrEventf(ctx, 5, "%v", errLeaseholderNotRaftLeader)
-				return nil, errLeaseholderNotRaftLeader
-			}
-		}
-	}
-
 	if adds := targets.voterAdditions; len(adds) > 0 {
 		// For all newly added voters, first add LEARNER replicas. They accept raft
 		// traffic (so they can catch up) but don't get to vote (so they don't
@@ -1210,56 +1195,34 @@ func (r *Replica) maybeTransferLeaseDuringLeaveJoint(
 	// complete. If we don't find the current leaseholder there this means it's being removed,
 	// and we're going to transfer the lease to another voter below, before exiting the JOINT config.
 	beingRemoved := true
+	voterIncomingTarget := roachpb.ReplicaDescriptor{}
 	for _, v := range voters {
-		if v.ReplicaID == r.ReplicaID() {
+		if beingRemoved && v.ReplicaID == r.ReplicaID() {
 			beingRemoved = false
-			break
+		}
+		if voterIncomingTarget == (roachpb.ReplicaDescriptor{}) &&
+			v.GetType() == roachpb.VOTER_INCOMING {
+			voterIncomingTarget = v
 		}
 	}
 	if !beingRemoved {
 		return nil
 	}
-	// TransferLeaseTarget looks for a suitable target for lease transfer.
-	// Replicas are filtered from considerations based on the arguments passed,
-	// as well as various indicators. One such filtering is a requirement that a
-	// target replica has applied a snapshot. We exclude VOTER_INCOMING replicas
-	// from this check, since they only move to this state after applying a
-	// snapshot. Another filtering is based on the lieveness status of nodes
-	// We do not transfer the lease to nodes in draining or unknown state.
-	// Unknown is a temporary state, and is usually resolved after receiving a
-	// gossip message. But we do not know whether a particular node is alive,
-	// and would rather stay in the JOINT config than transferring the lease
-	// to a dead node. If no candidates are found, we will remain in a JOINT
-	// config, and rely on upper layers to retry exiting from the config.
-	target := r.store.allocator.TransferLeaseTarget(
-		ctx,
-		r.SpanConfig(),
-		voters,
-		r,
-		r.leaseholderStats,
-		true, /* forceDecisionWithoutStats */
-		transferLeaseOptions{
-			goal:                     followTheWorkload,
-			checkTransferLeaseSource: false,
-			checkCandidateFullness:   false,
-			dryRun:                   false,
-		},
-	)
-	if target == (roachpb.ReplicaDescriptor{}) {
-		err := errors.Errorf(
-			"could not find a better lease transfer target for r%d", desc.RangeID)
-		log.VErrEventf(ctx, 5, "%v", err)
-		// Couldn't find a target. Returning nil means we're not exiting the JOINT config, and the
-		// caller will retry. Note that the JOINT config isn't rolled back.
-		return err
+
+	if voterIncomingTarget == (roachpb.ReplicaDescriptor{}) {
+		// Couldn't find a VOTER_INCOMING target. This should not happen since we only go into the
+		// JOINT config if the leaseholder is being removed, when there is a VOTER_INCOMING replica.
+		// Killing the leaseholder to force lease transfer.
+		log.Fatalf(ctx, "no VOTER_INCOMING to transfer lease to. "+
+			"Range descriptor: %v", desc)
 	}
 	log.VEventf(ctx, 5, "current leaseholder %v is being removed through an"+
-		" atomic replication change. Transferring lease to %v", r.String(), target)
-	err := r.store.DB().AdminTransferLease(ctx, r.startKey, target.StoreID)
+		" atomic replication change. Transferring lease to %v", r.String(), voterIncomingTarget)
+	err := r.store.DB().AdminTransferLease(ctx, r.startKey, voterIncomingTarget.StoreID)
 	if err != nil {
 		return err
 	}
-	log.VEventf(ctx, 5, "leaseholder transfer to %v complete", target)
+	log.VEventf(ctx, 5, "leaseholder transfer to %v complete", voterIncomingTarget)
 	return nil
 }
 
@@ -2870,30 +2833,13 @@ func (r *Replica) relocateReplicas(
 			if err != nil {
 				return rangeDesc, err
 			}
-
-			if !r.store.cfg.Settings.Version.IsActive(ctx,
-				clusterversion.EnableLeaseHolderRemoval) {
-				if leaseTarget != nil {
-					// NB: we may need to transfer even if there are no ops, to make
-					// sure the attempt is made to make the first target the final
-					// leaseholder.
-					if err := transferLease(*leaseTarget); err != nil {
-						return rangeDesc, err
-					}
+			if leaseTarget != nil {
+				if err := transferLease(*leaseTarget); err != nil {
+					return rangeDesc, err
 				}
-				if len(ops) == 0 {
-					// Done
-					return rangeDesc, ctx.Err()
-				}
-			} else if len(ops) == 0 {
-				if len(voterTargets) > 0 && transferLeaseToFirstVoter {
-					// NB: we may need to transfer even if there are no ops, to make
-					// sure the attempt is made to make the first target the final
-					// leaseholder.
-					if err := transferLease(voterTargets[0]); err != nil {
-						return rangeDesc, err
-					}
-				}
+			}
+			if len(ops) == 0 {
+				// Done
 				return rangeDesc, ctx.Err()
 			}
 
@@ -3086,6 +3032,7 @@ func (r *Replica) relocateOne(
 		shouldAdd = true
 	}
 
+	lhRemovalAllowed := false
 	var transferTarget *roachpb.ReplicationTarget
 	if len(args.targetsToRemove()) > 0 {
 		// Pick a replica to remove. Note that existingVoters/existingNonVoters may
@@ -3127,9 +3074,12 @@ func (r *Replica) relocateOne(
 		if err := r.store.DB().Run(ctx, &b); err != nil {
 			return nil, nil, errors.Wrap(err, "looking up lease")
 		}
-		curLeaseholder := b.RawResponse().Responses[0].GetLeaseInfo().Lease.Replica
-		shouldRemove = (curLeaseholder.StoreID != removalTarget.StoreID) ||
+		// Determines whether we can remove the leaseholder without first
+		// transferring the lease away.
+		lhRemovalAllowed = len(args.votersToAdd) > 0 &&
 			r.store.cfg.Settings.Version.IsActive(ctx, clusterversion.EnableLeaseHolderRemoval)
+		curLeaseholder := b.RawResponse().Responses[0].GetLeaseInfo().Lease.Replica
+		shouldRemove = (curLeaseholder.StoreID != removalTarget.StoreID) || lhRemovalAllowed
 		if args.targetType == voterTarget {
 			// If the voter being removed is about to be added as a non-voter, then we
 			// can just demote it.

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -345,10 +345,10 @@ func (r *Replica) propose(
 		// In case (1) the lease needs to be transferred out before a removal is
 		// proposed (cooperative transfer). The code below permits leaseholder
 		// removal only if entering a joint configuration (option 2 above) in which
-		// the leaseholder is (any kind of) voter. In this case, the lease is
-		// transferred to a different voter (potentially incoming) in
-		// maybeLeaveAtomicChangeReplicas right before we exit the joint
-		// configuration.
+		// the leaseholder is (any kind of) voter, and in addition, this joint config
+		// should include a VOTER_INCOMING replica. In this case, the lease is
+		// transferred to this new replica in maybeLeaveAtomicChangeReplicas right
+		// before we exit the joint configuration.
 		//
 		// When the leaseholder is replaced by a new replica, transferring the
 		// lease in the joint config allows transferring directly from old to new,
@@ -366,18 +366,20 @@ func (r *Replica) propose(
 		// See also https://github.com/cockroachdb/cockroach/issues/67740.
 		replID := r.ReplicaID()
 		rDesc, ok := p.command.ReplicatedEvalResult.State.Desc.GetReplicaDescriptorByID(replID)
-		lhRemovalAllowed := r.store.cfg.Settings.Version.IsActive(ctx,
+		hasVoterIncoming := p.command.ReplicatedEvalResult.State.Desc.ContainsVoterIncoming()
+		lhRemovalAllowed := hasVoterIncoming && r.store.cfg.Settings.Version.IsActive(ctx,
 			clusterversion.EnableLeaseHolderRemoval)
 		// Previously, we were not allowed to enter a joint config where the
-		// leaseholder is being removed (i.e., not a voter). In the new version
-		// we're allowed to enter such a joint config, but not to exit it in this
-		// state, i.e., the leaseholder must be some kind of voter in the next
-		// new config (potentially VOTER_DEMOTING).
+		// leaseholder is being removed (i.e., not a full voter). In the new version
+		// we're allowed to enter such a joint config (if it has a VOTER_INCOMING),
+		// but not to exit it in this state, i.e., the leaseholder must be some
+		// kind of voter in the next new config (potentially VOTER_DEMOTING).
 		if !ok ||
 			(lhRemovalAllowed && !rDesc.IsAnyVoter()) ||
 			(!lhRemovalAllowed && !rDesc.IsVoterNewConfig()) {
-			err := errors.Mark(errors.Newf("received invalid ChangeReplicasTrigger %s to remove self ("+
-				"leaseholder); lhRemovalAllowed: %v", crt, lhRemovalAllowed),
+			err := errors.Mark(errors.Newf("received invalid ChangeReplicasTrigger %s to remove "+
+				"self (leaseholder); hasVoterIncoming: %v, lhRemovalAllowed: %v; proposed descriptor: %v",
+				crt, hasVoterIncoming, lhRemovalAllowed, p.command.ReplicatedEvalResult.State.Desc),
 				errMarkInvalidReplicationChange)
 			log.Errorf(p.ctx, "%v", err)
 			return roachpb.NewError(err)

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -327,6 +327,16 @@ func (r *RangeDescriptor) GetReplicaDescriptorByID(replicaID ReplicaID) (Replica
 	return ReplicaDescriptor{}, false
 }
 
+// ContainsVoterIncoming returns true if the descriptor contains a VOTER_INCOMING replica.
+func (r *RangeDescriptor) ContainsVoterIncoming() bool {
+	for _, repDesc := range r.Replicas().Descriptors() {
+		if repDesc.GetType() == VOTER_INCOMING {
+			return true
+		}
+	}
+	return false
+}
+
 // IsInitialized returns false if this descriptor represents an
 // uninitialized range.
 // TODO(bdarnell): unify this with Validate().

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -899,22 +899,20 @@ func (tc *TestCluster) TransferRangeLeaseOrFatal(
 	}
 }
 
-// RemoveLeaseHolderOrFatal is a convenience wrapper around RemoveVoter
+// RemoveLeaseHolderOrFatal is a convenience version of TransferRangeLease and RemoveVoter
 func (tc *TestCluster) RemoveLeaseHolderOrFatal(
-	t testing.TB, rangeDesc roachpb.RangeDescriptor, src roachpb.ReplicationTarget,
+	t testing.TB,
+	rangeDesc roachpb.RangeDescriptor,
+	src roachpb.ReplicationTarget,
+	dest roachpb.ReplicationTarget,
 ) {
 	testutils.SucceedsSoon(t, func() error {
+		if err := tc.TransferRangeLease(rangeDesc, dest); err != nil {
+			return err
+		}
 		if _, err := tc.RemoveVoters(rangeDesc.StartKey.AsRawKey(), src); err != nil {
-			if strings.Contains(err.Error(), "to remove self (leaseholder)") ||
-				strings.Contains(err.Error(), "leaseholder moved") ||
-				strings.Contains(err.Error(), "isn't the Raft leader") {
+			if strings.Contains(err.Error(), "to remove self (leaseholder)") {
 				return err
-			} else if strings.Contains(err.Error(),
-				"trying to remove a replica that doesn't exist") {
-				// It's possible that on leaseholder initiates the removal but another one completes it.
-				// The first attempt throws an error because the leaseholder moves, the second attempt
-				// fails with the exception that the voter doesn't exist, which is expected.
-				return nil
 			}
 			t.Fatal(err)
 		}


### PR DESCRIPTION
… replica

In https://github.com/cockroachdb/cockroach/pull/74077 we allowed entering a JOINT
config when the leaseholder is being demoted, in which case we attempted to transfer the lease
away before leaving the JOINT config. Looking for a lease transfer target at that stage created
flakiness, since in some situations this target isn't found and we need to retry. This PR
takes the approach that when the leaseholder is being removed, we should enter the JOINT config
only if there is a VOTER_INCOMING replica. In that case, the lease is transferred directly to
that replica, without further checks. And otherwise, the lease must be transferred before attempting
to remove the leaseholder.

Release justification: fixes flakiness caused by #74077
Release note: None

Experiments to demonstrate that the benefits of  https://github.com/cockroachdb/cockroach/pull/74077
remain with this PR. Please refer to the #74077 for details.
1. No leaseholder preference:
<img width="985" alt="Screen Shot 2022-03-22 at 7 24 15 PM" src="https://user-images.githubusercontent.com/6037719/159631649-36a296a8-7619-4dab-8db1-a8b603b6d66e.png">


3. Leaseholder preference is rack 0:
<img width="977" alt="Screen Shot 2022-03-22 at 10 39 50 PM" src="https://user-images.githubusercontent.com/6037719/159631504-1cd3350a-89a5-4d77-b9a1-37dfdd2896ae.png">

