### PR TITLE
release: use REL Jira project to track releases

### DIFF
--- a/build/teamcity/internal/cockroach/release/process/pick_sha_impl.sh
+++ b/build/teamcity/internal/cockroach/release/process/pick_sha_impl.sh
@@ -29,7 +29,8 @@ bazel build --config=crosslinux //pkg/cmd/release
 $(bazel info --config=crosslinux bazel-bin)/pkg/cmd/release/release_/release \
   pick-sha \
   ${DRY_RUN:+--dry-run} \
-  --release-series=$RELEASE_SERIES \
+  --template-dir=pkg/cmd/release/templates \
+  --release-series="$RELEASE_SERIES" \
   --smtp-user=cronjob@cockroachlabs.com \
   --smtp-host=smtp.gmail.com \
   --smtp-port=587 \


### PR DESCRIPTION
Previously, we used RE Jira project to track releases.

The REL project was intended to be used from the beginning, but it was
missing some configuration tweaks.

This patch changes the Jira project and removes the in-line release
checklist in favour of Jira checklist.

Release note: None