### PR TITLE
bors: require on a passing GitHub CI (Cockroach) on the PR

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -8,7 +8,7 @@ status = ["GitHub CI (Cockroach)"]
 # r+-ed. If it's still in progress (for e.g. if CI is still running), bors will
 # construct the merge commit in parallel and simply wait for success right
 # before merging.
-pr_status = ["license/cla", "blathers/release-justification-check"]
+pr_status = ["license/cla", "blathers/release-justification-check", "GitHub CI (Cockroach)"]
 
 # List of PR labels that may not be attached to a PR when it is r+-ed.
 block_labels = ["do-not-merge"]
@@ -16,8 +16,8 @@ block_labels = ["do-not-merge"]
 # Number of seconds from when a merge commit is created to when its statuses
 # must pass.
 #
-# Set to 4 hours
-timeout_sec = 14400
+# Set to 3 hours
+timeout_sec = 10800
 
 [committer]
 name = "craig[bot]"


### PR DESCRIPTION
Some of the build configurations were made to skip bors branches. This
changes bors to require a green GitHub CI run on the PR so the CI tests
are guaranteed to be run before the merge can happen.

This change also shortens the overall build run timeout to 3 hours.

Release note: None