### PR TITLE
ccl/sqlproxyccl: add per-forwarder idle detector

### DIFF
--- a/pkg/ccl/sqlproxyccl/balancer/conn.go
+++ b/pkg/ccl/sqlproxyccl/balancer/conn.go
@@ -29,4 +29,7 @@ type ConnectionHandle interface {
 	// (e.g. 10.15.42.36:26257). This will be used to identify which pod the
 	// connection handle is attached to.
 	ServerRemoteAddr() string
+
+	// IsIdle returns true if the connection is idle, and false otherwise.
+	IsIdle() bool
 }

--- a/pkg/ccl/sqlproxyccl/forwarder.go
+++ b/pkg/ccl/sqlproxyccl/forwarder.go
@@ -17,10 +17,16 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/balancer"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/interceptor"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
+
+// idleTimeout represents the period of the idle detector. During this period,
+// if no messages have been received from / sent to the client, the forwarder
+// will be marked as idle.
+const idleTimeout = 30 * time.Second
 
 // forwarder is used to forward pgwire messages from the client to the server,
 // and vice-versa. The forwarder instance should always be constructed through
@@ -48,6 +54,10 @@ type forwarder struct {
 	// channel, it is guaranteed that the forwarder and all connections will
 	// be closed.
 	errCh chan error
+
+	// timeSource is the source of the time, and uses timeutil.DefaultTimeSource
+	// by default. This is often replaced in tests.
+	timeSource timeutil.TimeSource
 
 	// While not all of these fields may need to be guarded by a mutex, we do
 	// so for consistency. Fields like clientConn and serverConn need them
@@ -88,6 +98,25 @@ type forwarder struct {
 		// potential deadlocks.
 		request  *processor // client -> server
 		response *processor // server -> client
+
+		// state represents the state of the forwarder: active or idle. The
+		// forwarder is moved to the idle state by the idle detector if no
+		// messages have been transmitted from/to the client since the last idle
+		// check. The forwarder starts with an active state upon connection
+		// establishment.
+		state struct {
+			// lastRequestTransferredAt and lastResponseTransferredAt represent
+			// the logical clock's values that a message was received from, or
+			// sent to the client *during the last idle check*. In other words,
+			// these represent snapshot values, and does not get updated in
+			// real-time, unlike the fields in the processors. These fields are
+			// solely used to update the idle state's value.
+			lastRequestTransferredAt  uint64
+			lastResponseTransferredAt uint64
+
+			// idle indicates that the forwarder is idle.
+			idle bool
+		}
 	}
 }
 
