### PR TITLE
streamingccl: fix nil linter check error and stream_ingestion_test error

### DIFF
--- a/build/bazelutil/nogo_config.json
+++ b/build/bazelutil/nogo_config.json
@@ -100,7 +100,6 @@
     },
     "nilness": {
         "exclude_files": {
-            "cockroach/pkg/ccl/streamingccl/streamclient/random_stream_client.go": "https://github.com/cockroachdb/cockroach/issues/79926",
             "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",


### PR DESCRIPTION
Previously, the stream ingestion test has no error since no
duplicate event is generated. This PR fixes this and nil linter
check error at the same time.

Release note: None
Closes: https://github.com/cockroachdb/cockroach/issues/79926

Related to https://github.com/cockroachdb/cockroach/pull/79929 which 
disables random_stream_client nil linter check. Will re-enable it after it's 
merged.