### PR TITLE
release-22.1: changefeedccl: fix alter changefeed to handle targets with fully qualified names

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -609,6 +609,251 @@ func TestAlterChangefeedAddTargetErrors(t *testing.T) {
 	t.Run(`kafka`, kafkaTest(testFn, feedTestNoTenants))
 }
 
+func TestAlterChangefeedDatabaseQualifiedNames(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE DATABASE movr`)
+		sqlDB.Exec(t, `CREATE TABLE movr.drivers (id INT PRIMARY KEY, name STRING)`)
+		sqlDB.Exec(t, `CREATE TABLE movr.users (id INT PRIMARY KEY, name STRING)`)
+		sqlDB.Exec(t,
+			`INSERT INTO movr.drivers VALUES (1, 'Alice')`,
+		)
+		sqlDB.Exec(t,
+			`INSERT INTO movr.users VALUES (1, 'Bob')`,
+		)
+		testFeed := feed(t, f, `CREATE CHANGEFEED FOR movr.drivers WITH resolved = '100ms', diff`)
+		defer closeFeed(t, testFeed)
+
+		assertPayloads(t, testFeed, []string{
+			`drivers: [1]->{"after": {"id": 1, "name": "Alice"}, "before": null}`,
+		})
+
+		expectResolvedTimestamp(t, testFeed)
+
+		feed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+		require.True(t, ok)
+
+		require.NoError(t, feed.Pause())
+
+		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d ADD movr.users WITH initial_scan UNSET diff`, feed.JobID()))
+
+		require.NoError(t, feed.Resume())
+
+		assertPayloads(t, testFeed, []string{
+			`users: [1]->{"after": {"id": 1, "name": "Bob"}}`,
+		})
+
+		sqlDB.Exec(t,
+			`INSERT INTO movr.drivers VALUES (3, 'Carol')`,
+		)
+
+		assertPayloads(t, testFeed, []string{
+			`drivers: [3]->{"after": {"id": 3, "name": "Carol"}}`,
+		})
+	}
+
+	t.Run(`kafka`, kafkaTest(testFn))
+}
+
+func TestAlterChangefeedDatabaseScope(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE DATABASE movr`)
+		sqlDB.Exec(t, `CREATE DATABASE new_movr`)
+
+		sqlDB.Exec(t, `CREATE TABLE movr.drivers (id INT PRIMARY KEY, name STRING)`)
+		sqlDB.Exec(t, `CREATE TABLE new_movr.drivers (id INT PRIMARY KEY, name STRING)`)
+
+		sqlDB.Exec(t,
+			`INSERT INTO movr.drivers VALUES (1, 'Alice')`,
+		)
+		sqlDB.Exec(t,
+			`INSERT INTO new_movr.drivers VALUES (1, 'Bob')`,
+		)
+
+		testFeed := feed(t, f, `CREATE CHANGEFEED FOR movr.drivers WITH diff`)
+		defer closeFeed(t, testFeed)
+
+		assertPayloads(t, testFeed, []string{
+			`drivers: [1]->{"after": {"id": 1, "name": "Alice"}, "before": null}`,
+		})
+
+		feed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+		require.True(t, ok)
+
+		require.NoError(t, feed.Pause())
+
+		sqlDB.Exec(t, `USE new_movr`)
+
+		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d DROP movr.drivers ADD drivers WITH initial_scan UNSET diff`, feed.JobID()))
+
+		require.NoError(t, feed.Resume())
+
+		assertPayloads(t, testFeed, []string{
+			`drivers: [1]->{"after": {"id": 1, "name": "Bob"}}`,
+		})
+	}
+
+	t.Run(`kafka`, kafkaTest(testFn))
+}
+
+func TestAlterChangefeedDatabaseScopeUnqualifiedName(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE DATABASE movr`)
+		sqlDB.Exec(t, `CREATE DATABASE new_movr`)
+
+		sqlDB.Exec(t, `CREATE TABLE movr.drivers (id INT PRIMARY KEY, name STRING)`)
+		sqlDB.Exec(t, `CREATE TABLE new_movr.drivers (id INT PRIMARY KEY, name STRING)`)
+
+		sqlDB.Exec(t,
+			`INSERT INTO movr.drivers VALUES (1, 'Alice')`,
+		)
+
+		sqlDB.Exec(t, `USE movr`)
+		testFeed := feed(t, f, `CREATE CHANGEFEED FOR drivers WITH diff, resolved = '100ms'`)
+		defer closeFeed(t, testFeed)
+
+		assertPayloads(t, testFeed, []string{
+			`drivers: [1]->{"after": {"id": 1, "name": "Alice"}, "before": null}`,
+		})
+
+		expectResolvedTimestamp(t, testFeed)
+
+		feed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+		require.True(t, ok)
+
+		require.NoError(t, feed.Pause())
+
+		sqlDB.Exec(t, `USE new_movr`)
+
+		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d UNSET diff`, feed.JobID()))
+
+		require.NoError(t, feed.Resume())
+
+		sqlDB.Exec(t,
+			`INSERT INTO movr.drivers VALUES (2, 'Bob')`,
+		)
+
+		assertPayloads(t, testFeed, []string{
+			`drivers: [2]->{"after": {"id": 2, "name": "Bob"}}`,
+		})
+	}
+
+	t.Run(`kafka`, kafkaTest(testFn))
+}
+
+func TestAlterChangefeedColumnFamilyDatabaseScope(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE DATABASE movr`)
+		sqlDB.Exec(t, `CREATE TABLE movr.drivers (id INT PRIMARY KEY, name STRING, FAMILY onlyid (id), FAMILY onlyname (name))`)
+
+		sqlDB.Exec(t,
+			`INSERT INTO movr.drivers VALUES (1, 'Alice')`,
+		)
+
+		testFeed := feed(t, f, `CREATE CHANGEFEED FOR movr.drivers WITH diff, split_column_families`)
+		defer closeFeed(t, testFeed)
+
+		assertPayloads(t, testFeed, []string{
+			`drivers.onlyid: [1]->{"after": {"id": 1}, "before": null}`,
+			`drivers.onlyname: [1]->{"after": {"name": "Alice"}, "before": null}`,
+		})
+
+		feed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+		require.True(t, ok)
+
+		require.NoError(t, feed.Pause())
+
+		sqlDB.Exec(t, `USE movr`)
+
+		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d DROP movr.drivers ADD movr.drivers FAMILY onlyid ADD drivers FAMILY onlyname UNSET diff`, feed.JobID()))
+
+		require.NoError(t, feed.Resume())
+
+		sqlDB.Exec(t,
+			`INSERT INTO movr.drivers VALUES (2, 'Bob')`,
+		)
+
+		assertPayloads(t, testFeed, []string{
+			`drivers.onlyid: [2]->{"after": {"id": 2}}`,
+			`drivers.onlyname: [2]->{"after": {"name": "Bob"}}`,
+		})
+	}
+
+	t.Run(`kafka`, kafkaTest(testFn))
+}
+
+func TestAlterChangefeedAlterTableName(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE DATABASE movr`)
+		sqlDB.Exec(t, `CREATE TABLE movr.users (id INT PRIMARY KEY, name STRING)`)
+		sqlDB.Exec(t,
+			`INSERT INTO movr.users VALUES (1, 'Alice')`,
+		)
+		testFeed := feed(t, f, `CREATE CHANGEFEED FOR movr.users WITH diff, resolved = '100ms'`)
+		defer closeFeed(t, testFeed)
+
+		assertPayloads(t, testFeed, []string{
+			`users: [1]->{"after": {"id": 1, "name": "Alice"}, "before": null}`,
+		})
+
+		expectResolvedTimestamp(t, testFeed)
+
+		waitForSchemaChange(t, sqlDB, `ALTER TABLE movr.users RENAME TO movr.riders`)
+
+		var tsLogical string
+		sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&tsLogical)
+
+		ts := parseTimeToHLC(t, tsLogical)
+
+		// ensure that the high watermark has progressed past the time in which the
+		// schema change occurred
+		testutils.SucceedsSoon(t, func() error {
+			resolvedTS, _ := expectResolvedTimestamp(t, testFeed)
+			if resolvedTS.Less(ts) {
+				return errors.New("waiting for resolved timestamp to progress past the schema change event")
+			}
+			return nil
+		})
+
+		feed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+		require.True(t, ok)
+
+		require.NoError(t, feed.Pause())
+
+		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d UNSET diff`, feed.JobID()))
+
+		require.NoError(t, feed.Resume())
+
+		sqlDB.Exec(t,
+			`INSERT INTO movr.riders VALUES (2, 'Bob')`,
+		)
+		assertPayloads(t, testFeed, []string{
+			`users: [2]->{"after": {"id": 2, "name": "Bob"}}`,
+		})
+	}
+
+	t.Run(`kafka`, kafkaTest(testFn))
+}
+
 func TestAlterChangefeedInitialScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -71,12 +71,28 @@ func init() {
 	)
 }
 
