### PR TITLE
ui: decouple html base; allow development with short builds

### DIFF
--- a/pkg/ui/BUILD.bazel
+++ b/pkg/ui/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "ui",
@@ -12,7 +12,6 @@ go_library(
         "//pkg/build",
         "//pkg/util/httputil",
         "//pkg/util/log",
-        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 
@@ -50,5 +49,17 @@ test_suite(
     tests = [
         "//pkg/ui/workspaces/cluster-ui:lint",
         "//pkg/ui/workspaces/db-console:lint",
+    ],
+)
+
+go_test(
+    name = "ui_test",
+    srcs = ["ui_test.go"],
+    embed = [":ui"],
+    deps = [
+        "//pkg/base",
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/ui/ui_test.go
+++ b/pkg/ui/ui_test.go
@@ -1,0 +1,158 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package ui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+type noOIDCConfigured struct{}
+
+func (c *noOIDCConfigured) GetOIDCConf() OIDCUIConf {
+	return OIDCUIConf{
+		Enabled: false,
+	}
+}
+
+type testFs struct{}
+
+func (t testFs) Open(name string) (fs.File, error) {
+	if name == "test.json" {
+		return ioutil.TempFile("", "test.json")
+	}
+	return nil, errors.New("wrong filename")
+}
+
+func TestUIHandlerDevelopment(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	defer func() func() {
+		hold := Assets
+		Assets = &testFs{}
+		return func() {
+			Assets = hold
+		}
+	}()()
+
+	cfg := Config{
+		ExperimentalUseLogin: false,
+		LoginEnabled:         false,
+		NodeID:               &base.NodeIDContainer{},
+		GetUser: func(ctx context.Context) *string {
+			z := ""
+			return &z
+		},
+		OIDC: &noOIDCConfigured{},
+	}
+	server := httptest.NewServer(Handler(cfg))
+	defer server.Close()
+
+	tcs := []struct {
+		haveUI         bool
+		devHeader      bool
+		expectRootBody string
+	}{
+		{
+			haveUI:         false,
+			devHeader:      false,
+			expectRootBody: string(bareIndexHTML),
+		},
+		{
+			haveUI:         false,
+			devHeader:      true,
+			expectRootBody: string(indexHTML),
+		},
+		{
+			haveUI:         true,
+			devHeader:      false,
+			expectRootBody: string(indexHTML),
+		},
+		{
+			haveUI:         true,
+			devHeader:      true,
+			expectRootBody: string(indexHTML),
+		},
+	}
+
+	for i, tc := range tcs {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			HaveUI = tc.haveUI
+			req, err := http.NewRequest("GET", server.URL, nil)
+			require.NoError(t, err)
+			if tc.devHeader {
+				req.Header.Add("crdb-development", "true")
+			}
+
+			resp, err := server.Client().Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			s := &strings.Builder{}
+			_, err = io.Copy(s, resp.Body)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectRootBody, s.String())
+
+			req2, err := http.NewRequest("GET", server.URL+"/test.json", nil)
+			require.NoError(t, err)
+			if tc.devHeader {
+				req2.Header.Add("crdb-development", "true")
+			}
+			resp2, err := server.Client().Do(req2)
+			require.NoError(t, err)
+			require.Equal(t, 200, resp2.StatusCode)
+		})
+	}
+
+}
+
+func TestUIHandler(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	cfg := Config{
+		ExperimentalUseLogin: false,
+		LoginEnabled:         false,
+		NodeID:               &base.NodeIDContainer{},
+		GetUser: func(ctx context.Context) *string {
+			z := ""
+			return &z
+		},
+		OIDC: &noOIDCConfigured{},
+	}
+
+	server := httptest.NewServer(Handler(cfg))
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, 200, resp.StatusCode)
+
+	resp, err = server.Client().Get(server.URL + "/uiconfig")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, 200, resp.StatusCode)
+}

--- a/pkg/ui/workspaces/db-console/src/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/index.tsx
@@ -16,10 +16,23 @@ import { alertDataSync } from "src/redux/alerts";
 import { App } from "src/app";
 import { store, history } from "src/redux/state";
 import "src/redux/analytics";
+import {
+  DataFromServer,
+  fetchDataFromServer,
+  setDataFromServer,
+} from "src/util/dataFromServer";
 
-ReactDOM.render(
-  <App history={history} store={store} />,
-  document.getElementById("react-layout"),
-);
+async function fetchAndRender() {
+  setDataFromServer(
+    (await fetchDataFromServer().catch(() => {})) as DataFromServer,
+  );
 
-store.subscribe(alertDataSync(store));
+  ReactDOM.render(
+    <App history={history} store={store} />,
+    document.getElementById("react-layout"),
+  );
+
+  store.subscribe(alertDataSync(store));
+}
+
+fetchAndRender();

