### PR TITLE
release-22.1: Adding metrics required by the serverless autoscaler

### DIFF
--- a/pkg/ccl/serverccl/tenant_vars_test.go
+++ b/pkg/ccl/serverccl/tenant_vars_test.go
@@ -117,4 +117,11 @@ func TestTenantVars(t *testing.T) {
 
 	require.LessOrEqual(t, float64(cpuTime.User)*1e6, cpuUserNanos2)
 	require.LessOrEqual(t, float64(cpuTime.Sys)*1e6, cpuSysNanos2)
+
+	_, found = metrics["jobs_running_non_idle"]
+	require.True(t, found)
+	_, found = metrics["sql_query_count"]
+	require.True(t, found)
+	_, found = metrics["sql_conns"]
+	require.True(t, found)
 }

--- a/pkg/ccl/sqlproxyccl/server.go
+++ b/pkg/ccl/sqlproxyccl/server.go
@@ -36,7 +36,6 @@ type Server struct {
 	metrics         *metrics
 	metricsRegistry *metric.Registry
 
-	promMu             syncutil.Mutex
 	prometheusExporter metric.PrometheusExporter
 }
 
@@ -101,12 +100,11 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleVars(w http.ResponseWriter, r *http.Request) {
-	s.promMu.Lock()
-	defer s.promMu.Unlock()
-
 	w.Header().Set(httputil.ContentTypeHeader, httputil.PlaintextContentType)
-	s.prometheusExporter.ScrapeRegistry(s.metricsRegistry, true /* includeChildMetrics*/)
-	if err := s.prometheusExporter.PrintAsText(w); err != nil {
+	scrape := func(pm *metric.PrometheusExporter) {
+		pm.ScrapeRegistry(s.metricsRegistry, true /* includeChildMetrics*/)
+	}
+	if err := s.prometheusExporter.ScrapeAndPrintAsText(w, scrape); err != nil {
 		log.Errorf(r.Context(), "%v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}

--- a/pkg/jobs/metrics.go
+++ b/pkg/jobs/metrics.go
@@ -24,6 +24,8 @@ import (
 // Metrics are for production monitoring of each job type.
 type Metrics struct {
 	JobMetrics [jobspb.NumJobTypes]*JobTypeMetrics
+	// RunningNonIdleJobs is the total number of running jobs that are not idle.
+	RunningNonIdleJobs *metric.Gauge
 
 	RowLevelTTL  metric.Struct
 	Changefeed   metric.Struct
@@ -173,6 +175,16 @@ var (
 		Unit:        metric.Unit_COUNT,
 		MetricType:  io_prometheus_client.MetricType_GAUGE,
 	}
+
+	// MetaRunningNonIdleJobs is the count of currently running jobs that are not
+	// reporting as being idle.
+	MetaRunningNonIdleJobs = metric.Metadata{
+		Name:        "jobs.running_non_idle",
+		Help:        "number of running jobs that are not idle",
+		Measurement: "jobs",
+		Unit:        metric.Unit_COUNT,
+		MetricType:  io_prometheus_client.MetricType_GAUGE,
+	}
 )
 
 // MetricStruct implements the metric.Struct interface.
@@ -192,6 +204,7 @@ func (m *Metrics) init(histogramWindowInterval time.Duration) {
 	m.AdoptIterations = metric.NewCounter(metaAdoptIterations)
 	m.ClaimedJobs = metric.NewCounter(metaClaimedJobs)
 	m.ResumedJobs = metric.NewCounter(metaResumedClaimedJobs)
+	m.RunningNonIdleJobs = metric.NewGauge(MetaRunningNonIdleJobs)
 	for i := 0; i < jobspb.NumJobTypes; i++ {
 		jt := jobspb.Type(i)
 		if jt == jobspb.TypeUnspecified { // do not track TypeUnspecified

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1125,7 +1125,11 @@ func (r *Registry) stepThroughStateMachine(
 		var err error
 		func() {
 			jm.CurrentlyRunning.Inc(1)
-			defer jm.CurrentlyRunning.Dec(1)
+			r.metrics.RunningNonIdleJobs.Inc(1)
+			defer func() {
+				jm.CurrentlyRunning.Dec(1)
+				r.metrics.RunningNonIdleJobs.Dec(1)
+			}()
 			err = resumer.Resume(resumeCtx, execCtx)
 		}()
 
@@ -1219,7 +1223,11 @@ func (r *Registry) stepThroughStateMachine(
 		var err error
 		func() {
 			jm.CurrentlyRunning.Inc(1)
-			defer jm.CurrentlyRunning.Dec(1)
+			r.metrics.RunningNonIdleJobs.Inc(1)
+			defer func() {
+				jm.CurrentlyRunning.Dec(1)
+				r.metrics.RunningNonIdleJobs.Dec(1)
+			}()
 			err = resumer.OnFailOrCancel(onFailOrCancelCtx, execCtx)
 		}()
 		if successOnFailOrCancel := err == nil; successOnFailOrCancel {
@@ -1307,8 +1315,10 @@ func (r *Registry) MarkIdle(job *Job, isIdle bool) {
 		if aj.isIdle != isIdle {
 			log.Infof(r.serverCtx, "%s job %d: toggling idleness to %+v", jobType, job.ID(), isIdle)
 			if isIdle {
+				r.metrics.RunningNonIdleJobs.Dec(1)
 				jm.CurrentlyIdle.Inc(1)
 			} else {
+				r.metrics.RunningNonIdleJobs.Inc(1)
 				jm.CurrentlyIdle.Dec(1)
 			}
 			aj.isIdle = isIdle

--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -1038,22 +1038,26 @@ func TestJobIdleness(t *testing.T) {
 		job2 := createJob()
 
 		require.False(t, r.TestingIsJobIdle(job1.ID()))
-
+		require.EqualValues(t, 2, r.metrics.RunningNonIdleJobs.Value())
 		r.MarkIdle(job1, true)
 		r.MarkIdle(job2, true)
 		require.True(t, r.TestingIsJobIdle(job1.ID()))
 		require.Equal(t, int64(2), currentlyIdle.Value())
+		require.EqualValues(t, 0, r.metrics.RunningNonIdleJobs.Value())
 
 		// Repeated calls should not increase metric
 		r.MarkIdle(job1, true)
 		r.MarkIdle(job1, true)
 		require.Equal(t, int64(2), currentlyIdle.Value())
+		require.EqualValues(t, 0, r.metrics.RunningNonIdleJobs.Value())
 
 		r.MarkIdle(job1, false)
 		require.Equal(t, int64(1), currentlyIdle.Value())
 		require.False(t, r.TestingIsJobIdle(job1.ID()))
+		require.EqualValues(t, 1, r.metrics.RunningNonIdleJobs.Value())
 		r.MarkIdle(job2, false)
 		require.Equal(t, int64(0), currentlyIdle.Value())
+		require.EqualValues(t, 2, r.metrics.RunningNonIdleJobs.Value())
 
 		// Let the jobs complete
 		resumeErrChan <- nil

--- a/pkg/kv/kvserver/client_tenant_test.go
+++ b/pkg/kv/kvserver/client_tenant_test.go
@@ -89,9 +89,11 @@ func TestTenantsStorageMetricsOnSplit(t *testing.T) {
 			return true
 		})
 		ex := metric.MakePrometheusExporter()
-		ex.ScrapeRegistry(store.Registry(), true /* includeChildMetrics */)
+		scrape := func(ex *metric.PrometheusExporter) {
+			ex.ScrapeRegistry(store.Registry(), true /* includeChildMetrics */)
+		}
 		var in bytes.Buffer
-		if err := ex.PrintAsText(&in); err != nil {
+		if err := ex.ScrapeAndPrintAsText(&in, scrape); err != nil {
 			t.Fatalf("failed to print prometheus data: %v", err)
 		}
 		if seen != 2 {

--- a/pkg/server/server_http.go
+++ b/pkg/server/server_http.go
@@ -155,7 +155,7 @@ func (s *httpServer) setupRoutes(
 	// The /_status/vars endpoint is not authenticated either. Useful for monitoring.
 	s.mux.Handle(statusVars, http.HandlerFunc(varsHandler{metricSource, s.cfg.Settings}.handleVars))
 	// Same for /_status/load.
-	s.mux.Handle(loadStatusVars, http.HandlerFunc(makeStatusLoadHandler(ctx, runtimeStatSampler)))
+	s.mux.Handle(loadStatusVars, http.HandlerFunc(makeStatusLoadHandler(ctx, runtimeStatSampler, metricSource)))
 
 	if apiServer != nil {
 		// The new "v2" HTTP API tree.

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -64,6 +64,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -121,6 +122,7 @@ var (
 type metricMarshaler interface {
 	json.Marshaler
 	PrintAsText(io.Writer) error
+	ScrapeIntoPrometheus(pm *metric.PrometheusExporter)
 }
 
 func propagateGatewayMetadata(ctx context.Context) context.Context {

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -130,17 +130,12 @@ type MetricsRecorder struct {
 		storeRegistries map[roachpb.StoreID]*metric.Registry
 		stores          map[roachpb.StoreID]storeMetrics
 	}
-	// PrometheusExporter is not thread-safe even for operations that are
-	// logically read-only, but we don't want to block using it just because
-	// another goroutine is reading from the registries (i.e. using
-	// `mu.RLock()`), so we use a separate mutex just for prometheus.
-	// NOTE: promMu should always be locked BEFORE trying to lock mu.
-	promMu struct {
-		syncutil.Mutex
-		// prometheusExporter merges metrics into families and generates the
-		// prometheus text format.
-		prometheusExporter metric.PrometheusExporter
-	}
+
+	// prometheusExporter merges metrics into families and generates the
+	// prometheus text format. It has a ScrapeAndPrintAsText method for thread safe
+	// scrape and print so there is no need to have additional lock here.
+	prometheusExporter metric.PrometheusExporter
+
 	// WriteNodeStatus is a potentially long-running method (with a network
 	// round-trip) that requires a mutex to be safe for concurrent usage. We
 	// therefore give it its own mutex to avoid blocking other methods.
@@ -165,7 +160,7 @@ func NewMetricsRecorder(
 	}
 	mr.mu.storeRegistries = make(map[roachpb.StoreID]*metric.Registry)
 	mr.mu.stores = make(map[roachpb.StoreID]storeMetrics)
-	mr.promMu.prometheusExporter = metric.MakePrometheusExporter()
+	mr.prometheusExporter = metric.MakePrometheusExporter()
 	mr.clock = clock
 	return mr
 }
@@ -240,14 +235,9 @@ func (mr *MetricsRecorder) MarshalJSON() ([]byte, error) {
 	return json.Marshal(topLevel)
 }
 
-// scrapePrometheusLocked updates the prometheusExporter's metrics snapshot.
-func (mr *MetricsRecorder) scrapePrometheusLocked() {
-	mr.scrapeIntoPrometheus(&mr.promMu.prometheusExporter)
-}
-
-// scrapeIntoPrometheus updates the passed-in prometheusExporter's metrics
+// ScrapeIntoPrometheus updates the passed-in prometheusExporter's metrics
 // snapshot.
-func (mr *MetricsRecorder) scrapeIntoPrometheus(pm *metric.PrometheusExporter) {
+func (mr *MetricsRecorder) ScrapeIntoPrometheus(pm *metric.PrometheusExporter) {
 	mr.mu.RLock()
 	defer mr.mu.RUnlock()
 	if mr.mu.nodeRegistry == nil {
@@ -268,20 +258,11 @@ func (mr *MetricsRecorder) scrapeIntoPrometheus(pm *metric.PrometheusExporter) {
 // This is to avoid hanging requests from holding the lock.
 func (mr *MetricsRecorder) PrintAsText(w io.Writer) error {
 	var buf bytes.Buffer
-	if err := mr.lockAndPrintAsText(&buf); err != nil {
+	if err := mr.prometheusExporter.ScrapeAndPrintAsText(&buf, mr.ScrapeIntoPrometheus); err != nil {
 		return err
 	}
 	_, err := buf.WriteTo(w)
 	return err
-}
-
-// lockAndPrintAsText grabs the recorder lock and generates the prometheus
-// metrics page.
-func (mr *MetricsRecorder) lockAndPrintAsText(w io.Writer) error {
-	mr.promMu.Lock()
-	defer mr.promMu.Unlock()
-	mr.scrapePrometheusLocked()
-	return mr.promMu.prometheusExporter.PrintAsText(w)
 }
 
 // ExportToGraphite sends the current metric values to a Graphite server.
@@ -291,7 +272,7 @@ func (mr *MetricsRecorder) lockAndPrintAsText(w io.Writer) error {
 func (mr *MetricsRecorder) ExportToGraphite(
 	ctx context.Context, endpoint string, pm *metric.PrometheusExporter,
 ) error {
-	mr.scrapeIntoPrometheus(pm)
+	mr.ScrapeIntoPrometheus(pm)
 	graphiteExporter := metric.MakeGraphiteExporter(pm)
 	return graphiteExporter.Push(ctx, endpoint)
 }

--- a/pkg/server/status/recorder_test.go
+++ b/pkg/server/status/recorder_test.go
@@ -207,7 +207,6 @@ func TestMetricsRecorder(t *testing.T) {
 		{"testAggCounter", "aggcounter", 7},
 
 		// Stats needed for store summaries.
-		{"ranges", "counter", 1},
 		{"replicas.leaders", "gauge", 1},
 		{"replicas.leaseholders", "gauge", 1},
 		{"ranges", "gauge", 1},

--- a/pkg/testutils/metrictestutils/metrics_text.go
+++ b/pkg/testutils/metrictestutils/metrics_text.go
@@ -24,9 +24,11 @@ import (
 // to the given regexp, sorts them, and returns them in a multi-line string.
 func GetMetricsText(registry *metric.Registry, re *regexp.Regexp) (string, error) {
 	ex := metric.MakePrometheusExporter()
-	ex.ScrapeRegistry(registry, true /* includeChildMetrics */)
+	scrape := func(ex *metric.PrometheusExporter) {
+		ex.ScrapeRegistry(registry, true /* includeChildMetrics */)
+	}
 	var in bytes.Buffer
-	if err := ex.PrintAsText(&in); err != nil {
+	if err := ex.ScrapeAndPrintAsText(&in, scrape); err != nil {
 		return "", err
 	}
 	sc := bufio.NewScanner(&in)

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -2851,6 +2851,12 @@ var charts = []sectionDescription{
 		Organization: [][]string{{Jobs, "Execution"}},
 		Charts: []chartDescription{
 			{
+				Title: "Active",
+				Metrics: []string{
+					"jobs.running_non_idle",
+				},
+			},
+			{
 				Title: "Currently Running",
 				Metrics: []string{
 					"jobs.auto_create_stats.currently_running",

--- a/pkg/util/metric/aggmetric/agg_metric_test.go
+++ b/pkg/util/metric/aggmetric/agg_metric_test.go
@@ -33,8 +33,10 @@ func TestAggMetric(t *testing.T) {
 	writePrometheusMetrics := func(t *testing.T) string {
 		var in bytes.Buffer
 		ex := metric.MakePrometheusExporter()
-		ex.ScrapeRegistry(r, true /* includeChildMetrics */)
-		require.NoError(t, ex.PrintAsText(&in))
+		scrape := func(ex *metric.PrometheusExporter) {
+			ex.ScrapeRegistry(r, true /* includeChildMetrics */)
+		}
+		require.NoError(t, ex.ScrapeAndPrintAsText(&in, scrape))
 		var lines []string
 		for sc := bufio.NewScanner(&in); sc.Scan(); {
 			if !bytes.HasPrefix(sc.Bytes(), []byte{'#'}) {

--- a/pkg/util/metric/registry_test.go
+++ b/pkg/util/metric/registry_test.go
@@ -164,6 +164,25 @@ func TestRegistry(t *testing.T) {
 		t.Fatalf("missed names: %v", expNames)
 	}
 
+	// Test Select
+	selectExpNames := map[string]struct{}{
+		"top.histogram":   {},
+		"top.gauge":       {},
+		"not.in.registry": {},
+	}
+
+	r.Select(
+		selectExpNames,
+		func(name string, _ interface{}) {
+			if _, exist := selectExpNames[name]; !exist {
+				t.Errorf("unexpected name: %s", name)
+			}
+			delete(selectExpNames, name)
+		})
+	if len(selectExpNames) != 1 {
+		t.Fatalf("missed or selected names not in registry: %v", selectExpNames)
+	}
+
 	// Test get functions
 	if g := r.getGauge("top.gauge"); g != topGauge {
 		t.Errorf("getGauge returned %v, expected %v", g, topGauge)


### PR DESCRIPTION
Backport:
  * 1/1 commits from "server/status: selective metric export" (#79021)
  * 1/1 commits from "server/status: add running non-idle jobs metric" (#79022)
  * 1/1 commits from "server/status: add load related metrics" (#79023)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: Low risk, high reward changes to existing functionality

Release note: None