### PR TITLE
colexecproj: unset nulls in the default comparison operator

### DIFF
--- a/pkg/sql/colexec/colexecproj/default_cmp_proj_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/default_cmp_proj_ops.eg.go
@@ -38,6 +38,11 @@ func (d *defaultCmpProjOp) Next() coldata.Batch {
 	}
 	sel := batch.Selection()
 	output := batch.ColVec(d.outputIdx)
+	if output.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		output.Nulls().UnsetNulls()
+	}
 	d.allocator.PerformOperation([]coldata.Vec{output}, func() {
 		d.toDatumConverter.ConvertBatchAndDeselect(batch)
 		leftColumn := d.toDatumConverter.GetDatumColumn(d.col1Idx)
@@ -97,6 +102,11 @@ func (d *defaultCmpRConstProjOp) Next() coldata.Batch {
 	}
 	sel := batch.Selection()
 	output := batch.ColVec(d.outputIdx)
+	if output.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		output.Nulls().UnsetNulls()
+	}
 	d.allocator.PerformOperation([]coldata.Vec{output}, func() {
 		d.toDatumConverter.ConvertBatchAndDeselect(batch)
 		nonConstColumn := d.toDatumConverter.GetDatumColumn(d.colIdx)

--- a/pkg/sql/colexec/colexecproj/default_cmp_proj_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/default_cmp_proj_ops_tmpl.go
@@ -57,6 +57,11 @@ func (d *defaultCmp_KINDProjOp) Next() coldata.Batch {
 	}
 	sel := batch.Selection()
 	output := batch.ColVec(d.outputIdx)
+	if output.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		output.Nulls().UnsetNulls()
+	}
 	d.allocator.PerformOperation([]coldata.Vec{output}, func() {
 		d.toDatumConverter.ConvertBatchAndDeselect(batch)
 		// {{if .IsRightConst}}


### PR DESCRIPTION
Previously, we forgot to unset nulls in the default comparison operator
(which handles all comparisons that are not natively supported by the
vectorized engine), so whenever an output vector is reused, we could
produce an incorrect output. However, in most cases we got lucky because
`ResetInternalBatch` unsets nulls on all vectors, even if those aren't
owned by the caller of the method. (For context, our projection
operators append its output vector to a batch that is otherwise owned by
another operator, like `ColBatchScan`.) Thus, I decided to not include
a release note since the bug appears to be quite rare. There is also no
regression test since I'm working on improving the test harness that
would have caught this (currently, the test harness itself calls
`ResetInternalBatch` which hides this bug in the unit tests).

Release note: None