### PR TITLE
release-21.2: sql: fix handling of INT2VECTOR and OIDVECTOR in some cases

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -226,7 +226,12 @@ SELECT ARRAY[1,2,3]::TEXT[]
 query T
 SELECT ARRAY[1,2,3]::INT2VECTOR
 ----
-{1,2,3}
+1 2 3
+
+query T
+SELECT ARRAY[1,2,3]::OIDVECTOR
+----
+1 2 3
 
 # array subscript access
 
@@ -1745,3 +1750,19 @@ INSERT INTO t VALUES (
   '{192.168.100.128, ::ffff:10.4.3.2}',
   '{0101, 11}',
   '{12.34, 45.67}');
+
+# Regression test for losing the OID of the array during spilling to disk.
+
+# Lower the distsql_workmem so that the sort in the query below has to spill to
+# disk.
+statement ok
+SET distsql_workmem = '2B'
+
+# The output must be printed without the curly braces.
+query T
+SELECT indkey FROM pg_index WHERE indrelid = (SELECT oid FROM pg_class WHERE relname = 'k') ORDER BY 1
+----
+1
+
+statement ok
+RESET distsql_workmem

--- a/pkg/sql/rowenc/index_encoding_test.go
+++ b/pkg/sql/rowenc/index_encoding_test.go
@@ -779,7 +779,7 @@ func TestArrayEncoding(t *testing.T) {
 			enc := make([]byte, 0)
 			enc = append(enc, byte(len(test.encoding)))
 			enc = append(enc, test.encoding...)
-			d, _, err := DecodeArray(&DatumAlloc{}, test.datum.ParamTyp, enc)
+			d, _, err := DecodeArray(&DatumAlloc{}, types.MakeArray(test.datum.ParamTyp), enc)
 			hasNulls := d.(*tree.DArray).HasNulls
 			if test.datum.HasNulls != hasNulls {
 				t.Fatalf("expected %v to have HasNulls=%t, got %t", enc, test.datum.HasNulls, hasNulls)

--- a/pkg/sql/sem/tree/casts.go
+++ b/pkg/sql/sem/tree/casts.go
@@ -1404,6 +1404,9 @@ func performCastWithoutPrecisionTruncation(ctx *EvalContext, d Datum, t *types.T
 			return res, err
 		case *DArray:
 			dcast := NewDArray(t.ArrayContents())
+			if err := dcast.MaybeSetCustomOid(t); err != nil {
+				return nil, err
+			}
 			for _, e := range v.Array {
 				ecast := DNull
 				if e != DNull {

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -3948,7 +3948,24 @@ func MustBeDArray(e Expr) *DArray {
 	return i
 }
 
-// ResolvedType implements the TypedExpr interface.
+// MaybeSetCustomOid checks whether t has a special oid that we want to set into
+// d. Must be kept in sync with DArray.ResolvedType. Returns an error if t is
+// not an array type.
+func (d *DArray) MaybeSetCustomOid(t *types.T) error {
+	if t.Family() != types.ArrayFamily {
+		return errors.AssertionFailedf("expected array type, got %s", t.SQLString())
+	}
+	switch t.Oid() {
+	case oid.T_int2vector:
+		d.customOid = oid.T_int2vector
+	case oid.T_oidvector:
+		d.customOid = oid.T_oidvector
+	}
+	return nil
+}
+
+// ResolvedType implements the TypedExpr interface. Must be kept in sync with
+// DArray.MaybeSetCustomOid.
 func (d *DArray) ResolvedType() *types.T {
 	switch d.customOid {
 	case oid.T_int2vector:
@@ -4993,8 +5010,8 @@ func NewDName(d string) Datum {
 	return NewDNameFromDString(NewDString(d))
 }
 
-// NewDIntVectorFromDArray is a helper routine to create a *DIntVector
-// (implemented as a *DOidWrapper) initialized from an existing *DArray.
+// NewDIntVectorFromDArray is a helper routine to create a new *DArray,
+// initialized from an existing *DArray, with the special oid for IntVector.
 func NewDIntVectorFromDArray(d *DArray) Datum {
 	ret := new(DArray)
 	*ret = *d
@@ -5002,8 +5019,8 @@ func NewDIntVectorFromDArray(d *DArray) Datum {
 	return ret
 }
 
-// NewDOidVectorFromDArray is a helper routine to create a *DOidVector
-// (implemented as a *DOidWrapper) initialized from an existing *DArray.
+// NewDOidVectorFromDArray is a helper routine to create a new *DArray,
+// initialized from an existing *DArray, with the special oid for OidVector.
 func NewDOidVectorFromDArray(d *DArray) Datum {
 	ret := new(DArray)
 	*ret = *d


### PR DESCRIPTION
Backport 1/1 commits from #78520.

/cc @cockroachdb/release

---

Previously, we incorrectly handled arrays with special oids
(`INT2VECTOR` and `OIDVECTOR`) in a couple of scenarios:
- when casting to those special types
- when the array datum was spilled to disk.

This now fixed.

Release note (bug fix): Previously, CockroachDB could lose INT2VECTOR
and OIDVECTOR type of some arrays, and this is now fixed.

Release justification: bug fix.