### PR TITLE
ui/tracez: allow the trace to take up more horizontal space

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/tracez/tracez.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/tracez/tracez.tsx
@@ -438,10 +438,8 @@ const TraceView = ({
           </Button>
         </PageConfigItem>
       </PageConfig>
-      <section className="section">
-        <div>
-          <pre>{currentTrace.serialized_recording}</pre>
-        </div>
+      <section className="section" style={{ maxWidth: "none" }}>
+        <pre>{currentTrace.serialized_recording}</pre>
       </section>
     </>
   );


### PR DESCRIPTION
Before this patch, when displaying a trace in the /tracez page, the
horizontal space for the trace recording (which is a big blob of
pre-formatted text) was limited to a fairly small size, courtesy of the
"section" CSS class. This patch allows it to take up all the window,
which is useful for long log lines.

This patch overrides the size limit. I've attempted to remove the
section part completely instead, but the page header has a negative
bottom margin that the section class cancels out through a top margin,
so I've left it alone.

Release note: None

Before

![Screenshot from 2022-03-15 16-38-26](https://user-images.githubusercontent.com/377201/158469890-65f02bd1-0d1b-49d9-9369-583b880aaedf.png)


After

![Screenshot from 2022-03-15 16-40-41](https://user-images.githubusercontent.com/377201/158469920-1ebd42cf-b7c8-455b-8442-494a7095da23.png)

