### PR TITLE
sql: fix bug in ALTER INDEX ... PARTITION BY

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/schema_change_in_txn
+++ b/pkg/ccl/logictestccl/testdata/logic_test/schema_change_in_txn
@@ -1,0 +1,25 @@
+# Regression test for a situation involving creating a table in a transaction
+# and altering the index when referenced by name.
+subtest index_resolution_does_not_lead_to_new_version
+
+statement ok
+BEGIN;
+CREATE DATABASE db;
+CREATE TABLE db.t(i INT PRIMARY KEY, j INT, k INT);
+CREATE INDEX idx_i ON db.t (i);
+ALTER INDEX db.t@idx_i PARTITION BY LIST (i) (
+  PARTITION one_and_five    VALUES IN (1, 5),
+  PARTITION everything_else VALUES IN (DEFAULT)
+);
+COMMIT;
+
+# Before the change which introduced this test, it would erroneously return 2.
+query I
+SELECT (crdb_internal.pb_to_json('desc', descriptor)->'table'->>'version')::INT8
+  FROM system.descriptor
+ WHERE id = 'db.t'::regclass;
+----
+1
+
+statement ok
+DROP DATABASE db

--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -1424,10 +1424,10 @@ func TestPrimaryKeyChangeZoneConfigs(t *testing.T) {
 
 	// Write a table with some partitions into the database,
 	// and change its primary key.
-	if _, err := sqlDB.Exec(`
-CREATE DATABASE t;
-USE t;
-CREATE TABLE t (
+	for _, stmt := range []string{
+		`CREATE DATABASE t`,
+		`USE t`,
+		`CREATE TABLE t (
   x INT PRIMARY KEY,
   y INT NOT NULL,
   z INT,
@@ -1435,18 +1435,20 @@ CREATE TABLE t (
   INDEX i1 (z),
   INDEX i2 (w),
   FAMILY (x, y, z, w)
-);
-ALTER INDEX t@i1 PARTITION BY LIST (z) (
+)`,
+		`ALTER INDEX t@i1 PARTITION BY LIST (z) (
   PARTITION p1 VALUES IN (1)
-);
-ALTER INDEX t@i2 PARTITION BY LIST (w) (
+)`,
+		`ALTER INDEX t@i2 PARTITION BY LIST (w) (
   PARTITION p2 VALUES IN (3)
-);
-ALTER PARTITION p1 OF INDEX t@i1 CONFIGURE ZONE USING gc.ttlseconds = 15210;
-ALTER PARTITION p2 OF INDEX t@i2 CONFIGURE ZONE USING gc.ttlseconds = 15213;
-ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (y)
-`); err != nil {
-		t.Fatal(err)
+)`,
+		`ALTER PARTITION p1 OF INDEX t@i1 CONFIGURE ZONE USING gc.ttlseconds = 15210`,
+		`ALTER PARTITION p2 OF INDEX t@i2 CONFIGURE ZONE USING gc.ttlseconds = 15213`,
+		`ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (y)`,
+	} {
+		if _, err := sqlDB.Exec(stmt); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	// Get the zone config corresponding to the table.

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -1008,13 +1008,29 @@ func (p *planner) getTableAndIndex(
 	}
 	optIdx := idx.(*optIndex)
 
-	// Resolve the object name for logging if
-	// its missing.
+	// Set the object name for logging if it's missing.
 	if tableWithIndex.Table.ObjectName == "" {
-		tableWithIndex.Table = tree.MakeTableNameFromPrefix(qualifiedName.ObjectNamePrefix, qualifiedName.ObjectName)
+		tableWithIndex.Table = tree.MakeTableNameFromPrefix(
+			qualifiedName.ObjectNamePrefix, qualifiedName.ObjectName,
+		)
 	}
 
-	return tabledesc.NewBuilder(optIdx.tab.desc.TableDesc()).BuildExistingMutableTable(), optIdx.idx, nil
+	// Use the descriptor collection to get a proper handle to the mutable
+	// descriptor for the relevant table and use that mutable object to
+	// get a handle to the corresponding index.
+	tableID := optIdx.tab.desc.GetID()
+	mut, err := p.Descriptors().GetMutableTableVersionByID(ctx, tableID, p.Txn())
+	if err != nil {
+		return nil, nil, errors.NewAssertionErrorWithWrappedErrf(err,
+			"failed to re-resolve table %d for index %s", tableID, tableWithIndex)
+	}
+	retIdx, err := mut.FindIndexWithID(optIdx.idx.GetID())
+	if err != nil {
+		return nil, nil, errors.NewAssertionErrorWithWrappedErrf(err,
+			"retrieving index %s (%d) from table which was known to already exist for table %d",
+			tableWithIndex, optIdx.idx.GetID(), tableID)
+	}
+	return mut, retIdx, nil
 }
 
 // expandTableGlob expands pattern into a list of objects represented


### PR DESCRIPTION
There was a subtle bug here whereby we'd increment the version an
extra time when running ALTER INDEX ... PARTITION BY in the same
transaction as a previous DDL to the same table. It's not exactly
clear what the implications here would be. They are subtle.

Release note: None