### PR TITLE
release-21.2: sqlproxyccl: Add codeUnavailable to the list of error codes

### DIFF
--- a/pkg/ccl/sqlproxyccl/error.go
+++ b/pkg/ccl/sqlproxyccl/error.go
@@ -80,6 +80,10 @@ const (
 	// codeIdleDisconnect indicates that the connection was disconnected for
 	// being idle for longer than the specified timeout.
 	codeIdleDisconnect
+
+	// codeUnavailable indicates that the backend SQL server exists but is not
+	// accepting connections. For example, a tenant cluster that has maxPods set to 0.
+	codeUnavailable
 )
 
 // codeError is combines an error with one of the above codes to ease

--- a/pkg/ccl/sqlproxyccl/errorcode_string.go
+++ b/pkg/ccl/sqlproxyccl/errorcode_string.go
@@ -24,11 +24,12 @@ func _() {
 	_ = x[codeProxyRefusedConnection-14]
 	_ = x[codeExpiredClientConnection-15]
 	_ = x[codeIdleDisconnect-16]
+	_ = x[codeUnavailable-17]
 }
 
-const _errorCode_name = "codeAuthFailedcodeBackendReadFailedcodeBackendWriteFailedcodeClientReadFailedcodeClientWriteFailedcodeUnexpectedInsecureStartupMessagecodeSNIRoutingFailedcodeUnexpectedStartupMessagecodeParamsRoutingFailedcodeBackendDowncodeBackendRefusedTLScodeBackendDisconnectedcodeClientDisconnectedcodeProxyRefusedConnectioncodeExpiredClientConnectioncodeIdleDisconnect"
+const _errorCode_name = "codeAuthFailedcodeBackendReadFailedcodeBackendWriteFailedcodeClientReadFailedcodeClientWriteFailedcodeUnexpectedInsecureStartupMessagecodeSNIRoutingFailedcodeUnexpectedStartupMessagecodeParamsRoutingFailedcodeBackendDowncodeBackendRefusedTLScodeBackendDisconnectedcodeClientDisconnectedcodeProxyRefusedConnectioncodeExpiredClientConnectioncodeIdleDisconnectcodeUnavailable"
 
-var _errorCode_index = [...]uint16{0, 14, 35, 57, 77, 98, 134, 154, 182, 205, 220, 241, 264, 286, 312, 339, 357}
+var _errorCode_index = [...]uint16{0, 14, 35, 57, 77, 98, 134, 154, 182, 205, 220, 241, 264, 286, 312, 339, 357, 372}
 
 func (i errorCode) String() string {
 	i -= 1

--- a/pkg/ccl/sqlproxyccl/metrics.go
+++ b/pkg/ccl/sqlproxyccl/metrics.go
@@ -131,7 +131,7 @@ func (metrics *metrics) updateForError(err error) {
 		case codeProxyRefusedConnection:
 			metrics.RefusedConnCount.Inc(1)
 			metrics.BackendDownCount.Inc(1)
-		case codeParamsRoutingFailed:
+		case codeParamsRoutingFailed, codeUnavailable:
 			metrics.RoutingErrCount.Inc(1)
 			metrics.BackendDownCount.Inc(1)
 		case codeBackendDown:

--- a/pkg/ccl/sqlproxyccl/proxy.go
+++ b/pkg/ccl/sqlproxyccl/proxy.go
@@ -42,7 +42,8 @@ func toPgError(err error) *pgproto3.ErrorResponse {
 			codeBackendDisconnected,
 			codeAuthFailed,
 			codeProxyRefusedConnection,
-			codeIdleDisconnect:
+			codeIdleDisconnect,
+			codeUnavailable:
 			msg = codeErr.Error()
 		// The rest - the message sent back is sanitized.
 		case codeUnexpectedInsecureStartupMessage:

--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -292,8 +292,9 @@ func (handler *proxyHandler) handle(ctx context.Context, incomingConn *proxyConn
 		outgoingAddress, err = handler.outgoingAddress(ctx, clusterName, tenID)
 		if err != nil {
 			// Failure is assumed to be transient (and should be retried) except
-			// in case where the server was not found.
-			if status.Code(err) != codes.NotFound {
+			// in two cases. First, where the server was not found, and second,
+			// when the tenant cluster is intentionally unavailable (FailedPrecondition).
+			if status.Code(err) != codes.NotFound && status.Code(err) != codes.FailedPrecondition {
 				outgoingAddressErrs++
 				if outgoingAddressErr.ShouldLog() {
 					log.Ops.Errorf(ctx,
@@ -306,10 +307,20 @@ func (handler *proxyHandler) handle(ctx context.Context, incomingConn *proxyConn
 				continue
 			}
 
-			// Remap error for external consumption.
 			log.Errorf(ctx, "could not retrieve outgoing address: %v", err.Error())
-			err = newErrorf(
-				codeParamsRoutingFailed, "cluster %s-%d not found", clusterName, tenID.ToUint64())
+			// Remap error for external consumption.
+			// Either not found.
+			if status.Code(err) == codes.NotFound {
+				err = newErrorf(
+					codeParamsRoutingFailed, "cluster %s-%d not found", clusterName, tenID.ToUint64())
+			} else {
+				// Or unavailable.
+				if st, ok := status.FromError(err); ok {
+					err = newErrorf(codeUnavailable, "%v", st.Message())
+				} else {
+					err = newErrorf(codeUnavailable, "unavailable")
+				}
+			}
 			break
 		}
 

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -58,6 +58,10 @@ const backendError = "Backend error!"
 // the test directory server.
 const notFoundTenantID = 99
 
+// unavailableTenantID is used to trigger a FailedPrecondition error when it is requested in
+// the test directory server.
+const unavailableTenantID = 999
+
 func TestLongDBName(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -666,6 +670,13 @@ func TestDirectoryConnect(t *testing.T) {
 		require.Equal(t, 2, countReports)
 	})
 
+	t.Run("unavailable tenant", func(t *testing.T) {
+		url := fmt.Sprintf(
+			"postgres://root:admin@%s/?sslmode=disable&options=--cluster=tenant-cluster-%d",
+			addr, unavailableTenantID)
+		te.TestConnectErr(ctx, t, url, codeUnavailable, newErrorf(codeUnavailable, "tenant unavailable").Error())
+	})
+
 	t.Run("successful connection", func(t *testing.T) {
 		url := fmt.Sprintf("postgres://root:admin@%s/?sslmode=disable&options=--cluster=tenant-cluster-28", addr)
 		te.TestConnect(ctx, t, url, func(conn *pgx.Conn) {
@@ -1156,6 +1167,9 @@ func newDirectoryServer(
 		// Recognize special tenant ID that triggers an error.
 		if tenantID == notFoundTenantID {
 			return nil, status.Error(codes.NotFound, "tenant not found")
+		}
+		if tenantID == unavailableTenantID {
+			return nil, status.Error(codes.FailedPrecondition, "tenant unavailable")
 		}
 
 		log.TestingClearServerIdentifiers()


### PR DESCRIPTION
Backport 1/1 commits from #77442.

/cc @cockroachdb/release

---

Release justification: fixes for high-priority bug in existing functionality

Previously, if a tenant cluster had maxPods set to 0 the error returned by
directory.EnsureTenantAddr was not treated as a non-retryable error.

The tenant directory implementation used in CockroachCloud now identifies
this situation and returns a status error with codes.FailedPrecondition and
a descriptive message.

This patch adds a check for the FailedPrecondition error in
connector.lookupAddr.

Release note: None
