### PR TITLE
execbuilder: update stats in tpch_vec test

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/tpch_vec
+++ b/pkg/sql/opt/exec/execbuilder/testdata/tpch_vec
@@ -1,6 +1,8 @@
 # LogicTest: local
 
 # Note that statistics are populated for TPCH Scale Factor 1.
+statement ok
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
 
 statement ok
 CREATE TABLE public.region
@@ -12,25 +14,106 @@ CREATE TABLE public.region
 
 statement ok
 ALTER TABLE public.region INJECT STATISTICS '[
-  {
-    "columns": ["r_regionkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 5,
-    "distinct_count": 5
-  },
-  {
-    "columns": ["r_name"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 5,
-    "distinct_count": 5
-  },
-  {
-    "columns": ["r_comment"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 5,
-    "distinct_count": 5
-  }
-]'
+      {
+          "avg_size": 1,
+          "columns": [
+              "r_regionkey"
+          ],
+          "created_at": "2022-03-21 20:31:01.21114",
+          "distinct_count": 5,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "0"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "1"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "2"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "3"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "4"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 5
+      },
+      {
+          "avg_size": 9,
+          "columns": [
+              "r_name"
+          ],
+          "created_at": "2022-03-21 20:31:01.21114",
+          "distinct_count": 5,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "AFRICA"
+              },
+              {
+                  "distinct_range": 3,
+                  "num_eq": 1,
+                  "num_range": 3,
+                  "upper_bound": "MIDDLE EAST"
+              }
+          ],
+          "histo_col_type": "CHAR(25)",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 5
+      },
+      {
+          "avg_size": 68,
+          "columns": [
+              "r_comment"
+          ],
+          "created_at": "2022-03-21 20:31:01.21114",
+          "distinct_count": 5,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "ges. thinly even pinto beans ca"
+              },
+              {
+                  "distinct_range": 3,
+                  "num_eq": 1,
+                  "num_range": 3,
+                  "upper_bound": "uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl"
+              }
+          ],
+          "histo_col_type": "VARCHAR(152)",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 5
+      }
+  ]'
 
 statement ok
 CREATE TABLE public.nation
@@ -44,32 +127,273 @@ CREATE TABLE public.nation
 )
 
 statement ok
-ALTER TABLE public.nation INJECT STATISTICS '[
-  {
-    "columns": ["n_nationkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 25,
-    "distinct_count": 25
-  },
-  {
-    "columns": ["n_name"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 25,
-    "distinct_count": 25
-  },
-  {
-    "columns": ["n_regionkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 25,
-    "distinct_count": 5
-  },
-  {
-    "columns": ["n_comment"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 25,
-    "distinct_count": 25
-  }
-]'
+ALTER TABLE public.nation INJECT STATISTICS '
+  [
+      {
+          "avg_size": 1,
+          "columns": [
+              "n_nationkey"
+          ],
+          "created_at": "2022-03-21 20:30:16.668785",
+          "distinct_count": 25,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "0"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "1"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "2"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "3"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "4"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "5"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "6"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "7"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "8"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "9"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "10"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "11"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "12"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "13"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "14"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "15"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "16"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "17"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "18"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "19"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "20"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "21"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "22"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "23"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "24"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 25
+      },
+      {
+          "avg_size": 2,
+          "columns": [
+              "n_regionkey"
+          ],
+          "created_at": "2022-03-21 20:30:16.668785",
+          "distinct_count": 5,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 5,
+                  "num_range": 0,
+                  "upper_bound": "0"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 5,
+                  "num_range": 0,
+                  "upper_bound": "1"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 5,
+                  "num_range": 0,
+                  "upper_bound": "2"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 5,
+                  "num_range": 0,
+                  "upper_bound": "3"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 5,
+                  "num_range": 0,
+                  "upper_bound": "4"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 25
+      },
+      {
+          "avg_size": 10,
+          "columns": [
+              "n_name"
+          ],
+          "created_at": "2022-03-21 20:30:16.668785",
+          "distinct_count": 25,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "ALGERIA"
+              },
+              {
+                  "distinct_range": 23,
+                  "num_eq": 1,
+                  "num_range": 23,
+                  "upper_bound": "VIETNAM"
+              }
+          ],
+          "histo_col_type": "CHAR(25)",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 25
+      },
+      {
+          "avg_size": 77,
+          "columns": [
+              "n_comment"
+          ],
+          "created_at": "2022-03-21 20:30:16.668785",
+          "distinct_count": 25,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": " haggle. carefully final deposits detect slyly agai"
+              },
+              {
+                  "distinct_range": 23,
+                  "num_eq": 1,
+                  "num_range": 23,
+                  "upper_bound": "y final packages. slow foxes cajole quickly. quickly silent platelets breach ironic accounts. unusual pinto be"
+              }
+          ],
+          "histo_col_type": "VARCHAR(152)",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 25
+      }
+  ]'
 
 statement ok
 CREATE TABLE public.supplier
@@ -86,50 +410,3056 @@ CREATE TABLE public.supplier
 )
 
 statement ok
-ALTER TABLE public.supplier INJECT STATISTICS '[
-  {
-    "columns": ["s_suppkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 10000,
-    "distinct_count": 10000
-  },
-  {
-    "columns": ["s_name"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 10000,
-    "distinct_count": 10000
-  },
-  {
-    "columns": ["s_address"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 10000,
-    "distinct_count": 10000
-  },
-  {
-    "columns": ["s_nationkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 10000,
-    "distinct_count": 25
-  },
-  {
-    "columns": ["s_phone"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 10000,
-    "distinct_count": 10000
-  },
-  {
-    "columns": ["s_acctbal"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 10000,
-    "distinct_count": 10000
-  },
-  {
-    "columns": ["s_comment"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 10000,
-    "distinct_count": 10000
-  }
-]'
+ALTER TABLE public.supplier INJECT STATISTICS '
+  [
+      {
+          "avg_size": 3,
+          "columns": [
+              "s_suppkey"
+          ],
+          "created_at": "2022-03-21 20:30:19.218838",
+          "distinct_count": 9920,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 0,
+                  "num_range": 0,
+                  "upper_bound": "-9223372036854775808"
+              },
+              {
+                  "distinct_range": 3.092281986027956E-11,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "1"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "51"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "101"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "151"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "201"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "251"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "301"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "351"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "401"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "451"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "501"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "551"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "601"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "651"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "701"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "751"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "801"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "851"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "901"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "951"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1001"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1051"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1101"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1151"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1201"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1251"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1301"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1351"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1401"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1451"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1501"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1551"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1601"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1651"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1701"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1751"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1801"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1851"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1901"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1951"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2001"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2051"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2101"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2151"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2201"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2251"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2301"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2351"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2401"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2451"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2501"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2551"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2601"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2651"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2701"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2751"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2801"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2851"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2901"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2951"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3001"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3051"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3101"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3151"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3201"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3251"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3301"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3351"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3401"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3451"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3501"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3551"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3601"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3651"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3701"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3751"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3801"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3851"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3901"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3951"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4001"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4051"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4101"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4151"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4201"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4251"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4301"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4351"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4401"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4451"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4501"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4551"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4601"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4651"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4701"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4751"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4801"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4851"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4901"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4951"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5001"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5051"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5101"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5151"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5201"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5251"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5301"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5351"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5401"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5451"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5501"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5551"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5601"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5651"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5701"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5751"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5801"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5851"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5901"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5951"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6001"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6051"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6101"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6151"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6201"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6251"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6301"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6351"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6401"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6451"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6501"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6551"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6601"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6651"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6701"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6751"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6801"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6851"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6901"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6951"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "7001"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "7051"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "7101"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "7151"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "7201"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "7251"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "7301"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "7351"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "7401"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "7451"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "7501"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "7552"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "7603"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "7654"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "7705"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "7756"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "7807"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "7858"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "7909"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "7960"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8011"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8062"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8113"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8164"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8215"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8266"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8317"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8368"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8419"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8470"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8521"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8572"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8623"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8674"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8725"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8776"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8827"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8878"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8929"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8980"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9031"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9082"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9133"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9184"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9235"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9286"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9337"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9388"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9439"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9490"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9541"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9592"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9643"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9694"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9745"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9796"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9847"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9898"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9949"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "10000"
+              },
+              {
+                  "distinct_range": 3.092281986027956E-11,
+                  "num_eq": 0,
+                  "num_range": 0,
+                  "upper_bound": "9223372036854775807"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 10000
+      },
+      {
+          "avg_size": 2,
+          "columns": [
+              "s_nationkey"
+          ],
+          "created_at": "2022-03-21 20:30:19.218838",
+          "distinct_count": 25,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 420,
+                  "num_range": 0,
+                  "upper_bound": "0"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 413,
+                  "num_range": 0,
+                  "upper_bound": "1"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 397,
+                  "num_range": 0,
+                  "upper_bound": "2"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 412,
+                  "num_range": 0,
+                  "upper_bound": "3"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 415,
+                  "num_range": 0,
+                  "upper_bound": "4"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 380,
+                  "num_range": 0,
+                  "upper_bound": "5"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 402,
+                  "num_range": 0,
+                  "upper_bound": "6"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 396,
+                  "num_range": 0,
+                  "upper_bound": "7"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 415,
+                  "num_range": 0,
+                  "upper_bound": "8"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 405,
+                  "num_range": 0,
+                  "upper_bound": "9"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 393,
+                  "num_range": 0,
+                  "upper_bound": "10"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 438,
+                  "num_range": 0,
+                  "upper_bound": "11"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 377,
+                  "num_range": 0,
+                  "upper_bound": "12"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 362,
+                  "num_range": 0,
+                  "upper_bound": "13"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 376,
+                  "num_range": 0,
+                  "upper_bound": "14"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 373,
+                  "num_range": 0,
+                  "upper_bound": "15"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 406,
+                  "num_range": 0,
+                  "upper_bound": "16"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 421,
+                  "num_range": 0,
+                  "upper_bound": "17"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 407,
+                  "num_range": 0,
+                  "upper_bound": "18"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 398,
+                  "num_range": 0,
+                  "upper_bound": "19"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 411,
+                  "num_range": 0,
+                  "upper_bound": "20"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 399,
+                  "num_range": 0,
+                  "upper_bound": "21"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 401,
+                  "num_range": 0,
+                  "upper_bound": "22"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 390,
+                  "num_range": 0,
+                  "upper_bound": "23"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 393,
+                  "num_range": 0,
+                  "upper_bound": "24"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 10000
+      },
+      {
+          "avg_size": 20,
+          "columns": [
+              "s_name"
+          ],
+          "created_at": "2022-03-21 20:30:19.218838",
+          "distinct_count": 9990,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "Supplier#000000001"
+              },
+              {
+                  "distinct_range": 9988,
+                  "num_eq": 1,
+                  "num_range": 9998,
+                  "upper_bound": "Supplier#000010000"
+              }
+          ],
+          "histo_col_type": "CHAR(25)",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 10000
+      },
+      {
+          "avg_size": 27,
+          "columns": [
+              "s_address"
+          ],
+          "created_at": "2022-03-21 20:30:19.218838",
+          "distinct_count": 10000,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "  9aW1wwnBJJPnCx,nox0MA48Y0zpI1IeVfYZ"
+              },
+              {
+                  "distinct_range": 9998,
+                  "num_eq": 1,
+                  "num_range": 9998,
+                  "upper_bound": "zzfDhdtZcvmVzA8rNFU,Yctj1zBN"
+              }
+          ],
+          "histo_col_type": "VARCHAR(40)",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 10000
+      },
+      {
+          "avg_size": 17,
+          "columns": [
+              "s_phone"
+          ],
+          "created_at": "2022-03-21 20:30:19.218838",
+          "distinct_count": 10000,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "10-102-116-6785"
+              },
+              {
+                  "distinct_range": 9998,
+                  "num_eq": 1,
+                  "num_range": 9998,
+                  "upper_bound": "34-998-900-4911"
+              }
+          ],
+          "histo_col_type": "CHAR(15)",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 10000
+      },
+      {
+          "avg_size": 9,
+          "columns": [
+              "s_acctbal"
+          ],
+          "created_at": "2022-03-21 20:30:19.218838",
+          "distinct_count": 9967,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "-998.22"
+              },
+              {
+                  "distinct_range": 9965,
+                  "num_eq": 1,
+                  "num_range": 9998,
+                  "upper_bound": "9999.72"
+              }
+          ],
+          "histo_col_type": "FLOAT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 10000
+      },
+      {
+          "avg_size": 65,
+          "columns": [
+              "s_comment"
+          ],
+          "created_at": "2022-03-21 20:30:19.218838",
+          "distinct_count": 9934,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": " about the blithely express foxes. bli"
+              },
+              {
+                  "distinct_range": 9932,
+                  "num_eq": 1,
+                  "num_range": 9998,
+                  "upper_bound": "zzle furiously. bold accounts haggle furiously ironic excuses. fur"
+              }
+          ],
+          "histo_col_type": "VARCHAR(101)",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 10000
+      },
+      {
+          "avg_size": 3,
+          "columns": [
+              "s_suppkey"
+          ],
+          "created_at": "2022-03-21 20:30:24.547575",
+          "distinct_count": 9920,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 0,
+                  "num_range": 0,
+                  "upper_bound": "-9223372036854775808"
+              },
+              {
+                  "distinct_range": 3.092281986027956E-11,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "1"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "51"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "101"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "151"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "201"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "251"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "301"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "351"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "401"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "451"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "501"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "551"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "601"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "651"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "701"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "751"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "801"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "851"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "901"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "951"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1001"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1051"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1101"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1151"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1201"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1251"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1301"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1351"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1401"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1451"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1501"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1551"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1601"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1651"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1701"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1751"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1801"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1851"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1901"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "1951"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2001"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2051"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2101"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2151"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2201"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2251"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2301"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2351"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2401"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2451"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2501"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2551"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2601"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2651"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2701"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2751"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2801"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2851"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2901"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "2951"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3001"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3051"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3101"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3151"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3201"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3251"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3301"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3351"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3401"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3451"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3501"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3551"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3601"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3651"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3701"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3751"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3801"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3851"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3901"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "3951"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4001"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4051"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4101"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4151"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4201"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4251"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4301"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4351"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4401"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4451"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4501"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4551"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4601"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4651"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4701"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4751"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4801"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4851"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4901"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "4951"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5001"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5051"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5101"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5151"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5201"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5251"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5301"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5351"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5401"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5451"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5501"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5551"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5601"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5651"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5701"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5751"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5801"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5851"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5901"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "5951"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6001"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6051"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6101"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6151"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6201"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6251"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6301"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6351"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6401"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6451"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6501"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6551"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6601"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6651"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6701"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6751"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6801"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6851"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6901"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "6951"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "7001"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "7051"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "7101"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "7151"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "7201"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "7251"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "7301"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "7351"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "7401"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "7451"
+              },
+              {
+                  "distinct_range": 48.60002097180522,
+                  "num_eq": 1,
+                  "num_range": 49,
+                  "upper_bound": "7501"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "7552"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "7603"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "7654"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "7705"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "7756"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "7807"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "7858"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "7909"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "7960"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8011"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8062"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8113"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8164"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8215"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8266"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8317"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8368"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8419"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8470"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8521"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8572"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8623"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8674"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8725"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8776"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8827"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8878"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8929"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "8980"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9031"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9082"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9133"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9184"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9235"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9286"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9337"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9388"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9439"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9490"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9541"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9592"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9643"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9694"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9745"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9796"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9847"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9898"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "9949"
+              },
+              {
+                  "distinct_range": 49.59177253529016,
+                  "num_eq": 1,
+                  "num_range": 50,
+                  "upper_bound": "10000"
+              },
+              {
+                  "distinct_range": 3.092281986027956E-11,
+                  "num_eq": 0,
+                  "num_range": 0,
+                  "upper_bound": "9223372036854775807"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 1,
+          "null_count": 0,
+          "row_count": 10000
+      },
+      {
+          "avg_size": 2,
+          "columns": [
+              "s_nationkey"
+          ],
+          "created_at": "2022-03-21 20:30:24.547575",
+          "distinct_count": 25,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 420,
+                  "num_range": 0,
+                  "upper_bound": "0"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 413,
+                  "num_range": 0,
+                  "upper_bound": "1"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 397,
+                  "num_range": 0,
+                  "upper_bound": "2"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 412,
+                  "num_range": 0,
+                  "upper_bound": "3"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 415,
+                  "num_range": 0,
+                  "upper_bound": "4"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 380,
+                  "num_range": 0,
+                  "upper_bound": "5"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 402,
+                  "num_range": 0,
+                  "upper_bound": "6"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 396,
+                  "num_range": 0,
+                  "upper_bound": "7"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 415,
+                  "num_range": 0,
+                  "upper_bound": "8"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 405,
+                  "num_range": 0,
+                  "upper_bound": "9"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 393,
+                  "num_range": 0,
+                  "upper_bound": "10"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 438,
+                  "num_range": 0,
+                  "upper_bound": "11"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 377,
+                  "num_range": 0,
+                  "upper_bound": "12"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 362,
+                  "num_range": 0,
+                  "upper_bound": "13"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 376,
+                  "num_range": 0,
+                  "upper_bound": "14"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 373,
+                  "num_range": 0,
+                  "upper_bound": "15"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 406,
+                  "num_range": 0,
+                  "upper_bound": "16"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 421,
+                  "num_range": 0,
+                  "upper_bound": "17"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 407,
+                  "num_range": 0,
+                  "upper_bound": "18"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 398,
+                  "num_range": 0,
+                  "upper_bound": "19"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 411,
+                  "num_range": 0,
+                  "upper_bound": "20"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 399,
+                  "num_range": 0,
+                  "upper_bound": "21"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 401,
+                  "num_range": 0,
+                  "upper_bound": "22"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 390,
+                  "num_range": 0,
+                  "upper_bound": "23"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 393,
+                  "num_range": 0,
+                  "upper_bound": "24"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 1,
+          "null_count": 0,
+          "row_count": 10000
+      },
+      {
+          "avg_size": 20,
+          "columns": [
+              "s_name"
+          ],
+          "created_at": "2022-03-21 20:30:24.547575",
+          "distinct_count": 9990,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "Supplier#000000001"
+              },
+              {
+                  "distinct_range": 9988,
+                  "num_eq": 1,
+                  "num_range": 9998,
+                  "upper_bound": "Supplier#000010000"
+              }
+          ],
+          "histo_col_type": "CHAR(25)",
+          "histo_version": 1,
+          "null_count": 0,
+          "row_count": 10000
+      },
+      {
+          "avg_size": 27,
+          "columns": [
+              "s_address"
+          ],
+          "created_at": "2022-03-21 20:30:24.547575",
+          "distinct_count": 10000,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "  9aW1wwnBJJPnCx,nox0MA48Y0zpI1IeVfYZ"
+              },
+              {
+                  "distinct_range": 9998,
+                  "num_eq": 1,
+                  "num_range": 9998,
+                  "upper_bound": "zzfDhdtZcvmVzA8rNFU,Yctj1zBN"
+              }
+          ],
+          "histo_col_type": "VARCHAR(40)",
+          "histo_version": 1,
+          "null_count": 0,
+          "row_count": 10000
+      },
+      {
+          "avg_size": 17,
+          "columns": [
+              "s_phone"
+          ],
+          "created_at": "2022-03-21 20:30:24.547575",
+          "distinct_count": 10000,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "10-102-116-6785"
+              },
+              {
+                  "distinct_range": 9998,
+                  "num_eq": 1,
+                  "num_range": 9998,
+                  "upper_bound": "34-998-900-4911"
+              }
+          ],
+          "histo_col_type": "CHAR(15)",
+          "histo_version": 1,
+          "null_count": 0,
+          "row_count": 10000
+      },
+      {
+          "avg_size": 9,
+          "columns": [
+              "s_acctbal"
+          ],
+          "created_at": "2022-03-21 20:30:24.547575",
+          "distinct_count": 9967,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "-998.22"
+              },
+              {
+                  "distinct_range": 9965,
+                  "num_eq": 1,
+                  "num_range": 9998,
+                  "upper_bound": "9999.72"
+              }
+          ],
+          "histo_col_type": "FLOAT8",
+          "histo_version": 1,
+          "null_count": 0,
+          "row_count": 10000
+      },
+      {
+          "avg_size": 65,
+          "columns": [
+              "s_comment"
+          ],
+          "created_at": "2022-03-21 20:30:24.547575",
+          "distinct_count": 9934,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": " about the blithely express foxes. bli"
+              },
+              {
+                  "distinct_range": 9932,
+                  "num_eq": 1,
+                  "num_range": 9998,
+                  "upper_bound": "zzle furiously. bold accounts haggle furiously ironic excuses. fur"
+              }
+          ],
+          "histo_col_type": "VARCHAR(101)",
+          "histo_version": 1,
+          "null_count": 0,
+          "row_count": 10000
+      }
+  ]'
 
 statement ok
 CREATE TABLE public.part
@@ -146,62 +3476,1440 @@ CREATE TABLE public.part
 )
 
 statement ok
-ALTER TABLE public.part INJECT STATISTICS '[
-  {
-    "columns": ["p_partkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 200000,
-    "distinct_count": 200000
-  },
-  {
-    "columns": ["p_name"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 200000,
-    "distinct_count": 200000
-  },
-  {
-    "columns": ["p_mfgr"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 200000,
-    "distinct_count": 5
-  },
-  {
-    "columns": ["p_brand"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 200000,
-    "distinct_count": 25
-  },
-  {
-    "columns": ["p_type"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 200000,
-    "distinct_count": 150
-  },
-  {
-    "columns": ["p_size"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 200000,
-    "distinct_count": 50
-  },
-  {
-    "columns": ["p_container"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 200000,
-    "distinct_count": 40
-  },
-  {
-    "columns": ["p_retailprice"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 200000,
-    "distinct_count": 20000
-  },
-  {
-    "columns": ["p_comment"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 200000,
-    "distinct_count": 130000
-  }
-]'
+ALTER TABLE public.part INJECT STATISTICS '
+  [
+      {
+          "avg_size": 4,
+          "columns": [
+              "p_partkey"
+          ],
+          "created_at": "2022-03-21 20:30:17.882066",
+          "distinct_count": 199241,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 4,
+                  "num_range": 0,
+                  "upper_bound": "13"
+              },
+              {
+                  "distinct_range": 744.0343808530902,
+                  "num_eq": 4,
+                  "num_range": 867,
+                  "upper_bound": "760"
+              },
+              {
+                  "distinct_range": 1147.1749223463987,
+                  "num_eq": 4,
+                  "num_range": 1080,
+                  "upper_bound": "1913"
+              },
+              {
+                  "distinct_range": 919.8703086863211,
+                  "num_eq": 4,
+                  "num_range": 954,
+                  "upper_bound": "2837"
+              },
+              {
+                  "distinct_range": 898.0231766859013,
+                  "num_eq": 4,
+                  "num_range": 942,
+                  "upper_bound": "3739"
+              },
+              {
+                  "distinct_range": 894.0507478475722,
+                  "num_eq": 4,
+                  "num_range": 940,
+                  "upper_bound": "4637"
+              },
+              {
+                  "distinct_range": 985.400017425742,
+                  "num_eq": 4,
+                  "num_range": 989,
+                  "upper_bound": "5627"
+              },
+              {
+                  "distinct_range": 1013.1956098032279,
+                  "num_eq": 4,
+                  "num_range": 1004,
+                  "upper_bound": "6645"
+              },
+              {
+                  "distinct_range": 861.2754794347452,
+                  "num_eq": 4,
+                  "num_range": 924,
+                  "upper_bound": "7510"
+              },
+              {
+                  "distinct_range": 822.5344375391228,
+                  "num_eq": 4,
+                  "num_range": 904,
+                  "upper_bound": "8336"
+              },
+              {
+                  "distinct_range": 941.7154335093633,
+                  "num_eq": 4,
+                  "num_range": 965,
+                  "upper_bound": "9282"
+              },
+              {
+                  "distinct_range": 950.6515180163256,
+                  "num_eq": 4,
+                  "num_range": 970,
+                  "upper_bound": "10237"
+              },
+              {
+                  "distinct_range": 746.0221668755577,
+                  "num_eq": 4,
+                  "num_range": 868,
+                  "upper_bound": "10986"
+              },
+              {
+                  "distinct_range": 1123.360263179611,
+                  "num_eq": 4,
+                  "num_range": 1066,
+                  "upper_bound": "12115"
+              },
+              {
+                  "distinct_range": 997.3127522092998,
+                  "num_eq": 4,
+                  "num_range": 995,
+                  "upper_bound": "13117"
+              },
+              {
+                  "distinct_range": 976.4651251665412,
+                  "num_eq": 4,
+                  "num_range": 984,
+                  "upper_bound": "14098"
+              },
+              {
+                  "distinct_range": 1075.7261099643983,
+                  "num_eq": 4,
+                  "num_range": 1039,
+                  "upper_bound": "15179"
+              },
+              {
+                  "distinct_range": 1050.9139389239613,
+                  "num_eq": 4,
+                  "num_range": 1025,
+                  "upper_bound": "16235"
+              },
+              {
+                  "distinct_range": 1234.4828517867913,
+                  "num_eq": 4,
+                  "num_range": 1131,
+                  "upper_bound": "17476"
+              },
+              {
+                  "distinct_range": 953.6301426010336,
+                  "num_eq": 4,
+                  "num_range": 972,
+                  "upper_bound": "18434"
+              },
+              {
+                  "distinct_range": 944.6941636892891,
+                  "num_eq": 4,
+                  "num_range": 967,
+                  "upper_bound": "19383"
+              },
+              {
+                  "distinct_range": 849.3559492751449,
+                  "num_eq": 4,
+                  "num_range": 918,
+                  "upper_bound": "20236"
+              },
+              {
+                  "distinct_range": 1131.298655687804,
+                  "num_eq": 4,
+                  "num_range": 1070,
+                  "upper_bound": "21373"
+              },
+              {
+                  "distinct_range": 1144.198174305202,
+                  "num_eq": 4,
+                  "num_range": 1078,
+                  "upper_bound": "22523"
+              },
+              {
+                  "distinct_range": 741.0526559938091,
+                  "num_eq": 4,
+                  "num_range": 866,
+                  "upper_bound": "23267"
+              },
+              {
+                  "distinct_range": 1118.3986785096718,
+                  "num_eq": 4,
+                  "num_range": 1063,
+                  "upper_bound": "24391"
+              },
+              {
+                  "distinct_range": 853.3292023157185,
+                  "num_eq": 4,
+                  "num_range": 920,
+                  "upper_bound": "25248"
+              },
+              {
+                  "distinct_range": 827.5016592057488,
+                  "num_eq": 4,
+                  "num_range": 907,
+                  "upper_bound": "26079"
+              },
+              {
+                  "distinct_range": 818.5605681352033,
+                  "num_eq": 4,
+                  "num_range": 902,
+                  "upper_bound": "26901"
+              },
+              {
+                  "distinct_range": 1226.5465280332814,
+                  "num_eq": 4,
+                  "num_range": 1126,
+                  "upper_bound": "28134"
+              },
+              {
+                  "distinct_range": 1317.8059591734823,
+                  "num_eq": 4,
+                  "num_range": 1181,
+                  "upper_bound": "29459"
+              },
+              {
+                  "distinct_range": 1090.612500698277,
+                  "num_eq": 4,
+                  "num_range": 1047,
+                  "upper_bound": "30555"
+              },
+              {
+                  "distinct_range": 959.5872876942378,
+                  "num_eq": 4,
+                  "num_range": 975,
+                  "upper_bound": "31519"
+              },
+              {
+                  "distinct_range": 1107.482946602649,
+                  "num_eq": 4,
+                  "num_range": 1057,
+                  "upper_bound": "32632"
+              },
+              {
+                  "distinct_range": 948.6657488733347,
+                  "num_eq": 4,
+                  "num_range": 969,
+                  "upper_bound": "33585"
+              },
+              {
+                  "distinct_range": 882.1330384005773,
+                  "num_eq": 4,
+                  "num_range": 934,
+                  "upper_bound": "34471"
+              },
+              {
+                  "distinct_range": 946.6799641192653,
+                  "num_eq": 4,
+                  "num_range": 968,
+                  "upper_bound": "35422"
+              },
+              {
+                  "distinct_range": 1318.7978145355241,
+                  "num_eq": 4,
+                  "num_range": 1182,
+                  "upper_bound": "36748"
+              },
+              {
+                  "distinct_range": 962.5658086303239,
+                  "num_eq": 4,
+                  "num_range": 976,
+                  "upper_bound": "37715"
+              },
+              {
+                  "distinct_range": 1003.2689281720724,
+                  "num_eq": 4,
+                  "num_range": 998,
+                  "upper_bound": "38723"
+              },
+              {
+                  "distinct_range": 988.3782494648889,
+                  "num_eq": 4,
+                  "num_range": 990,
+                  "upper_bound": "39716"
+              },
+              {
+                  "distinct_range": 925.8282651724066,
+                  "num_eq": 4,
+                  "num_range": 957,
+                  "upper_bound": "40646"
+              },
+              {
+                  "distinct_range": 875.1807434183941,
+                  "num_eq": 4,
+                  "num_range": 931,
+                  "upper_bound": "41525"
+              },
+              {
+                  "distinct_range": 1057.8615424400723,
+                  "num_eq": 4,
+                  "num_range": 1029,
+                  "upper_bound": "42588"
+              },
+              {
+                  "distinct_range": 773.8486675860638,
+                  "num_eq": 4,
+                  "num_range": 881,
+                  "upper_bound": "43365"
+              },
+              {
+                  "distinct_range": 941.7154335093633,
+                  "num_eq": 4,
+                  "num_range": 965,
+                  "upper_bound": "44311"
+              },
+              {
+                  "distinct_range": 1011.2103010474179,
+                  "num_eq": 4,
+                  "num_range": 1003,
+                  "upper_bound": "45327"
+              },
+              {
+                  "distinct_range": 732.1071479628873,
+                  "num_eq": 4,
+                  "num_range": 862,
+                  "upper_bound": "46062"
+              },
+              {
+                  "distinct_range": 1090.612500698277,
+                  "num_eq": 4,
+                  "num_range": 1047,
+                  "upper_bound": "47158"
+              },
+              {
+                  "distinct_range": 979.4434554766086,
+                  "num_eq": 4,
+                  "num_range": 985,
+                  "upper_bound": "48142"
+              },
+              {
+                  "distinct_range": 1185.8705376156636,
+                  "num_eq": 4,
+                  "num_range": 1102,
+                  "upper_bound": "49334"
+              },
+              {
+                  "distinct_range": 787.7602221356176,
+                  "num_eq": 4,
+                  "num_range": 888,
+                  "upper_bound": "50125"
+              },
+              {
+                  "distinct_range": 762.917377456589,
+                  "num_eq": 4,
+                  "num_range": 876,
+                  "upper_bound": "50891"
+              },
+              {
+                  "distinct_range": 1042.9736302609947,
+                  "num_eq": 4,
+                  "num_range": 1020,
+                  "upper_bound": "51939"
+              },
+              {
+                  "distinct_range": 913.9122029363914,
+                  "num_eq": 4,
+                  "num_range": 951,
+                  "upper_bound": "52857"
+              },
+              {
+                  "distinct_range": 1101.5287666626905,
+                  "num_eq": 4,
+                  "num_range": 1053,
+                  "upper_bound": "53964"
+              },
+              {
+                  "distinct_range": 964.5514702832457,
+                  "num_eq": 4,
+                  "num_range": 977,
+                  "upper_bound": "54933"
+              },
+              {
+                  "distinct_range": 915.8982548876925,
+                  "num_eq": 4,
+                  "num_range": 952,
+                  "upper_bound": "55853"
+              },
+              {
+                  "distinct_range": 1011.2103010474179,
+                  "num_eq": 4,
+                  "num_range": 1003,
+                  "upper_bound": "56869"
+              },
+              {
+                  "distinct_range": 1054.8840169627329,
+                  "num_eq": 4,
+                  "num_range": 1027,
+                  "upper_bound": "57929"
+              },
+              {
+                  "distinct_range": 934.7649241082806,
+                  "num_eq": 4,
+                  "num_range": 962,
+                  "upper_bound": "58868"
+              },
+              {
+                  "distinct_range": 976.4651251665412,
+                  "num_eq": 4,
+                  "num_range": 984,
+                  "upper_bound": "59849"
+              },
+              {
+                  "distinct_range": 922.8493054699691,
+                  "num_eq": 4,
+                  "num_range": 955,
+                  "upper_bound": "60776"
+              },
+              {
+                  "distinct_range": 1028.0849933318382,
+                  "num_eq": 4,
+                  "num_range": 1012,
+                  "upper_bound": "61809"
+              },
+              {
+                  "distinct_range": 1227.5385764217306,
+                  "num_eq": 4,
+                  "num_range": 1127,
+                  "upper_bound": "63043"
+              },
+              {
+                  "distinct_range": 950.6515180163256,
+                  "num_eq": 4,
+                  "num_range": 970,
+                  "upper_bound": "63998"
+              },
+              {
+                  "distinct_range": 1031.06277973461,
+                  "num_eq": 4,
+                  "num_range": 1014,
+                  "upper_bound": "65034"
+              },
+              {
+                  "distinct_range": 925.8282651724066,
+                  "num_eq": 4,
+                  "num_range": 957,
+                  "upper_bound": "65964"
+              },
+              {
+                  "distinct_range": 987.3855090570669,
+                  "num_eq": 4,
+                  "num_range": 990,
+                  "upper_bound": "66956"
+              },
+              {
+                  "distinct_range": 1096.5668711123876,
+                  "num_eq": 4,
+                  "num_range": 1051,
+                  "upper_bound": "68058"
+              },
+              {
+                  "distinct_range": 1168.0115024454317,
+                  "num_eq": 4,
+                  "num_range": 1092,
+                  "upper_bound": "69232"
+              },
+              {
+                  "distinct_range": 868.2282248931602,
+                  "num_eq": 4,
+                  "num_range": 927,
+                  "upper_bound": "70104"
+              },
+              {
+                  "distinct_range": 900.0093650077836,
+                  "num_eq": 4,
+                  "num_range": 943,
+                  "upper_bound": "71008"
+              },
+              {
+                  "distinct_range": 932.779028242594,
+                  "num_eq": 4,
+                  "num_range": 961,
+                  "upper_bound": "71945"
+              },
+              {
+                  "distinct_range": 909.9400485768163,
+                  "num_eq": 4,
+                  "num_range": 949,
+                  "upper_bound": "72859"
+              },
+              {
+                  "distinct_range": 851.3425854045845,
+                  "num_eq": 4,
+                  "num_range": 919,
+                  "upper_bound": "73714"
+              },
+              {
+                  "distinct_range": 975.4723410377526,
+                  "num_eq": 4,
+                  "num_range": 983,
+                  "upper_bound": "74694"
+              },
+              {
+                  "distinct_range": 701.2908866396178,
+                  "num_eq": 4,
+                  "num_range": 848,
+                  "upper_bound": "75398"
+              },
+              {
+                  "distinct_range": 1041.9810772508229,
+                  "num_eq": 4,
+                  "num_range": 1020,
+                  "upper_bound": "76445"
+              },
+              {
+                  "distinct_range": 1215.6338447214675,
+                  "num_eq": 4,
+                  "num_range": 1120,
+                  "upper_bound": "77667"
+              },
+              {
+                  "distinct_range": 903.9816898249671,
+                  "num_eq": 4,
+                  "num_range": 945,
+                  "upper_bound": "78575"
+              },
+              {
+                  "distinct_range": 1066.7939506553503,
+                  "num_eq": 4,
+                  "num_range": 1034,
+                  "upper_bound": "79647"
+              },
+              {
+                  "distinct_range": 921.8563106737536,
+                  "num_eq": 4,
+                  "num_range": 955,
+                  "upper_bound": "80573"
+              },
+              {
+                  "distinct_range": 1173.9646040031485,
+                  "num_eq": 4,
+                  "num_range": 1095,
+                  "upper_bound": "81753"
+              },
+              {
+                  "distinct_range": 1017.1661863447007,
+                  "num_eq": 4,
+                  "num_range": 1006,
+                  "upper_bound": "82775"
+              },
+              {
+                  "distinct_range": 890.0782489213582,
+                  "num_eq": 4,
+                  "num_range": 938,
+                  "upper_bound": "83669"
+              },
+              {
+                  "distinct_range": 1218.6100586889897,
+                  "num_eq": 4,
+                  "num_range": 1122,
+                  "upper_bound": "84894"
+              },
+              {
+                  "distinct_range": 848.3626239774403,
+                  "num_eq": 4,
+                  "num_range": 917,
+                  "upper_bound": "85746"
+              },
+              {
+                  "distinct_range": 881.1398669626124,
+                  "num_eq": 4,
+                  "num_range": 934,
+                  "upper_bound": "86631"
+              },
+              {
+                  "distinct_range": 1124.3525718293333,
+                  "num_eq": 4,
+                  "num_range": 1066,
+                  "upper_bound": "87761"
+              },
+              {
+                  "distinct_range": 969.515558469677,
+                  "num_eq": 4,
+                  "num_range": 980,
+                  "upper_bound": "88735"
+              },
+              {
+                  "distinct_range": 803.6578160012274,
+                  "num_eq": 4,
+                  "num_range": 895,
+                  "upper_bound": "89542"
+              },
+              {
+                  "distinct_range": 829.488512354392,
+                  "num_eq": 4,
+                  "num_range": 908,
+                  "upper_bound": "90375"
+              },
+              {
+                  "distinct_range": 891.0713802563348,
+                  "num_eq": 4,
+                  "num_range": 939,
+                  "upper_bound": "91270"
+              },
+              {
+                  "distinct_range": 901.9955360297344,
+                  "num_eq": 4,
+                  "num_range": 944,
+                  "upper_bound": "92176"
+              },
+              {
+                  "distinct_range": 1051.906463173874,
+                  "num_eq": 4,
+                  "num_range": 1025,
+                  "upper_bound": "93233"
+              },
+              {
+                  "distinct_range": 1101.5287666626905,
+                  "num_eq": 4,
+                  "num_range": 1053,
+                  "upper_bound": "94340"
+              },
+              {
+                  "distinct_range": 1226.5465280332814,
+                  "num_eq": 4,
+                  "num_range": 1126,
+                  "upper_bound": "95573"
+              },
+              {
+                  "distinct_range": 1060.8390397717435,
+                  "num_eq": 4,
+                  "num_range": 1030,
+                  "upper_bound": "96639"
+              },
+              {
+                  "distinct_range": 724.1551589633245,
+                  "num_eq": 4,
+                  "num_range": 858,
+                  "upper_bound": "97366"
+              },
+              {
+                  "distinct_range": 1087.6352759668275,
+                  "num_eq": 4,
+                  "num_range": 1045,
+                  "upper_bound": "98459"
+              },
+              {
+                  "distinct_range": 1051.906463173874,
+                  "num_eq": 4,
+                  "num_range": 1025,
+                  "upper_bound": "99516"
+              },
+              {
+                  "distinct_range": 987.3855090570669,
+                  "num_eq": 4,
+                  "num_range": 990,
+                  "upper_bound": "100508"
+              },
+              {
+                  "distinct_range": 981.4289906946326,
+                  "num_eq": 4,
+                  "num_range": 987,
+                  "upper_bound": "101494"
+              },
+              {
+                  "distinct_range": 1155.112801627473,
+                  "num_eq": 4,
+                  "num_range": 1084,
+                  "upper_bound": "102655"
+              },
+              {
+                  "distinct_range": 1072.7487509159632,
+                  "num_eq": 4,
+                  "num_range": 1037,
+                  "upper_bound": "103733"
+              },
+              {
+                  "distinct_range": 1003.2689281720724,
+                  "num_eq": 4,
+                  "num_range": 998,
+                  "upper_bound": "104741"
+              },
+              {
+                  "distinct_range": 1101.5287666626905,
+                  "num_eq": 4,
+                  "num_range": 1053,
+                  "upper_bound": "105848"
+              },
+              {
+                  "distinct_range": 1085.65044473697,
+                  "num_eq": 4,
+                  "num_range": 1044,
+                  "upper_bound": "106939"
+              },
+              {
+                  "distinct_range": 820.547513119764,
+                  "num_eq": 4,
+                  "num_range": 903,
+                  "upper_bound": "107763"
+              },
+              {
+                  "distinct_range": 1067.786425012714,
+                  "num_eq": 4,
+                  "num_range": 1034,
+                  "upper_bound": "108836"
+              },
+              {
+                  "distinct_range": 900.0093650077836,
+                  "num_eq": 4,
+                  "num_range": 943,
+                  "upper_bound": "109740"
+              },
+              {
+                  "distinct_range": 1028.0849933318382,
+                  "num_eq": 4,
+                  "num_range": 1012,
+                  "upper_bound": "110773"
+              },
+              {
+                  "distinct_range": 1054.8840169627329,
+                  "num_eq": 4,
+                  "num_range": 1027,
+                  "upper_bound": "111833"
+              },
+              {
+                  "distinct_range": 1005.2542921797001,
+                  "num_eq": 4,
+                  "num_range": 999,
+                  "upper_bound": "112843"
+              },
+              {
+                  "distinct_range": 812.5996088808806,
+                  "num_eq": 4,
+                  "num_range": 900,
+                  "upper_bound": "113659"
+              },
+              {
+                  "distinct_range": 1077.7110008891584,
+                  "num_eq": 4,
+                  "num_range": 1040,
+                  "upper_bound": "114742"
+              },
+              {
+                  "distinct_range": 1133.2832265801349,
+                  "num_eq": 4,
+                  "num_range": 1072,
+                  "upper_bound": "115881"
+              },
+              {
+                  "distinct_range": 1160.0738917118167,
+                  "num_eq": 4,
+                  "num_range": 1087,
+                  "upper_bound": "117047"
+              },
+              {
+                  "distinct_range": 1159.0816788543239,
+                  "num_eq": 4,
+                  "num_range": 1087,
+                  "upper_bound": "118212"
+              },
+              {
+                  "distinct_range": 1010.2176415242586,
+                  "num_eq": 4,
+                  "num_range": 1002,
+                  "upper_bound": "119227"
+              },
+              {
+                  "distinct_range": 788.7538627164944,
+                  "num_eq": 4,
+                  "num_range": 888,
+                  "upper_bound": "120019"
+              },
+              {
+                  "distinct_range": 1315.8222426356524,
+                  "num_eq": 4,
+                  "num_range": 1180,
+                  "upper_bound": "121342"
+              },
+              {
+                  "distinct_range": 920.8633117487634,
+                  "num_eq": 4,
+                  "num_range": 954,
+                  "upper_bound": "122267"
+              },
+              {
+                  "distinct_range": 874.1875402509265,
+                  "num_eq": 4,
+                  "num_range": 930,
+                  "upper_bound": "123145"
+              },
+              {
+                  "distinct_range": 1193.8076302061554,
+                  "num_eq": 4,
+                  "num_range": 1107,
+                  "upper_bound": "124345"
+              },
+              {
+                  "distinct_range": 900.0093650077836,
+                  "num_eq": 4,
+                  "num_range": 943,
+                  "upper_bound": "125249"
+              },
+              {
+                  "distinct_range": 738.0708758109324,
+                  "num_eq": 4,
+                  "num_range": 865,
+                  "upper_bound": "125990"
+              },
+              {
+                  "distinct_range": 1005.2542921797001,
+                  "num_eq": 4,
+                  "num_range": 999,
+                  "upper_bound": "127000"
+              },
+              {
+                  "distinct_range": 1237.4589360821165,
+                  "num_eq": 4,
+                  "num_range": 1133,
+                  "upper_bound": "128244"
+              },
+              {
+                  "distinct_range": 1001.2835502120674,
+                  "num_eq": 4,
+                  "num_range": 997,
+                  "upper_bound": "129250"
+              },
+              {
+                  "distinct_range": 1200.7524593834703,
+                  "num_eq": 4,
+                  "num_range": 1111,
+                  "upper_bound": "130457"
+              },
+              {
+                  "distinct_range": 1035.0331154605024,
+                  "num_eq": 4,
+                  "num_range": 1016,
+                  "upper_bound": "131497"
+              },
+              {
+                  "distinct_range": 1019.1514542393954,
+                  "num_eq": 4,
+                  "num_range": 1007,
+                  "upper_bound": "132521"
+              },
+              {
+                  "distinct_range": 1011.2103010474179,
+                  "num_eq": 4,
+                  "num_range": 1003,
+                  "upper_bound": "133537"
+              },
+              {
+                  "distinct_range": 1159.0816788543239,
+                  "num_eq": 4,
+                  "num_range": 1087,
+                  "upper_bound": "134702"
+              },
+              {
+                  "distinct_range": 993.3418977172726,
+                  "num_eq": 4,
+                  "num_range": 993,
+                  "upper_bound": "135700"
+              },
+              {
+                  "distinct_range": 1157.097245409855,
+                  "num_eq": 4,
+                  "num_range": 1085,
+                  "upper_bound": "136863"
+              },
+              {
+                  "distinct_range": 989.3709862772315,
+                  "num_eq": 4,
+                  "num_range": 991,
+                  "upper_bound": "137857"
+              },
+              {
+                  "distinct_range": 1038.0108328745332,
+                  "num_eq": 4,
+                  "num_range": 1018,
+                  "upper_bound": "138900"
+              },
+              {
+                  "distinct_range": 966.5371168318945,
+                  "num_eq": 4,
+                  "num_range": 978,
+                  "upper_bound": "139871"
+              },
+              {
+                  "distinct_range": 840.415846613253,
+                  "num_eq": 4,
+                  "num_range": 913,
+                  "upper_bound": "140715"
+              },
+              {
+                  "distinct_range": 1168.0115024454317,
+                  "num_eq": 4,
+                  "num_range": 1092,
+                  "upper_bound": "141889"
+              },
+              {
+                  "distinct_range": 1156.1050248133038,
+                  "num_eq": 4,
+                  "num_range": 1085,
+                  "upper_bound": "143051"
+              },
+              {
+                  "distinct_range": 935.7578660099477,
+                  "num_eq": 4,
+                  "num_range": 962,
+                  "upper_bound": "143991"
+              },
+              {
+                  "distinct_range": 1277.1381828874587,
+                  "num_eq": 4,
+                  "num_range": 1157,
+                  "upper_bound": "145275"
+              },
+              {
+                  "distinct_range": 1077.7110008891584,
+                  "num_eq": 4,
+                  "num_range": 1040,
+                  "upper_bound": "146358"
+              },
+              {
+                  "distinct_range": 999.2981582433508,
+                  "num_eq": 4,
+                  "num_range": 996,
+                  "upper_bound": "147362"
+              },
+              {
+                  "distinct_range": 700.2967083845829,
+                  "num_eq": 4,
+                  "num_range": 848,
+                  "upper_bound": "148065"
+              },
+              {
+                  "distinct_range": 851.3425854045845,
+                  "num_eq": 4,
+                  "num_range": 919,
+                  "upper_bound": "148920"
+              },
+              {
+                  "distinct_range": 1073.7412069614331,
+                  "num_eq": 4,
+                  "num_range": 1038,
+                  "upper_bound": "149999"
+              },
+              {
+                  "distinct_range": 855.3776808971982,
+                  "num_eq": 4,
+                  "num_range": 931,
+                  "upper_bound": "150858"
+              },
+              {
+                  "distinct_range": 1128.4036713427458,
+                  "num_eq": 4,
+                  "num_range": 1077,
+                  "upper_bound": "151992"
+              },
+              {
+                  "distinct_range": 876.2375534497914,
+                  "num_eq": 4,
+                  "num_range": 941,
+                  "upper_bound": "152872"
+              },
+              {
+                  "distinct_range": 1199.8466310769245,
+                  "num_eq": 4,
+                  "num_range": 1119,
+                  "upper_bound": "154078"
+              },
+              {
+                  "distinct_range": 847.4305058591973,
+                  "num_eq": 4,
+                  "num_range": 927,
+                  "upper_bound": "154929"
+              },
+              {
+                  "distinct_range": 1065.8792574931194,
+                  "num_eq": 4,
+                  "num_range": 1042,
+                  "upper_bound": "156000"
+              },
+              {
+                  "distinct_range": 1112.525558489498,
+                  "num_eq": 4,
+                  "num_range": 1068,
+                  "upper_bound": "157118"
+              },
+              {
+                  "distinct_range": 922.9166613980874,
+                  "num_eq": 4,
+                  "num_range": 965,
+                  "upper_bound": "158045"
+              },
+              {
+                  "distinct_range": 1120.4647055924006,
+                  "num_eq": 4,
+                  "num_range": 1073,
+                  "upper_bound": "159171"
+              },
+              {
+                  "distinct_range": 953.6998733035762,
+                  "num_eq": 4,
+                  "num_range": 981,
+                  "upper_bound": "160129"
+              },
+              {
+                  "distinct_range": 1070.8419495678781,
+                  "num_eq": 4,
+                  "num_range": 1045,
+                  "upper_bound": "161205"
+              },
+              {
+                  "distinct_range": 1205.799615048725,
+                  "num_eq": 4,
+                  "num_range": 1122,
+                  "upper_bound": "162417"
+              },
+              {
+                  "distinct_range": 1305.995806751609,
+                  "num_eq": 4,
+                  "num_range": 1182,
+                  "upper_bound": "163730"
+              },
+              {
+                  "distinct_range": 995.4001639158311,
+                  "num_eq": 4,
+                  "num_range": 1003,
+                  "upper_bound": "164730"
+              },
+              {
+                  "distinct_range": 937.8122520715108,
+                  "num_eq": 4,
+                  "num_range": 973,
+                  "upper_bound": "165672"
+              },
+              {
+                  "distinct_range": 998.3785053667216,
+                  "num_eq": 4,
+                  "num_range": 1005,
+                  "upper_bound": "166675"
+              },
+              {
+                  "distinct_range": 1009.2988152404944,
+                  "num_eq": 4,
+                  "num_range": 1011,
+                  "upper_bound": "167689"
+              },
+              {
+                  "distinct_range": 892.12941314597,
+                  "num_eq": 4,
+                  "num_range": 949,
+                  "upper_bound": "168585"
+              },
+              {
+                  "distinct_range": 908.02012599659,
+                  "num_eq": 4,
+                  "num_range": 957,
+                  "upper_bound": "169497"
+              },
+              {
+                  "distinct_range": 1391.2948877576455,
+                  "num_eq": 4,
+                  "num_range": 1234,
+                  "upper_bound": "170896"
+              },
+              {
+                  "distinct_range": 863.3245458311139,
+                  "num_eq": 4,
+                  "num_range": 935,
+                  "upper_bound": "171763"
+              },
+              {
+                  "distinct_range": 1188.9325977477456,
+                  "num_eq": 4,
+                  "num_range": 1112,
+                  "upper_bound": "172958"
+              },
+              {
+                  "distinct_range": 1038.0867063127228,
+                  "num_eq": 4,
+                  "num_range": 1027,
+                  "upper_bound": "174001"
+              },
+              {
+                  "distinct_range": 1203.8152967830215,
+                  "num_eq": 4,
+                  "num_range": 1121,
+                  "upper_bound": "175211"
+              },
+              {
+                  "distinct_range": 1041.0646017700753,
+                  "num_eq": 4,
+                  "num_range": 1028,
+                  "upper_bound": "176257"
+              },
+              {
+                  "distinct_range": 1153.2117998484903,
+                  "num_eq": 4,
+                  "num_range": 1092,
+                  "upper_bound": "177416"
+              },
+              {
+                  "distinct_range": 1087.7145243250307,
+                  "num_eq": 4,
+                  "num_range": 1054,
+                  "upper_bound": "178509"
+              },
+              {
+                  "distinct_range": 918.9443455478805,
+                  "num_eq": 4,
+                  "num_range": 963,
+                  "upper_bound": "179432"
+              },
+              {
+                  "distinct_range": 944.763212569858,
+                  "num_eq": 4,
+                  "num_range": 976,
+                  "upper_bound": "180381"
+              },
+              {
+                  "distinct_range": 1224.650160723777,
+                  "num_eq": 4,
+                  "num_range": 1133,
+                  "upper_bound": "181612"
+              },
+              {
+                  "distinct_range": 972.565116388934,
+                  "num_eq": 4,
+                  "num_range": 991,
+                  "upper_bound": "182589"
+              },
+              {
+                  "distinct_range": 1213.7367916738558,
+                  "num_eq": 4,
+                  "num_range": 1127,
+                  "upper_bound": "183809"
+              },
+              {
+                  "distinct_range": 895.1090080006707,
+                  "num_eq": 4,
+                  "num_range": 951,
+                  "upper_bound": "184708"
+              },
+              {
+                  "distinct_range": 765.952757381849,
+                  "num_eq": 4,
+                  "num_range": 888,
+                  "upper_bound": "185477"
+              },
+              {
+                  "distinct_range": 839.4830153551594,
+                  "num_eq": 4,
+                  "num_range": 923,
+                  "upper_bound": "186320"
+              },
+              {
+                  "distinct_range": 1074.8120470990355,
+                  "num_eq": 4,
+                  "num_range": 1047,
+                  "upper_bound": "187400"
+              },
+              {
+                  "distinct_range": 824.5806012400438,
+                  "num_eq": 4,
+                  "num_range": 916,
+                  "upper_bound": "188228"
+              },
+              {
+                  "distinct_range": 1043.0498488820385,
+                  "num_eq": 4,
+                  "num_range": 1029,
+                  "upper_bound": "189276"
+              },
+              {
+                  "distinct_range": 994.4073762060436,
+                  "num_eq": 4,
+                  "num_range": 1003,
+                  "upper_bound": "190275"
+              },
+              {
+                  "distinct_range": 1000.3640483407037,
+                  "num_eq": 4,
+                  "num_range": 1006,
+                  "upper_bound": "191280"
+              },
+              {
+                  "distinct_range": 902.0612406378057,
+                  "num_eq": 4,
+                  "num_range": 954,
+                  "upper_bound": "192186"
+              },
+              {
+                  "distinct_range": 992.4217899037485,
+                  "num_eq": 4,
+                  "num_range": 1002,
+                  "upper_bound": "193183"
+              },
+              {
+                  "distinct_range": 1003.3423359551795,
+                  "num_eq": 4,
+                  "num_range": 1008,
+                  "upper_bound": "194191"
+              },
+              {
+                  "distinct_range": 1028.1601711619392,
+                  "num_eq": 4,
+                  "num_range": 1021,
+                  "upper_bound": "195224"
+              },
+              {
+                  "distinct_range": 919.9374308385832,
+                  "num_eq": 4,
+                  "num_range": 963,
+                  "upper_bound": "196148"
+              },
+              {
+                  "distinct_range": 899.0817388670961,
+                  "num_eq": 4,
+                  "num_range": 953,
+                  "upper_bound": "197051"
+              },
+              {
+                  "distinct_range": 998.3785053667216,
+                  "num_eq": 4,
+                  "num_range": 1005,
+                  "upper_bound": "198054"
+              },
+              {
+                  "distinct_range": 898.0885627946211,
+                  "num_eq": 4,
+                  "num_range": 952,
+                  "upper_bound": "198956"
+              },
+              {
+                  "distinct_range": 1033.1234806789148,
+                  "num_eq": 4,
+                  "num_range": 1024,
+                  "upper_bound": "199994"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 200000
+      },
+      {
+          "avg_size": 35,
+          "columns": [
+              "p_name"
+          ],
+          "created_at": "2022-03-21 20:30:17.882066",
+          "distinct_count": 198131,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 20,
+                  "num_range": 0,
+                  "upper_bound": "almond antique metallic honeydew green"
+              },
+              {
+                  "distinct_range": 198129,
+                  "num_eq": 20,
+                  "num_range": 199960,
+                  "upper_bound": "yellow white frosted pale peach"
+              }
+          ],
+          "histo_col_type": "VARCHAR(55)",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 200000
+      },
+      {
+          "avg_size": 16,
+          "columns": [
+              "p_mfgr"
+          ],
+          "created_at": "2022-03-21 20:30:17.882066",
+          "distinct_count": 5,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 41180,
+                  "num_range": 0,
+                  "upper_bound": "Manufacturer#1"
+              },
+              {
+                  "distinct_range": 3,
+                  "num_eq": 40000,
+                  "num_range": 118820,
+                  "upper_bound": "Manufacturer#5"
+              }
+          ],
+          "histo_col_type": "CHAR(25)",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 200000
+      },
+      {
+          "avg_size": 10,
+          "columns": [
+              "p_brand"
+          ],
+          "created_at": "2022-03-21 20:30:17.882066",
+          "distinct_count": 25,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 7380,
+                  "num_range": 0,
+                  "upper_bound": "Brand#11"
+              },
+              {
+                  "distinct_range": 23.000000000000004,
+                  "num_eq": 7900,
+                  "num_range": 184720,
+                  "upper_bound": "Brand#55"
+              }
+          ],
+          "histo_col_type": "CHAR(10)",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 200000
+      },
+      {
+          "avg_size": 23,
+          "columns": [
+              "p_type"
+          ],
+          "created_at": "2022-03-21 20:30:17.882066",
+          "distinct_count": 150,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1680,
+                  "num_range": 0,
+                  "upper_bound": "ECONOMY ANODIZED BRASS"
+              },
+              {
+                  "distinct_range": 148,
+                  "num_eq": 1120,
+                  "num_range": 197200,
+                  "upper_bound": "STANDARD POLISHED TIN"
+              }
+          ],
+          "histo_col_type": "VARCHAR(25)",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 200000
+      },
+      {
+          "avg_size": 2,
+          "columns": [
+              "p_size"
+          ],
+          "created_at": "2022-03-21 20:30:17.882066",
+          "distinct_count": 50,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 4140,
+                  "num_range": 0,
+                  "upper_bound": "1"
+              },
+              {
+                  "distinct_range": 48,
+                  "num_eq": 3980,
+                  "num_range": 191880,
+                  "upper_bound": "50"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 200000
+      },
+      {
+          "avg_size": 10,
+          "columns": [
+              "p_container"
+          ],
+          "created_at": "2022-03-21 20:30:17.882066",
+          "distinct_count": 40,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 5240,
+                  "num_range": 0,
+                  "upper_bound": "JUMBO BAG"
+              },
+              {
+                  "distinct_range": 38,
+                  "num_eq": 5060,
+                  "num_range": 189700,
+                  "upper_bound": "WRAP PKG"
+              }
+          ],
+          "histo_col_type": "CHAR(10)",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 200000
+      },
+      {
+          "avg_size": 9,
+          "columns": [
+              "p_retailprice"
+          ],
+          "created_at": "2022-03-21 20:30:17.882066",
+          "distinct_count": 20831,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 20,
+                  "num_range": 0,
+                  "upper_bound": "905.0"
+              },
+              {
+                  "distinct_range": 20829,
+                  "num_eq": 20,
+                  "num_range": 199960,
+                  "upper_bound": "2094.99"
+              }
+          ],
+          "histo_col_type": "FLOAT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 200000
+      },
+      {
+          "avg_size": 16,
+          "columns": [
+              "p_comment"
+          ],
+          "created_at": "2022-03-21 20:30:17.882066",
+          "distinct_count": 132344,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 20,
+                  "num_range": 0,
+                  "upper_bound": " about the "
+              },
+              {
+                  "distinct_range": 132342,
+                  "num_eq": 20,
+                  "num_range": 199960,
+                  "upper_bound": "zle fu"
+              }
+          ],
+          "histo_col_type": "VARCHAR(23)",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 200000
+      }
+  ]'
 
 statement ok
 CREATE TABLE public.partsupp
@@ -218,38 +4926,2533 @@ CREATE TABLE public.partsupp
 )
 
 statement ok
-ALTER TABLE public.partsupp INJECT STATISTICS '[
-  {
-    "columns": ["ps_partkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 800000,
-    "distinct_count": 200000
-  },
-  {
-    "columns": ["ps_suppkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 800000,
-    "distinct_count": 10000
-  },
-  {
-    "columns": ["ps_availqty"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 800000,
-    "distinct_count": 10000
-  },
-  {
-    "columns": ["ps_supplycost"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 800000,
-    "distinct_count": 100000
-  },
-  {
-    "columns": ["ps_comment"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 800000,
-    "distinct_count": 800000
-  }
-]'
+ALTER TABLE public.partsupp INJECT STATISTICS '
+  [
+      {
+          "avg_size": 4,
+          "columns": [
+              "ps_partkey"
+          ],
+          "created_at": "2022-03-21 20:30:20.942434",
+          "distinct_count": 199241,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 80,
+                  "num_range": 0,
+                  "upper_bound": "19"
+              },
+              {
+                  "distinct_range": 1037.0975402799702,
+                  "num_eq": 80,
+                  "num_range": 3921,
+                  "upper_bound": "1061"
+              },
+              {
+                  "distinct_range": 987.9283747834398,
+                  "num_eq": 80,
+                  "num_range": 3917,
+                  "upper_bound": "2053"
+              },
+              {
+                  "distinct_range": 780.1653620816329,
+                  "num_eq": 80,
+                  "num_range": 3906,
+                  "upper_bound": "2835"
+              },
+              {
+                  "distinct_range": 827.8148527861198,
+                  "num_eq": 80,
+                  "num_range": 3908,
+                  "upper_bound": "3665"
+              },
+              {
+                  "distinct_range": 1123.3223378888804,
+                  "num_eq": 80,
+                  "num_range": 3931,
+                  "upper_bound": "4795"
+              },
+              {
+                  "distinct_range": 938.6367523806308,
+                  "num_eq": 80,
+                  "num_range": 3914,
+                  "upper_bound": "5737"
+              },
+              {
+                  "distinct_range": 1228.574225456414,
+                  "num_eq": 80,
+                  "num_range": 3945,
+                  "upper_bound": "6975"
+              },
+              {
+                  "distinct_range": 1033.1686463137257,
+                  "num_eq": 80,
+                  "num_range": 3921,
+                  "upper_bound": "8013"
+              },
+              {
+                  "distinct_range": 835.7480268499854,
+                  "num_eq": 80,
+                  "num_range": 3908,
+                  "upper_bound": "8851"
+              },
+              {
+                  "distinct_range": 1094.9524748137035,
+                  "num_eq": 80,
+                  "num_range": 3927,
+                  "upper_bound": "9952"
+              },
+              {
+                  "distinct_range": 1091.0358740403176,
+                  "num_eq": 80,
+                  "num_range": 3927,
+                  "upper_bound": "11049"
+              },
+              {
+                  "distinct_range": 944.5580075837902,
+                  "num_eq": 159,
+                  "num_range": 3914,
+                  "upper_bound": "11997"
+              },
+              {
+                  "distinct_range": 1160.4281121126062,
+                  "num_eq": 80,
+                  "num_range": 3935,
+                  "upper_bound": "13165"
+              },
+              {
+                  "distinct_range": 924.8140158404009,
+                  "num_eq": 80,
+                  "num_range": 3913,
+                  "upper_bound": "14093"
+              },
+              {
+                  "distinct_range": 1071.4401993901997,
+                  "num_eq": 80,
+                  "num_range": 3925,
+                  "upper_bound": "15170"
+              },
+              {
+                  "distinct_range": 1210.1041087867118,
+                  "num_eq": 80,
+                  "num_range": 3942,
+                  "upper_bound": "16389"
+              },
+              {
+                  "distinct_range": 1019.4111083864731,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "17413"
+              },
+              {
+                  "distinct_range": 982.0197282894027,
+                  "num_eq": 80,
+                  "num_range": 3917,
+                  "upper_bound": "18399"
+              },
+              {
+                  "distinct_range": 1149.6950198026439,
+                  "num_eq": 80,
+                  "num_range": 3934,
+                  "upper_bound": "19556"
+              },
+              {
+                  "distinct_range": 1106.697176641404,
+                  "num_eq": 80,
+                  "num_range": 3929,
+                  "upper_bound": "20669"
+              },
+              {
+                  "distinct_range": 1013.5119879130893,
+                  "num_eq": 80,
+                  "num_range": 3919,
+                  "upper_bound": "21687"
+              },
+              {
+                  "distinct_range": 900.1084521119706,
+                  "num_eq": 80,
+                  "num_range": 3911,
+                  "upper_bound": "22590"
+              },
+              {
+                  "distinct_range": 942.5844422196581,
+                  "num_eq": 80,
+                  "num_range": 3914,
+                  "upper_bound": "23536"
+              },
+              {
+                  "distinct_range": 891.207665353829,
+                  "num_eq": 80,
+                  "num_range": 3911,
+                  "upper_bound": "24430"
+              },
+              {
+                  "distinct_range": 986.9437226505238,
+                  "num_eq": 80,
+                  "num_range": 3917,
+                  "upper_bound": "25421"
+              },
+              {
+                  "distinct_range": 929.7517414106455,
+                  "num_eq": 80,
+                  "num_range": 3913,
+                  "upper_bound": "26354"
+              },
+              {
+                  "distinct_range": 779.1717842938453,
+                  "num_eq": 80,
+                  "num_range": 3906,
+                  "upper_bound": "27135"
+              },
+              {
+                  "distinct_range": 969.2116561859747,
+                  "num_eq": 80,
+                  "num_range": 3916,
+                  "upper_bound": "28108"
+              },
+              {
+                  "distinct_range": 1075.3610175092567,
+                  "num_eq": 80,
+                  "num_range": 3925,
+                  "upper_bound": "29189"
+              },
+              {
+                  "distinct_range": 1045.9345559050525,
+                  "num_eq": 80,
+                  "num_range": 3922,
+                  "upper_bound": "30240"
+              },
+              {
+                  "distinct_range": 1188.6927664906277,
+                  "num_eq": 80,
+                  "num_range": 3939,
+                  "upper_bound": "31437"
+              },
+              {
+                  "distinct_range": 1161.4035209589829,
+                  "num_eq": 80,
+                  "num_range": 3935,
+                  "upper_bound": "32606"
+              },
+              {
+                  "distinct_range": 801.0223777567475,
+                  "num_eq": 80,
+                  "num_range": 3906,
+                  "upper_bound": "33409"
+              },
+              {
+                  "distinct_range": 952.4503948187569,
+                  "num_eq": 80,
+                  "num_range": 3915,
+                  "upper_bound": "34365"
+              },
+              {
+                  "distinct_range": 1166.2797467025255,
+                  "num_eq": 80,
+                  "num_range": 3936,
+                  "upper_bound": "35539"
+              },
+              {
+                  "distinct_range": 900.1084521119706,
+                  "num_eq": 80,
+                  "num_range": 3911,
+                  "upper_bound": "36442"
+              },
+              {
+                  "distinct_range": 973.1534721831861,
+                  "num_eq": 80,
+                  "num_range": 3916,
+                  "upper_bound": "37419"
+              },
+              {
+                  "distinct_range": 978.0796552580023,
+                  "num_eq": 80,
+                  "num_range": 3916,
+                  "upper_bound": "38401"
+              },
+              {
+                  "distinct_range": 1194.5348667662038,
+                  "num_eq": 80,
+                  "num_range": 3940,
+                  "upper_bound": "39604"
+              },
+              {
+                  "distinct_range": 831.7817515258133,
+                  "num_eq": 80,
+                  "num_range": 3908,
+                  "upper_bound": "40438"
+              },
+              {
+                  "distinct_range": 837.7309291382688,
+                  "num_eq": 159,
+                  "num_range": 3908,
+                  "upper_bound": "41278"
+              },
+              {
+                  "distinct_range": 853.588415727666,
+                  "num_eq": 80,
+                  "num_range": 3909,
+                  "upper_bound": "42134"
+              },
+              {
+                  "distinct_range": 1089.0772558511057,
+                  "num_eq": 80,
+                  "num_range": 3927,
+                  "upper_bound": "43229"
+              },
+              {
+                  "distinct_range": 952.4503948187569,
+                  "num_eq": 80,
+                  "num_range": 3915,
+                  "upper_bound": "44185"
+              },
+              {
+                  "distinct_range": 814.918188898092,
+                  "num_eq": 80,
+                  "num_range": 3907,
+                  "upper_bound": "45002"
+              },
+              {
+                  "distinct_range": 861.5132739377984,
+                  "num_eq": 80,
+                  "num_range": 3909,
+                  "upper_bound": "45866"
+              },
+              {
+                  "distinct_range": 831.6588730634766,
+                  "num_eq": 159,
+                  "num_range": 3829,
+                  "upper_bound": "46700"
+              },
+              {
+                  "distinct_range": 907.0288249864386,
+                  "num_eq": 80,
+                  "num_range": 3912,
+                  "upper_bound": "47610"
+              },
+              {
+                  "distinct_range": 969.2116561859747,
+                  "num_eq": 80,
+                  "num_range": 3916,
+                  "upper_bound": "48583"
+              },
+              {
+                  "distinct_range": 1221.7717682806829,
+                  "num_eq": 80,
+                  "num_range": 3944,
+                  "upper_bound": "49814"
+              },
+              {
+                  "distinct_range": 1234.4027436203148,
+                  "num_eq": 80,
+                  "num_range": 3946,
+                  "upper_bound": "51058"
+              },
+              {
+                  "distinct_range": 1010.5617495580129,
+                  "num_eq": 80,
+                  "num_range": 3919,
+                  "upper_bound": "52073"
+              },
+              {
+                  "distinct_range": 1109.6321529223646,
+                  "num_eq": 80,
+                  "num_range": 3929,
+                  "upper_bound": "53189"
+              },
+              {
+                  "distinct_range": 882.3033636496102,
+                  "num_eq": 80,
+                  "num_range": 3910,
+                  "upper_bound": "54074"
+              },
+              {
+                  "distinct_range": 994.8195643992607,
+                  "num_eq": 80,
+                  "num_range": 3918,
+                  "upper_bound": "55073"
+              },
+              {
+                  "distinct_range": 914.9351542371671,
+                  "num_eq": 80,
+                  "num_range": 3912,
+                  "upper_bound": "55991"
+              },
+              {
+                  "distinct_range": 945.5447201785079,
+                  "num_eq": 80,
+                  "num_range": 3914,
+                  "upper_bound": "56940"
+              },
+              {
+                  "distinct_range": 1016.4617745669668,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "57961"
+              },
+              {
+                  "distinct_range": 923.8263337602774,
+                  "num_eq": 80,
+                  "num_range": 3913,
+                  "upper_bound": "58888"
+              },
+              {
+                  "distinct_range": 755.3157872751149,
+                  "num_eq": 80,
+                  "num_range": 3905,
+                  "upper_bound": "59645"
+              },
+              {
+                  "distinct_range": 1184.7969336864705,
+                  "num_eq": 80,
+                  "num_range": 3938,
+                  "upper_bound": "60838"
+              },
+              {
+                  "distinct_range": 1090.6597991627166,
+                  "num_eq": 159,
+                  "num_range": 3849,
+                  "upper_bound": "61935"
+              },
+              {
+                  "distinct_range": 905.0517968811238,
+                  "num_eq": 80,
+                  "num_range": 3911,
+                  "upper_bound": "62843"
+              },
+              {
+                  "distinct_range": 891.0395875096655,
+                  "num_eq": 159,
+                  "num_range": 3832,
+                  "upper_bound": "63737"
+              },
+              {
+                  "distinct_range": 781.1589053178336,
+                  "num_eq": 80,
+                  "num_range": 3906,
+                  "upper_bound": "64520"
+              },
+              {
+                  "distinct_range": 829.7983797627344,
+                  "num_eq": 80,
+                  "num_range": 3908,
+                  "upper_bound": "65352"
+              },
+              {
+                  "distinct_range": 887.2506289325494,
+                  "num_eq": 80,
+                  "num_range": 3910,
+                  "upper_bound": "66242"
+              },
+              {
+                  "distinct_range": 1002.6922477474118,
+                  "num_eq": 80,
+                  "num_range": 3918,
+                  "upper_bound": "67249"
+              },
+              {
+                  "distinct_range": 859.532305531026,
+                  "num_eq": 80,
+                  "num_range": 3909,
+                  "upper_bound": "68111"
+              },
+              {
+                  "distinct_range": 951.4640109933869,
+                  "num_eq": 80,
+                  "num_range": 3914,
+                  "upper_bound": "69066"
+              },
+              {
+                  "distinct_range": 882.3033636496102,
+                  "num_eq": 80,
+                  "num_range": 3910,
+                  "upper_bound": "69951"
+              },
+              {
+                  "distinct_range": 1213.9942127287593,
+                  "num_eq": 80,
+                  "num_range": 3943,
+                  "upper_bound": "71174"
+              },
+              {
+                  "distinct_range": 988.653574559306,
+                  "num_eq": 159,
+                  "num_range": 3839,
+                  "upper_bound": "72167"
+              },
+              {
+                  "distinct_range": 1015.4785626083005,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "73187"
+              },
+              {
+                  "distinct_range": 820.871295391095,
+                  "num_eq": 80,
+                  "num_range": 3907,
+                  "upper_bound": "74010"
+              },
+              {
+                  "distinct_range": 933.7010964796827,
+                  "num_eq": 80,
+                  "num_range": 3913,
+                  "upper_bound": "74947"
+              },
+              {
+                  "distinct_range": 1033.1686463137257,
+                  "num_eq": 80,
+                  "num_range": 3921,
+                  "upper_bound": "75985"
+              },
+              {
+                  "distinct_range": 844.6698406776112,
+                  "num_eq": 80,
+                  "num_range": 3908,
+                  "upper_bound": "76832"
+              },
+              {
+                  "distinct_range": 1062.6152989122052,
+                  "num_eq": 80,
+                  "num_range": 3924,
+                  "upper_bound": "77900"
+              },
+              {
+                  "distinct_range": 988.9129778920217,
+                  "num_eq": 80,
+                  "num_range": 3917,
+                  "upper_bound": "78893"
+              },
+              {
+                  "distinct_range": 1156.525931625627,
+                  "num_eq": 80,
+                  "num_range": 3935,
+                  "upper_bound": "80057"
+              },
+              {
+                  "distinct_range": 1217.8834327562001,
+                  "num_eq": 80,
+                  "num_range": 3943,
+                  "upper_bound": "81284"
+              },
+              {
+                  "distinct_range": 846.6520281215594,
+                  "num_eq": 80,
+                  "num_range": 3908,
+                  "upper_bound": "82133"
+              },
+              {
+                  "distinct_range": 737.4115253589624,
+                  "num_eq": 80,
+                  "num_range": 3904,
+                  "upper_bound": "82872"
+              },
+              {
+                  "distinct_range": 1154.5745145614305,
+                  "num_eq": 80,
+                  "num_range": 3934,
+                  "upper_bound": "84034"
+              },
+              {
+                  "distinct_range": 1338.9741159341406,
+                  "num_eq": 80,
+                  "num_range": 3963,
+                  "upper_bound": "85386"
+              },
+              {
+                  "distinct_range": 990.8820368472965,
+                  "num_eq": 80,
+                  "num_range": 3917,
+                  "upper_bound": "86381"
+              },
+              {
+                  "distinct_range": 852.597624628244,
+                  "num_eq": 80,
+                  "num_range": 3909,
+                  "upper_bound": "87236"
+              },
+              {
+                  "distinct_range": 938.6367523806308,
+                  "num_eq": 80,
+                  "num_range": 3914,
+                  "upper_bound": "88178"
+              },
+              {
+                  "distinct_range": 1007.3318562974747,
+                  "num_eq": 159,
+                  "num_range": 3841,
+                  "upper_bound": "89190"
+              },
+              {
+                  "distinct_range": 966.2547890872239,
+                  "num_eq": 80,
+                  "num_range": 3916,
+                  "upper_bound": "90160"
+              },
+              {
+                  "distinct_range": 1138.955353353662,
+                  "num_eq": 80,
+                  "num_range": 3932,
+                  "upper_bound": "91306"
+              },
+              {
+                  "distinct_range": 858.5417596047845,
+                  "num_eq": 80,
+                  "num_range": 3909,
+                  "upper_bound": "92167"
+              },
+              {
+                  "distinct_range": 1048.8793024521772,
+                  "num_eq": 80,
+                  "num_range": 3923,
+                  "upper_bound": "93221"
+              },
+              {
+                  "distinct_range": 865.4747148978759,
+                  "num_eq": 80,
+                  "num_range": 3909,
+                  "upper_bound": "94089"
+              },
+              {
+                  "distinct_range": 1005.6436849798185,
+                  "num_eq": 80,
+                  "num_range": 3919,
+                  "upper_bound": "95099"
+              },
+              {
+                  "distinct_range": 926.7892432152071,
+                  "num_eq": 80,
+                  "num_range": 3913,
+                  "upper_bound": "96029"
+              },
+              {
+                  "distinct_range": 729.4508644954608,
+                  "num_eq": 80,
+                  "num_range": 3904,
+                  "upper_bound": "96760"
+              },
+              {
+                  "distinct_range": 1089.0772558511057,
+                  "num_eq": 80,
+                  "num_range": 3927,
+                  "upper_bound": "97855"
+              },
+              {
+                  "distinct_range": 961.3257192841475,
+                  "num_eq": 80,
+                  "num_range": 3915,
+                  "upper_bound": "98820"
+              },
+              {
+                  "distinct_range": 817.8949123582937,
+                  "num_eq": 80,
+                  "num_range": 3907,
+                  "upper_bound": "99640"
+              },
+              {
+                  "distinct_range": 1184.7969336864705,
+                  "num_eq": 80,
+                  "num_range": 3938,
+                  "upper_bound": "100833"
+              },
+              {
+                  "distinct_range": 836.739497674614,
+                  "num_eq": 80,
+                  "num_range": 3908,
+                  "upper_bound": "101672"
+              },
+              {
+                  "distinct_range": 1258.6667472462088,
+                  "num_eq": 80,
+                  "num_range": 3949,
+                  "upper_bound": "102941"
+              },
+              {
+                  "distinct_range": 998.7563023383982,
+                  "num_eq": 80,
+                  "num_range": 3918,
+                  "upper_bound": "103944"
+              },
+              {
+                  "distinct_range": 782.152413913031,
+                  "num_eq": 80,
+                  "num_range": 3906,
+                  "upper_bound": "104728"
+              },
+              {
+                  "distinct_range": 1067.5185435803257,
+                  "num_eq": 80,
+                  "num_range": 3924,
+                  "upper_bound": "105801"
+              },
+              {
+                  "distinct_range": 1048.8793024521772,
+                  "num_eq": 80,
+                  "num_range": 3923,
+                  "upper_bound": "106855"
+              },
+              {
+                  "distinct_range": 814.918188898092,
+                  "num_eq": 80,
+                  "num_range": 3907,
+                  "upper_bound": "107672"
+              },
+              {
+                  "distinct_range": 1075.3610175092567,
+                  "num_eq": 80,
+                  "num_range": 3925,
+                  "upper_bound": "108753"
+              },
+              {
+                  "distinct_range": 1156.525931625627,
+                  "num_eq": 80,
+                  "num_range": 3935,
+                  "upper_bound": "109917"
+              },
+              {
+                  "distinct_range": 1096.9104569564186,
+                  "num_eq": 80,
+                  "num_range": 3928,
+                  "upper_bound": "111020"
+              },
+              {
+                  "distinct_range": 1113.5447062280634,
+                  "num_eq": 80,
+                  "num_range": 3929,
+                  "upper_bound": "112140"
+              },
+              {
+                  "distinct_range": 1002.6922477474118,
+                  "num_eq": 80,
+                  "num_range": 3918,
+                  "upper_bound": "113147"
+              },
+              {
+                  "distinct_range": 1018.4280474975401,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "114170"
+              },
+              {
+                  "distinct_range": 1166.2797467025255,
+                  "num_eq": 80,
+                  "num_range": 3936,
+                  "upper_bound": "115344"
+              },
+              {
+                  "distinct_range": 1247.9948587148256,
+                  "num_eq": 159,
+                  "num_range": 3948,
+                  "upper_bound": "116602"
+              },
+              {
+                  "distinct_range": 937.6497137727322,
+                  "num_eq": 80,
+                  "num_range": 3913,
+                  "upper_bound": "117543"
+              },
+              {
+                  "distinct_range": 1200.374985955797,
+                  "num_eq": 80,
+                  "num_range": 3941,
+                  "upper_bound": "118752"
+              },
+              {
+                  "distinct_range": 880.3241576033859,
+                  "num_eq": 80,
+                  "num_range": 3910,
+                  "upper_bound": "119635"
+              },
+              {
+                  "distinct_range": 992.8508991405732,
+                  "num_eq": 80,
+                  "num_range": 3918,
+                  "upper_bound": "120632"
+              },
+              {
+                  "distinct_range": 839.7136736674216,
+                  "num_eq": 80,
+                  "num_range": 3908,
+                  "upper_bound": "121474"
+              },
+              {
+                  "distinct_range": 941.5975895633624,
+                  "num_eq": 80,
+                  "num_range": 3914,
+                  "upper_bound": "122419"
+              },
+              {
+                  "distinct_range": 1104.7402588751384,
+                  "num_eq": 80,
+                  "num_range": 3928,
+                  "upper_bound": "123530"
+              },
+              {
+                  "distinct_range": 875.3753975380291,
+                  "num_eq": 80,
+                  "num_range": 3910,
+                  "upper_bound": "124408"
+              },
+              {
+                  "distinct_range": 839.7136736674216,
+                  "num_eq": 80,
+                  "num_range": 3908,
+                  "upper_bound": "125250"
+              },
+              {
+                  "distinct_range": 1039.0616805249194,
+                  "num_eq": 80,
+                  "num_range": 3922,
+                  "upper_bound": "126294"
+              },
+              {
+                  "distinct_range": 995.8038230250698,
+                  "num_eq": 80,
+                  "num_range": 3918,
+                  "upper_bound": "127294"
+              },
+              {
+                  "distinct_range": 1005.6436849798185,
+                  "num_eq": 80,
+                  "num_range": 3919,
+                  "upper_bound": "128304"
+              },
+              {
+                  "distinct_range": 1112.5666481614649,
+                  "num_eq": 80,
+                  "num_range": 3929,
+                  "upper_bound": "129423"
+              },
+              {
+                  "distinct_range": 832.7733790018003,
+                  "num_eq": 80,
+                  "num_range": 3908,
+                  "upper_bound": "130258"
+              },
+              {
+                  "distinct_range": 1389.0922139328088,
+                  "num_eq": 80,
+                  "num_range": 3973,
+                  "upper_bound": "131662"
+              },
+              {
+                  "distinct_range": 1104.7402588751384,
+                  "num_eq": 80,
+                  "num_range": 3928,
+                  "upper_bound": "132773"
+              },
+              {
+                  "distinct_range": 1237.3162546818937,
+                  "num_eq": 80,
+                  "num_range": 3946,
+                  "upper_bound": "134020"
+              },
+              {
+                  "distinct_range": 1249.935701787803,
+                  "num_eq": 80,
+                  "num_range": 3948,
+                  "upper_bound": "135280"
+              },
+              {
+                  "distinct_range": 1112.5666481614649,
+                  "num_eq": 80,
+                  "num_range": 3929,
+                  "upper_bound": "136399"
+              },
+              {
+                  "distinct_range": 1000.7243742895265,
+                  "num_eq": 80,
+                  "num_range": 3918,
+                  "upper_bound": "137404"
+              },
+              {
+                  "distinct_range": 840.7049865758015,
+                  "num_eq": 80,
+                  "num_range": 3908,
+                  "upper_bound": "138247"
+              },
+              {
+                  "distinct_range": 1092.0151037259939,
+                  "num_eq": 80,
+                  "num_range": 3927,
+                  "upper_bound": "139345"
+              },
+              {
+                  "distinct_range": 1246.053793637375,
+                  "num_eq": 80,
+                  "num_range": 3947,
+                  "upper_bound": "140601"
+              },
+              {
+                  "distinct_range": 1054.7674017389231,
+                  "num_eq": 80,
+                  "num_range": 3923,
+                  "upper_bound": "141661"
+              },
+              {
+                  "distinct_range": 879.3344905870908,
+                  "num_eq": 80,
+                  "num_range": 3910,
+                  "upper_bound": "142543"
+              },
+              {
+                  "distinct_range": 818.8870779713083,
+                  "num_eq": 80,
+                  "num_range": 3907,
+                  "upper_bound": "143364"
+              },
+              {
+                  "distinct_range": 1077.321111812624,
+                  "num_eq": 80,
+                  "num_range": 3925,
+                  "upper_bound": "144447"
+              },
+              {
+                  "distinct_range": 1145.7904458917537,
+                  "num_eq": 80,
+                  "num_range": 3933,
+                  "upper_bound": "145600"
+              },
+              {
+                  "distinct_range": 856.5605446786532,
+                  "num_eq": 80,
+                  "num_range": 3909,
+                  "upper_bound": "146459"
+              },
+              {
+                  "distinct_range": 1114.5227107476042,
+                  "num_eq": 80,
+                  "num_range": 3930,
+                  "upper_bound": "147580"
+              },
+              {
+                  "distinct_range": 845.6609544313385,
+                  "num_eq": 80,
+                  "num_range": 3908,
+                  "upper_bound": "148428"
+              },
+              {
+                  "distinct_range": 929.7517414106455,
+                  "num_eq": 80,
+                  "num_range": 3913,
+                  "upper_bound": "149361"
+              },
+              {
+                  "distinct_range": 971.1826605644411,
+                  "num_eq": 80,
+                  "num_range": 3916,
+                  "upper_bound": "150336"
+              },
+              {
+                  "distinct_range": 1042.9893460378769,
+                  "num_eq": 80,
+                  "num_range": 3922,
+                  "upper_bound": "151384"
+              },
+              {
+                  "distinct_range": 990.8820368472965,
+                  "num_eq": 80,
+                  "num_range": 3917,
+                  "upper_bound": "152379"
+              },
+              {
+                  "distinct_range": 986.9437226505238,
+                  "num_eq": 80,
+                  "num_range": 3917,
+                  "upper_bound": "153370"
+              },
+              {
+                  "distinct_range": 1142.2968003508017,
+                  "num_eq": 80,
+                  "num_range": 4010,
+                  "upper_bound": "154519"
+              },
+              {
+                  "distinct_range": 1001.960321851883,
+                  "num_eq": 159,
+                  "num_range": 3997,
+                  "upper_bound": "155525"
+              },
+              {
+                  "distinct_range": 1021.3770788056297,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "156551"
+              },
+              {
+                  "distinct_range": 983.2381730050859,
+                  "num_eq": 80,
+                  "num_range": 3995,
+                  "upper_bound": "157538"
+              },
+              {
+                  "distinct_range": 1143.2744810943775,
+                  "num_eq": 80,
+                  "num_range": 4010,
+                  "upper_bound": "158688"
+              },
+              {
+                  "distinct_range": 1114.9004625556765,
+                  "num_eq": 80,
+                  "num_range": 4007,
+                  "upper_bound": "159809"
+              },
+              {
+                  "distinct_range": 761.353223808192,
+                  "num_eq": 80,
+                  "num_range": 3984,
+                  "upper_bound": "160572"
+              },
+              {
+                  "distinct_range": 982.2523254250871,
+                  "num_eq": 80,
+                  "num_range": 3995,
+                  "upper_bound": "161558"
+              },
+              {
+                  "distinct_range": 899.2794949103395,
+                  "num_eq": 80,
+                  "num_range": 3990,
+                  "upper_bound": "162460"
+              },
+              {
+                  "distinct_range": 983.0046248279281,
+                  "num_eq": 159,
+                  "num_range": 3917,
+                  "upper_bound": "163447"
+              },
+              {
+                  "distinct_range": 836.8543319541236,
+                  "num_eq": 80,
+                  "num_range": 3987,
+                  "upper_bound": "164286"
+              },
+              {
+                  "distinct_range": 1100.2070698933155,
+                  "num_eq": 80,
+                  "num_range": 4006,
+                  "upper_bound": "165392"
+              },
+              {
+                  "distinct_range": 1032.469838128016,
+                  "num_eq": 80,
+                  "num_range": 3999,
+                  "upper_bound": "166429"
+              },
+              {
+                  "distinct_range": 841.8143611978502,
+                  "num_eq": 80,
+                  "num_range": 3987,
+                  "upper_bound": "167273"
+              },
+              {
+                  "distinct_range": 1025.5846729979216,
+                  "num_eq": 80,
+                  "num_range": 3999,
+                  "upper_bound": "168303"
+              },
+              {
+                  "distinct_range": 1155.0025380297982,
+                  "num_eq": 80,
+                  "num_range": 4012,
+                  "upper_bound": "169465"
+              },
+              {
+                  "distinct_range": 990.1377918543169,
+                  "num_eq": 80,
+                  "num_range": 3996,
+                  "upper_bound": "170459"
+              },
+              {
+                  "distinct_range": 946.7310590926484,
+                  "num_eq": 80,
+                  "num_range": 3993,
+                  "upper_bound": "171409"
+              },
+              {
+                  "distinct_range": 1190.1408790030694,
+                  "num_eq": 80,
+                  "num_range": 4016,
+                  "upper_bound": "172607"
+              },
+              {
+                  "distinct_range": 1136.4296117365614,
+                  "num_eq": 80,
+                  "num_range": 4010,
+                  "upper_bound": "173750"
+              },
+              {
+                  "distinct_range": 1364.7829643771368,
+                  "num_eq": 80,
+                  "num_range": 4044,
+                  "upper_bound": "175128"
+              },
+              {
+                  "distinct_range": 922.0291729059999,
+                  "num_eq": 80,
+                  "num_range": 3991,
+                  "upper_bound": "176053"
+              },
+              {
+                  "distinct_range": 1082.55970790784,
+                  "num_eq": 80,
+                  "num_range": 4004,
+                  "upper_bound": "177141"
+              },
+              {
+                  "distinct_range": 874.5265043679942,
+                  "num_eq": 80,
+                  "num_range": 3989,
+                  "upper_bound": "178018"
+              },
+              {
+                  "distinct_range": 935.865627567618,
+                  "num_eq": 80,
+                  "num_range": 3992,
+                  "upper_bound": "178957"
+              },
+              {
+                  "distinct_range": 1049.1809070382774,
+                  "num_eq": 80,
+                  "num_range": 4001,
+                  "upper_bound": "180011"
+              },
+              {
+                  "distinct_range": 866.6001991473113,
+                  "num_eq": 80,
+                  "num_range": 3988,
+                  "upper_bound": "180880"
+              },
+              {
+                  "distinct_range": 1100.2070698933155,
+                  "num_eq": 80,
+                  "num_range": 4006,
+                  "upper_bound": "181986"
+              },
+              {
+                  "distinct_range": 729.5079004364263,
+                  "num_eq": 80,
+                  "num_range": 3984,
+                  "upper_bound": "182717"
+              },
+              {
+                  "distinct_range": 1030.5028930424792,
+                  "num_eq": 80,
+                  "num_range": 3999,
+                  "upper_bound": "183752"
+              },
+              {
+                  "distinct_range": 1024.600882351474,
+                  "num_eq": 80,
+                  "num_range": 3999,
+                  "upper_bound": "184781"
+              },
+              {
+                  "distinct_range": 1298.045041753083,
+                  "num_eq": 80,
+                  "num_range": 4032,
+                  "upper_bound": "186090"
+              },
+              {
+                  "distinct_range": 1121.7533858933766,
+                  "num_eq": 80,
+                  "num_range": 4008,
+                  "upper_bound": "187218"
+              },
+              {
+                  "distinct_range": 1127.6252880358527,
+                  "num_eq": 80,
+                  "num_range": 4009,
+                  "upper_bound": "188352"
+              },
+              {
+                  "distinct_range": 888.3913386128658,
+                  "num_eq": 80,
+                  "num_range": 3989,
+                  "upper_bound": "189243"
+              },
+              {
+                  "distinct_range": 984.2239737489074,
+                  "num_eq": 80,
+                  "num_range": 3995,
+                  "upper_bound": "190231"
+              },
+              {
+                  "distinct_range": 655.761875745403,
+                  "num_eq": 80,
+                  "num_range": 3982,
+                  "upper_bound": "190888"
+              },
+              {
+                  "distinct_range": 1078.6358228888269,
+                  "num_eq": 80,
+                  "num_range": 4003,
+                  "upper_bound": "191972"
+              },
+              {
+                  "distinct_range": 843.7981099426644,
+                  "num_eq": 80,
+                  "num_range": 3987,
+                  "upper_bound": "192818"
+              },
+              {
+                  "distinct_range": 856.6887638453816,
+                  "num_eq": 80,
+                  "num_range": 3988,
+                  "upper_bound": "193677"
+              },
+              {
+                  "distinct_range": 954.6297876074589,
+                  "num_eq": 80,
+                  "num_range": 3993,
+                  "upper_bound": "194635"
+              },
+              {
+                  "distinct_range": 1176.0280993437987,
+                  "num_eq": 159,
+                  "num_range": 3937,
+                  "upper_bound": "195819"
+              },
+              {
+                  "distinct_range": 986.1954345274099,
+                  "num_eq": 80,
+                  "num_range": 3995,
+                  "upper_bound": "196809"
+              },
+              {
+                  "distinct_range": 1064.895833511573,
+                  "num_eq": 80,
+                  "num_range": 4002,
+                  "upper_bound": "197879"
+              },
+              {
+                  "distinct_range": 862.6360953268082,
+                  "num_eq": 80,
+                  "num_range": 3988,
+                  "upper_bound": "198744"
+              },
+              {
+                  "distinct_range": 1243.6903078527207,
+                  "num_eq": 80,
+                  "num_range": 4024,
+                  "upper_bound": "199997"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 800000
+      },
+      {
+          "avg_size": 3,
+          "columns": [
+              "ps_suppkey"
+          ],
+          "created_at": "2022-03-21 20:30:20.942434",
+          "distinct_count": 9920,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 80,
+                  "num_range": 0,
+                  "upper_bound": "1"
+              },
+              {
+                  "distinct_range": 43.64081632653061,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "46"
+              },
+              {
+                  "distinct_range": 39.673469387755105,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "87"
+              },
+              {
+                  "distinct_range": 60.502040816326534,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "149"
+              },
+              {
+                  "distinct_range": 43.64081632653061,
+                  "num_eq": 240,
+                  "num_range": 3840,
+                  "upper_bound": "194"
+              },
+              {
+                  "distinct_range": 60.502040816326534,
+                  "num_eq": 320,
+                  "num_range": 3680,
+                  "upper_bound": "256"
+              },
+              {
+                  "distinct_range": 49.59183673469388,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "307"
+              },
+              {
+                  "distinct_range": 55.542857142857144,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "364"
+              },
+              {
+                  "distinct_range": 50.583673469387755,
+                  "num_eq": 240,
+                  "num_range": 3840,
+                  "upper_bound": "416"
+              },
+              {
+                  "distinct_range": 42.648979591836735,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "460"
+              },
+              {
+                  "distinct_range": 42.648979591836735,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "504"
+              },
+              {
+                  "distinct_range": 72.40408163265306,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "578"
+              },
+              {
+                  "distinct_range": 50.583673469387755,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "630"
+              },
+              {
+                  "distinct_range": 51.57551020408163,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "683"
+              },
+              {
+                  "distinct_range": 47.608163265306125,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "732"
+              },
+              {
+                  "distinct_range": 41.65714285714286,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "775"
+              },
+              {
+                  "distinct_range": 58.518367346938774,
+                  "num_eq": 240,
+                  "num_range": 3760,
+                  "upper_bound": "835"
+              },
+              {
+                  "distinct_range": 51.57551020408163,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "888"
+              },
+              {
+                  "distinct_range": 42.648979591836735,
+                  "num_eq": 240,
+                  "num_range": 3920,
+                  "upper_bound": "932"
+              },
+              {
+                  "distinct_range": 45.624489795918365,
+                  "num_eq": 400,
+                  "num_range": 3760,
+                  "upper_bound": "979"
+              },
+              {
+                  "distinct_range": 49.59183673469388,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "1030"
+              },
+              {
+                  "distinct_range": 43.64081632653061,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "1075"
+              },
+              {
+                  "distinct_range": 49.59183673469388,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "1126"
+              },
+              {
+                  "distinct_range": 42.648979591836735,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "1170"
+              },
+              {
+                  "distinct_range": 38.68163265306122,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "1210"
+              },
+              {
+                  "distinct_range": 53.55918367346939,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "1265"
+              },
+              {
+                  "distinct_range": 35.70612244897959,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "1302"
+              },
+              {
+                  "distinct_range": 54.55102040816327,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "1358"
+              },
+              {
+                  "distinct_range": 50.583673469387755,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "1410"
+              },
+              {
+                  "distinct_range": 46.61632653061225,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "1458"
+              },
+              {
+                  "distinct_range": 42.648979591836735,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "1502"
+              },
+              {
+                  "distinct_range": 49.59183673469388,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "1553"
+              },
+              {
+                  "distinct_range": 54.55102040816327,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "1609"
+              },
+              {
+                  "distinct_range": 43.64081632653061,
+                  "num_eq": 240,
+                  "num_range": 3840,
+                  "upper_bound": "1654"
+              },
+              {
+                  "distinct_range": 44.63265306122449,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "1700"
+              },
+              {
+                  "distinct_range": 54.55102040816327,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "1756"
+              },
+              {
+                  "distinct_range": 45.624489795918365,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "1803"
+              },
+              {
+                  "distinct_range": 44.63265306122449,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "1849"
+              },
+              {
+                  "distinct_range": 43.64081632653061,
+                  "num_eq": 240,
+                  "num_range": 3760,
+                  "upper_bound": "1894"
+              },
+              {
+                  "distinct_range": 58.518367346938774,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "1954"
+              },
+              {
+                  "distinct_range": 45.624489795918365,
+                  "num_eq": 240,
+                  "num_range": 3760,
+                  "upper_bound": "2001"
+              },
+              {
+                  "distinct_range": 43.64081632653061,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "2046"
+              },
+              {
+                  "distinct_range": 37.689795918367345,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "2085"
+              },
+              {
+                  "distinct_range": 43.64081632653061,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "2130"
+              },
+              {
+                  "distinct_range": 48.6,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "2180"
+              },
+              {
+                  "distinct_range": 56.53469387755102,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "2238"
+              },
+              {
+                  "distinct_range": 39.673469387755105,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "2279"
+              },
+              {
+                  "distinct_range": 61.49387755102041,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "2342"
+              },
+              {
+                  "distinct_range": 48.6,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "2392"
+              },
+              {
+                  "distinct_range": 47.608163265306125,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "2441"
+              },
+              {
+                  "distinct_range": 46.61632653061225,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "2489"
+              },
+              {
+                  "distinct_range": 43.64081632653061,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "2534"
+              },
+              {
+                  "distinct_range": 45.624489795918365,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "2581"
+              },
+              {
+                  "distinct_range": 44.63265306122449,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "2627"
+              },
+              {
+                  "distinct_range": 56.53469387755102,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "2685"
+              },
+              {
+                  "distinct_range": 48.6,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "2735"
+              },
+              {
+                  "distinct_range": 61.49387755102041,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "2798"
+              },
+              {
+                  "distinct_range": 56.53469387755102,
+                  "num_eq": 240,
+                  "num_range": 3840,
+                  "upper_bound": "2856"
+              },
+              {
+                  "distinct_range": 39.673469387755105,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "2897"
+              },
+              {
+                  "distinct_range": 61.49387755102041,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "2960"
+              },
+              {
+                  "distinct_range": 38.68163265306122,
+                  "num_eq": 400,
+                  "num_range": 3680,
+                  "upper_bound": "3000"
+              },
+              {
+                  "distinct_range": 48.6,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "3050"
+              },
+              {
+                  "distinct_range": 51.57551020408163,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "3103"
+              },
+              {
+                  "distinct_range": 45.624489795918365,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "3150"
+              },
+              {
+                  "distinct_range": 58.518367346938774,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "3210"
+              },
+              {
+                  "distinct_range": 42.648979591836735,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "3254"
+              },
+              {
+                  "distinct_range": 43.64081632653061,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "3299"
+              },
+              {
+                  "distinct_range": 49.59183673469388,
+                  "num_eq": 240,
+                  "num_range": 3840,
+                  "upper_bound": "3350"
+              },
+              {
+                  "distinct_range": 48.6,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "3400"
+              },
+              {
+                  "distinct_range": 50.583673469387755,
+                  "num_eq": 320,
+                  "num_range": 3840,
+                  "upper_bound": "3452"
+              },
+              {
+                  "distinct_range": 55.542857142857144,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "3509"
+              },
+              {
+                  "distinct_range": 58.518367346938774,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "3569"
+              },
+              {
+                  "distinct_range": 41.65714285714286,
+                  "num_eq": 240,
+                  "num_range": 3840,
+                  "upper_bound": "3612"
+              },
+              {
+                  "distinct_range": 57.5265306122449,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "3671"
+              },
+              {
+                  "distinct_range": 39.673469387755105,
+                  "num_eq": 320,
+                  "num_range": 3840,
+                  "upper_bound": "3712"
+              },
+              {
+                  "distinct_range": 54.55102040816327,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "3768"
+              },
+              {
+                  "distinct_range": 45.624489795918365,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "3815"
+              },
+              {
+                  "distinct_range": 44.63265306122449,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "3861"
+              },
+              {
+                  "distinct_range": 61.49387755102041,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "3924"
+              },
+              {
+                  "distinct_range": 51.57551020408163,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "3977"
+              },
+              {
+                  "distinct_range": 56.53469387755102,
+                  "num_eq": 400,
+                  "num_range": 3840,
+                  "upper_bound": "4035"
+              },
+              {
+                  "distinct_range": 47.608163265306125,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "4084"
+              },
+              {
+                  "distinct_range": 60.502040816326534,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "4146"
+              },
+              {
+                  "distinct_range": 43.64081632653061,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "4191"
+              },
+              {
+                  "distinct_range": 54.55102040816327,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "4247"
+              },
+              {
+                  "distinct_range": 40.66530612244898,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "4289"
+              },
+              {
+                  "distinct_range": 60.502040816326534,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "4351"
+              },
+              {
+                  "distinct_range": 59.51020408163265,
+                  "num_eq": 240,
+                  "num_range": 3840,
+                  "upper_bound": "4412"
+              },
+              {
+                  "distinct_range": 37.689795918367345,
+                  "num_eq": 320,
+                  "num_range": 3680,
+                  "upper_bound": "4451"
+              },
+              {
+                  "distinct_range": 49.59183673469388,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "4502"
+              },
+              {
+                  "distinct_range": 44.63265306122449,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "4548"
+              },
+              {
+                  "distinct_range": 48.6,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "4598"
+              },
+              {
+                  "distinct_range": 58.518367346938774,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "4658"
+              },
+              {
+                  "distinct_range": 54.55102040816327,
+                  "num_eq": 240,
+                  "num_range": 3920,
+                  "upper_bound": "4714"
+              },
+              {
+                  "distinct_range": 46.61632653061225,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "4762"
+              },
+              {
+                  "distinct_range": 52.56734693877551,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "4816"
+              },
+              {
+                  "distinct_range": 59.51020408163265,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "4877"
+              },
+              {
+                  "distinct_range": 47.608163265306125,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "4926"
+              },
+              {
+                  "distinct_range": 57.5265306122449,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "4985"
+              },
+              {
+                  "distinct_range": 42.648979591836735,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "5029"
+              },
+              {
+                  "distinct_range": 43.64081632653061,
+                  "num_eq": 240,
+                  "num_range": 3760,
+                  "upper_bound": "5074"
+              },
+              {
+                  "distinct_range": 35.70612244897959,
+                  "num_eq": 320,
+                  "num_range": 3840,
+                  "upper_bound": "5111"
+              },
+              {
+                  "distinct_range": 55.542857142857144,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "5168"
+              },
+              {
+                  "distinct_range": 41.65714285714286,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "5211"
+              },
+              {
+                  "distinct_range": 62.48571428571429,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "5275"
+              },
+              {
+                  "distinct_range": 51.57551020408163,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "5328"
+              },
+              {
+                  "distinct_range": 63.477551020408164,
+                  "num_eq": 400,
+                  "num_range": 3920,
+                  "upper_bound": "5393"
+              },
+              {
+                  "distinct_range": 70.42040816326531,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "5465"
+              },
+              {
+                  "distinct_range": 46.61632653061225,
+                  "num_eq": 400,
+                  "num_range": 3760,
+                  "upper_bound": "5513"
+              },
+              {
+                  "distinct_range": 69.42857142857143,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "5584"
+              },
+              {
+                  "distinct_range": 48.6,
+                  "num_eq": 320,
+                  "num_range": 3920,
+                  "upper_bound": "5634"
+              },
+              {
+                  "distinct_range": 41.65714285714286,
+                  "num_eq": 240,
+                  "num_range": 3760,
+                  "upper_bound": "5677"
+              },
+              {
+                  "distinct_range": 47.608163265306125,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "5726"
+              },
+              {
+                  "distinct_range": 49.59183673469388,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "5777"
+              },
+              {
+                  "distinct_range": 46.61632653061225,
+                  "num_eq": 240,
+                  "num_range": 3760,
+                  "upper_bound": "5825"
+              },
+              {
+                  "distinct_range": 48.6,
+                  "num_eq": 160,
+                  "num_range": 3760,
+                  "upper_bound": "5875"
+              },
+              {
+                  "distinct_range": 41.65714285714286,
+                  "num_eq": 240,
+                  "num_range": 3840,
+                  "upper_bound": "5918"
+              },
+              {
+                  "distinct_range": 49.59183673469388,
+                  "num_eq": 80,
+                  "num_range": 3840,
+                  "upper_bound": "5969"
+              },
+              {
+                  "distinct_range": 57.5265306122449,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "6028"
+              },
+              {
+                  "distinct_range": 36.69795918367347,
+                  "num_eq": 80,
+                  "num_range": 3840,
+                  "upper_bound": "6066"
+              },
+              {
+                  "distinct_range": 56.53469387755102,
+                  "num_eq": 240,
+                  "num_range": 3920,
+                  "upper_bound": "6124"
+              },
+              {
+                  "distinct_range": 40.66530612244898,
+                  "num_eq": 80,
+                  "num_range": 3840,
+                  "upper_bound": "6166"
+              },
+              {
+                  "distinct_range": 45.624489795918365,
+                  "num_eq": 80,
+                  "num_range": 3840,
+                  "upper_bound": "6213"
+              },
+              {
+                  "distinct_range": 43.64081632653061,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "6258"
+              },
+              {
+                  "distinct_range": 59.51020408163265,
+                  "num_eq": 80,
+                  "num_range": 3840,
+                  "upper_bound": "6319"
+              },
+              {
+                  "distinct_range": 46.61632653061225,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "6367"
+              },
+              {
+                  "distinct_range": 51.57551020408163,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "6420"
+              },
+              {
+                  "distinct_range": 45.624489795918365,
+                  "num_eq": 80,
+                  "num_range": 3840,
+                  "upper_bound": "6467"
+              },
+              {
+                  "distinct_range": 40.66530612244898,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "6509"
+              },
+              {
+                  "distinct_range": 56.53469387755102,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "6567"
+              },
+              {
+                  "distinct_range": 49.59183673469388,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "6618"
+              },
+              {
+                  "distinct_range": 59.51020408163265,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "6679"
+              },
+              {
+                  "distinct_range": 46.61632653061225,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "6727"
+              },
+              {
+                  "distinct_range": 38.68163265306122,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "6767"
+              },
+              {
+                  "distinct_range": 55.542857142857144,
+                  "num_eq": 240,
+                  "num_range": 3840,
+                  "upper_bound": "6824"
+              },
+              {
+                  "distinct_range": 50.583673469387755,
+                  "num_eq": 80,
+                  "num_range": 3840,
+                  "upper_bound": "6876"
+              },
+              {
+                  "distinct_range": 45.624489795918365,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "6923"
+              },
+              {
+                  "distinct_range": 56.53469387755102,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "6981"
+              },
+              {
+                  "distinct_range": 45.624489795918365,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "7028"
+              },
+              {
+                  "distinct_range": 50.583673469387755,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "7080"
+              },
+              {
+                  "distinct_range": 50.583673469387755,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "7132"
+              },
+              {
+                  "distinct_range": 45.624489795918365,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "7179"
+              },
+              {
+                  "distinct_range": 55.542857142857144,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "7236"
+              },
+              {
+                  "distinct_range": 48.6,
+                  "num_eq": 160,
+                  "num_range": 3760,
+                  "upper_bound": "7286"
+              },
+              {
+                  "distinct_range": 51.57551020408163,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "7339"
+              },
+              {
+                  "distinct_range": 39.673469387755105,
+                  "num_eq": 80,
+                  "num_range": 3840,
+                  "upper_bound": "7380"
+              },
+              {
+                  "distinct_range": 41.65714285714286,
+                  "num_eq": 240,
+                  "num_range": 3840,
+                  "upper_bound": "7423"
+              },
+              {
+                  "distinct_range": 44.63265306122449,
+                  "num_eq": 80,
+                  "num_range": 3840,
+                  "upper_bound": "7469"
+              },
+              {
+                  "distinct_range": 63.477551020408164,
+                  "num_eq": 240,
+                  "num_range": 3840,
+                  "upper_bound": "7534"
+              },
+              {
+                  "distinct_range": 57.5265306122449,
+                  "num_eq": 160,
+                  "num_range": 3760,
+                  "upper_bound": "7593"
+              },
+              {
+                  "distinct_range": 51.57551020408163,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "7646"
+              },
+              {
+                  "distinct_range": 45.624489795918365,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "7693"
+              },
+              {
+                  "distinct_range": 38.68163265306122,
+                  "num_eq": 240,
+                  "num_range": 3840,
+                  "upper_bound": "7733"
+              },
+              {
+                  "distinct_range": 66.4530612244898,
+                  "num_eq": 80,
+                  "num_range": 3840,
+                  "upper_bound": "7801"
+              },
+              {
+                  "distinct_range": 34.714285714285715,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "7837"
+              },
+              {
+                  "distinct_range": 43.64081632653061,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "7882"
+              },
+              {
+                  "distinct_range": 45.624489795918365,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "7929"
+              },
+              {
+                  "distinct_range": 61.49387755102041,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "7992"
+              },
+              {
+                  "distinct_range": 47.608163265306125,
+                  "num_eq": 240,
+                  "num_range": 3680,
+                  "upper_bound": "8041"
+              },
+              {
+                  "distinct_range": 38.68163265306122,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "8081"
+              },
+              {
+                  "distinct_range": 39.673469387755105,
+                  "num_eq": 240,
+                  "num_range": 3920,
+                  "upper_bound": "8122"
+              },
+              {
+                  "distinct_range": 44.63265306122449,
+                  "num_eq": 240,
+                  "num_range": 3840,
+                  "upper_bound": "8168"
+              },
+              {
+                  "distinct_range": 56.53469387755102,
+                  "num_eq": 240,
+                  "num_range": 3840,
+                  "upper_bound": "8226"
+              },
+              {
+                  "distinct_range": 45.624489795918365,
+                  "num_eq": 320,
+                  "num_range": 3760,
+                  "upper_bound": "8273"
+              },
+              {
+                  "distinct_range": 43.64081632653061,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "8318"
+              },
+              {
+                  "distinct_range": 41.65714285714286,
+                  "num_eq": 160,
+                  "num_range": 3760,
+                  "upper_bound": "8361"
+              },
+              {
+                  "distinct_range": 47.608163265306125,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "8410"
+              },
+              {
+                  "distinct_range": 44.63265306122449,
+                  "num_eq": 240,
+                  "num_range": 3760,
+                  "upper_bound": "8456"
+              },
+              {
+                  "distinct_range": 40.66530612244898,
+                  "num_eq": 160,
+                  "num_range": 3760,
+                  "upper_bound": "8498"
+              },
+              {
+                  "distinct_range": 49.59183673469388,
+                  "num_eq": 80,
+                  "num_range": 3840,
+                  "upper_bound": "8549"
+              },
+              {
+                  "distinct_range": 46.61632653061225,
+                  "num_eq": 160,
+                  "num_range": 3760,
+                  "upper_bound": "8597"
+              },
+              {
+                  "distinct_range": 42.648979591836735,
+                  "num_eq": 240,
+                  "num_range": 3840,
+                  "upper_bound": "8641"
+              },
+              {
+                  "distinct_range": 44.63265306122449,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "8687"
+              },
+              {
+                  "distinct_range": 47.608163265306125,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "8736"
+              },
+              {
+                  "distinct_range": 53.55918367346939,
+                  "num_eq": 240,
+                  "num_range": 3840,
+                  "upper_bound": "8791"
+              },
+              {
+                  "distinct_range": 49.59183673469388,
+                  "num_eq": 80,
+                  "num_range": 3840,
+                  "upper_bound": "8842"
+              },
+              {
+                  "distinct_range": 46.61632653061225,
+                  "num_eq": 80,
+                  "num_range": 3840,
+                  "upper_bound": "8890"
+              },
+              {
+                  "distinct_range": 42.648979591836735,
+                  "num_eq": 160,
+                  "num_range": 3760,
+                  "upper_bound": "8934"
+              },
+              {
+                  "distinct_range": 55.542857142857144,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "8991"
+              },
+              {
+                  "distinct_range": 61.49387755102041,
+                  "num_eq": 240,
+                  "num_range": 3760,
+                  "upper_bound": "9054"
+              },
+              {
+                  "distinct_range": 40.66530612244898,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "9096"
+              },
+              {
+                  "distinct_range": 34.714285714285715,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "9132"
+              },
+              {
+                  "distinct_range": 57.5265306122449,
+                  "num_eq": 240,
+                  "num_range": 3760,
+                  "upper_bound": "9191"
+              },
+              {
+                  "distinct_range": 52.56734693877551,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "9245"
+              },
+              {
+                  "distinct_range": 44.63265306122449,
+                  "num_eq": 160,
+                  "num_range": 3760,
+                  "upper_bound": "9291"
+              },
+              {
+                  "distinct_range": 36.69795918367347,
+                  "num_eq": 320,
+                  "num_range": 3680,
+                  "upper_bound": "9329"
+              },
+              {
+                  "distinct_range": 43.64081632653061,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "9374"
+              },
+              {
+                  "distinct_range": 45.624489795918365,
+                  "num_eq": 240,
+                  "num_range": 3680,
+                  "upper_bound": "9421"
+              },
+              {
+                  "distinct_range": 47.608163265306125,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "9470"
+              },
+              {
+                  "distinct_range": 50.583673469387755,
+                  "num_eq": 160,
+                  "num_range": 3920,
+                  "upper_bound": "9522"
+              },
+              {
+                  "distinct_range": 65.46122448979592,
+                  "num_eq": 160,
+                  "num_range": 3760,
+                  "upper_bound": "9589"
+              },
+              {
+                  "distinct_range": 41.65714285714286,
+                  "num_eq": 80,
+                  "num_range": 3920,
+                  "upper_bound": "9632"
+              },
+              {
+                  "distinct_range": 47.608163265306125,
+                  "num_eq": 240,
+                  "num_range": 3920,
+                  "upper_bound": "9681"
+              },
+              {
+                  "distinct_range": 46.61632653061225,
+                  "num_eq": 240,
+                  "num_range": 3760,
+                  "upper_bound": "9729"
+              },
+              {
+                  "distinct_range": 33.72244897959184,
+                  "num_eq": 160,
+                  "num_range": 3840,
+                  "upper_bound": "9764"
+              },
+              {
+                  "distinct_range": 46.61632653061225,
+                  "num_eq": 320,
+                  "num_range": 3760,
+                  "upper_bound": "9812"
+              },
+              {
+                  "distinct_range": 50.583673469387755,
+                  "num_eq": 240,
+                  "num_range": 3840,
+                  "upper_bound": "9864"
+              },
+              {
+                  "distinct_range": 40.66530612244898,
+                  "num_eq": 80,
+                  "num_range": 3760,
+                  "upper_bound": "9906"
+              },
+              {
+                  "distinct_range": 47.608163265306125,
+                  "num_eq": 80,
+                  "num_range": 3840,
+                  "upper_bound": "9955"
+              },
+              {
+                  "distinct_range": 43.64081632653061,
+                  "num_eq": 80,
+                  "num_range": 3840,
+                  "upper_bound": "10000"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 800000
+      },
+      {
+          "avg_size": 7,
+          "columns": [
+              "ps_partkey",
+              "ps_suppkey"
+          ],
+          "created_at": "2022-03-21 20:30:20.942434",
+          "distinct_count": 798302,
+          "histo_col_type": "",
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 800000
+      },
+      {
+          "avg_size": 4,
+          "columns": [
+              "ps_availqty"
+          ],
+          "created_at": "2022-03-21 20:30:20.942434",
+          "distinct_count": 9920,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 80,
+                  "num_range": 0,
+                  "upper_bound": "1"
+              },
+              {
+                  "distinct_range": 9918,
+                  "num_eq": 80,
+                  "num_range": 799840,
+                  "upper_bound": "9997"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 800000
+      },
+      {
+          "avg_size": 9,
+          "columns": [
+              "ps_supplycost"
+          ],
+          "created_at": "2022-03-21 20:30:20.942434",
+          "distinct_count": 100379,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 80,
+                  "num_range": 0,
+                  "upper_bound": "1.01"
+              },
+              {
+                  "distinct_range": 100377,
+                  "num_eq": 80,
+                  "num_range": 799840,
+                  "upper_bound": "1000.0"
+              }
+          ],
+          "histo_col_type": "FLOAT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 800000
+      },
+      {
+          "avg_size": 127,
+          "columns": [
+              "ps_comment"
+          ],
+          "created_at": "2022-03-21 20:30:20.942434",
+          "distinct_count": 799641,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 80,
+                  "num_range": 0,
+                  "upper_bound": " about the blithely regular packages. slyly final requests shall cajole silent plate"
+              },
+              {
+                  "distinct_range": 799639,
+                  "num_eq": 80,
+                  "num_range": 799840,
+                  "upper_bound": "zle finally bold, unusual foxes. furiously unusual foxes affix quickly acc"
+              }
+          ],
+          "histo_col_type": "VARCHAR(199)",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 800000
+      }
+  ]'
 
 statement ok
 CREATE TABLE public.customer
@@ -264,59 +7467,1552 @@ CREATE TABLE public.customer
     c_comment varchar(117) NOT NULL,
     INDEX c_nk (c_nationkey ASC),
     CONSTRAINT customer_fkey_nation FOREIGN KEY (c_nationkey) references public.nation (n_nationkey)
-)
-
-statement ok
-ALTER TABLE public.customer INJECT STATISTICS '[
-  {
-    "columns": ["c_custkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 150000,
-    "distinct_count": 150000
-  },
-  {
-    "columns": ["c_name"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 150000,
-    "distinct_count": 150000
-  },
-  {
-    "columns": ["c_address"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 150000,
-    "distinct_count": 150000
-  },
-  {
-    "columns": ["c_nationkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 150000,
-    "distinct_count": 25
-  },
-  {
-    "columns": ["c_phone"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 150000,
-    "distinct_count": 150000
-  },
-  {
-    "columns": ["c_acctbal"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 150000,
-    "distinct_count": 150000
-  },
-  {
-    "columns": ["c_mktsegment"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 150000,
-    "distinct_count": 5
-  },
-  {
-    "columns": ["c_comment"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 150000,
-    "distinct_count": 150000
-  }
-]'
+);
+ALTER TABLE public.customer INJECT STATISTICS '
+  [
+      {
+          "avg_size": 4,
+          "columns": [
+              "c_custkey"
+          ],
+          "created_at": "2022-03-21 20:30:22.072367",
+          "distinct_count": 148813,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 5,
+                  "num_range": 0,
+                  "upper_bound": "15"
+              },
+              {
+                  "distinct_range": 700.8447027666897,
+                  "num_eq": 5,
+                  "num_range": 721,
+                  "upper_bound": "722"
+              },
+              {
+                  "distinct_range": 695.9191366315544,
+                  "num_eq": 5,
+                  "num_range": 718,
+                  "upper_bound": "1424"
+              },
+              {
+                  "distinct_range": 587.4769331541498,
+                  "num_eq": 5,
+                  "num_range": 664,
+                  "upper_bound": "2016"
+              },
+              {
+                  "distinct_range": 754.0237075380655,
+                  "num_eq": 5,
+                  "num_range": 749,
+                  "upper_bound": "2777"
+              },
+              {
+                  "distinct_range": 769.7748297692478,
+                  "num_eq": 5,
+                  "num_range": 758,
+                  "upper_bound": "3554"
+              },
+              {
+                  "distinct_range": 811.1104643792025,
+                  "num_eq": 5,
+                  "num_range": 781,
+                  "upper_bound": "4373"
+              },
+              {
+                  "distinct_range": 742.2087435736743,
+                  "num_eq": 5,
+                  "num_range": 743,
+                  "upper_bound": "5122"
+              },
+              {
+                  "distinct_range": 817.0143183743552,
+                  "num_eq": 5,
+                  "num_range": 784,
+                  "upper_bound": "5947"
+              },
+              {
+                  "distinct_range": 703.7999074767729,
+                  "num_eq": 5,
+                  "num_range": 722,
+                  "upper_bound": "6657"
+              },
+              {
+                  "distinct_range": 730.392338417097,
+                  "num_eq": 5,
+                  "num_range": 736,
+                  "upper_bound": "7394"
+              },
+              {
+                  "distinct_range": 728.4227941252499,
+                  "num_eq": 5,
+                  "num_range": 735,
+                  "upper_bound": "8129"
+              },
+              {
+                  "distinct_range": 688.0376371832414,
+                  "num_eq": 5,
+                  "num_range": 714,
+                  "upper_bound": "8823"
+              },
+              {
+                  "distinct_range": 700.8447027666897,
+                  "num_eq": 5,
+                  "num_range": 721,
+                  "upper_bound": "9530"
+              },
+              {
+                  "distinct_range": 825.8695476102893,
+                  "num_eq": 5,
+                  "num_range": 789,
+                  "upper_bound": "10364"
+              },
+              {
+                  "distinct_range": 633.8312305409071,
+                  "num_eq": 5,
+                  "num_range": 686,
+                  "upper_bound": "11003"
+              },
+              {
+                  "distinct_range": 815.0464000467725,
+                  "num_eq": 5,
+                  "num_range": 783,
+                  "upper_bound": "11826"
+              },
+              {
+                  "distinct_range": 672.2723861581921,
+                  "num_eq": 5,
+                  "num_range": 706,
+                  "upper_bound": "12504"
+              },
+              {
+                  "distinct_range": 768.7904553303003,
+                  "num_eq": 5,
+                  "num_range": 757,
+                  "upper_bound": "13280"
+              },
+              {
+                  "distinct_range": 658.4752386051898,
+                  "num_eq": 5,
+                  "num_range": 699,
+                  "upper_bound": "13944"
+              },
+              {
+                  "distinct_range": 638.7606936898434,
+                  "num_eq": 5,
+                  "num_range": 689,
+                  "upper_bound": "14588"
+              },
+              {
+                  "distinct_range": 738.2701042999953,
+                  "num_eq": 5,
+                  "num_range": 741,
+                  "upper_bound": "15333"
+              },
+              {
+                  "distinct_range": 722.5139108720263,
+                  "num_eq": 5,
+                  "num_range": 732,
+                  "upper_bound": "16062"
+              },
+              {
+                  "distinct_range": 705.7699882304483,
+                  "num_eq": 5,
+                  "num_range": 723,
+                  "upper_bound": "16774"
+              },
+              {
+                  "distinct_range": 730.392338417097,
+                  "num_eq": 5,
+                  "num_range": 736,
+                  "upper_bound": "17511"
+              },
+              {
+                  "distinct_range": 653.5470890808342,
+                  "num_eq": 5,
+                  "num_range": 696,
+                  "upper_bound": "18170"
+              },
+              {
+                  "distinct_range": 738.2701042999953,
+                  "num_eq": 5,
+                  "num_range": 741,
+                  "upper_bound": "18915"
+              },
+              {
+                  "distinct_range": 788.4762074360158,
+                  "num_eq": 5,
+                  "num_range": 768,
+                  "upper_bound": "19711"
+              },
+              {
+                  "distinct_range": 632.8452972182523,
+                  "num_eq": 5,
+                  "num_range": 686,
+                  "upper_bound": "20349"
+              },
+              {
+                  "distinct_range": 671.2869559054976,
+                  "num_eq": 5,
+                  "num_range": 705,
+                  "upper_bound": "21026"
+              },
+              {
+                  "distinct_range": 703.7999074767729,
+                  "num_eq": 5,
+                  "num_range": 722,
+                  "upper_bound": "21736"
+              },
+              {
+                  "distinct_range": 660.4464094581657,
+                  "num_eq": 5,
+                  "num_range": 700,
+                  "upper_bound": "22402"
+              },
+              {
+                  "distinct_range": 564.780613135648,
+                  "num_eq": 5,
+                  "num_range": 653,
+                  "upper_bound": "22971"
+              },
+              {
+                  "distinct_range": 850.4640479590666,
+                  "num_eq": 5,
+                  "num_range": 804,
+                  "upper_bound": "23830"
+              },
+              {
+                  "distinct_range": 706.7550119837703,
+                  "num_eq": 5,
+                  "num_range": 724,
+                  "upper_bound": "24543"
+              },
+              {
+                  "distinct_range": 804.2222557357369,
+                  "num_eq": 5,
+                  "num_range": 777,
+                  "upper_bound": "25355"
+              },
+              {
+                  "distinct_range": 532.2006886454468,
+                  "num_eq": 5,
+                  "num_range": 639,
+                  "upper_bound": "25891"
+              },
+              {
+                  "distinct_range": 776.6651922146928,
+                  "num_eq": 5,
+                  "num_range": 762,
+                  "upper_bound": "26675"
+              },
+              {
+                  "distinct_range": 881.9381868342042,
+                  "num_eq": 5,
+                  "num_range": 822,
+                  "upper_bound": "27566"
+              },
+              {
+                  "distinct_range": 829.8049959298135,
+                  "num_eq": 5,
+                  "num_range": 792,
+                  "upper_bound": "28404"
+              },
+              {
+                  "distinct_range": 740.2394440596585,
+                  "num_eq": 5,
+                  "num_range": 742,
+                  "upper_bound": "29151"
+              },
+              {
+                  "distinct_range": 914.3884423220102,
+                  "num_eq": 5,
+                  "num_range": 841,
+                  "upper_bound": "30075"
+              },
+              {
+                  "distinct_range": 748.1164028025115,
+                  "num_eq": 5,
+                  "num_range": 746,
+                  "upper_bound": "30830"
+              },
+              {
+                  "distinct_range": 763.8684429875158,
+                  "num_eq": 5,
+                  "num_range": 755,
+                  "upper_bound": "31601"
+              },
+              {
+                  "distinct_range": 810.1264597108468,
+                  "num_eq": 5,
+                  "num_range": 781,
+                  "upper_bound": "32419"
+              },
+              {
+                  "distinct_range": 678.1847131484741,
+                  "num_eq": 5,
+                  "num_range": 709,
+                  "upper_bound": "33103"
+              },
+              {
+                  "distinct_range": 841.6105849129785,
+                  "num_eq": 5,
+                  "num_range": 799,
+                  "upper_bound": "33953"
+              },
+              {
+                  "distinct_range": 1050.0194908203086,
+                  "num_eq": 5,
+                  "num_range": 924,
+                  "upper_bound": "35015"
+              },
+              {
+                  "distinct_range": 648.6186181949298,
+                  "num_eq": 5,
+                  "num_range": 694,
+                  "upper_bound": "35669"
+              },
+              {
+                  "distinct_range": 694.9339893792874,
+                  "num_eq": 5,
+                  "num_range": 718,
+                  "upper_bound": "36370"
+              },
+              {
+                  "distinct_range": 663.4030713296414,
+                  "num_eq": 5,
+                  "num_range": 701,
+                  "upper_bound": "37039"
+              },
+              {
+                  "distinct_range": 851.4477282256619,
+                  "num_eq": 5,
+                  "num_range": 804,
+                  "upper_bound": "37899"
+              },
+              {
+                  "distinct_range": 694.9339893792874,
+                  "num_eq": 5,
+                  "num_range": 718,
+                  "upper_bound": "38600"
+              },
+              {
+                  "distinct_range": 764.8528642252398,
+                  "num_eq": 5,
+                  "num_range": 755,
+                  "upper_bound": "39372"
+              },
+              {
+                  "distinct_range": 935.0349309173125,
+                  "num_eq": 5,
+                  "num_range": 853,
+                  "upper_bound": "40317"
+              },
+              {
+                  "distinct_range": 825.8695476102893,
+                  "num_eq": 5,
+                  "num_range": 789,
+                  "upper_bound": "41151"
+              },
+              {
+                  "distinct_range": 947.8147329358184,
+                  "num_eq": 5,
+                  "num_range": 861,
+                  "upper_bound": "42109"
+              },
+              {
+                  "distinct_range": 665.374116722245,
+                  "num_eq": 5,
+                  "num_range": 702,
+                  "upper_bound": "42780"
+              },
+              {
+                  "distinct_range": 720.5441988986768,
+                  "num_eq": 5,
+                  "num_range": 731,
+                  "upper_bound": "43507"
+              },
+              {
+                  "distinct_range": 1049.0370137858606,
+                  "num_eq": 5,
+                  "num_range": 923,
+                  "upper_bound": "44568"
+              },
+              {
+                  "distinct_range": 747.1318177031445,
+                  "num_eq": 5,
+                  "num_range": 746,
+                  "upper_bound": "45322"
+              },
+              {
+                  "distinct_range": 785.5235744501533,
+                  "num_eq": 5,
+                  "num_range": 767,
+                  "upper_bound": "46115"
+              },
+              {
+                  "distinct_range": 740.2394440596585,
+                  "num_eq": 5,
+                  "num_range": 742,
+                  "upper_bound": "46862"
+              },
+              {
+                  "distinct_range": 779.6180674750517,
+                  "num_eq": 5,
+                  "num_range": 763,
+                  "upper_bound": "47649"
+              },
+              {
+                  "distinct_range": 637.774828057985,
+                  "num_eq": 5,
+                  "num_range": 688,
+                  "upper_bound": "48292"
+              },
+              {
+                  "distinct_range": 788.4762074360158,
+                  "num_eq": 5,
+                  "num_range": 768,
+                  "upper_bound": "49088"
+              },
+              {
+                  "distinct_range": 717.5895511846062,
+                  "num_eq": 5,
+                  "num_range": 730,
+                  "upper_bound": "49812"
+              },
+              {
+                  "distinct_range": 932.0856004928586,
+                  "num_eq": 5,
+                  "num_range": 852,
+                  "upper_bound": "50754"
+              },
+              {
+                  "distinct_range": 623.9712779938886,
+                  "num_eq": 5,
+                  "num_range": 681,
+                  "upper_bound": "51383"
+              },
+              {
+                  "distinct_range": 733.3465773900681,
+                  "num_eq": 5,
+                  "num_range": 738,
+                  "upper_bound": "52123"
+              },
+              {
+                  "distinct_range": 654.5327445475119,
+                  "num_eq": 5,
+                  "num_range": 697,
+                  "upper_bound": "52783"
+              },
+              {
+                  "distinct_range": 778.6337847971893,
+                  "num_eq": 5,
+                  "num_range": 763,
+                  "upper_bound": "53569"
+              },
+              {
+                  "distinct_range": 779.6180674750517,
+                  "num_eq": 5,
+                  "num_range": 763,
+                  "upper_bound": "54356"
+              },
+              {
+                  "distinct_range": 722.5139108720263,
+                  "num_eq": 5,
+                  "num_range": 732,
+                  "upper_bound": "55085"
+              },
+              {
+                  "distinct_range": 689.0228650181328,
+                  "num_eq": 5,
+                  "num_range": 714,
+                  "upper_bound": "55780"
+              },
+              {
+                  "distinct_range": 742.2087435736743,
+                  "num_eq": 5,
+                  "num_range": 743,
+                  "upper_bound": "56529"
+              },
+              {
+                  "distinct_range": 690.9932858947152,
+                  "num_eq": 5,
+                  "num_range": 716,
+                  "upper_bound": "57226"
+              },
+              {
+                  "distinct_range": 725.468399658146,
+                  "num_eq": 5,
+                  "num_range": 734,
+                  "upper_bound": "57958"
+              },
+              {
+                  "distinct_range": 908.4889320581121,
+                  "num_eq": 5,
+                  "num_range": 838,
+                  "upper_bound": "58876"
+              },
+              {
+                  "distinct_range": 753.0391811248085,
+                  "num_eq": 5,
+                  "num_range": 749,
+                  "upper_bound": "59636"
+              },
+              {
+                  "distinct_range": 978.2856627162416,
+                  "num_eq": 5,
+                  "num_range": 880,
+                  "upper_bound": "60625"
+              },
+              {
+                  "distinct_range": 775.6808822621924,
+                  "num_eq": 5,
+                  "num_range": 761,
+                  "upper_bound": "61408"
+              },
+              {
+                  "distinct_range": 798.317746711082,
+                  "num_eq": 5,
+                  "num_range": 774,
+                  "upper_bound": "62214"
+              },
+              {
+                  "distinct_range": 592.4098015550186,
+                  "num_eq": 5,
+                  "num_range": 666,
+                  "upper_bound": "62811"
+              },
+              {
+                  "distinct_range": 779.6180674750517,
+                  "num_eq": 5,
+                  "num_range": 763,
+                  "upper_bound": "63598"
+              },
+              {
+                  "distinct_range": 776.6651922146928,
+                  "num_eq": 5,
+                  "num_range": 762,
+                  "upper_bound": "64382"
+              },
+              {
+                  "distinct_range": 710.6949968861195,
+                  "num_eq": 5,
+                  "num_range": 726,
+                  "upper_bound": "65099"
+              },
+              {
+                  "distinct_range": 800.2859505731867,
+                  "num_eq": 5,
+                  "num_range": 775,
+                  "upper_bound": "65907"
+              },
+              {
+                  "distinct_range": 731.3770950419777,
+                  "num_eq": 5,
+                  "num_range": 737,
+                  "upper_bound": "66645"
+              },
+              {
+                  "distinct_range": 749.1009780551038,
+                  "num_eq": 5,
+                  "num_range": 747,
+                  "upper_bound": "67401"
+              },
+              {
+                  "distinct_range": 728.4227941252499,
+                  "num_eq": 5,
+                  "num_range": 735,
+                  "upper_bound": "68136"
+              },
+              {
+                  "distinct_range": 859.3169018979008,
+                  "num_eq": 5,
+                  "num_range": 809,
+                  "upper_bound": "69004"
+              },
+              {
+                  "distinct_range": 725.468399658146,
+                  "num_eq": 5,
+                  "num_range": 734,
+                  "upper_bound": "69736"
+              },
+              {
+                  "distinct_range": 769.7748297692478,
+                  "num_eq": 5,
+                  "num_range": 758,
+                  "upper_bound": "70513"
+              },
+              {
+                  "distinct_range": 751.0700991255578,
+                  "num_eq": 5,
+                  "num_range": 748,
+                  "upper_bound": "71271"
+              },
+              {
+                  "distinct_range": 808.1584253226281,
+                  "num_eq": 5,
+                  "num_range": 779,
+                  "upper_bound": "72087"
+              },
+              {
+                  "distinct_range": 694.9339893792874,
+                  "num_eq": 5,
+                  "num_range": 718,
+                  "upper_bound": "72788"
+              },
+              {
+                  "distinct_range": 680.1553926673962,
+                  "num_eq": 5,
+                  "num_range": 710,
+                  "upper_bound": "73474"
+              },
+              {
+                  "distinct_range": 771.7435508150025,
+                  "num_eq": 5,
+                  "num_range": 759,
+                  "upper_bound": "74253"
+              },
+              {
+                  "distinct_range": 795.3653763166207,
+                  "num_eq": 5,
+                  "num_range": 772,
+                  "upper_bound": "75056"
+              },
+              {
+                  "distinct_range": 882.9216360691291,
+                  "num_eq": 5,
+                  "num_range": 823,
+                  "upper_bound": "75948"
+              },
+              {
+                  "distinct_range": 527.2626271706871,
+                  "num_eq": 5,
+                  "num_range": 636,
+                  "upper_bound": "76479"
+              },
+              {
+                  "distinct_range": 664.3886002544132,
+                  "num_eq": 5,
+                  "num_range": 702,
+                  "upper_bound": "77149"
+              },
+              {
+                  "distinct_range": 714.634807062936,
+                  "num_eq": 5,
+                  "num_range": 728,
+                  "upper_bound": "77870"
+              },
+              {
+                  "distinct_range": 809.1424466991548,
+                  "num_eq": 5,
+                  "num_range": 780,
+                  "upper_bound": "78687"
+              },
+              {
+                  "distinct_range": 873.0868290268882,
+                  "num_eq": 5,
+                  "num_range": 817,
+                  "upper_bound": "79569"
+              },
+              {
+                  "distinct_range": 700.8447027666897,
+                  "num_eq": 5,
+                  "num_range": 721,
+                  "upper_bound": "80276"
+              },
+              {
+                  "distinct_range": 839.643064571583,
+                  "num_eq": 5,
+                  "num_range": 797,
+                  "upper_bound": "81124"
+              },
+              {
+                  "distinct_range": 720.5441988986768,
+                  "num_eq": 5,
+                  "num_range": 731,
+                  "upper_bound": "81851"
+              },
+              {
+                  "distinct_range": 632.8452972182523,
+                  "num_eq": 5,
+                  "num_range": 686,
+                  "upper_bound": "82489"
+              },
+              {
+                  "distinct_range": 766.8216784971561,
+                  "num_eq": 5,
+                  "num_range": 756,
+                  "upper_bound": "83263"
+              },
+              {
+                  "distinct_range": 696.9042724999717,
+                  "num_eq": 5,
+                  "num_range": 719,
+                  "upper_bound": "83966"
+              },
+              {
+                  "distinct_range": 606.2198025867727,
+                  "num_eq": 5,
+                  "num_range": 673,
+                  "upper_bound": "84577"
+              },
+              {
+                  "distinct_range": 826.8534216525113,
+                  "num_eq": 5,
+                  "num_range": 790,
+                  "upper_bound": "85412"
+              },
+              {
+                  "distinct_range": 830.7888381398194,
+                  "num_eq": 5,
+                  "num_range": 792,
+                  "upper_bound": "86251"
+              },
+              {
+                  "distinct_range": 850.4640479590666,
+                  "num_eq": 5,
+                  "num_range": 804,
+                  "upper_bound": "87110"
+              },
+              {
+                  "distinct_range": 712.6649236949465,
+                  "num_eq": 5,
+                  "num_range": 727,
+                  "upper_bound": "87829"
+              },
+              {
+                  "distinct_range": 713.6498707941018,
+                  "num_eq": 5,
+                  "num_range": 727,
+                  "upper_bound": "88549"
+              },
+              {
+                  "distinct_range": 751.0700991255578,
+                  "num_eq": 5,
+                  "num_range": 748,
+                  "upper_bound": "89307"
+              },
+              {
+                  "distinct_range": 863.251311679599,
+                  "num_eq": 5,
+                  "num_range": 811,
+                  "upper_bound": "90179"
+              },
+              {
+                  "distinct_range": 578.5967812351441,
+                  "num_eq": 5,
+                  "num_range": 660,
+                  "upper_bound": "90762"
+              },
+              {
+                  "distinct_range": 781.5866057230771,
+                  "num_eq": 5,
+                  "num_range": 765,
+                  "upper_bound": "91551"
+              },
+              {
+                  "distinct_range": 724.4835805808478,
+                  "num_eq": 5,
+                  "num_range": 733,
+                  "upper_bound": "92282"
+              },
+              {
+                  "distinct_range": 666.3596207685042,
+                  "num_eq": 5,
+                  "num_range": 703,
+                  "upper_bound": "92954"
+              },
+              {
+                  "distinct_range": 662.4175299124396,
+                  "num_eq": 5,
+                  "num_range": 701,
+                  "upper_bound": "93622"
+              },
+              {
+                  "distinct_range": 757.9617165538068,
+                  "num_eq": 5,
+                  "num_range": 751,
+                  "upper_bound": "94387"
+              },
+              {
+                  "distinct_range": 723.498750995061,
+                  "num_eq": 5,
+                  "num_range": 733,
+                  "upper_bound": "95117"
+              },
+              {
+                  "distinct_range": 657.4896341891418,
+                  "num_eq": 5,
+                  "num_range": 698,
+                  "upper_bound": "95780"
+              },
+              {
+                  "distinct_range": 644.6756069893564,
+                  "num_eq": 5,
+                  "num_range": 692,
+                  "upper_bound": "96430"
+              },
+              {
+                  "distinct_range": 671.2869559054976,
+                  "num_eq": 5,
+                  "num_range": 705,
+                  "upper_bound": "97107"
+              },
+              {
+                  "distinct_range": 781.5866057230771,
+                  "num_eq": 5,
+                  "num_range": 765,
+                  "upper_bound": "97896"
+              },
+              {
+                  "distinct_range": 670.301513440873,
+                  "num_eq": 5,
+                  "num_range": 705,
+                  "upper_bound": "98572"
+              },
+              {
+                  "distinct_range": 746.1472227304919,
+                  "num_eq": 5,
+                  "num_range": 745,
+                  "upper_bound": "99325"
+              },
+              {
+                  "distinct_range": 676.2139857382316,
+                  "num_eq": 5,
+                  "num_range": 708,
+                  "upper_bound": "100007"
+              },
+              {
+                  "distinct_range": 856.3660174217255,
+                  "num_eq": 5,
+                  "num_range": 807,
+                  "upper_bound": "100872"
+              },
+              {
+                  "distinct_range": 813.0784487715463,
+                  "num_eq": 5,
+                  "num_range": 782,
+                  "upper_bound": "101693"
+              },
+              {
+                  "distinct_range": 961.5764784827527,
+                  "num_eq": 5,
+                  "num_range": 869,
+                  "upper_bound": "102665"
+              },
+              {
+                  "distinct_range": 743.1933783063712,
+                  "num_eq": 5,
+                  "num_range": 743,
+                  "upper_bound": "103415"
+              },
+              {
+                  "distinct_range": 825.8695476102893,
+                  "num_eq": 5,
+                  "num_range": 789,
+                  "upper_bound": "104249"
+              },
+              {
+                  "distinct_range": 806.1903573887253,
+                  "num_eq": 5,
+                  "num_range": 778,
+                  "upper_bound": "105063"
+              },
+              {
+                  "distinct_range": 728.4227941252499,
+                  "num_eq": 5,
+                  "num_range": 735,
+                  "upper_bound": "105798"
+              },
+              {
+                  "distinct_range": 636.7889489662206,
+                  "num_eq": 5,
+                  "num_range": 688,
+                  "upper_bound": "106440"
+              },
+              {
+                  "distinct_range": 714.634807062936,
+                  "num_eq": 5,
+                  "num_range": 728,
+                  "upper_bound": "107161"
+              },
+              {
+                  "distinct_range": 743.1933783063712,
+                  "num_eq": 5,
+                  "num_range": 743,
+                  "upper_bound": "107911"
+              },
+              {
+                  "distinct_range": 911.4387162657852,
+                  "num_eq": 5,
+                  "num_range": 839,
+                  "upper_bound": "108832"
+              },
+              {
+                  "distinct_range": 763.8684429875158,
+                  "num_eq": 5,
+                  "num_range": 755,
+                  "upper_bound": "109603"
+              },
+              {
+                  "distinct_range": 770.7591949226357,
+                  "num_eq": 5,
+                  "num_range": 759,
+                  "upper_bound": "110381"
+              },
+              {
+                  "distinct_range": 636.7889489662206,
+                  "num_eq": 5,
+                  "num_range": 688,
+                  "upper_bound": "111023"
+              },
+              {
+                  "distinct_range": 716.6046472285801,
+                  "num_eq": 5,
+                  "num_range": 729,
+                  "upper_bound": "111746"
+              },
+              {
+                  "distinct_range": 626.9294091080875,
+                  "num_eq": 5,
+                  "num_range": 683,
+                  "upper_bound": "112378"
+              },
+              {
+                  "distinct_range": 636.7889489662206,
+                  "num_eq": 5,
+                  "num_range": 688,
+                  "upper_bound": "113020"
+              },
+              {
+                  "distinct_range": 631.9559395228868,
+                  "num_eq": 5,
+                  "num_range": 693,
+                  "upper_bound": "113657"
+              },
+              {
+                  "distinct_range": 750.2018134413983,
+                  "num_eq": 5,
+                  "num_range": 754,
+                  "upper_bound": "114414"
+              },
+              {
+                  "distinct_range": 717.700720855904,
+                  "num_eq": 5,
+                  "num_range": 737,
+                  "upper_bound": "115138"
+              },
+              {
+                  "distinct_range": 781.707609554438,
+                  "num_eq": 5,
+                  "num_range": 771,
+                  "upper_bound": "115927"
+              },
+              {
+                  "distinct_range": 652.6616855758153,
+                  "num_eq": 5,
+                  "num_range": 703,
+                  "upper_bound": "116585"
+              },
+              {
+                  "distinct_range": 660.5480478554827,
+                  "num_eq": 5,
+                  "num_range": 707,
+                  "upper_bound": "117251"
+              },
+              {
+                  "distinct_range": 598.4191564786271,
+                  "num_eq": 5,
+                  "num_range": 677,
+                  "upper_bound": "117854"
+              },
+              {
+                  "distinct_range": 861.4162393883197,
+                  "num_eq": 5,
+                  "num_range": 816,
+                  "upper_bound": "118724"
+              },
+              {
+                  "distinct_range": 668.4335891857676,
+                  "num_eq": 5,
+                  "num_range": 711,
+                  "upper_bound": "119398"
+              },
+              {
+                  "distinct_range": 762.0176412745299,
+                  "num_eq": 5,
+                  "num_range": 761,
+                  "upper_bound": "120167"
+              },
+              {
+                  "distinct_range": 686.1731493312136,
+                  "num_eq": 5,
+                  "num_range": 720,
+                  "upper_bound": "120859"
+              },
+              {
+                  "distinct_range": 602.3655493004696,
+                  "num_eq": 5,
+                  "num_range": 679,
+                  "upper_bound": "121466"
+              },
+              {
+                  "distinct_range": 786.6295195896787,
+                  "num_eq": 5,
+                  "num_range": 774,
+                  "upper_bound": "122260"
+              },
+              {
+                  "distinct_range": 604.3386544003667,
+                  "num_eq": 5,
+                  "num_range": 680,
+                  "upper_bound": "122869"
+              },
+              {
+                  "distinct_range": 658.5765349735622,
+                  "num_eq": 5,
+                  "num_range": 706,
+                  "upper_bound": "123533"
+              },
+              {
+                  "distinct_range": 693.070812686024,
+                  "num_eq": 5,
+                  "num_range": 724,
+                  "upper_bound": "124232"
+              },
+              {
+                  "distinct_range": 885.0237020596921,
+                  "num_eq": 5,
+                  "num_range": 830,
+                  "upper_bound": "125126"
+              },
+              {
+                  "distinct_range": 856.4974834340428,
+                  "num_eq": 5,
+                  "num_range": 814,
+                  "upper_bound": "125991"
+              },
+              {
+                  "distinct_range": 705.8792463169005,
+                  "num_eq": 5,
+                  "num_range": 731,
+                  "upper_bound": "126703"
+              },
+              {
+                  "distinct_range": 931.2434073579432,
+                  "num_eq": 5,
+                  "num_range": 857,
+                  "upper_bound": "127644"
+              },
+              {
+                  "distinct_range": 812.2198605189546,
+                  "num_eq": 5,
+                  "num_range": 788,
+                  "upper_bound": "128464"
+              },
+              {
+                  "distinct_range": 693.070812686024,
+                  "num_eq": 5,
+                  "num_range": 724,
+                  "upper_bound": "129163"
+              },
+              {
+                  "distinct_range": 942.0587122047463,
+                  "num_eq": 5,
+                  "num_range": 864,
+                  "upper_bound": "130115"
+              },
+              {
+                  "distinct_range": 830.9168435538569,
+                  "num_eq": 5,
+                  "num_range": 799,
+                  "upper_bound": "130954"
+              },
+              {
+                  "distinct_range": 784.6607829579225,
+                  "num_eq": 5,
+                  "num_range": 773,
+                  "upper_bound": "131746"
+              },
+              {
+                  "distinct_range": 699.9679027767983,
+                  "num_eq": 5,
+                  "num_range": 727,
+                  "upper_bound": "132452"
+              },
+              {
+                  "distinct_range": 722.6258679662737,
+                  "num_eq": 5,
+                  "num_range": 739,
+                  "upper_bound": "133181"
+              },
+              {
+                  "distinct_range": 823.0447936980177,
+                  "num_eq": 5,
+                  "num_range": 794,
+                  "upper_bound": "134012"
+              },
+              {
+                  "distinct_range": 793.5198132494162,
+                  "num_eq": 5,
+                  "num_range": 778,
+                  "upper_bound": "134813"
+              },
+              {
+                  "distinct_range": 1052.138852180228,
+                  "num_eq": 5,
+                  "num_range": 930,
+                  "upper_bound": "135877"
+              },
+              {
+                  "distinct_range": 809.2674290062062,
+                  "num_eq": 5,
+                  "num_range": 787,
+                  "upper_bound": "136694"
+              },
+              {
+                  "distinct_range": 890.9249227513357,
+                  "num_eq": 5,
+                  "num_range": 833,
+                  "upper_bound": "137594"
+              },
+              {
+                  "distinct_range": 785.645155821743,
+                  "num_eq": 5,
+                  "num_range": 774,
+                  "upper_bound": "138387"
+              },
+              {
+                  "distinct_range": 674.3472174341429,
+                  "num_eq": 5,
+                  "num_range": 714,
+                  "upper_bound": "139067"
+              },
+              {
+                  "distinct_range": 570.7873577777646,
+                  "num_eq": 5,
+                  "num_range": 664,
+                  "upper_bound": "139642"
+              },
+              {
+                  "distinct_range": 658.5765349735622,
+                  "num_eq": 5,
+                  "num_range": 706,
+                  "upper_bound": "140306"
+              },
+              {
+                  "distinct_range": 940.0923490879684,
+                  "num_eq": 5,
+                  "num_range": 862,
+                  "upper_bound": "141256"
+              },
+              {
+                  "distinct_range": 736.4148579424283,
+                  "num_eq": 5,
+                  "num_range": 747,
+                  "upper_bound": "141999"
+              },
+              {
+                  "distinct_range": 766.9404886915592,
+                  "num_eq": 5,
+                  "num_range": 763,
+                  "upper_bound": "142773"
+              },
+              {
+                  "distinct_range": 813.2039873554761,
+                  "num_eq": 5,
+                  "num_range": 789,
+                  "upper_bound": "143594"
+              },
+              {
+                  "distinct_range": 730.5055444071976,
+                  "num_eq": 5,
+                  "num_range": 744,
+                  "upper_bound": "144331"
+              },
+              {
+                  "distinct_range": 590.5256303262046,
+                  "num_eq": 5,
+                  "num_range": 673,
+                  "upper_bound": "144926"
+              },
+              {
+                  "distinct_range": 685.1877214045693,
+                  "num_eq": 5,
+                  "num_range": 720,
+                  "upper_bound": "145617"
+              },
+              {
+                  "distinct_range": 851.5785379628296,
+                  "num_eq": 5,
+                  "num_range": 811,
+                  "upper_bound": "146477"
+              },
+              {
+                  "distinct_range": 684.2022815171979,
+                  "num_eq": 5,
+                  "num_range": 719,
+                  "upper_bound": "147167"
+              },
+              {
+                  "distinct_range": 615.1896620706967,
+                  "num_eq": 5,
+                  "num_range": 685,
+                  "upper_bound": "147787"
+              },
+              {
+                  "distinct_range": 744.2933624789897,
+                  "num_eq": 5,
+                  "num_range": 751,
+                  "upper_bound": "148538"
+              },
+              {
+                  "distinct_range": 689.129361677507,
+                  "num_eq": 5,
+                  "num_range": 722,
+                  "upper_bound": "149233"
+              },
+              {
+                  "distinct_range": 757.0945517265703,
+                  "num_eq": 5,
+                  "num_range": 758,
+                  "upper_bound": "149997"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 150000
+      },
+      {
+          "avg_size": 2,
+          "columns": [
+              "c_nationkey"
+          ],
+          "created_at": "2022-03-21 20:30:22.072367",
+          "distinct_count": 25,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 5925,
+                  "num_range": 0,
+                  "upper_bound": "0"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 6255,
+                  "num_range": 0,
+                  "upper_bound": "1"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 6045,
+                  "num_range": 0,
+                  "upper_bound": "2"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 6165,
+                  "num_range": 0,
+                  "upper_bound": "3"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 6210,
+                  "num_range": 0,
+                  "upper_bound": "4"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 5865,
+                  "num_range": 0,
+                  "upper_bound": "5"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 6075,
+                  "num_range": 0,
+                  "upper_bound": "6"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 5505,
+                  "num_range": 0,
+                  "upper_bound": "7"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 5595,
+                  "num_range": 0,
+                  "upper_bound": "8"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 6150,
+                  "num_range": 0,
+                  "upper_bound": "9"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 5685,
+                  "num_range": 0,
+                  "upper_bound": "10"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 5820,
+                  "num_range": 0,
+                  "upper_bound": "11"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 6060,
+                  "num_range": 0,
+                  "upper_bound": "12"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 6195,
+                  "num_range": 0,
+                  "upper_bound": "13"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 6030,
+                  "num_range": 0,
+                  "upper_bound": "14"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 5910,
+                  "num_range": 0,
+                  "upper_bound": "15"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 5790,
+                  "num_range": 0,
+                  "upper_bound": "16"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 6225,
+                  "num_range": 0,
+                  "upper_bound": "17"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 5580,
+                  "num_range": 0,
+                  "upper_bound": "18"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 6225,
+                  "num_range": 0,
+                  "upper_bound": "19"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 6090,
+                  "num_range": 0,
+                  "upper_bound": "20"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 6480,
+                  "num_range": 0,
+                  "upper_bound": "21"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 6210,
+                  "num_range": 0,
+                  "upper_bound": "22"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 6360,
+                  "num_range": 0,
+                  "upper_bound": "23"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 5550,
+                  "num_range": 0,
+                  "upper_bound": "24"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 150000
+      },
+      {
+          "avg_size": 20,
+          "columns": [
+              "c_name"
+          ],
+          "created_at": "2022-03-21 20:30:22.072367",
+          "distinct_count": 150000,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "Customer#000000015"
+              },
+              {
+                  "distinct_range": 149998,
+                  "num_eq": 1,
+                  "num_range": 149998,
+                  "upper_bound": "Customer#000149997"
+              }
+          ],
+          "histo_col_type": "VARCHAR(25)",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 150000
+      },
+      {
+          "avg_size": 28,
+          "columns": [
+              "c_address"
+          ],
+          "created_at": "2022-03-21 20:30:22.072367",
+          "distinct_count": 149937,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 15,
+                  "num_range": 0,
+                  "upper_bound": "   5L06W67,Mw8G"
+              },
+              {
+                  "distinct_range": 149935,
+                  "num_eq": 15,
+                  "num_range": 149970,
+                  "upper_bound": "zzxGktzXTMKS1BxZlgQ9nqQ"
+              }
+          ],
+          "histo_col_type": "VARCHAR(40)",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 150000
+      },
+      {
+          "avg_size": 17,
+          "columns": [
+              "c_phone"
+          ],
+          "created_at": "2022-03-21 20:30:22.072367",
+          "distinct_count": 150000,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "10-101-769-8567"
+              },
+              {
+                  "distinct_range": 149998,
+                  "num_eq": 1,
+                  "num_range": 149998,
+                  "upper_bound": "34-998-190-8709"
+              }
+          ],
+          "histo_col_type": "CHAR(15)",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 150000
+      },
+      {
+          "avg_size": 9,
+          "columns": [
+              "c_acctbal"
+          ],
+          "created_at": "2022-03-21 20:30:22.072367",
+          "distinct_count": 140628,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 15,
+                  "num_range": 0,
+                  "upper_bound": "-999.95"
+              },
+              {
+                  "distinct_range": 140626,
+                  "num_eq": 15,
+                  "num_range": 149970,
+                  "upper_bound": "9998.97"
+              }
+          ],
+          "histo_col_type": "FLOAT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 150000
+      },
+      {
+          "avg_size": 11,
+          "columns": [
+              "c_mktsegment"
+          ],
+          "created_at": "2022-03-21 20:30:22.072367",
+          "distinct_count": 5,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 29760,
+                  "num_range": 0,
+                  "upper_bound": "AUTOMOBILE"
+              },
+              {
+                  "distinct_range": 3,
+                  "num_eq": 30990,
+                  "num_range": 89250,
+                  "upper_bound": "MACHINERY"
+              }
+          ],
+          "histo_col_type": "CHAR(10)",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 150000
+      },
+      {
+          "avg_size": 75,
+          "columns": [
+              "c_comment"
+          ],
+          "created_at": "2022-03-21 20:30:22.072367",
+          "distinct_count": 149323,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 15,
+                  "num_range": 0,
+                  "upper_bound": " Tiresias use carefully. entic"
+              },
+              {
+                  "distinct_range": 149321,
+                  "num_eq": 15,
+                  "num_range": 149970,
+                  "upper_bound": "zzle idly doggedly regular instructions. blit"
+              }
+          ],
+          "histo_col_type": "VARCHAR(117)",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 150000
+      }
+  ]'
 
 statement ok
 CREATE TABLE public.orders
@@ -336,62 +9032,3810 @@ CREATE TABLE public.orders
 )
 
 statement ok
-ALTER TABLE public.orders INJECT STATISTICS '[
-  {
-    "columns": ["o_orderkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1500000,
-    "distinct_count": 1500000
-  },
-  {
-    "columns": ["o_custkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1500000,
-    "distinct_count": 100000
-  },
-  {
-    "columns": ["o_orderstatus"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1500000,
-    "distinct_count": 3
-  },
-  {
-    "columns": ["o_totalprice"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1500000,
-    "distinct_count": 1500000
-  },
-  {
-    "columns": ["o_orderdate"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1500000,
-    "distinct_count": 2500
-  },
-  {
-    "columns": ["o_orderpriority"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1500000,
-    "distinct_count": 5
-  },
-  {
-    "columns": ["o_clerk"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1500000,
-    "distinct_count": 1000
-  },
-  {
-    "columns": ["o_shippriority"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1500000,
-    "distinct_count": 1
-  },
-  {
-    "columns": ["o_comment"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1500000,
-    "distinct_count": 1500000
-  }
-]'
+ALTER TABLE public.orders INJECT STATISTICS '
+  [
+      {
+          "avg_size": 4,
+          "columns": [
+              "o_orderkey"
+          ],
+          "created_at": "2022-03-21 20:30:27.422548",
+          "distinct_count": 1500000,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "610"
+              },
+              {
+                  "distinct_range": 7815.6177042625695,
+                  "num_eq": 1,
+                  "num_range": 7677,
+                  "upper_bound": "35397"
+              },
+              {
+                  "distinct_range": 7347.526326744527,
+                  "num_eq": 1,
+                  "num_range": 7411,
+                  "upper_bound": "63012"
+              },
+              {
+                  "distinct_range": 7548.108194086444,
+                  "num_eq": 1,
+                  "num_range": 7519,
+                  "upper_bound": "93568"
+              },
+              {
+                  "distinct_range": 7558.962643616731,
+                  "num_eq": 1,
+                  "num_range": 7525,
+                  "upper_bound": "124289"
+              },
+              {
+                  "distinct_range": 7462.810630032562,
+                  "num_eq": 1,
+                  "num_range": 7472,
+                  "upper_bound": "153569"
+              },
+              {
+                  "distinct_range": 7799.823186849026,
+                  "num_eq": 1,
+                  "num_range": 7667,
+                  "upper_bound": "188097"
+              },
+              {
+                  "distinct_range": 7535.891862834408,
+                  "num_eq": 1,
+                  "num_range": 7512,
+                  "upper_bound": "218468"
+              },
+              {
+                  "distinct_range": 7577.947820580539,
+                  "num_eq": 1,
+                  "num_range": 7536,
+                  "upper_bound": "249479"
+              },
+              {
+                  "distinct_range": 7434.383653483757,
+                  "num_eq": 1,
+                  "num_range": 7457,
+                  "upper_bound": "278342"
+              },
+              {
+                  "distinct_range": 7281.0566182523,
+                  "num_eq": 1,
+                  "num_range": 7376,
+                  "upper_bound": "305029"
+              },
+              {
+                  "distinct_range": 7174.397557534742,
+                  "num_eq": 1,
+                  "num_range": 7324,
+                  "upper_bound": "330277"
+              },
+              {
+                  "distinct_range": 7949.279058660979,
+                  "num_eq": 1,
+                  "num_range": 7760,
+                  "upper_bound": "367299"
+              },
+              {
+                  "distinct_range": 7441.089987426636,
+                  "num_eq": 1,
+                  "num_range": 7460,
+                  "upper_bound": "396260"
+              },
+              {
+                  "distinct_range": 7385.5879187425935,
+                  "num_eq": 1,
+                  "num_range": 7431,
+                  "upper_bound": "424417"
+              },
+              {
+                  "distinct_range": 7712.979445191142,
+                  "num_eq": 1,
+                  "num_range": 7615,
+                  "upper_bound": "457541"
+              },
+              {
+                  "distinct_range": 7241.274254976007,
+                  "num_eq": 1,
+                  "num_range": 7356,
+                  "upper_bound": "483684"
+              },
+              {
+                  "distinct_range": 7453.978937813436,
+                  "num_eq": 1,
+                  "num_range": 7467,
+                  "upper_bound": "512834"
+              },
+              {
+                  "distinct_range": 7644.019726885347,
+                  "num_eq": 1,
+                  "num_range": 7574,
+                  "upper_bound": "544868"
+              },
+              {
+                  "distinct_range": 7473.845958615985,
+                  "num_eq": 1,
+                  "num_range": 7478,
+                  "upper_bound": "574311"
+              },
+              {
+                  "distinct_range": 7326.935960610546,
+                  "num_eq": 1,
+                  "num_range": 7400,
+                  "upper_bound": "601636"
+              },
+              {
+                  "distinct_range": 7090.48601115163,
+                  "num_eq": 1,
+                  "num_range": 7284,
+                  "upper_bound": "625796"
+              },
+              {
+                  "distinct_range": 6574.285319244526,
+                  "num_eq": 1,
+                  "num_range": 7073,
+                  "upper_bound": "644130"
+              },
+              {
+                  "distinct_range": 7674.435807466865,
+                  "num_eq": 1,
+                  "num_range": 7592,
+                  "upper_bound": "676642"
+              },
+              {
+                  "distinct_range": 7243.779233493597,
+                  "num_eq": 1,
+                  "num_range": 7358,
+                  "upper_bound": "702819"
+              },
+              {
+                  "distinct_range": 7410.438837195413,
+                  "num_eq": 1,
+                  "num_range": 7444,
+                  "upper_bound": "731334"
+              },
+              {
+                  "distinct_range": 7338.245045375886,
+                  "num_eq": 1,
+                  "num_range": 7406,
+                  "upper_bound": "758818"
+              },
+              {
+                  "distinct_range": 7308.983227649387,
+                  "num_eq": 1,
+                  "num_range": 7391,
+                  "upper_bound": "785892"
+              },
+              {
+                  "distinct_range": 7389.977491011788,
+                  "num_eq": 1,
+                  "num_range": 7433,
+                  "upper_bound": "814112"
+              },
+              {
+                  "distinct_range": 8097.439356990127,
+                  "num_eq": 1,
+                  "num_range": 7856,
+                  "upper_bound": "853697"
+              },
+              {
+                  "distinct_range": 7990.829754109017,
+                  "num_eq": 1,
+                  "num_range": 7786,
+                  "upper_bound": "891429"
+              },
+              {
+                  "distinct_range": 7760.622500655286,
+                  "num_eq": 1,
+                  "num_range": 7643,
+                  "upper_bound": "925319"
+              },
+              {
+                  "distinct_range": 7522.562707425637,
+                  "num_eq": 1,
+                  "num_range": 7505,
+                  "upper_bound": "955489"
+              },
+              {
+                  "distinct_range": 7215.264682076898,
+                  "num_eq": 1,
+                  "num_range": 7344,
+                  "upper_bound": "981281"
+              },
+              {
+                  "distinct_range": 7279.2420584513875,
+                  "num_eq": 1,
+                  "num_range": 7376,
+                  "upper_bound": "1007943"
+              },
+              {
+                  "distinct_range": 7024.174245928877,
+                  "num_eq": 1,
+                  "num_range": 7253,
+                  "upper_bound": "1031271"
+              },
+              {
+                  "distinct_range": 7312.92769616144,
+                  "num_eq": 1,
+                  "num_range": 7393,
+                  "upper_bound": "1058400"
+              },
+              {
+                  "distinct_range": 7924.976125912964,
+                  "num_eq": 1,
+                  "num_range": 7745,
+                  "upper_bound": "1095010"
+              },
+              {
+                  "distinct_range": 7625.363556713757,
+                  "num_eq": 1,
+                  "num_range": 7563,
+                  "upper_bound": "1126753"
+              },
+              {
+                  "distinct_range": 7213.177945632043,
+                  "num_eq": 1,
+                  "num_range": 7343,
+                  "upper_bound": "1152517"
+              },
+              {
+                  "distinct_range": 7649.8957251914535,
+                  "num_eq": 1,
+                  "num_range": 7578,
+                  "upper_bound": "1184643"
+              },
+              {
+                  "distinct_range": 7527.012334507705,
+                  "num_eq": 1,
+                  "num_range": 7508,
+                  "upper_bound": "1214880"
+              },
+              {
+                  "distinct_range": 6923.662060077877,
+                  "num_eq": 1,
+                  "num_range": 7209,
+                  "upper_bound": "1236994"
+              },
+              {
+                  "distinct_range": 7276.408757780325,
+                  "num_eq": 1,
+                  "num_range": 7374,
+                  "upper_bound": "1263617"
+              },
+              {
+                  "distinct_range": 7544.085539214908,
+                  "num_eq": 1,
+                  "num_range": 7517,
+                  "upper_bound": "1294112"
+              },
+              {
+                  "distinct_range": 8055.569974230876,
+                  "num_eq": 1,
+                  "num_range": 7828,
+                  "upper_bound": "1332964"
+              },
+              {
+                  "distinct_range": 7529.533072893754,
+                  "num_eq": 1,
+                  "num_range": 7509,
+                  "upper_bound": "1363239"
+              },
+              {
+                  "distinct_range": 7583.620789015987,
+                  "num_eq": 1,
+                  "num_range": 7539,
+                  "upper_bound": "1394337"
+              },
+              {
+                  "distinct_range": 7571.675966328956,
+                  "num_eq": 1,
+                  "num_range": 7533,
+                  "upper_bound": "1425252"
+              },
+              {
+                  "distinct_range": 7514.443347516615,
+                  "num_eq": 1,
+                  "num_range": 7501,
+                  "upper_bound": "1455300"
+              },
+              {
+                  "distinct_range": 7867.7716380568145,
+                  "num_eq": 1,
+                  "num_range": 7709,
+                  "upper_bound": "1490950"
+              },
+              {
+                  "distinct_range": 7505.499738940414,
+                  "num_eq": 1,
+                  "num_range": 7496,
+                  "upper_bound": "1520864"
+              },
+              {
+                  "distinct_range": 7272.189274881207,
+                  "num_eq": 1,
+                  "num_range": 7372,
+                  "upper_bound": "1547429"
+              },
+              {
+                  "distinct_range": 7569.320746524656,
+                  "num_eq": 1,
+                  "num_range": 7531,
+                  "upper_bound": "1578308"
+              },
+              {
+                  "distinct_range": 7473.372915706336,
+                  "num_eq": 1,
+                  "num_range": 7478,
+                  "upper_bound": "1607744"
+              },
+              {
+                  "distinct_range": 7508.439423332966,
+                  "num_eq": 1,
+                  "num_range": 7497,
+                  "upper_bound": "1637702"
+              },
+              {
+                  "distinct_range": 7604.787322561027,
+                  "num_eq": 1,
+                  "num_range": 7552,
+                  "upper_bound": "1669126"
+              },
+              {
+                  "distinct_range": 7425.462750001881,
+                  "num_eq": 1,
+                  "num_range": 7452,
+                  "upper_bound": "1697859"
+              },
+              {
+                  "distinct_range": 7925.0944513091035,
+                  "num_eq": 1,
+                  "num_range": 7745,
+                  "upper_bound": "1734471"
+              },
+              {
+                  "distinct_range": 7174.018705001028,
+                  "num_eq": 1,
+                  "num_range": 7323,
+                  "upper_bound": "1759714"
+              },
+              {
+                  "distinct_range": 7229.600170138958,
+                  "num_eq": 1,
+                  "num_range": 7351,
+                  "upper_bound": "1785699"
+              },
+              {
+                  "distinct_range": 7539.793231835403,
+                  "num_eq": 1,
+                  "num_range": 7515,
+                  "upper_bound": "1816129"
+              },
+              {
+                  "distinct_range": 7135.285309591162,
+                  "num_eq": 1,
+                  "num_range": 7305,
+                  "upper_bound": "1840865"
+              },
+              {
+                  "distinct_range": 7220.027697095165,
+                  "num_eq": 1,
+                  "num_range": 7346,
+                  "upper_bound": "1866721"
+              },
+              {
+                  "distinct_range": 7803.671314795249,
+                  "num_eq": 1,
+                  "num_range": 7669,
+                  "upper_bound": "1901312"
+              },
+              {
+                  "distinct_range": 7896.774927421907,
+                  "num_eq": 1,
+                  "num_range": 7727,
+                  "upper_bound": "1937447"
+              },
+              {
+                  "distinct_range": 7830.981869996515,
+                  "num_eq": 1,
+                  "num_range": 7686,
+                  "upper_bound": "1972487"
+              },
+              {
+                  "distinct_range": 7779.968671093764,
+                  "num_eq": 1,
+                  "num_range": 7655,
+                  "upper_bound": "2006691"
+              },
+              {
+                  "distinct_range": 7746.757086878007,
+                  "num_eq": 1,
+                  "num_range": 7635,
+                  "upper_bound": "2040357"
+              },
+              {
+                  "distinct_range": 7503.426840870257,
+                  "num_eq": 1,
+                  "num_range": 7494,
+                  "upper_bound": "2070240"
+              },
+              {
+                  "distinct_range": 7792.2372957312555,
+                  "num_eq": 1,
+                  "num_range": 7662,
+                  "upper_bound": "2104644"
+              },
+              {
+                  "distinct_range": 7807.393457038408,
+                  "num_eq": 1,
+                  "num_range": 7672,
+                  "upper_bound": "2139296"
+              },
+              {
+                  "distinct_range": 7684.555064298075,
+                  "num_eq": 1,
+                  "num_range": 7598,
+                  "upper_bound": "2171968"
+              },
+              {
+                  "distinct_range": 7506.168105611024,
+                  "num_eq": 1,
+                  "num_range": 7496,
+                  "upper_bound": "2201892"
+              },
+              {
+                  "distinct_range": 7290.182404225301,
+                  "num_eq": 1,
+                  "num_range": 7381,
+                  "upper_bound": "2228705"
+              },
+              {
+                  "distinct_range": 7405.735789792412,
+                  "num_eq": 1,
+                  "num_range": 7441,
+                  "upper_bound": "2257152"
+              },
+              {
+                  "distinct_range": 8113.900460589786,
+                  "num_eq": 1,
+                  "num_range": 7867,
+                  "upper_bound": "2297027"
+              },
+              {
+                  "distinct_range": 7954.980061352796,
+                  "num_eq": 1,
+                  "num_range": 7764,
+                  "upper_bound": "2334146"
+              },
+              {
+                  "distinct_range": 7567.487668186122,
+                  "num_eq": 1,
+                  "num_range": 7530,
+                  "upper_bound": "2364997"
+              },
+              {
+                  "distinct_range": 6901.3305964922265,
+                  "num_eq": 1,
+                  "num_range": 7200,
+                  "upper_bound": "2386849"
+              },
+              {
+                  "distinct_range": 7436.78060407463,
+                  "num_eq": 1,
+                  "num_range": 7458,
+                  "upper_bound": "2415747"
+              },
+              {
+                  "distinct_range": 7748.617211842271,
+                  "num_eq": 1,
+                  "num_range": 7636,
+                  "upper_bound": "2449443"
+              },
+              {
+                  "distinct_range": 7650.278576610126,
+                  "num_eq": 1,
+                  "num_range": 7578,
+                  "upper_bound": "2481575"
+              },
+              {
+                  "distinct_range": 7273.936119325015,
+                  "num_eq": 1,
+                  "num_range": 7373,
+                  "upper_bound": "2508164"
+              },
+              {
+                  "distinct_range": 7499.343654209197,
+                  "num_eq": 1,
+                  "num_range": 7492,
+                  "upper_bound": "2537986"
+              },
+              {
+                  "distinct_range": 7191.685134973444,
+                  "num_eq": 1,
+                  "num_range": 7332,
+                  "upper_bound": "2563463"
+              },
+              {
+                  "distinct_range": 7552.5204069925985,
+                  "num_eq": 1,
+                  "num_range": 7522,
+                  "upper_bound": "2594086"
+              },
+              {
+                  "distinct_range": 6971.607602572197,
+                  "num_eq": 1,
+                  "num_range": 7230,
+                  "upper_bound": "2616772"
+              },
+              {
+                  "distinct_range": 7208.10272240745,
+                  "num_eq": 1,
+                  "num_range": 7340,
+                  "upper_bound": "2642468"
+              },
+              {
+                  "distinct_range": 7465.183749063692,
+                  "num_eq": 1,
+                  "num_range": 7473,
+                  "upper_bound": "2671783"
+              },
+              {
+                  "distinct_range": 7682.533652381744,
+                  "num_eq": 1,
+                  "num_range": 7597,
+                  "upper_bound": "2704423"
+              },
+              {
+                  "distinct_range": 6808.953669404499,
+                  "num_eq": 1,
+                  "num_range": 7162,
+                  "upper_bound": "2725221"
+              },
+              {
+                  "distinct_range": 7385.5879187425935,
+                  "num_eq": 1,
+                  "num_range": 7431,
+                  "upper_bound": "2753378"
+              },
+              {
+                  "distinct_range": 7465.048195066732,
+                  "num_eq": 1,
+                  "num_range": 7473,
+                  "upper_bound": "2782691"
+              },
+              {
+                  "distinct_range": 7239.061881424117,
+                  "num_eq": 1,
+                  "num_range": 7355,
+                  "upper_bound": "2808804"
+              },
+              {
+                  "distinct_range": 7686.638374815352,
+                  "num_eq": 1,
+                  "num_range": 7599,
+                  "upper_bound": "2841509"
+              },
+              {
+                  "distinct_range": 7477.8974430411645,
+                  "num_eq": 1,
+                  "num_range": 7480,
+                  "upper_bound": "2871012"
+              },
+              {
+                  "distinct_range": 7521.033697149145,
+                  "num_eq": 1,
+                  "num_range": 7504,
+                  "upper_bound": "2901159"
+              },
+              {
+                  "distinct_range": 7836.613812404417,
+                  "num_eq": 1,
+                  "num_range": 7689,
+                  "upper_bound": "2936292"
+              },
+              {
+                  "distinct_range": 7558.634285721129,
+                  "num_eq": 1,
+                  "num_range": 7525,
+                  "upper_bound": "2967008"
+              },
+              {
+                  "distinct_range": 7191.685134973444,
+                  "num_eq": 1,
+                  "num_range": 7332,
+                  "upper_bound": "2992485"
+              },
+              {
+                  "distinct_range": 7283.087391720883,
+                  "num_eq": 1,
+                  "num_range": 7378,
+                  "upper_bound": "3019200"
+              },
+              {
+                  "distinct_range": 7742.785538499563,
+                  "num_eq": 1,
+                  "num_range": 7632,
+                  "upper_bound": "3052802"
+              },
+              {
+                  "distinct_range": 7318.225371915327,
+                  "num_eq": 1,
+                  "num_range": 7395,
+                  "upper_bound": "3080005"
+              },
+              {
+                  "distinct_range": 7456.223413821028,
+                  "num_eq": 1,
+                  "num_range": 7469,
+                  "upper_bound": "3109188"
+              },
+              {
+                  "distinct_range": 7462.878460669756,
+                  "num_eq": 1,
+                  "num_range": 7472,
+                  "upper_bound": "3138469"
+              },
+              {
+                  "distinct_range": 7443.003161152965,
+                  "num_eq": 1,
+                  "num_range": 7461,
+                  "upper_bound": "3167458"
+              },
+              {
+                  "distinct_range": 7320.370013460692,
+                  "num_eq": 1,
+                  "num_range": 7397,
+                  "upper_bound": "3194691"
+              },
+              {
+                  "distinct_range": 7174.549081723915,
+                  "num_eq": 1,
+                  "num_range": 7324,
+                  "upper_bound": "3219941"
+              },
+              {
+                  "distinct_range": 7801.656130356316,
+                  "num_eq": 1,
+                  "num_range": 7668,
+                  "upper_bound": "3254499"
+              },
+              {
+                  "distinct_range": 7110.270743611655,
+                  "num_eq": 1,
+                  "num_range": 7293,
+                  "upper_bound": "3278912"
+              },
+              {
+                  "distinct_range": 7172.123540117911,
+                  "num_eq": 1,
+                  "num_range": 7323,
+                  "upper_bound": "3304130"
+              },
+              {
+                  "distinct_range": 7578.078349707042,
+                  "num_eq": 1,
+                  "num_range": 7536,
+                  "upper_bound": "3335143"
+              },
+              {
+                  "distinct_range": 7819.206299069783,
+                  "num_eq": 1,
+                  "num_range": 7679,
+                  "upper_bound": "3369989"
+              },
+              {
+                  "distinct_range": 7913.244746425788,
+                  "num_eq": 1,
+                  "num_range": 7737,
+                  "upper_bound": "3406401"
+              },
+              {
+                  "distinct_range": 7890.872025135336,
+                  "num_eq": 1,
+                  "num_range": 7723,
+                  "upper_bound": "3442437"
+              },
+              {
+                  "distinct_range": 7645.809191442638,
+                  "num_eq": 1,
+                  "num_range": 7575,
+                  "upper_bound": "3474499"
+              },
+              {
+                  "distinct_range": 7370.063131120316,
+                  "num_eq": 1,
+                  "num_range": 7422,
+                  "upper_bound": "3502434"
+              },
+              {
+                  "distinct_range": 7085.29647990844,
+                  "num_eq": 1,
+                  "num_range": 7281,
+                  "upper_bound": "3526528"
+              },
+              {
+                  "distinct_range": 7764.574142018011,
+                  "num_eq": 1,
+                  "num_range": 7646,
+                  "upper_bound": "3560482"
+              },
+              {
+                  "distinct_range": 7292.711577666576,
+                  "num_eq": 1,
+                  "num_range": 7382,
+                  "upper_bound": "3587330"
+              },
+              {
+                  "distinct_range": 7794.196449215362,
+                  "num_eq": 1,
+                  "num_range": 7663,
+                  "upper_bound": "3621766"
+              },
+              {
+                  "distinct_range": 7884.781003588893,
+                  "num_eq": 1,
+                  "num_range": 7719,
+                  "upper_bound": "3657700"
+              },
+              {
+                  "distinct_range": 7283.594832439475,
+                  "num_eq": 1,
+                  "num_range": 7378,
+                  "upper_bound": "3684422"
+              },
+              {
+                  "distinct_range": 7604.46375189149,
+                  "num_eq": 1,
+                  "num_range": 7551,
+                  "upper_bound": "3715841"
+              },
+              {
+                  "distinct_range": 7316.150540199529,
+                  "num_eq": 1,
+                  "num_range": 7394,
+                  "upper_bound": "3743015"
+              },
+              {
+                  "distinct_range": 7217.572923652897,
+                  "num_eq": 1,
+                  "num_range": 7345,
+                  "upper_bound": "3768838"
+              },
+              {
+                  "distinct_range": 7526.945970712959,
+                  "num_eq": 1,
+                  "num_range": 7507,
+                  "upper_bound": "3799074"
+              },
+              {
+                  "distinct_range": 7579.905182896896,
+                  "num_eq": 1,
+                  "num_range": 7537,
+                  "upper_bound": "3830115"
+              },
+              {
+                  "distinct_range": 7794.196449215362,
+                  "num_eq": 1,
+                  "num_range": 7663,
+                  "upper_bound": "3864551"
+              },
+              {
+                  "distinct_range": 7510.175138628321,
+                  "num_eq": 1,
+                  "num_range": 7498,
+                  "upper_bound": "3894535"
+              },
+              {
+                  "distinct_range": 7975.369284946805,
+                  "num_eq": 1,
+                  "num_range": 7777,
+                  "upper_bound": "3932002"
+              },
+              {
+                  "distinct_range": 7744.64775921436,
+                  "num_eq": 1,
+                  "num_range": 7634,
+                  "upper_bound": "3965634"
+              },
+              {
+                  "distinct_range": 7072.8246385556695,
+                  "num_eq": 1,
+                  "num_range": 7276,
+                  "upper_bound": "3989570"
+              },
+              {
+                  "distinct_range": 7475.737356946449,
+                  "num_eq": 1,
+                  "num_range": 7479,
+                  "upper_bound": "4019041"
+              },
+              {
+                  "distinct_range": 7467.487189767912,
+                  "num_eq": 1,
+                  "num_range": 7475,
+                  "upper_bound": "4048390"
+              },
+              {
+                  "distinct_range": 7390.255955787203,
+                  "num_eq": 1,
+                  "num_range": 7433,
+                  "upper_bound": "4076614"
+              },
+              {
+                  "distinct_range": 7780.09156272382,
+                  "num_eq": 1,
+                  "num_range": 7655,
+                  "upper_bound": "4110820"
+              },
+              {
+                  "distinct_range": 6829.29712558857,
+                  "num_eq": 1,
+                  "num_range": 7170,
+                  "upper_bound": "4131846"
+              },
+              {
+                  "distinct_range": 7432.121800048733,
+                  "num_eq": 1,
+                  "num_range": 7455,
+                  "upper_bound": "4160676"
+              },
+              {
+                  "distinct_range": 7473.440498012014,
+                  "num_eq": 1,
+                  "num_range": 7478,
+                  "upper_bound": "4190113"
+              },
+              {
+                  "distinct_range": 7037.482621941462,
+                  "num_eq": 1,
+                  "num_range": 7259,
+                  "upper_bound": "4213606"
+              },
+              {
+                  "distinct_range": 8024.01269701065,
+                  "num_eq": 1,
+                  "num_range": 7808,
+                  "upper_bound": "4251910"
+              },
+              {
+                  "distinct_range": 7149.722259109173,
+                  "num_eq": 1,
+                  "num_range": 7312,
+                  "upper_bound": "4276834"
+              },
+              {
+                  "distinct_range": 7390.325567549079,
+                  "num_eq": 1,
+                  "num_range": 7433,
+                  "upper_bound": "4305059"
+              },
+              {
+                  "distinct_range": 7347.597051405657,
+                  "num_eq": 1,
+                  "num_range": 7411,
+                  "upper_bound": "4332675"
+              },
+              {
+                  "distinct_range": 7631.658390658542,
+                  "num_eq": 1,
+                  "num_range": 7567,
+                  "upper_bound": "4364516"
+              },
+              {
+                  "distinct_range": 7473.845958615985,
+                  "num_eq": 1,
+                  "num_range": 7478,
+                  "upper_bound": "4393959"
+              },
+              {
+                  "distinct_range": 7664.222271503013,
+                  "num_eq": 1,
+                  "num_range": 7586,
+                  "upper_bound": "4426310"
+              },
+              {
+                  "distinct_range": 7318.010810745985,
+                  "num_eq": 1,
+                  "num_range": 7395,
+                  "upper_bound": "4453510"
+              },
+              {
+                  "distinct_range": 7684.428761618033,
+                  "num_eq": 1,
+                  "num_range": 7598,
+                  "upper_bound": "4486180"
+              },
+              {
+                  "distinct_range": 7403.715939641391,
+                  "num_eq": 1,
+                  "num_range": 7514,
+                  "upper_bound": "4513056"
+              },
+              {
+                  "distinct_range": 7157.625838602842,
+                  "num_eq": 1,
+                  "num_range": 7397,
+                  "upper_bound": "4536738"
+              },
+              {
+                  "distinct_range": 7893.793255172084,
+                  "num_eq": 1,
+                  "num_range": 7784,
+                  "upper_bound": "4570913"
+              },
+              {
+                  "distinct_range": 7613.65016123674,
+                  "num_eq": 1,
+                  "num_range": 7624,
+                  "upper_bound": "4600769"
+              },
+              {
+                  "distinct_range": 7655.028156803708,
+                  "num_eq": 1,
+                  "num_range": 7647,
+                  "upper_bound": "4631239"
+              },
+              {
+                  "distinct_range": 8038.136596630681,
+                  "num_eq": 1,
+                  "num_range": 7872,
+                  "upper_bound": "4667780"
+              },
+              {
+                  "distinct_range": 7482.683541145337,
+                  "num_eq": 1,
+                  "num_range": 7554,
+                  "upper_bound": "4695750"
+              },
+              {
+                  "distinct_range": 7839.375036299258,
+                  "num_eq": 1,
+                  "num_range": 7752,
+                  "upper_bound": "4729057"
+              },
+              {
+                  "distinct_range": 7807.44257760332,
+                  "num_eq": 1,
+                  "num_range": 7733,
+                  "upper_bound": "4761861"
+              },
+              {
+                  "distinct_range": 7477.772154469914,
+                  "num_eq": 1,
+                  "num_range": 7552,
+                  "upper_bound": "4789762"
+              },
+              {
+                  "distinct_range": 7626.921704827051,
+                  "num_eq": 1,
+                  "num_range": 7631,
+                  "upper_bound": "4819814"
+              },
+              {
+                  "distinct_range": 7807.251216769038,
+                  "num_eq": 1,
+                  "num_range": 7733,
+                  "upper_bound": "4852615"
+              },
+              {
+                  "distinct_range": 7527.189408970287,
+                  "num_eq": 1,
+                  "num_range": 7577,
+                  "upper_bound": "4881216"
+              },
+              {
+                  "distinct_range": 7392.6987106999895,
+                  "num_eq": 1,
+                  "num_range": 7508,
+                  "upper_bound": "4907942"
+              },
+              {
+                  "distinct_range": 7486.947022765701,
+                  "num_eq": 1,
+                  "num_range": 7556,
+                  "upper_bound": "4935972"
+              },
+              {
+                  "distinct_range": 8070.577471033878,
+                  "num_eq": 1,
+                  "num_range": 7892,
+                  "upper_bound": "4973057"
+              },
+              {
+                  "distinct_range": 7641.882055094398,
+                  "num_eq": 1,
+                  "num_range": 7639,
+                  "upper_bound": "5003331"
+              },
+              {
+                  "distinct_range": 7543.581895651936,
+                  "num_eq": 1,
+                  "num_range": 7586,
+                  "upper_bound": "5032167"
+              },
+              {
+                  "distinct_range": 7759.837340659544,
+                  "num_eq": 1,
+                  "num_range": 7706,
+                  "upper_bound": "5064230"
+              },
+              {
+                  "distinct_range": 7879.767929919393,
+                  "num_eq": 1,
+                  "num_range": 7776,
+                  "upper_bound": "5098180"
+              },
+              {
+                  "distinct_range": 7737.2378090193215,
+                  "num_eq": 1,
+                  "num_range": 7693,
+                  "upper_bound": "5129895"
+              },
+              {
+                  "distinct_range": 7845.561798173994,
+                  "num_eq": 1,
+                  "num_range": 7755,
+                  "upper_bound": "5163300"
+              },
+              {
+                  "distinct_range": 7581.027952940932,
+                  "num_eq": 1,
+                  "num_range": 7606,
+                  "upper_bound": "5192678"
+              },
+              {
+                  "distinct_range": 7554.064319819183,
+                  "num_eq": 1,
+                  "num_range": 7592,
+                  "upper_bound": "5221665"
+              },
+              {
+                  "distinct_range": 7643.830786665143,
+                  "num_eq": 1,
+                  "num_range": 7640,
+                  "upper_bound": "5251968"
+              },
+              {
+                  "distinct_range": 7209.1994850008205,
+                  "num_eq": 1,
+                  "num_range": 7420,
+                  "upper_bound": "5276292"
+              },
+              {
+                  "distinct_range": 7637.374933471887,
+                  "num_eq": 1,
+                  "num_range": 7637,
+                  "upper_bound": "5306499"
+              },
+              {
+                  "distinct_range": 7813.305683858249,
+                  "num_eq": 1,
+                  "num_range": 7736,
+                  "upper_bound": "5339395"
+              },
+              {
+                  "distinct_range": 7563.126780598842,
+                  "num_eq": 1,
+                  "num_range": 7597,
+                  "upper_bound": "5368513"
+              },
+              {
+                  "distinct_range": 7728.950322714895,
+                  "num_eq": 1,
+                  "num_range": 7688,
+                  "upper_bound": "5400101"
+              },
+              {
+                  "distinct_range": 7958.77956003739,
+                  "num_eq": 1,
+                  "num_range": 7823,
+                  "upper_bound": "5435330"
+              },
+              {
+                  "distinct_range": 7556.973015898733,
+                  "num_eq": 1,
+                  "num_range": 7593,
+                  "upper_bound": "5464359"
+              },
+              {
+                  "distinct_range": 7675.837017665369,
+                  "num_eq": 1,
+                  "num_range": 7658,
+                  "upper_bound": "5495141"
+              },
+              {
+                  "distinct_range": 7741.2758427301,
+                  "num_eq": 1,
+                  "num_range": 7695,
+                  "upper_bound": "5526918"
+              },
+              {
+                  "distinct_range": 7847.7056302380515,
+                  "num_eq": 1,
+                  "num_range": 7757,
+                  "upper_bound": "5560357"
+              },
+              {
+                  "distinct_range": 7643.629252752704,
+                  "num_eq": 1,
+                  "num_range": 7640,
+                  "upper_bound": "5590657"
+              },
+              {
+                  "distinct_range": 7347.318368502156,
+                  "num_eq": 1,
+                  "num_range": 7486,
+                  "upper_bound": "5616772"
+              },
+              {
+                  "distinct_range": 7958.77956003739,
+                  "num_eq": 1,
+                  "num_range": 7823,
+                  "upper_bound": "5652001"
+              },
+              {
+                  "distinct_range": 7305.9738715183585,
+                  "num_eq": 1,
+                  "num_range": 7466,
+                  "upper_bound": "5677569"
+              },
+              {
+                  "distinct_range": 7671.912934235918,
+                  "num_eq": 1,
+                  "num_range": 7656,
+                  "upper_bound": "5708292"
+              },
+              {
+                  "distinct_range": 7849.974119461804,
+                  "num_eq": 1,
+                  "num_range": 7758,
+                  "upper_bound": "5741767"
+              },
+              {
+                  "distinct_range": 7970.312973892871,
+                  "num_eq": 1,
+                  "num_range": 7830,
+                  "upper_bound": "5777185"
+              },
+              {
+                  "distinct_range": 7947.271877356172,
+                  "num_eq": 1,
+                  "num_range": 7816,
+                  "upper_bound": "5812226"
+              },
+              {
+                  "distinct_range": 7534.595448212467,
+                  "num_eq": 1,
+                  "num_range": 7581,
+                  "upper_bound": "5840933"
+              },
+              {
+                  "distinct_range": 7445.949867275138,
+                  "num_eq": 1,
+                  "num_range": 7535,
+                  "upper_bound": "5868390"
+              },
+              {
+                  "distinct_range": 7385.105816606424,
+                  "num_eq": 1,
+                  "num_range": 7505,
+                  "upper_bound": "5895013"
+              },
+              {
+                  "distinct_range": 7968.545585960317,
+                  "num_eq": 1,
+                  "num_range": 7829,
+                  "upper_bound": "5930402"
+              },
+              {
+                  "distinct_range": 8256.840590647082,
+                  "num_eq": 1,
+                  "num_range": 8012,
+                  "upper_bound": "5970692"
+              },
+              {
+                  "distinct_range": 7567.4747338278175,
+                  "num_eq": 1,
+                  "num_range": 7599,
+                  "upper_bound": "5999873"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 1500000
+      },
+      {
+          "avg_size": 4,
+          "columns": [
+              "o_custkey"
+          ],
+          "created_at": "2022-03-21 20:30:27.422548",
+          "distinct_count": 99846,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 150,
+                  "num_range": 0,
+                  "upper_bound": "16"
+              },
+              {
+                  "distinct_range": 432.50753452469,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "667"
+              },
+              {
+                  "distinct_range": 558.1871219436705,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "1507"
+              },
+              {
+                  "distinct_range": 586.0822703555529,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "2389"
+              },
+              {
+                  "distinct_range": 472.42208426804336,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "3100"
+              },
+              {
+                  "distinct_range": 462.44427440207824,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "3796"
+              },
+              {
+                  "distinct_range": 478.40843228556434,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "4516"
+              },
+              {
+                  "distinct_range": 639.8124776372152,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "5479"
+              },
+              {
+                  "distinct_range": 500.3557429887914,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "6232"
+              },
+              {
+                  "distinct_range": 629.8706125907246,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "7180"
+              },
+              {
+                  "distinct_range": 530.2751209000683,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "7978"
+              },
+              {
+                  "distinct_range": 450.4701017908585,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "8656"
+              },
+              {
+                  "distinct_range": 562.1732886248109,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "9502"
+              },
+              {
+                  "distinct_range": 430.51161397380235,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "10150"
+              },
+              {
+                  "distinct_range": 456.45728787974656,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "10837"
+              },
+              {
+                  "distinct_range": 526.286585839631,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "11629"
+              },
+              {
+                  "distinct_range": 556.1939092397212,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "12466"
+              },
+              {
+                  "distinct_range": 462.44427440207824,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "13162"
+              },
+              {
+                  "distinct_range": 520.3033365072638,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "13945"
+              },
+              {
+                  "distinct_range": 467.1006681517607,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "14648"
+              },
+              {
+                  "distinct_range": 385.9329464796835,
+                  "num_eq": 300,
+                  "num_range": 7200,
+                  "upper_bound": "15229"
+              },
+              {
+                  "distinct_range": 640.4751171558923,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "16193"
+              },
+              {
+                  "distinct_range": 478.40843228556434,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "16913"
+              },
+              {
+                  "distinct_range": 515.649348828315,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "17689"
+              },
+              {
+                  "distinct_range": 439.1604959806119,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "18350"
+              },
+              {
+                  "distinct_range": 696.6220738691171,
+                  "num_eq": 450,
+                  "num_range": 7200,
+                  "upper_bound": "19399"
+              },
+              {
+                  "distinct_range": 428.5156795854054,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "20044"
+              },
+              {
+                  "distinct_range": 530.2751209000683,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "20842"
+              },
+              {
+                  "distinct_range": 526.286585839631,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "21634"
+              },
+              {
+                  "distinct_range": 532.2692947466923,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "22435"
+              },
+              {
+                  "distinct_range": 499.025736601468,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "23186"
+              },
+              {
+                  "distinct_range": 515.649348828315,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "23962"
+              },
+              {
+                  "distinct_range": 476.4130131906813,
+                  "num_eq": 300,
+                  "num_range": 7350,
+                  "upper_bound": "24679"
+              },
+              {
+                  "distinct_range": 346.67538804113155,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "25201"
+              },
+              {
+                  "distinct_range": 453.1310967418639,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "25883"
+              },
+              {
+                  "distinct_range": 388.59479965642623,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "26468"
+              },
+              {
+                  "distinct_range": 465.77028414562835,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "27169"
+              },
+              {
+                  "distinct_range": 536.2574476391421,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "27976"
+              },
+              {
+                  "distinct_range": 580.1064078059496,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "28849"
+              },
+              {
+                  "distinct_range": 490.3802512312288,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "29587"
+              },
+              {
+                  "distinct_range": 327.3788137364086,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "30080"
+              },
+              {
+                  "distinct_range": 491.71037400725095,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "30820"
+              },
+              {
+                  "distinct_range": 550.8782699210554,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "31649"
+              },
+              {
+                  "distinct_range": 543.5683513223707,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "32467"
+              },
+              {
+                  "distinct_range": 507.00548038646343,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "33230"
+              },
+              {
+                  "distinct_range": 471.75691808161815,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "33940"
+              },
+              {
+                  "distinct_range": 552.2072338867266,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "34771"
+              },
+              {
+                  "distinct_range": 442.4869101115844,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "35437"
+              },
+              {
+                  "distinct_range": 524.2922275367911,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "36226"
+              },
+              {
+                  "distinct_range": 498.36072632737034,
+                  "num_eq": 450,
+                  "num_range": 7350,
+                  "upper_bound": "36976"
+              },
+              {
+                  "distinct_range": 493.0404797793332,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "37718"
+              },
+              {
+                  "distinct_range": 359.9832823512248,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "38260"
+              },
+              {
+                  "distinct_range": 463.109481912294,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "38957"
+              },
+              {
+                  "distinct_range": 526.286585839631,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "39749"
+              },
+              {
+                  "distinct_range": 459.78341744818385,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "40441"
+              },
+              {
+                  "distinct_range": 624.5666099950602,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "41381"
+              },
+              {
+                  "distinct_range": 413.87845277026065,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "42004"
+              },
+              {
+                  "distinct_range": 664.3164363845915,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "43004"
+              },
+              {
+                  "distinct_range": 477.74329603958915,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "43723"
+              },
+              {
+                  "distinct_range": 419.2011513170389,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "44354"
+              },
+              {
+                  "distinct_range": 641.1377372122665,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "45319"
+              },
+              {
+                  "distinct_range": 524.2922275367911,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "46108"
+              },
+              {
+                  "distinct_range": 408.5556840643057,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "46723"
+              },
+              {
+                  "distinct_range": 411.21707669451,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "47342"
+              },
+              {
+                  "distinct_range": 482.3991750373871,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "48068"
+              },
+              {
+                  "distinct_range": 378.61413115544894,
+                  "num_eq": 300,
+                  "num_range": 7350,
+                  "upper_bound": "48638"
+              },
+              {
+                  "distinct_range": 457.78774729036445,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "49327"
+              },
+              {
+                  "distinct_range": 546.2266217219903,
+                  "num_eq": 300,
+                  "num_range": 7350,
+                  "upper_bound": "50149"
+              },
+              {
+                  "distinct_range": 534.2634041622341,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "50953"
+              },
+              {
+                  "distinct_range": 409.2210337220542,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "51569"
+              },
+              {
+                  "distinct_range": 570.1445366135795,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "52427"
+              },
+              {
+                  "distinct_range": 508.3353664671243,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "53192"
+              },
+              {
+                  "distinct_range": 489.71518356632225,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "53929"
+              },
+              {
+                  "distinct_range": 412.547766861664,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "54550"
+              },
+              {
+                  "distinct_range": 428.5156795854054,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "55195"
+              },
+              {
+                  "distinct_range": 452.4658514275059,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "55876"
+              },
+              {
+                  "distinct_range": 444.4808859933995,
+                  "num_eq": 300,
+                  "num_range": 7200,
+                  "upper_bound": "56545"
+              },
+              {
+                  "distinct_range": 609.9750385412292,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "57463"
+              },
+              {
+                  "distinct_range": 442.4869101115844,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "58129"
+              },
+              {
+                  "distinct_range": 484.3944967549125,
+                  "num_eq": 300,
+                  "num_range": 7350,
+                  "upper_bound": "58858"
+              },
+              {
+                  "distinct_range": 460.44863566486583,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "59551"
+              },
+              {
+                  "distinct_range": 440.49106722754294,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "60214"
+              },
+              {
+                  "distinct_range": 604.6671207202448,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "61124"
+              },
+              {
+                  "distinct_range": 374.62183214489147,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "61688"
+              },
+              {
+                  "distinct_range": 503.6740106567223,
+                  "num_eq": 300,
+                  "num_range": 7200,
+                  "upper_bound": "62446"
+              },
+              {
+                  "distinct_range": 510.99507431017065,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "63215"
+              },
+              {
+                  "distinct_range": 509.66523123235737,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "63982"
+              },
+              {
+                  "distinct_range": 466.43238747104795,
+                  "num_eq": 300,
+                  "num_range": 7200,
+                  "upper_bound": "64684"
+              },
+              {
+                  "distinct_range": 560.1802489976504,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "65527"
+              },
+              {
+                  "distinct_range": 464.43988865087886,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "66226"
+              },
+              {
+                  "distinct_range": 454.46158036475293,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "66910"
+              },
+              {
+                  "distinct_range": 440.49106722754294,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "67573"
+              },
+              {
+                  "distinct_range": 387.26405111453124,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "68156"
+              },
+              {
+                  "distinct_range": 519.6384993286332,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "68938"
+              },
+              {
+                  "distinct_range": 544.2329312804071,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "69757"
+              },
+              {
+                  "distinct_range": 506.34052946798886,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "70519"
+              },
+              {
+                  "distinct_range": 570.8087391509429,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "71378"
+              },
+              {
+                  "distinct_range": 617.2718108381099,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "72307"
+              },
+              {
+                  "distinct_range": 605.9941900306553,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "73219"
+              },
+              {
+                  "distinct_range": 447.14380830688094,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "73892"
+              },
+              {
+                  "distinct_range": 473.7524070326537,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "74605"
+              },
+              {
+                  "distinct_range": 665.6401242575057,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "75607"
+              },
+              {
+                  "distinct_range": 528.2808841090829,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "76402"
+              },
+              {
+                  "distinct_range": 499.025736601468,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "77153"
+              },
+              {
+                  "distinct_range": 529.6103822240727,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "77950"
+              },
+              {
+                  "distinct_range": 477.07815632967777,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "78668"
+              },
+              {
+                  "distinct_range": 543.5683513223707,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "79486"
+              },
+              {
+                  "distinct_range": 502.35071652099475,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "80242"
+              },
+              {
+                  "distinct_range": 465.1050878189477,
+                  "num_eq": 300,
+                  "num_range": 7350,
+                  "upper_bound": "80942"
+              },
+              {
+                  "distinct_range": 403.8982099153216,
+                  "num_eq": 300,
+                  "num_range": 7350,
+                  "upper_bound": "81550"
+              },
+              {
+                  "distinct_range": 481.06894192483765,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "82274"
+              },
+              {
+                  "distinct_range": 442.4869101115844,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "82940"
+              },
+              {
+                  "distinct_range": 645.1130435738511,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "83911"
+              },
+              {
+                  "distinct_range": 678.2104244595081,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "84932"
+              },
+              {
+                  "distinct_range": 416.5398113166048,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "85559"
+              },
+              {
+                  "distinct_range": 468.43104042089317,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "86264"
+              },
+              {
+                  "distinct_range": 496.3656676938915,
+                  "num_eq": 300,
+                  "num_range": 7350,
+                  "upper_bound": "87011"
+              },
+              {
+                  "distinct_range": 456.45728787974656,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "87698"
+              },
+              {
+                  "distinct_range": 547.5557068840419,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "88522"
+              },
+              {
+                  "distinct_range": 424.52377140067813,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "89161"
+              },
+              {
+                  "distinct_range": 617.9350576647508,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "90091"
+              },
+              {
+                  "distinct_range": 552.2072338867266,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "90922"
+              },
+              {
+                  "distinct_range": 526.9513586707585,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "91715"
+              },
+              {
+                  "distinct_range": 629.8706125907246,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "92663"
+              },
+              {
+                  "distinct_range": 489.71518356632225,
+                  "num_eq": 300,
+                  "num_range": 7350,
+                  "upper_bound": "93400"
+              },
+              {
+                  "distinct_range": 554.2006126421447,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "94234"
+              },
+              {
+                  "distinct_range": 552.8560096213407,
+                  "num_eq": 300,
+                  "num_range": 7200,
+                  "upper_bound": "95066"
+              },
+              {
+                  "distinct_range": 511.65998759893955,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "95836"
+              },
+              {
+                  "distinct_range": 426.5197318893403,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "96478"
+              },
+              {
+                  "distinct_range": 350.6677658296356,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "97006"
+              },
+              {
+                  "distinct_range": 487.05487197734055,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "97739"
+              },
+              {
+                  "distinct_range": 538.2514236490329,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "98549"
+              },
+              {
+                  "distinct_range": 477.74329603958915,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "99268"
+              },
+              {
+                  "distinct_range": 417.2051480960263,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "99896"
+              },
+              {
+                  "distinct_range": 625.8927160498962,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "100838"
+              },
+              {
+                  "distinct_range": 423.8584484819153,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "101476"
+              },
+              {
+                  "distinct_range": 365.30641062757957,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "102026"
+              },
+              {
+                  "distinct_range": 609.9750385412292,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "102944"
+              },
+              {
+                  "distinct_range": 591.3933008461655,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "103834"
+              },
+              {
+                  "distinct_range": 463.109481912294,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "104531"
+              },
+              {
+                  "distinct_range": 369.9641306179159,
+                  "num_eq": 300,
+                  "num_range": 7350,
+                  "upper_bound": "105088"
+              },
+              {
+                  "distinct_range": 540.2453306426954,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "105901"
+              },
+              {
+                  "distinct_range": 483.0642860401501,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "106628"
+              },
+              {
+                  "distinct_range": 477.74329603958915,
+                  "num_eq": 300,
+                  "num_range": 7350,
+                  "upper_bound": "107347"
+              },
+              {
+                  "distinct_range": 522.2978106248382,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "108133"
+              },
+              {
+                  "distinct_range": 514.3195846444657,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "108907"
+              },
+              {
+                  "distinct_range": 572.1371117400681,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "109768"
+              },
+              {
+                  "distinct_range": 333.36741763574986,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "110270"
+              },
+              {
+                  "distinct_range": 611.9286299509199,
+                  "num_eq": 300,
+                  "num_range": 7200,
+                  "upper_bound": "111191"
+              },
+              {
+                  "distinct_range": 496.3656676938915,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "111938"
+              },
+              {
+                  "distinct_range": 651.7369340861118,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "112919"
+              },
+              {
+                  "distinct_range": 503.6806743345376,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "113677"
+              },
+              {
+                  "distinct_range": 401.23677645958975,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "114281"
+              },
+              {
+                  "distinct_range": 534.2634041622341,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "115085"
+              },
+              {
+                  "distinct_range": 418.5358181127888,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "115715"
+              },
+              {
+                  "distinct_range": 534.2634041622341,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "116519"
+              },
+              {
+                  "distinct_range": 502.35071652099475,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "117275"
+              },
+              {
+                  "distinct_range": 527.6161247784163,
+                  "num_eq": 300,
+                  "num_range": 7350,
+                  "upper_bound": "118069"
+              },
+              {
+                  "distinct_range": 582.0984709694629,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "118945"
+              },
+              {
+                  "distinct_range": 613.9553338589698,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "119869"
+              },
+              {
+                  "distinct_range": 384.60254699340334,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "120448"
+              },
+              {
+                  "distinct_range": 605.9941900306553,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "121360"
+              },
+              {
+                  "distinct_range": 386.5986759493136,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "121942"
+              },
+              {
+                  "distinct_range": 530.2751209000683,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "122740"
+              },
+              {
+                  "distinct_range": 649.7499839187487,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "123718"
+              },
+              {
+                  "distinct_range": 462.44655069080255,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "124414"
+              },
+              {
+                  "distinct_range": 427.1859906688584,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "125057"
+              },
+              {
+                  "distinct_range": 357.987204802732,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "125596"
+              },
+              {
+                  "distinct_range": 377.2835701577077,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "126164"
+              },
+              {
+                  "distinct_range": 500.360862781144,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "126917"
+              },
+              {
+                  "distinct_range": 527.6161247784163,
+                  "num_eq": 300,
+                  "num_range": 7350,
+                  "upper_bound": "127711"
+              },
+              {
+                  "distinct_range": 566.8396942776786,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "128564"
+              },
+              {
+                  "distinct_range": 336.69445760359383,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "129071"
+              },
+              {
+                  "distinct_range": 519.6458889407605,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "129853"
+              },
+              {
+                  "distinct_range": 394.5834982035334,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "130447"
+              },
+              {
+                  "distinct_range": 554.2139966830083,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "131281"
+              },
+              {
+                  "distinct_range": 534.2729946406972,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "132085"
+              },
+              {
+                  "distinct_range": 413.21374678051086,
+                  "num_eq": 300,
+                  "num_range": 7500,
+                  "upper_bound": "132707"
+              },
+              {
+                  "distinct_range": 537.5867725706064,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "133516"
+              },
+              {
+                  "distinct_range": 548.8970329337083,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "134342"
+              },
+              {
+                  "distinct_range": 533.6081887218082,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "135145"
+              },
+              {
+                  "distinct_range": 556.2077286759575,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "135982"
+              },
+              {
+                  "distinct_range": 481.0723861506547,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "136706"
+              },
+              {
+                  "distinct_range": 472.4249375743689,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "137417"
+              },
+              {
+                  "distinct_range": 525.6300420453665,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "138208"
+              },
+              {
+                  "distinct_range": 458.4550471046971,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "138898"
+              },
+              {
+                  "distinct_range": 562.8529658909534,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "139745"
+              },
+              {
+                  "distinct_range": 595.4008552126044,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "140641"
+              },
+              {
+                  "distinct_range": 520.3108165867151,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "141424"
+              },
+              {
+                  "distinct_range": 534.9377942316823,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "142229"
+              },
+              {
+                  "distinct_range": 477.7465023266624,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "142948"
+              },
+              {
+                  "distinct_range": 556.2077286759575,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "143785"
+              },
+              {
+                  "distinct_range": 463.11179344690896,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "144482"
+              },
+              {
+                  "distinct_range": 510.33636691434674,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "145250"
+              },
+              {
+                  "distinct_range": 635.2152950062106,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "146206"
+              },
+              {
+                  "distinct_range": 614.650881907038,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "147131"
+              },
+              {
+                  "distinct_range": 486.3936383752312,
+                  "num_eq": 300,
+                  "num_range": 7500,
+                  "upper_bound": "147863"
+              },
+              {
+                  "distinct_range": 483.7293932916543,
+                  "num_eq": 150,
+                  "num_range": 7350,
+                  "upper_bound": "148591"
+              },
+              {
+                  "distinct_range": 483.06787972088483,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "149318"
+              },
+              {
+                  "distinct_range": 444.48421305859324,
+                  "num_eq": 150,
+                  "num_range": 7500,
+                  "upper_bound": "149987"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 1500000
+      },
+      {
+          "avg_size": 4,
+          "columns": [
+              "o_orderdate"
+          ],
+          "created_at": "2022-03-21 20:30:27.422548",
+          "distinct_count": 2406,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 300,
+                  "num_range": 0,
+                  "upper_bound": "1992-01-01"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 450,
+                  "num_range": 7350,
+                  "upper_bound": "1992-01-14"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 1200,
+                  "num_range": 7200,
+                  "upper_bound": "1992-01-29"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 600,
+                  "num_range": 7200,
+                  "upper_bound": "1992-02-11"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 750,
+                  "num_range": 7350,
+                  "upper_bound": "1992-02-24"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1050,
+                  "num_range": 6750,
+                  "upper_bound": "1992-03-07"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 900,
+                  "num_range": 7350,
+                  "upper_bound": "1992-03-20"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 750,
+                  "num_range": 6750,
+                  "upper_bound": "1992-04-01"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 600,
+                  "num_range": 7350,
+                  "upper_bound": "1992-04-13"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 300,
+                  "num_range": 7350,
+                  "upper_bound": "1992-04-28"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 900,
+                  "num_range": 6600,
+                  "upper_bound": "1992-05-08"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 750,
+                  "num_range": 6900,
+                  "upper_bound": "1992-05-19"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 750,
+                  "num_range": 6900,
+                  "upper_bound": "1992-05-29"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 750,
+                  "num_range": 7350,
+                  "upper_bound": "1992-06-09"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 1050,
+                  "num_range": 6750,
+                  "upper_bound": "1992-06-23"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 450,
+                  "num_range": 7050,
+                  "upper_bound": "1992-07-04"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 600,
+                  "num_range": 6900,
+                  "upper_bound": "1992-07-14"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 900,
+                  "num_range": 6600,
+                  "upper_bound": "1992-07-28"
+              },
+              {
+                  "distinct_range": 15,
+                  "num_eq": 900,
+                  "num_range": 7350,
+                  "upper_bound": "1992-08-13"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 1200,
+                  "num_range": 7350,
+                  "upper_bound": "1992-08-23"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 300,
+                  "num_range": 7200,
+                  "upper_bound": "1992-09-06"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 600,
+                  "num_range": 6900,
+                  "upper_bound": "1992-09-21"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 900,
+                  "num_range": 6900,
+                  "upper_bound": "1992-10-05"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 750,
+                  "num_range": 6750,
+                  "upper_bound": "1992-10-19"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 450,
+                  "num_range": 7200,
+                  "upper_bound": "1992-11-01"
+              },
+              {
+                  "distinct_range": 15,
+                  "num_eq": 750,
+                  "num_range": 6750,
+                  "upper_bound": "1992-11-17"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 600,
+                  "num_range": 6900,
+                  "upper_bound": "1992-11-26"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 450,
+                  "num_range": 7200,
+                  "upper_bound": "1992-12-10"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 1050,
+                  "num_range": 6450,
+                  "upper_bound": "1992-12-24"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1050,
+                  "num_range": 6600,
+                  "upper_bound": "1993-01-06"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 750,
+                  "num_range": 6600,
+                  "upper_bound": "1993-01-17"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 1050,
+                  "num_range": 7200,
+                  "upper_bound": "1993-01-27"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1650,
+                  "num_range": 6600,
+                  "upper_bound": "1993-02-08"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 450,
+                  "num_range": 6900,
+                  "upper_bound": "1993-02-20"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 900,
+                  "num_range": 7050,
+                  "upper_bound": "1993-03-05"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 450,
+                  "num_range": 7200,
+                  "upper_bound": "1993-03-17"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 300,
+                  "num_range": 7200,
+                  "upper_bound": "1993-03-28"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1500,
+                  "num_range": 6000,
+                  "upper_bound": "1993-04-08"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 1200,
+                  "num_range": 7200,
+                  "upper_bound": "1993-04-22"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 600,
+                  "num_range": 6750,
+                  "upper_bound": "1993-05-05"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1050,
+                  "num_range": 6300,
+                  "upper_bound": "1993-05-18"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 750,
+                  "num_range": 6750,
+                  "upper_bound": "1993-05-31"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1050,
+                  "num_range": 7200,
+                  "upper_bound": "1993-06-13"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 900,
+                  "num_range": 7050,
+                  "upper_bound": "1993-06-27"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 1050,
+                  "num_range": 6300,
+                  "upper_bound": "1993-07-11"
+              },
+              {
+                  "distinct_range": 15,
+                  "num_eq": 600,
+                  "num_range": 7200,
+                  "upper_bound": "1993-07-27"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 1200,
+                  "num_range": 6300,
+                  "upper_bound": "1993-08-06"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 750,
+                  "num_range": 7050,
+                  "upper_bound": "1993-08-18"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 900,
+                  "num_range": 6900,
+                  "upper_bound": "1993-08-31"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 450,
+                  "num_range": 7050,
+                  "upper_bound": "1993-09-10"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 900,
+                  "num_range": 7050,
+                  "upper_bound": "1993-09-20"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 900,
+                  "num_range": 6900,
+                  "upper_bound": "1993-10-02"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 600,
+                  "num_range": 7050,
+                  "upper_bound": "1993-10-15"
+              },
+              {
+                  "distinct_range": 16,
+                  "num_eq": 300,
+                  "num_range": 7050,
+                  "upper_bound": "1993-11-01"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1050,
+                  "num_range": 6300,
+                  "upper_bound": "1993-11-13"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 900,
+                  "num_range": 7050,
+                  "upper_bound": "1993-11-27"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 750,
+                  "num_range": 6600,
+                  "upper_bound": "1993-12-09"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 600,
+                  "num_range": 7050,
+                  "upper_bound": "1993-12-20"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1050,
+                  "num_range": 6600,
+                  "upper_bound": "1993-12-31"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 750,
+                  "num_range": 6900,
+                  "upper_bound": "1994-01-11"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 600,
+                  "num_range": 7050,
+                  "upper_bound": "1994-01-24"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 750,
+                  "num_range": 6600,
+                  "upper_bound": "1994-02-05"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 900,
+                  "num_range": 7200,
+                  "upper_bound": "1994-02-18"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 750,
+                  "num_range": 6900,
+                  "upper_bound": "1994-03-05"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 750,
+                  "num_range": 7050,
+                  "upper_bound": "1994-03-16"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 900,
+                  "num_range": 7050,
+                  "upper_bound": "1994-03-28"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 750,
+                  "num_range": 6900,
+                  "upper_bound": "1994-04-08"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 750,
+                  "num_range": 7050,
+                  "upper_bound": "1994-04-19"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 1050,
+                  "num_range": 6900,
+                  "upper_bound": "1994-05-03"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1050,
+                  "num_range": 6900,
+                  "upper_bound": "1994-05-14"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 600,
+                  "num_range": 7200,
+                  "upper_bound": "1994-05-28"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 1200,
+                  "num_range": 6750,
+                  "upper_bound": "1994-06-07"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 750,
+                  "num_range": 6900,
+                  "upper_bound": "1994-06-18"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1200,
+                  "num_range": 6150,
+                  "upper_bound": "1994-06-30"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 2100,
+                  "num_range": 6450,
+                  "upper_bound": "1994-07-12"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 600,
+                  "num_range": 7050,
+                  "upper_bound": "1994-07-25"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 600,
+                  "num_range": 7200,
+                  "upper_bound": "1994-08-05"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 750,
+                  "num_range": 7050,
+                  "upper_bound": "1994-08-16"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 1200,
+                  "num_range": 6750,
+                  "upper_bound": "1994-08-31"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 600,
+                  "num_range": 6750,
+                  "upper_bound": "1994-09-13"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1050,
+                  "num_range": 6300,
+                  "upper_bound": "1994-09-26"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 750,
+                  "num_range": 6900,
+                  "upper_bound": "1994-10-09"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 900,
+                  "num_range": 6450,
+                  "upper_bound": "1994-10-24"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 300,
+                  "num_range": 7050,
+                  "upper_bound": "1994-11-07"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 900,
+                  "num_range": 6600,
+                  "upper_bound": "1994-11-17"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 1050,
+                  "num_range": 6900,
+                  "upper_bound": "1994-12-01"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 900,
+                  "num_range": 7200,
+                  "upper_bound": "1994-12-12"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 900,
+                  "num_range": 6900,
+                  "upper_bound": "1994-12-25"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 900,
+                  "num_range": 6600,
+                  "upper_bound": "1995-01-07"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1200,
+                  "num_range": 6600,
+                  "upper_bound": "1995-01-19"
+              },
+              {
+                  "distinct_range": 16,
+                  "num_eq": 900,
+                  "num_range": 6600,
+                  "upper_bound": "1995-02-05"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 600,
+                  "num_range": 6750,
+                  "upper_bound": "1995-02-17"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 750,
+                  "num_range": 6900,
+                  "upper_bound": "1995-03-01"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1200,
+                  "num_range": 6300,
+                  "upper_bound": "1995-03-13"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 750,
+                  "num_range": 6750,
+                  "upper_bound": "1995-03-26"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 600,
+                  "num_range": 7050,
+                  "upper_bound": "1995-04-09"
+              },
+              {
+                  "distinct_range": 15,
+                  "num_eq": 1050,
+                  "num_range": 6900,
+                  "upper_bound": "1995-04-25"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 900,
+                  "num_range": 7050,
+                  "upper_bound": "1995-05-09"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 750,
+                  "num_range": 6750,
+                  "upper_bound": "1995-05-21"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 1350,
+                  "num_range": 6300,
+                  "upper_bound": "1995-05-31"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 600,
+                  "num_range": 7050,
+                  "upper_bound": "1995-06-11"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1050,
+                  "num_range": 6600,
+                  "upper_bound": "1995-06-22"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 900,
+                  "num_range": 6450,
+                  "upper_bound": "1995-07-06"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 300,
+                  "num_range": 7050,
+                  "upper_bound": "1995-07-19"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 900,
+                  "num_range": 6450,
+                  "upper_bound": "1995-07-31"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 600,
+                  "num_range": 7200,
+                  "upper_bound": "1995-08-15"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 750,
+                  "num_range": 6900,
+                  "upper_bound": "1995-08-27"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 750,
+                  "num_range": 6900,
+                  "upper_bound": "1995-09-06"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1050,
+                  "num_range": 7050,
+                  "upper_bound": "1995-09-18"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 1500,
+                  "num_range": 6000,
+                  "upper_bound": "1995-09-28"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1350,
+                  "num_range": 6750,
+                  "upper_bound": "1995-10-09"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1350,
+                  "num_range": 7050,
+                  "upper_bound": "1995-10-20"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 600,
+                  "num_range": 6900,
+                  "upper_bound": "1995-10-30"
+              },
+              {
+                  "distinct_range": 16,
+                  "num_eq": 450,
+                  "num_range": 7050,
+                  "upper_bound": "1995-11-16"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 1350,
+                  "num_range": 6150,
+                  "upper_bound": "1995-11-26"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 1050,
+                  "num_range": 6450,
+                  "upper_bound": "1995-12-05"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 750,
+                  "num_range": 7050,
+                  "upper_bound": "1995-12-18"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 750,
+                  "num_range": 6600,
+                  "upper_bound": "1995-12-29"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 750,
+                  "num_range": 6450,
+                  "upper_bound": "1996-01-08"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 750,
+                  "num_range": 6900,
+                  "upper_bound": "1996-01-22"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 750,
+                  "num_range": 6450,
+                  "upper_bound": "1996-02-03"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1350,
+                  "num_range": 6600,
+                  "upper_bound": "1996-02-14"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 900,
+                  "num_range": 6900,
+                  "upper_bound": "1996-02-23"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 750,
+                  "num_range": 6600,
+                  "upper_bound": "1996-03-05"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 750,
+                  "num_range": 6600,
+                  "upper_bound": "1996-03-18"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 450,
+                  "num_range": 7050,
+                  "upper_bound": "1996-03-30"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 600,
+                  "num_range": 6750,
+                  "upper_bound": "1996-04-11"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 300,
+                  "num_range": 6900,
+                  "upper_bound": "1996-04-21"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 900,
+                  "num_range": 7050,
+                  "upper_bound": "1996-05-02"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 900,
+                  "num_range": 6750,
+                  "upper_bound": "1996-05-13"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 750,
+                  "num_range": 6750,
+                  "upper_bound": "1996-05-25"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 900,
+                  "num_range": 6900,
+                  "upper_bound": "1996-06-04"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 750,
+                  "num_range": 7050,
+                  "upper_bound": "1996-06-19"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 300,
+                  "num_range": 6900,
+                  "upper_bound": "1996-07-02"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 450,
+                  "num_range": 7050,
+                  "upper_bound": "1996-07-14"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 750,
+                  "num_range": 6450,
+                  "upper_bound": "1996-07-26"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 450,
+                  "num_range": 6900,
+                  "upper_bound": "1996-08-07"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 600,
+                  "num_range": 6600,
+                  "upper_bound": "1996-08-19"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 1200,
+                  "num_range": 7050,
+                  "upper_bound": "1996-08-28"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 300,
+                  "num_range": 7050,
+                  "upper_bound": "1996-09-08"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 750,
+                  "num_range": 7050,
+                  "upper_bound": "1996-09-20"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1050,
+                  "num_range": 6300,
+                  "upper_bound": "1996-10-01"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 900,
+                  "num_range": 6900,
+                  "upper_bound": "1996-10-14"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 900,
+                  "num_range": 6750,
+                  "upper_bound": "1996-10-25"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1350,
+                  "num_range": 6900,
+                  "upper_bound": "1996-11-06"
+              },
+              {
+                  "distinct_range": 7,
+                  "num_eq": 1050,
+                  "num_range": 6750,
+                  "upper_bound": "1996-11-14"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 600,
+                  "num_range": 6900,
+                  "upper_bound": "1996-11-25"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 600,
+                  "num_range": 6750,
+                  "upper_bound": "1996-12-05"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 900,
+                  "num_range": 6300,
+                  "upper_bound": "1996-12-15"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 450,
+                  "num_range": 6600,
+                  "upper_bound": "1996-12-26"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 750,
+                  "num_range": 6750,
+                  "upper_bound": "1997-01-07"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 900,
+                  "num_range": 6450,
+                  "upper_bound": "1997-01-17"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 750,
+                  "num_range": 6600,
+                  "upper_bound": "1997-02-01"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 900,
+                  "num_range": 6750,
+                  "upper_bound": "1997-02-14"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 450,
+                  "num_range": 6900,
+                  "upper_bound": "1997-02-28"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 600,
+                  "num_range": 6600,
+                  "upper_bound": "1997-03-11"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 750,
+                  "num_range": 6750,
+                  "upper_bound": "1997-03-24"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 750,
+                  "num_range": 6600,
+                  "upper_bound": "1997-04-04"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 750,
+                  "num_range": 6450,
+                  "upper_bound": "1997-04-18"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 450,
+                  "num_range": 6600,
+                  "upper_bound": "1997-04-30"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 600,
+                  "num_range": 6750,
+                  "upper_bound": "1997-05-12"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 900,
+                  "num_range": 6300,
+                  "upper_bound": "1997-05-23"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 600,
+                  "num_range": 6900,
+                  "upper_bound": "1997-06-04"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1050,
+                  "num_range": 6000,
+                  "upper_bound": "1997-06-15"
+              },
+              {
+                  "distinct_range": 6,
+                  "num_eq": 900,
+                  "num_range": 6450,
+                  "upper_bound": "1997-06-22"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1050,
+                  "num_range": 6600,
+                  "upper_bound": "1997-07-05"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 900,
+                  "num_range": 6150,
+                  "upper_bound": "1997-07-17"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 600,
+                  "num_range": 6750,
+                  "upper_bound": "1997-07-30"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 600,
+                  "num_range": 6750,
+                  "upper_bound": "1997-08-09"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 750,
+                  "num_range": 6750,
+                  "upper_bound": "1997-08-19"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 900,
+                  "num_range": 6300,
+                  "upper_bound": "1997-08-29"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 900,
+                  "num_range": 6000,
+                  "upper_bound": "1997-09-10"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 900,
+                  "num_range": 6150,
+                  "upper_bound": "1997-09-20"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1050,
+                  "num_range": 5850,
+                  "upper_bound": "1997-10-01"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 450,
+                  "num_range": 6450,
+                  "upper_bound": "1997-10-14"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 900,
+                  "num_range": 6450,
+                  "upper_bound": "1997-10-25"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 900,
+                  "num_range": 6750,
+                  "upper_bound": "1997-11-06"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 750,
+                  "num_range": 6450,
+                  "upper_bound": "1997-11-17"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 750,
+                  "num_range": 6450,
+                  "upper_bound": "1997-11-29"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 600,
+                  "num_range": 6300,
+                  "upper_bound": "1997-12-10"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 750,
+                  "num_range": 6450,
+                  "upper_bound": "1997-12-25"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 300,
+                  "num_range": 6750,
+                  "upper_bound": "1998-01-05"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 1200,
+                  "num_range": 6750,
+                  "upper_bound": "1998-01-15"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1350,
+                  "num_range": 5550,
+                  "upper_bound": "1998-01-28"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 1050,
+                  "num_range": 5700,
+                  "upper_bound": "1998-02-06"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 900,
+                  "num_range": 6450,
+                  "upper_bound": "1998-02-18"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 750,
+                  "num_range": 6300,
+                  "upper_bound": "1998-03-01"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 750,
+                  "num_range": 6450,
+                  "upper_bound": "1998-03-14"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 300,
+                  "num_range": 6600,
+                  "upper_bound": "1998-03-27"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 750,
+                  "num_range": 6450,
+                  "upper_bound": "1998-04-09"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 450,
+                  "num_range": 6300,
+                  "upper_bound": "1998-04-24"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 150,
+                  "num_range": 6450,
+                  "upper_bound": "1998-05-05"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 900,
+                  "num_range": 6300,
+                  "upper_bound": "1998-05-16"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 750,
+                  "num_range": 5850,
+                  "upper_bound": "1998-05-25"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 450,
+                  "num_range": 6150,
+                  "upper_bound": "1998-06-06"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 450,
+                  "num_range": 6150,
+                  "upper_bound": "1998-06-16"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 750,
+                  "num_range": 6300,
+                  "upper_bound": "1998-06-28"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 450,
+                  "num_range": 6300,
+                  "upper_bound": "1998-07-12"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 600,
+                  "num_range": 6450,
+                  "upper_bound": "1998-07-23"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 450,
+                  "num_range": 5700,
+                  "upper_bound": "1998-08-02"
+              }
+          ],
+          "histo_col_type": "DATE",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 1500000
+      },
+      {
+          "avg_size": 3,
+          "columns": [
+              "o_orderstatus"
+          ],
+          "created_at": "2022-03-21 20:30:27.422548",
+          "distinct_count": 3,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 718650,
+                  "num_range": 0,
+                  "upper_bound": "F"
+              },
+              {
+                  "distinct_range": 1,
+                  "num_eq": 37950,
+                  "num_range": 743400,
+                  "upper_bound": "P"
+              }
+          ],
+          "histo_col_type": "CHAR",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 1500000
+      },
+      {
+          "avg_size": 9,
+          "columns": [
+              "o_totalprice"
+          ],
+          "created_at": "2022-03-21 20:30:27.422548",
+          "distinct_count": 1459167,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 150,
+                  "num_range": 0,
+                  "upper_bound": "920.63"
+              },
+              {
+                  "distinct_range": 1459165,
+                  "num_eq": 150,
+                  "num_range": 1499700,
+                  "upper_bound": "446717.46"
+              }
+          ],
+          "histo_col_type": "FLOAT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 1500000
+      },
+      {
+          "avg_size": 11,
+          "columns": [
+              "o_orderpriority"
+          ],
+          "created_at": "2022-03-21 20:30:27.422548",
+          "distinct_count": 5,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 308400,
+                  "num_range": 0,
+                  "upper_bound": "1-URGENT"
+              },
+              {
+                  "distinct_range": 3,
+                  "num_eq": 305100,
+                  "num_range": 886500,
+                  "upper_bound": "5-LOW"
+              }
+          ],
+          "histo_col_type": "CHAR(15)",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 1500000
+      },
+      {
+          "avg_size": 17,
+          "columns": [
+              "o_clerk"
+          ],
+          "created_at": "2022-03-21 20:30:27.422548",
+          "distinct_count": 1000,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 2550,
+                  "num_range": 0,
+                  "upper_bound": "Clerk#000000001"
+              },
+              {
+                  "distinct_range": 998.0000000000001,
+                  "num_eq": 1500,
+                  "num_range": 1495950,
+                  "upper_bound": "Clerk#000001000"
+              }
+          ],
+          "histo_col_type": "CHAR(15)",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 1500000
+      },
+      {
+          "avg_size": 2,
+          "columns": [
+              "o_shippriority"
+          ],
+          "created_at": "2022-03-21 20:30:27.422548",
+          "distinct_count": 1,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1500000,
+                  "num_range": 0,
+                  "upper_bound": "0"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 1500000
+      },
+      {
+          "avg_size": 51,
+          "columns": [
+              "o_comment"
+          ],
+          "created_at": "2022-03-21 20:30:27.422548",
+          "distinct_count": 1469402,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 150,
+                  "num_range": 0,
+                  "upper_bound": " Tiresias are slyly permanent packages. furiously unusual requests boost qui"
+              },
+              {
+                  "distinct_range": 1469400,
+                  "num_eq": 150,
+                  "num_range": 1499700,
+                  "upper_bound": "zzle. slyly special platele"
+              }
+          ],
+          "histo_col_type": "VARCHAR(79)",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 1500000
+      }
+  ]'
 
 statement ok
 CREATE TABLE public.lineitem
@@ -427,104 +12871,7661 @@ CREATE TABLE public.lineitem
 )
 
 statement ok
-ALTER TABLE public.lineitem INJECT STATISTICS '[
-  {
-    "columns": ["l_orderkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 6001215,
-    "distinct_count": 1500000
-  },
-  {
-    "columns": ["l_partkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 6001215,
-    "distinct_count": 200000
-  },
-  {
-    "columns": ["l_suppkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 6001215,
-    "distinct_count": 10000
-  },
-  {
-    "columns": ["l_linenumber"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 6001215,
-    "distinct_count": 7
-  },
-  {
-    "columns": ["l_quantity"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 6001215,
-    "distinct_count": 50
-  },
-  {
-    "columns": ["l_extendedprice"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 6001215,
-    "distinct_count": 1000000
-  },
-  {
-    "columns": ["l_discount"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 6001215,
-    "distinct_count": 11
-  },
-  {
-    "columns": ["l_tax"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 6001215,
-    "distinct_count": 9
-  },
-  {
-    "columns": ["l_returnflag"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 6001215,
-    "distinct_count": 3
-  },
-  {
-    "columns": ["l_linestatus"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 6001215,
-    "distinct_count": 2
-  },
-  {
-    "columns": ["l_shipdate"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 6001215,
-    "distinct_count": 2500
-  },
-  {
-    "columns": ["l_commitdate"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 6001215,
-    "distinct_count": 2500
-  },
-  {
-    "columns": ["l_receiptdate"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 6001215,
-    "distinct_count": 2500
-  },
-  {
-    "columns": ["l_shipinstruct"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 6001215,
-    "distinct_count": 4
-  },
-  {
-    "columns": ["l_shipmode"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 6001215,
-    "distinct_count": 7
-  },
-  {
-    "columns": ["l_comment"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 6001215,
-    "distinct_count": 4500000
-  }
-]'
+ALTER TABLE public.lineitem INJECT STATISTICS '
+  [
+      {
+          "avg_size": 4,
+          "columns": [
+              "l_orderkey"
+          ],
+          "created_at": "2022-03-21 20:30:59.932306",
+          "distinct_count": 1527270,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 600,
+                  "num_range": 0,
+                  "upper_bound": "995"
+              },
+              {
+                  "distinct_range": 8179.1277615419085,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "36384"
+              },
+              {
+                  "distinct_range": 7704.273416139362,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "66657"
+              },
+              {
+                  "distinct_range": 7928.288954091793,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "99200"
+              },
+              {
+                  "distinct_range": 7488.632352789523,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "127493"
+              },
+              {
+                  "distinct_range": 7907.38027022569,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "159814"
+              },
+              {
+                  "distinct_range": 7612.552365630732,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "189222"
+              },
+              {
+                  "distinct_range": 7387.3095166001385,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "216646"
+              },
+              {
+                  "distinct_range": 8058.793920104251,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "250626"
+              },
+              {
+                  "distinct_range": 7205.145450934152,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "276576"
+              },
+              {
+                  "distinct_range": 6595.106211871789,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "298279"
+              },
+              {
+                  "distinct_range": 6494.526078328326,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "319367"
+              },
+              {
+                  "distinct_range": 7534.63548836692,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "348067"
+              },
+              {
+                  "distinct_range": 7801.543702450052,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "379297"
+              },
+              {
+                  "distinct_range": 7934.9325250335005,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "411911"
+              },
+              {
+                  "distinct_range": 8378.293167581227,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "449831"
+              },
+              {
+                  "distinct_range": 7591.6814035058405,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "479047"
+              },
+              {
+                  "distinct_range": 7717.223858064172,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "509445"
+              },
+              {
+                  "distinct_range": 8351.809124029578,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "547013"
+              },
+              {
+                  "distinct_range": 7495.357284061049,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "575365"
+              },
+              {
+                  "distinct_range": 7278.311634205718,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "601894"
+              },
+              {
+                  "distinct_range": 7556.248237227882,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "630788"
+              },
+              {
+                  "distinct_range": 7717.430454850461,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "661188"
+              },
+              {
+                  "distinct_range": 7147.298858750126,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "686692"
+              },
+              {
+                  "distinct_range": 7443.924095955439,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "714597"
+              },
+              {
+                  "distinct_range": 8272.663329063333,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "751142"
+              },
+              {
+                  "distinct_range": 7823.603153534316,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "782595"
+              },
+              {
+                  "distinct_range": 6955.671780083769,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "806691"
+              },
+              {
+                  "distinct_range": 7633.234467204136,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "836291"
+              },
+              {
+                  "distinct_range": 7066.27247366936,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "861187"
+              },
+              {
+                  "distinct_range": 7237.759752940289,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "887393"
+              },
+              {
+                  "distinct_range": 7254.789106352047,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "913734"
+              },
+              {
+                  "distinct_range": 6573.160803332919,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "935301"
+              },
+              {
+                  "distinct_range": 7629.693065047387,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "964868"
+              },
+              {
+                  "distinct_range": 7281.920334397703,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "991426"
+              },
+              {
+                  "distinct_range": 7931.285831450829,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1024001"
+              },
+              {
+                  "distinct_range": 7820.94416728191,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1055427"
+              },
+              {
+                  "distinct_range": 7164.426811075386,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1081062"
+              },
+              {
+                  "distinct_range": 7598.115125530396,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1110337"
+              },
+              {
+                  "distinct_range": 6992.128018935816,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1134693"
+              },
+              {
+                  "distinct_range": 7143.097396549537,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1160165"
+              },
+              {
+                  "distinct_range": 7981.223474632083,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1193280"
+              },
+              {
+                  "distinct_range": 7013.763341014423,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1217792"
+              },
+              {
+                  "distinct_range": 7789.280099088435,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1248899"
+              },
+              {
+                  "distinct_range": 7100.298852945238,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1274048"
+              },
+              {
+                  "distinct_range": 7364.694312101137,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1301283"
+              },
+              {
+                  "distinct_range": 7484.633893864052,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1329541"
+              },
+              {
+                  "distinct_range": 7996.0654594379685,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1362819"
+              },
+              {
+                  "distinct_range": 7663.8030544262065,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1392706"
+              },
+              {
+                  "distinct_range": 8086.935382654758,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1427008"
+              },
+              {
+                  "distinct_range": 7910.501414834894,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1459362"
+              },
+              {
+                  "distinct_range": 7333.844076705288,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1486342"
+              },
+              {
+                  "distinct_range": 7753.393639424673,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1517093"
+              },
+              {
+                  "distinct_range": 6839.846121568277,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1540386"
+              },
+              {
+                  "distinct_range": 7495.584911386653,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1568740"
+              },
+              {
+                  "distinct_range": 8033.379531525697,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1602433"
+              },
+              {
+                  "distinct_range": 8442.176811131078,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1641223"
+              },
+              {
+                  "distinct_range": 7372.016512501144,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1668519"
+              },
+              {
+                  "distinct_range": 6445.371691660176,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1689314"
+              },
+              {
+                  "distinct_range": 7513.272211290474,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1717824"
+              },
+              {
+                  "distinct_range": 7711.431356071761,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1748166"
+              },
+              {
+                  "distinct_range": 7646.3858230997985,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1777889"
+              },
+              {
+                  "distinct_range": 6778.151465973583,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1800768"
+              },
+              {
+                  "distinct_range": 7928.382670999597,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1833312"
+              },
+              {
+                  "distinct_range": 7880.424244874233,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1865350"
+              },
+              {
+                  "distinct_range": 7061.123046856352,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1890208"
+              },
+              {
+                  "distinct_range": 7421.837707148026,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1917924"
+              },
+              {
+                  "distinct_range": 7836.066633697021,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1949504"
+              },
+              {
+                  "distinct_range": 8203.671986015708,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1985191"
+              },
+              {
+                  "distinct_range": 8192.426265107062,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2020741"
+              },
+              {
+                  "distinct_range": 7168.463186713386,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2046407"
+              },
+              {
+                  "distinct_range": 7733.383602905651,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2076962"
+              },
+              {
+                  "distinct_range": 7805.417810532219,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2108231"
+              },
+              {
+                  "distinct_range": 7797.961481299452,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2139425"
+              },
+              {
+                  "distinct_range": 7325.551049978504,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2166337"
+              },
+              {
+                  "distinct_range": 7005.047338771494,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2190786"
+              },
+              {
+                  "distinct_range": 8106.885554501141,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2225319"
+              },
+              {
+                  "distinct_range": 8001.411644709043,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2258656"
+              },
+              {
+                  "distinct_range": 6978.445512158375,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2282914"
+              },
+              {
+                  "distinct_range": 7524.427982280778,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2311523"
+              },
+              {
+                  "distinct_range": 7465.922768531649,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2339618"
+              },
+              {
+                  "distinct_range": 7588.731136016001,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2368807"
+              },
+              {
+                  "distinct_range": 8149.4007385943005,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2403840"
+              },
+              {
+                  "distinct_range": 8511.98180486435,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2443616"
+              },
+              {
+                  "distinct_range": 7440.548428224257,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2471492"
+              },
+              {
+                  "distinct_range": 7845.7326534819185,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2503171"
+              },
+              {
+                  "distinct_range": 8004.847655159716,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2536546"
+              },
+              {
+                  "distinct_range": 6983.340233829548,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2560839"
+              },
+              {
+                  "distinct_range": 7622.701422487463,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2590341"
+              },
+              {
+                  "distinct_range": 7958.344529020531,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2623207"
+              },
+              {
+                  "distinct_range": 7277.564349531747,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2649730"
+              },
+              {
+                  "distinct_range": 7901.2191019512475,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2681986"
+              },
+              {
+                  "distinct_range": 7858.650437816855,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2713798"
+              },
+              {
+                  "distinct_range": 7909.934275618605,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2746146"
+              },
+              {
+                  "distinct_range": 7520.602705073387,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2774721"
+              },
+              {
+                  "distinct_range": 7421.955105154875,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2802438"
+              },
+              {
+                  "distinct_range": 7690.6203107574775,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2832580"
+              },
+              {
+                  "distinct_range": 7375.729169027825,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2859907"
+              },
+              {
+                  "distinct_range": 7704.377318454027,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2890181"
+              },
+              {
+                  "distinct_range": 8024.628758273643,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2923776"
+              },
+              {
+                  "distinct_range": 8089.884172289322,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2958112"
+              },
+              {
+                  "distinct_range": 7620.006607598851,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2987589"
+              },
+              {
+                  "distinct_range": 7759.78713602076,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3018403"
+              },
+              {
+                  "distinct_range": 8332.310809807013,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3055715"
+              },
+              {
+                  "distinct_range": 6901.046187214327,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3079428"
+              },
+              {
+                  "distinct_range": 7250.007401987431,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3105731"
+              },
+              {
+                  "distinct_range": 7931.472994943457,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3138308"
+              },
+              {
+                  "distinct_range": 7398.834571738558,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3165829"
+              },
+              {
+                  "distinct_range": 8103.272899702936,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3200320"
+              },
+              {
+                  "distinct_range": 7455.759237709824,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3228327"
+              },
+              {
+                  "distinct_range": 8489.128316420927,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3267776"
+              },
+              {
+                  "distinct_range": 7999.600924182763,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3301093"
+              },
+              {
+                  "distinct_range": 7535.306942879509,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3329799"
+              },
+              {
+                  "distinct_range": 8155.197361697665,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3364901"
+              },
+              {
+                  "distinct_range": 7409.950782660059,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3392516"
+              },
+              {
+                  "distinct_range": 7952.330667020978,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3425317"
+              },
+              {
+                  "distinct_range": 7435.8844759056365,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3453153"
+              },
+              {
+                  "distinct_range": 7398.597497505272,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3480672"
+              },
+              {
+                  "distinct_range": 7452.052590404787,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3508647"
+              },
+              {
+                  "distinct_range": 7313.058642807285,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3535457"
+              },
+              {
+                  "distinct_range": 7687.691262693357,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3565571"
+              },
+              {
+                  "distinct_range": 7380.033506357436,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3592934"
+              },
+              {
+                  "distinct_range": 7626.038575020162,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3622467"
+              },
+              {
+                  "distinct_range": 7759.685796649607,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3653280"
+              },
+              {
+                  "distinct_range": 7148.217008102216,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3678791"
+              },
+              {
+                  "distinct_range": 7759.584452619268,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3709603"
+              },
+              {
+                  "distinct_range": 7910.6904275447,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3741959"
+              },
+              {
+                  "distinct_range": 7476.387118437842,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3770145"
+              },
+              {
+                  "distinct_range": 7737.78907689015,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3800743"
+              },
+              {
+                  "distinct_range": 7469.722883490488,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3828871"
+              },
+              {
+                  "distinct_range": 7937.1735104410245,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3861509"
+              },
+              {
+                  "distinct_range": 7740.550834593849,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3892134"
+              },
+              {
+                  "distinct_range": 7262.069839565306,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3918533"
+              },
+              {
+                  "distinct_range": 7172.36326165762,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3944229"
+              },
+              {
+                  "distinct_range": 7937.080183639186,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3976866"
+              },
+              {
+                  "distinct_range": 7278.43615973082,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4003396"
+              },
+              {
+                  "distinct_range": 6705.482181808514,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4025799"
+              },
+              {
+                  "distinct_range": 8210.780088127887,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4061573"
+              },
+              {
+                  "distinct_range": 7491.940228430887,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4089895"
+              },
+              {
+                  "distinct_range": 7591.462995028163,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4119109"
+              },
+              {
+                  "distinct_range": 8536.330055256096,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4159238"
+              },
+              {
+                  "distinct_range": 8125.533322809582,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4193989"
+              },
+              {
+                  "distinct_range": 7922.094422192666,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4226466"
+              },
+              {
+                  "distinct_range": 7707.388384695694,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4256769"
+              },
+              {
+                  "distinct_range": 7318.210281534469,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4283621"
+              },
+              {
+                  "distinct_range": 8604.731457390933,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4324768"
+              },
+              {
+                  "distinct_range": 7677.724841571257,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4354787"
+              },
+              {
+                  "distinct_range": 7387.547703587221,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4382213"
+              },
+              {
+                  "distinct_range": 7915.975948493891,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4414625"
+              },
+              {
+                  "distinct_range": 7667.925269348942,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4444551"
+              },
+              {
+                  "distinct_range": 8226.214240984746,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4480515"
+              },
+              {
+                  "distinct_range": 7782.570862280902,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4511555"
+              },
+              {
+                  "distinct_range": 7477.955854059063,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "4539040"
+              },
+              {
+                  "distinct_range": 8045.670182968151,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "4571778"
+              },
+              {
+                  "distinct_range": 7626.530752434935,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "4600518"
+              },
+              {
+                  "distinct_range": 6789.859716474711,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "4623042"
+              },
+              {
+                  "distinct_range": 8317.98895263292,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "4658817"
+              },
+              {
+                  "distinct_range": 7932.508989717865,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "4690402"
+              },
+              {
+                  "distinct_range": 7772.541960405981,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "4720453"
+              },
+              {
+                  "distinct_range": 7954.452216587694,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "4752257"
+              },
+              {
+                  "distinct_range": 8054.64383244901,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "4785089"
+              },
+              {
+                  "distinct_range": 7637.188638422973,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "4813922"
+              },
+              {
+                  "distinct_range": 7478.8098559238415,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "4841414"
+              },
+              {
+                  "distinct_range": 8184.7597047046165,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "4875654"
+              },
+              {
+                  "distinct_range": 8120.2301970937115,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "4909185"
+              },
+              {
+                  "distinct_range": 8221.6333729974,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "4943840"
+              },
+              {
+                  "distinct_range": 7806.632731103328,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "4974209"
+              },
+              {
+                  "distinct_range": 7559.691460923423,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5002375"
+              },
+              {
+                  "distinct_range": 8129.359348063116,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5036005"
+              },
+              {
+                  "distinct_range": 8249.713751536046,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5070981"
+              },
+              {
+                  "distinct_range": 8291.173081566189,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5106439"
+              },
+              {
+                  "distinct_range": 7633.068596583709,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5135236"
+              },
+              {
+                  "distinct_range": 7329.057742783001,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5161536"
+              },
+              {
+                  "distinct_range": 8395.070312326638,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5198246"
+              },
+              {
+                  "distinct_range": 7998.48172245825,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5230496"
+              },
+              {
+                  "distinct_range": 8069.8333578694655,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5263488"
+              },
+              {
+                  "distinct_range": 8448.525552920575,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5300868"
+              },
+              {
+                  "distinct_range": 7040.741222550735,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5325057"
+              },
+              {
+                  "distinct_range": 7562.876895577876,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5353250"
+              },
+              {
+                  "distinct_range": 7676.767665456541,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5382432"
+              },
+              {
+                  "distinct_range": 6990.853082038483,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5406278"
+              },
+              {
+                  "distinct_range": 7621.817110739473,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5434977"
+              },
+              {
+                  "distinct_range": 7008.8463685246015,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5458946"
+              },
+              {
+                  "distinct_range": 7509.601550916518,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5486692"
+              },
+              {
+                  "distinct_range": 7158.801866819241,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5511718"
+              },
+              {
+                  "distinct_range": 8017.266023217977,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5544161"
+              },
+              {
+                  "distinct_range": 7850.27386385119,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5574944"
+              },
+              {
+                  "distinct_range": 7648.4824935410625,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5603876"
+              },
+              {
+                  "distinct_range": 7652.008060640322,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5632839"
+              },
+              {
+                  "distinct_range": 8492.805061858964,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5670788"
+              },
+              {
+                  "distinct_range": 8553.765151731284,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5709542"
+              },
+              {
+                  "distinct_range": 8144.122708505401,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5743333"
+              },
+              {
+                  "distinct_range": 7712.8218027985895,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5772838"
+              },
+              {
+                  "distinct_range": 7998.48172245825,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5805088"
+              },
+              {
+                  "distinct_range": 7793.613059779613,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5835335"
+              },
+              {
+                  "distinct_range": 8072.197130668178,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5868352"
+              },
+              {
+                  "distinct_range": 7913.600384947234,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5899750"
+              },
+              {
+                  "distinct_range": 7374.83909858943,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5926407"
+              },
+              {
+                  "distinct_range": 8333.559903190759,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5962368"
+              },
+              {
+                  "distinct_range": 8405.153678575303,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "5999203"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 6001215
+      },
+      {
+          "avg_size": 1,
+          "columns": [
+              "l_linenumber"
+          ],
+          "created_at": "2022-03-21 20:30:59.932306",
+          "distinct_count": 7,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1499104,
+                  "num_range": 0,
+                  "upper_bound": "1"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1328669,
+                  "num_range": 0,
+                  "upper_bound": "2"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1040611,
+                  "num_range": 0,
+                  "upper_bound": "3"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 841370,
+                  "num_range": 0,
+                  "upper_bound": "4"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 648731,
+                  "num_range": 0,
+                  "upper_bound": "5"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 430887,
+                  "num_range": 0,
+                  "upper_bound": "6"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 211843,
+                  "num_range": 0,
+                  "upper_bound": "7"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 6001215
+      },
+      {
+          "avg_size": 5,
+          "columns": [
+              "l_orderkey",
+              "l_linenumber"
+          ],
+          "created_at": "2022-03-21 20:30:59.932306",
+          "distinct_count": 5986645,
+          "histo_col_type": "",
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 6001215
+      },
+      {
+          "avg_size": 4,
+          "columns": [
+              "l_partkey"
+          ],
+          "created_at": "2022-03-21 20:30:59.932306",
+          "distinct_count": 199241,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 600,
+                  "num_range": 0,
+                  "upper_bound": "17"
+              },
+              {
+                  "distinct_range": 926.6897452943025,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "948"
+              },
+              {
+                  "distinct_range": 1002.4192298558062,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1955"
+              },
+              {
+                  "distinct_range": 910.7466959128934,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "2870"
+              },
+              {
+                  "distinct_range": 1231.6005646570004,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4107"
+              },
+              {
+                  "distinct_range": 938.6470323303495,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "5050"
+              },
+              {
+                  "distinct_range": 1067.1878679667198,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "6122"
+              },
+              {
+                  "distinct_range": 1064.1985462078023,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "7191"
+              },
+              {
+                  "distinct_range": 679.5724798825008,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "7874"
+              },
+              {
+                  "distinct_range": 803.13111258841,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "8681"
+              },
+              {
+                  "distinct_range": 844.9816172146044,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "9530"
+              },
+              {
+                  "distinct_range": 1245.5507328475521,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "10781"
+              },
+              {
+                  "distinct_range": 984.4832993018072,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "11770"
+              },
+              {
+                  "distinct_range": 1027.3302445140394,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "12802"
+              },
+              {
+                  "distinct_range": 1069.1807491393272,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "13876"
+              },
+              {
+                  "distinct_range": 1102.0632884867125,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "14983"
+              },
+              {
+                  "distinct_range": 725.4087468540479,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "15712"
+              },
+              {
+                  "distinct_range": 1034.3053286183135,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "16751"
+              },
+              {
+                  "distinct_range": 814.0919590381277,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "17569"
+              },
+              {
+                  "distinct_range": 1019.3587198234213,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "18593"
+              },
+              {
+                  "distinct_range": 955.5865222980755,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "19553"
+              },
+              {
+                  "distinct_range": 1154.8746395547785,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "20713"
+              },
+              {
+                  "distinct_range": 937.6505917440123,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "21655"
+              },
+              {
+                  "distinct_range": 993.451264578812,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "22653"
+              },
+              {
+                  "distinct_range": 1204.6966688500045,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "23863"
+              },
+              {
+                  "distinct_range": 1120.9956596252969,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "24989"
+              },
+              {
+                  "distinct_range": 950.6043193663925,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "25944"
+              },
+              {
+                  "distinct_range": 1131.9565060735317,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "27081"
+              },
+              {
+                  "distinct_range": 1244.554292262672,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "28331"
+              },
+              {
+                  "distinct_range": 863.9139883550251,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "29199"
+              },
+              {
+                  "distinct_range": 910.7466959129022,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "30114"
+              },
+              {
+                  "distinct_range": 931.6719482259892,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "31050"
+              },
+              {
+                  "distinct_range": 1028.3266851003652,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "32083"
+              },
+              {
+                  "distinct_range": 826.0492460741834,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "32913"
+              },
+              {
+                  "distinct_range": 902.7751712222008,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "33820"
+              },
+              {
+                  "distinct_range": 980.4975369564687,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "34805"
+              },
+              {
+                  "distinct_range": 1044.2697344815292,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "35854"
+              },
+              {
+                  "distinct_range": 840.9958548692526,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "36699"
+              },
+              {
+                  "distinct_range": 931.6719482259892,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "37635"
+              },
+              {
+                  "distinct_range": 1131.9565060735317,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "38772"
+              },
+              {
+                  "distinct_range": 910.7466959129022,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "39687"
+              },
+              {
+                  "distinct_range": 969.5366905067808,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "40661"
+              },
+              {
+                  "distinct_range": 1124.9814219701507,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "41791"
+              },
+              {
+                  "distinct_range": 1080.1415955886025,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "42876"
+              },
+              {
+                  "distinct_range": 710.4621380589782,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "43590"
+              },
+              {
+                  "distinct_range": 902.7751712222008,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "44497"
+              },
+              {
+                  "distinct_range": 1027.3302445140394,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "45529"
+              },
+              {
+                  "distinct_range": 1136.938709004419,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "46671"
+              },
+              {
+                  "distinct_range": 1081.138036174894,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "47757"
+              },
+              {
+                  "distinct_range": 1020.3551604097496,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "48782"
+              },
+              {
+                  "distinct_range": 1000.4263486831418,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "49787"
+              },
+              {
+                  "distinct_range": 1151.8853177964886,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "50944"
+              },
+              {
+                  "distinct_range": 916.7253394309279,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "51865"
+              },
+              {
+                  "distinct_range": 995.4441457514785,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "52865"
+              },
+              {
+                  "distinct_range": 895.8000871178366,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "53765"
+              },
+              {
+                  "distinct_range": 1336.2268258820784,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "55107"
+              },
+              {
+                  "distinct_range": 1145.9066742797777,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "56258"
+              },
+              {
+                  "distinct_range": 1013.3800763054466,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "57276"
+              },
+              {
+                  "distinct_range": 984.4832993018072,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "58265"
+              },
+              {
+                  "distinct_range": 1094.091763796572,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "59364"
+              },
+              {
+                  "distinct_range": 1045.2661750678483,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "60414"
+              },
+              {
+                  "distinct_range": 1261.4937822017048,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "61681"
+              },
+              {
+                  "distinct_range": 753.3090832715112,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "62438"
+              },
+              {
+                  "distinct_range": 856.9389042506598,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "63299"
+              },
+              {
+                  "distinct_range": 1035.301769204637,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "64339"
+              },
+              {
+                  "distinct_range": 1134.9458278320747,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "65479"
+              },
+              {
+                  "distinct_range": 1053.2376997583824,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "66537"
+              },
+              {
+                  "distinct_range": 1017.3658386507641,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "67559"
+              },
+              {
+                  "distinct_range": 889.8214435998099,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "68453"
+              },
+              {
+                  "distinct_range": 958.5758440570412,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "69416"
+              },
+              {
+                  "distinct_range": 1057.2234621036353,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "70478"
+              },
+              {
+                  "distinct_range": 1275.4439502996818,
+                  "num_eq": 1800,
+                  "num_range": 28806,
+                  "upper_bound": "71759"
+              },
+              {
+                  "distinct_range": 919.7146611899404,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "72683"
+              },
+              {
+                  "distinct_range": 856.9389042506598,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "73544"
+              },
+              {
+                  "distinct_range": 807.1168749337618,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "74355"
+              },
+              {
+                  "distinct_range": 907.7573741538891,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "75267"
+              },
+              {
+                  "distinct_range": 1024.3409227550596,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "76296"
+              },
+              {
+                  "distinct_range": 985.4797398881415,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "77286"
+              },
+              {
+                  "distinct_range": 909.7502553265646,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "78200"
+              },
+              {
+                  "distinct_range": 1187.7571788921482,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "79393"
+              },
+              {
+                  "distinct_range": 1002.4192298558062,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "80400"
+              },
+              {
+                  "distinct_range": 954.5900817117389,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "81359"
+              },
+              {
+                  "distinct_range": 1062.205665035187,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "82426"
+              },
+              {
+                  "distinct_range": 1068.184308553024,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "83499"
+              },
+              {
+                  "distinct_range": 1066.1914273804148,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "84570"
+              },
+              {
+                  "distinct_range": 882.8463594954451,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "85457"
+              },
+              {
+                  "distinct_range": 1014.3765168917763,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "86476"
+              },
+              {
+                  "distinct_range": 1039.2875315499268,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "87520"
+              },
+              {
+                  "distinct_range": 850.9602607326322,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "88375"
+              },
+              {
+                  "distinct_range": 976.5117746111288,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "89356"
+              },
+              {
+                  "distinct_range": 823.0599243151695,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "90183"
+              },
+              {
+                  "distinct_range": 965.5509281614377,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "91153"
+              },
+              {
+                  "distinct_range": 983.4868587154726,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "92141"
+              },
+              {
+                  "distinct_range": 1190.7465006496484,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "93337"
+              },
+              {
+                  "distinct_range": 903.7716118085384,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "94245"
+              },
+              {
+                  "distinct_range": 1091.1024420377432,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "95341"
+              },
+              {
+                  "distinct_range": 1096.0846449691167,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "96442"
+              },
+              {
+                  "distinct_range": 962.5616064024294,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "97409"
+              },
+              {
+                  "distinct_range": 826.0492460741834,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "98239"
+              },
+              {
+                  "distinct_range": 804.127553174748,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "99047"
+              },
+              {
+                  "distinct_range": 909.7502553265646,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "99961"
+              },
+              {
+                  "distinct_range": 1007.4014327874638,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "100973"
+              },
+              {
+                  "distinct_range": 1046.262615654167,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "102024"
+              },
+              {
+                  "distinct_range": 819.0741619698175,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "102847"
+              },
+              {
+                  "distinct_range": 973.5224528521231,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "103825"
+              },
+              {
+                  "distinct_range": 998.4334675104769,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "104828"
+              },
+              {
+                  "distinct_range": 980.4975369564687,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "105813"
+              },
+              {
+                  "distinct_range": 1146.9031148596732,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "106965"
+              },
+              {
+                  "distinct_range": 968.5402499204453,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "107938"
+              },
+              {
+                  "distinct_range": 1039.2875315499268,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "108982"
+              },
+              {
+                  "distinct_range": 819.0741619698175,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "109805"
+              },
+              {
+                  "distinct_range": 780.2129791026366,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "110589"
+              },
+              {
+                  "distinct_range": 838.0065331102388,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "111431"
+              },
+              {
+                  "distinct_range": 1075.1593926571286,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "112511"
+              },
+              {
+                  "distinct_range": 952.5972005390659,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "113468"
+              },
+              {
+                  "distinct_range": 964.5544875751016,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "114437"
+              },
+              {
+                  "distinct_range": 785.1951820343264,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "115226"
+              },
+              {
+                  "distinct_range": 1049.2519374131195,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "116280"
+              },
+              {
+                  "distinct_range": 930.6755076396519,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "117215"
+              },
+              {
+                  "distinct_range": 977.5082151974639,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "118197"
+              },
+              {
+                  "distinct_range": 763.2734891348911,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "118964"
+              },
+              {
+                  "distinct_range": 1005.4085516148014,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "119974"
+              },
+              {
+                  "distinct_range": 1192.739381821264,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "121172"
+              },
+              {
+                  "distinct_range": 942.6327946756977,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "122119"
+              },
+              {
+                  "distinct_range": 845.9780578009423,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "122969"
+              },
+              {
+                  "distinct_range": 1173.8070106893933,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "124148"
+              },
+              {
+                  "distinct_range": 1252.525816940944,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "125406"
+              },
+              {
+                  "distinct_range": 1108.0419320042438,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "126519"
+              },
+              {
+                  "distinct_range": 1073.1665114845318,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "127597"
+              },
+              {
+                  "distinct_range": 1080.1415955886025,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "128682"
+              },
+              {
+                  "distinct_range": 1102.0632884867125,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "129789"
+              },
+              {
+                  "distinct_range": 897.7929682905121,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "130691"
+              },
+              {
+                  "distinct_range": 1266.4759851231684,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "131963"
+              },
+              {
+                  "distinct_range": 1081.138036174894,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "133049"
+              },
+              {
+                  "distinct_range": 991.4583834061451,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "134045"
+              },
+              {
+                  "distinct_range": 967.5438093341093,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "135017"
+              },
+              {
+                  "distinct_range": 1040.2839721362482,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "136062"
+              },
+              {
+                  "distinct_range": 986.4761804744757,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "137053"
+              },
+              {
+                  "distinct_range": 873.8783942184042,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "137931"
+              },
+              {
+                  "distinct_range": 795.1595878977062,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "138730"
+              },
+              {
+                  "distinct_range": 1240.5685299228944,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "139976"
+              },
+              {
+                  "distinct_range": 1115.0170161079368,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "141096"
+              },
+              {
+                  "distinct_range": 1179.7856542050645,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "142281"
+              },
+              {
+                  "distinct_range": 938.6470323303495,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "143224"
+              },
+              {
+                  "distinct_range": 1223.6290399747638,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "144453"
+              },
+              {
+                  "distinct_range": 888.825003013472,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "145346"
+              },
+              {
+                  "distinct_range": 941.6363540893607,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "146292"
+              },
+              {
+                  "distinct_range": 973.5224528521231,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "147270"
+              },
+              {
+                  "distinct_range": 1003.4156704421381,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "148278"
+              },
+              {
+                  "distinct_range": 1071.1736303119314,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "149354"
+              },
+              {
+                  "distinct_range": 980.4975369564687,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "150339"
+              },
+              {
+                  "distinct_range": 877.8641565637557,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "151221"
+              },
+              {
+                  "distinct_range": 1003.4156704421381,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "152229"
+              },
+              {
+                  "distinct_range": 859.9282260096735,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "153093"
+              },
+              {
+                  "distinct_range": 1073.1665114845318,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "154171"
+              },
+              {
+                  "distinct_range": 952.597200539085,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "155128"
+              },
+              {
+                  "distinct_range": 900.7822900495286,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "156033"
+              },
+              {
+                  "distinct_range": 826.0492460741834,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "156863"
+              },
+              {
+                  "distinct_range": 945.6221164347237,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "157813"
+              },
+              {
+                  "distinct_range": 1113.0241349371508,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "158931"
+              },
+              {
+                  "distinct_range": 1187.7571789011386,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "160124"
+              },
+              {
+                  "distinct_range": 988.4690616472029,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "161117"
+              },
+              {
+                  "distinct_range": 1188.7536194871718,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "162311"
+              },
+              {
+                  "distinct_range": 968.5402499204772,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "163284"
+              },
+              {
+                  "distinct_range": 944.6256758483863,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "164233"
+              },
+              {
+                  "distinct_range": 907.7573741538934,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "165145"
+              },
+              {
+                  "distinct_range": 1042.276853309167,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "166192"
+              },
+              {
+                  "distinct_range": 1007.4014327875677,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "167204"
+              },
+              {
+                  "distinct_range": 1101.0668479017145,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "168310"
+              },
+              {
+                  "distinct_range": 1229.6076834865607,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "169545"
+              },
+              {
+                  "distinct_range": 1154.8746395592004,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "170705"
+              },
+              {
+                  "distinct_range": 944.6256758483863,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "171654"
+              },
+              {
+                  "distinct_range": 897.7929682905151,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "172556"
+              },
+              {
+                  "distinct_range": 1076.1558332441039,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "173637"
+              },
+              {
+                  "distinct_range": 1033.3088880322066,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "174675"
+              },
+              {
+                  "distinct_range": 988.4690616472029,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "175668"
+              },
+              {
+                  "distinct_range": 986.4761804745314,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "176659"
+              },
+              {
+                  "distinct_range": 696.5119698502465,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "177359"
+              },
+              {
+                  "distinct_range": 1161.849723662424,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "178526"
+              },
+              {
+                  "distinct_range": 834.0207707648872,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "179364"
+              },
+              {
+                  "distinct_range": 1073.1665114851603,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "180442"
+              },
+              {
+                  "distinct_range": 963.5580469887929,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "181410"
+              },
+              {
+                  "distinct_range": 1064.1985462083003,
+                  "num_eq": 1200,
+                  "num_range": 30006,
+                  "upper_bound": "182479"
+              },
+              {
+                  "distinct_range": 946.6185570210453,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "183430"
+              },
+              {
+                  "distinct_range": 908.7538147402313,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "184343"
+              },
+              {
+                  "distinct_range": 1099.073966729126,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "185447"
+              },
+              {
+                  "distinct_range": 1021.3516009962326,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "186473"
+              },
+              {
+                  "distinct_range": 1380.0702115441534,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "187859"
+              },
+              {
+                  "distinct_range": 978.5046557838426,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "188842"
+              },
+              {
+                  "distinct_range": 1073.1665114851603,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "189920"
+              },
+              {
+                  "distinct_range": 887.8285624271363,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "190812"
+              },
+              {
+                  "distinct_range": 954.5900817117594,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "191771"
+              },
+              {
+                  "distinct_range": 808.1133155201,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "192583"
+              },
+              {
+                  "distinct_range": 1042.276853309167,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "193630"
+              },
+              {
+                  "distinct_range": 1086.1202391072075,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "194721"
+              },
+              {
+                  "distinct_range": 1190.7465006592195,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "195917"
+              },
+              {
+                  "distinct_range": 1034.3053286185364,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "196956"
+              },
+              {
+                  "distinct_range": 885.8356812544605,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "197846"
+              },
+              {
+                  "distinct_range": 1189.7500600731987,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "199041"
+              },
+              {
+                  "distinct_range": 922.7039829489597,
+                  "num_eq": 600,
+                  "num_range": 30006,
+                  "upper_bound": "199968"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 6001215
+      },
+      {
+          "avg_size": 4,
+          "columns": [
+              "l_suppkey"
+          ],
+          "created_at": "2022-03-21 20:30:59.932306",
+          "distinct_count": 9920,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1200,
+                  "num_range": 0,
+                  "upper_bound": "3"
+              },
+              {
+                  "distinct_range": 33.739663093415004,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "38"
+              },
+              {
+                  "distinct_range": 35.724349157733535,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "75"
+              },
+              {
+                  "distinct_range": 53.586523736600306,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "130"
+              },
+              {
+                  "distinct_range": 33.739663093415004,
+                  "num_eq": 3001,
+                  "num_range": 28806,
+                  "upper_bound": "165"
+              },
+              {
+                  "distinct_range": 48.62480857580398,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "215"
+              },
+              {
+                  "distinct_range": 50.60949464012251,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "267"
+              },
+              {
+                  "distinct_range": 50.60949464012251,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "319"
+              },
+              {
+                  "distinct_range": 40.68606431852986,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "361"
+              },
+              {
+                  "distinct_range": 42.67075038284839,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "405"
+              },
+              {
+                  "distinct_range": 31.754977029096477,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "438"
+              },
+              {
+                  "distinct_range": 42.67075038284839,
+                  "num_eq": 3001,
+                  "num_range": 28206,
+                  "upper_bound": "482"
+              },
+              {
+                  "distinct_range": 56.5635528330781,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "540"
+              },
+              {
+                  "distinct_range": 47.63246554364471,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "589"
+              },
+              {
+                  "distinct_range": 42.67075038284839,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "633"
+              },
+              {
+                  "distinct_range": 39.6937212863706,
+                  "num_eq": 1800,
+                  "num_range": 28806,
+                  "upper_bound": "674"
+              },
+              {
+                  "distinct_range": 38.70137825421133,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "714"
+              },
+              {
+                  "distinct_range": 48.62480857580398,
+                  "num_eq": 1800,
+                  "num_range": 29406,
+                  "upper_bound": "764"
+              },
+              {
+                  "distinct_range": 50.60949464012251,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "816"
+              },
+              {
+                  "distinct_range": 36.716692189892804,
+                  "num_eq": 2400,
+                  "num_range": 27606,
+                  "upper_bound": "854"
+              },
+              {
+                  "distinct_range": 57.55589586523736,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "913"
+              },
+              {
+                  "distinct_range": 35.724349157733535,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "950"
+              },
+              {
+                  "distinct_range": 60.53292496171516,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "1012"
+              },
+              {
+                  "distinct_range": 45.64777947932618,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1059"
+              },
+              {
+                  "distinct_range": 47.63246554364471,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1108"
+              },
+              {
+                  "distinct_range": 47.63246554364471,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "1157"
+              },
+              {
+                  "distinct_range": 51.601837672281775,
+                  "num_eq": 2400,
+                  "num_range": 28206,
+                  "upper_bound": "1210"
+              },
+              {
+                  "distinct_range": 50.60949464012251,
+                  "num_eq": 1800,
+                  "num_range": 28806,
+                  "upper_bound": "1262"
+              },
+              {
+                  "distinct_range": 52.59418070444104,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1316"
+              },
+              {
+                  "distinct_range": 60.53292496171516,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "1378"
+              },
+              {
+                  "distinct_range": 54.57886676875957,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1434"
+              },
+              {
+                  "distinct_range": 56.5635528330781,
+                  "num_eq": 1800,
+                  "num_range": 29406,
+                  "upper_bound": "1492"
+              },
+              {
+                  "distinct_range": 71.44869831546707,
+                  "num_eq": 1800,
+                  "num_range": 29406,
+                  "upper_bound": "1565"
+              },
+              {
+                  "distinct_range": 43.66309341500766,
+                  "num_eq": 1800,
+                  "num_range": 28806,
+                  "upper_bound": "1610"
+              },
+              {
+                  "distinct_range": 43.66309341500766,
+                  "num_eq": 1800,
+                  "num_range": 28806,
+                  "upper_bound": "1655"
+              },
+              {
+                  "distinct_range": 56.5635528330781,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "1713"
+              },
+              {
+                  "distinct_range": 52.59418070444104,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1767"
+              },
+              {
+                  "distinct_range": 62.51761102603369,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "1831"
+              },
+              {
+                  "distinct_range": 43.66309341500766,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "1876"
+              },
+              {
+                  "distinct_range": 45.64777947932618,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1923"
+              },
+              {
+                  "distinct_range": 41.67840735068913,
+                  "num_eq": 2400,
+                  "num_range": 28806,
+                  "upper_bound": "1966"
+              },
+              {
+                  "distinct_range": 42.67075038284839,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "2010"
+              },
+              {
+                  "distinct_range": 63.50995405819295,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2075"
+              },
+              {
+                  "distinct_range": 53.586523736600306,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "2130"
+              },
+              {
+                  "distinct_range": 58.54823889739663,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2190"
+              },
+              {
+                  "distinct_range": 45.64777947932618,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "2237"
+              },
+              {
+                  "distinct_range": 52.59418070444104,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2291"
+              },
+              {
+                  "distinct_range": 37.709035222052066,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "2330"
+              },
+              {
+                  "distinct_range": 54.57886676875957,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2386"
+              },
+              {
+                  "distinct_range": 57.55589586523736,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2445"
+              },
+              {
+                  "distinct_range": 45.64777947932618,
+                  "num_eq": 3001,
+                  "num_range": 28206,
+                  "upper_bound": "2492"
+              },
+              {
+                  "distinct_range": 42.67075038284839,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "2536"
+              },
+              {
+                  "distinct_range": 44.65543644716692,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "2582"
+              },
+              {
+                  "distinct_range": 49.617151607963244,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "2633"
+              },
+              {
+                  "distinct_range": 63.50995405819295,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "2698"
+              },
+              {
+                  "distinct_range": 49.617151607963244,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2749"
+              },
+              {
+                  "distinct_range": 58.54823889739663,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2809"
+              },
+              {
+                  "distinct_range": 53.586523736600306,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "2864"
+              },
+              {
+                  "distinct_range": 38.70137825421133,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "2904"
+              },
+              {
+                  "distinct_range": 58.54823889739663,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "2964"
+              },
+              {
+                  "distinct_range": 40.68606431852986,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3006"
+              },
+              {
+                  "distinct_range": 51.601837672281775,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3059"
+              },
+              {
+                  "distinct_range": 51.601837672281775,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3112"
+              },
+              {
+                  "distinct_range": 51.601837672281775,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "3165"
+              },
+              {
+                  "distinct_range": 50.60949464012251,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "3217"
+              },
+              {
+                  "distinct_range": 48.62480857580398,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "3267"
+              },
+              {
+                  "distinct_range": 46.64012251148545,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3315"
+              },
+              {
+                  "distinct_range": 50.60949464012251,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3367"
+              },
+              {
+                  "distinct_range": 42.67075038284839,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "3411"
+              },
+              {
+                  "distinct_range": 55.57120980091884,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "3468"
+              },
+              {
+                  "distinct_range": 43.66309341500766,
+                  "num_eq": 1800,
+                  "num_range": 29406,
+                  "upper_bound": "3513"
+              },
+              {
+                  "distinct_range": 46.64012251148545,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "3561"
+              },
+              {
+                  "distinct_range": 48.62480857580398,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "3611"
+              },
+              {
+                  "distinct_range": 41.67840735068913,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "3654"
+              },
+              {
+                  "distinct_range": 50.60949464012251,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "3706"
+              },
+              {
+                  "distinct_range": 55.57120980091884,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "3763"
+              },
+              {
+                  "distinct_range": 35.724349157733535,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3800"
+              },
+              {
+                  "distinct_range": 53.586523736600306,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "3855"
+              },
+              {
+                  "distinct_range": 55.57120980091884,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3912"
+              },
+              {
+                  "distinct_range": 59.54058192955589,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "3973"
+              },
+              {
+                  "distinct_range": 56.5635528330781,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "4031"
+              },
+              {
+                  "distinct_range": 45.64777947932618,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4078"
+              },
+              {
+                  "distinct_range": 45.64777947932618,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4125"
+              },
+              {
+                  "distinct_range": 48.62480857580398,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4175"
+              },
+              {
+                  "distinct_range": 42.67075038284839,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "4219"
+              },
+              {
+                  "distinct_range": 58.54823889739663,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "4279"
+              },
+              {
+                  "distinct_range": 45.64777947932618,
+                  "num_eq": 1800,
+                  "num_range": 29406,
+                  "upper_bound": "4326"
+              },
+              {
+                  "distinct_range": 43.66309341500766,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "4371"
+              },
+              {
+                  "distinct_range": 50.60949464012251,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4423"
+              },
+              {
+                  "distinct_range": 45.64777947932618,
+                  "num_eq": 2400,
+                  "num_range": 29406,
+                  "upper_bound": "4470"
+              },
+              {
+                  "distinct_range": 40.68606431852986,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4512"
+              },
+              {
+                  "distinct_range": 47.63246554364471,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4561"
+              },
+              {
+                  "distinct_range": 48.62480857580398,
+                  "num_eq": 2400,
+                  "num_range": 29406,
+                  "upper_bound": "4611"
+              },
+              {
+                  "distinct_range": 48.62480857580398,
+                  "num_eq": 1800,
+                  "num_range": 29406,
+                  "upper_bound": "4661"
+              },
+              {
+                  "distinct_range": 42.67075038284839,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "4705"
+              },
+              {
+                  "distinct_range": 51.601837672281775,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4758"
+              },
+              {
+                  "distinct_range": 49.617151607963244,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4809"
+              },
+              {
+                  "distinct_range": 48.62480857580398,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "4859"
+              },
+              {
+                  "distinct_range": 60.53292496171516,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "4921"
+              },
+              {
+                  "distinct_range": 51.601837672281775,
+                  "num_eq": 1800,
+                  "num_range": 29406,
+                  "upper_bound": "4974"
+              },
+              {
+                  "distinct_range": 50.60949464012251,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "5026"
+              },
+              {
+                  "distinct_range": 47.63246554364471,
+                  "num_eq": 2400,
+                  "num_range": 28206,
+                  "upper_bound": "5075"
+              },
+              {
+                  "distinct_range": 41.67840735068913,
+                  "num_eq": 2400,
+                  "num_range": 27005,
+                  "upper_bound": "5118"
+              },
+              {
+                  "distinct_range": 51.601837672281775,
+                  "num_eq": 1800,
+                  "num_range": 28806,
+                  "upper_bound": "5171"
+              },
+              {
+                  "distinct_range": 45.64777947932618,
+                  "num_eq": 1800,
+                  "num_range": 27606,
+                  "upper_bound": "5218"
+              },
+              {
+                  "distinct_range": 48.62480857580398,
+                  "num_eq": 1800,
+                  "num_range": 28806,
+                  "upper_bound": "5268"
+              },
+              {
+                  "distinct_range": 47.63246554364471,
+                  "num_eq": 2400,
+                  "num_range": 28206,
+                  "upper_bound": "5317"
+              },
+              {
+                  "distinct_range": 40.68606431852986,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "5359"
+              },
+              {
+                  "distinct_range": 57.55589586523736,
+                  "num_eq": 600,
+                  "num_range": 28806,
+                  "upper_bound": "5418"
+              },
+              {
+                  "distinct_range": 44.65543644716692,
+                  "num_eq": 1800,
+                  "num_range": 27606,
+                  "upper_bound": "5464"
+              },
+              {
+                  "distinct_range": 48.62480857580398,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "5514"
+              },
+              {
+                  "distinct_range": 54.57886676875957,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "5570"
+              },
+              {
+                  "distinct_range": 43.66309341500766,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "5615"
+              },
+              {
+                  "distinct_range": 50.60949464012251,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "5667"
+              },
+              {
+                  "distinct_range": 53.586523736600306,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "5722"
+              },
+              {
+                  "distinct_range": 39.6937212863706,
+                  "num_eq": 600,
+                  "num_range": 28806,
+                  "upper_bound": "5763"
+              },
+              {
+                  "distinct_range": 54.57886676875957,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "5819"
+              },
+              {
+                  "distinct_range": 48.62480857580398,
+                  "num_eq": 600,
+                  "num_range": 28806,
+                  "upper_bound": "5869"
+              },
+              {
+                  "distinct_range": 47.63246554364471,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "5918"
+              },
+              {
+                  "distinct_range": 48.62480857580398,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "5968"
+              },
+              {
+                  "distinct_range": 63.50995405819295,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "6033"
+              },
+              {
+                  "distinct_range": 44.65543644716692,
+                  "num_eq": 2400,
+                  "num_range": 27606,
+                  "upper_bound": "6079"
+              },
+              {
+                  "distinct_range": 45.64777947932618,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "6126"
+              },
+              {
+                  "distinct_range": 43.66309341500766,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "6171"
+              },
+              {
+                  "distinct_range": 47.63246554364471,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "6220"
+              },
+              {
+                  "distinct_range": 57.55589586523736,
+                  "num_eq": 600,
+                  "num_range": 28806,
+                  "upper_bound": "6279"
+              },
+              {
+                  "distinct_range": 52.59418070444104,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "6333"
+              },
+              {
+                  "distinct_range": 59.54058192955589,
+                  "num_eq": 600,
+                  "num_range": 28806,
+                  "upper_bound": "6394"
+              },
+              {
+                  "distinct_range": 47.63246554364471,
+                  "num_eq": 1800,
+                  "num_range": 29406,
+                  "upper_bound": "6443"
+              },
+              {
+                  "distinct_range": 45.64777947932618,
+                  "num_eq": 600,
+                  "num_range": 28806,
+                  "upper_bound": "6490"
+              },
+              {
+                  "distinct_range": 50.60949464012251,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "6542"
+              },
+              {
+                  "distinct_range": 52.59418070444104,
+                  "num_eq": 1200,
+                  "num_range": 28206,
+                  "upper_bound": "6596"
+              },
+              {
+                  "distinct_range": 60.53292496171516,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "6658"
+              },
+              {
+                  "distinct_range": 40.68606431852986,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "6700"
+              },
+              {
+                  "distinct_range": 46.64012251148545,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "6748"
+              },
+              {
+                  "distinct_range": 41.67840735068913,
+                  "num_eq": 1800,
+                  "num_range": 29406,
+                  "upper_bound": "6791"
+              },
+              {
+                  "distinct_range": 56.5635528330781,
+                  "num_eq": 600,
+                  "num_range": 28806,
+                  "upper_bound": "6849"
+              },
+              {
+                  "distinct_range": 57.55589586523736,
+                  "num_eq": 1800,
+                  "num_range": 27606,
+                  "upper_bound": "6908"
+              },
+              {
+                  "distinct_range": 51.601837672281775,
+                  "num_eq": 1800,
+                  "num_range": 28806,
+                  "upper_bound": "6961"
+              },
+              {
+                  "distinct_range": 44.65543644716692,
+                  "num_eq": 1200,
+                  "num_range": 28206,
+                  "upper_bound": "7007"
+              },
+              {
+                  "distinct_range": 44.65543644716692,
+                  "num_eq": 1800,
+                  "num_range": 29406,
+                  "upper_bound": "7053"
+              },
+              {
+                  "distinct_range": 40.68606431852986,
+                  "num_eq": 1800,
+                  "num_range": 27606,
+                  "upper_bound": "7095"
+              },
+              {
+                  "distinct_range": 56.5635528330781,
+                  "num_eq": 600,
+                  "num_range": 28806,
+                  "upper_bound": "7153"
+              },
+              {
+                  "distinct_range": 51.601837672281775,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "7206"
+              },
+              {
+                  "distinct_range": 46.64012251148545,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "7254"
+              },
+              {
+                  "distinct_range": 48.62480857580398,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "7304"
+              },
+              {
+                  "distinct_range": 50.60949464012251,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "7356"
+              },
+              {
+                  "distinct_range": 47.63246554364471,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "7405"
+              },
+              {
+                  "distinct_range": 51.601837672281775,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "7458"
+              },
+              {
+                  "distinct_range": 56.5635528330781,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "7516"
+              },
+              {
+                  "distinct_range": 39.6937212863706,
+                  "num_eq": 1200,
+                  "num_range": 28206,
+                  "upper_bound": "7557"
+              },
+              {
+                  "distinct_range": 36.716692189892804,
+                  "num_eq": 3001,
+                  "num_range": 28206,
+                  "upper_bound": "7595"
+              },
+              {
+                  "distinct_range": 60.53292496171516,
+                  "num_eq": 2400,
+                  "num_range": 28806,
+                  "upper_bound": "7657"
+              },
+              {
+                  "distinct_range": 46.64012251148545,
+                  "num_eq": 1800,
+                  "num_range": 28806,
+                  "upper_bound": "7705"
+              },
+              {
+                  "distinct_range": 51.601837672281775,
+                  "num_eq": 2400,
+                  "num_range": 28206,
+                  "upper_bound": "7758"
+              },
+              {
+                  "distinct_range": 39.6937212863706,
+                  "num_eq": 600,
+                  "num_range": 28806,
+                  "upper_bound": "7799"
+              },
+              {
+                  "distinct_range": 55.57120980091884,
+                  "num_eq": 1800,
+                  "num_range": 28806,
+                  "upper_bound": "7856"
+              },
+              {
+                  "distinct_range": 36.716692189892804,
+                  "num_eq": 1200,
+                  "num_range": 28206,
+                  "upper_bound": "7894"
+              },
+              {
+                  "distinct_range": 33.739663093415004,
+                  "num_eq": 600,
+                  "num_range": 28806,
+                  "upper_bound": "7929"
+              },
+              {
+                  "distinct_range": 34.73200612557427,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "7965"
+              },
+              {
+                  "distinct_range": 38.70137825421133,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "8005"
+              },
+              {
+                  "distinct_range": 43.66309341500766,
+                  "num_eq": 2400,
+                  "num_range": 27005,
+                  "upper_bound": "8050"
+              },
+              {
+                  "distinct_range": 51.601837672281775,
+                  "num_eq": 600,
+                  "num_range": 28806,
+                  "upper_bound": "8103"
+              },
+              {
+                  "distinct_range": 46.64012251148545,
+                  "num_eq": 600,
+                  "num_range": 28806,
+                  "upper_bound": "8151"
+              },
+              {
+                  "distinct_range": 51.601837672281775,
+                  "num_eq": 1200,
+                  "num_range": 28206,
+                  "upper_bound": "8204"
+              },
+              {
+                  "distinct_range": 42.67075038284839,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "8248"
+              },
+              {
+                  "distinct_range": 51.601837672281775,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "8301"
+              },
+              {
+                  "distinct_range": 46.64012251148545,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "8349"
+              },
+              {
+                  "distinct_range": 58.54823889739663,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "8409"
+              },
+              {
+                  "distinct_range": 72.44104134762634,
+                  "num_eq": 1800,
+                  "num_range": 28806,
+                  "upper_bound": "8483"
+              },
+              {
+                  "distinct_range": 54.57886676875957,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "8539"
+              },
+              {
+                  "distinct_range": 52.59418070444104,
+                  "num_eq": 2400,
+                  "num_range": 27005,
+                  "upper_bound": "8593"
+              },
+              {
+                  "distinct_range": 55.57120980091884,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "8650"
+              },
+              {
+                  "distinct_range": 38.70137825421133,
+                  "num_eq": 600,
+                  "num_range": 28806,
+                  "upper_bound": "8690"
+              },
+              {
+                  "distinct_range": 60.53292496171516,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "8752"
+              },
+              {
+                  "distinct_range": 48.62480857580398,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "8802"
+              },
+              {
+                  "distinct_range": 50.60949464012251,
+                  "num_eq": 600,
+                  "num_range": 28806,
+                  "upper_bound": "8854"
+              },
+              {
+                  "distinct_range": 73.43338437978561,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "8929"
+              },
+              {
+                  "distinct_range": 49.617151607963244,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "8980"
+              },
+              {
+                  "distinct_range": 43.66309341500766,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "9025"
+              },
+              {
+                  "distinct_range": 51.601837672281775,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "9078"
+              },
+              {
+                  "distinct_range": 46.64012251148545,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "9126"
+              },
+              {
+                  "distinct_range": 46.64012251148545,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "9174"
+              },
+              {
+                  "distinct_range": 51.601837672281775,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "9227"
+              },
+              {
+                  "distinct_range": 46.64012251148545,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "9275"
+              },
+              {
+                  "distinct_range": 45.64777947932618,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "9322"
+              },
+              {
+                  "distinct_range": 47.63246554364471,
+                  "num_eq": 1800,
+                  "num_range": 28806,
+                  "upper_bound": "9371"
+              },
+              {
+                  "distinct_range": 54.57886676875957,
+                  "num_eq": 600,
+                  "num_range": 28806,
+                  "upper_bound": "9427"
+              },
+              {
+                  "distinct_range": 40.68606431852986,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "9469"
+              },
+              {
+                  "distinct_range": 43.66309341500766,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "9514"
+              },
+              {
+                  "distinct_range": 47.63246554364471,
+                  "num_eq": 2400,
+                  "num_range": 28206,
+                  "upper_bound": "9563"
+              },
+              {
+                  "distinct_range": 63.50995405819295,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "9628"
+              },
+              {
+                  "distinct_range": 44.65543644716692,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "9674"
+              },
+              {
+                  "distinct_range": 40.68606431852986,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "9716"
+              },
+              {
+                  "distinct_range": 59.54058192955589,
+                  "num_eq": 600,
+                  "num_range": 28806,
+                  "upper_bound": "9777"
+              },
+              {
+                  "distinct_range": 43.66309341500766,
+                  "num_eq": 1200,
+                  "num_range": 28206,
+                  "upper_bound": "9822"
+              },
+              {
+                  "distinct_range": 36.716692189892804,
+                  "num_eq": 2400,
+                  "num_range": 27606,
+                  "upper_bound": "9860"
+              },
+              {
+                  "distinct_range": 50.60949464012251,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "9912"
+              },
+              {
+                  "distinct_range": 39.6937212863706,
+                  "num_eq": 1800,
+                  "num_range": 29406,
+                  "upper_bound": "9953"
+              },
+              {
+                  "distinct_range": 42.67075038284839,
+                  "num_eq": 600,
+                  "num_range": 28206,
+                  "upper_bound": "9997"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 6001215
+      },
+      {
+          "avg_size": 4,
+          "columns": [
+              "l_shipdate"
+          ],
+          "created_at": "2022-03-21 20:30:59.932306",
+          "distinct_count": 2526,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 0,
+                  "num_range": 0,
+                  "upper_bound": "-infinity"
+              },
+              {
+                  "distinct_range": 5,
+                  "num_eq": 600,
+                  "num_range": 5,
+                  "upper_bound": "1992-01-07"
+              },
+              {
+                  "distinct_range": 51,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1992-02-28"
+              },
+              {
+                  "distinct_range": 18,
+                  "num_eq": 3001,
+                  "num_range": 28806,
+                  "upper_bound": "1992-03-18"
+              },
+              {
+                  "distinct_range": 20,
+                  "num_eq": 4801,
+                  "num_range": 26405,
+                  "upper_bound": "1992-04-08"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3001,
+                  "num_range": 29406,
+                  "upper_bound": "1992-04-20"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1992-05-02"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1992-05-13"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1800,
+                  "num_range": 29406,
+                  "upper_bound": "1992-05-26"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 3001,
+                  "num_range": 28206,
+                  "upper_bound": "1992-06-05"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3601,
+                  "num_range": 26405,
+                  "upper_bound": "1992-06-18"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 2400,
+                  "num_range": 28206,
+                  "upper_bound": "1992-06-29"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1992-07-13"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 3601,
+                  "num_range": 29406,
+                  "upper_bound": "1992-07-27"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 2400,
+                  "num_range": 29406,
+                  "upper_bound": "1992-08-08"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3601,
+                  "num_range": 28206,
+                  "upper_bound": "1992-08-21"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 3001,
+                  "num_range": 27606,
+                  "upper_bound": "1992-08-31"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 2400,
+                  "num_range": 28206,
+                  "upper_bound": "1992-09-13"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 4801,
+                  "num_range": 25205,
+                  "upper_bound": "1992-09-27"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 2400,
+                  "num_range": 28206,
+                  "upper_bound": "1992-10-11"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 3601,
+                  "num_range": 28206,
+                  "upper_bound": "1992-10-25"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1992-11-08"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 4201,
+                  "num_range": 28806,
+                  "upper_bound": "1992-11-23"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 3601,
+                  "num_range": 28806,
+                  "upper_bound": "1992-12-08"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3001,
+                  "num_range": 27606,
+                  "upper_bound": "1992-12-20"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4801,
+                  "num_range": 26405,
+                  "upper_bound": "1992-12-31"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 2400,
+                  "num_range": 27606,
+                  "upper_bound": "1993-01-13"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 29406,
+                  "upper_bound": "1993-01-24"
+              },
+              {
+                  "distinct_range": 20,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "1993-02-14"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3001,
+                  "num_range": 29406,
+                  "upper_bound": "1993-02-26"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 5401,
+                  "num_range": 25805,
+                  "upper_bound": "1993-03-09"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1993-03-19"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1800,
+                  "num_range": 28806,
+                  "upper_bound": "1993-03-31"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 4801,
+                  "num_range": 27606,
+                  "upper_bound": "1993-04-14"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 3601,
+                  "num_range": 27606,
+                  "upper_bound": "1993-04-28"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 4201,
+                  "num_range": 28806,
+                  "upper_bound": "1993-05-11"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 5401,
+                  "num_range": 28806,
+                  "upper_bound": "1993-05-22"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "1993-06-03"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 2400,
+                  "num_range": 28206,
+                  "upper_bound": "1993-06-14"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1993-06-24"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1800,
+                  "num_range": 27606,
+                  "upper_bound": "1993-07-06"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 2400,
+                  "num_range": 27005,
+                  "upper_bound": "1993-07-18"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1993-07-28"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 2400,
+                  "num_range": 28806,
+                  "upper_bound": "1993-08-09"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1200,
+                  "num_range": 28206,
+                  "upper_bound": "1993-08-21"
+              },
+              {
+                  "distinct_range": 15,
+                  "num_eq": 3001,
+                  "num_range": 27606,
+                  "upper_bound": "1993-09-06"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 2400,
+                  "num_range": 27005,
+                  "upper_bound": "1993-09-19"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "1993-09-29"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 4201,
+                  "num_range": 28806,
+                  "upper_bound": "1993-10-13"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1993-10-26"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1200,
+                  "num_range": 28206,
+                  "upper_bound": "1993-11-06"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 2400,
+                  "num_range": 28206,
+                  "upper_bound": "1993-11-20"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 4201,
+                  "num_range": 26405,
+                  "upper_bound": "1993-12-04"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3001,
+                  "num_range": 28806,
+                  "upper_bound": "1993-12-17"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3601,
+                  "num_range": 26405,
+                  "upper_bound": "1993-12-29"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 2400,
+                  "num_range": 27005,
+                  "upper_bound": "1994-01-10"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 2400,
+                  "num_range": 28206,
+                  "upper_bound": "1994-01-21"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1800,
+                  "num_range": 27606,
+                  "upper_bound": "1994-02-01"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 1200,
+                  "num_range": 28206,
+                  "upper_bound": "1994-02-15"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4801,
+                  "num_range": 24605,
+                  "upper_bound": "1994-02-26"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1994-03-11"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 600,
+                  "num_range": 28806,
+                  "upper_bound": "1994-03-25"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3001,
+                  "num_range": 28806,
+                  "upper_bound": "1994-04-05"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 4201,
+                  "num_range": 27606,
+                  "upper_bound": "1994-04-17"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 6001,
+                  "num_range": 24605,
+                  "upper_bound": "1994-04-26"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 26405,
+                  "upper_bound": "1994-05-07"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1994-05-21"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 2400,
+                  "num_range": 28806,
+                  "upper_bound": "1994-06-01"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 4801,
+                  "num_range": 28806,
+                  "upper_bound": "1994-06-14"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 4201,
+                  "num_range": 27606,
+                  "upper_bound": "1994-06-28"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 1800,
+                  "num_range": 27606,
+                  "upper_bound": "1994-07-08"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3001,
+                  "num_range": 28206,
+                  "upper_bound": "1994-07-20"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 2400,
+                  "num_range": 27606,
+                  "upper_bound": "1994-08-02"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "1994-08-15"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 3001,
+                  "num_range": 27606,
+                  "upper_bound": "1994-08-29"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1994-09-07"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 3601,
+                  "num_range": 28206,
+                  "upper_bound": "1994-09-21"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1994-10-03"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3601,
+                  "num_range": 27005,
+                  "upper_bound": "1994-10-16"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 26405,
+                  "upper_bound": "1994-10-27"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3001,
+                  "num_range": 27606,
+                  "upper_bound": "1994-11-08"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 3601,
+                  "num_range": 27606,
+                  "upper_bound": "1994-11-22"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 2400,
+                  "num_range": 28206,
+                  "upper_bound": "1994-12-05"
+              },
+              {
+                  "distinct_range": 15,
+                  "num_eq": 2400,
+                  "num_range": 28206,
+                  "upper_bound": "1994-12-21"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 5401,
+                  "num_range": 27005,
+                  "upper_bound": "1995-01-04"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4801,
+                  "num_range": 24605,
+                  "upper_bound": "1995-01-15"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3001,
+                  "num_range": 28206,
+                  "upper_bound": "1995-01-27"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1995-02-09"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3001,
+                  "num_range": 28806,
+                  "upper_bound": "1995-02-21"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4201,
+                  "num_range": 27005,
+                  "upper_bound": "1995-03-04"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 1800,
+                  "num_range": 28806,
+                  "upper_bound": "1995-03-14"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 4201,
+                  "num_range": 25205,
+                  "upper_bound": "1995-03-28"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 3001,
+                  "num_range": 26405,
+                  "upper_bound": "1995-04-11"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 3001,
+                  "num_range": 27606,
+                  "upper_bound": "1995-04-25"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3001,
+                  "num_range": 26405,
+                  "upper_bound": "1995-05-06"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1800,
+                  "num_range": 28806,
+                  "upper_bound": "1995-05-18"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4201,
+                  "num_range": 28806,
+                  "upper_bound": "1995-05-29"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4201,
+                  "num_range": 26405,
+                  "upper_bound": "1995-06-09"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 1800,
+                  "num_range": 28806,
+                  "upper_bound": "1995-06-23"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 3601,
+                  "num_range": 27606,
+                  "upper_bound": "1995-07-07"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1800,
+                  "num_range": 27606,
+                  "upper_bound": "1995-07-20"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 4201,
+                  "num_range": 26405,
+                  "upper_bound": "1995-07-29"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1200,
+                  "num_range": 28206,
+                  "upper_bound": "1995-08-10"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1995-08-20"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1995-09-02"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 2400,
+                  "num_range": 27606,
+                  "upper_bound": "1995-09-14"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 2400,
+                  "num_range": 28806,
+                  "upper_bound": "1995-09-26"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 1800,
+                  "num_range": 27606,
+                  "upper_bound": "1995-10-05"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1800,
+                  "num_range": 28806,
+                  "upper_bound": "1995-10-16"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 4201,
+                  "num_range": 27005,
+                  "upper_bound": "1995-10-29"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 4201,
+                  "num_range": 26405,
+                  "upper_bound": "1995-11-11"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1800,
+                  "num_range": 28806,
+                  "upper_bound": "1995-11-24"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1995-12-03"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1200,
+                  "num_range": 28206,
+                  "upper_bound": "1995-12-14"
+              },
+              {
+                  "distinct_range": 15,
+                  "num_eq": 4801,
+                  "num_range": 27606,
+                  "upper_bound": "1995-12-30"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1800,
+                  "num_range": 28806,
+                  "upper_bound": "1996-01-10"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 600,
+                  "num_range": 28206,
+                  "upper_bound": "1996-01-24"
+              },
+              {
+                  "distinct_range": 16,
+                  "num_eq": 1800,
+                  "num_range": 27606,
+                  "upper_bound": "1996-02-10"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4801,
+                  "num_range": 25805,
+                  "upper_bound": "1996-02-21"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 4201,
+                  "num_range": 25205,
+                  "upper_bound": "1996-03-01"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 600,
+                  "num_range": 28206,
+                  "upper_bound": "1996-03-15"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4201,
+                  "num_range": 28206,
+                  "upper_bound": "1996-03-26"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 3601,
+                  "num_range": 25805,
+                  "upper_bound": "1996-04-05"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 25205,
+                  "upper_bound": "1996-04-16"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3001,
+                  "num_range": 28206,
+                  "upper_bound": "1996-04-28"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 3001,
+                  "num_range": 26405,
+                  "upper_bound": "1996-05-08"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 3001,
+                  "num_range": 26405,
+                  "upper_bound": "1996-05-22"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 2400,
+                  "num_range": 28206,
+                  "upper_bound": "1996-06-04"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 3001,
+                  "num_range": 28206,
+                  "upper_bound": "1996-06-18"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 3001,
+                  "num_range": 27606,
+                  "upper_bound": "1996-06-28"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 2400,
+                  "num_range": 26405,
+                  "upper_bound": "1996-07-10"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1996-07-21"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 1800,
+                  "num_range": 27005,
+                  "upper_bound": "1996-07-30"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1800,
+                  "num_range": 27606,
+                  "upper_bound": "1996-08-12"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 1200,
+                  "num_range": 28206,
+                  "upper_bound": "1996-08-22"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 4201,
+                  "num_range": 25805,
+                  "upper_bound": "1996-09-01"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 5401,
+                  "num_range": 25205,
+                  "upper_bound": "1996-09-13"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3601,
+                  "num_range": 27005,
+                  "upper_bound": "1996-09-26"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 2400,
+                  "num_range": 26405,
+                  "upper_bound": "1996-10-07"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 3601,
+                  "num_range": 26405,
+                  "upper_bound": "1996-10-22"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 2400,
+                  "num_range": 28206,
+                  "upper_bound": "1996-11-05"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3601,
+                  "num_range": 25205,
+                  "upper_bound": "1996-11-17"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 2400,
+                  "num_range": 27005,
+                  "upper_bound": "1996-11-29"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1996-12-11"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3001,
+                  "num_range": 26405,
+                  "upper_bound": "1996-12-24"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 4201,
+                  "num_range": 24605,
+                  "upper_bound": "1997-01-06"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3001,
+                  "num_range": 26405,
+                  "upper_bound": "1997-01-18"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 3001,
+                  "num_range": 25805,
+                  "upper_bound": "1997-01-28"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 600,
+                  "num_range": 28206,
+                  "upper_bound": "1997-02-09"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3601,
+                  "num_range": 25805,
+                  "upper_bound": "1997-02-21"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1997-03-06"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 3601,
+                  "num_range": 26405,
+                  "upper_bound": "1997-03-16"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3001,
+                  "num_range": 26405,
+                  "upper_bound": "1997-03-27"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 3001,
+                  "num_range": 28206,
+                  "upper_bound": "1997-04-10"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1800,
+                  "num_range": 27005,
+                  "upper_bound": "1997-04-23"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1800,
+                  "num_range": 27005,
+                  "upper_bound": "1997-05-04"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 2400,
+                  "num_range": 26405,
+                  "upper_bound": "1997-05-15"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3601,
+                  "num_range": 27005,
+                  "upper_bound": "1997-05-27"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 4201,
+                  "num_range": 26405,
+                  "upper_bound": "1997-06-06"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 4201,
+                  "num_range": 28206,
+                  "upper_bound": "1997-06-18"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1997-07-02"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4201,
+                  "num_range": 28206,
+                  "upper_bound": "1997-07-13"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 3001,
+                  "num_range": 25805,
+                  "upper_bound": "1997-07-22"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3001,
+                  "num_range": 26405,
+                  "upper_bound": "1997-08-04"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 2400,
+                  "num_range": 28206,
+                  "upper_bound": "1997-08-18"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 2400,
+                  "num_range": 26405,
+                  "upper_bound": "1997-08-28"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3001,
+                  "num_range": 27606,
+                  "upper_bound": "1997-09-08"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1800,
+                  "num_range": 26405,
+                  "upper_bound": "1997-09-21"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1800,
+                  "num_range": 26405,
+                  "upper_bound": "1997-10-04"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3601,
+                  "num_range": 27606,
+                  "upper_bound": "1997-10-16"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 2400,
+                  "num_range": 26405,
+                  "upper_bound": "1997-10-27"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 1800,
+                  "num_range": 27005,
+                  "upper_bound": "1997-11-10"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 2400,
+                  "num_range": 27005,
+                  "upper_bound": "1997-11-21"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1997-12-01"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 4201,
+                  "num_range": 24005,
+                  "upper_bound": "1997-12-13"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1200,
+                  "num_range": 27606,
+                  "upper_bound": "1997-12-25"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 26405,
+                  "upper_bound": "1998-01-05"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1200,
+                  "num_range": 27005,
+                  "upper_bound": "1998-01-17"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4801,
+                  "num_range": 27606,
+                  "upper_bound": "1998-01-28"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1200,
+                  "num_range": 27005,
+                  "upper_bound": "1998-02-08"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 2400,
+                  "num_range": 27005,
+                  "upper_bound": "1998-02-19"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1998-03-04"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 4801,
+                  "num_range": 23405,
+                  "upper_bound": "1998-03-14"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3001,
+                  "num_range": 26405,
+                  "upper_bound": "1998-03-26"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 2400,
+                  "num_range": 27005,
+                  "upper_bound": "1998-04-06"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 4801,
+                  "num_range": 27005,
+                  "upper_bound": "1998-04-20"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3001,
+                  "num_range": 25205,
+                  "upper_bound": "1998-05-02"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 2400,
+                  "num_range": 25805,
+                  "upper_bound": "1998-05-12"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 3001,
+                  "num_range": 24605,
+                  "upper_bound": "1998-05-22"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1800,
+                  "num_range": 26405,
+                  "upper_bound": "1998-06-02"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1998-06-14"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 2400,
+                  "num_range": 26405,
+                  "upper_bound": "1998-06-23"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 1800,
+                  "num_range": 25805,
+                  "upper_bound": "1998-07-03"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1800,
+                  "num_range": 25205,
+                  "upper_bound": "1998-07-15"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1998-07-27"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3001,
+                  "num_range": 26405,
+                  "upper_bound": "1998-08-07"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4201,
+                  "num_range": 24605,
+                  "upper_bound": "1998-08-18"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 3001,
+                  "num_range": 24005,
+                  "upper_bound": "1998-08-28"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 2400,
+                  "num_range": 25205,
+                  "upper_bound": "1998-09-12"
+              },
+              {
+                  "distinct_range": 21,
+                  "num_eq": 1200,
+                  "num_range": 24605,
+                  "upper_bound": "1998-10-04"
+              },
+              {
+                  "distinct_range": 52,
+                  "num_eq": 600,
+                  "num_range": 24005,
+                  "upper_bound": "1998-11-26"
+              },
+              {
+                  "distinct_range": 5,
+                  "num_eq": 0,
+                  "num_range": 5,
+                  "upper_bound": "infinity"
+              }
+          ],
+          "histo_col_type": "DATE",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 6001215
+      },
+      {
+          "avg_size": 4,
+          "columns": [
+              "l_commitdate"
+          ],
+          "created_at": "2022-03-21 20:30:59.932306",
+          "distinct_count": 2466,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 0,
+                  "num_range": 0,
+                  "upper_bound": "-infinity"
+              },
+              {
+                  "distinct_range": 3.5,
+                  "num_eq": 600,
+                  "num_range": 3,
+                  "upper_bound": "1992-02-06"
+              },
+              {
+                  "distinct_range": 34,
+                  "num_eq": 600,
+                  "num_range": 29406,
+                  "upper_bound": "1992-03-12"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 4201,
+                  "num_range": 27606,
+                  "upper_bound": "1992-03-27"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3001,
+                  "num_range": 27606,
+                  "upper_bound": "1992-04-08"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3001,
+                  "num_range": 28206,
+                  "upper_bound": "1992-04-21"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4201,
+                  "num_range": 29406,
+                  "upper_bound": "1992-05-02"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 2400,
+                  "num_range": 29406,
+                  "upper_bound": "1992-05-12"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 3001,
+                  "num_range": 28806,
+                  "upper_bound": "1992-05-26"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 27005,
+                  "upper_bound": "1992-06-06"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3601,
+                  "num_range": 29406,
+                  "upper_bound": "1992-06-19"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "1992-07-02"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3601,
+                  "num_range": 29406,
+                  "upper_bound": "1992-07-14"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 1200,
+                  "num_range": 29406,
+                  "upper_bound": "1992-07-28"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1992-08-08"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3001,
+                  "num_range": 28206,
+                  "upper_bound": "1992-08-21"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 2400,
+                  "num_range": 28806,
+                  "upper_bound": "1992-09-04"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 3601,
+                  "num_range": 29406,
+                  "upper_bound": "1992-09-19"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3001,
+                  "num_range": 28206,
+                  "upper_bound": "1992-09-30"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 2400,
+                  "num_range": 27606,
+                  "upper_bound": "1992-10-14"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 27005,
+                  "upper_bound": "1992-10-25"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 2400,
+                  "num_range": 28206,
+                  "upper_bound": "1992-11-06"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 3001,
+                  "num_range": 28206,
+                  "upper_bound": "1992-11-21"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4801,
+                  "num_range": 28206,
+                  "upper_bound": "1992-12-02"
+              },
+              {
+                  "distinct_range": 19,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1992-12-22"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 5401,
+                  "num_range": 28206,
+                  "upper_bound": "1993-01-01"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1993-01-14"
+              },
+              {
+                  "distinct_range": 16,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "1993-01-31"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 3601,
+                  "num_range": 27005,
+                  "upper_bound": "1993-02-10"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 3001,
+                  "num_range": 27606,
+                  "upper_bound": "1993-02-24"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 2400,
+                  "num_range": 27005,
+                  "upper_bound": "1993-03-08"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "1993-03-22"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4201,
+                  "num_range": 25805,
+                  "upper_bound": "1993-04-02"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 4201,
+                  "num_range": 27606,
+                  "upper_bound": "1993-04-15"
+              },
+              {
+                  "distinct_range": 15,
+                  "num_eq": 600,
+                  "num_range": 28806,
+                  "upper_bound": "1993-05-01"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 4201,
+                  "num_range": 28806,
+                  "upper_bound": "1993-05-13"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 28806,
+                  "upper_bound": "1993-05-24"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1993-06-04"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1993-06-14"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "1993-06-28"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3601,
+                  "num_range": 28806,
+                  "upper_bound": "1993-07-10"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 7201,
+                  "num_range": 22204,
+                  "upper_bound": "1993-07-21"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3601,
+                  "num_range": 28806,
+                  "upper_bound": "1993-08-02"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 1800,
+                  "num_range": 27606,
+                  "upper_bound": "1993-08-12"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 5401,
+                  "num_range": 26405,
+                  "upper_bound": "1993-08-25"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3001,
+                  "num_range": 28806,
+                  "upper_bound": "1993-09-06"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3001,
+                  "num_range": 26405,
+                  "upper_bound": "1993-09-17"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 4801,
+                  "num_range": 28806,
+                  "upper_bound": "1993-09-29"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 1800,
+                  "num_range": 27606,
+                  "upper_bound": "1993-10-13"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3601,
+                  "num_range": 25805,
+                  "upper_bound": "1993-10-25"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 6601,
+                  "num_range": 25205,
+                  "upper_bound": "1993-11-09"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1993-11-23"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 3601,
+                  "num_range": 27005,
+                  "upper_bound": "1993-12-08"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 4201,
+                  "num_range": 28206,
+                  "upper_bound": "1993-12-20"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 1800,
+                  "num_range": 28806,
+                  "upper_bound": "1994-01-04"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 3001,
+                  "num_range": 27606,
+                  "upper_bound": "1994-01-14"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1994-01-24"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3001,
+                  "num_range": 28206,
+                  "upper_bound": "1994-02-06"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 4201,
+                  "num_range": 28206,
+                  "upper_bound": "1994-02-20"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 3001,
+                  "num_range": 27606,
+                  "upper_bound": "1994-03-06"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3601,
+                  "num_range": 27606,
+                  "upper_bound": "1994-03-18"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 4201,
+                  "num_range": 27606,
+                  "upper_bound": "1994-03-31"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3001,
+                  "num_range": 28806,
+                  "upper_bound": "1994-04-11"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3001,
+                  "num_range": 27606,
+                  "upper_bound": "1994-04-22"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 5401,
+                  "num_range": 28206,
+                  "upper_bound": "1994-05-03"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 1200,
+                  "num_range": 28206,
+                  "upper_bound": "1994-05-13"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 2400,
+                  "num_range": 27606,
+                  "upper_bound": "1994-05-24"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 2400,
+                  "num_range": 28806,
+                  "upper_bound": "1994-06-04"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 2400,
+                  "num_range": 27005,
+                  "upper_bound": "1994-06-16"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 2400,
+                  "num_range": 27005,
+                  "upper_bound": "1994-06-27"
+              },
+              {
+                  "distinct_range": 15,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1994-07-13"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 3001,
+                  "num_range": 28806,
+                  "upper_bound": "1994-07-27"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1800,
+                  "num_range": 28806,
+                  "upper_bound": "1994-08-09"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1800,
+                  "num_range": 28806,
+                  "upper_bound": "1994-08-22"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "1994-09-01"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 4801,
+                  "num_range": 27005,
+                  "upper_bound": "1994-09-13"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1994-09-26"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 5401,
+                  "num_range": 25805,
+                  "upper_bound": "1994-10-11"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3001,
+                  "num_range": 28806,
+                  "upper_bound": "1994-10-23"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3001,
+                  "num_range": 28206,
+                  "upper_bound": "1994-11-03"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3001,
+                  "num_range": 28806,
+                  "upper_bound": "1994-11-16"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 4801,
+                  "num_range": 24605,
+                  "upper_bound": "1994-11-28"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1200,
+                  "num_range": 28206,
+                  "upper_bound": "1994-12-10"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 2400,
+                  "num_range": 28806,
+                  "upper_bound": "1994-12-25"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 3601,
+                  "num_range": 28206,
+                  "upper_bound": "1995-01-08"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 28206,
+                  "upper_bound": "1995-01-19"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1995-01-31"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3001,
+                  "num_range": 26405,
+                  "upper_bound": "1995-02-13"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 2400,
+                  "num_range": 28806,
+                  "upper_bound": "1995-02-28"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 28206,
+                  "upper_bound": "1995-03-11"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3601,
+                  "num_range": 28206,
+                  "upper_bound": "1995-03-24"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 4801,
+                  "num_range": 26405,
+                  "upper_bound": "1995-04-07"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3001,
+                  "num_range": 26405,
+                  "upper_bound": "1995-04-19"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3001,
+                  "num_range": 26405,
+                  "upper_bound": "1995-04-30"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3001,
+                  "num_range": 26405,
+                  "upper_bound": "1995-05-11"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3601,
+                  "num_range": 25805,
+                  "upper_bound": "1995-05-24"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1800,
+                  "num_range": 27606,
+                  "upper_bound": "1995-06-04"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 4801,
+                  "num_range": 27606,
+                  "upper_bound": "1995-06-17"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 25805,
+                  "upper_bound": "1995-06-28"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 2400,
+                  "num_range": 27606,
+                  "upper_bound": "1995-07-10"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4201,
+                  "num_range": 28206,
+                  "upper_bound": "1995-07-21"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4201,
+                  "num_range": 27005,
+                  "upper_bound": "1995-08-01"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 2400,
+                  "num_range": 26405,
+                  "upper_bound": "1995-08-13"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3001,
+                  "num_range": 28206,
+                  "upper_bound": "1995-08-24"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 2400,
+                  "num_range": 28206,
+                  "upper_bound": "1995-09-04"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 25205,
+                  "upper_bound": "1995-09-15"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3001,
+                  "num_range": 25805,
+                  "upper_bound": "1995-09-28"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3001,
+                  "num_range": 28206,
+                  "upper_bound": "1995-10-11"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 2400,
+                  "num_range": 27005,
+                  "upper_bound": "1995-10-25"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3001,
+                  "num_range": 25805,
+                  "upper_bound": "1995-11-05"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3601,
+                  "num_range": 25805,
+                  "upper_bound": "1995-11-18"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3001,
+                  "num_range": 26405,
+                  "upper_bound": "1995-11-29"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 3601,
+                  "num_range": 26405,
+                  "upper_bound": "1995-12-08"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1800,
+                  "num_range": 27005,
+                  "upper_bound": "1995-12-21"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1200,
+                  "num_range": 28206,
+                  "upper_bound": "1996-01-03"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3001,
+                  "num_range": 25805,
+                  "upper_bound": "1996-01-14"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1800,
+                  "num_range": 27606,
+                  "upper_bound": "1996-01-25"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4801,
+                  "num_range": 25805,
+                  "upper_bound": "1996-02-05"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 1800,
+                  "num_range": 27606,
+                  "upper_bound": "1996-02-20"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4201,
+                  "num_range": 24605,
+                  "upper_bound": "1996-03-02"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3601,
+                  "num_range": 28206,
+                  "upper_bound": "1996-03-14"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 27005,
+                  "upper_bound": "1996-03-25"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 2400,
+                  "num_range": 27606,
+                  "upper_bound": "1996-04-07"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 25805,
+                  "upper_bound": "1996-04-18"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4201,
+                  "num_range": 28206,
+                  "upper_bound": "1996-04-29"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1996-05-14"
+              },
+              {
+                  "distinct_range": 15,
+                  "num_eq": 4801,
+                  "num_range": 27606,
+                  "upper_bound": "1996-05-30"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 7802,
+                  "num_range": 21604,
+                  "upper_bound": "1996-06-08"
+              },
+              {
+                  "distinct_range": 7,
+                  "num_eq": 5401,
+                  "num_range": 23405,
+                  "upper_bound": "1996-06-16"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1996-06-27"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 2400,
+                  "num_range": 27606,
+                  "upper_bound": "1996-07-10"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 4201,
+                  "num_range": 26405,
+                  "upper_bound": "1996-07-20"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 1800,
+                  "num_range": 27005,
+                  "upper_bound": "1996-07-30"
+              },
+              {
+                  "distinct_range": 15,
+                  "num_eq": 4201,
+                  "num_range": 28206,
+                  "upper_bound": "1996-08-15"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 600,
+                  "num_range": 28206,
+                  "upper_bound": "1996-08-24"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 2400,
+                  "num_range": 28206,
+                  "upper_bound": "1996-09-08"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1200,
+                  "num_range": 27606,
+                  "upper_bound": "1996-09-20"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 3601,
+                  "num_range": 28206,
+                  "upper_bound": "1996-10-04"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4801,
+                  "num_range": 26405,
+                  "upper_bound": "1996-10-15"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1800,
+                  "num_range": 27005,
+                  "upper_bound": "1996-10-28"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3601,
+                  "num_range": 25805,
+                  "upper_bound": "1996-11-10"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 2400,
+                  "num_range": 27606,
+                  "upper_bound": "1996-11-22"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3001,
+                  "num_range": 25805,
+                  "upper_bound": "1996-12-04"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 1800,
+                  "num_range": 27606,
+                  "upper_bound": "1996-12-14"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1996-12-27"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 2400,
+                  "num_range": 28206,
+                  "upper_bound": "1997-01-11"
+              },
+              {
+                  "distinct_range": 7,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1997-01-19"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 4201,
+                  "num_range": 27005,
+                  "upper_bound": "1997-02-02"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 4201,
+                  "num_range": 25805,
+                  "upper_bound": "1997-02-14"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 6601,
+                  "num_range": 24605,
+                  "upper_bound": "1997-02-25"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3601,
+                  "num_range": 26405,
+                  "upper_bound": "1997-03-09"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1800,
+                  "num_range": 27005,
+                  "upper_bound": "1997-03-20"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 2400,
+                  "num_range": 26405,
+                  "upper_bound": "1997-03-30"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 4201,
+                  "num_range": 27005,
+                  "upper_bound": "1997-04-12"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 4201,
+                  "num_range": 27005,
+                  "upper_bound": "1997-04-22"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1800,
+                  "num_range": 26405,
+                  "upper_bound": "1997-05-04"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 600,
+                  "num_range": 27606,
+                  "upper_bound": "1997-05-17"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 3601,
+                  "num_range": 26405,
+                  "upper_bound": "1997-05-26"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 2400,
+                  "num_range": 25805,
+                  "upper_bound": "1997-06-07"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 2400,
+                  "num_range": 26405,
+                  "upper_bound": "1997-06-21"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1800,
+                  "num_range": 26405,
+                  "upper_bound": "1997-07-03"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 3601,
+                  "num_range": 27606,
+                  "upper_bound": "1997-07-12"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 2400,
+                  "num_range": 27005,
+                  "upper_bound": "1997-07-24"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1997-08-07"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 1200,
+                  "num_range": 27005,
+                  "upper_bound": "1997-08-17"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3001,
+                  "num_range": 25205,
+                  "upper_bound": "1997-08-28"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1800,
+                  "num_range": 27005,
+                  "upper_bound": "1997-09-09"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 2400,
+                  "num_range": 27005,
+                  "upper_bound": "1997-09-21"
+              },
+              {
+                  "distinct_range": 16,
+                  "num_eq": 1200,
+                  "num_range": 27606,
+                  "upper_bound": "1997-10-08"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 27606,
+                  "upper_bound": "1997-10-19"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1997-11-01"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 25205,
+                  "upper_bound": "1997-11-12"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3001,
+                  "num_range": 26405,
+                  "upper_bound": "1997-11-25"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1800,
+                  "num_range": 27005,
+                  "upper_bound": "1997-12-08"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1997-12-17"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 4201,
+                  "num_range": 24005,
+                  "upper_bound": "1997-12-29"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3001,
+                  "num_range": 25805,
+                  "upper_bound": "1998-01-09"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 600,
+                  "num_range": 27606,
+                  "upper_bound": "1998-01-21"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 2400,
+                  "num_range": 27005,
+                  "upper_bound": "1998-02-01"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 25205,
+                  "upper_bound": "1998-02-12"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 2400,
+                  "num_range": 26405,
+                  "upper_bound": "1998-02-21"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 3001,
+                  "num_range": 24605,
+                  "upper_bound": "1998-03-03"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1998-03-13"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 2400,
+                  "num_range": 25805,
+                  "upper_bound": "1998-03-26"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 24605,
+                  "upper_bound": "1998-04-06"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 25805,
+                  "upper_bound": "1998-04-17"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1200,
+                  "num_range": 26405,
+                  "upper_bound": "1998-04-28"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1998-05-11"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1800,
+                  "num_range": 27005,
+                  "upper_bound": "1998-05-22"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1800,
+                  "num_range": 27005,
+                  "upper_bound": "1998-06-03"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 2400,
+                  "num_range": 25205,
+                  "upper_bound": "1998-06-15"
+              },
+              {
+                  "distinct_range": 7,
+                  "num_eq": 4201,
+                  "num_range": 27005,
+                  "upper_bound": "1998-06-23"
+              },
+              {
+                  "distinct_range": 7,
+                  "num_eq": 4801,
+                  "num_range": 24005,
+                  "upper_bound": "1998-07-01"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 2400,
+                  "num_range": 25805,
+                  "upper_bound": "1998-07-10"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 4801,
+                  "num_range": 25205,
+                  "upper_bound": "1998-07-22"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 4201,
+                  "num_range": 23405,
+                  "upper_bound": "1998-08-03"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3601,
+                  "num_range": 24005,
+                  "upper_bound": "1998-08-16"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 2400,
+                  "num_range": 24605,
+                  "upper_bound": "1998-08-26"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 3001,
+                  "num_range": 23405,
+                  "upper_bound": "1998-09-05"
+              },
+              {
+                  "distinct_range": 15,
+                  "num_eq": 3601,
+                  "num_range": 22805,
+                  "upper_bound": "1998-09-21"
+              },
+              {
+                  "distinct_range": 38,
+                  "num_eq": 600,
+                  "num_range": 23405,
+                  "upper_bound": "1998-10-30"
+              },
+              {
+                  "distinct_range": 3.5,
+                  "num_eq": 0,
+                  "num_range": 3,
+                  "upper_bound": "infinity"
+              }
+          ],
+          "histo_col_type": "DATE",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 6001215
+      },
+      {
+          "avg_size": 4,
+          "columns": [
+              "l_receiptdate"
+          ],
+          "created_at": "2022-03-21 20:30:59.932306",
+          "distinct_count": 2554,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 0,
+                  "num_range": 0,
+                  "upper_bound": "-infinity"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 600,
+                  "num_range": 12,
+                  "upper_bound": "1992-01-16"
+              },
+              {
+                  "distinct_range": 58,
+                  "num_eq": 2400,
+                  "num_range": 29406,
+                  "upper_bound": "1992-03-15"
+              },
+              {
+                  "distinct_range": 18,
+                  "num_eq": 3601,
+                  "num_range": 27605,
+                  "upper_bound": "1992-04-03"
+              },
+              {
+                  "distinct_range": 17,
+                  "num_eq": 3001,
+                  "num_range": 27605,
+                  "upper_bound": "1992-04-21"
+              },
+              {
+                  "distinct_range": 15,
+                  "num_eq": 4201,
+                  "num_range": 28206,
+                  "upper_bound": "1992-05-07"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 27005,
+                  "upper_bound": "1992-05-18"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 2400,
+                  "num_range": 29406,
+                  "upper_bound": "1992-05-31"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 3601,
+                  "num_range": 28206,
+                  "upper_bound": "1992-06-09"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1992-06-22"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1992-07-03"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3601,
+                  "num_range": 28806,
+                  "upper_bound": "1992-07-15"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "1992-07-30"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1992-08-12"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3001,
+                  "num_range": 28806,
+                  "upper_bound": "1992-08-24"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1800,
+                  "num_range": 28806,
+                  "upper_bound": "1992-09-04"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 4201,
+                  "num_range": 25805,
+                  "upper_bound": "1992-09-18"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3601,
+                  "num_range": 28206,
+                  "upper_bound": "1992-09-30"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3601,
+                  "num_range": 28206,
+                  "upper_bound": "1992-10-13"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 3001,
+                  "num_range": 29406,
+                  "upper_bound": "1992-10-28"
+              },
+              {
+                  "distinct_range": 15,
+                  "num_eq": 3001,
+                  "num_range": 29406,
+                  "upper_bound": "1992-11-13"
+              },
+              {
+                  "distinct_range": 15,
+                  "num_eq": 3001,
+                  "num_range": 29406,
+                  "upper_bound": "1992-11-29"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1992-12-11"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3601,
+                  "num_range": 26405,
+                  "upper_bound": "1992-12-24"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 4801,
+                  "num_range": 28806,
+                  "upper_bound": "1993-01-05"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 2400,
+                  "num_range": 28206,
+                  "upper_bound": "1993-01-18"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1993-01-30"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3001,
+                  "num_range": 27605,
+                  "upper_bound": "1993-02-12"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 3601,
+                  "num_range": 27605,
+                  "upper_bound": "1993-02-27"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 4201,
+                  "num_range": 25805,
+                  "upper_bound": "1993-03-11"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1800,
+                  "num_range": 27605,
+                  "upper_bound": "1993-03-24"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3001,
+                  "num_range": 27605,
+                  "upper_bound": "1993-04-04"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "1993-04-16"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 1800,
+                  "num_range": 27605,
+                  "upper_bound": "1993-04-30"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 600,
+                  "num_range": 28806,
+                  "upper_bound": "1993-05-12"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3601,
+                  "num_range": 27005,
+                  "upper_bound": "1993-05-25"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 5401,
+                  "num_range": 24005,
+                  "upper_bound": "1993-06-03"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 2400,
+                  "num_range": 27605,
+                  "upper_bound": "1993-06-14"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4801,
+                  "num_range": 25805,
+                  "upper_bound": "1993-06-25"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 3001,
+                  "num_range": 28806,
+                  "upper_bound": "1993-07-05"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 3601,
+                  "num_range": 28206,
+                  "upper_bound": "1993-07-20"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 6001,
+                  "num_range": 23405,
+                  "upper_bound": "1993-07-29"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4201,
+                  "num_range": 26405,
+                  "upper_bound": "1993-08-09"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 4801,
+                  "num_range": 24605,
+                  "upper_bound": "1993-08-21"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 4801,
+                  "num_range": 27605,
+                  "upper_bound": "1993-09-04"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1993-09-19"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "1993-10-01"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3601,
+                  "num_range": 27005,
+                  "upper_bound": "1993-10-14"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 3001,
+                  "num_range": 27605,
+                  "upper_bound": "1993-10-23"
+              },
+              {
+                  "distinct_range": 15,
+                  "num_eq": 3601,
+                  "num_range": 28806,
+                  "upper_bound": "1993-11-08"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4201,
+                  "num_range": 27605,
+                  "upper_bound": "1993-11-19"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 4201,
+                  "num_range": 28806,
+                  "upper_bound": "1993-12-04"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 2400,
+                  "num_range": 27605,
+                  "upper_bound": "1993-12-17"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 4201,
+                  "num_range": 27005,
+                  "upper_bound": "1993-12-29"
+              },
+              {
+                  "distinct_range": 15,
+                  "num_eq": 4801,
+                  "num_range": 26405,
+                  "upper_bound": "1994-01-14"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 4801,
+                  "num_range": 27605,
+                  "upper_bound": "1994-01-26"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 2400,
+                  "num_range": 27605,
+                  "upper_bound": "1994-02-06"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 2400,
+                  "num_range": 27005,
+                  "upper_bound": "1994-02-17"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1994-03-02"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1800,
+                  "num_range": 28806,
+                  "upper_bound": "1994-03-14"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 1800,
+                  "num_range": 27605,
+                  "upper_bound": "1994-03-28"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 2400,
+                  "num_range": 27005,
+                  "upper_bound": "1994-04-08"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 4201,
+                  "num_range": 25205,
+                  "upper_bound": "1994-04-20"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 4801,
+                  "num_range": 24605,
+                  "upper_bound": "1994-04-30"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3001,
+                  "num_range": 27605,
+                  "upper_bound": "1994-05-12"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3601,
+                  "num_range": 28206,
+                  "upper_bound": "1994-05-24"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 2400,
+                  "num_range": 27005,
+                  "upper_bound": "1994-06-02"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 2400,
+                  "num_range": 28206,
+                  "upper_bound": "1994-06-15"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3001,
+                  "num_range": 28806,
+                  "upper_bound": "1994-06-28"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 4801,
+                  "num_range": 24605,
+                  "upper_bound": "1994-07-10"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 27605,
+                  "upper_bound": "1994-07-21"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 2400,
+                  "num_range": 28806,
+                  "upper_bound": "1994-08-03"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 3601,
+                  "num_range": 27605,
+                  "upper_bound": "1994-08-18"
+              },
+              {
+                  "distinct_range": 7,
+                  "num_eq": 3001,
+                  "num_range": 26405,
+                  "upper_bound": "1994-08-26"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 4201,
+                  "num_range": 25205,
+                  "upper_bound": "1994-09-07"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 1800,
+                  "num_range": 27605,
+                  "upper_bound": "1994-09-21"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 4201,
+                  "num_range": 28806,
+                  "upper_bound": "1994-10-04"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1994-10-17"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "1994-10-30"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 28206,
+                  "upper_bound": "1994-11-10"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 4201,
+                  "num_range": 28806,
+                  "upper_bound": "1994-11-23"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1994-12-08"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 1200,
+                  "num_range": 28206,
+                  "upper_bound": "1994-12-22"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1995-01-03"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 3001,
+                  "num_range": 26405,
+                  "upper_bound": "1995-01-17"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 27005,
+                  "upper_bound": "1995-01-28"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1800,
+                  "num_range": 27605,
+                  "upper_bound": "1995-02-10"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 6601,
+                  "num_range": 22805,
+                  "upper_bound": "1995-02-21"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 28206,
+                  "upper_bound": "1995-03-04"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 6001,
+                  "num_range": 27605,
+                  "upper_bound": "1995-03-17"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 4201,
+                  "num_range": 26405,
+                  "upper_bound": "1995-03-26"
+              },
+              {
+                  "distinct_range": 15,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "1995-04-11"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 2400,
+                  "num_range": 28206,
+                  "upper_bound": "1995-04-25"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 4201,
+                  "num_range": 25205,
+                  "upper_bound": "1995-05-05"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1995-05-20"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1800,
+                  "num_range": 27605,
+                  "upper_bound": "1995-05-31"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 2400,
+                  "num_range": 28206,
+                  "upper_bound": "1995-06-11"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3001,
+                  "num_range": 28806,
+                  "upper_bound": "1995-06-22"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 4201,
+                  "num_range": 27605,
+                  "upper_bound": "1995-07-05"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 4801,
+                  "num_range": 28206,
+                  "upper_bound": "1995-07-19"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 2400,
+                  "num_range": 28206,
+                  "upper_bound": "1995-07-31"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3001,
+                  "num_range": 26405,
+                  "upper_bound": "1995-08-12"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 4801,
+                  "num_range": 27605,
+                  "upper_bound": "1995-08-24"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3001,
+                  "num_range": 27605,
+                  "upper_bound": "1995-09-06"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1200,
+                  "num_range": 28806,
+                  "upper_bound": "1995-09-19"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1995-09-29"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4201,
+                  "num_range": 26405,
+                  "upper_bound": "1995-10-10"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 4201,
+                  "num_range": 28206,
+                  "upper_bound": "1995-10-22"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 6601,
+                  "num_range": 26405,
+                  "upper_bound": "1995-11-02"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3601,
+                  "num_range": 28806,
+                  "upper_bound": "1995-11-15"
+              },
+              {
+                  "distinct_range": 15,
+                  "num_eq": 2400,
+                  "num_range": 28806,
+                  "upper_bound": "1995-12-01"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1995-12-11"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 2400,
+                  "num_range": 27005,
+                  "upper_bound": "1995-12-21"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 4201,
+                  "num_range": 27005,
+                  "upper_bound": "1996-01-04"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 5401,
+                  "num_range": 24005,
+                  "upper_bound": "1996-01-15"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1800,
+                  "num_range": 27605,
+                  "upper_bound": "1996-01-28"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1200,
+                  "num_range": 27605,
+                  "upper_bound": "1996-02-10"
+              },
+              {
+                  "distinct_range": 15,
+                  "num_eq": 3001,
+                  "num_range": 27605,
+                  "upper_bound": "1996-02-26"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 5401,
+                  "num_range": 24605,
+                  "upper_bound": "1996-03-09"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 25205,
+                  "upper_bound": "1996-03-20"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1996-03-31"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 2400,
+                  "num_range": 27605,
+                  "upper_bound": "1996-04-11"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1200,
+                  "num_range": 28206,
+                  "upper_bound": "1996-04-22"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1200,
+                  "num_range": 27605,
+                  "upper_bound": "1996-05-05"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 5401,
+                  "num_range": 23405,
+                  "upper_bound": "1996-05-14"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3001,
+                  "num_range": 25805,
+                  "upper_bound": "1996-05-26"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 2400,
+                  "num_range": 27605,
+                  "upper_bound": "1996-06-07"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4801,
+                  "num_range": 27005,
+                  "upper_bound": "1996-06-18"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 2400,
+                  "num_range": 26405,
+                  "upper_bound": "1996-07-01"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3001,
+                  "num_range": 27005,
+                  "upper_bound": "1996-07-12"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 4801,
+                  "num_range": 24605,
+                  "upper_bound": "1996-07-24"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4201,
+                  "num_range": 26405,
+                  "upper_bound": "1996-08-04"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 3601,
+                  "num_range": 25205,
+                  "upper_bound": "1996-08-14"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 4201,
+                  "num_range": 26405,
+                  "upper_bound": "1996-08-26"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 4201,
+                  "num_range": 27605,
+                  "upper_bound": "1996-09-07"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 3601,
+                  "num_range": 28206,
+                  "upper_bound": "1996-09-21"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1200,
+                  "num_range": 28206,
+                  "upper_bound": "1996-10-02"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 5401,
+                  "num_range": 24005,
+                  "upper_bound": "1996-10-12"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3601,
+                  "num_range": 27605,
+                  "upper_bound": "1996-10-24"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1996-11-07"
+              },
+              {
+                  "distinct_range": 15,
+                  "num_eq": 3601,
+                  "num_range": 28206,
+                  "upper_bound": "1996-11-23"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 5401,
+                  "num_range": 23405,
+                  "upper_bound": "1996-12-05"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1996-12-16"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3601,
+                  "num_range": 26405,
+                  "upper_bound": "1996-12-28"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3601,
+                  "num_range": 25205,
+                  "upper_bound": "1997-01-10"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 2400,
+                  "num_range": 26405,
+                  "upper_bound": "1997-01-23"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3001,
+                  "num_range": 28206,
+                  "upper_bound": "1997-02-03"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 4801,
+                  "num_range": 27605,
+                  "upper_bound": "1997-02-16"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 4801,
+                  "num_range": 27605,
+                  "upper_bound": "1997-03-02"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 2400,
+                  "num_range": 27605,
+                  "upper_bound": "1997-03-13"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3601,
+                  "num_range": 27005,
+                  "upper_bound": "1997-03-26"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1997-04-07"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1800,
+                  "num_range": 28206,
+                  "upper_bound": "1997-04-19"
+              },
+              {
+                  "distinct_range": 14,
+                  "num_eq": 5401,
+                  "num_range": 28206,
+                  "upper_bound": "1997-05-04"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1800,
+                  "num_range": 27005,
+                  "upper_bound": "1997-05-15"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 2400,
+                  "num_range": 26405,
+                  "upper_bound": "1997-05-26"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3601,
+                  "num_range": 27005,
+                  "upper_bound": "1997-06-07"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1200,
+                  "num_range": 27605,
+                  "upper_bound": "1997-06-18"
+              },
+              {
+                  "distinct_range": 7,
+                  "num_eq": 3601,
+                  "num_range": 26405,
+                  "upper_bound": "1997-06-26"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 3001,
+                  "num_range": 25805,
+                  "upper_bound": "1997-07-10"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 5401,
+                  "num_range": 26405,
+                  "upper_bound": "1997-07-21"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 27605,
+                  "upper_bound": "1997-08-01"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3001,
+                  "num_range": 26405,
+                  "upper_bound": "1997-08-14"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 4201,
+                  "num_range": 27005,
+                  "upper_bound": "1997-08-24"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3001,
+                  "num_range": 27605,
+                  "upper_bound": "1997-09-06"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3601,
+                  "num_range": 25805,
+                  "upper_bound": "1997-09-18"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 3001,
+                  "num_range": 26405,
+                  "upper_bound": "1997-10-02"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 4801,
+                  "num_range": 25205,
+                  "upper_bound": "1997-10-13"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 1200,
+                  "num_range": 27605,
+                  "upper_bound": "1997-10-27"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 4201,
+                  "num_range": 24005,
+                  "upper_bound": "1997-11-06"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 2400,
+                  "num_range": 25805,
+                  "upper_bound": "1997-11-19"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 2400,
+                  "num_range": 27605,
+                  "upper_bound": "1997-11-30"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 6001,
+                  "num_range": 24005,
+                  "upper_bound": "1997-12-12"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 2400,
+                  "num_range": 25805,
+                  "upper_bound": "1997-12-24"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3601,
+                  "num_range": 24605,
+                  "upper_bound": "1998-01-05"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 1200,
+                  "num_range": 26405,
+                  "upper_bound": "1998-01-15"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 3601,
+                  "num_range": 24005,
+                  "upper_bound": "1998-01-25"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1800,
+                  "num_range": 27005,
+                  "upper_bound": "1998-02-05"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 5401,
+                  "num_range": 22204,
+                  "upper_bound": "1998-02-17"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 3001,
+                  "num_range": 25805,
+                  "upper_bound": "1998-02-26"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 4201,
+                  "num_range": 27005,
+                  "upper_bound": "1998-03-10"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 3001,
+                  "num_range": 24605,
+                  "upper_bound": "1998-03-24"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 1800,
+                  "num_range": 26405,
+                  "upper_bound": "1998-04-03"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 2400,
+                  "num_range": 25205,
+                  "upper_bound": "1998-04-12"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 1200,
+                  "num_range": 26405,
+                  "upper_bound": "1998-04-23"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 3601,
+                  "num_range": 27005,
+                  "upper_bound": "1998-05-07"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 1800,
+                  "num_range": 27005,
+                  "upper_bound": "1998-05-20"
+              },
+              {
+                  "distinct_range": 7,
+                  "num_eq": 3601,
+                  "num_range": 25205,
+                  "upper_bound": "1998-05-28"
+              },
+              {
+                  "distinct_range": 10,
+                  "num_eq": 3601,
+                  "num_range": 26405,
+                  "upper_bound": "1998-06-08"
+              },
+              {
+                  "distinct_range": 13,
+                  "num_eq": 600,
+                  "num_range": 26405,
+                  "upper_bound": "1998-06-22"
+              },
+              {
+                  "distinct_range": 8,
+                  "num_eq": 3001,
+                  "num_range": 24605,
+                  "upper_bound": "1998-07-01"
+              },
+              {
+                  "distinct_range": 7,
+                  "num_eq": 6001,
+                  "num_range": 22204,
+                  "upper_bound": "1998-07-09"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3601,
+                  "num_range": 25205,
+                  "upper_bound": "1998-07-21"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 1800,
+                  "num_range": 25205,
+                  "upper_bound": "1998-08-02"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 3601,
+                  "num_range": 25205,
+                  "upper_bound": "1998-08-12"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 1200,
+                  "num_range": 25205,
+                  "upper_bound": "1998-08-22"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 1800,
+                  "num_range": 25205,
+                  "upper_bound": "1998-09-01"
+              },
+              {
+                  "distinct_range": 11,
+                  "num_eq": 3001,
+                  "num_range": 26405,
+                  "upper_bound": "1998-09-13"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 3001,
+                  "num_range": 24605,
+                  "upper_bound": "1998-09-26"
+              },
+              {
+                  "distinct_range": 19,
+                  "num_eq": 1800,
+                  "num_range": 24005,
+                  "upper_bound": "1998-10-16"
+              },
+              {
+                  "distinct_range": 63,
+                  "num_eq": 600,
+                  "num_range": 24605,
+                  "upper_bound": "1998-12-19"
+              },
+              {
+                  "distinct_range": 12,
+                  "num_eq": 0,
+                  "num_range": 12,
+                  "upper_bound": "infinity"
+              }
+          ],
+          "histo_col_type": "DATE",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 6001215
+      },
+      {
+          "avg_size": 8,
+          "columns": [
+              "l_partkey",
+              "l_suppkey"
+          ],
+          "created_at": "2022-03-21 20:30:59.932306",
+          "distinct_count": 797888,
+          "histo_col_type": "",
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 6001215
+      },
+      {
+          "avg_size": 9,
+          "columns": [
+              "l_quantity"
+          ],
+          "created_at": "2022-03-21 20:30:59.932306",
+          "distinct_count": 50,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 121225,
+                  "num_range": 0,
+                  "upper_bound": "1.0"
+              },
+              {
+                  "distinct_range": 48,
+                  "num_eq": 119424,
+                  "num_range": 5760566,
+                  "upper_bound": "50.0"
+              }
+          ],
+          "histo_col_type": "FLOAT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 6001215
+      },
+      {
+          "avg_size": 9,
+          "columns": [
+              "l_extendedprice"
+          ],
+          "created_at": "2022-03-21 20:30:59.932306",
+          "distinct_count": 925955,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 600,
+                  "num_range": 0,
+                  "upper_bound": "937.02"
+              },
+              {
+                  "distinct_range": 925953.0000000001,
+                  "num_eq": 600,
+                  "num_range": 6000015,
+                  "upper_bound": "103499.5"
+              }
+          ],
+          "histo_col_type": "FLOAT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 6001215
+      },
+      {
+          "avg_size": 9,
+          "columns": [
+              "l_discount"
+          ],
+          "created_at": "2022-03-21 20:30:59.932306",
+          "distinct_count": 11,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 570115,
+                  "num_range": 0,
+                  "upper_bound": "0.0"
+              },
+              {
+                  "distinct_range": 9,
+                  "num_eq": 519105,
+                  "num_range": 4911994,
+                  "upper_bound": "0.1"
+              }
+          ],
+          "histo_col_type": "FLOAT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 6001215
+      },
+      {
+          "avg_size": 9,
+          "columns": [
+              "l_tax"
+          ],
+          "created_at": "2022-03-21 20:30:59.932306",
+          "distinct_count": 9,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 688939,
+                  "num_range": 0,
+                  "upper_bound": "0.0"
+              },
+              {
+                  "distinct_range": 7,
+                  "num_eq": 636729,
+                  "num_range": 4675547,
+                  "upper_bound": "0.08"
+              }
+          ],
+          "histo_col_type": "FLOAT8",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 6001215
+      },
+      {
+          "avg_size": 3,
+          "columns": [
+              "l_returnflag"
+          ],
+          "created_at": "2022-03-21 20:30:59.932306",
+          "distinct_count": 3,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1473898,
+                  "num_range": 0,
+                  "upper_bound": "A"
+              },
+              {
+                  "distinct_range": 1,
+                  "num_eq": 1462496,
+                  "num_range": 3064821,
+                  "upper_bound": "R"
+              }
+          ],
+          "histo_col_type": "CHAR",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 6001215
+      },
+      {
+          "avg_size": 3,
+          "columns": [
+              "l_linestatus"
+          ],
+          "created_at": "2022-03-21 20:30:59.932306",
+          "distinct_count": 2,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 2973002,
+                  "num_range": 0,
+                  "upper_bound": "F"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 3028213,
+                  "num_range": 0,
+                  "upper_bound": "O"
+              }
+          ],
+          "histo_col_type": "CHAR",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 6001215
+      },
+      {
+          "avg_size": 14,
+          "columns": [
+              "l_shipinstruct"
+          ],
+          "created_at": "2022-03-21 20:30:59.932306",
+          "distinct_count": 4,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1480500,
+                  "num_range": 0,
+                  "upper_bound": "COLLECT COD"
+              },
+              {
+                  "distinct_range": 2,
+                  "num_eq": 1533911,
+                  "num_range": 2986805,
+                  "upper_bound": "TAKE BACK RETURN"
+              }
+          ],
+          "histo_col_type": "CHAR(25)",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 6001215
+      },
+      {
+          "avg_size": 7,
+          "columns": [
+              "l_shipmode"
+          ],
+          "created_at": "2022-03-21 20:30:59.932306",
+          "distinct_count": 7,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 813765,
+                  "num_range": 0,
+                  "upper_bound": "AIR"
+              },
+              {
+                  "distinct_range": 5,
+                  "num_eq": 843771,
+                  "num_range": 4343679,
+                  "upper_bound": "TRUCK"
+              }
+          ],
+          "histo_col_type": "CHAR(10)",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 6001215
+      },
+      {
+          "avg_size": 29,
+          "columns": [
+              "l_comment"
+          ],
+          "created_at": "2022-03-21 20:30:59.932306",
+          "distinct_count": 4643303,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 600,
+                  "num_range": 0,
+                  "upper_bound": " Tiresias shall have"
+              },
+              {
+                  "distinct_range": 4643301,
+                  "num_eq": 600,
+                  "num_range": 6000015,
+                  "upper_bound": "zle. accounts nag grouches. blithely ironi"
+              }
+          ],
+          "histo_col_type": "VARCHAR(44)",
+          "histo_version": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 6001215
+      }
+  ]'
 
 # Query 1
 query T
@@ -559,12 +20560,12 @@ EXPLAIN (VEC) SELECT s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_
           │   │ └ *colexecsel.selSuffixBytesBytesConstOp
           │   │   └ *colexecsel.selEQInt64Int64ConstOp
           │   │     └ *colfetcher.ColBatchScan
-          │   └ *colexecjoin.hashJoiner
-          │     ├ *colfetcher.ColBatchScan
-          │     └ *colexecjoin.hashJoiner
-          │       ├ *colfetcher.ColBatchScan
-          │       └ *colexecsel.selEQBytesBytesConstOp
-          │         └ *colfetcher.ColBatchScan
+          │   └ *rowexec.joinReader
+          │     └ *rowexec.joinReader
+          │       └ *rowexec.joinReader
+          │         └ *rowexec.joinReader
+          │           └ *colexecsel.selEQBytesBytesConstOp
+          │             └ *colfetcher.ColBatchScan
           └ *rowexec.joinReader
             └ *rowexec.joinReader
               └ *colexecsel.selEQBytesBytesConstOp
@@ -580,12 +20581,10 @@ EXPLAIN (VEC) SELECT l_orderkey, sum(l_extendedprice * (1 - l_discount)) AS reve
     └ *colexec.hashAggregator
       └ *rowexec.joinReader
         └ *colexecjoin.hashJoiner
-          ├ *colfetcher.ColBatchScan
-          └ *colexecjoin.hashJoiner
-            ├ *colexecsel.selLTInt64Int64ConstOp
-            │ └ *colfetcher.ColBatchScan
-            └ *colexecsel.selEQBytesBytesConstOp
-              └ *colfetcher.ColBatchScan
+          ├ *colexecsel.selLTInt64Int64ConstOp
+          │ └ *colfetcher.ColBatchScan
+          └ *colexecsel.selEQBytesBytesConstOp
+            └ *colfetcher.ColBatchScan
 
 # Query 4
 query T
@@ -615,10 +20614,10 @@ EXPLAIN (VEC) SELECT n_name, sum(l_extendedprice * (1 - l_discount)) AS revenue 
             │   ├ *colfetcher.ColIndexJoin
             │   │ └ *colfetcher.ColBatchScan
             │   └ *rowexec.joinReader
-            │     └ *colexecjoin.hashJoiner
-            │       ├ *colfetcher.ColBatchScan
-            │       └ *colexecsel.selEQBytesBytesConstOp
-            │         └ *colfetcher.ColBatchScan
+            │     └ *rowexec.joinReader
+            │       └ *rowexec.joinReader
+            │         └ *colexecsel.selEQBytesBytesConstOp
+            │           └ *colfetcher.ColBatchScan
             └ *colfetcher.ColBatchScan
 
 # Query 6
@@ -742,9 +20741,9 @@ EXPLAIN (VEC) SELECT c_custkey, c_name, sum(l_extendedprice * (1 - l_discount)) 
       └ *colexecproj.projMultFloat64Float64Op
         └ *colexecproj.projMinusFloat64ConstFloat64Op
           └ *colexecjoin.hashJoiner
-            ├ *rowexec.joinReader
-            │ └ *colexecjoin.hashJoiner
-            │   ├ *colfetcher.ColBatchScan
+            ├ *colexecjoin.hashJoiner
+            │ ├ *colfetcher.ColBatchScan
+            │ └ *rowexec.joinReader
             │   └ *colfetcher.ColIndexJoin
             │     └ *colfetcher.ColBatchScan
             └ *colfetcher.ColBatchScan
@@ -956,9 +20955,7 @@ EXPLAIN (VEC) SELECT s_name, s_address FROM supplier, nation WHERE s_suppkey IN 
 │
 └ Node 1
   └ *colexec.sortOp
-    └ *colexecjoin.hashJoiner
-      ├ *colexecsel.selEQBytesBytesConstOp
-      │ └ *colfetcher.ColBatchScan
+    └ *rowexec.joinReader
       └ *rowexec.joinReader
         └ *colexec.unorderedDistinct
           └ *rowexec.joinReader


### PR DESCRIPTION
This commit updates the stats that are injected in `tpch_vec` test as
well as adds the histograms to closer resemble the reality.

I noticed that several plans on the actual data set don't match what we
have in the test file; however, I didn't analyze whether changes to the
plans are improvements or regressions nor when those changes occurred.
Some of the differences are caused by the addition of the histograms.

Release note: None