### PR TITLE
changefeedccl: allow changefeed users to alter the end_time of an existing changefeed

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -141,10 +141,15 @@ func changefeedPlanHook(
 			return err
 		}
 
+		statementTime := hlc.Timestamp{
+			WallTime: p.ExtendedEvalContext().GetStmtTimestamp().UnixNano(),
+		}
+
 		jr, err := createChangefeedJobRecord(
 			ctx,
 			p,
 			changefeedStmt,
+			statementTime,
 			sinkURI,
 			opts,
 			jobspb.InvalidJobID,
@@ -243,6 +248,7 @@ func createChangefeedJobRecord(
 	ctx context.Context,
 	p sql.PlanHookState,
 	changefeedStmt *tree.CreateChangefeed,
+	statementTime hlc.Timestamp,
 	sinkURI string,
 	opts map[string]string,
 	jobID jobspb.JobID,
@@ -270,9 +276,6 @@ func createChangefeedJobRecord(
 		return nil, err
 	}
 
-	statementTime := hlc.Timestamp{
-		WallTime: p.ExtendedEvalContext().GetStmtTimestamp().UnixNano(),
-	}
 	var initialHighWater hlc.Timestamp
 	if cursor, ok := opts[changefeedbase.OptCursor]; ok {
 		asOfClause := tree.AsOfClause{Expr: tree.NewStrVal(cursor)}

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -247,11 +247,7 @@ var NoLongerExperimental = map[string]string{
 
 // AlterChangefeedUnsupportedOptions are changefeed options that we do not allow
 // users to alter.
-// TODO(sherman): At the moment we disallow altering both the initial_scan_only
-// and the end_time option. However, there are instances in which it should be
-// allowed to alter either of these options. We need to support the alteration
-// of these fields.
-var AlterChangefeedUnsupportedOptions = makeStringSet(OptCursor, OptInitialScan, OptNoInitialScan, OptInitialScanOnly, OptEndTime)
+var AlterChangefeedUnsupportedOptions = makeStringSet(OptCursor, OptInitialScan, OptNoInitialScan, OptInitialScanOnly)
 
 // AlterChangefeedOptionExpectValues is used to parse alter changefeed options
 // using PlanHookState.TypeAsStringOpts().


### PR DESCRIPTION
changefeedccl: allow changefeed users to alter the
end_time of an existing changefeed.

Prior to this PR, we introduced an end_time option
that users can set so that their changefeeds will
automatically complete with a successful end_time
once the changefeed has reached the timestamp.
However, in that PR we disallowed users from altering
the end_time option of an existing changefeed.

In this PR we remove that option from the denylist
and allow users to alter the end_time option of existing
changefeeds.

Example:

ALTER CHANGEFEED <job_id> SET end_time = '\<timestamp\>';

Release note (enterprise change): Allow users to alter
the end_time option of existing changefeeds.

Release jusitifcation: Low risk change with a lot of
benefits.