### PR TITLE
bazel: fix visibility of `spec.json` bazel target

### DIFF
--- a/docs/generated/swagger/BUILD.bazel
+++ b/docs/generated/swagger/BUILD.bazel
@@ -16,6 +16,7 @@ genrule(
         "@com_github_go_swagger_go_swagger//cmd/swagger",
         "@go_sdk//:bin/go",
     ],
+    visibility = ["//visibility:public"],
 )
 
 go_path(


### PR DESCRIPTION
Otherwise this breaks `//pkg/gen:docs` which is part of `dev gen docs`.

Release note: None

Jira issue: CRDB-14715