### PR TITLE
bazel: upgrade to bazel 5.1.0

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,1 +1,1 @@
-cockroachdb/5.0.0
+cockroachdb/5.1.0


### PR DESCRIPTION
Release note: None