### PR TITLE
ui: show the values for full scan, distSQL and vec

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
@@ -17,6 +17,7 @@ import {
   formatNumberForDisplay,
   longToInt,
   TimestampToMoment,
+  RenderCount,
 } from "../../util";
 
 export type PlanHashStats = cockroach.server.serverpb.StatementDetailsResponse.ICollectedStatementGroupedByPlanHash;
@@ -28,6 +29,9 @@ const planDetailsColumnLabels = {
   avgExecTime: "Average Execution Time",
   execCount: "Execution Count",
   avgRowsRead: "Average Rows Read",
+  fullScan: "Full Scan",
+  distSQL: "Distributed",
+  vectorized: "Vectorized",
 };
 export type PlanDetailsTableColumnKeys = keyof typeof planDetailsColumnLabels;
 
@@ -91,6 +95,39 @@ export const planDetailsTableTitles: PlanDetailsTableTitleType = {
       </Tooltip>
     );
   },
+  fullScan: () => {
+    return (
+      <Tooltip
+        style="tableTitle"
+        placement="bottom"
+        content={"If the Plan executed a Full Scan."}
+      >
+        {planDetailsColumnLabels.fullScan}
+      </Tooltip>
+    );
+  },
+  distSQL: () => {
+    return (
+      <Tooltip
+        style="tableTitle"
+        placement="bottom"
+        content={"If the Plan was distributed."}
+      >
+        {planDetailsColumnLabels.distSQL}
+      </Tooltip>
+    );
+  },
+  vectorized: () => {
+    return (
+      <Tooltip
+        style="tableTitle"
+        placement="bottom"
+        content={"If the Plan was vectorized."}
+      >
+        {planDetailsColumnLabels.vectorized}
+      </Tooltip>
+    );
+  },
 };
 
 export function makeExplainPlanColumns(
@@ -131,10 +168,34 @@ export function makeExplainPlanColumns(
       sort: (item: PlanHashStats) => longToInt(item.stats.count),
     },
     {
-      name: "avg_rows_read",
+      name: "avgRowsRead",
       title: planDetailsTableTitles.avgRowsRead(),
       cell: (item: PlanHashStats) => longToInt(item.stats.rows_read.mean),
       sort: (item: PlanHashStats) => longToInt(item.stats.rows_read.mean),
+    },
+    {
+      name: "fullScan",
+      title: planDetailsTableTitles.fullScan(),
+      cell: (item: PlanHashStats) =>
+        RenderCount(item.metadata.full_scan_count, item.metadata.total_count),
+      sort: (item: PlanHashStats) =>
+        RenderCount(item.metadata.full_scan_count, item.metadata.total_count),
+    },
+    {
+      name: "distSQL",
+      title: planDetailsTableTitles.distSQL(),
+      cell: (item: PlanHashStats) =>
+        RenderCount(item.metadata.dist_sql_count, item.metadata.total_count),
+      sort: (item: PlanHashStats) =>
+        RenderCount(item.metadata.dist_sql_count, item.metadata.total_count),
+    },
+    {
+      name: "vectorized",
+      title: planDetailsTableTitles.vectorized(),
+      cell: (item: PlanHashStats) =>
+        RenderCount(item.metadata.vec_count, item.metadata.total_count),
+      sort: (item: PlanHashStats) =>
+        RenderCount(item.metadata.vec_count, item.metadata.total_count),
     },
   ];
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -35,6 +35,7 @@ import {
   appAttr,
   appNamesAttr,
   statementAttr,
+  RenderCount,
 } from "src/util";
 import { Loading } from "src/loading";
 import { Button } from "src/button";
@@ -209,17 +210,6 @@ function renderTransactionType(implicitTxn: boolean) {
     return "Implicit";
   }
   return "Explicit";
-}
-
-function renderCount(yesCount: Long, totalCount: Long) {
-  if (longToInt(yesCount) == 0) {
-    return "No";
-  }
-  if (longToInt(yesCount) == longToInt(totalCount)) {
-    return "Yes";
-  }
-  const noCount = longToInt(totalCount) - longToInt(yesCount);
-  return `${longToInt(yesCount)} Yes / ${noCount} No`;
 }
 
 class NumericStatTable extends React.Component<NumericStatTableProps> {
@@ -457,6 +447,7 @@ export class StatementDetails extends React.Component<
       databases,
       dist_sql_count,
       failed_count,
+      full_scan_count,
       vec_count,
       total_count,
       implicit_txn,
@@ -692,15 +683,19 @@ export class StatementDetails extends React.Component<
                 </div>
                 <div className={summaryCardStylesCx("summary--card__item")}>
                   <Text>Failed?</Text>
-                  <Text>{renderCount(failed_count, total_count)}</Text>
+                  <Text>{RenderCount(failed_count, total_count)}</Text>
                 </div>
                 <div className={summaryCardStylesCx("summary--card__item")}>
                   <Text>Distributed execution?</Text>
-                  <Text>{renderCount(dist_sql_count, total_count)}</Text>
+                  <Text>{RenderCount(dist_sql_count, total_count)}</Text>
+                </div>
+                <div className={summaryCardStylesCx("summary--card__item")}>
+                  <Text>Full Scan?</Text>
+                  <Text>{RenderCount(full_scan_count, total_count)}</Text>
                 </div>
                 <div className={summaryCardStylesCx("summary--card__item")}>
                   <Text>Vectorized execution?</Text>
-                  <Text>{renderCount(vec_count, total_count)}</Text>
+                  <Text>{RenderCount(vec_count, total_count)}</Text>
                 </div>
                 <div className={summaryCardStylesCx("summary--card__item")}>
                   <Text>Transaction type</Text>

--- a/pkg/ui/workspaces/cluster-ui/src/util/format.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/format.ts
@@ -8,6 +8,8 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+import { longToInt } from "./fixLong";
+
 export const kibi = 1024;
 export const byteUnits: string[] = [
   "B",
@@ -163,3 +165,14 @@ export const DurationFitScale = (scale: string) => (nanoseconds: number) => {
 };
 
 export const DATE_FORMAT = "MMM DD, YYYY [at] h:mm A";
+
+export function RenderCount(yesCount: Long, totalCount: Long) {
+  if (longToInt(yesCount) == 0) {
+    return "No";
+  }
+  if (longToInt(yesCount) == longToInt(totalCount)) {
+    return "Yes";
+  }
+  const noCount = longToInt(totalCount) - longToInt(yesCount);
+  return `${longToInt(yesCount)} Yes / ${noCount} No`;
+}


### PR DESCRIPTION
Now that we have the correct values for full scan, distSQL
and vec, this commit adds those values to the Statement
Details page (Overview and Explain Plan tab)

Fixes #77698
<img width="787" alt="Screen Shot 2022-03-16 at 9 13 26 AM" src="https://user-images.githubusercontent.com/1017486/158597758-7a8ac4d7-de2e-4122-bb94-d92eb1d9d2ff.png">
<img width="1400" alt="Screen Shot 2022-03-16 at 9 13 35 AM" src="https://user-images.githubusercontent.com/1017486/158597776-229842e2-86fb-457a-9626-4cbb110940b8.png">



Release note (ui change): Add Full Scan, distributed and
vectorized information of the plan displayed on Statement Details
page (Overview and Explain Plan tabs)