### PR TITLE
kvserver: make allocator's disk utilization thresholds tunable

### DIFF
--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -1453,16 +1453,20 @@ func (a Allocator) RebalanceNonVoter(
 
 func (a *Allocator) scorerOptions() *rangeCountScorerOptions {
 	return &rangeCountScorerOptions{
-		deterministic:           a.storePool.deterministic,
-		rangeRebalanceThreshold: rangeRebalanceThreshold.Get(&a.storePool.st.SV),
+		deterministic:              a.storePool.deterministic,
+		rangeRebalanceThreshold:    rangeRebalanceThreshold.Get(&a.storePool.st.SV),
+		diskRebalanceToThreshold:   rebalanceToMaxFractionUsedThreshold.Get(&a.storePool.st.SV),
+		diskRebalanceFromThreshold: rebalanceFromMaxFractionUsedThreshold.Get(&a.storePool.st.SV),
 	}
 }
 
 func (a *Allocator) scorerOptionsForScatter() *scatterScorerOptions {
 	return &scatterScorerOptions{
 		rangeCountScorerOptions: rangeCountScorerOptions{
-			deterministic:           a.storePool.deterministic,
-			rangeRebalanceThreshold: 0,
+			deterministic:              a.storePool.deterministic,
+			rangeRebalanceThreshold:    0,
+			diskRebalanceToThreshold:   rebalanceToMaxFractionUsedThreshold.Get(&a.storePool.st.SV),
+			diskRebalanceFromThreshold: rebalanceFromMaxFractionUsedThreshold.Get(&a.storePool.st.SV),
 		},
 		// We set jitter to be equal to the padding around replica-count rebalancing
 		// because we'd like to make it such that rebalances made due to an

--- a/pkg/kv/kvserver/allocator_scorer_test.go
+++ b/pkg/kv/kvserver/allocator_scorer_test.go
@@ -1593,7 +1593,7 @@ func TestRebalanceConvergesRangeCountOnMean(t *testing.T) {
 	}
 }
 
-func TestMaxCapacity(t *testing.T) {
+func TestShouldShedReplicasBasedOnDiskCapacity(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -1603,9 +1603,10 @@ func TestMaxCapacity(t *testing.T) {
 		testStoreUSb:    true,
 		testStoreEurope: true,
 	}
+	options := rangeCountScorerOptions{diskRebalanceFromThreshold: rebalanceFromMaxFractionUsedDefault}
 
 	for _, s := range testStores {
-		if e, a := expectedCheck[s.StoreID], maxCapacityCheck(s); e != a {
+		if e, a := expectedCheck[s.StoreID], !options.rebalanceFromDiskCapacityCheck(s.Capacity); e != a {
 			t.Errorf("store %d expected max capacity check: %t, actual %t", s.StoreID, e, a)
 		}
 	}

--- a/pkg/kv/kvserver/store_pool.go
+++ b/pkg/kv/kvserver/store_pool.go
@@ -747,7 +747,7 @@ type StoreList struct {
 
 	// candidateRanges tracks range count stats for stores that are eligible to
 	// be rebalance targets (their used capacity percentage must be lower than
-	// maxFractionUsedThreshold).
+	// rebalanceFromMaxFractionUsedThreshold).
 	candidateRanges stat
 
 	// candidateLeases tracks range lease stats for stores that are eligible to
@@ -772,9 +772,7 @@ type StoreList struct {
 func makeStoreList(descriptors []roachpb.StoreDescriptor) StoreList {
 	sl := StoreList{stores: descriptors}
 	for _, desc := range descriptors {
-		if maxCapacityCheck(desc) {
-			sl.candidateRanges.update(float64(desc.Capacity.RangeCount))
-		}
+		sl.candidateRanges.update(float64(desc.Capacity.RangeCount))
 		sl.candidateLeases.update(float64(desc.Capacity.LeaseCount))
 		sl.candidateLogicalBytes.update(float64(desc.Capacity.LogicalBytes))
 		sl.candidateQueriesPerSecond.update(desc.Capacity.QueriesPerSecond)

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -251,9 +251,11 @@ func (sr *StoreRebalancer) Start(ctx context.Context, stopper *stop.Stopper) {
 // balance.
 func (sr *StoreRebalancer) scorerOptions() *qpsScorerOptions {
 	return &qpsScorerOptions{
-		deterministic:         sr.rq.allocator.storePool.deterministic,
-		qpsRebalanceThreshold: qpsRebalanceThreshold.Get(&sr.st.SV),
-		minRequiredQPSDiff:    minQPSDifferenceForTransfers.Get(&sr.st.SV),
+		deterministic:              sr.rq.allocator.storePool.deterministic,
+		qpsRebalanceThreshold:      qpsRebalanceThreshold.Get(&sr.st.SV),
+		minRequiredQPSDiff:         minQPSDifferenceForTransfers.Get(&sr.st.SV),
+		diskRebalanceToThreshold:   rebalanceToMaxFractionUsedThreshold.Get(&sr.st.SV),
+		diskRebalanceFromThreshold: rebalanceFromMaxFractionUsedThreshold.Get(&sr.st.SV),
 	}
 }
 


### PR DESCRIPTION
The allocator has two different disk space utilization thresholds that it uses
to determine a) when candidate stores are too full to be receiving any new
replicas, and b) when _existing_ stores are too full and should start shedding
replicas. Previously, these were static constants. This commit makes them
tunable.

Resolves https://github.com/cockroachdb/cockroach/issues/79461

Release note: none