### PR TITLE
changefeedccl: error on duplicate targets

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -563,10 +563,11 @@ func getTargetsAndTables(
 			}
 		}
 	}
+	seen := make(map[jobspb.ChangefeedTargetSpecification]tree.ChangefeedTarget)
 	for i, ct := range rawTargets {
 		desc, ok := targetDescs[ct.TableName]
 		if !ok {
-			return nil, nil, errors.Newf("could not match %v to a fetched descriptor. fetched were %v", ct.TableName, targetDescs)
+			return nil, nil, errors.Newf("could not match %v to a fetched descriptor. Fetched were %v", ct.TableName, targetDescs)
 		}
 		td, ok := desc.(catalog.TableDescriptor)
 		if !ok {
@@ -586,6 +587,13 @@ func getTargetsAndTables(
 			FamilyName:        string(ct.FamilyName),
 			StatementTimeName: tables[td.GetID()].StatementTimeName,
 		}
+		if dup, isDup := seen[targets[i]]; isDup {
+			return nil, nil, errors.Errorf(
+				"CHANGEFEED targets %s and %s are duplicates",
+				tree.AsString(&dup), tree.AsString(&ct),
+			)
+		}
+		seen[targets[i]] = ct
 	}
 	return targets, tables, nil
 }

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -3516,6 +3516,21 @@ func TestChangefeedErrors(t *testing.T) {
 		`EXPERIMENTAL CHANGEFEED FOR vw`,
 	)
 
+	sqlDB.ExpectErr(
+		t, `CHANGEFEED targets TABLE foo and TABLE foo are duplicates`,
+		`EXPERIMENTAL CHANGEFEED FOR foo, foo`,
+	)
+	sqlDB.ExpectErr(
+		t, `CHANGEFEED targets TABLE foo and TABLE defaultdb.foo are duplicates`,
+		`EXPERIMENTAL CHANGEFEED FOR foo, defaultdb.foo`,
+	)
+	sqlDB.Exec(t,
+		`CREATE TABLE threefams (a int, b int, c int, family f_a(a), family f_b(b), family f_c(c))`)
+	sqlDB.ExpectErr(
+		t, `CHANGEFEED targets TABLE foo FAMILY f_a and TABLE foo FAMILY f_a are duplicates`,
+		`EXPERIMENTAL CHANGEFEED FOR foo family f_a, foo FAMILY f_b, foo FAMILY f_a`,
+	)
+
 	// Backup has the same bad error message #28170.
 	sqlDB.ExpectErr(
 		t, `"information_schema.tables" does not exist`,


### PR DESCRIPTION
Previously, behavior if you gave two equivalent targets in a changefeed
was undefined. This PR adds validation and an error.

For example,
`use defaultdb; CREATE CHANGEFEED FOR defaultdb.foo, TABLE foo` will
error and give the canonicalized targets that resolved to the same
table. You can still do `FOR db1.foo, db2.foo` as those will resolve
to different tables even though they may emit to the same topic.

Closes https://github.com/cockroachdb/cockroach/issues/78285

Release note (sql change): Changefeed statements now detect duplicate targets and throw an error.