### PR TITLE
tests: don't swallow an error about no cast volatility

### DIFF
--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -165,9 +165,7 @@ func (db *verifyFormatDB) execWithTimeout(
 					}
 				}
 			}
-			// TODO(yuzefovich): allow "no volatility for cast tuple" errors to
-			// fail once #70831 is resolved.
-			if es := err.Error(); (strings.Contains(es, "internal error") && !strings.Contains(es, "no volatility for cast tuple")) ||
+			if es := err.Error(); strings.Contains(es, "internal error") ||
 				strings.Contains(es, "driver: bad connection") ||
 				strings.Contains(es, "unexpected error inside CockroachDB") {
 				return &crasher{


### PR DESCRIPTION
The underlying issue #70831 has been fixed.

Release note: None