### PR TITLE
rowenc: use unredacted type fam in DatumTypeToArrayElementEncodingType

### DIFF
--- a/pkg/sql/rowenc/valueside/BUILD.bazel
+++ b/pkg/sql/rowenc/valueside/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/util/timeutil/pgdate",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_lib_pq//oid",
     ],
 )

--- a/pkg/sql/rowenc/valueside/array.go
+++ b/pkg/sql/rowenc/valueside/array.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // encodeArray produces the value encoding for an array.
@@ -234,7 +235,9 @@ func DatumTypeToArrayElementEncodingType(t *types.T) (encoding.Type, error) {
 	case types.TupleFamily:
 		return encoding.Tuple, nil
 	default:
-		return 0, errors.AssertionFailedf("no known encoding type for %s", t)
+		return 0, errors.AssertionFailedf(
+			"no known encoding type for %s", redact.Safe(t.Family().Name()),
+		)
 	}
 }
 func checkElementType(paramType *types.T, elemType *types.T) error {


### PR DESCRIPTION
Instead of type name, use a type family name. No need to redact this.

See also: https://github.com/cockroachdb/cockroach/issues/76181

Release note: none