### PR TITLE
colexecjoin: optimize building output on the left in cross joiner

### DIFF
--- a/pkg/sql/colexec/colexecjoin/crossjoiner.eg.go
+++ b/pkg/sql/colexec/colexecjoin/crossjoiner.eg.go
@@ -112,14 +112,16 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										}
 										if srcNulls.NullAt(srcStartIdx) {
 											outNulls.SetNullRange(outStartIdx, outStartIdx+toAppend)
-											outStartIdx += toAppend
 										} else {
+											outCol := outCol[outStartIdx:]
+											_ = outCol[toAppend-1]
 											val := srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol.Set(outStartIdx, val)
-												outStartIdx++
+												//gcassert:bce
+												outCol.Set(i, val)
 											}
 										}
+										outStartIdx += toAppend
 									}
 								}
 							}
@@ -138,8 +140,7 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										if srcNulls.NullAt(srcStartIdx) {
 											outNulls.SetNull(outStartIdx)
 										} else {
-											val := srcCol.Get(srcStartIdx)
-											outCol.Set(outStartIdx, val)
+											outCol.Copy(srcCol, outStartIdx, srcStartIdx)
 										}
 										outStartIdx++
 										bs.curSrcStartIdx++
@@ -168,14 +169,12 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										}
 										if srcNulls.NullAt(srcStartIdx) {
 											outNulls.SetNullRange(outStartIdx, outStartIdx+toAppend)
-											outStartIdx += toAppend
 										} else {
-											val := srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol.Set(outStartIdx, val)
-												outStartIdx++
+												outCol.Copy(srcCol, outStartIdx+i, srcStartIdx)
 											}
 										}
+										outStartIdx += toAppend
 									}
 								}
 							}
@@ -224,14 +223,16 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										}
 										if srcNulls.NullAt(srcStartIdx) {
 											outNulls.SetNullRange(outStartIdx, outStartIdx+toAppend)
-											outStartIdx += toAppend
 										} else {
+											outCol := outCol[outStartIdx:]
+											_ = outCol[toAppend-1]
 											val := srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol.Set(outStartIdx, val)
-												outStartIdx++
+												//gcassert:bce
+												outCol.Set(i, val)
 											}
 										}
+										outStartIdx += toAppend
 									}
 								}
 							}
@@ -279,14 +280,16 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										}
 										if srcNulls.NullAt(srcStartIdx) {
 											outNulls.SetNullRange(outStartIdx, outStartIdx+toAppend)
-											outStartIdx += toAppend
 										} else {
+											outCol := outCol[outStartIdx:]
+											_ = outCol[toAppend-1]
 											val := srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol.Set(outStartIdx, val)
-												outStartIdx++
+												//gcassert:bce
+												outCol.Set(i, val)
 											}
 										}
+										outStartIdx += toAppend
 									}
 								}
 							case 32:
@@ -331,14 +334,16 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										}
 										if srcNulls.NullAt(srcStartIdx) {
 											outNulls.SetNullRange(outStartIdx, outStartIdx+toAppend)
-											outStartIdx += toAppend
 										} else {
+											outCol := outCol[outStartIdx:]
+											_ = outCol[toAppend-1]
 											val := srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol.Set(outStartIdx, val)
-												outStartIdx++
+												//gcassert:bce
+												outCol.Set(i, val)
 											}
 										}
+										outStartIdx += toAppend
 									}
 								}
 							case -1:
@@ -384,14 +389,16 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										}
 										if srcNulls.NullAt(srcStartIdx) {
 											outNulls.SetNullRange(outStartIdx, outStartIdx+toAppend)
-											outStartIdx += toAppend
 										} else {
+											outCol := outCol[outStartIdx:]
+											_ = outCol[toAppend-1]
 											val := srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol.Set(outStartIdx, val)
-												outStartIdx++
+												//gcassert:bce
+												outCol.Set(i, val)
 											}
 										}
+										outStartIdx += toAppend
 									}
 								}
 							}
