### PR TITLE
kvserver: don't GC if protected timestamp information isn't available

### DIFF
--- a/pkg/kv/kvserver/replica_protected_timestamp_test.go
+++ b/pkg/kv/kvserver/replica_protected_timestamp_test.go
@@ -54,6 +54,16 @@ func TestCheckProtectedTimestampsForGC(t *testing.T) {
 			},
 		},
 		{
+			name: "no PTS information is available",
+			test: func(t *testing.T, r *Replica, mp *manualPTSReader) {
+				mp.asOf = hlc.Timestamp{}
+				canGC, _, gcTimestamp, _, _, err := r.checkProtectedTimestampsForGC(ctx, makeTTLDuration(10))
+				require.NoError(t, err)
+				require.False(t, canGC)
+				require.Zero(t, gcTimestamp)
+			},
+		},
+		{
 			name: "have overlapping but new enough that it's okay",
 			test: func(t *testing.T, r *Replica, mp *manualPTSReader) {
 				ts := r.store.Clock().Now()


### PR DESCRIPTION
We only want to run GC on a replica that some PTS information (even if
it's stale). We don't want to run GC on a replica if no PTS information
is available however. This can happen if a Replica is being considered
for GC before the initial scan of the KVSubscriber has completed.

This wasn't an issue before this patch for implicit reasons -- this
patch just makes the check explicit and adds a test. Previously, we
wouldn't run GC if no PTS information was available because our lease
was guaranteed to be newer than the empty timestamp.

Release note: None