### PR TITLE
changefeedccl, backupresolver: refactor to hold on to mapping of target to descriptor

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -743,7 +743,7 @@ func backupPlanHook(
 		switch backupStmt.Coverage() {
 		case tree.RequestedDescriptors:
 			var err error
-			targetDescs, completeDBs, err = backupresolver.ResolveTargetsToDescriptors(ctx, p, endTime, backupStmt.Targets)
+			targetDescs, completeDBs, _, err = backupresolver.ResolveTargetsToDescriptors(ctx, p, endTime, backupStmt.Targets)
 			if err != nil {
 				return errors.Wrap(err, "failed to resolve targets specified in the BACKUP stmt")
 			}

--- a/pkg/ccl/backupccl/backupresolver/targets_test.go
+++ b/pkg/ccl/backupccl/backupresolver/targets_test.go
@@ -282,6 +282,12 @@ func TestDescriptorsMatchingTargets(t *testing.T) {
 				if !reflect.DeepEqual(test.expectedDBs, matchedDBNames) {
 					t.Fatalf("expected %q got %q", test.expectedDBs, matchedDBNames)
 				}
+				for _, p := range targets.Tables {
+					_, ok := matched.DescsByTablePattern[p]
+					if !ok {
+						t.Fatalf("no entry in %q for %q", matched.DescsByTablePattern, p)
+					}
+				}
 			}
 		})
 	}

