### PR TITLE
roachtest: fix node-postgres test

### DIFF
--- a/pkg/cmd/roachtest/tests/nodejs_postgres.go
+++ b/pkg/cmd/roachtest/tests/nodejs_postgres.go
@@ -112,6 +112,15 @@ func registerNodeJSPostgres(r registry.Registry) {
 		)
 		require.NoError(t, err)
 
+		// The upstream repo hasn't updated its dependencies in light of
+		// https://github.blog/2021-09-01-improving-git-protocol-security-github/
+		// so we need this configuration.
+		err = repeatRunE(
+			ctx, t, c, node, "configure git to avoid unauthenticated protocol",
+			`cd /mnt/data1/node-postgres && sudo git config --global url."https://github".insteadOf "git://github"`,
+		)
+		require.NoError(t, err)
+
 		err = repeatRunE(
 			ctx,
 			t,


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/78079

The upstream repo has outdated yarn dependencies. Rather than waiting
for a fix, we can just configure git to avoid the unauthenticated
protocol.

Release note: None