### PR TITLE
opt: do not cross-join input of semi-join

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -1886,39 +1886,45 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt (pk, a, b) VALUES 
 │   │
 │   └── • error if rows
 │       │
-│       └── • lookup join (semi)
-│           │ table: regional_by_row_table_virt@regional_by_row_table_virt_v_key
-│           │ equality: (lookup_join_const_col_@34, v_comp) = (crdb_region,v)
-│           │ equality cols are key
-│           │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
+│       └── • limit
+│           │ count: 1
 │           │
-│           └── • cross join
-│               │ estimated row count: 3
+│           └── • lookup join
+│               │ table: regional_by_row_table_virt@regional_by_row_table_virt_v_key
+│               │ equality: (lookup_join_const_col_@34, v_comp) = (crdb_region,v)
+│               │ equality cols are key
+│               │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
 │               │
-│               ├── • values
-│               │     size: 1 column, 3 rows
-│               │
-│               └── • scan buffer
-│                     label: buffer 1
+│               └── • cross join
+│                   │ estimated row count: 3
+│                   │
+│                   ├── • values
+│                   │     size: 1 column, 3 rows
+│                   │
+│                   └── • scan buffer
+│                         label: buffer 1
 │
 └── • constraint-check
     │
     └── • error if rows
         │
-        └── • lookup join (semi)
-            │ table: regional_by_row_table_virt@regional_by_row_table_virt_expr_key
-            │ equality: (lookup_join_const_col_@48, crdb_internal_idx_expr_comp) = (crdb_region,crdb_internal_idx_expr)
-            │ equality cols are key
-            │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
+        └── • limit
+            │ count: 1
             │
-            └── • cross join
-                │ estimated row count: 3
+            └── • lookup join
+                │ table: regional_by_row_table_virt@regional_by_row_table_virt_expr_key
+                │ equality: (lookup_join_const_col_@48, crdb_internal_idx_expr_comp) = (crdb_region,crdb_internal_idx_expr)
+                │ equality cols are key
+                │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
                 │
-                ├── • values
-                │     size: 1 column, 3 rows
-                │
-                └── • scan buffer
-                      label: buffer 1
+                └── • cross join
+                    │ estimated row count: 3
+                    │
+                    ├── • values
+                    │     size: 1 column, 3 rows
+                    │
+                    └── • scan buffer
+                          label: buffer 1
 
 query T
 SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table_virt (pk, a, b) VALUES (1, 1, 1)] OFFSET 2
@@ -1961,37 +1967,43 @@ SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table_virt (pk, a, b) VALUES 
 │   │
 │   └── • error if rows
 │       │
-│       └── • lookup join (semi)
-│           │ table: regional_by_row_table_virt@regional_by_row_table_virt_v_key
-│           │ equality: (lookup_join_const_col_@30, v_comp) = (crdb_region,v)
-│           │ equality cols are key
-│           │ pred: (upsert_pk != pk) OR (upsert_crdb_region != crdb_region)
+│       └── • limit
+│           │ count: 1
 │           │
-│           └── • cross join
+│           └── • lookup join
+│               │ table: regional_by_row_table_virt@regional_by_row_table_virt_v_key
+│               │ equality: (lookup_join_const_col_@30, v_comp) = (crdb_region,v)
+│               │ equality cols are key
+│               │ pred: (upsert_pk != pk) OR (upsert_crdb_region != crdb_region)
 │               │
-│               ├── • values
-│               │     size: 1 column, 3 rows
-│               │
-│               └── • scan buffer
-│                     label: buffer 1
+│               └── • cross join
+│                   │
+│                   ├── • values
+│                   │     size: 1 column, 3 rows
+│                   │
+│                   └── • scan buffer
+│                         label: buffer 1
 │
 └── • constraint-check
     │
     └── • error if rows
         │
-        └── • lookup join (semi)
-            │ table: regional_by_row_table_virt@regional_by_row_table_virt_expr_key
-            │ equality: (lookup_join_const_col_@44, crdb_internal_idx_expr_comp) = (crdb_region,crdb_internal_idx_expr)
-            │ equality cols are key
-            │ pred: (upsert_pk != pk) OR (upsert_crdb_region != crdb_region)
+        └── • limit
+            │ count: 1
             │
-            └── • cross join
+            └── • lookup join
+                │ table: regional_by_row_table_virt@regional_by_row_table_virt_expr_key
+                │ equality: (lookup_join_const_col_@44, crdb_internal_idx_expr_comp) = (crdb_region,crdb_internal_idx_expr)
+                │ equality cols are key
+                │ pred: (upsert_pk != pk) OR (upsert_crdb_region != crdb_region)
                 │
-                ├── • values
-                │     size: 1 column, 3 rows
-                │
-                └── • scan buffer
-                      label: buffer 1
+                └── • cross join
+                    │
+                    ├── • values
+                    │     size: 1 column, 3 rows
+                    │
+                    └── • scan buffer
+                          label: buffer 1
 
 statement ok
 INSERT INTO regional_by_row_table_virt (pk, a, b) VALUES (1, 1, 1)
@@ -2054,21 +2066,15 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt_partial (pk, a, b)
 │       │
 │       └── • lookup join (semi)
 │           │ table: regional_by_row_table_virt_partial@v_a_gt_0 (partial index)
-│           │ equality: (lookup_join_const_col_@36, v_comp) = (crdb_region,v)
+│           │ lookup condition: (v_comp = v) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
 │           │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
 │           │
-│           └── • cross join
-│               │ estimated row count: 3
+│           └── • filter
+│               │ estimated row count: 1
+│               │ filter: column2 > 0
 │               │
-│               ├── • values
-│               │     size: 1 column, 3 rows
-│               │
-│               └── • filter
-│                   │ estimated row count: 1
-│                   │ filter: column2 > 0
-│                   │
-│                   └── • scan buffer
-│                         label: buffer 1
+│               └── • scan buffer
+│                     label: buffer 1
 │
 ├── • constraint-check
 │   │
@@ -2076,21 +2082,15 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt_partial (pk, a, b)
 │       │
 │       └── • lookup join (semi)
 │           │ table: regional_by_row_table_virt_partial@v_v_gt_0 (partial index)
-│           │ equality: (lookup_join_const_col_@50, v_comp) = (crdb_region,v)
+│           │ lookup condition: (v_comp = v) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
 │           │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
 │           │
