### PR TITLE
log: multiline JSON log formatting

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -320,7 +320,7 @@ An event of type `set_cluster_setting` is recorded when a cluster setting is cha
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -347,7 +347,7 @@ is changed, either for another tenant or for all tenants.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -380,7 +380,7 @@ is directly or indirectly a member of the admin role) executes a query.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -414,7 +414,7 @@ a table marked as audited.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -455,7 +455,7 @@ and the cluster setting `sql.trace.log_statement_execute` is set.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -501,7 +501,7 @@ An event of type `alter_database_add_region` is recorded when a region is added 
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -525,7 +525,7 @@ AlterDatabaseAddRegion is recorded when a region is added to a database.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -549,7 +549,7 @@ An event of type `alter_database_placement` is recorded when the database placem
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -573,7 +573,7 @@ An event of type `alter_database_primary_region` is recorded when a primary regi
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -597,7 +597,7 @@ An event of type `alter_database_survival_goal` is recorded when the survival go
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -622,7 +622,7 @@ An event of type `alter_index` is recorded when an index is altered.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -645,7 +645,7 @@ An event of type `alter_sequence` is recorded when a sequence is altered.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -670,7 +670,7 @@ An event of type `alter_table` is recorded when a table is altered.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -693,7 +693,7 @@ EventAlterType is recorded when a user-defined type is altered.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -719,7 +719,7 @@ An event of type `comment_on_column` is recorded when a column is commented.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -745,7 +745,7 @@ An event of type `comment_on_constraint` is recorded when an constraint is comme
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -770,7 +770,7 @@ CommentOnTable is recorded when a database is commented.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -796,7 +796,7 @@ An event of type `comment_on_index` is recorded when an index is commented.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -820,7 +820,7 @@ An event of type `comment_on_index` is recorded when an index is commented.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -845,7 +845,7 @@ An event of type `comment_on_table` is recorded when a table is commented.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -869,7 +869,7 @@ An event of type `convert_to_schema` is recorded when a database is converted to
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -892,7 +892,7 @@ An event of type `create_database` is recorded when a database is created.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -917,7 +917,7 @@ An event of type `create_index` is recorded when an index is created.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -941,7 +941,7 @@ An event of type `create_schema` is recorded when a schema is created.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -965,7 +965,7 @@ An event of type `create_sequence` is recorded when a sequence is created.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -992,7 +992,7 @@ Events of this type are only collected when the cluster setting
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1016,7 +1016,7 @@ An event of type `create_table` is recorded when a table is created.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1040,7 +1040,7 @@ An event of type `create_type` is recorded when a user-defined type is created.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1065,7 +1065,7 @@ An event of type `create_view` is recorded when a view is created.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1089,7 +1089,7 @@ An event of type `drop_database` is recorded when a database is dropped.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1115,7 +1115,7 @@ An event of type `drop_index` is recorded when an index is dropped.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1138,7 +1138,7 @@ An event of type `drop_schema` is recorded when a schema is dropped.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1161,7 +1161,7 @@ An event of type `drop_sequence` is recorded when a sequence is dropped.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1185,7 +1185,7 @@ An event of type `drop_table` is recorded when a table is dropped.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1208,7 +1208,7 @@ An event of type `drop_type` is recorded when a user-defined type is dropped.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1232,7 +1232,7 @@ An event of type `drop_view` is recorded when a view is dropped.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1290,7 +1290,7 @@ initiated schema change rollback has completed.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1314,7 +1314,7 @@ An event of type `rename_database` is recorded when a database is renamed.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1338,7 +1338,7 @@ An event of type `rename_schema` is recorded when a schema is renamed.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1362,7 +1362,7 @@ An event of type `rename_table` is recorded when a table, sequence or view is re
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1386,7 +1386,7 @@ An event of type `rename_type` is recorded when a user-defined type is renamed.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1433,7 +1433,7 @@ An event of type `set_schema` is recorded when a table, view, sequence or type's
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1456,7 +1456,7 @@ An event of type `truncate_table` is recorded when a table is truncated.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1487,7 +1487,7 @@ patch releases without advance notice.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1518,7 +1518,7 @@ patch releases without advance notice.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1545,7 +1545,7 @@ using crdb_internal.unsafe_upsert_descriptor().
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1578,7 +1578,7 @@ patch releases without advance notice.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1615,7 +1615,7 @@ An event of type `alter_database_owner` is recorded when a database's owner is c
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1641,7 +1641,7 @@ An event of type `alter_default_privileges` is recorded when default privileges 
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1668,7 +1668,7 @@ An event of type `alter_schema_owner` is recorded when a schema's owner is chang
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1692,7 +1692,7 @@ An event of type `alter_table_owner` is recorded when the owner of a table, view
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1716,7 +1716,7 @@ An event of type `alter_type_owner` is recorded when the owner of a user-defiend
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1740,7 +1740,7 @@ added to / removed from a user for a database object.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1767,7 +1767,7 @@ removed from a user for a schema object.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1794,7 +1794,7 @@ from a user for a table, sequence or view object.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -1821,7 +1821,7 @@ removed from a user for a type object.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -2055,7 +2055,7 @@ set to a non-zero value, AND
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -2087,7 +2087,7 @@ are more statement within the transaction that haven't been executed yet.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -2114,7 +2114,7 @@ been executed yet.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -2174,7 +2174,7 @@ the "slow query" condition.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -2207,7 +2207,7 @@ mutation statements within the transaction that haven't been executed yet.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -2235,7 +2235,7 @@ mutation statements within the transaction that haven't been executed yet.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -2275,7 +2275,7 @@ An event of type `alter_role` is recorded when a role is altered.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -2298,7 +2298,7 @@ An event of type `create_role` is recorded when a role is created.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -2321,7 +2321,7 @@ An event of type `drop_role` is recorded when a role is dropped.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -2345,7 +2345,7 @@ An event of type `grant_role` is recorded when a role is granted.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -2466,7 +2466,7 @@ contains common SQL event/execution details.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -2511,7 +2511,7 @@ An event of type `remove_zone_config` is recorded when a zone config is removed.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
@@ -2534,7 +2534,7 @@ An event of type `set_zone_config` is recorded when a zone config is changed.
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | yes |
 | `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
 | `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |

--- a/pkg/util/log/eventpb/BUILD.bazel
+++ b/pkg/util/log/eventpb/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
     srcs = [
         "doc.go",
         "events.go",
+        "splittable.go",
         "sql_audit_events.go",
         ":gen-eventlog-channels-generated-go",  # keep
         ":gen-json-encode-generated-go",  # keep

--- a/pkg/util/log/eventpb/events.proto
+++ b/pkg/util/log/eventpb/events.proto
@@ -35,7 +35,7 @@ message CommonEventDetails {
 message CommonSQLEventDetails {
   // A normalized copy of the SQL statement that triggered the event.
   // The statement string contains a mix of sensitive and non-sensitive details (it is redactable).
-  string statement = 1 [(gogoproto.jsontag) = ",omitempty", (gogoproto.customtype) = "github.com/cockroachdb/redact.RedactableString", (gogoproto.nullable) = false, (gogoproto.moretags) = "redact:\"mixed\""];
+  string statement = 1 [(gogoproto.jsontag) = ",omitempty", (gogoproto.customtype) = "github.com/cockroachdb/redact.RedactableString", (gogoproto.nullable) = false, (gogoproto.moretags) = "redact:\"mixed\" splittable:\"true\""];
 
   // The statement tag. This is separate from the statement string,
   // since the statement string can contain sensitive information. The

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -39,9 +39,11 @@ func (m *AlterDatabaseAddRegion) AppendJSONFields(printComma bool, b redact.Reda
 		}
 		printComma = true
 		b = append(b, "\"DatabaseName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.DatabaseName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -51,9 +53,11 @@ func (m *AlterDatabaseAddRegion) AppendJSONFields(printComma bool, b redact.Reda
 		}
 		printComma = true
 		b = append(b, "\"RegionName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.RegionName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -73,9 +77,11 @@ func (m *AlterDatabaseDropRegion) AppendJSONFields(printComma bool, b redact.Red
 		}
 		printComma = true
 		b = append(b, "\"DatabaseName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.DatabaseName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -85,9 +91,11 @@ func (m *AlterDatabaseDropRegion) AppendJSONFields(printComma bool, b redact.Red
 		}
 		printComma = true
 		b = append(b, "\"RegionName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.RegionName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -107,9 +115,11 @@ func (m *AlterDatabaseOwner) AppendJSONFields(printComma bool, b redact.Redactab
 		}
 		printComma = true
 		b = append(b, "\"DatabaseName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.DatabaseName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -119,9 +129,11 @@ func (m *AlterDatabaseOwner) AppendJSONFields(printComma bool, b redact.Redactab
 		}
 		printComma = true
 		b = append(b, "\"Owner\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Owner)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -141,9 +153,11 @@ func (m *AlterDatabasePlacement) AppendJSONFields(printComma bool, b redact.Reda
 		}
 		printComma = true
 		b = append(b, "\"DatabaseName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.DatabaseName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -153,9 +167,11 @@ func (m *AlterDatabasePlacement) AppendJSONFields(printComma bool, b redact.Reda
 		}
 		printComma = true
 		b = append(b, "\"Placement\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Placement)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -175,9 +191,11 @@ func (m *AlterDatabasePrimaryRegion) AppendJSONFields(printComma bool, b redact.
 		}
 		printComma = true
 		b = append(b, "\"DatabaseName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.DatabaseName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -187,9 +205,11 @@ func (m *AlterDatabasePrimaryRegion) AppendJSONFields(printComma bool, b redact.
 		}
 		printComma = true
 		b = append(b, "\"PrimaryRegionName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.PrimaryRegionName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -209,9 +229,11 @@ func (m *AlterDatabaseSurvivalGoal) AppendJSONFields(printComma bool, b redact.R
 		}
 		printComma = true
 		b = append(b, "\"DatabaseName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.DatabaseName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -221,9 +243,11 @@ func (m *AlterDatabaseSurvivalGoal) AppendJSONFields(printComma bool, b redact.R
 		}
 		printComma = true
 		b = append(b, "\"SurvivalGoal\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.SurvivalGoal)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -245,9 +269,11 @@ func (m *AlterDefaultPrivileges) AppendJSONFields(printComma bool, b redact.Reda
 		}
 		printComma = true
 		b = append(b, "\"DatabaseName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.DatabaseName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -257,9 +283,11 @@ func (m *AlterDefaultPrivileges) AppendJSONFields(printComma bool, b redact.Reda
 		}
 		printComma = true
 		b = append(b, "\"RoleName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.RoleName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -277,9 +305,11 @@ func (m *AlterDefaultPrivileges) AppendJSONFields(printComma bool, b redact.Reda
 		}
 		printComma = true
 		b = append(b, "\"SchemaName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.SchemaName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -299,9 +329,11 @@ func (m *AlterIndex) AppendJSONFields(printComma bool, b redact.RedactableBytes)
 		}
 		printComma = true
 		b = append(b, "\"TableName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TableName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -311,9 +343,11 @@ func (m *AlterIndex) AppendJSONFields(printComma bool, b redact.RedactableBytes)
 		}
 		printComma = true
 		b = append(b, "\"IndexName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.IndexName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -342,9 +376,11 @@ func (m *AlterRole) AppendJSONFields(printComma bool, b redact.RedactableBytes) 
 		}
 		printComma = true
 		b = append(b, "\"RoleName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.RoleName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -359,7 +395,9 @@ func (m *AlterRole) AppendJSONFields(printComma bool, b redact.RedactableBytes) 
 				b = append(b, ',')
 			}
 			b = append(b, '"')
+
 			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), v))
