### PR TITLE
spanconfig/kvaccessor: re-work validation query

### DIFF
--- a/pkg/spanconfig/spanconfigkvaccessor/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigkvaccessor/BUILD.bazel
@@ -47,6 +47,8 @@ go_test(
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
+        "//pkg/util/log",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/spanconfig/spanconfigkvaccessor/kvaccessor.go
+++ b/pkg/spanconfig/spanconfigkvaccessor/kvaccessor.go
@@ -353,59 +353,64 @@ func (k *KVAccessor) constructValidationStmtAndArgs(
 	// what we do in GetSpanConfigRecords. For a single upserted span, we
 	// want effectively validate using:
 	//
+	//   -- verify only a single span overlaps with [$start, $end)
 	//   SELECT count(*) = 1 FROM system.span_configurations
 	//    WHERE start_key < $end AND end_key > $start
 	//
-	// Applying the GetSpanConfigRecords treatment, we can arrive at:
+	// With the naive form above that translates to an unbounded index scan on
+	// followed by a filter. Since start_key < end_key, and that spans are
+	// non-overlapping, we can instead do the following:
 	//
-	//   SELECT count(*) = 1 FROM (
-	//    SELECT * FROM span_configurations
-	//     WHERE start_key >= 100 AND start_key < 105
+	//   SELECT bool_and(valid) FROM (
+	//    SELECT bool_and(prev_end_key IS NULL OR start_key >= prev_end_key) AS valid FROM (
+	//     SELECT start_key, lag(end_key, 1) OVER (ORDER BY start_key) AS prev_end_key FROM span_configurations
+	//     WHERE start_key >= $start AND start_key < $end
+	//    )
 	//    UNION ALL
 	//    SELECT * FROM (
-	//      SELECT * FROM span_configurations
-	//      WHERE start_key < 100 ORDER BY start_key DESC LIMIT 1
-	//    ) WHERE end_key > 100
+	//     SELECT $start >= end_key FROM span_configurations
+	//     WHERE start_key < $start ORDER BY start_key DESC LIMIT 1
+	//    )
 	//   )
 	//
-	// To batch multiple query spans into the same statement, we make use of
-	// ALL and UNION ALL.
+	// The idea is to first find all spans that start within the span being
+	// upserted[1], compare each start key to the preceding end key[2] (if any)
+	// and ensure that they're non-overlapping[3]. We also verify the span with
+	// the start key immediately preceding the span being upserted[4]; ensuring
+	// that our upserted span does not overlap with it[5].
 	//
-	//   SELECT true = ALL(
-	//     ( ... validation statement for 1st query span ...),
-	//     UNION ALL
-	//     ( ... validation statement for 2nd query span ...),
-	//     ...
-	//   )
+	// When multiple spans are being upserted, we validate instead the span
+	// straddling all the individual spans being upserted, i.e.
+	// [$smallest-start-key, $largest-end-key).
 	//
-	var validationInnerStmtBuilder strings.Builder
-	validationQueryArgs := make([]interface{}, len(toUpsert)*2)
-	for i, entry := range toUpsert {
-		if i > 0 {
-			validationInnerStmtBuilder.WriteString(`UNION ALL`)
-		}
+	// [1]: WHERE start_key >= $start AND start_key < $end
+	// [2]: lag(end_key, 1) OVER (ORDER BY start_key) AS prev_end_key
+	// [3]: start_key >= prev_end_key
+	// [4]: WHERE start_key < $start ORDER BY start_key DESC LIMIT 1
+	// [5]: $start >= end_key
+	//
+	targetsToUpsert := spanconfig.TargetsFromRecords(toUpsert)
+	sort.Sort(spanconfig.Targets(targetsToUpsert))
 
-		startKeyIdx, endKeyIdx := i*2, (i*2)+1
-		validationQueryArgs[startKeyIdx] = entry.GetTarget().Encode().Key
-		validationQueryArgs[endKeyIdx] = entry.GetTarget().Encode().EndKey
+	validationQueryArgs := make([]interface{}, 2)
+	validationQueryArgs[0] = targetsToUpsert[0].Encode().Key
+	// NB: This is the largest key due to sort above + validation at the caller
+	// than ensures non-overlapping upser spans.
+	validationQueryArgs[1] = targetsToUpsert[len(targetsToUpsert)-1].Encode().EndKey
 
-		fmt.Fprintf(&validationInnerStmtBuilder, `
-SELECT count(*) = 1 FROM (
-  SELECT start_key, end_key, config FROM %[1]s
-   WHERE start_key >= $%[2]d AND start_key < $%[3]d
+	validationStmt := fmt.Sprintf(`
+SELECT bool_and(valid) FROM (
+  SELECT bool_and(prev_end_key IS NULL OR start_key >= prev_end_key) AS valid FROM (
+    SELECT start_key, lag(end_key, 1) OVER (ORDER BY start_key) AS prev_end_key FROM %[1]s
+    WHERE start_key >= $1 AND start_key < $2
+  )
   UNION ALL
-  SELECT start_key, end_key, config FROM (
-    SELECT start_key, end_key, config FROM %[1]s
-    WHERE start_key < $%[2]d ORDER BY start_key DESC LIMIT 1
-  ) WHERE end_key > $%[2]d
-)
-`,
-			k.configurationsTableFQN, // [1]
-			startKeyIdx+1,            // [2] -- prepared statement placeholder (1-indexed)
-			endKeyIdx+1,              // [3] -- prepared statement placeholder (1-indexed)
-		)
-	}
-	validationStmt := fmt.Sprintf("SELECT true = ALL(%s)", validationInnerStmtBuilder.String())
+  SELECT * FROM (
+    SELECT $1 >= end_key FROM %[1]s
+    WHERE start_key < $1 ORDER BY start_key DESC LIMIT 1
+  )
+)`, k.configurationsTableFQN)
+
 	return validationStmt, validationQueryArgs
 }
 
@@ -414,14 +419,7 @@ SELECT count(*) = 1 FROM (
 // expected to be valid and to have non-empty end keys. Spans are also expected
 // to be non-overlapping with other spans in the same list.
 func validateUpdateArgs(toDelete []spanconfig.Target, toUpsert []spanconfig.Record) error {
-	targetsToUpdate := func(recs []spanconfig.Record) []spanconfig.Target {
-		targets := make([]spanconfig.Target, len(recs))
-		for i, ent := range recs {
-			targets[i] = ent.GetTarget()
-		}
-		return targets
-	}(toUpsert)
-
+	targetsToUpdate := spanconfig.TargetsFromRecords(toUpsert)
 	for _, list := range [][]spanconfig.Target{toDelete, targetsToUpdate} {
 		if err := validateSpanTargets(list); err != nil {
 			return err

--- a/pkg/spanconfig/spanconfigkvaccessor/kvaccessor.go
+++ b/pkg/spanconfig/spanconfigkvaccessor/kvaccessor.go
@@ -395,7 +395,7 @@ func (k *KVAccessor) constructValidationStmtAndArgs(
 	validationQueryArgs := make([]interface{}, 2)
 	validationQueryArgs[0] = targetsToUpsert[0].Encode().Key
 	// NB: This is the largest key due to sort above + validation at the caller
-	// than ensures non-overlapping upser spans.
+	// than ensures non-overlapping upsert spans.
 	validationQueryArgs[1] = targetsToUpsert[len(targetsToUpsert)-1].Encode().EndKey
 
 	validationStmt := fmt.Sprintf(`

--- a/pkg/spanconfig/spanconfigkvaccessor/testdata/validation_encompass
+++ b/pkg/spanconfig/spanconfigkvaccessor/testdata/validation_encompass
@@ -1,0 +1,60 @@
+# Test a few instances where the kvaccessor validation should prevent us from
+# violating table invariants (installed spans are non-overlapping).
+# Specifically when updates overlap with and/or encompass spans already
+# present.
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state
+# set        [-A)  [-B|-C)  [--D--)
+kvaccessor-update
+upsert [b,c):A
+upsert [d,e):B
+upsert [e,f):C
+upsert [g,i):D
+----
+ok
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-A)  [-B|-C)  [--D--)
+# set     [--------X--------)
+kvaccessor-update
+upsert [a,g):X
+----
+err: expected to find single row containing upserted spans
+
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-A)  [-B|-C)  [--D--)
+# set     [--------X--|----Y---)
+kvaccessor-update
+upsert [a,e):X
+upsert [e,h):Y
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-A)  [-B|-C)  [--D--)
+# set     [--------X-----------)
+kvaccessor-update
+upsert [a,h):X
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-A)  [-B|-C)  [--D--)
+# set     [--------X-----|--Y--)
+kvaccessor-update
+upsert [a,f):X
+upsert [f,h):Y
+----
+err: expected to find single row containing upserted spans
+
+# All of the attempts above should've errored out -- expect to find the actual
+# state unchanged.
+kvaccessor-get
+span [a,j)
+----
+[b,c):A
+[d,e):B
+[e,f):C
+[g,i):D

--- a/pkg/spanconfig/spanconfigkvaccessor/testdata/validation_overlapping
+++ b/pkg/spanconfig/spanconfigkvaccessor/testdata/validation_overlapping
@@ -1,0 +1,159 @@
+# Test a few instances where the kvaccessor validation should prevent us from #
+# violating table invariants (installed spans are non-overlapping).
+# Specifically when updates partially overlap with what's already present.
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state
+# set        [-----X--------)
+# ====================================
+# result     [-----X--------)
+kvaccessor-update
+upsert [b,g):X
+----
+ok
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)
+kvaccessor-update
+upsert [a,c):A
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)              [--B--)
+kvaccessor-update
+upsert [a,c):A
+upsert [h,j):B
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)        [--B--)
+kvaccessor-update
+upsert [a,c):A
+upsert [f,h):B
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)     [--B--)
+kvaccessor-update
+upsert [a,c):A
+upsert [e,g):B
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)  [--B--)
+kvaccessor-update
+upsert [a,c):A
+upsert [d,f):B
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set           [--A--|--B--)
+kvaccessor-update
+upsert [c,e):A
+upsert [e,g):B
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)  [-B)  [--C--)
+kvaccessor-update
+upsert [a,c):A
+upsert [d,e):B
+upsert [f,h):C
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)  [-B)  [-C)
+kvaccessor-update
+upsert [a,c):A
+upsert [d,e):B
+upsert [f,g):C
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set              [-B)
+kvaccessor-update
+upsert [d,e):B
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set                    [-C)
+kvaccessor-update
+upsert [f,g):C
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)  [-B|-C|--D--)
+kvaccessor-update
+upsert [a,c):A
+upsert [d,e):B
+upsert [e,f):C
+upsert [f,h):D
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)              [--B--)
+kvaccessor-update
+upsert [a,c):A
+upsert [h,j):B
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)        [--B--)
+kvaccessor-update
+upsert [a,c):A
+upsert [f,h):B
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)     [--B--)
+# ====================================
+# result         [-X--|--B--)
+kvaccessor-update
+upsert [a,c):A
+upsert [e,g):B
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)  [-B)  [--C--)
+kvaccessor-update
+upsert [a,c):A
+upsert [d,e):B
+upsert [f,h):C
+----
+err: expected to find single row containing upserted spans
+
+# All of the attempts above should've errored out -- expect to find the actual
+# state unchanged.
+kvaccessor-get
+span [a,j)
+----
+[b,g):X

--- a/pkg/spanconfig/spanconfigkvaccessor/testdata/validation_straddle
+++ b/pkg/spanconfig/spanconfigkvaccessor/testdata/validation_straddle
@@ -1,0 +1,96 @@
+# Test a few instances where the kvaccessor validation should prevent us from
+# violating table invariants (installed spans are non-overlapping).
+# Specifically when updates overlap with and/or straddle multiple existing spans.
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state
+# set        [--A--)  [--B--)
+kvaccessor-update
+upsert [b,d):A
+upsert [e,g):B
+----
+ok
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set           [---X----)
+kvaccessor-update
+upsert [c,f):X
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set           [---X-------)
+kvaccessor-update
+upsert [c,g):X
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set           [---X----|xx)
+kvaccessor-update
+upsert [c,f):X
+delete [f,g)
+----
+err: expected to delete 1 row(s), deleted 0
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set           [---X----------)
+kvaccessor-update
+upsert [c,h):X
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set        [---X-------)
+kvaccessor-update
+upsert [b,f):X
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set     [------X-------)
+kvaccessor-update
+upsert [a,f):X
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set           [---X----)
+kvaccessor-update
+upsert [c,f):X
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set     [--X--|---Y----------)
+kvaccessor-update
+upsert [a,c):X
+upsert [c,h):Y
+----
+err: expected to find single row containing upserted spans
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set        [--X--|--Y--|-Z)
+kvaccessor-update
+upsert [b,d):X
+upsert [d,f):Y
+upsert [f,g):Z
+----
+err: expected to find single row containing upserted spans
+
+# All of the attempts above should've errored out -- expect to find the actual
+# state unchanged.
+kvaccessor-get
+span [a,j)
+----
+[b,d):A
+[e,g):B

--- a/pkg/spanconfig/spanconfigtestutils/utils.go
+++ b/pkg/spanconfig/spanconfigtestutils/utils.go
@@ -45,7 +45,7 @@ var configRe = regexp.MustCompile(`^(FALLBACK)|(^\w)$`)
 
 // ParseSpan is helper function that constructs a roachpb.Span from a string of
 // the form "[start, end)".
-func ParseSpan(t *testing.T, sp string) roachpb.Span {
+func ParseSpan(t testing.TB, sp string) roachpb.Span {
 	if !spanRe.MatchString(sp) {
 		t.Fatalf("expected %s to match span regex", sp)
 	}
@@ -60,7 +60,7 @@ func ParseSpan(t *testing.T, sp string) roachpb.Span {
 
 // parseSystemTarget is a helepr function that constructs a
 // spanconfig.SystemTarget from a string of the form {source=<id>,target=<id>}
-func parseSystemTarget(t *testing.T, systemTarget string) spanconfig.SystemTarget {
+func parseSystemTarget(t testing.TB, systemTarget string) spanconfig.SystemTarget {
 	if !systemTargetRe.MatchString(systemTarget) {
 		t.Fatalf("expected %s to match system target regex", systemTargetRe)
 	}
@@ -86,7 +86,7 @@ func parseSystemTarget(t *testing.T, systemTarget string) spanconfig.SystemTarge
 
 // ParseTarget is a helper function that constructs a spanconfig.Target from a
 // string that conforms to spanRe.
-func ParseTarget(t *testing.T, target string) spanconfig.Target {
+func ParseTarget(t testing.TB, target string) spanconfig.Target {
 	switch {
 	case spanRe.MatchString(target):
 		return spanconfig.MakeTargetFromSpan(ParseSpan(t, target))
@@ -101,7 +101,7 @@ func ParseTarget(t *testing.T, target string) spanconfig.Target {
 // ParseConfig is helper function that constructs a roachpb.SpanConfig that's
 // "tagged" with the given string (i.e. a constraint with the given string a
 // required key).
-func ParseConfig(t *testing.T, conf string) roachpb.SpanConfig {
+func ParseConfig(t testing.TB, conf string) roachpb.SpanConfig {
 	if !configRe.MatchString(conf) {
 		t.Fatalf("expected %s to match config regex", conf)
 	}
@@ -129,7 +129,7 @@ func ParseConfig(t *testing.T, conf string) roachpb.SpanConfig {
 // ParseSpanConfigRecord is helper function that constructs a
 // spanconfig.Target from a string of the form target:config. See
 // ParseTarget and ParseConfig above.
-func ParseSpanConfigRecord(t *testing.T, conf string) spanconfig.Record {
+func ParseSpanConfigRecord(t testing.TB, conf string) spanconfig.Record {
 	parts := strings.Split(conf, ":")
 	if len(parts) != 2 {
 		t.Fatalf("expected single %q separator", ":")
@@ -151,7 +151,7 @@ func ParseSpanConfigRecord(t *testing.T, conf string) spanconfig.Record {
 //		system-target {source=20,target=20}
 //		system-target {source=1,target=20}
 //
-func ParseKVAccessorGetArguments(t *testing.T, input string) []spanconfig.Target {
+func ParseKVAccessorGetArguments(t testing.TB, input string) []spanconfig.Target {
 	var targets []spanconfig.Target
 	for _, line := range strings.Split(input, "\n") {
 		line = strings.TrimSpace(line)
@@ -192,7 +192,7 @@ func ParseKVAccessorGetArguments(t *testing.T, input string) []spanconfig.Target
 // 		delete {source=1,target=20}:D
 //
 func ParseKVAccessorUpdateArguments(
-	t *testing.T, input string,
+	t testing.TB, input string,
 ) ([]spanconfig.Target, []spanconfig.Record) {
 	var toDelete []spanconfig.Target
 	var toUpsert []spanconfig.Record
@@ -225,7 +225,7 @@ func ParseKVAccessorUpdateArguments(
 //      set [c,d):C
 //      set [d,e):D
 //
-func ParseStoreApplyArguments(t *testing.T, input string) (updates []spanconfig.Update) {
+func ParseStoreApplyArguments(t testing.TB, input string) (updates []spanconfig.Update) {
 	for _, line := range strings.Split(input, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -274,7 +274,7 @@ func PrintSpan(sp roachpb.Span) string {
 }
 
 // PrintTarget is a helper function that prints a spanconfig.Target.
-func PrintTarget(t *testing.T, target spanconfig.Target) string {
+func PrintTarget(t testing.TB, target spanconfig.Target) string {
 	switch {
 	case target.IsSpanTarget():
 		return PrintSpan(target.GetSpan())
@@ -311,7 +311,7 @@ func PrintSpanConfig(config roachpb.SpanConfig) string {
 // entry is assumed to either have been constructed using ParseSpanConfigRecord
 // above, or the constituent span and config to have been constructed using the
 // Parse{Span,Config} helpers above.
-func PrintSpanConfigRecord(t *testing.T, record spanconfig.Record) string {
+func PrintSpanConfigRecord(t testing.TB, record spanconfig.Record) string {
 	return fmt.Sprintf("%s:%s", PrintTarget(t, record.GetTarget()), PrintSpanConfig(record.GetConfig()))
 }
 
@@ -478,7 +478,7 @@ func (rs SplitPoints) String() string {
 
 // GetSplitPoints returns a list of range split points as suggested by the given
 // StoreReader.
-func GetSplitPoints(ctx context.Context, t *testing.T, reader spanconfig.StoreReader) SplitPoints {
+func GetSplitPoints(ctx context.Context, t testing.TB, reader spanconfig.StoreReader) SplitPoints {
 	var splitPoints []SplitPoint
 	splitKey := roachpb.RKeyMin
 	for {
@@ -501,7 +501,7 @@ func GetSplitPoints(ctx context.Context, t *testing.T, reader spanconfig.StoreRe
 
 // ParseProtectionTarget returns a ptpb.Target based on the input. This target
 // could either refer to a Cluster, list of Tenants or SchemaObjects.
-func ParseProtectionTarget(t *testing.T, input string) *ptpb.Target {
+func ParseProtectionTarget(t testing.TB, input string) *ptpb.Target {
 	line := strings.Split(input, "\n")
 	if len(line) != 1 {
 		t.Fatal("only one target must be specified per protectedts operation")

--- a/pkg/spanconfig/target.go
+++ b/pkg/spanconfig/target.go
@@ -283,6 +283,16 @@ func TargetsFromProtos(protoTargets []roachpb.SpanConfigTarget) ([]Target, error
 	return targets, nil
 }
 
+// TargetsFromRecords extracts the list of underlying targets from the given
+// list of Records.
+func TargetsFromRecords(records []Record) []Target {
+	targets := make([]Target, len(records))
+	for i, rec := range records {
+		targets[i] = rec.GetTarget()
+	}
+	return targets
+}
+
 // TestingEntireSpanConfigurationStateTargets returns a list of targets which
 // can be used to read the entire span configuration state. This includes all
 // span configurations installed by all tenants and all system span


### PR DESCRIPTION
The previous validation query used point scans for each span being
upserted, and ended up being very memory intensive. This PR changes the
validation query to instead validate a single large span straddling all
the individual spans being upserted. The benchmark added in the previous
commit demonstrates the speed up:
```
   dev bench pkg/spanconfig/spanconfigkvaccessor
    -f=BenchmarkKVAccessorUpdate -v --bench-time=20x
```
Before:
```
  BenchmarkKVAccessorUpdate/batch-size=100-10       20     61.55 ms/batch     1.625 records/ms
  BenchmarkKVAccessorUpdate/batch-size=1000-10      20      1645 ms/batch     0.6078 records/ms
  BenchmarkKVAccessorUpdate/batch-size=10000-10     ran into memory bound account errors
```
After:
```
  BenchmarkKVAccessorUpdate/batch-size=100-10      200     11.25 ms/batch     8.889 records/ms
  BenchmarkKVAccessorUpdate/batch-size=1000-10     200     48.40 ms/batch     20.66 records/ms
  BenchmarkKVAccessorUpdate/batch-size=10000-10    200     222.6 ms/batch     44.92 records/ms
```
We want to validate that upserting spans does not break the invariant
that spans in the table are non-overlapping. We only need to validate
the spans that are being upserted, and can use a query similar to what
we do in GetSpanConfigRecords. For a single upserted span, we want
effectively validate using:
```sql
  -- verify only a single span overlaps with [$start, $end)
  SELECT count(*) = 1 FROM system.span_configurations
   WHERE start_key < $end AND end_key > $start
```
With the naive form above that translates to an unbounded index scan on
followed by a filter. Since start_key < end_key, and that spans are
non-overlapping, we can instead do the following:
```sql
  SELECT bool_and(valid) FROM (
   SELECT bool_and(prev_end_key IS NULL OR start_key >= prev_end_key) AS valid FROM (
    SELECT start_key, lag(end_key, 1) OVER (ORDER BY start_key) AS prev_end_key FROM span_configurations
    WHERE start_key >= $start AND start_key < $end
   )
   UNION ALL
   SELECT * FROM (
    SELECT $start >= end_key FROM span_configurations
    WHERE start_key < $start ORDER BY start_key DESC LIMIT 1
   )
  )
```
The idea is to first find all spans that start within the span being
upserted[^1], compare each start key to the preceding end key[^2] (if any)
and ensure that they're non-overlapping[^3]. We also verify the span with
the start key immediately preceding the span being upserted[^4]; ensuring
that our upserted span does not overlap with it[^5].

When multiple spans are being upserted, we validate instead the span
straddling all the individual spans being upserted, i.e.
[$smallest-start-key, $largest-end-key).

[^1]: WHERE start_key >= $start AND start_key < $end
[^2]: lag(end_key, 1) OVER (ORDER BY start_key) AS prev_end_key
[^3]: start_key >= prev_end_key
[^4]: WHERE start_key < $start ORDER BY start_key DESC LIMIT 1
[^5]: $start >= end_key

Release note: None
Release justification: low risk, high benefit change
