### PR TITLE
ui: set index created time as last used time

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.stories.tsx
@@ -126,6 +126,12 @@ const withData: DatabaseTablePageProps = {
         lastUsedType: "reset",
         indexName: "secondary",
       },
+      {
+        totalReads: 0,
+        lastUsed: moment("2022-03-12T14:31:00Z"),
+        lastUsedType: "created",
+        indexName: "secondary",
+      },
     ],
     lastReset: moment("2021-09-04T13:55:00Z"),
   },

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
@@ -239,25 +239,15 @@ export class DatabaseTablePage extends React.Component<
   }
 
   private getLastUsedString(indexStat: IndexStat) {
-    const lastReset = this.props.indexStats.lastReset;
-    switch (indexStat.lastUsedType) {
-      case "read":
-        return formatDate(
-          indexStat.lastUsed,
-          "[Last read:] MMM DD, YYYY [at] h:mm A",
-        );
-      case "reset":
-      default:
-        // TODO(lindseyjin): replace default case with create time after it's added to table_indexes
-        if (lastReset.isSame(this.minDate)) {
-          return "Never";
-        } else {
-          return formatDate(
-            lastReset,
-            "[Last reset:] MMM DD, YYYY [at] h:mm A",
-          );
-        }
+    // This case only occurs when we have no reads, resets, or creation time on
+    // the index.
+    if (indexStat.lastUsed.isSame(this.minDate)) {
+      return "Never";
     }
+    return formatDate(
+      indexStat.lastUsed,
+      `[Last ${indexStat.lastUsedType}:] MMM DD, YYYY [at] h:mm A`,
+    );
   }
 
   private indexStatsColumns: ColumnDescriptor<IndexStat>[] = [

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.spec.ts
@@ -275,8 +275,27 @@ describe("Database Table Page", function() {
           index_name: "jobs_status_created_idx",
           index_type: "secondary",
         },
+        {
+          statistics: {
+            key: {
+              table_id: 1,
+              index_id: 2,
+            },
+            stats: {
+              total_read_count: new Long(0),
+              last_read: makeTimestamp("0001-01-01T00:00:00Z"),
+              total_rows_read: new Long(0),
+              total_write_count: new Long(0),
+              last_write: makeTimestamp("0001-01-01T00:00:00Z"),
+              total_rows_written: new Long(0),
+            },
+          },
+          index_name: "index_no_reads_no_resets",
+          index_type: "secondary",
+          created_at: makeTimestamp("0001-01-01T00:00:00Z"),
+        },
       ],
-      last_reset: makeTimestamp("2021-11-12T20:18:22.167627Z"),
+      last_reset: makeTimestamp("0001-01-01T00:00:00Z"),
     });
 
     await driver.refreshIndexStats();
@@ -293,10 +312,16 @@ describe("Database Table Page", function() {
           ),
           lastUsedType: "read",
         },
+        {
+          indexName: "index_no_reads_no_resets",
+          totalReads: 0,
+          lastUsed: util.TimestampToMoment(
+            makeTimestamp("0001-01-01T00:00:00Z"),
+          ),
+          lastUsedType: "created",
+        },
       ],
-      lastReset: util.TimestampToMoment(
-        makeTimestamp("2021-11-12T20:18:22.167627Z"),
-      ),
+      lastReset: util.TimestampToMoment(makeTimestamp("0001-01-01T00:00:00Z")),
     });
   });
 });

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.ts
@@ -74,12 +74,20 @@ export const mapStateToProps = createSelector(
           indexStat.statistics?.stats?.last_read,
         );
         let lastUsed, lastUsedType;
-        if (lastRead.isAfter(lastReset)) {
-          lastUsed = lastRead;
-          lastUsedType = "read";
+        if (indexStat.created_at !== null) {
+          lastUsed = util.TimestampToMoment(indexStat.created_at);
+          lastUsedType = "created";
         } else {
           lastUsed = lastReset;
           lastUsedType = "reset";
+        }
+        if (lastReset.isAfter(lastUsed)) {
+          lastUsed = lastReset;
+          lastUsedType = "reset";
+        }
+        if (lastRead.isAfter(lastUsed)) {
+          lastUsed = lastRead;
+          lastUsedType = "read";
         }
         return {
           indexName: indexStat.index_name,

--- a/pkg/ui/workspaces/db-console/src/views/databases/utils.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/utils.ts
@@ -67,6 +67,6 @@ export function getNodesByRegionString(
 // makeTimestamp converts a string to a google.protobuf.Timestamp object.
 export function makeTimestamp(date: string): Timestamp {
   return new protos.google.protobuf.Timestamp({
-    seconds: new Long(Date.parse(date) * 1e-3),
+    seconds: new Long(new Date(date).getUTCSeconds()),
   });
 }


### PR DESCRIPTION
Resolves: #73766

Previously, database table page on db-console displayed "Never" when
there was no Last Read or Last Reset timestamp. This change sets the
default message to display the creation time of the timestamp if it
exists.

Release note (ui change): add index created time as an option on the
database table page