### PR TITLE
ui/tracez: better recording control

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -6943,6 +6943,8 @@ the tracing UI.
 | start | [google.protobuf.Timestamp](#cockroach.server.serverpb.GetTracingSnapshotResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
 | goroutine_id | [uint64](#cockroach.server.serverpb.GetTracingSnapshotResponse-uint64) |  |  | [reserved](#support-status) |
 | processed_tags | [SpanTag](#cockroach.server.serverpb.GetTracingSnapshotResponse-cockroach.server.serverpb.SpanTag) | repeated |  | [reserved](#support-status) |
+| current | [bool](#cockroach.server.serverpb.GetTracingSnapshotResponse-bool) |  | current is set if the span is still alive (i.e. still present in the active spans registry). | [reserved](#support-status) |
+| current_recording_mode | [cockroach.util.tracing.tracingpb.RecordingMode](#cockroach.server.serverpb.GetTracingSnapshotResponse-cockroach.util.tracing.tracingpb.RecordingMode) |  | current_recording_mode represents the span's current recording mode. This is not set if current == false. | [reserved](#support-status) |
 
 
 

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -3557,12 +3557,13 @@ func (s *adminServer) GetTracingSnapshot(
 	}
 
 	id := tracing.SnapshotID(req.SnapshotId)
-	snapshot, err := s.server.cfg.Tracer.GetSnapshot(id)
+	tr := s.server.cfg.Tracer
+	snapshot, err := tr.GetSnapshot(id)
 	if err != nil {
 		return nil, err
 	}
 
-	spansList := tracingui.ProcessSnapshot(snapshot)
+	spansList := tracingui.ProcessSnapshot(snapshot, tr.GetActiveSpansRegistry())
 
 	spans := make([]*serverpb.TracingSpan, len(spansList.Spans))
 	stacks := make(map[string]string)
@@ -3585,13 +3586,15 @@ func (s *adminServer) GetTracingSnapshot(
 		}
 
 		spans[i] = &serverpb.TracingSpan{
-			Operation:     s.Operation,
-			TraceID:       s.TraceID,
-			SpanID:        s.SpanID,
-			ParentSpanID:  s.ParentSpanID,
-			Start:         &s.Start,
-			GoroutineID:   s.GoroutineID,
-			ProcessedTags: tags,
+			Operation:            s.Operation,
+			TraceID:              s.TraceID,
+			SpanID:               s.SpanID,
+			ParentSpanID:         s.ParentSpanID,
+			Start:                s.Start,
+			GoroutineID:          s.GoroutineID,
+			ProcessedTags:        tags,
+			Current:              s.Current,
+			CurrentRecordingMode: s.CurrentRecordingMode.ToProto(),
 		}
 	}
 
@@ -3645,7 +3648,7 @@ func (s *adminServer) GetTrace(
 	// recording mode. If we were asked to display the current trace (as opposed
 	// to the trace saved in a snapshot), we also collect the recording.
 	traceStillExists := false
-	if err := s.server.cfg.Tracer.SpanRegistry().VisitSpans(func(sp tracing.RegistrySpan) error {
+	if err := s.server.cfg.Tracer.SpanRegistry().VisitRoots(func(sp tracing.RegistrySpan) error {
 		if sp.TraceID() != traceID {
 			return nil
 		}
@@ -3682,7 +3685,8 @@ func (s *adminServer) SetTraceRecordingType(
 		if sp.TraceID() != req.TraceID {
 			return nil
 		}
-		sp.SetRecordingType(tracing.RecordingVerbose) // NB: The recording type propagates to the children, recursively.
+		// NB: The recording type propagates to the children, recursively.
+		sp.SetRecordingType(tracing.RecordingTypeFromProto(req.RecordingMode))
 		return nil
 	})
 	return &serverpb.SetTraceRecordingTypeResponse{}, nil

--- a/pkg/server/node_tenant_test.go
+++ b/pkg/server/node_tenant_test.go
@@ -104,6 +104,7 @@ func TestRedactRecordingForTenant(t *testing.T) {
 			RedactableLogs    bool
 			Logs              []tracingpb.LogRecord
 			Verbose           bool
+			RecordingMode     tracingpb.RecordingMode
 			GoroutineID       uint64
 			Finished          bool
 			StructuredRecords []tracingpb.StructuredRecord

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -1191,9 +1191,15 @@ message TracingSpan {
   uint64 trace_id = 2 [(gogoproto.customname) = "TraceID"];
   uint64 span_id = 3 [(gogoproto.customname) = "SpanID"];
   uint64 parent_span_id = 4 [(gogoproto.customname) = "ParentSpanID"];
-  google.protobuf.Timestamp start = 5 [(gogoproto.stdtime) = true];
+  google.protobuf.Timestamp start = 5 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
   uint64 goroutine_id = 6 [(gogoproto.customname) = "GoroutineID"];
   repeated SpanTag processed_tags = 7;
+  // current is set if the span is still alive (i.e. still present in the active
+  // spans registry).
+  bool current = 8;
+  // current_recording_mode represents the span's current recording mode. This is
+  // not set if current == false.
+  util.tracing.tracingpb.RecordingMode current_recording_mode = 9;
 }
 
 // SpanTag represents a tag on a tracing span, in a form processed for the use

--- a/pkg/ui/workspaces/db-console/src/views/tracez/tracez.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/tracez/tracez.tsx
@@ -34,14 +34,15 @@ import {
   takeTracingSnapshot,
 } from "src/util/api";
 import { CaretRight } from "@cockroachlabs/icons";
+import { Switch } from "antd";
 import ISnapshotInfo = cockroach.server.serverpb.ISnapshotInfo;
+import ITracingSpan = cockroach.server.serverpb.ITracingSpan;
 import GetTracingSnapshotRequest = cockroach.server.serverpb.GetTracingSnapshotRequest;
 import GetTraceRequest = cockroach.server.serverpb.GetTraceRequest;
 import IGetTraceResponse = cockroach.server.serverpb.IGetTraceResponse;
 import ISpanTag = cockroach.server.serverpb.ISpanTag;
 import SetTraceRecordingTypeRequest = cockroach.server.serverpb.SetTraceRecordingTypeRequest;
 import RecordingMode = cockroach.util.tracing.tracingpb.RecordingMode;
-import { Switch } from "antd";
 
 const TS_FORMAT = "MMMM Do YYYY, h:mm:ss a"; // January 28th 2022, 7:12:40 pm;
 
@@ -75,9 +76,8 @@ const SnapshotSelector = ({
 };
 
 interface SnapshotRow {
-  span: cockroach.server.serverpb.ITracingSpan;
+  span: ITracingSpan;
   stack: string;
-  recording?: boolean;
 }
 
 const GoroutineToggler = ({ id, stack }: { id: Long; stack: string }) => {
@@ -184,9 +184,9 @@ const TagCell = (props: {
 };
 
 const snapshotColumns = (
-  setRecording: (span: cockroach.server.serverpb.ITracingSpan) => void,
+  setRecording: (span: ITracingSpan) => void,
   setSearch: (s: string) => void,
-  setTraceRecordingVerbose: (trace_id: Long) => void,
+  setTraceRecordingVerbose: (span: ITracingSpan) => void,
 ): ColumnDescriptor<SnapshotRow>[] => {
   return [
     {
@@ -205,12 +205,12 @@ const snapshotColumns = (
       name: "recording",
       cell: sr => (
         <Switch
-          checked={sr.recording}
-          // TODO(davidh): Implement toggling back and forth
-          onClick={() => setTraceRecordingVerbose(sr.span.trace_id)}
+          disabled={!sr.span.current}
+          checked={sr.span.current_recording_mode != RecordingMode.OFF}
+          onClick={() => setTraceRecordingVerbose(sr.span)}
         />
       ),
-      sort: sr => `${sr.recording}`,
+      sort: sr => `${sr.span.current_recording_mode}`,
     },
     {
       title: "Start Time",
@@ -242,7 +242,7 @@ const CurrentSnapshot = ({
   search: string;
   setRecording: (trace: cockroach.server.serverpb.ITracingSpan) => void;
   setSearch: (s: string) => void;
-  setTraceRecordingVerbose: (trace_id: Long) => void;
+  setTraceRecordingVerbose: (span: ITracingSpan) => void;
 }) => {
   const [sortSetting, setSortSetting] = useState<SortSetting>({
     ascending: true,
@@ -298,12 +298,14 @@ export const Tracez = () => {
       setSnapshot({
         id: req.snapshot.snapshot_id,
         captured_at: req.snapshot.captured_at,
-        rows: req.snapshot.spans.map(span => {
-          return {
-            span,
-            stack: req.snapshot.stacks[`${span.goroutine_id}`],
-          };
-        }),
+        rows: req.snapshot.spans.map(
+          (span: cockroach.server.serverpb.ITracingSpan): SnapshotRow => {
+            return {
+              span,
+              stack: req.snapshot.stacks[`${span.goroutine_id}`],
+            };
+          },
+        ),
       });
     });
   };
@@ -351,20 +353,24 @@ export const Tracez = () => {
     }
   }, [showTrace, snapshot, requestedSpan, showLiveTrace]);
 
-  const setTraceRecordingVerbose = (t: Long) => {
+  const setTraceRecordingVerbose = (span: ITracingSpan) => {
+    const recMode =
+      span.current_recording_mode != RecordingMode.OFF
+        ? RecordingMode.OFF
+        : RecordingMode.VERBOSE;
     setTraceRecordingType(
       new SetTraceRecordingTypeRequest({
-        trace_id: t,
-        recording_mode: RecordingMode.VERBOSE,
-        // TODO(davidh): do we need `span_id` on this request?
+        trace_id: span.trace_id,
+        recording_mode: recMode,
       }),
     ).then(() => {
+      // We modify the snapshot in place.
       setSnapshot({
         id: snapshot.id,
         captured_at: snapshot.captured_at,
         rows: snapshot.rows.map(r => {
-          if (r.span.trace_id === t) {
-            r.recording = true;
+          if (r.span.trace_id === span.trace_id) {
+            r.span.current_recording_mode = recMode;
           }
           return r;
         }),
@@ -458,7 +464,7 @@ interface SnapshotViewProps {
   setSearch: (s: string) => void;
   search: string;
   setRecording: (s: cockroach.server.serverpb.ITracingSpan) => void;
-  setTraceRecordingVerbose: (trace_id: Long) => void;
+  setTraceRecordingVerbose: (span: ITracingSpan) => void;
 }
 
 const SnapshotView = ({

--- a/pkg/ui/workspaces/db-console/src/views/tracez/tracez.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/tracez/tracez.tsx
@@ -77,7 +77,7 @@ const SnapshotSelector = ({
 interface SnapshotRow {
   span: cockroach.server.serverpb.ITracingSpan;
   stack: string;
-  verbose?: boolean;
+  recording?: boolean;
 }
 
 const GoroutineToggler = ({ id, stack }: { id: Long; stack: string }) => {
@@ -201,16 +201,16 @@ const snapshotColumns = (
       cell: sr => <TagCell sr={sr} setSearch={setSearch} />,
     },
     {
-      title: "Verbose",
-      name: "verbose",
+      title: "Recording",
+      name: "recording",
       cell: sr => (
         <Switch
-          checked={sr.verbose}
+          checked={sr.recording}
           // TODO(davidh): Implement toggling back and forth
           onClick={() => setTraceRecordingVerbose(sr.span.trace_id)}
         />
       ),
-      sort: sr => `${sr.verbose}`,
+      sort: sr => `${sr.recording}`,
     },
     {
       title: "Start Time",
@@ -364,7 +364,7 @@ export const Tracez = () => {
         captured_at: snapshot.captured_at,
         rows: snapshot.rows.map(r => {
           if (r.span.trace_id === t) {
-            r.verbose = true;
+            r.recording = true;
           }
           return r;
         }),

--- a/pkg/util/tracing/recording.go
+++ b/pkg/util/tracing/recording.go
@@ -70,6 +70,20 @@ func (t RecordingType) ToProto() tracingpb.RecordingMode {
 	}
 }
 
+// RecordingTypeFromProto converts from the proto values to the corresponding enum.
+func RecordingTypeFromProto(val tracingpb.RecordingMode) RecordingType {
+	switch val {
+	case tracingpb.RecordingMode_OFF:
+		return RecordingOff
+	case tracingpb.RecordingMode_STRUCTURED:
+		return RecordingStructured
+	case tracingpb.RecordingMode_VERBOSE:
+		return RecordingVerbose
+	default:
+		panic(fmt.Sprintf("invalid RecordingType: %d", val))
+	}
+}
+
 // RecordingTypeFromCarrierValue decodes a recording type carried by a carrier.
 func RecordingTypeFromCarrierValue(val string) RecordingType {
 	switch val {
@@ -421,7 +435,7 @@ func (r Recording) ToJaegerJSON(stmt, comment, nodeStr string) (string, error) {
 		// or not at the time each event was recorded, so we make a guess based on
 		// whether the span was verbose at the moment when the Recording was
 		// produced.
-		if !sp.Verbose {
+		if !(sp.Verbose || sp.RecordingMode == tracingpb.RecordingMode_VERBOSE) {
 			sp.Structured(func(sr *types.Any, t time.Time) {
 				jl := jaegerjson.Log{Timestamp: uint64(t.UnixNano() / 1000)}
 				jsonStr, err := MessageToJSONString(sr, true /* emitDefaults */)

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -650,6 +650,13 @@ func (sp *Span) reset(
 	sp.finishStack = ""
 }
 
+// visitOpenChildren calls the visitor for every open child. The receiver's lock
+// is held for the duration of the iteration, so the visitor should be quick.
+// The visitor is not allowed to hold on to children after it returns.
+func (sp *Span) visitOpenChildren(visitor func(sp *Span)) {
+	sp.i.crdb.visitOpenChildren(visitor)
+}
+
 // spanRef represents a reference to a span. In addition to a simple *Span, a
 // spanRef prevents the referenced span from being reallocated in between the
 // time when this spanRef was created and the time when release() is called. It

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -426,12 +426,12 @@ func (r *SpanRegistry) getSpanByID(id tracingpb.SpanID) RegistrySpan {
 	return crdbSpan
 }
 
-// VisitSpans calls the visitor callback for every local root span in the
+// VisitRoots calls the visitor callback for every local root span in the
 // registry. Iterations stops when the visitor returns an error. If that error
-// is iterutils.StopIteration(), then VisitSpans() returns nil.
+// is iterutils.StopIteration(), then VisitRoots() returns nil.
 //
 // The callback should not hold on to the span after it returns.
-func (r *SpanRegistry) VisitSpans(visitor func(span RegistrySpan) error) error {
+func (r *SpanRegistry) VisitRoots(visitor func(span RegistrySpan) error) error {
 	// Take a snapshot of the registry and release the lock.
 	r.mu.Lock()
 	spans := make([]spanRef, 0, len(r.mu.m))
@@ -456,6 +456,39 @@ func (r *SpanRegistry) VisitSpans(visitor func(span RegistrySpan) error) error {
 		}
 	}
 	return nil
+}
+
+// visitTrace recursively calls the visitor on sp and all its descedents.
+func visitTrace(sp *Span, visitor func(sp RegistrySpan)) {
+	visitor(sp.i.crdb)
+	sp.visitOpenChildren(func(sp *Span) {
+		visitTrace(sp, visitor)
+	})
+}
+
+// VisitSpans calls the visitor callback for every span in the
+// registry.
+//
+// The callback should not hold on to the span after it returns.
+func (r *SpanRegistry) VisitSpans(visitor func(span RegistrySpan)) {
+	// Take a snapshot of the registry and release the lock.
+	r.mu.Lock()
+	spans := make([]spanRef, 0, len(r.mu.m))
+	for _, sp := range r.mu.m {
+		// We'll keep the spans alive while we're visiting them below.
+		spans = append(spans, makeSpanRef(sp.sp))
+	}
+	r.mu.Unlock()
+
+	defer func() {
+		for i := range spans {
+			spans[i].release()
+		}
+	}()
+
+	for _, sp := range spans {
+		visitTrace(sp.Span, visitor)
+	}
 }
 
 // testingAll returns (pointers to) all the spans in the registry, in an
@@ -1399,6 +1432,12 @@ type RegistrySpan interface {
 
 var _ RegistrySpan = &crdbSpan{}
 
+// GetActiveSpansRegistry returns a pointer to the registry containing all
+// in-flight on the node.
+func (t *Tracer) GetActiveSpansRegistry() *SpanRegistry {
+	return t.activeSpansRegistry
+}
+
 // GetActiveSpanByID retrieves any active root span given its ID.
 func (t *Tracer) GetActiveSpanByID(spanID tracingpb.SpanID) RegistrySpan {
 	return t.activeSpansRegistry.getSpanByID(spanID)
@@ -1410,7 +1449,7 @@ func (t *Tracer) GetActiveSpanByID(spanID tracingpb.SpanID) RegistrySpan {
 //
 // The callback should not hold on to the span after it returns.
 func (t *Tracer) VisitSpans(visitor func(span RegistrySpan) error) error {
-	return t.activeSpansRegistry.VisitSpans(visitor)
+	return t.activeSpansRegistry.VisitRoots(visitor)
 }
 
 // TestingRecordAsyncSpans is a test-only helper that configures

--- a/pkg/util/tracing/tracer_snapshots.go
+++ b/pkg/util/tracing/tracer_snapshots.go
@@ -145,7 +145,7 @@ func (t *Tracer) generateSnapshot() SpansSnapshot {
 	capturedAt := timeutil.Now()
 	// Collect the traces.
 	traces := make([]Recording, 0, 1000)
-	_ = t.SpanRegistry().VisitSpans(func(sp RegistrySpan) error {
+	_ = t.SpanRegistry().VisitRoots(func(sp RegistrySpan) error {
 		rec := sp.GetFullRecording(RecordingVerbose)
 		traces = append(traces, rec)
 		return nil

--- a/pkg/util/tracing/tracingpb/recorded_span.proto
+++ b/pkg/util/tracing/tracingpb/recorded_span.proto
@@ -16,6 +16,7 @@ import "gogoproto/gogo.proto";
 import "google/protobuf/any.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/duration.proto";
+import "util/tracing/tracingpb/tracing.proto";
 
 // LogRecord is a log message recorded in a traced span.
 message LogRecord {
@@ -79,7 +80,13 @@ message RecordedSpan {
   repeated LogRecord logs = 9 [(gogoproto.nullable) = false];
   // verbose indicates whether the span was recording in verbose mode at the
   // time the recording was produced.
+  //
+  // This field is deprecated; it can be removed in 23.1. Use recording_mode
+  // instead.
   bool verbose = 16;
+  // recording_mode indicates the recording mode of the span at the the
+  // recording was produced.
+  RecordingMode recording_mode = 17;
 
   // The ID of the goroutine on which the span was created.
   uint64 goroutine_id = 12 [(gogoproto.customname) = "GoroutineID"];


### PR DESCRIPTION
Before this patch, the tracez did not properly display each span's
recording mode. It also didn't let you turn of a trace's recording.
Now, you can toggle recording on/off for each trace, and whenever a
snapshot is displayed, the *current* recording status of each span is
reflected. This is done by joining the snapshot with the live registry
when loading a snapshot in order to see which spans are currently
recording. We now also display a hint about spans from a snapshot that
are not live any more: their recording toggle is disabled.

This patch also fixes a bug causing all the spans to be displayed as
having the same start time.

Release note: None