### PR TITLE
sqlsmith: skip crdb_internal.complete_replication_stream

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -497,6 +497,7 @@ var functions = func() map[tree.FunctionClass]map[oid.Oid][]function {
 			"crdb_internal.reset_index_usage_stats",
 			"crdb_internal.start_replication_stream",
 			"crdb_internal.replication_stream_progress",
+			"crdb_internal.complete_replication_stream",
 		} {
 			skip = skip || strings.Contains(def.Name, substr)
 		}


### PR DESCRIPTION
Don't use crdb_internal.complete_replication_stream when generating
sqlsmith queries, since it currently causes a panic.

Informs #78553

Release note: None