### PR TITLE
backupccl: run TestFullClusterBackup with span configs

### DIFF
--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -50,16 +50,12 @@ func TestFullClusterBackup(t *testing.T) {
 
 	params := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
-			DisableSpanConfigs: true, // TODO(irfansharif): #75060.
 			Knobs: base.TestingKnobs{
 				SpanConfig: &spanconfig.TestingKnobs{
 					// We compare job progress before and after a restore. Disable
 					// the automatic jobs checkpointing which could possibly mutate
 					// the progress data during the backup/restore process.
 					JobDisablePersistingCheckpoints: true,
-				},
-				GCJob: &sql.GCJobTestingKnobs{
-					DisableNewProtectedTimestampSubsystemCheck: true,
 				},
 			},
 		}}
@@ -91,10 +87,17 @@ func TestFullClusterBackup(t *testing.T) {
 	}
 
 	// The claim_session_id field in jobs is a uuid and so needs to be excluded
-	// when comparing jobs pre/post restore.
+	// when comparing jobs pre/post restore. The span config reconciliation job
+	// too is something we exclude; because it's a singleton job, when restored
+	// into another cluster it self-terminates.
 	const jobsQuery = `
 SELECT id, status, created, payload, progress, created_by_type, created_by_id, claim_instance_id
 FROM system.jobs
+WHERE id NOT IN
+(
+	SELECT job_id FROM [SHOW AUTOMATIC JOBS]
+  WHERE job_type = 'AUTO SPAN CONFIG RECONCILIATION'
+)
 	`
 	// Pause SQL Stats compaction job to ensure the test is deterministic.
 	sqlDB.Exec(t, `PAUSE SCHEDULES SELECT id FROM [SHOW SCHEDULES FOR SQL STATISTICS]`)

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -16,6 +16,7 @@ import "errorspb/errors.proto";
 import "gogoproto/gogo.proto";
 import "roachpb/api.proto";
 import "roachpb/data.proto";
+import "roachpb/metadata.proto";
 import "roachpb/io-formats.proto";
 import "sql/catalog/descpb/structured.proto";
 import "sql/catalog/descpb/tenant.proto";
