### PR TITLE
backupccl: allow user to run SHOW BACKUP on locality aware backups

### DIFF
--- a/docs/generated/sql/bnf/show_backup.bnf
+++ b/docs/generated/sql/bnf/show_backup.bnf
@@ -1,11 +1,11 @@
 show_backup_stmt ::=
-	'SHOW' 'BACKUPS' 'IN' location
-	| 'SHOW' 'BACKUP' show_backup_details 'FROM' string_or_placeholder 'IN' string_or_placeholder 'WITH' kv_option_list
-	| 'SHOW' 'BACKUP' show_backup_details 'FROM' string_or_placeholder 'IN' string_or_placeholder 'WITH' 'OPTIONS' '(' kv_option_list ')'
-	| 'SHOW' 'BACKUP' show_backup_details 'FROM' string_or_placeholder 'IN' string_or_placeholder 
-	| 'SHOW' 'BACKUP' subdirectory 'IN' location 'WITH' kv_option_list
-	| 'SHOW' 'BACKUP' subdirectory 'IN' location 'WITH' 'OPTIONS' '(' kv_option_list ')'
-	| 'SHOW' 'BACKUP' subdirectory 'IN' location 
+	'SHOW' 'BACKUPS' 'IN' location_opt_list
+	| 'SHOW' 'BACKUP' show_backup_details 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list 'WITH' kv_option_list
+	| 'SHOW' 'BACKUP' show_backup_details 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list 'WITH' 'OPTIONS' '(' kv_option_list ')'
+	| 'SHOW' 'BACKUP' show_backup_details 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list 
+	| 'SHOW' 'BACKUP' subdirectory 'IN' location_opt_list 'WITH' kv_option_list
+	| 'SHOW' 'BACKUP' subdirectory 'IN' location_opt_list 'WITH' 'OPTIONS' '(' kv_option_list ')'
+	| 'SHOW' 'BACKUP' subdirectory 'IN' location_opt_list 
 	| 'SHOW' 'BACKUP' string_or_placeholder 'WITH' kv_option_list
 	| 'SHOW' 'BACKUP' string_or_placeholder 'WITH' 'OPTIONS' '(' kv_option_list ')'
 	| 'SHOW' 'BACKUP' string_or_placeholder 

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -699,9 +699,9 @@ use_stmt ::=
 	'USE' var_value
 
 show_backup_stmt ::=
-	'SHOW' 'BACKUPS' 'IN' string_or_placeholder
-	| 'SHOW' 'BACKUP' show_backup_details 'FROM' string_or_placeholder 'IN' string_or_placeholder opt_with_options
-	| 'SHOW' 'BACKUP' string_or_placeholder 'IN' string_or_placeholder opt_with_options
+	'SHOW' 'BACKUPS' 'IN' string_or_placeholder_opt_list
+	| 'SHOW' 'BACKUP' show_backup_details 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list opt_with_options
+	| 'SHOW' 'BACKUP' string_or_placeholder 'IN' string_or_placeholder_opt_list opt_with_options
 	| 'SHOW' 'BACKUP' string_or_placeholder opt_with_options
 	| 'SHOW' 'BACKUP' 'SCHEMAS' string_or_placeholder opt_with_options
 	| 'SHOW' 'BACKUP' 'FILES' string_or_placeholder opt_with_options

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -650,6 +650,7 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 	}
 
 	sqlDB.Exec(t, "BACKUP TO ($1, $2, $3)", backups...)
