### PR TITLE
opt: fix deduplication of unique constraints in test catalog

### DIFF
--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -553,14 +553,7 @@ func (tt *Table) addUniqueConstraint(
 	}
 	sort.Ints(cols)
 
-	// Don't add duplicate constraints.
-	for _, c := range tt.uniqueConstraints {
-		if reflect.DeepEqual(c.columnOrdinals, cols) && c.withoutIndex == withoutIndex {
-			return
-		}
-	}
-
-	// We didn't find an existing constraint, so add a new one.
+	// Create the constraint.
 	u := UniqueConstraint{
 		name:           tt.makeUniqueConstraintName(name, columns),
 		tabID:          tt.TabID,
@@ -572,6 +565,16 @@ func (tt *Table) addUniqueConstraint(
 	if predicate != nil {
 		u.predicate = tree.Serialize(predicate)
 	}
+
+	// Don't add duplicate constraints.
+	for _, c := range tt.uniqueConstraints {
+		if reflect.DeepEqual(c.columnOrdinals, u.columnOrdinals) &&
+			c.predicate == u.predicate &&
+			c.withoutIndex == u.withoutIndex {
+			return
+		}
+	}
+
 	tt.uniqueConstraints = append(tt.uniqueConstraints, u)
 }
 

--- a/pkg/sql/opt/testutils/testcat/testdata/table
+++ b/pkg/sql/opt/testutils/testcat/testdata/table
@@ -386,3 +386,32 @@ TABLE virtpk
  └── PRIMARY INDEX virtpk_pkey
       ├── v int not null as (a + 10) stored
       └── a int not null
+
+# Regression test for #76994. Only unique constraints with the same columns and
+# predicates should be deduplicated.
+exec-ddl
+CREATE TABLE t76994 (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  UNIQUE WITHOUT INDEX (a) WHERE b < 0,
+  UNIQUE WITHOUT INDEX (a) WHERE b < 0,
+  UNIQUE WITHOUT INDEX (a) WHERE b > 0
+)
+----
+
+exec-ddl
+SHOW CREATE t76994
+----
+TABLE t76994
+ ├── k int not null
+ ├── a int
+ ├── b int
+ ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
+ ├── tableoid oid [hidden] [system]
+ ├── PRIMARY INDEX t76994_pkey
+ │    └── k int not null
+ ├── UNIQUE WITHOUT INDEX (a)
+ │    └── WHERE b < 0
+ └── UNIQUE WITHOUT INDEX (a)
+      └── WHERE b > 0


### PR DESCRIPTION
This commit fixes a bug in the test catalog which incorrectly
de-duplicated unique constraints that had the same columns but different
predicates.

Fixes #76994

Release note: None