### PR TITLE
bazel: update arguments passed to `configure` for dev macOS arm builds

### DIFF
--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -175,6 +175,17 @@ config_setting(
 )
 
 config_setting(
+    name = "is_dev_macos_arm64",
+    constraint_values = [
+        "@io_bazel_rules_go//go/toolchain:darwin",
+        "@platforms//cpu:aarch64",
+    ],
+    flag_values = {
+        ":dev_flag": "true",
+    },
+)
+
+config_setting(
     name = "is_cross_linux",
     constraint_values = [
         "@io_bazel_rules_go//go/toolchain:linux",

--- a/c-deps/BUILD.bazel
+++ b/c-deps/BUILD.bazel
@@ -11,7 +11,16 @@ configure_make(
         "--enable-prof",
     ] + select({
         "@io_bazel_rules_go//go/platform:windows": ["--host=x86_64-w64-mingw32"],
-        "@io_bazel_rules_go//go/platform:darwin": ["--host=x86_64-apple-darwin19"],
+        "@io_bazel_rules_go//go/platform:darwin_amd64": ["--host=x86_64-apple-darwin19"],
+        "@io_bazel_rules_go//go/platform:darwin_arm64": ["--host=aarch64-apple-darwin19"],
+        # NB: Normally host detection is handled by configure, but the version
+        # of jemalloc we have vendored is pretty ancient and can't handle some
+        # of the newer M1 Macs. This arm of the select() can probably be deleted
+        # when we bump the vendored version.
+        "//build/toolchains:is_dev_macos_arm64": [
+            "--host=aarch64-apple-darwin19",
+            "--build=aarch64-apple-darwin19",
+        ],
         "@io_bazel_rules_go//go/platform:linux_arm64": ["--host=aarch64-unknown-linux-gnu"],
         "//conditions:default": [],
     }),


### PR DESCRIPTION
Release note: None