### PR TITLE
dev: address paper cuts and improve `dev <cmd> -h` consistency

### DIFF
--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -43,7 +43,7 @@ func makeBuildCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Com
 		Short: "Build the specified binaries",
 		Long: fmt.Sprintf(
 			"Build the specified binaries either using their bazel targets or one "+
-				"of the following shorthands:\n\t%s",
+				"of the following shorthands:\n\n\t%s",
 			strings.Join(allBuildTargets, "\n\t"),
 		),
 		// TODO(irfansharif): Flesh out the example usage patterns.
@@ -55,11 +55,7 @@ func makeBuildCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Com
 		RunE: runE,
 	}
 	buildCmd.Flags().String(volumeFlag, "bzlhome", "the Docker volume to use as the container home directory (only used for cross builds)")
-	buildCmd.Flags().String(crossFlag, "", `
-        Turns on cross-compilation. Builds the binary using the builder image w/ Docker.
-        You can optionally set a config, as in --cross=windows.
-        Defaults to linux if not specified. The config should be the name of a
-        build configuration specified in .bazelrc, minus the "cross" prefix.`)
+	buildCmd.Flags().String(crossFlag, "", "cross-compiles using the builder image (options: linux, linuxarm, macos, macosarm, windows)")
 	buildCmd.Flags().Lookup(crossFlag).NoOptDefVal = "linux"
 	addCommonBuildFlags(buildCmd)
 	return buildCmd

--- a/pkg/cmd/dev/testdata/datadriven/generate
+++ b/pkg/cmd/dev/testdata/datadriven/generate
@@ -16,3 +16,24 @@ bazel info workspace --color=no
 export COCKROACH_BAZEL_CAN_MIRROR=1
 export COCKROACH_BAZEL_FORCE_GENERATE=1
 crdb-checkout/build/bazelutil/bazel-generate.sh
+
+exec
+dev generate go
+----
+bazel run //pkg/gen:code
+
+exec
+dev generate docs
+----
+bazel run //pkg/gen:docs
+bazel info workspace --color=no
+crdb-checkout/build/bazelutil/generate_redact_safe.sh
+echo "" > crdb-checkout/docs/generated/redact_safe.md
+
+exec
+dev gen go docs
+----
+bazel run //pkg/gen
+bazel info workspace --color=no
+crdb-checkout/build/bazelutil/generate_redact_safe.sh
+echo "" > crdb-checkout/docs/generated/redact_safe.md

--- a/pkg/cmd/dev/testdata/datadriven/test
+++ b/pkg/cmd/dev/testdata/datadriven/test
@@ -16,7 +16,7 @@ bazel test pkg/util/tracing:all --test_env=GOTRACEBACK=all '--test_filter=TestSt
 exec
 dev test pkg/util/tracing -f TestStartChild* -v --show-logs
 ----
-bazel test pkg/util/tracing:all --test_env=GOTRACEBACK=all '--test_filter=TestStartChild*' --test_sharding_strategy=disabled --test_arg -test.v --test_arg -show-logs --test_output all
+bazel test pkg/util/tracing:all --test_env=GOTRACEBACK=all '--test_filter=TestStartChild*' --test_arg -test.v --test_arg -show-logs --test_sharding_strategy=disabled --test_output all
 
 exec
 dev test pkg/util/tracing -f TestStartChild* --ignore-cache
@@ -26,7 +26,7 @@ bazel test pkg/util/tracing:all --nocache_test_results --test_env=GOTRACEBACK=al
 exec
 dev test --stress pkg/util/tracing --filter TestStartChild* --cpus=12 --timeout=25s
 ----
-bazel test --local_cpu_resources=12 --test_sharding_strategy=disabled pkg/util/tracing:all --test_env=GOTRACEBACK=all --test_timeout=85 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' -maxtime=25s -p=12' '--test_filter=TestStartChild*' --test_sharding_strategy=disabled --test_output streamed
+bazel test --local_cpu_resources=12 pkg/util/tracing:all --test_env=GOTRACEBACK=all --test_timeout=85 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' -maxtime=25s -p=12' '--test_filter=TestStartChild*' --test_sharding_strategy=disabled --test_output streamed
 
 exec
 dev test //pkg/testutils --timeout=10s
@@ -67,12 +67,12 @@ exec
 dev test pkg/cmd/dev -f TestDataDriven/test --rewrite -v
 ----
 bazel info workspace --color=no
-bazel test pkg/cmd/dev:all --nocache_test_results --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/cmd/dev --test_filter=TestDataDriven/test --test_sharding_strategy=disabled --test_arg -test.v --test_output all
+bazel test pkg/cmd/dev:all --nocache_test_results --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/cmd/dev --test_filter=TestDataDriven/test --test_arg -test.v --test_sharding_strategy=disabled --test_output all
 
 exec
 dev test pkg/server -f=TestSpanStatsResponse -v --count=5 --vmodule=raft=1
 ----
