### PR TITLE
release-21.2: util/goschedstats: support go1.18

### DIFF
--- a/pkg/util/goschedstats/BUILD.bazel
+++ b/pkg/util/goschedstats/BUILD.bazel
@@ -4,6 +4,8 @@ go_library(
     name = "goschedstats",
     srcs = [
         "runnable.go",
+        "runtime_deferpool_go1.16.go",
+        "runtime_deferpool_go1.18.go",
         "runtime_go1.16.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/goschedstats",

--- a/pkg/util/goschedstats/runtime_deferpool_go1.16.go
+++ b/pkg/util/goschedstats/runtime_deferpool_go1.16.go
@@ -1,0 +1,19 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+//go:build gc && go1.16 && !go1.18
+// +build gc,go1.16,!go1.18
+
+package goschedstats
+
+type deferpool struct {
+	deferpool    [5][]uintptr // pool of available defer structs of different sizes (see panic.go)
+	deferpoolbuf [5][32]uintptr
+}

--- a/pkg/util/goschedstats/runtime_deferpool_go1.18.go
+++ b/pkg/util/goschedstats/runtime_deferpool_go1.18.go
@@ -1,0 +1,19 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+//go:build gc && go1.18
+// +build gc,go1.18
+
+package goschedstats
+
+type deferpool struct {
+	deferpool    []uintptr // pool of available defer structs (see panic.go)
+	deferpoolbuf [32]uintptr
+}

--- a/pkg/util/goschedstats/runtime_go1.16.go
+++ b/pkg/util/goschedstats/runtime_go1.16.go
@@ -9,10 +9,11 @@
 // licenses/APL.txt.
 //
 // The structure definitions in this file have been cross-checked against
-// go1.16, and go1.17beta1 (needs revalidation). Before allowing newer
-// versions, please check that the structures still match with those in
-// go/src/runtime.
-// +build gc,go1.16,!go1.18
+// go1.16, go1.17, and go1.18. Before allowing newer versions, please check that
+// the structures still match with those in go/src/runtime.
+
+//go:build gc && go1.16 && !go1.19
+// +build gc,go1.16,!go1.19
 
 package goschedstats
 
@@ -52,8 +53,10 @@ type p struct {
 	pcache      pageCache
 	raceprocctx uintptr
 
-	deferpool    [5][]uintptr // pool of available defer structs of different sizes (see panic.go)
-	deferpoolbuf [5][32]uintptr
+	// NOTE: the runtime does not have a deferpool struct type. We use one here to
+	// conditionally configure the size of these fields based on the go version.
+	// See runtime_deferpool_go1.16.go and runtime_deferpool_go1.18.go.
+	deferpool deferpool
 
 	// Cache of goroutine ids, amortizes accesses to runtime·sched.goidgen.
 	goidcache    uint64


### PR DESCRIPTION
Backport 1/1 commits from #77857.

/cc @cockroachdb/release

---

This commit bumps the maximum supported version of `pkg/util/goschedstats` to go1.18, now that 1.18 has officially been released: https://go.dev/doc/go1.18.

Unlike prior version updates, this commit is not quite as simple as bumping the version. This is because the runtime's `p` struct's memory layout was changed in https://github.com/golang/go/commit/e0e9fb8affbe37c2ff73b9afb60f726e747f428d. As a result, we now use conditional compilation to configure the size of the "deferpool" fields based on the go version.

This is the only change needed to compile CockroachDB using go1.18.

Release justification: Low-risk change that allows release to be built using go1.18.
