### PR TITLE
colexecop: reset the internal batch in a test operator

### DIFF
--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -244,6 +244,14 @@ func (b *Bytes) copyElements(srcElementsToCopy []element, src *Bytes, destIdx in
 	// Optimize copying of the elements by copying all of them directly into the
 	// destination. This way all inlined values become correctly set, and we
 	// only need to set the non-inlined values separately.
+	//
+	// Note that this behavior results in losing the references to the old
+	// non-inlined values, even if they could be reused. If Bytes is not Reset,
+	// then that unused space in Bytes.buffer can accumulate. However, checking
+	// whether there are old non-inlined values with non-zero capacity leads to
+	// performance regressions, and in the production code we do reset the Bytes
+	// in all cases, so we accept this poor behavior in such a hypothetical /
+	// test-only scenario. See #78703 for more details.
 	copy(destElements, srcElementsToCopy)
 	// Early bounds checks.
 	_ = destElements[len(srcElementsToCopy)-1]

--- a/pkg/sql/colexecop/testutils.go
+++ b/pkg/sql/colexecop/testutils.go
@@ -108,8 +108,9 @@ func (s *RepeatableBatchSource) Next() coldata.Batch {
 	if s.batchesToReturn != 0 && s.batchesReturned > s.batchesToReturn {
 		return coldata.ZeroBatch
 	}
-	s.output.SetSelection(s.sel != nil)
+	s.output.ResetInternalBatch()
 	if s.sel != nil {
+		s.output.SetSelection(true)
 		copy(s.output.Selection()[:s.batchLen], s.sel[:s.batchLen])
 	}
 	for i, colVec := range s.colVecs {


### PR DESCRIPTION
This commit makes a test operator that "owns" a batch to properly reset
the batch on each `Next` call. This is the expectation that we forgot to
follow.

This was discovered when running `BenchmarkLikeOps` which uses a Bytes
vector. Due to the way `Bytes.Copy` is implemented, the Bytes vector's
buffer could grow arbitrarily large because the test operator never
reset the vector.

Informs: #78592.

Release note: None