### PR TITLE
docker test: use bazel.FindBinary() to find docker-fsnotify

### DIFF
--- a/pkg/testutils/docker/BUILD.bazel
+++ b/pkg/testutils/docker/BUILD.bazel
@@ -10,6 +10,8 @@ go_test(
     ],
     gotags = ["docker"],
     deps = [
+        "//pkg/build/bazel",
+        "//pkg/testutils",
         "//pkg/util/contextutil",
         "//pkg/util/log",
         "@com_github_cockroachdb_errors//:errors",


### PR DESCRIPTION
Before: the binary was being found manually.

Why: the old method of finding the binary was not correct. It may have
also been broken bay a bazel builder image update which then caused the
docker image test to start flaking.

Now: use the bazel provided way of finding a dependant binary:
`bazel.FindBinary()`.

Release note: None