### PR TITLE
sql,cli: implement `\password` cli command

### DIFF
--- a/pkg/cli/clisqlclient/conn.go
+++ b/pkg/cli/clisqlclient/conn.go
@@ -633,7 +633,7 @@ func (c *sqlConn) fillPassword() error {
 		connURL.Host,
 		connURL.User.Username())
 
-	pwd, err := pprompt.PromptForPassword()
+	pwd, err := pprompt.PromptForPassword("" /* prompt */)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/clisqlshell/BUILD.bazel
+++ b/pkg/cli/clisqlshell/BUILD.bazel
@@ -19,6 +19,8 @@ go_library(
         "//pkg/cli/clisqlexec",
         "//pkg/cli/democluster/api",
         "//pkg/docs",
+        "//pkg/security/password",
+        "//pkg/security/pprompt",
         "//pkg/server/pgurl",
         "//pkg/sql/lexbase",
         "//pkg/sql/pgwire/pgcode",

--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -32,6 +32,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cli/clisqlclient"
 	"github.com/cockroachdb/cockroach/pkg/cli/clisqlexec"
 	"github.com/cockroachdb/cockroach/pkg/docs"
+	"github.com/cockroachdb/cockroach/pkg/security/password"
+	"github.com/cockroachdb/cockroach/pkg/security/pprompt"
 	"github.com/cockroachdb/cockroach/pkg/server/pgurl"
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -66,6 +68,8 @@ Connection
   \c, \connect {[DB] [USER] [HOST] [PORT] | [URL]}
                     connect to a server or print the current connection URL.
                     (Omitted values reuse previous parameters. Use '-' to skip a field.)
+  \password [USERNAME]   
+                    securely change the password for a user
 
 Input/Output
   \echo [STRING]    write the provided string to standard output.
@@ -1205,6 +1209,9 @@ func (c *cliState) doHandleCliCmd(loopState, nextState cliStateEnum) cliStateEnu
 			}
 		}
 
+	case `\password`:
+		return c.handlePassword(cmd[1:], cliRunStatement, errState)
+
 	case `\|`:
 		return c.pipeSyscmd(c.lastInputLine, nextState, errState)
 
@@ -1314,6 +1321,79 @@ func (c *cliState) doHandleCliCmd(loopState, nextState cliStateEnum) cliStateEnu
 	}
 
 	return loopState
