### PR TITLE
release-21.2: tabledesc: relax secondary index version validation

### DIFF
--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -1088,12 +1088,6 @@ func (desc *wrapper) validateTableIndexes(columnNames map[string]descpb.ColumnID
 		if idx.GetVersion() < descpb.StrictIndexColumnIDGuaranteesVersion {
 			continue
 		}
-		if !idx.Primary() && idx.Public() {
-			if idx.GetVersion() == descpb.PrimaryIndexWithStoredColumnsVersion {
-				return errors.AssertionFailedf("secondary index %q has invalid version %d which is for primary indexes",
-					idx.GetName(), idx.GetVersion())
-			}
-		}
 		slices := []struct {
 			name  string
 			slice []descpb.ColumnID


### PR DESCRIPTION
This commit relaxes the table descriptor validation logic in light of
the changes to index descriptor versioning in #76465 , which otherwise
would prevent correct mixed-version cluster operation.

Relates to #78426.

Release note (bug fix): fixes a bug which prevented a table created on
a 22.1 node to be queried on a 21.2 node in a mixed-version cluster.