### PR TITLE
sqlsmith: fix deadlock during generation

### DIFF
--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -206,6 +206,8 @@ func makeEquiJoinExpr(s *Smither, refs colRefs, forJoin bool) (tree.TableExpr, c
 		return nil, nil, false
 	}
 
+	s.lock.RLock()
+	defer s.lock.RUnlock()
 	// Determine overlapping types.
 	var available [][2]tree.TypedExpr
 	for _, leftCol := range leftRefs {

--- a/pkg/internal/sqlsmith/type.go
+++ b/pkg/internal/sqlsmith/type.go
@@ -59,9 +59,9 @@ func (s *Smither) randScalarType() *types.T {
 
 // isScalarType returns true if t is a member of types.Scalar, or a user defined
 // enum.
+// Requires s.lock to be held.
 func (s *Smither) isScalarType(t *types.T) bool {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
+	s.lock.AssertRHeld()
 	scalarTypes := types.Scalar
 	if s.types != nil {
 		scalarTypes = s.types.scalarTypes


### PR DESCRIPTION
Fixes a deadlock when sqlsmith generates join expressions.

Fixes: #78555

Release note: None