### PR TITLE
sql/importer: periodically check if IMPORT should replan

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -496,6 +496,7 @@ go_test(
         "descriptor_mutation_test.go",
         "distsql_physical_planner_test.go",
         "distsql_plan_backfill_test.go",
+        "distsql_plan_bulk_test.go",
         "distsql_plan_set_op_test.go",
         "distsql_running_test.go",
         "drop_helpers_test.go",

--- a/pkg/sql/distsql_plan_bulk.go
+++ b/pkg/sql/distsql_plan_bulk.go
@@ -13,9 +13,11 @@ package sql
 import (
 	"context"
 	"math/rand"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
 
@@ -94,4 +96,107 @@ func (dsp *DistSQLPlanner) setupAllNodesPlanningTenant(
 		sqlInstanceIDs[i], sqlInstanceIDs[j] = sqlInstanceIDs[j], sqlInstanceIDs[i]
 	})
 	return planCtx, sqlInstanceIDs, nil
+}
+
+// PhysicalPlanMaker describes a function that makes a physical plan.
+type PhysicalPlanMaker func(context.Context, *DistSQLPlanner) (*PhysicalPlan, *PlanningCtx, error)
+
+// calculatePlanGrowth returns the number of new or updated sql instances in one
+// physical plan relative to an old one, as well as that number as a fraction of
+// the number in the old one.
+func calculatePlanGrowth(before, after *PhysicalPlan) (int, float64) {
+	var changed int
+	beforeSpecs := before.GenerateFlowSpecs()
+	afterSpecs := after.GenerateFlowSpecs()
+
+	// How many nodes are in after that are not in before, or are in both but
+	// have changed their spec?
+	for n, afterSpec := range afterSpecs {
+		if beforeSpec, ok := beforeSpecs[n]; !ok {
+			changed++ // not in before at all
+		} else if len(beforeSpec.Processors) != len(afterSpec.Processors) {
+			changed++ // in before with different procs
+		} else {
+			for i := range beforeSpec.Processors {
+				// TODO(dt): add equality check method gen, use it.
+				if afterSpec.Processors[i].Size() != beforeSpec.Processors[i].Size() {
+					changed++ // procs have differnet specs
+					break
+				}
+			}
+		}
+	}
+
+	var frac float64
+	if changed > 0 {
+		frac = float64(changed) / float64(len(beforeSpecs))
+	}
+	return changed, frac
+}
+
+// PlanChangeDecision descrubes a function that decides if a plan has "changed"
+// within a given context, for example, if enough of its processor placements
+// have changed that it should be replanned.
+type PlanChangeDecision func(ctx context.Context, old, new *PhysicalPlan) bool
+
+// ReplanOnChangedFraction returns a PlanChangeDecision that returns true when a
+// new plan has a number of instances that would be assigned new or changed
+// processors exceeding the passed fraction of the old plan's total instances.
+// For example, if the old plan had three instances, A, B, and C, and the new
+// plan has B, C' and D, where D is new and C' differs from C, then it would
+// compare 2/3 = 0.6 to the threshold's value.
+func ReplanOnChangedFraction(thresholdFn func() float64) PlanChangeDecision {
+	return func(ctx context.Context, oldPlan, newPlan *PhysicalPlan) bool {
+		changed, growth := calculatePlanGrowth(oldPlan, newPlan)
+		threshold := thresholdFn()
+		replan := threshold != 0.0 && growth > threshold
+		if replan || growth > 0.1 || log.V(1) {
+			log.Infof(ctx, "Re-planning would add or alter flows on %d nodes / %.2f, threshold %.2f, replan %v",
+				changed, growth, threshold, replan)
+		}
+		return replan
+	}
+}
+
+// ErrPlanChanged is a sentinel marker error for use to signal a plan changed.
+var ErrPlanChanged = errors.New("physical plan has changed")
+
+// PhysicalPlanChangeChecker returns a function which will periodically call the
+// passed function at the requested interval until the returned channel is
+// closed and compare the plan it returns to the passed initial plan, returning
+// and error if it has changed (as defined by CalculatePlanGrowth) by more than
+// the passed threshold. A threshold of 0 disables it.
+func PhysicalPlanChangeChecker(
+	ctx context.Context,
+	initial *PhysicalPlan,
+	fn PhysicalPlanMaker,
+	execCtx interface{ DistSQLPlanner() *DistSQLPlanner },
+	decider PlanChangeDecision,
+	freq func() time.Duration,
+) (func(context.Context) error, func()) {
+	stop := make(chan struct{})
+
+	return func(ctx context.Context) error {
+		tick := time.NewTicker(freq())
+		defer tick.Stop()
+		done := ctx.Done()
+		for {
+			select {
+			case <-stop:
+				return nil
+			case <-done:
+				return ctx.Err()
+			case <-tick.C:
+				dsp := execCtx.DistSQLPlanner()
+				p, _, err := fn(ctx, dsp)
+				if err != nil {
+					log.Warningf(ctx, "job replanning check failed to generate plan: %v", err)
+					continue
+				}
+				if decider(ctx, initial, p) {
+					return ErrPlanChanged
+				}
+			}
+		}
+	}, func() { close(stop) }
 }

