### PR TITLE
dev: simplify --rewrite; add --stream-output

### DIFF
--- a/dev
+++ b/dev
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=23
+DEV_VERSION=24
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/bench.go
+++ b/pkg/cmd/dev/bench.go
@@ -46,6 +46,7 @@ func makeBenchCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Com
 	// `go help testflag`).
 	benchCmd.Flags().String(benchTimeFlag, "", "duration to run each benchmark for")
 	benchCmd.Flags().Bool(benchMemFlag, false, "print memory allocations for benchmarks")
+	benchCmd.Flags().Bool(streamOutputFlag, false, "stream bench output during run")
 	benchCmd.Flags().String(testArgsFlag, "", "additional arguments to pass to go test binary")
 
 	return benchCmd
@@ -55,16 +56,17 @@ func (d *dev) bench(cmd *cobra.Command, commandLine []string) error {
 	pkgs, additionalBazelArgs := splitArgsAtDash(cmd, commandLine)
 	ctx := cmd.Context()
 	var (
-		filter      = mustGetFlagString(cmd, filterFlag)
-		ignoreCache = mustGetFlagBool(cmd, ignoreCacheFlag)
-		timeout     = mustGetFlagDuration(cmd, timeoutFlag)
-		short       = mustGetFlagBool(cmd, shortFlag)
-		showLogs    = mustGetFlagBool(cmd, showLogsFlag)
-		verbose     = mustGetFlagBool(cmd, vFlag)
-		count       = mustGetFlagInt(cmd, countFlag)
-		benchTime   = mustGetFlagString(cmd, benchTimeFlag)
-		benchMem    = mustGetFlagBool(cmd, benchMemFlag)
-		testArgs    = mustGetFlagString(cmd, testArgsFlag)
+		filter       = mustGetFlagString(cmd, filterFlag)
+		ignoreCache  = mustGetFlagBool(cmd, ignoreCacheFlag)
+		timeout      = mustGetFlagDuration(cmd, timeoutFlag)
+		short        = mustGetFlagBool(cmd, shortFlag)
+		showLogs     = mustGetFlagBool(cmd, showLogsFlag)
+		verbose      = mustGetFlagBool(cmd, vFlag)
+		count        = mustGetFlagInt(cmd, countFlag)
+		benchTime    = mustGetFlagString(cmd, benchTimeFlag)
+		benchMem     = mustGetFlagBool(cmd, benchMemFlag)
+		streamOutput = mustGetFlagBool(cmd, streamOutputFlag)
+		testArgs     = mustGetFlagString(cmd, testArgsFlag)
 	)
 
 	// Enumerate all benches to run.
@@ -142,7 +144,7 @@ func (d *dev) bench(cmd *cobra.Command, commandLine []string) error {
 		}
 		args = append(args, goTestArgs...)
 	}
-	args = append(args, d.getTestOutputArgs(false /* stress */, verbose, showLogs)...)
+	args = append(args, d.getTestOutputArgs(false /* stress */, verbose, showLogs, streamOutput)...)
 	args = append(args, additionalBazelArgs...)
 	logCommand("bazel", args...)
 	return d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)

--- a/pkg/cmd/dev/testdata/datadriven/bench
+++ b/pkg/cmd/dev/testdata/datadriven/bench
@@ -9,6 +9,11 @@ dev bench pkg/sql/parser --filter=BenchmarkParse
 bazel test pkg/sql/parser:all --test_arg -test.run=- --test_arg -test.bench=BenchmarkParse --test_sharding_strategy=disabled --test_output errors
 
 exec
+dev bench pkg/sql/parser --filter=BenchmarkParse --stream-output
+----
+bazel test pkg/sql/parser:all --test_arg -test.run=- --test_arg -test.bench=BenchmarkParse --test_sharding_strategy=disabled --test_output streamed
+
+exec
 dev bench pkg/bench -f=BenchmarkTracing/1node/scan/trace=off --count=2 --bench-time=10x --bench-mem
 ----
 bazel test pkg/bench:all --test_arg -test.run=- --test_arg -test.bench=BenchmarkTracing/1node/scan/trace=off --test_sharding_strategy=disabled --test_arg -test.count=2 --test_arg -test.benchtime=10x --test_arg -test.benchmem --test_output errors

