### PR TITLE
release-22.1: backupccl: report row and byte size in SHOW BACKUP for tenant backups

### DIFF
--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/protoreflect"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -511,20 +510,9 @@ func backupShowerDefault(
 						}
 					}
 				}
-				descSizes := make(map[descpb.ID]roachpb.RowCount)
-				for _, file := range manifest.Files {
-					// TODO(dan): This assumes each file in the backup only
-					// contains data from a single table, which is usually but
-					// not always correct. It does not account for a BACKUP that
-					// happened to catch a newly created table that hadn't yet
-					// been split into its own range.
-					_, tableID, err := encoding.DecodeUvarintAscending(file.Span.Key)
-					if err != nil {
-						continue
-					}
-					s := descSizes[descpb.ID(tableID)]
-					s.Add(file.EntryCounts)
-					descSizes[descpb.ID(tableID)] = s
+				tableSizes, err := getTableSizes(manifest.Files)
+				if err != nil {
+					return nil, err
 				}
 				backupType := tree.NewDString("full")
 				if manifest.isIncremental() {
@@ -578,9 +566,9 @@ func backupShowerDefault(
 						dbID = desc.GetParentID()
 						parentSchemaName = schemaIDToName[desc.GetParentSchemaID()]
 						parentSchemaID = desc.GetParentSchemaID()
-						descSize := descSizes[desc.GetID()]
-						dataSizeDatum = tree.NewDInt(tree.DInt(descSize.DataSize))
-						rowCountDatum = tree.NewDInt(tree.DInt(descSize.Rows))
+						tableSize := tableSizes[desc.GetID()]
+						dataSizeDatum = tree.NewDInt(tree.DInt(tableSize.DataSize))
+						rowCountDatum = tree.NewDInt(tree.DInt(tableSize.Rows))
 
 						displayOptions := sql.ShowCreateDisplayOptions{
 							FKDisplayMode:  sql.OmitMissingFKClausesFromCreate,
@@ -673,6 +661,39 @@ func backupShowerDefault(
 			return rows, nil
 		},
 	}
+}
+
+// getTableSizes gathers row and size count for each table in the manifest
+func getTableSizes(files []BackupManifest_File) (map[descpb.ID]roachpb.RowCount, error) {
+	tableSizes := make(map[descpb.ID]roachpb.RowCount)
+	if len(files) == 0 {
+		return tableSizes, nil
+	}
+	_, tenantID, err := keys.DecodeTenantPrefix(files[0].Span.Key)
+	if err != nil {
+		return nil, err
+	}
+	showCodec := keys.MakeSQLCodec(tenantID)
+
+	for _, file := range files {
+		// TODO(dan): This assumes each file in the backup only
+		// contains data from a single table, which is usually but
+		// not always correct. It does not account for a BACKUP that
+		// happened to catch a newly created table that hadn't yet
+		// been split into its own range.
+
+		// TODO(msbutler): after handling the todo above, understand whether
+		// we should return an error if a key does not have tableId. The lack
+		// of error handling let #77705 sneak by our unit tests.
+		_, tableID, err := showCodec.DecodeTablePrefix(file.Span.Key)
+		if err != nil {
+			continue
+		}
+		s := tableSizes[descpb.ID(tableID)]
+		s.Add(file.EntryCounts)
+		tableSizes[descpb.ID(tableID)] = s
+	}
+	return tableSizes, nil
 }
 
 func nullIfEmpty(s string) tree.Datum {


### PR DESCRIPTION
Michael Butler (msbutler) commented:

Backport 1/1 commits from #77952.

/cc @cockroachdb/release

---

Previously, if a tenant or system tenant called SHOW BACKUP on a backup created
by a tenant, SHOW BACKUP would return no data on row or byte size. This patch
fixes this.

Informs #77705

Release justification: low risk bug fix
Release note (sql change): SHOW BACKUP now reports accurate row and byte size
counts on backups created by a tenant.


Jira Issue: DOC-3255