### PR TITLE
release-21.2: util/mon: mark monitor name and stack trace as safe from redacting

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/redact"
 )
 
 // Base config defaults.
@@ -593,7 +594,7 @@ func TempStorageConfigFromEnv(
 	maxSizeBytes int64,
 ) TempStorageConfig {
 	inMem := parentDir == "" && useStore.InMemory
-	var monitorName string
+	var monitorName redact.RedactableString
 	if inMem {
 		monitorName = "in-mem temp storage"
 	} else {

--- a/pkg/sql/buffer.go
+++ b/pkg/sql/buffer.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/redact"
 )
 
 // bufferNode consumes its input one row at a time, stores it in the buffer,
@@ -29,12 +30,13 @@ type bufferNode struct {
 	currentRow tree.Datums
 
 	// label is a string used to describe the node in an EXPLAIN plan.
+	// TODO(yuzefovich): make this redact.RedactableString.
 	label string
 }
 
 func (n *bufferNode) startExec(params runParams) error {
 	n.typs = planTypes(n.plan)
-	n.rows.init(n.typs, params.extendedEvalCtx, n.label)
+	n.rows.init(n.typs, params.extendedEvalCtx, redact.Sprint(n.label))
 	return nil
 }
 

--- a/pkg/sql/buffer_util.go
+++ b/pkg/sql/buffer_util.go
@@ -12,7 +12,6 @@ package sql
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -21,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/redact"
 )
 
 // rowContainerHelper is a wrapper around a disk-backed row container that
