### PR TITLE
roachtest: clearrange: update skipped test comment

### DIFF
--- a/pkg/cmd/roachtest/tests/clearrange.go
+++ b/pkg/cmd/roachtest/tests/clearrange.go
@@ -45,7 +45,7 @@ func registerClearRange(r registry.Registry) {
 		// and may need to be tweaked.
 		r.Add(registry.TestSpec{
 			Name:  fmt.Sprintf(`clearrange/zfs/checks=%t`, checks),
-			Skip:  "Consistently failing. See #70306 and #68420 for context.",
+			Skip:  "Consistently failing. See #68716 context.",
 			Owner: registry.OwnerStorage,
 			// 5h for import, 120 for the test. The import should take closer
 			// to <3:30h but it varies.


### PR DESCRIPTION
The ZFS clearrange tests are currently skipped. Update the comment to
reference the tracking issue.

Release note: None.