+
 			b = append(b, '"')
 		}
 		b = append(b, ']')
@@ -376,7 +414,9 @@ func (m *AlterRole) AppendJSONFields(printComma bool, b redact.RedactableBytes) 
 				b = append(b, ',')
 			}
 			b = append(b, '"')
+
 			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), v))
+
 			b = append(b, '"')
 		}
 		b = append(b, ']')
@@ -398,9 +438,11 @@ func (m *AlterSchemaOwner) AppendJSONFields(printComma bool, b redact.Redactable
 		}
 		printComma = true
 		b = append(b, "\"SchemaName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.SchemaName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -410,9 +452,11 @@ func (m *AlterSchemaOwner) AppendJSONFields(printComma bool, b redact.Redactable
 		}
 		printComma = true
 		b = append(b, "\"Owner\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Owner)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -432,9 +476,11 @@ func (m *AlterSequence) AppendJSONFields(printComma bool, b redact.RedactableByt
 		}
 		printComma = true
 		b = append(b, "\"SequenceName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.SequenceName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -454,9 +500,11 @@ func (m *AlterTable) AppendJSONFields(printComma bool, b redact.RedactableBytes)
 		}
 		printComma = true
 		b = append(b, "\"TableName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TableName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -480,9 +528,11 @@ func (m *AlterTable) AppendJSONFields(printComma bool, b redact.RedactableBytes)
 				b = append(b, ',')
 			}
 			b = append(b, '"')
+
 			b = append(b, redact.StartMarker()...)
 			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(v)))))
 			b = append(b, redact.EndMarker()...)
+
 			b = append(b, '"')
 		}
 		b = append(b, ']')
@@ -504,9 +554,11 @@ func (m *AlterTableOwner) AppendJSONFields(printComma bool, b redact.RedactableB
 		}
 		printComma = true
 		b = append(b, "\"TableName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TableName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -516,9 +568,11 @@ func (m *AlterTableOwner) AppendJSONFields(printComma bool, b redact.RedactableB
 		}
 		printComma = true
 		b = append(b, "\"Owner\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Owner)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -538,9 +592,11 @@ func (m *AlterType) AppendJSONFields(printComma bool, b redact.RedactableBytes) 
 		}
 		printComma = true
 		b = append(b, "\"TypeName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TypeName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -560,9 +616,11 @@ func (m *AlterTypeOwner) AppendJSONFields(printComma bool, b redact.RedactableBy
 		}
 		printComma = true
 		b = append(b, "\"TypeName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TypeName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -572,9 +630,11 @@ func (m *AlterTypeOwner) AppendJSONFields(printComma bool, b redact.RedactableBy
 		}
 		printComma = true
 		b = append(b, "\"Owner\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Owner)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -601,9 +661,11 @@ func (m *CapturedIndexUsageStats) AppendJSONFields(printComma bool, b redact.Red
 		}
 		printComma = true
 		b = append(b, "\"LastRead\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.LastRead)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -631,9 +693,11 @@ func (m *CapturedIndexUsageStats) AppendJSONFields(printComma bool, b redact.Red
 		}
 		printComma = true
 		b = append(b, "\"DatabaseName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.DatabaseName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -643,9 +707,11 @@ func (m *CapturedIndexUsageStats) AppendJSONFields(printComma bool, b redact.Red
 		}
 		printComma = true
 		b = append(b, "\"TableName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TableName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -655,9 +721,11 @@ func (m *CapturedIndexUsageStats) AppendJSONFields(printComma bool, b redact.Red
 		}
 		printComma = true
 		b = append(b, "\"IndexName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.IndexName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -667,9 +735,11 @@ func (m *CapturedIndexUsageStats) AppendJSONFields(printComma bool, b redact.Red
 		}
 		printComma = true
 		b = append(b, "\"IndexType\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.IndexType)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -711,9 +781,11 @@ func (m *CertsReload) AppendJSONFields(printComma bool, b redact.RedactableBytes
 		}
 		printComma = true
 		b = append(b, "\"ErrorMessage\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.ErrorMessage)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -735,9 +807,11 @@ func (m *ChangeDatabasePrivilege) AppendJSONFields(printComma bool, b redact.Red
 		}
 		printComma = true
 		b = append(b, "\"DatabaseName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.DatabaseName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -759,9 +833,11 @@ func (m *ChangeSchemaPrivilege) AppendJSONFields(printComma bool, b redact.Redac
 		}
 		printComma = true
 		b = append(b, "\"SchemaName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.SchemaName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -783,9 +859,11 @@ func (m *ChangeTablePrivilege) AppendJSONFields(printComma bool, b redact.Redact
 		}
 		printComma = true
 		b = append(b, "\"TableName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TableName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -807,9 +885,11 @@ func (m *ChangeTypePrivilege) AppendJSONFields(printComma bool, b redact.Redacta
 		}
 		printComma = true
 		b = append(b, "\"TypeName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TypeName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -827,7 +907,9 @@ func (m *ChangefeedFailed) AppendJSONFields(printComma bool, b redact.Redactable
 		}
 		printComma = true
 		b = append(b, "\"FailureType\":\""...)
+
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.FailureType)))
+
 		b = append(b, '"')
 	}
 
@@ -858,9 +940,11 @@ func (m *ClientAuthenticationFailed) AppendJSONFields(printComma bool, b redact.
 		}
 		printComma = true
 		b = append(b, "\"Detail\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Detail)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -870,7 +954,9 @@ func (m *ClientAuthenticationFailed) AppendJSONFields(printComma bool, b redact.
 		}
 		printComma = true
 		b = append(b, "\"Method\":\""...)
+
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.Method)))
+
 		b = append(b, '"')
 	}
 
@@ -892,7 +978,9 @@ func (m *ClientAuthenticationInfo) AppendJSONFields(printComma bool, b redact.Re
 		}
 		printComma = true
 		b = append(b, "\"Method\":\""...)
+
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.Method)))
+
 		b = append(b, '"')
 	}
 
@@ -902,9 +990,11 @@ func (m *ClientAuthenticationInfo) AppendJSONFields(printComma bool, b redact.Re
 		}
 		printComma = true
 		b = append(b, "\"Info\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Info)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -926,7 +1016,9 @@ func (m *ClientAuthenticationOk) AppendJSONFields(printComma bool, b redact.Reda
 		}
 		printComma = true
 		b = append(b, "\"Method\":\""...)
+
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.Method)))
+
 		b = append(b, '"')
 	}
 
@@ -996,9 +1088,11 @@ func (m *CommentOnColumn) AppendJSONFields(printComma bool, b redact.RedactableB
 		}
 		printComma = true
 		b = append(b, "\"TableName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TableName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -1008,9 +1102,11 @@ func (m *CommentOnColumn) AppendJSONFields(printComma bool, b redact.RedactableB
 		}
 		printComma = true
 		b = append(b, "\"ColumnName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.ColumnName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -1020,9 +1116,11 @@ func (m *CommentOnColumn) AppendJSONFields(printComma bool, b redact.RedactableB
 		}
 		printComma = true
 		b = append(b, "\"Comment\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Comment)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -1050,9 +1148,11 @@ func (m *CommentOnConstraint) AppendJSONFields(printComma bool, b redact.Redacta
 		}
 		printComma = true
 		b = append(b, "\"TableName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TableName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -1062,9 +1162,11 @@ func (m *CommentOnConstraint) AppendJSONFields(printComma bool, b redact.Redacta
 		}
 		printComma = true
 		b = append(b, "\"ConstraintName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.ConstraintName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -1074,9 +1176,11 @@ func (m *CommentOnConstraint) AppendJSONFields(printComma bool, b redact.Redacta
 		}
 		printComma = true
 		b = append(b, "\"Comment\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Comment)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -1104,9 +1208,11 @@ func (m *CommentOnDatabase) AppendJSONFields(printComma bool, b redact.Redactabl
 		}
 		printComma = true
 		b = append(b, "\"DatabaseName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.DatabaseName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -1116,9 +1222,11 @@ func (m *CommentOnDatabase) AppendJSONFields(printComma bool, b redact.Redactabl
 		}
 		printComma = true
 		b = append(b, "\"Comment\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Comment)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -1146,9 +1254,11 @@ func (m *CommentOnIndex) AppendJSONFields(printComma bool, b redact.RedactableBy
 		}
 		printComma = true
 		b = append(b, "\"TableName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TableName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -1158,9 +1268,11 @@ func (m *CommentOnIndex) AppendJSONFields(printComma bool, b redact.RedactableBy
 		}
 		printComma = true
 		b = append(b, "\"IndexName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.IndexName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -1170,9 +1282,11 @@ func (m *CommentOnIndex) AppendJSONFields(printComma bool, b redact.RedactableBy
 		}
 		printComma = true
 		b = append(b, "\"Comment\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Comment)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -1200,9 +1314,11 @@ func (m *CommentOnSchema) AppendJSONFields(printComma bool, b redact.RedactableB
 		}
 		printComma = true
 		b = append(b, "\"SchemaName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.SchemaName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -1212,9 +1328,11 @@ func (m *CommentOnSchema) AppendJSONFields(printComma bool, b redact.RedactableB
 		}
 		printComma = true
 		b = append(b, "\"Comment\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Comment)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -1242,9 +1360,11 @@ func (m *CommentOnTable) AppendJSONFields(printComma bool, b redact.RedactableBy
 		}
 		printComma = true
 		b = append(b, "\"TableName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TableName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -1254,9 +1374,11 @@ func (m *CommentOnTable) AppendJSONFields(printComma bool, b redact.RedactableBy
 		}
 		printComma = true
 		b = append(b, "\"Comment\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Comment)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -1282,7 +1404,9 @@ func (m *CommonChangefeedEventDetails) AppendJSONFields(printComma bool, b redac
 		}
 		printComma = true
 		b = append(b, "\"Description\":\""...)
