### PR TITLE
release-22.1: sql,jobs: merge only keys present at beginning of index backfill merge step

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -2659,6 +2659,26 @@ func (sc *SchemaChanger) distIndexMerge(
 	temporaryIndexes []descpb.IndexID,
 	fractionScaler *multiStageFractionScaler,
 ) error {
+	// We note the time at the start of the merge in order to limit the set of
+	// keys merged from the temporary index to what's already there as of
+	// mergeTimestamp. To identify the keys that should be merged, we perform a
+	// historical read on the temporary index as of mergeTimestamp. We then
+	// perform an additional read for the latest value for each key in order to
+	// get correct merged value.
+	//
+	// We do this because the temporary index is still accepting writes during the
+	// merge as we rely on it having the latest value or delete for every key. If
+	// we don't limit number of keys merged, then it is possible for the rate of
+	// new keys written to the temporary index to be faster than the rate at which
+	// merge.
+	//
+	// The mergeTimestamp is currently not persisted because if this job is ran as
+	// part of a restore, then timestamp will be too old and the job will fail. On
+	// the next resume, a mergeTimestamp newer than the GC time will be picked and
+	// the job can continue.
+	mergeTimestamp := sc.clock.Now()
+	log.Infof(ctx, "merging all keys in temporary index before time %v", mergeTimestamp)
+
 	// Gather the initial resume spans for the merge process.
 	progress, err := extractMergeProgress(sc.job, tableDesc, addedIndexes, temporaryIndexes)
 	if err != nil {
@@ -2708,7 +2728,7 @@ func (sc *SchemaChanger) distIndexMerge(
 	defer func() { _ = stop() }()
 
 	run, err := planner.plan(ctx, tableDesc, progress.TodoSpans, progress.AddedIndexes,
-		progress.TemporaryIndexes, metaFn)
+		progress.TemporaryIndexes, metaFn, mergeTimestamp)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/backfill/BUILD.bazel
+++ b/pkg/sql/backfill/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/sql/types",
         "//pkg/util",
         "//pkg/util/ctxgroup",
+        "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/mon",
         "//pkg/util/syncutil",

--- a/pkg/sql/backfill/mvcc_index_merger.go
+++ b/pkg/sql/backfill/mvcc_index_merger.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -56,6 +57,18 @@ var indexBackfillMergeBatchBytes = settings.RegisterIntSetting(
 	settings.NonNegativeInt,
 )
 
+// indexBackfillMergeNumWorkers is the number of parallel merges per node in the
+// cluster used for the merge step of the index backfill. It is currently
+// default to 4 as higher values didn't seem to improve the index build times in
+// the schemachange/index/tpcc/w=1000 roachtest.
+var indexBackfillMergeNumWorkers = settings.RegisterIntSetting(
+	settings.TenantWritable,
+	"bulkio.index_backfill.merge_num_workers",
+	"the number of parallel merges per node in the cluster",
+	4,
+	settings.PositiveInt,
+)
+
 // IndexBackfillMerger is a processor that merges entries from the corresponding
 // temporary index to a new index.
 type IndexBackfillMerger struct {
@@ -71,8 +84,8 @@ type IndexBackfillMerger struct {
 
 	output execinfra.RowReceiver
 
-	mon          *mon.BytesMonitor
-	boundAccount mon.BoundAccount
+	mon            *mon.BytesMonitor
+	muBoundAccount muBoundAccount
 }
 
 // OutputTypes is always nil.
@@ -102,17 +115,30 @@ func (ibm *IndexBackfillMerger) Run(ctx context.Context) {
 		completedSpanIdx []int32
 	}{}
 
-	progCh := make(chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress)
-	pushProgress := func() {
+	storeChunkProgress := func(chunk mergeChunk) {
 		mu.Lock()
-		var prog execinfrapb.RemoteProducerMetadata_BulkProcessorProgress
-		prog.CompletedSpans = append(prog.CompletedSpans, mu.completedSpans...)
-		mu.completedSpans = nil
-		prog.CompletedSpanIdx = append(prog.CompletedSpanIdx, mu.completedSpanIdx...)
-		mu.completedSpanIdx = nil
-		mu.Unlock()
+		defer mu.Unlock()
+		mu.completedSpans = append(mu.completedSpans, chunk.completedSpan)
+		mu.completedSpanIdx = append(mu.completedSpanIdx, chunk.spanIdx)
+	}
 
-		progCh <- prog
+	getStoredProgressForPush := func() execinfrapb.RemoteProducerMetadata_BulkProcessorProgress {
+		var prog execinfrapb.RemoteProducerMetadata_BulkProcessorProgress
+		mu.Lock()
+		defer mu.Unlock()
+
+		prog.CompletedSpans = append(prog.CompletedSpans, mu.completedSpans...)
+		prog.CompletedSpanIdx = append(prog.CompletedSpanIdx, mu.completedSpanIdx...)
+		mu.completedSpans, mu.completedSpanIdx = nil, nil
+		return prog
+	}
+
+	pushProgress := func() {
+		p := getStoredProgressForPush()
+		if p.CompletedSpans != nil {
+			log.VEventf(ctx, 2, "sending coordinator completed spans: %+v", p.CompletedSpans)
+		}
+		ibm.output.Push(nil, &execinfrapb.ProducerMetadata{BulkProcessorProgress: &p})
 	}
 
 	semaCtx := tree.MakeSemaContext()
@@ -121,109 +147,113 @@ func (ibm *IndexBackfillMerger) Run(ctx context.Context) {
 		return
 	}
 
-	// stopProgress will be closed when there is no more progress to report.
-	stopProgress := make(chan struct{})
+	numWorkers := int(indexBackfillMergeNumWorkers.Get(&ibm.evalCtx.Settings.SV))
+	mergeCh := make(chan mergeChunk)
+	mergeTimestamp := ibm.spec.MergeTimestamp
+
 	g := ctxgroup.WithContext(ctx)
-	g.GoCtx(func(ctx context.Context) error {
-		tick := time.NewTicker(indexBackfillMergeProgressReportInterval)
-		defer tick.Stop()
-		done := ctx.Done()
-		for {
-			select {
-			case <-done:
-				return ctx.Err()
-			case <-stopProgress:
-				return nil
-			case <-tick.C:
-				pushProgress()
+	runWorker := func(ctx context.Context) error {
+		for mergeChunk := range mergeCh {
+			err := ibm.merge(ctx, ibm.evalCtx.Codec, ibm.desc, ibm.spec.TemporaryIndexes[mergeChunk.spanIdx],
+				ibm.spec.AddedIndexes[mergeChunk.spanIdx], mergeChunk.keys, mergeChunk.completedSpan)
+			if err != nil {
+				return err
+			}
+
+			storeChunkProgress(mergeChunk)
+
+			// After the keys have been merged, we can free the memory used by the
+			// chunk.
+			mergeChunk.keys = nil
+			ibm.shrinkBoundAccount(ctx, mergeChunk.memUsed)
+
+			if knobs, ok := ibm.flowCtx.Cfg.TestingKnobs.IndexBackfillMergerTestingKnobs.(*IndexBackfillMergerTestingKnobs); ok {
+				if knobs != nil {
+					if knobs.PushesProgressEveryChunk {
+						pushProgress()
+					}
+
+					if knobs.RunAfterMergeChunk != nil {
+						knobs.RunAfterMergeChunk()
+					}
+				}
 			}
 		}
-	})
+		return nil
+	}
+
+	for worker := 0; worker < numWorkers; worker++ {
+		g.GoCtx(runWorker)
+	}
 
 	g.GoCtx(func(ctx context.Context) error {
-		defer close(stopProgress)
-		// TODO(rui): some room for improvement on single threaded
-		// implementation, e.g. run merge for spec spans in parallel.
+		defer close(mergeCh)
 		for i := range ibm.spec.Spans {
 			sp := ibm.spec.Spans[i]
 			idx := ibm.spec.SpanIdx[i]
 
 			key := sp.Key
 			for key != nil {
-				nextKey, err := ibm.Merge(ctx, ibm.evalCtx.Codec, ibm.desc, ibm.spec.TemporaryIndexes[idx], ibm.spec.AddedIndexes[idx],
-					key, sp.EndKey)
+				chunk, nextKey, err := ibm.scan(ctx, idx, key, sp.EndKey, mergeTimestamp)
 				if err != nil {
 					return err
 				}
-
-				completedSpan := roachpb.Span{}
-				if nextKey == nil {
-					completedSpan.Key = key
-					completedSpan.EndKey = sp.EndKey
-				} else {
-					completedSpan.Key = key
-					completedSpan.EndKey = nextKey
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case mergeCh <- chunk:
 				}
-
-				mu.Lock()
-				mu.completedSpans = append(mu.completedSpans, completedSpan)
-				mu.completedSpanIdx = append(mu.completedSpanIdx, idx)
-				mu.Unlock()
+				key = nextKey
 
 				if knobs, ok := ibm.flowCtx.Cfg.TestingKnobs.IndexBackfillMergerTestingKnobs.(*IndexBackfillMergerTestingKnobs); ok {
-					if knobs != nil && knobs.PushesProgressEveryChunk {
-						pushProgress()
+					if knobs != nil && knobs.RunAfterScanChunk != nil {
+						knobs.RunAfterScanChunk()
 					}
 				}
-
-				key = nextKey
 			}
 		}
 		return nil
 	})
 
+	workersDoneCh := make(chan error)
+	go func() { workersDoneCh <- g.Wait() }()
+
+	tick := time.NewTicker(indexBackfillMergeProgressReportInterval)
+	defer tick.Stop()
 	var err error
-	go func() {
-		defer close(progCh)
-		err = g.Wait()
-	}()
-
-	for prog := range progCh {
-		p := prog
-		if p.CompletedSpans != nil {
-			log.VEventf(ctx, 2, "sending coordinator completed spans: %+v", p.CompletedSpans)
+	for {
+		select {
+		case <-tick.C:
+			pushProgress()
+		case err = <-workersDoneCh:
+			if err != nil {
+				ibm.output.Push(nil, &execinfrapb.ProducerMetadata{Err: err})
+			}
+			return
 		}
-		ibm.output.Push(nil, &execinfrapb.ProducerMetadata{BulkProcessorProgress: &p})
-	}
-
-	if err != nil {
-		ibm.output.Push(nil, &execinfrapb.ProducerMetadata{Err: err})
 	}
 }
 
 var _ execinfra.Processor = &IndexBackfillMerger{}
 
-// Merge merges the entries from startKey to endKey from the index with sourceID
-// into the index with destinationID, up to a maximum of chunkSize entries.
-func (ibm *IndexBackfillMerger) Merge(
+type mergeChunk struct {
+	completedSpan roachpb.Span
+	keys          []roachpb.Key
+	spanIdx       int32
+	memUsed       int64
+}
+
+func (ibm *IndexBackfillMerger) scan(
 	ctx context.Context,
-	codec keys.SQLCodec,
-	table catalog.TableDescriptor,
-	sourceID descpb.IndexID,
-	destinationID descpb.IndexID,
+	spanIdx int32,
 	startKey roachpb.Key,
 	endKey roachpb.Key,
-) (roachpb.Key, error) {
-	sourcePrefix := rowenc.MakeIndexKeyPrefix(codec, table.GetID(), sourceID)
-	prefixLen := len(sourcePrefix)
-	destPrefix := rowenc.MakeIndexKeyPrefix(codec, table.GetID(), destinationID)
-
-	destKey := make([]byte, len(destPrefix))
-
+	readAsOf hlc.Timestamp,
+) (mergeChunk, roachpb.Key, error) {
 	if knobs, ok := ibm.flowCtx.Cfg.TestingKnobs.IndexBackfillMergerTestingKnobs.(*IndexBackfillMergerTestingKnobs); ok {
-		if knobs != nil && knobs.RunBeforeMergeChunk != nil {
-			if err := knobs.RunBeforeMergeChunk(startKey); err != nil {
-				return nil, err
+		if knobs != nil && knobs.RunBeforeScanChunk != nil {
+			if err := knobs.RunBeforeScanChunk(startKey); err != nil {
+				return mergeChunk{}, nil, err
 			}
 		}
 	}
@@ -231,15 +261,19 @@ func (ibm *IndexBackfillMerger) Merge(
 	chunkBytes := indexBackfillMergeBatchBytes.Get(&ibm.evalCtx.Settings.SV)
 
 	var nextStart roachpb.Key
-	err := ibm.flowCtx.Cfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+	var br *roachpb.BatchResponse
+	if err := ibm.flowCtx.Cfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		if err := txn.SetFixedTimestamp(ctx, readAsOf); err != nil {
+			return err
+		}
 		// For now just grab all of the destination KVs and merge the corresponding entries.
-		log.VInfof(ctx, 2, "merging batch [%s, %s) into index %d", startKey, endKey, destinationID)
+		log.VInfof(ctx, 2, "scanning batch [%s, %s) at %v to merge", startKey, endKey, readAsOf)
 		var ba roachpb.BatchRequest
 		ba.TargetBytes = chunkBytes
-		if err := ibm.boundAccount.Grow(ctx, chunkBytes); err != nil {
-			return errors.Errorf("failed to fetch keys to merge from temp index")
+		if err := ibm.growBoundAccount(ctx, chunkBytes); err != nil {
+			return errors.Wrap(err, "failed to fetch keys to merge from temp index")
 		}
-		defer ibm.boundAccount.Shrink(ctx, chunkBytes)
+		defer ibm.shrinkBoundAccount(ctx, chunkBytes)
 
 		ba.MaxSpanRequestKeys = chunkSize
 		ba.Add(&roachpb.ScanRequest{
@@ -249,69 +283,84 @@ func (ibm *IndexBackfillMerger) Merge(
 			},
 			ScanFormat: roachpb.KEY_VALUES,
 		})
-		br, pErr := txn.Send(ctx, ba)
+		var pErr *roachpb.Error
+		br, pErr = txn.Send(ctx, ba)
 		if pErr != nil {
 			return pErr.GoError()
 		}
+		return nil
+	}); err != nil {
+		return mergeChunk{}, nil, err
+	}
 
-		resp := br.Responses[0].GetScan()
+	resp := br.Responses[0].GetScan()
+	chunk := mergeChunk{
+		spanIdx: spanIdx,
+	}
+	var chunkMem int64
+	if len(resp.Rows) == 0 {
+		chunk.completedSpan = roachpb.Span{Key: startKey, EndKey: endKey}
+	} else {
+		nextStart = resp.Rows[len(resp.Rows)-1].Key.Next()
+		chunk.completedSpan = roachpb.Span{Key: startKey, EndKey: nextStart}
+
+		ibm.muBoundAccount.Lock()
+		for i := range resp.Rows {
+			chunk.keys = append(chunk.keys, resp.Rows[i].Key)
+			if err := ibm.muBoundAccount.boundAccount.Grow(ctx, int64(len(resp.Rows[i].Key))); err != nil {
+				ibm.muBoundAccount.Unlock()
+				return mergeChunk{}, nil, errors.Wrap(err, "failed to allocate space for merge keys")
+			}
+			chunkMem += int64(len(resp.Rows[i].Key))
+		}
+		ibm.muBoundAccount.Unlock()
+	}
+	chunk.memUsed = chunkMem
+	return chunk, nextStart, nil
+}
+
+// merge merges the latest values for sourceKeys from the index with sourceID
+// into the index with destinationID.
+func (ibm *IndexBackfillMerger) merge(
+	ctx context.Context,
+	codec keys.SQLCodec,
+	table catalog.TableDescriptor,
+	sourceID descpb.IndexID,
+	destinationID descpb.IndexID,
+	sourceKeys []roachpb.Key,
+	sourceSpan roachpb.Span,
+) error {
+	sourcePrefix := rowenc.MakeIndexKeyPrefix(codec, table.GetID(), sourceID)
+	destPrefix := rowenc.MakeIndexKeyPrefix(codec, table.GetID(), destinationID)
+
+	err := ibm.flowCtx.Cfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		var deletedCount int
 		txn.AddCommitTrigger(func(ctx context.Context) {
-			log.VInfof(ctx, 2, "merged batch of %d keys (%d deletes) (nextStart: %s) (commit timestamp: %s)",
-				len(resp.Rows),
+			log.VInfof(ctx, 2, "merged batch of %d keys (%d deletes) (span: %s) (commit timestamp: %s)",
+				len(sourceKeys),
 				deletedCount,
-				nextStart,
+				sourceSpan,
 				txn.CommitTimestamp(),
 			)
 		})
-		if len(resp.Rows) == 0 {
-			nextStart = nil
+		if len(sourceKeys) == 0 {
 			return nil
 		}
 
-		wb := txn.NewBatch()
-		var memUsedInMerge int64
-		for i := range resp.Rows {
-			sourceKV := &resp.Rows[i]
-
-			if len(sourceKV.Key) < prefixLen {
-				return errors.Errorf("key for index entry %v does not start with prefix %v", sourceKV, sourcePrefix)
-			}
-
-			destKey = destKey[:0]
-			destKey = append(destKey, destPrefix...)
-			destKey = append(destKey, sourceKV.Key[prefixLen:]...)
-
-			mergedEntry, deleted, err := mergeEntry(&resp.Rows[i], destKey)
-			if err != nil {
-				return err
-			}
-
-			if deleted {
-				deletedCount++
-				wb.Del(mergedEntry.Key)
-				if err := ibm.boundAccount.Grow(ctx, int64(len(mergedEntry.Key))); err != nil {
-					return errors.Errorf("failed to allocate space to merge delete from temp index")
-				}
-				memUsedInMerge += int64(len(mergedEntry.Key))
-			} else {
-				wb.Put(mergedEntry.Key, mergedEntry.Value)
-				if err := ibm.boundAccount.Grow(ctx, int64(len(mergedEntry.Key)+len(mergedEntry.Value.RawBytes))); err != nil {
-					return errors.Errorf("failed to allocate space to merge put from temp index")
-				}
-				memUsedInMerge += int64(len(mergedEntry.Key) + len(mergedEntry.Value.RawBytes))
-			}
+		wb, memUsedInMerge, deletedKeys, err := ibm.constructMergeBatch(ctx, txn, sourceKeys, sourcePrefix, destPrefix)
+		if err != nil {
+			return err
 		}
-		defer ibm.boundAccount.Shrink(ctx, memUsedInMerge)
+
+		defer ibm.shrinkBoundAccount(ctx, memUsedInMerge)
+		deletedCount = deletedKeys
 		if err := txn.Run(ctx, wb); err != nil {
 			return err
 		}
 
-		nextStart = resp.Rows[len(resp.Rows)-1].Key.Next()
-
 		if knobs, ok := ibm.flowCtx.Cfg.TestingKnobs.IndexBackfillMergerTestingKnobs.(*IndexBackfillMergerTestingKnobs); ok {
 			if knobs != nil && knobs.RunDuringMergeTxn != nil {
-				if err := knobs.RunDuringMergeTxn(ctx, txn, startKey, endKey); err != nil {
+				if err := knobs.RunDuringMergeTxn(ctx, txn, sourceSpan.Key, sourceSpan.EndKey); err != nil {
 					return err
 				}
 			}
@@ -319,18 +368,91 @@ func (ibm *IndexBackfillMerger) Merge(
 		return nil
 	})
 
-	if err != nil {
-		return nil, err
-	}
-
-	return nextStart, nil
+	return err
 }
 
-func mergeEntry(sourceKV *roachpb.KeyValue, destKey roachpb.Key) (*kv.KeyValue, bool, error) {
+func (ibm *IndexBackfillMerger) constructMergeBatch(
+	ctx context.Context,
+	txn *kv.Txn,
+	sourceKeys []roachpb.Key,
+	sourcePrefix []byte,
+	destPrefix []byte,
+) (*kv.Batch, int64, int, error) {
+	rb := txn.NewBatch()
+	for i := range sourceKeys {
+		rb.Get(sourceKeys[i])
+	}
+	if err := txn.Run(ctx, rb); err != nil {
+		return nil, 0, 0, err
+	}
+
+	// We acquire the bound account lock for the entirety of the merge batch
+	// construction so that we don't have to acquire the lock every time we want
+	// to grow the account.
+	var memUsedInMerge int64
+	ibm.muBoundAccount.Lock()
+	defer ibm.muBoundAccount.Unlock()
+	for i := range rb.Results {
+		// Since the source index is delete-preserving, reading the latest value for
+		// a key that has existed in the past should always return a value.
+		if rb.Results[i].Rows[0].Value == nil {
+			return nil, 0, 0, errors.AssertionFailedf("expected value to be present in temp index for key=%s", rb.Results[i].Rows[0].Key)
+		}
+		rowMem := int64(len(rb.Results[i].Rows[0].Key)) + int64(len(rb.Results[i].Rows[0].Value.RawBytes))
+		if err := ibm.muBoundAccount.boundAccount.Grow(ctx, rowMem); err != nil {
+			return nil, 0, 0, errors.Wrap(err, "failed to allocate space to read latest keys from temp index")
+		}
+		memUsedInMerge += rowMem
+	}
+
+	prefixLen := len(sourcePrefix)
+	destKey := make([]byte, len(destPrefix))
+	var deletedCount int
+	wb := txn.NewBatch()
+	for i := range rb.Results {
+		sourceKV := &rb.Results[i].Rows[0]
+		if len(sourceKV.Key) < prefixLen {
+			return nil, 0, 0, errors.Errorf("key for index entry %v does not start with prefix %v", sourceKV, sourcePrefix)
+		}
+
+		destKey = destKey[:0]
+		destKey = append(destKey, destPrefix...)
+		destKey = append(destKey, sourceKV.Key[prefixLen:]...)
+
+		mergedEntry, deleted, err := mergeEntry(sourceKV, destKey)
+		if err != nil {
+			return nil, 0, 0, err
+		}
+
+		entryBytes := mergedEntryBytes(mergedEntry, deleted)
+		if err := ibm.muBoundAccount.boundAccount.Grow(ctx, entryBytes); err != nil {
+			return nil, 0, 0, errors.Wrap(err, "failed to allocate space to merge entry from temp index")
+		}
+		memUsedInMerge += entryBytes
+		if deleted {
+			deletedCount++
+			wb.Del(mergedEntry.Key)
+		} else {
+			wb.Put(mergedEntry.Key, mergedEntry.Value)
+		}
+	}
+
+	return wb, memUsedInMerge, deletedCount, nil
+}
+
+func mergedEntryBytes(entry *kv.KeyValue, deleted bool) int64 {
+	if deleted {
+		return int64(len(entry.Key))
+	}
+
+	return int64(len(entry.Key) + len(entry.Value.RawBytes))
+}
+
+func mergeEntry(sourceKV *kv.KeyValue, destKey roachpb.Key) (*kv.KeyValue, bool, error) {
 	var destTagAndData []byte
 	var deleted bool
 
-	tempWrapper, err := rowenc.DecodeWrapper(&sourceKV.Value)
+	tempWrapper, err := rowenc.DecodeWrapper(sourceKV.Value)
 	if err != nil {
 		return nil, false, err
 	}
@@ -348,6 +470,18 @@ func mergeEntry(sourceKV *roachpb.KeyValue, destKey roachpb.Key) (*kv.KeyValue, 
 		Key:   destKey.Clone(),
 		Value: value,
 	}, deleted, nil
+}
+
+func (ibm *IndexBackfillMerger) growBoundAccount(ctx context.Context, growBy int64) error {
+	defer ibm.muBoundAccount.Unlock()
+	ibm.muBoundAccount.Lock()
+	return ibm.muBoundAccount.boundAccount.Grow(ctx, growBy)
+}
+
+func (ibm *IndexBackfillMerger) shrinkBoundAccount(ctx context.Context, shrinkBy int64) {
+	defer ibm.muBoundAccount.Unlock()
+	ibm.muBoundAccount.Lock()
+	ibm.muBoundAccount.boundAccount.Shrink(ctx, shrinkBy)
 }
 
 // NewIndexBackfillMerger creates a new IndexBackfillMerger.
@@ -369,22 +503,28 @@ func NewIndexBackfillMerger(
 		mon:     mergerMon,
 	}
 
-	ibm.boundAccount = mergerMon.MakeBoundAccount()
+	ibm.muBoundAccount.boundAccount = mergerMon.MakeBoundAccount()
 	return ibm, nil
 }
 
 // IndexBackfillMergerTestingKnobs is for testing the distributed processors for
 // the index backfill merge step.
 type IndexBackfillMergerTestingKnobs struct {
-	// RunBeforeMergeChunk is called once before the merge of each chunk. It is
+	// RunBeforeScanChunk is called once before the scan of each chunk. It is
 	// called with starting key of the chunk.
-	RunBeforeMergeChunk func(startKey roachpb.Key) error
+	RunBeforeScanChunk func(startKey roachpb.Key) error
+
+	// RunAfterScanChunk is called once after a chunk has been successfully scanned.
+	RunAfterScanChunk func()
 
 	RunDuringMergeTxn func(ctx context.Context, txn *kv.Txn, startKey roachpb.Key, endKey roachpb.Key) error
 
 	// PushesProgressEveryChunk forces the process to push the merge process after
 	// every chunk.
 	PushesProgressEveryChunk bool
+
+	// RunAfterMergeChunk is called once after a chunk has been successfully merged.
+	RunAfterMergeChunk func()
 }
 
 var _ base.ModuleTestingKnobs = &IndexBackfillMergerTestingKnobs{}

--- a/pkg/sql/delete_preserving_index_test.go
+++ b/pkg/sql/delete_preserving_index_test.go
@@ -484,6 +484,22 @@ func compareVersionedValueWrappers(
 	return nil
 }
 
+type fakeReceiver struct {
+	err error
+}
+
+func (f *fakeReceiver) ProducerDone() {
+}
+
+func (f *fakeReceiver) Push(
+	row rowenc.EncDatumRow, meta *execinfrapb.ProducerMetadata,
+) execinfra.ConsumerStatus {
+	if meta.Err != nil {
+		f.err = meta.Err
+	}
+	return 0
+}
+
 // This test tests that the schema changer is able to merge entries from a
 // delete-preserving index into a regular index.
 func TestMergeProcessor(t *testing.T) {
@@ -521,7 +537,7 @@ func TestMergeProcessor(t *testing.T) {
 			// with 3000/3, 4000/4 entries, and a delete for the 2000/2 entry.
 			dstDataSQL: `INSERT INTO d.t (k, a, b) VALUES (1, 100, 1000), (2, 200, 2000)`,
 			srcDataSQL: `INSERT INTO d.t (k, a, b) VALUES (3, 300, 3000), (4, 400, 4000);
-   								 DELETE FROM d.t WHERE k = 2`,
+  								 DELETE FROM d.t WHERE k = 2`,
 			// Insert another row for the 2000/2 entry just so that there's a primary
 			// index row for the index to return when we read it.
 			dstDataSQL2: `INSERT INTO d.t (k, a, b) VALUES (2, 201, 2000)`,
@@ -544,14 +560,14 @@ func TestMergeProcessor(t *testing.T) {
 				CREATE TABLE d.t (k INT PRIMARY KEY, a INT, b INT,
 					UNIQUE INDEX idx (b),
 					UNIQUE INDEX idx_temp (b)
-  			);`,
+ 			);`,
 			srcIndex: "idx_temp",
 			dstIndex: "idx",
 			// Populate dstIndex with some 1000/1, 2000/2 entries. Populate srcIndex
 			// with 3000/3, 4000/4 entries, and a delete for a nonexistent key.
 			dstDataSQL: `INSERT INTO d.t (k, a, b) VALUES (1, 100, 1000), (2, 200, 2000)`,
 			srcDataSQL: `INSERT INTO d.t (k, a, b) VALUES (3, 300, 3000), (4, 400, 4000);
-   								 DELETE FROM d.t WHERE k = 5`,
+  								 DELETE FROM d.t WHERE k = 5`,
 			dstContentsBeforeMerge: [][]string{
 				{"1", "1000"},
 				{"2", "2000"},
@@ -568,7 +584,7 @@ func TestMergeProcessor(t *testing.T) {
 			name: "index with overriding values",
 			setupSQL: `
 				CREATE DATABASE d;
-   			CREATE TABLE d.t (k INT PRIMARY KEY, a INT, b INT,
+  			CREATE TABLE d.t (k INT PRIMARY KEY, a INT, b INT,
 					UNIQUE INDEX idx (b),
 					UNIQUE INDEX idx_temp (b)
 				);`,
@@ -601,19 +617,16 @@ func TestMergeProcessor(t *testing.T) {
 		tableDesc := desctestutils.TestingGetMutableExistingTableDescriptor(kvDB, codec, "d", "t")
 		settings := server.ClusterSettings()
 		execCfg := server.ExecutorConfig().(sql.ExecutorConfig)
-		evalCtx := tree.EvalContext{Settings: settings}
-		//mm := mon.NewMonitor("MemoryMonitor", mon.MemoryResource, nil, nil, 0, math.MaxInt64, settings)
+		evalCtx := tree.EvalContext{Settings: settings, Codec: codec}
 		mm := mon.NewUnlimitedMonitor(ctx, "MemoryMonitor", mon.MemoryResource, nil, nil, math.MaxInt64, settings)
-		flowCtx := execinfra.FlowCtx{Cfg: &execinfra.ServerConfig{DB: kvDB,
-			Settings:          settings,
-			Codec:             codec,
-			BackfillerMonitor: mm,
-		},
-			EvalCtx: &evalCtx}
-
-		im, err := backfill.NewIndexBackfillMerger(ctx, &flowCtx, execinfrapb.IndexBackfillMergerSpec{}, nil)
-		if err != nil {
-			t.Fatal(err)
+		flowCtx := execinfra.FlowCtx{
+			Cfg: &execinfra.ServerConfig{
+				DB:                kvDB,
+				Settings:          settings,
+				Codec:             codec,
+				BackfillerMonitor: mm,
+			},
+			EvalCtx: &evalCtx,
 		}
 
 		// Here want to have different entries for the two indices, so we manipulate
@@ -626,7 +639,7 @@ func TestMergeProcessor(t *testing.T) {
 			}
 		}
 
-		err = mutateIndexByName(kvDB, codec, tableDesc, test.dstIndex, nil, descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY)
+		err := mutateIndexByName(kvDB, codec, tableDesc, test.dstIndex, nil, descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY)
 		require.NoError(t, err)
 		err = mutateIndexByName(kvDB, codec, tableDesc, test.srcIndex, setUseDeletePreservingEncoding(true), descpb.DescriptorMutation_DELETE_ONLY)
 		require.NoError(t, err)
@@ -679,9 +692,23 @@ func TestMergeProcessor(t *testing.T) {
 		}))
 
 		sp := tableDesc.IndexSpan(codec, srcIndex.GetID())
-		_, err = im.Merge(context.Background(), codec, tableDesc, srcIndex.GetID(), dstIndex.GetID(), sp.Key, sp.EndKey)
+
+		output := fakeReceiver{}
+		im, err := backfill.NewIndexBackfillMerger(ctx, &flowCtx, execinfrapb.IndexBackfillMergerSpec{
+			Table:            tableDesc.TableDescriptor,
+			TemporaryIndexes: []descpb.IndexID{srcIndex.GetID()},
+			AddedIndexes:     []descpb.IndexID{dstIndex.GetID()},
+			Spans:            []roachpb.Span{sp},
+			SpanIdx:          []int32{0},
+			MergeTimestamp:   kvDB.Clock().Now(),
+		}, &output)
 		if err != nil {
 			t.Fatal(err)
+		}
+
+		im.Run(ctx)
+		if output.err != nil {
+			t.Fatal(output.err)
 		}
 
 		require.NoError(t, sql.DescsTxn(ctx, &execCfg, func(

--- a/pkg/sql/distsql_plan_backfill.go
+++ b/pkg/sql/distsql_plan_backfill.go
@@ -55,12 +55,16 @@ func initIndexBackfillerSpec(
 }
 
 func initIndexBackfillMergerSpec(
-	desc descpb.TableDescriptor, addedIndexes []descpb.IndexID, temporaryIndexes []descpb.IndexID,
+	desc descpb.TableDescriptor,
+	addedIndexes []descpb.IndexID,
+	temporaryIndexes []descpb.IndexID,
+	mergeTimestamp hlc.Timestamp,
 ) (execinfrapb.IndexBackfillMergerSpec, error) {
 	return execinfrapb.IndexBackfillMergerSpec{
 		Table:            desc,
 		AddedIndexes:     addedIndexes,
 		TemporaryIndexes: temporaryIndexes,
+		MergeTimestamp:   mergeTimestamp,
 	}, nil
 }
 

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -336,5 +336,7 @@ message IndexBackfillMergerSpec {
   repeated roachpb.Span spans = 4 [(gogoproto.nullable) = false];
   repeated int32 span_idx = 5;
 
-  // NEXT ID: 8.
+  optional util.hlc.Timestamp mergeTimestamp = 8 [(gogoproto.nullable) = false];
+
+  // NEXT ID: 9.
 }

--- a/pkg/sql/mvcc_backfiller.go
+++ b/pkg/sql/mvcc_backfiller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 )
@@ -52,6 +53,7 @@ func (im *IndexBackfillerMergePlanner) plan(
 	todoSpanList [][]roachpb.Span,
 	addedIndexes, temporaryIndexes []descpb.IndexID,
 	metaFn func(_ context.Context, meta *execinfrapb.ProducerMetadata) error,
+	mergeTimestamp hlc.Timestamp,
 ) (func(context.Context) error, error) {
 	var p *PhysicalPlan
 	var evalCtx extendedEvalContext
@@ -64,7 +66,7 @@ func (im *IndexBackfillerMergePlanner) plan(
 		planCtx = im.execCfg.DistSQLPlanner.NewPlanningCtx(ctx, &evalCtx, nil /* planner */, txn,
 			DistributionTypeSystemTenantOnly)
 
-		spec, err := initIndexBackfillMergerSpec(*tableDesc.TableDesc(), addedIndexes, temporaryIndexes)
+		spec, err := initIndexBackfillMergerSpec(*tableDesc.TableDesc(), addedIndexes, temporaryIndexes, mergeTimestamp)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/mvcc_backfiller_test.go
+++ b/pkg/sql/mvcc_backfiller_test.go
@@ -74,6 +74,7 @@ func TestIndexBackfillMergeRetry(t *testing.T) {
 		return nil
 	}
 
+	mergeSerializeCh := make(chan struct{}, 1)
 	mergeChunk := 0
 	var seenKey roachpb.Key
 	checkStartingKey := func(key roachpb.Key) error {
@@ -111,7 +112,13 @@ func TestIndexBackfillMergeRetry(t *testing.T) {
 			SerializeIndexBackfillCreationAndIngestion: make(chan struct{}, 1),
 			IndexBackfillMergerTestingKnobs: &backfill.IndexBackfillMergerTestingKnobs{
 				PushesProgressEveryChunk: true,
-				RunBeforeMergeChunk:      checkStartingKey,
+				RunBeforeScanChunk:       checkStartingKey,
+				RunAfterScanChunk: func() {
+					<-mergeSerializeCh
+				},
+				RunAfterMergeChunk: func() {
+					mergeSerializeCh <- struct{}{}
+				},
 			},
 		},
 		// Disable backfill migrations, we still need the jobs table migration.
@@ -224,7 +231,7 @@ func TestIndexBackfillFractionTracking(t *testing.T) {
 			RunAfterBackfillChunk:      func() { assertFractionBetween("backfill", 0.0, 0.60) },
 			IndexBackfillMergerTestingKnobs: &backfill.IndexBackfillMergerTestingKnobs{
 				PushesProgressEveryChunk: true,
-				RunBeforeMergeChunk: func(_ roachpb.Key) error {
+				RunBeforeScanChunk: func(_ roachpb.Key) error {
 					assertFractionBetween("merge", 0.60, 1.00)
 					return nil
 				},
@@ -321,7 +328,7 @@ func TestRaceWithIndexBackfillMerge(t *testing.T) {
 		DistSQL: &execinfra.TestingKnobs{
 			RunBeforeBackfillChunk: populateTempIndexWithWrites,
 			IndexBackfillMergerTestingKnobs: &backfill.IndexBackfillMergerTestingKnobs{
-				RunBeforeMergeChunk: func(key roachpb.Key) error {
+				RunBeforeScanChunk: func(key roachpb.Key) error {
 					notifyMerge()
 					return nil
 				},
@@ -692,4 +699,62 @@ func splitIndex(
 		}
 	}
 	return nil
+}
+
+// TestIndexMergeEveryChunkWrite tests the case where the workload
+// writes sequentially into the key space faster than the merger and
+// write.
+func TestIndexMergeEveryChunkWrite(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	chunkSize := 10
+	rowsPerWrite := 20
+	rowIdx := 0
+	mergeSerializeCh := make(chan struct{}, 1)
+
+	params, _ := tests.CreateTestServerParams()
+	var writeMore func() error
+	params.Knobs = base.TestingKnobs{
+		DistSQL: &execinfra.TestingKnobs{
+			IndexBackfillMergerTestingKnobs: &backfill.IndexBackfillMergerTestingKnobs{
+				RunBeforeScanChunk: func(key roachpb.Key) error {
+					return writeMore()
+				},
+				RunAfterScanChunk: func() {
+					<-mergeSerializeCh
+				},
+				RunAfterMergeChunk: func() {
+					mergeSerializeCh <- struct{}{}
+				},
+			},
+		},
+	}
+
+	s, sqlDB, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(context.Background())
+
+	var mu syncutil.Mutex
+	writeMore = func() error {
+		mu.Lock()
+		defer mu.Unlock()
+		start := rowIdx
+		rowIdx += rowsPerWrite
+		for i := 1; i <= rowsPerWrite; i++ {
+			if _, err := sqlDB.Exec("UPSERT INTO t.test VALUES ($1, $2)", start+i, start+i); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if _, err := sqlDB.Exec(fmt.Sprintf(`SET CLUSTER SETTING bulkio.index_backfill.merge_batch_size = %d`, chunkSize)); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := sqlDB.Exec(`CREATE DATABASE t; CREATE TABLE t.test (k INT PRIMARY KEY, v int);`)
+	require.NoError(t, err)
+	require.NoError(t, writeMore(), "initial insert")
+	_, err = sqlDB.Exec("CREATE INDEX ON t.test (v)")
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Backport 1/1 commits from #77482.

/cc @cockroachdb/release

---

Previously, the merge step of the MVCC index backfiller scanned over all
entries in the temporary index, thus ran a risk of never catching up if new
keys were written to the temporary index faster than the merge could process
them. With this change, only the keys that are present in the temporary index
at the start of the merge step are merged into the final index, thus fixing
the number of merged KVs.

Release justification: improve the runtime of index backfills.
Release note: None


Jira issue: CRDB-14704