### PR TITLE
sqlproxyccl: exit pod-watcher-client on local context cancellation

### DIFF
--- a/pkg/ccl/sqlproxyccl/tenant/directory_cache.go
+++ b/pkg/ccl/sqlproxyccl/tenant/directory_cache.go
@@ -367,7 +367,7 @@ func (d *directoryCache) watchPods(ctx context.Context, stopper *stop.Stopper) e
 		watchPodsErr := log.Every(10 * time.Second)
 		recvErr := log.Every(10 * time.Second)
 
-		for {
+		for ctx.Err() == nil {
 			if client == nil {
 				client, err = d.client.WatchPods(ctx, &req)
 				if firstRun {
@@ -375,9 +375,6 @@ func (d *directoryCache) watchPods(ctx context.Context, stopper *stop.Stopper) e
 					firstRun = false
 				}
 				if err != nil {
-					if grpcutil.IsContextCanceled(err) {
-						break
-					}
 					if watchPodsErr.ShouldLog() {
 						log.Errorf(ctx, "err creating new watch pod client: %s", err)
 					}
@@ -391,9 +388,6 @@ func (d *directoryCache) watchPods(ctx context.Context, stopper *stop.Stopper) e
 			// Read the next watcher event.
 			resp, err := client.Recv()
 			if err != nil {
-				if grpcutil.IsContextCanceled(err) {
-					break
-				}
 				if recvErr.ShouldLog() {
 					log.Errorf(ctx, "err receiving stream events: %s", err)
 				}

--- a/pkg/ccl/sqlproxyccl/tenantdirsvr/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/tenantdirsvr/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "@com_github_gogo_status//:status",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
         "@org_golang_google_grpc//test/bufconn",
     ],
 )


### PR DESCRIPTION
Previously, we used grpcutil.IsContextCanceled to detect when a
returned gRPC error was the result of a context cancellation.

I believe that the intent of this code was to detect when the _local_
context was cancelled, indicating that we are shutting down and thus
the watch-pods-client goroutine should exit.

This works because the gRPC library converts a local context.Canceled
error into a gRPC error. And, in gRPC before 1.45, if a server handler
returned context.Canceled, the returned gRPC error would have
status.Unknown, and thus not trigger this exit behavior.

As of gRPC 1.45, however, a context.Canceled error returned by a
server handler will also result in a gRPC error with status.Canceled [0],
meaning that the previous code will force the goroutine to exit in
response to a server-side error. From my reading of this code, it
appears we want to retry all server-side errors.

To account for this, we now only break out of the retry loop if our
local context is done.

Further, I've changed the test directory server implementation to
return an arguably more appropriate error when it is shutting down.

Fixes #78197

Release note: None