### PR TITLE
[wip] kvserver: reproduce cluster-wide outage if liveness leaseholder deadlocks

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -2131,7 +2131,7 @@ func (ds *DistSender) sendToReplicas(
 			// replica into the cache, but without a leaseholder (and taking into
 			// account that the local node can't be down) it won't take long until we
 			// talk to a replica that tells us who the leaseholder is.
-			if ctx.Err() == nil {
+			if true || ctx.Err() == nil {
 				if lh := routing.Leaseholder(); lh != nil && *lh == curReplica {
 					routing.EvictLease(ctx)
 				}

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+roachprod destroy local || true
+roachprod create -n 5 local
+roachprod put local cockroach
+roachprod start local
+tail -F ~/local/*/logs/cockroach.log
+
+


### PR DESCRIPTION
This provides a reproduction of (internal) https://github.com/cockroachlabs/support/issues/1520.

Usage:

```
./run.sh

# wait for all replicas to have upreplicated, 1-2 minutes

pkill -HUP cockroach

# liveness should go dark, cluster unavailable
# search for the log line "deadlocking liveness leaseholder"
# and note the nodeID. Upon killing that node, the cluster
# will be healthy again.
```

Release note: None
