### PR TITLE
ui: add index recommendations on db console

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/common/styles.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/common/styles.module.scss
@@ -42,8 +42,7 @@ h2.base-heading {
 
 h3.base-heading {
   color: $colors--neutral-7;
-  font-family: $font-family--base;
-  font-weight: 600;
+  font-family: $font-family--semi-bold;
   font-style: normal;
   font-stretch: normal;
   font-size: 20px;

--- a/pkg/ui/workspaces/cluster-ui/src/core/typography.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/core/typography.module.scss
@@ -114,10 +114,9 @@ $spacing-xx-large: 48px;
 }
 
 @mixin text--body-strong {
-  font-family: $font-family--base;
+  font-family: $font-family--semi-bold;
   font-size: $font-size--medium;
   line-height: $line-height--medium;
-  font-weight: $font-weight--bold;
 }
 
 @mixin text--code {

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.module.scss
@@ -60,4 +60,8 @@
   &--primary {
     fill: $colors--primary-text;
   }
+
+  &--warning {
+    fill: $colors--functional-orange-3;
+  }
 }

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.stories.tsx
@@ -104,6 +104,7 @@ function createTable(): DatabaseDetailsPageDataTable {
       roles: roles,
       grants: grants,
       statsLastUpdated: moment("0001-01-01T00:00:00Z"),
+      hasIndexRecommendations: false,
     },
     stats: {
       loading: false,

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
@@ -35,6 +35,7 @@ import {
   statisticsClasses,
 } from "src/transactionsPage/transactionsPageClasses";
 import { Moment } from "moment";
+import { Caution } from "@cockroachlabs/icons";
 
 const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
@@ -101,6 +102,7 @@ export interface DatabaseDetailsPageDataTableDetails {
   roles: string[];
   grants: string[];
   statsLastUpdated?: Moment;
+  hasIndexRecommendations: boolean;
 }
 
 export interface DatabaseDetailsPageDataTableStats {
@@ -330,7 +332,22 @@ export class DatabaseDetailsPage extends React.Component<
             Indexes
           </Tooltip>
         ),
-        cell: table => table.details.indexCount,
+        cell: table => {
+          if (table.details.hasIndexRecommendations) {
+            return (
+              <div className={cx("icon__container")}>
+                <Tooltip
+                  placement="bottom"
+                  title="This table has index recommendations. Click the table name to see more details."
+                >
+                  <Caution className={cx("icon--s", "icon--warning")} />
+                </Tooltip>
+                {table.details.indexCount}
+              </div>
+            );
+          }
+          return table.details.indexCount;
+        },
         sort: table => table.details.indexCount,
         className: cx("database-table__col-index-count"),
         name: "indexCount",

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.module.scss
@@ -116,3 +116,35 @@
   }
 }
 
+.index-recommendations {
+  &-icon {
+    &__exist {
+      height: 10px;
+      width: 20px;
+      fill: $colors--warning;
+    }
+
+    &__none {
+      height: 10px;
+      width: 20px;
+      fill: $colors--neutral-11;
+    }
+  }
+
+  &-text {
+    &__border {
+      border-bottom: 1px dashed $colors--disabled;
+    }
+    &__tooltip-anchor {
+        a {
+          font-size: $font-size--small;
+          color: $colors--white;
+          text-decoration: underline;
+          &:hover {
+            opacity: 0.8;
+            color: $colors--white;
+          }
+        }
+    }
+  }
+}

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.stories.tsx
@@ -110,24 +110,34 @@ const withData: DatabaseTablePageProps = {
         lastUsed: moment("2021-10-11T11:29:00Z"),
         lastUsedType: "read",
         indexName: "primary",
+        indexRecommendations: [],
       },
       {
         totalReads: 3,
         lastUsed: moment("2021-11-10T16:29:00Z"),
         lastUsedType: "read",
         indexName: "primary",
+        indexRecommendations: [],
       },
       {
         totalReads: 2,
         lastUsed: moment("2021-09-04T13:55:00Z"),
         lastUsedType: "reset",
         indexName: "secondary",
+        indexRecommendations: [],
       },
       {
         totalReads: 0,
         lastUsed: moment("2022-03-12T14:31:00Z"),
         lastUsedType: "created",
         indexName: "secondary",
+        indexRecommendations: [
+          {
+            type: "DROP_UNUSED",
+            reason:
+              "This index has not been used and can be removed for better write performance.",
+          },
+        ],
       },
     ],
     lastReset: moment("2021-09-04T13:55:00Z"),

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.module.scss
@@ -61,3 +61,17 @@
     fill: $colors--primary-text;
   }
 }
