### PR TITLE
roachtest: bump max wh for weekly tpccbench/nodes=12/cpu=16

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -723,8 +723,8 @@ func registerTPCC(r registry.Registry) {
 		Nodes: 12,
 		CPUs:  16,
 
-		LoadWarehouses: gceOrAws(cloud, 8000, 10000),
-		EstimatedMax:   gceOrAws(cloud, 7000, 8000),
+		LoadWarehouses: gceOrAws(cloud, 10000, 10000),
+		EstimatedMax:   gceOrAws(cloud, 8000, 8000),
 
 		Tags: []string{`weekly`},
 	})


### PR DESCRIPTION
[It was maxing out, reliably.](https://roachperf.crdb.dev/?filter=&view=tpccbench%2Fnodes%3D12%2Fcpu%3D16&tab=gce)

Release note: None