--- a/pkg/cmd/dev/testdata/datadriven/test
+++ b/pkg/cmd/dev/testdata/datadriven/test
@@ -90,3 +90,8 @@ dev test pkg/ccl/logictestccl -f=TestTenantLogic/3node-tenant/system -v --rewrit
 ----
 bazel info workspace --color=no
 bazel test pkg/ccl/logictestccl:all --nocache_test_results --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/ccl/logictestccl --sandbox_writable_path=crdb-checkout/pkg/sql/logictest --test_filter=TestTenantLogic/3node-tenant/system --test_sharding_strategy=disabled --test_arg -test.v --test_output all
+
+exec
+dev test pkg/spanconfig/spanconfigkvsubscriber -f=TestDecodeSpanTargets -v --stream-output
+----
+bazel test pkg/spanconfig/spanconfigkvsubscriber:all --test_env=GOTRACEBACK=all --test_filter=TestDecodeSpanTargets --test_sharding_strategy=disabled --test_arg -test.v --test_output streamed

--- a/pkg/cmd/dev/testdata/datadriven/testlogic
+++ b/pkg/cmd/dev/testdata/datadriven/testlogic
@@ -1,41 +1,41 @@
 exec
 dev testlogic
 ----
-bazel test --test_env=GOTRACEBACK=all //pkg/sql/logictest:logictest_test --test_filter TestLogic/// --test_output errors
-bazel test --test_env=GOTRACEBACK=all //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic///' --test_output errors
-bazel test --test_env=GOTRACEBACK=all //pkg/sql/opt/exec/execbuilder:execbuilder_test --test_filter TestExecBuild/// --test_output errors
+bazel test --test_env=GOTRACEBACK=all //pkg/sql/logictest:logictest_test --test_filter TestLogic --test_output errors
+bazel test --test_env=GOTRACEBACK=all //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic' --test_output errors
+bazel test --test_env=GOTRACEBACK=all //pkg/sql/opt/exec/execbuilder:execbuilder_test --test_filter TestExecBuild --test_output errors
 
 exec
 dev testlogic ccl
 ----
-bazel test --test_env=GOTRACEBACK=all //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic///' --test_output errors
+bazel test --test_env=GOTRACEBACK=all //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic' --test_output errors
 
 exec
 dev testlogic ccl opt
 ----
-bazel test --test_env=GOTRACEBACK=all //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic///' --test_output errors
-bazel test --test_env=GOTRACEBACK=all //pkg/sql/opt/exec/execbuilder:execbuilder_test --test_filter TestExecBuild/// --test_output errors
+bazel test --test_env=GOTRACEBACK=all //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic' --test_output errors
+bazel test --test_env=GOTRACEBACK=all //pkg/sql/opt/exec/execbuilder:execbuilder_test --test_filter TestExecBuild --test_output errors
 
 exec
 dev testlogic base --ignore-cache 
 ----
-bazel test --test_env=GOTRACEBACK=all --nocache_test_results //pkg/sql/logictest:logictest_test --test_filter TestLogic/// --test_output errors
+bazel test --test_env=GOTRACEBACK=all --nocache_test_results //pkg/sql/logictest:logictest_test --test_filter TestLogic --test_output errors
 
 exec
 dev testlogic base --show-sql
 ----
-bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql //pkg/sql/logictest:logictest_test --test_filter TestLogic/// --test_output errors
+bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql //pkg/sql/logictest:logictest_test --test_filter TestLogic --test_output errors
 
 exec
 dev testlogic base --files=prepare|fk --subtests=20042 --config=local
 ----
-bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql --test_arg -config --test_arg local //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^prepare|fk$/20042' --test_output errors
+bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql --test_arg -config --test_arg local //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^prepare|fk$/^20042$' --test_output errors
 
 exec
 dev testlogic base --files=auto_span_config_reconciliation --config=local -v --show-logs --timeout=50s --rewrite
 ----
 bazel info workspace --color=no
-bazel test --test_env=GOTRACEBACK=all --nocache_test_results --test_arg -test.v --test_arg -show-logs --test_arg -show-sql --test_arg -config --test_arg local --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/sql/logictest --test_timeout=50 //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^auto_span_config_reconciliation$/' --test_output all
+bazel test --test_env=GOTRACEBACK=all --nocache_test_results --test_arg -test.v --test_arg -show-logs --test_arg -show-sql --test_arg -config --test_arg local --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/sql/logictest --test_timeout=50 //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^auto_span_config_reconciliation$' --test_output all
 
 exec
 dev testlogic base --files=auto_span_config_reconciliation --config=local --rewrite --stress
