### PR TITLE
sql: fix over parallelization of sqllite tests and revert a scapel left in patient

### DIFF
--- a/build/teamcity-sqllogictest.sh
+++ b/build/teamcity-sqllogictest.sh
@@ -17,10 +17,10 @@ export BUILDER_HIDE_GOPATH_SRC=0
 # TODO(yuzefovich): remove crdb_test_off tag once sqllite tests have been
 # adjusted to run in reasonable time with batch size randomizations.
 # WARNING! Keep all of this (including the flags/tags that we pass to the test)
-# in sync w/ build/teamcity/cockroach/ci/tests/sqlite_logic_test_impl.sh.
+# in sync w/ build/teamcity/cockroach/ci/nightlies/sqlite_logic_test_impl.sh.
 run_json_test build/builder.sh \
   stdbuf -oL -eL \
-  make test GOTESTFLAGS=-json TESTFLAGS="-v -bigtest -flex-types" TESTTIMEOUT='24h' PKG='./pkg/sql/logictest' TESTS='^TestSqlLiteLogic$$' TAGS=crdb_test_off
+  make test GOTESTFLAGS=-json TESTFLAGS="-v -bigtest -flex-types -parallel=4" TESTTIMEOUT='24h' PKG='./pkg/sql/logictest' TESTS='^TestSqlLiteLogic$$' TAGS=crdb_test_off
 
 # Run the tests with a multitenant configuration.
 run_json_test build/builder.sh \

--- a/build/teamcity/cockroach/nightlies/sqlite_logic_test_impl.sh
+++ b/build/teamcity/cockroach/nightlies/sqlite_logic_test_impl.sh
@@ -11,7 +11,7 @@ GO_TEST_JSON_OUTPUT_FILE=/artifacts/test.json.txt
 exit_status=0
 $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --config=ci \
     test //pkg/sql/logictest:logictest_test -- \
-    --test_arg -bigtest --test_arg -flex-types \
+    --test_arg -bigtest --test_arg -flex-types --test_arg -parallel=4 \
     --define gotags=bazel,crdb_test_off --test_timeout 86400 \
     --test_filter '^TestSqlLiteLogic$|^TestTenantSQLLiteLogic$' \
     --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE || $exit_status=$?

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -4048,17 +4048,11 @@ func RunLogicTestWithDefaultConfig(
 						!util.RaceEnabled &&
 						!cfg.useTenant &&
 						cfg.numNodes <= 5 {
-						// Skip parallelizing tests that use the kv-batch-size directive since
-						// the batch size is a global variable.
-						//
 						// We also cannot parallelise tests that use tenant servers
 						// because they change shared state in the logging configuration
 						// and there is an assertion against conflicting changes.
 						//
-						// TODO(jordan, radu): make sqlbase.kvBatchSize non-global to fix this.
-						if filepath.Base(path) != "select_index_span_ranges" {
-							t.Parallel() // SAFE FOR TESTING (this comments satisfies the linter)
-						}
+						t.Parallel() // SAFE FOR TESTING (this comments satisfies the linter)
 					}
 					rng, _ := randutil.NewTestRand()
 					lt := logicTest{

--- a/pkg/sql/logictest/logic_test.go
+++ b/pkg/sql/logictest/logic_test.go
@@ -11,7 +11,6 @@
 package logictest
 
 import (
-	"runtime"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -30,7 +29,6 @@ import (
 func TestLogic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	skip.UnderDeadlock(t, "times out and/or hangs")
-	runtime.GOMAXPROCS(16)
 	RunLogicTest(t, TestServerArgs{}, testutils.TestDataPath(t, "logic_test", "[^.]*"))
 }
 


### PR DESCRIPTION
sql: remove a scapel left in the patient
    
Commit 1472c10b2b7df4b85051d5d2855df5dcfcfd6733 inadvertently set
GOMAXPROCS to 16 for all TestLogic tests.
    
Release note: None

sql: limit sqllite tests to 4 parallel when run from teamcity

Running with a full GOMAXPROCS can cause upwards of 16GB of memory
to be used when we parallelize 5 node clusters with 512MB split
between block-cache and max-sql-memory.  With a limit of 4 we should
stay in the 2-3GB range.

Not sure how this will affect performance, we'll have to watch it
going forward.

Fixes: #78690

Release note: None