### PR TITLE
dev,bazel: don't do nogo checks by default; have doctor advise

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,16 +1,30 @@
+# Define a set up flag aliases, so people can use `--cross` instead of the
+# longer `//build/toolchains:cross_flag`.
+build --flag_alias=crdb_test=//build/toolchains:crdb_test_flag
+build --flag_alias=cross=//build/toolchains:cross_flag
+build --flag_alias=dev=//build/toolchains:dev_flag
+build --flag_alias=with_ui=//pkg/ui:with_ui_flag
+
+build:cross --cross
+build:dev --dev
+build:nonogo --//build/toolchains:nonogo_flag
+build:test --crdb_test
+build:with_ui --with_ui
+
+# Basic settings.
 build --define gotags=bazel,gss
 build --experimental_proto_descriptor_sets_include_source_info
 build --incompatible_strict_action_env --incompatible_enable_cc_toolchain_resolution
 build --symlink_prefix=_bazel/
 test --config=test --experimental_ui_max_stdouterr_bytes=10485760
-build:with_ui --define cockroach_with_ui=y
-build:test --define crdb_test=y
+build --ui_event_filters=-DEBUG
+query --ui_event_filters=-DEBUG
+clean --ui_event_filters=-WARNING
+info --ui_event_filters=-WARNING
+
 build:race --@io_bazel_rules_go//go/config:race --test_env=GORACE=halt_on_error=1 --test_sharding_strategy=disabled
 test:test --test_env=TZ=
 test:race --test_timeout=1200,6000,18000,72000
-
-build --ui_event_filters=-DEBUG
-query --ui_event_filters=-DEBUG
 
 # CI should always run with `--config=ci`.
 build:ci --experimental_convenience_symlinks=ignore
@@ -23,7 +37,6 @@ test:ci --test_output=errors
 test:ci --test_tmpdir=/artifacts/tmp
 
 build:cross --stamp
-build:cross --define cockroach_cross=y
 
 # Cross-compilation configurations. Add e.g. --config=crosslinux to turn these on.
 # Generally these should be used for development builds. Each cross config has
@@ -52,12 +65,9 @@ build:crosslinuxarmbase --config=cross
 # NB: This is consumed in `BUILD` files (see build/toolchains/BUILD.bazel).
 build:devdarwinx86_64 --platforms=//build/toolchains:darwin_x86_64
 build:devdarwinx86_64 --config=dev
-build:dev --define cockroach_bazel_dev=y
 build:dev --stamp --workspace_status_command=./build/bazelutil/stamp.sh
 build:dev --action_env=PATH
 build:dev --host_action_env=PATH
-
-build:nonogo --define cockroach_nonogo=y
 
 try-import %workspace%/.bazelrc.user
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -3,11 +3,16 @@
 build --flag_alias=crdb_test=//build/toolchains:crdb_test_flag
 build --flag_alias=cross=//build/toolchains:cross_flag
 build --flag_alias=dev=//build/toolchains:dev_flag
+build --flag_alias=lintonbuild=//build/toolchains:nogo_flag
+build --flag_alias=nolintonbuild=//build/toolchains:nonogo_explicit_flag
 build --flag_alias=with_ui=//pkg/ui:with_ui_flag
 
 build:cross --cross
 build:dev --dev
-build:nonogo --//build/toolchains:nonogo_flag
+build:lintonbuild --lintonbuild
+build:nolintonbuild --nolintonbuild
+# Note: nonogo is classically the name of the nolintonbuild configuration.
+build:nonogo --nolintonbuild
 build:test --crdb_test
 build:with_ui --with_ui
 
@@ -28,6 +33,7 @@ test:race --test_timeout=1200,6000,18000,72000
 
 # CI should always run with `--config=ci`.
 build:ci --experimental_convenience_symlinks=ignore
