### PR TITLE
release: generate sentry panic

### DIFF
--- a/pkg/cmd/release/BUILD.bazel
+++ b/pkg/cmd/release/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "orchestration.go",
         "pick_sha.go",
         "sender.go",
+        "sentry.go",
         "templates.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/release",

--- a/pkg/cmd/release/pick_sha.go
+++ b/pkg/cmd/release/pick_sha.go
@@ -150,5 +150,9 @@ func pickSHA(_ *cobra.Command, _ []string) error {
 	if err := sendMailPickSHA(args, opts); err != nil {
 		return fmt.Errorf("cannot send email: %w", err)
 	}
+	fmt.Println("Generating panic")
+	if err := generatePanic(nextRelease.buildInfo.Tag); err != nil {
+		return fmt.Errorf("cannot generate panic: %w", err)
+	}
 	return nil
 }

--- a/pkg/cmd/release/sentry.go
+++ b/pkg/cmd/release/sentry.go
@@ -1,0 +1,34 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// generatePanic downloads the cockroachdb binary and forces a panic crash in order to trigger a Sentry event,
+// which should file a GitHub issue.
+func generatePanic(tag string) error {
+	// the call usually exits non-zero on panic, but we don't need to fail in that case, thus "|| true"
+	// TODO: do not hardcode the URL
+	script := fmt.Sprintf(`
+curl https://cockroach-builds.s3.amazonaws.com/cockroach-%s.linux-amd64.tgz | tar -xz
+./cockroach-%s.linux-amd64/cockroach demo --insecure -e "select crdb_internal.force_panic('testing')" || true
+`, tag, tag)
+	cmd := exec.Command("bash", "-c", script)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to generate panic. output was: %s, err: %w", string(out), err)
+	}
+	fmt.Println(string(out))
+	return nil
+}


### PR DESCRIPTION
Previously, to generate a test panic and test its submission to Sentry
and GitHub, a release driver would need to download a binary to their
laptop and run a command. Usually this meant, that we tested against a
Darwin binary.

This patch makes the pick SHA phase to run this step.

Release note: None