### PR TITLE
sql/schemachanger: set non-cancelable property on jobs correctly

### DIFF
--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_multiregion
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_multiregion
@@ -367,7 +367,7 @@ upsert descriptor #108
   -  version: "1"
   +  version: "2"
 delete all comments for table descriptors [108]
-create job #1: "schema change job"
+create job #1 (non-cancelable: true): "schema change job"
   descriptor IDs: [105 107 108]
 # end PreCommitPhase
 commit transaction #1
@@ -710,10 +710,9 @@ upsert descriptor #108
   -  version: "2"
   +  version: "3"
 write *eventpb.DropTable to event log for descriptor #108: DROP TABLE ‹multi_region_test_db›.‹public›.‹table_regional_by_row›
-create job #2: "GC for dropping descriptor 108"
+create job #2 (non-cancelable: true): "GC for dropping descriptor 108"
   descriptor IDs: [108]
 update progress of schema change job #1
-set schema change job #1 to non-cancellable
 commit transaction #3
 # end PostCommitPhase
 
@@ -972,7 +971,7 @@ upsert descriptor #109
   -  version: "1"
   +  version: "2"
 delete all comments for table descriptors [109]
-create job #1: "schema change job"
+create job #1 (non-cancelable: true): "schema change job"
   descriptor IDs: [105 109]
 # end PreCommitPhase
 commit transaction #1
@@ -1209,10 +1208,9 @@ upsert descriptor #109
   -  version: "2"
   +  version: "3"
 write *eventpb.DropTable to event log for descriptor #109: DROP TABLE ‹multi_region_test_db›.‹public›.‹table_regional_by_table› CASCADE
-create job #2: "GC for dropping descriptor 109"
+create job #2 (non-cancelable: true): "GC for dropping descriptor 109"
   descriptor IDs: [109]
 update progress of schema change job #1
-set schema change job #1 to non-cancellable
 commit transaction #3
 # end PostCommitPhase
 
@@ -1660,7 +1658,7 @@ upsert descriptor #107
 delete comment for descriptor #104 of type DatabaseCommentType
 delete comment for descriptor #106 of type SchemaCommentType
 delete role settings for database on #104
-create job #1: "schema change job"
+create job #1 (non-cancelable: true): "schema change job"
   descriptor IDs: [104 105 106 107]
 # end PreCommitPhase
 commit transaction #1
@@ -1676,6 +1674,5 @@ delete descriptor #107
 deleting zone config for #104
 write *eventpb.DropDatabase to event log for descriptor #104: DROP DATABASE ‹multi_region_test_db› CASCADE
 update progress of schema change job #1
-set schema change job #1 to non-cancellable
 commit transaction #3
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/scbackup/job.go
+++ b/pkg/sql/schemachanger/scbackup/job.go
@@ -54,7 +54,6 @@ func CreateDeclarativeSchemaChangeJobs(
 			ds.JobID = newID
 			descriptorStates = append(descriptorStates, ds)
 		}
-		// TODO(ajwerner): Deal with rollback and revertibility.
 		currentState, err := scpb.MakeCurrentStateFromDescriptors(
 			descriptorStates,
 		)
