### PR TITLE
changefeedccl: fix alter changefeed to handle targets with fully qualified names

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -88,7 +88,7 @@ func alterChangefeedPlanHook(
 			return err
 		}
 
-		newTargets, newProgress, newStatementTime, err := generateNewTargets(ctx,
+		newTargets, newProgress, newStatementTime, originalSpecs, err := generateNewTargets(ctx,
 			p,
 			alterChangefeedStmt.Cmds,
 			newOptions,
@@ -109,10 +109,15 @@ func alterChangefeedPlanHook(
 		}
 		newChangefeedStmt.SinkURI = tree.NewDString(newSinkURI)
 
+		annotatedStmt := &annotatedChangefeedStatement{
+			CreateChangefeed: newChangefeedStmt,
+			originalSpecs:    originalSpecs,
+		}
+
 		jobRecord, err := createChangefeedJobRecord(
 			ctx,
 			p,
-			newChangefeedStmt,
+			annotatedStmt,
 			newSinkURI,
 			newOptions,
 			jobID,
@@ -272,7 +277,13 @@ func generateNewTargets(
 	opts map[string]string,
 	prevDetails jobspb.ChangefeedDetails,
 	prevProgress jobspb.Progress,
-) (tree.ChangefeedTargets, *jobspb.Progress, hlc.Timestamp, error) {
+) (
+	tree.ChangefeedTargets,
+	*jobspb.Progress,
+	hlc.Timestamp,
+	map[tree.ChangefeedTarget]jobspb.ChangefeedTargetSpecification,
+	error,
+) {
 
 	type targetKey struct {
 		TableID    descpb.ID
@@ -281,6 +292,13 @@ func generateNewTargets(
 	newTargets := make(map[targetKey]tree.ChangefeedTarget)
 	droppedTargets := make(map[targetKey]tree.ChangefeedTarget)
 	newTableDescs := make(map[descpb.ID]catalog.Descriptor)
+
+	// originalSpecs provides a mapping between tree.ChangefeedTargets that
+	// existed prior to the alteration of the changefeed to their corresponding
+	// jobspb.ChangefeedTargetSpecification. The purpose of this mapping is to ensure
+	// that the StatementTimeName of the existing targets are not modified when the
+	// name of the target was modified.
+	originalSpecs := make(map[tree.ChangefeedTarget]jobspb.ChangefeedTargetSpecification)
 
 	// When we add new targets with or without initial scans, indicating
 	// initial_scan or no_initial_scan in the job description would lose its
@@ -308,20 +326,35 @@ func generateNewTargets(
 	// perform these validations in the validateNewTargets function.
 	allDescs, err := backupresolver.LoadAllDescs(ctx, p.ExecCfg(), statementTime)
 	if err != nil {
-		return nil, nil, hlc.Timestamp{}, err
+		return nil, nil, hlc.Timestamp{}, nil, err
 	}
 	descResolver, err := backupresolver.NewDescriptorResolver(allDescs)
 	if err != nil {
-		return nil, nil, hlc.Timestamp{}, err
+		return nil, nil, hlc.Timestamp{}, nil, err
 	}
 
-	for _, target := range AllTargets(prevDetails) {
-		k := targetKey{TableID: target.TableID, FamilyName: tree.Name(target.FamilyName)}
-		newTargets[k] = tree.ChangefeedTarget{
-			TableName:  tree.NewUnresolvedName(target.StatementTimeName),
-			FamilyName: tree.Name(target.FamilyName),
+	for _, targetSpec := range AllTargets(prevDetails) {
+		k := targetKey{TableID: targetSpec.TableID, FamilyName: tree.Name(targetSpec.FamilyName)}
+		desc := descResolver.DescByID[targetSpec.TableID].(catalog.TableDescriptor)
+
+		tbName, err := getQualifiedTableNameObj(ctx, p.ExecCfg(), p.ExtendedEvalContext().Txn, desc)
+		if err != nil {
+			return nil, nil, hlc.Timestamp{}, nil, err
 		}
-		newTableDescs[target.TableID] = descResolver.DescByID[target.TableID]
+
+		tablePattern, err := tbName.NormalizeTablePattern()
+		if err != nil {
+			return nil, nil, hlc.Timestamp{}, nil, err
+		}
+
+		newTarget := tree.ChangefeedTarget{
+			TableName:  tablePattern,
+			FamilyName: tree.Name(targetSpec.FamilyName),
+		}
+		newTargets[k] = newTarget
+		newTableDescs[targetSpec.TableID] = descResolver.DescByID[targetSpec.TableID]
+
+		originalSpecs[newTarget] = targetSpec
 	}
 
 	for _, cmd := range alterCmds {
@@ -329,17 +362,17 @@ func generateNewTargets(
 		case *tree.AlterChangefeedAddTarget:
 			targetOptsFn, err := p.TypeAsStringOpts(ctx, v.Options, changefeedbase.AlterChangefeedTargetOptions)
 			if err != nil {
-				return nil, nil, hlc.Timestamp{}, err
+				return nil, nil, hlc.Timestamp{}, nil, err
 			}
 			targetOpts, err := targetOptsFn()
 			if err != nil {
-				return nil, nil, hlc.Timestamp{}, err
+				return nil, nil, hlc.Timestamp{}, nil, err
 			}
 
 			_, withInitialScan := targetOpts[changefeedbase.OptInitialScan]
 			_, noInitialScan := targetOpts[changefeedbase.OptNoInitialScan]
 			if withInitialScan && noInitialScan {
-				return nil, nil, hlc.Timestamp{}, pgerror.Newf(
+				return nil, nil, hlc.Timestamp{}, nil, pgerror.Newf(
 					pgcode.InvalidParameterValue,
 					`cannot specify both %q and %q`, changefeedbase.OptInitialScan,
 					changefeedbase.OptNoInitialScan,
@@ -352,17 +385,17 @@ func generateNewTargets(
 			}
 			existingTargetSpans, err := fetchSpansForDescs(ctx, p, opts, statementTime, existingTargetDescs)
 			if err != nil {
-				return nil, nil, hlc.Timestamp{}, err
+				return nil, nil, hlc.Timestamp{}, nil, err
 			}
 
 			var newTargetDescs []catalog.Descriptor
 			for _, target := range v.Targets {
 				desc, found, err := getTargetDesc(ctx, p, descResolver, target.TableName)
 				if err != nil {
-					return nil, nil, hlc.Timestamp{}, err
+					return nil, nil, hlc.Timestamp{}, nil, err
 				}
 				if !found {
-					return nil, nil, hlc.Timestamp{}, pgerror.Newf(
+					return nil, nil, hlc.Timestamp{}, nil, pgerror.Newf(
 						pgcode.InvalidParameterValue,
 						`target %q does not exist`,
 						tree.ErrString(&target),
@@ -376,7 +409,7 @@ func generateNewTargets(
 
 			addedTargetSpans, err := fetchSpansForDescs(ctx, p, opts, statementTime, newTargetDescs)
 			if err != nil {
-				return nil, nil, hlc.Timestamp{}, err
+				return nil, nil, hlc.Timestamp{}, nil, err
 			}
 
 			// By default, we will not perform an initial scan on newly added
@@ -390,16 +423,16 @@ func generateNewTargets(
 				withInitialScan,
 			)
 			if err != nil {
-				return nil, nil, hlc.Timestamp{}, err
+				return nil, nil, hlc.Timestamp{}, nil, err
 			}
 		case *tree.AlterChangefeedDropTarget:
 			for _, target := range v.Targets {
 				desc, found, err := getTargetDesc(ctx, p, descResolver, target.TableName)
 				if err != nil {
-					return nil, nil, hlc.Timestamp{}, err
+					return nil, nil, hlc.Timestamp{}, nil, err
 				}
 				if !found {
-					return nil, nil, hlc.Timestamp{}, pgerror.Newf(
+					return nil, nil, hlc.Timestamp{}, nil, pgerror.Newf(
 						pgcode.InvalidParameterValue,
 						`target %q does not exist`,
 						tree.ErrString(&target),
@@ -409,7 +442,7 @@ func generateNewTargets(
 				droppedTargets[k] = target
 				_, recognized := newTargets[k]
 				if !recognized {
-					return nil, nil, hlc.Timestamp{}, pgerror.Newf(
+					return nil, nil, hlc.Timestamp{}, nil, pgerror.Newf(
 						pgcode.InvalidParameterValue,
 						`target %q already not watched by changefeed`,
 						tree.ErrString(&target),
@@ -443,7 +476,7 @@ func generateNewTargets(
 		if len(droppedTargetDescs) > 0 {
 			droppedTargetSpans, err := fetchSpansForDescs(ctx, p, opts, statementTime, droppedTargetDescs)
 			if err != nil {
-				return nil, nil, hlc.Timestamp{}, err
+				return nil, nil, hlc.Timestamp{}, nil, err
 			}
 			removeSpansFromProgress(newJobProgress, droppedTargetSpans)
 		}
@@ -456,10 +489,10 @@ func generateNewTargets(
 	}
 
 	if err := validateNewTargets(ctx, p, newTargetList, newJobProgress, newJobStatementTime); err != nil {
-		return nil, nil, hlc.Timestamp{}, err
+		return nil, nil, hlc.Timestamp{}, nil, err
 	}
 
-	return newTargetList, &newJobProgress, newJobStatementTime, nil
+	return newTargetList, &newJobProgress, newJobStatementTime, originalSpecs, nil
 }
 
 func validateNewTargets(

--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -609,6 +609,251 @@ func TestAlterChangefeedAddTargetErrors(t *testing.T) {
 	t.Run(`kafka`, kafkaTest(testFn, feedTestNoTenants))
 }
 
+func TestAlterChangefeedDatabaseQualifiedNames(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE DATABASE movr`)
+		sqlDB.Exec(t, `CREATE TABLE movr.drivers (id INT PRIMARY KEY, name STRING)`)
+		sqlDB.Exec(t, `CREATE TABLE movr.users (id INT PRIMARY KEY, name STRING)`)
+		sqlDB.Exec(t,
+			`INSERT INTO movr.drivers VALUES (1, 'Alice')`,
+		)
+		sqlDB.Exec(t,
+			`INSERT INTO movr.users VALUES (1, 'Bob')`,
+		)
+		testFeed := feed(t, f, `CREATE CHANGEFEED FOR movr.drivers WITH resolved = '100ms', diff`)
+		defer closeFeed(t, testFeed)
+
+		assertPayloads(t, testFeed, []string{
+			`drivers: [1]->{"after": {"id": 1, "name": "Alice"}, "before": null}`,
+		})
+
+		expectResolvedTimestamp(t, testFeed)
+
+		feed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+		require.True(t, ok)
+
+		require.NoError(t, feed.Pause())
+
+		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d ADD movr.users WITH initial_scan UNSET diff`, feed.JobID()))
+
+		require.NoError(t, feed.Resume())
+
+		assertPayloads(t, testFeed, []string{
+			`users: [1]->{"after": {"id": 1, "name": "Bob"}}`,
+		})
+
+		sqlDB.Exec(t,
+			`INSERT INTO movr.drivers VALUES (3, 'Carol')`,
+		)
+
+		assertPayloads(t, testFeed, []string{
+			`drivers: [3]->{"after": {"id": 3, "name": "Carol"}}`,
+		})
+	}
+
+	t.Run(`kafka`, kafkaTest(testFn))
+}
+
+func TestAlterChangefeedDatabaseScope(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE DATABASE movr`)
+		sqlDB.Exec(t, `CREATE DATABASE new_movr`)
+
+		sqlDB.Exec(t, `CREATE TABLE movr.drivers (id INT PRIMARY KEY, name STRING)`)
+		sqlDB.Exec(t, `CREATE TABLE new_movr.drivers (id INT PRIMARY KEY, name STRING)`)
+
+		sqlDB.Exec(t,
+			`INSERT INTO movr.drivers VALUES (1, 'Alice')`,
+		)
+		sqlDB.Exec(t,
+			`INSERT INTO new_movr.drivers VALUES (1, 'Bob')`,
+		)
+
+		testFeed := feed(t, f, `CREATE CHANGEFEED FOR movr.drivers WITH diff`)
+		defer closeFeed(t, testFeed)
+
+		assertPayloads(t, testFeed, []string{
+			`drivers: [1]->{"after": {"id": 1, "name": "Alice"}, "before": null}`,
+		})
+
+		feed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+		require.True(t, ok)
+
+		require.NoError(t, feed.Pause())
+
+		sqlDB.Exec(t, `USE new_movr`)
+
+		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d DROP movr.drivers ADD drivers WITH initial_scan UNSET diff`, feed.JobID()))
+
+		require.NoError(t, feed.Resume())
+
+		assertPayloads(t, testFeed, []string{
+			`drivers: [1]->{"after": {"id": 1, "name": "Bob"}}`,
+		})
+	}
+
+	t.Run(`kafka`, kafkaTest(testFn))
+}
+
+func TestAlterChangefeedDatabaseScopeUnqualifiedName(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE DATABASE movr`)
+		sqlDB.Exec(t, `CREATE DATABASE new_movr`)
+
+		sqlDB.Exec(t, `CREATE TABLE movr.drivers (id INT PRIMARY KEY, name STRING)`)
+		sqlDB.Exec(t, `CREATE TABLE new_movr.drivers (id INT PRIMARY KEY, name STRING)`)
+
+		sqlDB.Exec(t,
+			`INSERT INTO movr.drivers VALUES (1, 'Alice')`,
+		)
+
+		sqlDB.Exec(t, `USE movr`)
+		testFeed := feed(t, f, `CREATE CHANGEFEED FOR drivers WITH diff, resolved = '100ms'`)
+		defer closeFeed(t, testFeed)
+
+		assertPayloads(t, testFeed, []string{
+			`drivers: [1]->{"after": {"id": 1, "name": "Alice"}, "before": null}`,
+		})
+
+		expectResolvedTimestamp(t, testFeed)
+
+		feed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+		require.True(t, ok)
+
+		require.NoError(t, feed.Pause())
+
+		sqlDB.Exec(t, `USE new_movr`)
+
+		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d UNSET diff`, feed.JobID()))
+
+		require.NoError(t, feed.Resume())
+
+		sqlDB.Exec(t,
+			`INSERT INTO movr.drivers VALUES (2, 'Bob')`,
+		)
+
+		assertPayloads(t, testFeed, []string{
+			`drivers: [2]->{"after": {"id": 2, "name": "Bob"}}`,
+		})
+	}
+
+	t.Run(`kafka`, kafkaTest(testFn))
+}
+
+func TestAlterChangefeedColumnFamilyDatabaseScope(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE DATABASE movr`)
+		sqlDB.Exec(t, `CREATE TABLE movr.drivers (id INT PRIMARY KEY, name STRING, FAMILY onlyid (id), FAMILY onlyname (name))`)
+
+		sqlDB.Exec(t,
+			`INSERT INTO movr.drivers VALUES (1, 'Alice')`,
+		)
+
+		testFeed := feed(t, f, `CREATE CHANGEFEED FOR movr.drivers WITH diff, split_column_families`)
+		defer closeFeed(t, testFeed)
+
+		assertPayloads(t, testFeed, []string{
+			`drivers.onlyid: [1]->{"after": {"id": 1}, "before": null}`,
+			`drivers.onlyname: [1]->{"after": {"name": "Alice"}, "before": null}`,
+		})
+
+		feed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+		require.True(t, ok)
+
+		require.NoError(t, feed.Pause())
+
+		sqlDB.Exec(t, `USE movr`)
+
+		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d DROP movr.drivers ADD movr.drivers FAMILY onlyid ADD drivers FAMILY onlyname UNSET diff`, feed.JobID()))
+
+		require.NoError(t, feed.Resume())
+
+		sqlDB.Exec(t,
+			`INSERT INTO movr.drivers VALUES (2, 'Bob')`,
+		)
+
+		assertPayloads(t, testFeed, []string{
+			`drivers.onlyid: [2]->{"after": {"id": 2}}`,
+			`drivers.onlyname: [2]->{"after": {"name": "Bob"}}`,
+		})
+	}
+
+	t.Run(`kafka`, kafkaTest(testFn))
+}
+
+func TestAlterChangefeedAlterTableName(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE DATABASE movr`)
+		sqlDB.Exec(t, `CREATE TABLE movr.users (id INT PRIMARY KEY, name STRING)`)
+		sqlDB.Exec(t,
+			`INSERT INTO movr.users VALUES (1, 'Alice')`,
+		)
+		testFeed := feed(t, f, `CREATE CHANGEFEED FOR movr.users WITH diff, resolved = '100ms'`)
+		defer closeFeed(t, testFeed)
+
+		assertPayloads(t, testFeed, []string{
+			`users: [1]->{"after": {"id": 1, "name": "Alice"}, "before": null}`,
+		})
+
+		expectResolvedTimestamp(t, testFeed)
+
+		waitForSchemaChange(t, sqlDB, `ALTER TABLE movr.users RENAME TO movr.riders`)
+
+		var tsLogical string
+		sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&tsLogical)
+
+		ts := parseTimeToHLC(t, tsLogical)
+
+		// ensure that the high watermark has progressed past the time in which the
+		// schema change occurred
+		testutils.SucceedsSoon(t, func() error {
+			resolvedTS, _ := expectResolvedTimestamp(t, testFeed)
+			if resolvedTS.Less(ts) {
+				return errors.New("waiting for resolved timestamp to progress past the schema change event")
+			}
+			return nil
+		})
+
+		feed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+		require.True(t, ok)
+
+		require.NoError(t, feed.Pause())
+
+		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d UNSET diff`, feed.JobID()))
+
+		require.NoError(t, feed.Resume())
+
+		sqlDB.Exec(t,
+			`INSERT INTO movr.riders VALUES (2, 'Bob')`,
+		)
+		assertPayloads(t, testFeed, []string{
+			`users: [2]->{"after": {"id": 2, "name": "Bob"}}`,
+		})
+	}
+
+	t.Run(`kafka`, kafkaTest(testFn))
+}
+
 func TestAlterChangefeedInitialScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
+++ b/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
@@ -422,7 +422,7 @@ func TestShowChangefeedJobsAlterChangefeed(t *testing.T) {
 		out = obtainJobRowFn()
 
 		require.Equal(t, jobID, out.id, "Expected id:%d but found id:%d", jobID, out.id)
-		require.Equal(t, "CREATE CHANGEFEED FOR TABLE bar INTO 'kafka://does.not.matter/'", out.description, "Expected description:%s but found description:%s", "CREATE CHANGEFEED FOR TABLE bar INTO 'kafka://does.not.matter/'", out.description)
+		require.Equal(t, "CREATE CHANGEFEED FOR TABLE d.public.bar INTO 'kafka://does.not.matter/'", out.description, "Expected description:%s but found description:%s", "CREATE CHANGEFEED FOR TABLE bar INTO 'kafka://does.not.matter/'", out.description)
 		require.Equal(t, sinkURI, out.SinkURI, "Expected sinkUri:%s but found sinkUri:%s", sinkURI, out.SinkURI)
 		require.Equal(t, "bar", out.topics, "Expected topics:%s but found topics:%s", "bar", sortedTopics)
 		require.Equal(t, "{d.public.bar}", string(out.FullTableNames), "Expected fullTableNames:%s but found fullTableNames:%s", "{d.public.bar}", string(out.FullTableNames))
@@ -433,7 +433,7 @@ func TestShowChangefeedJobsAlterChangefeed(t *testing.T) {
 		out = obtainJobRowFn()
 
 		require.Equal(t, jobID, out.id, "Expected id:%d but found id:%d", jobID, out.id)
-		require.Equal(t, "CREATE CHANGEFEED FOR TABLE bar INTO 'kafka://does.not.matter/' WITH resolved = '5s'", out.description, "Expected description:%s but found description:%s", "CREATE CHANGEFEED FOR TABLE bar INTO 'kafka://does.not.matter/ WITH resolved = '5s''", out.description)
+		require.Equal(t, "CREATE CHANGEFEED FOR TABLE d.public.bar INTO 'kafka://does.not.matter/' WITH resolved = '5s'", out.description, "Expected description:%s but found description:%s", "CREATE CHANGEFEED FOR TABLE bar INTO 'kafka://does.not.matter/ WITH resolved = '5s''", out.description)
 		require.Equal(t, sinkURI, out.SinkURI, "Expected sinkUri:%s but found sinkUri:%s", sinkURI, out.SinkURI)
 		require.Equal(t, "bar", out.topics, "Expected topics:%s but found topics:%s", "bar", sortedTopics)
 		require.Equal(t, "{d.public.bar}", string(out.FullTableNames), "Expected fullTableNames:%s but found fullTableNames:%s", "{d.public.bar}", string(out.FullTableNames))


### PR DESCRIPTION
changefeedccl: fix alter changefeed to handle targets with
fully qualified names

Resolves #79502

Currently, the ALTER CHANGEFEED statement would not work
with changefeeds that use fully qualified names in their
CREATE CHANGEFEED statement. This is because when we try
to include the existing targets, we would drop the
database/schema name that the user provided. Hence, when
we perform validation checks on the existing + new
changefeed targets, we would not be able to resolve the
existing targets that used fully qualified names and we
would return an error.

In this PR we ensure that we add each existing target
with their fully qualified name so that we can resolve
these targets in our validation checks. A consequence of
this change is that now every changefeed will display
the fully qualified name of every target in the
SHOW CHANGEFEED JOB query.

Release note (enterprise change): Fix the issue of not
being able to resolve existing targets when performing
validation checks by adding the fully qualified name
to the changefeed statement. As a result, every altered
changefeed will display the fully qualified name of every
target in the SHOW CHANGEFEED JOB query.

Release justification: Low risk bug fix.