### PR TITLE
sql/schemachanger/screl: various optimizations

### DIFF
--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -432,7 +432,7 @@ func (b *builderState) BackReferences(id catid.DescID) scbuildstmt.ElementResult
 			if ids.Contains(descID) || descID == id {
 				continue
 			}
-			if !screl.AllDescIDs(es.element).Contains(id) {
+			if !screl.ContainsDescID(es.element, id) {
 				continue
 			}
 			ids.Add(descID)

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -153,7 +153,7 @@ func dropCascadeDescriptor(b BuildCtx, id catid.DescID) {
 
 func undroppedBackrefs(b BuildCtx, id catid.DescID) ElementResultSet {
 	return b.BackReferences(id).Filter(func(_ scpb.Status, target scpb.TargetStatus, e scpb.Element) bool {
-		return target != scpb.ToAbsent && screl.AllDescIDs(e).Contains(id)
+		return target != scpb.ToAbsent && screl.ContainsDescID(e, id)
 	})
 }
 

--- a/pkg/sql/schemachanger/screl/BUILD.bazel
+++ b/pkg/sql/schemachanger/screl/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/sql/sem/catid",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "//pkg/util/iterutil",
         "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
@@ -46,6 +47,7 @@ go_test(
         "//pkg/sql/schemachanger/scpb",
         "//pkg/sql/sem/catid",
         "//pkg/sql/types",
+        "//pkg/util/iterutil",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/schemachanger/screl/scalars_test.go
+++ b/pkg/sql/schemachanger/screl/scalars_test.go
@@ -11,13 +11,14 @@
 package screl
 
 import (
+	"math"
 	"reflect"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	types "github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,7 +32,7 @@ func TestAllElementsHaveDescID(t *testing.T) {
 	}
 }
 
-func TestAllDescIDs(t *testing.T) {
+func TestAllDescIDsAndContainsDescID(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		input    scpb.Element
@@ -90,6 +91,11 @@ func TestAllDescIDs(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			require.ElementsMatch(t, tc.expected, AllDescIDs(tc.input).Ordered())
+			for _, id := range tc.expected {
+				require.Truef(t, ContainsDescID(tc.input, id), "contains %d", id)
+			}
+			require.False(t, ContainsDescID(tc.input, 0))
+			require.False(t, ContainsDescID(tc.input, math.MaxUint32))
 		})
 	}
 }

--- a/pkg/sql/schemachanger/screl/walk.go
+++ b/pkg/sql/schemachanger/screl/walk.go
@@ -102,9 +102,11 @@ func walk(wantType reflect.Type, toWalk interface{}, f func(interface{}) error) 
 			}
 		case reflect.Struct:
 			for i := 0; i < value.NumField(); i++ {
-				if f := value.Field(i); f.CanAddr() && value.Type().Field(i).IsExported() {
-					walk(f.Addr().Elem())
+				f := value.Field(i)
+				if !f.CanAddr() || !fieldIsExported(value.Type(), i) {
+					continue
 				}
+				walk(value.Field(i).Addr().Elem())
 			}
 		case reflect.Bool, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
 			reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
@@ -123,3 +125,22 @@ func walk(wantType reflect.Type, toWalk interface{}, f func(interface{}) error) 
 	walk(v.Elem())
 	return nil
 }
+
+// fieldIsExported caches whether a field is exported as an optimization to avoid
+// allocations due to (*reflect.Type).Field() calls.
+func fieldIsExported(typ reflect.Type, field int) bool {
+	k := fieldExportedCacheKey{typ: typ, field: field}
+	if exported, ok := fieldExportedCache[k]; ok {
+		return exported
+	}
+	exported := typ.Field(field).IsExported()
+	fieldExportedCache[k] = exported
+	return exported
+}
+
+type fieldExportedCacheKey struct {
+	typ   reflect.Type
+	field int
+}
+
+var fieldExportedCache = map[fieldExportedCacheKey]bool{}

--- a/pkg/sql/schemachanger/screl/walk.go
+++ b/pkg/sql/schemachanger/screl/walk.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	types "github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -58,6 +59,9 @@ func walk(wantType reflect.Type, toWalk interface{}, f func(interface{}) error) 
 			err = r
 		default:
 			err = errors.AssertionFailedf("failed to do walk: %v", r)
+		}
+		if iterutil.Done(err) {
+			err = nil
 		}
 	}()
 


### PR DESCRIPTION
See individual commits. This avoid allocations in hot paths.

Release note: None