### PR TITLE
sql/opt: split out row-level locking properties struct

### DIFF
--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -253,7 +253,7 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 	if err := rowenc.InitIndexFetchSpec(&trSpec.FetchSpec, e.planner.ExecCfg().Codec, tabDesc, idx, columnIDs); err != nil {
 		return nil, err
 	}
-	if params.Locking != nil {
+	if params.Locking.IsLocking() {
 		trSpec.LockingStrength = descpb.ToScanLockingStrength(params.Locking.Strength)
 		trSpec.LockingWaitPolicy = descpb.ToScanLockingWaitPolicy(params.Locking.WaitPolicy)
 		if trSpec.LockingStrength != descpb.ScanLockingStrength_FOR_NONE {
@@ -665,7 +665,7 @@ func (e *distSQLSpecExecFactory) ConstructLookupJoin(
 	isFirstJoinInPairedJoiner bool,
 	isSecondJoinInPairedJoiner bool,
 	reqOrdering exec.OutputOrdering,
-	locking *tree.LockingItem,
+	locking opt.Locking,
 	limitHint int64,
 ) (exec.Node, error) {
 	// TODO (rohany): Implement production of system columns by the underlying scan here.

--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -258,7 +258,7 @@ func constructVirtualScan(
 	if params.NeededCols.Contains(0) {
 		return nil, errors.Errorf("use of %s column not allowed.", table.Column(0).ColName())
 	}
-	if params.Locking != nil {
+	if params.Locking.IsLocking() {
 		// We shouldn't have allowed SELECT FOR UPDATE for a virtual table.
 		return nil, errors.AssertionFailedf("locking cannot be used with virtual table")
 	}

--- a/pkg/sql/opt/BUILD.bazel
+++ b/pkg/sql/opt/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "column_meta.go",
         "constants.go",
         "doc.go",
+        "locking.go",
         "metadata.go",
         "operator.go",
         "ordering.go",

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -934,7 +934,7 @@ func (b *Builder) canAutoCommit(rel memo.RelExpr) bool {
 // forUpdateLocking is the row-level locking mode used by mutations during their
 // initial row scan, when such locking is deemed desirable. The locking mode is
 // equivalent that used by a SELECT ... FOR UPDATE statement.
-var forUpdateLocking = &tree.LockingItem{Strength: tree.ForUpdate}
+var forUpdateLocking = opt.Locking{Strength: tree.ForUpdate}
 
 // shouldApplyImplicitLockingToMutationInput determines whether or not the
 // builder should apply a FOR UPDATE row-level locking mode to the initial row

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -570,7 +570,7 @@ func (b *Builder) scanParams(
 	}
 
 	// Raise error if row-level locking is part of a read-only transaction.
-	if locking != nil && locking.Strength > tree.ForNone && b.evalCtx.TxnReadOnly {
+	if locking.IsLocking() && b.evalCtx.TxnReadOnly {
 		return exec.ScanParams{}, opt.ColMap{}, pgerror.Newf(pgcode.ReadOnlySQLTransaction,
 			"cannot execute %s in a read-only transaction", locking.Strength.String())
 	}
@@ -1811,7 +1811,7 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 	tab := md.Table(join.Table)
 	idx := tab.Index(join.Index)
 
-	var locking *tree.LockingItem
+	var locking opt.Locking
 	if b.forceForUpdateLocking {
 		locking = forUpdateLocking
 	}

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
@@ -939,10 +940,7 @@ func (e *emitter) spansStr(table cat.Table, index cat.Index, scanParams exec.Sca
 	return sp.String()
 }
 
-func (e *emitter) emitLockingPolicy(locking *tree.LockingItem) {
-	if locking == nil {
-		return
-	}
+func (e *emitter) emitLockingPolicy(locking opt.Locking) {
 	strength := descpb.ToScanLockingStrength(locking.Strength)
 	waitPolicy := descpb.ToScanLockingWaitPolicy(locking.WaitPolicy)
 	if strength != descpb.ScanLockingStrength_FOR_NONE {

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/inverted"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -59,7 +60,7 @@ type ScanParams struct {
 	// scanned. It should not be set if there is a hard or soft limit.
 	Parallelize bool
 
-	Locking *tree.LockingItem
+	Locking opt.Locking
 
 	EstimatedRowCount float64
 

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -284,7 +284,7 @@ define LookupJoin {
     IsFirstJoinInPairedJoiner bool
     IsSecondJoinInPairedJoiner bool
     ReqOrdering exec.OutputOrdering
-    Locking *tree.LockingItem
+    Locking opt.Locking
     LimitHint int64
 }
 

--- a/pkg/sql/opt/locking.go
+++ b/pkg/sql/opt/locking.go
@@ -1,0 +1,52 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package opt
+
+import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+
+// Locking represents the row-level locking properties of a relational operator.
+// Each relational operator clause consist of two different row-level locking
+// properties.
+type Locking struct {
+	// The first property is locking strength (see tree.LockingStrength). Locking
+	// strength represents the degree of protection that a row-level lock provides.
+	// The stronger the lock, the more protection it provides for the lock holder
+	// but the more restrictive it is to concurrent transactions attempting to
+	// access the same row. In order from weakest to strongest, the lock strength
+	// variants are:
+	//
+	//   FOR KEY SHARE
+	//   FOR SHARE
+	//   FOR NO KEY UPDATE
+	//   FOR UPDATE
+	//
+	Strength tree.LockingStrength
+
+	// The second property is the locking wait policy (see tree.LockingWaitPolicy).
+	// A locking wait policy represents the policy a table scan uses to interact
+	// with row-level locks held by other transactions. Unlike locking strength,
+	// locking wait policy is optional to specify in a locking clause. If not
+	// specified, the policy defaults to blocking and waiting for locks to become
+	// available. The non-standard policies instruct scans to take other approaches
+	// to handling locks held by other transactions. These non-standard policies
+	// are:
+	//
+	//   SKIP LOCKED
+	//   NOWAIT
+	//
+	WaitPolicy tree.LockingWaitPolicy
+}
+
+// IsLocking returns whether the receiver is configured to use a row-level
+// locking mode.
+func (l Locking) IsLocking() bool {
+	return l.Strength != tree.ForNone
+}

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -679,7 +679,7 @@ func (s *ScanPrivate) IsVirtualTable(md *opt.Metadata) bool {
 // a SELECT .. FOR [KEY] UPDATE/SHARE clause or because the Scan was configured
 // as part of the row retrieval of a DELETE or UPDATE statement.
 func (s *ScanPrivate) IsLocking() bool {
-	return s.Locking != nil
+	return s.Locking.IsLocking()
 }
 
 // PartialIndexPredicate returns the FiltersExpr representing the predicate of

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -462,7 +462,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			}
 			tp.Child(b.String())
 		}
-		if private.Locking != nil {
+		if private.Locking.IsLocking() {
 			strength := ""
 			switch private.Locking.Strength {
 			case tree.ForNone:

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -635,11 +635,9 @@ func (h *hasher) HashPhysProps(val *physical.Required) {
 	}
 }
 
-func (h *hasher) HashLockingItem(val *tree.LockingItem) {
-	if val != nil {
-		h.HashByte(byte(val.Strength))
-		h.HashByte(byte(val.WaitPolicy))
-	}
+func (h *hasher) HashLocking(val opt.Locking) {
+	h.HashByte(byte(val.Strength))
+	h.HashByte(byte(val.WaitPolicy))
 }
 
 func (h *hasher) HashInvertedSpans(val inverted.Spans) {
@@ -1039,11 +1037,8 @@ func (h *hasher) IsPhysPropsEqual(l, r *physical.Required) bool {
 	return l.Equals(r)
 }
 
-func (h *hasher) IsLockingItemEqual(l, r *tree.LockingItem) bool {
-	if l == nil || r == nil {
-		return l == r
-	}
-	return l.Strength == r.Strength && l.WaitPolicy == r.WaitPolicy
+func (h *hasher) IsLockingEqual(l, r opt.Locking) bool {
+	return l == r
 }
 
 func (h *hasher) IsInvertedSpansEqual(l, r inverted.Spans) bool {

--- a/pkg/sql/opt/memo/interner_test.go
+++ b/pkg/sql/opt/memo/interner_test.go
@@ -447,26 +447,26 @@ func TestInterner(t *testing.T) {
 
 		// PhysProps hash/isEqual methods are tested in TestInternerPhysProps.
 
-		{hashFn: in.hasher.HashLockingItem, eqFn: in.hasher.IsLockingItemEqual, variations: []testVariation{
-			{val1: (*tree.LockingItem)(nil), val2: (*tree.LockingItem)(nil), equal: true},
+		{hashFn: in.hasher.HashLocking, eqFn: in.hasher.IsLockingEqual, variations: []testVariation{
+			{val1: opt.Locking{}, val2: opt.Locking{}, equal: true},
 			{
-				val1:  (*tree.LockingItem)(nil),
-				val2:  &tree.LockingItem{Strength: tree.ForUpdate},
+				val1:  opt.Locking{},
+				val2:  opt.Locking{Strength: tree.ForUpdate},
 				equal: false,
 			},
 			{
-				val1:  &tree.LockingItem{Strength: tree.ForShare},
-				val2:  &tree.LockingItem{Strength: tree.ForUpdate},
+				val1:  opt.Locking{Strength: tree.ForShare},
+				val2:  opt.Locking{Strength: tree.ForUpdate},
 				equal: false,
 			},
 			{
-				val1:  &tree.LockingItem{WaitPolicy: tree.LockWaitSkip},
-				val2:  &tree.LockingItem{WaitPolicy: tree.LockWaitError},
+				val1:  opt.Locking{WaitPolicy: tree.LockWaitSkip},
+				val2:  opt.Locking{WaitPolicy: tree.LockWaitError},
 				equal: false,
 			},
 			{
-				val1:  &tree.LockingItem{Strength: tree.ForUpdate, WaitPolicy: tree.LockWaitError},
-				val2:  &tree.LockingItem{Strength: tree.ForUpdate, WaitPolicy: tree.LockWaitError},
+				val1:  opt.Locking{Strength: tree.ForUpdate, WaitPolicy: tree.LockWaitError},
+				val2:  opt.Locking{Strength: tree.ForUpdate, WaitPolicy: tree.LockWaitError},
 				equal: true,
 			},
 		}},

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -74,7 +74,7 @@ func (b *logicalPropsBuilder) buildScanProps(scan *ScanExpr, rel *props.Relation
 	// Side Effects
 	// ------------
 	// A Locking option is a side-effect (we don't want to elide this scan).
-	if scan.Locking != nil {
+	if scan.Locking.IsLocking() {
 		rel.VolatilitySet.AddVolatile()
 	}
 

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -128,7 +128,7 @@ WHERE a.y>1 AND a.x::string=b.x
 ORDER BY y
 LIMIT 10
 ----
-memo (optimized, ~24KB, required=[presentation: y:2,x:5,c:10] [ordering: +2])
+memo (optimized, ~23KB, required=[presentation: y:2,x:5,c:10] [ordering: +2])
  ├── G1: (project G2 G3 y x)
  │    ├── [presentation: y:2,x:5,c:10] [ordering: +2]
  │    │    ├── best: (project G2="[ordering: +2]" G3 y x)

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -73,9 +73,14 @@ define ScanPrivate {
     # leave this unset (Strength = ForNone), which indicates that no row-level
     # locking will be performed while scanning the table. Stronger locking modes
     # are used by SELECT .. FOR [KEY] UPDATE/SHARE statements and by the initial
-    # row retrieval of DELETE and UPDATE statements. The locking item's Targets
-    # list will always be empty when part of a ScanPrivate.
-    Locking LockingItem
+    # row retrieval of DELETE and UPDATE statements.
+    #
+    # The row-level locking mode also dictates the policy used by the Scan when
+    # handling conflicting locks held by other active transactions. Most scans
+    # leave the policy set to its default (WaitPolicy = Block), but different
+    # wait policies are used by SELECT .. FOR UPDATE/SHARE SKIP LOCKED/NOWAIT
+    # statements to react differently to conflicting locks.
+    Locking Locking
 
     # LocalityOptimized is true if this scan is a child of a
     # LocalityOptimizedSearch operator, indicating that it either contains all

--- a/pkg/sql/opt/optbuilder/locking.go
+++ b/pkg/sql/opt/optbuilder/locking.go
@@ -10,7 +10,10 @@
 
 package optbuilder
 
-import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
 
 // lockingSpec maintains a collection of FOR [KEY] UPDATE/SHARE items that apply
 // to a given scope. Locking clauses can be applied to the lockingSpec as they
@@ -70,11 +73,15 @@ func (lm lockingSpec) isSet() bool {
 
 // get returns the first row-level locking mode in the spec. If the spec was the
 // outcome of filter operation, this will be the only locking mode in the spec.
-func (lm lockingSpec) get() *tree.LockingItem {
+func (lm lockingSpec) get() opt.Locking {
 	if lm.isSet() {
-		return lm[0]
+		spec := lm[0]
+		return opt.Locking{
+			Strength:   spec.Strength,
+			WaitPolicy: spec.WaitPolicy,
+		}
 	}
-	return nil
+	return opt.Locking{}
 }
 
 // apply merges the locking clause into the current locking spec. The effect of

--- a/pkg/sql/opt/optgen/cmd/optgen/metadata.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/metadata.go
@@ -242,7 +242,7 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"UniqueOrdinals":      {fullName: "cat.UniqueOrdinals", passByVal: true},
 		"ViewDeps":            {fullName: "opt.ViewDeps", passByVal: true},
 		"ViewTypeDeps":        {fullName: "opt.ViewTypeDeps", passByVal: true},
-		"LockingItem":         {fullName: "tree.LockingItem", isPointer: true},
+		"Locking":             {fullName: "opt.Locking", passByVal: true},
 		"MaterializeClause":   {fullName: "tree.MaterializeClause", passByVal: true},
 		"SpanExpression":      {fullName: "inverted.SpanExpression", isPointer: true, usePointerIntern: true},
 		"InvertedSpans":       {fullName: "inverted.Spans", passByVal: true},

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -1916,7 +1916,7 @@ memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4])
 memo
 SELECT DISTINCT ON (u) u, v, w FROM kuvw
 ----
-memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4])
+memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4])
  ├── G1: (distinct-on G2 G3 cols=(2)) (distinct-on G2 G3 cols=(2),ordering=+2)
  │    └── [presentation: u:2,v:3,w:4]
  │         ├── best: (distinct-on G2="[ordering: +2]" G3 cols=(2),ordering=+2)
@@ -1938,7 +1938,7 @@ memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4])
 memo
 SELECT DISTINCT ON (v) u, v, w FROM kuvw
 ----
-memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4])
+memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4])
  ├── G1: (distinct-on G2 G3 cols=(3)) (distinct-on G2 G3 cols=(3),ordering=+3)
  │    └── [presentation: u:2,v:3,w:4]
  │         ├── best: (distinct-on G2="[ordering: +3]" G3 cols=(3),ordering=+3)
@@ -1960,7 +1960,7 @@ memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4])
 memo
 SELECT DISTINCT ON (w) u, v, w FROM kuvw
 ----
-memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4])
+memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4])
  ├── G1: (distinct-on G2 G3 cols=(4)) (distinct-on G2 G3 cols=(4),ordering=+4)
  │    └── [presentation: u:2,v:3,w:4]
  │         ├── best: (distinct-on G2="[ordering: +4]" G3 cols=(4),ordering=+4)
@@ -1982,7 +1982,7 @@ memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4])
 memo
 SELECT DISTINCT ON (u) u, v, w FROM kuvw ORDER BY u, w
 ----
-memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4] [ordering: +2])
+memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4] [ordering: +2])
  ├── G1: (distinct-on G2 G3 cols=(2),ordering=+4 opt(2)) (distinct-on G2 G3 cols=(2),ordering=+4)
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +2]
  │    │    ├── best: (sort G1)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -6785,7 +6785,7 @@ WHERE n.name = 'Upper West Side'
 OR n.name = 'Upper East Side'
 GROUP BY n.name, n.geom
 ----