+}
+
+func (c *cliState) handlePassword(
+	cmd []string, nextState, errState cliStateEnum,
+) (resState cliStateEnum) {
+	if len(cmd) > 1 {
+		return c.invalidSyntax(errState)
+	}
+
+	passwordHashMethod, err := c.getPasswordHashMethod()
+	if err != nil {
+		fmt.Fprintf(c.iCtx.stderr, "retrieving hash method from server: %v\n", err)
+		c.exitErr = err
+		return errState
+	}
+
+	var escapedUserName string
+	if len(cmd) > 0 {
+		escapedUserName = lexbase.EscapeSQLIdent(cmd[0])
+	} else {
+		// "current_user" is a keyword.
+		escapedUserName = "current_user"
+	}
+	fmt.Fprintln(c.iCtx.stdout, "changing password for user", escapedUserName)
+
+	// TODO(jane,knz): currently Ctrl+C during password entry prints out
+	// a weird message and it's confusing to the user what they can do
+	// to stop the entry. This needs to be cleaned up.
+	password1, err := pprompt.PromptForPassword("" /* prompt */)
+	if err != nil {
+		fmt.Fprintf(c.iCtx.stderr, "reading password: %v\n", err)
+		c.exitErr = err
+		return errState
+	}
+
+	password2, err := pprompt.PromptForPassword("Enter it again: ")
+	if err != nil {
+		fmt.Fprintf(c.iCtx.stderr, "reading password: %v\n", err)
+		c.exitErr = err
+		return errState
+	}
+
+	if password1 != password2 {
+		c.exitErr = errors.New("passwords didn't match")
+		fmt.Fprintln(c.iCtx.stderr, c.exitErr)
+		return errState
+	}
+
+	var hashedPassword []byte
+	hashedPassword, err = password.HashPassword(
+		context.Background(),
+		passwordHashMethod.GetDefaultCost(),
+		passwordHashMethod,
+		password1,
+		nil, /* hashSem - no need to throttle hashing in CLI */
+	)
+
+	if err != nil {
+		fmt.Fprintf(c.iCtx.stderr, "hashing password: %v\n", err)
+		c.exitErr = err
+		return errState
+	}
+
+	c.concatLines = fmt.Sprintf(
+		`ALTER USER %s WITH LOGIN PASSWORD %s`,
+		// Note: we need to use .SQLIdentifier() to ensure that any special
+		// characters in the username are properly quoted, to make this robust
+		// to SQL injection.
+		escapedUserName,
+		lexbase.EscapeSQLString(string(hashedPassword)),
+	)
+
+	return nextState
 }
 
 func (c *cliState) handleConnect(
@@ -2223,4 +2303,42 @@ func (c *cliState) runWithInterruptableCtx(fn func(ctx context.Context) error) e
 	// Now run the query.
 	err := fn(ctx)
 	return err
+}
+
+// getPasswordHashMethod checks the session variable `password_encryption`
+// to get the password hash method.
+func (c *cliState) getPasswordHashMethod() (password.HashMethod, error) {
+	passwordHashMethodStr, err := c.getSessionVarValue("password_encryption")
+	if err != nil {
+		return password.HashInvalidMethod, err
+	}
+
+	hashMethod := password.LookupMethod(passwordHashMethodStr)
+	if hashMethod == password.HashInvalidMethod {
+		return password.HashInvalidMethod, errors.Newf("unknown hash method: %q", passwordHashMethodStr)
+	}
+	return hashMethod, nil
+}
+
+// getSessionVarValue is to get the value for a session variable.
+func (c *cliState) getSessionVarValue(sessionVar string) (string, error) {
+	query := fmt.Sprintf("SHOW %s", sessionVar)
+	var rows [][]string
+	var err error
+	err = c.runWithInterruptableCtx(func(ctx context.Context) error {
+		_, rows, err = c.sqlExecCtx.RunQuery(ctx, c.conn,
+			clisqlclient.MakeQuery(query), true)
+		return err
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	for _, row := range rows {
+		if len(row) != 0 {
+			return row[0], nil
+		}
+	}
+	return "", nil
 }

--- a/pkg/cli/interactive_tests/test_password.tcl
+++ b/pkg/cli/interactive_tests/test_password.tcl
@@ -1,0 +1,116 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+set certs_dir "/certs"
+set ::env(COCKROACH_INSECURE) "false"
+set ::env(COCKROACH_HOST) "localhost"
+
+proc start_secure_server {argv certs_dir extra} {
+    report "BEGIN START SECURE SERVER"
+    system "$argv start-single-node --host=localhost --socket-dir=. --certs-dir=$certs_dir --pid-file=server_pid -s=path=logs/db --background $extra >>expect-cmd.log 2>&1;
+            $argv sql --certs-dir=$certs_dir -e 'select 1'"
+    report "END START SECURE SERVER"
+}
+
+proc stop_secure_server {argv certs_dir} {
+    report "BEGIN STOP SECURE SERVER"
+    system "$argv quit --certs-dir=$certs_dir"
+    report "END STOP SECURE SERVER"
+}
+
+start_secure_server $argv $certs_dir ""
+
+spawn /bin/bash
+send "PS1=':''/# '\r"
+set prompt ":/# "
+eexpect $prompt
+
+send "$argv sql --certs-dir=$certs_dir\r"
+eexpect root@
+
+start_test "Test setting password"
+send "drop user if exists myuser;\r"
+eexpect "DROP ROLE"
+eexpect root@
+eexpect "/defaultdb>"
+# NB: the user cannot change their own password unless
+# they have the createlogin and createrole options.
+send "create user myuser with createrole createlogin;\r"
+eexpect "CREATE ROLE"
+eexpect root@
+eexpect "/defaultdb>"
+send "\\password myuser\r"
+eexpect "Enter password: "
+send "123\r"
+eexpect "Enter it again: "
+send "123\r"
+eexpect "ALTER ROLE"
+eexpect root@
+
+# check SQL injection
+send "\\password a;b\r"
+eexpect "Enter password: "
+send "123\r"
+eexpect "Enter it again: "
+send "123\r"
+eexpect "ERROR: role/user a;b does not exist"
+eexpect root@
+
+send "\\password myuser\r"
+eexpect "Enter password: "
+send "123\r"
+eexpect "Enter it again: "
+send "124\r"
+eexpect "passwords didn't match"
+eexpect root@
+eexpect "/defaultdb>"
+
+send "\\q\r"
+eexpect $prompt
+end_test
+
+start_test "Test connect to crdb with password"
+
+send "$argv sql --certs-dir=$certs_dir --user=myuser\r"
+eexpect "Enter password:"
+send "123\r"
+eexpect myuser@
+end_test
+
+start_test "Test change own password"
+send "\\password\r"
+eexpect "Enter password: "
+send "124\r"
+eexpect "Enter it again: "
+send "124\r"
+eexpect "ALTER ROLE"
+eexpect myuser@
+end_test
+
+send "\\q\r"
+eexpect $prompt
+
+start_test "Test connect to crdb with new own password"
+send "$argv sql --certs-dir=$certs_dir --user=myuser\r"
+eexpect "Enter password:"
+send "124\r"
+eexpect myuser@
+end_test
+
+send "\\q\r"
+eexpect $prompt
+
+start_test "Log in with wrong password"
+send "$argv sql --certs-dir=$certs_dir --user=myuser\r"
+eexpect "Enter password:"
+send "125\r"
+eexpect "password authentication failed"
+eexpect $prompt
+end_test
+
+send "exit 0\r"
+eexpect eof
+
+
+stop_secure_server $argv $certs_dir

--- a/pkg/security/password.go
+++ b/pkg/security/password.go
@@ -129,6 +129,23 @@ func hasClusterVersion(
 	return vh != nil && vh.IsActive(ctx, versionkey)
 }
 
+// GetConfiguredPasswordCost returns the configured hashing cost
+// for the given method.
+func GetConfiguredPasswordCost(
+	ctx context.Context, sv *settings.Values, method password.HashMethod,
+) (int, error) {
+	var cost int
+	switch method {
+	case password.HashBCrypt:
+		cost = int(BcryptCost.Get(sv))
+	case password.HashSCRAMSHA256:
+		cost = int(SCRAMCost.Get(sv))
+	default:
+		return -1, errors.Newf("unsupported hash method: %v", method)
+	}
+	return cost, nil
+}
+
 // GetConfiguredPasswordHashMethod returns the configured hash method
 // to use before storing passwords provided in cleartext from clients.
 func GetConfiguredPasswordHashMethod(

--- a/pkg/security/password/password.go
+++ b/pkg/security/password/password.go
@@ -81,7 +81,31 @@ func (h HashMethod) String() string {
 	case HashSCRAMSHA256:
 		return "scram-sha-256"
 	default:
-		panic(errors.AssertionFailedf("programming errof: unknown hash method %d", int(h)))
+		panic(errors.AssertionFailedf("programming error: unknown hash method %d", int(h)))
+	}
+}
+
+// GetDefaultCost retrieves the default hashing cost for the given method.
+func (h HashMethod) GetDefaultCost() int {
+	switch h {
+	case HashBCrypt:
+		return DefaultBcryptCost
+	case HashSCRAMSHA256:
+		return DefaultSCRAMCost
+	default:
+		return -1
+	}
+}
+
+// LookupMethod returns the HashMethod by name.
+func LookupMethod(s string) HashMethod {
+	switch s {
+	case HashBCrypt.String():
+		return HashBCrypt
+	case HashSCRAMSHA256.String():
+		return HashSCRAMSHA256
+	default:
+		return HashInvalidMethod
 	}
 }
 

--- a/pkg/security/pprompt/password.go
+++ b/pkg/security/pprompt/password.go
@@ -26,8 +26,11 @@ import (
 
 // PromptForPassword prompts for a password.
 // This is meant to be used when using a password.
-func PromptForPassword() (string, error) {
-	fmt.Print("Enter password: ")
+func PromptForPassword(prompt string) (string, error) {
+	if prompt == "" {
+		prompt = "Enter password: "
+	}
+	fmt.Print(prompt)
 	password, err := term.ReadPassword(int(os.Stdin.Fd()))
 	if err != nil {
 		return "", err

--- a/pkg/sql/create_role.go
+++ b/pkg/sql/create_role.go
@@ -285,14 +285,9 @@ func (p *planner) checkPasswordAndGetHash(
 	}
 
 	method := security.GetConfiguredPasswordHashMethod(ctx, &st.SV)
-	var cost int
-	switch method {
-	case password.HashBCrypt:
-		cost = int(security.BcryptCost.Get(&st.SV))
-	case password.HashSCRAMSHA256:
-		cost = int(security.SCRAMCost.Get(&st.SV))
-	default:
-		return nil, errors.Newf("unsupported hash method: %v", method)
+	cost, err := security.GetConfiguredPasswordCost(ctx, &st.SV, method)
+	if err != nil {
+		return hashedPassword, errors.HandleAsAssertionFailure(err)
 	}
 	hashedPassword, err = password.HashPassword(ctx, cost, method, passwordStr,
 		security.GetExpensiveHashComputeSem(ctx))

--- a/pkg/sql/lexbase/encode.go
+++ b/pkg/sql/lexbase/encode.go
@@ -74,6 +74,15 @@ func EncodeUnrestrictedSQLIdent(buf *bytes.Buffer, s string, flags EncodeFlags) 
 	EncodeEscapedSQLIdent(buf, s)
 }
 
+// EscapeSQLIdent ensures that the potential identifier in s is fully
+// quoted, so that any special character it contains is not at risk
+// of "spilling" in the surrounding syntax.
+func EscapeSQLIdent(s string) string {
+	var buf bytes.Buffer
+	EncodeEscapedSQLIdent(&buf, s)
+	return buf.String()
+}
+
 // EncodeEscapedSQLIdent writes the identifier in s to buf. The
 // identifier is always quoted. Double quotes inside the identifier
 // are escaped.


### PR DESCRIPTION
This commit is to add support for the `\password` that securely changes the
password for a user. 

fixes https://github.com/cockroachdb/cockroach/issues/48543

Release note (cli change): add support for `\password` cli command that enables
secure alteration of the password for a user. The given password will always be pre-hashed 
with the password hash method obtained via the session variable `password-encryption`,
i.e. `scram-sha-256` as the default hashing algorithm.