### PR TITLE
descmetadata: fix condition for bumping table version

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -343,6 +343,7 @@ ALL_TESTS = [
     "//pkg/sql/sem/tree/eval_test:eval_test_test",
     "//pkg/sql/sem/tree:tree_test",
     "//pkg/sql/sessiondata:sessiondata_test",
+    "//pkg/sql/sessioninit:sessioninit_test",
     "//pkg/sql/span:span_test",
     "//pkg/sql/sqlinstance/instanceprovider:instanceprovider_test",
     "//pkg/sql/sqlinstance/instancestorage:instancestorage_test",

--- a/pkg/sql/descmetadata/metadata_updater.go
+++ b/pkg/sql/descmetadata/metadata_updater.go
@@ -126,9 +126,9 @@ func (mu metadataUpdater) DeleteDatabaseRoleSettings(ctx context.Context, dbID d
 	if err != nil {
 		return err
 	}
-	// If system table updates should be minimized, avoid bumping up the version
-	// number of the table below.
-	if mu.cacheEnabled || rowsDeleted == 0 {
+	// If the cache is off or if no rows changed, there's no need to bump the
+	// table version.
+	if !mu.cacheEnabled || rowsDeleted == 0 {
 		return nil
 	}
 	// Bump the table version for the role settings table when we modify it.

--- a/pkg/sql/sessioninit/BUILD.bazel
+++ b/pkg/sql/sessioninit/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "sessioninit",
@@ -23,5 +23,32 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/syncutil/singleflight",
         "@com_github_cockroachdb_logtags//:logtags",
+    ],
+)
+
+go_test(
+    name = "sessioninit_test",
+    srcs = [
+        "cache_test.go",
+        "main_test.go",
+    ],
+    deps = [
+        ":sessioninit",
+        "//pkg/base",
+        "//pkg/kv",
+        "//pkg/security",
+        "//pkg/security/securitytest",
+        "//pkg/server",
+        "//pkg/sql",
+        "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/descs",
+        "//pkg/sql/sqlutil",
+        "//pkg/testutils/serverutils",
+        "//pkg/testutils/sqlutils",
+        "//pkg/testutils/testcluster",
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
+        "//pkg/util/randutil",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/sessioninit/cache_test.go
+++ b/pkg/sql/sessioninit/cache_test.go
@@ -1,0 +1,196 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sessioninit_test
+
+import (
+	"context"
+	gosql "database/sql"
+	"net/url"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessioninit"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCacheInvalidation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: false})
+	defer s.Stopper().Stop(ctx)
+	defer db.Close()
+
+	pgURL, cleanupFunc := sqlutils.PGUrl(
+		t, s.ServingSQLAddr(), "TestCacheInvalidation" /* prefix */, url.UserPassword("testuser", "abc"),
+	)
+	defer cleanupFunc()
+
+	// Extract login as a function so that we can call it to populate the cache
+	// with real information.
+	login := func() {
+		thisDB, err := gosql.Open("postgres", pgURL.String())
+		require.NoError(t, err)
+		var i int
+		err = thisDB.QueryRow("SELECT 1").Scan(&i)
+		require.NoError(t, err)
+		_ = thisDB.Close()
+	}
+
+	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
+	getSettingsFromCache := func() ([]sessioninit.SettingsCacheEntry, bool, error) {
+		didReadFromSystemTable := false
+		settings, err := execCfg.SessionInitCache.GetDefaultSettings(
+			ctx,
+			s.ClusterSettings(),
+			s.InternalExecutor().(sqlutil.InternalExecutor),
+			s.DB(),
+			s.CollectionFactory().(*descs.CollectionFactory),
+			security.TestUserName(),
+			"defaultdb",
+			func(ctx context.Context, txn *kv.Txn, ie sqlutil.InternalExecutor, username security.SQLUsername, databaseID descpb.ID) ([]sessioninit.SettingsCacheEntry, error) {
+				didReadFromSystemTable = true
+				return nil, nil
+			})
+		return settings, didReadFromSystemTable, err
+	}
+	getAuthInfoFromCache := func() (sessioninit.AuthInfo, bool, error) {
+		didReadFromSystemTable := false
+		aInfo, err := execCfg.SessionInitCache.GetAuthInfo(
+			ctx,
+			s.ClusterSettings(),
+			s.InternalExecutor().(sqlutil.InternalExecutor),
+			s.DB(),
+			s.CollectionFactory().(*descs.CollectionFactory),
+			security.TestUserName(),
+			func(ctx context.Context, txn *kv.Txn, ie sqlutil.InternalExecutor, username security.SQLUsername) (sessioninit.AuthInfo, error) {
+				didReadFromSystemTable = true
+				return sessioninit.AuthInfo{}, nil
+			})
+		return aInfo, didReadFromSystemTable, err
+	}
+
+	// Create user and warm the cache.
+	_, err := db.ExecContext(ctx, "CREATE USER testuser WITH PASSWORD 'abc'")
+	require.NoError(t, err)
+	login()
+
+	t.Run("default settings cache", func(t *testing.T) {
+		for _, stmt := range []string{
+			`ALTER ROLE ALL IN DATABASE postgres SET search_path = 'a'`,
+			`ALTER ROLE testuser SET search_path = 'b'`,
+		} {
+			_, err := db.ExecContext(ctx, stmt)
+			require.NoError(t, err)
+		}
+
+		// Check that the cache initially contains the default settings for testuser.
+		login()
+		settings, didReadFromSystemTable, err := getSettingsFromCache()
+		require.NoError(t, err)
+		require.False(t, didReadFromSystemTable)
+		require.Contains(t, settings, sessioninit.SettingsCacheEntry{
+			SettingsCacheKey: sessioninit.SettingsCacheKey{
+				DatabaseID: 0,
+				Username:   security.TestUserName(),
+			},
+			Settings: []string{"search_path=b"},
+		})
+
+		// Verify that dropping a database referenced in the default settings table
+		// causes the cache to be invalidated.
+		_, err = db.ExecContext(ctx, "DROP DATABASE postgres")
+		require.NoError(t, err)
+		settings, didReadFromSystemTable, err = getSettingsFromCache()
+		require.NoError(t, err)
+		require.True(t, didReadFromSystemTable)
+		require.Empty(t, settings)
+
+		// Verify that adding a new default setting causes the cache to be
+		// invalidated. We need to use login() to load "real" data.
+		_, err = db.ExecContext(ctx, `ALTER ROLE ALL SET search_path = 'c'`)
+		require.NoError(t, err)
+		login()
+		settings, didReadFromSystemTable, err = getSettingsFromCache()
+		require.NoError(t, err)
+		require.False(t, didReadFromSystemTable)
+		require.Contains(t, settings, sessioninit.SettingsCacheEntry{
+			SettingsCacheKey: sessioninit.SettingsCacheKey{
+				DatabaseID: 0,
+				Username:   security.MakeSQLUsernameFromPreNormalizedString(""),
+			},
+			Settings: []string{"search_path=c"},
+		})
+
+		// Verify that dropping a user referenced in the default settings table
+		// causes the cache to be invalidated.
+		_, err = db.ExecContext(ctx, "DROP USER testuser")
+		require.NoError(t, err)
+		settings, didReadFromSystemTable, err = getSettingsFromCache()
+		require.NoError(t, err)
+		require.True(t, didReadFromSystemTable)
+		require.Empty(t, settings)
+
+		// Re-create the user and warm the cache for the next test.
+		_, err = db.ExecContext(ctx, "CREATE USER testuser WITH PASSWORD 'abc'")
+		require.NoError(t, err)
+		login()
+	})
+
+	t.Run("auth info cache", func(t *testing.T) {
+		// Check that the cache initially contains info for testuser.
+		login()
+		aInfo, didReadFromSystemTable, err := getAuthInfoFromCache()
+		require.NoError(t, err)
+		require.False(t, didReadFromSystemTable)
+		require.True(t, aInfo.UserExists)
+		require.True(t, aInfo.CanLoginSQL)
+
+		// Verify that creating a different user invalidates the cache.
+		_, err = db.ExecContext(ctx, "CREATE USER testuser2")
+		require.NoError(t, err)
+		aInfo, didReadFromSystemTable, err = getAuthInfoFromCache()
+		require.NoError(t, err)
+		require.True(t, didReadFromSystemTable)
+
+		// Verify that dropping a user invalidates the cache
+		_, err = db.ExecContext(ctx, "DROP USER testuser2")
+		require.NoError(t, err)
+		aInfo, didReadFromSystemTable, err = getAuthInfoFromCache()
+		require.NoError(t, err)
+		require.True(t, didReadFromSystemTable)
+
+		// Verify that altering VALID UNTIL invalidates the cache
+		_, err = db.ExecContext(ctx, "ALTER USER testuser VALID UNTIL '2099-01-01'")
+		require.NoError(t, err)
+		aInfo, didReadFromSystemTable, err = getAuthInfoFromCache()
+		require.NoError(t, err)
+		require.True(t, didReadFromSystemTable)
+
+		// Sanity check to make sure the cache is used.
+		_, err = db.ExecContext(ctx, "SELECT 1")
+		require.NoError(t, err)
+		aInfo, didReadFromSystemTable, err = getAuthInfoFromCache()
+		require.NoError(t, err)
+		require.False(t, didReadFromSystemTable)
+	})
+}

--- a/pkg/sql/sessioninit/main_test.go
+++ b/pkg/sql/sessioninit/main_test.go
@@ -1,0 +1,33 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sessioninit_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+//go:generate ../../util/leaktest/add-leaktest.sh *_test.go
+
+func TestMain(m *testing.M) {
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
This condition was inverted incorrectly. If the cache is on, it's
important to bump the table version so the cache can be invalidated.

Release justification: high priority bugfix to new functionality.

Release note: None