### PR TITLE
sql, geo: check infinite coordinates in st_minimumboundingcircle and st_linemerge

### DIFF
--- a/pkg/geo/geomfn/topology_operations.go
+++ b/pkg/geo/geomfn/topology_operations.go
@@ -207,3 +207,18 @@ func MinimumRotatedRectangle(g geo.Geometry) (geo.Geometry, error) {
 	}
 	return gm, nil
 }
+
+// CheckBoundingBoxInfiniteCoordinates checks if the bounding box of a Geometry
+// has infinite coordinate.
+func CheckBoundingBoxInfiniteCoordinates(g geo.Geometry) bool {
+	boundingBox := g.BoundingBoxRef()
+	if boundingBox == nil {
+		return false
+	}
+	for _, coord := range []float64{boundingBox.LoX, boundingBox.LoY, boundingBox.HiX, boundingBox.HiY} {
+		if math.IsInf(coord, 0) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -5328,6 +5328,9 @@ LINESTRING (1 2, 3 4, 5 6)
 MULTILINESTRING ((1 2, 3 4), (5 6, 7 8))
 GEOMETRYCOLLECTION EMPTY
 
+statement error st_linemerge\(\): value out of range: overflow
+select st_linemerge('01020000C003000000000000000000F0FF000000000000F8FF60DB272315DEBAC13CDE36003499DEC1000000000000F0FF000000000000F8FF9CDB5D9AA401E1C1D0C80253A5F1C4C1000000000000F0FF000000000000F8FF003E39CD6CDDD2C1A6909F31D737F4C1'::geometry);
+
 subtest public_schema_resolution
 
 query T
@@ -5664,6 +5667,8 @@ SELECT ST_MinimumBoundingCircle(NULL::geometry) IS NULL;
 ----
 true
 
+statement error st_minimumboundingcircle\(\): value out of range: overflow
+select st_minimumboundingcircle(st_makepoint(((-0.27013513189303495):::FLOAT8::FLOAT8 // 5e-324:::FLOAT8::FLOAT8)::FLOAT8::FLOAT8, (-0.4968052087960828):::FLOAT8::FLOAT8)::GEOMETRY::GEOMETRY)::GEOMETRY
 
 subtest st_unaryunion
 

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -3181,6 +3181,9 @@ Note If the result has zero or one points, it will be returned as a POINT. If it
 		defProps(),
 		geometryOverload1(
 			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				if geomfn.CheckBoundingBoxInfiniteCoordinates(g.Geometry) {
+					return nil, pgerror.Newf(pgcode.InvalidParameterValue, "value out of range: overflow")
+				}
 				line, err := geomfn.LineMerge(g.Geometry)
 				if err != nil {
 					return nil, err
@@ -6468,6 +6471,9 @@ The parent_only boolean is always ignored.`,
 	"st_minimumboundingcircle": makeBuiltin(defProps(),
 		geometryOverload1(
 			func(evalContext *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				if geomfn.CheckBoundingBoxInfiniteCoordinates(g.Geometry) {
+					return nil, pgerror.Newf(pgcode.InvalidParameterValue, "value out of range: overflow")
+				}
 				polygon, _, _, err := geomfn.MinimumBoundingCircle(g.Geometry)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
This commit adds a check to determine if the bounding box of a Geometry has
any infinite coordinate in st_minimumboundingcircle and st_linemerge.

Fixes https://github.com/cockroachdb/cockroach/issues/75305
Fixes https://github.com/cockroachdb/cockroach/issues/74445

Release note: None

Jira issue: CRDB-14764