@@ -45,25 +45,25 @@ err: cannot combine --stress and --rewrite
 exec
 dev testlogic base --files=auto_span_config_reconciliation --config=local --count 5
 ----
-bazel test --test_env=GOTRACEBACK=all --test_arg -test.count=5 --test_arg -show-sql --test_arg -config --test_arg local //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^auto_span_config_reconciliation$/' --test_output errors
+bazel test --test_env=GOTRACEBACK=all --test_arg -test.count=5 --test_arg -show-sql --test_arg -config --test_arg local //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^auto_span_config_reconciliation$' --test_output errors
 
 exec
 dev testlogic base --files=auto_span_config_reconciliation --stress
 ----
-bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=86400 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' ' //pkg/sql/logictest:logictest_test --test_filter 'TestLogic//^auto_span_config_reconciliation$/' --test_output streamed
+bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=86400 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' ' //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^auto_span_config_reconciliation$' --test_output streamed
 
 exec
 dev testlogic base --files=auto_span_config_reconciliation --stress --timeout 1m --cpus 8
 ----
-bazel test --test_env=GOTRACEBACK=all --local_cpu_resources=8 --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=120 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' -maxtime=1m0s -p=8' //pkg/sql/logictest:logictest_test --test_filter 'TestLogic//^auto_span_config_reconciliation$/' --test_output streamed
+bazel test --test_env=GOTRACEBACK=all --local_cpu_resources=8 --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=120 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' -maxtime=1m0s -p=8' //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^auto_span_config_reconciliation$' --test_output streamed
 
 exec
 dev testlogic ccl --rewrite --show-logs  -v --files distsql_automatic_stats --config 3node-tenant
 ----
 bazel info workspace --color=no
-bazel test --test_env=GOTRACEBACK=all --nocache_test_results --test_arg -test.v --test_arg -show-logs --test_arg -show-sql --test_arg -config --test_arg 3node-tenant --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/ccl/logictestccl --sandbox_writable_path=crdb-checkout/pkg/sql/logictest //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic/^3node-tenant$/^distsql_automatic_stats$/' --test_output all
+bazel test --test_env=GOTRACEBACK=all --nocache_test_results --test_arg -test.v --test_arg -show-logs --test_arg -show-sql --test_arg -config --test_arg 3node-tenant --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/ccl/logictestccl --sandbox_writable_path=crdb-checkout/pkg/sql/logictest //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic/^3node-tenant$/^distsql_automatic_stats$' --test_output all
 
 exec
 dev testlogic base --files=auto_span_config_reconciliation --stress --stream-output
 ----
-bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=86400 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' ' //pkg/sql/logictest:logictest_test --test_filter 'TestLogic//^auto_span_config_reconciliation$/' --test_output streamed
+bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=86400 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' ' //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^auto_span_config_reconciliation$' --test_output streamed

--- a/pkg/cmd/dev/testdata/datadriven/testlogic
+++ b/pkg/cmd/dev/testdata/datadriven/testlogic
@@ -1,20 +1,20 @@
 exec
 dev testlogic
 ----
-bazel test --test_env=GOTRACEBACK=all --nocache_test_results //pkg/sql/logictest:logictest_test --test_filter TestLogic/// --test_output errors
-bazel test --test_env=GOTRACEBACK=all --nocache_test_results //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic///' --test_output errors
-bazel test --test_env=GOTRACEBACK=all --nocache_test_results //pkg/sql/opt/exec/execbuilder:execbuilder_test --test_filter TestExecBuild/// --test_output errors
+bazel test --test_env=GOTRACEBACK=all //pkg/sql/logictest:logictest_test --test_filter TestLogic/// --test_output errors
+bazel test --test_env=GOTRACEBACK=all //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic///' --test_output errors
+bazel test --test_env=GOTRACEBACK=all //pkg/sql/opt/exec/execbuilder:execbuilder_test --test_filter TestExecBuild/// --test_output errors
 
 exec
 dev testlogic ccl
 ----