-memo (optimized, ~34KB, required=[presentation: name:16,popn_per_sqkm:22])
+memo (optimized, ~33KB, required=[presentation: name:16,popn_per_sqkm:22])
  ├── G1: (project G2 G3 name)
  │    └── [presentation: name:16,popn_per_sqkm:22]
  │         ├── best: (project G2 G3 name)

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -535,7 +535,7 @@ inner-join (cross)
 memo join-limit=0
 SELECT * FROM bx, cy, dz, abc WHERE x = y AND y = z AND z = a
 ----
-memo (optimized, ~29KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16])
+memo (optimized, ~28KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16])
  ├── G1: (inner-join G2 G3 G4) (merge-join G2 G3 G5 inner-join,+2,+6)
  │    └── [presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16]
  │         ├── best: (inner-join G2 G3 G4)

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -2037,7 +2037,7 @@ memo (optimized, ~14KB, required=[presentation: d:1,e:2,f:3,g:4] [ordering: +1,+
 memo expect=GeneratePartialOrderTopK disable=GenerateLimitedTopKScans
 SELECT d, f, g FROM defg ORDER BY d, g LIMIT 10
 ----
-memo (optimized, ~5KB, required=[presentation: d:1,f:3,g:4] [ordering: +1,+4])
+memo (optimized, ~4KB, required=[presentation: d:1,f:3,g:4] [ordering: +1,+4])
  ├── G1: (limit G2 G3 ordering=+1,+4) (top-k G2 &{10 +1,+4 }) (top-k G2 &{10 +1,+4 +1})
  │    ├── [presentation: d:1,f:3,g:4] [ordering: +1,+4]
  │    │    ├── best: (top-k G2="[ordering: +1] [limit hint: 104.58]" &{10 +1,+4 +1})

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -47,7 +47,7 @@ scan a,rev
 memo
 SELECT k,f FROM a ORDER BY k DESC LIMIT 10
 ----
-memo (optimized, ~5KB, required=[presentation: k:1,f:3] [ordering: -1])
+memo (optimized, ~4KB, required=[presentation: k:1,f:3] [ordering: -1])
  ├── G1: (limit G2 G3 ordering=-1) (scan a,rev,cols=(1,3),lim=10(rev)) (top-k G2 &{10 -1 })
  │    ├── [presentation: k:1,f:3] [ordering: -1]
  │    │    ├── best: (scan a,rev,cols=(1,3),lim=10(rev))

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -849,7 +849,7 @@ index-join b
 memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k > 5
 ----
-memo (optimized, ~10KB, required=[presentation: k:1,u:2,v:3,j:4])
+memo (optimized, ~9KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G1: (select G2 G3) (select G4 G5) (index-join G6 b,cols=(1-4))
  │    └── [presentation: k:1,u:2,v:3,j:4]
  │         ├── best: (index-join G6 b,cols=(1-4))
@@ -1299,7 +1299,7 @@ memo (optimized, ~8KB, required=[presentation: j:5])
 memo
 SELECT i, k FROM kifs WHERE s >= 'foo'
 ----
-memo (optimized, ~8KB, required=[presentation: i:2,k:1])
+memo (optimized, ~7KB, required=[presentation: i:2,k:1])
  ├── G1: (project G2 G3 k i)
  │    └── [presentation: i:2,k:1]
  │         ├── best: (project G2 G3 k i)
@@ -6132,7 +6132,7 @@ memo (optimized, ~10KB, required=[presentation: q:2,t:5])
 memo
 SELECT c FROM zz_redundant WHERE b = 1
 ----
-memo (optimized, ~8KB, required=[presentation: c:3])
+memo (optimized, ~7KB, required=[presentation: c:3])
  ├── G1: (project G2 G3 c)
  │    └── [presentation: c:3]
  │         ├── best: (project G2 G3 c)

--- a/pkg/sql/opt/xform/testdata/rules/set
+++ b/pkg/sql/opt/xform/testdata/rules/set
@@ -21,7 +21,7 @@ CREATE TABLE kuvw (
 memo expect=GenerateStreamingSetOp
 SELECT u,v,w FROM kuvw UNION SELECT w,v,u FROM kuvw
 ----
-memo (optimized, ~11KB, required=[presentation: u:13,v:14,w:15])
+memo (optimized, ~10KB, required=[presentation: u:13,v:14,w:15])
  ├── G1: (union G2 G3) (union G2 G3 ordering=+13,+14,+15) (union G2 G3 ordering=+15,+14,+13) (union G2 G3 ordering=+14,+15,+13) (union G2 G3 ordering=+14,+13,+15)
  │    └── [presentation: u:13,v:14,w:15]
  │         ├── best: (union G2="[ordering: +2,+3,+4]" G3="[ordering: +10,+9,+8]" ordering=+13,+14,+15)

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -118,7 +118,7 @@ func (ef *execFactory) ConstructScan(
 	}
 	scan.reqOrdering = ReqOrdering(reqOrdering)
 	scan.estimatedRowCount = uint64(params.EstimatedRowCount)
-	if params.Locking != nil {
+	if params.Locking.IsLocking() {
 		scan.lockingStrength = descpb.ToScanLockingStrength(params.Locking.Strength)
 		scan.lockingWaitPolicy = descpb.ToScanLockingWaitPolicy(params.Locking.WaitPolicy)
 	}
@@ -654,7 +654,7 @@ func (ef *execFactory) ConstructLookupJoin(
 	isFirstJoinInPairedJoiner bool,
 	isSecondJoinInPairedJoiner bool,
 	reqOrdering exec.OutputOrdering,
-	locking *tree.LockingItem,
+	locking opt.Locking,
 	limitHint int64,
 ) (exec.Node, error) {
 	if table.IsVirtualTable() {
@@ -671,7 +671,7 @@ func (ef *execFactory) ConstructLookupJoin(
 	}
 
 	tableScan.index = idx
-	if locking != nil {
+	if locking.IsLocking() {
 		tableScan.lockingStrength = descpb.ToScanLockingStrength(locking.Strength)
 		tableScan.lockingWaitPolicy = descpb.ToScanLockingWaitPolicy(locking.WaitPolicy)
 	}

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -1017,9 +1017,6 @@ func (node *LockingClause) Format(ctx *FmtCtx) {
 }
 
 // LockingItem represents a single locking item in a locking clause.
-//
-// NOTE: if this struct changes, HashLockingItem and IsLockingItemEqual
-// in opt/memo/interner.go will need to be updated accordingly.
 type LockingItem struct {
 	Strength   LockingStrength
 	Targets    TableNames


### PR DESCRIPTION
This commit separates an unresolved row-level locking target from a new row-level physical property struct. The former is used to represent a row-level locking clause that is then "resolved" to specific relational operators. Once attached to a specific operator, the locking mode no longer needs to include a target, so it makes sense to represent it as a separate struct.

This addresses @RaduBerinde's comment from https://github.com/cockroachdb/cockroach/pull/60719.

I think it's correct to call row-level locking a "physical property", but I could be wrong about that.