### PR TITLE
sql: populate semantic type of DOid correctly in some cases

### DIFF
--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -1304,7 +1304,7 @@ func (cf *cFetcher) finalizeBatch() {
 			// Note that we don't need to update the memory accounting because
 			// oids are fixed length values and have already been accounted for
 			// when finalizing each row.
-			cf.machine.tableoidCol.Set(i, cf.table.da.NewDOid(tree.MakeDOid(tree.DInt(id))))
+			cf.machine.tableoidCol.Set(i, cf.table.da.NewDOid(tree.MakeDOid(tree.DInt(id), types.Oid)))
 		}
 	}
 	cf.machine.batch.SetLength(cf.machine.rowIdx)

--- a/pkg/sql/rowenc/keyside/decode.go
+++ b/pkg/sql/rowenc/keyside/decode.go
@@ -251,7 +251,7 @@ func Decode(
 		} else {
 			rkey, i, err = encoding.DecodeVarintDescending(key)
 		}
-		return a.NewDOid(tree.MakeDOid(tree.DInt(i))), rkey, err
+		return a.NewDOid(tree.MakeDOid(tree.DInt(i), valType)), rkey, err
 	case types.EnumFamily:
 		var r []byte
 		if dir == encoding.Ascending {

--- a/pkg/sql/rowenc/valueside/decode.go
+++ b/pkg/sql/rowenc/valueside/decode.go
@@ -189,7 +189,7 @@ func DecodeUntaggedDatum(
 		return a.NewDJSON(tree.DJSON{JSON: j}), b, nil
 	case types.OidFamily:
 		b, data, err := encoding.DecodeUntaggedIntValue(buf)
-		return a.NewDOid(tree.MakeDOid(tree.DInt(data))), b, err
+		return a.NewDOid(tree.MakeDOid(tree.DInt(data), t)), b, err
 	case types.ArrayFamily:
 		// Skip the encoded data length.
 		b, _, _, err := encoding.DecodeNonsortingUvarint(buf)

--- a/pkg/sql/rowenc/valueside/legacy.go
+++ b/pkg/sql/rowenc/valueside/legacy.go
@@ -328,7 +328,7 @@ func UnmarshalLegacy(a *tree.DatumAlloc, typ *types.T, value roachpb.Value) (tre
 		if err != nil {
 			return nil, err
 		}
-		return a.NewDOid(tree.MakeDOid(tree.DInt(v))), nil
+		return a.NewDOid(tree.MakeDOid(tree.DInt(v), typ)), nil
 	case types.ArrayFamily:
 		v, err := value.GetBytes()
 		if err != nil {

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -4828,13 +4828,15 @@ type DOid struct {
 }
 
 // MakeDOid is a helper routine to create a DOid initialized from a DInt.
-func MakeDOid(d DInt) DOid {
-	return DOid{DInt: d, semanticType: types.Oid, name: ""}
+func MakeDOid(d DInt, semanticType *types.T) DOid {
+	return DOid{DInt: d, semanticType: semanticType, name: ""}
 }
 
 // NewDOid is a helper routine to create a *DOid initialized from a DInt.
 func NewDOid(d DInt) *DOid {
-	oid := MakeDOid(d)
+	// TODO(yuzefovich): audit the callers of NewDOid to see whether any want to
+	// create a DOid with a semantic type different from types.Oid.
+	oid := MakeDOid(d, types.Oid)
 	return &oid
 }
 


### PR DESCRIPTION
This commit is a small step towards preserving the information of
a `DOid` during serialization / deserialization. Namely, we now preserve
the semantic type in some cases. There might be more cases where we want
to set a custom semantic type. Futhermore, `name` field is not preserved
at the moment.

Touches: #78547.

Release note: None