### PR TITLE
*: remove redundant newlines at end of Fprintln

### DIFF
--- a/pkg/cli/clisqlclient/conn.go
+++ b/pkg/cli/clisqlclient/conn.go
@@ -384,8 +384,8 @@ func (c *sqlConn) checkServerMetadata(ctx context.Context) error {
 			cv, err := version.Parse(client.Tag)
 			if err == nil {
 				if sv.Compare(cv) == -1 { // server ver < client ver
-					fmt.Fprintln(c.errw, "\nwarning: server version older than client! "+
-						"proceed with caution; some features may not be available.\n")
+					fmt.Fprint(c.errw, "\nwarning: server version older than client! "+
+						"proceed with caution; some features may not be available.\n\n")
 				}
 			}
 		}

--- a/pkg/util/log/test_log_scope.go
+++ b/pkg/util/log/test_log_scope.go
@@ -395,9 +395,9 @@ func (l *TestLogScope) Close(t tShim) {
 				// If the test failed or there was a panic, we keep the log
 				// files for further investigation.
 				if inPanic {
-					fmt.Fprintln(OrigStderr, "\nERROR: a panic has occurred!\n"+
+					fmt.Fprint(OrigStderr, "\nERROR: a panic has occurred!\n"+
 						"Details cannot be printed yet because we are still unwinding.\n"+
-						"Hopefully the test harness prints the panic below, otherwise check the test logs.\n")
+						"Hopefully the test harness prints the panic below, otherwise check the test logs.\n\n")
 				}
 				fmt.Fprintln(OrigStderr, "test logs left over in:", l.logDir)
 			} else {


### PR DESCRIPTION
Without this, compiling tests under go1.18 fails with:
```
pkg/cli/clisqlclient/conn.go:387:6: fmt.Fprintln arg list ends with redundant newline
pkg/util/log/test_log_scope.go:398:6: fmt.Fprintln arg list ends with redundant newline
```

After #77857, this is the only change needed to compile all tests using go1.18.

Release justification: None, wait for branch cut.