-│           └── • cross join
-│               │ estimated row count: 3
+│           └── • filter
+│               │ estimated row count: 1
+│               │ filter: v_comp > 0
 │               │
-│               ├── • values
-│               │     size: 1 column, 3 rows
-│               │
-│               └── • filter
-│                   │ estimated row count: 1
-│                   │ filter: v_comp > 0
-│                   │
-│                   └── • scan buffer
-│                         label: buffer 1
+│               └── • scan buffer
+│                     label: buffer 1
 │
 └── • constraint-check
     │
@@ -2098,21 +2098,15 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt_partial (pk, a, b)
         │
         └── • lookup join (semi)
             │ table: regional_by_row_table_virt_partial@a_plus_10_v_gt_0 (partial index)
-            │ equality: (lookup_join_const_col_@64, crdb_internal_idx_expr_comp) = (crdb_region,crdb_internal_idx_expr)
+            │ lookup condition: (crdb_internal_idx_expr_comp = crdb_internal_idx_expr) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
             │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
             │
-            └── • cross join
-                │ estimated row count: 3
+            └── • filter
+                │ estimated row count: 1
+                │ filter: v_comp > 0
                 │
-                ├── • values
-                │     size: 1 column, 3 rows
-                │
-                └── • filter
-                    │ estimated row count: 1
-                    │ filter: v_comp > 0
-                    │
-                    └── • scan buffer
-                          label: buffer 1
+                └── • scan buffer
+                      label: buffer 1
 
 query T
 SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table_virt_partial (pk, a, b) VALUES (1, 1, 1)] OFFSET 2
@@ -2157,19 +2151,14 @@ SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table_virt_partial (pk, a, b)
 │       │
 │       └── • lookup join (semi)
 │           │ table: regional_by_row_table_virt_partial@v_a_gt_0 (partial index)
-│           │ equality: (lookup_join_const_col_@34, v_comp) = (crdb_region,v)
+│           │ lookup condition: (v_comp = v) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
 │           │ pred: (upsert_pk != pk) OR (upsert_crdb_region != crdb_region)
 │           │
-│           └── • cross join
+│           └── • filter
+│               │ filter: column2 > 0
 │               │
-│               ├── • values
-│               │     size: 1 column, 3 rows
-│               │
-│               └── • filter
-│                   │ filter: column2 > 0
-│                   │
-│                   └── • scan buffer
-│                         label: buffer 1
+│               └── • scan buffer
+│                     label: buffer 1
 │
 ├── • constraint-check
 │   │
@@ -2177,19 +2166,14 @@ SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table_virt_partial (pk, a, b)
 │       │
 │       └── • lookup join (semi)
 │           │ table: regional_by_row_table_virt_partial@v_v_gt_0 (partial index)
-│           │ equality: (lookup_join_const_col_@48, v_comp) = (crdb_region,v)
+│           │ lookup condition: (v_comp = v) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
 │           │ pred: (upsert_pk != pk) OR (upsert_crdb_region != crdb_region)
 │           │
-│           └── • cross join
+│           └── • filter
+│               │ filter: v_comp > 0
 │               │
-│               ├── • values
-│               │     size: 1 column, 3 rows
-│               │
-│               └── • filter
-│                   │ filter: v_comp > 0
-│                   │
-│                   └── • scan buffer
-│                         label: buffer 1
+│               └── • scan buffer
+│                     label: buffer 1
 │
 └── • constraint-check
     │
@@ -2197,19 +2181,14 @@ SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table_virt_partial (pk, a, b)
         │
         └── • lookup join (semi)
             │ table: regional_by_row_table_virt_partial@a_plus_10_v_gt_0 (partial index)
-            │ equality: (lookup_join_const_col_@62, crdb_internal_idx_expr_comp) = (crdb_region,crdb_internal_idx_expr)
+            │ lookup condition: (crdb_internal_idx_expr_comp = crdb_internal_idx_expr) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
             │ pred: (upsert_pk != pk) OR (upsert_crdb_region != crdb_region)
             │
-            └── • cross join
+            └── • filter
+                │ filter: v_comp > 0
                 │
-                ├── • values
-                │     size: 1 column, 3 rows
-                │
-                └── • filter
-                    │ filter: v_comp > 0
-                    │
-                    └── • scan buffer
-                          label: buffer 1
+                └── • scan buffer
+                      label: buffer 1
 
 statement ok
 INSERT INTO regional_by_row_table_virt_partial (pk, a, b) VALUES (1, 1, 1)

