### PR TITLE
steamingccl: Support rangefeed initial scan in replication streaming

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 )
@@ -153,9 +152,9 @@ func ingestionPlanHook(
 		}
 
 		// TODO(adityamaru): Add privileges checks. Probably the same as RESTORE.
-
 		prefix := keys.MakeTenantPrefix(ingestionStmt.Targets.TenantID.TenantID)
-		startTime := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
+		// Empty start time indicates initial scan is enabled.
+		startTime := hlc.Timestamp{}
 		if ingestionStmt.AsOf.Expr != nil {
 			asOf, err := p.EvalAsOfTimestamp(ctx, ingestionStmt.AsOf)
 			if err != nil {

--- a/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
@@ -10,7 +10,6 @@ package streamingest
 
 import (
 	"context"
-	gosql "database/sql"
 	"fmt"
 	"net/url"
 	"testing"
@@ -29,33 +28,148 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
-func startTestClusterWithTenant(
-	ctx context.Context,
-	t *testing.T,
-	serverArgs base.TestServerArgs,
-	tenantID roachpb.TenantID,
-	numNodes int,
-) (serverutils.TestClusterInterface, *gosql.DB, *gosql.DB, func()) {
-	params := base.TestClusterArgs{ServerArgs: serverArgs}
-	c := testcluster.StartTestCluster(t, numNodes, params)
-	// TODO(casper): support adding splits when we have multiple nodes.
-	_, tenantConn := serverutils.StartTenant(t, c.Server(0), base.TestTenantArgs{TenantID: tenantID})
-	return c, c.ServerConn(0), tenantConn, func() {
-		tenantConn.Close()
-		c.Stopper().Stop(ctx)
-	}
+type execFunc func(t *testing.T, sysSQL *sqlutils.SQLRunner, tenantSQL *sqlutils.SQLRunner)
+
+type tenantStreamingClustersArgs struct {
+	srcTenantID roachpb.TenantID
+	srcInitFunc execFunc
+	srcNumNodes int
+
+	destTenantID roachpb.TenantID
+	destInitFunc execFunc
+	destNumNodes int
 }
 
-func compareResult(t *testing.T, src *sqlutils.SQLRunner, dest *sqlutils.SQLRunner, query string) {
-	sourceData := src.QueryStr(t, query)
-	destData := dest.QueryStr(t, query)
-	require.Equal(t, sourceData, destData)
+type tenantStreamingClusters struct {
+	t            *testing.T
+	args         tenantStreamingClustersArgs
+	srcSysSQL    *sqlutils.SQLRunner
+	srcTenantSQL *sqlutils.SQLRunner
+	srcURL       url.URL
+
+	destSysSQL    *sqlutils.SQLRunner
+	destTenantSQL *sqlutils.SQLRunner
 }
+
+func (c *tenantStreamingClusters) compareResult(query string) {
+	sourceData := c.srcTenantSQL.QueryStr(c.t, query)
+	destData := c.destTenantSQL.QueryStr(c.t, query)
+	require.Equal(c.t, sourceData, destData)
+}
+
+func (c *tenantStreamingClusters) cutover(
+	producerJobID, ingestionJobID int, cutoverTime time.Time,
+) {
+	// Wait for the job high watermark to reach the given cutover time.
+	testutils.SucceedsSoon(c.t, func() error {
+		progress := jobutils.GetJobProgress(c.t, c.destSysSQL, jobspb.JobID(ingestionJobID))
+		if progress.GetHighWater() == nil {
+			return errors.Newf("stream ingestion has not recorded any progress yet, waiting to advance pos %s",
+				cutoverTime.String())
+		}
+		highwater := *progress.GetHighWater()
+		if highwater.GoTime().Before(cutoverTime) {
+			return errors.Newf("waiting for stream ingestion job progress %s to advance beyond %s",
+				highwater.String(), cutoverTime.String())
+		}
+		return nil
+	})
+
+	// Cut over the ingestion job and the job will stop eventually.
+	c.destSysSQL.Exec(c.t, `SELECT crdb_internal.complete_stream_ingestion_job($1, $2)`, ingestionJobID, cutoverTime)
+	jobutils.WaitForJobToSucceed(c.t, c.destSysSQL, jobspb.JobID(ingestionJobID))
+	// TODO(casper): Make producer job exit normally in the cutover scenario.
+	c.srcSysSQL.CheckQueryResultsRetry(c.t,
+		fmt.Sprintf("SELECT status, error FROM [SHOW JOBS] WHERE job_id = %d", producerJobID),
+		[][]string{{"failed", fmt.Sprintf("replication stream %d timed out", producerJobID)}})
+}
+
+// Returns producer job ID and ingestion job ID.
+func (c *tenantStreamingClusters) startStreamReplication(startTime string) (int, int) {
+	var ingestionJobID, streamProducerJobID int
+	streamReplStmt := fmt.Sprintf("RESTORE TENANT %s FROM REPLICATION STREAM FROM '%s'",
+		c.args.srcTenantID, c.srcURL.String())
+	if startTime != "" {
+		streamReplStmt = streamReplStmt + fmt.Sprintf(" AS OF SYSTEM TIME %s", startTime)
+	}
+	c.destSysSQL.QueryRow(c.t, streamReplStmt).Scan(&ingestionJobID)
+	c.srcSysSQL.CheckQueryResultsRetry(c.t,
+		"SELECT count(*) FROM [SHOW JOBS] WHERE job_type = 'STREAM REPLICATION'", [][]string{{"1"}})
+	c.srcSysSQL.QueryRow(c.t, "SELECT job_id FROM [SHOW JOBS] WHERE job_type = 'STREAM REPLICATION'").
+		Scan(&streamProducerJobID)
+	return streamProducerJobID, ingestionJobID
+}
+
+func createtenantStreamingClusters(
+	ctx context.Context, t *testing.T, args tenantStreamingClustersArgs,
+) (*tenantStreamingClusters, func()) {
+	serverArgs := base.TestServerArgs{Knobs: base.TestingKnobs{
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()},
+	}
+
+	startTestClusterWithTenant := func(
+		ctx context.Context,
+		t *testing.T,
+		serverArgs base.TestServerArgs,
+		tenantID roachpb.TenantID,
+		numNodes int,
+	) (*sqlutils.SQLRunner, *sqlutils.SQLRunner, url.URL, func()) {
+		params := base.TestClusterArgs{ServerArgs: serverArgs}
+		c := testcluster.StartTestCluster(t, numNodes, params)
+		// TODO(casper): support adding splits when we have multiple nodes.
+		_, tenantConn := serverutils.StartTenant(t, c.Server(0), base.TestTenantArgs{TenantID: tenantID})
+		pgURL, cleanupSinkCert := sqlutils.PGUrl(t, c.Server(0).ServingSQLAddr(), t.Name(), url.User(security.RootUser))
+		return sqlutils.MakeSQLRunner(c.ServerConn(0)), sqlutils.MakeSQLRunner(tenantConn), pgURL, func() {
+			require.NoError(t, tenantConn.Close())
+			c.Stopper().Stop(ctx)
+			cleanupSinkCert()
+		}
+	}
+
+	// Start the source cluster.
+	sourceSysSQL, sourceTenantSQL, srcURL, srcCleanup := startTestClusterWithTenant(ctx, t, serverArgs, args.srcTenantID, args.srcNumNodes)
+	// Start the destination cluster.
+	destSysSQL, destTenantSQL, _, destCleanup := startTestClusterWithTenant(ctx, t, serverArgs, args.destTenantID, args.destNumNodes)
+
+	args.srcInitFunc(t, sourceSysSQL, sourceTenantSQL)
+	args.destInitFunc(t, destSysSQL, destTenantSQL)
+	return &tenantStreamingClusters{
+			t:             t,
+			args:          args,
+			srcSysSQL:     sourceSysSQL,
+			srcTenantSQL:  sourceTenantSQL,
+			srcURL:        srcURL,
+			destSysSQL:    destSysSQL,
+			destTenantSQL: destTenantSQL,
+		}, func() {
+			destCleanup()
+			srcCleanup()
+		}
+}
+
+func (c *tenantStreamingClusters) srcExec(exec execFunc) {
+	exec(c.t, c.srcSysSQL, c.srcTenantSQL)
+}
+
+var srcClusterSetting = `
+	SET CLUSTER SETTING kv.rangefeed.enabled = true;
+	SET CLUSTER SETTING kv.closed_timestamp.target_duration = '1s';
+	SET CLUSTER SETTING changefeed.experimental_poll_interval = '10ms';
+  SET CLUSTER SETTING stream_replication.job_liveness_timeout = '3s';
+  SET CLUSTER SETTING stream_replication.stream_liveness_track_frequency = '2s';
+  SET CLUSTER SETTING stream_replication.min_checkpoint_frequency = '1s';
+`
+
+var destClusterSetting = `
+	SET enable_experimental_stream_replication = true;
+	SET CLUSTER SETTING stream_replication.consumer_heartbeat_frequency = '100ms';
+	SET CLUSTER SETTING bulkio.stream_ingestion.minimum_flush_interval = '10ms';
+	SET CLUSTER SETTING bulkio.stream_ingestion.cutover_signal_poll_interval = '100ms';
+`
 
 func TestPartitionedTenantStreamingEndToEnd(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -65,53 +179,17 @@ func TestPartitionedTenantStreamingEndToEnd(t *testing.T) {
 	skip.UnderStress(t, "slow under stress")
 
 	ctx := context.Background()
-	args := base.TestServerArgs{Knobs: base.TestingKnobs{
-		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()},
-	}
-
-	// Start the source cluster.
-	tenantID := serverutils.TestTenantID()
-	sc, sourceSysDB, sourceTenantDB, srcCleanup := startTestClusterWithTenant(ctx, t, args, tenantID, 3)
-	defer srcCleanup()
-	sourceSysSQL, sourceTenantSQL := sqlutils.MakeSQLRunner(sourceSysDB), sqlutils.MakeSQLRunner(sourceTenantDB)
-
-	sourceSysSQL.Exec(t, `
-	SET CLUSTER SETTING kv.rangefeed.enabled = true;
-	SET CLUSTER SETTING kv.closed_timestamp.target_duration = '1s';
-	SET CLUSTER SETTING changefeed.experimental_poll_interval = '10ms';
-  SET CLUSTER SETTING stream_replication.job_liveness_timeout = '3s';
-  SET CLUSTER SETTING stream_replication.stream_liveness_track_frequency = '2s';
-  SET CLUSTER SETTING stream_replication.min_checkpoint_frequency = '1s';
-  `)
-
-	// Start the destination cluster.
-	_, destSysDB, destTenantDB, destCleanup := startTestClusterWithTenant(ctx, t, args, tenantID, 2)
-	defer destCleanup()
-	destSysSQL, destTenantSQL := sqlutils.MakeSQLRunner(destSysDB), sqlutils.MakeSQLRunner(destTenantDB)
-
-	destSysSQL.Exec(t, `
-	SET CLUSTER SETTING stream_replication.consumer_heartbeat_frequency = '100ms';
-	SET CLUSTER SETTING bulkio.stream_ingestion.minimum_flush_interval = '10ms';
-	SET CLUSTER SETTING bulkio.stream_ingestion.cutover_signal_poll_interval = '100ms';
-	SET enable_experimental_stream_replication = true;
-	`)
-
-	pgURL, cleanupSinkCert := sqlutils.PGUrl(t, sc.Server(0).ServingSQLAddr(), t.Name(), url.User(security.RootUser))
-	defer cleanupSinkCert()
-
-	var startTime string
-	sourceSysSQL.QueryRow(t, "SELECT cluster_logical_timestamp()").Scan(&startTime)
-	var ingestionJobID, streamProducerJobID int
-	destSysSQL.QueryRow(t,
-		`RESTORE TENANT `+tenantID.String()+` FROM REPLICATION STREAM FROM $1 AS OF SYSTEM TIME `+startTime,
-		pgURL.String(),
-	).Scan(&ingestionJobID)
-	sourceSysSQL.CheckQueryResultsRetry(t,
-		"SELECT count(*) FROM [SHOW JOBS] WHERE job_type = 'STREAM REPLICATION'", [][]string{{"1"}})
-	sourceSysSQL.QueryRow(t, "SELECT job_id FROM [SHOW JOBS] WHERE job_type = 'STREAM REPLICATION'").
-		Scan(&streamProducerJobID)
-
-	sourceTenantSQL.Exec(t, `
+	testTenantStreaming := func(t *testing.T, withInitialScan bool) {
+		// 'startTime' is a timestamp before we insert any data into the source cluster.
+		var startTime string
+		c, cleanup := createtenantStreamingClusters(ctx, t, tenantStreamingClustersArgs{
+			srcTenantID: roachpb.MakeTenantID(10),
+			srcInitFunc: func(t *testing.T, sysSQL *sqlutils.SQLRunner, tenantSQL *sqlutils.SQLRunner) {
+				sysSQL.Exec(t, srcClusterSetting)
+				if withInitialScan {
+					sysSQL.QueryRow(t, "SELECT cluster_logical_timestamp()").Scan(&startTime)
+				}
+				tenantSQL.Exec(t, `
 	CREATE DATABASE d;
 	CREATE TABLE d.t1(i int primary key, a string, b string);
 	CREATE TABLE d.t2(i int primary key);
@@ -119,41 +197,40 @@ func TestPartitionedTenantStreamingEndToEnd(t *testing.T) {
 	INSERT INTO d.t2 VALUES (2);
 	UPDATE d.t1 SET b = 'world' WHERE i = 42;
 	`)
-
-	sourceTenantSQL.Exec(t, `
+				tenantSQL.Exec(t, `
 	ALTER TABLE d.t1 DROP COLUMN b;
 	`)
+			},
+			srcNumNodes:  3,
+			destTenantID: roachpb.MakeTenantID(10),
+			destInitFunc: func(t *testing.T, sysSQL *sqlutils.SQLRunner, tenantSQL *sqlutils.SQLRunner) {
+				sysSQL.Exec(t, destClusterSetting)
+			},
+			destNumNodes: 2,
+		})
+		defer cleanup()
 
-	// Pick a cutover time, then wait for the job to reach that time.
-	cutoverTime := timeutil.Now().Round(time.Microsecond)
-	testutils.SucceedsSoon(t, func() error {
-		progress := jobutils.GetJobProgress(t, destSysSQL, jobspb.JobID(ingestionJobID))
-		if progress.GetHighWater() == nil {
-			return errors.Newf("stream ingestion has not recorded any progress yet, waiting to advance pos %s",
-				cutoverTime.String())
-		}
-		highwater := timeutil.Unix(0, progress.GetHighWater().WallTime)
-		if highwater.Before(cutoverTime) {
-			return errors.Newf("waiting for stream ingestion job progress %s to advance beyond %s",
-				highwater.String(), cutoverTime.String())
-		}
-		return nil
+		var cutoverTime time.Time
+		c.srcExec(func(t *testing.T, sysSQL *sqlutils.SQLRunner, tenantSQL *sqlutils.SQLRunner) {
+			sysSQL.QueryRow(t, "SELECT clock_timestamp()").Scan(&cutoverTime)
+		})
+		producerJobID, ingestionJobID := c.startStreamReplication(startTime)
+
+		c.cutover(producerJobID, ingestionJobID, cutoverTime)
+		c.compareResult("SELECT * FROM d.t1")
+		c.compareResult("SELECT * FROM d.t2")
+		// After cutover, changes to source won't be streamed into destination cluster.
+		c.srcExec(func(t *testing.T, sysSQL *sqlutils.SQLRunner, tenantSQL *sqlutils.SQLRunner) {
+			tenantSQL.Exec(t, `INSERT INTO d.t2 VALUES (3);`)
+		})
+		require.Equal(t, [][]string{{"2"}}, c.destTenantSQL.QueryStr(t, "SELECT * FROM d.t2"))
+	}
+
+	t.Run("initial-scan", func(t *testing.T) {
+		testTenantStreaming(t, true /* withInitialScan */)
 	})
 
-	compareResult(t, sourceTenantSQL, destTenantSQL, "SELECT * FROM d.t1")
-	compareResult(t, sourceTenantSQL, destTenantSQL, "SELECT * FROM d.t2")
-
-	// Cut over the ingestion job and the job will stop eventually.
-	destSysSQL.Exec(t, `SELECT crdb_internal.complete_stream_ingestion_job($1, $2)`, ingestionJobID, cutoverTime)
-	jobutils.WaitForJobToSucceed(t, destSysSQL, jobspb.JobID(ingestionJobID))
-	// TODO(casper): Make producer job exit normally in the cutover scenario.
-	sourceSysSQL.CheckQueryResultsRetry(t,
-		fmt.Sprintf("SELECT status, error FROM [SHOW JOBS] WHERE job_id = %d", streamProducerJobID),
-		[][]string{{"failed", fmt.Sprintf("replication stream %d timed out", streamProducerJobID)}})
-
-	// After cutover, changes to source won't be streamed into destination cluster.
-	sourceTenantSQL.Exec(t, `
-	INSERT INTO d.t2 VALUES (3);
-	`)
-	require.Equal(t, [][]string{{"2"}}, destTenantSQL.QueryStr(t, "SELECT * FROM d.t2"))
+	t.Run("no-initial-scan", func(t *testing.T) {
+		testTenantStreaming(t, false /* withInitialScan */)
+	})
 }

--- a/pkg/ccl/streamingccl/streamproducer/event_stream.go
+++ b/pkg/ccl/streamingccl/streamproducer/event_stream.go
@@ -106,7 +106,7 @@ func (s *eventStream) Start(ctx context.Context, txn *kv.Txn) error {
 		opts = append(opts,
 			rangefeed.WithInitialScan(func(ctx context.Context) {}),
 			rangefeed.WithScanRetryBehavior(rangefeed.ScanRetryRemaining),
-
+			rangefeed.WithRowTimestampInInitialScan(true),
 			rangefeed.WithOnInitialScanError(func(ctx context.Context, err error) (shouldFail bool) {
 				// TODO(yevgeniy): Update metrics
 				return false


### PR DESCRIPTION
This change supports users to enable initial scan when AsOf clause is not specified.

Release note (sql change): 'RESTORE TENANT tenant_id FROM REPLICATION STREAM FROM addr'
(as of time not specified) will enable initial scan.

Release justification: Cat 4.

Closes: https://github.com/cockroachdb/cockroach/issues/78397