### PR TITLE
sql/importer: re-validate unique constraints after IMPORT

### DIFF
--- a/pkg/ccl/importerccl/ccl_test.go
+++ b/pkg/ccl/importerccl/ccl_test.go
@@ -58,7 +58,7 @@ func TestImportMultiRegion(t *testing.T) {
 
 	baseDir := sharedTestdata(t)
 	tc, sqlDB, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
-		t, 2 /* numServers */, base.TestingKnobs{}, multiregionccltestutils.WithBaseDirectory(baseDir),
+		t, 3 /* numServers */, base.TestingKnobs{}, multiregionccltestutils.WithBaseDirectory(baseDir),
 	)
 	defer cleanup()
 
@@ -86,7 +86,7 @@ func TestImportMultiRegion(t *testing.T) {
 
 	// Create the databases
 	tdb.Exec(t, `CREATE DATABASE foo`)
-	tdb.Exec(t, `CREATE DATABASE multi_region PRIMARY REGION "us-east1"`)
+	tdb.Exec(t, `CREATE DATABASE multi_region PRIMARY REGION "us-east1" REGIONS "us-east1", "us-east2"`)
 
 	simpleOcf := fmt.Sprintf("nodelocal://0/avro/%s", "simple.ocf")
 
@@ -184,6 +184,17 @@ DROP VIEW IF EXISTS v`,
 				data:   "1,\"foo\",NULL,us-east1\n",
 			},
 			{
+				name:  "import-into-multi-region-regional-by-row-dupes",
+				db:    "multi_region",
+				table: "mr_regional_by_row",
+				create: "CREATE TABLE mr_regional_by_row (i INT8 PRIMARY KEY) LOCALITY REGIONAL BY ROW;" +
+					"INSERT INTO mr_regional_by_row (i, crdb_region) VALUES (1, 'us-east2')",
+				sql:       "IMPORT INTO mr_regional_by_row (i, crdb_region) CSV DATA ($1)",
+				args:      []interface{}{srv.URL},
+				data:      "1,us-east1\n",
+				errString: `failed to validate unique constraint`,
+			},
+			{
 				name:   "import-into-multi-region-regional-by-row-to-multi-region-database-concurrent-table-add",
 				db:     "multi_region",
 				table:  "mr_regional_by_row",
@@ -199,7 +210,7 @@ DROP VIEW IF EXISTS v`,
 				table:  "mr_regional_by_row",
 				create: "CREATE TABLE mr_regional_by_row (i INT8 PRIMARY KEY, s text, b bytea) LOCALITY REGIONAL BY ROW",
 				sql:    "IMPORT INTO mr_regional_by_row (i, s, b, crdb_region) CSV DATA ($1)",
-				during: `ALTER DATABASE multi_region ADD REGION "us-east2"`,
+				during: `ALTER DATABASE multi_region ADD REGION "us-east3"`,
 				errString: `type descriptor "crdb_internal_region" \(\d+\) has been ` +
 					`modified, potentially incompatibly, since import planning; ` +
 					`aborting to avoid possible corruption`,

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -381,7 +381,7 @@ func (p *planner) RevalidateUniqueConstraintsInCurrentDB(ctx context.Context) er
 	}
 
 	for _, tableDesc := range tableDescs {
-		if err = p.revalidateUniqueConstraintsInTable(ctx, tableDesc); err != nil {
+		if err = RevalidateUniqueConstraintsInTable(ctx, p.Txn(), p.ExecCfg().InternalExecutor, tableDesc); err != nil {
 			return err
 		}
 	}
@@ -402,7 +402,7 @@ func (p *planner) RevalidateUniqueConstraintsInTable(ctx context.Context, tableI
 	if err != nil {
 		return err
 	}
-	return p.revalidateUniqueConstraintsInTable(ctx, tableDesc)
+	return RevalidateUniqueConstraintsInTable(ctx, p.Txn(), p.ExecCfg().InternalExecutor, tableDesc)
 }
 
 // RevalidateUniqueConstraint verifies that the given unique constraint on the
@@ -465,7 +465,23 @@ func (p *planner) RevalidateUniqueConstraint(
 	return errors.Newf("unique constraint %s does not exist", constraintName)
 }
 
-// revalidateUniqueConstraintsInTable verifies that all unique constraints
+// HasVirtualUniqueConstraints returns true if the table has one or more
+// constraints that are validated by RevalidateUniqueConstraintsInTable.
+func HasVirtualUniqueConstraints(tableDesc catalog.TableDescriptor) bool {
+	for _, index := range tableDesc.ActiveIndexes() {
+		if index.IsUnique() && index.GetPartitioning().NumImplicitColumns() > 0 {
+			return true
+		}
+	}
+	for _, uc := range tableDesc.GetUniqueWithoutIndexConstraints() {
+		if uc.Validity == descpb.ConstraintValidity_Validated {
+			return true
+		}
+	}
+	return false
+}
+
+// RevalidateUniqueConstraintsInTable verifies that all unique constraints
 // defined on the given table are valid. In other words, it verifies that all
 // rows in the table have unique values for every unique constraint defined on
 // the table.
@@ -473,8 +489,8 @@ func (p *planner) RevalidateUniqueConstraint(
 // Note that we only need to validate UNIQUE constraints that are not already
 // enforced by an index. This includes implicitly partitioned UNIQUE indexes
 // and UNIQUE WITHOUT INDEX constraints.
-func (p *planner) revalidateUniqueConstraintsInTable(
-	ctx context.Context, tableDesc catalog.TableDescriptor,
+func RevalidateUniqueConstraintsInTable(
+	ctx context.Context, txn *kv.Txn, ie sqlutil.InternalExecutor, tableDesc catalog.TableDescriptor,
 ) error {
 	// Check implicitly partitioned UNIQUE indexes.
 	for _, index := range tableDesc.ActiveIndexes() {
@@ -485,8 +501,8 @@ func (p *planner) revalidateUniqueConstraintsInTable(
 				index.GetName(),
 				index.IndexDesc().KeyColumnIDs[index.GetPartitioning().NumImplicitColumns():],
 				index.GetPredicate(),
-				p.ExecCfg().InternalExecutor,
-				p.Txn(),
+				ie,
+				txn,
 				true, /* preExisting */
 			); err != nil {
 				log.Errorf(ctx, "validation of unique constraints failed for table %s: %s", tableDesc.GetName(), err)
@@ -504,8 +520,8 @@ func (p *planner) revalidateUniqueConstraintsInTable(
 				uc.Name,
 				uc.ColumnIDs,
 				uc.Predicate,
-				p.ExecCfg().InternalExecutor,
-				p.Txn(),
+				ie,
+				txn,
 				true, /* preExisting */
 			); err != nil {
 				log.Errorf(ctx, "validation of unique constraints failed for table %s: %s", tableDesc.GetName(), err)


### PR DESCRIPTION
Release note (bug fix): Previously IMPORT INTO could create duplicate entries violating UNIQUE constraints in REGIONAL BY ROW tables and tables utilizing UNIQUE WITHOUT INDEX constraints. A new post-IMPORT validation step for those tables now fails and rolls back the IMPORT in such cases.