### PR TITLE
ccl/sqlproxyccl: avoid transferring connections back to the same SQL pod

### DIFF
--- a/pkg/ccl/sqlproxyccl/conn_migration_test.go
+++ b/pkg/ccl/sqlproxyccl/conn_migration_test.go
@@ -256,6 +256,7 @@ func TestTransferConnection(t *testing.T) {
 			func(
 				tCtx context.Context,
 				token string,
+				selectPodFns ...podSelectorFunc,
 			) (net.Conn, error) {
 				require.Equal(t, ctx, tCtx)
 				require.Equal(t, "token", token)
@@ -310,6 +311,7 @@ func TestTransferConnection(t *testing.T) {
 			func(
 				tCtx context.Context,
 				token string,
+				selectPodFns ...podSelectorFunc,
 			) (net.Conn, error) {
 				require.Equal(t, ctx, tCtx)
 				require.Equal(t, "token", token)
@@ -381,6 +383,7 @@ func TestTransferConnection(t *testing.T) {
 			func(
 				tCtx context.Context,
 				token string,
+				selectPodFns ...podSelectorFunc,
 			) (net.Conn, error) {
 				require.Equal(t, ctx, tCtx)
 				require.Equal(t, "token", token)


### PR DESCRIPTION
Previously, there's a possibility where a transfer for a connection would
end up in the same SQL pod. This commit adds a pod selector function to
OpenTenantConnWithToken to allow callers to specify an exclude filter, and
that way, trying to open a connection would fail if there are no available
SQL pods.

Release note: None

Release justification: sqlproxy only change. The connection migration feature
isn't enabled anywhere yet.