### PR TITLE
roachtest: use SQL comparison in TLP

### DIFF
--- a/pkg/cmd/roachtest/tests/tlp.go
+++ b/pkg/cmd/roachtest/tests/tlp.go
@@ -210,8 +210,22 @@ func runTLPQuery(conn *gosql.DB, smither *sqlsmith.Smither, logStmt func(string)
 	}()
 
 	unpartitioned, partitioned, args := smither.GenerateTLP()
+	combined := sqlsmith.CombinedTLP(unpartitioned, partitioned)
 
 	return runWithTimeout(func() error {
+		counts := conn.QueryRow(combined, args...)
+		var undiffCount, diffCount int
+		if err := counts.Scan(&undiffCount, &diffCount); err != nil {
+			// Ignore errors.
+			//nolint:returnerrcheck
+			return nil
+		}
+		if undiffCount == 0 && diffCount == 0 {
+			return nil
+		}
+
+		// We found a TLP mismatch! Run individual queries again to print a diff.
+
 		rows1, err := conn.Query(unpartitioned)
 		if err != nil {
 			// Ignore errors.
@@ -239,14 +253,12 @@ func runTLPQuery(conn *gosql.DB, smither *sqlsmith.Smither, logStmt func(string)
 			return nil
 		}
 
-		if diff := unsortedMatricesDiff(unpartitionedRows, partitionedRows); diff != "" {
-			logStmt(unpartitioned)
-			logStmt(partitioned)
-			return errors.Newf(
-				"expected unpartitioned and partitioned results to be equal\n%s\nsql: %s\n%s\nwith args: %s",
-				diff, unpartitioned, partitioned, args)
-		}
-		return nil
+		diff := unsortedMatricesDiff(unpartitionedRows, partitionedRows)
+		logStmt(unpartitioned)
+		logStmt(partitioned)
+		return errors.Newf(
+			"expected unpartitioned and partitioned results to be equal\n%s\nsql: %s\n%s\nwith args: %s",
+			diff, unpartitioned, partitioned, args)
 	})
 }
 


### PR DESCRIPTION
Assists: #77279

TLP compares results of two queries, one unpartitioned and one
partitioned three ways by a predicate. We were comparing TLP results by
printing values to strings. Unfortunately there are some values which
are equal according to SQL comparison, but print differently. And TLP,
being the nefarious chaos monkey that it is, tends to find these. For
example:

```sql
  0::FLOAT
  -0::FLOAT

  'hello' COLLATE "en-US-u-ks-level2"
  'HELLO' COLLATE "en-US-u-ks-level2"

  INTERVAL '1 day'
  INTERVAL '24 hours'
```

When equal-yet-different values like these are used in MAX or MIN
aggregations, or are the keys for GROUP BY bucketing, it is
nondeterministic which value will be chosen. (This is also true in
PostgreSQL.) And sometimes the two TLP queries choose differently. This
is not indicative of a bug, yet TLP fails.

So this patch teaches TLP to use SQL comparison instead of string
comparison. To do so, we wrap both queries in a bigger query:

```sql
  WITH unpart AS MATERIALIZED (
    <unpartitioned query>
  ), part AS MATERIALIZED (
    <partitioned query>
  ), undiff AS (
    TABLE unpart EXCEPT ALL TABLE part
  ), diff AS (
    TABLE part EXCEPT ALL TABLE unpart
  )
  SELECT (SELECT count(*) FROM undiff), (SELECT count(*) FROM diff)
```

Only if this query returns counts other than 0 (meaning the SQL
comparison detected a real mismatch) do we diff the printed results.

Release note: None