### PR TITLE
kvserver: replica might crash evaluating a condition as leaseholder, …

### DIFF
--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -1210,11 +1210,20 @@ func (r *Replica) maybeTransferLeaseDuringLeaveJoint(
 	}
 
 	if voterIncomingTarget == (roachpb.ReplicaDescriptor{}) {
-		// Couldn't find a VOTER_INCOMING target. This should not happen since we only go into the
-		// JOINT config if the leaseholder is being removed, when there is a VOTER_INCOMING replica.
-		// Killing the leaseholder to force lease transfer.
-		log.Fatalf(ctx, "no VOTER_INCOMING to transfer lease to. "+
-			"Range descriptor: %v", desc)
+		// Couldn't find a VOTER_INCOMING target. When the leaseholder is being
+		// removed, we only enter a JOINT config if there is a VOTER_INCOMING
+		// replica. We also do not allow a demoted replica to accept the lease
+		// during a JOINT config. However, it is possible that our replica lost
+		// the lease and the new leaseholder is trying to remove it. In this case,
+		// it is possible that there is no VOTER_INCOMING replica.
+		// We check for this case in replica_raft propose, so here it is safe
+		// to continue trying to leave the JOINT config. If this is the case,
+		// our replica will not be able to leave the JOINT config, but the new
+		// leaseholder will be able to do so.
+		log.Infof(ctx, "no VOTER_INCOMING to transfer lease to. This replica probably lost the lease,"+
+			" but still thinks its the leaseholder. In this case the new leaseholder is expected to "+
+			"complete LEAVE_JOINT. Range descriptor: %v", desc)
+		return nil
 	}
 	log.VEventf(ctx, 5, "current leaseholder %v is being removed through an"+
 		" atomic replication change. Transferring lease to %v", r.String(), voterIncomingTarget)


### PR DESCRIPTION
…when it isn't

In https://github.com/cockroachdb/cockroach/pull/77841, we only remove the
leaseholder if there is a VOTER_INCOMING replica in the same JOINT config.
But it is also possible that a node A was the lesaeholder, and then the lease
gets transferred to node B, who tries to remove A. Since B isn't getting removed,
it is fine to enter a JOINT config without a VOTER_INCOMING node. But A
might still believe its the leaseholder, and this might cause it to
crash when it finds out that its in a JOINT config and there is no INCOMING node.
In this case, we can just continue, since an error will be thrown in replica_raft.go

This resolves https://github.com/cockroachdb/cockroach/issues/77937

Release note: None

Release justification: fixes flakiness caused by #77841