### PR TITLE
sql: use soft and hard limits in lookup and index joins

### DIFF
--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -109,6 +109,7 @@ var retiredSettings = map[string]struct{}{
 	"sql.telemetry.query_sampling.sample_rate":                       {},
 	"diagnostics.sql_stat_reset.interval":                            {},
 	"changefeed.mem.pushback_enabled":                                {},
+	"sql.distsql.index_join_limit_hint.enabled":                      {},
 
 	// removed as of 22.1.
 	"sql.defaults.drop_enum_value.enabled":                             {},

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -762,7 +762,7 @@ func NewColOperator(
 				ctx, getStreamingAllocator(ctx, args),
 				colmem.NewAllocator(ctx, cFetcherMemAcc, factory),
 				kvFetcherMemAcc, streamerBudgetAcc, flowCtx,
-				inputs[0].Root, core.JoinReader, inputTypes, streamerDiskMonitor,
+				inputs[0].Root, core.JoinReader, post, inputTypes, streamerDiskMonitor,
 			)
 			if err != nil {
 				return r, err

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -62,6 +62,10 @@ type ColIndexJoin struct {
 	// and may not correspond to batch boundaries.
 	startIdx int
 
+	// limitHintHelper is used in limiting batches of input rows in the presence
+	// of hard and soft limits.
+	limitHintHelper execinfra.LimitHintHelper
+
 	mem struct {
 		// inputBatchSize tracks the size of the rows that have been used to
 		// generate spans so far. This is used to prevent memory usage from growing
@@ -176,7 +180,7 @@ func (s *ColIndexJoin) Next() coldata.Batch {
 	for {
 		switch s.state {
 		case indexJoinConstructingSpans:
-			var rowCount int
+			var rowCount int64
 			var spans roachpb.Spans
 			s.mem.inputBatchSize = 0
 			for s.next() {
@@ -184,13 +188,26 @@ func (s *ColIndexJoin) Next() coldata.Batch {
 				// reference to input tuples after span generation. So, we can discard
 				// the input batch reference on each iteration.
 				endIdx := s.findEndIndex(rowCount > 0)
-				rowCount += endIdx - s.startIdx
+				// If we have a limit hint, make sure we don't include more rows
+				// than needed.
+				if l := s.limitHintHelper.LimitHint(); l != 0 && rowCount+int64(endIdx-s.startIdx) > l {
+					endIdx = s.startIdx + int(l-rowCount)
+				}
+				rowCount += int64(endIdx - s.startIdx)
 				s.spanAssembler.ConsumeBatch(s.batch, s.startIdx, endIdx)
 				s.startIdx = endIdx
+				if l := s.limitHintHelper.LimitHint(); l != 0 && rowCount == l {
+					// Reached the limit hint. Note that rowCount cannot be
+					// larger than l because we chopped the former off above.
+					break
+				}
 				if endIdx < s.batch.Length() {
 					// Reached the memory limit.
 					break
 				}
+			}
+			if err := s.limitHintHelper.ReadSomeRows(rowCount); err != nil {
+				colexecerror.InternalError(err)
 			}
 			spans = s.spanAssembler.GetSpans()
 			if len(spans) == 0 {
@@ -441,6 +458,7 @@ func NewColIndexJoin(
 	flowCtx *execinfra.FlowCtx,
 	input colexecop.Operator,
 	spec *execinfrapb.JoinReaderSpec,
+	post *execinfrapb.PostProcessSpec,
 	inputTypes []*types.T,
 	diskMonitor *mon.BytesMonitor,
 ) (*ColIndexJoin, error) {
@@ -508,6 +526,7 @@ func NewColIndexJoin(
 		ResultTypes:      tableArgs.typs,
 		maintainOrdering: spec.MaintainOrdering,
 		usesStreamer:     useStreamer,
+		limitHintHelper:  execinfra.MakeLimitHintHelper(spec.LimitHint, post),
 	}
 	op.mem.inputBatchSizeLimit = inputBatchSizeLimit
 	op.prepareMemLimit(inputTypes)

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2233,6 +2233,7 @@ func (dsp *DistSQLPlanner) createPlanForIndexJoin(
 		LockingStrength:   n.table.lockingStrength,
 		LockingWaitPolicy: n.table.lockingWaitPolicy,
 		MaintainOrdering:  len(n.reqOrdering) > 0,
+		LimitHint:         int64(n.limitHint),
 	}
 
 	fetchColIDs := make([]descpb.ColumnID, len(n.cols))
@@ -2301,6 +2302,7 @@ func (dsp *DistSQLPlanner) createPlanForLookupJoin(
 		LeftJoinWithPairedJoiner:          n.isSecondJoinInPairedJoiner,
 		OutputGroupContinuationForLeftRow: n.isFirstJoinInPairedJoiner,
 		LookupBatchBytesLimit:             dsp.distSQLSrv.TestingKnobs.JoinReaderBatchBytesLimit,
+		LimitHint:                         int64(n.limitHint),
 	}
 
 	fetchColIDs := make([]descpb.ColumnID, len(n.table.cols))

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -640,6 +640,7 @@ func (e *distSQLSpecExecFactory) ConstructIndexJoin(
 	keyCols []exec.NodeColumnOrdinal,
 	tableCols exec.TableColumnOrdinalSet,
 	reqOrdering exec.OutputOrdering,
+	limitHint int,
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: index join")
 }
@@ -659,6 +660,7 @@ func (e *distSQLSpecExecFactory) ConstructLookupJoin(
 	isSecondJoinInPairedJoiner bool,
 	reqOrdering exec.OutputOrdering,
 	locking *tree.LockingItem,
+	limitHint int,
 ) (exec.Node, error) {
 	// TODO (rohany): Implement production of system columns by the underlying scan here.
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: lookup join")

--- a/pkg/sql/execinfrapb/processors_sql.proto
+++ b/pkg/sql/execinfrapb/processors_sql.proto
@@ -379,6 +379,15 @@ message JoinReaderSpec {
   // used for lookups - it depends on whether the joiner decides it wants
   // DistSender-parallelism or not.
   optional int64 lookup_batch_bytes_limit = 18 [(gogoproto.nullable) = false];
+
+  // A hint for how many rows the consumer of the join reader output might
+  // need. This is used to size the initial batches of input rows to try to
+  // avoid reading many more rows than needed by the processor receiving the
+  // output.
+  //
+  // Not used if there is a limit set in the PostProcessSpec of this processor
+  // (that value will be used for sizing batches instead).
+  optional int64 limit_hint = 21 [(gogoproto.nullable) = false];
 }
 
 // SorterSpec is the specification for a "sorting aggregator". A sorting

--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -36,6 +36,8 @@ type indexJoinNode struct {
 	resultColumns colinfo.ResultColumns
 
 	reqOrdering ReqOrdering
+
+	limitHint int
 }
 
 func (n *indexJoinNode) startExec(params runParams) error {

--- a/pkg/sql/lookup_join.go
+++ b/pkg/sql/lookup_join.go
@@ -70,6 +70,8 @@ type lookupJoinNode struct {
 	isSecondJoinInPairedJoiner bool
 
 	reqOrdering ReqOrdering
+
+	limitHint int
 }
 
 func (lj *lookupJoinNode) startExec(params runParams) error {

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1723,7 +1723,7 @@ func (b *Builder) buildIndexJoin(join *memo.IndexJoinExpr) (execPlan, error) {
 	needed, output := b.getColumns(cols, join.Table)
 	res := execPlan{outputCols: output}
 	res.root, err = b.factory.ConstructIndexJoin(
-		input.root, tab, keyCols, needed, res.reqOrdering(join),
+		input.root, tab, keyCols, needed, res.reqOrdering(join), int(math.Ceil(join.RequiredPhysical().LimitHint)),
 	)
 	if err != nil {
 		return execPlan{}, err
@@ -1832,6 +1832,7 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 		join.IsSecondJoinInPairedJoiner,
 		res.reqOrdering(join),
 		locking,
+		int(math.Ceil(join.RequiredPhysical().LimitHint)),
 	)
 	if err != nil {
 		return execPlan{}, err

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_limit
@@ -1,0 +1,346 @@
+# LogicTest: local
+
+# This test file verifies that the lookup and index joins don't fetch too many
+# rows eagerly in the presence of limit hints.
+
+statement ok
+CREATE TABLE a (x INT PRIMARY KEY, y INT, z INT, INDEX (y));
+CREATE TABLE b (x INT PRIMARY KEY);
+INSERT INTO a VALUES (1, 1, 1), (2, 1, 1), (3, 2, 2), (4, 2, 2);
+INSERT INTO b VALUES (1), (2), (3), (4);
+
+# Query with an index join and a limit hint.
+query T
+EXPLAIN (OPT, VERBOSE) SELECT * FROM (SELECT * FROM a WHERE y = 1 UNION ALL SELECT * FROM a WHERE y = 2) LIMIT 1
+----
+limit
+ ├── columns: x:11 y:12 z:13
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=1]
+ ├── cost: 152.280001
+ ├── key: ()
+ ├── fd: ()-->(11-13)
+ ├── distribution: test
+ ├── prune: (11,13)
+ ├── union-all
+ │    ├── columns: x:11 y:12 z:13
+ │    ├── left columns: a.x:1 a.y:2 a.z:3
+ │    ├── right columns: a.x:6 a.y:7 a.z:8
+ │    ├── stats: [rows=20]
+ │    ├── cost: 152.260001
+ │    ├── limit hint: 1.00
+ │    ├── distribution: test
+ │    ├── prune: (11,13)
+ │    ├── index-join a
+ │    │    ├── columns: a.x:1 a.y:2 a.z:3
+ │    │    ├── stats: [rows=10, distinct(2)=1, null(2)=0, avgsize(2)=4]
+ │    │    ├── cost: 76.0200006
+ │    │    ├── key: (1)
+ │    │    ├── fd: ()-->(2), (1)-->(3)
+ │    │    ├── limit hint: 1.00
+ │    │    ├── distribution: test
+ │    │    ├── prune: (1,3)
+ │    │    └── scan a@a_y_idx
+ │    │         ├── columns: a.x:1 a.y:2
+ │    │         ├── constraint: /2/1: [/1 - /1]
+ │    │         ├── stats: [rows=10, distinct(2)=1, null(2)=0, avgsize(2)=4]
+ │    │         ├── cost: 15.1
+ │    │         ├── key: (1)
+ │    │         ├── fd: ()-->(2)
+ │    │         ├── limit hint: 1.00
+ │    │         └── distribution: test
+ │    └── index-join a
+ │         ├── columns: a.x:6 a.y:7 a.z:8
+ │         ├── stats: [rows=10, distinct(7)=1, null(7)=0, avgsize(7)=4]
+ │         ├── cost: 76.0200006
+ │         ├── key: (6)
+ │         ├── fd: ()-->(7), (6)-->(8)
+ │         ├── limit hint: 1.00
+ │         ├── distribution: test
+ │         ├── prune: (6,8)
+ │         └── scan a@a_y_idx
+ │              ├── columns: a.x:6 a.y:7
+ │              ├── constraint: /7/6: [/2 - /2]
+ │              ├── stats: [rows=10, distinct(7)=1, null(7)=0, avgsize(7)=4]
+ │              ├── cost: 15.1
+ │              ├── key: (6)
+ │              ├── fd: ()-->(7)
+ │              ├── limit hint: 1.00
+ │              └── distribution: test
+ └── 1
+
+# Run through the vectorized engine. Make sure that only a single row is scanned
+# and then a single row is looked up by the index join.
+query T
+EXPLAIN ANALYZE SELECT * FROM (SELECT * FROM a WHERE y = 1 UNION ALL SELECT * FROM a WHERE y = 2) LIMIT 1
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+rows read from KV: 2 (16 B)
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+·
+• limit
+│ nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 1
+│ count: 1
+│
+└── • union all
+    │ nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 1
+    │
+    ├── • index join
+    │   │ nodes: <hidden>
+    │   │ regions: <hidden>
+    │   │ actual row count: 1
+    │   │ KV time: 0µs
+    │   │ KV contention time: 0µs
+    │   │ KV rows read: 1
+    │   │ KV bytes read: 8 B
+    │   │ estimated max memory allocated: 0 B
+    │   │ estimated max sql temp disk usage: 0 B
+    │   │ table: a@a_pkey
+    │   │
+    │   └── • scan
+    │         nodes: <hidden>
+    │         regions: <hidden>
+    │         actual row count: 1
+    │         KV time: 0µs
+    │         KV contention time: 0µs
+    │         KV rows read: 1
+    │         KV bytes read: 8 B
+    │         estimated max memory allocated: 0 B
+    │         missing stats
+    │         table: a@a_y_idx
+    │         spans: [/1 - /1]
+    │
+    └── • index join
+        │ nodes: <hidden>
+        │ regions: <hidden>
+        │ actual row count: 0
+        │ KV time: 0µs
+        │ KV contention time: 0µs
+        │ KV rows read: 0
+        │ KV bytes read: 0 B
+        │ estimated max memory allocated: 0 B
+        │ estimated max sql temp disk usage: 0 B
+        │ table: a@a_pkey
+        │
+        └── • scan
+              nodes: <hidden>
+              regions: <hidden>
+              actual row count: 0
+              KV time: 0µs
+              KV contention time: 0µs
+              KV rows read: 0
+              KV bytes read: 0 B
+              estimated max memory allocated: 0 B
+              missing stats
+              table: a@a_y_idx
+              spans: [/2 - /2]
+
+statement ok
+SET vectorize = off
+
+# Run through the row-by-row engine. Make sure that only a single row is scanned
+# and then a single row is looked up by the index join.
+query T
+EXPLAIN ANALYZE SELECT * FROM (SELECT * FROM a WHERE y = 1 UNION ALL SELECT * FROM a WHERE y = 2) LIMIT 1
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+rows read from KV: 2 (16 B)
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+·
+• limit
+│ nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 1
+│ count: 1
+│
+└── • union all
+    │ nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 1
+    │
+    ├── • index join
+    │   │ nodes: <hidden>
+    │   │ regions: <hidden>
+    │   │ actual row count: 1
+    │   │ KV time: 0µs
+    │   │ KV contention time: 0µs
+    │   │ KV rows read: 1
+    │   │ KV bytes read: 8 B
+    │   │ table: a@a_pkey
+    │   │
+    │   └── • scan
+    │         nodes: <hidden>
+    │         regions: <hidden>
+    │         actual row count: 1
+    │         KV time: 0µs
+    │         KV contention time: 0µs
+    │         KV rows read: 1
+    │         KV bytes read: 8 B
+    │         missing stats
+    │         table: a@a_y_idx
+    │         spans: [/1 - /1]
+    │
+    └── • index join
+        │ nodes: <hidden>
+        │ regions: <hidden>
+        │ actual row count: 0
+        │ KV time: 0µs
+        │ KV contention time: 0µs
+        │ KV rows read: 0
+        │ KV bytes read: 0 B
+        │ table: a@a_pkey
+        │
+        └── • scan
+              nodes: <hidden>
+              regions: <hidden>
+              actual row count: 0
+              KV time: 0µs
+              KV contention time: 0µs
+              KV rows read: 0
+              KV bytes read: 0 B
+              missing stats
+              table: a@a_y_idx
+              spans: [/2 - /2]
+
+statement ok
+RESET vectorize
+
+# Inject such stats that the query below will have a limit hint of 1 for the
+# scan.
+statement ok
+ALTER TABLE a INJECT STATISTICS '[
+      {
+          "avg_size": 1,
+          "columns": ["x"],
+          "created_at": "2022-03-22 00:00:00",
+          "distinct_count": 1,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 1
+      },
+       {
+           "avg_size": 1,
+           "columns": ["y"],
+           "created_at": "2022-03-22 00:00:00",
+           "distinct_count": 1,
+           "name": "__auto__",
+           "null_count": 0,
+           "row_count": 1
+       },
+       {
+           "avg_size": 1,
+           "columns": ["z"],
+           "created_at": "2022-03-22 00:00:00",
+           "distinct_count": 1,
+           "name": "__auto__",
+           "null_count": 0,
+           "row_count": 1
+       }
+  ]'
+
+# Query with a lookup join and a limit hint.
+query T
+EXPLAIN (OPT, VERBOSE) SELECT b.x FROM a, b WHERE a.x = b.x LIMIT 1
+----
+project
+ ├── columns: x:6
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=1]
+ ├── cost: 21.145
+ ├── key: ()
+ ├── fd: ()-->(6)
+ ├── distribution: test
+ ├── prune: (6)
+ └── limit
+      ├── columns: a.x:1 b.x:6
+      ├── cardinality: [0 - 1]
+      ├── stats: [rows=1]
+      ├── cost: 21.125
+      ├── key: ()
+      ├── fd: ()-->(1,6), (6)==(1), (1)==(6)
+      ├── distribution: test
+      ├── inner-join (lookup b)
+      │    ├── columns: a.x:1 b.x:6
+      │    ├── key columns: [1] = [6]
+      │    ├── lookup columns are key
+      │    ├── stats: [rows=1, distinct(1)=1, null(1)=0, avgsize(1)=1, distinct(6)=1, null(6)=0, avgsize(6)=4]
+      │    ├── cost: 21.105
+      │    ├── key: (6)
+      │    ├── fd: (1)==(6), (6)==(1)
+      │    ├── limit hint: 1.00
+      │    ├── distribution: test
+      │    ├── scan a@a_y_idx
+      │    │    ├── columns: a.x:1
+      │    │    ├── stats: [rows=1, distinct(1)=1, null(1)=0, avgsize(1)=1]
+      │    │    ├── cost: 15.035
+      │    │    ├── key: (1)
+      │    │    ├── limit hint: 1.00
+      │    │    ├── distribution: test
+      │    │    ├── prune: (1)
+      │    │    ├── interesting orderings: (+1)
+      │    │    └── unfiltered-cols: (1-5)
+      │    └── filters (true)
+      └── 1
+
+# Perform a lookup join. Make sure that a single row is scanned and then a
+# single row is looked up.
+query T
+EXPLAIN ANALYZE SELECT b.x FROM a, b WHERE a.x = b.x LIMIT 1
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+rows read from KV: 2 (16 B)
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+·
+• limit
+│ nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 1
+│ KV time: 0µs
+│ KV contention time: 0µs
+│ KV rows read: 1
+│ KV bytes read: 8 B
+│ count: 1
+│
+└── • lookup join
+    │ nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 1
+    │ KV time: 0µs
+    │ KV contention time: 0µs
+    │ KV rows read: 1
+    │ KV bytes read: 8 B
+    │ table: b@b_pkey
+    │ equality: (x) = (x)
+    │ equality cols are key
+    │
+    └── • scan
+          nodes: <hidden>
+          regions: <hidden>
+          actual row count: 1
+          KV time: 0µs
+          KV contention time: 0µs
+          KV rows read: 1
+          KV bytes read: 8 B
+          estimated max memory allocated: 0 B
+          estimated row count: 1 (100% of the table; stats collected <hidden> ago)
+          table: a@a_y_idx
+          spans: FULL SCAN

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -249,6 +249,7 @@ define IndexJoin {
     KeyCols []exec.NodeColumnOrdinal
     TableCols exec.TableColumnOrdinalSet
     ReqOrdering exec.OutputOrdering
+    LimitHint int
 }
 
 # LookupJoin performs a lookup join.
@@ -284,6 +285,7 @@ define LookupJoin {
     IsSecondJoinInPairedJoiner bool
     ReqOrdering exec.OutputOrdering
     Locking *tree.LockingItem
+    LimitHint int
 }
 
 # InvertedJoin performs a lookup join into an inverted index.

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -597,6 +597,7 @@ func (ef *execFactory) ConstructIndexJoin(
 	keyCols []exec.NodeColumnOrdinal,
 	tableCols exec.TableColumnOrdinalSet,
 	reqOrdering exec.OutputOrdering,
+	limitHint int,
 ) (exec.Node, error) {
 	tabDesc := table.(*optTable).desc
 	colCfg := makeScanColumnsConfig(table, tableCols)
@@ -618,6 +619,7 @@ func (ef *execFactory) ConstructIndexJoin(
 		cols:          cols,
 		resultColumns: colinfo.ResultColumnsFromColumns(tabDesc.GetID(), cols),
 		reqOrdering:   ReqOrdering(reqOrdering),
+		limitHint:     limitHint,
 	}
 
 	n.keyCols = make([]int, len(keyCols))
@@ -644,6 +646,7 @@ func (ef *execFactory) ConstructLookupJoin(
 	isSecondJoinInPairedJoiner bool,
 	reqOrdering exec.OutputOrdering,
 	locking *tree.LockingItem,
+	limitHint int,
 ) (exec.Node, error) {
 	if table.IsVirtualTable() {
 		return ef.constructVirtualTableLookupJoin(joinType, input, table, index, eqCols, lookupCols, onCond)
@@ -680,6 +683,7 @@ func (ef *execFactory) ConstructLookupJoin(
 		isFirstJoinInPairedJoiner:  isFirstJoinInPairedJoiner,
 		isSecondJoinInPairedJoiner: isSecondJoinInPairedJoiner,
 		reqOrdering:                ReqOrdering(reqOrdering),
+		limitHint:                  limitHint,
 	}
 	n.eqCols = make([]int, len(eqCols))
 	for i, c := range eqCols {

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -217,6 +217,10 @@ type joinReader struct {
 	// used.
 	lookupBatchBytesLimit rowinfra.BytesLimit
 
+	// limitHintHelper is used in limiting batches of input rows in the presence
+	// of hard and soft limits.
+	limitHintHelper execinfra.LimitHintHelper
+
 	// scanStats is collected from the trace after we finish doing work for this
 	// join.
 	scanStats execinfra.ScanStats
@@ -316,6 +320,7 @@ func newJoinReader(
 		lockWaitPolicy:                    row.GetWaitPolicy(spec.LockingWaitPolicy),
 		usesStreamer:                      useStreamer,
 		lookupBatchBytesLimit:             rowinfra.BytesLimit(spec.LookupBatchBytesLimit),
+		limitHintHelper:                   execinfra.MakeLimitHintHelper(spec.LimitHint, post),
 	}
 	if readerType != indexJoinReaderType {
 		jr.groupingState = &inputBatchGroupingState{doGrouping: spec.LeftJoinWithPairedJoiner}
@@ -751,6 +756,10 @@ func (jr *joinReader) readInput() (
 			return jrStateUnknown, nil, jr.DrainHelper()
 		}
 		jr.scratchInputRows = append(jr.scratchInputRows, jr.rowAlloc.CopyRow(encDatumRow))
+
+		if l := jr.limitHintHelper.LimitHint(); l != 0 && l == int64(len(jr.scratchInputRows)) {
+			break
+		}
 	}
 
 	if err := jr.performMemoryAccounting(); err != nil {
@@ -778,6 +787,11 @@ func (jr *joinReader) readInput() (
 
 	if jr.groupingState != nil && len(jr.scratchInputRows) > 0 {
 		jr.updateGroupingStateForNonEmptyBatch()
+	}
+
+	if err := jr.limitHintHelper.ReadSomeRows(int64(len(jr.scratchInputRows))); err != nil {
+		jr.MoveToDraining(err)
+		return jrStateUnknown, nil, jr.DrainHelper()
 	}
 
 	// Figure out what key spans we need to lookup.


### PR DESCRIPTION
Previously, during the execution of lookup and index joins we completely
ignored the soft and hard limits and, instead, always fetched up to the
memory-based limit (which depends on the type of the join). This could
lead to having to read many more rows from the input and then looking up
many more rows from the KV layer than necessary.

This is now fixed by plumbing the soft and hard limits from the
optimizer and using them when sizing the batches of input rows to
perform lookup for. For index joins we know for sure that every input
row will get a looked up row; however, for lookup joins an input row
might result in a miss. To work around this we use a simple heuristic
for determining the limit-hint-based size of input batches: for the
first batch we use the limit hint as is, for the second batch we use 10x
of the original hint, and for the third and all consequent batches we
disable the limiting behavior altogether.

Fixes: #77715.

Release note (bug fix): CockroachDB might now fetch less rows when
performing lookup and index joins on the queries with LIMIT clause.