### PR TITLE
server: improve tsdump mapping defaults

### DIFF
--- a/pkg/server/import_ts.go
+++ b/pkg/server/import_ts.go
@@ -16,7 +16,6 @@ import (
 	"encoding/gob"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -30,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/errors/oserror"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -107,16 +107,20 @@ func maybeImportTS(ctx context.Context, s *Server) (returnErr error) {
 	defer f.Close()
 
 	if knobs.ImportTimeseriesMappingFile == "" {
-		return errors.Errorf("need to specify COCKROACH_DEBUG_TS_IMPORT_MAPPING_FILE; it should point at " +
-			"a YAML file that maps StoreID to NodeID. To generate from the source cluster, run the following command:\n \n" +
-			"cockroach sql --url \"<(unix/sql) url>\" --format tsv -e \\\n  \"select concat(store_id::string, ': ', node_id::string)" +
-			"from crdb_internal.kv_store_status\" | \\\n  grep -E '[0-9]+: [0-9]+' | tee tsdump.gob.yaml\n \n" +
-			"To create from a debug.zip file, run the following command:\n \n" +
-			"tail -n +2 debug/crdb_internal.kv_store_status.txt | awk '{print $2 \": \" $1}' > tsdump.gob.yaml\n \n" +
-			"Then export the created file: export COCKROACH_DEBUG_TS_IMPORT_MAPPING_FILE=tsdump.gob.yaml\n \n")
+		knobs.ImportTimeseriesMappingFile = knobs.ImportTimeseriesFile + ".yaml"
 	}
-	mapBytes, err := ioutil.ReadFile(knobs.ImportTimeseriesMappingFile)
+
+	mapBytes, err := os.ReadFile(knobs.ImportTimeseriesMappingFile)
 	if err != nil {
+		if oserror.IsNotExist(err) {
+			err = errors.Wrapf(err, "need to specify COCKROACH_DEBUG_TS_IMPORT_MAPPING_FILE; it should point at "+
+				"a YAML file that maps StoreID to NodeID. To generate from the source cluster, run the following command:\n \n"+
+				"cockroach sql --url \"<(unix/sql) url>\" --format tsv -e \\\n  \"select concat(store_id::string, ': ', node_id::string)"+
+				"from crdb_internal.kv_store_status\" | \\\n  grep -E '[0-9]+: [0-9]+' | tee tsdump.gob.yaml\n \n"+
+				"To create from a debug.zip file, run the following command:\n \n"+
+				"tail -n +2 debug/crdb_internal.kv_store_status.txt | awk '{print $2 \": \" $1}' > tsdump.gob.yaml\n \n"+
+				"Then export the created file: export COCKROACH_DEBUG_TS_IMPORT_MAPPING_FILE=tsdump.gob.yaml\n \n")
+		}
 		return err
 	}
 	storeToNode := map[roachpb.StoreID]roachpb.NodeID{}


### PR DESCRIPTION
Prior to recent changes, the mapping file defaulted to `<gobfile>.yaml`.
This default made sense and is resurrected here.

We rely on this in roachtest artifacts, and it's generally a useful
enough convention to keep around.

Release note: None
