### PR TITLE
sql: Deduplication logic for `ALTER PRIMARY KEY`

### DIFF
--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -638,6 +638,7 @@ func (p *planner) shouldCreateIndexes(
 // * The new primary key isn't the same set of columns and directions
 //   other than hash sharding.
 // * There is no partitioning change.
+// * There is no existing secondary index on the old primary key columns.
 func shouldCopyPrimaryKey(
 	desc *tabledesc.Mutable,
 	newPK *descpb.IndexDescriptor,
@@ -669,11 +670,44 @@ func shouldCopyPrimaryKey(
 		}
 		return true
 	}
+	alreadyHasSecondaryIndexOnPKColumns := func(desc catalog.TableDescriptor) bool {
+		// Return true if there exists a secondary index that is "identical" to desc's PK index. This function
+		// is used to avoid creating duplicate secondary index during `ALTER PRIMARY KEY`.
+
+		// Two indexes are considered "identical" if they have the same
+		// uniqueness AND partiallness AND same key columns in same order with same direction
+		isIdentical := func(idx1, idx2 catalog.Index) bool {
+			if idx1.IsUnique() != idx2.IsUnique() ||
+				idx1.IsPartial() != idx2.IsPartial() ||
+				idx1.NumKeyColumns() != idx2.NumKeyColumns() ||
+				(idx1.IsPartial() && idx1.GetPredicate() != idx2.GetPredicate()) {
+				return false
+			}
+
+			for i := 0; i < idx1.NumKeyColumns(); i++ {
+				if idx1.GetKeyColumnID(i) != idx2.GetKeyColumnID(i) ||
+					idx1.GetKeyColumnDirection(i) != idx2.GetKeyColumnDirection(i) {
+					return false
+				}
+			}
+
+			return true
+		}
+
+		pk := desc.GetPrimaryIndex()
+		for _, idx := range desc.PublicNonPrimaryIndexes() {
+			if isIdentical(pk, idx) {
+				return true
+			}
+		}
+		return false
+	}
 	oldPK := desc.GetPrimaryIndex().IndexDesc()
 	return alterPrimaryKeyLocalitySwap == nil &&
 		desc.HasPrimaryKey() &&
 		!desc.IsPrimaryIndexDefaultRowID() &&
-		!idsAndDirsMatch(oldPK, newPK)
+		!idsAndDirsMatch(oldPK, newPK) &&
+		!alreadyHasSecondaryIndexOnPKColumns(desc)
 }
 
 // addIndexMutationWithSpecificPrimaryKey adds an index mutation into the given

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1585,3 +1585,51 @@ SELECT substring(@2, strpos(@2, 'COMMENT')) FROM [SHOW CREATE pkey_comment];
 COMMENT ON INDEX public.pkey_comment@i2 IS 'idx2';
 COMMENT ON CONSTRAINT pkey_comment_a_b_key ON public.pkey_comment IS 'const';
 COMMENT ON CONSTRAINT i2 ON public.pkey_comment IS 'idx3'
+
+subtest test-index-deduplication
+
+# Regression for #78046: `ALTER PRIMARY KEY` should not create a secondary
+# index on the (old) primary key columns when there is already a secondary
+# index thereof.
+statement ok
+DROP TABLE IF EXISTS t;
+
+statement ok
+CREATE TABLE t (a INT PRIMARY KEY, b INT NOT NULL, UNIQUE INDEX t_a_key (a));
+
+statement ok
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (b);
+
+query TTT
+SELECT index_name, column_name, direction FROM [SHOW INDEXES FROM t]
+----
+t_pkey   b  ASC
+t_pkey   a  N/A
+t_a_key  a  ASC
+t_a_key  b  ASC
+
+# But if the existing index is not strictly equal to the (old) primary key
+# (even if, for example, the (old) primary key is a strict prefix of an
+# existing index), a secondary index on the (old) PK columns will still be
+# created.
+statement ok
+DROP TABLE IF EXISTS t;
+
+statement ok
+CREATE TABLE t (a INT PRIMARY KEY, b INT NOT NULL, UNIQUE INDEX t_a_b_key (a, b));
+
+statement ok
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (b);
+
+# Note that index `t_a_b_key` and `t_a_key` shall not be deemed as identical
+# even if they both have columns (a, b) in the sense that one enforces uniqueness
+# on only (a) but the other on (a, b).
+query TTTB
+SELECT index_name, column_name, direction, storing FROM [SHOW INDEXES FROM t]
+----
+t_pkey     b  ASC  false
+t_pkey     a  N/A  true
+t_a_b_key  a  ASC  false
+t_a_b_key  b  ASC  false
+t_a_key    a  ASC  false
+t_a_key    b  ASC  true


### PR DESCRIPTION
When we use `ALTER PRIMARY KEY` to change the primary key of a table, a new
secondary index on the old primary key columns will be created. 
This PR added deduplication logic for `ALTER PRIMARY KEY` if there exists a unique,
non-partial secondary index that has the same columns as the (old) PK columns in
the same order with same direction.

Release note (sql change): `ALTER PRIMARY KEY` will not create a seconday index on 
the old PK columns if there is already a unique, non-partial secondary index that is
"identical" to the (old) PK columns. Two indexes are "identical" if they have exactly
the same columns, in the same order, with same direction.

Fixes: #74116

Jira issue: CRDB-14766