+
+.index-recommendations-icon {
+  &__exist {
+    height: 10px;
+    width: 20px;
+    fill: $colors--functional-orange-3;
+  }
+
+  &__none {
+    height: 10px;
+    width: 20px;
+    fill: $colors--neutral-11;
+  }
+}

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.stories.tsx
@@ -87,6 +87,7 @@ const withData: DatabasesPageProps = {
       missingTables: [],
       nodesByRegionString:
         "gcp-europe-west1(n8), gcp-us-east1(n1), gcp-us-west1(n6)",
+      numIndexRecommendations: 0,
     };
   }),
   onSortingChange: () => {},

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
@@ -34,6 +34,7 @@ import {
 import { syncHistory, tableStatsClusterSetting } from "src/util";
 import classnames from "classnames/bind";
 import booleanSettingStyles from "../settings/booleanSetting.module.scss";
+import { CircleFilled } from "../icon";
 
 const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
@@ -86,6 +87,7 @@ export interface DatabasesPageDataDatabase {
   // String of nodes grouped by region in alphabetical order, e.g.
   // regionA(n1,n2), regionB(n3)
   nodesByRegionString?: string;
+  numIndexRecommendations: number;
 }
 
 // A "missing" table is one for which we were unable to gather size and range
@@ -204,6 +206,29 @@ export class DatabasesPage extends React.Component<
     }
   };
 
+  private renderIndexRecommendations = (
+    database: DatabasesPageDataDatabase,
+  ): React.ReactNode => {
+    const text =
+      database.numIndexRecommendations > 0
+        ? `${database.numIndexRecommendations} index ${
+            database.numIndexRecommendations > 1
+              ? "recommendations"
+              : "recommendation"
+          }`
+        : "None";
+    const classname =
+      database.numIndexRecommendations > 0
+        ? "index-recommendations-icon__exist"
+        : "index-recommendations-icon__none";
+    return (
+      <div>
+        <CircleFilled className={cx(classname)} />
+        <span>{text}</span>
+      </div>
+    );
+  };
+
   private columns: ColumnDescriptor<DatabasesPageDataDatabase>[] = [
     {
       title: (
@@ -280,6 +305,20 @@ export class DatabasesPage extends React.Component<
       className: cx("databases-table__col-node-regions"),
       name: "nodeRegions",
       hideIfTenant: true,
+    },
+    {
+      title: (
+        <Tooltip
+          placement="bottom"
+          title="Index recommendations will appear if the system detects improper index usage, such as the occurrence of unused indexes. Following index recommendations may help improve query performance."
+        >
+          Index recommendations
+        </Tooltip>
+      ),
+      cell: this.renderIndexRecommendations,
+      sort: database => database.numIndexRecommendations,
+      className: cx("databases-table__col-node-regions"),
+      name: "numIndexRecommendations",
     },
   ];
 

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.module.scss
@@ -40,6 +40,10 @@
   &--primary {
     fill: $colors--primary-text;
   }
+
+  &--warning {
+    fill: $colors--functional-orange-3;
+  }
 }
 
 .page-container {
@@ -71,12 +75,11 @@
     letter-spacing: 0.33px;
   }
   &--label {
-    font-family: $font-family--base;
+    font-family: $font-family--semi-bold;
     font-size: $font-size--medium;
-    font-weight: $font-weight--bold;
     line-height: $line-height--medium-small;
     letter-spacing: 0.1px;
-    color: $colors--neutral-6;
+    color: $colors--neutral-7;
     margin-right: 5px;
     margin-bottom: 0;
   }
@@ -91,5 +94,16 @@
     letter-spacing: 0.1px;
     color: $popover-color;
     margin-bottom: 0;
+  }
+}
+
+.index-recommendations {
+  &__tooltip-anchor {
+    a {
+      &:hover {
+        opacity: 0.8;
+        text-decoration: underline;
+      }
+    }
   }
 }

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.stories.tsx
@@ -29,6 +29,13 @@ const withData: IndexDetailsPageProps = {
     totalReads: 0,
     lastRead: moment("2021-10-21T22:00:00Z"),
     lastReset: moment("2021-12-02T07:12:00Z"),
+    indexRecommendations: [
+      {
+        type: "DROP_UNUSED",
+        reason:
+          "This index has not been used and can be removed for better write performance.",
+      },
+    ],
   },
   refreshIndexStats: () => {},
   resetIndexUsageStats: () => {},

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
@@ -16,11 +16,14 @@ import styles from "./indexDetailsPage.module.scss";
 import { baseHeadingClasses } from "src/transactionsPage/transactionsPageClasses";
 import { CaretRight } from "../icon/caretRight";
 import { Breadcrumbs } from "../breadcrumbs";
