### PR TITLE
release-21.1: server: VIEWACTIVITY role gates unredacted nodes info

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -59,6 +59,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
+	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
@@ -1339,9 +1340,11 @@ func (s *statusServer) Profile(
 func (s *statusServer) Nodes(
 	ctx context.Context, req *serverpb.NodesRequest,
 ) (*serverpb.NodesResponse, error) {
-	// The node status contains details about the command line, network
-	// addresses, env vars etc which are admin-only.
-	if _, err := s.privilegeChecker.requireAdminUser(ctx); err != nil {
+	ctx = propagateGatewayMetadata(ctx)
+	ctx = s.AnnotateCtx(ctx)
+
+	_, err := s.privilegeChecker.requireViewActivityPermission(ctx)
+	if err != nil {
 		return nil, err
 	}
 
@@ -1355,9 +1358,14 @@ func (s *statusServer) NodesUI(
 	// The node status contains details about the command line, network
 	// addresses, env vars etc which are admin-only.
 
-	_, isAdmin, err := s.privilegeChecker.getUserAndRole(ctx)
+	hasViewActivity := false
+	_, err := s.privilegeChecker.requireViewActivityPermission(ctx)
 	if err != nil {
-		return nil, err
+		if !grpcutil.IsAuthError(err) {
+			return nil, err
+		}
+	} else {
+		hasViewActivity = true
 	}
 
 	internalResp, _, err := s.nodesHelper(ctx, 0 /* limit */, 0 /* offset */)
@@ -1369,13 +1377,13 @@ func (s *statusServer) NodesUI(
 		LivenessByNodeID: internalResp.LivenessByNodeID,
 	}
 	for i, nodeStatus := range internalResp.Nodes {
-		resp.Nodes[i] = nodeStatusToResp(&nodeStatus, isAdmin)
+		resp.Nodes[i] = nodeStatusToResp(&nodeStatus, hasViewActivity)
 	}
 
 	return resp, err
 }
 
-func nodeStatusToResp(n *statuspb.NodeStatus, isAdmin bool) serverpb.NodeResponse {
+func nodeStatusToResp(n *statuspb.NodeStatus, hasViewActivity bool) serverpb.NodeResponse {
 	tiers := make([]serverpb.Tier, len(n.Desc.Locality.Tiers))
 	for j, t := range n.Desc.Locality.Tiers {
 		tiers[j] = serverpb.Tier{
@@ -1441,7 +1449,7 @@ func nodeStatusToResp(n *statuspb.NodeStatus, isAdmin bool) serverpb.NodeRespons
 		NumCpus:           n.NumCpus,
 	}
 
-	if isAdmin {
+	if hasViewActivity {
 		resp.Args = n.Args
 		resp.Env = n.Env
 		resp.Desc.Attrs = n.Desc.Attrs

--- a/pkg/sql/roleoption/role_option.go
+++ b/pkg/sql/roleoption/role_option.go
@@ -49,6 +49,11 @@ const (
 	NOCREATEDB
 	CREATELOGIN
 	NOCREATELOGIN
+	// VIEWACTIVITY is responsible for controlling access to DB Console
+	// endpoints that allow a user to view data in the UI without having
+	// the Admin role. In addition, the VIEWACTIVITY role permits viewing
+	// *unredacted* data in the `/nodes` and `/nodes_ui` endpoints which
+	// display IP addresses and hostnames.
 	VIEWACTIVITY
 	NOVIEWACTIVITY
 	CANCELQUERY


### PR DESCRIPTION
Backport 1/1 commits from #78045.

/cc @cockroachdb/release

Note: this backport omits the unit test added in `admin_test.go` in the original commit since the methods in 21.1 that are under test either do not exist in this version or have different APIs.

Release justification: high-priority need from customer that keeps existing functionality and adds ability to use the additional SQL role

---

Previously, the `Nodes` and `NodesUI` endpoints were gated behind the
Admin role. For the former endpoint requests would fail if the user
didn't have the Admin role, and for the latter, we'd show partially
redacted information that omitted hostnames and IP addresses.

This was deemed problematic for customers who did not want to set the
Admin role just to grant a user the ability to view detailed node
information about the cluster.

This PR changes the role gate for the endpoints above to use the
`VIEWACTIVITY` role option. Users with the option will be able to access
the `Nodes` endpoint and see unredacted nodes information at the
`NodesUI` endpoint used by the DB Console.

As a result, the nodes overview page as well as the node reports page
will now show unredacted information to users with `VIEWACTIVITY`.
(Existing functionality for Admins us also retained as those users
implicitly have the `VIEWACTIVITY` role.)

Resolves #77665

Release note (ui change, security update, api change): The
`_status/nodes` endpoint is avaible to all users with the
`VIEWACTIVITY` role option, not just Admins. In the DB Console, the
Nodes Overview and Node Reports pages will now display unredacted
information containing node hostnames and IP addresses for all users
with the `VIEWACTIVITY` role option. Previously this was also gated for
Admins only.
