### PR TITLE
release-22.1: sql: implement SHOW CLUSTER SETTING FOR TENANT 

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_settings
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_settings
@@ -26,6 +26,11 @@ WHERE variable = 'sql.notices.enabled'
 ----
 false  per-tenant-override
 
+query B
+SHOW CLUSTER SETTING sql.notices.enabled FOR TENANT 10
+----
+false
+
 user root
 
 query B retry
@@ -43,6 +48,11 @@ query TT
 SELECT value, origin FROM [SHOW CLUSTER SETTINGS FOR TENANT 10] WHERE variable = 'sql.notices.enabled'
 ----
 NULL  no-override
+
+query T
+SHOW CLUSTER SETTING sql.notices.enabled FOR TENANT 10
+----
+NULL
 
 user root
 
@@ -62,6 +72,11 @@ SELECT value, origin FROM [SHOW CLUSTER SETTINGS FOR TENANT 10] WHERE variable =
 ----
 false  all-tenants-override
 
+query B
+SHOW CLUSTER SETTING sql.notices.enabled FOR TENANT 10
+----
+false
+
 user root
 
 query B retry
@@ -79,6 +94,11 @@ query TT
 SELECT value, origin FROM [SHOW CLUSTER SETTINGS FOR TENANT 10] WHERE variable = 'sql.notices.enabled'
 ----
 true  per-tenant-override
+
+query B
+SHOW CLUSTER SETTING sql.notices.enabled FOR TENANT 10
+----
+true
 
 user root
 
@@ -104,6 +124,11 @@ query TT
 SELECT value, origin FROM [SHOW CLUSTER SETTINGS FOR TENANT 10] WHERE variable = 'sql.notices.enabled'
 ----
 true  per-tenant-override
+
+query B
+SHOW CLUSTER SETTING sql.notices.enabled FOR TENANT 10
+----
+true
 
 user root
 
@@ -140,6 +165,11 @@ query TT
 SELECT value, origin FROM [SHOW CLUSTER SETTINGS FOR TENANT 10] WHERE variable = 'kv.protectedts.reconciliation.interval'
 ----
 45s  per-tenant-override
+
+query T
+SHOW CLUSTER SETTING kv.protectedts.reconciliation.interval FOR TENANT 10
+----
+00:00:45
 
 user root
 