@@ -103,25 +132,48 @@ var _ balancer.ConnectionHandle = &forwarder{}
 // and callers will need to detect that (for now).
 func forward(
 	ctx context.Context,
+	stopper *stop.Stopper,
 	connector *connector,
 	metrics *metrics,
 	clientConn net.Conn,
 	serverConn net.Conn,
-) (*forwarder, error) {
+	timeSource timeutil.TimeSource,
+) (_ *forwarder, retErr error) {
+	if timeSource == nil {
+		timeSource = timeutil.DefaultTimeSource{}
+	}
+
 	ctx, cancelFn := context.WithCancel(ctx)
 	f := &forwarder{
-		ctx:       ctx,
-		ctxCancel: cancelFn,
-		errCh:     make(chan error, 1),
-		connector: connector,
-		metrics:   metrics,
+		ctx:        ctx,
+		ctxCancel:  cancelFn,
+		errCh:      make(chan error, 1),
+		connector:  connector,
+		metrics:    metrics,
+		timeSource: timeSource,
 	}
 	f.mu.clientConn = interceptor.NewPGConn(clientConn)
 	f.mu.serverConn = interceptor.NewPGConn(serverConn)
 
+	// Ensure that forwarder is closed whenever we get an error. This prevents
+	// a leak on the idle detector.
+	defer func() {
+		if retErr != nil {
+			f.Close()
+		}
+	}()
+
+	// Note that we don't obtain the f.mu lock here since the processors have
+	// not been resumed yet.
 	clockFn := makeLogicalClockFn()
 	f.mu.request = newProcessor(clockFn, f.mu.clientConn, f.mu.serverConn)  // client -> server
 	f.mu.response = newProcessor(clockFn, f.mu.serverConn, f.mu.clientConn) // server -> client
+	f.mu.state.lastRequestTransferredAt = f.mu.request.lastMessageTransferredAt()
+	f.mu.state.lastResponseTransferredAt = f.mu.response.lastMessageTransferredAt()
+
+	if err := stopper.RunAsyncTask(ctx, "idle-detector", f.detectIdle); err != nil {
+		return nil, err
+	}
 	if err := f.resumeProcessors(); err != nil {
 		return nil, err
 	}
@@ -168,6 +220,51 @@ func (f *forwarder) ServerRemoteAddr() string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.mu.serverConn.RemoteAddr().String()
+}
+
+// IsIdle returns true if the forwarder is idle, and false otherwise.
+//
+// IsIdle implements the balancer.ConnectionHandle interface.
+func (f *forwarder) IsIdle() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.mu.state.idle
+}
+
+// detectIdle runs periodically on a background goroutine to detect whether the
+// forwarder is idle, until the given context is cancelled.
+func (f *forwarder) detectIdle(ctx context.Context) {
+	timer := f.timeSource.NewTimer()
+	defer timer.Stop()
+	for {
+		timer.Reset(idleTimeout)
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.Ch():
+			timer.MarkRead()
+			f.refreshIdleState()
+		}
+	}
+}
+
+// refreshIdleState updates the idle state of the forwarder. The forwarder will
+// be marked as idle if no messages have been received from/sent to the client
+// since the last idle check. Note that an idle check is implicitly made during
+// forwarder creation, and the forwarder is implicitly assumed to be active
+// then.
+func (f *forwarder) refreshIdleState() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	reqAt := f.mu.request.lastMessageTransferredAt()
+	resAt := f.mu.response.lastMessageTransferredAt()
+
+	f.mu.state.idle = (f.mu.state.lastRequestTransferredAt == reqAt) &&
+		(f.mu.state.lastResponseTransferredAt == resAt)
+
+	f.mu.state.lastRequestTransferredAt = reqAt
+	f.mu.state.lastResponseTransferredAt = resAt
 }
 
 // resumeProcessors starts both the request and response processors
@@ -452,4 +549,12 @@ func (p *processor) suspend(ctx context.Context) error {
 		p.mu.cond.Wait()
 	}
 	return nil
+}
+
+// lastMessageTransferredAt returns the logical clock's value that the message
+// was last transferred at.
+func (p *processor) lastMessageTransferredAt() uint64 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.mu.lastMessageTransferredAt
 }

--- a/pkg/ccl/sqlproxyccl/forwarder_test.go
+++ b/pkg/ccl/sqlproxyccl/forwarder_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/jackc/pgproto3/v2"
@@ -32,11 +34,15 @@ func TestForward(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	bgCtx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(bgCtx)
 
 	t.Run("closed_when_processors_error", func(t *testing.T) {
 		p1, p2 := net.Pipe()
 
-		f, err := forward(bgCtx, nil /* connector */, nil /* metrics */, p1, p2)
+		f, err := forward(
+			bgCtx, stopper, nil /* connector */, nil /* metrics */, p1, p2, nil, /* timeSource */
+		)
 		require.NoError(t, err)
 		defer f.Close()
 
@@ -53,6 +59,22 @@ func TestForward(t *testing.T) {
 		})
 	})
 
