### PR TITLE
spanconfig: ensure single reconciliation job post-restore

### DIFF
--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -16,6 +16,7 @@ import "errorspb/errors.proto";
 import "gogoproto/gogo.proto";
 import "roachpb/api.proto";
 import "roachpb/data.proto";
+import "roachpb/metadata.proto";
 import "roachpb/io-formats.proto";
 import "sql/catalog/descpb/structured.proto";
 import "sql/catalog/descpb/tenant.proto";
@@ -961,7 +962,19 @@ message Payload {
   // the jobs.execution_errors.max_entries cluster setting.
   repeated RetriableExecutionFailure retriable_execution_failure_log = 32;
 
-  // NEXT ID: 34.
+  // CreationClusterID is populated at creation with the ClusterID, in case a
+  // job resuming later, needs to use this information, e.g. to determine if it
+  // has been restored into a different cluster, which might mean it should
+  // terminate, pause or update some other state.
+  bytes creation_cluster_id = 35 [(gogoproto.nullable) = false, (gogoproto.customname) = "CreationClusterID",
+    (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID"];
+
+  // CreationClusterVersion is populated at creation time with the then-active
+  // cluster version, in case a job resuming later needs to use this information
+  // to migrate or update the job.
+  roachpb.Version creation_cluster_version = 36 [(gogoproto.nullable) = false];
+
+  // NEXT ID: 37.
 }
 
 message Progress {

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -89,17 +89,18 @@ const (
 type Registry struct {
 	serverCtx context.Context
 
-	ac       log.AmbientContext
-	stopper  *stop.Stopper
-	db       *kv.DB
-	ex       sqlutil.InternalExecutor
-	clock    *hlc.Clock
-	nodeID   *base.SQLIDContainer
-	settings *cluster.Settings
-	execCtx  jobExecCtxMaker
-	metrics  Metrics
-	td       *tracedumper.TraceDumper
-	knobs    TestingKnobs
+	ac        log.AmbientContext
+	stopper   *stop.Stopper
+	db        *kv.DB
+	ex        sqlutil.InternalExecutor
+	clock     *hlc.Clock
+	clusterID *base.ClusterIDContainer
+	nodeID    *base.SQLIDContainer
+	settings  *cluster.Settings
+	execCtx   jobExecCtxMaker
+	metrics   Metrics
+	td        *tracedumper.TraceDumper
+	knobs     TestingKnobs
 
 	// adoptionChan is used to nudge the registry to resume claimed jobs and
 	// potentially attempt to claim jobs.
@@ -182,6 +183,7 @@ func MakeRegistry(
 	clock *hlc.Clock,
 	db *kv.DB,
 	ex sqlutil.InternalExecutor,
+	clusterID *base.ClusterIDContainer,
 	nodeID *base.SQLIDContainer,
 	sqlInstance sqlliveness.Instance,
 	settings *cluster.Settings,
@@ -198,6 +200,7 @@ func MakeRegistry(
 		clock:               clock,
 		db:                  db,
 		ex:                  ex,
+		clusterID:           clusterID,
 		nodeID:              nodeID,
 		sqlInstance:         sqlInstance,
 		settings:            settings,
@@ -275,27 +278,29 @@ func (r *Registry) MakeJobID() jobspb.JobID {
 }
 
 // newJob creates a new Job.
-func (r *Registry) newJob(record Record) *Job {
+func (r *Registry) newJob(ctx context.Context, record Record) *Job {
 	job := &Job{
 		id:        record.JobID,
 		registry:  r,
 		createdBy: record.CreatedBy,
 	}
-	job.mu.payload = r.makePayload(&record)
+	job.mu.payload = r.makePayload(ctx, &record)
 	job.mu.progress = r.makeProgress(&record)
 	job.mu.status = StatusRunning
 	return job
 }
 
 // makePayload creates a Payload structure based on the given Record.
-func (r *Registry) makePayload(record *Record) jobspb.Payload {
+func (r *Registry) makePayload(ctx context.Context, record *Record) jobspb.Payload {
 	return jobspb.Payload{
-		Description:   record.Description,
-		Statement:     record.Statements,
-		UsernameProto: record.Username.EncodeProto(),
-		DescriptorIDs: record.DescriptorIDs,
-		Details:       jobspb.WrapPayloadDetails(record.Details),
-		Noncancelable: record.NonCancelable,
+		Description:            record.Description,
+		Statement:              record.Statements,
+		UsernameProto:          record.Username.EncodeProto(),
+		DescriptorIDs:          record.DescriptorIDs,
+		Details:                jobspb.WrapPayloadDetails(record.Details),
+		Noncancelable:          record.NonCancelable,
+		CreationClusterVersion: r.settings.Version.ActiveVersion(ctx).Version,
+		CreationClusterID:      r.clusterID.Get(),
 	}
 }
 
@@ -344,7 +349,7 @@ func (r *Registry) createJobsInBatchWithTxn(
 		start = txn.ReadTimestamp().GoTime()
 	}
 	modifiedMicros := timeutil.ToUnixMicros(start)
-	stmt, args, jobIDs, err := r.batchJobInsertStmt(s.ID(), records, modifiedMicros)
+	stmt, args, jobIDs, err := r.batchJobInsertStmt(ctx, s.ID(), records, modifiedMicros)
 	if err != nil {
 		return nil, err
 	}
@@ -359,7 +364,7 @@ func (r *Registry) createJobsInBatchWithTxn(
 // batchJobInsertStmt creates an INSERT statement and its corresponding arguments
 // for batched jobs creation.
 func (r *Registry) batchJobInsertStmt(
-	sessionID sqlliveness.SessionID, records []*Record, modifiedMicros int64,
+	ctx context.Context, sessionID sqlliveness.SessionID, records []*Record, modifiedMicros int64,
 ) (string, []interface{}, []jobspb.JobID, error) {
 	instanceID := r.ID()
 	const numColumns = 6
@@ -377,7 +382,7 @@ func (r *Registry) batchJobInsertStmt(
 		`claim_session_id`:  func(rec *Record) interface{} { return sessionID.UnsafeBytes() },
 		`claim_instance_id`: func(rec *Record) interface{} { return instanceID },
 		`payload`: func(rec *Record) interface{} {
-			payload := r.makePayload(rec)
+			payload := r.makePayload(ctx, rec)
 			return marshalPanic(&payload)
 		},
 		`progress`: func(rec *Record) interface{} {
@@ -439,7 +444,7 @@ func (r *Registry) CreateJobWithTxn(
 	// TODO(sajjad): Clean up the interface - remove jobID from the params as
 	// Record now has JobID field.
 	record.JobID = jobID
-	j := r.newJob(record)
+	j := r.newJob(ctx, record)
 
 	s, err := r.sqlInstance.Session(ctx)
 	if err != nil {
@@ -476,7 +481,7 @@ func (r *Registry) CreateAdoptableJobWithTxn(
 	// TODO(sajjad): Clean up the interface - remove jobID from the params as
 	// Record now has JobID field.
 	record.JobID = jobID
-	j := r.newJob(record)
+	j := r.newJob(ctx, record)
 	if err := j.runInTxn(ctx, txn, func(ctx context.Context, txn *kv.Txn) error {
 		// Note: although the following uses ReadTimestamp and
 		// ReadTimestamp can diverge from the value of now() throughout a

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -427,6 +427,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 			cfg.clock,
 			cfg.db,
 			cfg.circularInternalExecutor,
+			cfg.ClusterIDContainer,
 			cfg.nodeIDContainer,
 			cfg.sqlLivenessProvider,
 			cfg.Settings,

--- a/pkg/spanconfig/spanconfigjob/job.go
+++ b/pkg/spanconfig/spanconfigjob/job.go
@@ -54,6 +54,19 @@ func (r *resumer) Resume(ctx context.Context, execCtxI interface{}) (jobErr erro
 	}()
 
 	execCtx := execCtxI.(sql.JobExecContext)
+	if !execCtx.ExecCfg().ClusterID().Equal(r.job.Payload().CreationClusterID) {
+		// When restoring a cluster, we don't want to end up with two instances of
+		// the singleton reconciliation job.
+		//
+		// TODO(irfansharif): We could instead give the reconciliation job a fixed
+		// ID and check whether the cluster we're restoring into doesn't already
+		// have a job with the same ID. Comparing cluster IDs during restore doesn't
+		// help when we're restoring into the same cluster the backup was run from.
+		log.Infof(ctx, "duplicate restored job (source-cluster-id=%s, dest-cluster-id=%s); exiting",
+			r.job.Payload().CreationClusterID, execCtx.ExecCfg().ClusterID())
+		return nil
+	}
+
 	rc := execCtx.SpanConfigReconciler()
 	stopper := execCtx.ExecCfg().DistSQLSrv.Stopper
 


### PR DESCRIPTION
Fixes #70173. When restoring a cluster, we don't want to end up with two
instances of the singleton reconciliation job.

Release note: None

---

First commit is from https://github.com/cockroachdb/cockroach/pull/79139.