### PR TITLE
sql: bump --max-sql-memory in a couple of tests

### DIFF
--- a/pkg/sql/builtin_mem_usage_test.go
+++ b/pkg/sql/builtin_mem_usage_test.go
@@ -29,7 +29,7 @@ import (
 // initial database connection, but small enough to overflow easily. It's set
 // to be comfortably large enough that the server can start up with a bit of
 // extra space to overflow.
-const lowMemoryBudget = 800000
+const lowMemoryBudget = 1 << 20 /* 1MiB */
 
 // rowSize is the length of the string present in each row of the table created
 // by createTableWithLongStrings.


### PR DESCRIPTION
The current value was small enough that we were hitting an out of memory
error during the test setup. This was caused by the fact that we now
have more memory accounting in place.

Fixes: #78127.
Fixes: #78482.

Release note: None