+	// testIdleState tests that the forwarder's idle state matches the expected
+	// idle state once the idle check runs.
+	testIdleState := func(t *testing.T, ts *timeutil.ManualTime, f *forwarder, expectedIdle bool) {
+		t.Helper()
+		ts.Advance(idleTimeout)
+		testutils.SucceedsSoon(t, func() error {
+			if f.IsIdle() == expectedIdle {
+				return nil
+			}
+			if expectedIdle {
+				return errors.New("connection is still active")
+			}
+			return errors.New("connection is still idle")
+		})
+	}
+
 	t.Run("client_to_server", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(bgCtx, 5*time.Second)
 		defer cancel()
@@ -62,10 +84,23 @@ func TestForward(t *testing.T) {
 		clientProxy, client := net.Pipe()
 		serverProxy, server := net.Pipe()
 
-		f, err := forward(ctx, nil /* connector */, nil /* metrics */, clientProxy, serverProxy)
+		// Use a custom time source for testing.
+		t0 := time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
+		timeSource := timeutil.NewManualTime(t0)
+
+		f, err := forward(
+			ctx,
+			stopper,
+			nil, /* connector */
+			nil, /* metrics */
+			clientProxy,
+			serverProxy,
+			timeSource,
+		)
 		require.NoError(t, err)
 		defer f.Close()
 		require.Nil(t, f.ctx.Err())
+		require.False(t, f.IsIdle())
 
 		f.mu.Lock()
 		requestProc := f.mu.request
@@ -85,14 +120,17 @@ func TestForward(t *testing.T) {
 		requestProc.mu.Unlock()
 
 		// Client writes some pgwire messages.
+		sendEventCh := make(chan struct{}, 1)
 		errChan := make(chan error, 1)
 		go func() {
+			<-sendEventCh
 			if _, err := client.Write((&pgproto3.Query{
 				String: "SELECT 1",
 			}).Encode(nil)); err != nil {
 				errChan <- err
 				return
 			}
+			<-sendEventCh
 			if _, err := client.Write((&pgproto3.Execute{
 				Portal:  "foobar",
 				MaxRows: 42,
@@ -100,6 +138,7 @@ func TestForward(t *testing.T) {
 				errChan <- err
 				return
 			}
+			<-sendEventCh
 			if _, err := client.Write((&pgproto3.Close{
 				ObjectType: 'P',
 			}).Encode(nil)); err != nil {
@@ -111,26 +150,44 @@ func TestForward(t *testing.T) {
 		// Server should receive messages in order.
 		backend := pgproto3.NewBackend(pgproto3.NewChunkReader(server), server)
 
+		// Send SELECT 1. Before we send, the forwarder should be idle.
+		testIdleState(t, timeSource, f, true)
+		sendEventCh <- struct{}{}
+
 		barrierStart <- struct{}{}
 		requestProc.mu.Lock()
 		require.Equal(t, byte(pgwirebase.ClientMsgSimpleQuery), requestProc.mu.lastMessageType)
 		require.Equal(t, initialClock+1, requestProc.mu.lastMessageTransferredAt)
 		requestProc.mu.Unlock()
+		// Idle state should not be updated right away. Once idle check runs,
+		// forwarder should be active.
+		require.True(t, f.IsIdle())
+		testIdleState(t, timeSource, f, false)
 		barrierEnd <- struct{}{}
 
+		// Server should receive SELECT 1.
 		msg, err := backend.Receive()
 		require.NoError(t, err)
 		m1, ok := msg.(*pgproto3.Query)
 		require.True(t, ok)
 		require.Equal(t, "SELECT 1", m1.String)
 
+		// Send Execute message. Before we send, the forwarder should be idle.
+		testIdleState(t, timeSource, f, true)
+		sendEventCh <- struct{}{}
+
 		barrierStart <- struct{}{}
 		requestProc.mu.Lock()
 		require.Equal(t, byte(pgwirebase.ClientMsgExecute), requestProc.mu.lastMessageType)
 		require.Equal(t, initialClock+2, requestProc.mu.lastMessageTransferredAt)
 		requestProc.mu.Unlock()
+		// Idle state should not be updated right away. Once idle check runs,
+		// forwarder should be active.
+		require.True(t, f.IsIdle())
+		testIdleState(t, timeSource, f, false)
 		barrierEnd <- struct{}{}
 
+		// Server receives Execute.
 		msg, err = backend.Receive()
 		require.NoError(t, err)
 		m2, ok := msg.(*pgproto3.Execute)
@@ -138,13 +195,22 @@ func TestForward(t *testing.T) {
 		require.Equal(t, "foobar", m2.Portal)
 		require.Equal(t, uint32(42), m2.MaxRows)
 
+		// Send Close message. Before we send, the forwarder should be idle.
+		testIdleState(t, timeSource, f, true)
+		sendEventCh <- struct{}{}
+
 		barrierStart <- struct{}{}
 		requestProc.mu.Lock()
 		require.Equal(t, byte(pgwirebase.ClientMsgClose), requestProc.mu.lastMessageType)
 		require.Equal(t, initialClock+3, requestProc.mu.lastMessageTransferredAt)
 		requestProc.mu.Unlock()
+		// Idle state should not be updated right away. Once idle check runs,
+		// forwarder should be active.
+		require.True(t, f.IsIdle())
+		testIdleState(t, timeSource, f, false)
 		barrierEnd <- struct{}{}
 
+		// Server receives Close.
 		msg, err = backend.Receive()
 		require.NoError(t, err)
 		m3, ok := msg.(*pgproto3.Close)
@@ -167,10 +233,23 @@ func TestForward(t *testing.T) {
 		clientProxy, client := net.Pipe()
 		serverProxy, server := net.Pipe()
 
-		f, err := forward(ctx, nil /* connector */, nil /* metrics */, clientProxy, serverProxy)
+		// Use a custom time source for testing.
+		t0 := time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
+		timeSource := timeutil.NewManualTime(t0)
+
+		f, err := forward(
+			ctx,
+			stopper,
+			nil, /* connector */
+			nil, /* metrics */
+			clientProxy,
+			serverProxy,
+			timeSource,
+		)
 		require.NoError(t, err)
 		defer f.Close()
 		require.Nil(t, f.ctx.Err())
+		require.False(t, f.IsIdle())
 
 		f.mu.Lock()
 		responseProc := f.mu.response
@@ -190,8 +269,10 @@ func TestForward(t *testing.T) {
 		responseProc.mu.Unlock()
 
 		// Server writes some pgwire messages.
+		recvEventCh := make(chan struct{}, 1)
 		errChan := make(chan error, 1)
 		go func() {
+			<-recvEventCh
 			if _, err := server.Write((&pgproto3.ErrorResponse{
 				Code:    "100",
 				Message: "foobarbaz",
@@ -199,6 +280,7 @@ func TestForward(t *testing.T) {
 				errChan <- err
 				return
 			}
+			<-recvEventCh
 			if _, err := server.Write((&pgproto3.ReadyForQuery{
 				TxStatus: 'I',
 			}).Encode(nil)); err != nil {
@@ -210,13 +292,22 @@ func TestForward(t *testing.T) {
 		// Client should receive messages in order.
 		frontend := pgproto3.NewFrontend(pgproto3.NewChunkReader(client), client)
 
+		// Receive an ErrorResponse. Before we receive, the forwarder should be idle.
+		testIdleState(t, timeSource, f, true)
+		recvEventCh <- struct{}{}
+
 		barrierStart <- struct{}{}
 		responseProc.mu.Lock()
 		require.Equal(t, byte(pgwirebase.ServerMsgErrorResponse), responseProc.mu.lastMessageType)
 		require.Equal(t, initialClock+1, responseProc.mu.lastMessageTransferredAt)
 		responseProc.mu.Unlock()
+		// Idle state should not be updated right away. Once idle check runs,
+		// forwarder should be active.
+		require.True(t, f.IsIdle())
+		testIdleState(t, timeSource, f, false)
 		barrierEnd <- struct{}{}
 
+		// Client receives ErrorResponse.
 		msg, err := frontend.Receive()
 		require.NoError(t, err)
 		m1, ok := msg.(*pgproto3.ErrorResponse)
@@ -224,13 +315,22 @@ func TestForward(t *testing.T) {
 		require.Equal(t, "100", m1.Code)
 		require.Equal(t, "foobarbaz", m1.Message)
 
+		// Receive a ReadyForQuery. Before we receive, the forwarder should be idle.
+		testIdleState(t, timeSource, f, true)
+		recvEventCh <- struct{}{}
+
 		barrierStart <- struct{}{}
 		responseProc.mu.Lock()
 		require.Equal(t, byte(pgwirebase.ServerMsgReady), responseProc.mu.lastMessageType)
 		require.Equal(t, initialClock+2, responseProc.mu.lastMessageTransferredAt)
 		responseProc.mu.Unlock()
+		// Idle state should not be updated right away. Once idle check runs,
+		// forwarder should be active.
+		require.True(t, f.IsIdle())
+		testIdleState(t, timeSource, f, false)
 		barrierEnd <- struct{}{}
 
+		// Client receives ReadyForQuery.
 		msg, err = frontend.Receive()
 		require.NoError(t, err)
 		m2, ok := msg.(*pgproto3.ReadyForQuery)
@@ -249,9 +349,11 @@ func TestForwarder_Context(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := logtags.AddTag(context.Background(), "foo", "bar")
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
 
 	p1, p2 := net.Pipe()
-	f, err := forward(ctx, nil /* connector */, nil /* metrics */, p1, p2)
+	f, err := forward(ctx, stopper, nil /* connector */, nil /* metrics */, p1, p2, nil /* timeSource */)
 	require.NoError(t, err)
 	defer f.Close()
 
@@ -264,9 +366,13 @@ func TestForwarder_Context(t *testing.T) {
 func TestForwarder_Close(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
 	p1, p2 := net.Pipe()
 
-	f, err := forward(context.Background(), nil /* connector */, nil /* metrics */, p1, p2)
+	f, err := forward(ctx, stopper, nil /* connector */, nil /* metrics */, p1, p2, nil /* timeSource */)
 	require.NoError(t, err)
 	defer f.Close()
 	require.Nil(t, f.ctx.Err())
@@ -278,8 +384,12 @@ func TestForwarder_Close(t *testing.T) {
 func TestForwarder_ServerRemoteAddr(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
 	p1, p2 := net.Pipe()
-	f, err := forward(context.Background(), nil /* connector */, nil /* metrics */, p1, p2)
+	f, err := forward(ctx, stopper, nil /* connector */, nil /* metrics */, p1, p2, nil /* timeSource */)
 	require.NoError(t, err)
 	defer f.Close()
 
@@ -289,9 +399,13 @@ func TestForwarder_ServerRemoteAddr(t *testing.T) {
 func TestForwarder_tryReportError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
 	p1, p2 := net.Pipe()
 
-	f, err := forward(context.Background(), nil /* connector */, nil /* metrics */, p1, p2)
+	f, err := forward(ctx, stopper, nil /* connector */, nil /* metrics */, p1, p2, nil /* timeSource */)
 	require.NoError(t, err)
 	defer f.Close()
 
@@ -320,12 +434,23 @@ func TestForwarder_tryReportError(t *testing.T) {
 
 func TestForwarder_replaceServerConn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
 	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
 
 	clientProxy, client := net.Pipe()
 	serverProxy, server := net.Pipe()
 
-	f, err := forward(context.Background(), nil /* connector */, nil /* metrics */, clientProxy, serverProxy)
+	f, err := forward(
+		ctx,
+		stopper,
+		nil, /* connector */
+		nil, /* metrics */
+		clientProxy,
+		serverProxy,
+		nil, /* timeSource */
+	)
 	require.NoError(t, err)
 	defer f.Close()
 

--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -390,7 +390,9 @@ func (handler *proxyHandler) handle(ctx context.Context, incomingConn *proxyConn
 	}()
 
 	// Pass ownership of conn and crdbConn to the forwarder.
-	f, err := forward(ctx, connector, handler.metrics, fe.conn, crdbConn)
+	f, err := forward(
+		ctx, handler.stopper, connector, handler.metrics, fe.conn, crdbConn, nil, /* timeSource */
+	)
 	if err != nil {
 		// Don't send to the client here for the same reason below.
 		handler.metrics.updateForError(err)


### PR DESCRIPTION
As part of the leastconns work, we need a mechanism that tells whether the
forwarder (or connection handle) is in an idle state. This commit adds an
idle detector to the forwarder, and the detector will run periodically on a
30 second interval on a background goroutine until the forwarder has been
closed. A forwarder instance is said to be idle if no messages have been
received from or sent to the client since the last idle check, which in this
case is once every 30 seconds.

The plan is to have another background task in the connection tracker that
periodically (e.g. every 5 seconds) updates the list of active/idle connections
on a per-pod basis for all tenants. During routing, the connector or balancer
will read these data to figure out where to route the incoming connection.

Release note: None