--- a/pkg/settings/bool.go
+++ b/pkg/settings/bool.go
@@ -46,11 +46,16 @@ func (b *BoolSetting) EncodedDefault() string {
 
 // DecodeToString decodes and renders an encoded value.
 func (b *BoolSetting) DecodeToString(encoded string) (string, error) {
-	bv, err := strconv.ParseBool(encoded)
+	bv, err := b.DecodeValue(encoded)
 	if err != nil {
 		return "", err
 	}
 	return EncodeBool(bv), nil
+}
+
+// DecodeValue decodes the value into a float.
+func (b *BoolSetting) DecodeValue(encoded string) (bool, error) {
+	return strconv.ParseBool(encoded)
 }
 
 // Typ returns the short (1 char) string denoting the type of setting.

--- a/pkg/settings/byte_size.go
+++ b/pkg/settings/byte_size.go
@@ -35,7 +35,7 @@ func (b *ByteSizeSetting) String(sv *Values) string {
 
 // DecodeToString decodes and renders an encoded value.
 func (b *ByteSizeSetting) DecodeToString(encoded string) (string, error) {
-	iv, err := b.decodeNum(encoded)
+	iv, err := b.DecodeValue(encoded)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/settings/common.go
+++ b/pkg/settings/common.go
@@ -127,6 +127,6 @@ type internalSetting interface {
 // numericSetting is used for settings that can be set using an integer value.
 type numericSetting interface {
 	internalSetting
-	decodeNum(value string) (int64, error)
+	DecodeValue(value string) (int64, error)
 	set(ctx context.Context, sv *Values, value int64) error
 }

--- a/pkg/settings/duration.go
+++ b/pkg/settings/duration.go
@@ -62,11 +62,16 @@ func (d *DurationSetting) EncodedDefault() string {
 
 // DecodeToString decodes and renders an encoded value.
 func (d *DurationSetting) DecodeToString(encoded string) (string, error) {
-	v, err := time.ParseDuration(encoded)
+	v, err := d.DecodeValue(encoded)
 	if err != nil {
 		return "", err
 	}
 	return EncodeDuration(v), nil
+}
+
+// DecodeValue decodes the value into a float.
+func (d *DurationSetting) DecodeValue(encoded string) (time.Duration, error) {
+	return time.ParseDuration(encoded)
 }
 
 // Typ returns the short (1 char) string denoting the type of setting.

--- a/pkg/settings/enum.go
+++ b/pkg/settings/enum.go
@@ -45,7 +45,7 @@ func (e *EnumSetting) String(sv *Values) string {
 
 // DecodeToString decodes and renders an encoded value.
 func (e *EnumSetting) DecodeToString(encoded string) (string, error) {
-	v, err := e.decodeNum(encoded)
+	v, err := e.DecodeValue(encoded)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/settings/float.go
+++ b/pkg/settings/float.go
@@ -50,11 +50,16 @@ func (f *FloatSetting) EncodedDefault() string {
 
 // DecodeToString decodes and renders an encoded value.
 func (f *FloatSetting) DecodeToString(encoded string) (string, error) {
-	fv, err := strconv.ParseFloat(encoded, 64)
+	fv, err := f.DecodeValue(encoded)
 	if err != nil {
 		return "", err
 	}
 	return EncodeFloat(fv), nil
+}
+
+// DecodeValue decodes the value into a float.
+func (f *FloatSetting) DecodeValue(encoded string) (float64, error) {
+	return strconv.ParseFloat(encoded, 64)
 }
 
 // Typ returns the short (1 char) string denoting the type of setting.

--- a/pkg/settings/int.go
+++ b/pkg/settings/int.go
@@ -49,14 +49,15 @@ func (i *IntSetting) EncodedDefault() string {
 
 // DecodeToString decodes and renders an encoded value.
 func (i *IntSetting) DecodeToString(encoded string) (string, error) {
-	iv, err := i.decodeNum(encoded)
+	iv, err := i.DecodeValue(encoded)
 	if err != nil {
 		return "", err
 	}
 	return EncodeInt(iv), nil
 }
 
-func (i *IntSetting) decodeNum(value string) (int64, error) {
+// DecodeValue decodes the value into an integer.
+func (i *IntSetting) DecodeValue(value string) (int64, error) {
 	return strconv.ParseInt(value, 10, 64)
 }
 

--- a/pkg/settings/updater.go
+++ b/pkg/settings/updater.go
@@ -92,32 +92,32 @@ func (u updater) Set(ctx context.Context, key string, value EncodedValue) error 
 	case *StringSetting:
 		return setting.set(ctx, u.sv, value.Value)
 	case *BoolSetting:
-		b, err := strconv.ParseBool(value.Value)
+		b, err := setting.DecodeValue(value.Value)
 		if err != nil {
 			return err
 		}
 		setting.set(ctx, u.sv, b)
 		return nil
 	case numericSetting:
-		i, err := setting.decodeNum(value.Value)
+		i, err := setting.DecodeValue(value.Value)
 		if err != nil {
 			return err
 		}
 		return setting.set(ctx, u.sv, i)
 	case *FloatSetting:
-		f, err := strconv.ParseFloat(value.Value, 64)
+		f, err := setting.DecodeValue(value.Value)
 		if err != nil {
 			return err
 		}
 		return setting.set(ctx, u.sv, f)
 	case *DurationSetting:
-		d, err := time.ParseDuration(value.Value)
+		d, err := setting.DecodeValue(value.Value)
 		if err != nil {
 			return err
 		}
 		return setting.set(ctx, u.sv, d)
 	case *DurationSettingWithExplicitUnit:
-		d, err := time.ParseDuration(value.Value)
+		d, err := setting.DecodeValue(value.Value)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/delegate/show_all_cluster_settings.go
+++ b/pkg/sql/delegate/show_all_cluster_settings.go
@@ -81,7 +81,7 @@ func (d *delegator) delegateShowTenantClusterSettingList(
 	// cannot evaluate it in the go code.
 	return parse(`
 WITH
-  tenant_id AS (SELECT (` + stmt.TenantID.String() + `) AS tenant_id),
+  tenant_id AS (SELECT (` + stmt.TenantID.String() + `):::INT AS tenant_id),
   isvalid AS (
     SELECT
       CASE

--- a/pkg/sql/logictest/testdata/logic_test/cluster_settings
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_settings
@@ -200,7 +200,7 @@ statement error ALTER TENANT can only be called by system operators
 ALTER TENANT 10 SET CLUSTER SETTING server.mem_profile.total_dump_size_limit='10M'
 
 skipif config 3node-tenant
-statement error cannot use ALTER TENANT to change cluster settings in system tenant
+statement error cannot use this statement to access cluster settings in system tenant
 ALTER TENANT 1 SET CLUSTER SETTING server.mem_profile.total_dump_size_limit='10M'
 
 skipif config 3node-tenant
@@ -223,9 +223,28 @@ skipif config 3node-tenant
 statement ok
 ALTER TENANT ALL RESET CLUSTER SETTING server.mem_profile.total_dump_size_limit
 
-skipif config 3node-tenant
-statement error unimplemented
+onlyif config 3node-tenant
+statement error SHOW CLUSTER SETTING FOR TENANT can only be called by system operators
 SHOW CLUSTER SETTING server.mem_profile.total_dump_size_limit FOR TENANT 10
+
+skipif config 3node-tenant
+query error tenant ID must be non-zero
+SHOW CLUSTER SETTING server.mem_profile.total_dump_size_limit FOR TENANT 0
+
+
+skipif config 3node-tenant
+query error use SHOW CLUSTER SETTING to display a setting for the system tenant
+SHOW CLUSTER SETTING server.mem_profile.total_dump_size_limit FOR TENANT 1
+
+skipif config 3node-tenant
+query error no tenant found with ID 1111
+SHOW CLUSTER SETTING server.mem_profile.total_dump_size_limit FOR TENANT 1111
+
+skipif config 3node-tenant
+query T
+SHOW CLUSTER SETTING server.mem_profile.total_dump_size_limit FOR TENANT 10
+----
+NULL
 
 onlyif config 3node-tenant
 query error SHOW CLUSTER SETTINGS FOR TENANT can only be called by system operators

--- a/pkg/sql/show_cluster_setting.go
+++ b/pkg/sql/show_cluster_setting.go
@@ -132,7 +132,12 @@ func (p *planner) ShowClusterSetting(
 		return nil, errors.AssertionFailedf("setting is masked: %v", name)
 	}
 
-	return planShowClusterSetting(setting, name,
+	columns, err := getShowClusterSettingPlanColumns(setting, name)
+	if err != nil {
+		return nil, err
+	}
+
+	return planShowClusterSetting(setting, name, columns,
 		func(ctx context.Context, p *planner) (bool, string, error) {
 			if verSetting, ok := setting.(*settings.VersionSetting); ok {
 				encoded, err := p.getCurrentEncodedVersionSettingValue(ctx, verSetting, name)
@@ -143,11 +148,9 @@ func (p *planner) ShowClusterSetting(
 	)
 }
 
-func planShowClusterSetting(
-	val settings.NonMaskedSetting,
-	name string,
-	getEncodedValue func(ctx context.Context, p *planner) (bool, string, error),
-) (planNode, error) {
+func getShowClusterSettingPlanColumns(
+	val settings.NonMaskedSetting, name string,
+) (colinfo.ResultColumns, error) {
 	var dType *types.T
 	switch val.(type) {
 	case *settings.IntSetting:
@@ -165,8 +168,15 @@ func planShowClusterSetting(
 	default:
 		return nil, errors.Errorf("unknown setting type for %s: %s", name, val.Typ())
 	}
+	return colinfo.ResultColumns{{Name: name, Typ: dType}}, nil
+}
 
-	columns := colinfo.ResultColumns{{Name: name, Typ: dType}}
+func planShowClusterSetting(
+	val settings.NonMaskedSetting,
+	name string,
+	columns colinfo.ResultColumns,
+	getEncodedValue func(ctx context.Context, p *planner) (bool, string, error),
+) (planNode, error) {
 	return &delayedNode{
 		name:    "SHOW CLUSTER SETTING " + name,
 		columns: columns,

--- a/pkg/sql/show_cluster_setting.go
+++ b/pkg/sql/show_cluster_setting.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -36,9 +35,13 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-func (p *planner) showVersionSetting(
-	ctx context.Context, st *cluster.Settings, s *settings.VersionSetting, name string,
+// getCurrentEncodedVersionSettingValue returns the encoded value of
+// the version setting. The caller is responsible for decoding the
+// value to transform it to a user-facing string.
+func (p *planner) getCurrentEncodedVersionSettingValue(
+	ctx context.Context, s *settings.VersionSetting, name string,
 ) (string, error) {
+	st := p.ExecCfg().Settings
 	var res string
 	// For the version setting we show the value from the KV store and
 	// additionally wait for the local setting instance to have observed the
@@ -98,12 +101,7 @@ func (p *planner) showVersionSetting(
 							localRawVal, kvRawVal, ctx.Err(), timeutil.Since(tBegin))
 					}
 
-					val, err := s.Decode(kvRawVal)
-					if err != nil {
-						return err
-					}
-
-					res = val.String()
+					res = string(kvRawVal)
 					return nil
 				})
 			})
@@ -118,7 +116,6 @@ func (p *planner) ShowClusterSetting(
 	ctx context.Context, n *tree.ShowClusterSetting,
 ) (planNode, error) {
 	name := strings.ToLower(n.Name)
-	st := p.ExecCfg().Settings
 	val, ok := settings.Lookup(
 		name, settings.LookupForLocalAccess, p.ExecCfg().Codec.ForSystemTenant(),
 	)
@@ -130,6 +127,27 @@ func (p *planner) ShowClusterSetting(
 		return nil, err
 	}
 
+	setting, ok := val.(settings.NonMaskedSetting)
+	if !ok {
+		return nil, errors.AssertionFailedf("setting is masked: %v", name)
+	}
+
+	return planShowClusterSetting(setting, name,
+		func(ctx context.Context, p *planner) (bool, string, error) {
+			if verSetting, ok := setting.(*settings.VersionSetting); ok {
+				encoded, err := p.getCurrentEncodedVersionSettingValue(ctx, verSetting, name)
+				return true, encoded, err
+			}
+			return true, setting.Encoded(&p.ExecCfg().Settings.SV), nil
+		},
+	)
+}
+
+func planShowClusterSetting(
+	val settings.NonMaskedSetting,
+	name string,
+	getEncodedValue func(ctx context.Context, p *planner) (bool, string, error),
+) (planNode, error) {
 	var dType *types.T
 	switch val.(type) {
 	case *settings.IntSetting:
@@ -153,32 +171,55 @@ func (p *planner) ShowClusterSetting(
 		name:    "SHOW CLUSTER SETTING " + name,
 		columns: columns,
 		constructor: func(ctx context.Context, p *planner) (planNode, error) {
+			isNotNull, encoded, err := getEncodedValue(ctx, p)
+			if err != nil {
+				return nil, err
+			}
+
 			var d tree.Datum
-			switch s := val.(type) {
-			case *settings.IntSetting:
-				d = tree.NewDInt(tree.DInt(s.Get(&st.SV)))
-			case *settings.StringSetting:
-				d = tree.NewDString(s.String(&st.SV))
-			case *settings.BoolSetting:
-				d = tree.MakeDBool(tree.DBool(s.Get(&st.SV)))
-			case *settings.FloatSetting:
-				d = tree.NewDFloat(tree.DFloat(s.Get(&st.SV)))
-			case *settings.DurationSetting:
-				d = &tree.DInterval{Duration: duration.MakeDuration(s.Get(&st.SV).Nanoseconds(), 0, 0)}
-			case *settings.DurationSettingWithExplicitUnit:
-				d = &tree.DInterval{Duration: duration.MakeDuration(s.Get(&st.SV).Nanoseconds(), 0, 0)}
-			case *settings.EnumSetting:
-				d = tree.NewDString(s.String(&st.SV))
-			case *settings.ByteSizeSetting:
-				d = tree.NewDString(s.String(&st.SV))
-			case *settings.VersionSetting:
-				valStr, err := p.showVersionSetting(ctx, st, s, name)
-				if err != nil {
-					return nil, err
+			d = tree.DNull
+			if isNotNull {
+				switch s := val.(type) {
+				case *settings.IntSetting:
+					v, err := s.DecodeValue(encoded)
+					if err != nil {
+						return nil, err
+					}
+					d = tree.NewDInt(tree.DInt(v))
+				case *settings.StringSetting, *settings.EnumSetting,
+					*settings.ByteSizeSetting, *settings.VersionSetting:
+					v, err := val.DecodeToString(encoded)
+					if err != nil {
+						return nil, err
+					}
+					d = tree.NewDString(v)
+				case *settings.BoolSetting:
+					v, err := s.DecodeValue(encoded)
+					if err != nil {
+						return nil, err
+					}
+					d = tree.MakeDBool(tree.DBool(v))
+				case *settings.FloatSetting:
+					v, err := s.DecodeValue(encoded)
+					if err != nil {
+						return nil, err
+					}
+					d = tree.NewDFloat(tree.DFloat(v))
+				case *settings.DurationSetting:
+					v, err := s.DecodeValue(encoded)
+					if err != nil {
+						return nil, err
+					}
+					d = &tree.DInterval{Duration: duration.MakeDuration(v.Nanoseconds(), 0, 0)}
+				case *settings.DurationSettingWithExplicitUnit:
+					v, err := s.DecodeValue(encoded)
+					if err != nil {
+						return nil, err
+					}
+					d = &tree.DInterval{Duration: duration.MakeDuration(v.Nanoseconds(), 0, 0)}
+				default:
+					return nil, errors.AssertionFailedf("unknown setting type for %s: %s (%T)", name, val.Typ(), val)
 				}
-				d = tree.NewDString(valStr)
-			default:
-				return nil, errors.Errorf("unknown setting type for %s: %s", name, val.Typ())
 			}
 
 			v := p.newContainerValuesNode(columns, 0)


### PR DESCRIPTION
Backport 2/2 commits from #77794.

/cc @cockroachdb/release

---

Fixes #77471

Release justification: needed for SRE ops in serverlesss
