### PR TITLE
asim: random load generator

### DIFF
--- a/pkg/kv/kvserver/asim/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/BUILD.bazel
@@ -1,22 +1,30 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "asim_lib",
-    srcs = ["asim.go"],
+    name = "asim",
+    srcs = [
+        "asim.go",
+        "workload.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/kv/kvserver",
         "//pkg/roachpb",
+        "//pkg/util/timeutil",
         "@com_github_google_btree//:btree",
     ],
 )
 
 go_test(
     name = "asim_test",
-    srcs = ["asim_test.go"],
+    srcs = [
+        "asim_test.go",
+        "workload_test.go",
+    ],
+    embed = [":asim"],
     deps = [
-        ":asim_lib",
+        "//pkg/util/timeutil",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/kv/kvserver/asim/asim.go
+++ b/pkg/kv/kvserver/asim/asim.go
@@ -19,27 +19,6 @@ import (
 	"github.com/google/btree"
 )
 
-// LoadEvent represent a kv operation such as a read or write.
-// TODO(lidor): support batches in the initial implementation.
-type LoadEvent struct {
-}
-
-// WorkloadGenerator generates workload where each op contains: key,
-// op type (e.g., read/write), size.
-type WorkloadGenerator interface {
-	// GetNext returns a LoadEvent which happens before maxTime, if exists.
-	GetNext(maxTime time.Time) (done bool, event LoadEvent)
-}
-
-// RandomWorkloadGenerator generates random operations within some limits.
-type RandomWorkloadGenerator struct {
-}
-
-// GetNext is part of the WorkloadGenerator interface.
-func (rwg *RandomWorkloadGenerator) GetNext(maxTime time.Time) (done bool, event LoadEvent) {
-	return true, LoadEvent{}
-}
-
 // ConfigEvent can be, for example, adding or removing a node in a region.
 type ConfigEvent struct {
 }

--- a/pkg/kv/kvserver/asim/workload.go
+++ b/pkg/kv/kvserver/asim/workload.go
@@ -1,0 +1,177 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package asim
+
+import (
+	"container/list"
+	"math/rand"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// LoadEvent represent a key access that generates load against the database.
+type LoadEvent struct {
+	isWrite bool
+	size    int64
+	key     int64
+}
+
+// WorkloadGenerator generates workload where each op contains: key,
+// op type (e.g., read/write), size.
+type WorkloadGenerator interface {
+	// GetNext returns a LoadEvent which happens before or at maxTime, if exists.
+	GetNext(maxTime time.Time) (done bool, event LoadEvent)
+}
+
+// RandomWorkloadGenerator generates random operations within some limits.
+type RandomWorkloadGenerator struct {
+	seed           int64
+	keyGenerator   keyGenerator
+	rand           *rand.Rand
+	lastRun        time.Time
+	rollsPerSecond float64
+	readRatio      float64
+	maxSize        int
+	minSize        int
+	opBuffer       list.List
+}
+
+func newRandomWorkloadGenerator(
+	seed int64, keyGenerator keyGenerator, rate float64, readRatio float64, maxSize int, minSize int,
+) *RandomWorkloadGenerator {
+	return &RandomWorkloadGenerator{
+		seed:           seed,
+		keyGenerator:   keyGenerator,
+		rand:           keyGenerator.rand(),
+		lastRun:        timeutil.Now().UTC(),
+		rollsPerSecond: rate,
+		readRatio:      readRatio,
+		maxSize:        maxSize,
+		minSize:        minSize,
+	}
+}
+
+// GetNext is part of the WorkloadGenerator interface.
+func (rwg *RandomWorkloadGenerator) GetNext(maxTime time.Time) (done bool, event LoadEvent) {
+	rwg.maybeUpdateBuffer(maxTime)
+	if next := rwg.opBuffer.Front(); next != nil {
+		rwg.opBuffer.Remove(next)
+		return false, next.Value.(LoadEvent)
+	}
+	return true, LoadEvent{}
+}
+
+// maybeUpdateBuffer checks the elapsed duration since last generating
+// operations and the maxTime passed in. If the duration multiplied by the rate
+// of operations per second is greater than or equal to 1, the operation buffer
+// is updated with new generated operations.
+func (rwg *RandomWorkloadGenerator) maybeUpdateBuffer(maxTime time.Time) {
+	elapsed := maxTime.Sub(rwg.lastRun).Seconds()
+	count := int(elapsed * rwg.rollsPerSecond)
+	// Do not attempt to generate additional load events if the elapsed
+	// duration is not sufficiently large. If we did, this would bump the last
+	// run to maxTime and we may end up in a cycle where no events are ever
+	// generated if the rate of load events is less than the interval at which
+	// this function is called.
+	if count < 1 {
+		return
+	}
+
+	// Here we skew slightly towards writes to take the difference in rounding.
+	reads := int(float64(count) * rwg.readRatio)
+	writes := count - reads
+	for read := 0; read < reads; read++ {
+		rwg.opBuffer.PushBack(
+			LoadEvent{
+				size:    int64(rwg.rand.Intn(rwg.maxSize-rwg.minSize+1) + rwg.minSize),
+				isWrite: false,
+				key:     rwg.keyGenerator.readKey(),
+			})
+	}
+	for write := 0; write < writes; write++ {
+		rwg.opBuffer.PushBack(
+			LoadEvent{
+				size:    int64(rwg.rand.Intn(rwg.maxSize-rwg.minSize+1) + rwg.minSize),
+				isWrite: true,
+				key:     rwg.keyGenerator.writeKey(),
+			})
+	}
+	rwg.lastRun = maxTime
+}
+
+// keyGenerator generates read and write keys.
+type keyGenerator interface {
+	writeKey() int64
+	readKey() int64
+	rand() *rand.Rand
+}
+
+// uniformGenerator generates keys with a uniform distribution. Note that keys
+// do not necessarily need to be written before they may have a read issued
+// against them.
+type uniformGenerator struct {
+	cycle  int64
+	random *rand.Rand
+}
+
+func newUniformGenerator(cycle int64, rand *rand.Rand) *uniformGenerator {
+	return &uniformGenerator{
+		cycle:  cycle,
+		random: rand,
+	}
+}
+
+func (g *uniformGenerator) writeKey() int64 {
+	return g.random.Int63n(g.cycle)
+}
+
+func (g *uniformGenerator) readKey() int64 {
+	return g.random.Int63n(g.cycle)
+}
+
+func (g *uniformGenerator) rand() *rand.Rand {
+	return g.random
+}
+
+// zipfianGenerator generates keys with a power-rank distribution. Note that keys
+// do not necessarily need to be written before they may have a read issued
+// against them.
+type zipfianGenerator struct {
+	cycle  int64
+	random *rand.Rand
+	zipf   *rand.Zipf
+}
+
+// newZipfianGenerator returns a key generator that generates reads and writes
+// following a Zipfian distribution. Where few keys are relatively frequent,
+// whilst the others are infrequently accessed. The generator generates values
+// k ∈ [0, cycle] such that P(k) is proportional to (v + k) ** (-s).
+// Requirements: cycle > 0, s > 1, and v >= 1
+func newZipfianGenerator(cycle int64, s float64, v float64, random *rand.Rand) *zipfianGenerator {
+	return &zipfianGenerator{
+		cycle:  cycle,
+		random: random,
+		zipf:   rand.NewZipf(random, s, v, uint64(cycle)),
+	}
+}
+
+func (g *zipfianGenerator) writeKey() int64 {
+	return int64(g.zipf.Uint64())
+}
+
+func (g *zipfianGenerator) readKey() int64 {
+	return int64(g.zipf.Uint64())
+}
+
+func (g *zipfianGenerator) rand() *rand.Rand {
+	return g.random
+}

--- a/pkg/kv/kvserver/asim/workload_test.go
+++ b/pkg/kv/kvserver/asim/workload_test.go
@@ -1,0 +1,134 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package asim
+
+import (
+	"math"
+	"math/rand"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
+)
+
+const testingSeed = 1
+
+type summaryStats struct {
+	writes, reads, size int
+	quartiles           [3]int
+}
+
+func quartiles(keyspace []int) [3]int {
+	sort.Ints(keyspace)
+	size := len(keyspace)
+	return [3]int{keyspace[size/4], keyspace[size/2], keyspace[(3*size)/4]}
+}
+
+func summary(ops []LoadEvent, cycleLength int) summaryStats {
+	writes := 0
+	reads := 0
+	sizeSum := 0
+	distribution := make([]int, len(ops))
+	for i, op := range ops {
+		sizeSum += int(op.size)
+		distribution[i] = int(op.key)
+		if op.isWrite {
+			writes++
+		} else {
+			reads++
+		}
+	}
+	return summaryStats{
+		writes:    writes,
+		reads:     reads,
+		size:      sizeSum,
+		quartiles: quartiles(distribution),
+	}
+}
+
+// TestRandWorkloadGenerator asserts that the randomly generated load is within
+// the range of possibility, given the input variables. In addition, the seed
+// for each test is fixed to testingSeed, the results are asserted on
+// deterministically with this assumption.
+func TestRandWorkloadGenerator(t *testing.T) {
+	cycleLength := 100
+	testCases := []struct {
+		keyGenerator      keyGenerator
+		rate              float64
+		readRatio         float64
+		maxSize           int
+		minSize           int
+		duration          time.Duration
+		expectedQuartiles [3]int
+		expectedReadRatio float64
+	}{
+		{
+			keyGenerator:      newUniformGenerator(int64(cycleLength), rand.New(rand.NewSource(testingSeed))),
+			rate:              10,
+			readRatio:         0.75,
+			maxSize:           1000,
+			minSize:           100,
+			duration:          1000 * time.Second,
+			expectedQuartiles: [3]int{25, 49, 75},
+		},
+		{
+			keyGenerator:      newUniformGenerator(int64(cycleLength), rand.New(rand.NewSource(testingSeed))),
+			rate:              10,
+			readRatio:         0.5,
+			maxSize:           1000,
+			minSize:           100,
+			duration:          1000 * time.Second,
+			expectedQuartiles: [3]int{25, 49, 75},
+		},
+		{
+			keyGenerator:      newZipfianGenerator(int64(cycleLength), 1.1, 1, rand.New(rand.NewSource(testingSeed))),
+			rate:              10,
+			readRatio:         0.75,
+			maxSize:           1000,
+			minSize:           100,
+			duration:          1000 * time.Second,
+			expectedQuartiles: [3]int{1, 4, 20},
+		},
+		{
+			keyGenerator:      newZipfianGenerator(int64(cycleLength), 1.1, 1, rand.New(rand.NewSource(testingSeed))),
+			rate:              10,
+			readRatio:         0.5,
+			maxSize:           1000,
+			minSize:           100,
+			duration:          1000 * time.Second,
+			expectedQuartiles: [3]int{1, 4, 20},
+		},
+	}
+
+	for _, tc := range testCases {
+		start := timeutil.Now().UTC()
+		workLoadGenerator := newRandomWorkloadGenerator(testingSeed, tc.keyGenerator, tc.rate, tc.readRatio, tc.maxSize, tc.minSize)
+		workLoadGenerator.lastRun = start
+		end := start.Add(tc.duration)
+
+		done := false
+		ops := make([]LoadEvent, 0)
+		next := LoadEvent{}
+		for !done {
+			done, next = workLoadGenerator.GetNext(end)
+			ops = append(ops, next)
+		}
+		stats := summary(ops, cycleLength)
+		count := stats.reads + stats.writes
+		require.Equal(t, 1+int(tc.rate)*(int(tc.duration)/int(time.Second)), count)
+		require.GreaterOrEqual(t, float64(stats.size)/float64(count), float64(tc.minSize))
+		require.LessOrEqual(t, stats.size/(count*1.0), tc.maxSize)
+		require.Equal(t, tc.expectedQuartiles, stats.quartiles)
+		require.Equal(t, math.Round(tc.readRatio*100), math.Round((float64(stats.reads)/float64(stats.reads+stats.writes))*100))
+	}
+}


### PR DESCRIPTION
This patch introduces a random workload generator for the allocator
simulator. The choice variables that exist are: (1) key access
distribution, (2) load event size, (3) read-write ratio and (4) rate of
load events.

Among these (1) and (2) are generated according to a probability
distribution. (3) and (4) are not random and are instead the rate of
reads vs. writes and operations generated per second respectively.

The intention is to support multiple distribution for key accesses,
similar to kv workload. Currently, only a uniform and zipfian
distribution are supported.

Release note: None