### PR TITLE
rowexec: fix recent index out of bounds

### DIFF
--- a/pkg/sql/rowexec/joinreader_strategies.go
+++ b/pkg/sql/rowexec/joinreader_strategies.go
@@ -570,9 +570,10 @@ func (s *joinReaderOrderingStrategy) processLookupRows(
 	} else {
 		// We have to allocate a new multimap but can reuse the old slices.
 		oldSlices := s.inputRowIdxToLookedUpRowIndices
-		s.inputRowIdxToLookedUpRowIndices = make([][]int, len(rows))
 		// Make sure to go up to the capacity to reuse all old slices.
-		for i := range oldSlices[:cap(oldSlices)] {
+		oldSlices = oldSlices[:cap(oldSlices)]
+		s.inputRowIdxToLookedUpRowIndices = make([][]int, len(rows))
+		for i := range oldSlices {
 			s.inputRowIdxToLookedUpRowIndices[i] = oldSlices[i][:0]
 		}
 	}


### PR DESCRIPTION
In a recent change to improve the reuse of some internal state in the
join reader (87aaf7d11686a513498b9149ae24189edabade75) we introduced
a silly bug that can cause index out of bounds error (iterating up to
the capacity of a slice but forgetting to update the length
accordingly). This is now fixed.

Addresses: #79490.

Release note: None