@@ -440,14 +447,16 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										}
 										if srcNulls.NullAt(srcStartIdx) {
 											outNulls.SetNullRange(outStartIdx, outStartIdx+toAppend)
-											outStartIdx += toAppend
 										} else {
+											outCol := outCol[outStartIdx:]
+											_ = outCol[toAppend-1]
 											val := srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol.Set(outStartIdx, val)
-												outStartIdx++
+												//gcassert:bce
+												outCol.Set(i, val)
 											}
 										}
+										outStartIdx += toAppend
 									}
 								}
 							}
@@ -496,14 +505,16 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										}
 										if srcNulls.NullAt(srcStartIdx) {
 											outNulls.SetNullRange(outStartIdx, outStartIdx+toAppend)
-											outStartIdx += toAppend
 										} else {
+											outCol := outCol[outStartIdx:]
+											_ = outCol[toAppend-1]
 											val := srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol.Set(outStartIdx, val)
-												outStartIdx++
+												//gcassert:bce
+												outCol.Set(i, val)
 											}
 										}
+										outStartIdx += toAppend
 									}
 								}
 							}
@@ -552,14 +563,16 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										}
 										if srcNulls.NullAt(srcStartIdx) {
 											outNulls.SetNullRange(outStartIdx, outStartIdx+toAppend)
-											outStartIdx += toAppend
 										} else {
+											outCol := outCol[outStartIdx:]
+											_ = outCol[toAppend-1]
 											val := srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol.Set(outStartIdx, val)
-												outStartIdx++
+												//gcassert:bce
+												outCol.Set(i, val)
 											}
 										}
+										outStartIdx += toAppend
 									}
 								}
 							}
@@ -578,8 +591,7 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										if srcNulls.NullAt(srcStartIdx) {
 											outNulls.SetNull(outStartIdx)
 										} else {
-											val := srcCol.Get(srcStartIdx)
-											outCol.Set(outStartIdx, val)
+											outCol.Copy(srcCol, outStartIdx, srcStartIdx)
 										}
 										outStartIdx++
 										bs.curSrcStartIdx++
@@ -608,14 +620,12 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										}
 										if srcNulls.NullAt(srcStartIdx) {
 											outNulls.SetNullRange(outStartIdx, outStartIdx+toAppend)
-											outStartIdx += toAppend
 										} else {
-											val := srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol.Set(outStartIdx, val)
-												outStartIdx++
+												outCol.Copy(srcCol, outStartIdx+i, srcStartIdx)
 											}
 										}
+										outStartIdx += toAppend
 									}
 								}
 							}
@@ -664,14 +674,13 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										}
 										if srcNulls.NullAt(srcStartIdx) {
 											outNulls.SetNullRange(outStartIdx, outStartIdx+toAppend)
-											outStartIdx += toAppend
 										} else {
 											val := srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol.Set(outStartIdx, val)
-												outStartIdx++
+												outCol.Set(outStartIdx+i, val)
 											}
 										}
+										outStartIdx += toAppend
 									}
 								}
 							}
@@ -751,14 +760,16 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										}
 										if srcNulls.NullAt(srcStartIdx) {
 											outNulls.SetNullRange(outStartIdx, outStartIdx+toAppend)
-											outStartIdx += toAppend
 										} else {
+											outCol := outCol[outStartIdx:]
+											_ = outCol[toAppend-1]
 											val := srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol.Set(outStartIdx, val)
-												outStartIdx++
+												//gcassert:bce
+												outCol.Set(i, val)
 											}
 										}
+										outStartIdx += toAppend
 									}
 								}
 							}
@@ -777,8 +788,7 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										if srcNulls.NullAt(srcStartIdx) {
 											outNulls.SetNull(outStartIdx)
 										} else {
-											val := srcCol.Get(srcStartIdx)
-											outCol.Set(outStartIdx, val)
+											outCol.Copy(srcCol, outStartIdx, srcStartIdx)
 										}
 										outStartIdx++
 										bs.curSrcStartIdx++
