### PR TITLE
ui: don't download .dll.js bundles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1407,9 +1407,6 @@ pkg/ui/assets.ccl.installed: $(UI_CCL_DLLS) $(UI_CCL_MANIFESTS) $(UI_JS_CCL) $(s
 pkg/ui/assets.oss.installed: $(UI_OSS_DLLS) $(UI_OSS_MANIFESTS) $(UI_JS_OSS)
 pkg/ui/assets.%.installed: pkg/ui/workspaces/db-console/webpack.app.js $(shell find pkg/ui/workspaces/db-console/src pkg/ui/workspaces/db-console/styl -type f) | bin/.bootstrap
 	find pkg/ui/dist$*/assets -mindepth 1 -not -name .gitkeep -delete
-	for dll in $(shell find pkg/ui/workspaces/db-console/dist -name '*.dll.js' -type f); do \
-		echo $$dll | sed -E "s/.oss.dll.js|.ccl.dll.js/.dll.js/" | sed -E "s|^.*\/|pkg/ui/dist$*/assets/|" | xargs -I{} cp $$dll {};\
-	done
 	$(NODE_RUN) -C pkg/ui/workspaces/db-console $(WEBPACK) --config webpack.app.js --env.dist=$*
 	touch $@
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -829,8 +829,6 @@ func TestServeIndexHTML(t *testing.T) {
 			window.dataFromServer = %s;
 		</script>
 
-		<script src="protos.dll.js" type="text/javascript"></script>
-		<script src="vendor.dll.js" type="text/javascript"></script>
 		<script src="bundle.js" type="text/javascript"></script>
 	</body>
 </html>

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -56,8 +56,6 @@ var indexHTMLTemplate = template.Must(template.New("index").Parse(`<!DOCTYPE htm
 			window.dataFromServer = {{.}};
 		</script>
 
-		<script src="protos.dll.js" type="text/javascript"></script>
-		<script src="vendor.dll.js" type="text/javascript"></script>
 		<script src="bundle.js" type="text/javascript"></script>
 	</body>
 </html>


### PR DESCRIPTION
Loading the CockroachDB admin UI (served from port 8080) would previously download three JS files: `bundle.js`, `vendor.dll.js`, and `protos.dll.js`. Neither `vendor.dll.js` nor `protos.dll.js` need to be included via `<script/>` tag, as they're used only as build-time tooling to accelerate webpack builds. Only a single file -- `bundle.js` -- needs to be loaded for the admin UI to be functional, and Bazel-produced builds don't have any `.dll.js` files to serve. Don't load `.dll.js` files via index.html.

Since dll file aren't being served directly to users anymore, there's no need to embed them in the `cockroach` binary. Stop copying `.dll.js` files into `pkg/ui/dist{oss,ccl}` during builds, reducing the `cockroach` binary size by ~19MB (darwin, x86) when built with GNU make.