### PR TITLE
bazel: disable sandboxing and avoid stamping

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -71,9 +71,10 @@ build:crosslinuxarmbase --config=cross
 # NB: This is consumed in `BUILD` files (see build/toolchains/BUILD.bazel).
 build:devdarwinx86_64 --platforms=//build/toolchains:darwin_x86_64
 build:devdarwinx86_64 --config=dev
-build:dev --stamp --workspace_status_command=./build/bazelutil/stamp.sh
+build:dev --workspace_status_command=./build/bazelutil/stamp.sh
 build:dev --action_env=PATH
 build:dev --host_action_env=PATH
+build:dev --spawn_strategy=local --strategy=Genrule=sandboxed
 
 try-import %workspace%/.bazelrc.user
 

--- a/pkg/cmd/dev/doctor.go
+++ b/pkg/cmd/dev/doctor.go
@@ -223,7 +223,6 @@ Please perform the following steps:
 	}
 	if failedStampTestMsg != "" {
 		failedStampTestMsg = failedStampTestMsg + fmt.Sprintf(`
-This may be because your Bazel is not configured to "stamp" built executables.
 Make sure one of the following lines is in the file %s/.bazelrc.user:
 `, workspace)
 		if runtime.GOOS == "darwin" && runtime.GOARCH == "amd64" {


### PR DESCRIPTION
- Sandboxing on MacOS have measurable overhead. See
  https://github.com/bazelbuild/bazel/issues/8230; it comes from
  symlinks being much slower to create. This commit disables sandboxing
  on local builds (still present in CI) to hopefully speed up builds.
  - If this proves to be buggy for whatever reason, we could opt out of
    sandboxing for go package compiles specifically using
    --strategy=GoCompilePkg=local.
  - In the future if we want local sandboxing, we could explore
    sandboxfs: https://bazel.build/docs/sandboxing
- When used with a remote build cache, these stamps (despite being marked
  as volatile), induce an unnecessary golink step when switching back
  and forth between branches. See bazelbuild/bazel#10075. Opting out
  here shaves a few precious seconds if the previously built binary is
  already available.

Release note: None

Jira issue: CRDB-14748