--- a/pkg/sql/distsql_plan_bulk.go
+++ b/pkg/sql/distsql_plan_bulk.go
@@ -12,7 +12,6 @@ package sql
 
 import (
 	"context"
-	"math/rand"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -60,13 +59,6 @@ func (dsp *DistSQLPlanner) setupAllNodesPlanningSystem(
 			nodes = append(nodes, nodeID)
 		}
 	}
-	// Shuffle node order so that multiple IMPORTs done in parallel will not
-	// identically schedule CSV reading. For example, if there are 3 nodes and 4
-	// files, the first node will get 2 files while the other nodes will each get 1
-	// file. Shuffling will make that first node random instead of always the same.
-	rand.Shuffle(len(nodes), func(i, j int) {
-		nodes[i], nodes[j] = nodes[j], nodes[i]
-	})
 	return planCtx, nodes, nil
 }
 
@@ -88,13 +80,6 @@ func (dsp *DistSQLPlanner) setupAllNodesPlanningTenant(
 	for i, pod := range pods {
 		sqlInstanceIDs[i] = pod.InstanceID
 	}
-	// Shuffle node order so that multiple IMPORTs done in parallel will not
-	// identically schedule CSV reading. For example, if there are 3 nodes and 4
-	// files, the first node will get 2 files while the other nodes will each get 1
-	// file. Shuffling will make that first node random instead of always the same.
-	rand.Shuffle(len(sqlInstanceIDs), func(i, j int) {
-		sqlInstanceIDs[i], sqlInstanceIDs[j] = sqlInstanceIDs[j], sqlInstanceIDs[i]
-	})
 	return planCtx, sqlInstanceIDs, nil
 }
 

