### PR TITLE
release-22.1: vendor: bump Pebble to 5591b6b889f9

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -1307,10 +1307,10 @@ def go_deps():
         patches = [
             "@cockroach//build/patches:com_github_cockroachdb_pebble.patch",
         ],
-        sha256 = "504148b3d67b30117e3aaeaa2eb6e5a09d0db701a3d0fb2291b41d3cbf2309a1",
-        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20220407171941-2120d145e292",
+        sha256 = "900848ee83360ced20e3436b346d805dc7a824c8ac935afe17a8476a35e0b522",
+        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20220408210401-5591b6b889f9",
         urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20220407171941-2120d145e292.zip",
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20220408210401-5591b6b889f9.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f
-	github.com/cockroachdb/pebble v0.0.0-20220407171941-2120d145e292
+	github.com/cockroachdb/pebble v0.0.0-20220408210401-5591b6b889f9
 	github.com/cockroachdb/redact v1.1.3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/stress v0.0.0-20220310203902-58fb4627376e

--- a/go.sum
+++ b/go.sum
@@ -440,8 +440,8 @@ github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f h1:6jduT9Hfc0n
 github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f/go.mod h1:Vz9DsVWQQhf3vs21MhPMZpMGSht7O/2vFW2xusFUVOs=
 github.com/cockroachdb/panicparse/v2 v2.0.0-20211103220158-604c82a44f1e h1:FrERdkPlRj+v7fc+PGpey3GUiDGuTR5CsmLCA54YJ8I=
 github.com/cockroachdb/panicparse/v2 v2.0.0-20211103220158-604c82a44f1e/go.mod h1:pMxsKyCewnV3xPaFvvT9NfwvDTcIx2Xqg0qL5Gq0SjM=
-github.com/cockroachdb/pebble v0.0.0-20220407171941-2120d145e292 h1:7fLxcRpQTdi1iic0cIUpK+hKKLM5XdPhEbWRRrxfvLU=
-github.com/cockroachdb/pebble v0.0.0-20220407171941-2120d145e292/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
+github.com/cockroachdb/pebble v0.0.0-20220408210401-5591b6b889f9 h1:1ETF6TvBMK+PGewXsWMrzH9VWMNdANFVTaXlo9sT4yM=
+github.com/cockroachdb/pebble v0.0.0-20220408210401-5591b6b889f9/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=
 github.com/cockroachdb/redact v1.1.3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=


### PR DESCRIPTION
5591b6b8 db: check ordering invariant for sublevel compactions
145d1e22 db: use sublevels for l0 manual compactions

Release note: None
Release justification: useful change for recovery from inverted lsms