### PR TITLE
spanconfig/job: improve retry behaviour under failures

### DIFF
--- a/pkg/spanconfig/spanconfigjob/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigjob/BUILD.bazel
@@ -13,6 +13,8 @@ go_library(
         "//pkg/sql",
         "//pkg/util",
         "//pkg/util/hlc",
+        "//pkg/util/log",
+        "//pkg/util/retry",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/spanconfig/spanconfigjob/job.go
+++ b/pkg/spanconfig/spanconfigjob/job.go
@@ -21,6 +21,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
@@ -40,7 +42,16 @@ var reconciliationJobCheckpointInterval = settings.RegisterDurationSetting(
 )
 
 // Resume implements the jobs.Resumer interface.
-func (r *resumer) Resume(ctx context.Context, execCtxI interface{}) error {
+func (r *resumer) Resume(ctx context.Context, execCtxI interface{}) (jobErr error) {
+	defer func() {
+		// This job retries internally, any error here should fail the entire job
+		// (at which point we expect the spanconfig.Manager to create a new one).
+		// Between the job's internal retries and the spanconfig.Manager, we don't
+		// need/want to rely on the job system's internal backoff (where retry
+		// durations aren't configurable on a per-job basis).
+		jobErr = jobs.MarkAsPermanentJobError(jobErr)
+	}()
+
 	execCtx := execCtxI.(sql.JobExecContext)
 	rc := execCtx.SpanConfigReconciler()
 	stopper := execCtx.ExecCfg().DistSQLSrv.Stopper
@@ -86,30 +97,67 @@ func (r *resumer) Resume(ctx context.Context, execCtxI interface{}) error {
 	})
 
 	shouldPersistCheckpoint := true
-	if knobs := execCtx.ExecCfg().SpanConfigTestingKnobs; knobs != nil && knobs.JobDisablePersistingCheckpoints {
-		shouldPersistCheckpoint = false
-	}
-	if err := rc.Reconcile(ctx, hlc.Timestamp{}, func() error {
-		if !shouldPersistCheckpoint {
-			return nil
-		}
-		if !persistCheckpoints.ShouldProcess(timeutil.Now()) {
-			return nil
-		}
+	shouldSkipRetry := false
+	var onCheckpointInterceptor func() error
 
-		return r.job.SetProgress(ctx, nil, jobspb.AutoSpanConfigReconciliationProgress{
-			Checkpoint: rc.Checkpoint(),
-		})
-	}); err != nil {
-		return err
+	if knobs := execCtx.ExecCfg().SpanConfigTestingKnobs; knobs != nil {
+		if knobs.JobDisablePersistingCheckpoints {
+			shouldPersistCheckpoint = false
+		}
+		shouldSkipRetry = knobs.JobDisableInternalRetry
+		onCheckpointInterceptor = knobs.JobOnCheckpointInterceptor
 	}
 
-	return nil
+	retryOpts := retry.Options{
+		InitialBackoff: 5 * time.Second,
+		MaxBackoff:     30 * time.Second,
+		Multiplier:     1.3,
+		MaxRetries:     40, // ~20 mins
+	}
+
+	const aWhile = 5 * time.Minute // arbitrary but much longer than a retry
+	for retrier := retry.StartWithCtx(ctx, retryOpts); retrier.Next(); {
+		started := timeutil.Now()
+		if err := rc.Reconcile(ctx, hlc.Timestamp{}, func() error {
+			if onCheckpointInterceptor != nil {
+				if err := onCheckpointInterceptor(); err != nil {
+					return err
+				}
+			}
+
+			if !shouldPersistCheckpoint {
+				return nil
+			}
+			if !persistCheckpoints.ShouldProcess(timeutil.Now()) {
+				return nil
+			}
+
+			if timeutil.Since(started) > aWhile {
+				retrier.Reset()
+			}
+
+			return r.job.SetProgress(ctx, nil, jobspb.AutoSpanConfigReconciliationProgress{
+				Checkpoint: rc.Checkpoint(),
+			})
+		}); err != nil {
+			log.Errorf(ctx, "reconciler failed with %v, retrying...", err)
+			if shouldSkipRetry {
+				break
+			}
+			continue
+		}
+		return nil // we're done here (the stopper was stopped, Reconcile exited cleanly)
+	}
+
+	return errors.Newf("reconciliation unsuccessful, failing job")
 }
 
 // OnFailOrCancel implements the jobs.Resumer interface.
-func (r *resumer) OnFailOrCancel(context.Context, interface{}) error {
-	return errors.AssertionFailedf("span config reconciliation job can never fail or be canceled")
+func (r *resumer) OnFailOrCancel(ctx context.Context, _ interface{}) error {
+	if jobs.HasErrJobCanceled(errors.DecodeError(ctx, *r.job.Payload().FinalResumeError)) {
+		return errors.AssertionFailedf("span config reconciliation job cannot be canceled")
+	}
+	return nil
 }
 
 func init() {

--- a/pkg/spanconfig/spanconfigmanager/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigmanager/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/protoutil",
+        "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_sync//errgroup",

--- a/pkg/spanconfig/spanconfigmanager/manager_test.go
+++ b/pkg/spanconfig/spanconfigmanager/manager_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
@@ -27,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -267,4 +269,93 @@ func TestReconciliationJobIsIdle(t *testing.T) {
 		}
 		return nil
 	})
+}
+
+// TestReconciliationJobErrorFailsJob tests that injecting an error into the
+// reconciliation job fails the entire job (if bypassing the internal retry); if
+// re-checked by the manager (and assuming we're no longer injecting an error),
+// the job runs successfully.
+func TestReconciliationJobErrorFailsJob(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	errMu := struct {
+		syncutil.Mutex
+		err error
+	}{}
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				SpanConfig: &spanconfig.TestingKnobs{
+					ManagerDisableJobCreation:                      true, // disable the automatic job creation
+					JobDisableInternalRetry:                        true,
+					SQLWatcherCheckpointNoopsEveryDurationOverride: 100 * time.Millisecond,
+					JobOnCheckpointInterceptor: func() error {
+						errMu.Lock()
+						defer errMu.Unlock()
+
+						return errMu.err
+					},
+				},
+			},
+		},
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	waitForJobStatus := func(jobID jobspb.JobID, status jobs.Status) {
+		testutils.SucceedsSoon(t, func() error {
+			var jobStatus string
+			tdb.QueryRow(t, `SELECT status FROM system.jobs WHERE id = $1`, jobID).Scan(&jobStatus)
+
+			if jobs.Status(jobStatus) != status {
+				return errors.Newf("expected jobID %d to have status %, got %s", jobID, status, jobStatus)
+			}
+			return nil
+		})
+	}
+
+	var jobID jobspb.JobID
+	ts := tc.Server(0)
+	manager := spanconfigmanager.New(
+		ts.DB(),
+		ts.JobRegistry().(*jobs.Registry),
+		ts.InternalExecutor().(*sql.InternalExecutor),
+		ts.Stopper(),
+		ts.ClusterSettings(),
+		ts.SpanConfigReconciler().(spanconfig.Reconciler),
+		&spanconfig.TestingKnobs{
+			ManagerCreatedJobInterceptor: func(jobI interface{}) {
+				jobID = jobI.(*jobs.Job).ID()
+			},
+		},
+	)
+
+	started, err := manager.TestingCreateAndStartJobIfNoneExists(ctx)
+	require.NoError(t, err)
+	require.True(t, started)
+
+	testutils.SucceedsSoon(t, func() error {
+		if jobID == jobspb.JobID(0) {
+			return errors.New("waiting for reconciliation job to be started")
+		}
+		return nil
+	})
+
+	errMu.Lock()
+	errMu.err = errors.New("injected")
+	errMu.Unlock()
+
+	waitForJobStatus(jobID, jobs.StatusFailed)
+
+	errMu.Lock()
+	errMu.err = nil
+	errMu.Unlock()
+
+	started, err = manager.TestingCreateAndStartJobIfNoneExists(ctx)
+	require.NoError(t, err)
+	require.True(t, started)
+
+	waitForJobStatus(jobID, jobs.StatusRunning)
 }

