### PR TITLE
server: tag kv request tracing spans with the BatchRequest

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1182,6 +1182,7 @@ func setupSpanForIncomingRPC(
 			tracing.WithServerSpanKind)
 	}
 
+	newSpan.SetLazyTag("request", ba)
 	return ctx, spanForRequest{
 		needRecording: needRecordingCollection,
 		tenID:         tenID,

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -986,6 +986,7 @@ func (t *Tracer) releaseSpanToPool(sp *Span) {
 	c.mu.openChildren = nil
 	c.mu.recording.finishedChildren = nil
 	c.mu.tags = nil
+	c.mu.lazyTags = nil
 	c.mu.recording.logs.Discard()
 	c.mu.recording.structured.Discard()
 	c.mu.Unlock()


### PR DESCRIPTION
This patch adds the BatchRequest as a tracing lazy tag to the respective
span, so that the request gets rendered in the tracing UI.

Release note: None