### PR TITLE
colexec: use Bytes.Copy instead of Get and Set in most places

### DIFF
--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -170,6 +170,9 @@ func NewBytes(n int) *Bytes {
 // Get returns the ith []byte in Bytes. Note that the returned byte slice is
 // unsafe for reuse if any write operation happens.
 //
+// If the returned value is then Set() into another Bytes, then use Bytes.Copy
+// instead.
+//
 // Note this function call is mostly inlined except in a handful of very large
 // generated functions, so we can't add the gcassert directive for it.
 func (b *Bytes) Get(i int) []byte {
@@ -177,6 +180,9 @@ func (b *Bytes) Get(i int) []byte {
 }
 
 // Set sets the ith []byte in Bytes.
+//
+// If the provided value is obtained via Get() from another Bytes, then use
+// Bytes.Copy instead.
 //
 // Note this function call is mostly inlined except in a handful of very large
 // generated functions, so we can't add the gcassert directive for it.

--- a/pkg/col/coldata/vec.eg.go
+++ b/pkg/col/coldata/vec.eg.go
@@ -966,8 +966,7 @@ func (m *memColumn) CopyWithReorderedSource(src Vec, sel, order []int) {
 					if nulls.NullAt(srcIdx) {
 						m.nulls.SetNull(destIdx)
 					} else {
-						v := fromCol.Get(srcIdx)
-						toCol.Set(destIdx, v)
+						toCol.Copy(fromCol, destIdx, srcIdx)
 					}
 				}
 			} else {
@@ -976,8 +975,7 @@ func (m *memColumn) CopyWithReorderedSource(src Vec, sel, order []int) {
 					destIdx := sel[i]
 					srcIdx := order[destIdx]
 					{
-						v := fromCol.Get(srcIdx)
-						toCol.Set(destIdx, v)
+						toCol.Copy(fromCol, destIdx, srcIdx)
 					}
 				}
 			}
@@ -1222,8 +1220,7 @@ func (m *memColumn) CopyWithReorderedSource(src Vec, sel, order []int) {
 					if nulls.NullAt(srcIdx) {
 						m.nulls.SetNull(destIdx)
 					} else {
-						v := fromCol.Get(srcIdx)
-						toCol.Set(destIdx, v)
+						toCol.Copy(fromCol, destIdx, srcIdx)
 					}
 				}
 			} else {
@@ -1232,8 +1229,7 @@ func (m *memColumn) CopyWithReorderedSource(src Vec, sel, order []int) {
 					destIdx := sel[i]
 					srcIdx := order[destIdx]
 					{
-						v := fromCol.Get(srcIdx)
-						toCol.Set(destIdx, v)
+						toCol.Copy(fromCol, destIdx, srcIdx)
 					}
 				}
 			}

