### PR TITLE
api: increase timeout of statements request for CC Console

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/fetchData.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/fetchData.ts
@@ -35,18 +35,24 @@ export function toArrayBuffer(encodedRequest: Uint8Array): ArrayBuffer {
  * @param ReqBuilder expects protobuf stub to encode request payload. It has to be
  * class type, not instance;
  * @param reqPayload is request payload object;
+ * @param timeout is the timeout for the request (optional),
+ * format is TimeoutValue (positive integer of at most 8 digits) +
+ * TimeoutUnit ( Hour → "H", Minute → "M", Second → "S", Millisecond → "m" ),
+ * e.g. "1M" (1 minute), default value "30S" (30 seconds);
  **/
 export const fetchData = <P extends ProtoBuilder<P>, T extends ProtoBuilder<T>>(
   RespBuilder: T,
   path: string,
   ReqBuilder?: P,
   reqPayload?: FirstConstructorParameter<P>,
+  timeout?: string,
 ): Promise<InstanceType<T>> => {
+  const grpcTimeout = timeout || "30S";
   const params: RequestInit = {
     headers: {
       Accept: "application/x-protobuf",
       "Content-Type": "application/x-protobuf",
-      "Grpc-Timeout": "30000m",
+      "Grpc-Timeout": grpcTimeout,
     },
     credentials: "same-origin",
   };

--- a/pkg/ui/workspaces/cluster-ui/src/api/statementsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/statementsApi.ts
@@ -38,6 +38,9 @@ export const getCombinedStatements = (
   return fetchData(
     cockroach.server.serverpb.StatementsResponse,
     `${STATEMENTS_PATH}?${queryStr}`,
+    null,
+    null,
+    "30M",
   );
 };
 
@@ -54,5 +57,8 @@ export const getStatementDetails = (
   return fetchData(
     cockroach.server.serverpb.StatementDetailsResponse,
     `${STATEMENT_DETAILS_PATH}/${req.fingerprint_id}?${queryStr}`,
+    null,
+    null,
+    "30M",
   );
 };


### PR DESCRIPTION
Follow up from https://github.com/cockroachdb/cockroach/pull/76739
Add timeout to fetchData function and increase the timeout
value for the Statement calls for usage on CC Console.

Release note: None