--- a/pkg/sql/distsql_plan_bulk_test.go
+++ b/pkg/sql/distsql_plan_bulk_test.go
@@ -1,0 +1,85 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"math"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCalculatePlanGrowth(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	for _, tc := range []struct {
+		name   string
+		before []physicalplan.Processor
+		after  []physicalplan.Processor
+		added  int
+		frac   float64
+	}{
+		{
+			name:  "zero to zero",
+			added: 0, frac: 0.0,
+		},
+		{
+			name:   "down to zero",
+			before: []physicalplan.Processor{{SQLInstanceID: 1}},
+			after:  []physicalplan.Processor{},
+			added:  0, frac: 0.0,
+		},
+		{
+			name:   "added from zero",
+			before: []physicalplan.Processor{},
+			after:  []physicalplan.Processor{{SQLInstanceID: 1}},
+			added:  1, frac: math.Inf(1),
+		},
+		{
+			name:   "changed inputs to same node",
+			before: []physicalplan.Processor{{SQLInstanceID: 1}},
+			after: []physicalplan.Processor{{SQLInstanceID: 1,
+				Spec: execinfrapb.ProcessorSpec{Core: execinfrapb.ProcessorCoreUnion{ChangeAggregator: &execinfrapb.ChangeAggregatorSpec{JobID: 1}}}}},
+			added: 1, frac: 1.0,
+		},
+		{
+			name:   "moved to new node",
+			before: []physicalplan.Processor{{SQLInstanceID: 1}},
+			after:  []physicalplan.Processor{{SQLInstanceID: 2}},
+			added:  1, frac: 1.0,
+		},
+		{
+			name:   "added node",
+			before: []physicalplan.Processor{{SQLInstanceID: 1}, {SQLInstanceID: 2}},
+			after:  []physicalplan.Processor{{SQLInstanceID: 1}, {SQLInstanceID: 2}, {SQLInstanceID: 3}},
+			added:  1, frac: 0.5,
+		},
+		{
+			name:   "removed node",
+			before: []physicalplan.Processor{{SQLInstanceID: 1}, {SQLInstanceID: 2}, {SQLInstanceID: 3}},
+			after:  []physicalplan.Processor{{SQLInstanceID: 1}, {SQLInstanceID: 2}},
+			added:  0, frac: 0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			before := PhysicalPlan{}
+			after := PhysicalPlan{}
+			before.PhysicalInfrastructure = &physicalplan.PhysicalInfrastructure{Processors: tc.before}
+			after.PhysicalInfrastructure = &physicalplan.PhysicalInfrastructure{Processors: tc.after}
+			added, frac := calculatePlanGrowth(&before, &after)
+			require.Equal(t, tc.added, added)
+			require.Equal(t, tc.frac, frac)
+		})
+	}
+}

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -32,6 +33,21 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+)
+
+var replanThreshold = settings.RegisterFloatSetting(
+	settings.TenantWritable,
+	"bulkio.import.replan_flow_threshold",
+	"fraction of initial flow instances that would be been added or updated if restarted above which an IMPORT is restarted (0=disabled)",
+	0.0,
+)
+
+var replanFrequency = settings.RegisterDurationSetting(
+	settings.TenantWritable,
+	"bulkio.import.replan_flow_frequency",
+	"frequency at which IMPORT checks to see if re-planning would change its physical processor placement",
+	time.Minute*2,
+	settings.PositiveDuration,
 )
 
 // distImport is used by IMPORT to run a DistSQL flow to ingest data by starting
