### PR TITLE
release-22.1: sql,*: remove PlanningCtx.ctx

### DIFF
--- a/pkg/ccl/backupccl/backup_processor_planning.go
+++ b/pkg/ccl/backupccl/backup_processor_planning.go
@@ -52,13 +52,13 @@ func distBackupPlanSpecs(
 	var introducedSpanPartitions []sql.SpanPartition
 	var err error
 	if len(spans) > 0 {
-		spanPartitions, err = dsp.PartitionSpans(planCtx, spans)
+		spanPartitions, err = dsp.PartitionSpans(ctx, planCtx, spans)
 		if err != nil {
 			return nil, err
 		}
 	}
 	if len(introducedSpans) > 0 {
-		introducedSpanPartitions, err = dsp.PartitionSpans(planCtx, introducedSpans)
+		introducedSpanPartitions, err = dsp.PartitionSpans(ctx, planCtx, introducedSpans)
 		if err != nil {
 			return nil, err
 		}
@@ -206,6 +206,6 @@ func distBackup(
 	defer close(progCh)
 	// Copy the evalCtx, as dsp.Run() might change it.
 	evalCtxCopy := *evalCtx
-	dsp.Run(planCtx, noTxn, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
+	dsp.Run(ctx, planCtx, noTxn, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
 	return rowResultWriter.Err()
 }

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -232,7 +232,7 @@ func distRestore(
 
 	// Copy the evalCtx, as dsp.Run() might change it.
 	evalCtxCopy := *evalCtx
-	dsp.Run(planCtx, noTxn, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
+	dsp.Run(ctx, planCtx, noTxn, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
 	return rowResultWriter.Err()
 }
 

--- a/pkg/ccl/changefeedccl/changefeeddist/distflow.go
+++ b/pkg/ccl/changefeedccl/changefeeddist/distflow.go
@@ -57,7 +57,7 @@ func StartDistChangefeed(
 	} else {
 		// All other feeds get a ChangeAggregator local on the leaseholder.
 		var err error
-		spanPartitions, err = dsp.PartitionSpans(planCtx, trackedSpans)
+		spanPartitions, err = dsp.PartitionSpans(ctx, planCtx, trackedSpans)
 		if err != nil {
 			return err
 		}
@@ -150,7 +150,7 @@ func StartDistChangefeed(
 
 	// Copy the evalCtx, as dsp.Run() might change it.
 	evalCtxCopy := *evalCtx
-	dsp.Run(planCtx, noTxn, p, recv, &evalCtxCopy, finishedSetupFn)()
+	dsp.Run(ctx, planCtx, noTxn, p, recv, &evalCtxCopy, finishedSetupFn)()
 	return resultRows.Err()
 }
 

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
@@ -150,7 +150,7 @@ func distStreamIngest(
 
 	// Copy the evalCtx, as dsp.Run() might change it.
 	evalCtxCopy := *evalCtx
-	dsp.Run(planCtx, noTxn, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
+	dsp.Run(ctx, planCtx, noTxn, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
 	return rw.Err()
 }
 

--- a/pkg/ccl/streamingccl/streamproducer/replication_stream_planning.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_stream_planning.go
@@ -236,7 +236,7 @@ func getReplicationStreamSpec(
 	for _, span := range replicatedSpans {
 		spans = append(spans, *span)
 	}
-	spanPartitions, err := dsp.PartitionSpans(planCtx, spans)
+	spanPartitions, err := dsp.PartitionSpans(evalCtx.Ctx(), planCtx, spans)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -981,7 +981,7 @@ func (sc *SchemaChanger) distIndexBackfill(
 		if err != nil {
 			return err
 		}
-		p, err = sc.distSQLPlanner.createBackfillerPhysicalPlan(planCtx, spec, todoSpans)
+		p, err = sc.distSQLPlanner.createBackfillerPhysicalPlan(ctx, planCtx, spec, todoSpans)
 		return err
 	}); err != nil {
 		return err
@@ -1153,6 +1153,7 @@ func (sc *SchemaChanger) distIndexBackfill(
 		// Copy the evalCtx, as dsp.Run() might change it.
 		evalCtxCopy := evalCtx
 		sc.distSQLPlanner.Run(
+			ctx,
 			planCtx,
 			nil, /* txn - the processors manage their own transactions */
 			p, recv, &evalCtxCopy,
@@ -1274,11 +1275,12 @@ func (sc *SchemaChanger) distColumnBackfill(
 			if err != nil {
 				return err
 			}
-			plan, err := sc.distSQLPlanner.createBackfillerPhysicalPlan(planCtx, spec, todoSpans)
+			plan, err := sc.distSQLPlanner.createBackfillerPhysicalPlan(ctx, planCtx, spec, todoSpans)
 			if err != nil {
 				return err
 			}
 			sc.distSQLPlanner.Run(
+				ctx,
 				planCtx,
 				nil, /* txn - the processors manage their own transactions */
 				plan, recv, &evalCtx,

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -688,7 +688,6 @@ const (
 // PlanningCtx contains data used and updated throughout the planning process of
 // a single query.
 type PlanningCtx struct {
-	ctx             context.Context
 	ExtendedEvalCtx *extendedEvalContext
 	spanIter        physicalplan.SpanResolverIterator
 	// NodesStatuses contains info for all SQLInstanceIDs that are referenced by
@@ -983,23 +982,22 @@ func (h *distSQLNodeHealth) check(ctx context.Context, sqlInstanceID base.SQLIns
 // either be unhealthy or running an incompatible version. The ranges owned by
 // such nodes are assigned to the gateway.
 func (dsp *DistSQLPlanner) PartitionSpans(
-	planCtx *PlanningCtx, spans roachpb.Spans,
+	ctx context.Context, planCtx *PlanningCtx, spans roachpb.Spans,
 ) ([]SpanPartition, error) {
 	if dsp.codec.ForSystemTenant() {
-		return dsp.partitionSpansSystem(planCtx, spans)
+		return dsp.partitionSpansSystem(ctx, planCtx, spans)
 	}
-	return dsp.partitionSpansTenant(planCtx, spans)
+	return dsp.partitionSpansTenant(ctx, planCtx, spans)
 }
 
 // partitionSpansSystem finds node owners for ranges touching the given spans
 // for a system tenant.
 func (dsp *DistSQLPlanner) partitionSpansSystem(
-	planCtx *PlanningCtx, spans roachpb.Spans,
+	ctx context.Context, planCtx *PlanningCtx, spans roachpb.Spans,
 ) ([]SpanPartition, error) {
 	if len(spans) == 0 {
 		panic("no spans")
 	}
-	ctx := planCtx.ctx
 	partitions := make([]SpanPartition, 0, 1)
 	if planCtx.isLocal {
 		// If we're planning locally, map all spans to the local node.
@@ -1076,7 +1074,7 @@ func (dsp *DistSQLPlanner) partitionSpansSystem(
 			if !inNodeMap {
 				// This is the first time we are seeing this sqlInstanceID for these
 				// spans. Check its health.
-				status := dsp.CheckInstanceHealthAndVersion(planCtx, sqlInstanceID)
+				status := dsp.CheckInstanceHealthAndVersion(ctx, planCtx, sqlInstanceID)
 				// If the node is unhealthy or its DistSQL version is incompatible, use
 				// the gateway to process this span instead of the unhealthy host.
 				// An empty address indicates an unhealthy host.
@@ -1128,12 +1126,11 @@ func (dsp *DistSQLPlanner) partitionSpansSystem(
 // partitionSpansTenant assigns SQL instances in a tenant to spans. Currently
 // assignments are made to all available instances in a round-robin fashion.
 func (dsp *DistSQLPlanner) partitionSpansTenant(
-	planCtx *PlanningCtx, spans roachpb.Spans,
+	ctx context.Context, planCtx *PlanningCtx, spans roachpb.Spans,
 ) ([]SpanPartition, error) {
 	if len(spans) == 0 {
 		panic("no spans")
 	}
-	ctx := planCtx.ctx
 	partitions := make([]SpanPartition, 0, 1)
 	if planCtx.isLocal {
 		// If we're planning locally, map all spans to the local node.
@@ -1280,7 +1277,7 @@ func (dsp *DistSQLPlanner) convertOrdering(
 // first range in the specified spans. But if that node is unhealthy or
 // incompatible, we use the gateway node instead.
 func (dsp *DistSQLPlanner) getInstanceIDForScan(
-	planCtx *PlanningCtx, spans []roachpb.Span, reverse bool,
+	ctx context.Context, planCtx *PlanningCtx, spans []roachpb.Span, reverse bool,
 ) (base.SQLInstanceID, error) {
 	if len(spans) == 0 {
 		panic("no spans")
@@ -1289,22 +1286,22 @@ func (dsp *DistSQLPlanner) getInstanceIDForScan(
 	// Determine the node ID for the first range to be scanned.
 	it := planCtx.spanIter
 	if reverse {
-		it.Seek(planCtx.ctx, spans[len(spans)-1], kvcoord.Descending)
+		it.Seek(ctx, spans[len(spans)-1], kvcoord.Descending)
 	} else {
-		it.Seek(planCtx.ctx, spans[0], kvcoord.Ascending)
+		it.Seek(ctx, spans[0], kvcoord.Ascending)
 	}
 	if !it.Valid() {
 		return 0, it.Error()
 	}
-	replDesc, err := it.ReplicaInfo(planCtx.ctx)
+	replDesc, err := it.ReplicaInfo(ctx)
 	if err != nil {
 		return 0, err
 	}
 
 	sqlInstanceID := base.SQLInstanceID(replDesc.NodeID)
-	status := dsp.CheckInstanceHealthAndVersion(planCtx, sqlInstanceID)
+	status := dsp.CheckInstanceHealthAndVersion(ctx, planCtx, sqlInstanceID)
 	if status != NodeOK {
-		log.Eventf(planCtx.ctx, "not planning on node %d: %s", sqlInstanceID, status)
+		log.Eventf(ctx, "not planning on node %d: %s", sqlInstanceID, status)
 		return dsp.gatewaySQLInstanceID, nil
 	}
 	return sqlInstanceID, nil
@@ -1313,14 +1310,14 @@ func (dsp *DistSQLPlanner) getInstanceIDForScan(
 // CheckInstanceHealthAndVersion returns a information about a node's health and
 // compatibility. The info is also recorded in planCtx.Nodes.
 func (dsp *DistSQLPlanner) CheckInstanceHealthAndVersion(
-	planCtx *PlanningCtx, sqlInstanceID base.SQLInstanceID,
+	ctx context.Context, planCtx *PlanningCtx, sqlInstanceID base.SQLInstanceID,
 ) NodeStatus {
 	if status, ok := planCtx.NodeStatuses[sqlInstanceID]; ok {
 		return status
 	}
 
 	var status NodeStatus
-	if err := dsp.nodeHealth.check(planCtx.ctx, sqlInstanceID); err != nil {
+	if err := dsp.nodeHealth.check(ctx, sqlInstanceID); err != nil {
 		status = NodeUnhealthy
 	} else if !dsp.nodeVersionIsCompatible(sqlInstanceID) {
 		status = NodeDistSQLVersionIncompatible
@@ -1334,7 +1331,7 @@ func (dsp *DistSQLPlanner) CheckInstanceHealthAndVersion(
 // createTableReaders generates a plan consisting of table reader processors,
 // one for each node that has spans that we are reading.
 func (dsp *DistSQLPlanner) createTableReaders(
-	planCtx *PlanningCtx, n *scanNode,
+	ctx context.Context, planCtx *PlanningCtx, n *scanNode,
 ) (*PhysicalPlan, error) {
 	spec, post, err := initTableReaderSpecTemplate(n, planCtx.ExtendedEvalCtx.Codec)
 	if err != nil {
@@ -1343,6 +1340,7 @@ func (dsp *DistSQLPlanner) createTableReaders(
 
 	p := planCtx.NewPhysicalPlan()
 	err = dsp.planTableReaders(
+		ctx,
 		planCtx,
 		p,
 		&tableReaderPlanningInfo{
@@ -1390,7 +1388,7 @@ var localScansConcurrencyLimit = settings.RegisterIntSetting(
 // maybeParallelizeLocalScans check whether we are planning such a TableReader
 // for the local flow that would benefit (and is safe) to parallelize.
 func (dsp *DistSQLPlanner) maybeParallelizeLocalScans(
-	planCtx *PlanningCtx, info *tableReaderPlanningInfo,
+	ctx context.Context, planCtx *PlanningCtx, info *tableReaderPlanningInfo,
 ) (spanPartitions []SpanPartition, parallelizeLocal bool) {
 	// For local plans, if:
 	// - there is no required ordering,
@@ -1417,7 +1415,7 @@ func (dsp *DistSQLPlanner) maybeParallelizeLocalScans(
 		// according to the respective leaseholders.
 		planCtx.isLocal = false
 		var err error
-		spanPartitions, err = dsp.PartitionSpans(planCtx, info.spans)
+		spanPartitions, err = dsp.PartitionSpans(ctx, planCtx, info.spans)
 		planCtx.isLocal = true
 		if err != nil {
 			// For some reason we couldn't partition the spans - fallback to
@@ -1451,7 +1449,7 @@ func (dsp *DistSQLPlanner) maybeParallelizeLocalScans(
 			// alloc will be non-nil only if actualConcurrency remains above 1.
 			var alloc *quotapool.IntAlloc
 			for actualConcurrency > 1 {
-				alloc, err = dsp.parallelLocalScansSem.TryAcquire(planCtx.ctx, uint64(actualConcurrency-1))
+				alloc, err = dsp.parallelLocalScansSem.TryAcquire(ctx, uint64(actualConcurrency-1))
 				if err == nil {
 					break
 				}
@@ -1491,7 +1489,7 @@ func (dsp *DistSQLPlanner) maybeParallelizeLocalScans(
 }
 
 func (dsp *DistSQLPlanner) planTableReaders(
-	planCtx *PlanningCtx, p *PhysicalPlan, info *tableReaderPlanningInfo,
+	ctx context.Context, planCtx *PlanningCtx, p *PhysicalPlan, info *tableReaderPlanningInfo,
 ) error {
 	var (
 		spanPartitions   []SpanPartition
@@ -1499,21 +1497,21 @@ func (dsp *DistSQLPlanner) planTableReaders(
 		err              error
 	)
 	if planCtx.isLocal {
-		spanPartitions, parallelizeLocal = dsp.maybeParallelizeLocalScans(planCtx, info)
+		spanPartitions, parallelizeLocal = dsp.maybeParallelizeLocalScans(ctx, planCtx, info)
 	} else if info.post.Limit == 0 {
 		// No hard limit - plan all table readers where their data live. Note
 		// that we're ignoring soft limits for now since the TableReader will
 		// still read too eagerly in the soft limit case. To prevent this we'll
 		// need a new mechanism on the execution side to modulate table reads.
 		// TODO(yuzefovich): add that mechanism.
-		spanPartitions, err = dsp.PartitionSpans(planCtx, info.spans)
+		spanPartitions, err = dsp.PartitionSpans(ctx, planCtx, info.spans)
 		if err != nil {
 			return err
 		}
 	} else {
 		// If the scan has a hard limit, use a single TableReader to avoid
 		// reading more rows than necessary.
-		sqlInstanceID, err := dsp.getInstanceIDForScan(planCtx, info.spans, info.reverse)
+		sqlInstanceID, err := dsp.getInstanceIDForScan(ctx, planCtx, info.spans, info.reverse)
 		if err != nil {
 			return err
 		}
@@ -2220,9 +2218,9 @@ func (dsp *DistSQLPlanner) planAggregators(
 }
 
 func (dsp *DistSQLPlanner) createPlanForIndexJoin(
-	planCtx *PlanningCtx, n *indexJoinNode,
+	ctx context.Context, planCtx *PlanningCtx, n *indexJoinNode,
 ) (*PhysicalPlan, error) {
-	plan, err := dsp.createPhysPlanForPlanNode(planCtx, n.input)
+	plan, err := dsp.createPhysPlanForPlanNode(ctx, planCtx, n.input)
 	if err != nil {
 		return nil, err
 	}
@@ -2303,9 +2301,9 @@ func (dsp *DistSQLPlanner) createPlanForIndexJoin(
 
 // createPlanForLookupJoin creates a distributed plan for a lookupJoinNode.
 func (dsp *DistSQLPlanner) createPlanForLookupJoin(
-	planCtx *PlanningCtx, n *lookupJoinNode,
+	ctx context.Context, planCtx *PlanningCtx, n *lookupJoinNode,
 ) (*PhysicalPlan, error) {
-	plan, err := dsp.createPhysPlanForPlanNode(planCtx, n.input)
+	plan, err := dsp.createPhysPlanForPlanNode(ctx, planCtx, n.input)
 	if err != nil {
 		return nil, err
 	}
@@ -2514,9 +2512,9 @@ func truncateToInputForLookupJoins(
 }
 
 func (dsp *DistSQLPlanner) createPlanForInvertedJoin(
-	planCtx *PlanningCtx, n *invertedJoinNode,
+	ctx context.Context, planCtx *PlanningCtx, n *invertedJoinNode,
 ) (*PhysicalPlan, error) {
-	plan, err := dsp.createPhysPlanForPlanNode(planCtx, n.input)
+	plan, err := dsp.createPhysPlanForPlanNode(ctx, planCtx, n.input)
 	if err != nil {
 		return nil, err
 	}
@@ -2722,9 +2720,9 @@ func (dsp *DistSQLPlanner) planZigzagJoin(
 }
 
 func (dsp *DistSQLPlanner) createPlanForInvertedFilter(
-	planCtx *PlanningCtx, n *invertedFilterNode,
+	ctx context.Context, planCtx *PlanningCtx, n *invertedFilterNode,
 ) (*PhysicalPlan, error) {
-	plan, err := dsp.createPhysPlanForPlanNode(planCtx, n.input)
+	plan, err := dsp.createPhysPlanForPlanNode(ctx, planCtx, n.input)
 	if err != nil {
 		return nil, err
 	}
@@ -2832,13 +2830,13 @@ func getTypesForPlanResult(node planNode, planToStreamColMap []int) ([]*types.T,
 }
 
 func (dsp *DistSQLPlanner) createPlanForJoin(
-	planCtx *PlanningCtx, n *joinNode,
+	ctx context.Context, planCtx *PlanningCtx, n *joinNode,
 ) (*PhysicalPlan, error) {
-	leftPlan, err := dsp.createPhysPlanForPlanNode(planCtx, n.left.plan)
+	leftPlan, err := dsp.createPhysPlanForPlanNode(ctx, planCtx, n.left.plan)
 	if err != nil {
 		return nil, err
 	}
-	rightPlan, err := dsp.createPhysPlanForPlanNode(planCtx, n.right.plan)
+	rightPlan, err := dsp.createPhysPlanForPlanNode(ctx, planCtx, n.right.plan)
 	if err != nil {
 		return nil, err
 	}
@@ -2959,32 +2957,32 @@ func (dsp *DistSQLPlanner) planJoiners(
 // createPhysPlan creates a PhysicalPlan as well as returns a non-nil cleanup
 // function that must be called after the flow has been cleaned up.
 func (dsp *DistSQLPlanner) createPhysPlan(
-	planCtx *PlanningCtx, plan planMaybePhysical,
+	ctx context.Context, planCtx *PlanningCtx, plan planMaybePhysical,
 ) (physPlan *PhysicalPlan, cleanup func(), err error) {
 	if plan.isPhysicalPlan() {
 		// TODO(yuzefovich): figure out how to propagate
 		// planCtx.getCleanupFunc() from the experimental DistSQL spec factory.
 		return plan.physPlan.PhysicalPlan, func() {}, nil
 	}
-	physPlan, err = dsp.createPhysPlanForPlanNode(planCtx, plan.planNode)
+	physPlan, err = dsp.createPhysPlanForPlanNode(ctx, planCtx, plan.planNode)
 	return physPlan, planCtx.getCleanupFunc(), err
 }
 
 func (dsp *DistSQLPlanner) createPhysPlanForPlanNode(
-	planCtx *PlanningCtx, node planNode,
+	ctx context.Context, planCtx *PlanningCtx, node planNode,
 ) (plan *PhysicalPlan, err error) {
 	planCtx.planDepth++
 
 	switch n := node.(type) {
 	// Keep these cases alphabetized, please!
 	case *distinctNode:
-		plan, err = dsp.createPlanForDistinct(planCtx, n)
+		plan, err = dsp.createPlanForDistinct(ctx, planCtx, n)
 
 	case *exportNode:
-		plan, err = dsp.createPlanForExport(planCtx, n)
+		plan, err = dsp.createPlanForExport(ctx, planCtx, n)
 
 	case *filterNode:
-		plan, err = dsp.createPhysPlanForPlanNode(planCtx, n.source.plan)
+		plan, err = dsp.createPhysPlanForPlanNode(ctx, planCtx, n.source.plan)
 		if err != nil {
 			return nil, err
 		}
@@ -2994,7 +2992,7 @@ func (dsp *DistSQLPlanner) createPhysPlanForPlanNode(
 		}
 
 	case *groupNode:
-		plan, err = dsp.createPhysPlanForPlanNode(planCtx, n.plan)
+		plan, err = dsp.createPhysPlanForPlanNode(ctx, planCtx, n.plan)
 		if err != nil {
 			return nil, err
 		}
@@ -3004,19 +3002,19 @@ func (dsp *DistSQLPlanner) createPhysPlanForPlanNode(
 		}
 
 	case *indexJoinNode:
-		plan, err = dsp.createPlanForIndexJoin(planCtx, n)
+		plan, err = dsp.createPlanForIndexJoin(ctx, planCtx, n)
 
 	case *invertedFilterNode:
-		plan, err = dsp.createPlanForInvertedFilter(planCtx, n)
+		plan, err = dsp.createPlanForInvertedFilter(ctx, planCtx, n)
 
 	case *invertedJoinNode:
-		plan, err = dsp.createPlanForInvertedJoin(planCtx, n)
+		plan, err = dsp.createPlanForInvertedJoin(ctx, planCtx, n)
 
 	case *joinNode:
-		plan, err = dsp.createPlanForJoin(planCtx, n)
+		plan, err = dsp.createPlanForJoin(ctx, planCtx, n)
 
 	case *limitNode:
-		plan, err = dsp.createPhysPlanForPlanNode(planCtx, n.plan)
+		plan, err = dsp.createPhysPlanForPlanNode(ctx, planCtx, n.plan)
 		if err != nil {
 			return nil, err
 		}
@@ -3029,16 +3027,16 @@ func (dsp *DistSQLPlanner) createPhysPlanForPlanNode(
 		}
 
 	case *lookupJoinNode:
-		plan, err = dsp.createPlanForLookupJoin(planCtx, n)
+		plan, err = dsp.createPlanForLookupJoin(ctx, planCtx, n)
 
 	case *ordinalityNode:
-		plan, err = dsp.createPlanForOrdinality(planCtx, n)
+		plan, err = dsp.createPlanForOrdinality(ctx, planCtx, n)
 
 	case *projectSetNode:
-		plan, err = dsp.createPlanForProjectSet(planCtx, n)
+		plan, err = dsp.createPlanForProjectSet(ctx, planCtx, n)
 
 	case *renderNode:
-		plan, err = dsp.createPhysPlanForPlanNode(planCtx, n.source.plan)
+		plan, err = dsp.createPhysPlanForPlanNode(ctx, planCtx, n.source.plan)
 		if err != nil {
 			return nil, err
 		}
@@ -3048,10 +3046,10 @@ func (dsp *DistSQLPlanner) createPhysPlanForPlanNode(
 		}
 
 	case *scanNode:
-		plan, err = dsp.createTableReaders(planCtx, n)
+		plan, err = dsp.createTableReaders(ctx, planCtx, n)
 
 	case *sortNode:
-		plan, err = dsp.createPhysPlanForPlanNode(planCtx, n.plan)
+		plan, err = dsp.createPhysPlanForPlanNode(ctx, planCtx, n.plan)
 		if err != nil {
 			return nil, err
 		}
@@ -3059,7 +3057,7 @@ func (dsp *DistSQLPlanner) createPhysPlanForPlanNode(
 		dsp.addSorters(plan, n.ordering, n.alreadyOrderedPrefix, 0 /* limit */)
 
 	case *topKNode:
-		plan, err = dsp.createPhysPlanForPlanNode(planCtx, n.plan)
+		plan, err = dsp.createPhysPlanForPlanNode(ctx, planCtx, n.plan)
 		if err != nil {
 			return nil, err
 		}
@@ -3073,11 +3071,11 @@ func (dsp *DistSQLPlanner) createPhysPlanForPlanNode(
 		plan, err = dsp.createPlanForUnary(planCtx, n)
 
 	case *unionNode:
-		plan, err = dsp.createPlanForSetOp(planCtx, n)
+		plan, err = dsp.createPlanForSetOp(ctx, planCtx, n)
 
 	case *valuesNode:
 		if mustWrapValuesNode(planCtx, n.specifiedInQuery) {
-			plan, err = dsp.wrapPlan(planCtx, n, false /* allowPartialDistribution */)
+			plan, err = dsp.wrapPlan(ctx, planCtx, n, false /* allowPartialDistribution */)
 		} else {
 			colTypes := getTypesFromResultColumns(n.columns)
 			var spec *execinfrapb.ValuesCoreSpec
@@ -3089,7 +3087,7 @@ func (dsp *DistSQLPlanner) createPhysPlanForPlanNode(
 		}
 
 	case *windowNode:
-		plan, err = dsp.createPlanForWindow(planCtx, n)
+		plan, err = dsp.createPlanForWindow(ctx, planCtx, n)
 
 	case *zeroNode:
 		plan, err = dsp.createPlanForZero(planCtx, n)
@@ -3099,21 +3097,21 @@ func (dsp *DistSQLPlanner) createPhysPlanForPlanNode(
 
 	case *createStatsNode:
 		if n.runAsJob {
-			plan, err = dsp.wrapPlan(planCtx, n, false /* allowPartialDistribution */)
+			plan, err = dsp.wrapPlan(ctx, planCtx, n, false /* allowPartialDistribution */)
 		} else {
 			// Create a job record but don't actually start the job.
 			var record *jobs.Record
-			record, err = n.makeJobRecord(planCtx.ctx)
+			record, err = n.makeJobRecord(ctx)
 			if err != nil {
 				return nil, err
 			}
-			plan, err = dsp.createPlanForCreateStats(planCtx, 0, /* jobID */
+			plan, err = dsp.createPlanForCreateStats(ctx, planCtx, 0, /* jobID */
 				record.Details.(jobspb.CreateStatsDetails))
 		}
 
 	default:
 		// Can't handle a node? We wrap it and continue on our way.
-		plan, err = dsp.wrapPlan(planCtx, n, false /* allowPartialDistribution */)
+		plan, err = dsp.wrapPlan(ctx, planCtx, n, false /* allowPartialDistribution */)
 	}
 
 	if err != nil {
@@ -3134,7 +3132,7 @@ func (dsp *DistSQLPlanner) createPhysPlanForPlanNode(
 
 	if dsp.shouldPlanTestMetadata() {
 		if err := plan.CheckLastStagePost(); err != nil {
-			log.Fatalf(planCtx.ctx, "%v", err)
+			log.Fatalf(ctx, "%v", err)
 		}
 		plan.AddNoGroupingStageWithCoreFunc(
 			func(_ int, _ *physicalplan.Processor) execinfrapb.ProcessorCoreUnion {
@@ -3159,7 +3157,7 @@ func (dsp *DistSQLPlanner) createPhysPlanForPlanNode(
 // plannable by DistSQL. If that sub-tree has DistSQL-plannable sources, they
 // will be planned by DistSQL and connected to the wrapper.
 func (dsp *DistSQLPlanner) wrapPlan(
-	planCtx *PlanningCtx, n planNode, allowPartialDistribution bool,
+	ctx context.Context, planCtx *PlanningCtx, n planNode, allowPartialDistribution bool,
 ) (*PhysicalPlan, error) {
 	useFastPath := planCtx.planDepth == 1 && planCtx.stmtType == tree.RowsAffected
 
@@ -3173,7 +3171,7 @@ func (dsp *DistSQLPlanner) wrapPlan(
 	// modify its parent later to connect its source to the DistSQL-planned
 	// subtree.
 	var firstNotWrapped planNode
-	if err := walkPlan(planCtx.ctx, n, planObserver{
+	if err := walkPlan(ctx, n, planObserver{
 		enterNode: func(ctx context.Context, nodeName string, plan planNode) (bool, error) {
 			switch plan.(type) {
 			case *explainVecNode, *explainPlanNode, *explainDDLNode:
@@ -3192,7 +3190,7 @@ func (dsp *DistSQLPlanner) wrapPlan(
 			// control of planning back to the DistSQL physical planner.
 			if !dsp.mustWrapNode(planCtx, plan) {
 				firstNotWrapped = plan
-				p, err = dsp.createPhysPlanForPlanNode(planCtx, plan)
+				p, err = dsp.createPhysPlanForPlanNode(ctx, planCtx, plan)
 				if err != nil {
 					return false, err
 				}
@@ -3393,9 +3391,9 @@ func (dsp *DistSQLPlanner) createDistinctSpec(
 }
 
 func (dsp *DistSQLPlanner) createPlanForDistinct(
-	planCtx *PlanningCtx, n *distinctNode,
+	ctx context.Context, planCtx *PlanningCtx, n *distinctNode,
 ) (*PhysicalPlan, error) {
-	plan, err := dsp.createPhysPlanForPlanNode(planCtx, n.plan)
+	plan, err := dsp.createPhysPlanForPlanNode(ctx, planCtx, n.plan)
 	if err != nil {
 		return nil, err
 	}
@@ -3433,9 +3431,9 @@ func (dsp *DistSQLPlanner) addDistinctProcessors(
 }
 
 func (dsp *DistSQLPlanner) createPlanForOrdinality(
-	planCtx *PlanningCtx, n *ordinalityNode,
+	ctx context.Context, planCtx *PlanningCtx, n *ordinalityNode,
 ) (*PhysicalPlan, error) {
-	plan, err := dsp.createPhysPlanForPlanNode(planCtx, n.source)
+	plan, err := dsp.createPhysPlanForPlanNode(ctx, planCtx, n.source)
 	if err != nil {
 		return nil, err
 	}
@@ -3479,9 +3477,9 @@ func createProjectSetSpec(
 }
 
 func (dsp *DistSQLPlanner) createPlanForProjectSet(
-	planCtx *PlanningCtx, n *projectSetNode,
+	ctx context.Context, planCtx *PlanningCtx, n *projectSetNode,
 ) (*PhysicalPlan, error) {
-	plan, err := dsp.createPhysPlanForPlanNode(planCtx, n.source)
+	plan, err := dsp.createPhysPlanForPlanNode(ctx, planCtx, n.source)
 	if err != nil {
 		return nil, err
 	}
@@ -3572,15 +3570,15 @@ func (dsp *DistSQLPlanner) isOnlyOnGateway(plan *PhysicalPlan) bool {
 //            |
 //          JOIN
 func (dsp *DistSQLPlanner) createPlanForSetOp(
-	planCtx *PlanningCtx, n *unionNode,
+	ctx context.Context, planCtx *PlanningCtx, n *unionNode,
 ) (*PhysicalPlan, error) {
 	leftLogicalPlan := n.left
-	leftPlan, err := dsp.createPhysPlanForPlanNode(planCtx, n.left)
+	leftPlan, err := dsp.createPhysPlanForPlanNode(ctx, planCtx, n.left)
 	if err != nil {
 		return nil, err
 	}
 	rightLogicalPlan := n.right
-	rightPlan, err := dsp.createPhysPlanForPlanNode(planCtx, n.right)
+	rightPlan, err := dsp.createPhysPlanForPlanNode(ctx, planCtx, n.right)
 	if err != nil {
 		return nil, err
 	}
@@ -3808,9 +3806,9 @@ func (dsp *DistSQLPlanner) createPlanForSetOp(
 // We add a new stage of windower processors for each different partitioning
 // scheme found in the query's window functions.
 func (dsp *DistSQLPlanner) createPlanForWindow(
-	planCtx *PlanningCtx, n *windowNode,
+	ctx context.Context, planCtx *PlanningCtx, n *windowNode,
 ) (*PhysicalPlan, error) {
-	plan, err := dsp.createPhysPlanForPlanNode(planCtx, n.plan)
+	plan, err := dsp.createPhysPlanForPlanNode(ctx, planCtx, n.plan)
 	if err != nil {
 		return nil, err
 	}
@@ -3956,9 +3954,9 @@ func (dsp *DistSQLPlanner) createPlanForWindow(
 // createPlanForExport creates a physical plan for EXPORT.
 // We add a new stage of CSV/Parquet Writer processors to the input plan.
 func (dsp *DistSQLPlanner) createPlanForExport(
-	planCtx *PlanningCtx, n *exportNode,
+	ctx context.Context, planCtx *PlanningCtx, n *exportNode,
 ) (*PhysicalPlan, error) {
-	plan, err := dsp.createPhysPlanForPlanNode(planCtx, n.source)
+	plan, err := dsp.createPhysPlanForPlanNode(ctx, planCtx, n.source)
 	if err != nil {
 		return nil, err
 	}
@@ -4091,7 +4089,6 @@ func (dsp *DistSQLPlanner) NewPlanningCtx(
 ) *PlanningCtx {
 	distribute := distributionType == DistributionTypeAlways || (distributionType == DistributionTypeSystemTenantOnly && evalCtx.Codec.ForSystemTenant())
 	planCtx := &PlanningCtx{
-		ctx:             ctx,
 		ExtendedEvalCtx: evalCtx,
 		infra:           physicalplan.MakePhysicalInfrastructure(uuid.FastMakeV4(), dsp.gatewaySQLInstanceID),
 		isLocal:         !distribute,

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -910,7 +910,8 @@ func TestPartitionSpans(t *testing.T) {
 				codec: keys.SystemSQLCodec,
 			}
 
-			planCtx := dsp.NewPlanningCtx(context.Background(), &extendedEvalContext{
+			ctx := context.Background()
+			planCtx := dsp.NewPlanningCtx(ctx, &extendedEvalContext{
 				EvalContext: tree.EvalContext{Codec: keys.SystemSQLCodec},
 			}, nil, nil, DistributionTypeSystemTenantOnly)
 			var spans []roachpb.Span
@@ -918,7 +919,7 @@ func TestPartitionSpans(t *testing.T) {
 				spans = append(spans, roachpb.Span{Key: roachpb.Key(s[0]), EndKey: roachpb.Key(s[1])})
 			}
 
-			partitions, err := dsp.PartitionSpans(planCtx, spans)
+			partitions, err := dsp.PartitionSpans(ctx, planCtx, spans)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1095,10 +1096,11 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 				codec: keys.SystemSQLCodec,
 			}
 
-			planCtx := dsp.NewPlanningCtx(context.Background(), &extendedEvalContext{
+			ctx := context.Background()
+			planCtx := dsp.NewPlanningCtx(ctx, &extendedEvalContext{
 				EvalContext: tree.EvalContext{Codec: keys.SystemSQLCodec},
 			}, nil, nil, DistributionTypeSystemTenantOnly)
-			partitions, err := dsp.PartitionSpans(planCtx, roachpb.Spans{span})
+			partitions, err := dsp.PartitionSpans(ctx, planCtx, roachpb.Spans{span})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1195,10 +1197,11 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 		codec: keys.SystemSQLCodec,
 	}
 
-	planCtx := dsp.NewPlanningCtx(context.Background(), &extendedEvalContext{
+	ctx := context.Background()
+	planCtx := dsp.NewPlanningCtx(ctx, &extendedEvalContext{
 		EvalContext: tree.EvalContext{Codec: keys.SystemSQLCodec},
 	}, nil, nil, DistributionTypeSystemTenantOnly)
-	partitions, err := dsp.PartitionSpans(planCtx, roachpb.Spans{span})
+	partitions, err := dsp.PartitionSpans(ctx, planCtx, roachpb.Spans{span})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/distsql_plan_backfill.go
+++ b/pkg/sql/distsql_plan_backfill.go
@@ -11,6 +11,7 @@
 package sql
 
 import (
+	"context"
 	"time"
 	"unsafe"
 
@@ -72,9 +73,9 @@ func initIndexBackfillMergerSpec(
 // processors, one for each node that has spans that we are reading. The plan is
 // finalized.
 func (dsp *DistSQLPlanner) createBackfillerPhysicalPlan(
-	planCtx *PlanningCtx, spec execinfrapb.BackfillerSpec, spans []roachpb.Span,
+	ctx context.Context, planCtx *PlanningCtx, spec execinfrapb.BackfillerSpec, spans []roachpb.Span,
 ) (*PhysicalPlan, error) {
-	spanPartitions, err := dsp.PartitionSpans(planCtx, spans)
+	spanPartitions, err := dsp.PartitionSpans(ctx, planCtx, spans)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +108,10 @@ func (dsp *DistSQLPlanner) createBackfillerPhysicalPlan(
 // of index merger processors, one for each node that has spans that
 // we are reading. The plan is finalized.
 func (dsp *DistSQLPlanner) createIndexBackfillerMergePhysicalPlan(
-	planCtx *PlanningCtx, spec execinfrapb.IndexBackfillMergerSpec, spans [][]roachpb.Span,
+	ctx context.Context,
+	planCtx *PlanningCtx,
+	spec execinfrapb.IndexBackfillMergerSpec,
+	spans [][]roachpb.Span,
 ) (*PhysicalPlan, error) {
 
 	var n int
@@ -140,7 +144,7 @@ func (dsp *DistSQLPlanner) createIndexBackfillerMergePhysicalPlan(
 		return idx
 	}
 
-	spanPartitions, err := dsp.PartitionSpans(planCtx, indexSpans)
+	spanPartitions, err := dsp.PartitionSpans(ctx, planCtx, indexSpans)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/distsql_plan_bulk.go
+++ b/pkg/sql/distsql_plan_bulk.go
@@ -50,7 +50,7 @@ func (dsp *DistSQLPlanner) setupAllNodesPlanningSystem(
 	// planCtx.NodeStatuses map ourselves. CheckInstanceHealthAndVersion() will
 	// populate it.
 	for _, node := range resp.Nodes {
-		_ /* NodeStatus */ = dsp.CheckInstanceHealthAndVersion(planCtx, base.SQLInstanceID(node.Desc.NodeID))
+		_ /* NodeStatus */ = dsp.CheckInstanceHealthAndVersion(ctx, planCtx, base.SQLInstanceID(node.Desc.NodeID))
 	}
 	nodes := make([]base.SQLInstanceID, 0, len(planCtx.NodeStatuses))
 	for nodeID, status := range planCtx.NodeStatuses {

--- a/pkg/sql/distsql_plan_ctas.go
+++ b/pkg/sql/distsql_plan_ctas.go
@@ -39,7 +39,7 @@ func PlanAndRunCTAS(
 		txn, distribute)
 	planCtx.stmtType = tree.Rows
 
-	physPlan, cleanup, err := dsp.createPhysPlan(planCtx, in)
+	physPlan, cleanup, err := dsp.createPhysPlan(ctx, planCtx, in)
 	defer cleanup()
 	if err != nil {
 		recv.SetError(errors.Wrapf(err, "constructing distSQL plan"))
@@ -55,5 +55,5 @@ func PlanAndRunCTAS(
 	// Make copy of evalCtx as Run might modify it.
 	evalCtxCopy := planner.ExtendedEvalContextCopy()
 	dsp.FinalizePlan(planCtx, physPlan)
-	dsp.Run(planCtx, txn, physPlan, recv, evalCtxCopy, nil /* finishedSetupFn */)()
+	dsp.Run(ctx, planCtx, txn, physPlan, recv, evalCtxCopy, nil /* finishedSetupFn */)()
 }

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -134,7 +134,9 @@ func (e *distSQLSpecExecFactory) ConstructValues(
 			specifiedInQuery: true,
 		}
 		planNodesToClose = []planNode{v}
-		physPlan, err = e.dsp.wrapPlan(planCtx, v, e.planningMode != distSQLLocalOnlyPlanning)
+		// TODO: don't use a stored context.
+		ctx := planCtx.EvalContext().Context
+		physPlan, err = e.dsp.wrapPlan(ctx, planCtx, v, e.planningMode != distSQLLocalOnlyPlanning)
 	} else {
 		// We can create a spec for the values processor, so we don't create a
 		// valuesNode.
@@ -163,7 +165,10 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 		return constructVirtualScan(
 			e, e.planner, table, index, params, reqOrdering,
 			func(d *delayedNode) (exec.Node, error) {
-				physPlan, err := e.dsp.wrapPlan(e.getPlanCtx(cannotDistribute), d, e.planningMode != distSQLLocalOnlyPlanning)
+				planCtx := e.getPlanCtx(cannotDistribute)
+				// TODO: don't use a stored context.
+				ctx := planCtx.EvalContext().Context
+				physPlan, err := e.dsp.wrapPlan(ctx, planCtx, d, e.planningMode != distSQLLocalOnlyPlanning)
 				if err != nil {
 					return nil, err
 				}
@@ -271,6 +276,7 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 	}
 
 	err = e.dsp.planTableReaders(
+		planCtx.EvalContext().Context, // TODO: don't use a stored context.
 		e.getPlanCtx(recommendation),
 		p,
 		&tableReaderPlanningInfo{
@@ -900,7 +906,8 @@ func (e *distSQLSpecExecFactory) ConstructExplain(
 		}
 	}
 
-	physPlan, err := e.dsp.wrapPlan(e.getPlanCtx(cannotDistribute), explainNode, e.planningMode != distSQLLocalOnlyPlanning)
+	planCtx := e.getPlanCtx(cannotDistribute)
+	physPlan, err := e.dsp.wrapPlan(planCtx.EvalContext().Context, planCtx, explainNode, e.planningMode != distSQLLocalOnlyPlanning)
 	if err != nil {
 		return nil, err
 	}
@@ -1040,7 +1047,8 @@ func (e *distSQLSpecExecFactory) ConstructOpaque(metadata opt.OpaqueMetadata) (e
 	if err != nil {
 		return nil, err
 	}
-	physPlan, err := e.dsp.wrapPlan(e.getPlanCtx(cannotDistribute), plan, e.planningMode != distSQLLocalOnlyPlanning)
+	planCtx := e.getPlanCtx(cannotDistribute)
+	physPlan, err := e.dsp.wrapPlan(planCtx.EvalContext().Context, planCtx, plan, e.planningMode != distSQLLocalOnlyPlanning)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -71,7 +71,7 @@ func (e *explainPlanNode) startExec(params runParams) error {
 		defer func() {
 			planCtx.planner.curPlan.subqueryPlans = outerSubqueries
 		}()
-		physicalPlan, err := newPhysPlanForExplainPurposes(planCtx, distSQLPlanner, plan.main)
+		physicalPlan, err := newPhysPlanForExplainPurposes(params.ctx, planCtx, distSQLPlanner, plan.main)
 		var diagramURL url.URL
 		var diagramJSON string
 		if err != nil {
@@ -239,12 +239,12 @@ func (e *explainPlanNode) Close(ctx context.Context) {
 }
 
 func newPhysPlanForExplainPurposes(
-	planCtx *PlanningCtx, distSQLPlanner *DistSQLPlanner, plan planMaybePhysical,
+	ctx context.Context, planCtx *PlanningCtx, distSQLPlanner *DistSQLPlanner, plan planMaybePhysical,
 ) (*PhysicalPlan, error) {
 	if plan.isPhysicalPlan() {
 		return plan.physPlan.PhysicalPlan, nil
 	}
-	physPlan, err := distSQLPlanner.createPhysPlanForPlanNode(planCtx, plan.planNode)
+	physPlan, err := distSQLPlanner.createPhysPlanForPlanNode(ctx, planCtx, plan.planNode)
 	// Release the resources right away since we won't be running the plan.
 	planCtx.getCleanupFunc()()
 	return physPlan, err

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -51,7 +51,7 @@ func (n *explainVecNode) startExec(params runParams) error {
 	defer func() {
 		planCtx.planner.curPlan.subqueryPlans = outerSubqueries
 	}()
-	physPlan, err := newPhysPlanForExplainPurposes(planCtx, distSQLPlanner, n.plan.main)
+	physPlan, err := newPhysPlanForExplainPurposes(params.ctx, planCtx, distSQLPlanner, n.plan.main)
 	if err != nil {
 		if len(n.plan.subqueryPlans) > 0 {
 			return errors.New("running EXPLAIN (VEC) on this query is " +

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -215,7 +215,7 @@ func distImport(
 		defer close(stopProgress)
 		// Copy the evalCtx, as dsp.Run() might change it.
 		evalCtxCopy := *evalCtx
-		dsp.Run(planCtx, nil, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
+		dsp.Run(ctx, planCtx, nil, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
 		return rowResultWriter.Err()
 	})
 

--- a/pkg/sql/index_backfiller.go
+++ b/pkg/sql/index_backfiller.go
@@ -180,7 +180,7 @@ func (ib *IndexBackfillPlanner) plan(
 		if err != nil {
 			return err
 		}
-		p, err = ib.execCfg.DistSQLPlanner.createBackfillerPhysicalPlan(planCtx, spec, sourceSpans)
+		p, err = ib.execCfg.DistSQLPlanner.createBackfillerPhysicalPlan(ctx, planCtx, spec, sourceSpans)
 		return err
 	}); err != nil {
 		return nil, err
@@ -201,7 +201,7 @@ func (ib *IndexBackfillPlanner) plan(
 		)
 		defer recv.Release()
 		evalCtxCopy := evalCtx
-		ib.execCfg.DistSQLPlanner.Run(planCtx, nil, p, recv, &evalCtxCopy, nil)()
+		ib.execCfg.DistSQLPlanner.Run(ctx, planCtx, nil, p, recv, &evalCtxCopy, nil)()
 		return cbw.Err()
 	}, nil
 }

--- a/pkg/sql/mvcc_backfiller.go
+++ b/pkg/sql/mvcc_backfiller.go
@@ -70,7 +70,7 @@ func (im *IndexBackfillerMergePlanner) plan(
 		if err != nil {
 			return err
 		}
-		p, err = im.execCfg.DistSQLPlanner.createIndexBackfillerMergePhysicalPlan(planCtx, spec, todoSpanList)
+		p, err = im.execCfg.DistSQLPlanner.createIndexBackfillerMergePhysicalPlan(ctx, planCtx, spec, todoSpanList)
 		return err
 	}); err != nil {
 		return nil, err
@@ -92,6 +92,7 @@ func (im *IndexBackfillerMergePlanner) plan(
 		defer recv.Release()
 		evalCtxCopy := evalCtx
 		im.execCfg.DistSQLPlanner.Run(
+			ctx,
 			planCtx,
 			nil, /* txn - the processors manage their own transactions */
 			p, recv, &evalCtxCopy,


### PR DESCRIPTION
Backport 1/1 commits from #79652.

/cc @cockroachdb/release

---

There are many places in the codebase where `planningCtx`s are passed between
goroutines and/or used inside closures that then have different (perhaps cancel-enabled) 
contexts in scope. In such cases, using the previously stored `planningCtx.ctx` ends up 
creating a bug, in that the code using it ignores the potentially cancelled context from 
where it was actually called. This is particularly true of most of the bulk flows which call 
`dsp.Run` in one of several `ctxgroup` tasks, others of which can fail and cancel the group's
context.

Instead, this change removes the ctx field and follows the golden rule of never store
a context.

Release note (bug fix): fix some cases where a job or schema change that had encountered an
error would continue to execute for some time before eventually failing.

Release justification: bug fix.