### PR TITLE
sql: use clear range to clean tables during rollback of create

### DIFF
--- a/pkg/sql/gcjob/table_garbage_collection.go
+++ b/pkg/sql/gcjob/table_garbage_collection.go
@@ -93,14 +93,7 @@ func ClearTableData(
 	sv *settings.Values,
 	table catalog.TableDescriptor,
 ) error {
-	// If DropTime isn't set, assume this drop request is from a version
-	// 1.1 server and invoke legacy code that uses DeleteRange and range GC.
-	if table.GetDropTime() == 0 {
-		log.Infof(ctx, "clearing data in chunks for table %d", table.GetID())
-		return sql.ClearTableDataInChunks(ctx, db, codec, sv, table, false /* traceKV */)
-	}
 	log.Infof(ctx, "clearing data for table %d", table.GetID())
-
 	tableKey := roachpb.RKey(codec.TablePrefix(uint32(table.GetID())))
 	tableSpan := roachpb.RSpan{Key: tableKey, EndKey: tableKey.PrefixEnd()}
 	return clearSpanData(ctx, db, distSender, tableSpan)

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1011,6 +1011,7 @@ func (sc *SchemaChanger) rollbackSchemaChange(ctx context.Context, err error) er
 
 		b := txn.NewBatch()
 		scTable.SetDropped()
+		scTable.DropTime = timeutil.Now().UnixNano()
 		if err := descsCol.WriteDescToBatch(ctx, false /* kvTrace */, scTable, b); err != nil {
 			return err
 		}

--- a/pkg/sql/tablewriter_delete.go
+++ b/pkg/sql/tablewriter_delete.go
@@ -55,45 +55,6 @@ func (td *tableDeleter) row(
 	return td.rd.DeleteRow(ctx, td.b, values, pm, traceKV)
 }
 
-// deleteAllRows runs the kv operations necessary to delete all sql rows in the
-// table passed at construction, using the DelRange KV request to delete data
-// quickly.
-//
-// resume is the resume-span which should be used for the table deletion when
-// the table deletion is chunked. The first call to this method should use a
-// zero resume-span. After a chunk is deleted a new resume-span is returned.
-//
-// limit is a limit on the number of keys deleted in the operation.
-//
-// Note that this method leaves a RocksDB deletion tombstone on every key in the
-// table, resulting in substantial write amplification. When possible, the
-// schema changer avoids using a tableDeleter entirely in favor of the
-// ClearRange KV request, which uses RocksDB range deletion tombstones to avoid
-// write amplification.
-func (td *tableDeleter) deleteAllRows(
-	ctx context.Context, resume roachpb.Span, limit int64, traceKV bool,
-) (roachpb.Span, error) {
-	if resume.Key == nil {
-		tablePrefix := td.rd.Helper.Codec.TablePrefix(uint32(td.tableDesc().GetID()))
-		// Delete rows and indexes starting with the table's prefix.
-		resume = roachpb.Span{
-			Key:    tablePrefix,
-			EndKey: tablePrefix.PrefixEnd(),
-		}
-	}
-
-	log.VEventf(ctx, 2, "DelRange %s - %s", resume.Key, resume.EndKey)
-	td.b.DelRange(resume.Key, resume.EndKey, false /* returnKeys */)
-	td.b.Header.MaxSpanRequestKeys = limit
-	if err := td.finalize(ctx); err != nil {
-		return resume, err
-	}
-	if l := len(td.b.Results); l != 1 {
-		panic(errors.AssertionFailedf("%d results returned", l))
-	}
-	return td.b.Results[0].ResumeSpanAsValue(), nil
-}
-
 // deleteIndex runs the kv operations necessary to delete all kv entries in the
 // given index.
 //


### PR DESCRIPTION
Fixes: #79123

Previously, when dropping a table during rollback of a create
we would clean up table data in chunks instead of doing a
clear range. This was inadequate because he code path in
question existed for compatibility Cockroach 1.1 and had terrible
performance characteristics for large tables. To address,
this patch will always use delete data using clear range when
dropping tables during rollback which will have better performance.

Release note (performance improvement): Rollback of CREATE
TABLE AS with large quantities of data has similar performance
to regular DROP TABLE.