+
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.Description)))
+
 		b = append(b, '"')
 	}
 
@@ -1292,7 +1416,9 @@ func (m *CommonChangefeedEventDetails) AppendJSONFields(printComma bool, b redac
 		}
 		printComma = true
 		b = append(b, "\"SinkType\":\""...)
+
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.SinkType)))
+
 		b = append(b, '"')
 	}
 
@@ -1311,7 +1437,9 @@ func (m *CommonChangefeedEventDetails) AppendJSONFields(printComma bool, b redac
 		}
 		printComma = true
 		b = append(b, "\"Resolved\":\""...)
+
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.Resolved)))
+
 		b = append(b, '"')
 	}
 
@@ -1321,7 +1449,9 @@ func (m *CommonChangefeedEventDetails) AppendJSONFields(printComma bool, b redac
 		}
 		printComma = true
 		b = append(b, "\"InitialScan\":\""...)
+
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.InitialScan)))
+
 		b = append(b, '"')
 	}
 
@@ -1331,7 +1461,9 @@ func (m *CommonChangefeedEventDetails) AppendJSONFields(printComma bool, b redac
 		}
 		printComma = true
 		b = append(b, "\"Format\":\""...)
+
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.Format)))
+
 		b = append(b, '"')
 	}
 
@@ -1356,7 +1488,9 @@ func (m *CommonConnectionDetails) AppendJSONFields(printComma bool, b redact.Red
 		}
 		printComma = true
 		b = append(b, "\"Network\":\""...)
+
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.Network)))
+
 		b = append(b, '"')
 	}
 
@@ -1366,9 +1500,11 @@ func (m *CommonConnectionDetails) AppendJSONFields(printComma bool, b redact.Red
 		}
 		printComma = true
 		b = append(b, "\"RemoteAddress\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.RemoteAddress)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -1393,9 +1529,11 @@ func (m *CommonDebugEventDetails) AppendJSONFields(printComma bool, b redact.Red
 		}
 		printComma = true
 		b = append(b, "\"User\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.User)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -1420,7 +1558,9 @@ func (m *CommonEventDetails) AppendJSONFields(printComma bool, b redact.Redactab
 		}
 		printComma = true
 		b = append(b, "\"EventType\":\""...)
+
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.EventType)))
+
 		b = append(b, '"')
 	}
 
@@ -1445,7 +1585,9 @@ func (m *CommonJobEventDetails) AppendJSONFields(printComma bool, b redact.Redac
 		}
 		printComma = true
 		b = append(b, "\"JobType\":\""...)
+
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.JobType)))
+
 		b = append(b, '"')
 	}
 
@@ -1455,9 +1597,11 @@ func (m *CommonJobEventDetails) AppendJSONFields(printComma bool, b redact.Redac
 		}
 		printComma = true
 		b = append(b, "\"Description\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Description)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -1467,9 +1611,11 @@ func (m *CommonJobEventDetails) AppendJSONFields(printComma bool, b redact.Redac
 		}
 		printComma = true
 		b = append(b, "\"User\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.User)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -1494,7 +1640,9 @@ func (m *CommonJobEventDetails) AppendJSONFields(printComma bool, b redact.Redac
 		}
 		printComma = true
 		b = append(b, "\"Status\":\""...)
+
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.Status)))
+
 		b = append(b, '"')
 	}
 
@@ -1537,9 +1685,11 @@ func (m *CommonLargeRowDetails) AppendJSONFields(printComma bool, b redact.Redac
 		}
 		printComma = true
 		b = append(b, "\"PrimaryKey\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.PrimaryKey)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -1612,7 +1762,11 @@ func (m *CommonSQLEventDetails) AppendJSONFields(printComma bool, b redact.Redac
 		}
 		printComma = true
 		b = append(b, "\"Statement\":\""...)
-		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.Statement)))
+		b = append(b, StartSplittableMarker()...)
+		b = append(b, redact.StartMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Statement)))))
+		b = append(b, redact.EndMarker()...)
+		b = append(b, EndSplittableMarker()...)
 		b = append(b, '"')
 	}
 
@@ -1622,7 +1776,9 @@ func (m *CommonSQLEventDetails) AppendJSONFields(printComma bool, b redact.Redac
 		}
 		printComma = true
 		b = append(b, "\"Tag\":\""...)
+
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.Tag)))
+
 		b = append(b, '"')
 	}
 
@@ -1640,6 +1796,7 @@ func (m *CommonSQLEventDetails) AppendJSONFields(printComma bool, b redact.Redac
 			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.User)))))
 			b = append(b, redact.EndMarker()...)
 		}
+
 		b = append(b, '"')
 	}
 
@@ -1666,6 +1823,7 @@ func (m *CommonSQLEventDetails) AppendJSONFields(printComma bool, b redact.Redac
 			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.ApplicationName)))))
 			b = append(b, redact.EndMarker()...)
 		}
+
 		b = append(b, '"')
 	}
 
@@ -1680,9 +1838,11 @@ func (m *CommonSQLEventDetails) AppendJSONFields(printComma bool, b redact.Redac
 				b = append(b, ',')
 			}
 			b = append(b, '"')
+
 			b = append(b, redact.StartMarker()...)
 			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(v)))))
 			b = append(b, redact.EndMarker()...)
+
 			b = append(b, '"')
 		}
 		b = append(b, ']')
@@ -1700,7 +1860,9 @@ func (m *CommonSQLExecDetails) AppendJSONFields(printComma bool, b redact.Redact
 		}
 		printComma = true
 		b = append(b, "\"ExecMode\":\""...)
+
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.ExecMode)))
+
 		b = append(b, '"')
 	}
 
@@ -1719,7 +1881,9 @@ func (m *CommonSQLExecDetails) AppendJSONFields(printComma bool, b redact.Redact
 		}
 		printComma = true
 		b = append(b, "\"SQLSTATE\":\""...)
+
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.SQLSTATE)))
+
 		b = append(b, '"')
 	}
 
@@ -1729,9 +1893,11 @@ func (m *CommonSQLExecDetails) AppendJSONFields(printComma bool, b redact.Redact
 		}
 		printComma = true
 		b = append(b, "\"ErrorText\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.ErrorText)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -1790,9 +1956,11 @@ func (m *CommonSQLPrivilegeEventDetails) AppendJSONFields(printComma bool, b red
 		}
 		printComma = true
 		b = append(b, "\"Grantee\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Grantee)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -1807,7 +1975,9 @@ func (m *CommonSQLPrivilegeEventDetails) AppendJSONFields(printComma bool, b red
 				b = append(b, ',')
 			}
 			b = append(b, '"')
+
 			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), v))
+
 			b = append(b, '"')
 		}
 		b = append(b, ']')
@@ -1824,7 +1994,9 @@ func (m *CommonSQLPrivilegeEventDetails) AppendJSONFields(printComma bool, b red
 				b = append(b, ',')
 			}
 			b = append(b, '"')
+
 			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), v))
+
 			b = append(b, '"')
 		}
 		b = append(b, ']')
@@ -1875,7 +2047,9 @@ func (m *CommonSessionDetails) AppendJSONFields(printComma bool, b redact.Redact
 		}
 		printComma = true
 		b = append(b, "\"Transport\":\""...)
+
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.Transport)))
+
 		b = append(b, '"')
 	}
 
@@ -1885,9 +2059,11 @@ func (m *CommonSessionDetails) AppendJSONFields(printComma bool, b redact.Redact
 		}
 		printComma = true
 		b = append(b, "\"User\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.User)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -1897,9 +2073,11 @@ func (m *CommonSessionDetails) AppendJSONFields(printComma bool, b redact.Redact
 		}
 		printComma = true
 		b = append(b, "\"SystemIdentity\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.SystemIdentity)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -1915,7 +2093,9 @@ func (m *CommonTxnRowsLimitDetails) AppendJSONFields(printComma bool, b redact.R
 		}
 		printComma = true
 		b = append(b, "\"TxnID\":\""...)
+
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.TxnID)))
+
 		b = append(b, '"')
 	}
 
@@ -1925,7 +2105,9 @@ func (m *CommonTxnRowsLimitDetails) AppendJSONFields(printComma bool, b redact.R
 		}
 		printComma = true
 		b = append(b, "\"SessionID\":\""...)
+
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.SessionID)))
+
 		b = append(b, '"')
 	}
 
@@ -1950,9 +2132,11 @@ func (m *CommonZoneConfigDetails) AppendJSONFields(printComma bool, b redact.Red
 		}
 		printComma = true
 		b = append(b, "\"Target\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Target)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -1962,9 +2146,11 @@ func (m *CommonZoneConfigDetails) AppendJSONFields(printComma bool, b redact.Red
 		}
 		printComma = true
 		b = append(b, "\"Config\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Config)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -1979,9 +2165,11 @@ func (m *CommonZoneConfigDetails) AppendJSONFields(printComma bool, b redact.Red
 				b = append(b, ',')
 			}
 			b = append(b, '"')
+
 			b = append(b, redact.StartMarker()...)
 			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(v)))))
 			b = append(b, redact.EndMarker()...)
+
 			b = append(b, '"')
 		}
 		b = append(b, ']')
