### PR TITLE
logictest: fix potential race with async statements

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -3313,6 +3313,7 @@ func (t *logicTest) unexpectedError(sql string, pos string, err error) bool {
 }
 
 func (t *logicTest) execStatement(stmt logicStatement) (bool, error) {
+	db := t.db
 	t.noticeBuffer = nil
 	if *showSQL {
 		t.outf("%s;", stmt.sql)
@@ -3339,7 +3340,7 @@ func (t *logicTest) execStatement(stmt logicStatement) (bool, error) {
 		startedChan := make(chan struct{})
 		go func() {
 			startedChan <- struct{}{}
-			res, err := t.db.Exec(execSQL)
+			res, err := db.Exec(execSQL)
 			pending.resultChan <- pendingExecResult{execSQL, res, err}
 		}()
 
@@ -3347,7 +3348,7 @@ func (t *logicTest) execStatement(stmt logicStatement) (bool, error) {
 		return true, nil
 	}
 
-	res, err := t.db.Exec(execSQL)
+	res, err := db.Exec(execSQL)
 	return t.finishExecStatement(stmt, execSQL, res, err)
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/cluster_locks
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_locks
@@ -34,13 +34,22 @@ statement ok
 BEGIN
 
 statement async readReq ok
-select * from t for update
+SELECT * FROM t
 
 user root
 
+query TTT colnames,retry
+SELECT user_name, query, phase FROM crdb_internal.cluster_queries WHERE user_name='testuser'
+----
+user_name   query             phase
+testuser    SELECT * FROM t   executing
+
 statement ok
-ROLLBACK
+COMMIT
 
 user testuser
 
 awaitstatement readReq
+
+statement ok
+COMMIT


### PR DESCRIPTION
While statements in logictests with the `async` option start a new
goroutine to execute the statement via `db.Exec(..)`, there was a
potential race because the database handle `t.db` was shared without a
mutex, and could be changed by other operations such as `user
<newuser>`. 
This change fixes the issue by capturing a reference to the
database handle prior to starting the goroutine, thus eliminating the
porential race.

Release note: None