### PR TITLE
sql: fix implicit txn check for SET and DECLARE

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cursor
+++ b/pkg/sql/logictest/testdata/logic_test/cursor
@@ -5,6 +5,9 @@ INSERT INTO a VALUES (1, 2), (2, 3)
 statement error DECLARE CURSOR can only be used in transaction blocks
 DECLARE foo CURSOR FOR SELECT * FROM a
 
+statement error DECLARE CURSOR can only be used in transaction blocks
+SELECT 1; DECLARE foo CURSOR FOR SELECT * FROM a
+
 statement error cursor \"foo\" does not exist
 CLOSE foo
 

--- a/pkg/sql/logictest/testdata/logic_test/set_local
+++ b/pkg/sql/logictest/testdata/logic_test/set_local
@@ -11,6 +11,11 @@ SET LOCAL TIME ZONE +6
 ----
 WARNING: SET LOCAL can only be used in transaction blocks
 
+query T noticetrace
+SELECT 1; SET LOCAL TIME ZONE +6
+----
+WARNING: SET LOCAL can only be used in transaction blocks
+
 statement ok
 SET intervalstyle_enabled = 'on'
 

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -164,7 +164,7 @@ func (p *planner) applyOnSessionDataMutators(
 	if local {
 		// We don't allocate a new SessionData object on implicit transactions.
 		// This no-ops in postgres with a warning, so copy accordingly.
-		if p.extendedEvalCtx.TxnIsSingleStmt {
+		if p.extendedEvalCtx.TxnImplicit {
 			p.BufferClientNotice(
 				ctx,
 				pgnotice.NewWithSeverityf(

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -43,7 +43,7 @@ func (p *planner) DeclareCursor(ctx context.Context, s *tree.DeclareCursor) (pla
 	return &delayedNode{
 		name: s.String(),
 		constructor: func(ctx context.Context, p *planner) (_ planNode, _ error) {
-			if p.extendedEvalCtx.TxnIsSingleStmt {
+			if p.extendedEvalCtx.TxnImplicit {
 				return nil, pgerror.Newf(pgcode.NoActiveSQLTransaction, "DECLARE CURSOR can only be used in transaction blocks")
 			}
 


### PR DESCRIPTION
These two operations actually care specifically about implicit
transactions; not single-statement transactions, like many other
commands.

Release note: None

Jira issue: CRDB-14716