### PR TITLE
backupccl: add deprecation warning for SHOW BACKUP without subdir

### DIFF
--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/protoreflect"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -301,8 +302,17 @@ func showBackupPlanHook(
 			if err != nil {
 				return err
 			}
+		} else {
+			// Deprecation notice for old `SHOW BACKUP` syntax. Remove this once the syntax is
+			// deleted in 22.2.
+			p.BufferClientNotice(ctx,
+				pgnotice.Newf("The `SHOW BACKUP` syntax without the `IN` keyword will be removed in a"+
+					" future release. Please switch over to using `SHOW BACKUP FROM <backup> IN"+
+					" <collection>` to view metadata on a backup collection: %s."+
+					" Also note that backups created using the `BACKUP TO` syntax may not be showable or"+
+					" restoreable in the next major version release. Use `BACKUP INTO` instead.",
+					"https://www.cockroachlabs.com/docs/stable/show-backup.html"))
 		}
-
 		if err := checkShowBackupURIPrivileges(ctx, p, dest); err != nil {
 			return err
 		}

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -37,6 +37,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TODO (msbutler): when refactoring these tests to data driven tests, keep the
+// original go test on 22.1 and only use new backup syntax in data driven test
+
 func TestShowBackup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/ccl/backupccl/testdata/backup-restore/feature-flags
+++ b/pkg/ccl/backupccl/testdata/backup-restore/feature-flags
@@ -63,6 +63,11 @@ BACKUP TO 'nodelocal://1/deprecated';
 NOTICE: The `BACKUP TO` syntax will be removed in a future release, please switch over to using `BACKUP INTO` to create a backup collection: https://www.cockroachlabs.com/docs/stable/backup.html#considerations. Backups created using the `BACKUP TO` syntax may not be restoreable in the next major version release.
 
 exec-sql
+SHOW BACKUP 'nodelocal://1/deprecated';
+----
+NOTICE: The `SHOW BACKUP` syntax without the `IN` keyword will be removed in a future release. Please switch over to using `SHOW BACKUP FROM <backup> IN <collection>` to view metadata on a backup collection: https://www.cockroachlabs.com/docs/stable/show-backup.html. Also note that backups created using the `BACKUP TO` syntax may not be showable or restoreable in the next major version release. Use `BACKUP INTO` instead.
+
+exec-sql
 BACKUP TO 'nodelocal://1/deprecated/incfrom' INCREMENTAL FROM 'nodelocal://1/deprecated';
 ----
 NOTICE: The `BACKUP TO` syntax will be removed in a future release, please switch over to using `BACKUP INTO` to create a backup collection: https://www.cockroachlabs.com/docs/stable/backup.html#considerations. Backups created using the `BACKUP TO` syntax may not be restoreable in the next major version release.


### PR DESCRIPTION
Informs: #78153

Release note (sql change): The `SHOW BACKUP` cmd  without the `IN` keyword to
specify a subdirectory is deprecated and will be removed from a future release.
Users are recommended to only create collection based backups and view them
with `SHOW BACKUP FROM <backup> IN <collection>`