### PR TITLE
backupccl: extend key rewriter to support rewriting tenant keys for stream replication

### DIFF
--- a/pkg/ccl/backupccl/key_rewriter.go
+++ b/pkg/ccl/backupccl/key_rewriter.go
@@ -87,6 +87,8 @@ type KeyRewriter struct {
 	// fromSystemTenant is true if the backup was produced by a system tenant,
 	// which is important in that it means any tenant prefixed keys belong to a
 	// backup of that tenant.
+	// It is also true when we use this to restore a tenant from a replication stream as
+	// it is only allowed for system tenant.
 	fromSystemTenant bool
 
 	prefixes prefixRewriter
@@ -94,9 +96,12 @@ type KeyRewriter struct {
 	descs    map[descpb.ID]catalog.TableDescriptor
 }
 
-// makeKeyRewriterFromRekeys makes a KeyRewriter from Rekey protos.
-func makeKeyRewriterFromRekeys(
-	codec keys.SQLCodec, tableRekeys []execinfrapb.TableRekey, tenantRekeys []execinfrapb.TenantRekey,
+// MakeKeyRewriterFromRekeys makes a KeyRewriter from Rekey protos.
+func MakeKeyRewriterFromRekeys(
+	codec keys.SQLCodec,
+	tableRekeys []execinfrapb.TableRekey,
+	tenantRekeys []execinfrapb.TenantRekey,
+	restoreTenantFromStream bool,
 ) (*KeyRewriter, error) {
 	descs := make(map[descpb.ID]catalog.TableDescriptor)
 	for _, rekey := range tableRekeys {
@@ -116,7 +121,7 @@ func makeKeyRewriterFromRekeys(
 		descs[descpb.ID(rekey.OldID)] = tabledesc.NewBuilder(table).BuildImmutableTable()
 	}
 
-	return makeKeyRewriter(codec, descs, tenantRekeys)
+	return makeKeyRewriter(codec, descs, tenantRekeys, restoreTenantFromStream)
 }
 
 var (
@@ -134,6 +139,7 @@ func makeKeyRewriter(
 	codec keys.SQLCodec,
 	descs map[descpb.ID]catalog.TableDescriptor,
 	tenants []execinfrapb.TenantRekey,
+	restoreTenantFromStream bool,
 ) (*KeyRewriter, error) {
 	var prefixes prefixRewriter
 	var tenantPrefixes prefixRewriter
@@ -174,6 +180,10 @@ func makeKeyRewriter(
 		return bytes.Compare(prefixes.rewrites[i].OldPrefix, prefixes.rewrites[j].OldPrefix) < 0
 	})
 	fromSystemTenant := false
+	// Only system tenant can restore a tenant from replication stream
+	if restoreTenantFromStream {
+		fromSystemTenant = true
+	}
 	for i := range tenants {
 		if tenants[i] == isBackupFromSystemTenantRekey {
 			fromSystemTenant = true
@@ -208,8 +218,10 @@ func MakeKeyRewriterPrefixIgnoringInterleaved(tableID descpb.ID, indexID descpb.
 // new value.
 func (kr *KeyRewriter) RewriteKey(key []byte) ([]byte, bool, error) {
 	// If we are reading a system tenant backup and this is a tenant key then it
-	// is part of a backup *of* that tenant, so we we only restore it if we have a
+	// is part of a backup *of* that tenant, so we only restore it if we have a
 	// tenant rekey for it, i.e. we're restoring that tenant.
+	// We also enable rekeying if we are restoring a tenant from a replication stream
+	// in which case we are restoring as a system tenant.
 	if kr.fromSystemTenant && bytes.HasPrefix(key, keys.TenantPrefix) {
 		k, ok := kr.tenants.rewriteKey(key)
 		return k, ok, nil

--- a/pkg/ccl/backupccl/key_rewriter_test.go
+++ b/pkg/ccl/backupccl/key_rewriter_test.go
@@ -74,7 +74,8 @@ func TestKeyRewriter(t *testing.T) {
 		},
 	}
 
-	kr, err := makeKeyRewriterFromRekeys(keys.SystemSQLCodec, rekeys, nil /* tenantRekeys */)
+	kr, err := MakeKeyRewriterFromRekeys(keys.SystemSQLCodec, rekeys,
+		nil /* tenantRekeys */, false /* restoreTenantFromStream */)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,10 +122,10 @@ func TestKeyRewriter(t *testing.T) {
 		desc.ID = oldID + 10
 		desc2 := tabledesc.NewBuilder(&desc.TableDescriptor).BuildCreatedMutableTable()
 		desc2.ID += 10
-		newKr, err := makeKeyRewriterFromRekeys(keys.SystemSQLCodec, []execinfrapb.TableRekey{
+		newKr, err := MakeKeyRewriterFromRekeys(keys.SystemSQLCodec, []execinfrapb.TableRekey{
 			{OldID: uint32(oldID), NewDesc: mustMarshalDesc(t, desc.TableDesc())},
 			{OldID: uint32(desc.ID), NewDesc: mustMarshalDesc(t, desc2.TableDesc())},
-		}, nil)
+		}, nil /* tenantRekeys */, false /* restoreTenantFromStream */)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -146,51 +147,91 @@ func TestKeyRewriter(t *testing.T) {
 		}
 	})
 
-	t.Run("tenants", func(t *testing.T) {
-		testTenantRekey := func(srcTenant, destTenant roachpb.TenantID) {
-			desc.ID = oldID + 10
-			srcCodec := keys.MakeSQLCodec(srcTenant)
-			destCodec := keys.MakeSQLCodec(destTenant)
-			newKr, err := makeKeyRewriterFromRekeys(destCodec, []execinfrapb.TableRekey{
-				{OldID: uint32(oldID), NewDesc: mustMarshalDesc(t, desc.TableDesc())},
-			}, nil)
-			require.NoError(t, err)
+	systemTenant := roachpb.SystemTenantID
+	tenant3 := roachpb.MakeTenantID(3)
+	tenant4 := roachpb.MakeTenantID(4)
 
-			key := rowenc.MakeIndexKeyPrefix(srcCodec, systemschema.NamespaceTable.GetID(), desc.GetPrimaryIndexID())
-			newKey, ok, err := newKr.RewriteKey(key)
-			require.NoError(t, err)
-			if !ok {
-				t.Fatalf("expected rewrite")
-			}
-			noTenantKey, tenantID, err := keys.DecodeTenantPrefix(newKey)
-			require.NoError(t, err)
-			require.Equal(t, destTenant, tenantID)
-			_, id, err := encoding.DecodeUvarintAscending(noTenantKey)
-			require.NoError(t, err)
-			require.Equal(t, oldID+10, descpb.ID(id))
+	// Restoring a tenant's data from a backup as another tenant.
+	testTableRekeyAsDiffTenant := func(srcTenant, destTenant roachpb.TenantID) {
+		desc.ID = oldID + 10
+		srcCodec := keys.MakeSQLCodec(srcTenant)
+		destCodec := keys.MakeSQLCodec(destTenant)
+		newKr, err := MakeKeyRewriterFromRekeys(destCodec, []execinfrapb.TableRekey{
+			{OldID: uint32(oldID), NewDesc: mustMarshalDesc(t, desc.TableDesc())},
+		}, nil /* tenantRekeys */, false /* restoreTenantFromStream */)
+		require.NoError(t, err)
+
+		key := rowenc.MakeIndexKeyPrefix(srcCodec, systemschema.NamespaceTable.GetID(), desc.GetPrimaryIndexID())
+		newKey, ok, err := newKr.RewriteKey(key)
+		require.NoError(t, err)
+		if !ok {
+			t.Fatalf("expected rewrite")
+		}
+		noTenantKey, tenantID, err := keys.DecodeTenantPrefix(newKey)
+		require.NoError(t, err)
+		require.Equal(t, destTenant, tenantID)
+		_, id, err := encoding.DecodeUvarintAscending(noTenantKey)
+		require.NoError(t, err)
+		require.Equal(t, oldID+10, descpb.ID(id))
+	}
+
+	tcs := []struct {
+		from, to roachpb.TenantID
+	}{
+		{from: systemTenant, to: tenant3},
+		{from: tenant3, to: tenant3},
+		{from: tenant3, to: tenant4},
+		// TODO: Restoring to the system tenant is currently special cased.
+		// {from: tenant3, to: systemTenant},
+	}
+	for _, tc := range tcs {
+		t.Run(fmt.Sprintf("from-tenant-%v-to-%v", tc.from, tc.to), func(t *testing.T) {
+			testTableRekeyAsDiffTenant(tc.from, tc.to)
+		})
+	}
+
+	// Restoring a tenant from replication stream to another tenant.
+	testTenantRekey := func(srcTenant, destTenant roachpb.TenantID) {
+		desc.ID = oldID + 10
+		srcCodec := keys.MakeSQLCodec(srcTenant)
+		destCodec := keys.MakeSQLCodec(destTenant)
+		newKr, err := MakeKeyRewriterFromRekeys(destCodec, nil,
+			[]execinfrapb.TenantRekey{
+				{
+					OldID: srcTenant,
+					NewID: destTenant,
+				},
+			}, true /* restoreTenantFromStream */)
+		require.NoError(t, err)
+
+		key := rowenc.MakeIndexKeyPrefix(srcCodec, systemschema.NamespaceTable.GetID(), desc.GetPrimaryIndexID())
+		oldNoTenantKey, oldTenantID, err := keys.DecodeTenantPrefix(key)
+		newKey, ok, err := newKr.RewriteKey(key)
+		require.NoError(t, err)
+		if !ok {
+			t.Fatalf("expected rewrite")
 		}
 
-		systemTenant := roachpb.SystemTenantID
-		tenant3 := roachpb.MakeTenantID(3)
-		tenant4 := roachpb.MakeTenantID(4)
+		require.NoError(t, err)
+		newNoTenantKey, newTenantID, err := keys.DecodeTenantPrefix(newKey)
+		require.NoError(t, err)
+		require.Equal(t, srcTenant, oldTenantID)
+		require.Equal(t, destTenant, newTenantID)
+		require.Equal(t, oldNoTenantKey, newNoTenantKey)
+	}
 
-		tcs := []struct {
-			from, to roachpb.TenantID
-		}{
-			{from: systemTenant, to: tenant3},
-			{from: tenant3, to: tenant3},
-			{from: tenant3, to: tenant4},
-			// TODO: Restoring to the system tenant is currently special cased.
-			// {from: tenant3, to: systemTenant},
-		}
-
-		for _, tc := range tcs {
-			t.Run(fmt.Sprintf("from-tenant-%v-to-%v", tc.from, tc.to), func(t *testing.T) {
-				testTenantRekey(tc.from, tc.to)
-			})
-		}
-	})
-
+	tcs = []struct {
+		from, to roachpb.TenantID
+	}{
+		// Rewriting a system tenant is not supported
+		{from: tenant3, to: tenant3},
+		{from: tenant3, to: tenant4},
+	}
+	for _, tc := range tcs {
+		t.Run(fmt.Sprintf("from-tenant-%v-to-%v", tc.from, tc.to), func(t *testing.T) {
+			testTenantRekey(tc.from, tc.to)
+		})
+	}
 }
 
 // mustMarshalDesc marshals the provided TableDescriptor.

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -356,7 +356,8 @@ func (rd *restoreDataProcessor) openSSTs(
 
 func (rd *restoreDataProcessor) runRestoreWorkers(ctx context.Context, ssts chan mergedSST) error {
 	return ctxgroup.GroupWorkers(ctx, rd.numWorkers, func(ctx context.Context, _ int) error {
-		kr, err := makeKeyRewriterFromRekeys(rd.FlowCtx.Codec(), rd.spec.TableRekeys, rd.spec.TenantRekeys)
+		kr, err := MakeKeyRewriterFromRekeys(rd.FlowCtx.Codec(), rd.spec.TableRekeys, rd.spec.TenantRekeys,
+			false /* restoreTenantFromStream */)
 		if err != nil {
 			return err
 		}

--- a/pkg/ccl/backupccl/restore_data_processor_test.go
+++ b/pkg/ccl/backupccl/restore_data_processor_test.go
@@ -376,7 +376,8 @@ func runTestIngest(t *testing.T, init func(*cluster.Settings)) {
 			require.NoError(t, mockRestoreDataProcessor.openSSTs(ctx, restoreSpanEntry, ssts))
 			close(ssts)
 			sst := <-ssts
-			rewriter, err := makeKeyRewriterFromRekeys(flowCtx.Codec(), mockRestoreDataSpec.TableRekeys, mockRestoreDataSpec.TenantRekeys)
+			rewriter, err := MakeKeyRewriterFromRekeys(flowCtx.Codec(), mockRestoreDataSpec.TableRekeys,
+				mockRestoreDataSpec.TenantRekeys, false /* restoreTenantFromStream */)
 			require.NoError(t, err)
 			_, err = mockRestoreDataProcessor.processRestoreSpanEntry(ctx, rewriter, sst)
 			require.NoError(t, err)

--- a/pkg/ccl/backupccl/split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/split_and_scatter_processor.go
@@ -221,7 +221,8 @@ func newSplitAndScatterProcessor(
 	}
 
 	db := flowCtx.Cfg.DB
-	kr, err := makeKeyRewriterFromRekeys(flowCtx.Codec(), spec.TableRekeys, spec.TenantRekeys)
+	kr, err := MakeKeyRewriterFromRekeys(flowCtx.Codec(), spec.TableRekeys, spec.TenantRekeys,
+		false /* restoreTenantFromStream */)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently key rewriter under backupccl can only rewrite tenant keys if this is
a backup produced by system tenant. This change makes it also works when we are
restoring a tenant from replication stream which is only allowed for system tenant.

Release note: None.