### PR TITLE
opt: disable index recommendations with PARTITION ALL BY

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -2809,3 +2809,56 @@ SELECT * FROM [EXPLAIN SELECT * FROM regional_by_row_table_as1 LIMIT 3] OFFSET 2
           table: regional_by_row_table_as1@regional_by_row_table_as1_pkey
           spans: [/'ca-central-1' - /'us-east-1']
           limit: 3
+
+subtest index_recommendations
+
+# Enable vectorize so we get consistent EXPLAIN output. We cannot use the
+# OFFSET 2 strategy for these tests because that disables the index
+# recommendation (index recommendations are only used when EXPLAIN is the
+# root of the query tree).
+statement ok
+SET index_recommendations_enabled = true;
+SET vectorize=on
+
+statement ok
+CREATE TABLE users (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name STRING NOT NULL,
+  email STRING NOT NULL UNIQUE,
+  INDEX (name)
+) LOCALITY REGIONAL BY ROW
+
+# Check that we don't recommend indexes that already exist.
+query T
+EXPLAIN INSERT INTO users (name, email)
+VALUES ('Craig Roacher', 'craig@cockroachlabs.com')
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • insert
+│   │ into: users(id, name, email, crdb_region)
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             size: 5 columns, 1 row
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • lookup join (semi)
+            │ table: users@users_email_key
+            │ lookup condition: (column2 = email) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+            │ pred: (id_default != id) OR (crdb_region_default != crdb_region)
+            │
+            └── • scan buffer
+                  label: buffer 1
+
+statement ok
+SET index_recommendations_enabled = false;
+RESET vectorize

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -136,6 +136,10 @@ type Table interface {
 
 	// Zone returns a table's zone.
 	Zone() Zone
+
+	// IsPartitionAllBy returns true if this is a PARTITION ALL BY table. This
+	// includes REGIONAL BY ROW tables.
+	IsPartitionAllBy() bool
 }
 
 // CheckConstraint contains the SQL text and the validity status for a check

--- a/pkg/sql/opt/indexrec/index_candidate_set.go
+++ b/pkg/sql/opt/indexrec/index_candidate_set.go
@@ -373,7 +373,14 @@ func addIndexToCandidates(
 		return
 	}
 
+	// Do not add indexes to PARTITION ALL BY tables.
+	// TODO(rytaft): Support these tables by adding implicit partitioning columns.
+	if currTable.IsPartitionAllBy() {
+		return
+	}
+
 	// Do not add indexes on spatial columns.
+	// TODO(rytaft): Support spatial predicates like st_contains() etc.
 	for _, indexCol := range newIndex {
 		colFamily := indexCol.Column.DatumType().Family()
 		if colFamily == types.GeometryFamily || colFamily == types.GeographyFamily {

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -755,6 +755,11 @@ func (tt *Table) Zone() cat.Zone {
 	return cat.AsZone(&zone)
 }
 
+// IsPartitionAllBy is part of the cat.Table interface.
+func (tt *Table) IsPartitionAllBy() bool {
+	return false
+}
+
 // FindOrdinal returns the ordinal of the column with the given name.
 func (tt *Table) FindOrdinal(name string) int {
 	for i, col := range tt.Columns {

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -1158,6 +1158,11 @@ func (ot *optTable) Zone() cat.Zone {
 	return ot.zone
 }
 
+// IsPartitionAllBy is part of the cat.Table interface.
+func (ot *optTable) IsPartitionAllBy() bool {
+	return ot.desc.IsPartitionAllBy()
+}
+
 // lookupColumnOrdinal returns the ordinal of the column with the given ID. A
 // cache makes the lookup O(1).
 func (ot *optTable) lookupColumnOrdinal(colID descpb.ColumnID) (int, error) {
@@ -2071,6 +2076,11 @@ func (ot *optVirtualTable) Unique(i cat.UniqueOrdinal) cat.UniqueConstraint {
 // Zone is part of the cat.Table interface.
 func (ot *optVirtualTable) Zone() cat.Zone {
 	panic(errors.AssertionFailedf("no zone"))
+}
+
+// IsPartitionAllBy is part of the cat.Table interface.
+func (ot *optVirtualTable) IsPartitionAllBy() bool {
+	return false
 }
 
 // CollectTypes is part of the cat.DataSource interface.


### PR DESCRIPTION
This commit disables index recommendations for tables with
`PARTITION ALL BY` (including `REGIONAL BY ROW` tables) because the
current recommendations are not valid. This is a backportable
fix, but a future PR will fix these recommendations and reenable
them.

Release note (sql change): Disabled index recommendations in `EXPLAIN`
output for `REGIONAL BY ROW` tables, as the previous recommendations were
not valid.