### PR TITLE
sql: error on new cursor with same name as portal

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1544,6 +1544,12 @@ func (ns prepStmtNamespace) HasActivePortals() bool {
 	return len(ns.portals) > 0
 }
 
+// HasPortal returns true if there exists a given named portal in the session.
+func (ns prepStmtNamespace) HasPortal(s string) bool {
+	_, ok := ns.portals[s]
+	return ok
+}
+
 // MigratablePreparedStatements returns a mapping of all prepared statements.
 func (ns prepStmtNamespace) MigratablePreparedStatements() []sessiondatapb.MigratableSession_PreparedStatement {
 	ret := make([]sessiondatapb.MigratableSession_PreparedStatement, 0, len(ns.prepStmts))

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -520,3 +520,8 @@ func (ps *DummyPreparedStatementState) HasActivePortals() bool {
 func (ps *DummyPreparedStatementState) MigratablePreparedStatements() []sessiondatapb.MigratableSession_PreparedStatement {
 	return nil
 }
+
+// HasPortal is part of the tree.PreparedStatementState interface.
+func (ps *DummyPreparedStatementState) HasPortal(_ string) bool {
+	return false
+}

--- a/pkg/sql/pgwire/testdata/pgtest/portals
+++ b/pkg/sql/pgwire/testdata/pgtest/portals
@@ -1170,3 +1170,138 @@ ReadyForQuery
 ----
 {"Type":"ErrorResponse","Code":"34000"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Verify that it's not possible to DECLARE a cursor of the same name as an open
+# portal.
+send
+Parse {"Query": "BEGIN"}
+Bind
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"BEGIN"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+send
+Close {"ObjectType": "S", "Name": "s"}
+Close {"ObjectType": "P", "Name": "p"}
+Parse {"Name": "s", "Query": "SELECT 1"}
+Bind {"DestinationPortal": "p", "PreparedStatement": "s"}
+Parse {"Query": "DECLARE p CURSOR FOR SELECT 1"}
+Bind
+Execute
+Sync
+----
+
+until
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"CloseComplete"}
+{"Type":"CloseComplete"}
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ErrorResponse","Code":"42P03"}
+{"Type":"ReadyForQuery","TxStatus":"E"}
+
+send
+Parse {"Query": "ROLLBACK"}
+Bind
+Execute
+Parse {"Query": "BEGIN"}
+Bind
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"ROLLBACK"}
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"BEGIN"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+# Test that creating a portal that declares a cursor with the same name as the
+# portal fails with a "duplicate cursor" error.
+
+send
+Parse {"Query": "DECLARE fnord CURSOR FOR SELECT 1", "Name": "bloop"}
+Bind {"DestinationPortal": "fnord", "PreparedStatement": "bloop"}
+Execute {"Portal": "fnord"}
+Sync
+----
+
+until
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ErrorResponse","Code":"42P03"}
+{"Type":"ReadyForQuery","TxStatus":"E"}
+
+# Test the converse case: ensure that a portal cannot be created with the same
+# name as an open cursor.
+
+send
+Parse {"Query": "ROLLBACK"}
+Bind
+Execute
+Parse {"Query": "BEGIN"}
+Bind
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"ROLLBACK"}
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"BEGIN"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+send
+Parse {"Query": "DECLARE sqlcursor CURSOR FOR SELECT 1"}
+Bind
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"DECLARE CURSOR"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+send
+Parse {"Name": "blah", "Query": "SELECT 1"}
+Bind {"DestinationPortal": "sqlcursor", "PreparedStatement": "blah"}
+Execute {"Portal": "sqlcursor"}
+Sync
+----
+
+until
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ErrorResponse","Code":"42P03"}
+{"Type":"ReadyForQuery","TxStatus":"E"}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3392,8 +3392,12 @@ type EvalSessionAccessor interface {
 // PreparedStatementState is a limited interface that exposes metadata about
 // prepared statements.
 type PreparedStatementState interface {
+	// HasActivePortals returns true if there are portals in the session.
 	HasActivePortals() bool
+	// MigratablePreparedStatements returns a mapping of all prepared statements.
 	MigratablePreparedStatements() []sessiondatapb.MigratableSession_PreparedStatement
+	// HasPortal returns true if there exists a given named portal in the session.
+	HasPortal(s string) bool
 }
 
 // ClientNoticeSender is a limited interface to send notices to the

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -765,7 +765,7 @@ func (n *DeclareCursor) StatementReturnType() StatementReturnType { return Ack }
 func (*DeclareCursor) StatementType() StatementType { return TypeDCL }
 
 // StatementTag returns a short string identifying the type of statement.
-func (*DeclareCursor) StatementTag() string { return "DECLARE" }
+func (*DeclareCursor) StatementTag() string { return "DECLARE CURSOR" }
 
 // StatementReturnType implements the Statement interface.
 func (n *Delete) StatementReturnType() StatementReturnType { return n.Returning.statementReturnType() }

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -53,6 +53,10 @@ func (p *planner) DeclareCursor(ctx context.Context, s *tree.DeclareCursor) (pla
 				return nil, pgerror.Newf(pgcode.DuplicateCursor, "cursor %q already exists", cursorName)
 			}
 
+			if p.extendedEvalCtx.PreparedStatementState.HasPortal(cursorName) {
+				return nil, pgerror.Newf(pgcode.DuplicateCursor, "cursor %q already exists as portal", cursorName)
+			}
+
 			// Try to plan the cursor query to make sure that it's valid.
 			stmt := makeStatement(parser.Statement{AST: s.Select}, ClusterWideID{})
 			pt := planTop{}


### PR DESCRIPTION
To remain compliant with Postgres, it's important that SQL-level cursors
(DECLARE) and wire-protocol-level portals share a namespace. It's hard
for us to completely support this due to the way the cursors are
implemented. To prevent complete confusion, we at least prevent creation
of sql cursors with the same name as active portals, and prevent
creation of portals with the same name as active cursors.

Also, a minor change to rename the command tag for DECLARE to be DECLARE
CURSOR to line up with postgres exactly.

Release note: None (bugfix to non-released feature)
Release justification: low-risk bugfix to new feature