### PR TITLE
release-22.1: sql/rowexec: deflake TestUncertaintyErrorIsReturned

### DIFF
--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -11,6 +11,7 @@
 package rowexec
 
 import (
+	"bytes"
 	"context"
 	gosql "database/sql"
 	"fmt"
@@ -646,8 +647,8 @@ func TestUncertaintyErrorIsReturned(t *testing.T) {
 
 	filters := make([]struct {
 		syncutil.Mutex
-		enabled          bool
-		tableIDsToFilter []int
+		enabled   bool
+		keyPrefix roachpb.Key
 	}, numNodes)
 
 	var allNodeIdxs []int
@@ -665,27 +666,19 @@ func TestUncertaintyErrorIsReturned(t *testing.T) {
 							}
 							filters[node].Lock()
 							enabled := filters[node].enabled
-							tableIDsToFilter := filters[node].tableIDsToFilter
+							keyPrefix := filters[node].keyPrefix
 							filters[node].Unlock()
 							if !enabled {
 								return nil
 							}
 
-							if req, ok := ba.GetArg(roachpb.Scan); !ok {
+							req, ok := ba.GetArg(roachpb.Scan)
+							if !ok {
 								return nil
-							} else if tableIDsToFilter != nil {
-								shouldReturnUncertaintyError := false
-								for _, tableID := range tableIDsToFilter {
-									if strings.Contains(req.(*roachpb.ScanRequest).Key.String(), fmt.Sprintf("/Table/%d", tableID)) {
-										shouldReturnUncertaintyError = true
-										break
-									}
-								}
-								if !shouldReturnUncertaintyError {
-									return nil
-								}
 							}
-
+							if !bytes.HasPrefix(req.(*roachpb.ScanRequest).Key, keyPrefix) {
+								return nil
+							}
 							return roachpb.NewError(
 								roachpb.NewReadWithinUncertaintyIntervalError(
 									ba.Timestamp,
@@ -709,6 +702,7 @@ func TestUncertaintyErrorIsReturned(t *testing.T) {
 	// Create a 30-row table, split and scatter evenly across the numNodes nodes.
 	dbConn := tc.ServerConn(0)
 	sqlutils.CreateTable(t, dbConn, "t", "x INT, y INT, INDEX (y)", 30, sqlutils.ToRowFn(sqlutils.RowIdxFn, sqlutils.RowIdxFn))
+	tableID := desctestutils.TestingGetPublicTableDescriptor(tc.Server(0).DB(), keys.SystemSQLCodec, "test", "t").GetID()
 	// onerow is a table created to test #51458. The value of the only row in this
 	// table is explicitly set to 2 so that it is routed by hash to a desired
 	// destination.
@@ -726,21 +720,14 @@ func TestUncertaintyErrorIsReturned(t *testing.T) {
 	defaultConn, cleanup := getPGXConnAndCleanupFunc(ctx, t, tc.Server(0).ServingSQLAddr())
 	defer cleanup()
 
-	// errorOriginSpec is a way for test cases to enable a request filter on the
-	// node index provided for the given tableNames.
-	type errorOriginSpec struct {
-		nodeIdx    int
-		tableNames []string
-	}
-
 	testCases := []struct {
 		query           string
 		expectedPlanURL string
 		// overrideErrorOrigin if non-nil, defines special request filtering
 		// behavior.
 		// The default behavior is to enable uncertainty errors for a single random
-		// node and for all scan requests.
-		overrideErrorOrigin []errorOriginSpec
+		// node.
+		overrideErrorOrigin []int
 		// if non-empty, this test will be skipped.
 		skip string
 	}{
@@ -755,14 +742,9 @@ func TestUncertaintyErrorIsReturned(t *testing.T) {
 		{
 			// This test reproduces 51458 and should be enabled once that issue is
 			// fixed.
-			query:           "SELECT * FROM t JOIN onerow ON t.x = onerow.x",
-			expectedPlanURL: "Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJy8lPFr2kAUx3_fX3E8GG3H2eSirSNQyGgzms5pp8IGJYyredWwmMvuLswi_u8jiWDjbDSk8yd93n3efb_f590S1O8IbBi5Pfd6TML4SZDPw8FX8uD-uO998vrk9MYbjUffemdkvedDsUGTu4HXJyJGKf6QQZ_o8wW5WtfnC598v3WHbtGx531xyclNyKeSz-33J0AhFgH2-RwV2A_AgIIFFNrgU0ikmKBSQmZLy3yjFyzANimEcZLq7GefwkRIBHsJOtQRgg1j_hjhEHmA0jCBQoCah1HeXjv6Z_ILn4HCtYjSeaxssqAkq0cJz6qWwUzwVxREqtdHbDo_PpMZV7NyT4eBv_IpKM2nCDZb0VekbvqksZABSgxKnfyM3Ldlh99brmZ3IoxRGp2ytAif9KnDzq5kOJ3l34DCINU2cRh1LOq0t6xubLQb2NihsS9aIjG62353Ht0pHc0OHzarO2yDmS3Dest5s-PO--I_zds6PHSrduiW2XrDxGtIbZfbFg-UU3z8K_rFm9BIrvWq3CP8QS6P8CDsUDBElYhY4UH33cw8YDDFIhMlUjnBeykm-TFFOci5_H4FqHSxui68uFjKBB4Od5rA3WqYbcPmS9iqhq1K-GMJNrfhdpPAquE9gVXDewLrNAnsoonnaniP52p4j-fLGrKtenCnCdythru1RuWv3v0NAAD__2MQZAI=",
-			overrideErrorOrigin: []errorOriginSpec{
-				{
-					nodeIdx:    0,
-					tableNames: []string{"t"},
-				},
-			},
+			query:               "SELECT * FROM t JOIN onerow ON t.x = onerow.x",
+			expectedPlanURL:     "Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJy8lPFr2kAUx3_fX3E8GG3H2eSirSNQyGgzms5pp8IGJYyredWwmMvuLswi_u8jiWDjbDSk8yd93n3efb_f590S1O8IbBi5Pfd6TML4SZDPw8FX8uD-uO998vrk9MYbjUffemdkvedDsUGTu4HXJyJGKf6QQZ_o8wW5WtfnC598v3WHbtGx531xyclNyKeSz-33J0AhFgH2-RwV2A_AgIIFFNrgU0ikmKBSQmZLy3yjFyzANimEcZLq7GefwkRIBHsJOtQRgg1j_hjhEHmA0jCBQoCah1HeXjv6Z_ILn4HCtYjSeaxssqAkq0cJz6qWwUzwVxREqtdHbDo_PpMZV7NyT4eBv_IpKM2nCDZb0VekbvqksZABSgxKnfyM3Ldlh99brmZ3IoxRGp2ytAif9KnDzq5kOJ3l34DCINU2cRh1LOq0t6xubLQb2NihsS9aIjG62353Ht0pHc0OHzarO2yDmS3Dest5s-PO--I_zds6PHSrduiW2XrDxGtIbZfbFg-UU3z8K_rFm9BIrvWq3CP8QS6P8CDsUDBElYhY4UH33cw8YDDFIhMlUjnBeykm-TFFOci5_H4FqHSxui68uFjKBB4Od5rA3WqYbcPmS9iqhq1K-GMJNrfhdpPAquE9gVXDewLrNAnsoonnaniP52p4j-fLGrKtenCnCdythru1RuWv3v0NAAD__2MQZAI=",
+			overrideErrorOrigin: []int{0},
 		},
 	}
 
@@ -806,20 +788,14 @@ func TestUncertaintyErrorIsReturned(t *testing.T) {
 						require.Equal(t, testCase.expectedPlanURL, actualPlanURL)
 					}()
 
-					errorOrigin := []errorOriginSpec{{nodeIdx: allNodeIdxs[rng.Intn(len(allNodeIdxs))]}}
+					errorOrigin := []int{allNodeIdxs[rng.Intn(len(allNodeIdxs))]}
 					if testCase.overrideErrorOrigin != nil {
 						errorOrigin = testCase.overrideErrorOrigin
 					}
-					for _, errorOriginSpec := range errorOrigin {
-						nodeIdx := errorOriginSpec.nodeIdx
+					for _, nodeIdx := range errorOrigin {
 						filters[nodeIdx].Lock()
 						filters[nodeIdx].enabled = true
-						for _, tableName := range errorOriginSpec.tableNames {
-							filters[nodeIdx].tableIDsToFilter = append(
-								filters[nodeIdx].tableIDsToFilter,
-								int(desctestutils.TestingGetPublicTableDescriptor(tc.Server(0).DB(), keys.SystemSQLCodec, "test", tableName).GetID()),
-							)
-						}
+						filters[nodeIdx].keyPrefix = keys.SystemSQLCodec.TablePrefix(uint32(tableID))
 						filters[nodeIdx].Unlock()
 					}
 					// Reset all filters for the next test case.
@@ -827,7 +803,7 @@ func TestUncertaintyErrorIsReturned(t *testing.T) {
 						for i := range filters {
 							filters[i].Lock()
 							filters[i].enabled = false
-							filters[i].tableIDsToFilter = nil
+							filters[i].keyPrefix = nil
 							filters[i].Unlock()
 						}
 					}()


### PR DESCRIPTION
Backport 1/1 commits from #78667.

/cc @cockroachdb/release

---

Fixes #78610.

This commit deflakes `TestUncertaintyErrorIsReturned` by scoping its filter to only KV Scans against the SQL table that the test is querying.

I'm not entirely sure why this become flaky after 208e2b4, but what follows is my best theory:
- the test uses replication factor 1
- the test performs a series `ALTER TABLE t EXPERIMENTAL_RELOCATE` ops
- before 208e2b4, these operations we handled as a multi-step process which involved adding a new voter, moving the lease, demoting the original voter, and removing the original voter.
- after 208e2b4, these operations all occur in a single joint-configuration.
- (conjecture) this compressed replica movement was able to complete without the client needing to update its range cache. As a result, the test's query needed to refresh the range cache after the filter was installed. However, because the filter was rejecting all traffic, it was rejecting even the meta range lookups (I saw this). So the test got stuck spinning on meta lookups.

Regardless of the exact explanation, this is a test flake and not an indication of anything more serious.

Release justification: fixes test flake.
