### PR TITLE
roachtest: remove c.Reset() in tpccbench

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1895,18 +1895,6 @@ func (c *clusterImpl) Stop(
 	}
 }
 
-func (c *clusterImpl) Reset(ctx context.Context, l *logger.Logger) error {
-	if c.t.Failed() {
-		return errors.New("already failed")
-	}
-	if ctx.Err() != nil {
-		return errors.Wrap(ctx.Err(), "cluster.Reset")
-	}
-	c.status("resetting cluster")
-	defer c.status()
-	return errors.Wrap(roachprod.Reset(l, c.name), "cluster.Reset")
-}
-
 // WipeE wipes a subset of the nodes in a cluster. See cluster.Start() for a
 // description of the nodes parameter.
 func (c *clusterImpl) WipeE(ctx context.Context, l *logger.Logger, nodes ...option.Option) error {

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -113,7 +113,6 @@ type Cluster interface {
 
 	// Internal niche tools.
 
-	Reset(ctx context.Context, l *logger.Logger) error
 	Reformat(ctx context.Context, l *logger.Logger, node option.NodeListOption, filesystem string) error
 	Install(
 		ctx context.Context, l *logger.Logger, nodes option.NodeListOption, software ...string,


### PR DESCRIPTION
This was originally introduced when CRDB could push the VM to brown out
(sometimes forever), which lost us lost of signal from `tpccbench` (on top of
causing flakes).

However, for a long time now we've deployed CRDB in a cgroup that leaves enough
headroom for the OS to reliably oomkill CRDB if necessary, so `c.Reset` is no
longer necessary.

Fixes https://github.com/cockroachdb/cockroach/issues/79568.

Release note: None
