### PR TITLE
[CRDB-3303] ui: handle latency not defined on network page

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/latency/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/latency/index.tsx
@@ -126,7 +126,7 @@ const renderMultipleHeaders = (
     const row: any[] = [];
     displayIdentities.forEach(identityB => {
       const a = nodesSummary.nodeStatusByID[identityA.nodeID].activity;
-      const nano = FixLong(a[identityB.nodeID].latency);
+      const nano = FixLong(a[identityB.nodeID]?.latency || 0);
       if (identityA.nodeID === identityB.nodeID) {
         row.push({ latency: 0, identityB });
       } else if (


### PR DESCRIPTION
Previously when a cluster with multiple nodes had a node stopped
and then another node quickly started, the network page would crash.
This was due to the node object holding the latency value being
undefined and the ui trying to read this key when that was undefined.
This occurs when a node is in an `UNAVAILABLE` state.
This patch resolves the issue by being more defensive on the front
end by safely attempting to access latency and if it is undefined,
set the value to 0. The existing code is able to handle this case
afterward and will eventually set the user friendly latency status
to `--`.
Resolves: #59322

Release note (ui change): Fixes a bug where a node in the
`UNAVAILABLE` state will not have latency defined and cause the
network page to crash.

Overview list page & network page when node status is `UNAVAILABLE`:

![Screen Shot 2022-03-22 at 5 14 47 PM](https://user-images.githubusercontent.com/17861665/159579337-a48fafb1-e8fd-4c47-a07b-df93de532f0a.png)

![Screen Shot 2022-03-22 at 5 14 59 PM](https://user-images.githubusercontent.com/17861665/159579355-dc8142c9-703b-4425-9890-aa702e354fb4.png)