--- a/pkg/col/coldata/vec_tmpl.go
+++ b/pkg/col/coldata/vec_tmpl.go
@@ -284,7 +284,7 @@ func _COPY_WITH_REORDERED_SOURCE(_SRC_HAS_NULLS bool) { // */}}
 		} else
 		// {{end}}
 		{
-			// {{if .IsBytesLike}}
+			// {{if .Global.IsBytesLike}}
 			toCol.Copy(fromCol, destIdx, srcIdx)
 			// {{else}}
 			v := fromCol.Get(srcIdx)

--- a/pkg/sql/colexec/colexecjoin/crossjoiner.eg.go
+++ b/pkg/sql/colexec/colexecjoin/crossjoiner.eg.go
@@ -1424,8 +1424,7 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 									if srcNulls.NullAt(bs.curSrcStartIdx) {
 										outNulls.SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(bs.curSrcStartIdx)
-										outCol.Set(outStartIdx, v)
+										outCol.Copy(srcCol, outStartIdx, bs.curSrcStartIdx)
 									}
 								} else {
 									out.Copy(
@@ -1632,8 +1631,7 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 									if srcNulls.NullAt(bs.curSrcStartIdx) {
 										outNulls.SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(bs.curSrcStartIdx)
-										outCol.Set(outStartIdx, v)
+										outCol.Copy(srcCol, outStartIdx, bs.curSrcStartIdx)
 									}
 								} else {
 									out.Copy(

--- a/pkg/sql/colexec/colexecjoin/crossjoiner_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/crossjoiner_tmpl.go
@@ -250,8 +250,12 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 									if srcNulls.NullAt(bs.curSrcStartIdx) {
 										outNulls.SetNull(outStartIdx)
 									} else {
+										// {{if .IsBytesLike}}
+										outCol.Copy(srcCol, outStartIdx, bs.curSrcStartIdx)
+										// {{else}}
 										v := srcCol.Get(bs.curSrcStartIdx)
 										outCol.Set(outStartIdx, v)
+										// {{end}}
 									}
 								} else {
 									out.Copy(

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
@@ -12626,8 +12626,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -13154,8 +13153,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -13365,8 +13363,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -13893,8 +13890,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
@@ -13744,8 +13744,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -14288,8 +14287,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -14505,8 +14503,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -15049,8 +15046,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
@@ -9356,8 +9356,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -9884,8 +9883,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -10095,8 +10093,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -10623,8 +10620,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
@@ -10060,8 +10060,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -10588,8 +10587,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -10799,8 +10797,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -11327,8 +11324,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
@@ -11570,8 +11570,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -12098,8 +12097,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -12309,8 +12307,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -12837,8 +12834,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
@@ -11552,8 +11552,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -12096,8 +12095,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -12313,8 +12311,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -12857,8 +12854,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
@@ -9312,8 +9312,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -9840,8 +9839,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -10051,8 +10049,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -10579,8 +10576,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
@@ -11504,8 +11504,7 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -12032,8 +12031,7 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -12243,8 +12241,7 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -12771,8 +12768,7 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
@@ -11548,8 +11548,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -12076,8 +12075,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -12287,8 +12285,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -12815,8 +12812,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
@@ -9268,8 +9268,7 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -9796,8 +9795,7 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -10007,8 +10005,7 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(
@@ -10535,8 +10532,7 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 											if srcNulls.NullAt(srcIdx) {
 												outNulls.SetNull(outStartIdx)
 											} else {
-												v := srcCol.Get(srcIdx)
-												outCol.Set(outStartIdx, v)
+												outCol.Copy(srcCol, outStartIdx, srcIdx)
 											}
 										} else {
 											out.Copy(

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
@@ -911,8 +911,12 @@ func _RIGHT_SWITCH(_JOIN_TYPE joinTypeInfo, _HAS_SELECTION bool) { // */}}
 							if srcNulls.NullAt(srcIdx) {
 								outNulls.SetNull(outStartIdx)
 							} else {
+								// {{if .IsBytesLike}}
+								outCol.Copy(srcCol, outStartIdx, srcIdx)
+								// {{else}}
 								v := srcCol.Get(srcIdx)
 								outCol.Set(outStartIdx, v)
+								// {{end}}
 							}
 						} else {
 							out.Copy(

--- a/pkg/sql/colexec/colexecwindow/first_last_nth_value_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/first_last_nth_value_tmpl.go
@@ -171,11 +171,15 @@ func (w *_OP_NAME_TYPEWindow) processBatch(batch coldata.Batch, startIdx, endIdx
 			continue
 		}
 		col := vec.TemplateType()
+		// {{if .IsBytesLike}}
+		outputCol.Copy(col, i, idx)
+		// {{else}}
 		val := col.Get(idx)
 		// {{if .Sliceable}}
 		//gcassert:bce
 		// {{end}}
 		outputCol.Set(i, val)
+		// {{end}}
 	}
 }
 

--- a/pkg/sql/colexec/colexecwindow/first_value.eg.go
+++ b/pkg/sql/colexec/colexecwindow/first_value.eg.go
@@ -205,8 +205,7 @@ func (w *firstValueBytesWindow) processBatch(batch coldata.Batch, startIdx, endI
 			continue
 		}
 		col := vec.Bytes()
-		val := col.Get(idx)
-		outputCol.Set(i, val)
+		outputCol.Copy(col, i, idx)
 	}
 }
 
@@ -507,8 +506,7 @@ func (w *firstValueJSONWindow) processBatch(batch coldata.Batch, startIdx, endId
 			continue
 		}
 		col := vec.JSON()
-		val := col.Get(idx)
-		outputCol.Set(i, val)
+		outputCol.Copy(col, i, idx)
 	}
 }
 

--- a/pkg/sql/colexec/colexecwindow/lag.eg.go
+++ b/pkg/sql/colexec/colexecwindow/lag.eg.go
@@ -315,8 +315,7 @@ func (w *lagBytesWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 						leadLagNulls.SetNull(i)
 						continue
 					}
-					val := defaultCol.Get(i)
-					leadLagCol.Set(i, val)
+					leadLagCol.Copy(defaultCol, i, i)
 					continue
 				}
 				vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
@@ -325,8 +324,7 @@ func (w *lagBytesWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 					continue
 				}
 				col := vec.Bytes()
-				val := col.Get(idx)
-				leadLagCol.Set(i, val)
+				leadLagCol.Copy(col, i, idx)
 			}
 			return
 		}
