### PR TITLE
ccl/sqlproxyccl: add server name indication (SNI) support

### DIFF
--- a/pkg/ccl/sqlproxyccl/frontend_admitter.go
+++ b/pkg/ccl/sqlproxyccl/frontend_admitter.go
@@ -17,9 +17,10 @@ import (
 
 // FrontendAdmitInfo contains the result of FrontendAdmit call.
 type FrontendAdmitInfo struct {
-	conn net.Conn
-	msg  *pgproto3.StartupMessage
-	err  error
+	conn          net.Conn
+	msg           *pgproto3.StartupMessage
+	err           error
+	sniServerName string
 }
 
 // FrontendAdmit is the default implementation of a frontend admitter. It can
@@ -34,7 +35,6 @@ var FrontendAdmit = func(
 	// `conn` could be replaced by `conn` embedded in a `tls.Conn` connection,
 	// hence it's important to close `conn` rather than `proxyConn` since closing
 	// the latter will not call `Close` method of `tls.Conn`.
-	var sniServerName string
 
 	// Read first message from client.
 	m, err := pgproto3.NewBackend(pgproto3.NewChunkReader(conn), conn).ReceiveStartupMessage()
@@ -51,6 +51,8 @@ var FrontendAdmit = func(
 	if _, ok := m.(*pgproto3.CancelRequest); ok {
 		return &FrontendAdmitInfo{conn: conn}
 	}
+
+	var sniServerName string
 
 	// If we have an incoming TLS Config, require that the client initiates with
 	// an SSLRequest message.
@@ -84,10 +86,6 @@ var FrontendAdmit = func(
 	}
 
 	if startup, ok := m.(*pgproto3.StartupMessage); ok {
-		// Add the sniServerName (if used) as parameter
-		if sniServerName != "" {
-			startup.Parameters["sni-server"] = sniServerName
-		}
 		// This forwards the remote addr to the backend.
 		startup.Parameters[remoteAddrStartupParam] = conn.RemoteAddr().String()
 		// The client is blocked from using session revival tokens; only the proxy
@@ -102,7 +100,7 @@ var FrontendAdmit = func(
 				),
 			}
 		}
-		return &FrontendAdmitInfo{conn: conn, msg: startup}
+		return &FrontendAdmitInfo{conn: conn, msg: startup, sniServerName: sniServerName}
 	}
 
 	code := codeUnexpectedStartupMessage

--- a/pkg/ccl/sqlproxyccl/frontend_admitter_test.go
+++ b/pkg/ccl/sqlproxyccl/frontend_admitter_test.go
@@ -80,6 +80,7 @@ func TestFrontendAdmitWithClientSSLRequire(t *testing.T) {
 
 	go func() {
 		cfg, err := pgconn.ParseConfig("postgres://localhost?sslmode=require")
+		cfg.TLSConfig.ServerName = "test"
 		require.NoError(t, err)
 		require.NotNil(t, cfg)
 		cfg.DialFunc = func(ctx context.Context, network, addr string) (net.Conn, error) {
@@ -96,6 +97,7 @@ func TestFrontendAdmitWithClientSSLRequire(t *testing.T) {
 	require.NotEqual(t, srv, fe.conn) // The connection was replaced by SSL
 	require.NotNil(t, fe.msg)
 	require.Contains(t, fe.msg.Parameters, remoteAddrStartupParam)
+	require.Equal(t, fe.sniServerName, "test")
 }
 
 // TestFrontendAdmitRequireEncryption sends StartupRequest when SSlRequest is

--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -507,7 +507,10 @@ func (handler *proxyHandler) setupIncomingCert(ctx context.Context) error {
 // the connection parameters, and rewrites the database and options parameters,
 // if necessary.
 //
-// We currently support embedding the cluster identifier in two ways:
+// We currently support embedding the cluster identifier in three ways:
+//
+// - Through server name identification (SNI) when using TLS connections
+//   (e.g. serverless-101.5xj.gcp-us-central1.cockroachlabs.cloud)
 //
 // - Within the database param (e.g. "happy-koala-3.defaultdb")
 //
@@ -528,8 +531,13 @@ func clusterNameAndTenantFromParams(
 		return fe.msg, "", roachpb.MaxTenantID, err
 	}
 
+	sniTenID, sniPresent := parseSNI(fe.sniServerName)
+
 	// No cluster identifiers were specified.
 	if clusterIdentifierDB == "" && clusterIdentifierOpt == "" {
+		if sniPresent {
+			return fe.msg, "", sniTenID, nil
+		}
 		err := errors.New("missing cluster identifier")
 		err = errors.WithHint(err, clusterIdentifierHint)
 		return fe.msg, "", roachpb.MaxTenantID, err
@@ -605,11 +613,54 @@ func clusterNameAndTenantFromParams(
 		}
 	}
 
+	// Cluster ID provided through one of options or database (or both and the
+	// info is matching). If sni has been provided as well - check for match.
+	if sniPresent && tenID != sniTenID.InternalValue {
+		err := errors.New("multiple different tenant IDs provided")
+		err = errors.WithHintf(err,
+			"Is '%d' (SNI) or '%d' (database/options) the identifier for the cluster that you're connecting to?",
+			sniTenID.InternalValue, tenID)
+		err = errors.WithHint(err, clusterIdentifierHint)
+		return fe.msg, "", roachpb.MaxTenantID, err
+	}
+
 	outMsg := &pgproto3.StartupMessage{
 		ProtocolVersion: fe.msg.ProtocolVersion,
 		Parameters:      paramsOut,
 	}
 	return outMsg, clusterName, roachpb.MakeTenantID(tenID), nil
+}
+
+// parseSNI parses the sni server name parameter if provided and returns the
+// extracted tenant id. If the extraction was successful the second parameter
+// will be true. If not - false.
+func parseSNI(sniServerName string) (roachpb.TenantID, bool) {
+	if sniServerName == "" {
+		return roachpb.MaxTenantID, false
+	}
+
+	// Try to obtain tenant ID from SNI
+	parts := strings.Split(sniServerName, ".")
+	if len(parts) == 0 {
+		return roachpb.MaxTenantID, false
+	}
+
+	hostname := parts[0]
+	hostnameParts := strings.Split(hostname, "-")
+	// TODO serverless prefix may not be appropriate for all cases where the proxy
+	// is used so it needs to be mad configurable. A better design would be to pass
+	// the options (database, options, sni server name) to the tenant directory
+	// and get back a routing id.
+	if len(hostnameParts) != 2 || !strings.EqualFold("serverless", hostnameParts[0]) {
+		return roachpb.MaxTenantID, false
+	}
+
+	tenID, err := strconv.ParseUint(hostnameParts[1], 10, 64)
+	if err != nil || tenID < roachpb.MinTenantID.ToUint64() {
+		return roachpb.MaxTenantID, false
+	}
+
+	return roachpb.MakeTenantID(tenID), true
 }
 
 // parseDatabaseParam parses the database parameter from the PG connection
@@ -697,6 +748,11 @@ following methods:
 2) Options parameter:
    Use "--cluster=<cluster identifier>" as the options parameter.
    (e.g. options="--cluster=active-roach-42")
+
+3) Host name:
+   Use a driver that supports server name identification (SNI) with TLS 
+   connection and the hostname assigned to your cluster 
+   (e.g. serverless-101.5xj.gcp-us-central1.cockroachlabs.cloud)
 
 For more details, please visit our docs site at:
 	https://www.cockroachlabs.com/docs/cockroachcloud/connect-to-a-serverless-cluster

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -237,6 +237,8 @@ func TestProxyAgainstSecureCRDB(t *testing.T) {
 	s, addr := newSecureProxyServer(
 		ctx, t, sql.Stopper(), &ProxyOptions{RoutingRule: sql.ServingSQLAddr(), SkipVerify: true},
 	)
+	_, port, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
 
 	url := fmt.Sprintf("postgres://bob:wrong@%s/tenant-cluster-28.defaultdb?sslmode=require", addr)
 	te.TestConnectErr(ctx, t, url, 0, "failed SASL auth")
@@ -244,13 +246,43 @@ func TestProxyAgainstSecureCRDB(t *testing.T) {
 	url = fmt.Sprintf("postgres://bob@%s/tenant-cluster-28.defaultdb?sslmode=require", addr)
 	te.TestConnectErr(ctx, t, url, 0, "failed SASL auth")
 
+	url = fmt.Sprintf("postgres://bob:builder@toothless-28.blah:%s/defaultdb?sslmode=require", port)
+	te.TestConnectErr(ctx, t, url, codeParamsRoutingFailed, "server error")
+
+	url = fmt.Sprintf("postgres://bob:builder@tenant-cluster-28.blah:%s/defaultdb?sslmode=require", port)
+	te.TestConnectErr(ctx, t, url, codeParamsRoutingFailed, "server error")
+
 	url = fmt.Sprintf("postgres://bob:builder@%s/tenant-cluster-28.defaultdb?sslmode=require", addr)
 	te.TestConnect(ctx, t, url, func(conn *pgx.Conn) {
 		require.Equal(t, int64(1), s.metrics.CurConnCount.Value())
 		require.NoError(t, runTestQuery(ctx, conn))
 	})
-	require.Equal(t, int64(1), s.metrics.SuccessfulConnCount.Count())
+
+	// SNI provides tenant ID.
+	url = fmt.Sprintf("postgres://bob:builder@serverless-28.blah:%s/defaultdb?sslmode=require", port)
+	te.TestConnect(ctx, t, url, func(conn *pgx.Conn) {
+		require.Equal(t, int64(1), s.metrics.CurConnCount.Value())
+		require.NoError(t, runTestQuery(ctx, conn))
+	})
+
+	// SNI and database provide tenant IDs that match.
+	url = fmt.Sprintf(
+		"postgres://bob:builder@serverless-28.blah:%s/tenant-cluster-28.defaultdb?sslmode=require", port,
+	)
+	te.TestConnect(ctx, t, url, func(conn *pgx.Conn) {
+		require.Equal(t, int64(1), s.metrics.CurConnCount.Value())
+		require.NoError(t, runTestQuery(ctx, conn))
+	})
+
+	// SNI and database provide tenant IDs that don't match.
+	url = fmt.Sprintf(
+		"postgres://bob:builder@serverless-28.blah:%s/tenant-cluster-29.defaultdb?sslmode=require", port,
+	)
+	te.TestConnectErr(ctx, t, url, codeParamsRoutingFailed, "server error")
+
+	require.Equal(t, int64(3), s.metrics.SuccessfulConnCount.Count())
 	require.Equal(t, int64(2), s.metrics.AuthFailedCount.Count())
+	require.Equal(t, int64(3), s.metrics.RoutingErrCount.Count())
 }
 
 func TestProxyTLSConf(t *testing.T) {
@@ -1466,7 +1498,13 @@ func (te *tester) TestConnect(ctx context.Context, t *testing.T, url string, fn 
 	t.Helper()
 	te.setAuthenticated(false)
 	te.setErrToClient(nil)
-	conn, err := pgx.Connect(ctx, url)
+	connConfig, err := pgx.ParseConfig(url)
+	require.NoError(t, err)
+	if !strings.EqualFold(connConfig.Host, "127.0.0.1") {
+		connConfig.TLSConfig.ServerName = connConfig.Host
+		connConfig.Host = "127.0.0.1"
+	}
+	conn, err := pgx.ConnectConfig(ctx, connConfig)
 	require.NoError(t, err)
 	fn(conn)
 	require.NoError(t, conn.Close(ctx))
@@ -1487,6 +1525,10 @@ func (te *tester) TestConnectErr(
 
 	// Prevent pgx from tying to connect to the `::1` ipv6 address for localhost.
 	cfg.LookupFunc = func(ctx context.Context, s string) ([]string, error) { return []string{s}, nil }
+	if !strings.EqualFold(cfg.Host, "127.0.0.1") && cfg.TLSConfig != nil {
+		cfg.TLSConfig.ServerName = cfg.Host
+		cfg.Host = "127.0.0.1"
+	}
 	conn, err := pgx.ConnectConfig(ctx, cfg)
 	if err == nil {
 		_ = conn.Close(ctx)


### PR DESCRIPTION
Previously the proxy supported two ways of providing tenant id and
cluster name information. One was through the database name. The second
was through the options parameter. As part of the serverless routing
changes, we want to support routing with a tenant id passed through SNI.
This PR adds the ability to route using SNI info.

Release justification: Low risk, high reward changes to existing functionality

Release note: None