### PR TITLE
release-21.1: ui: encode app name and database name on url

### DIFF
--- a/pkg/ui/cluster-ui/src/statementsTable/statementsTableContent.tsx
+++ b/pkg/ui/cluster-ui/src/statementsTable/statementsTableContent.tsx
@@ -494,12 +494,12 @@ interface StatementLinkProps {
 export const StatementLinkTarget = (props: StatementLinkProps) => {
   let base: string;
   if (props.app && props.app.length > 0) {
-    base = `/statements/${props.app}`;
+    base = `/statements/${encodeURIComponent(props.app)}`;
   } else {
     base = `/statement`;
   }
   if (props.database && props.database.length > 0) {
-    base = base + `/${props.database}/${props.implicitTxn}`;
+    base = base + `/${encodeURIComponent(props.database)}/${props.implicitTxn}`;
   } else {
     base = base + `/${props.implicitTxn}`;
   }


### PR DESCRIPTION
Previosuly, the app and database names were not being encoded
for url and names containing `/` were causing a Page Not Found
error since it couldn't match the route.
This commits properly encoded those values.

Fixes #77685

Release note (bug fix): Statement whose app name contains `/`
are now properly loading their details page.

Release justification: bug fix