### PR TITLE
jobs,builtins: add crdb_internal.job_debug_state to inspect exec state

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2993,6 +2993,8 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.is_at_least_version"></a><code>crdb_internal.is_at_least_version(version: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if the cluster version is not older than the argument.</p>
 </span></td></tr>
+<tr><td><a name="crdb_internal.job_debug_state"></a><code>crdb_internal.job_debug_state(job_id: <a href="int.html">int</a>) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Validate all TTL tables have a valid scheduled job attached.</p>
+</span></td></tr>
 <tr><td><a name="crdb_internal.lease_holder"></a><code>crdb_internal.lease_holder(key: <a href="bytes.html">bytes</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used to fetch the leaseholder corresponding to a request key</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.list_sql_keys_in_range"></a><code>crdb_internal.list_sql_keys_in_range(range_id: <a href="int.html">int</a>) &rarr; tuple{string AS key, string AS value}</code></td><td><span class="funcdesc"><p>Returns all SQL K/V pairs within the requested range.</p>

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -23,6 +23,7 @@ import "sql/catalog/descpb/tenant.proto";
 import "util/hlc/timestamp.proto";
 import "clusterversion/cluster_version.proto";
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/any.proto";
 
 enum EncryptionMode {
   Passphrase = 0;
@@ -1059,4 +1060,16 @@ message RetriableExecutionFailure {
   // that the error was too large. While the structure may be lost, at least
   // some information will be preserved.
   string truncated_error = 6;
+}
+
+// ExecutionInfo holds ephemeral information about the current execution of a 
+// job, for use in introspection and debugging. This could include information
+// extracted from traces, recorded during planning, or noted by the job itself.
+message ExecutionInfo {
+
+  // Details is avilable for individual jobs for job-specific details. 
+  google.protobuf.Any details = 1;
+
+  // CurrentDistPlan is the job's most recently started distributed flow plan.
+  string current_dist_plan = 2;
 }

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -838,6 +838,20 @@ func (p *PlanningCtx) flowSpecsToDiagram(
 	return diagram, nil
 }
 
+// GetDiagram gets the diagram URI string for the specified plan.
+func (p *PhysicalPlan) GetDiagram(stmt string) (string, error) {
+	specs := p.GenerateFlowSpecs()
+	diag, err := execinfrapb.GeneratePlanDiagram(stmt, specs, execinfrapb.DiagramFlags{})
+	if err != nil {
+		return "", err
+	}
+	_, u, err := diag.ToURL()
+	if err != nil {
+		return "", err
+	}
+	return u.String(), nil
+}
+
 // getCleanupFunc returns a non-nil function that needs to be called after the
 // local flow finished running. This can be called only after the physical
 // planning has been completed.

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -288,6 +288,11 @@ func (*DummyEvalPlanner) RepairTTLScheduledJobForTable(ctx context.Context, tabl
 	return errors.WithStack(errEvalPlanner)
 }
 
+// DebugJobInfo is part of the EvalPlanner interface.
+func (*DummyEvalPlanner) DebugJobInfo(ctx context.Context, jobID int64) (*tree.DJSON, error) {
+	return nil, errors.WithStack(errEvalPlanner)
+}
+
 // ExecutorConfig is part of the EvalPlanner interface.
 func (*DummyEvalPlanner) ExecutorConfig() interface{} {
 	return nil

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -6547,6 +6547,22 @@ table's zone configuration this will return NULL.`,
 		},
 	),
 
+	"crdb_internal.job_debug_state": makeBuiltin(
+		tree.FunctionProperties{
+			Category: categorySystemInfo,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"job_id", types.Int}},
+			ReturnType: tree.FixedReturnType(types.Jsonb),
+			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				jobID := tree.MustBeDInt(args[0])
+				return evalCtx.Planner.DebugJobInfo(evalCtx.Context, int64(jobID))
+			},
+			Info:       `Validate all TTL tables have a valid scheduled job attached.`,
+			Volatility: tree.VolatilityVolatile,
+		},
+	),
+
 	"crdb_internal.validate_ttl_scheduled_jobs": makeBuiltin(
 		tree.FunctionProperties{
 			Category: categorySystemInfo,

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3318,6 +3318,8 @@ type EvalPlanner interface {
 	// it is invalid.
 	RepairTTLScheduledJobForTable(ctx context.Context, tableID int64) error
 
+	DebugJobInfo(ctx context.Context, jobID int64) (*DJSON, error)
+
 	// QueryRowEx executes the supplied SQL statement and returns a single row, or
 	// nil if no row is found, or an error if more that one row is returned.
 	//


### PR DESCRIPTION
This is a stub of an idea for adding addtional introspection facilities to jobs,
via new ExecutionInfo field that the node coordinating execution manages and provides
access to via its registry. For now, this object is kept only in memory in the registry's
existing map of jobs it is executing, but in the future it could be serialized and persisted.

How this object is populated/updates remains an open question. For now, this change adds a
direct mutation API that one job -- IMPORT -- uses to set/update one field at a particular
point in job execution, specifically, to update the plan diagram info with the latest plan
when it starts execution of a distributed flow. However longer-term, it may be possible to
automatically populate this structure from the trace events associated with the job's
execution, e.g. if the job resumer (or even the registry?) were to start a process which
watched the job's trace events and extracted events or aggregations of events to update
fields in this object.

Release note: none.