-bazel test --test_env=GOTRACEBACK=all --nocache_test_results //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic///' --test_output errors
+bazel test --test_env=GOTRACEBACK=all //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic///' --test_output errors
 
 exec
 dev testlogic ccl opt
 ----
-bazel test --test_env=GOTRACEBACK=all --nocache_test_results //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic///' --test_output errors
-bazel test --test_env=GOTRACEBACK=all --nocache_test_results //pkg/sql/opt/exec/execbuilder:execbuilder_test --test_filter TestExecBuild/// --test_output errors
+bazel test --test_env=GOTRACEBACK=all //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic///' --test_output errors
+bazel test --test_env=GOTRACEBACK=all //pkg/sql/opt/exec/execbuilder:execbuilder_test --test_filter TestExecBuild/// --test_output errors
 
 exec
 dev testlogic base --ignore-cache 
@@ -24,18 +24,18 @@ bazel test --test_env=GOTRACEBACK=all --nocache_test_results //pkg/sql/logictest
 exec
 dev testlogic base --show-sql
 ----
-bazel test --test_env=GOTRACEBACK=all --nocache_test_results --test_arg -show-sql //pkg/sql/logictest:logictest_test --test_filter TestLogic/// --test_output errors
+bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql //pkg/sql/logictest:logictest_test --test_filter TestLogic/// --test_output errors
 
 exec
 dev testlogic base --files=prepare|fk --subtests=20042 --config=local
 ----
-bazel test --test_env=GOTRACEBACK=all --nocache_test_results --test_arg -show-sql --test_arg -config --test_arg local //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^prepare|fk$/20042' --test_output errors
+bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql --test_arg -config --test_arg local //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^prepare|fk$/20042' --test_output errors
 
 exec
 dev testlogic base --files=auto_span_config_reconciliation --config=local -v --show-logs --timeout=50s --rewrite
 ----
 bazel info workspace --color=no
-bazel test --test_env=GOTRACEBACK=all --test_arg -test.v --test_arg -show-logs --test_arg -show-sql --test_arg -config --test_arg local --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/sql/logictest --test_timeout=50 //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^auto_span_config_reconciliation$/' --test_output all
+bazel test --test_env=GOTRACEBACK=all --nocache_test_results --test_arg -test.v --test_arg -show-logs --test_arg -show-sql --test_arg -config --test_arg local --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/sql/logictest --test_timeout=50 //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^auto_span_config_reconciliation$/' --test_output all
 
 exec
 dev testlogic base --files=auto_span_config_reconciliation --config=local --rewrite --stress
@@ -45,20 +45,25 @@ err: cannot combine --stress and --rewrite
 exec
 dev testlogic base --files=auto_span_config_reconciliation --config=local --count 5
 ----
-bazel test --test_env=GOTRACEBACK=all --nocache_test_results --test_arg -test.count=5 --test_arg -show-sql --test_arg -config --test_arg local //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^auto_span_config_reconciliation$/' --test_output errors
+bazel test --test_env=GOTRACEBACK=all --test_arg -test.count=5 --test_arg -show-sql --test_arg -config --test_arg local //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^auto_span_config_reconciliation$/' --test_output errors
 
 exec
 dev testlogic base --files=auto_span_config_reconciliation --stress
 ----
-bazel test --test_env=GOTRACEBACK=all --nocache_test_results --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=86400 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' ' //pkg/sql/logictest:logictest_test --test_filter 'TestLogic//^auto_span_config_reconciliation$/' --test_output streamed
+bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=86400 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' ' //pkg/sql/logictest:logictest_test --test_filter 'TestLogic//^auto_span_config_reconciliation$/' --test_output streamed
 
 exec
 dev testlogic base --files=auto_span_config_reconciliation --stress --timeout 1m --cpus 8
 ----
-bazel test --test_env=GOTRACEBACK=all --local_cpu_resources=8 --nocache_test_results --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=120 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' -maxtime=1m0s -p=8' //pkg/sql/logictest:logictest_test --test_filter 'TestLogic//^auto_span_config_reconciliation$/' --test_output streamed
+bazel test --test_env=GOTRACEBACK=all --local_cpu_resources=8 --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=120 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' -maxtime=1m0s -p=8' //pkg/sql/logictest:logictest_test --test_filter 'TestLogic//^auto_span_config_reconciliation$/' --test_output streamed
 
 exec
 dev testlogic ccl --rewrite --show-logs  -v --files distsql_automatic_stats --config 3node-tenant
 ----
 bazel info workspace --color=no
