### PR TITLE
roachtest: update libpq test

### DIFF
--- a/pkg/cmd/roachtest/tests/libpq.go
+++ b/pkg/cmd/roachtest/tests/libpq.go
@@ -25,7 +25,7 @@ import (
 )
 
 var libPQReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
-var libPQSupportedTag = "v1.10.4"
+var libPQSupportedTag = "v1.10.5"
 
 func registerLibPQ(r registry.Registry) {
 	runLibPQ := func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/libpq_blocklist.go
+++ b/pkg/cmd/roachtest/tests/libpq_blocklist.go
@@ -17,7 +17,37 @@ var libPQBlocklists = blocklistsForVersion{
 	{"v22.1", "libPQBlocklist22_1", libPQBlocklist22_1, "libPQIgnorelist22_1", libPQIgnorelist22_1},
 }
 
-var libPQBlocklist22_1 = libPQBlocklist21_2
+var libPQBlocklist22_1 = blocklist{
+	"pq.ExampleConnectorWithNoticeHandler":           "unknown",
+	"pq.TestBinaryByteSliceToInt":                    "41547",
+	"pq.TestBinaryByteSlicetoUUID":                   "41547",
+	"pq.TestConnListen":                              "41522",
+	"pq.TestConnUnlisten":                            "41522",
+	"pq.TestConnUnlistenAll":                         "41522",
+	"pq.TestConnectorWithNoticeHandler_Simple":       "unknown",
+	"pq.TestConnectorWithNotificationHandler_Simple": "unknown",
+	"pq.TestCopyFromError":                           "5807",
+	"pq.TestCopyInRaiseStmtTrigger":                  "5807",
+	"pq.TestCopyInTypes":                             "5807",
+	"pq.TestCopyRespLoopConnectionError":             "5807",
+	"pq.TestEncodeAndParseTs":                        "41563",
+	"pq.TestInfinityTimestamp":                       "41564",
+	"pq.TestIssue186":                                "41558",
+	"pq.TestIssue196":                                "41689",
+	"pq.TestIssue282":                                "12137",
+	"pq.TestListenerFailedQuery":                     "41522",
+	"pq.TestListenerListen":                          "41522",
+	"pq.TestListenerReconnect":                       "41522",
+	"pq.TestListenerUnlisten":                        "41522",
+	"pq.TestListenerUnlistenAll":                     "41522",
+	"pq.TestNotifyExtra":                             "41522",
+	"pq.TestPing":                                    "35897",
+	"pq.TestQueryRowBugWorkaround":                   "5807",
+	"pq.TestReconnect":                               "35897",
+	"pq.TestRowsColumnTypes":                         "41688",
+	"pq.TestRuntimeParameters":                       "12137",
+	"pq.TestStringWithNul":                           "26366",
+}
 
 var libPQBlocklist21_2 = blocklist{
 	"pq.ExampleConnectorWithNoticeHandler":           "unknown",


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/79570

This allows the query cancel tests to pass.

Release note: None