### PR TITLE
changefeedccl: remove tenant timestamp protection gates

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -86,7 +86,6 @@ go_library(
         "//pkg/util/duration",
         "//pkg/util/encoding",
         "//pkg/util/envutil",
-        "//pkg/util/errorutil",
         "//pkg/util/hlc",
         "//pkg/util/httputil",
         "//pkg/util/humanizeutil",

--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -43,11 +43,6 @@ func emitResolvedTimestamp(
 	return nil
 }
 
-func shouldProtectTimestamps(codec keys.SQLCodec) bool {
-	// TODO(smiskin): Remove this restriction once tenant based pts are enabled
-	return codec.ForSystemTenant()
-}
-
 // createProtectedTimestampRecord will create a record to protect the spans for
 // this changefeed at the resolved timestamp. The progress struct will be
 // updated to refer to this new protected timestamp record.

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1514,16 +1514,14 @@ func (cf *changeFrontier) checkpointJobProgress(
 		changefeedProgress := progress.Details.(*jobspb.Progress_Changefeed).Changefeed
 		changefeedProgress.Checkpoint = &checkpoint
 
-		if shouldProtectTimestamps(cf.flowCtx.Codec()) {
-			timestampManager := cf.manageProtectedTimestamps
-			// TODO(samiskin): Remove this conditional and the associated deprecated
-			// methods once we're confident in ActiveProtectedTimestampsEnabled
-			if !changefeedbase.ActiveProtectedTimestampsEnabled.Get(&cf.flowCtx.Cfg.Settings.SV) {
-				timestampManager = cf.deprecatedManageProtectedTimestamps
-			}
-			if err := timestampManager(cf.Ctx, txn, changefeedProgress); err != nil {
-				log.Warningf(cf.Ctx, "error managing protected timestamp record: %v", err)
-			}
+		timestampManager := cf.manageProtectedTimestamps
+		// TODO(samiskin): Remove this conditional and the associated deprecated
+		// methods once we're confident in ActiveProtectedTimestampsEnabled
+		if !changefeedbase.ActiveProtectedTimestampsEnabled.Get(&cf.flowCtx.Cfg.Settings.SV) {
+			timestampManager = cf.deprecatedManageProtectedTimestamps
+		}
+		if err := timestampManager(cf.Ctx, txn, changefeedProgress); err != nil {
+			log.Warningf(cf.Ctx, "error managing protected timestamp record: %v", err)
 		}
 
 		if updateRunStatus {

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -448,12 +448,6 @@ func TestChangefeedTenantsExternalIOEnabled(t *testing.T) {
 	tenantSQL.Exec(t, serverSetupStatements)
 	tenantSQL.Exec(t, `CREATE TABLE foo_in_tenant (pk INT PRIMARY KEY)`)
 
-	t.Run("sinkful changefeed fails if protect_data_from_gc_on_pause is set", func(t *testing.T) {
-		tenantSQL.ExpectErr(t, "operation is unsupported in multi-tenancy mode",
-			`CREATE CHANGEFEED FOR foo_in_tenant INTO 'kafka://does-not-matter' WITH protect_data_from_gc_on_pause`,
-		)
-	})
-
 	t.Run("sinkful changefeed works", func(t *testing.T) {
 		f := makeKafkaFeedFactory(&testServerShim{
 			TestTenantInterface: tenantServer,


### PR DESCRIPTION
Now that protected timestamps function in tenants in 22.1 the pts gates in
changefeeds can be removed.

Resolves #76936

Release justification: low risk change turning off now-unneeded gates
Release note (enterprise change): changefeeds can now protect targets
from gc on user tenants