### PR TITLE
release-21.1: tree: correctly handle NULLs annotated as a tuple type

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -966,3 +966,15 @@ UNION
 SELECT (1::INT, NULL)
 ----
 (1,)
+
+# Regression test #74729. Correctly handle NULLs annotated as a tuple type.
+subtest regression_74729
+
+statement ok
+SELECT CASE WHEN true THEN ('a', 2) ELSE NULL:::RECORD END
+
+statement ok
+CREATE TABLE t74729 AS SELECT g % 2 = 1 AS _bool FROM generate_series(1, 5) AS g
+
+statement ok
+SELECT CASE WHEN _bool THEN (1, ('a', 2)) ELSE (3, NULL) END FROM t74729

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -2406,10 +2406,11 @@ func typeCheckSameTypedTupleExprs(
 		sameTypeExprs = sameTypeExprs[:0]
 		sameTypeExprsIndices = sameTypeExprsIndices[:0]
 		for exprIdx, expr := range exprs {
-			if expr == DNull {
+			tup, ok := expr.(*Tuple)
+			if !ok {
 				continue
 			}
-			sameTypeExprs = append(sameTypeExprs, expr.(*Tuple).Exprs[elemIdx])
+			sameTypeExprs = append(sameTypeExprs, tup.Exprs[elemIdx])
 			sameTypeExprsIndices = append(sameTypeExprsIndices, exprIdx)
 		}
 		desiredElem := types.Any
@@ -2427,8 +2428,15 @@ func typeCheckSameTypedTupleExprs(
 		resTypes.TupleContents()[elemIdx] = resType
 	}
 	for tupleIdx, expr := range exprs {
-		if expr != DNull {
-			expr.(*Tuple).typ = resTypes
+		if tup, ok := expr.(*Tuple); ok {
+			tup.typ = resTypes
+		}
+		if annotate, ok := expr.(*AnnotateTypeExpr); ok {
+			// The expression could be a NULL annotated with a tuple type, like
+			// NULL:::RECORD. At this point the checks above have already
+			// validated that the type annotation is a tuple and the inner
+			// expression is NULL.
+			expr = annotate.Expr
 		}
 		typedExprs[tupleIdx] = expr.(TypedExpr)
 	}
@@ -2440,7 +2448,10 @@ func typeCheckSameTypedTupleExprs(
 func checkAllExprsAreTuplesOrNulls(ctx context.Context, semaCtx *SemaContext, exprs []Expr) error {
 	for _, expr := range exprs {
 		_, isTuple := expr.(*Tuple)
-		isNull := expr == DNull
+		isNull, err := isNullOrAnnotatedNullTuple(ctx, semaCtx, expr)
+		if err != nil {
+			return err
+		}
 		if !(isTuple || isNull) {
 			typedExpr, err := expr.TypeCheck(ctx, semaCtx, types.Any)
 			if err != nil {
@@ -2456,10 +2467,11 @@ func checkAllExprsAreTuplesOrNulls(ctx context.Context, semaCtx *SemaContext, ex
 // length. Note that all nulls are skipped in this check.
 func checkAllTuplesHaveLength(exprs []Expr, expectedLen int) error {
 	for _, expr := range exprs {
-		if expr == DNull {
+		tup, ok := expr.(*Tuple)
+		if !ok {
 			continue
 		}
-		if err := checkTupleHasLength(expr.(*Tuple), expectedLen); err != nil {
+		if err := checkTupleHasLength(tup, expectedLen); err != nil {
 			return err
 		}
 	}
@@ -2471,6 +2483,28 @@ func checkTupleHasLength(t *Tuple, expectedLen int) error {
 		return pgerror.Newf(pgcode.DatatypeMismatch, "expected tuple %v to have a length of %d", t, expectedLen)
 	}
 	return nil
+}
+
+// isNullOrAnnotatedNullTuple returns true if the given expression is a DNull or
+// a DNull that is wrapped by an AnnotateTypeExpr with a type identical to
+// AnyTuple (e.g., NULL:::RECORD). An AnnotateTypeExpr should never have a tuple
+// type not identical to AnyTuple, because other tuple types could only be
+// expressed as composite types, and these are not yet supported. If the
+// AnnotateTypeExpr has a non-tuple type, the function returns false.
+func isNullOrAnnotatedNullTuple(
+	ctx context.Context, semaCtx *SemaContext, expr Expr,
+) (bool, error) {
+	if expr == DNull {
+		return true, nil
+	}
+	if annotate, ok := expr.(*AnnotateTypeExpr); ok && annotate.Expr == DNull {
+		annotateType, err := ResolveType(ctx, annotate.Type, semaCtx.GetTypeResolver())
+		if err != nil {
+			return false, err
+		}
+		return annotateType.Identical(types.AnyTuple), nil
+	}
+	return false, nil
 }
 
 type placeholderAnnotationVisitor struct {

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -159,6 +159,12 @@ func TestTypeCheck(t *testing.T) {
 		{`(1:::INT8, 2:::INT8)`, `(1:::INT8, 2:::INT8)`},
 		{`(ROW (1,2))`, `(1:::INT8, 2:::INT8)`},
 		{`ROW(1:::INT8, 2:::INT8)`, `(1:::INT8, 2:::INT8)`},
+		// Regression test #74729. Correctly handle NULLs annotated as a tuple
+		// type.
+		{
+			`CASE WHEN true THEN ('a', 2) ELSE NULL:::RECORD END`,
+			`CASE WHEN true THEN ('a':::STRING, 2:::INT8) ELSE NULL END`,
+		},
 
 		{`((ROW (1) AS a)).a`, `1:::INT8`},
 		{`((('1', 2) AS a, b)).a`, `'1':::STRING`},


### PR DESCRIPTION
Backport 1/1 commits from #78287.

/cc @cockroachdb/release

---

Fixes #74729

Release note (bug fix): A bug has been fixed that caused errors when
trying to evaluate queries with NULL values annotated as a tuple type,
such as `NULL:::RECORD`. This bug was present since version 19.1.

---

Release justification: This fixes a minor bug with type annotations
that causes internal errors.