### PR TITLE
roachtest: increase sysbench workload concurrency

### DIFF
--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -137,7 +137,7 @@ func registerSysbench(r registry.Registry) {
 	for w := sysbenchWorkload(0); w < numSysbenchWorkloads; w++ {
 		const n = 3
 		const cpus = 32
-		const conc = 4 * cpus
+		const conc = 8 * cpus
 		opts := sysbenchOptions{
 			workload:     w,
 			duration:     10 * time.Minute,


### PR DESCRIPTION
This commit increases the workload concurrency we use in sysbench from 4 threads per vCPU per node to 8 threads per vCPU per node. This increases top-line throughput across all workloads, meaning that they had room to grow.

We saw this in experimentation in https://github.com/cockroachdb/cockroach/pull/78102 and also in https://mariadb.com/ja/resources/blog/mariadb-xpand-crunches-cockroach-with-sysbench/.