### PR TITLE
sql: allow extra columns to be specified for COPY

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3176,6 +3176,10 @@ func (m *sessionDataMutator) SetEnableImplicitTransactionForBatchStatements(val 
 	m.data.EnableImplicitTransactionForBatchStatements = val
 }
 
+func (m *sessionDataMutator) SetCopyNumTrailingFields(val int32) {
+	m.data.CopyNumTrailingFields = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4686,6 +4686,7 @@ bytea_output                                          hex
 check_function_bodies                                 on
 client_encoding                                       UTF8
 client_min_messages                                   notice
+copy_num_trailing_fields                              0
 cost_scans_with_default_col_size                      off
 database                                              test
 datestyle                                             ISO, MDY

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4062,6 +4062,7 @@ bytea_output                                          hex                 NULL  
 check_function_bodies                                 on                  NULL      NULL        NULL        string
 client_encoding                                       UTF8                NULL      NULL        NULL        string
 client_min_messages                                   notice              NULL      NULL        NULL        string
+copy_num_trailing_fields                              0                   NULL      NULL        NULL        string
 cost_scans_with_default_col_size                      off                 NULL      NULL        NULL        string
 database                                              test                NULL      NULL        NULL        string
 datestyle                                             ISO, MDY            NULL      NULL        NULL        string
@@ -4181,6 +4182,7 @@ bytea_output                                          hex                 NULL  
 check_function_bodies                                 on                  NULL  user     NULL      on                  on
 client_encoding                                       UTF8                NULL  user     NULL      UTF8                UTF8
 client_min_messages                                   notice              NULL  user     NULL      notice              notice
+copy_num_trailing_fields                              0                   NULL  user     NULL      0                   0
 cost_scans_with_default_col_size                      off                 NULL  user     NULL      off                 off
 database                                              test                NULL  user     NULL      ·                   test
 datestyle                                             ISO, MDY            NULL  user     NULL      ISO, MDY            ISO, MDY
@@ -4294,6 +4296,7 @@ bytea_output                                          NULL    NULL     NULL     
 check_function_bodies                                 NULL    NULL     NULL     NULL        NULL
 client_encoding                                       NULL    NULL     NULL     NULL        NULL
 client_min_messages                                   NULL    NULL     NULL     NULL        NULL
+copy_num_trailing_fields                              NULL    NULL     NULL     NULL        NULL
 cost_scans_with_default_col_size                      NULL    NULL     NULL     NULL        NULL
 crdb_version                                          NULL    NULL     NULL     NULL        NULL
 database                                              NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -815,3 +815,17 @@ query T
 SHOW opt_split_scan_limit
 ----
 2048
+
+statement error cannot set copy_num_trailing_fields to a negative value
+SET copy_num_trailing_fields = -1
+
+statement error cannot set copy_num_trailing_fields to a value greater than 2147483647
+SET copy_num_trailing_fields = 8000000000
+
+statement ok
+SET copy_num_trailing_fields = 12
+
+query T
+SHOW copy_num_trailing_fields
+----
+12

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -34,6 +34,7 @@ bytea_output                                          hex
 check_function_bodies                                 on
 client_encoding                                       UTF8
 client_min_messages                                   notice
+copy_num_trailing_fields                              0
 cost_scans_with_default_col_size                      off
 database                                              test
 datestyle                                             ISO, MDY

--- a/pkg/sql/pgwire/testdata/pgtest/copy
+++ b/pkg/sql/pgwire/testdata/pgtest/copy
@@ -46,6 +46,106 @@ ReadyForQuery
 {"Type":"CommandComplete","CommandTag":"SELECT 3"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
+# Extra fields.
+
+send
+Query {"String": "DELETE FROM t"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DELETE 3"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "COPY t FROM STDIN"}
+CopyData {"Data": "1\tblah\tbad\n"}
+CopyDone
+----
+
+until
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"CopyInResponse","ColumnFormatCodes":[0,0]}
+{"Type":"ErrorResponse","Code":"22P04"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "COPY t FROM STDIN CSV"}
+CopyData {"Data": "2,blah,bad\n"}
+CopyDone
+----
+
+until
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"CopyInResponse","ColumnFormatCodes":[0,0]}
+{"Type":"ErrorResponse","Code":"22P04"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Set copy_num_trailing_fields - now it should be allowed.
+send
+Query {"String": "SET copy_num_trailing_fields = 1"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"SET"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "COPY t FROM STDIN"}
+CopyData {"Data": "1\tblah\tbad\n"}
+CopyDone
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CopyInResponse","ColumnFormatCodes":[0,0]}
+{"Type":"CommandComplete","CommandTag":"COPY 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "COPY t FROM STDIN CSV"}
+CopyData {"Data": "2,blah,bad\n"}
+CopyDone
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CopyInResponse","ColumnFormatCodes":[0,0]}
+{"Type":"CommandComplete","CommandTag":"COPY 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "SELECT * FROM t ORDER BY i"}
+----
+
+until ignore=RowDescription
+ReadyForQuery
+----
+{"Type":"DataRow","Values":[{"text":"1"},{"text":"blah"}]}
+{"Type":"DataRow","Values":[{"text":"2"},{"text":"blah"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 2"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "SET copy_num_trailing_fields = 0"}
+----
+
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"SET"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
 # Invalid ESCAPE syntax.
 send
 Query {"String": "COPY t FROM STDIN ESCAPE 'xxx'"}

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -242,6 +242,8 @@ message LocalOnlySessionData {
   // Setting this to false is a divergence from the pgwire protocol, but
   // matches the behavior of CockroachDB v21.2 and earlier.
   bool enable_implicit_transaction_for_batch_statements = 66;
+  // CopyNumTrailingFields is the trailing fields as input for COPY.
+  int32 copy_num_trailing_fields = 67;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2025,6 +2025,33 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalTrue,
 	},
+
+	// CockroachDB extension.
+	`copy_num_trailing_fields`: {
+		GetStringVal: makeIntGetStringValFn(`copy_num_trailing_fields`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := strconv.ParseInt(s, 10, 64)
+			if err != nil {
+				return err
+			}
+			if b < 0 {
+				return pgerror.Newf(pgcode.InvalidParameterValue,
+					"cannot set copy_num_trailing_fields to a negative value")
+			}
+			if b > math.MaxInt32 {
+				return pgerror.Newf(pgcode.InvalidParameterValue,
+					"cannot set copy_num_trailing_fields to a value greater than %d", math.MaxInt32)
+			}
+			m.SetCopyNumTrailingFields(int32(b))
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) (string, error) {
+			return strconv.FormatInt(int64(evalCtx.SessionData().CopyNumTrailingFields), 10), nil
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return strconv.FormatInt(0, 10)
+		},
+	},
 }
 
 const compatErrMsg = "this parameter is currently recognized only for compatibility and has no effect in CockroachDB."


### PR DESCRIPTION
The intention is for this to be used with AWS DMS in the PGURL with
the additional `--options=-c%20copy_num_trailing_fields=1`
speciifed.

Refs: #78688

Release note (sql change): Introduce a `copy_num_trailing_fields`
variable, which allows extra trailing columns for COPY.