### PR TITLE
server/status: selective metric export

### DIFF
--- a/pkg/ccl/sqlproxyccl/server.go
+++ b/pkg/ccl/sqlproxyccl/server.go
@@ -36,7 +36,6 @@ type Server struct {
 	metrics         *metrics
 	metricsRegistry *metric.Registry
 
-	promMu             syncutil.Mutex
 	prometheusExporter metric.PrometheusExporter
 }
 
@@ -101,12 +100,11 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleVars(w http.ResponseWriter, r *http.Request) {
-	s.promMu.Lock()
-	defer s.promMu.Unlock()
-
 	w.Header().Set(httputil.ContentTypeHeader, httputil.PlaintextContentType)
-	s.prometheusExporter.ScrapeRegistry(s.metricsRegistry, true /* includeChildMetrics*/)
-	if err := s.prometheusExporter.PrintAsText(w); err != nil {
+	scrape := func(pm *metric.PrometheusExporter) {
+		pm.ScrapeRegistry(s.metricsRegistry, true /* includeChildMetrics*/)
+	}
+	if err := s.prometheusExporter.ScrapeAndPrintAsText(w, scrape); err != nil {
 		log.Errorf(r.Context(), "%v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}

--- a/pkg/kv/kvserver/client_tenant_test.go
+++ b/pkg/kv/kvserver/client_tenant_test.go
@@ -89,9 +89,11 @@ func TestTenantsStorageMetricsOnSplit(t *testing.T) {
 			return true
 		})
 		ex := metric.MakePrometheusExporter()
-		ex.ScrapeRegistry(store.Registry(), true /* includeChildMetrics */)
+		scrape := func(ex *metric.PrometheusExporter) {
+			ex.ScrapeRegistry(store.Registry(), true /* includeChildMetrics */)
+		}
 		var in bytes.Buffer
-		if err := ex.PrintAsText(&in); err != nil {
+		if err := ex.ScrapeAndPrintAsText(&in, scrape); err != nil {
 			t.Fatalf("failed to print prometheus data: %v", err)
 		}
 		if seen != 2 {

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -64,6 +64,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -121,6 +122,7 @@ var (
 type metricMarshaler interface {
 	json.Marshaler
 	PrintAsText(io.Writer) error
+	ScrapeIntoPrometheus(pm *metric.PrometheusExporter)
 }
 
 func propagateGatewayMetadata(ctx context.Context) context.Context {

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -130,17 +130,12 @@ type MetricsRecorder struct {
 		storeRegistries map[roachpb.StoreID]*metric.Registry
 		stores          map[roachpb.StoreID]storeMetrics
 	}
-	// PrometheusExporter is not thread-safe even for operations that are
-	// logically read-only, but we don't want to block using it just because
-	// another goroutine is reading from the registries (i.e. using
-	// `mu.RLock()`), so we use a separate mutex just for prometheus.
-	// NOTE: promMu should always be locked BEFORE trying to lock mu.
-	promMu struct {
-		syncutil.Mutex
-		// prometheusExporter merges metrics into families and generates the
-		// prometheus text format.
-		prometheusExporter metric.PrometheusExporter
-	}
+
+	// prometheusExporter merges metrics into families and generates the
+	// prometheus text format. It has a ScrapeAndPrintAsText method for thread safe
+	// scrape and print so there is no need to have additional lock here.
+	prometheusExporter metric.PrometheusExporter
+
 	// WriteNodeStatus is a potentially long-running method (with a network
 	// round-trip) that requires a mutex to be safe for concurrent usage. We
 	// therefore give it its own mutex to avoid blocking other methods.
@@ -165,7 +160,7 @@ func NewMetricsRecorder(
 	}
 	mr.mu.storeRegistries = make(map[roachpb.StoreID]*metric.Registry)
 	mr.mu.stores = make(map[roachpb.StoreID]storeMetrics)
-	mr.promMu.prometheusExporter = metric.MakePrometheusExporter()
+	mr.prometheusExporter = metric.MakePrometheusExporter()
 	mr.clock = clock
 	return mr
 }
@@ -240,14 +235,9 @@ func (mr *MetricsRecorder) MarshalJSON() ([]byte, error) {
 	return json.Marshal(topLevel)
 }
 
-// scrapePrometheusLocked updates the prometheusExporter's metrics snapshot.
-func (mr *MetricsRecorder) scrapePrometheusLocked() {
-	mr.scrapeIntoPrometheus(&mr.promMu.prometheusExporter)
-}
-
-// scrapeIntoPrometheus updates the passed-in prometheusExporter's metrics
+// ScrapeIntoPrometheus updates the passed-in prometheusExporter's metrics
 // snapshot.
-func (mr *MetricsRecorder) scrapeIntoPrometheus(pm *metric.PrometheusExporter) {
+func (mr *MetricsRecorder) ScrapeIntoPrometheus(pm *metric.PrometheusExporter) {
 	mr.mu.RLock()
 	defer mr.mu.RUnlock()
 	if mr.mu.nodeRegistry == nil {
@@ -268,20 +258,11 @@ func (mr *MetricsRecorder) scrapeIntoPrometheus(pm *metric.PrometheusExporter) {
 // This is to avoid hanging requests from holding the lock.
 func (mr *MetricsRecorder) PrintAsText(w io.Writer) error {
 	var buf bytes.Buffer
-	if err := mr.lockAndPrintAsText(&buf); err != nil {
+	if err := mr.prometheusExporter.ScrapeAndPrintAsText(&buf, mr.ScrapeIntoPrometheus); err != nil {
 		return err
 	}
 	_, err := buf.WriteTo(w)
 	return err
-}
-
-// lockAndPrintAsText grabs the recorder lock and generates the prometheus
-// metrics page.
-func (mr *MetricsRecorder) lockAndPrintAsText(w io.Writer) error {
-	mr.promMu.Lock()
-	defer mr.promMu.Unlock()
-	mr.scrapePrometheusLocked()
-	return mr.promMu.prometheusExporter.PrintAsText(w)
 }
 
 // ExportToGraphite sends the current metric values to a Graphite server.
@@ -291,7 +272,7 @@ func (mr *MetricsRecorder) lockAndPrintAsText(w io.Writer) error {
 func (mr *MetricsRecorder) ExportToGraphite(
 	ctx context.Context, endpoint string, pm *metric.PrometheusExporter,
 ) error {
-	mr.scrapeIntoPrometheus(pm)
+	mr.ScrapeIntoPrometheus(pm)
 	graphiteExporter := metric.MakeGraphiteExporter(pm)
 	return graphiteExporter.Push(ctx, endpoint)
 }

--- a/pkg/server/status/recorder_test.go
+++ b/pkg/server/status/recorder_test.go
@@ -207,7 +207,6 @@ func TestMetricsRecorder(t *testing.T) {
 		{"testAggCounter", "aggcounter", 7},
 
 		// Stats needed for store summaries.
-		{"ranges", "counter", 1},
 		{"replicas.leaders", "gauge", 1},
 		{"replicas.leaseholders", "gauge", 1},
 		{"ranges", "gauge", 1},

--- a/pkg/testutils/metrictestutils/metrics_text.go
+++ b/pkg/testutils/metrictestutils/metrics_text.go
@@ -24,9 +24,11 @@ import (
 // to the given regexp, sorts them, and returns them in a multi-line string.
 func GetMetricsText(registry *metric.Registry, re *regexp.Regexp) (string, error) {
 	ex := metric.MakePrometheusExporter()
-	ex.ScrapeRegistry(registry, true /* includeChildMetrics */)
+	scrape := func(ex *metric.PrometheusExporter) {
+		ex.ScrapeRegistry(registry, true /* includeChildMetrics */)
+	}
 	var in bytes.Buffer
-	if err := ex.PrintAsText(&in); err != nil {
+	if err := ex.ScrapeAndPrintAsText(&in, scrape); err != nil {
 		return "", err
 	}
 	sc := bufio.NewScanner(&in)

--- a/pkg/util/metric/aggmetric/agg_metric_test.go
+++ b/pkg/util/metric/aggmetric/agg_metric_test.go
@@ -33,8 +33,10 @@ func TestAggMetric(t *testing.T) {
 	writePrometheusMetrics := func(t *testing.T) string {
 		var in bytes.Buffer
 		ex := metric.MakePrometheusExporter()
-		ex.ScrapeRegistry(r, true /* includeChildMetrics */)
-		require.NoError(t, ex.PrintAsText(&in))
+		scrape := func(ex *metric.PrometheusExporter) {
+			ex.ScrapeRegistry(r, true /* includeChildMetrics */)
+		}
+		require.NoError(t, ex.ScrapeAndPrintAsText(&in, scrape))
 		var lines []string
 		for sc := bufio.NewScanner(&in); sc.Scan(); {
 			if !bytes.HasPrefix(sc.Bytes(), []byte{'#'}) {

--- a/pkg/util/metric/registry_test.go
+++ b/pkg/util/metric/registry_test.go
@@ -164,6 +164,25 @@ func TestRegistry(t *testing.T) {
 		t.Fatalf("missed names: %v", expNames)
 	}
 
+	// Test Select
+	selectExpNames := map[string]struct{}{
+		"top.histogram":   {},
+		"top.gauge":       {},
+		"not.in.registry": {},
+	}
+
+	r.Select(
+		selectExpNames,
+		func(name string, _ interface{}) {
+			if _, exist := selectExpNames[name]; !exist {
+				t.Errorf("unexpected name: %s", name)
+			}
+			delete(selectExpNames, name)
+		})
+	if len(selectExpNames) != 1 {
+		t.Fatalf("missed or selected names not in registry: %v", selectExpNames)
+	}
+
 	// Test get functions
 	if g := r.getGauge("top.gauge"); g != topGauge {
 		t.Errorf("getGauge returned %v, expected %v", g, topGauge)


### PR DESCRIPTION
Previously PrometheusExporter could only export all the metrics in a
registry without ability to select a subset. For serverless we use a
separate metric endpoint (_status/load)  that currently shows cpu
utilization metrics that are generated each time the metrics are
pulled. We need however some additional metrics that are currently
tracked by MetricRecorder. Exporting all the metrics tracked by the
MetricRecorder is not desirable, as this incurs performance penalty
given the higher poll rate on the load endpoint.
So this PR modifies PrometheusExporter to only scrape a subset of all
the metrics.
A second change is how the locking is done when scraping and writing the
scraped output. Previously the lock when doing that was external and
was a responsibility of the caller. This PR adds a ScrapeAndPrintAsText
method to the exporter that is thread safe and does the locking
internally.

Release justification: Low risk, high reward changes to existing functionality
Release note: None

Jira issue: CRDB-14803