### PR TITLE
release-22.1: rangefeed: add lower safety threshold and emergency disable switch to rangefeed budgets

### DIFF
--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
     deps = [
         "//pkg/keys",
         "//pkg/roachpb",
+        "//pkg/settings",
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/util/bufalloc",

--- a/pkg/kv/kvserver/rangefeed/budget_test.go
+++ b/pkg/kv/kvserver/rangefeed/budget_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/stretchr/testify/require"
 )
@@ -173,21 +174,30 @@ func TestFeedBudget(t *testing.T) {
 }
 
 func TestBudgetFactory(t *testing.T) {
-	rootMon := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
+	s := cluster.MakeTestingClusterSettings()
+
+	rootMon := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, s)
 	rootMon.Start(context.Background(), nil, mon.MakeStandaloneBudget(10000000))
 	bf := NewBudgetFactory(context.Background(), rootMon, 10000, time.Second*5)
 
 	// Verify system ranges use own budget.
-	bSys := bf.CreateBudget(keys.MustAddr(keys.Meta1Prefix))
+	bSys := bf.CreateBudget(keys.MustAddr(keys.Meta1Prefix), &s.SV)
 	_, e := bSys.TryGet(context.Background(), 199)
 	require.NoError(t, e, "failed to obtain system range budget")
 	require.Equal(t, int64(0), rootMon.AllocBytes(), "System feeds should borrow from own budget")
 	require.Equal(t, int64(199), bf.Metrics().SystemBytesCount.Value(), "Metric was not updated")
 
 	// Verify user feeds use shared root budget.
-	bUsr := bf.CreateBudget(keys.MustAddr(keys.SystemSQLCodec.TablePrefix(keys.MaxReservedDescID + 1)))
+	bUsr := bf.CreateBudget(keys.MustAddr(keys.SystemSQLCodec.TablePrefix(keys.MaxReservedDescID+1)),
+		&s.SV)
 	_, e = bUsr.TryGet(context.Background(), 99)
 	require.NoError(t, e, "failed to obtain non-system budget")
 	require.Equal(t, int64(99), rootMon.AllocBytes(), "Non-system feeds should borrow from shared budget")
 	require.Equal(t, int64(99), bf.Metrics().SharedBytesCount.Value(), "Metric was not updated")
