### PR TITLE
sql/importer,kv/bulk: reset BulkAdder between files

### DIFF
--- a/pkg/kv/kvserver/kvserverbase/bulk_adder.go
+++ b/pkg/kv/kvserver/kvserverbase/bulk_adder.go
@@ -91,6 +91,10 @@ type BulkAdder interface {
 	Close(ctx context.Context)
 	// SetOnFlush sets a callback function called after flushing the buffer.
 	SetOnFlush(func(summary roachpb.BulkOpSummary))
+	// Reset resets the BulkAdder for adding a new batch of input such as a new
+	// file, which may leave some state as-is such as aggregate statistics, but
+	// should reset all behavior-affecting state.
+	Reset()
 }
 
 // DuplicateKeyError represents a failed attempt to ingest the same key twice

--- a/pkg/sql/importer/import_processor_test.go
+++ b/pkg/sql/importer/import_processor_test.go
@@ -220,6 +220,7 @@ func (*doNothingKeyAdder) CurrentBufferFill() float32                   { return
 func (*doNothingKeyAdder) GetSummary() roachpb.BulkOpSummary            { return roachpb.BulkOpSummary{} }
 func (*doNothingKeyAdder) Close(_ context.Context)                      {}
 func (a *doNothingKeyAdder) SetOnFlush(f func(_ roachpb.BulkOpSummary)) { a.onFlush = f }
+func (a *doNothingKeyAdder) Reset()                                     {}
 
 var eofOffset int64 = math.MaxInt64
 


### PR DESCRIPTION
IMPORT uses one bulkAdder for the lifetime of the processor, and as that processor works its way through separate files, it keeps sending the output to that one bulk adder. If the processor is processing files containing ordered data, but processes those files out of order, this means that despite having ordered data in the files the bulk-adder is adding out-of-order data. To make matters worse, it may at the micro-scale see that it is adding in-order data that fills a range from left to right, and conclude that the span further to the right, that it has not filled yet, is empty and should be cheap to scatter before it continues on to fill it. However if a prior file passed to the adder covered some higher span, then that RHS is not actually empty. While the adder creates _initial_ splits when it first flushes, if data from a second file is then passed to it subsequently, that data has no such splits created, so the spans for files would lack the initial splits, which critically include a split at the first key, preventing ranges being ingested by two different processors, or two files in one processor, from overlapping. 

This changes the import processor to make its batcher earlier and reset it between each file, so every file gets initial splits including that critical first split.