+	sqlDB.Exec(t, "BACKUP TO ($1,$2,$3) INCREMENTAL FROM $4", append(incrementals, backups[0])...)
 	sqlDB.Exec(t, "BACKUP INTO ($1, $2, $3)", collections...)
 	sqlDB.Exec(t, "BACKUP INTO LATEST IN ($1, $2, $3)", collections...)
 	sqlDB.Exec(t, "BACKUP INTO LATEST IN ($1, $2, $3) WITH incremental_location = ($4, $5, $6)",
@@ -664,6 +665,12 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 
 	time.Sleep(time.Second + 2)
 	sqlDB.Exec(t, "BACKUP INTO ($1, $2, $3) AS OF SYSTEM TIME '-1s'", collections...)
+
+	{
+		// Ensure old style show backup runs properly with locality aware uri
+		sqlDB.Exec(t, "SHOW BACKUP $1", backups[0])
+		sqlDB.Exec(t, "SHOW BACKUP $1", incrementals[0])
+	}
 
 	// Find the subdirectory created by the full BACKUP INTO statement.
 	matches, err := filepath.Glob(path.Join(tmpDir, "full/*/*/*/"+backupManifestName))
@@ -680,6 +687,8 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 		[][]string{
 			{fmt.Sprintf("BACKUP TO ('%s', '%s', '%s')", backups[0].(string), backups[1].(string),
 				backups[2].(string))},
+			{fmt.Sprintf("BACKUP TO ('%s', '%s', '%s') INCREMENTAL FROM '%s'", incrementals[0],
+				incrementals[1], incrementals[2], backups[0])},
 			{fmt.Sprintf("BACKUP INTO '%s' IN ('%s', '%s', '%s')", full1, collections[0],
 				collections[1], collections[2])},
 			{fmt.Sprintf("BACKUP INTO '%s' IN ('%s', '%s', '%s')", full1,
@@ -9581,6 +9590,7 @@ func TestBackupRestoreOldIncrementalDefault(t *testing.T) {
 
 		sib := fmt.Sprintf("BACKUP DATABASE fkdb INTO LATEST IN %s WITH incremental_location = %s", dest, inc)
 		sqlDB.Exec(t, sib)
+
 		sir := fmt.Sprintf("RESTORE DATABASE fkdb FROM LATEST IN %s WITH new_db_name = 'inc_fkdb'", dest)
 		sqlDB.Exec(t, sir)
 
@@ -9690,6 +9700,39 @@ func TestBackupRestoreSeparateExplicitIsDefault(t *testing.T) {
 
 		sib := fmt.Sprintf("BACKUP DATABASE fkdb INTO LATEST IN %s WITH incremental_location = %s", dest, inc)
 		sqlDB.Exec(t, sib)
+		{
+			// Locality Aware Show Backup validation
+			// TODO (msbutler): move to data driven test after 22.1 backport
+
+			// Assert the localities field populates correctly (not null if backup is locality aware).
+			localities := sqlDB.QueryStr(t,
+				fmt.Sprintf("SELECT locality FROM [SHOW BACKUP FILES FROM LATEST IN %s]", dest))
+			expectedLocalities := map[string]bool{"default": true, "dc=dc1": true, "dc=dc2": true}
+			for _, locality := range localities {
+				if len(br.dest) > 1 {
+					_, ok := expectedLocalities[locality[0]]
+					require.Equal(t, true, ok)
+				} else {
+					require.Equal(t, "NULL", locality[0])
+				}
+			}
+			// Assert show backup still works.
+			sqlDB.Exec(t, fmt.Sprintf("SHOW BACKUPS IN %s", dest))
+			sqlDB.Exec(t, fmt.Sprintf("SHOW BACKUP FROM LATEST IN %s", dest))
+
+			if len(br.dest) > 1 {
+				// Locality aware show backups will eventually fail if not all localities are provided,
+				// but for now, they're ok.
+				sqlDB.Exec(t, fmt.Sprintf("SHOW BACKUP FROM LATEST IN %s", br.dest[1]))
+
+				errorMsg := "SHOW BACKUP on locality aware backups using incremental_location is not" +
+					" supported yet"
+				sqlDB.ExpectErr(t, errorMsg, fmt.Sprintf("SHOW BACKUP FROM LATEST IN %s WITH incremental_location= %s", dest, br.inc[0]))
+			} else {
+				// non locality aware show backup with incremental_location should work!
+				sqlDB.Exec(t, fmt.Sprintf("SHOW BACKUP FROM LATEST IN %s WITH incremental_location= %s", dest, inc))
+			}
+		}
 		sir := fmt.Sprintf("RESTORE DATABASE fkdb FROM LATEST IN %s WITH new_db_name = 'inc_fkdb', incremental_location = %s", dest, inc)
 		sqlDB.Exec(t, sir)
 

--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -629,6 +629,8 @@ func loadBackupManifests(
 	return backupManifests, memSize, nil
 }
 
+var errLocalityDescriptor = errors.New(`Locality Descriptor not found`)
+
 // getLocalityInfo takes a list of stores and their URIs, along with the main
 // backup manifest searches each for the locality pieces listed in the the
 // main manifest, returning the mapping.
@@ -672,7 +674,7 @@ func getLocalityInfo(
 			}
 		}
 		if !found {
-			return info, errors.Errorf("expected manifest %s not found in backup locations", filename)
+			return info, errors.Mark(errors.Newf("expected manifest %s not found in backup locations", filename), errLocalityDescriptor)
 		}
 	}
 	info.URIsByOriginalLocalityKV = urisByOrigLocality

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -5702,28 +5702,28 @@ show_histogram_stmt:
 // %Text: SHOW BACKUP [SCHEMAS|FILES|RANGES] <location>
 // %SeeAlso: WEBDOCS/show-backup.html
 show_backup_stmt:
-  SHOW BACKUPS IN string_or_placeholder
+  SHOW BACKUPS IN string_or_placeholder_opt_list
  {
     $$.val = &tree.ShowBackup{
-      InCollection:    $4.expr(),
+      InCollection:    $4.stringOrPlaceholderOptList(),
     }
   }
-| SHOW BACKUP show_backup_details FROM string_or_placeholder IN string_or_placeholder opt_with_options
+| SHOW BACKUP show_backup_details FROM string_or_placeholder IN string_or_placeholder_opt_list opt_with_options
 	{
 		$$.val = &tree.ShowBackup{
 			From:    true,
 			Details:    $3.showBackupDetails(),
 			Path:    $5.expr(),
-			InCollection: $7.expr(),
+			InCollection: $7.stringOrPlaceholderOptList(),
 			Options: $8.kvOptions(),
 		}
 	}
-| SHOW BACKUP string_or_placeholder IN string_or_placeholder opt_with_options
+| SHOW BACKUP string_or_placeholder IN string_or_placeholder_opt_list opt_with_options
 	{
 		$$.val = &tree.ShowBackup{
 			Details:  tree.BackupDefaultDetails,
 			Path:    $3.expr(),
-			InCollection: $5.expr(),
+			InCollection: $5.stringOrPlaceholderOptList(),
 			Options: $6.kvOptions(),
 		}
 	}

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -87,10 +87,13 @@ const (
 	BackupSchemaDetails
 )
 
+// TODO (msbutler): 22.2 after removing old style show backup syntax, rename
+// Path to Subdir and InCollection to Dest.
+
 // ShowBackup represents a SHOW BACKUP statement.
 type ShowBackup struct {
 	Path         Expr
-	InCollection Expr
+	InCollection StringOrPlaceholderOptList
 	From         bool
 	Details      ShowBackupDetails
 	Options      KVOptions
@@ -100,7 +103,7 @@ type ShowBackup struct {
 func (node *ShowBackup) Format(ctx *FmtCtx) {
 	if node.InCollection != nil && node.Path == nil {
 		ctx.WriteString("SHOW BACKUPS IN ")
-		ctx.FormatNode(node.InCollection)
+		ctx.FormatNode(&node.InCollection)
 		return
 	}
 	ctx.WriteString("SHOW BACKUP ")
@@ -121,7 +124,7 @@ func (node *ShowBackup) Format(ctx *FmtCtx) {
 	ctx.FormatNode(node.Path)
 	if node.InCollection != nil {
 		ctx.WriteString(" IN ")
-		ctx.FormatNode(node.InCollection)
+		ctx.FormatNode(&node.InCollection)
 	}
 	if len(node.Options) > 0 {
 		ctx.WriteString(" WITH ")


### PR DESCRIPTION
Previously, the user could only run  SHOW BACKUP on the default locality of a
backup. This patch allows users to pass in all backup localities, allowing
future changes to SHOW BACKUP (e.g. https://github.com/cockroachdb/cockroach/issues/77694) to analyze data from backup files
in non default locaties.

Users can not yet run SHOW BACKUP for locality aware backups created using the
incremental_location parameter.

Informs https://github.com/cockroachdb/cockroach/issues/78632

Release note (sql change): users can pass locality aware backup URIs to SHOW
BACKUP. This change only affects SHOW BACKUP with the new syntax: e.g.:

SHOW BACKUP FROM LATEST IN (<collectionURI>, <localityURI1>, <localityURI2>)

Users can not yet run SHOW BACKUP for locality aware backups created using the
incremental_location parameter.