### PR TITLE
rangefeed: use raft msg based lower mem budget limit

### DIFF
--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -364,8 +364,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 	}
 	r.rangefeedMu.Unlock()
 
-	feedBudget := r.store.GetStoreConfig().RangefeedBudgetFactory.CreateBudget(r.startKey,
-		&r.store.cfg.Settings.SV)
+	feedBudget := r.store.GetStoreConfig().RangefeedBudgetFactory.CreateBudget(r.startKey)
 
 	// Create a new rangefeed.
 	desc := r.Desc()


### PR DESCRIPTION
Previously maximum memory budget per range could be lower
than maximum raft command size and is determined by total
SQL memory pool. This could cause rangefeed messages to
exceed full range budget with subsequent rangefeed restart.
This PR adds a lower boundary check for rangefeed memory
limit to ensure it is always above or equal to raft command
size.

Note that we read the command size in runtime as it is tenant writable
and could be configured in the cluster after nodes start but before 
rangefeeds for non system ranges are started. System ranges doesn't
use per range limit as they have smaller separate budget.