### PR TITLE
kvserver: check L0 sub-levels on allocation

### DIFF
--- a/pkg/kv/kvserver/allocator_scorer.go
+++ b/pkg/kv/kvserver/allocator_scorer.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/constraint"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -70,6 +71,50 @@ const (
 	// consider a store full/empty if it's at least minRebalanceThreshold
 	// away from the mean.
 	minRangeRebalanceThreshold = 2
+
+	// maxL0SublevelThreshold is the number of L0 sub-levels of a store
+	// descriptor, that when greater than this value and in excees of the
+	// average L0 sub-levels in the cluster - will have the action defined by
+	// l0SublevelsThresholdEnforce taken. This value does not affect the
+	// allocator in deciding to remove replicas from it's store, only
+	// potentially block adding or moving replicas to other stores.
+	maxL0SublevelThreshold = 20
+
+	// l0SublevelInterval is the period over which to accumulate statistics on
+	// the number of L0 sublevels within a store.
+	l0SublevelInterval = time.Minute * 5
+
+	// l0SublevelMaxSampled is maximum number of L0 sub-levels that may exist
+	// in a sample. This setting limits the extreme skew that could occur by
+	// capping the highest possible value considered.
+	l0SublevelMaxSampled = 500
+
+	// l0SubLevelWaterMark is the percentage above the mean after which a store
+	// could be conisdered unhealthy if also exceeding the threshold.
+	l0SubLevelWaterMark = 1.10
+)
+
+// storeHealthEnforcement represents the level of action that may be taken or
+// excluded when a candidate disk is considered unhealthy.
+type storeHealthEnforcement int64
+
+const (
+	// storeHealthNoAction will take no action upon candidate stores when they
+	// exceed l0SublevelThreshold.
+	storeHealthNoAction storeHealthEnforcement = iota
+	// storeHealthLogOnly will take no action upon candidate stores when they
+	// exceed l0SublevelThreshold except log an event.
+	storeHealthLogOnly
+	// storeHealthBlockRebalanceTo will take action to exclude candidate stores
+	// when they exceed l0SublevelThreshold and mean from being considered
+	// targets for rebalance actions only. Allocation actions such as adding
+	// upreplicaing an range will not be affected.
+	storeHealthBlockRebalanceTo
+	// storeHealthBlockAll will take action to exclude candidate stores when
+	// they exceed l0SublevelThreshold and mean from being candidates for all
+	// replica allocation and rebalancing. When enabled and stores exceed the
+	// threshold, they will not receive any new replicas.
+	storeHealthBlockAll
 )
 
 // rangeRebalanceThreshold is the minimum ratio of a store's range count to
@@ -86,6 +131,55 @@ var rangeRebalanceThreshold = func() *settings.FloatSetting {
 	s.SetVisibility(settings.Public)
 	return s
 }()
+
+// l0SublevelsThreshold is the maximum number of sub-levels within level 0 that
+// may exist on candidate store descriptors before they are considered
+// unhealthy. Once considered unhealthy, the action taken will be dictated by
+// l0SublevelsThresholdEnforce cluster setting defined below. The rationale for
+// using L0 sub-levels as opposed to read amplification is that it is more
+// generally the variable component that makes up read amplification. When
+// L0 sub-levels is high, it is an indicator of poor LSM health as L0 is usually
+// in memory and must be first visited before traversing any further level. See
+// this issue for additional information:
+// https://github.com/cockroachdb/pebble/issues/609
+var l0SublevelsThreshold = settings.RegisterIntSetting(
+	settings.SystemOnly,
+	"kv.allocator.l0_sublevels_threshold",
+	"the maximum number of l0 sublevels within a store that may exist "+
+		"before the action defined in "+
+		"`kv.allocator.l0_sublevels_threshold_enforce` will be taken "+
+		"if also exceeding the cluster average",
+	maxL0SublevelThreshold,
+)
+
+// l0SublevelsThresholdEnforce is the level of enforcement taken upon candidate
+// stores when their L0-sublevels exceeds the threshold defined in
+// l0SublevelThreshold. Under disabled and log enforcement, no action is taken
+// to exclude the candidate store either as a potential allocation nor
+// rebalance target by the replicate queue and store rebalancer. When the
+// enforcement level is rebalance, candidate stores will be excluded as targets
+// for rebalancing when exceeding the threshold, however will remain candidates
+// for allocation of voters and non-voters.  When allocate is set, candidates
+// are excluded as targets for all rebalancing and also allocation of voters
+// and non-voters.
+var l0SublevelsThresholdEnforce = settings.RegisterEnumSetting(
+	settings.SystemOnly,
+	"kv.allocator.l0_sublevels_threshold_enforce",
+	"the level of enforcement when a candidate disk has L0 sub-levels "+
+		"exceeding `kv.allocator.l0_sublevels_threshold` and above the "+
+		"cluster average:`block_none` will exclude "+
+		"no candidate stores, `block_none_log` will exclude no candidates but log an "+
+		"event, `block_rebalance_to` will exclude candidates stores from being "+
+		"targets of rebalance actions, `block_all` will exclude candidate stores "+
+		"from being targets of both allocation and rebalancing",
+	"block_none_log",
+	map[int64]string{
+		int64(storeHealthNoAction):         "block_none",
+		int64(storeHealthLogOnly):          "block_none_log",
+		int64(storeHealthBlockRebalanceTo): "block_rebalance_to",
+		int64(storeHealthBlockAll):         "block_all",
+	},
+)
 
 // CockroachDB has two heuristics that trigger replica rebalancing: range count
 // convergence and QPS convergence. scorerOptions defines the interface that
