### PR TITLE
release-22.1: add deperacation for old SHOW BACKUP syntax and refactor SHOW BACKUP parser

### DIFF
--- a/docs/generated/sql/bnf/show_backup.bnf
+++ b/docs/generated/sql/bnf/show_backup.bnf
@@ -9,3 +9,6 @@ show_backup_stmt ::=
 	| 'SHOW' 'BACKUP' 'SCHEMAS' location 'WITH' kv_option_list
 	| 'SHOW' 'BACKUP' 'SCHEMAS' location 'WITH' 'OPTIONS' '(' kv_option_list ')'
 	| 'SHOW' 'BACKUP' 'SCHEMAS' location 
+	| 'SHOW' 'BACKUP' 'SCHEMAS' location 'IN' string_or_placeholder 'WITH' kv_option_list
+	| 'SHOW' 'BACKUP' 'SCHEMAS' location 'IN' string_or_placeholder 'WITH' 'OPTIONS' '(' kv_option_list ')'
+	| 'SHOW' 'BACKUP' 'SCHEMAS' location 'IN' string_or_placeholder 

--- a/docs/generated/sql/bnf/show_backup.bnf
+++ b/docs/generated/sql/bnf/show_backup.bnf
@@ -1,14 +1,20 @@
 show_backup_stmt ::=
 	'SHOW' 'BACKUPS' 'IN' location
-	| 'SHOW' 'BACKUP' string_or_placeholder 'WITH' kv_option_list
-	| 'SHOW' 'BACKUP' string_or_placeholder 'WITH' 'OPTIONS' '(' kv_option_list ')'
-	| 'SHOW' 'BACKUP' string_or_placeholder 
+	| 'SHOW' 'BACKUP' show_backup_details 'FROM' string_or_placeholder 'IN' string_or_placeholder 'WITH' kv_option_list
+	| 'SHOW' 'BACKUP' show_backup_details 'FROM' string_or_placeholder 'IN' string_or_placeholder 'WITH' 'OPTIONS' '(' kv_option_list ')'
+	| 'SHOW' 'BACKUP' show_backup_details 'FROM' string_or_placeholder 'IN' string_or_placeholder 
 	| 'SHOW' 'BACKUP' subdirectory 'IN' location 'WITH' kv_option_list
 	| 'SHOW' 'BACKUP' subdirectory 'IN' location 'WITH' 'OPTIONS' '(' kv_option_list ')'
 	| 'SHOW' 'BACKUP' subdirectory 'IN' location 
+	| 'SHOW' 'BACKUP' string_or_placeholder 'WITH' kv_option_list
+	| 'SHOW' 'BACKUP' string_or_placeholder 'WITH' 'OPTIONS' '(' kv_option_list ')'
+	| 'SHOW' 'BACKUP' string_or_placeholder 
 	| 'SHOW' 'BACKUP' 'SCHEMAS' location 'WITH' kv_option_list
 	| 'SHOW' 'BACKUP' 'SCHEMAS' location 'WITH' 'OPTIONS' '(' kv_option_list ')'
 	| 'SHOW' 'BACKUP' 'SCHEMAS' location 
-	| 'SHOW' 'BACKUP' 'SCHEMAS' location 'IN' string_or_placeholder 'WITH' kv_option_list
-	| 'SHOW' 'BACKUP' 'SCHEMAS' location 'IN' string_or_placeholder 'WITH' 'OPTIONS' '(' kv_option_list ')'
-	| 'SHOW' 'BACKUP' 'SCHEMAS' location 'IN' string_or_placeholder 
+	| 'SHOW' 'BACKUP' 'FILES' string_or_placeholder 'WITH' kv_option_list
+	| 'SHOW' 'BACKUP' 'FILES' string_or_placeholder 'WITH' 'OPTIONS' '(' kv_option_list ')'
+	| 'SHOW' 'BACKUP' 'FILES' string_or_placeholder 
+	| 'SHOW' 'BACKUP' 'RANGES' string_or_placeholder 'WITH' kv_option_list
+	| 'SHOW' 'BACKUP' 'RANGES' string_or_placeholder 'WITH' 'OPTIONS' '(' kv_option_list ')'
+	| 'SHOW' 'BACKUP' 'RANGES' string_or_placeholder 

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -701,6 +701,7 @@ show_backup_stmt ::=
 	| 'SHOW' 'BACKUP' string_or_placeholder opt_with_options
 	| 'SHOW' 'BACKUP' string_or_placeholder 'IN' string_or_placeholder opt_with_options
 	| 'SHOW' 'BACKUP' 'SCHEMAS' string_or_placeholder opt_with_options
