### PR TITLE
vendor: bump Pebble to 6164579cf2cb

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -1307,10 +1307,10 @@ def go_deps():
         patches = [
             "@cockroach//build/patches:com_github_cockroachdb_pebble.patch",
         ],
-        sha256 = "c9eeda994d0939a8a678ae6a761345f10f24c7bc5dca946b222a3fc401b4cf14",
-        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20220310010958-93d472261892",
+        sha256 = "5b3237c6bcbfc1085831ddf636ce4b4243211f754ceabe9b8fd9bf8962629a12",
+        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20220322040433-6164579cf2cb",
         urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20220310010958-93d472261892.zip",
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20220322040433-6164579cf2cb.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f
-	github.com/cockroachdb/pebble v0.0.0-20220310010958-93d472261892
+	github.com/cockroachdb/pebble v0.0.0-20220322040433-6164579cf2cb
 	github.com/cockroachdb/redact v1.1.3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/stress v0.0.0-20220310203902-58fb4627376e

--- a/go.sum
+++ b/go.sum
@@ -440,8 +440,8 @@ github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f h1:6jduT9Hfc0n
 github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f/go.mod h1:Vz9DsVWQQhf3vs21MhPMZpMGSht7O/2vFW2xusFUVOs=
 github.com/cockroachdb/panicparse/v2 v2.0.0-20211103220158-604c82a44f1e h1:FrERdkPlRj+v7fc+PGpey3GUiDGuTR5CsmLCA54YJ8I=
 github.com/cockroachdb/panicparse/v2 v2.0.0-20211103220158-604c82a44f1e/go.mod h1:pMxsKyCewnV3xPaFvvT9NfwvDTcIx2Xqg0qL5Gq0SjM=
-github.com/cockroachdb/pebble v0.0.0-20220310010958-93d472261892 h1:zPixoCLBznHwirpBOENW6qFeqfs2tlmHhFNNwyokIrA=
-github.com/cockroachdb/pebble v0.0.0-20220310010958-93d472261892/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
+github.com/cockroachdb/pebble v0.0.0-20220322040433-6164579cf2cb h1:1JgeoLiHDlpa+AV6MU2qvDctffM9zoHiPRXOCvgOX2k=
+github.com/cockroachdb/pebble v0.0.0-20220322040433-6164579cf2cb/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=
 github.com/cockroachdb/redact v1.1.3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=


### PR DESCRIPTION
```
6164579c cache: use finalizer for freeing manually allocated memory
0ad18689 compaction: disentangle compaction rangedels from InternalIterator
2c7b5358 ci: build and test against Go version 1.18
02418522 internal/metamorphic: add range key iteration
70ff2a37 internal/rangekey: seek exhausted iters when switching directions
7a946186 db: avoid levelIter invariant violation on exhausted mergingIter
10191d70 db: move range keys from memtable to global arena atomically
a7cff657 db: fix determinism of limited reverse iteration with range keys
4ad1b577 *: Skip over files with no point keys in point key levelIter
e19101fb sstable: re-pool datablock buffers in the sstable Writer
f9d4a33d docs: minor tweaks to table format version RFC
910ce605 sstable: use a single level index in block property data driven test
56c5aebe internal/manifest: encode/decode range keys in manifest
11305409 internal/rangekey: refactor Coalescer into a pure function Coalesce
fb5fdde8 db: fix TestSplitUserKeyMigration flake
9f45cc9a db: mock event duration directly in tests
b1410e80 internal/lint: add a lint check to enforce crlfmt
9d3e2fc9 *: apply crlfmt
4dc50ecd internal/manifest: additional range key test cases for order checks
```

Release note: None.