### PR TITLE
dashboards/replication: add snapshot bytes recv per node

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -178,6 +178,21 @@ export default function(props: GraphDashboardProps) {
         />
       </Axis>
     </LineGraph>,
+
+    <LineGraph title="Snapshot Data Received" sources={storeSources}>
+      <Axis label="bytes">
+        {_.map(nodeIDs, nid => (
+          <Metric
+            key={nid}
+            name="cr.store.range.snapshots.rcvd-bytes"
+            title={nodeDisplayName(nodesSummary, nid)}
+            sources={storeIDsForNode(nodesSummary, nid)}
+            nonNegativeRate
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
     <LineGraph
       title="Circuit Breaker Tripped Replicas"
       tooltip={CircuitBreakerTrippedReplicasTooltip}


### PR DESCRIPTION
This is useful for seeing how much snapshot write load a node is processing.

Release note (ui change): The replication dashboard now includes a graph of snapshot bytes received per node.