### PR TITLE
server: proper error handling in sessions API

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -161,16 +161,22 @@ func (b *baseStatusServer) getLocalSessions(
 		return nil, serverError(ctx, err)
 	}
 
+	hasViewActivityRedacted, err := b.privilegeChecker.hasRoleOption(ctx, sessionUser, roleoption.VIEWACTIVITYREDACTED)
+	if err != nil {
+		return nil, serverError(ctx, err)
+	}
+
+	hasViewActivity, err := b.privilegeChecker.hasRoleOption(ctx, sessionUser, roleoption.VIEWACTIVITY)
+	if err != nil {
+		return nil, serverError(ctx, err)
+	}
+
 	reqUsername, err := security.MakeSQLUsernameFromPreNormalizedStringChecked(req.Username)
 	if err != nil {
 		return nil, serverError(ctx, err)
 	}
 
-	errViewActivity := b.privilegeChecker.requireViewActivityOrViewActivityRedactedPermission(ctx)
-	// TODO(knz): The following check on errViewActivity is incorrect, it
-	// does not properly handle non-privilege errors.
-	// See: https://github.com/cockroachdb/cockroach/issues/76288
-	if !isAdmin && errViewActivity != nil {
+	if !isAdmin && !hasViewActivity && !hasViewActivityRedacted {
 		// For non-superusers, requests with an empty username is
 		// implicitly a request for the client's own sessions.
 		if reqUsername.Undefined() {
@@ -184,11 +190,6 @@ func (b *baseStatusServer) getLocalSessions(
 				"client user %q does not have permission to view sessions from user %q",
 				sessionUser, reqUsername)
 		}
-	}
-
-	hasViewActivityRedacted, err := b.privilegeChecker.hasRoleOption(ctx, sessionUser, roleoption.VIEWACTIVITYREDACTED)
-	if err != nil {
-		return nil, serverError(ctx, err)
 	}
 
 	// The empty username means "all sessions".


### PR DESCRIPTION
Fixes #76288

Previously, part of the code in the sessions API that handles
privelege checking would swallow non-privelege related server
errors. The function
`requireViewActivityOrViewActivityRedactedPermission`
was being used to check if the user has either of the above
roles. This function returns an error as a single value, which
can be either a  privelege or non-privelege related error.
It is intended for use when either role is required to use the API,
with the error returned immediately, however the sessions API is
should work for users without these permissions if given the
correct request parameters.

This commit replaces the use of
`requireViewActivityOrViewActivityRedactedPermission` with
`hasRoleOption` to check for the possession of the VIEWACTIVITY
or VIEWACTIVITYREDACTED roles. This allows us to use both the
result of the role check and return errors encountered immediately.

Release note: None