### PR TITLE
release-21.2: Backport sequence transaction bug fixes

### DIFF
--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -417,7 +417,7 @@ func (so *importSequenceOperators) SetSequenceValue(
 
 // SetSequenceValueByID implements the tree.SequenceOperators interface.
 func (so *importSequenceOperators) SetSequenceValueByID(
-	ctx context.Context, seqID int64, newVal int64, isCalled bool,
+	ctx context.Context, seqID uint32, newVal int64, isCalled bool,
 ) error {
 	return errSequenceOperators
 }

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -56,6 +56,7 @@ go_library(
         "create_table.go",
         "create_type.go",
         "create_view.go",
+        "created_sequence.go",
         "data_source.go",
         "database.go",
         "database_region_change_finalizer.go",

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -844,6 +844,8 @@ func (s *Server) newConnExecutor(
 
 	ex.extraTxnState.hasAdminRoleCache = HasAdminRoleCache{}
 
+	ex.extraTxnState.createdSequences = make(map[descpb.ID]struct{})
+
 	ex.initPlanner(ctx, &ex.planner)
 
 	return ex
@@ -1268,6 +1270,10 @@ type connExecutor struct {
 		// has admin privilege. hasAdminRoleCache is set for the first statement
 		// in a transaction.
 		hasAdminRoleCache HasAdminRoleCache
+
+		// createdSequences keeps track of sequences created in the current transaction.
+		// The map key is the sequence descpb.ID.
+		createdSequences map[descpb.ID]struct{}
 	}
 
 	// sessionDataStack contains the user-configurable connection variables.
@@ -1486,6 +1492,9 @@ func (ex *connExecutor) resetExtraTxnState(ctx context.Context, ev txnEvent) err
 		p.decRef(ctx, &ex.extraTxnState.prepStmtsNamespaceMemAcc, name)
 		delete(ex.extraTxnState.prepStmtsNamespace.portals, name)
 	}
+
+	// Close all cursors.
+	ex.extraTxnState.createdSequences = make(map[descpb.ID]struct{})
 
 	switch ev {
 	case txnCommit, txnRollback:
@@ -2506,6 +2515,7 @@ func (ex *connExecutor) initPlanner(ctx context.Context, p *planner) {
 	p.sessionDataMutatorIterator = ex.dataMutatorIterator
 	p.noticeSender = nil
 	p.preparedStatements = ex.getPrepStmtsAccessor()
+	p.createdSequences = ex.getCreatedSequencesAccessor()
 
 	p.queryCacheSession.Init()
 	p.optPlanningCtx.init(p)
@@ -2844,6 +2854,12 @@ func (ex *connExecutor) serialize() serverpb.Session {
 
 func (ex *connExecutor) getPrepStmtsAccessor() preparedStatementsAccessor {
 	return connExPrepStmtsAccessor{
+		ex: ex,
+	}
+}
+
+func (ex *connExecutor) getCreatedSequencesAccessor() createdSequences {
+	return connExCreatedSequencesAccessor{
 		ex: ex,
 	}
 }

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -153,6 +153,9 @@ func doCreateSequence(
 	// Initialize the sequence value.
 	seqValueKey := p.ExecCfg().Codec.SequenceKey(uint32(id))
 	b := &kv.Batch{}
+	if err := p.createdSequences.addCreatedSequence(id); err != nil {
+		return nil, err
+	}
 	b.Inc(seqValueKey, desc.SequenceOpts.Start-desc.SequenceOpts.Increment)
 	if err := p.txn.Run(ctx, b); err != nil {
 		return nil, err

--- a/pkg/sql/created_sequence.go
+++ b/pkg/sql/created_sequence.go
@@ -1,0 +1,48 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/errors"
+)
+
+type createdSequences interface {
+	// addCreatedSequence adds a sequence to the set of sequences created in the current transaction.
+	addCreatedSequence(id descpb.ID) error
+	// isCreatedSequence checks if a sequence was created in the current transaction.
+	isCreatedSequence(id descpb.ID) bool
+}
+
+type connExCreatedSequencesAccessor struct {
+	ex *connExecutor
+}
+
+func (c connExCreatedSequencesAccessor) addCreatedSequence(id descpb.ID) error {
+	c.ex.extraTxnState.createdSequences[id] = struct{}{}
+	return nil
+}
+
+func (c connExCreatedSequencesAccessor) isCreatedSequence(id descpb.ID) bool {
+	_, ok := c.ex.extraTxnState.createdSequences[id]
+	return ok
+}
+
+// emptyCreatedSequences is the default impl used by the planner when the connExecutor is not available.
+type emptyCreatedSequences struct{}
+
+func (createdSequences emptyCreatedSequences) addCreatedSequence(id descpb.ID) error {
+	return errors.AssertionFailedf("addCreatedSequence not supported in emptyCreatedSequences")
+}
+
+func (createdSequences emptyCreatedSequences) isCreatedSequence(id descpb.ID) bool {
+	return false
+}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2899,7 +2899,7 @@ func (m *sessionDataMutator) SetStreamReplicationEnabled(val bool) {
 	m.data.EnableStreamReplication = val
 }
 
-// RecordLatestSequenceValue records that value to which the session incremented
+// RecordLatestSequenceVal records that value to which the session incremented
 // a sequence.
 func (m *sessionDataMutator) RecordLatestSequenceVal(seqID uint32, val int64) {
 	m.data.SequenceState.RecordValue(seqID, val)

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -129,7 +129,7 @@ func (so *DummySequenceOperators) SetSequenceValue(
 
 // SetSequenceValueByID implements the tree.SequenceOperators interface.
 func (so *DummySequenceOperators) SetSequenceValueByID(
-	ctx context.Context, seqID int64, newVal int64, isCalled bool,
+	ctx context.Context, seqID uint32, newVal int64, isCalled bool,
 ) error {
 	return errors.WithStack(errSequenceOperators)
 }

--- a/pkg/sql/internal_test.go
+++ b/pkg/sql/internal_test.go
@@ -85,7 +85,7 @@ func TestInternalExecutor(t *testing.T) {
 	}
 
 	// Reset the sequence to a clear value. Next nextval() will return 2.
-	if _, err := db.Exec("SELECT setval('test.seq', 1)"); err != nil {
+	if _, err := db.Exec("SELECT setval('test.seq', 1, true)"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -1923,3 +1923,103 @@ query I
 SELECT nextval('seq_txn')
 ----
 612
+
+# create a sequence and nextval in the same transaction
+statement ok
+BEGIN
+
+statement ok
+CREATE SEQUENCE nextval_txn_seq
+
+query I
+SELECT nextval('nextval_txn_seq')
+----
+1
+
+statement ok
+END
+
+query I
+SELECT nextval('nextval_txn_seq')
+----
+2
+
+# create a sequence and setval in the same transaction then nextval
+statement ok
+BEGIN
+
+statement ok
+CREATE SEQUENCE setval_txn_nextval_seq
+
+query I
+SELECT setval('setval_txn_nextval_seq', 2)
+----
+2
+
+statement ok
+END
+
+# should be 3 - see https://github.com/cockroachdb/cockroach/issues/79430
+query I
+SELECT nextval('setval_txn_nextval_seq')
+----
+2
+
+# create a sequence and setval then nextval in the same transaction
+statement ok
+BEGIN
+
+statement ok
+CREATE SEQUENCE setval_nextval_txn_seq
+
+query I
+SELECT setval('setval_nextval_txn_seq', 2)
+----
+2
+
+# should be 3 - see https://github.com/cockroachdb/cockroach/issues/79430
+query I
+SELECT nextval('setval_nextval_txn_seq')
+----
+2
+
+statement ok
+END
+
+# create a sequence and setval in the same transaction then currval
+statement ok
+BEGIN
+
+statement ok
+CREATE SEQUENCE setval_txn_currval_seq
+
+query I
+SELECT setval('setval_txn_currval_seq', 1)
+----
+1
+
+statement ok
+END
+
+# should be 1 - see https://github.com/cockroachdb/cockroach/issues/79436
+statement error currval of sequence .+ is not yet defined in this session
+SELECT currval('setval_txn_currval_seq')
+
+# create a sequence and setval then currval in the same transaction
+statement ok
+BEGIN
+
+statement ok
+CREATE SEQUENCE setval_currval_txn_seq
+
+query I
+SELECT setval('setval_currval_txn_seq', 1)
+----
+1
+
+# should be 1 - see https://github.com/cockroachdb/cockroach/issues/79436
+statement error currval of sequence .+ is not yet defined in this session
+SELECT currval('setval_currval_txn_seq')
+
+statement ok
+END

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -1878,3 +1878,48 @@ query I
 SELECT nextval('seq71135')
 ----
 500
+
+subtest sequence_in_txn
+
+# Make sure that setval and next work even if the transaction is rolled back;
+# they do not respect transaction boundaries.
+
+statement ok
+CREATE SEQUENCE seq_txn
+
+statement ok
+BEGIN
+
+query I
+SELECT setval('seq_txn', 600, true)
+----
+600
+
+statement ok
+ROLLBACK
+
+query I
+SELECT nextval('seq_txn')
+----
+601
+
+statement ok
+BEGIN
+
+query I
+SELECT setval('seq_txn', 610, true)
+----
+610
+
+query I
+SELECT nextval('seq_txn')
+----
+611
+
+statement ok
+ROLLBACK
+
+query I
+SELECT nextval('seq_txn')
+----
+612

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -418,7 +418,8 @@ SELECT setval('setval_test', 10)
 ----
 10
 
-# Calling setval changes currval and lastval.
+# Calling setval with is_called=false doesn't affect currval or lastval; they
+# return the last value obtained with nextval.
 query I
 SELECT currval('setval_test')
 ----
@@ -432,31 +433,36 @@ SELECT lastval()
 query I
 SELECT nextval('setval_test')
 ----
-11
+10
 
 query I
 SELECT currval('setval_test')
 ----
-11
+10
 
 query I
 SELECT lastval()
 ----
-11
+10
 
 let $setval_test_id
 SELECT 'setval_test'::regclass::int
 
 query I
-SELECT setval($setval_test_id::regclass, 20, false)
+SELECT setval($setval_test_id::regclass, 20)
 ----
 20
 
-# Calling setval doesn't affect currval or lastval; they return the last value obtained with nextval.
+# Calling setval with is_called=true does affect currval and lastval.
 query I
 SELECT currval($setval_test_id::regclass)
 ----
-11
+20
+
+query I
+SELECT lastval()
+----
+20
 
 query I
 SELECT nextval($setval_test_id::regclass)
@@ -947,11 +953,13 @@ user testuser
 
 # After the grant, testuser can select, increment, and set.
 
-statement ok
+query I
 SELECT nextval('priv_test')
+----
+1
 
 statement ok
-SELECT setval('priv_test', 5)
+SELECT setval('priv_test', 5, true)
 
 query I
 SELECT last_value FROM priv_test
@@ -1849,3 +1857,24 @@ query I
 SELECT nextval('seq71135')
 ----
 201
+
+# The 2-parameter version of setval uses is_called=false.
+query I
+SELECT setval('seq71135'::regclass::oid, 500)
+----
+500
+
+query I
+SELECT lastval()
+----
+201
+
+query I
+SELECT currval('seq71135')
+----
+201
+
+query I
+SELECT nextval('seq71135')
+----
+500

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -414,7 +414,7 @@ SELECT nextval('setval_test')
 2
 
 query I
-SELECT setval('setval_test', 10)
+SELECT setval('setval_test', 10, false)
 ----
 10
 
@@ -1858,7 +1858,7 @@ SELECT nextval('seq71135')
 ----
 201
 
-# The 2-parameter version of setval uses is_called=false.
+# The 2-parameter version of setval uses is_called=true.
 query I
 SELECT setval('seq71135'::regclass::oid, 500)
 ----
@@ -1867,17 +1867,17 @@ SELECT setval('seq71135'::regclass::oid, 500)
 query I
 SELECT lastval()
 ----
-201
+500
 
 query I
 SELECT currval('seq71135')
 ----
-201
+500
 
 query I
 SELECT nextval('seq71135')
 ----
-500
+501
 
 subtest sequence_in_txn
 
@@ -1924,6 +1924,8 @@ SELECT nextval('seq_txn')
 ----
 612
 
+subtest sequence_in_transaction
+
 # create a sequence and nextval in the same transaction
 statement ok
 BEGIN
@@ -1959,11 +1961,10 @@ SELECT setval('setval_txn_nextval_seq', 2)
 statement ok
 END
 
-# should be 3 - see https://github.com/cockroachdb/cockroach/issues/79430
 query I
 SELECT nextval('setval_txn_nextval_seq')
 ----
-2
+3
 
 # create a sequence and setval then nextval in the same transaction
 statement ok
@@ -1977,11 +1978,10 @@ SELECT setval('setval_nextval_txn_seq', 2)
 ----
 2
 
-# should be 3 - see https://github.com/cockroachdb/cockroach/issues/79430
 query I
 SELECT nextval('setval_nextval_txn_seq')
 ----
-2
+3
 
 statement ok
 END
@@ -2001,9 +2001,10 @@ SELECT setval('setval_txn_currval_seq', 1)
 statement ok
 END
 
-# should be 1 - see https://github.com/cockroachdb/cockroach/issues/79436
-statement error currval of sequence .+ is not yet defined in this session
+query I
 SELECT currval('setval_txn_currval_seq')
+----
+1
 
 # create a sequence and setval then currval in the same transaction
 statement ok
@@ -2017,9 +2018,10 @@ SELECT setval('setval_currval_txn_seq', 1)
 ----
 1
 
-# should be 1 - see https://github.com/cockroachdb/cockroach/issues/79436
-statement error currval of sequence .+ is not yet defined in this session
+query I
 SELECT currval('setval_currval_txn_seq')
+----
+1
 
 statement ok
 END

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -182,7 +182,9 @@ type planner struct {
 
 	preparedStatements preparedStatementsAccessor
 
-	// avoidCachedDescriptors, when true, instructs all code that
+	createdSequences createdSequences
+
+	// avoidLeasedDescriptors, when true, instructs all code that
 	// accesses table/view descriptors to force reading the descriptors
 	// within the transaction. This is necessary to read descriptors
 	// from the store for:
@@ -412,6 +414,7 @@ func newInternalPlanner(
 
 	p.queryCacheSession.Init()
 	p.optPlanningCtx.init(p)
+	p.createdSequences = emptyCreatedSequences{}
 
 	return p, func() {
 		// Note that we capture ctx here. This is only valid as long as we create

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2204,7 +2204,7 @@ var builtins = map[string]builtinDefinition{
 
 				newVal := tree.MustBeDInt(args[1])
 				if err := evalCtx.Sequence.SetSequenceValue(
-					evalCtx.Ctx(), qualifiedName, int64(newVal), true /* isCalled */); err != nil {
+					evalCtx.Ctx(), qualifiedName, int64(newVal), false /* isCalled */); err != nil {
 					return nil, err
 				}
 				return args[1], nil
@@ -2220,7 +2220,7 @@ var builtins = map[string]builtinDefinition{
 				oid := tree.MustBeDOid(args[0])
 				newVal := tree.MustBeDInt(args[1])
 				if err := evalCtx.Sequence.SetSequenceValueByID(
-					evalCtx.Ctx(), uint32(oid.DInt), int64(newVal), false /* isCalled */); err != nil {
+					evalCtx.Ctx(), uint32(oid.DInt), int64(newVal), true /* isCalled */); err != nil {
 					return nil, err
 				}
 				return args[1], nil

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2204,7 +2204,7 @@ var builtins = map[string]builtinDefinition{
 
 				newVal := tree.MustBeDInt(args[1])
 				if err := evalCtx.Sequence.SetSequenceValue(
-					evalCtx.Ctx(), qualifiedName, int64(newVal), true); err != nil {
+					evalCtx.Ctx(), qualifiedName, int64(newVal), true /* isCalled */); err != nil {
 					return nil, err
 				}
 				return args[1], nil
@@ -2220,7 +2220,7 @@ var builtins = map[string]builtinDefinition{
 				oid := tree.MustBeDOid(args[0])
 				newVal := tree.MustBeDInt(args[1])
 				if err := evalCtx.Sequence.SetSequenceValueByID(
-					evalCtx.Ctx(), int64(oid.DInt), int64(newVal), true); err != nil {
+					evalCtx.Ctx(), uint32(oid.DInt), int64(newVal), false /* isCalled */); err != nil {
 					return nil, err
 				}
 				return args[1], nil
@@ -2265,7 +2265,7 @@ var builtins = map[string]builtinDefinition{
 
 				newVal := tree.MustBeDInt(args[1])
 				if err := evalCtx.Sequence.SetSequenceValueByID(
-					evalCtx.Ctx(), int64(oid.DInt), int64(newVal), isCalled); err != nil {
+					evalCtx.Ctx(), uint32(oid.DInt), int64(newVal), isCalled); err != nil {
 					return nil, err
 				}
 				return args[1], nil

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3385,7 +3385,7 @@ type SequenceOperators interface {
 	// `newVal` is returned. Otherwise, the next call to nextval will return
 	// `newVal + seqOpts.Increment`.
 	// Takes in a sequence ID rather than a name, unlike SetSequenceValue.
-	SetSequenceValueByID(ctx context.Context, seqID int64, newVal int64, isCalled bool) error
+	SetSequenceValueByID(ctx context.Context, seqID uint32, newVal int64, isCalled bool) error
 }
 
 // TenantOperator is capable of interacting with tenant state, allowing SQL

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -148,16 +148,32 @@ func (p *planner) incrementSequenceUsingCache(
 ) (int64, error) {
 	seqOpts := descriptor.GetSequenceOpts()
 
-	cacheSize := seqOpts.EffectiveCacheSize()
+	sequenceID := descriptor.GetID()
+	createdInCurrentTxn := p.createdSequences.isCreatedSequence(sequenceID)
+	var cacheSize int64
+	if createdInCurrentTxn {
+		cacheSize = 1
+	} else {
+		cacheSize = seqOpts.EffectiveCacheSize()
+	}
 
 	fetchNextValues := func() (currentValue, incrementAmount, sizeOfCache int64, err error) {
-		seqValueKey := p.ExecCfg().Codec.SequenceKey(uint32(descriptor.GetID()))
+		seqValueKey := p.ExecCfg().Codec.SequenceKey(uint32(sequenceID))
 
-		// We *do not* use the planner txn here, since nextval does not respect
-		// transaction boundaries. This matches the specification at
-		// https://www.postgresql.org/docs/14/functions-sequence.html
-		endValue, err := kv.IncrementValRetryable(
-			ctx, p.ExecCfg().DB, seqValueKey, seqOpts.Increment*cacheSize)
+		// The planner txn is only used if the sequence is accessed in the same
+		// transaction that it was created. Otherwise, we *do not* use the planner
+		// txn here, since nextval does not respect transaction boundaries.
+		// This matches the specification at
+		// https://www.postgresql.org/docs/14/functions-sequence.html.
+		var endValue int64
+		if createdInCurrentTxn {
+			var res kv.KeyValue
+			res, err = p.txn.Inc(ctx, seqValueKey, seqOpts.Increment*cacheSize)
+			endValue = res.ValueInt()
+		} else {
+			endValue, err = kv.IncrementValRetryable(
+				ctx, p.ExecCfg().DB, seqValueKey, seqOpts.Increment*cacheSize)
+		}
 
 		if err != nil {
 			if errors.HasType(err, (*roachpb.IntegerOverflowError)(nil)) {
@@ -201,7 +217,7 @@ func (p *planner) incrementSequenceUsingCache(
 			return 0, err
 		}
 	} else {
-		val, err = p.GetOrInitSequenceCache().NextValue(uint32(descriptor.GetID()), uint32(descriptor.GetVersion()), fetchNextValues)
+		val, err = p.GetOrInitSequenceCache().NextValue(uint32(sequenceID), uint32(descriptor.GetVersion()), fetchNextValues)
 		if err != nil {
 			return 0, err
 		}
@@ -355,9 +371,16 @@ func setSequenceValueHelper(
 		return err
 	}
 
-	// We *do not* use the planner txn here, since setval does not respect
-	// transaction boundaries. This matches the specification at
-	// https://www.postgresql.org/docs/14/functions-sequence.html
+	createdInCurrentTxn := p.createdSequences.isCreatedSequence(descriptor.GetID())
+	if createdInCurrentTxn {
+		return p.txn.Put(ctx, seqValueKey, newVal)
+	}
+
+	// The planner txn is only used if the sequence is accessed in the same
+	// transaction that it was created. Otherwise, we *do not* use the planner
+	// txn here, since setval does not respect transaction boundaries.
+	// This matches the specification at
+	// https://www.postgresql.org/docs/14/functions-sequence.html.
 	// TODO(vilterp): not supposed to mix usage of Inc and Put on a key,
 	// according to comments on Inc operation. Switch to Inc if `desired-current`
 	// overflows correctly.

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -333,7 +333,7 @@ func (p *planner) SetSequenceValueByID(
 	}
 
 	// Clear out the cache and update the last value if needed.
-	p.sessionDataMutatorIterator.applyOnEachMutator(func(m sessionDataMutator) {
+	p.sessionDataMutatorIterator.applyForEachMutator(func(m sessionDataMutator) {
 		m.initSequenceCache()
 		if isCalled {
 			m.RecordLatestSequenceVal(seqID, newVal)


### PR DESCRIPTION
Backport:
  * 2/3 commits from "sql: fix bugs with sequence and setval" (#71643)
  * 1/1 commits from "sql: allow creating a sequence and calling nextval/setval on it within a transaction" (#77949)
  * 1/1 commits from "sql: default setval sequence function is_called parameter to true when not explicitly set" (#79761)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: Fixes bugs with creating and accessing a sequence inside a transaction.