### PR TITLE
ui: ui updates to Statements Page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/common/styles.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/common/styles.module.scss
@@ -56,5 +56,5 @@ h3.base-heading {
 
 .separator {
   border-left: 1px solid #C0C6D9;
-  padding-left: 25px;
+  padding-left: 12px;
 }

--- a/pkg/ui/workspaces/cluster-ui/src/core/colors.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/core/colors.module.scss
@@ -18,6 +18,7 @@ $colors--primary-blue-4: #005fb3;
 $colors--primary-blue-5: #00294d;
 $colors--primary-blue-6: #89b0ff;
 $colors--primary-blue-7: #b6ceff;
+$colors--primary-blue-alert: #e1ecff;
 
 $colors--primary-green-0: #daf8d4;
 $colors--primary-green-1: #b4f1aa;

--- a/pkg/ui/workspaces/cluster-ui/src/pageConfig/pageConfig.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/pageConfig/pageConfig.module.scss
@@ -23,7 +23,7 @@
     align-items: center;
 
     .page-config__item {
-      margin-right: 24px;
+      margin-right: 12px;
     }
   }
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
@@ -4,6 +4,12 @@
   white-space: nowrap;
   line-height: $line-height--medium;
   font-weight: $font-weight--bold;
+  color: $colors--primary-blue-3;
+
+  &:hover {
+    color: $colors--primary-blue-3;
+    text-decoration: underline;
+  }
 
   &__unset {
     color: $tooltip-color;

--- a/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/activateStatementDiagnosticsModal.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/activateStatementDiagnosticsModal.scss
@@ -93,6 +93,11 @@
     margin-top: $spacing-small;
     margin-left: $spacing-medium;
 
+    .ant-alert-info {
+        background-color: $colors--primary-blue-alert;
+        border: none;
+    }
+
     &-icon {
       margin-top: $spacing-medium-small;
     }

--- a/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/diagnosticStatusBadge.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/diagnosticStatusBadge.module.scss
@@ -1,5 +1,16 @@
+@import "src/core/index.module";
+
 .diagnostic-status-badge {
   &__content {
     width: fit-content;
   }
+}
+
+.tooltip--title a {
+    color: $colors--neutral-0;
+    text-decoration: underline;
+    &:hover {
+      opacity: 0.7;
+      color: $colors--neutral-0;
+    }
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/diagnosticStatusBadge.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/diagnosticStatusBadge.tsx
@@ -56,13 +56,13 @@ function mapStatusToDescription(diagnosticsStatus: DiagnosticStatuses) {
       );
     case "WAITING":
       return (
-        <div className={cx("tooltip__table--title")}>
+        <div className={cx("tooltip--title")}>
           <p>
             CockroachDB is waiting for the next SQL statement that matches this
             fingerprint.
           </p>
           <p>
-            {"When the most recent "}
+            {" When the most recent "}
             <Anchor href={statementDiagnostics} target="_blank">
               diagnostics
             </Anchor>

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
@@ -51,6 +51,12 @@
   width: fit-content;
 }
 
+.reset-btn-area {
+  height: $line-height--larger;
+  display: flex;
+  align-items: center;
+}
+
 .app-filter-dropdown {
   /* 
     we are truncating the text in the filter, 

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.tsx
@@ -111,7 +111,7 @@ export const StatementTableCell = {
                   return {
                     name: (
                       <div className={cx("diagnostic-report-dropdown-option")}>
-                        {`Cancel current diagnostic request`}
+                        {`Cancel diagnostic request`}
                       </div>
                     ),
                     value: dr,

--- a/pkg/ui/workspaces/db-console/src/views/app/containers/layout/layout.styl
+++ b/pkg/ui/workspaces/db-console/src/views/app/containers/layout/layout.styl
@@ -36,7 +36,7 @@ $subnav-background  = $background-color
     align-items center
 
     .page-config__item
-      margin-right 24px
+      margin-right 12px
 
   &__spread
     display flex

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/statementDiagnosticsHistory/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/statementDiagnosticsHistory/index.tsx
@@ -205,14 +205,14 @@ class StatementDiagnosticsHistoryView extends React.Component<
     if (totalCount <= this.tablePageSize) {
       return (
         <div className="diagnostics-history-view__table-header">
-          <Text>{`${totalCount} traces`}</Text>
+          <Text>{`${totalCount} diagnostics bundles`}</Text>
         </div>
       );
     }
 
     return (
       <div className="diagnostics-history-view__table-header">
-        <Text>{`${this.tablePageSize} of ${totalCount} traces`}</Text>
+        <Text>{`${this.tablePageSize} of ${totalCount} diagnostics bundles`}</Text>
       </div>
     );
   };

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/pageconfig/pageConfig.module.styl
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/pageconfig/pageConfig.module.styl
@@ -34,7 +34,7 @@
     align-items center
 
     .page-config__item
-      margin-right 24px
+      margin-right 12px
 
   &__spread
     display flex


### PR DESCRIPTION
This commit introduces fixes to Statements Page:

- Update style of link on tooltip for diagnostic status and
add space before `When`
Before
<img width="504" alt="Screen Shot 2022-03-18 at 3 57 22 PM" src="https://user-images.githubusercontent.com/1017486/159090521-b99f2721-5e02-4aee-af93-629292256fa5.png">

After
<img width="483" alt="Screen Shot 2022-03-18 at 3 57 13 PM" src="https://user-images.githubusercontent.com/1017486/159090544-84248037-b599-430c-9d79-338c736293b7.png">


- Remove word `current` from the Cancel Diagnostics request
Before
<img width="334" alt="Screen Shot 2022-03-18 at 3 58 01 PM" src="https://user-images.githubusercontent.com/1017486/159090581-96a5dd16-2e46-42ad-9340-f264d72bacdb.png">

After
<img width="229" alt="Screen Shot 2022-03-18 at 3 58 44 PM" src="https://user-images.githubusercontent.com/1017486/159090593-1cf444c9-85c8-484c-a095-c84a2532b91b.png">


- Slow loading message only show after a few seconds of page loading
Video: https://www.loom.com/share/dd9f41fc00994a1ea852747e6606afc7

- Space between item (search / filter/ time picker) are now 12px and
the size of both dividers are the same (using the heigh of all items)
Before
<img width="1253" alt="Screen Shot 2022-03-18 at 4 35 29 PM" src="https://user-images.githubusercontent.com/1017486/159090649-0e23f766-63fb-40ae-ae68-04ffa1987ced.png">

After
<img width="1156" alt="Screen Shot 2022-03-18 at 6 03 25 PM" src="https://user-images.githubusercontent.com/1017486/159090718-1ab25df0-0da9-43cb-b29b-9c5351f001de.png">


- Update color of alert message on Conditional Diagnostic Request
Before
<img width="504" alt="Screen Shot 2022-03-18 at 5 08 52 PM" src="https://user-images.githubusercontent.com/1017486/159090753-f1f62533-2392-462d-beaa-f479665bcc30.png">

After
<img width="516" alt="Screen Shot 2022-03-18 at 5 16 18 PM" src="https://user-images.githubusercontent.com/1017486/159090767-acef5ea6-23ab-486e-a1c5-d9ada1eb0ffc.png">

- Change `trace` to `diagnostic bundle`
Before
<img width="343" alt="Screen Shot 2022-03-18 at 5 21 03 PM" src="https://user-images.githubusercontent.com/1017486/159090803-f2a4547e-3792-4133-89b5-a72757c3f1fa.png">

After
<img width="374" alt="Screen Shot 2022-03-18 at 5 43 18 PM" src="https://user-images.githubusercontent.com/1017486/159090817-eff5e19f-29da-4d2c-95e2-fceb780d152c.png">

- Update link color/underline on hover for node and app name
Before
<img width="182" alt="Screen Shot 2022-03-18 at 5 46 34 PM" src="https://user-images.githubusercontent.com/1017486/159090832-06aa3a90-0488-4b4a-a7d4-0430b37da370.png">

After
<img width="202" alt="Screen Shot 2022-03-18 at 5 53 04 PM" src="https://user-images.githubusercontent.com/1017486/159090845-1d7b0428-7c79-4f88-a7e2-bb4efa692681.png">

Partially addresses #77982

Release note: None