### PR TITLE
release-21.2: vendor: bump Pebble to f9d4931a5fd2

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -733,8 +733,8 @@ def go_deps():
         name = "com_github_cockroachdb_pebble",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/pebble",
-        sum = "h1:CBC5G9uatpCr5/CzU3ZDrFGxmqB/vrH2QPWSmYUBNto=",
-        version = "v0.0.0-20220322140431-c50a066abbd3",
+        sum = "h1:4Q2hcUylCXvPk0UqCBzs0K1qYZTy33ylye2LnyRxsVw=",
+        version = "v0.0.0-20220407171955-f9d4931a5fd2",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f
-	github.com/cockroachdb/pebble v0.0.0-20220322140431-c50a066abbd3
+	github.com/cockroachdb/pebble v0.0.0-20220407171955-f9d4931a5fd2
 	github.com/cockroachdb/redact v1.1.3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/stress v0.0.0-20170808184505-29b5d31b4c3a

--- a/go.sum
+++ b/go.sum
@@ -305,8 +305,8 @@ github.com/cockroachdb/gostdlib v1.13.0/go.mod h1:eXX95p9QDrYwJfJ6AgeN9QnRa/lqqi
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f h1:6jduT9Hfc0njg5jJ1DdKCFPdMBrp/mdZfCpa5h+WM74=
 github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f/go.mod h1:Vz9DsVWQQhf3vs21MhPMZpMGSht7O/2vFW2xusFUVOs=
-github.com/cockroachdb/pebble v0.0.0-20220322140431-c50a066abbd3 h1:CBC5G9uatpCr5/CzU3ZDrFGxmqB/vrH2QPWSmYUBNto=
-github.com/cockroachdb/pebble v0.0.0-20220322140431-c50a066abbd3/go.mod h1:JXfQr3d+XO4bL1pxGwKKo09xylQSdZ/mpZ9b2wfVcPs=
+github.com/cockroachdb/pebble v0.0.0-20220407171955-f9d4931a5fd2 h1:4Q2hcUylCXvPk0UqCBzs0K1qYZTy33ylye2LnyRxsVw=
+github.com/cockroachdb/pebble v0.0.0-20220407171955-f9d4931a5fd2/go.mod h1:JXfQr3d+XO4bL1pxGwKKo09xylQSdZ/mpZ9b2wfVcPs=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=
 github.com/cockroachdb/redact v1.1.3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=


### PR DESCRIPTION
```
f9d4931a compaction: add L0CompactionFileThreshold compaction trigger
```

Release note (bug fix): Fix a bug where Pebble compaction heuristics
could allow a large compaction backlog to accumulate, eventually
triggering high read amplification.

Release justification: Fixes high severity bug resulting from an interaction
between Pebble compaction heuristics and admission control.