### PR TITLE
bazel: fix `nogo` config

### DIFF
--- a/build/bazelutil/nogo_config.json
+++ b/build/bazelutil/nogo_config.json
@@ -1,25 +1,28 @@
 {
     "assign": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         }
     },
     "composites": {
+        "exclude_files": {
+            "cockroach/pkg/.*_test.go$": "many existing failures"
+        },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "copylocks": {
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "deepequalerrors": {
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         },
         "exclude_files": {
             "_test\\.go$": "tests"
@@ -27,33 +30,33 @@
     },
     "errcheck": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/pkg/testutils/lint/lint_test.go": "not really sure why this is failing honestly"
+            "cockroach/pkg/.*_generated\\.go$": "generated code",
+            "cockroach/pkg/testutils/lint/lint_test.go": "not really sure why this is failing honestly"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "errcmp": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord/lock_spans_over_budget_error\\.go$": "invalid direct cast on error object",
-            "github.com/cockroachdb/cockroach/pkg/roachpb/batch_generated-gen\\.go$": "invalid direct cast on error object",
-            "github.com/cockroachdb/cockroach/pkg/roachpb/errors\\.go$": "invalid direct cast on error object",
-            "github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror/constraint_name\\.go$": "invalid direct cast on error object",
-            "github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror/pgcode\\.go$": "invalid direct cast on error object",
-            "github.com/cockroachdb/cockroach/pkg/testutils/lint/lint_test\\.go$": "invalid direct cast on error object",
-            "github.com/cockroachdb/cockroach/pkg/util/contextutil/timeout_error\\.go$": "invalid direct cast on error object",
-            "github.com/cockroachdb/cockroach/pkg/util/sysutil/sysutil_.*": "type can change by system"
+            "cockroach/pkg/.*_generated\\.go$": "generated code",
+            "cockroach/pkg/kv/kvclient/kvcoord/lock_spans_over_budget_error\\.go$": "invalid direct cast on error object",
+            "cockroach/pkg/roachpb/batch_generated-gen\\.go$": "invalid direct cast on error object",
+            "cockroach/pkg/roachpb/errors\\.go$": "invalid direct cast on error object",
+            "cockroach/pkg/sql/pgwire/pgerror/constraint_name\\.go$": "invalid direct cast on error object",
+            "cockroach/pkg/sql/pgwire/pgerror/pgcode\\.go$": "invalid direct cast on error object",
+            "cockroach/pkg/testutils/lint/lint_test\\.go$": "invalid direct cast on error object",
+            "cockroach/pkg/util/contextutil/timeout_error\\.go$": "invalid direct cast on error object",
+            "cockroach/pkg/util/sysutil/sysutil_.*": "type can change by system"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "errwrap": {
@@ -62,1606 +65,1607 @@
         ".*\\.pb\\.gw\\.go$": "generated code"
       },
       "only_files": {
-        "github.com/cockroachdb/cockroach/.*$": "first-party code"
+        "cockroach/pkg/.*$": "first-party code"
       }
     },
     "fmtsafe": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/pkg/roachprod/logger/log\\.go$": "format argument is not a constant expression",
-            "github.com/cockroachdb/cockroach/pkg/util/log/channels\\.go$": "format argument is not a constant expression"
+            "cockroach/pkg/roachprod/logger/log\\.go$": "format argument is not a constant expression",
+            "cockroach/pkg/util/log/channels\\.go$": "format argument is not a constant expression"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "grpcconnclose": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "hash": {
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "lostcancel": {
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "nilness": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/ccl/streamingccl/streamclient/random_stream_client.go": "https://github.com/cockroachdb/cockroach/issues/79926",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code",
+            "cockroach/pkg/.*_generated\\.go$": "generated code",
             "/_cgo_gotypes.go$": "cgo generated code",
             "_test\\.go$": "tests"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "returnerrcheck": {
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1000": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1001": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1002": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1003": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1004": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1005": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1006": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1007": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1008": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1009": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1010": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1011": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1012": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1016": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1017": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1018": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1019": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1020": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1021": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1023": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1024": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1025": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1028": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1029": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1030": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1031": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1032": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1033": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1034": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1035": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1036": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1037": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1038": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1039": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "S1040": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1000": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1001": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1002": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1003": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1004": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1005": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1006": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1007": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1008": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1010": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1011": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1012": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1013": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1014": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1015": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1016": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1017": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1018": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1019": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/pkg/roachpb/api_test.go$": "same package that grpc-go imports",
-            "github.com/cockroachdb/cockroach/pkg/rpc/codec.go$": "rpc/codec.go imports the same proto package that grpc-go imports (as of crdb@dd87d1145 and grpc-go@7b167fd6).",
-            "github.com/cockroachdb/cockroach/pkg/rpc/stats_handler.go$": "Using deprecated WireLength call",
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/roachpb/api_test.go$": "same package that grpc-go imports",
+            "cockroach/pkg/rpc/codec.go$": "rpc/codec.go imports the same proto package that grpc-go imports (as of crdb@dd87d1145 and grpc-go@7b167fd6).",
+            "cockroach/pkg/rpc/stats_handler.go$": "Using deprecated WireLength call",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1020": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1021": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1023": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1024": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1025": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1026": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1027": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1028": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1029": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA1030": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA2000": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA2001": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA2002": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA2003": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA3000": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA3001": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA4000": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA4001": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA4003": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA4004": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA4005": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA4006": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA4008": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA4009": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA4010": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA4011": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA4012": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA4013": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA4014": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA4015": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA4016": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA4017": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA4018": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA4019": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA4020": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA4021": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA4022": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA4023": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA4024": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA4025": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA4026": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA4027": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA5000": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA5001": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA5002": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA5003": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA5004": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA5005": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA5007": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA5008": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA5009": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA5010": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA5011": {
         "exclude_files": {
             "_test\\.go$": "tests",
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA5012": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA6000": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA6001": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA6002": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA6003": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA6005": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA9001": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA9002": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA9003": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA9004": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA9005": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "SA9006": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "ST1000": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*$": "skipped in default staticcheck config",
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*$": "skipped in default staticcheck config",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "ST1001": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "ST1003": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*$": "skipped in default staticcheck config",
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*$": "skipped in default staticcheck config",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "ST1005": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "ST1006": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "ST1008": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "ST1011": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "ST1011": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "ST1012": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "ST1013": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "ST1015": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "ST1016": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*$": "skipped in default staticcheck config",
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*$": "skipped in default staticcheck config",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "ST1017": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "ST1018": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "ST1019": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "ST1020": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*$": "skipped in default staticcheck config",
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*$": "skipped in default staticcheck config",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "ST1021": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*$": "skipped in default staticcheck config",
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*$": "skipped in default staticcheck config",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "ST1022": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*$": "skipped in default staticcheck config",
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*$": "skipped in default staticcheck config",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "ST1023": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "stdmethods": {
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "stringintconv": {
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "structtag": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         }
     },
     "testinggoroutine": {
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         },
         "exclude_files": {
             "_test\\.go$": "tests"
@@ -1669,31 +1673,31 @@
     },
     "unconvert": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "U1000": {
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "unreachable": {
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     },
     "unsafeptr": {
         "exclude_files": {
-            "github.com/cockroachdb/cockroach/pkg/sql/colexec/colexechash/hash\\.go$": "re-implements runtime.noescape for efficient hashing"
+            "cockroach/pkg/sql/colexec/colexechash/hash\\.go$": "re-implements runtime.noescape for efficient hashing"
         },
         "only_files": {
-            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+            "cockroach/pkg/.*$": "first-party code"
         }
     }
 }

--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -796,9 +796,6 @@ func tableToAvroSchema(
 	}
 
 	for _, col := range tableDesc.PublicColumns() {
-		if err != nil {
-			return nil, err
-		}
 		_, inFamily := include[col.GetID()]
 		virtual := col.IsVirtual() && virtualColumnVisibility == string(changefeedbase.OptVirtualColumnsNull)
 		if inFamily || virtual {

--- a/pkg/ccl/gssapiccl/get_user.go
+++ b/pkg/ccl/gssapiccl/get_user.go
@@ -17,8 +17,6 @@ package gssapiccl
 // to retrieve the current user.
 
 import (
-	"unsafe"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
 	"github.com/cockroachdb/errors"
 )
@@ -66,7 +64,7 @@ func getGssUser(c pgwire.AuthConn) (connClose func(), gssUser string, _ error) {
 		}
 
 		gbuf.length = C.ulong(len(token))
-		gbuf.value = C.CBytes([]byte(token))
+		gbuf.value = C.CBytes(token)
 
 		majStat = C.gss_accept_sec_context(
 			&minStat,
@@ -81,7 +79,7 @@ func getGssUser(c pgwire.AuthConn) (connClose func(), gssUser string, _ error) {
 			nil,
 			nil,
 		)
-		C.free(unsafe.Pointer(gbuf.value))
+		C.free(gbuf.value)
 
 		if outputToken.length != 0 {
 			outputBytes := C.GoBytes(outputToken.value, C.int(outputToken.length))

--- a/pkg/cmd/release/orchestration.go
+++ b/pkg/cmd/release/orchestration.go
@@ -85,9 +85,6 @@ func setOrchestrationVersion(_ *cobra.Command, _ []string) error {
 		}
 		// Go templates cannot be used here, because some files are templates already.
 		generatedContents := strings.ReplaceAll(string(contents), "@VERSION@", orchestrationFlags.version)
-		if err != nil {
-			return err
-		}
 		if strings.HasSuffix(destFile, ".yaml") {
 			generatedContents = fmt.Sprintf("# Generated file, DO NOT EDIT. Source: %s\n", filePath) + generatedContents
 		}

--- a/pkg/server/server_http.go
+++ b/pkg/server/server_http.go
@@ -127,7 +127,7 @@ func (s *httpServer) setupRoutes(
 
 	// Add HTTP authentication to the gRPC-gateway endpoints used by the UI,
 	// if not disabled by configuration.
-	var authenticatedHandler http.Handler = handleRequestsUnauthenticated
+	var authenticatedHandler = handleRequestsUnauthenticated
 	if s.cfg.RequireWebSession() {
 		authenticatedHandler = newAuthenticationMux(authnServer, authenticatedHandler)
 	}

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2566,9 +2566,6 @@ func (dsp *DistSQLPlanner) planZigzagJoin(
 		); err != nil {
 			return nil, err
 		}
-		if err != nil {
-			return nil, err
-		}
 
 		s.EqColumns.Columns = make([]uint32, len(side.eqCols))
 		for j, col := range side.eqCols {

--- a/pkg/util/log/eventpb/gen.go
+++ b/pkg/util/log/eventpb/gen.go
@@ -121,7 +121,7 @@ func run() error {
 	}
 	tmpl, err := template.New(tmplName).Funcs(tmplFuncs).Parse(tmplSrc)
 	if err != nil {
-		return errors.Wrap(err, tmplName)
+		return errors.Wrapf(err, "failed to parse template %q", tmplName)
 	}
 
 	// Read the input .proto file.

--- a/pkg/util/log/logconfig/gen.go
+++ b/pkg/util/log/logconfig/gen.go
@@ -215,7 +215,7 @@ func readInput(infos map[string]*sinkInfo) error {
 			}
 			if strings.HasPrefix(comment, "indicates ") {
 				comment = strings.TrimPrefix(comment, "indicates ")
-			} else if strings.HasPrefix(comment, "is ") {
+			} else {
 				comment = strings.TrimPrefix(comment, "is ")
 			}
 

--- a/pkg/util/targz/targz.go
+++ b/pkg/util/targz/targz.go
@@ -62,8 +62,5 @@ func AsFS(r io.Reader) (fs.FS, error) {
 
 	// Create a read-only io/fs.FS suitable for external use
 	iofs := afero.NewIOFS(fsys)
-	if err != nil {
-		return nil, errors.Wrap(err, "error creating uncompressed filesystem")
-	}
 	return iofs, nil
 }


### PR DESCRIPTION
When I wrote the `nogo` config originally, I identified first-party
lintable code by checking against the string
`github.com/cockroachdb/cockroach`. At some point in the last couple
months (may be related to a `rules_go` upgrade) this became
insufficient. Now I use the string `cockroach/pkg` to match for first-
party code which seems to work.

While getting these lints working again I fixed a few errors that
popped up and added one exception for already-suspect code: #79926.

Closes #79520.
Closes #76075.

Release note: None