### PR TITLE
ci: build `cockroach-sql` binary

### DIFF
--- a/build/teamcity/cockroach/ci/builds/build_impl.sh
+++ b/build/teamcity/cockroach/ci/builds/build_impl.sh
@@ -24,4 +24,5 @@ bazel build //pkg/cmd/bazci --config=ci
 $(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci --compilation_mode opt \
 		       --config "$CONFIG" --config ci --config with_ui \
 		       build //pkg/cmd/cockroach-short //pkg/cmd/cockroach \
+               //pkg/cmd/cockroach-sql \
 		       //pkg/cmd/cockroach-oss //c-deps:libgeos $EXTRA_TARGETS


### PR DESCRIPTION
Previously, the `cockroach-sql` binary was added to the source code, but
has never been added as a compilation target in our CI.

This patch enables building `cockroach-sql` as a part of CI.

Release note: None