+type annotatedChangefeedStatement struct {
+	*tree.CreateChangefeed
+	originalSpecs map[tree.ChangefeedTarget]jobspb.ChangefeedTargetSpecification
+}
+
+func getChangefeedStatement(stmt tree.Statement) *annotatedChangefeedStatement {
+	switch changefeed := stmt.(type) {
+	case *annotatedChangefeedStatement:
+		return changefeed
+	case *tree.CreateChangefeed:
+		return &annotatedChangefeedStatement{CreateChangefeed: changefeed}
+	default:
+		return nil
+	}
+}
+
 // changefeedPlanHook implements sql.PlanHookFn.
 func changefeedPlanHook(
 	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
 ) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
-	changefeedStmt, ok := stmt.(*tree.CreateChangefeed)
-	if !ok {
+	changefeedStmt := getChangefeedStatement(stmt)
+	if changefeedStmt == nil {
 		return nil, nil, nil, false, nil
 	}
 
@@ -246,7 +262,7 @@ func changefeedPlanHook(
 func createChangefeedJobRecord(
 	ctx context.Context,
 	p sql.PlanHookState,
-	changefeedStmt *tree.CreateChangefeed,
+	changefeedStmt *annotatedChangefeedStatement,
 	sinkURI string,
 	opts map[string]string,
 	jobID jobspb.JobID,
@@ -277,7 +293,7 @@ func createChangefeedJobRecord(
 		// Still serialize the experimental_ form for backwards compatibility
 	}
 
-	jobDescription, err := changefeedJobDescription(p, changefeedStmt, sinkURI, opts)
+	jobDescription, err := changefeedJobDescription(p, changefeedStmt.CreateChangefeed, sinkURI, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -325,7 +341,7 @@ func createChangefeedJobRecord(
 		return nil, err
 	}
 
-	targets, tables, err := getTargetsAndTables(ctx, p, targetDescs, changefeedStmt.Targets, opts)
+	targets, tables, err := getTargetsAndTables(ctx, p, targetDescs, changefeedStmt.Targets, changefeedStmt.originalSpecs, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -560,45 +576,69 @@ func getTargetsAndTables(
 	p sql.PlanHookState,
 	targetDescs []catalog.Descriptor,
 	rawTargets tree.ChangefeedTargets,
+	originalSpecs map[tree.ChangefeedTarget]jobspb.ChangefeedTargetSpecification,
 	opts map[string]string,
 ) ([]jobspb.ChangefeedTargetSpecification, jobspb.ChangefeedTargets, error) {
 	tables := make(jobspb.ChangefeedTargets, len(targetDescs))
 	targets := make([]jobspb.ChangefeedTargetSpecification, len(rawTargets))
+	seen := make(map[jobspb.ChangefeedTargetSpecification]tree.ChangefeedTarget)
 
-	for _, desc := range targetDescs {
-		if table, isTable := desc.(catalog.TableDescriptor); isTable {
-			if err := p.CheckPrivilege(ctx, desc, privilege.SELECT); err != nil {
-				return nil, nil, err
-			}
-			_, qualified := opts[changefeedbase.OptFullTableName]
-			name, err := getChangefeedTargetName(ctx, table, p.ExecCfg(), p.ExtendedEvalContext().Txn, qualified)
-			if err != nil {
-				return nil, nil, err
-			}
-			tables[table.GetID()] = jobspb.ChangefeedTargetTable{
-				StatementTimeName: name,
-			}
-		}
-	}
 	for i, ct := range rawTargets {
 		td, err := matchDescriptorToTablePattern(ctx, p, targetDescs, ct.TableName)
 		if err != nil {
 			return nil, nil, err
 		}
-		typ := jobspb.ChangefeedTargetSpecification_PRIMARY_FAMILY_ONLY
-		if ct.FamilyName != "" {
-			typ = jobspb.ChangefeedTargetSpecification_COLUMN_FAMILY
+
+		if err := p.CheckPrivilege(ctx, td, privilege.SELECT); err != nil {
+			return nil, nil, err
+		}
+
+		if spec, ok := originalSpecs[ct]; ok {
+			targets[i] = spec
+			if table, ok := tables[td.GetID()]; ok {
+				if table.StatementTimeName != spec.StatementTimeName {
+					return nil, nil, errors.Errorf(
+						`table with id %d is referenced with multiple statement time names: %q and %q`, td.GetID(),
+						table.StatementTimeName, spec.StatementTimeName)
+				}
+			} else {
+				tables[td.GetID()] = jobspb.ChangefeedTargetTable{
+					StatementTimeName: spec.StatementTimeName,
+				}
+			}
 		} else {
-			if td.NumFamilies() > 1 {
-				typ = jobspb.ChangefeedTargetSpecification_EACH_FAMILY
+			_, qualified := opts[changefeedbase.OptFullTableName]
+			name, err := getChangefeedTargetName(ctx, td, p.ExecCfg(), p.ExtendedEvalContext().Txn, qualified)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			tables[td.GetID()] = jobspb.ChangefeedTargetTable{
+				StatementTimeName: name,
+			}
+			typ := jobspb.ChangefeedTargetSpecification_PRIMARY_FAMILY_ONLY
+			if ct.FamilyName != "" {
+				typ = jobspb.ChangefeedTargetSpecification_COLUMN_FAMILY
+			} else {
+				if td.NumFamilies() > 1 {
+					typ = jobspb.ChangefeedTargetSpecification_EACH_FAMILY
+				}
+			}
+			targets[i] = jobspb.ChangefeedTargetSpecification{
+				Type:              typ,
+				TableID:           td.GetID(),
+				FamilyName:        string(ct.FamilyName),
+				StatementTimeName: tables[td.GetID()].StatementTimeName,
 			}
 		}
-		targets[i] = jobspb.ChangefeedTargetSpecification{
-			Type:              typ,
-			TableID:           td.GetID(),
-			FamilyName:        string(ct.FamilyName),
-			StatementTimeName: tables[td.GetID()].StatementTimeName,
+
+		if dup, isDup := seen[targets[i]]; isDup {
+			return nil, nil, errors.Errorf(
+				"CHANGEFEED targets %s and %s are duplicates",
+				tree.AsString(&dup), tree.AsString(&ct),
+			)
 		}
+		seen[targets[i]] = ct
 	}
 	return targets, tables, nil
 }

--- a/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
+++ b/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
@@ -422,7 +422,7 @@ func TestShowChangefeedJobsAlterChangefeed(t *testing.T) {
 		out = obtainJobRowFn()
 
 		require.Equal(t, jobID, out.id, "Expected id:%d but found id:%d", jobID, out.id)
-		require.Equal(t, "CREATE CHANGEFEED FOR TABLE bar INTO 'kafka://does.not.matter/'", out.description, "Expected description:%s but found description:%s", "CREATE CHANGEFEED FOR TABLE bar INTO 'kafka://does.not.matter/'", out.description)
+		require.Equal(t, "CREATE CHANGEFEED FOR TABLE d.public.bar INTO 'kafka://does.not.matter/'", out.description, "Expected description:%s but found description:%s", "CREATE CHANGEFEED FOR TABLE bar INTO 'kafka://does.not.matter/'", out.description)
 		require.Equal(t, sinkURI, out.SinkURI, "Expected sinkUri:%s but found sinkUri:%s", sinkURI, out.SinkURI)
 		require.Equal(t, "bar", out.topics, "Expected topics:%s but found topics:%s", "bar", sortedTopics)
 		require.Equal(t, "{d.public.bar}", string(out.FullTableNames), "Expected fullTableNames:%s but found fullTableNames:%s", "{d.public.bar}", string(out.FullTableNames))
@@ -433,7 +433,7 @@ func TestShowChangefeedJobsAlterChangefeed(t *testing.T) {
 		out = obtainJobRowFn()
 
 		require.Equal(t, jobID, out.id, "Expected id:%d but found id:%d", jobID, out.id)
-		require.Equal(t, "CREATE CHANGEFEED FOR TABLE bar INTO 'kafka://does.not.matter/' WITH resolved = '5s'", out.description, "Expected description:%s but found description:%s", "CREATE CHANGEFEED FOR TABLE bar INTO 'kafka://does.not.matter/ WITH resolved = '5s''", out.description)
+		require.Equal(t, "CREATE CHANGEFEED FOR TABLE d.public.bar INTO 'kafka://does.not.matter/' WITH resolved = '5s'", out.description, "Expected description:%s but found description:%s", "CREATE CHANGEFEED FOR TABLE bar INTO 'kafka://does.not.matter/ WITH resolved = '5s''", out.description)
 		require.Equal(t, sinkURI, out.SinkURI, "Expected sinkUri:%s but found sinkUri:%s", sinkURI, out.SinkURI)
 		require.Equal(t, "bar", out.topics, "Expected topics:%s but found topics:%s", "bar", sortedTopics)
 		require.Equal(t, "{d.public.bar}", string(out.FullTableNames), "Expected fullTableNames:%s but found fullTableNames:%s", "{d.public.bar}", string(out.FullTableNames))


### PR DESCRIPTION
Backport 1/1 commits from #79542.

/cc @cockroachdb/release

---

changefeedccl: fix alter changefeed to handle targets with
fully qualified names

Resolves #79502

Currently, the ALTER CHANGEFEED statement would not work
with changefeeds that use fully qualified names in their
CREATE CHANGEFEED statement. This is because when we try
to include the existing targets, we would drop the
database/schema name that the user provided. Hence, when
we perform validation checks on the existing + new
changefeed targets, we would not be able to resolve the
existing targets that used fully qualified names and we
would return an error.

In this PR we ensure that we add each existing target
with their fully qualified name so that we can resolve
these targets in our validation checks. A consequence of
this change is that now every changefeed will display
the fully qualified name of every target in the
SHOW CHANGEFEED JOB query.

Release note (enterprise change): Fix the issue of not
being able to resolve existing targets when performing
validation checks by adding the fully qualified name
to the changefeed statement. As a result, every altered
changefeed will display the fully qualified name of every
target in the SHOW CHANGEFEED JOB query.

Release justification: Low risk bug fix.
