### PR TITLE
release-21.2: backupccl: fix nil pointer exception in restore OnFailOrCancel

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1890,6 +1890,7 @@ func emitRestoreJobEvent(
 // change stuff to delete the keys in the background.
 func (r *restoreResumer) OnFailOrCancel(ctx context.Context, execCtx interface{}) error {
 	p := execCtx.(sql.JobExecContext)
+	r.execCfg = p.ExecCfg()
 	// Emit to the event log that the job has started reverting.
 	emitRestoreJobEvent(ctx, p, jobs.StatusReverting, r.job)
 

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -5057,7 +5057,7 @@ func TestImportWorkerFailure(t *testing.T) {
 	}
 
 	// But the job should be restarted and succeed eventually.
-	jobutils.WaitForJob(t, sqlDB, jobID)
+	jobutils.WaitForJobToSucceed(t, sqlDB, jobID)
 	sqlDB.CheckQueryResults(t,
 		`SELECT * FROM t ORDER BY i`,
 		sqlDB.QueryStr(t, `SELECT * FROM generate_series(0, $1)`, count-1),

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
@@ -125,7 +125,7 @@ INSERT INTO d.t2 VALUES (2);
 		`SELECT crdb_internal.complete_stream_ingestion_job($1, $2)`,
 		ingestionJobID, cutoverTime)
 
-	jobutils.WaitForJob(t, destSQL, jobspb.JobID(ingestionJobID))
+	jobutils.WaitForJobToSucceed(t, destSQL, jobspb.JobID(ingestionJobID))
 
 	query := "SELECT * FROM d.t1"
 	sourceData := sourceSQL.QueryStr(t, query)

--- a/pkg/sql/stats/create_stats_job_test.go
+++ b/pkg/sql/stats/create_stats_job_test.go
@@ -113,7 +113,7 @@ func TestCreateStatsControlJob(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		jobutils.WaitForJob(t, sqlDB, jobID)
+		jobutils.WaitForJobToSucceed(t, sqlDB, jobID)
 
 		// Now the job should have succeeded in producing stats.
 		sqlDB.CheckQueryResults(t,
@@ -230,7 +230,7 @@ func TestAtMostOneRunningCreateStats(t *testing.T) {
 
 	// Verify that the first job completed successfully.
 	sqlDB.Exec(t, fmt.Sprintf("RESUME JOB %d", jobID))
-	jobutils.WaitForJob(t, sqlDB, jobID)
+	jobutils.WaitForJobToSucceed(t, sqlDB, jobID)
 	<-errCh
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #78940.

/cc @cockroachdb/release

---

The execCfg field on the restore resumer was not being set correctly
in the OnFailOrCancel hook. This would lead to a nil pointer exception
during cleanup.

Other jobs such as import, backup use the execCfg directly off the
JobExecContext instead of storing it on the resumer. An alternative to
this fix could be to change all `r.ExecCfg` to use the execCfg on the JobExecContext.

Fixes: #76720

Release note (bug fix): Fixes a nil pointer exception during the
cleanup of a failed or cancelled restore job.

Release justification: High impact fix to existing functionality. Prevents a potential nil pointer exception.