### PR TITLE
release-21.2: log: remove spurious error logging from ETag handler

### DIFF
--- a/pkg/util/httputil/BUILD.bazel
+++ b/pkg/util/httputil/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/settings",
-        "//pkg/util/log",
         "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_gogo_protobuf//jsonpb",

--- a/pkg/util/httputil/handlers.go
+++ b/pkg/util/httputil/handlers.go
@@ -10,11 +10,7 @@
 
 package httputil
 
-import (
-	"net/http"
-
-	"github.com/cockroachdb/cockroach/pkg/util/log"
-)
+import "net/http"
 
 // EtagHandler creates an http.Handler middleware that wraps another HTTP
 // handler, adding support for the If-None-Match request header and ETag
@@ -58,9 +54,6 @@ func EtagHandler(contentHashes map[string]string, next http.Handler) http.Handle
 			// still fresh, and that it can use the provided ETag for its next
 			// request.
 			w.WriteHeader(304)
-			if _, err := w.Write(nil); err != nil {
-				log.Errorf(r.Context(), "Unable to write empty response body: %+v", err)
-			}
 			return
 		}
 


### PR DESCRIPTION
Backport 1/1 commits from #79811.

/cc @cockroachdb/release

----

The ETag handler previously attempted to explicitly write `nil` to the HTTP response body for 304 Not Modified responses. While this accurately represented the server's intention ("truncate the body") and behaved correctly from an HTTP client's perspective, it produced an unexpected error from the Go standard library that was logged by the handler. Don't write a `nil` body for HTTP 304 responses to avoid spurious error logging.

Release note (bug fix): HTTP 304 responses no longer result in error logs.

----

Release justification: Low risk, high benefit changes to existing functionality