### PR TITLE
roachtest: update node death expectations in disk-full test

### DIFF
--- a/pkg/cmd/roachtest/tests/disk_full.go
+++ b/pkg/cmd/roachtest/tests/disk_full.go
@@ -35,15 +35,14 @@ func registerDiskFull(r registry.Registry) {
 			}
 
 			nodes := c.Spec().NodeCount - 1
-			c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
-			c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))
+			c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, c.Spec().NodeCount))
 			c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Range(1, nodes))
 
 			t.Status("running workload")
 			m := c.NewMonitor(ctx, c.Range(1, nodes))
 			m.Go(func(ctx context.Context) error {
 				cmd := fmt.Sprintf(
-					"./workload run kv --tolerate-errors --init --read-percent=0"+
+					"./cockroach workload run kv --tolerate-errors --init --read-percent=0"+
 						" --concurrency=10 --duration=4m {pgurl:2-%d}",
 					nodes)
 				c.Run(ctx, c.Node(nodes+1), cmd)
@@ -118,13 +117,16 @@ func registerDiskFull(r registry.Registry) {
 
 				// Clear the emergency ballast. Clearing the ballast
 				// should allow the node to start, perform compactions,
-				// etc.
+				// etc. Allow a death here as the monitor may detect the
+				// node is still dead until the node has had its ballast
+				// file removed and has been successfully restarted.
 				t.L().Printf("removing the emergency ballast on n%d\n", n)
-				m.ResetDeaths()
+				m.ExpectDeath()
 				c.Run(ctx, c.Node(n), "rm -f {store-dir}/auxiliary/EMERGENCY_BALLAST")
 				if err := c.StartE(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Node(n)); err != nil {
 					t.Fatal(err)
 				}
+				m.ResetDeaths()
 
 				// Wait a little while and delete the large file we
 				// added to induce the out-of-disk condition.


### PR DESCRIPTION
Currently, the `disk-full` roachtest works by intentionally exhausting
disk space on one node in a four node cluster by creating a large
ballast file. After a period of attempting to restart the affected node,
which is expected to fail, and then removing the ballast file, the node
is able to be restarted.

There exists a small race in the test runner where the cluster monitor
can observe that one node is out of disk _while_ the ballast file is
being removed. This results in a context cancellation which fails the
test.

Address the race by allowing the monitor to observe a node death while
the ballast file is being removed. After the file has been removed and
the node has been restarted, the monitor should fail if it sees a
subsequent death.

Release justification: Roachtest only. Fixing a test flake.

Release note: None.

Touches #70873.