### PR TITLE
opt: inline constant insert values in uniqueness checks

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
@@ -34,9 +34,9 @@ CREATE TABLE t_child_partitioned (
    PARTITION us_east VALUES IN (('new york'))
 );
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
+# TODO(mgartner): In the FK check there is a lookup join that searches every
+# shard, but only one shard needs to be searched. Inlining the insert values in
+# the FK check should improve this plan.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_child VALUES (123, 321);
 ----
@@ -81,9 +81,9 @@ vectorized: true
                       columns: (column1, column2)
                       label: buffer 1
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
+# TODO(mgartner): In the FK check there is a lookup join that searches every
+# shard, but only one shard needs to be searched. Inlining the insert values in
+# the FK check should improve this plan.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_child_partitioned VALUES (123, 321, 'seattle');
 ----
@@ -116,23 +116,24 @@ vectorized: true
 │       │ columns: ()
 │       │
 │       └── • project
-│           │ columns: (column1)
-│           │ estimated row count: 0 (missing stats)
+│           │ columns: (id)
+│           │ estimated row count: 1 (missing stats)
 │           │
-│           └── • lookup join (semi)
-│               │ columns: (column1, column3)
-│               │ estimated row count: 0 (missing stats)
-│               │ table: t_child_partitioned@t_child_partitioned_pkey
-│               │ lookup condition: (column1 = id) AND (part IN ('new york', 'seattle'))
-│               │ pred: column3 != part
+│           └── • cross join (inner)
+│               │ columns: (id, id, part)
+│               │ estimated row count: 1 (missing stats)
 │               │
-│               └── • project
-│                   │ columns: (column1, column3)
-│                   │ estimated row count: 1
-│                   │
-│                   └── • scan buffer
-│                         columns: (column1, column2, column3, check1)
-│                         label: buffer 1
+│               ├── • values
+│               │     columns: (id)
+│               │     size: 1 column, 1 row
+│               │     row 0, expr 0: 123
+│               │
+│               └── • scan
+│                     columns: (id, part)
+│                     estimated row count: 1 (missing stats)
+│                     table: t_child_partitioned@t_child_partitioned_pkey
+│                     spans: /"new york"/123/0
+│                     limit: 1
 │
 └── • constraint-check
     │
@@ -205,9 +206,6 @@ vectorized: true
               row 0, expr 1: '4321'
               row 0, expr 2: gen_random_uuid()
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_gen_random_uuid (val, part) VALUES (4321, 'seattle') ON CONFLICT DO NOTHING;
 ----
@@ -259,9 +257,6 @@ vectorized: true
                       row 0, expr 1: '4321'
                       row 0, expr 2: gen_random_uuid()
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_gen_random_uuid (val, part) VALUES (4321, 'seattle'), (8765, 'new york') ON CONFLICT DO NOTHING;
 ----
@@ -333,9 +328,6 @@ CREATE TABLE t_unique_hash_pk (
   PARTITION us_east VALUES IN (('new york'))
 );
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle');
 ----
@@ -350,18 +342,14 @@ vectorized: true
 │   │ estimated row count: 0 (missing stats)
 │   │ into: t_unique_hash_pk(crdb_internal_id_shard_16, id, part)
 │   │
-│   └── • buffer
-│       │ columns: (crdb_internal_id_shard_16_comp, column1, column2, check1, check2)
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             columns: (crdb_internal_id_shard_16_comp, column1, column2, check1, check2)
-│             size: 5 columns, 1 row
-│             row 0, expr 0: 4321
-│             row 0, expr 1: 'seattle'
-│             row 0, expr 2: 9
-│             row 0, expr 3: true
-│             row 0, expr 4: true
+│   └── • values
+│         columns: (crdb_internal_id_shard_16_comp, column1, column2, check1, check2)
+│         size: 5 columns, 1 row
+│         row 0, expr 0: 4321
+│         row 0, expr 1: 'seattle'
+│         row 0, expr 2: 9
+│         row 0, expr 3: true
+│         row 0, expr 4: true
 │
 └── • constraint-check
     │
@@ -369,27 +357,44 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (column1)
-            │ estimated row count: 0 (missing stats)
+            │ columns: (id)
+            │ estimated row count: 1 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (crdb_internal_id_shard_16_comp, column1, column2)
-                │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
-                │ lookup condition: ((column1 = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                │ pred: (crdb_internal_id_shard_16_comp != crdb_internal_id_shard_16) OR (column2 != part)
+            └── • cross join (inner)
+                │ columns: (id, crdb_internal_id_shard_16, id, part)
+                │ estimated row count: 1 (missing stats)
                 │
-                └── • project
-                    │ columns: (crdb_internal_id_shard_16_comp, column1, column2)
-                    │ estimated row count: 1
+                ├── • values
+                │     columns: (id)
+                │     size: 1 column, 1 row
+                │     row 0, expr 0: 4321
+                │
+                └── • limit
+                    │ columns: (crdb_internal_id_shard_16, id, part)
+                    │ estimated row count: 1 (missing stats)
+                    │ count: 1
                     │
-                    └── • scan buffer
-                          columns: (crdb_internal_id_shard_16_comp, column1, column2, check1, check2)
-                          label: buffer 1
+                    └── • distinct
+                        │ columns: (crdb_internal_id_shard_16, id, part)
+                        │ estimated row count: 7 (missing stats)
+                        │ distinct on: id, part
+                        │
+                        └── • union all
+                            │ columns: (crdb_internal_id_shard_16, id, part)
+                            │ estimated row count: 2 (missing stats)
+                            │
+                            ├── • scan
+                            │     columns: (crdb_internal_id_shard_16, id, part)
+                            │     estimated row count: 1 (missing stats)
+                            │     table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                            │     spans
+                            │
+                            └── • scan
+                                  columns: (crdb_internal_id_shard_16, id, part)
+                                  estimated row count: 1 (missing stats)
+                                  table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                                  spans: /"new york"/9/4321/0
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle') ON CONFLICT DO NOTHING;
 ----
@@ -430,9 +435,6 @@ vectorized: true
               spans: /"new york"/9/4321/0 /"seattle"/9/4321/0
               parallel
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle'), (8765, 'new york') ON CONFLICT DO NOTHING;
 ----
@@ -517,9 +519,6 @@ vectorized: true
               spans: /"new york"/9/4321/0 /"seattle"/9/4321/0
               parallel
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle'), (8765, 'new york') ON CONFLICT (id) DO NOTHING;
 ----
@@ -564,9 +563,6 @@ vectorized: true
                   row 1, expr 0: 8765
                   row 1, expr 1: 'new york'
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle') ON CONFLICT (id) DO UPDATE SET id = excluded.id
 ----
@@ -656,9 +652,6 @@ vectorized: true
                           columns: (crdb_internal_id_shard_16_comp, column1, column2, crdb_internal_id_shard_16, id, part, crdb_internal_id_shard_16_comp, column1, part, check1, check2, upsert_part)
                           label: buffer 1
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle'), (8765, 'new york') ON CONFLICT (id) DO UPDATE SET id = excluded.id
 ----
@@ -799,9 +792,6 @@ vectorized: true
                   parallel
                   locking strength: for update
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle'), (8765, 'new york');
 ----
@@ -853,9 +843,6 @@ vectorized: true
                       row 1, expr 0: 8765
                       row 1, expr 1: 'new york'
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) UPDATE t_unique_hash_pk SET id = 1234 WHERE id = 4321;
 ----
@@ -933,9 +920,6 @@ CREATE TABLE t_unique_hash_sec_key (
 statement ok
 CREATE UNIQUE INDEX idx_uniq_hash_email ON t_unique_hash_sec_key (email) USING HASH;
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email, part) VALUES (4321, 'some_email', 'seattle');
 ----
@@ -950,19 +934,15 @@ vectorized: true
 │   │ estimated row count: 0 (missing stats)
 │   │ into: t_unique_hash_sec_key(id, email, part, crdb_internal_email_shard_16)
 │   │
-│   └── • buffer
-│       │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, check1, check2)
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, check1, check2)
-│             size: 6 columns, 1 row
-│             row 0, expr 0: 4321
-│             row 0, expr 1: 'some_email'
-│             row 0, expr 2: 'seattle'
-│             row 0, expr 3: 13
-│             row 0, expr 4: true
-│             row 0, expr 5: true
+│   └── • values
+│         columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, check1, check2)
+│         size: 6 columns, 1 row
+│         row 0, expr 0: 4321
+│         row 0, expr 1: 'some_email'
+│         row 0, expr 2: 'seattle'
+│         row 0, expr 3: 13
+│         row 0, expr 4: true
+│         row 0, expr 5: true
 │
 ├── • constraint-check
 │   │
@@ -970,23 +950,24 @@ vectorized: true
 │       │ columns: ()
 │       │
 │       └── • project
-│           │ columns: (column1)
-│           │ estimated row count: 0 (missing stats)
+│           │ columns: (id)
+│           │ estimated row count: 1 (missing stats)
 │           │
-│           └── • lookup join (semi)
-│               │ columns: (column1, column3)
-│               │ estimated row count: 0 (missing stats)
-│               │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-│               │ lookup condition: (column1 = id) AND (part IN ('new york', 'seattle'))
-│               │ pred: column3 != part
+│           └── • cross join (inner)
+│               │ columns: (id, id, part)
+│               │ estimated row count: 1 (missing stats)
 │               │
-│               └── • project
-│                   │ columns: (column1, column3)
-│                   │ estimated row count: 1
-│                   │
-│                   └── • scan buffer
-│                         columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, check1, check2)
-│                         label: buffer 1
+│               ├── • values
+│               │     columns: (id)
+│               │     size: 1 column, 1 row
+│               │     row 0, expr 0: 4321
+│               │
+│               └── • scan
+│                     columns: (id, part)
+│                     estimated row count: 1 (missing stats)
+│                     table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+│                     spans: /"new york"/4321/0
+│                     limit: 1
 │
 └── • constraint-check
     │
@@ -994,27 +975,50 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (column2)
-            │ estimated row count: 0 (missing stats)
+            │ columns: (email)
+            │ estimated row count: 1 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (column1, column2, column3)
-                │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
-                │ lookup condition: ((column2 = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                │ pred: (column1 != id) OR (column3 != part)
+            └── • cross join (inner)
+                │ columns: (email, id, email, part)
+                │ estimated row count: 1 (missing stats)
                 │
-                └── • project
-                    │ columns: (column1, column2, column3)
-                    │ estimated row count: 1
+                ├── • values
+                │     columns: (email)
+                │     size: 1 column, 1 row
+                │     row 0, expr 0: 'some_email'
+                │
+                └── • limit
+                    │ columns: (id, email, part)
+                    │ estimated row count: 1 (missing stats)
+                    │ count: 1
                     │
-                    └── • scan buffer
-                          columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, check1, check2)
-                          label: buffer 1
+                    └── • distinct
+                        │ columns: (id, email, part)
+                        │ estimated row count: 7 (missing stats)
+                        │ distinct on: id, part
+                        │
+                        └── • union all
+                            │ columns: (id, email, part)
+                            │ estimated row count: 2 (missing stats)
+                            │
+                            ├── • filter
+                            │   │ columns: (id, email, part)
+                            │   │ estimated row count: 1 (missing stats)
+                            │   │ filter: id != 4321
+                            │   │
+                            │   └── • scan
+                            │         columns: (id, email, part)
+                            │         estimated row count: 0 (missing stats)
+                            │         table: t_unique_hash_sec_key@idx_uniq_hash_email
+                            │         spans: /"new york"/13/"some_email"/0 /"seattle"/13/"some_email"/0
+                            │         parallel
+                            │
+                            └── • scan
+                                  columns: (id, email, part)
+                                  estimated row count: 1 (missing stats)
+                                  table: t_unique_hash_sec_key@idx_uniq_hash_email
+                                  spans: /"new york"/13/"some_email"/0
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email, part) VALUES (4321, 'some_email', 'seattle') ON CONFLICT DO NOTHING;
 ----
@@ -1068,9 +1072,6 @@ vectorized: true
                       spans: /"new york"/4321/0 /"seattle"/4321/0
                       parallel
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email, part) VALUES (4321, 'some_email', 'seattle'), (8765, 'another_email', 'new york') ON CONFLICT DO NOTHING;
 ----
