### PR TITLE
colexec: remove redundant benchmarks

### DIFF
--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -1172,25 +1172,17 @@ func BenchmarkAggregator(b *testing.B) {
 		numRows = []int{32, 32 * coldata.BatchSize()}
 		groupSizes = []int{1, coldata.BatchSize()}
 	}
-	for _, aggFn := range []execinfrapb.AggregatorSpec_Func{
-		// We choose any_not_null aggregate function because it is the simplest
-		// possible and, thus, its Compute function call will have the least
-		// impact when benchmarking the aggregator logic.
-		execinfrapb.AnyNotNull,
-		// min aggregate function has been used before transitioning to
-		// any_not_null in 22.1 cycle. It is kept so that we could use it for
-		// comparison of 22.1 against 21.2.
-		// TODO(yuzefovich): use only any_not_null in 22.2 (#75106).
-		execinfrapb.Min,
-	} {
-		for _, agg := range aggTypes {
-			for _, numInputRows := range numRows {
-				for _, groupSize := range groupSizes {
-					benchmarkAggregateFunction(
-						b, agg, aggFn, []*types.T{types.Int}, 1, /* numGroupCol */
-						groupSize, 0 /* distinctProb */, numInputRows,
-						0 /* chunkSize */, 0 /* limit */)
-				}
+	// We choose any_not_null aggregate function because it is the simplest
+	// possible and, thus, its Compute function call will have the least impact
+	// when benchmarking the aggregator logic.
+	aggFn := execinfrapb.AnyNotNull
+	for _, agg := range aggTypes {
+		for _, numInputRows := range numRows {
+			for _, groupSize := range groupSizes {
+				benchmarkAggregateFunction(
+					b, agg, aggFn, []*types.T{types.Int}, 1, /* numGroupCol */
+					groupSize, 0 /* distinctProb */, numInputRows,
+					0 /* chunkSize */, 0 /* limit */)
 			}
 		}
 	}

--- a/pkg/sql/colexec/distinct_test.go
+++ b/pkg/sql/colexec/distinct_test.go
@@ -637,11 +637,8 @@ func BenchmarkDistinct(b *testing.B) {
 		},
 	}
 	unorderedShuffled := "UnorderedShuffled"
-	// TODO(yuzefovich): remove Unordered in 22.2 without renaming
-	// unorderedShuffled (#75106).
-	distinctNames := []string{"Unordered", "PartiallyOrdered", "Ordered", unorderedShuffled}
-	distinctConstructors = append(distinctConstructors, distinctConstructors[0])
-	orderedColsFraction := []float64{0, 0.5, 1.0, 0}
+	distinctNames := []string{unorderedShuffled, "PartiallyOrdered", "Ordered"}
+	orderedColsFraction := []float64{0, 0.5, 1.0}
 	for distinctIdx, distinctConstructor := range distinctConstructors {
 		runDistinctBenchmarks(
 			ctx,

--- a/pkg/sql/colexec/external_distinct_test.go
+++ b/pkg/sql/colexec/external_distinct_test.go
@@ -281,48 +281,41 @@ func BenchmarkExternalDistinct(b *testing.B) {
 	var monitorRegistry colexecargs.MonitorRegistry
 	defer monitorRegistry.Close(ctx)
 
-	// TODO(yuzefovich): remove shuffleInput == false case in 22.2 without
-	// changing the name of the benchmark (#75106).
-	for _, shuffleInput := range []bool{false, true} {
-		for _, spillForced := range []bool{false, true} {
-			for _, maintainOrdering := range []bool{false, true} {
-				if !spillForced && maintainOrdering {
-					// The in-memory unordered distinct maintains the input ordering
-					// by design, so it's not an interesting case to test it with
-					// both options for 'maintainOrdering' parameter, and we skip
-					// one.
-					continue
-				}
-				flowCtx.Cfg.TestingKnobs.ForceDiskSpill = spillForced
-				name := fmt.Sprintf("spilled=%t/ordering=%t", spillForced, maintainOrdering)
-				if shuffleInput {
-					name = name + "/shuffled"
-				}
-				runDistinctBenchmarks(
-					ctx,
-					b,
-					func(allocator *colmem.Allocator, input colexecop.Operator, distinctCols []uint32, numOrderedCols int, typs []*types.T) (colexecop.Operator, error) {
-						var outputOrdering execinfrapb.Ordering
-						if maintainOrdering {
-							outputOrdering = convertDistinctColsToOrdering(distinctCols)
-						}
-						op, _, err := createExternalDistinct(
-							ctx, flowCtx, []colexecop.Operator{input}, typs,
-							distinctCols, false /* nullsAreDistinct */, "", /* errorOnDup */
-							outputOrdering, queueCfg, &colexecop.TestingSemaphore{},
-							nil /* spillingCallbackFn */, 0, /* numForcedRepartitions */
-							&monitorRegistry,
-						)
-						return op, err
-					},
-					func(nCols int) int {
-						return 0
-					},
-					name,
-					true, /* isExternal */
-					shuffleInput,
-				)
+	for _, spillForced := range []bool{false, true} {
+		for _, maintainOrdering := range []bool{false, true} {
+			if !spillForced && maintainOrdering {
+				// The in-memory unordered distinct maintains the input ordering
+				// by design, so it's not an interesting case to test it with
+				// both options for 'maintainOrdering' parameter, and we skip
+				// one.
+				continue
 			}
+			flowCtx.Cfg.TestingKnobs.ForceDiskSpill = spillForced
+			name := fmt.Sprintf("spilled=%t/ordering=%t/shuffled", spillForced, maintainOrdering)
+			runDistinctBenchmarks(
+				ctx,
+				b,
+				func(allocator *colmem.Allocator, input colexecop.Operator, distinctCols []uint32, numOrderedCols int, typs []*types.T) (colexecop.Operator, error) {
+					var outputOrdering execinfrapb.Ordering
+					if maintainOrdering {
+						outputOrdering = convertDistinctColsToOrdering(distinctCols)
+					}
+					op, _, err := createExternalDistinct(
+						ctx, flowCtx, []colexecop.Operator{input}, typs,
+						distinctCols, false /* nullsAreDistinct */, "", /* errorOnDup */
+						outputOrdering, queueCfg, &colexecop.TestingSemaphore{},
+						nil /* spillingCallbackFn */, 0, /* numForcedRepartitions */
+						&monitorRegistry,
+					)
+					return op, err
+				},
+				func(nCols int) int {
+					return 0
+				},
+				name,
+				true, /* isExternal */
+				true, /* shuffleInput */
+			)
 		}
 	}
 }

--- a/pkg/sql/colexec/external_hash_aggregator_test.go
+++ b/pkg/sql/colexec/external_hash_aggregator_test.go
@@ -184,42 +184,34 @@ func BenchmarkExternalHashAggregator(b *testing.B) {
 		numRows = []int{64 * coldata.BatchSize()}
 		groupSizes = []int{1, coldata.BatchSize()}
 	}
-	for _, aggFn := range []execinfrapb.AggregatorSpec_Func{
-		// We choose any_not_null aggregate function because it is the simplest
-		// possible and, thus, its Compute function call will have the least
-		// impact when benchmarking the aggregator logic.
-		execinfrapb.AnyNotNull,
-		// min aggregate function has been used before transitioning to
-		// any_not_null in 22.1 cycle. It is kept so that we could use it for
-		// comparison of 22.1 against 21.2.
-		// TODO(yuzefovich): use only any_not_null in 22.2 (#75106).
-		execinfrapb.Min,
-	} {
-		for _, spillForced := range []bool{false, true} {
-			flowCtx.Cfg.TestingKnobs.ForceDiskSpill = spillForced
-			for _, numInputRows := range numRows {
-				for _, groupSize := range groupSizes {
-					benchmarkAggregateFunction(
-						b, aggType{
-							new: func(args *colexecagg.NewAggregatorArgs) colexecop.ResettableOperator {
-								op, _, err := createExternalHashAggregator(
-									ctx, flowCtx, args, queueCfg, &colexecop.TestingSemaphore{},
-									0 /* numForcedRepartitions */, &monitorRegistry,
-								)
-								require.NoError(b, err)
-								// The hash-based partitioner is not a
-								// ResettableOperator, so in order to not change the
-								// signatures of the aggregator constructors, we
-								// wrap it with a noop operator. It is ok for the
-								// purposes of this benchmark.
-								return colexecop.NewNoop(op)
-							},
-							name:  fmt.Sprintf("spilled=%t", spillForced),
-							order: unordered,
+	// We choose any_not_null aggregate function because it is the simplest
+	// possible and, thus, its Compute function call will have the least impact
+	// when benchmarking the aggregator logic.
+	aggFn := execinfrapb.AnyNotNull
+	for _, spillForced := range []bool{false, true} {
+		flowCtx.Cfg.TestingKnobs.ForceDiskSpill = spillForced
+		for _, numInputRows := range numRows {
+			for _, groupSize := range groupSizes {
+				benchmarkAggregateFunction(
+					b, aggType{
+						new: func(args *colexecagg.NewAggregatorArgs) colexecop.ResettableOperator {
+							op, _, err := createExternalHashAggregator(
+								ctx, flowCtx, args, queueCfg, &colexecop.TestingSemaphore{},
+								0 /* numForcedRepartitions */, &monitorRegistry,
+							)
+							require.NoError(b, err)
+							// The hash-based partitioner is not a
+							// ResettableOperator, so in order to not change the
+							// signatures of the aggregator constructors, we
+							// wrap it with a noop operator. It is ok for the
+							// purposes of this benchmark.
+							return colexecop.NewNoop(op)
 						},
-						aggFn, []*types.T{types.Int}, 1 /* numGroupCol */, groupSize,
-						0 /* distinctProb */, numInputRows, 0 /* chunkSize */, 0 /* limit */)
-				}
+						name:  fmt.Sprintf("spilled=%t", spillForced),
+						order: unordered,
+					},
+					aggFn, []*types.T{types.Int}, 1 /* numGroupCol */, groupSize,
+					0 /* distinctProb */, numInputRows, 0 /* chunkSize */, 0 /* limit */)
 			}
 		}
 	}


### PR DESCRIPTION
This commit finishes the transition of some of the benchmarks in the
colexec package started in 22.1 cycle.

Fixes: #75106.

Release note: None

Jira issue: CRDB-14783