@@ -2003,9 +2191,11 @@ func (m *ConvertToSchema) AppendJSONFields(printComma bool, b redact.RedactableB
 		}
 		printComma = true
 		b = append(b, "\"DatabaseName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.DatabaseName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2015,9 +2205,11 @@ func (m *ConvertToSchema) AppendJSONFields(printComma bool, b redact.RedactableB
 		}
 		printComma = true
 		b = append(b, "\"NewDatabaseParent\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.NewDatabaseParent)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2045,9 +2237,11 @@ func (m *CreateDatabase) AppendJSONFields(printComma bool, b redact.RedactableBy
 		}
 		printComma = true
 		b = append(b, "\"DatabaseName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.DatabaseName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2067,9 +2261,11 @@ func (m *CreateIndex) AppendJSONFields(printComma bool, b redact.RedactableBytes
 		}
 		printComma = true
 		b = append(b, "\"TableName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TableName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2079,9 +2275,11 @@ func (m *CreateIndex) AppendJSONFields(printComma bool, b redact.RedactableBytes
 		}
 		printComma = true
 		b = append(b, "\"IndexName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.IndexName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2110,9 +2308,11 @@ func (m *CreateRole) AppendJSONFields(printComma bool, b redact.RedactableBytes)
 		}
 		printComma = true
 		b = append(b, "\"RoleName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.RoleName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2132,9 +2332,11 @@ func (m *CreateSchema) AppendJSONFields(printComma bool, b redact.RedactableByte
 		}
 		printComma = true
 		b = append(b, "\"SchemaName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.SchemaName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2144,9 +2346,11 @@ func (m *CreateSchema) AppendJSONFields(printComma bool, b redact.RedactableByte
 		}
 		printComma = true
 		b = append(b, "\"Owner\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Owner)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2166,9 +2370,11 @@ func (m *CreateSequence) AppendJSONFields(printComma bool, b redact.RedactableBy
 		}
 		printComma = true
 		b = append(b, "\"SequenceName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.SequenceName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2178,9 +2384,11 @@ func (m *CreateSequence) AppendJSONFields(printComma bool, b redact.RedactableBy
 		}
 		printComma = true
 		b = append(b, "\"Owner\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Owner)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2200,9 +2408,11 @@ func (m *CreateStatistics) AppendJSONFields(printComma bool, b redact.Redactable
 		}
 		printComma = true
 		b = append(b, "\"TableName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TableName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2222,9 +2432,11 @@ func (m *CreateTable) AppendJSONFields(printComma bool, b redact.RedactableBytes
 		}
 		printComma = true
 		b = append(b, "\"TableName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TableName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2234,9 +2446,11 @@ func (m *CreateTable) AppendJSONFields(printComma bool, b redact.RedactableBytes
 		}
 		printComma = true
 		b = append(b, "\"Owner\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Owner)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2256,9 +2470,11 @@ func (m *CreateType) AppendJSONFields(printComma bool, b redact.RedactableBytes)
 		}
 		printComma = true
 		b = append(b, "\"TypeName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TypeName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2268,9 +2484,11 @@ func (m *CreateType) AppendJSONFields(printComma bool, b redact.RedactableBytes)
 		}
 		printComma = true
 		b = append(b, "\"Owner\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Owner)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2290,9 +2508,11 @@ func (m *CreateView) AppendJSONFields(printComma bool, b redact.RedactableBytes)
 		}
 		printComma = true
 		b = append(b, "\"ViewName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.ViewName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2302,9 +2522,11 @@ func (m *CreateView) AppendJSONFields(printComma bool, b redact.RedactableBytes)
 		}
 		printComma = true
 		b = append(b, "\"Owner\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Owner)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2314,9 +2536,11 @@ func (m *CreateView) AppendJSONFields(printComma bool, b redact.RedactableBytes)
 		}
 		printComma = true
 		b = append(b, "\"ViewQuery\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.ViewQuery)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2372,9 +2596,11 @@ func (m *DebugRecoverReplica) AppendJSONFields(printComma bool, b redact.Redacta
 		}
 		printComma = true
 		b = append(b, "\"StartKey\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.StartKey)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2384,9 +2610,11 @@ func (m *DebugRecoverReplica) AppendJSONFields(printComma bool, b redact.Redacta
 		}
 		printComma = true
 		b = append(b, "\"EndKey\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.EndKey)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2406,9 +2634,11 @@ func (m *DebugSendKvBatch) AppendJSONFields(printComma bool, b redact.Redactable
 		}
 		printComma = true
 		b = append(b, "\"BatchRequest\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.BatchRequest)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2428,9 +2658,11 @@ func (m *DropDatabase) AppendJSONFields(printComma bool, b redact.RedactableByte
 		}
 		printComma = true
 		b = append(b, "\"DatabaseName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.DatabaseName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2445,9 +2677,11 @@ func (m *DropDatabase) AppendJSONFields(printComma bool, b redact.RedactableByte
 				b = append(b, ',')
 			}
 			b = append(b, '"')
+
 			b = append(b, redact.StartMarker()...)
 			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(v)))))
 			b = append(b, redact.EndMarker()...)
+
 			b = append(b, '"')
 		}
 		b = append(b, ']')
@@ -2469,9 +2703,11 @@ func (m *DropIndex) AppendJSONFields(printComma bool, b redact.RedactableBytes) 
 		}
 		printComma = true
 		b = append(b, "\"TableName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TableName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2481,9 +2717,11 @@ func (m *DropIndex) AppendJSONFields(printComma bool, b redact.RedactableBytes) 
 		}
 		printComma = true
 		b = append(b, "\"IndexName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.IndexName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2507,9 +2745,11 @@ func (m *DropIndex) AppendJSONFields(printComma bool, b redact.RedactableBytes) 
 				b = append(b, ',')
 			}
 			b = append(b, '"')
+
 			b = append(b, redact.StartMarker()...)
 			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(v)))))
 			b = append(b, redact.EndMarker()...)
+
 			b = append(b, '"')
 		}
 		b = append(b, ']')
@@ -2531,9 +2771,11 @@ func (m *DropRole) AppendJSONFields(printComma bool, b redact.RedactableBytes) (
 		}
 		printComma = true
 		b = append(b, "\"RoleName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.RoleName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2553,9 +2795,11 @@ func (m *DropSchema) AppendJSONFields(printComma bool, b redact.RedactableBytes)
 		}
 		printComma = true
 		b = append(b, "\"SchemaName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.SchemaName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2575,9 +2819,11 @@ func (m *DropSequence) AppendJSONFields(printComma bool, b redact.RedactableByte
 		}
 		printComma = true
 		b = append(b, "\"SequenceName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.SequenceName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2597,9 +2843,11 @@ func (m *DropTable) AppendJSONFields(printComma bool, b redact.RedactableBytes) 
 		}
 		printComma = true
 		b = append(b, "\"TableName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TableName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2614,9 +2862,11 @@ func (m *DropTable) AppendJSONFields(printComma bool, b redact.RedactableBytes) 
 				b = append(b, ',')
 			}
 			b = append(b, '"')
+
 			b = append(b, redact.StartMarker()...)
 			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(v)))))
 			b = append(b, redact.EndMarker()...)
+
 			b = append(b, '"')
 		}
 		b = append(b, ']')
@@ -2638,9 +2888,11 @@ func (m *DropType) AppendJSONFields(printComma bool, b redact.RedactableBytes) (
 		}
 		printComma = true
 		b = append(b, "\"TypeName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TypeName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2660,9 +2912,11 @@ func (m *DropView) AppendJSONFields(printComma bool, b redact.RedactableBytes) (
 		}
 		printComma = true
 		b = append(b, "\"ViewName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.ViewName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2677,9 +2931,11 @@ func (m *DropView) AppendJSONFields(printComma bool, b redact.RedactableBytes) (
 				b = append(b, ',')
 			}
 			b = append(b, '"')
+
 			b = append(b, redact.StartMarker()...)
 			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(v)))))
 			b = append(b, redact.EndMarker()...)
+
 			b = append(b, '"')
 		}
 		b = append(b, ']')
@@ -2745,9 +3001,11 @@ func (m *GrantRole) AppendJSONFields(printComma bool, b redact.RedactableBytes) 
 				b = append(b, ',')
 			}
 			b = append(b, '"')
+
 			b = append(b, redact.StartMarker()...)
 			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(v)))))
 			b = append(b, redact.EndMarker()...)
+
 			b = append(b, '"')
 		}
 		b = append(b, ']')
@@ -2764,9 +3022,11 @@ func (m *GrantRole) AppendJSONFields(printComma bool, b redact.RedactableBytes) 
 				b = append(b, ',')
 			}
 			b = append(b, '"')
+
 			b = append(b, redact.StartMarker()...)
 			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(v)))))
 			b = append(b, redact.EndMarker()...)
+
 			b = append(b, '"')
 		}
 		b = append(b, ']')
@@ -2866,9 +3126,11 @@ func (m *PasswordHashConverted) AppendJSONFields(printComma bool, b redact.Redac
 		}
 		printComma = true
 		b = append(b, "\"RoleName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.RoleName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2878,7 +3140,9 @@ func (m *PasswordHashConverted) AppendJSONFields(printComma bool, b redact.Redac
 		}
 		printComma = true
 		b = append(b, "\"OldMethod\":\""...)
+
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.OldMethod)))
+
 		b = append(b, '"')
 	}
 
@@ -2888,7 +3152,9 @@ func (m *PasswordHashConverted) AppendJSONFields(printComma bool, b redact.Redac
 		}
 		printComma = true
 		b = append(b, "\"NewMethod\":\""...)
+
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.NewMethod)))
+
 		b = append(b, '"')
 	}
 
