### PR TITLE
release-22.1: build: disable release justification

### DIFF
--- a/githooks/commit-msg
+++ b/githooks/commit-msg
@@ -52,7 +52,7 @@ IFS='
 notes=($($grep -iE '^release note' "$1"))
 
 # Set this to 1 to require a release justification note.
-require_justification=1
+require_justification=0
 justification=($($grep -iE '^release justification: \S+' "$1"))
 
 IFS=$saveIFS

--- a/githooks/prepare-commit-msg
+++ b/githooks/prepare-commit-msg
@@ -2,7 +2,7 @@
 #
 # Prepare the commit message by adding a release note.
 
-require_justification=1
+require_justification=0
 set -euo pipefail
 
 if [[ "${2-}" = "message" ]]; then


### PR DESCRIPTION
Backport 1/1 commits from #77804.

/cc @cockroachdb/release

---

Now that release-22.1 is cut, we can disable release justification
githook check and let blathers justification check take over.

Notes: 
- to be merged after the release-22.1 branch cut.
- `blathers/release-justification-check` will pass after `STABILITY_PERIOD` is turned off [as part of the branch cut runbook]

Tasks for tomorrow's branch cut (that relate to this PR):

- [x] cut `release-22.1` branch
- [x] turn off `STABILITY_PERIOD` to disable `blathers/release-justification-check` on master (we will now lean on pre-existing blathers check release justifications on `release-22.1`]
- [x] merge this PR
- [x] backport this PR to `release-22.1`

Release note: None
Release justification: internal-only / non-production / release-process code change

