### PR TITLE
roachtest: exit 11 after cluster provisioning failures

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -40,6 +40,11 @@ import (
 // test failed.
 const ExitCodeTestsFailed = 10
 
+// ExitCodeClusterProvisioningFailed is the exit code that results
+// from a run of roachtest in which some clusters could not be
+// created due to errors during cloud hardware allocation.
+const ExitCodeClusterProvisioningFailed = 11
+
 // runnerLogsDir is the dir under the artifacts root where the test runner log
 // and other runner-related logs (i.e. cluster creation logs) will be written.
 const runnerLogsDir = "_runner-logs"
@@ -328,6 +333,9 @@ runner itself.
 		code := 1
 		if errors.Is(err, errTestsFailed) {
 			code = ExitCodeTestsFailed
+		}
+		if errors.Is(err, errClusterProvisioningFailed) {
+			code = ExitCodeClusterProvisioningFailed
 		}
 		// Cobra has already printed the error message.
 		os.Exit(code)


### PR DESCRIPTION
`roachtest` exits nonzero if it was unable to run any tests due to cloud
flakiness (resource exhaustion etc). Previously the "nonzero" was 1
which is the catchall exit code. Now it uses 11 which can now signal
this specific failure mode, and could be special cased in our CI scripts
if we so desire in the future.

Release note: None
