### PR TITLE
release-21.1: ts: include histogram quantiles in tsdump

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -361,6 +361,7 @@ go_test(
         "@com_github_grpc_ecosystem_grpc_gateway//runtime:go_default_library",
         "@com_github_kr_pretty//:pretty",
         "@com_github_lib_pq//:pq",
+        "@com_github_prometheus_client_model//go",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//:go_default_library",

--- a/pkg/ts/server.go
+++ b/pkg/ts/server.go
@@ -337,7 +337,7 @@ func dumpImpl(
 ) error {
 	names := req.Names
 	if len(names) == 0 {
-		names = catalog.AllMetricsNames()
+		names = catalog.AllInternalTimeseriesMetricNames()
 	}
 	resolutions := req.Resolutions
 	if len(resolutions) == 0 {


### PR DESCRIPTION
Backport 1/1 commits from #69469.

/cc @cockroachdb/release

---

`cockroach debug tsdump` previously silently did not return metrics
backed by histograms. This is for technical reasons related to the
bookkeeping of metrics names and is rectified here by requiring some
extra tagging of metrics that are histograms so that they can be picked
up by tsdump. It's not pretty, but pragmatic: it works and it'll be
clear to anyone adding a histogram in the future how to proceed, even if
they may wonder why things work in such a roundabout manner (and if
they're curious about that, the relevant issues are linked in comments
as well).

I also renamed AllMetricsNames to AllInternalTimeseriesMetricsNames
to make clear what is being returned.

Demo:

```
killall -9 cockroach; rm -rf cockroach-data;
./cockroach start-single-node --insecure --background && \
./cockroach workload run kv --init \
    'postgres://root@127.0.0.1:26257?sslmode=disable' --duration=300s && \
./cockroach debug tsdump --format=raw --insecure > tsdump.gob && \
killall -9 cockroach && rm -rf cockroach-data && \
COCKROACH_DEBUG_TS_IMPORT_FILE=tsdump.gob ./cockroach start-single-node --insecure
```

![image](https://user-images.githubusercontent.com/5076964/131134624-b5471621-d23b-4ce7-9026-e8aeb3613231.png)

Release justification: low-risk observability fix
Release note (ops change): The ./cockroach debug tsdump command now
downloads histogram timeseries it silently omitted previously.
