### PR TITLE
backupccl: add UX guardrails during backup subdirectory resolution

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -5,6 +5,7 @@ admission.epoch_lifo.epoch_duration	duration	100ms	the duration of an epoch, for
 admission.epoch_lifo.queue_delay_threshold_to_switch_to_lifo	duration	105ms	the queue delay encountered by a (tenant,priority) for switching to epoch-LIFO ordering
 admission.sql_kv_response.enabled	boolean	true	when true, work performed by the SQL layer when receiving a KV response is subject to admission control
 admission.sql_sql_response.enabled	boolean	true	when true, work performed by the SQL layer when receiving a DistSQL response is subject to admission control
+bulkio.backup.deprecated_full_backup_with_subdir.enabled	boolean	false	when true, a backup command with a user specified subdirectory will create a full backup at the subdirectory if no backup already exists at that subdirectory.
 bulkio.backup.file_size	byte size	128 MiB	target size for individual data files produced during BACKUP
 bulkio.backup.read_timeout	duration	5m0s	amount of time after which a read attempt is considered timed out, which causes the backup to fail
 bulkio.backup.read_with_priority_after	duration	1m0s	amount of time since the read-as-of time above which a BACKUP should use priority when retrying reads

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -10,6 +10,7 @@
 <tr><td><code>admission.kv.tenant_weights.enabled</code></td><td>boolean</td><td><code>false</code></td><td>when true, tenant weights are enabled for KV admission control</td></tr>
 <tr><td><code>admission.sql_kv_response.enabled</code></td><td>boolean</td><td><code>true</code></td><td>when true, work performed by the SQL layer when receiving a KV response is subject to admission control</td></tr>
 <tr><td><code>admission.sql_sql_response.enabled</code></td><td>boolean</td><td><code>true</code></td><td>when true, work performed by the SQL layer when receiving a DistSQL response is subject to admission control</td></tr>
+<tr><td><code>bulkio.backup.deprecated_full_backup_with_subdir.enabled</code></td><td>boolean</td><td><code>false</code></td><td>when true, a backup command with a user specified subdirectory will create a full backup at the subdirectory if no backup already exists at that subdirectory.</td></tr>
 <tr><td><code>bulkio.backup.file_size</code></td><td>byte size</td><td><code>128 MiB</code></td><td>target size for individual data files produced during BACKUP</td></tr>
 <tr><td><code>bulkio.backup.read_timeout</code></td><td>duration</td><td><code>5m0s</code></td><td>amount of time after which a read attempt is considered timed out, which causes the backup to fail</td></tr>
 <tr><td><code>bulkio.backup.read_with_priority_after</code></td><td>duration</td><td><code>1m0s</code></td><td>amount of time since the read-as-of time above which a BACKUP should use priority when retrying reads</td></tr>

--- a/pkg/ccl/backupccl/backup_destination_test.go
+++ b/pkg/ccl/backupccl/backup_destination_test.go
@@ -344,9 +344,14 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 						require.NoError(t, err)
 					}
 
