### PR TITLE
sql: implement to_reg* builtins

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -3072,6 +3072,18 @@ table. Returns an error if validation fails.</p>
 </span></td></tr>
 <tr><td><a name="session_user"></a><code>session_user() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the session user. This function is provided for compatibility with PostgreSQL.</p>
 </span></td></tr>
+<tr><td><a name="to_regclass"></a><code>to_regclass(text: <a href="string.html">string</a>) &rarr; regtype</code></td><td><span class="funcdesc"><p>Translates a textual relation name to its OID</p>
+</span></td></tr>
+<tr><td><a name="to_regnamespace"></a><code>to_regnamespace(text: <a href="string.html">string</a>) &rarr; regtype</code></td><td><span class="funcdesc"><p>Translates a textual schema name to its OID</p>
+</span></td></tr>
+<tr><td><a name="to_regproc"></a><code>to_regproc(text: <a href="string.html">string</a>) &rarr; regtype</code></td><td><span class="funcdesc"><p>Translates a textual function or procedure name to its OID</p>
+</span></td></tr>
+<tr><td><a name="to_regprocedure"></a><code>to_regprocedure(text: <a href="string.html">string</a>) &rarr; regtype</code></td><td><span class="funcdesc"><p>Translates a textual function or procedure name(with argument types) to its OID</p>
+</span></td></tr>
+<tr><td><a name="to_regrole"></a><code>to_regrole(text: <a href="string.html">string</a>) &rarr; regtype</code></td><td><span class="funcdesc"><p>Translates a textual role name to its OID</p>
+</span></td></tr>
+<tr><td><a name="to_regtype"></a><code>to_regtype(text: <a href="string.html">string</a>) &rarr; regtype</code></td><td><span class="funcdesc"><p>Translates a textual type name to its OID</p>
+</span></td></tr>
 <tr><td><a name="version"></a><code>version() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the node’s version of CockroachDB.</p>
 </span></td></tr></tbody>
 </table>

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -610,3 +610,133 @@ a            NULL
 b            c
 ·            d
 e            f=g
+
+
+statement ok
+CREATE TYPE test_type AS ENUM ('open', 'closed', 'inactive');
+
+statement ok
+CREATE ROLE test_role LOGIN;
+
+statement ok
+CREATE TABLE t1 (a int);
+
+query T
+SELECT to_regclass('pg_roles')
+----
+pg_roles
+
+query T
+SELECT to_regclass('4294967230')
+----
+NULL
+
+query T
+SELECT to_regclass('pg_policy')
+----
+pg_policy
+
+query T
+SELECT to_regclass('t1')
+----
+t1
+
+query T
+SELECT to_regnamespace('crdb_internal')
+----
+crdb_internal
+
+query T
+SELECT to_regnamespace('public')
+----
+public
+
+query T
+SELECT to_regnamespace('1330834471')
+----
+NULL
+
+query T
+SELECT to_regnamespace(' 1330834471')
+----
+NULL
+
+query T
+SELECT to_regproc('_st_contains')
+----
+_st_contains
+
+query T
+SELECT to_regproc('version')
+----
+version
+
+query T
+SELECT to_regproc('bit_in')
+----
+bit_in
+
+query T
+SELECT to_regprocedure('bit_in')
+----
+bit_in
+
+query T
+SELECT to_regprocedure('version')
+----
+version
+
+query T
+SELECT to_regprocedure('961893967')
+----
+NULL
+
+query T
+SELECT to_regrole('admin')
+----
+admin
+
+query T
+SELECT to_regrole('test_role')
+----
+test_role
+
+query T
+SELECT to_regrole('foo')
+----
+NULL
+
+query T
+SELECT to_regrole('1546506610')
+----
+NULL
+
+query T
+SELECT to_regtype('interval')
+----
+interval
+
+query T
+SELECT to_regtype('integer')
+----
+bigint
+
+query T
+SELECT to_regtype('int_4')
+----
+NULL
+
+query T
+SELECT to_regtype('string')
+----
+text
+
+query T
+SELECT to_regtype('1186')
+----
+NULL
+
+query T
+SELECT to_regtype('test_type')
+----
+test_type


### PR DESCRIPTION
Resolves #77838
This commit implements the `to_regclass`, `to_regnamespace`, `to_regproc`,
`to_regprocedure`, `to_regrole`, and `to_regtype` builtins.

Release note (<category, see below>): The `to_regclass`, `to_regnamespace`, `to_regproc`,
`to_regprocedure`, `to_regrole`, and `to_regtype` builtin functions are now supported,
improving compatibility with PostgreSQL.