### PR TITLE
[DNM] stats: overrides for DefaultRefreshInterval and DefaultAsOfTime

### DIFF
--- a/pkg/ccl/workloadccl/BUILD.bazel
+++ b/pkg/ccl/workloadccl/BUILD.bazel
@@ -42,7 +42,7 @@ go_test(
         "//pkg/security",
         "//pkg/security/securitytest",
         "//pkg/server",
-        "//pkg/sql/stats",
+        "//pkg/sql/sqlstats",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -655,7 +655,6 @@ go_test(
         "//pkg/sql/sqlstats",
         "//pkg/sql/sqltestutils",
         "//pkg/sql/sqlutil",
-        "//pkg/sql/stats",
         "//pkg/sql/stmtdiagnostics",
         "//pkg/sql/tests",
         "//pkg/sql/types",

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -196,7 +196,7 @@ go_test(
         "//pkg/sql/rowexec",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
-        "//pkg/sql/stats",
+        "//pkg/sql/sqlstats",
         "//pkg/sql/tests",
         "//pkg/sql/types",
         "//pkg/testutils",

--- a/pkg/sql/logictest/BUILD.bazel
+++ b/pkg/sql/logictest/BUILD.bazel
@@ -31,7 +31,6 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondatapb",
         "//pkg/sql/sqlstats",
-        "//pkg/sql/stats",
         "//pkg/testutils",
         "//pkg/testutils/floatcmp",
         "//pkg/testutils/physicalplanutils",

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -57,7 +57,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
-	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/floatcmp"
 	"github.com/cockroachdb/cockroach/pkg/testutils/physicalplanutils"
@@ -1553,6 +1552,11 @@ func (t *logicTest) newCluster(serverArgs TestServerArgs, opts []clusterOpt) {
 				},
 				SQLStatsKnobs: &sqlstats.TestingKnobs{
 					AOSTClause: "AS OF SYSTEM TIME '-1us'",
+					// Update the defaults for automatic statistics to avoid delays in testing.
+					// Avoid making the DefaultAsOfTime too small to avoid interacting with
+					// schema changes and causing transaction retries.
+					DefaultRefreshIntervalOverride: time.Millisecond,
+					DefaultAsOfTimeOverride:        10 * time.Millisecond,
 				},
 			},
 			ClusterName:   "testclustername",
@@ -1639,13 +1643,6 @@ func (t *logicTest) newCluster(serverArgs TestServerArgs, opts []clusterOpt) {
 		paramsPerNode[i] = nodeParams
 	}
 	params.ServerArgsPerNode = paramsPerNode
-
-	// Update the defaults for automatic statistics to avoid delays in testing.
-	// Avoid making the DefaultAsOfTime too small to avoid interacting with
-	// schema changes and causing transaction retries.
-	// TODO(radu): replace these with testing knobs.
-	stats.DefaultAsOfTime = 10 * time.Millisecond
-	stats.DefaultRefreshInterval = time.Millisecond
 
 	t.cluster = serverutils.StartNewTestCluster(t.rootT, cfg.numNodes, params)
 	if cfg.useFakeSpanResolver {

--- a/pkg/sql/sqlstats/test_utils.go
+++ b/pkg/sql/sqlstats/test_utils.go
@@ -29,6 +29,14 @@ type TestingKnobs struct {
 	// AOSTClause overrides the AS OF SYSTEM TIME clause in queries used in
 	// persistedsqlstats.
 	AOSTClause string
+
+	// DefaultRefreshIntervalOverride, if greater than 0, overrides the autostats
+	// refresh interval as defined by DefaultRefreshInterval.
+	DefaultRefreshIntervalOverride time.Duration
+
+	// DefaultAsOfTimeOverride, if greater than 0, overrides the AS OF time for
+	// automatic runs of CREATE STATISTICS as defined by DefaultAsOfTime.
+	DefaultAsOfTimeOverride time.Duration
 }
 
 // ModuleTestingKnobs implements base.ModuleTestingKnobs interface.

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -109,13 +109,13 @@ var AutomaticStatisticsMinStaleRows = func() *settings.IntSetting {
 // the stats for each table should be refreshed. It is mutable for testing.
 // NB: Updates to this value after Refresher.Start has been called will not
 // have any effect.
-var DefaultRefreshInterval = time.Minute
+const DefaultRefreshInterval = time.Minute
 
 // DefaultAsOfTime is a duration which is used to define the AS OF time for
 // automatic runs of CREATE STATISTICS. It is mutable for testing.
 // NB: Updates to this value after MakeRefresher has been called will not have
 // any effect.
-var DefaultAsOfTime = 30 * time.Second
+const DefaultAsOfTime = 30 * time.Second
 
 // bufferedChanFullLogLimiter is used to minimize spamming the log with
 // "buffered channel is full" errors.


### PR DESCRIPTION
This commit makes DefaultRefreshInterval and DefaultAsOfTime constants,
and provides overrides for them. Previously they were global variables,
so we had to make sure to always reset them when done.  Could sharded
tests have written to and accessed these in two separate test threads,
causing flakiness?

Release note: none