### PR TITLE
spanconfigsqltranslator: skip PTS tests

### DIFF
--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/protectedts
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/protectedts
@@ -121,9 +121,10 @@ translate system-span-configurations
 {source=1,target=111}                      protection_policies=[{ts: 3}]
 {source=1,target=112}                      protection_policies=[{ts: 3}]
 
-translate database=db
-----
-/Table/106{-/2}                            num_replicas=7 num_voters=5 protection_policies=[{ts: 6}]
-/Table/106/{2-3}                           ttl_seconds=1 num_replicas=7 num_voters=5 protection_policies=[{ts: 6}]
-/Table/10{6/3-7}                           num_replicas=7 num_voters=5 protection_policies=[{ts: 6}]
-/Table/10{7-8}                             num_replicas=7
+# TODO(arul): Unskip this.
+# translate database=db
+# ----
+# /Table/106{-/2}                            num_replicas=7 num_voters=5 protection_policies=[{ts: 6}]
+# /Table/106/{2-3}                           ttl_seconds=1 num_replicas=7 num_voters=5 protection_policies=[{ts: 6}]
+# /Table/10{6/3-7}                           num_replicas=7 num_voters=5 protection_policies=[{ts: 6}]
+# /Table/10{7-8}                             num_replicas=7

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/protectedts
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/protectedts
@@ -103,9 +103,10 @@ translate system-span-configurations
 ----
 {source=10,target=10}                      protection_policies=[{ts: 3}]
 
-translate database=db
-----
-/Tenant/10/Table/106{-/2}                  num_replicas=7 num_voters=5 protection_policies=[{ts: 5}]
-/Tenant/10/Table/106/{2-3}                 ttl_seconds=1 num_replicas=7 num_voters=5 protection_policies=[{ts: 5}]
-/Tenant/10/Table/10{6/3-7}                 num_replicas=7 num_voters=5 protection_policies=[{ts: 5}]
-/Tenant/10/Table/10{7-8}                   num_replicas=7
+# TODO(arul): Unskip this.
+# translate database=db
+# ----
+# /Tenant/10/Table/106{-/2}                  num_replicas=7 num_voters=5 protection_policies=[{ts: 5}]
+# /Tenant/10/Table/106/{2-3}                 ttl_seconds=1 num_replicas=7 num_voters=5 protection_policies=[{ts: 5}]
+# /Tenant/10/Table/10{6/3-7}                 num_replicas=7 num_voters=5 protection_policies=[{ts: 5}]
+# /Tenant/10/Table/10{7-8}                   num_replicas=7


### PR DESCRIPTION
These seem to be failing reliably on master with errors like:

```
                expected:
                /Tenant/10/Table/106{-/2}                  num_replicas=7 num_voters=5 protection_policies=[{ts: 5}]
                /Tenant/10/Table/106/{2-3}                 ttl_seconds=1 num_replicas=7 num_voters=5 protection_policies=[{ts: 5}]
                /Tenant/10/Table/10{6/3-7}                 num_replicas=7 num_voters=5 protection_policies=[{ts: 5}]
                /Tenant/10/Table/10{7-8}                   num_replicas=7

                found:
                /Tenant/10/Table/106{-/2}                  num_replicas=7 num_voters=5 protection_policies=[{ts: 5}]
                /Tenant/10/Table/106/{2-3}                 ttl_seconds=1 num_replicas=7 num_voters=5 protection_policies=[{ts: 5}]
                /Tenant/10/Table/106/{3-4}                 ttl_seconds=1 num_replicas=7 num_voters=5 protection_policies=[{ts: 5}]
                /Tenant/10/Table/10{6/4-7}                 num_replicas=7 num_voters=5 protection_policies=[{ts: 5}]
                /Tenant/10/Table/10{7-8}                   num_replicas=7
```

Of note is the /Tenant/10/Table/106/{3-4} -- which is a range carved
for an index with ID 3. We only have one index set up in this test
(ID 2). This might have something to do with temp indexes, but I'm not
sure how/why it would come into play here. Nevertheless, while we
investigate, it's worth skipping this test.

Release note: None