### PR TITLE
release-22.1: vendor: bump Pebble to 833c64e250c6

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -1307,10 +1307,10 @@ def go_deps():
         patches = [
             "@cockroach//build/patches:com_github_cockroachdb_pebble.patch",
         ],
-        sha256 = "c9eeda994d0939a8a678ae6a761345f10f24c7bc5dca946b222a3fc401b4cf14",
-        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20220310010958-93d472261892",
+        sha256 = "d84080ba41fb0b806bbb16cdf3ed9675a10308dc3d27429d5f9271a0b0af5ee1",
+        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20220322140401-833c64e250c6",
         urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20220310010958-93d472261892.zip",
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20220322140401-833c64e250c6.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f
-	github.com/cockroachdb/pebble v0.0.0-20220310010958-93d472261892
+	github.com/cockroachdb/pebble v0.0.0-20220322140401-833c64e250c6
 	github.com/cockroachdb/redact v1.1.3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/stress v0.0.0-20220310203902-58fb4627376e

--- a/go.sum
+++ b/go.sum
@@ -440,8 +440,8 @@ github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f h1:6jduT9Hfc0n
 github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f/go.mod h1:Vz9DsVWQQhf3vs21MhPMZpMGSht7O/2vFW2xusFUVOs=
 github.com/cockroachdb/panicparse/v2 v2.0.0-20211103220158-604c82a44f1e h1:FrERdkPlRj+v7fc+PGpey3GUiDGuTR5CsmLCA54YJ8I=
 github.com/cockroachdb/panicparse/v2 v2.0.0-20211103220158-604c82a44f1e/go.mod h1:pMxsKyCewnV3xPaFvvT9NfwvDTcIx2Xqg0qL5Gq0SjM=
-github.com/cockroachdb/pebble v0.0.0-20220310010958-93d472261892 h1:zPixoCLBznHwirpBOENW6qFeqfs2tlmHhFNNwyokIrA=
-github.com/cockroachdb/pebble v0.0.0-20220310010958-93d472261892/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
+github.com/cockroachdb/pebble v0.0.0-20220322140401-833c64e250c6 h1:vTx7rN+S5M8SCwz39Ih5a1hOSU3LQJqec7aT4OUJapY=
+github.com/cockroachdb/pebble v0.0.0-20220322140401-833c64e250c6/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=
 github.com/cockroachdb/redact v1.1.3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=

--- a/scripts/bump-pebble.sh
+++ b/scripts/bump-pebble.sh
@@ -20,8 +20,8 @@ popd() { builtin popd "$@" > /dev/null; }
 # NOTE: After a new release has been cut, update this to the appropriate
 # Cockroach branch name (i.e. release-22.2, etc.), and corresponding Pebble
 # branch name (e.g. crl-release-21.2, etc.).
-BRANCH=master
-PEBBLE_BRANCH=master
+BRANCH=release-22.1
+PEBBLE_BRANCH=crl-release-22.1
 
 # The script can only be run from a specific branch.
 if [ "$(git rev-parse --abbrev-ref HEAD)" != "$BRANCH" ]; then


### PR DESCRIPTION
**scripts: update bump-pebble script**

Update the branches in the `bump-pebble.sh` script to match the
Cockroach and Pebble release branch names.

Release note: None.

---

**vendor: bump Pebble to 833c64e250c6**
```
833c64e2 cache: use finalizer for freeing manually allocated memory
fb5fdde8 db: fix TestSplitUserKeyMigration flake
9f45cc9a db: mock event duration directly in tests
b1410e80 internal/lint: add a lint check to enforce crlfmt
9d3e2fc9 *: apply crlfmt
4dc50ecd internal/manifest: additional range key test cases for order checks
```

Release note (bug fix): Fixes a memory leak in the Pebble block cache.

---

Release justification: Bug fix.