### PR TITLE
release-22.1: concurrency: refactor the ContentionEventTracer to avoid deadlock

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 )
@@ -129,7 +128,6 @@ type Config struct {
 	// Configs + Knobs.
 	MaxLockTableSize  int64
 	DisableTxnPushing bool
-	OnContentionEvent func(*roachpb.ContentionEvent) // may be nil; allowed to mutate the event
 	TxnWaitKnobs      txnwait.TestingKnobs
 }
 
@@ -143,8 +141,7 @@ func (c *Config) initDefaults() {
 func NewManager(cfg Config) Manager {
 	cfg.initDefaults()
 	m := new(managerImpl)
-	timeSource := timeutil.DefaultTimeSource{}
-	lt := newLockTable(cfg.MaxLockTableSize, cfg.RangeDesc.RangeID, timeSource)
+	lt := newLockTable(cfg.MaxLockTableSize, cfg.RangeDesc.RangeID, cfg.Clock)
 	*m = managerImpl{
 		st: cfg.Settings,
 		// TODO(nvanbenschoten): move pkg/storage/spanlatch to a new
@@ -158,14 +155,12 @@ func NewManager(cfg Config) Manager {
 		},
 		lt: lt,
 		ltw: &lockTableWaiterImpl{
-			st:                   cfg.Settings,
-			clock:                cfg.Clock,
-			stopper:              cfg.Stopper,
-			ir:                   cfg.IntentResolver,
-			lt:                   lt,
-			contentionEventClock: timeSource,
-			disableTxnPushing:    cfg.DisableTxnPushing,
-			onContentionEvent:    cfg.OnContentionEvent,
+			st:                cfg.Settings,
+			clock:             cfg.Clock,
+			stopper:           cfg.Stopper,
+			ir:                cfg.IntentResolver,
+			lt:                lt,
+			disableTxnPushing: cfg.DisableTxnPushing,
 		},
 		// TODO(nvanbenschoten): move pkg/storage/txnwait to a new
 		// pkg/storage/concurrency/txnwait package.

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -78,6 +78,7 @@ import (
 // debug-lock-table
 // debug-disable-txn-pushes
 // debug-set-clock           ts=<secs>
+// debug-advance-clock       ts=<secs>
 // debug-set-discovered-locks-threshold-to-consult-finalized-txn-cache n=<count>
 // debug-set-max-locks n=<count>
 // reset
@@ -530,6 +531,12 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				c.manual.Set(nanos)
 				return ""
 
+			case "debug-advance-clock":
+				var secs int
+				d.ScanArgs(t, "ts", &secs)
+				c.manual.Increment(int64(secs) * time.Second.Nanoseconds())
+				return ""
+
 			case "debug-set-discovered-locks-threshold-to-consult-finalized-txn-cache":
 				var n int
 				d.ScanArgs(t, "n", &n)
@@ -643,9 +650,6 @@ func (c *cluster) makeConfig() concurrency.Config {
 		Settings:       c.st,
 		Clock:          c.clock,
 		IntentResolver: c,
-		OnContentionEvent: func(ev *roachpb.ContentionEvent) {
-			ev.Duration = 1234 * time.Millisecond // for determinism
-		},
 		TxnWaitMetrics: txnwait.NewMetrics(time.Minute),
 	}
 }

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -97,19 +97,15 @@ var LockTableDeadlockDetectionPushDelay = settings.RegisterDurationSetting(
 
 // lockTableWaiterImpl is an implementation of lockTableWaiter.
 type lockTableWaiterImpl struct {
-	st                   *cluster.Settings
-	clock                *hlc.Clock
-	stopper              *stop.Stopper
-	ir                   IntentResolver
-	lt                   lockTable
-	contentionEventClock timeutil.TimeSource
+	st      *cluster.Settings
+	clock   *hlc.Clock
+	stopper *stop.Stopper
+	ir      IntentResolver
+	lt      lockTable
 
 	// When set, WriteIntentError are propagated instead of pushing
 	// conflicting transactions.
 	disableTxnPushing bool
-	// When set, called just before each ContentionEvent is emitted.
-	// Is allowed to mutate the event.
-	onContentionEvent func(ev *roachpb.ContentionEvent)
 	// When set, called just before each push timer event is processed.
 	onPushTimer func()
 }
@@ -147,8 +143,9 @@ func (w *lockTableWaiterImpl) WaitOn(
 	// Used to enforce lock timeouts.
 	var lockDeadline time.Time
 
-	h := getOrCreateContentionEventTracer(ctx, w.onContentionEvent, w.contentionEventClock)
-	defer h.close()
+	tracer := newContentionEventTracer(tracing.SpanFromContext(ctx), w.clock)
+	// Make sure the contention time info is finalized when exiting the function.
+	defer tracer.notify(ctx, waitingState{kind: doneWaiting})
 
 	for {
 		select {
@@ -161,7 +158,7 @@ func (w *lockTableWaiterImpl) WaitOn(
 			timerC = nil
 			state := guard.CurState()
 			log.Eventf(ctx, "lock wait-queue event: %s", state)
-			h.notify(ctx, state)
+			tracer.notify(ctx, state)
 			switch state.kind {
 			case waitFor, waitForDistinguished:
 				if req.WaitPolicy == lock.WaitPolicy_Error {
@@ -872,40 +869,36 @@ const tagWaited = "lock_wait"
 // contentionEventTracer adds lock contention information to the trace, in the
 // form of events and tags. The contentionEventTracer is associated with a
 // tracing span.
-//
-// A contentionEventTracer should be created through
-// getOrCreateContentionEventTracer() when a request starts waiting in the lock
-// table (on what might turn out to be multiple locks). If the span has waited
-// on locks before, the same contentionEventTracer from before is reused, as it
-// keeps track of prior wait times. close() should be called when the waiting is
-// over.
-//
-// contentionEventTracer is thread-safe; Render can be called asynchronously.
 type contentionEventTracer struct {
 	sp      *tracing.Span
 	onEvent func(event *roachpb.ContentionEvent) // may be nil
-	clock   timeutil.TimeSource
+	tag     contentionTag
+}
 
-	mu struct {
+// contentionTag represents a lazy tracing span tag containing lock contention
+// information. The contentionTag is fed info from the parent
+// contentionEventTracer.
+type contentionTag struct {
+	clock *hlc.Clock
+	mu    struct {
 		syncutil.Mutex
 
-		// closed is set on close(), and reset by getOrCreateContentionEventTracer
-		// if the contentionEventTracer is used again.
-		closed bool
-		// lockWait accumulates time waited for locks when the contentionEventTracer
-		// is closed.
+		// lockWait accumulates time waited for locks before the current waiting
+		// period (the current waiting period starts at waitStart).
 		lockWait time.Duration
 
 		// waiting is set if the contentionEventTracer has been notified of a lock
 		// that the underlying request is waiting on. The contentionEventTracer
 		// starts with waiting=false, and transitions to waiting=true on the first
-		// notify=true call.
+		// notify() call. It transitions back to waiting=false on terminal events,
+		// and can then continue transitioning back and forth (in case the request
+		// is sequenced again and encounters more locks).
 		waiting bool
 
 		// waitStart represents the timestamp when the request started waiting on
 		// locks in the current iteration of the contentionEventTracer. The wait
-		// time in previous iterations is accumulated in lockWait. On close,
-		// timeutil.Since(waitStart) is added to lockWait.
+		// time in previous iterations is accumulated in lockWait. When not waiting
+		// any more, timeutil.Since(waitStart) is added to lockWait.
 		waitStart time.Time
 
 		// curState is the current wait state, if any. It is overwritten every time
@@ -919,97 +912,51 @@ type contentionEventTracer struct {
 	}
 }
 
-var _ tracing.LazyTag = &contentionEventTracer{}
+// newContentionEventTracer creates a contentionEventTracer and associates it
+// with the provided tracing span. The contentionEventTracer will emit events to
+// the respective span and will also act as a lazy tag on the span.
+//
+// sp can be nil, in which case the tracer will not do anything.
+//
+// It is legal to create a tracer on a span that has previously had another
+// tracer. In that case, the new tracer will absorb the counters from the
+// previous one, and replace it as a span tag. However, it is illegal to create
+// a contentionEventTracer on a span that already has an "active"
+// contentionEventTracer; two tracers sharing a span concurrently doesn't work,
+// as they'd clobber each other. The expectation is that, if this span had a
+// tracer on it, that tracer should have been properly shutdown.
+func newContentionEventTracer(sp *tracing.Span, clock *hlc.Clock) *contentionEventTracer {
+	t := &contentionEventTracer{}
+	t.tag.clock = clock
 
-// getOrCreateContentionEventTracer looks in the span to see if there's already
-// a contentionEventTracer. If there is, it returns it. If there isn't, a new
-// one is created and associated with the span as a lazy tag.
-func getOrCreateContentionEventTracer(
-	ctx context.Context, onEvent func(ev *roachpb.ContentionEvent), clock timeutil.TimeSource,
-) *contentionEventTracer {
-	sp := tracing.SpanFromContext(ctx)
-	var h *contentionEventTracer
-	t, ok := sp.GetLazyTag(tagContentionTracer)
+	// If the span had previously had contention info, we'll absorb the info into
+	// the new tracer/tag.
+	oldTag, ok := sp.GetLazyTag(tagContentionTracer)
 	if ok {
-		h = t.(*contentionEventTracer)
-		h.clock = clock
-		h.mu.Lock()
-		defer h.mu.Unlock()
-		if !h.mu.closed {
-			log.Fatalf(ctx, "unexpectedly found non-closed contentionEventTracer")
+		oldContentionTag := oldTag.(*contentionTag)
+		oldContentionTag.mu.Lock()
+		waiting := oldContentionTag.mu.waiting
+		if waiting {
+			oldContentionTag.mu.Unlock()
+			panic("span already contains contention tag in the waiting state")
 		}
-		h.mu.closed = false
-		h.mu.waiting = false
-		h.mu.waitStart = h.clock.Now()
-		return h
+		t.tag.mu.numLocks = oldContentionTag.mu.numLocks
+		t.tag.mu.lockWait = oldContentionTag.mu.lockWait
+		oldContentionTag.mu.Unlock()
 	}
-	h = &contentionEventTracer{
-		sp:      sp,
-		onEvent: onEvent,
-		clock:   clock,
-	}
-	h.mu.waitStart = h.clock.Now()
-	sp.SetLazyTag(tagContentionTracer, h)
-	return h
+
+	sp.SetLazyTag(tagContentionTracer, &t.tag)
+	t.sp = sp
+	return t
 }
 
-// Render implements the tracing.LazyTag interface.
-func (h *contentionEventTracer) Render() []attribute.KeyValue {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	tags := make([]attribute.KeyValue, 0, 4)
-	if h.mu.numLocks > 0 {
-		tags = append(tags, attribute.KeyValue{
-			Key:   tagNumLocks,
-			Value: attribute.IntValue(h.mu.numLocks),
-		})
-	}
-	// Compute how long the request has waited on locks by adding the prior wait
-	// time (if any) and the current wait time (if we're currently waiting).
-	lockWait := h.mu.lockWait
-	if !h.mu.waitStart.IsZero() {
-		lockWait += h.clock.Since(h.mu.waitStart)
-	}
-	tags = append(tags, attribute.KeyValue{
-		Key:   tagWaited,
-		Value: attribute.StringValue(string(humanizeutil.Duration(lockWait))),
-	})
-
-	if h.mu.waiting {
-		tags = append(tags, attribute.KeyValue{
-			Key:   tagWaitKey,
-			Value: attribute.StringValue(h.mu.curState.key.String()),
-		})
-		tags = append(tags, attribute.KeyValue{
-			Key:   tagLockHolderTxn,
-			Value: attribute.StringValue(h.mu.curState.txn.ID.String()),
-		})
-		tags = append(tags, attribute.KeyValue{
-			Key:   tagWaitStart,
-			Value: attribute.StringValue(h.mu.curState.lockWaitStart.Format("15:04:05.123")),
-		})
-	}
-	return tags
+// SetOnContentionEvent registers a callback to be called before each event is
+// emitted. The callback may modify the event.
+func (h *contentionEventTracer) SetOnContentionEvent(f func(ev *roachpb.ContentionEvent)) {
+	h.onEvent = f
 }
 
-// emitLocked records a ContentionEvent to the tracing span corresponding to the
-// current wait state (if any).
-func (h *contentionEventTracer) emitLocked() {
-	if !h.mu.waiting {
-		return
-	}
-	ev := &roachpb.ContentionEvent{
-		Key:      h.mu.curState.key,
-		TxnMeta:  *h.mu.curState.txn,
-		Duration: h.clock.Since(h.mu.curState.lockWaitStart),
-	}
-	if h.onEvent != nil {
-		// NB: this is intentionally above the call to RecordStructured so that
-		// this interceptor gets to mutate the event (used for test determinism).
-		h.onEvent(ev)
-	}
-	h.sp.RecordStructured(ev)
-}
+var _ tracing.LazyTag = &contentionTag{}
 
 // notify processes an event from the lock table.
 // compares the waitingState's active txn (if any) against the current
@@ -1017,21 +964,51 @@ func (h *contentionEventTracer) emitLocked() {
 // same event and no action is taken. If they differ, the open event (if any) is
 // finalized and added to the Span, and a new event initialized from the inputs.
 func (h *contentionEventTracer) notify(ctx context.Context, s waitingState) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	if h.mu.closed {
-		log.Fatalf(ctx, "notify() unexpectedly called after close(). new state: %s", s)
-	}
 	if h.sp == nil {
 		// No span to manipulate - don't do any work.
 		return
 	}
 
-	firstLock := !h.mu.waiting
+	event := h.tag.notify(ctx, s)
+	if event != nil {
+		h.emit(event)
+	}
+}
+
+// emit records a ContentionEvent to the tracing span corresponding to the
+// current wait state (if any).
+func (h *contentionEventTracer) emit(event *roachpb.ContentionEvent) {
+	if event == nil {
+		return
+	}
+	if h.onEvent != nil {
+		// NB: this is intentionally above the call to RecordStructured so that
+		// this interceptor gets to mutate the event (used for test determinism).
+		h.onEvent(event)
+	}
+	h.sp.RecordStructured(event)
+}
+
+func (tag *contentionTag) generateEventLocked() *roachpb.ContentionEvent {
+	if !tag.mu.waiting {
+		return nil
+	}
+
+	return &roachpb.ContentionEvent{
+		Key:      tag.mu.curState.key,
+		TxnMeta:  *tag.mu.curState.txn,
+		Duration: tag.clock.PhysicalTime().Sub(tag.mu.curState.lockWaitStart),
+	}
+}
+
+// See contentionEventTracer.notify.
+func (tag *contentionTag) notify(ctx context.Context, s waitingState) *roachpb.ContentionEvent {
+	tag.mu.Lock()
+	defer tag.mu.Unlock()
 
 	// Depending on the kind of notification, we check whether we're now waiting
-	// on a different key than we were previously. If so, we emitLocked a
-	// ContentionEvent.
+	// on a different key than we were previously. If we're now waiting on a
+	// different key, we'll return an event corresponding to the previous key.
 	switch s.kind {
 	case waitFor, waitForDistinguished, waitSelf, waitElsewhere:
 		// If we're tracking an event and see a different txn/key, the event is
@@ -1039,47 +1016,79 @@ func (h *contentionEventTracer) notify(ctx context.Context, s waitingState) {
 		//
 		// NB: we're guaranteed to have `s.{txn,key}` populated here.
 		var differentLock bool
-		if firstLock {
+		if !tag.mu.waiting {
 			differentLock = true
 		} else {
-			curLockHolder, curKey := h.mu.curState.txn.ID, h.mu.curState.key
+			curLockHolder, curKey := tag.mu.curState.txn.ID, tag.mu.curState.key
 			differentLock = !curLockHolder.Equal(s.txn.ID) || !curKey.Equal(s.key)
 		}
+		var res *roachpb.ContentionEvent
 		if differentLock {
-			h.emitLocked()
-			h.mu.numLocks++
+			res = tag.generateEventLocked()
 		}
-		h.mu.curState = s
-		h.mu.waiting = true
+		tag.mu.curState = s
+		tag.mu.waiting = true
+		if differentLock {
+			tag.mu.waitStart = tag.clock.PhysicalTime()
+			tag.mu.numLocks++
+			return res
+		}
+		return nil
 	case doneWaiting, waitQueueMaxLengthExceeded:
 		// There will be no more state updates; we're done waiting.
-		h.closeLocked()
-		return
+		res := tag.generateEventLocked()
+		tag.mu.waiting = false
+		tag.mu.curState = waitingState{}
+		tag.mu.lockWait += tag.clock.PhysicalTime().Sub(tag.mu.waitStart)
+		// Accumulate the wait time.
+		tag.mu.waitStart = time.Time{}
+		return res
 	default:
 		kind := s.kind // escapes to the heap
 		log.Fatalf(ctx, "unhandled waitingState.kind: %v", kind)
 	}
+	panic("unreachable")
 }
 
-// close marks the contentionEventTracer as not waiting on a lock.
-func (h *contentionEventTracer) close() {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	h.closeLocked()
-}
-
-func (h *contentionEventTracer) closeLocked() {
-	if h.mu.closed || h.sp == nil {
-		return
+// Render implements the tracing.LazyTag interface.
+func (tag *contentionTag) Render() []attribute.KeyValue {
+	tag.mu.Lock()
+	defer tag.mu.Unlock()
+	tags := make([]attribute.KeyValue, 0, 4)
+	if tag.mu.numLocks > 0 {
+		tags = append(tags, attribute.KeyValue{
+			Key:   tagNumLocks,
+			Value: attribute.IntValue(tag.mu.numLocks),
+		})
+	}
+	// Compute how long the request has waited on locks by adding the prior wait
+	// time (if any) and the current wait time (if we're currently waiting).
+	lockWait := tag.mu.lockWait
+	if !tag.mu.waitStart.IsZero() {
+		lockWait += tag.clock.PhysicalTime().Sub(tag.mu.waitStart)
+	}
+	if lockWait != 0 {
+		tags = append(tags, attribute.KeyValue{
+			Key:   tagWaited,
+			Value: attribute.StringValue(string(humanizeutil.Duration(lockWait))),
+		})
 	}
 
-	h.emitLocked()
-	h.mu.closed = true
-	// Accumulate the wait time.
-	h.mu.lockWait += h.clock.Since(h.mu.waitStart)
-	h.mu.curState = waitingState{}
-	h.mu.waiting = false
-	h.mu.waitStart = time.Time{}
+	if tag.mu.waiting {
+		tags = append(tags, attribute.KeyValue{
+			Key:   tagWaitKey,
+			Value: attribute.StringValue(tag.mu.curState.key.String()),
+		})
+		tags = append(tags, attribute.KeyValue{
+			Key:   tagLockHolderTxn,
+			Value: attribute.StringValue(tag.mu.curState.txn.ID.String()),
+		})
+		tags = append(tags, attribute.KeyValue{
+			Key:   tagWaitStart,
+			Value: attribute.StringValue(tag.mu.curState.lockWaitStart.Format("15:04:05.123")),
+		})
+	}
+	return tags
 }
 
 const (

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
@@ -115,12 +115,11 @@ func setupLockTableWaiterTest() (
 		signal: make(chan struct{}, 1),
 	}
 	w := &lockTableWaiterImpl{
-		st:                   st,
-		clock:                hlc.NewClock(manual.UnixNano, time.Nanosecond),
-		stopper:              stop.NewStopper(),
-		ir:                   ir,
-		lt:                   &mockLockTable{},
-		contentionEventClock: timeutil.DefaultTimeSource{},
+		st:      st,
+		clock:   hlc.NewClock(manual.UnixNano, time.Nanosecond),
+		stopper: stop.NewStopper(),
+		ir:      ir,
+		lt:      &mockLockTable{},
 	}
 	return w, ir, guard, manual
 }
@@ -927,28 +926,29 @@ func BenchmarkTxnCache(b *testing.B) {
 	}
 }
 
-func TestContentionEventHelper(t *testing.T) {
+func TestContentionEventTracer(t *testing.T) {
 	tr := tracing.NewTracer()
 	ctx, sp := tr.StartSpanCtx(context.Background(), "foo", tracing.WithRecording(tracing.RecordingVerbose))
 	defer sp.Finish()
+	clock := hlc.NewClock(hlc.UnixNano, 0 /* maxOffset */)
 
 	var events []*roachpb.ContentionEvent
 
-	h := getOrCreateContentionEventTracer(ctx,
-		func(ev *roachpb.ContentionEvent) {
-			events = append(events, ev)
-		}, timeutil.DefaultTimeSource{})
-	defer h.close()
+	h := newContentionEventTracer(sp, clock)
+	h.SetOnContentionEvent(func(ev *roachpb.ContentionEvent) {
+		events = append(events, ev)
+	})
 	txn := makeTxnProto("foo")
 	h.notify(ctx, waitingState{
 		kind: waitForDistinguished,
 		key:  roachpb.Key("a"),
 		txn:  &txn.TxnMeta,
 	})
-	require.Zero(t, h.mu.lockWait)
-	require.NotZero(t, h.mu.waitStart)
+	require.Zero(t, h.tag.mu.lockWait)
+	require.NotZero(t, h.tag.mu.waitStart)
 	require.Empty(t, events)
 	rec := sp.GetRecording(tracing.RecordingVerbose)
+	require.Contains(t, rec[0].Tags, tagNumLocks)
 	require.Equal(t, "1", rec[0].Tags[tagNumLocks])
 	require.Contains(t, rec[0].Tags, tagWaited)
 	require.Contains(t, rec[0].Tags, tagWaitKey)
@@ -957,41 +957,32 @@ func TestContentionEventHelper(t *testing.T) {
 
 	// Another event for the same txn/key should not mutate
 	// or emitLocked an event.
-	prevNumLocks := h.mu.numLocks
+	prevNumLocks := h.tag.mu.numLocks
 	h.notify(ctx, waitingState{
 		kind: waitFor,
 		key:  roachpb.Key("a"),
 		txn:  &txn.TxnMeta,
 	})
 	require.Empty(t, events)
-	require.Zero(t, h.mu.lockWait)
-	require.Equal(t, prevNumLocks, h.mu.numLocks)
+	require.Zero(t, h.tag.mu.lockWait)
+	require.Equal(t, prevNumLocks, h.tag.mu.numLocks)
 
 	h.notify(ctx, waitingState{
 		kind: waitForDistinguished,
 		key:  roachpb.Key("b"),
 		txn:  &txn.TxnMeta,
 	})
-	require.Zero(t, h.mu.lockWait)
+	require.Zero(t, h.tag.mu.lockWait)
 	require.Len(t, events, 1)
 	require.Equal(t, txn.TxnMeta, events[0].TxnMeta)
 	require.Equal(t, roachpb.Key("a"), events[0].Key)
 	require.NotZero(t, events[0].Duration)
 
-	h.close()
-	require.NotZero(t, h.mu.lockWait)
+	h.notify(ctx, waitingState{kind: doneWaiting})
+	require.NotZero(t, h.tag.mu.lockWait)
 	require.Len(t, events, 2)
 
-	oldH := h
-	h = getOrCreateContentionEventTracer(ctx,
-		func(ev *roachpb.ContentionEvent) {
-			events = append(events, ev)
-		}, timeutil.DefaultTimeSource{})
-	require.Equal(t, oldH, h)
-	require.Equal(t, 2, h.mu.numLocks)
-	require.NotZero(t, h.mu.lockWait)
-	lockWaitBefore := h.mu.lockWait
-
+	lockWaitBefore := h.tag.mu.lockWait
 	h.notify(ctx, waitingState{
 		kind: waitFor,
 		key:  roachpb.Key("b"),
@@ -1001,11 +992,18 @@ func TestContentionEventHelper(t *testing.T) {
 		kind: doneWaiting,
 	})
 	require.Len(t, events, 3)
-	require.Less(t, lockWaitBefore, h.mu.lockWait)
+	require.Less(t, lockWaitBefore, h.tag.mu.lockWait)
 	rec = sp.GetRecording(tracing.RecordingVerbose)
 	require.Equal(t, "3", rec[0].Tags[tagNumLocks])
 	require.Contains(t, rec[0].Tags, tagWaited)
 	require.NotContains(t, rec[0].Tags, tagWaitKey)
 	require.NotContains(t, rec[0].Tags, tagWaitStart)
 	require.NotContains(t, rec[0].Tags, tagLockHolderTxn)
+
+	// Create a new tracer on the same span and check that the new tracer
+	// incorporates the info of the old one.
+	anotherTracer := newContentionEventTracer(sp, clock)
+	require.NotZero(t, anotherTracer.tag.mu.numLocks)
+	require.Equal(t, h.tag.mu.numLocks, anotherTracer.tag.mu.numLocks)
+	require.Equal(t, h.tag.mu.lockWait, anotherTracer.tag.mu.lockWait)
 }

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
@@ -120,12 +120,15 @@ sequence req=req3
 [2] sequence req3: pushing timestamp of txn 00000002 above 14.000000000,1
 [2] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
 
+debug-advance-clock ts=123
+----
+
 on-txn-updated txn=txn2 status=committed
 ----
 [-] update txn: committing txn2
 [2] sequence req3: resolving intent "k" for txn 00000002 with COMMITTED status
 [2] sequence req3: lock wait-queue event: done waiting
-[2] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.234s
+[2] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 123.000s
 [2] sequence req3: acquiring latches
 [2] sequence req3: scanning lock table for conflicting locks
 [2] sequence req3: sequencing complete, returned guard
@@ -217,17 +220,20 @@ sequence req=req6
 [3] sequence req6: lock wait-queue event: wait for txn 00000002 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 2)
 [3] sequence req6: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
+debug-advance-clock ts=123
+----
+
 on-txn-updated txn=txn2 status=pending ts=18,1
 ----
 [-] update txn: increasing timestamp of txn2
 [2] sequence req5: resolving intent "k" for txn 00000002 with PENDING status
 [2] sequence req5: lock wait-queue event: done waiting
-[2] sequence req5: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.234s
+[2] sequence req5: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 123.000s
 [2] sequence req5: acquiring latches
 [2] sequence req5: scanning lock table for conflicting locks
 [2] sequence req5: sequencing complete, returned guard
 [3] sequence req6: lock wait-queue event: done waiting
-[3] sequence req6: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.234s
+[3] sequence req6: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 123.000s
 [3] sequence req6: acquiring latches
 [3] sequence req6: scanning lock table for conflicting locks
 [3] sequence req6: sequencing complete, returned guard
@@ -258,12 +264,15 @@ finish req=req6
 [4] sequence req7: pushing txn 00000002 to abort
 [4] sequence req7: blocked on select in concurrency_test.(*cluster).PushTransaction
 
+debug-advance-clock ts=123
+----
+
 on-txn-updated txn=txn2 status=committed
 ----
 [-] update txn: committing txn2
 [4] sequence req7: resolving intent "k" for txn 00000002 with COMMITTED status
 [4] sequence req7: lock wait-queue event: done waiting
-[4] sequence req7: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.234s
+[4] sequence req7: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 123.000s
 [4] sequence req7: acquiring latches
 [4] sequence req7: scanning lock table for conflicting locks
 [4] sequence req7: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
@@ -96,6 +96,9 @@ global: num=10
   holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
 local: num=0
 
+debug-advance-clock ts=123
+----
+
 # txn1 is the distinguished waiter on key "a". It will push txn2, notice that it
 # is aborted, and then resolve key "a". Once txn2 is in the finalizedTxnCache,
 # txn1 will create a batch to resolve all other keys together.
@@ -104,7 +107,7 @@ on-txn-updated txn=txn2 status=aborted
 [-] update txn: aborting txn2
 [3] sequence req1: resolving intent "a" for txn 00000002 with ABORTED status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on "a" for 1.234s
+[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on "a" for 123.000s
 [3] sequence req1: resolving a batch of 9 intent(s)
 [3] sequence req1: resolving intent "b" for txn 00000002 with ABORTED status
 [3] sequence req1: resolving intent "c" for txn 00000002 with ABORTED status
@@ -178,12 +181,15 @@ sequence req=req1
 [3] sequence req1: pushing txn 00000002 to abort
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 
+debug-advance-clock ts=123
+----
+
 on-txn-updated txn=txn2 status=committed
 ----
 [-] update txn: committing txn2
 [3] sequence req1: resolving intent "a" for txn 00000002 with COMMITTED status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on "a" for 1.234s
+[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on "a" for 123.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
@@ -367,12 +373,15 @@ global: num=4
   holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
+debug-advance-clock ts=123
+----
+
 on-txn-updated txn=txn2 status=aborted
 ----
 [-] update txn: aborting txn2
 [4] sequence req1: resolving intent "a" for txn 00000002 with ABORTED status
 [4] sequence req1: lock wait-queue event: done waiting
-[4] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on "a" for 1.234s
+[4] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on "a" for 123.000s
 [4] sequence req1: resolving a batch of 1 intent(s)
 [4] sequence req1: resolving intent "b" for txn 00000002 with ABORTED status
 [4] sequence req1: acquiring latches
@@ -583,6 +592,9 @@ global: num=5
     active: false req: 5, txn: 00000001-0000-0000-0000-000000000000
 local: num=0
 
+debug-advance-clock ts=123
+----
+
 # req1 resolves intent c, skips waiting at d, and waits at e. req2 resolves a,
 # and waits at b.
 on-txn-updated txn=txn3 status=aborted
@@ -590,12 +602,12 @@ on-txn-updated txn=txn3 status=aborted
 [-] update txn: aborting txn3
 [3] sequence req1: resolving intent "c" for txn 00000003 with ABORTED status
 [3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000005 holding lock @ key "e" (queuedWriters: 1, queuedReaders: 0)
-[3] sequence req1: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 1.234s
+[3] sequence req1: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 123.000s
 [3] sequence req1: pushing txn 00000005 to abort
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 [6] sequence req2: resolving intent "a" for txn 00000003 with ABORTED status
 [6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000004 holding lock @ key "b" (queuedWriters: 0, queuedReaders: 1)
-[6] sequence req2: conflicted with 00000003-0000-0000-0000-000000000000 on "a" for 1.234s
+[6] sequence req2: conflicted with 00000003-0000-0000-0000-000000000000 on "a" for 123.000s
 [6] sequence req2: pushing timestamp of txn 00000004 above 11.000000000,1
 [6] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -620,6 +632,9 @@ global: num=4
    distinguished req: 5
 local: num=0
 
+debug-advance-clock ts=123
+----
+
 # The txn holding b is aborted. At this point req2 can resolve both b and d
 # and continue to evaluation.
 on-txn-updated txn=txn4 status=aborted
@@ -627,7 +642,7 @@ on-txn-updated txn=txn4 status=aborted
 [-] update txn: aborting txn4
 [6] sequence req2: resolving intent "b" for txn 00000004 with ABORTED status
 [6] sequence req2: lock wait-queue event: done waiting
-[6] sequence req2: conflicted with 00000004-0000-0000-0000-000000000000 on "b" for 1.234s
+[6] sequence req2: conflicted with 00000004-0000-0000-0000-000000000000 on "b" for 123.000s
 [6] sequence req2: resolving a batch of 1 intent(s)
 [6] sequence req2: resolving intent "d" for txn 00000003 with ABORTED status
 [6] sequence req2: acquiring latches
@@ -659,7 +674,7 @@ on-txn-updated txn=txn5 status=aborted
 [-] update txn: aborting txn5
 [3] sequence req1: resolving intent "e" for txn 00000005 with ABORTED status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000005-0000-0000-0000-000000000000 on "e" for 1.234s
+[3] sequence req1: conflicted with 00000005-0000-0000-0000-000000000000 on "e" for 123.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
@@ -57,6 +57,9 @@ global: num=1
    distinguished req: 1
 local: num=0
 
+debug-advance-clock ts=123
+----
+
 # txn1 is the distinguished waiter on key "a". It will push txn2, notice that it
 # is aborted, and then resolve key "a". This places txn2 in the finalizedTxnCache.
 on-txn-updated txn=txn2 status=aborted
@@ -64,7 +67,7 @@ on-txn-updated txn=txn2 status=aborted
 [-] update txn: aborting txn2
 [3] sequence req1: resolving intent "a" for txn 00000002 with ABORTED status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on "a" for 1.234s
+[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on "a" for 123.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
@@ -164,11 +164,11 @@ on-txn-updated txn=txn1 status=aborted
 ----
 [-] update txn: aborting txn1
 [4] sequence req1r: detected pusher aborted
-[4] sequence req1r: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 1.234s
+[4] sequence req1r: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 0.000s
 [4] sequence req1r: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED): <nil>
 [6] sequence req3r: resolving intent "a" for txn 00000001 with ABORTED status
 [6] sequence req3r: lock wait-queue event: done waiting
-[6] sequence req3r: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 1.234s
+[6] sequence req3r: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 0.000s
 [6] sequence req3r: acquiring latches
 [6] sequence req3r: scanning lock table for conflicting locks
 [6] sequence req3r: sequencing complete, returned guard
@@ -183,7 +183,7 @@ on-txn-updated txn=txn3 status=committed
 [-] update txn: committing txn3
 [5] sequence req2r: resolving intent "c" for txn 00000003 with COMMITTED status
 [5] sequence req2r: lock wait-queue event: done waiting
-[5] sequence req2r: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 1.234s
+[5] sequence req2r: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 0.000s
 [5] sequence req2r: acquiring latches
 [5] sequence req2r: scanning lock table for conflicting locks
 [5] sequence req2r: sequencing complete, returned guard
@@ -389,16 +389,16 @@ on-txn-updated txn=txn1 status=aborted
 [-] update txn: aborting txn1
 [4] sequence req4w: resolving intent "a" for txn 00000001 with ABORTED status
 [4] sequence req4w: lock wait-queue event: done waiting
-[4] sequence req4w: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 1.234s
+[4] sequence req4w: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 0.000s
 [4] sequence req4w: acquiring latches
 [4] sequence req4w: scanning lock table for conflicting locks
 [4] sequence req4w: sequencing complete, returned guard
 [5] sequence req1w2: detected pusher aborted
-[5] sequence req1w2: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 1.234s
+[5] sequence req1w2: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 0.000s
 [5] sequence req1w2: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED): <nil>
 [7] sequence req3w2: resolving intent "a" for txn 00000001 with ABORTED status
 [7] sequence req3w2: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key "a" (queuedWriters: 1, queuedReaders: 0)
-[7] sequence req3w2: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 1.234s
+[7] sequence req3w2: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 0.000s
 [7] sequence req3w2: pushing txn 00000004 to detect request deadlock
 [7] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -407,7 +407,7 @@ finish req=req4w
 ----
 [-] finish req4w: finishing request
 [7] sequence req3w2: lock wait-queue event: done waiting
-[7] sequence req3w2: conflicted with 00000004-0000-0000-0000-000000000000 on "a" for 1.234s
+[7] sequence req3w2: conflicted with 00000004-0000-0000-0000-000000000000 on "a" for 0.000s
 [7] sequence req3w2: acquiring latches
 [7] sequence req3w2: scanning lock table for conflicting locks
 [7] sequence req3w2: sequencing complete, returned guard
@@ -422,7 +422,7 @@ on-txn-updated txn=txn3 status=committed
 [-] update txn: committing txn3
 [6] sequence req2w2: resolving intent "c" for txn 00000003 with COMMITTED status
 [6] sequence req2w2: lock wait-queue event: done waiting
-[6] sequence req2w2: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 1.234s
+[6] sequence req2w2: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 0.000s
 [6] sequence req2w2: acquiring latches
 [6] sequence req2w2: scanning lock table for conflicting locks
 [6] sequence req2w2: sequencing complete, returned guard
@@ -560,7 +560,7 @@ on-txn-updated txn=txn2 status=committed
 [-] update txn: committing txn2
 [4] sequence req4w: resolving intent "b" for txn 00000002 with COMMITTED status
 [4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "c" (queuedWriters: 1, queuedReaders: 0)
-[4] sequence req4w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 1.234s
+[4] sequence req4w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 0.000s
 [4] sequence req4w: pushing txn 00000003 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -638,10 +638,10 @@ on-txn-updated txn=txn4 status=aborted
 ----
 [-] update txn: aborting txn4
 [4] sequence req4w: detected pusher aborted
-[4] sequence req4w: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 1.234s
+[4] sequence req4w: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 0.000s
 [4] sequence req4w: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED): <nil>
 [5] sequence req1w2: lock wait-queue event: done waiting
-[5] sequence req1w2: conflicted with 00000004-0000-0000-0000-000000000000 on "b" for 1.234s
+[5] sequence req1w2: conflicted with 00000004-0000-0000-0000-000000000000 on "b" for 0.000s
 [5] sequence req1w2: acquiring latches
 [5] sequence req1w2: scanning lock table for conflicting locks
 [5] sequence req1w2: sequencing complete, returned guard
@@ -656,7 +656,7 @@ on-txn-updated txn=txn1 status=committed
 [-] update txn: committing txn1
 [6] sequence req3w2: resolving intent "a" for txn 00000001 with COMMITTED status
 [6] sequence req3w2: lock wait-queue event: done waiting
-[6] sequence req3w2: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 1.234s
+[6] sequence req3w2: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 0.000s
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: sequencing complete, returned guard
@@ -794,7 +794,7 @@ on-txn-updated txn=txn2 status=committed
 [-] update txn: committing txn2
 [4] sequence req4w: resolving intent "b" for txn 00000002 with COMMITTED status
 [4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "c" (queuedWriters: 1, queuedReaders: 0)
-[4] sequence req4w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 1.234s
+[4] sequence req4w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 0.000s
 [4] sequence req4w: pushing txn 00000003 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -872,11 +872,11 @@ on-txn-updated txn=txn1 status=aborted
 ----
 [-] update txn: aborting txn1
 [5] sequence req1w2: detected pusher aborted
-[5] sequence req1w2: conflicted with 00000004-0000-0000-0000-000000000000 on "b" for 1.234s
+[5] sequence req1w2: conflicted with 00000004-0000-0000-0000-000000000000 on "b" for 0.000s
 [5] sequence req1w2: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED): <nil>
 [6] sequence req3w2: resolving intent "a" for txn 00000001 with ABORTED status
 [6] sequence req3w2: lock wait-queue event: done waiting
-[6] sequence req3w2: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 1.234s
+[6] sequence req3w2: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 0.000s
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: sequencing complete, returned guard
@@ -891,7 +891,7 @@ on-txn-updated txn=txn3 status=committed
 [-] update txn: committing txn3
 [4] sequence req4w: resolving intent "c" for txn 00000003 with COMMITTED status
 [4] sequence req4w: lock wait-queue event: done waiting
-[4] sequence req4w: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 1.234s
+[4] sequence req4w: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 0.000s
 [4] sequence req4w: acquiring latches
 [4] sequence req4w: scanning lock table for conflicting locks
 [4] sequence req4w: sequencing complete, returned guard
@@ -1050,7 +1050,7 @@ on-txn-updated txn=txn1 status=committed
 [-] update txn: committing txn1
 [5] sequence req4w: resolving intent "a" for txn 00000001 with COMMITTED status
 [5] sequence req4w: lock wait-queue event: wait for txn 00000002 holding lock @ key "b" (queuedWriters: 2, queuedReaders: 0)
-[5] sequence req4w: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 1.234s
+[5] sequence req4w: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 0.000s
 [5] sequence req4w: pushing txn 00000002 to abort
 [5] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -1059,12 +1059,12 @@ on-txn-updated txn=txn2 status=committed
 [-] update txn: committing txn2
 [4] sequence req5w: resolving intent "b" for txn 00000002 with COMMITTED status
 [4] sequence req5w: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "c" (queuedWriters: 1, queuedReaders: 0)
-[4] sequence req5w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 1.234s
+[4] sequence req5w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 0.000s
 [4] sequence req5w: pushing txn 00000003 to abort
 [4] sequence req5w: blocked on select in concurrency_test.(*cluster).PushTransaction
 [5] sequence req4w: resolving intent "b" for txn 00000002 with COMMITTED status
 [5] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000005 running request @ key "b" (queuedWriters: 1, queuedReaders: 0)
-[5] sequence req4w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 1.234s
+[5] sequence req4w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 0.000s
 [5] sequence req4w: pushing txn 00000005 to detect request deadlock
 [5] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -1131,10 +1131,10 @@ on-txn-updated txn=txn4 status=aborted
 ----
 [-] update txn: aborting txn4
 [5] sequence req4w: detected pusher aborted
-[5] sequence req4w: conflicted with 00000005-0000-0000-0000-000000000000 on "b" for 1.234s
+[5] sequence req4w: conflicted with 00000005-0000-0000-0000-000000000000 on "b" for 0.000s
 [5] sequence req4w: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED): <nil>
 [6] sequence req3w2: lock wait-queue event: done waiting
-[6] sequence req3w2: conflicted with 00000004-0000-0000-0000-000000000000 on "a" for 1.234s
+[6] sequence req3w2: conflicted with 00000004-0000-0000-0000-000000000000 on "a" for 0.000s
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: sequencing complete, returned guard
@@ -1149,7 +1149,7 @@ on-txn-updated txn=txn3 status=committed
 [-] update txn: committing txn3
 [4] sequence req5w: resolving intent "c" for txn 00000003 with COMMITTED status
 [4] sequence req5w: lock wait-queue event: done waiting
-[4] sequence req5w: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 1.234s
+[4] sequence req5w: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 0.000s
 [4] sequence req5w: acquiring latches
 [4] sequence req5w: scanning lock table for conflicting locks
 [4] sequence req5w: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
@@ -184,13 +184,13 @@ on-txn-updated txn=txn3 status=committed
 [-] update txn: committing txn3
 [5] sequence req4: resolving intent "k" for txn 00000003 with COMMITTED status
 [5] sequence req4: lock wait-queue event: done waiting
-[5] sequence req4: conflicted with 00000003-0000-0000-0000-000000000000 on "k" for 1.234s
+[5] sequence req4: conflicted with 00000003-0000-0000-0000-000000000000 on "k" for 0.000s
 [5] sequence req4: acquiring latches
 [5] sequence req4: scanning lock table for conflicting locks
 [5] sequence req4: sequencing complete, returned guard
 [7] sequence req2: resolving intent "k" for txn 00000003 with COMMITTED status
 [7] sequence req2: lock wait-queue event: done waiting
-[7] sequence req2: conflicted with 00000003-0000-0000-0000-000000000000 on "k" for 1.234s
+[7] sequence req2: conflicted with 00000003-0000-0000-0000-000000000000 on "k" for 0.000s
 [7] sequence req2: acquiring latches
 [7] sequence req2: scanning lock table for conflicting locks
 [7] sequence req2: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
@@ -47,7 +47,7 @@ on-txn-updated txn=txn1 status=aborted
 [-] update txn: aborting txn1
 [3] sequence req1: resolving intent "k" for txn 00000001 with ABORTED status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout
@@ -106,7 +106,7 @@ sequence req=reqTimeout1
 [4] sequence reqTimeout1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
 [4] sequence reqTimeout1: pushing txn 00000001 to check if abandoned
 [4] sequence reqTimeout1: pushee not abandoned
-[4] sequence reqTimeout1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[4] sequence reqTimeout1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
 [4] sequence reqTimeout1: sequencing complete, returned error: conflicting intents on "k" [reason=lock_timeout]
 
 # -------------------------------------------------------------
@@ -119,7 +119,7 @@ on-txn-updated txn=txn1 status=committed
 [-] update txn: committing txn1
 [3] sequence req3: resolving intent "k2" for txn 00000001 with COMMITTED status
 [3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k3" (queuedWriters: 1, queuedReaders: 0)
-[3] sequence req3: conflicted with 00000001-0000-0000-0000-000000000000 on "k2" for 1.234s
+[3] sequence req3: conflicted with 00000001-0000-0000-0000-000000000000 on "k2" for 0.000s
 [3] sequence req3: pushing txn 00000002 to abort
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -163,7 +163,7 @@ sequence req=reqTimeout2
 [6] sequence reqTimeout2: scanning lock table for conflicting locks
 [6] sequence reqTimeout2: waiting in lock wait-queues
 [6] sequence reqTimeout2: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key "k2" (queuedWriters: 1, queuedReaders: 0)
-[6] sequence reqTimeout2: conflicted with 00000003-0000-0000-0000-000000000000 on "k2" for 1.234s
+[6] sequence reqTimeout2: conflicted with 00000003-0000-0000-0000-000000000000 on "k2" for 0.000s
 [6] sequence reqTimeout2: sequencing complete, returned error: conflicting intents on "k2" [reason=lock_timeout]
 
 # -------------------------------------------------------------
@@ -196,7 +196,7 @@ sequence req=reqTimeout3
 [9] sequence reqTimeout3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k4" (queuedWriters: 0, queuedReaders: 1)
 [9] sequence reqTimeout3: pushing txn 00000002 to check if abandoned
 [9] sequence reqTimeout3: pushee not abandoned
-[9] sequence reqTimeout3: conflicted with 00000002-0000-0000-0000-000000000000 on "k4" for 1.234s
+[9] sequence reqTimeout3: conflicted with 00000002-0000-0000-0000-000000000000 on "k4" for 0.000s
 [9] sequence reqTimeout3: sequencing complete, returned error: conflicting intents on "k4" [reason=lock_timeout]
 
 debug-lock-table
@@ -223,7 +223,7 @@ on-txn-updated txn=txn2 status=aborted
 [-] update txn: aborting txn2
 [3] sequence req3: resolving intent "k3" for txn 00000002 with ABORTED status
 [3] sequence req3: lock wait-queue event: done waiting
-[3] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on "k3" for 1.234s
+[3] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on "k3" for 0.000s
 [3] sequence req3: acquiring latches
 [3] sequence req3: scanning lock table for conflicting locks
 [3] sequence req3: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/optimistic
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/optimistic
@@ -102,7 +102,7 @@ on-txn-updated txn=txn1 status=committed
 [-] update txn: committing txn1
 [4] sequence req3: resolving intent "d" for txn 00000001 with COMMITTED status
 [4] sequence req3: lock wait-queue event: done waiting
-[4] sequence req3: conflicted with 00000001-0000-0000-0000-000000000000 on "d" for 1.234s
+[4] sequence req3: conflicted with 00000001-0000-0000-0000-000000000000 on "d" for 0.000s
 [4] sequence req3: acquiring latches
 [4] sequence req3: scanning lock table for conflicting locks
 [4] sequence req3: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/queue_length_exceeded
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/queue_length_exceeded
@@ -119,23 +119,23 @@ on-txn-updated txn=txn1 status=committed
 [-] update txn: committing txn1
 [2] sequence req2: resolving intent "k" for txn 00000001 with COMMITTED status
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
 [3] sequence req3: resolving intent "k" for txn 00000001 with COMMITTED status
 [3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 running request @ key "k" (queuedWriters: 2, queuedReaders: 0)
-[3] sequence req3: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[3] sequence req3: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
 [3] sequence req3: pushing txn 00000002 to detect request deadlock
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
 [4] sequence req4: resolving intent "k" for txn 00000001 with COMMITTED status
 [4] sequence req4: lock wait-queue event: wait for txn 00000002 running request @ key "k" (queuedWriters: 2, queuedReaders: 0)
-[4] sequence req4: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[4] sequence req4: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
 [4] sequence req4: pushing txn 00000002 to detect request deadlock
 [4] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
 [5] sequence req5r: resolving intent "k" for txn 00000001 with COMMITTED status
 [5] sequence req5r: lock wait-queue event: done waiting
-[5] sequence req5r: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[5] sequence req5r: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
 [5] sequence req5r: acquiring latches
 [5] sequence req5r: scanning lock table for conflicting locks
 [5] sequence req5r: sequencing complete, returned guard
@@ -196,13 +196,13 @@ on-txn-updated txn=txn2 status=aborted
 [-] update txn: aborting txn2
 [3] sequence req3: resolving intent "k" for txn 00000002 with ABORTED status
 [3] sequence req3: lock wait-queue event: done waiting
-[3] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.234s
+[3] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 0.000s
 [3] sequence req3: acquiring latches
 [3] sequence req3: scanning lock table for conflicting locks
 [3] sequence req3: sequencing complete, returned guard
 [4] sequence req4: resolving intent "k" for txn 00000002 with ABORTED status
 [4] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key "k" (queuedWriters: 1, queuedReaders: 0)
-[4] sequence req4: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.234s
+[4] sequence req4: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 0.000s
 [4] sequence req4: pushing txn 00000003 to detect request deadlock
 [4] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -210,7 +210,7 @@ finish req=req3
 ----
 [-] finish req3: finishing request
 [4] sequence req4: lock wait-queue event: done waiting
-[4] sequence req4: conflicted with 00000003-0000-0000-0000-000000000000 on "k" for 1.234s
+[4] sequence req4: conflicted with 00000003-0000-0000-0000-000000000000 on "k" for 0.000s
 [4] sequence req4: acquiring latches
 [4] sequence req4: scanning lock table for conflicting locks
 [4] sequence req4: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
@@ -114,7 +114,7 @@ on-lease-updated leaseholder=false lease-seq=2
 ----
 [-] transfer lease: released
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -196,7 +196,7 @@ on-lock-updated req=reqRes1 txn=txn1 key=k status=committed
 ----
 [-] update lock: committing txn 00000001 @ k
 [7] sequence req2: lock wait-queue event: done waiting
-[7] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[7] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
 [7] sequence req2: acquiring latches
 [7] sequence req2: waiting to acquire read latch k2@10.000000000,1, held by write latch k2@10.000000000,1
 [7] sequence req2: blocked on select in spanlatch.(*Manager).waitForSignal
@@ -313,7 +313,7 @@ on-lock-updated req=reqRes2 txn=txn2 key=k status=committed
 ----
 [-] update lock: committing txn 00000002 @ k
 [13] sequence req3: lock wait-queue event: done waiting
-[13] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.234s
+[13] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 0.000s
 [13] sequence req3: acquiring latches
 [13] sequence req3: waiting to acquire write latch k@10.000000000,1, held by write latch k@10.000000000,1
 [13] sequence req3: blocked on select in spanlatch.(*Manager).waitForSignal
@@ -427,7 +427,7 @@ on-split
 ----
 [-] split range: complete
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -474,7 +474,7 @@ on-lock-updated req=reqRes1 txn=txn1 key=k status=committed
 ----
 [-] update lock: committing txn 00000001 @ k
 [4] sequence req2: lock wait-queue event: done waiting
-[4] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[4] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
 [4] sequence req2: acquiring latches
 [4] sequence req2: waiting to acquire write latch k@10.000000000,1, held by write latch k@10.000000000,1
 [4] sequence req2: blocked on select in spanlatch.(*Manager).waitForSignal
@@ -609,7 +609,7 @@ on-merge
 ----
 [-] merge range: complete
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -698,7 +698,7 @@ on-lock-updated req=reqRes1 txn=txn1 key=k status=committed
 ----
 [-] update lock: committing txn 00000001 @ k
 [8] sequence req2: lock wait-queue event: done waiting
-[8] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[8] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
 [8] sequence req2: acquiring latches
 [8] sequence req2: waiting to acquire write latch k@10.000000000,1, held by write latch k@10.000000000,1
 [8] sequence req2: blocked on select in spanlatch.(*Manager).waitForSignal
@@ -812,7 +812,7 @@ on-snapshot-applied
 ----
 [-] snapshot replica: applied
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -859,7 +859,7 @@ on-lock-updated req=reqRes1 txn=txn1 key=k status=committed
 ----
 [-] update lock: committing txn 00000001 @ k
 [4] sequence req2: lock wait-queue event: done waiting
-[4] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[4] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
 [4] sequence req2: acquiring latches
 [4] sequence req2: waiting to acquire write latch k@10.000000000,1, held by write latch k@10.000000000,1
 [4] sequence req2: blocked on select in spanlatch.(*Manager).waitForSignal

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
@@ -49,7 +49,7 @@ on-txn-updated txn=txn1 status=pending ts=15,2
 [-] update txn: increasing timestamp of txn1
 [3] sequence req1: resolving intent "k" for txn 00000001 with PENDING status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
@@ -115,7 +115,7 @@ on-txn-updated txn=txn1 status=pending ts=135,1
 [-] update txn: increasing timestamp of txn1
 [3] sequence req1: resolving intent "k" for txn 00000001 with PENDING status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
@@ -184,7 +184,7 @@ on-txn-updated txn=txn1 status=pending ts=150,2?
 [-] update txn: increasing timestamp of txn1
 [3] sequence req1: resolving intent "k" for txn 00000001 with PENDING status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
@@ -298,13 +298,13 @@ on-txn-updated txn=txn1 status=committed
 [-] update txn: committing txn1
 [3] sequence req1: resolving intent "k" for txn 00000001 with COMMITTED status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
 [5] sequence req2-retry: resolving intent "k" for txn 00000001 with COMMITTED status
 [5] sequence req2-retry: lock wait-queue event: done waiting
-[5] sequence req2-retry: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[5] sequence req2-retry: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
 [5] sequence req2-retry: acquiring latches
 [5] sequence req2-retry: scanning lock table for conflicting locks
 [5] sequence req2-retry: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/update
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/update
@@ -72,7 +72,7 @@ on-txn-updated txn=txn1 status=pending ts=12,2
 [-] update txn: increasing timestamp of txn1
 [2] sequence req2: resolving intent "k" for txn 00000001 with PENDING status
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -193,7 +193,7 @@ on-txn-updated txn=txn1 status=pending ts=12,2
 [-] update txn: increasing timestamp of txn1
 [2] sequence req2: resolving intent "k" for txn 00000001 with PENDING status
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -323,7 +323,7 @@ on-txn-updated txn=txn1 status=pending ts=12,2
 [-] update txn: increasing timestamp of txn1
 [2] sequence req2: resolving intent "k" for txn 00000001 with PENDING status
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -397,7 +397,7 @@ on-txn-updated txn=txn1 status=committed
 [-] update txn: committing txn1
 [3] sequence req4: resolving intent "k" for txn 00000001 with COMMITTED status
 [3] sequence req4: lock wait-queue event: done waiting
-[3] sequence req4: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[3] sequence req4: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
 [3] sequence req4: acquiring latches
 [3] sequence req4: scanning lock table for conflicting locks
 [3] sequence req4: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_elsewhere
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_elsewhere
@@ -91,6 +91,9 @@ finish req=reqSecondLock
 ----
 [-] finish reqSecondLock: finishing request
 
+debug-advance-clock ts=123
+----
+
 # Abort the writing txn. This will cause the blocked request to unblock. Note
 # that we expect the "conflicted with" contention event after the push. This
 # shows that the event is emitted only after the request exits both the waitFor
@@ -102,7 +105,7 @@ on-txn-updated txn=txnWriter status=aborted
 [4] sequence reqWaiter: lock wait-queue event: wait elsewhere for txn 00000001 @ key "k"
 [4] sequence reqWaiter: pushing txn 00000001 to abort
 [4] sequence reqWaiter: resolving intent "k" for txn 00000001 with ABORTED status
-[4] sequence reqWaiter: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[4] sequence reqWaiter: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 123.000s
 [4] sequence reqWaiter: acquiring latches
 [4] sequence reqWaiter: scanning lock table for conflicting locks
 [4] sequence reqWaiter: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
@@ -106,7 +106,7 @@ sequence req=reqNoWait1
 [4] sequence reqNoWait1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
 [4] sequence reqNoWait1: pushing txn 00000001 to check if abandoned
 [4] sequence reqNoWait1: pushee not abandoned
-[4] sequence reqNoWait1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[4] sequence reqNoWait1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
 [4] sequence reqNoWait1: sequencing complete, returned error: conflicting intents on "k" [reason=wait_policy]
 
 # -------------------------------------------------------------
@@ -114,12 +114,15 @@ sequence req=reqNoWait1
 # The request removes the abandoned unreplicated lock and proceeds.
 # -------------------------------------------------------------
 
+debug-advance-clock ts=123
+----
+
 on-txn-updated txn=txn1 status=committed
 ----
 [-] update txn: committing txn1
 [3] sequence req3: resolving intent "k2" for txn 00000001 with COMMITTED status
 [3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k3" (queuedWriters: 1, queuedReaders: 0)
-[3] sequence req3: conflicted with 00000001-0000-0000-0000-000000000000 on "k2" for 1.234s
+[3] sequence req3: conflicted with 00000001-0000-0000-0000-000000000000 on "k2" for 123.000s
 [3] sequence req3: pushing txn 00000002 to abort
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -163,7 +166,7 @@ sequence req=reqNoWait2
 [6] sequence reqNoWait2: scanning lock table for conflicting locks
 [6] sequence reqNoWait2: waiting in lock wait-queues
 [6] sequence reqNoWait2: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key "k2" (queuedWriters: 1, queuedReaders: 0)
-[6] sequence reqNoWait2: conflicted with 00000003-0000-0000-0000-000000000000 on "k2" for 1.234s
+[6] sequence reqNoWait2: conflicted with 00000003-0000-0000-0000-000000000000 on "k2" for 0.000s
 [6] sequence reqNoWait2: sequencing complete, returned error: conflicting intents on "k2" [reason=wait_policy]
 
 # -------------------------------------------------------------
@@ -196,7 +199,7 @@ sequence req=reqNoWait3
 [9] sequence reqNoWait3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k4" (queuedWriters: 0, queuedReaders: 1)
 [9] sequence reqNoWait3: pushing txn 00000002 to check if abandoned
 [9] sequence reqNoWait3: pushee not abandoned
-[9] sequence reqNoWait3: conflicted with 00000002-0000-0000-0000-000000000000 on "k4" for 1.234s
+[9] sequence reqNoWait3: conflicted with 00000002-0000-0000-0000-000000000000 on "k4" for 0.000s
 [9] sequence reqNoWait3: sequencing complete, returned error: conflicting intents on "k4" [reason=wait_policy]
 
 debug-lock-table
@@ -218,12 +221,15 @@ local: num=0
 # lock. The request resolves the abandoned lock and proceeds.
 # -------------------------------------------------------------
 
+debug-advance-clock ts=123
+----
+
 on-txn-updated txn=txn2 status=aborted
 ----
 [-] update txn: aborting txn2
 [3] sequence req3: resolving intent "k3" for txn 00000002 with ABORTED status
 [3] sequence req3: lock wait-queue event: done waiting
-[3] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on "k3" for 1.234s
+[3] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on "k3" for 123.000s
 [3] sequence req3: acquiring latches
 [3] sequence req3: scanning lock table for conflicting locks
 [3] sequence req3: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_self
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_self
@@ -71,23 +71,26 @@ sequence req=reqTxn2
 [4] sequence reqTxn2: pushing txn 00000002 to abort
 [4] sequence reqTxn2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
+debug-advance-clock ts=123
+----
+
 on-txn-updated txn=txnOld status=committed
 ----
 [-] update txn: committing txnOld
 [2] sequence reqTxn1: resolving intent "k" for txn 00000002 with COMMITTED status
 [2] sequence reqTxn1: lock wait-queue event: done waiting
-[2] sequence reqTxn1: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.234s
+[2] sequence reqTxn1: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 123.000s
 [2] sequence reqTxn1: acquiring latches
 [2] sequence reqTxn1: scanning lock table for conflicting locks
 [2] sequence reqTxn1: sequencing complete, returned guard
 [3] sequence reqTxnMiddle: resolving intent "k" for txn 00000002 with COMMITTED status
 [3] sequence reqTxnMiddle: lock wait-queue event: wait for (distinguished) txn 00000001 running request @ key "k" (queuedWriters: 2, queuedReaders: 0)
-[3] sequence reqTxnMiddle: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.234s
+[3] sequence reqTxnMiddle: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 123.000s
 [3] sequence reqTxnMiddle: pushing txn 00000001 to detect request deadlock
 [3] sequence reqTxnMiddle: blocked on select in concurrency_test.(*cluster).PushTransaction
 [4] sequence reqTxn2: resolving intent "k" for txn 00000002 with COMMITTED status
 [4] sequence reqTxn2: lock wait-queue event: wait self @ key "k"
-[4] sequence reqTxn2: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 1.234s
+[4] sequence reqTxn2: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 123.000s
 [4] sequence reqTxn2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 debug-lock-table
@@ -111,12 +114,12 @@ finish req=reqTxn1
 ----
 [-] finish reqTxn1: finishing request
 [3] sequence reqTxnMiddle: lock wait-queue event: done waiting
-[3] sequence reqTxnMiddle: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[3] sequence reqTxnMiddle: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 123.000s
 [3] sequence reqTxnMiddle: acquiring latches
 [3] sequence reqTxnMiddle: scanning lock table for conflicting locks
 [3] sequence reqTxnMiddle: sequencing complete, returned guard
 [4] sequence reqTxn2: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key "k" (queuedWriters: 1, queuedReaders: 0)
-[4] sequence reqTxn2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[4] sequence reqTxn2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 123.000s
 [4] sequence reqTxn2: pushing txn 00000003 to detect request deadlock
 [4] sequence reqTxn2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -124,7 +127,7 @@ finish req=reqTxnMiddle
 ----
 [-] finish reqTxnMiddle: finishing request
 [4] sequence reqTxn2: lock wait-queue event: done waiting
-[4] sequence reqTxn2: conflicted with 00000003-0000-0000-0000-000000000000 on "k" for 1.234s
+[4] sequence reqTxn2: conflicted with 00000003-0000-0000-0000-000000000000 on "k" for 123.000s
 [4] sequence reqTxn2: acquiring latches
 [4] sequence reqTxn2: scanning lock table for conflicting locks
 [4] sequence reqTxn2: sequencing complete, returned guard


### PR DESCRIPTION
Backport 1/1 commits from #77853.

/cc @cockroachdb/release

---

The recently introduced ContentionEventTracer theoretically permits
deadlocks occur, as discovered by the deadlock detector. This was
because the ContentionEventTracer holds its lock while calling into
the tracing Span (which takes the Span's lock) for emitting trace
events. But, if one collects the Span's recording, the Span also calls
into the ContentionEventTracer.Render, as the ContentionEventTracer is
registered as a span (lazy) tag.

This patch fixes this potential deadlock by restructuring the
ContentionEventTracer. Instead of the ContentionEventTracer acting as a
tracing tag directly, a new tag struct is introduced. The new struct
doesn't call into the span.

Because the span is no longer linked to a ContentionEventTracer, this
patch also lifts up the creation of the ContentionEventTracer. Before,
the CET was created under the lockTableWaiter, which checked to see if
the Span has a CET and, if not, creates one. The lockTableWaiter could
be called into several times for a request, and it was basically using
the Span as "thread-local storage" to remember this anicilarrry state
across calls. In retrospect, that was not nice to begin with, and
maintaining it would make it even uglier now.
This patch lifts the creation of the CET to the replica's request
evaluation, which is the proper scope.

This patch also mucks with the datadriven concurrency manager tests.
These tests were using a particular testing hook to brutally override
a timing-dependent duration in contention events in order to make the
test output deterministic. This patch switches to getting determinism
from the lockTable's manual clock. This is one less knob to use;
additionally, the deterministic test output was sometimes non-sensical
(requests with the no-wait policy appearing to have waited for some
duration on a lock). The test was already using a manual clock for some
things, but not for the lock table. This change caused the diffs to the
datadriven tests; for some of the tests, I went to the trouble of
advancing the clock here and there in order to demonstrate that the
contention events have the right duration in them. In other tests, I've
more simply re-written them to expect a zero duration.
In the process, I've made timeutil.ManualTime a bit more ergonomic, and
added a deprecation notice to hlc.ManualClock - timeutil.ManualTime
should now be strictly better.

Release note: None
Release justification: Bug fix for new code.

Fixes https://github.com/cockroachdb/cockroach/issues/77812
Fixes https://github.com/cockroachdb/cockroach/issues/77816
Fixes https://github.com/cockroachdb/cockroach/issues/77817
Fixes https://github.com/cockroachdb/cockroach/issues/77818
Fixes https://github.com/cockroachdb/cockroach/issues/77819
Fixes https://github.com/cockroachdb/cockroach/issues/77820
Fixes https://github.com/cockroachdb/cockroach/issues/77821
Fixes https://github.com/cockroachdb/cockroach/issues/77822
Fixed https://github.com/cockroachdb/cockroach/issues/77826
Fixed https://github.com/cockroachdb/cockroach/issues/77827
