### PR TITLE
server: improve proxy cookie management

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
@@ -175,7 +175,7 @@ const ProxyToNodeSelector = (props: ProxyToNodeSelectorProps) => {
       return cookie[0] === remoteNodeIDCookieName;
     });
   const setNodeIDCookie = (nodeID: string) => {
-    document.cookie = `${remoteNodeIDCookieName}=${nodeID}`;
+    document.cookie = `${remoteNodeIDCookieName}=${nodeID};path=/`;
     location.reload();
   };
   let currentNodeID = props.nodeID;
@@ -195,7 +195,7 @@ const ProxyToNodeSelector = (props: ProxyToNodeSelectorProps) => {
       Proxied to {currentNodeID}{" "}
       <button
         onClick={() =>
-          setNodeIDCookie(";expires=Thu, 01 Jan 1970 00:00:01 GMT")
+          setNodeIDCookie(";expires=Thu, 01 Jan 1970 00:00:01 GMT;path=/")
         }
       >
         Reset


### PR DESCRIPTION
Previously, when the node proxy encountered an error, it would always
set a cookie clearing header. This could cause confusing behavior when a
cookie was present in the browser, but a query param was used for
proxying and encountered an error (the underlying cookie would get
deleted). Additionally, the header that removed the cookie lacked an
expiration and a path field which led to multiple inconsistent cookies
being set in the browser when different paths were accessed while a
cookie was set.

Now, the cookie is cleared *only* when one was used for routing to a
NodeID and the `set-cookie` header sets a path and expiration field.

Resolves #76695

Release note: None