### PR TITLE
sql: clean up some long argument lists in fetchers

### DIFF
--- a/pkg/ccl/changefeedccl/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/rowfetcher_cache.go
@@ -223,13 +223,10 @@ func (c *rowFetcherCache) RowFetcherForColumnFamily(
 
 	if err := rf.Init(
 		context.TODO(),
-		false, /* reverse */
-		descpb.ScanLockingStrength_FOR_NONE,
-		descpb.ScanLockingWaitPolicy_BLOCK,
-		0, /* lockTimeout */
-		&c.a,
-		nil, /* memMonitor */
-		&spec,
+		row.FetcherInitArgs{
+			Alloc: &c.a,
+			Spec:  &spec,
+		},
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/cliccl/debug_backup.go
+++ b/pkg/ccl/cliccl/debug_backup.go
@@ -619,16 +619,11 @@ func makeRowFetcher(
 	}
 
 	var rf row.Fetcher
-	if err := rf.Init(
-		ctx,
-		false, /*reverse*/
-		descpb.ScanLockingStrength_FOR_NONE,
-		descpb.ScanLockingWaitPolicy_BLOCK,
-		0, /* lockTimeout */
-		&tree.DatumAlloc{},
-		nil, /*mon.BytesMonitor*/
-		&spec,
-	); err != nil {
+	if err := rf.Init(ctx,
+		row.FetcherInitArgs{
+			Alloc: &tree.DatumAlloc{},
+			Spec:  &spec,
+		}); err != nil {
 		return rf, err
 	}
 	return rf, nil

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -152,13 +152,11 @@ func (cb *ColumnBackfiller) init(
 
 	return cb.fetcher.Init(
 		evalCtx.Context,
-		false, /* reverse */
-		descpb.ScanLockingStrength_FOR_NONE,
-		descpb.ScanLockingWaitPolicy_BLOCK,
-		0, /* lockTimeout */
-		&cb.alloc,
-		cb.mon,
-		&spec,
+		row.FetcherInitArgs{
+			Alloc:      &cb.alloc,
+			MemMonitor: cb.mon,
+			Spec:       &spec,
+		},
 	)
 }
 
@@ -848,13 +846,11 @@ func (ib *IndexBackfiller) BuildIndexEntriesChunk(
 	var fetcher row.Fetcher
 	if err := fetcher.Init(
 		ib.evalCtx.Context,
-		false, /* reverse */
-		descpb.ScanLockingStrength_FOR_NONE,
-		descpb.ScanLockingWaitPolicy_BLOCK,
-		0, /* lockTimeout */
-		&ib.alloc,
-		ib.mon,
-		&spec,
+		row.FetcherInitArgs{
+			Alloc:      &ib.alloc,
+			MemMonitor: ib.mon,
+			Spec:       &spec,
+		},
 	); err != nil {
 		return nil, nil, 0, err
 	}

--- a/pkg/sql/delete_preserving_index_test.go
+++ b/pkg/sql/delete_preserving_index_test.go
@@ -776,13 +776,12 @@ func fetchIndex(
 	const reverse = false
 	require.NoError(t, fetcher.Init(
 		ctx,
-		reverse,
-		descpb.ScanLockingStrength_FOR_NONE,
-		descpb.ScanLockingWaitPolicy_BLOCK,
-		0,
-		&alloc,
-		mm.Monitor(),
-		&spec,
+		row.FetcherInitArgs{
+			Reverse:    reverse,
+			Alloc:      &alloc,
+			MemMonitor: mm.Monitor(),
+			Spec:       &spec,
+		},
 	))
 
 	require.NoError(t, fetcher.StartScan(

--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -98,13 +98,10 @@ func (d *deleteRangeNode) startExec(params runParams) error {
 	}
 	if err := d.fetcher.Init(
 		params.ctx,
-		false, /* reverse */
-		descpb.ScanLockingStrength_FOR_NONE,
-		descpb.ScanLockingWaitPolicy_BLOCK,
-		0, /* lockTimeout */
-		params.p.alloc,
-		nil, /* memMonitor */
-		&spec,
+		row.FetcherInitArgs{
+			Alloc: params.p.alloc,
+			Spec:  &spec,
+		},
 	); err != nil {
 		return err
 	}

--- a/pkg/sql/indexbackfiller_test.go
+++ b/pkg/sql/indexbackfiller_test.go
@@ -390,7 +390,6 @@ INSERT INTO foo VALUES (1), (10), (100);
 
 		require.NoError(t, err)
 		spans := []roachpb.Span{table.IndexSpan(keys.SystemSQLCodec, indexID)}
-		const reverse = false
 		var fetcherCols []descpb.ColumnID
 		for _, col := range table.PublicColumns() {
 			if colIDsNeeded.Contains(col.GetID()) {
@@ -409,13 +408,11 @@ INSERT INTO foo VALUES (1), (10), (100);
 		var fetcher row.Fetcher
 		require.NoError(t, fetcher.Init(
 			ctx,
-			reverse,
-			descpb.ScanLockingStrength_FOR_NONE,
-			descpb.ScanLockingWaitPolicy_BLOCK,
-			0,
-			&alloc,
-			mm.Monitor(),
-			&spec,
+			row.FetcherInitArgs{
+				Alloc:      &alloc,
+				MemMonitor: mm.Monitor(),
+				Spec:       &spec,
+			},
 		))
 
 		require.NoError(t, fetcher.StartScan(

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -268,13 +268,10 @@ func DecodeRowInfo(
 	rf.IgnoreUnexpectedNulls = true
 	if err := rf.Init(
 		ctx,
-		false, /* reverse */
-		descpb.ScanLockingStrength_FOR_NONE,
-		descpb.ScanLockingWaitPolicy_BLOCK,
-		0, /* lockTimeout */
-		&tree.DatumAlloc{},
-		nil, /* memMonitor */
-		&spec,
+		FetcherInitArgs{
+			Alloc: &tree.DatumAlloc{},
+			Spec:  &spec,
+		},
 	); err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -203,40 +203,42 @@ func (rf *Fetcher) Close(ctx context.Context) {
 	}
 }
 
+// FetcherInitArgs contains arguments for Fetcher.Init.
+type FetcherInitArgs struct {
+	Reverse        bool
+	LockStrength   descpb.ScanLockingStrength
+	LockWaitPolicy descpb.ScanLockingWaitPolicy
+	LockTimeout    time.Duration
+	Alloc          *tree.DatumAlloc
+	MemMonitor     *mon.BytesMonitor
+	Spec           *descpb.IndexFetchSpec
+}
+
 // Init sets up a Fetcher for a given table and index. If we are using a
 // non-primary index, tables.ValNeededForCol can only refer to columns in the
 // index.
-func (rf *Fetcher) Init(
-	ctx context.Context,
-	reverse bool,
-	lockStrength descpb.ScanLockingStrength,
-	lockWaitPolicy descpb.ScanLockingWaitPolicy,
-	lockTimeout time.Duration,
-	alloc *tree.DatumAlloc,
-	memMonitor *mon.BytesMonitor,
-	spec *descpb.IndexFetchSpec,
-) error {
-	if spec.Version != descpb.IndexFetchSpecVersionInitial {
-		return errors.Newf("unsupported IndexFetchSpec version %d", spec.Version)
+func (rf *Fetcher) Init(ctx context.Context, args FetcherInitArgs) error {
+	if args.Spec.Version != descpb.IndexFetchSpecVersionInitial {
+		return errors.Newf("unsupported IndexFetchSpec version %d", args.Spec.Version)
 	}
-	rf.reverse = reverse
-	rf.lockStrength = lockStrength
-	rf.lockWaitPolicy = lockWaitPolicy
-	rf.lockTimeout = lockTimeout
-	rf.alloc = alloc
+	rf.reverse = args.Reverse
+	rf.lockStrength = args.LockStrength
+	rf.lockWaitPolicy = args.LockWaitPolicy
+	rf.lockTimeout = args.LockTimeout
+	rf.alloc = args.Alloc
 
-	if memMonitor != nil {
-		rf.mon = mon.NewMonitorInheritWithLimit("fetcher-mem", 0 /* limit */, memMonitor)
-		rf.mon.Start(ctx, memMonitor, mon.BoundAccount{})
+	if args.MemMonitor != nil {
+		rf.mon = mon.NewMonitorInheritWithLimit("fetcher-mem", 0 /* limit */, args.MemMonitor)
+		rf.mon.Start(ctx, args.MemMonitor, mon.BoundAccount{})
 		memAcc := rf.mon.MakeBoundAccount()
 		rf.kvFetcherMemAcc = &memAcc
 	}
 
 	table := &rf.table
 	*table = tableInfo{
-		spec:       *spec,
-		row:        make(rowenc.EncDatumRow, len(spec.FetchedColumns)),
-		decodedRow: make(tree.Datums, len(spec.FetchedColumns)),
+		spec:       *args.Spec,
+		row:        make(rowenc.EncDatumRow, len(args.Spec.FetchedColumns)),
+		decodedRow: make(tree.Datums, len(args.Spec.FetchedColumns)),
 
 		// These slice fields might get re-allocated below, so reslice them from
 		// the old table here in case they've got enough capacity already.
@@ -247,8 +249,8 @@ func (rf *Fetcher) Init(
 		oidOutputIdx:       noOutputColumn,
 	}
 
-	for idx := range spec.FetchedColumns {
-		colID := spec.FetchedColumns[idx].ColumnID
+	for idx := range args.Spec.FetchedColumns {
+		colID := args.Spec.FetchedColumns[idx].ColumnID
 		table.colIdxMap.Set(colID, idx)
 		if colinfo.IsColIDSystemColumn(colID) {
 			switch colinfo.GetSystemColumnKindFromColumnID(colID) {
@@ -258,13 +260,13 @@ func (rf *Fetcher) Init(
 
 			case catpb.SystemColumnKind_TABLEOID:
 				table.oidOutputIdx = idx
-				table.tableOid = tree.NewDOid(tree.DInt(spec.TableID))
+				table.tableOid = tree.NewDOid(tree.DInt(args.Spec.TableID))
 			}
 		}
 	}
 
-	if len(spec.FetchedColumns) > 0 {
-		table.neededValueColsByIdx.AddRange(0, len(spec.FetchedColumns)-1)
+	if len(args.Spec.FetchedColumns) > 0 {
+		table.neededValueColsByIdx.AddRange(0, len(args.Spec.FetchedColumns)-1)
 	}
 
 	nExtraCols := 0
@@ -273,7 +275,7 @@ func (rf *Fetcher) Init(
 	if table.spec.IsSecondaryIndex && table.spec.IsUniqueIndex {
 		nExtraCols = int(table.spec.NumKeySuffixColumns)
 	}
-	nIndexCols := len(spec.KeyAndSuffixColumns) - nExtraCols
+	nIndexCols := len(args.Spec.KeyAndSuffixColumns) - nExtraCols
 
 	neededIndexCols := 0
 	compositeIndexCols := 0
@@ -283,7 +285,7 @@ func (rf *Fetcher) Init(
 		table.indexColIdx = make([]int, nIndexCols)
 	}
 	for i := 0; i < nIndexCols; i++ {
-		id := spec.KeyAndSuffixColumns[i].ColumnID
+		id := args.Spec.KeyAndSuffixColumns[i].ColumnID
 		colIdx, ok := table.colIdxMap.Get(id)
 		if ok {
 			table.indexColIdx[i] = colIdx
@@ -292,7 +294,7 @@ func (rf *Fetcher) Init(
 		} else {
 			table.indexColIdx[i] = -1
 		}
-		if spec.KeyAndSuffixColumns[i].IsComposite {
+		if args.Spec.KeyAndSuffixColumns[i].IsComposite {
 			compositeIndexCols++
 		}
 	}
@@ -304,7 +306,7 @@ func (rf *Fetcher) Init(
 	// The number of columns we need to read from the value part of the key.
 	// It's the total number of needed columns minus the ones we read from the
 	// index key, except for composite columns.
-	table.neededValueCols = len(spec.FetchedColumns) - neededIndexCols + compositeIndexCols
+	table.neededValueCols = len(args.Spec.FetchedColumns) - neededIndexCols + compositeIndexCols
 
 	if cap(table.keyVals) >= nIndexCols {
 		table.keyVals = table.keyVals[:nIndexCols]

--- a/pkg/sql/row/fetcher_mvcc_test.go
+++ b/pkg/sql/row/fetcher_mvcc_test.go
@@ -91,13 +91,10 @@ func TestRowFetcherMVCCMetadata(t *testing.T) {
 	var rf row.Fetcher
 	if err := rf.Init(
 		ctx,
-		false, /* reverse */
-		descpb.ScanLockingStrength_FOR_NONE,
-		descpb.ScanLockingWaitPolicy_BLOCK,
-		0, /* lockTimeout */
-		&tree.DatumAlloc{},
-		nil, /* memMonitor */
-		&spec,
+		row.FetcherInitArgs{
+			Alloc: &tree.DatumAlloc{},
+			Spec:  &spec,
+		},
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/row/fetcher_test.go
+++ b/pkg/sql/row/fetcher_test.go
@@ -73,13 +73,12 @@ func initFetcher(
 
 	if err := fetcher.Init(
 		context.Background(),
-		reverseScan,
-		descpb.ScanLockingStrength_FOR_NONE,
-		descpb.ScanLockingWaitPolicy_BLOCK,
-		0, /* lockTimeout */
-		alloc,
-		memMon,
-		&spec,
+		FetcherInitArgs{
+			Reverse:    reverseScan,
+			Alloc:      alloc,
+			MemMonitor: memMon,
+			Spec:       &spec,
+		},
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -706,13 +705,10 @@ func TestRowFetcherReset(t *testing.T) {
 	spec := makeIndexFetchSpec(t, args)
 	if err := resetFetcher.Init(
 		ctx,
-		false, /*reverse*/
-		descpb.ScanLockingStrength_FOR_NONE,
-		descpb.ScanLockingWaitPolicy_BLOCK,
-		0, /* lockTimeout */
-		&da,
-		nil, /* memMonitor */
-		&spec,
+		FetcherInitArgs{
+			Alloc: &da,
+			Spec:  &spec,
+		},
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -92,18 +92,20 @@ func NewKVFetcher(
 
 	kvBatchFetcher, err := makeKVBatchFetcher(
 		ctx,
-		sendFn,
-		spans,
-		reverse,
-		batchBytesLimit,
-		firstBatchLimit,
-		lockStrength,
-		lockWaitPolicy,
-		lockTimeout,
-		acc,
-		forceProductionKVBatchSize,
-		txn.AdmissionHeader(),
-		txn.DB().SQLKVResponseAdmissionQ,
+		kvBatchFetcherArgs{
+			sendFn:                     sendFn,
+			spans:                      spans,
+			reverse:                    reverse,
+			batchBytesLimit:            batchBytesLimit,
+			firstBatchKeyLimit:         firstBatchLimit,
+			lockStrength:               lockStrength,
+			lockWaitPolicy:             lockWaitPolicy,
+			lockTimeout:                lockTimeout,
+			acc:                        acc,
+			forceProductionKVBatchSize: forceProductionKVBatchSize,
+			requestAdmissionHeader:     txn.AdmissionHeader(),
+			responseAdmissionQ:         txn.DB().SQLKVResponseAdmissionQ,
+		},
 	)
 	return newKVFetcher(&kvBatchFetcher), err
 }

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -278,13 +278,12 @@ func newInvertedJoiner(
 	var fetcher row.Fetcher
 	if err := fetcher.Init(
 		flowCtx.EvalCtx.Context,
-		false, /* reverse */
-		descpb.ScanLockingStrength_FOR_NONE,
-		descpb.ScanLockingWaitPolicy_BLOCK,
-		flowCtx.EvalCtx.SessionData().LockTimeout,
-		&ij.alloc,
-		flowCtx.EvalCtx.Mon,
-		&spec.FetchSpec,
+		row.FetcherInitArgs{
+			LockTimeout: flowCtx.EvalCtx.SessionData().LockTimeout,
+			Alloc:       &ij.alloc,
+			MemMonitor:  flowCtx.EvalCtx.Mon,
+			Spec:        &spec.FetchSpec,
+		},
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -385,13 +385,14 @@ func newJoinReader(
 	var fetcher row.Fetcher
 	if err := fetcher.Init(
 		flowCtx.EvalCtx.Context,
-		false, /* reverse */
-		spec.LockingStrength,
-		spec.LockingWaitPolicy,
-		flowCtx.EvalCtx.SessionData().LockTimeout,
-		&jr.alloc,
-		flowCtx.EvalCtx.Mon,
-		&spec.FetchSpec,
+		row.FetcherInitArgs{
+			LockStrength:   spec.LockingStrength,
+			LockWaitPolicy: spec.LockingWaitPolicy,
+			LockTimeout:    flowCtx.EvalCtx.SessionData().LockTimeout,
+			Alloc:          &jr.alloc,
+			MemMonitor:     flowCtx.EvalCtx.Mon,
+			Spec:           &spec.FetchSpec,
+		},
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -135,13 +135,15 @@ func newTableReader(
 	var fetcher row.Fetcher
 	if err := fetcher.Init(
 		flowCtx.EvalCtx.Context,
-		spec.Reverse,
-		spec.LockingStrength,
-		spec.LockingWaitPolicy,
-		flowCtx.EvalCtx.SessionData().LockTimeout,
-		&tr.alloc,
-		flowCtx.EvalCtx.Mon,
-		&spec.FetchSpec,
+		row.FetcherInitArgs{
+			Reverse:        spec.Reverse,
+			LockStrength:   spec.LockingStrength,
+			LockWaitPolicy: spec.LockingWaitPolicy,
+			LockTimeout:    flowCtx.EvalCtx.SessionData().LockTimeout,
+			Alloc:          &tr.alloc,
+			MemMonitor:     flowCtx.EvalCtx.Mon,
+			Spec:           &spec.FetchSpec,
+		},
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -442,13 +442,12 @@ func (z *zigzagJoiner) setupInfo(
 	var fetcher row.Fetcher
 	if err := fetcher.Init(
 		flowCtx.EvalCtx.Context,
-		false, /* reverse */
-		descpb.ScanLockingStrength_FOR_NONE,
-		descpb.ScanLockingWaitPolicy_BLOCK,
-		flowCtx.EvalCtx.SessionData().LockTimeout,
-		&info.alloc,
-		flowCtx.EvalCtx.Mon,
-		&spec.FetchSpec,
+		row.FetcherInitArgs{
+			LockTimeout: flowCtx.EvalCtx.SessionData().LockTimeout,
+			Alloc:       &info.alloc,
+			MemMonitor:  flowCtx.EvalCtx.Mon,
+			Spec:        &spec.FetchSpec,
+		},
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR is a pure refactor that replaces some overly-long argument lists with argument structs.