### PR TITLE
roachtests: adjust tpch_concurrency a bit

### DIFF
--- a/pkg/cmd/roachtest/tests/tpch_concurrency.go
+++ b/pkg/cmd/roachtest/tests/tpch_concurrency.go
@@ -158,7 +158,7 @@ func registerTPCHConcurrency(r registry.Registry) {
 		// additional step to ensure that some kind of lower bound for the
 		// supported concurrency is always sustained and fail the test if it
 		// isn't.
-		minConcurrency, maxConcurrency := 32, 192
+		minConcurrency, maxConcurrency := 48, 160
 		// Run the binary search to find the largest concurrency that doesn't
 		// crash a node in the cluster. The current range is represented by
 		// [minConcurrency, maxConcurrency).
@@ -193,9 +193,9 @@ func registerTPCHConcurrency(r registry.Registry) {
 		},
 		// By default, the timeout is 10 hours which might not be sufficient
 		// given that a single iteration of checkConcurrency might take on the
-		// order of one hour, so in order to let each test run to complete we'll
-		// give it 18 hours. Successful runs typically take a lot less, around
-		// six hours.
-		Timeout: 18 * time.Hour,
+		// order of an hour and a half, so in order to let each test run to
+		// complete, we'll give it 12 hours. Successful runs typically take
+		// less, around 8 hours.
+		Timeout: 12 * time.Hour,
 	})
 }


### PR DESCRIPTION
This commit lowers the timeout of `tpch_concurrency` test from 18 to 12
hours as well as adjusts the range of search from [32, 192] to [48, 160].
A typical single iteration takes less than an hour and a half, and given
that we'll do at most 7 iterations in the new range, we should expect
for the test to take at most 10.5 hours, but we'll keep it at 12 just in
case.

Release note: None