### PR TITLE
release-22.1: sql/schemachanger: block concurrent declarative schema changes

### DIFF
--- a/pkg/sql/catalog/dbdesc/database_desc.go
+++ b/pkg/sql/catalog/dbdesc/database_desc.go
@@ -477,6 +477,12 @@ func (desc *immutable) GetPostDeserializationChanges() catalog.PostDeserializati
 	return desc.changes
 }
 
+// HasConcurrentSchemaChanges implements catalog.Descriptor.
+func (desc *immutable) HasConcurrentSchemaChanges() bool {
+	return desc.DeclarativeSchemaChangerState != nil &&
+		desc.DeclarativeSchemaChangerState.JobID != catpb.InvalidJobID
+}
+
 // GetDefaultPrivilegeDescriptor returns a DefaultPrivilegeDescriptor.
 func (desc *immutable) GetDefaultPrivilegeDescriptor() catalog.DefaultPrivilegeDescriptor {
 	defaultPrivilegeDescriptor := desc.GetDefaultPrivileges()

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -217,6 +217,10 @@ type Descriptor interface {
 	// GetPostDeserializationChanges returns the set of ways the Descriptor
 	// was changed after running RunPostDeserializationChanges.
 	GetPostDeserializationChanges() PostDeserializationChanges
+
+	// HasConcurrentSchemaChanges returns if declarative schema
+	// changes are currently in progress.
+	HasConcurrentSchemaChanges() bool
 }
 
 // DatabaseDescriptor encapsulates the concept of a database.

--- a/pkg/sql/catalog/schemadesc/schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc.go
@@ -264,6 +264,12 @@ func (desc *immutable) GetPostDeserializationChanges() catalog.PostDeserializati
 	return desc.changes
 }
 
+// HasConcurrentSchemaChanges implements catalog.Descriptor.
+func (desc *immutable) HasConcurrentSchemaChanges() bool {
+	return desc.DeclarativeSchemaChangerState != nil &&
+		desc.DeclarativeSchemaChangerState.JobID != catpb.InvalidJobID
+}
+
 // MaybeIncrementVersion implements the MutableDescriptor interface.
 func (desc *Mutable) MaybeIncrementVersion() {
 	// Already incremented, no-op.

--- a/pkg/sql/catalog/schemadesc/synthetic_schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/synthetic_schema_desc.go
@@ -116,6 +116,11 @@ func (p synthetic) GetPostDeserializationChanges() catalog.PostDeserializationCh
 	return catalog.PostDeserializationChanges{}
 }
 
+// HasConcurrentSchemaChanges implements catalog.Descriptor.
+func (p synthetic) HasConcurrentSchemaChanges() bool {
+	return false
+}
+
 // GetDefaultPrivilegeDescriptor returns a DefaultPrivilegeDescriptor.
 func (p synthetic) GetDefaultPrivilegeDescriptor() catalog.DefaultPrivilegeDescriptor {
 	return catprivilege.MakeDefaultPrivileges(catprivilege.MakeDefaultPrivilegeDescriptor(catpb.DefaultPrivilegeDescriptor_SCHEMA))

--- a/pkg/sql/catalog/table_elements.go
+++ b/pkg/sql/catalog/table_elements.go
@@ -788,13 +788,3 @@ func ColumnNeedsBackfill(col Column) bool {
 	}
 	return col.HasDefault() || !col.IsNullable() || col.IsComputed()
 }
-
-// HasConcurrentSchemaChanges returns whether the table descriptor is undergoing
-// concurrent schema changes.
-func HasConcurrentSchemaChanges(table TableDescriptor) bool {
-	// TODO(ajwerner): For now we simply check for the absence of mutations. Once
-	// we start implementing schema changes with ops to be executed during
-	// statement execution, we'll have to take into account mutations that were
-	// written in this transaction.
-	return len(table.AllMutations()) > 0
-}