-bazel test --test_env=GOTRACEBACK=all --test_arg -test.v --test_arg -show-logs --test_arg -show-sql --test_arg -config --test_arg 3node-tenant --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/ccl/logictestccl --sandbox_writable_path=crdb-checkout/pkg/sql/logictest //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic/^3node-tenant$/^distsql_automatic_stats$/' --test_output all
+bazel test --test_env=GOTRACEBACK=all --nocache_test_results --test_arg -test.v --test_arg -show-logs --test_arg -show-sql --test_arg -config --test_arg 3node-tenant --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/ccl/logictestccl --sandbox_writable_path=crdb-checkout/pkg/sql/logictest //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic/^3node-tenant$/^distsql_automatic_stats$/' --test_output all
+
+exec
+dev testlogic base --files=auto_span_config_reconciliation --stress --stream-output
+----
+bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=86400 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' ' //pkg/sql/logictest:logictest_test --test_filter 'TestLogic//^auto_span_config_reconciliation$/' --test_output streamed

--- a/pkg/cmd/dev/testlogic.go
+++ b/pkg/cmd/dev/testlogic.go
@@ -179,13 +179,13 @@ func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 			args = append(args, goTestArgs...)
 		}
 
-		// TODO(irfansharif): Is this right? --config and --files is optional.
 		selector := fmt.Sprintf(
-			"%s/%s/%s/%s",
+			"%s%s%s%s",
 			selectorPrefix,
 			maybeAddBeginEndMarkers(config),
 			maybeAddBeginEndMarkers(files),
-			subtests)
+			maybeAddBeginEndMarkers(subtests),
+		)
 		args = append(args, testTarget)
 		args = append(args, "--test_filter", selector)
 		args = append(args, d.getTestOutputArgs(stress, verbose, showLogs, streamOutput)...)
@@ -202,5 +202,5 @@ func maybeAddBeginEndMarkers(s string) string {
 	if len(s) == 0 {
 		return s
 	}
-	return "^" + s + "$"
+	return "/^" + s + "$"
 }

--- a/pkg/cmd/dev/ui.go
+++ b/pkg/cmd/dev/ui.go
@@ -21,11 +21,12 @@ import (
 )
 
 const (
-	// ossFlag is the name of the boolean long (GNU-style) flag that builds only the open-source parts of the UI
+	// ossFlag is the name of the boolean long (GNU-style) flag that builds only
+	// the open-source parts of the UI.
 	ossFlag = "oss"
 )
 
