### PR TITLE
[POC] kvserver: crash once and cordon replica in case of an apply fatal error

### DIFF
--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -160,6 +160,9 @@ var (
 	// localStoreIdentSuffix stores an immutable identifier for this
 	// store, created when the store is first bootstrapped.
 	localStoreIdentSuffix = []byte("iden")
+	// localStoreCordonRangeSuffix stores the range ID of a range that should
+	// be cordoned off on this store.
+	localStoreCordonRangeSuffix = []byte("cran")
 	// localStoreNodeTombstoneSuffix stores key value pairs that map
 	// nodeIDs to time of removal from cluster.
 	localStoreNodeTombstoneSuffix = []byte("ntmb")

--- a/pkg/keys/doc.go
+++ b/pkg/keys/doc.go
@@ -218,6 +218,7 @@ var _ = [...]interface{}{
 	StoreGossipKey,         // "goss"
 	StoreHLCUpperBoundKey,  // "hlcu"
 	StoreIdentKey,          // "iden"
+	StoreCordonRangeKey,    // "cran"
 	StoreNodeTombstoneKey,  // "ntmb"
 	StoreLastUpKey,         // "uptm"
 	StoreCachedSettingsKey, // "stng"

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -55,6 +55,12 @@ func StoreIdentKey() roachpb.Key {
 	return MakeStoreKey(localStoreIdentSuffix, nil)
 }
 
+// StoreCordonRangeKey returns a store-local key that records the
+// range ID of a range that should be cordoned off on this store.
+func StoreCordonRangeKey() roachpb.Key {
+	return MakeStoreKey(localStoreCordonRangeSuffix, nil)
+}
+
 // StoreGossipKey returns a store-local key for the gossip bootstrap metadata.
 func StoreGossipKey() roachpb.Key {
 	return MakeStoreKey(localStoreGossipSuffix, nil)

--- a/pkg/kv/kvserver/cordon_integration_test.go
+++ b/pkg/kv/kvserver/cordon_integration_test.go
@@ -1,0 +1,94 @@
+package kvserver_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCordonIfPanicDuringApply(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderShort(t)
+
+	ctx := context.Background()
+
+	dir, cleanupFn := testutils.TempDir(t)
+	defer cleanupFn()
+
+	testArgs := func(dontPanicOnApplyPanicOrFatalError bool) base.TestServerArgs {
+		return base.TestServerArgs{
+			Settings: cluster.MakeClusterSettings(),
+			// We will start up a second server after stopping the first one to
+			// simulate a server restart, since cordoning in response to a panic
+			// during apply only takes effect after a server restart. So we use
+			// the same store for the two servers (they are the same node). This
+			// way, the should cordon write to storage done by the first server is
+			// seen by the second server at startup.
+			StoreSpecs: []base.StoreSpec{{Path: dir + "/store-1"}},
+			Knobs: base.TestingKnobs{
+				Store: &kvserver.StoreTestingKnobs{
+					DontPanicOnApplyPanicOrFatalError: dontPanicOnApplyPanicOrFatalError,
+					// Simulate a panic during apply!
+					TestingApplyFilter: func(args kvserverbase.ApplyFilterArgs) (int, *roachpb.Error) {
+						for _, ru := range args.Req.Requests {
+							key := ru.GetInner().Header().Key
+							// The time-series range is continuously written to.
+							if bytes.HasPrefix(key, keys.TimeseriesPrefix) {
+								panic("boom")
+							}
+						}
+						return 0, nil
+					},
+				},
+			},
+		}
+	}
+
+	s, _, kvDB := serverutils.StartServer(t,
+		// In production, the first time the panic at apply time is experienced, we expect the
+		// server to mark the replica as to be cordoned and crash after re-throwing the panic.
+		// In this test, we expect the server to mark the replicas as to be cordoned but also
+		// to NOT re-throw the panic. Else the test would fail due to a uncaught panic.
+		testArgs(true /* dontPanicOnApplyPanicOrFatalError */))
+
+	// TODO(josh): This is gnarly. Can we force the scheduler to run on the range with the
+	// apply time panic, instead of sleeping here?
+	time.Sleep(10 * time.Second)
+	s.Stopper().Stop(ctx)
+
+	s, _, kvDB = serverutils.StartServer(t,
+		// On the second run of the server, we don't expect a panic, as on startup, the replica
+		// should be cordoned. All raft machinery should stop, so the TestingApplyFilter up above
+		// shouldn't run.
+		testArgs(false /* dontPanicOnApplyPanicOrFatalError */))
+	defer s.Stopper().Stop(ctx)
+
+	time.Sleep(10 * time.Second)
+
+	// On the second run of the server, we expect requests to the cordoned range to fail fast.
+	//
+	// Note that if this was a three node cluster, and if only one replica was failing to apply
+	// some entry, we'd expect that one replica to cordon on restart, which would imply shedding
+	// the lease. As a result, we'd expect reads & writes to the range to succeed, rather than
+	// fail fast.
+	// TODO(josh): Test behavior on a three node cluster.
+	_, err := kvDB.Get(ctx, keys.TimeseriesPrefix)
+	require.Error(t, err)
+	require.Regexp(t, "cordoned", err.Error())
+}

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -870,6 +870,11 @@ func (b *replicaAppBatch) ApplyToStateMachine(ctx context.Context) error {
 		}
 	}
 
+	// TODO(josh): Remove.
+	if b.r.RangeID == 54 {
+		panic("josh second boom")
+	}
+
 	// Apply the write batch to RockDB. Entry application is done without
 	// syncing to disk. The atomicity guarantees of the batch and the fact that
 	// the applied state is stored in this batch, ensure that if the batch ends

--- a/pkg/kv/kvserver/scheduler_test.go
+++ b/pkg/kv/kvserver/scheduler_test.go
@@ -236,7 +236,7 @@ func TestSchedulerLoop(t *testing.T) {
 
 	m := newStoreMetrics(metric.TestSampleInterval)
 	p := newTestProcessor()
-	s := newRaftScheduler(log.MakeTestingAmbientContext(stopper.Tracer()), m, p, 1)
+	s := newRaftScheduler(log.MakeTestingAmbientContext(stopper.Tracer()), m, p, 1, nil)
 
 	s.Start(stopper)
 	s.EnqueueRaftTicks(1, 2, 3)
@@ -264,7 +264,7 @@ func TestSchedulerBuffering(t *testing.T) {
 
 	m := newStoreMetrics(metric.TestSampleInterval)
 	p := newTestProcessor()
-	s := newRaftScheduler(log.MakeTestingAmbientContext(stopper.Tracer()), m, p, 1)
+	s := newRaftScheduler(log.MakeTestingAmbientContext(stopper.Tracer()), m, p, 1, nil)
 	s.Start(stopper)
 
 	testCases := []struct {

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -64,7 +64,8 @@ type StoreTestingKnobs struct {
 	// a forced error and the command will not be applied. If it returns an error
 	// on some replicas but not others, the behavior is poorly defined. The
 	// returned int is interpreted as a proposalReevaluationReason.
-	TestingApplyFilter kvserverbase.ReplicaApplyFilter
+	TestingApplyFilter                kvserverbase.ReplicaApplyFilter
+	DontPanicOnApplyPanicOrFatalError bool
 	// TestingApplyForcedErrFilter is like TestingApplyFilter, but it is only
 	// invoked when there is a pre-existing forced error. The returned int and
 	// *Error replace the existing proposalReevaluationReason (if initially zero


### PR DESCRIPTION
https://github.com/cockroachdb/cockroach/issues/75944

**kvserver: crash once and cordon replica in case of an apply fatal error**

This commit is a POC of an approach to reducing blast radius of panics or
fatal errors that happen during application.

Without this commit, kvserver repeatedly restarts. Repeateldy restarting
means a cluster wide impact on reliability. It also makes debugging hard,
as tools like the admin UI are affected by the restarts. We especially note
the impact on serverless. Repeatedly restarting means that an apply fatal error
results in an outage that affects multiple tenants, even if the range with the
apply fatal error is in a single tenant's keyspace (which is likely).

With this commit, kvserver crashes a single time and cordons the replica at
start up time. Cordoning means the raft scheduler doesn't schedule the replica.
Since cordoning happens post restart, and since a node can't resume its leases
post restart, the node will shed its lease of the cordoned range. As a result,
if only one replica of 3+ experiences an apply fatal error, the range will stay
available. If a quorum experience an apply fatal error on the other hand, the
range will become unavailable. Reads and writes to the range will fail fast,
rather than hang, to improve the user experience.

There has been some discussion about removing the replica in case a single
replica experiences an apply fatal error. This commit doesn't chew that off.
Even without that, this commit is an improvement over the status quo.

This commit introduces an integration test that tests the behavior of a one
node CRDB cluster in face of an apply fatal error. I have yet to test the
behavor of a multi-node cluster.

Release note: None.