### PR TITLE
storage: add storage.marked-for-compaction-files metric

### DIFF
--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -404,7 +404,7 @@ var (
 	}
 	metaRdbNumSSTables = metric.Metadata{
 		Name:        "rocksdb.num-sstables",
-		Help:        "Number of rocksdb SSTables",
+		Help:        "Number of storage engine SSTables",
 		Measurement: "SSTables",
 		Unit:        metric.Unit_COUNT,
 	}
@@ -413,6 +413,12 @@ var (
 		Help:        "Estimated pending compaction bytes",
 		Measurement: "Storage",
 		Unit:        metric.Unit_BYTES,
+	}
+	metaRdbMarkedForCompactionFiles = metric.Metadata{
+		Name:        "storage.marked-for-compaction-files",
+		Help:        "Count of SSTables marked for compaction",
+		Measurement: "SSTables",
+		Unit:        metric.Unit_COUNT,
 	}
 	metaRdbL0Sublevels = metric.Metadata{
 		Name:        "storage.l0-sublevels",
@@ -1382,6 +1388,7 @@ type StoreMetrics struct {
 	RdbReadAmplification        *metric.Gauge
 	RdbNumSSTables              *metric.Gauge
 	RdbPendingCompaction        *metric.Gauge
+	RdbMarkedForCompactionFiles *metric.Gauge
 	RdbL0Sublevels              *metric.Gauge
 	RdbL0NumFiles               *metric.Gauge
 	RdbWriteStalls              *metric.Gauge
@@ -1827,6 +1834,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		RdbReadAmplification:        metric.NewGauge(metaRdbReadAmplification),
 		RdbNumSSTables:              metric.NewGauge(metaRdbNumSSTables),
 		RdbPendingCompaction:        metric.NewGauge(metaRdbPendingCompaction),
+		RdbMarkedForCompactionFiles: metric.NewGauge(metaRdbMarkedForCompactionFiles),
 		RdbL0Sublevels:              metric.NewGauge(metaRdbL0Sublevels),
 		RdbL0NumFiles:               metric.NewGauge(metaRdbL0NumFiles),
 		RdbWriteStalls:              metric.NewGauge(metaRdbWriteStalls),
@@ -2054,6 +2062,7 @@ func (sm *StoreMetrics) updateEngineMetrics(m storage.Metrics) {
 	sm.RdbTableReadersMemEstimate.Update(m.TableCache.Size)
 	sm.RdbReadAmplification.Update(int64(m.ReadAmp()))
 	sm.RdbPendingCompaction.Update(int64(m.Compact.EstimatedDebt))
+	sm.RdbMarkedForCompactionFiles.Update(int64(m.Compact.MarkedFiles))
 	sm.RdbL0Sublevels.Update(int64(m.Levels[0].Sublevels))
 	sm.RdbL0NumFiles.Update(m.Levels[0].NumFiles)
 	sm.RdbNumSSTables.Update(m.NumSSTables())

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -2604,6 +2604,15 @@ var charts = []sectionDescription{
 		},
 	},
 	{
+		Organization: [][]string{{StorageLayer, "RocksDB", "Migrations"}},
+		Charts: []chartDescription{
+			{
+				Title:   "SSTables Marked for Compaction",
+				Metrics: []string{"storage.marked-for-compaction-files"},
+			},
+		},
+	},
+	{
 		Organization: [][]string{{StorageLayer, "RocksDB", "Overview"}},
 		Charts: []chartDescription{
 			{


### PR DESCRIPTION
Add a timeseries metric for the count of files marked for compaction.
This metric isn't universally useful but it's expected to be useful as a
timeseries metric within specific contexts, particularly surrounding
storage-engine background migrations.

The 22.1 release included the first part of a two-step storage engine
migration (see #77634) which marks files for compaction if they're a
member of an 'atomic compaction unit' within Pebble.

This metric will be useful when upgraading from 22.1 to 22.2 to verify
that zero files are marked for compaction before upgrading to 22.2, at
which point compacting the remaining marked files will block upgrade
finalization.

The metric is expected to be useful going forward for future migrations
(eg, deprecating support for range-del-v1 blocks) or monitoring the
progress of online encryption-at-rest key rotation (#74804).

Release note (ops change): Adds a new metric for monitoring storage-level
background migrations.

Jira issue: CRDB-14762