### PR TITLE
opt: copy check constraint filter props when duplicating table

### DIFF
--- a/pkg/sql/opt/BUILD.bazel
+++ b/pkg/sql/opt/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
     size = "small",
     srcs = [
         "colset_test.go",
+        "filters_test.go",
         "metadata_test.go",
         "operator_test.go",
         "ordering_test.go",
@@ -58,6 +59,7 @@ go_test(
         "//pkg/sql/opt/cat",
         "//pkg/sql/opt/memo",
         "//pkg/sql/opt/norm",
+        "//pkg/sql/opt/optbuilder",
         "//pkg/sql/opt/testutils/testcat",
         "//pkg/sql/privilege",
         "//pkg/sql/sem/eval",

--- a/pkg/sql/opt/colset.go
+++ b/pkg/sql/opt/colset.go
@@ -138,6 +138,21 @@ func (s ColSet) ToList() ColList {
 	return res
 }
 
+// CopyAndMaybeRemap looks up each ColumnID from s in the colMap. If present,
+// the mapped ColumnID is added a new ColSet, otherwise the unmapped ColumnID is
+// added. The new ColSet is returned to the caller.
+func (s ColSet) CopyAndMaybeRemap(colMap ColMap) ColSet {
+	newCols := ColSet{}
+	for srcCol, ok := s.Next(0); ok; srcCol, ok = s.Next(srcCol + 1) {
+		if newColID, ok := colMap.Get(int(srcCol)); ok {
+			newCols.Add(ColumnID(newColID))
+		} else {
+			newCols.Add(srcCol)
+		}
+	}
+	return newCols
+}
+
 // TranslateColSet is used to translate a ColSet from one set of column IDs
 // to an equivalent set. This is relevant for set operations such as UNION,
 // INTERSECT and EXCEPT, and can be used to map a ColSet defined on the left

--- a/pkg/sql/opt/constraint/columns.go
+++ b/pkg/sql/opt/constraint/columns.go
@@ -143,6 +143,19 @@ func (c *Columns) RemapColumns(from, to opt.TableID) Columns {
 	return newColumns
 }
 
+// CopyAndMaybeRemapColumnsWithColMap copies ordering columns in c and
+// conditionally remaps them according to a colMap if they can be found in the
+// colMap. The original OrderingColumns are not mutated.
+func (c *Columns) CopyAndMaybeRemapColumnsWithColMap(colMap opt.ColMap) Columns {
+	var newColumns Columns
+	newColumns.firstCol = c.firstCol.CopyAndMaybeRemapColumn(colMap)
+	newColumns.otherCols = make([]opt.OrderingColumn, len(c.otherCols))
+	for i := range c.otherCols {
+		newColumns.otherCols[i] = c.otherCols[i].CopyAndMaybeRemapColumn(colMap)
+	}
+	return newColumns
+}
+
 // ColSet returns the columns as a ColSet.
 func (c *Columns) ColSet() opt.ColSet {
 	var r opt.ColSet

--- a/pkg/sql/opt/constraint/constraint.go
+++ b/pkg/sql/opt/constraint/constraint.go
@@ -84,6 +84,23 @@ func (c *Constraint) IsUnconstrained() bool {
 	return c.Spans.Count() == 1 && c.Spans.Get(0).IsUnconstrained()
 }
 
+// Immutable indicates if this Constraint has been marked as immutable.
+func (c *Constraint) Immutable() bool {
+	return c.Spans.Immutable()
+}
+
+// Equals returns true if the two Constraints are identical.
+func (c *Constraint) Equals(other *Constraint, evalCtx *eval.Context) bool {
+	if other == nil {
+		return false
+	}
+	if !c.Columns.Equals(&other.Columns) {
+		return false
+	}
+	keyCtx := MakeKeyContext(&c.Columns, evalCtx)
+	return c.Spans.Equals(&other.Spans, &keyCtx)
+}
+
 // UnionWith merges the spans of the given constraint into this constraint.  The
 // columns of both constraints must be the same. Constrained columns in the
 // merged constraint can have values that are part of either of the input

--- a/pkg/sql/opt/constraint/constraint_set_test.go
+++ b/pkg/sql/opt/constraint/constraint_set_test.go
@@ -20,6 +20,39 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
+func TestTrivialConstraintSetEquals(t *testing.T) {
+	// If compile errors are seen in this function, that may mean one or more of the
+	// following functions need to be updated:
+	//   constraint.Set.Equals
+	//   constraint.Constraint.Equals
+	//   constraint.Set.CopyAndMaybeRemapConstraintSetWithColMap
+	//   opt.OrderingColumn.CopyAndMaybeRemapColumn
+	//   constraint.Columns.CopyAndMaybeRemapColumnsWithColMap
+	// Please inspect them and modify as appropriate.
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := eval.NewTestingEvalContext(st)
+
+	cs1 := Set{Constraint{
+		Columns{opt.OrderingColumn(1), nil},
+		Spans{Span{Key{tree.NewDInt(tree.DInt(1)), nil},
+			Key{tree.NewDInt(tree.DInt(2)), nil}, IncludeBoundary, IncludeBoundary},
+			nil, 1, true}},
+		nil, 1, false}
+	cs2 := Set{Constraint{
+		Columns{opt.OrderingColumn(1), nil},
+		Spans{Span{Key{tree.NewDInt(tree.DInt(1)), nil},
+			Key{tree.NewDInt(tree.DInt(3)), nil}, IncludeBoundary, IncludeBoundary},
+			nil, 1, true}},
+		nil, 1, false}
+	cs1Copy := cs1
+	if cs1.Equals(&cs2, evalCtx) {
+		t.Errorf("Constraint Sets expected to be unequal. cs1: %v: cs2: %v", cs1, cs2)
+	}
+	if !cs1.Equals(&cs1Copy, evalCtx) {
+		t.Errorf("Constraint Sets expected to be equal. cs1: %v: cs1Copy: %v", cs1, cs1Copy)
+	}
+}
+
 func TestConstraintSetIntersect(t *testing.T) {
 	kc1 := testKeyContext(1)
 	kc2 := testKeyContext(2)
@@ -273,6 +306,47 @@ func TestExtractCols(t *testing.T) {
 	}
 }
 
+// TestConstraintSetCopyRemap tests that mapping and then unmapping a constraint
+// set results in the original constraint set.
+func TestConstraintSetCopyRemap(t *testing.T) {
+	type testCase struct {
+		constraint string
+	}
+
+	cases := []testCase{
+		{"/1: [/2 - /5] [/8 - /10]"},
+		{"/2: [/3 - ]"},
+		{"/3: [/6 - /6]"},
+		{"/1/2/3: [/1/2 - /1/3] [/1/4 - /1]"},
+		{"/1/2/3: [/1/2/3 - /1/2/3] [/1/2/5 - /1/2/8]"},
+		{"/1/2/3: [/1/2/NULL - /1/2/3] [/1/2/5 - /1/2/8]"},
+		{"/3/-2: [/5/3 - /5/2]"},
+		{"/-3/2/1: [/5/3/1 - /5/3/4] [/3/5/1 - /3/5/4]"},
+		{"/3/1/-2: [/5/3/8 - /5/3/6] [/9/5/4 - /9/5/1]"},
+		{"/3/1/-2: [/5/3/8 - /5/3/6] [/9/5/4 - /9/5/NULL]"},
+		{"/1: [/2 - /5] [/8 - /10]"},
+	}
+	var colMap opt.ColMap
+	var reverseMap opt.ColMap
+	const maxColID = 150
+	for i := 1; i <= maxColID; i++ {
+		colMap.Set(i, i+maxColID)
+		reverseMap.Set(i+maxColID, i)
+	}
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := eval.NewTestingEvalContext(st)
+	for _, tc := range cases {
+		cs := Unconstrained
+		constraint := ParseConstraint(evalCtx, tc.constraint)
+		cs = cs.Intersect(evalCtx, SingleConstraint(&constraint))
+		setRemapped := cs.CopyAndMaybeRemapConstraintSetWithColMap(colMap)
+		setReRemapped := setRemapped.CopyAndMaybeRemapConstraintSetWithColMap(reverseMap)
+		if !cs.Equals(setReRemapped, evalCtx) || !setReRemapped.Equals(cs, evalCtx) {
+			t.Errorf("Sets not equal. set: %v, setReRemapped: %v", cs, setReRemapped)
+		}
+	}
+}
+
 func TestExtractConstColsForSet(t *testing.T) {
 	type vals map[opt.ColumnID]string
 	type testCase struct {
@@ -448,4 +522,93 @@ func newSpanTestData() *spanTestData {
 	data.spGe1015.Init(key1015, IncludeBoundary, EmptyKey, IncludeBoundary)
 
 	return data
+}
+
+// TestEqualsNegative tests that a copy of constraints made with function
+// CopyAndMaybeRemapConstraintSetWithColMap, with no columns remapped, is
+// identical to the original constraint, and that unsetting the `immutable` flag
+// in the copy makes it unequal.
+func TestEqualsNegative(t *testing.T) {
+	type testCase struct {
+		constraints []string
+	}
+
+	cases := []testCase{
+		{[]string{`/1/-3: [/1/13 - /1/7]`}},
+		{[]string{`/1/2: [/10/4 - /10/5] [/12/4 - /12/5]`}},
+		{[]string{`/1: [/10 - /10]`}},
+		{[]string{`/-1: [/10 - /10]`}},
+		{[]string{`/1: [/10 - /11]`}},
+		{[]string{`/1: [/10 - /10] [/11 - /11]`}},
+		{[]string{`/1: [/10 - /10] [/11 - /11] [/12 - /12]`}},
+		{[]string{`/1: [/10 - /10] [/11 - /11] [/12 - /13]`}},
+		{[]string{`/1/2: [/10/2 - /10/4]`}},
+		{[]string{`/1/2: [/10/2 - /10/2]`}},
+		{
+			[]string{
+				`/1: [/10 - /10]`,
+				`/1: [/8 - /8]`,
+			},
+		},
+		{
+			[]string{
+				`/1: [/10 - /10]`,
+				`/1: [/10/8 - /10/8]`,
+			},
+		},
+	}
+
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := eval.NewTestingEvalContext(st)
+	var colMap opt.ColMap
+	for _, tc := range cases {
+		var cs *Set
+		for i, constraint := range tc.constraints {
+			constraint := ParseConstraint(evalCtx, constraint)
+			constraint.Spans.makeImmutable()
+			if i == 0 {
+				cs = SingleConstraint(&constraint)
+			} else {
+				cs = cs.Union(evalCtx, SingleConstraint(&constraint))
+			}
+		}
+		csRemapped := cs.CopyAndMaybeRemapConstraintSetWithColMap(colMap)
+		if !csRemapped.Equals(cs, evalCtx) || !cs.Equals(csRemapped, evalCtx) {
+			t.Errorf("Constraint Sets expected to match. cs: %v: csRemapped: %v", cs, csRemapped)
+		}
+		// Make a copy of the constraint Set with a firstConstraint Spans that has
+		// the immutable flag unset.
+		spans := csRemapped.firstConstraint.Spans
+		spansCopy := Spans{}
+		spansCopy.Alloc(int(spans.numSpans))
+
+		for i := 0; i < int(spans.numSpans); i++ {
+			spansCopy.Append(spans.Get(i))
+		}
+		csRemapped.firstConstraint.Spans = spansCopy
+
+		if csRemapped.Equals(cs, evalCtx) || cs.Equals(csRemapped, evalCtx) {
+			t.Errorf("Constraint Sets expected to be unequal. cs: %v: csRemapped: %v", cs, csRemapped)
+		}
+		csRemapped.firstConstraint.Spans.makeImmutable()
+
+		// Now they should match since Equals checks if Spans are immutable.
+		if !csRemapped.Equals(cs, evalCtx) || !cs.Equals(csRemapped, evalCtx) {
+			t.Errorf("Constraint Sets expected to be equal. cs: %v: csRemapped: %v", cs, csRemapped)
+		}
+	}
+}
+
+func TestEqualsTrival(t *testing.T) {
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := eval.NewTestingEvalContext(st)
+	if !Unconstrained.Equals(Unconstrained, evalCtx) {
+		t.Errorf("Constraint Sets expected to be equal.")
+	}
+	if !Contradiction.Equals(Contradiction, evalCtx) {
+		t.Errorf("Constraint Sets expected to be equal.")
+	}
+	if Contradiction.Equals(Unconstrained, evalCtx) {
+		t.Errorf("Constraint Sets expected to be unequal.")
+	}
 }

--- a/pkg/sql/opt/filters_test.go
+++ b/pkg/sql/opt/filters_test.go
@@ -1,0 +1,183 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package opt_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// TestDuplicateTableWithCheckConstraint tests that we can accurately duplicate
+// the optimizer's representation check constraint filters when calling
+// DuplicateTable.
+func TestDuplicateTableWithCheckConstraint(t *testing.T) {
+	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	var f norm.Factory
+	cat := testcat.New()
+	f.Init(&evalCtx, cat /* catalog */)
+	var c norm.CustomFuncs
+	c.Init(&f)
+	semaCtx := tree.MakeSemaContext()
+	ctx := context.Background()
+	builder := optbuilder.New(ctx, &semaCtx, &evalCtx, cat, &f, nil)
+
+	_, err := cat.ExecuteDDL("CREATE TABLE a (i INT CHECK (i IN (5,2,8,5,9)), i2 INT CHECK (i = i2), PRIMARY KEY (i2, i))")
+	if err != nil {
+		t.Fatal(err)
+	}
+	md := f.Metadata()
+	tn := tree.NewUnqualifiedTableName("a")
+	a := md.AddTable(cat.Table(tn), tn)
+
+	tabMeta := md.TableMeta(a)
+	builder.AddCheckConstraintsForTable(tabMeta)
+
+	// Duplicate the table.
+	dupA := md.DuplicateTable(a, f.RemapCols)
+	dupTabMeta := md.TableMeta(dupA)
+
+	if dupTabMeta.Constraints == nil {
+		t.Fatalf("expected constraints to be duplicated")
+	}
+
+	origConstraints := *tabMeta.Constraints.(*memo.FiltersExpr)
+	dupedConstraints := *dupTabMeta.Constraints.(*memo.FiltersExpr)
+	if len(origConstraints) != len(dupedConstraints) {
+		t.Fatalf("Length of original constraints doesn't match length of duped constraints")
+	}
+	for i := range origConstraints {
+		if origConstraints[i].ScalarProps().Equals(dupedConstraints[i].ScalarProps(), &evalCtx) {
+			t.Fatalf("Scalar properties of duplicated constraints including remapping not expected to match original constraints")
+		}
+	}
+
+	// Now remap back to original column ids and check for equality.
+	colMap := makeColMap(dupTabMeta, tabMeta)
+	doublyRemappedConstraints := *f.RemapCols(&dupedConstraints, colMap).(*memo.FiltersExpr)
+
+	for i := range origConstraints {
+		if !origConstraints[i].ScalarProps().Equals(doublyRemappedConstraints[i].ScalarProps(), &evalCtx) {
+			t.Fatalf("Scalar properties of doubly-remapped, duplicated constraints do not match the original constraints")
+		}
+	}
+}
+
+// BenchmarkCopyConstructConstraints compares the cost of copying scalar
+// properties of a copied filter with constructing the copied filter from
+// scratch.
+func BenchmarkCopyConstructConstraints(b *testing.B) {
+	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	var f norm.Factory
+	cat := testcat.New()
+	f.Init(&evalCtx, cat /* catalog */)
+	var c norm.CustomFuncs
+	c.Init(&f)
+	semaCtx := tree.MakeSemaContext()
+	ctx := context.Background()
+	builder := optbuilder.New(ctx, &semaCtx, &evalCtx, cat, &f, nil)
+
+	_, err := cat.ExecuteDDL(
+		`CREATE TABLE a (i INT
+		CHECK (i IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,28,29,30,
+					31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,
+					61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,
+					91,92,93,94,95,96,97,98,99,100,
+					101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,
+					121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,
+					141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,
+					161,162,163,164,165,166,167,168,169,170,171,172,173,174,175,176,177,178,179,180,
+					181,182,183,184,185,186,187,188,189,190,191,192,193,194,195,196,197,198,199,200,
+					201,202,203,204,205,206,207,208,209,210,211,212,213,214,215,216,217,218,219,220,
+					221,222,223,224,225,226,227,228,229,230,231,232,233,234,235,236,237,238,239,240))
+		, i2 INT CHECK (i = i2), PRIMARY KEY(i2, i))`)
+	if err != nil {
+		b.Fatal(err)
+	}
+	md := f.Metadata()
+	tn := tree.NewUnqualifiedTableName("a")
+	a := md.AddTable(cat.Table(tn), tn)
+
+	tabMeta := md.TableMeta(a)
+	builder.AddCheckConstraintsForTable(tabMeta)
+
+	// Duplicate the table.
+	dupA := md.DuplicateTable(a, f.RemapCols)
+	dupTabMeta := md.TableMeta(dupA)
+
+	if dupTabMeta.Constraints == nil {
+		b.Fatalf("expected constraints to be duplicated")
+	}
+	origConstraints := *tabMeta.Constraints.(*memo.FiltersExpr)
+
+	colMap := makeColMap(tabMeta, dupTabMeta)
+	replace := f.ColumnRemapFunction(colMap)
+
+	var cols opt.ColSet
+	for i := 0; i < tabMeta.Table.ColumnCount(); i++ {
+		cols.Add(tabMeta.MetaID.ColumnID(i))
+	}
+	sp := memo.ScanPrivate{Table: tabMeta.MetaID, Cols: cols}
+	selectExpr := f.ConstructSelect(f.ConstructScan(&sp), origConstraints)
+
+	// Run the operation 10000 times per execution of the benchmark function. This
+	// causes GC pressure to become a factor and a huge discrepancy in the number
+	// of times the test can be run in one second is apparent. Example results:
+	//                          # of executions in 1 sec     Time per execution
+	// ------------------------------------------------------------------------
+	// ConstructFilterTest-32         	               7        146437858 ns/op
+	// CopyConstructFilterTest-32             1000000000           0.1694 ns/op
+
+	const numOps = 10000
+	runBench1 := func(b *testing.B) {
+		b.ResetTimer()
+		b.StartTimer()
+		for i := 0; i < numOps; i++ {
+			_ = replace(selectExpr)
+		}
+		b.StopTimer()
+	}
+	runBench2 := func(b *testing.B) {
+		b.ResetTimer()
+		b.StartTimer()
+		for i := 0; i < numOps; i++ {
+			_ = replace(&origConstraints)
+		}
+		b.StopTimer()
+	}
+
+	// This is the slower way to construct a copy of filters.
+	b.Run(`ConstructFilterTest`, func(b *testing.B) {
+		runBench1(b)
+	})
+
+	// Copy constructing filters should be faster.
+	b.Run(`CopyConstructFilterTest`, func(b *testing.B) {
+		runBench2(b)
+	})
+
+}
+
+func makeColMap(fromTable *opt.TableMeta, toTable *opt.TableMeta) opt.ColMap {
+	colMap := opt.ColMap{}
+	for i := 0; i < fromTable.Table.ColumnCount(); i++ {
+		colMap.Set(int(fromTable.MetaID.ColumnID(i)), int(toTable.MetaID.ColumnID(i)))
+	}
+	return colMap
+}

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -589,7 +589,7 @@ func (b *Builder) buildScan(
 		private.Flags.NoZigzagJoin = true
 	}
 
-	b.addCheckConstraintsForTable(tabMeta)
+	b.AddCheckConstraintsForTable(tabMeta)
 	b.addComputedColsForTable(tabMeta)
 
 	outScope.expr = b.factory.ConstructScan(&private)
@@ -631,14 +631,14 @@ func (b *Builder) buildScan(
 	return outScope
 }
 
-// addCheckConstraintsForTable extracts filters from the check constraints that
+// AddCheckConstraintsForTable extracts filters from the check constraints that
 // apply to the table and adds them to the table metadata (see
 // TableMeta.Constraints). To do this, the scalar expressions of the check
 // constraints are built here.
 //
 // These expressions are used as "known truths" about table data; as such they
 // can only contain immutable operators.
-func (b *Builder) addCheckConstraintsForTable(tabMeta *opt.TableMeta) {
+func (b *Builder) AddCheckConstraintsForTable(tabMeta *opt.TableMeta) {
 	// Columns of a user defined type have a constraint to ensure
 	// enum values for that column belong to the UDT. We do not want to
 	// track view deps here, or else a view depending on a table with a

--- a/pkg/sql/opt/ordering.go
+++ b/pkg/sql/opt/ordering.go
@@ -55,6 +55,18 @@ func (c OrderingColumn) RemapColumn(from, to TableID) OrderingColumn {
 	return MakeOrderingColumn(newColID, c.Descending())
 }
 
+// CopyAndMaybeRemapColumn copies an OrderingColumn c and conditionally remaps
+// it according to a colMap if c is found in the colMap.
+func (c OrderingColumn) CopyAndMaybeRemapColumn(colMap ColMap) OrderingColumn {
+	var remappedCol ColumnID
+	if dstCol, ok := colMap.Get(int(c.ID())); ok {
+		remappedCol = ColumnID(dstCol)
+	} else {
+		remappedCol = c.ID()
+	}
+	return MakeOrderingColumn(remappedCol, c.Descending())
+}
+
 func (c OrderingColumn) String() string {
 	var buf bytes.Buffer
 	c.Format(&buf)

--- a/pkg/sql/opt/props/BUILD.bazel
+++ b/pkg/sql/opt/props/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
         "histogram_test.go",
         "multiplicity_test.go",
         "ordering_choice_test.go",
+        "scalar_test.go",
         "selectivity_test.go",
         "statistics_test.go",
         "volatility_test.go",

--- a/pkg/sql/opt/props/func_dep.go
+++ b/pkg/sql/opt/props/func_dep.go
@@ -569,6 +569,31 @@ func (f *FuncDepSet) RemapFrom(fdset *FuncDepSet, fromCols, toCols opt.ColList) 
 	f.key = opt.TranslateColSetStrict(f.key, fromCols, toCols)
 }
 
+// newFieldCompileCheck is a reminder to update function CopyAndMaybeRemap when
+// a new field is added to FuncDepSet. Please don't fix the compilation failure
+// without updating CopyAndMaybeRemap to properly handle the newly added field.
+var newFieldCompileCheck = FuncDepSet{[]funcDep{{opt.MakeColSet(1, 2),
+	opt.MakeColSet(3, 4), true, true}}, strictKey,
+	opt.MakeColSet(1, 2)}
+
+// CopyAndMaybeRemap copies f, remapping column IDs according to the colMap,
+// if a mapping exists.
+func (f *FuncDepSet) CopyAndMaybeRemap(colMap opt.ColMap) FuncDepSet {
+	newFuncDepSet := FuncDepSet{}
+	if f.deps != nil {
+		newFuncDepSet.deps = make([]funcDep, len(f.deps))
+	}
+	for i := range f.deps {
+		newFuncDepSet.deps[i].from = f.deps[i].from.CopyAndMaybeRemap(colMap)
+		newFuncDepSet.deps[i].to = f.deps[i].to.CopyAndMaybeRemap(colMap)
+		newFuncDepSet.deps[i].strict = f.deps[i].strict
+		newFuncDepSet.deps[i].equiv = f.deps[i].equiv
+	}
+	newFuncDepSet.hasKey = f.hasKey
+	newFuncDepSet.key = f.key.CopyAndMaybeRemap(colMap)
+	return newFuncDepSet
+}
+
 // ColsAreStrictKey returns true if the given columns contain a strict key for the
 // relation. This means that any two rows in the relation will never have the
 // same values for this set of columns. If the columns are nullable, then at
@@ -1990,6 +2015,28 @@ func (f *FuncDepSet) makeEquivMap(from, to opt.ColSet) map[opt.ColumnID]opt.Colu
 	return equivMap
 }
 
+// Equals tests if two FuncDepSets are identical.
+func (f *FuncDepSet) Equals(other *FuncDepSet) bool {
+	if other == nil {
+		return false
+	}
+	if len(f.deps) != len(other.deps) {
+		return false
+	}
+	for i := range f.deps {
+		if !f.deps[i].Equals(&other.deps[i]) {
+			return false
+		}
+	}
+	if f.hasKey != other.hasKey {
+		return false
+	}
+	if !f.key.Equals(other.key) {
+		return false
+	}
+	return true
+}
+
 // isConstant returns true if this FD contains the set of constant columns. If
 // it exists, it must always be the first FD in the set.
 func (f *funcDep) isConstant() bool {
@@ -2019,6 +2066,26 @@ func (f *funcDep) removeFromCols(remove opt.ColSet) bool {
 	}
 	return !f.isConstant()
 
+}
+
+// Equals tests if two funcDeps are identical.
+func (f *funcDep) Equals(other *funcDep) bool {
+	if other == nil {
+		return false
+	}
+	if f.equiv != other.equiv {
+		return false
+	}
+	if f.strict != other.strict {
+		return false
+	}
+	if !f.to.Equals(other.to) {
+		return false
+	}
+	if !f.from.Equals(other.from) {
+		return false
+	}
+	return true
 }
 
 // removeToCols removes columns in the given set from this FD's dependant set.

--- a/pkg/sql/opt/props/func_dep_test.go
+++ b/pkg/sql/opt/props/func_dep_test.go
@@ -1330,6 +1330,21 @@ func makeJoinFD(t *testing.T) *props.FuncDepSet {
 	return join
 }
 
+func testFDRemap(t *testing.T, fd *props.FuncDepSet) {
+	var colMap opt.ColMap
+	var reverseMap opt.ColMap
+	const maxColID = 150
+	for i := 1; i <= maxColID; i++ {
+		colMap.Set(i, i+maxColID)
+		reverseMap.Set(i+maxColID, i)
+	}
+	fdRemapped := fd.CopyAndMaybeRemap(colMap)
+	fdReRemapped := fdRemapped.CopyAndMaybeRemap(reverseMap)
+	if !fd.Equals(&fdReRemapped) || !fdReRemapped.Equals(fd) {
+		t.Errorf("FDs not equal. fd: %v, fdReRemapped: %v", fd, fdReRemapped)
+	}
+}
+
 func verifyFD(t *testing.T, f *props.FuncDepSet, expected string) {
 	t.Helper()
 	actual := f.String()
@@ -1356,6 +1371,7 @@ func verifyFD(t *testing.T, f *props.FuncDepSet, expected string) {
 	} else {
 		testColsAreStrictKey(t, f, opt.ColSet{}, false)
 	}
+	testFDRemap(t, f)
 }
 
 func testColsAreStrictKey(t *testing.T, f *props.FuncDepSet, cols opt.ColSet, expected bool) {

--- a/pkg/sql/opt/props/logical.go
+++ b/pkg/sql/opt/props/logical.go
@@ -13,6 +13,7 @@ package props
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 )
 
 // AvailableRuleProps is a bit set that indicates when lazily-populated Rule
@@ -45,6 +46,8 @@ const (
 
 // Shared are properties that are shared by both relational and scalar
 // expressions.
+// Note: If new fields are added to this struct, the Equals and CopyFrom
+//       functions must be updated.
 type Shared struct {
 	// Populated is set to true once the properties have been built for the
 	// operator.
@@ -277,6 +280,8 @@ type Relational struct {
 // Scalar properties are logical properties that are computed for scalar
 // expressions that return primitive-valued types. Scalar properties are
 // lazily populated on request.
+// Note: If new fields are added to this struct, the Equals and CopyFrom
+//       functions must be updated.
 type Scalar struct {
 	Shared
 
@@ -338,6 +343,83 @@ type Scalar struct {
 		// been set.
 		HasHoistableSubquery bool
 	}
+}
+
+// Equals returns true if the shared properties in s are identical to those in
+// "other". The Rule.WithUses map is not compared, as it is lazily populated.
+func (s *Shared) Equals(other *Shared) bool {
+	if other == nil {
+		return false
+	}
+	if s.Populated != other.Populated ||
+		s.HasSubquery != other.HasSubquery ||
+		s.HasCorrelatedSubquery != other.HasCorrelatedSubquery ||
+		s.VolatilitySet != other.VolatilitySet ||
+		s.CanMutate != other.CanMutate ||
+		s.HasPlaceholder != other.HasPlaceholder ||
+		!s.OuterCols.Equals(other.OuterCols) {
+		return false
+	}
+	return true
+}
+
+// Equals returns true if the scalar properties in s are identical to those in
+// "other", including Shared properties.
+func (s *Scalar) Equals(other *Scalar, evalCtx *eval.Context) bool {
+	if other == nil {
+		return false
+	}
+	if !s.Shared.Equals(&other.Shared) {
+		return false
+	}
+	if !s.Constraints.Equals(other.Constraints, evalCtx) {
+		return false
+	}
+	if !s.FuncDeps.Equals(&other.FuncDeps) {
+		return false
+	}
+	if s.TightConstraints != other.TightConstraints {
+		return false
+	}
+	if s.Rule.HasHoistableSubquery != other.Rule.HasHoistableSubquery {
+		return false
+	}
+	if s.Rule.Available != other.Rule.Available {
+		return false
+	}
+	return true
+}
+
+// CopyFrom copies all properties from fromProps into s, remapping any
+// ColumnIDs or ColSets using colMap. Panics if a column cannot be remapped.
+// Scalar.Rule.WithUses is not copied as it is lazily populated, so will get
+// filled in later.
+func (s *Scalar) CopyFrom(fromProps *Scalar, colMap opt.ColMap) {
+	// Shared Properties
+	s.HasSubquery = fromProps.HasSubquery
+	s.HasCorrelatedSubquery = fromProps.HasCorrelatedSubquery
+	s.VolatilitySet = fromProps.VolatilitySet
+	s.CanMutate = fromProps.CanMutate
+	s.HasPlaceholder = fromProps.HasPlaceholder
+	s.OuterCols = fromProps.OuterCols.CopyAndMaybeRemap(colMap)
+	s.HasPlaceholder = fromProps.HasPlaceholder
+	// toProps.Rule.WithUses is lazily populated later on, if required, and the
+	// copy would have different WithIDs, so we intentionally do not copy it.
+
+	// Scalar Properties
+	s.FuncDeps = fromProps.FuncDeps.CopyAndMaybeRemap(colMap)
+	s.TightConstraints = fromProps.TightConstraints
+	s.Rule.Available = fromProps.Rule.Available
+	s.Rule.HasHoistableSubquery = fromProps.Rule.HasHoistableSubquery
+
+	fromConstraints := fromProps.Constraints
+	// Map from one set of constraints to another to save memory by sharing
+	// Spans and processing overhead and making a copy of Constraints instead
+	// of recomputing from scratch.
+	if fromConstraints != nil {
+		s.Constraints = fromConstraints.CopyAndMaybeRemapConstraintSetWithColMap(colMap)
+	}
+	s.Populated = true
 }
 
 // IsAvailable returns true if the specified rule property has been populated

--- a/pkg/sql/opt/props/scalar_test.go
+++ b/pkg/sql/opt/props/scalar_test.go
@@ -1,0 +1,83 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package props_test
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+)
+
+func fieldsString(val *reflect.Value) string {
+	var sb strings.Builder
+	for i, n := 0, val.Type().NumField(); i < n; i++ {
+		if i > 0 {
+			sb.WriteRune(';')
+		}
+		sb.WriteString(fmt.Sprintf(
+			"%s:%s",
+			val.Type().Field(i).Name,
+			val.Type().Field(i).Type,
+		))
+	}
+	return sb.String() + ";"
+}
+
+var propsMatchString = "Populated:bool;HasSubquery:bool;HasCorrelatedSubquery:bool;" +
+	"VolatilitySet:props.VolatilitySet;CanMutate:bool;HasPlaceholder:bool;OuterCols:opt.ColSet;" +
+	"Rule:struct { WithUses props.WithUsesMap };Shared:props.Shared;Constraints:*constraint.Set;" +
+	"FuncDeps:props.FuncDepSet;TightConstraints:bool;Rule:struct { Available props.AvailableRuleProps;" +
+	" HasHoistableSubquery bool };"
+
+// TestScalarPropsChanged acts as a reminder to update the Equals and
+// CopyFrom functions when props.Shared or props.Scalar changes.
+func TestScalarPropsChanged(t *testing.T) {
+	shared := &props.Shared{}
+	scalar := &props.Scalar{}
+	sharedVal := reflect.Indirect(reflect.ValueOf(shared))
+	scalarVal := reflect.Indirect(reflect.ValueOf(scalar))
+	checkString := fieldsString(&sharedVal) + fieldsString(&scalarVal)
+	if propsMatchString != checkString {
+		t.Errorf(
+			`
+expected: %s
+actual:   %s 
+Shared or Scalar properties has changed. 
+Please make sure to update the Equals and CopyFrom
+functions of struct props.Shared and props.Scalar.`, propsMatchString, checkString)
+	}
+}
+
+var constraintMatchString = "Columns:constraint.Columns;Spans:constraint.Spans;firstConstraint:" +
+	"constraint.Constraint;otherConstraints:[]constraint.Constraint;length:int32;contradiction:bool;"
+
+// TestConstraintChanged acts as a reminder to update the Equals functions in
+// Constraint and constraint.Set if new fields are added.
+func TestConstraintChanged(t *testing.T) {
+	c := &constraint.Constraint{}
+	cs := &constraint.Set{}
+	constraintVal := reflect.Indirect(reflect.ValueOf(c))
+	constraintSetVal := reflect.Indirect(reflect.ValueOf(cs))
+	checkString := fieldsString(&constraintVal) + fieldsString(&constraintSetVal)
+	if constraintMatchString != checkString {
+		t.Errorf(
+			`
+expected: %s
+actual:   %s 
+Constraint or constraint.Set fields have changed. 
+Please make sure to update the Equals and CopyAndMaybeRemapConstraintSetWithColMap
+functions in struct constraint.Constraint and constraint.Set.`, constraintMatchString, checkString)
+	}
+}

--- a/pkg/sql/opt/xform/general_funcs.go
+++ b/pkg/sql/opt/xform/general_funcs.go
@@ -717,6 +717,7 @@ func (c *CustomFuncs) wrapScanInLimitedSelect(
 		scan,
 		c.RemapScanColsInFilter(filters, originalScanPrivate, newScanPrivate),
 	)
+
 	if limit != 0 {
 		limitedSelect = c.e.f.ConstructLimit(
 			limitedSelect,


### PR DESCRIPTION
This commit copies check constraint filter properties when
DuplicateTable is called, remapping ColumnIDs in ScalarProps and
reusing Spans so they don't have to be rebuilt.

For the following test case, runtime drops from appr. 310ms to 180ms:
```
CREATE TABLE t (i INT PRIMARY KEY USING HASH WITH BUCKET_COUNT = 256, j int);
INSERT INTO t SELECT g,g FROM generate_series(1, 1000000) g(g);
ANALYZE t;
EXPLAIN SELECT * FROM t WHERE i%2 != 0 ORDER BY i LIMIT 1 OFFSET 49;
```

Release justification: Performance improvement for ORDER BY queries
involving hash-sharded tables.

Release note: none