### PR TITLE
sql: fix migration with new system.table_statistics column

### DIFF
--- a/pkg/migration/migrations/alter_table_statistics_avg_size.go
+++ b/pkg/migration/migrations/alter_table_statistics_avg_size.go
@@ -21,8 +21,9 @@ import (
 )
 
 const addAvgSizeCol = `
-ALTER TABLE system.table_statistics 
+ALTER TABLE system.table_statistics
 ADD COLUMN IF NOT EXISTS "avgSize" INT8 NOT NULL DEFAULT (INT8 '0')
+FAMILY "fam_0_tableID_statisticID_name_columnIDs_createdAt_rowCount_distinctCount_nullCount_histogram"
 `
 
 func alterSystemTableStatisticsAddAvgSize(

--- a/pkg/migration/migrations/alter_table_statistics_avg_size_test.go
+++ b/pkg/migration/migrations/alter_table_statistics_avg_size_test.go
@@ -58,6 +58,8 @@ func TestAlterSystemTableStatisticsTable(t *testing.T) {
 	var (
 		validationSchemas = []migrations.Schema{
 			{Name: "avgSize", ValidationFn: migrations.HasColumn},
+			{Name: "fam_0_tableID_statisticID_name_columnIDs_createdAt_rowCount_distinctCount_nullCount_histogram",
+				ValidationFn: migrations.HasColumnFamily},
 		}
 	)
 

--- a/pkg/migration/migrations/helpers_test.go
+++ b/pkg/migration/migrations/helpers_test.go
@@ -31,6 +31,7 @@ import (
 var (
 	HasColumn         = hasColumn
 	HasIndex          = hasIndex
+	HasColumnFamily   = hasColumnFamily
 	CreateSystemTable = createSystemTable
 )
 

--- a/pkg/sql/catalog/systemschema/system.go
+++ b/pkg/sql/catalog/systemschema/system.go
@@ -251,10 +251,10 @@ CREATE TABLE system.table_statistics (
 	"rowCount"      INT8       NOT NULL,
 	"distinctCount" INT8       NOT NULL,
 	"nullCount"     INT8       NOT NULL,
-	"avgSize"       INT8       NOT NULL DEFAULT 0,
 	histogram       BYTES,
+	"avgSize"       INT8       NOT NULL DEFAULT 0,
 	CONSTRAINT "primary" PRIMARY KEY ("tableID", "statisticID"),
-	FAMILY ("tableID", "statisticID", name, "columnIDs", "createdAt", "rowCount", "distinctCount", "nullCount", "avgSize", histogram)
+	FAMILY "fam_0_tableID_statisticID_name_columnIDs_createdAt_rowCount_distinctCount_nullCount_histogram" ("tableID", "statisticID", name, "columnIDs", "createdAt", "rowCount", "distinctCount", "nullCount", histogram, "avgSize")
 );`
 
 	// locations are used to map a locality specified by a node to geographic
@@ -1311,12 +1311,12 @@ var (
 				{Name: "rowCount", ID: 6, Type: types.Int},
 				{Name: "distinctCount", ID: 7, Type: types.Int},
 				{Name: "nullCount", ID: 8, Type: types.Int},
-				{Name: "avgSize", ID: 9, Type: types.Int, DefaultExpr: &zeroIntString},
-				{Name: "histogram", ID: 10, Type: types.Bytes, Nullable: true},
+				{Name: "histogram", ID: 9, Type: types.Bytes, Nullable: true},
+				{Name: "avgSize", ID: 10, Type: types.Int, DefaultExpr: &zeroIntString},
 			},
 			[]descpb.ColumnFamilyDescriptor{
 				{
-					Name: "fam_0_tableID_statisticID_name_columnIDs_createdAt_rowCount_distinctCount_nullCount_avgSize_histogram",
+					Name: "fam_0_tableID_statisticID_name_columnIDs_createdAt_rowCount_distinctCount_nullCount_histogram",
 					ID:   0,
 					ColumnNames: []string{
 						"tableID",
@@ -1327,8 +1327,8 @@ var (
 						"rowCount",
 						"distinctCount",
 						"nullCount",
-						"avgSize",
 						"histogram",
+						"avgSize",
 					},
 					ColumnIDs: []descpb.ColumnID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 				},

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -1601,6 +1601,7 @@ system              public             630200280_42_8_not_null                  
 system              public             630200280_42_9_not_null                                                                                         system         public        statement_statistics             CHECK            NO             NO
 system              public             check_crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8  system         public        statement_statistics             CHECK            NO             NO
 system              public             primary                                                                                                         system         public        statement_statistics             PRIMARY KEY      NO             NO
+system              public             630200280_20_10_not_null                                                                                        system         public        table_statistics                 CHECK            NO             NO
 system              public             630200280_20_1_not_null                                                                                         system         public        table_statistics                 CHECK            NO             NO
 system              public             630200280_20_2_not_null                                                                                         system         public        table_statistics                 CHECK            NO             NO
 system              public             630200280_20_4_not_null                                                                                         system         public        table_statistics                 CHECK            NO             NO
@@ -1608,7 +1609,6 @@ system              public             630200280_20_5_not_null                  
 system              public             630200280_20_6_not_null                                                                                         system         public        table_statistics                 CHECK            NO             NO
 system              public             630200280_20_7_not_null                                                                                         system         public        table_statistics                 CHECK            NO             NO
 system              public             630200280_20_8_not_null                                                                                         system         public        table_statistics                 CHECK            NO             NO
-system              public             630200280_20_9_not_null                                                                                         system         public        table_statistics                 CHECK            NO             NO
 system              public             primary                                                                                                         system         public        table_statistics                 PRIMARY KEY      NO             NO
 system              public             630200280_50_1_not_null                                                                                         system         public        tenant_settings                  CHECK            NO             NO
 system              public             630200280_50_2_not_null                                                                                         system         public        tenant_settings                  CHECK            NO             NO
@@ -1693,6 +1693,7 @@ system              public             630200280_19_3_not_null                  
 system              public             630200280_19_4_not_null                                                                                         createdAt IS NOT NULL
 system              public             630200280_19_5_not_null                                                                                         expiresAt IS NOT NULL
 system              public             630200280_19_7_not_null                                                                                         lastUsedAt IS NOT NULL
+system              public             630200280_20_10_not_null                                                                                        avgSize IS NOT NULL
 system              public             630200280_20_1_not_null                                                                                         tableID IS NOT NULL
 system              public             630200280_20_2_not_null                                                                                         statisticID IS NOT NULL
 system              public             630200280_20_4_not_null                                                                                         columnIDs IS NOT NULL
@@ -1700,7 +1701,6 @@ system              public             630200280_20_5_not_null                  
 system              public             630200280_20_6_not_null                                                                                         rowCount IS NOT NULL
 system              public             630200280_20_7_not_null                                                                                         distinctCount IS NOT NULL
 system              public             630200280_20_8_not_null                                                                                         nullCount IS NOT NULL
-system              public             630200280_20_9_not_null                                                                                         avgSize IS NOT NULL
 system              public             630200280_21_1_not_null                                                                                         localityKey IS NOT NULL
 system              public             630200280_21_2_not_null                                                                                         localityValue IS NOT NULL
 system              public             630200280_21_3_not_null                                                                                         latitude IS NOT NULL
@@ -2150,11 +2150,11 @@ system         public        statement_statistics             plan              
 system         public        statement_statistics             plan_hash                                                                                                 4
 system         public        statement_statistics             statistics                                                                                                9
 system         public        statement_statistics             transaction_fingerprint_id                                                                                3
-system         public        table_statistics                 avgSize                                                                                                   9
+system         public        table_statistics                 avgSize                                                                                                   10
 system         public        table_statistics                 columnIDs                                                                                                 4
 system         public        table_statistics                 createdAt                                                                                                 5
 system         public        table_statistics                 distinctCount                                                                                             7
-system         public        table_statistics                 histogram                                                                                                 10
+system         public        table_statistics                 histogram                                                                                                 9
 system         public        table_statistics                 name                                                                                                      3
 system         public        table_statistics                 nullCount                                                                                                 8
 system         public        table_statistics                 rowCount                                                                                                  6


### PR DESCRIPTION
Before this change, the new `system.table_statistics` column `avgSize`
introduced in version 22.1.12 was appended to the end of the table
during migration, but the system schema had the new column in a
different order. The column was also not added to the existing column
family containing all table columns during migration.

This change fixes both the system schema and the migration commands so
that the column ordering is the same and the new column is added to the
existing column family. Unfortunately, this means that the existing
column family name is unable to be updated to include the column.

Fixes: #77979

Release justification: Fixes a schema migration bug in the
table_statistics table.

Release note: None