### PR TITLE
rowexec: use streamer only for index joins

### DIFF
--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -300,6 +300,7 @@ func newJoinReader(
 		shouldLimitBatches = false
 	}
 	useStreamer := flowCtx.Txn != nil && flowCtx.Txn.Type() == kv.LeafTxn &&
+		readerType == indexJoinReaderType &&
 		row.CanUseStreamer(flowCtx.EvalCtx.Ctx(), flowCtx.EvalCtx.Settings)
 
 	jr := &joinReader{


### PR DESCRIPTION
When adding the support of InOrder mode to the streamer, I mistakenly
removed the check in the join reader code path that an index join is
performed, so we could use the streamer for lookup joins which is not
supported at the moment.

Fixes: #78145.
Fixes: #78157.

Release note: None