### PR TITLE
dev: fix panic with multiple targets and extra args

### DIFF
--- a/dev
+++ b/dev
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=26
+DEV_VERSION=27
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/testdata/datadriven/test
+++ b/pkg/cmd/dev/testdata/datadriven/test
@@ -95,3 +95,8 @@ exec
 dev test pkg/spanconfig/spanconfigkvsubscriber -f=TestDecodeSpanTargets -v --stream-output
 ----
 bazel test pkg/spanconfig/spanconfigkvsubscriber:all --test_env=GOTRACEBACK=all --test_filter=TestDecodeSpanTargets --test_sharding_strategy=disabled --test_arg -test.v --test_output streamed
+
+exec
+dev test pkg/sql/schemachanger pkg/sql/schemachanger/scplan -- --test_sharding_strategy=disabled
+----
+bazel test pkg/sql/schemachanger:all pkg/sql/schemachanger/scplan:all --test_env=GOTRACEBACK=all --test_output errors --test_sharding_strategy=disabled

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -122,7 +122,7 @@ func splitArgsAtDash(cmd *cobra.Command, args []string) (before, after []string)
 		// NB: Have to do this verbose slicing to force Go to copy the
 		// memory. Otherwise later `append`s will break stuff.
 		before = args[0:argsLenAtDash:argsLenAtDash]
-		after = args[argsLenAtDash : len(args) : len(args)-argsLenAtDash+1]
+		after = args[argsLenAtDash:len(args):len(args)]
 	}
 	return
 }


### PR DESCRIPTION
The 3rd parameter is in terms of the pre-sliced offsets, not the post. Before
this change, the added test would panic.

Release note: None