+	| 'SHOW' 'BACKUP' 'SCHEMAS' string_or_placeholder 'IN' string_or_placeholder opt_with_options
 
 show_columns_stmt ::=
 	'SHOW' 'COLUMNS' 'FROM' table_name with_comment

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -698,10 +698,12 @@ use_stmt ::=
 
 show_backup_stmt ::=
 	'SHOW' 'BACKUPS' 'IN' string_or_placeholder
-	| 'SHOW' 'BACKUP' string_or_placeholder opt_with_options
+	| 'SHOW' 'BACKUP' show_backup_details 'FROM' string_or_placeholder 'IN' string_or_placeholder opt_with_options
 	| 'SHOW' 'BACKUP' string_or_placeholder 'IN' string_or_placeholder opt_with_options
+	| 'SHOW' 'BACKUP' string_or_placeholder opt_with_options
 	| 'SHOW' 'BACKUP' 'SCHEMAS' string_or_placeholder opt_with_options
-	| 'SHOW' 'BACKUP' 'SCHEMAS' string_or_placeholder 'IN' string_or_placeholder opt_with_options
+	| 'SHOW' 'BACKUP' 'FILES' string_or_placeholder opt_with_options
+	| 'SHOW' 'BACKUP' 'RANGES' string_or_placeholder opt_with_options
 
 show_columns_stmt ::=
 	'SHOW' 'COLUMNS' 'FROM' table_name with_comment
@@ -1767,6 +1769,11 @@ to_or_eq ::=
 var_value ::=
 	a_expr
 	| extra_var_value
+
+show_backup_details ::=
+	'SCHEMAS'
+	| 'FILES'
+	| 'RANGES'
 
 with_comment ::=
 	'WITH' 'COMMENT'

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/protoreflect"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -297,8 +298,17 @@ func showBackupPlanHook(
 			if err != nil {
 				return err
 			}
+		} else {
+			// Deprecation notice for old `SHOW BACKUP` syntax. Remove this once the syntax is
+			// deleted in 22.2.
+			p.BufferClientNotice(ctx,
+				pgnotice.Newf("The `SHOW BACKUP` syntax without the `IN` keyword will be removed in a"+
+					" future release. Please switch over to using `SHOW BACKUP FROM <backup> IN"+
+					" <collection>` to view metadata on a backup collection: %s."+
+					" Also note that backups created using the `BACKUP TO` syntax may not be showable or"+
+					" restoreable in the next major version release. Use `BACKUP INTO` instead.",
+					"https://www.cockroachlabs.com/docs/stable/show-backup.html"))
 		}
