### PR TITLE
jobs: show pause reason in SHOW JOBS + UI

### DIFF
--- a/pkg/jobs/errors.go
+++ b/pkg/jobs/errors.go
@@ -65,6 +65,9 @@ func MarkPauseRequestError(reason error) error {
 	return errors.Mark(reason, errPauseSelfSentinel)
 }
 
+// PauseRequestExplained is a prose used to wrap and explain a pause-request error.
+const PauseRequestExplained = "pausing due to error; use RESUME JOB to try to proceed once the issue is resolved, or CANCEL JOB to rollback"
+
 // InvalidStatusError is the error returned when the desired operation is
 // invalid given the job's current status.
 type InvalidStatusError struct {

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1144,7 +1144,7 @@ func (r *Registry) stepThroughStateMachine(
 			if err := r.PauseRequested(ctx, nil, job.ID(), err.Error()); err != nil {
 				return err
 			}
-			return errPauseSelfSentinel
+			return errors.Wrap(err, PauseRequestExplained)
 		}
 		// TODO(spaskob): enforce a limit on retries.
 

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -901,11 +901,11 @@ CREATE TABLE crdb_internal.jobs (
 							return nil, err
 						}
 
-						if len(progress.RunningStatus) > 0 {
-							if s, ok := status.(*tree.DString); ok {
-								if jobs.Status(*s) == jobs.StatusRunning {
-									runningStatus = tree.NewDString(progress.RunningStatus)
-								}
+						if s, ok := status.(*tree.DString); ok {
+							if jobs.Status(*s) == jobs.StatusRunning && len(progress.RunningStatus) > 0 {
+								runningStatus = tree.NewDString(progress.RunningStatus)
+							} else if jobs.Status(*s) == jobs.StatusPaused && payload != nil && payload.PauseReason != "" {
+								errorStr = tree.NewDString(fmt.Sprintf("%s: %s", jobs.PauseRequestExplained, payload.PauseReason))
 							}
 						}
 						traceID = tree.NewDInt(tree.DInt(progress.TraceID))

--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobStatusOptions.ts
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobStatusOptions.ts
@@ -41,6 +41,9 @@ export function jobToVisual(job: Job): JobStatusVisual {
     case JOB_STATUS_CANCELED:
     case JOB_STATUS_CANCEL_REQUESTED:
     case JOB_STATUS_PAUSED:
+      return job.error == ""
+        ? JobStatusVisual.BadgeOnly
+        : JobStatusVisual.BadgeWithErrorMessage;
     case JOB_STATUS_PAUSE_REQUESTED:
     case JOB_STATUS_REVERTING:
     default:


### PR DESCRIPTION
See commits. 

In action (with #78546) on the CLI:

<img width="1396" alt="Screen Shot 2022-03-25 at 11 26 28 PM" src="https://user-images.githubusercontent.com/15615/160223030-c41b52d6-099d-431b-9c91-233057b0c9c8.png">

And on the DB Console:
<img width="970" alt="Screen Shot 2022-03-25 at 11 19 07 PM" src="https://user-images.githubusercontent.com/15615/160223055-6ce78fc8-4c58-4879-ac05-8bac0422b7b3.png">
