### PR TITLE
pkg/server: move pebble metrics initialization

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1327,8 +1327,6 @@ func (s *Server) PreStart(ctx context.Context) error {
 	); err != nil {
 		return err
 	}
-	// Stores have been initialized, so Node can now provide Pebble metrics.
-	s.storeGrantCoords.SetPebbleMetricsProvider(ctx, s.node)
 
 	log.Event(ctx, "started node")
 	if err := s.startPersistingHLCUpperBound(ctx, hlcUpperBoundExists); err != nil {
@@ -1399,6 +1397,16 @@ func (s *Server) PreStart(ctx context.Context) error {
 	//   the hazard described in Node.start, around initializing additional
 	//   stores)
 	s.node.waitForAdditionalStoreInit()
+
+	// Stores have been initialized, so Node can now provide Pebble metrics.
+	//
+	// Note that all existing stores will be operational before Pebble-level
+	// admission control is online. However, we won’t have started to heartbeat
+	// our liveness record until after we call SetPebbleMetricsProvider, so the
+	// existing stores shouldn’t be able to acquire leases yet. Although, below
+	// Raft commands like log application and snapshot application may be able
+	// to bypass admission control.
+	s.storeGrantCoords.SetPebbleMetricsProvider(ctx, s.node)
 
 	// Once all stores are initialized, check if offline storage recovery
 	// was done prior to start and record any actions appropriately.

--- a/pkg/util/admission/granter.go
+++ b/pkg/util/admission/granter.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"math"
 	"time"
+	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -1221,7 +1222,11 @@ type StoreGrantCoordinators struct {
 	// These metrics are shared by WorkQueues across stores.
 	workQueueMetrics WorkQueueMetrics
 
-	gcMap                 map[int32]*GrantCoordinator
+	gcMap syncutil.IntMap // map[int64(StoreID)]*GrantCoordinator
+	// numStores is used to track the number of stores which have been added
+	// to the gcMap. This is used because the IntMap doesn't expose a size
+	// api.
+	numStores             int
 	pebbleMetricsProvider PebbleMetricsProvider
 	closeCh               chan struct{}
 }
@@ -1234,13 +1239,18 @@ func (sgc *StoreGrantCoordinators) SetPebbleMetricsProvider(
 	if sgc.pebbleMetricsProvider != nil {
 		panic(errors.AssertionFailedf("SetPebbleMetricsProvider called more than once"))
 	}
-	sgc.gcMap = make(map[int32]*GrantCoordinator)
 	sgc.pebbleMetricsProvider = pmp
 	sgc.closeCh = make(chan struct{})
 	metrics := sgc.pebbleMetricsProvider.GetPebbleMetrics()
 	for _, m := range metrics {
 		gc := sgc.initGrantCoordinator(m.StoreID)
-		sgc.gcMap[m.StoreID] = gc
+		// Defensive call to LoadAndStore even though Store ought to be sufficient
+		// since SetPebbleMetricsProvider can only be called once. This code
+		// guards against duplication of stores returned by GetPebbleMetrics.
+		_, loaded := sgc.gcMap.LoadOrStore(int64(m.StoreID), unsafe.Pointer(gc))
+		if !loaded {
+			sgc.numStores++
+		}
 		gc.pebbleMetricsTick(startupCtx, m.Metrics)
 		gc.allocateIOTokensTick()
 	}
@@ -1258,12 +1268,13 @@ func (sgc *StoreGrantCoordinators) SetPebbleMetricsProvider(
 				ticks++
 				if ticks%adjustmentInterval == 0 {
 					metrics := sgc.pebbleMetricsProvider.GetPebbleMetrics()
-					if len(metrics) != len(sgc.gcMap) {
+					if len(metrics) != sgc.numStores {
 						log.Warningf(ctx,
-							"expected %d store metrics and found %d metrics", len(sgc.gcMap), len(metrics))
+							"expected %d store metrics and found %d metrics", sgc.numStores, len(metrics))
 					}
 					for _, m := range metrics {
-						if gc, ok := sgc.gcMap[m.StoreID]; ok {
+						if unsafeGc, ok := sgc.gcMap.Load(int64(m.StoreID)); ok {
+							gc := (*GrantCoordinator)(unsafeGc)
 							gc.pebbleMetricsTick(ctx, m.Metrics)
 						} else {
 							log.Warningf(ctx,
@@ -1271,9 +1282,13 @@ func (sgc *StoreGrantCoordinators) SetPebbleMetricsProvider(
 						}
 					}
 				}
-				for _, gc := range sgc.gcMap {
+				sgc.gcMap.Range(func(_ int64, unsafeGc unsafe.Pointer) bool {
+					gc := (*GrantCoordinator)(unsafeGc)
 					gc.allocateIOTokensTick()
-				}
+					// true indicates that iteration should continue after the
+					// current entry has been processed.
+					return true
+				})
 			case <-sgc.closeCh:
 				done = true
 			}
@@ -1333,7 +1348,8 @@ func (sgc *StoreGrantCoordinators) initGrantCoordinator(storeID int32) *GrantCoo
 // TryGetQueueForStore returns a WorkQueue for the given storeID, or nil if
 // the storeID is not known.
 func (sgc *StoreGrantCoordinators) TryGetQueueForStore(storeID int32) *WorkQueue {
-	if granter, ok := sgc.gcMap[storeID]; ok {
+	if unsafeGranter, ok := sgc.gcMap.Load(int64(storeID)); ok {
+		granter := (*GrantCoordinator)(unsafeGranter)
 		return granter.GetWorkQueue(KVWork)
 	}
 	return nil
@@ -1344,9 +1360,14 @@ func (sgc *StoreGrantCoordinators) close() {
 	if sgc.closeCh != nil {
 		close(sgc.closeCh)
 	}
-	for _, c := range sgc.gcMap {
-		c.Close()
-	}
+
+	sgc.gcMap.Range(func(_ int64, unsafeGc unsafe.Pointer) bool {
+		gc := (*GrantCoordinator)(unsafeGc)
+		gc.Close()
+		// true indicates that iteration should continue after the
+		// current entry has been processed.
+		return true
+	})
 }
 
 // GrantCoordinators holds a regular GrantCoordinator for all work, and a

--- a/pkg/util/admission/granter_test.go
+++ b/pkg/util/admission/granter_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -273,9 +274,15 @@ func TestStoreCoordinators(t *testing.T) {
 	require.Equal(t, 3, len(requesters))
 	// Confirm that the store IDs are as expected.
 	var actualStores []int32
-	for s := range storeCoords.gcMap {
-		actualStores = append(actualStores, s)
-	}
+
+	storeCoords.gcMap.Range(func(s int64, _ unsafe.Pointer) bool {
+		// The int32 conversion is lossless since we only store int32s in the
+		// gcMap.
+		actualStores = append(actualStores, int32(s))
+		// true indicates that iteration should continue after the
+		// current entry has been processed.
+		return true
+	})
 	sort.Slice(actualStores, func(i, j int) bool { return actualStores[i] < actualStores[j] })
 	require.Equal(t, []int32{10, 20}, actualStores)
 	// Do tryGet on all requesters. The requester for the Regular


### PR DESCRIPTION
Currently, we don't wait for all the stores to initialize before calling
`SetPebbleMetricsProvider`. This may lead to the metrics provider printing
a warning because it can later detect a store which it doesn't know about.

Release note: None

Jira issue: CRDB-14808