### PR TITLE
ccl/sqlproxyccl: cleanup balancer and connection tracker

### DIFF
--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach-go/v2/crdb"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvtenantccl"
-	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/balancer"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/denylist"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenant"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenantdirsvr"
@@ -855,12 +854,17 @@ func TestConnectionMigration(t *testing.T) {
 			_ = db.PingContext(tCtx)
 		}()
 
-		var conns []balancer.ConnectionHandle
+		var f *forwarder
 		require.Eventually(t, func() bool {
-			conns = proxy.handler.connTracker.GetConns(tenantID)
-			return len(conns) != 0
+			connsMap := proxy.handler.connTracker.GetConnsMap(tenantID)
+			for _, conns := range connsMap {
+				if len(conns) != 0 {
+					f = conns[0].(*forwarder)
+					return true
+				}
+			}
+			return false
 		}, 10*time.Second, 100*time.Millisecond)
-		f := conns[0].(*forwarder)
 
 		// Set up forwarder hooks.
 		prevTenant1 := true
@@ -1060,12 +1064,17 @@ func TestConnectionMigration(t *testing.T) {
 			_ = conn.PingContext(tCtx)
 		}()
 
-		var conns []balancer.ConnectionHandle
+		var f *forwarder
 		require.Eventually(t, func() bool {
-			conns = proxy.handler.connTracker.GetConns(tenantID)
-			return len(conns) != 0
+			connsMap := proxy.handler.connTracker.GetConnsMap(tenantID)
+			for _, conns := range connsMap {
+				if len(conns) != 0 {
+					f = conns[0].(*forwarder)
+					return true
+				}
+			}
+			return false
 		}, 10*time.Second, 100*time.Millisecond)
-		f := conns[0].(*forwarder)
 
 		initSuccessCount := f.metrics.ConnMigrationSuccessCount.Count()
 		initErrorRecoverableCount := f.metrics.ConnMigrationErrorRecoverableCount.Count()
@@ -1140,8 +1149,8 @@ func TestConnectionMigration(t *testing.T) {
 
 	// All connections should eventually be terminated.
 	require.Eventually(t, func() bool {
-		conns := proxy.handler.connTracker.GetConns(tenantID)
-		return len(conns) == 0
+		connsMap := proxy.handler.connTracker.GetConnsMap(tenantID)
+		return len(connsMap) == 0
 	}, 10*time.Second, 100*time.Millisecond)
 }
 


### PR DESCRIPTION
This is a follow up to #79725. Previously, there were two issues:
1. Some of the ConnTracker APIs (e.g. GetConns and OnDisconnect) were forcing
   creation of tenant entries even though that was unnecessary.
2. We were holding onto a large portion of memory (with connections from all
   tenants).

This commit addresses the two issues above: (1) tenant entries are no longer
being created when that was unnecessary, and (2) instead of holding onto all
the connections at once, we will retrieve the tenant's connections one by one.
At the same time, to avoid extra allocations that are solely used during data
transformations, we update the ConnTracker API to return a list of connection
handles indexed by pod's address directly.

Note that we may reintroduce the data transformation in future PRs, depending
on how we implement the connection rebalancing logic. That is currently
unclear.

Release note: None