@@ -341,8 +339,7 @@ func (w *lagBytesWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 			w.idx++
 			if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 				// The offset is out of range, so set the output value to the default.
-				val := defaultCol.Get(i)
-				leadLagCol.Set(i, val)
+				leadLagCol.Copy(defaultCol, i, i)
 				continue
 			}
 			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
@@ -351,8 +348,7 @@ func (w *lagBytesWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 				continue
 			}
 			col := vec.Bytes()
-			val := col.Get(idx)
-			leadLagCol.Set(i, val)
+			leadLagCol.Copy(col, i, idx)
 		}
 		return
 	}
@@ -366,8 +362,7 @@ func (w *lagBytesWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 					leadLagNulls.SetNull(i)
 					continue
 				}
-				val := defaultCol.Get(i)
-				leadLagCol.Set(i, val)
+				leadLagCol.Copy(defaultCol, i, i)
 				continue
 			}
 			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
@@ -376,8 +371,7 @@ func (w *lagBytesWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 				continue
 			}
 			col := vec.Bytes()
-			val := col.Get(idx)
-			leadLagCol.Set(i, val)
+			leadLagCol.Copy(col, i, idx)
 		}
 		return
 	}
@@ -386,8 +380,7 @@ func (w *lagBytesWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 		w.idx++
 		if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 			// The offset is out of range, so set the output value to the default.
-			val := defaultCol.Get(i)
-			leadLagCol.Set(i, val)
+			leadLagCol.Copy(defaultCol, i, i)
 			continue
 		}
 		vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
@@ -396,8 +389,7 @@ func (w *lagBytesWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 			continue
 		}
 		col := vec.Bytes()
-		val := col.Get(idx)
-		leadLagCol.Set(i, val)
+		leadLagCol.Copy(col, i, idx)
 	}
 }
 
@@ -1367,8 +1359,7 @@ func (w *lagJSONWindow) processBatch(batch coldata.Batch, startIdx, endIdx int) 
 						leadLagNulls.SetNull(i)
 						continue
 					}
-					val := defaultCol.Get(i)
-					leadLagCol.Set(i, val)
+					leadLagCol.Copy(defaultCol, i, i)
 					continue
 				}
 				vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
@@ -1377,8 +1368,7 @@ func (w *lagJSONWindow) processBatch(batch coldata.Batch, startIdx, endIdx int) 
 					continue
 				}
 				col := vec.JSON()
-				val := col.Get(idx)
-				leadLagCol.Set(i, val)
+				leadLagCol.Copy(col, i, idx)
 			}
 			return
 		}
@@ -1393,8 +1383,7 @@ func (w *lagJSONWindow) processBatch(batch coldata.Batch, startIdx, endIdx int) 
 			w.idx++
 			if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 				// The offset is out of range, so set the output value to the default.
