### PR TITLE
Revert "dev: fix testlogic selector"

### DIFF
--- a/dev
+++ b/dev
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=24
+DEV_VERSION=25
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/testdata/datadriven/testlogic
+++ b/pkg/cmd/dev/testdata/datadriven/testlogic
@@ -1,41 +1,41 @@
 exec
 dev testlogic
 ----
-bazel test --test_env=GOTRACEBACK=all //pkg/sql/logictest:logictest_test --test_filter TestLogic --test_output errors
-bazel test --test_env=GOTRACEBACK=all //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic' --test_output errors
-bazel test --test_env=GOTRACEBACK=all //pkg/sql/opt/exec/execbuilder:execbuilder_test --test_filter TestExecBuild --test_output errors
+bazel test --test_env=GOTRACEBACK=all //pkg/sql/logictest:logictest_test --test_filter TestLogic/// --test_output errors
+bazel test --test_env=GOTRACEBACK=all //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic///' --test_output errors
+bazel test --test_env=GOTRACEBACK=all //pkg/sql/opt/exec/execbuilder:execbuilder_test --test_filter TestExecBuild/// --test_output errors
 
 exec
 dev testlogic ccl
 ----
-bazel test --test_env=GOTRACEBACK=all //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic' --test_output errors
+bazel test --test_env=GOTRACEBACK=all //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic///' --test_output errors
 
 exec
 dev testlogic ccl opt
 ----
-bazel test --test_env=GOTRACEBACK=all //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic' --test_output errors
-bazel test --test_env=GOTRACEBACK=all //pkg/sql/opt/exec/execbuilder:execbuilder_test --test_filter TestExecBuild --test_output errors
+bazel test --test_env=GOTRACEBACK=all //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic///' --test_output errors
+bazel test --test_env=GOTRACEBACK=all //pkg/sql/opt/exec/execbuilder:execbuilder_test --test_filter TestExecBuild/// --test_output errors
 
 exec
 dev testlogic base --ignore-cache 
 ----
-bazel test --test_env=GOTRACEBACK=all --nocache_test_results //pkg/sql/logictest:logictest_test --test_filter TestLogic --test_output errors
+bazel test --test_env=GOTRACEBACK=all --nocache_test_results //pkg/sql/logictest:logictest_test --test_filter TestLogic/// --test_output errors
 
 exec
 dev testlogic base --show-sql
 ----
-bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql //pkg/sql/logictest:logictest_test --test_filter TestLogic --test_output errors
+bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql //pkg/sql/logictest:logictest_test --test_filter TestLogic/// --test_output errors
 
 exec
 dev testlogic base --files=prepare|fk --subtests=20042 --config=local
 ----
-bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql --test_arg -config --test_arg local //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^prepare|fk$/^20042$' --test_output errors
+bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql --test_arg -config --test_arg local //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^prepare|fk$/20042' --test_output errors
 
 exec
 dev testlogic base --files=auto_span_config_reconciliation --config=local -v --show-logs --timeout=50s --rewrite
 ----
 bazel info workspace --color=no
-bazel test --test_env=GOTRACEBACK=all --nocache_test_results --test_arg -test.v --test_arg -show-logs --test_arg -show-sql --test_arg -config --test_arg local --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/sql/logictest --test_timeout=50 //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^auto_span_config_reconciliation$' --test_output all
+bazel test --test_env=GOTRACEBACK=all --nocache_test_results --test_arg -test.v --test_arg -show-logs --test_arg -show-sql --test_arg -config --test_arg local --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/sql/logictest --test_timeout=50 //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^auto_span_config_reconciliation$/' --test_output all
 
 exec
 dev testlogic base --files=auto_span_config_reconciliation --config=local --rewrite --stress
@@ -45,25 +45,35 @@ err: cannot combine --stress and --rewrite
 exec
 dev testlogic base --files=auto_span_config_reconciliation --config=local --count 5
 ----
-bazel test --test_env=GOTRACEBACK=all --test_arg -test.count=5 --test_arg -show-sql --test_arg -config --test_arg local //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^auto_span_config_reconciliation$' --test_output errors
+bazel test --test_env=GOTRACEBACK=all --test_arg -test.count=5 --test_arg -show-sql --test_arg -config --test_arg local //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^auto_span_config_reconciliation$/' --test_output errors
 
 exec
 dev testlogic base --files=auto_span_config_reconciliation --stress
 ----
-bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=86400 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' ' //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^auto_span_config_reconciliation$' --test_output streamed
+bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=86400 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' ' //pkg/sql/logictest:logictest_test --test_filter 'TestLogic//^auto_span_config_reconciliation$/' --test_output streamed
 
 exec
 dev testlogic base --files=auto_span_config_reconciliation --stress --timeout 1m --cpus 8
 ----
-bazel test --test_env=GOTRACEBACK=all --local_cpu_resources=8 --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=120 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' -maxtime=1m0s -p=8' //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^auto_span_config_reconciliation$' --test_output streamed
+bazel test --test_env=GOTRACEBACK=all --local_cpu_resources=8 --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=120 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' -maxtime=1m0s -p=8' //pkg/sql/logictest:logictest_test --test_filter 'TestLogic//^auto_span_config_reconciliation$/' --test_output streamed
 
 exec
 dev testlogic ccl --rewrite --show-logs  -v --files distsql_automatic_stats --config 3node-tenant
 ----
 bazel info workspace --color=no
-bazel test --test_env=GOTRACEBACK=all --nocache_test_results --test_arg -test.v --test_arg -show-logs --test_arg -show-sql --test_arg -config --test_arg 3node-tenant --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/ccl/logictestccl --sandbox_writable_path=crdb-checkout/pkg/sql/logictest //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic/^3node-tenant$/^distsql_automatic_stats$' --test_output all
+bazel test --test_env=GOTRACEBACK=all --nocache_test_results --test_arg -test.v --test_arg -show-logs --test_arg -show-sql --test_arg -config --test_arg 3node-tenant --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/ccl/logictestccl --sandbox_writable_path=crdb-checkout/pkg/sql/logictest //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic/^3node-tenant$/^distsql_automatic_stats$/' --test_output all
 
 exec
 dev testlogic base --files=auto_span_config_reconciliation --stress --stream-output
 ----
-bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=86400 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' ' //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^auto_span_config_reconciliation$' --test_output streamed
+bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=86400 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' ' //pkg/sql/logictest:logictest_test --test_filter 'TestLogic//^auto_span_config_reconciliation$/' --test_output streamed
+
+exec
+dev testlogic base --files=auto_span_config_reconciliation --stress --stream-output
+----
+bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=86400 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' ' //pkg/sql/logictest:logictest_test --test_filter 'TestLogic//^auto_span_config_reconciliation$/' --test_output streamed
+
+exec
+dev testlogic base --files=auto_span_config_reconciliation --stress --stream-output
+----
+bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql --test_sharding_strategy=disabled --test_timeout=86400 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' ' //pkg/sql/logictest:logictest_test --test_filter 'TestLogic//^auto_span_config_reconciliation$/' --test_output streamed

--- a/pkg/cmd/dev/testlogic.go
+++ b/pkg/cmd/dev/testlogic.go
@@ -179,13 +179,13 @@ func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 			args = append(args, goTestArgs...)
 		}
 
+		// TODO(irfansharif): Is this right? --config and --files is optional.
 		selector := fmt.Sprintf(
-			"%s%s%s%s",
+			"%s/%s/%s/%s",
 			selectorPrefix,
 			maybeAddBeginEndMarkers(config),
 			maybeAddBeginEndMarkers(files),
-			maybeAddBeginEndMarkers(subtests),
-		)
+			subtests)
 		args = append(args, testTarget)
 		args = append(args, "--test_filter", selector)
 		args = append(args, d.getTestOutputArgs(stress, verbose, showLogs, streamOutput)...)
@@ -202,5 +202,5 @@ func maybeAddBeginEndMarkers(s string) string {
 	if len(s) == 0 {
 		return s
 	}
-	return "/^" + s + "$"
+	return "^" + s + "$"
 }


### PR DESCRIPTION
This reverts commit c07e2f266d3e10ec9bfcbbfc3eb2d1d9c924c558. It was a
buggy change that changed how we select what subtests to run.

Release note: None