+					fullBackupExists := false
+					if expectedIncDir != "" {
+						fullBackupExists = true
+					}
 					collectionURI, defaultURI, chosenSuffix, urisByLocalityKV, prevBackupURIs, err := resolveDest(
 						ctx, security.RootUserName(),
-						jobspb.BackupDetails_Destination{To: collectionTo, Subdir: subdir, IncrementalStorage: incrementalTo},
+						jobspb.BackupDetails_Destination{To: collectionTo, Subdir: subdir,
+							IncrementalStorage: incrementalTo, Exists: fullBackupExists},
 						endTime,
 						incrementalFrom,
 						&execCfg,

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -1500,7 +1501,10 @@ func getBackupDetailAndManifest(
 		// This is complex right now, but should be easier shortly.
 		// TODO(benbardin): Support verifying actual existence of localities for
 		// each layer after deprecating TO-syntax in 22.2
-		if !setsAreEqual(localityKVs, prevLocalityKVs) {
+		sort.Strings(localityKVs)
+		sort.Strings(prevLocalityKVs)
+		if !(len(localityKVs) == 0 && len(prevLocalityKVs) == 0) && !reflect.DeepEqual(localityKVs,
+			prevLocalityKVs) {
 			// Note that this won't verify the default locality. That's not
 			// necessary, because the default locality defines the backup manifest
 			// location. If that URI isn't right, the backup chain will fail to
@@ -1542,22 +1546,6 @@ func getBackupDetailAndManifest(
 	}
 
 	return updatedDetails, backupManifest, nil
-}
-
-func setsAreEqual(first []string, second []string) bool {
-	if len(first) != len(second) {
-		return false
-	}
-	sortedFirst := first
-	sortedSecond := second
-	sort.Strings(sortedFirst)
-	sort.Strings(sortedSecond)
-	for i := range sortedFirst {
-		if sortedFirst[i] != sortedSecond[i] {
-			return false
-		}
-	}
-	return true
 }
 
 func getTenantInfo(

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -108,6 +108,17 @@ type (
 	}
 )
 
+// featureFullBackupUserSubdir, when true, will create a full backup at a user
+// specified subdirectory if no backup already exists at that subdirectory. As
+// of 22.1, this feature is default disabled, and will be totally disabled by 22.2.
+var featureFullBackupUserSubdir = settings.RegisterBoolSetting(
+	settings.TenantWritable,
+	"bulkio.backup.deprecated_full_backup_with_subdir.enabled",
+	"when true, a backup command with a user specified subdirectory will create a full backup at"+
+		" the subdirectory if no backup already exists at that subdirectory.",
+	false,
+).WithPublic()
+
 // getPublicIndexTableSpans returns all the public index spans of the
 // provided table.
 func getPublicIndexTableSpans(
@@ -699,16 +710,11 @@ func backupPlanHook(
 		if backupStmt.Nested {
 			if backupStmt.AppendToLatest {
 				initialDetails.Destination.Subdir = latestFileName
+				initialDetails.Destination.Exists = true
+
 			} else if subdir != "" {
 				initialDetails.Destination.Subdir = "/" + strings.TrimPrefix(subdir, "/")
-				// Deprecation notice for `BACKUP INTO` syntax with an explicit subdir.
-				// Remove this once the syntax is deleted in 22.2.
-				p.BufferClientNotice(ctx,
-					pgnotice.Newf("BACKUP commands with an explicitly specified"+
-						" subdirectory will be removed in a future release. Users can create a full backup via `BACKUP ... "+
-						"INTO <collectionURI>`, or an incremental backup on the latest full backup in their "+
-						"collection via `BACKUP ... INTO LATEST IN <collectionURI>`"))
-
+				initialDetails.Destination.Exists = true
 			} else {
 				initialDetails.Destination.Subdir = endTime.GoTime().Format(DateBasedIntoFolderName)
 			}
@@ -1460,6 +1466,13 @@ func getBackupDetailAndManifest(
 
 		if err := requireEnterprise(execCfg, "incremental"); err != nil {
 			return jobspb.BackupDetails{}, BackupManifest{}, err
+		}
+		lastEndTime := prevBackups[len(prevBackups)-1].EndTime
+		if lastEndTime.Compare(initialDetails.EndTime) > 0 {
+			return jobspb.BackupDetails{}, BackupManifest{},
+				errors.Newf("`AS OF SYSTEM TIME` %s must be greater than "+
+					"the previous backup's end time of %s.",
+					initialDetails.EndTime.GoTime(), lastEndTime.GoTime())
 		}
 	}
 

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -652,7 +652,6 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 	sqlDB.Exec(t, "BACKUP TO ($1, $2, $3)", backups...)
 	sqlDB.Exec(t, "BACKUP INTO ($1, $2, $3)", collections...)
 	sqlDB.Exec(t, "BACKUP INTO LATEST IN ($1, $2, $3)", collections...)
-	sqlDB.Exec(t, "BACKUP INTO $4 IN ($1, $2, $3)", append(collections, "subdir")...)
 	sqlDB.Exec(t, "BACKUP INTO LATEST IN ($1, $2, $3) WITH incremental_location = ($4, $5, $6)",
 		append(collections, incrementals...)...)
 
@@ -660,16 +659,24 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 		"BACKUP INTO LATEST IN $4 WITH incremental_location = ($1, $2, $3)",
 		append(incrementals, collections[0])...)
 
+	sqlDB.ExpectErr(t, "The full backup cannot get written to '/subdir', a user defined subdirectory. To take a full backup, remove the subdirectory from the backup command",
+		"BACKUP INTO $4 IN ($1, $2, $3)", append(collections, "subdir")...)
+
+	time.Sleep(time.Second + 2)
+	sqlDB.Exec(t, "BACKUP INTO ($1, $2, $3) AS OF SYSTEM TIME '-1s'", collections...)
+
 	// Find the subdirectory created by the full BACKUP INTO statement.
 	matches, err := filepath.Glob(path.Join(tmpDir, "full/*/*/*/"+backupManifestName))
 	require.NoError(t, err)
-	require.Equal(t, 1, len(matches))
+	require.Equal(t, 2, len(matches))
 	for i := range matches {
 		matches[i] = strings.TrimPrefix(filepath.Dir(matches[i]), tmpDir)
 	}
 	full1 := strings.TrimPrefix(matches[0], "/full")
+	asOf1 := strings.TrimPrefix(matches[1], "/full")
+
 	sqlDB.CheckQueryResults(
-		t, "SELECT description FROM [SHOW JOBS]",
+		t, "SELECT description FROM [SHOW JOBS] WHERE status != 'failed'",
 		[][]string{
 			{fmt.Sprintf("BACKUP TO ('%s', '%s', '%s')", backups[0].(string), backups[1].(string),
 				backups[2].(string))},
@@ -677,13 +684,16 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 				collections[1], collections[2])},
 			{fmt.Sprintf("BACKUP INTO '%s' IN ('%s', '%s', '%s')", full1,
 				collections[0], collections[1], collections[2])},
-			{fmt.Sprintf("BACKUP INTO '%s' IN ('%s', '%s', '%s')", "/subdir",
-				collections[0], collections[1], collections[2])},
 			{fmt.Sprintf("BACKUP INTO '%s' IN ('%s', '%s', '%s') WITH incremental_location = ('%s', '%s', '%s')",
-				"/subdir", collections[0], collections[1], collections[2], incrementals[0],
+				full1, collections[0], collections[1], collections[2], incrementals[0],
 				incrementals[1], incrementals[2])},
+			{fmt.Sprintf("BACKUP INTO '%s' IN ('%s', '%s', '%s') AS OF SYSTEM TIME '-1s'", asOf1, collections[0],
+				collections[1], collections[2])},
 		},
 	)
+	sqlDB.CheckQueryResults(t, "SELECT description FROM [SHOW JOBS] WHERE status = 'failed'",
+		[][]string{{fmt.Sprintf("BACKUP INTO '%s' IN ('%s', '%s', '%s')", "/subdir", collections[0],
+			collections[1], collections[2])}})
 
 	sqlDB.Exec(t, "DROP DATABASE data CASCADE")
 	sqlDB.Exec(t, "RESTORE DATABASE data FROM ($1, $2, $3)", backups...)
@@ -692,15 +702,16 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 	sqlDB.Exec(t, "RESTORE DATABASE data FROM $4 IN ($1, $2, $3)", append(collections, full1)...)
 
 	sqlDB.Exec(t, "DROP DATABASE data CASCADE")
-	sqlDB.Exec(t, "RESTORE DATABASE data FROM $4 IN ($1, $2, $3)", append(collections, "subdir")...)
+	sqlDB.Exec(t, "RESTORE DATABASE data FROM $7 IN ($1, $2, "+
+		"$3) WITH incremental_location = ($4, $5, $6)",
+		append(collections, incrementals[0], incrementals[1], incrementals[2], full1)...)
 
+	// Test restoring from the AOST backup
 	sqlDB.Exec(t, "DROP DATABASE data CASCADE")
 	sqlDB.Exec(t, "RESTORE DATABASE data FROM LATEST IN ($1, $2, $3)", collections...)
 
 	sqlDB.Exec(t, "DROP DATABASE data CASCADE")
-	sqlDB.Exec(t, "RESTORE DATABASE data FROM LATEST IN ($1, $2, "+
-		"$3) WITH incremental_location = ($4, $5, $6)",
-		append(collections, incrementals[0], incrementals[1], incrementals[2])...)
+	sqlDB.Exec(t, "RESTORE DATABASE data FROM $4 IN ($1, $2, $3)", append(collections, asOf1)...)
 
 	// The flavors of BACKUP and RESTORE which automatically resolve the right
 	// directory to read/write data to, have URIs with the resolved path written
@@ -718,8 +729,8 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 	}
 
 	resolvedCollectionURIs := getResolvedCollectionURIs(collections, full1)
-	resolvedSubdirURIs := getResolvedCollectionURIs(collections, "subdir")
-	resolvedIncURIs := getResolvedCollectionURIs(incrementals, "subdir")
+	resolvedIncURIs := getResolvedCollectionURIs(incrementals, full1)
+	resolvedAsOfCollectionURIs := getResolvedCollectionURIs(collections, asOf1)
 
 	sqlDB.CheckQueryResults(
 		t, "SELECT description FROM [SHOW JOBS] WHERE job_type='RESTORE'",
@@ -729,16 +740,16 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 			{fmt.Sprintf("RESTORE DATABASE data FROM ('%s', '%s', '%s')",
 				resolvedCollectionURIs[0], resolvedCollectionURIs[1],
 				resolvedCollectionURIs[2])},
+			{fmt.Sprintf("RESTORE DATABASE data FROM ('%s', '%s', '%s') WITH incremental_location = ('%s', '%s', '%s')",
+				resolvedCollectionURIs[0], resolvedCollectionURIs[1], resolvedCollectionURIs[2],
+				resolvedIncURIs[0], resolvedIncURIs[1], resolvedIncURIs[2])},
 			{fmt.Sprintf("RESTORE DATABASE data FROM ('%s', '%s', '%s')",
-				resolvedSubdirURIs[0], resolvedSubdirURIs[1],
-				resolvedSubdirURIs[2])},
+				resolvedAsOfCollectionURIs[0], resolvedAsOfCollectionURIs[1],
+				resolvedAsOfCollectionURIs[2])},
 			// and again from LATEST IN...
 			{fmt.Sprintf("RESTORE DATABASE data FROM ('%s', '%s', '%s')",
-				resolvedSubdirURIs[0], resolvedSubdirURIs[1],
-				resolvedSubdirURIs[2])},
-			{fmt.Sprintf("RESTORE DATABASE data FROM ('%s', '%s', '%s') WITH incremental_location = ('%s', '%s', '%s')",
-				resolvedSubdirURIs[0], resolvedSubdirURIs[1], resolvedSubdirURIs[2],
-				resolvedIncURIs[0], resolvedIncURIs[1], resolvedIncURIs[2])},
+				resolvedAsOfCollectionURIs[0], resolvedAsOfCollectionURIs[1],
+				resolvedAsOfCollectionURIs[2])},
 		},
 	)
 }
