### PR TITLE
bulk: don't scatter after pre-splitting on table boundaries

### DIFF
--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -30,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -298,14 +296,6 @@ func presplitTableBoundaries(
 		for _, span := range tblDesc.AllIndexSpans(cfg.Codec) {
 			if err := cfg.DB.AdminSplit(ctx, span.Key, expirationTime); err != nil {
 				return err
-			}
-
-			log.VEventf(ctx, 1, "scattering index range %s", span.Key)
-			scatterReq := &roachpb.AdminScatterRequest{
-				RequestHeader: roachpb.RequestHeaderFromSpan(span),
-			}
-			if _, pErr := kv.SendWrapped(ctx, cfg.DB.NonTransactionalSender(), scatterReq); pErr != nil {
-				log.Errorf(ctx, "failed to scatter span %s: %s", span.Key, pErr)
 			}
 		}
 	}


### PR DESCRIPTION
This commit removes the call to `AdminScatter` in `presplitTableBoundaries`.
Now that `AdminScatter` has been fixed, this use was problematic when
restarting an IMPORT job for two reasons. First, the `AdminScatter` did not
carry a `MaxSize`, so it would scatter the ranges it targeted even if they
were not empty. Second, the `AdminScatter` was targeting the entire index
span, instead of just the key that was split. Combined, this meant that
restarting an IMPORT would scatter the entire table, which could have been
very large if the previous IMPORT iteration had run for a long time.

Now that we're more confident in the splits and scatters performed by the
`BufferingAdder`, the scattering in `presplitTableBoundaries` no longer
seems important, so this commit removes it entirely.

This avoids behavior like we see in the following test. A node restarted around
23:00. This caused the IMPORT job to retry from a checkpoint. The issue that
is resolved by this PR caused the ~20TB table to be scattered, leading to the
tremendous amount of snapshot activity.

<img width="997" alt="Screen Shot 2022-04-06 at 7 49 50 PM" src="https://user-images.githubusercontent.com/5438456/162092666-1d473862-6c07-4279-8202-2dc71276fdbf.png">


<img width="1001" alt="Screen Shot 2022-04-06 at 7 49 22 PM" src="https://user-images.githubusercontent.com/5438456/162092605-ffd8e2b4-4003-4ca1-9cb5-2a232f217159.png">


Release justification: avoids a regression in IMPORT performance.