### PR TITLE
kv/bulk: fix kvBuf test

### DIFF
--- a/pkg/kv/bulk/kv_buf_test.go
+++ b/pkg/kv/bulk/kv_buf_test.go
@@ -63,7 +63,7 @@ func TestKvBuf(t *testing.T) {
 	b := kvBuf{}
 	for i := range src {
 		size := sz(len(src[i].key) + len(src[i].value))
-		fits := len(b.entries) < cap(b.entries) && len(b.slab)+int(size) < cap(b.slab)
+		fits := len(b.entries) <= cap(b.entries) && len(b.slab)+int(size) <= cap(b.slab)
 
 		require.Equal(t, fits, b.fits(ctx, size, 0, &none))
 		if !fits {


### PR DESCRIPTION
x 'fits' in y if less than _or equal_, not just less; the code had this right but the
test did not.

Release note: none.