### PR TITLE
docs: generate swagger docs w/ bazel

### DIFF
--- a/docs/generated/bazel_targets.txt
+++ b/docs/generated/bazel_targets.txt
@@ -10,3 +10,4 @@ documentation. Lines not beginning with // should be ignored.
 //docs/generated/settings:settings_for_tenants
 //docs/generated/sql
 //docs/generated/sql/bnf
+//docs/generated/swagger

--- a/docs/generated/swagger/BUILD.bazel
+++ b/docs/generated/swagger/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_path")
+
+genrule(
+    name = "swagger",
+    srcs = [
+        ":swagger_go_path",
+    ],
+    outs = ["spec.json"],
+    cmd = """
+      GO_REL_PATH=`dirname $(location @go_sdk//:bin/go)`
+      GO_ABS_PATH=`cd $$GO_REL_PATH && pwd`
+      env PATH=$$GO_ABS_PATH HOME=$(GENDIR) GOPATH=$$(cd $(location :swagger_go_path) && pwd) GO111MODULE=off \
+          $(location @com_github_go_swagger_go_swagger//cmd/swagger) generate spec -w $(location :swagger_go_path)/src/github.com/cockroachdb/cockroach/pkg --scan-models -t bazel -o $@
+    """,
+    exec_tools = [
+        "@com_github_go_swagger_go_swagger//cmd/swagger",
+        "@go_sdk//:bin/go",
+    ],
+)
+
+go_path(
+    name = "swagger_go_path",
+    deps = [
+        "//pkg/server",
+    ],
+)

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -95,6 +95,7 @@ var buildTargetMapping = map[string]string{
 	"short":            "//pkg/cmd/cockroach-short:cockroach-short",
 	"staticcheck":      "@co_honnef_go_tools//cmd/staticcheck:staticcheck",
 	"stress":           stressTarget,
+	"swagger":          "@com_github_go_swagger_go_swagger//cmd/swagger:swagger",
 	"workload":         "//pkg/cmd/workload:workload",
 }
 

--- a/pkg/gen/docs.bzl
+++ b/pkg/gen/docs.bzl
@@ -258,6 +258,7 @@ DOCS_SRCS = [
   "//docs/generated/sql:functions.md",
   "//docs/generated/sql:operators.md",
   "//docs/generated/sql:window_functions.md",
+  "//docs/generated/swagger:spec.json",
   "//docs/generated:eventlog.md",
   "//docs/generated:logformats.md",
   "//docs/generated:logging.md",


### PR DESCRIPTION
Also build in CI as well as `dev generate docs`.

Closes #77395.

Release note: None