### PR TITLE
release-21.2: cli: Fix demo simulated latencies in --insecure mode

### DIFF
--- a/pkg/cli/interactive_tests/test_demo_global_insecure.tcl
+++ b/pkg/cli/interactive_tests/test_demo_global_insecure.tcl
@@ -8,7 +8,7 @@ set timeout 90
 start_test "Check --global flag runs as expected"
 
 # Start a demo with --global set
-spawn $argv demo --no-example-database --nodes 9 --global
+spawn $argv demo --no-example-database --nodes 9 --global --insecure
 
 # Ensure db is defaultdb.
 eexpect "defaultdb>"
@@ -58,3 +58,5 @@ expect {
         exp_continue
     }
 }
+
+end_test


### PR DESCRIPTION
Backport 1/1 commits from #77861.

/cc @cockroachdb/release

---

Previously we were not initializing the simulated latency correctly in all
cases. In the insecure case specifically, we may have had an uninitialized
simulated latency header which we'd then use as the simulated latency for the
given transmission. This commit changes the initialization so that we only
setup a simulated latency header if the supplied simulated latency is not 
set to zero.

The commit also adds a test for both --insecure and secure mode to validate
that the simulated latencies are setup correctly.

Release justification: bug fix
Release note (cli change): Fixes a bug where demo with the --global
flag would not simulate latencies correctly when combined with the --insecure
flag.

Resolves: #77001 and #63098
