### PR TITLE
cli: Disable multi-tenancy demo by default

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -613,7 +613,6 @@ func setDemoContextDefaults() {
 	demoCtx.SQLPort, _ = strconv.Atoi(base.DefaultPort)
 	demoCtx.HTTPPort, _ = strconv.Atoi(base.DefaultHTTPPort)
 	demoCtx.WorkloadMaxQPS = 25
-	demoCtx.Multitenant = true
 	demoCtx.DefaultEnableRangefeeds = true
 
 	demoCtx.disableEnterpriseFeatures = false

--- a/pkg/cli/interactive_tests/test_demo.tcl
+++ b/pkg/cli/interactive_tests/test_demo.tcl
@@ -3,7 +3,7 @@
 source [file join [file dirname $argv0] common.tcl]
 
 start_test "Check that demo insecure says hello properly"
-spawn $argv demo --insecure=true
+spawn $argv demo --insecure=true --multitenant=true
 # Be polite.
 eexpect "Welcome"
 # Warn the user that they won't get persistence.
@@ -43,7 +43,7 @@ start_test "Check that demo insecure says hello properly"
 
 # With env var.
 set ::env(COCKROACH_INSECURE) "true"
-spawn $argv demo --no-example-database
+spawn $argv demo --no-example-database --multitenant=true
 eexpect "Welcome"
 eexpect "defaultdb>"
 
@@ -98,7 +98,7 @@ start_test "Check that demo secure says hello properly"
 
 # With env var.
 set ::env(COCKROACH_INSECURE) "false"
-spawn $argv demo --no-example-database
+spawn $argv demo --no-example-database --multitenant=true
 eexpect "Welcome"
 eexpect "Username: \"demo\", password"
 eexpect "Directory with certificate files"
@@ -211,7 +211,7 @@ end_test
 
 start_test "Check that the port numbers can be overridden from the command line."
 
-spawn $argv demo --no-example-database --nodes 3 --http-port 8000
+spawn $argv demo --no-example-database --nodes 3 --http-port 8000 --multitenant=true
 eexpect "Welcome"
 eexpect "defaultdb>"
 
@@ -228,7 +228,7 @@ eexpect "defaultdb>"
 send_eof
 eexpect eof
 
-spawn $argv demo --no-example-database --nodes 3 --sql-port 23000
+spawn $argv demo --no-example-database --nodes 3 --sql-port 23000 --multitenant=true
 eexpect "Welcome"
 eexpect "defaultdb>"
 

--- a/pkg/cli/interactive_tests/test_demo_partitioning.tcl
+++ b/pkg/cli/interactive_tests/test_demo_partitioning.tcl
@@ -130,7 +130,7 @@ eexpect $prompt
 end_test
 
 start_test "Expect an error if geo-partitioning is requested with multitenant mode"
-send "$argv demo --geo-partitioned-replicas\r"
+send "$argv demo --geo-partitioned-replicas --multitenant=true\r"
 # expect a failure
 eexpect "operation is unsupported in multi-tenancy mode"
 eexpect $prompt


### PR DESCRIPTION
In #71988 we enabled multi-tenancy by default as a means to draw out
gaps when running in that mode. That effort was largely successful, and
identified several issues which are now on the MT team's backlog. Unfortunately
however, we weren't able to resolve all of these issues in time for the 22.1
release. As a result, we're now disabling multi-tenancy by default in 22.1. We
will try to enable it again on master once this change is backported so that we
can continue testing in this mode by default.

Release justification: Disabling functionality not yet ready for GA.

Release note (cli change): cockroach demo is reverted back to not run
multi-tenant mode by default.