### PR TITLE
ui: ui updates to Database page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.module.scss
@@ -22,6 +22,10 @@
   }
 }
 
+.tab-pane {
+  margin-left: 1px;
+}
+
 .summary-card {
   h4 {
     @include text--body-strong;
@@ -69,6 +73,7 @@
   &__summary-card {
     width: fit-content;
     padding: 0;
+    margin-left: 9px;
   }
 
   &__header {
@@ -91,6 +96,11 @@
 
   &__reset-btn {
     color: $colors--primary-blue-3;
+
+    &:hover {
+      color: $colors--primary-blue-3;
+      text-decoration: underline;
+    }
   }
 
   &-table {

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
@@ -352,7 +352,7 @@ export class DatabaseTablePage extends React.Component<
             onChange={this.onTabChange}
             activeKey={this.state.tab}
           >
-            <TabPane tab="Overview" key="overview">
+            <TabPane tab="Overview" key="overview" className={cx("tab-pane")}>
               <Row gutter={18}>
                 <Col className="gutter-row" span={18}>
                   <SqlBox value={this.props.details.createStatement} />
@@ -436,7 +436,7 @@ export class DatabaseTablePage extends React.Component<
                     <div className={cx("index-stats__reset-info")}>
                       <Tooltip
                         placement="bottom"
-                        title="Index stats accumulate from the time they were last cleared. Clicking ‘Reset all index stats’ will reset index stats for the entire cluster."
+                        title="Index stats accumulate from the time the index was created or had its stats reset. Clicking ‘Reset all index stats’ will reset index stats for the entire cluster."
                       >
                         <div
                           className={cx("index-stats__last-reset", "underline")}
@@ -474,7 +474,7 @@ export class DatabaseTablePage extends React.Component<
                 </SummaryCard>
               </Row>
             </TabPane>
-            <TabPane tab="Grants" key="grants">
+            <TabPane tab="Grants" key="grants" className={cx("tab-pane")}>
               <DatabaseTableGrantsTable
                 data={this.props.details.grants}
                 columns={this.grantsColumns}

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
@@ -157,7 +157,7 @@ export class IndexDetailsPage extends React.Component<
             <div className={cx("reset-info")}>
               <Tooltip
                 placement="bottom"
-                title="Index stats accumulate from the time they were last cleared. Clicking ‘Reset all index stats’ will reset index stats for the entire cluster."
+                title="Index stats accumulate from the time the index was created or had its stats reset.. Clicking ‘Reset all index stats’ will reset index stats for the entire cluster."
               >
                 <div className={cx("last-reset", "underline")}>
                   Last reset:{" "}

--- a/pkg/ui/workspaces/cluster-ui/src/settings/booleanSetting.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/settings/booleanSetting.module.scss
@@ -2,6 +2,7 @@
 
 .crl-hover-text {
   font-size: 12px;
+  color: white;
 
   &__dashed-underline {
     color: inherit;
@@ -12,8 +13,16 @@
   }
 
   &__link-text {
-  color: inherit;
-  font-size: inherit;
+    color: inherit;
+    font-size: inherit;
+    font-weight: 600;
+    text-decoration: underline;
+
+    &:hover {
+      color: inherit;
+      opacity: 0.7;
+      text-decoration: underline;
+    }
   }
 }
 
@@ -22,15 +31,15 @@
   &__enabled {
     fill: $colors--success;
     margin-right: 8px;
-    height: 8px;
-    width: 8px;
+    height: 10px;
+    width: 10px;
   }
 
   &__disabled {
     fill: $colors--disabled;
     margin-right: 8px;
-    height: 8px;
-    width: 8px;
+    height: 10px;
+    width: 10px;
   }
 }
 


### PR DESCRIPTION
This commit introduces ui fixes on the Database page (and other
child pages of it)
Partially addresses #77982

- Auto Stats circle is no longer cut off
Before
<img width="265" alt="Screen Shot 2022-03-18 at 10 20 26 AM" src="https://user-images.githubusercontent.com/1017486/159035594-ab378c69-657d-4898-90cb-500aeb7775c5.png">
After
<img width="288" alt="Screen Shot 2022-03-18 at 10 23 14 AM" src="https://user-images.githubusercontent.com/1017486/159035651-bcf4eb96-4568-4c45-9115-48476233bba3.png">


- Added the link style to the link on Auto Stats tooltip
<img width="299" alt="Screen Shot 2022-03-18 at 10 45 17 AM" src="https://user-images.githubusercontent.com/1017486/159035698-3aa337c3-e6cb-42bf-aa60-a9d6ba78d9bf.png">


- Updated tooltip message on reset index stats to add
`from the time the index was created or had its stats reset`
Before
<img width="381" alt="Screen Shot 2022-03-18 at 11 13 38 AM" src="https://user-images.githubusercontent.com/1017486/159035750-1af30635-aebb-47f9-b40a-d4bf9debe67a.png">
After
<img width="313" alt="Screen Shot 2022-03-18 at 11 15 03 AM" src="https://user-images.githubusercontent.com/1017486/159035788-b30153dd-1a1b-4aca-b8c0-62fb42614281.png">


- Updated the reset stats link when hover to use the correct blue
and add underline
<img width="242" alt="Screen Shot 2022-03-18 at 11 35 02 AM" src="https://user-images.githubusercontent.com/1017486/159035996-3d2a0b7c-4ac9-4ec0-a004-424dff4595a4.png">


- Adjusted alignment of summary cards inside Table details
Before
<img width="357" alt="Screen Shot 2022-03-18 at 11 26 17 AM" src="https://user-images.githubusercontent.com/1017486/159035880-21f75ad2-3c6d-4ece-ad7d-c12500ef25c9.png">
After
<img width="443" alt="Screen Shot 2022-03-18 at 11 31 21 AM" src="https://user-images.githubusercontent.com/1017486/159035944-8c19eaae-4fc6-4855-b597-17589fce115e.png">



Release note: None