### PR TITLE
sql: allow creating a sequence and calling nextval/setval on it within a transaction

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -58,6 +58,7 @@ go_library(
         "create_table.go",
         "create_type.go",
         "create_view.go",
+        "created_sequence.go",
         "data_source.go",
         "database.go",
         "database_region_change_finalizer.go",

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -932,6 +932,8 @@ func (s *Server) newConnExecutor(
 
 	ex.extraTxnState.atomicAutoRetryCounter = new(int32)
 
+	ex.extraTxnState.createdSequences = make(map[descpb.ID]struct{})
+
 	ex.initPlanner(ctx, &ex.planner)
 
 	return ex
@@ -1381,6 +1383,10 @@ type connExecutor struct {
 		// has admin privilege. hasAdminRoleCache is set for the first statement
 		// in a transaction.
 		hasAdminRoleCache HasAdminRoleCache
+
+		// createdSequences keeps track of sequences created in the current transaction.
+		// The map key is the sequence descpb.ID.
+		createdSequences map[descpb.ID]struct{}
 	}
 
 	// sessionDataStack contains the user-configurable connection variables.
@@ -1650,6 +1656,8 @@ func (ex *connExecutor) resetExtraTxnState(ctx context.Context, ev txnEvent) err
 
 	// Close all cursors.
 	ex.extraTxnState.sqlCursors.closeAll()
+
+	ex.extraTxnState.createdSequences = make(map[descpb.ID]struct{})
 
 	switch ev.eventType {
 	case txnCommit, txnRollback:
@@ -2750,6 +2758,7 @@ func (ex *connExecutor) initPlanner(ctx context.Context, p *planner) {
 	p.noticeSender = nil
 	p.preparedStatements = ex.getPrepStmtsAccessor()
 	p.sqlCursors = ex.getCursorAccessor()
+	p.createdSequences = ex.getCreatedSequencesAccessor()
 
 	p.queryCacheSession.Init()
 	p.optPlanningCtx.init(p)
@@ -3113,6 +3122,12 @@ func (ex *connExecutor) getPrepStmtsAccessor() preparedStatementsAccessor {
 
 func (ex *connExecutor) getCursorAccessor() sqlCursors {
 	return connExCursorAccessor{
+		ex: ex,
+	}
+}
+
+func (ex *connExecutor) getCreatedSequencesAccessor() createdSequences {
+	return connExCreatedSequencesAccessor{
 		ex: ex,
 	}
 }

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -158,6 +158,9 @@ func doCreateSequence(
 	// Initialize the sequence value.
 	seqValueKey := p.ExecCfg().Codec.SequenceKey(uint32(id))
 	b := &kv.Batch{}
+	if err := p.createdSequences.addCreatedSequence(id); err != nil {
+		return nil, err
+	}
 	b.Inc(seqValueKey, desc.SequenceOpts.Start-desc.SequenceOpts.Increment)
 	if err := p.txn.Run(ctx, b); err != nil {
 		return nil, err

--- a/pkg/sql/created_sequence.go
+++ b/pkg/sql/created_sequence.go
@@ -1,0 +1,48 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/errors"
+)
+
+type createdSequences interface {
+	// addCreatedSequence adds a sequence to the set of sequences created in the current transaction.
+	addCreatedSequence(id descpb.ID) error
+	// isCreatedSequence checks if a sequence was created in the current transaction.
+	isCreatedSequence(id descpb.ID) bool
+}
+
+type connExCreatedSequencesAccessor struct {
+	ex *connExecutor
+}
+
+func (c connExCreatedSequencesAccessor) addCreatedSequence(id descpb.ID) error {
+	c.ex.extraTxnState.createdSequences[id] = struct{}{}
+	return nil
+}
+
+func (c connExCreatedSequencesAccessor) isCreatedSequence(id descpb.ID) bool {
+	_, ok := c.ex.extraTxnState.createdSequences[id]
+	return ok
+}
+
+// emptyCreatedSequences is the default impl used by the planner when the connExecutor is not available.
+type emptyCreatedSequences struct{}
+
+func (createdSequences emptyCreatedSequences) addCreatedSequence(id descpb.ID) error {
+	return errors.AssertionFailedf("addCreatedSequence not supported in emptyCreatedSequences")
+}
+
+func (createdSequences emptyCreatedSequences) isCreatedSequence(id descpb.ID) bool {
+	return false
+}

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -2072,3 +2072,103 @@ CREATE SEQUENCE seqas_error
   INCREMENT BY 1
   MAXVALUE 123456
   CACHE 1
+
+# create a sequence and nextval in the same transaction
+statement ok
+BEGIN
+
+statement ok
+CREATE SEQUENCE nextval_txn_seq
+
+query I
+SELECT nextval('nextval_txn_seq')
+----
+1
+
+statement ok
+END
+
+query I
+SELECT nextval('nextval_txn_seq')
+----
+2
+
+# create a sequence and setval in the same transaction then nextval
+statement ok
+BEGIN
+
+statement ok
+CREATE SEQUENCE setval_txn_nextval_seq
+
+query I
+SELECT setval('setval_txn_nextval_seq', 2)
+----
+2
+
+statement ok
+END
+
+# should be 3 - see https://github.com/cockroachdb/cockroach/issues/79430
+query I
+SELECT nextval('setval_txn_nextval_seq')
+----
+2
+
+# create a sequence and setval then nextval in the same transaction
+statement ok
+BEGIN
+
+statement ok
+CREATE SEQUENCE setval_nextval_txn_seq
+
+query I
+SELECT setval('setval_nextval_txn_seq', 2)
+----
+2
+
+# should be 3 - see https://github.com/cockroachdb/cockroach/issues/79430
+query I
+SELECT nextval('setval_nextval_txn_seq')
+----
+2
+
+statement ok
+END
+
+# create a sequence and setval in the same transaction then currval
+statement ok
+BEGIN
+
+statement ok
+CREATE SEQUENCE setval_txn_currval_seq
+
+query I
+SELECT setval('setval_txn_currval_seq', 1)
+----
+1
+
+statement ok
+END
+
+# should be 1 - see https://github.com/cockroachdb/cockroach/issues/79436
+statement error currval of sequence .+ is not yet defined in this session
+SELECT currval('setval_txn_currval_seq')
+
+# create a sequence and setval then currval in the same transaction
+statement ok
+BEGIN
+
+statement ok
+CREATE SEQUENCE setval_currval_txn_seq
+
+query I
+SELECT setval('setval_currval_txn_seq', 1)
+----
+1
+
+# should be 1 - see https://github.com/cockroachdb/cockroach/issues/79436
+statement error currval of sequence .+ is not yet defined in this session
+SELECT currval('setval_currval_txn_seq')
+
+statement ok
+END

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -188,6 +188,8 @@ type planner struct {
 
 	sqlCursors sqlCursors
 
+	createdSequences createdSequences
+
 	// avoidLeasedDescriptors, when true, instructs all code that
 	// accesses table/view descriptors to force reading the descriptors
 	// within the transaction. This is necessary to read descriptors
@@ -411,6 +413,7 @@ func newInternalPlanner(
 
 	p.queryCacheSession.Init()
 	p.optPlanningCtx.init(p)
+	p.createdSequences = emptyCreatedSequences{}
 
 	return p, func() {
 		// Note that we capture ctx here. This is only valid as long as we create


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/61425

Release note (bug fix): nextval/setval are non-transactional
except when it is called in the same transaction that the sequence
was created in. This change prevents a bug where creating a 
sequence and calling nextval/setval on it within a transaction 
caused the query containing nextval to hang.