### PR TITLE
logictest: deflake tests with async statements

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -3336,11 +3336,14 @@ func (t *logicTest) execStatement(stmt logicStatement) (bool, error) {
 		}
 		t.pendingStatements[stmt.statementName] = pending
 
+		startedChan := make(chan struct{})
 		go func() {
+			startedChan <- struct{}{}
 			res, err := t.db.Exec(execSQL)
 			pending.resultChan <- pendingExecResult{execSQL, res, err}
 		}()
 
+		<-startedChan
 		return true, nil
 	}
 


### PR DESCRIPTION
While async statements in logictests were introduced in #79010, in some
cases tests with async statements would fail due to a race condition.
This is fixed by updating the logic such that when an async statement is
issued, the goroutine running that statement is ensured to have started
before execution continues to other lines in the test.

Fixes #79565.

Release note: None

Release Justification: Testing change only.