### PR TITLE
release-21.2: sql: use clear range to clean tables during rollback of create

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -871,6 +871,7 @@ func (sc *SchemaChanger) rollbackSchemaChange(ctx context.Context, err error) er
 
 		b := txn.NewBatch()
 		scTable.SetDropped()
+		scTable.DropTime = timeutil.Now().UnixNano()
 		if err := descsCol.WriteDescToBatch(ctx, false /* kvTrace */, scTable, b); err != nil {
 			return err
 		}


### PR DESCRIPTION
Backport 1/1 commits from #79543.

/cc @cockroachdb/release

---

Fixes: #79123

Previously, when dropping a table during rollback of a create
we would clean up table data in chunks instead of doing a
clear range. This was inadequate because he code path in
question existed for compatibility Cockroach 1.1 and had terrible
performance characteristics for large tables. To address,
this patch will always use delete data using clear range when
dropping tables during rollback which will have better performance.

Release note (performance improvement): Rollback of CREATE
TABLE AS with large quantities of data has similar performance
to regular DROP TABLE.

Release justification: low risk since it's used during rollback when a table will be deleted and exploits existing logic we should have been using.