### PR TITLE
sql/pgwire: add sql.conn.failures metric

### DIFF
--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -2270,6 +2270,13 @@ var charts = []sectionDescription{
 				AxisLabel: "Latency",
 			},
 			{
+				Title: "Connection Failures",
+				Metrics: []string{
+					"sql.conn.failures",
+				},
+				AxisLabel: "Failures",
+			},
+			{
 				Title: "Open Transactions",
 				Metrics: []string{
 					"sql.txns.open",


### PR DESCRIPTION
Related to #73566

This commit adds the the new sql.conn.failures counter metric that
reflects the number of failed SQL connections.

Release note (sql change): the new sql.conn.failures counter metric shows
number of failed SQL connections.