### PR TITLE
sql/catalog/lease: attempt to fix flake

### DIFF
--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -31,6 +31,8 @@ go_library(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/internal/catkv",
         "//pkg/sql/catalog/nstree",
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqlutil",


### PR DESCRIPTION
It's not really clear exactly how we run into a conflict, we'd
need to pick the same expiration as an already existing lease but
not the same as the current lease. This means that the lease which
we conflict with must be in the process of being dropped. We'll
handle the edge case, but I'm not sure how to test whether it
happens in practice.

Fixes #78479.

Release note: None