### PR TITLE
backupccl: Write once backup roachtests

### DIFF
--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -1162,7 +1162,7 @@ func readLatestCheckpointFile(
 		checkpoint = strings.TrimSuffix(p, backupManifestChecksumSuffix)
 		checkpointFound = true
 		// We only want the first checkpoint so return an error that it is
-		// listing.
+		// done listing.
 		return cloud.ErrListingDone
 	})
 	// If the list failed because the storage used does not support listing,


### PR DESCRIPTION
Added two roachtests, one that writes to a s3 object locked
bucket to ensure that nothing is being overwritten.

One that simulates backup planning on a v22.1 node and executes
on a v21.2 node. This way we can see if the v21.2 node can properly
find the v22.1 node.

Release note: none

Jira issue: CRDB-14805