### PR TITLE
ccl/multitenantccl: add kv ru metric

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side.go
@@ -299,6 +299,7 @@ func (c *tenantSideCostController) updateRunState(ctx context.Context) {
 		ru += float64(deltaPGWireEgressBytes) * float64(c.costCfg.PGWireEgressByte)
 	}
 
+	// KV RUs are not included here, these metrics correspond only to the SQL pod.
 	c.mu.Lock()
 	c.mu.consumption.SQLPodsCPUSeconds += deltaCPU
 	c.mu.consumption.PGWireEgressBytes += deltaPGWireEgressBytes
@@ -609,11 +610,15 @@ func (c *tenantSideCostController) OnResponse(
 	if isWrite, writeBytes := req.IsWrite(); isWrite {
 		c.mu.consumption.WriteRequests++
 		c.mu.consumption.WriteBytes += uint64(writeBytes)
-		c.mu.consumption.RU += float64(c.costCfg.KVWriteCost(writeBytes))
+		writeRU := float64(c.costCfg.KVWriteCost(writeBytes))
+		c.mu.consumption.KVRU += writeRU
+		c.mu.consumption.RU += writeRU
 	} else {
 		c.mu.consumption.ReadRequests++
 		readBytes := resp.ReadBytes()
 		c.mu.consumption.ReadBytes += uint64(readBytes)
-		c.mu.consumption.RU += float64(c.costCfg.KVReadCost(readBytes))
+		readRU := float64(c.costCfg.KVReadCost(readBytes))
+		c.mu.consumption.KVRU += readRU
+		c.mu.consumption.RU += readRU
 	}
 }

