### PR TITLE
cluster: Revert "cluster: use WaitConditionNextExit"

### DIFF
--- a/pkg/acceptance/cluster/dockercluster.go
+++ b/pkg/acceptance/cluster/dockercluster.go
@@ -235,7 +235,7 @@ func (l *DockerCluster) OneShot(
 	if err := l.oneshot.Start(ctx); err != nil {
 		return err
 	}
-	return l.oneshot.Wait(ctx, container.WaitConditionNextExit)
+	return l.oneshot.Wait(ctx, container.WaitConditionNotRunning)
 }
 
 // stopOnPanic is invoked as a deferred function in Start in order to attempt
@@ -372,7 +372,7 @@ func (l *DockerCluster) initCluster(ctx context.Context) {
 	// and it'll get in the way of future runs.
 	l.vols = c
 	maybePanic(c.Start(ctx))
-	maybePanic(c.Wait(ctx, container.WaitConditionNextExit))
+	maybePanic(c.Wait(ctx, container.WaitConditionNotRunning))
 }
 
 // cockroachEntryPoint returns the value to be used as


### PR DESCRIPTION
This reverts commit 65437495b20caf547e9354ff05e433b9067e7624.
That commit was an (unsuccessful) attempt to fix #58955, and in the
presence of this change the `acceptance` tests are very likely to hang
forever under Ubuntu 20.04 due to a race condition where the container
exits before we begin waiting on it.

Release note: None