### PR TITLE
sql,*: remove PlanningCtx.ctx

### DIFF
--- a/pkg/ccl/backupccl/backup_processor_planning.go
+++ b/pkg/ccl/backupccl/backup_processor_planning.go
@@ -52,13 +52,13 @@ func distBackupPlanSpecs(
 	var introducedSpanPartitions []sql.SpanPartition
 	var err error
 	if len(spans) > 0 {
-		spanPartitions, err = dsp.PartitionSpans(planCtx, spans)
+		spanPartitions, err = dsp.PartitionSpans(ctx, planCtx, spans)
 		if err != nil {
 			return nil, err
 		}
 	}
 	if len(introducedSpans) > 0 {
-		introducedSpanPartitions, err = dsp.PartitionSpans(planCtx, introducedSpans)
+		introducedSpanPartitions, err = dsp.PartitionSpans(ctx, planCtx, introducedSpans)
 		if err != nil {
 			return nil, err
 		}
@@ -206,6 +206,6 @@ func distBackup(
 	defer close(progCh)
 	// Copy the evalCtx, as dsp.Run() might change it.
 	evalCtxCopy := *evalCtx
-	dsp.Run(planCtx, noTxn, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
+	dsp.Run(ctx, planCtx, noTxn, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
 	return rowResultWriter.Err()
 }

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -232,7 +232,7 @@ func distRestore(
 
 	// Copy the evalCtx, as dsp.Run() might change it.
 	evalCtxCopy := *evalCtx
-	dsp.Run(planCtx, noTxn, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
+	dsp.Run(ctx, planCtx, noTxn, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
 	return rowResultWriter.Err()
 }
 

--- a/pkg/ccl/changefeedccl/changefeeddist/distflow.go
+++ b/pkg/ccl/changefeedccl/changefeeddist/distflow.go
@@ -57,7 +57,7 @@ func StartDistChangefeed(
 	} else {
 		// All other feeds get a ChangeAggregator local on the leaseholder.
 		var err error
-		spanPartitions, err = dsp.PartitionSpans(planCtx, trackedSpans)
+		spanPartitions, err = dsp.PartitionSpans(ctx, planCtx, trackedSpans)
 		if err != nil {
 			return err
 		}
@@ -150,7 +150,7 @@ func StartDistChangefeed(
 
 	// Copy the evalCtx, as dsp.Run() might change it.
 	evalCtxCopy := *evalCtx
-	dsp.Run(planCtx, noTxn, p, recv, &evalCtxCopy, finishedSetupFn)()
+	dsp.Run(ctx, planCtx, noTxn, p, recv, &evalCtxCopy, finishedSetupFn)()
 	return resultRows.Err()
 }
 

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
@@ -156,7 +156,7 @@ func distStreamIngest(
 
 	// Copy the evalCtx, as dsp.Run() might change it.
 	evalCtxCopy := *evalCtx
-	dsp.Run(planCtx, noTxn, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
+	dsp.Run(ctx, planCtx, noTxn, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
 	return rw.Err()
 }
 

--- a/pkg/ccl/streamingccl/streamproducer/stream_lifetime.go
+++ b/pkg/ccl/streamingccl/streamproducer/stream_lifetime.go
@@ -244,7 +244,7 @@ func getReplicationStreamSpec(
 	for _, span := range replicatedSpans {
 		spans = append(spans, *span)
 	}
-	spanPartitions, err := dsp.PartitionSpans(planCtx, spans)
+	spanPartitions, err := dsp.PartitionSpans(evalCtx.Ctx(), planCtx, spans)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -980,7 +980,7 @@ func (sc *SchemaChanger) distIndexBackfill(
 		if err != nil {
 			return err
 		}
-		p, err = sc.distSQLPlanner.createBackfillerPhysicalPlan(planCtx, spec, todoSpans)
+		p, err = sc.distSQLPlanner.createBackfillerPhysicalPlan(ctx, planCtx, spec, todoSpans)
 		return err
 	}); err != nil {
 		return err
@@ -1152,6 +1152,7 @@ func (sc *SchemaChanger) distIndexBackfill(
 		// Copy the evalCtx, as dsp.Run() might change it.
 		evalCtxCopy := evalCtx
 		sc.distSQLPlanner.Run(
+			ctx,
 			planCtx,
 			nil, /* txn - the processors manage their own transactions */
 			p, recv, &evalCtxCopy,
@@ -1273,11 +1274,12 @@ func (sc *SchemaChanger) distColumnBackfill(
 			if err != nil {
 				return err
 			}
-			plan, err := sc.distSQLPlanner.createBackfillerPhysicalPlan(planCtx, spec, todoSpans)
+			plan, err := sc.distSQLPlanner.createBackfillerPhysicalPlan(ctx, planCtx, spec, todoSpans)
 			if err != nil {
 				return err
 			}
 			sc.distSQLPlanner.Run(
+				ctx,
 				planCtx,
 				nil, /* txn - the processors manage their own transactions */
 				plan, recv, &evalCtx,

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -914,7 +914,8 @@ func TestPartitionSpans(t *testing.T) {
 				codec: keys.SystemSQLCodec,
 			}
 
-			planCtx := dsp.NewPlanningCtx(context.Background(), &extendedEvalContext{
+			ctx := context.Background()
+			planCtx := dsp.NewPlanningCtx(ctx, &extendedEvalContext{
 				EvalContext: tree.EvalContext{Codec: keys.SystemSQLCodec},
 			}, nil, nil, DistributionTypeSystemTenantOnly)
 			var spans []roachpb.Span
@@ -922,7 +923,7 @@ func TestPartitionSpans(t *testing.T) {
 				spans = append(spans, roachpb.Span{Key: roachpb.Key(s[0]), EndKey: roachpb.Key(s[1])})
 			}
 
-			partitions, err := dsp.PartitionSpans(planCtx, spans)
+			partitions, err := dsp.PartitionSpans(ctx, planCtx, spans)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1099,10 +1100,11 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 				codec: keys.SystemSQLCodec,
 			}
 
-			planCtx := dsp.NewPlanningCtx(context.Background(), &extendedEvalContext{
+			ctx := context.Background()
+			planCtx := dsp.NewPlanningCtx(ctx, &extendedEvalContext{
 				EvalContext: tree.EvalContext{Codec: keys.SystemSQLCodec},
 			}, nil, nil, DistributionTypeSystemTenantOnly)
-			partitions, err := dsp.PartitionSpans(planCtx, roachpb.Spans{span})
+			partitions, err := dsp.PartitionSpans(ctx, planCtx, roachpb.Spans{span})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1199,10 +1201,11 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 		codec: keys.SystemSQLCodec,
 	}
 
-	planCtx := dsp.NewPlanningCtx(context.Background(), &extendedEvalContext{
+	ctx := context.Background()
+	planCtx := dsp.NewPlanningCtx(ctx, &extendedEvalContext{
 		EvalContext: tree.EvalContext{Codec: keys.SystemSQLCodec},
 	}, nil, nil, DistributionTypeSystemTenantOnly)
-	partitions, err := dsp.PartitionSpans(planCtx, roachpb.Spans{span})
+	partitions, err := dsp.PartitionSpans(ctx, planCtx, roachpb.Spans{span})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/distsql_plan_backfill.go
+++ b/pkg/sql/distsql_plan_backfill.go
@@ -11,6 +11,7 @@
 package sql
 
 import (
+	"context"
 	"time"
 	"unsafe"
 
@@ -72,9 +73,9 @@ func initIndexBackfillMergerSpec(
 // processors, one for each node that has spans that we are reading. The plan is
 // finalized.
 func (dsp *DistSQLPlanner) createBackfillerPhysicalPlan(
-	planCtx *PlanningCtx, spec execinfrapb.BackfillerSpec, spans []roachpb.Span,
+	ctx context.Context, planCtx *PlanningCtx, spec execinfrapb.BackfillerSpec, spans []roachpb.Span,
 ) (*PhysicalPlan, error) {
-	spanPartitions, err := dsp.PartitionSpans(planCtx, spans)
+	spanPartitions, err := dsp.PartitionSpans(ctx, planCtx, spans)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +108,10 @@ func (dsp *DistSQLPlanner) createBackfillerPhysicalPlan(
 // of index merger processors, one for each node that has spans that
 // we are reading. The plan is finalized.
 func (dsp *DistSQLPlanner) createIndexBackfillerMergePhysicalPlan(
-	planCtx *PlanningCtx, spec execinfrapb.IndexBackfillMergerSpec, spans [][]roachpb.Span,
+	ctx context.Context,
+	planCtx *PlanningCtx,
+	spec execinfrapb.IndexBackfillMergerSpec,
+	spans [][]roachpb.Span,
 ) (*PhysicalPlan, error) {
 
 	var n int
@@ -140,7 +144,7 @@ func (dsp *DistSQLPlanner) createIndexBackfillerMergePhysicalPlan(
 		return idx
 	}
 
-	spanPartitions, err := dsp.PartitionSpans(planCtx, indexSpans)
+	spanPartitions, err := dsp.PartitionSpans(ctx, planCtx, indexSpans)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/distsql_plan_bulk.go
+++ b/pkg/sql/distsql_plan_bulk.go
@@ -50,7 +50,7 @@ func (dsp *DistSQLPlanner) setupAllNodesPlanningSystem(
 	// planCtx.NodeStatuses map ourselves. CheckInstanceHealthAndVersion() will
 	// populate it.
 	for _, node := range resp.Nodes {
-		_ /* NodeStatus */ = dsp.CheckInstanceHealthAndVersion(planCtx, base.SQLInstanceID(node.Desc.NodeID))
+		_ /* NodeStatus */ = dsp.CheckInstanceHealthAndVersion(ctx, planCtx, base.SQLInstanceID(node.Desc.NodeID))
 	}
 	nodes := make([]base.SQLInstanceID, 0, len(planCtx.NodeStatuses))
 	for nodeID, status := range planCtx.NodeStatuses {

--- a/pkg/sql/distsql_plan_ctas.go
+++ b/pkg/sql/distsql_plan_ctas.go
@@ -39,7 +39,7 @@ func PlanAndRunCTAS(
 		txn, distribute)
 	planCtx.stmtType = tree.Rows
 
-	physPlan, cleanup, err := dsp.createPhysPlan(planCtx, in)
+	physPlan, cleanup, err := dsp.createPhysPlan(ctx, planCtx, in)
 	defer cleanup()
 	if err != nil {
 		recv.SetError(errors.Wrapf(err, "constructing distSQL plan"))
@@ -55,5 +55,5 @@ func PlanAndRunCTAS(
 	// Make copy of evalCtx as Run might modify it.
 	evalCtxCopy := planner.ExtendedEvalContextCopy()
 	dsp.FinalizePlan(planCtx, physPlan)
-	dsp.Run(planCtx, txn, physPlan, recv, evalCtxCopy, nil /* finishedSetupFn */)()
+	dsp.Run(ctx, planCtx, txn, physPlan, recv, evalCtxCopy, nil /* finishedSetupFn */)()
 }

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -134,7 +134,9 @@ func (e *distSQLSpecExecFactory) ConstructValues(
 			specifiedInQuery: true,
 		}
 		planNodesToClose = []planNode{v}
-		physPlan, err = e.dsp.wrapPlan(planCtx, v, e.planningMode != distSQLLocalOnlyPlanning)
+		// TODO: don't use a stored context.
+		ctx := planCtx.EvalContext().Context
+		physPlan, err = e.dsp.wrapPlan(ctx, planCtx, v, e.planningMode != distSQLLocalOnlyPlanning)
 	} else {
 		// We can create a spec for the values processor, so we don't create a
 		// valuesNode.
@@ -163,7 +165,10 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 		return constructVirtualScan(
 			e, e.planner, table, index, params, reqOrdering,
 			func(d *delayedNode) (exec.Node, error) {
-				physPlan, err := e.dsp.wrapPlan(e.getPlanCtx(cannotDistribute), d, e.planningMode != distSQLLocalOnlyPlanning)
+				planCtx := e.getPlanCtx(cannotDistribute)
+				// TODO: don't use a stored context.
+				ctx := planCtx.EvalContext().Context
+				physPlan, err := e.dsp.wrapPlan(ctx, planCtx, d, e.planningMode != distSQLLocalOnlyPlanning)
 				if err != nil {
 					return nil, err
 				}
@@ -271,6 +276,7 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 	}
 
 	err = e.dsp.planTableReaders(
+		planCtx.EvalContext().Context, // TODO: don't use a stored context.
 		e.getPlanCtx(recommendation),
 		p,
 		&tableReaderPlanningInfo{
@@ -903,7 +909,8 @@ func (e *distSQLSpecExecFactory) ConstructExplain(
 		}
 	}
 
-	physPlan, err := e.dsp.wrapPlan(e.getPlanCtx(cannotDistribute), explainNode, e.planningMode != distSQLLocalOnlyPlanning)
+	planCtx := e.getPlanCtx(cannotDistribute)
+	physPlan, err := e.dsp.wrapPlan(planCtx.EvalContext().Context, planCtx, explainNode, e.planningMode != distSQLLocalOnlyPlanning)
 	if err != nil {
 		return nil, err
 	}
@@ -1043,7 +1050,8 @@ func (e *distSQLSpecExecFactory) ConstructOpaque(metadata opt.OpaqueMetadata) (e
 	if err != nil {
 		return nil, err
 	}
-	physPlan, err := e.dsp.wrapPlan(e.getPlanCtx(cannotDistribute), plan, e.planningMode != distSQLLocalOnlyPlanning)
+	planCtx := e.getPlanCtx(cannotDistribute)
+	physPlan, err := e.dsp.wrapPlan(planCtx.EvalContext().Context, planCtx, plan, e.planningMode != distSQLLocalOnlyPlanning)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -71,7 +71,7 @@ func (e *explainPlanNode) startExec(params runParams) error {
 		defer func() {
 			planCtx.planner.curPlan.subqueryPlans = outerSubqueries
 		}()
-		physicalPlan, err := newPhysPlanForExplainPurposes(planCtx, distSQLPlanner, plan.main)
+		physicalPlan, err := newPhysPlanForExplainPurposes(params.ctx, planCtx, distSQLPlanner, plan.main)
 		var diagramURL url.URL
 		var diagramJSON string
 		if err != nil {
@@ -239,12 +239,12 @@ func (e *explainPlanNode) Close(ctx context.Context) {
 }
 
 func newPhysPlanForExplainPurposes(
-	planCtx *PlanningCtx, distSQLPlanner *DistSQLPlanner, plan planMaybePhysical,
+	ctx context.Context, planCtx *PlanningCtx, distSQLPlanner *DistSQLPlanner, plan planMaybePhysical,
 ) (*PhysicalPlan, error) {
 	if plan.isPhysicalPlan() {
 		return plan.physPlan.PhysicalPlan, nil
 	}
-	physPlan, err := distSQLPlanner.createPhysPlanForPlanNode(planCtx, plan.planNode)
+	physPlan, err := distSQLPlanner.createPhysPlanForPlanNode(ctx, planCtx, plan.planNode)
 	// Release the resources right away since we won't be running the plan.
 	planCtx.getCleanupFunc()()
 	return physPlan, err

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -51,7 +51,7 @@ func (n *explainVecNode) startExec(params runParams) error {
 	defer func() {
 		planCtx.planner.curPlan.subqueryPlans = outerSubqueries
 	}()
-	physPlan, err := newPhysPlanForExplainPurposes(planCtx, distSQLPlanner, n.plan.main)
+	physPlan, err := newPhysPlanForExplainPurposes(params.ctx, planCtx, distSQLPlanner, n.plan.main)
 	if err != nil {
 		if len(n.plan.subqueryPlans) > 0 {
 			return errors.New("running EXPLAIN (VEC) on this query is " +

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -213,7 +213,7 @@ func distImport(
 		defer close(stopProgress)
 		// Copy the evalCtx, as dsp.Run() might change it.
 		evalCtxCopy := *evalCtx
-		dsp.Run(planCtx, nil, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
+		dsp.Run(ctx, planCtx, nil, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
 		return rowResultWriter.Err()
 	})
 

--- a/pkg/sql/index_backfiller.go
+++ b/pkg/sql/index_backfiller.go
@@ -180,7 +180,7 @@ func (ib *IndexBackfillPlanner) plan(
 		if err != nil {
 			return err
 		}
-		p, err = ib.execCfg.DistSQLPlanner.createBackfillerPhysicalPlan(planCtx, spec, sourceSpans)
+		p, err = ib.execCfg.DistSQLPlanner.createBackfillerPhysicalPlan(ctx, planCtx, spec, sourceSpans)
 		return err
 	}); err != nil {
 		return nil, err
@@ -201,7 +201,7 @@ func (ib *IndexBackfillPlanner) plan(
 		)
 		defer recv.Release()
 		evalCtxCopy := evalCtx
-		ib.execCfg.DistSQLPlanner.Run(planCtx, nil, p, recv, &evalCtxCopy, nil)()
+		ib.execCfg.DistSQLPlanner.Run(ctx, planCtx, nil, p, recv, &evalCtxCopy, nil)()
 		return cbw.Err()
 	}, nil
 }

--- a/pkg/sql/mvcc_backfiller.go
+++ b/pkg/sql/mvcc_backfiller.go
@@ -70,7 +70,7 @@ func (im *IndexBackfillerMergePlanner) plan(
 		if err != nil {
 			return err
 		}
-		p, err = im.execCfg.DistSQLPlanner.createIndexBackfillerMergePhysicalPlan(planCtx, spec, todoSpanList)
+		p, err = im.execCfg.DistSQLPlanner.createIndexBackfillerMergePhysicalPlan(ctx, planCtx, spec, todoSpanList)
 		return err
 	}); err != nil {
 		return nil, err
@@ -92,6 +92,7 @@ func (im *IndexBackfillerMergePlanner) plan(
 		defer recv.Release()
 		evalCtxCopy := evalCtx
 		im.execCfg.DistSQLPlanner.Run(
+			ctx,
 			planCtx,
 			nil, /* txn - the processors manage their own transactions */
 			p, recv, &evalCtxCopy,


### PR DESCRIPTION
There are many places in the codebase where `planningCtx`s are passed between
goroutines and/or used inside closures that then have different (perhaps cancel-enabled) 
contexts in scope. In such cases, using the previously stored `planningCtx.ctx` ends up 
creating a bug, in that the code using it ignores the potentially cancelled context from 
where it was actually called. This is particularly true of most of the bulk flows which call 
`dsp.Run` in one of several `ctxgroup` tasks, others of which can fail and cancel the group's
context.

Instead, this change removes the ctx field and follows the golden rule of never store
a context.

Release note (bug fix): fix some cases where a job or schema change that had encountered an
error would continue to execute for some time before eventually failing.