### PR TITLE
util/contextutil: clarify `RunWithTimeout` error message

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -7390,8 +7390,9 @@ func TestBackupExportRequestTimeout(t *testing.T) {
 	// export request but since the intent was laid by a high priority txn it
 	// should hang. The timeout should save us in this case.
 	_, err := sqlSessions[1].DB.ExecContext(ctx, "BACKUP data.bank TO 'nodelocal://0/timeout'")
-	require.True(t, testutils.IsError(err,
-		`timeout: operation "ExportRequest for span /Table/\d+/.*\" timed out after 3s`))
+	require.Regexp(t,
+		`timeout: operation "ExportRequest for span /Table/\d+/.*\" timed out after \S+ \(given timeout 3s\)`,
+		err.Error())
 }
 
 func TestBackupDoesNotHangOnIntent(t *testing.T) {

--- a/pkg/util/contextutil/timeout_error.go
+++ b/pkg/util/contextutil/timeout_error.go
@@ -55,10 +55,16 @@ func (t *TimeoutError) Format(s fmt.State, verb rune) { errors.FormatError(t, s,
 
 // FormatError implements errors.Formatter.
 func (t *TimeoutError) FormatError(p errors.Printer) error {
-	p.Printf("operation %q timed out after %s", t.operation, t.timeout)
+	// NB: With RunWithTimeout(), it is possible for both the caller and the
+	// callee to have set their own context timeout that is smaller than the
+	// timeout set by RunWithTimeout. It is also possible for the operation to run
+	// for much longer than the timeout, e.g. if the callee does not check the
+	// context in a timely manner. The error message must make this clear.
+	p.Printf("operation %q timed out", t.operation)
 	if t.took != 0 {
-		p.Printf(" (took %s)", t.took.Round(time.Millisecond))
+		p.Printf(" after %s", t.took.Round(time.Millisecond))
 	}
+	p.Printf(" (given timeout %s)", t.timeout)
 	return t.cause
 }
 


### PR DESCRIPTION
`RunWithTimeout` gave an error message of this form:

```
operation "send-snapshot" timed out after 1m (took 1m): context deadline exceeded
```

However, this can be misleading because either the caller or callee can
set their own context timeout that is less than then one set by
`RunWithTimeout`, in which case it looks like:

```
operation "send-snapshot" timed out after 1m (took 1s): context deadline exceeded
```

This is even worse on old versions, where the "took 1s" is not included,
leading the reader to believe the operation actually took 1m when it
only took 1s.

This patch clarifies the error message somewhat:

```
operation "send-snapshot" timed out after 1s (given timeout 1m): context deadline exceeded
```

Resolves #79424.

Release note: None