### PR TITLE
colflow: forward only one error in routerOutput

### DIFF
--- a/pkg/sql/colflow/routers.go
+++ b/pkg/sql/colflow/routers.go
@@ -308,7 +308,7 @@ func (o *routerOutputOp) cancel(ctx context.Context, err error) {
 }
 
 func (o *routerOutputOp) forwardErrLocked(err error) {
-	if err != nil {
+	if err != nil && o.mu.forwardedErr == nil {
 		o.mu.forwardedErr = err
 	}
 }


### PR DESCRIPTION
This was always the intention, and the comment on `forwardedErr` says
that once set, it'll never change. I don't think we ever would try to
overwrite it, so it was never a problem, but it still nice to have an
explicit non-nil check.

Release note: None