### PR TITLE
ui: add all jobs to jobs page filter

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/jobs/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/index.tsx
@@ -51,6 +51,27 @@ const typeOptions = [
     value: JobType.AUTO_CREATE_STATS.toString(),
     label: "Auto-Statistics Creation",
   },
+  { value: JobType.SCHEMA_CHANGE_GC.toString(), label: "Schema Change GC" },
+  {
+    value: JobType.TYPEDESC_SCHEMA_CHANGE.toString(),
+    label: "Type Descriptor Schema Changes",
+  },
+  { value: JobType.STREAM_INGESTION.toString(), label: "Stream Ingestion" },
+  { value: JobType.NEW_SCHEMA_CHANGE.toString(), label: "New Schema Changes" },
+  { value: JobType.MIGRATION.toString(), label: "Migrations" },
+  {
+    value: JobType.AUTO_SPAN_CONFIG_RECONCILIATION.toString(),
+    label: "Span Config Reconciliation",
+  },
+  {
+    value: JobType.AUTO_SQL_STATS_COMPACTION.toString(),
+    label: "SQL Stats Compactions",
+  },
+  { value: JobType.STREAM_REPLICATION.toString(), label: "Stream Replication" },
+  {
+    value: JobType.ROW_LEVEL_TTL.toString(),
+    label: "Time-to-live Deletions",
+  },
 ];
 
 export const typeSetting = new LocalSetting<AdminUIState, number>(


### PR DESCRIPTION
<img width="604" alt="image" src="https://user-images.githubusercontent.com/3646147/163288704-498f0de7-699a-48db-8667-9c7d63b0f8ef.png">

Resolves #79915

Release note (ui change): More jobs now shows up as a types filter
on the jobs page.