### PR TITLE
release-21.2: sql: fix overflow for soft limits

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2231,7 +2231,7 @@ func (dsp *DistSQLPlanner) createPlanForIndexJoin(
 		LockingWaitPolicy: n.table.lockingWaitPolicy,
 		MaintainOrdering:  len(n.reqOrdering) > 0,
 		HasSystemColumns:  n.table.containsSystemColumns,
-		LimitHint:         int64(n.limitHint),
+		LimitHint:         n.limitHint,
 	}
 
 	post := execinfrapb.PostProcessSpec{
@@ -2290,7 +2290,7 @@ func (dsp *DistSQLPlanner) createPlanForLookupJoin(
 		HasSystemColumns:         n.table.containsSystemColumns,
 		LeftJoinWithPairedJoiner: n.isSecondJoinInPairedJoiner,
 		LookupBatchBytesLimit:    dsp.distSQLSrv.TestingKnobs.JoinReaderBatchBytesLimit,
-		LimitHint:                int64(n.limitHint),
+		LimitHint:                n.limitHint,
 	}
 	joinReaderSpec.IndexIdx, err = getIndexIdx(n.table.index, n.table.desc)
 	if err != nil {

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -643,7 +643,7 @@ func (e *distSQLSpecExecFactory) ConstructIndexJoin(
 	keyCols []exec.NodeColumnOrdinal,
 	tableCols exec.TableColumnOrdinalSet,
 	reqOrdering exec.OutputOrdering,
-	limitHint int,
+	limitHint int64,
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: index join")
 }
@@ -662,7 +662,7 @@ func (e *distSQLSpecExecFactory) ConstructLookupJoin(
 	isSecondJoinInPairedJoiner bool,
 	reqOrdering exec.OutputOrdering,
 	locking *tree.LockingItem,
-	limitHint int,
+	limitHint int64,
 ) (exec.Node, error) {
 	// TODO (rohany): Implement production of system columns by the underlying scan here.
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: lookup join")

--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -37,7 +37,7 @@ type indexJoinNode struct {
 
 	reqOrdering ReqOrdering
 
-	limitHint int
+	limitHint int64
 }
 
 func (n *indexJoinNode) startExec(params runParams) error {

--- a/pkg/sql/logictest/testdata/logic_test/limit
+++ b/pkg/sql/logictest/testdata/logic_test/limit
@@ -351,3 +351,7 @@ SELECT oid::INT, typname FROM pg_type ORDER BY oid LIMIT 3
 16  bool
 17  bytea
 18  char
+
+# Regression test for limit hint overflowing int64 range and becoming negative.
+statement ok
+SELECT * FROM t65171 WHERE x = 1 OFFSET 1 LIMIT 9223372036854775807

--- a/pkg/sql/lookup_join.go
+++ b/pkg/sql/lookup_join.go
@@ -67,7 +67,7 @@ type lookupJoinNode struct {
 
 	reqOrdering ReqOrdering
 
-	limitHint int
+	limitHint int64
 }
 
 func (lj *lookupJoinNode) startExec(params runParams) error {

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -14,7 +14,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
@@ -576,7 +575,7 @@ func (b *Builder) scanParams(
 		sqltelemetry.IncrementPartitioningCounter(sqltelemetry.PartitionConstrainedScan)
 	}
 
-	softLimit := int64(math.Ceil(reqProps.LimitHint))
+	softLimit := reqProps.LimitHintInt64()
 	hardLimit := scan.HardLimit.RowCount()
 
 	// If this is a bounded staleness query, check that it touches at most one
@@ -1628,7 +1627,7 @@ func (b *Builder) buildIndexJoin(join *memo.IndexJoinExpr) (execPlan, error) {
 	needed, output := b.getColumns(cols, join.Table)
 	res := execPlan{outputCols: output}
 	res.root, err = b.factory.ConstructIndexJoin(
-		input.root, tab, keyCols, needed, res.reqOrdering(join), int(math.Ceil(join.RequiredPhysical().LimitHint)),
+		input.root, tab, keyCols, needed, res.reqOrdering(join), join.RequiredPhysical().LimitHintInt64(),
 	)
 	if err != nil {
 		return execPlan{}, err
@@ -1721,7 +1720,7 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 		join.IsSecondJoinInPairedJoiner,
 		res.reqOrdering(join),
 		locking,
-		int(math.Ceil(join.RequiredPhysical().LimitHint)),
+		join.RequiredPhysical().LimitHintInt64(),
 	)
 	if err != nil {
 		return execPlan{}, err

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -245,7 +245,7 @@ define IndexJoin {
     KeyCols []exec.NodeColumnOrdinal
     TableCols exec.TableColumnOrdinalSet
     ReqOrdering exec.OutputOrdering
-    LimitHint int
+    LimitHint int64
 }
 
 # LookupJoin performs a lookup join.
@@ -280,7 +280,7 @@ define LookupJoin {
     IsSecondJoinInPairedJoiner bool
     ReqOrdering exec.OutputOrdering
     Locking *tree.LockingItem
-    LimitHint int
+    LimitHint int64
 }
 
 # InvertedJoin performs a lookup join into an inverted index.

--- a/pkg/sql/opt/props/physical/required.go
+++ b/pkg/sql/opt/props/physical/required.go
@@ -13,6 +13,7 @@ package physical
 import (
 	"bytes"
 	"fmt"
+	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
@@ -51,7 +52,7 @@ type Required struct {
 	// that only the hinted number of rows will be needed.
 	// A LimitHint of 0 indicates "no limit". The LimitHint is an intermediate
 	// float64 representation, and can be converted to an integer number of rows
-	// using math.Ceil.
+	// using LimitHintInt64.
 	LimitHint float64
 }
 
@@ -107,6 +108,16 @@ func (p *Required) String() string {
 // Equals returns true if the two physical properties are identical.
 func (p *Required) Equals(rhs *Required) bool {
 	return p.Presentation.Equals(rhs.Presentation) && p.Ordering.Equals(&rhs.Ordering) && p.LimitHint == rhs.LimitHint
+}
+
+// LimitHintInt64 returns the limit hint converted to an int64.
+func (p *Required) LimitHintInt64() int64 {
+	h := int64(math.Ceil(p.LimitHint))
+	if h < 0 {
+		// If we have an overflow, then disable the limit hint.
+		h = 0
+	}
+	return h
 }
 
 // Presentation specifies the naming, membership (including duplicates), and

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -599,7 +599,7 @@ func (ef *execFactory) ConstructIndexJoin(
 	keyCols []exec.NodeColumnOrdinal,
 	tableCols exec.TableColumnOrdinalSet,
 	reqOrdering exec.OutputOrdering,
-	limitHint int,
+	limitHint int64,
 ) (exec.Node, error) {
 	tabDesc := table.(*optTable).desc
 	colCfg := makeScanColumnsConfig(table, tableCols)
@@ -656,7 +656,7 @@ func (ef *execFactory) ConstructLookupJoin(
 	isSecondJoinInPairedJoiner bool,
 	reqOrdering exec.OutputOrdering,
 	locking *tree.LockingItem,
-	limitHint int,
+	limitHint int64,
 ) (exec.Node, error) {
 	if table.IsVirtualTable() {
 		return ef.constructVirtualTableLookupJoin(joinType, input, table, index, eqCols, lookupCols, onCond)


### PR DESCRIPTION
Backport 1/1 commits from #79865.

/cc @cockroachdb/release

---

We're tracking `LimitHint` property as a float and later convert it to
an int64. Previously, this could lead to overflows when the limit hint
value exceeds the range of int64, and we now instead will use a value of
0 (i.e. disable the soft limit).

Fixes: #77578.
Fixes: #79759.

Release note (bug fix): Previously, CockroachDB could encounter an
internal error when evaluating queries with OFFSET and LIMIT clauses
when the addition of the `offset` and the `limit` value would be larger
than `int64` range.

Release justification: bug fix.