### PR TITLE
encoding: fix DecodeFloatDescending for positive zero

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/float
+++ b/pkg/sql/logictest/testdata/logic_test/float
@@ -69,10 +69,25 @@ SELECT * FROM i WHERE f = 0
 0
 
 statement ok
-CREATE INDEX ON i (f)
+CREATE INDEX i_f_asc ON i (f)
 
 query R rowsort
 SELECT * FROM i WHERE f = 0
+----
+-0
+0
+
+statement ok
+CREATE INDEX i_f_desc ON i (f DESC)
+
+query R rowsort
+SELECT * FROM i@i_f_asc;
+----
+-0
+0
+
+query R rowsort
+SELECT * FROM i@i_f_desc;
 ----
 -0
 0

--- a/pkg/util/encoding/float.go
+++ b/pkg/util/encoding/float.go
@@ -93,5 +93,13 @@ func DecodeFloatAscending(buf []byte) ([]byte, float64, error) {
 // DecodeFloatDescending decodes floats encoded with EncodeFloatDescending.
 func DecodeFloatDescending(buf []byte) ([]byte, float64, error) {
 	b, r, err := DecodeFloatAscending(buf)
-	return b, -r, err
+	if r != 0 {
+		// All values except for 0 and NaN were negated in
+		// EncodeFloatDescending, so we have to negate them back. Note that we
+		// don't need to check whether r is NaN since negating NaN gives back
+		// NaN too. Negative zero uses composite indexes to decode itself
+		// correctly.
+		r = -r
+	}
+	return b, r, err
 }

--- a/pkg/util/encoding/float_test.go
+++ b/pkg/util/encoding/float_test.go
@@ -105,6 +105,12 @@ func TestEncodeFloatOrdered(t *testing.T) {
 				if !math.IsNaN(dec) {
 					t.Errorf("unexpected mismatch for %v. got %v", c.Value, dec)
 				}
+			} else if c.Value == 0 {
+				// Both -0 and +0 should decode as +0. We need to check bit-for-bit
+				// equality to confirm this.
+				if math.Float64bits(dec) != math.Float64bits(0) {
+					t.Errorf("unexpected mismatch for %v, should be +0. got %v", c.Value, dec)
+				}
 			} else if dec != c.Value {
 				t.Errorf("unexpected mismatch for %v. got %v", c.Value, dec)
 			}


### PR DESCRIPTION
Fixes: #77279

Our old friend -0 is back. This time the problem was in
DecodeFloatDescending, which was decoding both +0 and -0 as -0. Fix it
to decode both as +0. (-0 is then properly decoded as -0 when the value
part of the composite encoding is decoded.)

Note that the on-disk data was correct. Only the decoding was affected.

Release note (bug fix): Queries reading from an index or primary key on
FLOAT or REAL columns DESC would read -0 for every +0 value stored in the
index. Fix this to correctly read +0 for +0 and -0 for -0.

Co-authored-by: Yahor Yuzefovich <yahor@cockroachlabs.com>