### PR TITLE
distsql: clean up the determination of txn type in mixed version

### DIFF
--- a/pkg/sql/distsql/BUILD.bazel
+++ b/pkg/sql/distsql/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//pkg/sql/execinfrapb",
         "//pkg/sql/faketreeeval",
         "//pkg/sql/flowinfra",
-        "//pkg/sql/row",
         "//pkg/sql/rowflow",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/faketreeeval"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
-	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowflow"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -407,24 +406,11 @@ func (ds *ServerImpl) setupFlow(
 	}
 
 	// Figure out what txn the flow needs to run in, if any. For gateway flows
-	// that have no remote flows and also no concurrency, the txn comes from
-	// localState.Txn. Otherwise, we create a txn based on the request's
-	// LeafTxnInputState.
-	useLeaf := false
-	if req.LeafTxnInputState != nil && row.CanUseStreamer(ctx, ds.Settings) {
-		for _, proc := range req.Flow.Processors {
-			if jr := proc.Core.JoinReader; jr != nil {
-				if jr.IsIndexJoin() {
-					// Index joins are executed via the Streamer API that has
-					// concurrency.
-					useLeaf = true
-					break
-				}
-			}
-		}
-	}
+	// that have no remote flows and also no concurrency, the (root) txn comes
+	// from localState.Txn if we haven't already created a leaf txn. Otherwise,
+	// we create, if necessary, a txn based on the request's LeafTxnInputState.
 	var txn *kv.Txn
-	if localState.IsLocal && !f.ConcurrentTxnUse() && !useLeaf {
+	if localState.IsLocal && !f.ConcurrentTxnUse() && leafTxn == nil {
 		txn = localState.Txn
 	} else {
 		// If I haven't created the leaf already, do it now.


### PR DESCRIPTION
This commit cleans up the way we determine what txn type to use for
a particular flow.

Addresses: #78150.

Release note: None