### PR TITLE
sql: introduce pg_catalog_hide_hidden_columns session setting

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3176,6 +3176,10 @@ func (m *sessionDataMutator) SetEnableImplicitTransactionForBatchStatements(val 
 	m.data.EnableImplicitTransactionForBatchStatements = val
 }
 
+func (m *sessionDataMutator) SetPGCatalogHideHiddenColumns(val bool) {
+	m.data.PGCatalogHideHiddenColumns = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4755,6 +4755,7 @@ optimizer_use_multicol_stats                          on
 override_multi_region_zone_config                     off
 parallelize_multi_key_lookup_joins_enabled            off
 password_encryption                                   scram-sha-256
+pg_catalog_hide_hidden_columns                        off
 prefer_lookup_joins_for_fks                           off
 propagate_input_ordering                              off
 reorder_joins_limit                                   8

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4129,6 +4129,7 @@ optimizer_use_multicol_stats                          on                  NULL  
 override_multi_region_zone_config                     off                 NULL      NULL        NULL        string
 parallelize_multi_key_lookup_joins_enabled            off                 NULL      NULL        NULL        string
 password_encryption                                   scram-sha-256       NULL      NULL        NULL        string
+pg_catalog_hide_hidden_columns                        off                 NULL      NULL        NULL        string
 prefer_lookup_joins_for_fks                           off                 NULL      NULL        NULL        string
 propagate_input_ordering                              off                 NULL      NULL        NULL        string
 reorder_joins_limit                                   8                   NULL      NULL        NULL        string
@@ -4248,6 +4249,7 @@ optimizer_use_multicol_stats                          on                  NULL  
 override_multi_region_zone_config                     off                 NULL  user     NULL      off                 off
 parallelize_multi_key_lookup_joins_enabled            off                 NULL  user     NULL      false               false
 password_encryption                                   scram-sha-256       NULL  user     NULL      scram-sha-256       scram-sha-256
+pg_catalog_hide_hidden_columns                        off                 NULL  user     NULL      off                 off
 prefer_lookup_joins_for_fks                           off                 NULL  user     NULL      off                 off
 propagate_input_ordering                              off                 NULL  user     NULL      off                 off
 reorder_joins_limit                                   8                   NULL  user     NULL      8                   8
@@ -4363,6 +4365,7 @@ optimizer_use_multicol_stats                          NULL    NULL     NULL     
 override_multi_region_zone_config                     NULL    NULL     NULL     NULL        NULL
 parallelize_multi_key_lookup_joins_enabled            NULL    NULL     NULL     NULL        NULL
 password_encryption                                   NULL    NULL     NULL     NULL        NULL
+pg_catalog_hide_hidden_columns                        NULL    NULL     NULL     NULL        NULL
 prefer_lookup_joins_for_fks                           NULL    NULL     NULL     NULL        NULL
 propagate_input_ordering                              NULL    NULL     NULL     NULL        NULL
 reorder_joins_limit                                   NULL    NULL     NULL     NULL        NULL
@@ -5619,3 +5622,50 @@ JOIN pg_authid ON usesysid = oid
 ----
 passed
 true
+
+# Test hiding hidden columns.
+statement ok
+CREATE TABLE hidden_tbl (id INT, hidden INT NOT VISIBLE)
+
+query OTOITTT colnames
+SELECT ad.oid, c.relname, adrelid, adnum, adbin, adsrc, pg_get_expr(ad.adbin, ad.adrelid)
+FROM pg_catalog.pg_attrdef ad
+JOIN pg_catalog.pg_class c ON ad.adrelid = c.oid
+WHERE c.relname = 'hidden_tbl'
+----
+oid         relname     adrelid  adnum  adbin           adsrc           pg_get_expr
+3679639651  hidden_tbl  188      3      unique_rowid()  unique_rowid()  unique_rowid()
+
+query OTTOIIIII colnames
+SELECT attrelid, c.relname, attname, atttypid, attstattarget, attlen, attnum, attndims, attcacheoff
+FROM pg_catalog.pg_attribute a
+JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
+WHERE c.relname = 'hidden_tbl'
+----
+attrelid  relname     attname  atttypid  attstattarget  attlen  attnum  attndims  attcacheoff
+188       hidden_tbl  id       20        0              8       1       0         -1
+188       hidden_tbl  hidden   20        0              8       2       0         -1
+188       hidden_tbl  rowid    20        0              8       3       0         -1
+
+statement ok
+SET pg_catalog_hide_hidden_columns = true
+
+query OTOITTT colnames
+SELECT ad.oid, c.relname, adrelid, adnum, adbin, adsrc, pg_get_expr(ad.adbin, ad.adrelid)
+FROM pg_catalog.pg_attrdef ad
+JOIN pg_catalog.pg_class c ON ad.adrelid = c.oid
+WHERE c.relname = 'hidden_tbl'
+----
+oid  relname  adrelid  adnum  adbin  adsrc  pg_get_expr
+
+query OTTOIIIII colnames
+SELECT attrelid, c.relname, attname, atttypid, attstattarget, attlen, attnum, attndims, attcacheoff
+FROM pg_catalog.pg_attribute a
+JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
+WHERE c.relname = 'hidden_tbl'
+----
+attrelid  relname     attname  atttypid  attstattarget  attlen  attnum  attndims  attcacheoff
+188       hidden_tbl  id       20        0              8       1       0         -1
+
+statement ok
+SET pg_catalog_hide_hidden_columns = false

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -101,6 +101,7 @@ optimizer_use_multicol_stats                          on
 override_multi_region_zone_config                     off
 parallelize_multi_key_lookup_joins_enabled            off
 password_encryption                                   scram-sha-256
+pg_catalog_hide_hidden_columns                        off
 prefer_lookup_joins_for_fks                           off
 propagate_input_ordering                              off
 reorder_joins_limit                                   8

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -358,6 +358,9 @@ https://www.postgresql.org/docs/9.5/catalog-pg-attrdef.html`,
 				// pg_attrdef only expects rows for columns with default values.
 				continue
 			}