-import { Search as IndexIcon } from "@cockroachlabs/icons";
+import { Caution, Search as IndexIcon } from "@cockroachlabs/icons";
 import { SqlBox } from "src/sql";
 import { Col, Row, Tooltip } from "antd";
 import { SummaryCard } from "../summaryCard";
 import moment, { Moment } from "moment";
+import { Heading } from "@cockroachlabs/ui-components";
+import { Anchor } from "../anchor";
+import { performanceTuningRecipes } from "../util";
 
 const cx = classNames.bind(styles);
 
@@ -60,6 +63,12 @@ interface IndexDetails {
   totalReads: number;
   lastRead: Moment;
   lastReset: Moment;
+  indexRecommendations: IndexRecommendation[];
+}
+
+interface IndexRecommendation {
+  type: string;
+  reason: string;
 }
 
 export interface IndexDetailPageActions {
@@ -116,6 +125,53 @@ export class IndexDetailsPage extends React.Component<
     } else {
       return timestamp.format("MMM DD, YYYY [at] h:mm A [(UTC)]");
     }
+  }
+
+  private renderIndexRecommendations(
+    indexRecommendations: IndexRecommendation[],
+  ) {
+    if (indexRecommendations.length === 0) {
+      return "None";
+    }
+    return indexRecommendations.map(recommendation => {
+      let recommendationType: string;
+      switch (recommendation.type) {
+        case "DROP_UNUSED":
+          recommendationType = "Drop unused index";
+      }
+      // TODO(thomas): using recommendation.type as the key seems not good.
+      //  - if it is possible for an index to have multiple recommendations of the same type
+      //  this could cause issues.
+      return (
+        <tr
+          key={recommendationType}
+          className={cx("summary-card--row", "table__row")}
+        >
+          <td
+            className={cx(
+              "table__cell",
+              "summary-card--label",
+              "icon__container",
+            )}
+          >
+            <Caution className={cx("icon--s", "icon--warning")} />
+            {recommendationType}
+          </td>
+          <td
+            className={cx(
+              "summary-card--value",
+              "index-recommendations__tooltip-anchor",
+            )}
+          >
+            <span className={cx("summary-card--label")}>Reason:</span>{" "}
+            {recommendation.reason}{" "}
+            <Anchor href={performanceTuningRecipes} target="_blank">
+              Learn more
+            </Anchor>
+          </td>
+        </tr>
+      );
+    });
   }
 
   render() {
@@ -186,7 +242,7 @@ export class IndexDetailsPage extends React.Component<
             </Row>
             <Row gutter={18}>
               <Col className="gutter-row" span={18}>
-                <SummaryCard className={cx("summary-card")}>
+                <SummaryCard className={cx("summary-card--row")}>
                   <table className="table">
                     <tbody>
                       <tr className={cx("summary-card--row", "table__row")}>
@@ -225,6 +281,20 @@ export class IndexDetailsPage extends React.Component<
                           </p>
                         </td>
                       </tr>
+                    </tbody>
+                  </table>
+                </SummaryCard>
+              </Col>
+            </Row>
+            <Row gutter={18}>
+              <Col className="gutter-row" span={18}>
+                <SummaryCard className={cx("summary-card--row")}>
+                  <Heading type="h5">Index recommendations</Heading>
+                  <table className="table">
+                    <tbody>
+                      {this.renderIndexRecommendations(
+                        this.props.details.indexRecommendations,
+                      )}
                     </tbody>
                   </table>
                 </SummaryCard>

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
@@ -117,7 +117,6 @@ function formatStatementStart(session: ISession): string {
 
   return start.format(formatStr);
 }
-
 const SessionStatus = (props: { session: ISession }) => {
   const { session } = props;
   const status = session.active_queries.length > 0 ? "Active" : "Idle";

--- a/pkg/ui/workspaces/cluster-ui/src/util/docs.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/docs.ts
@@ -118,3 +118,6 @@ export const transactionLayerOverview = docsURL(
 // Not actually a docs URL.
 export const startTrial = "https://www.cockroachlabs.com/pricing/start-trial/";
 export const transactionsTable = docsURL("ui-transactions-page.html");
+export const performanceTuningRecipes = docsURLNoVersion(
+  "performance-recipes.html#fix-slow-writes",
+);

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.spec.ts
@@ -162,6 +162,7 @@ describe("Database Details Page", function() {
             roles: [],
             grants: [],
             statsLastUpdated: null,
+            hasIndexRecommendations: false,
           },
           stats: {
             loading: false,
@@ -182,6 +183,7 @@ describe("Database Details Page", function() {
             roles: [],
             grants: [],
             statsLastUpdated: null,
+            hasIndexRecommendations: false,
           },
           stats: {
             loading: false,
@@ -321,6 +323,7 @@ describe("Database Details Page", function() {
       statsLastUpdated: util.TimestampToMoment(
         makeTimestamp("0001-01-01T00:00:00Z"),
       ),
+      hasIndexRecommendations: false,
     });
 
     driver.assertTableDetails("bar", {
@@ -334,6 +337,7 @@ describe("Database Details Page", function() {
       statsLastUpdated: util.TimestampToMoment(
         makeTimestamp("0001-01-01T00:00:00Z"),
       ),
+      hasIndexRecommendations: false,
     });
   });
 

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.ts
@@ -150,6 +150,8 @@ export const mapStateToProps = createSelector(
             statsLastUpdated: details?.data?.stats_last_created_at
               ? util.TimestampToMoment(details?.data?.stats_last_created_at)
               : null,
+            hasIndexRecommendations:
+              details?.data?.has_index_recommendations || false,
           },
           stats: {
             loading: !!stats?.inFlight,

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.spec.ts
@@ -311,6 +311,7 @@ describe("Database Table Page", function() {
             makeTimestamp("2021-11-19T23:01:05.167627Z"),
           ),
           lastUsedType: "read",
+          indexRecommendations: [],
         },
         {
           indexName: "index_no_reads_no_resets",
@@ -319,6 +320,7 @@ describe("Database Table Page", function() {
             makeTimestamp("0001-01-01T00:00:00Z"),
           ),
           lastUsedType: "created",
+          indexRecommendations: [],
         },
       ],
       lastReset: util.TimestampToMoment(makeTimestamp("0001-01-01T00:00:00Z")),

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.ts
@@ -40,6 +40,8 @@ const {
   TableIndexStatsRequest,
 } = cockroach.server.serverpb;
 
+const { RecommendationType } = cockroach.sql.IndexRecommendation;
+
 export const mapStateToProps = createSelector(
   (_state: AdminUIState, props: RouteComponentProps): string =>
     getMatchParamByName(props.match, databaseNameAttr),
@@ -89,14 +91,29 @@ export const mapStateToProps = createSelector(
           lastUsed = lastRead;
           lastUsedType = "read";
         }
+        const filteredIndexRecommendations =
+          indexStats?.data?.index_recommendations.filter(
+            indexRec =>
+              indexRec.index_id === indexStat?.statistics.key.index_id,
+          ) || [];
+        const indexRecommendations = filteredIndexRecommendations.map(
+          indexRec => {
+            return {
+              type: RecommendationType[indexRec.type].toString(),
+              reason: indexRec.reason,
+            };
+          },
+        );
         return {
           indexName: indexStat.index_name,
           totalReads: longToInt(indexStat.statistics?.stats?.total_read_count),
           lastUsed: lastUsed,
           lastUsedType: lastUsedType,
+          indexRecommendations,
         };
       },
     );
+
     const grants = _.flatMap(details?.data?.grants, grant =>
       _.map(grant.privileges, privilege => {
         return { user: grant.user, privilege };

--- a/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.spec.ts
@@ -139,6 +139,7 @@ describe("Databases Page", function() {
           rangeCount: 0,
           nodesByRegionString: "",
           missingTables: [],
+          numIndexRecommendations: 0,
         },
         {
           loading: false,
@@ -149,6 +150,7 @@ describe("Databases Page", function() {
           rangeCount: 0,
           nodesByRegionString: "",
           missingTables: [],
+          numIndexRecommendations: 0,
         },
       ],
       sortSetting: { ascending: true, columnTitle: "name" },
@@ -193,6 +195,7 @@ describe("Databases Page", function() {
       rangeCount: 3,
       nodesByRegionString: "",
       missingTables: [],
+      numIndexRecommendations: 0,
     });
 
     driver.assertDatabaseProperties("test", {
@@ -204,6 +207,7 @@ describe("Databases Page", function() {
       rangeCount: 42,
       nodesByRegionString: "",
       missingTables: [],
+      numIndexRecommendations: 0,
     });
   });
 
@@ -235,6 +239,7 @@ describe("Databases Page", function() {
           rangeCount: 3,
           nodesByRegionString: "",
           missingTables: [{ loading: false, name: "bar" }],
+          numIndexRecommendations: 0,
         });
       });
 
@@ -270,6 +275,7 @@ describe("Databases Page", function() {
           rangeCount: 8,
           nodesByRegionString: "",
           missingTables: [],
+          numIndexRecommendations: 0,
         });
       });
     });
@@ -299,6 +305,7 @@ describe("Databases Page", function() {
             { loading: false, name: "foo" },
             { loading: false, name: "bar" },
           ],
+          numIndexRecommendations: 0,
         });
       });
 
@@ -334,6 +341,7 @@ describe("Databases Page", function() {
           rangeCount: 3,
           nodesByRegionString: "",
           missingTables: [{ loading: false, name: "bar" }],
+          numIndexRecommendations: 0,
         });
 
         await driver.refreshTableStats("system", "bar");
@@ -347,6 +355,7 @@ describe("Databases Page", function() {
           rangeCount: 8,
           nodesByRegionString: "",
           missingTables: [],
+          numIndexRecommendations: 0,
         });
       });
     });

