### PR TITLE
pgwire: add detailed error message for index out of bounds in decodeBinaryTuple

### DIFF
--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -14,6 +14,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"math"
 	"strconv"
@@ -513,7 +514,7 @@ func DecodeDatum(
 	case FormatBinary:
 		switch id {
 		case oid.T_record:
-			return decodeBinaryTuple(evalCtx, t, b)
+			return decodeBinaryTuple(evalCtx, b)
 		case oid.T_bool:
 			if len(b) > 0 {
 				switch b[0] {
@@ -846,7 +847,7 @@ func validateStringBytes(b []byte) error {
 	return nil
 }
 
-//PGNumericSign indicates the sign of a numeric.
+// PGNumericSign indicates the sign of a numeric.
 //go:generate stringer -type=PGNumericSign
 type PGNumericSign uint16
 
@@ -989,53 +990,94 @@ func decodeBinaryArray(
 	return arr, nil
 }
 
-func decodeBinaryTuple(evalCtx *tree.EvalContext, t *types.T, b []byte) (tree.Datum, error) {
-	if len(b) < 4 {
-		return nil, pgerror.Newf(pgcode.Syntax, "tuple requires a 4 byte header for binary format")
+const tupleHeaderSize, oidSize, elementSize = 4, 4, 4
+
+func decodeBinaryTuple(evalCtx *tree.EvalContext, b []byte) (tree.Datum, error) {
+
+	bufferLength := int32(len(b))
+	if bufferLength < tupleHeaderSize {
+		return nil, pgerror.Newf(
+			pgcode.Syntax,
+			"tuple requires a %d byte header for binary format. bufferLength=%d",
+			tupleHeaderSize, bufferLength)
 	}
 
-	totalLength := int32(len(b))
-	numberOfElements := int32(binary.BigEndian.Uint32(b[0:4]))
+	bufferStartIdx := int32(0)
+	bufferEndIdx := bufferStartIdx + tupleHeaderSize
+	numberOfElements := int32(binary.BigEndian.Uint32(b[bufferStartIdx:bufferEndIdx]))
+	if numberOfElements < 0 {
+		return nil, pgerror.Newf(
+			pgcode.Syntax,
+			"tuple must have non-negative number of elements. numberOfElements=%d",
+			numberOfElements)
+	}
+	bufferStartIdx = bufferEndIdx
+
 	typs := make([]*types.T, numberOfElements)
 	datums := make(tree.Datums, numberOfElements)
-	curByte := int32(4)
-	curIdx := int32(0)
 
-	for curIdx < numberOfElements {
+	elementIdx := int32(0)
 
-		if totalLength < curByte+4 {
-			return nil, pgerror.Newf(pgcode.Syntax, "tuple requires 4 bytes for each element OID for binary format")
+	// getStateString is used to output current state in error messages
+	getSyntaxError := func(message string, args ...interface{}) error {
+		formattedMessage := fmt.Sprintf(message, args...)
+		return pgerror.Newf(
+			pgcode.Syntax,
+			"%s elementIdx=%d bufferLength=%d bufferStartIdx=%d bufferEndIdx=%d",
+			formattedMessage, elementIdx, bufferLength, bufferStartIdx, bufferEndIdx)
+	}
+
+	for elementIdx < numberOfElements {
+
+		bytesToRead := int32(oidSize)
+		bufferEndIdx = bufferStartIdx + bytesToRead
+		if bufferEndIdx < bufferStartIdx {
+			return nil, getSyntaxError("integer overflow reading element OID for binary format. ")
+		}
+		if bufferLength < bufferEndIdx {
+			return nil, getSyntaxError("insufficient bytes reading element OID for binary format. ")
 		}
 
-		elementOID := int32(binary.BigEndian.Uint32(b[curByte : curByte+4]))
-		elementType := types.OidToType[oid.Oid(elementOID)]
-		typs[curIdx] = elementType
-		curByte = curByte + 4
+		elementOID := int32(binary.BigEndian.Uint32(b[bufferStartIdx:bufferEndIdx]))
+		elementType, ok := types.OidToType[oid.Oid(elementOID)]
+		if !ok {
+			return nil, getSyntaxError("element type not found for OID %d. ", elementOID)
+		}
+		typs[elementIdx] = elementType
+		bufferStartIdx = bufferEndIdx
 
-		if totalLength < curByte+4 {
-			return nil, pgerror.Newf(pgcode.Syntax, "tuple requires 4 bytes for the size of each element for binary format")
+		bytesToRead = int32(elementSize)
+		bufferEndIdx = bufferStartIdx + bytesToRead
+		if bufferEndIdx < bufferStartIdx {
+			return nil, getSyntaxError("integer overflow reading element size for binary format. ")
+		}
+		if bufferLength < bufferEndIdx {
+			return nil, getSyntaxError("insufficient bytes reading element size for binary format. ")
 		}
 
-		elementLength := int32(binary.BigEndian.Uint32(b[curByte : curByte+4]))
-		curByte = curByte + 4
-
-		if elementLength == -1 {
-			datums[curIdx] = tree.DNull
+		bytesToRead = int32(binary.BigEndian.Uint32(b[bufferStartIdx:bufferEndIdx]))
+		bufferStartIdx = bufferEndIdx
+		if bytesToRead == -1 {
+			datums[elementIdx] = tree.DNull
 		} else {
-			if totalLength < curByte+elementLength {
-				return nil, pgerror.Newf(pgcode.Syntax, "tuple requires %d bytes for element %d for binary format", elementLength, curIdx)
+			bufferEndIdx = bufferStartIdx + bytesToRead
+			if bufferEndIdx < bufferStartIdx {
+				return nil, getSyntaxError("integer overflow reading element for binary format. ")
+			}
+			if bufferLength < bufferEndIdx {
+				return nil, getSyntaxError("insufficient bytes reading element for binary format. ")
 			}
 
-			colDatum, err := DecodeDatum(evalCtx, elementType, FormatBinary, b[curByte:curByte+elementLength])
+			colDatum, err := DecodeDatum(evalCtx, elementType, FormatBinary, b[bufferStartIdx:bufferEndIdx])
 
 			if err != nil {
 				return nil, err
 			}
 
-			curByte = curByte + elementLength
-			datums[curIdx] = colDatum
+			bufferStartIdx = bufferEndIdx
+			datums[elementIdx] = colDatum
 		}
-		curIdx++
+		elementIdx++
 	}
 
 	tupleTyps := types.MakeTuple(typs)

--- a/pkg/sql/pgwire/testdata/pgtest/tuple
+++ b/pkg/sql/pgwire/testdata/pgtest/tuple
@@ -91,3 +91,166 @@ ReadyForQuery
 {"Type":"ParseComplete"}
 {"Type":"ErrorResponse","Code":"0A000","Message":"error in argument for $1: could not parse \"(1,cat)\" as type tuple: cannot parse anonymous record type"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+# empty parameter
+send
+Parse {"Name": "s_empty_param", "Query": "SELECT $1::record"}
+Bind {"DestinationPortal": "p_empty_param", "PreparedStatement": "s_empty_param", "ParameterFormatCodes": [1], "Parameters": [{"binary":""}], "ResultFormatCodes": [0]}
+Execute {"Portal": "p_empty_param"}
+Sync
+----
+
+until crdb_only keepErrMessage
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ErrorResponse","Code":"42601","Message":"error in argument for $1: tuple requires a 4 byte header for binary format. bufferLength=0"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# negative length tuple
+# FFFFFFFF - -1 element
+send
+Parse {"Name": "s_negative_tuple", "Query": "SELECT $1::record"}
+Bind {"DestinationPortal": "p_negative_tuple", "PreparedStatement": "s_negative_tuple", "ParameterFormatCodes": [1], "Parameters": [{"binary":"FFFFFFFF"}], "ResultFormatCodes": [0]}
+Execute {"Portal": "p_negative_tuple"}
+Sync
+----
+
+until crdb_only keepErrMessage
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ErrorResponse","Code":"42601","Message":"error in argument for $1: tuple must have non-negative number of elements. numberOfElements=-1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# not enough bytes for element OID
+# 00000001 - 1 element
+send
+Parse {"Name": "s_element_oid_no_bytes", "Query": "SELECT $1::record"}
+Bind {"DestinationPortal": "p_element_oid_no_bytes", "PreparedStatement": "s_element_oid_no_bytes", "ParameterFormatCodes": [1], "Parameters": [{"binary":"00000001"}], "ResultFormatCodes": [0]}
+Execute {"Portal": "p_element_oid_no_bytes"}
+Sync
+----
+
+until crdb_only keepErrMessage
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ErrorResponse","Code":"42601","Message":"error in argument for $1: insufficient bytes reading element OID for binary format. elementIdx=0 bufferLength=4 bufferStartIdx=4 bufferEndIdx=8"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# element OID not found
+# 00000001 - 1 element
+# 00000000 - OID does not exist
+send
+Parse {"Name": "s_element_oid_not_found", "Query": "SELECT $1::record"}
+Bind {"DestinationPortal": "p_element_oid_not_found", "PreparedStatement": "s_element_oid_not_found", "ParameterFormatCodes": [1], "Parameters": [{"binary":"0000000100000000"}], "ResultFormatCodes": [0]}
+Execute {"Portal": "p_element_oid_not_found"}
+Sync
+----
+
+until crdb_only keepErrMessage
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ErrorResponse","Code":"42601","Message":"error in argument for $1: element type not found for OID 0. elementIdx=0 bufferLength=8 bufferStartIdx=4 bufferEndIdx=8"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# not enough bytes for element size
+# 00000001 - 1 element
+# 00000010 - bool OID
+send
+Parse {"Name": "s_element_size_no_bytes", "Query": "SELECT $1::record"}
+Bind {"DestinationPortal": "p_element_size_no_bytes", "PreparedStatement": "s_element_size_no_bytes", "ParameterFormatCodes": [1], "Parameters": [{"binary":"0000000100000010"}], "ResultFormatCodes": [0]}
+Execute {"Portal": "p_element_size_no_bytes"}
+Sync
+----
+
+until crdb_only keepErrMessage
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ErrorResponse","Code":"42601","Message":"error in argument for $1: insufficient bytes reading element size for binary format. elementIdx=0 bufferLength=8 bufferStartIdx=8 bufferEndIdx=12"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# null element
+# 00000001 - 1 element
+# 00000010 - bool OID
+# FFFFFFFF - -1 byte element size
+send
+Parse {"Name": "s_element_null", "Query": "SELECT $1::record"}
+Bind {"DestinationPortal": "p_element_null", "PreparedStatement": "s_element_null", "ParameterFormatCodes": [1], "Parameters": [{"binary":"0000000100000010FFFFFFFF"}], "ResultFormatCodes": [0]}
+Execute {"Portal": "p_element_null"}
+Sync
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"()"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# element requires more bytes
+# 00000001 - 1 element
+# 00000010 - bool OID
+# 00000000 - 0 byte element size
+send
+Parse {"Name": "s_element_needs_bytes", "Query": "SELECT $1::record"}
+Bind {"DestinationPortal": "p_element_needs_bytes", "PreparedStatement": "s_element_needs_bytes", "ParameterFormatCodes": [1], "Parameters": [{"binary":"000000010000001000000000"}], "ResultFormatCodes": [0]}
+Execute {"Portal": "p_element_needs_bytes"}
+Sync
+----
+
+until crdb_only keepErrMessage
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ErrorResponse","Code":"42601","Message":"error in argument for $1: unsupported binary bool: "}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# not enough bytes for element
+# 00000001 - 1 element
+# 00000010 - bool OID
+# 00000001 - 1 byte element size
+send
+Parse {"Name": "s_element_no_bytes", "Query": "SELECT $1::record"}
+Bind {"DestinationPortal": "p_element_no_bytes", "PreparedStatement": "s_element_no_bytes", "ParameterFormatCodes": [1], "Parameters": [{"binary":"000000010000001000000001"}], "ResultFormatCodes": [0]}
+Execute {"Portal": "p_element_no_bytes"}
+Sync
+----
+
+until crdb_only keepErrMessage
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ErrorResponse","Code":"42601","Message":"error in argument for $1: insufficient bytes reading element for binary format. elementIdx=0 bufferLength=12 bufferStartIdx=12 bufferEndIdx=13"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# negative element size
+# 00000001 - 1 element
+# 00000010 - bool OID
+# FFFFFFFE - -2 byte element size
+send
+Parse {"Name": "s_element_negative_size", "Query": "SELECT $1::record"}
+Bind {"DestinationPortal": "p_element_negative_size", "PreparedStatement": "s_element_negative_size", "ParameterFormatCodes": [1], "Parameters": [{"binary":"0000000100000010FFFFFFFE"}], "ResultFormatCodes": [0]}
+Execute {"Portal": "p_element_negative_size"}
+Sync
+----
+
+until crdb_only keepErrMessage
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ErrorResponse","Code":"42601","Message":"error in argument for $1: integer overflow reading element for binary format. elementIdx=0 bufferLength=12 bufferStartIdx=12 bufferEndIdx=10"}
+{"Type":"ReadyForQuery","TxStatus":"I"}


### PR DESCRIPTION
refs https://github.com/cockroachdb/cockroach/issues/77796

Release note (bug fix): Added a detailed error message for index out of bounds
when decoding a binary tuple datum. This does not fix the root cause, but
should give more insight into what is happening.