### PR TITLE
cdc: fix pubsub test and make region friendlier

### DIFF
--- a/pkg/ccl/changefeedccl/sink_pubsub.go
+++ b/pkg/ccl/changefeedccl/sink_pubsub.go
@@ -11,6 +11,7 @@ package changefeedccl
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"hash/crc32"
 	"net/url"
 
@@ -182,7 +183,7 @@ func MakePubsubSink(
 			topics:        p.getTopicsMap(targets, pubsubTopicName),
 			ctx:           ctx,
 			projectID:     projectID,
-			region:        region,
+			region:        gcpEndpointForRegion(region),
 			url:           pubsubURL,
 			withTopicName: pubsubTopicName,
 		}
@@ -533,4 +534,11 @@ func (p *gcpPubsubClient) forEachTopic(f func(descpb.ID, *topicStruct) error) er
 		}
 	}
 	return nil
+}
+
+// Generate the cloud endpoint that's specific to a region (e.g. us-east1).
+// Ideally this would be discoverable via API but doesn't seem to be.
+// A hardcoded approach looks to be correct right now.
+func gcpEndpointForRegion(region string) string {
+	return fmt.Sprintf("%s-pubsub.googleapis.com:443", region)
 }

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -153,7 +153,7 @@ func cdcBasicTest(ctx context.Context, t test.Test, c cluster.Cluster, args cdcT
 
 		sinkURI = fmt.Sprintf("webhook-%s", sinkDestHost.String())
 	} else if args.whichSink == pubsubSink {
-		sinkURI = changefeedccl.GcpScheme + `://cockroach-ephemeral` + "?AUTH=implicit&topic_name=pubsubSink-roachtest"
+		sinkURI = changefeedccl.GcpScheme + `://cockroach-ephemeral` + "?AUTH=implicit&topic_name=pubsubSink-roachtest&region=us-east1"
 	} else {
 		t.Status("installing kafka")
 		kafka.install(ctx)


### PR DESCRIPTION
The roachtest was failing because it wasn't specifying region.
Manual acceptance testing was failing because the "region" param
was actually expected to be a full-on URL. This changes it so
that it takes a region param like "us-east1".

Fixes #78124
Fixes #75640

Release note: None