### PR TITLE
backupccl: fix nil pointer exception in restore OnFailOrCancel

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -9854,3 +9854,37 @@ func TestBackupRestoreSeparateExplicitIsDefault(t *testing.T) {
 		sqlDB.Exec(t, "DROP DATABASE inc_fkdb;")
 	}
 }
+
+// TestRestoreOnFailOrCancelAfterPause is a regression test that ensures that we
+// can cancel a paused restore job. Previously, this test would result in a nil
+// pointer exception when accessing the `r.execCfg` since the resumer was not
+// correctly initialized.
+//
+// TODO(adityamaru): Migrate to datadriven test once 78430 merges.
+func TestRestoreOnFailOrCancelAfterPause(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const numAccounts = 1
+	_, sqlDB, dataDir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
+	defer cleanupFn()
+
+	sqlDB.Exec(t, `BACKUP INTO 'nodelocal://1/foo'`)
+
+	_, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, dataDir,
+		InitManualReplication, base.TestClusterArgs{
+			ServerArgs: base.TestServerArgs{
+				Knobs: base.TestingKnobs{JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()},
+			},
+		})
+	defer cleanupEmptyCluster()
+
+	// Start a restore and expect it to hit a pausepoint error.
+	sqlDBRestore.Exec(t, `SET CLUSTER SETTING jobs.debug.pausepoints = 'restore.before_load_descriptors_from_backup'`)
+	var id jobspb.JobID
+	sqlDBRestore.QueryRow(t, `RESTORE FROM LATEST IN 'nodelocal://1/foo' WITH detached`).Scan(&id)
+	jobutils.WaitForJobToPause(t, sqlDBRestore, id)
+
+	sqlDBRestore.Exec(t, `CANCEL JOB $1`, id)
+	jobutils.WaitForJobToCancel(t, sqlDBRestore, id)
+}

--- a/pkg/testutils/jobutils/jobs_verification.go
+++ b/pkg/testutils/jobutils/jobs_verification.go
@@ -46,6 +46,12 @@ func WaitForJobToPause(t testing.TB, db *sqlutils.SQLRunner, jobID jobspb.JobID)
 	waitForJobToHaveStatus(t, db, jobID, jobs.StatusPaused)
 }
 
+// WaitForJobToCancel waits for the specified job ID to be cancelled.
+func WaitForJobToCancel(t testing.TB, db *sqlutils.SQLRunner, jobID jobspb.JobID) {
+	t.Helper()
+	waitForJobToHaveStatus(t, db, jobID, jobs.StatusCanceled)
+}
+
 func waitForJobToHaveStatus(
 	t testing.TB, db *sqlutils.SQLRunner, jobID jobspb.JobID, expectedStatus jobs.Status,
 ) {


### PR DESCRIPTION
The execCfg field on the restore resumer was not being set correctly
in the OnFailOrCancel hook. This would lead to a nil pointer exception
during cleanup.

Other jobs such as import, backup use the execCfg directly off the
JobExecContext instead of storing it on the resumer. An alternative to
this fix could be to change all `r.ExecCfg` to use the execCfg on the JobExecContext.

Fixes: #76720

Release note (bug fix): Fixes a nil pointer exception during the
cleanup of a failed or cancelled restore job.