### PR TITLE
ui: sort items in the sql activity dropdown menu

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
@@ -109,7 +109,7 @@ function getSessionAppFilterOptions(sessions: SessionInfo[]): string[] {
     ),
   );
 
-  return Array.from(uniqueAppNames);
+  return Array.from(uniqueAppNames).sort();
 }
 
 export class SessionsPage extends React.Component<

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -81,7 +81,9 @@ export const selectApps = createSelector(sqlStatsSelector, sqlStatsState => {
       }
     },
   );
-  return [].concat(sawBlank ? ["(unset)"] : []).concat(Object.keys(apps));
+  return []
+    .concat(sawBlank ? ["(unset)"] : [])
+    .concat(Object.keys(apps).sort());
 });
 
 // selectDatabases returns the array of all databases with statement statistics present
@@ -99,7 +101,9 @@ export const selectDatabases = createSelector(
           s.key.key_data.database ? s.key.key_data.database : "(unset)",
         ),
       ),
-    ).filter((dbName: string) => dbName !== null && dbName.length > 0);
+    )
+      .filter((dbName: string) => dbName !== null && dbName.length > 0)
+      .sort();
   },
 );
 

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
@@ -45,7 +45,7 @@ export const getTrxAppFilterOptions = (
       .map(t => (t.stats_data.app ? t.stats_data.app : "(unset)")),
   );
 
-  return Array.from(uniqueAppNames);
+  return Array.from(uniqueAppNames).sort();
 };
 
 export const collectStatementsText = (statements: Statement[]): string =>

--- a/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
@@ -214,7 +214,7 @@ describe("selectApps", () => {
 
     const result = selectApps(state);
 
-    assert.deepEqual(result, ["(unset)", "foobar", "cockroach sql"]);
+    assert.deepEqual(result, ["(unset)", "cockroach sql", "foobar"]);
   });
 });
 

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -188,7 +188,10 @@ export const selectApps = createSelector(
         }
       },
     );
-    return [].concat(sawBlank ? ["(unset)"] : []).concat(Object.keys(apps));
+    return []
+      .concat(sawBlank ? ["(unset)"] : [])
+      .concat(Object.keys(apps))
+      .sort();
   },
 );
 
@@ -206,7 +209,9 @@ export const selectDatabases = createSelector(
           s.key.key_data.database ? s.key.key_data.database : "(unset)",
         ),
       ),
-    ).filter((dbName: string) => dbName !== null && dbName.length > 0);
+    )
+      .filter((dbName: string) => dbName !== null && dbName.length > 0)
+      .sort();
   },
 );
 


### PR DESCRIPTION
Fixes #78081.

Previously, app names in the dropdown menu for the stmts, txns, and
sessions pages were unsorted. This change sorts these app names.

Statements page:
<img width="584" alt="statements-page" src="https://user-images.githubusercontent.com/35943354/159062772-c3a39f9f-50b2-43b8-a635-77506b715456.png">

Transactions page:
<img width="584" alt="transactions-page" src="https://user-images.githubusercontent.com/35943354/159062801-ae172a16-9eee-4b5a-bc9b-b37b2ff6b1e5.png">

Sessions page:
<img width="444" alt="sessions-page" src="https://user-images.githubusercontent.com/35943354/159062817-83d4eb53-9c91-44ae-9788-a3bacf4e469d.png">

Release note (ui change): app names in the dropdown menu are sorted.