### PR TITLE
colexecjoin: clarify the cross joiner a bit

### DIFF
--- a/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
@@ -14091,8 +14091,6 @@ func (o *mergeJoinExceptAllOp) buildFromBufferedGroup() (bufferedGroupComplete b
 			bg.helper.buildFromLeftInput(o.Ctx, o.builderState.outCount)
 		}
 		o.builderState.outCount += willEmit
-		bg.helper.builderState.numEmittedCurLeftBatch += willEmit
-		bg.helper.builderState.numEmittedTotal += willEmit
 		if o.builderState.outCount == o.outputCapacity {
 			return false
 		}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
@@ -15260,7 +15260,6 @@ func (o *mergeJoinFullOuterOp) buildFromBufferedGroup() (bufferedGroupComplete b
 		}
 		o.builderState.outCount += willEmit
 		bg.helper.builderState.numEmittedCurLeftBatch += willEmit
-		bg.helper.builderState.numEmittedTotal += willEmit
 		if o.builderState.outCount == o.outputCapacity {
 			return false
 		}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
@@ -10772,7 +10772,6 @@ func (o *mergeJoinInnerOp) buildFromBufferedGroup() (bufferedGroupComplete bool)
 		}
 		o.builderState.outCount += willEmit
 		bg.helper.builderState.numEmittedCurLeftBatch += willEmit
-		bg.helper.builderState.numEmittedTotal += willEmit
 		if o.builderState.outCount == o.outputCapacity {
 			return false
 		}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
@@ -11481,7 +11481,6 @@ func (o *mergeJoinIntersectAllOp) buildFromBufferedGroup() (bufferedGroupComplet
 			bg.helper.buildFromLeftInput(o.Ctx, o.builderState.outCount)
 		}
 		o.builderState.outCount += willEmit
-		bg.helper.builderState.numEmittedCurLeftBatch += willEmit
 		bg.helper.builderState.numEmittedTotal += willEmit
 		if o.builderState.outCount == o.outputCapacity {
 			return false

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
@@ -13001,8 +13001,6 @@ func (o *mergeJoinLeftAntiOp) buildFromBufferedGroup() (bufferedGroupComplete bo
 			bg.helper.buildFromLeftInput(o.Ctx, o.builderState.outCount)
 		}
 		o.builderState.outCount += willEmit
-		bg.helper.builderState.numEmittedCurLeftBatch += willEmit
-		bg.helper.builderState.numEmittedTotal += willEmit
 		if o.builderState.outCount == o.outputCapacity {
 			return false
 		}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
@@ -13028,7 +13028,6 @@ func (o *mergeJoinLeftOuterOp) buildFromBufferedGroup() (bufferedGroupComplete b
 		}
 		o.builderState.outCount += willEmit
 		bg.helper.builderState.numEmittedCurLeftBatch += willEmit
-		bg.helper.builderState.numEmittedTotal += willEmit
 		if o.builderState.outCount == o.outputCapacity {
 			return false
 		}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
@@ -10725,8 +10725,6 @@ func (o *mergeJoinLeftSemiOp) buildFromBufferedGroup() (bufferedGroupComplete bo
 			bg.helper.buildFromLeftInput(o.Ctx, o.builderState.outCount)
 		}
 		o.builderState.outCount += willEmit
-		bg.helper.builderState.numEmittedCurLeftBatch += willEmit
-		bg.helper.builderState.numEmittedTotal += willEmit
 		if o.builderState.outCount == o.outputCapacity {
 			return false
 		}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
@@ -12953,7 +12953,6 @@ func (o *mergeJoinRightAntiOp) buildFromBufferedGroup() (bufferedGroupComplete b
 			bg.helper.buildFromRightInput(o.Ctx, o.builderState.outCount)
 		}
 		o.builderState.outCount += willEmit
-		bg.helper.builderState.numEmittedCurLeftBatch += willEmit
 		bg.helper.builderState.numEmittedTotal += willEmit
 		if o.builderState.outCount == o.outputCapacity {
 			return false

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
@@ -13004,7 +13004,6 @@ func (o *mergeJoinRightOuterOp) buildFromBufferedGroup() (bufferedGroupComplete 
 		}
 		o.builderState.outCount += willEmit
 		bg.helper.builderState.numEmittedCurLeftBatch += willEmit
-		bg.helper.builderState.numEmittedTotal += willEmit
 		if o.builderState.outCount == o.outputCapacity {
 			return false
 		}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
@@ -10684,7 +10684,6 @@ func (o *mergeJoinRightSemiOp) buildFromBufferedGroup() (bufferedGroupComplete b
 			bg.helper.buildFromRightInput(o.Ctx, o.builderState.outCount)
 		}
 		o.builderState.outCount += willEmit
-		bg.helper.builderState.numEmittedCurLeftBatch += willEmit
 		bg.helper.builderState.numEmittedTotal += willEmit
 		if o.builderState.outCount == o.outputCapacity {
 			return false

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
@@ -1266,8 +1266,12 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) buildFromBufferedGroup() (bufferedGroupCo
 			// {{end}}
 		}
 		o.builderState.outCount += willEmit
+		// {{if or (or _JOIN_TYPE.IsInner _JOIN_TYPE.IsLeftOuter) _JOIN_TYPE.IsRightOuter}}
 		bg.helper.builderState.numEmittedCurLeftBatch += willEmit
+		// {{end}}
+		// {{if or (or _JOIN_TYPE.IsRightSemi _JOIN_TYPE.IsRightAnti) (and _JOIN_TYPE.IsLeftSemi _JOIN_TYPE.IsSetOp)}}
 		bg.helper.builderState.numEmittedTotal += willEmit
+		// {{end}}
 		if o.builderState.outCount == o.outputCapacity {
 			return false
 		}


### PR DESCRIPTION
This commit clarifies several fields in the cross joiner to indicate
which join types are using those. It also updates the merge joiner
template to not update those fields in the join types that don't use
them.

Release note: None