### PR TITLE
kv: introducing a simulator for the allocator

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -135,6 +135,7 @@ ALL_TESTS = [
     "//pkg/kv/kvprober:kvprober_test",
     "//pkg/kv/kvserver/abortspan:abortspan_test",
     "//pkg/kv/kvserver/apply:apply_test",
+    "//pkg/kv/kvserver/asim:asim_test",
     "//pkg/kv/kvserver/batcheval/result:result_test",
     "//pkg/kv/kvserver/batcheval:batcheval_test",
     "//pkg/kv/kvserver/closedts/sidetransport:sidetransport_test",

--- a/pkg/kv/kvserver/asim/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "asim_lib",
+    srcs = ["asim.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/kv/kvserver",
+        "//pkg/roachpb",
+        "@com_github_google_btree//:btree",
+    ],
+)
+
+go_test(
+    name = "asim_test",
+    srcs = ["asim_test.go"],
+    deps = [
+        ":asim_lib",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/kv/kvserver/asim/asim.go
+++ b/pkg/kv/kvserver/asim/asim.go
@@ -1,0 +1,300 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package asim
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/google/btree"
+)
+
+// LoadEvent represent a kv operation such as a read or write.
+// TODO(lidor): support batches in the initial implementation.
+type LoadEvent struct {
+}
+
+// WorkloadGenerator generates workload where each op contains: key,
+// op type (e.g., read/write), size.
+type WorkloadGenerator interface {
+	// GetNext returns a LoadEvent which happens before maxTime, if exists.
+	GetNext(maxTime time.Time) (done bool, event LoadEvent)
+}
+
+// RandomWorkloadGenerator generates random operations within some limits.
+type RandomWorkloadGenerator struct {
+}
+
+// GetNext is part of the WorkloadGenerator interface.
+func (rwg *RandomWorkloadGenerator) GetNext(maxTime time.Time) (done bool, event LoadEvent) {
+	return true, LoadEvent{}
+}
+
+// ConfigEvent can be, for example, adding or removing a node in a region.
+type ConfigEvent struct {
+}
+
+// ConfigLoader is responsible for loading configurations such as adding and
+// removing nodes.
+type ConfigLoader struct {
+}
+
+// GetNext returns a ConfigEvent which happens before maxTime, if exists.
+func (sr *ConfigLoader) GetNext(maxTime time.Time) (bool, *ConfigEvent) {
+	return true, nil
+}
+
+// Range spans keys greater or equal to MinKey and smaller than the MinKey of
+// the next range.
+type Range struct {
+	MinKey string
+}
+
+// Less is part of the btree.Item interface.
+func (r *Range) Less(than btree.Item) bool {
+	return r.MinKey < than.(*Range).MinKey
+}
+
+// RangeMap (unlike a regular map) can return the Range responsible for a key.
+type RangeMap struct {
+	ranges *btree.BTree
+}
+
+// NewRangeMap returns a valid empty RangeMap.
+func NewRangeMap() *RangeMap {
+	return &RangeMap{ranges: btree.New(8)}
+}
+
+// AddRange adds a range to the RangeMap.
+func (r *RangeMap) AddRange(repl *Range) {
+	// TODO: should we panic/fail if the range exists?
+	r.ranges.ReplaceOrInsert(repl)
+}
+
+// GetRange returns the range that should own the key.
+// TODO: guarantee that we have a minimum key, otherwise we might return nil.
+func (r *RangeMap) GetRange(key string) *Range {
+	keyToFind := &Range{MinKey: key}
+	var rng *Range
+
+	// If keyToFind equals to MinKey of the range, we found the right range, if
+	// the range is Less than keyToFind then this is the right range also.
+	r.ranges.DescendLessOrEqual(keyToFind, func(i btree.Item) bool {
+		rng = i.(*Range)
+		return false
+	})
+	return rng
+}
+
+// Replica represents a replica of a range.
+type Replica struct {
+	spanConf *roachpb.SpanConfig
+	desc     *roachpb.RangeDescriptor
+}
+
+// Store simulates a store within a node.
+type Store struct {
+	replicas  map[int]*Replica
+	allocator kvserver.Allocator
+}
+
+// Node represents a node within the cluster.
+// TODO: add regions.
+type Node struct {
+	nodeDesc *roachpb.NodeDescriptor
+	Stores   []*Store
+}
+
+// NewNode constructs a valid node.
+func NewNode() *Node {
+	return &Node{Stores: make([]*Store, 0, 1)}
+}
+
+// State offers two ways to access replicas, one is by looking up the node,
+// then store, and then all replicas on that store - we use this, for example,
+// when running the allocator code for all replicas in a store. And another by
+// locating the range in the RangeMap - this is used when applying the load over
+// the key space.
+type State struct {
+	lastNodeID int
+	Nodes      map[int]*Node
+
+	// This is the entire key space.
+	Ranges RangeMap
+}
+
+// NewState constructs a valid empty state.
+func NewState() *State {
+	return &State{Nodes: make(map[int]*Node)}
+}
+
+// AddNode adds a node to the cluster.
+func (s *State) AddNode(ctx context.Context) (nodeID int) {
+	s.lastNodeID++
+	nodeID = s.lastNodeID
+	n := NewNode()
+	n.nodeDesc = &roachpb.NodeDescriptor{NodeID: roachpb.NodeID(nodeID)}
+	s.Nodes[nodeID] = n
+	return nodeID
+}
+
+// AddStore adds a store to an existing node.
+func (s *State) AddStore(ctx context.Context, node int) {
+	allocator := kvserver.MakeAllocator(
+		nil,
+		func(string) (time.Duration, bool) {
+			return 0, true
+		},
+		nil,
+		nil,
+	)
+	s.Nodes[node].Stores = append(s.Nodes[node].Stores, &Store{allocator: allocator})
+}
+
+// ApplyStateChange updates the state with config changes.
+func (s *State) ApplyStateChange(ctx context.Context, event *ConfigEvent) {
+}
+
+// ApplyAllocatorAction updates the state with allocator ops such as
+// moving/adding/removing replicas.
+func (s *State) ApplyAllocatorAction(
+	ctx context.Context, action kvserver.AllocatorAction, priority float64,
+) {
+}
+
+// ApplyLoad updates the state replicas with the LoadEvent info. These events
+// are in the form of "key, read/write, size" and are incrementing counters such
+// as QPS for replicas. Note that this means we don't store which keys were
+// written and therefore reads never fail.
+func (s *State) ApplyLoad(ctx context.Context, le LoadEvent) {
+}
+
+func shouldRun(time.Time) bool {
+	return false
+}
+
+// RunAllocator runs the allocator code for some replicas as needed.
+func RunAllocator(
+	ctx context.Context,
+	allocator kvserver.Allocator,
+	spanConf roachpb.SpanConfig,
+	desc *roachpb.RangeDescriptor,
+	tick time.Time,
+) (done bool, action kvserver.AllocatorAction, priority float64) {
+	// TODO: we should pace the calls to ComputeAction. The replicate queue tries
+	// to call ComputeAction for all replicas at a steady pace, to complete a pass
+	// within 10 minutes. We should have similar logic here (using simulated
+	// time).
+	if !shouldRun(tick) {
+		return true, kvserver.AllocatorNoop, 0
+	}
+	action, priority = allocator.ComputeAction(ctx, spanConf, desc)
+	return false, action, priority
+}
+
+// Simulator simulates an entire cluster, and runs the allocators of each store
+// in that cluster.
+type Simulator struct {
+	curr     time.Time
+	end      time.Time
+	interval time.Duration
+
+	// The simulator can run multiple workload Generators in parallel.
+	generators []WorkloadGenerator
+	conf       *ConfigLoader
+	prevState  *State
+	nextState  *State
+}
+
+// NewSimulator constructs a valid Simulator.
+func NewSimulator(
+	start, end time.Time, interval time.Duration, wgs []WorkloadGenerator, conf *ConfigLoader,
+) *Simulator {
+	return &Simulator{
+		curr:       start,
+		end:        end,
+		interval:   interval,
+		generators: wgs,
+		conf:       conf,
+		prevState:  NewState(),
+		nextState:  NewState(),
+	}
+}
+
+// GetNextTickTime returns a simulated tick time, or an indication that the
+// simulation is done.
+func (s *Simulator) GetNextTickTime() (done bool, tick time.Time) {
+	s.curr = s.curr.Add(s.interval)
+	if s.curr.After(s.end) {
+		return true, time.Time{}
+	}
+	return false, s.curr
+}
+
+// RunSim runs a simulation until GetNextTickTime() is done. A simulation is
+// executed by "ticks" - we run a full tick and then move to next one. In each
+// tick we first apply the state changes such as adding or removing Nodes, then
+// we apply the load changes such as updating the QPS for replicas, and last, we
+// run the actual allocator code. The input for the allocator is the state we
+// updated, and the operations recommended by the allocator (rebalances,
+// adding/removing replicas, etc.) are applied on a new state. This means that
+// the allocators view a stale state without the recent updates form other
+// allocators. Note that we are currently ignoring gossip delays, meaning all
+// allocators view the exact same state in each tick.
+//
+// TODO: simulation run settings should be loaded from a config such as a yaml
+// file or a "datadriven" style file.
+func (s *Simulator) RunSim(ctx context.Context) {
+	for {
+		done, tick := s.GetNextTickTime()
+		if done {
+			break
+		}
+
+		for {
+			done, event := s.conf.GetNext(tick)
+			if done {
+				break
+			}
+			s.nextState.ApplyStateChange(ctx, event)
+		}
+
+		for _, generator := range s.generators {
+			for {
+				done, event := generator.GetNext(tick)
+				if done {
+					break
+				}
+				s.nextState.ApplyLoad(ctx, event)
+			}
+		}
+
+		// Done with config and load updates, the state is ready for the allocators.
+		s.prevState = s.nextState
+
+		for _, node := range s.prevState.Nodes {
+			for _, store := range node.Stores {
+				for _, r := range store.replicas {
+					// Run the real allocator code. Note that the input is from PrevState.
+					done, action, priority := RunAllocator(ctx, store.allocator, *r.spanConf, r.desc, tick)
+					if done {
+						break
+					}
+
+					// The allocator ops are applied on NextState.
+					s.nextState.ApplyAllocatorAction(ctx, action, priority)
+				}
+			}
+		}
+	}
+}

--- a/pkg/kv/kvserver/asim/asim_test.go
+++ b/pkg/kv/kvserver/asim/asim_test.go
@@ -1,0 +1,61 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package asim_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStateUpdates(t *testing.T) {
+	ctx := context.Background()
+
+	s := asim.NewState()
+	s.AddNode(ctx)
+	require.Equal(t, 1, len(s.Nodes))
+
+	s.AddStore(ctx, 1)
+	require.Equal(t, 1, len(s.Nodes[1].Stores))
+}
+
+func TestRunAllocatorSimulator(t *testing.T) {
+	ctx := context.Background()
+
+	rwg := make([]asim.WorkloadGenerator, 1)
+	rwg[0] = &asim.RandomWorkloadGenerator{}
+	scl := &asim.ConfigLoader{}
+	start := time.Date(2022, 03, 21, 11, 0, 0, 0, time.UTC)
+	end := start.Add(25 * time.Second)
+	interval := 10 * time.Second
+	sim := asim.NewSimulator(start, end, interval, rwg, scl)
+	sim.RunSim(ctx)
+}
+
+func TestRangeMap(t *testing.T) {
+	m := asim.NewRangeMap()
+
+	r1 := asim.Range{MinKey: "b"}
+	r2 := asim.Range{MinKey: "f"}
+	r3 := asim.Range{MinKey: "x"}
+
+	m.AddRange(&r1)
+	m.AddRange(&r2)
+	m.AddRange(&r3)
+
+	require.Equal(t, (*asim.Range)(nil), m.GetRange("a"))
+	require.Equal(t, &r1, m.GetRange("b"))
+	require.Equal(t, &r1, m.GetRange("c"))
+	require.Equal(t, &r3, m.GetRange("z"))
+}


### PR DESCRIPTION
We currently have good testing around the allocator, but we think that a
simulator would increase our confidence when making allocation changes.

This pr adds a rough skeleton for a simulator for the allocation code.
The plan is to make this simulator run the store rebalancer logic
(rebalance by QPS) and simulate the replicate queue code.

Release note: None.