@@ -3524,8 +3535,23 @@ func TestBackupAsOfSystemTime(t *testing.T) {
 
 	beforeDir := localFoo + `/beforeTs`
 	sqlDB.Exec(t, fmt.Sprintf(`BACKUP DATABASE data TO '%s' AS OF SYSTEM TIME %s`, beforeDir, beforeTs))
+
 	equalDir := localFoo + `/equalTs`
 	sqlDB.Exec(t, fmt.Sprintf(`BACKUP DATABASE data TO '%s' AS OF SYSTEM TIME %s`, equalDir, equalTs))
+	{
+		// testing UX guardrails for AS OF SYSTEM TIME backups in collections
+		sqlDB.Exec(t, fmt.Sprintf(`BACKUP DATABASE data INTO '%s' AS OF SYSTEM TIME %s`, equalDir, equalTs))
+
+		sqlDB.ExpectErr(t, "`AS OF SYSTEM TIME` .* must be greater than the previous backup's end time of",
+			fmt.Sprintf(`BACKUP DATABASE data INTO LATEST IN '%s' AS OF SYSTEM TIME %s`,
+				equalDir,
+				beforeTs))
+
+		sqlDB.ExpectErr(t, "A full backup already exists in .* Consider running an incremental backup"+
+			" to this full backup via `BACKUP INTO ",
+			fmt.Sprintf(`BACKUP DATABASE data INTO '%s' AS OF SYSTEM TIME %s`, equalDir,
+				equalTs))
+	}
 
 	sqlDB.Exec(t, `DROP TABLE data.bank`)
 	sqlDB.Exec(t, `RESTORE data.* FROM $1`, beforeDir)

--- a/pkg/ccl/backupccl/testdata/backup-restore/feature-flags
+++ b/pkg/ccl/backupccl/testdata/backup-restore/feature-flags
@@ -73,11 +73,6 @@ BACKUP TO 'nodelocal://1/deprecated/incfrom' INCREMENTAL FROM 'nodelocal://1/dep
 NOTICE: The `BACKUP TO` syntax will be removed in a future release, please switch over to using `BACKUP INTO` to create a backup collection: https://www.cockroachlabs.com/docs/stable/backup.html#considerations. Backups created using the `BACKUP TO` syntax may not be restoreable in the next major version release.
 
 exec-sql
-BACKUP INTO 'deprecatedExplicitSubdir' IN 'nodelocal://1/deprecated';
-----
-NOTICE: BACKUP commands with an explicitly specified subdirectory will be removed in a future release. Users can create a full backup via `BACKUP ... INTO <collectionURI>`, or an incremental backup on the latest full backup in their collection via `BACKUP ... INTO LATEST IN <collectionURI>`
-
-exec-sql
 DROP TABLE d.t;
 ----
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/mismatched-localities
+++ b/pkg/ccl/backupccl/testdata/backup-restore/mismatched-localities
@@ -17,7 +17,7 @@ BACKUP INTO LATEST IN (
   'nodelocal://1/database_backup?COCKROACH_LOCALITY=region%3Dus-west-1',
   'nodelocal://1/database_backup?COCKROACH_LOCALITY=region%3Dus-east-1');
 ----
-pq: Requested backup has localities [region=us-west-1 region=us-east-1], but a previous backup layer in this collection has localities [region=us-west-1]. Mismatched backup layers are not supported. Please take a new full backup with the new localities, or an incremental backup with matching localities.
+pq: Requested backup has localities [region=us-east-1 region=us-west-1], but a previous backup layer in this collection has localities [region=us-west-1]. Mismatched backup layers are not supported. Please take a new full backup with the new localities, or an incremental backup with matching localities.
 
 exec-sql
 BACKUP INTO LATEST IN (

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -161,6 +161,8 @@ message BackupDetails {
     // Subdir is the path within the collection path in to to backup to.
     string subdir = 2;
     repeated string incremental_storage = 3;
+    // Exists is true if a backup should already exist at the destination
+    bool exists = 4;
   }
 
   util.hlc.Timestamp start_time = 1 [(gogoproto.nullable) = false];


### PR DESCRIPTION
Informs https://github.com/cockroachdb/cockroach/issues/79674, https://github.com/cockroachdb/cockroach/issues/79672

The changes in this PR sprang out of discussions in https://github.com/cockroachdb/cockroach/pull/79447 which deprecated the
ability to pass an explicit subdirectory in any backup command. This PR tweaks
that deprecation warning and adds further UX guardrails.

Release note (backward-incompatible change): This patch introduces a few UX guardrails, including
one breaking change:

[breaking]: After further discussion, we realized explicit subdirectories were
useful for running incremental backups, but not for full backups. To that end,
this pr throws an error if: a) a user passes a subdirectory; b)
there does not already exist a full backup in that subdirectory. The user can
enable this deprecated syntax by switching the new
bulkio.backup.deprecated_full_backup_with_subdir cluster setting to true.

Discussion in https://github.com/cockroachdb/cockroach/pull/79447 also lead to a discovery of two
bugs for backups with AS OF SYSTEM TIME:

Previously, a user could run an AS OF SYSTEM TIME
incremental backup with an end time earlier than the previous backup's end time
, which could lead to an out of order incremental backup chain. This PR causes
the incremental backup to fail if the AS OF SYSTEM TIME is less than the
previous backup's end time.

Previously, if a user ran `BACKUP INTO dest AS OF SYSTEM TIME t` and a full
backup subdirectory already existed at t, the backup would mistakingly increment
on that full backup instead of failing. Without the IN keyword, the user expects
a full backup, not an incremental backup. In this patch, the full backup fails
when it detects a full backup already exists at the resolved subdirectory.