### PR TITLE
release-21.2: sql: optionally group statement statistics by transaction fingerprint ID

### DIFF
--- a/pkg/sql/sqlstats/sslocal/BUILD.bazel
+++ b/pkg/sql/sqlstats/sslocal/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "sslocal",
     srcs = [
+        "cluster_settings.go",
         "sql_stats.go",
         "sql_stats_controller.go",
         "sslocal_iterator.go",
@@ -47,6 +48,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/server/serverpb",
+        "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/sessionphase",
@@ -54,6 +56,7 @@ go_test(
         "//pkg/sql/sqlstats/persistedsqlstats",
         "//pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil",
         "//pkg/sql/tests",
+        "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",

--- a/pkg/sql/sqlstats/sslocal/cluster_settings.go
+++ b/pkg/sql/sqlstats/sslocal/cluster_settings.go
@@ -1,0 +1,25 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sslocal
+
+import "github.com/cockroachdb/cockroach/pkg/settings"
+
+// AssociateStmtWithTxnFingerprint determines whether to segment
+// per-statement statistics by transaction fingerprint. While enabled by
+// default, it may be useful to disable for workloads that run the same
+// statements across many (ad-hoc) transaction fingerprints, producing
+// higher-cardinality data in the system.statement_statistics table than
+// the cleanup job is able to keep up with. See #78338.
+var AssociateStmtWithTxnFingerprint = settings.RegisterBoolSetting(
+	"sql.stats.associate_stmt_with_txn_fingerprint.enabled",
+	"whether to segment per-statement query statistics by transaction fingerprint",
+	true,
+)

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessionphase"
@@ -26,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/sslocal"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -483,6 +485,124 @@ func TestExplicitTxnFingerprintAccounting(t *testing.T) {
 		require.Equal(t, tc.curFingerprintCount, sqlStats.GetTotalFingerprintCount(),
 			"testCase: %+v", tc)
 	}
+}
+
+func TestAssociatingStmtStatsWithTxnFingerprint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	type simulatedTxn struct {
+		stmtFingerprints               []string
+		expectedStatsCountWhenEnabled  int
+		expectedStatsCountWhenDisabled int
+	}
+
+	// The test will run these simulated txns serially, stopping to check
+	// the cumulative statement stats counts along the way.
+	simulatedTxns := []simulatedTxn{
+		{
+			stmtFingerprints: []string{
+				"BEGIN",
+				"SELECT _",
+				"COMMIT",
+			},
+			expectedStatsCountWhenEnabled:  3,
+			expectedStatsCountWhenDisabled: 3,
+		},
+		{
+			stmtFingerprints: []string{
+				"BEGIN",
+				"SELECT _",
+				"SELECT _, _",
+				"COMMIT",
+			},
+			expectedStatsCountWhenEnabled:  7, // All 4 fingerprints look new, since they belong to a new txn fingerprint.
+			expectedStatsCountWhenDisabled: 4, // Only the `SELECT _, _` looks new, since txn fingerprint doesn't matter.
+		},
+	}
+
+	st := cluster.MakeTestingClusterSettings()
+	updater := st.MakeUpdater()
+	monitor := mon.NewUnlimitedMonitor(
+		context.Background(),
+		"test",
+		mon.MemoryResource,
+		nil,
+		nil,
+		math.MaxInt64,
+		st,
+	)
+
+	testutils.RunTrueAndFalse(t, "enabled", func(t *testing.T, enabled bool) {
+		// Establish the cluster setting.
+		setting := sslocal.AssociateStmtWithTxnFingerprint
+		err := updater.Set(ctx, "sql.stats.associate_stmt_with_txn_fingerprint.enabled",
+			settings.EncodeBool(enabled),
+			setting.Typ(),
+		)
+		require.NoError(t, err)
+
+		// Construct the SQL Stats machinery.
+		sqlStats := sslocal.New(
+			st,
+			sqlstats.MaxMemSQLStatsStmtFingerprints,
+			sqlstats.MaxMemSQLStatsTxnFingerprints,
+			nil,
+			nil,
+			monitor,
+			nil,
+			nil,
+		)
+		appStats := sqlStats.GetApplicationStats("" /* appName */)
+		statsCollector := sslocal.NewStatsCollector(
+			st,
+			appStats,
+			sessionphase.NewTimes(),
+			nil, /* knobs */
+		)
+
+		for _, txn := range simulatedTxns {
+			// Collect stats for the simulated transaction.
+			txnFingerprintIDHash := util.MakeFNV64()
+			statsCollector.StartExplicitTransaction()
+
+			for _, fingerprint := range txn.stmtFingerprints {
+				stmtFingerprintID, err := statsCollector.RecordStatement(
+					ctx,
+					roachpb.StatementStatisticsKey{Query: fingerprint},
+					sqlstats.RecordedStmtStats{},
+				)
+				require.NoError(t, err)
+				txnFingerprintIDHash.Add(uint64(stmtFingerprintID))
+			}
+
+			transactionFingerprintID := roachpb.TransactionFingerprintID(txnFingerprintIDHash.Sum())
+			statsCollector.EndExplicitTransaction(ctx, transactionFingerprintID)
+			err := statsCollector.RecordTransaction(ctx, transactionFingerprintID, sqlstats.RecordedTxnStats{})
+			require.NoError(t, err)
+
+			// Gather the collected stats so that we can assert on them.
+			var stats []*roachpb.CollectedStatementStatistics
+			err = statsCollector.IterateStatementStats(
+				ctx,
+				&sqlstats.IteratorOptions{},
+				func(_ context.Context, s *roachpb.CollectedStatementStatistics) error {
+					stats = append(stats, s)
+					return nil
+				},
+			)
+			require.NoError(t, err)
+
+			// Make sure we see the counts we expect.
+			expectedCount := txn.expectedStatsCountWhenEnabled
+			if !enabled {
+				expectedCount = txn.expectedStatsCountWhenDisabled
+			}
+			require.Equal(t, expectedCount, len(stats), "testCase: %+v, stats: %+v", txn, stats)
+		}
+	})
 }
 
 func TestTxnStatsDiscardedAfterPrematureStatementExecutionAbortion(t *testing.T) {


### PR DESCRIPTION
Backport 1/1 commits from #78671.

/cc @cockroachdb/release

Release justification: Category 4: Low risk, high benefit changes to existing functionality

---

Fixes #78338.

We have seen some workloads where the same statements are executed
across multiple ad-hoc transactions, each with a different transaction
fingerprint ID, resulting in so many rows being flushed to the
`system.statement_statistics` table that the cleanup job isn't able to
keep up.

This commit introduces a new cluster setting,
`sql.metrics.statement_details.segment_by_txn_fingerprint.enabled`,
that may be disabled to mitigate against the impact of these
high-cardinality statistics.

(Not filing a release note as this is not intended to be a public
cluster setting.)

Release note: None
