### PR TITLE
kvserver: include closedTS in ReplicaUnavailableError

### DIFF
--- a/pkg/kv/kvserver/replica_circuit_breaker.go
+++ b/pkg/kv/kvserver/replica_circuit_breaker.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 	"go.etcd.io/etcd/raft/v3"
@@ -258,6 +259,7 @@ func replicaUnavailableError(
 	replDesc roachpb.ReplicaDescriptor,
 	lm liveness.IsLiveMap,
 	rs *raft.Status,
+	closedTS hlc.Timestamp,
 ) error {
 	nonLiveRepls := roachpb.MakeReplicaSet(nil)
 	for _, rDesc := range desc.Replicas().Descriptors() {
@@ -278,16 +280,18 @@ func replicaUnavailableError(
 	var _ redact.SafeFormatter = desc
 	var _ redact.SafeFormatter = replDesc
 
-	if len(nonLiveRepls.AsProto()) > 0 {
-		err = errors.Wrapf(err, "replicas on non-live nodes: %v (lost quorum: %t)", nonLiveRepls, !canMakeProgress)
+	var buf redact.StringBuilder
+	if !canMakeProgress {
+		buf.Printf("lost quorum (down: %v); ", nonLiveRepls)
 	}
-
-	err = errors.Wrapf(
-		err,
-		"raft status: %+v", redact.Safe(rs), // raft status contains no PII
+	buf.Printf(
+		"closed timestamp: %s (%s); raft status: %+v",
+		closedTS,
+		redact.Safe(timeutil.Unix(0, closedTS.WallTime).UTC().Format("2006-01-02 15:04:05")),
+		redact.Safe(rs), /* raft status contains no PII */
 	)
 
-	return roachpb.NewReplicaUnavailableError(err, desc, replDesc)
+	return roachpb.NewReplicaUnavailableError(errors.Wrapf(err, "%s", buf), desc, replDesc)
 }
 
 func (r *Replica) replicaUnavailableError(err error) error {
@@ -295,5 +299,6 @@ func (r *Replica) replicaUnavailableError(err error) error {
 	replDesc, _ := desc.GetReplicaDescriptor(r.store.StoreID())
 
 	isLiveMap, _ := r.store.livenessMap.Load().(liveness.IsLiveMap)
-	return replicaUnavailableError(err, desc, replDesc, isLiveMap, r.RaftStatus())
+	ct := r.GetCurrentClosedTimestamp(context.Background())
+	return replicaUnavailableError(err, desc, replDesc, isLiveMap, r.RaftStatus(), ct)
 }

--- a/pkg/kv/kvserver/testdata/replica_unavailable_error.txt
+++ b/pkg/kv/kvserver/testdata/replica_unavailable_error.txt
@@ -1,3 +1,3 @@
 echo
 ----
-replica unavailable: (n1,s10):1 unable to serve request to r10:‹{a-z}› [(n1,s10):1, (n2,s20):2, next=3, gen=0]: raft status: {"id":"0","term":0,"vote":"0","commit":0,"lead":"0","raftState":"StateFollower","applied":0,"progress":{},"leadtransferee":"0"}: replicas on non-live nodes: (n2,s20):2 (lost quorum: true): probe failed
+replica unavailable: (n1,s10):1 unable to serve request to r10:‹{a-z}› [(n1,s10):1, (n2,s20):2, next=3, gen=0]: lost quorum (down: (n2,s20):2); closed timestamp: 1136214245.000000000,0 (2006-01-02 15:04:05); raft status: {"id":"0","term":0,"vote":"0","commit":0,"lead":"0","raftState":"StateFollower","applied":0,"progress":{},"leadtransferee":"0"}: probe failed


### PR DESCRIPTION
This is helpful as the closed timestamp is the best candidate for AOST queries
to use for at least that replica.

Release note: None
