### PR TITLE
release-21.2: sql/importer: re-validate unique constraints after IMPORT

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -2145,6 +2145,10 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 		}
 	}
 
+	if err := r.checkVirtualConstraints(ctx, p.ExecCfg(), r.job); err != nil {
+		return err
+	}
+
 	// If the table being imported into referenced UDTs, ensure that a concurrent
 	// schema change on any of the typeDescs has not modified the type descriptor. If
 	// it has, it is unsafe to import the data and we fail the import job.
@@ -2302,6 +2306,35 @@ func (r *importResumer) publishSchemas(ctx context.Context, execCfg *sql.Executo
 		}
 		return nil
 	})
+}
+
+// checkVirtualConstraints checks constraints that are enforced via runtime
+// checks, such as uniqueness checks that are not directly backed by an index.
+func (*importResumer) checkVirtualConstraints(
+	ctx context.Context, execCfg *sql.ExecutorConfig, job *jobs.Job,
+) error {
+	for _, tbl := range job.Details().(jobspb.ImportDetails).Tables {
+		desc := tabledesc.NewBuilder(tbl.Desc).BuildExistingMutableTable()
+		desc.SetPublic()
+
+		if sql.HasVirtualUniqueConstraints(desc) {
+			if err := job.RunningStatus(ctx, nil /* txn */, func(_ context.Context, _ jobspb.Details) (jobs.RunningStatus, error) {
+				return jobs.RunningStatus(fmt.Sprintf("re-validating %s", desc.GetName())), nil
+			}); err != nil {
+				return errors.Wrapf(err, "failed to update running status of job %d", errors.Safe(job.ID()))
+			}
+		}
+
+		if err := execCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			ie := job.MakeSessionBoundInternalExecutor(ctx, sql.NewFakeSessionData(execCfg.SV()))
+			return ie.WithSyntheticDescriptors([]catalog.Descriptor{desc}, func() error {
+				return sql.RevalidateUniqueConstraintsInTable(ctx, txn, ie, desc)
+			})
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // checkForUDTModification checks whether any of the types referenced by the

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -788,6 +789,12 @@ func (ie *wrappedInternalExecutor) QueryIteratorEx(
 		}
 	}
 	return ie.wrapped.QueryIteratorEx(ctx, opName, txn, session, stmt, qargs...)
+}
+
+func (ie *wrappedInternalExecutor) WithSyntheticDescriptors(
+	descs []catalog.Descriptor, run func() error,
+) error {
+	panic("not implemented")
 }
 
 func (ie *wrappedInternalExecutor) getErrFunc() func(statement string) error {

--- a/pkg/sql/sqlutil/internal_executor.go
+++ b/pkg/sql/sqlutil/internal_executor.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -142,6 +143,9 @@ type InternalExecutor interface {
 		stmt string,
 		qargs ...interface{},
 	) (InternalRows, error)
+
+	// WithSyntheticDescriptors sets synthetic descriptors. See implementation.
+	WithSyntheticDescriptors(descs []catalog.Descriptor, run func() error) error
 }
 
 // InternalRows is an iterator interface that's exposed by the internal


### PR DESCRIPTION
David Taylor (dt) commented:

Backport 1/1 commits from #79293.

/cc @cockroachdb/release

---

Release note (bug fix): Previously IMPORT INTO could create duplicate entries violating UNIQUE constraints in REGIONAL BY ROW tables and tables utilizing UNIQUE WITHOUT INDEX constraints. A new post-IMPORT validation step for those tables now fails and rolls back the IMPORT in such cases.


Release justification: severe bug.

Jira issue: CRDB-14695

Jira Issue: DOC-3123