-				val := defaultCol.Get(i)
-				leadLagCol.Set(i, val)
+				leadLagCol.Copy(defaultCol, i, i)
 				continue
 			}
 			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
@@ -1403,8 +1392,7 @@ func (w *lagJSONWindow) processBatch(batch coldata.Batch, startIdx, endIdx int) 
 				continue
 			}
 			col := vec.JSON()
-			val := col.Get(idx)
-			leadLagCol.Set(i, val)
+			leadLagCol.Copy(col, i, idx)
 		}
 		return
 	}
@@ -1418,8 +1406,7 @@ func (w *lagJSONWindow) processBatch(batch coldata.Batch, startIdx, endIdx int) 
 					leadLagNulls.SetNull(i)
 					continue
 				}
-				val := defaultCol.Get(i)
-				leadLagCol.Set(i, val)
+				leadLagCol.Copy(defaultCol, i, i)
 				continue
 			}
 			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
@@ -1428,8 +1415,7 @@ func (w *lagJSONWindow) processBatch(batch coldata.Batch, startIdx, endIdx int) 
 				continue
 			}
 			col := vec.JSON()
-			val := col.Get(idx)
-			leadLagCol.Set(i, val)
+			leadLagCol.Copy(col, i, idx)
 		}
 		return
 	}
@@ -1438,8 +1424,7 @@ func (w *lagJSONWindow) processBatch(batch coldata.Batch, startIdx, endIdx int) 
 		w.idx++
 		if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 			// The offset is out of range, so set the output value to the default.
-			val := defaultCol.Get(i)
-			leadLagCol.Set(i, val)
+			leadLagCol.Copy(defaultCol, i, i)
 			continue
 		}
 		vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
@@ -1448,8 +1433,7 @@ func (w *lagJSONWindow) processBatch(batch coldata.Batch, startIdx, endIdx int) 
 			continue
 		}
 		col := vec.JSON()
-		val := col.Get(idx)
-		leadLagCol.Set(i, val)
+		leadLagCol.Copy(col, i, idx)
 	}
 }
 

--- a/pkg/sql/colexec/colexecwindow/last_value.eg.go
+++ b/pkg/sql/colexec/colexecwindow/last_value.eg.go
@@ -205,8 +205,7 @@ func (w *lastValueBytesWindow) processBatch(batch coldata.Batch, startIdx, endId
 			continue
 		}
 		col := vec.Bytes()
-		val := col.Get(idx)
-		outputCol.Set(i, val)
+		outputCol.Copy(col, i, idx)
 	}
 }
 
@@ -507,8 +506,7 @@ func (w *lastValueJSONWindow) processBatch(batch coldata.Batch, startIdx, endIdx
 			continue
 		}
 		col := vec.JSON()
-		val := col.Get(idx)
-		outputCol.Set(i, val)
+		outputCol.Copy(col, i, idx)
 	}
 }
 

--- a/pkg/sql/colexec/colexecwindow/lead.eg.go
+++ b/pkg/sql/colexec/colexecwindow/lead.eg.go
@@ -315,8 +315,7 @@ func (w *leadBytesWindow) processBatch(batch coldata.Batch, startIdx, endIdx int
 						leadLagNulls.SetNull(i)
 						continue
 					}
-					val := defaultCol.Get(i)
-					leadLagCol.Set(i, val)
+					leadLagCol.Copy(defaultCol, i, i)
 					continue
 				}
 				vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
@@ -325,8 +324,7 @@ func (w *leadBytesWindow) processBatch(batch coldata.Batch, startIdx, endIdx int
 					continue
 				}
 				col := vec.Bytes()
-				val := col.Get(idx)
-				leadLagCol.Set(i, val)
+				leadLagCol.Copy(col, i, idx)
 			}
 			return
 		}