-
 		if err := checkShowBackupURIPrivileges(ctx, p, dest); err != nil {
 			return err
 		}

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -37,6 +37,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TODO (msbutler): when refactoring these tests to data driven tests, keep the
+// original go test on 22.1 and only use new backup syntax in data driven test
+
 func TestShowBackup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -492,7 +492,8 @@ func TestShowBackups(t *testing.T) {
 	// check that we can show the inc layers in the individual full backups.
 	b1 := sqlDBRestore.QueryStr(t, `SELECT * FROM [SHOW BACKUP $1 IN $2] WHERE object_type='table'`, rows[0][0], full)
 	require.Equal(t, 4, len(b1))
-	b2 := sqlDBRestore.QueryStr(t, `SELECT * FROM [SHOW BACKUP $1 IN $2] WHERE object_type='table'`, rows[1][0], full)
+	b2 := sqlDBRestore.QueryStr(t,
+		`SELECT * FROM [SHOW BACKUP FROM $1 IN $2] WHERE object_type='table'`, rows[1][0], full)
 	require.Equal(t, 3, len(b2))
 
 	require.Equal(t,
@@ -526,7 +527,8 @@ func TestShowNonDefaultBackups(t *testing.T) {
 	// Get base number of files, schemas, and ranges in the backup
 	var oldCount [3]int
 	for i, typ := range []string{"FILES", "SCHEMAS", "RANGES"} {
-		query := fmt.Sprintf(`SELECT count(*) FROM [SHOW BACKUP %s LATEST IN '%s']`, typ, fullNonDefault)
+		query := fmt.Sprintf(`SELECT count(*) FROM [SHOW BACKUP %s FROM LATEST IN '%s']`, typ,
+			fullNonDefault)
 		count, err := strconv.Atoi(sqlDB.QueryStr(t, query)[0][0])
 		require.NoError(t, err, "error converting original count to integer")
 		oldCount[i] = count
@@ -540,12 +542,13 @@ func TestShowNonDefaultBackups(t *testing.T) {
 	// Show backup should contain more rows as new files/schemas/ranges were
 	// added in the incremental backup
 	for i, typ := range []string{"FILES", "SCHEMAS", "RANGES"} {
-		query := fmt.Sprintf(`SELECT count(*) FROM [SHOW BACKUP %s LATEST IN '%s']`, typ, fullNonDefault)
+		query := fmt.Sprintf(`SELECT count(*) FROM [SHOW BACKUP %s FROM LATEST IN '%s']`, typ,
+			fullNonDefault)
 		newCount, err := strconv.Atoi(sqlDB.QueryStr(t, query)[0][0])
 		require.NoError(t, err, "error converting new count to integer")
 		require.Greater(t, newCount, oldCount[i])
 
-		queryInc := fmt.Sprintf(`SELECT count(*) FROM [SHOW BACKUP %s LATEST IN '%s' WITH incremental_location='%s']`, typ,
+		queryInc := fmt.Sprintf(`SELECT count(*) FROM [SHOW BACKUP %s FROM LATEST IN '%s' WITH incremental_location='%s']`, typ,
 			fullNonDefault, incNonDefault)
 		newCountInc, err := strconv.Atoi(sqlDB.QueryStr(t, queryInc)[0][0])
 		require.NoError(t, err, "error converting new count to integer")

--- a/pkg/ccl/backupccl/testdata/backup-restore/feature-flags
+++ b/pkg/ccl/backupccl/testdata/backup-restore/feature-flags
@@ -63,6 +63,11 @@ BACKUP TO 'nodelocal://1/deprecated';
 NOTICE: The `BACKUP TO` syntax will be removed in a future release, please switch over to using `BACKUP INTO` to create a backup collection: https://www.cockroachlabs.com/docs/stable/backup.html#considerations. Backups created using the `BACKUP TO` syntax may not be restoreable in the next major version release.
 
 exec-sql
+SHOW BACKUP 'nodelocal://1/deprecated';
+----
+NOTICE: The `SHOW BACKUP` syntax without the `IN` keyword will be removed in a future release. Please switch over to using `SHOW BACKUP FROM <backup> IN <collection>` to view metadata on a backup collection: https://www.cockroachlabs.com/docs/stable/show-backup.html. Also note that backups created using the `BACKUP TO` syntax may not be showable or restoreable in the next major version release. Use `BACKUP INTO` instead.
+
+exec-sql
 BACKUP TO 'nodelocal://1/deprecated/incfrom' INCREMENTAL FROM 'nodelocal://1/deprecated';
 ----
 NOTICE: The `BACKUP TO` syntax will be removed in a future release, please switch over to using `BACKUP INTO` to create a backup collection: https://www.cockroachlabs.com/docs/stable/backup.html#considerations. Backups created using the `BACKUP TO` syntax may not be restoreable in the next major version release.

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -5767,6 +5767,16 @@ show_backup_stmt:
       Options: $5.kvOptions(),
     }
   }
+| SHOW BACKUP SCHEMAS string_or_placeholder IN string_or_placeholder opt_with_options
+	{
+		$$.val = &tree.ShowBackup{
+			Details: tree.BackupDefaultDetails,
+			ShouldIncludeSchemas: true,
+			Path:    $4.expr(),
+			InCollection: $6.expr(),
+			Options: $7.kvOptions(),
+		}
+	}
 | SHOW BACKUP RANGES string_or_placeholder opt_with_options
   {
     /* SKIP DOC */
@@ -5775,6 +5785,16 @@ show_backup_stmt:
       Path:    $4.expr(),
       Options: $5.kvOptions(),
     }
+  }
+| SHOW BACKUP RANGES string_or_placeholder IN string_or_placeholder opt_with_options
+  {
+		/* SKIP DOC */
+		$$.val = &tree.ShowBackup{
+			Details: tree.BackupRangeDetails,
+			Path:    $4.expr(),
+			InCollection: $6.expr(),
+			Options: $7.kvOptions(),
+		}
   }
 | SHOW BACKUP FILES string_or_placeholder opt_with_options
   {
@@ -5785,6 +5805,16 @@ show_backup_stmt:
       Options: $5.kvOptions(),
     }
   }
+| SHOW BACKUP FILES string_or_placeholder IN string_or_placeholder opt_with_options
+	{
+		/* SKIP DOC */
+		$$.val = &tree.ShowBackup{
+			Details: tree.BackupFileDetails,
+			Path:    $4.expr(),
+			InCollection: $6.expr(),
+			Options: $7.kvOptions(),
+		}
+	}
 | SHOW BACKUP error // SHOW HELP: SHOW BACKUP
 
 // %Help: SHOW CLUSTER SETTING - display cluster settings

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -672,6 +672,9 @@ func (u *sqlSymUnion) replicationOptions() *tree.ReplicationOptions {
 func (u *sqlSymUnion) copyOptions() *tree.CopyOptions {
   return u.val.(*tree.CopyOptions)
 }
+func (u *sqlSymUnion) showBackupDetails() tree.ShowBackupDetails {
+  return u.val.(tree.ShowBackupDetails)
+}
 func (u *sqlSymUnion) restoreOptions() *tree.RestoreOptions {
   return u.val.(*tree.RestoreOptions)
 }
@@ -1182,6 +1185,7 @@ func (u *sqlSymUnion) cursorStmt() tree.CursorStmt {
 %type <[]tree.KVOption> kv_option_list opt_with_options var_set_list opt_with_schedule_options
 %type <*tree.BackupOptions> opt_with_backup_options backup_options backup_options_list
 %type <*tree.RestoreOptions> opt_with_restore_options restore_options restore_options_list
+%type <tree.ShowBackupDetails> show_backup_details
 %type <*tree.CopyOptions> opt_with_copy_options copy_options copy_options_list
 %type <str> import_format
 %type <str> storage_parameter_key
@@ -5741,81 +5745,76 @@ show_backup_stmt:
       InCollection:    $4.expr(),
     }
   }
-| SHOW BACKUP string_or_placeholder opt_with_options
-  {
-    $$.val = &tree.ShowBackup{
-      Details: tree.BackupDefaultDetails,
-      Path:    $3.expr(),
-      Options: $4.kvOptions(),
-    }
-  }
-| SHOW BACKUP string_or_placeholder IN string_or_placeholder opt_with_options
-  {
-    $$.val = &tree.ShowBackup{
-      Details: tree.BackupDefaultDetails,
-      Path:    $3.expr(),
-      InCollection: $5.expr(),
-      Options: $6.kvOptions(),
-    }
-  }
-| SHOW BACKUP SCHEMAS string_or_placeholder opt_with_options
-  {
-    $$.val = &tree.ShowBackup{
-      Details: tree.BackupDefaultDetails,
-      ShouldIncludeSchemas: true,
-      Path:    $4.expr(),
-      Options: $5.kvOptions(),
-    }
-  }
-| SHOW BACKUP SCHEMAS string_or_placeholder IN string_or_placeholder opt_with_options
+| SHOW BACKUP show_backup_details FROM string_or_placeholder IN string_or_placeholder opt_with_options
 	{
 		$$.val = &tree.ShowBackup{
-			Details: tree.BackupDefaultDetails,
-			ShouldIncludeSchemas: true,
+			From:    true,
+			Details:    $3.showBackupDetails(),
+			Path:    $5.expr(),
+			InCollection: $7.expr(),
+			Options: $8.kvOptions(),
+		}
+	}
+| SHOW BACKUP string_or_placeholder IN string_or_placeholder opt_with_options
+	{
+		$$.val = &tree.ShowBackup{
+			Details:  tree.BackupDefaultDetails,
+			Path:    $3.expr(),
+			InCollection: $5.expr(),
+			Options: $6.kvOptions(),
+		}
+	}
+| SHOW BACKUP string_or_placeholder opt_with_options
+	{
+		$$.val = &tree.ShowBackup{
+		  Details:  tree.BackupDefaultDetails,
+			Path:    $3.expr(),
+			Options: $4.kvOptions(),
+		}
+	}
+| SHOW BACKUP SCHEMAS string_or_placeholder opt_with_options
+	{
+		$$.val = &tree.ShowBackup{
+		  Details:  tree.BackupSchemaDetails,
 			Path:    $4.expr(),
-			InCollection: $6.expr(),
-			Options: $7.kvOptions(),
+			Options: $5.kvOptions(),
+		}
+	}
+| SHOW BACKUP FILES string_or_placeholder opt_with_options
+	{
+		$$.val = &tree.ShowBackup{
+		  Details:  tree.BackupFileDetails,
+			Path:    $4.expr(),
+			Options: $5.kvOptions(),
 		}
 	}
 | SHOW BACKUP RANGES string_or_placeholder opt_with_options
-  {
-    /* SKIP DOC */
-    $$.val = &tree.ShowBackup{
-      Details: tree.BackupRangeDetails,
-      Path:    $4.expr(),
-      Options: $5.kvOptions(),
-    }
-  }
-| SHOW BACKUP RANGES string_or_placeholder IN string_or_placeholder opt_with_options
-  {
-		/* SKIP DOC */
-		$$.val = &tree.ShowBackup{
-			Details: tree.BackupRangeDetails,
-			Path:    $4.expr(),
-			InCollection: $6.expr(),
-			Options: $7.kvOptions(),
-		}
-  }
-| SHOW BACKUP FILES string_or_placeholder opt_with_options
-  {
-    /* SKIP DOC */
-    $$.val = &tree.ShowBackup{
-      Details: tree.BackupFileDetails,
-      Path:    $4.expr(),
-      Options: $5.kvOptions(),
-    }
-  }
-| SHOW BACKUP FILES string_or_placeholder IN string_or_placeholder opt_with_options
 	{
-		/* SKIP DOC */
 		$$.val = &tree.ShowBackup{
-			Details: tree.BackupFileDetails,
+		  Details:  tree.BackupRangeDetails,
 			Path:    $4.expr(),
-			InCollection: $6.expr(),
-			Options: $7.kvOptions(),
+			Options: $5.kvOptions(),
 		}
 	}
 | SHOW BACKUP error // SHOW HELP: SHOW BACKUP
+
+show_backup_details:
+  /* EMPTY -- default */
+  {
+    $$.val = tree.BackupDefaultDetails
+  }
+| SCHEMAS
+  {
+    $$.val = tree.BackupSchemaDetails
+  }
+| FILES
+	{
+	$$.val = tree.BackupFileDetails
+	}
+| RANGES
+	{
+	$$.val = tree.BackupRangeDetails
+	}
 
 // %Help: SHOW CLUSTER SETTING - display cluster settings
 // %Category: Cfg

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -167,20 +167,36 @@ SHOW BACKUP '_' IN '_' -- literals removed
 SHOW BACKUP 'foo' IN 'bar' -- identifiers removed
 
 parse
-SHOW BACKUP FILES 'foo' IN 'bar'
+SHOW BACKUP FROM $1 IN $2 WITH foo = 'bar'
 ----
-SHOW BACKUP FILES 'foo' IN 'bar'
-SHOW BACKUP FILES ('foo') IN ('bar') -- fully parenthesized
-SHOW BACKUP FILES '_' IN '_' -- literals removed
-SHOW BACKUP FILES 'foo' IN 'bar' -- identifiers removed
+SHOW BACKUP FROM $1 IN $2 WITH foo = 'bar'
+SHOW BACKUP FROM ($1) IN ($2) WITH foo = ('bar') -- fully parenthesized
+SHOW BACKUP FROM $1 IN $2 WITH foo = '_' -- literals removed
+SHOW BACKUP FROM $1 IN $2 WITH _ = 'bar' -- identifiers removed
 
 parse
-SHOW BACKUP RANGES 'foo' IN 'bar'
+SHOW BACKUP FILES FROM 'foo' IN 'bar'
 ----
-SHOW BACKUP RANGES 'foo' IN 'bar'
-SHOW BACKUP RANGES ('foo') IN ('bar') -- fully parenthesized
-SHOW BACKUP RANGES '_' IN '_' -- literals removed
-SHOW BACKUP RANGES 'foo' IN 'bar' -- identifiers removed
+SHOW BACKUP FILES FROM 'foo' IN 'bar'
+SHOW BACKUP FILES FROM ('foo') IN ('bar') -- fully parenthesized
+SHOW BACKUP FILES FROM '_' IN '_' -- literals removed
+SHOW BACKUP FILES FROM 'foo' IN 'bar' -- identifiers removed
+
+parse
+SHOW BACKUP RANGES FROM 'foo' IN 'bar'
+----
+SHOW BACKUP RANGES FROM 'foo' IN 'bar'
+SHOW BACKUP RANGES FROM ('foo') IN ('bar') -- fully parenthesized
+SHOW BACKUP RANGES FROM '_' IN '_' -- literals removed
+SHOW BACKUP RANGES FROM 'foo' IN 'bar' -- identifiers removed
+
+parse
+SHOW BACKUP SCHEMAS FROM 'foo' IN 'bar'
+----
+SHOW BACKUP SCHEMAS FROM 'foo' IN 'bar'
+SHOW BACKUP SCHEMAS FROM ('foo') IN ('bar') -- fully parenthesized
+SHOW BACKUP SCHEMAS FROM '_' IN '_' -- literals removed
+SHOW BACKUP SCHEMAS FROM 'foo' IN 'bar' -- identifiers removed
 
 parse
 SHOW BACKUP $1 IN $2 WITH foo = 'bar'

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -167,6 +167,22 @@ SHOW BACKUP '_' IN '_' -- literals removed
 SHOW BACKUP 'foo' IN 'bar' -- identifiers removed
 
 parse
+SHOW BACKUP FILES 'foo' IN 'bar'
+----
+SHOW BACKUP FILES 'foo' IN 'bar'
+SHOW BACKUP FILES ('foo') IN ('bar') -- fully parenthesized
+SHOW BACKUP FILES '_' IN '_' -- literals removed
+SHOW BACKUP FILES 'foo' IN 'bar' -- identifiers removed
+
+parse
+SHOW BACKUP RANGES 'foo' IN 'bar'
+----
+SHOW BACKUP RANGES 'foo' IN 'bar'
+SHOW BACKUP RANGES ('foo') IN ('bar') -- fully parenthesized
+SHOW BACKUP RANGES '_' IN '_' -- literals removed
+SHOW BACKUP RANGES 'foo' IN 'bar' -- identifiers removed
+
+parse
 SHOW BACKUP $1 IN $2 WITH foo = 'bar'
 ----
 SHOW BACKUP $1 IN $2 WITH foo = 'bar'

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -72,28 +72,28 @@ func (node *ShowClusterSettingList) Format(ctx *FmtCtx) {
 	ctx.WriteString(" CLUSTER SETTINGS")
 }
 
-// BackupDetails represents the type of details to display for a SHOW BACKUP
+// ShowBackupDetails represents the type of details to display for a SHOW BACKUP
 // statement.
-type BackupDetails int
+type ShowBackupDetails int
 
 const (
 	// BackupDefaultDetails identifies a bare SHOW BACKUP statement.
-	BackupDefaultDetails BackupDetails = iota
+	BackupDefaultDetails ShowBackupDetails = iota
 	// BackupRangeDetails identifies a SHOW BACKUP RANGES statement.
 	BackupRangeDetails
 	// BackupFileDetails identifies a SHOW BACKUP FILES statement.
 	BackupFileDetails
-	// BackupManifestAsJSON displays full backup manifest as json
-	BackupManifestAsJSON
+	// BackupSchemaDetails identifies a SHOW BACKUP SCHEMAS statement.
+	BackupSchemaDetails
 )
 
 // ShowBackup represents a SHOW BACKUP statement.
 type ShowBackup struct {
-	Path                 Expr
-	InCollection         Expr
-	Details              BackupDetails
-	ShouldIncludeSchemas bool
-	Options              KVOptions
+	Path         Expr
+	InCollection Expr
+	From         bool
+	Details      ShowBackupDetails
+	Options      KVOptions
 }
 
 // Format implements the NodeFormatter interface.
@@ -104,14 +104,20 @@ func (node *ShowBackup) Format(ctx *FmtCtx) {
 		return
 	}
 	ctx.WriteString("SHOW BACKUP ")
-	if node.Details == BackupRangeDetails {
+
+	switch node.Details {
+	case BackupRangeDetails:
 		ctx.WriteString("RANGES ")
-	} else if node.Details == BackupFileDetails {
+	case BackupFileDetails:
 		ctx.WriteString("FILES ")
-	}
-	if node.ShouldIncludeSchemas {
+	case BackupSchemaDetails:
 		ctx.WriteString("SCHEMAS ")
 	}
+
+	if node.From {
+		ctx.WriteString("FROM ")
+	}
+
 	ctx.FormatNode(node.Path)
 	if node.InCollection != nil {
 		ctx.WriteString(" IN ")


### PR DESCRIPTION
Backport:
  * 1/1 commits from "backupccl: allow SHOW BACKUP FILES/RANGES/SCHEMAS in backup collections" (#77871)
  * 1/1 commits from "backupccl: simplify SHOW BACKUP grammar and add FROM keyword" (#78427)
  * 1/1 commits from "backupccl: add deprecation warning for SHOW BACKUP without subdir" (#78626)

Please see individual PRs for details.

Fixes #78153

/cc @cockroachdb/release

Release justification: low risk and self contained refactor of SHOW BACKUP parser and a deprecation notice.