### PR TITLE
ui: Hide table stats collection setting for non-admins

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
@@ -91,7 +91,7 @@ export interface DatabaseTablePageData {
   stats: DatabaseTablePageDataStats;
   indexStats: DatabaseTablePageIndexStats;
   showNodeRegionsSection?: boolean;
-  automaticStatsCollectionEnabled: boolean;
+  automaticStatsCollectionEnabled?: boolean;
 }
 
 export interface DatabaseTablePageDataDetails {
@@ -372,27 +372,29 @@ export class DatabaseTablePage extends React.Component<
                         )}
                       />
                     )}
-                    <SummaryCardItemBoolSetting
-                      label="Auto Stats Collection"
-                      value={this.props.automaticStatsCollectionEnabled}
-                      toolTipText={
-                        <span>
-                          {" "}
-                          Automatic statistics can help improve query
-                          performance. Learn how to{" "}
-                          <Anchor
-                            href={tableStatsClusterSetting}
-                            target="_blank"
-                            className={booleanSettingCx(
-                              "crl-hover-text__link-text",
-                            )}
-                          >
-                            manage statistics collection
-                          </Anchor>
-                          .
-                        </span>
-                      }
-                    />
+                    {this.props.automaticStatsCollectionEnabled != null && (
+                      <SummaryCardItemBoolSetting
+                        label="Auto Stats Collection"
+                        value={this.props.automaticStatsCollectionEnabled}
+                        toolTipText={
+                          <span>
+                            {" "}
+                            Automatic statistics can help improve query
+                            performance. Learn how to{" "}
+                            <Anchor
+                              href={tableStatsClusterSetting}
+                              target="_blank"
+                              className={booleanSettingCx(
+                                "crl-hover-text__link-text",
+                              )}
+                            >
+                              manage statistics collection
+                            </Anchor>
+                            .
+                          </span>
+                        }
+                      />
+                    )}
                   </SummaryCard>
                 </Col>
 

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
@@ -71,7 +71,7 @@ export interface DatabasesPageData {
   loaded: boolean;
   databases: DatabasesPageDataDatabase[];
   sortSetting: SortSetting;
-  automaticStatsCollectionEnabled: boolean;
+  automaticStatsCollectionEnabled?: boolean;
   showNodeRegionsColumn?: boolean;
 }
 
@@ -294,25 +294,27 @@ export class DatabasesPage extends React.Component<
       <div>
         <div className={baseHeadingClasses.wrapper}>
           <h3 className={baseHeadingClasses.tableName}>Databases</h3>
-          <BooleanSetting
-            text={"Auto stats collection"}
-            enabled={this.props.automaticStatsCollectionEnabled}
-            tooltipText={
-              <span>
-                {" "}
-                Automatic statistics can help improve query performance. Learn
-                how to{" "}
-                <Anchor
-                  href={tableStatsClusterSetting}
-                  target="_blank"
-                  className={booleanSettingCx("crl-hover-text__link-text")}
-                >
-                  manage statistics collection
-                </Anchor>
-                .
-              </span>
-            }
-          />
+          {this.props.automaticStatsCollectionEnabled != null && (
+            <BooleanSetting
+              text={"Auto stats collection"}
+              enabled={this.props.automaticStatsCollectionEnabled}
+              tooltipText={
+                <span>
+                  {" "}
+                  Automatic statistics can help improve query performance. Learn
+                  how to{" "}
+                  <Anchor
+                    href={tableStatsClusterSetting}
+                    target="_blank"
+                    className={booleanSettingCx("crl-hover-text__link-text")}
+                  >
+                    manage statistics collection
+                  </Anchor>
+                  .
+                </span>
+              }
+            />
+          )}
         </div>
         <section className={sortableTableCx("cl-table-container")}>
           <div className={statisticsClasses.statistic}>


### PR DESCRIPTION
This PR hides the table statistics collection setting from non-admins in the DB Console.


https://user-images.githubusercontent.com/27286675/159566500-9310e9cc-eb8d-4a39-ae07-6620d36a27a2.mov

Part 1/2 of https://github.com/cockroachdb/cockroach/issues/77974.

(For background, see https://github.com/cockroachdb/cockroach/issues/77974#issuecomment-1072656497)

Release justification: low-risk change

Release note: None