### PR TITLE
settings: retire kv.rangefeed.separated_intent_scan.enabled 

### DIFF
--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -123,6 +123,7 @@ var retiredSettings = map[string]struct{}{
 	"schemachanger.backfiller.max_sst_size":                            {},
 	"kv.bulk_ingest.buffer_increment":                                  {},
 	"schemachanger.backfiller.buffer_increment":                        {},
+	"kv.rangefeed.separated_intent_scan.enabled":                       {},
 }
 
 // register adds a setting to the registry.


### PR DESCRIPTION
This setting was added in a 21.2 backport

https://github.com/cockroachdb/cockroach/pull/72315

but was never added to master:

https://github.com/cockroachdb/cockroach/pull/71295

So from the perspective of someone who upgrades from 21.2, it is now a
retired setting.

Release justification: Low-risk bug fix

Release note: None