+build:ci --lintonbuild
 # Set `-test.v` in Go tests.
 # Ref: https://github.com/bazelbuild/rules_go/pull/2456
 test:ci --test_env=GO_TEST_WRAP_TESTV=1

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -143,8 +143,7 @@ nogo(
     config = "//build/bazelutil:nogo_config.json",
     visibility = ["//visibility:public"],
     deps = select({
-        "//build/toolchains:nonogo": [],
-        "//conditions:default": [
+        "//build/toolchains:nogo": [
             "@org_golang_x_tools//go/analysis/passes/asmdecl:go_default_library",
             "@org_golang_x_tools//go/analysis/passes/assign:go_default_library",
             "@org_golang_x_tools//go/analysis/passes/atomic:go_default_library",
@@ -198,5 +197,6 @@ nogo(
             "//pkg/testutils/lint/passes/timer",
             "//pkg/testutils/lint/passes/unconvert",
         ] + STATICCHECK_CHECKS,
+        "//conditions:default": [],
     }),
 )

--- a/build/bazelutil/BUILD.bazel
+++ b/build/bazelutil/BUILD.bazel
@@ -1,5 +1,6 @@
 exports_files(["nogo_config.json"])
 
+load("@bazel_skylib//rules:analysis_test.bzl", "analysis_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load(":lint.bzl", "lint_binary")
 
@@ -8,6 +9,17 @@ genrule(
     outs = ["test_stamping.txt"],
     cmd = """cat bazel-out/stable-status.txt | grep STABLE_BUILD > $@""",
     stamp = True,
+)
+
+analysis_test(
+    name = "test_nogo_configured",
+    targets = select(
+        {
+            "//build/toolchains:nogo": [],
+            "//build/toolchains:nonogo_explicit": [],
+        },
+        no_match_error = "must use exactly one of `--config lintonbuild` or `--config nolintonbuild` explicitly",
+    ),
 )
 
 lint_binary(

--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+
 toolchain(
     name = "cross_linux_toolchain",
     exec_compatible_with = [
@@ -123,24 +125,42 @@ platform(
     ],
 )
 
+bool_flag(
+    name = "crdb_test_flag",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
 config_setting(
     name = "crdb_test",
-    define_values = {
-        "crdb_test": "y",
+    flag_values = {
+        ":crdb_test_flag": "true",
     },
+)
+
+bool_flag(
+    name = "dev_flag",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "dev",
-    define_values = {
-        "cockroach_bazel_dev": "y",
+    flag_values = {
+        ":dev_flag": "true",
     },
+)
+
+bool_flag(
+    name = "cross_flag",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "cross",
-    define_values = {
-        "cockroach_cross": "y",
+    flag_values = {
+        ":cross_flag": "true",
     },
 )
 
@@ -149,8 +169,8 @@ config_setting(
     constraint_values = [
         "@io_bazel_rules_go//go/toolchain:darwin",
     ],
-    define_values = {
-        "cockroach_cross": "y",
+    flag_values = {
+        ":cross_flag": "true",
     },
 )
 
@@ -159,8 +179,8 @@ config_setting(
     constraint_values = [
         "@io_bazel_rules_go//go/toolchain:linux",
     ],
-    define_values = {
-        "cockroach_cross": "y",
+    flag_values = {
+        ":cross_flag": "true",
     },
 )
 
@@ -171,9 +191,15 @@ config_setting(
     },
 )
 
+bool_flag(
+    name = "nonogo_flag",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
 config_setting(
     name = "nonogo",
-    define_values = {
-        "cockroach_nonogo": "y",
+    flag_values = {
+        ":nonogo_flag": "true",
     },
 )

--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -192,14 +192,32 @@ config_setting(
 )
 
 bool_flag(
-    name = "nonogo_flag",
+    name = "nogo_flag",
     build_setting_default = False,
     visibility = ["//visibility:public"],
 )
 
 config_setting(
-    name = "nonogo",
+    name = "nogo",
     flag_values = {
-        ":nonogo_flag": "true",
+        ":nogo_flag": "true",
     },
+)
+
+# Note: the flag nonogo_flag and config_setting nonogo_explicit aren't meant
+# to be directly used in select()'s. Not using nogo is the default behavior.
+# The flag and config_setting are here solely so that they can be used by `dev`
+# to check whether an option is configured.
+bool_flag(
+    name = "nonogo_explicit_flag",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "nonogo_explicit",
+    flag_values = {
+        ":nonogo_explicit_flag": "true",
+    },
+    visibility = ["//build/bazelutil:__pkg__"],
 )

--- a/dev
+++ b/dev
@@ -3,17 +3,21 @@
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=26
+DEV_VERSION=27
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions
 BINARY_PATH=$BINARY_DIR/dev.$DEV_VERSION
 
-if [[ ! -f "$BINARY_PATH" || ! -z "${DEV_FORCE_REBUILD-}" ]]; then
+if [[ -f "$BINARY_PATH" && ! -z "${DEV_FORCE_REBUILD-}" ]]; then
+    rm "$BINARY_PATH"
+fi
+
+if [[ ! -f "$BINARY_PATH" ]]; then
     echo "$BINARY_PATH not found, building..."
     mkdir -p $BINARY_DIR
-    bazel build //pkg/cmd/dev --config nonogo
-    cp $(bazel info bazel-bin --config nonogo)/pkg/cmd/dev/dev_/dev $BINARY_PATH
+    bazel build //pkg/cmd/dev --//build/toolchains:nogo_flag
+    cp $(bazel info bazel-bin --//build/toolchains:nogo_flag)/pkg/cmd/dev/dev_/dev $BINARY_PATH
     # The Bazel-built binary won't have write permissions.
     chmod a+w $BINARY_PATH
 fi

--- a/pkg/cmd/dev/cache.go
+++ b/pkg/cmd/dev/cache.go
@@ -136,11 +136,11 @@ func (d *dev) setUpCache(ctx context.Context) (string, error) {
 
 	log.Printf("Configuring cache...\n")
 
-	err := d.exec.CommandContextInheritingStdStreams(ctx, "bazel", "build", bazelRemoteTarget)
+	err := d.exec.CommandContextInheritingStdStreams(ctx, "bazel", "build", bazelRemoteTarget, "--//build/toolchains:nonogo_explicit_flag")
 	if err != nil {
 		return "", err
 	}
-	bazelRemoteLoc, err := d.exec.CommandContextSilent(ctx, "bazel", "run", bazelRemoteTarget, "--run_under=//build/bazelutil/whereis")
+	bazelRemoteLoc, err := d.exec.CommandContextSilent(ctx, "bazel", "run", bazelRemoteTarget, "--//build/toolchains:nonogo_explicit_flag", "--run_under=//build/bazelutil/whereis")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cmd/dev/lint.go
+++ b/pkg/cmd/dev/lint.go
@@ -76,5 +76,14 @@ func (d *dev) lint(cmd *cobra.Command, commandLine []string) error {
 		env = append(env, envvar)
 		return d.exec.CommandContextWithEnv(ctx, env, "bazel", args...)
 	}
-	return d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)
+	err := d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)
+	if err != nil {
+		return err
+	}
+	if !short {
+		args := []string{"build", "//pkg/cmd/cockroach-short", "--//build/toolchains:nogo_flag"}
+		logCommand("bazel", args...)
+		return d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)
+	}
+	return nil
 }

--- a/pkg/cmd/dev/testdata/datadriven/lint
+++ b/pkg/cmd/dev/testdata/datadriven/lint
@@ -2,6 +2,7 @@ exec
 dev lint
 ----
 bazel run --config=test //build/bazelutil:lint -- -test.v
+bazel build //pkg/cmd/cockroach-short --//build/toolchains:nogo_flag
 
 exec
 dev lint --short --timeout=5m
@@ -18,6 +19,7 @@ exec
 dev lint -f TestLowercaseFunctionNames --cpus 4
 ----
 bazel run --config=test //build/bazelutil:lint --local_cpu_resources=4 -- -test.v -test.run Lint/TestLowercaseFunctionNames
+bazel build //pkg/cmd/cockroach-short --//build/toolchains:nogo_flag
 
 exec
 dev lint pkg/cmd/dev pkg/spanconfig

--- a/pkg/ui/BUILD.bazel
+++ b/pkg/ui/BUILD.bazel
@@ -1,12 +1,13 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "ui",
     srcs = ["ui.go"],
     # keep
     embedsrcs = select({
-        "//pkg/ui:cockroach_with_ui": [
+        "//pkg/ui:with_ui": [
             "dist_vendor/list.min.js",
             "dist_vendor/.gitkeep",
         ],
@@ -24,10 +25,16 @@ go_library(
     ],
 )
 
+bool_flag(
+    name = "with_ui_flag",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
 config_setting(
-    name = "cockroach_with_ui",
-    define_values = {
-        "cockroach_with_ui": "y",
+    name = "with_ui",
+    flag_values = {
+        ":with_ui_flag": "true",
     },
     visibility = ["//visibility:public"],
 )

--- a/pkg/ui/distccl/BUILD.bazel
+++ b/pkg/ui/distccl/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 genrule(
     name = "genassets",
     srcs = select({
-        "//pkg/ui:cockroach_with_ui": ["//pkg/ui/workspaces/db-console:db-console-ccl"],
+        "//pkg/ui:with_ui": ["//pkg/ui/workspaces/db-console:db-console-ccl"],
         "//conditions:default": ["//pkg/ui:gen-empty-index.html"],
     }),
     outs = ["assets.tar.gz"],

--- a/pkg/ui/distoss/BUILD.bazel
+++ b/pkg/ui/distoss/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 genrule(
     name = "genassets",
     srcs = select({
-        "//pkg/ui:cockroach_with_ui": ["//pkg/ui/workspaces/db-console:db-console-oss"],
+        "//pkg/ui:with_ui": ["//pkg/ui/workspaces/db-console:db-console-oss"],
         "//conditions:default": ["//pkg/ui:gen-empty-index.html"],
     }),
     outs = ["assets.tar.gz"],


### PR DESCRIPTION
Up until this point `nogo` has been enabled by default and we've
required opting out with `--config nonogo`. Unfortunately `nogo` has a
non-negligible performance impact (see https://github.com/cockroachdb/cockroach/issues/73944) so having it on by
default is not what we want to be doing. Preserving the current behavior
as opt-in is still desirable though.

We have `dev doctor` advise about this case and recommend that you
explicitly set one of `--config lintonbuild` or
`--config nolintonbuild`. If you have neither or both configured,
`doctor` will detect that. (You can still override one with the other on
the command line.) We also have `dev lint` build `cockroach-short` with
`nogo` if running in non-`short` mode to cover that case for people who
have opted out of `nogo`.

`--config nonogo` is still supported as an alias for `nolintonbuild`.

Closes https://github.com/cockroachdb/cockroach/issues/73944.
Closes https://github.com/cockroachdb/cockroach/issues/78666.

Release note: None