@@ -1141,42 +1142,38 @@ vectorized: true
 │   │ into: t_unique_hash_sec_key(id, email, part, crdb_internal_email_shard_16)
 │   │ arbiter constraints: idx_uniq_hash_email
 │   │
-│   └── • buffer
+│   └── • render
 │       │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, check1, check2)
-│       │ label: buffer 1
+│       │ estimated row count: 0 (missing stats)
+│       │ render check1: column3 IN ('new york', 'seattle')
+│       │ render check2: crdb_internal_email_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+│       │ render column1: column1
+│       │ render column2: column2
+│       │ render column3: column3
+│       │ render crdb_internal_email_shard_16_comp: crdb_internal_email_shard_16_comp
 │       │
-│       └── • render
-│           │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, check1, check2)
+│       └── • cross join (anti)
+│           │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp)
 │           │ estimated row count: 0 (missing stats)
-│           │ render check1: column3 IN ('new york', 'seattle')
-│           │ render check2: crdb_internal_email_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
-│           │ render column1: column1
-│           │ render column2: column2
-│           │ render column3: column3
-│           │ render crdb_internal_email_shard_16_comp: crdb_internal_email_shard_16_comp
 │           │
-│           └── • cross join (anti)
-│               │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp)
-│               │ estimated row count: 0 (missing stats)
+│           ├── • values
+│           │     columns: (column1, column2, column3, crdb_internal_email_shard_16_comp)
+│           │     size: 4 columns, 1 row
+│           │     row 0, expr 0: 4321
+│           │     row 0, expr 1: 'some_email'
+│           │     row 0, expr 2: 'seattle'
+│           │     row 0, expr 3: 13
+│           │
+│           └── • project
+│               │ columns: ()
+│               │ estimated row count: 1 (missing stats)
 │               │
-│               ├── • values
-│               │     columns: (column1, column2, column3, crdb_internal_email_shard_16_comp)
-│               │     size: 4 columns, 1 row
-│               │     row 0, expr 0: 4321
-│               │     row 0, expr 1: 'some_email'
-│               │     row 0, expr 2: 'seattle'
-│               │     row 0, expr 3: 13
-│               │
-│               └── • project
-│                   │ columns: ()
-│                   │ estimated row count: 1 (missing stats)
-│                   │
-│                   └── • scan
-│                         columns: (email)
-│                         estimated row count: 1 (missing stats)
-│                         table: t_unique_hash_sec_key@idx_uniq_hash_email
-│                         spans: /"new york"/13/"some_email"/0 /"seattle"/13/"some_email"/0
-│                         parallel
+│               └── • scan
+│                     columns: (email)
+│                     estimated row count: 1 (missing stats)
+│                     table: t_unique_hash_sec_key@idx_uniq_hash_email
+│                     spans: /"new york"/13/"some_email"/0 /"seattle"/13/"some_email"/0
+│                     parallel
 │
 └── • constraint-check
     │
@@ -1184,27 +1181,25 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (column1)
-            │ estimated row count: 0 (missing stats)
+            │ columns: (id)
+            │ estimated row count: 1 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (column1, column3)
-                │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-                │ lookup condition: (column1 = id) AND (part IN ('new york', 'seattle'))
-                │ pred: column3 != part
+            └── • cross join (inner)
+                │ columns: (id, id, part)
+                │ estimated row count: 1 (missing stats)
                 │
-                └── • project
-                    │ columns: (column1, column3)
-                    │ estimated row count: 0 (missing stats)
-                    │
-                    └── • scan buffer
-                          columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, check1, check2)
-                          label: buffer 1
+                ├── • values
+                │     columns: (id)
+                │     size: 1 column, 1 row
+                │     row 0, expr 0: 4321
+                │
+                └── • scan
+                      columns: (id, part)
+                      estimated row count: 1 (missing stats)
+                      table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+                      spans: /"new york"/4321/0
+                      limit: 1
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email, part) VALUES (4321, 'some_email', 'seattle'), (8765, 'another_email', 'new york') ON CONFLICT (email) DO NOTHING;
 ----
@@ -1283,9 +1278,6 @@ vectorized: true
                           columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, check1, check2)
                           label: buffer 1
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email, part) VALUES (4321, 'some_email', 'seattle') ON CONFLICT (email) DO UPDATE SET email = 'bad_email';
 ----
@@ -1417,9 +1409,6 @@ vectorized: true
                           columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, part, check1, check2, upsert_id, upsert_part)
                           label: buffer 1
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email, part) VALUES (4321, 'some_email', 'seattle'), (8765, 'another_email', 'new york') ON CONFLICT (email) DO UPDATE SET email = 'bad_email';
 ----
@@ -1566,9 +1555,6 @@ vectorized: true
                           columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, part, check1, check2, upsert_id, upsert_part)
                           label: buffer 1
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_sec_key VALUES (1, 'email1', 'seattle');
 ----
@@ -1657,9 +1643,6 @@ vectorized: true
                           columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part, crdb_internal_email_shard_16, column2, column3, crdb_internal_email_shard_16_comp, part, check1, check2, upsert_id)
                           label: buffer 1
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_sec_key VALUES (1, 'email1', 'seattle'), (8765, 'email2', 'new york');
 ----
@@ -1759,9 +1742,6 @@ vectorized: true
                           columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part, crdb_internal_email_shard_16, column2, column3, crdb_internal_email_shard_16_comp, part, check1, check2, upsert_id)
                           label: buffer 1
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) UPDATE t_unique_hash_sec_key SET email = 'email1' WHERE id = 2;
 ----

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -731,74 +731,54 @@ vectorized: true
 ├── • insert
 │   │ into: t(pk, pk2, partition_by, a, b, c, d)
 │   │
-│   └── • buffer
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             size: 8 columns, 1 row
+│   └── • values
+│         size: 8 columns, 1 row
 │
 ├── • constraint-check
 │   │
 │   └── • error if rows
 │       │
-│       └── • hash join (right semi)
-│           │ equality: (pk) = (column1)
-│           │ right cols are key
-│           │ pred: column3 != partition_by
+│       └── • cross join
 │           │
-│           ├── • scan
-│           │     missing stats
-│           │     table: t@t_a_idx
-│           │     spans: FULL SCAN
+│           ├── • values
+│           │     size: 1 column, 1 row
 │           │
-│           └── • scan buffer
-│                 label: buffer 1
+│           └── • limit
+│               │ count: 1
+│               │
+│               └── • filter
+│                   │ filter: pk = 1
+│                   │
+│                   └── • scan
+│                         missing stats
+│                         table: t@t_a_idx
+│                         spans: [ - /0] [/2 - ]
 │
 ├── • constraint-check
 │   │
 │   └── • error if rows
 │       │
-│       └── • hash join (right semi)
-│           │ equality: (b) = (column5)
-│           │ right cols are key
-│           │ pred: (column1 != pk) OR (column3 != partition_by)
+│       └── • cross join
 │           │
-│           ├── • scan
-│           │     missing stats
-│           │     table: t@t_b_key
-│           │     spans: FULL SCAN
+│           ├── • values
+│           │     size: 1 column, 1 row
 │           │
-│           └── • scan buffer
-│                 label: buffer 1
+│           └── • limit
+│               │ count: 1
+│               │
+│               └── • filter
+│                   │ filter: (b = 1) AND ((pk != 1) OR (partition_by != 1))
+│                   │
+│                   └── • scan
+│                         missing stats
+│                         table: t@t_b_key
+│                         spans: FULL SCAN
 │
 └── • constraint-check
     │
     └── • error if rows
         │
-        └── • limit
-            │ count: 1
-            │
-            └── • lookup join
-                │ table: t@t_pkey
-                │ equality: (partition_by, pk) = (partition_by,pk)
-                │ equality cols are key
-                │
-                └── • hash join
-                    │ equality: (c) = (column6)
-                    │ right cols are key
-                    │ pred: (column1 != pk) OR (column3 != partition_by)
-                    │
-                    ├── • scan
-                    │     missing stats
-                    │     table: t@t_c_key (partial index)
-                    │     spans: FULL SCAN
-                    │
-                    └── • filter
-                        │ estimated row count: 1
-                        │ filter: column7 > 100
-                        │
-                        └── • scan buffer
-                              label: buffer 1
+        └── • norows
 
 statement ok
 INSERT INTO t VALUES (1, 1, 1, 1, 1, 1, 1), (2, 2, 2, 2, 2, 2, 2)

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
@@ -37,7 +37,7 @@ CREATE TABLE t_child_regional (
 # single shard. This is unnecessary and could be improved by having the shard
 # number calculated instead of looking at all possible shards.
 query T retry
-EXPLAIN (VERBOSE) INSERT INTO t_child VALUES (123, 321);
+EXPLAIN (VERBOSE) INSERT INTO t_child VALUES (123, 321)
 ----
 distribution: local
 vectorized: true
@@ -91,7 +91,7 @@ vectorized: true
 # single shard. This is unnecessary and could be improved by having the shard
 # number calculated instead of looking at all possible shards.
 query T
-EXPLAIN (VERBOSE) INSERT INTO t_child_regional VALUES (123, 321);
+EXPLAIN (VERBOSE) INSERT INTO t_child_regional VALUES (123, 321)
 ----
 distribution: local
 vectorized: true
@@ -122,23 +122,24 @@ vectorized: true
 │       │ columns: ()
 │       │
 │       └── • project
-│           │ columns: (column1)
-│           │ estimated row count: 0 (missing stats)
+│           │ columns: (id)
+│           │ estimated row count: 1 (missing stats)
 │           │
-│           └── • lookup join (semi)
-│               │ columns: (column1, crdb_region_default)
-│               │ estimated row count: 0 (missing stats)
-│               │ table: t_child_regional@t_child_regional_pkey
-│               │ lookup condition: (column1 = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
-│               │ pred: crdb_region_default != crdb_region
+│           └── • cross join (inner)
+│               │ columns: (id, id, crdb_region)
+│               │ estimated row count: 1 (missing stats)
 │               │
-│               └── • project
-│                   │ columns: (column1, crdb_region_default)
-│                   │ estimated row count: 1
-│                   │
-│                   └── • scan buffer
-│                         columns: (column1, column2, crdb_region_default, check1)
-│                         label: buffer 1
+│               ├── • values
+│               │     columns: (id)
+│               │     size: 1 column, 1 row
+│               │     row 0, expr 0: 123
+│               │
+│               └── • scan
+│                     columns: (id, crdb_region)
+│                     estimated row count: 1 (missing stats)
+│                     table: t_child_regional@t_child_regional_pkey
+│                     spans: /"\x80"/123/0 /"\xc0"/123/0
+│                     limit: 1
 │
 └── • constraint-check
     │
@@ -214,9 +215,6 @@ vectorized: true
               row 0, expr 1: gen_random_uuid()
               row 0, expr 2: 'ap-southeast-2'
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_gen_random_uuid (val) VALUES (4321) ON CONFLICT DO NOTHING;
 ----
@@ -275,9 +273,6 @@ vectorized: true
                           row 0, expr 1: gen_random_uuid()
                           row 0, expr 2: 'ap-southeast-2'
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_gen_random_uuid (val) VALUES (4321), (8765) ON CONFLICT DO NOTHING;
 ----
@@ -349,9 +344,6 @@ CREATE TABLE t_unique_hash_pk (
   id INT PRIMARY KEY USING HASH
 ) LOCALITY REGIONAL BY ROW;
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id) VALUES (4321);
 ----
@@ -366,18 +358,14 @@ vectorized: true
 │   │ estimated row count: 0 (missing stats)
 │   │ into: t_unique_hash_pk(crdb_internal_id_shard_16, id, crdb_region)
 │   │
-│   └── • buffer
-│       │ columns: (crdb_internal_id_shard_16_comp, column1, crdb_region_default, check1, check2)
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             columns: (crdb_internal_id_shard_16_comp, column1, crdb_region_default, check1, check2)
-│             size: 5 columns, 1 row
-│             row 0, expr 0: 4321
-│             row 0, expr 1: 'ap-southeast-2'
-│             row 0, expr 2: 9
-│             row 0, expr 3: true
-│             row 0, expr 4: true
+│   └── • values
+│         columns: (crdb_internal_id_shard_16_comp, column1, crdb_region_default, check1, check2)
+│         size: 5 columns, 1 row
+│         row 0, expr 0: 4321
+│         row 0, expr 1: 'ap-southeast-2'
+│         row 0, expr 2: 9
+│         row 0, expr 3: true
+│         row 0, expr 4: true
 │
 └── • constraint-check
     │
@@ -385,23 +373,44 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (column1)
-            │ estimated row count: 0 (missing stats)
+            │ columns: (id)
+            │ estimated row count: 1 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (crdb_internal_id_shard_16_comp, column1, crdb_region_default)
-                │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
-                │ lookup condition: ((column1 = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                │ pred: (crdb_internal_id_shard_16_comp != crdb_internal_id_shard_16) OR (crdb_region_default != crdb_region)
+            └── • cross join (inner)
+                │ columns: (id, crdb_internal_id_shard_16, id, crdb_region)
+                │ estimated row count: 1 (missing stats)
                 │
-                └── • project
-                    │ columns: (crdb_internal_id_shard_16_comp, column1, crdb_region_default)
-                    │ estimated row count: 1
+                ├── • values
+                │     columns: (id)
+                │     size: 1 column, 1 row
+                │     row 0, expr 0: 4321
+                │
+                └── • limit
+                    │ columns: (crdb_internal_id_shard_16, id, crdb_region)
+                    │ estimated row count: 1 (missing stats)
+                    │ count: 1
                     │
-                    └── • scan buffer
-                          columns: (crdb_internal_id_shard_16_comp, column1, crdb_region_default, check1, check2)
-                          label: buffer 1
+                    └── • filter
+                        │ columns: (crdb_internal_id_shard_16, id, crdb_region)
+                        │ estimated row count: 7 (missing stats)
+                        │ filter: (crdb_internal_id_shard_16 != 9) OR (crdb_region != 'ap-southeast-2')
+                        │
+                        └── • union all
+                            │ columns: (crdb_internal_id_shard_16, id, crdb_region)
+                            │ estimated row count: 1 (missing stats)
+                            │ limit: 3
+                            │
+                            ├── • scan
+                            │     columns: (crdb_internal_id_shard_16, id, crdb_region)
+                            │     estimated row count: 1 (missing stats)
+                            │     table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                            │     spans: /"@"/9/4321/0
+                            │
+                            └── • scan
+                                  columns: (crdb_internal_id_shard_16, id, crdb_region)
+                                  estimated row count: 1 (missing stats)
+                                  table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                                  spans: /"\x80"/9/4321/0 /"\xc0"/9/4321/0
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id) VALUES (4321) ON CONFLICT DO NOTHING;
@@ -454,9 +463,6 @@ vectorized: true
                   spans: /"\x80"/9/4321/0 /"\xc0"/9/4321/0
                   parallel
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id) VALUES (4321), (8765) ON CONFLICT DO NOTHING;
 ----
@@ -557,9 +563,6 @@ vectorized: true
                   spans: /"\x80"/9/4321/0 /"\xc0"/9/4321/0
                   parallel
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id) VALUES (4321), (8765) ON CONFLICT (id) DO NOTHING;
 ----
