### PR TITLE
sql: fix overflow for soft limits

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2234,7 +2234,7 @@ func (dsp *DistSQLPlanner) createPlanForIndexJoin(
 		LockingStrength:   n.table.lockingStrength,
 		LockingWaitPolicy: n.table.lockingWaitPolicy,
 		MaintainOrdering:  len(n.reqOrdering) > 0,
-		LimitHint:         int64(n.limitHint),
+		LimitHint:         n.limitHint,
 	}
 
 	fetchColIDs := make([]descpb.ColumnID, len(n.cols))
@@ -2303,7 +2303,7 @@ func (dsp *DistSQLPlanner) createPlanForLookupJoin(
 		LeftJoinWithPairedJoiner:          n.isSecondJoinInPairedJoiner,
 		OutputGroupContinuationForLeftRow: n.isFirstJoinInPairedJoiner,
 		LookupBatchBytesLimit:             dsp.distSQLSrv.TestingKnobs.JoinReaderBatchBytesLimit,
-		LimitHint:                         int64(n.limitHint),
+		LimitHint:                         n.limitHint,
 	}
 
 	fetchColIDs := make([]descpb.ColumnID, len(n.table.cols))

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -646,7 +646,7 @@ func (e *distSQLSpecExecFactory) ConstructIndexJoin(
 	keyCols []exec.NodeColumnOrdinal,
 	tableCols exec.TableColumnOrdinalSet,
 	reqOrdering exec.OutputOrdering,
-	limitHint int,
+	limitHint int64,
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: index join")
 }
@@ -666,7 +666,7 @@ func (e *distSQLSpecExecFactory) ConstructLookupJoin(
 	isSecondJoinInPairedJoiner bool,
 	reqOrdering exec.OutputOrdering,
 	locking *tree.LockingItem,
-	limitHint int,
+	limitHint int64,
 ) (exec.Node, error) {
 	// TODO (rohany): Implement production of system columns by the underlying scan here.
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: lookup join")

--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -37,7 +37,7 @@ type indexJoinNode struct {
 
 	reqOrdering ReqOrdering
 
-	limitHint int
+	limitHint int64
 }
 
 func (n *indexJoinNode) startExec(params runParams) error {

--- a/pkg/sql/logictest/testdata/logic_test/limit
+++ b/pkg/sql/logictest/testdata/logic_test/limit
@@ -358,3 +358,7 @@ SELECT oid::INT, typname FROM pg_type ORDER BY oid LIMIT 3
 16  bool
 17  bytea
 18  char
+
+# Regression test for limit hint overflowing int64 range and becoming negative.
+statement ok
+SELECT * FROM t65171 WHERE x = 1 OFFSET 1 LIMIT 9223372036854775807

--- a/pkg/sql/lookup_join.go
+++ b/pkg/sql/lookup_join.go
@@ -71,7 +71,7 @@ type lookupJoinNode struct {
 
 	reqOrdering ReqOrdering
 
-	limitHint int
+	limitHint int64
 }
 
 func (lj *lookupJoinNode) startExec(params runParams) error {

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -14,7 +14,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
@@ -595,7 +594,7 @@ func (b *Builder) scanParams(
 		sqltelemetry.IncrementPartitioningCounter(sqltelemetry.PartitionConstrainedScan)
 	}
 
-	softLimit := int64(math.Ceil(reqProps.LimitHint))
+	softLimit := reqProps.LimitHintInt64()
 	hardLimit := scan.HardLimit.RowCount()
 
 	// If this is a bounded staleness query, check that it touches at most one
@@ -1723,7 +1722,7 @@ func (b *Builder) buildIndexJoin(join *memo.IndexJoinExpr) (execPlan, error) {
 	needed, output := b.getColumns(cols, join.Table)
 	res := execPlan{outputCols: output}
 	res.root, err = b.factory.ConstructIndexJoin(
-		input.root, tab, keyCols, needed, res.reqOrdering(join), int(math.Ceil(join.RequiredPhysical().LimitHint)),
+		input.root, tab, keyCols, needed, res.reqOrdering(join), join.RequiredPhysical().LimitHintInt64(),
 	)
 	if err != nil {
 		return execPlan{}, err
@@ -1832,7 +1831,7 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 		join.IsSecondJoinInPairedJoiner,
 		res.reqOrdering(join),
 		locking,
-		int(math.Ceil(join.RequiredPhysical().LimitHint)),
+		join.RequiredPhysical().LimitHintInt64(),
 	)
 	if err != nil {
 		return execPlan{}, err

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -249,7 +249,7 @@ define IndexJoin {
     KeyCols []exec.NodeColumnOrdinal
     TableCols exec.TableColumnOrdinalSet
     ReqOrdering exec.OutputOrdering
-    LimitHint int
+    LimitHint int64
 }
 
 # LookupJoin performs a lookup join.
@@ -285,7 +285,7 @@ define LookupJoin {
     IsSecondJoinInPairedJoiner bool
     ReqOrdering exec.OutputOrdering
     Locking *tree.LockingItem
-    LimitHint int
+    LimitHint int64
 }
 
 # InvertedJoin performs a lookup join into an inverted index.

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -597,7 +597,7 @@ func (ef *execFactory) ConstructIndexJoin(
 	keyCols []exec.NodeColumnOrdinal,
 	tableCols exec.TableColumnOrdinalSet,
 	reqOrdering exec.OutputOrdering,
-	limitHint int,
+	limitHint int64,
 ) (exec.Node, error) {
 	tabDesc := table.(*optTable).desc
 	colCfg := makeScanColumnsConfig(table, tableCols)
@@ -655,7 +655,7 @@ func (ef *execFactory) ConstructLookupJoin(
 	isSecondJoinInPairedJoiner bool,
 	reqOrdering exec.OutputOrdering,
 	locking *tree.LockingItem,
-	limitHint int,
+	limitHint int64,
 ) (exec.Node, error) {
 	if table.IsVirtualTable() {
 		return ef.constructVirtualTableLookupJoin(joinType, input, table, index, eqCols, lookupCols, onCond)


### PR DESCRIPTION
We're tracking `LimitHint` property as a float and later convert it to
an int64. Previously, this could lead to overflows when the limit hint
value exceeds the range of int64, and we now instead will use a value of
0 (i.e. disable the soft limit).

Fixes: #77578.
Fixes: #79759.

Release note (bug fix): Previously, CockroachDB could encounter an
internal error when evaluating queries with OFFSET and LIMIT clauses
when the addition of the `offset` and the `limit` value would be larger
than `int64` range.