### PR TITLE
admission: introduce soft slots for speculative concurrency

### DIFF
--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -3248,6 +3248,8 @@ var charts = []sectionDescription{
 				Metrics: []string{
 					"admission.granter.total_slots.kv",
 					"admission.granter.used_slots.kv",
+					"admission.granter.total_moderate_slots.kv",
+					"admission.granter.used_soft_slots.kv",
 					"admission.granter.used_slots.sql-leaf-start",
 					"admission.granter.used_slots.sql-root-start",
 				},

--- a/pkg/util/admission/granter_test.go
+++ b/pkg/util/admission/granter_test.go
@@ -90,19 +90,27 @@ func (tr *testRequester) setStoreRequestEstimates(estimates storeRequestEstimate
 	// Only used by ioLoadListener, so don't bother.
 }
 
+// setModerateSlotsClamp is used in testing to force a value for kvsa.moderateSlotsClamp.
+func (kvsa *kvSlotAdjuster) setModerateSlotsClamp(val int) {
+	kvsa.moderateSlotsClampOverride = val
+	kvsa.moderateSlotsClamp = val
+}
+
 // TestGranterBasic is a datadriven test with the following commands:
 //
 // init-grant-coordinator min-cpu=<int> max-cpu=<int> sql-kv-tokens=<int>
-//   sql-sql-tokens=<int> sql-leaf=<int> sql-root=<int>
+// sql-sql-tokens=<int> sql-leaf=<int> sql-root=<int>
 // set-has-waiting-requests work=<kind> v=<true|false>
 // set-return-value-from-granted work=<kind> v=<int>
 // try-get work=<kind> [v=<int>]
 // return-grant work=<kind> [v=<int>]
 // took-without-permission work=<kind> [v=<int>]
 // continue-grant-chain work=<kind>
-// cpu-load runnable=<int> procs=<int> [infrequent=<bool>]
+// cpu-load runnable=<int> procs=<int> [infrequent=<bool>] [clamp=<int>]
 // init-store-grant-coordinator
 // set-io-tokens tokens=<int>
+// try-get-soft-slots slots=<int>
+// return-soft-slots slots=<int>
 func TestGranterBasic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -110,6 +118,7 @@ func TestGranterBasic(t *testing.T) {
 	var ambientCtx log.AmbientContext
 	var requesters [numWorkKinds]*testRequester
 	var coord *GrantCoordinator
+	var ssg *SoftSlotGranter
 	clearRequesterAndCoord := func() {
 		coord = nil
 		for i := range requesters {
@@ -154,8 +163,12 @@ func TestGranterBasic(t *testing.T) {
 				return req
 			}
 			delayForGrantChainTermination = 0
+			opts.RunnableAlphaOverride = 1 // This gives weight to only the most recent sample.
 			coords, _ := NewGrantCoordinators(ambientCtx, opts)
 			coord = coords.Regular
+			var err error
+			ssg, err = MakeSoftSlotGranter(coord)
+			require.NoError(t, err)
 			return flushAndReset()
 
 		case "init-store-grant-coordinator":
@@ -236,6 +249,13 @@ func TestGranterBasic(t *testing.T) {
 			if d.HasArg("infrequent") {
 				d.ScanArgs(t, "infrequent", &infrequent)
 			}
+			if d.HasArg("clamp") {
+				var clamp int
+				d.ScanArgs(t, "clamp", &clamp)
+				kvsa := coord.cpuLoadListener.(*kvSlotAdjuster)
+				kvsa.setModerateSlotsClamp(clamp)
+			}
+
 			samplePeriod := time.Millisecond
 			if infrequent {
 				samplePeriod = 250 * time.Millisecond
@@ -252,6 +272,19 @@ func TestGranterBasic(t *testing.T) {
 			coord.granters[KVWork].(*kvStoreTokenGranter).setAvailableIOTokensLocked(int64(tokens))
 			coord.mu.Unlock()
 			coord.testingTryGrant()
+			return flushAndReset()
+
+		case "try-get-soft-slots":
+			var slots int
+			d.ScanArgs(t, "slots", &slots)
+			granted := ssg.TryGetSlots(slots)
+			fmt.Fprintf(&buf, "requested: %d, granted: %d\n", slots, granted)
+			return flushAndReset()
+
+		case "return-soft-slots":
+			var slots int
+			d.ScanArgs(t, "slots", &slots)
+			ssg.ReturnSlots(slots)
 			return flushAndReset()
 
 		default:

--- a/pkg/util/admission/testdata/granter
+++ b/pkg/util/admission/testdata/granter
@@ -1,14 +1,14 @@
 init-grant-coordinator min-cpu=1 max-cpu=3 sql-kv-tokens=2 sql-sql-tokens=1 sql-leaf=2 sql-root=1
 ----
 GrantCoordinator:
-(chain: id: 1 active: false index: 0) kv: used: 0, total: 1 sql-kv-response: avail: 2
+(chain: id: 1 active: false index: 0) kv: used: 0, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
 
 try-get work=kv
 ----
 kv: tryGet(1) returned true
 GrantCoordinator:
-(chain: id: 1 active: false index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 2
+(chain: id: 1 active: false index: 0) kv: used: 1, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
 
 # No more slots.
@@ -16,13 +16,13 @@ try-get work=kv
 ----
 kv: tryGet(1) returned false
 GrantCoordinator:
-(chain: id: 1 active: false index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 2
+(chain: id: 1 active: false index: 0) kv: used: 1, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
 
 set-has-waiting-requests work=kv v=true
 ----
 GrantCoordinator:
-(chain: id: 1 active: false index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 2
+(chain: id: 1 active: false index: 0) kv: used: 1, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
 
 # Since no more KV slots, couldn't get.
@@ -30,13 +30,13 @@ try-get work=sql-kv-response
 ----
 sql-kv-response: tryGet(1) returned false
 GrantCoordinator:
-(chain: id: 1 active: false index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 2
+(chain: id: 1 active: false index: 0) kv: used: 1, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
 
 set-has-waiting-requests work=sql-kv-response v=true
 ----
 GrantCoordinator:
-(chain: id: 1 active: false index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 2
+(chain: id: 1 active: false index: 0) kv: used: 1, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
 
 # Since no more KV slots, couldn't get.
@@ -44,13 +44,13 @@ try-get work=sql-leaf-start
 ----
 sql-leaf-start: tryGet(1) returned false
 GrantCoordinator:
-(chain: id: 1 active: false index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 2
+(chain: id: 1 active: false index: 0) kv: used: 1, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
 
 set-has-waiting-requests work=sql-leaf-start v=true
 ----
 GrantCoordinator:
-(chain: id: 1 active: false index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 2
+(chain: id: 1 active: false index: 0) kv: used: 1, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
 
 # Since no more KV slots, couldn't get.
@@ -58,13 +58,13 @@ try-get work=sql-root-start
 ----
 sql-root-start: tryGet(1) returned false
 GrantCoordinator:
-(chain: id: 1 active: false index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 2
+(chain: id: 1 active: false index: 0) kv: used: 1, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
 
 set-has-waiting-requests work=sql-root-start v=true
 ----
 GrantCoordinator:
-(chain: id: 1 active: false index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 2
+(chain: id: 1 active: false index: 0) kv: used: 1, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
 
 return-grant work=kv
@@ -72,19 +72,19 @@ return-grant work=kv
 kv: returnGrant(1)
 kv: granted in chain 1, and returning 1
 GrantCoordinator:
-(chain: id: 1 active: true index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 2
+(chain: id: 1 active: true index: 0) kv: used: 1, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
 
 set-has-waiting-requests work=kv v=false
 ----
 GrantCoordinator:
-(chain: id: 1 active: true index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 2
+(chain: id: 1 active: true index: 0) kv: used: 1, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
 
 set-return-value-from-granted work=kv v=0
 ----
 GrantCoordinator:
-(chain: id: 1 active: true index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 2
+(chain: id: 1 active: true index: 0) kv: used: 1, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
 
 # The grant chain dies out since kv slots are fully used.
@@ -92,7 +92,7 @@ continue-grant-chain work=kv
 ----
 kv: continueGrantChain
 GrantCoordinator:
-(chain: id: 2 active: false index: 1) kv: used: 1, total: 1 sql-kv-response: avail: 2
+(chain: id: 2 active: false index: 1) kv: used: 1, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
 
 # Grant to sql-kv-response consumes a token.
@@ -101,7 +101,7 @@ return-grant work=kv
 kv: returnGrant(1)
 sql-kv-response: granted in chain 2, and returning 1
 GrantCoordinator:
-(chain: id: 2 active: true index: 1) kv: used: 0, total: 1 sql-kv-response: avail: 1
+(chain: id: 2 active: true index: 1) kv: used: 0, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 1
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
 
 # Grant to sql-kv-response consumes another token. None left.
@@ -110,7 +110,7 @@ continue-grant-chain work=sql-kv-response
 sql-kv-response: continueGrantChain
 sql-kv-response: granted in chain 2, and returning 1
 GrantCoordinator:
-(chain: id: 2 active: true index: 1) kv: used: 0, total: 1 sql-kv-response: avail: 0
+(chain: id: 2 active: true index: 1) kv: used: 0, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
 
 # Even though there are still waiting requests for sql-kv-response, no more
@@ -120,7 +120,7 @@ continue-grant-chain work=sql-kv-response
 sql-kv-response: continueGrantChain
 sql-leaf-start: granted in chain 2, and returning 1
 GrantCoordinator:
-(chain: id: 2 active: true index: 3) kv: used: 0, total: 1 sql-kv-response: avail: 0
+(chain: id: 2 active: true index: 3) kv: used: 0, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 0, total: 1
 
 continue-grant-chain work=sql-leaf-start
@@ -128,7 +128,7 @@ continue-grant-chain work=sql-leaf-start
 sql-leaf-start: continueGrantChain
 sql-leaf-start: granted in chain 2, and returning 1
 GrantCoordinator:
-(chain: id: 2 active: true index: 3) kv: used: 0, total: 1 sql-kv-response: avail: 0
+(chain: id: 2 active: true index: 3) kv: used: 0, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 0, total: 1
 
 # Even though there are still waiting requests for sql-leaf-start, no more
@@ -138,7 +138,7 @@ continue-grant-chain work=sql-leaf-start
 sql-leaf-start: continueGrantChain
 sql-root-start: granted in chain 2, and returning 1
 GrantCoordinator:
-(chain: id: 2 active: true index: 4) kv: used: 0, total: 1 sql-kv-response: avail: 0
+(chain: id: 2 active: true index: 4) kv: used: 0, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 1, total: 1
 
 # sql-root-start ran out of tokens. Grant chain dies out.
@@ -146,7 +146,7 @@ continue-grant-chain work=sql-root-start
 ----
 sql-root-start: continueGrantChain
 GrantCoordinator:
-(chain: id: 3 active: false index: 5) kv: used: 0, total: 1 sql-kv-response: avail: 0
+(chain: id: 3 active: false index: 5) kv: used: 0, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 1, total: 1
 
 # Return sql-leaf-start slot. This will cause another grant chain to start
@@ -156,7 +156,7 @@ return-grant work=sql-leaf-start
 sql-leaf-start: returnGrant(1)
 sql-leaf-start: granted in chain 3, and returning 1
 GrantCoordinator:
-(chain: id: 3 active: true index: 3) kv: used: 0, total: 1 sql-kv-response: avail: 0
+(chain: id: 3 active: true index: 3) kv: used: 0, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 1, total: 1
 
 # Return another sql-leaf-start slot. The grant chain is already active and
@@ -165,7 +165,7 @@ return-grant work=sql-leaf-start
 ----
 sql-leaf-start: returnGrant(1)
 GrantCoordinator:
-(chain: id: 3 active: true index: 3) kv: used: 0, total: 1 sql-kv-response: avail: 0
+(chain: id: 3 active: true index: 3) kv: used: 0, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
 
 # The kv slots are fully used after this tryGet, which succeeds.
@@ -173,7 +173,7 @@ try-get work=kv
 ----
 kv: tryGet(1) returned true
 GrantCoordinator:
-(chain: id: 3 active: true index: 3) kv: used: 1, total: 1 sql-kv-response: avail: 0
+(chain: id: 3 active: true index: 3) kv: used: 1, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
 
 # This tryGet for kv fails and forces termination of the grant chain.
@@ -181,13 +181,13 @@ try-get work=kv
 ----
 kv: tryGet(1) returned false
 GrantCoordinator:
-(chain: id: 4 active: false index: 3) kv: used: 1, total: 1 sql-kv-response: avail: 0
+(chain: id: 4 active: false index: 3) kv: used: 1, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
 
 set-has-waiting-requests work=kv v=true
 ----
 GrantCoordinator:
-(chain: id: 4 active: false index: 3) kv: used: 1, total: 1 sql-kv-response: avail: 0
+(chain: id: 4 active: false index: 3) kv: used: 1, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
 
 # The grant chain cannot continue since it was force terminated, and a new one
@@ -196,14 +196,14 @@ continue-grant-chain work=sql-leaf-start
 ----
 sql-leaf-start: continueGrantChain
 GrantCoordinator:
-(chain: id: 4 active: false index: 3) kv: used: 1, total: 1 sql-kv-response: avail: 0
+(chain: id: 4 active: false index: 3) kv: used: 1, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
 
 # Pretend that the kv work that was waiting is gone.
 set-has-waiting-requests work=kv v=false
 ----
 GrantCoordinator:
-(chain: id: 4 active: false index: 3) kv: used: 1, total: 1 sql-kv-response: avail: 0
+(chain: id: 4 active: false index: 3) kv: used: 1, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
 
 # Some other kv work takes without permission.
@@ -211,14 +211,14 @@ took-without-permission work=kv
 ----
 kv: tookWithoutPermission(1)
 GrantCoordinator:
-(chain: id: 4 active: false index: 3) kv: used: 2, total: 1 sql-kv-response: avail: 0
+(chain: id: 4 active: false index: 3) kv: used: 2, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
 
 # Refill the tokens and increase the kv slots to 2.
 cpu-load runnable=0 procs=1
 ----
 GrantCoordinator:
-(chain: id: 4 active: false index: 1) kv: used: 2, total: 2 sql-kv-response: avail: 2
+(chain: id: 4 active: false index: 1) kv: used: 2, high(moderate)-total: 2(0) moderate-clamp: 0 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
 
 # Tokens don't get overfull. And kv slots increased to 3. This causes a grant
@@ -227,14 +227,14 @@ cpu-load runnable=0 procs=1
 ----
 sql-kv-response: granted in chain 4, and returning 1
 GrantCoordinator:
-(chain: id: 4 active: true index: 1) kv: used: 2, total: 3 sql-kv-response: avail: 1
+(chain: id: 4 active: true index: 1) kv: used: 2, high(moderate)-total: 3(0) moderate-clamp: 0 sql-kv-response: avail: 1
 sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
 
 # Overload and kv slots decreased. Forces termination of grant chain 4.
 cpu-load runnable=2 procs=1
 ----
 GrantCoordinator:
-(chain: id: 5 active: false index: 1) kv: used: 2, total: 2 sql-kv-response: avail: 2
+(chain: id: 5 active: false index: 1) kv: used: 2, high(moderate)-total: 2(0) moderate-clamp: -1 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
 
 # Grant chain 4 terminates.
@@ -242,7 +242,7 @@ continue-grant-chain work=sql-kv-response
 ----
 sql-kv-response: continueGrantChain
 GrantCoordinator:
-(chain: id: 5 active: false index: 1) kv: used: 2, total: 2 sql-kv-response: avail: 2
+(chain: id: 5 active: false index: 1) kv: used: 2, high(moderate)-total: 2(0) moderate-clamp: -1 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
 
 # Return a slot for sql-leaf-start. Grant chain cannot start since KV slots
@@ -251,7 +251,7 @@ return-grant work=sql-leaf-start
 ----
 sql-leaf-start: returnGrant(1)
 GrantCoordinator:
-(chain: id: 5 active: false index: 1) kv: used: 2, total: 2 sql-kv-response: avail: 2
+(chain: id: 5 active: false index: 1) kv: used: 2, high(moderate)-total: 2(0) moderate-clamp: -1 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 1, total: 1
 
 # Underload and kv slots increased. The number of procs=4, so can grant 4 at
@@ -264,7 +264,7 @@ sql-kv-response: granted in chain 0, and returning 1
 sql-leaf-start: granted in chain 0, and returning 1
 sql-leaf-start: granted in chain 5, and returning 1
 GrantCoordinator:
-(chain: id: 5 active: true index: 3) kv: used: 2, total: 3 sql-kv-response: avail: 0
+(chain: id: 5 active: true index: 3) kv: used: 2, high(moderate)-total: 3(0) moderate-clamp: 0 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 1, total: 1
 
 # There is now a free sql-root-start slot, which the grant chain will get to.
@@ -272,7 +272,7 @@ return-grant work=sql-root-start
 ----
 sql-root-start: returnGrant(1)
 GrantCoordinator:
-(chain: id: 5 active: true index: 3) kv: used: 2, total: 3 sql-kv-response: avail: 0
+(chain: id: 5 active: true index: 3) kv: used: 2, high(moderate)-total: 3(0) moderate-clamp: 0 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 0, total: 1
 
 # Continuing with chain-id=0 has no effect.
@@ -280,7 +280,7 @@ continue-grant-chain work=sql-kv-response
 ----
 sql-kv-response: continueGrantChain
 GrantCoordinator:
-(chain: id: 5 active: true index: 3) kv: used: 2, total: 3 sql-kv-response: avail: 0
+(chain: id: 5 active: true index: 3) kv: used: 2, high(moderate)-total: 3(0) moderate-clamp: 0 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 0, total: 1
 
 # Continuing chain-id=5 causes a grant to sql-root-start and the chain dies
@@ -290,7 +290,7 @@ continue-grant-chain work=sql-leaf-start
 sql-leaf-start: continueGrantChain
 sql-root-start: granted in chain 0, and returning 1
 GrantCoordinator:
-(chain: id: 6 active: false index: 5) kv: used: 2, total: 3 sql-kv-response: avail: 0
+(chain: id: 6 active: false index: 5) kv: used: 2, high(moderate)-total: 3(0) moderate-clamp: 0 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 1, total: 1
 
 #####################################################################
@@ -298,7 +298,7 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: use
 init-grant-coordinator min-cpu=1 max-cpu=3 sql-kv-tokens=1 sql-sql-tokens=1 sql-leaf=2 sql-root=2
 ----
 GrantCoordinator:
-(chain: id: 1 active: false index: 0) kv: used: 0, total: 1 sql-kv-response: avail: 1
+(chain: id: 1 active: false index: 0) kv: used: 0, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 1
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
 
 # No more slots after this slot is granted.
@@ -306,7 +306,7 @@ try-get work=kv
 ----
 kv: tryGet(1) returned true
 GrantCoordinator:
-(chain: id: 1 active: false index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 1
+(chain: id: 1 active: false index: 0) kv: used: 1, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 1
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
 
 # Since no more KV slots, cannot grant token to sql-kv-response.
@@ -314,7 +314,7 @@ try-get work=sql-kv-response
 ----
 sql-kv-response: tryGet(1) returned false
 GrantCoordinator:
-(chain: id: 1 active: false index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 1
+(chain: id: 1 active: false index: 0) kv: used: 1, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 1
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
 
 # Since no more KV slots, cannot grant token to sql-sql-response.
@@ -322,7 +322,7 @@ try-get work=sql-sql-response
 ----
 sql-sql-response: tryGet(1) returned false
 GrantCoordinator:
-(chain: id: 1 active: false index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 1
+(chain: id: 1 active: false index: 0) kv: used: 1, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 1
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
 
 # CPULoad shows overload, so cannot increase KV slots, but since it is
@@ -330,7 +330,7 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: use
 cpu-load runnable=20 procs=1 infrequent=true
 ----
 GrantCoordinator:
-(chain: id: 1 active: false index: 5) kv: used: 1, total: 1 sql-kv-response: avail: 1
+(chain: id: 1 active: false index: 5) kv: used: 1, high(moderate)-total: 1(0) moderate-clamp: -19 sql-kv-response: avail: 1
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
 
 # sql-kv-response can get a token.
@@ -338,7 +338,7 @@ try-get work=sql-kv-response
 ----
 sql-kv-response: tryGet(1) returned true
 GrantCoordinator:
-(chain: id: 1 active: false index: 5) kv: used: 1, total: 1 sql-kv-response: avail: 0
+(chain: id: 1 active: false index: 5) kv: used: 1, high(moderate)-total: 1(0) moderate-clamp: -19 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
 
 # sql-kv-response can get another token, even though tokens are exhausted.
@@ -346,7 +346,7 @@ try-get work=sql-kv-response
 ----
 sql-kv-response: tryGet(1) returned true
 GrantCoordinator:
-(chain: id: 1 active: false index: 5) kv: used: 1, total: 1 sql-kv-response: avail: -1
+(chain: id: 1 active: false index: 5) kv: used: 1, high(moderate)-total: 1(0) moderate-clamp: -19 sql-kv-response: avail: -1
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
 
 # sql-sql-response can get a token.
@@ -354,7 +354,7 @@ try-get work=sql-sql-response
 ----
 sql-sql-response: tryGet(1) returned true
 GrantCoordinator:
-(chain: id: 1 active: false index: 5) kv: used: 1, total: 1 sql-kv-response: avail: -1
+(chain: id: 1 active: false index: 5) kv: used: 1, high(moderate)-total: 1(0) moderate-clamp: -19 sql-kv-response: avail: -1
 sql-sql-response: avail: 0 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
 
 # sql-sql-response can get another token, even though tokens are exhausted.
@@ -362,7 +362,7 @@ try-get work=sql-sql-response
 ----
 sql-sql-response: tryGet(1) returned true
 GrantCoordinator:
-(chain: id: 1 active: false index: 5) kv: used: 1, total: 1 sql-kv-response: avail: -1
+(chain: id: 1 active: false index: 5) kv: used: 1, high(moderate)-total: 1(0) moderate-clamp: -19 sql-kv-response: avail: -1
 sql-sql-response: avail: -1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
 
 # KV can get another slot even though slots are exhausted.
@@ -370,7 +370,7 @@ try-get work=kv
 ----
 kv: tryGet(1) returned true
 GrantCoordinator:
-(chain: id: 1 active: false index: 5) kv: used: 2, total: 1 sql-kv-response: avail: -1
+(chain: id: 1 active: false index: 5) kv: used: 2, high(moderate)-total: 1(0) moderate-clamp: -19 sql-kv-response: avail: -1
 sql-sql-response: avail: -1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
 
 #####################################################################
@@ -461,3 +461,320 @@ kv: returnGrant(1)
 kv: granted in chain 0, and returning 100
 GrantCoordinator:
 (chain: id: 0 active: false index: 5) io-avail: -99
+
+#####################################################################
+# Test soft slots
+init-grant-coordinator min-cpu=1 max-cpu=6 sql-kv-tokens=2 sql-sql-tokens=1 sql-leaf=2 sql-root=1
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 0) kv: used: 0, high(moderate)-total: 1(1) moderate-clamp: 6 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+try-get-soft-slots slots=2
+----
+requested: 2, granted: 1
+GrantCoordinator:
+(chain: id: 1 active: false index: 0) kv: used: 0, high(moderate)-total: 1(1) moderate-clamp: 6 used-soft: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+try-get-soft-slots slots=2
+----
+requested: 2, granted: 0
+GrantCoordinator:
+(chain: id: 1 active: false index: 0) kv: used: 0, high(moderate)-total: 1(1) moderate-clamp: 6 used-soft: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+return-soft-slots slots=1
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 0) kv: used: 0, high(moderate)-total: 1(1) moderate-clamp: 6 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+try-get-soft-slots slots=2
+----
+requested: 2, granted: 1
+GrantCoordinator:
+(chain: id: 1 active: false index: 0) kv: used: 0, high(moderate)-total: 1(1) moderate-clamp: 6 used-soft: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+cpu-load runnable=0 procs=4 clamp=100
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 0, high(moderate)-total: 2(2) moderate-clamp: 100 used-soft: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+try-get-soft-slots slots=2
+----
+requested: 2, granted: 1
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 0, high(moderate)-total: 2(2) moderate-clamp: 100 used-soft: 2 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+# Over-commitment.
+try-get work=kv
+----
+kv: tryGet(1) returned true
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 1, high(moderate)-total: 2(2) moderate-clamp: 100 used-soft: 2 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+# Over-commitment.
+try-get work=kv
+----
+kv: tryGet(1) returned true
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 2, high(moderate)-total: 2(2) moderate-clamp: 100 used-soft: 2 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+try-get work=kv
+----
+kv: tryGet(1) returned false
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 2, high(moderate)-total: 2(2) moderate-clamp: 100 used-soft: 2 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+# No longer over-committed.
+return-soft-slots slots=2
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 2, high(moderate)-total: 2(2) moderate-clamp: 100 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+try-get-soft-slots slots=2
+----
+requested: 2, granted: 0
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 2, high(moderate)-total: 2(2) moderate-clamp: 100 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+cpu-load runnable=4 procs=8 clamp=100
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 2, high(moderate)-total: 3(2) moderate-clamp: 100 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+try-get-soft-slots slots=2
+----
+requested: 2, granted: 0
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 2, high(moderate)-total: 3(2) moderate-clamp: 100 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+cpu-load runnable=1 procs=8 clamp=100
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 2, high(moderate)-total: 3(3) moderate-clamp: 100 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+try-get-soft-slots slots=2
+----
+requested: 2, granted: 1
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 2, high(moderate)-total: 3(3) moderate-clamp: 100 used-soft: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+cpu-load runnable=3 procs=8 clamp=100
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 2, high(moderate)-total: 4(3) moderate-clamp: 100 used-soft: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+return-grant work=kv
+----
+kv: returnGrant(1)
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 1, high(moderate)-total: 4(3) moderate-clamp: 100 used-soft: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+try-get-soft-slots slots=2
+----
+requested: 2, granted: 1
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 1, high(moderate)-total: 4(3) moderate-clamp: 100 used-soft: 2 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+cpu-load runnable=2 procs=8 clamp=100
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 1, high(moderate)-total: 4(4) moderate-clamp: 100 used-soft: 2 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+cpu-load runnable=2 procs=8 clamp=100
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 1, high(moderate)-total: 4(4) moderate-clamp: 100 used-soft: 2 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+try-get-soft-slots slots=2
+----
+requested: 2, granted: 1
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 1, high(moderate)-total: 4(4) moderate-clamp: 100 used-soft: 3 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+cpu-load runnable=2 procs=8 clamp=100
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 1, high(moderate)-total: 5(5) moderate-clamp: 100 used-soft: 3 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+cpu-load runnable=6 procs=8 clamp=100
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 1, high(moderate)-total: 5(4) moderate-clamp: 100 used-soft: 3 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+cpu-load runnable=6 procs=8 clamp=100
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 1, high(moderate)-total: 5(3) moderate-clamp: 100 used-soft: 3 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+cpu-load runnable=6 procs=8 clamp=100
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 1, high(moderate)-total: 5(3) moderate-clamp: 100 used-soft: 3 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+#####################################################################
+# Test soft slots is not higher than regular slots.
+init-grant-coordinator min-cpu=1 max-cpu=6 sql-kv-tokens=2 sql-sql-tokens=1 sql-leaf=2 sql-root=1
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 0) kv: used: 0, high(moderate)-total: 1(1) moderate-clamp: 6 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+try-get-soft-slots slots=1
+----
+requested: 1, granted: 1
+GrantCoordinator:
+(chain: id: 1 active: false index: 0) kv: used: 0, high(moderate)-total: 1(1) moderate-clamp: 6 used-soft: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+cpu-load runnable=2 procs=8 clamp=100
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 0, high(moderate)-total: 2(2) moderate-clamp: 100 used-soft: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+try-get-soft-slots slots=1
+----
+requested: 1, granted: 1
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 0, high(moderate)-total: 2(2) moderate-clamp: 100 used-soft: 2 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+cpu-load runnable=2 procs=8 clamp=100
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 0, high(moderate)-total: 3(3) moderate-clamp: 100 used-soft: 2 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+return-soft-slots slots=2
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 0, high(moderate)-total: 3(3) moderate-clamp: 100 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+cpu-load runnable=10 procs=8 clamp=100
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 0, high(moderate)-total: 3(3) moderate-clamp: 100 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+try-get work=kv
+----
+kv: tryGet(1) returned true
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 1, high(moderate)-total: 3(3) moderate-clamp: 100 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+try-get work=kv
+----
+kv: tryGet(1) returned true
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 2, high(moderate)-total: 3(3) moderate-clamp: 100 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+try-get work=kv
+----
+kv: tryGet(1) returned true
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 3, high(moderate)-total: 3(3) moderate-clamp: 100 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+cpu-load runnable=10 procs=8 clamp=100
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 3, high(moderate)-total: 2(2) moderate-clamp: 100 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+#####################################################################
+# Test clamping down on total moderate slots.
+init-grant-coordinator min-cpu=1 max-cpu=100 sql-kv-tokens=2 sql-sql-tokens=1 sql-leaf=2 sql-root=1
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 0) kv: used: 0, high(moderate)-total: 1(1) moderate-clamp: 100 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+try-get-soft-slots slots=1
+----
+requested: 1, granted: 1
+GrantCoordinator:
+(chain: id: 1 active: false index: 0) kv: used: 0, high(moderate)-total: 1(1) moderate-clamp: 100 used-soft: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+cpu-load runnable=0 procs=8
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 0, high(moderate)-total: 2(2) moderate-clamp: 4 used-soft: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+try-get-soft-slots slots=1
+----
+requested: 1, granted: 1
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 0, high(moderate)-total: 2(2) moderate-clamp: 4 used-soft: 2 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+cpu-load runnable=0 procs=2
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 0, high(moderate)-total: 3(1) moderate-clamp: 1 used-soft: 2 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+# The moderate slots clamp is set to -1, because 10/2-6=-1.
+cpu-load runnable=6 procs=10
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 0, high(moderate)-total: 3(0) moderate-clamp: -1 used-soft: 2 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+# Making sure total moderate slots is set to 0, and not a negative value.
+cpu-load runnable=6 procs=10
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 0, high(moderate)-total: 3(0) moderate-clamp: -1 used-soft: 2 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+#####################################################################
+# Make sure the moderate slots clamp has no effect when it is higher than the total moderate slots.
+init-grant-coordinator min-cpu=1 max-cpu=3 sql-kv-tokens=2 sql-sql-tokens=1 sql-leaf=2 sql-root=1
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 0) kv: used: 0, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+try-get-soft-slots slots=1
+----
+requested: 1, granted: 1
+GrantCoordinator:
+(chain: id: 1 active: false index: 0) kv: used: 0, high(moderate)-total: 1(1) moderate-clamp: 3 used-soft: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+# Should increase total moderate slots to 2, since the moderate clamp was 3 which is higher.
+cpu-load runnable=0 procs=2 clamp=3
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 5) kv: used: 0, high(moderate)-total: 2(2) moderate-clamp: 3 used-soft: 1 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1


### PR DESCRIPTION
This is for using additional theads for Pebble compaction compression
and later for adjusting the number of concurrent compactions.

Since these slots are not acquired or released in a very fine grained
manner, we've chosen to model these in way that allows for
over-commitment. The SoftSlotGranter should be used for acquiring
and releasing such slots, instead of WorkQueue, since there is no
queueing for such slots.

Release note: None