### PR TITLE
dev,bazel: provide some easier ways to build/run all tests

### DIFF
--- a/build/bazelutil/bazel-generate.sh
+++ b/build/bazelutil/bazel-generate.sh
@@ -59,7 +59,7 @@ else
   bazel run pkg/gen/genbzl --run_under="cd $PWD && " -- --out-dir pkg/gen
 fi
 
-if files_unchanged_from_upstream $(find ./pkg -name BUILD.bazel) $(find ./pkg -name '*.bzl'); then
+if files_unchanged_from_upstream $(find ./pkg/cmd/generate-test-suites -name BUILD.bazel -or -name '*.go') $(find ./pkg -name BUILD.bazel) $(find ./pkg -name '*.bzl'); then
   echo "Skipping //pkg/cmd/generate-test-suites (relevant files are unchanged from upstream)."
 else
   CONTENTS=$(bazel run //pkg/cmd/generate-test-suites --run_under="cd $PWD && ")

--- a/dev
+++ b/dev
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=27
+DEV_VERSION=28
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -498,6 +498,15 @@ ALL_TESTS = [
 # [2] https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes-tests
 
 test_suite(
+    name = "all_tests",
+    tags = [
+        "-broken_in_bazel",
+        "-integration",
+    ],
+    tests = ALL_TESTS,
+)
+
+test_suite(
     name = "small_tests",
     tags = [
         "-broken_in_bazel",

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -71,6 +71,7 @@ func makeBuildCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Com
 
 // buildTargetMapping maintains shorthands that map 1:1 with bazel targets.
 var buildTargetMapping = map[string]string{
+	"all_tests":        "//pkg:all_tests",
 	"bazel-remote":     bazelRemoteTarget,
 	"buildifier":       "@com_github_bazelbuild_buildtools//buildifier:buildifier",
 	"buildozer":        "@com_github_bazelbuild_buildtools//buildozer:buildozer",
@@ -96,6 +97,7 @@ var buildTargetMapping = map[string]string{
 	"staticcheck":      "@co_honnef_go_tools//cmd/staticcheck:staticcheck",
 	"stress":           stressTarget,
 	"swagger":          "@com_github_go_swagger_go_swagger//cmd/swagger:swagger",
+	"tests":            "//pkg:all_tests",
 	"workload":         "//pkg/cmd/workload:workload",
 }
 
@@ -322,7 +324,7 @@ func (d *dev) getBasicBuildArgs(
 				typ := fields[0]
 				args = append(args, fullTargetName)
 				buildTargets = append(buildTargets, buildTarget{fullName: fullTargetName, kind: typ})
-				if typ == "go_test" || typ == "go_transition_test" {
+				if typ == "go_test" || typ == "go_transition_test" || typ == "test_suite" {
 					shouldBuildWithTestConfig = true
 				}
 			}

--- a/pkg/cmd/dev/testdata/datadriven/test
+++ b/pkg/cmd/dev/testdata/datadriven/test
@@ -77,7 +77,7 @@ bazel test pkg/server:all --test_env=GOTRACEBACK=all --test_filter=TestSpanStats
 exec
 dev test --short
 ----
-bazel test pkg/...:all --test_env=GOTRACEBACK=all --test_arg -test.short --test_output errors
+bazel test //pkg:all_tests --test_env=GOTRACEBACK=all --test_arg -test.short --test_output errors
 
 exec
 dev test pkg/kv/kvserver -f TestStoreRangeSplitMergeGeneration --test-args '-test.memprofile=mem.out'

--- a/pkg/cmd/generate-test-suites/main.go
+++ b/pkg/cmd/generate-test-suites/main.go
@@ -77,6 +77,16 @@ ALL_TESTS = [`)
 # [1] https://docs.bazel.build/versions/master/be/general.html#test_suite
 # [2] https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes-tests`)
 
+	fmt.Println(`
+test_suite(
+    name = "all_tests",
+    tags = [
+        "-broken_in_bazel",
+        "-integration",
+    ],
+    tests = ALL_TESTS,
+)`)
+
 	for _, size := range []string{"small", "medium", "large", "enormous"} {
 		fmt.Printf(`
 test_suite(


### PR DESCRIPTION
1. Provide a `pkg:all_tests` target. This captures all the same tests
   as `pkg:{small,medium,large,enormous}_tests` but requiring much less
   typing.
2. Provide `dev build` support for building all tests.
3. Expose `all`/`all_tests` aliases in `dev test` as well.

Release note: None