### PR TITLE
sql: allow pg_type.oid lookup join on null value

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -5628,3 +5628,11 @@ JOIN pg_authid ON usesysid = oid
 ----
 passed
 true
+
+# Regression test for crashing when performing a lookup join of NULL into
+# pg_type.oid virtual table (#76768).
+query T
+SELECT pg_type.oid
+FROM (SELECT null::OID AS b) AS a
+INNER LOOKUP JOIN pg_type ON pg_type.oid=a.b
+----

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -78,7 +78,12 @@ type virtualSchemaDef interface {
 type virtualIndex struct {
 	// populate populates the table given the constraint. matched is true if any
 	// rows were generated.
-	populate func(ctx context.Context, constraint tree.Datum, p *planner, db catalog.DatabaseDescriptor,
+	// unwrappedConstraint is unwrapped and never tree.DNull.
+	populate func(
+		ctx context.Context,
+		unwrappedConstraint tree.Datum,
+		p *planner,
+		db catalog.DatabaseDescriptor,
 		addRow func(...tree.Datum) error,
 	) (matched bool, err error)
 
@@ -626,17 +631,22 @@ func (e *virtualDefEntry) makeConstrainedRowsGenerator(
 				break
 			}
 			constraintDatum := span.StartKey().Value(0)
+			unwrappedConstraint := tree.UnwrapDatum(p.EvalContext(), constraintDatum)
 			virtualIndex := def.getIndex(index.GetID())
-
-			// For each span, run the index's populate method, constrained to the
-			// constraint span's value.
-			found, err := virtualIndex.populate(ctx, constraintDatum, p, dbDesc,
-				addRowIfPassesFilter(idxConstraint))
-			if err != nil {
-				return err
+			// NULL constraint will not match any row.
+			matched := unwrappedConstraint != tree.DNull
+			if matched {
+				// For each span, run the index's populate method, constrained to the
+				// constraint span's value.
+				var err error
+				matched, err = virtualIndex.populate(ctx, unwrappedConstraint, p, dbDesc,
+					addRowIfPassesFilter(idxConstraint))
+				if err != nil {
+					return err
+				}
 			}
-			if !found && virtualIndex.partial {
-				// If we found nothing, and the index was partial, we have no choice
+			if !matched && virtualIndex.partial {
+				// If no row was matched, and the index was partial, we have no choice
 				// but to populate the entire table and search through it.
 				break
 			}


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/76768

Release note (bug fix): Doing a lookup join on pg_type.oid no longer
results in an error.
Example:
SELECT pg_type.oid
FROM (SELECT null::OID AS b) AS a
INNER LOOKUP JOIN pg_type ON pg_type.oid=a.b

Jira issue: CRDB-14738