### PR TITLE
sql: support {GRANT|REVOKE} PRIVILEGES ... ON {SEQUENCE | ALL SEQUENCES IN SCHEMA}

### DIFF
--- a/docs/generated/sql/bnf/grant_stmt.bnf
+++ b/docs/generated/sql/bnf/grant_stmt.bnf
@@ -19,6 +19,12 @@ grant_stmt ::=
 	| 'GRANT' 'ALL'  'ON' 'SCHEMA' schema_name_list 'TO' role_spec_list 
 	| 'GRANT' privilege_list 'ON' 'SCHEMA' schema_name_list 'TO' role_spec_list 'WITH' 'GRANT' 'OPTION'
 	| 'GRANT' privilege_list 'ON' 'SCHEMA' schema_name_list 'TO' role_spec_list 
+	| 'GRANT' 'ALL' 'PRIVILEGES' 'ON' 'ALL' 'SEQUENCES' 'IN' 'SCHEMA' schema_name_list 'TO' role_spec_list 'WITH' 'GRANT' 'OPTION'
+	| 'GRANT' 'ALL' 'PRIVILEGES' 'ON' 'ALL' 'SEQUENCES' 'IN' 'SCHEMA' schema_name_list 'TO' role_spec_list 
+	| 'GRANT' 'ALL'  'ON' 'ALL' 'SEQUENCES' 'IN' 'SCHEMA' schema_name_list 'TO' role_spec_list 'WITH' 'GRANT' 'OPTION'
+	| 'GRANT' 'ALL'  'ON' 'ALL' 'SEQUENCES' 'IN' 'SCHEMA' schema_name_list 'TO' role_spec_list 
+	| 'GRANT' privilege_list 'ON' 'ALL' 'SEQUENCES' 'IN' 'SCHEMA' schema_name_list 'TO' role_spec_list 'WITH' 'GRANT' 'OPTION'
+	| 'GRANT' privilege_list 'ON' 'ALL' 'SEQUENCES' 'IN' 'SCHEMA' schema_name_list 'TO' role_spec_list 
 	| 'GRANT' 'ALL' 'PRIVILEGES' 'ON' 'ALL' 'TABLES' 'IN' 'SCHEMA' schema_name_list 'TO' role_spec_list 'WITH' 'GRANT' 'OPTION'
 	| 'GRANT' 'ALL' 'PRIVILEGES' 'ON' 'ALL' 'TABLES' 'IN' 'SCHEMA' schema_name_list 'TO' role_spec_list 
 	| 'GRANT' 'ALL'  'ON' 'ALL' 'TABLES' 'IN' 'SCHEMA' schema_name_list 'TO' role_spec_list 'WITH' 'GRANT' 'OPTION'

--- a/docs/generated/sql/bnf/revoke_stmt.bnf
+++ b/docs/generated/sql/bnf/revoke_stmt.bnf
@@ -22,6 +22,9 @@ revoke_stmt ::=
 	| 'REVOKE' 'ALL' 'PRIVILEGES' 'ON' 'ALL' 'TABLES' 'IN' 'SCHEMA' schema_name_list 'FROM' role_spec_list
 	| 'REVOKE' 'ALL'  'ON' 'ALL' 'TABLES' 'IN' 'SCHEMA' schema_name_list 'FROM' role_spec_list
 	| 'REVOKE' privilege_list 'ON' 'ALL' 'TABLES' 'IN' 'SCHEMA' schema_name_list 'FROM' role_spec_list
+	| 'REVOKE' 'ALL' 'PRIVILEGES' 'ON' 'ALL' 'SEQUENCES' 'IN' 'SCHEMA' schema_name_list 'FROM' role_spec_list
+	| 'REVOKE' 'ALL'  'ON' 'ALL' 'SEQUENCES' 'IN' 'SCHEMA' schema_name_list 'FROM' role_spec_list
+	| 'REVOKE' privilege_list 'ON' 'ALL' 'SEQUENCES' 'IN' 'SCHEMA' schema_name_list 'FROM' role_spec_list
 	| 'REVOKE' 'GRANT' 'OPTION' 'FOR' 'ALL' 'PRIVILEGES' 'ON' 'ALL' 'TABLES' 'IN' 'SCHEMA' schema_name_list 'FROM' role_spec_list
 	| 'REVOKE' 'GRANT' 'OPTION' 'FOR' 'ALL'  'ON' 'ALL' 'TABLES' 'IN' 'SCHEMA' schema_name_list 'FROM' role_spec_list
 	| 'REVOKE' 'GRANT' 'OPTION' 'FOR' privilege_list 'ON' 'ALL' 'TABLES' 'IN' 'SCHEMA' schema_name_list 'FROM' role_spec_list

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -82,6 +82,7 @@ grant_stmt ::=
 	| 'GRANT' privilege_list 'TO' role_spec_list 'WITH' 'ADMIN' 'OPTION'
 	| 'GRANT' privileges 'ON' 'TYPE' target_types 'TO' role_spec_list opt_with_grant_option
 	| 'GRANT' privileges 'ON' 'SCHEMA' schema_name_list 'TO' role_spec_list opt_with_grant_option
+	| 'GRANT' privileges 'ON' 'ALL' 'SEQUENCES' 'IN' 'SCHEMA' schema_name_list 'TO' role_spec_list opt_with_grant_option
 	| 'GRANT' privileges 'ON' 'ALL' 'TABLES' 'IN' 'SCHEMA' schema_name_list 'TO' role_spec_list opt_with_grant_option
 
 prepare_stmt ::=
@@ -97,6 +98,7 @@ revoke_stmt ::=
 	| 'REVOKE' privileges 'ON' 'SCHEMA' schema_name_list 'FROM' role_spec_list
 	| 'REVOKE' 'GRANT' 'OPTION' 'FOR' privileges 'ON' 'SCHEMA' schema_name_list 'FROM' role_spec_list
 	| 'REVOKE' privileges 'ON' 'ALL' 'TABLES' 'IN' 'SCHEMA' schema_name_list 'FROM' role_spec_list
