### PR TITLE
ui: fix storybook config in cluster-ui 

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/.storybook/main.js
+++ b/pkg/ui/workspaces/cluster-ui/.storybook/main.js
@@ -9,7 +9,7 @@
 // licenses/APL.txt.
 
 const path = require("path");
-const appConfig = require("../webpack.config");
+const appConfig = require("../webpack.config")();
 
 module.exports = {
   stories: ['../src/**/*.stories.tsx'],


### PR DESCRIPTION
Before, Storybook config file relied on Webpack
configuration that was defined as a config object.
Recently, Webpack configuration was changed to
export function config instead of object. As result
it broke storybook config.
This change calls webpack config function to get
required configuration.

Release note: None