### PR TITLE
distsql: simple projection in experimental distsql planner panics

### DIFF
--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -349,8 +349,8 @@ func (e *distSQLSpecExecFactory) ConstructSimpleProject(
 ) (exec.Node, error) {
 	physPlan, plan := getPhysPlan(n)
 	projection := make([]uint32, len(cols))
-	for i := range cols {
-		projection[i] = uint32(cols[physPlan.PlanToStreamColMap[i]])
+	for i, col := range cols {
+		projection[i] = uint32(physPlan.PlanToStreamColMap[col])
 	}
 	newColMap := identityMap(physPlan.PlanToStreamColMap, len(cols))
 	physPlan.AddProjection(
@@ -370,8 +370,8 @@ func (e *distSQLSpecExecFactory) ConstructSerializingProject(
 	physPlan, plan := getPhysPlan(n)
 	physPlan.EnsureSingleStreamOnGateway()
 	projection := make([]uint32, len(cols))
-	for i := range cols {
-		projection[i] = uint32(cols[physPlan.PlanToStreamColMap[i]])
+	for i, col := range cols {
+		projection[i] = uint32(physPlan.PlanToStreamColMap[col])
 	}
 	physPlan.AddProjection(projection, execinfrapb.Ordering{})
 	physPlan.ResultColumns = getResultColumnsForSimpleProject(cols, colNames, physPlan.GetResultTypes(), physPlan.ResultColumns)

--- a/pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning
+++ b/pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning
@@ -49,6 +49,13 @@ SELECT v, k FROM kv
 1  2
 2  3
 
+query IIII rowsort
+SELECT v, k, k, v FROM kv
+----
+1  1  1  1
+1  2  2  1
+2  3  3  2
+
 query III rowsort
 SELECT k, v, k + v FROM kv
 ----


### PR DESCRIPTION
Previously, selecting a given column from a table more than once could
cause an `index out of range` panic when experimental_distsql_planning
is set to always, for example:
```
CREATE TABLE kv (k INT PRIMARY KEY, v INT);
INSERT INTO kv VALUES (1, 1), (2, 1), (3, 2);
SET experimental_distsql_planning = always;
SELECT v, k, k, v FROM kv;
```
This commit fixes the issue, which is due to incorrect mapping of
selected columns to source column ordinals in
`ConstructSimpleProject`.

Release note: none