### PR TITLE
optgen: teach GoLand how to comment out lines in optgen files

### DIFF
--- a/pkg/sql/opt/optgen/lang/support/textmate/OptGen.tmbundle/Preferences/comments.plist
+++ b/pkg/sql/opt/optgen/lang/support/textmate/OptGen.tmbundle/Preferences/comments.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Comments</string>
+	<key>scope</key>
+	<string>source.optgen</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string># </string>
+			</dict>
+		</array>
+	</dict>
+	<key>uuid</key>
+	<string>46F9A6F8-2E81-4BC0-B81F-D12750D89AA9</string>
+</dict>
+</plist>


### PR DESCRIPTION
The optgen textmate bundle, which currently provides syntax highlighting
support, now informs GoLand how to comment and uncomment lines in optgen
files. Highlighted lines can now be commented or uncommented with
`Code > Comment with Line Comment` or any hotkey associated with the
same action. When using the IdeaVim plugin with `set commentary` in
your `.ideavimrc`, `gc` and `gcc` can be used to comment and uncomment
lines, behaving exactly the same as they do for other source code files.

NOTE: You must restart GoLand in order for these changes to take affect.

Release justification: This change only affects development tooling.

Release note: None