### PR TITLE
pkg/server: Add last modified timestamp and coordinator ID to /jobs

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -5913,6 +5913,7 @@ JobResponse contains the job record for a job.
 | next_run | [google.protobuf.Timestamp](#cockroach.server.serverpb.JobsResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
 | num_runs | [int64](#cockroach.server.serverpb.JobsResponse-int64) |  |  | [reserved](#support-status) |
 | execution_failures | [JobResponse.ExecutionFailure](#cockroach.server.serverpb.JobsResponse-cockroach.server.serverpb.JobResponse.ExecutionFailure) | repeated | ExecutionFailures is a log of execution failures of the job. It is not guaranteed to contain all execution failures and some execution failures may not contain an error or end. | [reserved](#support-status) |
+| coordinator_id | [int64](#cockroach.server.serverpb.JobsResponse-int64) |  | coordinator_id identifies the node coordinating the job. This value will only be present for jobs that are currently running or recently ran. | [reserved](#support-status) |
 
 
 
@@ -5992,6 +5993,7 @@ JobResponse contains the job record for a job.
 | next_run | [google.protobuf.Timestamp](#cockroach.server.serverpb.JobResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
 | num_runs | [int64](#cockroach.server.serverpb.JobResponse-int64) |  |  | [reserved](#support-status) |
 | execution_failures | [JobResponse.ExecutionFailure](#cockroach.server.serverpb.JobResponse-cockroach.server.serverpb.JobResponse.ExecutionFailure) | repeated | ExecutionFailures is a log of execution failures of the job. It is not guaranteed to contain all execution failures and some execution failures may not contain an error or end. | [reserved](#support-status) |
+| coordinator_id | [int64](#cockroach.server.serverpb.JobResponse-int64) |  | coordinator_id identifies the node coordinating the job. This value will only be present for jobs that are currently running or recently ran. | [reserved](#support-status) |
 
 
 

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -637,6 +637,10 @@ message JobResponse {
   // guaranteed to contain all execution failures and some execution failures
   // may not contain an error or end.
   repeated ExecutionFailure execution_failures = 20;
+
+  // coordinator_id identifies the node coordinating the job. This value will
+  // only be present for jobs that are currently running or recently ran.
+  int64 coordinator_id = 21 [(gogoproto.customname) = "CoordinatorID"];
 }
 
 // LocationsRequest requests system locality location information.

--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobTable.tsx
@@ -145,6 +145,21 @@ const jobsTableColumns: ColumnDescriptor<Job>[] = [
     sort: job => util.TimestampToMoment(job?.created).valueOf(),
   },
   {
+    name: "lastModifiedTime",
+    title: (
+      <Tooltip
+        placement="bottom"
+        style="tableTitle"
+        content={<p>Date and time the job was last modified.</p>}
+      >
+        {"Modified Time (UTC)"}
+      </Tooltip>
+    ),
+    cell: job =>
+      util.TimestampToMoment(job?.modified).format(DATE_FORMAT_24_UTC),
+    sort: job => util.TimestampToMoment(job?.modified).valueOf(),
+  },
+  {
     name: "lastExecutionTime",
     title: (
       <Tooltip
@@ -172,6 +187,25 @@ const jobsTableColumns: ColumnDescriptor<Job>[] = [
     ),
     cell: job => String(job.num_runs),
     sort: job => job.num_runs?.toNumber(),
+  },
+  {
+    name: "coordinatorID",
+    title: (
+      <Tooltip
+        placement="bottom"
+        style="tableTitle"
+        content={<p>ID of the coordinating node.</p>}
+      >
+        {"Coordinator Node"}
+      </Tooltip>
+    ),
+    // If the coordinator ID is unset, we don't want to display anything, but
+    // the default value of `0` is fine for sorting.
+    cell: job =>
+      Object.prototype.hasOwnProperty.call(job, "coordinator_id")
+        ? String(job.coordinator_id)
+        : "",
+    sort: job => job.coordinator_id?.toNumber(),
   },
 ];
 


### PR DESCRIPTION
These values were previously unavailable in UI, but are helpful for debugging..

Release note (ui change): Add last modified timestamp and coordinator ID to
Jobs page to aid in debugging jobs issues.