### PR TITLE
sql: block operations properly on implicit transactions

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -668,7 +668,7 @@ func backupPlanHook(
 		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer span.Finish()
 
-		if !(p.IsAutoCommit() || backupStmt.Options.Detached) {
+		if !(p.ExtendedEvalContext().TxnIsSingleStmt || backupStmt.Options.Detached) {
 			return errors.Errorf("BACKUP cannot be used inside a multi-statement transaction without DETACHED option")
 		}
 

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1149,7 +1149,7 @@ func restorePlanHook(
 		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer span.Finish()
 
-		if !(p.IsAutoCommit() || restoreStmt.Options.Detached) {
+		if !(p.ExtendedEvalContext().TxnIsSingleStmt || restoreStmt.Options.Detached) {
 			return errors.Errorf("RESTORE cannot be used inside a multi-statement transaction without DETACHED option")
 		}
 

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -50,13 +50,14 @@ func TestShowBackup(t *testing.T) {
 	_, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitManualReplication, base.TestClusterArgs{})
 	defer cleanupFn()
 	defer cleanupEmptyCluster()
-	sqlDB.Exec(t, `
+	sqlDB.ExecMultiple(t, strings.Split(`
 SET CLUSTER SETTING sql.cross_db_fks.enabled = TRUE;
 CREATE TYPE data.welcome AS ENUM ('hello', 'hi');
 USE data; CREATE SCHEMA sc;
 CREATE TABLE data.sc.t1 (a INT);
 CREATE TABLE data.sc.t2 (a data.welcome);
-`)
+`,
+		`;`)...)
 
 	const full, inc, inc2 = localFoo + "/full", localFoo + "/inc", localFoo + "/inc2"
 
@@ -768,13 +769,13 @@ func TestShowBackupWithDebugIDs(t *testing.T) {
 	defer cleanupFn()
 
 	// add 1 type, 1 schema, and 2 tables to the database
-	sqlDB.Exec(t, `
+	sqlDB.ExecMultiple(t, strings.Split(`
 		SET CLUSTER SETTING sql.cross_db_fks.enabled = TRUE;
 		CREATE TYPE data.welcome AS ENUM ('hello', 'hi');
 		USE data; CREATE SCHEMA sc;
 		CREATE TABLE data.sc.t1 (a INT);
-		CREATE TABLE data.sc.t2 (a data.welcome);
-  `)
+		CREATE TABLE data.sc.t2 (a data.welcome);`,
+		`;`)...)
 
 	const full = localFoo + "/full"
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/backup-dropped-descriptors
+++ b/pkg/ccl/backupccl/testdata/backup-restore/backup-dropped-descriptors
@@ -7,7 +7,13 @@ new-server name=s1
 
 exec-sql
 SET use_declarative_schema_changer = 'off';
+----
+
+exec-sql
 SET CLUSTER SETTING jobs.debug.pausepoints = 'schemachanger.before.exec';
+----
+
+exec-sql
 CREATE DATABASE d;
 CREATE TABLE d.foo (id INT);
 ----
@@ -118,6 +124,9 @@ CREATE TABLE d2.s.t (id INT);
 
 exec-sql
 SET use_declarative_schema_changer = 'off';
+----
+
+exec-sql
 SET CLUSTER SETTING jobs.debug.pausepoints = 'schemachanger.before.exec';
 ----
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/column-families
+++ b/pkg/ccl/backupccl/testdata/backup-restore/column-families
@@ -24,7 +24,13 @@ ALTER TABLE cfs SPLIT AT SELECT a FROM cfs;
 exec-sql
 -- Split the output files very small to catch output SSTs mid-row.
 SET CLUSTER SETTING bulkio.backup.file_size = '1';
+----
+
+exec-sql
 SET CLUSTER SETTING kv.bulk_sst.target_size = '1';
+----
+
+exec-sql
 SET CLUSTER SETTING bulkio.backup.merge_file_buffer_size = '1MiB';
 ----
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/max-row-size
+++ b/pkg/ccl/backupccl/testdata/backup-restore/max-row-size
@@ -46,6 +46,9 @@ pq: row larger than max row size: table 112 family 0 primary key /Table/112/1/2/
 
 exec-sql
 SET CLUSTER SETTING sql.guardrails.max_row_size_err = DEFAULT;
+----
+
+exec-sql
 INSERT INTO d2.maxrow VALUES (2, repeat('y', 20000));
 ----
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-on-fail-or-cancel-ttl
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-on-fail-or-cancel-ttl
@@ -18,6 +18,9 @@ BACKUP DATABASE d INTO 'userfile:///foo'
 # Attempt the restore but pause it before publishing descriptors.
 exec-sql
 SET CLUSTER SETTING jobs.debug.pausepoints = 'restore.before_publishing_descriptors';
+----
+
+exec-sql
 DROP DATABASE d;
 ----
 
@@ -52,7 +55,13 @@ BACKUP DATABASE d INTO 'userfile:///foo'
 # Attempt the restore but pause it after publishing descriptors.
 exec-sql
 SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+exec-sql
 SET CLUSTER SETTING jobs.debug.pausepoints = 'restore.after_publishing_descriptors';
+----
+
+exec-sql
 DROP DATABASE d;
 ----
 

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -374,8 +374,7 @@ func TestChangefeedTenants(t *testing.T) {
 
 	tenantServer, tenantDB := serverutils.StartTenant(t, kvServer, tenantArgs)
 	tenantSQL := sqlutils.MakeSQLRunner(tenantDB)
-	tenantSQL.Exec(t, serverSetupStatements)
-
+	tenantSQL.ExecMultiple(t, strings.Split(serverSetupStatements, ";")...)
 	tenantSQL.Exec(t, `CREATE TABLE foo_in_tenant (pk INT PRIMARY KEY)`)
 	t.Run("changefeed on non-tenant table fails", func(t *testing.T) {
 		kvSQL := sqlutils.MakeSQLRunner(kvSQLdb)
@@ -445,7 +444,7 @@ func TestChangefeedTenantsExternalIOEnabled(t *testing.T) {
 
 	tenantServer, tenantDB := serverutils.StartTenant(t, kvServer, tenantArgs)
 	tenantSQL := sqlutils.MakeSQLRunner(tenantDB)
-	tenantSQL.Exec(t, serverSetupStatements)
+	tenantSQL.ExecMultiple(t, strings.Split(serverSetupStatements, ";")...)
 	tenantSQL.Exec(t, `CREATE TABLE foo_in_tenant (pk INT PRIMARY KEY)`)
 
 	t.Run("sinkful changefeed works", func(t *testing.T) {
@@ -952,7 +951,7 @@ func TestChangefeedExternalIODisabled(t *testing.T) {
 		})
 		defer s.Stopper().Stop(ctx)
 		sqlDB := sqlutils.MakeSQLRunner(db)
-		sqlDB.Exec(t, serverSetupStatements)
+		sqlDB.ExecMultiple(t, strings.Split(serverSetupStatements, ";")...)
 		sqlDB.Exec(t, "CREATE TABLE target_table (pk INT PRIMARY KEY)")
 		for _, proto := range disallowedSinkProtos {
 			sqlDB.ExpectErr(t, "Outbound IO is disabled by configuration, cannot create changefeed",

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/testdata/boundedstaleness/single_row
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/testdata/boundedstaleness/single_row
@@ -140,6 +140,9 @@ reset-matching-stmt-for-tracing
 # Set a super high closed bounded staleness target and execute a schema change.
 exec
 SET CLUSTER SETTING kv.closed_timestamp.target_duration = '1hr';
+----
+
+exec
 ALTER TABLE t ADD COLUMN new_col INT NOT NULL DEFAULT 2
 ----
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_default_primary_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_default_primary_region
@@ -2,6 +2,8 @@
 
 statement ok
 SET CLUSTER SETTING sql.defaults.primary_region = "invalid-region-name";
+
+statement ok
 SET CLUSTER SETTING sql.multiregion.drop_primary_region.enabled = 'off'
 
 # Test invalid default primary region name.

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_import_export
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_import_export
@@ -82,6 +82,8 @@ CREATE TABLE team (
   dislikes string[],
   FAMILY "primary" (id, name, likes, dislikes)
 );
+
+statement ok
 IMPORT INTO team CSV DATA ('nodelocal://1/team_export/export*.csv') WITH DELIMITER = '|'
 
 query ITTT colnames

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
@@ -5,6 +5,8 @@
 # we need to wait for the system config to propagate.
 statement ok
 SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '10ms';
+
+statement ok
 SET CLUSTER SETTING kv.closed_timestamp.target_duration = '10ms';
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
@@ -3,6 +3,8 @@
 
 statement ok
 SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '10ms';
+
+statement ok
 SET CLUSTER SETTING kv.closed_timestamp.target_duration = '10ms';
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -6,6 +6,8 @@
 # we need to wait for the system config to propagate.
 statement ok
 SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '10ms';
+
+statement ok
 SET CLUSTER SETTING kv.closed_timestamp.target_duration = '10ms';
 
 statement ok
@@ -1280,6 +1282,8 @@ CREATE INDEX new_idx ON regional_by_row_table(a, b)
 # #56201).
 statement ok
 CREATE TABLE t56201 (a INT, b STRING, c STRING NOT NULL) LOCALITY REGIONAL BY ROW;
+
+statement ok
 ALTER TABLE t56201 INJECT STATISTICS '[
   {
     "columns": ["a"],
@@ -1301,6 +1305,8 @@ ALTER TABLE t56201 INJECT STATISTICS '[
     "created_at": "2018-01-01 1:00:00.00000+00:00"
   }
 ]';
+
+statement ok
 ALTER TABLE t56201 ADD CONSTRAINT key_a_b UNIQUE (a, b);
 
 query T

--- a/pkg/ccl/multiregionccl/datadriven_test.go
+++ b/pkg/ccl/multiregionccl/datadriven_test.go
@@ -171,12 +171,16 @@ func TestMultiRegionDataDriven(t *testing.T) {
 				// Speed up closing of timestamps, in order to sleep less below before
 				// we can use follower_read_timestamp(). follower_read_timestamp() uses
 				// sum of the following settings.
-				_, err = sqlConn.Exec(
-					"SET CLUSTER SETTING kv.closed_timestamp.target_duration = '0.4s';" +
-						"SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '0.1s';" +
-						"SET CLUSTER SETTING kv.closed_timestamp.propagation_slack = '0.5s'")
-				if err != nil {
-					return err.Error()
+				for _, stmt := range strings.Split(`
+SET CLUSTER SETTING kv.closed_timestamp.target_duration = '0.4s';
+SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '0.1s';
+SET CLUSTER SETTING kv.closed_timestamp.propagation_slack = '0.5s'
+`,
+					";") {
+					_, err = sqlConn.Exec(stmt)
+					if err != nil {
+						return err.Error()
+					}
 				}
 
 			case "cleanup-cluster":

--- a/pkg/ccl/multiregionccl/region_test.go
+++ b/pkg/ccl/multiregionccl/region_test.go
@@ -401,10 +401,10 @@ ALTER TABLE db.public.global CONFIGURE ZONE USING
 
 			_, err := sqlDB.Exec(`
 CREATE DATABASE db PRIMARY REGION "us-east1" REGIONS "us-east2";
-CREATE TABLE db.global () LOCALITY GLOBAL;
-SET CLUSTER SETTING sql.defaults.multiregion_placement_policy.enabled = true;`)
+CREATE TABLE db.global () LOCALITY GLOBAL;`)
 			require.NoError(t, err)
-
+			_, err = sqlDB.Exec(`SET CLUSTER SETTING sql.defaults.multiregion_placement_policy.enabled = true;`)
+			require.NoError(t, err)
 			go func() {
 				defer func() {
 					close(regionOpFinished)

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/indexes
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/indexes
@@ -100,6 +100,9 @@ block-gc-jobs
 # with the mvcc-index-backfiller.
 exec-sql
 SET CLUSTER SETTING sql.mvcc_compliant_index_creation.enabled = true;
+----
+
+exec-sql
 CREATE INDEX idx2 ON db.t (j);
 ALTER INDEX db.t@idx2 CONFIGURE ZONE USING gc.ttlseconds = 1;
 ----
@@ -134,6 +137,9 @@ translate database=db table=t
 # with the non-mvcc-index-backfiller.
 exec-sql
 SET CLUSTER SETTING sql.mvcc_compliant_index_creation.enabled = false;
+----
+
+exec-sql
 CREATE INDEX idx3 ON db.t (j);
 ALTER INDEX db.t@idx3 CONFIGURE ZONE USING gc.ttlseconds = 1;
 ----
@@ -153,6 +159,9 @@ translate database=db table=t
 # zone configuration should also be cleaned up.
 exec-sql
 SET CLUSTER SETTING sql.mvcc_compliant_index_creation.enabled = true;
+----
+
+exec-sql
 CREATE TABLE db.t2(i INT PRIMARY KEY, j INT);
 CREATE INDEX idx ON db.t2 (j);
 ALTER INDEX db.t2@idx CONFIGURE ZONE USING gc.ttlseconds = 1;
@@ -165,6 +174,9 @@ translate database=db table=t2
 
 exec-sql
 SET CLUSTER SETTING sql.mvcc_compliant_index_creation.enabled = false;
+----
+
+exec-sql
 CREATE TABLE db.t3(i INT PRIMARY KEY, j INT);
 CREATE INDEX idx ON db.t3 (j);
 ALTER INDEX db.t3@idx CONFIGURE ZONE USING gc.ttlseconds = 1;

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
@@ -11,6 +11,7 @@ package streamingest
 import (
 	"context"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -67,13 +68,14 @@ func TestTenantStreaming(t *testing.T) {
 	resetFreq := changefeedbase.TestingSetDefaultMinCheckpointFrequency(50 * time.Millisecond)
 	defer resetFreq()
 	// Set required cluster settings.
-	_, err := sourceDB.Exec(`
+	sourceDBRunner := sqlutils.MakeSQLRunner(sourceDB)
+	sourceDBRunner.ExecMultiple(t, strings.Split(`
 SET CLUSTER SETTING kv.rangefeed.enabled = true;
 SET CLUSTER SETTING kv.closed_timestamp.target_duration = '1s';
 SET CLUSTER SETTING changefeed.experimental_poll_interval = '10ms';
 SET CLUSTER SETTING stream_replication.min_checkpoint_frequency = '1s';
-`)
-	require.NoError(t, err)
+`,
+		";")...)
 
 	// Start the destination server.
 	hDest, cleanupDest := streamingtest.NewReplicationHelper(t, base.TestServerArgs{})
@@ -81,12 +83,13 @@ SET CLUSTER SETTING stream_replication.min_checkpoint_frequency = '1s';
 	// destSQL refers to the system tenant as that's the one that's running the
 	// job.
 	destSQL := hDest.SysDB
-	destSQL.Exec(t, `
+	destSQL.ExecMultiple(t, strings.Split(`
 SET CLUSTER SETTING stream_replication.consumer_heartbeat_frequency = '2s';
 SET CLUSTER SETTING bulkio.stream_ingestion.minimum_flush_interval = '5us';
 SET CLUSTER SETTING bulkio.stream_ingestion.cutover_signal_poll_interval = '100ms';
 SET enable_experimental_stream_replication = true;
-`)
+`,
+		";")...)
 
 	// Sink to read data from.
 	pgURL, cleanupSink := sqlutils.PGUrl(t, source.ServingSQLAddr(), t.Name(), url.User(security.RootUser))

--- a/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -183,7 +184,7 @@ func TestPartitionedTenantStreamingEndToEnd(t *testing.T) {
 		c, cleanup := createtenantStreamingClusters(ctx, t, tenantStreamingClustersArgs{
 			srcTenantID: roachpb.MakeTenantID(10),
 			srcInitFunc: func(t *testing.T, sysSQL *sqlutils.SQLRunner, tenantSQL *sqlutils.SQLRunner) {
-				sysSQL.Exec(t, srcClusterSetting)
+				sysSQL.ExecMultiple(t, strings.Split(srcClusterSetting, ";")...)
 				if withInitialScan {
 					sysSQL.QueryRow(t, "SELECT cluster_logical_timestamp()").Scan(&startTime)
 				}
@@ -202,7 +203,7 @@ func TestPartitionedTenantStreamingEndToEnd(t *testing.T) {
 			srcNumNodes:  3,
 			destTenantID: roachpb.MakeTenantID(10),
 			destInitFunc: func(t *testing.T, sysSQL *sqlutils.SQLRunner, tenantSQL *sqlutils.SQLRunner) {
-				sysSQL.Exec(t, destClusterSetting)
+				sysSQL.ExecMultiple(t, strings.Split(destClusterSetting, ";")...)
 			},
 			destNumNodes: 2,
 		})

--- a/pkg/ccl/streamingccl/streamingtest/replication_helpers.go
+++ b/pkg/ccl/streamingccl/streamingtest/replication_helpers.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"context"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -193,13 +194,13 @@ func NewReplicationHelper(
 	resetFreq := changefeedbase.TestingSetDefaultMinCheckpointFrequency(50 * time.Millisecond)
 
 	// Set required cluster settings.
-	_, err := db.Exec(`
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.ExecMultiple(t, strings.Split(`
 SET CLUSTER SETTING kv.rangefeed.enabled = true;
 SET CLUSTER SETTING kv.closed_timestamp.target_duration = '1s';
 SET CLUSTER SETTING changefeed.experimental_poll_interval = '10ms';
 SET CLUSTER SETTING sql.defaults.experimental_stream_replication.enabled = 'on';
-`)
-	require.NoError(t, err)
+`, `;`)...)
 
 	// Start tenant server
 	tenantID := serverutils.TestTenantID()

--- a/pkg/ccl/telemetryccl/testdata/telemetry/multiregion
+++ b/pkg/ccl/telemetryccl/testdata/telemetry/multiregion
@@ -378,6 +378,9 @@ exec
 USE survive_region;
 CREATE TABLE t7 (a INT);
 INSERT INTO t7 VALUES (1),(2),(3);
+----
+
+exec
 EXPORT INTO CSV 'nodelocal://0/t7' FROM TABLE t7;
 ----
 
@@ -392,6 +395,9 @@ sql.multiregion.import
 # rapidly.
 exec
 SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '10ms';
+----
+
+exec
 SET CLUSTER SETTING kv.closed_timestamp.target_duration = '5ms';
 ----
 

--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"math/rand"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -35,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
@@ -707,12 +709,12 @@ func TestClosedTimestampFrozenAfterSubsumption(t *testing.T) {
 			// lease but not over the RHS lease.
 			tc, _ := setupTestClusterWithDummyRange(t, clusterArgs, "cttest" /* dbName */, "kv" /* tableName */, numNodes)
 			defer tc.Stopper().Stop(ctx)
-			_, err := tc.ServerConn(0).Exec(fmt.Sprintf(`
+			sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+			sqlDB.ExecMultiple(t, strings.Split(fmt.Sprintf(`
 SET CLUSTER SETTING kv.closed_timestamp.target_duration = '%s';
 SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '%s';
 SET CLUSTER SETTING kv.closed_timestamp.follower_reads_enabled = true;
-`, 5*time.Second, 100*time.Millisecond))
-			require.NoError(t, err)
+`, 5*time.Second, 100*time.Millisecond), ";")...)
 			leftDesc, rightDesc := splitDummyRangeInTestCluster(t, tc, "cttest", "kv", hlc.Timestamp{} /* splitExpirationTime */)
 
 			leftLeaseholder := getCurrentLeaseholder(t, tc, leftDesc)
@@ -1184,12 +1186,13 @@ func setupClusterForClosedTSTesting(
 	dbName, tableName string,
 ) (tc serverutils.TestClusterInterface, db0 *gosql.DB, kvTableDesc roachpb.RangeDescriptor) {
 	tc, desc := setupTestClusterWithDummyRange(t, clusterArgs, dbName, tableName, numNodes)
-	_, err := tc.ServerConn(0).Exec(fmt.Sprintf(`
+	sqlRunner := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	sqlRunner.ExecMultiple(t, strings.Split(fmt.Sprintf(`
 SET CLUSTER SETTING kv.closed_timestamp.target_duration = '%s';
 SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '%s';
 SET CLUSTER SETTING kv.closed_timestamp.follower_reads_enabled = true;
-`, targetDuration, targetDuration/4))
-	require.NoError(t, err)
+`, targetDuration, targetDuration/4),
+		";")...)
 
 	return tc, tc.ServerConn(0), desc
 }

--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -259,8 +259,8 @@ func alterColumnTypeGeneral(
 		}
 	}
 
-	// Disallow ALTER COLUMN TYPE general inside an explicit transaction.
-	if !params.p.EvalContext().TxnImplicit {
+	// Disallow ALTER COLUMN TYPE general inside a multi-statement transaction.
+	if !params.extendedEvalCtx.TxnIsSingleStmt {
 		return AlterColTypeInTxnNotSupportedErr
 	}
 

--- a/pkg/sql/alter_column_type_test.go
+++ b/pkg/sql/alter_column_type_test.go
@@ -80,9 +80,9 @@ INSERT INTO test2 VALUES ('hello');`)
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		sqlDB.Exec(t, `
-SET enable_experimental_alter_column_type_general = true;
-ALTER TABLE test ALTER COLUMN x TYPE STRING;`)
+		sqlDB.ExecMultiple(t,
+			`SET enable_experimental_alter_column_type_general = true;`,
+			`ALTER TABLE test ALTER COLUMN x TYPE STRING;`)
 		wg.Done()
 	}()
 
@@ -156,9 +156,9 @@ INSERT INTO test2 VALUES (true);
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		sqlDB.Exec(t, `
-SET enable_experimental_alter_column_type_general = true;
-ALTER TABLE test ALTER COLUMN x TYPE BOOL USING (x > 0);`)
+		sqlDB.ExecMultiple(t,
+			`SET enable_experimental_alter_column_type_general = true;`,
+			`ALTER TABLE test ALTER COLUMN x TYPE BOOL USING (x > 0);`)
 		wg.Done()
 	}()
 
@@ -330,10 +330,10 @@ func TestSchemaChangeBeforeAlterColumnType(t *testing.T) {
 	s, db, _ := serverutils.StartServer(t, params)
 	sqlDB := sqlutils.MakeSQLRunner(db)
 	defer s.Stopper().Stop(ctx)
-
+	sqlDB.ExecMultiple(t,
+		`SET use_declarative_schema_changer = 'off';`,
+		`SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'off';`)
 	sqlDB.Exec(t, `
-SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'off';
-SET use_declarative_schema_changer = 'off';
 CREATE DATABASE t;
 CREATE TABLE t.test (x INT NOT NULL, y INT);
 `)
@@ -394,10 +394,10 @@ CREATE TABLE t.test (x INT);
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		sqlDB.Exec(t, `
-SET enable_experimental_alter_column_type_general = true;
-ALTER TABLE t.test ALTER COLUMN x TYPE STRING;
-`)
+		sqlDB.ExecMultiple(t,
+			`SET enable_experimental_alter_column_type_general = true;`,
+			`ALTER TABLE t.test ALTER COLUMN x TYPE STRING;`,
+		)
 		wg.Done()
 	}()
 

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -457,7 +457,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 			if params.SessionData().SafeUpdates {
 				err := pgerror.DangerousStatementf("ALTER TABLE DROP COLUMN will " +
 					"remove all data in that column")
-				if !params.extendedEvalCtx.TxnImplicit {
+				if !params.extendedEvalCtx.TxnIsSingleStmt {
 					err = errors.WithIssueLink(err, errors.IssueLink{
 						IssueURL: "https://github.com/cockroachdb/cockroach/issues/46541",
 						Detail: "when used in an explicit transaction combined with other " +
@@ -708,7 +708,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 			if !ok {
 				return errors.AssertionFailedf("missing stats data")
 			}
-			if !params.p.EvalContext().TxnImplicit {
+			if !params.extendedEvalCtx.TxnIsSingleStmt {
 				return errors.New("cannot inject statistics in an explicit transaction")
 			}
 			if err := injectTableStats(params, n.tableDesc, sd); err != nil {

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -563,13 +563,20 @@ func TestCantLeaseDeletedTable(testingT *testing.T) {
 	t := newLeaseTest(testingT, params)
 	defer t.cleanup()
 
+	_, err := t.db.Exec(`SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'off';`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = t.db.Exec(`SET use_declarative_schema_changer = 'off';`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	sql := `
-SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'off';
-SET use_declarative_schema_changer = 'off';
 CREATE DATABASE test;
 CREATE TABLE test.t(a INT PRIMARY KEY);
 `
-	_, err := t.db.Exec(sql)
+	_, err = t.db.Exec(sql)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -650,13 +650,21 @@ func TestLeasesOnDeletedTableAreReleasedImmediately(t *testing.T) {
 	s, db, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())
 
+	_, err := db.Exec(`SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'off'`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = db.Exec(`SET use_declarative_schema_changer = 'off';`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	stmt := `
-SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'off';
-SET use_declarative_schema_changer = 'off';
 CREATE DATABASE test;
 CREATE TABLE test.t(a INT PRIMARY KEY);
 `
-	_, err := db.Exec(stmt)
+	_, err = db.Exec(stmt)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/colfetcher/bytes_read_test.go
+++ b/pkg/sql/colfetcher/bytes_read_test.go
@@ -41,6 +41,9 @@ func TestBytesRead(t *testing.T) {
 	// first row in one batch and then the second row in another batch.
 	_, err := conn.ExecContext(ctx, `
 SET CLUSTER SETTING sql.stats.automatic_collection.enabled=false;
+`)
+	require.NoError(t, err)
+	_, err = conn.ExecContext(ctx, `
 CREATE TABLE t (a INT PRIMARY KEY, b INT, c INT, INDEX(b));
 INSERT INTO t VALUES (1, 1, 1), (2, 2, 2);
 `)

--- a/pkg/sql/colfetcher/vectorized_batch_size_test.go
+++ b/pkg/sql/colfetcher/vectorized_batch_size_test.go
@@ -79,8 +79,9 @@ func TestScanBatchSize(t *testing.T) {
 
 			// Create the table with disabled automatic table stats collection (so
 			// that we can control whether they are present or not).
-			_, err := conn.ExecContext(ctx, `
-SET CLUSTER SETTING sql.stats.automatic_collection.enabled=false;
+			_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled=false;`)
+			assert.NoError(t, err)
+			_, err = conn.ExecContext(ctx, `
 CREATE TABLE t (a PRIMARY KEY, b) AS SELECT i, i FROM generate_series(1, 511) AS g(i)
 `)
 			assert.NoError(t, err)

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1245,6 +1245,10 @@ type connExecutor struct {
 		// statement traces to give more information in statement diagnostic bundles.
 		autoRetryReason error
 
+		// firstStmtExecuted indicates that the first statement inside this
+		// transaction has been executed.
+		firstStmtExecuted bool
+
 		// numDDL keeps track of how many DDL statements have been
 		// executed so far.
 		numDDL int
@@ -1626,6 +1630,7 @@ func (ns *prepStmtNamespace) resetTo(
 // (e.g. onTxnFinish() and onTxnRestart()).
 func (ex *connExecutor) resetExtraTxnState(ctx context.Context, ev txnEvent) error {
 	ex.extraTxnState.jobs = nil
+	ex.extraTxnState.firstStmtExecuted = false
 	ex.extraTxnState.hasAdminRoleCache = HasAdminRoleCache{}
 	ex.extraTxnState.schemaChangerState = SchemaChangerState{
 		mode: ex.sessionData().NewSchemaChangerMode,
@@ -2670,6 +2675,7 @@ func (ex *connExecutor) resetEvalCtx(evalCtx *extendedEvalContext, txn *kv.Txn, 
 	evalCtx.TxnState = ex.getTransactionState()
 	evalCtx.TxnReadOnly = ex.state.readOnly
 	evalCtx.TxnImplicit = ex.implicitTxn()
+	evalCtx.TxnIsSingleStmt = false
 	if newTxn || !ex.implicitTxn() {
 		// Only update the stmt timestamp if in a new txn or an explicit txn. This is because this gets
 		// called multiple times during an extended protocol implicit txn, but we
@@ -2831,7 +2837,9 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 	case txnStart:
 		atomic.StoreInt32(ex.extraTxnState.atomicAutoRetryCounter, 0)
 		ex.extraTxnState.autoRetryReason = nil
+		ex.extraTxnState.firstStmtExecuted = false
 		ex.recordTransactionStart(advInfo.txnEvent.txnID)
+		// Start of the transaction, so no statements were executed earlier.
 		// Bump the txn counter for logging.
 		ex.extraTxnState.txnCounter++
 		if !ex.server.cfg.Codec.ForSystemTenant() {

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -669,6 +669,8 @@ func (ex *connExecutor) execStmtInOpenState(
 	p.cancelChecker.Reset(ctx)
 
 	p.autoCommit = canAutoCommit && !ex.server.cfg.TestingKnobs.DisableAutoCommitDuringExec
+	p.extendedEvalCtx.TxnIsSingleStmt = canAutoCommit && !ex.extraTxnState.firstStmtExecuted
+	ex.extraTxnState.firstStmtExecuted = true
 
 	var stmtThresholdSpan *tracing.Span
 	alreadyRecording := ex.transitionCtx.sessionTracing.Enabled()

--- a/pkg/sql/create_stats_test.go
+++ b/pkg/sql/create_stats_test.go
@@ -52,7 +52,9 @@ func TestStatsWithLowTTL(t *testing.T) {
 
 	r := sqlutils.MakeSQLRunner(db)
 	r.Exec(t, `
-		SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;
+`)
+	r.Exec(t, `
 		CREATE DATABASE test;
 		USE test;
 		CREATE TABLE t (k INT PRIMARY KEY, a INT, b INT);

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -375,9 +375,9 @@ func (n *createTableNode) startExec(params runParams) error {
 			return err
 		}
 
-		// If we have an implicit txn we want to run CTAS async, and consequently
-		// ensure it gets queued as a SchemaChange.
-		if params.p.ExtendedEvalContext().TxnImplicit {
+		// If we have a single statement txn we want to run CTAS async, and
+		// consequently ensure it gets queued as a SchemaChange.
+		if params.extendedEvalCtx.TxnIsSingleStmt {
 			desc.State = descpb.DescriptorState_ADD
 		}
 	} else {
@@ -500,9 +500,9 @@ func (n *createTableNode) startExec(params runParams) error {
 		return err
 	}
 
-	// If we are in an explicit txn or the source has placeholders, we execute the
-	// CTAS query synchronously.
-	if n.n.As() && !params.p.ExtendedEvalContext().TxnImplicit {
+	// If we are in a multi-statement txn or the source has placeholders, we
+	// execute the CTAS query synchronously.
+	if n.n.As() && !params.extendedEvalCtx.TxnIsSingleStmt {
 		err = func() error {
 			// The data fill portion of CREATE AS must operate on a read snapshot,
 			// so that it doesn't end up observing its own writes.

--- a/pkg/sql/delete_preserving_index_test.go
+++ b/pkg/sql/delete_preserving_index_test.go
@@ -79,10 +79,9 @@ func TestDeletePreservingIndexEncoding(t *testing.T) {
 	}
 
 	server, sqlDB, kvDB := serverutils.StartServer(t, params)
-	_, err := sqlDB.Exec(`
-SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'off';
-SET use_declarative_schema_changer = 'off';
-`)
+	_, err := sqlDB.Exec(`SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'off';`)
+	require.NoError(t, err)
+	_, err = sqlDB.Exec(`SET use_declarative_schema_changer = 'off';`)
 	require.NoError(t, err)
 	defer server.Stopper().Stop(context.Background())
 

--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -899,6 +899,10 @@ func TestSchemaChangeCommandsWithPendingMutations(t *testing.T) {
 
 	if _, err := sqlDB.Exec(`
 SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'off';
+`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec(`
 SET use_declarative_schema_changer = 'off';
 CREATE DATABASE t;
 CREATE TABLE t.test (a STRING PRIMARY KEY, b STRING, c STRING, INDEX foo (c));

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -375,7 +375,11 @@ func TestDistSQLRangeCachesIntegrationTest(t *testing.T) {
 	tc.Server(3).DistSenderI().(*kvcoord.DistSender).DisableFirstRangeUpdates()
 	db3 := tc.ServerConn(3)
 	// Force the DistSQL on this connection.
-	_, err := db3.Exec(`SET CLUSTER SETTING sql.defaults.distsql = always; SET distsql = always`)
+	_, err := db3.Exec(`SET CLUSTER SETTING sql.defaults.distsql = always;`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db3.Exec(`SET distsql = always`)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -1298,8 +1298,10 @@ func dropLargeDatabaseGeneric(
 	defer s.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(db)
 	sqlDB.Exec(t, `
-CREATE DATABASE largedb;
 SET CLUSTER SETTING sql.catalog.descs.validate_on_write.enabled=no;
+`)
+	sqlDB.Exec(t, `
+CREATE DATABASE largedb;
 `)
 	stmts, err := sqltestutils.GenerateViewBasedGraphSchema(workloadParams)
 	require.NoError(t, err)

--- a/pkg/sql/event_log_test.go
+++ b/pkg/sql/event_log_test.go
@@ -694,7 +694,7 @@ func TestPerfLogging(t *testing.T) {
 	for _, tc := range testCases {
 		if tc.setup != "" {
 			t.Log(tc.setup)
-			db.Exec(t, tc.setup)
+			db.ExecMultiple(t, strings.Split(tc.setup, ";")...)
 			if tc.query == "" {
 				continue
 			}
@@ -739,7 +739,7 @@ func TestPerfLogging(t *testing.T) {
 
 		if tc.cleanup != "" {
 			t.Log(tc.cleanup)
-			db.Exec(t, tc.cleanup)
+			db.ExecMultiple(t, strings.Split(tc.cleanup, ";")...)
 		}
 	}
 }

--- a/pkg/sql/explain_tree_test.go
+++ b/pkg/sql/explain_tree_test.go
@@ -41,8 +41,9 @@ func TestPlanToTreeAndPlanToString(t *testing.T) {
 
 	execCfg := s.ExecutorConfig().(ExecutorConfig)
 	r := sqlutils.MakeSQLRunner(sqlDB)
-	r.Exec(t, `
-		SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;
+	r.ExecMultiple(t,
+		`SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;`,
+		`
 		CREATE DATABASE t;
 		USE t;
 	`)

--- a/pkg/sql/export.go
+++ b/pkg/sql/export.go
@@ -123,7 +123,7 @@ func (ef *execFactory) ConstructExport(
 		return nil, err
 	}
 
-	if !ef.planner.IsAutoCommit() {
+	if !ef.planner.ExtendedEvalContext().TxnIsSingleStmt {
 		return nil, errors.Errorf("EXPORT cannot be used inside a multi-statement transaction")
 	}
 

--- a/pkg/sql/importer/import_planning.go
+++ b/pkg/sql/importer/import_planning.go
@@ -372,7 +372,7 @@ func importPlanHook(
 		ctx, span := tracing.ChildSpan(ctx, importStmt.StatementTag())
 		defer span.Finish()
 
-		if !(p.IsAutoCommit() || isDetached) {
+		if !(p.ExtendedEvalContext().TxnIsSingleStmt || isDetached) {
 			return errors.Errorf("IMPORT cannot be used inside a multi-statement transaction without DETACHED option")
 		}
 

--- a/pkg/sql/logictest/testdata/logic_test/feature_counts
+++ b/pkg/sql/logictest/testdata/logic_test/feature_counts
@@ -13,9 +13,15 @@ errorcodes.42601
 
 statement ok
 SET CLUSTER SETTING server.auth_log.sql_connections.enabled = true;
+
+statement ok
 SET CLUSTER SETTING server.auth_log.sql_connections.enabled = false;
-  SET CLUSTER SETTING server.auth_log.sql_sessions.enabled = true;
-  SET CLUSTER SETTING server.auth_log.sql_sessions.enabled = false
+
+statement ok
+SET CLUSTER SETTING server.auth_log.sql_sessions.enabled = true;
+
+statement ok
+SET CLUSTER SETTING server.auth_log.sql_sessions.enabled = false
 
 query IT colnames
 SELECT usage_count, feature_name

--- a/pkg/sql/logictest/testdata/logic_test/index_join
+++ b/pkg/sql/logictest/testdata/logic_test/index_join
@@ -13,6 +13,8 @@ CREATE TABLE lineitem
     INDEX l_sd (l_shipdate ASC)
 );
 INSERT INTO lineitem VALUES (1, 200, '1994-01-01');
+
+statement ok
 ALTER TABLE lineitem INJECT STATISTICS '[
   {
     "columns": ["l_orderkey"],

--- a/pkg/sql/logictest/testdata/logic_test/jobs
+++ b/pkg/sql/logictest/testdata/logic_test/jobs
@@ -1,6 +1,8 @@
 # Disable declarative schema changer for this test.
 statement ok
 SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'off';
+
+statement ok;
 SET use_declarative_schema_changer = 'off';
 
 # These test verify that a user's job are visible via

--- a/pkg/sql/logictest/testdata/logic_test/materialized_view
+++ b/pkg/sql/logictest/testdata/logic_test/materialized_view
@@ -90,7 +90,7 @@ SELECT y FROM v WHERE y > 4
 statement ok
 BEGIN
 
-statement error pq: cannot refresh view in an explicit transaction
+statement error  pq: cannot refresh view in a multi-statement transaction
 REFRESH MATERIALIZED VIEW v
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -1038,6 +1038,8 @@ subtest join
 statement ok
 CREATE TABLE join_small (m INT, n INT);
 CREATE TABLE join_large (i INT, s STRING, INDEX (i) WHERE s IN ('foo', 'bar', 'baz'));
+
+statement ok
 ALTER TABLE join_small INJECT STATISTICS '[
   {
     "columns": ["m"],
@@ -1046,6 +1048,8 @@ ALTER TABLE join_small INJECT STATISTICS '[
     "distinct_count": 20
   }
 ]';
+
+statement ok
 ALTER TABLE join_large INJECT STATISTICS '[
   {
     "columns": ["i"],
@@ -1060,6 +1064,8 @@ ALTER TABLE join_large INJECT STATISTICS '[
     "distinct_count": 50
   }
 ]';
+
+statement ok
 INSERT INTO join_small VALUES (1, 1), (2, 2), (3, 3);
 INSERT INTO join_large VALUES (1, 'foo'), (2, 'not'), (3, 'bar'), (4, 'not');
 

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -1547,4 +1547,6 @@ hash8  SCRAM-SHA-256$200000
 # Reset cluster setting after test completion.
 statement ok
 RESET CLUSTER SETTING server.user_login.password_encryption;
+
+statement ok
 RESET CLUSTER SETTING server.user_login.password_hashes.default_cost.scram_sha_256

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_feature_flags
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_feature_flags
@@ -17,7 +17,11 @@ CREATE SCHEMA s;
 # Test CREATE TYPE.
 statement ok
 SET CLUSTER SETTING feature.schema_change.enabled = TRUE;
+
+statement ok
 CREATE SCHEMA s;
+
+statement ok
 SET CLUSTER SETTING feature.schema_change.enabled = FALSE
 
 statement error pq: feature CREATE TYPE is part of the schema change category, which was disabled by the database administrator
@@ -34,7 +38,11 @@ CREATE SEQUENCE seq
 # Test CREATE INDEX.
 statement ok
 SET CLUSTER SETTING feature.schema_change.enabled = TRUE;
+
+statement ok
 CREATE TABLE t1(a INT8, b INT8);
+
+statement ok
 SET CLUSTER SETTING feature.schema_change.enabled = FALSE
 
 statement error pq: feature CREATE INDEX is part of the schema change category, which was disabled by the database administrator
@@ -43,7 +51,11 @@ CREATE INDEX on t1 (a, b)
 # Test ALTER DATABASE OWNER.
 statement ok
 SET CLUSTER SETTING feature.schema_change.enabled = TRUE;
+
+statement ok
 CREATE DATABASE d;
+
+statement ok
 SET CLUSTER SETTING feature.schema_change.enabled = FALSE
 
 statement error pq: feature ALTER DATABASE is part of the schema change category, which was disabled by the database administrator
@@ -71,7 +83,11 @@ ALTER DATABASE d CONVERT TO SCHEMA WITH PARENT test
 
 statement ok
 SET CLUSTER SETTING feature.schema_change.enabled = TRUE;
+
+statement ok
 CREATE TABLE t();
+
+statement ok
 SET CLUSTER SETTING feature.schema_change.enabled = FALSE
 
 # Test ALTER TABLE PARTITION BY.
@@ -140,7 +156,11 @@ ALTER TABLE t1 UNSPLIT ALL
 
 statement ok
 SET CLUSTER SETTING feature.schema_change.enabled = TRUE;
+
+statement ok
 CREATE INDEX i on t1 (a, b);
+
+statement ok
 SET CLUSTER SETTING feature.schema_change.enabled = FALSE;
 
 # Test RENAME COLUMN, throws ALTER TABLE error.
@@ -178,7 +198,11 @@ ALTER SCHEMA s OWNER TO testuser
 # Test ALTER TYPE.
 statement ok
 SET CLUSTER SETTING feature.schema_change.enabled = TRUE;
+
+statement ok
 CREATE TYPE s.typ AS ENUM ();
+
+statement ok
 SET CLUSTER SETTING feature.schema_change.enabled = FALSE
 
 # Test ALTER TYPE ADD VALUE.
@@ -200,7 +224,11 @@ ALTER TYPE s.typ SET SCHEMA s
 # Test ALTER SEQUENCE.
 statement ok
 SET CLUSTER SETTING feature.schema_change.enabled = TRUE;
+
+statement ok
 CREATE SEQUENCE seq;
+
+statement ok
 SET CLUSTER SETTING feature.schema_change.enabled = FALSE
 
 # Test RENAME SEQUENCE.
@@ -245,7 +273,11 @@ DROP SEQUENCE seq
 # Test DROP VIEW.
 statement ok
 SET CLUSTER SETTING feature.schema_change.enabled = TRUE;
+
+statement ok
 CREATE VIEW public.bar (x) AS SELECT 1 AS x;
+
+statement ok
 SET CLUSTER SETTING feature.schema_change.enabled = FALSE
 
 # Test ALTER VIEW SET SCHEMA

--- a/pkg/sql/logictest/testdata/logic_test/statement_statistics
+++ b/pkg/sql/logictest/testdata/logic_test/statement_statistics
@@ -109,7 +109,10 @@ SELECT x FROM test WHERE y = 1/z
 # Set a cluster setting to make it show up below. Which one is set
 # does not matter.
 statement ok
-SET CLUSTER SETTING debug.panic_on_failed_assertions = true; RESET CLUSTER SETTING debug.panic_on_failed_assertions
+SET CLUSTER SETTING debug.panic_on_failed_assertions = true;
+
+statement ok
+RESET CLUSTER SETTING debug.panic_on_failed_assertions
 
 statement ok
 SHOW application_name

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -1220,6 +1220,6 @@ regular
 
 # Sanity: Implicit txns with multiple statements can't have SET CLUSTER
 # SETTING.
-statement error pq: SET CLUSTER SETTING cannot be used inside an explicit transaction
+statement error pq: SET CLUSTER SETTING cannot be used inside a multi-statement transaction
 SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'on';
 SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'off';

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -1217,3 +1217,9 @@ query T
 SHOW default_transaction_quality_of_service
 ----
 regular
+
+# Sanity: Implicit txns with multiple statements can't have SET CLUSTER
+# SETTING.
+statement error pq: SET CLUSTER SETTING cannot be used inside an explicit transaction
+SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'on';
+SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'off';

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -1220,6 +1220,8 @@ DROP TABLE target
 # Regression test for UPSERT batching logic (#51391).
 statement ok
 SET CLUSTER SETTING kv.raft.command.max_size='4MiB';
+
+statement ok
 CREATE TABLE src (s STRING);
 CREATE TABLE dest (s STRING);
 INSERT INTO src
@@ -1235,6 +1237,8 @@ UPSERT INTO dest (s) (SELECT s FROM src)
 
 statement ok
 RESET CLUSTER SETTING kv.raft.command.max_size;
+
+statement ok
 DROP TABLE src;
 DROP TABLE dest
 

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -315,6 +315,8 @@ CREATE TABLE c (a INT, b INT, c INT, d INT, PRIMARY KEY (a, c), INDEX sec (b));
 CREATE TABLE d (a INT, b INT, PRIMARY KEY (b, a));
 INSERT INTO c VALUES (1, 1, 1, 0), (2, 1, 2, 0);
 INSERT INTO d VALUES (1, 1), (1, 2);
+
+statement ok
 ALTER TABLE c INJECT STATISTICS '[
   {
     "columns": ["a"],

--- a/pkg/sql/materialized_view_test.go
+++ b/pkg/sql/materialized_view_test.go
@@ -60,6 +60,10 @@ CREATE MATERIALIZED VIEW t.v AS SELECT x FROM t.t;
 	// Update the view and refresh it.
 	if _, err := sqlDB.Exec(`
 INSERT INTO t.t VALUES (3);
+`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec(`
 REFRESH MATERIALIZED VIEW t.v;
 `); err != nil {
 		t.Fatal(err)

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -1414,6 +1414,8 @@ SET prefer_lookup_joins_for_fks = false
 # into the child table.
 statement ok
 CREATE TABLE small_parent (p INT PRIMARY KEY);
+
+statement ok
 ALTER TABLE small_parent INJECT STATISTICS '[
   {
     "columns": ["p"],

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -1827,6 +1827,8 @@ vectorized: true
 # values.
 statement ok
 CREATE TABLE nulls (x INT, y INT);
+
+statement ok
 ALTER TABLE nulls INJECT STATISTICS '[
     {
         "columns": [

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace_nonmetamorphic
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace_nonmetamorphic
@@ -117,7 +117,10 @@ batch flow coordinator  InitPut /Table/108/2/2/0 -> /BYTES/0x8a
 sql query               execution failed after 0 rows: duplicate key value violates unique constraint "woo"
 
 statement ok
-SET tracing = on,kv,results; CREATE TABLE t.kv2 AS TABLE t.kv; SET tracing = off
+SET tracing = on,kv,results; CREATE TABLE t.kv2 AS TABLE t.kv;
+
+statement ok
+SET tracing = off
 
 query TT
 $trace_query
@@ -127,7 +130,10 @@ batch flow coordinator  CPut /Table/3/1/109/2/1 -> table:<name:"kv2" id:109 vers
 sql query               rows affected: 0
 
 statement ok
-SET tracing = on,kv,results; UPDATE t.kv2 SET v = v + 2; SET tracing = off
+SET tracing = on,kv,results; UPDATE t.kv2 SET v = v + 2;
+
+statement ok
+SET tracing = off
 
 query TT
 $trace_query

--- a/pkg/sql/opt/exec/execbuilder/testdata/tpch_vec
+++ b/pkg/sql/opt/exec/execbuilder/testdata/tpch_vec
@@ -7466,6 +7466,8 @@ CREATE TABLE public.customer
     INDEX c_nk (c_nationkey ASC),
     CONSTRAINT customer_fkey_nation FOREIGN KEY (c_nationkey) references public.nation (n_nationkey)
 );
+
+statement ok
 ALTER TABLE public.customer INJECT STATISTICS '
   [
       {

--- a/pkg/sql/pgwire/testdata/auth/password_change
+++ b/pkg/sql/pgwire/testdata/auth/password_change
@@ -58,6 +58,10 @@ subtest regular_user/scram
 
 sql
 SET CLUSTER SETTING server.user_login.password_encryption = 'scram-sha-256';
+----
+ok
+
+sql
 DROP USER userpw;
 ----
 ok

--- a/pkg/sql/pgwire/testdata/auth/scram
+++ b/pkg/sql/pgwire/testdata/auth/scram
@@ -4,12 +4,32 @@ config secure
 sql
 -- prevent auto-converting passwords, so that each sub-test exercises its own hash method.
 SET CLUSTER SETTING server.user_login.upgrade_bcrypt_stored_passwords_to_scram.enabled = false;
+----
+ok
+
+sql
 -- Explicit hash.
 CREATE USER abc WITH PASSWORD 'SCRAM-SHA-256$4096:pAlYy62NTdETKb291V/Wow==$OXMAj9oD53QucEYVMBcdhRnjg2/S/iZY/88ShZnputA=:r8l4c1pk9bmDi+8an059l/nt9Bg1zb1ikkg+DeRv4UQ=';
+----
+ok
+
+sql
 -- Automatic hashes.
 SET CLUSTER SETTING server.user_login.password_encryption = 'crdb-bcrypt';
+----
+ok
+
+sql
 CREATE USER foo WITH PASSWORD 'abc';
+----
+ok
+
+sql
 SET CLUSTER SETTING server.user_login.password_encryption = 'scram-sha-256';
+----
+ok
+
+sql
 CREATE USER abc2 WITH PASSWORD 'abc'
 ----
 ok

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -108,7 +108,6 @@ type PlanHookState interface {
 	MigrationJobDeps() migration.JobDeps
 	SpanConfigReconciler() spanconfig.Reconciler
 	BufferClientNotice(ctx context.Context, notice pgnotice.Notice)
-	IsAutoCommit() bool
 }
 
 // AddPlanHook adds a hook used to short-circuit creating a planNode from a

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -471,6 +471,7 @@ func internalExtendedEvalCtx(
 			SessionDataStack:          sds,
 			TxnReadOnly:               false,
 			TxnImplicit:               true,
+			TxnIsSingleStmt:           true,
 			Context:                   ctx,
 			Mon:                       plannerMon,
 			TestingKnobs:              evalContextTestingKnobs,
@@ -500,11 +501,6 @@ func (p *planner) SemaCtx() *tree.SemaContext {
 // Note: if the context will be modified, use ExtendedEvalContextCopy instead.
 func (p *planner) ExtendedEvalContext() *extendedEvalContext {
 	return &p.extendedEvalCtx
-}
-
-// IsAutoCommit implements the PlanHookState interface.
-func (p *planner) IsAutoCommit() bool {
-	return p.autoCommit
 }
 
 func (p *planner) ExtendedEvalContextCopy() *extendedEvalContext {

--- a/pkg/sql/refresh_materialized_view.go
+++ b/pkg/sql/refresh_materialized_view.go
@@ -30,8 +30,8 @@ type refreshMaterializedViewNode struct {
 func (p *planner) RefreshMaterializedView(
 	ctx context.Context, n *tree.RefreshMaterializedView,
 ) (planNode, error) {
-	if !p.EvalContext().TxnImplicit {
-		return nil, pgerror.Newf(pgcode.InvalidTransactionState, "cannot refresh view in an explicit transaction")
+	if !p.extendedEvalCtx.TxnIsSingleStmt {
+		return nil, pgerror.Newf(pgcode.InvalidTransactionState, "cannot refresh view in a multi-statement transaction")
 	}
 	_, desc, err := p.ResolveMutableTableDescriptorEx(ctx, n.Name, true /* required */, tree.ResolveRequireViewDesc)
 	if err != nil {

--- a/pkg/sql/schema_change_plan_node.go
+++ b/pkg/sql/schema_change_plan_node.go
@@ -55,7 +55,7 @@ func (p *planner) SchemaChange(ctx context.Context, stmt tree.Statement) (planNo
 	// support it.
 	if mode == sessiondatapb.UseNewSchemaChangerOff ||
 		((mode == sessiondatapb.UseNewSchemaChangerOn ||
-			mode == sessiondatapb.UseNewSchemaChangerUnsafe) && !p.extendedEvalCtx.TxnImplicit) {
+			mode == sessiondatapb.UseNewSchemaChangerUnsafe) && !p.extendedEvalCtx.TxnIsSingleStmt) {
 		return nil, false, nil
 	}
 	scs := p.extendedEvalCtx.SchemaChangerState

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -754,7 +754,11 @@ func TestDropWhileBackfill(t *testing.T) {
 	sqlDB := tc.ServerConn(0)
 
 	if _, err := sqlDB.Exec(`
-SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'off';
+	SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'off';
+`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec(`
 SET use_declarative_schema_changer = 'off';
 CREATE DATABASE t;
 CREATE TABLE t.test (k INT PRIMARY KEY, v INT, pi DECIMAL DEFAULT (DECIMAL '3.14'));

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3602,7 +3602,11 @@ type EvalContext struct {
 	TxnState string
 	// TxnReadOnly specifies if the current transaction is read-only.
 	TxnReadOnly bool
+	// TxnImplicit specifies if the current transaction is implicit.
 	TxnImplicit bool
+	// TxnIsSingleStmt specifies the current implicit transaction consists of only
+	// a single statement.
+	TxnIsSingleStmt bool
 
 	Settings    *cluster.Settings
 	ClusterID   uuid.UUID

--- a/pkg/sql/session_state.go
+++ b/pkg/sql/session_state.go
@@ -39,7 +39,7 @@ var maxSerializedSessionSize = settings.RegisterByteSizeSetting(
 func (p *planner) SerializeSessionState() (*tree.DBytes, error) {
 	evalCtx := p.EvalContext()
 	return serializeSessionState(
-		!evalCtx.TxnImplicit,
+		!evalCtx.TxnIsSingleStmt,
 		evalCtx.PreparedStatementState,
 		p.SessionData(),
 		p.ExecCfg(),
@@ -111,10 +111,10 @@ func serializeSessionState(
 // DeserializeSessionState deserializes the given state into the current session.
 func (p *planner) DeserializeSessionState(state *tree.DBytes) (*tree.DBool, error) {
 	evalCtx := p.ExtendedEvalContext()
-	if !evalCtx.TxnImplicit {
+	if !evalCtx.TxnIsSingleStmt {
 		return nil, pgerror.Newf(
 			pgcode.InvalidTransactionState,
-			"cannot deserialize a session whilst inside a transaction",
+			"cannot deserialize a session whilst inside a multi-statement transaction",
 		)
 	}
 

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -193,8 +193,8 @@ func (p *planner) getAndValidateTypedClusterSetting(
 }
 
 func (n *setClusterSettingNode) startExec(params runParams) error {
-	if !params.p.ExtendedEvalContext().TxnImplicit {
-		return errors.Errorf("SET CLUSTER SETTING cannot be used inside an explicit transaction")
+	if !params.extendedEvalCtx.TxnIsSingleStmt {
+		return errors.Errorf("SET CLUSTER SETTING cannot be used inside a multi-statement transaction")
 	}
 
 	expectedEncodedValue, err := writeSettingInternal(

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -164,7 +164,7 @@ func (p *planner) applyOnSessionDataMutators(
 	if local {
 		// We don't allocate a new SessionData object on implicit transactions.
 		// This no-ops in postgres with a warning, so copy accordingly.
-		if p.EvalContext().TxnImplicit {
+		if p.extendedEvalCtx.TxnIsSingleStmt {
 			p.BufferClientNotice(
 				ctx,
 				pgnotice.NewWithSeverityf(

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -43,7 +43,7 @@ func (p *planner) DeclareCursor(ctx context.Context, s *tree.DeclareCursor) (pla
 	return &delayedNode{
 		name: s.String(),
 		constructor: func(ctx context.Context, p *planner) (_ planNode, _ error) {
-			if p.extendedEvalCtx.TxnImplicit {
+			if p.extendedEvalCtx.TxnIsSingleStmt {
 				return nil, pgerror.Newf(pgcode.NoActiveSQLTransaction, "DECLARE CURSOR can only be used in transaction blocks")
 			}
 

--- a/pkg/sql/sqltestutils/show_create_table.go
+++ b/pkg/sql/sqltestutils/show_create_table.go
@@ -49,6 +49,10 @@ func ShowCreateTableTest(
 
 	if _, err := sqlDB.Exec(`
     SET CLUSTER SETTING sql.cross_db_fks.enabled = TRUE;
+`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec(`
 		CREATE DATABASE d;
 		USE d;
 		-- Create a table we can point FKs to.

--- a/pkg/sql/tenant.go
+++ b/pkg/sql/tenant.go
@@ -534,8 +534,8 @@ func gcTenantJob(
 func (p *planner) GCTenant(ctx context.Context, tenID uint64) error {
 	// TODO(jeffswenson): Delete internal_crdb.gc_tenant after the DestroyTenant
 	// changes are deployed to all Cockroach Cloud serverless hosts.
-	if !p.ExtendedEvalContext().TxnImplicit {
-		return errors.Errorf("gc_tenant cannot be used inside a transaction")
+	if !p.extendedEvalCtx.TxnIsSingleStmt {
+		return errors.Errorf("gc_tenant cannot be used inside a multi-statement transaction")
 	}
 	var info *descpb.TenantInfo
 	if txnErr := p.ExecCfg().DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {

--- a/pkg/sql/testdata/session_migration/errors
+++ b/pkg/sql/testdata/session_migration/errors
@@ -44,7 +44,7 @@ BEGIN
 exec
 SELECT crdb_internal.deserialize_session( decode('$x', 'hex') )
 ----
-ERROR: crdb_internal.deserialize_session(): cannot deserialize a session whilst inside a transaction (SQLSTATE 25000)
+ERROR: crdb_internal.deserialize_session(): cannot deserialize a session whilst inside a multi-statement transaction (SQLSTATE 25000)
 
 reset
 ----

--- a/pkg/sql/testdata/telemetry/feature_flags
+++ b/pkg/sql/testdata/telemetry/feature_flags
@@ -24,6 +24,9 @@ SET CLUSTER SETTING feature.schema_change.enabled = TRUE;
 exec
 CREATE TABLE t(a int, b int);
 INSERT INTO t (a, b) VALUES (0, 1);
+----
+
+exec
 SET CLUSTER SETTING feature.stats.enabled = FALSE;
 ----
 

--- a/pkg/sql/ttl/ttljob/ttljob_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_test.go
@@ -268,7 +268,7 @@ INSERT INTO t (id, crdb_internal_expiration) VALUES (1, now() - '1 month'), (2, 
 			})
 			defer cleanupFunc()
 
-			th.sqlDB.Exec(t, tc.setup)
+			th.sqlDB.ExecMultiple(t, strings.Split(tc.setup, ";")...)
 
 			// Force the schedule to execute.
 			th.env.SetTime(timeutil.Now().Add(time.Hour * 24))

--- a/pkg/testutils/sqlutils/sql_runner.go
+++ b/pkg/testutils/sqlutils/sql_runner.go
@@ -65,6 +65,18 @@ func (sr *SQLRunner) Exec(t testutils.TB, query string, args ...interface{}) gos
 	return r
 }
 
+// ExecMultiple is a wrapper around gosql.Exec that executes multiple statements
+// and kills the test on error.
+func (sr *SQLRunner) ExecMultiple(t testutils.TB, queries ...string) {
+	t.Helper()
+	for _, query := range queries {
+		_, err := sr.DB.ExecContext(context.Background(), query)
+		if err != nil {
+			t.Fatalf("error executing '%s': %s", query, err)
+		}
+	}
+}
+
 func (sr *SQLRunner) succeedsWithin(t testutils.TB, f func() error) {
 	t.Helper()
 	d := sr.SucceedsSoonDuration


### PR DESCRIPTION
Previously, an enhancement was made to allow implicit
transactions to execute multiple statements, which caused
code to block operations in implicit transactions to break.
This was problematic because these scenarios cared that
only a single statement is executed, and not if it was
only an implicit transition. For example, the declarative
schema changer and legacy schema changer could be mixed
in implicit transactions after this change. To address this,
this patch modifies places that we're checking for implicit
transactions to instead check for single statement transactions.

Release note: None
