### PR TITLE
jobs: Rewrite job scheduler query logic.

### DIFF
--- a/pkg/jobs/job_scheduler.go
+++ b/pkg/jobs/job_scheduler.go
@@ -23,9 +23,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/scheduledjobs"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -70,65 +70,66 @@ func newJobScheduler(
 
 const allSchedules = 0
 
-// getFindSchedulesStatement returns SQL statement used for finding
-// scheduled jobs that should be started.
-func getFindSchedulesStatement(env scheduledjobs.JobSchedulerEnv, maxSchedules int64) string {
-	limitClause := ""
-	if maxSchedules != allSchedules {
-		limitClause = fmt.Sprintf("LIMIT %d", maxSchedules)
+var errScheduleNotRunnable = errors.New("schedule not runnable")
+
+// loadCandidateScheduleForExecution looks up and locks candidate schedule for execution.
+// The schedule is locked via FOR UPDATE clause to ensure that only this scheduler can modify it.
+// If schedule cannot execute, a errScheduleNotRunnable error is returned.
+func loadCandidateScheduleForExecution(
+	ctx context.Context,
+	scheduleID int64,
+	env scheduledjobs.JobSchedulerEnv,
+	ie sqlutil.InternalExecutor,
+	txn *kv.Txn,
+) (*ScheduledJob, error) {
+	lookupStmt := fmt.Sprintf(
+		"SELECT * FROM %s WHERE schedule_id=%d AND next_run < %s FOR UPDATE",
+		env.ScheduledJobsTableName(), scheduleID, env.NowExpr())
+	row, cols, err := ie.QueryRowExWithCols(
+		ctx, "find-scheduled-jobs-exec",
+		txn,
+		sessiondata.InternalExecutorOverride{User: security.RootUserName()},
+		lookupStmt)
+	if err != nil {
+		return nil, err
 	}
 
-	return fmt.Sprintf(
-		`
-SELECT
-  (SELECT count(*)
-   FROM %s J
-   WHERE
-      J.created_by_type = '%s' AND J.created_by_id = S.schedule_id AND
-      J.status NOT IN ('%s', '%s', '%s', '%s')
-  ) AS num_running, S.*
-FROM %s S
-WHERE next_run < %s
-ORDER BY random()
-%s
-FOR UPDATE`, env.SystemJobsTableName(), CreatedByScheduledJobs,
-		StatusSucceeded, StatusCanceled, StatusFailed, StatusRevertFailed,
-		env.ScheduledJobsTableName(), env.NowExpr(), limitClause)
+	if row == nil {
+		return nil, errScheduleNotRunnable
+	}
+
+	j := NewScheduledJob(env)
+	if err := j.InitFromDatums(row, cols); err != nil {
+		return nil, err
+	}
+	return j, nil
 }
 
-// unmarshalScheduledJob is a helper to deserialize a row returned by
-// getFindSchedulesStatement() into a ScheduledJob
-func (s *jobScheduler) unmarshalScheduledJob(
-	row []tree.Datum, cols []colinfo.ResultColumn,
-) (*ScheduledJob, int64, error) {
-	j := NewScheduledJob(s.env)
-	if err := j.InitFromDatums(row[1:], cols[1:]); err != nil {
-		return nil, 0, err
+// lookupNumRunningJobs returns the number of running jobs for the specified schedule.
+func lookupNumRunningJobs(
+	ctx context.Context,
+	scheduleID int64,
+	env scheduledjobs.JobSchedulerEnv,
+	ie sqlutil.InternalExecutor,
+) (int64, error) {
+	lookupStmt := fmt.Sprintf(
+		"SELECT count(*) FROM %s WHERE created_by_type = '%s' AND created_by_id = %d AND status IN %s",
+		env.SystemJobsTableName(), CreatedByScheduledJobs, scheduleID, NonTerminalStatusTupleString)
+	row, err := ie.QueryRowEx(
+		ctx, "lookup-num-running",
+		/*txn=*/ nil,
+		sessiondata.InternalExecutorOverride{User: security.RootUserName()},
+		lookupStmt)
+	if err != nil {
+		return 0, err
 	}
-
-	if n, ok := row[0].(*tree.DInt); ok {
-		return j, int64(*n), nil
-	}
-
-	return nil, 0, errors.Newf("expected int found %T instead", row[0])
+	return int64(tree.MustBeDInt(row[0])), nil
 }
 
 const recheckRunningAfter = 1 * time.Minute
 
-type loopStats struct {
-	rescheduleWait, rescheduleSkip, started int64
-	malformed                               int64
-}
-
-func (s *loopStats) updateMetrics(m *SchedulerMetrics) {
-	m.NumStarted.Update(s.started)
-	m.RescheduleSkip.Update(s.rescheduleSkip)
-	m.RescheduleWait.Update(s.rescheduleWait)
-	m.NumMalformedSchedules.Update(s.malformed)
-}
-
 func (s *jobScheduler) processSchedule(
-	ctx context.Context, schedule *ScheduledJob, numRunning int64, stats *loopStats, txn *kv.Txn,
+	ctx context.Context, schedule *ScheduledJob, numRunning int64, txn *kv.Txn,
 ) error {
 	if numRunning > 0 {
 		switch schedule.ScheduleDetails().Wait {
@@ -138,14 +139,14 @@ func (s *jobScheduler) processSchedule(
 			// a job.  It would also be nice not to log each event.
 			schedule.SetNextRun(s.env.Now().Add(recheckRunningAfter))
 			schedule.SetScheduleStatus("delayed due to %d already running", numRunning)
-			stats.rescheduleWait++
+			s.metrics.RescheduleWait.Inc(1)
 			return schedule.Update(ctx, s.InternalExecutor, txn)
 		case jobspb.ScheduleDetails_SKIP:
 			if err := schedule.ScheduleNextRun(); err != nil {
 				return err
 			}
 			schedule.SetScheduleStatus("rescheduled due to %d already running", numRunning)
-			stats.rescheduleSkip++
+			s.metrics.RescheduleSkip.Inc(1)
 			return schedule.Update(ctx, s.InternalExecutor, txn)
 		}
 	}
@@ -184,7 +185,7 @@ func (s *jobScheduler) processSchedule(
 		return errors.Wrapf(err, "executing schedule %d", schedule.ScheduleID())
 	}
 
-	stats.started++
+	s.metrics.NumStarted.Inc(1)
 
 	// Persist any mutations to the underlying schedule.
 	return schedule.Update(ctx, s.InternalExecutor, txn)
@@ -231,16 +232,98 @@ func withSavePoint(ctx context.Context, txn *kv.Txn, fn func() error) error {
 	return execErr
 }
 
-func (s *jobScheduler) executeSchedules(
-	ctx context.Context, maxSchedules int64, txn *kv.Txn,
-) (retErr error) {
-	var stats loopStats
-	defer stats.updateMetrics(&s.metrics)
+// executeCandidateSchedule attempts to execute schedule.
+// The schedule is executed only if it's running.
+func (s *jobScheduler) executeCandidateSchedule(
+	ctx context.Context, candidate int64, txn *kv.Txn,
+) error {
+	schedule, err := loadCandidateScheduleForExecution(ctx, candidate, s.env, s.InternalExecutor, txn)
+	if err != nil {
+		if errors.Is(err, errScheduleNotRunnable) {
+			return nil
+		}
+		s.metrics.NumMalformedSchedules.Inc(1)
+		log.Errorf(ctx, "error parsing schedule %d: %s", candidate, err)
+		return err
+	}
 
-	findSchedulesStmt := getFindSchedulesStatement(s.env, maxSchedules)
+	if !s.env.IsExecutorEnabled(schedule.ExecutorType()) {
+		log.Infof(ctx, "Ignoring schedule %d: %s executor disabled",
+			schedule.ScheduleID(), schedule.ExecutorType())
+		return nil
+	}
+
+	numRunning, err := lookupNumRunningJobs(ctx, schedule.ScheduleID(), s.env, s.InternalExecutor)
+	if err != nil {
+		return err
+	}
+
+	timeout := schedulerScheduleExecutionTimeout.Get(&s.Settings.SV)
+	if processErr := withSavePoint(ctx, txn, func() error {
+		if timeout > 0 {
+			return contextutil.RunWithTimeout(
+				ctx, fmt.Sprintf("process-schedule-%d", schedule.ScheduleID()), timeout,
+				func(ctx context.Context) error {
+					return s.processSchedule(ctx, schedule, numRunning, txn)
+				})
+		}
+		return s.processSchedule(ctx, schedule, numRunning, txn)
+	}); processErr != nil {
+		if errors.HasType(processErr, (*savePointError)(nil)) {
+			return errors.Wrapf(processErr, "savepoint error for schedule %d", schedule.ScheduleID())
+		}
+
+		// Failed to process schedule.
+		s.metrics.NumErrSchedules.Inc(1)
+		log.Errorf(ctx,
+			"error processing schedule %d: %+v", schedule.ScheduleID(), processErr)
+
+		// Try updating schedule record to indicate schedule execution error.
+		if err := withSavePoint(ctx, txn, func() error {
+			// Discard changes already made to the schedule, and treat schedule
+			// execution failure the same way we treat job failure.
+			schedule.ClearDirty()
+			DefaultHandleFailedRun(schedule,
+				"failed to create job for schedule %d: err=%s",
+				schedule.ScheduleID(), processErr)
+
+			// DefaultHandleFailedRun assumes schedule already had its next run set.
+			// So, if the policy is to reschedule based on regular recurring schedule,
+			// we need to set next run again..
+			if schedule.HasRecurringSchedule() &&
+				schedule.ScheduleDetails().OnError == jobspb.ScheduleDetails_RETRY_SCHED {
+				if err := schedule.ScheduleNextRun(); err != nil {
+					return err
+				}
+			}
+			return schedule.Update(ctx, s.InternalExecutor, txn)
+		}); err != nil {
+			if errors.HasType(err, (*savePointError)(nil)) {
+				return errors.Wrapf(err,
+					"savepoint error for schedule %d", schedule.ScheduleID())
+			}
+			log.Errorf(ctx, "error recording processing error for schedule %d: %+v",
+				schedule.ScheduleID(), err)
+		}
+	}
+	return nil
+}
+
+func (s *jobScheduler) executeSchedules(ctx context.Context, maxSchedules int64) (retErr error) {
+	// Lookup a set of candidate schedules to execute.
+	// NB: this lookup happens under nil txn; we ensure the schedule is still runnable
+	// using per-schedule exclusive (for update) query.
+	limitClause := ""
+	if maxSchedules != allSchedules {
+		limitClause = fmt.Sprintf("LIMIT %d", maxSchedules)
+	}
+
+	findSchedulesStmt := fmt.Sprintf(
+		`SELECT schedule_id FROM %s WHERE next_run < %s ORDER BY random() %s`,
+		s.env.ScheduledJobsTableName(), s.env.NowExpr(), limitClause)
 	it, err := s.InternalExecutor.QueryIteratorEx(
 		ctx, "find-scheduled-jobs",
-		txn,
+		/*txn=*/ nil,
 		sessiondata.InternalExecutorOverride{User: security.RootUserName()},
 		findSchedulesStmt)
 
@@ -257,66 +340,11 @@ func (s *jobScheduler) executeSchedules(
 	var ok bool
 	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
 		row := it.Cur()
-		schedule, numRunning, err := s.unmarshalScheduledJob(row, it.Types())
-		if err != nil {
-			stats.malformed++
-			log.Errorf(ctx, "error parsing schedule: %+v", row)
-			continue
-		}
-
-		if !s.env.IsExecutorEnabled(schedule.ExecutorType()) {
-			log.Infof(ctx, "Ignoring schedule %d: %s executor disabled",
-				schedule.ScheduleID(), schedule.ExecutorType())
-			continue
-		}
-
-		timeout := schedulerScheduleExecutionTimeout.Get(&s.Settings.SV)
-		if processErr := withSavePoint(ctx, txn, func() error {
-			if timeout > 0 {
-				return contextutil.RunWithTimeout(
-					ctx, fmt.Sprintf("process-schedule-%d", schedule.ScheduleID()), timeout,
-					func(ctx context.Context) error {
-						return s.processSchedule(ctx, schedule, numRunning, &stats, txn)
-					})
-			}
-			return s.processSchedule(ctx, schedule, numRunning, &stats, txn)
-		}); processErr != nil {
-			if errors.HasType(processErr, (*savePointError)(nil)) {
-				return errors.Wrapf(processErr, "savepoint error for schedule %d", schedule.ScheduleID())
-			}
-
-			// Failed to process schedule.
-			s.metrics.NumErrSchedules.Inc(1)
-			log.Errorf(ctx,
-				"error processing schedule %d: %+v", schedule.ScheduleID(), processErr)
-
-			// Try updating schedule record to indicate schedule execution error.
-			if err := withSavePoint(ctx, txn, func() error {
-				// Discard changes already made to the schedule, and treat schedule
-				// execution failure the same way we treat job failure.
-				schedule.ClearDirty()
-				DefaultHandleFailedRun(schedule,
-					"failed to create job for schedule %d: err=%s",
-					schedule.ScheduleID(), processErr)
-
-				// DefaultHandleFailedRun assumes schedule already had its next run set.
-				// So, if the policy is to reschedule based on regular recurring schedule,
-				// we need to set next run again..
-				if schedule.HasRecurringSchedule() &&
-					schedule.ScheduleDetails().OnError == jobspb.ScheduleDetails_RETRY_SCHED {
-					if err := schedule.ScheduleNextRun(); err != nil {
-						return err
-					}
-				}
-				return schedule.Update(ctx, s.InternalExecutor, txn)
-			}); err != nil {
-				if errors.HasType(err, (*savePointError)(nil)) {
-					return errors.Wrapf(err,
-						"savepoint error for schedule %d", schedule.ScheduleID())
-				}
-				log.Errorf(ctx, "error recording processing error for schedule %d: %+v",
-					schedule.ScheduleID(), err)
-			}
+		candidateID := int64(tree.MustBeDInt(row[0]))
+		if err := s.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			return s.executeCandidateSchedule(ctx, candidateID, txn)
+		}); err != nil {
+			log.Errorf(ctx, "error executing candidate schedule %d: %s", candidateID, err)
 		}
 	}
 
@@ -421,9 +449,7 @@ func (s *jobScheduler) runDaemon(ctx context.Context, stopper *stop.Stopper) {
 
 				maxSchedules := schedulerMaxJobsPerIterationSetting.Get(&s.Settings.SV)
 				if err := whenDisabled.withCancelOnDisabled(ctx, &s.Settings.SV, func(ctx context.Context) error {
-					return s.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-						return s.executeSchedules(ctx, maxSchedules, txn)
-					})
+					return s.executeSchedules(ctx, maxSchedules)
 				}); err != nil {
 					log.Errorf(ctx, "error executing schedules: %+v", err)
 				}
@@ -538,8 +564,8 @@ func StartJobSchedulerDaemon(
 
 	if daemonKnobs != nil && daemonKnobs.TakeOverJobsScheduling != nil {
 		daemonKnobs.TakeOverJobsScheduling(
-			func(ctx context.Context, maxSchedules int64, txn *kv.Txn) error {
-				return scheduler.executeSchedules(ctx, maxSchedules, txn)
+			func(ctx context.Context, maxSchedules int64) error {
+				return scheduler.executeSchedules(ctx, maxSchedules)
 			})
 		return
 	}

--- a/pkg/jobs/job_scheduler_test.go
+++ b/pkg/jobs/job_scheduler_test.go
@@ -94,10 +94,7 @@ func TestJobSchedulerReschedulesRunning(t *testing.T) {
 			// The job should not run -- it should be rescheduled `recheckJobAfter` time in the
 			// future.
 			s := newJobScheduler(h.cfg, h.env, metric.NewRegistry())
-			require.NoError(t,
-				h.cfg.DB.Txn(context.Background(), func(ctx context.Context, txn *kv.Txn) error {
-					return s.executeSchedules(ctx, allSchedules, txn)
-				}))
+			require.NoError(t, s.executeSchedules(ctx, allSchedules))
 
 			if wait == jobspb.ScheduleDetails_WAIT {
 				expectedRunTime = h.env.Now().Add(recheckRunningAfter)
@@ -151,10 +148,7 @@ func TestJobSchedulerExecutesAfterTerminal(t *testing.T) {
 
 			// Execute the job and verify it has the next run scheduled.
 			s := newJobScheduler(h.cfg, h.env, metric.NewRegistry())
-			require.NoError(t,
-				h.cfg.DB.Txn(context.Background(), func(ctx context.Context, txn *kv.Txn) error {
-					return s.executeSchedules(ctx, allSchedules, txn)
-				}))
+			require.NoError(t, s.executeSchedules(ctx, allSchedules))
 
 			expectedRunTime = cronMustParse(t, "@hourly").Next(h.env.Now())
 			loaded = h.loadSchedule(t, j.ScheduleID())
@@ -191,10 +185,7 @@ func TestJobSchedulerExecutesAndSchedulesNextRun(t *testing.T) {
 
 	// Execute the job and verify it has the next run scheduled.
 	s := newJobScheduler(h.cfg, h.env, metric.NewRegistry())
-	require.NoError(t,
-		h.cfg.DB.Txn(context.Background(), func(ctx context.Context, txn *kv.Txn) error {
-			return s.executeSchedules(ctx, allSchedules, txn)
-		}))
+	require.NoError(t, s.executeSchedules(ctx, allSchedules))
 
 	expectedRunTime = cronMustParse(t, "@hourly").Next(h.env.Now())
 	loaded = h.loadSchedule(t, j.ScheduleID())
@@ -540,10 +531,8 @@ func TestJobSchedulerToleratesBadSchedules(t *testing.T) {
 	}
 	h.env.SetTime(scheduleRunTime.Add(time.Second))
 	daemon := newJobScheduler(h.cfg, h.env, metric.NewRegistry())
-	require.NoError(t,
-		h.cfg.DB.Txn(context.Background(), func(ctx context.Context, txn *kv.Txn) error {
-			return daemon.executeSchedules(ctx, numJobs, txn)
-		}))
+	require.NoError(t, daemon.executeSchedules(ctx, numJobs))
+
 	require.Equal(t, numJobs, ex.numCalls)
 }
 
@@ -584,10 +573,7 @@ func TestJobSchedulerRetriesFailed(t *testing.T) {
 			require.NoError(t, schedule.Update(ctx, h.cfg.InternalExecutor, nil))
 
 			h.env.SetTime(execTime)
-			require.NoError(t,
-				h.cfg.DB.Txn(context.Background(), func(ctx context.Context, txn *kv.Txn) error {
-					return daemon.executeSchedules(ctx, 1, txn)
-				}))
+			require.NoError(t, daemon.executeSchedules(ctx, 1))
 
 			loaded := h.loadSchedule(t, schedule.ScheduleID())
 			require.EqualValues(t, tc.nextRun, loaded.NextRun())
@@ -735,14 +721,9 @@ INSERT INTO defaultdb.foo VALUES(1, 1)
 	// Execute schedule on another thread.
 	g := ctxgroup.WithContext(context.Background())
 	ready := make(chan struct{})
-	g.Go(func() error {
-		return h.cfg.DB.Txn(context.Background(),
-			func(ctx context.Context, txn *kv.Txn) error {
-				<-ready
-				err := h.execSchedules(ctx, allSchedules, txn)
-				return err
-			},
-		)
+	g.GoCtx(func(ctx context.Context) error {
+		<-ready
+		return h.execSchedules(ctx, allSchedules)
 	})
 
 	require.NoError(t,
@@ -767,8 +748,7 @@ INSERT INTO defaultdb.foo VALUES(1, 1)
 			return nil
 		}))
 
-	err := g.Wait()
-	require.True(t, errors.HasType(err, &savePointError{}))
+	require.NoError(t, g.Wait())
 
 	// Reload schedule -- verify it doesn't have any errors in its status.
 	updated := h.loadSchedule(t, schedule.ScheduleID())

--- a/pkg/jobs/testing_knobs.go
+++ b/pkg/jobs/testing_knobs.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/scheduledjobs"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -36,7 +35,7 @@ type TestingKnobs struct {
 	// daemon logic.
 	// This function will be passed in a function which the caller
 	// may invoke directly, bypassing normal job scheduler daemon logic.
-	TakeOverJobsScheduling func(func(ctx context.Context, maxSchedules int64, txn *kv.Txn) error)
+	TakeOverJobsScheduling func(func(ctx context.Context, maxSchedules int64) error)
 
 	// CaptureJobScheduler is a function which will be passed a fully constructed job scheduler.
 	// The scheduler is passed in as interface{} because jobScheduler is an unexported type.

--- a/pkg/jobs/testutils_test.go
+++ b/pkg/jobs/testutils_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type execSchedulesFn func(ctx context.Context, maxSchedules int64, txn *kv.Txn) error
+type execSchedulesFn func(ctx context.Context, maxSchedules int64) error
 type testHelper struct {
 	env           *jobstest.JobSchedulerTestEnv
 	server        serverutils.TestServerInterface
@@ -70,7 +70,7 @@ func newTestHelperForTables(
 	env := jobstest.NewJobSchedulerTestEnv(envTableType, timeutil.Now())
 	knobs := &TestingKnobs{
 		JobSchedulerEnv: env,
-		TakeOverJobsScheduling: func(daemon func(ctx context.Context, maxSchedules int64, txn *kv.Txn) error) {
+		TakeOverJobsScheduling: func(daemon func(ctx context.Context, maxSchedules int64) error) {
 			execSchedules = daemon
 		},
 	}

--- a/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
@@ -70,7 +70,6 @@ go_test(
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/jobs/jobstest",
-        "//pkg/kv",
         "//pkg/roachpb",
         "//pkg/scheduledjobs",
         "//pkg/security",

--- a/pkg/sql/ttl/ttljob/ttljob_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_test.go
@@ -67,12 +67,10 @@ func newRowLevelTTLTestJobTestHelper(
 
 	knobs := &jobs.TestingKnobs{
 		JobSchedulerEnv: th.env,
-		TakeOverJobsScheduling: func(fn func(ctx context.Context, maxSchedules int64, txn *kv.Txn) error) {
+		TakeOverJobsScheduling: func(fn func(ctx context.Context, maxSchedules int64) error) {
 			th.executeSchedules = func() error {
 				defer th.server.JobRegistry().(*jobs.Registry).TestingNudgeAdoptionQueue()
-				return th.cfg.DB.Txn(context.Background(), func(ctx context.Context, txn *kv.Txn) error {
-					return fn(ctx, 0 /* allSchedules */, txn)
-				})
+				return fn(context.Background(), 0 /* allSchedules */)
 			}
 		},
 


### PR DESCRIPTION
Prior to this change, job scheduler would lookup a set of
schedules to execute, and it would lock each schedule via `FOR UPDATE`
clause.  The query was a complext query that also performed joins
on `system.job` table.  This resulted in a larger read set of rows
being locked, and it made transaction restarts more expensive.

This PR modifies the querying logic so that the scheduler first
obtains a set of potential schedules to execute.  Then, each schedule
executes under its own transaction, where only a single schedule is
locked for update (to guarantee only one scheduler executes this schedule).

Release Notes (enterprise change): Job scheduler is more efficient
and should no longer lock-up jobs and scheduled jobs tables.

Release Justification: Stability improvement for scheduled jobs system.