### PR TITLE
release-22.1: sql: fix join reader errors hitting memory limit

### DIFF
--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -423,12 +423,16 @@ func newJoinReader(
 		}
 	}
 
-	// We will create a memory monitor with at least 100KiB of memory limit
-	// since the join reader doesn't know how to spill its in-memory state to
-	// disk (separate from the buffered rows). It is most likely that if the
-	// target limit is below 100KiB, then we're in a test scenario and we don't
-	// want to error out.
-	const minMemoryLimit = 100 << 10
+	// We will create a memory monitor with a hard memory limit since the join
+	// reader doesn't know how to spill its in-memory state to disk (separate
+	// from the buffered rows). It is most likely that if the target limit is
+	// really low then we're in a test scenario and we don't want to error out.
+	minMemoryLimit := int64(8 << 20)
+	// Streamer can handle lower memory limit and doing so makes testing at
+	// the limits more efficient.
+	if jr.usesStreamer {
+		minMemoryLimit = 100 << 10
+	}
 	memoryLimit := execinfra.GetWorkMemLimit(flowCtx)
 	if memoryLimit < minMemoryLimit {
 		memoryLimit = minMemoryLimit


### PR DESCRIPTION
Restore non-streamer memory limit lower bound to 8MiB for join reader.
Streamer can handle a lower limit so we lowered it to 100KiB but that is
too low for some cases (like sqllitetests).  Also tpchvec roachtest
has 650KiB lower limit for workmem which is too low for query 20 so
restoring the 8MiB lower bound will fix that as well.

In master where streamer is on limit remains 100KiB.

Fixes: https://github.com/cockroachdb/cockroach/issues/78247
Fixes: https://github.com/cockroachdb/cockroach/issues/78341
Fixes: https://github.com/cockroachdb/cockroach/issues/77929

Release note: None

Release justification: fixes tests and restores previous behavior.
