### PR TITLE
ui: ui improvements

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
@@ -134,6 +134,7 @@ export function makeExplainPlanColumns(
   handleDetails: (plan: PlanHashStats) => void,
 ): ColumnDescriptor<PlanHashStats>[] {
   const duration = (v: number) => Duration(v * 1e9);
+  const count = (v: number) => v.toFixed(1);
   return [
     {
       name: "planID",
@@ -170,8 +171,10 @@ export function makeExplainPlanColumns(
     {
       name: "avgRowsRead",
       title: planDetailsTableTitles.avgRowsRead(),
-      cell: (item: PlanHashStats) => longToInt(item.stats.rows_read.mean),
-      sort: (item: PlanHashStats) => longToInt(item.stats.rows_read.mean),
+      cell: (item: PlanHashStats) =>
+        formatNumberForDisplay(item.stats.rows_read.mean, count),
+      sort: (item: PlanHashStats) =>
+        formatNumberForDisplay(item.stats.rows_read.mean, count),
     },
     {
       name: "fullScan",

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -750,6 +750,15 @@ export class StatementDetails extends React.Component<
             </Col>
           </Row>
         </TabPane>
+        <TabPane tab="Explain Plans" key="explain-plan">
+          <Row gutter={24}>
+            <Col className="gutter-row" span={24}>
+              <SqlBox value={formatted_query} size={SqlBoxSize.small} />
+            </Col>
+          </Row>
+          <p className={summaryCardStylesCx("summary--card__divider")} />
+          <PlanDetails plans={statement_statistics_per_plan_hash} />
+        </TabPane>
         {!isTenant && !hasViewActivityRedactedRole && (
           <TabPane
             tab={`Diagnostics ${
@@ -772,15 +781,6 @@ export class StatementDetails extends React.Component<
             />
           </TabPane>
         )}
-        <TabPane tab="Explain Plan" key="explain-plan">
-          <Row gutter={24}>
-            <Col className="gutter-row" span={24}>
-              <SqlBox value={formatted_query} size={SqlBoxSize.small} />
-            </Col>
-          </Row>
-          <p className={summaryCardStylesCx("summary--card__divider")} />
-          <PlanDetails plans={statement_statistics_per_plan_hash} />
-        </TabPane>
         <TabPane
           tab="Execution Stats"
           key="execution-stats"

--- a/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/activateStatementDiagnosticsModal.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/activateStatementDiagnosticsModal.scss
@@ -12,17 +12,29 @@
     display: flex;
     flex-direction: column;
 
+    .ant-radio {
+      top: 0;
+    }
+
     /* Overriding radio button colors. */
     .ant-radio-checked .ant-radio-inner {
       border-color: $colors--primary-blue-3;
-    }
 
-    .ant-radio-checked .ant-radio-inner:after{
-      background-color: $colors--primary-blue-3;
+      &:after {
+        background-color: white;
+        top: 4px;
+        left: 4px;
+        margin-left: 0;
+        margin-top: 0;
+      }
     }
 
     .ant-radio:hover .ant-radio-inner {
       border-color: $colors--primary-blue-3;
+    }
+
+    .ant-checkbox-checked .ant-checkbox-inner {
+      background-color: $colors--primary-blue-3;
     }
   }
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/activateStatementDiagnosticsModal.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/activateStatementDiagnosticsModal.tsx
@@ -116,15 +116,13 @@ export const ActivateStatementDiagnosticsModal = React.forwardRef(
       >
         <Text>
           Diagnostics will be collected for the next execution that matches this{" "}
-          <Anchor href={statementsSql}>statement fingerprint</Anchor>, or
-          according to the latency threshold set below. The request is cancelled
-          when a single bundle is captured.{" "}
+          <Anchor href={statementsSql}>statement fingerprint</Anchor>, or when
+          the execution of the statement fingerprint exceeds a specified
+          latency. The request is cancelled when a single bundle is captured.{" "}
           <Anchor href={statementDiagnostics}>Learn more</Anchor>
         </Text>
         <div className={cx("diagnostic__options-container")}>
-          <Text className={cx("diagnostic__heading")}>
-            Collect Diagnostics:
-          </Text>
+          <Text className={cx("diagnostic__heading")}>Collect diagnostics</Text>
           <Radio.Group value={conditional}>
             <Button.Group className={cx("diagnostic__btn-group")}>
               <Radio
@@ -132,14 +130,14 @@ export const ActivateStatementDiagnosticsModal = React.forwardRef(
                 className={cx("diagnostic__radio-btn")}
                 onChange={() => setConditional(false)}
               >
-                On the next instance of the statement
+                On the next execution
               </Radio>
               <Radio
                 value={true}
                 className={cx("diagnostic__radio-btn")}
                 onChange={() => setConditional(true)}
               >
-                On the next instance of the statement that runs longer than:
+                On the next execution where the latency exceeds
                 <div className={cx("diagnostic__conditional-container")}>
                   <div className={cx("diagnostic__min-latency-container")}>
                     <Input

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementTypeSelect.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementTypeSelect.module.scss
@@ -48,6 +48,10 @@
   transform: scaleY(0);
 }
 
+:global(.ant-radio) {
+  top: 0;
+}
+
 :global(.ant-radio-checked .ant-radio-inner) {
   background-color: $colors--link;
   border-color: $colors--link;
@@ -59,4 +63,6 @@
   width: 6px;
   top: 4px;
   left: 4px;
+  margin-left: 0;
+  margin-top: 0;
 }


### PR DESCRIPTION
This commits makes ui improvements:
- Change order of tabs on Statement Details
and change Explain Plan to plural

Before
<img width="623" alt="Screen Shot 2022-03-31 at 11 45 56 AM" src="https://user-images.githubusercontent.com/1017486/161096229-d9fa1bb5-3ffc-4913-a96d-e1c8f1e2379b.png">


After
<img width="587" alt="Screen Shot 2022-03-31 at 10 07 51 AM" src="https://user-images.githubusercontent.com/1017486/161096000-aea6f7fb-3883-4b73-89dd-fe122f89813b.png">

- Use one decimal point on Plans Table
Before
<img width="269" alt="Screen Shot 2022-03-30 at 4 42 15 PM" src="https://user-images.githubusercontent.com/1017486/161095849-d753f0aa-c582-4276-b0aa-a254020f9419.png">

After
<img width="207" alt="Screen Shot 2022-03-30 at 6 28 00 PM" src="https://user-images.githubusercontent.com/1017486/161095872-4f7fccea-3270-4868-b145-52c4ddbb80bb.png">

- Update Text on Statement Diagnostics Modal
Before
<img width="555" alt="Screen Shot 2022-03-31 at 11 46 49 AM" src="https://user-images.githubusercontent.com/1017486/161096430-2f1d9336-6098-49ae-bfec-1d1c11657fef.png">


After
<img width="534" alt="Screen Shot 2022-03-31 at 3 48 48 PM" src="https://user-images.githubusercontent.com/1017486/161137169-0f5566a6-ed8b-4ce4-a217-a44708068d74.png">



- Fix radio button selection on Statement Diagnostic Modal
Before
<img width="142" alt="Screen Shot 2022-03-31 at 11 49 40 AM" src="https://user-images.githubusercontent.com/1017486/161097037-17f351ba-7470-4ac6-b4a0-0c1a85127a72.png">

After
<img width="87" alt="Screen Shot 2022-03-31 at 3 27 26 PM" src="https://user-images.githubusercontent.com/1017486/161134171-555b48ca-28aa-48de-99ff-348b29a30992.png">



Partially Adresses #77982
Fixes #78364
Fixes #78369

Release note (ui change): change Explain Plan tab on Statement Details to Explain Plans (plural) and change order of tabs on Statement Details to Overview, Explain Plan, Diagnostics and Execution Stats.