### PR TITLE
release-21.2: roachtest: update liquibase test harness and blocklist

### DIFF
--- a/pkg/cmd/roachtest/tests/liquibase.go
+++ b/pkg/cmd/roachtest/tests/liquibase.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 )
 
-var supportedLiquibaseHarnessCommit = "05a91da4869b68f9e3a47c033f856acfb9f01106"
+var supportedLiquibaseHarnessCommit = "1790ddef2d0339c5c96839ac60ac424c130dadd8"
 
 // This test runs the Liquibase test harness against a single cockroach node.
 func registerLiquibase(r registry.Registry) {

--- a/pkg/cmd/roachtest/tests/liquibase_blocklist.go
+++ b/pkg/cmd/roachtest/tests/liquibase_blocklist.go
@@ -17,7 +17,9 @@ var liquibaseBlocklists = blocklistsForVersion{
 }
 
 var liquibaseBlocklist21_2 = blocklist{
-	"liquibase.harness.change.ChangeObjectTests.apply addDefaultValueSequenceNext against cockroachdb 20.2; verify generated SQL and DB snapshot": "",
+	"liquibase.harness.change.ChangeObjectTests.apply addCheckConstraint against cockroachdb 20.2":  "unknown",
+	"liquibase.harness.change.ChangeObjectTests.apply createPackage against cockroachdb 20.2":       "unknown",
+	"liquibase.harness.change.ChangeObjectTests.apply dropCheckConstraint against cockroachdb 20.2": "unknown",
 }
 
 var liquibaseBlocklist21_1 = liquibaseBlocklist20_2


### PR DESCRIPTION
Release justification: test only change
Release note: None