### PR TITLE
kvserver: slightly optimize allocs in tick

### DIFF
--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -300,6 +300,14 @@ func shouldReplicaQuiesce(
 		}
 		return nil, nil, false
 	}
+
+	if q.hasRaftReadyRLocked() {
+		if log.V(4) {
+			log.Infof(ctx, "not quiescing: raft ready")
+		}
+		return nil, nil, false
+	}
+
 	status := q.raftStatusRLocked()
 	if status == nil {
 		if log.V(4) {
@@ -387,12 +395,6 @@ func shouldReplicaQuiesce(
 		if log.V(4) {
 			log.Infof(ctx, "not quiescing: %d not found in progress: %+v",
 				status.ID, status.Progress)
-		}
-		return nil, nil, false
-	}
-	if q.hasRaftReadyRLocked() {
-		if log.V(4) {
-			log.Infof(ctx, "not quiescing: raft ready")
 		}
 		return nil, nil, false
 	}


### PR DESCRIPTION
Saw this in a random heap profile during recent experiments.  We could reduce
these allocations by calling `BasicStatus` instead of `Status` and then
visiting the progresses in-place, but that's a more complicated change.

There's a decent chance that most of the time we don't even need to call
`Status()` because there's a ready anyway.

![image](https://user-images.githubusercontent.com/5076964/162733534-fb821e03-0907-4850-a85c-cf1a76fd9de8.png)

Release note: None
