### PR TITLE
backup,sql/importer,sql: pause job if a node is running out of disk

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -158,6 +158,10 @@ func restoreWithRetry(
 			break
 		}
 
+		if errors.HasType(err, &roachpb.InsufficientSpaceError{}) {
+			return roachpb.RowCount{}, jobs.MarkPauseRequestError(errors.UnwrapAll(err))
+		}
+
 		if joberror.IsPermanentBulkJobError(err) {
 			return roachpb.RowCount{}, err
 		}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -2007,6 +2007,9 @@ func (sc *SchemaChanger) backfillIndexes(
 	if err := sc.distIndexBackfill(
 		ctx, version, addingSpans, addedIndexes, writeAtRequestTimestamp, backfill.IndexMutationFilter, fractionScaler,
 	); err != nil {
+		if errors.HasType(err, &roachpb.InsufficientSpaceError{}) {
+			return jobs.MarkPauseRequestError(errors.UnwrapAll(err))
+		}
 		return err
 	}
 

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -1221,6 +1221,10 @@ func ingestWithRetry(
 			break
 		}
 
+		if errors.HasType(err, &roachpb.InsufficientSpaceError{}) {
+			return res, jobs.MarkPauseRequestError(errors.UnwrapAll(err))
+		}
+
 		if joberror.IsPermanentBulkJobError(err) {
 			return res, err
 		}


### PR DESCRIPTION
See commits.

Significantly friendlier with #78543.