-bazel test pkg/server:all --test_env=GOTRACEBACK=all --test_filter=TestSpanStatsResponse --test_sharding_strategy=disabled --test_arg -test.v --test_arg -test.count=5 --test_arg -vmodule=raft=1 --test_output all
+bazel test pkg/server:all --test_env=GOTRACEBACK=all --test_filter=TestSpanStatsResponse --test_arg -test.v --test_arg -test.count=5 --test_arg -vmodule=raft=1 --test_sharding_strategy=disabled --test_output all
 
 exec
 dev test --short
@@ -83,20 +83,41 @@ exec
 dev test pkg/kv/kvserver -f TestStoreRangeSplitMergeGeneration --test-args '-test.memprofile=mem.out'
 ----
 bazel info workspace --color=no
-bazel test pkg/kv/kvserver:all --test_env=GOTRACEBACK=all --test_filter=TestStoreRangeSplitMergeGeneration --test_sharding_strategy=disabled --test_arg -test.outputdir=crdb-checkout --sandbox_writable_path=crdb-checkout --test_arg -test.memprofile=mem.out --test_output errors
+bazel test pkg/kv/kvserver:all --test_env=GOTRACEBACK=all --test_filter=TestStoreRangeSplitMergeGeneration --test_arg -test.outputdir=crdb-checkout --sandbox_writable_path=crdb-checkout --test_arg -test.memprofile=mem.out --test_sharding_strategy=disabled --test_output errors
 
 exec
 dev test pkg/ccl/logictestccl -f=TestTenantLogic/3node-tenant/system -v --rewrite
 ----
 bazel info workspace --color=no
-bazel test pkg/ccl/logictestccl:all --nocache_test_results --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/ccl/logictestccl --sandbox_writable_path=crdb-checkout/pkg/sql/logictest --test_filter=TestTenantLogic/3node-tenant/system --test_sharding_strategy=disabled --test_arg -test.v --test_output all
+bazel test pkg/ccl/logictestccl:all --nocache_test_results --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/ccl/logictestccl --sandbox_writable_path=crdb-checkout/pkg/sql/logictest --test_filter=TestTenantLogic/3node-tenant/system --test_arg -test.v --test_sharding_strategy=disabled --test_output all
 
 exec
 dev test pkg/spanconfig/spanconfigkvsubscriber -f=TestDecodeSpanTargets -v --stream-output
 ----
-bazel test pkg/spanconfig/spanconfigkvsubscriber:all --test_env=GOTRACEBACK=all --test_filter=TestDecodeSpanTargets --test_sharding_strategy=disabled --test_arg -test.v --test_output streamed
+bazel test pkg/spanconfig/spanconfigkvsubscriber:all --test_env=GOTRACEBACK=all --test_filter=TestDecodeSpanTargets --test_arg -test.v --test_sharding_strategy=disabled --test_output streamed
 
 exec
 dev test pkg/sql/schemachanger pkg/sql/schemachanger/scplan -- --test_sharding_strategy=disabled
 ----
 bazel test pkg/sql/schemachanger:all pkg/sql/schemachanger/scplan:all --test_env=GOTRACEBACK=all --test_output errors --test_sharding_strategy=disabled
+
+exec
+dev test
+----
+bazel test //pkg:all_tests --test_env=GOTRACEBACK=all --test_output errors
+
+exec
+dev test pkg/...
+----
+bazel test //pkg:all_tests --test_env=GOTRACEBACK=all --test_output errors
+
+exec
+dev test pkg/spanconfig/... pkg/ccl/spanconfigccl/...
+----
+bazel test pkg/spanconfig/...:all pkg/ccl/spanconfigccl/...:all --test_env=GOTRACEBACK=all --test_output errors
+
+exec
+dev test pkg/sql/schemachanger --rewrite -v
+----
+bazel info workspace --color=no
+bazel test pkg/sql/schemachanger:all --nocache_test_results --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/sql/schemachanger --test_arg -test.v --test_sharding_strategy=disabled --test_output all


### PR DESCRIPTION
- Disable test sharding under --rewrite; sharded package test runners
  can trample over one another when updating data files
- Generate cgo files with naked `dev gen`
- Remove the `dev gen go+docs` target but retain the fast path when both
  the `go` and `docs` targets are specified (`dev gen go docs` for e.g.)
- Remove the `all` and `all_tests` moniker for `dev test`, and retain
  the sanitized path when testing everything using `dev test pkg/...`.
  The latter syntax feels closer to the `go test` expansion.
- Edit some help text padding to wrap more cleanly in terminals

Release note: None