### PR TITLE
release-21.2: sql: scheduled logger to capture index usage stats

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2205,6 +2205,32 @@ An event of type `drop_role` is recorded when a role is dropped.
 Events in this category are logged to the `TELEMETRY` channel.
 
 
+### `captured_index_usage_stats`
+
+An event of type `captured_index_usage_stats`
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `TotalReadCount` | TotalReadCount is the number of times this index has been read from. | no |
+| `LastRead` | LastRead is the timestamp that this index was last being read from. | yes |
+| `TableID` | TableID is the ID of the table this index is created on. This is same as descpb.TableID and is unique within the cluster. | no |
+| `IndexID` | IndexID is the ID of the index within the scope of the given table. | no |
+| `DatabaseName` |  | yes |
+| `TableName` |  | yes |
+| `IndexName` |  | yes |
+| `IndexType` |  | yes |
+| `IsUnique` |  | no |
+| `IsInverted` |  | no |
+
+
+#### Common fields
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
+| `EventType` | The type of the event. | no |
+
 ### `sampled_query`
 
 An event of type `sampled_query` is the SQL query event logged to the telemetry channel. It

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -287,6 +287,7 @@ ALL_TESTS = [
     "//pkg/sql/rowexec:rowexec_test",
     "//pkg/sql/rowflow:rowflow_test",
     "//pkg/sql/scanner:scanner_test",
+    "//pkg/sql/scheduledlogging:scheduledlogging_test",
     "//pkg/sql/schemachange:schemachange_test",
     "//pkg/sql/schemachanger/scbuild:scbuild_test",
     "//pkg/sql/schemachanger/scexec:scexec_test",

--- a/pkg/base/testing_knobs.go
+++ b/pkg/base/testing_knobs.go
@@ -19,29 +19,31 @@ type ModuleTestingKnobs interface {
 // TestingKnobs contains facilities for controlling various parts of the
 // system for testing.
 type TestingKnobs struct {
-	Store                   ModuleTestingKnobs
-	KVClient                ModuleTestingKnobs
-	RangeFeed               ModuleTestingKnobs
-	SQLExecutor             ModuleTestingKnobs
-	SQLLeaseManager         ModuleTestingKnobs
-	SQLSchemaChanger        ModuleTestingKnobs
-	SQLNewSchemaChanger     ModuleTestingKnobs
-	SQLTypeSchemaChanger    ModuleTestingKnobs
-	GCJob                   ModuleTestingKnobs
-	PGWireTestingKnobs      ModuleTestingKnobs
-	StartupMigrationManager ModuleTestingKnobs
-	DistSQL                 ModuleTestingKnobs
-	SQLEvalContext          ModuleTestingKnobs
-	NodeLiveness            ModuleTestingKnobs
-	Server                  ModuleTestingKnobs
-	TenantTestingKnobs      ModuleTestingKnobs
-	JobsTestingKnobs        ModuleTestingKnobs
-	BackupRestore           ModuleTestingKnobs
-	Streaming               ModuleTestingKnobs
-	MigrationManager        ModuleTestingKnobs
-	IndexUsageStatsKnobs    ModuleTestingKnobs
-	SQLStatsKnobs           ModuleTestingKnobs
-	SpanConfig              ModuleTestingKnobs
-	SQLLivenessKnobs        ModuleTestingKnobs
-	TelemetryLoggingKnobs   ModuleTestingKnobs
+	Store                        ModuleTestingKnobs
+	KVClient                     ModuleTestingKnobs
+	RangeFeed                    ModuleTestingKnobs
+	SQLExecutor                  ModuleTestingKnobs
+	SQLLeaseManager              ModuleTestingKnobs
+	SQLSchemaChanger             ModuleTestingKnobs
+	SQLDeclarativeSchemaChanger  ModuleTestingKnobs
+	SQLTypeSchemaChanger         ModuleTestingKnobs
+	GCJob                        ModuleTestingKnobs
+	PGWireTestingKnobs           ModuleTestingKnobs
+	StartupMigrationManager      ModuleTestingKnobs
+	DistSQL                      ModuleTestingKnobs
+	SQLEvalContext               ModuleTestingKnobs
+	NodeLiveness                 ModuleTestingKnobs
+	Server                       ModuleTestingKnobs
+	TenantTestingKnobs           ModuleTestingKnobs
+	JobsTestingKnobs             ModuleTestingKnobs
+	BackupRestore                ModuleTestingKnobs
+	TTL                          ModuleTestingKnobs
+	Streaming                    ModuleTestingKnobs
+	MigrationManager             ModuleTestingKnobs
+	IndexUsageStatsKnobs         ModuleTestingKnobs
+	SQLStatsKnobs                ModuleTestingKnobs
+	SpanConfig                   ModuleTestingKnobs
+	SQLLivenessKnobs             ModuleTestingKnobs
+	TelemetryLoggingKnobs        ModuleTestingKnobs
+	CapturedIndexUsageStatsKnobs ModuleTestingKnobs
 }

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -146,6 +146,8 @@ go_library(
         "//pkg/sql/querycache",
         "//pkg/sql/roleoption",
         "//pkg/sql/schemachanger/scexec",
+        "//pkg/sql/scheduledlogging",
+        "//pkg/sql/schemachanger/scdeps",
         "//pkg/sql/schemachanger/scjob",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -343,6 +343,7 @@ go_library(
         "//pkg/sql/rowenc",
         "//pkg/sql/rowexec",
         "//pkg/sql/rowinfra",
+        "//pkg/sql/scheduledlogging",
         "//pkg/sql/schemachange",
         "//pkg/sql/schemachanger/scbuild",
         "//pkg/sql/schemachanger/scexec",

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -72,7 +72,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/querycache"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
-	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
+	"github.com/cockroachdb/cockroach/pkg/sql/scheduledlogging"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
@@ -1088,20 +1088,24 @@ type ExecutorConfig struct {
 	RowMetrics           *row.Metrics
 	InternalRowMetrics   *row.Metrics
 
-	TestingKnobs                  ExecutorTestingKnobs
-	MigrationTestingKnobs         *migration.TestingKnobs
-	PGWireTestingKnobs            *PGWireTestingKnobs
-	SchemaChangerTestingKnobs     *SchemaChangerTestingKnobs
-	NewSchemaChangerTestingKnobs  *scexec.NewSchemaChangerTestingKnobs
-	TypeSchemaChangerTestingKnobs *TypeSchemaChangerTestingKnobs
-	GCJobTestingKnobs             *GCJobTestingKnobs
-	DistSQLRunTestingKnobs        *execinfra.TestingKnobs
-	EvalContextTestingKnobs       tree.EvalContextTestingKnobs
-	TenantTestingKnobs            *TenantTestingKnobs
-	BackupRestoreTestingKnobs     *BackupRestoreTestingKnobs
-	StreamingTestingKnobs         *StreamingTestingKnobs
-	SQLStatsTestingKnobs          *sqlstats.TestingKnobs
-	TelemetryLoggingTestingKnobs  *TelemetryLoggingTestingKnobs
+	TestingKnobs                         ExecutorTestingKnobs
+	MigrationTestingKnobs                *migration.TestingKnobs
+	PGWireTestingKnobs                   *PGWireTestingKnobs
+	SchemaChangerTestingKnobs            *SchemaChangerTestingKnobs
+	DeclarativeSchemaChangerTestingKnobs *scrun.TestingKnobs
+	TypeSchemaChangerTestingKnobs        *TypeSchemaChangerTestingKnobs
+	GCJobTestingKnobs                    *GCJobTestingKnobs
+	DistSQLRunTestingKnobs               *execinfra.TestingKnobs
+	EvalContextTestingKnobs              tree.EvalContextTestingKnobs
+	TenantTestingKnobs                   *TenantTestingKnobs
+	TTLTestingKnobs                      *TTLTestingKnobs
+	BackupRestoreTestingKnobs            *BackupRestoreTestingKnobs
+	StreamingTestingKnobs                *StreamingTestingKnobs
+	SQLStatsTestingKnobs                 *sqlstats.TestingKnobs
+	TelemetryLoggingTestingKnobs         *TelemetryLoggingTestingKnobs
+	SpanConfigTestingKnobs               *spanconfig.TestingKnobs
+	CaptureIndexUsageStatsKnobs          *scheduledlogging.CaptureIndexUsageStatsTestingKnobs
+
 	// HistogramWindowInterval is (server.Config).HistogramWindowInterval.
 	HistogramWindowInterval time.Duration
 

--- a/pkg/sql/scheduledlogging/BUILD.bazel
+++ b/pkg/sql/scheduledlogging/BUILD.bazel
@@ -1,0 +1,51 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "scheduledlogging",
+    srcs = ["captured_index_usage_stats.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/scheduledlogging",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/kv",
+        "//pkg/roachpb",
+        "//pkg/security",
+        "//pkg/settings",
+        "//pkg/settings/cluster",
+        "//pkg/sql/sem/tree",
+        "//pkg/sql/sessiondata",
+        "//pkg/sql/sqlutil",
+        "//pkg/util/log",
+        "//pkg/util/log/eventpb",
+        "//pkg/util/stop",
+        "//pkg/util/timeutil",
+        "@com_github_cockroachdb_errors//:errors",
+    ],
+)
+
+go_test(
+    name = "scheduledlogging_test",
+    srcs = [
+        "captured_index_usage_stats_test.go",
+        "main_test.go",
+    ],
+    embed = [":scheduledlogging"],
+    deps = [
+        "//pkg/base",
+        "//pkg/security",
+        "//pkg/security/securitytest",
+        "//pkg/server",
+        "//pkg/settings/cluster",
+        "//pkg/testutils",
+        "//pkg/testutils/serverutils",
+        "//pkg/testutils/sqlutils",
+        "//pkg/testutils/testcluster",
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
+        "//pkg/util/log/channel",
+        "//pkg/util/log/logconfig",
+        "//pkg/util/randutil",
+        "//pkg/util/syncutil",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/sql/scheduledlogging/captured_index_usage_stats.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats.go
@@ -1,0 +1,318 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package scheduledlogging
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+)
+
+var telemetryCaptureIndexUsageStatsEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
+	"sql.telemetry.capture_index_usage_stats.enabled",
+	"enable/disable capturing index usage statistics to the telemetry logging channel",
+	true,
+)
+
+var telemetryCaptureIndexUsageStatsInterval = settings.RegisterDurationSetting(
+	settings.SystemOnly,
+	"sql.telemetry.capture_index_usage_stats.interval",
+	"the scheduled interval time between capturing index usage statistics when capturing index usage statistics is enabled",
+	8*time.Hour,
+	settings.NonNegativeDuration,
+)
+
+var telemetryCaptureIndexUsageStatsStatusCheckEnabledInterval = settings.RegisterDurationSetting(
+	settings.SystemOnly,
+	"sql.telemetry.capture_index_usage_stats.check_enabled_interval",
+	"the scheduled interval time between checks to see if index usage statistics has been enabled",
+	10*time.Minute,
+	settings.NonNegativeDuration,
+)
+
+var telemetryCaptureIndexUsageStatsLoggingDelay = settings.RegisterDurationSetting(
+	settings.SystemOnly,
+	"sql.telemetry.capture_index_usage_stats.logging_delay",
+	"the time delay between emitting individual index usage stats logs, this is done to "+
+		"mitigate the log-line limit of 10 logs per second on the telemetry pipeline",
+	500*time.Millisecond,
+	settings.NonNegativeDuration,
+)
+
+// CaptureIndexUsageStatsTestingKnobs provides hooks and knobs for unit tests.
+type CaptureIndexUsageStatsTestingKnobs struct {
+	// getLoggingDuration allows tests to override the duration of the index
+	// usage stats logging operation.
+	getLoggingDuration func() time.Duration
+	// getOverlapDuration allows tests to override the duration until the next
+	// scheduled interval in the case that the logging duration exceeds the
+	// default scheduled interval duration.
+	getOverlapDuration func() time.Duration
+}
+
+// ModuleTestingKnobs implements base.ModuleTestingKnobs interface.
+func (*CaptureIndexUsageStatsTestingKnobs) ModuleTestingKnobs() {}
+
+// CaptureIndexUsageStatsLoggingScheduler is responsible for logging index usage stats
+// on a scheduled interval.
+type CaptureIndexUsageStatsLoggingScheduler struct {
+	db                      *kv.DB
+	st                      *cluster.Settings
+	ie                      sqlutil.InternalExecutor
+	knobs                   *CaptureIndexUsageStatsTestingKnobs
+	currentCaptureStartTime time.Time
+}
+
+func (s *CaptureIndexUsageStatsLoggingScheduler) getLoggingDuration() time.Duration {
+	if s.knobs != nil && s.knobs.getLoggingDuration != nil {
+		return s.knobs.getLoggingDuration()
+	}
+	return timeutil.Since(s.currentCaptureStartTime)
+}
+
+func (s *CaptureIndexUsageStatsLoggingScheduler) durationOnOverlap() time.Duration {
+	if s.knobs != nil && s.knobs.getOverlapDuration != nil {
+		return s.knobs.getOverlapDuration()
+	}
+	// If the logging duration overlaps into the next scheduled interval, start
+	// the next scheduled interval immediately instead of waiting.
+	return 0 * time.Second
+}
+
+func (s *CaptureIndexUsageStatsLoggingScheduler) durationUntilNextInterval() time.Duration {
+	// If telemetry is disabled, return the disabled interval duration.
+	if !telemetryCaptureIndexUsageStatsEnabled.Get(&s.st.SV) {
+		return telemetryCaptureIndexUsageStatsStatusCheckEnabledInterval.Get(&s.st.SV)
+	}
+	// If the previous logging operation took longer than or equal to the set
+	// schedule interval, schedule the next interval immediately.
+	if s.getLoggingDuration() >= telemetryCaptureIndexUsageStatsInterval.Get(&s.st.SV) {
+		return s.durationOnOverlap()
+	}
+	// Otherwise, schedule the next interval normally.
+	return telemetryCaptureIndexUsageStatsInterval.Get(&s.st.SV)
+}
+
+// Start starts the capture index usage statistics logging scheduler.
+func Start(
+	ctx context.Context,
+	stopper *stop.Stopper,
+	db *kv.DB,
+	cs *cluster.Settings,
+	ie sqlutil.InternalExecutor,
+	knobs *CaptureIndexUsageStatsTestingKnobs,
+) {
+	scheduler := CaptureIndexUsageStatsLoggingScheduler{
+		db:    db,
+		st:    cs,
+		ie:    ie,
+		knobs: knobs,
+	}
+	scheduler.start(ctx, stopper)
+}
+
+func (s *CaptureIndexUsageStatsLoggingScheduler) start(ctx context.Context, stopper *stop.Stopper) {
+	_ = stopper.RunAsyncTask(ctx, "capture-index-usage-stats", func(ctx context.Context) {
+		// Start the scheduler immediately.
+		for timer := time.NewTimer(0 * time.Second); ; timer.Reset(s.durationUntilNextInterval()) {
+			select {
+			case <-stopper.ShouldQuiesce():
+				timer.Stop()
+				return
+			case <-timer.C:
+				s.currentCaptureStartTime = timeutil.Now()
+				if !telemetryCaptureIndexUsageStatsEnabled.Get(&s.st.SV) {
+					continue
+				}
+
+				err := captureIndexUsageStats(ctx, s.ie, stopper, telemetryCaptureIndexUsageStatsLoggingDelay.Get(&s.st.SV))
+				if err != nil {
+					log.Warningf(ctx, "error capturing index usage stats: %+v", err)
+				}
+			}
+		}
+	})
+}
+
+func captureIndexUsageStats(
+	ctx context.Context,
+	ie sqlutil.InternalExecutor,
+	stopper *stop.Stopper,
+	loggingDelay time.Duration,
+) error {
+	allDatabaseNames, err := getAllDatabaseNames(ctx, ie)
+	if err != nil {
+		return err
+	}
+
+	// Capture index usage statistics for each database.
+	var ok bool
+	expectedNumDatums := 9
+	var allCapturedIndexUsageStats []eventpb.EventPayload
+	for _, databaseName := range allDatabaseNames {
+		// Omit index usage statistics on the default databases 'system',
+		// 'defaultdb', and 'postgres'.
+		if databaseName == "system" || databaseName == "defaultdb" || databaseName == "postgres" {
+			continue
+		}
+		stmt := fmt.Sprintf(`
+		SELECT
+		 ti.descriptor_name as table_name,
+		 ti.descriptor_id as table_id,
+		 ti.index_name,
+		 ti.index_id,
+		 ti.index_type,
+		 ti.is_unique,
+		 ti.is_inverted,
+		 total_reads,
+		 last_read
+		FROM %s.crdb_internal.index_usage_statistics AS us
+		JOIN %s.crdb_internal.table_indexes ti
+		ON us.index_id = ti.index_id
+		 AND us.table_id = ti.descriptor_id
+		ORDER BY total_reads ASC;
+	`, databaseName, databaseName)
+
+		it, err := ie.QueryIteratorEx(
+			ctx,
+			"capture-index-usage-stats",
+			nil,
+			sessiondata.InternalExecutorOverride{User: security.NodeUserName()},
+			stmt,
+		)
+		if err != nil {
+			return err
+		}
+
+		for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
+			var row tree.Datums
+			if err != nil {
+				return err
+			}
+			if row = it.Cur(); row == nil {
+				return errors.New("unexpected null row while capturing index usage stats")
+			}
+
+			if row.Len() != expectedNumDatums {
+				return errors.Newf("expected %d columns, received %d while capturing index usage stats", expectedNumDatums, row.Len())
+			}
+
+			tableName := tree.MustBeDString(row[0])
+			tableID := tree.MustBeDInt(row[1])
+			indexName := tree.MustBeDString(row[2])
+			indexID := tree.MustBeDInt(row[3])
+			indexType := tree.MustBeDString(row[4])
+			isUnique := tree.MustBeDBool(row[5])
+			isInverted := tree.MustBeDBool(row[6])
+			totalReads := tree.MustBeDInt(row[7])
+			lastRead := time.Time{}
+			if row[8] != tree.DNull {
+				lastRead = tree.MustBeDTimestampTZ(row[8]).Time
+			}
+
+			capturedIndexStats := &eventpb.CapturedIndexUsageStats{
+				TableID:        uint32(roachpb.TableID(tableID)),
+				IndexID:        uint32(roachpb.IndexID(indexID)),
+				TotalReadCount: uint64(totalReads),
+				LastRead:       lastRead.String(),
+				DatabaseName:   databaseName,
+				TableName:      string(tableName),
+				IndexName:      string(indexName),
+				IndexType:      string(indexType),
+				IsUnique:       bool(isUnique),
+				IsInverted:     bool(isInverted),
+			}
+
+			allCapturedIndexUsageStats = append(allCapturedIndexUsageStats, capturedIndexStats)
+		}
+		if err = it.Close(); err != nil {
+			return err
+		}
+	}
+	logIndexUsageStatsWithDelay(ctx, allCapturedIndexUsageStats, stopper, loggingDelay)
+	return nil
+}
+
+// logIndexUsageStatsWithDelay logs an eventpb.EventPayload at each
+// telemetryCaptureIndexUsageStatsLoggingDelay to avoid exceeding the 10
+// log-line per second limit per node on the telemetry logging pipeline.
+// Currently, this log-line limit is only shared with 1 other telemetry event,
+// SampledQuery, which now has a logging frequency of 8 logs per second.
+func logIndexUsageStatsWithDelay(
+	ctx context.Context, events []eventpb.EventPayload, stopper *stop.Stopper, delay time.Duration,
+) {
+
+	// Log the first event immediately.
+	timer := time.NewTimer(0 * time.Second)
+	for len(events) > 0 {
+		select {
+		case <-stopper.ShouldQuiesce():
+			timer.Stop()
+			return
+		case <-timer.C:
+			event := events[0]
+			log.StructuredEvent(ctx, event)
+			events = events[1:]
+			// Apply a delay to subsequent events.
+			timer.Reset(delay)
+		}
+	}
+	timer.Stop()
+}
+
+func getAllDatabaseNames(ctx context.Context, ie sqlutil.InternalExecutor) ([]string, error) {
+	var allDatabaseNames []string
+	var ok bool
+	var expectedNumDatums = 1
+
+	it, err := ie.QueryIteratorEx(
+		ctx,
+		"get-all-db-names",
+		nil,
+		sessiondata.InternalExecutorOverride{User: security.NodeUserName()},
+		`SELECT database_name FROM [SHOW DATABASES]`,
+	)
+	if err != nil {
+		return []string{}, err
+	}
+
+	// We have to make sure to close the iterator since we might return from the
+	// for loop early (before Next() returns false).
+	defer func() { err = errors.CombineErrors(err, it.Close()) }()
+	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
+		var row tree.Datums
+		if row = it.Cur(); row == nil {
+			return []string{}, errors.New("unexpected null row while capturing index usage stats")
+		}
+		if row.Len() != expectedNumDatums {
+			return []string{}, errors.Newf("expected %d columns, received %d while capturing index usage stats", expectedNumDatums, row.Len())
+		}
+
+		databaseName := string(tree.MustBeDString(row[0]))
+		allDatabaseNames = append(allDatabaseNames, databaseName)
+	}
+	return allDatabaseNames, nil
+}

--- a/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
@@ -1,0 +1,328 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package scheduledlogging
+
+import (
+	"context"
+	"math"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/channel"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logconfig"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+type stubDurations struct {
+	syncutil.RWMutex
+	loggingDuration time.Duration
+	overlapDuration time.Duration
+}
+
+func (s *stubDurations) setLoggingDuration(d time.Duration) {
+	s.Lock()
+	defer s.Unlock()
+	s.loggingDuration = d
+}
+
+func (s *stubDurations) getLoggingDuration() time.Duration {
+	s.RLock()
+	defer s.RUnlock()
+	return s.loggingDuration
+}
+
+func (s *stubDurations) setOverlapDuration(d time.Duration) {
+	s.Lock()
+	defer s.Unlock()
+	s.overlapDuration = d
+}
+
+func (s *stubDurations) getOverlapDuration() time.Duration {
+	s.RLock()
+	defer s.RUnlock()
+	return s.overlapDuration
+}
+
+func installTelemetryLogFileSink(t *testing.T, sc *log.TestLogScope) func() {
+	// Enable logging channels.
+	log.TestingResetActive()
+	cfg := logconfig.DefaultConfig()
+	// Make a sink for just the session log.
+	cfg.Sinks.FileGroups = map[string]*logconfig.FileSinkConfig{
+		"telemetry": {
+			Channels: logconfig.SelectChannels(channel.TELEMETRY),
+		}}
+	dir := sc.GetDirectory()
+	require.NoError(t, cfg.Validate(&dir), "expected no errors validating log config")
+	cleanup, err := log.ApplyConfig(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return cleanup
+}
+
+func TestCaptureIndexUsageStats(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	sc := log.ScopeWithoutShowLogs(t)
+	defer sc.Close(t)
+
+	cleanup := installTelemetryLogFileSink(t, sc)
+	defer cleanup()
+
+	sd := stubDurations{}
+	sd.setLoggingDuration(1 * time.Second)
+	sd.setOverlapDuration(10 * time.Second)
+	stubScheduleInterval := 20 * time.Second
+	stubScheduleCheckEnabledInterval := 1 * time.Second
+	stubLoggingDelay := 0 * time.Second
+
+	// timeBuffer is a short time buffer to account for delays in the schedule
+	// timings when running tests. The time buffer is smaller than the difference
+	// between each schedule interval to ensure that there is no overlap.
+	timeBuffer := 5 * time.Second
+
+	settings := cluster.MakeTestingClusterSettings()
+	// Configure capture index usage statistics to be disabled. This is to test
+	// whether the disabled interval works correctly. We start in a disabled
+	// state, once the disabled interval expires, we check whether we have
+	// transitioned to an enabled state, if we have, we check that the expected
+	// logs have been emitted.
+	telemetryCaptureIndexUsageStatsEnabled.Override(context.Background(), &settings.SV, false)
+	// Configure the schedule interval at which we capture index usage
+	// statistics.
+	telemetryCaptureIndexUsageStatsInterval.Override(context.Background(), &settings.SV, stubScheduleInterval)
+	// Configure the schedule interval at which we check whether capture index
+	// usage statistics has been enabled.
+	telemetryCaptureIndexUsageStatsStatusCheckEnabledInterval.Override(context.Background(), &settings.SV, stubScheduleCheckEnabledInterval)
+	// Configure the delay between each emission of index usage stats logs.
+	telemetryCaptureIndexUsageStatsLoggingDelay.Override(context.Background(), &settings.SV, stubLoggingDelay)
+
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Settings: settings,
+		Knobs: base.TestingKnobs{
+			CapturedIndexUsageStatsKnobs: &CaptureIndexUsageStatsTestingKnobs{
+				getLoggingDuration: sd.getLoggingDuration,
+				getOverlapDuration: sd.getOverlapDuration,
+			},
+		},
+	})
+
+	defer s.Stopper().Stop(context.Background())
+
+	db := sqlutils.MakeSQLRunner(sqlDB)
+
+	// Create test databases.
+	db.Exec(t, "CREATE DATABASE test")
+	db.Exec(t, "CREATE DATABASE test2")
+
+	// Create a table for each database.
+	db.Exec(t, "CREATE TABLE test.test_table (num INT PRIMARY KEY, letter char)")
+	db.Exec(t, "CREATE TABLE test2.test2_table (num INT PRIMARY KEY, letter char)")
+
+	// Create an index on each created table (each table now has two indices:
+	// primary and this one)
+	db.Exec(t, "CREATE INDEX ON test.test_table (letter)")
+	db.Exec(t, "CREATE INDEX ON test2.test2_table (letter)")
+
+	// Check that telemetry log file contains all the entries we're expecting, at the scheduled intervals.
+
+	// Enable capture of index usage stats.
+	telemetryCaptureIndexUsageStatsEnabled.Override(context.Background(), &s.ClusterSettings().SV, true)
+
+	expectedTotalNumEntriesInSingleInterval := 4
+	expectedNumberOfIndividualIndexEntriesInSingleInterval := 1
+
+	// Expect index usage statistics logs once the schedule disabled interval has passed.
+	// Assert that we have the expected number of total logs and expected number
+	// of logs for each index.
+	testutils.SucceedsWithin(t, func() error {
+		return checkNumTotalEntriesAndNumIndexEntries(
+			expectedTotalNumEntriesInSingleInterval,
+			expectedNumberOfIndividualIndexEntriesInSingleInterval,
+		)
+	}, stubScheduleCheckEnabledInterval+timeBuffer)
+
+	// Verify that a second schedule has run after the enabled interval has passed.
+	// Expect number of total entries to hold 2 times the number of entries in a
+	// single interval.
+	expectedTotalNumEntriesAfterTwoIntervals := expectedTotalNumEntriesInSingleInterval * 2
+	// Expect number of individual index entries to hold 2 times the number of
+	// entries in a single interval.
+	expectedNumberOfIndividualIndexEntriesAfterTwoIntervals := expectedNumberOfIndividualIndexEntriesInSingleInterval * 2
+	// Set the logging duration for the next run to be longer than the schedule
+	// interval duration.
+	stubLoggingDuration := stubScheduleInterval * 2
+	sd.setLoggingDuration(stubLoggingDuration)
+
+	// Expect index usage statistics logs once the schedule enabled interval has passed.
+	// Assert that we have the expected number of total logs and expected number
+	// of logs for each index.
+	testutils.SucceedsWithin(t, func() error {
+		return checkNumTotalEntriesAndNumIndexEntries(
+			expectedTotalNumEntriesAfterTwoIntervals,
+			expectedNumberOfIndividualIndexEntriesAfterTwoIntervals,
+		)
+	}, stubScheduleInterval+timeBuffer)
+
+	// Verify that a third schedule has run after the overlap duration has passed.
+	// Expect number of total entries to hold 3 times the number of entries in a
+	// single interval.
+	expectedTotalNumEntriesAfterThreeIntervals := expectedTotalNumEntriesInSingleInterval * 3
+	// Expect number of individual index entries to hold 3 times the number of
+	// entries in a single interval.
+	expectedNumberOfIndividualIndexEntriesAfterThreeIntervals := expectedNumberOfIndividualIndexEntriesInSingleInterval * 3
+
+	// Assert that we have the expected number of total logs and expected number
+	// of logs for each index.
+	testutils.SucceedsWithin(t, func() error {
+		return checkNumTotalEntriesAndNumIndexEntries(
+			expectedTotalNumEntriesAfterThreeIntervals,
+			expectedNumberOfIndividualIndexEntriesAfterThreeIntervals,
+		)
+	}, sd.getOverlapDuration()+timeBuffer)
+	// Stop capturing index usage statistics.
+	telemetryCaptureIndexUsageStatsEnabled.Override(context.Background(), &settings.SV, false)
+
+	// Iterate through entries, ensure that the timestamp difference between each
+	// schedule is as expected.
+	startTimestamp := int64(0)
+	endTimestamp := int64(math.MaxInt64)
+	maxEntries := 10000
+	entries, err := log.FetchEntriesFromFiles(
+		startTimestamp,
+		endTimestamp,
+		maxEntries,
+		regexp.MustCompile(`"EventType":"captured_index_usage_stats"`),
+		log.WithMarkedSensitiveData,
+	)
+
+	require.NoError(t, err, "expected no error fetching entries from files")
+
+	// Sort slice by timestamp, ascending order.
+	sort.Slice(entries, func(a int, b int) bool {
+		return entries[a].Time < entries[b].Time
+	})
+
+	testData := []time.Duration{
+		0 * time.Second,
+		// the difference in number of seconds between first and second schedule
+		stubScheduleInterval,
+		// the difference in number of seconds between second and third schedule
+		sd.getOverlapDuration(),
+	}
+
+	var (
+		previousTimestamp = int64(0)
+		currentTimestamp  = int64(0)
+	)
+
+	// Check the timestamp differences between schedules.
+	for idx, expectedDuration := range testData {
+		entriesLowerBound := idx * expectedTotalNumEntriesInSingleInterval
+		entriesUpperBound := (idx + 1) * expectedTotalNumEntriesInSingleInterval
+		scheduleEntryBlock := entries[entriesLowerBound:entriesUpperBound]
+		// Take the first log entry from the schedule.
+		currentTimestamp = scheduleEntryBlock[0].Time
+		// If this is the first iteration, initialize the previous timestamp.
+		if idx == 0 {
+			previousTimestamp = currentTimestamp
+		}
+
+		nanoSecondDiff := currentTimestamp - previousTimestamp
+		// We allow for integer division to remove any miscellaneous nanosecond
+		// delay from the logging.
+		secondDiff := nanoSecondDiff / 1e9
+		actualDuration := time.Duration(secondDiff) * time.Second
+		require.Equal(t, expectedDuration, actualDuration)
+		previousTimestamp = currentTimestamp
+	}
+}
+
+// checkNumTotalEntriesAndNumIndexEntries is a helper function that verifies that
+// we are getting the correct number of total log entries and correct number of
+// log entries for each index. Also checks that each log entry contains a node_id
+// field, used to filter node-duplicate logs downstream.
+func checkNumTotalEntriesAndNumIndexEntries(
+	expectedTotalEntries int, expectedIndividualIndexEntries int,
+) error {
+	// Fetch log entries.
+	entries, err := log.FetchEntriesFromFiles(
+		0,
+		math.MaxInt64,
+		10000,
+		regexp.MustCompile(`"EventType":"captured_index_usage_stats"`),
+		log.WithMarkedSensitiveData,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	// Assert that we have the correct number of entries.
+	if expectedTotalEntries != len(entries) {
+		return errors.Newf("expected %d total entries, got %d", expectedTotalEntries, len(entries))
+	}
+
+	var (
+		numEntriesForTestTablePrimaryKeyIndex  int
+		numEntriesForTestTableLetterIndex      int
+		numEntriesForTest2TablePrimaryKeyIndex int
+		numEntriesForTest2TableLetterIndex     int
+	)
+
+	for _, e := range entries {
+		if strings.Contains(e.Message, `"IndexName":"‹test_table_pkey›"`) {
+			numEntriesForTestTablePrimaryKeyIndex++
+		}
+		if strings.Contains(e.Message, `"IndexName":"‹test_table_letter_idx›"`) {
+			numEntriesForTestTableLetterIndex++
+		}
+		if strings.Contains(e.Message, `"TableName":"‹test2_table_pkey›"`) {
+			numEntriesForTest2TablePrimaryKeyIndex++
+		}
+		if strings.Contains(e.Message, `"TableName":"‹test2_table_letter_idx›"`) {
+			numEntriesForTest2TableLetterIndex++
+		}
+		// Check that the entry has a tag for a node ID of 1.
+		if !strings.Contains(e.Tags, `n1`) {
+			return errors.Newf("expected the entry's tags to include n1, but include got %s", e.Tags)
+		}
+	}
+
+	// Assert that we have the correct number index usage statistic entries for
+	// each index we created across the tables in each database.
+	if expectedIndividualIndexEntries != numEntriesForTestTablePrimaryKeyIndex {
+		return errors.Newf("expected %d test_table primary key index entries, got %d", expectedIndividualIndexEntries, numEntriesForTestTablePrimaryKeyIndex)
+	}
+	if expectedIndividualIndexEntries != numEntriesForTestTablePrimaryKeyIndex {
+		return errors.Newf("expected %d test_table letter index entries, got %d", expectedIndividualIndexEntries, numEntriesForTestTableLetterIndex)
+	}
+	if expectedIndividualIndexEntries != numEntriesForTestTablePrimaryKeyIndex {
+		return errors.Newf("expected %d test2_table primary key index entries, got %d", expectedIndividualIndexEntries, numEntriesForTest2TablePrimaryKeyIndex)
+	}
+	if expectedIndividualIndexEntries != numEntriesForTestTablePrimaryKeyIndex {
+		return errors.Newf("expected %d test2_table letter index entries, got %d", expectedIndividualIndexEntries, numEntriesForTest2TableLetterIndex)
+	}
+	return nil
+}

--- a/pkg/sql/scheduledlogging/main_test.go
+++ b/pkg/sql/scheduledlogging/main_test.go
@@ -1,0 +1,31 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package scheduledlogging_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestMain(m *testing.M) {
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}

--- a/pkg/sql/telemetry_logging.go
+++ b/pkg/sql/telemetry_logging.go
@@ -21,11 +21,13 @@ import (
 
 // Default value used to designate the maximum frequency at which events
 // are logged to the telemetry channel.
-const defaultMaxEventFrequency = 10
+const defaultMaxEventFrequency = 8
 
 var telemetryMaxEventFrequency = settings.RegisterIntSetting(
 	"sql.telemetry.query_sampling.max_event_frequency",
-	"the max event frequency at which we sample queries for telemetry",
+	"the max event frequency at which we sample queries for telemetry, "+
+		"note that this value shares a log-line limit of 10 logs per second on the "+
+		"telemetry pipeline with all other telemetry events",
 	defaultMaxEventFrequency,
 	settings.NonNegativeInt,
 )

--- a/pkg/util/log/eventpb/eventlog_channels_generated.go
+++ b/pkg/util/log/eventpb/eventlog_channels_generated.go
@@ -255,6 +255,9 @@ func (m *CreateRole) LoggingChannel() logpb.Channel { return logpb.Channel_USER_
 func (m *DropRole) LoggingChannel() logpb.Channel { return logpb.Channel_USER_ADMIN }
 
 // LoggingChannel implements the EventPayload interface.
+func (m *CapturedIndexUsageStats) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
+
+// LoggingChannel implements the EventPayload interface.
 func (m *SampledQuery) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
 
 // LoggingChannel implements the EventPayload interface.

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -553,6 +553,117 @@ func (m *AlterTypeOwner) AppendJSONFields(printComma bool, b redact.RedactableBy
 }
 
 // AppendJSONFields implements the EventPayload interface.
+func (m *CapturedIndexUsageStats) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
+
+	if m.TotalReadCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TotalReadCount\":"...)
+		b = strconv.AppendUint(b, uint64(m.TotalReadCount), 10)
+	}
+
+	if m.LastRead != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"LastRead\":\""...)
+		b = append(b, redact.StartMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.LastRead)))))
+		b = append(b, redact.EndMarker()...)
+		b = append(b, '"')
+	}
+
+	if m.TableID != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TableID\":"...)
+		b = strconv.AppendUint(b, uint64(m.TableID), 10)
+	}
+
+	if m.IndexID != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"IndexID\":"...)
+		b = strconv.AppendUint(b, uint64(m.IndexID), 10)
+	}
+
+	if m.DatabaseName != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"DatabaseName\":\""...)
+		b = append(b, redact.StartMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.DatabaseName)))))
+		b = append(b, redact.EndMarker()...)
+		b = append(b, '"')
+	}
+
+	if m.TableName != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TableName\":\""...)
+		b = append(b, redact.StartMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TableName)))))
+		b = append(b, redact.EndMarker()...)
+		b = append(b, '"')
+	}
+
+	if m.IndexName != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"IndexName\":\""...)
+		b = append(b, redact.StartMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.IndexName)))))
+		b = append(b, redact.EndMarker()...)
+		b = append(b, '"')
+	}
+
+	if m.IndexType != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"IndexType\":\""...)
+		b = append(b, redact.StartMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.IndexType)))))
+		b = append(b, redact.EndMarker()...)
+		b = append(b, '"')
+	}
+
+	if m.IsUnique {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"IsUnique\":true"...)
+	}
+
+	if m.IsInverted {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"IsInverted\":true"...)
+	}
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
 func (m *CertsReload) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
 
 	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -45,3 +45,29 @@ message SampledQuery {
   string distribution = 6 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 }
 