@@ -2932,9 +3198,11 @@ func (m *RenameDatabase) AppendJSONFields(printComma bool, b redact.RedactableBy
 		}
 		printComma = true
 		b = append(b, "\"DatabaseName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.DatabaseName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2944,9 +3212,11 @@ func (m *RenameDatabase) AppendJSONFields(printComma bool, b redact.RedactableBy
 		}
 		printComma = true
 		b = append(b, "\"NewDatabaseName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.NewDatabaseName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2966,9 +3236,11 @@ func (m *RenameSchema) AppendJSONFields(printComma bool, b redact.RedactableByte
 		}
 		printComma = true
 		b = append(b, "\"SchemaName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.SchemaName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -2978,9 +3250,11 @@ func (m *RenameSchema) AppendJSONFields(printComma bool, b redact.RedactableByte
 		}
 		printComma = true
 		b = append(b, "\"NewSchemaName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.NewSchemaName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -3000,9 +3274,11 @@ func (m *RenameTable) AppendJSONFields(printComma bool, b redact.RedactableBytes
 		}
 		printComma = true
 		b = append(b, "\"TableName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TableName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -3012,9 +3288,11 @@ func (m *RenameTable) AppendJSONFields(printComma bool, b redact.RedactableBytes
 		}
 		printComma = true
 		b = append(b, "\"NewTableName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.NewTableName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -3034,9 +3312,11 @@ func (m *RenameType) AppendJSONFields(printComma bool, b redact.RedactableBytes)
 		}
 		printComma = true
 		b = append(b, "\"TypeName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TypeName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -3046,9 +3326,11 @@ func (m *RenameType) AppendJSONFields(printComma bool, b redact.RedactableBytes)
 		}
 		printComma = true
 		b = append(b, "\"NewTypeName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.NewTypeName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -3078,9 +3360,11 @@ func (m *ReverseSchemaChange) AppendJSONFields(printComma bool, b redact.Redacta
 		}
 		printComma = true
 		b = append(b, "\"Error\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Error)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -3090,7 +3374,9 @@ func (m *ReverseSchemaChange) AppendJSONFields(printComma bool, b redact.Redacta
 		}
 		printComma = true
 		b = append(b, "\"SQLSTATE\":\""...)
+
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.SQLSTATE)))
+
 		b = append(b, '"')
 	}
 
@@ -3300,7 +3586,9 @@ func (m *SampledQuery) AppendJSONFields(printComma bool, b redact.RedactableByte
 		}
 		printComma = true
 		b = append(b, "\"Distribution\":\""...)
+
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.Distribution)))
+
 		b = append(b, '"')
 	}
 
@@ -3322,9 +3610,11 @@ func (m *SensitiveTableAccess) AppendJSONFields(printComma bool, b redact.Redact
 		}
 		printComma = true
 		b = append(b, "\"TableName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TableName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -3334,7 +3624,9 @@ func (m *SensitiveTableAccess) AppendJSONFields(printComma bool, b redact.Redact
 		}
 		printComma = true
 		b = append(b, "\"AccessMode\":\""...)
+
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.AccessMode)))
+
 		b = append(b, '"')
 	}
 
@@ -3354,7 +3646,9 @@ func (m *SetClusterSetting) AppendJSONFields(printComma bool, b redact.Redactabl
 		}
 		printComma = true
 		b = append(b, "\"SettingName\":\""...)
+
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.SettingName)))
+
 		b = append(b, '"')
 	}
 
@@ -3364,9 +3658,11 @@ func (m *SetClusterSetting) AppendJSONFields(printComma bool, b redact.Redactabl
 		}
 		printComma = true
 		b = append(b, "\"Value\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Value)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -3386,9 +3682,11 @@ func (m *SetSchema) AppendJSONFields(printComma bool, b redact.RedactableBytes) 
 		}
 		printComma = true
 		b = append(b, "\"DescriptorName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.DescriptorName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -3398,9 +3696,11 @@ func (m *SetSchema) AppendJSONFields(printComma bool, b redact.RedactableBytes) 
 		}
 		printComma = true
 		b = append(b, "\"NewDescriptorName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.NewDescriptorName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -3410,9 +3710,11 @@ func (m *SetSchema) AppendJSONFields(printComma bool, b redact.RedactableBytes) 
 		}
 		printComma = true
 		b = append(b, "\"DescriptorType\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.DescriptorType)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -3432,7 +3734,9 @@ func (m *SetTenantClusterSetting) AppendJSONFields(printComma bool, b redact.Red
 		}
 		printComma = true
 		b = append(b, "\"SettingName\":\""...)
+
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.SettingName)))
+
 		b = append(b, '"')
 	}
 
@@ -3442,9 +3746,11 @@ func (m *SetTenantClusterSetting) AppendJSONFields(printComma bool, b redact.Red
 		}
 		printComma = true
 		b = append(b, "\"Value\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Value)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -3517,9 +3823,11 @@ func (m *TruncateTable) AppendJSONFields(printComma bool, b redact.RedactableByt
 		}
 		printComma = true
 		b = append(b, "\"TableName\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TableName)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -3605,9 +3913,11 @@ func (m *UnsafeDeleteDescriptor) AppendJSONFields(printComma bool, b redact.Reda
 		}
 		printComma = true
 		b = append(b, "\"Name\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Name)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -3625,9 +3935,11 @@ func (m *UnsafeDeleteDescriptor) AppendJSONFields(printComma bool, b redact.Reda
 		}
 		printComma = true
 		b = append(b, "\"ForceNotice\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.ForceNotice)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -3665,9 +3977,11 @@ func (m *UnsafeDeleteNamespaceEntry) AppendJSONFields(printComma bool, b redact.
 		}
 		printComma = true
 		b = append(b, "\"Name\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Name)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -3685,9 +3999,11 @@ func (m *UnsafeDeleteNamespaceEntry) AppendJSONFields(printComma bool, b redact.
 		}
 		printComma = true
 		b = append(b, "\"ForceNotice\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.ForceNotice)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -3707,9 +4023,11 @@ func (m *UnsafeUpsertDescriptor) AppendJSONFields(printComma bool, b redact.Reda
 		}
 		printComma = true
 		b = append(b, "\"PreviousDescriptor\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.PreviousDescriptor)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -3719,9 +4037,11 @@ func (m *UnsafeUpsertDescriptor) AppendJSONFields(printComma bool, b redact.Reda
 		}
 		printComma = true
 		b = append(b, "\"NewDescriptor\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.NewDescriptor)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -3739,9 +4059,11 @@ func (m *UnsafeUpsertDescriptor) AppendJSONFields(printComma bool, b redact.Reda
 		}
 		printComma = true
 		b = append(b, "\"ForceNotice\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.ForceNotice)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -3779,9 +4101,11 @@ func (m *UnsafeUpsertNamespaceEntry) AppendJSONFields(printComma bool, b redact.
 		}
 		printComma = true
 		b = append(b, "\"Name\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Name)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 
@@ -3816,9 +4140,11 @@ func (m *UnsafeUpsertNamespaceEntry) AppendJSONFields(printComma bool, b redact.
 		}
 		printComma = true
 		b = append(b, "\"ValidationErrors\":\""...)
+
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.ValidationErrors)))))
 		b = append(b, redact.EndMarker()...)
+
 		b = append(b, '"')
 	}
 

--- a/pkg/util/log/eventpb/splittable.go
+++ b/pkg/util/log/eventpb/splittable.go
@@ -1,0 +1,26 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package eventpb
+
+const (
+	SplittableMarkerStart = '❰'
+	StringSplittableStart = string(SplittableMarkerStart)
+	SplittableMarkerEnd   = '❱'
+	StringSplittableEnd   = string(SplittableMarkerEnd)
+)
+
+func StartSplittableMarker() []byte {
+	return []byte(StringSplittableStart)
+}
+
+func EndSplittableMarker() []byte {
+	return []byte(StringSplittableEnd)
+}

--- a/pkg/util/log/format_json.go
+++ b/pkg/util/log/format_json.go
@@ -17,8 +17,11 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/cockroachdb/cockroach/pkg/util/jsonbytes"
+	"github.com/cockroachdb/cockroach/pkg/util/log/channel"
+	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
@@ -387,23 +390,60 @@ func formatJSON(entry logEntry, forFluent bool, tags tagChoice) *buffer {
 		buf.WriteByte('}')
 	}
 
+	commonPrefixLen := buf.Len()
+	var lastLogLinePayloadMsgLen int
+
 	if entry.structured {
-		buf.WriteString(`,"event":{`)
-		buf.WriteString(entry.payload.message) // Already JSON.
+		prefix := `,"event":{`
+		buf.WriteString(prefix)
+		if entry.ch == channel.TELEMETRY {
+			eventPrefixLen := buf.Len()
+			lastLogLinePayloadMsgLen = buf.maybeJSONMultiLine(eventPrefixLen, entry.payload.redactable, entry.payload.message, true, entry.payload.truncate, 0)
+			lastLogLinePayloadMsgLen += len(prefix) + 2 // Add 2 for the opening comma and the closing bracket
+		} else {
+			buf.WriteString(entry.payload.message) // Already JSON.
+		}
 		buf.WriteByte('}')
 	} else {
 		// Message.
-		buf.WriteString(`,"message":"`)
-		escapeString(buf, entry.payload.message)
-		buf.WriteByte('"')
+		if entry.ch == channel.TELEMETRY {
+			buf.WriteString(`,`)
+			msgBuffer := getBuffer()
+			escapeString(msgBuffer, entry.payload.message)
+			msgString := `"message":"` + msgBuffer.String() + `"`
+			// Message prefix length increments by 1 to include the comma written
+			// above.
+			messagePrefixLen := commonPrefixLen + 1
+			lastLogLinePayloadMsgLen = buf.maybeJSONMultiLine(messagePrefixLen, entry.payload.redactable, msgString, false, entry.payload.truncate, 0)
+			lastLogLinePayloadMsgLen += 1 // Add 1 for the opening comma
+		} else {
+			buf.WriteString(`,"message":"`)
+			escapeString(buf, entry.payload.message)
+			buf.WriteByte('"')
+		}
 	}
 
 	// Stacks.
 	if len(entry.stacks) > 0 {
-		buf.WriteString(`,"stacks":"`)
-		escapeString(buf, string(entry.stacks))
-		buf.WriteByte('"')
+		if entry.ch == channel.TELEMETRY {
+			buf.WriteString(`,`)
+			stacksBuffer := getBuffer()
+			escapeString(stacksBuffer, string(entry.stacks))
+			stacksString := `"stacks":"` + stacksBuffer.String() + `"`
+			// Stacks prefix length increments by 1 to include the comma written
+			// above.
+			stacksPrefixLen := commonPrefixLen + 1
+			//lines := strings.Split(buf.String(), "\n")
+			//currentLog := lines[len(lines)-1] // Can we do this in a better way without splitting? (how can we get the length of the current log without splitting?)
+			//payloadSpaceConsumedByCurrentLog := len(currentLog) - stacksPrefixLen
+			buf.maybeJSONMultiLine(stacksPrefixLen, false, stacksString, false, entry.payload.truncate, lastLogLinePayloadMsgLen)
+		} else {
+			buf.WriteString(`,"stacks":"`)
+			escapeString(buf, string(entry.stacks))
+			buf.WriteByte('"')
+		}
 	}
