### PR TITLE
sql: break dependency from config/zonepb to sql/catalog/descpb (option 2)

### DIFF
--- a/pkg/config/zonepb/BUILD.bazel
+++ b/pkg/config/zonepb/BUILD.bazel
@@ -16,8 +16,6 @@ go_library(
         "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/roachpb",
-        "//pkg/sql/catalog/descpb",
-        "//pkg/sql/opt/cat",
         "//pkg/sql/sem/tree",
         "//pkg/util/log",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/config/zonepb/zone.go
+++ b/pkg/config/zonepb/zone.go
@@ -20,8 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -77,8 +75,8 @@ var NamedZonesByID = func() map[uint32]NamedZone {
 
 // IsNamedZoneID returns true if the given ID is one of the pseudo-table IDs
 // that maps to named zones.
-func IsNamedZoneID(id descpb.ID) bool {
-	_, ok := NamedZonesByID[(uint32(id))]
+func IsNamedZoneID(id uint32) bool {
+	_, ok := NamedZonesByID[id]
 	return ok
 }
 
@@ -1062,7 +1060,7 @@ func (z *ZoneConfig) ReplicaConstraintsCount() int {
 }
 
 // ReplicaConstraints is part of the cat.Zone interface.
-func (z *ZoneConfig) ReplicaConstraints(i int) cat.ReplicaConstraints {
+func (z *ZoneConfig) ReplicaConstraints(i int) *ConstraintsConjunction {
 	return &z.Constraints[i]
 }
 
@@ -1072,7 +1070,7 @@ func (z *ZoneConfig) VoterConstraintsCount() int {
 }
 
 // VoterConstraint is part of the cat.Zone interface.
-func (z *ZoneConfig) VoterConstraint(i int) cat.ReplicaConstraints {
+func (z *ZoneConfig) VoterConstraint(i int) *ConstraintsConjunction {
 	return &z.VoterConstraints[i]
 }
 
@@ -1082,17 +1080,17 @@ func (z *ZoneConfig) LeasePreferenceCount() int {
 }
 
 // LeasePreference is part of the cat.Zone interface.
-func (z *ZoneConfig) LeasePreference(i int) cat.ConstraintSet {
+func (z *ZoneConfig) LeasePreference(i int) *LeasePreference {
 	return &z.LeasePreferences[i]
 }
 
-// ConstraintCount is part of the cat.LeasePreference interface.
+// ConstraintCount is part of the cat.ConstraintSet interface.
 func (l *LeasePreference) ConstraintCount() int {
 	return len(l.Constraints)
 }
 
-// Constraint is part of the cat.LeasePreference interface.
-func (l *LeasePreference) Constraint(i int) cat.Constraint {
+// Constraint is part of the cat.ConstraintSet interface.
+func (l *LeasePreference) Constraint(i int) *Constraint {
 	return &l.Constraints[i]
 }
 
@@ -1121,7 +1119,7 @@ func (c *ConstraintsConjunction) ConstraintCount() int {
 }
 
 // Constraint is part of the cat.ReplicaConstraints interface.
-func (c *ConstraintsConjunction) Constraint(i int) cat.Constraint {
+func (c *ConstraintsConjunction) Constraint(i int) *Constraint {
 	return &c.Constraints[i]
 }
 

--- a/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
+++ b/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
@@ -216,7 +216,7 @@ func (s *SQLTranslator) generateSpanConfigurations(
 	descsCol *descs.Collection,
 	ptsStateReader *spanconfig.ProtectedTimestampStateReader,
 ) (_ []spanconfig.Record, err error) {
-	if zonepb.IsNamedZoneID(id) {
+	if zonepb.IsNamedZoneID(uint32(id)) {
 		return s.generateSpanConfigurationsForNamedZone(ctx, txn, id)
 	}
 
@@ -489,7 +489,7 @@ func (s *SQLTranslator) generateSpanConfigurationsForTable(
 func (s *SQLTranslator) findDescendantLeafIDs(
 	ctx context.Context, id descpb.ID, txn *kv.Txn, descsCol *descs.Collection,
 ) (descpb.IDs, error) {
-	if zonepb.IsNamedZoneID(id) {
+	if zonepb.IsNamedZoneID(uint32(id)) {
 		return s.findDescendantLeafIDsForNamedZone(ctx, id, txn, descsCol)
 	}
 	// We're dealing with a SQL Object here.

--- a/pkg/sql/opt/cat/BUILD.bazel
+++ b/pkg/sql/opt/cat/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/cat",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/config/zonepb",
         "//pkg/geo/geoindex",
         "//pkg/roachpb",
         "//pkg/security",

--- a/pkg/sql/opt/cat/zone.go
+++ b/pkg/sql/opt/cat/zone.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 )
 
@@ -30,7 +31,7 @@ type Zone interface {
 
 	// ReplicaConstraints returns the ith set of replica constraints in the zone,
 	// where i < ReplicaConstraintsCount.
-	ReplicaConstraints(i int) ReplicaConstraints
+	ReplicaConstraints(i int) *zonepb.ConstraintsConjunction
 
 	// VoterConstraintsCount returns the number of voter replica constraint sets
 	// that are part of this zone.
@@ -38,7 +39,7 @@ type Zone interface {
 
 	// VoterConstraint returns the ith set of voter replica constraints in the
 	// zone, where i < VoterConstraintsCount.
-	VoterConstraint(i int) ReplicaConstraints
+	VoterConstraint(i int) *zonepb.ConstraintsConjunction
 
 	// LeasePreferenceCount returns the number of lease preferences that are part
 	// of this zone.
@@ -46,7 +47,7 @@ type Zone interface {
 
 	// LeasePreference returns the ith lease preference in the zone, where
 	// i < LeasePreferenceCount.
-	LeasePreference(i int) ConstraintSet
+	LeasePreference(i int) *zonepb.LeasePreference
 }
 
 // ConstraintSet is a set of constraints that apply to a range, restricting
@@ -58,7 +59,7 @@ type ConstraintSet interface {
 
 	// Constraint returns the ith constraint in the set, where
 	// i < ConstraintCount.
-	Constraint(i int) Constraint
+	Constraint(i int) *zonepb.Constraint
 }
 
 // ReplicaConstraints is a set of constraints that apply to one or more replicas


### PR DESCRIPTION
This commit breaks the dependency that `pkg/config/zonepb` previously had on `pkg/sql/catalog/descpb` and `pkg/sql/opt/cat`. This allows us to establish a dependency from `pkg/sql/catalog/descpb` to `pkg/config/zonepb`.

The approach this commit takes is to remove all references to `pkg/sql/cat` package in the `pkg/sql/cat.Zone` interface. This allows the `zonepb.ZoneConfig` struct to continue implementing the `cat.Zone` interface without it establishing an explicit dependency on the `pkg/sql/opt/cat` package. This is a smaller change than alternatives, but it couples the implementation of `cat.Zone` to the `zonepb` package in a way that may be undesirable.