@@ -807,14 +817,12 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										}
 										if srcNulls.NullAt(srcStartIdx) {
 											outNulls.SetNullRange(outStartIdx, outStartIdx+toAppend)
-											outStartIdx += toAppend
 										} else {
-											val := srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol.Set(outStartIdx, val)
-												outStartIdx++
+												outCol.Copy(srcCol, outStartIdx+i, srcStartIdx)
 											}
 										}
+										outStartIdx += toAppend
 									}
 								}
 							}
@@ -863,14 +871,16 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										}
 										if srcNulls.NullAt(srcStartIdx) {
 											outNulls.SetNullRange(outStartIdx, outStartIdx+toAppend)
-											outStartIdx += toAppend
 										} else {
+											outCol := outCol[outStartIdx:]
+											_ = outCol[toAppend-1]
 											val := srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol.Set(outStartIdx, val)
-												outStartIdx++
+												//gcassert:bce
+												outCol.Set(i, val)
 											}
 										}
+										outStartIdx += toAppend
 									}
 								}
 							}
@@ -918,14 +928,16 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										}
 										if srcNulls.NullAt(srcStartIdx) {
 											outNulls.SetNullRange(outStartIdx, outStartIdx+toAppend)
-											outStartIdx += toAppend
 										} else {
+											outCol := outCol[outStartIdx:]
+											_ = outCol[toAppend-1]
 											val := srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol.Set(outStartIdx, val)
-												outStartIdx++
+												//gcassert:bce
+												outCol.Set(i, val)
 											}
 										}
+										outStartIdx += toAppend
 									}
 								}
 							case 32:
@@ -970,14 +982,16 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										}
 										if srcNulls.NullAt(srcStartIdx) {
 											outNulls.SetNullRange(outStartIdx, outStartIdx+toAppend)
-											outStartIdx += toAppend
 										} else {
+											outCol := outCol[outStartIdx:]
+											_ = outCol[toAppend-1]
 											val := srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol.Set(outStartIdx, val)
-												outStartIdx++
+												//gcassert:bce
+												outCol.Set(i, val)
 											}
 										}
+										outStartIdx += toAppend
 									}
 								}
 							case -1:
@@ -1023,14 +1037,16 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										}
 										if srcNulls.NullAt(srcStartIdx) {
 											outNulls.SetNullRange(outStartIdx, outStartIdx+toAppend)
-											outStartIdx += toAppend
 										} else {
+											outCol := outCol[outStartIdx:]
+											_ = outCol[toAppend-1]
 											val := srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol.Set(outStartIdx, val)
-												outStartIdx++
+												//gcassert:bce
+												outCol.Set(i, val)
 											}
 										}
+										outStartIdx += toAppend
 									}
 								}
 							}
@@ -1079,14 +1095,16 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										}
 										if srcNulls.NullAt(srcStartIdx) {
 											outNulls.SetNullRange(outStartIdx, outStartIdx+toAppend)
-											outStartIdx += toAppend
 										} else {
+											outCol := outCol[outStartIdx:]
+											_ = outCol[toAppend-1]
 											val := srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol.Set(outStartIdx, val)
-												outStartIdx++
+												//gcassert:bce
+												outCol.Set(i, val)
 											}
 										}
+										outStartIdx += toAppend
 									}
 								}
 							}
@@ -1135,14 +1153,16 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										}
 										if srcNulls.NullAt(srcStartIdx) {
 											outNulls.SetNullRange(outStartIdx, outStartIdx+toAppend)
-											outStartIdx += toAppend
 										} else {
+											outCol := outCol[outStartIdx:]
+											_ = outCol[toAppend-1]
 											val := srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol.Set(outStartIdx, val)
-												outStartIdx++
+												//gcassert:bce
+												outCol.Set(i, val)
 											}
 										}
+										outStartIdx += toAppend
 									}
 								}
 							}
