### PR TITLE
release-22.1: ui: Filter by columns for Hot Ranges page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/dropdown/dropdown.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/dropdown/dropdown.module.scss
@@ -36,6 +36,15 @@
   width: max-content;
 }
 
+.crl-dropdown__container__wrapped {
+  padding: 0 $spacing-small $spacing-small;
+  width: 320px;
+  max-width: 320px;
+  > * {
+    padding-top: $spacing-small;
+  }
+}
+
 .crl-dropdown__item {
   height: $line-height--large;
   padding: $spacing-xx-small $spacing-small;

--- a/pkg/ui/workspaces/cluster-ui/src/dropdown/dropdown.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/dropdown/dropdown.tsx
@@ -53,7 +53,7 @@ interface DropdownButtonProps {
   customProps?: Partial<ButtonProps>;
 }
 
-const DropdownButton: React.FC<DropdownButtonProps> = ({
+export const DropdownButton: React.FC<DropdownButtonProps> = ({
   children,
   customProps = {},
 }) => {

--- a/pkg/ui/workspaces/cluster-ui/src/filter/filterCheckboxOption.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/filter/filterCheckboxOption.tsx
@@ -1,0 +1,82 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import Select, { Props, OptionsType } from "react-select";
+import { noop } from "lodash";
+import { CheckboxOption } from "../multiSelectCheckbox/multiSelectCheckbox";
+import { filterLabel } from "../queryFilter/filterClasses";
+import { StylesConfig } from "react-select/src/styles";
+
+export type FilterCheckboxOptionItem = { label: string; value: string };
+export type FilterCheckboxOptionsType = OptionsType<FilterCheckboxOptionItem>;
+
+export type FilterCheckboxOptionProps = {
+  label: string;
+  // onSelectionChanged callback function is called with all selected options.
+  onSelectionChanged?: (options: OptionsType<FilterCheckboxOptionItem>) => void;
+  triggerClear?: (fn: () => void) => void;
+} & Props;
+
+export const FilterCheckboxOption = (props: FilterCheckboxOptionProps) => {
+  const {
+    label,
+    onSelectionChanged = noop,
+    options,
+    placeholder,
+    ...selectProps
+  } = props;
+
+  const customStyles: StylesConfig<FilterCheckboxOptionItem, true> = {
+    container: provided => ({
+      ...provided,
+      border: "none",
+    }),
+    option: (provided, state) => ({
+      ...provided,
+      backgroundColor: state.isSelected ? "#DEEBFF" : provided.backgroundColor,
+      color: "#394455",
+    }),
+    control: provided => ({
+      ...provided,
+      width: "100%",
+      borderColor: "#C0C6D9",
+    }),
+    dropdownIndicator: provided => ({
+      ...provided,
+      color: "#C0C6D9",
+    }),
+    singleValue: provided => ({
+      ...provided,
+      color: "#475872",
+    }),
+    menu: provided => ({
+      ...provided,
+      zIndex: 3,
+    }),
+  };
+
+  return (
+    <div>
+      <div className={filterLabel.margin}>{label}</div>
+      <Select
+        {...selectProps}
+        isMulti
+        options={options}
+        placeholder={placeholder}
+        onChange={onSelectionChanged}
+        hideSelectedOptions={false}
+        closeMenuOnSelect={false}
+        components={{ Option: CheckboxOption }}
+        styles={customStyles}
+      />
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/filter/filterDropdown.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/filter/filterDropdown.stories.tsx
@@ -1,0 +1,37 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { noop } from "lodash";
+import { FilterDropdown } from "./filterDropdown";
+import { FilterCheckboxOption } from "./filterCheckboxOption";
+import { FilterSearchOption } from "./filterSearchOption";
+
+storiesOf("FilterDropdown", module)
+  .addDecorator(renderChild => (
+    <div style={{ padding: "12px", display: "flex" }}>{renderChild()}</div>
+  ))
+  .add("default", () => (
+    <FilterDropdown label="Filters" onSubmit={noop}>
+      <FilterCheckboxOption
+        label="Node ID"
+        value={[{ label: "1", value: "1" }]}
+        options={[
+          { label: "1", value: "1" },
+          { label: "2", value: "2" },
+          { label: "3", value: "3" },
+          { label: "4", value: "4" },
+        ]}
+        placeholder="Select"
+      />
+      <FilterSearchOption label="Store ID" />
+    </FilterDropdown>
+  ));

--- a/pkg/ui/workspaces/cluster-ui/src/filter/filterDropdown.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/filter/filterDropdown.tsx
@@ -1,0 +1,84 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { DropdownButton } from "../dropdown";
+import { OutsideEventHandler } from "../outsideEventHandler";
+import classnames from "classnames/bind";
+import styles from "../dropdown/dropdown.module.scss";
+import { applyBtn } from "../queryFilter/filterClasses";
+import { Button } from "../button";
+
+const cx = classnames.bind(styles);
+
+type FilterDropdownProps = React.PropsWithChildren<{
+  className?: string;
+  label: string;
+  onSubmit: () => void;
+}>;
+
+export const FilterDropdown = ({
+  className,
+  label,
+  onSubmit,
+  children,
+}: FilterDropdownProps) => {
+  const [isOpen, setIsOpen] = React.useState<boolean>(false);
+  const toggleMenuState = React.useCallback(() => {
+    setIsOpen(!isOpen);
+  }, [isOpen]);
+
+  const onSubmitCallback = React.useCallback(() => {
+    onSubmit();
+    setIsOpen(false);
+  }, [onSubmit]);
+
+  const menuStyles = cx(
+    "crl-dropdown__menu",
+    `crl-dropdown__menu--align-left`,
+    {
+      "crl-dropdown__menu--open": isOpen,
+    },
+  );
+
+  return (
+    <div
+      className={cx("crl-dropdown", className)}
+      onClick={event => event.stopPropagation()}
+    >
+      <OutsideEventHandler onOutsideClick={() => setIsOpen(false)}>
+        <div className={cx("crl-dropdown__handler")} onClick={toggleMenuState}>
+          <DropdownButton isOpen={true}>{label}</DropdownButton>
+        </div>
+        <div className={cx("crl-dropdown__overlay")}>
+          <div className={menuStyles}>
+            <div
+              className={cx(
+                "crl-dropdown__container",
+                "crl-dropdown__container__wrapped",
+              )}
+            >
+              {children}
+              <div className={applyBtn.wrapper}>
+                <Button
+                  className={applyBtn.btn}
+                  textAlign="center"
+                  onClick={onSubmitCallback}
+                >
+                  Apply
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </OutsideEventHandler>
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/filter/filterSearchOption.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/filter/filterSearchOption.tsx
@@ -1,0 +1,34 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { Search } from "../search";
+import { filterLabel } from "../queryFilter/filterClasses";
+
+export type FilterSearchOptionProps = {
+  label: string;
+  onChanged?: (value: string) => void;
+  value?: string;
+};
+
+export const FilterSearchOption = (props: FilterSearchOptionProps) => {
+  const { label, onChanged, value } = props;
+  return (
+    <div>
+      <div className={filterLabel.margin}>{label}</div>
+      <Search
+        onChange={onChanged}
+        renderSuffix={false}
+        placeholder="Search"
+        value={value}
+      />
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/filter/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/filter/index.ts
@@ -1,0 +1,13 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+export * from "./filterDropdown";
+export * from "./filterCheckboxOption";
+export * from "./filterSearchOption";

--- a/pkg/ui/workspaces/cluster-ui/src/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/index.ts
@@ -22,6 +22,7 @@ export * from "./databasesPage";
 export * from "./downloadFile";
 export * from "./dropdown";
 export * from "./empty";
+export * from "./filter";
 export * from "./highlightedText";
 export * from "./indexDetailsPage";
 export * from "./loading";

--- a/pkg/ui/workspaces/cluster-ui/src/multiSelectCheckbox/multiSelectCheckbox.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/multiSelectCheckbox/multiSelectCheckbox.tsx
@@ -36,7 +36,7 @@ export interface MultiSelectCheckboxProps {
  * @param props
  * @constructor
  */
-const CheckboxOption = (props: any) => {
+export const CheckboxOption = (props: any) => {
   return (
     <components.Option {...props}>
       <input

--- a/pkg/ui/workspaces/cluster-ui/src/search/search.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/search/search.tsx
@@ -12,6 +12,7 @@ import React from "react";
 import { Button, Form, Input } from "antd";
 import { InputProps } from "antd/lib/input";
 import classNames from "classnames/bind";
+import { noop } from "lodash";
 import {
   Cancel as CancelIcon,
   Search as SearchIcon,
@@ -20,8 +21,11 @@ import styles from "./search.module.scss";
 
 interface ISearchProps {
   onSubmit: (search: string) => void;
+  onChange?: (value: string) => void;
   onClear?: () => void;
   defaultValue?: string;
+  placeholder?: string;
+  renderSuffix?: boolean;
 }
 
 interface ISearchState {
@@ -30,12 +34,21 @@ interface ISearchState {
   submit?: boolean;
 }
 
-type TSearchProps = ISearchProps & InputProps;
+type TSearchProps = ISearchProps &
+  Omit<InputProps, "onSubmit" | "defaultValue" | "placeholder" | "onChange">; // Omit shadowed props by ISearchProps type.
 
 const cx = classNames.bind(styles);
 
 export class Search extends React.Component<TSearchProps, ISearchState> {
-  state = {
+  static defaultProps: Partial<ISearchProps> = {
+    placeholder: "Search Statements",
+    renderSuffix: true,
+    onSubmit: noop,
+    onChange: noop,
+    onClear: noop,
+  };
+
+  state: ISearchState = {
     value: this.props.defaultValue || "",
     submitted: false,
   };
@@ -53,8 +66,10 @@ export class Search extends React.Component<TSearchProps, ISearchState> {
   };
 
   onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    event.persist();
     const value: string = event.target.value;
     const submitted = value.length === 0;
+    this.props.onChange(value);
     this.setState(
       { value, submitted },
       () => submitted && this.onSubmit(event),
@@ -68,6 +83,9 @@ export class Search extends React.Component<TSearchProps, ISearchState> {
   };
 
   renderSuffix = () => {
+    if (!this.props.renderSuffix) {
+      return null;
+    }
     const { value, submitted } = this.state;
     if (value.length > 0) {
       if (submitted) {
@@ -96,7 +114,10 @@ export class Search extends React.Component<TSearchProps, ISearchState> {
 
   render() {
     const { value, submitted } = this.state;
-    const { onClear, ...inputProps } = this.props;
+    // We pull out onSubmit and onClear so that they will not be passed
+    // to the Input component as part of inputProps.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { onSubmit, onClear, onChange, ...inputProps } = this.props;
     const className = submitted ? cx("submitted") : "";
 
     return (
@@ -104,7 +125,6 @@ export class Search extends React.Component<TSearchProps, ISearchState> {
         <Form.Item>
           <Input
             className={className}
-            placeholder="Search Statements"
             onChange={this.onChange}
             prefix={<SearchIcon className={cx("prefix-icon")} />}
             suffix={this.renderSuffix()}

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRanges.module.styl
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRanges.module.styl
@@ -22,3 +22,7 @@
   color $colors--primary-blue-2
   &:hover
     color $colors--primary-blue-2
+
+.hotranges-dropdown-filter
+  width max-content
+  margin-top $line-height--x-small

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesFilter.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesFilter.tsx
@@ -1,0 +1,384 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React, { useCallback, useEffect, useState, useMemo } from "react";
+import ReactDOM from "react-dom";
+import {
+  Button,
+  FilterCheckboxOption,
+  FilterCheckboxOptionsType,
+  FilterDropdown,
+  FilterSearchOption,
+} from "@cockroachlabs/cluster-ui";
+import { isEmpty, isArray, isString } from "lodash";
+import classNames from "classnames/bind";
+import { useHistory } from "react-router-dom";
+import { cockroach } from "src/js/protos";
+import styles from "./hotRanges.module.styl";
+
+type HotRange = cockroach.server.serverpb.HotRangesResponseV2.IHotRange;
+
+const cx = classNames.bind(styles);
+
+export type HotRangesFilterProps = {
+  hotRanges: HotRange[];
+  onChange: (filteredHotRanges: HotRange[]) => void;
+  nodeIdToLocalityMap: Map<number, string>;
+  clearButtonContainer: Element;
+};
+
+export const HotRangesFilter = (props: HotRangesFilterProps) => {
+  const { hotRanges, onChange, nodeIdToLocalityMap } = props;
+
+  // nodeIdsOptions is a list of uniq node IDs that are available in
+  // provided list of hot ranges.
+  const nodeIdsOptions = useMemo(
+    () =>
+      Array.from(new Set(hotRanges.map(r => `${r.node_id}`)))
+        .sort()
+        .map(nodeId => ({ label: nodeId, value: nodeId })),
+    [hotRanges],
+  );
+
+  // databaseOptions is a list of uniq database names that are available in
+  // provided list of hot ranges.
+  const databaseOptions = useMemo(
+    () =>
+      Array.from(new Set(hotRanges.map(r => r.database_name)))
+        .filter(i => !isEmpty(i))
+        .sort()
+        .map(dbName => ({ label: dbName, value: dbName })),
+    [hotRanges],
+  );
+
+  // localitiesOptions is a list of uniq localities that are available in
+  // provided list of hot ranges.
+  const localitiesOptions = useMemo(
+    () =>
+      Array.from(nodeIdToLocalityMap.values())
+        .sort()
+        .map(locality => ({ label: locality, value: locality })),
+    [nodeIdToLocalityMap],
+  );
+
+  const history = useHistory();
+
+  // define filter names that are used in URL search params to preserve filter options.
+  const nodeIds = "node_ids";
+  const storeId = "store_id";
+  const dbNames = "db_names";
+  const table = "table";
+  const indexName = "index";
+  const localities = "localities";
+
+  // initialize states of filter options with values from URL search params.
+  const [filterNodeIds, setFilterNodeIds] = useState<FilterCheckboxOptionsType>(
+    [],
+  );
+  const [filterStoreId, setFilterStoreId] = useState<string>();
+  const [filterDbNames, setFilterDbNames] = useState<FilterCheckboxOptionsType>(
+    [],
+  );
+  const [filterTableName, setFilterTableName] = useState<string>();
+  const [filterIndexName, setFilterIndexName] = useState<string>();
+  const [filterLocalities, setFilterLocalities] = useState<
+    FilterCheckboxOptionsType
+  >([]);
+
+  // stagedFilteredHotRanges preserves intermediate filters states that are selected but
+  // is not Applied yet.
+  const [stagedFilteredHotRanges, setStagedFilteredHotRanges] = useState<
+    HotRange[]
+  >([]);
+
+  // getFiltersCount returns how many filter options are selected.
+  const getFiltersCount = useCallback(
+    (filters: Array<FilterCheckboxOptionsType | string>) =>
+      filters.filter(f => !isEmpty(f)).length,
+    [],
+  );
+
+  const [filtersCount, setFiltersCount] = useState<number>(0);
+
+  // filterBy function performs actual filtering of hot ranges regarding provided
+  // filters options.
+  const filterBy = useCallback(
+    (
+      ranges: HotRange[],
+      nodeIds: FilterCheckboxOptionsType,
+      storeId: string,
+      dbNames: FilterCheckboxOptionsType,
+      tableName: string,
+      indexName: string,
+      localities: FilterCheckboxOptionsType,
+    ) => {
+      const hasNoFilters = [
+        nodeIds,
+        storeId,
+        dbNames,
+        tableName,
+        indexName,
+        localities,
+      ].every(isEmpty);
+
+      if (hasNoFilters) {
+        return ranges;
+      }
+
+      let filtered = [...ranges];
+
+      if (!isEmpty(nodeIds)) {
+        filtered = filtered.filter(r =>
+          nodeIds.some(f => f.value === r.node_id?.toString()),
+        );
+      }
+
+      if (!isEmpty(storeId)) {
+        filtered = filtered.filter(r =>
+          r.store_id.toString().includes(storeId),
+        );
+      }
+
+      if (!isEmpty(dbNames)) {
+        filtered = filtered.filter(r =>
+          dbNames.some(f => f.value === r.database_name),
+        );
+      }
+
+      if (!isEmpty(tableName)) {
+        filtered = filtered.filter(r => r.table_name?.includes(tableName));
+      }
+
+      if (!isEmpty(indexName)) {
+        filtered = filtered.filter(r => r.index_name?.includes(indexName));
+      }
+
+      if (!isEmpty(localities)) {
+        filtered = filtered.filter(r => {
+          const locality = nodeIdToLocalityMap.get(r.node_id);
+          return localities.some(f => f.value === locality);
+        });
+      }
+      return filtered;
+    },
+    [nodeIdToLocalityMap],
+  );
+
+  // Following effect is required to filter hot ranges every time when
+  // hot ranges list is updated after filters are changed (it is possible
+  // when: a) filter options are retrieved from URL search params; b) when
+  // hot ranges are periodically updated and new data is received from server).
+  useEffect(() => {
+    const searchParams = new URLSearchParams(history.location.search);
+    const nodeIdsFilter = (searchParams.get(nodeIds) || "")
+      .split("|")
+      .filter(i => !isEmpty(i))
+      .map(i => ({ label: i, value: i }));
+    const storeIdFilter = searchParams.get(storeId);
+    const dbNamesFilter = (searchParams.get(dbNames) || "")
+      .split("|")
+      .filter(i => !isEmpty(i))
+      .map(i => ({ label: i, value: i }));
+    const tableNameFilter = searchParams.get(table);
+    const indexNameFilter = searchParams.get(indexName);
+    const localitiesFilter = (searchParams.get(localities) || "")
+      .split("|")
+      .filter(i => !isEmpty(i))
+      .map(i => ({ label: i, value: i }));
+
+    setFilterNodeIds(nodeIdsFilter);
+    setFilterStoreId(storeIdFilter);
+    setFilterDbNames(dbNamesFilter);
+    setFilterTableName(tableNameFilter);
+    setFilterIndexName(indexNameFilter);
+    setFilterLocalities(localitiesFilter);
+
+    setFiltersCount(
+      getFiltersCount([
+        nodeIdsFilter,
+        storeIdFilter,
+        dbNamesFilter,
+        tableNameFilter,
+        indexNameFilter,
+        localitiesFilter,
+      ]),
+    );
+
+    const filtered = filterBy(
+      hotRanges,
+      nodeIdsFilter,
+      storeIdFilter,
+      dbNamesFilter,
+      tableNameFilter,
+      indexNameFilter,
+      localitiesFilter,
+    );
+    onChange(filtered);
+  }, [hotRanges, onChange, history, filterBy, getFiltersCount]);
+
+  useEffect(() => {
+    const filtered = filterBy(
+      hotRanges,
+      filterNodeIds,
+      filterStoreId,
+      filterDbNames,
+      filterTableName,
+      filterIndexName,
+      filterLocalities,
+    );
+    setStagedFilteredHotRanges(filtered);
+  }, [
+    filterNodeIds,
+    filterStoreId,
+    filterDbNames,
+    filterTableName,
+    filterIndexName,
+    filterLocalities,
+    hotRanges,
+    filterBy,
+  ]);
+
+  const getSearchParams = useCallback(() => {
+    const params = new URLSearchParams();
+    [
+      [nodeIds, filterNodeIds],
+      [storeId, filterStoreId],
+      [dbNames, filterDbNames],
+      [table, filterTableName],
+      [indexName, filterIndexName],
+      [localities, filterLocalities],
+    ]
+      .filter(f => !isEmpty(f[1]))
+      .forEach(
+        ([name, value]: [string, FilterCheckboxOptionsType | string]) => {
+          if (isArray(value)) {
+            params.set(name, value.map(f => f.value).join("|"));
+          }
+          if (isString(value)) {
+            params.set(name, value);
+          }
+        },
+      );
+    return params;
+  }, [
+    filterNodeIds,
+    filterStoreId,
+    filterDbNames,
+    filterTableName,
+    filterIndexName,
+    filterLocalities,
+  ]);
+
+  // onApply is a callback function that is fired when user click "Apply" button
+  // in DropdownFilter.
+  const onApply = useCallback(() => {
+    setFiltersCount(
+      getFiltersCount([
+        filterNodeIds,
+        filterStoreId,
+        filterDbNames,
+        filterTableName,
+        filterIndexName,
+        filterLocalities,
+      ]),
+    );
+    onChange(stagedFilteredHotRanges);
+    history.location.search = getSearchParams().toString();
+    history.replace(history.location);
+  }, [
+    getFiltersCount,
+    filterNodeIds,
+    filterStoreId,
+    filterDbNames,
+    filterTableName,
+    filterIndexName,
+    filterLocalities,
+    onChange,
+    stagedFilteredHotRanges,
+    history,
+    getSearchParams,
+  ]);
+
+  // onClearClick function clears all filters, URL search params, and resets filters counter.
+  const onClearClick = useCallback(() => {
+    setFilterNodeIds([]);
+    setFilterStoreId(undefined);
+    setFilterDbNames([]);
+    setFilterTableName(undefined);
+    setFilterIndexName(undefined);
+    setFilterLocalities([]);
+    onChange(hotRanges);
+    setFiltersCount(0);
+    history.location.search = getSearchParams().toString();
+    history.replace(history.location);
+  }, [onChange, hotRanges, history, getSearchParams]);
+
+  return (
+    <div>
+      <FilterDropdown
+        label={`Filter (${filtersCount})`}
+        onSubmit={onApply}
+        className={cx("hotranges-dropdown-filter")}
+      >
+        <FilterCheckboxOption
+          label="Node ID"
+          options={nodeIdsOptions}
+          placeholder="Select"
+          value={filterNodeIds}
+          onSelectionChanged={options => {
+            setFilterNodeIds(options as any);
+          }}
+        />
+        <FilterSearchOption
+          label="Store ID"
+          onChanged={setFilterStoreId}
+          value={filterStoreId}
+        />
+        <FilterCheckboxOption
+          label="Database"
+          options={databaseOptions}
+          value={filterDbNames}
+          placeholder="Select"
+          onSelectionChanged={options => {
+            setFilterDbNames(options as any);
+          }}
+        />
+        <FilterSearchOption
+          label="Table"
+          onChanged={setFilterTableName}
+          value={filterTableName}
+        />
+        <FilterSearchOption
+          label="Index"
+          onChanged={setFilterIndexName}
+          value={filterIndexName}
+        />
+        <FilterCheckboxOption
+          label="Locality"
+          options={localitiesOptions}
+          placeholder="Select"
+          onSelectionChanged={o => setFilterLocalities(o as any)}
+          value={filterLocalities}
+        />
+      </FilterDropdown>
+      {props.clearButtonContainer &&
+        filtersCount > 0 &&
+        ReactDOM.createPortal(
+          <>
+            <span>&nbsp;&nbsp;&nbsp;-</span>
+            <Button onClick={onClearClick} type="flat" size="small">
+              clear filter
+            </Button>
+          </>,
+          props.clearButtonContainer,
+        )}
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
@@ -18,12 +18,18 @@ import {
   ResultsPerPageLabel,
   SortSetting,
   Anchor,
+  EmptyTable,
 } from "@cockroachlabs/cluster-ui";
 import classNames from "classnames/bind";
 import { round } from "lodash";
 import styles from "./hotRanges.module.styl";
 import { cockroach } from "src/js/protos";
-import { readsAndWritesOverviewPage, uiDebugPages } from "src/util/docs";
+import {
+  performanceBestPracticesHotSpots,
+  readsAndWritesOverviewPage,
+  uiDebugPages,
+} from "src/util/docs";
+import emptyTableResultsImg from "assets/emptyState/empty-table-results.svg";
 
 const PAGE_SIZE = 50;
 const cx = classNames.bind(styles);
@@ -32,12 +38,14 @@ interface HotRangesTableProps {
   hotRangesList: cockroach.server.serverpb.HotRangesResponseV2.IHotRange[];
   lastUpdate?: string;
   nodeIdToLocalityMap: Map<number, string>;
+  clearFilterContainer: React.ReactNode;
 }
 
 const HotRangesTable = ({
   hotRangesList,
   nodeIdToLocalityMap,
   lastUpdate,
+  clearFilterContainer,
 }: HotRangesTableProps) => {
   const [pagination, setPagination] = useState({
     pageSize: PAGE_SIZE,
@@ -48,9 +56,6 @@ const HotRangesTable = ({
     columnTitle: "qps",
   });
 
-  if (hotRangesList.length === 0) {
-    return <div>No hot ranges</div>;
-  }
   const columns: ColumnDescriptor<
     cockroach.server.serverpb.HotRangesResponseV2.IHotRange
   >[] = [
@@ -218,8 +223,9 @@ const HotRangesTable = ({
               ...pagination,
               total: hotRangesList.length,
             }}
-            pageName="hot ranges"
+            pageName="results"
           />
+          {clearFilterContainer}
         </h4>
         <h4 className="cl-count-title">
           {lastUpdate && `Last update: ${lastUpdate}`}
@@ -237,6 +243,17 @@ const HotRangesTable = ({
           })
         }
         pagination={pagination}
+        renderNoResult={
+          <EmptyTable
+            title="No hot ranges"
+            icon={emptyTableResultsImg}
+            footer={
+              <Anchor href={performanceBestPracticesHotSpots} target="_blank">
+                Learn more about hot ranges
+              </Anchor>
+            }
+          />
+        }
       />
       <Pagination
         pageSize={PAGE_SIZE}

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/index.tsx
@@ -10,7 +10,7 @@
 
 import { cockroach } from "src/js/protos";
 import { useDispatch, useSelector } from "react-redux";
-import React, { useEffect } from "react";
+import React, { useRef, useEffect, useState } from "react";
 import { Helmet } from "react-helmet";
 import { refreshHotRanges } from "../../redux/apiReducers";
 import HotRangesTable from "./hotRangesTable";
@@ -28,9 +28,11 @@ import {
 import { selectNodeLocalities } from "src/redux/localities";
 import { DATE_FORMAT_24_UTC } from "src/util/format";
 import { performanceBestPracticesHotSpots } from "src/util/docs";
+import { HotRangesFilter } from "src/views/hotRanges/hotRangesFilter";
 
 const cx = classNames.bind(styles);
 const HotRangesRequest = cockroach.server.serverpb.HotRangesRequest;
+type HotRange = cockroach.server.serverpb.HotRangesResponseV2.IHotRange;
 
 const HotRangesPage = () => {
   const dispatch = useDispatch();
@@ -57,6 +59,12 @@ const HotRangesPage = () => {
     );
   }, [dispatch]);
 
+  const [filteredHotRanges, setFilteredHotRanges] = useState<HotRange[]>(
+    hotRanges,
+  );
+
+  const clearButtonRef = useRef<HTMLSpanElement>();
+
   return (
     <React.Fragment>
       <Helmet title="Hot Ranges" />
@@ -71,17 +79,24 @@ const HotRangesPage = () => {
           find and reduce hot spots.
         </Anchor>
       </Text>
+      <HotRangesFilter
+        hotRanges={hotRanges}
+        onChange={setFilteredHotRanges}
+        nodeIdToLocalityMap={nodeIdToLocalityMap}
+        clearButtonContainer={clearButtonRef.current}
+      />
       <ErrorBoundary>
         <Loading
           loading={isLoading}
           error={lastError}
           render={() => (
             <HotRangesTable
-              hotRangesList={hotRanges}
+              hotRangesList={filteredHotRanges}
               lastUpdate={
                 lastSetAt && lastSetAt?.utc().format(DATE_FORMAT_24_UTC)
               }
               nodeIdToLocalityMap={nodeIdToLocalityMap}
+              clearFilterContainer={<span ref={clearButtonRef} />}
             />
           )}
           page={undefined}


### PR DESCRIPTION
Backport 2/2 commits from #79038.

/cc @cockroachdb/release

---

The current change implements filtering by column
on the Hot Ranges page. It allows users to filter
hot ranges by one or many fields to narrow
down results.

In addition, filter parameters are preserved
in URL path, so filter params are restored after
page is reloaded.

Release note (ui change): Filtering by column is
added to the Hot Ranges page.

Release justification: bug fixes and low-risk updates to new functionality

Resolves: #76159

<img width="902" alt="Screen Shot 2022-03-31 at 16 06 05" src="https://user-images.githubusercontent.com/3106437/161061647-7cead45a-09d5-444d-b107-b5e671251557.png">

