### PR TITLE
workload/demo: fix geo-paritioned-replicas for demo

### DIFF
--- a/pkg/cli/interactive_tests/test_demo_partitioning.tcl
+++ b/pkg/cli/interactive_tests/test_demo_partitioning.tcl
@@ -36,7 +36,7 @@ eexpect $prompt
 
 start_test "Expect partitioning succeeds"
 # test that partitioning works if a license could be acquired
-send "$argv demo --geo-partitioned-replicas\r"
+send "$argv demo --multitenant=false --geo-partitioned-replicas\r"
 
 # wait for the shell to start up
 wait_for_partitioning_or_exit
@@ -149,6 +149,13 @@ eexpect "ERROR: use of partitions requires an enterprise license"
 eexpect $prompt
 end_test
 
+start_test "Expect an error if geo-partitioning is requested with multitenant mode"
+send "$argv demo --geo-partitioned-replicas\r"
+# expect a failure
+eexpect "operation is unsupported in multi-tenancy mode"
+eexpect $prompt
+end_test
+
 start_test "Expect an error if geo-partitioning is requested and a license cannot be acquired"
 send "export COCKROACH_DEMO_LICENSE_URL=https://127.0.0.1:9999/\r"
 eexpect $prompt
@@ -164,12 +171,11 @@ start_test "Expect an error if geo-partitioning is requested and license acquisi
 send "export COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING=true\r"
 send "$argv demo --geo-partitioned-replicas\r"
 # expect a failure
-eexpect ERROR:
 eexpect "enterprise features are needed for this demo"
-# clean up after the test
-eexpect $prompt"
-
-# clean up after the test
 eexpect $prompt
+end_test
 
+# clean up after the test
+send_eof
+eexpect eof
 end_test

--- a/pkg/workload/movr/movr.go
+++ b/pkg/workload/movr/movr.go
@@ -316,7 +316,7 @@ func (g *movr) Hooks() workload.Hooks {
 				default:
 					return errors.Errorf("unsupported survival goal: %s", g.survivalGoal)
 				}
