### PR TITLE
release 21.2: server,sql,ui: fix SQL Stats behaivor in mixed version state

### DIFF
--- a/pkg/server/statements.go
+++ b/pkg/server/statements.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catconstants"
@@ -25,7 +26,10 @@ import (
 func (s *statusServer) Statements(
 	ctx context.Context, req *serverpb.StatementsRequest,
 ) (*serverpb.StatementsResponse, error) {
-	if req.Combined {
+	clusterVersion := s.st.Version.ActiveVersionOrEmpty(ctx)
+	isCombinedSQLStatsAvailable := clusterVersion.IsActive(clusterversion.SQLStatsTables)
+
+	if req.Combined && isCombinedSQLStatsAvailable {
 		combinedRequest := serverpb.CombinedStatementsStatsRequest{
 			Start: req.Start,
 			End:   req.End,

--- a/pkg/server/tenant_status.go
+++ b/pkg/server/tenant_status.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
@@ -477,7 +478,10 @@ func (t *tenantStatusServer) CombinedStatementStats(
 func (t *tenantStatusServer) Statements(
 	ctx context.Context, req *serverpb.StatementsRequest,
 ) (*serverpb.StatementsResponse, error) {
-	if req.Combined {
+	clusterVersion := t.st.Version.ActiveVersionOrEmpty(ctx)
+	isCombinedSQLStatsAvailable := clusterVersion.IsActive(clusterversion.SQLStatsTables)
+
+	if req.Combined && isCombinedSQLStatsAvailable {
 		combinedRequest := serverpb.CombinedStatementsStatsRequest{
 			Start: req.Start,
 			End:   req.End,


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/73825
Resolves https://github.com/cockroachdb/cockroach/issues/79802
Partially addresses https://github.com/cockroachdb/cockroach/issues/78351

Previously, SQL Stats did not behave well in mixed version state. There
were few symptoms:
1. SQL Activity Page failed to load during 21.1-21.2 mixed
   version state. The page displayed the error message "descriptor not
   found".
2. Error message in the logs shows SQL Stats was trying to flush during
   the mixed-version state, which caused "descriptor not found" error.
3. Reset SQL Stats during mixed version state could also run into mixed
   version state.
All of the symptoms above were caused by the new SQL Stat system table
not yet available during the mixed version state.
This commit addresses the above symptoms by introducing version gate in
the SQL Stats subsystem.

Release note (bug fix): SQL Activity Page no longer returns "descriptor
not found" error during 21.1-21.2 mixed version state.

Release note (bug fix): Resetting SQL Stats in 21.1-21.2 mixed version
state previously can cause "descriptor not found" error. This is now
addressed.

Release note (bug fix): Previously SQL Stats would attempts to flushes
statistics into disk during 21.1-21.2 mixed version state. This would
fail due to the missing statistics tables during the mixed version
state, which causes "descriptor not found" error messages be logged.
This is now fixed and SQL Stats will not attempt to flush to disk during
mixed version state.