### PR TITLE
sql: add sharded bucket count to crdb_internal.table_indexes

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -276,10 +276,10 @@ SELECT * FROM crdb_internal.table_columns WHERE descriptor_name = ''
 ----
 descriptor_id  descriptor_name  column_id  column_name  column_type  nullable  default_expr  hidden
 
-query ITITTBBBT colnames
+query ITITTBBBIT colnames
 SELECT * FROM crdb_internal.table_indexes WHERE descriptor_name = ''
 ----
-descriptor_id  descriptor_name  index_id  index_name  index_type  is_unique  is_inverted  is_sharded  created_at
+descriptor_id  descriptor_name  index_id  index_name  index_type  is_unique  is_inverted  is_sharded shard_bucket_count created_at
 
 query ITITTITTB colnames
 SELECT * FROM crdb_internal.index_columns WHERE descriptor_name = ''

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -397,10 +397,10 @@ SELECT * FROM crdb_internal.table_columns WHERE descriptor_name = ''
 ----
 descriptor_id  descriptor_name  column_id  column_name  column_type  nullable  default_expr  hidden
 
-query ITITTBBBT colnames
+query ITITTBBBIT colnames
 SELECT * FROM crdb_internal.table_indexes WHERE descriptor_name = ''
 ----
-descriptor_id  descriptor_name  index_id  index_name  index_type  is_unique  is_inverted  is_sharded created_at
+descriptor_id  descriptor_name  index_id  index_name  index_type  is_unique  is_inverted  is_sharded shard_bucket_count created_at
 
 query ITITTITTB colnames
 SELECT * FROM crdb_internal.index_columns WHERE descriptor_name = ''

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -1447,6 +1447,7 @@ CREATE TABLE crdb_internal.table_indexes (
    is_unique BOOL NOT NULL,
    is_inverted BOOL NOT NULL,
    is_sharded BOOL NOT NULL,
+   shard_bucket_count INT8 NULL,
    created_at TIMESTAMP NULL
 )  CREATE TABLE crdb_internal.table_indexes (
    descriptor_id INT8 NULL,
@@ -1457,6 +1458,7 @@ CREATE TABLE crdb_internal.table_indexes (
    is_unique BOOL NOT NULL,
    is_inverted BOOL NOT NULL,
    is_sharded BOOL NOT NULL,
+   shard_bucket_count INT8 NULL,
    created_at TIMESTAMP NULL
 )  {}  {}
 CREATE TABLE crdb_internal.table_row_statistics (

--- a/pkg/sql/logictest/testdata/logic_test/dependencies
+++ b/pkg/sql/logictest/testdata/logic_test/dependencies
@@ -41,29 +41,29 @@ descriptor_id  descriptor_name  column_id  column_name  column_type             
 115            test_uwi_child   1          a            family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false        true      NULL            false
 115            test_uwi_child   2          rowid        family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false        false     unique_rowid()  true
 
-query ITITTBBB colnames
-  SELECT descriptor_id, descriptor_name, index_id, index_name, index_type, is_unique, is_inverted, is_sharded
+query ITITTBBBI colnames
+  SELECT descriptor_id, descriptor_name, index_id, index_name, index_type, is_unique, is_inverted, is_sharded, shard_bucket_count
     FROM crdb_internal.table_indexes
    WHERE descriptor_name LIKE 'test_%'
 ORDER BY descriptor_id, index_id
 ----
-descriptor_id  descriptor_name  index_id  index_name            index_type  is_unique  is_inverted  is_sharded
-106            test_kv          1         test_kv_pkey          primary     true       false        false
-106            test_kv          2         test_v_idx            secondary   true       false        false
-106            test_kv          4         test_v_idx2           secondary   false      false        false
-106            test_kv          6         test_v_idx3           secondary   false      false        false
-107            test_kvr1        1         test_kvr1_pkey        primary     true       false        false
-108            test_kvr2        1         test_kvr2_pkey        primary     true       false        false
-108            test_kvr2        2         test_kvr2_v_key       secondary   true       false        false
-109            test_kvr3        1         test_kvr3_pkey        primary     true       false        false
-109            test_kvr3        2         test_kvr3_v_key       secondary   true       false        false
-110            test_kvi1        1         test_kvi1_pkey        primary     true       false        false
-111            test_kvi2        1         test_kvi2_pkey        primary     true       false        false
-111            test_kvi2        2         test_kvi2_idx         secondary   true       false        false
-112            test_v1          0         ·                     primary     false      false        false
-113            test_v2          0         ·                     primary     false      false        false
-114            test_uwi_parent  1         test_uwi_parent_pkey  primary     true       false        false
-115            test_uwi_child   1         test_uwi_child_pkey   primary     true       false        false
+descriptor_id  descriptor_name  index_id  index_name            index_type  is_unique  is_inverted  is_sharded  shard_bucket_count
+106            test_kv          1         test_kv_pkey          primary     true       false        false       NULL
+106            test_kv          2         test_v_idx            secondary   true       false        false       NULL
+106            test_kv          4         test_v_idx2           secondary   false      false        false       NULL
+106            test_kv          6         test_v_idx3           secondary   false      false        false       NULL
+107            test_kvr1        1         test_kvr1_pkey        primary     true       false        false       NULL
+108            test_kvr2        1         test_kvr2_pkey        primary     true       false        false       NULL
+108            test_kvr2        2         test_kvr2_v_key       secondary   true       false        false       NULL
+109            test_kvr3        1         test_kvr3_pkey        primary     true       false        false       NULL
+109            test_kvr3        2         test_kvr3_v_key       secondary   true       false        false       NULL
+110            test_kvi1        1         test_kvi1_pkey        primary     true       false        false       NULL
+111            test_kvi2        1         test_kvi2_pkey        primary     true       false        false       NULL
+111            test_kvi2        2         test_kvi2_idx         secondary   true       false        false       NULL
+112            test_v1          0         ·                     primary     false      false        false       NULL
+113            test_v2          0         ·                     primary     false      false        false       NULL
+114            test_uwi_parent  1         test_uwi_parent_pkey  primary     true       false        false       NULL
+115            test_uwi_child   1         test_uwi_child_pkey   primary     true       false        false       NULL
 
 query ITITTITTB colnames
 SELECT * FROM crdb_internal.index_columns WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, index_id, column_type, column_id

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -608,14 +608,14 @@ subtest test_table_indexes
 statement ok
 CREATE TABLE poor_t (a INT PRIMARY KEY, b INT, INDEX t_idx_b (b) USING HASH WITH (bucket_count=8))
 
-query ITITTBBB colnames
-SELECT descriptor_id, descriptor_name, index_id, index_name, index_type, is_unique, is_inverted, is_sharded
+query ITITTBBBI colnames
+SELECT descriptor_id, descriptor_name, index_id, index_name, index_type, is_unique, is_inverted, is_sharded, shard_bucket_count
   FROM crdb_internal.table_indexes
  WHERE descriptor_name = 'poor_t'
 ----
-descriptor_id  descriptor_name  index_id  index_name   index_type  is_unique  is_inverted  is_sharded
-127            poor_t           1         poor_t_pkey  primary     true       false        false
-127            poor_t           2         t_idx_b      secondary   false      false        true
+descriptor_id  descriptor_name  index_id  index_name   index_type  is_unique  is_inverted  is_sharded  shard_bucket_count
+127            poor_t           1         poor_t_pkey  primary     true       false        false       NULL
+127            poor_t           2         t_idx_b      secondary   false      false        true        8
 
 statement ok
 DROP TABLE poor_t


### PR DESCRIPTION
Fixes #73057

Release justification: lost risk and beneficial index info.
Release note (sql change): bucket count of hash sharded index is
now being shown from the crdb_internal.table_indexes table.