@@ -341,8 +339,7 @@ func (w *leadBytesWindow) processBatch(batch coldata.Batch, startIdx, endIdx int
 			w.idx++
 			if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 				// The offset is out of range, so set the output value to the default.
-				val := defaultCol.Get(i)
-				leadLagCol.Set(i, val)
+				leadLagCol.Copy(defaultCol, i, i)
 				continue
 			}
 			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
@@ -351,8 +348,7 @@ func (w *leadBytesWindow) processBatch(batch coldata.Batch, startIdx, endIdx int
 				continue
 			}
 			col := vec.Bytes()
-			val := col.Get(idx)
-			leadLagCol.Set(i, val)
+			leadLagCol.Copy(col, i, idx)
 		}
 		return
 	}
@@ -366,8 +362,7 @@ func (w *leadBytesWindow) processBatch(batch coldata.Batch, startIdx, endIdx int
 					leadLagNulls.SetNull(i)
 					continue
 				}
-				val := defaultCol.Get(i)
-				leadLagCol.Set(i, val)
+				leadLagCol.Copy(defaultCol, i, i)
 				continue
 			}
 			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
@@ -376,8 +371,7 @@ func (w *leadBytesWindow) processBatch(batch coldata.Batch, startIdx, endIdx int
 				continue
 			}
 			col := vec.Bytes()
-			val := col.Get(idx)
-			leadLagCol.Set(i, val)
+			leadLagCol.Copy(col, i, idx)
 		}
 		return
 	}
@@ -386,8 +380,7 @@ func (w *leadBytesWindow) processBatch(batch coldata.Batch, startIdx, endIdx int
 		w.idx++
 		if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 			// The offset is out of range, so set the output value to the default.
-			val := defaultCol.Get(i)
-			leadLagCol.Set(i, val)
+			leadLagCol.Copy(defaultCol, i, i)
 			continue
 		}
 		vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
@@ -396,8 +389,7 @@ func (w *leadBytesWindow) processBatch(batch coldata.Batch, startIdx, endIdx int
 			continue
 		}
 		col := vec.Bytes()
-		val := col.Get(idx)
-		leadLagCol.Set(i, val)
+		leadLagCol.Copy(col, i, idx)
 	}
 }
 
@@ -1367,8 +1359,7 @@ func (w *leadJSONWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 						leadLagNulls.SetNull(i)
 						continue
 					}
-					val := defaultCol.Get(i)
-					leadLagCol.Set(i, val)
+					leadLagCol.Copy(defaultCol, i, i)
 					continue
 				}
 				vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
@@ -1377,8 +1368,7 @@ func (w *leadJSONWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 					continue
 				}
 				col := vec.JSON()
-				val := col.Get(idx)
-				leadLagCol.Set(i, val)
+				leadLagCol.Copy(col, i, idx)
 			}
 			return
 		}
@@ -1393,8 +1383,7 @@ func (w *leadJSONWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 			w.idx++
 			if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 				// The offset is out of range, so set the output value to the default.
-				val := defaultCol.Get(i)
-				leadLagCol.Set(i, val)
+				leadLagCol.Copy(defaultCol, i, i)
 				continue
 			}
 			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
@@ -1403,8 +1392,7 @@ func (w *leadJSONWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 				continue
 			}
 			col := vec.JSON()
-			val := col.Get(idx)
-			leadLagCol.Set(i, val)
+			leadLagCol.Copy(col, i, idx)
 		}
 		return
 	}
@@ -1418,8 +1406,7 @@ func (w *leadJSONWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 					leadLagNulls.SetNull(i)
 					continue
 				}
-				val := defaultCol.Get(i)
-				leadLagCol.Set(i, val)
+				leadLagCol.Copy(defaultCol, i, i)
 				continue
 			}
 			vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
@@ -1428,8 +1415,7 @@ func (w *leadJSONWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 				continue
 			}
 			col := vec.JSON()
-			val := col.Get(idx)
-			leadLagCol.Set(i, val)
+			leadLagCol.Copy(col, i, idx)
 		}
 		return
 	}