+			if column.IsHidden() && p.SessionData().PGCatalogHideHiddenColumns {
+				continue
+			}
 			displayExpr, err := schemaexpr.FormatExprForDisplay(
 				ctx, table, column.GetDefaultExpr(), &p.semaCtx, p.SessionData(), tree.FmtPGCatalog,
 			)
@@ -387,8 +390,11 @@ https://www.postgresql.org/docs/12/catalog-pg-attribute.html`,
 		table catalog.TableDescriptor,
 		lookup simpleSchemaResolver,
 		addRow func(...tree.Datum) error) error {
-		// addColumn adds adds either a table or a index column to the pg_attribute table.
+		// addColumn adds either a table or a index column to the pg_attribute table.
 		addColumn := func(column catalog.Column, attRelID tree.Datum, attNum uint32) error {
+			if column.IsHidden() && p.SessionData().PGCatalogHideHiddenColumns {
+				return nil
+			}
 			colTyp := column.GetType()
 			// Sets the attgenerated column to 's' if the column is generated/
 			// computed stored, "v" if virtual, zero byte otherwise.

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -242,6 +242,9 @@ message LocalOnlySessionData {
   // Setting this to false is a divergence from the pgwire protocol, but
   // matches the behavior of CockroachDB v21.2 and earlier.
   bool enable_implicit_transaction_for_batch_statements = 66;
+  // PGCatalogHideHiddenColumns is true if hidden columns should be omitted
+  // from pg_catalog tables.
+  bool pg_catalog_hide_hidden_columns = 67 [(gogoproto.customname)="PGCatalogHideHiddenColumns"];
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2025,6 +2025,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalTrue,
 	},
+
+	// CockroachDB extension.
+	`pg_catalog_hide_hidden_columns`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`pg_catalog_hide_hidden_columns`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("pg_catalog_hide_hidden_columns", s)
+			if err != nil {
+				return err
+			}
+			m.SetPGCatalogHideHiddenColumns(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().PGCatalogHideHiddenColumns), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 const compatErrMsg = "this parameter is currently recognized only for compatibility and has no effect in CockroachDB."


### PR DESCRIPTION
PG has no concept of invisible columns, but CRDB does. This can fool
tools in thinking a column may exist, but may not actually show up in
results.

Release note (sql change): Introduce a pg_catalog_hide_hidden_columns
session variable, which hides hidden columns from appearing on
pg_catalog tables, e.g. pg_attrdef and pg_attributes.