### PR TITLE
dev: copy built binaries rather than symlinking them

### DIFF
--- a/pkg/cmd/dev/testdata/datadriven/dev-build
+++ b/pkg/cmd/dev/testdata/datadriven/dev-build
@@ -6,9 +6,9 @@ bazel info workspace --color=no
 mkdir crdb-checkout/bin
 bazel info bazel-bin --color=no
 rm crdb-checkout/cockroach-short
-ln -s sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkout/cockroach-short
+cp sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkout/cockroach-short
 rm crdb-checkout/cockroach
-ln -s sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkout/cockroach
+cp sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkout/cockroach
 
 exec
 dev build cockroach-short --cpus=12
@@ -18,9 +18,9 @@ bazel info workspace --color=no
 mkdir crdb-checkout/bin
 bazel info bazel-bin --color=no
 rm crdb-checkout/cockroach-short
-ln -s sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkout/cockroach-short
+cp sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkout/cockroach-short
 rm crdb-checkout/cockroach
-ln -s sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkout/cockroach
+cp sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkout/cockroach
 
 exec
 dev build --debug short
@@ -30,9 +30,9 @@ bazel info workspace --color=no
 mkdir crdb-checkout/bin
 bazel info bazel-bin --color=no
 rm crdb-checkout/cockroach-short
-ln -s sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkout/cockroach-short
+cp sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkout/cockroach-short
 rm crdb-checkout/cockroach
-ln -s sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkout/cockroach
+cp sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkout/cockroach
 
 exec
 dev build short -- -s
@@ -42,9 +42,9 @@ bazel info workspace --color=no
 mkdir crdb-checkout/bin
 bazel info bazel-bin --color=no
 rm crdb-checkout/cockroach-short
-ln -s sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkout/cockroach-short
+cp sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkout/cockroach-short
 rm crdb-checkout/cockroach
-ln -s sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkout/cockroach
+cp sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkout/cockroach
 
 exec
 dev build -- --verbose_failures --sandbox_debug
@@ -55,7 +55,7 @@ bazel info workspace --color=no
 mkdir crdb-checkout/bin
 bazel info bazel-bin --color=no
 rm crdb-checkout/cockroach
-ln -s sandbox/pkg/cmd/cockroach/cockroach_/cockroach crdb-checkout/cockroach
+cp sandbox/pkg/cmd/cockroach/cockroach_/cockroach crdb-checkout/cockroach
 
 exec
 dev build stress
@@ -65,4 +65,4 @@ bazel info workspace --color=no
 mkdir crdb-checkout/bin
 bazel info bazel-bin --color=no
 rm crdb-checkout/bin/stress
-ln -s sandbox/external/com_github_cockroachdb_stress/stress_/stress crdb-checkout/bin/stress
+cp sandbox/external/com_github_cockroachdb_stress/stress_/stress crdb-checkout/bin/stress


### PR DESCRIPTION
This uses more disk space but is resilient to the confusing case
where your Bazel `output_base` gets deleted (either due to
`bazel clean --expunge` or if your `output_base` gets wiped due to a
macOS upgrade).

Release note: None