### PR TITLE
release-21.2: cli,backup,import,sql: add cli flag to allow non-admin node-based access

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -580,6 +580,15 @@ type ExternalIODirConfig struct {
 	// DisableOutbound disables the use of any external-io that dials out such as
 	// to s3, gcs, or even `nodelocal` as it may need to dial another node.
 	DisableOutbound bool
+
+	// EnableNonAdminImplicitAndArbitraryOutbound removes the usual restriction to
+	// only admin users placed on usage of node-granted access, such as to the
+	// implicit auth via the machine account for the node or to arbitrary network
+	// addresses (which are accessed from the node and might otherwise not be
+	// reachable). Instead, all users can use implicit auth, http addresses and
+	// configure custom endpoints. This should only be used if all users with SQL
+	// access should have access to anything the node has access to.
+	EnableNonAdminImplicitAndArbitraryOutbound bool
 }
 
 // TempStorageConfigFromEnv creates a TempStorageConfig.

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -533,8 +533,7 @@ func checkPrivilegesForBackup(
 			}
 		}
 	}
-	knobs := p.ExecCfg().BackupRestoreTestingKnobs
-	if knobs != nil && knobs.AllowImplicitAccess {
+	if p.ExecCfg().ExternalIODirConfig.EnableNonAdminImplicitAndArbitraryOutbound {
 		return nil
 	}
 	// Check that none of the destinations require an admin role.

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1646,8 +1646,7 @@ func checkPrivilegesForRestore(
 				"only users with the CREATEDB privilege can restore databases")
 		}
 	}
