### PR TITLE
colexecjoin: add some comments in `hashJoiner.congregate`

### DIFF
--- a/pkg/sql/catalog/descpb/join_type.go
+++ b/pkg/sql/catalog/descpb/join_type.go
@@ -103,12 +103,6 @@ func (j JoinType) IsLeftAntiOrExceptAll() bool {
 	return j == LeftAntiJoin || j == ExceptAllJoin
 }
 
-// IsRightSemiOrRightAnti returns whether j is either RIGHT SEMI or RIGHT ANTI
-// join type.
-func (j JoinType) IsRightSemiOrRightAnti() bool {
-	return j == RightSemiJoin || j == RightAntiJoin
-}
-
 // MakeOutputTypes computes the output types for this join type.
 func (j JoinType) MakeOutputTypes(left, right []*types.T) []*types.T {
 	numOutputTypes := 0

--- a/pkg/sql/colexec/colexecjoin/BUILD.bazel
+++ b/pkg/sql/colexec/colexecjoin/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/sql/sem/tree",  # keep
         "//pkg/sql/types",
         "//pkg/util",
+        "//pkg/util/buildutil",
         "//pkg/util/duration",  # keep
         "//pkg/util/json",  # keep
         "//pkg/util/mon",

--- a/pkg/sql/colexec/colexecjoin/hashjoiner.eg.go
+++ b/pkg/sql/colexec/colexecjoin/hashjoiner.eg.go
@@ -49,7 +49,7 @@ const _ = "template_distinctCollectProbeNoOuter"
 func (hj *hashJoiner) collect(batch coldata.Batch, batchSize int, sel []int) int {
 	nResults := 0
 
-	if hj.spec.JoinType.IsRightSemiOrRightAnti() {
+	if !hj.spec.JoinType.ShouldIncludeLeftColsInOutput() {
 		collectRightSemiAnti(hj, batchSize)
 		return 0
 	}
@@ -85,7 +85,7 @@ func (hj *hashJoiner) collect(batch coldata.Batch, batchSize int, sel []int) int
 func (hj *hashJoiner) distinctCollect(batch coldata.Batch, batchSize int, sel []int) int {
 	nResults := 0
 
-	if hj.spec.JoinType.IsRightSemiOrRightAnti() {
+	if !hj.spec.JoinType.ShouldIncludeLeftColsInOutput() {
 		collectRightSemiAnti(hj, batchSize)
 		return 0
 	}

--- a/pkg/sql/colexec/colexecjoin/hashjoiner.go
+++ b/pkg/sql/colexec/colexecjoin/hashjoiner.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -412,7 +413,7 @@ func (hj *hashJoiner) emitRight(matched bool) {
 // in a single output batch (this is the case with non-distinct collectProbe*
 // methods).
 func (hj *hashJoiner) prepareForCollecting(batchSize int) {
-	if hj.spec.JoinType.IsRightSemiOrRightAnti() {
+	if !hj.spec.JoinType.ShouldIncludeLeftColsInOutput() {
 		// Right semi/anti joins have a separate collecting method that simply
 		// records the fact whether build rows had a match and don't need these
 		// probing slices.
@@ -568,7 +569,18 @@ func (hj *hashJoiner) exec() coldata.Batch {
 // congregate uses the probeIdx and buildIdx pairs to stitch together the
 // resulting join rows and add them to the output batch with the left table
 // columns preceding the right table columns.
+//
+// This method should not be called for RIGHT SEMI and RIGHT ANTI joins because
+// they populate the output after probing is done, when in the hjEmittingRight
+// state.
 func (hj *hashJoiner) congregate(nResults int, batch coldata.Batch) {
+	if buildutil.CrdbTestBuild {
+		if !hj.spec.JoinType.ShouldIncludeLeftColsInOutput() {
+			panic(errors.AssertionFailedf(
+				"unexpectedly hashJoiner.congregate is called for RIGHT SEMI or RIGHT ANTI join",
+			))
+		}
+	}
 	hj.resetOutput(nResults)
 	// We have already fully built the hash table from the right input and now
 	// are only populating output one batch at a time. If we were to use a
@@ -576,19 +588,20 @@ func (hj *hashJoiner) congregate(nResults int, batch coldata.Batch) {
 	// very hard to fall back to disk backed hash joiner because we might have
 	// already emitted partial output.
 	hj.outputUnlimitedAllocator.PerformOperation(hj.output.ColVecs(), func() {
-		if hj.spec.JoinType.ShouldIncludeLeftColsInOutput() {
-			outCols := hj.output.ColVecs()[:len(hj.spec.Left.SourceTypes)]
-			for i := range hj.spec.Left.SourceTypes {
-				outCol := outCols[i]
-				valCol := batch.ColVec(i)
-				outCol.Copy(
-					coldata.SliceArgs{
-						Src:       valCol,
-						Sel:       hj.probeState.probeIdx,
-						SrcEndIdx: nResults,
-					},
-				)
-			}
+		// Populate the left output columns which are needed by all join types
+		// other than RIGHT SEMI and RIGHT ANTI joins, and those two types don't
+		// use this code path.
+		outCols := hj.output.ColVecs()[:len(hj.spec.Left.SourceTypes)]
+		for i := range hj.spec.Left.SourceTypes {
+			outCol := outCols[i]
+			valCol := batch.ColVec(i)
+			outCol.Copy(
+				coldata.SliceArgs{
+					Src:       valCol,
+					Sel:       hj.probeState.probeIdx,
+					SrcEndIdx: nResults,
+				},
+			)
 		}
 
 		if hj.spec.JoinType.ShouldIncludeRightColsInOutput() {
@@ -596,7 +609,7 @@ func (hj *hashJoiner) congregate(nResults int, batch coldata.Batch) {
 			// If the hash table is empty, then there is nothing to copy. The nulls
 			// will be set below.
 			if hj.ht.Vals.Length() > 0 {
-				outCols := hj.output.ColVecs()[rightColOffset : rightColOffset+len(hj.spec.Right.SourceTypes)]
+				outCols = hj.output.ColVecs()[rightColOffset : rightColOffset+len(hj.spec.Right.SourceTypes)]
 				for i := range hj.spec.Right.SourceTypes {
 					outCol := outCols[i]
 					valCol := hj.ht.Vals.ColVec(i)

--- a/pkg/sql/colexec/colexecjoin/hashjoiner_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/hashjoiner_tmpl.go
@@ -259,7 +259,7 @@ func distinctCollectProbeNoOuter(
 func (hj *hashJoiner) collect(batch coldata.Batch, batchSize int, sel []int) int {
 	nResults := 0
 
-	if hj.spec.JoinType.IsRightSemiOrRightAnti() {
+	if !hj.spec.JoinType.ShouldIncludeLeftColsInOutput() {
 		collectRightSemiAnti(hj, batchSize)
 		return 0
 	}
@@ -295,7 +295,7 @@ func (hj *hashJoiner) collect(batch coldata.Batch, batchSize int, sel []int) int
 func (hj *hashJoiner) distinctCollect(batch coldata.Batch, batchSize int, sel []int) int {
 	nResults := 0
 
-	if hj.spec.JoinType.IsRightSemiOrRightAnti() {
+	if !hj.spec.JoinType.ShouldIncludeLeftColsInOutput() {
 		collectRightSemiAnti(hj, batchSize)
 		return 0
 	}


### PR DESCRIPTION
I spent some time puzzling why when populating the output of the hash
joiner we always use non-zero offset for the right columns. It turned
out that RIGHT SEMI and RIGHT ANTI joins (which would have a zero
offset) don't go through the code path in question, so this commit adds
some comments and removes a conditional that is always true.

This commit additionally removes one method on `JoinType` in favor of
another that is its "inverse" (i.e. negated).

Release note: None