### PR TITLE
kv,changefeedccl: make kv.rangefeed.enabled a TenantReadOnly setting 

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -478,8 +478,11 @@ func validateSettings(ctx context.Context, p sql.PlanHookState) error {
 	// Changefeeds are based on the Rangefeed abstraction, which
 	// requires the `kv.rangefeed.enabled` setting to be true.
 	if !kvserver.RangefeedEnabled.Get(&p.ExecCfg().Settings.SV) {
-		return errors.Errorf("rangefeeds require the kv.rangefeed.enabled setting. See %s",
-			docs.URL(`change-data-capture.html#enable-rangefeeds-to-reduce-latency`))
+		docsURL := docs.URL(`change-data-capture.html#enable-rangefeeds-to-reduce-latency`)
+		if !p.ExecCfg().Codec.ForSystemTenant() {
+			return errors.Errorf("rangefeeds require the system cluster operator set kv.rangefeed.enable to true for this tenant. See %s", docsURL)
+		}
+		return errors.Errorf("rangefeeds require the kv.rangefeed.enabled setting. See %s", docsURL)
 	}
 
 	ok, err := p.HasRoleOption(ctx, roleoption.CONTROLCHANGEFEED)

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -374,7 +374,7 @@ func TestChangefeedTenants(t *testing.T) {
 
 	tenantServer, tenantDB := serverutils.StartTenant(t, kvServer, tenantArgs)
 	tenantSQL := sqlutils.MakeSQLRunner(tenantDB)
-	tenantSQL.Exec(t, serverSetupStatements)
+	tenantSQL.Exec(t, tenantSetupStatements)
 
 	tenantSQL.Exec(t, `CREATE TABLE foo_in_tenant (pk INT PRIMARY KEY)`)
 	t.Run("changefeed on non-tenant table fails", func(t *testing.T) {
@@ -445,7 +445,7 @@ func TestChangefeedTenantsExternalIOEnabled(t *testing.T) {
 
 	tenantServer, tenantDB := serverutils.StartTenant(t, kvServer, tenantArgs)
 	tenantSQL := sqlutils.MakeSQLRunner(tenantDB)
-	tenantSQL.Exec(t, serverSetupStatements)
+	tenantSQL.Exec(t, tenantSetupStatements)
 	tenantSQL.Exec(t, `CREATE TABLE foo_in_tenant (pk INT PRIMARY KEY)`)
 
 	t.Run("sinkful changefeed works", func(t *testing.T) {
@@ -952,7 +952,8 @@ func TestChangefeedExternalIODisabled(t *testing.T) {
 		})
 		defer s.Stopper().Stop(ctx)
 		sqlDB := sqlutils.MakeSQLRunner(db)
-		sqlDB.Exec(t, serverSetupStatements)
+		sqlDB.Exec(t, hostSetupStatements)
+		sqlDB.Exec(t, tenantSetupStatements)
 		sqlDB.Exec(t, "CREATE TABLE target_table (pk INT PRIMARY KEY)")
 		for _, proto := range disallowedSinkProtos {
 			sqlDB.ExpectErr(t, "Outbound IO is disabled by configuration, cannot create changefeed",

--- a/pkg/cli/initial_sql.go
+++ b/pkg/cli/initial_sql.go
@@ -56,7 +56,26 @@ func runInitialSQL(
 		}
 	}
 
+	if err := enableRangefeeds(ctx, s); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+func enableRangefeeds(ctx context.Context, s *server.Server) error {
+	return s.RunLocalSQL(ctx, func(ctx context.Context, ie *sql.InternalExecutor) error {
+		enableRangefeedStmt := "SET CLUSTER SETTING kv.rangefeed.enabled = true"
+		if _, err := ie.Exec(ctx, "enable-rangefeeds", nil, enableRangefeedStmt); err != nil {
+			return err
+		}
+
+		enableRangfeedForTenantsStmt := "ALTER TENANT ALL SET CLUSTER SETTING kv.rangefeed.enabled = true"
+		if _, err := ie.Exec(ctx, "enable-rangefeeds-for-tenants", nil, enableRangfeedForTenantsStmt); err != nil {
+			return err
+		}
+		return nil
+	})
 }
 
 // createAdminUser creates an admin user with the given name.

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -43,7 +43,7 @@ import (
 // ranges and ranges covering tables in the system database); this setting
 // covers everything else.
 var RangefeedEnabled = settings.RegisterBoolSetting(
-	settings.TenantWritable,
+	settings.TenantReadOnly,
 	"kv.rangefeed.enabled",
 	"if set, rangefeed registration is enabled",
 	false,


### PR DESCRIPTION
This setting is used by kvserver and the value in the tenant does not
matter. However, we do what to read the value from the tenant so we
can generate nice error messages for CHANGEFEED users.

Currently, the cluster setting system doesn't have a class of setting
that lets us do this. However, by changing the setting to a
TenantReadOnly setting, we can at least make it so that tenants do not
have to set a no-op setting only to have their changefeeds still fail
because of a host-level cluster setting.

The downside is that an operator of a multi-tenant cluster will have
to run two commands to enable rangefeeds for all tenants:

```
SET CLUSTER SETTING kv.rangefeed.enabled = true;
ALTER TENANT ALL SET CLUSTER SETTING kv.rangefeed.enabled = true;
```

Release note: `kv.rangefeed.enabled` no longer needs to be set in a
tenant in addition to the host cluster.