### PR TITLE
sql,roachtest: fix sqlsmith setup to return multiple stmts

### DIFF
--- a/pkg/ccl/backupccl/backup_rand_test.go
+++ b/pkg/ccl/backupccl/backup_rand_test.go
@@ -51,8 +51,10 @@ func TestBackupRestoreRandomDataRoundtrips(t *testing.T) {
 	sqlDB.Exec(t, "CREATE DATABASE rand")
 
 	setup := sqlsmith.Setups[sqlsmith.RandTableSetupName](rng)
-	if _, err := tc.Conns[0].Exec(setup); err != nil {
-		t.Fatal(err)
+	for _, stmt := range setup {
+		if _, err := tc.Conns[0].Exec(stmt); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	tables := sqlDB.Query(t, `SELECT name FROM crdb_internal.tables WHERE 

--- a/pkg/cmd/roachtest/tests/tlp.go
+++ b/pkg/cmd/roachtest/tests/tlp.go
@@ -117,11 +117,13 @@ func runOneTLP(
 	setup := sqlsmith.Setups[sqlsmith.RandTableSetupName](rnd)
 
 	t.Status("executing setup")
-	t.L().Printf("setup:\n%s", setup)
-	if _, err := conn.Exec(setup); err != nil {
-		t.Fatal(err)
-	} else {
-		logStmt(setup)
+	t.L().Printf("setup:\n%s", strings.Join(setup, "\n"))
+	for _, stmt := range setup {
+		if _, err := conn.Exec(stmt); err != nil {
+			t.Fatal(err)
+		} else {
+			logStmt(stmt)
+		}
 	}
 
 	setStmtTimeout := fmt.Sprintf("SET statement_timeout='%s';", statementTimeout.String())

--- a/pkg/cmd/roachtest/tests/tpc_utils.go
+++ b/pkg/cmd/roachtest/tests/tpc_utils.go
@@ -77,7 +77,10 @@ func loadTPCHDataset(
 
 	t.L().Printf("restoring tpch scale factor %d\n", sf)
 	tpchURL := fmt.Sprintf("gs://cockroach-fixtures/workload/tpch/scalefactor=%d/backup?AUTH=implicit", sf)
-	query := fmt.Sprintf(`CREATE DATABASE IF NOT EXISTS tpch; RESTORE tpch.* FROM '%s' WITH into_db = 'tpch';`, tpchURL)
+	if _, err := db.ExecContext(ctx, `CREATE DATABASE IF NOT EXISTS tpch;`); err != nil {
+		return err
+	}
+	query := fmt.Sprintf(`RESTORE tpch.* FROM '%s' WITH into_db = 'tpch';`, tpchURL)
 	_, err := db.ExecContext(ctx, query)
 	return err
 }

--- a/pkg/compose/compare/compare/compare_test.go
+++ b/pkg/compose/compare/compare/compare_test.go
@@ -126,7 +126,9 @@ func TestCompare(t *testing.T) {
 			t.Logf("starting test: %s", confName)
 			rng, _ := randutil.NewTestRand()
 			setup := config.setup(rng)
-			setup, _ = randgen.ApplyString(rng, setup, config.setupMutators...)
+			for i := range setup {
+				setup[i], _ = randgen.ApplyString(rng, setup[i], config.setupMutators...)
+			}
 
 			conns := map[string]cmpconn.Conn{}
 			for _, testCn := range config.conns {
@@ -149,10 +151,12 @@ func TestCompare(t *testing.T) {
 						t.Fatalf("%s: %v", testCn.name, err)
 					}
 				}
-				connSetup, _ := randgen.ApplyString(rng, setup, testCn.mutators...)
-				if err := conn.Exec(ctx, connSetup); err != nil {
-					t.Log(connSetup)
-					t.Fatalf("%s: %v", testCn.name, err)
+				for i := range setup {
+					stmt, _ := randgen.ApplyString(rng, setup[i], testCn.mutators...)
+					if err := conn.Exec(ctx, stmt); err != nil {
+						t.Log(stmt)
+						t.Fatalf("%s: %v", testCn.name, err)
+					}
 				}
 				conns[testCn.name] = conn
 			}

--- a/pkg/internal/sqlsmith/sqlsmith_test.go
+++ b/pkg/internal/sqlsmith/sqlsmith_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -45,9 +46,11 @@ func TestSetups(t *testing.T) {
 			rnd, _ := randutil.NewTestRand()
 
 			sql := setup(rnd)
-			if _, err := sqlDB.Exec(sql); err != nil {
-				t.Log(sql)
-				t.Fatal(err)
+			for _, stmt := range sql {
+				if _, err := sqlDB.Exec(stmt); err != nil {
+					t.Log(stmt)
+					t.Fatal(err)
+				}
 			}
 		})
 	}
@@ -85,9 +88,11 @@ func TestRandTableInserts(t *testing.T) {
 	rnd, _ := randutil.NewTestRand()
 
 	setup := randTablesN(rnd, 10)
-	if _, err := sqlDB.Exec(setup); err != nil {
-		t.Log(setup)
-		t.Fatal(err)
+	for _, stmt := range setup {
+		if _, err := sqlDB.Exec(stmt); err != nil {
+			t.Log(stmt)
+			t.Fatal(err)
+		}
 	}
 
 	insertOnly := simpleOption("insert only", func(s *Smither) {
@@ -168,8 +173,10 @@ func TestGenerateParse(t *testing.T) {
 	settings := setting(rnd)
 	t.Log("setting:", settingName, settings.Options)
 	setupSQL := setup(rnd)
-	t.Log(setupSQL)
-	db.Exec(t, setupSQL)
+	t.Log(strings.Join(setupSQL, "\n"))
+	for _, stmt := range setupSQL {
+		db.Exec(t, stmt)
+	}
 
 	smither, err := NewSmither(sqlDB, rnd, settings.Options...)
 	if err != nil {

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -560,11 +560,14 @@ func TestRandomSyntaxSQLSmith(t *testing.T) {
 		setups := []string{sqlsmith.RandTableSetupName, "seed"}
 		for _, s := range setups {
 			randTables := sqlsmith.Setups[s](r.Rnd)
-			if err := db.exec(t, ctx, randTables); err != nil {
-				return err
+			for _, stmt := range randTables {
+				if err := db.exec(t, ctx, stmt); err != nil {
+					return err
+				}
+				tableStmts = append(tableStmts, stmt)
+				t.Logf("%s;", stmt)
 			}
-			tableStmts = append(tableStmts, randTables)
-			t.Logf("%s;", randTables)
+
 		}
 		var err error
 		smither, err = sqlsmith.NewSmither(db.db, r.Rnd, sqlsmith.DisableMutations())


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/77902
fixes https://github.com/cockroachdb/cockroach/issues/77887

Rather than doing the setup in one large batch, it now returns multiple
strings. This is because batch statements are now treated as an implicit
txn, which is not always desired.

Release note: None