### PR TITLE
backupccl: allow cluster restore from different tenant

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -118,7 +118,6 @@ go_library(
         "//pkg/util/contextutil",
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",
-        "//pkg/util/errorutil/unimplemented",
         "//pkg/util/hlc",
         "//pkg/util/interval",
         "//pkg/util/ioctx",

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -6660,12 +6660,12 @@ func TestBackupRestoreInsideTenant(t *testing.T) {
 				tenant10C2.CheckQueryResults(t, `SELECT * FROM foo.bar`, tenant10.QueryStr(t, `SELECT * FROM foo.bar`))
 			})
 			t.Run("into-different-tenant-id", func(t *testing.T) {
-				tenant11C2.ExpectErr(t, `cannot cluster RESTORE backups taken from different tenant: 10`,
-					`RESTORE FROM $1`, httpAddr)
+				tenant11C2.Exec(t, `RESTORE FROM $1`, httpAddr)
+				tenant11C2.CheckQueryResults(t, `SELECT * FROM foo.bar`, tenant10.QueryStr(t, `SELECT * FROM foo.bar`))
 			})
 			t.Run("into-system-tenant-id", func(t *testing.T) {
-				systemDB2.ExpectErr(t, `cannot cluster RESTORE backups taken from different tenant: 10`,
-					`RESTORE FROM $1`, httpAddr)
+				systemDB2.Exec(t, `RESTORE FROM $1`, httpAddr)
+				systemDB2.CheckQueryResults(t, `SELECT * FROM foo.bar`, tenant10.QueryStr(t, `SELECT * FROM foo.bar`))
 			})
 		})
 
@@ -6717,8 +6717,7 @@ func TestBackupRestoreInsideTenant(t *testing.T) {
 				defer cleanupEmptyCluster()
 
 				emptySystemDB.Exec(t, `BACKUP TO $1`, httpAddrEmpty)
-				tenant20C2.ExpectErr(t, `cannot cluster RESTORE backups taken from different tenant: system`,
-					`RESTORE FROM $1`, httpAddrEmpty)
+				tenant20C2.Exec(t, `RESTORE FROM $1`, httpAddrEmpty)
 			})
 		})
 
@@ -6728,6 +6727,50 @@ func TestBackupRestoreInsideTenant(t *testing.T) {
 			systemDB.CheckQueryResults(t, `SELECT * FROM data.bank`, tenant10.QueryStr(t, `SELECT * FROM data.bank`))
 		})
 
+	})
+}
+
+// TestBackupRestoreTenantSettings tests the behaviour of the custom restore function for
+// the system.tenant_settings table.
+func TestBackupRestoreTenantSettings(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const numAccounts = 1
+
+	makeTenant := func(srv serverutils.TestServerInterface, tenant uint64) (*sqlutils.SQLRunner, func()) {
+		_, conn := serverutils.StartTenant(t, srv, base.TestTenantArgs{TenantID: roachpb.MakeTenantID(tenant)})
+		cleanup := func() { conn.Close() }
+		return sqlutils.MakeSQLRunner(conn), cleanup
+	}
+	tc, systemDB, dir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
+	_, _ = tc, systemDB
+	defer cleanupFn()
+
+	// NB: tenant certs for 10, 11, and 20 are embedded. See:
+	_ = security.EmbeddedTenantIDs()
+
+	// Create another server.
+	tc2, _, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, dir, InitManualReplication, base.TestClusterArgs{})
+	srv2 := tc2.Server(0)
+	defer cleanupEmptyCluster()
+
+	tenant10C2, cleanupT10C2 := makeTenant(srv2, 10)
+	defer cleanupT10C2()
+
+	systemDB.Exec(t, `ALTER TENANT ALL SET CLUSTER SETTING sql.notices.enabled = false`)
+	backup2HttpAddr, backup2Cleanup := makeInsecureHTTPServer(t)
+	defer backup2Cleanup()
+	systemDB.Exec(t, `BACKUP TO $1`, backup2HttpAddr)
+
+	t.Run("cluster-restore-into-tenant-with-tenant-settings-succeeds", func(t *testing.T) {
+		tenant10C2.Exec(t, `RESTORE FROM $1`, backup2HttpAddr)
+	})
+
+	_, systemDB2, cleanupDB2 := backupRestoreTestSetupEmpty(t, singleNode, dir, InitManualReplication, base.TestClusterArgs{})
+	defer cleanupDB2()
+	t.Run("cluster-restore-into-cluster-with-tenant-settings-succeeds", func(t *testing.T) {
+		systemDB2.Exec(t, `RESTORE FROM $1`, backup2HttpAddr)
+		systemDB2.CheckQueryResults(t, `SELECT * FROM system.tenant_settings`, systemDB.QueryStr(t, `SELECT * FROM system.tenant_settings`))
 	})
 }
 
