### PR TITLE
kv: support FOR {UPDATE,SHARE} SKIP LOCKED

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
@@ -562,13 +562,12 @@ func (sr *txnSpanRefresher) tryRefreshTxnSpans(
 func (sr *txnSpanRefresher) appendRefreshSpans(
 	ctx context.Context, ba roachpb.BatchRequest, br *roachpb.BatchResponse,
 ) error {
-	ba.RefreshSpanIterate(br, func(span roachpb.Span) {
+	return ba.RefreshSpanIterate(br, func(span roachpb.Span) {
 		if log.ExpensiveLogEnabled(ctx, 3) {
 			log.VEventf(ctx, 3, "recording span to refresh: %s", span.String())
 		}
 		sr.refreshFootprint.insert(span)
 	})
-	return nil
 }
 
 // canForwardReadTimestampWithoutRefresh returns whether the transaction can

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -125,6 +125,7 @@ go_library(
         "//pkg/kv/kvserver/closedts/sidetransport",
         "//pkg/kv/kvserver/closedts/tracker",
         "//pkg/kv/kvserver/concurrency",
+        "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/kv/kvserver/concurrency/poison",
         "//pkg/kv/kvserver/constraint",
         "//pkg/kv/kvserver/gc",

--- a/pkg/kv/kvserver/batcheval/cmd_get.go
+++ b/pkg/kv/kvserver/batcheval/cmd_get.go
@@ -54,10 +54,12 @@ func Get(
 	var err error
 	val, intent, err = storage.MVCCGet(ctx, reader, args.Key, h.Timestamp, storage.MVCCGetOptions{
 		Inconsistent:     h.ReadConsistency != roachpb.CONSISTENT,
+		SkipLocked:       h.WaitPolicy == lock.WaitPolicy_SkipLocked,
 		Txn:              h.Txn,
 		FailOnMoreRecent: args.KeyLocking != lock.None,
 		Uncertainty:      cArgs.Uncertainty,
 		MemoryAccount:    cArgs.EvalCtx.GetResponseMemoryAccount(),
+		LockTable:        cArgs.Concurrency,
 	})
 	if err != nil {
 		return result.Result{}, err

--- a/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
@@ -44,6 +44,7 @@ func ReverseScan(
 		clusterversion.TargetBytesAvoidExcess)
 	opts := storage.MVCCScanOptions{
 		Inconsistent:           h.ReadConsistency != roachpb.CONSISTENT,
+		SkipLocked:             h.WaitPolicy == lock.WaitPolicy_SkipLocked,
 		Txn:                    h.Txn,
 		MaxKeys:                h.MaxSpanRequestKeys,
 		MaxIntents:             storage.MaxIntentsPerWriteIntentError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
@@ -54,6 +55,7 @@ func ReverseScan(
 		FailOnMoreRecent:       args.KeyLocking != lock.None,
 		Reverse:                true,
 		MemoryAccount:          cArgs.EvalCtx.GetResponseMemoryAccount(),
+		LockTable:              cArgs.Concurrency,
 	}
 
 	switch args.ScanFormat {

--- a/pkg/kv/kvserver/batcheval/cmd_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_scan.go
@@ -44,6 +44,7 @@ func Scan(
 		clusterversion.TargetBytesAvoidExcess)
 	opts := storage.MVCCScanOptions{
 		Inconsistent:           h.ReadConsistency != roachpb.CONSISTENT,
+		SkipLocked:             h.WaitPolicy == lock.WaitPolicy_SkipLocked,
 		Txn:                    h.Txn,
 		Uncertainty:            cArgs.Uncertainty,
 		MaxKeys:                h.MaxSpanRequestKeys,
@@ -55,6 +56,7 @@ func Scan(
 		FailOnMoreRecent:       args.KeyLocking != lock.None,
 		Reverse:                false,
 		MemoryAccount:          cArgs.EvalCtx.GetResponseMemoryAccount(),
+		LockTable:              cArgs.Concurrency,
 	}
 
 	switch args.ScanFormat {

--- a/pkg/kv/kvserver/batcheval/declare.go
+++ b/pkg/kv/kvserver/batcheval/declare.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/uncertainty"
@@ -121,5 +122,6 @@ type CommandArgs struct {
 	Now     hlc.ClockTimestamp
 	// *Stats should be mutated to reflect any writes made by the command.
 	Stats       *enginepb.MVCCStats
+	Concurrency *concurrency.Guard
 	Uncertainty uncertainty.Interval
 }

--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -767,6 +767,14 @@ type lockTableGuard interface {
 	// so this checking is practically only going to find unreplicated locks
 	// that conflict.
 	CheckOptimisticNoConflicts(*spanset.SpanSet) (ok bool)
+
+	// IsKeyLockedByConflictingTxn returns whether the provided key is locked by a
+	// conflicting transaction in the lockTableGuard's snapshot of the lock table,
+	// given the caller's own desired locking strength. If so, the lock holder is
+	// returned. A transaction's own lock does not appear to be locked to itself.
+	// The method is used by requests in conjunction with the SkipLocked wait
+	// policy to determine which keys they should skip over during evaluation.
+	IsKeyLockedByConflictingTxn(roachpb.Key, lock.Strength) (bool, *enginepb.TxnMeta)
 }
 
 // lockTableWaiter is concerned with waiting in lock wait-queues for locks held

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -732,6 +732,18 @@ func (g *Guard) CheckOptimisticNoLatchConflicts() (ok bool) {
 	return g.lm.CheckOptimisticNoConflicts(g.lg, g.Req.LatchSpans)
 }
 
+// IsKeyLockedByConflictingTxn returns whether the provided key is locked by a
+// conflicting transaction in the Guard's snapshot of the lock table, given the
+// caller's own desired locking strength. If so, the lock holder is returned. A
+// transaction's own lock does not appear to be locked to itself. The method is
+// used by requests in conjunction with the SkipLocked wait policy to determine
+// which keys they should skip over during evaluation.
+func (g *Guard) IsKeyLockedByConflictingTxn(
+	key roachpb.Key, strength lock.Strength,
+) (bool, *enginepb.TxnMeta) {
+	return g.ltg.IsKeyLockedByConflictingTxn(key, strength)
+}
+
 func (g *Guard) moveLatchGuard() latchGuard {
 	lg := g.lg
 	g.lg = nil

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -65,7 +65,8 @@ import (
 // handle-write-intent-error  req=<req-name> txn=<txn-name> key=<key> lease-seq=<seq>
 // handle-txn-push-error      req=<req-name> txn=<txn-name> key=<key>  TODO(nvanbenschoten): implement this
 //
-// check-opt-no-conflicts req=<req-name>
+// check-opt-no-conflicts            req=<req-name>
+// is-key-locked-by-conflicting-txn  req=<req-name> key=<key> strength=<strength>
 //
 // on-lock-acquired  req=<req-name> key=<key> [seq=<seq>] [dur=r|u]
 // on-lock-updated   req=<req-name> txn=<txn-name> key=<key> status=[committed|aborted|pending] [ts=<int>[,<int>]]
@@ -346,6 +347,21 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				reqs, _ := scanRequests(t, d, c)
 				latchSpans, lockSpans := c.collectSpans(t, g.Req.Txn, g.Req.Timestamp, reqs)
 				return fmt.Sprintf("no-conflicts: %t", g.CheckOptimisticNoConflicts(latchSpans, lockSpans))
+
+			case "is-key-locked-by-conflicting-txn":
+				var reqName string
+				d.ScanArgs(t, "req", &reqName)
+				g, ok := c.guardsByReqName[reqName]
+				if !ok {
+					d.Fatalf(t, "unknown request: %s", reqName)
+				}
+				var key string
+				d.ScanArgs(t, "key", &key)
+				strength := scanLockStrength(t, d)
+				if ok, txn := g.IsKeyLockedByConflictingTxn(roachpb.Key(key), strength); ok {
+					return fmt.Sprintf("locked: true, holder: %s", txn.ID)
+				}
+				return "locked: false"
 
 			case "on-lock-acquired":
 				var reqName string

--- a/pkg/kv/kvserver/concurrency/datadriven_util_test.go
+++ b/pkg/kv/kvserver/concurrency/datadriven_util_test.go
@@ -44,6 +44,24 @@ func scanTimestampWithName(t *testing.T, d *datadriven.TestData, name string) hl
 	return ts
 }
 
+func scanLockStrength(t *testing.T, d *datadriven.TestData) lock.Strength {
+	var strS string
+	d.ScanArgs(t, "strength", &strS)
+	switch strS {
+	case "none":
+		return lock.None
+	case "shared":
+		return lock.Shared
+	case "upgrade":
+		return lock.Upgrade
+	case "exclusive":
+		return lock.Exclusive
+	default:
+		d.Fatalf(t, "unknown lock strength: %s", strS)
+		return 0
+	}
+}
+
 func scanLockDurability(t *testing.T, d *datadriven.TestData) lock.Durability {
 	var durS string
 	d.ScanArgs(t, "dur", &durS)
@@ -70,6 +88,8 @@ func scanWaitPolicy(t *testing.T, d *datadriven.TestData, required bool) lock.Wa
 		return lock.WaitPolicy_Block
 	case "error":
 		return lock.WaitPolicy_Error
+	case "skip-locked":
+		return lock.WaitPolicy_SkipLocked
 	default:
 		d.Fatalf(t, "unknown wait policy: %s", policy)
 		return 0

--- a/pkg/kv/kvserver/concurrency/lock/locking.go
+++ b/pkg/kv/kvserver/concurrency/lock/locking.go
@@ -12,7 +12,7 @@
 // concurrency control in the key-value layer.
 package lock
 
-import fmt "fmt"
+import "fmt"
 
 // MaxDurability is the maximum value in the Durability enum.
 const MaxDurability = Unreplicated

--- a/pkg/kv/kvserver/concurrency/lock/locking.proto
+++ b/pkg/kv/kvserver/concurrency/lock/locking.proto
@@ -167,15 +167,21 @@ enum Durability {
 // until the conflicting lock is released, but other policies can make sense in
 // special situations.
 enum WaitPolicy {
-  // Block indicates that if a request encounters a conflicting locks held by
+  // Block indicates that if a request encounters a conflicting lock held by
   // another active transaction, it should wait for the conflicting lock to be
   // released before proceeding.
   Block = 0;
 
-  // Error indicates that if a request encounters a conflicting locks held by
+  // Error indicates that if a request encounters a conflicting lock held by
   // another active transaction, it should raise an error instead of blocking.
   // If the request encounters a conflicting lock that was abandoned by an
   // inactive transaction, which is likely due to a transaction coordinator
   // crash, the lock is removed and no error is raised.
   Error = 1;
+
+  // SkipLocked indicates that if a request encounters a conflicting lock held
+  // by another transaction while scanning, it should skip over the key that is
+  // locked instead of blocking and later acquiring a lock on that key. The
+  // locked key will not be included in the scan result.
+  SkipLocked = 2;
 }

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -63,7 +63,7 @@ new-txn txn=<name> ts=<int>[,<int>] epoch=<int> [seq=<int>]
 
  Creates a TxnMeta.
 
-new-request r=<name> txn=<name>|none ts=<int>[,<int>] spans=r|w@<start>[,<end>]+... [max-lock-wait-queue-length=<int>]
+new-request r=<name> txn=<name>|none ts=<int>[,<int>] spans=r|w@<start>[,<end>]+... [skip-locked] [max-lock-wait-queue-length=<int>]
 ----
 
  Creates a Request.
@@ -116,6 +116,12 @@ check-opt-no-conflicts r=<name> spans=r|w@<start>[,<end>]+...
 no-conflicts: <bool>
 
  Checks whether the request, which previously called ScanOptimistic, has no lock conflicts.
+
+is-key-locked-by-conflicting-txn r=<name> k=<key> strength=<strength>
+----
+locked: <bool>
+
+ Checks whether the provided key is locked by a conflicting transaction.
 
 dequeue r=<name>
 ----
@@ -291,6 +297,10 @@ func TestLockTableBasic(t *testing.T) {
 					d.Fatalf(t, "unknown txn %s", txnName)
 				}
 				ts := scanTimestamp(t, d)
+				waitPolicy := lock.WaitPolicy_Block
+				if d.HasArg("skip-locked") {
+					waitPolicy = lock.WaitPolicy_SkipLocked
+				}
 				var maxLockWaitQueueLength int
 				if d.HasArg("max-lock-wait-queue-length") {
 					d.ScanArgs(t, "max-lock-wait-queue-length", &maxLockWaitQueueLength)
@@ -298,6 +308,7 @@ func TestLockTableBasic(t *testing.T) {
 				spans := scanSpans(t, d, ts)
 				req := Request{
 					Timestamp:              ts,
+					WaitPolicy:             waitPolicy,
 					MaxLockWaitQueueLength: maxLockWaitQueueLength,
 					LatchSpans:             spans,
 					LockSpans:              spans,
@@ -476,6 +487,21 @@ func TestLockTableBasic(t *testing.T) {
 				}
 				spans := scanSpans(t, d, req.Timestamp)
 				return fmt.Sprintf("no-conflicts: %t", g.CheckOptimisticNoConflicts(spans))
+
+			case "is-key-locked-by-conflicting-txn":
+				var reqName string
+				d.ScanArgs(t, "r", &reqName)
+				g := guardsByReqName[reqName]
+				if g == nil {
+					d.Fatalf(t, "unknown guard: %s", reqName)
+				}
+				var key string
+				d.ScanArgs(t, "k", &key)
+				strength := scanLockStrength(t, d)
+				if ok, txn := g.IsKeyLockedByConflictingTxn(roachpb.Key(key), strength); ok {
+					return fmt.Sprintf("locked: true, holder: %s", txn.ID)
+				}
+				return "locked: false"
 
 			case "dequeue":
 				var reqName string
@@ -682,6 +708,24 @@ func scanSpans(t *testing.T, d *datadriven.TestData, ts hlc.Timestamp) *spanset.
 		spans.AddMVCC(sa, getSpan(t, d, p), ts)
 	}
 	return spans
+}
+
+func scanLockStrength(t *testing.T, d *datadriven.TestData) lock.Strength {
+	var strS string
+	d.ScanArgs(t, "strength", &strS)
+	switch strS {
+	case "none":
+		return lock.None
+	case "shared":
+		return lock.Shared
+	case "upgrade":
+		return lock.Upgrade
+	case "exclusive":
+		return lock.Exclusive
+	default:
+		d.Fatalf(t, "unknown lock strength: %s", strS)
+		return 0
+	}
 }
 
 func intentsToResolveToStr(toResolve []roachpb.LockUpdate, startOnNewLine bool) string {

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
@@ -86,6 +86,11 @@ func (g *mockLockTableGuard) ResolveBeforeScanning() []roachpb.LockUpdate {
 func (g *mockLockTableGuard) CheckOptimisticNoConflicts(*spanset.SpanSet) (ok bool) {
 	return true
 }
+func (g *mockLockTableGuard) IsKeyLockedByConflictingTxn(
+	roachpb.Key, lock.Strength,
+) (bool, *enginepb.TxnMeta) {
+	panic("unimplemented")
+}
 func (g *mockLockTableGuard) notify() { g.signal <- struct{}{} }
 
 // mockLockTable overrides TransactionIsFinalized, which is the only LockTable

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_skip
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_skip
@@ -1,0 +1,120 @@
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+new-txn name=txn2 ts=11,1 epoch=0
+----
+
+# -------------------------------------------------------------
+# Prep: Txn 1 acquire locks at key k and key k2
+#       Txn 2 acquire locks at key k3
+# -------------------------------------------------------------
+
+new-request name=req1 txn=txn1 ts=10,0
+  put key=k  value=v
+  put key=k2 value=v2
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+on-lock-acquired req=req1 key=k
+----
+[-] acquire lock: txn 00000001 @ k
+
+on-lock-acquired req=req1 key=k2
+----
+[-] acquire lock: txn 00000001 @ k2
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+new-request name=req2 txn=txn2 ts=11,0
+  put key=k3 value=v
+----
+
+sequence req=req2
+----
+[2] sequence req2: sequencing request
+[2] sequence req2: acquiring latches
+[2] sequence req2: scanning lock table for conflicting locks
+[2] sequence req2: sequencing complete, returned guard
+
+on-lock-acquired req=req2 key=k3
+----
+[-] acquire lock: txn 00000002 @ k3
+
+finish req=req2
+----
+[-] finish req2: finishing request
+
+debug-lock-table
+----
+global: num=3
+ lock: "k"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+ lock: "k2"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
+ lock: "k3"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+local: num=0
+
+# -------------------------------------------------------------
+# Read-only request with WaitPolicy_Skip hits lock sequences
+# without blocking and then probes into the lock table while
+# evaluating to determine which keys to skip over.
+# -------------------------------------------------------------
+
+new-request name=reqSkipLocked txn=txn2 ts=9,0 wait-policy=skip-locked
+  scan key=k endkey=k5
+----
+
+sequence req=reqSkipLocked
+----
+[3] sequence reqSkipLocked: sequencing request
+[3] sequence reqSkipLocked: acquiring latches
+[3] sequence reqSkipLocked: scanning lock table for conflicting locks
+[3] sequence reqSkipLocked: sequencing complete, returned guard
+
+is-key-locked-by-conflicting-txn req=reqSkipLocked key=k strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn req=reqSkipLocked key=k2 strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn req=reqSkipLocked key=k3 strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn req=reqSkipLocked key=k4 strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn req=reqSkipLocked key=k strength=exclusive
+----
+locked: true, holder: 00000001-0000-0000-0000-000000000000
+
+is-key-locked-by-conflicting-txn req=reqSkipLocked key=k2 strength=exclusive
+----
+locked: true, holder: 00000001-0000-0000-0000-000000000000
+
+is-key-locked-by-conflicting-txn req=reqSkipLocked key=k3 strength=exclusive
+----
+locked: false
+
+is-key-locked-by-conflicting-txn req=reqSkipLocked key=k4 strength=exclusive
+----
+locked: false
+
+finish req=reqSkipLocked
+----
+[-] finish reqSkipLocked: finishing request
+
+reset
+----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/optimistic
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/optimistic
@@ -109,3 +109,33 @@ global: num=2
  lock: "g"
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
+
+# ---------------------------------------------------------------------------------
+# Test with a Skip wait policy. Even though the lock table has a conflicting lock,
+# it assumes that the request saw and handled this lock during evaluation, so it
+# does not trigger a conflict.
+# ---------------------------------------------------------------------------------
+
+new-request r=req4 txn=txn2 ts=11,1 spans=r@a,i skip-locked
+----
+
+scan-opt r=req4
+----
+start-waiting: false
+
+should-wait r=req4
+----
+false
+
+check-opt-no-conflicts r=req4 spans=r@a,i
+----
+no-conflicts: true
+
+dequeue r=req4
+----
+global: num=2
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "g"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+local: num=0

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/skip_locked
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/skip_locked
@@ -1,0 +1,152 @@
+new-lock-table maxlocks=10000
+----
+
+new-txn txn=txn1 ts=10,1 epoch=0
+----
+
+new-txn txn=txn2 ts=9,1 epoch=0
+----
+
+# keyspace:
+#  a: unlocked
+#  b: locked by txn1
+#  c: locked by txn2
+#  d: locked by txn1
+#  e: unlocked
+
+new-request r=req1 txn=txn1 ts=10,1 spans=w@b,d
+----
+
+scan r=req1
+----
+start-waiting: false
+
+should-wait r=req1
+----
+false
+
+acquire r=req1 k=b durability=u
+----
+global: num=1
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+local: num=0
+
+acquire r=req1 k=d durability=u
+----
+global: num=2
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+local: num=0
+
+dequeue r=req1
+----
+global: num=2
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+local: num=0
+
+new-request r=req2 txn=txn2 ts=9,1 spans=w@c
+----
+
+scan r=req2
+----
+start-waiting: false
+
+should-wait r=req2
+----
+false
+
+acquire r=req2 k=c durability=u
+----
+global: num=3
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 9.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+local: num=0
+
+dequeue r=req2
+----
+global: num=3
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 9.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+local: num=0
+
+# ---------------------------------------------------------------------------------
+# req3 will scan the lock table with a Skip wait policy. It will not need to wait.
+# Once it begins evaluating, it will probe into the lock table to determine which
+# keys to skip.
+# ---------------------------------------------------------------------------------
+
+new-request r=req3 txn=txn2 ts=9,1 spans=r@a,f skip-locked
+----
+
+scan r=req3
+----
+start-waiting: false
+
+should-wait r=req3
+----
+false
+
+is-key-locked-by-conflicting-txn r=req3 k=a strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req3 k=b strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req3 k=c strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req3 k=d strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req3 k=e strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req3 k=a strength=exclusive
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req3 k=b strength=exclusive
+----
+locked: true, holder: 00000000-0000-0000-0000-000000000001
+
+is-key-locked-by-conflicting-txn r=req3 k=c strength=exclusive
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req3 k=d strength=exclusive
+----
+locked: true, holder: 00000000-0000-0000-0000-000000000001
+
+is-key-locked-by-conflicting-txn r=req3 k=e strength=exclusive
+----
+locked: false
+
+dequeue r=req3
+----
+global: num=3
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 9.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+local: num=0

--- a/pkg/kv/kvserver/intentresolver/intent_resolver.go
+++ b/pkg/kv/kvserver/intentresolver/intent_resolver.go
@@ -452,6 +452,9 @@ func (ir *IntentResolver) runAsyncTask(
 // encountered during another command but did not interfere with the
 // execution of that command. This occurs during inconsistent
 // reads.
+// TODO(nvanbenschoten): is this needed if the intents could not have
+// expired yet (i.e. they are not at least 5s old)? Should we filter
+// those out? If we don't, will this be too expensive for SKIP LOCKED?
 func (ir *IntentResolver) CleanupIntentsAsync(
 	ctx context.Context, intents []roachpb.Intent, allowSyncProcessing bool,
 ) error {

--- a/pkg/kv/kvserver/replica_evaluate.go
+++ b/pkg/kv/kvserver/replica_evaluate.go
@@ -149,6 +149,7 @@ func evaluateBatch(
 	rec batcheval.EvalContext,
 	ms *enginepb.MVCCStats,
 	ba *roachpb.BatchRequest,
+	g *concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
 	readOnly bool,
@@ -269,7 +270,7 @@ func evaluateBatch(
 		// may carry a response transaction and in the case of WriteTooOldError
 		// (which is sometimes deferred) it is fully populated.
 		curResult, err := evaluateCommand(
-			ctx, readWriter, rec, ms, baHeader, args, reply, st, ui)
+			ctx, readWriter, rec, ms, baHeader, args, reply, g, st, ui)
 
 		if filter := rec.EvalKnobs().TestingPostEvalFilter; filter != nil {
 			filterArgs := kvserverbase.FilterArgs{
@@ -476,6 +477,7 @@ func evaluateCommand(
 	h roachpb.Header,
 	args roachpb.Request,
 	reply roachpb.Response,
+	g *concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
 ) (result.Result, error) {
@@ -493,6 +495,7 @@ func evaluateCommand(
 			Args:        args,
 			Now:         now,
 			Stats:       ms,
+			Concurrency: g,
 			Uncertainty: ui,
 		}
 

--- a/pkg/kv/kvserver/replica_evaluate_test.go
+++ b/pkg/kv/kvserver/replica_evaluate_test.go
@@ -681,6 +681,7 @@ func TestEvaluateBatch(t *testing.T) {
 				d.MockEvalCtx.EvalContext(),
 				&d.ms,
 				&d.ba,
+				nil, /* g */
 				nil, /* st */
 				uncertainty.Interval{},
 				d.readOnly,

--- a/pkg/kv/kvserver/replica_gossip.go
+++ b/pkg/kv/kvserver/replica_gossip.go
@@ -94,7 +94,7 @@ func (r *Replica) MaybeGossipNodeLivenessRaftMuLocked(
 	defer rw.Close()
 
 	br, result, pErr :=
-		evaluateBatch(ctx, kvserverbase.CmdIDKey(""), rw, rec, nil, &ba, nil /* st */, uncertainty.Interval{}, true /* readOnly */)
+		evaluateBatch(ctx, kvserverbase.CmdIDKey(""), rw, rec, nil, &ba, nil /* g */, nil /* st */, uncertainty.Interval{}, true /* readOnly */)
 	if pErr != nil {
 		return errors.Wrapf(pErr.GoError(), "couldn't scan node liveness records in span %s", span)
 	}

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -636,9 +636,9 @@ func (r *Replica) evaluateProposal(
 	ctx context.Context,
 	idKey kvserverbase.CmdIDKey,
 	ba *roachpb.BatchRequest,
+	g *concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
-	g *concurrency.Guard,
 ) (*result.Result, bool, *roachpb.Error) {
 	if ba.Timestamp.IsEmpty() {
 		return nil, false, roachpb.NewErrorf("can't propose Raft command with zero timestamp")
@@ -654,7 +654,7 @@ func (r *Replica) evaluateProposal(
 	//
 	// TODO(tschottdorf): absorb all returned values in `res` below this point
 	// in the call stack as well.
-	batch, ms, br, res, pErr := r.evaluateWriteBatch(ctx, idKey, ba, st, ui, g)
+	batch, ms, br, res, pErr := r.evaluateWriteBatch(ctx, idKey, ba, g, st, ui)
 
 	// Note: reusing the proposer's batch when applying the command on the
 	// proposer was explored as an optimization but resulted in no performance
@@ -750,11 +750,11 @@ func (r *Replica) requestToProposal(
 	ctx context.Context,
 	idKey kvserverbase.CmdIDKey,
 	ba *roachpb.BatchRequest,
+	g *concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
-	g *concurrency.Guard,
 ) (*ProposalData, *roachpb.Error) {
-	res, needConsensus, pErr := r.evaluateProposal(ctx, idKey, ba, st, ui, g)
+	res, needConsensus, pErr := r.evaluateProposal(ctx, idKey, ba, g, st, ui)
 
 	// Fill out the results even if pErr != nil; we'll return the error below.
 	proposal := &ProposalData{

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -110,7 +110,7 @@ func (r *Replica) evalAndPropose(
 ) (chan proposalResult, func(), kvserverbase.CmdIDKey, *roachpb.Error) {
 	defer tok.DoneIfNotMoved(ctx)
 	idKey := makeIDKey()
-	proposal, pErr := r.requestToProposal(ctx, idKey, ba, st, ui, g)
+	proposal, pErr := r.requestToProposal(ctx, idKey, ba, g, st, ui)
 	log.Event(proposal.ctx, "evaluated request")
 
 	// If the request hit a server-side concurrency retry error, immediately

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -354,18 +354,51 @@ func (r *Replica) collectSpansRead(
 	ba *roachpb.BatchRequest, br *roachpb.BatchResponse,
 ) (latchSpans, lockSpans *spanset.SpanSet, _ error) {
 	baCopy := *ba
-	baCopy.Requests = make([]roachpb.RequestUnion, len(baCopy.Requests))
-	j := 0
-	for i := 0; i < len(baCopy.Requests); i++ {
+	baCopy.Requests = make([]roachpb.RequestUnion, 0, len(ba.Requests))
+	for i := 0; i < len(ba.Requests); i++ {
 		baReq := ba.Requests[i]
 		req := baReq.GetInner()
 		header := req.Header()
-
 		resp := br.Responses[i].GetInner()
+
+		if ba.WaitPolicy == lock.WaitPolicy_SkipLocked && roachpb.CanSkipLocked(req) {
+			// If the request is using a SkipLocked wait policy, it behaves as if run
+			// at a lower isolation level for any keys that it skips over. If the read
+			// request did not return a key, it does not need to check for conflicts
+			// with latches held on that key. Instead, the request only needs to check
+			// for conflicting latches on the keys that were returned.
+			//
+			// To achieve this, we add a Get request for each of the keys in the
+			// response's result set, even if the original request was a ranged scan.
+			// This will lead to the returned span set (which is used for optimistic
+			// eval validation) containing a set of point latch spans which correspond
+			// to the response keys. Note that the Get requests are constructed with
+			// the same key locking mode as the original read.
+			//
+			// This is similar to how the timestamp cache and refresh spans handle the
+			// SkipLocked wait policy.
+			if err := roachpb.ResponseKeyIterate(req, resp, func(key roachpb.Key) {
+				// TODO(nvanbenschoten): we currently perform a per-response key memory
+				// allocation. If this becomes an issue, we could pre-allocate chunks of
+				// these structs to amortize the cost.
+				getAlloc := new(struct {
+					get   roachpb.GetRequest
+					union roachpb.RequestUnion_Get
+				})
+				getAlloc.get.Key = key
+				getAlloc.get.KeyLocking = req.(roachpb.LockingReadRequest).KeyLockingStrength()
+				getAlloc.union.Get = &getAlloc.get
+				ru := roachpb.RequestUnion{Value: &getAlloc.union}
+				baCopy.Requests = append(baCopy.Requests, ru)
+			}); err != nil {
+				return nil, nil, err
+			}
+			continue
+		}
+
 		if resp.Header().ResumeSpan == nil {
 			// Fully evaluated.
-			baCopy.Requests[j] = baReq
-			j++
+			baCopy.Requests = append(baCopy.Requests, baReq)
 			continue
 		}
 
@@ -393,17 +426,16 @@ func (r *Replica) collectSpansRead(
 			header.Key = t.ResumeSpan.EndKey
 		default:
 			// Consider it fully evaluated, which is safe.
-			baCopy.Requests[j] = baReq
-			j++
+			baCopy.Requests = append(baCopy.Requests, baReq)
 			continue
 		}
 		// The ResumeSpan has changed the header.
+		var ru roachpb.RequestUnion
 		req = req.ShallowCopy()
 		req.SetHeader(header)
-		baCopy.Requests[j].MustSetInner(req)
-		j++
+		ru.MustSetInner(req)
+		baCopy.Requests = append(baCopy.Requests, ru)
 	}
-	baCopy.Requests = baCopy.Requests[:j]
 
 	// Collect the batch's declared spans again, this time with the
 	// span bounds constrained to what was read.

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/poison"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/replicastats"
@@ -1092,10 +1093,36 @@ func (r *Replica) collectSpans(
 
 	// Note that we are letting locking readers be considered for optimistic
 	// evaluation. This is correct, though not necessarily beneficial.
-	considerOptEval := ba.IsReadOnly() && ba.IsAllTransactional() && ba.Header.MaxSpanRequestKeys > 0 &&
+	considerOptEval := ba.IsReadOnly() && ba.IsAllTransactional() &&
 		optimisticEvalLimitedScans.Get(&r.ClusterSettings().SV)
-	// When considerOptEval, these are computed below and used to decide whether
-	// to actually do optimistic evaluation.
+
+	// If the request is using a SkipLocked wait policy, we always perform
+	// optimistic evaluation. In Replica.collectSpansRead, SkipLocked reads are
+	// able to constraint their read spans down to point reads on just those keys
+	// that were returned and were not already locked. This means that there is a
+	// good chance that some or all of the write latches that the SkipLocked read
+	// would have blocked on won't overlap with the keys that the request ends up
+	// returning, so they won't conflict when checking for optimistic conflicts.
+	//
+	// Concretely, SkipLocked reads can ignore write latches when:
+	// 1. a key is first being written to non-transactionally (or through 1PC)
+	//    and its write is in flight.
+	// 2. a key is locked and its value is being updated by a write from its
+	//    transaction that is in flight.
+	// 3. a key is locked and the lock is being removed by intent resolution.
+	//
+	// In all three of these cases, optimistic evaluation improves concurrency
+	// because the SkipLocked request does not return the key that is currently
+	// write latched. However, SkipLocked reads will fail optimistic evaluation
+	// if they return a key that is write latched. For instance, it can fail if
+	// it returns a key that is being updated without first being locked.
+	optEvalForSkipLocked := considerOptEval && ba.Header.WaitPolicy == lock.WaitPolicy_SkipLocked
+
+	// If the request is using a key limit, we may want it to perform optimistic
+	// evaluation, depending on how large the limit is.
+	considerOptEvalForLimit := considerOptEval && ba.Header.MaxSpanRequestKeys > 0
+	// When considerOptEvalForLimit, these are computed below and used to decide
+	// whether to actually do optimistic evaluation.
 	hasScans := false
 	numGets := 0
 
@@ -1111,7 +1138,7 @@ func (r *Replica) collectSpans(
 		inner := union.GetInner()
 		if cmd, ok := batcheval.LookupCommand(inner.Method()); ok {
 			cmd.DeclareKeys(desc, &ba.Header, inner, latchSpans, lockSpans, r.Clock().MaxOffset())
-			if considerOptEval {
+			if considerOptEvalForLimit {
 				switch inner.(type) {
 				case *roachpb.ScanRequest, *roachpb.ReverseScanRequest:
 					hasScans = true
@@ -1136,12 +1163,12 @@ func (r *Replica) collectSpans(
 		}
 	}
 
-	requestEvalKind = concurrency.PessimisticEval
-	if considerOptEval {
+	optEvalForLimit := false
+	if considerOptEvalForLimit {
 		// Evaluate batches optimistically if they have a key limit which is less
 		// than the upper bound on number of keys that can be returned for this
 		// batch. For scans, the upper bound is the number of live keys on the
-		// Range. For gets, it is the minimum of he number of live keys on the
+		// Range. For gets, it is the minimum of the number of live keys on the
 		// Range and the number of gets. Ignoring write latches and locks can be
 		// beneficial because it can help avoid waiting on writes to keys that the
 		// batch will never actually need to read due to the overestimate of its
@@ -1165,8 +1192,13 @@ func (r *Replica) collectSpans(
 			upperBoundKeys = int64(numGets)
 		}
 		if ba.Header.MaxSpanRequestKeys < upperBoundKeys {
-			requestEvalKind = concurrency.OptimisticEval
+			optEvalForLimit = true
 		}
+	}
+
+	requestEvalKind = concurrency.PessimisticEval
+	if optEvalForSkipLocked || optEvalForLimit {
+		requestEvalKind = concurrency.OptimisticEval
 	}
 
 	return latchSpans, lockSpans, requestEvalKind, nil

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -7971,7 +7971,7 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 		ba.Timestamp = tc.Clock().Now()
 		ba.Add(&roachpb.PutRequest{RequestHeader: roachpb.RequestHeader{Key: roachpb.Key(id)}})
 		st := r.CurrentLeaseStatus(ctx)
-		cmd, pErr := r.requestToProposal(ctx, kvserverbase.CmdIDKey(id), &ba, &st, uncertainty.Interval{}, allSpansGuard())
+		cmd, pErr := r.requestToProposal(ctx, kvserverbase.CmdIDKey(id), &ba, allSpansGuard(), &st, uncertainty.Interval{})
 		if pErr != nil {
 			t.Fatal(pErr)
 		}
@@ -8094,7 +8094,7 @@ func TestReplicaRefreshMultiple(t *testing.T) {
 	incCmdID = makeIDKey()
 	atomic.StoreInt32(&filterActive, 1)
 	st := repl.CurrentLeaseStatus(ctx)
-	proposal, pErr := repl.requestToProposal(ctx, incCmdID, &ba, &st, uncertainty.Interval{}, allSpansGuard())
+	proposal, pErr := repl.requestToProposal(ctx, incCmdID, &ba, allSpansGuard(), &st, uncertainty.Interval{})
 	if pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -8799,7 +8799,7 @@ func TestReplicaEvaluationNotTxnMutation(t *testing.T) {
 	assignSeqNumsForReqs(txn, &txnPut, &txnPut2)
 	origTxn := txn.Clone()
 
-	batch, _, _, _, pErr := tc.repl.evaluateWriteBatch(ctx, makeIDKey(), &ba, nil, uncertainty.Interval{}, allSpansGuard())
+	batch, _, _, _, pErr := tc.repl.evaluateWriteBatch(ctx, makeIDKey(), &ba, allSpansGuard(), nil, uncertainty.Interval{})
 	defer batch.Close()
 	if pErr != nil {
 		t.Fatal(pErr)
@@ -13280,7 +13280,7 @@ func TestContainsEstimatesClampProposal(t *testing.T) {
 		req := putArgs(roachpb.Key("some-key"), []byte("some-value"))
 		ba.Add(&req)
 		st := tc.repl.CurrentLeaseStatus(ctx)
-		proposal, err := tc.repl.requestToProposal(ctx, cmdIDKey, &ba, &st, uncertainty.Interval{}, allSpansGuard())
+		proposal, err := tc.repl.requestToProposal(ctx, cmdIDKey, &ba, allSpansGuard(), &st, uncertainty.Interval{})
 		if err != nil {
 			t.Error(err)
 		}

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -2695,11 +2695,11 @@ func TestReplicaLatchingSplitDeclaresWrites(t *testing.T) {
 	}
 }
 
-// TestReplicaLatchingOptimisticEvaluation verifies that limited scans
+// TestReplicaLatchingOptimisticEvaluationKeyLimit verifies that limited scans
 // evaluate optimistically without waiting for latches to be acquired. In some
 // cases, this allows them to avoid waiting on writes that their
 // over-estimated declared spans overlapped with.
-func TestReplicaLatchingOptimisticEvaluation(t *testing.T) {
+func TestReplicaLatchingOptimisticEvaluationKeyLimit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	testutils.RunTrueAndFalse(t, "point-reads", func(t *testing.T, pointReads bool) {
@@ -2818,6 +2818,138 @@ func TestReplicaLatchingOptimisticEvaluation(t *testing.T) {
 				}
 			})
 		}
+	})
+}
+
+// TestReplicaLatchingOptimisticEvaluationSkipLocked verifies that reads using
+// the SkipLocked wait policy evaluate optimistically without waiting for
+// latches to be acquired. In some cases, this allows them to avoid waiting on
+// latches that are touching the same keys but that the weaker isolation level
+// of SkipLocked allows the read to skip.
+func TestReplicaLatchingOptimisticEvaluationSkipLocked(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	testutils.RunTrueAndFalse(t, "point-reads", func(t *testing.T, pointReads bool) {
+		testutils.RunTrueAndFalse(t, "locking-reads", func(t *testing.T, lockingReads bool) {
+			var baRead roachpb.BatchRequest
+			baRead.WaitPolicy = lock.WaitPolicy_SkipLocked
+			if pointReads {
+				gArgs1, gArgs2 := getArgsString("a"), getArgsString("b")
+				gArgs3, gArgs4 := getArgsString("c"), getArgsString("d")
+				if lockingReads {
+					gArgs1.KeyLocking = lock.Exclusive
+					gArgs2.KeyLocking = lock.Exclusive
+					gArgs3.KeyLocking = lock.Exclusive
+					gArgs4.KeyLocking = lock.Exclusive
+				}
+				baRead.Add(gArgs1, gArgs2, gArgs3, gArgs4)
+			} else {
+				// Split into two back-to-back scans for better test coverage.
+				sArgs1 := scanArgsString("a", "c")
+				sArgs2 := scanArgsString("c", "e")
+				if lockingReads {
+					sArgs1.KeyLocking = lock.Exclusive
+					sArgs2.KeyLocking = lock.Exclusive
+				}
+				baRead.Add(sArgs1, sArgs2)
+			}
+			// The state that will block two writes while holding latches.
+			var blockWriters atomic.Value
+			blockKey1, blockKey2 := roachpb.Key("c"), roachpb.Key("d")
+			blockWriters.Store(false)
+			blockCh := make(chan struct{})
+			blockedCh := make(chan struct{}, 1)
+			// Setup filter to block the writes.
+			tc := testContext{}
+			tsc := TestStoreConfig(nil)
+			tsc.TestingKnobs.EvalKnobs.TestingEvalFilter =
+				func(filterArgs kvserverbase.FilterArgs) *roachpb.Error {
+					// Make sure the direct GC path doesn't interfere with this test.
+					reqKey := filterArgs.Req.Header().Key
+					if !reqKey.Equal(blockKey1) && !reqKey.Equal(blockKey2) {
+						return nil
+					}
+					if filterArgs.Req.Method() == roachpb.Put && blockWriters.Load().(bool) {
+						blockedCh <- struct{}{}
+						<-blockCh
+					}
+					return nil
+				}
+			ctx := context.Background()
+			stopper := stop.NewStopper()
+			defer stopper.Stop(ctx)
+			tc.StartWithStoreConfig(ctx, t, stopper, tsc)
+			// Write initial keys on some, but not all keys.
+			for _, k := range []string{"a", "b", "c"} {
+				pArgs := putArgs([]byte(k), []byte("value"))
+				_, pErr := tc.SendWrapped(&pArgs)
+				require.Nil(t, pErr)
+			}
+
+			// Write #1: lock key "c" and then write to it again in the same txn. Since
+			// the key is locked at the time the write is blocked and the SkipLocked
+			// read evaluates, the read skips over the key and does not conflict with
+			// the write's latches.
+			txn := newTransaction("locker", blockKey1, 0, tc.Clock())
+			txnH := roachpb.Header{Txn: txn}
+			putArgs1 := putArgs(blockKey1, []byte("value"))
+			_, pErr := tc.SendWrappedWith(txnH, &putArgs1)
+			require.Nil(t, pErr)
+			// Write to the blocked key again, and this time stall. Note that this could
+			// also be the ResolveIntent request that's removing the lock, which is
+			// likely an even more common cause of blocking today. However, we use a Put
+			// here because we may stop acquiring latches during intent resolution in
+			// the future and don't want this test to break when we do.
+			errCh := make(chan *roachpb.Error, 3)
+			blockWriters.Store(true)
+			go func() {
+				_, pErr := tc.SendWrappedWith(txnH, &putArgs1)
+				errCh <- pErr
+			}()
+			<-blockedCh
+
+			// Write #2: perform an initial write on key "d". Since the key is missing
+			// at the time the write is blocked and the SkipLocked read evaluates, the
+			// read skips over the key and does not conflict with the write's latches.
+			putArgs2 := putArgs(blockKey2, []byte("value"))
+			go func() {
+				_, pErr := tc.SendWrappedWith(txnH, &putArgs2)
+				errCh <- pErr
+			}()
+			<-blockedCh
+
+			// The writes are now blocked while holding latches. Issue the read.
+			blockWriters.Store(false)
+			var respKeys []roachpb.Key
+			go func() {
+				errCh <- func() *roachpb.Error {
+					br, pErr := tc.Sender().Send(ctx, baRead)
+					if pErr != nil {
+						return pErr
+					}
+					for i, req := range baRead.Requests {
+						resp := br.Responses[i]
+						if err := roachpb.ResponseKeyIterate(req.GetInner(), resp.GetInner(), func(k roachpb.Key) {
+							respKeys = append(respKeys, k)
+						}); err != nil {
+							return roachpb.NewError(err)
+						}
+					}
+					return nil
+				}()
+			}()
+
+			// The read should complete first.
+			require.Nil(t, <-errCh)
+			// The writes should complete next, after they are unblocked.
+			close(blockCh)
+			require.Nil(t, <-errCh)
+			require.Nil(t, <-errCh)
+
+			// The read should have only returned the unlocked keys.
+			expRespKeys := []roachpb.Key{roachpb.Key("a"), roachpb.Key("b")}
+			require.Equal(t, expRespKeys, respKeys)
+		})
 	})
 }
 

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -382,9 +382,9 @@ func (r *Replica) evaluateWriteBatch(
 	ctx context.Context,
 	idKey kvserverbase.CmdIDKey,
 	ba *roachpb.BatchRequest,
+	g *concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
-	g *concurrency.Guard,
 ) (storage.Batch, enginepb.MVCCStats, *roachpb.BatchResponse, result.Result, *roachpb.Error) {
 	log.Event(ctx, "executing read-write batch")
 
@@ -396,7 +396,7 @@ func (r *Replica) evaluateWriteBatch(
 	// Attempt 1PC execution, if applicable. If not transactional or there are
 	// indications that the batch's txn will require retry, execute as normal.
 	if r.canAttempt1PCEvaluation(ctx, ba, g) {
-		res := r.evaluate1PC(ctx, idKey, ba, st, g)
+		res := r.evaluate1PC(ctx, idKey, ba, g, st)
 		switch res.success {
 		case onePCSucceeded:
 			return res.batch, res.stats, res.br, res.res, nil
@@ -428,7 +428,7 @@ func (r *Replica) evaluateWriteBatch(
 	rec := NewReplicaEvalContext(ctx, r, g.LatchSpans(), ba.RequiresClosedTSOlderThanStorageSnapshot())
 	defer rec.Release()
 	batch, br, res, pErr := r.evaluateWriteBatchWithServersideRefreshes(
-		ctx, idKey, rec, ms, ba, st, ui, g, nil /* deadline */)
+		ctx, idKey, rec, ms, ba, g, st, ui, nil /* deadline */)
 	return batch, *ms, br, res, pErr
 }
 
@@ -471,8 +471,8 @@ func (r *Replica) evaluate1PC(
 	ctx context.Context,
 	idKey kvserverbase.CmdIDKey,
 	ba *roachpb.BatchRequest,
-	st *kvserverpb.LeaseStatus,
 	g *concurrency.Guard,
+	st *kvserverpb.LeaseStatus,
 ) (onePCRes onePCResult) {
 	log.VEventf(ctx, 2, "attempting 1PC execution")
 
@@ -508,10 +508,10 @@ func (r *Replica) evaluate1PC(
 	ms := new(enginepb.MVCCStats)
 	if ba.CanForwardReadTimestamp {
 		batch, br, res, pErr = r.evaluateWriteBatchWithServersideRefreshes(
-			ctx, idKey, rec, ms, &strippedBa, st, ui, g, etArg.Deadline)
+			ctx, idKey, rec, ms, &strippedBa, g, st, ui, etArg.Deadline)
 	} else {
 		batch, br, res, pErr = r.evaluateWriteBatchWrapper(
-			ctx, idKey, rec, ms, &strippedBa, st, ui, g)
+			ctx, idKey, rec, ms, &strippedBa, g, st, ui)
 	}
 
 	if pErr != nil || (!ba.CanForwardReadTimestamp && ba.Timestamp != br.Timestamp) {
@@ -601,9 +601,9 @@ func (r *Replica) evaluateWriteBatchWithServersideRefreshes(
 	rec batcheval.EvalContext,
 	ms *enginepb.MVCCStats,
 	ba *roachpb.BatchRequest,
+	g *concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
-	g *concurrency.Guard,
 	deadline *hlc.Timestamp,
 ) (batch storage.Batch, br *roachpb.BatchResponse, res result.Result, pErr *roachpb.Error) {
 	goldenMS := *ms
@@ -617,7 +617,7 @@ func (r *Replica) evaluateWriteBatchWithServersideRefreshes(
 			batch.Close()
 		}
 
-		batch, br, res, pErr = r.evaluateWriteBatchWrapper(ctx, idKey, rec, ms, ba, st, ui, g)
+		batch, br, res, pErr = r.evaluateWriteBatchWrapper(ctx, idKey, rec, ms, ba, g, st, ui)
 
 		var success bool
 		if pErr == nil {
@@ -645,13 +645,13 @@ func (r *Replica) evaluateWriteBatchWrapper(
 	rec batcheval.EvalContext,
 	ms *enginepb.MVCCStats,
 	ba *roachpb.BatchRequest,
+	g *concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
-	g *concurrency.Guard,
 ) (storage.Batch, *roachpb.BatchResponse, result.Result, *roachpb.Error) {
 	batch, opLogger := r.newBatchedEngine(ba, g)
 	now := timeutil.Now()
-	br, res, pErr := evaluateBatch(ctx, idKey, batch, rec, ms, ba, st, ui, false /* readOnly */)
+	br, res, pErr := evaluateBatch(ctx, idKey, batch, rec, ms, ba, g, st, ui, false /* readOnly */)
 	r.store.metrics.ReplicaWriteBatchEvaluationLatency.RecordValue(timeutil.Since(now).Nanoseconds())
 	if pErr == nil {
 		if opLogger != nil {

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
@@ -1998,6 +1999,80 @@ func TestStoreScanResumeTSCache(t *testing.T) {
 	require.Equal(t, makeTS(t3.UnixNano(), 0), rTS)
 	rTS, _ = store.tsCache.GetMax(roachpb.Key("c"), nil)
 	require.Equal(t, makeTS(t2.UnixNano(), 0), rTS)
+}
+
+// TestStoreSkipLockedTSCache verifies that the timestamp cache is properly
+// updated when get, scan, and reverse scan requests use the SkipLocked wait
+// policy.
+func TestStoreSkipLockedTSCache(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	for _, tc := range []struct {
+		name string
+		reqs []roachpb.Request
+	}{
+		{"get", []roachpb.Request{getArgsString("a"), getArgsString("b"), getArgsString("c")}},
+		{"scan", []roachpb.Request{scanArgsString("a", "d")}},
+		{"revscan", []roachpb.Request{revScanArgsString("a", "d")}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			stopper := stop.NewStopper()
+			defer stopper.Stop(ctx)
+			store, manualClock := createTestStore(ctx, t, testStoreOpts{createSystemRanges: true}, stopper)
+
+			// Write three keys at time t0.
+			t0 := timeutil.Unix(1, 0)
+			manualClock.MustAdvanceTo(t0)
+			h := roachpb.Header{Timestamp: makeTS(t0.UnixNano(), 0)}
+			for _, keyStr := range []string{"a", "b", "c"} {
+				putArgs := putArgs(roachpb.Key(keyStr), []byte("value"))
+				_, pErr := kv.SendWrappedWith(ctx, store.TestSender(), h, &putArgs)
+				require.Nil(t, pErr)
+			}
+
+			// Lock the middle key at t1.
+			t1 := timeutil.Unix(2, 0)
+			manualClock.MustAdvanceTo(t1)
+			lockedKey := roachpb.Key("b")
+			txn := roachpb.MakeTransaction("locker", lockedKey, 0, makeTS(t1.UnixNano(), 0), 0, 0)
+			txnH := roachpb.Header{Txn: &txn}
+			putArgs := putArgs(lockedKey, []byte("newval"))
+			_, pErr := kv.SendWrappedWith(ctx, store.TestSender(), txnH, &putArgs)
+			require.Nil(t, pErr)
+
+			// Read the span at t2 using a SkipLocked wait policy.
+			t2 := timeutil.Unix(3, 0)
+			manualClock.MustAdvanceTo(t2)
+			ba := roachpb.BatchRequest{}
+			ba.Timestamp = makeTS(t2.UnixNano(), 0)
+			ba.WaitPolicy = lock.WaitPolicy_SkipLocked
+			ba.Add(tc.reqs...)
+			br, pErr := store.TestSender().Send(ctx, ba)
+			require.Nil(t, pErr)
+
+			// Validate the response keys. The locked key should not be included.
+			var respKeys []string
+			for i, ru := range br.Responses {
+				req, resp := ba.Requests[i].GetInner(), ru.GetInner()
+				require.NoError(t, roachpb.ResponseKeyIterate(req, resp, func(k roachpb.Key) {
+					respKeys = append(respKeys, string(k))
+				}))
+			}
+			sort.Strings(respKeys) // normalize reverse scan
+			require.Equal(t, []string{"a", "c"}, respKeys)
+
+			// Verify the timestamp cache has been set for "a" and "c", but not for "b".
+			t2TS := makeTS(t2.UnixNano(), 0)
+			rTS, _ := store.tsCache.GetMax(roachpb.Key("a"), nil)
+			require.True(t, rTS.EqOrdering(t2TS))
+			rTS, _ = store.tsCache.GetMax(roachpb.Key("b"), nil)
+			require.True(t, rTS.Less(t2TS))
+			rTS, _ = store.tsCache.GetMax(roachpb.Key("c"), nil)
+			require.True(t, rTS.EqOrdering(t2TS))
+		})
+	}
 }
 
 // TestStoreScanIntents verifies that a scan across 10 intents resolves

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -94,6 +94,7 @@ const (
 	updatesTSCacheOnErr                                       // commands which make read data available on errors
 	needsRefresh                                              // commands which require refreshes to avoid serializable retries
 	canBackpressure                                           // commands which deserve backpressure when a Range grows too large
+	canSkipLocked                                             // commands which can evaluate under the SkipLocked wait policy
 	bypassesReplicaCircuitBreaker                             // commands which bypass the replica circuit breaker, i.e. opt out of fail-fast
 	requiresClosedTSOlderThanStorageSnapshot                  // commands which read a replica's closed timestamp that is older than the state of the storage engine
 )
@@ -205,6 +206,12 @@ func CanBackpressure(args Request) bool {
 	return (args.flags() & canBackpressure) != 0
 }
 
+// CanSkipLocked returns whether the command can evaluate under the
+// SkipLocked wait policy.
+func CanSkipLocked(args Request) bool {
+	return (args.flags() & canSkipLocked) != 0
+}
+
 // BypassesReplicaCircuitBreaker returns whether the command bypasses
 // the per-Replica circuit breakers. These requests will thus hang when
 // addressed to an unavailable range (instead of failing fast).
@@ -224,6 +231,34 @@ type Request interface {
 	// ShallowCopy returns a shallow copy of the receiver.
 	ShallowCopy() Request
 	flags() flag
+}
+
+// LockingReadRequest is an interface used to expose the key-level locking
+// strength of a read-only request.
+type LockingReadRequest interface {
+	Request
+	KeyLockingStrength() lock.Strength
+}
+
+var _ LockingReadRequest = (*GetRequest)(nil)
+
+// KeyLockingStrength implements the LockingReadRequest interface.
+func (gr *GetRequest) KeyLockingStrength() lock.Strength {
+	return gr.KeyLocking
+}
+
+var _ LockingReadRequest = (*ScanRequest)(nil)
+
+// KeyLockingStrength implements the LockingReadRequest interface.
+func (sr *ScanRequest) KeyLockingStrength() lock.Strength {
+	return sr.KeyLocking
+}
+
+var _ LockingReadRequest = (*ReverseScanRequest)(nil)
+
+// KeyLockingStrength implements the LockingReadRequest interface.
+func (rsr *ReverseScanRequest) KeyLockingStrength() lock.Strength {
+	return rsr.KeyLocking
 }
 
 // SizedWriteRequest is an interface used to expose the number of bytes a
@@ -1221,7 +1256,7 @@ func flagForLockStrength(l lock.Strength) flag {
 
 func (gr *GetRequest) flags() flag {
 	maybeLocking := flagForLockStrength(gr.KeyLocking)
-	return isRead | isTxn | maybeLocking | updatesTSCache | needsRefresh
+	return isRead | isTxn | maybeLocking | updatesTSCache | needsRefresh | canSkipLocked
 }
 
 func (*PutRequest) flags() flag {
@@ -1307,12 +1342,12 @@ func (*RevertRangeRequest) flags() flag {
 
 func (sr *ScanRequest) flags() flag {
 	maybeLocking := flagForLockStrength(sr.KeyLocking)
-	return isRead | isRange | isTxn | maybeLocking | updatesTSCache | needsRefresh
+	return isRead | isRange | isTxn | maybeLocking | updatesTSCache | needsRefresh | canSkipLocked
 }
 
 func (rsr *ReverseScanRequest) flags() flag {
 	maybeLocking := flagForLockStrength(rsr.KeyLocking)
-	return isRead | isRange | isReverse | isTxn | maybeLocking | updatesTSCache | needsRefresh
+	return isRead | isRange | isReverse | isTxn | maybeLocking | updatesTSCache | needsRefresh | canSkipLocked
 }
 
 // EndTxn updates the timestamp cache to prevent replays.

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -2328,6 +2328,11 @@ message Header {
   // If an Error wait policy is set and a conflicting lock held by an active
   // transaction is encountered, a WriteIntentError will be returned.
   //
+  // If a SkipLocked wait policy is set and a conflicting lock held by an active
+  // transaction is encountered, the corresponding key is not included in the
+  // response and the lock is ignored (i.e. the lock does not cause the request
+  // to block or throw an error).
+  //
   // If the desired behavior is to block on the conflicting lock up to some
   // maximum duration, use the Block wait policy and set a context timeout.
   kv.kvserver.concurrency.lock.WaitPolicy wait_policy = 18;

--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -477,7 +477,7 @@ func (ba *BatchRequest) LockSpanIterate(br *BatchResponse, fn func(Span, lock.Du
 // ResumeSpan is subtracted from the request span to provide a more
 // minimal span of keys affected by the request. The supplied function
 // is called with each span.
-func (ba *BatchRequest) RefreshSpanIterate(br *BatchResponse, fn func(Span)) {
+func (ba *BatchRequest) RefreshSpanIterate(br *BatchResponse, fn func(Span)) error {
 	for i, arg := range ba.Requests {
 		req := arg.GetInner()
 		if !NeedsRefresh(req) {
@@ -487,10 +487,32 @@ func (ba *BatchRequest) RefreshSpanIterate(br *BatchResponse, fn func(Span)) {
 		if br != nil {
 			resp = br.Responses[i].GetInner()
 		}
-		if span, ok := ActualSpan(req, resp); ok {
-			fn(span)
+		if ba.WaitPolicy == lock.WaitPolicy_SkipLocked && CanSkipLocked(req) {
+			// If the request is using a SkipLocked wait policy, it behaves as if run
+			// at a lower isolation level for any keys that it skips over. For this
+			// reason, the request only adds point reads for the individual keys
+			// returned to the timestamp cache, as opposed to adding an entry across
+			// the entire read span. See Replica.updateTimestampCache.
+			//
+			// For the same reason, the request only records refresh spans for the
+			// individual keys returned, instead of recording a refresh span across
+			// the entire read span. Because the issuing transaction is not intending
+			// to enforce serializable isolation across keys that were skipped by this
+			// request, it does not need to validate that they have not changed if the
+			// transaction ever needs to refresh.
+			if err := ResponseKeyIterate(req, resp, func(k Key) {
+				fn(Span{Key: k})
+			}); err != nil {
+				return err
+			}
+		} else {
+			// Otherwise, call the function with the span which was operated on.
+			if span, ok := ActualSpan(req, resp); ok {
+				fn(span)
+			}
 		}
 	}
+	return nil
 }
 
 // ActualSpan returns the actual request span which was operated on,
@@ -514,6 +536,57 @@ func ActualSpan(req Request, resp Response) (Span, bool) {
 		}
 	}
 	return h.Span(), true
+}
+
+// ResponseKeyIterate calls the passed function with the keys returned
+// in the provided request's response. If no keys are being returned,
+// the function will not be called.
+func ResponseKeyIterate(req Request, resp Response, fn func(Key)) error {
+	if resp == nil {
+		return nil
+	}
+	switch v := resp.(type) {
+	case *GetResponse:
+		if v.Value != nil {
+			fn(req.Header().Key)
+		}
+	case *ScanResponse:
+		// If ScanFormat == KEY_VALUES.
+		for _, kv := range v.Rows {
+			fn(kv.Key)
+		}
+		// If ScanFormat == BATCH_RESPONSE.
+		if err := enginepb.ScanDecodeKeyValues(v.BatchResponses, func(key []byte, _ hlc.Timestamp, _ []byte) error {
+			// Clone the key to avoid handing out slices that directly point into the
+			// BatchResponses buffer, which contains the response's keys and values.
+			// This guards against callers which store the response keys in a data
+			// structure accidentally retaining long-lasting references to this
+			// response's underlying result buffer and preventing it from being GCed.
+			//
+			// This is not a concern for other scan formats because keys and values
+			// are already separate heap allocations.
+			fn(Key(key).Clone())
+			return nil
+		}); err != nil {
+			return err
+		}
+	case *ReverseScanResponse:
+		// If ScanFormat == KEY_VALUES.
+		for _, kv := range v.Rows {
+			fn(kv.Key)
+		}
+		// If ScanFormat == BATCH_RESPONSE.
+		if err := enginepb.ScanDecodeKeyValues(v.BatchResponses, func(key []byte, _ hlc.Timestamp, _ []byte) error {
+			// Same explanation as above.
+			fn(Key(key).Clone())
+			return nil
+		}); err != nil {
+			return err
+		}
+	default:
+		return errors.Errorf("cannot iterate over response keys of %s request", req.Method())
+	}
+	return nil
 }
 
 // Combine combines each slot of the given request into the corresponding slot

--- a/pkg/sql/catalog/descpb/locking.go
+++ b/pkg/sql/catalog/descpb/locking.go
@@ -57,7 +57,7 @@ func (wp ScanLockingWaitPolicy) PrettyString() string {
 	switch wp {
 	case ScanLockingWaitPolicy_BLOCK:
 		return "block"
-	case ScanLockingWaitPolicy_SKIP:
+	case ScanLockingWaitPolicy_SKIP_LOCKED:
 		return "skip locked"
 	case ScanLockingWaitPolicy_ERROR:
 		return "nowait"
@@ -72,8 +72,8 @@ func ToScanLockingWaitPolicy(wp tree.LockingWaitPolicy) ScanLockingWaitPolicy {
 	switch wp {
 	case tree.LockWaitBlock:
 		return ScanLockingWaitPolicy_BLOCK
-	case tree.LockWaitSkip:
-		return ScanLockingWaitPolicy_SKIP
+	case tree.LockWaitSkipLocked:
+		return ScanLockingWaitPolicy_SKIP_LOCKED
 	case tree.LockWaitError:
 		return ScanLockingWaitPolicy_ERROR
 	default:

--- a/pkg/sql/catalog/descpb/locking.proto
+++ b/pkg/sql/catalog/descpb/locking.proto
@@ -123,11 +123,11 @@ enum ScanLockingWaitPolicy {
   // BLOCK represents the default - wait for the lock to become available.
   BLOCK = 0;
 
-  // SKIP represents SKIP LOCKED - skip rows that can't be locked.
+  // SKIP_LOCKED represents SKIP LOCKED - skip rows that can't be locked.
   //
-  // NOTE: SKIP is not currently implemented and does not make it out of the SQL
-  // optimizer without throwing an error.
-  SKIP  = 1;
+  // NOTE: SKIP_LOCKED is not currently implemented and does not make it out of
+  // the SQL optimizer without throwing an error.
+  SKIP_LOCKED = 1;
 
   // ERROR represents NOWAIT - raise an error if a row cannot be locked.
   ERROR = 2;

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -1425,7 +1425,7 @@ func (f *ExprFmtCtx) formatLockingWithPrefix(
 	wait := ""
 	switch locking.WaitPolicy {
 	case tree.LockWaitBlock:
-	case tree.LockWaitSkip:
+	case tree.LockWaitSkipLocked:
 		wait = ",skip-locked"
 	case tree.LockWaitError:
 		wait = ",nowait"

--- a/pkg/sql/opt/memo/interner_test.go
+++ b/pkg/sql/opt/memo/interner_test.go
@@ -511,7 +511,7 @@ func TestInterner(t *testing.T) {
 				equal: false,
 			},
 			{
-				val1:  opt.Locking{WaitPolicy: tree.LockWaitSkip},
+				val1:  opt.Locking{WaitPolicy: tree.LockWaitSkipLocked},
 				val2:  opt.Locking{WaitPolicy: tree.LockWaitError},
 				equal: false,
 			},

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -1306,7 +1306,7 @@ func (b *Builder) validateLockingInFrom(
 		switch li.WaitPolicy {
 		case tree.LockWaitBlock:
 			// Default. Block on conflicting locks.
-		case tree.LockWaitSkip:
+		case tree.LockWaitSkipLocked:
 			panic(unimplementedWithIssueDetailf(40476, "",
 				"SKIP LOCKED lock wait policy is not supported"))
 		case tree.LockWaitError:

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -10123,7 +10123,7 @@ opt_locked_rels:
 
 opt_nowait_or_skip:
   /* EMPTY */ { $$.val = tree.LockWaitBlock }
-| SKIP LOCKED { $$.val = tree.LockWaitSkip }
+| SKIP LOCKED { $$.val = tree.LockWaitSkipLocked }
 | NOWAIT      { $$.val = tree.LockWaitError }
 
 select_clause:

--- a/pkg/sql/row/locking.go
+++ b/pkg/sql/row/locking.go
@@ -51,7 +51,7 @@ func getWaitPolicy(lockWaitPolicy descpb.ScanLockingWaitPolicy) lock.WaitPolicy 
 	case descpb.ScanLockingWaitPolicy_BLOCK:
 		return lock.WaitPolicy_Block
 
-	case descpb.ScanLockingWaitPolicy_SKIP:
+	case descpb.ScanLockingWaitPolicy_SKIP_LOCKED:
 		// Should not get here. Query should be rejected during planning.
 		panic(errors.AssertionFailedf("unsupported wait policy %s", lockWaitPolicy))
 

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -1108,17 +1108,17 @@ const (
 	// LockWaitBlock represents the default - wait for the lock to become
 	// available.
 	LockWaitBlock LockingWaitPolicy = iota
-	// LockWaitSkip represents SKIP LOCKED - skip rows that can't be locked.
-	LockWaitSkip
+	// LockWaitSkipLocked represents SKIP LOCKED - skip rows that can't be locked.
+	LockWaitSkipLocked
 	// LockWaitError represents NOWAIT - raise an error if a row cannot be
 	// locked.
 	LockWaitError
 )
 
 var lockingWaitPolicyName = [...]string{
-	LockWaitBlock: "",
-	LockWaitSkip:  "SKIP LOCKED",
-	LockWaitError: "NOWAIT",
+	LockWaitBlock:      "",
+	LockWaitSkipLocked: "SKIP LOCKED",
+	LockWaitError:      "NOWAIT",
 }
 
 func (p LockingWaitPolicy) String() string {

--- a/pkg/storage/enginepb/decode.go
+++ b/pkg/storage/enginepb/decode.go
@@ -125,3 +125,27 @@ func ScanDecodeKeyValueNoTS(repr []byte) (key []byte, value []byte, orepr []byte
 	}
 	return key, value, ret, err
 }
+
+// ScanDecodeKeyValues decodes all key/value pairs returned in one or more
+// MVCCScan "batches" (this is not the RocksDB batch repr format). The provided
+// function is called for each key/value pair.
+func ScanDecodeKeyValues(
+	repr [][]byte, fn func(key []byte, ts hlc.Timestamp, rawBytes []byte) error,
+) error {
+	var k []byte
+	var ts hlc.Timestamp
+	var rawBytes []byte
+	var err error
+	for _, data := range repr {
+		for len(data) > 0 {
+			k, ts, rawBytes, data, err = ScanDecodeKeyValue(data)
+			if err != nil {
+				return err
+			}
+			if err = fn(k, ts, rawBytes); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/uncertainty"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -688,26 +689,54 @@ func MVCCBlindPutProto(
 	return MVCCBlindPut(ctx, writer, ms, key, timestamp, localTimestamp, value, txn)
 }
 
+// LockTableView is a transaction-bound view into an in-memory collections of
+// key-level locks. The set of per-key locks stored in the in-memory lock table
+// structure overlaps with those stored in the persistent lock table keyspace
+// (i.e. intents produced by an MVCCKeyAndIntentsIterKind iterator), but one is
+// not a subset of the other. There are locks only stored in the in-memory lock
+// table (i.e. unreplicated locks) and locks only stored in the persistent lock
+// table keyspace (i.e. replicated locks that have yet to be "discovered").
+type LockTableView interface {
+	// IsKeyLockedByConflictingTxn returns whether the specified key is locked by
+	// a conflicting transaction, given the caller's own desired locking strength.
+	// If so, the lock holder is returned. A transaction's own lock does not
+	// appear to be locked to itself (false is returned). The method is used by
+	// requests in conjunction with the SkipLocked wait policy to determine which
+	// keys they should skip over during evaluation.
+	IsKeyLockedByConflictingTxn(roachpb.Key, lock.Strength) (bool, *enginepb.TxnMeta)
+}
+
 // MVCCGetOptions bundles options for the MVCCGet family of functions.
 type MVCCGetOptions struct {
 	// See the documentation for MVCCGet for information on these parameters.
 	Inconsistent     bool
+	SkipLocked       bool
 	Tombstones       bool
 	FailOnMoreRecent bool
 	Txn              *roachpb.Transaction
 	Uncertainty      uncertainty.Interval
 	// MemoryAccount is used for tracking memory allocations.
 	MemoryAccount *mon.BoundAccount
+	// LockTable is used to determine whether keys are locked in the in-memory
+	// lock table when scanning with the SkipLocked option.
+	LockTable LockTableView
 }
 
 func (opts *MVCCGetOptions) validate() error {
 	if opts.Inconsistent && opts.Txn != nil {
 		return errors.Errorf("cannot allow inconsistent reads within a transaction")
 	}
+	if opts.Inconsistent && opts.SkipLocked {
+		return errors.Errorf("cannot allow inconsistent reads with skip locked option")
+	}
 	if opts.Inconsistent && opts.FailOnMoreRecent {
 		return errors.Errorf("cannot allow inconsistent reads with fail on more recent option")
 	}
 	return nil
+}
+
+func (opts *MVCCGetOptions) errOnIntents() bool {
+	return !opts.Inconsistent && !opts.SkipLocked
 }
 
 // newMVCCIterator sets up a suitable iterator for high-level MVCC operations
@@ -758,6 +787,13 @@ func newMVCCIterator(
 // If the timestamp is specified as hlc.Timestamp{}, the value is expected to be
 // "inlined". See MVCCPut().
 //
+// When reading in "skip locked" mode, a key that is locked by a transaction
+// other than the reader is not included in the result set and does not result
+// in a WriteIntentError. Instead, the key is included in the encountered intent
+// result parameter so that it can be resolved asynchronously. In this mode, the
+// LockTableView provided in the options is consulted any observed key to
+// determine whether it is locked with an unreplicated lock.
+//
 // When reading in "fail on more recent" mode, a WriteTooOldError will be
 // returned if the read observes a version with a timestamp above the read
 // timestamp. Similarly, a WriteIntentError will be returned if the read
@@ -801,10 +837,12 @@ func mvccGet(
 	*mvccScanner = pebbleMVCCScanner{
 		parent:           iter,
 		memAccount:       opts.MemoryAccount,
+		lockTable:        opts.LockTable,
 		start:            key,
 		ts:               timestamp,
 		maxKeys:          1,
 		inconsistent:     opts.Inconsistent,
+		skipLocked:       opts.SkipLocked,
 		tombstones:       opts.Tombstones,
 		failOnMoreRecent: opts.FailOnMoreRecent,
 		keyBuf:           mvccScanner.keyBuf,
@@ -824,7 +862,7 @@ func mvccGet(
 	if err != nil {
 		return optionalValue{}, nil, err
 	}
-	if !opts.Inconsistent && len(intents) > 0 {
+	if opts.errOnIntents() && len(intents) > 0 {
 		return optionalValue{}, nil, &roachpb.WriteIntentError{Intents: intents}
 	}
 
@@ -2804,6 +2842,7 @@ func mvccScanToBytes(
 	*mvccScanner = pebbleMVCCScanner{
 		parent:                 iter,
 		memAccount:             opts.MemoryAccount,
+		lockTable:              opts.LockTable,
 		reverse:                opts.Reverse,
 		start:                  key,
 		end:                    endKey,
@@ -2815,6 +2854,7 @@ func mvccScanToBytes(
 		wholeRows:              opts.WholeRowsOfSize > 1, // single-KV rows don't need processing
 		maxIntents:             opts.MaxIntents,
 		inconsistent:           opts.Inconsistent,
+		skipLocked:             opts.SkipLocked,
 		tombstones:             opts.Tombstones,
 		failOnMoreRecent:       opts.FailOnMoreRecent,
 		keyBuf:                 mvccScanner.keyBuf,
@@ -2848,7 +2888,7 @@ func mvccScanToBytes(
 		return MVCCScanResult{}, err
 	}
 
-	if !opts.Inconsistent && len(res.Intents) > 0 {
+	if opts.errOnIntents() && len(res.Intents) > 0 {
 		return MVCCScanResult{}, &roachpb.WriteIntentError{Intents: res.Intents}
 	}
 	return res, nil
@@ -2917,6 +2957,7 @@ func buildScanIntents(data []byte) ([]roachpb.Intent, error) {
 type MVCCScanOptions struct {
 	// See the documentation for MVCCScan for information on these parameters.
 	Inconsistent     bool
+	SkipLocked       bool
 	Tombstones       bool
 	Reverse          bool
 	FailOnMoreRecent bool
@@ -2964,16 +3005,26 @@ type MVCCScanOptions struct {
 	MaxIntents int64
 	// MemoryAccount is used for tracking memory allocations.
 	MemoryAccount *mon.BoundAccount
+	// LockTable is used to determine whether keys are locked in the in-memory
+	// lock table when scanning with the SkipLocked option.
+	LockTable LockTableView
 }
 
 func (opts *MVCCScanOptions) validate() error {
 	if opts.Inconsistent && opts.Txn != nil {
 		return errors.Errorf("cannot allow inconsistent reads within a transaction")
 	}
+	if opts.Inconsistent && opts.SkipLocked {
+		return errors.Errorf("cannot allow inconsistent reads with skip locked option")
+	}
 	if opts.Inconsistent && opts.FailOnMoreRecent {
 		return errors.Errorf("cannot allow inconsistent reads with fail on more recent option")
 	}
 	return nil
+}
+
+func (opts *MVCCScanOptions) errOnIntents() bool {
+	return !opts.Inconsistent && !opts.SkipLocked
 }
 
 // MVCCScanResult groups the values returned from an MVCCScan operation. Depending
@@ -3034,6 +3085,13 @@ type MVCCScanResult struct {
 //
 // Note that transactional scans must be consistent. Put another way, only
 // non-transactional scans may be inconsistent.
+//
+// When scanning in "skip locked" mode, keys that are locked by transactions
+// other than the reader are not included in the result set and do not result in
+// a WriteIntentError. Instead, these keys are included in the encountered
+// intents result parameter so that they can be resolved asynchronously. In this
+// mode, the LockTableView provided in the options is consulted for each key to
+// determine whether it is locked with an unreplicated lock.
 //
 // When scanning in "fail on more recent" mode, a WriteTooOldError will be
 // returned if the scan observes a version with a timestamp at or above the read

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -1269,21 +1269,9 @@ func MVCCScanDecodeKeyValue(repr []byte) (key MVCCKey, value []byte, orepr []byt
 // MVCCScan "batches" (this is not the RocksDB batch repr format). The provided
 // function is called for each key/value pair.
 func MVCCScanDecodeKeyValues(repr [][]byte, fn func(key MVCCKey, rawBytes []byte) error) error {
-	var k MVCCKey
-	var rawBytes []byte
-	var err error
-	for _, data := range repr {
-		for len(data) > 0 {
-			k, rawBytes, data, err = MVCCScanDecodeKeyValue(data)
-			if err != nil {
-				return err
-			}
-			if err = fn(k, rawBytes); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
+	return enginepb.ScanDecodeKeyValues(repr, func(k []byte, ts hlc.Timestamp, rawBytes []byte) error {
+		return fn(MVCCKey{k, ts}, rawBytes)
+	})
 }
 
 // replayTransactionalWrite performs a transactional write under the assumption

--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/uncertainty"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -296,8 +297,11 @@ type pebbleMVCCScanner struct {
 	pointIter *pointSynthesizingIter
 	// memAccount is used to account for the size of the scan results.
 	memAccount *mon.BoundAccount
-	reverse    bool
-	peeked     bool
+	// lockTable is used to determine whether keys are locked in the in-memory
+	// lock table when scanning with the skipLocked option.
+	lockTable LockTableView
+	reverse   bool
+	peeked    bool
 	// Iteration bounds. Does not contain MVCC timestamp.
 	start, end roachpb.Key
 	// Timestamp with which MVCCScan/MVCCGet was called.
@@ -346,11 +350,13 @@ type pebbleMVCCScanner struct {
 	meta enginepb.MVCCMetadata
 	// Bools copied over from MVCC{Scan,Get}Options. See the comment on the
 	// package level MVCCScan for what these mean.
-	inconsistent, tombstones bool
-	failOnMoreRecent         bool
-	isGet                    bool
-	keyBuf                   []byte
-	savedBuf                 []byte
+	inconsistent     bool
+	skipLocked       bool
+	tombstones       bool
+	failOnMoreRecent bool
+	isGet            bool
+	keyBuf           []byte
+	savedBuf         []byte
 	// cur* variables store the "current" record we're pointing to. Updated in
 	// updateCurrent. Note that the timestamp can be clobbered in the case of
 	// adding an intent from the intent history but is otherwise meaningful.
@@ -582,9 +588,22 @@ func (p *pebbleMVCCScanner) getAndAdvance(ctx context.Context) bool {
 				// 2. Our txn's read timestamp is equal to the most recent
 				// version's timestamp and the scanner has been configured to
 				// throw a write too old error on equal or more recent versions.
-				// Merge the current timestamp with the maximum timestamp we've
-				// seen so we know to return an error, but then keep scanning so
-				// that we can return the largest possible time.
+
+				if p.skipLocked {
+					if locked, ok := p.isKeyLockedByConflictingTxn(ctx, p.curRawKey); !ok {
+						return false
+					} else if locked {
+						// 2a. the scanner was configured to skip locked keys, and
+						// this key was locked, so we can advance past it without
+						// raising the write too old error.
+						return p.advanceKey()
+					}
+				}
+
+				// 2b. We need to raise a write too old error. Merge the current
+				// timestamp with the maximum timestamp we've seen so we know to
+				// return an error, but then keep scanning so that we can return
+				// the largest possible time.
 				p.mostRecentTS.Forward(p.curUnsafeKey.Timestamp)
 				if len(p.mostRecentKey) == 0 {
 					p.mostRecentKey = append(p.mostRecentKey, p.curUnsafeKey.Key...)
@@ -602,9 +621,22 @@ func (p *pebbleMVCCScanner) getAndAdvance(ctx context.Context) bool {
 			// 4. Our txn's read timestamp is less than the most recent
 			// version's timestamp and the scanner has been configured to
 			// throw a write too old error on equal or more recent versions.
-			// Merge the current timestamp with the maximum timestamp we've
-			// seen so we know to return an error, but then keep scanning so
-			// that we can return the largest possible time.
+
+			if p.skipLocked {
+				if locked, ok := p.isKeyLockedByConflictingTxn(ctx, p.curRawKey); !ok {
+					return false
+				} else if locked {
+					// 4a. the scanner was configured to skip locked keys, and
+					// this key was locked, so we can advance past it without
+					// raising the write too old error.
+					return p.advanceKey()
+				}
+			}
+
+			// 4b. We need to raise a write too old error. Merge the current
+			// timestamp with the maximum timestamp we've seen so we know to
+			// return an error, but then keep scanning so that we can return
+			// the largest possible time.
 			p.mostRecentTS.Forward(p.curUnsafeKey.Timestamp)
 			if len(p.mostRecentKey) == 0 {
 				p.mostRecentKey = append(p.mostRecentKey, p.curUnsafeKey.Key...)
@@ -691,19 +723,28 @@ func (p *pebbleMVCCScanner) getAndAdvance(ctx context.Context) bool {
 			// p.intents is a pebble.Batch which grows its byte slice capacity in
 			// chunks to amortize allocations. The memMonitor is under-counting here
 			// by only accounting for the key and value bytes.
-			if p.err = p.memAccount.Grow(ctx, int64(len(p.curRawKey)+len(p.curRawValue))); p.err != nil {
-				p.err = errors.Wrapf(p.err, "scan with start key %s", p.start)
+			if !p.addCurIntent(ctx) {
 				return false
 			}
-			p.err = p.intents.Set(p.curRawKey, p.curRawValue, nil)
-			if p.err != nil {
-				return false
-			}
-
 			return p.seekVersion(ctx, prevTS, false)
 		}
 
-		// 10. The key contains an intent which was not written by our
+		if p.skipLocked {
+			// 10. The scanner has been configured with the skipLocked option. Ignore
+			// intents written by other transactions and seek to the next key.
+			// However, we return the intent separately if we have room; the caller
+			// may want to resolve it. Unlike below, this intent will not result in
+			// a WriteIntentError because MVCC{Scan,Get}Options.errOnIntents returns
+			// false when skipLocked in enabled.
+			if p.maxIntents == 0 || int64(p.intents.Count()) < p.maxIntents {
+				if !p.addCurIntent(ctx) {
+					return false
+				}
+			}
+			return p.advanceKey()
+		}
+
+		// 11. The key contains an intent which was not written by our
 		// transaction and either:
 		// - our read timestamp is equal to or newer than that of the
 		//   intent
@@ -714,16 +755,7 @@ func (p *pebbleMVCCScanner) getAndAdvance(ctx context.Context) bool {
 		// Note that this will trigger an error higher up the stack. We
 		// continue scanning so that we can return all of the intents
 		// in the scan range.
-		//
-		// p.intents is a pebble.Batch which grows its byte slice capacity in
-		// chunks to amortize allocations. The memMonitor is under-counting here
-		// by only accounting for the key and value bytes.
-		if p.err = p.memAccount.Grow(ctx, int64(len(p.curRawKey)+len(p.curRawValue))); p.err != nil {
-			p.err = errors.Wrapf(p.err, "scan with start key %s", p.start)
-			return false
-		}
-		p.err = p.intents.Set(p.curRawKey, p.curRawValue, nil)
-		if p.err != nil {
+		if !p.addCurIntent(ctx) {
 			return false
 		}
 		// Limit number of intents returned in write intent error.
@@ -736,14 +768,14 @@ func (p *pebbleMVCCScanner) getAndAdvance(ctx context.Context) bool {
 
 	if p.txnEpoch == p.meta.Txn.Epoch {
 		if p.txnSequence >= p.meta.Txn.Sequence && !enginepb.TxnSeqIsIgnored(p.meta.Txn.Sequence, p.txnIgnoredSeqNums) {
-			// 11. We're reading our own txn's intent at an equal or higher sequence.
+			// 12. We're reading our own txn's intent at an equal or higher sequence.
 			// Note that we read at the intent timestamp, not at our read timestamp
 			// as the intent timestamp may have been pushed forward by another
 			// transaction. Txn's always need to read their own writes.
 			return p.seekVersion(ctx, metaTS, false)
 		}
 
-		// 12. We're reading our own txn's intent at a lower sequence than is
+		// 13. We're reading our own txn's intent at a lower sequence than is
 		// currently present in the intent. This means the intent we're seeing
 		// was written at a higher sequence than the read and that there may or
 		// may not be earlier versions of the intent (with lower sequence
@@ -768,7 +800,7 @@ func (p *pebbleMVCCScanner) getAndAdvance(ctx context.Context) bool {
 			}
 			return p.addAndAdvance(ctx, p.curUnsafeKey.Key, p.keyBuf, p.curUnsafeValue.Value.RawBytes)
 		}
-		// 13. If no value in the intent history has a sequence number equal to
+		// 14. If no value in the intent history has a sequence number equal to
 		// or less than the read, we must ignore the intents laid down by the
 		// transaction all together. We ignore the intent by insisting that the
 		// timestamp we're reading at is a historical timestamp < the intent
@@ -777,7 +809,7 @@ func (p *pebbleMVCCScanner) getAndAdvance(ctx context.Context) bool {
 	}
 
 	if p.txnEpoch < p.meta.Txn.Epoch {
-		// 14. We're reading our own txn's intent but the current txn has
+		// 15. We're reading our own txn's intent but the current txn has
 		// an earlier epoch than the intent. Return an error so that the
 		// earlier incarnation of our transaction aborts (presumably
 		// this is some operation that was retried).
@@ -786,7 +818,7 @@ func (p *pebbleMVCCScanner) getAndAdvance(ctx context.Context) bool {
 		return false
 	}
 
-	// 15. We're reading our own txn's intent but the current txn has a
+	// 16. We're reading our own txn's intent but the current txn has a
 	// later epoch than the intent. This can happen if the txn was
 	// restarted and an earlier iteration wrote the value we're now
 	// reading. In this case, we ignore the intent and read the
@@ -924,6 +956,19 @@ func (p *pebbleMVCCScanner) addAndAdvance(
 	// to include tombstones in the results.
 	if len(rawValue) == 0 && !p.tombstones {
 		return p.advanceKey()
+	}
+
+	// If the scanner has been configured with the skipLocked option, don't
+	// include locked keys in the result set. Consult the in-memory lock table to
+	// determine whether this is locked with an unreplicated lock. Replicated
+	// locks will be represented as intents, which will be skipped over in
+	// getAndAdvance.
+	if p.skipLocked {
+		if locked, ok := p.isKeyLockedByConflictingTxn(ctx, rawKey); !ok {
+			return false
+		} else if locked {
+			return p.advanceKey()
+		}
 	}
 
 	// Check if adding the key would exceed a limit.
@@ -1267,6 +1312,70 @@ func (p *pebbleMVCCScanner) clearPeeked() {
 	if p.reverse {
 		p.peeked = false
 	}
+}
+
+// isKeyLockedByConflictingTxn consults the in-memory lock table to determine
+// whether the provided key is locked with an unreplicated lock by a different
+// txn. When p.skipLocked, this method should be called before adding a key to
+// the scan's result set or throwing a write too old error on behalf of a key.
+// If the key is locked, skipLocked instructs the scan to skip over it instead.
+func (p *pebbleMVCCScanner) isKeyLockedByConflictingTxn(
+	ctx context.Context, rawKey []byte,
+) (locked, ok bool) {
+	key, _, err := enginepb.DecodeKey(rawKey)
+	if err != nil {
+		p.err = err
+		return false, false
+	}
+	strength := lock.None
+	if p.failOnMoreRecent {
+		strength = lock.Exclusive
+	}
+	if ok, txn := p.lockTable.IsKeyLockedByConflictingTxn(key, strength); ok {
+		// The key is locked, so ignore it. However, we return the lock holder
+		// separately if we have room; the caller may want to resolve it.
+		if p.maxIntents == 0 || int64(p.intents.Count()) < p.maxIntents {
+			if !p.addKeyAndMetaAsIntent(ctx, key, txn) {
+				return false, false
+			}
+		}
+		return true, true
+	}
+	return false, true
+}
+
+// addCurIntent adds the key-value pair that the scanner is currently
+// pointing to as an intent to the intents set.
+func (p *pebbleMVCCScanner) addCurIntent(ctx context.Context) bool {
+	return p.addRawIntent(ctx, p.curRawKey, p.curRawValue)
+}
+
+// addKeyAndMetaAsIntent adds the key and transaction meta as an intent to
+// the intents set.
+func (p *pebbleMVCCScanner) addKeyAndMetaAsIntent(
+	ctx context.Context, key roachpb.Key, txn *enginepb.TxnMeta,
+) bool {
+	mvccKey := MakeMVCCMetadataKey(key)
+	mvccVal := enginepb.MVCCMetadata{Txn: txn}
+	encodedKey := EncodeMVCCKey(mvccKey)
+	encodedVal, err := protoutil.Marshal(&mvccVal)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	return p.addRawIntent(ctx, encodedKey, encodedVal)
+}
+
+func (p *pebbleMVCCScanner) addRawIntent(ctx context.Context, key, value []byte) bool {
+	// p.intents is a pebble.Batch which grows its byte slice capacity in
+	// chunks to amortize allocations. The memMonitor is under-counting here
+	// by only accounting for the key and value bytes.
+	if p.err = p.memAccount.Grow(ctx, int64(len(key)+len(value))); p.err != nil {
+		p.err = errors.Wrapf(p.err, "scan with start key %s", p.start)
+		return false
+	}
+	p.err = p.intents.Set(key, value, nil)
+	return p.err == nil
 }
 
 func (p *pebbleMVCCScanner) intentsRepr() []byte {

--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -661,49 +661,48 @@ func (p *pebbleMVCCScanner) getAndAdvance(ctx context.Context) bool {
 	}
 
 	ownIntent := p.txn != nil && p.meta.Txn.ID.Equal(p.txn.ID)
-	conflictingIntent := metaTS.LessEq(p.ts) || p.failOnMoreRecent
-
-	if !ownIntent && !conflictingIntent {
-		// 8. The key contains an intent, but we're reading below the intent.
-		// Seek to the desired version, checking for uncertainty if necessary.
-		//
-		// Note that if we own the intent (i.e. we're reading transactionally)
-		// we want to read the intent regardless of our read timestamp and fall
-		// into case 11 below.
-		if p.checkUncertainty {
-			// The intent's provisional value may be within the uncertainty window. Or
-			// there could be a different, uncertain committed value in the window. To
-			// detect either case, seek to and past the uncertainty interval's global
-			// limit and check uncertainty as we scan.
-			return p.seekVersion(ctx, p.uncertainty.GlobalLimit, true)
-		}
-		return p.seekVersion(ctx, p.ts, false)
-	}
-
-	if p.inconsistent {
-		// 9. The key contains an intent and we're doing an inconsistent
-		// read at a timestamp newer than the intent. We ignore the
-		// intent by insisting that the timestamp we're reading at is a
-		// historical timestamp < the intent timestamp. However, we
-		// return the intent separately; the caller may want to resolve
-		// it.
-		//
-		// p.intents is a pebble.Batch which grows its byte slice capacity in
-		// chunks to amortize allocations. The memMonitor is under-counting here
-		// by only accounting for the key and value bytes.
-		if p.err = p.memAccount.Grow(ctx, int64(len(p.curRawKey)+len(p.curRawValue))); p.err != nil {
-			p.err = errors.Wrapf(p.err, "scan with start key %s", p.start)
-			return false
-		}
-		p.err = p.intents.Set(p.curRawKey, p.curRawValue, nil)
-		if p.err != nil {
-			return false
-		}
-
-		return p.seekVersion(ctx, prevTS, false)
-	}
-
 	if !ownIntent {
+		conflictingIntent := metaTS.LessEq(p.ts) || p.failOnMoreRecent
+		if !conflictingIntent {
+			// 8. The key contains an intent, but we're reading below the intent.
+			// Seek to the desired version, checking for uncertainty if necessary.
+			//
+			// Note that if we own the intent (i.e. we're reading transactionally)
+			// we want to read the intent regardless of our read timestamp and fall
+			// into case 11 below.
+			if p.checkUncertainty {
+				// The intent's provisional value may be within the uncertainty window.
+				// Or there could be a different, uncertain committed value in the
+				// window. To detect either case, seek to and past the uncertainty
+				// interval's global limit and check uncertainty as we scan.
+				return p.seekVersion(ctx, p.uncertainty.GlobalLimit, true)
+			}
+			return p.seekVersion(ctx, p.ts, false)
+		}
+
+		if p.inconsistent {
+			// 9. The key contains an intent and we're doing an inconsistent
+			// read at a timestamp newer than the intent. We ignore the
+			// intent by insisting that the timestamp we're reading at is a
+			// historical timestamp < the intent timestamp. However, we
+			// return the intent separately; the caller may want to resolve
+			// it.
+			//
+			// p.intents is a pebble.Batch which grows its byte slice capacity in
+			// chunks to amortize allocations. The memMonitor is under-counting here
+			// by only accounting for the key and value bytes.
+			if p.err = p.memAccount.Grow(ctx, int64(len(p.curRawKey)+len(p.curRawValue))); p.err != nil {
+				p.err = errors.Wrapf(p.err, "scan with start key %s", p.start)
+				return false
+			}
+			p.err = p.intents.Set(p.curRawKey, p.curRawValue, nil)
+			if p.err != nil {
+				return false
+			}
+
+			return p.seekVersion(ctx, prevTS, false)
+		}
+
 		// 10. The key contains an intent which was not written by our
 		// transaction and either:
 		// - our read timestamp is equal to or newer than that of the

--- a/pkg/storage/testdata/mvcc_histories/skip_locked
+++ b/pkg/storage/testdata/mvcc_histories/skip_locked
@@ -1,0 +1,1195 @@
+## Test opts.SkipLocked.
+
+# Setup:
+#
+# k1: value   @ ts 11
+# k2: value   @ ts 12
+# k2: intent  @ ts 13
+# k3: intent  @ ts 14
+# k4: value   @ ts 15
+# k4: lock    @ ts 16
+# k5: value   @ ts 17
+#
+
+run ok
+txn_begin t=A ts=12,0
+txn_begin t=B ts=13,0
+txn_begin t=C ts=14,0
+txn_begin t=D ts=15,0
+txn_begin t=E ts=16,0
+----
+>> at end:
+txn: "E" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=16.000000000,0 wto=false gul=0,0
+
+run ok
+put k=k1 v=v1 ts=11,0
+put k=k2 v=v2 ts=12,0
+put k=k2 v=v3 ts=13,0 t=B
+put k=k3 v=v4 ts=14,0 t=C
+put k=k4 v=v5 ts=15,0
+put k=k5 v=v6 ts=17,0
+add_lock k=k4 t=E
+----
+>> at end:
+data: "k1"/11.000000000,0 -> /BYTES/v1
+meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0} ts=13.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k2"/13.000000000,0 -> /BYTES/v3
+data: "k2"/12.000000000,0 -> /BYTES/v2
+meta: "k3"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0} ts=14.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k3"/14.000000000,0 -> /BYTES/v4
+data: "k4"/15.000000000,0 -> /BYTES/v5
+data: "k5"/17.000000000,0 -> /BYTES/v6
+lock-table: {k4:00000000-0000-0000-0000-000000000005}
+
+# Test cases:
+#
+# for failOnMoreRecent in (true, false):
+#   for ts in (10, 11, 12, 13, 14, 15, 16, 17, 18):
+#     for txn in (nil, A, B, C, D, E):
+#       if txn != nil && txn.read_ts != ts: continue
+#       for op in (get, scan, revscan):
+#         testCase()
+#
+
+run ok
+get ts=10 k=k1 skipLocked
+----
+get: "k1" -> <no data>
+
+run ok
+get ts=10 k=k2 skipLocked
+----
+get: "k2" -> <no data>
+
+run ok
+get ts=10 k=k3 skipLocked
+----
+get: "k3" -> <no data>
+
+run ok
+get ts=10 k=k4 skipLocked
+----
+get: "k4" -> <no data>
+
+run ok
+get ts=10 k=k5 skipLocked
+----
+get: "k5" -> <no data>
+
+run ok
+scan ts=10 k=k1 end=k6 skipLocked
+----
+scan: "k1"-"k6" -> <no data>
+
+run ok
+scan ts=10 k=k1 end=k6 reverse skipLocked
+----
+scan: "k1"-"k6" -> <no data>
+
+run ok
+get ts=11 k=k1 skipLocked
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=11 k=k2 skipLocked
+----
+get: "k2" -> <no data>
+
+run ok
+get ts=11 k=k3 skipLocked
+----
+get: "k3" -> <no data>
+
+run ok
+get ts=11 k=k4 skipLocked
+----
+get: "k4" -> <no data>
+
+run ok
+get ts=11 k=k5 skipLocked
+----
+get: "k5" -> <no data>
+
+run ok
+scan ts=11 k=k1 end=k6 skipLocked
+----
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+scan ts=11 k=k1 end=k6 reverse skipLocked
+----
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=12 k=k1 skipLocked
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=12 k=k2 skipLocked
+----
+get: "k2" -> /BYTES/v2 @12.000000000,0
+
+run ok
+get ts=12 k=k3 skipLocked
+----
+get: "k3" -> <no data>
+
+run ok
+get ts=12 k=k4 skipLocked
+----
+get: "k4" -> <no data>
+
+run ok
+get ts=12 k=k5 skipLocked
+----
+get: "k5" -> <no data>
+
+run ok
+scan ts=12 k=k1 end=k6 skipLocked
+----
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+scan: "k2" -> /BYTES/v2 @12.000000000,0
+
+run ok
+scan ts=12 k=k1 end=k6 reverse skipLocked
+----
+scan: "k2" -> /BYTES/v2 @12.000000000,0
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=12 t=A k=k1 skipLocked
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=12 t=A k=k2 skipLocked
+----
+get: "k2" -> /BYTES/v2 @12.000000000,0
+
+run ok
+get ts=12 t=A k=k3 skipLocked
+----
+get: "k3" -> <no data>
+
+run ok
+get ts=12 t=A k=k4 skipLocked
+----
+get: "k4" -> <no data>
+
+run ok
+get ts=12 t=A k=k5 skipLocked
+----
+get: "k5" -> <no data>
+
+run ok
+scan ts=12 t=A k=k1 end=k6 skipLocked
+----
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+scan: "k2" -> /BYTES/v2 @12.000000000,0
+
+run ok
+scan ts=12 t=A k=k1 end=k6 reverse skipLocked
+----
+scan: "k2" -> /BYTES/v2 @12.000000000,0
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=13 k=k1 skipLocked
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=13 k=k2 skipLocked
+----
+get: "k2" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=13 k=k3 skipLocked
+----
+get: "k3" -> <no data>
+
+run ok
+get ts=13 k=k4 skipLocked
+----
+get: "k4" -> <no data>
+
+run ok
+get ts=13 k=k5 skipLocked
+----
+get: "k5" -> <no data>
+
+run ok
+scan ts=13 k=k1 end=k6 skipLocked
+----
+scan: intent "k2" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+scan ts=13 k=k1 end=k6 reverse skipLocked
+----
+scan: intent "k2" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=13 t=B k=k1 skipLocked
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=13 t=B k=k2 skipLocked
+----
+get: "k2" -> /BYTES/v3 @13.000000000,0
+
+run ok
+get ts=13 t=B k=k3 skipLocked
+----
+get: "k3" -> <no data>
+
+run ok
+get ts=13 t=B k=k4 skipLocked
+----
+get: "k4" -> <no data>
+
+run ok
+get ts=13 t=B k=k5 skipLocked
+----
+get: "k5" -> <no data>
+
+run ok
+scan ts=13 t=B k=k1 end=k6 skipLocked
+----
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+scan: "k2" -> /BYTES/v3 @13.000000000,0
+
+run ok
+scan ts=13 t=B k=k1 end=k6 reverse skipLocked
+----
+scan: "k2" -> /BYTES/v3 @13.000000000,0
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=14 k=k1 skipLocked
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=14 k=k2 skipLocked
+----
+get: "k2" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=14 k=k3 skipLocked
+----
+get: "k3" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=14 k=k4 skipLocked
+----
+get: "k4" -> <no data>
+
+run ok
+get ts=14 k=k5 skipLocked
+----
+get: "k5" -> <no data>
+
+run ok
+scan ts=14 k=k1 end=k6 skipLocked
+----
+scan: intent "k2" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: intent "k3" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+scan ts=14 k=k1 end=k6 reverse skipLocked
+----
+scan: intent "k3" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+scan: intent "k2" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=14 t=C k=k1 skipLocked
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=14 t=C k=k2 skipLocked
+----
+get: "k2" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=14 t=C k=k3 skipLocked
+----
+get: "k3" -> /BYTES/v4 @14.000000000,0
+
+run ok
+get ts=14 t=C k=k4 skipLocked
+----
+get: "k4" -> <no data>
+
+run ok
+get ts=14 t=C k=k5 skipLocked
+----
+get: "k5" -> <no data>
+
+run ok
+scan ts=14 t=C k=k1 end=k6 skipLocked
+----
+scan: intent "k2" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+scan: "k3" -> /BYTES/v4 @14.000000000,0
+
+run ok
+scan ts=14 t=C k=k1 end=k6 reverse skipLocked
+----
+scan: intent "k2" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: "k3" -> /BYTES/v4 @14.000000000,0
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=15 k=k1 skipLocked
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=15 k=k2 skipLocked
+----
+get: "k2" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=15 k=k3 skipLocked
+----
+get: "k3" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=15 k=k4 skipLocked
+----
+get: "k4" -> /BYTES/v5 @15.000000000,0
+
+run ok
+get ts=15 k=k5 skipLocked
+----
+get: "k5" -> <no data>
+
+run ok
+scan ts=15 k=k1 end=k6 skipLocked
+----
+scan: intent "k2" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: intent "k3" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+scan: "k4" -> /BYTES/v5 @15.000000000,0
+
+run ok
+scan ts=15 k=k1 end=k6 reverse skipLocked
+----
+scan: intent "k3" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+scan: intent "k2" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: "k4" -> /BYTES/v5 @15.000000000,0
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=15 t=D k=k1 skipLocked
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=15 t=D k=k2 skipLocked
+----
+get: "k2" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=15 t=D k=k3 skipLocked
+----
+get: "k3" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=15 t=D k=k4 skipLocked
+----
+get: "k4" -> /BYTES/v5 @15.000000000,0
+
+run ok
+get ts=15 t=D k=k5 skipLocked
+----
+get: "k5" -> <no data>
+
+run ok
+scan ts=15 t=D k=k1 end=k6 skipLocked
+----
+scan: intent "k2" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: intent "k3" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+scan: "k4" -> /BYTES/v5 @15.000000000,0
+
+run ok
+scan ts=15 t=D k=k1 end=k6 reverse skipLocked
+----
+scan: intent "k3" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+scan: intent "k2" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: "k4" -> /BYTES/v5 @15.000000000,0
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=16 k=k1 skipLocked
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=16 k=k2 skipLocked
+----
+get: "k2" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=16 k=k3 skipLocked
+----
+get: "k3" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=16 k=k4 skipLocked
+----
+get: "k4" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run ok
+get ts=16 k=k5 skipLocked
+----
+get: "k5" -> <no data>
+
+run ok
+scan ts=16 k=k1 end=k6 skipLocked
+----
+scan: intent "k2" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: intent "k3" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+scan: intent "k4" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+scan ts=16 k=k1 end=k6 reverse skipLocked
+----
+scan: intent "k4" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+scan: intent "k3" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+scan: intent "k2" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=16 t=E k=k1 skipLocked
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=16 t=E k=k2 skipLocked
+----
+get: "k2" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=16 t=E k=k3 skipLocked
+----
+get: "k3" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=16 t=E k=k4 skipLocked
+----
+get: "k4" -> /BYTES/v5 @15.000000000,0
+
+run ok
+get ts=16 t=E k=k5 skipLocked
+----
+get: "k5" -> <no data>
+
+run ok
+scan ts=16 t=E k=k1 end=k6 skipLocked
+----
+scan: intent "k2" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: intent "k3" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+scan: "k4" -> /BYTES/v5 @15.000000000,0
+
+run ok
+scan ts=16 t=E k=k1 end=k6 reverse skipLocked
+----
+scan: intent "k3" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+scan: intent "k2" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: "k4" -> /BYTES/v5 @15.000000000,0
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=17 k=k1 skipLocked
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=17 k=k2 skipLocked
+----
+get: "k2" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=17 k=k3 skipLocked
+----
+get: "k3" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=17 k=k4 skipLocked
+----
+get: "k4" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run ok
+get ts=17 k=k5 skipLocked
+----
+get: "k5" -> /BYTES/v6 @17.000000000,0
+
+run ok
+scan ts=17 k=k1 end=k6 skipLocked
+----
+scan: intent "k2" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: intent "k3" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+scan: intent "k4" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+scan: "k5" -> /BYTES/v6 @17.000000000,0
+
+run ok
+scan ts=17 k=k1 end=k6 reverse skipLocked
+----
+scan: intent "k4" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+scan: intent "k3" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+scan: intent "k2" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: "k5" -> /BYTES/v6 @17.000000000,0
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=18 k=k1 skipLocked
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=18 k=k2 skipLocked
+----
+get: "k2" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=18 k=k3 skipLocked
+----
+get: "k3" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=18 k=k4 skipLocked
+----
+get: "k4" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run ok
+get ts=18 k=k5 skipLocked
+----
+get: "k5" -> /BYTES/v6 @17.000000000,0
+
+run ok
+scan ts=18 k=k1 end=k6 skipLocked
+----
+scan: intent "k2" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: intent "k3" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+scan: intent "k4" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+scan: "k5" -> /BYTES/v6 @17.000000000,0
+
+run ok
+scan ts=18 k=k1 end=k6 reverse skipLocked
+----
+scan: intent "k4" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+scan: intent "k3" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+scan: intent "k2" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: "k5" -> /BYTES/v6 @17.000000000,0
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+
+run error
+get ts=10 k=k1 skipLocked failOnMoreRecent
+----
+get: "k1" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 10.000000000,0 too old; wrote at 11.000000000,1
+
+run ok
+get ts=10 k=k2 skipLocked failOnMoreRecent
+----
+get: "k2" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=10 k=k3 skipLocked failOnMoreRecent
+----
+get: "k3" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=10 k=k4 skipLocked failOnMoreRecent
+----
+get: "k4" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run error
+get ts=10 k=k5 skipLocked failOnMoreRecent
+----
+get: "k5" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 10.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+scan ts=10 k=k1 end=k6 skipLocked failOnMoreRecent
+----
+scan: "k1"-"k6" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 10.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+scan ts=10 k=k1 end=k6 reverse skipLocked failOnMoreRecent
+----
+scan: "k1"-"k6" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 10.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+get ts=11 k=k1 skipLocked failOnMoreRecent
+----
+get: "k1" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 11.000000000,0 too old; wrote at 11.000000000,1
+
+run ok
+get ts=11 k=k2 skipLocked failOnMoreRecent
+----
+get: "k2" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=11 k=k3 skipLocked failOnMoreRecent
+----
+get: "k3" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=11 k=k4 skipLocked failOnMoreRecent
+----
+get: "k4" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run error
+get ts=11 k=k5 skipLocked failOnMoreRecent
+----
+get: "k5" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 11.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+scan ts=11 k=k1 end=k6 skipLocked failOnMoreRecent
+----
+scan: "k1"-"k6" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 11.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+scan ts=11 k=k1 end=k6 reverse skipLocked failOnMoreRecent
+----
+scan: "k1"-"k6" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 11.000000000,0 too old; wrote at 17.000000000,1
+
+run ok
+get ts=12 k=k1 skipLocked failOnMoreRecent
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=12 k=k2 skipLocked failOnMoreRecent
+----
+get: "k2" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=12 k=k3 skipLocked failOnMoreRecent
+----
+get: "k3" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=12 k=k4 skipLocked failOnMoreRecent
+----
+get: "k4" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run error
+get ts=12 k=k5 skipLocked failOnMoreRecent
+----
+get: "k5" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+scan ts=12 k=k1 end=k6 skipLocked failOnMoreRecent
+----
+scan: "k1"-"k6" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+scan ts=12 k=k1 end=k6 reverse skipLocked failOnMoreRecent
+----
+scan: "k1"-"k6" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; wrote at 17.000000000,1
+
+run ok
+get ts=12 t=A k=k1 skipLocked failOnMoreRecent
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=12 t=A k=k2 skipLocked failOnMoreRecent
+----
+get: "k2" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=12 t=A k=k3 skipLocked failOnMoreRecent
+----
+get: "k3" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=12 t=A k=k4 skipLocked failOnMoreRecent
+----
+get: "k4" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run error
+get ts=12 t=A k=k5 skipLocked failOnMoreRecent
+----
+get: "k5" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+scan ts=12 t=A k=k1 end=k6 skipLocked failOnMoreRecent
+----
+scan: "k1"-"k6" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+scan ts=12 t=A k=k1 end=k6 reverse skipLocked failOnMoreRecent
+----
+scan: "k1"-"k6" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 12.000000000,0 too old; wrote at 17.000000000,1
+
+run ok
+get ts=13 k=k1 skipLocked failOnMoreRecent
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=13 k=k2 skipLocked failOnMoreRecent
+----
+get: "k2" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=13 k=k3 skipLocked failOnMoreRecent
+----
+get: "k3" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=13 k=k4 skipLocked failOnMoreRecent
+----
+get: "k4" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run error
+get ts=13 k=k5 skipLocked failOnMoreRecent
+----
+get: "k5" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+scan ts=13 k=k1 end=k6 skipLocked failOnMoreRecent
+----
+scan: "k1"-"k6" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+scan ts=13 k=k1 end=k6 reverse skipLocked failOnMoreRecent
+----
+scan: "k1"-"k6" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; wrote at 17.000000000,1
+
+run ok
+get ts=13 t=B k=k1 skipLocked failOnMoreRecent
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=13 t=B k=k2 skipLocked failOnMoreRecent
+----
+get: "k2" -> /BYTES/v3 @13.000000000,0
+
+run ok
+get ts=13 t=B k=k3 skipLocked failOnMoreRecent
+----
+get: "k3" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=13 t=B k=k4 skipLocked failOnMoreRecent
+----
+get: "k4" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run error
+get ts=13 t=B k=k5 skipLocked failOnMoreRecent
+----
+get: "k5" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+scan ts=13 t=B k=k1 end=k6 skipLocked failOnMoreRecent
+----
+scan: "k1"-"k6" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+scan ts=13 t=B k=k1 end=k6 reverse skipLocked failOnMoreRecent
+----
+scan: "k1"-"k6" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 13.000000000,0 too old; wrote at 17.000000000,1
+
+run ok
+get ts=14 k=k1 skipLocked failOnMoreRecent
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=14 k=k2 skipLocked failOnMoreRecent
+----
+get: "k2" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=14 k=k3 skipLocked failOnMoreRecent
+----
+get: "k3" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=14 k=k4 skipLocked failOnMoreRecent
+----
+get: "k4" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run error
+get ts=14 k=k5 skipLocked failOnMoreRecent
+----
+get: "k5" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+scan ts=14 k=k1 end=k6 skipLocked failOnMoreRecent
+----
+scan: "k1"-"k6" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+scan ts=14 k=k1 end=k6 reverse skipLocked failOnMoreRecent
+----
+scan: "k1"-"k6" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; wrote at 17.000000000,1
+
+run ok
+get ts=14 t=C k=k1 skipLocked failOnMoreRecent
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=14 t=C k=k2 skipLocked failOnMoreRecent
+----
+get: "k2" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=14 t=C k=k3 skipLocked failOnMoreRecent
+----
+get: "k3" -> /BYTES/v4 @14.000000000,0
+
+run ok
+get ts=14 t=C k=k4 skipLocked failOnMoreRecent
+----
+get: "k4" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run error
+get ts=14 t=C k=k5 skipLocked failOnMoreRecent
+----
+get: "k5" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+scan ts=14 t=C k=k1 end=k6 skipLocked failOnMoreRecent
+----
+scan: "k1"-"k6" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+scan ts=14 t=C k=k1 end=k6 reverse skipLocked failOnMoreRecent
+----
+scan: "k1"-"k6" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 14.000000000,0 too old; wrote at 17.000000000,1
+
+run ok
+get ts=15 k=k1 skipLocked failOnMoreRecent
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=15 k=k2 skipLocked failOnMoreRecent
+----
+get: "k2" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=15 k=k3 skipLocked failOnMoreRecent
+----
+get: "k3" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=15 k=k4 skipLocked failOnMoreRecent
+----
+get: "k4" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run error
+get ts=15 k=k5 skipLocked failOnMoreRecent
+----
+get: "k5" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+scan ts=15 k=k1 end=k6 skipLocked failOnMoreRecent
+----
+scan: "k1"-"k6" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+scan ts=15 k=k1 end=k6 reverse skipLocked failOnMoreRecent
+----
+scan: "k1"-"k6" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; wrote at 17.000000000,1
+
+run ok
+get ts=15 t=D k=k1 skipLocked failOnMoreRecent
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=15 t=D k=k2 skipLocked failOnMoreRecent
+----
+get: "k2" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=15 t=D k=k3 skipLocked failOnMoreRecent
+----
+get: "k3" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=15 t=D k=k4 skipLocked failOnMoreRecent
+----
+get: "k4" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run error
+get ts=15 t=D k=k5 skipLocked failOnMoreRecent
+----
+get: "k5" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+scan ts=15 t=D k=k1 end=k6 skipLocked failOnMoreRecent
+----
+scan: "k1"-"k6" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+scan ts=15 t=D k=k1 end=k6 reverse skipLocked failOnMoreRecent
+----
+scan: "k1"-"k6" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 15.000000000,0 too old; wrote at 17.000000000,1
+
+run ok
+get ts=16 k=k1 skipLocked failOnMoreRecent
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=16 k=k2 skipLocked failOnMoreRecent
+----
+get: "k2" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=16 k=k3 skipLocked failOnMoreRecent
+----
+get: "k3" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=16 k=k4 skipLocked failOnMoreRecent
+----
+get: "k4" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run error
+get ts=16 k=k5 skipLocked failOnMoreRecent
+----
+get: "k5" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+scan ts=16 k=k1 end=k6 skipLocked failOnMoreRecent
+----
+scan: "k1"-"k6" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+scan ts=16 k=k1 end=k6 reverse skipLocked failOnMoreRecent
+----
+scan: "k1"-"k6" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; wrote at 17.000000000,1
+
+run ok
+get ts=16 t=E k=k1 skipLocked failOnMoreRecent
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=16 t=E k=k2 skipLocked failOnMoreRecent
+----
+get: "k2" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=16 t=E k=k3 skipLocked failOnMoreRecent
+----
+get: "k3" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=16 t=E k=k4 skipLocked failOnMoreRecent
+----
+get: "k4" -> /BYTES/v5 @15.000000000,0
+
+run error
+get ts=16 t=E k=k5 skipLocked failOnMoreRecent
+----
+get: "k5" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+scan ts=16 t=E k=k1 end=k6 skipLocked failOnMoreRecent
+----
+scan: "k1"-"k6" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+scan ts=16 t=E k=k1 end=k6 reverse skipLocked failOnMoreRecent
+----
+scan: "k1"-"k6" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 16.000000000,0 too old; wrote at 17.000000000,1
+
+run ok
+get ts=17 k=k1 skipLocked failOnMoreRecent
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=17 k=k2 skipLocked failOnMoreRecent
+----
+get: "k2" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=17 k=k3 skipLocked failOnMoreRecent
+----
+get: "k3" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=17 k=k4 skipLocked failOnMoreRecent
+----
+get: "k4" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run error
+get ts=17 k=k5 skipLocked failOnMoreRecent
+----
+get: "k5" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 17.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+scan ts=17 k=k1 end=k6 skipLocked failOnMoreRecent
+----
+scan: "k1"-"k6" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 17.000000000,0 too old; wrote at 17.000000000,1
+
+run error
+scan ts=17 k=k1 end=k6 reverse skipLocked failOnMoreRecent
+----
+scan: "k1"-"k6" -> <no data>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k5" at timestamp 17.000000000,0 too old; wrote at 17.000000000,1
+
+run ok
+get ts=18 k=k1 skipLocked failOnMoreRecent
+----
+get: "k1" -> /BYTES/v1 @11.000000000,0
+
+run ok
+get ts=18 k=k2 skipLocked failOnMoreRecent
+----
+get: "k2" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+get: "k2" -> <no data>
+
+run ok
+get ts=18 k=k3 skipLocked failOnMoreRecent
+----
+get: "k3" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+get: "k3" -> <no data>
+
+run ok
+get ts=18 k=k4 skipLocked failOnMoreRecent
+----
+get: "k4" -> intent {id=00000000 key=/Min pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+get: "k4" -> <no data>
+
+run ok
+get ts=18 k=k5 skipLocked failOnMoreRecent
+----
+get: "k5" -> /BYTES/v6 @17.000000000,0
+
+run ok
+scan ts=18 k=k1 end=k6 skipLocked failOnMoreRecent
+----
+scan: intent "k2" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: intent "k3" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+scan: intent "k4" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+scan: "k1" -> /BYTES/v1 @11.000000000,0
+scan: "k5" -> /BYTES/v6 @17.000000000,0
+
+run ok
+scan ts=18 k=k1 end=k6 reverse skipLocked failOnMoreRecent
+----
+scan: intent "k4" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0}
+scan: intent "k3" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0}
+scan: intent "k2" {id=00000000 key=/Min pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0}
+scan: "k5" -> /BYTES/v6 @17.000000000,0
+scan: "k1" -> /BYTES/v1 @11.000000000,0


### PR DESCRIPTION
KV portion of #40476.
Assists #62734.
Assists #72407.
Assists #78564.

**NOTE: the SQL changes here were extracted from this PR and moved to https://github.com/cockroachdb/cockroach/pull/83627. This allows us to land the KV portion of this change without exposing it yet.**

```sql
CREATE TABLE kv (k INT PRIMARY KEY, v INT)
INSERT INTO kv VALUES (1, 1), (2, 2), (3, 3)


-- in session 1
BEGIN; UPDATE kv SET v = 0 WHERE k = 1 RETURNING *

  k | v
----+----
  1 | 0


-- in session 2
BEGIN; SELECT * FROM kv ORDER BY k LIMIT 1 FOR UPDATE SKIP LOCKED

  k | v
----+----
  2 | 2


-- in session 3
BEGIN; SELECT * FROM kv FOR UPDATE SKIP LOCKED

  k | v
----+----
  3 | 3
```

These semantics closely match those of FOR {UPDATE,SHARE} SKIP LOCKED in PostgreSQL. With SKIP LOCKED, any selected rows that cannot be immediately locked are skipped. Skipping locked rows provides an inconsistent view of the data, so this is not suitable for general purpose work, but can be used to avoid lock contention with multiple consumers accessing a queue-like table.

[Here](https://www.pgcasts.com/episodes/the-skip-locked-feature-in-postgres-9-5) is a short video that explains why users might want to use SKIP LOCKED in Postgres. The same motivation applies to CockroachDB. However, SKIP LOCKED is not a complete solution to queues, as MVCC garbage will still become a major problem with sufficiently high consumer throughput. Even with a very low gc.ttl, CockroachDB does not garbage collect MVCC garbage fast enough to avoid slowing down consumers that scan from the head of a queue over MVCC tombstones of previously consumed queue entries.

----

### Implementation

Skip locked has a number of touchpoints in Storage and KV. To understand these, we first need to understand the isolation model of skip-locked. When a request is using a SkipLocked wait policy, it behaves as if run at a weaker isolation level for any keys that it skips over. If the read request does not return a key, it does not make a claim about whether that key does or does not exist or what the key's value was at the read's MVCC timestamp. Instead, it only makes a claim about the set of keys that are returned. For those keys which were not skipped and were returned (and often locked, if combined with a locking strength, though this is not required), serializable isolation is enforced.

When the `pebbleMVCCScanner` is configured with the skipLocked option, it does not include locked keys in the result set. To support this, the MVCC layer needs to be provided access to the in-memory lock table, so that it can determine whether keys are locked with unreplicated lock. Replicated locks are represented as intents, which will be skipped over in getAndAdvance.

Requests using the SkipLocked wait policy acquire the same latches as before and wait on all latches ahead of them in line. However, if a request is using a SkipLocked wait policy, we always perform optimistic evaluation. In Replica.collectSpansRead, SkipLocked reads are able to constrain their read spans down to point reads on just those keys that were returned and were not already locked. This means that there is a good chance that some or all of the write latches that the SkipLocked read would have blocked on won't overlap with the keys that the request ends up returning, so they won't conflict when checking for optimistic conflicts.

Skip locked requests do not scan the lock table when initially sequencing. Instead, they capture a snapshot of the in-memory lock table while sequencing and scan the lock table as they perform their MVCC scan using the btree snapshot stored in the concurrency guard. MVCC was taught about skip locked in the previous commit.

Skip locked requests add point reads for each of the keys returned to the timestamp cache, instead of adding a single ranged read. This satisfies the weaker isolation level of skip locked. Because the issuing transaction is not intending to enforce serializable isolation across keys that were skipped by its request, it does not need to prevent writes below its read timestamp to keys that were skipped.

Similarly, Skip locked requests only records refresh spans for the individual keys returned, instead of recording a refresh span across the entire read span. Because the issuing transaction is not intending to enforce serializable isolation across keys that were skipped by its request, it does not need to validate that they have not changed if the transaction ever needs to refresh.

----

### Benchmarking

I haven't done any serious benchmarking with this SKIP LOCKED yet, though I'd like to. At some point, I would like to build a simple queue-like workload into the `workload` tool and experiment with various consumer access patterns (non-locking reads, locking reads, skip-locked reads), indexing schemes, concurrency levels (for producers and consumers), and batch sizes.