### PR TITLE
kvserver: print old stack in SetPriorityID assertion

### DIFF
--- a/pkg/kv/kvserver/scheduler.go
+++ b/pkg/kv/kvserver/scheduler.go
@@ -14,6 +14,7 @@ import (
 	"container/list"
 	"context"
 	"fmt"
+	"runtime/debug"
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -76,6 +77,7 @@ type rangeIDQueue struct {
 
 	// High priority.
 	priorityID     roachpb.RangeID
+	priorityStack  []byte // for debugging in case of assertion failure; see #75939
 	priorityQueued bool
 }
 
@@ -123,9 +125,10 @@ func (q *rangeIDQueue) Len() int {
 func (q *rangeIDQueue) SetPriorityID(id roachpb.RangeID) {
 	if q.priorityID != 0 && q.priorityID != id {
 		panic(fmt.Sprintf(
-			"priority range ID already set: old=%d, new=%d",
-			q.priorityID, id))
+			"priority range ID already set: old=%d, new=%d, first set at:\n\n%s",
+			q.priorityID, id, q.priorityStack))
 	}
+	q.priorityStack = debug.Stack()
 	q.priorityID = id
 }
 

--- a/pkg/kv/kvserver/scheduler.go
+++ b/pkg/kv/kvserver/scheduler.go
@@ -121,10 +121,7 @@ func (q *rangeIDQueue) Len() int {
 }
 
 func (q *rangeIDQueue) SetPriorityID(id roachpb.RangeID) {
-	if q.priorityID != 0 && q.priorityID != id &&
-		// This assertion is temporarily disabled, see:
-		// https://github.com/cockroachdb/cockroach/issues/75939
-		false {
+	if q.priorityID != 0 && q.priorityID != id {
 		panic(fmt.Sprintf(
 			"priority range ID already set: old=%d, new=%d",
 			q.priorityID, id))


### PR DESCRIPTION
Closes #75939.
    
The issue appears to have been fixed; I've run 100ks of iterations
without a reproduction. Should it ever reproduce, the additional
stack trace should give valuable clues to debug the issue anew.
    
Release note: None