@@ -140,6 +234,9 @@ type scorerOptions interface {
 	// with the same QPS) that would converge the range's existing stores' QPS the
 	// most.
 	removalMaximallyConvergesScore(removalCandStoreList StoreList, existing roachpb.StoreDescriptor) int
+	// getStoreHealthOptions returns the scorer options for store health. It is
+	// used to inform scoring based on the health of a store.
+	getStoreHealthOptions() storeHealthOptions
 }
 
 func jittered(val float64, jitter float64, rand allocatorRand) float64 {
@@ -181,6 +278,7 @@ func (o *scatterScorerOptions) maybeJitterStoreStats(
 // This means that the resulting rebalancing decisions will further the goal of
 // converging range counts across stores in the cluster.
 type rangeCountScorerOptions struct {
+	storeHealthOptions
 	deterministic           bool
 	rangeRebalanceThreshold float64
 }
@@ -295,6 +393,7 @@ func (o *rangeCountScorerOptions) removalMaximallyConvergesScore(
 // queries-per-second. This means that the resulting rebalancing decisions will
 // further the goal of converging QPS across stores in the cluster.
 type qpsScorerOptions struct {
+	storeHealthOptions
 	deterministic                             bool
 	qpsRebalanceThreshold, minRequiredQPSDiff float64
 
@@ -443,13 +542,15 @@ func (o *qpsScorerOptions) removalMaximallyConvergesScore(
 	return 0
 }
 
-// candidate store for allocation.
+// candidate store for allocation. These are ordered by importance.
 type candidate struct {
 	store          roachpb.StoreDescriptor
 	valid          bool
 	fullDisk       bool
 	necessary      bool
 	diversityScore float64
+	highReadAmp    bool
+	l0SubLevels    int
 	convergesScore int
 	balanceScore   balanceStatus
 	rangeCount     int
@@ -457,9 +558,9 @@ type candidate struct {
 }
 
 func (c candidate) String() string {
-	str := fmt.Sprintf("s%d, valid:%t, fulldisk:%t, necessary:%t, diversity:%.2f, converges:%d, "+
+	str := fmt.Sprintf("s%d, valid:%t, fulldisk:%t, necessary:%t, diversity:%.2f, highReadAmp: %t, l0SubLevels: %d, converges:%d, "+
 		"balance:%d, rangeCount:%d, queriesPerSecond:%.2f",
-		c.store.StoreID, c.valid, c.fullDisk, c.necessary, c.diversityScore, c.convergesScore,
+		c.store.StoreID, c.valid, c.fullDisk, c.necessary, c.diversityScore, c.highReadAmp, c.l0SubLevels, c.convergesScore,
 		c.balanceScore, c.rangeCount, c.store.Capacity.QueriesPerSecond)
 	if c.details != "" {
 		return fmt.Sprintf("%s, details:(%s)", str, c.details)
@@ -482,6 +583,12 @@ func (c candidate) compactString() string {
 	if c.diversityScore != 0 {
 		fmt.Fprintf(&buf, ", diversity:%.2f", c.diversityScore)
 	}
+	if c.highReadAmp {
+		fmt.Fprintf(&buf, ", highReadAmp:%t", c.highReadAmp)
+	}
+	if c.l0SubLevels > 0 {
+		fmt.Fprintf(&buf, ", l0SubLevels:%d", c.l0SubLevels)
+	}
 	fmt.Fprintf(&buf, ", converges:%d, balance:%d, rangeCount:%d",
 		c.convergesScore, c.balanceScore, c.rangeCount)
 	if c.details != "" {
@@ -502,29 +609,43 @@ func (c candidate) less(o candidate) bool {
 // candidate is.
 func (c candidate) compare(o candidate) float64 {
 	if !o.valid {
-		return 6
+		return 60
 	}
 	if !c.valid {
-		return -6
+		return -60
 	}
 	if o.fullDisk {
-		return 5
+		return 50
 	}
 	if c.fullDisk {
-		return -5
+		return -50
 	}
 	if c.necessary != o.necessary {
 		if c.necessary {
-			return 4
+			return 40
 		}
-		return -4
+		return -40
 	}
 	if !scoresAlmostEqual(c.diversityScore, o.diversityScore) {
 		if c.diversityScore > o.diversityScore {
-			return 3
+			return 30
 		}
-		return -3
+		return -30
 	}
+	// If both o and c have high read amplification, then we prefer the
+	// canidate with lower read amp.
+	if o.highReadAmp && c.highReadAmp {
+		if o.l0SubLevels > c.l0SubLevels {
+			return 25
+		}
+	}
+	if c.highReadAmp {
+		return -25
+	}
+	if o.highReadAmp {
+		return 25
+	}
+
 	if c.convergesScore != o.convergesScore {
 		if c.convergesScore > o.convergesScore {
 			return 2 + float64(c.convergesScore-o.convergesScore)/10.0
@@ -587,6 +708,7 @@ func (c byScoreAndID) Less(i, j int) bool {
 		c[i].rangeCount == c[j].rangeCount &&
 		c[i].necessary == c[j].necessary &&
 		c[i].fullDisk == c[j].fullDisk &&
+		c[i].highReadAmp == c[j].highReadAmp &&
 		c[i].valid == c[j].valid {
 		return c[i].store.StoreID < c[j].store.StoreID
 	}
@@ -594,11 +716,12 @@ func (c byScoreAndID) Less(i, j int) bool {
 }
 func (c byScoreAndID) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
 
-// onlyValidAndNotFull returns all the elements in a sorted (by score reversed)
-// candidate list that are valid and not nearly full.
-func (cl candidateList) onlyValidAndNotFull() candidateList {
+// onlyValidAndHealthyDisk returns all the elements in a sorted (by score
+// reversed) candidate list that are valid and not nearly full or with high
+// read amplification.
+func (cl candidateList) onlyValidAndHealthyDisk() candidateList {
 	for i := len(cl) - 1; i >= 0; i-- {
-		if cl[i].valid && !cl[i].fullDisk {
+		if cl[i].valid && !cl[i].fullDisk && !cl[i].highReadAmp {
 			return cl[:i+1]
 		}
 	}
@@ -608,7 +731,7 @@ func (cl candidateList) onlyValidAndNotFull() candidateList {
 // best returns all the elements in a sorted (by score reversed) candidate list
 // that share the highest constraint score and are valid.
 func (cl candidateList) best() candidateList {
-	cl = cl.onlyValidAndNotFull()
+	cl = cl.onlyValidAndHealthyDisk()
 	if len(cl) <= 1 {
 		return cl
 	}
@@ -646,6 +769,14 @@ func (cl candidateList) worst() candidateList {
 	if cl[len(cl)-1].fullDisk {
 		for i := len(cl) - 2; i >= 0; i-- {
 			if !cl[i].fullDisk {
+				return cl[i+1:]
+			}
+		}
+	}
+	// Are there candidates with high read amplification? If so, pick those.
+	if cl[len(cl)-1].highReadAmp {
+		for i := len(cl) - 2; i >= 0; i-- {
+			if !cl[i].highReadAmp {
 				return cl[i+1:]
 			}
 		}
@@ -774,7 +905,11 @@ func rankedCandidateListForAllocation(
 			continue
 		}
 
-		if !maxCapacityCheck(s) {
+		if !maxCapacityCheck(s) || !options.storeHealthOptions.readAmpIsHealthy(
+			ctx,
+			s,
+			candidateStores.candidateL0Sublevels.mean,
+		) {
 			continue
 		}
 		diversityScore := diversityAllocateScore(s, existingStoreLocalities)
@@ -808,6 +943,7 @@ func rankedCandidateListForAllocation(
 //
 // Stores that are marked as not valid, are in violation of a required criteria.
 func candidateListForRemoval(
+	ctx context.Context,
 	existingReplsStoreList StoreList,
 	constraintsCheck constraintsCheckFn,
 	existingStoreLocalities map[roachpb.StoreID]roachpb.Locality,
@@ -827,10 +963,15 @@ func candidateListForRemoval(
 		}
 		diversityScore := diversityRemovalScore(s.StoreID, existingStoreLocalities)
 		candidates = append(candidates, candidate{
-			store:          s,
-			valid:          constraintsOK,
-			necessary:      necessary,
-			fullDisk:       !maxCapacityCheck(s),
+			store:     s,
+			valid:     constraintsOK,
+			necessary: necessary,
+			fullDisk:  !maxCapacityCheck(s),
+			// When removing a replica from a store, we do not want to include
+			// high amplification in ranking stores. This would submit already
+			// high read amplification stores to additional load of moving a
+			// replica.
+			highReadAmp:    false,
 			diversityScore: diversityScore,
 		})
 	}
@@ -980,10 +1121,11 @@ const (
 // decision would minimize the QPS range between the existing store and the
 // coldest store in the equivalence class.
 func bestStoreToMinimizeQPSDelta(
-	replQPS, rebalanceThreshold, minRequiredQPSDiff float64,
+	replQPS float64,
 	existing roachpb.StoreID,
 	candidates []roachpb.StoreID,
 	storeDescMap map[roachpb.StoreID]*roachpb.StoreDescriptor,
+	options *qpsScorerOptions,
 ) (bestCandidate roachpb.StoreID, reason declineReason) {
 	storeQPSMap := make(map[roachpb.StoreID]float64, len(candidates)+1)
 	for _, store := range candidates {
@@ -1027,7 +1169,7 @@ func bestStoreToMinimizeQPSDelta(
 	// `bestCandidate` (not accounting for the replica under consideration) is
 	// higher than `minQPSDifferenceForTransfers`.
 	diffIgnoringRepl := existingQPSIgnoringRepl - bestCandQPS
-	if diffIgnoringRepl < minRequiredQPSDiff {
+	if diffIgnoringRepl < options.minRequiredQPSDiff {
 		return 0, deltaNotSignificant
 	}
 
@@ -1035,7 +1177,7 @@ func bestStoreToMinimizeQPSDelta(
 	// the equivalence class.
 	mean := domainStoreList.candidateQueriesPerSecond.mean
 	overfullThreshold := overfullQPSThreshold(
-		&qpsScorerOptions{qpsRebalanceThreshold: rebalanceThreshold},
+		options,
 		mean,
 	)
 	if existingQPS < overfullThreshold {
@@ -1093,11 +1235,10 @@ func (o *qpsScorerOptions) getRebalanceTargetToMinimizeDelta(
 	}
 	return bestStoreToMinimizeQPSDelta(
 		o.qpsPerReplica,
-		o.qpsRebalanceThreshold,
-		o.minRequiredQPSDiff,
 		eqClass.existing.StoreID,
 		candidates,
 		storeListToMap(domainStoreList),
+		o,
 	)
 }
 
@@ -1127,6 +1268,7 @@ func rankedCandidateListForRebalancing(
 			}
 			valid, necessary := removalConstraintsChecker(store)
 			fullDisk := !maxCapacityCheck(store)
+
 			if !valid {
 				if !needRebalanceFrom {
 					log.VEventf(ctx, 2, "s%d: should-rebalance(invalid): locality:%q",
@@ -1142,10 +1284,15 @@ func rankedCandidateListForRebalancing(
 				needRebalanceFrom = true
 			}
 			existingStores[store.StoreID] = candidate{
-				store:          store,
-				valid:          valid,
-				necessary:      necessary,
-				fullDisk:       fullDisk,
+				store:     store,
+				valid:     valid,
+				necessary: necessary,
+				fullDisk:  fullDisk,
+				// When rebalancing a replica away from a store, we do not want
+				// to include high amplification in ranking stores. This would
+				// submit already high read amplification stores to additional
+				// load of moving a replica.
+				highReadAmp:    false,
 				diversityScore: curDiversityScore,
 			}
 		}
@@ -1215,15 +1362,19 @@ func rankedCandidateListForRebalancing(
 				continue
 			}
 
+			// NB: We construct equivalence classes based on locality hierarchies,
+			// the diversityScore must be the only thing that's populated at
+			// this stage, in additon to hard checks and validation.
+			// TODO(kvoli,ayushshah15): Refactor this to make it harder to
+			// inadvertently break the invariant above,
 			constraintsOK, necessary := rebalanceConstraintsChecker(store, existing.store)
-			maxCapacityOK := maxCapacityCheck(store)
 			diversityScore := diversityRebalanceFromScore(
 				store, existing.store.StoreID, existingStoreLocalities)
 			cand := candidate{
 				store:          store,
 				valid:          constraintsOK,
 				necessary:      necessary,
-				fullDisk:       !maxCapacityOK,
+				fullDisk:       !maxCapacityCheck(store),
 				diversityScore: diversityScore,
 			}
 			if !cand.less(existing) {
@@ -1322,6 +1473,14 @@ func rankedCandidateListForRebalancing(
 			// rebalance candidates.
 			s := cand.store
 			cand.fullDisk = !rebalanceToMaxCapacityCheck(s)
+			cand.l0SubLevels = int(s.Capacity.L0Sublevels)
+			cand.highReadAmp = !options.getStoreHealthOptions().rebalanceToReadAmpIsHealthy(
+				ctx,
+				s,
+				// We only wish to compare the read amplification to the
+				// comparable stores average and not the cluster.
+				comparable.candidateSL.candidateL0Sublevels.mean,
+			)
 			cand.balanceScore = options.balanceScore(comparable.candidateSL, s.Capacity)
 			cand.convergesScore = options.rebalanceToConvergesScore(comparable, s)
 			cand.rangeCount = int(s.Capacity.RangeCount)
@@ -1854,6 +2013,73 @@ func rebalanceConvergesRangeCountOnMean(
 
 func convergesOnMean(oldVal, newVal, mean float64) bool {
 	return math.Abs(newVal-mean) < math.Abs(oldVal-mean)
+}
+
+type storeHealthOptions struct {
+	enforcementLevel    storeHealthEnforcement
+	l0SublevelThreshold int64
+}
+
+func (o storeHealthOptions) getStoreHealthOptions() storeHealthOptions {
+	return o
+}
+
+// readAmpIsHealthy returns true if the store read amplification does not exceed
+// the cluster threshold and mean, or the enforcement level does not include
+// excluding candidates from being allocation targets.
+func (o storeHealthOptions) readAmpIsHealthy(
+	ctx context.Context, store roachpb.StoreDescriptor, avg float64,
+) bool {
+	if o.enforcementLevel == storeHealthNoAction ||
+		store.Capacity.L0Sublevels < o.l0SublevelThreshold {
+		return true
+	}
+
+	// Still log an event when the L0 sub-levels exceeds the threshold, however
+	// does not exceed the cluster average. This is enabled to avoid confusion
+	// where candidate stores are still targets, despite exeeding the
+	// threshold.
+	if float64(store.Capacity.L0Sublevels) < avg*l0SubLevelWaterMark {
+		log.Eventf(ctx, "s%d, allocate check l0 sublevels %d exceeds threshold %d, but below average: %f, action enabled %d",
+			store.StoreID, store.Capacity.L0Sublevels,
+			o.l0SublevelThreshold, avg, o.enforcementLevel)
+		return true
+	}
+
+	log.Eventf(ctx, "s%d, allocate check l0 sublevels %d exceeds threshold %d, above average: %f, action enabled %d",
+		store.StoreID, store.Capacity.L0Sublevels,
+		o.l0SublevelThreshold, avg, o.enforcementLevel)
+
+	// The store is only considered unhealthy when the enforcement level is
+	// storeHealthBlockAll.
+	return o.enforcementLevel < storeHealthBlockAll
+}
+
+// rebalanceToReadAmpIsHealthy returns true if the store read amplification does
+// not exceed the cluster threshold and mean, or the enforcement level does not
+// include excluding candidates from being rebalancing targets.
+func (o storeHealthOptions) rebalanceToReadAmpIsHealthy(
+	ctx context.Context, store roachpb.StoreDescriptor, avg float64,
+) bool {
+	if o.enforcementLevel == storeHealthNoAction ||
+		store.Capacity.L0Sublevels < o.l0SublevelThreshold {
+		return true
+	}
+
+	if float64(store.Capacity.L0Sublevels) < avg*l0SubLevelWaterMark {
+		log.Eventf(ctx, "s%d, allocate check l0 sublevels %d exceeds threshold %d, but below average watermark: %f, action enabled %d",
+			store.StoreID, store.Capacity.L0Sublevels,
+			o.l0SublevelThreshold, avg*l0SubLevelWaterMark, o.enforcementLevel)
+		return true
+	}
+
+	log.Eventf(ctx, "s%d, allocate check l0 sublevels %d exceeds threshold %d, above average watermark: %f, action enabled %d",
+		store.StoreID, store.Capacity.L0Sublevels,
+		o.l0SublevelThreshold, avg*l0SubLevelWaterMark, o.enforcementLevel)
+
+	// The store is only considered unhealthy when the enforcement level is
+	// storeHealthBlockRebalanceTo or storeHealthBlockAll.
+	return o.enforcementLevel < storeHealthBlockRebalanceTo
 }
 
 // maxCapacityCheck returns true if the store has room for a new replica.

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -2990,7 +2990,7 @@ func (r *Replica) relocateOne(
 			conf,
 			existingVoters,
 			existingNonVoters,
-			r.store.allocator.scorerOptions(),
+			r.store.allocator.scorerOptions(ctx),
 			// NB: Allow the allocator to return target stores that might be on the
 			// same node as an existing replica. This is to ensure that relocations
 			// that require "lateral" movement of replicas within a node can succeed.
@@ -3060,7 +3060,7 @@ func (r *Replica) relocateOne(
 			existingVoters,
 			existingNonVoters,
 			args.targetType,
-			r.store.allocator.scorerOptions(),
+			r.store.allocator.scorerOptions(ctx),
 		)
 		if err != nil {
 			return nil, nil, errors.Wrapf(

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -431,7 +431,7 @@ func (rq *replicateQueue) shouldQueue(
 			nonVoterReplicas,
 			rangeUsageInfo,
 			storeFilterThrottled,
-			rq.allocator.scorerOptions(),
+			rq.allocator.scorerOptions(ctx),
 		)
 		if ok {
 			log.VEventf(ctx, 2, "rebalance target found for voter, enqueuing")
@@ -445,7 +445,7 @@ func (rq *replicateQueue) shouldQueue(
 			nonVoterReplicas,
 			rangeUsageInfo,
 			storeFilterThrottled,
-			rq.allocator.scorerOptions(),
+			rq.allocator.scorerOptions(ctx),
 		)
 		if ok {
 			log.VEventf(ctx, 2, "rebalance target found for non-voter, enqueuing")
@@ -1004,7 +1004,7 @@ func (rq *replicateQueue) findRemoveVoter(
 		candidates,
 		existingVoters,
 		existingNonVoters,
-		rq.allocator.scorerOptions(),
+		rq.allocator.scorerOptions(ctx),
 	)
 }
 
@@ -1119,7 +1119,7 @@ func (rq *replicateQueue) removeNonVoter(
 		existingNonVoters,
 		existingVoters,
 		existingNonVoters,
-		rq.allocator.scorerOptions(),
+		rq.allocator.scorerOptions(ctx),
 	)
 	if err != nil {
 		return false, err
@@ -1301,9 +1301,9 @@ func (rq *replicateQueue) considerRebalance(
 	desc, conf := repl.DescAndSpanConfig()
 	rebalanceTargetType := voterTarget
 
-	scorerOpts := scorerOptions(rq.allocator.scorerOptions())
+	scorerOpts := scorerOptions(rq.allocator.scorerOptions(ctx))
 	if scatter {
-		scorerOpts = rq.allocator.scorerOptionsForScatter()
+		scorerOpts = rq.allocator.scorerOptionsForScatter(ctx)
 	}
 	if !rq.store.TestingKnobs().DisableReplicaRebalancing {
 		rangeUsageInfo := rangeUsageInfoForRepl(repl)

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2966,7 +2966,11 @@ func (s *Store) Capacity(ctx context.Context, useCached bool) (roachpb.StoreCapa
 	capacity.LogicalBytes = logicalBytes
 	capacity.QueriesPerSecond = totalQueriesPerSecond
 	capacity.WritesPerSecond = totalWritesPerSecond
-	capacity.L0Sublevels = s.metrics.RdbL0Sublevels.Value()
+	// We gossip the maximum number of L0 sub-levels that have been seen in
+	// past 2 windows. The recording length may vary between 5 and 10 minutes
+	// accordingly.
+	windowedL0Sublevels, _ := s.metrics.L0SubLevelsHistogram.Windowed()
+	capacity.L0Sublevels = windowedL0Sublevels.Max()
 	capacity.BytesPerReplica = roachpb.PercentilesFromData(bytesPerReplica)
 	capacity.WritesPerReplica = roachpb.PercentilesFromData(writesPerReplica)
 	s.recordNewPerSecondStats(totalQueriesPerSecond, totalWritesPerSecond)

--- a/pkg/kv/kvserver/store_pool.go
+++ b/pkg/kv/kvserver/store_pool.go
@@ -765,6 +765,10 @@ type StoreList struct {
 	// candidateWritesPerSecond tracks writes-per-second stats for stores that are
 	// eligible to be rebalance targets.
 	candidateWritesPerSecond stat
+
+	// candidateWritesPerSecond tracks L0 sub-level stats for stores that are
+	// eligible to be rebalance targets.
+	candidateL0Sublevels stat
 }
 
 // Generates a new store list based on the passed in descriptors. It will
@@ -779,6 +783,7 @@ func makeStoreList(descriptors []roachpb.StoreDescriptor) StoreList {
 		sl.candidateLogicalBytes.update(float64(desc.Capacity.LogicalBytes))
 		sl.candidateQueriesPerSecond.update(desc.Capacity.QueriesPerSecond)
 		sl.candidateWritesPerSecond.update(desc.Capacity.WritesPerSecond)
+		sl.candidateL0Sublevels.update(float64(desc.Capacity.L0Sublevels))
 	}
 	return sl
 }

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -249,8 +249,9 @@ func (sr *StoreRebalancer) Start(ctx context.Context, stopper *stop.Stopper) {
 // `scorerOptions` here, which sets the range count rebalance threshold.
 // Instead, we use our own implementation of `scorerOptions` that promotes QPS
 // balance.
-func (sr *StoreRebalancer) scorerOptions() *qpsScorerOptions {
+func (sr *StoreRebalancer) scorerOptions(ctx context.Context) *qpsScorerOptions {
 	return &qpsScorerOptions{
+		storeHealthOptions:    sr.rq.allocator.storeHealthOptions(ctx),
 		deterministic:         sr.rq.allocator.storePool.deterministic,
 		qpsRebalanceThreshold: qpsRebalanceThreshold.Get(&sr.st.SV),
 		minRequiredQPSDiff:    minQPSDifferenceForTransfers.Get(&sr.st.SV),
@@ -270,7 +271,7 @@ func (sr *StoreRebalancer) scorerOptions() *qpsScorerOptions {
 func (sr *StoreRebalancer) rebalanceStore(
 	ctx context.Context, mode LBRebalancingMode, allStoresList StoreList,
 ) {
-	options := sr.scorerOptions()
+	options := sr.scorerOptions(ctx)
 	var localDesc *roachpb.StoreDescriptor
 	for i := range allStoresList.stores {
 		if allStoresList.stores[i].StoreID == sr.rq.store.StoreID() {
@@ -360,7 +361,7 @@ func (sr *StoreRebalancer) rebalanceStore(
 			&replicasToMaybeRebalance,
 			localDesc,
 			allStoresList,
-			sr.scorerOptions(),
+			sr.scorerOptions(ctx),
 		)
 		if replWithStats.repl == nil {
 			log.Infof(ctx,

--- a/pkg/kv/kvserver/store_rebalancer_test.go
+++ b/pkg/kv/kvserver/store_rebalancer_test.go
@@ -53,6 +53,7 @@ var (
 			},
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 3000,
+				L0Sublevels:      maxL0SublevelThreshold - 10,
 			},
 		},
 		{
@@ -70,6 +71,7 @@ var (
 			},
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 2800,
+				L0Sublevels:      maxL0SublevelThreshold - 5,
 			},
 		},
 		{
@@ -87,6 +89,7 @@ var (
 			},
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 2600,
+				L0Sublevels:      maxL0SublevelThreshold + 2,
 			},
 		},
 		{
@@ -104,6 +107,7 @@ var (
 			},
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 2400,
+				L0Sublevels:      maxL0SublevelThreshold - 10,
 			},
 		},
 		{
@@ -121,6 +125,7 @@ var (
 			},
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 2200,
+				L0Sublevels:      maxL0SublevelThreshold - 3,
 			},
 		},
 		{
@@ -138,6 +143,7 @@ var (
 			},
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 2000,
+				L0Sublevels:      maxL0SublevelThreshold + 2,
 			},
 		},
 		{
@@ -155,6 +161,7 @@ var (
 			},
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 1800,
+				L0Sublevels:      maxL0SublevelThreshold - 10,
 			},
 		},
 		{
@@ -172,6 +179,7 @@ var (
 			},
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 1600,
+				L0Sublevels:      maxL0SublevelThreshold - 5,
 			},
 		},
 		{
@@ -189,6 +197,7 @@ var (
 			},
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 1400,
+				L0Sublevels:      maxL0SublevelThreshold + 3,
 			},
 		},
 	}
@@ -230,6 +239,188 @@ var (
 			Node:    roachpb.NodeDescriptor{NodeID: 5},
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 500,
+			},
+		},
+	}
+
+	// noLocalityAscendingReadAmpStores specifies a set of stores identical to
+	// noLocalityStores, however they have ascending read
+	// amplification. Where store 1, store 2 and store 3 are below the
+	// threshold, whilst store 4 and store 5 are above.
+	noLocalityAscendingReadAmpStores = []*roachpb.StoreDescriptor{
+		{
+			StoreID: 1,
+			Node:    roachpb.NodeDescriptor{NodeID: 1},
+			Capacity: roachpb.StoreCapacity{
+				QueriesPerSecond: 1500,
+				L0Sublevels:      maxL0SublevelThreshold - 15,
+			},
+		},
+		{
+			StoreID: 2,
+			Node:    roachpb.NodeDescriptor{NodeID: 2},
+			Capacity: roachpb.StoreCapacity{
+				QueriesPerSecond: 1300,
+				L0Sublevels:      maxL0SublevelThreshold - 10,
+			},
+		},
+		{
+			StoreID: 3,
+			Node:    roachpb.NodeDescriptor{NodeID: 3},
+			Capacity: roachpb.StoreCapacity{
+				QueriesPerSecond: 1000,
+				L0Sublevels:      maxL0SublevelThreshold - 5,
+			},
+		},
+		{
+			StoreID: 4,
+			Node:    roachpb.NodeDescriptor{NodeID: 4},
+			Capacity: roachpb.StoreCapacity{
+				QueriesPerSecond: 900,
+				L0Sublevels:      maxL0SublevelThreshold + 20,
+			},
+		},
+		{
+			StoreID: 5,
+			Node:    roachpb.NodeDescriptor{NodeID: 5},
+			Capacity: roachpb.StoreCapacity{
+				QueriesPerSecond: 500,
+				L0Sublevels:      maxL0SublevelThreshold + 25,
+			},
+		},
+	}
+
+	// noLocalityUniformQPSHighReadAmp specifies a set of stores that are
+	// identical, except store 1 and 2 have high read amp.
+	noLocalityUniformQPSHighReadAmp = []*roachpb.StoreDescriptor{
+		{
+			StoreID: 1,
+			Node:    roachpb.NodeDescriptor{NodeID: 1},
+			Capacity: roachpb.StoreCapacity{
+				QueriesPerSecond: 1000,
+				L0Sublevels:      maxL0SublevelThreshold + 100,
+			},
+		},
+		{
+			StoreID: 2,
+			Node:    roachpb.NodeDescriptor{NodeID: 2},
+			Capacity: roachpb.StoreCapacity{
+				QueriesPerSecond: 1000,
+				L0Sublevels:      maxL0SublevelThreshold - 15,
+			},
+		},
+		{
+			StoreID: 3,
+			Node:    roachpb.NodeDescriptor{NodeID: 3},
+			Capacity: roachpb.StoreCapacity{
+				QueriesPerSecond: 1000,
+				L0Sublevels:      maxL0SublevelThreshold + 100,
+			},
+		},
+		{
+			StoreID: 4,
+			Node:    roachpb.NodeDescriptor{NodeID: 4},
+			Capacity: roachpb.StoreCapacity{
+				QueriesPerSecond: 1000,
+				L0Sublevels:      maxL0SublevelThreshold - 15,
+			},
+		},
+		{
+			StoreID: 5,
+			Node:    roachpb.NodeDescriptor{NodeID: 5},
+			Capacity: roachpb.StoreCapacity{
+				QueriesPerSecond: 1000,
+				L0Sublevels:      maxL0SublevelThreshold + 100,
+			},
+		},
+	}
+	// noLocalityHighReadAmpStores specifies a set of stores identical to
+	// noLocalityStores, however they all have read amplification that exceeds
+	// the threshold.
+	noLocalityHighReadAmpStores = []*roachpb.StoreDescriptor{
+		{
+			StoreID: 1,
+			Node:    roachpb.NodeDescriptor{NodeID: 1},
+			Capacity: roachpb.StoreCapacity{
+				QueriesPerSecond: 1500,
+				L0Sublevels:      maxL0SublevelThreshold + 1,
+			},
+		},
+		{
+			StoreID: 2,
+			Node:    roachpb.NodeDescriptor{NodeID: 2},
+			Capacity: roachpb.StoreCapacity{
+				QueriesPerSecond: 1300,
+				L0Sublevels:      maxL0SublevelThreshold + 1,
+			},
+		},
+		{
+			StoreID: 3,
+			Node:    roachpb.NodeDescriptor{NodeID: 3},
+			Capacity: roachpb.StoreCapacity{
+				QueriesPerSecond: 1000,
+				L0Sublevels:      maxL0SublevelThreshold + 1,
+			},
+		},
+		{
+			StoreID: 4,
+			Node:    roachpb.NodeDescriptor{NodeID: 4},
+			Capacity: roachpb.StoreCapacity{
+				QueriesPerSecond: 900,
+				L0Sublevels:      maxL0SublevelThreshold + 1,
+			},
+		},
+		{
+			StoreID: 5,
+			Node:    roachpb.NodeDescriptor{NodeID: 5},
+			Capacity: roachpb.StoreCapacity{
+				QueriesPerSecond: 500,
+				L0Sublevels:      maxL0SublevelThreshold + 1,
+			},
+		},
+	}
+	// noLocalityHighReadAmpSkewedStores specifies a set of stores identical to
+	// noLocalityStores, however they all have read amplification that exceeds
+	// the threshold in ascending order.
+	noLocalityHighReadAmpSkewedStores = []*roachpb.StoreDescriptor{
+		{
+			StoreID: 1,
+			Node:    roachpb.NodeDescriptor{NodeID: 1},
+			Capacity: roachpb.StoreCapacity{
+				QueriesPerSecond: 1500,
+				L0Sublevels:      maxL0SublevelThreshold + 1,
+			},
+		},
+		{
+			StoreID: 2,
+			Node:    roachpb.NodeDescriptor{NodeID: 2},
+			Capacity: roachpb.StoreCapacity{
+				QueriesPerSecond: 1300,
+				L0Sublevels:      maxL0SublevelThreshold + 10,
+			},
+		},
+		{
+			StoreID: 3,
+			Node:    roachpb.NodeDescriptor{NodeID: 3},
+			Capacity: roachpb.StoreCapacity{
+				QueriesPerSecond: 1000,
+				L0Sublevels:      maxL0SublevelThreshold + 50,
+			},
+		},
+		{
+			StoreID: 4,
+			Node:    roachpb.NodeDescriptor{NodeID: 4},
+			Capacity: roachpb.StoreCapacity{
+				QueriesPerSecond: 900,
+				L0Sublevels:      maxL0SublevelThreshold + 100,
+			},
+		},
+		{
+			StoreID: 5,
+			Node:    roachpb.NodeDescriptor{NodeID: 5},
+			Capacity: roachpb.StoreCapacity{
+				QueriesPerSecond: 500,
+				L0Sublevels:      maxL0SublevelThreshold + 100,
 			},
 		},
 	}
@@ -632,6 +823,7 @@ func TestChooseRangeToRebalanceRandom(t *testing.T) {
 				&localDesc,
 				storeList,
 				&qpsScorerOptions{
+					storeHealthOptions:    storeHealthOptions{enforcementLevel: storeHealthNoAction},
 					deterministic:         false,
 					qpsRebalanceThreshold: qpsRebalanceThreshold,
 				},
@@ -725,21 +917,24 @@ func TestChooseRangeToRebalanceAcrossHeterogeneousZones(t *testing.T) {
 		expRebalancedVoters, expRebalancedNonVoters []roachpb.StoreID
 	}{
 		// All the replicas are already on the best possible stores. No
-		// rebalancing should be attempted.
+		// rebalancing should be attempted, note here that the high read
+		// amp of the current stores is ignored as it is not considered in
+		// moving a replica away from a store.
 		{
 			name:                "no rebalance",
 			voters:              []roachpb.StoreID{3, 6, 9},
 			constraints:         oneReplicaPerRegion,
 			expRebalancedVoters: []roachpb.StoreID{},
 		},
-		// A replica is in a heavily loaded region, on a relatively heavily loaded
-		// store. We expect it to be moved to a less busy store within the same
-		// region.
+		// A replica is in a heavily loaded region, on a relatively heavily
+		// loaded store. We expect it to be moved to a less busy store
+		// within the same region. However, it cannot be the least busy
+		// store as it has high read amp (3).
 		{
 			name:                "rebalance one replica within heavy region",
 			voters:              []roachpb.StoreID{1, 6, 9},
 			constraints:         oneReplicaPerRegion,
-			expRebalancedVoters: []roachpb.StoreID{9, 6, 3},
+			expRebalancedVoters: []roachpb.StoreID{9, 6, 2},
 		},
 		// Two replicas are in the hot region, both on relatively heavily loaded
 		// nodes. We expect one of those replicas to be moved to a less busy store
@@ -761,22 +956,26 @@ func TestChooseRangeToRebalanceAcrossHeterogeneousZones(t *testing.T) {
 		// maximized, replicas on hot stores are rebalanced to cooler stores within
 		// the same region.
 		{
-			// Within the hottest region, expect rebalance from the hottest node (n1)
-			// to the coolest node (n3). Within the lease hot region, we don't expect
-			// a rebalance from n8 to n9 because the qps difference between the two
+			// Within the hottest region, expect rebalance from the hottest
+			// node (n1) to the coolest node (n3), however since n3 has
+			// high read amp it should instead rebalance to n2. Within the
+			// lease hot region, we don't expect a rebalance from n8 to n9
+			// because the qps difference between the two
 			// stores is too small.
 			name:                "QPS balance without constraints",
 			voters:              []roachpb.StoreID{1, 5, 8},
-			expRebalancedVoters: []roachpb.StoreID{8, 5, 3},
+			expRebalancedVoters: []roachpb.StoreID{8, 5, 2},
 		},
 		{
-			// Within the second hottest region, expect rebalance from the hottest
-			// node (n4) to the coolest node (n6). Within the lease hot region, we
-			// don't expect a rebalance from n8 to n9 because the qps difference
-			// between the two stores is too small.
+			// Within the second hottest region, expect rebalance from the
+			// hottest node (n4) to the coolest node (n6), however since n6
+			// has high read amp instead expect n5 to be selected. Within
+			// the lease hot region, we don't expect a rebalance from n8 to
+			// n9 because the qps difference between the two stores is too
+			// small.
 			name:                "QPS balance without constraints",
 			voters:              []roachpb.StoreID{8, 4, 3},
-			expRebalancedVoters: []roachpb.StoreID{8, 6, 3},
+			expRebalancedVoters: []roachpb.StoreID{8, 5, 3},
 		},
 
 		// Multi-region database configurations.
@@ -790,9 +989,10 @@ func TestChooseRangeToRebalanceAcrossHeterogeneousZones(t *testing.T) {
 			constraints:      oneReplicaPerRegion,
 
 			expRebalancedVoters: []roachpb.StoreID{3, 2, 1},
-			// NB: Expect the non-voter on node 4 (hottest node in region B) to move
-			// to node 6 (least hot region in region B).
-			expRebalancedNonVoters: []roachpb.StoreID{6, 9},
+			// NB: Expect the non-voter on node 4 (hottest node in region B) to
+			// move to node 5 (least hot region in region B), the least hot
+			// node without high read amp.
+			expRebalancedNonVoters: []roachpb.StoreID{5, 9},
 		},
 		{
 			name:   "primary region with second highest QPS, region survival, one voter on sub-optimal node",
@@ -812,19 +1012,22 @@ func TestChooseRangeToRebalanceAcrossHeterogeneousZones(t *testing.T) {
 			// constraints require at least one replica per each region.
 			voterConstraints: twoReplicasInHotRegion,
 			constraints:      oneReplicaPerRegion,
-			// NB: We've got 3 voters in the hottest region, but we only need 2. We
-			// expect that one of the voters from the hottest region will be moved to
-			// the least hot region. Additionally, in region B, we've got one replica
-			// on store 4 (which is the hottest store in that region). We expect that
-			// replica to be moved to store 6.
-			expRebalancedVoters: []roachpb.StoreID{9, 2, 6, 8, 3},
+			// NB: We've got 3 voters in the hottest region, but we only need
+			// 2. We expect that one of the voters from the hottest region
+			// will be moved to the least hot region. Additionally, in
+			// region B, we've got one replica on store 4 (which is the
+			// hottest store in that region). We expect that replica to be
+			// moved to store 5, which is the least hot node without high
+			// read amp.
+			expRebalancedVoters: []roachpb.StoreID{9, 2, 5, 8, 3},
 		},
 		{
 			name:        "one voter on sub-optimal node in the coldest region",
 			voters:      []roachpb.StoreID{5, 6, 7},
 			constraints: append(twoReplicasInSecondHottestRegion, oneReplicaInColdestRegion...),
-			// NB: Expect replica from node 7 to move to node 9.
-			expRebalancedVoters: []roachpb.StoreID{9, 5, 6},
+			// NB: Expect replica from node 7 to move to node 8, despite node 9
+			// having lower qps because node 9 exceeds the l0 sub-level threshold,
+			expRebalancedVoters: []roachpb.StoreID{8, 5, 6},
 		},
 	}
 	for _, tc := range testCases {
@@ -883,7 +1086,11 @@ func TestChooseRangeToRebalanceAcrossHeterogeneousZones(t *testing.T) {
 				&hottestRanges,
 				&localDesc,
 				storeList,
-				&qpsScorerOptions{deterministic: true, qpsRebalanceThreshold: 0.05},
+				&qpsScorerOptions{
+					storeHealthOptions:    storeHealthOptions{enforcementLevel: storeHealthBlockRebalanceTo},
+					deterministic:         true,
+					qpsRebalanceThreshold: 0.05,
+				},
 			)
 
 			require.Len(t, voterTargets, len(tc.expRebalancedVoters))
@@ -955,7 +1162,10 @@ func TestChooseRangeToRebalanceIgnoresRangeOnBestStores(t *testing.T) {
 	loadRanges(rr, s, []testRange{{voters: []roachpb.StoreID{localDesc.StoreID}, qps: 100}})
 	hottestRanges := rr.topQPS()
 	sr.chooseRangeToRebalance(
-		ctx, &hottestRanges, &localDesc, storeList, &qpsScorerOptions{qpsRebalanceThreshold: 0.05},
+		ctx, &hottestRanges, &localDesc, storeList, &qpsScorerOptions{
+			storeHealthOptions:    storeHealthOptions{enforcementLevel: storeHealthNoAction},
+			qpsRebalanceThreshold: 0.05,
+		},
 	)
 	trace := finishAndGetRecording()
 	require.Regexpf(
@@ -1117,7 +1327,11 @@ func TestChooseRangeToRebalanceOffHotNodes(t *testing.T) {
 				&hottestRanges,
 				&localDesc,
 				storeList,
-				&qpsScorerOptions{deterministic: true, qpsRebalanceThreshold: tc.rebalanceThreshold},
+				&qpsScorerOptions{
+					storeHealthOptions:    storeHealthOptions{enforcementLevel: storeHealthNoAction},
+					deterministic:         true,
+					qpsRebalanceThreshold: tc.rebalanceThreshold,
+				},
 			)
 			require.Len(t, voterTargets, len(tc.expRebalancedVoters))
 
@@ -1210,7 +1424,11 @@ func TestNoLeaseTransferToBehindReplicas(t *testing.T) {
 		&hottestRanges,
 		&localDesc,
 		storeList,
-		&qpsScorerOptions{deterministic: true, qpsRebalanceThreshold: 0.05},
+		&qpsScorerOptions{
+			storeHealthOptions:    storeHealthOptions{enforcementLevel: storeHealthNoAction},
+			deterministic:         true,
+			qpsRebalanceThreshold: 0.05,
+		},
 	)
 	expectTargets := []roachpb.ReplicationTarget{
 		{NodeID: 4, StoreID: 4}, {NodeID: 3, StoreID: 3}, {NodeID: 5, StoreID: 5},
@@ -1218,5 +1436,169 @@ func TestNoLeaseTransferToBehindReplicas(t *testing.T) {
 	if !reflect.DeepEqual(targets, expectTargets) {
 		t.Errorf("got targets %v for range with RaftStatus %v; want %v",
 			targets, sr.getRaftStatusFn(repl), expectTargets)
+	}
+}
+
+// TestStoreRebalancerReadAmpCheck checks that:
+//  - Under (1) disabled and (2) log that rebalancing decisions are unaffected
+//    by high read amplification.
+//  - Under (3) rebalanceOnly and (4) allocate that rebalance decisions exclude
+//    stores with high readamplification as candidate targets.
+func TestStoreRebalancerReadAmpCheck(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	type testCase struct {
+		name            string
+		stores          []*roachpb.StoreDescriptor
+		conf            roachpb.SpanConfig
+		expectedTargets []roachpb.ReplicationTarget
+		enforcement     storeHealthEnforcement
+	}
+	tests := []testCase{
+		{
+			name: "ignore read amp on allocation when storeHealthNoAction enforcement",
+			// NB: All stores have high read amp, this should be ignored.
+			stores: noLocalityHighReadAmpStores,
+			conf:   emptySpanConfig(),
+			expectedTargets: []roachpb.ReplicationTarget{
+				{NodeID: 4, StoreID: 4}, {NodeID: 3, StoreID: 3}, {NodeID: 5, StoreID: 5},
+			},
+			enforcement: storeHealthNoAction,
+		},
+		{
+			name: "ignore read amp on allocation when storeHealthLogOnly enforcement",
+			// NB: All stores have high read amp, this should be ignored.
+			stores: noLocalityHighReadAmpStores,
+			conf:   emptySpanConfig(),
+			expectedTargets: []roachpb.ReplicationTarget{
+				{NodeID: 4, StoreID: 4}, {NodeID: 3, StoreID: 3}, {NodeID: 5, StoreID: 5},
+			},
+			enforcement: storeHealthLogOnly,
+		},
+		{
+			name: "don't stop rebalancing when read amp uniformly above threshold and storeHealthBlockRebalanceTo enforcement",
+			// NB: All stores have high uniformly high read  (threshold+1) this should be ignored.
+			stores: noLocalityHighReadAmpStores,
+			conf:   emptySpanConfig(),
+			expectedTargets: []roachpb.ReplicationTarget{
+				{NodeID: 4, StoreID: 4}, {NodeID: 3, StoreID: 3}, {NodeID: 5, StoreID: 5},
+			},
+			enforcement: storeHealthBlockRebalanceTo,
+		},
+		{
+			name: "don't stop rebalancing when read amp uniformly above threshold and storeHealthBlockRebalanceTo enforcement",
+			// NB: All stores have high uniformly high read  (threshold+1) this should be ignored.
+			stores: noLocalityHighReadAmpStores,
+			conf:   emptySpanConfig(),
+			expectedTargets: []roachpb.ReplicationTarget{
+				{NodeID: 4, StoreID: 4}, {NodeID: 3, StoreID: 3}, {NodeID: 5, StoreID: 5},
+			},
+			enforcement: storeHealthBlockAll,
+		},
+		{
+			name: "rebalance should ignore stores with high read amp that are also above the mean when storeHealthBlockAll enforcement",
+			// NB: All stores have high read amp, however store 2 is below the mean read amp so is a viable candidate.
+			stores: noLocalityHighReadAmpSkewedStores,
+			conf:   emptySpanConfig(),
+			expectedTargets: []roachpb.ReplicationTarget{
+				{NodeID: 2, StoreID: 2}, {NodeID: 3, StoreID: 3}, {NodeID: 5, StoreID: 5},
+			},
+			enforcement: storeHealthBlockAll,
+		},
+		{
+			name: "rebalance should ignore stores with high read amp that are also above the mean when storeHealthBlockRebalanceTo enforcement",
+			// NB: All stores have high read amp, however store 2 is below the mean read amp so is a viable candidate.
+			stores: noLocalityHighReadAmpSkewedStores,
+			conf:   emptySpanConfig(),
+			expectedTargets: []roachpb.ReplicationTarget{
+				{NodeID: 2, StoreID: 2}, {NodeID: 3, StoreID: 3}, {NodeID: 5, StoreID: 5},
+			},
+			enforcement: storeHealthBlockRebalanceTo,
+		},
+		{
+			name: "rebalance should ignore stores with high read amp when storeHealthBlockRebalanceTo enforcement",
+			// NB: Store 4, 5 have high read amp, they should not be rebalance
+			// targets. Only 1,2,3 are valid targets, yet only 2 is not already
+			// a voter. 1 should transfer it's lease to 2. 5 could also have
+			// transferred its lease to 2, However, high read amp does not
+			// affect removing replicas from stores, only in blocking new
+			// replicas.
+			stores: noLocalityAscendingReadAmpStores,
+			conf:   emptySpanConfig(),
+			expectedTargets: []roachpb.ReplicationTarget{
+				{NodeID: 2, StoreID: 2}, {NodeID: 3, StoreID: 3}, {NodeID: 5, StoreID: 5},
+			},
+			enforcement: storeHealthBlockRebalanceTo,
+		},
+		{
+			name: "rebalance should ignore stores with high read amp when storeHealthBlockAll enforcement",
+			// NB: This scenario and result should be identical to storeHealthBlockRebalanceTo.
+			stores: noLocalityAscendingReadAmpStores,
+			conf:   emptySpanConfig(),
+			expectedTargets: []roachpb.ReplicationTarget{
+				{NodeID: 2, StoreID: 2}, {NodeID: 3, StoreID: 3}, {NodeID: 5, StoreID: 5},
+			},
+			enforcement: storeHealthBlockAll,
+		},
+		{
+			name: "rebalance should not rebalance away from stores with high read amp when storeHealthBlockAll enforcement",
+			// NB: Node 1,3,5 all have extremely high read amp. However, since
+			// read amp does not trigger rebalancing away, only blocking
+			// rebalancing to this should be ignored and no action taken.
+			stores:          noLocalityUniformQPSHighReadAmp,
+			conf:            emptySpanConfig(),
+			expectedTargets: nil,
+			enforcement:     storeHealthBlockAll,
+		},
+		{
+			name: "rebalance should not rebalance away from stores with high read amp when storeHealthBlockRebalanceTo enforcement",
+			// NB: Node 1,3,5 all have extremely high read amp. However, since
+			// read amp does not trigger rebalancing away, only blocking
+			// rebalancing to this should be ignored and no action taken.
+			stores:          noLocalityUniformQPSHighReadAmp,
+			conf:            emptySpanConfig(),
+			expectedTargets: nil,
+			enforcement:     storeHealthBlockRebalanceTo,
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d_%s", i+1, test.name), func(t *testing.T) {
+			stopper, g, _, a, _ := createTestAllocator(ctx, 10, false /* deterministic */)
+			defer stopper.Stop(ctx)
+			storeList, _, _ := a.storePool.getStoreList(storeFilterThrottled)
+
+			localDesc := *noLocalityStores[0]
+			cfg := TestStoreConfig(nil)
+			cfg.Gossip = g
+			cfg.StorePool = a.storePool
+			s := createTestStoreWithoutStart(ctx, t, stopper, testStoreOpts{createSystemRanges: true}, &cfg)
+			gossiputil.NewStoreGossiper(cfg.Gossip).GossipStores(test.stores, t)
+			s.Ident = &roachpb.StoreIdent{StoreID: localDesc.StoreID}
+			rq := newReplicateQueue(s, a)
+			rr := newReplicaRankings()
+
+			sr := NewStoreRebalancer(cfg.AmbientCtx, cfg.Settings, rq, rr)
+
+			// Load in a range with replicas on an overfull node, a slightly underfull
+			// node, and a very underfull node.
+			loadRanges(rr, s, []testRange{{voters: []roachpb.StoreID{1, 3, 5}, qps: 100}})
+			hottestRanges := rr.topQPS()
+
+			_, targetVoters, _ := sr.chooseRangeToRebalance(
+				ctx,
+				&hottestRanges,
+				&localDesc,
+				storeList,
+				&qpsScorerOptions{
+					storeHealthOptions:    storeHealthOptions{enforcementLevel: test.enforcement, l0SublevelThreshold: maxL0SublevelThreshold},
+					deterministic:         true,
+					qpsRebalanceThreshold: 0.05,
+				},
+			)
+			require.Equal(t, test.expectedTargets, targetVoters)
+		})
 	}
 }

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -651,6 +651,17 @@ var charts = []sectionDescription{
 	{
 		Organization: [][]string{
 			{DistributionLayer, "Rebalancing"},
+		},
+		Charts: []chartDescription{
+			{
+				Title:   "L0 sub-level rebalancing",
+				Metrics: []string{"rebalancing.l0_sublevels_histogram"},
+			},
+		},
+	},
+	{
+		Organization: [][]string{
+			{DistributionLayer, "Rebalancing"},
 			{ReplicationLayer, "Leases"},
 		},
 		Charts: []chartDescription{

--- a/pkg/ts/catalog/metrics.go
+++ b/pkg/ts/catalog/metrics.go
@@ -91,6 +91,7 @@ var histogramMetricsNames = map[string]struct{}{
 	"txnwaitqueue.query.wait_time":              {},
 	"raft.process.applycommitted.latency":       {},
 	"sql.stats.txn_stats_collection.duration":   {},
+	"rebalancing.l0_sublevels_histogram":        {},
 }
 
 func allInternalTSMetricsNames() []string {


### PR DESCRIPTION
Previously, the only store health signal used as a hard allocation and
rebalancing constraint was disk capacity. This patch introduces L0
sub-levels as an additional constraint, to avoid allocation and
rebalancing to replicas to stores which are unhealthy, indicated by a
high number of L0 sub-levlels.

A store's sub-level count  must exceed both the (1) threshold and (2)
cluster mean watermark (10% above mean) in order to be considered
unhealthy. The average check ensures that a cluster full of  moderately
high read amplification stores is not unable to make progress, whilst
still ensuring that positively skewed distributions exclude the positive
tail.

Simulation of the effect on candidate exclusion under different L0
sub-level distributions by using the mean as an additional check vs
percentiles can be found here:
https://gist.github.com/kvoli/be27efd4662e89e8918430a9c7117858

The L0 sub-level value for each store descriptor is smoothed to be the
maximum over a 5 minute window:

![image](https://user-images.githubusercontent.com/39606633/161317965-7a7f1b2a-a625-49cb-8b03-5eed386ef07f.png)


The threshold corresponds to the cluster setting
`kv.allocator.L0_sublevels_threshold`, which is the number of L0
sub-levels, that when a candidate store exceeds it will be potentially
excluded as a target for rebalancing, or both rebalancing and allocation
of replicas.

The enforcement of this threshold can be applied under 4 different
levels of strictness. This is configured by the cluster setting:
`kv.allocator.L0_sublevels_threshold_enforce`.

The 4 levels are:

`block_none`: L0 sub-levels is ignored entirely.
`block_none_log`: L0 sub-levels are logged if threshold exceeded.

Both states below log as above.

`block_rebalance_to`: L0 sub-levels are considered when excluding stores
for rebalance targets.
`block_all`: L0 sub-levels are considered when excluding stores for
rebalance targets and allocation targets.

By default, `kv.allocator.L0_sublevels_threshold` is `20`. Which
corresponds to admissions control's threshold, above which it begins
limiting admission of work to a store based on store health. The default
enforcement level of `kv.allocator.L0_sublevels_threshold_enforce` is
`block_none_log`.

resolves https://github.com/cockroachdb/cockroach/issues/73714

Release justification: low risk, high benefit during high read
amplification scenarios where an operator may limit rebalancing to high
read amplification stores, to stop fueling the flame.

Release note (ops change): introduce cluster settings
`kv.allocator.l0_sublevels_threshold` and
`kv.allocator.L0_sublevels_threshold_enforce`, which enable excluding
stores as targets for allocation and rebalancing of replicas when they
have high read amplification, indicated by the number of L0 sub-levels
in level 0 of the store's LSM. When both
`kv.allocator.l0_sublevels_threshold` and the cluster average is
exceeded, the action corresponding to
`kv.allocator.l0_sublevels_threshold_enforce` is taken. `block_none`
will exclude no candidate stores, `block_none_log` will exclude no
candidates but log an event, `block_rebalance_to` will exclude
candidates stores from being targets of rebalance actions, `block_all`
will exclude candidate stores from being targets of both allocation and
rebalancing. Default `kv.allocator.l0_sublevels_threshold` is set to
`20` and `kv.allocator.l0_sublevels_threshold_enforce` is set to
`block_none_log`.