### PR TITLE
kvserver: measure the number of bytes sent/received via snapshots

### DIFF
--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -496,6 +496,18 @@ var (
 		Measurement: "Snapshots",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaRangeSnapshotRcvdBytes = metric.Metadata{
+		Name:        "range.snapshots.rcvd-bytes",
+		Help:        "Number of snapshot bytes received",
+		Measurement: "Bytes",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaRangeSnapshotSentBytes = metric.Metadata{
+		Name:        "range.snapshots.sent-bytes",
+		Help:        "Number of snapshot bytes sent",
+		Measurement: "Bytes",
+		Unit:        metric.Unit_COUNT,
+	}
 	metaRangeRaftLeaderTransfers = metric.Metadata{
 		Name:        "range.raftleadertransfers",
 		Help:        "Number of raft leader transfers",
@@ -1384,16 +1396,20 @@ type StoreMetrics struct {
 	// accordingly.
 
 	// Range event metrics.
-	RangeSplits                                  *metric.Counter
-	RangeMerges                                  *metric.Counter
-	RangeAdds                                    *metric.Counter
-	RangeRemoves                                 *metric.Counter
+	RangeSplits                 *metric.Counter
+	RangeMerges                 *metric.Counter
+	RangeAdds                   *metric.Counter
+	RangeRemoves                *metric.Counter
+	RangeRaftLeaderTransfers    *metric.Counter
+	RangeLossOfQuorumRecoveries *metric.Counter
+
+	// Range snapshot metrics.
 	RangeSnapshotsGenerated                      *metric.Counter
 	RangeSnapshotsAppliedByVoters                *metric.Counter
 	RangeSnapshotsAppliedForInitialUpreplication *metric.Counter
 	RangeSnapshotsAppliedByNonVoters             *metric.Counter
-	RangeRaftLeaderTransfers                     *metric.Counter
-	RangeLossOfQuorumRecoveries                  *metric.Counter
+	RangeSnapshotRcvdBytes                       *metric.Counter
+	RangeSnapshotSentBytes                       *metric.Counter
 
 	// Raft processing metrics.
 	RaftTicks                 *metric.Counter
@@ -1828,6 +1844,8 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		RangeSnapshotsAppliedByVoters: metric.NewCounter(metaRangeSnapshotsAppliedByVoters),
 		RangeSnapshotsAppliedForInitialUpreplication: metric.NewCounter(metaRangeSnapshotsAppliedForInitialUpreplication),
 		RangeSnapshotsAppliedByNonVoters:             metric.NewCounter(metaRangeSnapshotsAppliedByNonVoter),
+		RangeSnapshotRcvdBytes:                       metric.NewCounter(metaRangeSnapshotRcvdBytes),
+		RangeSnapshotSentBytes:                       metric.NewCounter(metaRangeSnapshotSentBytes),
 		RangeRaftLeaderTransfers:                     metric.NewCounter(metaRangeRaftLeaderTransfers),
 		RangeLossOfQuorumRecoveries:                  metric.NewCounter(metaRangeLossOfQuorumRecoveries),
 

--- a/pkg/kv/kvserver/raft_transport.go
+++ b/pkg/kv/kvserver/raft_transport.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -687,6 +688,7 @@ func (t *RaftTransport) SendSnapshot(
 	snap *OutgoingSnapshot,
 	newBatch func() storage.Batch,
 	sent func(),
+	bytesSentCounter *metric.Counter,
 ) error {
 	nodeID := header.RaftMessageRequest.ToReplica.NodeID
 
@@ -705,7 +707,5 @@ func (t *RaftTransport) SendSnapshot(
 			log.Warningf(ctx, "failed to close snapshot stream: %+v", err)
 		}
 	}()
-	return sendSnapshot(
-		ctx, t.st, stream, storePool, header, snap, newBatch, sent,
-	)
+	return sendSnapshot(ctx, t.st, stream, storePool, header, snap, newBatch, sent, bytesSentCounter)
 }

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -2619,6 +2619,7 @@ func (r *Replica) sendSnapshot(
 				snap,
 				newBatchFn,
 				sent,
+				r.store.metrics.RangeSnapshotSentBytes,
 			)
 		})
 	if err != nil {

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
@@ -68,11 +69,22 @@ type outgoingSnapshotStream interface {
 type snapshotStrategy interface {
 	// Receive streams SnapshotRequests in from the provided stream and
 	// constructs an IncomingSnapshot.
-	Receive(context.Context, incomingSnapshotStream, kvserverpb.SnapshotRequest_Header) (IncomingSnapshot, error)
+	Receive(
+		context.Context,
+		incomingSnapshotStream,
+		kvserverpb.SnapshotRequest_Header,
+		*metric.Counter,
+	) (IncomingSnapshot, error)
 
 	// Send streams SnapshotRequests created from the OutgoingSnapshot in to the
 	// provided stream. On nil error, the number of bytes sent is returned.
-	Send(context.Context, outgoingSnapshotStream, kvserverpb.SnapshotRequest_Header, *OutgoingSnapshot) (int64, error)
+	Send(
+		context.Context,
+		outgoingSnapshotStream,
+		kvserverpb.SnapshotRequest_Header,
+		*OutgoingSnapshot,
+		*metric.Counter,
+	) (int64, error)
 
 	// Status provides a status report on the work performed during the
 	// snapshot. Only valid if the strategy succeeded.
@@ -239,7 +251,10 @@ func (msstw *multiSSTWriter) Close() {
 // 3. Two lock-table key ranges (optional)
 // 4. User key range
 func (kvSS *kvBatchSnapshotStrategy) Receive(
-	ctx context.Context, stream incomingSnapshotStream, header kvserverpb.SnapshotRequest_Header,
+	ctx context.Context,
+	stream incomingSnapshotStream,
+	header kvserverpb.SnapshotRequest_Header,
+	bytesRcvdCounter *metric.Counter,
 ) (IncomingSnapshot, error) {
 	assertStrategy(ctx, header, kvserverpb.SnapshotRequest_KV_BATCH)
 
@@ -263,6 +278,7 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 		}
 
 		if req.KVBatch != nil {
+			bytesRcvdCounter.Inc(int64(len(req.KVBatch)))
 			batchReader, err := storage.NewRocksDBBatchReader(req.KVBatch)
 			if err != nil {
 				return noSnap, errors.Wrap(err, "failed to decode batch")
@@ -324,12 +340,13 @@ func (kvSS *kvBatchSnapshotStrategy) Send(
 	stream outgoingSnapshotStream,
 	header kvserverpb.SnapshotRequest_Header,
 	snap *OutgoingSnapshot,
+	bytesSentMetric *metric.Counter,
 ) (int64, error) {
 	assertStrategy(ctx, header, kvserverpb.SnapshotRequest_KV_BATCH)
 
-	// bytesSent is updated as key-value batches are sent with sendBatch. It
-	// does not reflect the log entries sent (which are never sent in newer
-	// versions of CRDB, as of VersionUnreplicatedTruncatedState).
+	// bytesSent is updated as key-value batches are sent with sendBatch. It does
+	// not reflect the log entries sent (which are never sent in newer versions of
+	// CRDB, as of VersionUnreplicatedTruncatedState).
 	bytesSent := int64(0)
 
 	// Iterate over all keys using the provided iterator and stream out batches
@@ -362,6 +379,7 @@ func (kvSS *kvBatchSnapshotStrategy) Send(
 				return 0, err
 			}
 			bytesSent += bLen
+			bytesSentMetric.Inc(bLen)
 			b.Close()
 			b = nil
 		}
@@ -371,6 +389,7 @@ func (kvSS *kvBatchSnapshotStrategy) Send(
 			return 0, err
 		}
 		bytesSent += int64(b.Len())
+		bytesSentMetric.Inc(int64(b.Len()))
 	}
 
 	kvSS.status = redact.Sprintf("kv pairs: %d", kvs)
@@ -706,7 +725,7 @@ func (s *Store) receiveSnapshot(
 		log.Infof(ctx, "accepted snapshot reservation for r%d", header.State.Desc.RangeID)
 	}
 
-	inSnap, err := ss.Receive(ctx, stream, *header)
+	inSnap, err := ss.Receive(ctx, stream, *header, s.metrics.RangeSnapshotRcvdBytes)
 	if err != nil {
 		return err
 	}
@@ -1073,6 +1092,7 @@ func SendEmptySnapshot(
 		&outgoingSnap,
 		eng.NewBatch,
 		func() {},
+		nil, /* bytesSentCounter */
 	)
 }
 
@@ -1091,7 +1111,14 @@ func sendSnapshot(
 	snap *OutgoingSnapshot,
 	newBatch func() storage.Batch,
 	sent func(),
+	bytesSentCounter *metric.Counter,
 ) error {
+	if bytesSentCounter == nil {
+		// NB: Some tests and an offline tool (ResetQuorum) call into `sendSnapshot`
+		// with a nil counter. We pass in a fake metrics counter here that isn't
+		// hooked up to anything.
+		bytesSentCounter = metric.NewCounter(metric.Metadata{Name: "range.snapshots.sent-bytes"})
+	}
 	start := timeutil.Now()
 	to := header.RaftMessageRequest.ToReplica
 	if err := stream.Send(&kvserverpb.SnapshotRequest{Header: &header}); err != nil {
@@ -1153,7 +1180,7 @@ func sendSnapshot(
 		log.Fatalf(ctx, "unknown snapshot strategy: %s", header.Strategy)
 	}
 
-	numBytesSent, err := ss.Send(ctx, stream, header, snap)
+	numBytesSent, err := ss.Send(ctx, stream, header, snap, bytesSentCounter)
 	if err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -2773,7 +2773,9 @@ func TestSendSnapshotThrottling(t *testing.T) {
 		sp := &fakeStorePool{}
 		expectedErr := errors.New("")
 		c := fakeSnapshotStream{nil, expectedErr}
-		err := sendSnapshot(ctx, st, c, sp, header, nil, newBatch, nil)
+		err := sendSnapshot(
+			ctx, st, c, sp, header, nil /* snap */, newBatch, nil /* sent */, nil, /* bytesSentCounter */
+		)
 		if sp.failedThrottles != 1 {
 			t.Fatalf("expected 1 failed throttle, but found %d", sp.failedThrottles)
 		}
@@ -2789,7 +2791,9 @@ func TestSendSnapshotThrottling(t *testing.T) {
 			Status: kvserverpb.SnapshotResponse_ERROR,
 		}
 		c := fakeSnapshotStream{resp, nil}
-		err := sendSnapshot(ctx, st, c, sp, header, nil, newBatch, nil)
+		err := sendSnapshot(
+			ctx, st, c, sp, header, nil /* snap */, newBatch, nil /* sent */, nil, /* bytesSentCounter */
+		)
 		if sp.failedThrottles != 1 {
 			t.Fatalf("expected 1 failed throttle, but found %d", sp.failedThrottles)
 		}

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -604,6 +604,13 @@ var charts = []sectionDescription{
 					"range.snapshots.applied-non-voter",
 				},
 			},
+			{
+				Title: "Snapshot Bytes",
+				Metrics: []string{
+					"range.snapshots.rcvd-bytes",
+					"range.snapshots.sent-bytes",
+				},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
Release justification: low-risk observability improvement

Release note (ops change): This patch adds a new metric that charts the number
of bytes received via snapshots on any given store.
