### PR TITLE
bors: require 1 PR approval before merging

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -10,6 +10,10 @@ status = ["GitHub CI (Cockroach)"]
 # before merging.
 pr_status = ["license/cla", "blathers/release-justification-check"]
 
+# Number of project members who must approve the PR (using GitHub Reviews)
+# before it is pushed to master.
+required_approvals = 1
+
 # List of PR labels that may not be attached to a PR when it is r+-ed.
 block_labels = ["do-not-merge"]
 


### PR DESCRIPTION
Previously, bors was able to merge with some status checks passed, but
didn't require a PR approval in order to merge a PR.

This patch enforces bors to require 1 PR approval before merging.

Release note: None