### PR TITLE
release-22.1: roachtest: de-flake sstable corruption test

### DIFF
--- a/pkg/cmd/roachtest/tests/sstable_corruption.go
+++ b/pkg/cmd/roachtest/tests/sstable_corruption.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
-	"github.com/stretchr/testify/require"
+	"github.com/cockroachdb/errors"
 )
 
 func runSSTableCorruption(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -135,14 +135,42 @@ func runSSTableCorruption(ctx context.Context, t test.Test, c cluster.Cluster) {
 		m := c.NewMonitor(ctx)
 		// Run a workload to try to get the node to notice corruption and crash.
 		m.Go(func(ctx context.Context) error {
-			_ = c.RunE(ctx, workloadNode,
-				fmt.Sprintf("./cockroach workload run tpcc --warehouses=100 --tolerate-errors --duration=%s", 2*time.Minute))
-			// Don't return an error from the workload. We want outcome of WaitE to be
-			// determined by the monitor noticing that a node died. The workload may
-			// also fail, despite --tolerate-errors, if a node crashes too early.
-			return nil
+			const timeout = 10 * time.Minute
+			ctx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+			for {
+				err := errors.CombineErrors(
+					c.RunE(
+						ctx, workloadNode,
+						"./cockroach workload run tpcc --warehouses=100 --tolerate-errors",
+					),
+					errors.New("workload unexpectedly returned nil"),
+				)
+				// NOTE: the workload is fallible, however, we don't want to return the
+				// error to the caller of WaitE (below), as we want it to see any error
+				// caused due to a node death. The workload is just a means of surfacing
+				// the corruption. The workload could also return early with a nil
+				// error, which is unexpected. In both cases, simply log the error and
+				// determine whether to continue based on the context (timeout, or other
+				// context cancellation).
+				if err != nil {
+					t.L().Printf("workload failed: %s", err)
+				}
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(time.Second):
+					// Loop.
+				}
+			}
 		})
-		require.Error(t, m.WaitE())
+
+		t.L().Printf("waiting for monitor to observe error ...")
+		err := m.WaitE()
+		t.L().Printf("monitor observed error: %s", err)
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			t.Fatal(err)
+		}
 	}
 
 	// Exempt corrupted nodes from roachtest harness' post-test liveness checks.


### PR DESCRIPTION
This is a backport of #78527 for 22.1.

---

Currently, the `sstable-corruption/table` randomly selects a number of
SSTables on each node to corrupt, before restarting the cluster and
running a workload in an attempt to notice the corruption. The test uses
a monitor to monitor for node death, and also run the background
workload.

There exists a race where monitor's workload goroutine can exit soon
after starting (e.g. due to #77627), and _before_ the monitor encounters
the failure of a node. The test expects an error to be returned by the
monitor, which fails due to the former error being nil.

Address the race by continuing to run the workload even in the case of
failure, exiting only when a timeout is exceeded (due to not
encountering corruption within the allotted time), or other context
cancellation (i.e. a node death _was_ observed by the monitor and the
test is being torn down).

Release note: None.

Release justification: roachtest only.