### PR TITLE
release-21.1: workload/schemachange: disable schemachange/random-load workload

### DIFF
--- a/pkg/cmd/roachtest/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/schemachange_random_load.go
@@ -78,6 +78,10 @@ func registerRandomLoadBenchSpec(r *testRegistry, b randomLoadBenchSpec) {
 		// fix (or bypass) minor schema change bugs that are discovered.
 		NonReleaseBlocker: true,
 		Run: func(ctx context.Context, t *test, c *cluster) {
+			// The schemachange workload is extremely noisy in 21.2, so we are going
+			// leave it disabled until the workload gets fully stabilized in then next
+			// release (via epic: CRDB-13725).
+			t.Skip("disabled in 21.1 since schemachange workload is not stable")
 			runSchemaChangeRandomLoad(ctx, t, c, b.Ops, b.Concurrency)
 		},
 	})


### PR DESCRIPTION
Previously, the schemachange workload was enabled on 21.1,
but due to a number of test issues could lead to flaky
failures. This was inadequate because it created tons of
noise for developers to investigate. To address this,
this patch will disable this test in 21.1. Releases
after 22.1 have the required fixes to make this test
stable.

Release note: None
Release justification: low only disabling a flaky test