### PR TITLE
cli: add debug encode-key command

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -57,6 +57,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
+	"github.com/cockroachdb/cockroach/pkg/util/keysutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -549,6 +550,31 @@ Decode a hexadecimal-encoded key and pretty-print it. For example:
 				return err
 			}
 			fmt.Println(k)
+		}
+		return nil
+	},
+}
+
+var debugEncodeKeyCmd = &cobra.Command{
+	Use:   "encode-key",
+	Short: "encode <key>",
+	Long: `
+Encode a pretty-printed key into the hexadecimal representation of the key bytes.
+Note that many key types are currently unsupported.  For example:
+
+	$ encode-key /Table/104/1
+	F089
+`,
+	Args: cobra.ArbitraryArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		for _, arg := range args {
+			scanner := keysutil.MakePrettyScanner(nil /* tableParser */)
+			key, err := scanner.Scan(arg)
+			if err != nil {
+				return err
+			}
+			hexStr := gohex.EncodeToString(key)
+			fmt.Println(hexStr)
 		}
 		return nil
 	},
@@ -1543,6 +1569,7 @@ var debugCmds = []*cobra.Command{
 	debugBallastCmd,
 	debugCheckLogConfigCmd,
 	debugDecodeKeyCmd,
+	debugEncodeKeyCmd,
 	debugDecodeValueCmd,
 	debugDecodeProtoCmd,
 	debugGossipValuesCmd,

--- a/pkg/util/keysutil/keys.go
+++ b/pkg/util/keysutil/keys.go
@@ -149,6 +149,8 @@ outer:
 				continue outer
 			}
 		}
+		// TODO(sarkesian): support arbitrary key elements beyond TableID/IndexID,
+		// such as /Table/104/1/"hello".
 		return mkErr(errors.New("can't handle key"))
 	}
 	if s.validateRoundTrip {


### PR DESCRIPTION
While previously we have had a `cockroach debug decode-key` command that
would parse a hex-encoded MVCC key and output a pretty-printed MVCC key
such as `/Table/15/1/"a"/1642815338.072261000,0`, this change adds
support for the reverse operation, albeit in a minimal fashion due to
the current limitations of the `keysutil.PrettyScanner`.  This
`encode-key` only supports basic table and index IDs without individual
keys or MVCC timestamps.  For example,
```
$ cockroach debug encode-key /Table/104/1
f089
```

Release justification: Added debug command that affects no existing
functionality.
Release note: None