--- a/pkg/sql/catalog/tabledesc/table_desc.go
+++ b/pkg/sql/catalog/tabledesc/table_desc.go
@@ -59,6 +59,13 @@ func (desc *wrapper) GetPostDeserializationChanges() catalog.PostDeserialization
 	return desc.changes
 }
 
+// HasConcurrentSchemaChanges implements catalog.Descriptor.
+func (desc *wrapper) HasConcurrentSchemaChanges() bool {
+	return (desc.DeclarativeSchemaChangerState != nil &&
+		desc.DeclarativeSchemaChangerState.JobID != catpb.InvalidJobID) ||
+		len(desc.Mutations) > 0
+}
+
 // ActiveChecks implements the TableDescriptor interface.
 func (desc *wrapper) ActiveChecks() []descpb.TableDescriptor_CheckConstraint {
 	checks := make([]descpb.TableDescriptor_CheckConstraint, len(desc.Checks))

--- a/pkg/sql/catalog/typedesc/table_implicit_record_type.go
+++ b/pkg/sql/catalog/typedesc/table_implicit_record_type.go
@@ -340,6 +340,11 @@ func (v TableImplicitRecordType) GetPostDeserializationChanges() catalog.PostDes
 	return catalog.PostDeserializationChanges{}
 }
 
+// HasConcurrentSchemaChanges implements catalog.Descriptor.
+func (v TableImplicitRecordType) HasConcurrentSchemaChanges() bool {
+	return false
+}
+
 func (v TableImplicitRecordType) panicNotSupported(message string) {
 	panic(errors.AssertionFailedf("implicit table record type for table %q: not supported: %s", v.GetName(), message))
 }

--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -972,6 +972,18 @@ func (desc *immutable) GetPostDeserializationChanges() catalog.PostDeserializati
 	return desc.changes
 }
 
