### PR TITLE
release-21.2: backupccl: allow user to run SHOW BACKUP on an encrypted incremental backup

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -67,6 +67,7 @@ const (
 	backupOptWithDebugIDs       = "debug_ids"
 	localityURLParam            = "COCKROACH_LOCALITY"
 	defaultLocalityValue        = "default"
+	backupOptEncDir             = "encryption_info_dir"
 )
 
 type tableAndIndex struct {

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -4567,6 +4567,11 @@ func TestEncryptedBackup(t *testing.T) {
 
 			sqlDB.Exec(t, fmt.Sprintf(`SHOW BACKUP $1 WITH %s`, encryptionOption), backupLoc1)
 
+			sqlDB.Exec(t, fmt.Sprintf(`SHOW BACKUP $1 WITH %s,encryption_info_dir='%s'`,
+				encryptionOption,
+				backupLoc1),
+				backupLoc1inc)
+
 			var expectedShowError string
 			if tc.useKMS {
 				expectedShowError = `one of the provided URIs was not used when encrypting the base BACKUP`
@@ -4580,6 +4585,9 @@ func TestEncryptedBackup(t *testing.T) {
 				`SHOW BACKUP $1`, backupLoc1)
 			sqlDB.ExpectErr(t, `could not find or read encryption information`,
 				fmt.Sprintf(`SHOW BACKUP $1 WITH %s`, encryptionOption), plainBackupLoc1)
+
+			sqlDB.ExpectErr(t, `If you are running SHOW BACKUP exclusively on an incremental backup`,
+				fmt.Sprintf(`SHOW BACKUP $1 WITH %s`, encryptionOption), backupLoc1inc)
 
 			sqlDB.Exec(t, fmt.Sprintf(`RESTORE DATABASE neverappears FROM ($1, $2), ($3, $4) WITH %s`,
 				encryptionOption), backupLoc1, backupLoc2, backupLoc1inc, backupLoc2inc)

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -181,6 +181,7 @@ func showBackupPlanHook(
 		backupOptWithPrivileges: sql.KVStringOptRequireNoValue,
 		backupOptAsJSON:         sql.KVStringOptRequireNoValue,
 		backupOptWithDebugIDs:   sql.KVStringOptRequireNoValue,
+		backupOptEncDir:         sql.KVStringOptRequireValue,
 	}
 	optsFn, err := p.TypeAsStringOpts(ctx, backup.Options, expected)
 	if err != nil {
@@ -254,9 +255,26 @@ func showBackupPlanHook(
 		}
 		defer store.Close()
 
+		// A user that calls SHOW BACKUP <incremental_dir> on an encrypted incremental
+		// backup will need to pass their full backup's directory to the
+		// encryption_info_dir parameter because the `ENCRYPTION-INFO` file
+		// necessary to decode the incremental backup lives in the full backup dir.
+		encStore := store
+		if encDir, ok := opts[backupOptEncDir]; ok {
+			encStore, err = p.ExecCfg().DistSQLSrv.ExternalStorageFromURI(ctx, encDir, p.User())
+			if err != nil {
+				return errors.Wrap(err, "make storage")
+			}
+			defer encStore.Close()
+		}
 		var encryption *jobspb.BackupEncryptionOptions
+		showEncErr := `If you are running SHOW BACKUP exclusively on an incremental backup, 
+you must pass the 'encryption_info_dir' parameter that points to the directory of your full backup`
 		if passphrase, ok := opts[backupOptEncPassphrase]; ok {
-			opts, err := readEncryptionOptions(ctx, store)
+			opts, err := readEncryptionOptions(ctx, encStore)
+			if errors.Is(err, errEncryptionInfoRead) {
+				return errors.WithHint(err, showEncErr)
+			}
 			if err != nil {
 				return err
 			}
@@ -264,7 +282,10 @@ func showBackupPlanHook(
 			encryption = &jobspb.BackupEncryptionOptions{Mode: jobspb.EncryptionMode_Passphrase,
 				Key: encryptionKey}
 		} else if kms, ok := opts[backupOptEncKMS]; ok {
-			opts, err := readEncryptionOptions(ctx, store)
+			opts, err := readEncryptionOptions(ctx, encStore)
+			if errors.Is(err, errEncryptionInfoRead) {
+				return errors.WithHint(err, showEncErr)
+			}
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Backport 1/1 commits from #78032.

/cc @cockroachdb/release

---

Previously, SHOW BACKUP <incremental_location> WITH kms='blah' (or with
encryption_passphrase) failed because the ENCRYPTION-INFO file is stored in the
full backup directory, not in the incremental directory. This patch adds the
encryption_dir parameter to SHOW BACKUP, which the user must set to the full
backup directory in order to view an incremental backup created with kms or an
encryption passphrase.

Fixes #77984

Release note (sql change): when the user runs SHOW BACKUP
on an encrypted incremental backup, they must set the encryption_info_dir directory
to the full backup directory in order for SHOW BACKUP to work.

Release Justification: non-invasive bug fix important to Cockroach Cloud