### PR TITLE
bazel: fix `sql-gen.sh` script

### DIFF
--- a/pkg/sql/parser/sql-gen.sh
+++ b/pkg/sql/parser/sql-gen.sh
@@ -16,8 +16,8 @@ sed -E -f types_regex.tmp < $1 | \
 rm types_regex.tmp
 
 ret=$($4 -p sql -o $3 sql-gen.y); \
-  if expr "$$ret" : ".*conflicts" >/dev/null; then \
-    echo "$$ret"; exit 1; \
+  if expr "$ret" : ".*conflicts" >/dev/null; then \
+    echo "$ret"; exit 1; \
   fi;
 rm sql-gen.y
 $5 -w $3


### PR DESCRIPTION
This command was cargo culted from the `Makefile`, which uses double
`$$` because the `$` needs to be escaped in the `make` context. In the
`bash` context that this script runs in, however, `"$$ret"` evalutes to
the value of the special variable `$$` (the PID of the current process)
concatenated to the string `ret`. Obviously, this string will never
contain the word `"conflicts"` so this means the Bazel build is unable
to detect the error case where the SQL grammar has conflicts.

Release note: None