### PR TITLE
sql: explicitly stop the mem monitor of internal executor in some cases

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1096,6 +1096,7 @@ func (ex *connExecutor) close(ctx context.Context, closeType closeType) {
 
 	if ex.hasCreatedTemporarySchema && !ex.server.cfg.TestingKnobs.DisableTempObjectsCleanupOnSessionExit {
 		ie := MakeInternalExecutor(ctx, ex.server, MemoryMetrics{}, ex.server.cfg.Settings)
+		defer ie.Close(ctx)
 		err := cleanupSessionTempObjects(
 			ctx,
 			ex.server.cfg.Settings,

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -94,7 +94,8 @@ func (ie *InternalExecutor) WithSyntheticDescriptors(
 	return run()
 }
 
-// MakeInternalExecutor creates an InternalExecutor.
+// MakeInternalExecutor creates an InternalExecutor. If the executor is
+// short-lived, then it must be closed explicitly.
 func MakeInternalExecutor(
 	ctx context.Context, s *Server, memMetrics MemoryMetrics, settings *cluster.Settings,
 ) InternalExecutor {
@@ -112,6 +113,13 @@ func MakeInternalExecutor(
 		s:          s,
 		mon:        monitor,
 		memMetrics: memMetrics,
+	}
+}
+
+func (ie *InternalExecutor) Close(ctx context.Context) {
+	if ie.mon != nil {
+		ie.mon.Stop(ctx)
+		ie.mon = nil
 	}
 }
 

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -877,6 +877,7 @@ func (p *planner) QueryRowEx(
 	qargs ...interface{},
 ) (tree.Datums, error) {
 	ie := p.ExecCfg().InternalExecutorFactory(ctx, p.SessionData())
+	defer ie.(*InternalExecutor).Close(ctx)
 	return ie.QueryRowEx(ctx, opName, txn, override, stmt, qargs...)
 }
 


### PR DESCRIPTION
If I'm reading the code right, then we currently never stop the monitor
created for an internal executor. We correctly close the accounts bound
to it, but the monitor might decide to not release the whole allocation
back to its pool (`sql` monitor). Thus, I think it's possible that we
have a fake memory leak. This commit explicitly stops these monitors in
some cases.

Release note: None