### PR TITLE
tree: correctly handle NULLs annotated as a tuple type

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -1173,3 +1173,15 @@ FROM
       (NULL, (2:::DECIMAL, ARRAY[(1::INT8, 2::INT8, 3::INT8)]))
   )
     AS t2 (c3, c4)
+
+# Regression test #74729. Correctly handle NULLs annotated as a tuple type.
+subtest regression_74729
+
+statement ok
+SELECT CASE WHEN true THEN ('a', 2) ELSE NULL:::RECORD END
+
+statement ok
+CREATE TABLE t74729 AS SELECT g % 2 = 1 AS _bool FROM generate_series(1, 5) AS g
+
+statement ok
+SELECT CASE WHEN _bool THEN (1, ('a', 2)) ELSE (3, NULL) END FROM t74729

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -2570,7 +2570,10 @@ func typeCheckSameTypedTupleExprs(
 func checkAllExprsAreTuplesOrNulls(ctx context.Context, semaCtx *SemaContext, exprs []Expr) error {
 	for _, expr := range exprs {
 		_, isTuple := expr.(*Tuple)
-		isNull := expr == DNull
+		isNull, err := isNullOrAnnotatedNullTuple(ctx, semaCtx, expr)
+		if err != nil {
+			return err
+		}
 		if !(isTuple || isNull) {
 			// We avoid calling TypeCheck on Tuple exprs since that causes the
 			// types to be resolved, which we only want to do later in type-checking.
@@ -2605,6 +2608,28 @@ func checkTupleHasLength(t *Tuple, expectedLen int) error {
 		return pgerror.Newf(pgcode.DatatypeMismatch, "expected tuple %v to have a length of %d", t, expectedLen)
 	}
 	return nil
+}
+
+// isNullOrAnnotatedNullTuple returns true if the given expression is a DNull or
+// a DNull that is wrapped by an AnnotateTypeExpr with a type identical to
+// AnyTuple (e.g., NULL:::RECORD). An AnnotateTypeExpr should never have a tuple
+// type not identical to AnyTuple, because other tuple types could only be
+// expressed as composite types, and these are not yet supported. If the
+// AnnotateTypeExpr has a non-tuple type, the function returns false.
+func isNullOrAnnotatedNullTuple(
+	ctx context.Context, semaCtx *SemaContext, expr Expr,
+) (bool, error) {
+	if expr == DNull {
+		return true, nil
+	}
+	if annotate, ok := expr.(*AnnotateTypeExpr); ok && annotate.Expr == DNull {
+		annotateType, err := ResolveType(ctx, annotate.Type, semaCtx.GetTypeResolver())
+		if err != nil {
+			return false, err
+		}
+		return annotateType.Identical(types.AnyTuple), nil
+	}
+	return false, nil
 }
 
 type placeholderAnnotationVisitor struct {

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -161,6 +161,12 @@ func TestTypeCheck(t *testing.T) {
 		{`(1:::INT8, 2:::INT8)`, `(1:::INT8, 2:::INT8)`},
 		{`(ROW (1,2))`, `(1:::INT8, 2:::INT8)`},
 		{`ROW(1:::INT8, 2:::INT8)`, `(1:::INT8, 2:::INT8)`},
+		// Regression test #74729. Correctly handle NULLs annotated as a tuple
+		// type.
+		{
+			`CASE WHEN true THEN ('a', 2) ELSE NULL:::RECORD END`,
+			`CASE WHEN true THEN ('a':::STRING, 2:::INT8) ELSE NULL END`,
+		},
 
 		{`((ROW (1) AS a)).a`, `1:::INT8`},
 		{`((('1', 2) AS a, b)).a`, `'1':::STRING`},


### PR DESCRIPTION
Fixes #74729

Release note (bug fix): A bug has been fixed that caused errors when
trying to evaluate queries with NULL values annotated as a tuple type,
such as `NULL:::RECORD`. This bug was present since version 19.1.