### PR TITLE
changefeedccl: send different column families to different topics

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "sink_webhook.go",
         "testing_knobs.go",
         "tls.go",
+        "topic.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl",
     visibility = ["//visibility:public"],

--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -90,7 +90,7 @@ func TestAlterChangefeedAddTargetFamily(t *testing.T) {
 
 		sqlDB.Exec(t, `INSERT INTO foo VALUES(1, 'hello')`)
 		assertPayloads(t, testFeed, []string{
-			`foo: [1]->{"after": {"a": 1}}`,
+			`foo.onlya: [1]->{"after": {"a": 1}}`,
 		})
 
 		feed, ok := testFeed.(cdctest.EnterpriseTestFeed)
@@ -106,9 +106,9 @@ func TestAlterChangefeedAddTargetFamily(t *testing.T) {
 
 		sqlDB.Exec(t, `INSERT INTO foo VALUES(2, 'goodbye')`)
 		assertPayloads(t, testFeed, []string{
-			`foo: [1]->{"after": {"b": "hello"}}`,
-			`foo: [2]->{"after": {"a": 2}}`,
-			`foo: [2]->{"after": {"b": "goodbye"}}`,
+			`foo.onlyb: [1]->{"after": {"b": "hello"}}`,
+			`foo.onlya: [2]->{"after": {"a": 2}}`,
+			`foo.onlyb: [2]->{"after": {"b": "goodbye"}}`,
 		})
 	}
 
@@ -128,7 +128,7 @@ func TestAlterChangefeedSwitchFamily(t *testing.T) {
 
 		sqlDB.Exec(t, `INSERT INTO foo VALUES(1, 'hello')`)
 		assertPayloads(t, testFeed, []string{
-			`foo: [1]->{"after": {"a": 1}}`,
+			`foo.onlya: [1]->{"after": {"a": 1}}`,
 		})
 
 		feed, ok := testFeed.(cdctest.EnterpriseTestFeed)
@@ -144,8 +144,8 @@ func TestAlterChangefeedSwitchFamily(t *testing.T) {
 
 		sqlDB.Exec(t, `INSERT INTO foo VALUES(2, 'goodbye')`)
 		assertPayloads(t, testFeed, []string{
-			`foo: [1]->{"after": {"b": "hello"}}`,
-			`foo: [2]->{"after": {"b": "goodbye"}}`,
+			`foo.onlyb: [1]->{"after": {"b": "hello"}}`,
+			`foo.onlyb: [2]->{"after": {"b": "goodbye"}}`,
 		})
 	}
 
@@ -212,8 +212,8 @@ func TestAlterChangefeedDropTargetFamily(t *testing.T) {
 		sqlDB.Exec(t, `INSERT INTO foo VALUES(1, 'hello')`)
 		sqlDB.Exec(t, `INSERT INTO foo VALUES(2, 'goodbye')`)
 		assertPayloads(t, testFeed, []string{
-			`foo: [1]->{"after": {"a": 1}}`,
-			`foo: [2]->{"after": {"a": 2}}`,
+			`foo.onlya: [1]->{"after": {"a": 1}}`,
+			`foo.onlya: [2]->{"after": {"a": 2}}`,
 		})
 
 	}

--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -767,8 +767,11 @@ func tableToAvroSchema(
 		return nil, err
 	}
 	var name string
+	// Even though we now always specify a family,
+	// for backwards compatibility schemas for tables with only one family
+	// don't get family-specific names.
 	if tableDesc.NumFamilies() > 1 {
-		name = SQLNameToAvroName(tableDesc.GetName() + family.Name)
+		name = SQLNameToAvroName(tableDesc.GetName() + "." + family.Name)
 	} else {
 		name = SQLNameToAvroName(tableDesc.GetName())
 	}

--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -244,7 +244,7 @@ func createBenchmarkChangefeed(
 	}
 	serverCfg := s.DistSQLServer().(*distsql.ServerImpl).ServerConfig
 	eventConsumer := newKVEventToRowConsumer(ctx, &serverCfg, sf, initialHighWater,
-		sink, encoder, details, TestingKnobs{})
+		sink, encoder, details, TestingKnobs{}, nil)
 	tickFn := func(ctx context.Context) (*jobspb.ResolvedSpan, error) {
 		event, err := buf.Get(ctx)
 		if err != nil {

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -100,6 +100,7 @@ type changeAggregator struct {
 	metrics    *Metrics
 	sliMetrics *sliMetrics
 	knobs      TestingKnobs
+	topicNamer *TopicNamer
 }
 
 type timestampLowerBoundOracle interface {
@@ -169,6 +170,13 @@ func newChangeAggregatorProcessor(
 	var err error
 	if ca.encoder, err = getEncoder(ca.spec.Feed.Opts, AllTargets(ca.spec.Feed)); err != nil {
 		return nil, err
+	}
+
+	if _, needTopics := ca.spec.Feed.Opts[changefeedbase.OptTopicInValue]; needTopics {
+		ca.topicNamer, err = MakeTopicNamer(ca.spec.Feed.TargetSpecifications)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// MinCheckpointFrequency controls how frequently the changeAggregator flushes the sink
@@ -296,7 +304,7 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 	} else {
 		ca.eventConsumer = newKVEventToRowConsumer(
 			ctx, ca.flowCtx.Cfg, ca.frontier.SpanFrontier(), initialHighWater,
-			ca.sink, ca.encoder, ca.spec.Feed, ca.knobs)
+			ca.sink, ca.encoder, ca.spec.Feed, ca.knobs, ca.topicNamer)
 	}
 }
 
@@ -671,15 +679,17 @@ type kvEventConsumer interface {
 }
 
 type kvEventToRowConsumer struct {
-	frontier  *span.Frontier
-	encoder   Encoder
-	scratch   bufalloc.ByteAllocator
-	sink      Sink
-	cursor    hlc.Timestamp
-	knobs     TestingKnobs
-	rfCache   *rowFetcherCache
-	details   jobspb.ChangefeedDetails
-	kvFetcher row.SpanKVFetcher
+	frontier             *span.Frontier
+	encoder              Encoder
+	scratch              bufalloc.ByteAllocator
+	sink                 Sink
+	cursor               hlc.Timestamp
+	knobs                TestingKnobs
+	rfCache              *rowFetcherCache
+	details              jobspb.ChangefeedDetails
+	kvFetcher            row.SpanKVFetcher
+	topicDescriptorCache map[TopicIdentifier]TopicDescriptor
+	topicNamer           *TopicNamer
 }
 
 var _ kvEventConsumer = &kvEventToRowConsumer{}
@@ -693,6 +703,7 @@ func newKVEventToRowConsumer(
 	encoder Encoder,
 	details jobspb.ChangefeedDetails,
 	knobs TestingKnobs,
+	topicNamer *TopicNamer,
 ) kvEventConsumer {
 	rfCache := newRowFetcherCache(
 		ctx,
@@ -704,21 +715,163 @@ func newKVEventToRowConsumer(
 	)
 
 	return &kvEventToRowConsumer{
-		frontier: frontier,
-		encoder:  encoder,
-		sink:     sink,
-		cursor:   cursor,
-		rfCache:  rfCache,
-		details:  details,
-		knobs:    knobs,
+		frontier:             frontier,
+		encoder:              encoder,
+		sink:                 sink,
+		cursor:               cursor,
+		rfCache:              rfCache,
+		details:              details,
+		knobs:                knobs,
+		topicDescriptorCache: make(map[TopicIdentifier]TopicDescriptor),
+		topicNamer:           topicNamer,
 	}
 }
 
 type tableDescriptorTopic struct {
-	catalog.TableDescriptor
+	tableDesc           catalog.TableDescriptor
+	spec                jobspb.ChangefeedTargetSpecification
+	nameComponentsCache []string
+	identifierCache     TopicIdentifier
+}
+
+// GetNameComponents implements the TopicDescriptor interface
+func (tdt *tableDescriptorTopic) GetNameComponents() []string {
+	if len(tdt.nameComponentsCache) == 0 {
+		tdt.nameComponentsCache = []string{tdt.spec.StatementTimeName}
+	}
+	return tdt.nameComponentsCache
+}
+
+// GetTopicIdentifier implements the TopicDescriptor interface
+func (tdt *tableDescriptorTopic) GetTopicIdentifier() TopicIdentifier {
+	if tdt.identifierCache.TableID == 0 {
+		tdt.identifierCache = TopicIdentifier{
+			TableID: tdt.tableDesc.GetID(),
+		}
+	}
+	return tdt.identifierCache
+}
+
+// GetVersion implements the TopicDescriptor interface
+func (tdt *tableDescriptorTopic) GetVersion() descpb.DescriptorVersion {
+	return tdt.tableDesc.GetVersion()
+}
+
+// GetTargetSpecification implements the TopicDescriptor interface
+func (tdt *tableDescriptorTopic) GetTargetSpecification() jobspb.ChangefeedTargetSpecification {
+	return tdt.spec
 }
 
 var _ TopicDescriptor = &tableDescriptorTopic{}
+
+type columnFamilyTopic struct {
+	tableDesc           catalog.TableDescriptor
+	familyDesc          descpb.ColumnFamilyDescriptor
+	spec                jobspb.ChangefeedTargetSpecification
+	nameComponentsCache []string
+	identifierCache     TopicIdentifier
+}
+
+// GetNameComponents implements the TopicDescriptor interface
+func (cft *columnFamilyTopic) GetNameComponents() []string {
+	if len(cft.nameComponentsCache) == 0 {
+		cft.nameComponentsCache = []string{
+			cft.spec.StatementTimeName,
+			cft.familyDesc.Name,
+		}
+	}
+	return cft.nameComponentsCache
+}
+
+// GetTopicIdentifier implements the TopicDescriptor interface
+func (cft *columnFamilyTopic) GetTopicIdentifier() TopicIdentifier {
+	if cft.identifierCache.TableID == 0 {
+		cft.identifierCache = TopicIdentifier{
+			TableID:  cft.tableDesc.GetID(),
+			FamilyID: cft.familyDesc.ID,
+		}
+	}
+	return cft.identifierCache
+}
+
+// GetVersion implements the TopicDescriptor interface
+func (cft *columnFamilyTopic) GetVersion() descpb.DescriptorVersion {
+	return cft.tableDesc.GetVersion()
+}
+
+// GetTargetSpecification implements the TopicDescriptor interface
+func (cft *columnFamilyTopic) GetTargetSpecification() jobspb.ChangefeedTargetSpecification {
+	return cft.spec
+}
+
+var _ TopicDescriptor = &columnFamilyTopic{}
+
+type noTopic struct{}
+
+func (n noTopic) GetNameComponents() []string {
+	return []string{}
+}
+
+func (n noTopic) GetTopicIdentifier() TopicIdentifier {
+	return TopicIdentifier{}
+}
+
+func (n noTopic) GetVersion() descpb.DescriptorVersion {
+	return 0
+}
+
+func (n noTopic) GetTargetSpecification() jobspb.ChangefeedTargetSpecification {
+	return jobspb.ChangefeedTargetSpecification{}
+}
+
+var _ TopicDescriptor = &noTopic{}
+
+func makeTopicDescriptorFromSpecForRow(
+	s jobspb.ChangefeedTargetSpecification, r encodeRow,
+) (TopicDescriptor, error) {
+	switch s.Type {
+	case jobspb.ChangefeedTargetSpecification_PRIMARY_FAMILY_ONLY:
+		return &tableDescriptorTopic{
+			tableDesc: r.tableDesc,
+			spec:      s,
+		}, nil
+	case jobspb.ChangefeedTargetSpecification_EACH_FAMILY, jobspb.ChangefeedTargetSpecification_COLUMN_FAMILY:
+		familyDesc, err := r.tableDesc.FindFamilyByID(r.familyID)
+		if err != nil {
+			return noTopic{}, err
+		}
+		return &columnFamilyTopic{
+			tableDesc:  r.tableDesc,
+			spec:       s,
+			familyDesc: *familyDesc,
+		}, nil
+	default:
+		return noTopic{}, errors.AssertionFailedf("Unsupported target type %s", s.Type)
+	}
+}
+
+func (c *kvEventToRowConsumer) topicForRow(r encodeRow) (TopicDescriptor, error) {
+	if topic, ok := c.topicDescriptorCache[TopicIdentifier{TableID: r.tableDesc.GetID(), FamilyID: r.familyID}]; ok {
+		if topic.GetVersion() == r.tableDesc.GetVersion() {
+			return topic, nil
+		}
+	}
+	family, err := r.tableDesc.FindFamilyByID(r.familyID)
+	if err != nil {
+		return noTopic{}, err
+	}
+	for _, s := range c.details.TargetSpecifications {
+		if s.TableID == r.tableDesc.GetID() && (s.FamilyName == "" || s.FamilyName == family.Name) {
+			topic, err := makeTopicDescriptorFromSpecForRow(s, r)
+			if err != nil {
+				return noTopic{}, err
+			}
+			c.topicDescriptorCache[topic.GetTopicIdentifier()] = topic
+			return topic, nil
+		}
+	}
+	return noTopic{}, errors.AssertionFailedf("no TargetSpecification for row %v", r)
+}
 
 // ConsumeEvent implements kvEventConsumer interface
 func (c *kvEventToRowConsumer) ConsumeEvent(ctx context.Context, ev kvevent.Event) error {
@@ -734,6 +887,17 @@ func (c *kvEventToRowConsumer) ConsumeEvent(ctx context.Context, ev kvevent.Even
 			return nil
 		}
 		return err
+	}
+
+	topic, err := c.topicForRow(r)
+	if err != nil {
+		return err
+	}
+	if c.topicNamer != nil {
+		r.topic, err = c.topicNamer.Name(topic)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Ensure that r updates are strictly newer than the least resolved timestamp
@@ -765,7 +929,7 @@ func (c *kvEventToRowConsumer) ConsumeEvent(ctx context.Context, ev kvevent.Even
 		}
 	}
 	if err := c.sink.EmitRow(
-		ctx, tableDescriptorTopic{r.tableDesc},
+		ctx, topic,
 		keyCopy, valueCopy, r.updated, r.mvccTimestamp, ev.DetachAlloc(),
 	); err != nil {
 		return err
@@ -903,22 +1067,6 @@ var _ kvEventConsumer = &nativeKVConsumer{}
 
 func newNativeKVConsumer(sink Sink) kvEventConsumer {
 	return &nativeKVConsumer{sink: sink}
-}
-
-type noTopic struct{}
-
-var _ TopicDescriptor = &noTopic{}
-
-func (n noTopic) GetName() string {
-	return ""
-}
-
-func (n noTopic) GetID() descpb.ID {
-	return 0
-}
-
-func (n noTopic) GetVersion() descpb.DescriptorVersion {
-	return 0
 }
 
 // ConsumeEvent implements kvEventConsumer interface.

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -650,6 +650,14 @@ func validateSink(
 		return err
 	}
 	if sink, ok := canarySink.(SinkWithTopics); ok {
+		_, resolved := opts[changefeedbase.OptResolvedTimestamps]
+		_, split := opts[changefeedbase.OptSplitColumnFamilies]
+		if resolved && split {
+			return errors.Newf("Resolved timestamps are not currently supported with %s for this sink"+
+				" as the set of topics to fan them out to may change. Instead, use TABLE tablename FAMILY familyname"+
+				" to specify individual families to watch.", changefeedbase.OptSplitColumnFamilies)
+		}
+
 		topics := sink.Topics()
 		for _, topic := range topics {
 			p.BufferClientNotice(ctx, pgnotice.Newf(`changefeed will emit to topic %s`, topic))

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -518,12 +518,13 @@ func TestChangefeedFullTableName(t *testing.T) {
 			assertPayloads(t, foo, []string{`d.public.foo: [1]->{"after": {"a": 1, "b": "a"}}`})
 		})
 	}
-	// TODO(zinger): Plumb this option through to all encoders so it works in sinkless mode
-	// t.Run(`sinkless`, sinklessTest(testFn))
+
+	t.Run(`cloudstorage`, cloudStorageTest(testFn))
+	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
 	t.Run(`kafka`, kafkaTest(testFn))
 	t.Run(`webhook`, webhookTest(testFn))
-	// t.Run(`pubsub`, pubsubTest(testFn))
+	t.Run(`pubsub`, pubsubTest(testFn))
 }
 
 func TestChangefeedMultiTable(t *testing.T) {
@@ -1773,7 +1774,7 @@ func TestChangefeedEachColumnFamily(t *testing.T) {
 		sqlDB := sqlutils.MakeSQLRunner(db)
 
 		// Table with 2 column families.
-		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING, c STRING, FAMILY (a,b), FAMILY (c))`)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING, c STRING, FAMILY most (a,b), FAMILY only_c (c))`)
 		sqlDB.Exec(t, `INSERT INTO foo values (0, 'dog', 'cat')`)
 
 		// Must specify WITH split_column_families
@@ -1783,34 +1784,38 @@ func TestChangefeedEachColumnFamily(t *testing.T) {
 		defer closeFeed(t, foo)
 
 		assertPayloads(t, foo, []string{
-			`foo: [0]->{"after": {"a": 0, "b": "dog"}}`,
-			`foo: [0]->{"after": {"c": "cat"}}`,
+			`foo.most: [0]->{"after": {"a": 0, "b": "dog"}}`,
+			`foo.only_c: [0]->{"after": {"c": "cat"}}`,
 		})
 
 		// No messages for unaffected column families.
 		sqlDB.Exec(t, `UPDATE foo SET c='lion' WHERE a=0`)
 		sqlDB.Exec(t, `UPDATE foo SET c='tiger' WHERE a=0`)
 		assertPayloads(t, foo, []string{
-			`foo: [0]->{"after": {"c": "lion"}}`,
-			`foo: [0]->{"after": {"c": "tiger"}}`,
+			`foo.only_c: [0]->{"after": {"c": "lion"}}`,
+			`foo.only_c: [0]->{"after": {"c": "tiger"}}`,
 		})
 
 		// No messages on insert for families where no non-null values were set.
 		sqlDB.Exec(t, `INSERT INTO foo values (1, 'puppy', null)`)
 		sqlDB.Exec(t, `INSERT INTO foo values (2, null, 'kitten')`)
 		assertPayloads(t, foo, []string{
-			`foo: [1]->{"after": {"a": 1, "b": "puppy"}}`,
-			`foo: [2]->{"after": {"a": 2, "b": null}}`,
-			`foo: [2]->{"after": {"c": "kitten"}}`,
+			`foo.most: [1]->{"after": {"a": 1, "b": "puppy"}}`,
+			`foo.most: [2]->{"after": {"a": 2, "b": null}}`,
+			`foo.only_c: [2]->{"after": {"c": "kitten"}}`,
 		})
 
+		sqlDB.Exec(t, `DELETE FROM foo WHERE a>0`)
+
 		// Deletes send a message for each column family.
-		fooWithDiff := feed(t, f, `CREATE CHANGEFEED FOR foo WITH split_column_families, diff, no_initial_scan, resolved='1s'`)
+		fooWithDiff := feed(t, f, `CREATE CHANGEFEED FOR foo WITH split_column_families, diff`)
 		defer closeFeed(t, fooWithDiff)
 		sqlDB.Exec(t, `DELETE FROM foo WHERE a=0`)
 		assertPayloads(t, fooWithDiff, []string{
-			`foo: [0]->{"after": null, "before": {"a": 0, "b": "dog"}}`,
-			`foo: [0]->{"after": null, "before": {"c": "tiger"}}`,
+			`foo.most: [0]->{"after": {"a": 0, "b": "dog"}, "before": null}`,
+			`foo.only_c: [0]->{"after": {"c": "tiger"}, "before": null}`,
+			`foo.most: [0]->{"after": null, "before": {"a": 0, "b": "dog"}}`,
+			`foo.only_c: [0]->{"after": null, "before": {"c": "tiger"}}`,
 		})
 
 		// Table with a second column family added after the changefeed starts.
@@ -1830,7 +1835,10 @@ func TestChangefeedEachColumnFamily(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
+	t.Run(`cloudstorage`, cloudStorageTest(testFn))
 	t.Run(`kafka`, kafkaTest(testFn))
+	t.Run(`webhook`, webhookTest(testFn))
+	t.Run(`pubsub`, pubsubTest(testFn))
 }
 
 func TestChangefeedSingleColumnFamily(t *testing.T) {
@@ -1851,24 +1859,24 @@ func TestChangefeedSingleColumnFamily(t *testing.T) {
 		fooMost := feed(t, f, `CREATE CHANGEFEED FOR foo FAMILY most`)
 		defer closeFeed(t, fooMost)
 		assertPayloads(t, fooMost, []string{
-			`foo: [0]->{"after": {"a": 0, "b": "dog"}}`,
-			`foo: [1]->{"after": {"a": 1, "b": "dollar"}}`,
+			`foo.most: [0]->{"after": {"a": 0, "b": "dog"}}`,
+			`foo.most: [1]->{"after": {"a": 1, "b": "dollar"}}`,
 		})
 
 		fooRest := feed(t, f, `CREATE CHANGEFEED FOR foo FAMILY rest`)
 		defer closeFeed(t, fooRest)
 		assertPayloads(t, fooRest, []string{
-			`foo: [0]->{"after": {"c": "cat"}}`,
-			`foo: [1]->{"after": {"c": "cent"}}`,
+			`foo.rest: [0]->{"after": {"c": "cat"}}`,
+			`foo.rest: [1]->{"after": {"c": "cent"}}`,
 		})
 
 		fooBoth := feed(t, f, `CREATE CHANGEFEED FOR foo FAMILY rest, foo FAMILY most`)
 		defer closeFeed(t, fooBoth)
 		assertPayloads(t, fooBoth, []string{
-			`foo: [0]->{"after": {"a": 0, "b": "dog"}}`,
-			`foo: [0]->{"after": {"c": "cat"}}`,
-			`foo: [1]->{"after": {"a": 1, "b": "dollar"}}`,
-			`foo: [1]->{"after": {"c": "cent"}}`,
+			`foo.most: [0]->{"after": {"a": 0, "b": "dog"}}`,
+			`foo.rest: [0]->{"after": {"c": "cat"}}`,
+			`foo.most: [1]->{"after": {"a": 1, "b": "dollar"}}`,
+			`foo.rest: [1]->{"after": {"c": "cent"}}`,
 		})
 	}
 
@@ -1896,19 +1904,19 @@ func TestChangefeedSingleColumnFamilySchemaChanges(t *testing.T) {
 		fooMost := feed(t, f, `CREATE CHANGEFEED FOR foo FAMILY most`)
 		defer closeFeed(t, fooMost)
 		assertPayloads(t, fooMost, []string{
-			`foo: [0]->{"after": {"a": 0, "b": "dog"}}`,
+			`foo.most: [0]->{"after": {"a": 0, "b": "dog"}}`,
 		})
 
 		fooRest := feed(t, f, `CREATE CHANGEFEED FOR foo FAMILY rest`)
 		defer closeFeed(t, fooRest)
 		assertPayloads(t, fooRest, []string{
-			`foo: [0]->{"after": {"c": "cat"}}`,
+			`foo.rest: [0]->{"after": {"c": "cat"}}`,
 		})
 
 		// Add a column to an existing family, it shows up in the feed for that family
 		sqlDB.Exec(t, `ALTER TABLE foo ADD COLUMN more int DEFAULT 11 FAMILY most`)
 		assertPayloads(t, fooMost, []string{
-			`foo: [0]->{"after": {"a": 0, "b": "dog", "more": 11}}`,
+			`foo.most: [0]->{"after": {"a": 0, "b": "dog", "more": 11}}`,
 		})
 
 		// Removing all columns in a watched family fails the feed
@@ -1936,14 +1944,14 @@ func TestChangefeedEachColumnFamilySchemaChanges(t *testing.T) {
 		foo := feed(t, f, `CREATE CHANGEFEED FOR foo WITH split_column_families`)
 		defer closeFeed(t, foo)
 		assertPayloads(t, foo, []string{
-			`foo: [0]->{"after": {"a": 0, "b": "dog"}}`,
-			`foo: [0]->{"after": {"c": "cat"}}`,
+			`foo.f1: [0]->{"after": {"a": 0, "b": "dog"}}`,
+			`foo.f2: [0]->{"after": {"c": "cat"}}`,
 		})
 
 		// Add a column to an existing family
 		sqlDB.Exec(t, `ALTER TABLE foo ADD COLUMN d string DEFAULT 'hi' FAMILY f2`)
 		assertPayloads(t, foo, []string{
-			`foo: [0]->{"after": {"c": "cat", "d": "hi"}}`,
+			`foo.f2: [0]->{"after": {"c": "cat", "d": "hi"}}`,
 		})
 
 		// Add a column to a new family.
@@ -1953,7 +1961,7 @@ func TestChangefeedEachColumnFamilySchemaChanges(t *testing.T) {
 		sqlDB.Exec(t, `ALTER TABLE foo ADD COLUMN e string CREATE FAMILY f3`)
 		sqlDB.Exec(t, `UPDATE foo SET e='hello' WHERE a=0`)
 		assertPayloads(t, foo, []string{
-			`foo: [0]->{"after": {"e": "hello"}}`,
+			`foo.f3: [0]->{"after": {"e": "hello"}}`,
 		})
 
 	}
@@ -1975,8 +1983,8 @@ func TestChangefeedColumnFamilyAvro(t *testing.T) {
 		foo := feed(t, f, `CREATE CHANGEFEED FOR foo WITH split_column_families, format=avro`)
 		defer closeFeed(t, foo)
 		assertPayloads(t, foo, []string{
-			`foo: {"a":{"long":0}}->{"after":{"foomost":{"a":{"long":0},"b":{"string":"dog"}}}}`,
-			`foo: {"a":{"long":0}}->{"after":{"foojustc":{"c":{"string":"cat"}}}}`,
+			`foo.most: {"a":{"long":0}}->{"after":{"foo_u002e_most":{"a":{"long":0},"b":{"string":"dog"}}}}`,
+			`foo.justc: {"a":{"long":0}}->{"after":{"foo_u002e_justc":{"c":{"string":"cat"}}}}`,
 		})
 
 	}
@@ -2715,47 +2723,6 @@ func TestChangefeedStoredComputedColumn(t *testing.T) {
 	t.Run(`kafka`, kafkaTest(testFn))
 	t.Run(`webhook`, webhookTest(testFn))
 	t.Run(`pubsub`, pubsubTest(testFn))
-}
-
-func TestChangefeedEachColumnFamilyVirtualColumns(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
-
-		sqlDB := sqlutils.MakeSQLRunner(db)
-
-		// Table with 2 column families.
-		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING, c STRING, FAMILY f1 (a,b), FAMILY f2 (c))`)
-		sqlDB.Exec(t, `INSERT INTO foo values (0, 'dog', 'cat')`)
-		foo := feed(t, f, `CREATE CHANGEFEED FOR foo WITH split_column_families`)
-		defer closeFeed(t, foo)
-		assertPayloads(t, foo, []string{
-			`foo: [0]->{"after": {"a": 0, "b": "dog"}}`,
-			`foo: [0]->{"after": {"c": "cat"}}`,
-		})
-
-		// Add a column to an existing family
-		sqlDB.Exec(t, `ALTER TABLE foo ADD COLUMN d string DEFAULT 'hi' FAMILY f2`)
-		assertPayloads(t, foo, []string{
-			`foo: [0]->{"after": {"c": "cat", "d": "hi"}}`,
-		})
-
-		// Add a column to a new family.
-		// Behavior here is a little wonky with default values in a way
-		// that's likely to change with declarative schema changer,
-		// so not asserting anything either way about that.
-		sqlDB.Exec(t, `ALTER TABLE foo ADD COLUMN e string CREATE FAMILY f3`)
-		sqlDB.Exec(t, `UPDATE foo SET e='hello' WHERE a=0`)
-		assertPayloads(t, foo, []string{
-			`foo: [0]->{"after": {"e": "hello"}}`,
-		})
-
-	}
-
-	t.Run(`sinkless`, sinklessTest(testFn))
-	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`kafka`, kafkaTest(testFn))
 }
 
 func TestChangefeedVirtualComputedColumn(t *testing.T) {

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -682,8 +682,8 @@ func TestAvroSchemaNaming(t *testing.T) {
 		sqlDB.Exec(t, `UPDATE movr.drivers SET vehicle_id = 1 WHERE id=1`)
 
 		assertPayloads(t, multiFamilyFeed, []string{
-			`drivers: {"id":{"long":1}}->{"after":{"driversprimary":{"id":{"long":1},"name":{"string":"Alice"}}}}`,
-			`drivers: {"id":{"long":1}}->{"after":{"driversvolatile":{"vehicle_id":{"long":1}}}}`,
+			`drivers.primary: {"id":{"long":1}}->{"after":{"drivers_u002e_primary":{"id":{"long":1},"name":{"string":"Alice"}}}}`,
+			`drivers.volatile: {"id":{"long":1}}->{"after":{"drivers_u002e_volatile":{"vehicle_id":{"long":1}}}}`,
 		})
 
 		assertRegisteredSubjects(t, foo.registry, []string{

--- a/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
+++ b/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
@@ -114,7 +114,7 @@ func TestShowChangefeedJobsBasic(t *testing.T) {
 			u, err := url.Parse(sinkURI)
 			require.NoError(t, err)
 			if u.Scheme == changefeedbase.SinkSchemeKafka {
-				require.Equal(t, "foo", out.topics, "Expected topics:%s but found format:%s", "foo", out.topics)
+				require.Equal(t, "foo", out.topics, "Expected topics:%s but found topics:%s", "foo", out.topics)
 			}
 		}
 		require.Equal(t, "{d.public.foo}", string(out.FullTableNames), "Expected fullTableNames:%s but found fullTableNames:%s", "{d.public.foo}", string(out.FullTableNames))

--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -283,6 +284,7 @@ type cloudStorageSink struct {
 	targetMaxFileSize int64
 	settings          *cluster.Settings
 	partitionFormat   string
+	topicNamer        *TopicNamer
 
 	ext          string
 	rowDelimiter []byte
@@ -347,6 +349,15 @@ func makeCloudStorageSink(
 	if err != nil {
 		return nil, err
 	}
+
+	// Using + rather than . here because some consumers may be relying on there being exactly
+	// one '.' in the filepath, and '+' shares with '-' the useful property of being
+	// lexicographically earlier than '.'.
+	tn, err := MakeTopicNamer([]jobspb.ChangefeedTargetSpecification{}, WithJoinByte('+'))
+	if err != nil {
+		return nil, err
+	}
+
 	s := &cloudStorageSink{
 		srcID:             srcID,
 		sinkID:            sinkID,
@@ -358,6 +369,7 @@ func makeCloudStorageSink(
 		// TODO(dan,ajwerner): Use the jobs framework's session ID once that's available.
 		jobSessionID: sessID,
 		metrics:      m,
+		topicNamer:   tn,
 	}
 
 	if partitionFormat := u.consumeParam(changefeedbase.SinkParamPartitionFormat); partitionFormat != "" {
@@ -415,7 +427,8 @@ func makeCloudStorageSink(
 func (s *cloudStorageSink) getOrCreateFile(
 	topic TopicDescriptor, eventMVCC hlc.Timestamp,
 ) *cloudStorageSinkFile {
-	key := cloudStorageSinkKey{topic.GetName(), int64(topic.GetVersion())}
+	name, _ := s.topicNamer.Name(topic)
+	key := cloudStorageSinkKey{name, int64(topic.GetVersion())}
 	if item := s.files.Get(key); item != nil {
 		f := item.(*cloudStorageSinkFile)
 		if eventMVCC.Less(f.oldestMVCC) {

--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
@@ -85,7 +84,7 @@ type kafkaSink struct {
 	kafkaCfg       *sarama.Config
 	client         kafkaClient
 	producer       sarama.AsyncProducer
-	topics         map[descpb.ID]string
+	topics         *TopicNamer
 
 	lastMetadataRefresh time.Time
 
@@ -217,9 +216,10 @@ func (s *kafkaSink) EmitRow(
 	updated, mvcc hlc.Timestamp,
 	alloc kvevent.Alloc,
 ) error {
-	topic, isKnownTopic := s.topics[topicDescr.GetID()]
-	if !isKnownTopic {
-		return errors.Errorf(`cannot emit to undeclared topic: %s`, topicDescr.GetName())
+
+	topic, err := s.topics.Name(topicDescr)
+	if err != nil {
+		return err
 	}
 
 	msg := &sarama.ProducerMessage{
@@ -246,17 +246,13 @@ func (s *kafkaSink) EmitResolvedTimestamp(
 	// actively working on stability. At the same time, revisit this tuning.
 	const metadataRefreshMinDuration = time.Minute
 	if timeutil.Since(s.lastMetadataRefresh) > metadataRefreshMinDuration {
-		topics := make([]string, 0, len(s.topics))
-		for _, topic := range s.topics {
-			topics = append(topics, topic)
-		}
-		if err := s.client.RefreshMetadata(topics...); err != nil {
+		if err := s.client.RefreshMetadata(s.topics.DisplayNamesSlice()...); err != nil {
 			return err
 		}
 		s.lastMetadataRefresh = timeutil.Now()
 	}
 
-	for _, topic := range s.topics {
+	return s.topics.Each(func(topic string) error {
 		payload, err := encoder.EncodeResolvedTimestamp(ctx, topic, resolved)
 		if err != nil {
 			return err
@@ -282,8 +278,8 @@ func (s *kafkaSink) EmitResolvedTimestamp(
 				return err
 			}
 		}
-	}
-	return nil
+		return nil
+	})
 }
 
 // Flush implements the Sink interface.
@@ -388,12 +384,10 @@ func (s *kafkaSink) workerLoop() {
 	}
 }
 
+// Topics gives the names of all topics that have been initialized
+// and will receive resolved timestamps.
 func (s *kafkaSink) Topics() []string {
-	var topics []string
-	for _, topic := range s.topics {
-		topics = append(topics, topic)
-	}
-	return topics
+	return s.topics.DisplayNamesSlice()
 }
 
 type changefeedPartitioner struct {
@@ -417,24 +411,6 @@ func (p *changefeedPartitioner) Partition(
 		return message.Partition, nil
 	}
 	return p.hash.Partition(message, numPartitions)
-}
-
-func makeTopicsMap(
-	prefix string, name string, targets []jobspb.ChangefeedTargetSpecification,
-) map[descpb.ID]string {
-	topics := make(map[descpb.ID]string)
-	useSingleName := name != ""
-	if useSingleName {
-		name = prefix + SQLNameToKafkaName(name)
-	}
-	for _, t := range targets {
-		if useSingleName {
-			topics[t.TableID] = name
-		} else {
-			topics[t.TableID] = prefix + SQLNameToKafkaName(t.StatementTimeName)
-		}
-	}
-	return topics
 }
 
 type jsonDuration time.Duration
@@ -669,12 +645,20 @@ func makeKafkaSink(
 		return nil, err
 	}
 
+	topics, err := MakeTopicNamer(
+		targets,
+		WithPrefix(kafkaTopicPrefix), WithSingleName(kafkaTopicName), WithSanitizeFn(SQLNameToKafkaName))
+
+	if err != nil {
+		return nil, err
+	}
+
 	sink := &kafkaSink{
 		ctx:            ctx,
 		kafkaCfg:       config,
 		bootstrapAddrs: u.Host,
-		topics:         makeTopicsMap(kafkaTopicPrefix, kafkaTopicName, targets),
 		metrics:        m,
+		topics:         topics,
 	}
 
 	if unknownParams := u.remainingQueryParams(); len(unknownParams) > 0 {

--- a/pkg/ccl/changefeedccl/sink_pubsub.go
+++ b/pkg/ccl/changefeedccl/sink_pubsub.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
@@ -44,12 +43,11 @@ func isPubsubSink(u *url.URL) bool {
 }
 
 type pubsubClient interface {
-	openTopics() error
+	init() error
 	closeTopics()
 	flushTopics()
-	sendMessage([]byte, descpb.ID, string) error
-	sendMessageToAllTopics([]byte) error
-	getTopicName(descpb.ID) string
+	sendMessage(content []byte, topic string, key string) error
+	sendMessageToAllTopics(content []byte) error
 }
 
 // payload struct is sent to the sink
@@ -64,22 +62,16 @@ type pubsubMessage struct {
 	alloc   kvevent.Alloc
 	message payload
 	isFlush bool
-	topicID descpb.ID
 }
 
 type gcpPubsubClient struct {
-	client        *pubsub.Client
-	topics        map[descpb.ID]*topicStruct
-	ctx           context.Context
-	projectID     string
-	region        string
-	url           sinkURL
-	withTopicName string
-}
-
-type topicStruct struct {
-	topicName   string
-	topicClient *pubsub.Topic
+	client     *pubsub.Client
+	topics     map[string]*pubsub.Topic
+	ctx        context.Context
+	projectID  string
+	region     string
+	topicNamer *TopicNamer
+	url        sinkURL
 }
 
 type pubsubSink struct {
@@ -97,7 +89,8 @@ type pubsubSink struct {
 	// errChan is written to indicate an error while sending message.
 	errChan chan error
 
-	client pubsubClient
+	client     pubsubClient
+	topicNamer *TopicNamer
 }
 
 // TODO: unify gcp credentials code with gcp cloud storage credentials code
@@ -179,15 +172,19 @@ func MakePubsubSink(
 		if region == "" {
 			return nil, errors.New("region query parameter not found")
 		}
+		tn, err := MakeTopicNamer(targets, WithSingleName(pubsubTopicName))
+		if err != nil {
+			return nil, err
+		}
 		g := &gcpPubsubClient{
-			topics:        p.getTopicsMap(targets, pubsubTopicName),
-			ctx:           ctx,
-			projectID:     projectID,
-			region:        gcpEndpointForRegion(region),
-			url:           pubsubURL,
-			withTopicName: pubsubTopicName,
+			topicNamer: tn,
+			ctx:        ctx,
+			projectID:  projectID,
+			region:     gcpEndpointForRegion(region),
+			url:        pubsubURL,
 		}
 		p.client = g
+		p.topicNamer = tn
 		return p, nil
 	default:
 		return nil, errors.Errorf("unknown scheme: %s", u.Scheme)
@@ -196,8 +193,7 @@ func MakePubsubSink(
 
 func (p *pubsubSink) Dial() error {
 	p.setupWorkers()
-	err := p.client.openTopics()
-	return err
+	return p.client.init()
 }
 
 // EmitRow pushes a message to event channel where it is consumed by workers
@@ -209,12 +205,15 @@ func (p *pubsubSink) EmitRow(
 	mvcc hlc.Timestamp,
 	alloc kvevent.Alloc,
 ) error {
+	topicName, err := p.topicNamer.Name(topic)
+	if err != nil {
+		return err
+	}
 	m := pubsubMessage{
-		alloc: alloc, isFlush: false, topicID: topic.GetID(), message: payload{
+		alloc: alloc, isFlush: false, message: payload{
 			Key:   key,
 			Value: value,
-			// we use getTopicName because of the option use full topic name which is not exposed in topic.GetName()
-			Topic: topic.GetName(),
+			Topic: topicName,
 		}}
 
 	// calculate index by hashing key
@@ -290,29 +289,22 @@ func (p *pubsubSink) Close() error {
 	return nil
 }
 
-func (p *gcpPubsubClient) getTopicClient(topicID descpb.ID) (*pubsub.Topic, error) {
-	if topicStruct, ok := p.topics[topicID]; ok {
-		return topicStruct.topicClient, nil
-	}
-	return nil, errors.New("topic client does not exist")
+// Topics gives the names of all topics that have been initialized
+// and will receive resolved timestamps.
+func (p *pubsubSink) Topics() []string {
+	return p.topicNamer.DisplayNamesSlice()
 }
 
-func (p *pubsubSink) getTopicsMap(
-	targets []jobspb.ChangefeedTargetSpecification, pubsubTopicName string,
-) map[descpb.ID]*topicStruct {
-	topics := make(map[descpb.ID]*topicStruct)
-
-	//creates a topic for each target
-	for _, target := range targets {
-		var topicName string
-		if pubsubTopicName != "" {
-			topicName = pubsubTopicName
-		} else {
-			topicName = target.StatementTimeName
-		}
-		topics[target.TableID] = &topicStruct{topicName: topicName}
+func (p *gcpPubsubClient) getTopicClient(name string) (*pubsub.Topic, error) {
+	if topic, ok := p.topics[name]; ok {
+		return topic, nil
 	}
-	return topics
+	topic, err := p.openTopic(name)
+	if err != nil {
+		return nil, err
+	}
+	p.topics[name] = topic
+	return topic, nil
 }
 
 // setupWorkers sets up the channels used by the sink and starts a goroutine for every worker
@@ -354,7 +346,7 @@ func (p *pubsubSink) workerLoop(workerIndex int) {
 			if err != nil {
 				p.exitWorkersWithError(err)
 			}
-			err = p.client.sendMessage(b, msg.topicID, string(msg.message.Key))
+			err = p.client.sendMessage(b, msg.message.Topic, string(msg.message.Key))
 			if err != nil {
 				p.exitWorkersWithError(err)
 			}
@@ -412,8 +404,8 @@ func (p *pubsubSink) flushWorkers() error {
 	}
 }
 
-// Dial connects to gcp client and opens a topic
-func (p *gcpPubsubClient) openTopics() error {
+// init opens a gcp client
+func (p *gcpPubsubClient) init() error {
 	var client *pubsub.Client
 	var err error
 
@@ -436,14 +428,10 @@ func (p *gcpPubsubClient) openTopics() error {
 		return errors.Wrap(err, "opening client")
 	}
 	p.client = client
+	p.topics = make(map[string]*pubsub.Topic)
 
-	return p.forEachTopic(func(id descpb.ID, t *topicStruct) error {
-		t.topicClient, err = p.openTopic(t.topicName)
-		if err != nil {
-			return err
-		}
-		return nil
-	})
+	return nil
+
 }
 
 // openTopic optimistically creates the topic
@@ -461,15 +449,15 @@ func (p *gcpPubsubClient) openTopic(topicName string) (*pubsub.Topic, error) {
 }
 
 func (p *gcpPubsubClient) closeTopics() {
-	_ = p.forEachTopic(func(id descpb.ID, t *topicStruct) error {
-		t.topicClient.Stop()
+	_ = p.forEachTopic(func(_ string, t *pubsub.Topic) error {
+		t.Stop()
 		return nil
 	})
 }
 
 // sendMessage sends a message to the topic
-func (p *gcpPubsubClient) sendMessage(m []byte, topicID descpb.ID, key string) error {
-	t, err := p.getTopicClient(topicID)
+func (p *gcpPubsubClient) sendMessage(m []byte, topic string, key string) error {
+	t, err := p.getTopicClient(topic)
 	if err != nil {
 		return err
 	}
@@ -489,8 +477,11 @@ func (p *gcpPubsubClient) sendMessage(m []byte, topicID descpb.ID, key string) e
 }
 
 func (p *gcpPubsubClient) sendMessageToAllTopics(m []byte) error {
-	return p.forEachTopic(func(ID descpb.ID, _ *topicStruct) error {
-		err := p.sendMessage(m, ID, "")
+	return p.forEachTopic(func(_ string, t *pubsub.Topic) error {
+		res := t.Publish(p.ctx, &pubsub.Message{
+			Data: m,
+		})
+		_, err := res.Get(p.ctx)
 		if err != nil {
 			return errors.Wrap(err, "emitting resolved timestamp")
 		}
@@ -498,42 +489,21 @@ func (p *gcpPubsubClient) sendMessageToAllTopics(m []byte) error {
 	})
 }
 
-func (p *gcpPubsubClient) getTopicName(topicID descpb.ID) string {
-	if topicStruct, ok := p.topics[topicID]; ok {
-		return topicStruct.topicName
-	}
-	return ""
-}
-
-// getAllTopics return a map of the topics. If withTopicName is set
-// then it will just return a map of the first key/val
-func (p *gcpPubsubClient) getAllTopics() map[descpb.ID]*topicStruct {
-	if p.withTopicName != "" {
-		for ID, t := range p.topics {
-			m := make(map[descpb.ID]*topicStruct)
-			m[ID] = t
-			return m
-		}
-	}
-	return p.topics
-}
-
 func (p *gcpPubsubClient) flushTopics() {
-	_ = p.forEachTopic(func(_ descpb.ID, t *topicStruct) error {
-		t.topicClient.Flush()
+	_ = p.forEachTopic(func(_ string, t *pubsub.Topic) error {
+		t.Flush()
 		return nil
 	})
 }
 
-func (p *gcpPubsubClient) forEachTopic(f func(descpb.ID, *topicStruct) error) error {
-	topics := p.getAllTopics()
-	for topicID, topicStruct := range topics {
-		err := f(topicID, topicStruct)
+func (p *gcpPubsubClient) forEachTopic(f func(name string, topicClient *pubsub.Topic) error) error {
+	return p.topicNamer.Each(func(n string) error {
+		t, err := p.getTopicClient(n)
 		if err != nil {
 			return err
 		}
-	}
-	return nil
+		return f(n, t)
+	})
 }
 
 // Generate the cloud endpoint that's specific to a region (e.g. us-east1).

--- a/pkg/ccl/changefeedccl/sink_sql.go
+++ b/pkg/ccl/changefeedccl/sink_sql.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -55,16 +54,15 @@ const (
 type sqlSink struct {
 	db *gosql.DB
 
-	uri       string
-	tableName string
-	topics    map[string]struct{}
-	hasher    hash.Hash32
+	uri        string
+	tableName  string
+	topicNamer *TopicNamer
+	hasher     hash.Hash32
 
 	rowBuf  []interface{}
 	scratch bufalloc.ByteAllocator
 
-	targetNames map[descpb.ID]string
-	metrics     *sliMetrics
+	metrics *sliMetrics
 }
 
 // TODO(dan): Make tableName configurable or based on the job ID or
@@ -82,11 +80,9 @@ func makeSQLSink(
 		return nil, errors.Errorf(`must specify database`)
 	}
 
-	topics := make(map[string]struct{})
-	targetNames := make(map[descpb.ID]string)
-	for _, t := range targets {
-		topics[t.StatementTimeName] = struct{}{}
-		targetNames[t.TableID] = t.StatementTimeName
+	topicNamer, err := MakeTopicNamer(targets)
+	if err != nil {
+		return nil, err
 	}
 
 	uri := u.String()
@@ -101,12 +97,11 @@ func makeSQLSink(
 	}
 
 	return &sqlSink{
-		uri:         uri,
-		tableName:   tableName,
-		topics:      topics,
-		hasher:      fnv.New32a(),
-		targetNames: targetNames,
-		metrics:     m,
+		uri:        uri,
+		tableName:  tableName,
+		topicNamer: topicNamer,
+		hasher:     fnv.New32a(),
+		metrics:    m,
 	}, nil
 }
 
@@ -134,9 +129,9 @@ func (s *sqlSink) EmitRow(
 	defer alloc.Release(ctx)
 	defer s.metrics.recordOneMessage()(mvcc, len(key)+len(value), sinkDoesNotCompress)
 
-	topic := s.targetNames[topicDescr.GetID()]
-	if _, ok := s.topics[topic]; !ok {
-		return errors.Errorf(`cannot emit to undeclared topic: %s`, topic)
+	topic, err := s.topicNamer.Name(topicDescr)
+	if err != nil {
+		return err
 	}
 
 	// Hashing logic copied from sarama.HashPartitioner.
@@ -160,7 +155,7 @@ func (s *sqlSink) EmitResolvedTimestamp(
 	defer s.metrics.recordResolvedCallback()()
 
 	var noKey, noValue []byte
-	for topic := range s.topics {
+	return s.topicNamer.Each(func(topic string) error {
 		payload, err := encoder.EncodeResolvedTimestamp(ctx, topic, resolved)
 		if err != nil {
 			return err
@@ -171,8 +166,14 @@ func (s *sqlSink) EmitResolvedTimestamp(
 				return err
 			}
 		}
-	}
-	return nil
+		return nil
+	})
+}
+
+// Topics gives the names of all topics that have been initialized
+// and will receive resolved timestamps.
+func (s *sqlSink) Topics() []string {
+	return s.topicNamer.DisplayNamesSlice()
 }
 
 func (s *sqlSink) emit(

--- a/pkg/ccl/changefeedccl/topic.go
+++ b/pkg/ccl/changefeedccl/topic.go
@@ -1,0 +1,224 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/errors"
+)
+
+// TopicDescriptor describes topic emitted by the sink.
+type TopicDescriptor interface {
+	// GetNameComponents returns the names that should go into any string-based topic identifier.
+	// If the topic is a table, this will be the statement time name of the table, fully-qualified
+	// if that option was set when creating the changefeed.
+	GetNameComponents() []string
+	// GetTopicIdentifier returns a struct suitable for use as a unique key in a map containing
+	// all topics in a feed.
+	GetTopicIdentifier() TopicIdentifier
+	// GetVersion returns topic version.
+	// For example, the underlying data source (e.g. table) may change, in which case
+	// we may want to emit same Name/ID, but a different version number.
+	GetVersion() descpb.DescriptorVersion
+	// GetTargetSpecification() returns the target specification for this topic.
+	// Currently this is assumed to be 1:1, or to be many: 1 for EachColumnFamily topics.
+	GetTargetSpecification() jobspb.ChangefeedTargetSpecification
+}
+
+// TopicIdentifier is a minimal set of fields that
+// uniquely identifies a topic.
+type TopicIdentifier struct {
+	TableID  descpb.ID
+	FamilyID descpb.FamilyID
+}
+
+// TopicNamer generates and caches the strings used as topic keys by sinks,
+// using target specifications, options, and sink-specific string manipulation.
+type TopicNamer struct {
+	join       byte
+	prefix     string
+	singleName string
+	sanitize   func(string) string
+
+	// DisplayNames are initialized once from specs and may contain placeholder strings.
+	DisplayNames map[jobspb.ChangefeedTargetSpecification]string
+
+	// FullNames are generated whenever Name() is actually called (usually during sink.EmitRow).
+	// They do not contain placeholder strings.
+	FullNames map[TopicIdentifier]string
+
+	sliceCache []string
+}
+
+// TopicNameOption is an optional argument to MakeTopicNamer.
+type TopicNameOption interface {
+	set(*TopicNamer)
+}
+
+type optJoinByte byte
+
+func (o optJoinByte) set(tn *TopicNamer) {
+	tn.join = byte(o)
+}
+
+// WithJoinByte overrides the default '.' separator between a table and family name.
+func WithJoinByte(b byte) TopicNameOption {
+	return optJoinByte(b)
+}
+
+type optPrefix string
+
+func (o optPrefix) set(tn *TopicNamer) {
+	tn.prefix = string(o)
+}
+
+// WithPrefix defines a prefix string for all topics named by this TopicNamer.
+func WithPrefix(s string) TopicNameOption {
+	return optPrefix(s)
+}
+
+type optSingleName string
+
+func (o optSingleName) set(tn *TopicNamer) {
+	tn.singleName = string(o)
+}
+
+// WithSingleName causes all topics named by this TopicNamer to be the same,
+// overriding things like the table name but not options like WithPrefix.
+func WithSingleName(s string) TopicNameOption {
+	return optSingleName(s)
+}
+
+type optSanitize func(string) string
+
+func (o optSanitize) set(tn *TopicNamer) {
+	tn.sanitize = o
+}
+
+// WithSanitizeFn defines a post-processor for all topic names.
+func WithSanitizeFn(fn func(string) string) TopicNameOption {
+	return optSanitize(fn)
+}
+
+// MakeTopicNamer creates a TopicNamer.
+// specs are used to populate DisplayNames and the values iterated over in Each.
+// Add options using WithJoinByte, WithPrefix, WithSingleName, and/or WithSanitizeFn.
+func MakeTopicNamer(
+	specs []jobspb.ChangefeedTargetSpecification, opts ...TopicNameOption,
+) (*TopicNamer, error) {
+	tn := &TopicNamer{
+		join:         '.',
+		DisplayNames: make(map[jobspb.ChangefeedTargetSpecification]string, len(specs)),
+		FullNames:    make(map[TopicIdentifier]string),
+	}
+	for _, opt := range opts {
+		opt.set(tn)
+	}
+	for _, s := range specs {
+		name, err := tn.makeDisplayName(s)
+		if err != nil {
+			return nil, err
+		}
+		tn.DisplayNames[s] = name
+	}
+
+	return tn, nil
+
+}
+
+const familyPlaceholder = "{family}"
+
+// Name generates (with caching) a sink's topic identifier string.
+func (tn *TopicNamer) Name(td TopicDescriptor) (string, error) {
+	if name, ok := tn.FullNames[td.GetTopicIdentifier()]; ok {
+		return name, nil
+	}
+	name, err := tn.makeName(td.GetTargetSpecification(), td)
+	tn.FullNames[td.GetTopicIdentifier()] = name
+	return name, err
+}
+
+// DisplayNamesSlice gives all topics that are going to be emitted to,
+// suitable for displaying to the user on feed creation.
+func (tn *TopicNamer) DisplayNamesSlice() []string {
+	if len(tn.sliceCache) > 0 {
+		return tn.sliceCache
+	}
+	for _, n := range tn.DisplayNames {
+		tn.sliceCache = append(tn.sliceCache, n)
+		if tn.singleName != "" {
+			return tn.sliceCache
+		}
+	}
+	return tn.sliceCache
+}
+
+// Each is a convenience method that iterates a function over DisplayNamesSlice.
+func (tn *TopicNamer) Each(fn func(string) error) error {
+	for _, name := range tn.DisplayNames {
+		err := fn(name)
+		if tn.singleName != "" || err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// A nil topic descriptor means we're building solely from the spec
+// and should use placeholders if necessary. Only necessary in the
+// EACH_FAMILY case as in the COLUMN_FAMILY case we know the name from
+// the spec.
+func (tn *TopicNamer) makeName(
+	s jobspb.ChangefeedTargetSpecification, td TopicDescriptor,
+) (string, error) {
+	switch s.Type {
+	case jobspb.ChangefeedTargetSpecification_PRIMARY_FAMILY_ONLY:
+		return tn.nameFromComponents(s.StatementTimeName), nil
+	case jobspb.ChangefeedTargetSpecification_COLUMN_FAMILY:
+		return tn.nameFromComponents(s.StatementTimeName, s.FamilyName), nil
+	case jobspb.ChangefeedTargetSpecification_EACH_FAMILY:
+		if td == nil {
+			return tn.nameFromComponents(s.StatementTimeName, familyPlaceholder), nil
+		}
+		return tn.nameFromComponents(td.GetNameComponents()...), nil
+	default:
+		return "", errors.AssertionFailedf("unrecognized type %s", s.Type)
+	}
+}
+
+func (tn *TopicNamer) makeDisplayName(s jobspb.ChangefeedTargetSpecification) (string, error) {
+	return tn.makeName(s, nil /* no topic descriptor yet, use placeholders if needed */)
+}
+
+func (tn *TopicNamer) nameFromComponents(components ...string) string {
+	// Use strings.Builder rather than strings.Join because the join
+	// character isn't used with the prefix, so we save a string copy this way.
+	var b strings.Builder
+	b.WriteString(tn.prefix)
+	if tn.singleName != "" {
+		b.WriteString(tn.singleName)
+	} else {
+		for i, c := range components {
+			if i > 0 {
+				b.WriteByte(tn.join)
+			}
+			b.WriteString(c)
+		}
+	}
+	str := b.String()
+
+	if tn.sanitize != nil {
+		return tn.sanitize(str)
+	}
+
+	return str
+}


### PR DESCRIPTION
This change necessitated touching every sink, which was making me
cranky, so this commit refactors to pull topic name generation
out of sink and encoder code and into a new topic.go file.
The goal here is that when we add another target type, sinks won't
need to know about it.

As a side effect, this also addresses an old TODO to implement
full_table_name on all sinks. The other options that affect topic
name generation logic are all at the sink level, so they haven't
moved to global application by default, but it'd be easy to do.

One interesting consequence of having different topics per family
is that we lose the invariant enforced by some sinks that no new
topics get created after initialization. For split_column_families,
a topic is now created "lazily" when emitting to it. The topics shown
in e.g. SHOW CHANGEFEED JOB will in the case of split_column_families
be placeholders. A topic will display as foo.{family} when events
for foo will actually be emitted to foo.primary, foo.family2, etc.
For now, in Kafka, PubSub and SqlSink I've disallowed sending resolved
 timestamps with split_column_families since the change frontier
 doesn't have the full set of topics to emit them to. This is a solveable
problem but not trivial because of schema changes.

Arguably this ship already sailed with ALTER CHANGEFEED, but it
still seems worth calling out, as we could still special-case back
in the old behavior if there's still a need for it.

Release note (enterprise change): Changefeed messages for tables with multiple column families will append the family name to the table name in the default topic. For example, `CREATE CHANGEFEED FOR TABLE foo, TABLE bar FAMILY primary` will emit to the topics "foo" and "bar.primary". A changefeed created with the `split_column_families` option will create new topics if new families are added to a watched table that already had multiple column families. In cloud storage sinks such as s3, the filename will include the family separated by a dash (e.g. "bar-primary"). The full_table_name option is now supported for all sinks.