+
 	buf.WriteByte('}')
 	buf.WriteByte('\n')
 	return buf
@@ -413,6 +453,330 @@ func escapeString(buf *buffer, s string) {
 	b := buf.Bytes()
 	b = jsonbytes.EncodeString(b, s)
 	buf.Buffer = *bytes.NewBuffer(b)
+}
+
+type jsonLongLineLen int
+
+// truncateLineLenJSON is the max length of a message/event/stack with JSON
+// formatting, before it gets truncated.
+var truncateLineLenJSON jsonLongLineLen
+
+// splitLineLenJSON is the max length of a message/event/stack with JSON
+// formatting, before it gets broken into multiple lines.
+var splitLineLenJSON jsonLongLineLen
+
+// longLineLenJSON is the line length being used during formatting, it is set
+// to either truncateLineLenJSON or splitLineLenJSON depending on whether we
+// are truncating or splitting the log.
+var longLineLenJSON jsonLongLineLen
+
+func init() {
+	truncateLineLenJSON.set(2048)
+	splitLineLenJSON.set(10240)
+}
+
+func (l *jsonLongLineLen) set(v int) {
+	// We refuse to break a long entry in the middle of a UTF-8
+	// sequence, so the effective max length needs to be reduced by the
+	// maximum size of an UTF-8 sequence.
+	suffixLen := utf8.UTFMax
+	// We also refuse to break a long entry in the middle of a redaction
+	// marker. Additionally, if we observe a start redaction marker,
+	// we are going to insert a closing redaction marker after it
+	// before we break up the line.
+	if len(startRedactionMarker)+len(endRedactionMarker) > suffixLen {
+		suffixLen = len(startRedactionMarker) + len(endRedactionMarker)
+	}
+	// We need to add opening and closing splittable markers when we split.
+	suffixLen += len(startSplittableMarker) + len(endSplittableMarker)
+	// If we are breaking in the middle of a string, we need to include a closing
+	// quotation mark.
+	suffixLen++
+	// Need to add a closing bracket to close the payload message.
+	suffixLen++
+	// Need to add a closing bracket to close the log entry.
+	suffixLen++
+	newMax := v - suffixLen
+	if newMax < 1 {
+		panic("max line length cannot be zero or negative")
+	}
+	*l = jsonLongLineLen(newMax)
+}
+
+func resetLongLineLenJSON(truncate bool) {
+	longLineLenJSON = truncateLineLenJSON
+	if !truncate {
+		longLineLenJSON = splitLineLenJSON
+	}
+}
+
+var startSplittableMarker = string(eventpb.StartSplittableMarker())
+var endSplittableMarker = string(eventpb.EndSplittableMarker())
+
+// shouldSplitOnKey checks if the key space exceeds or matches the remaining
+// amount of space in log. If so, split the log early (move key to next log).
+// Note: this implementation assumes that the key buffer length will not exceed
+// the entire longLineLenJSON.
+func shouldSplitOnKey(prefixLen int, lastLen int, keyBufferLen int) bool {
+	// We only split on a JSON key when there is not enough space for the key,
+	// and the smallest part of its value. longLineLenJSON already accounts for
+	// a value's suffix length (max utf8 character, redaction markers, and
+	// closing string quote), here we include the opening string quote as a
+	// prefix.
+	const valueOpeningQuoteLen = 1
+	return prefixLen+lastLen+keyBufferLen >= int(longLineLenJSON)+valueOpeningQuoteLen
+}
+
+func shouldSplitOnValue(prefixLen, totalLen int, isStringValue bool, isSplittable bool, isEvent bool) bool {
+	// If the payload is structured, but we are either:
+	// - not in a string value
+	// - or the value is not designated as splittable
+	// we do not split the value.
+	// Otherwise, we split if the long line length has
+	// been exceeded.
+	if isEvent && (!isStringValue || !isSplittable) {
+		return false
+	}
+	if prefixLen+totalLen >= int(longLineLenJSON) {
+		return true
+	}
+	return false
+}
+
+func (buf *buffer) maybeJSONMultiLine(prefixLen int, redactable bool, msg string, isEvent bool, truncate bool, payloadSpaceConsumedInCurrentLog int) int {
+	var i int
+	for i = len(msg) - 1; i > 0 && msg[i] == '\n'; i-- {
+		msg = msg[:i]
+	}
+
+	resetLongLineLenJSON(truncate)
+	lastLen := payloadSpaceConsumedInCurrentLog
+	beforeColon := true
+	betweenRedactionMarkers := false
+	betweenSplittableMarkers := false
+	betweenQuotesInKey := false
+	betweenQuotesInValue := false
+	inValueNoQuotes := false
+	var keyBuffer []byte
+	var valueBuffer []byte
+
+	// Note: This implementation is under the assumption the payload is
+	// well-formed JSON, and that the payload message does not contain inner
+	// JSON objects.
+	for i, w := 0, 0; i < len(msg); i += w {
+		runeValue, width := utf8.DecodeRuneInString(msg[i:])
+		w = width
+		if beforeColon {
+			keyBuffer = append(keyBuffer, string(runeValue)...)
+			if runeValue == '"' {
+				betweenQuotesInKey = !betweenQuotesInKey
+			}
+			if runeValue == ':' && !betweenQuotesInKey {
+				if shouldSplitOnKey(prefixLen, lastLen, len(keyBuffer)) {
+					// If the last byte in the buffer is a comma.
+					if buf.Bytes()[len(buf.Bytes())-1] == ',' {
+						// If the message is a structured event, replace with closing
+						// bracket.
+						if isEvent {
+							buf.Bytes()[len(buf.Bytes())-1] = '}'
+						} else {
+							// Otherwise, truncate the buffer to remove the comma byte.
+							buf.Truncate(len(buf.Bytes()) - 1)
+						}
+					}
+					// Close the entire log.
+					buf.WriteByte('}')
+					// If we are not splitting (we are truncating), end early.
+					if truncate {
+						return lastLen
+					}
+					// Move to next log.
+					buf.WriteByte('\n')
+					// Previous payload space has been freed, reset long line length.
+					resetLongLineLenJSON(truncate)
+					// Write the prefix.
+					buf.Write(buf.Bytes()[0:prefixLen])
+					// Reset the length of the log.
+					lastLen = 0
+				}
+				// Update that we have past the JSON field's colon (i.e. entering JSON
+				// value).
+				beforeColon = !beforeColon
+				// Move to the next character.
+				continue
+			}
+		}
+
+		// If we are after the colon (i.e. in the JSON value).
+		if !beforeColon {
+			// If the value buffer is empty, this is the first character in the new
+			// value.
+			if len(valueBuffer) == 0 {
+				if runeValue == '"' {
+					valueBuffer = append(valueBuffer, string(runeValue)...)
+					betweenQuotesInValue = true
+					continue
+				} else {
+					inValueNoQuotes = true
+				}
+			}
+
+			// Check if the log should be split.
+			if shouldSplitOnValue(prefixLen, lastLen+len(keyBuffer)+len(valueBuffer), betweenQuotesInValue, betweenSplittableMarkers, isEvent) {
+				buf.Write(keyBuffer)
+				buf.Write(valueBuffer)
+				if betweenRedactionMarkers {
+					// We are breaking a long line in-between redaction
+					// markers. Ensures that the opening and closing markers do
+					// not straddle log entries.
+					buf.WriteString(endRedactionMarker)
+				}
+				if betweenSplittableMarkers {
+					// We are breaking a long line in-between splittable
+					// markers. Ensures that the opening and closing markers do
+					// not straddle log entries.
+					buf.WriteString(endSplittableMarker)
+				}
+				if betweenQuotesInValue {
+					// Add a closing quote.
+					buf.WriteByte('"')
+				}
+				// If we have reached the end of the log, finish instead of creating
+				// another (empty) log. Closing event & log bracket will be added by
+				// caller.
+				if i+w >= len(msg) {
+					return lastLen
+				}
+				if isEvent {
+					// Add a closing bracket.
+					buf.WriteByte('}')
+				}
+				// Close the entire JSON payload.
+				buf.WriteByte('}')
+				// If we are not splitting (we are truncating), end early.
+				if truncate {
+					return lastLen
+				}
+				// Move to next log.
+				buf.WriteByte('\n')
+				// Previous payload space has been freed, reset long line length.
+				resetLongLineLenJSON(truncate)
+				// Reset the length of the log.
+				lastLen = 0
+				// Clear the value buffer.
+				valueBuffer = valueBuffer[:0]
+				// Write the prefix (i.e. "... event:{").
+				buf.Write(buf.Bytes()[0:prefixLen])
+				if betweenQuotesInValue {
+					// Write an opening quote to the value buffer.
+					valueBuffer = append(valueBuffer, '"')
+				}
+				if betweenSplittableMarkers {
+					// See above: if we are splitting in-between splittable
+					// markers, continue the split item on the new line.
+					valueBuffer = append(valueBuffer, startSplittableMarker...)
+				}
+				if betweenRedactionMarkers {
+					// See above: if we are splitting in-between redaction
+					// markers, continue the sensitive item on the new line.
+					valueBuffer = append(valueBuffer, startRedactionMarker...)
+				}
+			}
+
+			if redactable {
+				// If we see an opening redaction marker, remember this fact
+				// so that we close/open it properly.
+				if strings.HasPrefix(msg[i:], startRedactionMarker) {
+					betweenRedactionMarkers = true
+					valueBuffer = append(valueBuffer, startRedactionMarker...)
+					w = len(startRedactionMarker)
+					continue
+				} else if strings.HasPrefix(msg[i:], endRedactionMarker) {
+					betweenRedactionMarkers = false
+					valueBuffer = append(valueBuffer, endRedactionMarker...)
+					w = len(endRedactionMarker)
+					continue
+				}
+			}
+
+			// If we see an opening splittable marker, remember this fact
+			// so that we close/open it properly.
+			if strings.HasPrefix(msg[i:], startSplittableMarker) {
+				betweenSplittableMarkers = true
+				valueBuffer = append(valueBuffer, startSplittableMarker...)
+				w = len(startSplittableMarker)
+				continue
+			} else if strings.HasPrefix(msg[i:], endSplittableMarker) {
+				betweenSplittableMarkers = false
+				valueBuffer = append(valueBuffer, endSplittableMarker...)
+				w = len(endSplittableMarker)
+				continue
+			}
+
+			// After checking for a log split and redaction markers, append the
+			// current rune to the value buffer.
+			valueBuffer = append(valueBuffer, string(runeValue)...)
+
+			if betweenQuotesInValue {
+				// If we are in a string value and the current rune is a backslash.
+				if runeValue == '\\' {
+					// Append the escaped character.
+					nextRuneValue, nextWidth := utf8.DecodeRuneInString(msg[i+w:])
+					valueBuffer = append(valueBuffer, string(nextRuneValue)...)
+					w += nextWidth
+				} else if runeValue == '"' {
+					// If we are in a string value and the current rune is a double
+					// quote, we have reached the end of the string.
+
+					// If there exists another rune after the closing quote, another JSON
+					// field exists, append a comma after the current value.
+					if i+w < len(msg)-1 {
+						nextRuneValue, nextWidth := utf8.DecodeRuneInString(msg[i+w:])
+						// Expect the next character to be a comma if we encounter the
+						// closing quotation mark, and we are not at the end of msg.
+						if nextRuneValue == ',' {
+							valueBuffer = append(valueBuffer, string(nextRuneValue)...)
+							w += nextWidth
+						} else {
+							panic("expected comma after closing quotation mark in value got " + string(nextRuneValue))
+						}
+					}
+
+					// We have parsed the entire value. Write the key-value pair.
+					buf.Write(keyBuffer)
+					buf.Write(valueBuffer)
+					lastLen += len(keyBuffer) + len(valueBuffer)
+					// Clear the buffers.
+					keyBuffer = keyBuffer[:0]
+					valueBuffer = valueBuffer[:0]
+					// Update that we are out of the value.
+					beforeColon = !beforeColon
+					betweenQuotesInValue = false
+				}
+			}
+
+			if inValueNoQuotes {
+				// We write the current key-value pairing to the buffer when:
+				//	- we are in a non-string value and encounter a comma, we have
+				// 	finished parsing the value
+				// 	- there is no comma, but we have finished parsing the message
+				//	(there does not exist another rune after the current rune)
+				if runeValue == ',' || i+w >= len(msg) {
+					// We have parsed the entire value. Write the key-value pair.
+					buf.Write(keyBuffer)
+					buf.Write(valueBuffer)
+					lastLen += len(keyBuffer) + len(valueBuffer)
+					// Clear the buffers.
+					keyBuffer = keyBuffer[:0]
+					valueBuffer = valueBuffer[:0]
+					// Update that we are out of the value.
+					beforeColon = !beforeColon
+					inValueNoQuotes = false
+				}
+			}
+		}
+	}
+	return lastLen
 }
 
 type entryDecoderJSON struct {

--- a/pkg/util/log/format_json_test.go
+++ b/pkg/util/log/format_json_test.go
@@ -13,6 +13,7 @@ package log
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -93,7 +94,129 @@ func TestJSONFormats(t *testing.T) {
 
 		return buf.String()
 	})
