### PR TITLE
workload/schemachange: disable schema change mixed versions workload

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
@@ -52,6 +52,7 @@ func uploadAndInitSchemaChangeWorkload() versionStep {
 func runSchemaChangeWorkloadStep(loadNode, maxOps, concurrency int) versionStep {
 	var numFeatureRuns int
 	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
+		t.Skip("disabled due to flaky nature of schema change workload")
 		numFeatureRuns++
 		t.L().Printf("Workload step run: %d", numFeatureRuns)
 		runCmd := []string{


### PR DESCRIPTION
Fixes: #78500

Previously, the mixed version schema change workload was
enabled despite the flaky nature of the schema change workload.
This led to intermittent failures related to the workload itself,
and not cockroach. To address this, this patch will disable
the schemachange/mixed-versions tests.

Release note: None