+
+	// Verify is budget is disabled in settings, nil budget is created.
+	RangefeedBudgetsEnabled.Override(context.Background(), &s.SV, false)
+	bUsr = bf.CreateBudget(keys.MustAddr(keys.SystemSQLCodec.TablePrefix(keys.MaxReservedDescID+1)),
+		&s.SV)
+	require.Nil(t, bUsr, "Range budget when budgets are disabled.")
 }

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -537,10 +538,7 @@ func TestProcessorSlowConsumer(t *testing.T) {
 func TestProcessorMemoryBudgetExceeded(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
-	m.Start(context.Background(), nil, mon.MakeStandaloneBudget(40))
-	b := m.MakeBoundAccount()
-	fb := NewFeedBudget(&b, 0)
+	fb := newTestBudget(40)
 
 	stopper := stop.NewStopper()
 	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
@@ -608,10 +606,7 @@ func TestProcessorMemoryBudgetExceeded(t *testing.T) {
 func TestProcessorMemoryBudgetReleased(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
-	m.Start(context.Background(), nil, mon.MakeStandaloneBudget(40))
-	b := m.MakeBoundAccount()
-	fb := NewFeedBudget(&b, 0)
+	fb := newTestBudget(40)
 
 	stopper := stop.NewStopper()
 	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
@@ -1086,10 +1081,12 @@ func TestBudgetReleaseOnProcessorStop(t *testing.T) {
 	// as sync events used to flush queues.
 	const channelCapacity = totalEvents/2 + 10
 
+	s := cluster.MakeTestingClusterSettings()
 	m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
 	m.Start(context.Background(), nil, mon.MakeStandaloneBudget(math.MaxInt64))
+	//budgetEnabled := int32(1)
 	b := m.MakeBoundAccount()
-	fb := NewFeedBudget(&b, 0)
+	fb := NewFeedBudget(&b, 0, &s.SV)
 
 	stopper := stop.NewStopper()
 	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
@@ -1177,10 +1174,7 @@ func TestBudgetReleaseOnLastStreamError(t *testing.T) {
 	// objects. Ideally it would be nice to have
 	const channelCapacity = totalEvents + 5
 
-	m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
-	m.Start(context.Background(), nil, mon.MakeStandaloneBudget(math.MaxInt64))
-	b := m.MakeBoundAccount()
-	fb := NewFeedBudget(&b, 0)
+	fb := newTestBudget(math.MaxInt64)
 
 	stopper := stop.NewStopper()
 	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
@@ -1234,6 +1228,15 @@ func TestBudgetReleaseOnLastStreamError(t *testing.T) {
 	requireBudgetDrainedSoon(t, p, rStream)
 }
 
+func newTestBudget(limit int64) *FeedBudget {
+	s := cluster.MakeTestingClusterSettings()
+	m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
+	m.Start(context.Background(), nil, mon.MakeStandaloneBudget(limit))
+	b := m.MakeBoundAccount()
+	fb := NewFeedBudget(&b, 0, &s.SV)
+	return fb
+}
+
 // TestBudgetReleaseOnOneStreamError verifies that if one stream fails while
 // other keeps running, accounting correctly releases memory budget for shared
 // events.
@@ -1248,10 +1251,7 @@ func TestBudgetReleaseOnOneStreamError(t *testing.T) {
 	// as sync events used to flush queues.
 	const channelCapacity = totalEvents/2 + 10
 
-	m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
-	m.Start(context.Background(), nil, mon.MakeStandaloneBudget(math.MaxInt64))
-	b := m.MakeBoundAccount()
-	fb := NewFeedBudget(&b, 0)
+	fb := newTestBudget(math.MaxInt64)
 
 	stopper := stop.NewStopper()
 	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
@@ -1417,10 +1417,7 @@ func BenchmarkProcessorWithBudget(b *testing.B) {
 
 	var budget *FeedBudget
 	if false {
-		m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
-		m.Start(context.Background(), nil, mon.MakeStandaloneBudget(math.MaxInt64))
-		acc := m.MakeBoundAccount()
-		budget = NewFeedBudget(&acc, 0)
+		budget = newTestBudget(math.MaxInt64)
 	}
 
 	stopper := stop.NewStopper()

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -364,7 +364,8 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 	}
 	r.rangefeedMu.Unlock()
 
-	feedBudget := r.store.GetStoreConfig().RangefeedBudgetFactory.CreateBudget(r.startKey)
+	feedBudget := r.store.GetStoreConfig().RangefeedBudgetFactory.CreateBudget(r.startKey,
+		&r.store.cfg.Settings.SV)
 
 	// Create a new rangefeed.
 	desc := r.Desc()

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -364,8 +364,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 	}
 	r.rangefeedMu.Unlock()
 
-	feedBudget := r.store.GetStoreConfig().RangefeedBudgetFactory.CreateBudget(r.startKey,
-		&r.store.cfg.Settings.SV)
+	feedBudget := r.store.GetStoreConfig().RangefeedBudgetFactory.CreateBudget(r.startKey)
 
 	// Create a new rangefeed.
 	desc := r.Desc()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -495,7 +495,8 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 					return raftCmdLimit
 				}
 				return limit
-			}))
+			},
+			&st.SV))
 	if rangeReedBudgetFactory != nil {
 		registry.AddMetricStruct(rangeReedBudgetFactory.Metrics())
 	}


### PR DESCRIPTION
Backport:
  * 1/1 commits from "rangefeed: add a cluster setting to disable rangefeed budgets" (#78600)
  * 1/1 commits from "rangefeed: use raft msg based lower mem budget limit" (#78950)
  * 1/1 commits from "rangefeed: disable rangefeed memory budgets dynamically" (#78969)

Please see individual PRs for details.

Release justification: This backport adds: a safety switch for the new feature to disable it on the fly without restarting nodes (#78600 & #78969) and a lower limit for memory budget that relies on raft command side to protect from misconfigurations where very low budget configuration would prevent rangefeeds from working.

/cc @cockroachdb/release


Jira issue: CRDB-14730