+// HasConcurrentSchemaChanges implements catalog.Descriptor.
+func (desc *immutable) HasConcurrentSchemaChanges() bool {
+	if desc.DeclarativeSchemaChangerState != nil &&
+		desc.DeclarativeSchemaChangerState.JobID != catpb.InvalidJobID {
+		return true
+	}
+	// TODO(fqazi): In the future we may not have concurrent declarative schema
+	// changes without a job ID. So, we should scan the elements involved for
+	// types.
+	return false
+}
+
 // GetIDClosure implements the TypeDescriptor interface.
 func (desc *immutable) GetIDClosure() (map[descpb.ID]struct{}, error) {
 	ret := make(map[descpb.ID]struct{})

--- a/pkg/sql/schema_change_plan_node.go
+++ b/pkg/sql/schema_change_plan_node.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scbuild"
@@ -112,17 +111,15 @@ func (p *planner) WaitForDescriptorSchemaChanges(
 				if err := txn.SetFixedTimestamp(ctx, now); err != nil {
 					return err
 				}
-				table, err := descriptors.GetImmutableTableByID(ctx, txn, descID,
-					tree.ObjectLookupFlags{
-						CommonLookupFlags: tree.CommonLookupFlags{
-							Required:    true,
-							AvoidLeased: true,
-						},
+				desc, err := descriptors.GetImmutableDescriptorByID(ctx, txn, descID,
+					tree.CommonLookupFlags{
+						Required:    true,
+						AvoidLeased: true,
 					})
 				if err != nil {
 					return err
 				}
-				blocked = catalog.HasConcurrentSchemaChanges(table)
+				blocked = desc.HasConcurrentSchemaChanges()
 				return nil
 			}); err != nil {
 			return err

--- a/pkg/sql/schemachanger/scbuild/build.go
+++ b/pkg/sql/schemachanger/scbuild/build.go
@@ -15,8 +15,10 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scbuild/internal/scbuildstmt"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/screl"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
@@ -86,6 +88,15 @@ func Build(
 		ts.Targets = append(ts.Targets, scpb.MakeTarget(e.target, e.element, &e.metadata))
 		current = append(current, e.current)
 	}
+	// Ensure that no concurrent schema change are on going on any targets.
+	descSet := screl.AllTargetDescIDs(ts)
+	descSet.ForEach(func(id descpb.ID) {
+		bs.ensureDescriptor(id)
+		desc := bs.descCache[id].desc
+		if desc.HasConcurrentSchemaChanges() {
+			panic(scerrors.ConcurrentSchemaChangeError(desc))
+		}
+	})
 	return scpb.CurrentState{TargetState: ts, Current: current}, nil
 }
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
@@ -85,7 +85,6 @@ func AlterTable(b BuildCtx, n *tree.AlterTable) {
 	}
 	tn.ObjectNamePrefix = b.NamePrefix(tbl)
 	b.SetUnresolvedNameAnnotation(n.Table, &tn)
-	b.CheckNoConcurrentSchemaChanges(tbl)
 	b.IncrementSchemaChangeAlterCounter("table")
 	for _, cmd := range n.Cmds {
 		info := supportedAlterTableStatements[reflect.TypeOf(cmd)]

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
@@ -181,10 +181,6 @@ type TableHelpers interface {
 		partBy *tree.PartitionBy,
 	) catpb.PartitioningDescriptor
 
-	// CheckNoConcurrentSchemaChanges panics if the underlying table is undergoing
-	// concurrent schema changes.
-	CheckNoConcurrentSchemaChanges(table *scpb.Table)
-
 	// ResolveTypeRef resolves a type reference.
 	ResolveTypeRef(typeref tree.ResolvableTypeReference) scpb.TypeT
 

--- a/pkg/sql/schemachanger/scerrors/errors.go
+++ b/pkg/sql/schemachanger/scerrors/errors.go
@@ -82,6 +82,6 @@ func ConcurrentSchemaChangeDescID(err error) descpb.ID {
 
 // ConcurrentSchemaChangeError returns a concurrent schema change error for the
 // given table.
-func ConcurrentSchemaChangeError(table catalog.TableDescriptor) error {
-	return &concurrentSchemaChangeError{descID: table.GetID()}
+func ConcurrentSchemaChangeError(desc catalog.Descriptor) error {
+	return &concurrentSchemaChangeError{descID: desc.GetID()}
 }

--- a/pkg/sql/schemachanger/scrun/scrun.go
+++ b/pkg/sql/schemachanger/scrun/scrun.go
@@ -144,6 +144,12 @@ func executeStage(
 	if err := scexec.ExecuteStage(ctx, deps, stage.Ops()); err != nil {
 		return errors.Wrapf(p.DecorateErrorWithPlanDetails(err), "error executing %s", stage.String())
 	}
+	if knobs != nil && knobs.AfterStage != nil {
+		if err := knobs.AfterStage(p, stageIdx); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/sql/schemachanger/scrun/testing_knobs.go
+++ b/pkg/sql/schemachanger/scrun/testing_knobs.go
@@ -19,6 +19,10 @@ type TestingKnobs struct {
 	// Errors returned are injected into the executor.
 	BeforeStage func(p scplan.Plan, stageIdx int) error
 
+	// AfterStage is invoked after all ops are executed.
+	// Errors returned are injected into the executor.
+	AfterStage func(p scplan.Plan, stageIdx int) error
+
 	// BeforeWaitingForConcurrentSchemaChanges is called at the start of waiting
 	// for concurrent schema changes to finish.
 	BeforeWaitingForConcurrentSchemaChanges func(stmts []string)


### PR DESCRIPTION
Backport 1/1 commits from #77656.

/cc @cockroachdb/release

---

Fixes: #77648, #77172

Previously, the declarative schema change only blocked
concurrent schema change operations for tables, 
specifically when adding new columns. This was inadequate
because concurrent updates on certain objects like databases
when dropping can lead to issues as well. For example, when
dropping a schema, the database will need to be modified to
remove the dropped schema. To address this, this patch enforces
that only one schema change is allowed for a given schema object
at a time when using the declarative schema changer.

Release justification: low risk and leads to better concurrency
safety guarantees for declarative schema changer by allowing
a single drop along with the set of impacted objects.
Release note: None

