### PR TITLE
cli: disable client-side query cancellation for now

### DIFF
--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -2010,6 +2010,14 @@ func (c *cliState) serverSideParse(sql string) (helpText string, err error) {
 	return "", nil
 }
 
+// At this time, lib/pq contains a bug whereby a query cancellation
+// results in the driver dropping the connection. This results in poor
+// user UX. Instead of suffering the UX drawback, we choose to disable
+// query cancellation for a little while more until we switch the shell
+// to use pgx instead.
+// See: https://github.com/cockroachdb/cockroach/issues/76483
+const queryCancelEnabled = false
+
 func (c *cliState) maybeHandleInterrupt() func() {
 	if !c.cliCtx.IsInteractive {
 		return func() {}
@@ -2017,49 +2025,66 @@ func (c *cliState) maybeHandleInterrupt() func() {
 	intCh := make(chan os.Signal, 1)
 	signal.Notify(intCh, os.Interrupt)
 	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		for {
-			select {
-			case <-intCh:
-				c.iCtx.mu.Lock()
-				cancelFn, doneCh := c.iCtx.mu.cancelFn, c.iCtx.mu.doneCh
-				c.iCtx.mu.Unlock()
-				if cancelFn == nil {
-					// No query currently executing; nothing to do.
-					continue
+
+	if !queryCancelEnabled {
+		go func() {
+			for {
+				select {
+				case <-ctx.Done():
+					// Shell is terminating.
+					return
+				case <-intCh:
 				}
-
-				fmt.Fprintf(c.iCtx.stderr, "\nattempting to cancel query...\n")
-				// Cancel the query's context, which should make the driver
-				// send a cancellation message.
-				cancelFn()
-
-				// Now wait for the shell to process the cancellation.
-				//
-				// If it takes too long (e.g. server has become unresponsive,
-				// or we're connected to a pre-22.1 server which does not
-				// support cancellation), fall back to the previous behavior
-				// which is to interrupt the shell altogether.
-				tooLongTimer := time.After(3 * time.Second)
-			wait:
-				for {
-					select {
-					case <-doneCh:
-						break wait
-					case <-tooLongTimer:
-						fmt.Fprintln(c.iCtx.stderr, "server does not respond to query cancellation; a second interrupt will stop the shell.")
-						signal.Reset(os.Interrupt)
-					}
-				}
-				// Re-arm the signal handler.
-				signal.Notify(intCh, os.Interrupt)
-
-			case <-ctx.Done():
-				// Shell is terminating.
-				return
+				fmt.Fprintln(c.iCtx.stderr,
+					"query cancellation disabled in this client; a second interrupt will stop the shell.")
+				signal.Reset(os.Interrupt)
 			}
-		}
-	}()
+		}()
+	} else {
+		go func() {
+			for {
+				select {
+				case <-intCh:
+					c.iCtx.mu.Lock()
+					cancelFn, doneCh := c.iCtx.mu.cancelFn, c.iCtx.mu.doneCh
+					c.iCtx.mu.Unlock()
+					if cancelFn == nil {
+						// No query currently executing; nothing to do.
+						continue
+					}
+
+					fmt.Fprintf(c.iCtx.stderr, "\nattempting to cancel query...\n")
+					// Cancel the query's context, which should make the driver
+					// send a cancellation message.
+					cancelFn()
+
+					// Now wait for the shell to process the cancellation.
+					//
+					// If it takes too long (e.g. server has become unresponsive,
+					// or we're connected to a pre-22.1 server which does not
+					// support cancellation), fall back to the previous behavior
+					// which is to interrupt the shell altogether.
+					tooLongTimer := time.After(3 * time.Second)
+				wait:
+					for {
+						select {
+						case <-doneCh:
+							break wait
+						case <-tooLongTimer:
+							fmt.Fprintln(c.iCtx.stderr, "server does not respond to query cancellation; a second interrupt will stop the shell.")
+							signal.Reset(os.Interrupt)
+						}
+					}
+					// Re-arm the signal handler.
+					signal.Notify(intCh, os.Interrupt)
+
+				case <-ctx.Done():
+					// Shell is terminating.
+					return
+				}
+			}
+		}()
+	}
 	return cancel
 }
 

--- a/pkg/cli/interactive_tests/test_interrupt.tcl.disabled
+++ b/pkg/cli/interactive_tests/test_interrupt.tcl.disabled
@@ -1,5 +1,7 @@
 #! /usr/bin/env expect -f
 
+# Disabled until https://github.com/cockroachdb/cockroach/issues/76483 is resolved.
+
 source [file join [file dirname $argv0] common.tcl]
 
 start_server $argv


### PR DESCRIPTION
As discussed in issue #76483, there's a bug in lib/pq
which causes the session to be aborted on query cancellation.

The resulting UX is just too poor; if the session terminates, there's
no real benefit in keeping the shell alive. The user may as well stop
the shell and then restart it, which makes the situation clearer.

This commit thus disables cancellation support in the client
temporarily until we fix #76483.

Release note (cli change): The mechanism for query cancellation
is disabled in the `sql` shell until a later patch release.