### PR TITLE
cli: cosmetic change in the output of `start`

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -983,7 +983,7 @@ func reportServerInfo(
 		buf.Printf("cluster name:\t%s\n", baseCfg.ClusterName)
 	}
 	clusterID := serverCfg.BaseConfig.ClusterIDContainer.Get()
-	if clusterID.Equal(tenantClusterID) {
+	if tenantClusterID.Equal(uuid.Nil) {
 		buf.Printf("clusterID:\t%s\n", clusterID)
 	} else {
 		buf.Printf("storage clusterID:\t%s\n", clusterID)


### PR DESCRIPTION
This fixes a cosmetic bug that made its way in the previous change
to `reportServerInfo`. (#74005)

Release note: None