### PR TITLE
sql: optionally group statement statistics by transaction fingerprint ID

### DIFF
--- a/pkg/sql/sqlstats/sslocal/BUILD.bazel
+++ b/pkg/sql/sqlstats/sslocal/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "sslocal",
     srcs = [
+        "cluster_settings.go",
         "sql_stats.go",
         "sql_stats_controller.go",
         "sslocal_iterator.go",
@@ -48,6 +49,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/server/serverpb",
+        "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/sessionphase",
@@ -55,6 +57,7 @@ go_test(
         "//pkg/sql/sqlstats/persistedsqlstats",
         "//pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil",
         "//pkg/sql/tests",
+        "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",

--- a/pkg/sql/sqlstats/sslocal/cluster_settings.go
+++ b/pkg/sql/sqlstats/sslocal/cluster_settings.go
@@ -1,0 +1,26 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sslocal
+
+import "github.com/cockroachdb/cockroach/pkg/settings"
+
+// AssociateStmtWithTxnFingerprint determines whether to segment
+// per-statment statistics by transaction fingerprint. While enabled by
+// default, it may be useful to disable for workloads that run the same
+// statements across many (ad-hoc) transaction fingerprints, producing
+// higher-cardinality data in the system.statement_statistics table than
+// the cleanup job is able to keep up with. See #78338.
+var AssociateStmtWithTxnFingerprint = settings.RegisterBoolSetting(
+	settings.TenantWritable,
+	"sql.stats.associate_stmt_with_txn_fingerprint.enabled",
+	"whether to segment per-statement query statistics by transaction fingerprint",
+	true,
+)

--- a/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
@@ -87,12 +87,19 @@ func (s *StatsCollector) StartExplicitTransaction() {
 func (s *StatsCollector) EndExplicitTransaction(
 	ctx context.Context, transactionFingerprintID roachpb.TransactionFingerprintID,
 ) {
+	// We possibly ignore the transactionFingerprintID, for situations where
+	// grouping by it would otherwise result in collecting higher-cardinality
+	// data in the system tables than the cleanup job is able to keep up with.
+	// See #78338.
+	if !AssociateStmtWithTxnFingerprint.Get(&s.st.SV) {
+		transactionFingerprintID = roachpb.InvalidTransactionFingerprintID
+	}
+
 	var discardedStats uint64
 	discardedStats += s.flushTarget.MergeApplicationStatementStats(
 		ctx,
 		s.ApplicationStats,
-		func(statistics *roachpb.CollectedStatementStatistics,
-		) {
+		func(statistics *roachpb.CollectedStatementStatistics) {
 			statistics.Key.TransactionFingerprintID = transactionFingerprintID
 		},
 	)


### PR DESCRIPTION
Fixes #78338.

We have seen some workloads where the same statements are executed
across multiple ad-hoc transactions, each with a different transaction
fingerprint ID, resulting in so many rows being flushed to the
`system.statement_statistics` table that the cleanup job isn't able to
keep up.

This commit introduces a new cluster setting,
`sql.metrics.statement_details.segment_by_txn_fingerprint.enabled`,
that may be disabled to mitigate against the impact of these
high-cardinality statistics.

(Not filing a release note as this is not intended to be a public
cluster setting.)

Release note: None