### PR TITLE
sql: ignore non-existent columns when injecting stats

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -197,6 +197,40 @@ statistics_name  column_names  row_count  distinct_count  null_count
 NULL             {b}           256        4               0
 s1               {a}           256        4               0
 
+# Ignore stats with non-existent columns.
+query T noticetrace
+ALTER TABLE data INJECT STATISTICS '[
+    {
+        "columns": ["z"],
+        "created_at": "2018-05-01 1:00:00.00000+00:00",
+        "row_count": 10,
+        "distinct_count": 2
+    },
+    {
+        "columns": ["a", "z"],
+        "created_at": "2018-05-01 1:00:00.00000+00:00",
+        "row_count": 10,
+        "distinct_count": 2
+    },
+    {
+        "columns": ["a"],
+        "created_at": "2018-05-01 1:00:00.00000+00:00",
+        "row_count": 10,
+        "distinct_count": 2
+    }
+]'
+----
+NOTICE: column "z" does not exist
+NOTICE: column "z" does not exist
+
+query TTIII colnames
+SELECT statistics_name, column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE data]
+ORDER BY statistics_name, column_names::STRING
+----
+statistics_name  column_names  row_count  distinct_count  null_count
+NULL             {a}           10         2               0
+
 # Test AS OF SYSTEM TIME
 
 # We're reading from timestamps that precede the GC thresholds, disable strict
@@ -216,7 +250,6 @@ FROM [SHOW STATISTICS FOR TABLE data]
 ORDER BY statistics_name, column_names::STRING
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
-NULL             {b}           256        4               0
 s2               {a}           256        4               0
 
 #


### PR DESCRIPTION
Previously, an `ALTER TABLE ... INJECT STATS` command would return an
error if the given stats JSON included any columns that were not present
in the table descriptor. Statistics in statement bundles often include
dropped columns, so reproducing issues with a bundle required tediously
removing stats for these columns. This commit changes the stats
injection behavior so that a notice is issued for stats with
non-existent columns rather than an error. Any stats for existing
columns will be injected successfully.

Informs #68184

Release note (sql change): `ALTER TABLE ... INJECT STATISTICS ...` will
now issue notices when the given statistics JSON includes non-existent
columns, rather than resulting in an error. Any statistics in the JSON
for existing columns will be injected successfully.