### PR TITLE
WORKSPACE: update rules_go version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,12 +13,12 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Load go bazel tools. This gives us access to the go bazel SDK/toolchains.
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "a80c384a85ab9f6318419ed38a39b13e8481e9d2ea25a696ea9e25438e017b5f",
-    strip_prefix = "cockroachdb-rules_go-f96cc04",
+    sha256 = "8a993815a6a7cfe47e46238383f0e36a80b9ce0ac482f855c7288a31565b5661",
+    strip_prefix = "cockroachdb-rules_go-58cb947",
     urls = [
-        # cockroachdb/rules_go as of f96cc0445102a7b08bceeb0bba32b4d82467a065
+        # cockroachdb/rules_go as of 58cb94707783f529462d4c6d3c698933a1022942
         # (upstream release-0.29 plus a few patches).
-        "https://storage.googleapis.com/public-bazel-artifacts/bazel/cockroachdb-rules_go-v0.27.0-54-gf96cc04.tar.gz",
+        "https://storage.googleapis.com/public-bazel-artifacts/bazel/cockroachdb-rules_go-v0.27.0-56-g58cb947.tar.gz",
     ],
 )
 


### PR DESCRIPTION
The rules_go version has been bumped to accept the new changes from
cockroachdb/rules_go#5.

Finishing blow for #76377.

Release note: None