### PR TITLE
kv: ignore unevaluated Get requests after optimistic evaluation

### DIFF
--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -352,6 +352,9 @@ func (r *Replica) collectSpansRead(
 		}
 
 		switch t := resp.(type) {
+		case *roachpb.GetResponse:
+			// The request did not evaluate. Ignore it.
+			continue
 		case *roachpb.ScanResponse:
 			if header.Key.Equal(t.ResumeSpan.Key) {
 				// The request did not evaluate. Ignore it.


### PR DESCRIPTION
Related to but distinct from #78584.

This commit adds logic to avoid checking for optimistic evaluation conflicts for Get requests which were not evaluated due to a batch-level byte or key limit. This parallels existing logic that does the same for Scan and ReverseScan requests. This was likely missed in the past because we only recently began using Get requests in more places.

The effect of this change is that limited batches of point reads will conflict less with writes, reducing read/write contention. Batches of this form could be issued by a statement that looks like: `SELECT * FROM t WHERE id IN (1, 3, 5) LIMIT 2`.