### PR TITLE
pkg/util/admission: track history for bytes added per work

### DIFF
--- a/pkg/util/admission/granter.go
+++ b/pkg/util/admission/granter.go
@@ -1508,8 +1508,9 @@ type ioLoadListener struct {
 	l0Bytes          int64
 	l0AddedBytes     uint64
 	// Exponentially smoothed per interval values.
-	smoothedBytesRemoved int64
-	smoothedNumAdmit     float64
+	smoothedBytesRemoved      int64
+	smoothedNumAdmit          float64
+	smoothedBytesAddedPerWork float64
 
 	// totalTokens represents the tokens to give out until the next call to
 	// adjustTokens. They are given out with smoothing -- tokensAllocated
@@ -1651,19 +1652,41 @@ func (io *ioLoadListener) adjustTokens(ctx context.Context, m *pebble.Metrics) {
 		// situation.
 		doLog = false
 	}
+	// Attribute the bytesAdded equally to all the admitted work.
+	// INVARIANT: perWork >= 0
+	if perWork := float64(bytesAdded) / float64(admitted); perWork > 0 && admitted > 1 {
+		// Track an exponentially smoothed estimate of bytes added per work when
+		// there was some work actually admitted. Note we treat having admitted
+		// one item as the same as having admitted zero both because we clamp
+		// admitted to 1 and if we only admitted one thing, do we really want to
+		// use that for our estimate? The conjunction includes perWork > 0 (and
+		// not just admitted), since we have seen situation where perWork=0 and
+		// admitted > 1. This can happen since the stats from Pebble (bytesAdded)
+		// and those from the requester (admitted) are not synchronized -- the
+		// bytes are written to Pebble after admission, so there is a lag from
+		// when the counter is incremented in the latter and the bytes are
+		// incremented in the former.
+		if io.smoothedBytesAddedPerWork == 0 {
+			io.smoothedBytesAddedPerWork = perWork
+		} else {
+			io.smoothedBytesAddedPerWork = alpha*perWork +
+				(1-alpha)*io.smoothedBytesAddedPerWork
+		}
+	}
+
 	// We constrain admission if the store if over the threshold.
 	if m.Levels[0].NumFiles > L0FileCountOverloadThreshold.Get(&io.settings.SV) ||
 		m.Levels[0].Sublevels > int32(L0SubLevelCountOverloadThreshold.Get(&io.settings.SV)) {
-		// Attribute the bytesAdded equally to all the admitted work.
-		// INVARIANT: bytesAddedPerWork >= 0
-		bytesAddedPerWork := float64(bytesAdded) / float64(admitted)
-		if bytesAddedPerWork == 0 {
-			// We are here because bytesAdded was 0. This will be very rare.
-			bytesAddedPerWork = 1
+
+		smoothedBytesAddedPerWork := io.smoothedBytesAddedPerWork
+		if io.smoothedBytesAddedPerWork < 1 {
+			// Rare case where we've never seen any work items or somehow the
+			// estimate is less than 1. This is important to avoid overflow.
+			smoothedBytesAddedPerWork = 1
 		}
 		// Don't admit more work than we can remove via compactions. numAdmit
 		// tracks our goal for admission.
-		numAdmit := float64(io.smoothedBytesRemoved) / bytesAddedPerWork
+		numAdmit := float64(io.smoothedBytesRemoved) / smoothedBytesAddedPerWork
 		// Scale down since we want to get under the thresholds over time. This
 		// scaling could be adjusted based on how much above the threshold we are,
 		// but for now we just use a constant.
@@ -1686,7 +1709,7 @@ func (io *ioLoadListener) adjustTokens(ctx context.Context, m *pebble.Metrics) {
 		}
 	} else {
 		// Under the threshold. Maintain a smoothedNumAdmit so that it is not 0
-		// when we first go over the threshold. Instead use what we actually
+		// when we first go over the threshold. Instead, use what we actually
 		// admitted.
 		io.smoothedNumAdmit = alpha*float64(admitted) + (1-alpha)*io.smoothedNumAdmit
 		io.totalTokens = unlimitedTokens

--- a/pkg/util/admission/granter_test.go
+++ b/pkg/util/admission/granter_test.go
@@ -377,9 +377,10 @@ func TestIOLoadListener(t *testing.T) {
 				// Do the ticks until just before next adjustment.
 				var buf strings.Builder
 				fmt.Fprintf(&buf, "admitted: %d, bytes: %d, added-bytes: %d,\nsmoothed-removed: %d, "+
-					"smoothed-admit: %d,\ntokens: %s, tokens-allocated: %s\n", ioll.admittedCount,
+					"smoothed-admit: %d, smoothed-bytes-added-per-work: %d,\ntokens: %s, tokens-allocated: %s\n", ioll.admittedCount,
 					ioll.l0Bytes, ioll.l0AddedBytes, ioll.smoothedBytesRemoved,
-					int64(ioll.smoothedNumAdmit), tokensForIntervalToString(ioll.totalTokens),
+					int64(ioll.smoothedNumAdmit), int64(ioll.smoothedBytesAddedPerWork),
+					tokensForIntervalToString(ioll.totalTokens),
 					tokensFor1sToString(ioll.tokensAllocated))
 				for i := 0; i < adjustmentInterval; i++ {
 					ioll.allocateTokensTick()

--- a/pkg/util/admission/testdata/io_load_listener
+++ b/pkg/util/admission/testdata/io_load_listener
@@ -2,7 +2,7 @@
 set-state admitted=0 l0-bytes=10000 l0-added=1000 l0-files=21 l0-sublevels=21
 ----
 admitted: 0, bytes: 10000, added-bytes: 1000,
-smoothed-removed: 0, smoothed-admit: 0,
+smoothed-removed: 0, smoothed-admit: 0, smoothed-bytes-added-per-work: 0,
 tokens: unlimited, tokens-allocated: 0
 tick: 0, setAvailableIOTokens: unlimited
 tick: 1, setAvailableIOTokens: unlimited
@@ -27,7 +27,7 @@ tick: 14, setAvailableIOTokens: unlimited
 set-state admitted=10000 l0-bytes=10000 l0-added=101000 l0-files=21 l0-sublevels=21
 ----
 admitted: 10000, bytes: 10000, added-bytes: 101000,
-smoothed-removed: 50000, smoothed-admit: 1250,
+smoothed-removed: 50000, smoothed-admit: 1250, smoothed-bytes-added-per-work: 10,
 tokens: 1250, tokens-allocated: 0
 tick: 0, setAvailableIOTokens: 84
 tick: 1, setAvailableIOTokens: 84
@@ -49,7 +49,7 @@ tick: 14, setAvailableIOTokens: 74
 set-state admitted=20000 l0-bytes=10000 l0-added=201000 l0-files=21 l0-sublevels=21
 ----
 admitted: 20000, bytes: 10000, added-bytes: 201000,
-smoothed-removed: 75000, smoothed-admit: 2500,
+smoothed-removed: 75000, smoothed-admit: 2500, smoothed-bytes-added-per-work: 10,
 tokens: 2500, tokens-allocated: 0
 tick: 0, setAvailableIOTokens: 167
 tick: 1, setAvailableIOTokens: 167
@@ -71,30 +71,30 @@ tick: 14, setAvailableIOTokens: 162
 set-state admitted=20000 l0-bytes=10000 l0-added=201000 l0-files=21 l0-sublevels=21
 ----
 admitted: 20000, bytes: 10000, added-bytes: 201000,
-smoothed-removed: 37500, smoothed-admit: 10625,
-tokens: 10625, tokens-allocated: 0
-tick: 0, setAvailableIOTokens: 709
-tick: 1, setAvailableIOTokens: 709
-tick: 2, setAvailableIOTokens: 709
-tick: 3, setAvailableIOTokens: 709
-tick: 4, setAvailableIOTokens: 709
-tick: 5, setAvailableIOTokens: 709
-tick: 6, setAvailableIOTokens: 709
-tick: 7, setAvailableIOTokens: 709
-tick: 8, setAvailableIOTokens: 709
-tick: 9, setAvailableIOTokens: 709
-tick: 10, setAvailableIOTokens: 709
-tick: 11, setAvailableIOTokens: 709
-tick: 12, setAvailableIOTokens: 709
-tick: 13, setAvailableIOTokens: 709
-tick: 14, setAvailableIOTokens: 699
+smoothed-removed: 37500, smoothed-admit: 2187, smoothed-bytes-added-per-work: 10,
+tokens: 2187, tokens-allocated: 0
+tick: 0, setAvailableIOTokens: 146
+tick: 1, setAvailableIOTokens: 146
+tick: 2, setAvailableIOTokens: 146
+tick: 3, setAvailableIOTokens: 146
+tick: 4, setAvailableIOTokens: 146
+tick: 5, setAvailableIOTokens: 146
+tick: 6, setAvailableIOTokens: 146
+tick: 7, setAvailableIOTokens: 146
+tick: 8, setAvailableIOTokens: 146
+tick: 9, setAvailableIOTokens: 146
+tick: 10, setAvailableIOTokens: 146
+tick: 11, setAvailableIOTokens: 146
+tick: 12, setAvailableIOTokens: 146
+tick: 13, setAvailableIOTokens: 146
+tick: 14, setAvailableIOTokens: 143
 
 # l0-sublevels drops below threshold. We calculate the smoothed values, but
 # don't limit the tokens.
-set-state admitted=30000 l0-bytes=10000 l0-added=301000 l0-files=21 l0-sublevels=20
+set-state admitted=30000 l0-bytes=10000 l0-added=501000 l0-files=21 l0-sublevels=20
 ----
-admitted: 30000, bytes: 10000, added-bytes: 301000,
-smoothed-removed: 68750, smoothed-admit: 10312,
+admitted: 30000, bytes: 10000, added-bytes: 501000,
+smoothed-removed: 168750, smoothed-admit: 6093, smoothed-bytes-added-per-work: 20,
 tokens: unlimited, tokens-allocated: 0
 tick: 0, setAvailableIOTokens: unlimited
 tick: 1, setAvailableIOTokens: unlimited


### PR DESCRIPTION
Before this patch, when no bytes were admitted in an interval, we'd assume that
the correct estimate per byte was 1. This meant that we could see a huge jump
in tokens which effectively disabled the throttling of admission control.

Backports will address https://github.com/cockroachdb/cockroach/issues/79214. 

Release note (bug fix): Fixed a bug in IO admission control which could result
in admission control failing to rate-limit when traffic was stalled such that
no work was admitted, despite the store's being in an unhealthy state.

Jira issue: CRDB-14724