### PR TITLE
release-22.1: release: generate release archive checksums

### DIFF
--- a/pkg/cmd/publish-provisional-artifacts/main.go
+++ b/pkg/cmd/publish-provisional-artifacts/main.go
@@ -261,7 +261,13 @@ func putRelease(svc s3I, o opts) {
 }
 
 func markLatestRelease(svc s3I, o opts) {
+	markLatestReleaseWithSuffix(svc, o, "")
+	markLatestReleaseWithSuffix(svc, o, release.ChecksumSuffix)
+}
+
+func markLatestReleaseWithSuffix(svc s3I, o opts, suffix string) {
 	_, keyRelease := s3KeyRelease(o)
+	keyRelease += suffix
 	log.Printf("Downloading from %s/%s", o.BucketName, keyRelease)
 	binary, err := svc.GetObject(&s3.GetObjectInput{
 		Bucket: &o.BucketName,
@@ -279,6 +285,7 @@ func markLatestRelease(svc s3I, o opts) {
 	oLatest := o
 	oLatest.VersionStr = latestStr
 	_, keyLatest := s3KeyRelease(oLatest)
+	keyLatest += suffix
 	log.Printf("Uploading to s3://%s/%s", o.BucketName, keyLatest)
 	putObjectInput := s3.PutObjectInput{
 		Bucket:       &o.BucketName,

--- a/pkg/cmd/publish-provisional-artifacts/main_test.go
+++ b/pkg/cmd/publish-provisional-artifacts/main_test.go
@@ -55,7 +55,12 @@ func (s *mockS3) PutObject(i *s3.PutObjectInput) (*s3.PutObjectOutput, error) {
 		if err != nil {
 			return nil, err
 		}
-		if utf8.Valid(bytes) {
+		if strings.HasSuffix(*i.Key, release.ChecksumSuffix) {
+			// Unfortunately the archive tarball checksum changes every time,
+			// because we generate tarballs and the copy file modification time from the generated files.
+			// This makes the checksum not reproducible.
+			s.puts = append(s.puts, fmt.Sprintf("%s CONTENTS <sha256sum>", url))
+		} else if utf8.Valid(bytes) {
 			s.puts = append(s.puts, fmt.Sprintf("%s CONTENTS %s", url, bytes))
 		} else {
 			s.puts = append(s.puts, fmt.Sprintf("%s CONTENTS <binary stuff>", url))
@@ -159,10 +164,14 @@ func TestProvisional(t *testing.T) {
 			expectedPuts: []string{
 				"s3://binaries.cockroachdb.com/cockroach-v0.0.1-alpha.linux-amd64.tgz " +
 					"CONTENTS <binary stuff>",
+				"s3://binaries.cockroachdb.com/cockroach-v0.0.1-alpha.linux-amd64.tgz.sha256sum CONTENTS <sha256sum>",
 				"s3://binaries.cockroachdb.com/cockroach-v0.0.1-alpha.darwin-10.9-amd64.tgz " +
 					"CONTENTS <binary stuff>",
+				"s3://binaries.cockroachdb.com/cockroach-v0.0.1-alpha.darwin-10.9-amd64.tgz.sha256sum CONTENTS <sha256sum>",
 				"s3://binaries.cockroachdb.com/cockroach-v0.0.1-alpha.windows-6.2-amd64.zip " +
 					"CONTENTS <binary stuff>",
+				"s3://binaries.cockroachdb.com/cockroach-v0.0.1-alpha.windows-6.2-amd64.zip." +
+					"sha256sum CONTENTS <sha256sum>",
 			},
 		},
 		{
@@ -259,16 +268,22 @@ func TestBless(t *testing.T) {
 			},
 			expectedGets: []string{
 				"s3://binaries.cockroachdb.com/cockroach-v0.0.1.linux-amd64.tgz",
+				"s3://binaries.cockroachdb.com/cockroach-v0.0.1.linux-amd64.tgz.sha256sum",
 				"s3://binaries.cockroachdb.com/cockroach-v0.0.1.darwin-10.9-amd64.tgz",
+				"s3://binaries.cockroachdb.com/cockroach-v0.0.1.darwin-10.9-amd64.tgz.sha256sum",
 				"s3://binaries.cockroachdb.com/cockroach-v0.0.1.windows-6.2-amd64.zip",
+				"s3://binaries.cockroachdb.com/cockroach-v0.0.1.windows-6.2-amd64.zip.sha256sum",
 			},
 			expectedPuts: []string{
 				"s3://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz/no-cache " +
 					"CONTENTS s3://binaries.cockroachdb.com/cockroach-v0.0.1.linux-amd64.tgz",
+				"s3://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz.sha256sum/no-cache CONTENTS <sha256sum>",
 				"s3://binaries.cockroachdb.com/cockroach-latest.darwin-10.9-amd64.tgz/no-cache " +
 					"CONTENTS s3://binaries.cockroachdb.com/cockroach-v0.0.1.darwin-10.9-amd64.tgz",
+				"s3://binaries.cockroachdb.com/cockroach-latest.darwin-10.9-amd64.tgz.sha256sum/no-cache CONTENTS <sha256sum>",
 				"s3://binaries.cockroachdb.com/cockroach-latest.windows-6.2-amd64.zip/no-cache " +
 					"CONTENTS s3://binaries.cockroachdb.com/cockroach-v0.0.1.windows-6.2-amd64.zip",
+				"s3://binaries.cockroachdb.com/cockroach-latest.windows-6.2-amd64.zip.sha256sum/no-cache CONTENTS <sha256sum>",
 			},
 		},
 	}


### PR DESCRIPTION
Backport 1/1 commits from #79158.

/cc @cockroachdb/release

---

Previously, we published release archives without their checksums.
Without checksums there was a risk of downloading corrupt files without
a way to verify their integrity.

This patch adds a new functionality to generate checksums for the
release archives and upload them next to the archive files.

Fixes #79059

Release note: None
Release justification: not part of the product