### PR TITLE
release-21.1: roachprod: update thrift artifact url for use with charybdefs

### DIFF
--- a/pkg/cmd/roachprod/install/install.go
+++ b/pkg/cmd/roachprod/install/install.go
@@ -39,7 +39,7 @@ sudo service cassandra stop;
     sudo mkdir -p "${thrift_dir}"
     sudo chmod 777 "${thrift_dir}"
     cd "${thrift_dir}"
-    curl "https://downloads.apache.org/thrift/0.13.0/thrift-0.13.0.tar.gz" | sudo tar xvz --strip-components 1
+    curl "https://archive.apache.org/dist/thrift/0.13.0/thrift-0.13.0.tar.gz" | sudo tar xvz --strip-components 1
     sudo ./configure --prefix=/usr
     sudo make -j$(nproc)
     sudo make install


### PR DESCRIPTION
This is a manual backport of #78023 to 21.1.

---

The version of Thrift used in tests that use charybdefs has disappeared
from the Apache artifacts repository that is used currently, which
causes any roachtest that depends on charybdefs to fail due to not being
able to fetch the artifact it needs.

Update the artifact URL to pull from the Apache archive instead.

Touches #78006,#78007,#78008,#78010,#78015,#78016.

Release note: None.

---

Release justification: Test only. Fixes a flaky test.