### PR TITLE
ui: add snapshot bytes sent metric to the replication dashboard

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -193,6 +193,20 @@ export default function(props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
+    <LineGraph title="Snapshot Data Sent" sources={storeSources}>
+      <Axis label="bytes">
+        {_.map(nodeIDs, nid => (
+            <Metric
+                key={nid}
+                name="cr.store.range.snapshots.sent-bytes"
+                title={nodeDisplayName(nodesSummary, nid)}
+                sources={storeIDsForNode(nodesSummary, nid)}
+                nonNegativeRate
+            />
+        ))}
+      </Axis>
+    </LineGraph>,
+
     <LineGraph
       title="Circuit Breaker Tripped Replicas"
       tooltip={CircuitBreakerTrippedReplicasTooltip}


### PR DESCRIPTION
Release note (ui change): the replication dashboard now includes a graph of
snapshot bytes sent per node.