### PR TITLE
Revert "sql/catalog/descs: enforce invariant that OriginalVersion doe…

### DIFF
--- a/pkg/sql/catalog/descs/uncommitted_descriptors.go
+++ b/pkg/sql/catalog/descs/uncommitted_descriptors.go
@@ -164,13 +164,6 @@ func (ud *uncommittedDescriptors) add(
 	for _, n := range uNew.immutable.GetDrainingNames() {
 		ud.descNames.Add(n)
 	}
-	if prev, ok := ud.descs.GetByID(mut.GetID()).(*uncommittedDescriptor); ok {
-		if prev.mutable.OriginalVersion() != mut.OriginalVersion() {
-			return nil, errors.AssertionFailedf(
-				"cannot add a version of descriptor with a different original version" +
-					" than it was previously added with")
-		}
-	}
 	ud.descs.Upsert(uNew)
 	return uNew.immutable, err
 }


### PR DESCRIPTION
…s not change"

This reverts commit 1da50fdbd01ce785c58414085f5c453d24df4602.

Release note: None