### PR TITLE
sql/catalog/descs: fix descriptor lookup during public schema migration

### DIFF
--- a/pkg/sql/catalog/descs/database.go
+++ b/pkg/sql/catalog/descs/database.go
@@ -60,8 +60,10 @@ func (tc *Collection) GetDatabaseDesc(
 func (tc *Collection) getDatabaseByName(
 	ctx context.Context, txn *kv.Txn, name string, flags tree.DatabaseLookupFlags,
 ) (catalog.DatabaseDescriptor, error) {
+	const alwaysLookupLeasedPublicSchema = false
 	found, desc, err := tc.getByName(
 		ctx, txn, nil, nil, name, flags.AvoidLeased, flags.RequireMutable, flags.AvoidSynthetic,
+		alwaysLookupLeasedPublicSchema,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/catalog/descs/descriptor.go
+++ b/pkg/sql/catalog/descs/descriptor.go
@@ -271,13 +271,17 @@ func (tc *Collection) getByName(
 	sc catalog.SchemaDescriptor,
 	name string,
 	avoidLeased, mutable, avoidSynthetic bool,
+	alwaysLookupLeasedPublicSchema bool, // passed through to getSchemaByName
 ) (found bool, desc catalog.Descriptor, err error) {
 	var parentID, parentSchemaID descpb.ID
 	if db != nil {
 		if sc == nil {
 			// Schema descriptors are handled in a special way, see getSchemaByName
 			// function declaration for details.
-			return getSchemaByName(ctx, tc, txn, db, name, avoidLeased, mutable, avoidSynthetic)
+			return getSchemaByName(
+				ctx, tc, txn, db, name, avoidLeased, mutable, avoidSynthetic,
+				alwaysLookupLeasedPublicSchema,
+			)
 		}
 		parentID, parentSchemaID = db.GetID(), sc.GetID()
 	}
@@ -338,7 +342,7 @@ func (tc *Collection) getByName(
 	if err != nil {
 		return false, nil, err
 	}
-	return true, descs[0], err
+	return descs[0] != nil, descs[0], err
 }
 
 // withReadFromStore updates the state of the Collection, especially its
@@ -385,6 +389,16 @@ func (tc *Collection) deadlineHolder(txn *kv.Txn) deadlineHolder {
 //
 // TODO(ajwerner): Understand and rationalize the namespace lookup given the
 // schema lookup by ID path only returns descriptors owned by this session.
+//
+// The alwaysLookupLeasedPublicSchema parameter indicates that a missing public
+// schema entry in the database descriptor should not be interpreted to
+// mean that the public schema is the synthetic public schema, and, instead
+// the public schema should be looked up via the lease manager by name.
+// This is a workaround activated during the public schema migration to
+// avoid a situation where the database does not know about the new public
+// schema but the table in the lease manager does.
+//
+// TODO(ajwerner): Remove alwaysLookupLeasedPublicSchema in 22.2.
 func getSchemaByName(
 	ctx context.Context,
 	tc *Collection,
@@ -392,8 +406,17 @@ func getSchemaByName(
 	db catalog.DatabaseDescriptor,
 	name string,
 	avoidLeased, mutable, avoidSynthetic bool,
+	alwaysLookupLeasedPublicSchema bool,
 ) (bool, catalog.Descriptor, error) {
 	if !db.HasPublicSchemaWithDescriptor() && name == tree.PublicSchema {
+		// TODO(ajwerner): Remove alwaysLookupLeasedPublicSchema in 22.2.
+		if alwaysLookupLeasedPublicSchema {
+			desc, _, err := tc.leased.getByName(ctx, txn, db.GetID(), 0, catconstants.PublicSchemaName)
+			if err != nil {
+				return false, desc, err
+			}
+			return true, desc, nil
+		}
 		return true, schemadesc.GetPublicSchema(), nil
 	}
 	if sc := tc.virtual.getSchemaByName(name); sc != nil {

--- a/pkg/sql/catalog/descs/object.go
+++ b/pkg/sql/catalog/descs/object.go
@@ -13,6 +13,8 @@ package descs
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
@@ -61,8 +63,10 @@ func (tc *Collection) getObjectByName(
 			err = sqlerrors.NewUndefinedRelationError(&tn)
 		}
 	}()
+	const alwaysLookupLeasedPublicSchema = false
 	prefix, desc, err = tc.getObjectByNameIgnoringRequiredAndType(
 		ctx, txn, catalogName, schemaName, objectName, flags,
+		alwaysLookupLeasedPublicSchema,
 	)
 	if err != nil || desc == nil {
 		return prefix, nil, err
@@ -136,6 +140,7 @@ func (tc *Collection) getObjectByNameIgnoringRequiredAndType(
 	txn *kv.Txn,
 	catalogName, schemaName, objectName string,
 	flags tree.ObjectLookupFlags,
+	alwaysLookupLeasedPublicSchema bool,
 ) (prefix catalog.ResolvedObjectPrefix, _ catalog.Descriptor, err error) {
 
 	flags.Required = false
@@ -184,8 +189,9 @@ func (tc *Collection) getObjectByNameIgnoringRequiredAndType(
 
 	// Read the ID of the schema out of the database descriptor
 	// to avoid the need to go look up the schema.
-
-	sc, err := tc.getSchemaByName(ctx, txn, db, schemaName, parentFlags)
+	sc, err := tc.getSchemaByNameMaybeLookingUpPublicSchema(
+		ctx, txn, db, schemaName, parentFlags, alwaysLookupLeasedPublicSchema,
+	)
 	if err != nil || sc == nil {
 		return prefix, nil, err
 	}
@@ -193,10 +199,33 @@ func (tc *Collection) getObjectByNameIgnoringRequiredAndType(
 	prefix.Schema = sc
 	found, obj, err := tc.getByName(
 		ctx, txn, db, sc, objectName, flags.AvoidLeased, flags.RequireMutable, flags.AvoidSynthetic,
+		false, // alwaysLookupLeasedPublicSchema
 	)
 	if !found || err != nil {
+		// We add a special case to deal with the public schema migration. During
+		// that migration, we create a real descriptor for the public schema and we
+		// re-parent the members of the descriptor-less public schema into this new
+		// schema. The hazard is that we have a lease on the database descriptor
+		// which does not know about the new public schema, but the table we're
+		// going to lease does. When we fail to find the descriptor we're looking
+		// for and notice that we're using the old public schema ID, and that we're
+		// in the midst of the relevant migration, then we go back around through
+		// the same logic but with a flag (alwaysLookupLeasedPublicSchema) which will
+		// suppress the assumption that a missing public schema implies a public
+		// synthetic ID=29 public schema, and force resolution of the correct
+		// schema ID.
+		//
+		// TODO(ajwerner): Remove this for 22.2.
+		if !alwaysLookupLeasedPublicSchema && sc.GetID() == keys.PublicSchemaID &&
+			!tc.settings.Version.IsActive(ctx, clusterversion.PublicSchemasWithDescriptors) &&
+			tc.settings.Version.IsActive(ctx, clusterversion.PublicSchemasWithDescriptors-1) {
+			const alwaysLookupLeasedPublicSchema = true
+			return tc.getObjectByNameIgnoringRequiredAndType(
+				ctx, txn, catalogName, schemaName, objectName, flags,
+				alwaysLookupLeasedPublicSchema,
+			)
+		}
 		return prefix, nil, err
 	}
-
 	return prefix, obj, nil
 }

--- a/pkg/sql/catalog/descs/schema.go
+++ b/pkg/sql/catalog/descs/schema.go
@@ -66,8 +66,27 @@ func (tc *Collection) getSchemaByName(
 	schemaName string,
 	flags tree.SchemaLookupFlags,
 ) (catalog.SchemaDescriptor, error) {
+	const alwaysLookupLeasedPublicSchema = false
+	return tc.getSchemaByNameMaybeLookingUpPublicSchema(
+		ctx, txn, db, schemaName, flags, alwaysLookupLeasedPublicSchema,
+	)
+}
+
+// Like getSchemaByName but with the optional flag to avoid trusting a
+// cache miss in the database descriptor for the ID of the public schema.
+//
+// TODO(ajwerner): Remove this split in 22.2.
+func (tc *Collection) getSchemaByNameMaybeLookingUpPublicSchema(
+	ctx context.Context,
+	txn *kv.Txn,
+	db catalog.DatabaseDescriptor,
+	schemaName string,
+	flags tree.SchemaLookupFlags,
+	alwaysLookupLeasedPublicSchema bool,
+) (catalog.SchemaDescriptor, error) {
 	found, desc, err := tc.getByName(
-		ctx, txn, db, nil, schemaName, flags.AvoidLeased, flags.RequireMutable, flags.AvoidSynthetic,
+		ctx, txn, db, nil, schemaName, flags.AvoidLeased, flags.RequireMutable,
+		flags.AvoidSynthetic, alwaysLookupLeasedPublicSchema,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR adds some special-case logic to the descs.Collection to deal with the
situation when the public schema is moving from being vitual to being a real
schema descriptor. During this transition, it's possible for the table in the
lease manager to have been updated before the database descriptor which would
contain the reference to the new public schema. The trick is that we want to
fall back to resolving the public schema for the database in the case where
we know we're in the midst of this migration and we fail to find a descriptor
at the virtual public schema ID.

The change ends up being rather minimal. The test, as written, would fail
readily under stress before the change. The cost of this change should be
pretty minimal: in some rare cases, one extra lookup may need to occur to
find the correct public schema and one extra lookup will occur due to the
cache miss with the old schema ID. 

Fixes #75805.

Release note: None