### PR TITLE
release-21.2: server: VIEWACTIVITY role gates unredacted nodes info

### DIFF
--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -62,6 +63,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -2428,5 +2430,82 @@ func TestAdminDecommissionedOperations(t *testing.T) {
 				return true
 			}, 10*time.Second, 100*time.Millisecond, "timed out waiting for gRPC error, got %s", err)
 		})
+	}
+}
+
+func TestAdminPrivilegeChecker(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
+
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, "CREATE USER withadmin")
+	sqlDB.Exec(t, "GRANT admin TO withadmin")
+	sqlDB.Exec(t, "CREATE USER withva")
+	sqlDB.Exec(t, "ALTER ROLE withva WITH VIEWACTIVITY")
+	sqlDB.Exec(t, "CREATE USER withvaredacted")
+	sqlDB.Exec(t, "ALTER ROLE withvaredacted WITH VIEWACTIVITYREDACTED")
+	sqlDB.Exec(t, "CREATE USER withvaandredacted")
+	sqlDB.Exec(t, "ALTER ROLE withvaandredacted WITH VIEWACTIVITY")
+	sqlDB.Exec(t, "ALTER ROLE withvaandredacted WITH VIEWACTIVITYREDACTED")
+	sqlDB.Exec(t, "CREATE USER withoutprivs")
+
+	underTest := &adminPrivilegeChecker{
+		ie: s.InternalExecutor().(*sql.InternalExecutor),
+	}
+
+	withAdmin, err := security.MakeSQLUsernameFromPreNormalizedStringChecked("withadmin")
+	require.NoError(t, err)
+	withVa, err := security.MakeSQLUsernameFromPreNormalizedStringChecked("withva")
+	require.NoError(t, err)
+	withVaRedacted, err := security.MakeSQLUsernameFromPreNormalizedStringChecked("withvaredacted")
+	require.NoError(t, err)
+	withVaAndRedacted, err := security.MakeSQLUsernameFromPreNormalizedStringChecked("withvaandredacted")
+	require.NoError(t, err)
+	withoutPrivs, err := security.MakeSQLUsernameFromPreNormalizedStringChecked("withoutprivs")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name            string
+		checkerFun      func(context.Context) error
+		usernameWantErr map[security.SQLUsername]bool
+	}{
+		{
+			"requireViewActivityPermission",
+			underTest.requireViewActivityPermission,
+			map[security.SQLUsername]bool{
+				withAdmin: false, withVa: false, withVaRedacted: true, withVaAndRedacted: false, withoutPrivs: true,
+			},
+		},
+		{
+			"requireViewActivityOrViewActivityRedactedPermission",
+			underTest.requireViewActivityOrViewActivityRedactedPermission,
+			map[security.SQLUsername]bool{
+				withAdmin: false, withVa: false, withVaRedacted: false, withVaAndRedacted: false, withoutPrivs: true,
+			},
+		},
+		{
+			"requireViewActivityAndNoViewActivityRedactedPermission",
+			underTest.requireViewActivityAndNoViewActivityRedactedPermission,
+			map[security.SQLUsername]bool{
+				withAdmin: false, withVa: false, withVaRedacted: true, withVaAndRedacted: true, withoutPrivs: true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		for userName, wantErr := range tt.usernameWantErr {
+			t.Run(fmt.Sprintf("%s-%s", tt.name, userName), func(t *testing.T) {
+				ctx := context.Background()
+				ctx = metadata.NewIncomingContext(ctx, metadata.New(map[string]string{"websessionuser": userName.SQLIdentifier()}))
+				err := tt.checkerFun(ctx)
+				if wantErr {
+					require.Error(t, err)
+					return
+				}
+				require.NoError(t, err)
+			})
+		}
 	}
 }

--- a/pkg/sql/roleoption/role_option.go
+++ b/pkg/sql/roleoption/role_option.go
@@ -49,6 +49,11 @@ const (
 	NOCREATEDB
 	CREATELOGIN
 	NOCREATELOGIN
+	// VIEWACTIVITY is responsible for controlling access to DB Console
+	// endpoints that allow a user to view data in the UI without having
+	// the Admin role. In addition, the VIEWACTIVITY role permits viewing
+	// *unredacted* data in the `/nodes` and `/nodes_ui` endpoints which
+	// display IP addresses and hostnames.
 	VIEWACTIVITY
 	NOVIEWACTIVITY
 	CANCELQUERY


### PR DESCRIPTION
Backport 1/1 commits from #78045.

/cc @cockroachdb/release

Release justification: high-priority need from customer that keeps existing functionality and adds ability to use the additional SQL role

---

Previously, the `Nodes` and `NodesUI` endpoints were gated behind the
Admin role. For the former endpoint requests would fail if the user
didn't have the Admin role, and for the latter, we'd show partially
redacted information that omitted hostnames and IP addresses.

This was deemed problematic for customers who did not want to set the
Admin role just to grant a user the ability to view detailed node
information about the cluster.

This PR changes the role gate for the endpoints above to use the
`VIEWACTIVITY` role option. Users with the option will be able to access
the `Nodes` endpoint and see unredacted nodes information at the
`NodesUI` endpoint used by the DB Console.

As a result, the nodes overview page as well as the node reports page
will now show unredacted information to users with `VIEWACTIVITY`.
(Existing functionality for Admins us also retained as those users
implicitly have the `VIEWACTIVITY` role.)

Resolves #77665

Release note (ui change, security update, api change): The
`_status/nodes` endpoint is avaible to all users with the
`VIEWACTIVITY` role option, not just Admins. In the DB Console, the
Nodes Overview and Node Reports pages will now display unredacted
information containing node hostnames and IP addresses for all users
with the `VIEWACTIVITY` role option. Previously this was also gated for
Admins only.
