### PR TITLE
roachprod: do not send status report to slack

### DIFF
--- a/pkg/roachprod/cloud/gc.go
+++ b/pkg/roachprod/cloud/gc.go
@@ -312,11 +312,7 @@ func GCClusters(l *logger.Logger, cloud *Cloud, dryrun bool) error {
 		}
 	}
 
-	// Send out notification to #roachprod-status.
 	client := makeSlackClient()
-	channel, _ := findChannel(client, "roachprod-status", "")
-	postStatus(l, client, channel, dryrun, &s, badVMs)
-
 	// Send out user notifications if any of the user's clusters are expired or
 	// will be destroyed.
 	for user, status := range users {
@@ -330,6 +326,7 @@ func GCClusters(l *logger.Logger, cloud *Cloud, dryrun bool) error {
 		}
 	}
 
+	channel, _ := findChannel(client, "roachprod-status", "")
 	if !dryrun {
 		if len(badVMs) > 0 {
 			// Destroy bad VMs.


### PR DESCRIPTION
Previously, the roachprod GC job posted cluster status on each run. This
made the #roachprod-status channel very spammy and not actionable.

This patch removes the status generation part.

Release note: None