### PR TITLE
spanconfig: disable secondary tenant zone configs

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -37,6 +37,7 @@ ALL_TESTS = [
     "//pkg/ccl/serverccl/statusccl:statusccl_test",
     "//pkg/ccl/serverccl:serverccl_test",
     "//pkg/ccl/spanconfigccl/spanconfigcomparedccl:spanconfigcomparedccl_test",
+    "//pkg/ccl/spanconfigccl/spanconfigmanagerccl:spanconfigmanagerccl_test",
     "//pkg/ccl/spanconfigccl/spanconfigreconcilerccl:spanconfigreconcilerccl_test",
     "//pkg/ccl/spanconfigccl/spanconfigsplitterccl:spanconfigsplitterccl_test",
     "//pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl:spanconfigsqltranslatorccl_test",

--- a/pkg/ccl/jobsccl/jobsprotectedtsccl/jobs_protected_ts_test.go
+++ b/pkg/ccl/jobsccl/jobsprotectedtsccl/jobs_protected_ts_test.go
@@ -152,12 +152,12 @@ func TestJobsProtectedTimestamp(t *testing.T) {
 	hostRunner.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'")
 	hostRunner.Exec(t, "SET CLUSTER SETTING kv.protectedts.reconciliation.interval = '1ms';")
 	// Also set what tenants see for these settings.
-	// TODO(radu): use ALTER TENANT statement when that is available.
-	hostRunner.Exec(t, `INSERT INTO system.tenant_settings (tenant_id, name, value, value_type)
-		SELECT 0, name, value, "valueType" FROM system.settings
-		WHERE name IN ('kv.closed_timestamp.target_duration', 'kv.protectedts.reconciliation.interval')`)
+	hostRunner.Exec(t, "ALTER TENANT ALL SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'")
+	hostRunner.Exec(t, "ALTER TENANT ALL SET CLUSTER SETTING kv.protectedts.reconciliation.interval = '1ms';")
 
 	t.Run("secondary-tenant", func(t *testing.T) {
+		hostRunner.Exec(t, "ALTER TENANT ALL SET CLUSTER SETTING spanconfig.tenant_reconciliation_job.enabled = true;")
+
 		ten10, conn10 := serverutils.StartTenant(t, s0, base.TestTenantArgs{TenantID: roachpb.MakeTenantID(10)})
 		defer conn10.Close()
 		ptp := ten10.ExecutorConfig().(sql.ExecutorConfig).ProtectedTimestampProvider
@@ -267,12 +267,12 @@ func TestSchedulesProtectedTimestamp(t *testing.T) {
 	hostRunner.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'")
 	hostRunner.Exec(t, "SET CLUSTER SETTING kv.protectedts.reconciliation.interval = '1ms';")
 	// Also set what tenants see for these settings.
-	// TODO(radu): use ALTER TENANT statement when that is available.
-	hostRunner.Exec(t, `INSERT INTO system.tenant_settings (tenant_id, name, value, value_type)
-		SELECT 0, name, value, "valueType" FROM system.settings
-		WHERE name IN ('kv.closed_timestamp.target_duration', 'kv.protectedts.reconciliation.interval')`)
+	hostRunner.Exec(t, "ALTER TENANT ALL SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'")
+	hostRunner.Exec(t, "ALTER TENANT ALL SET CLUSTER SETTING kv.protectedts.reconciliation.interval = '1ms';")
 
 	t.Run("secondary-tenant", func(t *testing.T) {
+		hostRunner.Exec(t, "ALTER TENANT ALL SET CLUSTER SETTING spanconfig.tenant_reconciliation_job.enabled = true;")
+
 		ten10, conn10 := serverutils.StartTenant(t, s0, base.TestTenantArgs{TenantID: roachpb.MakeTenantID(10)})
 		defer conn10.Close()
 		ptp := ten10.ExecutorConfig().(sql.ExecutorConfig).ProtectedTimestampProvider

--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -1,4 +1,5 @@
 # LogicTest: 3node-tenant
+# tenant-cluster-setting-override-opt: enable-reconciliation-job-for-secondary-tenants
 
 query II
 SELECT count(distinct(node_id)), count(*)  FROM crdb_internal.node_runtime_info
@@ -11,8 +12,6 @@ SELECT node_id, name FROM crdb_internal.leases ORDER BY name
 0  eventlog
 0  jobs
 0  locations
-0  protected_ts_meta
-0  protected_ts_records
 0  role_members
 0  role_options
 0  scheduled_jobs

--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -1099,6 +1099,10 @@ func testTxnIDResolutionRPC(ctx context.Context, t *testing.T, helper *tenantTes
 }
 
 func testTenantRangesRPC(_ context.Context, t *testing.T, helper *tenantTestHelper) {
+	_, err := helper.hostCluster.ServerConn(0).Exec(
+		"ALTER TENANT ALL SET CLUSTER SETTING spanconfig.tenant_reconciliation_job.enabled = true")
+	require.NoError(t, err)
+
 	tenantA := helper.testCluster().tenant(0).tenant.TenantStatusServer().(serverpb.TenantStatusServer)
 	tenantB := helper.controlCluster().tenant(0).tenant.TenantStatusServer().(serverpb.TenantStatusServer)
 

--- a/pkg/ccl/spanconfigccl/spanconfigmanagerccl/BUILD.bazel
+++ b/pkg/ccl/spanconfigccl/spanconfigmanagerccl/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "spanconfigmanagerccl_test",
+    srcs = [
+        "main_test.go",
+        "manager_test.go",
+    ],
+    deps = [
+        "//pkg/base",
+        "//pkg/ccl/kvccl/kvtenantccl",
+        "//pkg/ccl/utilccl",
+        "//pkg/jobs",
+        "//pkg/roachpb",
+        "//pkg/security",
+        "//pkg/security/securitytest",
+        "//pkg/server",
+        "//pkg/spanconfig",
+        "//pkg/spanconfig/spanconfigmanager",
+        "//pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster",
+        "//pkg/sql",
+        "//pkg/testutils",
+        "//pkg/testutils/serverutils",
+        "//pkg/testutils/testcluster",
+        "//pkg/util/leaktest",
+        "//pkg/util/randutil",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/ccl/spanconfigccl/spanconfigmanagerccl/main_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigmanagerccl/main_test.go
@@ -1,0 +1,33 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package spanconfigmanagerccl
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+//go:generate ../../../util/leaktest/add-leaktest.sh *_test.go
+
+func TestMain(m *testing.M) {
+	defer utilccl.TestingEnableEnterprise()()
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}

--- a/pkg/ccl/spanconfigccl/spanconfigmanagerccl/manager_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigmanagerccl/manager_test.go
@@ -1,0 +1,96 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package spanconfigmanagerccl
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvtenantccl"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigmanager"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManagerCheckJobConditions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	scKnobs := &spanconfig.TestingKnobs{
+		ManagerDisableJobCreation: true,
+	}
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				SpanConfig: scKnobs,
+			},
+		},
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	spanConfigTestCluster := spanconfigtestcluster.NewHandle(t, tc, scKnobs)
+	defer spanConfigTestCluster.Cleanup()
+
+	systemTenant := spanConfigTestCluster.InitializeTenant(ctx, roachpb.SystemTenantID)
+	secondaryTenant := spanConfigTestCluster.InitializeTenant(ctx, roachpb.MakeTenantID(10))
+	secondaryTenant.Exec(`SET CLUSTER SETTING spanconfig.reconciliation_job.enabled = false;`)
+
+	var interceptCount int32
+	checkInterceptCountGreaterThan := func(min int32) int32 {
+		var currentCount int32
+		testutils.SucceedsSoon(t, func() error {
+			if currentCount = atomic.LoadInt32(&interceptCount); !(currentCount > min) {
+				return errors.Errorf("expected intercept count(=%d) > min(=%d)",
+					currentCount, min)
+			}
+			return nil
+		})
+		return currentCount
+	}
+	manager := spanconfigmanager.New(
+		secondaryTenant.ExecutorConfig().(sql.ExecutorConfig).DB,
+		secondaryTenant.JobRegistry().(*jobs.Registry),
+		secondaryTenant.ExecutorConfig().(sql.ExecutorConfig).InternalExecutor,
+		secondaryTenant.ExecutorConfig().(sql.ExecutorConfig).Codec,
+		secondaryTenant.Stopper(),
+		secondaryTenant.ClusterSettings(),
+		secondaryTenant.SpanConfigReconciler().(spanconfig.Reconciler),
+		&spanconfig.TestingKnobs{
+			ManagerDisableJobCreation: true,
+			ManagerCheckJobInterceptor: func() {
+				atomic.AddInt32(&interceptCount, 1)
+			},
+		},
+	)
+
+	var currentCount int32
+	require.NoError(t, manager.Start(ctx))
+	currentCount = checkInterceptCountGreaterThan(currentCount) // wait for an initial check
+
+	secondaryTenant.Exec(`SET CLUSTER SETTING spanconfig.reconciliation_job.enabled = true;`)
+	currentCount = checkInterceptCountGreaterThan(currentCount) // the job enablement setting triggers a check
+
+	systemTenant.Exec(`ALTER TENANT 10 SET CLUSTER SETTING spanconfig.tenant_reconciliation_job.enabled = true;`)
+	currentCount = checkInterceptCountGreaterThan(currentCount) // the tenant job enablement setting triggers a check
+
+	secondaryTenant.Exec(`SET CLUSTER SETTING spanconfig.reconciliation_job.check_interval = '25m'`)
+	_ = checkInterceptCountGreaterThan(currentCount) // the job check interval setting triggers a check
+}

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -964,6 +964,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 			cfg.db,
 			jobRegistry,
 			cfg.circularInternalExecutor,
+			codec,
 			cfg.stopper,
 			cfg.Settings,
 			spanConfigReconciler,

--- a/pkg/spanconfig/spanconfigjob/job.go
+++ b/pkg/spanconfig/spanconfigjob/job.go
@@ -160,6 +160,9 @@ func (r *resumer) Resume(ctx context.Context, execCtxI interface{}) (jobErr erro
 				retrier.Reset()
 			}
 
+			// TODO(irfansharif): We could peek at spanconfig.tenant_reconciliation_job.enabled,
+			// which if false, could be used as an indicator that the host tenant
+			// wants to disable all in-flight reconciliation jobs.
 			return r.job.SetProgress(ctx, nil, jobspb.AutoSpanConfigReconciliationProgress{
 				Checkpoint: rc.Checkpoint(),
 			})

--- a/pkg/spanconfig/spanconfigmanager/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigmanager/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
+        "//pkg/keys",
         "//pkg/kv",
         "//pkg/security",
         "//pkg/settings",

--- a/pkg/sql/logictest/testdata/logic_test/auto_span_config_reconciliation_job
+++ b/pkg/sql/logictest/testdata/logic_test/auto_span_config_reconciliation_job
@@ -1,3 +1,5 @@
+# tenant-cluster-setting-override-opt: enable-reconciliation-job-for-secondary-tenants
+
 statement ok
 SET CLUSTER SETTING spanconfig.reconciliation_job.enabled = true;
 

--- a/pkg/sql/logictest/testdata/logic_test/jobs
+++ b/pkg/sql/logictest/testdata/logic_test/jobs
@@ -1,3 +1,5 @@
+# tenant-cluster-setting-override-opt: enable-reconciliation-job-for-secondary-tenants
+
 # Disable declarative schema changer for this test.
 statement ok
 SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'off';


### PR DESCRIPTION
#77344 outlines the various ways how without additional cost
attribution or resource limiting, tenant zone configs provides
a sufficient API to induce (costly) work in the host cluster. While
better attribution/limiting is underway, this PR introduces two cluster
settings to effectively switch off this machinery all throughout, and/or
enable it selectively for specific tenants. These settings will also
help us roll out this functionality more gradually as we build the
controls described in #77344.

 - spanconfig.tenant_reconciliation_job.enabled, a tenant-readonly
   setting that allows the host to disable the span config reconcilation
   job across all tenants. Defaults to false.
 - spanconfig.tenant_kvaccessor.enabled, a system only setting that
   rejects all KVAccessor requests issued by secondary tenants. Defaults
   to true, but acts as a global kill switch to reject all
   tenant reconciliation requests.

Release note: None


Jira issue: CRDB-14786