### PR TITLE
backupccl: fix paper cut in latest files directory structure

### DIFF
--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -96,7 +96,7 @@ const (
 
 	// latestHistoryDirectory is the directory where all 22.1 and beyond
 	// LATEST files will be stored as we no longer want to overwrite it.
-	latestHistoryDirectory = backupMetadataDirectory + "latest"
+	latestHistoryDirectory = backupMetadataDirectory + "/" + "latest"
 
 	// backupMetadataDirectory is the directory where metadata about a backup
 	// collection is stored. In v22.1 it contains the latest directory.


### PR DESCRIPTION
Prior to this change, the LATEST files of a backup were written to
`metadatalatest/` instead of `metadata/latest/`, this patch fixes
that.

Release note (bug fix): The LATEST file that points to the latest full
backup in a collection was written to a directory path with the wrong
structure.