### PR TITLE
sql/catalog/descs: enforce invariant that OriginalVersion does not ch…

### DIFF
--- a/pkg/sql/catalog/descs/uncommitted_descriptors.go
+++ b/pkg/sql/catalog/descs/uncommitted_descriptors.go
@@ -164,6 +164,13 @@ func (ud *uncommittedDescriptors) add(
 	for _, n := range uNew.immutable.GetDrainingNames() {
 		ud.descNames.Add(n)
 	}
+	if prev, ok := ud.descs.GetByID(mut.GetID()).(*uncommittedDescriptor); ok {
+		if prev.mutable.OriginalVersion() != mut.OriginalVersion() {
+			return nil, errors.AssertionFailedf(
+				"cannot add a version of descriptor with a different original version" +
+					" than it was previously added with")
+		}
+	}
 	ud.descs.Upsert(uNew)
 	return uNew.immutable, err
 }


### PR DESCRIPTION
…ange

It's a bug any time we increment a version more than once in the context
of a single descriptor collection. Let's enforce it. This would have prevented bugs
like the one fixed in #79561.

Release note: None