### PR TITLE
release-21.2: backupccl: report row and byte size in SHOW BACKUP for tenant backups

### DIFF
--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/protoreflect"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -393,20 +392,9 @@ func backupShowerDefault(
 						}
 					}
 				}
-				descSizes := make(map[descpb.ID]RowCount)
-				for _, file := range manifest.Files {
-					// TODO(dan): This assumes each file in the backup only contains
-					// data from a single table, which is usually but not always
-					// correct. It does not account for interleaved tables or if a
-					// BACKUP happened to catch a newly created table that hadn't yet
-					// been split into its own range.
-					_, tableID, err := encoding.DecodeUvarintAscending(file.Span.Key)
-					if err != nil {
-						continue
-					}
-					s := descSizes[descpb.ID(tableID)]
-					s.add(file.EntryCounts)
-					descSizes[descpb.ID(tableID)] = s
+				tableSizes, err := getTableSizes(manifest.Files)
+				if err != nil {
+					return nil, err
 				}
 				backupType := tree.NewDString("full")
 				if manifest.isIncremental() {
@@ -460,9 +448,9 @@ func backupShowerDefault(
 						dbID = desc.GetParentID()
 						parentSchemaName = schemaIDToName[desc.GetParentSchemaID()]
 						parentSchemaID = desc.GetParentSchemaID()
-						descSize := descSizes[desc.GetID()]
-						dataSizeDatum = tree.NewDInt(tree.DInt(descSize.DataSize))
-						rowCountDatum = tree.NewDInt(tree.DInt(descSize.Rows))
+						tableSize := tableSizes[desc.GetID()]
+						dataSizeDatum = tree.NewDInt(tree.DInt(tableSize.DataSize))
+						rowCountDatum = tree.NewDInt(tree.DInt(tableSize.Rows))
 
 						displayOptions := sql.ShowCreateDisplayOptions{
 							FKDisplayMode:  sql.OmitMissingFKClausesFromCreate,
@@ -555,6 +543,39 @@ func backupShowerDefault(
 			return rows, nil
 		},
 	}
+}
+
+// getTableSizes gathers row and size count for each table in the manifest
+func getTableSizes(files []BackupManifest_File) (map[descpb.ID]RowCount, error) {
+	tableSizes := make(map[descpb.ID]RowCount)
+	if len(files) == 0 {
+		return tableSizes, nil
+	}
+	_, tenantID, err := keys.DecodeTenantPrefix(files[0].Span.Key)
+	if err != nil {
+		return nil, err
+	}
+	showCodec := keys.MakeSQLCodec(tenantID)
+
+	for _, file := range files {
+		// TODO(dan): This assumes each file in the backup only contains
+		// data from a single table, which is usually but not always
+		// correct. It does not account for interleaved tables or if a
+		// BACKUP happened to catch a newly created table that hadn't yet
+		// been split into its own range.
+
+		// TODO(msbutler): after handling the todo above, understand whether
+		// we should return an error if a key does not have tableId. The lack
+		// of error handling let #77705 sneak by our unit tests.
+		_, tableID, err := showCodec.DecodeTablePrefix(file.Span.Key)
+		if err != nil {
+			continue
+		}
+		s := tableSizes[descpb.ID(tableID)]
+		s.add(file.EntryCounts)
+		tableSizes[descpb.ID(tableID)] = s
+	}
+	return tableSizes, nil
 }
 
 func nullIfEmpty(s string) tree.Datum {

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -440,6 +440,50 @@ func TestShowBackups(t *testing.T) {
 	)
 }
 
+// TestShowBackupTenantView ensures that SHOW BACKUP on a tenant backup returns the same results
+// as a SHOW BACKUP on a cluster backup that contains the same data.
+// TODO(msbutler): convert to data driven test, and test cluster and database
+// level backups once tenants support nodelocal or once http external storage supports listing.
+func TestShowBackupTenantView(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const numAccounts = 1
+	_, tc, systemDB, _, cleanupFn := BackupRestoreTestSetup(t, singleNode, numAccounts,
+		InitManualReplication)
+	defer cleanupFn()
+	srv := tc.Server(0)
+
+	_ = security.EmbeddedTenantIDs()
+
+	_, conn10 := serverutils.StartTenant(t, srv, base.TestTenantArgs{TenantID: roachpb.MakeTenantID(10)})
+	defer conn10.Close()
+
+	tenant10 := sqlutils.MakeSQLRunner(conn10)
+	dataQuery := `CREATE DATABASE foo; CREATE TABLE foo.bar(i int primary key); INSERT INTO foo.bar VALUES (110), (210)`
+	backupQuery := `BACKUP TABLE foo.bar INTO $1`
+	showBackupQuery := "SELECT object_name, object_type, rows FROM [SHOW BACKUP LATEST IN $1]"
+	tenant10.Exec(t, dataQuery)
+
+	// First, assert that SHOW BACKUPS on a tenant backup returns the same results if
+	// either the system tenant or tenant10 calls it.
+	tenantAddr, httpServerCleanup := makeInsecureHTTPServer(t)
+	defer httpServerCleanup()
+
+	tenant10.Exec(t, backupQuery, tenantAddr)
+	systemTenantShowRes := systemDB.QueryStr(t, showBackupQuery, tenantAddr)
+	require.Equal(t, systemTenantShowRes, tenant10.QueryStr(t, showBackupQuery, tenantAddr))
+
+	// If the system tenant created the same data, and conducted the same backup,
+	// the row counts should look the same.
+	systemAddr, httpServerCleanup2 := makeInsecureHTTPServer(t)
+	defer httpServerCleanup2()
+
+	systemDB.Exec(t, dataQuery)
+	systemDB.Exec(t, backupQuery, systemAddr)
+	require.Equal(t, systemTenantShowRes, systemDB.QueryStr(t, showBackupQuery, systemAddr))
+}
+
 func TestShowBackupTenants(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)


### PR DESCRIPTION
Backport 1/1 commits from #77952.

/cc @cockroachdb/release

---

Previously, if a tenant or system tenant called SHOW BACKUP on a backup created
by a tenant, SHOW BACKUP would return no data on row or byte size. This patch
fixes this.

Fixes #77705

Release justification: low risk bug fix
Release note (sql change): SHOW BACKUP now reports accurate row and byte size
counts on backups created by a tenant.


Jira issue: CRDB-14728