### PR TITLE
nightly: enable race for nightly pebble metamorphic test

### DIFF
--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# This script is run by the Pebble Nightly Metamorphic Race - TeamCity build
+# configuration.
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+mkdir -p artifacts
+
+# Pull in the latest version of Pebble from upstream. The benchmarks run
+# against the tip of the 'master' branch. We do this by `go get`ting the
+# latest version of the module, and then running `mirror` to update `DEPS.bzl`
+# accordingly.
+bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@latest
+NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror)
+echo "$NEW_DEPS_BZL_CONTENT" > DEPS.bzl
+
+# Use the Pebble SHA from the version in the modified DEPS.bzl file.
+# Note that we need to pluck the Git SHA from the go.sum-style version, i.e.
+# v0.0.0-20220214174839-6af77d5598c9SUM => 6af77d5598c9
+PEBBLE_SHA=$(grep 'version =' DEPS.bzl | cut -d'"' -f2 | cut -d'-' -f3)
+echo "Pebble module Git SHA: $PEBBLE_SHA"
+
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e BUILD_VCS_NUMBER=$PEBBLE_SHA -e GITHUB_API_TOKEN -e GITHUB_REPO -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL" \
+                               run_bazel build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race_impl.sh

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race_impl.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+source "$dir/teamcity-bazel-support.sh"  # For process_test_json
+
+set -euxo pipefail
+ARTIFACTS_DIR=/artifacts/meta
+mkdir -p $ARTIFACTS_DIR
+GO_TEST_JSON_OUTPUT_FILE=/artifacts/test.json.txt
+
+echo "TC_SERVER_URL is $TC_SERVER_URL"
+
+bazel build //pkg/cmd/bazci //pkg/cmd/github-post //pkg/cmd/testfilter --config=ci
+
+BAZEL_BIN=$(bazel info bazel-bin --config ci)
+
+exit_status=0
+# NB: If adjusting the metamorphic test flags below, be sure to also update
+# pkg/cmd/github-post/main.go to ensure the GitHub issue poster includes the
+# correct flags in the reproduction command.
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --config=race --config=ci test \
+                                      @com_github_cockroachdb_pebble//internal/metamorphic:metamorphic_test -- \
+                                      --test_timeout=14400 '--test_filter=TestMeta$' \
+                                      --define gotags=bazel,invariants \
+                                      "--test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE" \
+                                      --run_under "@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts 'GO_TEST_JSON_OUTPUT_FILE=cat,XML_OUTPUT_FILE=$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci merge-test-xmls' -maxtime 3h -maxfails 1 -stderr -p 1" \
+                                      --test_arg -dir --test_arg $ARTIFACTS_DIR \
+                                      --test_arg -ops --test_arg "uniform:5000-10000" \
+                                      --test_output streamed \
+    || exit_status=$?
+
+BAZEL_SUPPORT_EXTRA_GITHUB_POST_ARGS=--formatter=pebble-metamorphic process_test_json \
+    $BAZEL_BIN/pkg/cmd/testfilter/testfilter_/testfilter \
+    $BAZEL_BIN/pkg/cmd/github-post/github-post_/github-post \
+    /artifacts $GO_TEST_JSON_OUTPUT_FILE $exit_status
+
+exit $exit_status


### PR DESCRIPTION
We want to enable the race detector on some portion of the
nightly metamorphic test runs to improve coverage of pebble
features which could potentially cause data races.

Release note: None