### PR TITLE
lease: add a defensive check for nil-ness

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -722,6 +722,9 @@ func NameMatchesDescriptor(
 // findNewest returns the newest descriptor version state for the ID.
 func (m *Manager) findNewest(id descpb.ID) *descriptorVersionState {
 	t := m.findDescriptorState(id, false /* create */)
+	if t == nil {
+		return nil
+	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.mu.active.findNewest()


### PR DESCRIPTION
Previously, return from mananger.findDescriptorState is used directly
without checking nil-ness. It seems the original author assumed the
that return will never be nil. It will be safer to check nil-ness.

Release note: None