### PR TITLE
opt: add ContainedBy operator (<@) to FoldNullComparisonLeft norm rule

### DIFF
--- a/pkg/sql/opt/norm/rules/comp.opt
+++ b/pkg/sql/opt/norm/rules/comp.opt
@@ -98,8 +98,8 @@
 [FoldNullComparisonLeft, Normalize]
 (Eq | Ne | Ge | Gt | Le | Lt | Like | NotLike | ILike | NotILike
         | SimilarTo | NotSimilarTo | RegMatch | NotRegMatch
-        | RegIMatch | NotRegIMatch | Contains | Overlaps
-        | JsonExists | JsonSomeExists | JsonAllExists
+        | RegIMatch | NotRegIMatch | Contains | ContainedBy
+        | Overlaps | JsonExists | JsonSomeExists | JsonAllExists
     $left:(Null)
     *
 )

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -301,6 +301,7 @@ WHERE
     null::string !~* 'foo' OR 'foo' !~* null::string OR
     null::string[] && ARRAY['foo'] OR ARRAY['foo'] && null::string[] OR
     null::jsonb @> '"foo"' OR '"foo"' <@ null::jsonb OR
+    null::jsonb <@ '"foo"' OR '"foo"' @> null::jsonb OR
     null::jsonb ? 'foo' OR '{}' ? null::string OR
     null::jsonb ?| ARRAY['foo'] OR '{}' ?| null::string[] OR
     null::jsonb ?& ARRAY['foo'] OR '{}' ?& null::string[]


### PR DESCRIPTION
Fixes: #77745

When we originally made the ContainedBy operator (<@) distinct from the
Contains operator (@>) we forgot to add ContainedBy to the
FoldNullComparisonLeft normalization rule. It was only added to the
FoldNullComparisonRight rule. Correct this.

Release note (bug fix): fix an optimizer bug that prevented expressions
of the form (NULL::STRING[] <@ ARRAY['x']) from being folded to NULL.