### PR TITLE
ccl/sqlproxyccl: add connection tracker component

### DIFF
--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -101,6 +101,7 @@ go_test(
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_cockroach_go_v2//crdb",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_jackc_pgconn//:pgconn",
         "@com_github_jackc_pgproto3_v2//:pgproto3",
         "@com_github_jackc_pgx_v4//:pgx",

--- a/pkg/ccl/sqlproxyccl/balancer/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/balancer/BUILD.bazel
@@ -4,15 +4,20 @@ go_library(
     name = "balancer",
     srcs = [
         "balancer.go",
+        "conn.go",
+        "conn_tracker.go",
         "pod.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/balancer",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ccl/sqlproxyccl/tenant",
+        "//pkg/roachpb",
+        "//pkg/util/log",
         "//pkg/util/randutil",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_logtags//:logtags",
     ],
 )
 
@@ -20,11 +25,13 @@ go_test(
     name = "balancer_test",
     srcs = [
         "balancer_test.go",
+        "conn_tracker_test.go",
         "pod_test.go",
     ],
     embed = [":balancer"],
     deps = [
         "//pkg/ccl/sqlproxyccl/tenant",
+        "//pkg/roachpb",
         "//pkg/util/leaktest",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/ccl/sqlproxyccl/balancer/balancer.go
+++ b/pkg/ccl/sqlproxyccl/balancer/balancer.go
@@ -36,6 +36,8 @@ type Balancer struct {
 
 // NewBalancer constructs a new Balancer instance that is responsible for
 // load balancing SQL connections within the proxy.
+//
+// TODO(jaylim-crl): Update Balancer to take in a ConnTracker object.
 func NewBalancer() *Balancer {
 	b := &Balancer{}
 	b.mu.rng, _ = randutil.NewPseudoRand()

--- a/pkg/ccl/sqlproxyccl/balancer/conn.go
+++ b/pkg/ccl/sqlproxyccl/balancer/conn.go
@@ -1,0 +1,32 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package balancer
+
+import "context"
+
+// ConnectionHandle corresponds to the connection's handle, which will always
+// be instances of the forwarder.
+type ConnectionHandle interface {
+	// Context returns the context object associated with the handle.
+	Context() context.Context
+
+	// Close closes the connection handle.
+	Close()
+
+	// TransferConnection performs a connection migration on the connection
+	// handle. Invoking this blocks until the connection migration process has
+	// been completed.
+	TransferConnection() error
+
+	// ServerRemoteAddr returns the remote address of the connection between
+	// the proxy and the server, which is basically the SQL pod's address
+	// (e.g. 10.15.42.36:26257). This will be used to identify which pod the
+	// connection handle is attached to.
+	ServerRemoteAddr() string
+}

--- a/pkg/ccl/sqlproxyccl/balancer/conn_tracker.go
+++ b/pkg/ccl/sqlproxyccl/balancer/conn_tracker.go
@@ -1,0 +1,148 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package balancer
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/logtags"
+)
+
+// ConnTracker tracks all connection handles associated with each tenant, and
+// handles are grouped by SQL pods.
+type ConnTracker struct {
+	mu struct {
+		syncutil.Mutex
+		tenants map[roachpb.TenantID]*tenantEntry
+	}
+}
+
+// NewConnTracker returns a new instance of the connection tracker. All exposed
+// methods on the connection tracker are thread-safe.
+func NewConnTracker() *ConnTracker {
+	t := &ConnTracker{}
+	t.mu.tenants = make(map[roachpb.TenantID]*tenantEntry)
+	return t
+}
+
+// OnConnect registers the connection handle for tracking under the given
+// tenant. If the handler has already been registered, this returns false.
+func (t *ConnTracker) OnConnect(tenantID roachpb.TenantID, handle ConnectionHandle) bool {
+	e := t.ensureTenantEntry(tenantID)
+	success := e.addHandle(handle)
+	if success {
+		logTrackerEvent("OnConnect", handle)
+	}
+	return success
+}
+
+// OnDisconnect unregisters the connection handle under the given tenant. If
+// the handler cannot be found, this returns false.
+func (t *ConnTracker) OnDisconnect(tenantID roachpb.TenantID, handle ConnectionHandle) bool {
+	e := t.ensureTenantEntry(tenantID)
+	success := e.removeHandle(handle)
+	if success {
+		logTrackerEvent("OnDisconnect", handle)
+	}
+	return success
+}
+
+// GetConns returns a snapshot of connections for the given tenant.
+func (t *ConnTracker) GetConns(tenantID roachpb.TenantID) []ConnectionHandle {
+	e := t.ensureTenantEntry(tenantID)
+	return e.getConns()
+}
+
+// ensureTenantEntry ensures that an entry has been created for the given
+// tenant. If an entry already exists, that will be returned instead.
+func (t *ConnTracker) ensureTenantEntry(tenantID roachpb.TenantID) *tenantEntry {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	entry, ok := t.mu.tenants[tenantID]
+	if !ok {
+		entry = newTenantEntry()
+		t.mu.tenants[tenantID] = entry
+	}
+	return entry
+}
+
+func logTrackerEvent(event string, handle ConnectionHandle) {
+	// The right approach would be for the caller to pass in a ctx object. For
+	// simplicity, we'll just use a background context here since it's only used
+	// for logging. Since we want logs to tie back to the connection, we'll copy
+	// the logtags associated with the handle's context.
+	logCtx := logtags.WithTags(context.Background(), logtags.FromContext(handle.Context()))
+	log.Infof(logCtx, "%s: %s", event, handle.ServerRemoteAddr())
+}
+
+// tenantEntry is a connection tracker entry that stores connection information
+// for a single tenant. All methods on tenantEntry are thread-safe.
+type tenantEntry struct {
+	// mu synchronizes access to the list of connections associated with this
+	// tenant.
+	mu struct {
+		syncutil.Mutex
+		conns map[ConnectionHandle]struct{}
+	}
+}
+
+// newTenantEntry returns a new instance of tenantEntry.
+func newTenantEntry() *tenantEntry {
+	e := &tenantEntry{}
+	e.mu.conns = make(map[ConnectionHandle]struct{})
+	return e
+}
+
+// addHandle adds the handle to the entry based on the handle's active server
+// remote address. This returns true if the operation was successful, and false
+// otherwise.
+func (e *tenantEntry) addHandle(handle ConnectionHandle) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	// Handle already exists.
+	if _, ok := e.mu.conns[handle]; ok {
+		return false
+	}
+	e.mu.conns[handle] = struct{}{}
+	return true
+}
+
+// removeHandle deletes the handle from the tenant entry. This returns true if
+// the operation was successful, and false otherwise.
+func (e *tenantEntry) removeHandle(handle ConnectionHandle) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	// Handle does not exists.
+	if _, ok := e.mu.conns[handle]; !ok {
+		return false
+	}
+	delete(e.mu.conns, handle)
+	return true
+}
+
+// getConns returns a snapshot of connections.
+func (e *tenantEntry) getConns() []ConnectionHandle {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	// Perform a copy to avoid races whenever the map gets mutated through
+	// addHandle or removeHandle. Copying 50K entries (the number of conns that
+	// we plan to support in each proxy) would be a few ms (~5ms).
+	conns := make([]ConnectionHandle, 0, len(e.mu.conns))
+	for handle := range e.mu.conns {
+		conns = append(conns, handle)
+	}
+	return conns
+}

--- a/pkg/ccl/sqlproxyccl/balancer/conn_tracker_test.go
+++ b/pkg/ccl/sqlproxyccl/balancer/conn_tracker_test.go
@@ -1,0 +1,107 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package balancer
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnTracker(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tracker := NewConnTracker()
+	makeConn := func(tenantID int, podAddr string) (roachpb.TenantID, *testConnectionHandle) {
+		return roachpb.MakeTenantID(uint64(tenantID)), newTestConnectionHandle(podAddr)
+	}
+
+	tenantID, handle := makeConn(20, "127.0.0.10:8090")
+	require.True(t, tracker.OnConnect(tenantID, handle))
+	require.False(t, tracker.OnConnect(tenantID, handle))
+
+	conns := tracker.GetConns(tenantID)
+	require.Len(t, conns, 1)
+	require.Equal(t, handle, conns[0])
+
+	// Non-existent.
+	conns = tracker.GetConns(roachpb.MakeTenantID(10))
+	require.Empty(t, conns)
+
+	require.True(t, tracker.OnDisconnect(tenantID, handle))
+	require.False(t, tracker.OnDisconnect(tenantID, handle))
+
+	// Ensure methods are thread-safe.
+	var wg sync.WaitGroup
+	const clients = 50
+	wg.Add(clients)
+	for i := 0; i < clients; i++ {
+		go func() {
+			defer wg.Done()
+			tenantID, handle := makeConn(1+rand.Intn(5), fmt.Sprintf("127.0.0.10:%d", rand.Intn(5)))
+			require.True(t, tracker.OnConnect(tenantID, handle))
+			time.Sleep(250 * time.Millisecond)
+			require.True(t, tracker.OnDisconnect(tenantID, handle))
+		}()
+	}
+
+	wg.Wait()
+	for _, entry := range tracker.mu.tenants {
+		require.Empty(t, entry.mu.conns)
+	}
+}
+
+func TestTenantEntry(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	entry := newTenantEntry()
+
+	h1 := newTestConnectionHandle("10.0.0.1:12345")
+	require.True(t, entry.addHandle(h1))
+	require.False(t, entry.addHandle(h1))
+
+	conns := entry.getConns()
+	require.Len(t, conns, 1)
+
+	require.True(t, entry.removeHandle(h1))
+	require.False(t, entry.removeHandle(h1))
+
+	require.Empty(t, entry.getConns())
+	require.Len(t, conns, 1)
+}
+
+// testConnectionHandle is a test connection handle that only implements a
+// small subset of methods.
+type testConnectionHandle struct {
+	ConnectionHandle
+	remoteAddr string
+}
+
+var _ ConnectionHandle = &testConnectionHandle{}
+
+func newTestConnectionHandle(remoteAddr string) *testConnectionHandle {
+	return &testConnectionHandle{remoteAddr: remoteAddr}
+}
+
+// Context implements the ConnectionHandle interface.
+func (h *testConnectionHandle) Context() context.Context {
+	return context.Background()
+}
+
+// ServerRemoteAddr implements the ConnectionHandle interface.
+func (h *testConnectionHandle) ServerRemoteAddr() string {
+	return h.remoteAddr
+}

--- a/pkg/ccl/sqlproxyccl/conn_migration.go
+++ b/pkg/ccl/sqlproxyccl/conn_migration.go
@@ -122,6 +122,8 @@ var errTransferCannotStart = errors.New("transfer cannot be started")
 // future. That way, we could either transfer to another random SQL pod, or to
 // a specific SQL pod. If we do that, TransferConnection would take in some kind
 // of policy parameter(s).
+//
+// TransferConnection implements the balancer.ConnectionHandle interface.
 func (f *forwarder) TransferConnection() (retErr error) {
 	// A previous non-recoverable transfer would have closed the forwarder, so
 	// return right away.

--- a/pkg/ccl/sqlproxyccl/forwarder.go
+++ b/pkg/ccl/sqlproxyccl/forwarder.go
@@ -15,6 +15,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/balancer"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/interceptor"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -90,6 +91,8 @@ type forwarder struct {
 	}
 }
 
+var _ balancer.ConnectionHandle = &forwarder{}
+
 // forward returns a new instance of forwarder, and starts forwarding messages
 // from clientConn to serverConn (and vice-versa). When this is called, it is
 // expected that the caller passes ownership of both clientConn and serverConn
@@ -125,7 +128,16 @@ func forward(
 	return f, nil
 }
 
+// Context returns the context associated with the forwarder.
+//
+// Context implements the balancer.ConnectionHandle interface.
+func (f *forwarder) Context() context.Context {
+	return f.ctx
+}
+
 // Close closes the forwarder and all connections. This is idempotent.
+//
+// Close implements the balancer.ConnectionHandle interface.
 func (f *forwarder) Close() {
 	f.ctxCancel()
 
@@ -146,6 +158,16 @@ func (f *forwarder) Close() {
 	clientConn, serverConn := f.getConns()
 	clientConn.Close()
 	serverConn.Close()
+}
+
+// ServerRemoteAddr returns the remote address associated with serverConn, i.e.
+// the address of the SQL pod.
+//
+// ServerRemoteAddr implements the balancer.ConnectionHandle interface.
+func (f *forwarder) ServerRemoteAddr() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.mu.serverConn.RemoteAddr().String()
 }
 
 // resumeProcessors starts both the request and response processors

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach-go/v2/crdb"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvtenantccl"
+	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/balancer"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/denylist"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenant"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenantdirsvr"
@@ -800,20 +801,10 @@ func TestConnectionMigration(t *testing.T) {
 	// difficult to work with, and there isn't a way to easily stub out fake
 	// loads. For this test, we will stub out lookupAddr in the connector. We
 	// will alternate between tenant1 and tenant2, starting with tenant1.
-	forwarderCh := make(chan *forwarder)
 	opts := &ProxyOptions{SkipVerify: true, RoutingRule: tenant1.SQLAddr()}
-	opts.testingKnobs.afterForward = func(f *forwarder) error {
-		select {
-		case forwarderCh <- f:
-		case <-time.After(10 * time.Second):
-			return errors.New("no receivers for forwarder")
-		}
-		return nil
-	}
 	proxy, addr := newSecureProxyServer(ctx, t, s.Stopper(), opts)
 
-	// The tenant ID does not matter here since we stubbed RoutingRule.
-	connectionString := fmt.Sprintf("postgres://testuser:hunter2@%s/?sslmode=require&options=--cluster=tenant-cluster-28", addr)
+	connectionString := fmt.Sprintf("postgres://testuser:hunter2@%s/?sslmode=require&options=--cluster=tenant-cluster-%s", addr, tenantID)
 
 	type queryer interface {
 		QueryRowContext(context.Context, string, ...interface{}) *gosql.Row
@@ -864,12 +855,12 @@ func TestConnectionMigration(t *testing.T) {
 			_ = db.PingContext(tCtx)
 		}()
 
-		var f *forwarder
-		select {
-		case f = <-forwarderCh:
-		case <-time.After(10 * time.Second):
-			t.Fatal("no connection")
-		}
+		var conns []balancer.ConnectionHandle
+		require.Eventually(t, func() bool {
+			conns = proxy.handler.connTracker.GetConns(tenantID)
+			return len(conns) != 0
+		}, 10*time.Second, 100*time.Millisecond)
+		f := conns[0].(*forwarder)
 
 		// Set up forwarder hooks.
 		prevTenant1 := true
@@ -1069,12 +1060,12 @@ func TestConnectionMigration(t *testing.T) {
 			_ = conn.PingContext(tCtx)
 		}()
 
-		var f *forwarder
-		select {
-		case f = <-forwarderCh:
-		case <-time.After(10 * time.Second):
-			t.Fatal("no connection")
-		}
+		var conns []balancer.ConnectionHandle
+		require.Eventually(t, func() bool {
+			conns = proxy.handler.connTracker.GetConns(tenantID)
+			return len(conns) != 0
+		}, 10*time.Second, 100*time.Millisecond)
+		f := conns[0].(*forwarder)
 
 		initSuccessCount := f.metrics.ConnMigrationSuccessCount.Count()
 		initErrorRecoverableCount := f.metrics.ConnMigrationErrorRecoverableCount.Count()
@@ -1146,6 +1137,12 @@ func TestConnectionMigration(t *testing.T) {
 		require.Equal(t, totalAttempts-1,
 			f.metrics.ConnMigrationTransferResponseMessageSize.TotalCount())
 	})
+
+	// All connections should eventually be terminated.
+	require.Eventually(t, func() bool {
+		conns := proxy.handler.connTracker.GetConns(tenantID)
+		return len(conns) == 0
+	}, 10*time.Second, 100*time.Millisecond)
 }
 
 func TestClusterNameAndTenantFromParams(t *testing.T) {


### PR DESCRIPTION
#### ccl/sqlproxyccl: add connection tracker component 

This commit adds a connection tracker component to the balancer, and this will
be used to track all instances of forwarders for each tenant. The forwarders
can then be used for connection migration.

Release note: None
  
#### ccl/sqlproxyccl: make forwarder implement balancer.ConnectionHandle 

This commit makes the forwarder struct implement the balancer.ConnectionHandle
interface. This then allows the forwarder to be stored within the connection
tracker component.

Release note: None
  
#### ccl/sqlproxyccl: register forwarders with the connection tracker 

This commit registers all forwarders with the connection tracker. At the same
time, we remove the afterForward testing hook since that is no longer needed.

Release note: None