@@ -961,7 +962,19 @@ message Payload {
   // the jobs.execution_errors.max_entries cluster setting.
   repeated RetriableExecutionFailure retriable_execution_failure_log = 32;
 
-  // NEXT ID: 34.
+  // CreationClusterID is populated at creation with the ClusterID, in case a
+  // job resuming later, needs to use this information, e.g. to determine if it
+  // has been restored into a different cluster, which might mean it should
+  // terminate, pause or update some other state.
+  bytes creation_cluster_id = 35 [(gogoproto.nullable) = false, (gogoproto.customname) = "CreationClusterID",
+    (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID"];
+
+  // CreationClusterVersion is populated at creation time with the then-active
+  // cluster version, in case a job resuming later needs to use this information
+  // to migrate or update the job.
+  roachpb.Version creation_cluster_version = 36 [(gogoproto.nullable) = false];
+
+  // NEXT ID: 37.
 }
 
 message Progress {

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -89,17 +89,18 @@ const (
 type Registry struct {
 	serverCtx context.Context
 
-	ac       log.AmbientContext
-	stopper  *stop.Stopper
-	db       *kv.DB
-	ex       sqlutil.InternalExecutor
-	clock    *hlc.Clock
-	nodeID   *base.SQLIDContainer
-	settings *cluster.Settings
-	execCtx  jobExecCtxMaker
-	metrics  Metrics
-	td       *tracedumper.TraceDumper
-	knobs    TestingKnobs
+	ac        log.AmbientContext
+	stopper   *stop.Stopper
+	db        *kv.DB
+	ex        sqlutil.InternalExecutor
+	clock     *hlc.Clock
+	clusterID *base.ClusterIDContainer
+	nodeID    *base.SQLIDContainer
+	settings  *cluster.Settings
+	execCtx   jobExecCtxMaker
+	metrics   Metrics
+	td        *tracedumper.TraceDumper
+	knobs     TestingKnobs
 
 	// adoptionChan is used to nudge the registry to resume claimed jobs and
 	// potentially attempt to claim jobs.
@@ -182,6 +183,7 @@ func MakeRegistry(
 	clock *hlc.Clock,
 	db *kv.DB,
 	ex sqlutil.InternalExecutor,
+	clusterID *base.ClusterIDContainer,
 	nodeID *base.SQLIDContainer,
 	sqlInstance sqlliveness.Instance,
 	settings *cluster.Settings,
@@ -198,6 +200,7 @@ func MakeRegistry(
 		clock:               clock,
 		db:                  db,
 		ex:                  ex,
+		clusterID:           clusterID,
 		nodeID:              nodeID,
 		sqlInstance:         sqlInstance,
 		settings:            settings,
@@ -275,27 +278,29 @@ func (r *Registry) MakeJobID() jobspb.JobID {
 }
 
 // newJob creates a new Job.
-func (r *Registry) newJob(record Record) *Job {
+func (r *Registry) newJob(ctx context.Context, record Record) *Job {
 	job := &Job{
 		id:        record.JobID,
 		registry:  r,
 		createdBy: record.CreatedBy,
 	}
-	job.mu.payload = r.makePayload(&record)
+	job.mu.payload = r.makePayload(ctx, &record)
 	job.mu.progress = r.makeProgress(&record)
 	job.mu.status = StatusRunning
 	return job
 }
 
 // makePayload creates a Payload structure based on the given Record.
-func (r *Registry) makePayload(record *Record) jobspb.Payload {
+func (r *Registry) makePayload(ctx context.Context, record *Record) jobspb.Payload {
 	return jobspb.Payload{
-		Description:   record.Description,
-		Statement:     record.Statements,
-		UsernameProto: record.Username.EncodeProto(),
-		DescriptorIDs: record.DescriptorIDs,
-		Details:       jobspb.WrapPayloadDetails(record.Details),
-		Noncancelable: record.NonCancelable,
+		Description:            record.Description,
+		Statement:              record.Statements,
+		UsernameProto:          record.Username.EncodeProto(),
+		DescriptorIDs:          record.DescriptorIDs,
+		Details:                jobspb.WrapPayloadDetails(record.Details),
+		Noncancelable:          record.NonCancelable,
+		CreationClusterVersion: r.settings.Version.ActiveVersion(ctx).Version,
+		CreationClusterID:      r.clusterID.Get(),
 	}
 }
 
@@ -344,7 +349,7 @@ func (r *Registry) createJobsInBatchWithTxn(
 		start = txn.ReadTimestamp().GoTime()
 	}
 	modifiedMicros := timeutil.ToUnixMicros(start)
-	stmt, args, jobIDs, err := r.batchJobInsertStmt(s.ID(), records, modifiedMicros)
+	stmt, args, jobIDs, err := r.batchJobInsertStmt(ctx, s.ID(), records, modifiedMicros)
 	if err != nil {
 		return nil, err
 	}
@@ -359,7 +364,7 @@ func (r *Registry) createJobsInBatchWithTxn(
 // batchJobInsertStmt creates an INSERT statement and its corresponding arguments
 // for batched jobs creation.
 func (r *Registry) batchJobInsertStmt(
-	sessionID sqlliveness.SessionID, records []*Record, modifiedMicros int64,
+	ctx context.Context, sessionID sqlliveness.SessionID, records []*Record, modifiedMicros int64,
 ) (string, []interface{}, []jobspb.JobID, error) {
 	instanceID := r.ID()
 	const numColumns = 6
@@ -377,7 +382,7 @@ func (r *Registry) batchJobInsertStmt(
 		`claim_session_id`:  func(rec *Record) interface{} { return sessionID.UnsafeBytes() },
 		`claim_instance_id`: func(rec *Record) interface{} { return instanceID },
 		`payload`: func(rec *Record) interface{} {
-			payload := r.makePayload(rec)
+			payload := r.makePayload(ctx, rec)
 			return marshalPanic(&payload)
 		},
 		`progress`: func(rec *Record) interface{} {
@@ -439,7 +444,7 @@ func (r *Registry) CreateJobWithTxn(
 	// TODO(sajjad): Clean up the interface - remove jobID from the params as
 	// Record now has JobID field.
 	record.JobID = jobID
-	j := r.newJob(record)
+	j := r.newJob(ctx, record)
 
 	s, err := r.sqlInstance.Session(ctx)
 	if err != nil {
@@ -476,7 +481,7 @@ func (r *Registry) CreateAdoptableJobWithTxn(
 	// TODO(sajjad): Clean up the interface - remove jobID from the params as
 	// Record now has JobID field.
 	record.JobID = jobID
-	j := r.newJob(record)
+	j := r.newJob(ctx, record)
 	if err := j.runInTxn(ctx, txn, func(ctx context.Context, txn *kv.Txn) error {
 		// Note: although the following uses ReadTimestamp and
 		// ReadTimestamp can diverge from the value of now() throughout a

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -427,6 +427,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 			cfg.clock,
 			cfg.db,
 			cfg.circularInternalExecutor,
+			cfg.ClusterIDContainer,
 			cfg.nodeIDContainer,
 			cfg.sqlLivenessProvider,
 			cfg.Settings,

--- a/pkg/sql/gcjob/refresh_statuses.go
+++ b/pkg/sql/gcjob/refresh_statuses.go
@@ -314,12 +314,6 @@ func isProtected(
 			return true, nil
 		}
 
-		// Skip checking the new protected timestamp subsystem if the testing knob
-		// says as such.
-		if execCfg.GCJobTestingKnobs.DisableNewProtectedTimestampSubsystemCheck {
-			return false, nil
-		}
-
 		spanConfigRecords, err := kvAccessor.GetSpanConfigRecords(ctx, spanconfig.Targets{
 			spanconfig.MakeTargetFromSpan(sp),
 		})

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -2269,14 +2269,6 @@ type GCJobTestingKnobs struct {
 	// protected timestamp status of a table or an index. The protection status is
 	// passed in along with the jobID.
 	RunAfterIsProtectedCheck func(jobID jobspb.JobID, isProtected bool)
-	// DisableNewProtectedTimestampSubsystemCheck disables checking the new
-	// protected timestamp subsystem when checking the protection status of a
-	// table or an index. This is useful for tests that disable the span
-	// configuration infrastructure, as the new protected timestamp subsystem is
-	// built on top of it.
-	// TODO(arul): Once we've fully migrated all tests to use span configurations
-	// we should be able to get rid of this testing knob as well.
-	DisableNewProtectedTimestampSubsystemCheck bool
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
Closes #75060; speculating that #79222 fixed the underlying issue.
Previously the reconciliation job errored out with "expected to delete
11 row(s), deleted 10", which could conceivably occur if there were two
instances of the reconciliation job running post-restore (something
\#79222 fixes).

Release note: None

---

First two commits are from #79139 and #79222 respectively.