### PR TITLE
release-21.1: Backport tsdump improvements 

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -69,8 +69,16 @@ import (
 // node throwaway clusters and consequently this variable is only used for
 // the start-single-node command.
 //
+// To be able to visualize the timeseries data properly, a mapping file must be
+// provided as well. This maps StoreIDs to the owning NodeID, i.e. the file
+// looks like this (if s1 is on n3 and s2 is on n4):
+// 1: 3
+// 2: 4
+// [...]
+//
 // See #64329 for details.
 var debugTSImportFile = envutil.EnvOrDefaultString("COCKROACH_DEBUG_TS_IMPORT_FILE", "")
+var debugTSImportMappingFile = envutil.EnvOrDefaultString("COCKROACH_DEBUG_TS_IMPORT_MAPPING_FILE", debugTSImportFile+".yaml")
 
 // startCmd starts a node by initializing the stores and joining
 // the cluster.
@@ -272,7 +280,10 @@ func runStartSingleNode(cmd *cobra.Command, args []string) error {
 
 	// Allow passing in a timeseries file.
 	if debugTSImportFile != "" {
-		serverCfg.TestingKnobs.Server = &server.TestingKnobs{ImportTimeseriesFile: debugTSImportFile}
+		serverCfg.TestingKnobs.Server = &server.TestingKnobs{
+			ImportTimeseriesFile:        debugTSImportFile,
+			ImportTimeseriesMappingFile: debugTSImportMappingFile,
+		}
 	}
 
 	return runStart(cmd, args, true /*startSingleNode*/)

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -190,6 +190,8 @@ go_library(
         "@com_github_grpc_ecosystem_grpc_gateway//runtime:go_default_library",
         "@com_github_grpc_ecosystem_grpc_gateway//utilities:go_default_library",
         "@com_github_marusama_semaphore//:semaphore",
+        "@com_github_opentracing_opentracing_go//ext",
+        "@in_gopkg_yaml_v2//:yaml_v2",
         "@io_etcd_go_etcd_raft_v3//:raft",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes",

--- a/pkg/server/import_ts.go
+++ b/pkg/server/import_ts.go
@@ -1,0 +1,261 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/gob"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/ts"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+	yaml "gopkg.in/yaml.v2"
+)
+
+// maxBatchSize governs the maximum size of the kv batch comprising of ts data
+// to be written to the DB.
+const maxBatchSize = 10000
+
+func maybeImportTS(ctx context.Context, s *Server) (returnErr error) {
+	var deferError func(error)
+	{
+		var defErr error
+		deferError = func(err error) {
+			log.Infof(ctx, "%v", err)
+			defErr = errors.CombineErrors(defErr, err)
+		}
+		defer func() {
+			if returnErr == nil {
+				returnErr = defErr
+			}
+		}()
+	}
+	knobs, _ := s.cfg.TestingKnobs.Server.(*TestingKnobs)
+	if knobs == nil {
+		return nil
+	}
+	tsImport := knobs.ImportTimeseriesFile
+	if tsImport == "" {
+		return nil
+	}
+
+	// Suppress writing of node statuses for the local node (n1). If it wrote one,
+	// and the imported data also contains n1 but with a different set of stores,
+	// we'd effectively clobber the timeseries display for n1 (which relies on the
+	// store statuses to map the store timeseries to the node under which they
+	// fall). An alternative to this is setting a FirstStoreID and FirstNodeID that
+	// is not in use in the data set to import.
+	s.node.suppressNodeStatus.Set(true)
+
+	// Disable writing of new timeseries, as well as roll-ups and deletion.
+	for _, stmt := range []string{
+		"SET CLUSTER SETTING kv.raft_log.disable_synchronization_unsafe = 'true';",
+		"SET CLUSTER SETTING timeseries.storage.enabled = 'false';",
+		"SET CLUSTER SETTING timeseries.storage.resolution_10s.ttl = '99999h';",
+		"SET CLUSTER SETTING timeseries.storage.resolution_30m.ttl = '99999h';",
+	} {
+		if _, err := s.sqlServer.internalExecutor.ExecEx(
+			ctx, "tsdump-cfg", nil, /* txn */
+			sessiondata.InternalExecutorOverride{
+				User: security.RootUserName(),
+			},
+			stmt,
+		); err != nil {
+			return errors.Wrapf(err, "%s", stmt)
+		}
+	}
+	if tsImport == "-" {
+		// YOLO mode to look at timeseries after previous import error. This setting is used
+		// to override errors seen during a prior run of tsdump. Since the timeseries data
+		// has already been loaded during the previous tsdump run, we can simply return
+		// here and allow the user to proceed with viewing the loaded timeseries data.
+		return nil
+	}
+	// In practice we only allow populating time series in `start-single-node` due
+	// to complexities detailed below. Additionally, we allow it only on a fresh
+	// single-node single-store cluster and we also guard against join flags even
+	// though there shouldn't be any.
+	if !s.InitialStart() || len(s.cfg.JoinList) > 0 || len(s.cfg.Stores.Specs) != 1 {
+		return errors.New("cannot import timeseries into an existing cluster or a multi-{store,node} cluster")
+	}
+
+	f, err := os.Open(tsImport)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if knobs.ImportTimeseriesMappingFile == "" {
+		return errors.Errorf("need to specify COCKROACH_DEBUG_TS_IMPORT_MAPPING_FILE; it should point at " +
+			"a YAML file that maps StoreID to NodeID. To generate from the source cluster, run the following command:\n \n" +
+			"cockroach sql --url \"<(unix/sql) url>\" --format tsv -e \\\n  \"select concat(store_id::string, ': ', node_id::string)" +
+			"from crdb_internal.kv_store_status\" | \\\n  grep -E '[0-9]+: [0-9]+' | tee tsdump.gob.yaml\n \n" +
+			"To create from a debug.zip file, run the following command:\n \n" +
+			"tail -n +2 debug/crdb_internal.kv_store_status.txt | awk '{print $2 \": \" $1}' > tsdump.gob.yaml\n \n" +
+			"Then export the created file: export COCKROACH_DEBUG_TS_IMPORT_MAPPING_FILE=tsdump.gob.yaml\n \n")
+	}
+	mapBytes, err := ioutil.ReadFile(knobs.ImportTimeseriesMappingFile)
+	if err != nil {
+		return err
+	}
+	storeToNode := map[roachpb.StoreID]roachpb.NodeID{}
+	if err := yaml.NewDecoder(bytes.NewReader(mapBytes)).Decode(&storeToNode); err != nil {
+		return err
+	}
+	batch := &kv.Batch{}
+
+	var batchSize int
+	maybeFlush := func(force bool) error {
+		if batchSize == 0 {
+			// Nothing to write to DB.
+			return nil
+		}
+		if batchSize < maxBatchSize && !force {
+			return nil
+		}
+		err := s.db.Run(ctx, batch)
+		if err != nil {
+			return err
+		}
+		log.Infof(ctx, "imported %d ts pairs\n", batchSize)
+		*batch, batchSize = kv.Batch{}, 0
+		return nil
+	}
+
+	nodeIDs := map[string]struct{}{}
+	storeIDs := map[string]struct{}{}
+	dec := gob.NewDecoder(f)
+	for {
+		var v roachpb.KeyValue
+		err := dec.Decode(&v)
+		if err != nil {
+			if err == io.EOF {
+				if err := maybeFlush(true /* force */); err != nil {
+					return err
+				}
+				break
+			}
+			return err
+		}
+
+		name, source, _, _, err := ts.DecodeDataKey(v.Key)
+		if err != nil {
+			deferError(err)
+			continue
+		}
+		if strings.HasPrefix(name, "cr.node.") {
+			nodeIDs[source] = struct{}{}
+		} else if strings.HasPrefix(name, "cr.store.") {
+			storeIDs[source] = struct{}{}
+		} else {
+			deferError(errors.Errorf("unknown metric %s", name))
+			continue
+		}
+
+		p := roachpb.NewPut(v.Key, v.Value)
+		p.(*roachpb.PutRequest).Inline = true
+		batch.AddRawRequest(p)
+		batchSize++
+		if err := maybeFlush(false /* force */); err != nil {
+			return err
+		}
+	}
+
+	fakeStatuses := makeFakeNodeStatuses(storeToNode)
+	if err := checkFakeStatuses(fakeStatuses, storeIDs); err != nil {
+		// The checks are pretty strict and in particular make sure that there is at
+		// least one data point for each store. Sometimes stores are down for the
+		// time periods passed to tsdump or decommissioned nodes show up, etc; these
+		// are important to point out but often the data set is actually OK and we
+		// want to be able to view it.
+		deferError(errors.Wrapf(err, "consider updating the mapping file %s or restarting the server with "+
+			"COCKROACH_DEBUG_TS_IMPORT_FILE=- to ignore the error", knobs.ImportTimeseriesMappingFile))
+	}
+
+	// Write the statuses.
+	for _, status := range fakeStatuses {
+		key := keys.NodeStatusKey(status.Desc.NodeID)
+		if err := s.db.PutInline(ctx, key, &status); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func makeFakeNodeStatuses(storeToNode map[roachpb.StoreID]roachpb.NodeID) []statuspb.NodeStatus {
+	var sl []statuspb.NodeStatus
+	nodeToStore := map[roachpb.NodeID][]roachpb.StoreID{}
+	for sid, nid := range storeToNode {
+		nodeToStore[nid] = append(nodeToStore[nid], sid)
+	}
+
+	for nodeID, storeIDs := range nodeToStore {
+		sort.Slice(storeIDs, func(i, j int) bool {
+			return storeIDs[i] < storeIDs[j]
+		})
+		nodeStatus := statuspb.NodeStatus{
+			Desc: roachpb.NodeDescriptor{
+				NodeID: nodeID,
+			},
+		}
+		for _, storeID := range storeIDs {
+			nodeStatus.StoreStatuses = append(nodeStatus.StoreStatuses, statuspb.StoreStatus{Desc: roachpb.StoreDescriptor{
+				Node:    nodeStatus.Desc, // don't want cycles here
+				StoreID: storeID,
+			}})
+		}
+
+		sl = append(sl, nodeStatus)
+	}
+	sort.Slice(sl, func(i, j int) bool {
+		return sl[i].Desc.NodeID < sl[j].Desc.NodeID
+	})
+	return sl
+}
+
+func checkFakeStatuses(fakeStatuses []statuspb.NodeStatus, storeIDs map[string]struct{}) error {
+	for _, status := range fakeStatuses {
+		for _, ss := range status.StoreStatuses {
+			storeID := ss.Desc.StoreID
+			strID := fmt.Sprint(storeID)
+			if _, ok := storeIDs[strID]; !ok {
+				// This is likely an mistake and where it isn't (for example since store
+				// is long gone and hasn't supplied metrics in a long time) the user can
+				// react by removing the assignment from the yaml file and trying again.
+				return errors.Errorf(
+					"s%d supplied in input mapping, but no timeseries found for it",
+					ss.Desc.StoreID,
+				)
+			}
+
+			delete(storeIDs, strID)
+		}
+	}
+	if len(storeIDs) > 0 {
+		return errors.Errorf(
+			"need to map the remaining stores %v to nodes", storeIDs)
+	}
+	return nil
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -11,11 +11,9 @@
 package server
 
 import (
-	"bytes"
 	"compress/gzip"
 	"context"
 	"crypto/tls"
-	"encoding/gob"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -64,7 +62,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/heapprofiler"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
-	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -104,7 +101,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	grpcstatus "google.golang.org/grpc/status"
-	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -1889,153 +1885,6 @@ func (s *Server) PreStart(ctx context.Context) error {
 	log.Event(ctx, "server initialized")
 
 	return maybeImportTS(ctx, s)
-}
-
-func maybeImportTS(ctx context.Context, s *Server) error {
-	knobs, _ := s.cfg.TestingKnobs.Server.(*TestingKnobs)
-	if knobs == nil {
-		return nil
-	}
-	tsImport := knobs.ImportTimeseriesFile
-	if tsImport == "" {
-		return nil
-	}
-
-	// In practice we only allow populating time series in `start-single-node` due
-	// to complexities detailed below. Additionally, we allow it only on a fresh
-	// single-node single-store cluster and we also guard against join flags even
-	// though there shouldn't be any.
-	if !s.InitialStart() || len(s.cfg.JoinList) > 0 || len(s.cfg.Stores.Specs) != 1 {
-		return errors.New("cannot import timeseries into an existing cluster or a multi-{store,node} cluster")
-	}
-
-	// Also do a best effort at disabling the timeseries of the local node to cause
-	// confusion.
-	ts.TimeseriesStorageEnabled.Override(ctx, &s.ClusterSettings().SV, false)
-
-	// Suppress writing of node statuses for the local node (n1). If it wrote one,
-	// and the imported data also contains n1 but with a different set of stores,
-	// we'd effectively clobber the timeseries display for n1 (which relies on the
-	// store statuses to map the store timeseries to the node under which they
-	// fall). An alternative to this is setting a FirstStoreID and FirstNodeID that
-	// is not in use in the data set to import.
-	s.node.suppressNodeStatus.Set(true)
-
-	f, err := os.Open(tsImport)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	b := &kv.Batch{}
-	var n int
-	maybeFlush := func(force bool) error {
-		if n < 100 && !force {
-			return nil
-		}
-		err := s.db.Run(ctx, b)
-		if err != nil {
-			return err
-		}
-		log.Infof(ctx, "imported %d ts pairs\n", n)
-		*b, n = kv.Batch{}, 0
-		return nil
-	}
-
-	nodeIDs := map[string]struct{}{}
-	storeIDs := map[string]struct{}{}
-	dec := gob.NewDecoder(f)
-	for {
-		var v roachpb.KeyValue
-		err := dec.Decode(&v)
-		if err != nil {
-			if err == io.EOF {
-				if err := maybeFlush(true /* force */); err != nil {
-					return err
-				}
-				break
-			}
-			return err
-		}
-
-		name, source, _, _, err := ts.DecodeDataKey(v.Key)
-		if err != nil {
-			return err
-		}
-		if strings.HasPrefix(name, "cr.node.") {
-			nodeIDs[source] = struct{}{}
-		} else if strings.HasPrefix(name, "cr.store.") {
-			storeIDs[source] = struct{}{}
-		} else {
-			return errors.Errorf("unknown metric %s", name)
-		}
-
-		p := roachpb.NewPut(v.Key, v.Value)
-		p.(*roachpb.PutRequest).Inline = true
-		b.AddRawRequest(p)
-		n++
-		if err := maybeFlush(false /* force */); err != nil {
-			return err
-		}
-	}
-
-	nodeToStore := map[string][]string{}
-	for n := range nodeIDs {
-		// By default, assume that each node has one store, with a
-		// matching ID, i.e. n1->s1, n2->s2, etc.
-		nodeToStore[n] = []string{n}
-	}
-	storeToNode := map[string]string{}
-	if knobs.ImportTimeseriesMappingFile == "" {
-		return errors.Errorf("need to specify COCKROACH_DEBUG_TS_IMPORT_MAPPING_FILE; it should point at " +
-			"a YAML file that maps StoreID to NodeID. For example, if s1 is on n1 and s2 is on n5:\n\n1: 1\n2:5")
-	}
-	mapBytes, err := ioutil.ReadFile(knobs.ImportTimeseriesMappingFile)
-	if err != nil {
-		return err
-	}
-	if err := yaml.NewDecoder(bytes.NewReader(mapBytes)).Decode(&storeToNode); err != nil {
-		return err
-	}
-	for sid, nid := range storeToNode {
-		nodeToStore[nid] = append(nodeToStore[nid], sid)
-	}
-
-	for nodeString, storeStrings := range nodeToStore {
-		nid, err := strconv.ParseInt(nodeString, 10, 32)
-		if err != nil {
-			return err
-		}
-		nodeID := roachpb.NodeID(nid)
-
-		var ss []statuspb.StoreStatus
-		for _, storeString := range storeStrings {
-			sid, err := strconv.ParseInt(storeString, 10, 32)
-			if err != nil {
-				return err
-			}
-			ss = append(ss, statuspb.StoreStatus{Desc: roachpb.StoreDescriptor{StoreID: roachpb.StoreID(sid)}})
-			delete(storeIDs, nodeString)
-		}
-
-		ns := statuspb.NodeStatus{
-			Desc: roachpb.NodeDescriptor{
-				NodeID: nodeID,
-			},
-			StoreStatuses: ss,
-		}
-		key := keys.NodeStatusKey(nodeID)
-		if err := s.db.PutInline(ctx, key, &ns); err != nil {
-			return err
-		}
-	}
-	if len(storeIDs) > 0 {
-		return errors.Errorf(
-			"need to map the remaining stores %v to nodes %v, please provide an updated mapping file %s",
-			storeIDs, nodeIDs, knobs.ImportTimeseriesMappingFile)
-	}
-
-	return nil
 }
 
 // AcceptClients starts listening for incoming SQL clients over the network.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -11,6 +11,7 @@
 package server
 
 import (
+	"bytes"
 	"compress/gzip"
 	"context"
 	"crypto/tls"
@@ -103,6 +104,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	grpcstatus "google.golang.org/grpc/status"
+	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -1907,6 +1909,18 @@ func maybeImportTS(ctx context.Context, s *Server) error {
 		return errors.New("cannot import timeseries into an existing cluster or a multi-{store,node} cluster")
 	}
 
+	// Also do a best effort at disabling the timeseries of the local node to cause
+	// confusion.
+	ts.TimeseriesStorageEnabled.Override(ctx, &s.ClusterSettings().SV, false)
+
+	// Suppress writing of node statuses for the local node (n1). If it wrote one,
+	// and the imported data also contains n1 but with a different set of stores,
+	// we'd effectively clobber the timeseries display for n1 (which relies on the
+	// store statuses to map the store timeseries to the node under which they
+	// fall). An alternative to this is setting a FirstStoreID and FirstNodeID that
+	// is not in use in the data set to import.
+	s.node.suppressNodeStatus.Set(true)
+
 	f, err := os.Open(tsImport)
 	if err != nil {
 		return err
@@ -1971,6 +1985,21 @@ func maybeImportTS(ctx context.Context, s *Server) error {
 		// matching ID, i.e. n1->s1, n2->s2, etc.
 		nodeToStore[n] = []string{n}
 	}
+	storeToNode := map[string]string{}
+	if knobs.ImportTimeseriesMappingFile == "" {
+		return errors.Errorf("need to specify COCKROACH_DEBUG_TS_IMPORT_MAPPING_FILE; it should point at " +
+			"a YAML file that maps StoreID to NodeID. For example, if s1 is on n1 and s2 is on n5:\n\n1: 1\n2:5")
+	}
+	mapBytes, err := ioutil.ReadFile(knobs.ImportTimeseriesMappingFile)
+	if err != nil {
+		return err
+	}
+	if err := yaml.NewDecoder(bytes.NewReader(mapBytes)).Decode(&storeToNode); err != nil {
+		return err
+	}
+	for sid, nid := range storeToNode {
+		nodeToStore[nid] = append(nodeToStore[nid], sid)
+	}
 
 	for nodeString, storeStrings := range nodeToStore {
 		nid, err := strconv.ParseInt(nodeString, 10, 32)
@@ -2000,15 +2029,10 @@ func maybeImportTS(ctx context.Context, s *Server) error {
 			return err
 		}
 	}
-	if len(storeIDs) == 0 {
-		log.Warningf(ctx, "*** guessed the assignment of nodes to stores: %v ***", nodeToStore)
-	} else {
-		// If you end up here, you can adjust nodeToStore above with the correct mapping and run
-		// a custom binary. We could add an env var that takes JSON if this becomes too burdensome.
-		// Another complication is the fact that at least n1 is live and will write regular statuses,
-		// and generally whatever nodes are running in the cluster have to have the right storeIDs
-		// or things will quickly be out of whack.
-		return errors.Errorf("unable to guess the assignment of remaining stores %v to nodes %v, needs manual mapping", storeIDs, nodeIDs)
+	if len(storeIDs) > 0 {
+		return errors.Errorf(
+			"need to map the remaining stores %v to nodes %v, please provide an updated mapping file %s",
+			storeIDs, nodeIDs, knobs.ImportTimeseriesMappingFile)
 	}
 
 	return nil

--- a/pkg/server/server_import_ts_test.go
+++ b/pkg/server/server_import_ts_test.go
@@ -12,6 +12,7 @@ package server_test
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,6 +41,9 @@ func TestServerWithTimeseriesImport(t *testing.T) {
 	ctx := context.Background()
 
 	path := filepath.Join(t.TempDir(), "dump.raw")
+	require.NoError(t,
+		ioutil.WriteFile(path+".yaml", []byte("1: 1"), 0644),
+	)
 
 	var bytesDumped int64
 	func() {
@@ -58,7 +62,8 @@ func TestServerWithTimeseriesImport(t *testing.T) {
 	args.ServerArgs.Settings = cluster.MakeTestingClusterSettings()
 	ts.TimeseriesStorageEnabled.Override(&args.ServerArgs.Settings.SV, false)
 	args.ServerArgs.Knobs.Server = &server.TestingKnobs{
-		ImportTimeseriesFile: path,
+		ImportTimeseriesFile:        path,
+		ImportTimeseriesMappingFile: path + ".yaml",
 	}
 	srv := testcluster.StartTestCluster(t, 1, args)
 	defer srv.Stopper().Stop(ctx)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1269,3 +1269,73 @@ func TestSQLDecommissioned(t *testing.T) {
 		return err != nil
 	}, 10*time.Second, 100*time.Millisecond, "timed out waiting for queries to error")
 }
+
+func Test_makeFakeNodeStatuses(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	n1Desc := roachpb.NodeDescriptor{NodeID: 1}
+	n9Desc := roachpb.NodeDescriptor{NodeID: 9}
+	tests := []struct {
+		name       string
+		mapping    map[roachpb.StoreID]roachpb.NodeID
+		storesSeen map[string]struct{}
+
+		exp    []statuspb.NodeStatus
+		expErr string
+	}{
+		{
+			name:       "store-missing-in-mapping",
+			mapping:    map[roachpb.StoreID]roachpb.NodeID{1: 1},
+			storesSeen: map[string]struct{}{"1": {}, "2": {}},
+			expErr:     `need to map the remaining stores`,
+		},
+		{
+			name:       "store-only-in-mapping",
+			mapping:    map[roachpb.StoreID]roachpb.NodeID{1: 1, 3: 9},
+			storesSeen: map[string]struct{}{"9": {}},
+			expErr:     `s1 supplied in input mapping, but no timeseries found for it`,
+		},
+		{
+			name:       "success",
+			mapping:    map[roachpb.StoreID]roachpb.NodeID{1: 1, 3: 9},
+			storesSeen: map[string]struct{}{"1": {}, "3": {}},
+			exp: []statuspb.NodeStatus{
+				{Desc: n1Desc, StoreStatuses: []statuspb.StoreStatus{{Desc: roachpb.StoreDescriptor{
+					StoreID: 1,
+					Node:    n1Desc,
+				}}}},
+				{Desc: n9Desc, StoreStatuses: []statuspb.StoreStatus{{Desc: roachpb.StoreDescriptor{
+					StoreID: 3,
+					Node:    n9Desc,
+				}}}},
+			},
+		},
+		{
+			name: "success-multi-store",
+			// n1 has [s1,s12], n3 has [s3,s6].
+			mapping:    map[roachpb.StoreID]roachpb.NodeID{1: 1, 3: 9, 12: 1, 6: 9},
+			storesSeen: map[string]struct{}{"1": {}, "3": {}, "6": {}, "12": {}},
+			exp: []statuspb.NodeStatus{
+				{Desc: n1Desc, StoreStatuses: []statuspb.StoreStatus{
+					{Desc: roachpb.StoreDescriptor{StoreID: 1, Node: n1Desc}},
+					{Desc: roachpb.StoreDescriptor{StoreID: 12, Node: n1Desc}},
+				}},
+				{Desc: n9Desc, StoreStatuses: []statuspb.StoreStatus{
+					{Desc: roachpb.StoreDescriptor{StoreID: 3, Node: n9Desc}},
+					{Desc: roachpb.StoreDescriptor{StoreID: 6, Node: n9Desc}},
+				}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := makeFakeNodeStatuses(tt.mapping)
+			var err error
+			if err = checkFakeStatuses(result, tt.storesSeen); err != nil {
+				result = nil
+			}
+			require.Equal(t, tt.exp, result)
+			require.True(t, testutils.IsError(err, tt.expErr), "%+v didn't match expectation %s", err, tt.expErr)
+		})
+	}
+}

--- a/pkg/server/testing_knobs.go
+++ b/pkg/server/testing_knobs.go
@@ -89,6 +89,9 @@ type TestingKnobs struct {
 	// ImportTimeseriesFile, if set, is a file created via `DumpRaw` that written
 	// back to the KV layer upon server start.
 	ImportTimeseriesFile string
+	// ImportTimeseriesMappingFile points to a file containing a YAML map from storeID
+	// to nodeID, for use with ImportTimeseriesFile.
+	ImportTimeseriesMappingFile string
 	// DrainSleepFn used in testing to override the usual sleep function with
 	// a custom function that counts the number of times the sleep function is called.
 	DrainSleepFn func(time.Duration)


### PR DESCRIPTION
Backport:
  * 1/1 commits from "server: simplify use of COCKROACH_DEBUG_TS_IMPORT_FILE" (#69525)
  * 1/1 commits from "server: Allow bypass of tsdump's strict checks" (#77247)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: low risk, high benefit changes to existing functionality