### PR TITLE
backupccl: add deprecation notice for backup commands that store backups in non time based subdirectories

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/feature-flags
+++ b/pkg/ccl/backupccl/testdata/backup-restore/feature-flags
@@ -75,7 +75,7 @@ NOTICE: The `BACKUP TO` syntax will be removed in a future release, please switc
 exec-sql
 BACKUP INTO 'deprecatedExplicitSubdir' IN 'nodelocal://1/deprecated';
 ----
-NOTICE: BACKUP commands with an explicitly specified subdirectory will be removed in a future release. Users can create a full backup via `BACKUP ... INTO <collectionURI>`, or an incremental backup on the latest full backup in their collection via `BACKUP ... INTO LATEST IN <collectionURI>`
+NOTICE: BACKUP commands with a non time based subdirectory will be removed in a future release. Users can create a full backup via `BACKUP ... INTO <collectionURI>` or an incremental backup to the latest full backup in their collection via `BACKUP ... INTO LATEST IN <collectionURI>` or to a specific time based subdirectory `BACKUP INTO 2021/03/23-213101.37 IN <collectionURI>`
 
 exec-sql
 DROP TABLE d.t;


### PR DESCRIPTION
Release note (sql change): #79447 mistakingly warned users that
explicit time based backup subdirectories were deprecated. CRDB still welcomes
these! Non time based subdirectories will be deprecated.

Informs #79672 