### PR TITLE
backupccl: Block incremental backups with mismatched localities.

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/mismatched-localities
+++ b/pkg/ccl/backupccl/testdata/backup-restore/mismatched-localities
@@ -1,0 +1,32 @@
+new-server name=s1 allow-implicit-access localities=us-east-1,us-west-1
+----
+
+exec-sql
+CREATE DATABASE d PRIMARY REGION "us-east-1" REGIONS "us-west-1";
+----
+
+exec-sql
+BACKUP INTO (
+  'nodelocal://1/default?COCKROACH_LOCALITY=default',
+  'nodelocal://1/database_backup?COCKROACH_LOCALITY=region%3Dus-west-1');
+----
+
+exec-sql
+BACKUP INTO LATEST IN (
+  'nodelocal://1/default?COCKROACH_LOCALITY=default',
+  'nodelocal://1/database_backup?COCKROACH_LOCALITY=region%3Dus-west-1',
+  'nodelocal://1/database_backup?COCKROACH_LOCALITY=region%3Dus-east-1');
+----
+pq: Requested backup has localities [region=us-west-1 region=us-east-1], but a previous backup layer in this collection has localities [region=us-west-1]. Mismatched backup layers are not supported. Please take a new full backup with the new localities, or an incremental backup with matching localities.
+
+exec-sql
+BACKUP INTO LATEST IN (
+  'nodelocal://1/default?COCKROACH_LOCALITY=default',
+  'nodelocal://1/database_backup?COCKROACH_LOCALITY=region%3Dus-east-1');
+----
+pq: Requested backup has localities [region=us-east-1], but a previous backup layer in this collection has localities [region=us-west-1]. Mismatched backup layers are not supported. Please take a new full backup with the new localities, or an incremental backup with matching localities.
+
+exec-sql
+BACKUP INTO LATEST IN  'nodelocal://1/default?COCKROACH_LOCALITY=default';
+----
+pq: Requested backup has localities [], but a previous backup layer in this collection has localities [region=us-west-1]. Mismatched backup layers are not supported. Please take a new full backup with the new localities, or an incremental backup with matching localities.


### PR DESCRIPTION
backupccl: Block incremental backups with mismatched localities

Release note (enterprise change): Block incremental backups with mismatched localities.