### PR TITLE
cli: default to num procs concurrency in debug compact

### DIFF
--- a/pkg/ccl/cliccl/debug.go
+++ b/pkg/ccl/cliccl/debug.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl/enginepbccl"
 	"github.com/cockroachdb/cockroach/pkg/cli"
 	"github.com/cockroachdb/cockroach/pkg/cli/clierrorplus"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -160,7 +161,7 @@ func runEncryptionStatus(cmd *cobra.Command, args []string) error {
 
 	dir := args[0]
 
-	db, err := cli.OpenExistingStore(dir, stopper, true /* readOnly */, false /* disableAutomaticCompactions */)
+	db, err := cli.OpenEngine(dir, stopper, storage.MustExist, storage.ReadOnly)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/debug_check_store.go
+++ b/pkg/cli/debug_check_store.go
@@ -146,7 +146,7 @@ func checkStoreRangeStats(
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 
-	eng, err := OpenExistingStore(dir, stopper, true /* readOnly */, false /* disableAutomaticCompactions */)
+	eng, err := OpenEngine(dir, stopper, storage.MustExist, storage.ReadOnly)
 	if err != nil {
 		return err
 	}
@@ -220,7 +220,7 @@ func checkStoreRaftState(
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 
-	db, err := OpenExistingStore(dir, stopper, true /* readOnly */, false /* disableAutomaticCompactions */)
+	db, err := OpenEngine(dir, stopper, storage.MustExist, storage.ReadOnly)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/debug_recover_loss_of_quorum.go
+++ b/pkg/cli/debug_recover_loss_of_quorum.go
@@ -203,7 +203,7 @@ func runDebugDeadReplicaCollect(cmd *cobra.Command, args []string) error {
 
 	var stores []storage.Engine
 	for _, storeSpec := range debugRecoverCollectInfoOpts.Stores.Specs {
-		db, err := OpenExistingStore(storeSpec.Path, stopper, true /* readOnly */, false /* disableAutomaticCompactions */)
+		db, err := OpenEngine(storeSpec.Path, stopper, storage.MustExist, storage.ReadOnly)
 		if err != nil {
 			return errors.Wrapf(err, "failed to open store at path %q, ensure that store path is "+
 				"correct and that it is not used by another process", storeSpec.Path)
@@ -457,7 +457,7 @@ func runDebugExecuteRecoverPlan(cmd *cobra.Command, args []string) error {
 	var localNodeID roachpb.NodeID
 	batches := make(map[roachpb.StoreID]storage.Batch)
 	for _, storeSpec := range debugRecoverExecuteOpts.Stores.Specs {
-		store, err := OpenExistingStore(storeSpec.Path, stopper, false /* readOnly */, false /* disableAutomaticCompactions */)
+		store, err := OpenEngine(storeSpec.Path, stopper, storage.MustExist)
 		if err != nil {
 			return errors.Wrapf(err, "failed to open store at path %q. ensure that store path is "+
 				"correct and that it is not used by another process", storeSpec.Path)

--- a/pkg/cli/debug_synctest.go
+++ b/pkg/cli/debug_synctest.go
@@ -116,7 +116,7 @@ func runSyncer(
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 
-	db, err := OpenEngine(dir, stopper, OpenEngineOptions{})
+	db, err := OpenEngine(dir, stopper)
 	if err != nil {
 		if expSeq == 0 {
 			// Failed on first open, before we tried to corrupt anything. Hard stop.

--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -119,6 +119,15 @@ func CacheSize(size int64) ConfigOption {
 	}
 }
 
+// MaxConcurrentCompactions configures the maximum number of concurrent
+// compactions an Engine will execute.
+func MaxConcurrentCompactions(n int) ConfigOption {
+	return func(cfg *engineConfig) error {
+		cfg.Opts.MaxConcurrentCompactions = n
+		return nil
+	}
+}
+
 // EncryptionAtRest configures an engine to use encryption-at-rest. It is used
 // for configuring in-memory engines, which are used in tests. It is not safe
 // to modify the given slice afterwards as it is captured by reference.


### PR DESCRIPTION
**cli: remove OpenExistingStore**

Remove OpenExistingStore, replacing its call sites with calls to OpenEngine,
including the storage.MustExist config option.

**cli: default to num procs concurrency in debug compact**

Now that some concurrency within manual offline compactions is possible,
default to a max compaction concurrency equal to the number of
processors during offline manual compactions. Add a new
`--max-concurrency` flag to the debug compact command to override this
default.

The undocumented `COCKROACH_ROCKSDB_CONCURRENCY` environment variable
will no longer affect the maximum concurrency for this offline
compaction. That environment variable is intended for controlling
compaction concurrency for a running CockroachDB node. The switch to an
explicit flag for this command makes the concurrency control more
discoverable (it appears within the command help output) and allows for
the more reasonable default concurrency in this context.

Release note (cli change): Changes the default `debug compact`
maximum compaction concurrency to the number of processors, and adds a
`--max-concurrency` flag for overriding the new default.