--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -639,16 +639,12 @@ func fetchSpansForDescs(
 	statementTime hlc.Timestamp,
 	descs []catalog.Descriptor,
 ) ([]roachpb.Span, error) {
-	_, tables, err := getTargetsAndTables(ctx, p, descs, tree.ChangefeedTargets{}, opts)
-	if err != nil {
-		return nil, err
+	targets := make([]jobspb.ChangefeedTargetSpecification, len(descs))
+	for i, d := range descs {
+		targets[i] = jobspb.ChangefeedTargetSpecification{TableID: d.GetID()}
 	}
 
-	details := jobspb.ChangefeedDetails{
-		Tables: tables,
-	}
-
-	spans, err := fetchSpansForTargets(ctx, p.ExecCfg(), AllTargets(details), statementTime)
+	spans, err := fetchSpansForTargets(ctx, p.ExecCfg(), targets, statementTime)
 
 	return spans, err
 }

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -299,10 +299,13 @@ func createChangefeedJobRecord(
 		endTime = statementTime
 	}
 
-	targetList := uniqueTableNames(changefeedStmt.Targets)
+	tableOnlyTargetList := tree.TargetList{}
+	for _, t := range changefeedStmt.Targets {
+		tableOnlyTargetList.Tables = append(tableOnlyTargetList.Tables, t.TableName)
+	}
 
 	// This grabs table descriptors once to get their ids.
-	targetDescs, err := getTableDescriptors(ctx, p, &targetList, statementTime, initialHighWater)
+	targetDescs, err := getTableDescriptors(ctx, p, &tableOnlyTargetList, statementTime, initialHighWater)
 	if err != nil {
 		return nil, err
 	}
@@ -499,7 +502,7 @@ func getTableDescriptors(
 	targets *tree.TargetList,
 	statementTime hlc.Timestamp,
 	initialHighWater hlc.Timestamp,
-) ([]catalog.Descriptor, error) {
+) (map[tree.TablePattern]catalog.Descriptor, error) {
 	// For now, disallow targeting a database or wildcard table selection.
 	// Getting it right as tables enter and leave the set over time is
 	// tricky.
@@ -517,9 +520,7 @@ func getTableDescriptors(
 		}
 	}
 
-	// This grabs table descriptors once to get their ids.
-	targetDescs, _, err := backupresolver.ResolveTargetsToDescriptors(
-		ctx, p, statementTime, targets)
+	_, _, targetDescs, err := backupresolver.ResolveTargetsToDescriptors(ctx, p, statementTime, targets)
 	if err != nil {
 		var m *backupresolver.MissingTableErr
 		if errors.As(err, &m) {
@@ -540,7 +541,7 @@ func getTableDescriptors(
 func getTargetsAndTables(
 	ctx context.Context,
 	p sql.PlanHookState,
-	targetDescs []catalog.Descriptor,
+	targetDescs map[tree.TablePattern]catalog.Descriptor,
 	rawTargets tree.ChangefeedTargets,
 	opts map[string]string,
 ) ([]jobspb.ChangefeedTargetSpecification, jobspb.ChangefeedTargets, error) {
@@ -563,9 +564,13 @@ func getTargetsAndTables(
 		}
 	}
 	for i, ct := range rawTargets {
-		td, err := matchDescriptorToTablePattern(ctx, p, targetDescs, ct.TableName)
-		if err != nil {
-			return nil, nil, err
+		desc, ok := targetDescs[ct.TableName]
+		if !ok {
+			return nil, nil, errors.Newf("could not match %v to a fetched descriptor. fetched were %v", ct.TableName, targetDescs)
+		}
+		td, ok := desc.(catalog.TableDescriptor)
+		if !ok {
+			return nil, nil, errors.Errorf(`CHANGEFEED cannot target %s`, tree.AsString(&ct))
 		}
 		typ := jobspb.ChangefeedTargetSpecification_PRIMARY_FAMILY_ONLY
 		if ct.FamilyName != "" {
@@ -583,49 +588,6 @@ func getTargetsAndTables(
 		}
 	}
 	return targets, tables, nil
-}
-
-// TODO (zinger): This is redoing work already done in backupresolver. Have backupresolver
-// return a map of descriptors to table patterns so this isn't necessary and is less fragile.
-func matchDescriptorToTablePattern(
-	ctx context.Context, p sql.PlanHookState, descs []catalog.Descriptor, t tree.TablePattern,
-) (catalog.TableDescriptor, error) {
-	pattern, err := t.NormalizeTablePattern()
-	if err != nil {
-		return nil, err
-	}
-	name, ok := pattern.(*tree.TableName)
-	if !ok {
-		return nil, errors.Newf("%v is not a TableName", pattern)
-	}
-	for _, desc := range descs {
-		tbl, ok := desc.(catalog.TableDescriptor)
-		if !ok {
-			continue
-		}
-		if tbl.GetName() != string(name.ObjectName) {
-			continue
-		}
-		qtn, err := getQualifiedTableNameObj(ctx, p.ExecCfg(), p.ExtendedEvalContext().Txn, tbl)
-		if err != nil {
-			return nil, err
-		}
-		switch name.ToUnresolvedObjectName().NumParts {
-		case 1:
-			if qtn.CatalogName == tree.Name(p.CurrentDatabase()) {
-				return tbl, nil
-			}
-		case 2:
-			if qtn.CatalogName == name.SchemaName {
-				return tbl, nil
-			}
-		case 3:
-			if qtn.CatalogName == name.CatalogName && qtn.SchemaName == name.SchemaName {
-				return tbl, nil
-			}
-		}
-	}
-	return nil, errors.Newf("could not match %v to a fetched descriptor", t)
 }
 
 func validateSink(
@@ -1152,20 +1114,4 @@ func AllTargets(cd jobspb.ChangefeedDetails) (targets []jobspb.ChangefeedTargetS
 		}
 	}
 	return
-}
-
-// uniqueTableNames creates a TargetList whose Tables are
-// the table names in cts, removing duplicates.
-func uniqueTableNames(cts tree.ChangefeedTargets) tree.TargetList {
-	uniqueTablePatterns := make(map[string]tree.TablePattern)
-	for _, t := range cts {
-		uniqueTablePatterns[t.TableName.String()] = t.TableName
-	}
-
-	targetList := tree.TargetList{}
-	for _, t := range uniqueTablePatterns {
-		targetList.Tables = append(targetList.Tables, t)
-	}
-
-	return targetList
 }


### PR DESCRIPTION

Changefeed statements need to resolve a bunch of table names at once,
 but unlike backups and grants they need to know which returned
descriptor corresponded to which input because they (now) take
target-specific options. We were reconstructing this awkwardly on
the calling side. This PR adds an optional parameter to the
 backupresolver method being used so that it can track which
 descriptor belongs to which input.

I'm probably being overly polite by making this optional,
but hey, it is a little extra memory footprint and not my package.

Release note: None