### PR TITLE
release-21.1: update activerecordAdapterVersion to v6.1.8

### DIFF
--- a/pkg/cmd/roachtest/activerecord.go
+++ b/pkg/cmd/roachtest/activerecord.go
@@ -21,7 +21,7 @@ import (
 var activerecordResultRegex = regexp.MustCompile(`^(?P<test>[^\s]+#[^\s]+) = (?P<timing>\d+\.\d+ s) = (?P<result>.)$`)
 var railsReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)\.?(?P<subpoint>\d*)$`)
 var supportedRailsVersion = "6.1"
-var activerecordAdapterVersion = "v6.1.3"
+var activerecordAdapterVersion = "v6.1.8"
 
 // This test runs activerecord's full test suite against a single cockroach node.
 


### PR DESCRIPTION
fixes cockroachdb#78120

Release justification: test only change
Release note: None