### PR TITLE
sql: return an error when partition spans has no healthy instances

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1149,6 +1149,9 @@ func (dsp *DistSQLPlanner) partitionSpansTenant(
 	if err != nil {
 		return nil, err
 	}
+	if len(instances) == 0 {
+		return nil, errors.New("no healthy sql instances available for planning")
+	}
 	// Randomize the order in which we assign partitions, so that work is
 	// allocated fairly across queries.
 	rand.Shuffle(len(instances), func(i, j int) {


### PR DESCRIPTION
If there are no SQL instances available for planning,
partitionSpansTenant in the DistSQL planner will panic. This PR fixes
the issue so that it instead returns an error if there are no instances
available.

Fixes: #77590

Release justification: Fixes a bug in DistSQL that can cause a panic for
non-system tenants.

Release note: None