### PR TITLE
bazel: re-enable sandboxing

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -78,7 +78,6 @@ build:devdarwinx86_64 --config=dev
 build:dev --workspace_status_command=./build/bazelutil/stamp.sh
 build:dev --action_env=PATH
 build:dev --host_action_env=PATH
-build:dev --spawn_strategy=local --strategy=Genrule=sandboxed
 
 try-import %workspace%/.bazelrc.user
 


### PR DESCRIPTION
\#79360 disable sandboxing for all things but code-gen; we've seen build
failures as a result. This commit reverts it while we investigate.

Release note: None