### PR TITLE
changefeedccl: unify initial_scan option syntax

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -10,6 +10,7 @@ package changefeedccl
 
 import (
 	"context"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -21,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/errors"
 )
 
 const (
@@ -97,11 +99,61 @@ func makeSpansToProtect(
 	return spansToProtect
 }
 
-// initialScanFromOptions returns whether or not the options indicate the need
-// for an initial scan on the first run.
-func initialScanFromOptions(opts map[string]string) bool {
+// initialScanTypeFromOpts determines the type of initial scan the changefeed
+// should perform on the first run given the options provided from the user
+func initialScanTypeFromOpts(opts map[string]string) (changefeedbase.InitialScanType, error) {
 	_, cursor := opts[changefeedbase.OptCursor]
-	_, initialScan := opts[changefeedbase.OptInitialScan]
-	_, noInitialScan := opts[changefeedbase.OptNoInitialScan]
-	return (cursor && initialScan) || (!cursor && !noInitialScan)
+	initialScanType, initialScanSet := opts[changefeedbase.OptInitialScan]
+	_, initialScanOnlySet := opts[changefeedbase.OptInitialScanOnly]
+	_, noInitialScanSet := opts[changefeedbase.OptNoInitialScan]
+
+	if initialScanSet && noInitialScanSet {
+		return changefeedbase.InitialScan, errors.Errorf(
+			`cannot specify both %s and %s`, changefeedbase.OptInitialScan,
+			changefeedbase.OptNoInitialScan)
+	}
+
+	if initialScanSet && initialScanOnlySet {
+		return changefeedbase.InitialScan, errors.Errorf(
+			`cannot specify both %s and %s`, changefeedbase.OptInitialScan,
+			changefeedbase.OptInitialScanOnly)
+	}
+
+	if noInitialScanSet && initialScanOnlySet {
+		return changefeedbase.InitialScan, errors.Errorf(
+			`cannot specify both %s and %s`, changefeedbase.OptInitialScanOnly,
+			changefeedbase.OptNoInitialScan)
+	}
+
+	if initialScanSet {
+		const opt = changefeedbase.OptInitialScan
+		switch strings.ToLower(initialScanType) {
+		case ``, `yes`:
+			return changefeedbase.InitialScan, nil
+		case `no`:
+			return changefeedbase.NoInitialScan, nil
+		case `only`:
+			return changefeedbase.OnlyInitialScan, nil
+		default:
+			return changefeedbase.InitialScan, errors.Errorf(
+				`unknown %s: %s`, opt, initialScanType)
+		}
+	}
+
+	if initialScanOnlySet {
+		return changefeedbase.OnlyInitialScan, nil
+	}
+
+	if noInitialScanSet {
+		return changefeedbase.NoInitialScan, nil
+	}
+
+	// If we reach this point, this implies that the user did not specify any initial scan
+	// options. In this case the default behaviour is to perform an initial scan if the
+	// cursor is not specified.
+	if !cursor {
+		return changefeedbase.InitialScan, nil
+	}
+
+	return changefeedbase.NoInitialScan, nil
 }

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -753,41 +753,62 @@ func TestChangefeedInitialScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	noInitialScanTests := map[string]string{
+		`no cursor - no initial scan`:     `CREATE CHANGEFEED FOR no_initial_scan WITH no_initial_scan, resolved='1s'`,
+		`no cursor - no initial backfill`: `CREATE CHANGEFEED FOR no_initial_scan WITH initial_scan = 'no', resolved='1s'`,
+	}
+
+	initialScanTests := map[string]string{
+		`cursor - with initial scan`:     `CREATE CHANGEFEED FOR initial_scan WITH initial_scan, resolved='1s', cursor='%s'`,
+		`cursor - with initial backfill`: `CREATE CHANGEFEED FOR initial_scan WITH initial_scan = 'yes', resolved='1s', cursor='%s'`,
+	}
+
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(db)
-		t.Run(`no cursor - no initial scan`, func(t *testing.T) {
-			sqlDB.Exec(t, `CREATE TABLE no_initial_scan (a INT PRIMARY KEY)`)
-			sqlDB.Exec(t, `INSERT INTO no_initial_scan VALUES (1)`)
 
-			noInitialScan := feed(t, f, `CREATE CHANGEFEED FOR no_initial_scan `+
-				`WITH no_initial_scan, resolved='1s'`)
-			defer closeFeed(t, noInitialScan)
-			expectResolvedTimestamp(t, noInitialScan)
-			sqlDB.Exec(t, `INSERT INTO no_initial_scan VALUES (2)`)
-			assertPayloads(t, noInitialScan, []string{
-				`no_initial_scan: [2]->{"after": {"a": 2}}`,
-			})
-		})
+		for testName, changefeedStmt := range noInitialScanTests {
+			t.Run(testName, func(t *testing.T) {
+				sqlDB.Exec(t, `CREATE TABLE no_initial_scan (a INT PRIMARY KEY)`)
+				sqlDB.Exec(t, `INSERT INTO no_initial_scan VALUES (1)`)
 
-		t.Run(`cursor - with initial scan`, func(t *testing.T) {
-			sqlDB.Exec(t, `CREATE TABLE initial_scan (a INT PRIMARY KEY)`)
-			sqlDB.Exec(t, `INSERT INTO initial_scan VALUES (1), (2), (3)`)
-			var tsStr string
-			var i int
-			sqlDB.QueryRow(t, `SELECT count(*), cluster_logical_timestamp() from initial_scan`).Scan(&i, &tsStr)
-			initialScan := feed(t, f, `CREATE CHANGEFEED FOR initial_scan `+
-				`WITH initial_scan, resolved='1s', cursor='`+tsStr+`'`)
-			defer closeFeed(t, initialScan)
-			assertPayloads(t, initialScan, []string{
-				`initial_scan: [1]->{"after": {"a": 1}}`,
-				`initial_scan: [2]->{"after": {"a": 2}}`,
-				`initial_scan: [3]->{"after": {"a": 3}}`,
+				noInitialScan := feed(t, f, changefeedStmt)
+				defer func() {
+					closeFeed(t, noInitialScan)
+					sqlDB.Exec(t, `DROP TABLE no_initial_scan`)
+				}()
+
+				expectResolvedTimestamp(t, noInitialScan)
+
+				sqlDB.Exec(t, `INSERT INTO no_initial_scan VALUES (2)`)
+				assertPayloads(t, noInitialScan, []string{
+					`no_initial_scan: [2]->{"after": {"a": 2}}`,
+				})
 			})
-			sqlDB.Exec(t, `INSERT INTO initial_scan VALUES (4)`)
-			assertPayloads(t, initialScan, []string{
-				`initial_scan: [4]->{"after": {"a": 4}}`,
+		}
+
+		for testName, changefeedStmtFormat := range initialScanTests {
+			t.Run(testName, func(t *testing.T) {
+				sqlDB.Exec(t, `CREATE TABLE initial_scan (a INT PRIMARY KEY)`)
+				sqlDB.Exec(t, `INSERT INTO initial_scan VALUES (1), (2), (3)`)
+				var tsStr string
+				var i int
+				sqlDB.QueryRow(t, `SELECT count(*), cluster_logical_timestamp() from initial_scan`).Scan(&i, &tsStr)
+				initialScan := feed(t, f, fmt.Sprintf(changefeedStmtFormat, tsStr))
+				defer func() {
+					closeFeed(t, initialScan)
+					sqlDB.Exec(t, `DROP TABLE initial_scan`)
+				}()
+				assertPayloads(t, initialScan, []string{
+					`initial_scan: [1]->{"after": {"a": 1}}`,
+					`initial_scan: [2]->{"after": {"a": 2}}`,
+					`initial_scan: [3]->{"after": {"a": 3}}`,
+				})
+				sqlDB.Exec(t, `INSERT INTO initial_scan VALUES (4)`)
+				assertPayloads(t, initialScan, []string{
+					`initial_scan: [4]->{"after": {"a": 4}}`,
+				})
 			})
-		})
+		}
 	}
 
 	t.Run(`sinkless`, sinklessTest(testFn))
@@ -3759,6 +3780,16 @@ func TestChangefeedErrors(t *testing.T) {
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH no_initial_scan, initial_scan_only`, `kafka://nope`,
 	)
 
+	// WITH initial_scan_only and initial_scan disallowed
+	sqlDB.ExpectErr(
+		t, `cannot specify both initial_scan and initial_scan_only`,
+		`CREATE CHANGEFEED FOR foo INTO $1 WITH initial_scan_only, initial_scan`, `kafka://nope`,
+	)
+	sqlDB.ExpectErr(
+		t, `cannot specify both initial_scan and initial_scan_only`,
+		`CREATE CHANGEFEED FOR foo INTO $1 WITH initial_scan, initial_scan_only`, `kafka://nope`,
+	)
+
 	// WITH only_initial_scan and end_time disallowed
 	sqlDB.ExpectErr(
 		t, `cannot specify both initial_scan_only and end_time`,
@@ -3767,6 +3798,28 @@ func TestChangefeedErrors(t *testing.T) {
 	sqlDB.ExpectErr(
 		t, `cannot specify both initial_scan_only and end_time`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH end_time = '1', initial_scan_only`, `kafka://nope`,
+	)
+
+	sqlDB.ExpectErr(
+		t, `cannot specify both initial_scan='only' and end_time`,
+		`CREATE CHANGEFEED FOR foo INTO $1 WITH end_time = '1', initial_scan = 'only'`, `kafka://nope`,
+	)
+	sqlDB.ExpectErr(
+		t, `cannot specify both initial_scan='only' and end_time`,
+		`CREATE CHANGEFEED FOR foo INTO $1 WITH initial_scan = 'only', end_time = '1'`, `kafka://nope`,
+	)
+
+	sqlDB.ExpectErr(
+		t, `unknown initial_scan: foo`,
+		`CREATE CHANGEFEED FOR foo INTO $1 WITH initial_scan = 'foo'`, `kafka://nope`,
+	)
+	sqlDB.ExpectErr(
+		t, `cannot specify both initial_scan and no_initial_scan`,
+		`CREATE CHANGEFEED FOR foo INTO $1 WITH initial_scan = 'yes', no_initial_scan`, `kafka://nope`,
+	)
+	sqlDB.ExpectErr(
+		t, `cannot specify both initial_scan and initial_scan_only`,
+		`CREATE CHANGEFEED FOR foo INTO $1 WITH initial_scan = 'no', initial_scan_only`, `kafka://nope`,
 	)
 
 	var tsCurrent string
@@ -5747,42 +5800,52 @@ func TestChangefeedOnlyInitialScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	initialScanOnlyTests := map[string]string{
+		`initial scan only`:     `CREATE CHANGEFEED FOR foo WITH initial_scan_only`,
+		`initial backfill only`: `CREATE CHANGEFEED FOR foo WITH initial_scan = 'only'`,
+	}
+
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(db)
 
-		sqlDB.Exec(t, "CREATE TABLE foo (a INT PRIMARY KEY)")
-		sqlDB.Exec(t, "INSERT INTO foo VALUES (1), (2), (3)")
+		for testName, changefeedStmt := range initialScanOnlyTests {
+			t.Run(testName, func(t *testing.T) {
+				sqlDB.Exec(t, "CREATE TABLE foo (a INT PRIMARY KEY)")
+				sqlDB.Exec(t, "INSERT INTO foo VALUES (1), (2), (3)")
 
-		feed := feed(t, f, "CREATE CHANGEFEED FOR foo WITH initial_scan_only")
+				feed := feed(t, f, changefeedStmt)
 
-		sqlDB.Exec(t, "INSERT INTO foo VALUES (4), (5), (6)")
+				sqlDB.Exec(t, "INSERT INTO foo VALUES (4), (5), (6)")
 
-		seenMoreMessages := false
-		g := ctxgroup.WithContext(context.Background())
-		g.Go(func() error {
-			assertPayloads(t, feed, []string{
-				`foo: [1]->{"after": {"a": 1}}`,
-				`foo: [2]->{"after": {"a": 2}}`,
-				`foo: [3]->{"after": {"a": 3}}`,
+				seenMoreMessages := false
+				g := ctxgroup.WithContext(context.Background())
+				g.Go(func() error {
+					assertPayloads(t, feed, []string{
+						`foo: [1]->{"after": {"a": 1}}`,
+						`foo: [2]->{"after": {"a": 2}}`,
+						`foo: [3]->{"after": {"a": 3}}`,
+					})
+					for {
+						_, err := feed.Next()
+						if err != nil {
+							return err
+						}
+						seenMoreMessages = true
+					}
+				})
+				defer func() {
+					closeFeed(t, feed)
+					sqlDB.Exec(t, `DROP TABLE foo`)
+					_ = g.Wait()
+					require.False(t, seenMoreMessages)
+				}()
+
+				jobFeed := feed.(cdctest.EnterpriseTestFeed)
+				require.NoError(t, jobFeed.WaitForStatus(func(s jobs.Status) bool {
+					return s == jobs.StatusSucceeded
+				}))
 			})
-			for {
-				_, err := feed.Next()
-				if err != nil {
-					return err
-				}
-				seenMoreMessages = true
-			}
-		})
-		defer func() {
-			closeFeed(t, feed)
-			_ = g.Wait()
-			require.False(t, seenMoreMessages)
-		}()
-
-		jobFeed := feed.(cdctest.EnterpriseTestFeed)
-		require.NoError(t, jobFeed.WaitForStatus(func(s jobs.Status) bool {
-			return s == jobs.StatusSucceeded
-		}))
+		}
 	}
 	t.Run(`enterprise`, enterpriseTest(testFn))
 	t.Run(`cloudstorage`, cloudStorageTest(testFn))

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -31,6 +31,17 @@ type SchemaChangePolicy string
 // include virtual columns in an event
 type VirtualColumnVisibility string
 
+// InitialScanType configures whether the changefeed will perform an
+// initial scan, and the type of initial scan that it will perform
+type InitialScanType int
+
+// Constants for the initial scan types
+const (
+	InitialScan InitialScanType = iota
+	NoInitialScan
+	OnlyInitialScan
+)
+
 // Constants for the options.
 const (
 	OptAvroSchemaPrefix         = `avro_schema_prefix`
@@ -184,7 +195,7 @@ var ChangefeedOptionExpectValues = map[string]sql.KVStringOptValidate{
 	OptSchemaChangeEvents:       sql.KVStringOptRequireValue,
 	OptSchemaChangePolicy:       sql.KVStringOptRequireValue,
 	OptSplitColumnFamilies:      sql.KVStringOptRequireNoValue,
-	OptInitialScan:              sql.KVStringOptRequireNoValue,
+	OptInitialScan:              sql.KVStringOptAny,
 	OptNoInitialScan:            sql.KVStringOptRequireNoValue,
 	OptInitialScanOnly:          sql.KVStringOptRequireNoValue,
 	OptProtectDataFromGCOnPause: sql.KVStringOptRequireNoValue,
@@ -251,7 +262,8 @@ var NoLongerExperimental = map[string]string{
 // and the end_time option. However, there are instances in which it should be
 // allowed to alter either of these options. We need to support the alteration
 // of these fields.
-var AlterChangefeedUnsupportedOptions = makeStringSet(OptCursor, OptInitialScan, OptNoInitialScan, OptInitialScanOnly, OptEndTime)
+var AlterChangefeedUnsupportedOptions = makeStringSet(OptCursor, OptInitialScan,
+	OptNoInitialScan, OptInitialScanOnly, OptEndTime)
 
 // AlterChangefeedOptionExpectValues is used to parse alter changefeed options
 // using PlanHookState.TypeAsStringOpts().


### PR DESCRIPTION
Resolves #79324

Currently, we have explicit options for each possible
behaviour that a user would like to achieve for
initial scans on changefeeds. For instance, a user
could specify:

- initial_scan
- no_initial_scan
- initial_scan_only

This seems a bit sprawling, and can inadvertently cause
contradictions in a changefeed statement. Hence, in this
PR we extend the option `initial_scan` to take on three
possible values: `'yes|no|only'`. Once this change
is made we will remove the explicit options from the
docs, but we will keep these options for backwards
compatibility.

Release note (enterprise change): Unify the syntax that
allows users to define the behaviour they would like
for initial scans on changefeeds by extending the
`initial_scan` option to take on three possible values:
`'yes|no|only'`.

Release justification: Small, safe refactor that will
improve the user experience when creating changefeeds.

Jira issue: CRDB-14693