### PR TITLE
release-21.1: util/contextutil: clarify `RunWithTimeout` error message

### DIFF
--- a/pkg/util/contextutil/BUILD.bazel
+++ b/pkg/util/contextutil/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/util/log",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//errorspb",
         "@com_github_gogo_protobuf//proto",
@@ -28,5 +29,6 @@ go_test(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//errbase",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/util/contextutil/context.go
+++ b/pkg/util/contextutil/context.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -86,11 +87,13 @@ func RunWithTimeout(
 ) error {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
+	start := timeutil.Now()
 	err := fn(ctx)
 	if err != nil && errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		err = &TimeoutError{
 			operation: op,
-			duration:  timeout,
+			timeout:   timeout,
+			took:      timeutil.Since(start),
 			cause:     err,
 		}
 	}

--- a/pkg/util/contextutil/timeout_error.go
+++ b/pkg/util/contextutil/timeout_error.go
@@ -55,10 +55,16 @@ func (t *TimeoutError) Format(s fmt.State, verb rune) { errors.FormatError(t, s,
 
 // FormatError implements errors.Formatter.
 func (t *TimeoutError) FormatError(p errors.Printer) error {
-	p.Printf("operation %q timed out after %s", t.operation, t.timeout)
+	// NB: With RunWithTimeout(), it is possible for both the caller and the
+	// callee to have set their own context timeout that is smaller than the
+	// timeout set by RunWithTimeout. It is also possible for the operation to run
+	// for much longer than the timeout, e.g. if the callee does not check the
+	// context in a timely manner. The error message must make this clear.
+	p.Printf("operation %q timed out", t.operation)
 	if t.took != 0 {
-		p.Printf(" (took %s)", t.took.Round(time.Millisecond))
+		p.Printf(" after %s", t.took.Round(time.Millisecond))
 	}
+	p.Printf(" (given timeout %s)", t.timeout)
 	return t.cause
 }
 

--- a/pkg/util/contextutil/timeout_error.go
+++ b/pkg/util/contextutil/timeout_error.go
@@ -24,9 +24,15 @@ import (
 // TimeoutError is a wrapped ContextDeadlineExceeded error. It indicates that
 // an operation didn't complete within its designated timeout.
 type TimeoutError struct {
+	// The operation that timed out.
 	operation string
-	duration  time.Duration
-	cause     error
+	// The configured timeout.
+	timeout time.Duration
+	// The duration of the operation. This is usually expected to be the same as
+	// the timeout, but can be longer if the timeout was not observed expediently
+	// (because the ctx was not checked sufficiently often).
+	took  time.Duration
+	cause error
 }
 
 var _ error = (*TimeoutError)(nil)
@@ -49,7 +55,10 @@ func (t *TimeoutError) Format(s fmt.State, verb rune) { errors.FormatError(t, s,
 
 // FormatError implements errors.Formatter.
 func (t *TimeoutError) FormatError(p errors.Printer) error {
-	p.Printf("operation %q timed out after %s", t.operation, t.duration)
+	p.Printf("operation %q timed out after %s", t.operation, t.timeout)
+	if t.took != 0 {
+		p.Printf(" (took %s)", t.took.Round(time.Millisecond))
+	}
 	return t.cause
 }
 
@@ -73,9 +82,9 @@ func encodeTimeoutError(
 ) (msgPrefix string, safe []string, details proto.Message) {
 	t := err.(*TimeoutError)
 	details = &errorspb.StringsPayload{
-		Details: []string{t.operation, t.duration.String()},
+		Details: []string{t.operation, t.timeout.String(), t.took.String()},
 	}
-	msgPrefix = fmt.Sprintf("operation %q timed out after %s", t.operation, t.duration)
+	msgPrefix = fmt.Sprintf("operation %q timed out after %s", t.operation, t.timeout)
 	return msgPrefix, nil, details
 }
 
@@ -91,14 +100,23 @@ func decodeTimeoutError(
 		return nil
 	}
 	op := m.Details[0]
-	dur, decodeErr := time.ParseDuration(m.Details[1])
+	timeout, decodeErr := time.ParseDuration(m.Details[1])
 	if decodeErr != nil {
 		// Not encoded by our encode function. Bail out.
 		return nil //nolint:returnerrcheck
 	}
+	var took time.Duration
+	if len(m.Details) >= 3 {
+		took, decodeErr = time.ParseDuration(m.Details[2])
+		if decodeErr != nil {
+			// Not encoded by our encode function. Bail out.
+			return nil //nolint:returnerrcheck
+		}
+	}
 	return &TimeoutError{
 		operation: op,
-		duration:  dur,
+		timeout:   timeout,
+		took:      took,
 		cause:     cause,
 	}
 }

--- a/pkg/util/contextutil/timeout_error_test.go
+++ b/pkg/util/contextutil/timeout_error_test.go
@@ -21,13 +21,31 @@ import (
 )
 
 func TestEncodeDecode(t *testing.T) {
-	origErr := &TimeoutError{
-		operation: "hello",
-		duration:  3 * time.Minute,
-		cause:     fmt.Errorf("woo")}
-	enc := errbase.EncodeError(context.Background(), origErr)
-	newErr := errbase.DecodeError(context.Background(), enc)
+	ctx := context.Background()
+	{
+		origErr := &TimeoutError{
+			operation: "hello",
+			timeout:   3 * time.Minute,
+			cause:     fmt.Errorf("woo"),
+		}
+		enc := errbase.EncodeError(ctx, origErr)
+		newErr := errbase.DecodeError(ctx, enc)
 
-	assert.Equal(t, origErr.Error(), newErr.Error())
-	assert.Equal(t, origErr, newErr)
+		assert.Equal(t, origErr.Error(), newErr.Error())
+		assert.Equal(t, origErr, newErr)
+	}
+
+	{
+		origErr := &TimeoutError{
+			operation: "hello",
+			timeout:   3 * time.Minute,
+			took:      4 * time.Minute,
+			cause:     fmt.Errorf("woo"),
+		}
+		enc := errbase.EncodeError(ctx, origErr)
+		newErr := errbase.DecodeError(ctx, enc)
+
+		assert.Equal(t, origErr.Error(), newErr.Error())
+		assert.Equal(t, origErr, newErr)
+	}
 }


### PR DESCRIPTION
Backport:
  * 1/1 commits from "contextutil: record actual duration in TimeoutError" (#69484)
  * 1/1 commits from "util/contextutil: clarify `RunWithTimeout` error message" (#79767)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: log observability fix.