-				q := fmt.Sprintf(
+				qs := fmt.Sprintf(
 					`
 ALTER DATABASE %[1]s SET PRIMARY REGION "us-east1";
 ALTER DATABASE %[1]s ADD REGION "us-west1";
@@ -326,8 +326,10 @@ ALTER DATABASE %[1]s SURVIVE %s FAILURE
 					g.Meta().Name,
 					survivalGoal,
 				)
-				if _, err := db.Exec(q); err != nil {
-					return err
+				for _, q := range strings.Split(qs, ";") {
+					if _, err := db.Exec(q); err != nil {
+						return err
+					}
 				}
 				for _, rbrTable := range rbrTables {
 					if g.inferCRDBRegionColumn {
@@ -384,104 +386,91 @@ ALTER DATABASE %[1]s SURVIVE %s FAILURE
 				return nil
 			}
 
-			// Create us-west, us-east and europe-west partitions.
-			q := `
-		ALTER TABLE users PARTITION BY LIST (city) (
-			PARTITION us_west VALUES IN ('seattle', 'san francisco', 'los angeles'),
-			PARTITION us_east VALUES IN ('new york', 'boston', 'washington dc'),
-			PARTITION europe_west VALUES IN ('amsterdam', 'paris', 'rome')
-		);
-		ALTER TABLE vehicles PARTITION BY LIST (city) (
-			PARTITION us_west VALUES IN ('seattle', 'san francisco', 'los angeles'),
-			PARTITION us_east VALUES IN ('new york', 'boston', 'washington dc'),
-			PARTITION europe_west VALUES IN ('amsterdam', 'paris', 'rome')
-		);
-		ALTER INDEX vehicles_auto_index_fk_city_ref_users PARTITION BY LIST (city) (
-			PARTITION us_west VALUES IN ('seattle', 'san francisco', 'los angeles'),
-			PARTITION us_east VALUES IN ('new york', 'boston', 'washington dc'),
-			PARTITION europe_west VALUES IN ('amsterdam', 'paris', 'rome')
-		);
-		ALTER TABLE rides PARTITION BY LIST (city) (
-			PARTITION us_west VALUES IN ('seattle', 'san francisco', 'los angeles'),
-			PARTITION us_east VALUES IN ('new york', 'boston', 'washington dc'),
-			PARTITION europe_west VALUES IN ('amsterdam', 'paris', 'rome')
-		);
-		ALTER INDEX rides_auto_index_fk_city_ref_users PARTITION BY LIST (city) (
-			PARTITION us_west VALUES IN ('seattle', 'san francisco', 'los angeles'),
-			PARTITION us_east VALUES IN ('new york', 'boston', 'washington dc'),
-			PARTITION europe_west VALUES IN ('amsterdam', 'paris', 'rome')
-		);
-		ALTER INDEX rides_auto_index_fk_vehicle_city_ref_vehicles PARTITION BY LIST (vehicle_city) (
-			PARTITION us_west VALUES IN ('seattle', 'san francisco', 'los angeles'),
-			PARTITION us_east VALUES IN ('new york', 'boston', 'washington dc'),
-			PARTITION europe_west VALUES IN ('amsterdam', 'paris', 'rome')
-		);
-		ALTER TABLE user_promo_codes PARTITION BY LIST (city) (
-			PARTITION us_west VALUES IN ('seattle', 'san francisco', 'los angeles'),
-			PARTITION us_east VALUES IN ('new york', 'boston', 'washington dc'),
-			PARTITION europe_west VALUES IN ('amsterdam', 'paris', 'rome')
-		);
-		ALTER TABLE vehicle_location_histories PARTITION BY LIST (city) (
-			PARTITION us_west VALUES IN ('seattle', 'san francisco', 'los angeles'),
-			PARTITION us_east VALUES IN ('new york', 'boston', 'washington dc'),
-			PARTITION europe_west VALUES IN ('amsterdam', 'paris', 'rome')
-		);
-	`
-			if _, err := db.Exec(q); err != nil {
-				return err
+			qs := []string{
+				// Create us-west, us-east and europe-west partitions.
+				`ALTER TABLE users PARTITION BY LIST (city) (
+					PARTITION us_west VALUES IN ('seattle', 'san francisco', 'los angeles'),
+					PARTITION us_east VALUES IN ('new york', 'boston', 'washington dc'),
+					PARTITION europe_west VALUES IN ('amsterdam', 'paris', 'rome')
+				);`,
+				`ALTER TABLE vehicles PARTITION BY LIST (city) (
+					PARTITION us_west VALUES IN ('seattle', 'san francisco', 'los angeles'),
+					PARTITION us_east VALUES IN ('new york', 'boston', 'washington dc'),
+					PARTITION europe_west VALUES IN ('amsterdam', 'paris', 'rome')
+				);`,
+				`ALTER INDEX vehicles_auto_index_fk_city_ref_users PARTITION BY LIST (city) (
+					PARTITION us_west VALUES IN ('seattle', 'san francisco', 'los angeles'),
+					PARTITION us_east VALUES IN ('new york', 'boston', 'washington dc'),
+					PARTITION europe_west VALUES IN ('amsterdam', 'paris', 'rome')
+				);`,
+				`ALTER TABLE rides PARTITION BY LIST (city) (
+					PARTITION us_west VALUES IN ('seattle', 'san francisco', 'los angeles'),
+					PARTITION us_east VALUES IN ('new york', 'boston', 'washington dc'),
+					PARTITION europe_west VALUES IN ('amsterdam', 'paris', 'rome')
+				);`,
+				`ALTER INDEX rides_auto_index_fk_city_ref_users PARTITION BY LIST (city) (
+					PARTITION us_west VALUES IN ('seattle', 'san francisco', 'los angeles'),
+					PARTITION us_east VALUES IN ('new york', 'boston', 'washington dc'),
+					PARTITION europe_west VALUES IN ('amsterdam', 'paris', 'rome')
+				);`,
+				`ALTER INDEX rides_auto_index_fk_vehicle_city_ref_vehicles PARTITION BY LIST (vehicle_city) (
+					PARTITION us_west VALUES IN ('seattle', 'san francisco', 'los angeles'),
+					PARTITION us_east VALUES IN ('new york', 'boston', 'washington dc'),
+					PARTITION europe_west VALUES IN ('amsterdam', 'paris', 'rome')
+				);`,
+				`ALTER TABLE user_promo_codes PARTITION BY LIST (city) (
+					PARTITION us_west VALUES IN ('seattle', 'san francisco', 'los angeles'),
+					PARTITION us_east VALUES IN ('new york', 'boston', 'washington dc'),
+					PARTITION europe_west VALUES IN ('amsterdam', 'paris', 'rome')
+				);`,
+				`ALTER TABLE vehicle_location_histories PARTITION BY LIST (city) (
+					PARTITION us_west VALUES IN ('seattle', 'san francisco', 'los angeles'),
+					PARTITION us_east VALUES IN ('new york', 'boston', 'washington dc'),
+					PARTITION europe_west VALUES IN ('amsterdam', 'paris', 'rome')
+				);`,
+
+				// Alter the partitions to place replicas in the appropriate zones.
+				`ALTER PARTITION us_west OF INDEX users@* CONFIGURE ZONE USING CONSTRAINTS='["+region=us-west1"]';`,
+				`ALTER PARTITION us_east OF INDEX users@* CONFIGURE ZONE USING CONSTRAINTS='["+region=us-east1"]';`,
+				`ALTER PARTITION europe_west OF INDEX users@* CONFIGURE ZONE USING CONSTRAINTS='["+region=europe-west1"]';`,
+
+				`ALTER PARTITION us_west OF INDEX vehicles@* CONFIGURE ZONE USING CONSTRAINTS='["+region=us-west1"]';`,
+				`ALTER PARTITION us_east OF INDEX vehicles@* CONFIGURE ZONE USING CONSTRAINTS='["+region=us-east1"]';`,
+				`ALTER PARTITION europe_west OF INDEX vehicles@* CONFIGURE ZONE USING CONSTRAINTS='["+region=europe-west1"]';`,
+
+				`ALTER PARTITION us_west OF INDEX rides@* CONFIGURE ZONE USING CONSTRAINTS='["+region=us-west1"]';`,
+				`ALTER PARTITION us_east OF INDEX rides@* CONFIGURE ZONE USING CONSTRAINTS='["+region=us-east1"]';`,
+				`ALTER PARTITION europe_west OF INDEX rides@* CONFIGURE ZONE USING CONSTRAINTS='["+region=europe-west1"]';`,
+
+				`ALTER PARTITION us_west OF INDEX user_promo_codes@* CONFIGURE ZONE USING CONSTRAINTS='["+region=us-west1"]';`,
+				`ALTER PARTITION us_east OF INDEX user_promo_codes@* CONFIGURE ZONE USING CONSTRAINTS='["+region=us-east1"]';`,
+				`ALTER PARTITION europe_west OF INDEX user_promo_codes@* CONFIGURE ZONE USING CONSTRAINTS='["+region=europe-west1"]';`,
+
+				`ALTER PARTITION us_west OF INDEX vehicle_location_histories@* CONFIGURE ZONE USING CONSTRAINTS='["+region=us-west1"]';`,
+				`ALTER PARTITION us_east OF INDEX vehicle_location_histories@* CONFIGURE ZONE USING CONSTRAINTS='["+region=us-east1"]';`,
+				`ALTER PARTITION europe_west OF INDEX vehicle_location_histories@* CONFIGURE ZONE USING CONSTRAINTS='["+region=europe-west1"]';`,
+
+				// Create some duplicate indexes for the promo_codes table.
+				`CREATE INDEX promo_codes_idx_us_west ON promo_codes (code) STORING (description, creation_time,expiration_time, rules);`,
+				`CREATE INDEX promo_codes_idx_europe_west ON promo_codes (code) STORING (description, creation_time, expiration_time, rules);`,
+
+				// Apply configurations to the index for fast reads.
+				`ALTER TABLE promo_codes CONFIGURE ZONE USING num_replicas = 3,
+					constraints = '{"+region=us-east1": 1}',
+					lease_preferences = '[[+region=us-east1]]';`,
+				`ALTER INDEX promo_codes@promo_codes_idx_us_west CONFIGURE ZONE USING
+					num_replicas = 3,
+					constraints = '{"+region=us-west1": 1}',
+					lease_preferences = '[[+region=us-west1]]';`,
+				`ALTER INDEX promo_codes@promo_codes_idx_europe_west CONFIGURE ZONE USING
+					num_replicas = 3,
+					constraints = '{"+region=europe-west1": 1}',
+					lease_preferences = '[[+region=europe-west1]]';`,
 			}
-
-			// Alter the partitions to place replicas in the appropriate zones.
-			q = `
-		ALTER PARTITION us_west OF INDEX users@* CONFIGURE ZONE USING CONSTRAINTS='["+region=us-west1"]';
-		ALTER PARTITION us_east OF INDEX users@* CONFIGURE ZONE USING CONSTRAINTS='["+region=us-east1"]';
-		ALTER PARTITION europe_west OF INDEX users@* CONFIGURE ZONE USING CONSTRAINTS='["+region=europe-west1"]';
-
-		ALTER PARTITION us_west OF INDEX vehicles@* CONFIGURE ZONE USING CONSTRAINTS='["+region=us-west1"]';
-		ALTER PARTITION us_east OF INDEX vehicles@* CONFIGURE ZONE USING CONSTRAINTS='["+region=us-east1"]';
-		ALTER PARTITION europe_west OF INDEX vehicles@* CONFIGURE ZONE USING CONSTRAINTS='["+region=europe-west1"]';
-
-		ALTER PARTITION us_west OF INDEX rides@* CONFIGURE ZONE USING CONSTRAINTS='["+region=us-west1"]';
-		ALTER PARTITION us_east OF INDEX rides@* CONFIGURE ZONE USING CONSTRAINTS='["+region=us-east1"]';
-		ALTER PARTITION europe_west OF INDEX rides@* CONFIGURE ZONE USING CONSTRAINTS='["+region=europe-west1"]';
-
-		ALTER PARTITION us_west OF INDEX user_promo_codes@* CONFIGURE ZONE USING CONSTRAINTS='["+region=us-west1"]';
-		ALTER PARTITION us_east OF INDEX user_promo_codes@* CONFIGURE ZONE USING CONSTRAINTS='["+region=us-east1"]';
-		ALTER PARTITION europe_west OF INDEX user_promo_codes@* CONFIGURE ZONE USING CONSTRAINTS='["+region=europe-west1"]';
-
-		ALTER PARTITION us_west OF INDEX vehicle_location_histories@* CONFIGURE ZONE USING CONSTRAINTS='["+region=us-west1"]';
-		ALTER PARTITION us_east OF INDEX vehicle_location_histories@* CONFIGURE ZONE USING CONSTRAINTS='["+region=us-east1"]';
-		ALTER PARTITION europe_west OF INDEX vehicle_location_histories@* CONFIGURE ZONE USING CONSTRAINTS='["+region=europe-west1"]';
-	`
-			if _, err := db.Exec(q); err != nil {
-				return err
-			}
-
-			// Create some duplicate indexes for the promo_codes table.
-			q = `
-		CREATE INDEX promo_codes_idx_us_west ON promo_codes (code) STORING (description, creation_time, expiration_time, rules);
-		CREATE INDEX promo_codes_idx_europe_west ON promo_codes (code) STORING (description, creation_time, expiration_time, rules);
-	`
-			if _, err := db.Exec(q); err != nil {
-				return err
-			}
-
-			// Apply configurations to the index for fast reads.
-			q = `
-		ALTER TABLE promo_codes CONFIGURE ZONE USING num_replicas = 3,
-			constraints = '{"+region=us-east1": 1}',
-			lease_preferences = '[[+region=us-east1]]';
-		ALTER INDEX promo_codes@promo_codes_idx_us_west CONFIGURE ZONE USING
-			num_replicas = 3,
-			constraints = '{"+region=us-west1": 1}',
-			lease_preferences = '[[+region=us-west1]]';
-		ALTER INDEX promo_codes@promo_codes_idx_europe_west CONFIGURE ZONE USING
-			num_replicas = 3,
-			constraints = '{"+region=europe-west1": 1}',
-			lease_preferences = '[[+region=europe-west1]]';
-	`
-			if _, err := db.Exec(q); err != nil {
-				return err
+			for _, q := range qs {
+				if _, err := db.Exec(q); err != nil {
+					return err
+				}
 			}
 			return nil
 		},


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/79437

Previously, using geo-paritioned-replicas in demo would hang. This was
caused by new behavior that runs all batch statements inside of an
implicit transaction block. Creating an index and partitioning it
immediately is not supported well within a single transaction.

The fix is to run the statements separately, which matches the behavior
of how this used to work.

No release note, since the bug is not in any released version.

Release note: None