### PR TITLE
sysutil: explicitly chown file in TestGetFileACLInfo

### DIFF
--- a/pkg/util/sysutil/acl_unix_test.go
+++ b/pkg/util/sysutil/acl_unix_test.go
@@ -43,13 +43,22 @@ func TestGetFileACLInfo(t *testing.T) {
 		if err := ioutil.WriteFile(filename, exampleData, f.mode); err != nil {
 			t.Fatalf("#%d: could not write file %s: %v", testNum, f.filename, err)
 		}
+
+		// Explicitly set file ownership to account for
+		// different file GID behaviour amongst different
+		// unixes and filesystems.
+		expectedUID := os.Getuid()
+		expectedGID := os.Getgid()
+		if err := os.Chown(filename, expectedUID, expectedGID); err != nil {
+			t.Fatalf("#%d: could not chown file: %s: %v", testNum, f.filename, err)
+		}
 		info, err := os.Stat(filename)
 		if nil != err {
 			t.Errorf("#%d: failed to stat new test file %s: %v", testNum, f.filename, err)
 		}
 		aclInfo := GetFileACLInfo(info)
-		assert.True(t, aclInfo.IsOwnedByUID(uint64(os.Getuid())))
-		assert.True(t, aclInfo.IsOwnedByGID(uint64(os.Getgid())))
+		assert.True(t, aclInfo.IsOwnedByUID(uint64(expectedUID)))
+		assert.True(t, aclInfo.IsOwnedByGID(uint64(expectedGID)))
 		assert.False(t, ExceedsPermissions(aclInfo.Mode(), f.mode))
 	}
 }


### PR DESCRIPTION
This test assumed that the GID of a newly created file would match the
GID of the creating process.

While this is a reasonable assumption on Linux, it isn't strictly true
across all unix-like operating systems and filesystem..

_The Linux Programming Interface_ summarises the situation on Linux:

> The group ID of the new file may be taken from either the effective
group ID of the process (equivalent to the System V default behavior)
or the group ID of the parent directory (the BSD behavior)...Which of
the two values is used as the new file's group ID is determined by
various factors, including the type of file system on which the new
file is created. [0]

On macOS, the default behavior appears to be the BSD behavior, leading
to this test failing under Bazel when the temporary directory's GID is
0 (wheel) instead of the user's primary group ID.

To solve this, we explicitly change the ownership of the file to a
known UID and GID.

[0] Michael Kerrisk. 2010. The Linux Programming Interface: A Linux
and UNIX System Programming Handbook (1st. ed.). No Starch Press,
USA. Page 291.

Release note: None