@@ -1438,8 +1424,7 @@ func (w *leadJSONWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 		w.idx++
 		if requestedIdx < 0 || requestedIdx >= w.partitionSize {
 			// The offset is out of range, so set the output value to the default.
-			val := defaultCol.Get(i)
-			leadLagCol.Set(i, val)
+			leadLagCol.Copy(defaultCol, i, i)
 			continue
 		}
 		vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
@@ -1448,8 +1433,7 @@ func (w *leadJSONWindow) processBatch(batch coldata.Batch, startIdx, endIdx int)
 			continue
 		}
 		col := vec.JSON()
-		val := col.Get(idx)
-		leadLagCol.Set(i, val)
+		leadLagCol.Copy(col, i, idx)
 	}
 }
 

--- a/pkg/sql/colexec/colexecwindow/lead_lag_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/lead_lag_tmpl.go
@@ -209,6 +209,9 @@ func _PROCESS_BATCH(_OFFSET_HAS_NULLS bool, _DEFAULT_HAS_NULLS bool) { // */}}
 				continue
 			}
 			// {{end}}
+			// {{if .IsBytesLike}}
+			leadLagCol.Copy(defaultCol, i, i)
+			// {{else}}
 			// {{if .Sliceable}}
 			//gcassert:bce
 			// {{end}}
@@ -217,6 +220,7 @@ func _PROCESS_BATCH(_OFFSET_HAS_NULLS bool, _DEFAULT_HAS_NULLS bool) { // */}}
 			//gcassert:bce
 			// {{end}}
 			leadLagCol.Set(i, val)
+			// {{end}}
 			continue
 		}
 		vec, idx, _ := w.buffer.GetVecWithTuple(w.Ctx, 0 /* colIdx */, requestedIdx)
@@ -225,11 +229,15 @@ func _PROCESS_BATCH(_OFFSET_HAS_NULLS bool, _DEFAULT_HAS_NULLS bool) { // */}}
 			continue
 		}
 		col := vec.TemplateType()
+		// {{if .IsBytesLike}}
+		leadLagCol.Copy(col, i, idx)
+		// {{else}}
 		val := col.Get(idx)
 		// {{if .Sliceable}}
 		//gcassert:bce
 		// {{end}}
 		leadLagCol.Set(i, val)
+		// {{end}}
 	}
 	// {{end}}
 	// {{/*

--- a/pkg/sql/colexec/colexecwindow/nth_value.eg.go
+++ b/pkg/sql/colexec/colexecwindow/nth_value.eg.go
@@ -252,8 +252,7 @@ func (w *nthValueBytesWindow) processBatch(batch coldata.Batch, startIdx, endIdx
 			continue
 		}
 		col := vec.Bytes()
-		val := col.Get(idx)
-		outputCol.Set(i, val)
+		outputCol.Copy(col, i, idx)
 	}
 }
 
@@ -690,8 +689,7 @@ func (w *nthValueJSONWindow) processBatch(batch coldata.Batch, startIdx, endIdx 
 			continue
 		}
 		col := vec.JSON()
