### PR TITLE
pgwire: avoid internal error for tuple in prepared statement

### DIFF
--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -317,6 +317,12 @@ func DecodeDatum(
 	switch code {
 	case FormatText:
 		switch id {
+		case oid.T_record:
+			d, _, err := tree.ParseDTupleFromString(evalCtx, string(b), t)
+			if err != nil {
+				return nil, err
+			}
+			return d, nil
 		case oid.T_bool:
 			t, err := strconv.ParseBool(string(b))
 			if err != nil {

--- a/pkg/sql/pgwire/testdata/pgtest/tuple
+++ b/pkg/sql/pgwire/testdata/pgtest/tuple
@@ -64,3 +64,30 @@ ReadyForQuery
 {"Type":"DataRow","Values":[{"text":"(a,b,c,\"d \",e,\"f  \")"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Try to send a prepared statement with a tuple argument.
+# 'S' for Statement
+# ParameterFormatCodes = [0] for text format
+send
+Parse {"Name": "s4", "Query": "select $1 AS a", "ParameterOIDs": [2249]}
+Bind {"DestinationPortal": "p4", "PreparedStatement": "s4", "ParameterFormatCodes": [0], "Parameters": [{"text":"(1,cat)"}]}
+Execute {"Portal": "p4"}
+Sync
+----
+
+# Postgres has a slightly different error message.
+until noncrdb_only keepErrMessage
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ErrorResponse","Code":"0A000","Message":"input of anonymous composite types is not implemented"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+until crdb_only keepErrMessage
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ErrorResponse","Code":"0A000","Message":"error in argument for $1: could not parse \"(1,cat)\" as type tuple: cannot parse anonymous record type"}
+{"Type":"ReadyForQuery","TxStatus":"I"}


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/76283

Neither Postgres nor CRDB can handle this, but before this change, CRDB
would show an internal error that would cause a Sentry report. Now this
is fixed.

Release note: None