### PR TITLE
WIP: opt: inline constant values for FK and uniqueness checks

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_tpcc
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_tpcc
@@ -1,0 +1,245 @@
+# LogicTest: multiregion-9node-3region-3azs
+
+statement ok
+CREATE DATABASE tpcc PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1";
+USE tpcc
+
+# NB: This doesn't include the foreign key reference to warehouse since we
+# don't need the warehouse table for this test.
+statement ok
+CREATE TABLE district (
+        d_id INT8 NOT NULL,
+        d_w_id INT8 NOT NULL,
+        d_name VARCHAR(10) NOT NULL,
+        d_street_1 VARCHAR(20) NOT NULL,
+        d_street_2 VARCHAR(20) NOT NULL,
+        d_city VARCHAR(20) NOT NULL,
+        d_state CHAR(2) NOT NULL,
+        d_zip CHAR(9) NOT NULL,
+        d_tax DECIMAL(4,4) NOT NULL,
+        d_ytd DECIMAL(12,2) NOT NULL,
+        d_next_o_id INT8 NOT NULL,
+        crdb_region crdb_internal_region NOT VISIBLE NOT NULL AS (CASE WHEN d_w_id BETWEEN 0:::INT8 AND 1665:::INT8 THEN 'ap-southeast-2':::crdb_internal_region WHEN d_w_id BETWEEN 1666:::INT8 AND 3332:::INT8 THEN 'us-east-1':::crdb_internal_region WHEN d_w_id BETWEEN 3333:::INT8 AND 4999:::INT8 THEN 'ca-central-1':::crdb_internal_region END) STORED,
+        CONSTRAINT "primary" PRIMARY KEY (d_w_id ASC, d_id ASC),
+        FAMILY "primary" (d_id, d_w_id, d_name, d_street_1, d_street_2, d_city, d_state, d_zip, d_tax, d_ytd, d_next_o_id, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+statement ok
+CREATE TABLE customer (
+        c_id INT8 NOT NULL,
+        c_d_id INT8 NOT NULL,
+        c_w_id INT8 NOT NULL,
+        c_first VARCHAR(16) NOT NULL,
+        c_middle CHAR(2) NOT NULL,
+        c_last VARCHAR(16) NOT NULL,
+        c_street_1 VARCHAR(20) NOT NULL,
+        c_street_2 VARCHAR(20) NOT NULL,
+        c_city VARCHAR(20) NOT NULL,
+        c_state CHAR(2) NOT NULL,
+        c_zip CHAR(9) NOT NULL,
+        c_phone CHAR(16) NOT NULL,
+        c_since TIMESTAMP NOT NULL,
+        c_credit CHAR(2) NOT NULL,
+        c_credit_lim DECIMAL(12,2) NOT NULL,
+        c_discount DECIMAL(4,4) NOT NULL,
+        c_balance DECIMAL(12,2) NOT NULL,
+        c_ytd_payment DECIMAL(12,2) NOT NULL,
+        c_payment_cnt INT8 NOT NULL,
+        c_delivery_cnt INT8 NOT NULL,
+        c_data VARCHAR(500) NOT NULL,
+        crdb_region crdb_internal_region NOT VISIBLE NOT NULL AS (CASE WHEN c_w_id BETWEEN 0:::INT8 AND 1665:::INT8 THEN 'ap-southeast-2':::crdb_internal_region WHEN c_w_id BETWEEN 1666:::INT8 AND 3332:::INT8 THEN 'us-east-1':::crdb_internal_region WHEN c_w_id BETWEEN 3333:::INT8 AND 4999:::INT8 THEN 'ca-central-1':::crdb_internal_region END) STORED,
+        CONSTRAINT "primary" PRIMARY KEY (c_w_id ASC, c_d_id ASC, c_id ASC),
+        CONSTRAINT fk_c_w_id_ref_district FOREIGN KEY (c_w_id, c_d_id) REFERENCES district(d_w_id, d_id) NOT VALID,
+        INDEX customer_idx (c_w_id ASC, c_d_id ASC, c_last ASC, c_first ASC),
+        FAMILY "primary" (c_id, c_d_id, c_w_id, c_first, c_middle, c_last, c_street_1, c_street_2, c_city, c_state, c_zip, c_phone, c_since, c_credit, c_credit_lim, c_discount, c_balance, c_ytd_payment, c_payment_cnt, c_delivery_cnt, c_data, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+statement ok
+CREATE TABLE history (
+        rowid UUID NOT NULL DEFAULT gen_random_uuid(),
+        h_c_id INT8 NOT NULL,
+        h_c_d_id INT8 NOT NULL,
+        h_c_w_id INT8 NOT NULL,
+        h_d_id INT8 NOT NULL,
+        h_w_id INT8 NOT NULL,
+        h_date TIMESTAMP NULL,
+        h_amount DECIMAL(6,2) NULL,
+        h_data VARCHAR(24) NULL,
+        crdb_region crdb_internal_region NOT VISIBLE NOT NULL AS (CASE WHEN h_w_id BETWEEN 0:::INT8 AND 1665:::INT8 THEN 'ap-southeast-2':::crdb_internal_region WHEN h_w_id BETWEEN 1666:::INT8 AND 3332:::INT8 THEN 'us-east-1':::crdb_internal_region WHEN h_w_id BETWEEN 3333:::INT8 AND 4999:::INT8 THEN 'ca-central-1':::crdb_internal_region END) STORED,
+        CONSTRAINT "primary" PRIMARY KEY (h_w_id ASC, rowid ASC),
+        CONSTRAINT fk_h_c_w_id_ref_customer FOREIGN KEY (h_c_w_id, h_c_d_id, h_c_id) REFERENCES customer(c_w_id, c_d_id, c_id) NOT VALID,
+        CONSTRAINT fk_h_w_id_ref_district FOREIGN KEY (h_w_id, h_d_id) REFERENCES district(d_w_id, d_id) NOT VALID,
+        FAMILY "primary" (rowid, h_c_id, h_c_d_id, h_c_w_id, h_d_id, h_w_id, h_date, h_amount, h_data, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+statement ok
+ALTER TABLE district INJECT STATISTICS '[
+    {
+        "columns": [
+            "d_w_id"
+        ],
+        "created_at": "2021-04-13 19:54:56.008454",
+        "distinct_count": 5004,
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 50000
+    },
+    {
+        "columns": [
+            "d_id"
+        ],
+        "created_at": "2021-04-13 19:54:56.008454",
+        "distinct_count": 10,
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 50000
+    }
+]'
+
+statement ok
+ALTER TABLE customer INJECT STATISTICS '[
+    {
+        "columns": [
+            "c_d_id"
+        ],
+        "created_at": "2021-04-13 20:35:46.476858",
+        "distinct_count": 10,
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 150000000
+    },
+    {
+        "columns": [
+            "c_w_id"
+        ],
+        "created_at": "2021-04-13 20:35:46.476858",
+        "distinct_count": 4998,
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 150000000
+    },
+    {
+        "columns": [
+            "c_id"
+        ],
+        "created_at": "2021-04-13 20:35:46.476858",
+        "distinct_count": 2999,
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 150000000
+    }
+]'
+
+statement ok
+ALTER TABLE history INJECT STATISTICS '[
+    {
+        "columns": [
+            "h_w_id"
+        ],
+        "created_at": "2021-04-13 20:58:06.757925",
+        "distinct_count": 4998,
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 150000000
+    },
+    {
+        "columns": [
+            "h_c_id"
+        ],
+        "created_at": "2021-04-13 20:58:06.757925",
+        "distinct_count": 2999,
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 150000000
+    },
+    {
+        "columns": [
+            "h_c_d_id"
+        ],
+        "created_at": "2021-04-13 20:58:06.757925",
+        "distinct_count": 10,
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 150000000
+    },
+    {
+        "columns": [
+            "h_c_w_id"
+        ],
+        "created_at": "2021-04-13 20:58:06.757925",
+        "distinct_count": 4998,
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 150000000
+    },
+    {
+        "columns": [
+            "h_d_id"
+        ],
+        "created_at": "2021-04-13 20:58:06.757925",
+        "distinct_count": 10,
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 150000000
+    }
+]'
+
+# Regression test for #63735. Ensure that we choose locality optimized anti
+# joins for the foreign key checks.
+query T
+EXPLAIN INSERT
+INTO
+  history (h_c_id, h_c_d_id, h_c_w_id, h_d_id, h_w_id, h_amount, h_date, h_data)
+VALUES
+  (2057, 4, 3, 4, 3, 2100.9, '2021-04-15 15:22:14', '9    zmssaF9m'),
+  (2058, 4, 3, 4, 3, 2100.9, '2021-04-15 15:22:14', '9    zmssaF9m')
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • insert
+│   │ into: history(rowid, h_c_id, h_c_d_id, h_c_w_id, h_d_id, h_w_id, h_date, h_amount, h_data, crdb_region)
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │ estimated row count: 2
+│           │
+│           └── • render
+│               │ estimated row count: 2
+│               │
+│               └── • values
+│                     size: 8 columns, 2 rows
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • lookup join (anti)
+│           │ table: customer@primary
+│           │ equality: (crdb_region_eq, h_c_w_id, h_c_d_id, h_c_id) = (crdb_region,c_w_id,c_d_id,c_id)
+│           │ equality cols are key
+│           │
+│           └── • render
+│               │ estimated row count: 2
+│               │
+│               └── • scan buffer
+│                     label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • lookup join (anti)
+            │ table: district@primary
+            │ equality: (crdb_region_eq, h_w_id, h_d_id) = (crdb_region,d_w_id,d_id)
+            │ equality cols are key
+            │
+            └── • render
+                │ estimated row count: 2
+                │
+                └── • scan buffer
+                      label: buffer 1

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
@@ -51,35 +51,32 @@ vectorized: true
 │   │ estimated row count: 0 (missing stats)
 │   │ into: t_child(id, pid)
 │   │
-│   └── • buffer
-│       │ columns: (column1, column2)
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             columns: (column1, column2)
-│             size: 2 columns, 1 row
-│             row 0, expr 0: 123
-│             row 0, expr 1: 321
+│   └── • values
+│         columns: (column1, column2)
+│         size: 2 columns, 1 row
+│         row 0, expr 0: 123
+│         row 0, expr 1: 321
 │
 └── • constraint-check
     │
     └── • error if rows
         │ columns: ()
         │
-        └── • lookup join (anti)
-            │ columns: (column2)
+        └── • cross join (anti)
+            │ columns: (pid)
             │ estimated row count: 0 (missing stats)
-            │ table: t_parent@t_parent_pkey
-            │ equality cols are key
-            │ lookup condition: ((column2 = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
             │
-            └── • project
-                │ columns: (column2)
-                │ estimated row count: 1
-                │
-                └── • scan buffer
-                      columns: (column1, column2)
-                      label: buffer 1
+            ├── • values
+            │     columns: (pid)
+            │     size: 1 column, 1 row
+            │     row 0, expr 0: 321
+            │
+            └── • scan
+                  columns: (id)
+                  estimated row count: 1 (missing stats)
+                  table: t_parent@t_parent_pkey
+                  spans: /"new york"/10/321/0 /"seattle"/10/321/0
+                  parallel
 
 # TODO (mgartner): there is a lookup join with lookup condition checking every
 # single shard. This is unnecessary and could be improved by having the shard
@@ -98,17 +95,13 @@ vectorized: true
 │   │ estimated row count: 0 (missing stats)
 │   │ into: t_child_partitioned(id, pid, part)
 │   │
-│   └── • buffer
-│       │ columns: (column1, column2, column3, check1)
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             columns: (column1, column2, column3, check1)
-│             size: 4 columns, 1 row
-│             row 0, expr 0: 123
-│             row 0, expr 1: 321
-│             row 0, expr 2: 'seattle'
-│             row 0, expr 3: true
+│   └── • values
+│         columns: (column1, column2, column3, check1)
+│         size: 4 columns, 1 row
+│         row 0, expr 0: 123
+│         row 0, expr 1: 321
+│         row 0, expr 2: 'seattle'
+│         row 0, expr 3: true
 │
 ├── • constraint-check
 │   │
@@ -116,43 +109,45 @@ vectorized: true
 │       │ columns: ()
 │       │
 │       └── • project
-│           │ columns: (column1)
-│           │ estimated row count: 0 (missing stats)
+│           │ columns: (id)
+│           │ estimated row count: 1 (missing stats)
 │           │
-│           └── • lookup join (semi)
-│               │ columns: (column1, column3)
-│               │ estimated row count: 0 (missing stats)
-│               │ table: t_child_partitioned@t_child_partitioned_pkey
-│               │ lookup condition: (column1 = id) AND (part IN ('new york', 'seattle'))
-│               │ pred: column3 != part
+│           └── • cross join (inner)
+│               │ columns: (id, id, part)
+│               │ estimated row count: 1 (missing stats)
 │               │
-│               └── • project
-│                   │ columns: (column1, column3)
-│                   │ estimated row count: 1
-│                   │
-│                   └── • scan buffer
-│                         columns: (column1, column2, column3, check1)
-│                         label: buffer 1
+│               ├── • values
+│               │     columns: (id)
+│               │     size: 1 column, 1 row
+│               │     row 0, expr 0: 123
+│               │
+│               └── • scan
+│                     columns: (id, part)
+│                     estimated row count: 1 (missing stats)
+│                     table: t_child_partitioned@t_child_partitioned_pkey
+│                     spans: /"new york"/123/0
+│                     limit: 1
 │
 └── • constraint-check
     │
     └── • error if rows
         │ columns: ()
         │
-        └── • lookup join (anti)
-            │ columns: (column2)
+        └── • cross join (anti)
+            │ columns: (pid)
             │ estimated row count: 0 (missing stats)
-            │ table: t_parent@t_parent_pkey
-            │ equality cols are key
-            │ lookup condition: ((column2 = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
             │
-            └── • project
-                │ columns: (column2)
-                │ estimated row count: 1
-                │
-                └── • scan buffer
-                      columns: (column1, column2, column3, check1)
-                      label: buffer 1
+            ├── • values
+            │     columns: (pid)
+            │     size: 1 column, 1 row
+            │     row 0, expr 0: 321
+            │
+            └── • scan
+                  columns: (id)
+                  estimated row count: 1 (missing stats)
+                  table: t_parent@t_parent_pkey
+                  spans: /"new york"/10/321/0 /"seattle"/10/321/0
+                  parallel
 
 subtest test_uniqueness_check_uuid
 
@@ -350,18 +345,14 @@ vectorized: true
 │   │ estimated row count: 0 (missing stats)
 │   │ into: t_unique_hash_pk(crdb_internal_id_shard_16, id, part)
 │   │
-│   └── • buffer
-│       │ columns: (crdb_internal_id_shard_16_comp, column1, column2, check1, check2)
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             columns: (crdb_internal_id_shard_16_comp, column1, column2, check1, check2)
-│             size: 5 columns, 1 row
-│             row 0, expr 0: 4321
-│             row 0, expr 1: 'seattle'
-│             row 0, expr 2: 9
-│             row 0, expr 3: true
-│             row 0, expr 4: true
+│   └── • values
+│         columns: (crdb_internal_id_shard_16_comp, column1, column2, check1, check2)
+│         size: 5 columns, 1 row
+│         row 0, expr 0: 4321
+│         row 0, expr 1: 'seattle'
+│         row 0, expr 2: 9
+│         row 0, expr 3: true
+│         row 0, expr 4: true
 │
 └── • constraint-check
     │
@@ -369,23 +360,43 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (column1)
-            │ estimated row count: 0 (missing stats)
+            │ columns: (id)
+            │ estimated row count: 1 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (crdb_internal_id_shard_16_comp, column1, column2)
-                │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
-                │ lookup condition: ((column1 = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                │ pred: (crdb_internal_id_shard_16_comp != crdb_internal_id_shard_16) OR (column2 != part)
+            └── • cross join (inner)
+                │ columns: (id, crdb_internal_id_shard_16, id, part)
+                │ estimated row count: 1 (missing stats)
                 │
-                └── • project
-                    │ columns: (crdb_internal_id_shard_16_comp, column1, column2)
-                    │ estimated row count: 1
+                ├── • values
+                │     columns: (id)
+                │     size: 1 column, 1 row
+                │     row 0, expr 0: 4321
+                │
+                └── • limit
+                    │ columns: (crdb_internal_id_shard_16, id, part)
+                    │ estimated row count: 1 (missing stats)
+                    │ count: 1
                     │
-                    └── • scan buffer
-                          columns: (crdb_internal_id_shard_16_comp, column1, column2, check1, check2)
-                          label: buffer 1
+                    └── • distinct
+                        │ columns: (crdb_internal_id_shard_16, id, part)
+                        │ estimated row count: 7 (missing stats)
+                        │ distinct on: id, part
+                        │
+                        └── • union all
+                            │ columns: (crdb_internal_id_shard_16, id, part)
+                            │ estimated row count: 2 (missing stats)
+                            │
+                            ├── • scan
+                            │     columns: (crdb_internal_id_shard_16, id, part)
+                            │     estimated row count: 1 (missing stats)
+                            │     table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                            │     spans
+                            │
+                            └── • scan
+                                  columns: (crdb_internal_id_shard_16, id, part)
+                                  estimated row count: 1 (missing stats)
+                                  table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                                  spans: /"new york"/9/4321/0
 
 # TODO (mgartner): there is a lookup join with lookup condition checking every
 # single shard. This is unnecessary and could be improved by having the shard
@@ -950,19 +961,15 @@ vectorized: true
 │   │ estimated row count: 0 (missing stats)
 │   │ into: t_unique_hash_sec_key(id, email, part, crdb_internal_email_shard_16)
 │   │
-│   └── • buffer
-│       │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, check1, check2)
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, check1, check2)
-│             size: 6 columns, 1 row
-│             row 0, expr 0: 4321
-│             row 0, expr 1: 'some_email'
-│             row 0, expr 2: 'seattle'
-│             row 0, expr 3: 13
-│             row 0, expr 4: true
-│             row 0, expr 5: true
+│   └── • values
+│         columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, check1, check2)
+│         size: 6 columns, 1 row
+│         row 0, expr 0: 4321
+│         row 0, expr 1: 'some_email'
+│         row 0, expr 2: 'seattle'
+│         row 0, expr 3: 13
+│         row 0, expr 4: true
+│         row 0, expr 5: true
 │
 ├── • constraint-check
 │   │
@@ -970,23 +977,24 @@ vectorized: true
 │       │ columns: ()
 │       │
 │       └── • project
-│           │ columns: (column1)
-│           │ estimated row count: 0 (missing stats)
+│           │ columns: (id)
+│           │ estimated row count: 1 (missing stats)
 │           │
-│           └── • lookup join (semi)
-│               │ columns: (column1, column3)
-│               │ estimated row count: 0 (missing stats)
-│               │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-│               │ lookup condition: (column1 = id) AND (part IN ('new york', 'seattle'))
-│               │ pred: column3 != part
+│           └── • cross join (inner)
+│               │ columns: (id, id, part)
+│               │ estimated row count: 1 (missing stats)
 │               │
-│               └── • project
-│                   │ columns: (column1, column3)
-│                   │ estimated row count: 1
-│                   │
-│                   └── • scan buffer
-│                         columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, check1, check2)
-│                         label: buffer 1
+│               ├── • values
+│               │     columns: (id)
+│               │     size: 1 column, 1 row
+│               │     row 0, expr 0: 4321
+│               │
+│               └── • scan
+│                     columns: (id, part)
+│                     estimated row count: 1 (missing stats)
+│                     table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+│                     spans: /"new york"/4321/0
+│                     limit: 1
 │
 └── • constraint-check
     │
@@ -994,23 +1002,49 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (column2)
-            │ estimated row count: 0 (missing stats)
+            │ columns: (email)
+            │ estimated row count: 1 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (column1, column2, column3)
-                │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
-                │ lookup condition: ((column2 = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                │ pred: (column1 != id) OR (column3 != part)
+            └── • cross join (inner)
+                │ columns: (email, id, email, part)
+                │ estimated row count: 1 (missing stats)
                 │
-                └── • project
-                    │ columns: (column1, column2, column3)
-                    │ estimated row count: 1
+                ├── • values
+                │     columns: (email)
+                │     size: 1 column, 1 row
+                │     row 0, expr 0: 'some_email'
+                │
+                └── • limit
+                    │ columns: (id, email, part)
+                    │ estimated row count: 1 (missing stats)
+                    │ count: 1
                     │
-                    └── • scan buffer
-                          columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, check1, check2)
-                          label: buffer 1
+                    └── • distinct
+                        │ columns: (id, email, part)
+                        │ estimated row count: 7 (missing stats)
+                        │ distinct on: id, part
+                        │
+                        └── • union all
+                            │ columns: (id, email, part)
+                            │ estimated row count: 2 (missing stats)
+                            │
+                            ├── • filter
+                            │   │ columns: (id, email, part)
+                            │   │ estimated row count: 1 (missing stats)
+                            │   │ filter: id != 4321
+                            │   │
+                            │   └── • scan
+                            │         columns: (id, email, part)
+                            │         estimated row count: 0 (missing stats)
+                            │         table: t_unique_hash_sec_key@idx_uniq_hash_email
+                            │         spans: /"new york"/13/"some_email"/0 /"seattle"/13/"some_email"/0
+                            │         parallel
+                            │
+                            └── • scan
+                                  columns: (id, email, part)
+                                  estimated row count: 1 (missing stats)
+                                  table: t_unique_hash_sec_key@idx_uniq_hash_email
+                                  spans: /"new york"/13/"some_email"/0
 
 # TODO (mgartner): there is a lookup join with lookup condition checking every
 # single shard. This is unnecessary and could be improved by having the shard
@@ -1141,42 +1175,38 @@ vectorized: true
 │   │ into: t_unique_hash_sec_key(id, email, part, crdb_internal_email_shard_16)
 │   │ arbiter constraints: idx_uniq_hash_email
 │   │
-│   └── • buffer
+│   └── • render
 │       │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, check1, check2)
-│       │ label: buffer 1
+│       │ estimated row count: 0 (missing stats)
+│       │ render check1: column3 IN ('new york', 'seattle')
+│       │ render check2: crdb_internal_email_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+│       │ render column1: column1
+│       │ render column2: column2
+│       │ render column3: column3
+│       │ render crdb_internal_email_shard_16_comp: crdb_internal_email_shard_16_comp
 │       │
-│       └── • render
-│           │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, check1, check2)
+│       └── • cross join (anti)
+│           │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp)
 │           │ estimated row count: 0 (missing stats)
-│           │ render check1: column3 IN ('new york', 'seattle')
-│           │ render check2: crdb_internal_email_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
-│           │ render column1: column1
-│           │ render column2: column2
-│           │ render column3: column3
-│           │ render crdb_internal_email_shard_16_comp: crdb_internal_email_shard_16_comp
 │           │
-│           └── • cross join (anti)
-│               │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp)
-│               │ estimated row count: 0 (missing stats)
+│           ├── • values
+│           │     columns: (column1, column2, column3, crdb_internal_email_shard_16_comp)
+│           │     size: 4 columns, 1 row
+│           │     row 0, expr 0: 4321
+│           │     row 0, expr 1: 'some_email'
+│           │     row 0, expr 2: 'seattle'
+│           │     row 0, expr 3: 13
+│           │
+│           └── • project
+│               │ columns: ()
+│               │ estimated row count: 1 (missing stats)
 │               │
-│               ├── • values
-│               │     columns: (column1, column2, column3, crdb_internal_email_shard_16_comp)
-│               │     size: 4 columns, 1 row
-│               │     row 0, expr 0: 4321
-│               │     row 0, expr 1: 'some_email'
-│               │     row 0, expr 2: 'seattle'
-│               │     row 0, expr 3: 13
-│               │
-│               └── • project
-│                   │ columns: ()
-│                   │ estimated row count: 1 (missing stats)
-│                   │
-│                   └── • scan
-│                         columns: (email)
-│                         estimated row count: 1 (missing stats)
-│                         table: t_unique_hash_sec_key@idx_uniq_hash_email
-│                         spans: /"new york"/13/"some_email"/0 /"seattle"/13/"some_email"/0
-│                         parallel
+│               └── • scan
+│                     columns: (email)
+│                     estimated row count: 1 (missing stats)
+│                     table: t_unique_hash_sec_key@idx_uniq_hash_email
+│                     spans: /"new york"/13/"some_email"/0 /"seattle"/13/"some_email"/0
+│                     parallel
 │
 └── • constraint-check
     │
@@ -1184,23 +1214,24 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (column1)
-            │ estimated row count: 0 (missing stats)
+            │ columns: (id)
+            │ estimated row count: 1 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (column1, column3)
-                │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-                │ lookup condition: (column1 = id) AND (part IN ('new york', 'seattle'))
-                │ pred: column3 != part
+            └── • cross join (inner)
+                │ columns: (id, id, part)
+                │ estimated row count: 1 (missing stats)
                 │
-                └── • project
-                    │ columns: (column1, column3)
-                    │ estimated row count: 0 (missing stats)
-                    │
-                    └── • scan buffer
-                          columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, check1, check2)
-                          label: buffer 1
+                ├── • values
+                │     columns: (id)
+                │     size: 1 column, 1 row
+                │     row 0, expr 0: 4321
+                │
+                └── • scan
+                      columns: (id, part)
+                      estimated row count: 1 (missing stats)
+                      table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+                      spans: /"new york"/4321/0
+                      limit: 1
 
 # TODO (mgartner): there is a lookup join with lookup condition checking every
 # single shard. This is unnecessary and could be improved by having the shard

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -260,44 +260,42 @@ vectorized: true
 ├── • insert
 │   │ into: fk_using_implicit_columns_against_t(pk, ref_t_pk, ref_t_c)
 │   │
-│   └── • buffer
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             size: 3 columns, 1 row
+│   └── • values
+│         size: 3 columns, 1 row
 │
 ├── • constraint-check
 │   │
 │   └── • error if rows
 │       │
-│       └── • hash join (right anti)
-│           │ equality: (pk) = (column2)
-│           │ left cols are key
-│           │ right cols are key
+│       └── • cross join (anti)
 │           │
-│           ├── • scan
-│           │     missing stats
-│           │     table: t@t_b_idx
-│           │     spans: FULL SCAN
+│           ├── • values
+│           │     size: 1 column, 1 row
 │           │
-│           └── • scan buffer
-│                 label: buffer 1
+│           └── • filter
+│               │ filter: pk = 1
+│               │
+│               └── • scan
+│                     missing stats
+│                     table: t@primary
+│                     spans: [ - /0/1] [/1/1 - /1/1] [/2/1 - ]
 │
 └── • constraint-check
     │
     └── • error if rows
         │
-        └── • hash join (right anti)
-            │ equality: (c) = (column3)
-            │ right cols are key
+        └── • cross join (anti)
             │
-            ├── • scan
-            │     missing stats
-            │     table: t@t_c_key
-            │     spans: FULL SCAN
+            ├── • values
+            │     size: 1 column, 1 row
             │
-            └── • scan buffer
-                  label: buffer 1
+            └── • filter
+                │ filter: c = 4
+                │
+                └── • scan
+                      missing stats
+                      table: t@t_c_key
+                      spans: [ - /2/4] [/3/4 - /3/4] [/4/4 - ]
 
 statement ok
 INSERT INTO fk_using_implicit_columns_against_t VALUES (1, 1, 4)
@@ -731,45 +729,48 @@ vectorized: true
 ├── • insert
 │   │ into: t(pk, pk2, partition_by, a, b, c, d)
 │   │
-│   └── • buffer
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             size: 8 columns, 1 row
+│   └── • values
+│         size: 8 columns, 1 row
 │
 ├── • constraint-check
 │   │
 │   └── • error if rows
 │       │
-│       └── • hash join (right semi)
-│           │ equality: (pk) = (column1)
-│           │ right cols are key
-│           │ pred: column3 != partition_by
+│       └── • cross join
 │           │
-│           ├── • scan
-│           │     missing stats
-│           │     table: t@t_a_idx
-│           │     spans: FULL SCAN
+│           ├── • values
+│           │     size: 1 column, 1 row
 │           │
-│           └── • scan buffer
-│                 label: buffer 1
+│           └── • limit
+│               │ count: 1
+│               │
+│               └── • filter
+│                   │ filter: pk = 1
+│                   │
+│                   └── • scan
+│                         missing stats
+│                         table: t@t_a_idx
+│                         spans: [ - /0] [/2 - ]
 │
 ├── • constraint-check
 │   │
 │   └── • error if rows
 │       │
-│       └── • hash join (right semi)
-│           │ equality: (b) = (column5)
-│           │ right cols are key
-│           │ pred: (column1 != pk) OR (column3 != partition_by)
+│       └── • cross join
 │           │
-│           ├── • scan
-│           │     missing stats
-│           │     table: t@t_b_key
-│           │     spans: FULL SCAN
+│           ├── • values
+│           │     size: 1 column, 1 row
 │           │
-│           └── • scan buffer
-│                 label: buffer 1
+│           └── • limit
+│               │ count: 1
+│               │
+│               └── • filter
+│                   │ filter: (b = 1) AND ((pk != 1) OR (partition_by != 1))
+│                   │
+│                   └── • scan
+│                         missing stats
+│                         table: t@t_b_key
+│                         spans: FULL SCAN
 │
 └── • constraint-check
     │

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
@@ -50,42 +50,43 @@ vectorized: true
 │   │ estimated row count: 0 (missing stats)
 │   │ into: t_child(id, pid)
 │   │
-│   └── • buffer
-│       │ columns: (column1, column2)
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             columns: (column1, column2)
-│             size: 2 columns, 1 row
-│             row 0, expr 0: 123
-│             row 0, expr 1: 321
+│   └── • values
+│         columns: (column1, column2)
+│         size: 2 columns, 1 row
+│         row 0, expr 0: 123
+│         row 0, expr 1: 321
 │
 └── • constraint-check
     │
     └── • error if rows
         │ columns: ()
         │
-        └── • lookup join (anti)
-            │ columns: (column2)
+        └── • cross join (anti)
+            │ columns: (pid)
             │ estimated row count: 0 (missing stats)
-            │ table: t_parent@t_parent_pkey
-            │ equality cols are key
-            │ lookup condition: ((column2 = id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
             │
-            └── • lookup join (anti)
-                │ columns: (column2)
+            ├── • values
+            │     columns: (pid)
+            │     size: 1 column, 1 row
+            │     row 0, expr 0: 321
+            │
+            └── • union all
+                │ columns: (id)
                 │ estimated row count: 1 (missing stats)
-                │ table: t_parent@t_parent_pkey
-                │ equality cols are key
-                │ lookup condition: ((column2 = id) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ limit: 1
                 │
-                └── • project
-                    │ columns: (column2)
-                    │ estimated row count: 1
-                    │
-                    └── • scan buffer
-                          columns: (column1, column2)
-                          label: buffer 1
+                ├── • scan
+                │     columns: (id)
+                │     estimated row count: 1 (missing stats)
+                │     table: t_parent@t_parent_pkey
+                │     spans: /"@"/10/321/0
+                │
+                └── • scan
+                      columns: (id)
+                      estimated row count: 1 (missing stats)
+                      table: t_parent@t_parent_pkey
+                      spans: /"\x80"/10/321/0 /"\xc0"/10/321/0
+                      parallel
 
 # TODO (mgartner): there is a lookup join with lookup condition checking every
 # single shard. This is unnecessary and could be improved by having the shard
@@ -104,17 +105,13 @@ vectorized: true
 │   │ estimated row count: 0 (missing stats)
 │   │ into: t_child_regional(id, pid, crdb_region)
 │   │
-│   └── • buffer
-│       │ columns: (column1, column2, crdb_region_default, check1)
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             columns: (column1, column2, crdb_region_default, check1)
-│             size: 4 columns, 1 row
-│             row 0, expr 0: 123
-│             row 0, expr 1: 321
-│             row 0, expr 2: 'ap-southeast-2'
-│             row 0, expr 3: true
+│   └── • values
+│         columns: (column1, column2, crdb_region_default, check1)
+│         size: 4 columns, 1 row
+│         row 0, expr 0: 123
+│         row 0, expr 1: 321
+│         row 0, expr 2: 'ap-southeast-2'
+│         row 0, expr 3: true
 │
 ├── • constraint-check
 │   │
@@ -122,50 +119,56 @@ vectorized: true
 │       │ columns: ()
 │       │
 │       └── • project
-│           │ columns: (column1)
-│           │ estimated row count: 0 (missing stats)
+│           │ columns: (id)
+│           │ estimated row count: 1 (missing stats)
 │           │
-│           └── • lookup join (semi)
-│               │ columns: (column1, crdb_region_default)
-│               │ estimated row count: 0 (missing stats)
-│               │ table: t_child_regional@t_child_regional_pkey
-│               │ lookup condition: (column1 = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
-│               │ pred: crdb_region_default != crdb_region
+│           └── • cross join (inner)
+│               │ columns: (id, id, crdb_region)
+│               │ estimated row count: 1 (missing stats)
 │               │
-│               └── • project
-│                   │ columns: (column1, crdb_region_default)
-│                   │ estimated row count: 1
-│                   │
-│                   └── • scan buffer
-│                         columns: (column1, column2, crdb_region_default, check1)
-│                         label: buffer 1
+│               ├── • values
+│               │     columns: (id)
+│               │     size: 1 column, 1 row
+│               │     row 0, expr 0: 123
+│               │
+│               └── • scan
+│                     columns: (id, crdb_region)
+│                     estimated row count: 1 (missing stats)
+│                     table: t_child_regional@t_child_regional_pkey
+│                     spans: /"\x80"/123/0 /"\xc0"/123/0
+│                     limit: 1
 │
 └── • constraint-check
     │
     └── • error if rows
         │ columns: ()
         │
-        └── • lookup join (anti)
-            │ columns: (column2)
+        └── • cross join (anti)
+            │ columns: (pid)
             │ estimated row count: 0 (missing stats)
-            │ table: t_parent@t_parent_pkey
-            │ equality cols are key
-            │ lookup condition: ((column2 = id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
             │
-            └── • lookup join (anti)
-                │ columns: (column2)
+            ├── • values
+            │     columns: (pid)
+            │     size: 1 column, 1 row
+            │     row 0, expr 0: 321
+            │
+            └── • union all
+                │ columns: (id)
                 │ estimated row count: 1 (missing stats)
-                │ table: t_parent@t_parent_pkey
-                │ equality cols are key
-                │ lookup condition: ((column2 = id) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ limit: 1
                 │
-                └── • project
-                    │ columns: (column2)
-                    │ estimated row count: 1
-                    │
-                    └── • scan buffer
-                          columns: (column1, column2, crdb_region_default, check1)
-                          label: buffer 1
+                ├── • scan
+                │     columns: (id)
+                │     estimated row count: 1 (missing stats)
+                │     table: t_parent@t_parent_pkey
+                │     spans: /"@"/10/321/0
+                │
+                └── • scan
+                      columns: (id)
+                      estimated row count: 1 (missing stats)
+                      table: t_parent@t_parent_pkey
+                      spans: /"\x80"/10/321/0 /"\xc0"/10/321/0
+                      parallel
 
 subtest test_uniqueness_check_uuid
 
@@ -366,18 +369,14 @@ vectorized: true
 │   │ estimated row count: 0 (missing stats)
 │   │ into: t_unique_hash_pk(crdb_internal_id_shard_16, id, crdb_region)
 │   │
-│   └── • buffer
-│       │ columns: (crdb_internal_id_shard_16_comp, column1, crdb_region_default, check1, check2)
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             columns: (crdb_internal_id_shard_16_comp, column1, crdb_region_default, check1, check2)
-│             size: 5 columns, 1 row
-│             row 0, expr 0: 4321
-│             row 0, expr 1: 'ap-southeast-2'
-│             row 0, expr 2: 9
-│             row 0, expr 3: true
-│             row 0, expr 4: true
+│   └── • values
+│         columns: (crdb_internal_id_shard_16_comp, column1, crdb_region_default, check1, check2)
+│         size: 5 columns, 1 row
+│         row 0, expr 0: 4321
+│         row 0, expr 1: 'ap-southeast-2'
+│         row 0, expr 2: 9
+│         row 0, expr 3: true
+│         row 0, expr 4: true
 │
 └── • constraint-check
     │
@@ -385,23 +384,44 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (column1)
-            │ estimated row count: 0 (missing stats)
+            │ columns: (id)
+            │ estimated row count: 1 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (crdb_internal_id_shard_16_comp, column1, crdb_region_default)
-                │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
-                │ lookup condition: ((column1 = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                │ pred: (crdb_internal_id_shard_16_comp != crdb_internal_id_shard_16) OR (crdb_region_default != crdb_region)
+            └── • cross join (inner)
+                │ columns: (id, crdb_internal_id_shard_16, id, crdb_region)
+                │ estimated row count: 1 (missing stats)
                 │
-                └── • project
-                    │ columns: (crdb_internal_id_shard_16_comp, column1, crdb_region_default)
-                    │ estimated row count: 1
+                ├── • values
+                │     columns: (id)
+                │     size: 1 column, 1 row
+                │     row 0, expr 0: 4321
+                │
+                └── • limit
+                    │ columns: (crdb_internal_id_shard_16, id, crdb_region)
+                    │ estimated row count: 1 (missing stats)
+                    │ count: 1
                     │
-                    └── • scan buffer
-                          columns: (crdb_internal_id_shard_16_comp, column1, crdb_region_default, check1, check2)
-                          label: buffer 1
+                    └── • filter
+                        │ columns: (crdb_internal_id_shard_16, id, crdb_region)
+                        │ estimated row count: 7 (missing stats)
+                        │ filter: (crdb_internal_id_shard_16 != 9) OR (crdb_region != 'ap-southeast-2')
+                        │
+                        └── • union all
+                            │ columns: (crdb_internal_id_shard_16, id, crdb_region)
+                            │ estimated row count: 1 (missing stats)
+                            │ limit: 3
+                            │
+                            ├── • scan
+                            │     columns: (crdb_internal_id_shard_16, id, crdb_region)
+                            │     estimated row count: 1 (missing stats)
+                            │     table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                            │     spans: /"@"/9/4321/0
+                            │
+                            └── • scan
+                                  columns: (crdb_internal_id_shard_16, id, crdb_region)
+                                  estimated row count: 1 (missing stats)
+                                  table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                                  spans: /"\x80"/9/4321/0 /"\xc0"/9/4321/0
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id) VALUES (4321) ON CONFLICT DO NOTHING;
@@ -1009,19 +1029,15 @@ vectorized: true
 │   │ estimated row count: 0 (missing stats)
 │   │ into: t_unique_hash_sec_key(id, email, crdb_region, crdb_internal_email_shard_16)
 │   │
-│   └── • buffer
-│       │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, check1, check2)
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, check1, check2)
-│             size: 6 columns, 1 row
-│             row 0, expr 0: 4321
-│             row 0, expr 1: 'some_email'
-│             row 0, expr 2: 'ap-southeast-2'
-│             row 0, expr 3: 13
-│             row 0, expr 4: true
-│             row 0, expr 5: true
+│   └── • values
+│         columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, check1, check2)
+│         size: 6 columns, 1 row
+│         row 0, expr 0: 4321
+│         row 0, expr 1: 'some_email'
+│         row 0, expr 2: 'ap-southeast-2'
+│         row 0, expr 3: 13
+│         row 0, expr 4: true
+│         row 0, expr 5: true
 │
 ├── • constraint-check
 │   │
@@ -1029,23 +1045,24 @@ vectorized: true
 │       │ columns: ()
 │       │
 │       └── • project
-│           │ columns: (column1)
-│           │ estimated row count: 0 (missing stats)
+│           │ columns: (id)
+│           │ estimated row count: 1 (missing stats)
 │           │
-│           └── • lookup join (semi)
-│               │ columns: (column1, crdb_region_default)
-│               │ estimated row count: 0 (missing stats)
-│               │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-│               │ lookup condition: (column1 = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
-│               │ pred: crdb_region_default != crdb_region
+│           └── • cross join (inner)
+│               │ columns: (id, id, crdb_region)
+│               │ estimated row count: 1 (missing stats)
 │               │
-│               └── • project
-│                   │ columns: (column1, crdb_region_default)
-│                   │ estimated row count: 1
-│                   │
-│                   └── • scan buffer
-│                         columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, check1, check2)
-│                         label: buffer 1
+│               ├── • values
+│               │     columns: (id)
+│               │     size: 1 column, 1 row
+│               │     row 0, expr 0: 4321
+│               │
+│               └── • scan
+│                     columns: (id, crdb_region)
+│                     estimated row count: 1 (missing stats)
+│                     table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+│                     spans: /"\x80"/4321/0 /"\xc0"/4321/0
+│                     limit: 1
 │
 └── • constraint-check
     │
@@ -1053,23 +1070,60 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (column2)
-            │ estimated row count: 0 (missing stats)
+            │ columns: (email)
+            │ estimated row count: 1 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (column1, column2, crdb_region_default)
-                │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
-                │ lookup condition: ((column2 = email) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                │ pred: (column1 != id) OR (crdb_region_default != crdb_region)
+            └── • cross join (inner)
+                │ columns: (email, id, email, crdb_region)
+                │ estimated row count: 1 (missing stats)
                 │
-                └── • project
-                    │ columns: (column1, column2, crdb_region_default)
-                    │ estimated row count: 1
+                ├── • values
+                │     columns: (email)
+                │     size: 1 column, 1 row
+                │     row 0, expr 0: 'some_email'
+                │
+                └── • limit
+                    │ columns: (id, email, crdb_region)
+                    │ estimated row count: 1 (missing stats)
+                    │ count: 1
                     │
-                    └── • scan buffer
-                          columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, check1, check2)
-                          label: buffer 1
+                    └── • distinct
+                        │ columns: (id, email, crdb_region)
+                        │ estimated row count: 7 (missing stats)
+                        │ distinct on: id, crdb_region
+                        │
+                        └── • union all
+                            │ columns: (id, email, crdb_region)
+                            │ estimated row count: 2 (missing stats)
+                            │
+                            ├── • filter
+                            │   │ columns: (id, email, crdb_region)
+                            │   │ estimated row count: 1 (missing stats)
+                            │   │ filter: id != 4321
+                            │   │
+                            │   └── • union all
+                            │       │ columns: (id, email, crdb_region)
+                            │       │ estimated row count: 1 (missing stats)
+                            │       │ limit: 1
+                            │       │
+                            │       ├── • scan
+                            │       │     columns: (id, email, crdb_region)
+                            │       │     estimated row count: 1 (missing stats)
+                            │       │     table: t_unique_hash_sec_key@idx_uniq_hash_email
+                            │       │     spans: /"@"/13/"some_email"/0
+                            │       │
+                            │       └── • scan
+                            │             columns: (id, email, crdb_region)
+                            │             estimated row count: 1 (missing stats)
+                            │             table: t_unique_hash_sec_key@idx_uniq_hash_email
+                            │             spans: /"\x80"/13/"some_email"/0 /"\xc0"/13/"some_email"/0
+                            │             parallel
+                            │
+                            └── • scan
+                                  columns: (id, email, crdb_region)
+                                  estimated row count: 1 (missing stats)
+                                  table: t_unique_hash_sec_key@idx_uniq_hash_email
+                                  spans: /"\x80"/13/"some_email"/0 /"\xc0"/13/"some_email"/0
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email') ON CONFLICT DO NOTHING;
@@ -1213,53 +1267,49 @@ vectorized: true
 │   │ into: t_unique_hash_sec_key(id, email, crdb_region, crdb_internal_email_shard_16)
 │   │ arbiter constraints: idx_uniq_hash_email
 │   │
-│   └── • buffer
+│   └── • render
 │       │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, check1, check2)
-│       │ label: buffer 1
+│       │ estimated row count: 0 (missing stats)
+│       │ render check1: crdb_internal_email_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+│       │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
+│       │ render column1: column1
+│       │ render column2: column2
+│       │ render crdb_region_default: crdb_region_default
+│       │ render crdb_internal_email_shard_16_comp: crdb_internal_email_shard_16_comp
 │       │
-│       └── • render
-│           │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, check1, check2)
+│       └── • cross join (anti)
+│           │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
 │           │ estimated row count: 0 (missing stats)
-│           │ render check1: crdb_internal_email_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
-│           │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
-│           │ render column1: column1
-│           │ render column2: column2
-│           │ render crdb_region_default: crdb_region_default
-│           │ render crdb_internal_email_shard_16_comp: crdb_internal_email_shard_16_comp
 │           │
-│           └── • cross join (anti)
-│               │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
-│               │ estimated row count: 0 (missing stats)
+│           ├── • values
+│           │     columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
+│           │     size: 4 columns, 1 row
+│           │     row 0, expr 0: 4321
+│           │     row 0, expr 1: 'some_email'
+│           │     row 0, expr 2: 'ap-southeast-2'
+│           │     row 0, expr 3: 13
+│           │
+│           └── • project
+│               │ columns: ()
+│               │ estimated row count: 1 (missing stats)
 │               │
-│               ├── • values
-│               │     columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
-│               │     size: 4 columns, 1 row
-│               │     row 0, expr 0: 4321
-│               │     row 0, expr 1: 'some_email'
-│               │     row 0, expr 2: 'ap-southeast-2'
-│               │     row 0, expr 3: 13
-│               │
-│               └── • project
-│                   │ columns: ()
+│               └── • union all
+│                   │ columns: (email)
 │                   │ estimated row count: 1 (missing stats)
+│                   │ limit: 1
 │                   │
-│                   └── • union all
-│                       │ columns: (email)
-│                       │ estimated row count: 1 (missing stats)
-│                       │ limit: 1
-│                       │
-│                       ├── • scan
-│                       │     columns: (email)
-│                       │     estimated row count: 1 (missing stats)
-│                       │     table: t_unique_hash_sec_key@idx_uniq_hash_email
-│                       │     spans: /"@"/13/"some_email"/0
-│                       │
-│                       └── • scan
-│                             columns: (email)
-│                             estimated row count: 1 (missing stats)
-│                             table: t_unique_hash_sec_key@idx_uniq_hash_email
-│                             spans: /"\x80"/13/"some_email"/0 /"\xc0"/13/"some_email"/0
-│                             parallel
+│                   ├── • scan
+│                   │     columns: (email)
+│                   │     estimated row count: 1 (missing stats)
+│                   │     table: t_unique_hash_sec_key@idx_uniq_hash_email
+│                   │     spans: /"@"/13/"some_email"/0
+│                   │
+│                   └── • scan
+│                         columns: (email)
+│                         estimated row count: 1 (missing stats)
+│                         table: t_unique_hash_sec_key@idx_uniq_hash_email
+│                         spans: /"\x80"/13/"some_email"/0 /"\xc0"/13/"some_email"/0
+│                         parallel
 │
 └── • constraint-check
     │
@@ -1267,23 +1317,24 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (column1)
-            │ estimated row count: 0 (missing stats)
+            │ columns: (id)
+            │ estimated row count: 1 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (column1, crdb_region_default)
-                │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-                │ lookup condition: (column1 = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
-                │ pred: crdb_region_default != crdb_region
+            └── • cross join (inner)
+                │ columns: (id, id, crdb_region)
+                │ estimated row count: 1 (missing stats)
                 │
-                └── • project
-                    │ columns: (column1, crdb_region_default)
-                    │ estimated row count: 0 (missing stats)
-                    │
-                    └── • scan buffer
-                          columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, check1, check2)
-                          label: buffer 1
+                ├── • values
+                │     columns: (id)
+                │     size: 1 column, 1 row
+                │     row 0, expr 0: 4321
+                │
+                └── • scan
+                      columns: (id, crdb_region)
+                      estimated row count: 1 (missing stats)
+                      table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+                      spans: /"\x80"/4321/0 /"\xc0"/4321/0
+                      limit: 1
 
 # TODO (mgartner): there is a lookup join with lookup condition checking every
 # single shard. This is unnecessary and could be improved by having the shard

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -1096,40 +1096,45 @@ SELECT * FROM [EXPLAIN INSERT INTO child VALUES (1, 1)] OFFSET 2
 ├── • insert
 │   │ into: child(c_id, c_p_id, crdb_region)
 │   │
-│   └── • buffer
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             size: 4 columns, 1 row
+│   └── • values
+│         size: 4 columns, 1 row
 │
 ├── • constraint-check
 │   │
 │   └── • error if rows
 │       │
-│       └── • lookup join (semi)
-│           │ table: child@child_pkey
-│           │ lookup condition: (column1 = c_id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
-│           │ pred: crdb_region_default != crdb_region
+│       └── • cross join
 │           │
-│           └── • scan buffer
-│                 label: buffer 1
+│           ├── • values
+│           │     size: 1 column, 1 row
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: child@child_pkey
+│                 spans: [/'ca-central-1'/1 - /'ca-central-1'/1] [/'us-east-1'/1 - /'us-east-1'/1]
+│                 limit: 1
 │
 └── • constraint-check
     │
     └── • error if rows
         │
-        └── • lookup join (anti)
-            │ table: parent@parent_pkey
-            │ equality cols are key
-            │ lookup condition: (column2 = p_id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))
+        └── • cross join (anti)
             │
-            └── • lookup join (anti)
-                │ table: parent@parent_pkey
-                │ equality cols are key
-                │ lookup condition: (column2 = p_id) AND (crdb_region = 'ap-southeast-2')
+            ├── • values
+            │     size: 1 column, 1 row
+            │
+            └── • union all
+                │ limit: 1
                 │
-                └── • scan buffer
-                      label: buffer 1
+                ├── • scan
+                │     missing stats
+                │     table: parent@parent_pkey
+                │     spans: [/'ap-southeast-2'/1 - /'ap-southeast-2'/1]
+                │
+                └── • scan
+                      missing stats
+                      table: parent@parent_pkey
+                      spans: [/'ca-central-1'/1 - /'ca-central-1'/1] [/'us-east-1'/1 - /'us-east-1'/1]
 
 query T
 SELECT * FROM [EXPLAIN UPSERT INTO child VALUES (1, 1)] OFFSET 2
@@ -1168,18 +1173,23 @@ SELECT * FROM [EXPLAIN UPSERT INTO child VALUES (1, 1)] OFFSET 2
     │
     └── • error if rows
         │
-        └── • lookup join (anti)
-            │ table: parent@parent_pkey
-            │ equality cols are key
-            │ lookup condition: (column2 = p_id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))
+        └── • cross join (anti)
             │
-            └── • lookup join (anti)
-                │ table: parent@parent_pkey
-                │ equality cols are key
-                │ lookup condition: (column2 = p_id) AND (crdb_region = 'ap-southeast-2')
+            ├── • values
+            │     size: 1 column, 1 row
+            │
+            └── • union all
+                │ limit: 1
                 │
-                └── • scan buffer
-                      label: buffer 1
+                ├── • scan
+                │     missing stats
+                │     table: parent@parent_pkey
+                │     spans: [/'ap-southeast-2'/1 - /'ap-southeast-2'/1]
+                │
+                └── • scan
+                      missing stats
+                      table: parent@parent_pkey
+                      spans: [/'ca-central-1'/1 - /'ca-central-1'/1] [/'us-east-1'/1 - /'us-east-1'/1]
 
 query T
 SELECT * FROM [EXPLAIN DELETE FROM parent WHERE p_id = 1] OFFSET 2
@@ -1217,6 +1227,53 @@ SELECT * FROM [EXPLAIN DELETE FROM parent WHERE p_id = 1] OFFSET 2
             │
             └── • scan buffer
                   label: buffer 1
+
+# An insert FK check only needs to search a single region when the region is a
+# computed column dependent on the FK column and a constant value is inserted.
+statement ok
+CREATE TABLE parent_comp (
+  pk INT PRIMARY KEY,
+  crdb_region crdb_internal_region AS (
+    CASE WHEN pk <= 10 THEN 'us-east-1' ELSE 'ap-southeast-2' END
+  ) STORED,
+  FAMILY (pk, crdb_region)
+) LOCALITY REGIONAL BY ROW;
+
+statement ok
+CREATE TABLE child_comp (
+  pk INT PRIMARY KEY,
+  p_pk INT REFERENCES parent_comp (pk),
+  crdb_region crdb_internal_region AS (
+    CASE WHEN pk <= 10 THEN 'us-east-1' ELSE 'ap-southeast-2' END
+  ) STORED,
+  FAMILY (pk, p_pk, crdb_region)
+) LOCALITY REGIONAL BY ROW;
+
+query T
+SELECT * FROM [EXPLAIN INSERT INTO child_comp VALUES (1, 1)] OFFSET 2
+----
+·
+• root
+│
+├── • insert
+│   │ into: child_comp(pk, p_pk, crdb_region)
+│   │
+│   └── • values
+│         size: 4 columns, 1 row
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • cross join (anti)
+            │
+            ├── • values
+            │     size: 1 column, 1 row
+            │
+            └── • scan
+                  missing stats
+                  table: parent_comp@parent_comp_pkey
+                  spans: [/'us-east-1'/1 - /'us-east-1'/1]
 
 # Tests creating a index and a unique constraint on a REGIONAL BY ROW table.
 statement ok
@@ -1477,63 +1534,106 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table (pk, pk2, a, b) VALUES 
 ├── • insert
 │   │ into: regional_by_row_table(pk, pk2, a, b, j, crdb_region)
 │   │
-│   └── • buffer
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             size: 8 columns, 1 row
+│   └── • values
+│         size: 8 columns, 1 row
 │
 ├── • constraint-check
 │   │
 │   └── • error if rows
 │       │
-│       └── • lookup join (semi)
-│           │ table: regional_by_row_table@regional_by_row_table_pkey
-│           │ lookup condition: (column1 = pk) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
-│           │ pred: crdb_region_default != crdb_region
+│       └── • cross join
 │           │
-│           └── • scan buffer
-│                 label: buffer 1
+│           ├── • values
+│           │     size: 1 column, 1 row
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: regional_by_row_table@regional_by_row_table_pkey
+│                 spans: [/'ca-central-1'/1 - /'ca-central-1'/1] [/'us-east-1'/1 - /'us-east-1'/1]
+│                 limit: 1
 │
 ├── • constraint-check
 │   │
 │   └── • error if rows
 │       │
-│       └── • lookup join (semi)
-│           │ table: regional_by_row_table@regional_by_row_table_b_key
-│           │ lookup condition: (column4 = b) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
-│           │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
+│       └── • cross join
 │           │
-│           └── • scan buffer
-│                 label: buffer 1
-│
-├── • constraint-check
-│   │
-│   └── • error if rows
-│       │
-│       └── • lookup join (semi)
-│           │ table: regional_by_row_table@new_idx
-│           │ lookup condition: ((column3 = a) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (b > 0)
-│           │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
+│           ├── • values
+│           │     size: 1 column, 1 row
 │           │
-│           └── • filter
-│               │ estimated row count: 1
-│               │ filter: column4 > 0
+│           └── • limit
+│               │ count: 1
 │               │
-│               └── • scan buffer
-│                     label: buffer 1
+│               └── • filter
+│                   │ filter: (pk != 1) OR (crdb_region != 'ap-southeast-2')
+│                   │
+│                   └── • union all
+│                       │ limit: 3
+│                       │
+│                       ├── • scan
+│                       │     missing stats
+│                       │     table: regional_by_row_table@regional_by_row_table_b_key
+│                       │     spans: [/'ap-southeast-2'/1 - /'ap-southeast-2'/1]
+│                       │
+│                       └── • scan
+│                             missing stats
+│                             table: regional_by_row_table@regional_by_row_table_b_key
+│                             spans: [/'ca-central-1'/1 - /'ca-central-1'/1] [/'us-east-1'/1 - /'us-east-1'/1]
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • lookup join
+│           │ table: regional_by_row_table@regional_by_row_table_pkey
+│           │ equality: (crdb_region, pk) = (crdb_region,pk)
+│           │ equality cols are key
+│           │
+│           └── • render
+│               │
+│               └── • limit
+│                   │ count: 1
+│                   │
+│                   └── • filter
+│                       │ filter: (pk != 1) OR (crdb_region != 'ap-southeast-2')
+│                       │
+│                       └── • union all
+│                           │ limit: 3
+│                           │
+│                           ├── • scan
+│                           │     missing stats
+│                           │     table: regional_by_row_table@uniq_idx (partial index)
+│                           │     spans: [/'ap-southeast-2'/1 - /'ap-southeast-2'/1]
+│                           │
+│                           └── • scan
+│                                 missing stats
+│                                 table: regional_by_row_table@uniq_idx (partial index)
+│                                 spans: [/'ca-central-1'/1 - /'ca-central-1'/1] [/'us-east-1'/1 - /'us-east-1'/1]
 │
 └── • constraint-check
     │
     └── • error if rows
         │
-        └── • lookup join (semi)
-            │ table: regional_by_row_table@new_idx
-            │ lookup condition: ((column3 = a) AND (column4 = b)) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
-            │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
+        └── • cross join (semi)
             │
-            └── • scan buffer
-                  label: buffer 1
+            ├── • values
+            │     size: 2 columns, 1 row
+            │
+            └── • filter
+                │ filter: (pk != 1) OR (crdb_region != 'ap-southeast-2')
+                │
+                └── • union all
+                    │ limit: 3
+                    │
+                    ├── • scan
+                    │     missing stats
+                    │     table: regional_by_row_table@new_idx
+                    │     spans: [/'ap-southeast-2'/1/1 - /'ap-southeast-2'/1/1]
+                    │
+                    └── • scan
+                          missing stats
+                          table: regional_by_row_table@new_idx
+                          spans: [/'ca-central-1'/1/1 - /'ca-central-1'/1/1] [/'us-east-1'/1/1 - /'us-east-1'/1/1]
 
 statement error pq: duplicate key value violates unique constraint "regional_by_row_table_b_key"\nDETAIL: Key \(b\)=\(3\) already exists\.
 INSERT INTO regional_by_row_table (crdb_region, pk, pk2, a, b) VALUES ('us-east-1', 2, 3, 2, 3)
@@ -1802,23 +1902,36 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_as (pk, a, b) VALUES (1
 ├── • insert
 │   │ into: regional_by_row_table_as(pk, a, b, crdb_region_col)
 │   │
-│   └── • buffer
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             size: 5 columns, 1 row
+│   └── • values
+│         size: 5 columns, 1 row
 │
 └── • constraint-check
     │
     └── • error if rows
         │
-        └── • lookup join (semi)
-            │ table: regional_by_row_table_as@regional_by_row_table_as_b_key
-            │ lookup condition: (column3 = b) AND (crdb_region_col IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
-            │ pred: (column1 != pk) OR (crdb_region_col_comp != crdb_region_col)
+        └── • cross join
             │
-            └── • scan buffer
-                  label: buffer 1
+            ├── • values
+            │     size: 1 column, 1 row
+            │
+            └── • limit
+                │ count: 1
+                │
+                └── • filter
+                    │ filter: (pk != 1) OR (crdb_region_col != 'us-east-1')
+                    │
+                    └── • union all
+                        │ limit: 3
+                        │
+                        ├── • scan
+                        │     missing stats
+                        │     table: regional_by_row_table_as@regional_by_row_table_as_b_key
+                        │     spans: [/'ap-southeast-2'/1 - /'ap-southeast-2'/1]
+                        │
+                        └── • scan
+                              missing stats
+                              table: regional_by_row_table_as@regional_by_row_table_as_b_key
+                              spans: [/'ca-central-1'/1 - /'ca-central-1'/1] [/'us-east-1'/1 - /'us-east-1'/1]
 
 statement error pq: duplicate key value violates unique constraint "regional_by_row_table_as_pkey"\nDETAIL: Key \(pk\)=\(1\) already exists\.
 INSERT INTO regional_by_row_table_as (pk, a, b) VALUES (1, 1, 1)
@@ -1862,61 +1975,69 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt (pk, a, b) VALUES 
 ├── • insert
 │   │ into: regional_by_row_table_virt(pk, a, b, v, crdb_region, crdb_internal_idx_expr)
 │   │
-│   └── • buffer
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             size: 7 columns, 1 row
+│   └── • values
+│         size: 7 columns, 1 row
 │
 ├── • constraint-check
 │   │
 │   └── • error if rows
 │       │
-│       └── • lookup join (semi)
-│           │ table: regional_by_row_table_virt@regional_by_row_table_virt_pkey
-│           │ lookup condition: (column1 = pk) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
-│           │ pred: crdb_region_default != crdb_region
+│       └── • cross join
 │           │
-│           └── • scan buffer
-│                 label: buffer 1
+│           ├── • values
+│           │     size: 1 column, 1 row
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: regional_by_row_table_virt@regional_by_row_table_virt_pkey
+│                 spans: [/'ca-central-1'/1 - /'ca-central-1'/1] [/'us-east-1'/1 - /'us-east-1'/1]
+│                 limit: 1
 │
 ├── • constraint-check
 │   │
 │   └── • error if rows
 │       │
-│       └── • lookup join (semi)
-│           │ table: regional_by_row_table_virt@regional_by_row_table_virt_v_key
-│           │ equality: (lookup_join_const_col_@34, v_comp) = (crdb_region,v)
-│           │ equality cols are key
-│           │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
+│       └── • cross join
 │           │
-│           └── • cross join
-│               │ estimated row count: 3
+│           ├── • values
+│           │     size: 1 column, 1 row
+│           │
+│           └── • limit
+│               │ count: 1
 │               │
-│               ├── • values
-│               │     size: 1 column, 3 rows
-│               │
-│               └── • scan buffer
-│                     label: buffer 1
+│               └── • filter
+│                   │ filter: ((a + b) = 2) AND ((pk != 1) OR (crdb_region != 'ap-southeast-2'))
+│                   │
+│                   └── • scan
+│                         missing stats
+│                         table: regional_by_row_table_virt@regional_by_row_table_virt_pkey
+│                         spans: [/'ap-southeast-2' - /'ap-southeast-2'] [/'ca-central-1' - /'us-east-1']
 │
 └── • constraint-check
     │
     └── • error if rows
         │
-        └── • lookup join (semi)
-            │ table: regional_by_row_table_virt@regional_by_row_table_virt_expr_key
-            │ equality: (lookup_join_const_col_@48, crdb_internal_idx_expr_comp) = (crdb_region,crdb_internal_idx_expr)
-            │ equality cols are key
-            │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
+        └── • cross join
             │
-            └── • cross join
-                │ estimated row count: 3
+            ├── • values
+            │     size: 1 column, 1 row
+            │
+            └── • limit
+                │ count: 1
                 │
-                ├── • values
-                │     size: 1 column, 3 rows
-                │
-                └── • scan buffer
-                      label: buffer 1
+                └── • filter
+                    │ filter: a = 1
+                    │
+                    └── • index join
+                        │ table: regional_by_row_table_virt@regional_by_row_table_virt_pkey
+                        │
+                        └── • filter
+                            │ filter: (pk != 1) OR (crdb_region != 'ap-southeast-2')
+                            │
+                            └── • scan
+                                  missing stats
+                                  table: regional_by_row_table_virt@regional_by_row_table_virt_expr_key
+                                  spans: [/'ap-southeast-2'/11 - /'ap-southeast-2'/11] [/'ca-central-1'/11 - /'ca-central-1'/11] [/'us-east-1'/11 - /'us-east-1'/11]
 
 query T
 SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table_virt (pk, a, b) VALUES (1, 1, 1)] OFFSET 2
@@ -2028,89 +2149,85 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt_partial (pk, a, b)
 ├── • insert
 │   │ into: regional_by_row_table_virt_partial(pk, a, b, v, crdb_region, crdb_internal_idx_expr)
 │   │
-│   └── • buffer
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             size: 9 columns, 1 row
+│   └── • values
+│         size: 9 columns, 1 row
 │
 ├── • constraint-check
 │   │
 │   └── • error if rows
 │       │
-│       └── • lookup join (semi)
+│       └── • cross join
+│           │
+│           ├── • values
+│           │     size: 1 column, 1 row
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: regional_by_row_table_virt_partial@regional_by_row_table_virt_partial_pkey
+│                 spans: [/'ca-central-1'/1 - /'ca-central-1'/1] [/'us-east-1'/1 - /'us-east-1'/1]
+│                 limit: 1
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • lookup join
 │           │ table: regional_by_row_table_virt_partial@regional_by_row_table_virt_partial_pkey
-│           │ lookup condition: (column1 = pk) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
-│           │ pred: crdb_region_default != crdb_region
+│           │ equality: (crdb_region, pk) = (crdb_region,pk)
+│           │ equality cols are key
 │           │
-│           └── • scan buffer
-│                 label: buffer 1
+│           └── • render
+│               │
+│               └── • limit
+│                   │ count: 1
+│                   │
+│                   └── • filter
+│                       │ filter: (pk != 1) OR (crdb_region != 'ap-southeast-2')
+│                       │
+│                       └── • scan
+│                             missing stats
+│                             table: regional_by_row_table_virt_partial@v_a_gt_0 (partial index)
+│                             spans: [/'ap-southeast-2'/2 - /'ap-southeast-2'/2] [/'ca-central-1'/2 - /'ca-central-1'/2] [/'us-east-1'/2 - /'us-east-1'/2]
 │
 ├── • constraint-check
 │   │
 │   └── • error if rows
 │       │
-│       └── • lookup join (semi)
-│           │ table: regional_by_row_table_virt_partial@v_a_gt_0 (partial index)
-│           │ equality: (lookup_join_const_col_@36, v_comp) = (crdb_region,v)
-│           │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
+│       └── • cross join
 │           │
-│           └── • cross join
-│               │ estimated row count: 3
-│               │
-│               ├── • values
-│               │     size: 1 column, 3 rows
+│           ├── • values
+│           │     size: 1 column, 1 row
+│           │
+│           └── • limit
+│               │ count: 1
 │               │
 │               └── • filter
-│                   │ estimated row count: 1
-│                   │ filter: column2 > 0
+│                   │ filter: ((a + b) = 2) AND ((pk != 1) OR (crdb_region != 'ap-southeast-2'))
 │                   │
-│                   └── • scan buffer
-│                         label: buffer 1
-│
-├── • constraint-check
-│   │
-│   └── • error if rows
-│       │
-│       └── • lookup join (semi)
-│           │ table: regional_by_row_table_virt_partial@v_v_gt_0 (partial index)
-│           │ equality: (lookup_join_const_col_@50, v_comp) = (crdb_region,v)
-│           │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
-│           │
-│           └── • cross join
-│               │ estimated row count: 3
-│               │
-│               ├── • values
-│               │     size: 1 column, 3 rows
-│               │
-│               └── • filter
-│                   │ estimated row count: 1
-│                   │ filter: v_comp > 0
-│                   │
-│                   └── • scan buffer
-│                         label: buffer 1
+│                   └── • scan
+│                         missing stats
+│                         table: regional_by_row_table_virt_partial@regional_by_row_table_virt_partial_pkey
+│                         spans: [/'ap-southeast-2' - /'ap-southeast-2'] [/'ca-central-1' - /'us-east-1']
 │
 └── • constraint-check
     │
     └── • error if rows
         │
-        └── • lookup join (semi)
-            │ table: regional_by_row_table_virt_partial@a_plus_10_v_gt_0 (partial index)
-            │ equality: (lookup_join_const_col_@64, crdb_internal_idx_expr_comp) = (crdb_region,crdb_internal_idx_expr)
-            │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
+        └── • cross join
             │
-            └── • cross join
-                │ estimated row count: 3
-                │
-                ├── • values
-                │     size: 1 column, 3 rows
+            ├── • values
+            │     size: 1 column, 1 row
+            │
+            └── • limit
+                │ count: 1
                 │
                 └── • filter
-                    │ estimated row count: 1
-                    │ filter: v_comp > 0
+                    │ filter: ((a = 1) AND (b > -1)) AND ((pk != 1) OR (crdb_region != 'ap-southeast-2'))
                     │
-                    └── • scan buffer
-                          label: buffer 1
+                    └── • scan
+                          missing stats
+                          table: regional_by_row_table_virt_partial@regional_by_row_table_virt_partial_pkey
+                          spans: [/'ap-southeast-2' - /'ap-southeast-2'] [/'ca-central-1' - /'us-east-1']
 
 query T
 SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table_virt_partial (pk, a, b) VALUES (1, 1, 1)] OFFSET 2

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -999,17 +999,36 @@ CREATE TABLE nonunique_idx_child (
   CONSTRAINT "fk" FOREIGN KEY (ref1, ref2) REFERENCES nonunique_idx_parent (k1, k2)
 )
 
+# TODO(mgartner/radu): This query should use the insert fast path. Inlining the
+# values removes the lookup join in the FK check  that the insert fast path
+# relies on.
 query T
 EXPLAIN INSERT INTO nonunique_idx_child VALUES (0, 1, 10)
 ----
 distribution: local
 vectorized: true
 ·
-• insert fast path
-  into: nonunique_idx_child(k, ref1, ref2)
-  auto commit
-  FK check: nonunique_idx_parent@nonunique_idx_parent_k2_idx
-  size: 3 columns, 1 row
+• root
+│
+├── • insert
+│   │ into: nonunique_idx_child(k, ref1, ref2)
+│   │
+│   └── • values
+│         size: 3 columns, 1 row
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • cross join (anti)
+            │
+            ├── • values
+            │     size: 2 columns, 1 row
+            │
+            └── • scan
+                  missing stats
+                  table: nonunique_idx_parent@nonunique_idx_parent_k2_idx
+                  spans: [/10/1 - /10/1]
 
 # Regression test for #46397: upserter was looking at the incorrect ordinal for
 # the check because of an extra input column used by the FK check.

--- a/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
@@ -1401,44 +1401,31 @@ vectorized: true
 │   │ estimated row count: 0 (missing stats)
 │   │ into: t_child_pk(id, pid)
 │   │
-│   └── • buffer
-│       │ columns: (column1, column2)
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             columns: (column1, column2)
-│             size: 2 columns, 1 row
-│             row 0, expr 0: 123
-│             row 0, expr 1: 321
+│   └── • values
+│         columns: (column1, column2)
+│         size: 2 columns, 1 row
+│         row 0, expr 0: 123
+│         row 0, expr 1: 321
 │
 └── • constraint-check
     │
     └── • error if rows
         │ columns: ()
         │
-        └── • project
+        └── • cross join (anti)
             │ columns: (pid)
             │ estimated row count: 0 (missing stats)
             │
-            └── • lookup join (anti)
-                │ columns: (crdb_internal_id_shard_16_eq, pid)
-                │ table: t_parent_pk@t_parent_pk_pkey
-                │ equality: (crdb_internal_id_shard_16_eq, pid) = (crdb_internal_id_shard_16,id)
-                │ equality cols are key
-                │
-                └── • render
-                    │ columns: (crdb_internal_id_shard_16_eq, pid)
-                    │ estimated row count: 1
-                    │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
-                    │ render pid: column2
-                    │
-                    └── • project
-                        │ columns: (column2)
-                        │ estimated row count: 1
-                        │
-                        └── • scan buffer
-                              columns: (column1, column2)
-                              label: buffer 1
+            ├── • values
+            │     columns: (pid)
+            │     size: 1 column, 1 row
+            │     row 0, expr 0: 321
+            │
+            └── • scan
+                  columns: (id)
+                  estimated row count: 1 (missing stats)
+                  table: t_parent_pk@t_parent_pk_pkey
+                  spans: /10/321/0
 
 statement ok
 CREATE TABLE t_parent_sec (
@@ -1471,41 +1458,28 @@ vectorized: true
 │   │ estimated row count: 0 (missing stats)
 │   │ into: t_child_sec(id, pid)
 │   │
-│   └── • buffer
-│       │ columns: (column1, column2)
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             columns: (column1, column2)
-│             size: 2 columns, 1 row
-│             row 0, expr 0: 123
-│             row 0, expr 1: 321
+│   └── • values
+│         columns: (column1, column2)
+│         size: 2 columns, 1 row
+│         row 0, expr 0: 123
+│         row 0, expr 1: 321
 │
 └── • constraint-check
     │
     └── • error if rows
         │ columns: ()
         │
-        └── • project
+        └── • cross join (anti)
             │ columns: (pid)
             │ estimated row count: 0 (missing stats)
             │
-            └── • lookup join (anti)
-                │ columns: (crdb_internal_real_id_shard_16_eq, pid)
-                │ table: t_parent_sec@idx_t_parent_sec_real_id
-                │ equality: (crdb_internal_real_id_shard_16_eq, pid) = (crdb_internal_real_id_shard_16,real_id)
-                │ equality cols are key
-                │
-                └── • render
-                    │ columns: (crdb_internal_real_id_shard_16_eq, pid)
-                    │ estimated row count: 1
-                    │ render crdb_internal_real_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
-                    │ render pid: column2
-                    │
-                    └── • project
-                        │ columns: (column2)
-                        │ estimated row count: 1
-                        │
-                        └── • scan buffer
-                              columns: (column1, column2)
-                              label: buffer 1
+            ├── • values
+            │     columns: (pid)
+            │     size: 1 column, 1 row
+            │     row 0, expr 0: 321
+            │
+            └── • scan
+                  columns: (real_id)
+                  estimated row count: 1 (missing stats)
+                  table: t_parent_sec@idx_t_parent_sec_real_id
+                  spans: /10/321/0

--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -630,19 +630,46 @@ statement ok
 CREATE TABLE t62270_parent (id INT PRIMARY KEY);
 CREATE TABLE t62270_child (c UUID DEFAULT (gen_random_uuid()), p INT REFERENCES t62270_parent (id));
 
+# TODO(mgartner/radu): This query should use the insert fast path. Inlining the
+# values removes the lookup join in the FK check  that the insert fast path
+# relies on.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t62270_child (p) VALUES (1)
 ----
 distribution: local
 vectorized: true
 ·
-• insert fast path
-  columns: ()
-  estimated row count: 0 (missing stats)
-  into: t62270_child(c, p, rowid)
-  auto commit
-  FK check: t62270_parent@t62270_parent_pkey
-  size: 3 columns, 1 row
-  row 0, expr 0: gen_random_uuid()
-  row 0, expr 1: 1
-  row 0, expr 2: unique_rowid()
+• root
+│ columns: ()
+│
+├── • insert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: t62270_child(c, p, rowid)
+│   │
+│   └── • values
+│         columns: (c_default, column1, rowid_default)
+│         size: 3 columns, 1 row
+│         row 0, expr 0: 1
+│         row 0, expr 1: gen_random_uuid()
+│         row 0, expr 2: unique_rowid()
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • cross join (anti)
+            │ columns: (p)
+            │ estimated row count: 0 (missing stats)
+            │
+            ├── • values
+            │     columns: (p)
+            │     size: 1 column, 1 row
+            │     row 0, expr 0: 1
+            │
+            └── • scan
+                  columns: (id)
+                  estimated row count: 1 (missing stats)
+                  table: t62270_parent@t62270_parent_pkey
+                  spans: /1/0

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -832,6 +832,52 @@ func (prj *ProjectExpr) InternalFDs() *props.FuncDepSet {
 	return &prj.internalFuncDeps
 }
 
+// FindInlinableConstants returns the set of input columns that are synthesized
+// constant value expressions: ConstOp, TrueOp, FalseOp, or NullOp. Constant
+// value expressions can often be inlined into referencing expressions. Only
+// Project and Values operators synthesize constant value expressions.
+func FindInlinableConstants(input RelExpr) opt.ColSet {
+	var cols opt.ColSet
+	if project, ok := input.(*ProjectExpr); ok {
+		for i := range project.Projections {
+			item := &project.Projections[i]
+			if opt.IsConstValueOp(item.Element) {
+				cols.Add(item.Col)
+			}
+		}
+	} else if values, ok := input.(*ValuesExpr); ok && len(values.Rows) == 1 {
+		tup := values.Rows[0].(*TupleExpr)
+		for i, scalar := range tup.Elems {
+			if opt.IsConstValueOp(scalar) {
+				cols.Add(values.Cols[i])
+			}
+		}
+	}
+	return cols
+}
+
+// ExtractColumnFromProjectOrValues searches a Project or Values input
+// expression for the column having the given id. It returns the expression for
+// that column.
+func ExtractColumnFromProjectOrValues(input RelExpr, col opt.ColumnID) opt.ScalarExpr {
+	if project, ok := input.(*ProjectExpr); ok {
+		for i := range project.Projections {
+			item := &project.Projections[i]
+			if item.Col == col {
+				return item.Element
+			}
+		}
+	} else if values, ok := input.(*ValuesExpr); ok && len(values.Rows) == 1 {
+		tup := values.Rows[0].(*TupleExpr)
+		for i, scalar := range tup.Elems {
+			if values.Cols[i] == col {
+				return scalar
+			}
+		}
+	}
+	panic(errors.AssertionFailedf("could not find column to extract"))
+}
+
 // ExprIsNeverNull makes a best-effort attempt to prove that the provided
 // scalar is always non-NULL, given the set of outer columns that are known
 // to be not null. This is particularly useful with check constraints.

--- a/pkg/sql/opt/norm/testdata/rules/with
+++ b/pkg/sql/opt/norm/testdata/rules/with
@@ -546,29 +546,28 @@ CREATE TABLE child (c INT PRIMARY KEY, p INT REFERENCES parent(p))
 norm format=show-all
 WITH cte AS (INSERT INTO child VALUES (1, 1) RETURNING c) SELECT c FROM cte UNION SELECT c+1 FROM cte
 ----
-with &2 (cte)
+with &1 (cte)
  ├── columns: c:14(int!null)
  ├── cardinality: [1 - 2]
  ├── volatile, mutations
  ├── stats: [rows=2, distinct(14)=2, null(14)=0, avgsize(14)=4]
- ├── cost: 1056.9075
+ ├── cost: 1054.45
  ├── key: (14)
  ├── insert t.public.child
  │    ├── columns: t.public.child.c:1(int!null)
  │    ├── insert-mapping:
  │    │    ├── column1:5 => t.public.child.c:1
  │    │    └── column2:6 => t.public.child.p:2
- │    ├── input binding: &1
  │    ├── cardinality: [1 - 1]
  │    ├── volatile, mutations
  │    ├── stats: [rows=1, distinct(1)=1, null(1)=0, avgsize(1)=4]
- │    ├── cost: 1056.7975
+ │    ├── cost: 1054.34
  │    ├── key: ()
  │    ├── fd: ()-->(1)
  │    ├── values
  │    │    ├── columns: column1:5(int!null) column2:6(int!null)
  │    │    ├── cardinality: [1 - 1]
- │    │    ├── stats: [rows=1, distinct(5)=1, null(5)=0, avgsize(5)=4, distinct(6)=1, null(6)=0, avgsize(6)=4]
+ │    │    ├── stats: [rows=1, distinct(5)=1, null(5)=0, avgsize(5)=4]
  │    │    ├── cost: 0.02
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(5,6)
@@ -578,39 +577,43 @@ with &2 (cte)
  │    │         └── const: 1 [type=int]
  │    └── f-k-checks
  │         └── f-k-checks-item: child(p) -> parent(p)
- │              └── anti-join (hash)
+ │              └── anti-join (cross)
  │                   ├── columns: p:7(int!null)
  │                   ├── cardinality: [0 - 1]
  │                   ├── stats: [rows=1e-10]
- │                   ├── cost: 1056.7675
+ │                   ├── cost: 1054.31
  │                   ├── key: ()
  │                   ├── fd: ()-->(7)
- │                   ├── cte-uses
- │                   │    └── &1: count=1 used-columns=(6)
- │                   ├── with-scan &1
+ │                   ├── prune: (7)
+ │                   ├── values
  │                   │    ├── columns: p:7(int!null)
- │                   │    ├── mapping:
- │                   │    │    └──  column2:6(int) => p:7(int)
  │                   │    ├── cardinality: [1 - 1]
- │                   │    ├── stats: [rows=1, distinct(7)=1, null(7)=0, avgsize(7)=4]
- │                   │    ├── cost: 0.01
+ │                   │    ├── stats: [rows=1]
+ │                   │    ├── cost: 0.02
  │                   │    ├── key: ()
  │                   │    ├── fd: ()-->(7)
  │                   │    ├── prune: (7)
- │                   │    └── cte-uses
- │                   │         └── &1: count=1 used-columns=(6)
- │                   ├── scan t.public.parent
+ │                   │    └── tuple [type=tuple{int}]
+ │                   │         └── const: 1 [type=int]
+ │                   ├── select
  │                   │    ├── columns: t.public.parent.p:8(int!null)
- │                   │    ├── stats: [rows=1000, distinct(8)=1000, null(8)=0, avgsize(8)=4]
- │                   │    ├── cost: 1044.22
- │                   │    ├── key: (8)
- │                   │    ├── prune: (8)
- │                   │    ├── interesting orderings: (+8)
- │                   │    └── unfiltered-cols: (8-10)
- │                   └── filters
- │                        └── eq [type=bool, outer=(7,8), constraints=(/7: (/NULL - ]; /8: (/NULL - ]), fd=(7)==(8), (8)==(7)]
- │                             ├── variable: p:7 [type=int]
- │                             └── variable: t.public.parent.p:8 [type=int]
+ │                   │    ├── cardinality: [0 - 1]
+ │                   │    ├── stats: [rows=1, distinct(8)=1, null(8)=0, avgsize(8)=4]
+ │                   │    ├── cost: 1054.24
+ │                   │    ├── key: ()
+ │                   │    ├── fd: ()-->(8)
+ │                   │    ├── scan t.public.parent
+ │                   │    │    ├── columns: t.public.parent.p:8(int!null)
+ │                   │    │    ├── stats: [rows=1000, distinct(8)=1000, null(8)=0, avgsize(8)=4]
+ │                   │    │    ├── cost: 1044.22
+ │                   │    │    ├── key: (8)
+ │                   │    │    ├── prune: (8)
+ │                   │    │    └── interesting orderings: (+8)
+ │                   │    └── filters
+ │                   │         └── eq [type=bool, outer=(8), constraints=(/8: [/1 - /1]; tight), fd=()-->(8)]
+ │                   │              ├── variable: t.public.parent.p:8 [type=int]
+ │                   │              └── const: 1 [type=int]
+ │                   └── filters (true)
  └── union
       ├── columns: c:14(int!null)
       ├── left columns: c:11(int)
@@ -620,7 +623,7 @@ with &2 (cte)
       ├── stats: [rows=2, distinct(14)=2, null(14)=0, avgsize(14)=4]
       ├── cost: 0.1
       ├── key: (14)
-      ├── with-scan &2 (cte)
+      ├── with-scan &1 (cte)
       │    ├── columns: c:11(int!null)
       │    ├── mapping:
       │    │    └──  t.public.child.c:1(int) => c:11(int)
@@ -639,7 +642,7 @@ with &2 (cte)
            ├── key: ()
            ├── fd: ()-->(13)
            ├── prune: (13)
-           ├── with-scan &2 (cte)
+           ├── with-scan &1 (cte)
            │    ├── columns: c:12(int!null)
            │    ├── mapping:
            │    │    └──  t.public.child.c:1(int) => c:12(int)

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -277,6 +277,10 @@ func (b *Builder) buildInsert(ins *tree.Insert, inScope *scope) (outScope *scope
 	// both cases, include columns undergoing mutations in the write-only state.
 	mb.addSynthesizedColsForInsert()
 
+	// Set insertExpr. This expression is used when building FK and uniqueness
+	// checks. See mutationBuilder.buildCheckInputScan.
+	mb.insertExpr = mb.outScope.expr
+
 	var returning tree.ReturningExprs
 	if resultsNeeded(ins.Returning) {
 		returning = *ins.Returning.(*tree.ReturningExprs)

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -60,6 +60,11 @@ type mutationBuilder struct {
 	// fetchScope contains the set of columns fetched from the target table.
 	fetchScope *scope
 
+	// insertExpr is the expression that produces the values which will be
+	// inserted into the target table. It is only populated for INSERT and
+	// UPSERT expressions.
+	insertExpr memo.RelExpr
+
 	// targetColList is an ordered list of IDs of the table columns into which
 	// values will be inserted, or which will be updated with new values. It is
 	// incrementally built as the mutation operator is built.
@@ -1303,27 +1308,28 @@ const (
 	checkInputScanFetchedVals
 )
 
-// buildCheckInputScan constructs a WithScan that iterates over the input to the
-// mutation operator. Used in expressions that generate rows for checking for FK
-// and uniqueness violations.
+// buildCheckInputScan constructs an expression that produces the new values of
+// rows during a mutation. It is used in expressions that generate rows for
+// checking for FK and uniqueness violations. It returns either a WithScan that
+// iterates over the input to the mutation operator, or a Values expression with
+// constant mutation values inlined.
 //
 // The WithScan expression will scan either the new values or the fetched values
 // for the given table ordinals (which correspond to FK or unique columns).
 //
-// Returns a scope containing the WithScan expression and the output columns
-// from the WithScan. The output columns map 1-to-1 to tabOrdinals. Also returns
-// the subset of these columns that can be assumed to be not null (either
-// because they are not null in the mutation input or because they are
+// Returns a scope containing the WithScan or Values expression and the output
+// columns from the WithScan. The output columns map 1-to-1 to tabOrdinals. Also
+// returns the subset of these columns that can be assumed to be not null
+// (either because they are not null in the mutation input or because they are
 // non-nullable table columns).
-//
 func (mb *mutationBuilder) buildCheckInputScan(
 	typ checkInputScanType, tabOrdinals []int,
-) (withScanScope *scope, notNullOutCols opt.ColSet) {
+) (outScope *scope, notNullOutCols opt.ColSet) {
 	// inputCols are the column IDs from the mutation input that we are scanning.
 	inputCols := make(opt.ColList, len(tabOrdinals))
 
-	withScanScope = mb.b.allocScope()
-	withScanScope.cols = make([]scopeColumn, len(inputCols))
+	outScope = mb.b.allocScope()
+	outScope.cols = make([]scopeColumn, len(inputCols))
 
 	for i, tabOrd := range tabOrdinals {
 		if typ == checkInputScanNewVals {
@@ -1338,11 +1344,11 @@ func (mb *mutationBuilder) buildCheckInputScan(
 		// Synthesize a new output column for the input column, using the name
 		// of the column in the underlying table. The table's column names are
 		// used because partial unique constraint checks must filter the
-		// WithScan rows with a predicate expression that references the table's
-		// columns.
+		// WithScan or Values rows with a predicate expression that references
+		// the table's columns.
 		tableCol := mb.b.factory.Metadata().Table(mb.tabID).Column(tabOrd)
 		outCol := mb.md.AddColumn(string(tableCol.ColName()), tableCol.DatumType())
-		withScanScope.cols[i] = scopeColumn{
+		outScope.cols[i] = scopeColumn{
 			id:   outCol,
 			name: scopeColName(tableCol.ColName()),
 			typ:  tableCol.DatumType(),
@@ -1357,11 +1363,35 @@ func (mb *mutationBuilder) buildCheckInputScan(
 		}
 	}
 
-	withScanScope.expr = mb.b.factory.ConstructWithScan(&memo.WithScanPrivate{
+	if mb.insertExpr != nil {
+		constCols := memo.FindInlinableConstants(mb.insertExpr)
+		if inputCols.ToSet().SubsetOf(constCols) {
+			elems := make(memo.ScalarListExpr, len(inputCols))
+			colTypes := make([]*types.T, len(inputCols))
+			for i, colID := range inputCols {
+				elem := memo.ExtractColumnFromProjectOrValues(mb.insertExpr, colID)
+				elems[i] = elem
+				colTypes[i] = elem.DataType()
+			}
+
+			tupleTyp := types.MakeTuple(colTypes)
+			row := mb.b.factory.ConstructTuple(elems, tupleTyp)
+			outScope.expr = mb.b.factory.ConstructValues(memo.ScalarListExpr{row}, &memo.ValuesPrivate{
+				Cols: outScope.colList(),
+				ID:   mb.b.factory.Metadata().NextUniqueID(),
+			})
+
+			return outScope, notNullOutCols
+		}
+	}
+
+	mb.ensureWithID()
+	outScope.expr = mb.b.factory.ConstructWithScan(&memo.WithScanPrivate{
 		With:    mb.withID,
 		InCols:  inputCols,
-		OutCols: withScanScope.colList(),
+		OutCols: outScope.colList(),
 		ID:      mb.b.factory.Metadata().NextUniqueID(),
 	})
-	return withScanScope, notNullOutCols
+
+	return outScope, notNullOutCols
 }

--- a/pkg/sql/opt/optbuilder/mutation_builder_unique.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_unique.go
@@ -41,7 +41,6 @@ func (mb *mutationBuilder) buildUniqueChecksForInsert() {
 		return
 	}
 
-	mb.ensureWithID()
 	h := &mb.uniqueCheckHelper
 
 	for i, n := 0, mb.tab.UniqueCount(); i < n; i++ {

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
@@ -32,6 +32,54 @@ insert child
                 └── filters
                      └── p:7 = parent.p:8
 
+# Build a Values expression instead of a WithScan when the INSERT FK columns are
+# constant.
+build
+INSERT INTO child VALUES (100, 1)
+----
+insert child
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:5 => c:1
+ │    └── column2:6 => child.p:2
+ ├── values
+ │    ├── columns: column1:5!null column2:6!null
+ │    └── (100, 1)
+ └── f-k-checks
+      └── f-k-checks-item: child(p) -> parent(p)
+           └── anti-join (hash)
+                ├── columns: p:7!null
+                ├── values
+                │    ├── columns: p:7!null
+                │    └── (1,)
+                ├── scan parent
+                │    └── columns: parent.p:8!null
+                └── filters
+                     └── p:7 = parent.p:8
+
+build
+INSERT INTO child VALUES ((floor(random() * 100))::INT, 1)
+----
+insert child
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:5 => c:1
+ │    └── column2:6 => child.p:2
+ ├── values
+ │    ├── columns: column1:5 column2:6!null
+ │    └── (floor(random() * 100.0)::INT8, 1)
+ └── f-k-checks
+      └── f-k-checks-item: child(p) -> parent(p)
+           └── anti-join (hash)
+                ├── columns: p:7!null
+                ├── values
+                │    ├── columns: p:7!null
+                │    └── (1,)
+                ├── scan parent
+                │    └── columns: parent.p:8!null
+                └── filters
+                     └── p:7 = parent.p:8
+
 build
 INSERT INTO child VALUES (100, 1), (200, 1) ON CONFLICT DO NOTHING
 ----
@@ -356,7 +404,6 @@ insert multi_col_child
  │    ├── column2:8 => multi_col_child.p:2
  │    ├── column3:9 => multi_col_child.q:3
  │    └── column4:10 => multi_col_child.r:4
- ├── input binding: &1
  ├── values
  │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null
  │    └── (1, 10, 10, 10)
@@ -364,12 +411,9 @@ insert multi_col_child
       └── f-k-checks-item: multi_col_child(p,q,r) -> multi_col_parent(p,q,r)
            └── anti-join (hash)
                 ├── columns: p:11!null q:12!null r:13!null
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: p:11!null q:12!null r:13!null
-                │    └── mapping:
-                │         ├──  column2:8 => p:11
-                │         ├──  column3:9 => q:12
-                │         └──  column4:10 => r:13
+                │    └── (10, 10, 10)
                 ├── scan multi_col_parent
                 │    └── columns: multi_col_parent.p:14!null multi_col_parent.q:15!null multi_col_parent.r:16!null
                 └── filters
@@ -483,7 +527,6 @@ insert multi_col_child_full
  │    ├── column2:8 => multi_col_child_full.p:2
  │    ├── column3:9 => multi_col_child_full.q:3
  │    └── column4:10 => multi_col_child_full.r:4
- ├── input binding: &1
  ├── values
  │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null
  │    └── (1, 10, 10, 10)
@@ -491,12 +534,9 @@ insert multi_col_child_full
       └── f-k-checks-item: multi_col_child_full(p,q,r) -> multi_col_parent(p,q,r)
            └── anti-join (hash)
                 ├── columns: p:11!null q:12!null r:13!null
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: p:11!null q:12!null r:13!null
-                │    └── mapping:
-                │         ├──  column2:8 => p:11
-                │         ├──  column3:9 => q:12
-                │         └──  column4:10 => r:13
+                │    └── (10, 10, 10)
                 ├── scan multi_col_parent
                 │    └── columns: multi_col_parent.p:14!null multi_col_parent.q:15!null multi_col_parent.r:16!null
                 └── filters

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-upsert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-upsert
@@ -61,6 +61,32 @@ upsert c1
                 └── filters
                      └── p:9 = p.p:10
 
+# Build a Values expression instead of a WithScan when the INSERT FK columns are
+# constant.
+build
+UPSERT INTO c1 VALUES (100, 1, 10)
+----
+upsert c1
+ ├── columns: <none>
+ ├── upsert-mapping:
+ │    ├── column1:6 => c:1
+ │    ├── column2:7 => c1.p:2
+ │    └── column3:8 => i:3
+ ├── values
+ │    ├── columns: column1:6!null column2:7!null column3:8!null
+ │    └── (100, 1, 10)
+ └── f-k-checks
+      └── f-k-checks-item: c1(p) -> p(p)
+           └── anti-join (hash)
+                ├── columns: p:9!null
+                ├── values
+                │    ├── columns: p:9!null
+                │    └── (1,)
+                ├── scan p
+                │    └── columns: p.p:10!null
+                └── filters
+                     └── p:9 = p.p:10
+
 build
 UPSERT INTO c1(c) VALUES (100), (200)
 ----
@@ -570,7 +596,6 @@ upsert cpq
  │    ├── column2:8 => cpq.p:2
  │    ├── column3:9 => cpq.q:3
  │    └── column4:10 => cpq.other:4
- ├── input binding: &1
  ├── values
  │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null
  │    └── (1, 1, 1, 1)
@@ -578,11 +603,9 @@ upsert cpq
       └── f-k-checks-item: cpq(p,q) -> pq(p,q)
            └── anti-join (hash)
                 ├── columns: p:11!null q:12!null
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: p:11!null q:12!null
-                │    └── mapping:
-                │         ├──  column2:8 => p:11
-                │         └──  column3:9 => q:12
+                │    └── (1, 1)
                 ├── scan pq
                 │    └── columns: pq.p:14 pq.q:15
                 └── filters
@@ -771,7 +794,6 @@ upsert cpq
  │    ├── p_default:14 => cpq.p:2
  │    ├── q_default:15 => cpq.q:3
  │    └── other_default:16 => cpq.other:4
- ├── input binding: &1
  ├── project
  │    ├── columns: p_default:14!null q_default:15!null other_default:16 x:7
  │    ├── project
@@ -786,11 +808,9 @@ upsert cpq
       └── f-k-checks-item: cpq(p,q) -> pq(p,q)
            └── anti-join (hash)
                 ├── columns: p:17!null q:18!null
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: p:17!null q:18!null
-                │    └── mapping:
-                │         ├──  p_default:14 => p:17
-                │         └──  q_default:15 => q:18
+                │    └── (4, 8)
                 ├── scan pq
                 │    └── columns: pq.p:20 pq.q:21
                 └── filters

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
@@ -354,7 +354,6 @@ insert uniq
  │    ├── column3:10 => uniq.w:3
  │    ├── column4:11 => uniq.x:4
  │    └── column5:12 => uniq.y:5
- ├── input binding: &1
  ├── upsert-distinct-on
  │    ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null column5:12!null
  │    ├── grouping columns: column3:10!null
@@ -382,14 +381,9 @@ insert uniq
                 ├── columns: x:30!null y:31!null
                 └── semi-join (hash)
                      ├── columns: k:27!null v:28!null w:29!null x:30!null y:31!null
-                     ├── with-scan &1
+                     ├── values
                      │    ├── columns: k:27!null v:28!null w:29!null x:30!null y:31!null
-                     │    └── mapping:
-                     │         ├──  column1:8 => k:27
-                     │         ├──  column2:9 => v:28
-                     │         ├──  column3:10 => w:29
-                     │         ├──  column4:11 => x:30
-                     │         └──  column5:12 => y:31
+                     │    └── (1, 2, 3, 4, 5)
                      ├── scan uniq
                      │    └── columns: uniq.k:20!null uniq.v:21 uniq.w:22 uniq.x:23 uniq.y:24
                      └── filters
@@ -410,7 +404,6 @@ insert uniq
  │    ├── column3:10 => uniq.w:3
  │    ├── column4:11 => uniq.x:4
  │    └── column5:12 => uniq.y:5
- ├── input binding: &1
  ├── upsert-distinct-on
  │    ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null column5:12!null
  │    ├── grouping columns: column3:10!null
@@ -438,14 +431,9 @@ insert uniq
                 ├── columns: x:30!null y:31!null
                 └── semi-join (hash)
                      ├── columns: k:27!null v:28!null w:29!null x:30!null y:31!null
-                     ├── with-scan &1
+                     ├── values
                      │    ├── columns: k:27!null v:28!null w:29!null x:30!null y:31!null
-                     │    └── mapping:
-                     │         ├──  column1:8 => k:27
-                     │         ├──  column2:9 => v:28
-                     │         ├──  column3:10 => w:29
-                     │         ├──  column4:11 => x:30
-                     │         └──  column5:12 => y:31
+                     │    └── (1, 2, 3, 4, 5)
                      ├── scan uniq
                      │    └── columns: uniq.k:20!null uniq.v:21 uniq.w:22 uniq.x:23 uniq.y:24
                      └── filters
@@ -1368,6 +1356,13 @@ CREATE TABLE uniq_partial_constraint_and_index (
 # Use a pseudo-partial index as the only arbiter. Note that we use the "norm"
 # directive instead of "build" to ensure that partial index predicates are fully
 # normalized when choosing arbiter indexes.
+# TODO(mgartner): There is no need to plan a uniqueness check because the
+# pseudo-partial index arbiter ensures that the unique constraint is not
+# violated. In this particular case, with one constant row being inserted, the
+# unique check is normalized to an empty Values expression. One option is to
+# recognize an empty Values uniqueness check and eliminate it. Eliminating this
+# uniqueness check in more general cases would require recognizing that the
+# check is not necessary and not building it in the first place.
 norm
 INSERT INTO uniq_partial_constraint_and_index VALUES (1, 1, 1)
 ON CONFLICT (a) WHERE b > 10 DO NOTHING
@@ -1380,7 +1375,6 @@ insert uniq_partial_constraint_and_index
  │    ├── column2:7 => uniq_partial_constraint_and_index.a:2
  │    └── column3:8 => uniq_partial_constraint_and_index.b:3
  ├── partial index put columns: partial_index_put1:15
- ├── input binding: &1
  ├── project
  │    ├── columns: partial_index_put1:15!null column1:6!null column2:7!null column3:8!null
  │    ├── anti-join (cross)
@@ -1401,31 +1395,8 @@ insert uniq_partial_constraint_and_index
  │         └── true [as=partial_index_put1:15]
  └── unique-checks
       └── unique-checks-item: uniq_partial_constraint_and_index(a)
-           └── project
-                ├── columns: a:22!null
-                └── semi-join (hash)
-                     ├── columns: k:21!null a:22!null b:23!null
-                     ├── select
-                     │    ├── columns: k:21!null a:22!null b:23!null
-                     │    ├── with-scan &1
-                     │    │    ├── columns: k:21!null a:22!null b:23!null
-                     │    │    └── mapping:
-                     │    │         ├──  column1:6 => k:21
-                     │    │         ├──  column2:7 => a:22
-                     │    │         └──  column3:8 => b:23
-                     │    └── filters
-                     │         └── b:23 > 10
-                     ├── select
-                     │    ├── columns: uniq_partial_constraint_and_index.k:16!null uniq_partial_constraint_and_index.a:17 uniq_partial_constraint_and_index.b:18!null
-                     │    ├── scan uniq_partial_constraint_and_index
-                     │    │    ├── columns: uniq_partial_constraint_and_index.k:16!null uniq_partial_constraint_and_index.a:17 uniq_partial_constraint_and_index.b:18
-                     │    │    └── partial index predicates
-                     │    │         └── uniq_partial_constraint_and_index_a_key: filters (true)
-                     │    └── filters
-                     │         └── uniq_partial_constraint_and_index.b:18 > 10
-                     └── filters
-                          ├── a:22 = uniq_partial_constraint_and_index.a:17
-                          └── k:21 != uniq_partial_constraint_and_index.k:16
+           └── values
+                └── columns: a:22!null
 
 exec-ddl
 CREATE TABLE uniq_constraint_and_partial_index (
@@ -1639,3 +1610,45 @@ insert uniq_computed_pk
                      └── filters
                           ├── d:44 = uniq_computed_pk.d:35
                           └── (i:42 != uniq_computed_pk.i:33) OR (c_i_expr:45 != uniq_computed_pk.c_i_expr:36)
+
+exec-ddl
+CREATE TABLE uniq_default (
+  k INT PRIMARY KEY,
+  a INT DEFAULT (10),
+  b INT,
+  UNIQUE WITHOUT INDEX (a, b)
+)
+----
+
+# Inline default values in uniqueness check. The norm directive is used so that
+# the projection of the default value is normalized into the values expression.
+# This normalization is required for the values to be inlined in the constraint
+# check.
+norm
+INSERT INTO uniq_default (k, b) VALUES (1, 100)
+----
+insert uniq_default
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:6 => uniq_default.k:1
+ │    ├── a_default:8 => uniq_default.a:2
+ │    └── column2:7 => uniq_default.b:3
+ ├── values
+ │    ├── columns: column1:6!null column2:7!null a_default:8!null
+ │    └── (1, 100, 10)
+ └── unique-checks
+      └── unique-checks-item: uniq_default(a,b)
+           └── semi-join (cross)
+                ├── columns: a:15!null b:16!null
+                ├── values
+                │    ├── columns: a:15!null b:16!null
+                │    └── (10, 100)
+                ├── select
+                │    ├── columns: uniq_default.k:9!null uniq_default.a:10!null uniq_default.b:11!null
+                │    ├── scan uniq_default
+                │    │    └── columns: uniq_default.k:9!null uniq_default.a:10 uniq_default.b:11
+                │    └── filters
+                │         ├── uniq_default.a:10 = 10
+                │         ├── uniq_default.b:11 = 100
+                │         └── uniq_default.k:9 != 1
+                └── filters (true)

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-upsert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-upsert
@@ -1507,7 +1507,6 @@ upsert uniq_fk_child
  ├── upsert-mapping:
  │    ├── column1:5 => k:1
  │    └── column2:6 => uniq_fk_child.a:2
- ├── input binding: &1
  ├── values
  │    ├── columns: column1:5!null column2:6!null
  │    └── (1, 2)
@@ -1515,10 +1514,9 @@ upsert uniq_fk_child
       └── f-k-checks-item: uniq_fk_child(a) -> uniq_fk_parent(a)
            └── anti-join (hash)
                 ├── columns: a:7!null
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: a:7!null
-                │    └── mapping:
-                │         └──  column2:6 => a:7
+                │    └── (2,)
                 ├── scan uniq_fk_parent
                 │    └── columns: uniq_fk_parent.a:8
                 └── filters

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -871,39 +871,43 @@ insert c
  ├── insert-mapping:
  │    ├── column1:5 => c:1
  │    └── column2:6 => c.p:2
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── stats: [rows=0]
- ├── cost: 6.08
+ ├── cost: 5.13
  ├── values
  │    ├── columns: column1:5!null column2:6!null
  │    ├── cardinality: [1 - 1]
- │    ├── stats: [rows=1, distinct(6)=1, null(6)=0, avgsize(6)=4]
+ │    ├── stats: [rows=1]
  │    ├── cost: 0.02
  │    ├── key: ()
  │    ├── fd: ()-->(5,6)
  │    └── (1, 1)
  └── f-k-checks
       └── f-k-checks-item: c(p) -> p(p)
-           └── anti-join (lookup p)
+           └── anti-join (cross)
                 ├── columns: p:7!null
-                ├── key columns: [7] = [8]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── stats: [rows=1e-10]
-                ├── cost: 6.05
+                ├── cost: 5.1
                 ├── key: ()
                 ├── fd: ()-->(7)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: p:7!null
-                │    ├── mapping:
-                │    │    └──  column2:6 => p:7
                 │    ├── cardinality: [1 - 1]
-                │    ├── stats: [rows=1, distinct(7)=1, null(7)=0, avgsize(7)=4]
-                │    ├── cost: 0.01
+                │    ├── stats: [rows=1]
+                │    ├── cost: 0.02
                 │    ├── key: ()
-                │    └── fd: ()-->(7)
+                │    ├── fd: ()-->(7)
+                │    └── (1,)
+                ├── scan p
+                │    ├── columns: p.p:8!null
+                │    ├── constraint: /8: [/1 - /1]
+                │    ├── cardinality: [0 - 1]
+                │    ├── stats: [rows=1, distinct(8)=1, null(8)=0, avgsize(8)=4]
+                │    ├── cost: 5.03
+                │    ├── key: ()
+                │    └── fd: ()-->(8)
                 └── filters (true)
 
 # Avoid performing a lookup join with virtual tables if the filter is

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -149,7 +149,6 @@ insert order
  │    ├── o_carrier_id_default:18 => o_carrier_id:6
  │    ├── column6:16 => o_ol_cnt:7
  │    └── column7:17 => o_all_local:8
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -160,22 +159,23 @@ insert order
  │    └── (100, 5, 10, 50, '2019-08-26 16:50:41', 10, 1, NULL)
  └── f-k-checks
       └── f-k-checks-item: order(o_w_id,o_d_id,o_c_id) -> customer(c_w_id,c_d_id,c_id)
-           └── anti-join (lookup customer)
+           └── anti-join (cross)
                 ├── columns: o_w_id:19!null o_d_id:20!null o_c_id:21!null
-                ├── key columns: [19 20 21] = [24 23 22]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(19-21)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: o_w_id:19!null o_d_id:20!null o_c_id:21!null
-                │    ├── mapping:
-                │    │    ├──  column3:13 => o_w_id:19
-                │    │    ├──  column2:12 => o_d_id:20
-                │    │    └──  column4:14 => o_c_id:21
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(19-21)
+                │    ├── fd: ()-->(19-21)
+                │    └── (10, 5, 50)
+                ├── scan customer
+                │    ├── columns: c_id:22!null c_d_id:23!null c_w_id:24!null
+                │    ├── constraint: /24/23/22: [/10/5/50 - /10/5/50]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(22-24)
                 └── filters (true)
 
 opt format=hide-qual
@@ -187,7 +187,6 @@ insert new_order
  │    ├── column1:6 => new_order.no_o_id:1
  │    ├── column2:7 => new_order.no_d_id:2
  │    └── column3:8 => new_order.no_w_id:3
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -198,22 +197,23 @@ insert new_order
  │    └── (2000, 100, 10)
  └── f-k-checks
       └── f-k-checks-item: new_order(no_w_id,no_d_id,no_o_id) -> order(o_w_id,o_d_id,o_id)
-           └── anti-join (lookup order)
+           └── anti-join (cross)
                 ├── columns: no_w_id:9!null no_d_id:10!null no_o_id:11!null
-                ├── key columns: [9 10 11] = [14 13 12]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(9-11)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: no_w_id:9!null no_d_id:10!null no_o_id:11!null
-                │    ├── mapping:
-                │    │    ├──  column3:8 => no_w_id:9
-                │    │    ├──  column2:7 => no_d_id:10
-                │    │    └──  column1:6 => no_o_id:11
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(9-11)
+                │    ├── fd: ()-->(9-11)
+                │    └── (10, 100, 2000)
+                ├── scan order
+                │    ├── columns: o_id:12!null o_d_id:13!null o_w_id:14!null
+                │    ├── constraint: /14/13/-12: [/10/100/2000 - /10/100/2000]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(12-14)
                 └── filters (true)
 
 opt format=hide-qual
@@ -612,7 +612,6 @@ insert history
  │    ├── column7:18 => h_date:7
  │    ├── h_amount_cast:20 => h_amount:8
  │    └── h_data_cast:21 => h_data:9
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -624,39 +623,42 @@ insert history
  │    └── (1343, 5, 10, 5, 10, '2019-08-26 16:50:41', 3860.61, '8    Kdcgphy3', gen_random_uuid())
  └── f-k-checks
       ├── f-k-checks-item: history(h_c_w_id,h_c_d_id,h_c_id) -> customer(c_w_id,c_d_id,c_id)
-      │    └── anti-join (lookup customer)
+      │    └── anti-join (cross)
       │         ├── columns: h_c_w_id:23!null h_c_d_id:24!null h_c_id:25!null
-      │         ├── key columns: [23 24 25] = [28 27 26]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(23-25)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: h_c_w_id:23!null h_c_d_id:24!null h_c_id:25!null
-      │         │    ├── mapping:
-      │         │    │    ├──  column3:14 => h_c_w_id:23
-      │         │    │    ├──  column2:13 => h_c_d_id:24
-      │         │    │    └──  column1:12 => h_c_id:25
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(23-25)
+      │         │    ├── fd: ()-->(23-25)
+      │         │    └── (10, 5, 1343)
+      │         ├── scan customer
+      │         │    ├── columns: c_id:26!null c_d_id:27!null c_w_id:28!null
+      │         │    ├── constraint: /28/27/26: [/10/5/1343 - /10/5/1343]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(26-28)
       │         └── filters (true)
       └── f-k-checks-item: history(h_w_id,h_d_id) -> district(d_w_id,d_id)
-           └── anti-join (lookup district)
+           └── anti-join (cross)
                 ├── columns: h_w_id:49!null h_d_id:50!null
-                ├── key columns: [49 50] = [52 51]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(49,50)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: h_w_id:49!null h_d_id:50!null
-                │    ├── mapping:
-                │    │    ├──  column5:16 => h_w_id:49
-                │    │    └──  column4:15 => h_d_id:50
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(49,50)
+                │    ├── fd: ()-->(49,50)
+                │    └── (10, 5)
+                ├── scan district
+                │    ├── columns: d_id:51!null d_w_id:52!null
+                │    ├── constraint: /52/51: [/10/5 - /10/5]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(51,52)
                 └── filters (true)
 
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
@@ -152,7 +152,6 @@ insert order
  │    ├── o_carrier_id_default:18 => o_carrier_id:6
  │    ├── column6:16 => o_ol_cnt:7
  │    └── column7:17 => o_all_local:8
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -163,22 +162,23 @@ insert order
  │    └── (100, 5, 10, 50, '2019-08-26 16:50:41', 10, 1, NULL)
  └── f-k-checks
       └── f-k-checks-item: order(o_w_id,o_d_id,o_c_id) -> customer(c_w_id,c_d_id,c_id)
-           └── anti-join (lookup customer)
+           └── anti-join (cross)
                 ├── columns: o_w_id:19!null o_d_id:20!null o_c_id:21!null
-                ├── key columns: [19 20 21] = [24 23 22]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(19-21)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: o_w_id:19!null o_d_id:20!null o_c_id:21!null
-                │    ├── mapping:
-                │    │    ├──  column3:13 => o_w_id:19
-                │    │    ├──  column2:12 => o_d_id:20
-                │    │    └──  column4:14 => o_c_id:21
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(19-21)
+                │    ├── fd: ()-->(19-21)
+                │    └── (10, 5, 50)
+                ├── scan customer
+                │    ├── columns: c_id:22!null c_d_id:23!null c_w_id:24!null
+                │    ├── constraint: /24/23/22: [/10/5/50 - /10/5/50]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(22-24)
                 └── filters (true)
 
 opt format=hide-qual
@@ -190,7 +190,6 @@ insert new_order
  │    ├── column1:6 => new_order.no_o_id:1
  │    ├── column2:7 => new_order.no_d_id:2
  │    └── column3:8 => new_order.no_w_id:3
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -201,22 +200,23 @@ insert new_order
  │    └── (2000, 100, 10)
  └── f-k-checks
       └── f-k-checks-item: new_order(no_w_id,no_d_id,no_o_id) -> order(o_w_id,o_d_id,o_id)
-           └── anti-join (lookup order)
+           └── anti-join (cross)
                 ├── columns: no_w_id:9!null no_d_id:10!null no_o_id:11!null
-                ├── key columns: [9 10 11] = [14 13 12]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(9-11)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: no_w_id:9!null no_d_id:10!null no_o_id:11!null
-                │    ├── mapping:
-                │    │    ├──  column3:8 => no_w_id:9
-                │    │    ├──  column2:7 => no_d_id:10
-                │    │    └──  column1:6 => no_o_id:11
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(9-11)
+                │    ├── fd: ()-->(9-11)
+                │    └── (10, 100, 2000)
+                ├── scan order
+                │    ├── columns: o_id:12!null o_d_id:13!null o_w_id:14!null
+                │    ├── constraint: /14/13/-12: [/10/100/2000 - /10/100/2000]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(12-14)
                 └── filters (true)
 
 opt format=hide-qual
@@ -615,7 +615,6 @@ insert history
  │    ├── column7:18 => h_date:7
  │    ├── h_amount_cast:20 => h_amount:8
  │    └── h_data_cast:21 => h_data:9
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -627,39 +626,42 @@ insert history
  │    └── (1343, 5, 10, 5, 10, '2019-08-26 16:50:41', 3860.61, '8    Kdcgphy3', gen_random_uuid())
  └── f-k-checks
       ├── f-k-checks-item: history(h_c_w_id,h_c_d_id,h_c_id) -> customer(c_w_id,c_d_id,c_id)
-      │    └── anti-join (lookup customer)
+      │    └── anti-join (cross)
       │         ├── columns: h_c_w_id:23!null h_c_d_id:24!null h_c_id:25!null
-      │         ├── key columns: [23 24 25] = [28 27 26]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(23-25)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: h_c_w_id:23!null h_c_d_id:24!null h_c_id:25!null
-      │         │    ├── mapping:
-      │         │    │    ├──  column3:14 => h_c_w_id:23
-      │         │    │    ├──  column2:13 => h_c_d_id:24
-      │         │    │    └──  column1:12 => h_c_id:25
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(23-25)
+      │         │    ├── fd: ()-->(23-25)
+      │         │    └── (10, 5, 1343)
+      │         ├── scan customer
+      │         │    ├── columns: c_id:26!null c_d_id:27!null c_w_id:28!null
+      │         │    ├── constraint: /28/27/26: [/10/5/1343 - /10/5/1343]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(26-28)
       │         └── filters (true)
       └── f-k-checks-item: history(h_w_id,h_d_id) -> district(d_w_id,d_id)
-           └── anti-join (lookup district)
+           └── anti-join (cross)
                 ├── columns: h_w_id:49!null h_d_id:50!null
-                ├── key columns: [49 50] = [52 51]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(49,50)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: h_w_id:49!null h_d_id:50!null
-                │    ├── mapping:
-                │    │    ├──  column5:16 => h_w_id:49
-                │    │    └──  column4:15 => h_d_id:50
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(49,50)
+                │    ├── fd: ()-->(49,50)
+                │    └── (10, 5)
+                ├── scan district
+                │    ├── columns: d_id:51!null d_w_id:52!null
+                │    ├── constraint: /52/51: [/10/5 - /10/5]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(51,52)
                 └── filters (true)
 
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -146,7 +146,6 @@ insert order
  │    ├── o_carrier_id_default:18 => o_carrier_id:6
  │    ├── column6:16 => o_ol_cnt:7
  │    └── column7:17 => o_all_local:8
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -157,22 +156,23 @@ insert order
  │    └── (100, 5, 10, 50, '2019-08-26 16:50:41', 10, 1, NULL)
  └── f-k-checks
       └── f-k-checks-item: order(o_w_id,o_d_id,o_c_id) -> customer(c_w_id,c_d_id,c_id)
-           └── anti-join (lookup customer)
+           └── anti-join (cross)
                 ├── columns: o_w_id:19!null o_d_id:20!null o_c_id:21!null
-                ├── key columns: [19 20 21] = [24 23 22]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(19-21)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: o_w_id:19!null o_d_id:20!null o_c_id:21!null
-                │    ├── mapping:
-                │    │    ├──  column3:13 => o_w_id:19
-                │    │    ├──  column2:12 => o_d_id:20
-                │    │    └──  column4:14 => o_c_id:21
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(19-21)
+                │    ├── fd: ()-->(19-21)
+                │    └── (10, 5, 50)
+                ├── scan customer
+                │    ├── columns: c_id:22!null c_d_id:23!null c_w_id:24!null
+                │    ├── constraint: /24/23/22: [/10/5/50 - /10/5/50]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(22-24)
                 └── filters (true)
 
 opt format=hide-qual
@@ -184,7 +184,6 @@ insert new_order
  │    ├── column1:6 => new_order.no_o_id:1
  │    ├── column2:7 => new_order.no_d_id:2
  │    └── column3:8 => new_order.no_w_id:3
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -195,22 +194,23 @@ insert new_order
  │    └── (2000, 100, 10)
  └── f-k-checks
       └── f-k-checks-item: new_order(no_w_id,no_d_id,no_o_id) -> order(o_w_id,o_d_id,o_id)
-           └── anti-join (lookup order)
+           └── anti-join (cross)
                 ├── columns: no_w_id:9!null no_d_id:10!null no_o_id:11!null
-                ├── key columns: [9 10 11] = [14 13 12]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(9-11)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: no_w_id:9!null no_d_id:10!null no_o_id:11!null
-                │    ├── mapping:
-                │    │    ├──  column3:8 => no_w_id:9
-                │    │    ├──  column2:7 => no_d_id:10
-                │    │    └──  column1:6 => no_o_id:11
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(9-11)
+                │    ├── fd: ()-->(9-11)
+                │    └── (10, 100, 2000)
+                ├── scan order
+                │    ├── columns: o_id:12!null o_d_id:13!null o_w_id:14!null
+                │    ├── constraint: /14/13/-12: [/10/100/2000 - /10/100/2000]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(12-14)
                 └── filters (true)
 
 opt format=hide-qual
@@ -609,7 +609,6 @@ insert history
  │    ├── column7:18 => h_date:7
  │    ├── h_amount_cast:20 => h_amount:8
  │    └── h_data_cast:21 => h_data:9
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -621,39 +620,42 @@ insert history
  │    └── (1343, 5, 10, 5, 10, '2019-08-26 16:50:41', 3860.61, '8    Kdcgphy3', gen_random_uuid())
  └── f-k-checks
       ├── f-k-checks-item: history(h_c_w_id,h_c_d_id,h_c_id) -> customer(c_w_id,c_d_id,c_id)
-      │    └── anti-join (lookup customer)
+      │    └── anti-join (cross)
       │         ├── columns: h_c_w_id:23!null h_c_d_id:24!null h_c_id:25!null
-      │         ├── key columns: [23 24 25] = [28 27 26]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(23-25)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: h_c_w_id:23!null h_c_d_id:24!null h_c_id:25!null
-      │         │    ├── mapping:
-      │         │    │    ├──  column3:14 => h_c_w_id:23
-      │         │    │    ├──  column2:13 => h_c_d_id:24
-      │         │    │    └──  column1:12 => h_c_id:25
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(23-25)
+      │         │    ├── fd: ()-->(23-25)
+      │         │    └── (10, 5, 1343)
+      │         ├── scan customer
+      │         │    ├── columns: c_id:26!null c_d_id:27!null c_w_id:28!null
+      │         │    ├── constraint: /28/27/26: [/10/5/1343 - /10/5/1343]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(26-28)
       │         └── filters (true)
       └── f-k-checks-item: history(h_w_id,h_d_id) -> district(d_w_id,d_id)
-           └── anti-join (lookup district)
+           └── anti-join (cross)
                 ├── columns: h_w_id:49!null h_d_id:50!null
-                ├── key columns: [49 50] = [52 51]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(49,50)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: h_w_id:49!null h_d_id:50!null
-                │    ├── mapping:
-                │    │    ├──  column5:16 => h_w_id:49
-                │    │    └──  column4:15 => h_d_id:50
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(49,50)
+                │    ├── fd: ()-->(49,50)
+                │    └── (10, 5)
+                ├── scan district
+                │    ├── columns: d_id:51!null d_w_id:52!null
+                │    ├── constraint: /52/51: [/10/5 - /10/5]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(51,52)
                 └── filters (true)
 
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/external/tpce
+++ b/pkg/sql/opt/xform/testdata/external/tpce
@@ -551,7 +551,7 @@ update_trade_submitted AS (
 )
 SELECT * FROM request_list;
 ----
-with &2 (update_last_trade)
+with &1 (update_last_trade)
  ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
  ├── volatile, mutations
  ├── key: (139)
@@ -591,7 +591,7 @@ with &2 (update_last_trade)
  │    │              └── '2020-06-15 22:27:42.148484' [as=lt_dts_new:17]
  │    └── projections
  │         └── NULL [as="?column?":19]
- └── with &3 (request_list)
+ └── with &2 (request_list)
       ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
       ├── volatile, mutations
       ├── key: (139)
@@ -621,7 +621,7 @@ with &2 (update_last_trade)
       │    │         └── (((trade_request.tr_tt_id:21 = 'TMB') AND (trade_request.tr_bid_price:24 >= 1E+2)) OR ((trade_request.tr_tt_id:21 = 'TMS') AND (trade_request.tr_bid_price:24 <= 1E+2))) OR ((trade_request.tr_tt_id:21 = 'TLS') AND (trade_request.tr_bid_price:24 >= 1E+2)) [outer=(21,24), immutable, constraints=(/21: [/'TLS' - /'TLS'] [/'TMB' - /'TMB'] [/'TMS' - /'TMS']; /24: (/NULL - ])]
       │    └── projections
       │         └── trade_request.tr_bid_price:24::FLOAT8 [as=tr_bid_price:28, outer=(24), immutable]
-      └── with &4 (delete_trade_request)
+      └── with &3 (delete_trade_request)
            ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
            ├── volatile, mutations
            ├── key: (139)
@@ -650,7 +650,7 @@ with &2 (update_last_trade)
            │    │         │         ├── lookup columns are key
            │    │         │         ├── key: (45)
            │    │         │         ├── fd: (37)-->(38,39,42), (37)==(45), (45)==(37)
-           │    │         │         ├── with-scan &3 (request_list)
+           │    │         │         ├── with-scan &2 (request_list)
            │    │         │         │    ├── columns: tr_t_id:45!null
            │    │         │         │    ├── mapping:
            │    │         │         │    │    └──  trade_request.tr_t_id:20 => tr_t_id:45
@@ -660,7 +660,7 @@ with &2 (update_last_trade)
            │    │              └── trade_request.tr_tt_id:38 IN ('TLB', 'TLS', 'TSL') [as=partial_index_del1:49, outer=(38)]
            │    └── projections
            │         └── NULL [as="?column?":50]
-           └── with &6 (insert_trade_history)
+           └── with &5 (insert_trade_history)
                 ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
                 ├── volatile, mutations
                 ├── key: (139)
@@ -675,7 +675,7 @@ with &2 (update_last_trade)
                 │    │    │    ├── tr_t_id:56 => trade_history.th_t_id:51
                 │    │    │    ├── timestamp:61 => th_dts:52
                 │    │    │    └── th_st_id_cast:62 => trade_history.th_st_id:53
-                │    │    ├── input binding: &5
+                │    │    ├── input binding: &4
                 │    │    ├── volatile, mutations
                 │    │    ├── key: (51)
                 │    │    ├── fd: ()-->(53)
@@ -683,7 +683,7 @@ with &2 (update_last_trade)
                 │    │    │    ├── columns: th_st_id_cast:62!null timestamp:61!null tr_t_id:56!null
                 │    │    │    ├── key: (56)
                 │    │    │    ├── fd: ()-->(61,62)
-                │    │    │    ├── with-scan &3 (request_list)
+                │    │    │    ├── with-scan &2 (request_list)
                 │    │    │    │    ├── columns: tr_t_id:56!null
                 │    │    │    │    ├── mapping:
                 │    │    │    │    │    └──  trade_request.tr_t_id:20 => tr_t_id:56
@@ -698,27 +698,34 @@ with &2 (update_last_trade)
                 │    │         │         ├── key columns: [63] = [64]
                 │    │         │         ├── lookup columns are key
                 │    │         │         ├── key: (63)
-                │    │         │         ├── with-scan &5
+                │    │         │         ├── with-scan &4
                 │    │         │         │    ├── columns: th_t_id:63!null
                 │    │         │         │    ├── mapping:
                 │    │         │         │    │    └──  tr_t_id:56 => th_t_id:63
                 │    │         │         │    └── key: (63)
                 │    │         │         └── filters (true)
                 │    │         └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
-                │    │              └── anti-join (lookup status_type)
+                │    │              └── anti-join (cross)
                 │    │                   ├── columns: th_st_id:81!null
-                │    │                   ├── key columns: [81] = [82]
-                │    │                   ├── lookup columns are key
+                │    │                   ├── cardinality: [0 - 1]
+                │    │                   ├── key: ()
                 │    │                   ├── fd: ()-->(81)
-                │    │                   ├── with-scan &5
+                │    │                   ├── values
                 │    │                   │    ├── columns: th_st_id:81!null
-                │    │                   │    ├── mapping:
-                │    │                   │    │    └──  th_st_id_cast:62 => th_st_id:81
-                │    │                   │    └── fd: ()-->(81)
+                │    │                   │    ├── cardinality: [1 - 1]
+                │    │                   │    ├── key: ()
+                │    │                   │    ├── fd: ()-->(81)
+                │    │                   │    └── ('SBMT',)
+                │    │                   ├── scan status_type
+                │    │                   │    ├── columns: st_id:82!null
+                │    │                   │    ├── constraint: /82: [/'SBMT' - /'SBMT']
+                │    │                   │    ├── cardinality: [0 - 1]
+                │    │                   │    ├── key: ()
+                │    │                   │    └── fd: ()-->(82)
                 │    │                   └── filters (true)
                 │    └── projections
                 │         └── NULL [as="?column?":86]
-                └── with &8 (update_trade_submitted)
+                └── with &7 (update_trade_submitted)
                      ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
                      ├── volatile, mutations
                      ├── key: (139)
@@ -733,7 +740,7 @@ with &2 (update_last_trade)
                      │    │    ├── update-mapping:
                      │    │    │    ├── t_dts_new:126 => t_dts:88
                      │    │    │    └── t_st_id_cast:127 => trade.t_st_id:89
-                     │    │    ├── input binding: &7
+                     │    │    ├── input binding: &6
                      │    │    ├── volatile, mutations
                      │    │    ├── key: (87)
                      │    │    ├── project
@@ -750,7 +757,7 @@ with &2 (update_last_trade)
                      │    │    │    │         ├── lookup columns are key
                      │    │    │    │         ├── key: (121)
                      │    │    │    │         ├── fd: (104)-->(105-116,118), (104)==(121), (121)==(104)
-                     │    │    │    │         ├── with-scan &3 (request_list)
+                     │    │    │    │         ├── with-scan &2 (request_list)
                      │    │    │    │         │    ├── columns: tr_t_id:121!null
                      │    │    │    │         │    ├── mapping:
                      │    │    │    │         │    │    └──  trade_request.tr_t_id:20 => tr_t_id:121
@@ -766,7 +773,7 @@ with &2 (update_last_trade)
                      │    │                   ├── key columns: [133] = [134]
                      │    │                   ├── lookup columns are key
                      │    │                   ├── fd: ()-->(133)
-                     │    │                   ├── with-scan &7
+                     │    │                   ├── with-scan &6
                      │    │                   │    ├── columns: t_st_id:133!null
                      │    │                   │    ├── mapping:
                      │    │                   │    │    └──  t_st_id_cast:127 => t_st_id:133
@@ -774,7 +781,7 @@ with &2 (update_last_trade)
                      │    │                   └── filters (true)
                      │    └── projections
                      │         └── NULL [as="?column?":138]
-                     └── with-scan &3 (request_list)
+                     └── with-scan &2 (request_list)
                           ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
                           ├── mapping:
                           │    ├──  trade_request.tr_t_id:20 => tr_t_id:139
@@ -2920,7 +2927,7 @@ insert_trade_history AS (
 )
 SELECT 1;
 ----
-with &2 (insert_trade)
+with &1 (insert_trade)
  ├── columns: "?column?":121!null
  ├── cardinality: [1 - 1]
  ├── volatile, mutations
@@ -2951,7 +2958,6 @@ with &2 (insert_trade)
  │    │    │    ├── t_tax_cast:41 => t_tax:14
  │    │    │    └── column15:32 => t_lifo:15
  │    │    ├── check columns: check1:42 check2:43 check3:44 check4:45 check5:46
- │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── volatile, mutations
  │    │    ├── key: ()
@@ -2964,72 +2970,84 @@ with &2 (insert_trade)
  │    │    │    └── (0, '2020-06-17 22:27:42.148484', true, 0, NULL, true, 'SBMT', 'TMB', 'SYMB', 10, 100.00, 'Name', 1.00, 0.00, 0.00, true, true, true, true, true)
  │    │    └── f-k-checks
  │    │         ├── f-k-checks-item: trade(t_st_id) -> status_type(st_id)
- │    │         │    └── anti-join (lookup status_type)
+ │    │         │    └── anti-join (cross)
  │    │         │         ├── columns: t_st_id:47!null
- │    │         │         ├── key columns: [47] = [48]
- │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
  │    │         │         ├── fd: ()-->(47)
- │    │         │         ├── with-scan &1
+ │    │         │         ├── values
  │    │         │         │    ├── columns: t_st_id:47!null
- │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  t_st_id_cast:33 => t_st_id:47
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(47)
+ │    │         │         │    ├── fd: ()-->(47)
+ │    │         │         │    └── ('SBMT',)
+ │    │         │         ├── scan status_type
+ │    │         │         │    ├── columns: st_id:48!null
+ │    │         │         │    ├── constraint: /48: [/'SBMT' - /'SBMT']
+ │    │         │         │    ├── cardinality: [0 - 1]
+ │    │         │         │    ├── key: ()
+ │    │         │         │    └── fd: ()-->(48)
  │    │         │         └── filters (true)
  │    │         ├── f-k-checks-item: trade(t_tt_id) -> trade_type(tt_id)
- │    │         │    └── anti-join (lookup trade_type)
+ │    │         │    └── anti-join (cross)
  │    │         │         ├── columns: t_tt_id:52!null
- │    │         │         ├── key columns: [52] = [53]
- │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
  │    │         │         ├── fd: ()-->(52)
- │    │         │         ├── with-scan &1
+ │    │         │         ├── values
  │    │         │         │    ├── columns: t_tt_id:52!null
- │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  t_tt_id_cast:34 => t_tt_id:52
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(52)
+ │    │         │         │    ├── fd: ()-->(52)
+ │    │         │         │    └── ('TMB',)
+ │    │         │         ├── scan trade_type
+ │    │         │         │    ├── columns: tt_id:53!null
+ │    │         │         │    ├── constraint: /53: [/'TMB' - /'TMB']
+ │    │         │         │    ├── cardinality: [0 - 1]
+ │    │         │         │    ├── key: ()
+ │    │         │         │    └── fd: ()-->(53)
  │    │         │         └── filters (true)
  │    │         ├── f-k-checks-item: trade(t_s_symb) -> security(s_symb)
- │    │         │    └── anti-join (lookup security)
+ │    │         │    └── anti-join (cross)
  │    │         │         ├── columns: t_s_symb:59!null
- │    │         │         ├── key columns: [59] = [60]
- │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
  │    │         │         ├── fd: ()-->(59)
- │    │         │         ├── with-scan &1
+ │    │         │         ├── values
  │    │         │         │    ├── columns: t_s_symb:59!null
- │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  t_s_symb_cast:35 => t_s_symb:59
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(59)
+ │    │         │         │    ├── fd: ()-->(59)
+ │    │         │         │    └── ('SYMB',)
+ │    │         │         ├── scan security
+ │    │         │         │    ├── columns: s_symb:60!null
+ │    │         │         │    ├── constraint: /60: [/'SYMB' - /'SYMB']
+ │    │         │         │    ├── cardinality: [0 - 1]
+ │    │         │         │    ├── key: ()
+ │    │         │         │    └── fd: ()-->(60)
  │    │         │         └── filters (true)
  │    │         └── f-k-checks-item: trade(t_ca_id) -> customer_account(ca_id)
- │    │              └── anti-join (lookup customer_account)
+ │    │              └── anti-join (cross)
  │    │                   ├── columns: t_ca_id:78!null
- │    │                   ├── key columns: [78] = [79]
- │    │                   ├── lookup columns are key
  │    │                   ├── cardinality: [0 - 1]
  │    │                   ├── key: ()
  │    │                   ├── fd: ()-->(78)
- │    │                   ├── with-scan &1
+ │    │                   ├── values
  │    │                   │    ├── columns: t_ca_id:78!null
- │    │                   │    ├── mapping:
- │    │                   │    │    └──  column9:26 => t_ca_id:78
  │    │                   │    ├── cardinality: [1 - 1]
  │    │                   │    ├── key: ()
- │    │                   │    └── fd: ()-->(78)
+ │    │                   │    ├── fd: ()-->(78)
+ │    │                   │    └── (0,)
+ │    │                   ├── scan customer_account
+ │    │                   │    ├── columns: ca_id:79!null
+ │    │                   │    ├── constraint: /79: [/0 - /0]
+ │    │                   │    ├── cardinality: [0 - 1]
+ │    │                   │    ├── key: ()
+ │    │                   │    └── fd: ()-->(79)
  │    │                   └── filters (true)
  │    └── projections
  │         └── 1 [as="?column?":87]
- └── with &4 (insert_trade_history)
+ └── with &2 (insert_trade_history)
       ├── columns: "?column?":121!null
       ├── cardinality: [1 - 1]
       ├── volatile, mutations
@@ -3047,7 +3065,6 @@ with &2 (insert_trade)
       │    │    │    ├── column1:93 => trade_history.th_t_id:88
       │    │    │    ├── column2:94 => th_dts:89
       │    │    │    └── th_st_id_cast:96 => trade_history.th_st_id:90
-      │    │    ├── input binding: &3
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── volatile, mutations
       │    │    ├── key: ()
@@ -3060,36 +3077,42 @@ with &2 (insert_trade)
       │    │    │    └── (0, '2020-06-15 22:27:42.148484', 'SBMT')
       │    │    └── f-k-checks
       │    │         ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
-      │    │         │    └── anti-join (lookup trade)
+      │    │         │    └── anti-join (cross)
       │    │         │         ├── columns: th_t_id:97!null
-      │    │         │         ├── key columns: [97] = [98]
-      │    │         │         ├── lookup columns are key
       │    │         │         ├── cardinality: [0 - 1]
       │    │         │         ├── key: ()
       │    │         │         ├── fd: ()-->(97)
-      │    │         │         ├── with-scan &3
+      │    │         │         ├── values
       │    │         │         │    ├── columns: th_t_id:97!null
-      │    │         │         │    ├── mapping:
-      │    │         │         │    │    └──  column1:93 => th_t_id:97
       │    │         │         │    ├── cardinality: [1 - 1]
       │    │         │         │    ├── key: ()
-      │    │         │         │    └── fd: ()-->(97)
+      │    │         │         │    ├── fd: ()-->(97)
+      │    │         │         │    └── (0,)
+      │    │         │         ├── scan trade
+      │    │         │         │    ├── columns: t_id:98!null
+      │    │         │         │    ├── constraint: /98: [/0 - /0]
+      │    │         │         │    ├── cardinality: [0 - 1]
+      │    │         │         │    ├── key: ()
+      │    │         │         │    └── fd: ()-->(98)
       │    │         │         └── filters (true)
       │    │         └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
-      │    │              └── anti-join (lookup status_type)
+      │    │              └── anti-join (cross)
       │    │                   ├── columns: th_st_id:115!null
-      │    │                   ├── key columns: [115] = [116]
-      │    │                   ├── lookup columns are key
       │    │                   ├── cardinality: [0 - 1]
       │    │                   ├── key: ()
       │    │                   ├── fd: ()-->(115)
-      │    │                   ├── with-scan &3
+      │    │                   ├── values
       │    │                   │    ├── columns: th_st_id:115!null
-      │    │                   │    ├── mapping:
-      │    │                   │    │    └──  th_st_id_cast:96 => th_st_id:115
       │    │                   │    ├── cardinality: [1 - 1]
       │    │                   │    ├── key: ()
-      │    │                   │    └── fd: ()-->(115)
+      │    │                   │    ├── fd: ()-->(115)
+      │    │                   │    └── ('SBMT',)
+      │    │                   ├── scan status_type
+      │    │                   │    ├── columns: st_id:116!null
+      │    │                   │    ├── constraint: /116: [/'SBMT' - /'SBMT']
+      │    │                   │    ├── cardinality: [0 - 1]
+      │    │                   │    ├── key: ()
+      │    │                   │    └── fd: ()-->(116)
       │    │                   └── filters (true)
       │    └── projections
       │         └── 1 [as="?column?":120]
@@ -3170,7 +3193,7 @@ insert_trade_request AS (
 )
 SELECT 1;
 ----
-with &2 (insert_trade)
+with &1 (insert_trade)
  ├── columns: "?column?":195!null
  ├── cardinality: [1 - 1]
  ├── volatile, mutations
@@ -3201,7 +3224,6 @@ with &2 (insert_trade)
  │    │    │    ├── t_tax_cast:41 => t_tax:14
  │    │    │    └── column15:32 => t_lifo:15
  │    │    ├── check columns: check1:42 check2:43 check3:44 check4:45 check5:46
- │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── volatile, mutations
  │    │    ├── key: ()
@@ -3214,72 +3236,84 @@ with &2 (insert_trade)
  │    │    │    └── (0, '2020-06-17 22:27:42.148484', true, 0, NULL, true, 'SBMT', 'TMB', 'SYMB', 10, 100.00, 'Name', 1.00, 0.00, 0.00, true, true, true, true, true)
  │    │    └── f-k-checks
  │    │         ├── f-k-checks-item: trade(t_st_id) -> status_type(st_id)
- │    │         │    └── anti-join (lookup status_type)
+ │    │         │    └── anti-join (cross)
  │    │         │         ├── columns: t_st_id:47!null
- │    │         │         ├── key columns: [47] = [48]
- │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
  │    │         │         ├── fd: ()-->(47)
- │    │         │         ├── with-scan &1
+ │    │         │         ├── values
  │    │         │         │    ├── columns: t_st_id:47!null
- │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  t_st_id_cast:33 => t_st_id:47
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(47)
+ │    │         │         │    ├── fd: ()-->(47)
+ │    │         │         │    └── ('SBMT',)
+ │    │         │         ├── scan status_type
+ │    │         │         │    ├── columns: st_id:48!null
+ │    │         │         │    ├── constraint: /48: [/'SBMT' - /'SBMT']
+ │    │         │         │    ├── cardinality: [0 - 1]
+ │    │         │         │    ├── key: ()
+ │    │         │         │    └── fd: ()-->(48)
  │    │         │         └── filters (true)
  │    │         ├── f-k-checks-item: trade(t_tt_id) -> trade_type(tt_id)
- │    │         │    └── anti-join (lookup trade_type)
+ │    │         │    └── anti-join (cross)
  │    │         │         ├── columns: t_tt_id:52!null
- │    │         │         ├── key columns: [52] = [53]
- │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
  │    │         │         ├── fd: ()-->(52)
- │    │         │         ├── with-scan &1
+ │    │         │         ├── values
  │    │         │         │    ├── columns: t_tt_id:52!null
- │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  t_tt_id_cast:34 => t_tt_id:52
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(52)
+ │    │         │         │    ├── fd: ()-->(52)
+ │    │         │         │    └── ('TMB',)
+ │    │         │         ├── scan trade_type
+ │    │         │         │    ├── columns: tt_id:53!null
+ │    │         │         │    ├── constraint: /53: [/'TMB' - /'TMB']
+ │    │         │         │    ├── cardinality: [0 - 1]
+ │    │         │         │    ├── key: ()
+ │    │         │         │    └── fd: ()-->(53)
  │    │         │         └── filters (true)
  │    │         ├── f-k-checks-item: trade(t_s_symb) -> security(s_symb)
- │    │         │    └── anti-join (lookup security)
+ │    │         │    └── anti-join (cross)
  │    │         │         ├── columns: t_s_symb:59!null
- │    │         │         ├── key columns: [59] = [60]
- │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
  │    │         │         ├── fd: ()-->(59)
- │    │         │         ├── with-scan &1
+ │    │         │         ├── values
  │    │         │         │    ├── columns: t_s_symb:59!null
- │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  t_s_symb_cast:35 => t_s_symb:59
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(59)
+ │    │         │         │    ├── fd: ()-->(59)
+ │    │         │         │    └── ('SYMB',)
+ │    │         │         ├── scan security
+ │    │         │         │    ├── columns: s_symb:60!null
+ │    │         │         │    ├── constraint: /60: [/'SYMB' - /'SYMB']
+ │    │         │         │    ├── cardinality: [0 - 1]
+ │    │         │         │    ├── key: ()
+ │    │         │         │    └── fd: ()-->(60)
  │    │         │         └── filters (true)
  │    │         └── f-k-checks-item: trade(t_ca_id) -> customer_account(ca_id)
- │    │              └── anti-join (lookup customer_account)
+ │    │              └── anti-join (cross)
  │    │                   ├── columns: t_ca_id:78!null
- │    │                   ├── key columns: [78] = [79]
- │    │                   ├── lookup columns are key
  │    │                   ├── cardinality: [0 - 1]
  │    │                   ├── key: ()
  │    │                   ├── fd: ()-->(78)
- │    │                   ├── with-scan &1
+ │    │                   ├── values
  │    │                   │    ├── columns: t_ca_id:78!null
- │    │                   │    ├── mapping:
- │    │                   │    │    └──  column9:26 => t_ca_id:78
  │    │                   │    ├── cardinality: [1 - 1]
  │    │                   │    ├── key: ()
- │    │                   │    └── fd: ()-->(78)
+ │    │                   │    ├── fd: ()-->(78)
+ │    │                   │    └── (0,)
+ │    │                   ├── scan customer_account
+ │    │                   │    ├── columns: ca_id:79!null
+ │    │                   │    ├── constraint: /79: [/0 - /0]
+ │    │                   │    ├── cardinality: [0 - 1]
+ │    │                   │    ├── key: ()
+ │    │                   │    └── fd: ()-->(79)
  │    │                   └── filters (true)
  │    └── projections
  │         └── 1 [as="?column?":87]
- └── with &4 (insert_trade_history)
+ └── with &2 (insert_trade_history)
       ├── columns: "?column?":195!null
       ├── cardinality: [1 - 1]
       ├── volatile, mutations
@@ -3297,7 +3331,6 @@ with &2 (insert_trade)
       │    │    │    ├── column1:93 => trade_history.th_t_id:88
       │    │    │    ├── column2:94 => th_dts:89
       │    │    │    └── th_st_id_cast:96 => trade_history.th_st_id:90
-      │    │    ├── input binding: &3
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── volatile, mutations
       │    │    ├── key: ()
@@ -3310,40 +3343,46 @@ with &2 (insert_trade)
       │    │    │    └── (0, '2020-06-15 22:27:42.148484', 'SBMT')
       │    │    └── f-k-checks
       │    │         ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
-      │    │         │    └── anti-join (lookup trade)
+      │    │         │    └── anti-join (cross)
       │    │         │         ├── columns: th_t_id:97!null
-      │    │         │         ├── key columns: [97] = [98]
-      │    │         │         ├── lookup columns are key
       │    │         │         ├── cardinality: [0 - 1]
       │    │         │         ├── key: ()
       │    │         │         ├── fd: ()-->(97)
-      │    │         │         ├── with-scan &3
+      │    │         │         ├── values
       │    │         │         │    ├── columns: th_t_id:97!null
-      │    │         │         │    ├── mapping:
-      │    │         │         │    │    └──  column1:93 => th_t_id:97
       │    │         │         │    ├── cardinality: [1 - 1]
       │    │         │         │    ├── key: ()
-      │    │         │         │    └── fd: ()-->(97)
+      │    │         │         │    ├── fd: ()-->(97)
+      │    │         │         │    └── (0,)
+      │    │         │         ├── scan trade
+      │    │         │         │    ├── columns: t_id:98!null
+      │    │         │         │    ├── constraint: /98: [/0 - /0]
+      │    │         │         │    ├── cardinality: [0 - 1]
+      │    │         │         │    ├── key: ()
+      │    │         │         │    └── fd: ()-->(98)
       │    │         │         └── filters (true)
       │    │         └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
-      │    │              └── anti-join (lookup status_type)
+      │    │              └── anti-join (cross)
       │    │                   ├── columns: th_st_id:115!null
-      │    │                   ├── key columns: [115] = [116]
-      │    │                   ├── lookup columns are key
       │    │                   ├── cardinality: [0 - 1]
       │    │                   ├── key: ()
       │    │                   ├── fd: ()-->(115)
-      │    │                   ├── with-scan &3
+      │    │                   ├── values
       │    │                   │    ├── columns: th_st_id:115!null
-      │    │                   │    ├── mapping:
-      │    │                   │    │    └──  th_st_id_cast:96 => th_st_id:115
       │    │                   │    ├── cardinality: [1 - 1]
       │    │                   │    ├── key: ()
-      │    │                   │    └── fd: ()-->(115)
+      │    │                   │    ├── fd: ()-->(115)
+      │    │                   │    └── ('SBMT',)
+      │    │                   ├── scan status_type
+      │    │                   │    ├── columns: st_id:116!null
+      │    │                   │    ├── constraint: /116: [/'SBMT' - /'SBMT']
+      │    │                   │    ├── cardinality: [0 - 1]
+      │    │                   │    ├── key: ()
+      │    │                   │    └── fd: ()-->(116)
       │    │                   └── filters (true)
       │    └── projections
       │         └── 1 [as="?column?":120]
-      └── with &6 (insert_trade_request)
+      └── with &3 (insert_trade_request)
            ├── columns: "?column?":195!null
            ├── cardinality: [1 - 1]
            ├── volatile, mutations
@@ -3366,7 +3405,6 @@ with &2 (insert_trade)
            │    │    │    └── column6:134 => trade_request.tr_b_id:126
            │    │    ├── check columns: check1:139 check2:140
            │    │    ├── partial index put columns: partial_index_put1:141
-           │    │    ├── input binding: &5
            │    │    ├── cardinality: [1 - 1]
            │    │    ├── volatile, mutations
            │    │    ├── key: ()
@@ -3379,68 +3417,80 @@ with &2 (insert_trade)
            │    │    │    └── (0, 0, 'TMB', 'SYMB', 10, 100.00, true, true, false)
            │    │    └── f-k-checks
            │    │         ├── f-k-checks-item: trade_request(tr_t_id) -> trade(t_id)
-           │    │         │    └── anti-join (lookup trade)
+           │    │         │    └── anti-join (cross)
            │    │         │         ├── columns: tr_t_id:142!null
-           │    │         │         ├── key columns: [142] = [143]
-           │    │         │         ├── lookup columns are key
            │    │         │         ├── cardinality: [0 - 1]
            │    │         │         ├── key: ()
            │    │         │         ├── fd: ()-->(142)
-           │    │         │         ├── with-scan &5
+           │    │         │         ├── values
            │    │         │         │    ├── columns: tr_t_id:142!null
-           │    │         │         │    ├── mapping:
-           │    │         │         │    │    └──  column1:129 => tr_t_id:142
            │    │         │         │    ├── cardinality: [1 - 1]
            │    │         │         │    ├── key: ()
-           │    │         │         │    └── fd: ()-->(142)
+           │    │         │         │    ├── fd: ()-->(142)
+           │    │         │         │    └── (0,)
+           │    │         │         ├── scan trade
+           │    │         │         │    ├── columns: t_id:143!null
+           │    │         │         │    ├── constraint: /143: [/0 - /0]
+           │    │         │         │    ├── cardinality: [0 - 1]
+           │    │         │         │    ├── key: ()
+           │    │         │         │    └── fd: ()-->(143)
            │    │         │         └── filters (true)
            │    │         ├── f-k-checks-item: trade_request(tr_tt_id) -> trade_type(tt_id)
-           │    │         │    └── anti-join (lookup trade_type)
+           │    │         │    └── anti-join (cross)
            │    │         │         ├── columns: tr_tt_id:160!null
-           │    │         │         ├── key columns: [160] = [161]
-           │    │         │         ├── lookup columns are key
            │    │         │         ├── cardinality: [0 - 1]
            │    │         │         ├── key: ()
            │    │         │         ├── fd: ()-->(160)
-           │    │         │         ├── with-scan &5
+           │    │         │         ├── values
            │    │         │         │    ├── columns: tr_tt_id:160!null
-           │    │         │         │    ├── mapping:
-           │    │         │         │    │    └──  tr_tt_id_cast:135 => tr_tt_id:160
            │    │         │         │    ├── cardinality: [1 - 1]
            │    │         │         │    ├── key: ()
-           │    │         │         │    └── fd: ()-->(160)
+           │    │         │         │    ├── fd: ()-->(160)
+           │    │         │         │    └── ('TMB',)
+           │    │         │         ├── scan trade_type
+           │    │         │         │    ├── columns: tt_id:161!null
+           │    │         │         │    ├── constraint: /161: [/'TMB' - /'TMB']
+           │    │         │         │    ├── cardinality: [0 - 1]
+           │    │         │         │    ├── key: ()
+           │    │         │         │    └── fd: ()-->(161)
            │    │         │         └── filters (true)
            │    │         ├── f-k-checks-item: trade_request(tr_s_symb) -> security(s_symb)
-           │    │         │    └── anti-join (lookup security)
+           │    │         │    └── anti-join (cross)
            │    │         │         ├── columns: tr_s_symb:167!null
-           │    │         │         ├── key columns: [167] = [168]
-           │    │         │         ├── lookup columns are key
            │    │         │         ├── cardinality: [0 - 1]
            │    │         │         ├── key: ()
            │    │         │         ├── fd: ()-->(167)
-           │    │         │         ├── with-scan &5
+           │    │         │         ├── values
            │    │         │         │    ├── columns: tr_s_symb:167!null
-           │    │         │         │    ├── mapping:
-           │    │         │         │    │    └──  tr_s_symb_cast:136 => tr_s_symb:167
            │    │         │         │    ├── cardinality: [1 - 1]
            │    │         │         │    ├── key: ()
-           │    │         │         │    └── fd: ()-->(167)
+           │    │         │         │    ├── fd: ()-->(167)
+           │    │         │         │    └── ('SYMB',)
+           │    │         │         ├── scan security
+           │    │         │         │    ├── columns: s_symb:168!null
+           │    │         │         │    ├── constraint: /168: [/'SYMB' - /'SYMB']
+           │    │         │         │    ├── cardinality: [0 - 1]
+           │    │         │         │    ├── key: ()
+           │    │         │         │    └── fd: ()-->(168)
            │    │         │         └── filters (true)
            │    │         └── f-k-checks-item: trade_request(tr_b_id) -> broker(b_id)
-           │    │              └── anti-join (lookup broker)
+           │    │              └── anti-join (cross)
            │    │                   ├── columns: tr_b_id:186!null
-           │    │                   ├── key columns: [186] = [187]
-           │    │                   ├── lookup columns are key
            │    │                   ├── cardinality: [0 - 1]
            │    │                   ├── key: ()
            │    │                   ├── fd: ()-->(186)
-           │    │                   ├── with-scan &5
+           │    │                   ├── values
            │    │                   │    ├── columns: tr_b_id:186!null
-           │    │                   │    ├── mapping:
-           │    │                   │    │    └──  column6:134 => tr_b_id:186
            │    │                   │    ├── cardinality: [1 - 1]
            │    │                   │    ├── key: ()
-           │    │                   │    └── fd: ()-->(186)
+           │    │                   │    ├── fd: ()-->(186)
+           │    │                   │    └── (0,)
+           │    │                   ├── scan broker
+           │    │                   │    ├── columns: b_id:187!null
+           │    │                   │    ├── constraint: /187: [/0 - /0]
+           │    │                   │    ├── cardinality: [0 - 1]
+           │    │                   │    ├── key: ()
+           │    │                   │    └── fd: ()-->(187)
            │    │                   └── filters (true)
            │    └── projections
            │         └── 1 [as="?column?":194]
@@ -3601,7 +3651,6 @@ insert holding_summary
  │    ├── column1:6 => holding_summary.hs_ca_id:1
  │    ├── hs_s_symb_cast:9 => holding_summary.hs_s_symb:2
  │    └── hs_qty_cast:10 => hs_qty:3
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -3612,36 +3661,42 @@ insert holding_summary
  │    └── (0, 'ROACH', 100)
  └── f-k-checks
       ├── f-k-checks-item: holding_summary(hs_ca_id) -> customer_account(ca_id)
-      │    └── anti-join (lookup customer_account)
+      │    └── anti-join (cross)
       │         ├── columns: hs_ca_id:11!null
-      │         ├── key columns: [11] = [12]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(11)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: hs_ca_id:11!null
-      │         │    ├── mapping:
-      │         │    │    └──  column1:6 => hs_ca_id:11
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(11)
+      │         │    ├── fd: ()-->(11)
+      │         │    └── (0,)
+      │         ├── scan customer_account
+      │         │    ├── columns: ca_id:12!null
+      │         │    ├── constraint: /12: [/0 - /0]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(12)
       │         └── filters (true)
       └── f-k-checks-item: holding_summary(hs_s_symb) -> security(s_symb)
-           └── anti-join (lookup security)
+           └── anti-join (cross)
                 ├── columns: hs_s_symb:20!null
-                ├── key columns: [20] = [21]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(20)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: hs_s_symb:20!null
-                │    ├── mapping:
-                │    │    └──  hs_s_symb_cast:9 => hs_s_symb:20
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(20)
+                │    ├── fd: ()-->(20)
+                │    └── ('ROACH',)
+                ├── scan security
+                │    ├── columns: s_symb:21!null
+                │    ├── constraint: /21: [/'ROACH' - /'ROACH']
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(21)
                 └── filters (true)
 
 # Q4
@@ -3763,18 +3818,23 @@ insert holding_history
       │         │    └── cardinality: [3 - 3]
       │         └── filters (true)
       └── f-k-checks-item: holding_history(hh_t_id) -> trade(t_id)
-           └── anti-join (lookup trade)
+           └── anti-join (cross)
                 ├── columns: hh_t_id:29!null
-                ├── key columns: [29] = [30]
-                ├── lookup columns are key
-                ├── cardinality: [0 - 3]
+                ├── cardinality: [0 - 1]
+                ├── key: ()
                 ├── fd: ()-->(29)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: hh_t_id:29!null
-                │    ├── mapping:
-                │    │    └──  "?column?":10 => hh_t_id:29
-                │    ├── cardinality: [3 - 3]
-                │    └── fd: ()-->(29)
+                │    ├── cardinality: [1 - 1]
+                │    ├── key: ()
+                │    ├── fd: ()-->(29)
+                │    └── (0,)
+                ├── scan trade
+                │    ├── columns: t_id:30!null
+                │    ├── constraint: /30: [/0 - /0]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(30)
                 └── filters (true)
 
 # Q8
@@ -3844,7 +3904,6 @@ insert holding
  │    ├── h_price_cast:16 => h_price:5
  │    └── h_qty_cast:17 => h_qty:6
  ├── check columns: check1:18
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -3855,37 +3914,42 @@ insert holding
  │    └── (0, 0, '2020-06-15 22:27:42.148484', 'ROACH', 100.00, 10, true)
  └── f-k-checks
       ├── f-k-checks-item: holding(h_t_id) -> trade(t_id)
-      │    └── anti-join (lookup trade)
+      │    └── anti-join (cross)
       │         ├── columns: h_t_id:19!null
-      │         ├── key columns: [19] = [20]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(19)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: h_t_id:19!null
-      │         │    ├── mapping:
-      │         │    │    └──  column1:9 => h_t_id:19
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(19)
+      │         │    ├── fd: ()-->(19)
+      │         │    └── (0,)
+      │         ├── scan trade
+      │         │    ├── columns: t_id:20!null
+      │         │    ├── constraint: /20: [/0 - /0]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(20)
       │         └── filters (true)
       └── f-k-checks-item: holding(h_ca_id,h_s_symb) -> holding_summary(hs_ca_id,hs_s_symb)
-           └── anti-join (lookup holding_summary)
+           └── anti-join (cross)
                 ├── columns: h_ca_id:37!null h_s_symb:38!null
-                ├── key columns: [37 38] = [39 40]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(37,38)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: h_ca_id:37!null h_s_symb:38!null
-                │    ├── mapping:
-                │    │    ├──  column2:10 => h_ca_id:37
-                │    │    └──  h_s_symb_cast:15 => h_s_symb:38
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(37,38)
+                │    ├── fd: ()-->(37,38)
+                │    └── (0, 'ROACH')
+                ├── scan holding_summary
+                │    ├── columns: hs_ca_id:39!null hs_s_symb:40!null
+                │    ├── constraint: /39/40: [/0/'ROACH' - /0/'ROACH']
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(39,40)
                 └── filters (true)
 
 # Q11
@@ -4219,7 +4283,7 @@ with &2 (update_trade_commission)
  │    │                   └── filters (true)
  │    └── projections
  │         └── 1 [as="?column?":52]
- └── with &4 (update_broker_commission)
+ └── with &3 (update_broker_commission)
       ├── columns: "?column?":104!null
       ├── cardinality: [1 - 1]
       ├── volatile, mutations
@@ -4259,7 +4323,7 @@ with &2 (update_trade_commission)
       │    │              └── b_num_trades:63 + 1 [as=b_num_trades_new:68, outer=(63), immutable]
       │    └── projections
       │         └── 1 [as="?column?":70]
-      └── with &6 (insert_trade_history)
+      └── with &4 (insert_trade_history)
            ├── columns: "?column?":104!null
            ├── cardinality: [1 - 1]
            ├── volatile, mutations
@@ -4277,7 +4341,6 @@ with &2 (update_trade_commission)
            │    │    │    ├── column1:76 => trade_history.th_t_id:71
            │    │    │    ├── column2:77 => th_dts:72
            │    │    │    └── th_st_id_cast:79 => trade_history.th_st_id:73
-           │    │    ├── input binding: &5
            │    │    ├── cardinality: [1 - 1]
            │    │    ├── volatile, mutations
            │    │    ├── key: ()
@@ -4290,36 +4353,42 @@ with &2 (update_trade_commission)
            │    │    │    └── (0, '2020-06-15 22:27:42.148484', 'ACTV')
            │    │    └── f-k-checks
            │    │         ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
-           │    │         │    └── anti-join (lookup trade)
+           │    │         │    └── anti-join (cross)
            │    │         │         ├── columns: th_t_id:80!null
-           │    │         │         ├── key columns: [80] = [81]
-           │    │         │         ├── lookup columns are key
            │    │         │         ├── cardinality: [0 - 1]
            │    │         │         ├── key: ()
            │    │         │         ├── fd: ()-->(80)
-           │    │         │         ├── with-scan &5
+           │    │         │         ├── values
            │    │         │         │    ├── columns: th_t_id:80!null
-           │    │         │         │    ├── mapping:
-           │    │         │         │    │    └──  column1:76 => th_t_id:80
            │    │         │         │    ├── cardinality: [1 - 1]
            │    │         │         │    ├── key: ()
-           │    │         │         │    └── fd: ()-->(80)
+           │    │         │         │    ├── fd: ()-->(80)
+           │    │         │         │    └── (0,)
+           │    │         │         ├── scan trade
+           │    │         │         │    ├── columns: t_id:81!null
+           │    │         │         │    ├── constraint: /81: [/0 - /0]
+           │    │         │         │    ├── cardinality: [0 - 1]
+           │    │         │         │    ├── key: ()
+           │    │         │         │    └── fd: ()-->(81)
            │    │         │         └── filters (true)
            │    │         └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
-           │    │              └── anti-join (lookup status_type)
+           │    │              └── anti-join (cross)
            │    │                   ├── columns: th_st_id:98!null
-           │    │                   ├── key columns: [98] = [99]
-           │    │                   ├── lookup columns are key
            │    │                   ├── cardinality: [0 - 1]
            │    │                   ├── key: ()
            │    │                   ├── fd: ()-->(98)
-           │    │                   ├── with-scan &5
+           │    │                   ├── values
            │    │                   │    ├── columns: th_st_id:98!null
-           │    │                   │    ├── mapping:
-           │    │                   │    │    └──  th_st_id_cast:79 => th_st_id:98
            │    │                   │    ├── cardinality: [1 - 1]
            │    │                   │    ├── key: ()
-           │    │                   │    └── fd: ()-->(98)
+           │    │                   │    ├── fd: ()-->(98)
+           │    │                   │    └── ('ACTV',)
+           │    │                   ├── scan status_type
+           │    │                   │    ├── columns: st_id:99!null
+           │    │                   │    ├── constraint: /99: [/'ACTV' - /'ACTV']
+           │    │                   │    ├── cardinality: [0 - 1]
+           │    │                   │    ├── key: ()
+           │    │                   │    └── fd: ()-->(99)
            │    │                   └── filters (true)
            │    └── projections
            │         └── 1 [as="?column?":103]
@@ -4356,7 +4425,7 @@ SET ca_bal = ca_bal + 100.00:::FLOAT8::DECIMAL
 WHERE ca_id = 0
 RETURNING ca_bal::FLOAT8;
 ----
-with &2 (insert_settlement)
+with &1 (insert_settlement)
  ├── columns: ca_bal:82!null
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
@@ -4375,7 +4444,6 @@ with &2 (insert_settlement)
  │    │    │    ├── se_cash_type_cast:11 => se_cash_type:2
  │    │    │    ├── column3:9 => se_cash_due_date:3
  │    │    │    └── se_amt_cast:12 => se_amt:4
- │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── volatile, mutations
  │    │    ├── key: ()
@@ -4388,24 +4456,27 @@ with &2 (insert_settlement)
  │    │    │    └── (0, '2020-06-15', 'Margin', 100.00)
  │    │    └── f-k-checks
  │    │         └── f-k-checks-item: settlement(se_t_id) -> trade(t_id)
- │    │              └── anti-join (lookup trade)
+ │    │              └── anti-join (cross)
  │    │                   ├── columns: se_t_id:13!null
- │    │                   ├── key columns: [13] = [14]
- │    │                   ├── lookup columns are key
  │    │                   ├── cardinality: [0 - 1]
  │    │                   ├── key: ()
  │    │                   ├── fd: ()-->(13)
- │    │                   ├── with-scan &1
+ │    │                   ├── values
  │    │                   │    ├── columns: se_t_id:13!null
- │    │                   │    ├── mapping:
- │    │                   │    │    └──  column1:7 => se_t_id:13
  │    │                   │    ├── cardinality: [1 - 1]
  │    │                   │    ├── key: ()
- │    │                   │    └── fd: ()-->(13)
+ │    │                   │    ├── fd: ()-->(13)
+ │    │                   │    └── (0,)
+ │    │                   ├── scan trade
+ │    │                   │    ├── columns: t_id:14!null
+ │    │                   │    ├── constraint: /14: [/0 - /0]
+ │    │                   │    ├── cardinality: [0 - 1]
+ │    │                   │    ├── key: ()
+ │    │                   │    └── fd: ()-->(14)
  │    │                   └── filters (true)
  │    └── projections
  │         └── 1 [as="?column?":31]
- └── with &4 (insert_cash_transaction)
+ └── with &2 (insert_cash_transaction)
       ├── columns: ca_bal:82!null
       ├── cardinality: [0 - 1]
       ├── volatile, mutations
@@ -4424,7 +4495,6 @@ with &2 (insert_settlement)
       │    │    │    ├── column2:39 => ct_dts:33
       │    │    │    ├── ct_amt_cast:42 => ct_amt:34
       │    │    │    └── ct_name_cast:43 => ct_name:35
-      │    │    ├── input binding: &3
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── volatile, mutations
       │    │    ├── key: ()
@@ -4437,20 +4507,23 @@ with &2 (insert_settlement)
       │    │    │    └── (0, '2020-06-10 22:27:42.148484', 100.00, 'Buy 2 shares of ROACH')
       │    │    └── f-k-checks
       │    │         └── f-k-checks-item: cash_transaction(ct_t_id) -> trade(t_id)
-      │    │              └── anti-join (lookup trade)
+      │    │              └── anti-join (cross)
       │    │                   ├── columns: ct_t_id:44!null
-      │    │                   ├── key columns: [44] = [45]
-      │    │                   ├── lookup columns are key
       │    │                   ├── cardinality: [0 - 1]
       │    │                   ├── key: ()
       │    │                   ├── fd: ()-->(44)
-      │    │                   ├── with-scan &3
+      │    │                   ├── values
       │    │                   │    ├── columns: ct_t_id:44!null
-      │    │                   │    ├── mapping:
-      │    │                   │    │    └──  column1:38 => ct_t_id:44
       │    │                   │    ├── cardinality: [1 - 1]
       │    │                   │    ├── key: ()
-      │    │                   │    └── fd: ()-->(44)
+      │    │                   │    ├── fd: ()-->(44)
+      │    │                   │    └── (0,)
+      │    │                   ├── scan trade
+      │    │                   │    ├── columns: t_id:45!null
+      │    │                   │    ├── constraint: /45: [/0 - /0]
+      │    │                   │    ├── cardinality: [0 - 1]
+      │    │                   │    ├── key: ()
+      │    │                   │    └── fd: ()-->(45)
       │    │                   └── filters (true)
       │    └── projections
       │         └── 1 [as="?column?":62]
@@ -4498,7 +4571,7 @@ insert_settlement AS (
 )
 SELECT ca_bal::FLOAT8 FROM customer_account WHERE ca_id = 0;
 ----
-with &2 (insert_settlement)
+with &1 (insert_settlement)
  ├── columns: ca_bal:40!null
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
@@ -4517,7 +4590,6 @@ with &2 (insert_settlement)
  │    │    │    ├── se_cash_type_cast:11 => se_cash_type:2
  │    │    │    ├── column3:9 => se_cash_due_date:3
  │    │    │    └── se_amt_cast:12 => se_amt:4
- │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── volatile, mutations
  │    │    ├── key: ()
@@ -4530,20 +4602,23 @@ with &2 (insert_settlement)
  │    │    │    └── (0, '2020-06-15', 'Margin', 100.00)
  │    │    └── f-k-checks
  │    │         └── f-k-checks-item: settlement(se_t_id) -> trade(t_id)
- │    │              └── anti-join (lookup trade)
+ │    │              └── anti-join (cross)
  │    │                   ├── columns: se_t_id:13!null
- │    │                   ├── key columns: [13] = [14]
- │    │                   ├── lookup columns are key
  │    │                   ├── cardinality: [0 - 1]
  │    │                   ├── key: ()
  │    │                   ├── fd: ()-->(13)
- │    │                   ├── with-scan &1
+ │    │                   ├── values
  │    │                   │    ├── columns: se_t_id:13!null
- │    │                   │    ├── mapping:
- │    │                   │    │    └──  column1:7 => se_t_id:13
  │    │                   │    ├── cardinality: [1 - 1]
  │    │                   │    ├── key: ()
- │    │                   │    └── fd: ()-->(13)
+ │    │                   │    ├── fd: ()-->(13)
+ │    │                   │    └── (0,)
+ │    │                   ├── scan trade
+ │    │                   │    ├── columns: t_id:14!null
+ │    │                   │    ├── constraint: /14: [/0 - /0]
+ │    │                   │    ├── cardinality: [0 - 1]
+ │    │                   │    ├── key: ()
+ │    │                   │    └── fd: ()-->(14)
  │    │                   └── filters (true)
  │    └── projections
  │         └── 1 [as="?column?":31]

--- a/pkg/sql/opt/xform/testdata/external/tpce-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpce-no-stats
@@ -569,7 +569,7 @@ update_trade_submitted AS (
 )
 SELECT * FROM request_list;
 ----
-with &2 (update_last_trade)
+with &1 (update_last_trade)
  ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
  ├── volatile, mutations
  ├── key: (139)
@@ -609,7 +609,7 @@ with &2 (update_last_trade)
  │    │              └── '2020-06-15 22:27:42.148484' [as=lt_dts_new:17]
  │    └── projections
  │         └── NULL [as="?column?":19]
- └── with &3 (request_list)
+ └── with &2 (request_list)
       ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
       ├── volatile, mutations
       ├── key: (139)
@@ -639,7 +639,7 @@ with &2 (update_last_trade)
       │    │         └── (((trade_request.tr_tt_id:21 = 'TMB') AND (trade_request.tr_bid_price:24 >= 1E+2)) OR ((trade_request.tr_tt_id:21 = 'TMS') AND (trade_request.tr_bid_price:24 <= 1E+2))) OR ((trade_request.tr_tt_id:21 = 'TLS') AND (trade_request.tr_bid_price:24 >= 1E+2)) [outer=(21,24), immutable, constraints=(/21: [/'TLS' - /'TLS'] [/'TMB' - /'TMB'] [/'TMS' - /'TMS']; /24: (/NULL - ])]
       │    └── projections
       │         └── trade_request.tr_bid_price:24::FLOAT8 [as=tr_bid_price:28, outer=(24), immutable]
-      └── with &4 (delete_trade_request)
+      └── with &3 (delete_trade_request)
            ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
            ├── volatile, mutations
            ├── key: (139)
@@ -668,7 +668,7 @@ with &2 (update_last_trade)
            │    │         │         ├── lookup columns are key
            │    │         │         ├── key: (45)
            │    │         │         ├── fd: (37)-->(38,39,42), (37)==(45), (45)==(37)
-           │    │         │         ├── with-scan &3 (request_list)
+           │    │         │         ├── with-scan &2 (request_list)
            │    │         │         │    ├── columns: tr_t_id:45!null
            │    │         │         │    ├── mapping:
            │    │         │         │    │    └──  trade_request.tr_t_id:20 => tr_t_id:45
@@ -678,7 +678,7 @@ with &2 (update_last_trade)
            │    │              └── trade_request.tr_tt_id:38 IN ('TLB', 'TLS', 'TSL') [as=partial_index_del1:49, outer=(38)]
            │    └── projections
            │         └── NULL [as="?column?":50]
-           └── with &6 (insert_trade_history)
+           └── with &5 (insert_trade_history)
                 ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
                 ├── volatile, mutations
                 ├── key: (139)
@@ -693,7 +693,7 @@ with &2 (update_last_trade)
                 │    │    │    ├── tr_t_id:56 => trade_history.th_t_id:51
                 │    │    │    ├── timestamp:61 => th_dts:52
                 │    │    │    └── th_st_id_cast:62 => trade_history.th_st_id:53
-                │    │    ├── input binding: &5
+                │    │    ├── input binding: &4
                 │    │    ├── volatile, mutations
                 │    │    ├── key: (51)
                 │    │    ├── fd: ()-->(53)
@@ -701,7 +701,7 @@ with &2 (update_last_trade)
                 │    │    │    ├── columns: th_st_id_cast:62!null timestamp:61!null tr_t_id:56!null
                 │    │    │    ├── key: (56)
                 │    │    │    ├── fd: ()-->(61,62)
-                │    │    │    ├── with-scan &3 (request_list)
+                │    │    │    ├── with-scan &2 (request_list)
                 │    │    │    │    ├── columns: tr_t_id:56!null
                 │    │    │    │    ├── mapping:
                 │    │    │    │    │    └──  trade_request.tr_t_id:20 => tr_t_id:56
@@ -716,27 +716,34 @@ with &2 (update_last_trade)
                 │    │         │         ├── key columns: [63] = [64]
                 │    │         │         ├── lookup columns are key
                 │    │         │         ├── key: (63)
-                │    │         │         ├── with-scan &5
+                │    │         │         ├── with-scan &4
                 │    │         │         │    ├── columns: th_t_id:63!null
                 │    │         │         │    ├── mapping:
                 │    │         │         │    │    └──  tr_t_id:56 => th_t_id:63
                 │    │         │         │    └── key: (63)
                 │    │         │         └── filters (true)
                 │    │         └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
-                │    │              └── anti-join (lookup status_type)
+                │    │              └── anti-join (cross)
                 │    │                   ├── columns: th_st_id:81!null
-                │    │                   ├── key columns: [81] = [82]
-                │    │                   ├── lookup columns are key
+                │    │                   ├── cardinality: [0 - 1]
+                │    │                   ├── key: ()
                 │    │                   ├── fd: ()-->(81)
-                │    │                   ├── with-scan &5
+                │    │                   ├── values
                 │    │                   │    ├── columns: th_st_id:81!null
-                │    │                   │    ├── mapping:
-                │    │                   │    │    └──  th_st_id_cast:62 => th_st_id:81
-                │    │                   │    └── fd: ()-->(81)
+                │    │                   │    ├── cardinality: [1 - 1]
+                │    │                   │    ├── key: ()
+                │    │                   │    ├── fd: ()-->(81)
+                │    │                   │    └── ('SBMT',)
+                │    │                   ├── scan status_type
+                │    │                   │    ├── columns: st_id:82!null
+                │    │                   │    ├── constraint: /82: [/'SBMT' - /'SBMT']
+                │    │                   │    ├── cardinality: [0 - 1]
+                │    │                   │    ├── key: ()
+                │    │                   │    └── fd: ()-->(82)
                 │    │                   └── filters (true)
                 │    └── projections
                 │         └── NULL [as="?column?":86]
-                └── with &8 (update_trade_submitted)
+                └── with &7 (update_trade_submitted)
                      ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
                      ├── volatile, mutations
                      ├── key: (139)
@@ -751,7 +758,7 @@ with &2 (update_last_trade)
                      │    │    ├── update-mapping:
                      │    │    │    ├── t_dts_new:126 => t_dts:88
                      │    │    │    └── t_st_id_cast:127 => trade.t_st_id:89
-                     │    │    ├── input binding: &7
+                     │    │    ├── input binding: &6
                      │    │    ├── volatile, mutations
                      │    │    ├── key: (87)
                      │    │    ├── project
@@ -768,7 +775,7 @@ with &2 (update_last_trade)
                      │    │    │    │         ├── lookup columns are key
                      │    │    │    │         ├── key: (121)
                      │    │    │    │         ├── fd: (104)-->(105-116,118), (104)==(121), (121)==(104)
-                     │    │    │    │         ├── with-scan &3 (request_list)
+                     │    │    │    │         ├── with-scan &2 (request_list)
                      │    │    │    │         │    ├── columns: tr_t_id:121!null
                      │    │    │    │         │    ├── mapping:
                      │    │    │    │         │    │    └──  trade_request.tr_t_id:20 => tr_t_id:121
@@ -784,7 +791,7 @@ with &2 (update_last_trade)
                      │    │                   ├── key columns: [133] = [134]
                      │    │                   ├── lookup columns are key
                      │    │                   ├── fd: ()-->(133)
-                     │    │                   ├── with-scan &7
+                     │    │                   ├── with-scan &6
                      │    │                   │    ├── columns: t_st_id:133!null
                      │    │                   │    ├── mapping:
                      │    │                   │    │    └──  t_st_id_cast:127 => t_st_id:133
@@ -792,7 +799,7 @@ with &2 (update_last_trade)
                      │    │                   └── filters (true)
                      │    └── projections
                      │         └── NULL [as="?column?":138]
-                     └── with-scan &3 (request_list)
+                     └── with-scan &2 (request_list)
                           ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
                           ├── mapping:
                           │    ├──  trade_request.tr_t_id:20 => tr_t_id:139
@@ -2951,7 +2958,7 @@ insert_trade_history AS (
 )
 SELECT 1;
 ----
-with &2 (insert_trade)
+with &1 (insert_trade)
  ├── columns: "?column?":121!null
  ├── cardinality: [1 - 1]
  ├── volatile, mutations
@@ -2982,7 +2989,6 @@ with &2 (insert_trade)
  │    │    │    ├── t_tax_cast:41 => t_tax:14
  │    │    │    └── column15:32 => t_lifo:15
  │    │    ├── check columns: check1:42 check2:43 check3:44 check4:45 check5:46
- │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── volatile, mutations
  │    │    ├── key: ()
@@ -2995,72 +3001,84 @@ with &2 (insert_trade)
  │    │    │    └── (0, '2020-06-17 22:27:42.148484', true, 0, NULL, true, 'SBMT', 'TMB', 'SYMB', 10, 100.00, 'Name', 1.00, 0.00, 0.00, true, true, true, true, true)
  │    │    └── f-k-checks
  │    │         ├── f-k-checks-item: trade(t_st_id) -> status_type(st_id)
- │    │         │    └── anti-join (lookup status_type)
+ │    │         │    └── anti-join (cross)
  │    │         │         ├── columns: t_st_id:47!null
- │    │         │         ├── key columns: [47] = [48]
- │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
  │    │         │         ├── fd: ()-->(47)
- │    │         │         ├── with-scan &1
+ │    │         │         ├── values
  │    │         │         │    ├── columns: t_st_id:47!null
- │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  t_st_id_cast:33 => t_st_id:47
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(47)
+ │    │         │         │    ├── fd: ()-->(47)
+ │    │         │         │    └── ('SBMT',)
+ │    │         │         ├── scan status_type
+ │    │         │         │    ├── columns: st_id:48!null
+ │    │         │         │    ├── constraint: /48: [/'SBMT' - /'SBMT']
+ │    │         │         │    ├── cardinality: [0 - 1]
+ │    │         │         │    ├── key: ()
+ │    │         │         │    └── fd: ()-->(48)
  │    │         │         └── filters (true)
  │    │         ├── f-k-checks-item: trade(t_tt_id) -> trade_type(tt_id)
- │    │         │    └── anti-join (lookup trade_type)
+ │    │         │    └── anti-join (cross)
  │    │         │         ├── columns: t_tt_id:52!null
- │    │         │         ├── key columns: [52] = [53]
- │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
  │    │         │         ├── fd: ()-->(52)
- │    │         │         ├── with-scan &1
+ │    │         │         ├── values
  │    │         │         │    ├── columns: t_tt_id:52!null
- │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  t_tt_id_cast:34 => t_tt_id:52
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(52)
+ │    │         │         │    ├── fd: ()-->(52)
+ │    │         │         │    └── ('TMB',)
+ │    │         │         ├── scan trade_type
+ │    │         │         │    ├── columns: tt_id:53!null
+ │    │         │         │    ├── constraint: /53: [/'TMB' - /'TMB']
+ │    │         │         │    ├── cardinality: [0 - 1]
+ │    │         │         │    ├── key: ()
+ │    │         │         │    └── fd: ()-->(53)
  │    │         │         └── filters (true)
  │    │         ├── f-k-checks-item: trade(t_s_symb) -> security(s_symb)
- │    │         │    └── anti-join (lookup security)
+ │    │         │    └── anti-join (cross)
  │    │         │         ├── columns: t_s_symb:59!null
- │    │         │         ├── key columns: [59] = [60]
- │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
  │    │         │         ├── fd: ()-->(59)
- │    │         │         ├── with-scan &1
+ │    │         │         ├── values
  │    │         │         │    ├── columns: t_s_symb:59!null
- │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  t_s_symb_cast:35 => t_s_symb:59
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(59)
+ │    │         │         │    ├── fd: ()-->(59)
+ │    │         │         │    └── ('SYMB',)
+ │    │         │         ├── scan security
+ │    │         │         │    ├── columns: s_symb:60!null
+ │    │         │         │    ├── constraint: /60: [/'SYMB' - /'SYMB']
+ │    │         │         │    ├── cardinality: [0 - 1]
+ │    │         │         │    ├── key: ()
+ │    │         │         │    └── fd: ()-->(60)
  │    │         │         └── filters (true)
  │    │         └── f-k-checks-item: trade(t_ca_id) -> customer_account(ca_id)
- │    │              └── anti-join (lookup customer_account)
+ │    │              └── anti-join (cross)
  │    │                   ├── columns: t_ca_id:78!null
- │    │                   ├── key columns: [78] = [79]
- │    │                   ├── lookup columns are key
  │    │                   ├── cardinality: [0 - 1]
  │    │                   ├── key: ()
  │    │                   ├── fd: ()-->(78)
- │    │                   ├── with-scan &1
+ │    │                   ├── values
  │    │                   │    ├── columns: t_ca_id:78!null
- │    │                   │    ├── mapping:
- │    │                   │    │    └──  column9:26 => t_ca_id:78
  │    │                   │    ├── cardinality: [1 - 1]
  │    │                   │    ├── key: ()
- │    │                   │    └── fd: ()-->(78)
+ │    │                   │    ├── fd: ()-->(78)
+ │    │                   │    └── (0,)
+ │    │                   ├── scan customer_account
+ │    │                   │    ├── columns: ca_id:79!null
+ │    │                   │    ├── constraint: /79: [/0 - /0]
+ │    │                   │    ├── cardinality: [0 - 1]
+ │    │                   │    ├── key: ()
+ │    │                   │    └── fd: ()-->(79)
  │    │                   └── filters (true)
  │    └── projections
  │         └── 1 [as="?column?":87]
- └── with &4 (insert_trade_history)
+ └── with &2 (insert_trade_history)
       ├── columns: "?column?":121!null
       ├── cardinality: [1 - 1]
       ├── volatile, mutations
@@ -3078,7 +3096,6 @@ with &2 (insert_trade)
       │    │    │    ├── column1:93 => trade_history.th_t_id:88
       │    │    │    ├── column2:94 => th_dts:89
       │    │    │    └── th_st_id_cast:96 => trade_history.th_st_id:90
-      │    │    ├── input binding: &3
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── volatile, mutations
       │    │    ├── key: ()
@@ -3091,36 +3108,42 @@ with &2 (insert_trade)
       │    │    │    └── (0, '2020-06-15 22:27:42.148484', 'SBMT')
       │    │    └── f-k-checks
       │    │         ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
-      │    │         │    └── anti-join (lookup trade)
+      │    │         │    └── anti-join (cross)
       │    │         │         ├── columns: th_t_id:97!null
-      │    │         │         ├── key columns: [97] = [98]
-      │    │         │         ├── lookup columns are key
       │    │         │         ├── cardinality: [0 - 1]
       │    │         │         ├── key: ()
       │    │         │         ├── fd: ()-->(97)
-      │    │         │         ├── with-scan &3
+      │    │         │         ├── values
       │    │         │         │    ├── columns: th_t_id:97!null
-      │    │         │         │    ├── mapping:
-      │    │         │         │    │    └──  column1:93 => th_t_id:97
       │    │         │         │    ├── cardinality: [1 - 1]
       │    │         │         │    ├── key: ()
-      │    │         │         │    └── fd: ()-->(97)
+      │    │         │         │    ├── fd: ()-->(97)
+      │    │         │         │    └── (0,)
+      │    │         │         ├── scan trade
+      │    │         │         │    ├── columns: t_id:98!null
+      │    │         │         │    ├── constraint: /98: [/0 - /0]
+      │    │         │         │    ├── cardinality: [0 - 1]
+      │    │         │         │    ├── key: ()
+      │    │         │         │    └── fd: ()-->(98)
       │    │         │         └── filters (true)
       │    │         └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
-      │    │              └── anti-join (lookup status_type)
+      │    │              └── anti-join (cross)
       │    │                   ├── columns: th_st_id:115!null
-      │    │                   ├── key columns: [115] = [116]
-      │    │                   ├── lookup columns are key
       │    │                   ├── cardinality: [0 - 1]
       │    │                   ├── key: ()
       │    │                   ├── fd: ()-->(115)
-      │    │                   ├── with-scan &3
+      │    │                   ├── values
       │    │                   │    ├── columns: th_st_id:115!null
-      │    │                   │    ├── mapping:
-      │    │                   │    │    └──  th_st_id_cast:96 => th_st_id:115
       │    │                   │    ├── cardinality: [1 - 1]
       │    │                   │    ├── key: ()
-      │    │                   │    └── fd: ()-->(115)
+      │    │                   │    ├── fd: ()-->(115)
+      │    │                   │    └── ('SBMT',)
+      │    │                   ├── scan status_type
+      │    │                   │    ├── columns: st_id:116!null
+      │    │                   │    ├── constraint: /116: [/'SBMT' - /'SBMT']
+      │    │                   │    ├── cardinality: [0 - 1]
+      │    │                   │    ├── key: ()
+      │    │                   │    └── fd: ()-->(116)
       │    │                   └── filters (true)
       │    └── projections
       │         └── 1 [as="?column?":120]
@@ -3201,7 +3224,7 @@ insert_trade_request AS (
 )
 SELECT 1;
 ----
-with &2 (insert_trade)
+with &1 (insert_trade)
  ├── columns: "?column?":195!null
  ├── cardinality: [1 - 1]
  ├── volatile, mutations
@@ -3232,7 +3255,6 @@ with &2 (insert_trade)
  │    │    │    ├── t_tax_cast:41 => t_tax:14
  │    │    │    └── column15:32 => t_lifo:15
  │    │    ├── check columns: check1:42 check2:43 check3:44 check4:45 check5:46
- │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── volatile, mutations
  │    │    ├── key: ()
@@ -3245,72 +3267,84 @@ with &2 (insert_trade)
  │    │    │    └── (0, '2020-06-17 22:27:42.148484', true, 0, NULL, true, 'SBMT', 'TMB', 'SYMB', 10, 100.00, 'Name', 1.00, 0.00, 0.00, true, true, true, true, true)
  │    │    └── f-k-checks
  │    │         ├── f-k-checks-item: trade(t_st_id) -> status_type(st_id)
- │    │         │    └── anti-join (lookup status_type)
+ │    │         │    └── anti-join (cross)
  │    │         │         ├── columns: t_st_id:47!null
- │    │         │         ├── key columns: [47] = [48]
- │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
  │    │         │         ├── fd: ()-->(47)
- │    │         │         ├── with-scan &1
+ │    │         │         ├── values
  │    │         │         │    ├── columns: t_st_id:47!null
- │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  t_st_id_cast:33 => t_st_id:47
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(47)
+ │    │         │         │    ├── fd: ()-->(47)
+ │    │         │         │    └── ('SBMT',)
+ │    │         │         ├── scan status_type
+ │    │         │         │    ├── columns: st_id:48!null
+ │    │         │         │    ├── constraint: /48: [/'SBMT' - /'SBMT']
+ │    │         │         │    ├── cardinality: [0 - 1]
+ │    │         │         │    ├── key: ()
+ │    │         │         │    └── fd: ()-->(48)
  │    │         │         └── filters (true)
  │    │         ├── f-k-checks-item: trade(t_tt_id) -> trade_type(tt_id)
- │    │         │    └── anti-join (lookup trade_type)
+ │    │         │    └── anti-join (cross)
  │    │         │         ├── columns: t_tt_id:52!null
- │    │         │         ├── key columns: [52] = [53]
- │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
  │    │         │         ├── fd: ()-->(52)
- │    │         │         ├── with-scan &1
+ │    │         │         ├── values
  │    │         │         │    ├── columns: t_tt_id:52!null
- │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  t_tt_id_cast:34 => t_tt_id:52
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(52)
+ │    │         │         │    ├── fd: ()-->(52)
+ │    │         │         │    └── ('TMB',)
+ │    │         │         ├── scan trade_type
+ │    │         │         │    ├── columns: tt_id:53!null
+ │    │         │         │    ├── constraint: /53: [/'TMB' - /'TMB']
+ │    │         │         │    ├── cardinality: [0 - 1]
+ │    │         │         │    ├── key: ()
+ │    │         │         │    └── fd: ()-->(53)
  │    │         │         └── filters (true)
  │    │         ├── f-k-checks-item: trade(t_s_symb) -> security(s_symb)
- │    │         │    └── anti-join (lookup security)
+ │    │         │    └── anti-join (cross)
  │    │         │         ├── columns: t_s_symb:59!null
- │    │         │         ├── key columns: [59] = [60]
- │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
  │    │         │         ├── fd: ()-->(59)
- │    │         │         ├── with-scan &1
+ │    │         │         ├── values
  │    │         │         │    ├── columns: t_s_symb:59!null
- │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  t_s_symb_cast:35 => t_s_symb:59
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(59)
+ │    │         │         │    ├── fd: ()-->(59)
+ │    │         │         │    └── ('SYMB',)
+ │    │         │         ├── scan security
+ │    │         │         │    ├── columns: s_symb:60!null
+ │    │         │         │    ├── constraint: /60: [/'SYMB' - /'SYMB']
+ │    │         │         │    ├── cardinality: [0 - 1]
+ │    │         │         │    ├── key: ()
+ │    │         │         │    └── fd: ()-->(60)
  │    │         │         └── filters (true)
  │    │         └── f-k-checks-item: trade(t_ca_id) -> customer_account(ca_id)
- │    │              └── anti-join (lookup customer_account)
+ │    │              └── anti-join (cross)
  │    │                   ├── columns: t_ca_id:78!null
- │    │                   ├── key columns: [78] = [79]
- │    │                   ├── lookup columns are key
  │    │                   ├── cardinality: [0 - 1]
  │    │                   ├── key: ()
  │    │                   ├── fd: ()-->(78)
- │    │                   ├── with-scan &1
+ │    │                   ├── values
  │    │                   │    ├── columns: t_ca_id:78!null
- │    │                   │    ├── mapping:
- │    │                   │    │    └──  column9:26 => t_ca_id:78
  │    │                   │    ├── cardinality: [1 - 1]
  │    │                   │    ├── key: ()
- │    │                   │    └── fd: ()-->(78)
+ │    │                   │    ├── fd: ()-->(78)
+ │    │                   │    └── (0,)
+ │    │                   ├── scan customer_account
+ │    │                   │    ├── columns: ca_id:79!null
+ │    │                   │    ├── constraint: /79: [/0 - /0]
+ │    │                   │    ├── cardinality: [0 - 1]
+ │    │                   │    ├── key: ()
+ │    │                   │    └── fd: ()-->(79)
  │    │                   └── filters (true)
  │    └── projections
  │         └── 1 [as="?column?":87]
- └── with &4 (insert_trade_history)
+ └── with &2 (insert_trade_history)
       ├── columns: "?column?":195!null
       ├── cardinality: [1 - 1]
       ├── volatile, mutations
@@ -3328,7 +3362,6 @@ with &2 (insert_trade)
       │    │    │    ├── column1:93 => trade_history.th_t_id:88
       │    │    │    ├── column2:94 => th_dts:89
       │    │    │    └── th_st_id_cast:96 => trade_history.th_st_id:90
-      │    │    ├── input binding: &3
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── volatile, mutations
       │    │    ├── key: ()
@@ -3341,40 +3374,46 @@ with &2 (insert_trade)
       │    │    │    └── (0, '2020-06-15 22:27:42.148484', 'SBMT')
       │    │    └── f-k-checks
       │    │         ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
-      │    │         │    └── anti-join (lookup trade)
+      │    │         │    └── anti-join (cross)
       │    │         │         ├── columns: th_t_id:97!null
-      │    │         │         ├── key columns: [97] = [98]
-      │    │         │         ├── lookup columns are key
       │    │         │         ├── cardinality: [0 - 1]
       │    │         │         ├── key: ()
       │    │         │         ├── fd: ()-->(97)
-      │    │         │         ├── with-scan &3
+      │    │         │         ├── values
       │    │         │         │    ├── columns: th_t_id:97!null
-      │    │         │         │    ├── mapping:
-      │    │         │         │    │    └──  column1:93 => th_t_id:97
       │    │         │         │    ├── cardinality: [1 - 1]
       │    │         │         │    ├── key: ()
-      │    │         │         │    └── fd: ()-->(97)
+      │    │         │         │    ├── fd: ()-->(97)
+      │    │         │         │    └── (0,)
+      │    │         │         ├── scan trade
+      │    │         │         │    ├── columns: t_id:98!null
+      │    │         │         │    ├── constraint: /98: [/0 - /0]
+      │    │         │         │    ├── cardinality: [0 - 1]
+      │    │         │         │    ├── key: ()
+      │    │         │         │    └── fd: ()-->(98)
       │    │         │         └── filters (true)
       │    │         └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
-      │    │              └── anti-join (lookup status_type)
+      │    │              └── anti-join (cross)
       │    │                   ├── columns: th_st_id:115!null
-      │    │                   ├── key columns: [115] = [116]
-      │    │                   ├── lookup columns are key
       │    │                   ├── cardinality: [0 - 1]
       │    │                   ├── key: ()
       │    │                   ├── fd: ()-->(115)
-      │    │                   ├── with-scan &3
+      │    │                   ├── values
       │    │                   │    ├── columns: th_st_id:115!null
-      │    │                   │    ├── mapping:
-      │    │                   │    │    └──  th_st_id_cast:96 => th_st_id:115
       │    │                   │    ├── cardinality: [1 - 1]
       │    │                   │    ├── key: ()
-      │    │                   │    └── fd: ()-->(115)
+      │    │                   │    ├── fd: ()-->(115)
+      │    │                   │    └── ('SBMT',)
+      │    │                   ├── scan status_type
+      │    │                   │    ├── columns: st_id:116!null
+      │    │                   │    ├── constraint: /116: [/'SBMT' - /'SBMT']
+      │    │                   │    ├── cardinality: [0 - 1]
+      │    │                   │    ├── key: ()
+      │    │                   │    └── fd: ()-->(116)
       │    │                   └── filters (true)
       │    └── projections
       │         └── 1 [as="?column?":120]
-      └── with &6 (insert_trade_request)
+      └── with &3 (insert_trade_request)
            ├── columns: "?column?":195!null
            ├── cardinality: [1 - 1]
            ├── volatile, mutations
@@ -3397,7 +3436,6 @@ with &2 (insert_trade)
            │    │    │    └── column6:134 => trade_request.tr_b_id:126
            │    │    ├── check columns: check1:139 check2:140
            │    │    ├── partial index put columns: partial_index_put1:141
-           │    │    ├── input binding: &5
            │    │    ├── cardinality: [1 - 1]
            │    │    ├── volatile, mutations
            │    │    ├── key: ()
@@ -3410,68 +3448,80 @@ with &2 (insert_trade)
            │    │    │    └── (0, 0, 'TMB', 'SYMB', 10, 100.00, true, true, false)
            │    │    └── f-k-checks
            │    │         ├── f-k-checks-item: trade_request(tr_t_id) -> trade(t_id)
-           │    │         │    └── anti-join (lookup trade)
+           │    │         │    └── anti-join (cross)
            │    │         │         ├── columns: tr_t_id:142!null
-           │    │         │         ├── key columns: [142] = [143]
-           │    │         │         ├── lookup columns are key
            │    │         │         ├── cardinality: [0 - 1]
            │    │         │         ├── key: ()
            │    │         │         ├── fd: ()-->(142)
-           │    │         │         ├── with-scan &5
+           │    │         │         ├── values
            │    │         │         │    ├── columns: tr_t_id:142!null
-           │    │         │         │    ├── mapping:
-           │    │         │         │    │    └──  column1:129 => tr_t_id:142
            │    │         │         │    ├── cardinality: [1 - 1]
            │    │         │         │    ├── key: ()
-           │    │         │         │    └── fd: ()-->(142)
+           │    │         │         │    ├── fd: ()-->(142)
+           │    │         │         │    └── (0,)
+           │    │         │         ├── scan trade
+           │    │         │         │    ├── columns: t_id:143!null
+           │    │         │         │    ├── constraint: /143: [/0 - /0]
+           │    │         │         │    ├── cardinality: [0 - 1]
+           │    │         │         │    ├── key: ()
+           │    │         │         │    └── fd: ()-->(143)
            │    │         │         └── filters (true)
            │    │         ├── f-k-checks-item: trade_request(tr_tt_id) -> trade_type(tt_id)
-           │    │         │    └── anti-join (lookup trade_type)
+           │    │         │    └── anti-join (cross)
            │    │         │         ├── columns: tr_tt_id:160!null
-           │    │         │         ├── key columns: [160] = [161]
-           │    │         │         ├── lookup columns are key
            │    │         │         ├── cardinality: [0 - 1]
            │    │         │         ├── key: ()
            │    │         │         ├── fd: ()-->(160)
-           │    │         │         ├── with-scan &5
+           │    │         │         ├── values
            │    │         │         │    ├── columns: tr_tt_id:160!null
-           │    │         │         │    ├── mapping:
-           │    │         │         │    │    └──  tr_tt_id_cast:135 => tr_tt_id:160
            │    │         │         │    ├── cardinality: [1 - 1]
            │    │         │         │    ├── key: ()
-           │    │         │         │    └── fd: ()-->(160)
+           │    │         │         │    ├── fd: ()-->(160)
+           │    │         │         │    └── ('TMB',)
+           │    │         │         ├── scan trade_type
+           │    │         │         │    ├── columns: tt_id:161!null
+           │    │         │         │    ├── constraint: /161: [/'TMB' - /'TMB']
+           │    │         │         │    ├── cardinality: [0 - 1]
+           │    │         │         │    ├── key: ()
+           │    │         │         │    └── fd: ()-->(161)
            │    │         │         └── filters (true)
            │    │         ├── f-k-checks-item: trade_request(tr_s_symb) -> security(s_symb)
-           │    │         │    └── anti-join (lookup security)
+           │    │         │    └── anti-join (cross)
            │    │         │         ├── columns: tr_s_symb:167!null
-           │    │         │         ├── key columns: [167] = [168]
-           │    │         │         ├── lookup columns are key
            │    │         │         ├── cardinality: [0 - 1]
            │    │         │         ├── key: ()
            │    │         │         ├── fd: ()-->(167)
-           │    │         │         ├── with-scan &5
+           │    │         │         ├── values
            │    │         │         │    ├── columns: tr_s_symb:167!null
-           │    │         │         │    ├── mapping:
-           │    │         │         │    │    └──  tr_s_symb_cast:136 => tr_s_symb:167
            │    │         │         │    ├── cardinality: [1 - 1]
            │    │         │         │    ├── key: ()
-           │    │         │         │    └── fd: ()-->(167)
+           │    │         │         │    ├── fd: ()-->(167)
+           │    │         │         │    └── ('SYMB',)
+           │    │         │         ├── scan security
+           │    │         │         │    ├── columns: s_symb:168!null
+           │    │         │         │    ├── constraint: /168: [/'SYMB' - /'SYMB']
+           │    │         │         │    ├── cardinality: [0 - 1]
+           │    │         │         │    ├── key: ()
+           │    │         │         │    └── fd: ()-->(168)
            │    │         │         └── filters (true)
            │    │         └── f-k-checks-item: trade_request(tr_b_id) -> broker(b_id)
-           │    │              └── anti-join (lookup broker)
+           │    │              └── anti-join (cross)
            │    │                   ├── columns: tr_b_id:186!null
-           │    │                   ├── key columns: [186] = [187]
-           │    │                   ├── lookup columns are key
            │    │                   ├── cardinality: [0 - 1]
            │    │                   ├── key: ()
            │    │                   ├── fd: ()-->(186)
-           │    │                   ├── with-scan &5
+           │    │                   ├── values
            │    │                   │    ├── columns: tr_b_id:186!null
-           │    │                   │    ├── mapping:
-           │    │                   │    │    └──  column6:134 => tr_b_id:186
            │    │                   │    ├── cardinality: [1 - 1]
            │    │                   │    ├── key: ()
-           │    │                   │    └── fd: ()-->(186)
+           │    │                   │    ├── fd: ()-->(186)
+           │    │                   │    └── (0,)
+           │    │                   ├── scan broker
+           │    │                   │    ├── columns: b_id:187!null
+           │    │                   │    ├── constraint: /187: [/0 - /0]
+           │    │                   │    ├── cardinality: [0 - 1]
+           │    │                   │    ├── key: ()
+           │    │                   │    └── fd: ()-->(187)
            │    │                   └── filters (true)
            │    └── projections
            │         └── 1 [as="?column?":194]
@@ -3632,7 +3682,6 @@ insert holding_summary
  │    ├── column1:6 => holding_summary.hs_ca_id:1
  │    ├── hs_s_symb_cast:9 => holding_summary.hs_s_symb:2
  │    └── hs_qty_cast:10 => hs_qty:3
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -3643,36 +3692,42 @@ insert holding_summary
  │    └── (0, 'ROACH', 100)
  └── f-k-checks
       ├── f-k-checks-item: holding_summary(hs_ca_id) -> customer_account(ca_id)
-      │    └── anti-join (lookup customer_account)
+      │    └── anti-join (cross)
       │         ├── columns: hs_ca_id:11!null
-      │         ├── key columns: [11] = [12]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(11)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: hs_ca_id:11!null
-      │         │    ├── mapping:
-      │         │    │    └──  column1:6 => hs_ca_id:11
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(11)
+      │         │    ├── fd: ()-->(11)
+      │         │    └── (0,)
+      │         ├── scan customer_account
+      │         │    ├── columns: ca_id:12!null
+      │         │    ├── constraint: /12: [/0 - /0]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(12)
       │         └── filters (true)
       └── f-k-checks-item: holding_summary(hs_s_symb) -> security(s_symb)
-           └── anti-join (lookup security)
+           └── anti-join (cross)
                 ├── columns: hs_s_symb:20!null
-                ├── key columns: [20] = [21]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(20)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: hs_s_symb:20!null
-                │    ├── mapping:
-                │    │    └──  hs_s_symb_cast:9 => hs_s_symb:20
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(20)
+                │    ├── fd: ()-->(20)
+                │    └── ('ROACH',)
+                ├── scan security
+                │    ├── columns: s_symb:21!null
+                │    ├── constraint: /21: [/'ROACH' - /'ROACH']
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(21)
                 └── filters (true)
 
 # Q4
@@ -3794,18 +3849,23 @@ insert holding_history
       │         │    └── cardinality: [3 - 3]
       │         └── filters (true)
       └── f-k-checks-item: holding_history(hh_t_id) -> trade(t_id)
-           └── anti-join (lookup trade)
+           └── anti-join (cross)
                 ├── columns: hh_t_id:29!null
-                ├── key columns: [29] = [30]
-                ├── lookup columns are key
-                ├── cardinality: [0 - 3]
+                ├── cardinality: [0 - 1]
+                ├── key: ()
                 ├── fd: ()-->(29)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: hh_t_id:29!null
-                │    ├── mapping:
-                │    │    └──  "?column?":10 => hh_t_id:29
-                │    ├── cardinality: [3 - 3]
-                │    └── fd: ()-->(29)
+                │    ├── cardinality: [1 - 1]
+                │    ├── key: ()
+                │    ├── fd: ()-->(29)
+                │    └── (0,)
+                ├── scan trade
+                │    ├── columns: t_id:30!null
+                │    ├── constraint: /30: [/0 - /0]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(30)
                 └── filters (true)
 
 # Q8
@@ -3875,7 +3935,6 @@ insert holding
  │    ├── h_price_cast:16 => h_price:5
  │    └── h_qty_cast:17 => h_qty:6
  ├── check columns: check1:18
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -3886,37 +3945,42 @@ insert holding
  │    └── (0, 0, '2020-06-15 22:27:42.148484', 'ROACH', 100.00, 10, true)
  └── f-k-checks
       ├── f-k-checks-item: holding(h_t_id) -> trade(t_id)
-      │    └── anti-join (lookup trade)
+      │    └── anti-join (cross)
       │         ├── columns: h_t_id:19!null
-      │         ├── key columns: [19] = [20]
-      │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]
       │         ├── key: ()
       │         ├── fd: ()-->(19)
-      │         ├── with-scan &1
+      │         ├── values
       │         │    ├── columns: h_t_id:19!null
-      │         │    ├── mapping:
-      │         │    │    └──  column1:9 => h_t_id:19
       │         │    ├── cardinality: [1 - 1]
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(19)
+      │         │    ├── fd: ()-->(19)
+      │         │    └── (0,)
+      │         ├── scan trade
+      │         │    ├── columns: t_id:20!null
+      │         │    ├── constraint: /20: [/0 - /0]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(20)
       │         └── filters (true)
       └── f-k-checks-item: holding(h_ca_id,h_s_symb) -> holding_summary(hs_ca_id,hs_s_symb)
-           └── anti-join (lookup holding_summary)
+           └── anti-join (cross)
                 ├── columns: h_ca_id:37!null h_s_symb:38!null
-                ├── key columns: [37 38] = [39 40]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(37,38)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: h_ca_id:37!null h_s_symb:38!null
-                │    ├── mapping:
-                │    │    ├──  column2:10 => h_ca_id:37
-                │    │    └──  h_s_symb_cast:15 => h_s_symb:38
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(37,38)
+                │    ├── fd: ()-->(37,38)
+                │    └── (0, 'ROACH')
+                ├── scan holding_summary
+                │    ├── columns: hs_ca_id:39!null hs_s_symb:40!null
+                │    ├── constraint: /39/40: [/0/'ROACH' - /0/'ROACH']
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(39,40)
                 └── filters (true)
 
 # Q11
@@ -4248,7 +4312,7 @@ with &2 (update_trade_commission)
  │    │                   └── filters (true)
  │    └── projections
  │         └── 1 [as="?column?":52]
- └── with &4 (update_broker_commission)
+ └── with &3 (update_broker_commission)
       ├── columns: "?column?":104!null
       ├── cardinality: [1 - 1]
       ├── volatile, mutations
@@ -4288,7 +4352,7 @@ with &2 (update_trade_commission)
       │    │              └── b_num_trades:63 + 1 [as=b_num_trades_new:68, outer=(63), immutable]
       │    └── projections
       │         └── 1 [as="?column?":70]
-      └── with &6 (insert_trade_history)
+      └── with &4 (insert_trade_history)
            ├── columns: "?column?":104!null
            ├── cardinality: [1 - 1]
            ├── volatile, mutations
@@ -4306,7 +4370,6 @@ with &2 (update_trade_commission)
            │    │    │    ├── column1:76 => trade_history.th_t_id:71
            │    │    │    ├── column2:77 => th_dts:72
            │    │    │    └── th_st_id_cast:79 => trade_history.th_st_id:73
-           │    │    ├── input binding: &5
            │    │    ├── cardinality: [1 - 1]
            │    │    ├── volatile, mutations
            │    │    ├── key: ()
@@ -4319,36 +4382,42 @@ with &2 (update_trade_commission)
            │    │    │    └── (0, '2020-06-15 22:27:42.148484', 'ACTV')
            │    │    └── f-k-checks
            │    │         ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
-           │    │         │    └── anti-join (lookup trade)
+           │    │         │    └── anti-join (cross)
            │    │         │         ├── columns: th_t_id:80!null
-           │    │         │         ├── key columns: [80] = [81]
-           │    │         │         ├── lookup columns are key
            │    │         │         ├── cardinality: [0 - 1]
            │    │         │         ├── key: ()
            │    │         │         ├── fd: ()-->(80)
-           │    │         │         ├── with-scan &5
+           │    │         │         ├── values
            │    │         │         │    ├── columns: th_t_id:80!null
-           │    │         │         │    ├── mapping:
-           │    │         │         │    │    └──  column1:76 => th_t_id:80
            │    │         │         │    ├── cardinality: [1 - 1]
            │    │         │         │    ├── key: ()
-           │    │         │         │    └── fd: ()-->(80)
+           │    │         │         │    ├── fd: ()-->(80)
+           │    │         │         │    └── (0,)
+           │    │         │         ├── scan trade
+           │    │         │         │    ├── columns: t_id:81!null
+           │    │         │         │    ├── constraint: /81: [/0 - /0]
+           │    │         │         │    ├── cardinality: [0 - 1]
+           │    │         │         │    ├── key: ()
+           │    │         │         │    └── fd: ()-->(81)
            │    │         │         └── filters (true)
            │    │         └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
-           │    │              └── anti-join (lookup status_type)
+           │    │              └── anti-join (cross)
            │    │                   ├── columns: th_st_id:98!null
-           │    │                   ├── key columns: [98] = [99]
-           │    │                   ├── lookup columns are key
            │    │                   ├── cardinality: [0 - 1]
            │    │                   ├── key: ()
            │    │                   ├── fd: ()-->(98)
-           │    │                   ├── with-scan &5
+           │    │                   ├── values
            │    │                   │    ├── columns: th_st_id:98!null
-           │    │                   │    ├── mapping:
-           │    │                   │    │    └──  th_st_id_cast:79 => th_st_id:98
            │    │                   │    ├── cardinality: [1 - 1]
            │    │                   │    ├── key: ()
-           │    │                   │    └── fd: ()-->(98)
+           │    │                   │    ├── fd: ()-->(98)
+           │    │                   │    └── ('ACTV',)
+           │    │                   ├── scan status_type
+           │    │                   │    ├── columns: st_id:99!null
+           │    │                   │    ├── constraint: /99: [/'ACTV' - /'ACTV']
+           │    │                   │    ├── cardinality: [0 - 1]
+           │    │                   │    ├── key: ()
+           │    │                   │    └── fd: ()-->(99)
            │    │                   └── filters (true)
            │    └── projections
            │         └── 1 [as="?column?":103]
@@ -4385,7 +4454,7 @@ SET ca_bal = ca_bal + 100.00:::FLOAT8::DECIMAL
 WHERE ca_id = 0
 RETURNING ca_bal::FLOAT8;
 ----
-with &2 (insert_settlement)
+with &1 (insert_settlement)
  ├── columns: ca_bal:82!null
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
@@ -4404,7 +4473,6 @@ with &2 (insert_settlement)
  │    │    │    ├── se_cash_type_cast:11 => se_cash_type:2
  │    │    │    ├── column3:9 => se_cash_due_date:3
  │    │    │    └── se_amt_cast:12 => se_amt:4
- │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── volatile, mutations
  │    │    ├── key: ()
@@ -4417,24 +4485,27 @@ with &2 (insert_settlement)
  │    │    │    └── (0, '2020-06-15', 'Margin', 100.00)
  │    │    └── f-k-checks
  │    │         └── f-k-checks-item: settlement(se_t_id) -> trade(t_id)
- │    │              └── anti-join (lookup trade)
+ │    │              └── anti-join (cross)
  │    │                   ├── columns: se_t_id:13!null
- │    │                   ├── key columns: [13] = [14]
- │    │                   ├── lookup columns are key
  │    │                   ├── cardinality: [0 - 1]
  │    │                   ├── key: ()
  │    │                   ├── fd: ()-->(13)
- │    │                   ├── with-scan &1
+ │    │                   ├── values
  │    │                   │    ├── columns: se_t_id:13!null
- │    │                   │    ├── mapping:
- │    │                   │    │    └──  column1:7 => se_t_id:13
  │    │                   │    ├── cardinality: [1 - 1]
  │    │                   │    ├── key: ()
- │    │                   │    └── fd: ()-->(13)
+ │    │                   │    ├── fd: ()-->(13)
+ │    │                   │    └── (0,)
+ │    │                   ├── scan trade
+ │    │                   │    ├── columns: t_id:14!null
+ │    │                   │    ├── constraint: /14: [/0 - /0]
+ │    │                   │    ├── cardinality: [0 - 1]
+ │    │                   │    ├── key: ()
+ │    │                   │    └── fd: ()-->(14)
  │    │                   └── filters (true)
  │    └── projections
  │         └── 1 [as="?column?":31]
- └── with &4 (insert_cash_transaction)
+ └── with &2 (insert_cash_transaction)
       ├── columns: ca_bal:82!null
       ├── cardinality: [0 - 1]
       ├── volatile, mutations
@@ -4453,7 +4524,6 @@ with &2 (insert_settlement)
       │    │    │    ├── column2:39 => ct_dts:33
       │    │    │    ├── ct_amt_cast:42 => ct_amt:34
       │    │    │    └── ct_name_cast:43 => ct_name:35
-      │    │    ├── input binding: &3
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── volatile, mutations
       │    │    ├── key: ()
@@ -4466,20 +4536,23 @@ with &2 (insert_settlement)
       │    │    │    └── (0, '2020-06-10 22:27:42.148484', 100.00, 'Buy 2 shares of ROACH')
       │    │    └── f-k-checks
       │    │         └── f-k-checks-item: cash_transaction(ct_t_id) -> trade(t_id)
-      │    │              └── anti-join (lookup trade)
+      │    │              └── anti-join (cross)
       │    │                   ├── columns: ct_t_id:44!null
-      │    │                   ├── key columns: [44] = [45]
-      │    │                   ├── lookup columns are key
       │    │                   ├── cardinality: [0 - 1]
       │    │                   ├── key: ()
       │    │                   ├── fd: ()-->(44)
-      │    │                   ├── with-scan &3
+      │    │                   ├── values
       │    │                   │    ├── columns: ct_t_id:44!null
-      │    │                   │    ├── mapping:
-      │    │                   │    │    └──  column1:38 => ct_t_id:44
       │    │                   │    ├── cardinality: [1 - 1]
       │    │                   │    ├── key: ()
-      │    │                   │    └── fd: ()-->(44)
+      │    │                   │    ├── fd: ()-->(44)
+      │    │                   │    └── (0,)
+      │    │                   ├── scan trade
+      │    │                   │    ├── columns: t_id:45!null
+      │    │                   │    ├── constraint: /45: [/0 - /0]
+      │    │                   │    ├── cardinality: [0 - 1]
+      │    │                   │    ├── key: ()
+      │    │                   │    └── fd: ()-->(45)
       │    │                   └── filters (true)
       │    └── projections
       │         └── 1 [as="?column?":62]
@@ -4527,7 +4600,7 @@ insert_settlement AS (
 )
 SELECT ca_bal::FLOAT8 FROM customer_account WHERE ca_id = 0;
 ----
-with &2 (insert_settlement)
+with &1 (insert_settlement)
  ├── columns: ca_bal:40!null
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
@@ -4546,7 +4619,6 @@ with &2 (insert_settlement)
  │    │    │    ├── se_cash_type_cast:11 => se_cash_type:2
  │    │    │    ├── column3:9 => se_cash_due_date:3
  │    │    │    └── se_amt_cast:12 => se_amt:4
- │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── volatile, mutations
  │    │    ├── key: ()
@@ -4559,20 +4631,23 @@ with &2 (insert_settlement)
  │    │    │    └── (0, '2020-06-15', 'Margin', 100.00)
  │    │    └── f-k-checks
  │    │         └── f-k-checks-item: settlement(se_t_id) -> trade(t_id)
- │    │              └── anti-join (lookup trade)
+ │    │              └── anti-join (cross)
  │    │                   ├── columns: se_t_id:13!null
- │    │                   ├── key columns: [13] = [14]
- │    │                   ├── lookup columns are key
  │    │                   ├── cardinality: [0 - 1]
  │    │                   ├── key: ()
  │    │                   ├── fd: ()-->(13)
- │    │                   ├── with-scan &1
+ │    │                   ├── values
  │    │                   │    ├── columns: se_t_id:13!null
- │    │                   │    ├── mapping:
- │    │                   │    │    └──  column1:7 => se_t_id:13
  │    │                   │    ├── cardinality: [1 - 1]
  │    │                   │    ├── key: ()
- │    │                   │    └── fd: ()-->(13)
+ │    │                   │    ├── fd: ()-->(13)
+ │    │                   │    └── (0,)
+ │    │                   ├── scan trade
+ │    │                   │    ├── columns: t_id:14!null
+ │    │                   │    ├── constraint: /14: [/0 - /0]
+ │    │                   │    ├── cardinality: [0 - 1]
+ │    │                   │    ├── key: ()
+ │    │                   │    └── fd: ()-->(14)
  │    │                   └── filters (true)
  │    └── projections
  │         └── 1 [as="?column?":31]

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -397,7 +397,6 @@ insert fk_b
  ├── insert-mapping:
  │    ├── column1:5 => b:1
  │    └── column2:6 => fk_b.a:2
- ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
@@ -408,20 +407,23 @@ insert fk_b
  │    └── (1, 1)
  └── f-k-checks
       └── f-k-checks-item: fk_b(a) -> fk_a(a)
-           └── anti-join (lookup fk_a)
+           └── anti-join (cross)
                 ├── columns: a:7!null
-                ├── key columns: [7] = [8]
-                ├── lookup columns are key
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(7)
-                ├── with-scan &1
+                ├── values
                 │    ├── columns: a:7!null
-                │    ├── mapping:
-                │    │    └──  column2:6 => a:7
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
-                │    └── fd: ()-->(7)
+                │    ├── fd: ()-->(7)
+                │    └── (1,)
+                ├── scan fk_a
+                │    ├── columns: fk_a.a:8!null
+                │    ├── constraint: /8: [/1 - /1]
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(8)
                 └── filters (true)
 
 # --------------------------------------------------


### PR DESCRIPTION
In FK and uniqueness checks, WithScans that buffer the mutation's input
are replaced with Values expression when inserted values are constant.
This is especially beneficial for `REGIONAL BY ROW` tables where the
`crdb_region` column is a computed column dependent on a FK. Because the
constant values are inlined, the optimizer is not able to reduce a FK
check that scans multiple regions with a FK check that checks only a
single region.

Informs #63882

Release note (performance improvement): Previously, foreign key checks
performed for inserts into `REGIONAL BY ROW` tables always searched the
parent table in all regions to check for FK violations. Now, only a
single region is searched if constant values are inserted and the
`crdb_region` column is a computed column dependent on the FK column.