### PR TITLE
release-22.1: fix broken sqlite logic test nightly

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,12 +1,14 @@
 # Define a set up flag aliases, so people can use `--cross` instead of the
 # longer `//build/toolchains:cross_flag`.
 build --flag_alias=crdb_test=//build/toolchains:crdb_test_flag
+build --flag_alias=crdb_test_off=//build/toolchains:crdb_test_off_flag
 build --flag_alias=cross=//build/toolchains:cross_flag
 build --flag_alias=dev=//build/toolchains:dev_flag
 build --flag_alias=lintonbuild=//build/toolchains:nogo_flag
 build --flag_alias=nolintonbuild=//build/toolchains:nonogo_explicit_flag
 build --flag_alias=with_ui=//pkg/ui:with_ui_flag
 
+build:crdb_test_off --crdb_test_off
 build:cross --cross
 build:dev --dev
 build:lintonbuild --lintonbuild

--- a/build/teamcity/cockroach/nightlies/sqlite_logic_test_impl.sh
+++ b/build/teamcity/cockroach/nightlies/sqlite_logic_test_impl.sh
@@ -11,7 +11,7 @@ GO_TEST_JSON_OUTPUT_FILE=/artifacts/test.json.txt
 exit_status=0
 $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --config=ci --config=crdb_test_off \
     test //pkg/sql/logictest:logictest_test -- \
-    --test_arg -bigtest --test_arg -flex-types --test_arg -parallel=4 \
+    --test_arg -bigtest --test_arg -flex-types --test_arg -test.parallel=4 \
     --test_timeout 86400 --test_filter '^TestSqlLiteLogic$|^TestTenantSQLLiteLogic$' \
     --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE || exit_status=$?
 process_test_json \

--- a/build/teamcity/cockroach/nightlies/sqlite_logic_test_impl.sh
+++ b/build/teamcity/cockroach/nightlies/sqlite_logic_test_impl.sh
@@ -9,11 +9,10 @@ bazel build //pkg/cmd/bazci //pkg/cmd/github-post //pkg/cmd/testfilter --config=
 BAZEL_BIN=$(bazel info bazel-bin --config=ci)
 GO_TEST_JSON_OUTPUT_FILE=/artifacts/test.json.txt
 exit_status=0
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --config=ci \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --config=ci --config=crdb_test_off \
     test //pkg/sql/logictest:logictest_test -- \
-    --test_arg -bigtest --test_arg -flex-types \
-    --define gotags=bazel,crdb_test_off --test_timeout 86400 \
-    --test_filter '^TestSqlLiteLogic$|^TestTenantSQLLiteLogic$' \
+    --test_arg -bigtest --test_arg -flex-types --test_arg -parallel=4 \
+    --test_timeout 86400 --test_filter '^TestSqlLiteLogic$|^TestTenantSQLLiteLogic$' \
     --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE || exit_status=$?
 process_test_json \
         $BAZEL_BIN/pkg/cmd/testfilter/testfilter_/testfilter \

--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -125,16 +125,32 @@ platform(
     ],
 )
 
+# There are aliases for each of these flags defined in .bazelrc; for example,
+# --crdb_test instead of --//build/toolchains:crdb_test_flag.
+#
+# crdb_test_flag is set to true for every `bazel test` invocation (see .bazelrc).
+# When building a test executable via `bazel build`, you want to make sure you
+# set this flag (via `--config test` or `--crdb_test`) or else the executable
+# won't be compiled with the appropriate test logic.
+# crdb_test_off_flag is provided as an override to disable this default behavior
+# if desired. It's unnecessary under any other circumstances.
 bool_flag(
     name = "crdb_test_flag",
     build_setting_default = False,
     visibility = ["//visibility:public"],
 )
 
+bool_flag(
+    name = "crdb_test_off_flag",
+    build_setting_default = False,
+    visibility = [":__pkg__"],
+)
+
 config_setting(
     name = "crdb_test",
     flag_values = {
         ":crdb_test_flag": "true",
+        ":crdb_test_off_flag": "false",
     },
 )
 


### PR DESCRIPTION
Backport:
  * 1/1 commits from "bazel: provide opt-out for `crdb_test` configuration, update nightly" (#79541)
  * 1/1 commits from "test: fix bazel sqllite invocation" (#79651)

Please see individual PRs for details.

/cc @cockroachdb/release

Release note: None
Release justification: Fix broken nightly