### PR TITLE
roachtest: wait for 3x replication in disk-full

### DIFF
--- a/pkg/cmd/roachtest/tests/disk_full.go
+++ b/pkg/cmd/roachtest/tests/disk_full.go
@@ -41,12 +41,12 @@ func registerDiskFull(r registry.Registry) {
 
 			// Node 1 will soon be killed, when the ballast file fills up its disk. To
 			// ensure that the ranges containing system tables are available on other
-			// nodes, we wait here for at least two replicas of each range. Without
-			// this, it's possible that we end up deadlocked on a system query that
-			// requires a range on node 1, but node 1 will not restart until the query
+			// nodes, we wait here for 3x replication of each range. Without this,
+			// it's possible that we end up deadlocked on a system query that requires
+			// a range on node 1, but node 1 will not restart until the query
 			// completes.
 			db := c.Conn(ctx, t.L(), 1)
-			err := WaitForReplication(ctx, t, db, 2)
+			err := WaitFor3XReplication(ctx, t, db)
 			require.NoError(t, err)
 			_ = db.Close()
 


### PR DESCRIPTION
Improve on #78456 by waiting fro 3x replication, rather than 2x.

Release note: None.