### PR TITLE
ui: fix broken links to statement details

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
@@ -66,9 +66,6 @@ import {
   StatisticTableColumnKeys,
 } from "../statsTableUtil/statsTableUtil";
 import { TableStatistics } from "../tableStatistics";
-import * as protos from "@cockroachlabs/crdb-protobuf-client";
-
-type ISessionsResponse = protos.cockroach.server.serverpb.IListSessionsResponse;
 
 const statementsPageCx = classNames.bind(statementsPageStyles);
 const sessionsPageCx = classNames.bind(sessionPageStyles);

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.module.scss
@@ -25,9 +25,7 @@
 
 .cl-table__col-query-text {
   font-family: $font-family--monospace;
-  font-size: 12px;
-  display: inline-block;
-  max-width: 400px;
+  font-size: $font-size--medium;
   div {
     font-size: $font-size--small;
     @include line-clamp(2);

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
@@ -90,18 +90,9 @@ const StatementTableCell = (props: { session: ISession }) => {
   const stmtSummary = session.active_queries[0].sql_summary;
   const stmtCellText = computeOrUseStmtSummary(sql, stmtSummary);
   return (
-    <Link
-      to={StatementLinkTarget({
-        statementFingerprintID: stmt.id,
-        statementNoConstants: stmt.sql_no_constants,
-        implicitTxn: session.active_txn?.implicit,
-        appNames: [session.application_name],
-      })}
-    >
-      <Tooltip placement="bottom" style="tableTitle" content={<>{sql}</>}>
-        <div className={cx("cl-table__col-query-text")}>{stmtCellText}</div>
-      </Tooltip>
-    </Link>
+    <Tooltip placement="bottom" style="tableTitle" content={<>{sql}</>}>
+      <div className={cx("cl-table__col-query-text")}>{stmtCellText}</div>
+    </Tooltip>
   );
 };
 

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/statementDiagnosticsHistory/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/statementDiagnosticsHistory/index.tsx
@@ -115,9 +115,13 @@ class StatementDiagnosticsHistoryView extends React.Component<
           return <StatementColumn fingerprint={fingerprint} />;
         }
 
+        const base = `/statement/${implicitTxn}`;
+        const statementFingerprintID = statement.id.toString();
+        const path = `${base}/${encodeURIComponent(statementFingerprintID)}`;
+
         return (
           <Link
-            to={`/statement/${implicitTxn}/${encodeURIComponent(query)}`}
+            to={path}
             className="crl-statements-diagnostics-view__statements-link"
           >
             <StatementColumn fingerprint={fingerprint} />


### PR DESCRIPTION
Previously the statement links on Advanced Debug
and Sessions page that would open the Statement Details page
were crashing.
This commits fixes the correcy path on the Advanced Debug
link and removes the link on the Sessions page, since that
one would not make sense for active queries. In the future
we can add link for past queries.
This commits also fixes the position of the Statement
on the Sessions table.

Fixes #77978

Previous alignment
<img width="836" alt="Screen Shot 2022-03-17 at 5 18 11 PM" src="https://user-images.githubusercontent.com/1017486/158897680-9c77db56-f16e-4157-b051-97338bc5674b.png">


Fixed alignment
<img width="993" alt="Screen Shot 2022-03-17 at 5 13 54 PM" src="https://user-images.githubusercontent.com/1017486/158897703-55310df1-5b52-4856-94f7-6d30d81acdae.png">


Release note (bug fix): Fix broken links to Statement Details
page on Advanced Debug and Sessions page.