### PR TITLE
backupccl: allow SHOW BACKUP FILES/RANGES/SCHEMAS in backup collections

### DIFF
--- a/docs/generated/sql/bnf/show_backup.bnf
+++ b/docs/generated/sql/bnf/show_backup.bnf
@@ -9,3 +9,6 @@ show_backup_stmt ::=
 	| 'SHOW' 'BACKUP' 'SCHEMAS' location 'WITH' kv_option_list
 	| 'SHOW' 'BACKUP' 'SCHEMAS' location 'WITH' 'OPTIONS' '(' kv_option_list ')'
 	| 'SHOW' 'BACKUP' 'SCHEMAS' location 
+	| 'SHOW' 'BACKUP' 'SCHEMAS' location 'IN' string_or_placeholder 'WITH' kv_option_list
+	| 'SHOW' 'BACKUP' 'SCHEMAS' location 'IN' string_or_placeholder 'WITH' 'OPTIONS' '(' kv_option_list ')'
+	| 'SHOW' 'BACKUP' 'SCHEMAS' location 'IN' string_or_placeholder 

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -701,6 +701,7 @@ show_backup_stmt ::=
 	| 'SHOW' 'BACKUP' string_or_placeholder opt_with_options
 	| 'SHOW' 'BACKUP' string_or_placeholder 'IN' string_or_placeholder opt_with_options
 	| 'SHOW' 'BACKUP' 'SCHEMAS' string_or_placeholder opt_with_options
+	| 'SHOW' 'BACKUP' 'SCHEMAS' string_or_placeholder 'IN' string_or_placeholder opt_with_options
 
 show_columns_stmt ::=
 	'SHOW' 'COLUMNS' 'FROM' table_name with_comment

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -5701,6 +5701,16 @@ show_backup_stmt:
       Options: $5.kvOptions(),
     }
   }
+| SHOW BACKUP SCHEMAS string_or_placeholder IN string_or_placeholder opt_with_options
+	{
+		$$.val = &tree.ShowBackup{
+			Details: tree.BackupDefaultDetails,
+			ShouldIncludeSchemas: true,
+			Path:    $4.expr(),
+			InCollection: $6.expr(),
+			Options: $7.kvOptions(),
+		}
+	}
 | SHOW BACKUP RANGES string_or_placeholder opt_with_options
   {
     /* SKIP DOC */
@@ -5709,6 +5719,16 @@ show_backup_stmt:
       Path:    $4.expr(),
       Options: $5.kvOptions(),
     }
+  }
+| SHOW BACKUP RANGES string_or_placeholder IN string_or_placeholder opt_with_options
+  {
+		/* SKIP DOC */
+		$$.val = &tree.ShowBackup{
+			Details: tree.BackupRangeDetails,
+			Path:    $4.expr(),
+			InCollection: $6.expr(),
+			Options: $7.kvOptions(),
+		}
   }
 | SHOW BACKUP FILES string_or_placeholder opt_with_options
   {
@@ -5719,6 +5739,16 @@ show_backup_stmt:
       Options: $5.kvOptions(),
     }
   }
+| SHOW BACKUP FILES string_or_placeholder IN string_or_placeholder opt_with_options
+	{
+		/* SKIP DOC */
+		$$.val = &tree.ShowBackup{
+			Details: tree.BackupFileDetails,
+			Path:    $4.expr(),
+			InCollection: $6.expr(),
+			Options: $7.kvOptions(),
+		}
+	}
 | SHOW BACKUP error // SHOW HELP: SHOW BACKUP
 
 // %Help: SHOW CLUSTER SETTING - display cluster settings

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -167,6 +167,22 @@ SHOW BACKUP '_' IN '_' -- literals removed
 SHOW BACKUP 'foo' IN 'bar' -- identifiers removed
 
 parse
+SHOW BACKUP FILES 'foo' IN 'bar'
+----
+SHOW BACKUP FILES 'foo' IN 'bar'
+SHOW BACKUP FILES ('foo') IN ('bar') -- fully parenthesized
+SHOW BACKUP FILES '_' IN '_' -- literals removed
+SHOW BACKUP FILES 'foo' IN 'bar' -- identifiers removed
+
+parse
+SHOW BACKUP RANGES 'foo' IN 'bar'
+----
+SHOW BACKUP RANGES 'foo' IN 'bar'
+SHOW BACKUP RANGES ('foo') IN ('bar') -- fully parenthesized
+SHOW BACKUP RANGES '_' IN '_' -- literals removed
+SHOW BACKUP RANGES 'foo' IN 'bar' -- identifiers removed
+
+parse
 SHOW BACKUP $1 IN $2 WITH foo = 'bar'
 ----
 SHOW BACKUP $1 IN $2 WITH foo = 'bar'


### PR DESCRIPTION
Fixes #77697

Release justification: low risk bug fixes

Release note: SHOW BACKUP SCHEMAS can be called with SHOW BACKUP IN syntax.