### PR TITLE
[WIP] Try to simulate a one way network partition where a node can send raft messages but not receive any

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -2049,7 +2049,7 @@ func (ds *DistSender) sendToReplicas(
 			// replica into the cache, but without a leaseholder (and taking into
 			// account that the local node can't be down) it won't take long until we
 			// talk to a replica that tells us who the leaseholder is.
-			if ctx.Err() == nil {
+			if true || ctx.Err() == nil {
 				if lh := routing.Leaseholder(); lh != nil && *lh == curReplica {
 					routing.EvictLease(ctx)
 				}

--- a/pkg/kv/kvserver/raft.go
+++ b/pkg/kv/kvserver/raft.go
@@ -68,15 +68,11 @@ func (r *raftLogger) Debugf(format string, v ...interface{}) {
 }
 
 func (r *raftLogger) Info(v ...interface{}) {
-	if log.V(2) {
-		log.InfofDepth(r.ctx, 1, "", v...)
-	}
+	log.InfofDepth(r.ctx, 1, "", v...)
 }
 
 func (r *raftLogger) Infof(format string, v ...interface{}) {
-	if log.V(2) {
-		log.InfofDepth(r.ctx, 1, format, v...)
-	}
+	log.InfofDepth(r.ctx, 1, format, v...)
 }
 
 func (r *raftLogger) Warning(v ...interface{}) {

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -272,6 +272,7 @@ func newRaftConfig(
 		MaxInflightMsgs:           storeCfg.RaftMaxInflightMsgs,
 		Storage:                   strg,
 		Logger:                    logger,
+		CheckQuorum:               true,
 
 		PreVote: true,
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -517,6 +517,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		LivenessThreshold:       nlActive,
 		RenewalDuration:         nlRenewal,
 		Settings:                st,
+		Tracer:                  cfg.AmbientCtx.Tracer,
 		HistogramWindowInterval: cfg.HistogramWindowInterval(),
 		OnNodeDecommissioned: func(liveness livenesspb.Liveness) {
 			if knobs, ok := cfg.TestingKnobs.Server.(*TestingKnobs); ok && knobs.OnDecommissionedCallback != nil {

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+./bin/roachprod destroy local || true
+./bin/roachprod create -n 5 local
+./bin/roachprod put local cockroach
+./bin/roachprod start local
+tail -F ~/local/*/logs/cockroach.log


### PR DESCRIPTION
Exploration of this comment about `CheckQuorum` from @tbg: https://github.com/cockroachlabs/support/issues/1520#issuecomment-1092105429, following the style of https://github.com/cockroachdb/cockroach/pull/79648.

I've tried to hack `raft_transport.go` to blackhole all incoming raft traffic. As I haven't touched `SendAsync`, I think the send side works fine as desired (that way leader can send heartbeats). I'm pretty confused about `raft_transport.go` overall as per all the stuff about it not being standard sync RPCs. So I think it's quite possible that this repro doesn't actually simulate what I want it to. Only one way to find out tho... Put it up for review? Also see the logs down below; `CheckQuorum` does appear to change behavior in a meaningful way for availability, at least if the logs are to be taken at face value.

Usage:

```
./run.sh

# wait for all replicas to have upreplicated, 1-2 minutes

# find PID of node with liveness lease
kill -HUP pid
```

Without `CheckQuorum` set to `false` (the way it is on master), I see the following log lines:

```
~/local$ ag 'quorum|became candidate|became leader|time to' | egrep 'time to|r2\/'
1/logs/cockroach.crlMBP-C02CC5FRMD6TMjYz.joshimhoff.2022-04-08T21_15_52Z.098691.log:80:I220408 21:15:54.393170 228 vendor/go.etcd.io/etcd/raft/v3/raft.go:693 ⋮ [n1,s1,r2/1:‹/System/NodeLiveness{-Max}›] 46  1 became candidate at term 6
1/logs/cockroach.crlMBP-C02CC5FRMD6TMjYz.joshimhoff.2022-04-08T21_15_52Z.098691.log:82:I220408 21:15:54.393198 228 vendor/go.etcd.io/etcd/raft/v3/raft.go:745 ⋮ [n1,s1,r2/1:‹/System/NodeLiveness{-Max}›] 48  1 became leader at term 6
5/logs/cockroach.crlMBP-C02CC5FRMD6TMjYz.joshimhoff.2022-04-08T21_16_06Z.098825.log:716:I220408 21:18:38.285137 295 vendor/go.etcd.io/etcd/raft/v3/raft.go:693 ⋮ [n5,s5,r2/4:‹/System/NodeLiveness{-Max}›] 647  4 became candidate at term 7
5/logs/cockroach.crlMBP-C02CC5FRMD6TMjYz.joshimhoff.2022-04-08T21_16_06Z.098825.log:726:I220408 21:18:38.425254 327 vendor/go.etcd.io/etcd/raft/v3/raft.go:745 ⋮ [n5,s5,r2/4:‹/System/NodeLiveness{-Max}›] 657  4 became leader at term 7
5/logs/cockroach.crlMBP-C02CC5FRMD6TMjYz.joshimhoff.2022-04-08T21_16_06Z.098825.log:848:W220408 21:19:13.610503 1021 kv/kvserver/raft_transport.go:341 ⋮ [-] 779  time to drop incoming raft messages for range
```

Partitioned node is (hopefully) not receiving any raft messages post the "time to drop" log line, and yet no other node becomes leader. Bad.

With `CheckQuorum` set to `true`, what I see is different:

```
~/local$ ag 'quorum|became candidate|became leader|time to' | egrep 'time to|r2\/'
1/logs/cockroach.crlMBP-C02CC5FRMD6TMjYz.joshimhoff.2022-04-08T20_17_58Z.094926.log:79:I220408 20:17:59.818452 354 vendor/go.etcd.io/etcd/raft/v3/raft.go:693 ⋮ [n1,s1,r2/1:‹/System/NodeLiveness{-Max}›] 45  1 became candidate at term 6
1/logs/cockroach.crlMBP-C02CC5FRMD6TMjYz.joshimhoff.2022-04-08T20_17_58Z.094926.log:82:I220408 20:17:59.818470 354 vendor/go.etcd.io/etcd/raft/v3/raft.go:745 ⋮ [n1,s1,r2/1:‹/System/NodeLiveness{-Max}›] 48  1 became leader at term 6
5/logs/cockroach.crlMBP-C02CC5FRMD6TMjYz.joshimhoff.2022-04-08T20_18_11Z.094994.log:924:I220408 20:21:26.040516 318 vendor/go.etcd.io/etcd/raft/v3/raft.go:693 ⋮ [n5,s5,r2/4:‹/System/NodeLiveness{-Max}›] 855  4 became candidate at term 8
5/logs/cockroach.crlMBP-C02CC5FRMD6TMjYz.joshimhoff.2022-04-08T20_18_11Z.094994.log:934:I220408 20:21:26.155931 289 vendor/go.etcd.io/etcd/raft/v3/raft.go:745 ⋮ [n5,s5,r2/4:‹/System/NodeLiveness{-Max}›] 865  4 became leader at term 8
4/logs/cockroach.crlMBP-C02CC5FRMD6TMjYz.joshimhoff.2022-04-08T20_18_07Z.094978.log:710:I220408 20:20:32.468616 287 vendor/go.etcd.io/etcd/raft/v3/raft.go:693 ⋮ [n4,s4,r2/2:‹/System/NodeLiveness{-Max}›] 641  2 became candidate at term 7
4/logs/cockroach.crlMBP-C02CC5FRMD6TMjYz.joshimhoff.2022-04-08T20_18_07Z.094978.log:720:I220408 20:20:32.600239 314 vendor/go.etcd.io/etcd/raft/v3/raft.go:745 ⋮ [n4,s4,r2/2:‹/System/NodeLiveness{-Max}›] 651  2 became leader at term 7
4/logs/cockroach.crlMBP-C02CC5FRMD6TMjYz.joshimhoff.2022-04-08T20_18_07Z.094978.log:905:W220408 20:21:18.527344 706 kv/kvserver/raft_transport.go:341 ⋮ [-] 836  time to drop incoming raft messages for range
4/logs/cockroach.crlMBP-C02CC5FRMD6TMjYz.joshimhoff.2022-04-08T20_18_07Z.094978.log:1044:W220408 20:21:22.520510 346 vendor/go.etcd.io/etcd/raft/v3/raft.go:996 ⋮ [n4,s4,r2/2:‹/System/NodeLiveness{-Max}›] 975  2 stepped down to follower since quorum is not active
```

Specifically, you can see the partitioned node steps down to a follower via the `CheckQuorum` feature, as per the last log line. Another node even becomes the raft leader after that (log lines are not in order, sorry).

That seems... good??? Maybe???

At yet!! Liveness heartbeats still fail cluster wide even after a new raft leader is elected according to logs. I pulled in https://github.com/cockroachdb/cockroach/pull/79648/commits/08781787e692fab68521525ceae750a5065dcb01 thinking this might be the same cache invalidation bug in `dist_sender.go`. But liveness heartbeats still fail with that commit. They only stop failing when I `SIGKILL` the "partitioned" node, as expected.

I really like `roachprod ... local`.