### PR TITLE
sql: Allow users to restrict root logins to localhost

### DIFF
--- a/pkg/sql/pgwire/hba_conf.go
+++ b/pkg/sql/pgwire/hba_conf.go
@@ -204,7 +204,7 @@ func ParseAndNormalize(val string) (*hba.Conf, error) {
 		return conf, err
 	}
 
-	if len(conf.Entries) == 0 || !conf.Entries[0].Equivalent(rootEntry) {
+	if len(conf.Entries) == 0 || !(conf.Entries[0].Equivalent(rootEntry) || conf.Entries[0].Equivalent(rootLocalEntry)) {
 		entries := make([]hba.Entry, 1, len(conf.Entries)+1)
 		entries[0] = rootEntry
 		entries = append(entries, conf.Entries...)
@@ -247,6 +247,15 @@ var rootEntry = hba.Entry{
 	Address:  hba.AnyAddr{},
 	Method:   hba.String{Value: "cert-password"},
 	Input:    "host  all root all cert-password # CockroachDB mandatory rule",
+}
+
+var _, localhostCidrBytes, _ = net.ParseCIDR("127.0.0.1/32")
+var rootLocalEntry = hba.Entry{
+	ConnType: hba.ConnHostAny,
+	User:     []hba.String{{Value: security.RootUser, Quoted: false}},
+	Address:  localhostCidrBytes,
+	Method:   hba.String{Value: "cert-password"},
+	Input:    "host all root 127.0.0.1/32 cert-password # Alternative to the CockroachDB mandatory rule",
 }
 
 // DefaultHBAConfig is used when the stored HBA configuration string

--- a/pkg/sql/pgwire/testdata/auth/hba_alternative_root_rule
+++ b/pkg/sql/pgwire/testdata/auth/hba_alternative_root_rule
@@ -1,0 +1,58 @@
+# This verifies that if the first line of the HBA config
+# is:
+#     host  all root 127.0.0.1/32 cert-password
+# the default root rule of:
+#     host  all root all cert-password
+# will not be included
+
+config secure
+----
+
+set_hba
+host  all root 127.0.0.1/32 cert-password
+----
+# Active authentication configuration on this node:
+# Original configuration:
+# host  all root 127.0.0.1/32 cert-password
+#
+# Interpreted configuration:
+# TYPE DATABASE USER ADDRESS      METHOD        OPTIONS
+host   all      root 127.0.0.1/32 cert-password
+
+subtest root_localhost
+
+# Root can connect because the tests originate from 127.0.0.1
+connect user=root
+----
+ok defaultdb
+
+subtest end root_localhost
+
+# This verifies that if the first line of the HBA config
+# is slightly different, the default root rule is still
+# included. The following:
+#    host all root 127.0.0.2/32 cert-password
+# will be converted into:
+#    host  all root all cert-password
+#    host all root 127.0.0.2/32 cert-password
+set_hba
+host all root 127.0.0.2/32 cert-password
+----
+# Active authentication configuration on this node:
+# Original configuration:
+# host  all root all cert-password # CockroachDB mandatory rule
+# host all root 127.0.0.2/32 cert-password
+#
+# Interpreted configuration:
+# TYPE DATABASE USER ADDRESS      METHOD        OPTIONS
+host   all      root all          cert-password
+host   all      root 127.0.0.2/32 cert-password
+
+subtest root_default_rule
+
+# Root can connect because of the default rule
+connect user=root
+----
+ok defaultdb
+
+subtest end root_default_rule


### PR DESCRIPTION
Previously, no matter what you included in your HBA configuration, CRDB
would include a permission to allow the root user to login over TCP
using cert-password.

This change makes it so that if the first HBA configuration line allows
the root user to use cert-password auth over TCP from localhost, then
the default rule allowing the root user to login from anywhere won't
be added.

This feature is expected to only be used by security conscious users.

Release justification:
Release note (ops change): HBA configuration can now be used to
restrict admin logins to originating from localhost. This allows
security conscious users to better restrict acces to their instance.