### PR TITLE
release-21.1: cli: Fix demo simluated latencies in --insecure mode

### DIFF
--- a/pkg/cli/interactive_tests/test_demo_global_insecure.tcl
+++ b/pkg/cli/interactive_tests/test_demo_global_insecure.tcl
@@ -8,7 +8,7 @@ set timeout 90
 start_test "Check --global flag runs as expected"
 
 # Start a demo with --global set
-spawn $argv demo --no-example-database --nodes 9 --global
+spawn $argv demo --no-example-database --nodes 9 --global --insecure
 
 # Ensure db is defaultdb.
 eexpect "defaultdb>"
@@ -58,3 +58,5 @@ expect {
         exp_continue
     }
 }
+
+end_test

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -937,9 +937,22 @@ func (d *delayingConn) Read(b []byte) (n int, err error) {
 			return 0, errors.WithStack(errMagicNotFound)
 		}
 
-		// Once we receive our first packet, we set our delay to the expected
-		// delay that was sent on the write side.
-		d.latency = time.Duration(hdr.DelayMS) * time.Millisecond
+		// Once we receive our first packet with a DelayMS field set, we set our
+		// delay to the expected delay that was sent on the write side. We only
+		// want to set the latency the first time we receive a non-zero DelayMS
+		// because there are cases (still not yet fully debugged, but which
+		// occur when demo is run with the --insecure flag) where we set a
+		// non-zero DelayMS which is then overwritten, in a subsequent call to
+		// this function, with a zero value. Since the simulated latencies are
+		// not dynamic, overwriting a non-zero value with a zero value is
+		// never valid. Rather than perform the lengthy investigation to
+		// determine why we're being called with a zero DelayMS after we've set
+		// d.latency to a non-zero value, we instead key off of a zero value of
+		// d.latency to indicate that d.latency has not yet been initialized.
+		// Once it's initialized to a non-zero value, we won't update it again.
+		if d.latency == 0 && hdr.DelayMS != 0 {
+			d.latency = time.Duration(hdr.DelayMS) * time.Millisecond
+		}
 		defer func() {
 			time.Sleep(timeutil.Until(timeutil.Unix(0, hdr.ReadTime)))
 		}()


### PR DESCRIPTION
Backport 1/1 commits from #77861.

/cc @cockroachdb/release

---

Previously we were not initializing the simulated latency correctly in all
cases. In the insecure case specifically, we may have had an uninitialized
simulated latency header which we'd then use as the simulated latency for the
given transmission. This commit changes the initialization so that we only
setup a simulated latency header if the supplied simulated latency is not 
set to zero.

The commit also adds a test for both --insecure and secure mode to validate
that the simulated latencies are setup correctly.

Release justification: bug fix
Release note (cli change): Fixes a bug where demo with the --global
flag would not simulate latencies correctly when combined with the --insecure
flag.

Resolves: #77001 and #63098
