### PR TITLE
backupccl: mark backup ExportRequests as Bulk priority

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -409,14 +409,10 @@ func runBackupProcessor(
 					admissionHeader := roachpb.AdmissionHeader{
 						// Export requests are currently assigned NormalPri.
 						//
-						// TODO(bulkio): the priority should vary based on the urgency of
-						// these background requests. These exports should get LowPri,
-						// unless they are being retried and need to be completed in a
-						// timely manner for compliance with RPO and data retention
-						// policies. Consider deriving this from the UserPriority field.
-						Priority:                 int32(admission.NormalPri),
+						// TODO(dt): Consider linking this to/from the UserPriority field.
+						Priority:                 int32(admission.BulkNormalPri),
 						CreateTime:               timeutil.Now().UnixNano(),
-						Source:                   roachpb.AdmissionHeader_ROOT_KV,
+						Source:                   roachpb.AdmissionHeader_FROM_SQL,
 						NoMemoryReservedAtSource: true,
 					}
 					log.Infof(ctx, "sending ExportRequest for span %s (attempt %d, priority %s)",

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -152,6 +152,9 @@ const (
 	TTLLowPri WorkPriority = -100
 	// UserLowPri is low priority work from user submissions (SQL).
 	UserLowPri WorkPriority = -50
+	// BulkNormalPri is bulk priority work from bulk jobs, which could be run due
+	// to user submissions or be automatic.
+	BulkNormalPri WorkPriority = -30
 	// NormalPri is normal priority work.
 	NormalPri WorkPriority = 0
 	// UserHighPri is high priority work from user submissions (SQL).


### PR DESCRIPTION
This adds a new "bulk normal" priority that is lower than normal user priority but higher than low user priority, and then assigns that priority on AddSSTable and Export requests.

Release note (bug fix): BACKUP read requests are now sent with lower admission control priority than normal traffic.

Jira issue: CRDB-14711
Epic CRDB-2264