### PR TITLE
dev: fix staging error post-`dev build tests`

### DIFF
--- a/dev
+++ b/dev
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=28
+DEV_VERSION=29
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -66,12 +66,9 @@ func makeBuildCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Com
 }
 
 // TODO(irfansharif): Add grouping shorthands like "all" or "bins", etc.
-// TODO(irfansharif): Make sure all the relevant binary targets are defined
-// above, and in usage docs.
 
 // buildTargetMapping maintains shorthands that map 1:1 with bazel targets.
 var buildTargetMapping = map[string]string{
-	"all_tests":        "//pkg:all_tests",
 	"bazel-remote":     bazelRemoteTarget,
 	"buildifier":       "@com_github_bazelbuild_buildtools//buildifier:buildifier",
 	"buildozer":        "@com_github_bazelbuild_buildtools//buildozer:buildozer",
@@ -337,7 +334,11 @@ func (d *dev) getBasicBuildArgs(
 		}
 
 		args = append(args, aliased)
-		buildTargets = append(buildTargets, buildTarget{fullName: aliased, kind: "go_binary"})
+		if aliased == "//pkg:all_tests" {
+			buildTargets = append(buildTargets, buildTarget{fullName: aliased, kind: "test_suite"})
+		} else {
+			buildTargets = append(buildTargets, buildTarget{fullName: aliased, kind: "go_binary"})
+		}
 	}
 
 	// Add --config=with_ui iff we're building a target that needs it.

--- a/pkg/cmd/dev/testdata/datadriven/dev-build
+++ b/pkg/cmd/dev/testdata/datadriven/dev-build
@@ -66,3 +66,11 @@ mkdir crdb-checkout/bin
 bazel info bazel-bin --color=no
 rm crdb-checkout/bin/stress
 cp sandbox/external/com_github_cockroachdb_stress/stress_/stress crdb-checkout/bin/stress
+
+exec
+dev build tests
+----
+bazel build //pkg:all_tests
+bazel info workspace --color=no
+mkdir crdb-checkout/bin
+bazel info bazel-bin --color=no


### PR DESCRIPTION
We were treating the test target as a `go_binary`, therefore trying to
stage it.

Release note: None