--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -595,6 +595,36 @@ SELECT * FROM (VALUES (1), (2)) AS u(y) WHERE NOT EXISTS (
 1
 2
 
+# Regression test for #78681. Ensure that invalid lookup joins are not created
+# for semi joins.
+statement ok
+CREATE TABLE t78681 (
+  x INT NOT NULL CHECK (x in (1, 3)),
+  y INT NOT NULL,
+  PRIMARY KEY (x, y)
+)
+
+# Insert stats so that a lookup semi-join is selected.
+statement ok
+ALTER TABLE t78681 INJECT STATISTICS '[
+  {
+    "columns": ["x"],
+    "created_at": "2018-05-01 1:00:00.00000+00:00",
+    "row_count": 10000000,
+    "distinct_count": 2
+  }
+]'
+
+statement ok
+INSERT INTO t78681 VALUES (1, 1), (3, 1)
+
+query I rowsort
+SELECT * FROM (VALUES (1), (2)) AS u(y) WHERE EXISTS (
+  SELECT * FROM t78681 t WHERE u.y = t.y
+)
+----
+1
+
 statement ok
 CREATE TABLE lookup_expr (
   r STRING NOT NULL CHECK (r IN ('east', 'west')),

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -751,31 +751,47 @@ vectorized: true
 │               │ columns: (column1, column3)
 │               │ estimated row count: 1 (missing stats)
 │               │
-│               └── • lookup join (semi)
-│                   │ columns: ("lookup_join_const_col_@12", column1, column3)
-│                   │ table: uniq_enum@uniq_enum_pkey
-│                   │ equality: (lookup_join_const_col_@12, column3) = (r,i)
-│                   │ equality cols are key
-│                   │ pred: column1 != r
+│               └── • distinct
+│                   │ columns: (column1, column3, rownum)
+│                   │ estimated row count: 2 (missing stats)
+│                   │ distinct on: rownum
 │                   │
-│                   └── • cross join (inner)
-│                       │ columns: ("lookup_join_const_col_@12", column1, column3)
-│                       │ estimated row count: 6
-│                       │
-│                       ├── • values
-│                       │     columns: ("lookup_join_const_col_@12")
-│                       │     size: 1 column, 3 rows
-│                       │     row 0, expr 0: 'us-east'
-│                       │     row 1, expr 0: 'us-west'
-│                       │     row 2, expr 0: 'eu-west'
+│                   └── • project
+│                       │ columns: (column1, column3, rownum)
 │                       │
 │                       └── • project
-│                           │ columns: (column1, column3)
-│                           │ estimated row count: 2
+│                           │ columns: (r, i, column1, column3, rownum)
+│                           │ estimated row count: 7 (missing stats)
 │                           │
-│                           └── • scan buffer
-│                                 columns: (column1, column2, column3, column4, check1)
-│                                 label: buffer 1
+│                           └── • lookup join (inner)
+│                               │ columns: ("lookup_join_const_col_@12", column1, column3, rownum, r, i)
+│                               │ table: uniq_enum@uniq_enum_pkey
+│                               │ equality: (lookup_join_const_col_@12, column3) = (r,i)
+│                               │ equality cols are key
+│                               │ pred: column1 != r
+│                               │
+│                               └── • cross join (inner)
+│                                   │ columns: ("lookup_join_const_col_@12", column1, column3, rownum)
+│                                   │ estimated row count: 6
+│                                   │
+│                                   ├── • values
+│                                   │     columns: ("lookup_join_const_col_@12")
+│                                   │     size: 1 column, 3 rows
+│                                   │     row 0, expr 0: 'us-east'
+│                                   │     row 1, expr 0: 'us-west'
+│                                   │     row 2, expr 0: 'eu-west'
+│                                   │
+│                                   └── • ordinality
+│                                       │ columns: (column1, column3, rownum)
+│                                       │ estimated row count: 2
+│                                       │
+│                                       └── • project
+│                                           │ columns: (column1, column3)
+│                                           │ estimated row count: 2
+│                                           │
+│                                           └── • scan buffer
+│                                                 columns: (column1, column2, column3, column4, check1)
+│                                                 label: buffer 1
 │
 └── • constraint-check
     │
@@ -790,31 +806,47 @@ vectorized: true
                 │ columns: (column1, column2, column3, column4)
                 │ estimated row count: 1 (missing stats)
                 │
-                └── • lookup join (semi)
-                    │ columns: ("lookup_join_const_col_@22", column1, column2, column3, column4)
-                    │ table: uniq_enum@uniq_enum_r_s_j_key
-                    │ equality: (lookup_join_const_col_@22, column2, column4) = (r,s,j)
-                    │ equality cols are key
-                    │ pred: (column1 != r) OR (column3 != i)
+                └── • distinct
+                    │ columns: (column1, column2, column3, column4, rownum)
+                    │ estimated row count: 0 (missing stats)
+                    │ distinct on: rownum
                     │
-                    └── • cross join (inner)
-                        │ columns: ("lookup_join_const_col_@22", column1, column2, column3, column4)
-                        │ estimated row count: 6
-                        │
-                        ├── • values
-                        │     columns: ("lookup_join_const_col_@22")
-                        │     size: 1 column, 3 rows
-                        │     row 0, expr 0: 'us-east'
-                        │     row 1, expr 0: 'us-west'
-                        │     row 2, expr 0: 'eu-west'
+                    └── • project
+                        │ columns: (column1, column2, column3, column4, rownum)
                         │
                         └── • project
-                            │ columns: (column1, column2, column3, column4)
-                            │ estimated row count: 2
+                            │ columns: (r, s, i, j, column1, column2, column3, column4, rownum)
+                            │ estimated row count: 0 (missing stats)
                             │
-                            └── • scan buffer
-                                  columns: (column1, column2, column3, column4, check1)
-                                  label: buffer 1
+                            └── • lookup join (inner)
+                                │ columns: ("lookup_join_const_col_@22", column1, column2, column3, column4, rownum, r, s, i, j)
+                                │ table: uniq_enum@uniq_enum_r_s_j_key
+                                │ equality: (lookup_join_const_col_@22, column2, column4) = (r,s,j)
+                                │ equality cols are key
+                                │ pred: (column1 != r) OR (column3 != i)
+                                │
+                                └── • cross join (inner)
+                                    │ columns: ("lookup_join_const_col_@22", column1, column2, column3, column4, rownum)
+                                    │ estimated row count: 6
+                                    │
+                                    ├── • values
+                                    │     columns: ("lookup_join_const_col_@22")
+                                    │     size: 1 column, 3 rows
+                                    │     row 0, expr 0: 'us-east'
+                                    │     row 1, expr 0: 'us-west'
+                                    │     row 2, expr 0: 'eu-west'
+                                    │
+                                    └── • ordinality
+                                        │ columns: (column1, column2, column3, column4, rownum)
+                                        │ estimated row count: 2
+                                        │
+                                        └── • project
+                                            │ columns: (column1, column2, column3, column4)
+                                            │ estimated row count: 2
+                                            │
+                                            └── • scan buffer
+                                                  columns: (column1, column2, column3, column4, check1)
+                                                  label: buffer 1
 
 # Test that we use the index when available for the insert checks. This uses
 # the default value for columns r and j.
@@ -874,31 +906,47 @@ vectorized: true
                 │ columns: (r_default, column2)
                 │ estimated row count: 1 (missing stats)
                 │
-                └── • lookup join (semi)
-                    │ columns: ("lookup_join_const_col_@12", r_default, column2)
-                    │ table: uniq_enum@uniq_enum_pkey
-                    │ equality: (lookup_join_const_col_@12, column2) = (r,i)
-                    │ equality cols are key
-                    │ pred: r_default != r
+                └── • distinct
+                    │ columns: (r_default, column2, rownum)
+                    │ estimated row count: 2 (missing stats)
+                    │ distinct on: rownum
                     │
-                    └── • cross join (inner)
-                        │ columns: ("lookup_join_const_col_@12", r_default, column2)
-                        │ estimated row count: 6
-                        │
-                        ├── • values
-                        │     columns: ("lookup_join_const_col_@12")
-                        │     size: 1 column, 3 rows
-                        │     row 0, expr 0: 'us-east'
-                        │     row 1, expr 0: 'us-west'
-                        │     row 2, expr 0: 'eu-west'
+                    └── • project
+                        │ columns: (r_default, column2, rownum)
                         │
                         └── • project
-                            │ columns: (r_default, column2)
-                            │ estimated row count: 2
+                            │ columns: (r, i, r_default, column2, rownum)
+                            │ estimated row count: 7 (missing stats)
                             │
-                            └── • scan buffer
-                                  columns: (r_default, column1, column2, j_default, check1)
-                                  label: buffer 1
+                            └── • lookup join (inner)
+                                │ columns: ("lookup_join_const_col_@12", r_default, column2, rownum, r, i)
+                                │ table: uniq_enum@uniq_enum_pkey
+                                │ equality: (lookup_join_const_col_@12, column2) = (r,i)
+                                │ equality cols are key
+                                │ pred: r_default != r
+                                │
+                                └── • cross join (inner)
+                                    │ columns: ("lookup_join_const_col_@12", r_default, column2, rownum)
+                                    │ estimated row count: 6
+                                    │
+                                    ├── • values
+                                    │     columns: ("lookup_join_const_col_@12")
+                                    │     size: 1 column, 3 rows
+                                    │     row 0, expr 0: 'us-east'
+                                    │     row 1, expr 0: 'us-west'
+                                    │     row 2, expr 0: 'eu-west'
+                                    │
+                                    └── • ordinality
+                                        │ columns: (r_default, column2, rownum)
+                                        │ estimated row count: 2
+                                        │
+                                        └── • project
+                                            │ columns: (r_default, column2)
+                                            │ estimated row count: 2
+                                            │
+                                            └── • scan buffer
+                                                  columns: (r_default, column1, column2, j_default, check1)
+                                                  label: buffer 1
 
 # Test that we use the index when available for de-duplicating INSERT ON
 # CONFLICT DO NOTHING rows before inserting.
@@ -1329,39 +1377,25 @@ vectorized: true
             │ columns: (column3)
             │ estimated row count: 1
             │
-            └── • project
+            └── • lookup join (semi)
                 │ columns: (column1, column2, column3, column4)
                 │ estimated row count: 1
+                │ table: uniq_partial_enum@uniq_partial_enum_r_b_idx (partial index)
+                │ lookup condition: (column3 = b) AND (r IN ('us-east', 'us-west', 'eu-west'))
+                │ pred: (column1 != r) OR (column2 != a)
                 │
-                └── • lookup join (semi)
-                    │ columns: ("lookup_join_const_col_@13", column1, column2, column3, column4)
-                    │ table: uniq_partial_enum@uniq_partial_enum_r_b_idx (partial index)
-                    │ equality: (lookup_join_const_col_@13, column3) = (r,b)
-                    │ pred: (column1 != r) OR (column2 != a)
+                └── • filter
+                    │ columns: (column1, column2, column3, column4)
+                    │ estimated row count: 2
+                    │ filter: column4 IN ('bar', 'baz', 'foo')
                     │
-                    └── • cross join (inner)
-                        │ columns: ("lookup_join_const_col_@13", column1, column2, column3, column4)
-                        │ estimated row count: 6
+                    └── • project
+                        │ columns: (column1, column2, column3, column4)
+                        │ estimated row count: 2
                         │
-                        ├── • values
-                        │     columns: ("lookup_join_const_col_@13")
-                        │     size: 1 column, 3 rows
-                        │     row 0, expr 0: 'us-east'
-                        │     row 1, expr 0: 'us-west'
-                        │     row 2, expr 0: 'eu-west'
-                        │
-                        └── • filter
-                            │ columns: (column1, column2, column3, column4)
-                            │ estimated row count: 2
-                            │ filter: column4 IN ('bar', 'baz', 'foo')
-                            │
-                            └── • project
-                                │ columns: (column1, column2, column3, column4)
-                                │ estimated row count: 2
-                                │
-                                └── • scan buffer
-                                      columns: (column1, column2, column3, column4, check1, partial_index_put1)
-                                      label: buffer 1
+                        └── • scan buffer
+                              columns: (column1, column2, column3, column4, check1, partial_index_put1)
+                              label: buffer 1
 
 # Test that we use the partial index when available for de-duplicating INSERT ON
 # CONFLICT DO NOTHING rows before inserting.
@@ -2189,31 +2223,47 @@ vectorized: true
 │               │ columns: (r_new, i_new)
 │               │ estimated row count: 3 (missing stats)
 │               │
-│               └── • lookup join (semi)
-│                   │ columns: (r_new, i_new, "lookup_join_const_col_@17")
-│                   │ table: uniq_enum@uniq_enum_pkey
-│                   │ equality: (lookup_join_const_col_@17, i_new) = (r,i)
-│                   │ equality cols are key
-│                   │ pred: r_new != r
+│               └── • distinct
+│                   │ columns: (r_new, i_new, rownum)
+│                   │ estimated row count: 9 (missing stats)
+│                   │ distinct on: rownum
 │                   │
-│                   └── • cross join (inner)
-│                       │ columns: (r_new, i_new, "lookup_join_const_col_@17")
-│                       │ estimated row count: 28 (missing stats)
+│                   └── • project
+│                       │ columns: (r_new, i_new, rownum)
 │                       │
-│                       ├── • project
-│                       │   │ columns: (r_new, i_new)
-│                       │   │ estimated row count: 9 (missing stats)
-│                       │   │
-│                       │   └── • scan buffer
-│                       │         columns: (r, s, i, j, r_new, s_new, i_new, check1)
-│                       │         label: buffer 1
-│                       │
-│                       └── • values
-│                             columns: ("lookup_join_const_col_@17")
-│                             size: 1 column, 3 rows
-│                             row 0, expr 0: 'us-east'
-│                             row 1, expr 0: 'us-west'
-│                             row 2, expr 0: 'eu-west'
+│                       └── • project
+│                           │ columns: (r, i, r_new, i_new, rownum)
+│                           │ estimated row count: 31 (missing stats)
+│                           │
+│                           └── • lookup join (inner)
+│                               │ columns: (r_new, i_new, rownum, "lookup_join_const_col_@17", r, i)
+│                               │ table: uniq_enum@uniq_enum_pkey
+│                               │ equality: (lookup_join_const_col_@17, i_new) = (r,i)
+│                               │ equality cols are key
+│                               │ pred: r_new != r
+│                               │
+│                               └── • cross join (inner)
+│                                   │ columns: (r_new, i_new, rownum, "lookup_join_const_col_@17")
+│                                   │ estimated row count: 28 (missing stats)
+│                                   │
+│                                   ├── • ordinality
+│                                   │   │ columns: (r_new, i_new, rownum)
+│                                   │   │ estimated row count: 9 (missing stats)
+│                                   │   │
+│                                   │   └── • project
+│                                   │       │ columns: (r_new, i_new)
+│                                   │       │ estimated row count: 9 (missing stats)
+│                                   │       │
+│                                   │       └── • scan buffer
+│                                   │             columns: (r, s, i, j, r_new, s_new, i_new, check1)
+│                                   │             label: buffer 1
+│                                   │
+│                                   └── • values
+│                                         columns: ("lookup_join_const_col_@17")
+│                                         size: 1 column, 3 rows
+│                                         row 0, expr 0: 'us-east'
+│                                         row 1, expr 0: 'us-west'
+│                                         row 2, expr 0: 'eu-west'
 │
 └── • constraint-check
     │
@@ -2228,31 +2278,47 @@ vectorized: true
                 │ columns: (r_new, s_new, i_new, j)
                 │ estimated row count: 3 (missing stats)
                 │
-                └── • lookup join (semi)
-                    │ columns: (r_new, s_new, i_new, j, "lookup_join_const_col_@27")
-                    │ table: uniq_enum@uniq_enum_r_s_j_key
-                    │ equality: (lookup_join_const_col_@27, s_new, j) = (r,s,j)
-                    │ equality cols are key
-                    │ pred: (r_new != r) OR (i_new != i)
+                └── • distinct
+                    │ columns: (r_new, s_new, i_new, j, rownum)
+                    │ estimated row count: 0 (missing stats)
+                    │ distinct on: rownum
                     │
-                    └── • cross join (inner)
-                        │ columns: (r_new, s_new, i_new, j, "lookup_join_const_col_@27")
-                        │ estimated row count: 28 (missing stats)
+                    └── • project
+                        │ columns: (r_new, s_new, i_new, j, rownum)
                         │
-                        ├── • project
-                        │   │ columns: (r_new, s_new, i_new, j)
-                        │   │ estimated row count: 9 (missing stats)
-                        │   │
-                        │   └── • scan buffer
-                        │         columns: (r, s, i, j, r_new, s_new, i_new, check1)
-                        │         label: buffer 1
-                        │
-                        └── • values
-                              columns: ("lookup_join_const_col_@27")
-                              size: 1 column, 3 rows
-                              row 0, expr 0: 'us-east'
-                              row 1, expr 0: 'us-west'
-                              row 2, expr 0: 'eu-west'
+                        └── • project
+                            │ columns: (r, s, i, j, r_new, s_new, i_new, j, rownum)
+                            │ estimated row count: 0 (missing stats)
+                            │
+                            └── • lookup join (inner)
+                                │ columns: (r_new, s_new, i_new, j, rownum, "lookup_join_const_col_@27", r, s, i, j)
+                                │ table: uniq_enum@uniq_enum_r_s_j_key
+                                │ equality: (lookup_join_const_col_@27, s_new, j) = (r,s,j)
+                                │ equality cols are key
+                                │ pred: (r_new != r) OR (i_new != i)
+                                │
+                                └── • cross join (inner)
+                                    │ columns: (r_new, s_new, i_new, j, rownum, "lookup_join_const_col_@27")
+                                    │ estimated row count: 28 (missing stats)
+                                    │
+                                    ├── • ordinality
+                                    │   │ columns: (r_new, s_new, i_new, j, rownum)
+                                    │   │ estimated row count: 9 (missing stats)
+                                    │   │
+                                    │   └── • project
+                                    │       │ columns: (r_new, s_new, i_new, j)
+                                    │       │ estimated row count: 9 (missing stats)
+                                    │       │
+                                    │       └── • scan buffer
+                                    │             columns: (r, s, i, j, r_new, s_new, i_new, check1)
+                                    │             label: buffer 1
+                                    │
+                                    └── • values
+                                          columns: ("lookup_join_const_col_@27")
+                                          size: 1 column, 3 rows
+                                          row 0, expr 0: 'us-east'
+                                          row 1, expr 0: 'us-west'
+                                          row 2, expr 0: 'eu-west'
 
 # None of the updated values have nulls.
 query T
@@ -2507,39 +2573,25 @@ vectorized: true
             │ columns: (b_new)
             │ estimated row count: 0
             │
-            └── • project
+            └── • lookup join (semi)
                 │ columns: (r, a, b_new, c)
                 │ estimated row count: 0
+                │ table: uniq_partial_enum@uniq_partial_enum_r_b_idx (partial index)
+                │ lookup condition: (b_new = b) AND (r IN ('us-east', 'us-west', 'eu-west'))
+                │ pred: (r != r) OR (a != a)
                 │
-                └── • lookup join (semi)
-                    │ columns: ("lookup_join_const_col_@16", r, a, b_new, c)
-                    │ table: uniq_partial_enum@uniq_partial_enum_r_b_idx (partial index)
-                    │ equality: (lookup_join_const_col_@16, b_new) = (r,b)
-                    │ pred: (r != r) OR (a != a)
+                └── • filter
+                    │ columns: (r, a, b_new, c)
+                    │ estimated row count: 1
+                    │ filter: c IN ('bar', 'baz', 'foo')
                     │
-                    └── • cross join (inner)
-                        │ columns: ("lookup_join_const_col_@16", r, a, b_new, c)
-                        │ estimated row count: 3
+                    └── • project
+                        │ columns: (r, a, b_new, c)
+                        │ estimated row count: 1
                         │
-                        ├── • values
-                        │     columns: ("lookup_join_const_col_@16")
-                        │     size: 1 column, 3 rows
-                        │     row 0, expr 0: 'us-east'
-                        │     row 1, expr 0: 'us-west'
-                        │     row 2, expr 0: 'eu-west'
-                        │
-                        └── • filter
-                            │ columns: (r, a, b_new, c)
-                            │ estimated row count: 1
-                            │ filter: c IN ('bar', 'baz', 'foo')
-                            │
-                            └── • project
-                                │ columns: (r, a, b_new, c)
-                                │ estimated row count: 1
-                                │
-                                └── • scan buffer
-                                      columns: (r, a, b, b_new, partial_index_put1, partial_index_put1, c)
-                                      label: buffer 1
+                        └── • scan buffer
+                              columns: (r, a, b, b_new, partial_index_put1, partial_index_put1, c)
+                              label: buffer 1
 
 # By default, we do not require checks on UUID columns set to gen_random_uuid(),
 # but we do for UUID columns set to other values.
@@ -3407,31 +3459,47 @@ vectorized: true
 │               │ columns: (upsert_r, upsert_i)
 │               │ estimated row count: 1 (missing stats)
 │               │
-│               └── • lookup join (semi)
-│                   │ columns: ("lookup_join_const_col_@20", upsert_r, upsert_i)
-│                   │ table: uniq_enum@uniq_enum_pkey
-│                   │ equality: (lookup_join_const_col_@20, upsert_i) = (r,i)
-│                   │ equality cols are key
-│                   │ pred: upsert_r != r
+│               └── • distinct
+│                   │ columns: (upsert_r, upsert_i, rownum)
+│                   │ estimated row count: 2 (missing stats)
+│                   │ distinct on: rownum
 │                   │
-│                   └── • cross join (inner)
-│                       │ columns: ("lookup_join_const_col_@20", upsert_r, upsert_i)
-│                       │ estimated row count: 6 (missing stats)
-│                       │
-│                       ├── • values
-│                       │     columns: ("lookup_join_const_col_@20")
-│                       │     size: 1 column, 3 rows
-│                       │     row 0, expr 0: 'us-east'
-│                       │     row 1, expr 0: 'us-west'
-│                       │     row 2, expr 0: 'eu-west'
+│                   └── • project
+│                       │ columns: (upsert_r, upsert_i, rownum)
 │                       │
 │                       └── • project
-│                           │ columns: (upsert_r, upsert_i)
-│                           │ estimated row count: 2 (missing stats)
+│                           │ columns: (r, i, upsert_r, upsert_i, rownum)
+│                           │ estimated row count: 7 (missing stats)
 │                           │
-│                           └── • scan buffer
-│                                 columns: (column1, column2, column3, column4, r, s, i, j, column2, column4, r, check1, upsert_r, upsert_i)
-│                                 label: buffer 1
+│                           └── • lookup join (inner)
+│                               │ columns: ("lookup_join_const_col_@20", upsert_r, upsert_i, rownum, r, i)
+│                               │ table: uniq_enum@uniq_enum_pkey
+│                               │ equality: (lookup_join_const_col_@20, upsert_i) = (r,i)
+│                               │ equality cols are key
+│                               │ pred: upsert_r != r
+│                               │
+│                               └── • cross join (inner)
+│                                   │ columns: ("lookup_join_const_col_@20", upsert_r, upsert_i, rownum)
+│                                   │ estimated row count: 6 (missing stats)
+│                                   │
+│                                   ├── • values
+│                                   │     columns: ("lookup_join_const_col_@20")
+│                                   │     size: 1 column, 3 rows
+│                                   │     row 0, expr 0: 'us-east'
+│                                   │     row 1, expr 0: 'us-west'
+│                                   │     row 2, expr 0: 'eu-west'
+│                                   │
+│                                   └── • ordinality
+│                                       │ columns: (upsert_r, upsert_i, rownum)
+│                                       │ estimated row count: 2 (missing stats)
+│                                       │
+│                                       └── • project
+│                                           │ columns: (upsert_r, upsert_i)
+│                                           │ estimated row count: 2 (missing stats)
+│                                           │
+│                                           └── • scan buffer
+│                                                 columns: (column1, column2, column3, column4, r, s, i, j, column2, column4, r, check1, upsert_r, upsert_i)
+│                                                 label: buffer 1
 │
 └── • constraint-check
     │
@@ -3446,31 +3514,47 @@ vectorized: true
                 │ columns: (upsert_r, column2, upsert_i, column4)
                 │ estimated row count: 1 (missing stats)
                 │
-                └── • lookup join (semi)
-                    │ columns: ("lookup_join_const_col_@30", upsert_r, column2, upsert_i, column4)
-                    │ table: uniq_enum@uniq_enum_r_s_j_key
-                    │ equality: (lookup_join_const_col_@30, column2, column4) = (r,s,j)
-                    │ equality cols are key
-                    │ pred: (upsert_r != r) OR (upsert_i != i)
+                └── • distinct
+                    │ columns: (upsert_r, column2, upsert_i, column4, rownum)
+                    │ estimated row count: 0 (missing stats)
+                    │ distinct on: rownum
                     │
-                    └── • cross join (inner)
-                        │ columns: ("lookup_join_const_col_@30", upsert_r, column2, upsert_i, column4)
-                        │ estimated row count: 6 (missing stats)
-                        │
-                        ├── • values
-                        │     columns: ("lookup_join_const_col_@30")
-                        │     size: 1 column, 3 rows
-                        │     row 0, expr 0: 'us-east'
-                        │     row 1, expr 0: 'us-west'
-                        │     row 2, expr 0: 'eu-west'
+                    └── • project
+                        │ columns: (upsert_r, column2, upsert_i, column4, rownum)
                         │
                         └── • project
-                            │ columns: (upsert_r, column2, upsert_i, column4)
-                            │ estimated row count: 2 (missing stats)
+                            │ columns: (r, s, i, j, upsert_r, column2, upsert_i, column4, rownum)
+                            │ estimated row count: 0 (missing stats)
                             │
-                            └── • scan buffer
-                                  columns: (column1, column2, column3, column4, r, s, i, j, column2, column4, r, check1, upsert_r, upsert_i)
-                                  label: buffer 1
+                            └── • lookup join (inner)
+                                │ columns: ("lookup_join_const_col_@30", upsert_r, column2, upsert_i, column4, rownum, r, s, i, j)
+                                │ table: uniq_enum@uniq_enum_r_s_j_key
+                                │ equality: (lookup_join_const_col_@30, column2, column4) = (r,s,j)
+                                │ equality cols are key
+                                │ pred: (upsert_r != r) OR (upsert_i != i)
+                                │
+                                └── • cross join (inner)
+                                    │ columns: ("lookup_join_const_col_@30", upsert_r, column2, upsert_i, column4, rownum)
+                                    │ estimated row count: 6 (missing stats)
+                                    │
+                                    ├── • values
+                                    │     columns: ("lookup_join_const_col_@30")
+                                    │     size: 1 column, 3 rows
+                                    │     row 0, expr 0: 'us-east'
+                                    │     row 1, expr 0: 'us-west'
+                                    │     row 2, expr 0: 'eu-west'
+                                    │
+                                    └── • ordinality
+                                        │ columns: (upsert_r, column2, upsert_i, column4, rownum)
+                                        │ estimated row count: 2 (missing stats)
+                                        │
+                                        └── • project
+                                            │ columns: (upsert_r, column2, upsert_i, column4)
+                                            │ estimated row count: 2 (missing stats)
+                                            │
+                                            └── • scan buffer
+                                                  columns: (column1, column2, column3, column4, r, s, i, j, column2, column4, r, check1, upsert_r, upsert_i)
+                                                  label: buffer 1
 
 # Test that we use the index when available for the ON CONFLICT checks.
 query T
@@ -3558,31 +3642,47 @@ vectorized: true
                 │ columns: (upsert_r, upsert_i)
                 │ estimated row count: 1 (missing stats)
                 │
-                └── • lookup join (semi)
-                    │ columns: ("lookup_join_const_col_@23", upsert_r, upsert_i)
-                    │ table: uniq_enum@uniq_enum_pkey
-                    │ equality: (lookup_join_const_col_@23, upsert_i) = (r,i)
-                    │ equality cols are key
-                    │ pred: upsert_r != r
+                └── • distinct
+                    │ columns: (upsert_r, upsert_i, rownum)
+                    │ estimated row count: 2 (missing stats)
+                    │ distinct on: rownum
                     │
-                    └── • cross join (inner)
-                        │ columns: ("lookup_join_const_col_@23", upsert_r, upsert_i)
-                        │ estimated row count: 6 (missing stats)
-                        │
-                        ├── • values
-                        │     columns: ("lookup_join_const_col_@23")
-                        │     size: 1 column, 3 rows
-                        │     row 0, expr 0: 'us-east'
-                        │     row 1, expr 0: 'us-west'
-                        │     row 2, expr 0: 'eu-west'
+                    └── • project
+                        │ columns: (upsert_r, upsert_i, rownum)
                         │
                         └── • project
-                            │ columns: (upsert_r, upsert_i)
-                            │ estimated row count: 2 (missing stats)
+                            │ columns: (r, i, upsert_r, upsert_i, rownum)
+                            │ estimated row count: 7 (missing stats)
                             │
-                            └── • scan buffer
-                                  columns: (column1, column2, column3, column4, r, s, i, j, upsert_i, r, check1, upsert_r)
-                                  label: buffer 1
+                            └── • lookup join (inner)
+                                │ columns: ("lookup_join_const_col_@23", upsert_r, upsert_i, rownum, r, i)
+                                │ table: uniq_enum@uniq_enum_pkey
+                                │ equality: (lookup_join_const_col_@23, upsert_i) = (r,i)
+                                │ equality cols are key
+                                │ pred: upsert_r != r
+                                │
+                                └── • cross join (inner)
+                                    │ columns: ("lookup_join_const_col_@23", upsert_r, upsert_i, rownum)
+                                    │ estimated row count: 6 (missing stats)
+                                    │
+                                    ├── • values
+                                    │     columns: ("lookup_join_const_col_@23")
+                                    │     size: 1 column, 3 rows
+                                    │     row 0, expr 0: 'us-east'
+                                    │     row 1, expr 0: 'us-west'
+                                    │     row 2, expr 0: 'eu-west'
+                                    │
+                                    └── • ordinality
+                                        │ columns: (upsert_r, upsert_i, rownum)
+                                        │ estimated row count: 2 (missing stats)
+                                        │
+                                        └── • project
+                                            │ columns: (upsert_r, upsert_i)
+                                            │ estimated row count: 2 (missing stats)
+                                            │
+                                            └── • scan buffer
+                                                  columns: (column1, column2, column3, column4, r, s, i, j, upsert_i, r, check1, upsert_r)
+                                                  label: buffer 1
 
 # None of the upserted values have nulls.
 query T
@@ -4083,39 +4183,25 @@ vectorized: true
             │ columns: (column3)
             │ estimated row count: 1
             │
-            └── • project
+            └── • lookup join (semi)
                 │ columns: (upsert_r, upsert_a, column3, column4)
                 │ estimated row count: 1
+                │ table: uniq_partial_enum@uniq_partial_enum_r_b_idx (partial index)
+                │ lookup condition: (column3 = b) AND (r IN ('us-east', 'us-west', 'eu-west'))
+                │ pred: (upsert_r != r) OR (upsert_a != a)
                 │
-                └── • lookup join (semi)
-                    │ columns: ("lookup_join_const_col_@22", upsert_r, upsert_a, column3, column4)
-                    │ table: uniq_partial_enum@uniq_partial_enum_r_b_idx (partial index)
-                    │ equality: (lookup_join_const_col_@22, column3) = (r,b)
-                    │ pred: (upsert_r != r) OR (upsert_a != a)
+                └── • filter
+                    │ columns: (upsert_r, upsert_a, column3, column4)
+                    │ estimated row count: 2
+                    │ filter: column4 IN ('bar', 'baz', 'foo')
                     │
-                    └── • cross join (inner)
-                        │ columns: ("lookup_join_const_col_@22", upsert_r, upsert_a, column3, column4)
-                        │ estimated row count: 6
+                    └── • project
+                        │ columns: (upsert_r, upsert_a, column3, column4)
+                        │ estimated row count: 2
                         │
-                        ├── • values
-                        │     columns: ("lookup_join_const_col_@22")
-                        │     size: 1 column, 3 rows
-                        │     row 0, expr 0: 'us-east'
-                        │     row 1, expr 0: 'us-west'
-                        │     row 2, expr 0: 'eu-west'
-                        │
-                        └── • filter
-                            │ columns: (upsert_r, upsert_a, column3, column4)
-                            │ estimated row count: 2
-                            │ filter: column4 IN ('bar', 'baz', 'foo')
-                            │
-                            └── • project
-                                │ columns: (upsert_r, upsert_a, column3, column4)
-                                │ estimated row count: 2
-                                │
-                                └── • scan buffer
-                                      columns: (column1, column2, column3, column4, r, a, b, c, column3, column4, r, check1, partial_index_put1, partial_index_del1, upsert_r, upsert_a)
-                                      label: buffer 1
+                        └── • scan buffer
+                              columns: (column1, column2, column3, column4, r, a, b, c, column3, column4, r, check1, partial_index_put1, partial_index_del1, upsert_r, upsert_a)
+                              label: buffer 1
 
 # Test that we use the partial index when available for de-duplicating INSERT ON
 # CONFLICT DO UPDATE rows before inserting.

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -456,12 +456,13 @@ func (c *CustomFuncs) generateLookupJoinsImpl(
 			}
 
 			if len(foundVals) > 1 {
-				if joinType == opt.LeftJoinOp || joinType == opt.AntiJoinOp {
-					// We cannot use the method constructJoinWithConstants to create a cross
-					// join for left or anti joins, because constructing a cross join with
-					// foundVals will increase the size of the input. As a result,
-					// non-matching input rows will show up more than once in the output,
-					// which is incorrect (see #59615).
+				if joinType == opt.LeftJoinOp || joinType == opt.SemiJoinOp || joinType == opt.AntiJoinOp {
+					// We cannot use the method constructJoinWithConstants to
+					// create a cross join for left, semi, or anti joins,
+					// because constructing a cross join with foundVals will
+					// increase the size of the input. As a result, non-matching
+					// input rows will show up more than once in the output,
+					// which is incorrect (see #59615 and #78685).
 					shouldBuildMultiSpanLookupJoin = true
 					break
 				}

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -2834,8 +2834,8 @@ exec-ddl
 DROP INDEX shard_b_null_idx
 ----
 
-# Regression test for #59615. Ensure that invalid lookup joins are not created
-# for left and anti joins.
+# Regression test for #59615 and #78681. Ensure that invalid lookup joins are
+# not created for left, semi, and anti joins.
 exec-ddl
 CREATE TABLE t59615 (
   x INT NOT NULL CHECK (x in (1, 3)),
@@ -2856,6 +2856,26 @@ left-join (lookup t59615 [as=t])
  │         └── x:2 IN (1, 3) [outer=(2), constraints=(/2: [/1 - /1] [/3 - /3]; tight)]
  ├── cardinality: [2 - ]
  ├── fd: (2,3)-->(4)
+ ├── values
+ │    ├── columns: column1:1!null
+ │    ├── cardinality: [2 - 2]
+ │    ├── (1,)
+ │    └── (2,)
+ └── filters (true)
+
+# Regression test for #78681.
+opt expect=GenerateLookupJoins
+SELECT * FROM (VALUES (1), (2)) AS u(y) WHERE EXISTS (
+  SELECT * FROM t59615 t WHERE u.y = t.y
+)
+----
+semi-join (lookup t59615 [as=t])
+ ├── columns: y:1!null
+ ├── lookup expression
+ │    └── filters
+ │         ├── column1:1 = y:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+ │         └── x:2 IN (1, 3) [outer=(2), constraints=(/2: [/1 - /1] [/3 - /3]; tight)]
+ ├── cardinality: [0 - 2]
  ├── values
  │    ├── columns: column1:1!null
  │    ├── cardinality: [2 - 2]
@@ -5095,20 +5115,13 @@ SELECT m FROM small WHERE EXISTS (SELECT * FROM virt WHERE m = virt.v1)
 ----
 semi-join (lookup virt@j_v1)
  ├── columns: m:1
- ├── key columns: [16 1] = [8 9]
+ ├── lookup expression
+ │    └── filters
+ │         ├── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
+ │         └── j:8 IN (10, 20, 30) [outer=(8), constraints=(/8: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
  ├── immutable
- ├── inner-join (cross)
- │    ├── columns: m:1 "lookup_join_const_col_@8":16!null
- │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
- │    ├── scan small
- │    │    └── columns: m:1
- │    ├── values
- │    │    ├── columns: "lookup_join_const_col_@8":16!null
- │    │    ├── cardinality: [3 - 3]
- │    │    ├── (10,)
- │    │    ├── (20,)
- │    │    └── (30,)
- │    └── filters (true)
+ ├── scan small
+ │    └── columns: m:1
  └── filters (true)
 
 # Anti-join with multiple constant values based on optional filters.
@@ -5737,20 +5750,13 @@ SELECT m FROM small WHERE EXISTS (SELECT * FROM virt WHERE virt.l IN (1, 2, 3) A
 ----
 semi-join (lookup virt@l_v1)
  ├── columns: m:1
- ├── key columns: [16 1] = [13 9]
+ ├── lookup expression
+ │    └── filters
+ │         ├── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
+ │         └── l:13 IN (1, 2, 3) [outer=(13), constraints=(/13: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
  ├── immutable
- ├── inner-join (cross)
- │    ├── columns: m:1 "lookup_join_const_col_@13":16!null
- │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
- │    ├── scan small
- │    │    └── columns: m:1
- │    ├── values
- │    │    ├── columns: "lookup_join_const_col_@13":16!null
- │    │    ├── cardinality: [3 - 3]
- │    │    ├── (1,)
- │    │    ├── (2,)
- │    │    └── (3,)
- │    └── filters (true)
+ ├── scan small
+ │    └── columns: m:1
  └── filters (true)
 
 # Semi-join with multiple constant values for the leading lookup column and a


### PR DESCRIPTION
This commit fixes a logical correctness bug caused when
`GenerateLookupJoins` cross-joins the input of a semi-join with a set of
constant values to constrain the prefix columns of the lookup index. The
cross-join is an invalid transformation because it increases the size of
the join's input and can increase the size of the join's output.

We already avoid these cross-joins for left and anti-joins (see #59646).
When addressing those cases, the semi-join case was incorrectly assumed
to be safe.

Fixes #78681

Release note (bug fix): A bug has been fixed which caused the optimizer
to generate invalid query plans which could result in incorrect query
results. The bug, which has been present since version 21.1.0, can
appear if all of the following conditions are true: 1) the query
contains a semi-join, such as queries in the form:
`SELECT * FROM t1 WHERE EXISTS (SELECT * FROM t2 WHERE t1.a = t2.a);`,
2) the inner table has an index containing the equality column, like
`t2.a` in the example query, 3) the index contains one or more
columns that prefix the equality column, and 4) the prefix columns are
`NOT NULL` and are constrained to a set of constant values via a `CHECK`
constraint or an `IN` condition in the filter.
