### PR TITLE
statusccl: disable intermittently failing test

### DIFF
--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -108,7 +108,7 @@ func TestTenantCannotSeeNonTenantStats(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-
+	skip.WithIssue(t, 77410, "disabled because of stress / intermittent failures")
 	serverParams, _ := tests.CreateTestServerParams()
 	serverParams.Knobs.SpanConfig = &spanconfig.TestingKnobs{
 		ManagerDisableJobCreation: true, // TODO(irfansharif): #74919.


### PR DESCRIPTION
Previously TestTenantCannotSeeNonTenantStats test would
intermittently fail due to a timing issue. This was
inadequate since this test could fail due to an internal
statement to expire sessions. To address this, this patch
temporarily disables the problematic test.

Release note: None