### PR TITLE
release-21.2: tree: correctly handle NULLs annotated as a tuple type

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -979,3 +979,15 @@ UNION
 SELECT (1::INT, NULL)
 ----
 (1,)
+
+# Regression test #74729. Correctly handle NULLs annotated as a tuple type.
+subtest regression_74729
+
+statement ok
+SELECT CASE WHEN true THEN ('a', 2) ELSE NULL:::RECORD END
+
+statement ok
+CREATE TABLE t74729 AS SELECT g % 2 = 1 AS _bool FROM generate_series(1, 5) AS g
+
+statement ok
+SELECT CASE WHEN _bool THEN (1, ('a', 2)) ELSE (3, NULL) END FROM t74729

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -159,6 +159,12 @@ func TestTypeCheck(t *testing.T) {
 		{`(1:::INT8, 2:::INT8)`, `(1:::INT8, 2:::INT8)`},
 		{`(ROW (1,2))`, `(1:::INT8, 2:::INT8)`},
 		{`ROW(1:::INT8, 2:::INT8)`, `(1:::INT8, 2:::INT8)`},
+		// Regression test #74729. Correctly handle NULLs annotated as a tuple
+		// type.
+		{
+			`CASE WHEN true THEN ('a', 2) ELSE NULL:::RECORD END`,
+			`CASE WHEN true THEN ('a':::STRING, 2:::INT8) ELSE NULL END`,
+		},
 
 		{`((ROW (1) AS a)).a`, `1:::INT8`},
 		{`((('1', 2) AS a, b)).a`, `'1':::STRING`},


### PR DESCRIPTION
Backport 1/1 commits from #78287.

/cc @cockroachdb/release

---

Fixes #74729

Release note (bug fix): A bug has been fixed that caused errors when
trying to evaluate queries with NULL values annotated as a tuple type,
such as `NULL:::RECORD`. This bug was present since version 19.1.

---

Release justification: This fixes a minor bug with type annotations
that causes internal errors.