@@ -1191,14 +1211,16 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										}
 										if srcNulls.NullAt(srcStartIdx) {
 											outNulls.SetNullRange(outStartIdx, outStartIdx+toAppend)
-											outStartIdx += toAppend
 										} else {
+											outCol := outCol[outStartIdx:]
+											_ = outCol[toAppend-1]
 											val := srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol.Set(outStartIdx, val)
-												outStartIdx++
+												//gcassert:bce
+												outCol.Set(i, val)
 											}
 										}
+										outStartIdx += toAppend
 									}
 								}
 							}
@@ -1217,8 +1239,7 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										if srcNulls.NullAt(srcStartIdx) {
 											outNulls.SetNull(outStartIdx)
 										} else {
-											val := srcCol.Get(srcStartIdx)
-											outCol.Set(outStartIdx, val)
+											outCol.Copy(srcCol, outStartIdx, srcStartIdx)
 										}
 										outStartIdx++
 										bs.curSrcStartIdx++
@@ -1247,14 +1268,12 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										}
 										if srcNulls.NullAt(srcStartIdx) {
 											outNulls.SetNullRange(outStartIdx, outStartIdx+toAppend)
-											outStartIdx += toAppend
 										} else {
-											val := srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol.Set(outStartIdx, val)
-												outStartIdx++
+												outCol.Copy(srcCol, outStartIdx+i, srcStartIdx)
 											}
 										}
+										outStartIdx += toAppend
 									}
 								}
 							}
@@ -1303,14 +1322,13 @@ func (b *crossJoinerBase) buildFromLeftInput(ctx context.Context, destStartIdx i
 										}
 										if srcNulls.NullAt(srcStartIdx) {
 											outNulls.SetNullRange(outStartIdx, outStartIdx+toAppend)
-											outStartIdx += toAppend
 										} else {
 											val := srcCol.Get(srcStartIdx)
 											for i := 0; i < toAppend; i++ {
-												outCol.Set(outStartIdx, val)
-												outStartIdx++
+												outCol.Set(outStartIdx+i, val)
 											}
 										}
+										outStartIdx += toAppend
 									}
 								}
 							}

--- a/pkg/sql/colexec/colexecjoin/crossjoiner_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/crossjoiner_tmpl.go
@@ -87,8 +87,12 @@ func buildFromLeftBatch(b *crossJoinerBase, currentBatch coldata.Batch, sel []in
 						if srcNulls.NullAt(srcStartIdx) {
 							outNulls.SetNull(outStartIdx)
 						} else {
+							// {{if .IsBytesLike}}
+							outCol.Copy(srcCol, outStartIdx, srcStartIdx)
+							// {{else}}
 							val := srcCol.Get(srcStartIdx)
 							outCol.Set(outStartIdx, val)
+							// {{end}}
 						}
 						outStartIdx++
 						bs.curSrcStartIdx++
@@ -102,6 +106,7 @@ func buildFromLeftBatch(b *crossJoinerBase, currentBatch coldata.Batch, sel []in
 						} else {
 							srcStartIdx = bs.curSrcStartIdx
 						}
+						// {{/* toAppend will always be positive. */}}
 						toAppend := leftNumRepeats - bs.numRepeatsIdx
 						if outStartIdx+toAppend > outputCapacity {
 							// We don't have enough space to repeat the current
@@ -120,14 +125,40 @@ func buildFromLeftBatch(b *crossJoinerBase, currentBatch coldata.Batch, sel []in
 						}
 						if srcNulls.NullAt(srcStartIdx) {
 							outNulls.SetNullRange(outStartIdx, outStartIdx+toAppend)
-							outStartIdx += toAppend
 						} else {
+							// {{if not .IsBytesLike}}
+							// {{if .Sliceable}}
+							outCol := outCol[outStartIdx:]
+							_ = outCol[toAppend-1]
+							// {{end}}
 							val := srcCol.Get(srcStartIdx)
+							// {{end}}
 							for i := 0; i < toAppend; i++ {
-								outCol.Set(outStartIdx, val)
-								outStartIdx++
+								// {{if .IsBytesLike}}
+								outCol.Copy(srcCol, outStartIdx+i, srcStartIdx)
+								// {{else}}
+								// {{if .Sliceable}}
+								// {{/*
+								//     For the sliceable types, we sliced outCol
+								//     to start at outStartIdx, so we use index
+								//     i directly.
+								// */}}
+								//gcassert:bce
+								outCol.Set(i, val)
+								// {{else}}
+								// {{/*
+								//     For the non-sliceable types, outCol
+								//     vector is the original one (i.e. without
+								//     an adjustment), so we need to add
+								//     outStartIdx to set the element at the
+								//     correct index.
+								// */}}
+								outCol.Set(outStartIdx+i, val)
+								// {{end}}
+								// {{end}}
 							}
 						}
+						outStartIdx += toAppend
 					}
 				}
 				// {{end}}


