### PR TITLE
release-22.1: ccl/sqlproxyccl: remove routing rule fallback resolution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,6 +71,7 @@ require (
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/go-swagger/go-swagger v0.26.1
 	github.com/gogo/protobuf v1.3.2
+	github.com/gogo/status v1.1.0
 	github.com/golang-commonmark/markdown v0.0.0-20180910011815-a8f139058164
 	github.com/golang/geo v0.0.0-20200319012246-673a6f80352d
 	github.com/golang/mock v1.6.0
@@ -230,7 +231,6 @@ require (
 	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/gofrs/uuid v4.0.0+incompatible // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
-	github.com/gogo/status v1.1.0 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang-jwt/jwt/v4 v4.0.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/ccl/sqlproxyccl/idle",
         "//pkg/ccl/sqlproxyccl/interceptor",
         "//pkg/ccl/sqlproxyccl/tenant",
+        "//pkg/ccl/sqlproxyccl/tenantdirsvr",
         "//pkg/ccl/sqlproxyccl/throttler",
         "//pkg/roachpb",
         "//pkg/security/certmgr",
@@ -46,6 +47,7 @@ go_library(
         "@com_github_jackc_pgproto3_v2//:pgproto3",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//credentials/insecure",
         "@org_golang_google_grpc//status",
     ],
 )

--- a/pkg/ccl/sqlproxyccl/connector.go
+++ b/pkg/ccl/sqlproxyccl/connector.go
@@ -11,9 +11,7 @@ package sqlproxyccl
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"net"
-	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenant"
@@ -48,24 +46,10 @@ type connector struct {
 	TenantID    roachpb.TenantID
 
 	// DirectoryCache corresponds to the tenant directory cache, which will be
-	// used to resolve tenants to their corresponding IP addresses. If this
-	// isn't set, we will fallback to use RoutingRule.
+	// used to resolve tenants to their corresponding IP addresses.
 	//
-	// TODO(jaylim-crl): Remove the RoutingRule field. RoutingRule should not
-	// be in here.
-	//
-	// NOTE: This field is optional.
+	// NOTE: This field is required.
 	DirectoryCache tenant.DirectoryCache
-
-	// RoutingRule refers to the static rule that will be used when resolving
-	// tenants. This will be used directly whenever the DirectoryCache field
-	// isn't specified, or as a fallback if one was specified.
-	//
-	// The literal "{{clusterName}}" will be replaced with ClusterName within
-	// the RoutingRule string.
-	//
-	// NOTE: This field is optional, if DirectoryCache isn't set.
-	RoutingRule string
 
 	// StartupMsg represents the startup message associated with the client.
 	// This will be used when establishing a pgwire connection with the SQL pod.
@@ -234,19 +218,17 @@ func (c *connector) dialTenantCluster(ctx context.Context) (net.Conn, error) {
 				// Report the failure to the directory cache so that it can
 				// refresh any stale information that may have caused the
 				// problem.
-				if c.DirectoryCache != nil {
-					if err = reportFailureToDirectoryCache(
-						ctx, c.TenantID, serverAddr, c.DirectoryCache,
-					); err != nil {
-						reportFailureErrs++
-						if reportFailureErr.ShouldLog() {
-							log.Ops.Errorf(ctx,
-								"report failure (%d errors skipped): %v",
-								reportFailureErrs,
-								err,
-							)
-							reportFailureErrs = 0
-						}
+				if err = reportFailureToDirectoryCache(
+					ctx, c.TenantID, serverAddr, c.DirectoryCache,
+				); err != nil {
+					reportFailureErrs++
+					if reportFailureErr.ShouldLog() {
+						log.Ops.Errorf(ctx,
+							"report failure (%d errors skipped): %v",
+							reportFailureErrs,
+							err,
+						)
+						reportFailureErrs = 0
 					}
 				}
 				continue
@@ -269,9 +251,6 @@ func (c *connector) dialTenantCluster(ctx context.Context) (net.Conn, error) {
 	return nil, errors.Mark(err, ctx.Err())
 }
 
-// resolveTCPAddr indirection to allow test hooks.
-var resolveTCPAddr = net.ResolveTCPAddr
-
 // lookupAddr returns an address (that must include both host and port)
 // pointing to one of the SQL pods for the tenant associated with this
 // connector.
@@ -284,40 +263,22 @@ func (c *connector) lookupAddr(ctx context.Context) (string, error) {
 		return c.testingKnobs.lookupAddr(ctx)
 	}
 
-	// First try to lookup tenant in the directory cache (if available).
-	if c.DirectoryCache != nil {
-		addr, err := c.DirectoryCache.EnsureTenantAddr(ctx, c.TenantID, c.ClusterName)
-		switch {
-		case err == nil:
-			return addr, nil
-		case status.Code(err) == codes.FailedPrecondition:
-			if st, ok := status.FromError(err); ok {
-				return "", newErrorf(codeUnavailable, "%v", st.Message())
-			}
-			return "", newErrorf(codeUnavailable, "unavailable")
-		case status.Code(err) != codes.NotFound:
-			return "", markAsRetriableConnectorError(err)
-		default:
-			// Fallback to old resolution rule.
+	// Lookup tenant in the directory cache.
+	addr, err := c.DirectoryCache.EnsureTenantAddr(ctx, c.TenantID, c.ClusterName)
+	switch {
+	case err == nil:
+		return addr, nil
+	case status.Code(err) == codes.FailedPrecondition:
+		if st, ok := status.FromError(err); ok {
+			return "", newErrorf(codeUnavailable, "%v", st.Message())
 		}
-	}
-
-	// Derive DNS address and then try to resolve it. If it does not exist, then
-	// map to a GRPC NotFound error.
-	//
-	// TODO(jaylim-crl): This code is temporary. Remove this once we have fully
-	// replaced this with a Directory GRPC server. This fallback does not need
-	// to exist.
-	addr := strings.ReplaceAll(
-		c.RoutingRule, "{{clusterName}}",
-		fmt.Sprintf("%s-%d", c.ClusterName, c.TenantID.ToUint64()),
-	)
-	if _, err := resolveTCPAddr("tcp", addr); err != nil {
-		log.Errorf(ctx, "could not retrieve SQL server address: %v", err.Error())
+		return "", newErrorf(codeUnavailable, "unavailable")
+	case status.Code(err) == codes.NotFound:
 		return "", newErrorf(codeParamsRoutingFailed,
 			"cluster %s-%d not found", c.ClusterName, c.TenantID.ToUint64())
+	default:
+		return "", markAsRetriableConnectorError(err)
 	}
-	return addr, nil
 }
 
 // dialSQLServer dials the given address for the SQL pod, and forwards the

--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/denylist"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/idle"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenant"
+	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenantdirsvr"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/throttler"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/certmgr"
@@ -31,6 +32,7 @@ import (
 	"github.com/cockroachdb/logtags"
 	"github.com/jackc/pgproto3/v2"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 var (
@@ -76,6 +78,9 @@ type ProxyOptions struct {
 	// RoutingRule for constructing the backend address for each incoming
 	// connection. Optionally use '{{clusterName}}'
 	// which will be substituted with the cluster name.
+	//
+	// TODO(jaylim-crl): Rename RoutingRule to TestRoutingRule to be
+	// explicit that this is only used in a testing environment.
 	RoutingRule string
 	// DirectoryAddr specified optional {HOSTNAME}:{PORT} for service that does
 	// the resolution from backend id to IP address. If specified - it will be
@@ -173,33 +178,58 @@ func newProxyHandler(
 		throttler.WithBaseDelay(handler.ThrottleBaseDelay),
 	)
 
+	var conn *grpc.ClientConn
 	if handler.DirectoryAddr != "" {
-		//lint:ignore SA1019 grpc.WithInsecure is deprecated
-		conn, err := grpc.Dial(handler.DirectoryAddr, grpc.WithInsecure())
+		conn, err = grpc.Dial(
+			handler.DirectoryAddr,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
 		if err != nil {
 			return nil, err
 		}
-		// nolint:grpcconnclose
-		stopper.AddCloser(stop.CloserFn(func() { _ = conn.Close() /* nolint:grpcconnclose */ }))
-
-		// If a drain timeout has been specified, then start the idle monitor
-		// and the pod watcher. When a pod enters the DRAINING state, the pod
-		// watcher will set the idle monitor to detect connections without
-		// activity and terminate them.
-		var dirOpts []tenant.DirOption
-		if options.DrainTimeout != 0 {
-			handler.idleMonitor = idle.NewMonitor(ctx, options.DrainTimeout)
-
-			podWatcher := make(chan *tenant.Pod)
-			go handler.startPodWatcher(ctx, podWatcher)
-			dirOpts = append(dirOpts, tenant.PodWatcher(podWatcher))
-		}
-
-		client := tenant.NewDirectoryClient(conn)
-		handler.directoryCache, err = tenant.NewDirectoryCache(ctx, stopper, client, dirOpts...)
+	} else {
+		// If no directory address was specified, assume routing rule, and
+		// start an in-memory simple directory server.
+		_, grpcServer := tenantdirsvr.NewTestSimpleDirectoryServer(handler.RoutingRule)
+		ln, err := tenantdirsvr.ListenAndServeInMemGRPC(ctx, stopper, grpcServer)
 		if err != nil {
 			return nil, err
 		}
+
+		dialerFunc := func(ctx context.Context, addr string) (net.Conn, error) {
+			return ln.DialContext(ctx)
+		}
+		conn, err = grpc.DialContext(
+			ctx,
+			"",
+			grpc.WithContextDialer(dialerFunc),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+	stopper.AddCloser(stop.CloserFn(func() {
+		_ = conn.Close() // nolint:grpcconnclose
+	}))
+
+	// If a drain timeout has been specified, then start the idle monitor and
+	// the pod watcher. When a pod enters the DRAINING state, the pod watcher
+	// will set the idle monitor to detect connections without activity and
+	// terminate them.
+	var dirOpts []tenant.DirOption
+	if options.DrainTimeout != 0 {
+		handler.idleMonitor = idle.NewMonitor(ctx, options.DrainTimeout)
+
+		podWatcher := make(chan *tenant.Pod)
+		go handler.startPodWatcher(ctx, podWatcher)
+		dirOpts = append(dirOpts, tenant.PodWatcher(podWatcher))
+	}
+
+	client := tenant.NewDirectoryClient(conn)
+	handler.directoryCache, err = tenant.NewDirectoryCache(ctx, stopper, client, dirOpts...)
+	if err != nil {
+		return nil, err
 	}
 
 	return &handler, nil

--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -76,8 +76,7 @@ type ProxyOptions struct {
 	// Insecure if set, will not use TLS for the backend connection. For testing.
 	Insecure bool
 	// RoutingRule for constructing the backend address for each incoming
-	// connection. Optionally use '{{clusterName}}'
-	// which will be substituted with the cluster name.
+	// connection.
 	//
 	// TODO(jaylim-crl): Rename RoutingRule to TestRoutingRule to be
 	// explicit that this is only used in a testing environment.
@@ -102,9 +101,22 @@ type ProxyOptions struct {
 	// response to the first connection failure.
 	ThrottleBaseDelay time.Duration
 
-	// Used for testing.
+	// testingKnobs are knobs used for testing.
 	testingKnobs struct {
+		// afterForward gets invoked after a connection was being forwarded.
+		//
+		// TODO(jaylim-crl): Once the connection manager is in, we can consider
+		// retrieving the forwarder from there, and get rid of this variable
+		// entirely.
 		afterForward func(*forwarder) error
+
+		// dirOpts is used to customize the directory cache created by the
+		// proxy.
+		dirOpts []tenant.DirOption
+
+		// directoryServer represents the in-memory directory server that is
+		// created whenever a routing rule is used.
+		directoryServer tenant.DirectoryServer
 	}
 }
 
@@ -135,7 +147,7 @@ type proxyHandler struct {
 	// to their IP addresses.
 	directoryCache tenant.DirectoryCache
 
-	// CertManger keeps up to date the certificates used.
+	// certManager keeps up to date the certificates used.
 	certManager *certmgr.CertManager
 }
 
@@ -190,11 +202,12 @@ func newProxyHandler(
 	} else {
 		// If no directory address was specified, assume routing rule, and
 		// start an in-memory simple directory server.
-		_, grpcServer := tenantdirsvr.NewTestSimpleDirectoryServer(handler.RoutingRule)
+		directoryServer, grpcServer := tenantdirsvr.NewTestSimpleDirectoryServer(handler.RoutingRule)
 		ln, err := tenantdirsvr.ListenAndServeInMemGRPC(ctx, stopper, grpcServer)
 		if err != nil {
 			return nil, err
 		}
+		handler.testingKnobs.directoryServer = directoryServer
 
 		dialerFunc := func(ctx context.Context, addr string) (net.Conn, error) {
 			return ln.DialContext(ctx)
@@ -224,6 +237,9 @@ func newProxyHandler(
 		podWatcher := make(chan *tenant.Pod)
 		go handler.startPodWatcher(ctx, podWatcher)
 		dirOpts = append(dirOpts, tenant.PodWatcher(podWatcher))
+	}
+	if handler.testingKnobs.dirOpts != nil {
+		dirOpts = append(dirOpts, handler.testingKnobs.dirOpts...)
 	}
 
 	client := tenant.NewDirectoryClient(conn)
@@ -305,13 +321,10 @@ func (handler *proxyHandler) handle(ctx context.Context, incomingConn *proxyConn
 	}
 
 	connector := &connector{
-		ClusterName: clusterName,
-		TenantID:    tenID,
-		RoutingRule: handler.RoutingRule,
-		StartupMsg:  backendStartupMsg,
-	}
-	if handler.directoryCache != nil {
-		connector.DirectoryCache = handler.directoryCache
+		ClusterName:    clusterName,
+		TenantID:       tenID,
+		DirectoryCache: handler.directoryCache,
+		StartupMsg:     backendStartupMsg,
 	}
 
 	// TLS options for the proxy are split into Insecure and SkipVerify.

--- a/pkg/ccl/sqlproxyccl/tenant/directory_cache.go
+++ b/pkg/ccl/sqlproxyccl/tenant/directory_cache.go
@@ -182,8 +182,9 @@ func (d *directoryCache) EnsureTenantAddr(
 		return "", err
 	}
 
-	// Check the cluster name matches, if specified.
-	if clusterName != "" && clusterName != entry.ClusterName {
+	// Check if the cluster name matches. This can be skipped if clusterName
+	// is empty, or the ClusterName returned by the directory server is empty.
+	if clusterName != "" && entry.ClusterName != "" && clusterName != entry.ClusterName {
 		// Return a GRPC NotFound error.
 		log.Errorf(ctx, "cluster name %s doesn't match expected %s", clusterName, entry.ClusterName)
 		return "", status.Errorf(codes.NotFound,

--- a/pkg/ccl/sqlproxyccl/tenant/pod.go
+++ b/pkg/ccl/sqlproxyccl/tenant/pod.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The Cockroach Authors.
+// Copyright 2022 The Cockroach Authors.
 //
 // Licensed as a CockroachDB Enterprise file under the Cockroach Community
 // License (the "License"); you may not use this file except in compliance with

--- a/pkg/ccl/sqlproxyccl/tenantdirsvr/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/tenantdirsvr/BUILD.bazel
@@ -2,17 +2,26 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "tenantdirsvr",
-    srcs = ["test_directory_svr.go"],
+    srcs = [
+        "in_mem_listener.go",
+        "test_directory_svr.go",
+        "test_simple_directory_svr.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenantdirsvr",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ccl/sqlproxyccl/tenant",
         "//pkg/roachpb",
+        "//pkg/util/grpcutil",
         "//pkg/util/log",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
+        "@com_github_gogo_status//:status",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//test/bufconn",
     ],
 )

--- a/pkg/ccl/sqlproxyccl/tenantdirsvr/in_mem_listener.go
+++ b/pkg/ccl/sqlproxyccl/tenantdirsvr/in_mem_listener.go
@@ -1,0 +1,72 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package tenantdirsvr
+
+import (
+	"context"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/errors"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// ListenAndServeInMemGRPC is similar to netutil.ListenAndServeGRPC, but uses
+// an in-memory listener instead.
+func ListenAndServeInMemGRPC(
+	ctx context.Context, stopper *stop.Stopper, server *grpc.Server,
+) (*bufconn.Listener, error) {
+	// defaultListenerBufSize corresponds to the listener's in-memory buffer
+	// size. Since this is meant to be used within a test environment, 1 MiB
+	// should be sufficient.
+	const defaultListenerBufSize = 1 << 20 // 1 MiB
+
+	// Use bufconn to create an in-memory listener.
+	ln := bufconn.Listen(defaultListenerBufSize)
+
+	stopper.AddCloser(stop.CloserFn(server.GracefulStop))
+	waitQuiesce := func(context.Context) {
+		<-stopper.ShouldQuiesce()
+		fatalIfUnexpected(ln.Close())
+	}
+	if err := stopper.RunAsyncTask(ctx, "listen-quiesce", waitQuiesce); err != nil {
+		waitQuiesce(ctx)
+		return nil, err
+	}
+
+	if err := stopper.RunAsyncTask(ctx, "serve", func(context.Context) {
+		fatalIfUnexpected(server.Serve(ln))
+	}); err != nil {
+		return nil, err
+	}
+	return ln, nil
+}
+
+// fatalIfUnexpected calls Log.Fatal(err) unless err is nil, or an error that
+// comes from the net package indicating that the listener was closed or from
+// the Stopper indicating quiescence.
+//
+// NOTE: This is the same as netutil.FatalIfUnexpected, but calls our custom
+// isClosedConnection instead.
+func fatalIfUnexpected(err error) {
+	if err != nil && !isClosedConnection(err) && !errors.Is(err, stop.ErrUnavailable) {
+		log.Fatalf(context.TODO(), "%+v", err)
+	}
+}
+
+// isClosedConnection returns true if err's Cause is an error produced by gRPC
+// on closed connections. This wraps grpcutil.IsClosedConnection, and includes
+// a custom test for a "closed" error, which is returned by the bufconn listener
+// in https://github.com/grpc/grpc-go/blob/a82cc96f/test/bufconn/bufconn.go#L49.
+func isClosedConnection(err error) bool {
+	return grpcutil.IsClosedConnection(err) || strings.Contains(err.Error(), "closed")
+}

--- a/pkg/ccl/sqlproxyccl/tenantdirsvr/test_directory_svr.go
+++ b/pkg/ccl/sqlproxyccl/tenantdirsvr/test_directory_svr.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The Cockroach Authors.
+// Copyright 2022 The Cockroach Authors.
 //
 // Licensed as a CockroachDB Enterprise file under the Cockroach Community
 // License (the "License"); you may not use this file except in compliance with
@@ -104,7 +104,7 @@ func New(stopper *stop.Stopper, args ...string) (*TestDirectoryServer, error) {
 	dir.TenantStarterFunc = dir.startTenantLocked
 	dir.proc.processByAddrByTenantID = map[uint64]map[net.Addr]*Process{}
 	dir.listen.eventListeners = list.New()
-	stopper.AddCloser(stop.CloserFn(func() { dir.grpcServer.GracefulStop() }))
+	stopper.AddCloser(stop.CloserFn(dir.grpcServer.GracefulStop))
 	tenant.RegisterDirectoryServer(dir.grpcServer, dir)
 	return dir, nil
 }

--- a/pkg/ccl/sqlproxyccl/tenantdirsvr/test_simple_directory_svr.go
+++ b/pkg/ccl/sqlproxyccl/tenantdirsvr/test_simple_directory_svr.go
@@ -1,0 +1,132 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package tenantdirsvr
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenant"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/gogo/status"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+// TestSimpleDirectoryServer is a directory server that returns a single
+// pre-defined address for all tenants. It is expected that a SQL pod is
+// listening on that address.
+//
+// The metadata of such tenants will not have a clusterName returned, so
+// validation of cluster names through the directory cache will be skipped.
+type TestSimpleDirectoryServer struct {
+	// podAddr refers to the address of the SQL pod, which consists of both the
+	// host and port (e.g. "127.0.0.1:26257").
+	podAddr string
+
+	mu struct {
+		syncutil.Mutex
+
+		// deleted indicates that the tenant has been deleted. A NotFound
+		// error will be returned when trying to resume a SQL pod, or read the
+		// tenant's metadata.
+		deleted map[roachpb.TenantID]struct{}
+	}
+}
+
+var _ tenant.DirectoryServer = &TestSimpleDirectoryServer{}
+
+// NewTestSimpleDirectoryServer constructs a new simple directory server.
+func NewTestSimpleDirectoryServer(podAddr string) (tenant.DirectoryServer, *grpc.Server) {
+	dir := &TestSimpleDirectoryServer{podAddr: podAddr}
+	dir.mu.deleted = make(map[roachpb.TenantID]struct{})
+	grpcServer := grpc.NewServer()
+	tenant.RegisterDirectoryServer(grpcServer, dir)
+	return dir, grpcServer
+}
+
+// ListPods returns a list with a single RUNNING pod. The load of the pod will
+// always be zero, and the address of the pod will be the same regardless of
+// tenant ID. If the tenant has been deleted, no pods will be returned.
+//
+// ListPods implements the tenant.DirectoryServer interface.
+func (d *TestSimpleDirectoryServer) ListPods(
+	ctx context.Context, req *tenant.ListPodsRequest,
+) (*tenant.ListPodsResponse, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if _, ok := d.mu.deleted[roachpb.MakeTenantID(req.TenantID)]; ok {
+		return &tenant.ListPodsResponse{}, nil
+	}
+	return &tenant.ListPodsResponse{
+		Pods: []*tenant.Pod{
+			{
+				TenantID: req.TenantID,
+				Addr:     d.podAddr,
+				State:    tenant.RUNNING,
+			},
+		},
+	}, nil
+}
+
+// WatchPods is a no-op for the simple directory.
+//
+// WatchPods implements the tenant.DirectoryServer interface.
+func (d *TestSimpleDirectoryServer) WatchPods(
+	req *tenant.WatchPodsRequest, server tenant.Directory_WatchPodsServer,
+) error {
+	return nil
+}
+
+// EnsurePod is a no-op for the simple directory since it assumes that a SQL
+// pod is actively listening at the associated pod address. However, if the
+// tenant has been deleted, a GRPC NotFound error will be returned. This would
+// mimic the behavior that we have in the actual tenant directory.
+//
+// EnsurePod implements the tenant.DirectoryServer interface.
+func (d *TestSimpleDirectoryServer) EnsurePod(
+	ctx context.Context, req *tenant.EnsurePodRequest,
+) (*tenant.EnsurePodResponse, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if _, ok := d.mu.deleted[roachpb.MakeTenantID(req.TenantID)]; ok {
+		return nil, status.Errorf(codes.NotFound, "tenant has been deleted")
+	}
+	return &tenant.EnsurePodResponse{}, nil
+}
+
+// GetTenant returns an empty response regardless of tenants. However, if the
+// tenant has been deleted, a GRPC NotFound error will be returned.
+//
+// GetTenant implements the tenant.DirectoryServer interface.
+func (d *TestSimpleDirectoryServer) GetTenant(
+	ctx context.Context, req *tenant.GetTenantRequest,
+) (*tenant.GetTenantResponse, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if _, ok := d.mu.deleted[roachpb.MakeTenantID(req.TenantID)]; ok {
+		return nil, status.Errorf(codes.NotFound, "tenant has been deleted")
+	}
+	// Note that we do not return a ClusterName field here. Doing this skips
+	// the clusterName validation in the directory cache which makes testing
+	// easier. If we hardcoded a cluster name here, all connection strings will
+	// need to be updated to use that cluster name, including the one used by
+	// the ORM tests, which is currently hardcoded to "prancing-pony":
+	// https://github.com/cockroachdb/cockroach-go/blob/e1659d1d/testserver/tenant.go#L244.
+	return &tenant.GetTenantResponse{}, nil
+}
+
+// DeleteTenant marks the given tenant as deleted, so that a NotFound error
+// will be returned for certain directory server endpoints. This also changes
+// the behavior of ListPods so no pods are returned.
+func (d *TestSimpleDirectoryServer) DeleteTenant(tenantID roachpb.TenantID) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.mu.deleted[tenantID] = struct{}{}
+}

--- a/pkg/cli/cliflags/flags_mt.go
+++ b/pkg/cli/cliflags/flags_mt.go
@@ -55,10 +55,8 @@ var (
 	}
 
 	RoutingRule = FlagInfo{
-		Name: "routing-rule",
-		Description: `
-Routing rule for incoming connections. Use '{{clusterName}}' for substitution.
-This rule must include the port of the SQL pod.`,
+		Name:        "routing-rule",
+		Description: "Routing rule for incoming connections. This rule must include the port of the SQL pod.",
 	}
 
 	DirectoryAddr = FlagInfo{

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -864,6 +864,7 @@ func TestLint(t *testing.T) {
 			":!server/testserver.go",
 			":!util/tracing/*_test.go",
 			":!ccl/sqlproxyccl/tenantdirsvr/test_directory_svr.go",
+			":!ccl/sqlproxyccl/tenantdirsvr/test_simple_directory_svr.go",
 		)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Backport 2/2 commits from #78280.

/cc @cockroachdb/release

----

#### ccl/sqlproxyccl: add tenantdirsvr.testSimpleDirectoryServer 

This commit adds a new implementation of tenant.DirectoryServer which will be
used for testing. When a directory address is not passed to the proxy during
startup, a simple directory server, which is in-memory, will be created to
back the routing rule.

Release note: None

#### ccl/sqlproxyccl: remove routing rule fallback resolution

Previously, --routing-rule was used as a fallback resolution if a tenant
cannot be found from the directory cache. This feature is no longer needed
within cloud, and this commit addresses a TODO to remove that fallback. Since
the routing rule has proven to be handy in tests and local development, we've
chosen to maintain that, and made that an implementation of a directory server
instead. That way, all existing tests will exercise the directory cache as
well.

One side effect to that is that the --routing-rule flag no longer support
substitutions for the '{{clusterName}}' literal. This is fine as there was
no strong use case to maintain this substitution rule.

Release note: None

----

Release justification: sqlproxy only change. The upcoming proxy load rebalancing
work builds on top of this.
