### PR TITLE
changefeedccl: support end time option for changefeeds

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -346,6 +346,14 @@ func TestAlterChangefeedErrors(t *testing.T) {
 			`pq: cannot alter option "initial_scan"`,
 			fmt.Sprintf(`ALTER CHANGEFEED %d UNSET initial_scan`, feed.JobID()),
 		)
+		sqlDB.ExpectErr(t,
+			`pq: cannot alter option "initial_scan_only"`,
+			fmt.Sprintf(`ALTER CHANGEFEED %d UNSET initial_scan_only`, feed.JobID()),
+		)
+		sqlDB.ExpectErr(t,
+			`pq: cannot alter option "end_time"`,
+			fmt.Sprintf(`ALTER CHANGEFEED %d UNSET end_time`, feed.JobID()),
+		)
 
 		sqlDB.ExpectErr(t,
 			`cannot unset option "sink"`,

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -226,6 +226,8 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 	}
 	spans, err := ca.setupSpansAndFrontier(frontierHighWater)
 
+	endTime := ca.spec.Feed.EndTime
+
 	if err != nil {
 		ca.MoveToDraining(err)
 		ca.cancel()
@@ -281,7 +283,7 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 
 	ca.sink = &errorWrapperSink{wrapped: ca.sink}
 
-	ca.eventProducer, err = ca.startKVFeed(ctx, spans, initialHighWater, needsInitialScan, ca.sliMetrics)
+	ca.eventProducer, err = ca.startKVFeed(ctx, spans, initialHighWater, needsInitialScan, endTime, ca.sliMetrics)
 	if err != nil {
 		// Early abort in the case that there is an error creating the sink.
 		ca.MoveToDraining(err)
@@ -303,6 +305,7 @@ func (ca *changeAggregator) startKVFeed(
 	spans []roachpb.Span,
 	initialHighWater hlc.Timestamp,
 	needsInitialScan bool,
+	endTime hlc.Timestamp,
 	sm *sliMetrics,
 ) (kvevent.Reader, error) {
 	cfg := ca.flowCtx.Cfg
@@ -312,7 +315,7 @@ func (ca *changeAggregator) startKVFeed(
 
 	// KVFeed takes ownership of the kvevent.Writer portion of the buffer, while
 	// we return the kvevent.Reader part to the caller.
-	kvfeedCfg := ca.makeKVFeedCfg(ctx, spans, buf, initialHighWater, needsInitialScan, sm)
+	kvfeedCfg := ca.makeKVFeedCfg(ctx, spans, buf, initialHighWater, needsInitialScan, endTime, sm)
 
 	// Give errCh enough buffer both possible errors from supporting goroutines,
 	// but only the first one is ever used.
@@ -343,6 +346,7 @@ func (ca *changeAggregator) makeKVFeedCfg(
 	buf kvevent.Writer,
 	initialHighWater hlc.Timestamp,
 	needsInitialScan bool,
+	endTime hlc.Timestamp,
 	sm *sliMetrics,
 ) kvfeed.Config {
 	schemaChangeEvents := changefeedbase.SchemaChangeEventClass(
@@ -353,7 +357,10 @@ func (ca *changeAggregator) makeKVFeedCfg(
 	cfg := ca.flowCtx.Cfg
 
 	var sf schemafeed.SchemaFeed
-	if schemaChangePolicy == changefeedbase.OptSchemaChangePolicyIgnore {
+
+	initialScanOnly := endTime.EqOrdering(initialHighWater)
+
+	if schemaChangePolicy == changefeedbase.OptSchemaChangePolicyIgnore || initialScanOnly {
 		sf = schemafeed.DoNothingSchemaFeed
 	} else {
 		sf = schemafeed.New(ctx, cfg, schemaChangeEvents, AllTargets(ca.spec.Feed),
@@ -375,6 +382,7 @@ func (ca *changeAggregator) makeKVFeedCfg(
 		OnBackfillRangeCallback: ca.sliMetrics.getBackfillRangeCallback(),
 		MM:                      ca.kvFeedMemMon,
 		InitialHighWater:        initialHighWater,
+		EndTime:                 endTime,
 		WithDiff:                withDiff,
 		NeedsInitialScan:        needsInitialScan,
 		SchemaChangeEvents:      schemaChangeEvents,
@@ -1287,14 +1295,19 @@ func (cf *changeFrontier) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetad
 		if cf.frontier.schemaChangeBoundaryReached() &&
 			(cf.frontier.boundaryType == jobspb.ResolvedSpan_EXIT ||
 				cf.frontier.boundaryType == jobspb.ResolvedSpan_RESTART) {
-			err := pgerror.Newf(pgcode.SchemaChangeOccurred,
-				"schema change occurred at %v", cf.frontier.boundaryTime.Next().AsOfSystemTime())
+			var err error
+			endTime := cf.spec.Feed.EndTime
+			if endTime.IsEmpty() || endTime.Less(cf.frontier.boundaryTime.Next()) {
+				err = pgerror.Newf(pgcode.SchemaChangeOccurred,
+					"schema change occurred at %v", cf.frontier.boundaryTime.Next().AsOfSystemTime())
 
-			// Detect whether this boundary should be used to kill or restart the
-			// changefeed.
-			if cf.frontier.boundaryType == jobspb.ResolvedSpan_RESTART {
-				err = changefeedbase.MarkRetryableError(err)
+				// Detect whether this boundary should be used to kill or restart the
+				// changefeed.
+				if cf.frontier.boundaryType == jobspb.ResolvedSpan_RESTART {
+					err = changefeedbase.MarkRetryableError(err)
+				}
 			}
+
 			// TODO(ajwerner): make this more useful by at least informing the client
 			// of which tables changed.
 			cf.MoveToDraining(err)

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -277,6 +277,20 @@ func createChangefeedJobRecord(
 		statementTime = initialHighWater
 	}
 
+	endTime := hlc.Timestamp{}
+	if endTimeOpt, ok := opts[changefeedbase.OptEndTime]; ok {
+		asOfClause := tree.AsOfClause{Expr: tree.NewStrVal(endTimeOpt)}
+		asOf, err := tree.EvalAsOfTimestamp(ctx, asOfClause, p.SemaCtx(), &p.ExtendedEvalContext().EvalContext)
+		if err != nil {
+			return nil, err
+		}
+		endTime = asOf.Timestamp
+	}
+
+	if _, ok := opts[changefeedbase.OptInitialScanOnly]; ok {
+		endTime = statementTime
+	}
+
 	targetList := uniqueTableNames(changefeedStmt.Targets)
 
 	// This grabs table descriptors once to get their ids.
@@ -305,6 +319,7 @@ func createChangefeedJobRecord(
 		Opts:                 opts,
 		SinkURI:              sinkURI,
 		StatementTime:        statementTime,
+		EndTime:              endTime,
 		TargetSpecifications: targets,
 	}
 
@@ -802,6 +817,30 @@ func validateDetails(details jobspb.ChangefeedDetails) (jobspb.ChangefeedDetails
 		default:
 			return jobspb.ChangefeedDetails{}, errors.Errorf(
 				`unknown %s: %s`, opt, v)
+		}
+	}
+	{
+		_, noInitialScan := details.Opts[changefeedbase.OptNoInitialScan]
+		_, onlyInitialScan := details.Opts[changefeedbase.OptInitialScanOnly]
+		_, endTime := details.Opts[changefeedbase.OptEndTime]
+		if onlyInitialScan && noInitialScan {
+			return jobspb.ChangefeedDetails{}, errors.Errorf(
+				`cannot specify both %s and %s`, changefeedbase.OptInitialScanOnly,
+				changefeedbase.OptNoInitialScan)
+		}
+		if endTime && onlyInitialScan {
+			return jobspb.ChangefeedDetails{}, errors.Errorf(
+				`cannot specify both %s and %s`, changefeedbase.OptInitialScanOnly,
+				changefeedbase.OptEndTime)
+		}
+	}
+	{
+		if !details.EndTime.IsEmpty() && details.EndTime.Less(details.StatementTime) {
+			return jobspb.ChangefeedDetails{}, errors.Errorf(
+				`specified end time %s cannot be less than statement time %s`,
+				details.EndTime.AsOfSystemTime(),
+				details.StatementTime.AsOfSystemTime(),
+			)
 		}
 	}
 	return details, nil

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -36,6 +36,7 @@ const (
 	OptAvroSchemaPrefix         = `avro_schema_prefix`
 	OptConfluentSchemaRegistry  = `confluent_schema_registry`
 	OptCursor                   = `cursor`
+	OptEndTime                  = `end_time`
 	OptEnvelope                 = `envelope`
 	OptFormat                   = `format`
 	OptFullTableName            = `full_table_name`
@@ -93,6 +94,8 @@ const (
 	OptNoInitialScan = `no_initial_scan`
 	// Sentinel value to indicate that all resolved timestamp events should be emitted.
 	OptEmitAllResolvedTimestamps = ``
+
+	OptInitialScanOnly = `initial_scan_only`
 
 	OptEnvelopeKeyOnly       EnvelopeType = `key_only`
 	OptEnvelopeRow           EnvelopeType = `row`
@@ -166,6 +169,7 @@ var ChangefeedOptionExpectValues = map[string]sql.KVStringOptValidate{
 	OptAvroSchemaPrefix:         sql.KVStringOptRequireValue,
 	OptConfluentSchemaRegistry:  sql.KVStringOptRequireValue,
 	OptCursor:                   sql.KVStringOptRequireValue,
+	OptEndTime:                  sql.KVStringOptRequireValue,
 	OptEnvelope:                 sql.KVStringOptRequireValue,
 	OptFormat:                   sql.KVStringOptRequireValue,
 	OptFullTableName:            sql.KVStringOptRequireNoValue,
@@ -182,6 +186,7 @@ var ChangefeedOptionExpectValues = map[string]sql.KVStringOptValidate{
 	OptSplitColumnFamilies:      sql.KVStringOptRequireNoValue,
 	OptInitialScan:              sql.KVStringOptRequireNoValue,
 	OptNoInitialScan:            sql.KVStringOptRequireNoValue,
+	OptInitialScanOnly:          sql.KVStringOptRequireNoValue,
 	OptProtectDataFromGCOnPause: sql.KVStringOptRequireNoValue,
 	OptKafkaSinkConfig:          sql.KVStringOptRequireValue,
 	OptWebhookSinkConfig:        sql.KVStringOptRequireValue,
@@ -201,14 +206,14 @@ func makeStringSet(opts ...string) map[string]struct{} {
 }
 
 // CommonOptions is options common to all sinks
-var CommonOptions = makeStringSet(OptCursor, OptEnvelope,
+var CommonOptions = makeStringSet(OptCursor, OptEndTime, OptEnvelope,
 	OptFormat, OptFullTableName,
 	OptKeyInValue, OptTopicInValue,
 	OptResolvedTimestamps, OptUpdatedTimestamps,
 	OptMVCCTimestamps, OptDiff, OptSplitColumnFamilies,
 	OptSchemaChangeEvents, OptSchemaChangePolicy,
 	OptProtectDataFromGCOnPause, OptOnError,
-	OptInitialScan, OptNoInitialScan,
+	OptInitialScan, OptNoInitialScan, OptInitialScanOnly,
 	OptMinCheckpointFrequency, OptMetricsScope, OptVirtualColumns, Topics)
 
 // SQLValidOptions is options exclusive to SQL sink
@@ -241,8 +246,12 @@ var NoLongerExperimental = map[string]string{
 }
 
 // AlterChangefeedUnsupportedOptions are changefeed options that we do not allow
-// users to alter
-var AlterChangefeedUnsupportedOptions = makeStringSet(OptCursor, OptInitialScan, OptNoInitialScan)
+// users to alter.
+// TODO(sherman): At the moment we disallow altering both the initial_scan_only
+// and the end_time option. However, there are instances in which it should be
+// allowed to alter either of these options. We need to support the alteration
+// of these fields.
+var AlterChangefeedUnsupportedOptions = makeStringSet(OptCursor, OptInitialScan, OptNoInitialScan, OptInitialScanOnly, OptEndTime)
 
 // AlterChangefeedOptionExpectValues is used to parse alter changefeed options
 // using PlanHookState.TypeAsStringOpts().

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
@@ -85,6 +85,7 @@ func TestKVFeed(t *testing.T) {
 		schemaChangeEvents changefeedbase.SchemaChangeEventClass
 		schemaChangePolicy changefeedbase.SchemaChangePolicy
 		initialHighWater   hlc.Timestamp
+		endTime            hlc.Timestamp
 		spans              []roachpb.Span
 		checkpoint         []roachpb.Span
 		events             []roachpb.RangeFeedEvent
@@ -121,7 +122,7 @@ func TestKVFeed(t *testing.T) {
 		f := newKVFeed(buf, tc.spans, tc.checkpoint,
 			tc.schemaChangeEvents, tc.schemaChangePolicy,
 			tc.needsInitialScan, tc.withDiff,
-			tc.initialHighWater,
+			tc.initialHighWater, tc.endTime,
 			keys.SystemSQLCodec,
 			tf, sf, rangefeedFactory(ref.run), bufferFactory, TestingKnobs{})
 		ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -761,6 +761,7 @@ message ChangefeedDetails {
   // time of the changefeed, which is no longer the case. We should rename this
   // field to ScanTime instead.
   util.hlc.Timestamp statement_time = 7 [(gogoproto.nullable) = false];
+  util.hlc.Timestamp end_time = 9 [(gogoproto.nullable) = false];
   repeated ChangefeedTargetSpecification target_specifications = 8 [(gogoproto.nullable) = false];
 
   reserved 1, 2, 5;


### PR DESCRIPTION
changefeedccl: Support end_time and initial_scan_only
options for changefeeds

Currently, users cannot indicate when they would like
their changefeeds to stop running. This becomes an
issue when a user would like to run a changefeed
until a certain time, or would like to run an initial
scan only.

In this PR we introduce the capability that will allow
users to indicate a time at which they would like their
changefeed to stop running. This can be achieved by
providing a timestamp for the 'end_time' option.

Moreover, users can also indicate if they want to perform
an initial scan only. This can be achieved by providing the
'initial_scan_only' option.

When the end time is reached, or the initial scan is
complete (when given the initial_scan_only option), we end
the changefeed job with a successful status.

Release note (enterprise change): Allow users to provide
an end time for changefeeds through the 'end_time' option.
When this option is provided, the changefeed will run until
it has reached the end time, and then the changefeed job will
end with a successful status code. Furthermore, we now provide
an 'initial_scan_only' option. When this option is set, the
changefeed job will end with a successful status code
immediately after the initial scan completed.

Release Justification: This feature is low danger, yet
highly desired from users.