### PR TITLE
ccl/sqlproxyccl: add rebalancer queue for connection rebalancing

### DIFF
--- a/pkg/ccl/sqlproxyccl/balancer/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/balancer/BUILD.bazel
@@ -15,9 +15,11 @@ go_library(
         "//pkg/roachpb",
         "//pkg/util/log",
         "//pkg/util/randutil",
+        "//pkg/util/stop",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
+        "@com_github_marusama_semaphore//:semaphore",
     ],
 )
 
@@ -33,7 +35,10 @@ go_test(
         "//pkg/ccl/sqlproxyccl/tenant",
         "//pkg/roachpb",
         "//pkg/util/leaktest",
+        "//pkg/util/log",
+        "//pkg/util/stop",
         "//pkg/util/timeutil",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/ccl/sqlproxyccl/balancer/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/balancer/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
         "//pkg/ccl/sqlproxyccl/tenant",
         "//pkg/roachpb",
         "//pkg/util/leaktest",
+        "//pkg/util/timeutil",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/ccl/sqlproxyccl/balancer/balancer.go
+++ b/pkg/ccl/sqlproxyccl/balancer/balancer.go
@@ -16,7 +16,9 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenant"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/marusama/semaphore"
@@ -25,6 +27,37 @@ import (
 // ErrNoAvailablePods is an error that indicates that no pods are available
 // for selection.
 var ErrNoAvailablePods = errors.New("no available pods")
+
+// defaultMaxConcurrentRebalances represents the maximum number of concurrent
+// rebalance requests that are being processed. This effectively limits the
+// number of concurrent transfers per proxy.
+const defaultMaxConcurrentRebalances = 100
+
+// maxTransferAttempts represents the maximum number of transfer attempts per
+// rebalance requests when the previous attempts failed (possibly due to an
+// unsafe transfer point). Note that each transfer attempt currently has a
+// timeout of 15 seconds, so retrying up to 3 times may hold onto processSem
+// up to 45 seconds for each rebalance request.
+//
+// TODO(jaylim-crl): Reduce transfer timeout to 5 seconds.
+const maxTransferAttempts = 3
+
+// balancerOptions controls the behavior of the balancer component.
+type balancerOptions struct {
+	maxConcurrentRebalances int
+}
+
+// Option defines an option that can be passed to NewBalancer in order to
+// control its behavior.
+type Option func(opts *balancerOptions)
+
+// MaxConcurrentRebalances defines the maximum number of concurrent rebalance
+// operations for the balancer. This defaults to defaultMaxConcurrentRebalances.
+func MaxConcurrentRebalances(max int) Option {
+	return func(opts *balancerOptions) {
+		opts.maxConcurrentRebalances = max
+	}
+}
 
 // Balancer handles load balancing of SQL connections within the proxy.
 // All methods on the Balancer instance are thread-safe.
@@ -37,16 +70,54 @@ type Balancer struct {
 		// be used for load balancing.
 		rng *rand.Rand
 	}
+
+	// stopper is used to start async tasks (e.g. transfer requests) within the
+	// balancer.
+	stopper *stop.Stopper
+
+	// queue represents the rebalancer queue. All transfer requests should be
+	// enqueued to this queue instead of calling the transfer API directly.
+	queue *rebalancerQueue
+
+	// processSem is used to limit the number of concurrent rebalance requests
+	// that are being processed.
+	processSem semaphore.Semaphore
 }
 
 // NewBalancer constructs a new Balancer instance that is responsible for
 // load balancing SQL connections within the proxy.
 //
 // TODO(jaylim-crl): Update Balancer to take in a ConnTracker object.
-func NewBalancer() *Balancer {
-	b := &Balancer{}
+func NewBalancer(ctx context.Context, stopper *stop.Stopper, opts ...Option) (*Balancer, error) {
+	// Handle options.
+	options := &balancerOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+	if options.maxConcurrentRebalances == 0 {
+		options.maxConcurrentRebalances = defaultMaxConcurrentRebalances
+	}
+
+	// Ensure that ctx gets cancelled on stopper's quiescing.
+	ctx, _ = stopper.WithCancelOnQuiesce(ctx)
+
+	q, err := newRebalancerQueue(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	b := &Balancer{
+		stopper:    stopper,
+		queue:      q,
+		processSem: semaphore.New(options.maxConcurrentRebalances),
+	}
 	b.mu.rng, _ = randutil.NewPseudoRand()
-	return b
+
+	if err := b.stopper.RunAsyncTask(ctx, "processQueue", b.processQueue); err != nil {
+		return nil, err
+	}
+
+	return b, nil
 }
 
 // SelectTenantPod selects a tenant pod from the given list based on a weighted
@@ -68,6 +139,61 @@ func (b *Balancer) randFloat32() float32 {
 	return b.mu.rng.Float32()
 }
 
+// processQueue runs on a background goroutine, and invokes TransferConnection
+// for each rebalance request.
+func (b *Balancer) processQueue(ctx context.Context) {
+	// processOneReq processors a request from the balancer queue. If the queue
+	// is empty, this blocks. This returns true if processing should continue,
+	// or false otherwise.
+	processOneReq := func() (canContinue bool) {
+		if err := b.processSem.Acquire(ctx, 1); err != nil {
+			log.Errorf(ctx, "could not acquire processSem: %v", err.Error())
+			return false
+		}
+
+		req, err := b.queue.dequeue(ctx)
+		if err != nil {
+			// Context is cancelled.
+			log.Errorf(ctx, "could not dequeue from rebalancer queue: %v", err.Error())
+			return false
+		}
+
+		// TODO(jaylim-crl): implement enhancements:
+		//   1. Add metrics to track the number of active transfers.
+		//   2. Rate limit the number of transfers per connection (e.g. once
+		//      every 5 minutes). This ensures that the connection isn't
+		//      ping-ponged between pods within a short interval. However, for
+		//      draining ones, we may want to move right away (or after 60 secs),
+		//      even if the connection was recently transferred to the draining
+		//      pod.
+		if err := b.stopper.RunAsyncTask(ctx, "processQueue-item", func(ctx context.Context) {
+			defer b.processSem.Release(1)
+
+			// Each request is retried up to maxTransferAttempts.
+			for i := 0; i < maxTransferAttempts && ctx.Err() == nil; i++ {
+				// TODO(jaylim-crl): Once the TransferConnection API accepts a
+				// destination, we could update this code, and pass along dst.
+				err := req.conn.TransferConnection( /* req.dst */ )
+				if err == nil || errors.Is(err, context.Canceled) ||
+					req.dst == req.conn.ServerRemoteAddr() {
+					break
+				}
+
+				// Retry again if the connection hasn't been closed or
+				// transferred to the destination.
+				time.Sleep(250 * time.Millisecond)
+			}
+		}); err != nil {
+			// We should not hit this case, but if we did, log and abandon the
+			// transfer.
+			log.Errorf(ctx, "could not run async task for processQueue-item: %v", err.Error())
+		}
+		return true
+	}
+	for ctx.Err() == nil && processOneReq() {
+	}
+}
+
 // rebalanceRequest corresponds to a rebalance request. For now, this only
 // indicates where the connection should be transferred to through dst.
 type rebalanceRequest struct {
@@ -76,8 +202,8 @@ type rebalanceRequest struct {
 	dst       string
 }
 
-// rebalancerQueue represents the balancer's internal queue which is used for
-// rebalancing requests.
+// balancerQueue represents the balancer's internal queue which is used for
+// rebalancing requests. All methods on the queue are thread-safe.
 type rebalancerQueue struct {
 	mu       syncutil.Mutex
 	sem      semaphore.Semaphore

--- a/pkg/ccl/sqlproxyccl/balancer/balancer_test.go
+++ b/pkg/ccl/sqlproxyccl/balancer/balancer_test.go
@@ -6,25 +6,28 @@
 //
 //     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
 
-package balancer_test
+package balancer
 
 import (
+	"context"
+	"fmt"
 	"testing"
+	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/balancer"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenant"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBalancer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	b := balancer.NewBalancer()
+	b := NewBalancer()
 
 	t.Run("no pods", func(t *testing.T) {
 		pod, err := b.SelectTenantPod([]*tenant.Pod{})
-		require.EqualError(t, err, balancer.ErrNoAvailablePods.Error())
+		require.EqualError(t, err, ErrNoAvailablePods.Error())
 		require.Nil(t, pod)
 	})
 
@@ -34,3 +37,119 @@ func TestBalancer(t *testing.T) {
 		require.Contains(t, []string{"1", "2"}, pod.Addr)
 	})
 }
+
+func TestRebalancerQueue(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	q, err := newRebalancerQueue(ctx)
+	require.NoError(t, err)
+
+	// Use a custom time source for testing.
+	t0 := time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
+	timeSource := timeutil.NewManualTime(t0)
+
+	// Create rebalance requests for the same connection handle.
+	conn1 := &testBalancerConnHandle{}
+	req1 := &rebalanceRequest{
+		createdAt: timeSource.Now(),
+		conn:      conn1,
+		dst:       "foo1",
+	}
+	timeSource.Advance(5 * time.Second)
+	req2 := &rebalanceRequest{
+		createdAt: timeSource.Now(),
+		conn:      conn1,
+		dst:       "foo2",
+	}
+	timeSource.Advance(5 * time.Second)
+	req3 := &rebalanceRequest{
+		createdAt: timeSource.Now(),
+		conn:      conn1,
+		dst:       "foo3",
+	}
+
+	// Enqueue in a specific order. req3 overrides req1; req2 is a no-op.
+	q.enqueue(req1)
+	q.enqueue(req3)
+	q.enqueue(req2)
+	require.Len(t, q.elements, 1)
+	require.Equal(t, 1, q.queue.Len())
+
+	// Create another request.
+	conn2 := &testBalancerConnHandle{}
+	req4 := &rebalanceRequest{
+		createdAt: timeSource.Now(),
+		conn:      conn2,
+		dst:       "bar1",
+	}
+	q.enqueue(req4)
+	require.Len(t, q.elements, 2)
+	require.Equal(t, 2, q.queue.Len())
+
+	// Dequeue the items.
+	item, err := q.dequeue(ctx)
+	require.NoError(t, err)
+	require.Equal(t, req3, item)
+	item, err = q.dequeue(ctx)
+	require.NoError(t, err)
+	require.Equal(t, req4, item)
+	require.Empty(t, q.elements)
+	require.Equal(t, 0, q.queue.Len())
+
+	// Cancel the context. Dequeue should return immediately with an error.
+	cancel()
+	req4, err = q.dequeue(ctx)
+	require.EqualError(t, err, context.Canceled.Error())
+}
+
+func TestRebalancerQueueBlocking(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	q, err := newRebalancerQueue(ctx)
+	require.NoError(t, err)
+
+	reqCh := make(chan *rebalanceRequest, 10)
+	go func() {
+		for {
+			req, err := q.dequeue(ctx)
+			if err != nil {
+				break
+			}
+			reqCh <- req
+		}
+	}()
+
+	// Use a custom time source for testing.
+	t0 := time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
+	timeSource := timeutil.NewManualTime(t0)
+
+	const reqCount = 100
+	for i := 0; i < reqCount; i++ {
+		req := &rebalanceRequest{
+			createdAt: timeSource.Now(),
+			conn:      &testBalancerConnHandle{},
+			dst:       fmt.Sprint(i),
+		}
+		q.enqueue(req)
+		timeSource.Advance(1 * time.Second)
+	}
+
+	for i := 0; i < reqCount; i++ {
+		req := <-reqCh
+		require.Equal(t, fmt.Sprint(i), req.dst)
+	}
+}
+
+// testBalancerConnHandle is a test connection handle that is used for testing
+// the balancer. This currently does not require any methods to be implemented.
+type testBalancerConnHandle struct {
+	ConnectionHandle
+}
+
+var _ ConnectionHandle = &testBalancerConnHandle{}

--- a/pkg/ccl/sqlproxyccl/balancer/balancer_test.go
+++ b/pkg/ccl/sqlproxyccl/balancer/balancer_test.go
@@ -11,19 +11,28 @@ package balancer
 import (
 	"context"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenant"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
-func TestBalancer(t *testing.T) {
+func TestBalancer_SelectTenantPod(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	b := NewBalancer()
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	b, err := NewBalancer(ctx, stopper)
+	require.NoError(t, err)
 
 	t.Run("no pods", func(t *testing.T) {
 		pod, err := b.SelectTenantPod([]*tenant.Pod{})
@@ -35,6 +44,176 @@ func TestBalancer(t *testing.T) {
 		pod, err := b.SelectTenantPod([]*tenant.Pod{{Addr: "1"}, {Addr: "2"}})
 		require.NoError(t, err)
 		require.Contains(t, []string{"1", "2"}, pod.Addr)
+	})
+}
+
+func TestRebalancer_processQueue(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	b, err := NewBalancer(ctx, stopper, MaxConcurrentRebalances(1))
+	require.NoError(t, err)
+
+	// Use a custom time source for testing.
+	t0 := time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
+	timeSource := timeutil.NewManualTime(t0)
+
+	// syncReq is used to wait until the test has completed processing the
+	// items that are of concern.
+	syncCh := make(chan struct{})
+	syncReq := &rebalanceRequest{
+		createdAt: timeSource.Now(),
+		conn: &testBalancerConnHandle{
+			onTransferConnection: func() error {
+				syncCh <- struct{}{}
+				return nil
+			},
+		},
+		dst: "foo",
+	}
+
+	t.Run("retries_up_to_maxTransferAttempts", func(t *testing.T) {
+		count := 0
+		req := &rebalanceRequest{
+			createdAt: timeSource.Now(),
+			conn: &testBalancerConnHandle{
+				onTransferConnection: func() error {
+					count++
+					return errors.New("cannot transfer")
+				},
+			},
+			dst: "foo",
+		}
+		b.queue.enqueue(req)
+
+		// Wait until the item has been processed.
+		b.queue.enqueue(syncReq)
+		<-syncCh
+
+		// Ensure that we only retried up to 3 times.
+		require.Equal(t, 3, count)
+	})
+
+	t.Run("conn_was_transferred_by_other", func(t *testing.T) {
+		count := 0
+		conn := &testBalancerConnHandle{}
+		conn.onTransferConnection = func() error {
+			count++
+			// Simulate that connection was transferred by someone else.
+			conn.remoteAddr = "foo"
+			return errors.New("cannot transfer")
+		}
+		req := &rebalanceRequest{
+			createdAt: timeSource.Now(),
+			conn:      conn,
+			dst:       "foo",
+		}
+		b.queue.enqueue(req)
+
+		// Wait until the item has been processed.
+		b.queue.enqueue(syncReq)
+		<-syncCh
+
+		// We should only retry once.
+		require.Equal(t, 1, count)
+	})
+
+	t.Run("conn_was_transferred", func(t *testing.T) {
+		count := 0
+		conn := &testBalancerConnHandle{}
+		conn.onTransferConnection = func() error {
+			count++
+			conn.remoteAddr = "foo"
+			return nil
+		}
+		req := &rebalanceRequest{
+			createdAt: timeSource.Now(),
+			conn:      conn,
+			dst:       "foo",
+		}
+		b.queue.enqueue(req)
+
+		// Wait until the item has been processed.
+		b.queue.enqueue(syncReq)
+		<-syncCh
+
+		// We should only retry once.
+		require.Equal(t, 1, count)
+	})
+
+	t.Run("conn_was_closed", func(t *testing.T) {
+		count := 0
+		conn := &testBalancerConnHandle{}
+		conn.onTransferConnection = func() error {
+			count++
+			return context.Canceled
+		}
+		req := &rebalanceRequest{
+			createdAt: timeSource.Now(),
+			conn:      conn,
+			dst:       "foo",
+		}
+		b.queue.enqueue(req)
+
+		// Wait until the item has been processed.
+		b.queue.enqueue(syncReq)
+		<-syncCh
+
+		// We should only retry once.
+		require.Equal(t, 1, count)
+	})
+
+	t.Run("limit_concurrent_rebalances", func(t *testing.T) {
+		const reqCount = 100
+
+		// Allow up to 2 concurrent rebalances.
+		b.processSem.SetLimit(2)
+
+		// wg is used to wait until all transfers have completed.
+		var wg sync.WaitGroup
+		wg.Add(reqCount)
+
+		// waitCh is used to wait until all items have fully been enqueued.
+		waitCh := make(chan struct{})
+
+		var count int32
+		for i := 0; i < reqCount; i++ {
+			req := &rebalanceRequest{
+				createdAt: timeSource.Now(),
+				conn: &testBalancerConnHandle{
+					onTransferConnection: func() error {
+						// Block until all requests are enqueued.
+						<-waitCh
+
+						defer func() {
+							newCount := atomic.AddInt32(&count, -1)
+							require.True(t, newCount >= 0)
+							wg.Done()
+						}()
+
+						// Count should not exceed the maximum number of
+						// concurrent rebalances defined.
+						newCount := atomic.AddInt32(&count, 1)
+						require.True(t, newCount <= 2)
+						return nil
+					},
+				},
+				dst: "foo",
+			}
+			b.queue.enqueue(req)
+		}
+
+		// Close the channel to unblock.
+		close(waitCh)
+
+		// Wait until all transfers have completed.
+		wg.Wait()
+
+		// We should only transfer once for every connection.
+		require.Equal(t, int32(0), count)
 	})
 }
 
@@ -103,6 +282,7 @@ func TestRebalancerQueue(t *testing.T) {
 	cancel()
 	req4, err = q.dequeue(ctx)
 	require.EqualError(t, err, context.Canceled.Error())
+	require.Nil(t, req4)
 }
 
 func TestRebalancerQueueBlocking(t *testing.T) {
@@ -147,9 +327,21 @@ func TestRebalancerQueueBlocking(t *testing.T) {
 }
 
 // testBalancerConnHandle is a test connection handle that is used for testing
-// the balancer. This currently does not require any methods to be implemented.
+// the balancer.
 type testBalancerConnHandle struct {
 	ConnectionHandle
+	remoteAddr           string
+	onTransferConnection func() error
 }
 
 var _ ConnectionHandle = &testBalancerConnHandle{}
+
+// TransferConnection implements the ConnectionHandle interface.
+func (h *testBalancerConnHandle) TransferConnection() error {
+	return h.onTransferConnection()
+}
+
+// ServerRemoteAddr implements the ConnectionHandle interface.
+func (h *testBalancerConnHandle) ServerRemoteAddr() string {
+	return h.remoteAddr
+}

--- a/pkg/ccl/sqlproxyccl/balancer/conn_tracker_test.go
+++ b/pkg/ccl/sqlproxyccl/balancer/conn_tracker_test.go
@@ -25,8 +25,8 @@ func TestConnTracker(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	tracker := NewConnTracker()
-	makeConn := func(tenantID int, podAddr string) (roachpb.TenantID, *testConnectionHandle) {
-		return roachpb.MakeTenantID(uint64(tenantID)), newTestConnectionHandle(podAddr)
+	makeConn := func(tenantID int, podAddr string) (roachpb.TenantID, *testTrackerConnHandle) {
+		return roachpb.MakeTenantID(uint64(tenantID)), newTestTrackerConnHandle(podAddr)
 	}
 
 	tenantID, handle := makeConn(20, "127.0.0.10:8090")
@@ -69,7 +69,7 @@ func TestTenantEntry(t *testing.T) {
 
 	entry := newTenantEntry()
 
-	h1 := newTestConnectionHandle("10.0.0.1:12345")
+	h1 := newTestTrackerConnHandle("10.0.0.1:12345")
 	require.True(t, entry.addHandle(h1))
 	require.False(t, entry.addHandle(h1))
 
@@ -83,25 +83,25 @@ func TestTenantEntry(t *testing.T) {
 	require.Len(t, conns, 1)
 }
 
-// testConnectionHandle is a test connection handle that only implements a
-// small subset of methods.
-type testConnectionHandle struct {
+// testTrackerConnHandle is a test connection handle that only implements a
+// small subset of methods used for testing the connection tracker.
+type testTrackerConnHandle struct {
 	ConnectionHandle
 	remoteAddr string
 }
 
-var _ ConnectionHandle = &testConnectionHandle{}
+var _ ConnectionHandle = &testTrackerConnHandle{}
 
-func newTestConnectionHandle(remoteAddr string) *testConnectionHandle {
-	return &testConnectionHandle{remoteAddr: remoteAddr}
+func newTestTrackerConnHandle(remoteAddr string) *testTrackerConnHandle {
+	return &testTrackerConnHandle{remoteAddr: remoteAddr}
 }
 
 // Context implements the ConnectionHandle interface.
-func (h *testConnectionHandle) Context() context.Context {
+func (h *testTrackerConnHandle) Context() context.Context {
 	return context.Background()
 }
 
 // ServerRemoteAddr implements the ConnectionHandle interface.
-func (h *testConnectionHandle) ServerRemoteAddr() string {
+func (h *testTrackerConnHandle) ServerRemoteAddr() string {
 	return h.remoteAddr
 }

--- a/pkg/ccl/sqlproxyccl/balancer/conn_tracker_test.go
+++ b/pkg/ccl/sqlproxyccl/balancer/conn_tracker_test.go
@@ -18,11 +18,13 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
 )
 
 func TestConnTracker(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	tracker := NewConnTracker()
 	makeConn := func(tenantID int, podAddr string) (roachpb.TenantID, *testTrackerConnHandle) {

--- a/pkg/ccl/sqlproxyccl/connector_test.go
+++ b/pkg/ccl/sqlproxyccl/connector_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgproto3/v2"
@@ -480,13 +481,19 @@ func TestConnector_dialTenantCluster(t *testing.T) {
 func TestConnector_lookupAddr(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	balancer, err := balancer.NewBalancer(ctx, stopper)
+	require.NoError(t, err)
 
 	t.Run("successful", func(t *testing.T) {
 		var lookupTenantPodsFnCount int
+
 		c := &connector{
 			ClusterName: "my-foo",
 			TenantID:    roachpb.MakeTenantID(10),
-			Balancer:    balancer.NewBalancer(),
+			Balancer:    balancer,
 		}
 		c.DirectoryCache = &testTenantDirectoryCache{
 			lookupTenantPodsFn: func(
@@ -525,7 +532,7 @@ func TestConnector_lookupAddr(t *testing.T) {
 		c := &connector{
 			ClusterName: "my-foo",
 			TenantID:    roachpb.MakeTenantID(10),
-			Balancer:    balancer.NewBalancer(),
+			Balancer:    balancer,
 		}
 		c.DirectoryCache = &testTenantDirectoryCache{
 			lookupTenantPodsFn: func(
@@ -588,7 +595,7 @@ func TestConnector_lookupAddr(t *testing.T) {
 		c := &connector{
 			ClusterName: "my-foo",
 			TenantID:    roachpb.MakeTenantID(10),
-			Balancer:    balancer.NewBalancer(),
+			Balancer:    balancer,
 		}
 		c.DirectoryCache = &testTenantDirectoryCache{
 			lookupTenantPodsFn: func(
@@ -613,7 +620,7 @@ func TestConnector_lookupAddr(t *testing.T) {
 		c := &connector{
 			ClusterName: "my-foo",
 			TenantID:    roachpb.MakeTenantID(10),
-			Balancer:    balancer.NewBalancer(),
+			Balancer:    balancer,
 		}
 		c.DirectoryCache = &testTenantDirectoryCache{
 			lookupTenantPodsFn: func(
@@ -638,7 +645,7 @@ func TestConnector_lookupAddr(t *testing.T) {
 		c := &connector{
 			ClusterName: "my-foo",
 			TenantID:    roachpb.MakeTenantID(10),
-			Balancer:    balancer.NewBalancer(),
+			Balancer:    balancer,
 		}
 		c.DirectoryCache = &testTenantDirectoryCache{
 			lookupTenantPodsFn: func(


### PR DESCRIPTION
#### ccl/sqlproxyccl: add rebalancer queue for rebalance requests 

This commit adds a rebalancer queue implementation to the balancer component.
The queue will be used for rebalance requests for the connection migration
work. This is done to ensure a centralized location that invokes the
TransferConnection method on the connection handles. Doing this also enables
us to limit the number of concurrent transfers within the proxy.

Release note: None

#### ccl/sqlproxyccl: run rebalancer queue processor in the background 

The previous commit added a rebalancer queue. This commit connects the queue to
the balancer, and runs the queue processor in the background. By the default,
we limit up to 100 concurrent transfers at any point in time, and each transfer
will be retried up to 3 times.

Release note: None

Jira issue: CRDB-14727