### PR TITLE
changefeedccl: Make scan request size configurable.

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -108,6 +108,14 @@ var ScanRequestLimit = settings.RegisterIntSetting(
 	0,
 )
 
+// ScanRequestSize is the target size of the scan request response.
+var ScanRequestSize = settings.RegisterIntSetting(
+	settings.TenantWritable,
+	"changefeed.backfill.scan_request_size",
+	"the maximum number of bytes returned by each scan request",
+	16<<20,
+)
+
 // SinkThrottleConfig describes throttling configuration for the sink.
 // 0 values for any of the settings disable that setting.
 type SinkThrottleConfig struct {

--- a/pkg/ccl/changefeedccl/kvfeed/scanner.go
+++ b/pkg/ccl/changefeedccl/kvfeed/scanner.go
@@ -128,7 +128,7 @@ func (p *scanRequestScanner) exportSpan(
 	}
 	stopwatchStart := timeutil.Now()
 	var scanDuration, bufferDuration time.Duration
-	const targetBytesPerScan = 16 << 20 // 16 MiB
+	targetBytesPerScan := changefeedbase.ScanRequestSize.Get(&p.settings.SV)
 	for remaining := &span; remaining != nil; {
 		start := timeutil.Now()
 		b := txn.NewBatch()


### PR DESCRIPTION
Add a `changefeed.backfill.scan_request_size` setting to control
scan request size during backfill.  The default is maintained
at 16MB.  However, some latency sensitive environments may choose
to lower this setting, while increasing scan parallelism to
ensure that the latches are held for shorter periods of time.

Release Notes: Add a `changefeed.backfill.scan_request_size` setting
to control scan request size during backfill.

Relese Justification: Low danger stability and performance improvement.