### PR TITLE
spanconfigsqltranslator: update test output

### DIFF
--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/protectedts
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/protectedts
@@ -121,10 +121,10 @@ translate system-span-configurations
 {source=1,target=111}                      protection_policies=[{ts: 3}]
 {source=1,target=112}                      protection_policies=[{ts: 3}]
 
-# TODO(arul): Unskip this.
-# translate database=db
-# ----
-# /Table/106{-/2}                            num_replicas=7 num_voters=5 protection_policies=[{ts: 6}]
-# /Table/106/{2-3}                           ttl_seconds=1 num_replicas=7 num_voters=5 protection_policies=[{ts: 6}]
-# /Table/10{6/3-7}                           num_replicas=7 num_voters=5 protection_policies=[{ts: 6}]
-# /Table/10{7-8}                             num_replicas=7
+translate database=db
+----
+/Table/106{-/2}                            num_replicas=7 num_voters=5 protection_policies=[{ts: 6}]
+/Table/106/{2-3}                           ttl_seconds=1 num_replicas=7 num_voters=5 protection_policies=[{ts: 6}]
+/Table/106/{3-4}                           ttl_seconds=1 num_replicas=7 num_voters=5 protection_policies=[{ts: 6}]
+/Table/10{6/4-7}                           num_replicas=7 num_voters=5 protection_policies=[{ts: 6}]
+/Table/10{7-8}                             num_replicas=7

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/protectedts
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/protectedts
@@ -103,10 +103,10 @@ translate system-span-configurations
 ----
 {source=10,target=10}                      protection_policies=[{ts: 3}]
 
-# TODO(arul): Unskip this.
-# translate database=db
-# ----
-# /Tenant/10/Table/106{-/2}                  num_replicas=7 num_voters=5 protection_policies=[{ts: 5}]
-# /Tenant/10/Table/106/{2-3}                 ttl_seconds=1 num_replicas=7 num_voters=5 protection_policies=[{ts: 5}]
-# /Tenant/10/Table/10{6/3-7}                 num_replicas=7 num_voters=5 protection_policies=[{ts: 5}]
-# /Tenant/10/Table/10{7-8}                   num_replicas=7
+translate database=db
+----
+/Tenant/10/Table/106{-/2}                  num_replicas=7 num_voters=5 protection_policies=[{ts: 5}]
+/Tenant/10/Table/106/{2-3}                 ttl_seconds=1 num_replicas=7 num_voters=5 protection_policies=[{ts: 5}]
+/Tenant/10/Table/106/{3-4}                 ttl_seconds=1 num_replicas=7 num_voters=5 protection_policies=[{ts: 5}]
+/Tenant/10/Table/10{6/4-7}                 num_replicas=7 num_voters=5 protection_policies=[{ts: 5}]
+/Tenant/10/Table/10{7-8}                   num_replicas=7


### PR DESCRIPTION
Fallout from #78087 which caused a merge-skew. Now that we're setting
zone configurations on temporary indexes as well, we expect the
SQLTranslator to pick them up.

Release note: None