+// CapturedIndexUsageStats
+message CapturedIndexUsageStats {
+  CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+
+  // Couldn't use roachpb.CollectedIndexUsageStatistics due to circular dependency.
+
+  // TotalReadCount is the number of times this index has been read from.
+  uint64 total_read_count = 2;
+
+  // LastRead is the timestamp that this index was last being read from.
+  string last_read = 3 [(gogoproto.jsontag) = ",omitempty"];
+
+  // TableID is the ID of the table this index is created on. This is same as
+  // descpb.TableID and is unique within the cluster.
+  uint32 table_id = 4 [(gogoproto.customname) = "TableID"];
+
+  // IndexID is the ID of the index within the scope of the given table.
+  uint32 index_id = 5 [(gogoproto.customname) = "IndexID"];
+
+  string database_name = 6 [(gogoproto.jsontag) = ",omitempty"];
+  string table_name = 7 [(gogoproto.jsontag) = ",omitempty"];
+  string index_name = 8 [(gogoproto.jsontag) = ",omitempty"];
+  string index_type = 9 [(gogoproto.jsontag) = ",omitempty"];
+  bool is_unique = 10 [(gogoproto.jsontag) = ",omitempty"];
+  bool is_inverted = 11 [(gogoproto.jsontag) = ",omitempty"];
+}


### PR DESCRIPTION
Backport 1/1 commits from #76886.

/cc @cockroachdb/release

---

Resolves: #72486

This change introduces a scheduled logger that captures index usage
statistics logs on a time interval.

Release note (sql change): Initial implementation of a scheduled logger
used to capture index usage statistics to the telemetry logging channel.

Release justification: Category 4: Low risk, high benefit changes to
existing functionality.
