### PR TITLE
bulk: don't return error in the case of closed/draining consumer

### DIFF
--- a/pkg/sql/importer/exportcsv.go
+++ b/pkg/sql/importer/exportcsv.go
@@ -295,9 +295,9 @@ func (sp *csvWriter) Run(ctx context.Context) {
 				return err
 			}
 			if cs != execinfra.NeedMoreRows {
-				// TODO(dt): presumably this is because our recv already closed due to
-				// another error... so do we really need another one?
-				return errors.New("unexpected closure of consumer")
+				// We don't return an error here because we want the error (if any) that
+				// actually caused the consumer to enter a closed/draining state to take precendence.
+				return nil
 			}
 			if done {
 				break

--- a/pkg/sql/importer/exportparquet.go
+++ b/pkg/sql/importer/exportparquet.go
@@ -838,9 +838,9 @@ func (sp *parquetWriterProcessor) Run(ctx context.Context) {
 				return err
 			}
 			if cs != execinfra.NeedMoreRows {
-				// TODO(dt): presumably this is because our recv already closed due to
-				// another error... so do we really need another one?
-				return errors.New("unexpected closure of consumer")
+				// We don't return an error here because we want the error (if any) that
+				// actually caused the consumer to enter a closed/draining state to take precendence.
+				return nil
 			}
 			if done {
 				break


### PR DESCRIPTION
Users hit errors such as ReadWithinUncertaintyIntervalError but
only receive the "unexpected closure of consumer" error previously returned
by the export processors. 

Not returning an error in this case is consistent with other callers of
EmitRow.

Not returning the error means that in some cases a retriable error
encountered during export is now retried while it wasn't in the
past. Note that this retry can happen after some files have already
been written to external storage.

Fixes #79229

Release note: Fix issue where some exports would receive "unexpected
closure of consumer" rather than the actual error the export
encountered.