### PR TITLE
release-22.1: update v22.1.0-prerelease-5

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "22.1.0-prerelease-4",
+  "version": "22.1.0-prerelease-5",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",

--- a/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/activateStatementDiagnosticsModal.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/activateStatementDiagnosticsModal.scss
@@ -21,9 +21,9 @@
       border-color: $colors--primary-blue-3;
 
       &:after {
-        background-color: white;
-        top: 4px;
-        left: 4px;
+        background-color: $colors--primary-blue-3;
+        top: 3px;
+        left: 3px;
         margin-left: 0;
         margin-top: 0;
       }


### PR DESCRIPTION
Release justification: low-risk change

/cc @cockroachdb/release

---
Align cluster-ui version to version published on npm.
Update spacing/color on radio button that was different
on this version.

Release note: None

Jira issue: CRDB-14710