### PR TITLE
dev: add support for `dev generate cgo`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -549,6 +549,9 @@ native-tag := $(subst -,_,$(TARGET_TRIPLE))$(if $(use-stdmalloc),_stdmalloc)
 # encounters a given native tag or when the build signature changes (see
 # build/defs.mk.sig). These tags are unset when building with the Go toolchain
 # directly, so these files are only compiled when building with Make.
+#
+# NB: If you update the zcgo_flags.go generation below, make sure to make the
+# corresponding changes to `dev generate cgo`.
 CGO_PKGS := \
 	pkg/cli \
 	pkg/cli/clisqlshell \

--- a/dev
+++ b/dev
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=27
+DEV_VERSION=28
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions


### PR DESCRIPTION
The contents of these files here is basically cargo-culted from the
`Makefile`. I have verified that I can get a build working via the
following steps:

    ./dev generate go cgo
    ./dev go -- build ./pkg/cmd/cockroach-short

We don't exactly mirror the previous contents of the `zcgo_flags.go`
files that `make` would create. One difference is that we don't populate
the `zcgo_flags` files in `go-libedit` to configure how the C sources
are built and linked, so we get the default behavior, which is fine, but
means the `go build`-built binary and the Bazel-built binary will be
using a different compiled archive (maybe compiled with different flags/
a different configuration/etc.) for the `libedit` sources.

With `make`, we address this by putting a `zcgo_flags_extra.go` file in
the sources for `go-libedit` right in `vendor`. Post-Bazel we have no
reason for `vendor` and have no plans to keep it in the long-term so
this is not really suitable. I'm punting on this for now -- the default
behavior will probably be "good enough" for most people.

Closes #77170.

Release note: None