### PR TITLE
sql: gate tenant's multi-region abstraction usage behind cluster setting

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -187,6 +187,7 @@ go_test(
         "//pkg/blobs",
         "//pkg/ccl/kvccl",
         "//pkg/ccl/multiregionccl",
+        "//pkg/ccl/multiregionccl/multiregionccltestutils",
         "//pkg/ccl/multitenantccl",
         "//pkg/ccl/partitionccl",
         "//pkg/ccl/storageccl",

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -1,3 +1,4 @@
+# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant
 
 query TTTT colnames

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_default_primary_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_default_primary_region
@@ -1,3 +1,4 @@
+# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_drop_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_drop_region
@@ -1,3 +1,4 @@
+# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant
 
 query TTTT

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_privileges
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_privileges
@@ -1,3 +1,4 @@
+# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant
 
 user root

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_secondary_tenants_abstractions_disallowed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_secondary_tenants_abstractions_disallowed
@@ -1,0 +1,10 @@
+# LogicTest: multiregion-9node-3region-3azs-tenant
+
+statement error pq: setting sql.multi_region.allow_abstractions_for_secondary_tenants.enabled disallows use of multi-region abstractions
+CREATE DATABASE db PRIMARY REGION "us-east1"
+
+statement ok
+CREATE DATABASE db
+
+statement error pq: setting sql.multi_region.allow_abstractions_for_secondary_tenants.enabled disallows use of multi-region abstractions
+ALTER DATABASE db SET PRIMARY REGION "us-east-1"

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_show
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_show
@@ -1,3 +1,4 @@
+# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-zone-configs-for-secondary-tenants
+# tenant-cluster-setting-override-opt: allow-zone-configs-for-secondary-tenants allow-multi-region-abstractions-for-secondary-tenants
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant
 
 query TTTT

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-zone-configs-for-secondary-tenants
+# tenant-cluster-setting-override-opt: allow-zone-configs-for-secondary-tenants allow-multi-region-abstractions-for-secondary-tenants
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-tenant
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_auto_rehoming
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_auto_rehoming
@@ -1,3 +1,4 @@
+# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_placement_restricted
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_placement_restricted
@@ -1,3 +1,4 @@
+# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-tenant
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_rename_column
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_rename_column
@@ -1,3 +1,4 @@
+# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-tenant
 
 # This test seems to flake (#60717).

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_table_placement_restricted
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_table_placement_restricted
@@ -1,3 +1,4 @@
+# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-tenant
 
 statement ok

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -365,7 +365,7 @@ var DefaultPrimaryRegion = settings.RegisterStringSetting(
 // cluster setting that governs secondary tenant multi-region abstraction usage.
 const SecondaryTenantsMultiRegionAbstractionsEnabledSettingName = "sql.multi_region.allow_abstractions_for_secondary_tenants.enabled"
 
-// secondaryTenantMultiRegionAbstractionsEnabled controls if secondary tenants
+// SecondaryTenantsMultiRegionAbstractionsEnabled controls if secondary tenants
 // are allowed to use multi-region abstractions. In particular, it controls if
 // secondary tenants are allowed to add a region to their database. It has no
 // effect on the system tenant.
@@ -373,7 +373,7 @@ const SecondaryTenantsMultiRegionAbstractionsEnabledSettingName = "sql.multi_reg
 // This setting has no effect for existing multi-region databases that have
 // already been configured. It only affects regions being added to new
 // databases.
-var secondaryTenantsMultiRegionAbstractionsEnabled = settings.RegisterBoolSetting(
+var SecondaryTenantsMultiRegionAbstractionsEnabled = settings.RegisterBoolSetting(
 	settings.TenantReadOnly,
 	SecondaryTenantsMultiRegionAbstractionsEnabledSettingName,
 	"allow secondary tenants to use multi-region abstractions",
@@ -392,7 +392,7 @@ func (p *planner) maybeInitializeMultiRegionMetadata(
 	placement tree.DataPlacement,
 ) (*multiregion.RegionConfig, error) {
 	if !p.execCfg.Codec.ForSystemTenant() &&
-		!secondaryTenantsMultiRegionAbstractionsEnabled.Get(&p.execCfg.Settings.SV) {
+		!SecondaryTenantsMultiRegionAbstractionsEnabled.Get(&p.execCfg.Settings.SV) {
 		// There was no primary region provided, let the thing pass through.
 		if primaryRegion == "" && len(regions) == 0 {
 			return nil, nil

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -361,6 +361,25 @@ var DefaultPrimaryRegion = settings.RegisterStringSetting(
 	"",
 ).WithPublic()
 
+// SecondaryTenantsMultiRegionAbstractionsEnabledSettingName is the name of the
+// cluster setting that governs secondary tenant multi-region abstraction usage.
+const SecondaryTenantsMultiRegionAbstractionsEnabledSettingName = "sql.multi_region.allow_abstractions_for_secondary_tenants.enabled"
+
+// secondaryTenantMultiRegionAbstractionsEnabled controls if secondary tenants
+// are allowed to use multi-region abstractions. In particular, it controls if
+// secondary tenants are allowed to add a region to their database. It has no
+// effect on the system tenant.
+//
+// This setting has no effect for existing multi-region databases that have
+// already been configured. It only affects regions being added to new
+// databases.
+var secondaryTenantsMultiRegionAbstractionsEnabled = settings.RegisterBoolSetting(
+	settings.TenantReadOnly,
+	SecondaryTenantsMultiRegionAbstractionsEnabledSettingName,
+	"allow secondary tenants to use multi-region abstractions",
+	false,
+)
+
 // maybeInitializeMultiRegionMetadata initializes multi-region metadata if a
 // primary region is supplied and works as a pass-through otherwise. It creates
 // a new region config from the given parameters and reserves an ID for the
@@ -372,6 +391,21 @@ func (p *planner) maybeInitializeMultiRegionMetadata(
 	regions []tree.Name,
 	placement tree.DataPlacement,
 ) (*multiregion.RegionConfig, error) {
+	if !p.execCfg.Codec.ForSystemTenant() &&
+		!secondaryTenantsMultiRegionAbstractionsEnabled.Get(&p.execCfg.Settings.SV) {
+		// There was no primary region provided, let the thing pass through.
+		if primaryRegion == "" && len(regions) == 0 {
+			return nil, nil
+		}
+
+		return nil, errors.WithHint(pgerror.Newf(
+			pgcode.InvalidDatabaseDefinition,
+			"setting %s disallows use of multi-region abstractions",
+			SecondaryTenantsMultiRegionAbstractionsEnabledSettingName,
+		),
+			"consider omitting the primary region")
+	}
+
 	if primaryRegion == "" && len(regions) == 0 {
 		defaultPrimaryRegion := DefaultPrimaryRegion.Get(&p.execCfg.Settings.SV)
 		if defaultPrimaryRegion == "" {

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -171,6 +171,8 @@ import (
 // The options are:
 // - allow-zone-configs-for-secondary-tenants: If specified, secondary tenants
 // are allowed to alter their zone configurations.
+// - allow-multi-region-abstractions-for-secondary-tenants: If specified,
+// secondary tenants are allowed to make use of multi-region abstractions.
 //
 //
 // ###########################################
@@ -1763,6 +1765,22 @@ func (t *logicTest) newCluster(
 				t.Fatal(err)
 			}
 		}
+
+		if clusterSettingOverrideArgs.overrideMultiTenantMultiRegionAbstractionsAllowed {
+			conn := t.cluster.ServerConn(0)
+			// Allow secondary tenants to make use of multi-region abstractions if the
+			// configuration indicates as such. As this is a tenant read-only cluster
+			// setting, only the operator is allowed to set it.
+			if _, err := conn.Exec(
+				fmt.Sprintf(
+					"ALTER TENANT $1 SET CLUSTER SETTING %s = true",
+					sql.SecondaryTenantsMultiRegionAbstractionsEnabledSettingName,
+				),
+				serverutils.TestTenantID().ToUint64(),
+			); err != nil {
+				t.Fatal(err)
+			}
+		}
 	}
 
 	// Set cluster settings.
@@ -1856,40 +1874,58 @@ func (t *logicTest) newCluster(
 	}
 
 	if clusterSettingOverrideArgs.overrideMultiTenantZoneConfigsAllowed {
-		// Wait until all tenant servers are aware of the setting override.
-		testutils.SucceedsSoon(t.rootT, func() error {
-			for i := 0; i < len(t.tenantAddrs); i++ {
-				pgURL, cleanup := sqlutils.PGUrl(t.rootT, t.tenantAddrs[0], "Tenant", url.User(security.RootUser))
-				defer cleanup()
-				if params.ServerArgs.Insecure {
-					pgURL.RawQuery = "sslmode=disable"
-				}
-				db, err := gosql.Open("postgres", pgURL.String())
-				if err != nil {
-					t.Fatal(err)
-				}
-				defer db.Close()
-
-				var val string
-				err = db.QueryRow(
-					"SHOW CLUSTER SETTING sql.zone_configs.allow_for_secondary_tenant.enabled",
-				).Scan(&val)
-				if err != nil {
-					t.Fatal(errors.Wrapf(err, "%d", i))
-				}
-				if val == "false" {
-					return errors.Errorf("tenant server %d is still waiting zone config cluster setting update",
-						i,
-					)
-				}
-			}
-			return nil
-		})
+		t.waitForTenantReadOnlyClusterSettingToTakeEffectOrFatal(
+			"sql.zone_configs.allow_for_secondary_tenant.enabled", "true", params.ServerArgs.Insecure,
+		)
+	}
+	if clusterSettingOverrideArgs.overrideMultiTenantMultiRegionAbstractionsAllowed {
+		t.waitForTenantReadOnlyClusterSettingToTakeEffectOrFatal(
+			sql.SecondaryTenantsMultiRegionAbstractionsEnabledSettingName,
+			"true",
+			params.ServerArgs.Insecure,
+		)
 	}
 
 	// db may change over the lifetime of this function, with intermediate
 	// values cached in t.clients and finally closed in t.close().
 	t.clusterCleanupFuncs = append(t.clusterCleanupFuncs, t.setUser(security.RootUser, 0 /* nodeIdxOverride */))
+}
+
+// waitForTenantReadOnlyClusterSettingToTakeEffectOrFatal waits until all tenant
+// servers are aware about the supplied setting's expected value. Fatal's if
+// this doesn't happen within the SucceedsSoonDuration.
+func (t *logicTest) waitForTenantReadOnlyClusterSettingToTakeEffectOrFatal(
+	settingName string, expValue string, insecure bool,
+) {
+	// Wait until all tenant servers are aware of the setting override.
+	testutils.SucceedsSoon(t.rootT, func() error {
+		for i := 0; i < len(t.tenantAddrs); i++ {
+			pgURL, cleanup := sqlutils.PGUrl(t.rootT, t.tenantAddrs[0], "Tenant", url.User(security.RootUser))
+			defer cleanup()
+			if insecure {
+				pgURL.RawQuery = "sslmode=disable"
+			}
+			db, err := gosql.Open("postgres", pgURL.String())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+
+			var val string
+			err = db.QueryRow(
+				fmt.Sprintf("SHOW CLUSTER SETTING %s", settingName),
+			).Scan(&val)
+			if err != nil {
+				t.Fatal(errors.Wrapf(err, "%d", i))
+			}
+			if val != expValue {
+				return errors.Errorf("tenant server %d is still waiting zone config cluster setting update",
+					i,
+				)
+			}
+		}
+		return nil
+	})
 }
 
 // shutdownCluster performs the necessary cleanup to shutdown the current test
@@ -2102,10 +2138,15 @@ func readTestFileConfigs(
 }
 
 type tenantClusterSettingOverrideArgs struct {
-	// if set, the sql.zone_configs.allow_for_secondary_tenant.enabled defaults
+	// If set, the sql.zone_configs.allow_for_secondary_tenant.enabled default
 	// is set to true by the host. This is allows logic tests that run on
 	// secondary tenants to use zone configurations.
 	overrideMultiTenantZoneConfigsAllowed bool
+	// If set, the
+	// sql.multi_region.allow_abstractions_for_secondary_tenants.enabled default
+	// is set to true by the host. This allows logic tests that run on secondary
+	// tenants to make use of multi-region abstractions.
+	overrideMultiTenantMultiRegionAbstractionsAllowed bool
 }
 
 // tenantClusterSettingOverrideOpt is implemented by options for configuring
@@ -2113,6 +2154,19 @@ type tenantClusterSettingOverrideArgs struct {
 // tenant, these options have no effect.
 type tenantClusterSettingOverrideOpt interface {
 	apply(*tenantClusterSettingOverrideArgs)
+}
+
+// tenantClusterSettingOverrideMultiTenantMultiRegionAbstractionsAllowed
+// corresponds to the allow-multi-region-abstractions-for-secondary-tenants
+// directive.
+type tenantClusterSettingOverrideMultiTenantMultiRegionAbstractionsAllowed struct{}
+
+var _ tenantClusterSettingOverrideOpt = &tenantClusterSettingOverrideMultiTenantMultiRegionAbstractionsAllowed{}
+
+func (t tenantClusterSettingOverrideMultiTenantMultiRegionAbstractionsAllowed) apply(
+	args *tenantClusterSettingOverrideArgs,
+) {
+	args.overrideMultiTenantMultiRegionAbstractionsAllowed = true
 }
 
 // tenantClusterSettingOverrideMultiTenantZoneConfigsAllowed corresponds to
@@ -2243,6 +2297,8 @@ func readTenantClusterSettingOverrideArgs(
 		switch opt {
 		case "allow-zone-configs-for-secondary-tenants":
 			res = append(res, tenantClusterSettingOverrideMultiTenantZoneConfigsAllowed{})
+		case "allow-multi-region-abstractions-for-secondary-tenants":
+			res = append(res, tenantClusterSettingOverrideMultiTenantMultiRegionAbstractionsAllowed{})
 		default:
 			t.Fatalf("unrecognized cluster option: %s", opt)
 		}


### PR DESCRIPTION
This patch introduces a tenant read-only cluster setting called
`sql.multi_region.allow_abstractions_for_secondary_tenants.enabled`
which allows the operator to control if secondary tenants can make use
of multi-region abstractions. It defaults to false.

This setting is checked against when creating new MR databases or
altering existing ones to make use of MR features (by setting the
primary region). It has nothing to do with MR databases that may have
been created previously which could happen if this setting was ever
flipped to true by the operator.

This setting doesn't effect the system tenant. It also takes precedence
over `sql.defaults.primary_region`, which is tenant writeable.

Release note (sql change): introduces new cluster setting which allows
the operator to control if a secondary tenant can make use of MR
abstractions. The setting is called
`sql.multi_region.allow_abstractions_for_secondary_tenants.enabled`.