--- a/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.ts
@@ -101,6 +101,7 @@ const selectDatabases = createSelector(
       });
 
       const nodesByRegionString = getNodesByRegionString(nodes, nodeRegions);
+      const numIndexRecommendations = stats?.num_index_recommendations || 0;
 
       return {
         loading: !!details?.inFlight,
@@ -110,6 +111,7 @@ const selectDatabases = createSelector(
         tableCount: details?.data?.table_names?.length || 0,
         rangeCount: rangeCount,
         nodesByRegionString,
+        numIndexRecommendations,
         missingTables: missingTables.map(table => {
           return {
             loading: !!tableStats[generateTableID(database, table)]?.inFlight,

--- a/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.spec.ts
@@ -142,6 +142,7 @@ describe("Index Details Page", function() {
           totalReads: 0,
           lastRead: moment(),
           lastReset: moment(),
+          indexRecommendations: [],
         },
       },
       false,
@@ -193,6 +194,7 @@ describe("Index Details Page", function() {
         lastReset: util.TimestampToMoment(
           makeTimestamp("2021-11-12T20:18:22.167627Z"),
         ),
+        indexRecommendations: [],
       },
     });
   });


### PR DESCRIPTION
This change introduces index recommendations to the db console. More
specifically:
- an index recommendations column was added to the databases page
- a caution icon was added to the indexes column of the database details
  page to signal which tables have index recommendations
- an index recommendations column was added to the database table page
- an index recommendations section was added to the index details page

These changes also include a change to the typography to allow fonts to appear bolded.

**Typography changes, before:**
![Screen Shot 2022-04-05 at 10 02 52 AM](https://user-images.githubusercontent.com/15315413/161772069-10d7c1d1-29a3-4982-8a37-365982e04be1.png)
![Screen Shot 2022-04-05 at 10 02 45 AM](https://user-images.githubusercontent.com/15315413/161772072-823e291d-15d3-4d4f-b2f1-b0d72c0083e2.png)
![Screen Shot 2022-04-05 at 10 02 30 AM](https://user-images.githubusercontent.com/15315413/161772074-9d51aec9-ee1f-485b-9cd5-719f8c1445c3.png)

**Typography changes, after:**
![Screen Shot 2022-04-05 at 9 52 03 AM](https://user-images.githubusercontent.com/15315413/161772184-c449b089-7132-4eef-8990-156147044c68.png)
![Screen Shot 2022-04-05 at 9 51 57 AM](https://user-images.githubusercontent.com/15315413/161772186-8f7ec838-f073-4ba0-acc6-30ba670cb48f.png)
![Screen Shot 2022-04-05 at 9 51 44 AM](https://user-images.githubusercontent.com/15315413/161772187-132321f6-566e-46c6-ba4a-34b72d77b48e.png)

Changes can be seen at the:
- index name/table name/database name
- field/column labels on the database table page, index detail page, cluster overview page (essentially wherever headers were used with the intention to be bolded)

Index Recommendations Changes:
https://www.loom.com/share/3cccabd246404fd69517f0a3bf85ea87

Part of: #72134

Release note (ui change): add index recommendations to the databases pages
(databases, database details, database table, and index details pages) for db
console.

Jira issue: CRDB-14756