### PR TITLE
logictest: add support for async statements that block due to lock contention

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -220,6 +220,22 @@ import (
 //    Runs the statement that follows and expects an
 //    error that matches the given regexp.
 //
+//  - statement async <name> <options>
+//    Runs a statement asynchronously, marking it as a pending
+//    statement with a unique name, to be completed and validated later with
+//    "awaitstatement". This is intended for use with statements that may block,
+//    such as those contending on locks. Other statement options described
+//    above are supported, though the statement may not be in a "repeat".
+//    Incomplete pending statements will result in an error on test completion.
+//    Note that as the statement will be run asynchronously, subsequent queries
+//    that depend on the state of the asynchronous statement should be run with
+//    the "retry" option to ensure deterministic testing and avoid racing with
+//    the asynchronous statement.
+//
+//  - awaitstatement <name>
+//    Completes a pending statement with the provided name, validating its
+//    results as expected per the given options to "statement async <name>...".
+//
 //  - query <typestring> <options> <label>
 //    Runs the query that follows and verifies the results (specified after the
 //    query and a ---- separator). Example:
@@ -999,6 +1015,28 @@ type logicStatement struct {
 	expectErrCode string
 	// expected rows affected count. -1 to avoid testing this.
 	expectCount int64
+	// if this statement is to run asynchronously, and become a pendingStatement.
+	expectAsync bool
+	// the name key to use for the pendingStatement.
+	statementName string
+}
+
+// pendingExecResult represents a final SQL query string run and the resulting
+// output and error from running it against the DB.
+type pendingExecResult struct {
+	execSQL string
+	res     gosql.Result
+	err     error
+}
+
+// pendingStatement encapsulates a logicStatement that is expected to block and
+// as such is run in a separate goroutine, as well as the channel on which to
+// receive the results of the statement execution.
+type pendingStatement struct {
+	logicStatement
+
+	// the channel on which to receive the execution results, when completed.
+	resultChan chan pendingExecResult
 }
 
 // readSQL reads the lines of a SQL statement or query until the first blank
@@ -1376,6 +1414,9 @@ type logicTest struct {
 
 	// varMap remembers the variables set with "let".
 	varMap map[string]string
+
+	// pendingStatements tracks any async statements by name key.
+	pendingStatements map[string]pendingStatement
 
 	// noticeBuffer retains the notices from the past query.
 	noticeBuffer []string
@@ -1976,6 +2017,7 @@ CREATE DATABASE test; USE test;
 
 	t.labelMap = make(map[string]string)
 	t.varMap = make(map[string]string)
+	t.pendingStatements = make(map[string]pendingStatement)
 
 	t.progress = 0
 	t.failures = 0
@@ -2623,6 +2665,33 @@ func (t *logicTest) processSubtest(
 			}
 			time.Sleep(duration)
 
+		case "awaitstatement":
+			if len(fields) != 2 {
+				return errors.New("invalid line format")
+			}
+
+			name := fields[1]
+
+			var pending pendingStatement
+			var ok bool
+			if pending, ok = t.pendingStatements[name]; !ok {
+				return errors.Newf("pending statement with name %q unknown", name)
+			}
+
+			execRes := <-pending.resultChan
+			cont, err := t.finishExecStatement(pending.logicStatement, execRes.execSQL, execRes.res, execRes.err)
+
+			if err != nil {
+				if !cont {
+					return err
+				}
+				t.Error(err)
+			}
+
+			delete(t.pendingStatements, name)
+
+			t.success(path)
+
 		case "statement":
 			stmt := logicStatement{
 				pos:         fmt.Sprintf("\n%s:%d", path, s.line+subtest.lineLineIndexIntoFile),
@@ -2634,6 +2703,12 @@ func (t *logicTest) processSubtest(
 			} else if m := errorRE.FindStringSubmatch(s.Text()); m != nil {
 				stmt.expectErrCode = m[1]
 				stmt.expectErr = m[2]
+			}
+			if len(fields) >= 3 && fields[1] == "async" {
+				stmt.expectAsync = true
+				stmt.statementName = fields[2]
+				copy(fields[1:], fields[3:])
+				fields = fields[:len(fields)-2]
 			}
 			if len(fields) >= 3 && fields[1] == "count" {
 				n, err := strconv.ParseInt(fields[2], 10, 64)
@@ -2781,6 +2856,8 @@ func (t *logicTest) processSubtest(
 
 						case "round-in-strings":
 							query.roundFloatsInStrings = true
+
+						// TODO(sarkesian): support "async" options for queries as well as statements
 
 						default:
 							if strings.HasPrefix(opt, "nodeidx=") {
@@ -3247,7 +3324,33 @@ func (t *logicTest) execStatement(stmt logicStatement) (bool, error) {
 			t.outf("rewrote:\n%s\n", execSQL)
 		}
 	}
+
+	if stmt.expectAsync {
+		if _, ok := t.pendingStatements[stmt.statementName]; ok {
+			return false, errors.Newf("pending statement with name %q already exists", stmt.statementName)
+		}
+
+		pending := pendingStatement{
+			logicStatement: stmt,
+			resultChan:     make(chan pendingExecResult),
+		}
+		t.pendingStatements[stmt.statementName] = pending
+
+		go func() {
+			res, err := t.db.Exec(execSQL)
+			pending.resultChan <- pendingExecResult{execSQL, res, err}
+		}()
+
+		return true, nil
+	}
+
 	res, err := t.db.Exec(execSQL)
+	return t.finishExecStatement(stmt, execSQL, res, err)
+}
+
+func (t *logicTest) finishExecStatement(
+	stmt logicStatement, execSQL string, res gosql.Result, err error,
+) (bool, error) {
 	if err == nil {
 		sqlutils.VerifyStatementPrettyRoundtrip(t.t(), stmt.sql)
 	}
@@ -3731,6 +3834,27 @@ func (t *logicTest) success(file string) {
 }
 
 func (t *logicTest) validateAfterTestCompletion() error {
+	// Check any remaining pending statements
+	if len(t.pendingStatements) > 0 {
+		log.Warningf(context.Background(), "%d remaining pending statements", len(t.pendingStatements))
+	}
+	for name, pending := range t.pendingStatements {
+		select {
+		case execRes := <-pending.resultChan:
+			// check if execRes shows that statement completed successfully
+			cont, err := t.finishExecStatement(pending.logicStatement, execRes.execSQL, execRes.res, execRes.err)
+
+			if err != nil {
+				if !cont {
+					return errors.Wrapf(execRes.err, "pending statement %q resulted in error", name)
+				}
+				t.Errorf("pending statement %q resulted in error: %v", name, execRes.err)
+			}
+		default:
+			t.Fatalf("pending statement %q did not finish", name)
+		}
+	}
+
 	// Close all clients other than "root"
 	for username, c := range t.clients {
 		if username == "root" {

--- a/pkg/sql/logictest/testdata/logic_test/cluster_locks
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_locks
@@ -1,0 +1,46 @@
+# LogicTest: !3node-tenant
+
+# Create a table, write a row, lock it, then switch users.
+statement ok
+CREATE TABLE t (k STRING PRIMARY KEY, v STRING)
+
+statement ok
+GRANT ALL ON t TO testuser
+
+statement ok
+INSERT INTO t VALUES ('a', 'val1'), ('b', 'val2'), ('c', 'val3'), ('l', 'val4'), ('m', 'val5'), ('p', 'val6'), ('s', 'val7'), ('t', 'val8'), ('z', 'val9')
+
+query TTT colnames
+ALTER TABLE t SPLIT AT VALUES ('d'), ('r')
+----
+key                   pretty  split_enforced_until
+[242 137 18 100 0 1]  /"d"    2262-04-11 23:47:16.854776 +0000 +0000
+[242 137 18 114 0 1]  /"r"    2262-04-11 23:47:16.854776 +0000 +0000
+
+query TTTI colnames,rowsort
+SELECT start_key, end_key, replicas, lease_holder FROM [SHOW RANGES FROM TABLE t]
+----
+start_key  end_key  replicas  lease_holder
+NULL       /"d"     {1}       1
+/"d"       /"r"     {1}       1
+/"r"       NULL     {1}       1
+
+statement count 7
+BEGIN; UPDATE t SET v = concat(v, '_updated') WHERE k >= 'b' and k < 'z'
+
+user testuser
+
+statement ok
+BEGIN
+
+statement async readReq ok
+select * from t for update
+
+user root
+
+statement ok
+ROLLBACK
+
+user testuser
+
+awaitstatement readReq


### PR DESCRIPTION
While previously each statement in a logictest was expected to complete
(with success or error), this change adds support for a new type of
statement in a logictest that is expected to block and be completed
later. This change enables the ability to test what happens during lock
contention, as in the case a statement is waiting on locks and does not
have a lock timeout set, the statement will block until it can proceed
(by obtaining the locks).

This feature is supported by the syntax:
```
statement async namedStatement ok
<some statement that will block as it cannot obtain locks>
...
<operations that would free the locks namedStatement is waiting on>
...
awaitstatement namedStatement
<wait on namedStatement to complete and validate that results are ok>
```

Release note: None

Release Justification: Testing change only.