### PR TITLE
ttljob: fix range decoding bug

### DIFF
--- a/pkg/sql/ttl/ttljob/ttljob_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_test.go
@@ -481,7 +481,10 @@ func TestRowLevelTTLJobRandomEntries(t *testing.T) {
 				for i := 0; i < tc.numSplits; i++ {
 					var values []interface{}
 					var placeholders []string
-					for idx := 0; idx < tbDesc.GetPrimaryIndex().NumKeyColumns(); idx++ {
+
+					// Note we can split a PRIMARY KEY partially.
+					numKeyCols := 1 + rng.Intn(tbDesc.GetPrimaryIndex().NumKeyColumns())
+					for idx := 0; idx < numKeyCols; idx++ {
 						col, err := tbDesc.FindColumnWithID(tbDesc.GetPrimaryIndex().GetKeyColumnID(idx))
 						require.NoError(t, err)
 						placeholders = append(placeholders, fmt.Sprintf("$%d", idx+1))


### PR DESCRIPTION
Previously, when a range was split by a prefix of a PRIMARY KEY, the TTL
job would fail. This PR rectifies that.

Resolves #78162
Release note: None