@@ -50,13 +66,46 @@ func distImport(
 	alwaysFlushProgress bool,
 	procsPerNode int,
 ) (roachpb.BulkOpSummary, error) {
-	dsp := execCtx.DistSQLPlanner()
-	evalCtx := execCtx.ExtendedEvalContext()
 
-	planCtx, sqlInstanceIDs, err := dsp.SetupAllNodesPlanning(ctx, evalCtx, execCtx.ExecCfg())
+	dsp := execCtx.DistSQLPlanner()
+	makePlan := func(ctx context.Context, dsp *sql.DistSQLPlanner) (*sql.PhysicalPlan, *sql.PlanningCtx, error) {
+		evalCtx := execCtx.ExtendedEvalContext()
+
+		planCtx, sqlInstanceIDs, err := dsp.SetupAllNodesPlanning(ctx, evalCtx, execCtx.ExecCfg())
+		if err != nil {
+			return nil, nil, err
+		}
+
+		inputSpecs := makeImportReaderSpecs(job, tables, typeDescs, from, format, sqlInstanceIDs, walltime,
+			execCtx.User(), procsPerNode)
+
+		p := planCtx.NewPhysicalPlan()
+
+		// Setup a one-stage plan with one proc per input spec.
+		corePlacement := make([]physicalplan.ProcessorCorePlacement, len(inputSpecs))
+		for i := range inputSpecs {
+			corePlacement[i].SQLInstanceID = sqlInstanceIDs[i%len(sqlInstanceIDs)]
+			corePlacement[i].Core.ReadImport = inputSpecs[i]
+		}
+		p.AddNoInputStage(
+			corePlacement,
+			execinfrapb.PostProcessSpec{},
+			// The direct-ingest readers will emit a binary encoded BulkOpSummary.
+			[]*types.T{types.Bytes, types.Bytes},
+			execinfrapb.Ordering{},
+		)
+
+		p.PlanToStreamColMap = []int{0, 1}
+
+		dsp.FinalizePlan(planCtx, p)
+		return p, planCtx, nil
+	}
+
+	p, planCtx, err := makePlan(ctx, dsp)
 	if err != nil {
 		return roachpb.BulkOpSummary{}, err
 	}
+	evalCtx := planCtx.ExtendedEvalCtx
 
 	// accumulatedBulkSummary accumulates the BulkOpSummary returned from each
 	// processor in their progress updates. It stores stats about the amount of
@@ -68,29 +117,6 @@ func distImport(
 	accumulatedBulkSummary.Lock()
 	accumulatedBulkSummary.BulkOpSummary = getLastImportSummary(job)
 	accumulatedBulkSummary.Unlock()
-
-	inputSpecs := makeImportReaderSpecs(job, tables, typeDescs, from, format, sqlInstanceIDs, walltime,
-		execCtx.User(), procsPerNode)
-
-	p := planCtx.NewPhysicalPlan()
-
-	// Setup a one-stage plan with one proc per input spec.
-	corePlacement := make([]physicalplan.ProcessorCorePlacement, len(inputSpecs))
-	for i := range inputSpecs {
-		corePlacement[i].SQLInstanceID = sqlInstanceIDs[i%len(sqlInstanceIDs)]
-		corePlacement[i].Core.ReadImport = inputSpecs[i]
-	}
-	p.AddNoInputStage(
-		corePlacement,
-		execinfrapb.PostProcessSpec{},
-		// The direct-ingest readers will emit a binary encoded BulkOpSummary.
-		[]*types.T{types.Bytes, types.Bytes},
-		execinfrapb.Ordering{},
-	)
-
-	p.PlanToStreamColMap = []int{0, 1}
-
-	dsp.FinalizePlan(planCtx, p)
 
 	importDetails := job.Progress().Details.(*jobspb.Progress_Import).Import
 	if importDetails.ReadProgress == nil {
@@ -189,7 +215,14 @@ func distImport(
 	)
 	defer recv.Release()
 
+	replanChecker, cancelReplanner := sql.PhysicalPlanChangeChecker(
+		ctx, p, makePlan, execCtx,
+		sql.ReplanOnChangedFraction(func() float64 { return replanThreshold.Get(&execCtx.ExecCfg().Settings.SV) }),
+		func() time.Duration { return replanFrequency.Get(&execCtx.ExecCfg().Settings.SV) },
+	)
+
 	stopProgress := make(chan struct{})
+
 	g := ctxgroup.WithContext(ctx)
 	g.GoCtx(func(ctx context.Context) error {
 		tick := time.NewTicker(time.Second * 10)
@@ -205,17 +238,22 @@ func distImport(
 				if err := updateJobProgress(); err != nil {
 					return err
 				}
+
 			}
 		}
 	})
 
 	g.GoCtx(func(ctx context.Context) error {
+		defer cancelReplanner()
 		defer close(stopProgress)
+
 		// Copy the evalCtx, as dsp.Run() might change it.
 		evalCtxCopy := *evalCtx
 		dsp.Run(ctx, planCtx, nil, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
 		return rowResultWriter.Err()
 	})
+
+	g.GoCtx(replanChecker)
 
 	if err := g.Wait(); err != nil {
 		return roachpb.BulkOpSummary{}, err


### PR DESCRIPTION
This adds a setting, bulkio.import.replan_flow_threshold, which can be set to a fraction
change in the number of instances involved in an IMPORT above which the execution of the
IMPORT will be stopped and restarted, to re-plan according to the updated cluster configuration.
The change is defined as the number of additional instances assigned work, or existing instances
assigned differnet work versus the number of instances in the existing plan. The frequency at
which this is checked can be configured with bulkio.import.replan_flow_frequency.

By default this is not enabled yet; if enabled it runs at a default frequency of 2min.
Both of these settings remain non-public for the time being.

Release note: none.