### PR TITLE
release-21.2: jobs: reset claim session ID when adoption is disabled

### DIFF
--- a/pkg/jobs/helpers_test.go
+++ b/pkg/jobs/helpers_test.go
@@ -99,7 +99,7 @@ const (
 	AdoptQuery                     = claimQuery
 	CancelQuery                    = pauseAndCancelUpdate
 	GcQuery                        = expiredJobsQuery
-	RemoveClaimsQuery              = removeClaimsQuery
+	RemoveClaimsQuery              = removeClaimsForDeadSessionsQuery
 	ProcessJobsQuery               = processQueryWithBackoff
 	IntervalBaseSettingKey         = intervalBaseSettingKey
 	AdoptIntervalSettingKey        = adoptIntervalSettingKey

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -737,7 +737,7 @@ func (r *Registry) UpdateJobWithTxn(
 // TODO (sajjad): make maxAdoptionsPerLoop a cluster setting.
 var maxAdoptionsPerLoop = envutil.EnvOrDefaultInt(`COCKROACH_JOB_ADOPTIONS_PER_PERIOD`, 10)
 
-const removeClaimsQuery = `
+const removeClaimsForDeadSessionsQuery = `
 UPDATE system.jobs
    SET claim_session_id = NULL
  WHERE claim_session_id in (
@@ -747,6 +747,14 @@ SELECT claim_session_id
    AND NOT crdb_internal.sql_liveness_is_alive(claim_session_id)
  FETCH FIRST $2 ROWS ONLY)
 `
+const removeClaimsForSessionQuery = `
+UPDATE system.jobs
+   SET claim_session_id = NULL
+ WHERE claim_session_id in (
+SELECT claim_session_id
+ WHERE claim_session_id = $1
+   AND status IN ` + claimableStatusTupleString + `
+)`
 
 // Start polls the current node for liveness failures and cancels all registered
 // jobs if it observes a failure. Otherwise it starts all the main daemons of
@@ -783,7 +791,7 @@ func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) error {
 			_, err := r.ex.ExecEx(
 				ctx, "expire-sessions", nil,
 				sessiondata.InternalExecutorOverride{User: security.RootUserName()},
-				removeClaimsQuery,
+				removeClaimsForDeadSessionsQuery,
 				s.ID().UnsafeBytes(),
 				cancellationsUpdateLimitSetting.Get(&r.settings.SV),
 			)
@@ -808,17 +816,44 @@ func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) error {
 	// claimJobs iterates the set of jobs which are not currently claimed and
 	// claims jobs up to maxAdoptionsPerLoop.
 	claimJobs := withSession(func(ctx context.Context, s sqlliveness.Session) {
+		if r.adoptionDisabled(ctx) {
+			log.Warningf(ctx, "job adoption is disabled, registry will not claim any jobs")
+			return
+		}
 		r.metrics.AdoptIterations.Inc(1)
 		if err := r.claimJobs(ctx, s); err != nil {
 			log.Errorf(ctx, "error claiming jobs: %s", err)
 		}
 	})
+	// removeClaimsFromJobs queries the jobs table for non-terminal jobs and
+	// nullifies their claims if the claims are owned by the current session.
+	removeClaimsFromSession := func(ctx context.Context, s sqlliveness.Session) {
+		if err := r.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			// Run the expiration transaction at low priority to ensure that it does
+			// not contend with foreground reads. Note that the adoption and cancellation
+			// queries also use low priority so they will interact nicely.
+			if err := txn.SetUserPriority(roachpb.MinUserPriority); err != nil {
+				return errors.WithAssertionFailure(err)
+			}
+			_, err := r.ex.ExecEx(
+				ctx, "remove-claims-for-session", nil,
+				sessiondata.InternalExecutorOverride{User: security.RootUserName()},
+				removeClaimsForSessionQuery, s.ID().UnsafeBytes(),
+			)
+			return err
+		}); err != nil {
+			log.Errorf(ctx, "error expiring job sessions: %s", err)
+		}
+	}
 	// processClaimedJobs iterates the jobs claimed by the current node that
 	// are in the running or reverting state, and then it starts those jobs if
 	// they are not already running.
 	processClaimedJobs := withSession(func(ctx context.Context, s sqlliveness.Session) {
+		// If job adoption is disabled for the registry then we remove our claim on
+		// all adopted job, and cancel them.
 		if r.adoptionDisabled(ctx) {
-			log.Warningf(ctx, "canceling all adopted jobs due to liveness failure")
+			log.Warningf(ctx, "job adoptions is disabled, canceling all adopted jobs due to liveness failure")
+			removeClaimsFromSession(ctx, s)
 			r.cancelAllAdoptedJobs()
 			return
 		}

--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -927,3 +927,42 @@ func TestJitterCalculation(t *testing.T) {
 		})
 	}
 }
+
+// TestDisablingJobAdoptionClearsClaimSessionID tests that jobs adopted by a
+// registry for which job adoption has been disabled, have their
+// claim_session_id cleared prior to having their context canceled. This will
+// allow other job registries in the cluster to claim and run this job.
+func TestDisablingJobAdoptionClearsClaimSessionID(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	intervalOverride := time.Millisecond
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			JobsTestingKnobs: &TestingKnobs{
+				DisableAdoptions: true,
+				IntervalOverrides: TestingIntervalOverrides{
+					Adopt:  &intervalOverride,
+					Cancel: &intervalOverride,
+				},
+			},
+		},
+	})
+	ctx := context.Background()
+	defer s.Stopper().Stop(ctx)
+	tdb := sqlutils.MakeSQLRunner(db)
+
+	r := s.JobRegistry().(*Registry)
+	session, err := r.sqlInstance.Session(ctx)
+	require.NoError(t, err)
+
+	// Insert a running job with a `claim_session_id` equal to our overridden test
+	// session.
+	tdb.Exec(t,
+		"INSERT INTO system.jobs (id, status, created, payload, claim_session_id) values ($1, $2, $3, 'test'::bytes, $4)",
+		1, StatusRunning, timeutil.Now(), session.ID(),
+	)
+
+	// We expect the adopt loop to clear the claim session since job adoption is
+	// disabled on this registry.
+	tdb.CheckQueryResultsRetry(t, `SELECT claim_session_id FROM system.jobs WHERE id = 1`, [][]string{{"NULL"}})
+}


### PR DESCRIPTION
This change fixes a bug where a registry that has its job adoption
disabled was not clearing the `claim_sesssion_id` for jobs that
it had already claimed, before cancelling them. This meant that other
registries in the cluster were unable to claim and run these jobs.

This change also makes it such that a registry with disabled job
adoption does not claim any new jobs.

Release note: None

Release justification: bug fix to existing functionality