### PR TITLE
rangefeed: disable rangefeed memory budgets dynamically

### DIFF
--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -537,10 +538,7 @@ func TestProcessorSlowConsumer(t *testing.T) {
 func TestProcessorMemoryBudgetExceeded(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
-	m.Start(context.Background(), nil, mon.MakeStandaloneBudget(40))
-	b := m.MakeBoundAccount()
-	fb := NewFeedBudget(&b, 0)
+	fb := newTestBudget(40)
 
 	stopper := stop.NewStopper()
 	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
@@ -608,10 +606,7 @@ func TestProcessorMemoryBudgetExceeded(t *testing.T) {
 func TestProcessorMemoryBudgetReleased(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
-	m.Start(context.Background(), nil, mon.MakeStandaloneBudget(40))
-	b := m.MakeBoundAccount()
-	fb := NewFeedBudget(&b, 0)
+	fb := newTestBudget(40)
 
 	stopper := stop.NewStopper()
 	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
@@ -1086,10 +1081,12 @@ func TestBudgetReleaseOnProcessorStop(t *testing.T) {
 	// as sync events used to flush queues.
 	const channelCapacity = totalEvents/2 + 10
 
+	s := cluster.MakeTestingClusterSettings()
 	m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
 	m.Start(context.Background(), nil, mon.MakeStandaloneBudget(math.MaxInt64))
+	//budgetEnabled := int32(1)
 	b := m.MakeBoundAccount()
-	fb := NewFeedBudget(&b, 0)
+	fb := NewFeedBudget(&b, 0, &s.SV)
 
 	stopper := stop.NewStopper()
 	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
@@ -1177,10 +1174,7 @@ func TestBudgetReleaseOnLastStreamError(t *testing.T) {
 	// objects. Ideally it would be nice to have
 	const channelCapacity = totalEvents + 5
 
-	m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
-	m.Start(context.Background(), nil, mon.MakeStandaloneBudget(math.MaxInt64))
-	b := m.MakeBoundAccount()
-	fb := NewFeedBudget(&b, 0)
+	fb := newTestBudget(math.MaxInt64)
 
 	stopper := stop.NewStopper()
 	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
@@ -1234,6 +1228,15 @@ func TestBudgetReleaseOnLastStreamError(t *testing.T) {
 	requireBudgetDrainedSoon(t, p, rStream)
 }
 
+func newTestBudget(limit int64) *FeedBudget {
+	s := cluster.MakeTestingClusterSettings()
+	m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
+	m.Start(context.Background(), nil, mon.MakeStandaloneBudget(limit))
+	b := m.MakeBoundAccount()
+	fb := NewFeedBudget(&b, 0, &s.SV)
+	return fb
+}
+
 // TestBudgetReleaseOnOneStreamError verifies that if one stream fails while
 // other keeps running, accounting correctly releases memory budget for shared
 // events.
@@ -1248,10 +1251,7 @@ func TestBudgetReleaseOnOneStreamError(t *testing.T) {
 	// as sync events used to flush queues.
 	const channelCapacity = totalEvents/2 + 10
 
-	m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
-	m.Start(context.Background(), nil, mon.MakeStandaloneBudget(math.MaxInt64))
-	b := m.MakeBoundAccount()
-	fb := NewFeedBudget(&b, 0)
+	fb := newTestBudget(math.MaxInt64)
 
 	stopper := stop.NewStopper()
 	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
@@ -1417,10 +1417,7 @@ func BenchmarkProcessorWithBudget(b *testing.B) {
 
 	var budget *FeedBudget
 	if false {
-		m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
-		m.Start(context.Background(), nil, mon.MakeStandaloneBudget(math.MaxInt64))
-		acc := m.MakeBoundAccount()
-		budget = NewFeedBudget(&acc, 0)
+		budget = newTestBudget(math.MaxInt64)
 	}
 
 	stopper := stop.NewStopper()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -495,7 +495,8 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 					return raftCmdLimit
 				}
 				return limit
-			}))
+			},
+			&st.SV))
 	if rangeReedBudgetFactory != nil {
 		registry.AddMetricStruct(rangeReedBudgetFactory.Metrics())
 	}


### PR DESCRIPTION
Previously memory budgets could only be disabled on new
rangefeeds where processor is not already running. Existing
rangefeeds will continue to limit used memory.
In case budgets needs to be urgently disabled on a big cluster
you'll have to restart all system rangefeeds which means you
likely end up restarting all nodes. This is disruptive and
should be avoided.
This PR adds an atomic flag that existing budgets could check
and stop allocation checks if it is reset to false.

Release note (ops change): Rangefeed memory budgets could be
disabled on the fly when cluster setting is changed without
the need to restart the feed.