### PR TITLE
sql: introduce expect_and_ignore_not_visible_columns_in_copy session var

### DIFF
--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -55,12 +55,13 @@ type copyMachineInterface interface {
 // See: https://www.postgresql.org/docs/current/static/sql-copy.html
 // and: https://www.postgresql.org/docs/current/static/protocol-flow.html#PROTOCOL-COPY
 type copyMachine struct {
-	table         tree.TableExpr
-	columns       tree.NameList
-	resultColumns colinfo.ResultColumns
-	format        tree.CopyFormat
-	csvEscape     rune
-	delimiter     byte
+	table                    tree.TableExpr
+	columns                  tree.NameList
+	resultColumns            colinfo.ResultColumns
+	expectedHiddenColumnIdxs []int
+	format                   tree.CopyFormat
+	csvEscape                rune
+	delimiter                byte
 	// textDelim is delimiter converted to a []byte so that we don't have to do that per row.
 	textDelim   []byte
 	null        string
@@ -216,6 +217,16 @@ func newCopyMachine(
 			PGAttributeNum: col.GetPGAttributeNum(),
 		}
 	}
+	// If there are no column specifiers and we expect non-visible columns
+	// to have field data then we have to populate the expectedHiddenColumnIdxs
+	// field with the columns indexes we expect to be hidden.
+	if c.p.SessionData().ExpectAndIgnoreNotVisibleColumnsInCopy && len(n.Columns) == 0 {
+		for i, col := range tableDesc.PublicColumns() {
+			if col.IsHidden() {
+				c.expectedHiddenColumnIdxs = append(c.expectedHiddenColumnIdxs, i)
+			}
+		}
+	}
 	c.rowsMemAcc = c.p.extendedEvalCtx.Mon.MakeBoundAccount()
 	c.bufMemAcc = c.p.extendedEvalCtx.Mon.MakeBoundAccount()
 	c.processRows = c.insertRows
@@ -268,7 +279,7 @@ func (c *copyMachine) run(ctx context.Context) error {
 		c.csvReader = csv.NewReader(&c.csvInput)
 		c.csvReader.Comma = rune(c.delimiter)
 		c.csvReader.ReuseRecord = true
-		c.csvReader.FieldsPerRecord = len(c.resultColumns)
+		c.csvReader.FieldsPerRecord = len(c.resultColumns) + len(c.expectedHiddenColumnIdxs)
 		if c.csvEscape != 0 {
 			c.csvReader.Escape = c.csvEscape
 		}
@@ -474,11 +485,26 @@ func (c *copyMachine) readCSVData(ctx context.Context, final bool) (brk bool, er
 	return false, err
 }
 
-func (c *copyMachine) readCSVTuple(ctx context.Context, record []string) error {
-	if len(record) != len(c.resultColumns) {
-		return pgerror.Newf(pgcode.BadCopyFileFormat,
-			"expected %d values, got %d", len(c.resultColumns), len(record))
+func (c *copyMachine) maybeIgnoreHiddenColumnsStr(in []string) []string {
+	if len(c.expectedHiddenColumnIdxs) == 0 {
+		return in
 	}
+	ret := in[:0]
+	nextStartIdx := 0
+	for _, toIdx := range c.expectedHiddenColumnIdxs {
+		ret = append(ret, in[nextStartIdx:toIdx]...)
+		nextStartIdx = toIdx + 1
+	}
+	ret = append(ret, in[nextStartIdx:]...)
+	return ret
+}
+
+func (c *copyMachine) readCSVTuple(ctx context.Context, record []string) error {
+	if expected := len(c.resultColumns) + len(c.expectedHiddenColumnIdxs); expected != len(record) {
+		return pgerror.Newf(pgcode.BadCopyFileFormat,
+			"expected %d values, got %d", expected, len(record))
+	}
+	record = c.maybeIgnoreHiddenColumnsStr(record)
 	exprs := make(tree.Exprs, len(record))
 	for i, s := range record {
 		if s == c.null {
@@ -506,6 +532,12 @@ func (c *copyMachine) readCSVTuple(ctx context.Context, record []string) error {
 }
 
 func (c *copyMachine) readBinaryData(ctx context.Context, final bool) (brk bool, err error) {
+	if len(c.expectedHiddenColumnIdxs) > 0 {
+		return false, pgerror.Newf(
+			pgcode.FeatureNotSupported,
+			"expect_and_ignore_not_visible_columns_in_copy not supported in binary mode",
+		)
+	}
 	switch c.binaryState {
 	case binaryStateNeedSignature:
 		if readSoFar, err := c.readBinarySignature(); err != nil {
@@ -718,12 +750,27 @@ func (c *copyMachine) insertRows(ctx context.Context) (retErr error) {
 	return nil
 }
 
+func (c *copyMachine) maybeIgnoreHiddenColumnsBytes(in [][]byte) [][]byte {
+	if len(c.expectedHiddenColumnIdxs) == 0 {
+		return in
+	}
+	ret := in[:0]
+	nextStartIdx := 0
+	for _, toIdx := range c.expectedHiddenColumnIdxs {
+		ret = append(ret, in[nextStartIdx:toIdx]...)
+		nextStartIdx = toIdx + 1
+	}
+	ret = append(ret, in[nextStartIdx:]...)
+	return ret
+}
+
 func (c *copyMachine) readTextTuple(ctx context.Context, line []byte) error {
 	parts := bytes.Split(line, c.textDelim)
-	if len(parts) != len(c.resultColumns) {
+	if expected := len(c.resultColumns) + len(c.expectedHiddenColumnIdxs); expected != len(parts) {
 		return pgerror.Newf(pgcode.BadCopyFileFormat,
-			"expected %d values, got %d", len(c.resultColumns), len(parts))
+			"expected %d values, got %d", expected, len(parts))
 	}
+	parts = c.maybeIgnoreHiddenColumnsBytes(parts)
 	exprs := make(tree.Exprs, len(parts))
 	for i, part := range parts {
 		s := string(part)

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3176,6 +3176,10 @@ func (m *sessionDataMutator) SetEnableImplicitTransactionForBatchStatements(val 
 	m.data.EnableImplicitTransactionForBatchStatements = val
 }
 
+func (m *sessionDataMutator) SetExpectAndIgnoreNotVisibleColumnsInCopy(val bool) {
+	m.data.ExpectAndIgnoreNotVisibleColumnsInCopy = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4714,6 +4714,7 @@ enable_seqscan                                        on
 enable_super_regions                                  off
 enable_zigzag_join                                    on
 escape_string_warning                                 on
+expect_and_ignore_not_visible_columns_in_copy         off
 experimental_computed_column_rewrites                 ·
 experimental_enable_auto_rehoming                     off
 experimental_enable_hash_sharded_indexes              on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4090,6 +4090,7 @@ enable_seqscan                                        on                  NULL  
 enable_super_regions                                  off                 NULL      NULL        NULL        string
 enable_zigzag_join                                    on                  NULL      NULL        NULL        string
 escape_string_warning                                 on                  NULL      NULL        NULL        string
+expect_and_ignore_not_visible_columns_in_copy         off                 NULL      NULL        NULL        string
 experimental_distsql_planning                         off                 NULL      NULL        NULL        string
 experimental_enable_auto_rehoming                     off                 NULL      NULL        NULL        string
 experimental_enable_implicit_column_partitioning      off                 NULL      NULL        NULL        string
@@ -4209,6 +4210,7 @@ enable_seqscan                                        on                  NULL  
 enable_super_regions                                  off                 NULL  user     NULL      off                 off
 enable_zigzag_join                                    on                  NULL  user     NULL      on                  on
 escape_string_warning                                 on                  NULL  user     NULL      on                  on
+expect_and_ignore_not_visible_columns_in_copy         off                 NULL  user     NULL      off                 off
 experimental_distsql_planning                         off                 NULL  user     NULL      off                 off
 experimental_enable_auto_rehoming                     off                 NULL  user     NULL      off                 off
 experimental_enable_implicit_column_partitioning      off                 NULL  user     NULL      off                 off
@@ -4323,6 +4325,7 @@ enable_seqscan                                        NULL    NULL     NULL     
 enable_super_regions                                  NULL    NULL     NULL     NULL        NULL
 enable_zigzag_join                                    NULL    NULL     NULL     NULL        NULL
 escape_string_warning                                 NULL    NULL     NULL     NULL        NULL
+expect_and_ignore_not_visible_columns_in_copy         NULL    NULL     NULL     NULL        NULL
 experimental_distsql_planning                         NULL    NULL     NULL     NULL        NULL
 experimental_enable_auto_rehoming                     NULL    NULL     NULL     NULL        NULL
 experimental_enable_implicit_column_partitioning      NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -62,6 +62,7 @@ enable_seqscan                                        on
 enable_super_regions                                  off
 enable_zigzag_join                                    on
 escape_string_warning                                 on
+expect_and_ignore_not_visible_columns_in_copy         off
 experimental_distsql_planning                         off
 experimental_enable_auto_rehoming                     off
 experimental_enable_implicit_column_partitioning      off

--- a/pkg/sql/pgwire/testdata/pgtest/copy
+++ b/pkg/sql/pgwire/testdata/pgtest/copy
@@ -46,6 +46,134 @@ ReadyForQuery
 {"Type":"CommandComplete","CommandTag":"SELECT 3"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
+# Extra fields.
+
+send crdb_only
+Query {"String": "CREATE TABLE copy_hidden_table (id INT, nv TEXT NOT VISIBLE, t TEXT)"}
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send crdb_only
+Query {"String": "COPY copy_hidden_table FROM STDIN"}
+CopyData {"Data": "1\tblah\tbad\tpk\n"}
+CopyDone
+----
+
+until crdb_only keepErrMessage
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"CopyInResponse","ColumnFormatCodes":[0,0]}
+{"Type":"ErrorResponse","Code":"22P04","Message":"expected 2 values, got 4"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send crdb_only
+Query {"String": "COPY copy_hidden_table FROM STDIN CSV"}
+CopyData {"Data": "2,blah,bad,pk\n"}
+CopyDone
+----
+
+until crdb_only keepErrMessage
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"CopyInResponse","ColumnFormatCodes":[0,0]}
+{"Type":"ErrorResponse","Code":"22P04","Message":"read CSV record: record on line 1: wrong number of fields"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send crdb_only
+Query {"String": "COPY copy_hidden_table FROM STDIN"}
+CopyData {"Data": "3\tgood\n"}
+CopyDone
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"CopyInResponse","ColumnFormatCodes":[0,0]}
+{"Type":"CommandComplete","CommandTag":"COPY 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Set expect_and_ignore_not_visible_columns_in_copy - now it should be allowed.
+# We insert 4 columns because the rowid column is also implicit.
+send crdb_only
+Query {"String": "SET expect_and_ignore_not_visible_columns_in_copy = true"}
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"SET"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send crdb_only
+Query {"String": "COPY copy_hidden_table FROM STDIN"}
+CopyData {"Data": "1\tblah\tgood\tpk\n"}
+CopyDone
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"CopyInResponse","ColumnFormatCodes":[0,0]}
+{"Type":"CommandComplete","CommandTag":"COPY 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send crdb_only
+Query {"String": "COPY copy_hidden_table FROM STDIN CSV"}
+CopyData {"Data": "2,blah,good,pk\n"}
+CopyDone
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"CopyInResponse","ColumnFormatCodes":[0,0]}
+{"Type":"CommandComplete","CommandTag":"COPY 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send crdb_only
+Query {"String": "COPY copy_hidden_table FROM STDIN"}
+CopyData {"Data": "4\tnow_bad\n"}
+CopyDone
+----
+
+until crdb_only keepErrMessage
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"CopyInResponse","ColumnFormatCodes":[0,0]}
+{"Type":"ErrorResponse","Code":"22P04","Message":"expected 4 values, got 2"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send crdb_only
+Query {"String": "SELECT *, nv FROM copy_hidden_table ORDER BY id"}
+----
+
+until ignore=RowDescription crdb_only
+ReadyForQuery
+----
+{"Type":"DataRow","Values":[{"text":"1"},{"text":"good"},null]}
+{"Type":"DataRow","Values":[{"text":"2"},{"text":"good"},null]}
+{"Type":"DataRow","Values":[{"text":"3"},{"text":"good"},null]}
+{"Type":"CommandComplete","CommandTag":"SELECT 3"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send crdb_only
+Query {"String": "SET expect_and_ignore_not_visible_columns_in_copy = false"}
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"SET"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
 # Invalid ESCAPE syntax.
 send
 Query {"String": "COPY t FROM STDIN ESCAPE 'xxx'"}

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -242,6 +242,10 @@ message LocalOnlySessionData {
   // Setting this to false is a divergence from the pgwire protocol, but
   // matches the behavior of CockroachDB v21.2 and earlier.
   bool enable_implicit_transaction_for_batch_statements = 66;
+  // ExpectAndIgnoreNotVisibleColumnsInCopy changes behaviour for COPY t FROM ...
+  // (with no column name specifiers) to expect and ignore not visible column
+  // fields.
+  bool expect_and_ignore_not_visible_columns_in_copy = 67;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2025,6 +2025,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalTrue,
 	},
+
+	// CockroachDB extension.
+	`expect_and_ignore_not_visible_columns_in_copy`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`expect_and_ignore_not_visible_columns_in_copy`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("expect_and_ignore_not_visible_columns_in_copy", s)
+			if err != nil {
+				return err
+			}
+			m.SetExpectAndIgnoreNotVisibleColumnsInCopy(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().ExpectAndIgnoreNotVisibleColumnsInCopy), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 const compatErrMsg = "this parameter is currently recognized only for compatibility and has no effect in CockroachDB."


### PR DESCRIPTION
Release note (sql change): Introduced a
`expect_and_ignore_not_visible_columns_in_copy` session variable. If this
is set, COPY with no column specifiers will assume hidden columns are in
the copy data, but will ignore them when applying the COPY.

Resolves #79007