### PR TITLE
server/status: add load related metrics

### DIFF
--- a/pkg/ccl/serverccl/tenant_vars_test.go
+++ b/pkg/ccl/serverccl/tenant_vars_test.go
@@ -117,4 +117,11 @@ func TestTenantVars(t *testing.T) {
 
 	require.LessOrEqual(t, float64(cpuTime.User)*1e6, cpuUserNanos2)
 	require.LessOrEqual(t, float64(cpuTime.Sys)*1e6, cpuSysNanos2)
+
+	_, found = metrics["jobs_running_non_idle"]
+	require.True(t, found)
+	_, found = metrics["sql_query_count"]
+	require.True(t, found)
+	_, found = metrics["sql_conns"]
+	require.True(t, found)
 }

--- a/pkg/server/server_http.go
+++ b/pkg/server/server_http.go
@@ -155,7 +155,7 @@ func (s *httpServer) setupRoutes(
 	// The /_status/vars endpoint is not authenticated either. Useful for monitoring.
 	s.mux.Handle(statusVars, http.HandlerFunc(varsHandler{metricSource, s.cfg.Settings}.handleVars))
 	// Same for /_status/load.
-	s.mux.Handle(loadStatusVars, http.HandlerFunc(makeStatusLoadHandler(ctx, runtimeStatSampler)))
+	s.mux.Handle(loadStatusVars, http.HandlerFunc(makeStatusLoadHandler(ctx, runtimeStatSampler, metricSource)))
 
 	if apiServer != nil {
 		// The new "v2" HTTP API tree.


### PR DESCRIPTION
Previously there were only CPU related metrics available on the
_status/load endpoint. For serverless we need in addition to these, the
metrics which show the total number of current sql connections, the
number of sql queries executed and the number of jobs currently running
that are not idle. This PR adds the three new metrics by using selective
prometheus exporter and scraping the MetricsRecorder.

Release justification: Low risk, high reward changes to existing functionality

Release note: None

Will be re-based once #79021 and #79022 are merged.