+	| 'REVOKE' privileges 'ON' 'ALL' 'SEQUENCES' 'IN' 'SCHEMA' schema_name_list 'FROM' role_spec_list
 	| 'REVOKE' 'GRANT' 'OPTION' 'FOR' privileges 'ON' 'ALL' 'TABLES' 'IN' 'SCHEMA' schema_name_list 'FROM' role_spec_list
 
 savepoint_stmt ::=
@@ -334,6 +336,7 @@ targets ::=
 	| col_name_keyword
 	| unreserved_keyword
 	| complex_table_pattern
+	| 'SEQUENCE' table_pattern_list
 	| table_pattern ',' table_pattern_list
 	| 'TABLE' table_pattern_list
 	| 'TENANT' iconst64
@@ -1364,12 +1367,12 @@ complex_table_pattern ::=
 	| db_object_name_component '.' '*'
 	| '*'
 
+table_pattern_list ::=
+	( table_pattern ) ( ( ',' table_pattern ) )*
+
 table_pattern ::=
 	simple_db_object_name
 	| complex_table_pattern
-
-table_pattern_list ::=
-	( table_pattern ) ( ( ',' table_pattern ) )*
 
 iconst64 ::=
 	'ICONST'

--- a/pkg/ccl/backupccl/backupresolver/targets.go
+++ b/pkg/ccl/backupccl/backupresolver/targets.go
@@ -322,7 +322,7 @@ func DescriptorsMatchingTargets(
 	asOf hlc.Timestamp,
 ) (DescriptorsMatched, error) {
 	ret := DescriptorsMatched{
-		DescsByTablePattern: make(map[tree.TablePattern]catalog.Descriptor, len(targets.Tables)),
+		DescsByTablePattern: make(map[tree.TablePattern]catalog.Descriptor, len(targets.Tables.TablePatterns)),
 	}
 
 	r, err := NewDescriptorResolver(descriptors)
@@ -424,7 +424,7 @@ func DescriptorsMatchingTargets(
 	alreadyRequestedTables := make(map[descpb.ID]struct{})
 	// Process specific SCHEMAs requested for a database.
 	alreadyRequestedSchemasByDBs := make(map[descpb.ID]map[string]struct{})
-	for _, pattern := range targets.Tables {
+	for _, pattern := range targets.Tables.TablePatterns {
 		var err error
 		origPat := pattern
 		pattern, err = pattern.NormalizeTablePattern()

--- a/pkg/ccl/backupccl/backupresolver/targets_test.go
+++ b/pkg/ccl/backupccl/backupresolver/targets_test.go
@@ -283,7 +283,7 @@ func TestDescriptorsMatchingTargets(t *testing.T) {
 				if !reflect.DeepEqual(test.expectedDBs, matchedDBNames) {
 					t.Fatalf("expected %q got %q", test.expectedDBs, matchedDBNames)
 				}
-				for _, p := range targets.Tables {
+				for _, p := range targets.Tables.TablePatterns {
 					_, ok := matched.DescsByTablePattern[p]
 					if !ok {
 						t.Fatalf("no entry in %q for %q", matched.DescsByTablePattern, p)

--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -750,13 +750,13 @@ func makeScheduledBackupEval(
 	ctx context.Context, p sql.PlanHookState, schedule *tree.ScheduledBackup,
 ) (*scheduledBackupEval, error) {
 	var err error
-	if schedule.Targets != nil && schedule.Targets.Tables != nil {
+	if schedule.Targets != nil && schedule.Targets.Tables.TablePatterns != nil {
 		// Table backup targets must be fully qualified during scheduled backup
 		// planning. This is because the actual execution of the backup job occurs
 		// in a background, scheduled job session, that does not have the same
 		// resolution configuration as during planning.
-		schedule.Targets.Tables, err = fullyQualifyScheduledBackupTargetTables(ctx, p,
-			schedule.Targets.Tables)
+		schedule.Targets.Tables.TablePatterns, err = fullyQualifyScheduledBackupTargetTables(ctx, p,
+			schedule.Targets.Tables.TablePatterns)
 		if err != nil {
 			return nil, errors.Wrap(err, "qualifying backup target tables")
 		}

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -348,7 +348,7 @@ func createChangefeedJobRecord(
 
 	tableOnlyTargetList := tree.TargetList{}
 	for _, t := range changefeedStmt.Targets {
-		tableOnlyTargetList.Tables = append(tableOnlyTargetList.Tables, t.TableName)
+		tableOnlyTargetList.Tables.TablePatterns = append(tableOnlyTargetList.Tables.TablePatterns, t.TableName)
 	}
 
 	// This grabs table descriptors once to get their ids.
@@ -569,7 +569,7 @@ func getTableDescriptors(
 		return nil, errors.Errorf(`CHANGEFEED cannot target %s`,
 			tree.AsString(targets))
 	}
-	for _, t := range targets.Tables {
+	for _, t := range targets.Tables.TablePatterns {
 		p, err := t.NormalizeTablePattern()
 		if err != nil {
 			return nil, err

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
@@ -146,7 +146,7 @@ func ingestionPlanHook(
 		streamAddress = streamingccl.StreamAddress(url.String())
 
 		if ingestionStmt.Targets.Types != nil || ingestionStmt.Targets.Databases != nil ||
-			ingestionStmt.Targets.Tables != nil || ingestionStmt.Targets.Schemas != nil {
+			ingestionStmt.Targets.Tables.TablePatterns != nil || ingestionStmt.Targets.Schemas != nil {
 			return errors.Newf("unsupported target in ingestion query, "+
 				"only tenant ingestion is supported: %s", ingestionStmt.String())
 		}

--- a/pkg/internal/sqlsmith/bulkio.go
+++ b/pkg/internal/sqlsmith/bulkio.go
@@ -91,7 +91,7 @@ func makeBackup(s *Smither) (tree.Statement, bool) {
 	name := fmt.Sprintf("%s/%s", s.bulkSrv.URL, s.name("backup"))
 	var targets tree.TargetList
 	seen := map[tree.TableName]bool{}
-	for len(targets.Tables) < 1 || s.coin() {
+	for len(targets.Tables.TablePatterns) < 1 || s.coin() {
 		table, ok := s.getRandTable()
 		if !ok {
 			return nil, false
@@ -100,7 +100,7 @@ func makeBackup(s *Smither) (tree.Statement, bool) {
 			continue
 		}
 		seen[*table.TableName] = true
-		targets.Tables = append(targets.Tables, table.TableName)
+		targets.Tables.TablePatterns = append(targets.Tables.TablePatterns, table.TableName)
 	}
 	s.lock.Lock()
 	s.bulkBackups[name] = targets
@@ -129,10 +129,10 @@ func makeRestore(s *Smither) (tree.Statement, bool) {
 		return nil, false
 	}
 	// Choose some random subset of tables.
-	s.rnd.Shuffle(len(targets.Tables), func(i, j int) {
-		targets.Tables[i], targets.Tables[j] = targets.Tables[j], targets.Tables[i]
+	s.rnd.Shuffle(len(targets.Tables.TablePatterns), func(i, j int) {
+		targets.Tables.TablePatterns[i], targets.Tables.TablePatterns[j] = targets.Tables.TablePatterns[j], targets.Tables.TablePatterns[i]
 	})
-	targets.Tables = targets.Tables[:1+s.rnd.Intn(len(targets.Tables))]
+	targets.Tables.TablePatterns = targets.Tables.TablePatterns[:1+s.rnd.Intn(len(targets.Tables.TablePatterns))]
 
 	db := s.name("db")
 	if _, err := s.db.Exec(fmt.Sprintf(`CREATE DATABASE %s`, db)); err != nil {

--- a/pkg/sql/catalog/catpb/privilege_test.go
+++ b/pkg/sql/catalog/catpb/privilege_test.go
@@ -313,6 +313,7 @@ func TestValidPrivilegesForObjects(t *testing.T) {
 		{privilege.Database, privilege.DBPrivileges},
 		{privilege.Schema, privilege.SchemaPrivileges},
 		{privilege.Type, privilege.TypePrivileges},
+		{privilege.Sequence, privilege.SequencePrivileges},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/sql/catalog/catprivilege/fix.go
+++ b/pkg/sql/catalog/catprivilege/fix.go
@@ -64,8 +64,8 @@ func MaybeFixUsagePrivForTablesAndDBs(ptr **catpb.PrivilegeDescriptor) bool {
 // * fixing default privileges for the "root" user
 // * fixing maximum privileges for users.
 // * populating the owner field if previously empty.
-// * updating version field to Version21_2.
-// MaybeFixPrivileges can be removed after v21.2.
+// * updating version field older than 21.2 to Version21_2.
+// MaybeFixPrivileges can be removed after v22.2.
 func MaybeFixPrivileges(
 	ptr **catpb.PrivilegeDescriptor,
 	parentID, parentSchemaID descpb.ID,

--- a/pkg/sql/catalog/resolver/resolver_test.go
+++ b/pkg/sql/catalog/resolver/resolver_test.go
@@ -445,7 +445,7 @@ func TestResolveTablePatternOrName(t *testing.T) {
 				if err != nil {
 					return nil, "", err
 				}
-				tp, err := stmt.AST.(*tree.Grant).Targets.Tables[0].NormalizeTablePattern()
+				tp, err := stmt.AST.(*tree.Grant).Targets.Tables.TablePatterns[0].NormalizeTablePattern()
 				if err != nil {
 					return nil, "", err
 				}

--- a/pkg/sql/catalog/tabledesc/table_desc_builder.go
+++ b/pkg/sql/catalog/tabledesc/table_desc_builder.go
@@ -235,11 +235,20 @@ func maybeFillInDescriptor(
 	if parentSchemaID == descpb.InvalidID {
 		parentSchemaID = keys.PublicSchemaID
 	}
+
+	var objectType privilege.ObjectType
+
+	if desc.IsSequence() {
+		objectType = privilege.Sequence
+	} else {
+		objectType = privilege.Table
+	}
+
 	fixedPrivileges := catprivilege.MaybeFixPrivileges(
 		&desc.Privileges,
 		desc.GetParentID(),
 		parentSchemaID,
-		privilege.Table,
+		objectType,
 		desc.GetName(),
 	)
 	addedGrantOptions := catprivilege.MaybeUpdateGrantOptions(desc.Privileges)

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -495,7 +495,11 @@ func (desc *wrapper) ValidateSelf(vea catalog.ValidationErrorAccumulator) {
 	if desc.Privileges == nil {
 		vea.Report(errors.AssertionFailedf("privileges not set"))
 	} else {
-		vea.Report(catprivilege.Validate(*desc.Privileges, desc, privilege.Table))
+		if desc.IsSequence() {
+			vea.Report(catprivilege.Validate(*desc.Privileges, desc, privilege.Sequence))
+		} else {
+			vea.Report(catprivilege.Validate(*desc.Privileges, desc, privilege.Table))
+		}
 	}
 
 	// Validate that the depended-on-by references are well-formed.

--- a/pkg/sql/delegate/show_grants.go
+++ b/pkg/sql/delegate/show_grants.go
@@ -187,7 +187,7 @@ FROM "".information_schema.type_privileges`
 			// if the type of target is table.
 			var allTables tree.TableNames
 
-			for _, tableTarget := range n.Targets.Tables {
+			for _, tableTarget := range n.Targets.Tables.TablePatterns {
 				tableGlob, err := tableTarget.NormalizeTablePattern()
 				if err != nil {
 					return nil, err

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1364,7 +1364,15 @@ func populateTablePrivileges(
 			// TODO(knz): This should filter for the current user, see
 			// https://github.com/cockroachdb/cockroach/issues/35572
 			populateGrantOption := p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.ValidateGrantOption)
-			for _, u := range table.GetPrivileges().Show(privilege.Table) {
+
+			var tableType privilege.ObjectType
+			if table.IsSequence() {
+				tableType = privilege.Sequence
+			} else {
+				tableType = privilege.Table
+			}
+
+			for _, u := range table.GetPrivileges().Show(tableType) {
 				granteeNameStr := tree.NewDString(u.User.Normalized())
 				for _, priv := range u.Privileges {
 					var isGrantable tree.Datum

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_sequence
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_sequence
@@ -89,6 +89,7 @@ test           public       s2          testuser   DROP            true
 test           public       s2          testuser   GRANT           true
 test           public       s2          testuser   INSERT          true
 test           public       s2          testuser   UPDATE          true
+test           public       s2          testuser   USAGE           true
 test           public       s2          testuser   ZONECONFIG      true
 test           public       s2          testuser2  CREATE          true
 test           public       s2          testuser2  DELETE          true
@@ -96,6 +97,7 @@ test           public       s2          testuser2  DROP            true
 test           public       s2          testuser2  GRANT           true
 test           public       s2          testuser2  INSERT          true
 test           public       s2          testuser2  UPDATE          true
+test           public       s2          testuser2  USAGE           true
 test           public       s2          testuser2  ZONECONFIG      true
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/grant_on_all_sequences_in_schema
+++ b/pkg/sql/logictest/testdata/logic_test/grant_on_all_sequences_in_schema
@@ -1,0 +1,88 @@
+statement ok
+CREATE USER testuser2
+
+statement ok
+CREATE SCHEMA s;
+CREATE SCHEMA s2;
+
+# Granting in a schema with no sequences should be okay.
+statement ok
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA s TO testuser
+
+query TTTTT colnames
+SHOW GRANTS FOR testuser
+----
+database_name  schema_name  relation_name  grantee  privilege_type
+
+statement ok
+CREATE SEQUENCE s.q;
+CREATE SEQUENCE s2.q;
+CREATE TABLE s.t();
+CREATE TABLE s2.t();
+
+statement ok
+SET ROLE testuser
+
+statement error pq: user testuser does not have USAGE privilege on schema s
+SELECT * FROM s.q;
+
+statement ok
+SET ROLE root
+
+statement ok
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA s TO testuser
+
+query TTTTT colnames
+SHOW GRANTS FOR testuser
+----
+database_name  schema_name  relation_name  grantee   privilege_type
+test           s            q              testuser  SELECT
+
+statement ok
+GRANT USAGE ON ALL SEQUENCES IN SCHEMA s TO testuser
+
+query TTTTT colnames
+SHOW GRANTS FOR testuser
+----
+database_name  schema_name  relation_name  grantee   privilege_type
+test           s            q              testuser  SELECT
+test           s            q              testuser  USAGE
+
+statement ok
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA s, s2 TO testuser, testuser2
+
+query TTTTT colnames
+SHOW GRANTS FOR testuser, testuser2
+----
+database_name  schema_name  relation_name  grantee    privilege_type
+test           s            q              testuser   SELECT
+test           s            q              testuser   USAGE
+test           s            q              testuser2  SELECT
+test           s2           q              testuser   SELECT
+test           s2           q              testuser2  SELECT
+
+statement ok
+GRANT ALL ON ALL SEQUENCES IN SCHEMA s, s2 TO testuser, testuser2
+
+query TTTTT colnames
+SHOW GRANTS FOR testuser, testuser2
+----
+database_name  schema_name  relation_name  grantee    privilege_type
+test           s            q              testuser   ALL
+test           s            q              testuser2  ALL
+test           s2           q              testuser   ALL
+test           s2           q              testuser2  ALL
+
+statement ok
+CREATE USER testuser3
+
+# Sequences are treated as a subset of tables.
+statement ok
+GRANT ALL ON ALL TABLES IN SCHEMA s2 TO testuser3
+
+query TTTTT colnames
+SHOW GRANTS FOR testuser3
+----
+database_name  schema_name  relation_name  grantee    privilege_type
+test           s2           q              testuser3  ALL
+test           s2           t              testuser3  ALL

--- a/pkg/sql/logictest/testdata/logic_test/grant_sequence
+++ b/pkg/sql/logictest/testdata/logic_test/grant_sequence
@@ -1,0 +1,230 @@
+# LogicTest: local
+
+statement ok
+CREATE SEQUENCE a START 1 INCREMENT BY 2
+
+statement ok
+CREATE USER readwrite
+
+statement ok
+SET ROLE readwrite
+
+statement error pq: user readwrite does not have SELECT privilege on relation a
+SELECT * FROM a;
+
+statement error pq: nextval\(\): user readwrite does not have UPDATE or USAGE privilege on relation a
+SELECT nextval('a')
+
+statement ok
+SET ROLE root
+
+statement ok
+GRANT USAGE ON SEQUENCE a TO readwrite
+
+statement ok
+SET ROLE readwrite
+
+query I
+SELECT nextval('a')
+----
+1
+
+query I
+SELECT currval('a')
+----
+1
+
+statement ok
+SET ROLE root
+
+statement ok
+GRANT ALL ON SEQUENCE a TO readwrite
+
+query TTTTTB colnames
+SHOW GRANTS ON SEQUENCE a
+----
+database_name  schema_name  table_name  grantee    privilege_type  is_grantable
+test           public       a           admin      ALL             true
+test           public       a           readwrite  ALL             true
+test           public       a           root       ALL             true
+
+statement ok
+REVOKE UPDATE ON SEQUENCE a FROM readwrite
+
+query TTTTTB colnames
+SHOW GRANTS ON SEQUENCE a
+----
+database_name  schema_name  table_name  grantee    privilege_type  is_grantable
+test           public       a           admin      ALL             true
+test           public       a           readwrite  CREATE          true
+test           public       a           readwrite  DELETE          true
+test           public       a           readwrite  DROP            true
+test           public       a           readwrite  GRANT           true
+test           public       a           readwrite  INSERT          true
+test           public       a           readwrite  SELECT          true
+test           public       a           readwrite  USAGE           true
+test           public       a           readwrite  ZONECONFIG      true
+test           public       a           root       ALL             true
+
+statement ok
+GRANT UPDATE ON SEQUENCE a TO readwrite
+
+statement ok
+SET ROLE readwrite
+
+query IIB
+SELECT * FROM a;
+----
+1  0  true
+
+query I
+SELECT nextval('a')
+----
+3
+
+query I
+SELECT nextval('a')
+----
+5
+
+statement ok
+SET ROLE root
+
+query T noticetrace
+GRANT CREATE, DROP, USAGE ON SEQUENCE a TO readwrite
+----
+NOTICE: grant options were automatically applied but this behavior is deprecated
+HINT: please use WITH GRANT OPTION
+NOTICE: some privileges have no effect on sequences: [CREATE]
+
+query TTTTTTTT
+SELECT * FROM information_schema.table_privileges WHERE grantee = 'readwrite';
+----
+NULL  readwrite  test  public  a  CREATE      YES  NO
+NULL  readwrite  test  public  a  DELETE      YES  NO
+NULL  readwrite  test  public  a  DROP        YES  NO
+NULL  readwrite  test  public  a  GRANT       YES  NO
+NULL  readwrite  test  public  a  INSERT      YES  NO
+NULL  readwrite  test  public  a  SELECT      YES  YES
+NULL  readwrite  test  public  a  UPDATE      YES  NO
+NULL  readwrite  test  public  a  USAGE       YES  NO
+NULL  readwrite  test  public  a  ZONECONFIG  YES  NO
+
+statement ok
+REVOKE SELECT,DROP,CREATE ON SEQUENCE a FROM readwrite
+
+query TTTTTTTT
+SELECT * FROM information_schema.table_privileges WHERE grantee = 'readwrite';
+----
+NULL  readwrite  test  public  a  DELETE      YES  NO
+NULL  readwrite  test  public  a  GRANT       YES  NO
+NULL  readwrite  test  public  a  INSERT      YES  NO
+NULL  readwrite  test  public  a  UPDATE      YES  NO
+NULL  readwrite  test  public  a  USAGE       YES  NO
+NULL  readwrite  test  public  a  ZONECONFIG  YES  NO
+
+statement ok
+CREATE SEQUENCE b START 1 INCREMENT BY 2
+
+statement ok
+GRANT ALL ON ALL SEQUENCES IN SCHEMA test.public TO readwrite;
+
+query TTTTTTTT
+SELECT * FROM information_schema.table_privileges WHERE grantee = 'readwrite';
+----
+NULL  readwrite  test  public  a  ALL  YES  NO
+NULL  readwrite  test  public  b  ALL  YES  NO
+
+statement ok
+REVOKE SELECT ON ALL SEQUENCES IN SCHEMA test.public FROM readwrite;
+
+query TTTTTTTT
+SELECT * FROM information_schema.table_privileges WHERE grantee = 'readwrite';
+----
+NULL  readwrite  test  public  a  CREATE      YES  NO
+NULL  readwrite  test  public  a  DELETE      YES  NO
+NULL  readwrite  test  public  a  DROP        YES  NO
+NULL  readwrite  test  public  a  GRANT       YES  NO
+NULL  readwrite  test  public  a  INSERT      YES  NO
+NULL  readwrite  test  public  a  UPDATE      YES  NO
+NULL  readwrite  test  public  a  USAGE       YES  NO
+NULL  readwrite  test  public  a  ZONECONFIG  YES  NO
+NULL  readwrite  test  public  b  CREATE      YES  NO
+NULL  readwrite  test  public  b  DELETE      YES  NO
+NULL  readwrite  test  public  b  DROP        YES  NO
+NULL  readwrite  test  public  b  GRANT       YES  NO
+NULL  readwrite  test  public  b  INSERT      YES  NO
+NULL  readwrite  test  public  b  UPDATE      YES  NO
+NULL  readwrite  test  public  b  USAGE       YES  NO
+NULL  readwrite  test  public  b  ZONECONFIG  YES  NO
+
+subtest grant_drop_on_sequences
+
+statement ok
+SET ROLE root
+
+statement ok
+CREATE SEQUENCE to_drop_seq
+
+statement ok
+CREATE ROLE user1
+
+statement ok
+SET ROLE user1
+
+statement error user user1 does not have DROP privilege on relation to_drop_seq
+DROP SEQUENCE to_drop_seq
+
+statement ok
+SET ROLE root
+
+statement ok
+GRANT DROP ON SEQUENCE to_drop_seq TO user1
+
+statement ok
+SET ROLE user1
+
+statement ok
+DROP SEQUENCE to_drop_seq
+
+
+subtest grant_grant_on_sequences
+
+statement ok
+SET ROLE root
+
+statement ok
+CREATE SEQUENCE to_drop_seq
+
+statement ok
+GRANT DROP ON SEQUENCE to_drop_seq TO user1
+
+statement ok
+CREATE ROLE user2
+
+statement ok
+SET ROLE user1
+
+statement error user user1 missing WITH GRANT OPTION privilege on DROP
+GRANT DROP ON SEQUENCE to_drop_seq TO user2
+
+statement ok
+SET ROLE root
+
+statement ok
+GRANT GRANT ON SEQUENCE to_drop_seq TO user1
+
+statement ok
+SET ROLE user1
+
+statement ok
+GRANT DROP ON SEQUENCE to_drop_seq TO user2
+
+statement ok
+SET ROLE user2
+
+statement ok
+DROP SEQUENCE to_drop_seq
+
+statement ok
+SET ROLE root

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -932,7 +932,7 @@ user testuser
 statement error pq: user testuser does not have SELECT privilege on relation priv_test
 SELECT * FROM priv_test
 
-statement error pq: nextval\(\): user testuser does not have UPDATE privilege on relation priv_test
+statement error pq: nextval\(\): user testuser does not have UPDATE or USAGE privilege on relation priv_test
 SELECT nextval('priv_test')
 
 statement error pq: setval\(\): user testuser does not have UPDATE privilege on relation priv_test

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -575,8 +575,6 @@ func TestUnimplementedSyntax(t *testing.T) {
 		{`UPDATE foo SET a.b = 1`, 27792, ``, ``},
 		{`UPDATE Foo SET x.y = z`, 27792, ``, ``},
 
-		{`GRANT SELECT ON SEQUENCE a`, 74780, `grant privileges on sequence`, ``},
-
 		{`REINDEX INDEX a`, 0, `reindex index`, `CockroachDB does not require reindexing.`},
 		{`REINDEX INDEX CONCURRENTLY a`, 0, `reindex index`, `CockroachDB does not require reindexing.`},
 		{`REINDEX TABLE a`, 0, `reindex table`, `CockroachDB does not require reindexing.`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4694,6 +4694,18 @@ grant_stmt:
   {
     return unimplemented(sqllex, "grant privileges on schema with")
   }
+| GRANT privileges ON ALL SEQUENCES IN SCHEMA schema_name_list TO role_spec_list opt_with_grant_option
+  {
+    $$.val = &tree.Grant{
+      Privileges: $2.privilegeList(),
+      Targets: tree.TargetList{
+        Schemas: $8.objectNamePrefixList(),
+        AllSequencesInSchema: true,
+      },
+      Grantees: $10.roleSpecList(),
+      WithGrantOption: $11.bool(),
+    }
+  }
 | GRANT privileges ON ALL TABLES IN SCHEMA schema_name_list TO role_spec_list opt_with_grant_option
   {
     $$.val = &tree.Grant{
@@ -4705,10 +4717,6 @@ grant_stmt:
       Grantees: $10.roleSpecList(),
       WithGrantOption: $11.bool(),
     }
-  }
-| GRANT privileges ON SEQUENCE error
-  {
-    return unimplementedWithIssueDetail(sqllex, 74780, "grant privileges on sequence")
   }
 | GRANT error // SHOW HELP: GRANT
 
@@ -4790,6 +4798,18 @@ revoke_stmt:
       GrantOptionFor: false,
     }
   }
+| REVOKE privileges ON ALL SEQUENCES IN SCHEMA schema_name_list FROM role_spec_list
+  {
+    $$.val = &tree.Revoke{
+      Privileges: $2.privilegeList(),
+      Targets: tree.TargetList{
+        Schemas: $8.objectNamePrefixList(),
+        AllSequencesInSchema: true,
+      },
+      Grantees: $10.roleSpecList(),
+      GrantOptionFor: false,
+    }
+  }
 | REVOKE GRANT OPTION FOR privileges ON ALL TABLES IN SCHEMA schema_name_list FROM role_spec_list
   {
     $$.val = &tree.Revoke{
@@ -4801,10 +4821,6 @@ revoke_stmt:
       Grantees: $13.roleSpecList(),
       GrantOptionFor: true,
     }
-  }
-| REVOKE privileges ON SEQUENCE error
-  {
-    return unimplemented(sqllex, "revoke privileges on sequence")
   }
 | REVOKE error // SHOW HELP: REVOKE
 
@@ -6770,11 +6786,11 @@ opt_on_targets_roles:
 targets:
   IDENT
   {
-    $$.val = tree.TargetList{Tables: tree.TablePatterns{&tree.UnresolvedName{NumParts:1, Parts: tree.NameParts{$1}}}}
+    $$.val = tree.TargetList{Tables: tree.TableAttrs{IsSequence: false, TablePatterns: tree.TablePatterns{&tree.UnresolvedName{NumParts:1, Parts: tree.NameParts{$1}}}}}
   }
 | col_name_keyword
   {
-    $$.val = tree.TargetList{Tables: tree.TablePatterns{&tree.UnresolvedName{NumParts:1, Parts: tree.NameParts{$1}}}}
+    $$.val = tree.TargetList{Tables: tree.TableAttrs{IsSequence: false, TablePatterns: tree.TablePatterns{&tree.UnresolvedName{NumParts:1, Parts: tree.NameParts{$1}}}}}
   }
 | unreserved_keyword
   {
@@ -6811,22 +6827,26 @@ targets:
     // of increasing (or attempting to modify) the grey magic occurring
     // here.
     $$.val = tree.TargetList{
-      Tables: tree.TablePatterns{&tree.UnresolvedName{NumParts:1, Parts: tree.NameParts{$1}}},
+      Tables: tree.TableAttrs{IsSequence: false, TablePatterns:tree.TablePatterns{&tree.UnresolvedName{NumParts:1, Parts: tree.NameParts{$1}}}},
       ForRoles: $1 == "role", // backdoor for "SHOW GRANTS ON ROLE" (no name list)
     }
   }
 | complex_table_pattern
   {
-    $$.val = tree.TargetList{Tables: tree.TablePatterns{$1.unresolvedName()}}
+    $$.val = tree.TargetList{Tables: tree.TableAttrs{IsSequence: false, TablePatterns: tree.TablePatterns{$1.unresolvedName()}}}
+  }
+| SEQUENCE table_pattern_list
+  {
+    $$.val = tree.TargetList{Tables: tree.TableAttrs{IsSequence: true, TablePatterns: $2.tablePatterns()}}
   }
 | table_pattern ',' table_pattern_list
   {
     remainderPats := $3.tablePatterns()
-    $$.val = tree.TargetList{Tables: append(tree.TablePatterns{$1.unresolvedName()}, remainderPats...)}
+    $$.val = tree.TargetList{Tables: tree.TableAttrs{IsSequence: false, TablePatterns: append(tree.TablePatterns{$1.unresolvedName()}, remainderPats...)}}
   }
 | TABLE table_pattern_list
   {
-    $$.val = tree.TargetList{Tables: $2.tablePatterns()}
+    $$.val = tree.TargetList{Tables: tree.TableAttrs{IsSequence: false, TablePatterns: $2.tablePatterns()}}
   }
 // TODO(knz): This should learn how to parse more complex expressions
 // and placeholders.

--- a/pkg/sql/parser/testdata/grant_revoke
+++ b/pkg/sql/parser/testdata/grant_revoke
@@ -256,6 +256,54 @@ GRANT SELECT, UPDATE ON ALL TABLES IN SCHEMA s1, s2 TO root, bar -- fully parent
 GRANT SELECT, UPDATE ON ALL TABLES IN SCHEMA s1, s2 TO root, bar -- literals removed
 GRANT SELECT, UPDATE ON ALL TABLES IN SCHEMA _, _ TO _, _ -- identifiers removed
 
+parse
+GRANT SELECT ON SEQUENCE s1 TO root, bar
+----
+GRANT SELECT ON SEQUENCE s1 TO root, bar
+GRANT SELECT ON SEQUENCE (s1) TO root, bar -- fully parenthesized
+GRANT SELECT ON SEQUENCE s1 TO root, bar -- literals removed
+GRANT SELECT ON SEQUENCE _ TO _, _ -- identifiers removed
+
+parse
+GRANT ALL ON SEQUENCE s1 TO root, bar
+----
+GRANT ALL ON SEQUENCE s1 TO root, bar
+GRANT ALL ON SEQUENCE (s1) TO root, bar -- fully parenthesized
+GRANT ALL ON SEQUENCE s1 TO root, bar -- literals removed
+GRANT ALL ON SEQUENCE _ TO _, _ -- identifiers removed
+
+parse
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA s1, s2 TO root, bar
+----
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA s1, s2 TO root, bar
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA s1, s2 TO root, bar -- fully parenthesized
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA s1, s2 TO root, bar -- literals removed
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA _, _ TO _, _ -- identifiers removed
+
+parse
+REVOKE SELECT ON SEQUENCE s1 FROM root, bar
+----
+REVOKE SELECT ON SEQUENCE s1 FROM root, bar
+REVOKE SELECT ON SEQUENCE (s1) FROM root, bar -- fully parenthesized
+REVOKE SELECT ON SEQUENCE s1 FROM root, bar -- literals removed
+REVOKE SELECT ON SEQUENCE _ FROM _, _ -- identifiers removed
+
+parse
+REVOKE ALL ON SEQUENCE s1 FROM root, bar
+----
+REVOKE ALL ON SEQUENCE s1 FROM root, bar
+REVOKE ALL ON SEQUENCE (s1) FROM root, bar -- fully parenthesized
+REVOKE ALL ON SEQUENCE s1 FROM root, bar -- literals removed
+REVOKE ALL ON SEQUENCE _ FROM _, _ -- identifiers removed
+
+parse
+REVOKE SELECT ON ALL SEQUENCES IN SCHEMA s1, s2 FROM root, bar
+----
+REVOKE SELECT ON ALL SEQUENCES IN SCHEMA s1, s2 FROM root, bar
+REVOKE SELECT ON ALL SEQUENCES IN SCHEMA s1, s2 FROM root, bar -- fully parenthesized
+REVOKE SELECT ON ALL SEQUENCES IN SCHEMA s1, s2 FROM root, bar -- literals removed
+REVOKE SELECT ON ALL SEQUENCES IN SCHEMA _, _ FROM _, _ -- identifiers removed
+
 ## Tables are the default, but can also be specified with
 ## REVOKE x ON TABLE y. However, the stringer does not output TABLE.
 

--- a/pkg/sql/privilege/privilege.go
+++ b/pkg/sql/privilege/privilege.go
@@ -70,6 +70,8 @@ const (
 	Table ObjectType = "table"
 	// Type represents a type object.
 	Type ObjectType = "type"
+	// Sequence represents a sequence object.
+	Sequence ObjectType = "sequence"
 )
 
 // Predefined sets of privileges.
@@ -81,6 +83,11 @@ var (
 	TablePrivileges  = List{ALL, CREATE, DROP, GRANT, SELECT, INSERT, DELETE, UPDATE, ZONECONFIG}
 	SchemaPrivileges = List{ALL, GRANT, CREATE, USAGE}
 	TypePrivileges   = List{ALL, GRANT, USAGE}
+	// SequencePrivileges is appended with TablePrivileges as well. This is because
+	// before v22.2 we treated Sequences the same as Tables. This is to avoid making
+	// certain privileges unavailable after upgrade migration.
+	// Note that "CREATE, INSERT, DELETE, ZONECONFIG" are no-op privileges on sequences.
+	SequencePrivileges = List{ALL, USAGE, SELECT, UPDATE, CREATE, DROP, GRANT, INSERT, DELETE, ZONECONFIG}
 )
 
 // Mask returns the bitmask for a given privilege.
@@ -268,6 +275,8 @@ func GetValidPrivilegesForObject(objectType ObjectType) List {
 		return DBPrivileges
 	case Type:
 		return TypePrivileges
+	case Sequence:
+		return SequencePrivileges
 	case Any:
 		return AllPrivileges
 	default:

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -510,11 +510,11 @@ func getDescriptorsFromTargetListForPrivilegeChange(
 		return descs, nil
 	}
 
-	if len(targets.Tables) == 0 {
+	if len(targets.Tables.TablePatterns) == 0 {
 		return nil, errNoTable
 	}
-	descs := make([]catalog.Descriptor, 0, len(targets.Tables))
-	for _, tableTarget := range targets.Tables {
+	descs := make([]catalog.Descriptor, 0, len(targets.Tables.TablePatterns))
+	for _, tableTarget := range targets.Tables.TablePatterns {
 		tableGlob, err := tableTarget.NormalizeTablePattern()
 		if err != nil {
 			return nil, err

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -445,7 +445,7 @@ func getDescriptorsFromTargetListForPrivilegeChange(
 		if len(targets.Schemas) == 0 {
 			return nil, errNoSchema
 		}
-		if targets.AllTablesInSchema {
+		if targets.AllTablesInSchema || targets.AllSequencesInSchema {
 			// Get all the descriptors for the tables in the specified schemas.
 			db, err := p.Descriptors().GetMutableDatabaseByName(ctx, p.txn, p.CurrentDatabase(), flags)
 			if err != nil {
@@ -464,8 +464,22 @@ func getDescriptorsFromTargetListForPrivilegeChange(
 					return nil, err
 				}
 				for _, mut := range muts {
-					if mut != nil && mut.DescriptorType() == catalog.Table {
-						descs = append(descs, mut)
+					if targets.AllTablesInSchema {
+						if mut != nil {
+							if mut.DescriptorType() == catalog.Table {
+								descs = append(descs, mut)
+							}
+						}
+					} else if targets.AllSequencesInSchema {
+						if mut.DescriptorType() == catalog.Table {
+							tableDesc, err := catalog.AsTableDescriptor(mut)
+							if err != nil {
+								return nil, err
+							}
+							if tableDesc.IsSequence() {
+								descs = append(descs, mut)
+							}
+						}
 					}
 				}
 			}
@@ -529,7 +543,17 @@ func getDescriptorsFromTargetListForPrivilegeChange(
 		}
 		for _, mut := range muts {
 			if mut != nil && mut.DescriptorType() == catalog.Table {
-				descs = append(descs, mut)
+				if targets.Tables.IsSequence {
+					tableDesc, err := catalog.AsTableDescriptor(mut)
+					if err != nil {
+						return nil, err
+					}
+					if tableDesc.IsSequence() {
+						descs = append(descs, mut)
+					}
+				} else {
+					descs = append(descs, mut)
+				}
 			}
 		}
 	}

--- a/pkg/sql/sem/tree/alter_default_privileges.go
+++ b/pkg/sql/sem/tree/alter_default_privileges.go
@@ -72,7 +72,7 @@ type AlterDefaultPrivilegesTargetObject uint32
 func (t AlterDefaultPrivilegesTargetObject) ToPrivilegeObjectType() privilege.ObjectType {
 	targetObjectToPrivilegeObject := map[AlterDefaultPrivilegesTargetObject]privilege.ObjectType{
 		Tables:    privilege.Table,
-		Sequences: privilege.Table,
+		Sequences: privilege.Sequence,
 		Schemas:   privilege.Schema,
 		Types:     privilege.Type,
 	}

--- a/pkg/sql/sem/tree/name_resolution_test.go
+++ b/pkg/sql/sem/tree/name_resolution_test.go
@@ -74,7 +74,7 @@ func TestClassifyTablePattern(t *testing.T) {
 				if err != nil {
 					return nil, err
 				}
-				tp, err := stmt.AST.(*tree.Grant).Targets.Tables[0].NormalizeTablePattern()
+				tp, err := stmt.AST.(*tree.Grant).Targets.Tables.TablePatterns[0].NormalizeTablePattern()
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -2145,7 +2145,10 @@ func (node *TargetList) docRow(p *PrettyCfg) pretty.TableRow {
 	if node.TenantID.Specified {
 		return p.row("TENANT", p.Doc(&node.TenantID))
 	}
-	return p.row("TABLE", p.Doc(&node.Tables))
+	if node.Tables.IsSequence {
+		return p.row("SEQUENCE", p.Doc(&node.Tables.TablePatterns))
+	}
+	return p.row("TABLE", p.Doc(&node.Tables.TablePatterns))
 }
 
 func (node *AsOfClause) doc(p *PrettyCfg) pretty.Doc {

--- a/pkg/sql/sem/tree/table_pattern.go
+++ b/pkg/sql/sem/tree/table_pattern.go
@@ -72,6 +72,13 @@ func (at *AllTablesSelector) NormalizeTablePattern() (TablePattern, error) { ret
 // Used by e.g. the GRANT statement.
 type TablePatterns []TablePattern
 
+// TableAttrs saves the table petterns and a bool field IsSequence that shows
+// if all tables are sequences.
+type TableAttrs struct {
+	IsSequence    bool
+	TablePatterns TablePatterns
+}
+
 // Format implements the NodeFormatter interface.
 func (tt *TablePatterns) Format(ctx *FmtCtx) {
 	for i, t := range *tt {

--- a/pkg/sql/sqltelemetry/iam.go
+++ b/pkg/sql/sqltelemetry/iam.go
@@ -32,11 +32,16 @@ const (
 	OnSchema = "on_schema"
 	// OnTable is used when a GRANT/REVOKE is happening on a table.
 	OnTable = "on_table"
+	// OnSequence is used when a GRANT/REVOKE is happening on a sequence.
+	OnSequence = "on_sequence"
 	// OnType is used when a GRANT/REVOKE is happening on a type.
 	OnType = "on_type"
 	// OnAllTablesInSchema is used when a GRANT/REVOKE is happening on
 	// all tables in a set of schemas.
 	OnAllTablesInSchema = "on_all_tables_in_schemas"
+	// OnAllSequencesInSchema is used when a GRANT/REVOKE is happening on
+	// all sequences in a set of schemas.
+	OnAllSequencesInSchema = "on_all_sequences_in_schemas"
 
 	iamRoles = "iam.roles"
 )


### PR DESCRIPTION
Add support for `{GRANT|REVOKE} PRIVILEGES ... ON {SEQUENCE | ALL SEQUENCES IN SCHEMA}` syntax.

Fixes #74780
Fixes #69584

Release Note(sql): Add support for `{GRANT|REVOKE} PRIVILEGES ... 
ON {SEQUENCE | ALL SEQUENCES IN SCHEMA}` syntax. 
The privileges allowed for sequences will be those in 
[Postgres14](https://www.postgresql.org/docs/14/sql-grant.html)
(`ALL, USAGE, SELECT, UPDATE`) in addition to the existing CRBD 
table privileges
(`ALL, CREATE, DROP, GRANT, SELECT, INSERT, DELETE, UPDATE,
 ZONECONFIG`).
This is because before 22.2 we allow granting table privileges to sequences
via `ALTER DEFAULT PRIVILEGES ... ON SEQUENCE`.
Note that now sequences are still treated as a subset of tables, 
which means `{GRANT|REVOKE} ... ON TABLE sequence_name` works,
 and `GRANT ... ON ALL TABLES IN SCHEMA`
also grant privileges on all sequences in the schema to the target user.