--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
@@ -455,11 +455,13 @@ func (ts *testState) usage(t *testing.T, d *datadriven.TestData, args cmdArgs) s
 	c := ts.provider.waitForConsumption(t)
 	return fmt.Sprintf(""+
 		"RU:  %.2f\n"+
+		"KVRU:  %.2f\n"+
 		"Reads:  %d requests (%d bytes)\n"+
 		"Writes:  %d requests (%d bytes)\n"+
 		"SQL Pods CPU seconds:  %.2f\n"+
 		"PGWire egress:  %d bytes\n",
 		c.RU,
+		c.KVRU,
 		c.ReadRequests,
 		c.ReadBytes,
 		c.WriteRequests,

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/consumption
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/consumption
@@ -3,6 +3,7 @@
 usage
 ----
 RU:  0.00
+KVRU:  0.00
 Reads:  0 requests (0 bytes)
 Writes:  0 requests (0 bytes)
 SQL Pods CPU seconds:  0.00
@@ -14,6 +15,7 @@ read bytes=1024000
 usage
 ----
 RU:  105.83
+KVRU:  105.83
 Reads:  1 requests (1024000 bytes)
 Writes:  0 requests (0 bytes)
 SQL Pods CPU seconds:  0.00
@@ -25,6 +27,7 @@ write bytes=1024
 usage
 ----
 RU:  113.58
+KVRU:  113.58
 Reads:  1 requests (1024000 bytes)
 Writes:  1 requests (1024 bytes)
 SQL Pods CPU seconds:  0.00
@@ -37,6 +40,7 @@ cpu
 usage
 ----
 RU:  1113.58
+KVRU:  113.58
 Reads:  1 requests (1024000 bytes)
 Writes:  1 requests (1024 bytes)
 SQL Pods CPU seconds:  1.00
@@ -54,6 +58,7 @@ write bytes=4096
 usage
 ----
 RU:  1148.39
+KVRU:  148.39
 Reads:  2 requests (1089536 bytes)
 Writes:  3 requests (9216 bytes)
 SQL Pods CPU seconds:  1.00
@@ -66,6 +71,7 @@ cpu
 usage
 ----
 RU:  3601148.39
+KVRU:  148.39
 Reads:  2 requests (1089536 bytes)
 Writes:  3 requests (9216 bytes)
 SQL Pods CPU seconds:  3601.00
@@ -78,6 +84,7 @@ pgwire-egress
 usage
 ----
 RU:  3601158.74
+KVRU:  148.39
 Reads:  2 requests (1089536 bytes)
 Writes:  3 requests (9216 bytes)
 SQL Pods CPU seconds:  3601.00

--- a/pkg/ccl/multitenantccl/tenantcostserver/metrics.go
+++ b/pkg/ccl/multitenantccl/tenantcostserver/metrics.go
@@ -26,6 +26,7 @@ import (
 // each tenant, as last reported to this node).
 type Metrics struct {
 	TotalRU                *aggmetric.AggGaugeFloat64
+	TotalKVRU              *aggmetric.AggGaugeFloat64
 	TotalReadRequests      *aggmetric.AggGauge
 	TotalReadBytes         *aggmetric.AggGauge
 	TotalWriteRequests     *aggmetric.AggGauge
@@ -51,6 +52,12 @@ var (
 	metaTotalRU = metric.Metadata{
 		Name:        "tenant.consumption.request_units",
 		Help:        "Total RU consumption",
+		Measurement: "Request Units",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaTotalKVRU = metric.Metadata{
+		Name:        "tenant.consumption.kv_request_units",
+		Help:        "RU consumption attributable to KV",
 		Measurement: "Request Units",
 		Unit:        metric.Unit_COUNT,
 	}
@@ -96,6 +103,7 @@ func (m *Metrics) init() {
 	b := aggmetric.MakeBuilder(multitenant.TenantIDLabel)
 	*m = Metrics{
 		TotalRU:                b.GaugeFloat64(metaTotalRU),
+		TotalKVRU:              b.GaugeFloat64(metaTotalKVRU),
 		TotalReadRequests:      b.Gauge(metaTotalReadRequests),
 		TotalReadBytes:         b.Gauge(metaTotalReadBytes),
 		TotalWriteRequests:     b.Gauge(metaTotalWriteRequests),
@@ -109,6 +117,7 @@ func (m *Metrics) init() {
 // tenantMetrics represent metrics for an individual tenant.
 type tenantMetrics struct {
 	totalRU                *aggmetric.GaugeFloat64
+	totalKVRU              *aggmetric.GaugeFloat64
 	totalReadRequests      *aggmetric.Gauge
 	totalReadBytes         *aggmetric.Gauge
 	totalWriteRequests     *aggmetric.Gauge
@@ -130,6 +139,7 @@ func (m *Metrics) getTenantMetrics(tenantID roachpb.TenantID) tenantMetrics {
 		tid := tenantID.String()
 		tm = tenantMetrics{
 			totalRU:                m.TotalRU.AddChild(tid),
+			totalKVRU:              m.TotalKVRU.AddChild(tid),
 			totalReadRequests:      m.TotalReadRequests.AddChild(tid),
 			totalReadBytes:         m.TotalReadBytes.AddChild(tid),
 			totalWriteRequests:     m.TotalWriteRequests.AddChild(tid),

--- a/pkg/ccl/multitenantccl/tenantcostserver/server_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostserver/server_test.go
@@ -140,6 +140,7 @@ func (ts *testState) tokenBucketRequest(t *testing.T, d *datadriven.TestData) st
 		SeqNum             int64  `yaml:"seq_num"`
 		Consumption        struct {
 			RU                float64 `yaml:"ru"`
+			KVRU              float64 `yaml:"kvru"`
 			ReadReq           uint64  `yaml:"read_req"`
 			ReadBytes         uint64  `yaml:"read_bytes"`
 			WriteReq          uint64  `yaml:"write_req"`
@@ -173,6 +174,7 @@ func (ts *testState) tokenBucketRequest(t *testing.T, d *datadriven.TestData) st
 		SeqNum:             args.SeqNum,
 		ConsumptionSinceLastRequest: roachpb.TenantConsumption{
 			RU:                args.Consumption.RU,
+			KVRU:              args.Consumption.KVRU,
 			ReadRequests:      args.Consumption.ReadReq,
 			ReadBytes:         args.Consumption.ReadBytes,
 			WriteRequests:     args.Consumption.WriteReq,

--- a/pkg/ccl/multitenantccl/tenantcostserver/system_table.go
+++ b/pkg/ccl/multitenantccl/tenantcostserver/system_table.go
@@ -581,8 +581,9 @@ func InspectTenantMetadata(
 		tenant.Bucket.RUCurrent,
 		tenant.Bucket.CurrentShareSum,
 	)
-	fmt.Fprintf(&buf, "Consumption: ru=%.12g  reads=%d req/%d bytes  writes=%d req/%d bytes  pod-cpu-usage: %g secs  pgwire-egress=%d bytes\n",
+	fmt.Fprintf(&buf, "Consumption: ru=%.12g kvru=%.12g  reads=%d req/%d bytes  writes=%d req/%d bytes  pod-cpu-usage: %g secs  pgwire-egress=%d bytes\n",
 		tenant.Consumption.RU,
+		tenant.Consumption.KVRU,
 		tenant.Consumption.ReadRequests,
 		tenant.Consumption.ReadBytes,
 		tenant.Consumption.WriteRequests,

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/cleanup
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/cleanup
@@ -22,7 +22,7 @@ instance_id: 9
 inspect tenant=5
 ----
 Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
-Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
+Consumption: ru=0 kvru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
 Last update: 00:00:00.000
 First active instance: 3
   Instance 3:  lease="foo"  seq=2  shares=0.0  next-instance=5  last-update=00:00:00.000
@@ -48,7 +48,7 @@ instance_id: 3
 inspect tenant=13
 ----
 Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
-Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
+Consumption: ru=0 kvru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
 Last update: 00:00:00.000
 First active instance: 2
   Instance 2:  lease="foo"  seq=5  shares=0.0  next-instance=3  last-update=00:00:00.000
@@ -74,7 +74,7 @@ next_live_instance_id: 9
 wait-inspect tenant=5
 ----
 Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10030000  current-share-sum=0
-Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
+Consumption: ru=0 kvru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
 Last update: 00:05:00.000
 First active instance: 3
   Instance 3:  lease="foo"  seq=2  shares=0.0  next-instance=5  last-update=00:00:00.000
@@ -95,7 +95,7 @@ next_live_instance_id: 3
 wait-inspect tenant=5
 ----
 Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10060000  current-share-sum=0
-Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
+Consumption: ru=0 kvru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
 Last update: 00:10:00.000
 First active instance: 3
   Instance 3:  lease="foo"  seq=2  shares=0.0  next-instance=5  last-update=00:00:00.000
@@ -116,7 +116,7 @@ next_live_instance_id: 5
 wait-inspect tenant=5
 ----
 Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10090000  current-share-sum=0
-Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
+Consumption: ru=0 kvru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
 Last update: 00:15:00.000
 First active instance: 5
   Instance 5:  lease="foo"  seq=10  shares=0.0  next-instance=0  last-update=00:15:00.000
@@ -124,7 +124,7 @@ First active instance: 5
 inspect tenant=13
 ----
 Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
-Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
+Consumption: ru=0 kvru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
 Last update: 00:00:00.000
 First active instance: 2
   Instance 2:  lease="foo"  seq=5  shares=0.0  next-instance=3  last-update=00:00:00.000

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/configure
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/configure
@@ -18,7 +18,7 @@ max_burst_ru: 5000
 inspect tenant=5
 ----
 Bucket state: ru-burst-limit=5000  ru-refill-rate=100  ru-current=1000  current-share-sum=0
-Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
+Consumption: ru=0 kvru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
 Last update: 00:00:00.000
 First active instance: 0
 
@@ -26,6 +26,7 @@ token-bucket-request tenant=5
 instance_id: 1
 consumption:
   ru: 10
+  kvru: 10
   read_req: 20
   read_bytes: 30
   write_req: 40
@@ -37,7 +38,7 @@ consumption:
 inspect tenant=5
 ----
 Bucket state: ru-burst-limit=5000  ru-refill-rate=100  ru-current=1000  current-share-sum=0
-Consumption: ru=10  reads=20 req/30 bytes  writes=40 req/50 bytes  pod-cpu-usage: 60 secs  pgwire-egress=70 bytes
+Consumption: ru=10 kvru=10  reads=20 req/30 bytes  writes=40 req/50 bytes  pod-cpu-usage: 60 secs  pgwire-egress=70 bytes
 Last update: 00:00:00.000
 First active instance: 1
   Instance 1:  lease="foo"  seq=1  shares=0.0  next-instance=0  last-update=00:00:00.000
@@ -55,7 +56,7 @@ refill_rate: 100
 inspect tenant=5
 ----
 Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=2000  current-share-sum=0
-Consumption: ru=10  reads=20 req/30 bytes  writes=40 req/50 bytes  pod-cpu-usage: 60 secs  pgwire-egress=70 bytes
+Consumption: ru=10 kvru=10  reads=20 req/30 bytes  writes=40 req/50 bytes  pod-cpu-usage: 60 secs  pgwire-egress=70 bytes
 Last update: 00:01:00.000
 First active instance: 1
   Instance 1:  lease="foo"  seq=1  shares=0.0  next-instance=0  last-update=00:00:00.000

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/instances
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/instances
@@ -18,7 +18,7 @@ instance_id: 10
 inspect tenant=5
 ----
 Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
-Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
+Consumption: ru=0 kvru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
 Last update: 00:00:00.000
 First active instance: 10
   Instance 10:  lease="foo"  seq=1  shares=0.0  next-instance=0  last-update=00:00:00.000
@@ -30,7 +30,7 @@ instance_id: 10
 inspect tenant=5
 ----
 Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
-Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
+Consumption: ru=0 kvru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
 Last update: 00:00:00.000
 First active instance: 10
   Instance 10:  lease="foo"  seq=2  shares=0.0  next-instance=0  last-update=00:00:00.000
@@ -42,7 +42,7 @@ instance_id: 20
 inspect tenant=5
 ----
 Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
-Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
+Consumption: ru=0 kvru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
 Last update: 00:00:00.000
 First active instance: 10
   Instance 10:  lease="foo"  seq=2  shares=0.0  next-instance=20  last-update=00:00:00.000
@@ -55,7 +55,7 @@ instance_id: 15
 inspect tenant=5
 ----
 Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
-Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
+Consumption: ru=0 kvru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
 Last update: 00:00:00.000
 First active instance: 10
   Instance 10:  lease="foo"  seq=2  shares=0.0  next-instance=15  last-update=00:00:00.000
@@ -69,7 +69,7 @@ instance_id: 1
 inspect tenant=5
 ----
 Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
-Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
+Consumption: ru=0 kvru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
 Last update: 00:00:00.000
 First active instance: 1
   Instance 1:  lease="foo"  seq=5  shares=0.0  next-instance=10  last-update=00:00:00.000

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/metrics
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/metrics
@@ -5,6 +5,7 @@ token-bucket-request tenant=5
 instance_id: 1
 consumption:
   ru: 10
+  kvru: 8
   read_req: 20
   read_bytes: 30
   write_req: 40
@@ -16,6 +17,7 @@ consumption:
 metrics
 tenant_id="5"
 ----
+tenant_consumption_kv_request_units{tenant_id="5"} 8
 tenant_consumption_pgwire_egress_bytes{tenant_id="5"} 70
 tenant_consumption_read_bytes{tenant_id="5"} 30
 tenant_consumption_read_requests{tenant_id="5"} 20
@@ -28,6 +30,7 @@ token-bucket-request tenant=5
 instance_id: 1
 consumption:
   ru: 100
+  kvru: 80
   read_req: 200
   read_bytes: 300
   write_req: 400
@@ -40,6 +43,7 @@ token-bucket-request tenant=5
 instance_id: 2
 consumption:
   ru: 1000
+  kvru: 800
   read_req: 2000
   read_bytes: 3000
   write_req: 4000
@@ -51,7 +55,7 @@ consumption:
 inspect tenant=5
 ----
 Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
-Consumption: ru=1110  reads=2220 req/3330 bytes  writes=4440 req/5550 bytes  pod-cpu-usage: 6660 secs  pgwire-egress=7770 bytes
+Consumption: ru=1110 kvru=888  reads=2220 req/3330 bytes  writes=4440 req/5550 bytes  pod-cpu-usage: 6660 secs  pgwire-egress=7770 bytes
 Last update: 00:00:00.000
 First active instance: 1
   Instance 1:  lease="foo"  seq=2  shares=0.0  next-instance=2  last-update=00:00:00.000
@@ -60,6 +64,7 @@ First active instance: 1
 metrics
 tenant_id="5"
 ----
+tenant_consumption_kv_request_units{tenant_id="5"} 888
 tenant_consumption_pgwire_egress_bytes{tenant_id="5"} 7770
 tenant_consumption_read_bytes{tenant_id="5"} 3330
 tenant_consumption_read_requests{tenant_id="5"} 2220

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/requests
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/requests
@@ -21,7 +21,7 @@ ru: 10
 inspect tenant=5
 ----
 Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=-10  current-share-sum=0
-Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
+Consumption: ru=0 kvru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
 Last update: 00:00:00.000
 First active instance: 1
   Instance 1:  lease="foo"  seq=2  shares=0.0  next-instance=0  last-update=00:00:00.000
@@ -40,7 +40,7 @@ ru: 500
 inspect tenant=5
 ----
 Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=490  current-share-sum=0
-Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
+Consumption: ru=0 kvru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
 Last update: 00:00:10.000
 First active instance: 1
   Instance 1:  lease="foo"  seq=3  shares=0.0  next-instance=0  last-update=00:00:10.000
@@ -71,7 +71,7 @@ ru: 10
 inspect tenant=5
 ----
 Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=230  current-share-sum=0
-Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
+Consumption: ru=0 kvru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
 Last update: 00:00:10.000
 First active instance: 1
   Instance 1:  lease="foo"  seq=5  shares=0.0  next-instance=2  last-update=00:00:09.000
@@ -90,7 +90,7 @@ instance_id: 1
 inspect tenant=5
 ----
 Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=230  current-share-sum=0
-Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
+Consumption: ru=0 kvru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
 Last update: 00:00:10.000
 First active instance: 1
   Instance 1:  lease="foo"  seq=6  shares=0.0  next-instance=2  last-update=00:00:10.000
@@ -109,7 +109,7 @@ instance_id: 1
 inspect tenant=5
 ----
 Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=330  current-share-sum=0
-Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
+Consumption: ru=0 kvru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes
 Last update: 00:00:11.000
 First active instance: 1
   Instance 1:  lease="foo"  seq=7  shares=0.0  next-instance=2  last-update=00:00:11.000

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/seqnum
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/seqnum
@@ -7,6 +7,7 @@ instance_lease: "foo"
 seq_num: 1
 consumption:
   ru: 10
+  kvru: 10
   read_req: 20
   read_bytes: 30
   write_req: 40
@@ -18,7 +19,7 @@ consumption:
 inspect tenant=5
 ----
 Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
-Consumption: ru=10  reads=20 req/30 bytes  writes=40 req/50 bytes  pod-cpu-usage: 60 secs  pgwire-egress=70 bytes
+Consumption: ru=10 kvru=10  reads=20 req/30 bytes  writes=40 req/50 bytes  pod-cpu-usage: 60 secs  pgwire-egress=70 bytes
 Last update: 00:00:00.000
 First active instance: 1
   Instance 1:  lease="foo"  seq=1  shares=0.0  next-instance=0  last-update=00:00:00.000
@@ -30,6 +31,7 @@ instance_lease: "foo"
 seq_num: 2
 consumption:
   ru: 10
+  kvru: 10
   read_req: 20
   read_bytes: 30
   write_req: 40
@@ -41,7 +43,7 @@ consumption:
 inspect tenant=5
 ----
 Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
-Consumption: ru=20  reads=40 req/60 bytes  writes=80 req/100 bytes  pod-cpu-usage: 120 secs  pgwire-egress=140 bytes
+Consumption: ru=20 kvru=20  reads=40 req/60 bytes  writes=80 req/100 bytes  pod-cpu-usage: 120 secs  pgwire-egress=140 bytes
 Last update: 00:00:00.000
 First active instance: 1
   Instance 1:  lease="foo"  seq=2  shares=0.0  next-instance=0  last-update=00:00:00.000
@@ -53,6 +55,7 @@ instance_lease: "foo"
 seq_num: 2
 consumption:
   ru: 10
+  kvru: 10
   read_req: 20
   read_bytes: 30
   write_req: 40
@@ -64,7 +67,7 @@ consumption:
 inspect tenant=5
 ----
 Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
-Consumption: ru=20  reads=40 req/60 bytes  writes=80 req/100 bytes  pod-cpu-usage: 120 secs  pgwire-egress=140 bytes
+Consumption: ru=20 kvru=20  reads=40 req/60 bytes  writes=80 req/100 bytes  pod-cpu-usage: 120 secs  pgwire-egress=140 bytes
 Last update: 00:00:00.000
 First active instance: 1
   Instance 1:  lease="foo"  seq=2  shares=0.0  next-instance=0  last-update=00:00:00.000
@@ -87,7 +90,7 @@ consumption:
 inspect tenant=5
 ----
 Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
-Consumption: ru=20  reads=40 req/60 bytes  writes=80 req/100 bytes  pod-cpu-usage: 120 secs  pgwire-egress=140 bytes
+Consumption: ru=20 kvru=20  reads=40 req/60 bytes  writes=80 req/100 bytes  pod-cpu-usage: 120 secs  pgwire-egress=140 bytes
 Last update: 00:00:00.000
 First active instance: 1
   Instance 1:  lease="foo"  seq=2  shares=0.0  next-instance=0  last-update=00:00:00.000
@@ -99,6 +102,7 @@ instance_lease: "bar"
 seq_num: 1
 consumption:
   ru: 10
+  kvru: 20
   read_req: 20
   read_bytes: 30
   write_req: 40
@@ -110,7 +114,7 @@ consumption:
 inspect tenant=5
 ----
 Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
-Consumption: ru=30  reads=60 req/90 bytes  writes=120 req/150 bytes  pod-cpu-usage: 180 secs  pgwire-egress=210 bytes
+Consumption: ru=30 kvru=40  reads=60 req/90 bytes  writes=120 req/150 bytes  pod-cpu-usage: 180 secs  pgwire-egress=210 bytes
 Last update: 00:00:00.000
 First active instance: 1
   Instance 1:  lease="bar"  seq=1  shares=0.0  next-instance=0  last-update=00:00:00.000
@@ -122,6 +126,7 @@ instance_lease: "baz"
 seq_num: 1
 consumption:
   ru: 10
+  kvru: 30
   read_req: 20
   read_bytes: 30
   write_req: 40
@@ -133,7 +138,7 @@ consumption:
 inspect tenant=5
 ----
 Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
-Consumption: ru=40  reads=80 req/120 bytes  writes=160 req/200 bytes  pod-cpu-usage: 240 secs  pgwire-egress=280 bytes
+Consumption: ru=40 kvru=70  reads=80 req/120 bytes  writes=160 req/200 bytes  pod-cpu-usage: 240 secs  pgwire-egress=280 bytes
 Last update: 00:00:00.000
 First active instance: 1
   Instance 1:  lease="bar"  seq=1  shares=0.0  next-instance=2  last-update=00:00:00.000

--- a/pkg/ccl/multitenantccl/tenantcostserver/token_bucket.go
+++ b/pkg/ccl/multitenantccl/tenantcostserver/token_bucket.go
@@ -123,6 +123,7 @@ func (s *instance) TokenBucketRequest(
 
 	// Report current consumption.
 	metrics.totalRU.Update(consumption.RU)
+	metrics.totalKVRU.Update(consumption.KVRU)
 	metrics.totalReadRequests.Update(int64(consumption.ReadRequests))
 	metrics.totalReadBytes.Update(int64(consumption.ReadBytes))
 	metrics.totalWriteRequests.Update(int64(consumption.WriteRequests))

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1652,6 +1652,7 @@ var _ = (*TenantConsumption).Equal
 // Add consumption from the given structure.
 func (c *TenantConsumption) Add(other *TenantConsumption) {
 	c.RU += other.RU
+	c.KVRU += other.KVRU
 	c.ReadRequests += other.ReadRequests
 	c.ReadBytes += other.ReadBytes
 	c.WriteRequests += other.WriteRequests
@@ -1666,6 +1667,12 @@ func (c *TenantConsumption) Sub(other *TenantConsumption) {
 		c.RU = 0
 	} else {
 		c.RU -= other.RU
+	}
+
+	if c.KVRU < other.KVRU {
+		c.KVRU = 0
+	} else {
+		c.KVRU -= other.KVRU
 	}
 
 	if c.ReadRequests < other.ReadRequests {

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -2753,6 +2753,7 @@ message TenantSetting {
 // tenant, which directly factors into their bill.
 message TenantConsumption {
   double r_u = 1;
+  double kv_r_u = 8 [(gogoproto.customname) = "KVRU"];
   uint64 read_requests = 2;
   uint64 read_bytes = 3;
   uint64 write_requests = 4;

--- a/pkg/roachpb/api_test.go
+++ b/pkg/roachpb/api_test.go
@@ -274,6 +274,7 @@ func TestTenantConsumptionAddSub(t *testing.T) {
 		WriteBytes:        5,
 		SQLPodsCPUSeconds: 6,
 		PGWireEgressBytes: 7,
+		KVRU:              8,
 	}
 	var b TenantConsumption
 	for i := 0; i < 10; i++ {
@@ -287,6 +288,7 @@ func TestTenantConsumptionAddSub(t *testing.T) {
 		WriteBytes:        50,
 		SQLPodsCPUSeconds: 60,
 		PGWireEgressBytes: 70,
+		KVRU:              80,
 	}); b != exp {
 		t.Errorf("expected\n%#v\ngot\n%#v", exp, b)
 	}
@@ -301,6 +303,7 @@ func TestTenantConsumptionAddSub(t *testing.T) {
 		WriteBytes:        45,
 		SQLPodsCPUSeconds: 54,
 		PGWireEgressBytes: 63,
+		KVRU:              72,
 	}); c != exp {
 		t.Errorf("expected\n%#v\ngot\n%#v", exp, c)
 	}


### PR DESCRIPTION
Previously, tenant consumption metrics included total request units and
it's dis-aggregated components. This patch adds
`tenant.consumption.kv_request_units` tracking the portion of
`tenant.consumption.request_units` attributable to kv.

Release justification: None
Release note: None