### PR TITLE
sql: fix `SHOW SCHEMAS FROM` to include user-defined schemas

### DIFF
--- a/pkg/sql/delegate/show_schemas.go
+++ b/pkg/sql/delegate/show_schemas.go
@@ -30,8 +30,8 @@ func (d *delegator) delegateShowSchemas(n *tree.ShowSchemas) (tree.Statement, er
 	getSchemasQuery := fmt.Sprintf(`
       SELECT nspname AS schema_name, rolname AS owner
       FROM %[1]s.information_schema.schemata i
-      INNER JOIN pg_catalog.pg_namespace n ON (n.nspname = i.schema_name)
-      LEFT JOIN pg_catalog.pg_roles r ON (n.nspowner = r.oid)
+      INNER JOIN %[1]s.pg_catalog.pg_namespace n ON (n.nspname = i.schema_name)
+      LEFT JOIN %[1]s.pg_catalog.pg_roles r ON (n.nspowner = r.oid)
 			WHERE catalog_name = %[2]s
 			ORDER BY schema_name`,
 		name.String(), // note: (tree.Name).String() != string(name)

--- a/pkg/sql/logictest/testdata/logic_test/database
+++ b/pkg/sql/logictest/testdata/logic_test/database
@@ -41,6 +41,10 @@ postgres       root   NULL            {}       NULL           NULL
 system         node   NULL            {}       NULL           NULL
 test           root   NULL            {}       NULL           NULL
 
+# Verify that SHOW SCHEMAS FROM a includes user-defined schemas.
+statement ok
+CREATE SCHEMA a.s
+
 query TT colnames
 SHOW SCHEMAS FROM a
 ----
@@ -50,6 +54,7 @@ information_schema  NULL
 pg_catalog          NULL
 pg_extension        NULL
 public              admin
+s                   root
 
 statement ok
 CREATE DATABASE b TEMPLATE=template0


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/79282

The search query had a broken join condition which would incorrectly
filter out user-defined schemas, since using the unqualified pg_catalog
would only look in the current database.

Release note (bug fix): Fixed a bug where `SHOW SCHEMAS FROM <schema>`
would not include user-defined schemas.