### PR TITLE
sql: increase crdb_internal.invalid_objects coverage

### DIFF
--- a/pkg/sql/catalog/internal/catkv/catalog_query.go
+++ b/pkg/sql/catalog/internal/catkv/catalog_query.go
@@ -85,14 +85,14 @@ func lookupIDs(
 	}
 	ret := make([]descpb.ID, len(nameInfos))
 	for i, nameInfo := range nameInfos {
-		id := cb.LookupNamespaceEntry(nameInfo)
-		if id == descpb.InvalidID {
+		ne := cb.LookupNamespaceEntry(nameInfo)
+		if ne == nil {
 			if cq.isRequired {
 				return nil, errors.AssertionFailedf("expected namespace entry for %s, none found", nameInfo.String())
 			}
 			continue
 		}
-		ret[i] = id
+		ret[i] = ne.GetID()
 	}
 	return ret, nil
 }

--- a/pkg/sql/catalog/nstree/BUILD.bazel
+++ b/pkg/sql/catalog/nstree/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/clusterversion",
+        "//pkg/keys",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/internal/validate",

--- a/pkg/sql/catalog/nstree/catalog.go
+++ b/pkg/sql/catalog/nstree/catalog.go
@@ -12,8 +12,10 @@ package nstree
 
 import (
 	"context"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/internal/validate"
@@ -59,15 +61,11 @@ func (c Catalog) LookupDescriptorEntry(id descpb.ID) catalog.Descriptor {
 }
 
 // LookupNamespaceEntry looks up a descriptor ID by name.
-func (c Catalog) LookupNamespaceEntry(key catalog.NameKey) descpb.ID {
+func (c Catalog) LookupNamespaceEntry(key catalog.NameKey) catalog.NameEntry {
 	if !c.IsInitialized() || key == nil {
-		return descpb.InvalidID
+		return nil
 	}
-	e := c.underlying.byName.getByName(key.GetParentID(), key.GetParentSchemaID(), key.GetName())
-	if e == nil {
-		return descpb.InvalidID
-	}
-	return e.GetID()
+	return c.underlying.byName.getByName(key.GetParentID(), key.GetParentSchemaID(), key.GetName())
 }
 
 // OrderedDescriptors returns the descriptors in an ordered fashion.
@@ -124,7 +122,11 @@ func (c Catalog) DereferenceDescriptorIDs(
 ) ([]descpb.ID, error) {
 	ret := make([]descpb.ID, len(reqs))
 	for i, req := range reqs {
-		ret[i] = c.LookupNamespaceEntry(req)
+		ne := c.LookupNamespaceEntry(req)
+		if ne == nil {
+			continue
+		}
+		ret[i] = ne.GetID()
 	}
 	return ret, nil
 }
@@ -138,6 +140,53 @@ func (c Catalog) Validate(
 	descriptors ...catalog.Descriptor,
 ) (ve catalog.ValidationErrors) {
 	return validate.Validate(ctx, version, c, telemetry, targetLevel, descriptors...)
+}
+
+// ValidateNamespaceEntry returns an error if the specified namespace entry
+// is invalid.
+func (c Catalog) ValidateNamespaceEntry(key catalog.NameKey) error {
+	ne := c.LookupNamespaceEntry(key)
+	if ne == nil {
+		return errors.New("invalid descriptor ID")
+	}
+	// Handle special cases.
+	switch ne.GetID() {
+	case descpb.InvalidID:
+		return errors.New("invalid descriptor ID")
+	case keys.PublicSchemaID:
+		// The public schema doesn't have a descriptor.
+		return nil
+	default:
+		isSchema := ne.GetParentID() != keys.RootNamespaceID && ne.GetParentSchemaID() == keys.RootNamespaceID
+		if isSchema && strings.HasPrefix(ne.GetName(), "pg_temp_") {
+			// Temporary schemas have namespace entries but not descriptors.
+			return nil
+		}
+	}
+	// Compare the namespace entry with the referenced descriptor.
+	desc := c.LookupDescriptorEntry(ne.GetID())
+	if desc == nil {
+		return catalog.ErrDescriptorNotFound
+	}
+	// TODO(postamar): remove draining name checks in 22.2
+	for _, dn := range desc.GetDrainingNames() {
+		if ne.GetParentID() == dn.GetParentID() &&
+			ne.GetParentSchemaID() == dn.GetParentSchemaID() &&
+			ne.GetName() == dn.GetName() {
+			return nil
+		}
+	}
+	if desc.Dropped() {
+		return errors.Newf("no matching name info in draining names of dropped %s",
+			desc.DescriptorType())
+	}
+	if ne.GetParentID() == desc.GetParentID() &&
+		ne.GetParentSchemaID() == desc.GetParentSchemaID() &&
+		ne.GetName() == desc.GetName() {
+		return nil
+	}
+	return errors.Newf("no matching name info found in non-dropped %s %q",
+		desc.DescriptorType(), desc.GetName())
 }
 
 // ValidateWithRecover is like Validate but which recovers from panics.

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -4670,55 +4670,114 @@ CREATE TABLE crdb_internal.invalid_objects (
 		if err != nil {
 			return err
 		}
+		version := p.ExecCfg().Settings.Version.ActiveVersion(ctx)
 
-		addRowsForObject := func(dbDesc catalog.DatabaseDescriptor, schema string, descriptor catalog.Descriptor) (err error) {
+		addValidationErrorRow := func(scName string, ne catalog.NameEntry, validationError error, lCtx tableLookupFn) error {
+			if validationError == nil {
+				return nil
+			}
+			dbName := fmt.Sprintf("[%d]", ne.GetParentID())
+			if scName == "" {
+				scName = fmt.Sprintf("[%d]", ne.GetParentSchemaID())
+			}
+			if n, ok := lCtx.dbNames[ne.GetParentID()]; ok {
+				dbName = n
+			}
+			if n, err := lCtx.getSchemaNameByID(ne.GetParentSchemaID()); err == nil {
+				scName = n
+			}
+			objName := ne.GetName()
+			if ne.GetParentSchemaID() == descpb.InvalidID {
+				scName = objName
+				objName = ""
+				if ne.GetParentID() == descpb.InvalidID {
+					dbName = scName
+					scName = ""
+				}
+			}
+			return addRow(
+				tree.NewDInt(tree.DInt(ne.GetID())),
+				tree.NewDString(dbName),
+				tree.NewDString(scName),
+				tree.NewDString(objName),
+				tree.NewDString(validationError.Error()),
+			)
+		}
+
+		doDescriptorValidationErrors := func(schema string, descriptor catalog.Descriptor, lCtx tableLookupFn) (err error) {
 			if descriptor == nil {
 				return nil
 			}
-			var dbName string
-			if dbDesc != nil {
-				dbName = dbDesc.GetName()
-			}
-			addValidationErrorRow := func(validationError error) {
-				if err == nil {
-					err = addRow(
-						tree.NewDInt(tree.DInt(descriptor.GetID())),
-						tree.NewDString(dbName),
-						tree.NewDString(schema),
-						tree.NewDString(descriptor.GetName()),
-						tree.NewDString(validationError.Error()),
-					)
+			doError := func(validationError error) {
+				if err != nil {
+					return
 				}
+				err = addValidationErrorRow(schema, descriptor, validationError, lCtx)
 			}
-			version := p.ExecCfg().Settings.Version.ActiveVersion(ctx)
-			ve := c.ValidateWithRecover(
-				ctx,
-				version,
-				descriptor)
+			ve := c.ValidateWithRecover(ctx, version, descriptor)
 			for _, validationError := range ve {
-				addValidationErrorRow(validationError)
+				doError(validationError)
 			}
-			jobs.ValidateJobReferencesInDescriptor(descriptor, jmg, addValidationErrorRow)
+			jobs.ValidateJobReferencesInDescriptor(descriptor, jmg, doError)
 			return err
 		}
 
+		// Validate table descriptors
 		const allowAdding = true
 		if err := forEachTableDescWithTableLookupInternalFromDescriptors(
 			ctx, p, dbContext, hideVirtual, allowAdding, c, func(
-				dbDesc catalog.DatabaseDescriptor, schema string, descriptor catalog.TableDescriptor, _ tableLookupFn,
+				_ catalog.DatabaseDescriptor, schema string, descriptor catalog.TableDescriptor, lCtx tableLookupFn,
 			) error {
-				return addRowsForObject(dbDesc, schema, descriptor)
+				return doDescriptorValidationErrors(schema, descriptor, lCtx)
 			}); err != nil {
 			return err
 		}
 
 		// Validate type descriptors.
-		return forEachTypeDescWithTableLookupInternalFromDescriptors(
+		if err := forEachTypeDescWithTableLookupInternalFromDescriptors(
 			ctx, p, dbContext, allowAdding, c, func(
-				dbDesc catalog.DatabaseDescriptor, schema string, descriptor catalog.TypeDescriptor, _ tableLookupFn,
+				_ catalog.DatabaseDescriptor, schema string, descriptor catalog.TypeDescriptor, lCtx tableLookupFn,
 			) error {
-				return addRowsForObject(dbDesc, schema, descriptor)
+				return doDescriptorValidationErrors(schema, descriptor, lCtx)
+			}); err != nil {
+			return err
+		}
+
+		// Validate database & schema descriptors, and namespace entries.
+		{
+			lCtx := newInternalLookupCtx(c.OrderedDescriptors(), dbContext)
+
+			if err := c.ForEachDescriptorEntry(func(desc catalog.Descriptor) error {
+				switch d := desc.(type) {
+				case catalog.DatabaseDescriptor:
+					if dbContext != nil && d.GetID() != dbContext.GetID() {
+						return nil
+					}
+				case catalog.SchemaDescriptor:
+					if dbContext != nil && d.GetParentID() != dbContext.GetID() {
+						return nil
+					}
+				default:
+					return nil
+				}
+				return doDescriptorValidationErrors("" /* scName */, desc, lCtx)
+			}); err != nil {
+				return err
+			}
+
+			return c.ForEachNamespaceEntry(func(ne catalog.NameEntry) error {
+				if dbContext != nil {
+					if ne.GetParentID() == descpb.InvalidID {
+						if ne.GetID() != dbContext.GetID() {
+							return nil
+						}
+					} else if ne.GetParentID() != dbContext.GetID() {
+						return nil
+					}
+				}
+				return addValidationErrorRow("" /* scName */, ne, c.ValidateNamespaceEntry(ne), lCtx)
 			})
+		}
 	},
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -996,6 +996,41 @@ other_db       testuser  DROP            NO
 statement ok
 SET DATABASE = test
 
+## crdb_internal.invalid_objects
+subtest invalid_objects
+
+query ITTTT colnames
+SELECT * FROM crdb_internal.invalid_objects
+----
+id  database_name  schema_name  obj_name  error
+
+# corrupt the namespace table
+statement ok
+SELECT crdb_internal.unsafe_upsert_namespace_entry(0, 0, 'baddb', 500, true);
+SELECT crdb_internal.unsafe_upsert_namespace_entry(1, 0, 'badschema', 501, true);
+SELECT crdb_internal.unsafe_upsert_namespace_entry(1, 29, 'badobj', 502, true);
+SELECT crdb_internal.unsafe_upsert_namespace_entry(1, 404, 'badobj', 503, true);
+
+query ITTTT colnames
+SELECT * FROM "".crdb_internal.invalid_objects
+----
+id   database_name  schema_name  obj_name  error
+500  baddb          ·            ·         descriptor not found
+501  system         badschema    ·         descriptor not found
+502  system         public       badobj    descriptor not found
+503  system         [404]        badobj    descriptor not found
+
+statement ok
+SELECT crdb_internal.unsafe_delete_namespace_entry(0, 0, 'baddb', 500, true);
+SELECT crdb_internal.unsafe_delete_namespace_entry(1, 0, 'badschema', 501, true);
+SELECT crdb_internal.unsafe_delete_namespace_entry(1, 29, 'badobj', 502, true);
+SELECT crdb_internal.unsafe_delete_namespace_entry(1, 404, 'badobj', 503, true);
+
+query ITTTT colnames
+SELECT * FROM crdb_internal.invalid_objects
+----
+id  database_name  schema_name  obj_name  error
+
 # crdb_internal can be used with the anonymous database.
 # It should show information across all databases.
 subtest anonymous_database

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -334,7 +334,11 @@ func (s *TestState) mayGetByName(
 		ParentSchemaID: parentSchemaID,
 		Name:           name,
 	}
-	id := s.catalog.LookupNamespaceEntry(key)
+	ne := s.catalog.LookupNamespaceEntry(key)
+	if ne == nil {
+		return nil
+	}
+	id := ne.GetID()
 	if id == descpb.InvalidID {
 		return nil
 	}
@@ -669,12 +673,13 @@ func (b *testCatalogChangeBatcher) ValidateAndRun(ctx context.Context) error {
 	})
 	for _, nameInfo := range names {
 		expectedID := b.namesToDelete[nameInfo]
-		actualID := b.s.catalog.LookupNamespaceEntry(nameInfo)
-		if actualID == descpb.InvalidID {
+		ne := b.s.catalog.LookupNamespaceEntry(nameInfo)
+		if ne == nil {
 			return errors.AssertionFailedf(
 				"cannot delete missing namespace entry %v", nameInfo)
 		}
-		if actualID != expectedID {
+
+		if actualID := ne.GetID(); actualID != expectedID {
 			return errors.AssertionFailedf(
 				"expected deleted namespace entry %v to have ID %d, instead is %d", nameInfo, expectedID, actualID)
 		}


### PR DESCRIPTION
The invalid_objects virtual table is used to check the validity of the
catalog. The catalog comprises the state encoded in system.namespace and
system.descriptor. Previously, this table would only perform validation
checks on table and type descriptors.

This commit extends validation coverage to database and schema
descriptors as well as dangling descriptor ID references in the namespace
table. Now, the entirety of the catalog can be validated just as it
would be by running `cockroach debug doctor examine`.

Fixes #77143.
    
Release note: None

Jira issue: CRDB-14714