### PR TITLE
opt: reduce test catalog allocations in micro benchmarks

### DIFF
--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -201,7 +201,7 @@ var schemas = []string{
 	(
 		a INT PRIMARY KEY,
 		b INT,
-		INDEX (b)
+		INDEX b_idx (b)
 	)
 	`,
 }
@@ -304,7 +304,10 @@ func init() {
 	// Add a table with many columns and many indexes.
 	var indexes strings.Builder
 	for i := 0; i < 250; i++ {
-		indexes.WriteString(",\nINDEX (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w)")
+		indexes.WriteString(fmt.Sprintf(
+			",\nINDEX idx%d (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w)",
+			i,
+		))
 	}
 	tableK := fmt.Sprintf(`CREATE TABLE k (
 		id INT PRIMARY KEY,

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -922,7 +922,7 @@ func (tt *Table) makeIndexName(defName tree.Name, cols tree.IndexElemList, typ i
 	}
 
 	if typ == primaryIndex {
-		return fmt.Sprintf("%s_pkey", tt.TabName.Table())
+		return tt.TabName.Table() + "_pkey"
 	}
 
 	var sb strings.Builder


### PR DESCRIPTION
Memory profiles taken while running optimizer benchmarks showed ~10% of
allocations in the test catalog. These allocations occur when generating
names for indexes with `fmt.Sprintf`.

The allocations themselves aren't a concern because they only occur in
the test catalog, so they cannot affect real queries. However, they do
clutter the memory profile and distract from more important allocations.
This commit reduces these allocations by explicitly naming secondary
indexes in the benchmark schemas. It also slightly reduces allocations
by using string concatenation with `+` instead of `fmt.Sprintf` when
assigning names to primary indexes.

Release note: None