### PR TITLE
sql: session variable to allow multiple modification subqueries of table

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3204,6 +3204,10 @@ func (m *sessionDataMutator) SetExpectAndIgnoreNotVisibleColumnsInCopy(val bool)
 	m.data.ExpectAndIgnoreNotVisibleColumnsInCopy = val
 }
 
+func (m *sessionDataMutator) SetMultipleModificationsOfTable(val bool) {
+	m.data.MultipleModificationsOfTable = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4728,6 +4728,7 @@ enable_experimental_stream_replication                off
 enable_implicit_select_for_update                     on
 enable_implicit_transaction_for_batch_statements      on
 enable_insert_fast_path                               on
+enable_multiple_modifications_of_table                off
 enable_multiregion_placement_policy                   off
 enable_seqscan                                        on
 enable_super_regions                                  off

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4096,6 +4096,7 @@ enable_experimental_stream_replication                off                 NULL  
 enable_implicit_select_for_update                     on                  NULL      NULL        NULL        string
 enable_implicit_transaction_for_batch_statements      on                  NULL      NULL        NULL        string
 enable_insert_fast_path                               on                  NULL      NULL        NULL        string
+enable_multiple_modifications_of_table                off                 NULL      NULL        NULL        string
 enable_multiregion_placement_policy                   off                 NULL      NULL        NULL        string
 enable_seqscan                                        on                  NULL      NULL        NULL        string
 enable_super_regions                                  off                 NULL      NULL        NULL        string
@@ -4215,6 +4216,7 @@ enable_experimental_stream_replication                off                 NULL  
 enable_implicit_select_for_update                     on                  NULL  user     NULL      on                  on
 enable_implicit_transaction_for_batch_statements      on                  NULL  user     NULL      on                  on
 enable_insert_fast_path                               on                  NULL  user     NULL      on                  on
+enable_multiple_modifications_of_table                off                 NULL  user     NULL      off                 off
 enable_multiregion_placement_policy                   off                 NULL  user     NULL      off                 off
 enable_seqscan                                        on                  NULL  user     NULL      on                  on
 enable_super_regions                                  off                 NULL  user     NULL      off                 off
@@ -4330,6 +4332,7 @@ enable_experimental_stream_replication                NULL    NULL     NULL     
 enable_implicit_select_for_update                     NULL    NULL     NULL     NULL        NULL
 enable_implicit_transaction_for_batch_statements      NULL    NULL     NULL     NULL        NULL
 enable_insert_fast_path                               NULL    NULL     NULL     NULL        NULL
+enable_multiple_modifications_of_table                NULL    NULL     NULL     NULL        NULL
 enable_multiregion_placement_policy                   NULL    NULL     NULL     NULL        NULL
 enable_seqscan                                        NULL    NULL     NULL     NULL        NULL
 enable_super_regions                                  NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -56,6 +56,7 @@ enable_experimental_stream_replication                off
 enable_implicit_select_for_update                     on
 enable_implicit_transaction_for_batch_statements      on
 enable_insert_fast_path                               on
+enable_multiple_modifications_of_table                off
 enable_multiregion_placement_policy                   off
 enable_seqscan                                        on
 enable_super_regions                                  off

--- a/pkg/sql/logictest/testdata/logic_test/with
+++ b/pkg/sql/logictest/testdata/logic_test/with
@@ -997,6 +997,31 @@ EXPERIMENTAL SCRUB TABLE t WITH OPTIONS INDEX ALL
 statement ok
 RESET CLUSTER SETTING sql.multiple_modifications_of_table.enabled
 
+# Multiple mutations can also be explicitly allowed with a session setting.
+statement ok
+SET enable_multiple_modifications_of_table = true
+
+# Multiple updates of different rows in the same table.
+query II rowsort
+WITH
+  u1 AS (UPDATE t SET j = j - 40 WHERE i < 20 RETURNING *),
+  u2 AS (UPDATE t SET j = j + 40 WHERE i >= 20 RETURNING *)
+TABLE u1 UNION ALL TABLE u2
+----
+2 60
+4 60
+6 60
+8 60
+20 440
+
+# Check for corruption.
+query TTTTTTTT
+EXPERIMENTAL SCRUB TABLE t WITH OPTIONS INDEX ALL
+----
+
+statement ok
+RESET enable_multiple_modifications_of_table
+
 # Tests with multiple mutations on the same table, modifying the same
 # rows. These testcases vary the type of mutation and the form. All should fail
 # with an error. When issue 70731 is fixed, some might no longer fail.

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// TODO(michae2): Remove this when #70731 is fixed.
 var multipleModificationsOfTableEnabled = settings.RegisterBoolSetting(
 	settings.TenantWritable,
 	"sql.multiple_modifications_of_table.enabled",
@@ -493,7 +494,9 @@ func (b *Builder) checkMultipleMutations(tab cat.Table, simpleInsert bool) {
 	}
 	allSimpleInserts = allSimpleInserts && simpleInsert
 	b.areAllTableMutationsSimpleInserts[tab.ID()] = allSimpleInserts
-	if !allSimpleInserts && !multipleModificationsOfTableEnabled.Get(&b.evalCtx.Settings.SV) {
+	if !allSimpleInserts &&
+		!multipleModificationsOfTableEnabled.Get(&b.evalCtx.Settings.SV) &&
+		!b.evalCtx.SessionData().MultipleModificationsOfTable {
 		panic(pgerror.Newf(
 			pgcode.FeatureNotSupported,
 			"multiple modification subqueries of the same table %q are not supported unless "+

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -246,6 +246,10 @@ message LocalOnlySessionData {
   // (with no column name specifiers) to expect and ignore not visible column
   // fields.
   bool expect_and_ignore_not_visible_columns_in_copy = 67;
+  // MultipleModificationsOfTable allows statements containing multiple INSERT
+  // ON CONFLICT, UPSERT, UPDATE, or DELETE subqueries modifying the same table,
+  // at the risk of data corruption if the same row is modified multiple times.
+  bool multiple_modifications_of_table = 68;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2049,6 +2049,24 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalFalse,
 	},
+
+	// TODO(michae2): Remove this when #70731 is fixed.
+	// CockroachDB extension.
+	`enable_multiple_modifications_of_table`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`enable_multiple_modifications_of_table`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("enable_multiple_modifications_of_table", s)
+			if err != nil {
+				return err
+			}
+			m.SetMultipleModificationsOfTable(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().MultipleModificationsOfTable), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 const compatErrMsg = "this parameter is currently recognized only for compatibility and has no effect in CockroachDB."


### PR DESCRIPTION
Add a new session variable, enable_multiple_modifications_of_table,
which can be used instead of sql.multiple_modifications_of_table.enabled
to allow execution of statements with multiple modification subqueries
of the same table.

Instead of making the original cluster setting the GlobalDefault of this
new session setting, the original cluster setting is kept in the
optbuilder logic. This is to avoid breaking applications that are
already toggling the cluster setting mid-session to allow statements.

Fixes: #76261

Release note (sql change): Add a new session variable,
enable_multiple_modifications_of_table, which can be used instead of
cluster variable sql.multiple_modifications_of_table.enabled to allow
statements containing multiple INSERT ON CONFLICT, UPSERT, UPDATE, or
DELETE subqueries modifying the same table. Note that underlying issue
70731 is not fixed. As with sql.multiple_modifications_of_table.enabled,
be warned that with this session variable enabled there is nothing to
prevent the table corruption seen in issue 70731 from occuring if the
same row is modified multiple times by different subqueries of a single
statment. It's best to rewrite these statements, but the session
variable is provided as an aid if this is not possible.