### PR DESCRIPTION
This commit updates the way we're building output in the cross joiner
from the left input (also used by the merge joiner when building from
the buffered group). There, we need to repeat a single tuple `toAppend`
times, so we do it in a loop. This commit adds the optimization of
using `Bytes.Copy` for the bytes-like types as well as BCE for
sliceable types.
```
name                                                   old speed      new speed       delta
CrossJoiner/spillForced=false/type=INNER/rows=1-24     1.01MB/s ± 1%   1.00MB/s ± 2%   -1.18%  (p=0.013 n=10+10)
CrossJoiner/spillForced=false/type=INNER/rows=16-24     207MB/s ± 0%    205MB/s ± 2%   -0.76%  (p=0.023 n=10+10)
CrossJoiner/spillForced=false/type=INNER/rows=256-24   6.77GB/s ± 1%   7.78GB/s ± 0%  +14.92%  (p=0.000 n=10+8)
CrossJoiner/spillForced=false/type=INNER/rows=2048-24  8.87GB/s ± 1%  10.33GB/s ± 0%  +16.55%  (p=0.000 n=9+9)
CrossJoiner/spillForced=false/type=INNER/rows=8192-24  8.92GB/s ± 1%  10.39GB/s ± 1%  +16.52%  (p=0.000 n=10+10)
```
```
name                                       old speed      new speed      delta
MergeJoiner/rows=32-24                     34.7MB/s ± 2%  34.6MB/s ± 3%    ~     (p=0.896 n=10+10)
MergeJoiner/rows=512-24                    94.7MB/s ± 3%  94.6MB/s ± 2%    ~     (p=0.619 n=10+9)
MergeJoiner/rows=4096-24                    235MB/s ± 1%   233MB/s ± 1%  -0.94%  (p=0.004 n=9+10)
MergeJoiner/rows=32768-24                   341MB/s ± 3%   340MB/s ± 2%    ~     (p=0.315 n=10+10)
MergeJoiner/oneSideRepeat-rows=32-24       44.1MB/s ± 2%  44.1MB/s ± 3%    ~     (p=0.839 n=10+10)
MergeJoiner/oneSideRepeat-rows=512-24       252MB/s ± 2%   262MB/s ± 2%  +3.93%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=4096-24      904MB/s ± 1%   953MB/s ± 2%  +5.50%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=32768-24    1.45GB/s ± 1%  1.53GB/s ± 2%  +5.43%  (p=0.000 n=10+9)
MergeJoiner/bothSidesRepeat-rows=32-24     27.1MB/s ± 1%  27.2MB/s ± 2%    ~     (p=0.722 n=10+10)
MergeJoiner/bothSidesRepeat-rows=512-24     124MB/s ± 3%   127MB/s ± 2%  +2.55%  (p=0.001 n=10+10)
MergeJoiner/bothSidesRepeat-rows=4096-24    150MB/s ± 1%   152MB/s ± 1%  +1.25%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=32768-24  84.8MB/s ± 1%  86.4MB/s ± 0%  +1.93%  (p=0.000 n=10+10)
```

Release note: None