### PR TITLE
release 21.2: ui: fix explain plan not rendering

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
@@ -61,11 +61,23 @@ export function aggregateNumericStats(
 export function coalesceSensitiveInfo(
   a: protos.cockroach.sql.ISensitiveInfo,
   b: protos.cockroach.sql.ISensitiveInfo,
-) {
+): protos.cockroach.sql.ISensitiveInfo {
+  let planDesc = a.most_recent_plan_description;
+  let mostRecentPlanTimestamp = a.most_recent_plan_timestamp;
+
+  const planSampledNanoA = a.most_recent_plan_timestamp?.nanos || 0;
+  const planSampledNanoB = b.most_recent_plan_timestamp?.nanos || 0;
+
+  // Always return the most recently sampled plan.
+  if (planSampledNanoA < planSampledNanoB) {
+    planDesc = b.most_recent_plan_description;
+    mostRecentPlanTimestamp = b.most_recent_plan_timestamp;
+  }
+
   return {
     last_err: a.last_err || b.last_err,
-    most_recent_plan_description:
-      a.most_recent_plan_description || b.most_recent_plan_description,
+    most_recent_plan_description: planDesc,
+    most_recent_plan_timestamp: mostRecentPlanTimestamp,
   };
 }
 


### PR DESCRIPTION
Partially resolves #69237

Previously, in a multi-node cluster, query plans for single statement
fingerprints may only be sampled in the subset of the nodes in the
cluster.  Console previsouly assumed that when the query plan was
not sampled, it would be represented as "null". Unfortunately, this
is not the case, since the backend API always sends back a valid
JSON object with empty "Name" and "Children" fields for empty sampled
plan. This caused the Statement Detail page to incorrectly pick the
empty query plan to render.

This commit updates the frontend statement statistics aggregation logic to
properly discard the empty query plan.

Release note (bug fix): Previously Statement Detail Page fails to load query
plan even after when the plan has been sampled. This is now fixed.