### PR TITLE
release-21.2: backupccl: mark backup ExportRequests as Bulk priority

### DIFF
--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -429,8 +429,23 @@ func (f NonTransactionalFactoryFunc) NonTransactionalSender() Sender {
 func SendWrappedWith(
 	ctx context.Context, sender Sender, h roachpb.Header, args roachpb.Request,
 ) (roachpb.Response, *roachpb.Error) {
+	return SendWrappedWithAdmission(ctx, sender, h, roachpb.AdmissionHeader{}, args)
+}
+
+// SendWrappedWithAdmission is a convenience function which wraps the request
+// in a batch and sends it via the provided Sender and headers. It returns the
+// unwrapped response or an error. It's valid to pass a `nil` context; an
+// empty one is used in that case.
+func SendWrappedWithAdmission(
+	ctx context.Context,
+	sender Sender,
+	h roachpb.Header,
+	ah roachpb.AdmissionHeader,
+	args roachpb.Request,
+) (roachpb.Response, *roachpb.Error) {
 	ba := roachpb.BatchRequest{}
 	ba.Header = h
+	ba.AdmissionHeader = ah
 	ba.Add(args)
 
 	br, pErr := sender.Send(ctx, ba)

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -68,6 +68,9 @@ type WorkPriority int8
 const (
 	// LowPri is low priority work.
 	LowPri WorkPriority = math.MinInt8
+	// BulkNormalPri is bulk priority work from bulk jobs, which could be run due
+	// to user submissions or be automatic.
+	BulkNormalPri WorkPriority = -30
 	// NormalPri is normal priority work.
 	NormalPri WorkPriority = 0
 	// HighPri is high priority work.


### PR DESCRIPTION
Backport 1/1 commits from #79086.

/cc @cockroachdb/release

---

This adds a new "bulk normal" priority that is lower than normal user priority but higher than low user priority, and then assigns that priority on AddSSTable and Export requests.

Release note (bug fix): BACKUP read requests are now sent with lower admission control priority than normal traffic.

Jira issue: CRDB-14711


Jira issue: CRDB-14758