### PR TITLE
kv/bulk,backupccl: disable auto-splits during RESTORE

### DIFF
--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -434,6 +434,7 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 		evalCtx.Settings,
 		disallowShadowingBelow,
 		writeAtBatchTS,
+		false, /* splitFilledRanges */
 	)
 	if err != nil {
 		return summary, err


### PR DESCRIPTION
RESTORE does its own range-by-range pre-splitting, so we don't need to split as we fill at all.

Release note: none.

Release justification: bug fix in new or updated functionality.