### PR TITLE
ui: ui updates to Sessions page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -179,7 +179,7 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
                   type="secondary"
                   size="small"
                 >
-                  Cancel query
+                  Cancel statement
                 </Button>
                 <Button
                   onClick={() => {

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetailsConnected.tsx
@@ -43,13 +43,13 @@ export const SessionDetailsPageConnected = withRouter(
         analyticsActions.track({
           name: "Session Actions Clicked",
           page: "Sessions Details",
-          action: "Terminate Session",
+          action: "Cancel Session",
         }),
       onTerminateStatementClick: () =>
         analyticsActions.track({
           name: "Session Actions Clicked",
           page: "Sessions Details",
-          action: "Terminate Statement",
+          action: "Cancel Statement",
         }),
       onBackButtonClick: () =>
         analyticsActions.track({

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
@@ -331,7 +331,7 @@ export class SessionsPage extends React.Component<
 
     const isColumnSelected = (c: ColumnDescriptor<SessionInfo>) => {
       return (
-        (!userSelectedColumnsToShow && c.showByDefault) ||
+        (userSelectedColumnsToShow === null && c.showByDefault !== false) ||
         (userSelectedColumnsToShow &&
           userSelectedColumnsToShow.includes(c.name)) ||
         c.alwaysShow

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPageConnected.tsx
@@ -130,13 +130,13 @@ export const SessionsPageConnected = withRouter(
         analyticsActions.track({
           name: "Session Actions Clicked",
           page: "Sessions",
-          action: "Terminate Session",
+          action: "Cancel Session",
         }),
       onTerminateStatementClick: () =>
         analyticsActions.track({
           name: "Session Actions Clicked",
           page: "Sessions",
-          action: "Terminate Statement",
+          action: "Cancel Statement",
         }),
       onFilterChange: (value: Filters) => {
         dispatch(

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
@@ -227,28 +227,28 @@ export function makeSessionsColumns(
       cell: ({ session }) => {
         const menuItems: DropdownItem[] = [
           {
-            value: "terminateStatement",
-            name: "Terminate Statement",
+            value: "cancelStatement",
+            name: "Cancel Statement",
             disabled: session.active_queries?.length === 0,
           },
           {
-            value: "terminateSession",
-            name: "Terminate Session",
+            value: "cancelSession",
+            name: "Cancel Session",
           },
         ];
 
         const onMenuItemChange = (
-          value: "terminateStatement" | "terminateSession",
+          value: "cancelStatement" | "cancelSession",
         ) => {
           switch (value) {
-            case "terminateSession":
+            case "cancelSession":
               onTerminateSessionClick && onTerminateSessionClick();
               terminateSessionRef?.current?.showModalFor({
                 session_id: session.id,
                 node_id: session.node_id.toString(),
               });
               break;
-            case "terminateStatement":
+            case "cancelStatement":
               if (session.active_queries?.length > 0) {
                 onTerminateStatementClick && onTerminateStatementClick();
                 terminateQueryRef?.current?.showModalFor({

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/terminateQueryModal.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/terminateQueryModal.tsx
@@ -56,10 +56,10 @@ const TerminateQueryModal = (
       onCancel={onCancelHandler}
       okText="Yes"
       cancelText="No"
-      title="Terminate the Statement?"
+      title="Cancel the Statement"
     >
       <Text>
-        Terminating a statement ends the statement, returning an error to the
+        Cancelling a statement ends the statement, returning an error to the
         session.
       </Text>
     </Modal>

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/terminateSessionModal.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/terminateSessionModal.tsx
@@ -57,10 +57,10 @@ const TerminateSessionModal = (
       onCancel={onCancelHandler}
       okText="Yes"
       cancelText="No"
-      title="Terminate the Session?"
+      title="Cancel the Session"
     >
       <Text>
-        Terminating a session ends the session, terminating its associated
+        Cancelling a session ends the session, cancelling its associated
         connection. The client that holds this session will receive a
         &quot;connection terminated&quot; event.
       </Text>

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.module.scss
@@ -66,8 +66,10 @@
 }
 
 .node-link {
-  display: flex;
-  font-weight: $font-weight--bold;
-  line-height: $line-height--medium;
-  white-space: nowrap;
+  text-align: right;
+  color: $colors--primary-blue-3;
+  &:hover {
+    color: $colors--primary-blue-3;
+    text-decoration: underline;
+  }
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.tsx
@@ -247,7 +247,7 @@ export const NodeLink = (props: {
   nodeNames?: NodeNames;
 }): React.ReactElement => (
   <Link to={`/node/${props.nodeId}`}>
-    <div className={cx("node-name-tooltip__info-icon")}>
+    <div className={cx("node-link")}>
       {props.nodeNames ? props.nodeNames[props.nodeId] : "N" + props.nodeId}
     </div>
   </Link>

--- a/pkg/ui/workspaces/cluster-ui/src/store/analytics/analytics.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/analytics/analytics.reducer.ts
@@ -61,7 +61,7 @@ type SessionClicked = {
 type SessionActionsClicked = {
   name: "Session Actions Clicked";
   page: Page;
-  action: "Terminate Statement" | "Terminate Session";
+  action: "Cancel Statement" | "Cancel Session";
 };
 
 type FilterEvent = {

--- a/pkg/ui/workspaces/cluster-ui/src/store/notifications/notifications.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/notifications/notifications.sagas.ts
@@ -40,7 +40,7 @@ export function* notifificationsSaga() {
   yield all([
     takeEvery(terminateQueryActions.terminateSessionCompleted, function*() {
       yield put(
-        notificationAction(NotificationType.Success, "Session terminated."),
+        notificationAction(NotificationType.Success, "Session cancelled."),
       );
     }),
 
@@ -48,14 +48,14 @@ export function* notifificationsSaga() {
       yield put(
         notificationAction(
           NotificationType.Error,
-          "There was an error terminating the session",
+          "There was an error cancelling the session",
         ),
       );
     }),
 
     takeEvery(terminateQueryActions.terminateQueryCompleted, function*() {
       yield put(
-        notificationAction(NotificationType.Success, "Query terminated."),
+        notificationAction(NotificationType.Success, "Statement cancelled."),
       );
     }),
 
@@ -63,7 +63,7 @@ export function* notifificationsSaga() {
       yield put(
         notificationAction(
           NotificationType.Error,
-          "There was an error terminating the query.",
+          "There was an error cancelling the statement.",
         ),
       );
     }),

--- a/pkg/ui/workspaces/db-console/src/redux/alerts.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/alerts.ts
@@ -445,9 +445,9 @@ export const terminateSessionAlertSelector = createSelector(
     if (status === "FAILED") {
       return {
         level: AlertLevel.CRITICAL,
-        title: "There was an error terminating the session.",
+        title: "There was an error cancelling the session.",
         text:
-          "Please try activating again. If the problem continues please reach out to customer support.",
+          "Please try cancelling again. If the problem continues please reach out to customer support.",
         showAsAlert: true,
         dismiss: (dispatch: Dispatch<Action>) => {
           dispatch(terminateSessionAlertLocalSetting.set({ show: false }));
@@ -457,7 +457,7 @@ export const terminateSessionAlertSelector = createSelector(
     }
     return {
       level: AlertLevel.SUCCESS,
-      title: "Session terminated.",
+      title: "Session cancelled.",
       showAsAlert: true,
       autoClose: true,
       closable: false,
@@ -490,9 +490,9 @@ export const terminateQueryAlertSelector = createSelector(
     if (status === "FAILED") {
       return {
         level: AlertLevel.CRITICAL,
-        title: "There was an error terminating the query.",
+        title: "There was an error cancelling the statement.",
         text:
-          "Please try terminating again. If the problem continues please reach out to customer support.",
+          "Please try cancelling again. If the problem continues please reach out to customer support.",
         showAsAlert: true,
         dismiss: (dispatch: Dispatch<Action>) => {
           dispatch(terminateQueryAlertLocalSetting.set({ show: false }));
@@ -502,7 +502,7 @@ export const terminateQueryAlertSelector = createSelector(
     }
     return {
       level: AlertLevel.SUCCESS,
-      title: "Query terminated.",
+      title: "Statement cancelled.",
       showAsAlert: true,
       autoClose: true,
       closable: false,


### PR DESCRIPTION
This commit introduces ui fixes on Session and
Session Details page:

- Show all columns by default
- Update actions dropdown from Terminate to Cancel
Before
<img width="201" alt="Screen Shot 2022-03-18 at 12 45 56 PM" src="https://user-images.githubusercontent.com/1017486/159063901-3441465f-9b18-489f-a708-300a4c69b78b.png">
After
<img width="229" alt="Screen Shot 2022-03-18 at 12 51 57 PM" src="https://user-images.githubusercontent.com/1017486/159063946-355f8cda-6c09-4e82-a41e-9808d328b6be.png">


- Update Cancel Statement and Cancel Sessions Modal to
update from Terminate to Cancel and remove `?`
Before
<img width="622" alt="Screen Shot 2022-03-18 at 12 45 41 PM" src="https://user-images.githubusercontent.com/1017486/159064111-99555900-733d-4e1c-b115-e929e473f3ba.png">
<img width="604" alt="Screen Shot 2022-03-18 at 12 45 50 PM" src="https://user-images.githubusercontent.com/1017486/159064139-ae58151e-12f3-4887-8507-eb4ecf665bc4.png">

After
<img width="597" alt="Screen Shot 2022-03-18 at 12 58 39 PM" src="https://user-images.githubusercontent.com/1017486/159064308-a5772b4a-c523-4a8b-a2dd-587b2a4d7814.png">
<img width="613" alt="Screen Shot 2022-03-18 at 12 58 58 PM" src="https://user-images.githubusercontent.com/1017486/159064322-71c5910c-de8c-4de0-a4e3-25b49a04ccbe.png">



- Update Cancel Statement success message to `Statement`
Before
<img width="538" alt="Screen Shot 2022-03-18 at 12 53 00 PM" src="https://user-images.githubusercontent.com/1017486/159064225-6eaca061-86a2-4bb8-bdc2-0cad482dc7fe.png">

After
<img width="541" alt="Screen Shot 2022-03-18 at 12 56 53 PM" src="https://user-images.githubusercontent.com/1017486/159064267-b30de8ad-aa0b-442b-94d8-6d04daac08db.png">


- Update Cancel Query to Cancel Statement
Before
<img width="392" alt="Screen Shot 2022-03-18 at 12 59 39 PM" src="https://user-images.githubusercontent.com/1017486/159064413-6e9b27cc-6b4c-459b-a4d4-e1f31555b30f.png">


After
<img width="366" alt="Screen Shot 2022-03-18 at 1 01 06 PM" src="https://user-images.githubusercontent.com/1017486/159063589-57da86fb-2456-4ca8-b843-f285c5a67540.png">

- Right align nodes with larger names
Before
<img width="546" alt="Screen Shot 2022-03-18 at 1 13 50 PM" src="https://user-images.githubusercontent.com/1017486/159063708-ed07077e-036e-4339-a542-2df99214fb96.png">

After
<img width="578" alt="Screen Shot 2022-03-18 at 1 15 30 PM" src="https://user-images.githubusercontent.com/1017486/159063748-0e37aded-b049-4254-adca-122d53a59b81.png">


- Update color and hover on Node link
Before
<img width="568" alt="Screen Shot 2022-03-18 at 1 02 10 PM" src="https://user-images.githubusercontent.com/1017486/159063640-81619657-b099-4eb9-9d1e-48738269e2a2.png">

After
<img width="241" alt="Screen Shot 2022-03-18 at 1 17 23 PM" src="https://user-images.githubusercontent.com/1017486/159063784-2eeaa137-504b-4548-8062-a83c74d4513b.png">


Partially addresses #77982

Release note: None