### PR TITLE
kvserver: default allocator l0 action to rebalance

### DIFF
--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -1596,7 +1596,7 @@ func (a *Allocator) leaseholderShouldMoveDueToPreferences(
 // considering the threshold for L0 sub-levels. This threshold is not
 // considered in allocation or rebalancing decisions (excluding candidate
 // stores as targets) when enforcementLevel is set to storeHealthNoAction or
-// storeHealthLogOnly. By default storeHealthLogOnly is the action taken. When
+// storeHealthLogOnly. By default storeHealthBlockRebalanceTo is the action taken. When
 // there is a mixed version cluster, storeHealthNoAction is set instead.
 func (a *Allocator) storeHealthOptions(ctx context.Context) storeHealthOptions {
 	enforcementLevel := storeHealthNoAction

--- a/pkg/kv/kvserver/allocator_scorer.go
+++ b/pkg/kv/kvserver/allocator_scorer.go
@@ -172,7 +172,7 @@ var l0SublevelsThresholdEnforce = settings.RegisterEnumSetting(
 		"event, `block_rebalance_to` will exclude candidates stores from being "+
 		"targets of rebalance actions, `block_all` will exclude candidate stores "+
 		"from being targets of both allocation and rebalancing",
-	"block_none_log",
+	"block_rebalance_to",
 	map[int64]string{
 		int64(storeHealthNoAction):         "block_none",
 		int64(storeHealthLogOnly):          "block_none_log",


### PR DESCRIPTION
Previously, the default enforcement level was set to log only for
enforcing constraints on not moving replicas to stores with high L0
sub-levels.

This patch updates the enforcement level to be block_rebalance_to.
Stores with L0 sub-level count exceeding the watermark mean of their
equivalence class and also the threshold, will not be candidates for
rebalancing to.

This does not cause stores to shed replicas when they have high read amp,
only limit movement to other stores with high read amp.

Release note ops: The default L0 sub-level enforcement for rebalancing
and allocation decisions is now set to block_rebalance_to. This has the
effect of stopping rebalancing to stores which have high read
amplification.