@@ -609,9 +612,6 @@ vectorized: true
                       row 0, expr 0: 4321
                       row 1, expr 0: 8765
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id) VALUES (4321) ON CONFLICT (id) DO UPDATE SET id = excluded.id
 ----
@@ -711,9 +711,6 @@ vectorized: true
                           columns: (crdb_internal_id_shard_16_comp, column1, crdb_region_default, crdb_internal_id_shard_16, id, crdb_region, crdb_internal_id_shard_16_comp, column1, crdb_region, check1, check2, upsert_crdb_region)
                           label: buffer 1
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id) VALUES (4321), (8765) ON CONFLICT (id) DO UPDATE SET id = excluded.id
 ----
@@ -858,9 +855,6 @@ vectorized: true
                   spans: /"\x80"/9/4321/0 /"\xc0"/9/4321/0
                   parallel
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_pk (id) VALUES (4321), (8765);
 ----
@@ -906,9 +900,6 @@ vectorized: true
                   row 0, expr 0: 4321
                   row 1, expr 0: 8765
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) UPDATE t_unique_hash_pk SET id = 1234 WHERE id = 4321;
 ----
@@ -992,9 +983,6 @@ CREATE TABLE t_unique_hash_sec_key (
 statement ok
 CREATE UNIQUE INDEX idx_uniq_hash_email ON t_unique_hash_sec_key (email) USING HASH;
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email');
 ----
@@ -1009,19 +997,15 @@ vectorized: true
 │   │ estimated row count: 0 (missing stats)
 │   │ into: t_unique_hash_sec_key(id, email, crdb_region, crdb_internal_email_shard_16)
 │   │
-│   └── • buffer
-│       │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, check1, check2)
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, check1, check2)
-│             size: 6 columns, 1 row
-│             row 0, expr 0: 4321
-│             row 0, expr 1: 'some_email'
-│             row 0, expr 2: 'ap-southeast-2'
-│             row 0, expr 3: 13
-│             row 0, expr 4: true
-│             row 0, expr 5: true
+│   └── • values
+│         columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, check1, check2)
+│         size: 6 columns, 1 row
+│         row 0, expr 0: 4321
+│         row 0, expr 1: 'some_email'
+│         row 0, expr 2: 'ap-southeast-2'
+│         row 0, expr 3: 13
+│         row 0, expr 4: true
+│         row 0, expr 5: true
 │
 ├── • constraint-check
 │   │
@@ -1029,23 +1013,24 @@ vectorized: true
 │       │ columns: ()
 │       │
 │       └── • project
-│           │ columns: (column1)
-│           │ estimated row count: 0 (missing stats)
+│           │ columns: (id)
+│           │ estimated row count: 1 (missing stats)
 │           │
-│           └── • lookup join (semi)
-│               │ columns: (column1, crdb_region_default)
-│               │ estimated row count: 0 (missing stats)
-│               │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-│               │ lookup condition: (column1 = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
-│               │ pred: crdb_region_default != crdb_region
+│           └── • cross join (inner)
+│               │ columns: (id, id, crdb_region)
+│               │ estimated row count: 1 (missing stats)
 │               │
-│               └── • project
-│                   │ columns: (column1, crdb_region_default)
-│                   │ estimated row count: 1
-│                   │
-│                   └── • scan buffer
-│                         columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, check1, check2)
-│                         label: buffer 1
+│               ├── • values
+│               │     columns: (id)
+│               │     size: 1 column, 1 row
+│               │     row 0, expr 0: 4321
+│               │
+│               └── • scan
+│                     columns: (id, crdb_region)
+│                     estimated row count: 1 (missing stats)
+│                     table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+│                     spans: /"\x80"/4321/0 /"\xc0"/4321/0
+│                     limit: 1
 │
 └── • constraint-check
     │
@@ -1053,23 +1038,60 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (column2)
-            │ estimated row count: 0 (missing stats)
+            │ columns: (email)
+            │ estimated row count: 1 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (column1, column2, crdb_region_default)
-                │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
-                │ lookup condition: ((column2 = email) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                │ pred: (column1 != id) OR (crdb_region_default != crdb_region)
+            └── • cross join (inner)
+                │ columns: (email, id, email, crdb_region)
+                │ estimated row count: 1 (missing stats)
                 │
-                └── • project
-                    │ columns: (column1, column2, crdb_region_default)
-                    │ estimated row count: 1
+                ├── • values
+                │     columns: (email)
+                │     size: 1 column, 1 row
+                │     row 0, expr 0: 'some_email'
+                │
+                └── • limit
+                    │ columns: (id, email, crdb_region)
+                    │ estimated row count: 1 (missing stats)
+                    │ count: 1
                     │
-                    └── • scan buffer
-                          columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, check1, check2)
-                          label: buffer 1
+                    └── • distinct
+                        │ columns: (id, email, crdb_region)
+                        │ estimated row count: 7 (missing stats)
+                        │ distinct on: id, crdb_region
+                        │
+                        └── • union all
+                            │ columns: (id, email, crdb_region)
+                            │ estimated row count: 2 (missing stats)
+                            │
+                            ├── • filter
+                            │   │ columns: (id, email, crdb_region)
+                            │   │ estimated row count: 1 (missing stats)
+                            │   │ filter: id != 4321
+                            │   │
+                            │   └── • union all
+                            │       │ columns: (id, email, crdb_region)
+                            │       │ estimated row count: 1 (missing stats)
+                            │       │ limit: 1
+                            │       │
+                            │       ├── • scan
+                            │       │     columns: (id, email, crdb_region)
+                            │       │     estimated row count: 1 (missing stats)
+                            │       │     table: t_unique_hash_sec_key@idx_uniq_hash_email
+                            │       │     spans: /"@"/13/"some_email"/0
+                            │       │
+                            │       └── • scan
+                            │             columns: (id, email, crdb_region)
+                            │             estimated row count: 1 (missing stats)
+                            │             table: t_unique_hash_sec_key@idx_uniq_hash_email
+                            │             spans: /"\x80"/13/"some_email"/0 /"\xc0"/13/"some_email"/0
+                            │             parallel
+                            │
+                            └── • scan
+                                  columns: (id, email, crdb_region)
+                                  estimated row count: 1 (missing stats)
+                                  table: t_unique_hash_sec_key@idx_uniq_hash_email
+                                  spans: /"\x80"/13/"some_email"/0 /"\xc0"/13/"some_email"/0
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email') ON CONFLICT DO NOTHING;
@@ -1135,9 +1157,6 @@ vectorized: true
                           spans: /"\x80"/4321/0 /"\xc0"/4321/0
                           parallel
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email'), (8765, 'another_email') ON CONFLICT DO NOTHING;
 ----
@@ -1213,53 +1232,49 @@ vectorized: true
 │   │ into: t_unique_hash_sec_key(id, email, crdb_region, crdb_internal_email_shard_16)
 │   │ arbiter constraints: idx_uniq_hash_email
 │   │
-│   └── • buffer
+│   └── • render
 │       │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, check1, check2)
-│       │ label: buffer 1
+│       │ estimated row count: 0 (missing stats)
+│       │ render check1: crdb_internal_email_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+│       │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
+│       │ render column1: column1
+│       │ render column2: column2
+│       │ render crdb_region_default: crdb_region_default
+│       │ render crdb_internal_email_shard_16_comp: crdb_internal_email_shard_16_comp
 │       │
-│       └── • render
-│           │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, check1, check2)
+│       └── • cross join (anti)
+│           │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
 │           │ estimated row count: 0 (missing stats)
-│           │ render check1: crdb_internal_email_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
-│           │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
-│           │ render column1: column1
-│           │ render column2: column2
-│           │ render crdb_region_default: crdb_region_default
-│           │ render crdb_internal_email_shard_16_comp: crdb_internal_email_shard_16_comp
 │           │
-│           └── • cross join (anti)
-│               │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
-│               │ estimated row count: 0 (missing stats)
+│           ├── • values
+│           │     columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
+│           │     size: 4 columns, 1 row
+│           │     row 0, expr 0: 4321
+│           │     row 0, expr 1: 'some_email'
+│           │     row 0, expr 2: 'ap-southeast-2'
+│           │     row 0, expr 3: 13
+│           │
+│           └── • project
+│               │ columns: ()
+│               │ estimated row count: 1 (missing stats)
 │               │
-│               ├── • values
-│               │     columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
-│               │     size: 4 columns, 1 row
-│               │     row 0, expr 0: 4321
-│               │     row 0, expr 1: 'some_email'
-│               │     row 0, expr 2: 'ap-southeast-2'
-│               │     row 0, expr 3: 13
-│               │
-│               └── • project
-│                   │ columns: ()
+│               └── • union all
+│                   │ columns: (email)
 │                   │ estimated row count: 1 (missing stats)
+│                   │ limit: 1
 │                   │
-│                   └── • union all
-│                       │ columns: (email)
-│                       │ estimated row count: 1 (missing stats)
-│                       │ limit: 1
-│                       │
-│                       ├── • scan
-│                       │     columns: (email)
-│                       │     estimated row count: 1 (missing stats)
-│                       │     table: t_unique_hash_sec_key@idx_uniq_hash_email
-│                       │     spans: /"@"/13/"some_email"/0
-│                       │
-│                       └── • scan
-│                             columns: (email)
-│                             estimated row count: 1 (missing stats)
-│                             table: t_unique_hash_sec_key@idx_uniq_hash_email
-│                             spans: /"\x80"/13/"some_email"/0 /"\xc0"/13/"some_email"/0
-│                             parallel
+│                   ├── • scan
+│                   │     columns: (email)
+│                   │     estimated row count: 1 (missing stats)
+│                   │     table: t_unique_hash_sec_key@idx_uniq_hash_email
+│                   │     spans: /"@"/13/"some_email"/0
+│                   │
+│                   └── • scan
+│                         columns: (email)
+│                         estimated row count: 1 (missing stats)
+│                         table: t_unique_hash_sec_key@idx_uniq_hash_email
+│                         spans: /"\x80"/13/"some_email"/0 /"\xc0"/13/"some_email"/0
+│                         parallel
 │
 └── • constraint-check
     │
