### PR TITLE
release-22.1: sql: block operations properly on implicit transactions

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -665,7 +665,7 @@ func backupPlanHook(
 		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer span.Finish()
 
-		if !(p.IsAutoCommit() || backupStmt.Options.Detached) {
+		if !(p.ExtendedEvalContext().TxnIsSingleStmt || backupStmt.Options.Detached) {
 			return errors.Errorf("BACKUP cannot be used inside a multi-statement transaction without DETACHED option")
 		}
 

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1149,7 +1149,7 @@ func restorePlanHook(
 		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer span.Finish()
 
-		if !(p.IsAutoCommit() || restoreStmt.Options.Detached) {
+		if !(p.ExtendedEvalContext().TxnIsSingleStmt || restoreStmt.Options.Detached) {
 			return errors.Errorf("RESTORE cannot be used inside a multi-statement transaction without DETACHED option")
 		}
 

--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -259,8 +259,8 @@ func alterColumnTypeGeneral(
 		}
 	}
 
-	// Disallow ALTER COLUMN TYPE general inside an explicit transaction.
-	if !params.p.EvalContext().TxnImplicit {
+	// Disallow ALTER COLUMN TYPE general inside a multi-statement transaction.
+	if !params.extendedEvalCtx.TxnIsSingleStmt {
 		return AlterColTypeInTxnNotSupportedErr
 	}
 

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -457,7 +457,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 			if params.SessionData().SafeUpdates {
 				err := pgerror.DangerousStatementf("ALTER TABLE DROP COLUMN will " +
 					"remove all data in that column")
-				if !params.extendedEvalCtx.TxnImplicit {
+				if !params.extendedEvalCtx.TxnIsSingleStmt {
 					err = errors.WithIssueLink(err, errors.IssueLink{
 						IssueURL: "https://github.com/cockroachdb/cockroach/issues/46541",
 						Detail: "when used in an explicit transaction combined with other " +
@@ -708,7 +708,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 			if !ok {
 				return errors.AssertionFailedf("missing stats data")
 			}
-			if !params.p.EvalContext().TxnImplicit {
+			if !params.extendedEvalCtx.TxnIsSingleStmt {
 				return errors.New("cannot inject statistics in an explicit transaction")
 			}
 			if err := injectTableStats(params, n.tableDesc, sd); err != nil {

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -563,13 +563,20 @@ func TestCantLeaseDeletedTable(testingT *testing.T) {
 	t := newLeaseTest(testingT, params)
 	defer t.cleanup()
 
+	_, err := t.db.Exec(`SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'off';`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = t.db.Exec(`SET use_declarative_schema_changer = 'off';`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	sql := `
-SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'off';
-SET use_declarative_schema_changer = 'off';
 CREATE DATABASE test;
 CREATE TABLE test.t(a INT PRIMARY KEY);
 `
-	_, err := t.db.Exec(sql)
+	_, err = t.db.Exec(sql)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1245,6 +1245,10 @@ type connExecutor struct {
 		// statement traces to give more information in statement diagnostic bundles.
 		autoRetryReason error
 
+		// firstStmtExecuted indicates that the first statement inside this
+		// transaction has been executed.
+		firstStmtExecuted bool
+
 		// numDDL keeps track of how many DDL statements have been
 		// executed so far.
 		numDDL int
@@ -1626,6 +1630,7 @@ func (ns *prepStmtNamespace) resetTo(
 // (e.g. onTxnFinish() and onTxnRestart()).
 func (ex *connExecutor) resetExtraTxnState(ctx context.Context, ev txnEvent) error {
 	ex.extraTxnState.jobs = nil
+	ex.extraTxnState.firstStmtExecuted = false
 	ex.extraTxnState.hasAdminRoleCache = HasAdminRoleCache{}
 	ex.extraTxnState.schemaChangerState = SchemaChangerState{
 		mode: ex.sessionData().NewSchemaChangerMode,
@@ -2679,6 +2684,7 @@ func (ex *connExecutor) resetEvalCtx(evalCtx *extendedEvalContext, txn *kv.Txn, 
 	evalCtx.TxnState = ex.getTransactionState()
 	evalCtx.TxnReadOnly = ex.state.readOnly
 	evalCtx.TxnImplicit = ex.implicitTxn()
+	evalCtx.TxnIsSingleStmt = false
 	if newTxn || !ex.implicitTxn() {
 		// Only update the stmt timestamp if in a new txn or an explicit txn. This is because this gets
 		// called multiple times during an extended protocol implicit txn, but we
@@ -2840,7 +2846,9 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 	case txnStart:
 		atomic.StoreInt32(ex.extraTxnState.atomicAutoRetryCounter, 0)
 		ex.extraTxnState.autoRetryReason = nil
+		ex.extraTxnState.firstStmtExecuted = false
 		ex.recordTransactionStart(advInfo.txnEvent.txnID)
+		// Start of the transaction, so no statements were executed earlier.
 		// Bump the txn counter for logging.
 		ex.extraTxnState.txnCounter++
 		if !ex.server.cfg.Codec.ForSystemTenant() {

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -669,6 +669,8 @@ func (ex *connExecutor) execStmtInOpenState(
 	p.cancelChecker.Reset(ctx)
 
 	p.autoCommit = canAutoCommit && !ex.server.cfg.TestingKnobs.DisableAutoCommitDuringExec
+	p.extendedEvalCtx.TxnIsSingleStmt = canAutoCommit && !ex.extraTxnState.firstStmtExecuted
+	ex.extraTxnState.firstStmtExecuted = true
 
 	var stmtThresholdSpan *tracing.Span
 	alreadyRecording := ex.transitionCtx.sessionTracing.Enabled()

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -375,9 +375,9 @@ func (n *createTableNode) startExec(params runParams) error {
 			return err
 		}
 
-		// If we have an implicit txn we want to run CTAS async, and consequently
-		// ensure it gets queued as a SchemaChange.
-		if params.p.ExtendedEvalContext().TxnImplicit {
+		// If we have a single statement txn we want to run CTAS async, and
+		// consequently ensure it gets queued as a SchemaChange.
+		if params.extendedEvalCtx.TxnIsSingleStmt {
 			desc.State = descpb.DescriptorState_ADD
 		}
 	} else {
@@ -500,9 +500,9 @@ func (n *createTableNode) startExec(params runParams) error {
 		return err
 	}
 
-	// If we are in an explicit txn or the source has placeholders, we execute the
-	// CTAS query synchronously.
-	if n.n.As() && !params.p.ExtendedEvalContext().TxnImplicit {
+	// If we are in a multi-statement txn or the source has placeholders, we
+	// execute the CTAS query synchronously.
+	if n.n.As() && !params.extendedEvalCtx.TxnIsSingleStmt {
 		err = func() error {
 			// The data fill portion of CREATE AS must operate on a read snapshot,
 			// so that it doesn't end up observing its own writes.

--- a/pkg/sql/export.go
+++ b/pkg/sql/export.go
@@ -123,7 +123,7 @@ func (ef *execFactory) ConstructExport(
 		return nil, err
 	}
 
-	if !ef.planner.IsAutoCommit() {
+	if !ef.planner.ExtendedEvalContext().TxnIsSingleStmt {
 		return nil, errors.Errorf("EXPORT cannot be used inside a multi-statement transaction")
 	}
 

--- a/pkg/sql/importer/import_planning.go
+++ b/pkg/sql/importer/import_planning.go
@@ -372,7 +372,7 @@ func importPlanHook(
 		ctx, span := tracing.ChildSpan(ctx, importStmt.StatementTag())
 		defer span.Finish()
 
-		if !(p.IsAutoCommit() || isDetached) {
+		if !(p.ExtendedEvalContext().TxnIsSingleStmt || isDetached) {
 			return errors.Errorf("IMPORT cannot be used inside a multi-statement transaction without DETACHED option")
 		}
 

--- a/pkg/sql/logictest/testdata/logic_test/materialized_view
+++ b/pkg/sql/logictest/testdata/logic_test/materialized_view
@@ -81,7 +81,7 @@ SELECT y FROM v WHERE y > 4
 statement ok
 BEGIN
 
-statement error pq: cannot refresh view in an explicit transaction
+statement error  pq: cannot refresh view in a multi-statement transaction
 REFRESH MATERIALIZED VIEW v
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -1217,9 +1217,3 @@ query T
 SHOW default_transaction_quality_of_service
 ----
 regular
-
-# Sanity: Implicit txns with multiple statements can't have SET CLUSTER
-# SETTING.
-statement error pq: SET CLUSTER SETTING cannot be used inside an explicit transaction
-SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'on';
-SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'off';

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -1217,3 +1217,9 @@ query T
 SHOW default_transaction_quality_of_service
 ----
 regular
+
+# Sanity: Implicit txns with multiple statements can't have SET CLUSTER
+# SETTING.
+statement error pq: SET CLUSTER SETTING cannot be used inside an explicit transaction
+SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'on';
+SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'off';

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -1827,6 +1827,8 @@ vectorized: true
 # values.
 statement ok
 CREATE TABLE nulls (x INT, y INT);
+
+statement ok
 ALTER TABLE nulls INJECT STATISTICS '[
     {
         "columns": [

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -108,7 +108,6 @@ type PlanHookState interface {
 	MigrationJobDeps() migration.JobDeps
 	SpanConfigReconciler() spanconfig.Reconciler
 	BufferClientNotice(ctx context.Context, notice pgnotice.Notice)
-	IsAutoCommit() bool
 }
 
 // AddPlanHook adds a hook used to short-circuit creating a planNode from a

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -470,6 +470,7 @@ func internalExtendedEvalCtx(
 			SessionDataStack:          sds,
 			TxnReadOnly:               false,
 			TxnImplicit:               true,
+			TxnIsSingleStmt:           true,
 			Context:                   ctx,
 			Mon:                       plannerMon,
 			TestingKnobs:              evalContextTestingKnobs,
@@ -499,11 +500,6 @@ func (p *planner) SemaCtx() *tree.SemaContext {
 // Note: if the context will be modified, use ExtendedEvalContextCopy instead.
 func (p *planner) ExtendedEvalContext() *extendedEvalContext {
 	return &p.extendedEvalCtx
-}
-
-// IsAutoCommit implements the PlanHookState interface.
-func (p *planner) IsAutoCommit() bool {
-	return p.autoCommit
 }
 
 func (p *planner) ExtendedEvalContextCopy() *extendedEvalContext {

--- a/pkg/sql/refresh_materialized_view.go
+++ b/pkg/sql/refresh_materialized_view.go
@@ -30,8 +30,8 @@ type refreshMaterializedViewNode struct {
 func (p *planner) RefreshMaterializedView(
 	ctx context.Context, n *tree.RefreshMaterializedView,
 ) (planNode, error) {
-	if !p.EvalContext().TxnImplicit {
-		return nil, pgerror.Newf(pgcode.InvalidTransactionState, "cannot refresh view in an explicit transaction")
+	if !p.extendedEvalCtx.TxnIsSingleStmt {
+		return nil, pgerror.Newf(pgcode.InvalidTransactionState, "cannot refresh view in a multi-statement transaction")
 	}
 	_, desc, err := p.ResolveMutableTableDescriptorEx(ctx, n.Name, true /* required */, tree.ResolveRequireViewDesc)
 	if err != nil {

--- a/pkg/sql/schema_change_plan_node.go
+++ b/pkg/sql/schema_change_plan_node.go
@@ -55,7 +55,7 @@ func (p *planner) SchemaChange(ctx context.Context, stmt tree.Statement) (planNo
 	// support it.
 	if mode == sessiondatapb.UseNewSchemaChangerOff ||
 		((mode == sessiondatapb.UseNewSchemaChangerOn ||
-			mode == sessiondatapb.UseNewSchemaChangerUnsafe) && !p.extendedEvalCtx.TxnImplicit) {
+			mode == sessiondatapb.UseNewSchemaChangerUnsafe) && !p.extendedEvalCtx.TxnIsSingleStmt) {
 		return nil, false, nil
 	}
 	scs := p.extendedEvalCtx.SchemaChangerState

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3602,7 +3602,11 @@ type EvalContext struct {
 	TxnState string
 	// TxnReadOnly specifies if the current transaction is read-only.
 	TxnReadOnly bool
+	// TxnImplicit specifies if the current transaction is implicit.
 	TxnImplicit bool
+	// TxnIsSingleStmt specifies the current implicit transaction consists of only
+	// a single statement.
+	TxnIsSingleStmt bool
 
 	Settings    *cluster.Settings
 	ClusterID   uuid.UUID

--- a/pkg/sql/session_state.go
+++ b/pkg/sql/session_state.go
@@ -39,7 +39,7 @@ var maxSerializedSessionSize = settings.RegisterByteSizeSetting(
 func (p *planner) SerializeSessionState() (*tree.DBytes, error) {
 	evalCtx := p.EvalContext()
 	return serializeSessionState(
-		!evalCtx.TxnImplicit,
+		!evalCtx.TxnIsSingleStmt,
 		evalCtx.PreparedStatementState,
 		p.SessionData(),
 		p.ExecCfg(),
@@ -111,10 +111,10 @@ func serializeSessionState(
 // DeserializeSessionState deserializes the given state into the current session.
 func (p *planner) DeserializeSessionState(state *tree.DBytes) (*tree.DBool, error) {
 	evalCtx := p.ExtendedEvalContext()
-	if !evalCtx.TxnImplicit {
+	if !evalCtx.TxnIsSingleStmt {
 		return nil, pgerror.Newf(
 			pgcode.InvalidTransactionState,
-			"cannot deserialize a session whilst inside a transaction",
+			"cannot deserialize a session whilst inside a multi-statement transaction",
 		)
 	}
 

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -191,8 +191,8 @@ func (p *planner) getAndValidateTypedClusterSetting(
 }
 
 func (n *setClusterSettingNode) startExec(params runParams) error {
-	if !params.p.ExtendedEvalContext().TxnImplicit {
-		return errors.Errorf("SET CLUSTER SETTING cannot be used inside an explicit transaction")
+	if !params.extendedEvalCtx.TxnIsSingleStmt {
+		return errors.Errorf("SET CLUSTER SETTING cannot be used inside a multi-statement transaction")
 	}
 
 	expectedEncodedValue, err := writeSettingInternal(

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -164,7 +164,7 @@ func (p *planner) applyOnSessionDataMutators(
 	if local {
 		// We don't allocate a new SessionData object on implicit transactions.
 		// This no-ops in postgres with a warning, so copy accordingly.
-		if p.EvalContext().TxnImplicit {
+		if p.extendedEvalCtx.TxnIsSingleStmt {
 			p.BufferClientNotice(
 				ctx,
 				pgnotice.NewWithSeverityf(

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -43,7 +43,7 @@ func (p *planner) DeclareCursor(ctx context.Context, s *tree.DeclareCursor) (pla
 	return &delayedNode{
 		name: s.String(),
 		constructor: func(ctx context.Context, p *planner) (_ planNode, _ error) {
-			if p.extendedEvalCtx.TxnImplicit {
+			if p.extendedEvalCtx.TxnIsSingleStmt {
 				return nil, pgerror.Newf(pgcode.NoActiveSQLTransaction, "DECLARE CURSOR can only be used in transaction blocks")
 			}
 

--- a/pkg/sql/tenant.go
+++ b/pkg/sql/tenant.go
@@ -534,8 +534,8 @@ func gcTenantJob(
 func (p *planner) GCTenant(ctx context.Context, tenID uint64) error {
 	// TODO(jeffswenson): Delete internal_crdb.gc_tenant after the DestroyTenant
 	// changes are deployed to all Cockroach Cloud serverless hosts.
-	if !p.ExtendedEvalContext().TxnImplicit {
-		return errors.Errorf("gc_tenant cannot be used inside a transaction")
+	if !p.extendedEvalCtx.TxnIsSingleStmt {
+		return errors.Errorf("gc_tenant cannot be used inside a multi-statement transaction")
 	}
 	var info *descpb.TenantInfo
 	if txnErr := p.ExecCfg().DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {

--- a/pkg/sql/testdata/session_migration/errors
+++ b/pkg/sql/testdata/session_migration/errors
@@ -44,7 +44,7 @@ BEGIN
 exec
 SELECT crdb_internal.deserialize_session( decode('$x', 'hex') )
 ----
-ERROR: crdb_internal.deserialize_session(): cannot deserialize a session whilst inside a transaction (SQLSTATE 25000)
+ERROR: crdb_internal.deserialize_session(): cannot deserialize a session whilst inside a multi-statement transaction (SQLSTATE 25000)
 
 reset
 ----


### PR DESCRIPTION
Backport 2/2 commits from #78512.

/cc @cockroachdb/release

---

Previously, an enhancement was made to allow implicit
transactions to execute multiple statements, which caused
code to block operations in implicit transactions to break.
This was problematic because these scenarios cared that
only a single statement is executed, and not if it was
only an implicit transition. For example, the declarative
schema changer and legacy schema changer could be mixed
in implicit transactions after this change. To address this,
this patch modifies places that we're checking for implicit
transactions to instead check for single statement transactions.

Release note: None
Release justification: Low risk and mainly focused on fixing behaviour with a disabled feature for multiple statements in implicit transactions


Jira issue: CRDB-14719

Jira issue: CRDB-14722