### PR TITLE
release: add wrappers for the post blockers phase

### DIFF
--- a/build/teamcity/internal/cockroach/release/process/post_blockers.sh
+++ b/build/teamcity/internal/cockroach/release/process/post_blockers.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname $(dirname "${0}"))))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_start_block "Run Post Blockers Release Phase"
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e DRY_RUN -e RELEASE_SERIES -e SMTP_PASSWORD -e SMTP_USER -e GITHUB_TOKEN -e PUBLISH_DATE -e PREP_DATE -e NEXT_VERSION" \
+  run_bazel build/teamcity/internal/cockroach/release/process/post_blockers_impl.sh
+tc_end_block "Run Post Blockers Release Phase"

--- a/build/teamcity/internal/cockroach/release/process/post_blockers_impl.sh
+++ b/build/teamcity/internal/cockroach/release/process/post_blockers_impl.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+to=dev-inf+release-dev@cockroachlabs.com
+
+# override dev defaults with production values
+if [[ -z "${DRY_RUN}" ]] ; then
+  echo "Dry run"
+  to=releases@cockroachlabs.com
+fi
+
+# run git fetch in order to get all remote branches
+git fetch -q origin
+bazel build --config=crosslinux //pkg/cmd/release
+
+$(bazel info --config=crosslinux bazel-bin)/pkg/cmd/release/release_/release \
+  post-blockers \
+  ${NEXT_VERSION:+--next-version=$NEXT_VERSION} \
+  --release-series="$RELEASE_SERIES" \
+  --template-dir=pkg/cmd/release/templates \
+  --smtp-user=cronjob@cockroachlabs.com \
+  --smtp-host=smtp.gmail.com \
+  --smtp-port=587 \
+  --publish-date="$PUBLISH_DATE" \
+  --prep-date="$PREP_DATE" \
+  --to=$to

--- a/pkg/cmd/release/github.go
+++ b/pkg/cmd/release/github.go
@@ -80,11 +80,11 @@ func (c *githubClientImpl) openIssues(labels []string) ([]githubIssue, error) {
 		// TODO: This pagination pattern is a potential race condition: we may want to move to graphql api,
 		// which has cursor-based pagination. But for now, this is probably good enough, as issues don't
 		// change _that_ frequently.
-		issues, _, err := c.client.Issues.List(
+		issues, _, err := c.client.Issues.ListByRepo(
 			c.ctx,
-			true, /* all: true searches `/issues/`, false searches `/user/issues/` */
-			&github.IssueListOptions{
-				Filter: "all",
+			c.owner,
+			c.repo,
+			&github.IssueListByRepoOptions{
 				State:  "open",
 				Labels: labels,
 				ListOptions: github.ListOptions{


### PR DESCRIPTION
Previously, the logic around release blocker fetching was using the
`/issues` API end point, which is used to list issues for the
authenticated. The PR switches to the repo-specific API end point.

This patch adds TeamCity wrappers to run the blockers phase as well.

Release note: None