@@ -6797,12 +6840,11 @@ func TestBackupRestoreInsideMultiPodTenant(t *testing.T) {
 				tenant10C2[0].CheckQueryResults(t, `SELECT * FROM foo.bar`, tenant10[0].QueryStr(t, `SELECT * FROM foo.bar`))
 			})
 			t.Run("into-different-tenant-id", func(t *testing.T) {
-				tenant11C2.ExpectErr(t, `cannot cluster RESTORE backups taken from different tenant: 10`,
-					`RESTORE FROM $1`, httpAddr)
+				tenant11C2.Exec(t, `RESTORE FROM $1`, httpAddr)
+				tenant11C2.CheckQueryResults(t, `SELECT * FROM foo.bar`, tenant10[0].QueryStr(t, `SELECT * FROM foo.bar`))
 			})
 			t.Run("into-system-tenant-id", func(t *testing.T) {
-				systemDB2.ExpectErr(t, `cannot cluster RESTORE backups taken from different tenant: 10`,
-					`RESTORE FROM $1`, httpAddr)
+				systemDB2.Exec(t, `RESTORE FROM $1`, httpAddr)
 			})
 		})
 
@@ -6854,8 +6896,7 @@ func TestBackupRestoreInsideMultiPodTenant(t *testing.T) {
 				defer cleanupEmptyCluster()
 
 				emptySystemDB.Exec(t, `BACKUP TO $1`, httpAddrEmpty)
-				tenant20C2.ExpectErr(t, `cannot cluster RESTORE backups taken from different tenant: system`,
-					`RESTORE FROM $1`, httpAddrEmpty)
+				tenant20C2.Exec(t, `RESTORE FROM $1`, httpAddrEmpty)
 			})
 		})
 

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -50,7 +50,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -1279,13 +1278,6 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	}
 
 	if !backupCodec.TenantPrefix().Equal(p.ExecCfg().Codec.TenantPrefix()) {
-		// Disallow cluster restores until values like jobs are relocatable.
-		if details.DescriptorCoverage == tree.AllDescriptors {
-			return unimplemented.NewWithIssuef(62277,
-				"cannot cluster RESTORE backups taken from different tenant: %s",
-				backupTenantID.String())
-		}
-
 		// Ensure old processors fail if this is a previously unsupported restore of
 		// a tenant backup by the system tenant, which the old rekey processor would
 		// mishandle since it assumed the system tenant always restored tenant keys

--- a/pkg/ccl/backupccl/system_schema.go
+++ b/pkg/ccl/backupccl/system_schema.go
@@ -113,6 +113,43 @@ func defaultSystemTableRestoreFunc(
 
 // Custom restore functions for different system tables.
 
+// tenantSettingsTableRestoreFunc restores the system.tenant_settings table. It
+// returns an error when trying to restore a non-empty tenant_settings table
+// into a non-system tenant.
+func tenantSettingsTableRestoreFunc(
+	ctx context.Context,
+	execCfg *sql.ExecutorConfig,
+	txn *kv.Txn,
+	systemTableName, tempTableName string,
+) error {
+	if execCfg.Codec.ForSystemTenant() {
+		return defaultSystemTableRestoreFunc(ctx, execCfg, txn, systemTableName, tempTableName)
+	}
+
+	if count, err := queryTableRowCount(ctx, execCfg.InternalExecutor, txn, tempTableName); err == nil && count > 0 {
+		log.Warningf(ctx, "skipping restore of %d entries in system.tenant_settings table", count)
+	} else if err != nil {
+		log.Warningf(ctx, "skipping restore of entries in system.tenant_settings table (count failed: %s)", err.Error())
+	}
+	return nil
+}
+
+func queryTableRowCount(
+	ctx context.Context, ie *sql.InternalExecutor, txn *kv.Txn, tableName string,
+) (int64, error) {
+	countQuery := fmt.Sprintf("SELECT count(1) FROM %s", tableName)
+	row, err := ie.QueryRow(ctx, fmt.Sprintf("count-%s", tableName), txn, countQuery)
+	if err != nil {
+		return 0, errors.Wrapf(err, "counting rows in %q", tableName)
+	}
+
+	count, ok := row[0].(*tree.DInt)
+	if !ok {
+		return 0, errors.AssertionFailedf("failed to read count as DInt (was %T)", row[0])
+	}
+	return int64(*count), nil
+}
+
 // jobsMigrationFunc resets the progress on schema change jobs, and marks all
 // other jobs as reverting.
 func jobsMigrationFunc(
@@ -360,6 +397,7 @@ var systemTableBackupConfiguration = map[string]systemBackupConfiguration{
 	},
 	systemschema.TenantSettingsTable.GetName(): {
 		shouldIncludeInClusterBackup: optInToClusterBackup,
+		customRestoreFunc:            tenantSettingsTableRestoreFunc,
 	},
 }
 


### PR DESCRIPTION
This removes a prohibition for cluster restores with mismatched tenant
IDs since we believe they are now correct as of #73831

This allows users to take a cluster backup in a tenant and restore it
into another tenant.

The new tenant_settings table needs special care since it may exist in
the source tenant but not the target tenant when the source tenant is
the system tenant.

In this change, we throw an error in the case of a non-empty
tenant_settings table being restored into a non-system tenant. This is
a bit user-unfriendly since we detect this error rather late in the
restore process.

Release note: None

Jira issue: CRDB-14844