@@ -1267,27 +1282,25 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (column1)
-            │ estimated row count: 0 (missing stats)
+            │ columns: (id)
+            │ estimated row count: 1 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (column1, crdb_region_default)
-                │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-                │ lookup condition: (column1 = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
-                │ pred: crdb_region_default != crdb_region
+            └── • cross join (inner)
+                │ columns: (id, id, crdb_region)
+                │ estimated row count: 1 (missing stats)
                 │
-                └── • project
-                    │ columns: (column1, crdb_region_default)
-                    │ estimated row count: 0 (missing stats)
-                    │
-                    └── • scan buffer
-                          columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, check1, check2)
-                          label: buffer 1
+                ├── • values
+                │     columns: (id)
+                │     size: 1 column, 1 row
+                │     row 0, expr 0: 4321
+                │
+                └── • scan
+                      columns: (id, crdb_region)
+                      estimated row count: 1 (missing stats)
+                      table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+                      spans: /"\x80"/4321/0 /"\xc0"/4321/0
+                      limit: 1
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email'), (8765, 'another_email') ON CONFLICT (email) DO NOTHING;
 ----
@@ -1371,9 +1384,6 @@ vectorized: true
                           columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, check1, check2)
                           label: buffer 1
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email') ON CONFLICT (email) DO UPDATE SET email = 'bad_email';
 ----
@@ -1516,9 +1526,6 @@ vectorized: true
                           columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, crdb_region, check1, check2, upsert_id, upsert_crdb_region)
                           label: buffer 1
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email'), (8765, 'another_email') ON CONFLICT (email) DO UPDATE SET email = 'bad_email';
 ----
@@ -1664,9 +1671,6 @@ vectorized: true
                           columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, crdb_region, check1, check2, upsert_id, upsert_crdb_region)
                           label: buffer 1
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_sec_key VALUES (1, 'email1');
 ----
@@ -1766,9 +1770,6 @@ vectorized: true
                           columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region, crdb_internal_email_shard_16, column2, crdb_region_default, crdb_internal_email_shard_16_comp, crdb_region, check1, check2, upsert_id)
                           label: buffer 1
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_sec_key VALUES (1, 'email1'), (8765, 'email2');
 ----
@@ -1867,9 +1868,6 @@ vectorized: true
                           columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region, crdb_internal_email_shard_16, column2, crdb_region_default, crdb_internal_email_shard_16_comp, crdb_region, check1, check2, upsert_id)
                           label: buffer 1
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) UPDATE t_unique_hash_sec_key SET email = 'email1' WHERE id = 2;
 ----

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -1108,6 +1108,58 @@ SELECT * FROM [EXPLAIN INSERT INTO child VALUES (1, 1)] OFFSET 2
 │   │
 │   └── • error if rows
 │       │
+│       └── • cross join
+│           │
+│           ├── • values
+│           │     size: 1 column, 1 row
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: child@child_pkey
+│                 spans: [/'ca-central-1'/1 - /'ca-central-1'/1] [/'us-east-1'/1 - /'us-east-1'/1]
+│                 limit: 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • lookup join (anti)
+            │ table: parent@parent_pkey
+            │ equality cols are key
+            │ lookup condition: (column2 = p_id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))
+            │
+            └── • lookup join (anti)
+                │ table: parent@parent_pkey
+                │ equality cols are key
+                │ lookup condition: (column2 = p_id) AND (crdb_region = 'ap-southeast-2')
+                │
+                └── • scan buffer
+                      label: buffer 1
+
+# Non-constant insert values cannot be inlined in uniqueness check, and all
+# regions must be searched for duplicates.
+query T
+SELECT * FROM [EXPLAIN INSERT INTO child VALUES (1, 1), (2, 2)] OFFSET 2
+----
+·
+• root
+│
+├── • insert
+│   │ into: child(c_id, c_p_id, crdb_region)
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │ estimated row count: 2
+│           │
+│           └── • values
+│                 size: 2 columns, 2 rows
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
 │       └── • lookup join (semi)
 │           │ table: child@child_pkey
 │           │ lookup condition: (column1 = c_id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
@@ -1467,9 +1519,6 @@ ALTER TABLE regional_by_row_table ADD CONSTRAINT unique_b_a UNIQUE(b, a)
 
 # We should plan uniqueness checks for all unique indexes in
 # REGIONAL BY ROW tables.
-# TODO(treilly): The constraint check for uniq_idx should use uniq_idx but due
-# to stats issues w/ empty stats, partial indexes and multicol stats its not.
-# Hopefully fixing #67583 (and possibly #67479) will resolve this.
 query T
 SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table (pk, pk2, a, b) VALUES (1, 1, 1, 1)] OFFSET 2
 ----
@@ -1479,63 +1528,106 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table (pk, pk2, a, b) VALUES 
 ├── • insert
 │   │ into: regional_by_row_table(pk, pk2, a, b, j, crdb_region)
 │   │
-│   └── • buffer
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             size: 8 columns, 1 row
+│   └── • values
+│         size: 8 columns, 1 row
 │
 ├── • constraint-check
 │   │
 │   └── • error if rows
 │       │
-│       └── • lookup join (semi)
-│           │ table: regional_by_row_table@regional_by_row_table_pkey
-│           │ lookup condition: (column1 = pk) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
-│           │ pred: crdb_region_default != crdb_region
+│       └── • cross join
 │           │
-│           └── • scan buffer
-│                 label: buffer 1
+│           ├── • values
+│           │     size: 1 column, 1 row
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: regional_by_row_table@regional_by_row_table_pkey
+│                 spans: [/'ca-central-1'/1 - /'ca-central-1'/1] [/'us-east-1'/1 - /'us-east-1'/1]
+│                 limit: 1
 │
 ├── • constraint-check
 │   │
 │   └── • error if rows
 │       │
-│       └── • lookup join (semi)
-│           │ table: regional_by_row_table@regional_by_row_table_b_key
-│           │ lookup condition: (column4 = b) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
-│           │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
+│       └── • cross join
 │           │
