### PR TITLE
sql: use qualifiable schema name for comment on schema

### DIFF
--- a/docs/generated/sql/bnf/comment.bnf
+++ b/docs/generated/sql/bnf/comment.bnf
@@ -1,6 +1,6 @@
 comment_stmt ::=
 	'COMMENT' 'ON' 'DATABASE' database_name 'IS' comment_text
-	| 'COMMENT' 'ON' 'SCHEMA' schema_name 'IS' comment_text
+	| 'COMMENT' 'ON' 'SCHEMA' qualifiable_schema_name 'IS' comment_text
 	| 'COMMENT' 'ON' 'TABLE' table_name 'IS' comment_text
 	| 'COMMENT' 'ON' 'COLUMN' column_name 'IS' comment_text
 	| 'COMMENT' 'ON' 'INDEX' table_index_name 'IS' comment_text

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -58,7 +58,7 @@ copy_from_stmt ::=
 
 comment_stmt ::=
 	'COMMENT' 'ON' 'DATABASE' database_name 'IS' comment_text
-	| 'COMMENT' 'ON' 'SCHEMA' schema_name 'IS' comment_text
+	| 'COMMENT' 'ON' 'SCHEMA' qualifiable_schema_name 'IS' comment_text
 	| 'COMMENT' 'ON' 'TABLE' table_name 'IS' comment_text
 	| 'COMMENT' 'ON' 'COLUMN' column_path 'IS' comment_text
 	| 'COMMENT' 'ON' 'INDEX' table_index_name 'IS' comment_text
@@ -298,8 +298,9 @@ comment_text ::=
 	'SCONST'
 	| 'NULL'
 
-schema_name ::=
+qualifiable_schema_name ::=
 	name
+	| name '.' name
 
 column_path ::=
 	name
@@ -1376,10 +1377,6 @@ privilege ::=
 type_name_list ::=
 	( type_name ) ( ( ',' type_name ) )*
 
-qualifiable_schema_name ::=
-	name
-	| name '.' name
-
 type_list ::=
 	( typename ) ( ( ',' typename ) )*
 
@@ -2023,6 +2020,9 @@ alter_zone_partition_stmt ::=
 	'ALTER' 'PARTITION' partition_name 'OF' 'TABLE' table_name set_zone_config
 	| 'ALTER' 'PARTITION' partition_name 'OF' 'INDEX' table_index_name set_zone_config
 	| 'ALTER' 'PARTITION' partition_name 'OF' 'INDEX' table_name '@' '*' set_zone_config
+
+schema_name ::=
+	name
 
 opt_add_val_placement ::=
 	'BEFORE' 'SCONST'

--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -854,10 +854,18 @@ statement ok
 CREATE DATABASE comment_db
 
 statement ok
-USE comment_db
+CREATE SCHEMA comment_db.foo
 
 statement ok
-CREATE SCHEMA foo
+COMMENT ON SCHEMA comment_db.foo IS 'foo'
+
+query T
+SELECT comment FROM system.comments LIMIT 1
+----
+foo
+
+statement ok
+USE comment_db
 
 statement ok
 COMMENT ON SCHEMA foo IS 'bar'

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3682,9 +3682,9 @@ comment_stmt:
   {
     $$.val = &tree.CommentOnDatabase{Name: tree.Name($4), Comment: $6.strPtr()}
   }
-| COMMENT ON SCHEMA schema_name IS comment_text
+| COMMENT ON SCHEMA qualifiable_schema_name IS comment_text
   {
-    $$.val = &tree.CommentOnSchema{Name: tree.Name($4), Comment: $6.strPtr()}
+    $$.val = &tree.CommentOnSchema{Name: $4.objectNamePrefix(), Comment: $6.strPtr()}
   }
 | COMMENT ON TABLE table_name IS comment_text
   {

--- a/pkg/sql/sem/tree/comment_on_schema.go
+++ b/pkg/sql/sem/tree/comment_on_schema.go
@@ -14,7 +14,7 @@ import "github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 
 // CommentOnSchema represents an COMMENT ON SCHEMA statement.
 type CommentOnSchema struct {
-	Name    Name
+	Name    ObjectNamePrefix
 	Comment *string
 }
 


### PR DESCRIPTION
Previously we only use current db to resolve a schema when comment
on a schema. This is painful at least for our testing sometimes
because we need to switch db before commenting on a schema.

Release justification: low impact but can be useful for users.
Release note (sql change): `COMMENT ON SCHEMA` now can use qualified
schema name. So can do both `COMMENT ON SCHEMA sc_name ...` and
`COMMENT ON SCHEMA db_name.sc_name ...`.