### PR TITLE
workload: support fixture import in multi-tenant mode

### DIFF
--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -352,7 +352,16 @@ func ImportFixture(
 
 	var numNodes int
 	if err := sqlDB.QueryRow(numNodesQuery).Scan(&numNodes); err != nil {
-		return 0, err
+		if strings.Contains(err.Error(), "operation is unsupported in multi-tenancy mode") {
+			// If the query is unsupported because we're in multi-tenant mode. Assume
+			// that the cluster has 1 node for the purposes of running CSV servers.
+			// Tenants won't use DistSQL to parallelize IMPORT across SQL pods. Doing
+			// something better here is tracked in:
+			//  https://github.com/cockroachdb/cockroach/issues/78968
+			numNodes = 1
+		} else {
+			return 0, err
+		}
 	}
 
 	var bytesAtomic int64


### PR DESCRIPTION
Fixes #75449.

This commit fixes fixture import into tenants, which do not have access to the `crdb_internal.gossip_liveness` table. This fixes the following:
- `[cockroach] workload fixtures import`
- `[cockroach] workload init --data-loader=IMPORT`

Release justification: low-risk change that improves workload functionality.