### PR TITLE
roachprod: force wait=true for `stop --signal=9`

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -224,6 +224,10 @@ func (c *SyncedCluster) newSession(node Node) (session, error) {
 // When running roachprod stop without other flags, the signal is 9 (SIGKILL)
 // and wait is true.
 func (c *SyncedCluster) Stop(ctx context.Context, l *logger.Logger, sig int, wait bool) error {
+	if sig == 9 {
+		// `kill -9` without wait is never what a caller wants. See #77334.
+		wait = true
+	}
 	display := fmt.Sprintf("%s: stopping", c.Name)
 	if wait {
 		display += " and waiting"

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -675,7 +675,9 @@ func Monitor(
 type StopOpts struct {
 	ProcessTag string
 	Sig        int
-	Wait       bool
+	// If Wait is set, roachprod waits until the PID disappears (i.e. the
+	// process has terminated).
+	Wait bool // forced to true when Sig == 9
 }
 
 // DefaultStopOpts returns StopOpts populated with the default values used by Stop.


### PR DESCRIPTION
Touches #77334.

Release note: None
