### PR TITLE
jobs: reset claim session ID when adoption is disabled

### DIFF
--- a/pkg/jobs/helpers_test.go
+++ b/pkg/jobs/helpers_test.go
@@ -122,7 +122,7 @@ const (
 	AdoptQuery                     = claimQuery
 	CancelQuery                    = pauseAndCancelUpdate
 	GcQuery                        = expiredJobsQuery
-	RemoveClaimsQuery              = removeClaimsQuery
+	RemoveClaimsQuery              = removeClaimsForDeadSessionsQuery
 	ProcessJobsQuery               = processQueryWithBackoff
 	IntervalBaseSettingKey         = intervalBaseSettingKey
 	AdoptIntervalSettingKey        = adoptIntervalSettingKey


### PR DESCRIPTION
This change fixes a bug where a registry that has its job adoption
disabled was not clearing the `claim_sesssion_id` for jobs that
it had already claimed, before cancelling them. This meant that other
registries in the cluster were unable to claim and run these jobs.

This change also makes it such that a registry with disabled job
adoption does not claim any new jobs.

Release note: None