+}
 
+func TestFormatJSONLongLineBreaks(t *testing.T) {
+	formats := []logFormatter{
+		formatJSONFull{},
+	}
+	datadriven.RunTest(t, "testdata/json_break_lines", func(t *testing.T, td *datadriven.TestData) string {
+		if td.Cmd != "run" {
+			t.Fatalf("unknown command: %s", td.Cmd)
+		}
+
+		// Two closing brackets are appended after the log formatting if the
+		// payload + prefix length match the long line length exactly. These are
+		// not accounted for so we add a buffer here.
+		const bufferSuffixLen = 2
+		var payloadMsgLen int
+		var prefixLen int
+		var redactable bool
+		var structured bool
+		var withLongStack bool
+		var truncate bool
+		var logChannel int
+		td.ScanArgs(t, "payloadMsgLen", &payloadMsgLen)
+		td.ScanArgs(t, "prefixLen", &prefixLen)
+		td.ScanArgs(t, "redactable", &redactable)
+		td.ScanArgs(t, "structured", &structured)
+		td.ScanArgs(t, "withLongStack", &withLongStack)
+		td.ScanArgs(t, "truncate", &truncate)
+		td.ScanArgs(t, "channel", &logChannel)
+
+		defer func(truncate bool, prevTrunc int, prevSplit int) {
+			if truncate {
+				truncateLineLenJSON = jsonLongLineLen(prevTrunc)
+			} else {
+				splitLineLenJSON = jsonLongLineLen(prevSplit)
+			}
+		}(truncate, int(truncateLineLenJSON), int(splitLineLenJSON))
+
+		if truncate {
+			truncateLineLenJSON.set(prefixLen + payloadMsgLen)
+		} else {
+			splitLineLenJSON.set(prefixLen + payloadMsgLen)
+		}
+
+		longLine := string(bytes.Repeat([]byte("a"), 50))
+
+		withBigStack := func(e logEntry) logEntry {
+			e.stacks = []byte("this is " + longLine + " fake stack")
+			return e
+		}
+
+		entry := logEntry{
+			payload: entryPayload{
+				redactable: redactable,
+				truncate:   truncate,
+				message:    td.Input,
+			},
+			ch:         logpb.Channel(logChannel),
+			structured: structured,
+		}
+
+		if withLongStack {
+			entry = withBigStack(entry)
+		}
+
+		var buf bytes.Buffer
+		for _, f := range formats {
+			b := f.formatEntry(entry)
+			out := b.String()
+			putBuffer(b)
+
+			lines := strings.Split(out, "\n")
+			for _, l := range lines {
+				l = strings.TrimSuffix(l, "\n")
+				if len(l) == 0 {
+					continue
+				}
+
+				if len(l) > prefixLen+payloadMsgLen+bufferSuffixLen {
+					t.Fatalf("line too large: %d bytes, expected max %d - %s", len(l), prefixLen+payloadMsgLen, l)
+				}
+
+				fmt.Fprintf(&buf, "%s: %s\n", f.formatterName(), l)
+
+				// Verify that the JSON log is valid JSON format.
+				var raw map[string]interface{}
+				if unMarshalErr := json.Unmarshal([]byte(l), &raw); unMarshalErr != nil {
+					t.Fatalf("error unmarshaling log line %s\n, with error: %v", l, unMarshalErr)
+				}
+
+				var eventOrMsgBytes []byte
+				var eventOrMsgInterface interface{}
+				var err error
+
+				if structured {
+					eventOrMsgInterface = raw["event"]
+				} else {
+					eventOrMsgInterface = raw["message"]
+				}
+
+				if !withLongStack && eventOrMsgInterface == nil {
+					t.Fatalf("couldn't parse event/message from log line")
+				}
+
+				// Verify that the event/message follows valid JSON format.
+				eventOrMsgBytes, err = json.Marshal(eventOrMsgInterface)
+
+				if err != nil {
+					t.Fatalf("error marshalling eventPayload %v: %v", eventOrMsgInterface, err)
+				}
+
+				// If the log is structured.
+				if structured {
+					// Get the raw event.
+					var rawEvent map[string]interface{}
+					if unMarshalErr := json.Unmarshal(eventOrMsgBytes, &rawEvent); unMarshalErr != nil {
+						t.Fatalf("error unmarshaling event %s\n, with error: %v", eventOrMsgBytes, unMarshalErr)
+					}
+				}
+			}
+		}
+		return buf.String()
+	})
 }
 
 func TestJsonDecode(t *testing.T) {

--- a/pkg/util/log/log_entry.go
+++ b/pkg/util/log/log_entry.go
@@ -170,6 +170,11 @@ type entryPayload struct {
 
 	// Whether the payload message is redactable or not.
 	redactable bool
+
+	// Whether the payload message is intended to be truncated if it exceeds a
+	// threshold size. If not the payload message is  split into multiple logs if
+	// instead.
+	truncate bool
 }
 
 func makeRedactablePayload(ctx context.Context, m redact.RedactableString) entryPayload {
@@ -177,6 +182,8 @@ func makeRedactablePayload(ctx context.Context, m redact.RedactableString) entry
 		message:    string(m),
 		tags:       makeFormattableTags(ctx, true /* redactable */),
 		redactable: true,
+		// By default, truncate payloads instead of splitting.
+		truncate: true,
 	}
 }
 
@@ -185,6 +192,8 @@ func makeUnsafePayload(ctx context.Context, m string) entryPayload {
 		message:    m,
 		tags:       makeFormattableTags(ctx, false /* redactable */),
 		redactable: false,
+		// By default, truncate payloads instead of splitting.
+		truncate: true,
 	}
 }
 