-	knobs := p.ExecCfg().BackupRestoreTestingKnobs
-	if knobs != nil && knobs.AllowImplicitAccess {
+	if p.ExecCfg().ExternalIODirConfig.EnableNonAdminImplicitAndArbitraryOutbound {
 		return nil
 	}
 	// Check that none of the sources rely on implicit access.

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -48,6 +48,9 @@ func checkShowBackupURIPrivileges(ctx context.Context, p sql.PlanHookState, uri 
 	if conf.AccessIsWithExplicitAuth() {
 		return nil
 	}
+	if p.ExecCfg().ExternalIODirConfig.EnableNonAdminImplicitAndArbitraryOutbound {
+		return nil
+	}
 	hasAdmin, err := p.HasAdminRole(ctx)
 	if err != nil {
 		return err

--- a/pkg/ccl/backupccl/testdata/backup-restore/backup-permissions
+++ b/pkg/ccl/backupccl/testdata/backup-restore/backup-permissions
@@ -26,6 +26,8 @@ BACKUP TABLE d.t TO 'nodelocal://0/test-nonroot-table';
 ----
 
 # Start a new cluster with the same IO dir.
+# nodelocal IO is a form of implicit access (since it is accessed as the node,
+# so we require the allow-implicit-access flag.
 new-server name=s2 allow-implicit-access
 ----
 
@@ -105,7 +107,12 @@ BACKUP DATABASE d2 TO 'nodelocal://0/d2';
 BACKUP TABLE d2.t TO 'nodelocal://0/d2-table';
 ----
 
-# Test that implicit access is disallowed when the testing knob isn't set.
+exec-sql server=s2 user=testuser
+SHOW BACKUP 'http://COCKROACH_TEST_HTTP_SERVER/'
+----
+pq: http storage file does not exist: error response from server: 404 Not Found "404 page not found\n": external_storage: file doesn't exist
+
+# Test that implicit access is disallowed when the testing knob is not set.
 new-server name=s3 share-io-dir=s1
 ----
 
@@ -118,7 +125,25 @@ NOTICE: GRANT SELECT ON DATABASE is deprecated.
 This statement was automatically converted to USE d; ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO testuser;
 Please use ALTER DEFAULT PRIVILEGES going forward
 
+exec-sql server=s3 user=testuser
+SHOW BACKUP 'http://COCKROACH_TEST_HTTP_SERVER/'
+----
+pq: only users with the admin role are allowed to SHOW BACKUP from the specified http URI
+
 exec-sql user=testuser
 BACKUP DATABASE d TO 'nodelocal://0/test3'
 ----
 pq: user testuser does not have CONNECT privilege on database d
+
+# Test that http access is disallowed by disable http even if allow-non-admin is on.
+new-server name=s4 allow-implicit-access disable-http
+----
+
+exec-sql server=s4
+CREATE USER testuser
+----
+
+exec-sql server=s4 user=testuser
+SHOW BACKUP 'http://COCKROACH_TEST_HTTP_SERVER/'
+----
+pq: make storage: external http access disabled

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -410,21 +410,23 @@ func importPlanHook(
 
 		// Certain ExternalStorage URIs require super-user access. Check all the
 		// URIs passed to the IMPORT command.
-		for _, file := range filenamePatterns {
-			conf, err := cloud.ExternalStorageConfFromURI(file, p.User())
-			if err != nil {
-				// If it is a workload URI, it won't parse as a storage config, but it
-				// also doesn't have any auth concerns so just continue.
-				if _, workloadErr := parseWorkloadConfig(file); workloadErr == nil {
-					continue
-				}
-				return err
-			}
-			if !conf.AccessIsWithExplicitAuth() {
-				err := p.RequireAdminRole(ctx,
-					fmt.Sprintf("IMPORT from the specified %s URI", conf.Provider.String()))
+		if !p.ExecCfg().ExternalIODirConfig.EnableNonAdminImplicitAndArbitraryOutbound {
+			for _, file := range filenamePatterns {
+				conf, err := cloud.ExternalStorageConfFromURI(file, p.User())
 				if err != nil {
+					// If it is a workload URI, it won't parse as a storage config, but it
+					// also doesn't have any auth concerns so just continue.
+					if _, workloadErr := parseWorkloadConfig(file); workloadErr == nil {
+						continue
+					}
 					return err
+				}
+				if !conf.AccessIsWithExplicitAuth() {
+					err := p.RequireAdminRole(ctx,
+						fmt.Sprintf("IMPORT from the specified %s URI", conf.Provider.String()))
+					if err != nil {
+						return err
+					}
 				}
 			}
 		}

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -683,6 +683,13 @@ Instead, require the user to always specify access keys.`,
 		Description: `
 Disable use of "external" IO, such as to S3, GCS, or the file system (nodelocal), or anything other than userfile.`,
 	}
+	ExternalIOEnableNonAdminImplicitAndArbitraryOutbound = FlagInfo{
+		Name: "external-io-enable-non-admin-implicit-access",
+		Description: `
+Allow non-admin users to specify arbitrary network addressses (e.g. https:// URIs or custom endpoints in s3:// URIs) and 
+implicit credentials (machine account/role providers) when running operations like IMPORT/EXPORT/BACKUP/etc. 
+Note: that --external-io-disable-http or --external-io-disable-implicit-credentials still apply, this only removes the admin-user requirement.`,
+	}
 
 	// KeySize, CertificateLifetime, AllowKeyReuse, and OverwriteFiles are used for
 	// certificate generation functions.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -486,6 +486,7 @@ func init() {
 		boolFlag(f, &serverCfg.ExternalIODirConfig.DisableHTTP, cliflags.ExternalIODisableHTTP)
 		boolFlag(f, &serverCfg.ExternalIODirConfig.DisableOutbound, cliflags.ExternalIODisabled)
 		boolFlag(f, &serverCfg.ExternalIODirConfig.DisableImplicitCredentials, cliflags.ExternalIODisableImplicitCredentials)
+		boolFlag(f, &serverCfg.ExternalIODirConfig.EnableNonAdminImplicitAndArbitraryOutbound, cliflags.ExternalIOEnableNonAdminImplicitAndArbitraryOutbound)
 
 		// Certificate principal map.
 		stringSliceFlag(f, &startCtx.serverCertPrincipalMap, cliflags.CertPrincipalMap)

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1358,10 +1358,6 @@ func (*TenantTestingKnobs) ModuleTestingKnobs() {}
 
 // BackupRestoreTestingKnobs contains knobs for backup and restore behavior.
 type BackupRestoreTestingKnobs struct {
-	// AllowImplicitAccess allows implicit access to data sources for non-admin
-	// users. This enables using nodelocal for testing BACKUP/RESTORE permissions.
-	AllowImplicitAccess bool
-
 	// CaptureResolvedTableDescSpans allows for intercepting the spans which are
 	// resolved during backup planning, and will eventually be backed up during
 	// execution.

--- a/pkg/sql/export.go
+++ b/pkg/sql/export.go
@@ -135,7 +135,7 @@ func (ef *execFactory) ConstructExport(
 	if err != nil {
 		panic(err)
 	}
-	if !admin {
+	if !admin && !ef.planner.ExecCfg().ExternalIODirConfig.EnableNonAdminImplicitAndArbitraryOutbound {
 		conf, err := cloud.ExternalStorageConfFromURI(string(*destination), ef.planner.User())
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Backport 1/1 commits from #71594.

/cc @cockroachdb/release

---

Typically when running statements like BACKUP, IMPORT, or EXPORT, we
only allow an admin user to direct that operation to interact with some
remote resource that might be reachable only by virtue of being accessed
by the node running the operation.

Specifically, access to s3 or google cloud storage using 'implicit'
auth, which uses the respective SDK methods to use the running machine's
role or machine account, is typically only available to admin users, as
is the ability to specify arbitrary network URIs using http:// or the
custom-endpoint parameters to the other storage providers. This is
because in these cases, the fact that the node is accessing that s3
bucket or network URI may allow a degree of access the user might not
otherwise have, and thus we restrict this to highly trusted admin users.

This change introduces a flag,
--external-io-enable-non-admin-implicit-access, that removes this
restriction, allowing any SQL user who can invoke IMPORT, BACKUP or
EXPORT commands to point those operations at URIs that would otherwise
be restricted to admin-only users as described above. This may be
desirable in an environment where network access is already controlled,
for example at the container level, or where all users, not just admin
users, are trusted enough to have the node make network requests on
their behalf.

Release note (security update): add a new flag --external-io-enable-non-admin-implicit-access
that can remove the admin-only restriction on interacting with arbitrary network endpoint and
using 'implicit' auth in operations such as BACKUP, IMPORT or EXPORT.

Release justification: Fixes backwards compatibility problem with 21.1