@@ -34,14 +34,14 @@ type rowContainerHelper struct {
 }
 
 func (c *rowContainerHelper) init(
-	typs []*types.T, evalContext *extendedEvalContext, opName string,
+	typs []*types.T, evalContext *extendedEvalContext, opName redact.RedactableString,
 ) {
 	distSQLCfg := &evalContext.DistSQLPlanner.distSQLSrv.ServerConfig
 	c.memMonitor = execinfra.NewLimitedMonitorNoFlowCtx(
 		evalContext.Context, evalContext.Mon, distSQLCfg, evalContext.SessionData(),
-		fmt.Sprintf("%s-limited", opName),
+		redact.Sprintf("%s-limited", opName),
 	)
-	c.diskMonitor = execinfra.NewMonitor(evalContext.Context, distSQLCfg.ParentDiskMonitor, fmt.Sprintf("%s-disk", opName))
+	c.diskMonitor = execinfra.NewMonitor(evalContext.Context, distSQLCfg.ParentDiskMonitor, redact.Sprintf("%s-disk", opName))
 	c.rows = &rowcontainer.DiskBackedRowContainer{}
 	c.rows.Init(
 		colinfo.NoOrdering, typs, &evalContext.EvalContext,

--- a/pkg/sql/colcontainer/diskqueue_test.go
+++ b/pkg/sql/colcontainer/diskqueue_test.go
@@ -182,7 +182,7 @@ func TestDiskQueueCloseOnErr(t *testing.T) {
 
 	serverCfg := &execinfra.ServerConfig{}
 	serverCfg.TestingKnobs.ForceDiskSpill = true
-	diskMon := execinfra.NewLimitedMonitorNoFlowCtx(ctx, testDiskMonitor, serverCfg, nil /* sd */, t.Name())
+	diskMon := execinfra.NewLimitedMonitorNoFlowCtx(ctx, testDiskMonitor, serverCfg, nil /* sd */, "test-disk")
 	defer diskMon.Stop(ctx)
 	diskAcc := diskMon.MakeBoundAccount()
 	defer diskAcc.Close(ctx)

--- a/pkg/sql/colexec/colbuilder/BUILD.bazel
+++ b/pkg/sql/colexec/colbuilder/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//pkg/util/log/logcrash",
         "//pkg/util/mon",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/sql/colexec/disk_spiller.go
+++ b/pkg/sql/colexec/disk_spiller.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // oneInputDiskSpiller is an Operator that manages the fallback from a one
@@ -74,7 +75,7 @@ import (
 func NewOneInputDiskSpiller(
 	input colexecop.Operator,
 	inMemoryOp colexecop.BufferingInMemoryOperator,
-	inMemoryMemMonitorName string,
+	inMemoryMemMonitorName redact.RedactableString,
 	diskBackedOpConstructor func(input colexecop.Operator) colexecop.Operator,
 	spillingCallbackFn func(),
 ) colexecop.Operator {
@@ -82,7 +83,7 @@ func NewOneInputDiskSpiller(
 	return &diskSpillerBase{
 		inputs:                 []colexecop.Operator{input},
 		inMemoryOp:             inMemoryOp,
-		inMemoryMemMonitorName: inMemoryMemMonitorName,
+		inMemoryMemMonitorName: string(inMemoryMemMonitorName),
 		diskBackedOp:           diskBackedOpConstructor(diskBackedOpInput),
 		spillingCallbackFn:     spillingCallbackFn,
 	}
@@ -141,7 +142,7 @@ func NewOneInputDiskSpiller(
 func NewTwoInputDiskSpiller(
 	inputOne, inputTwo colexecop.Operator,
 	inMemoryOp colexecop.BufferingInMemoryOperator,
-	inMemoryMemMonitorName string,
+	inMemoryMemMonitorName redact.RedactableString,
 	diskBackedOpConstructor func(inputOne, inputTwo colexecop.Operator) colexecop.Operator,
 	spillingCallbackFn func(),
 ) colexecop.Operator {
@@ -150,7 +151,7 @@ func NewTwoInputDiskSpiller(
 	return &diskSpillerBase{
 		inputs:                 []colexecop.Operator{inputOne, inputTwo},
 		inMemoryOp:             inMemoryOp,
-		inMemoryMemMonitorName: inMemoryMemMonitorName,
+		inMemoryMemMonitorName: string(inMemoryMemMonitorName),
 		diskBackedOp:           diskBackedOpConstructor(diskBackedOpInputOne, diskBackedOpInputTwo),
 		spillingCallbackFn:     spillingCallbackFn,
 	}

--- a/pkg/sql/colflow/BUILD.bazel
+++ b/pkg/sql/colflow/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//pkg/util/treeprinter",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_marusama_semaphore//:semaphore",
     ],
 )

--- a/pkg/sql/execinfra/BUILD.bazel
+++ b/pkg/sql/execinfra/BUILD.bazel
@@ -65,6 +65,7 @@ go_library(
         "//pkg/util/tracing/tracingpb",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_gogo_protobuf//types",
         "@com_github_marusama_semaphore//:semaphore",
         "@org_golang_google_grpc//:go_default_library",

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/optional"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // Processor is a common interface implemented by all processors, used by the
@@ -929,7 +930,9 @@ func (pb *ProcessorBaseNoHelper) ConsumerClosed() {
 // NewMonitor is a utility function used by processors to create a new
 // memory monitor with the given name and start it. The returned monitor must
 // be closed.
-func NewMonitor(ctx context.Context, parent *mon.BytesMonitor, name string) *mon.BytesMonitor {
+func NewMonitor(
+	ctx context.Context, parent *mon.BytesMonitor, name redact.RedactableString,
+) *mon.BytesMonitor {
 	monitor := mon.NewMonitorInheritWithLimit(name, 0 /* limit */, parent)
 	monitor.Start(ctx, parent, mon.BoundAccount{})
 	return monitor
@@ -942,7 +945,7 @@ func NewMonitor(ctx context.Context, parent *mon.BytesMonitor, name string) *mon
 // ServerConfig.TestingKnobs.ForceDiskSpill is set or
 // ServerConfig.TestingKnobs.MemoryLimitBytes if not.
 func NewLimitedMonitor(
-	ctx context.Context, parent *mon.BytesMonitor, flowCtx *FlowCtx, name string,
+	ctx context.Context, parent *mon.BytesMonitor, flowCtx *FlowCtx, name redact.RedactableString,
 ) *mon.BytesMonitor {
 	limitedMon := mon.NewMonitorInheritWithLimit(name, GetWorkMemLimit(flowCtx), parent)
 	limitedMon.Start(ctx, parent, mon.BoundAccount{})
@@ -956,7 +959,7 @@ func NewLimitedMonitorNoFlowCtx(
 	parent *mon.BytesMonitor,
 	config *ServerConfig,
 	sd *sessiondata.SessionData,
-	name string,
+	name redact.RedactableString,
 ) *mon.BytesMonitor {
 	// Create a fake FlowCtx populating only the required fields.
 	flowCtx := &FlowCtx{

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -12,7 +12,6 @@ package sql
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs"
@@ -45,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
+	"github.com/cockroachdb/redact"
 )
 
 // extendedEvalContext extends tree.EvalContext with fields that are needed for
@@ -294,6 +294,7 @@ func NewInternalPlanner(
 // Returns a cleanup function that must be called once the caller is done with
 // the planner.
 func newInternalPlanner(
+	// TODO(yuzefovich): make this redact.RedactableString.
 	opName string,
 	txn *kv.Txn,
 	user security.SQLUsername,
@@ -357,7 +358,7 @@ func newInternalPlanner(
 	p.semaCtx.DateStyle = sd.GetDateStyle()
 	p.semaCtx.IntervalStyle = sd.GetIntervalStyle()
 
-	plannerMon := mon.NewMonitor(fmt.Sprintf("internal-planner.%s.%s", user, opName),
+	plannerMon := mon.NewMonitor(redact.Sprintf("internal-planner.%s.%s", user, opName),
 		mon.MemoryResource,
 		memMetrics.CurBytesCount, memMetrics.MaxBytesHist,
 		-1, /* increment */

--- a/pkg/sql/rowexec/BUILD.bazel
+++ b/pkg/sql/rowexec/BUILD.bazel
@@ -92,6 +92,7 @@ go_library(
         "@com_github_axiomhq_hyperloglog//:hyperloglog",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/sql/rowexec/sorter.go
+++ b/pkg/sql/rowexec/sorter.go
@@ -12,7 +12,6 @@ package rowexec
 
 import (
 	"context"
-	"fmt"
 	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
@@ -23,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/optional"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // sorter sorts the input rows according to the specified ordering.
@@ -44,7 +44,7 @@ func (s *sorterBase) init(
 	self execinfra.RowSource,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
-	processorName string,
+	processorName redact.RedactableString,
 	input execinfra.RowSource,
 	post *execinfrapb.PostProcessSpec,
 	output execinfra.RowReceiver,
@@ -60,7 +60,7 @@ func (s *sorterBase) init(
 
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The processor will overflow to disk if this limit is not enough.
-	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx, fmt.Sprintf("%s-limited", processorName))
+	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx, redact.Sprintf("%s-limited", processorName))
 	if err := s.ProcessorBase.Init(
 		self, post, input.OutputTypes(), flowCtx, processorID, output, memMonitor, opts,
 	); err != nil {
@@ -68,7 +68,7 @@ func (s *sorterBase) init(
 		return err
 	}
 
-	s.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, fmt.Sprintf("%s-disk", processorName))
+	s.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, redact.Sprintf("%s-disk", processorName))
 	rc := rowcontainer.DiskBackedRowContainer{}
 	rc.Init(
 		ordering,

--- a/pkg/sql/rowflow/BUILD.bazel
+++ b/pkg/sql/rowflow/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/sql/rowflow/routers.go
+++ b/pkg/sql/rowflow/routers.go
@@ -16,7 +16,6 @@ package rowflow
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"hash/crc32"
 	"sort"
 	"sync"
@@ -33,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 type router interface {
@@ -271,17 +271,17 @@ func (rb *routerBase) init(ctx context.Context, flowCtx *execinfra.FlowCtx, type
 		evalCtx := flowCtx.NewEvalCtx()
 		rb.outputs[i].memoryMonitor = execinfra.NewLimitedMonitor(
 			ctx, evalCtx.Mon, flowCtx,
-			fmt.Sprintf("router-limited-%d", rb.outputs[i].streamID),
+			redact.Sprintf("router-limited-%d", rb.outputs[i].streamID),
 		)
 		rb.outputs[i].diskMonitor = execinfra.NewMonitor(
 			ctx, flowCtx.DiskMonitor,
-			fmt.Sprintf("router-disk-%d", rb.outputs[i].streamID),
+			redact.Sprintf("router-disk-%d", rb.outputs[i].streamID),
 		)
 		// Note that the monitor is an unlimited one since we don't know how
 		// to fallback to disk if a memory budget error is encountered when
 		// we're popping rows from the row container into the row buffer.
 		rb.outputs[i].rowBufToPushFromMon = execinfra.NewMonitor(
-			ctx, evalCtx.Mon, fmt.Sprintf("router-unlimited-%d", rb.outputs[i].streamID),
+			ctx, evalCtx.Mon, redact.Sprintf("router-unlimited-%d", rb.outputs[i].streamID),
 		)
 		memAcc := rb.outputs[i].rowBufToPushFromMon.MakeBoundAccount()
 		rb.outputs[i].rowBufToPushFromAcc = &memAcc

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//pkg/util/randutil",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@org_golang_x_tools//container/intsets",
     ],
 )

--- a/pkg/util/mon/BUILD.bazel
+++ b/pkg/util/mon/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/util/metric",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/util/smalltrace.go
+++ b/pkg/util/smalltrace.go
@@ -12,8 +12,9 @@ package util
 
 import (
 	"runtime"
-	"strconv"
 	"strings"
+
+	"github.com/cockroachdb/redact"
 )
 
 var prefix = func() string {
@@ -27,12 +28,13 @@ var prefix = func() string {
 
 // GetSmallTrace returns a comma-separated string containing the top
 // 5 callers from a given skip level.
-func GetSmallTrace(skip int) string {
+func GetSmallTrace(skip int) redact.RedactableString {
 	var pcs [5]uintptr
-	nCallers := runtime.Callers(skip, pcs[:])
-	callers := make([]string, 0, nCallers)
+	runtime.Callers(skip, pcs[:])
 	frames := runtime.CallersFrames(pcs[:])
+	var callers redact.StringBuilder
 
+	var callerPrefix redact.RedactableString
 	for {
 		f, more := frames.Next()
 		function := strings.TrimPrefix(f.Function, prefix)
@@ -40,11 +42,12 @@ func GetSmallTrace(skip int) string {
 		if index := strings.LastIndexByte(file, '/'); index >= 0 {
 			file = file[index+1:]
 		}
-		callers = append(callers, file+":"+strconv.Itoa(f.Line)+":"+function)
+		callers.Printf("%s%s:%d:%s", callerPrefix, file, f.Line, function)
+		callerPrefix = ","
 		if !more {
 			break
 		}
 	}
 
-	return strings.Join(callers, ",")
+	return callers.RedactableString()
 }

--- a/pkg/util/smalltrace_test.go
+++ b/pkg/util/smalltrace_test.go
@@ -23,7 +23,7 @@ import (
 
 func testSmallTrace2(t *testing.T) {
 	s := GetSmallTrace(2)
-	if !strings.Contains(s, "smalltrace_test.go:1009:util.testSmallTrace,smalltrace_test.go:1013:util.TestGenerateSmallTrace") {
+	if !strings.Contains(string(s), "‹smalltrace_test.go›:‹1002›:‹util.testSmallTrace2›,‹smalltrace_test.go›:‹1009›:‹util.testSmallTrace›,‹smalltrace_test.go›:‹1013›:‹util.TestGenerateSmallTrace›") {
 		t.Fatalf("trace not generated properly: %q", s)
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #78352.

/cc @cockroachdb/release

---

Release note: None

Release justification: low risk improvement to debuggability.