-// makeUICmd initializes the top-level 'ui' subcommand
+// makeUICmd initializes the top-level 'ui' subcommand.
 func makeUICmd(d *dev) *cobra.Command {
 	uiCmd := &cobra.Command{
 		Use:   "ui",
@@ -41,9 +42,9 @@ func makeUICmd(d *dev) *cobra.Command {
 
 // UIDirectories contains the absolute path to the root of each UI sub-project.
 type UIDirectories struct {
-	// clusterUI is the absolute path to ./pkg/ui/workspaces/cluster-ui
+	// clusterUI is the absolute path to ./pkg/ui/workspaces/cluster-ui.
 	clusterUI string
-	// dbConsole is the absolute path to ./pkg/ui/workspaces/db-console
+	// dbConsole is the absolute path to ./pkg/ui/workspaces/db-console.
 	dbConsole string
 }
 
@@ -60,15 +61,19 @@ func getUIDirs(d *dev) (*UIDirectories, error) {
 	}, nil
 }
 
-// makeUIWatchCmd initializes the 'ui watch' subcommand, which sets up a live-reloading HTTP server for db-console and a
-// file-watching rebuilder for cluster-ui.
+// makeUIWatchCmd initializes the 'ui watch' subcommand, which sets up a
+// live-reloading HTTP server for db-console and a file-watching rebuilder for
+// cluster-ui.
 func makeUIWatchCmd(d *dev) *cobra.Command {
 	const (
-		// portFlag is the name of the long (GNU-style) flag that controls which port webpack's dev server listens on
+		// portFlag is the name of the long (GNU-style) flag that controls which
+		// port webpack's dev server listens on.
 		portFlag = "port"
-		// dbTargetFlag is the name of the long (GNU-style) flag that determines which DB instance to proxy to
+		// dbTargetFlag is the name of the long (GNU-style) flag that determines
+		// which DB instance to proxy to.
 		dbTargetFlag = "db"
-		// secureFlag is the name of the boolean long (GNU-style) flag that makes webpack's dev server use HTTPS
+		// secureFlag is the name of the boolean long (GNU-style) flag that makes
+		// webpack's dev server use HTTPS.
 		secureFlag = "secure"
 	)
 
@@ -80,7 +85,7 @@ func makeUIWatchCmd(d *dev) *cobra.Command {
 Replaces 'make ui-watch'.`,
 		Args: cobra.MinimumNArgs(0),
 		RunE: func(cmd *cobra.Command, commandLine []string) error {
-			// Create a context that cancels when OS signals come in
+			// Create a context that cancels when OS signals come in.
 			ctx, stop := signal.NotifyContext(d.cli.Context(), os.Interrupt, os.Kill)
 			defer stop()
 
@@ -89,7 +94,7 @@ Replaces 'make ui-watch'.`,
 				return err
 			}
 
-			// Build prerequisites for db-console and cluster-ui
+			// Build prerequisites for db-console and cluster-ui.
 			args := []string{
 				"build",
 				"//pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client",
@@ -105,7 +110,7 @@ Replaces 'make ui-watch'.`,
 				return err
 			}
 
-			// Extract remaining flags
+			// Extract remaining flags.
 			portNumber, err := cmd.Flags().GetInt16(portFlag)
 			if err != nil {
 				log.Fatalf("unexpected error: %v", err)
@@ -124,7 +129,8 @@ Replaces 'make ui-watch'.`,
 			}
 			secure := mustGetFlagBool(cmd, secureFlag)
 
-			// `yarn` is required to be on a user's path, since it won't run via Bazel
+			// `yarn` is required to be on a user's path, since it won't run via
+			// Bazel.
 			err = d.ensureBinaryInPath("yarn")
 			if err != nil {
 				return err
@@ -158,7 +164,8 @@ Replaces 'make ui-watch'.`,
 				"webpack-dev-server",
 				"--config", "webpack.app.js",
 				"--mode", "development",
-				// Polyfill WEBPACK_SERVE for webpack v4; it's set in webpack v5 via `webpack serve`
+				// Polyfill WEBPACK_SERVE for webpack v4; it's set in webpack v5 via
+				// `webpack serve`.
 				"--env.WEBPACK_SERVE",
 				"--env.dist=" + webpackDist,
 				"--env.target=" + dbTarget,
@@ -168,14 +175,14 @@ Replaces 'make ui-watch'.`,
 				args = append(args, "--https")
 			}
 
-			// Start the db-console web server + watcher
+			// Start the db-console web server + watcher.
 			err = nbExec.CommandContextInheritingStdStreams(ctx, "yarn", args...)
 			if err != nil {
 				log.Fatalf("Unable to serve db-console: %v", err)
 				return err
 			}
 
-			// Wait for OS signals to cancel if we're not in test-mode
+			// Wait for OS signals to cancel if we're not in test-mode.
 			if !d.exec.IsDryrun() {
 				<-ctx.Done()
 			}
@@ -211,13 +218,18 @@ Replaces 'make ui-lint'.`,
 				return err
 			}
 
-			// Build prerequisites for db-console and cluster-ui
+			// Build prerequisites for db-console and cluster-ui.
 			args := []string{
 				"test",
 				"//pkg/ui:lint",
 			}
 			args = append(args,
-				d.getTestOutputArgs(false /* stream */, isVerbose, false /* showLogs */)...,
+				d.getTestOutputArgs(
+					false, /* stream */
+					isVerbose,
+					false, /* showLogs */
+					false, /* streamOutput */
+				)...,
 			)
 
 			logCommand("bazel", args...)


### PR DESCRIPTION
--rewrite was previously a string flag, with the allowance to pass in
additional arguments to the test binary. We now have --test-arg for
that. While here, fix a tiny bug in dev testlogic where we ignored
cached test data when --rewrite was false, considered it when it was
true (opposite of what we wanted).

Separately, it's useful to be able to stream test output during test
runs (especially long ones).

Release justification: Non-production code
Release note: None