### PR TITLE
sql/schemachanger: track jobs created to use better jobs API

### DIFF
--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_multiregion
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_multiregion
@@ -365,6 +365,7 @@ create job #1 (non-cancelable: true): "DROP TABLE multi_region_test_db.public.ta
   descriptor IDs: [105 107 108]
 # end PreCommitPhase
 commit transaction #1
+notified job registry to adopt jobs: [1]
 # begin PostCommitPhase
 begin transaction #2
 commit transaction #2
@@ -701,6 +702,7 @@ create job #2 (non-cancelable: true): "GC for DROP TABLE multi_region_test_db.pu
   descriptor IDs: [108]
 update progress of schema change job #1
 commit transaction #3
+notified job registry to adopt jobs: [2]
 # end PostCommitPhase
 
 setup
@@ -955,6 +957,7 @@ create job #1 (non-cancelable: true): "DROP TABLE multi_region_test_db.public.ta
   descriptor IDs: [105 109]
 # end PreCommitPhase
 commit transaction #1
+notified job registry to adopt jobs: [1]
 # begin PostCommitPhase
 begin transaction #2
 commit transaction #2
@@ -1184,6 +1187,7 @@ create job #2 (non-cancelable: true): "GC for DROP TABLE multi_region_test_db.pu
   descriptor IDs: [109]
 update progress of schema change job #1
 commit transaction #3
+notified job registry to adopt jobs: [2]
 # end PostCommitPhase
 
 test
@@ -1638,6 +1642,7 @@ create job #1 (non-cancelable: true): "DROP DATABASE multi_region_test_db CASCAD
   descriptor IDs: [104 105 106 107]
 # end PreCommitPhase
 commit transaction #1
+notified job registry to adopt jobs: [1]
 # begin PostCommitPhase
 begin transaction #2
 commit transaction #2

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -745,6 +745,7 @@ func (s *TestState) CreateJob(ctx context.Context, record jobs.Record) error {
 		return errors.New("invalid 0 job ID")
 	}
 	record.JobID = jobspb.JobID(1 + len(s.jobs))
+	s.createdJobsInCurrentTxn = append(s.createdJobsInCurrentTxn, record.JobID)
 	s.jobs = append(s.jobs, record)
 	s.LogSideEffectf("create job #%d (non-cancelable: %v): %q\n  descriptor IDs: %v",
 		record.JobID,
@@ -753,6 +754,11 @@ func (s *TestState) CreateJob(ctx context.Context, record jobs.Record) error {
 		record.DescriptorIDs,
 	)
 	return nil
+}
+
+// CreatedJobs implements the scexec.TransactionalJobRegistry interface.
+func (s *TestState) CreatedJobs() []jobspb.JobID {
+	return s.createdJobsInCurrentTxn
 }
 
 // CheckPausepoint is a no-op.

--- a/pkg/sql/schemachanger/scexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/dependencies.go
@@ -113,6 +113,10 @@ type TransactionalJobRegistry interface {
 	// id which was assigned to that job, or an error otherwise.
 	CreateJob(ctx context.Context, record jobs.Record) error
 
+	// CreatedJobs is the set of jobs created thus far in the current
+	// transaction.
+	CreatedJobs() []jobspb.JobID
+
 	// CheckPausepoint returns a PauseRequestError if the named pause-point is
 	// set.
 	//

--- a/pkg/sql/schemachanger/testdata/alter_table_add_column
+++ b/pkg/sql/schemachanger/testdata/alter_table_add_column
@@ -210,6 +210,7 @@ create job #1 (non-cancelable: false): "ALTER TABLE db.public.tbl ADD COLUMN j I
   descriptor IDs: [106]
 # end PreCommitPhase
 commit transaction #1
+notified job registry to adopt jobs: [1]
 # begin PostCommitPhase
 begin transaction #2
 commit transaction #2
@@ -562,4 +563,5 @@ create job #2 (non-cancelable: true): "GC for ALTER TABLE db.public.tbl ADD COLU
   descriptor IDs: [106]
 update progress of schema change job #1
 commit transaction #8
+notified job registry to adopt jobs: [2]
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/drop
+++ b/pkg/sql/schemachanger/testdata/drop
@@ -134,6 +134,7 @@ create job #1 (non-cancelable: true): "DROP SCHEMA db.sc"
   descriptor IDs: [104 106]
 # end PreCommitPhase
 commit transaction #1
+notified job registry to adopt jobs: [1]
 # begin PostCommitPhase
 begin transaction #2
 commit transaction #2
@@ -494,6 +495,7 @@ create job #1 (non-cancelable: true): "DROP TABLE db.sc.t"
   descriptor IDs: [108]
 # end PreCommitPhase
 commit transaction #1
+notified job registry to adopt jobs: [1]
 # begin PostCommitPhase
 begin transaction #2
 commit transaction #2
@@ -809,6 +811,7 @@ create job #2 (non-cancelable: true): "GC for DROP TABLE db.sc.t"
   descriptor IDs: [108]
 update progress of schema change job #1
 commit transaction #3
+notified job registry to adopt jobs: [2]
 # end PostCommitPhase
 
 test
@@ -1149,6 +1152,7 @@ create job #1 (non-cancelable: true): "DROP SCHEMA db.sc CASCADE"
   descriptor IDs: [104 107 109 110]
 # end PreCommitPhase
 commit transaction #1
+notified job registry to adopt jobs: [1]
 # begin PostCommitPhase
 begin transaction #2
 commit transaction #2
@@ -1405,6 +1409,7 @@ create job #1 (non-cancelable: true): "DROP DATABASE db CASCADE"
   descriptor IDs: [104 105]
 # end PreCommitPhase
 commit transaction #1
+notified job registry to adopt jobs: [1]
 # begin PostCommitPhase
 begin transaction #2
 commit transaction #2
@@ -4108,6 +4113,7 @@ create job #1 (non-cancelable: true): "DROP DATABASE db1 CASCADE"
   descriptor IDs: [111 112 113 114 115 116 117 118 119 120 121 122 123 124 125]
 # end PreCommitPhase
 commit transaction #1
+notified job registry to adopt jobs: [1]
 # begin PostCommitPhase
 begin transaction #2
 commit transaction #2
@@ -5215,4 +5221,5 @@ create job #2 (non-cancelable: true): "GC for DROP DATABASE db1 CASCADE"
   descriptor IDs: [114 115 116 117 118 111]
 update progress of schema change job #1
 commit transaction #3
+notified job registry to adopt jobs: [2]
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/index
+++ b/pkg/sql/schemachanger/testdata/index
@@ -106,6 +106,7 @@ create job #1 (non-cancelable: false): "CREATE INDEX idx1 ON defaultdb.public.t 
   descriptor IDs: [104]
 # end PreCommitPhase
 commit transaction #1
+notified job registry to adopt jobs: [1]
 # begin PostCommitPhase
 begin transaction #2
 commit transaction #2


### PR DESCRIPTION
This change adopts d.jobRegistry.NotifyToResume which more precisely tells the
jobs subsystem how to adopt jobs.

Relates to #79905.

Release note (performance improvement): Fixes a regression in previous betas
which made running multiple schema changes concurrently less efficient.