### PR TITLE
sql: keep experimental_enable_hash_sharded_indexes var as noop

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -1019,3 +1019,8 @@ SELECT * FROM t ORDER BY x
 x  duped
 1  true
 2  true
+
+# NOTE: Please keep this statement at the end this file.
+# This session variable has noop and is just kept for backward compatibility.
+statement ok
+set experimental_enable_hash_sharded_indexes = on

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4715,6 +4715,7 @@ enable_zigzag_join                                    on
 escape_string_warning                                 on
 experimental_computed_column_rewrites                 ·
 experimental_enable_auto_rehoming                     off
+experimental_enable_hash_sharded_indexes              on
 experimental_enable_implicit_column_partitioning      off
 experimental_enable_temp_tables                       off
 experimental_enable_unique_without_index_constraints  on

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1575,6 +1575,23 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	// This is only kept for backwards compatibility and no longer has any effect.
+	`experimental_enable_hash_sharded_indexes`: {
+		Hidden:       true,
+		GetStringVal: makePostgresBoolGetStringValFn(`experimental_enable_hash_sharded_indexes`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			_, err := paramparse.ParseBoolVar("experimental_enable_hash_sharded_indexes", s)
+			return err
+		},
+		Get: func(evalCtx *extendedEvalContext) (string, error) {
+			return formatBoolAsPostgresSetting(true), nil
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return formatBoolAsPostgresSetting(true)
+		},
+	},
+
+	// CockroachDB extension.
 	`disallow_full_table_scans`: {
 		GetStringVal: makePostgresBoolGetStringValFn(`disallow_full_table_scans`),
 		Set: func(_ context.Context, m sessionDataMutator, s string) error {


### PR DESCRIPTION
Fixes #77954

Release justification: needed for session var backward compatibility.
Release note (sql change): experimental_enable_hash_sharded_indexes
used to be set to enable the hash sharded index feature. since we now
enable the feature by default, user don't need to set this var anymore.
But still keeping it as noop for backward compatibility.