### PR TITLE
release-21.2: Fix sequence transaction bugs

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -56,6 +56,7 @@ go_library(
         "create_table.go",
         "create_type.go",
         "create_view.go",
+        "created_sequence.go",
         "data_source.go",
         "database.go",
         "database_region_change_finalizer.go",

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -153,6 +153,9 @@ func doCreateSequence(
 	// Initialize the sequence value.
 	seqValueKey := p.ExecCfg().Codec.SequenceKey(uint32(id))
 	b := &kv.Batch{}
+	if err := p.createdSequences.addCreatedSequence(id); err != nil {
+		return nil, err
+	}
 	b.Inc(seqValueKey, desc.SequenceOpts.Start-desc.SequenceOpts.Increment)
 	if err := p.txn.Run(ctx, b); err != nil {
 		return nil, err

--- a/pkg/sql/created_sequence.go
+++ b/pkg/sql/created_sequence.go
@@ -1,0 +1,48 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/errors"
+)
+
+type createdSequences interface {
+	// addCreatedSequence adds a sequence to the set of sequences created in the current transaction.
+	addCreatedSequence(id descpb.ID) error
+	// isCreatedSequence checks if a sequence was created in the current transaction.
+	isCreatedSequence(id descpb.ID) bool
+}
+
+type connExCreatedSequencesAccessor struct {
+	ex *connExecutor
+}
+
+func (c connExCreatedSequencesAccessor) addCreatedSequence(id descpb.ID) error {
+	c.ex.extraTxnState.createdSequences[id] = struct{}{}
+	return nil
+}
+
+func (c connExCreatedSequencesAccessor) isCreatedSequence(id descpb.ID) bool {
+	_, ok := c.ex.extraTxnState.createdSequences[id]
+	return ok
+}
+
+// emptyCreatedSequences is the default impl used by the planner when the connExecutor is not available.
+type emptyCreatedSequences struct{}
+
+func (createdSequences emptyCreatedSequences) addCreatedSequence(id descpb.ID) error {
+	return errors.AssertionFailedf("addCreatedSequence not supported in emptyCreatedSequences")
+}
+
+func (createdSequences emptyCreatedSequences) isCreatedSequence(id descpb.ID) bool {
+	return false
+}

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -1849,3 +1849,48 @@ query I
 SELECT nextval('seq71135')
 ----
 201
+
+subtest sequence_in_txn
+
+# Make sure that setval and next work even if the transaction is rolled back;
+# they do not respect transaction boundaries.
+
+statement ok
+CREATE SEQUENCE seq_txn
+
+statement ok
+BEGIN
+
+query I
+SELECT setval('seq_txn', 600, true)
+----
+600
+
+statement ok
+ROLLBACK
+
+query I
+SELECT nextval('seq_txn')
+----
+601
+
+statement ok
+BEGIN
+
+query I
+SELECT setval('seq_txn', 610, true)
+----
+610
+
+query I
+SELECT nextval('seq_txn')
+----
+611
+
+statement ok
+ROLLBACK
+
+query I
+SELECT nextval('seq_txn')
+----
+612

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -1894,3 +1894,103 @@ query I
 SELECT nextval('seq_txn')
 ----
 612
+
+# create a sequence and nextval in the same transaction
+statement ok
+BEGIN
+
+statement ok
+CREATE SEQUENCE nextval_txn_seq
+
+query I
+SELECT nextval('nextval_txn_seq')
+----
+1
+
+statement ok
+END
+
+query I
+SELECT nextval('nextval_txn_seq')
+----
+2
+
+# create a sequence and setval in the same transaction then nextval
+statement ok
+BEGIN
+
+statement ok
+CREATE SEQUENCE setval_txn_nextval_seq
+
+query I
+SELECT setval('setval_txn_nextval_seq', 2)
+----
+2
+
+statement ok
+END
+
+# should be 3 - see https://github.com/cockroachdb/cockroach/issues/79430
+query I
+SELECT nextval('setval_txn_nextval_seq')
+----
+2
+
+# create a sequence and setval then nextval in the same transaction
+statement ok
+BEGIN
+
+statement ok
+CREATE SEQUENCE setval_nextval_txn_seq
+
+query I
+SELECT setval('setval_nextval_txn_seq', 2)
+----
+2
+
+# should be 3 - see https://github.com/cockroachdb/cockroach/issues/79430
+query I
+SELECT nextval('setval_nextval_txn_seq')
+----
+2
+
+statement ok
+END
+
+# create a sequence and setval in the same transaction then currval
+statement ok
+BEGIN
+
+statement ok
+CREATE SEQUENCE setval_txn_currval_seq
+
+query I
+SELECT setval('setval_txn_currval_seq', 1)
+----
+1
+
+statement ok
+END
+
+# should be 1 - see https://github.com/cockroachdb/cockroach/issues/79436
+statement error currval of sequence .+ is not yet defined in this session
+SELECT currval('setval_txn_currval_seq')
+
+# create a sequence and setval then currval in the same transaction
+statement ok
+BEGIN
+
+statement ok
+CREATE SEQUENCE setval_currval_txn_seq
+
+query I
+SELECT setval('setval_currval_txn_seq', 1)
+----
+1
+
+# should be 1 - see https://github.com/cockroachdb/cockroach/issues/79436
+statement error currval of sequence .+ is not yet defined in this session
+SELECT currval('setval_currval_txn_seq')
+
+statement ok
+END

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -182,7 +182,9 @@ type planner struct {
 
 	preparedStatements preparedStatementsAccessor
 
-	// avoidCachedDescriptors, when true, instructs all code that
+	createdSequences createdSequences
+
+	// avoidLeasedDescriptors, when true, instructs all code that
 	// accesses table/view descriptors to force reading the descriptors
 	// within the transaction. This is necessary to read descriptors
 	// from the store for:
@@ -412,6 +414,7 @@ func newInternalPlanner(
 
 	p.queryCacheSession.Init()
 	p.optPlanningCtx.init(p)
+	p.createdSequences = emptyCreatedSequences{}
 
 	return p, func() {
 		// Note that we capture ctx here. This is only valid as long as we create

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -153,8 +153,11 @@ func (p *planner) incrementSequenceUsingCache(
 	fetchNextValues := func() (currentValue, incrementAmount, sizeOfCache int64, err error) {
 		seqValueKey := p.ExecCfg().Codec.SequenceKey(uint32(descriptor.GetID()))
 
+		// We *do not* use the planner txn here, since nextval does not respect
+		// transaction boundaries. This matches the specification at
+		// https://www.postgresql.org/docs/14/functions-sequence.html
 		endValue, err := kv.IncrementValRetryable(
-			ctx, p.txn.DB(), seqValueKey, seqOpts.Increment*cacheSize)
+			ctx, p.ExecCfg().DB, seqValueKey, seqOpts.Increment*cacheSize)
 
 		if err != nil {
 			if errors.HasType(err, (*roachpb.IntegerOverflowError)(nil)) {
@@ -341,21 +344,13 @@ func setSequenceValueHelper(
 		return err
 	}
 
+	// We *do not* use the planner txn here, since setval does not respect
+	// transaction boundaries. This matches the specification at
+	// https://www.postgresql.org/docs/14/functions-sequence.html
 	// TODO(vilterp): not supposed to mix usage of Inc and Put on a key,
 	// according to comments on Inc operation. Switch to Inc if `desired-current`
 	// overflows correctly.
-	if err := p.txn.Put(ctx, seqValueKey, newVal); err != nil {
-		return err
-	}
-
-	// Clear out the cache and update the last value if needed.
-	p.sessionDataMutatorIterator.applyForEachMutator(func(m sessionDataMutator) {
-		m.initSequenceCache()
-		if isCalled {
-			m.RecordLatestSequenceVal(uint32(descriptor.GetID()), newVal)
-		}
-	})
-	return nil
+	return p.ExecCfg().DB.Put(ctx, seqValueKey, newVal)
 }
 
 // MakeSequenceKeyVal returns the key and value of a sequence being set

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -148,16 +148,32 @@ func (p *planner) incrementSequenceUsingCache(
 ) (int64, error) {
 	seqOpts := descriptor.GetSequenceOpts()
 
-	cacheSize := seqOpts.EffectiveCacheSize()
+	sequenceID := descriptor.GetID()
+	createdInCurrentTxn := p.createdSequences.isCreatedSequence(sequenceID)
+	var cacheSize int64
+	if createdInCurrentTxn {
+		cacheSize = 1
+	} else {
+		cacheSize = seqOpts.EffectiveCacheSize()
+	}
 
 	fetchNextValues := func() (currentValue, incrementAmount, sizeOfCache int64, err error) {
-		seqValueKey := p.ExecCfg().Codec.SequenceKey(uint32(descriptor.GetID()))
+		seqValueKey := p.ExecCfg().Codec.SequenceKey(uint32(sequenceID))
 
-		// We *do not* use the planner txn here, since nextval does not respect
-		// transaction boundaries. This matches the specification at
-		// https://www.postgresql.org/docs/14/functions-sequence.html
-		endValue, err := kv.IncrementValRetryable(
-			ctx, p.ExecCfg().DB, seqValueKey, seqOpts.Increment*cacheSize)
+		// The planner txn is only used if the sequence is accessed in the same
+		// transaction that it was created. Otherwise, we *do not* use the planner
+		// txn here, since nextval does not respect transaction boundaries.
+		// This matches the specification at
+		// https://www.postgresql.org/docs/14/functions-sequence.html.
+		var endValue int64
+		if createdInCurrentTxn {
+			var res kv.KeyValue
+			res, err = p.txn.Inc(ctx, seqValueKey, seqOpts.Increment*cacheSize)
+			endValue = res.ValueInt()
+		} else {
+			endValue, err = kv.IncrementValRetryable(
+				ctx, p.ExecCfg().DB, seqValueKey, seqOpts.Increment*cacheSize)
+		}
 
 		if err != nil {
 			if errors.HasType(err, (*roachpb.IntegerOverflowError)(nil)) {
@@ -201,7 +217,7 @@ func (p *planner) incrementSequenceUsingCache(
 			return 0, err
 		}
 	} else {
-		val, err = p.GetOrInitSequenceCache().NextValue(uint32(descriptor.GetID()), uint32(descriptor.GetVersion()), fetchNextValues)
+		val, err = p.GetOrInitSequenceCache().NextValue(uint32(sequenceID), uint32(descriptor.GetVersion()), fetchNextValues)
 		if err != nil {
 			return 0, err
 		}
@@ -344,13 +360,33 @@ func setSequenceValueHelper(
 		return err
 	}
 
-	// We *do not* use the planner txn here, since setval does not respect
-	// transaction boundaries. This matches the specification at
-	// https://www.postgresql.org/docs/14/functions-sequence.html
-	// TODO(vilterp): not supposed to mix usage of Inc and Put on a key,
-	// according to comments on Inc operation. Switch to Inc if `desired-current`
-	// overflows correctly.
-	return p.ExecCfg().DB.Put(ctx, seqValueKey, newVal)
+	createdInCurrentTxn := p.createdSequences.isCreatedSequence(descriptor.GetID())
+	if createdInCurrentTxn {
+		if err := p.txn.Put(ctx, seqValueKey, newVal); err != nil {
+			return err
+		}
+	} else {
+		// The planner txn is only used if the sequence is accessed in the same
+		// transaction that it was created. Otherwise, we *do not* use the planner
+		// txn here, since setval does not respect transaction boundaries.
+		// This matches the specification at
+		// https://www.postgresql.org/docs/14/functions-sequence.html.
+		// TODO(vilterp): not supposed to mix usage of Inc and Put on a key,
+		// according to comments on Inc operation. Switch to Inc if `desired-current`
+		// overflows correctly.
+		if err := p.ExecCfg().DB.Put(ctx, seqValueKey, newVal); err != nil {
+			return err
+		}
+	}
+
+	// Clear out the cache and update the last value if needed.
+	p.sessionDataMutatorIterator.applyForEachMutator(func(m sessionDataMutator) {
+		m.initSequenceCache()
+		if isCalled {
+			m.RecordLatestSequenceVal(uint32(descriptor.GetID()), newVal)
+		}
+	})
+	return nil
 }
 
 // MakeSequenceKeyVal returns the key and value of a sequence being set


### PR DESCRIPTION
Backport:
  * 1/3 commits from "sql: fix bugs with sequence and setval" (#71643)
  * 1/1 commits from "sql: allow creating a sequence and calling nextval/setval on it within a transaction" (#77949)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: Fixes deadlock when creating and accessing sequence within a transaction