### PR TITLE
colexec: shuffle hash joiner unit test cases

### DIFF
--- a/pkg/sql/colexec/crossjoiner_test.go
+++ b/pkg/sql/colexec/crossjoiner_test.go
@@ -388,7 +388,7 @@ func TestCrossJoiner(t *testing.T) {
 		for _, tc := range getCJTestCases() {
 			for _, tc := range tc.mutateTypes() {
 				log.Infof(ctx, "spillForced=%t", spillForced)
-				runHashJoinTestCase(t, tc, func(sources []colexecop.Operator) (colexecop.Operator, error) {
+				runHashJoinTestCase(t, tc, nil /* rng */, func(sources []colexecop.Operator) (colexecop.Operator, error) {
 					spec := createSpecForHashJoiner(tc)
 					args := &colexecargs.NewColOperatorArgs{
 						Spec:                spec,

--- a/pkg/sql/colexec/external_hash_joiner_test.go
+++ b/pkg/sql/colexec/external_hash_joiner_test.go
@@ -76,7 +76,7 @@ func TestExternalHashJoiner(t *testing.T) {
 					// allNullsInjection test for now.
 					tc.skipAllNullsInjection = true
 				}
-				runHashJoinTestCase(t, tc, func(sources []colexecop.Operator) (colexecop.Operator, error) {
+				runHashJoinTestCase(t, tc, rng, func(sources []colexecop.Operator) (colexecop.Operator, error) {
 					sem := colexecop.NewTestingSemaphore(externalHJMinPartitions)
 					semsToCheck = append(semsToCheck, sem)
 					spec := createSpecForHashJoiner(tc)

--- a/pkg/sql/colexec/joiner_utils_test.go
+++ b/pkg/sql/colexec/joiner_utils_test.go
@@ -12,6 +12,7 @@ package colexec
 
 import (
 	"fmt"
+	"math/rand"
 	"strings"
 
 	"github.com/cockroachdb/apd/v3"
@@ -59,6 +60,18 @@ func (tc *joinTestCase) init() {
 			tc.rightDirections[i] = execinfrapb.Ordering_Column_ASC
 		}
 	}
+}
+
+// shuffleInputTuples reorders input tuples on both sides of the join. This
+// should only be called when tc is fed into a hash joiner.
+func (tc *joinTestCase) shuffleInputTuples(rng *rand.Rand) {
+	shuffle := func(tuples colexectestutils.Tuples) {
+		rng.Shuffle(len(tuples), func(i, j int) {
+			tuples[i], tuples[j] = tuples[j], tuples[i]
+		})
+	}
+	shuffle(tc.leftTuples)
+	shuffle(tc.rightTuples)
 }
 
 // mirror attempts to create a "mirror" test case of tc and returns nil if it


### PR DESCRIPTION
This increases the test coverage. Additionally, the cross joiner that
uses the same helper now uses an ordered verifier (but without shuffling
the input tuples since then the expected results might change for some
join types).

Fixes: #77994.

Release note: None