### PR TITLE
backupccl: add deprecation notice for backup cmd with explicit subdir

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -792,6 +792,14 @@ func backupPlanHook(
 				initialDetails.Destination.Subdir = latestFileName
 			} else if subdir != "" {
 				initialDetails.Destination.Subdir = "/" + strings.TrimPrefix(subdir, "/")
+				// Deprecation notice for `BACKUP INTO` syntax with an explicit subdir.
+				// Remove this once the syntax is deleted in 22.2.
+				p.BufferClientNotice(ctx,
+					pgnotice.Newf("BACKUP commands with an explicitly specified"+
+						" subdirectory will be removed in a future release. Users can create a full backup via `BACKUP ... "+
+						"INTO <collectionURI>`, or an incremental backup on the latest full backup in their "+
+						"collection via `BACKUP ... INTO LATEST IN <collectionURI>`"))
+
 			} else {
 				initialDetails.Destination.Subdir = endTime.GoTime().Format(DateBasedIntoFolderName)
 			}

--- a/pkg/ccl/backupccl/testdata/backup-restore/feature-flags
+++ b/pkg/ccl/backupccl/testdata/backup-restore/feature-flags
@@ -73,6 +73,11 @@ BACKUP TO 'nodelocal://1/deprecated/incfrom' INCREMENTAL FROM 'nodelocal://1/dep
 NOTICE: The `BACKUP TO` syntax will be removed in a future release, please switch over to using `BACKUP INTO` to create a backup collection: https://www.cockroachlabs.com/docs/stable/backup.html#considerations. Backups created using the `BACKUP TO` syntax may not be restoreable in the next major version release.
 
 exec-sql
+BACKUP INTO 'deprecatedExplicitSubdir' IN 'nodelocal://1/deprecated';
+----
+NOTICE: BACKUP commands with an explicitly specified subdirectory will be removed in a future release. Users can create a full backup via `BACKUP ... INTO <collectionURI>`, or an incremental backup on the latest full backup in their collection via `BACKUP ... INTO LATEST IN <collectionURI>`
+
+exec-sql
 DROP TABLE d.t;
 ----
 


### PR DESCRIPTION
backupccl: add deprecation notice for backup cmd with explicit subdir
    
  Release note (sql change): Previously, Backup commands allowed the user to
  specify a custom subdirectory name for their backups via `BACKUP .. INTO
  <subdir> IN <collectionURI>`. After this change, this will no longer be
  supported. Users can only create a full backup via `Backup ... INTO
  <collectionURI>` or an incremental backup on the latest full backup in their
  collection via `BACKUP ... INTO LATEST IN <collectionURI>`. This deprecation
  also removes the need to address a bug in `SHOW BACKUPS IN` which cannot display
  user defined subdirectories.