-│           └── • scan buffer
-│                 label: buffer 1
-│
-├── • constraint-check
-│   │
-│   └── • error if rows
-│       │
-│       └── • lookup join (semi)
-│           │ table: regional_by_row_table@new_idx
-│           │ lookup condition: ((column3 = a) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (b > 0)
-│           │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
+│           ├── • values
+│           │     size: 1 column, 1 row
 │           │
-│           └── • filter
-│               │ estimated row count: 1
-│               │ filter: column4 > 0
+│           └── • limit
+│               │ count: 1
 │               │
-│               └── • scan buffer
-│                     label: buffer 1
+│               └── • filter
+│                   │ filter: (pk != 1) OR (crdb_region != 'ap-southeast-2')
+│                   │
+│                   └── • union all
+│                       │ limit: 3
+│                       │
+│                       ├── • scan
+│                       │     missing stats
+│                       │     table: regional_by_row_table@regional_by_row_table_b_key
+│                       │     spans: [/'ap-southeast-2'/1 - /'ap-southeast-2'/1]
+│                       │
+│                       └── • scan
+│                             missing stats
+│                             table: regional_by_row_table@regional_by_row_table_b_key
+│                             spans: [/'ca-central-1'/1 - /'ca-central-1'/1] [/'us-east-1'/1 - /'us-east-1'/1]
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • lookup join
+│           │ table: regional_by_row_table@regional_by_row_table_pkey
+│           │ equality: (crdb_region, pk) = (crdb_region,pk)
+│           │ equality cols are key
+│           │
+│           └── • render
+│               │
+│               └── • limit
+│                   │ count: 1
+│                   │
+│                   └── • filter
+│                       │ filter: (pk != 1) OR (crdb_region != 'ap-southeast-2')
+│                       │
+│                       └── • union all
+│                           │ limit: 3
+│                           │
+│                           ├── • scan
+│                           │     missing stats
+│                           │     table: regional_by_row_table@uniq_idx (partial index)
+│                           │     spans: [/'ap-southeast-2'/1 - /'ap-southeast-2'/1]
+│                           │
+│                           └── • scan
+│                                 missing stats
+│                                 table: regional_by_row_table@uniq_idx (partial index)
+│                                 spans: [/'ca-central-1'/1 - /'ca-central-1'/1] [/'us-east-1'/1 - /'us-east-1'/1]
 │
 └── • constraint-check
     │
     └── • error if rows
         │
-        └── • lookup join (semi)
-            │ table: regional_by_row_table@new_idx
-            │ lookup condition: ((column3 = a) AND (column4 = b)) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
-            │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
+        └── • cross join (semi)
             │
-            └── • scan buffer
-                  label: buffer 1
+            ├── • values
+            │     size: 2 columns, 1 row
+            │
+            └── • filter
+                │ filter: (pk != 1) OR (crdb_region != 'ap-southeast-2')
+                │
+                └── • union all
+                    │ limit: 3
+                    │
+                    ├── • scan
+                    │     missing stats
+                    │     table: regional_by_row_table@new_idx
+                    │     spans: [/'ap-southeast-2'/1/1 - /'ap-southeast-2'/1/1]
+                    │
+                    └── • scan
+                          missing stats
+                          table: regional_by_row_table@new_idx
+                          spans: [/'ca-central-1'/1/1 - /'ca-central-1'/1/1] [/'us-east-1'/1/1 - /'us-east-1'/1/1]
 
 statement error pq: duplicate key value violates unique constraint "regional_by_row_table_b_key"\nDETAIL: Key \(b\)=\(3\) already exists\.
 INSERT INTO regional_by_row_table (crdb_region, pk, pk2, a, b) VALUES ('us-east-1', 2, 3, 2, 3)
@@ -1804,23 +1896,36 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_as (pk, a, b) VALUES (1
 ├── • insert
 │   │ into: regional_by_row_table_as(pk, a, b, crdb_region_col)
 │   │
-│   └── • buffer
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             size: 5 columns, 1 row
+│   └── • values
+│         size: 5 columns, 1 row
 │
 └── • constraint-check
     │
     └── • error if rows
         │
-        └── • lookup join (semi)
-            │ table: regional_by_row_table_as@regional_by_row_table_as_b_key
-            │ lookup condition: (column3 = b) AND (crdb_region_col IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
-            │ pred: (column1 != pk) OR (crdb_region_col_comp != crdb_region_col)
+        └── • cross join
             │
-            └── • scan buffer
-                  label: buffer 1
+            ├── • values
+            │     size: 1 column, 1 row
+            │
+            └── • limit
+                │ count: 1
+                │
+                └── • filter
+                    │ filter: (pk != 1) OR (crdb_region_col != 'us-east-1')
+                    │
+                    └── • union all
+                        │ limit: 3
+                        │
+                        ├── • scan
+                        │     missing stats
+                        │     table: regional_by_row_table_as@regional_by_row_table_as_b_key
+                        │     spans: [/'ap-southeast-2'/1 - /'ap-southeast-2'/1]
+                        │
+                        └── • scan
+                              missing stats
+                              table: regional_by_row_table_as@regional_by_row_table_as_b_key
+                              spans: [/'ca-central-1'/1 - /'ca-central-1'/1] [/'us-east-1'/1 - /'us-east-1'/1]
 
 statement error pq: duplicate key value violates unique constraint "regional_by_row_table_as_pkey"\nDETAIL: Key \(pk\)=\(1\) already exists\.
 INSERT INTO regional_by_row_table_as (pk, a, b) VALUES (1, 1, 1)
@@ -1864,67 +1969,69 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt (pk, a, b) VALUES 
 ├── • insert
 │   │ into: regional_by_row_table_virt(pk, a, b, v, crdb_region, crdb_internal_idx_expr)
 │   │
-│   └── • buffer
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             size: 7 columns, 1 row
+│   └── • values
+│         size: 7 columns, 1 row
 │
 ├── • constraint-check
 │   │
 │   └── • error if rows
 │       │
-│       └── • lookup join (semi)
-│           │ table: regional_by_row_table_virt@regional_by_row_table_virt_pkey
-│           │ lookup condition: (column1 = pk) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
-│           │ pred: crdb_region_default != crdb_region
+│       └── • cross join
 │           │
-│           └── • scan buffer
-│                 label: buffer 1
+│           ├── • values
+│           │     size: 1 column, 1 row
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: regional_by_row_table_virt@regional_by_row_table_virt_pkey
+│                 spans: [/'ca-central-1'/1 - /'ca-central-1'/1] [/'us-east-1'/1 - /'us-east-1'/1]
+│                 limit: 1
 │
 ├── • constraint-check
 │   │
 │   └── • error if rows
 │       │
-│       └── • limit
-│           │ count: 1
+│       └── • cross join
 │           │
-│           └── • lookup join
-│               │ table: regional_by_row_table_virt@regional_by_row_table_virt_v_key
-│               │ equality: (lookup_join_const_col_@34, v_comp) = (crdb_region,v)
-│               │ equality cols are key
-│               │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
+│           ├── • values
+│           │     size: 1 column, 1 row
+│           │
+│           └── • limit
+│               │ count: 1
 │               │
-│               └── • cross join
-│                   │ estimated row count: 3
+│               └── • filter
+│                   │ filter: ((a + b) = 2) AND ((pk != 1) OR (crdb_region != 'ap-southeast-2'))
 │                   │
-│                   ├── • values
-│                   │     size: 1 column, 3 rows
-│                   │
-│                   └── • scan buffer
-│                         label: buffer 1
+│                   └── • scan
+│                         missing stats
+│                         table: regional_by_row_table_virt@regional_by_row_table_virt_pkey
+│                         spans: [/'ap-southeast-2' - /'ap-southeast-2'] [/'ca-central-1' - /'us-east-1']
 │
 └── • constraint-check
     │
     └── • error if rows
         │
-        └── • limit
-            │ count: 1
+        └── • cross join
             │
-            └── • lookup join
-                │ table: regional_by_row_table_virt@regional_by_row_table_virt_expr_key
-                │ equality: (lookup_join_const_col_@48, crdb_internal_idx_expr_comp) = (crdb_region,crdb_internal_idx_expr)
-                │ equality cols are key
-                │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
+            ├── • values
+            │     size: 1 column, 1 row
+            │
+            └── • limit
+                │ count: 1
                 │
-                └── • cross join
-                    │ estimated row count: 3
+                └── • filter
+                    │ filter: a = 1
                     │
-                    ├── • values
-                    │     size: 1 column, 3 rows
-                    │
-                    └── • scan buffer
-                          label: buffer 1
+                    └── • index join
+                        │ table: regional_by_row_table_virt@regional_by_row_table_virt_pkey
+                        │
+                        └── • filter
+                            │ filter: (pk != 1) OR (crdb_region != 'ap-southeast-2')
+                            │
+                            └── • scan
+                                  missing stats
+                                  table: regional_by_row_table_virt@regional_by_row_table_virt_expr_key
+                                  spans: [/'ap-southeast-2'/11 - /'ap-southeast-2'/11] [/'ca-central-1'/11 - /'ca-central-1'/11] [/'us-east-1'/11 - /'us-east-1'/11]
 
 query T
 SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table_virt (pk, a, b) VALUES (1, 1, 1)] OFFSET 2
@@ -2042,71 +2149,85 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt_partial (pk, a, b)
 ├── • insert
 │   │ into: regional_by_row_table_virt_partial(pk, a, b, v, crdb_region, crdb_internal_idx_expr)
 │   │
-│   └── • buffer
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             size: 9 columns, 1 row
+│   └── • values
+│         size: 9 columns, 1 row
 │
 ├── • constraint-check
 │   │
 │   └── • error if rows
 │       │
-│       └── • lookup join (semi)
+│       └── • cross join
+│           │
+│           ├── • values
+│           │     size: 1 column, 1 row
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: regional_by_row_table_virt_partial@regional_by_row_table_virt_partial_pkey
+│                 spans: [/'ca-central-1'/1 - /'ca-central-1'/1] [/'us-east-1'/1 - /'us-east-1'/1]
+│                 limit: 1
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • lookup join
 │           │ table: regional_by_row_table_virt_partial@regional_by_row_table_virt_partial_pkey
-│           │ lookup condition: (column1 = pk) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
-│           │ pred: crdb_region_default != crdb_region
+│           │ equality: (crdb_region, pk) = (crdb_region,pk)
+│           │ equality cols are key
 │           │
-│           └── • scan buffer
-│                 label: buffer 1
+│           └── • render
+│               │
+│               └── • limit
+│                   │ count: 1
+│                   │
+│                   └── • filter
+│                       │ filter: (pk != 1) OR (crdb_region != 'ap-southeast-2')
+│                       │
+│                       └── • scan
+│                             missing stats
+│                             table: regional_by_row_table_virt_partial@v_a_gt_0 (partial index)
+│                             spans: [/'ap-southeast-2'/2 - /'ap-southeast-2'/2] [/'ca-central-1'/2 - /'ca-central-1'/2] [/'us-east-1'/2 - /'us-east-1'/2]
 │
 ├── • constraint-check
 │   │
 │   └── • error if rows
 │       │
-│       └── • lookup join (semi)
-│           │ table: regional_by_row_table_virt_partial@v_a_gt_0 (partial index)
-│           │ lookup condition: (v_comp = v) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
-│           │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
+│       └── • cross join
 │           │
-│           └── • filter
-│               │ estimated row count: 1
-│               │ filter: column2 > 0
-│               │
-│               └── • scan buffer
-│                     label: buffer 1
-│
-├── • constraint-check
-│   │
-│   └── • error if rows
-│       │
-│       └── • lookup join (semi)
-│           │ table: regional_by_row_table_virt_partial@v_v_gt_0 (partial index)
-│           │ lookup condition: (v_comp = v) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
-│           │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
+│           ├── • values
+│           │     size: 1 column, 1 row
 │           │
-│           └── • filter
-│               │ estimated row count: 1
-│               │ filter: v_comp > 0
+│           └── • limit
+│               │ count: 1
 │               │
-│               └── • scan buffer
-│                     label: buffer 1
+│               └── • filter
+│                   │ filter: ((a + b) = 2) AND ((pk != 1) OR (crdb_region != 'ap-southeast-2'))
+│                   │
+│                   └── • scan
+│                         missing stats
+│                         table: regional_by_row_table_virt_partial@regional_by_row_table_virt_partial_pkey
+│                         spans: [/'ap-southeast-2' - /'ap-southeast-2'] [/'ca-central-1' - /'us-east-1']
 │
 └── • constraint-check
     │
     └── • error if rows
         │
-        └── • lookup join (semi)
-            │ table: regional_by_row_table_virt_partial@a_plus_10_v_gt_0 (partial index)
-            │ lookup condition: (crdb_internal_idx_expr_comp = crdb_internal_idx_expr) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
-            │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
+        └── • cross join
             │
-            └── • filter
-                │ estimated row count: 1
-                │ filter: v_comp > 0
+            ├── • values
+            │     size: 1 column, 1 row
+            │
+            └── • limit
+                │ count: 1
                 │
-                └── • scan buffer
-                      label: buffer 1
+                └── • filter
+                    │ filter: ((a = 1) AND (b > -1)) AND ((pk != 1) OR (crdb_region != 'ap-southeast-2'))
+                    │
+                    └── • scan
+                          missing stats
+                          table: regional_by_row_table_virt_partial@regional_by_row_table_virt_partial_pkey
+                          spans: [/'ap-southeast-2' - /'ap-southeast-2'] [/'ca-central-1' - /'us-east-1']
 
 query T
 SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table_virt_partial (pk, a, b) VALUES (1, 1, 1)] OFFSET 2

--- a/pkg/sql/opt/exec/explain/testdata/gists_tpce
+++ b/pkg/sql/opt/exec/explain/testdata/gists_tpce
@@ -219,7 +219,7 @@ explain(shape):
 • root
 │
 ├── • scan buffer
-│     label: buffer 3 (request_list)
+│     label: buffer 2 (request_list)
 │
 ├── • subquery
 │   │ id: @S1
@@ -227,7 +227,7 @@ explain(shape):
 │   │ exec mode: all rows
 │   │
 │   └── • buffer
-│       │ label: buffer 2 (update_last_trade)
+│       │ label: buffer 1 (update_last_trade)
 │       │
 │       └── • render
 │           │
@@ -248,7 +248,7 @@ explain(shape):
 │   │ exec mode: all rows
 │   │
 │   └── • buffer
-│       │ label: buffer 3 (request_list)
+│       │ label: buffer 2 (request_list)
 │       │
 │       └── • render
 │           │
@@ -266,7 +266,7 @@ explain(shape):
 │   │ exec mode: all rows
 │   │
 │   └── • buffer
-│       │ label: buffer 4 (delete_trade_request)
+│       │ label: buffer 3 (delete_trade_request)
 │       │
 │       └── • render
 │           │
@@ -281,7 +281,7 @@ explain(shape):
 │                       │ equality cols are key
 │                       │
 │                       └── • scan buffer
-│                             label: buffer 3 (request_list)
+│                             label: buffer 2 (request_list)
 │
 ├── • subquery
 │   │ id: @S4
@@ -289,7 +289,7 @@ explain(shape):
 │   │ exec mode: all rows
 │   │
 │   └── • buffer
-│       │ label: buffer 6 (insert_trade_history)
+│       │ label: buffer 5 (insert_trade_history)
 │       │
 │       └── • render
 │           │
@@ -297,12 +297,12 @@ explain(shape):
 │               │ into: trade_history(th_t_id, th_dts, th_st_id)
 │               │
 │               └── • buffer
-│                   │ label: buffer 5
+│                   │ label: buffer 4
 │                   │
 │                   └── • render
 │                       │
 │                       └── • scan buffer
-│                             label: buffer 3 (request_list)
+│                             label: buffer 2 (request_list)
 │
 ├── • subquery
 │   │ id: @S5
@@ -310,7 +310,7 @@ explain(shape):
 │   │ exec mode: all rows
 │   │
 │   └── • buffer
-│       │ label: buffer 8 (update_trade_submitted)
+│       │ label: buffer 7 (update_trade_submitted)
 │       │
 │       └── • render
 │           │
@@ -319,7 +319,7 @@ explain(shape):
 │               │ set: t_dts, t_st_id
 │               │
 │               └── • buffer
-│                   │ label: buffer 7
+│                   │ label: buffer 6
 │                   │
 │                   └── • render
 │                       │
@@ -329,7 +329,7 @@ explain(shape):
 │                           │ equality cols are key
 │                           │
 │                           └── • scan buffer
-│                                 label: buffer 3 (request_list)
+│                                 label: buffer 2 (request_list)
 │
 ├── • constraint-check
 │   │
@@ -341,7 +341,7 @@ explain(shape):
 │           │ equality cols are key
 │           │
 │           └── • scan buffer
-│                 label: buffer 5
+│                 label: buffer 4
 │
 ├── • constraint-check
 │   │
@@ -353,7 +353,7 @@ explain(shape):
 │           │ equality cols are key
 │           │
 │           └── • scan buffer
-│                 label: buffer 5
+│                 label: buffer 4
 │
 └── • constraint-check
     │
@@ -365,7 +365,7 @@ explain(shape):
             │ equality cols are key
             │
             └── • scan buffer
-                  label: buffer 7
+                  label: buffer 6
 explain(gist):
 • root
 │

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -832,6 +832,52 @@ func (prj *ProjectExpr) InternalFDs() *props.FuncDepSet {
 	return &prj.internalFuncDeps
 }
 
+// FindInlinableConstants returns the set of input columns that are synthesized
+// constant value expressions: ConstOp, TrueOp, FalseOp, or NullOp. Constant
+// value expressions can often be inlined into referencing expressions. Only
+// Project and Values operators synthesize constant value expressions.
+func FindInlinableConstants(input RelExpr) opt.ColSet {
+	var cols opt.ColSet
+	if project, ok := input.(*ProjectExpr); ok {
+		for i := range project.Projections {
+			item := &project.Projections[i]
+			if opt.IsConstValueOp(item.Element) {
+				cols.Add(item.Col)
+			}
+		}
+	} else if values, ok := input.(*ValuesExpr); ok && len(values.Rows) == 1 {
+		tup := values.Rows[0].(*TupleExpr)
+		for i, scalar := range tup.Elems {
+			if opt.IsConstValueOp(scalar) {
+				cols.Add(values.Cols[i])
+			}
+		}
+	}
+	return cols
+}
+
+// ExtractColumnFromProjectOrValues searches a Project or Values input
+// expression for the column having the given id. It returns the expression for
+// that column.
+func ExtractColumnFromProjectOrValues(input RelExpr, col opt.ColumnID) opt.ScalarExpr {
+	if project, ok := input.(*ProjectExpr); ok {
+		for i := range project.Projections {
+			item := &project.Projections[i]
+			if item.Col == col {
+				return item.Element
+			}
+		}
+	} else if values, ok := input.(*ValuesExpr); ok && len(values.Rows) == 1 {
+		tup := values.Rows[0].(*TupleExpr)
+		for i, scalar := range tup.Elems {
+			if values.Cols[i] == col {
+				return scalar
+			}
+		}
+	}
+	panic(errors.AssertionFailedf("could not find column to extract"))
+}
+
 // ExprIsNeverNull makes a best-effort attempt to prove that the provided
 // scalar is always non-NULL, given the set of outer columns that are known
 // to be not null. This is particularly useful with check constraints.

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -277,6 +277,10 @@ func (b *Builder) buildInsert(ins *tree.Insert, inScope *scope) (outScope *scope
 	// both cases, include columns undergoing mutations in the write-only state.
 	mb.addSynthesizedColsForInsert()
 
+	// Set insertExpr. This expression is used when building uniqueness checks.
+	// See mutationBuilder.buildCheckInputScan.
+	mb.insertExpr = mb.outScope.expr
+
 	var returning tree.ReturningExprs
 	if resultsNeeded(ins.Returning) {
 		returning = *ins.Returning.(*tree.ReturningExprs)

--- a/pkg/sql/opt/optbuilder/mutation_builder_fk.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_fk.go
@@ -71,12 +71,6 @@ func (mb *mutationBuilder) buildFKChecksForInsert() {
 		return
 	}
 
-	// TODO(radu): if the input is a VALUES with constant expressions, we don't
-	// need to buffer it. This could be a normalization rule, but it's probably
-	// more efficient if we did it in here (or we'd end up building the entire FK
-	// subtrees twice).
-	mb.ensureWithID()
-
 	h := &mb.fkCheckHelper
 	for i, n := 0, mb.tab.OutboundForeignKeyCount(); i < n; i++ {
 		if h.initWithOutboundFK(mb, i) {
@@ -170,8 +164,7 @@ func (mb *mutationBuilder) buildFKChecksAndCascadesForDelete() {
 			continue
 		}
 
-		mb.ensureWithID()
-		withScanScope, _ := mb.buildCheckInputScan(checkInputScanFetchedVals, h.tabOrdinals)
+		withScanScope, _ := mb.buildCheckInputScan(checkInputScanFetchedVals, h.tabOrdinals, true /* isFK */)
 		mb.fkChecks = append(mb.fkChecks, h.buildDeletionCheck(withScanScope.expr, withScanScope.colList()))
 	}
 	telemetry.Inc(sqltelemetry.ForeignKeyChecksUseCounter)
@@ -239,8 +232,6 @@ func (mb *mutationBuilder) buildFKChecksForUpdate() {
 		return
 	}
 
-	mb.ensureWithID()
-
 	// An Update can be thought of an insertion paired with a deletion, so for an
 	// Update we can emit both semi-joins and anti-joins.
 
@@ -288,6 +279,7 @@ func (mb *mutationBuilder) buildFKChecksForUpdate() {
 
 		if a := h.fk.UpdateReferenceAction(); a != tree.Restrict && a != tree.NoAction {
 			telemetry.Inc(sqltelemetry.ForeignKeyCascadesUseCounter)
+			mb.ensureWithID()
 			builder := newOnUpdateCascadeBuilder(mb.tab, i, h.otherTab, a)
 
 			oldCols := make(opt.ColList, len(h.tabOrdinals))
@@ -336,8 +328,8 @@ func (mb *mutationBuilder) buildFKChecksForUpdate() {
 		// performance either: we would be incurring extra cost (more complicated
 		// expressions, scanning the input buffer twice) for a rare case.
 
-		oldRowsScope, _ := mb.buildCheckInputScan(checkInputScanFetchedVals, h.tabOrdinals)
-		newRowsScope, _ := mb.buildCheckInputScan(checkInputScanNewVals, h.tabOrdinals)
+		oldRowsScope, _ := mb.buildCheckInputScan(checkInputScanFetchedVals, h.tabOrdinals, true /* isFK */)
+		newRowsScope, _ := mb.buildCheckInputScan(checkInputScanNewVals, h.tabOrdinals, true /* isFK */)
 		colsForOldRow := oldRowsScope.colList()
 		colsForNewRow := newRowsScope.colList()
 
@@ -384,8 +376,6 @@ func (mb *mutationBuilder) buildFKChecksForUpsert() {
 		return
 	}
 
-	mb.ensureWithID()
-
 	h := &mb.fkCheckHelper
 	for i := 0; i < numOutbound; i++ {
 		if h.initWithOutboundFK(mb, i) {
@@ -407,6 +397,7 @@ func (mb *mutationBuilder) buildFKChecksForUpsert() {
 
 		if a := h.fk.UpdateReferenceAction(); a != tree.Restrict && a != tree.NoAction {
 			telemetry.Inc(sqltelemetry.ForeignKeyCascadesUseCounter)
+			mb.ensureWithID()
 			builder := newOnUpdateCascadeBuilder(mb.tab, i, h.otherTab, a)
 
 			oldCols := make(opt.ColList, len(h.tabOrdinals))
@@ -441,8 +432,8 @@ func (mb *mutationBuilder) buildFKChecksForUpsert() {
 		// insertions (using a "canaryCol IS NOT NULL" condition). But the rows we
 		// would filter out have all-null fetched values anyway and will never match
 		// in the semi join.
-		oldRowsScope, _ := mb.buildCheckInputScan(checkInputScanFetchedVals, h.tabOrdinals)
-		newRowsScope, _ := mb.buildCheckInputScan(checkInputScanNewVals, h.tabOrdinals)
+		oldRowsScope, _ := mb.buildCheckInputScan(checkInputScanFetchedVals, h.tabOrdinals, true /* isFK */)
+		newRowsScope, _ := mb.buildCheckInputScan(checkInputScanNewVals, h.tabOrdinals, true /* isFK */)
 		colsForOldRow := oldRowsScope.colList()
 		colsForNewRow := newRowsScope.colList()
 
@@ -643,7 +634,7 @@ func (h *fkCheckHelper) allocOrdinals(numCols int) {
 // mutation operator.
 func (h *fkCheckHelper) buildInsertionCheck() memo.FKChecksItem {
 	withScanScope, notNullWithScanCols := h.mb.buildCheckInputScan(
-		checkInputScanNewVals, h.tabOrdinals,
+		checkInputScanNewVals, h.tabOrdinals, true, /* isFK */
 	)
 
 	numCols := len(withScanScope.cols)

--- a/pkg/sql/opt/optbuilder/mutation_builder_unique.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_unique.go
@@ -41,7 +41,6 @@ func (mb *mutationBuilder) buildUniqueChecksForInsert() {
 		return
 	}
 
-	mb.ensureWithID()
 	h := &mb.uniqueCheckHelper
 
 	for i, n := 0, mb.tab.UniqueCount(); i < n; i++ {
@@ -310,7 +309,7 @@ func (h *uniqueCheckHelper) buildInsertionCheck() memo.UniqueChecksItem {
 	// existing values on the right.
 
 	withScanScope, _ := h.mb.buildCheckInputScan(
-		checkInputScanNewVals, h.scanOrdinals,
+		checkInputScanNewVals, h.scanOrdinals, false, /* isFK */
 	)
 
 	// Build the join filters:
@@ -338,7 +337,7 @@ func (h *uniqueCheckHelper) buildInsertionCheck() memo.UniqueChecksItem {
 
 	// If the unique constraint is partial, we need to filter out inserted rows
 	// that don't satisfy the predicate. We also need to make sure that rows do
-	// not match existing rows in the the table that do not satisfy the
+	// not match existing rows in the table that do not satisfy the
 	// predicate. So we add the predicate as a filter on both the WithScan
 	// columns and the Scan columns.
 	if isPartial {

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
@@ -341,9 +341,61 @@ insert uniq
            └── first-agg [as=column3:10]
                 └── column3:10
 
-# On conflict clause references unique without index constraint.
+# On conflict clause references unique without index constraint. The insert
+# values are inlined in the uniqueness check.
 build
 INSERT INTO uniq VALUES (1, 2, 3, 4, 5) ON CONFLICT (w) DO NOTHING
+----
+insert uniq
+ ├── arbiter constraints: unique_w
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:8 => uniq.k:1
+ │    ├── column2:9 => uniq.v:2
+ │    ├── column3:10 => uniq.w:3
+ │    ├── column4:11 => uniq.x:4
+ │    └── column5:12 => uniq.y:5
+ ├── upsert-distinct-on
+ │    ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null column5:12!null
+ │    ├── grouping columns: column3:10!null
+ │    ├── anti-join (hash)
+ │    │    ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null column5:12!null
+ │    │    ├── values
+ │    │    │    ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null column5:12!null
+ │    │    │    └── (1, 2, 3, 4, 5)
+ │    │    ├── scan uniq
+ │    │    │    └── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17
+ │    │    └── filters
+ │    │         └── column3:10 = uniq.w:15
+ │    └── aggregations
+ │         ├── first-agg [as=column1:8]
+ │         │    └── column1:8
+ │         ├── first-agg [as=column2:9]
+ │         │    └── column2:9
+ │         ├── first-agg [as=column4:11]
+ │         │    └── column4:11
+ │         └── first-agg [as=column5:12]
+ │              └── column5:12
+ └── unique-checks
+      └── unique-checks-item: uniq(x,y)
+           └── project
+                ├── columns: x:30!null y:31!null
+                └── semi-join (hash)
+                     ├── columns: k:27!null v:28!null w:29!null x:30!null y:31!null
+                     ├── values
+                     │    ├── columns: k:27!null v:28!null w:29!null x:30!null y:31!null
+                     │    └── (1, 2, 3, 4, 5)
+                     ├── scan uniq
+                     │    └── columns: uniq.k:20!null uniq.v:21 uniq.w:22 uniq.x:23 uniq.y:24
+                     └── filters
+                          ├── x:30 = uniq.x:23
+                          ├── y:31 = uniq.y:24
+                          └── k:27 != uniq.k:20
+
+# On conflict clause references unique without index constraint. The insert
+# values are not inlined because they are not constant.
+build
+INSERT INTO uniq VALUES (1, 2, 3, 4, 5), (6, 7, 8, 9, 10) ON CONFLICT (w) DO NOTHING
 ----
 insert uniq
  ├── arbiter constraints: unique_w
@@ -362,7 +414,8 @@ insert uniq
  │    │    ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null column5:12!null
  │    │    ├── values
  │    │    │    ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null column5:12!null
- │    │    │    └── (1, 2, 3, 4, 5)
+ │    │    │    ├── (1, 2, 3, 4, 5)
+ │    │    │    └── (6, 7, 8, 9, 10)
  │    │    ├── scan uniq
  │    │    │    └── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17
  │    │    └── filters
@@ -410,7 +463,6 @@ insert uniq
  │    ├── column3:10 => uniq.w:3
  │    ├── column4:11 => uniq.x:4
  │    └── column5:12 => uniq.y:5
- ├── input binding: &1
  ├── upsert-distinct-on
  │    ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null column5:12!null
  │    ├── grouping columns: column3:10!null
@@ -438,14 +490,9 @@ insert uniq
                 ├── columns: x:30!null y:31!null
                 └── semi-join (hash)
                      ├── columns: k:27!null v:28!null w:29!null x:30!null y:31!null
-                     ├── with-scan &1
+                     ├── values
                      │    ├── columns: k:27!null v:28!null w:29!null x:30!null y:31!null
-                     │    └── mapping:
-                     │         ├──  column1:8 => k:27
-                     │         ├──  column2:9 => v:28
-                     │         ├──  column3:10 => w:29
-                     │         ├──  column4:11 => x:30
-                     │         └──  column5:12 => y:31
+                     │    └── (1, 2, 3, 4, 5)
                      ├── scan uniq
                      │    └── columns: uniq.k:20!null uniq.v:21 uniq.w:22 uniq.x:23 uniq.y:24
                      └── filters
@@ -1368,6 +1415,13 @@ CREATE TABLE uniq_partial_constraint_and_index (
 # Use a pseudo-partial index as the only arbiter. Note that we use the "norm"
 # directive instead of "build" to ensure that partial index predicates are fully
 # normalized when choosing arbiter indexes.
+# TODO(mgartner): There is no need to plan a uniqueness check because the
+# pseudo-partial index arbiter ensures that the unique constraint is not
+# violated. In this particular case, with one constant row being inserted, the
+# unique check is normalized to an empty Values expression. One option is to
+# recognize an empty Values uniqueness check and eliminate it. Eliminating this
+# uniqueness check in more general cases would require recognizing that the
+# check is not necessary and not building it in the first place.
 norm
 INSERT INTO uniq_partial_constraint_and_index VALUES (1, 1, 1)
 ON CONFLICT (a) WHERE b > 10 DO NOTHING
@@ -1380,7 +1434,6 @@ insert uniq_partial_constraint_and_index
  │    ├── column2:7 => uniq_partial_constraint_and_index.a:2
  │    └── column3:8 => uniq_partial_constraint_and_index.b:3
  ├── partial index put columns: partial_index_put1:15
- ├── input binding: &1
  ├── project
  │    ├── columns: partial_index_put1:15!null column1:6!null column2:7!null column3:8!null
  │    ├── anti-join (cross)
@@ -1401,31 +1454,8 @@ insert uniq_partial_constraint_and_index
  │         └── true [as=partial_index_put1:15]
  └── unique-checks
       └── unique-checks-item: uniq_partial_constraint_and_index(a)
-           └── project
-                ├── columns: a:22!null
-                └── semi-join (hash)
-                     ├── columns: k:21!null a:22!null b:23!null
-                     ├── select
-                     │    ├── columns: k:21!null a:22!null b:23!null
-                     │    ├── with-scan &1
-                     │    │    ├── columns: k:21!null a:22!null b:23!null
-                     │    │    └── mapping:
-                     │    │         ├──  column1:6 => k:21
-                     │    │         ├──  column2:7 => a:22
-                     │    │         └──  column3:8 => b:23
-                     │    └── filters
-                     │         └── b:23 > 10
-                     ├── select
-                     │    ├── columns: uniq_partial_constraint_and_index.k:16!null uniq_partial_constraint_and_index.a:17 uniq_partial_constraint_and_index.b:18!null
-                     │    ├── scan uniq_partial_constraint_and_index
-                     │    │    ├── columns: uniq_partial_constraint_and_index.k:16!null uniq_partial_constraint_and_index.a:17 uniq_partial_constraint_and_index.b:18
-                     │    │    └── partial index predicates
-                     │    │         └── uniq_partial_constraint_and_index_a_key: filters (true)
-                     │    └── filters
-                     │         └── uniq_partial_constraint_and_index.b:18 > 10
-                     └── filters
-                          ├── a:22 = uniq_partial_constraint_and_index.a:17
-                          └── k:21 != uniq_partial_constraint_and_index.k:16
+           └── values
+                └── columns: a:22!null
 
 exec-ddl
 CREATE TABLE uniq_constraint_and_partial_index (
@@ -1639,3 +1669,45 @@ insert uniq_computed_pk
                      └── filters
                           ├── d:44 = uniq_computed_pk.d:35
                           └── (i:42 != uniq_computed_pk.i:33) OR (c_i_expr:45 != uniq_computed_pk.c_i_expr:36)
+
+exec-ddl
+CREATE TABLE uniq_default (
+  k INT PRIMARY KEY,
+  a INT DEFAULT (10),
+  b INT,
+  UNIQUE WITHOUT INDEX (a, b)
+)
+----
+
+# Inline default values in uniqueness check. The norm directive is used so that
+# the projection of the default value is normalized into the values expression.
+# This normalization is required for the values to be inlined in the constraint
+# check.
+norm
+INSERT INTO uniq_default (k, b) VALUES (1, 100)
+----
+insert uniq_default
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:6 => uniq_default.k:1
+ │    ├── a_default:8 => uniq_default.a:2
+ │    └── column2:7 => uniq_default.b:3
+ ├── values
+ │    ├── columns: column1:6!null column2:7!null a_default:8!null
+ │    └── (1, 100, 10)
+ └── unique-checks
+      └── unique-checks-item: uniq_default(a,b)
+           └── semi-join (cross)
+                ├── columns: a:15!null b:16!null
+                ├── values
+                │    ├── columns: a:15!null b:16!null
+                │    └── (10, 100)
+                ├── select
+                │    ├── columns: uniq_default.k:9!null uniq_default.a:10!null uniq_default.b:11!null
+                │    ├── scan uniq_default
+                │    │    └── columns: uniq_default.k:9!null uniq_default.a:10 uniq_default.b:11
+                │    └── filters
+                │         ├── uniq_default.a:10 = 10
+                │         ├── uniq_default.b:11 = 100
+                │         └── uniq_default.k:9 != 1
+                └── filters (true)

--- a/pkg/sql/opt/xform/testdata/external/tpce
+++ b/pkg/sql/opt/xform/testdata/external/tpce
@@ -551,7 +551,7 @@ update_trade_submitted AS (
 )
 SELECT * FROM request_list;
 ----
-with &2 (update_last_trade)
+with &1 (update_last_trade)
  ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
  ├── volatile, mutations
  ├── key: (139)
@@ -591,7 +591,7 @@ with &2 (update_last_trade)
  │    │              └── '2020-06-15 22:27:42.148484' [as=lt_dts_new:17]
  │    └── projections
  │         └── NULL [as="?column?":19]
- └── with &3 (request_list)
+ └── with &2 (request_list)
       ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
       ├── volatile, mutations
       ├── key: (139)
@@ -621,7 +621,7 @@ with &2 (update_last_trade)
       │    │         └── (((trade_request.tr_tt_id:21 = 'TMB') AND (trade_request.tr_bid_price:24 >= 1E+2)) OR ((trade_request.tr_tt_id:21 = 'TMS') AND (trade_request.tr_bid_price:24 <= 1E+2))) OR ((trade_request.tr_tt_id:21 = 'TLS') AND (trade_request.tr_bid_price:24 >= 1E+2)) [outer=(21,24), immutable, constraints=(/21: [/'TLS' - /'TLS'] [/'TMB' - /'TMB'] [/'TMS' - /'TMS']; /24: (/NULL - ])]
       │    └── projections
       │         └── trade_request.tr_bid_price:24::FLOAT8 [as=tr_bid_price:28, outer=(24), immutable]
-      └── with &4 (delete_trade_request)
+      └── with &3 (delete_trade_request)
            ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
            ├── volatile, mutations
            ├── key: (139)
@@ -650,7 +650,7 @@ with &2 (update_last_trade)
            │    │         │         ├── lookup columns are key
            │    │         │         ├── key: (45)
            │    │         │         ├── fd: (37)-->(38,39,42), (37)==(45), (45)==(37)
-           │    │         │         ├── with-scan &3 (request_list)
+           │    │         │         ├── with-scan &2 (request_list)
            │    │         │         │    ├── columns: tr_t_id:45!null
            │    │         │         │    ├── mapping:
            │    │         │         │    │    └──  trade_request.tr_t_id:20 => tr_t_id:45
@@ -660,7 +660,7 @@ with &2 (update_last_trade)
            │    │              └── trade_request.tr_tt_id:38 IN ('TLB', 'TLS', 'TSL') [as=partial_index_del1:49, outer=(38)]
            │    └── projections
            │         └── NULL [as="?column?":50]
-           └── with &6 (insert_trade_history)
+           └── with &5 (insert_trade_history)
                 ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
                 ├── volatile, mutations
                 ├── key: (139)
@@ -675,7 +675,7 @@ with &2 (update_last_trade)
                 │    │    │    ├── tr_t_id:56 => trade_history.th_t_id:51
                 │    │    │    ├── timestamp:61 => th_dts:52
                 │    │    │    └── th_st_id_cast:62 => trade_history.th_st_id:53
-                │    │    ├── input binding: &5
+                │    │    ├── input binding: &4
                 │    │    ├── volatile, mutations
                 │    │    ├── key: (51)
                 │    │    ├── fd: ()-->(53)
@@ -683,7 +683,7 @@ with &2 (update_last_trade)
                 │    │    │    ├── columns: th_st_id_cast:62!null timestamp:61!null tr_t_id:56!null
                 │    │    │    ├── key: (56)
                 │    │    │    ├── fd: ()-->(61,62)
-                │    │    │    ├── with-scan &3 (request_list)
+                │    │    │    ├── with-scan &2 (request_list)
                 │    │    │    │    ├── columns: tr_t_id:56!null
                 │    │    │    │    ├── mapping:
                 │    │    │    │    │    └──  trade_request.tr_t_id:20 => tr_t_id:56
@@ -698,7 +698,7 @@ with &2 (update_last_trade)
                 │    │         │         ├── key columns: [63] = [64]
                 │    │         │         ├── lookup columns are key
                 │    │         │         ├── key: (63)
-                │    │         │         ├── with-scan &5
+                │    │         │         ├── with-scan &4
                 │    │         │         │    ├── columns: th_t_id:63!null
                 │    │         │         │    ├── mapping:
                 │    │         │         │    │    └──  tr_t_id:56 => th_t_id:63
@@ -710,7 +710,7 @@ with &2 (update_last_trade)
                 │    │                   ├── key columns: [81] = [82]
                 │    │                   ├── lookup columns are key
                 │    │                   ├── fd: ()-->(81)
-                │    │                   ├── with-scan &5
+                │    │                   ├── with-scan &4
                 │    │                   │    ├── columns: th_st_id:81!null
                 │    │                   │    ├── mapping:
                 │    │                   │    │    └──  th_st_id_cast:62 => th_st_id:81
@@ -718,7 +718,7 @@ with &2 (update_last_trade)
                 │    │                   └── filters (true)
                 │    └── projections
                 │         └── NULL [as="?column?":86]
-                └── with &8 (update_trade_submitted)
+                └── with &7 (update_trade_submitted)
                      ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
                      ├── volatile, mutations
                      ├── key: (139)
@@ -733,7 +733,7 @@ with &2 (update_last_trade)
                      │    │    ├── update-mapping:
                      │    │    │    ├── t_dts_new:126 => t_dts:88
                      │    │    │    └── t_st_id_cast:127 => trade.t_st_id:89
-                     │    │    ├── input binding: &7
+                     │    │    ├── input binding: &6
                      │    │    ├── volatile, mutations
                      │    │    ├── key: (87)
                      │    │    ├── project
@@ -750,7 +750,7 @@ with &2 (update_last_trade)
                      │    │    │    │         ├── lookup columns are key
                      │    │    │    │         ├── key: (121)
                      │    │    │    │         ├── fd: (104)-->(105-116,118), (104)==(121), (121)==(104)
-                     │    │    │    │         ├── with-scan &3 (request_list)
+                     │    │    │    │         ├── with-scan &2 (request_list)
                      │    │    │    │         │    ├── columns: tr_t_id:121!null
                      │    │    │    │         │    ├── mapping:
                      │    │    │    │         │    │    └──  trade_request.tr_t_id:20 => tr_t_id:121
@@ -766,7 +766,7 @@ with &2 (update_last_trade)
                      │    │                   ├── key columns: [133] = [134]
                      │    │                   ├── lookup columns are key
                      │    │                   ├── fd: ()-->(133)
-                     │    │                   ├── with-scan &7
+                     │    │                   ├── with-scan &6
                      │    │                   │    ├── columns: t_st_id:133!null
                      │    │                   │    ├── mapping:
                      │    │                   │    │    └──  t_st_id_cast:127 => t_st_id:133
@@ -774,7 +774,7 @@ with &2 (update_last_trade)
                      │    │                   └── filters (true)
                      │    └── projections
                      │         └── NULL [as="?column?":138]
-                     └── with-scan &3 (request_list)
+                     └── with-scan &2 (request_list)
                           ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
                           ├── mapping:
                           │    ├──  trade_request.tr_t_id:20 => tr_t_id:139
@@ -4219,7 +4219,7 @@ with &2 (update_trade_commission)
  │    │                   └── filters (true)
  │    └── projections
  │         └── 1 [as="?column?":52]
- └── with &4 (update_broker_commission)
+ └── with &3 (update_broker_commission)
       ├── columns: "?column?":104!null
       ├── cardinality: [1 - 1]
       ├── volatile, mutations
@@ -4259,7 +4259,7 @@ with &2 (update_trade_commission)
       │    │              └── b_num_trades:63 + 1 [as=b_num_trades_new:68, outer=(63), immutable]
       │    └── projections
       │         └── 1 [as="?column?":70]
-      └── with &6 (insert_trade_history)
+      └── with &5 (insert_trade_history)
            ├── columns: "?column?":104!null
            ├── cardinality: [1 - 1]
            ├── volatile, mutations
@@ -4277,7 +4277,7 @@ with &2 (update_trade_commission)
            │    │    │    ├── column1:76 => trade_history.th_t_id:71
            │    │    │    ├── column2:77 => th_dts:72
            │    │    │    └── th_st_id_cast:79 => trade_history.th_st_id:73
-           │    │    ├── input binding: &5
+           │    │    ├── input binding: &4
            │    │    ├── cardinality: [1 - 1]
            │    │    ├── volatile, mutations
            │    │    ├── key: ()
@@ -4297,7 +4297,7 @@ with &2 (update_trade_commission)
            │    │         │         ├── cardinality: [0 - 1]
            │    │         │         ├── key: ()
            │    │         │         ├── fd: ()-->(80)
-           │    │         │         ├── with-scan &5
+           │    │         │         ├── with-scan &4
            │    │         │         │    ├── columns: th_t_id:80!null
            │    │         │         │    ├── mapping:
            │    │         │         │    │    └──  column1:76 => th_t_id:80
@@ -4313,7 +4313,7 @@ with &2 (update_trade_commission)
            │    │                   ├── cardinality: [0 - 1]
            │    │                   ├── key: ()
            │    │                   ├── fd: ()-->(98)
-           │    │                   ├── with-scan &5
+           │    │                   ├── with-scan &4
            │    │                   │    ├── columns: th_st_id:98!null
            │    │                   │    ├── mapping:
            │    │                   │    │    └──  th_st_id_cast:79 => th_st_id:98

--- a/pkg/sql/opt/xform/testdata/external/tpce-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpce-no-stats
@@ -569,7 +569,7 @@ update_trade_submitted AS (
 )
 SELECT * FROM request_list;
 ----
-with &2 (update_last_trade)
+with &1 (update_last_trade)
  ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
  ├── volatile, mutations
  ├── key: (139)
@@ -609,7 +609,7 @@ with &2 (update_last_trade)
  │    │              └── '2020-06-15 22:27:42.148484' [as=lt_dts_new:17]
  │    └── projections
  │         └── NULL [as="?column?":19]
- └── with &3 (request_list)
+ └── with &2 (request_list)
       ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
       ├── volatile, mutations
       ├── key: (139)
@@ -639,7 +639,7 @@ with &2 (update_last_trade)
       │    │         └── (((trade_request.tr_tt_id:21 = 'TMB') AND (trade_request.tr_bid_price:24 >= 1E+2)) OR ((trade_request.tr_tt_id:21 = 'TMS') AND (trade_request.tr_bid_price:24 <= 1E+2))) OR ((trade_request.tr_tt_id:21 = 'TLS') AND (trade_request.tr_bid_price:24 >= 1E+2)) [outer=(21,24), immutable, constraints=(/21: [/'TLS' - /'TLS'] [/'TMB' - /'TMB'] [/'TMS' - /'TMS']; /24: (/NULL - ])]
       │    └── projections
       │         └── trade_request.tr_bid_price:24::FLOAT8 [as=tr_bid_price:28, outer=(24), immutable]
-      └── with &4 (delete_trade_request)
+      └── with &3 (delete_trade_request)
            ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
            ├── volatile, mutations
            ├── key: (139)
@@ -668,7 +668,7 @@ with &2 (update_last_trade)
            │    │         │         ├── lookup columns are key
            │    │         │         ├── key: (45)
            │    │         │         ├── fd: (37)-->(38,39,42), (37)==(45), (45)==(37)
-           │    │         │         ├── with-scan &3 (request_list)
+           │    │         │         ├── with-scan &2 (request_list)
            │    │         │         │    ├── columns: tr_t_id:45!null
            │    │         │         │    ├── mapping:
            │    │         │         │    │    └──  trade_request.tr_t_id:20 => tr_t_id:45
@@ -678,7 +678,7 @@ with &2 (update_last_trade)
            │    │              └── trade_request.tr_tt_id:38 IN ('TLB', 'TLS', 'TSL') [as=partial_index_del1:49, outer=(38)]
            │    └── projections
            │         └── NULL [as="?column?":50]
-           └── with &6 (insert_trade_history)
+           └── with &5 (insert_trade_history)
                 ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
                 ├── volatile, mutations
                 ├── key: (139)
@@ -693,7 +693,7 @@ with &2 (update_last_trade)
                 │    │    │    ├── tr_t_id:56 => trade_history.th_t_id:51
                 │    │    │    ├── timestamp:61 => th_dts:52
                 │    │    │    └── th_st_id_cast:62 => trade_history.th_st_id:53
-                │    │    ├── input binding: &5
+                │    │    ├── input binding: &4
                 │    │    ├── volatile, mutations
                 │    │    ├── key: (51)
                 │    │    ├── fd: ()-->(53)
@@ -701,7 +701,7 @@ with &2 (update_last_trade)
                 │    │    │    ├── columns: th_st_id_cast:62!null timestamp:61!null tr_t_id:56!null
                 │    │    │    ├── key: (56)
                 │    │    │    ├── fd: ()-->(61,62)
-                │    │    │    ├── with-scan &3 (request_list)
+                │    │    │    ├── with-scan &2 (request_list)
                 │    │    │    │    ├── columns: tr_t_id:56!null
                 │    │    │    │    ├── mapping:
                 │    │    │    │    │    └──  trade_request.tr_t_id:20 => tr_t_id:56
@@ -716,7 +716,7 @@ with &2 (update_last_trade)
                 │    │         │         ├── key columns: [63] = [64]
                 │    │         │         ├── lookup columns are key
                 │    │         │         ├── key: (63)
-                │    │         │         ├── with-scan &5
+                │    │         │         ├── with-scan &4
                 │    │         │         │    ├── columns: th_t_id:63!null
                 │    │         │         │    ├── mapping:
                 │    │         │         │    │    └──  tr_t_id:56 => th_t_id:63
@@ -728,7 +728,7 @@ with &2 (update_last_trade)
                 │    │                   ├── key columns: [81] = [82]
                 │    │                   ├── lookup columns are key
                 │    │                   ├── fd: ()-->(81)
-                │    │                   ├── with-scan &5
+                │    │                   ├── with-scan &4
                 │    │                   │    ├── columns: th_st_id:81!null
                 │    │                   │    ├── mapping:
                 │    │                   │    │    └──  th_st_id_cast:62 => th_st_id:81
@@ -736,7 +736,7 @@ with &2 (update_last_trade)
                 │    │                   └── filters (true)
                 │    └── projections
                 │         └── NULL [as="?column?":86]
-                └── with &8 (update_trade_submitted)
+                └── with &7 (update_trade_submitted)
                      ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
                      ├── volatile, mutations
                      ├── key: (139)
@@ -751,7 +751,7 @@ with &2 (update_last_trade)
                      │    │    ├── update-mapping:
                      │    │    │    ├── t_dts_new:126 => t_dts:88
                      │    │    │    └── t_st_id_cast:127 => trade.t_st_id:89
-                     │    │    ├── input binding: &7
+                     │    │    ├── input binding: &6
                      │    │    ├── volatile, mutations
                      │    │    ├── key: (87)
                      │    │    ├── project
@@ -768,7 +768,7 @@ with &2 (update_last_trade)
                      │    │    │    │         ├── lookup columns are key
                      │    │    │    │         ├── key: (121)
                      │    │    │    │         ├── fd: (104)-->(105-116,118), (104)==(121), (121)==(104)
-                     │    │    │    │         ├── with-scan &3 (request_list)
+                     │    │    │    │         ├── with-scan &2 (request_list)
                      │    │    │    │         │    ├── columns: tr_t_id:121!null
                      │    │    │    │         │    ├── mapping:
                      │    │    │    │         │    │    └──  trade_request.tr_t_id:20 => tr_t_id:121
@@ -784,7 +784,7 @@ with &2 (update_last_trade)
                      │    │                   ├── key columns: [133] = [134]
                      │    │                   ├── lookup columns are key
                      │    │                   ├── fd: ()-->(133)
-                     │    │                   ├── with-scan &7
+                     │    │                   ├── with-scan &6
                      │    │                   │    ├── columns: t_st_id:133!null
                      │    │                   │    ├── mapping:
                      │    │                   │    │    └──  t_st_id_cast:127 => t_st_id:133
@@ -792,7 +792,7 @@ with &2 (update_last_trade)
                      │    │                   └── filters (true)
                      │    └── projections
                      │         └── NULL [as="?column?":138]
-                     └── with-scan &3 (request_list)
+                     └── with-scan &2 (request_list)
                           ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
                           ├── mapping:
                           │    ├──  trade_request.tr_t_id:20 => tr_t_id:139
@@ -4248,7 +4248,7 @@ with &2 (update_trade_commission)
  │    │                   └── filters (true)
  │    └── projections
  │         └── 1 [as="?column?":52]
- └── with &4 (update_broker_commission)
+ └── with &3 (update_broker_commission)
       ├── columns: "?column?":104!null
       ├── cardinality: [1 - 1]
       ├── volatile, mutations
@@ -4288,7 +4288,7 @@ with &2 (update_trade_commission)
       │    │              └── b_num_trades:63 + 1 [as=b_num_trades_new:68, outer=(63), immutable]
       │    └── projections
       │         └── 1 [as="?column?":70]
-      └── with &6 (insert_trade_history)
+      └── with &5 (insert_trade_history)
            ├── columns: "?column?":104!null
            ├── cardinality: [1 - 1]
            ├── volatile, mutations
@@ -4306,7 +4306,7 @@ with &2 (update_trade_commission)
            │    │    │    ├── column1:76 => trade_history.th_t_id:71
            │    │    │    ├── column2:77 => th_dts:72
            │    │    │    └── th_st_id_cast:79 => trade_history.th_st_id:73
-           │    │    ├── input binding: &5
+           │    │    ├── input binding: &4
            │    │    ├── cardinality: [1 - 1]
            │    │    ├── volatile, mutations
            │    │    ├── key: ()
@@ -4326,7 +4326,7 @@ with &2 (update_trade_commission)
            │    │         │         ├── cardinality: [0 - 1]
            │    │         │         ├── key: ()
            │    │         │         ├── fd: ()-->(80)
-           │    │         │         ├── with-scan &5
+           │    │         │         ├── with-scan &4
            │    │         │         │    ├── columns: th_t_id:80!null
            │    │         │         │    ├── mapping:
            │    │         │         │    │    └──  column1:76 => th_t_id:80
@@ -4342,7 +4342,7 @@ with &2 (update_trade_commission)
            │    │                   ├── cardinality: [0 - 1]
            │    │                   ├── key: ()
            │    │                   ├── fd: ()-->(98)
-           │    │                   ├── with-scan &5
+           │    │                   ├── with-scan &4
            │    │                   │    ├── columns: th_st_id:98!null
            │    │                   │    ├── mapping:
            │    │                   │    │    └──  th_st_id_cast:79 => th_st_id:98


### PR DESCRIPTION
#### opt: move constant value helpers to memo package

This commit moves some logic in normalization custom functions to the
memo package so that it can be used more generally in the future.

Release note: None

#### opt: inline constant insert values in uniqueness checks

In uniqueness checks, WithScans that buffer the mutation's input are now
replaced with Values expression when inserted values are constant. This
allows further optimization of the uniqueness check sub-expression. It
is particularly beneficial for `REGIONAL BY ROW` tables and hash-sharded
`REGIONAL BY ROW` tables because it reduces the search space for
duplicate values.

Note that this inlining does not occur for FK checks. The FK insert fast
path relies on WithScans in FK checks. Until this limitation is lifted,
inlining constant insert values would prevent the fast path from being
planned.

Informs #63882

Release note (performance improvement): Previously, uniqueness checks
performed for inserts into REGIONAL BY ROW tables always searched all
regions for duplicates. In some cases, these checks will now only search
a subset of regions when inserting a single row of constant values.