--- a/pkg/spanconfig/testing_knobs.go
+++ b/pkg/spanconfig/testing_knobs.go
@@ -41,6 +41,14 @@ type TestingKnobs struct {
 	// job from persisting checkpoints.
 	JobDisablePersistingCheckpoints bool
 
+	// JobDisableInternalRetry disables the span config reconciliation job's
+	// internal retry loop.
+	JobDisableInternalRetry bool
+
+	// JobPersistCheckpointInterceptor, if set, is invoked before the
+	// reconciliation job persists checkpoints.
+	JobOnCheckpointInterceptor func() error
+
 	// KVSubscriberRangeFeedKnobs control lifecycle events for the rangefeed
 	// underlying the KVSubscriber.
 	KVSubscriberRangeFeedKnobs base.ModuleTestingKnobs


### PR DESCRIPTION
Previously if the reconciliation job failed (say, with retryable buffer
overflow errors from the sqlwatcher[^1]), we relied on the jobs
subsystem's backoff mechanism to re-kick the reconciliation job. The
retry loop there however is far too large, and has a max back-off of
24H; far too long for the span config reconciliation job. Instead we can
control the retry behavior directly within the reconciliation job,
something this PR now does. We still want to bound the number of
internal retries, possibly bouncing the job around to elsewhere in the
cluster afterwards. To do so, we now use the spanconfig.Manager's
periodic checks (every 10m per node) -- we avoid the jobs subsystem
retry loop by marking every error as a permanent one.

[^1]: In future PRs we'll introduce tests adding 100k-1M tables in large
     batches; when sufficiently large it's possible to blow past the
     sqlwatcher's rangefeed buffer limits on incremental updates. In
     these scenarios we want to gracefully fail + recover by re-starting
     the reconciler and re-running the initial scan.

Release justification: low risk, high benefit change
Release note: None