### PR TITLE
ci: fix some janky ci scripts that prevent posting issues to github

### DIFF
--- a/build/teamcity/cockroach/nightlies/optimizer_tests_impl.sh
+++ b/build/teamcity/cockroach/nightlies/optimizer_tests_impl.sh
@@ -17,7 +17,7 @@ exit_status_large=0
 $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --config=ci --artifacts $ARTIFACTS_DIR \
     test //pkg/sql/opt:opt_test -- \
     --define gotags=bazel,crdb_test,fast_int_set_large \
-    --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE || $exit_status_large=$?
+    --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE || exit_status_large=$?
 process_test_json \
         $BAZEL_BIN/pkg/cmd/testfilter/testfilter_/testfilter \
         $BAZEL_BIN/pkg/cmd/github-post/github-post_/github-post \
@@ -37,7 +37,7 @@ exit_status_small=0
 $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --config=ci \
     test //pkg/sql/opt:opt_test -- \
     --define gotags=bazel,crdb_test,fast_int_set_small \
-    --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE || $exit_status_small=$?
+    --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE || exit_status_small=$?
 process_test_json \
         $BAZEL_BIN/pkg/cmd/testfilter/testfilter_/testfilter \
         $BAZEL_BIN/pkg/cmd/github-post/github-post_/github-post \

--- a/build/teamcity/cockroach/nightlies/sqlite_logic_test_impl.sh
+++ b/build/teamcity/cockroach/nightlies/sqlite_logic_test_impl.sh
@@ -14,7 +14,7 @@ $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --config=ci \
     --test_arg -bigtest --test_arg -flex-types --test_arg -parallel=4 \
     --define gotags=bazel,crdb_test_off --test_timeout 86400 \
     --test_filter '^TestSqlLiteLogic$|^TestTenantSQLLiteLogic$' \
-    --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE || $exit_status=$?
+    --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE || exit_status=$?
 process_test_json \
         $BAZEL_BIN/pkg/cmd/testfilter/testfilter_/testfilter \
         $BAZEL_BIN/pkg/cmd/github-post/github-post_/github-post \


### PR DESCRIPTION
In a couple places in `82e0b121c715c59cebbb8d53e29edf7952d6913f` I
accidentally did `$exit_status=$?` instead of `exit_status=$?`, which is
not a proper variable assignment. This was causing these jobs to fail
before they could post issues to GitHub.

Closes #79403.

Release note: None