### PR TITLE
sql: break dependency from config/zonepb to sql/catalog/descpb

### DIFF
--- a/pkg/config/zonepb/BUILD.bazel
+++ b/pkg/config/zonepb/BUILD.bazel
@@ -16,8 +16,6 @@ go_library(
         "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/roachpb",
-        "//pkg/sql/catalog/descpb",
-        "//pkg/sql/opt/cat",
         "//pkg/sql/sem/tree",
         "//pkg/util/log",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/config/zonepb/zone.go
+++ b/pkg/config/zonepb/zone.go
@@ -20,8 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -77,8 +75,8 @@ var NamedZonesByID = func() map[uint32]NamedZone {
 
 // IsNamedZoneID returns true if the given ID is one of the pseudo-table IDs
 // that maps to named zones.
-func IsNamedZoneID(id descpb.ID) bool {
-	_, ok := NamedZonesByID[(uint32(id))]
+func IsNamedZoneID(id uint32) bool {
+	_, ok := NamedZonesByID[id]
 	return ok
 }
 
@@ -528,7 +526,7 @@ func validateVoterConstraintsCompatibility(
 	return nil
 }
 
-// InheritFromParent hydrates a zones missing fields from its parent.
+// InheritFromParent hydrates a zone's missing fields from its parent.
 func (z *ZoneConfig) InheritFromParent(parent *ZoneConfig) {
 	// Allow for subzonePlaceholders to inherit fields from parents if needed.
 	if z.NumReplicas == nil || (z.NumReplicas != nil && *z.NumReplicas == 0) {
@@ -1056,46 +1054,6 @@ func (z ZoneConfig) SubzoneSplits() []roachpb.RKey {
 	return out
 }
 
-// ReplicaConstraintsCount is part of the cat.Zone interface.
-func (z *ZoneConfig) ReplicaConstraintsCount() int {
-	return len(z.Constraints)
-}
-
-// ReplicaConstraints is part of the cat.Zone interface.
-func (z *ZoneConfig) ReplicaConstraints(i int) cat.ReplicaConstraints {
-	return &z.Constraints[i]
-}
-
-// VoterConstraintsCount is part of the cat.Zone interface.
-func (z *ZoneConfig) VoterConstraintsCount() int {
-	return len(z.VoterConstraints)
-}
-
-// VoterConstraint is part of the cat.Zone interface.
-func (z *ZoneConfig) VoterConstraint(i int) cat.ReplicaConstraints {
-	return &z.VoterConstraints[i]
-}
-
-// LeasePreferenceCount is part of the cat.Zone interface.
-func (z *ZoneConfig) LeasePreferenceCount() int {
-	return len(z.LeasePreferences)
-}
-
-// LeasePreference is part of the cat.Zone interface.
-func (z *ZoneConfig) LeasePreference(i int) cat.ConstraintSet {
-	return &z.LeasePreferences[i]
-}
-
-// ConstraintCount is part of the cat.LeasePreference interface.
-func (l *LeasePreference) ConstraintCount() int {
-	return len(l.Constraints)
-}
-
-// Constraint is part of the cat.LeasePreference interface.
-func (l *LeasePreference) Constraint(i int) cat.Constraint {
-	return &l.Constraints[i]
-}
-
 func (c ConstraintsConjunction) String() string {
 	var sb strings.Builder
 	for i, cons := range c.Constraints {
@@ -1108,36 +1066,6 @@ func (c ConstraintsConjunction) String() string {
 		fmt.Fprintf(&sb, ":%d", c.NumReplicas)
 	}
 	return sb.String()
-}
-
-// ReplicaCount is part of the cat.ReplicaConstraints interface.
-func (c *ConstraintsConjunction) ReplicaCount() int32 {
-	return c.NumReplicas
-}
-
-// ConstraintCount is part of the cat.ReplicaConstraints interface.
-func (c *ConstraintsConjunction) ConstraintCount() int {
-	return len(c.Constraints)
-}
-
-// Constraint is part of the cat.ReplicaConstraints interface.
-func (c *ConstraintsConjunction) Constraint(i int) cat.Constraint {
-	return &c.Constraints[i]
-}
-
-// IsRequired is part of the cat.Constraint interface.
-func (c *Constraint) IsRequired() bool {
-	return c.Type == Constraint_REQUIRED
-}
-
-// GetKey is part of the cat.Constraint interface.
-func (c *Constraint) GetKey() string {
-	return c.Key
-}
-
-// GetValue is part of the cat.Constraint interface.
-func (c *Constraint) GetValue() string {
-	return c.Value
 }
 
 // EnsureFullyHydrated returns an assertion error if the zone config is not

--- a/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
+++ b/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
@@ -216,7 +216,7 @@ func (s *SQLTranslator) generateSpanConfigurations(
 	descsCol *descs.Collection,
 	ptsStateReader *spanconfig.ProtectedTimestampStateReader,
 ) (_ []spanconfig.Record, err error) {
-	if zonepb.IsNamedZoneID(id) {
+	if zonepb.IsNamedZoneID(uint32(id)) {
 		return s.generateSpanConfigurationsForNamedZone(ctx, txn, id)
 	}
 
@@ -489,7 +489,7 @@ func (s *SQLTranslator) generateSpanConfigurationsForTable(
 func (s *SQLTranslator) findDescendantLeafIDs(
 	ctx context.Context, id descpb.ID, txn *kv.Txn, descsCol *descs.Collection,
 ) (descpb.IDs, error) {
-	if zonepb.IsNamedZoneID(id) {
+	if zonepb.IsNamedZoneID(uint32(id)) {
 		return s.findDescendantLeafIDsForNamedZone(ctx, id, txn, descsCol)
 	}
 	// We're dealing with a SQL Object here.

--- a/pkg/sql/opt/cat/BUILD.bazel
+++ b/pkg/sql/opt/cat/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/cat",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/config/zonepb",
         "//pkg/geo/geoindex",
         "//pkg/roachpb",
         "//pkg/security",

--- a/pkg/sql/opt/indexrec/BUILD.bazel
+++ b/pkg/sql/opt/indexrec/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/indexrec",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/config/zonepb",
         "//pkg/geo/geoindex",
         "//pkg/roachpb",
         "//pkg/sql/catalog/colinfo",

--- a/pkg/sql/opt/indexrec/hypothetical_index.go
+++ b/pkg/sql/opt/indexrec/hypothetical_index.go
@@ -11,7 +11,6 @@
 package indexrec
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -34,7 +33,7 @@ type hypotheticalIndex struct {
 	indexOrdinal int
 
 	// zone stores the table's zone.
-	zone *zonepb.ZoneConfig
+	zone cat.Zone
 
 	// suffixKeyColsOrdList contains all implicit column ordinals. Implicit
 	// columns are columns that are in the table's primary key but are not already
@@ -57,7 +56,7 @@ func (hi *hypotheticalIndex) init(
 	cols []cat.IndexColumn,
 	indexOrd int,
 	inverted bool,
-	zone *zonepb.ZoneConfig,
+	zone cat.Zone,
 ) {
 	hi.tab = tab
 	hi.name = name

--- a/pkg/sql/opt/indexrec/hypothetical_table.go
+++ b/pkg/sql/opt/indexrec/hypothetical_table.go
@@ -13,7 +13,6 @@ package indexrec
 import (
 	"fmt"
 
-	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -54,7 +53,7 @@ func BuildOptAndHypTableMaps(
 				indexCols,
 				indexOrd,
 				inverted,
-				t.Zone().(*zonepb.ZoneConfig),
+				t.Zone(),
 			)
 
 			// Do not add hypothetical inverted indexes for which there is an existing

--- a/pkg/sql/opt/props/physical/BUILD.bazel
+++ b/pkg/sql/opt/props/physical/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
         "//pkg/config/zonepb",
         "//pkg/roachpb",
         "//pkg/sql/opt",
+        "//pkg/sql/opt/cat",
         "//pkg/sql/opt/props",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/sql/opt/props/physical/distribution_test.go
+++ b/pkg/sql/opt/props/physical/distribution_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"gopkg.in/yaml.v2"
@@ -187,7 +188,7 @@ func TestGetRegionsFromZone(t *testing.T) {
 			}
 		}
 
-		regions := getRegionsFromZone(zone)
+		regions := getRegionsFromZone(cat.AsZone(zone))
 		actual := make([]string, 0, len(regions))
 		for r := range regions {
 			actual = append(actual, r)

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -19,7 +19,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
@@ -704,7 +703,7 @@ func (tt *Table) addIndexWithVersion(
 		IdxName:  tt.makeIndexName(def.Name, def.Columns, typ),
 		Unique:   typ != nonUniqueIndex,
 		Inverted: def.Inverted,
-		IdxZone:  &zonepb.ZoneConfig{},
+		IdxZone:  cat.EmptyZone(),
 		table:    tt,
 		version:  version,
 	}
@@ -790,7 +789,7 @@ func (tt *Table) addIndexWithVersion(
 				p := &partitionBy.List[i]
 				idx.partitions[i] = Partition{
 					name:   string(p.Name),
-					zone:   &zonepb.ZoneConfig{},
+					zone:   cat.EmptyZone(),
 					datums: make([]tree.Datums, 0, len(p.Exprs)),
 				}
 

--- a/pkg/sql/opt/testutils/testcat/set_zone_config.go
+++ b/pkg/sql/opt/testutils/testcat/set_zone_config.go
@@ -14,13 +14,14 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"gopkg.in/yaml.v2"
 )
 
 // SetZoneConfig is a partial implementation of the ALTER TABLE ... CONFIGURE
 // ZONE USING statement.
-func (tc *Catalog) SetZoneConfig(stmt *tree.SetZoneConfig) *zonepb.ZoneConfig {
+func (tc *Catalog) SetZoneConfig(stmt *tree.SetZoneConfig) cat.Zone {
 	// Update the table name to include catalog and schema if not provided.
 	tabName := stmt.TableOrIndex.Table
 	tc.qualifyTableName(&tabName)
@@ -74,7 +75,7 @@ func (tc *Catalog) SetZoneConfig(stmt *tree.SetZoneConfig) *zonepb.ZoneConfig {
 
 // makeZoneConfig constructs a ZoneConfig from options provided to the CONFIGURE
 // ZONE USING statement.
-func makeZoneConfig(options tree.KVOptions) *zonepb.ZoneConfig {
+func makeZoneConfig(options tree.KVOptions) cat.Zone {
 	zone := &zonepb.ZoneConfig{}
 	for i := range options {
 		switch options[i].Key {
@@ -102,5 +103,5 @@ func makeZoneConfig(options tree.KVOptions) *zonepb.ZoneConfig {
 			}
 		}
 	}
-	return zone
+	return cat.AsZone(zone)
 }

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -752,7 +752,7 @@ func (tt *Table) Unique(i cat.UniqueOrdinal) cat.UniqueConstraint {
 // Zone is part of the cat.Table interface.
 func (tt *Table) Zone() cat.Zone {
 	zone := zonepb.DefaultZoneConfig()
-	return &zone
+	return cat.AsZone(&zone)
 }
 
 // FindOrdinal returns the ordinal of the column with the given name.
@@ -843,7 +843,7 @@ type Index struct {
 
 	// IdxZone is the zone associated with the index. This may be inherited from
 	// the parent table, database, or even the default zone.
-	IdxZone *zonepb.ZoneConfig
+	IdxZone cat.Zone
 
 	// Ordinal is the ordinal of this index in the table.
 	ordinal int
@@ -991,7 +991,7 @@ func (ti *Index) SetPartitions(partitions []Partition) {
 // Partition implements the cat.Partition interface for testing purposes.
 type Partition struct {
 	name   string
-	zone   *zonepb.ZoneConfig
+	zone   cat.Zone
 	datums []tree.Datums
 }
 

--- a/pkg/sql/opt/xform/BUILD.bazel
+++ b/pkg/sql/opt/xform/BUILD.bazel
@@ -80,6 +80,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/settings/cluster",
         "//pkg/sql/opt",
+        "//pkg/sql/opt/cat",
         "//pkg/sql/opt/constraint",
         "//pkg/sql/opt/memo",
         "//pkg/sql/opt/norm",

--- a/pkg/sql/opt/xform/coster_test.go
+++ b/pkg/sql/opt/xform/coster_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"gopkg.in/yaml.v2"
@@ -91,7 +92,7 @@ func TestLocalityMatchScore(t *testing.T) {
 			}
 		}
 
-		actual := math.Round(localityMatchScore(zone, locality)*100) / 100
+		actual := math.Round(localityMatchScore(cat.AsZone(zone), locality)*100) / 100
 		if actual != tc.expected {
 			t.Errorf("locality=%v, constraints=%v, leasePrefs=%v: expected %v, got %v",
 				tc.locality, tc.constraints, tc.leasePrefs, tc.expected, actual)

--- a/pkg/sql/opt/xform/general_funcs_test.go
+++ b/pkg/sql/opt/xform/general_funcs_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/partition"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -102,7 +103,7 @@ func TestIsZoneLocal(t *testing.T) {
 			}
 		}
 
-		actual := partition.IsZoneLocal(zone, tc.localRegion)
+		actual := partition.IsZoneLocal(cat.AsZone(zone), tc.localRegion)
 		if actual != tc.expected {
 			t.Errorf("locality=%v, constraints=%v, voterConstraints=%v, leasePrefs=%v: expected %v, got %v",
 				tc.localRegion, tc.constraints, tc.voterConstraints, tc.leasePrefs, tc.expected, actual)

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/config"
-	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -455,13 +454,13 @@ func (oc *optCatalog) dataSourceForTable(
 	return ds, nil
 }
 
-var emptyZoneConfig = &zonepb.ZoneConfig{}
+var emptyZoneConfig = cat.EmptyZone()
 
 // getZoneConfig returns the ZoneConfig data structure for the given table.
 // ZoneConfigs are stored in protobuf binary format in the SystemConfig, which
 // is gossiped around the cluster. Note that the returned ZoneConfig might be
 // somewhat stale, since it's taken from the gossiped SystemConfig.
-func (oc *optCatalog) getZoneConfig(desc catalog.TableDescriptor) (*zonepb.ZoneConfig, error) {
+func (oc *optCatalog) getZoneConfig(desc catalog.TableDescriptor) (cat.Zone, error) {
 	// Lookup table's zone if system config is available (it may not be as node
 	// is starting up and before it's received the gossiped config). If it is
 	// not available, use an empty config that has no zone constraints.
@@ -474,9 +473,9 @@ func (oc *optCatalog) getZoneConfig(desc catalog.TableDescriptor) (*zonepb.ZoneC
 	}
 	if zone == nil {
 		// This can happen with tests that override the hook.
-		zone = emptyZoneConfig
+		return emptyZoneConfig, nil
 	}
-	return zone, err
+	return cat.AsZone(zone), nil
 }
 
 func (oc *optCatalog) codec() keys.SQLCodec {
@@ -617,7 +616,7 @@ type optTable struct {
 	// stats are the inlined wrappers for table statistics.
 	stats []optTableStat
 
-	zone *zonepb.ZoneConfig
+	zone cat.Zone
 
 	// family is the inlined wrapper for the table's primary family. The primary
 	// family is the first family explicitly specified by the user. If no families
@@ -651,7 +650,7 @@ func newOptTable(
 	desc catalog.TableDescriptor,
 	codec keys.SQLCodec,
 	stats []*stats.TableStatistic,
-	tblZone *zonepb.ZoneConfig,
+	tblZone cat.Zone,
 ) (*optTable, error) {
 	ot := &optTable{
 		desc:     desc,
@@ -793,20 +792,17 @@ func newOptTable(
 		// use the table zone. Save subzones that apply to partitions, since we will
 		// use those later when initializing partitions in the index.
 		idxZone := tblZone
-		partZones := make(map[string]*zonepb.ZoneConfig)
-		for j := range tblZone.Subzones {
-			subzone := &tblZone.Subzones[j]
-			if subzone.IndexID == uint32(idx.GetID()) {
-				if subzone.PartitionName == "" {
+		partZones := make(map[string]cat.Zone)
+		for j := 0; j < tblZone.SubzoneCount(); j++ {
+			subzone := tblZone.Subzone(j)
+			if subzone.Index() == cat.StableID(idx.GetID()) {
+				copyZone := subzone.Zone().InheritFromParent(tblZone)
+				if subzone.Partition() == "" {
 					// Subzone applies to the whole index.
-					copyZone := subzone.Config
-					copyZone.InheritFromParent(tblZone)
-					idxZone = &copyZone
+					idxZone = copyZone
 				} else {
 					// Subzone applies to a partition.
-					copyZone := subzone.Config
-					copyZone.InheritFromParent(tblZone)
-					partZones[subzone.PartitionName] = &copyZone
+					partZones[subzone.Partition()] = copyZone
 				}
 			}
 		}
@@ -968,7 +964,7 @@ func (ot *optTable) PostgresDescriptorID() cat.StableID {
 // isStale checks if the optTable object needs to be refreshed because the stats,
 // zone config, or used types have changed. False positives are ok.
 func (ot *optTable) isStale(
-	rawDesc catalog.TableDescriptor, tableStats []*stats.TableStatistic, zone *zonepb.ZoneConfig,
+	rawDesc catalog.TableDescriptor, tableStats []*stats.TableStatistic, zone cat.Zone,
 ) bool {
 	// Fast check to verify that the statistics haven't changed: we check the
 	// length and the address of the underlying array. This is not a perfect
@@ -1021,7 +1017,7 @@ func (ot *optTable) Equals(other cat.Object) bool {
 
 	// Verify that indexes are in same zones. For performance, skip deep equality
 	// check if it's the same as the previous index (common case).
-	var prevLeftZone, prevRightZone *zonepb.ZoneConfig
+	var prevLeftZone, prevRightZone cat.Zone
 	for i := range ot.indexes {
 		leftZone := ot.indexes[i].zone
 		rightZone := otherTable.indexes[i].zone
@@ -1132,7 +1128,7 @@ func (ot *optTable) OutboundForeignKeyCount() int {
 	return len(ot.outboundFKs)
 }
 
-// OutboundForeignKeyCount is part of the cat.Table interface.
+// OutboundForeignKey is part of the cat.Table interface.
 func (ot *optTable) OutboundForeignKey(i int) cat.ForeignKeyConstraint {
 	return &ot.outboundFKs[i]
 }
@@ -1197,7 +1193,7 @@ func (ot *optTable) CollectTypes(ord int) (descpb.IDs, error) {
 type optIndex struct {
 	tab  *optTable
 	idx  catalog.Index
-	zone *zonepb.ZoneConfig
+	zone cat.Zone
 
 	// columnOrds maps the index columns to table column ordinals.
 	columnOrds []int
@@ -1229,8 +1225,8 @@ func (oi *optIndex) init(
 	tab *optTable,
 	indexOrdinal int,
 	idx catalog.Index,
-	zone *zonepb.ZoneConfig,
-	partZones map[string]*zonepb.ZoneConfig,
+	zone cat.Zone,
+	partZones map[string]cat.Zone,
 	invertedColOrd int,
 ) {
 	oi.tab = tab
@@ -1263,7 +1259,7 @@ func (oi *optIndex) init(
 	_ = idxPartitioning.ForEachList(func(name string, values [][]byte, subPartitioning catalog.Partitioning) error {
 		op := optPartition{
 			name:   name,
-			zone:   &zonepb.ZoneConfig{},
+			zone:   cat.EmptyZone(),
 			datums: make([]tree.Datums, 0, len(values)),
 		}
 
@@ -1479,7 +1475,7 @@ func (oi *optIndex) Partition(i int) cat.Partition {
 // partition of an index.
 type optPartition struct {
 	name   string
-	zone   *zonepb.ZoneConfig
+	zone   cat.Zone
 	datums []tree.Datums
 }
 


### PR DESCRIPTION
This commit breaks the dependency that `pkg/config/zonepb` previously had on `pkg/sql/catalog/descpb` and `pkg/sql/opt/cat`. This allows us to establish a dependency from `pkg/sql/catalog/descpb` to `pkg/config/zonepb`.

The approach this commit takes is to stop implementing `cat.Zone` and its related interface on `zonepb.ZoneConfig` directly. Instead, we provide a default implementation of `cat.Zone` from `pkg/sql/cat` that shares the same structure as `zonepb.ZoneConfig`. To do so, we need to expand the interface slightly.

Release justification: None, wait for branch cut.