--- a/pkg/ui/workspaces/db-console/src/redux/alerts.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/alerts.ts
@@ -41,6 +41,7 @@ import {
 } from "src/redux/nodes";
 import { AdminUIState, AppDispatch } from "./state";
 import * as docsURL from "src/util/docs";
+import { getDataFromServer } from "../util/dataFromServer";
 
 export enum AlertLevel {
   NOTIFICATION,
@@ -536,6 +537,34 @@ export const panelAlertsSelector = createSelector(
 );
 
 /**
+ * dataFromServerAlertSelector returns an alert when the
+ * `dataFromServer` window variable is unset. This variable is retrieved
+ * prior to page render and contains some base metadata about the
+ * backing CRDB node.
+ */
+export const dataFromServerAlertSelector = createSelector(
+  () => {},
+  (): Alert => {
+    if (_.isEmpty(getDataFromServer())) {
+      return {
+        level: AlertLevel.CRITICAL,
+        title: "There was an error retrieving base DB Console configuration.",
+        text: "Please try refreshing the page. If the problem continues please reach out to customer support.",
+        showAsAlert: true,
+        dismiss: (_: Dispatch<Action>) => {
+          // Dismiss is a no-op here because the alert component itself
+          // is dismissable by default and because we do want to keep
+          // showing it if the metadata continues to be missing.
+          return Promise.resolve();
+        },
+      };
+    } else {
+      return null;
+    }
+  },
+);
+
+/**
  * Selector which returns an array of all active alerts which should be
  * displayed as a banner, which appears at the top of the page and overlaps
  * content in recognition of the severity of the alert; currently, this includes
@@ -548,6 +577,7 @@ export const bannerAlertsSelector = createSelector(
   cancelStatementDiagnosticsAlertSelector,
   terminateSessionAlertSelector,
   terminateQueryAlertSelector,
+  dataFromServerAlertSelector,
   (...alerts: Alert[]): Alert[] => {
     return _.without(alerts, null, undefined);
   },

--- a/pkg/ui/workspaces/db-console/src/util/dataFromServer.ts
+++ b/pkg/ui/workspaces/db-console/src/util/dataFromServer.ts
@@ -19,7 +19,6 @@ export interface DataFromServer {
   OIDCLoginEnabled: boolean;
   OIDCButtonText: string;
 }
-
 // Tell TypeScript about `window.dataFromServer`, which is set in a script
 // tag in index.html, the contents of which are generated in a Go template
 // server-side.
@@ -29,6 +28,25 @@ declare global {
   }
 }
 
+export function fetchDataFromServer(): Promise<DataFromServer> {
+  return fetch("/uiconfig", {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+  }).then(resp => {
+    if (resp.status >= 400) {
+      throw new Error(`Error response from server: ${resp.status}`);
+    }
+    return resp.json();
+  });
+}
+
 export function getDataFromServer(): DataFromServer {
   return window.dataFromServer || ({} as DataFromServer);
+}
+
+export function setDataFromServer(d: DataFromServer) {
+  window.dataFromServer = d;
 }

--- a/pkg/ui/workspaces/db-console/webpack.app.js
+++ b/pkg/ui/workspaces/db-console/webpack.app.js
@@ -201,6 +201,9 @@ module.exports = (env, argv) => {
         "/": {
           secure: false,
           target: env.target || process.env.TARGET,
+          headers: {
+            "CRDB-Development": "true",
+          },
         },
       },
     },


### PR DESCRIPTION
Previously, a few small issues prevented the UI development process from
making independent choices from CRDB. First, the base HTML template
contained data available in a global variable. Second, the "short" build
would break this template and keep us from developing on the UI when
we're just tweaking server endpoints.

This PR solves both problems. First, the templated variables are removed
and retrieved a startup in `index.tsx`. The React bootstrap waits for
the JSON response which is saved in a global variable by the JS code
instead of the backend. An attempt was made to remove the need for this
global variable but that changes quite a bit of code. In particular, all
of our links to docs pages rely on the global availability of the
cluster version number. Changing this would require that all docs link
generation functions take the version number as input instead of being
statically generated.

Second, the webpack dev server proxy will now attack a header to its
requests allowing us to notice this on the CRDB server and short circuit
the response on short builds to render the base HTML template as if it
was a "full" build. When the webpack dev server is running and serving
dev assets from memory, this lets us interact with DB Console on the
3000 port and develop using the hot reload workflow. This will shorten
dev feedback loops by making builds faster when backend endpoints are
being tweaked.

Release note: None