-		val := col.Get(idx)
-		outputCol.Set(i, val)
+		outputCol.Copy(col, i, idx)
 	}
 }
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/vec_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/vec_gen.go
@@ -31,7 +31,7 @@ func genVec(inputFileContents string, wr io.Writer) error {
 	s := r.Replace(inputFileContents)
 
 	copyWithReorderedSource := makeFunctionRegex("_COPY_WITH_REORDERED_SOURCE", 1)
-	s = copyWithReorderedSource.ReplaceAllString(s, `{{template "copyWithReorderedSource" buildDict "SrcHasNulls" $1}}`)
+	s = copyWithReorderedSource.ReplaceAllString(s, `{{template "copyWithReorderedSource" buildDict "Global" . "SrcHasNulls" $1}}`)
 
 	s = replaceManipulationFuncs(s)
 

--- a/pkg/sql/colexec/ordered_synchronizer.eg.go
+++ b/pkg/sql/colexec/ordered_synchronizer.eg.go
@@ -169,8 +169,7 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 					default:
 						srcCol := vec.Bytes()
 						outCol := o.outVecs.BytesCols[o.outVecs.ColsMap[i]]
-						v := srcCol.Get(srcRowIdx)
-						outCol.Set(outputIdx, v)
+						outCol.Copy(srcCol, outputIdx, srcRowIdx)
 					}
 				case types.DecimalFamily:
 					switch o.typs[i].Width() {
@@ -233,8 +232,7 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 					default:
 						srcCol := vec.JSON()
 						outCol := o.outVecs.JSONCols[o.outVecs.ColsMap[i]]
-						v := srcCol.Get(srcRowIdx)
-						outCol.Set(outputIdx, v)
+						outCol.Copy(srcCol, outputIdx, srcRowIdx)
 					}
 				case typeconv.DatumVecCanonicalTypeFamily:
 					switch o.typs[i].Width() {

--- a/pkg/sql/colexec/ordered_synchronizer_tmpl.go
+++ b/pkg/sql/colexec/ordered_synchronizer_tmpl.go
@@ -184,8 +184,12 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 					case _TYPE_WIDTH:
 						srcCol := vec._TYPE()
 						outCol := o.outVecs._TYPECols[o.outVecs.ColsMap[i]]
+						// {{if .IsBytesLike}}
+						outCol.Copy(srcCol, outputIdx, srcRowIdx)
+						// {{else}}
 						v := srcCol.Get(srcRowIdx)
 						outCol.Set(outputIdx, v)
+						// {{end}}
 						// {{end}}
 					}
 					// {{end}}

--- a/pkg/sql/colexec/vec_comparators.eg.go
+++ b/pkg/sql/colexec/vec_comparators.eg.go
@@ -125,8 +125,7 @@ func (c *BytesVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int) {
 		c.nulls[dstVecIdx].SetNull(dstIdx)
 	} else {
 		c.nulls[dstVecIdx].UnsetNull(dstIdx)
-		v := c.vecs[srcVecIdx].Get(srcIdx)
-		c.vecs[dstVecIdx].Set(dstIdx, v)
+		c.vecs[dstVecIdx].Copy(c.vecs[srcVecIdx], dstIdx, srcIdx)
 	}
 }
 
@@ -486,8 +485,7 @@ func (c *JSONVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int) {
 		c.nulls[dstVecIdx].SetNull(dstIdx)
 	} else {
 		c.nulls[dstVecIdx].UnsetNull(dstIdx)
-		v := c.vecs[srcVecIdx].Get(srcIdx)
-		c.vecs[dstVecIdx].Set(dstIdx, v)
+		c.vecs[dstVecIdx].Copy(c.vecs[srcVecIdx], dstIdx, srcIdx)
 	}
 }
 

--- a/pkg/sql/colexec/vec_comparators_tmpl.go
+++ b/pkg/sql/colexec/vec_comparators_tmpl.go
@@ -112,8 +112,12 @@ func (c *_TYPEVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int) {
 		c.nulls[dstVecIdx].SetNull(dstIdx)
 	} else {
 		c.nulls[dstVecIdx].UnsetNull(dstIdx)
+		// {{if .IsBytesLike}}
+		c.vecs[dstVecIdx].Copy(c.vecs[srcVecIdx], dstIdx, srcIdx)
+		// {{else}}
 		v := c.vecs[srcVecIdx].Get(srcIdx)
 		c.vecs[dstVecIdx].Set(dstIdx, v)
+		// {{end}}
 	}
 }
 


### PR DESCRIPTION
**coldata: fix the usage of Bytes.Copy in CopyWithReorderedSource**

This was the intention but wasn't working because the call happens
inside a separate template.

Release note: None

**colexec: use Bytes.Copy instead of Get and Set in most places**

This commit audits our code for the usage of `Bytes.Get` followed by
`Bytes.Set` pattern and replaces those with `Bytes.Copy` (which is
faster for inlined values) in non-test code.

Release note: None