--- a/pkg/util/log/testdata/json_break_lines
+++ b/pkg/util/log/testdata/json_break_lines
@@ -1,0 +1,180 @@
+# Test for unstructured log with no split.
+run payloadMsgLen=100 redactable=true structured=false withLongStack=false truncate=false channel=12 prefixLen=178
+hello ‹world› and universe
+----
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"message":"hello ‹world› and universe"}
+
+# Test for unstructured log, with split. Max len is 23 after suffix length.
+run payloadMsgLen=38 redactable=false structured=false withLongStack=false truncate=false channel=12 prefixLen=178
+hello world and universe
+----
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":0,"message":"hello world "}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":0,"message":"and universe"}
+
+# Test for unstructured log, split with correct redaction markers. Max len is 23 after suffix length.
+run payloadMsgLen=38 redactable=true structured=false withLongStack=false truncate=false channel=12 prefixLen=178
+hello ‹world› and universe
+----
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"message":"hello ‹wor›"}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"message":"‹ld› and"}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"message":" universe"}
+
+# Test for structured log, don't split on an integer value. Max len is 23 after suffix length.
+run payloadMsgLen=38 redactable=false structured=true withLongStack=false truncate=false channel=12 prefixLen=187
+"Timestamp":1647874213395872000
+----
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":0,"event":{"Timestamp":1647874213395872000}}
+
+# Test for structured log, don't split on a field that does not contain splittable markers. Max len is 23 after suffix length.
+run payloadMsgLen=38 redactable=false structured=true withLongStack=false truncate=false channel=12 prefixLen=187
+"StringField":"this is a string value"
+----
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":0,"event":{"StringField":"this is a string value"}}
+
+# Test for structured log, split on an string value with correction quotations. Max len is 26 after suffix length.
+run payloadMsgLen=41 redactable=false structured=true withLongStack=false truncate=false channel=12 prefixLen=187
+"StringField":"❰this is a string value❱"
+----
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":0,"event":{"StringField":"❰this is ❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":0,"event":{"StringField":"❰a string❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":0,"event":{"StringField":"❰ value❱"}}
+
+# Test for structured log, split on an string value with correction quotations and redaction markers. Max len is 26 after suffix length.
+run payloadMsgLen=41 redactable=true structured=true withLongStack=false truncate=false channel=12 prefixLen=187
+"StringField":"❰‹this is a string›❱"
+----
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"StringField":"❰‹this ›❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"StringField":"❰‹is a ›❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"StringField":"❰‹strin›❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"StringField":"❰‹g›❱"}}
+
+# Multi-field structured log, integer and string fields, split string with escaped characters and redaction markers. Max len is 26 after suffix length.
+# Split early on *all* JSON keys.
+run payloadMsgLen=41 redactable=true structured=true withLongStack=false truncate=false channel=12 prefixLen=187
+"Number":12345678901234567890,"Statement":"❰SELECT id, name, something FROM \"\".\"\".table WHERE column = ‹'secret_column'›❱","User":"‹test›"
+----
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Number":12345678901234567890}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Statement":"❰SELECT id,❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Statement":"❰ name, som❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Statement":"❰ething FRO❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Statement":"❰M \"\".\"\"❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Statement":"❰.table WHE❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Statement":"❰RE column ❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Statement":"❰= ‹'secr›❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Statement":"❰‹et_colu›❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Statement":"❰‹mn'›❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"User":"‹test›"}}
+
+# Multi-field structured log, integer and string fields, split with escaped characters and redaction markers. Max len is 46 after suffix length.
+# Split early on *some* JSON keys.
+run payloadMsgLen=61 redactable=true structured=true withLongStack=false truncate=false channel=12 prefixLen=187
+"Number":1234567890,"Statement":"❰SELECT id, name, something FROM \"\".\"\".table WHERE column = ‹'secret_column'›❱","User":"‹test›"
+----
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Number":1234567890,"Statement":"❰SELECT id,❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Statement":"❰ name, something FROM \"\".\"\"❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Statement":"❰.table WHERE column = ‹'secr›❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Statement":"❰‹et_column'›❱","User":"‹test›"}}
+
+# Test for unstructured log containing multi-byte sequences.
+run payloadMsgLen=38 redactable=false structured=false withLongStack=false truncate=false channel=12 prefixLen=178
+☃☃☃☃☃☃☃☃☃☃☃☃
+----
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":0,"message":"☃☃☃☃"}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":0,"message":"☃☃☃☃"}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":0,"message":"☃☃☃☃"}
+
+# Test for splitting long stack.
+run payloadMsgLen=58 redactable=true structured=false withLongStack=true truncate=false channel=12 prefixLen=178
+----
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"message":"","stacks":"this is aaaaaaaaaaaa"}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"stacks":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"stacks":"aaaaa fake stack"}
+
+# Multi-field structured log, integer and string fields, split with escaped characters and redaction markers. Max len is 46 after suffix length.
+# Include long stack.
+run payloadMsgLen=61 redactable=true structured=true withLongStack=true truncate=false channel=12 prefixLen=187
+"Number":1234567890,"Message":"❰This is a \"message\" for ‹you›❱"
+----
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Number":1234567890,"Message":"❰This is a \"❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Message":"❰message\" for ‹you›❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"stacks":"this is aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"stacks":"aaaaaaaaaaaaa fake stack"}
+
+# Multi-field structured log, integer and string fields, split with escaped characters and redaction markers. Max len is 46 after suffix length.
+# Split early on *some* JSON keys. Include long stack.
+run payloadMsgLen=61 redactable=true structured=true withLongStack=true truncate=false channel=12 prefixLen=187
+"Number":1234567890,"Statement":"❰SELECT id, name, something FROM \"\".\"\".table WHERE column = ‹'secret_column'›❱","User":"‹user›","AnotherKey":"❰value!❱"
+----
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Number":1234567890,"Statement":"❰SELECT id,❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Statement":"❰ name, something FROM \"\".\"\"❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Statement":"❰.table WHERE column = ‹'secr›❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Statement":"❰‹et_column'›❱","User":"‹user›"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"AnotherKey":"❰value!❱"},"stacks":"this i"}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"stacks":"s aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"stacks":"aaaaaaa fake stack"}
+
+# Multi-field structured log, integer and string fields, split with escaped characters and redaction markers. Max len is 46 after suffix length.
+# Include long stack.
+run payloadMsgLen=61 redactable=true structured=true withLongStack=true truncate=false channel=12 prefixLen=187
+"Number":1234567890,"Message":"❰This is a \"message\" for ‹you›❱"
+----
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Number":1234567890,"Message":"❰This is a \"❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Message":"❰message\" for ‹you›❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"stacks":"this is aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"stacks":"aaaaaaaaaaaaa fake stack"}
+
+# Test for split in middle of redaction marker. This test splits in the middle of both the start and ending redaction marker. Max len 26 after suffix length.
+run payloadMsgLen=41 redactable=true structured=true withLongStack=false truncate=false channel=12 prefixLen=187
+"Redaction":"❰This is ‹marker›❱"
+----
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Redaction":"❰This is ‹›❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Redaction":"❰‹marker›❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Redaction":"❰❱"}}
+
+# Test for split right before the closing redaction marker. Max len 33 after suffix length.
+run payloadMsgLen=48 redactable=true structured=true withLongStack=false truncate=false channel=12 prefixLen=187
+"Redaction":"❰This is ‹marker›❱"
+----
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Redaction":"❰This is ‹marker›❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Redaction":"❰‹›❱"}}
+
+# Test for split right before the closing splittable marker. Max len 31 after suffix length.
+run payloadMsgLen=46 redactable=false structured=true withLongStack=false truncate=false channel=12 prefixLen=187
+"Splittable":"❰This is marker❱"
+----
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":0,"event":{"Splittable":"❰This is marker❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":0,"event":{"Splittable":"❰❱"}}
+
+# Test for split right before the closing quotation marker. Should not split as we are outside of splittable markers. Max len 38 after suffix length.
+run payloadMsgLen=53 redactable=false structured=true withLongStack=false truncate=false channel=12 prefixLen=187
+"Quotation":"❰This is a quotation❱"
+----
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":0,"event":{"Quotation":"❰This is a quotation❱"}}
+
+# Test for split in middle of escape character. Max len 28 after suffix length.
+run payloadMsgLen=43 redactable=true structured=true withLongStack=false truncate=false channel=12 prefixLen=187
+"Redaction":"❰This is an \"escaped\" string❱"
+----
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Redaction":"❰This is an \"❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Redaction":"❰escaped\" st❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":1,"event":{"Redaction":"❰ring❱"}}
+
+# Test for no split if payload is exact size of configured max len after considering suffix length. Max len 39 after suffix length.
+run payloadMsgLen=54 redactable=false structured=true withLongStack=false truncate=false channel=12 prefixLen=187
+"Exact":"❰This is an exact length❱"
+----
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":0,"event":{"Exact":"❰This is an exact length❱"}}
+
+# Test for when JSON key contains a colon. Max len 25 after suffix length.
+# Note what occurs when we split immediately prior to the closing "splittable" marker on the 2nd last log line.
+# The closing suffix safety ensures we close the 2nd last log line with the appropriate closing markers (splittable, quote, bracket)
+# but we also incur a log line where the remaining message is ❱".
+run payloadMsgLen=40 redactable=false structured=true withLongStack=false truncate=false channel=12 prefixLen=187
+"FirstKey":12345,":KeyWithColon":"❰This is a value❱"
+----
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":0,"event":{"FirstKey":12345}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":0,"event":{":KeyWithColon":"❰This ❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":0,"event":{":KeyWithColon":"❰is a ❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":0,"event":{":KeyWithColon":"❰value❱"}}
+json: {"channel_numeric":12,"channel":"TELEMETRY","timestamp":"0.000000000","severity_numeric":0,"severity":"UNKNOWN","goroutine":0,"file":"","line":0,"entry_counter":0,"redactable":0,"event":{":KeyWithColon":"❰❱"}}
+


### PR DESCRIPTION
Issue: https://cockroachlabs.atlassian.net/browse/SREOPS-4287

Previously, each JSON log carried an entire event and stack. This was
problematic as events and stacks could be very large, causing issues
downstream in our logging pipeline. This change splits long strings with
events/stacks into multiple JSON logs. A split occurs when a long string
causes the event/stack to exceed a configured size.

Example (unstructured event, line length set to 30):
```
hello ‹world› and universe
 ----
json: {...,"entry_counter":1,"message":"hello ‹wor›"}
json: {...,"entry_counter":1,"message":"‹ld› and"}
json: {...,"entry_counter":1,"message":"universe"}
 ```

Note that the configured max size applies only to strings within the
event/stack as we do not split on non-string values (we also do not
split on specific string fields like usernames and SQLSTATE).
Consequently, long integer values can cause the event/stack to exceed
the configured max size.

Release note (cli change): introduce multiline JSON log formatting to
split large events into multiple JSON logs. The configured max size for
an event/stack is 1000 bytes. A long event and stack in the same log can
therefore take a combined 2000 bytes. Note that the configured max size
applies only to strings within the event/stack as we do not split on
non-string values. Consequently, long integer values can cause the
event/stack to exceed the configured max size.