### PR TITLE
migrations: Fix migration discrepancy on a system table.

### DIFF
--- a/pkg/migration/migrations/alter_statement_diagnostics_requests.go
+++ b/pkg/migration/migrations/alter_statement_diagnostics_requests.go
@@ -26,14 +26,14 @@ import (
 const (
 	addColsToStmtDiagReqs = `
 ALTER TABLE system.statement_diagnostics_requests
-  ADD COLUMN min_execution_latency INTERVAL NULL,
-  ADD COLUMN expires_at TIMESTAMPTZ NULL`
+  ADD COLUMN min_execution_latency INTERVAL NULL FAMILY "primary",
+  ADD COLUMN expires_at TIMESTAMPTZ NULL FAMILY "primary"`
 
 	createCompletedIdxV2 = `
 CREATE INDEX completed_idx_v2 ON system.statement_diagnostics_requests (completed, ID)
   STORING (statement_fingerprint, min_execution_latency, expires_at)`
 
-	dropCompletedIdx = `DROP INDEX IF EXISTS completed_idx`
+	dropCompletedIdx = `DROP INDEX IF EXISTS system.statement_diagnostics_requests@completed_idx`
 )
 
 // alterSystemStmtDiagReqs changes the schema of the

--- a/pkg/migration/migrations/alter_statement_diagnostics_requests_test.go
+++ b/pkg/migration/migrations/alter_statement_diagnostics_requests_test.go
@@ -62,6 +62,8 @@ func TestAlterSystemStmtDiagReqs(t *testing.T) {
 		validationSchemas = []migrations.Schema{
 			{Name: "min_execution_latency", ValidationFn: migrations.HasColumn},
 			{Name: "expires_at", ValidationFn: migrations.HasColumn},
+			{Name: "primary", ValidationFn: migrations.HasColumnFamily},
+			{Name: "completed_idx", ValidationFn: migrations.DoesNotHaveIndex},
 		}
 	)
 

--- a/pkg/migration/migrations/helpers_test.go
+++ b/pkg/migration/migrations/helpers_test.go
@@ -31,6 +31,7 @@ import (
 var (
 	HasColumn         = hasColumn
 	HasIndex          = hasIndex
+	DoesNotHaveIndex  = doesNotHaveIndex
 	HasColumnFamily   = hasColumnFamily
 	CreateSystemTable = createSystemTable
 )

--- a/pkg/migration/migrations/schema_changes.go
+++ b/pkg/migration/migrations/schema_changes.go
@@ -249,6 +249,14 @@ func hasIndex(storedTable, expectedTable catalog.TableDescriptor, indexName stri
 	return true, nil
 }
 
+// doesNotHaveIndex returns true if storedTable does not have an index named indexName.
+func doesNotHaveIndex(
+	storedTable, expectedTable catalog.TableDescriptor, indexName string,
+) (bool, error) {
+	idx, _ := storedTable.FindIndexWithName(indexName)
+	return idx == nil, nil
+}
+
 // hasColumnFamily returns true if storedTable already has the given column
 // family, comparing with expectedTable. storedTable descriptor must be read
 // from system storage as compared to reading from the systemschema package. On


### PR DESCRIPTION
Previously, the migration code for system table
`statement_diagnostics_requests` results in discrepancies when compared
to the table definition after bootstrapping. The discrepancies are
summarized in #77980.

This PR fixes it to ensure this table has exactly the same definition
after cluster upgrading as that from bootstrapping.

Release note: None

Fixes: #77980

Sister Issue: #78302

Related PR that discovers this discrepancy: #77970