@@ -64,6 +63,7 @@ func CreateDeclarativeSchemaChangeJobs(
 		records = append(records, scexec.MakeDeclarativeSchemaChangeJobRecord(
 			newID,
 			currentState.Statements,
+			!currentState.Revertible, // NonCancelable
 			currentState.Authorization,
 			screl.AllTargetDescIDs(currentState.TargetState).Ordered(),
 		))

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -741,8 +741,9 @@ func (s *TestState) CreateJob(ctx context.Context, record jobs.Record) error {
 	}
 	record.JobID = jobspb.JobID(1 + len(s.jobs))
 	s.jobs = append(s.jobs, record)
-	s.LogSideEffectf("create job #%d: %q\n  descriptor IDs: %v",
+	s.LogSideEffectf("create job #%d (non-cancelable: %v): %q\n  descriptor IDs: %v",
 		record.JobID,
+		record.NonCancelable,
 		record.Description,
 		record.DescriptorIDs,
 	)

--- a/pkg/sql/schemachanger/scexec/scmutationexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/dependencies.go
@@ -98,7 +98,7 @@ type MutationVisitorStateUpdater interface {
 	AddNewGCJobForIndex(tbl catalog.TableDescriptor, index catalog.Index)
 
 	// AddNewSchemaChangerJob adds a schema changer job.
-	AddNewSchemaChangerJob(jobID jobspb.JobID, stmts []scpb.Statement, auth scpb.Authorization, descriptors descpb.IDs) error
+	AddNewSchemaChangerJob(jobID jobspb.JobID, stmts []scpb.Statement, isNonCancelable bool, auth scpb.Authorization, descriptors descpb.IDs) error
 
 	// UpdateSchemaChangerJob will update the progress and payload of the
 	// schema changer job.

--- a/pkg/sql/schemachanger/scexec/scmutationexec/schema_change_job.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/schema_change_job.go
@@ -22,7 +22,9 @@ import (
 func (m *visitor) CreateSchemaChangerJob(
 	ctx context.Context, job scop.CreateSchemaChangerJob,
 ) error {
-	return m.s.AddNewSchemaChangerJob(job.JobID, job.Statements, job.Authorization, job.DescriptorIDs)
+	return m.s.AddNewSchemaChangerJob(
+		job.JobID, job.Statements, job.NonCancelable, job.Authorization, job.DescriptorIDs,
+	)
 }
 
 func (m *visitor) UpdateSchemaChangerJob(

--- a/pkg/sql/schemachanger/scop/mutation.go
+++ b/pkg/sql/schemachanger/scop/mutation.go
@@ -403,6 +403,10 @@ type CreateSchemaChangerJob struct {
 	Authorization scpb.Authorization
 	Statements    []scpb.Statement
 	DescriptorIDs []descpb.ID
+
+	// NonCancelable maps to the job's property, but in the schema changer can
+	// be thought of as !Revertible.
+	NonCancelable bool
 }
 
 // RemoveAllTableComments is used to delete all comments associated with a

--- a/pkg/sql/schemachanger/scpb/scpb.proto
+++ b/pkg/sql/schemachanger/scpb/scpb.proto
@@ -116,15 +116,6 @@ message DescriptorState {
   // Note, if this value is true, the targets have had their directions
   // flipped already.
   //
-  // TODO(ajwerner): Should we capture the error with which the job
-  // failed for a higher-fidelity restore?
-  //
-  // TODO(ajwerner): Do we need to track this state? In principle the
-  // answer seems like yes, and the reason is that if we've rolled back
-  // and have had the direction of the targets flipped, then we won't
-  // be able to know that and we might try to revert the revert, which
-  // would be confusing.
-  //
   bool in_rollback = 8;
 
   // Targets is the set of targets in the schema change belonging to this

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table
@@ -155,6 +155,7 @@ PostCommitPhase stage 4 of 4 with 10 MutationType ops
     *scop.SetJobStateOnDescriptor
       DescriptorID: 106
     *scop.UpdateSchemaChangerJob
+      IsNonCancelable: true
       JobID: 1
 PostCommitNonRevertiblePhase stage 1 of 2 with 5 MutationType ops
   transitions:
@@ -327,6 +328,7 @@ PostCommitPhase stage 4 of 4 with 8 MutationType ops
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
     *scop.UpdateSchemaChangerJob
+      IsNonCancelable: true
       JobID: 1
 PostCommitNonRevertiblePhase stage 1 of 2 with 3 MutationType ops
   transitions:
@@ -545,6 +547,7 @@ PostCommitPhase stage 4 of 4 with 10 MutationType ops
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
     *scop.UpdateSchemaChangerJob
+      IsNonCancelable: true
       JobID: 1
 PostCommitNonRevertiblePhase stage 1 of 2 with 3 MutationType ops
   transitions:
@@ -703,6 +706,7 @@ PostCommitPhase stage 4 of 4 with 8 MutationType ops
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
     *scop.UpdateSchemaChangerJob
+      IsNonCancelable: true
       JobID: 1
 PostCommitNonRevertiblePhase stage 1 of 2 with 3 MutationType ops
   transitions:
@@ -962,6 +966,7 @@ PostCommitPhase stage 4 of 4 with 15 MutationType ops
     *scop.SetJobStateOnDescriptor
       DescriptorID: 107
     *scop.UpdateSchemaChangerJob
+      IsNonCancelable: true
       JobID: 1
 PostCommitNonRevertiblePhase stage 1 of 2 with 5 MutationType ops
   transitions:

--- a/pkg/sql/schemachanger/scplan/testdata/create_index
+++ b/pkg/sql/schemachanger/scplan/testdata/create_index
@@ -79,6 +79,7 @@ PostCommitPhase stage 4 of 4 with 4 MutationType ops
       DescriptorID: 104
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      IsNonCancelable: true
       JobID: 1
 
 deps
@@ -173,6 +174,7 @@ PostCommitPhase stage 4 of 4 with 4 MutationType ops
       DescriptorID: 104
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      IsNonCancelable: true
       JobID: 1
 
 deps

--- a/pkg/sql/schemachanger/scplan/testdata/drop_database
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_database
@@ -574,6 +574,7 @@ PreCommitPhase stage 1 of 1 with 84 MutationType ops
       - 116
       - 117
       JobID: 1
+      NonCancelable: true
       Statements:
       - statement: DROP DATABASE db1 CASCADE
         redactedstatement: DROP DATABASE ‹db1› CASCADE

--- a/pkg/sql/schemachanger/scplan/testdata/drop_schema
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_schema
@@ -1289,6 +1289,7 @@ PreCommitPhase stage 1 of 1 with 62 MutationType ops
       - 112
       - 113
       JobID: 1
+      NonCancelable: true
       Statements:
       - statement: DROP SCHEMA defaultdb.sc1 CASCADE
         redactedstatement: DROP SCHEMA ‹defaultdb›.‹sc1› CASCADE

--- a/pkg/sql/schemachanger/scplan/testdata/drop_sequence
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_sequence
@@ -41,6 +41,7 @@ PreCommitPhase stage 1 of 1 with 5 MutationType ops
       DescriptorIDs:
       - 104
       JobID: 1
+      NonCancelable: true
       Statements:
       - statement: DROP SEQUENCE defaultdb.sq1
         redactedstatement: DROP SEQUENCE ‹defaultdb›.public.‹sq1›
@@ -143,6 +144,7 @@ PreCommitPhase stage 1 of 1 with 11 MutationType ops
       - 105
       - 106
       JobID: 1
+      NonCancelable: true
       Statements:
       - statement: DROP SEQUENCE defaultdb.sq1 CASCADE
         redactedstatement: DROP SEQUENCE ‹defaultdb›.public.‹sq1› CASCADE

--- a/pkg/sql/schemachanger/scplan/testdata/drop_table
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_table
@@ -233,6 +233,7 @@ PreCommitPhase stage 1 of 1 with 33 MutationType ops
       - 108
       - 109
       JobID: 1
+      NonCancelable: true
       Statements:
       - statement: DROP TABLE defaultdb.shipments CASCADE
         redactedstatement: DROP TABLE ‹defaultdb›.public.‹shipments› CASCADE
@@ -892,6 +893,7 @@ PreCommitPhase stage 1 of 1 with 18 MutationType ops
       - 111
       - 112
       JobID: 1
+      NonCancelable: true
       Statements:
       - statement: DROP TABLE defaultdb.greeter
         redactedstatement: DROP TABLE ‹defaultdb›.public.‹greeter›

--- a/pkg/sql/schemachanger/scplan/testdata/drop_type
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_type
@@ -60,6 +60,7 @@ PreCommitPhase stage 1 of 1 with 7 MutationType ops
       - 104
       - 105
       JobID: 1
+      NonCancelable: true
       Statements:
       - statement: DROP TYPE defaultdb.typ
         redactedstatement: DROP TYPE ‹defaultdb›.‹public›.‹typ›

--- a/pkg/sql/schemachanger/scplan/testdata/drop_view
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_view
@@ -60,6 +60,7 @@ PreCommitPhase stage 1 of 1 with 8 MutationType ops
       - 104
       - 105
       JobID: 1
+      NonCancelable: true
       Statements:
       - statement: DROP VIEW defaultdb.v1
         redactedstatement: DROP VIEW ‹defaultdb›.public.‹v1›
@@ -433,6 +434,7 @@ PreCommitPhase stage 1 of 1 with 40 MutationType ops
       - 110
       - 111
       JobID: 1
+      NonCancelable: true
       Statements:
       - statement: DROP VIEW defaultdb.v1 CASCADE
         redactedstatement: DROP VIEW ‹defaultdb›.public.‹v1› CASCADE

--- a/pkg/sql/schemachanger/scrun/BUILD.bazel
+++ b/pkg/sql/schemachanger/scrun/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scrun",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/roachpb",
         "//pkg/settings/cluster",

--- a/pkg/sql/schemachanger/scrun/scrun.go
+++ b/pkg/sql/schemachanger/scrun/scrun.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -204,9 +205,11 @@ func makeState(
 		return scpb.CurrentState{}, err
 	}
 	if !rollback && state.InRollback {
-		return scpb.CurrentState{}, errors.Errorf(
+		// If we do not mark the error as permanent, but we've configured the job to
+		// be non-cancelable, we'll never make it to the reverting state.
+		return scpb.CurrentState{}, jobs.MarkAsPermanentJobError(errors.Errorf(
 			"job in running state but schema change in rollback, " +
-				"returning an error to restart in the reverting state")
+				"returning an error to restart in the reverting state"))
 	}
 	if rollback && !state.InRollback {
 		state.Rollback()

--- a/pkg/sql/schemachanger/testdata/alter_table_add_column
+++ b/pkg/sql/schemachanger/testdata/alter_table_add_column
@@ -40,6 +40,7 @@ upsert descriptor #106
   +          NULL DEFAULT ‹42›
   +        statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT NULL DEFAULT 42
   +        statementTag: ALTER TABLE
+  +    revertible: true
   +    targetRanks:
   +    - 0
   +    - 1
@@ -204,7 +205,7 @@ upsert descriptor #106
   -  version: "1"
   +  version: "2"
 write *eventpb.AlterTable to event log for descriptor #106: ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL DEFAULT ‹42›
-create job #1: "schema change job"
+create job #1 (non-cancelable: false): "schema change job"
   descriptor IDs: [106]
 # end PreCommitPhase
 commit transaction #1
@@ -288,6 +289,12 @@ upsert descriptor #106
        jobId: "1"
        relevantStatements:
   ...
+           statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT NULL DEFAULT 42
+           statementTag: ALTER TABLE
+  -    revertible: true
+       targetRanks:
+       - 0
+  ...
        columnNames:
        - i
   -    - crdb_internal_column_2_name_placeholder
@@ -364,6 +371,7 @@ upsert descriptor #106
   -  version: "3"
   +  version: "4"
 update progress of schema change job #1
+set schema change job #1 to non-cancellable
 commit transaction #6
 begin transaction #7
 ## PostCommitNonRevertiblePhase stage 1 of 2 with 3 MutationType ops
@@ -388,7 +396,6 @@ upsert descriptor #106
   -  version: "4"
   +  version: "5"
 update progress of schema change job #1
-set schema change job #1 to non-cancellable
 commit transaction #7
 begin transaction #8
 ## PostCommitNonRevertiblePhase stage 2 of 2 with 4 MutationType ops
@@ -549,7 +556,7 @@ upsert descriptor #106
      unexposedParentSchemaId: 105
   -  version: "5"
   +  version: "6"
-create job #2: "GC for dropping table 106 index 1"
+create job #2 (non-cancelable: true): "GC for dropping table 106 index 1"
   descriptor IDs: [106]
 update progress of schema change job #1
 commit transaction #8

--- a/pkg/sql/schemachanger/testdata/drop
+++ b/pkg/sql/schemachanger/testdata/drop
@@ -138,7 +138,7 @@ upsert descriptor #106
   +  state: DROP
   +  version: "2"
 delete comment for descriptor #106 of type SchemaCommentType
-create job #1: "schema change job"
+create job #1 (non-cancelable: true): "schema change job"
   descriptor IDs: [104 106]
 # end PreCommitPhase
 commit transaction #1
@@ -162,7 +162,6 @@ upsert descriptor #104
 delete descriptor #106
 write *eventpb.DropSchema to event log for descriptor #106: DROP SCHEMA ‹db›.‹sc›
 update progress of schema change job #1
-set schema change job #1 to non-cancellable
 commit transaction #3
 # end PostCommitPhase
 
@@ -507,7 +506,7 @@ upsert descriptor #108
   -  version: "1"
   +  version: "2"
 delete all comments for table descriptors [108]
-create job #1: "schema change job"
+create job #1 (non-cancelable: true): "schema change job"
   descriptor IDs: [108]
 # end PreCommitPhase
 commit transaction #1
@@ -831,10 +830,9 @@ upsert descriptor #108
   -  version: "2"
   +  version: "3"
 write *eventpb.DropTable to event log for descriptor #108: DROP TABLE ‹db›.‹sc›.‹t›
-create job #2: "GC for dropping descriptor 108"
+create job #2 (non-cancelable: true): "GC for dropping descriptor 108"
   descriptor IDs: [108]
 update progress of schema change job #1
-set schema change job #1 to non-cancellable
 commit transaction #3
 # end PostCommitPhase
 
@@ -1178,7 +1176,7 @@ upsert descriptor #110
   +  state: DROP
   +  version: "2"
 delete comment for descriptor #107 of type SchemaCommentType
-create job #1: "schema change job"
+create job #1 (non-cancelable: true): "schema change job"
   descriptor IDs: [104 107 109 110]
 # end PreCommitPhase
 commit transaction #1
@@ -1204,7 +1202,6 @@ delete descriptor #109
 delete descriptor #110
 write *eventpb.DropSchema to event log for descriptor #107: DROP SCHEMA ‹db›.‹sc› CASCADE
 update progress of schema change job #1
-set schema change job #1 to non-cancellable
 commit transaction #3
 # end PostCommitPhase
 
@@ -1432,7 +1429,7 @@ upsert descriptor #105
 delete comment for descriptor #104 of type DatabaseCommentType
 delete comment for descriptor #105 of type SchemaCommentType
 delete role settings for database on #104
-create job #1: "schema change job"
+create job #1 (non-cancelable: true): "schema change job"
   descriptor IDs: [104 105]
 # end PreCommitPhase
 commit transaction #1
@@ -1446,7 +1443,6 @@ delete descriptor #105
 deleting zone config for #104
 write *eventpb.DropDatabase to event log for descriptor #104: DROP DATABASE ‹db› CASCADE
 update progress of schema change job #1
-set schema change job #1 to non-cancellable
 commit transaction #3
 # end PostCommitPhase
 
@@ -4231,7 +4227,7 @@ delete comment for descriptor #112 of type SchemaCommentType
 delete comment for descriptor #113 of type SchemaCommentType
 delete all comments for table descriptors [114 115 116 117 118 119 120 121 122 125]
 delete role settings for database on #111
-create job #1: "schema change job"
+create job #1 (non-cancelable: true): "schema change job"
   descriptor IDs: [111 112 113 114 115 116 117 118 119 120 121 122 123 124 125]
 # end PreCommitPhase
 commit transaction #1
@@ -6420,9 +6416,8 @@ delete descriptor #123
 delete descriptor #124
 write *eventpb.DropDatabase to event log for descriptor #111: DROP DATABASE ‹db1› CASCADE
 delete scheduleId: <redacted>
-create job #2: "GC for dropping descriptors 111 114 115 116 117 118 119 120 121 122 125"
+create job #2 (non-cancelable: true): "GC for dropping descriptors 111 114 115 116 117 118 119 120 121 122 125"
   descriptor IDs: [114 115 119 120 121 122 125 117 118 116]
 update progress of schema change job #1
-set schema change job #1 to non-cancellable
 commit transaction #3
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/index
+++ b/pkg/sql/schemachanger/testdata/index
@@ -28,6 +28,7 @@ upsert descriptor #104
   +        redactedStatement: CREATE INDEX ‹idx1› ON ‹defaultdb›.‹public›.‹t› (‹v›)
   +        statement: CREATE INDEX idx1 ON t (v)
   +        statementTag: CREATE INDEX
+  +    revertible: true
   +    targetRanks:
   +    - 0
   +    - 1
@@ -100,7 +101,7 @@ upsert descriptor #104
      unexposedParentSchemaId: 101
   -  version: "1"
   +  version: "2"
-create job #1: "schema change job"
+create job #1 (non-cancelable: false): "schema change job"
   descriptor IDs: [104]
 # end PreCommitPhase
 commit transaction #1
@@ -156,6 +157,7 @@ upsert descriptor #104
   -        redactedStatement: CREATE INDEX ‹idx1› ON ‹defaultdb›.‹public›.‹t› (‹v›)
   -        statement: CREATE INDEX idx1 ON t (v)
   -        statementTag: CREATE INDEX
+  -    revertible: true
   -    targetRanks:
   -    - 0
   -    - 1
@@ -243,5 +245,6 @@ upsert descriptor #104
   -  version: "3"
   +  version: "4"
 update progress of schema change job #1
+set schema change job #1 to non-cancellable
 commit transaction #6
 # end PostCommitPhase


### PR DESCRIPTION
This PR sets the non-cancelability of jobs at the correct moment so that
there is not a phase where the job is cancelable but the state implies that
the job should not be reverted. It also propagates this state correctly to
descriptors so that it can be correctly synthesized during a restore.

Backport will address #76441.

Release note: None