### PR TITLE
backupccl: set shorter closed_timestamp settings in datadriven tests

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -208,6 +208,7 @@ go_test(
         "//pkg/kv/bulk",
         "//pkg/kv/kvclient/kvcoord",
         "//pkg/kv/kvserver",
+        "//pkg/kv/kvserver/closedts",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/protectedts",
         "//pkg/kv/kvserver/protectedts/ptpb",


### PR DESCRIPTION
This change drops the `kv.closed_timestamp.side_transport_interval`
and `kv.closed_timestamp.target_duration` in the servers started as part
of the datadriven framework. This change was motivated by the fact that
cluster settings set in certain multi-node datadriven tests were not being
observed by all nodes in the cluster. Cluster settings are now backed by
rangefeeds instead of gossiping the SystemSpanConfig and so these settings
should speed up when all nodes become aware of changes to their values.

Fixes: #77264

Release note: None