### PR TITLE
ci: add scripts for bazel-based `ui test`, `ui lint` ci jobs

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -144,7 +144,7 @@ The `bazelbuilder` image is used exclusively for performing builds using Bazel. 
     docker manifest push cockroachdb/bazel:$TAG
 ```
 - Then, update `build/teamcity-bazel-support.sh` with the new tag and commit all your changes.
-- Ensure the "GitHub CI (Optional)" job passes on your PR before merging.
+- Ensure the "Bazel CI" job passes on your PR before merging.
 
 #  Dependencies
 

--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -64,6 +64,18 @@ RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key a
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     google-cloud-sdk
 
+# chrome is needed for UI tests. Unfortunately it is only distributed for x86_64
+# and not for ARM. Chrome shouldn't need to be installed when we migrate away
+# from Karma for UI testing.
+RUN case ${TARGETPLATFORM} in \
+    "linux/amd64") \
+      curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+      && echo "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main" | tee /etc/apt/sources.list.d/google.list \
+      && apt-get update \
+      && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      google-chrome-stable ;; \
+    esac
+
 RUN apt-get purge -y \
     apt-transport-https \
     flex \

--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -1,7 +1,7 @@
 # FYI: You can run `./dev builder` to run this Docker image. :)
 # `dev` depends on this variable! Don't change the name or format unless you
 # also update `dev` accordingly.
-BAZEL_IMAGE=cockroachdb/bazel:20220121-121551
+BAZEL_IMAGE=cockroachdb/bazel:20220328-163955
 
 # Call `run_bazel $NAME_OF_SCRIPT` to start an appropriately-configured Docker
 # container with the `cockroachdb/bazel` image running the given script.

--- a/build/teamcity/cockroach/ci/tests/ui_lint.sh
+++ b/build/teamcity/cockroach/ci/tests/ui_lint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_start_block "Run UI tests"
+run_bazel build/teamcity/cockroach/ci/tests/ui_lint_impl.sh
+tc_end_block "Run UI tests"

--- a/build/teamcity/cockroach/ci/tests/ui_lint_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/ui_lint_impl.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+bazel build //pkg/cmd/bazci --config=ci
+$(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci test --config=ci //pkg/ui:lint

--- a/build/teamcity/cockroach/ci/tests/ui_test.sh
+++ b/build/teamcity/cockroach/ci/tests/ui_test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_start_block "Run UI tests"
+run_bazel build/teamcity/cockroach/ci/tests/ui_test_impl.sh
+tc_end_block "Run UI tests"

--- a/build/teamcity/cockroach/ci/tests/ui_test_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/ui_test_impl.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+bazel build //pkg/cmd/bazci --config=ci
+$(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci test --config=ci //pkg/ui/workspaces/db-console:karma //pkg/ui/workspaces/cluster-ui:jest

--- a/pkg/cmd/bazci/bazci.go
+++ b/pkg/cmd/bazci/bazci.go
@@ -229,6 +229,8 @@ func getBuildInfo(args parsedArgs) (buildInfo, error) {
 			// to replace (it's the output directory for the configuration).
 			componentsTestlogs[len(componentsTestlogs)-2] = componentsBinLocation[len(componentsTestlogs)-2]
 			ret.transitionTests[fullTarget] = strings.Join(componentsTestlogs, "/")
+		case "nodejs_test":
+			ret.tests = append(ret.tests, fullTarget)
 		case "test_suite":
 			// Expand the list of tests from the test suite with another query.
 			allTests, err := runBazelReturningStdout("query", "tests("+fullTarget+")")


### PR DESCRIPTION
These scripts just do the same logic that `dev` does for the same
functions.

Release note: None