### PR TITLE
kvserver: suppress stack trace for rebalance relocation errors

### DIFF
--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -375,7 +375,7 @@ func (sr *StoreRebalancer) rebalanceStore(
 				true, /* transferLeaseToFirstVoter */
 			)
 		}); err != nil {
-			log.Errorf(ctx, "unable to relocate range to %v: %+v", voterTargets, err)
+			log.Errorf(ctx, "unable to relocate range to %v: %v", voterTargets, err)
 			continue
 		}
 		sr.metrics.RangeRebalanceCount.Inc(1)


### PR DESCRIPTION
This patch suppresses the error stack trace for replica relocation
errors during rebalancing. These often show up in logs due to benign
range descriptor races, and look much scarier than they really are:

```
teamcity-4683777-1648272138-41-n6cpu4-geo-0001> E220326 08:55:38.827321 250 kv/kvserver/pkg/kv/kvserver/store_rebalancer.go:378 â‹® [n1,s1,store-rebalancer] 1251 unable to relocate range to [n3,s3 n5,s5 n4,s4 n6,s6 n2,s2]: while carrying out changes [{ADD_VOTER n6,s6} {REMOVE_VOTER n1,s1}]: removing learners from r40:â€¹Ã—â€º [(n1,s1):1LEARNER, (n5,s5):2, (n4,s4):3, (n3,s3):4, (n2,s2):5, (n6,s6):6, next=7, gen=11]: change replicas of r40 failed: descriptor changed: [expected] r40:â€¹Ã—â€º [(n1,s1):1LEARNER, (n5,s5):2, (n4,s4):3, (n3,s3):4, (n2,s2):5, (n6,s6):6, next=7, gen=11] != [actual] r40:â€¹Ã—â€º [(n6,s6):6, (n5,s5):2, (n4,s4):3, (n3,s3):4, (n2,s2):5, next=7, gen=12]
(1)
  | (opaque error wrapper)
  | type name: github.com/cockroachdb/errors/withstack/*withstack.withStack
  | reportable 0:
  |
  | github.com/cockroachdb/cockroach/pkg/kv/kvserver.(*Replica).relocateReplicas
  | 	github.com/cockroachdb/cockroach/pkg/kv/kvserver/pkg/kv/kvserver/replica_command.go:2906
  | github.com/cockroachdb/cockroach/pkg/kv/kvserver.(*Replica).AdminRelocateRange
  | 	github.com/cockroachdb/cockroach/pkg/kv/kvserver/pkg/kv/kvserver/replica_command.go:2807
  | github.com/cockroachdb/cockroach/pkg/kv/kvserver.(*Replica).executeAdminBatch
  | 	github.com/cockroachdb/cockroach/pkg/kv/kvserver/pkg/kv/kvserver/replica_send.go:951
  | github.com/cockroachdb/cockroach/pkg/kv/kvserver.(*Replica).sendWithoutRangeID
  | 	github.com/cockroachdb/cockroach/pkg/kv/kvserver/pkg/kv/kvserver/replica_send.go:177
  | github.com/cockroachdb/cockroach/pkg/kv/kvserver.(*Replica).Send
  | 	github.com/cockroachdb/cockroach/pkg/kv/kvserver/pkg/kv/kvserver/replica_send.go:100
  | github.com/cockroachdb/cockroach/pkg/kv/kvserver.(*Store).Send
```

Release note: None