### PR TITLE
release-21.2: ui: update cluster-ui version to 21.2.5

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "21.2.4",
+  "version": "21.2.5",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Update cluster-ui version to match published npm version.

Release note: None
Release justification: non-production change