### PR TITLE
ccl/sqlproxyccl: add a TenantCache to keep track of connection counts

### DIFF
--- a/pkg/ccl/sqlproxyccl/balancer/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/balancer/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "conn_tracker.go",
         "metrics.go",
         "pod.go",
+        "tenant_cache.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/balancer",
     visibility = ["//visibility:public"],
@@ -32,6 +33,7 @@ go_test(
         "balancer_test.go",
         "conn_tracker_test.go",
         "pod_test.go",
+        "tenant_cache_test.go",
     ],
     embed = [":balancer"],
     deps = [

--- a/pkg/ccl/sqlproxyccl/balancer/balancer_test.go
+++ b/pkg/ccl/sqlproxyccl/balancer/balancer_test.go
@@ -262,15 +262,16 @@ func TestRebalancer_rebalanceLoop(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 
-	metrics := NewMetrics()
-	directoryCache := newTestDirectoryCache()
-	connTracker := NewConnTracker()
-
 	// Use a custom time source for testing.
 	t0 := time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
 	timeSource := timeutil.NewManualTime(t0)
 
-	_, err := NewBalancer(
+	metrics := NewMetrics()
+	directoryCache := newTestDirectoryCache()
+	connTracker, err := NewConnTracker(ctx, stopper, timeSource)
+	require.NoError(t, err)
+
+	_, err = NewBalancer(
 		ctx,
 		stopper,
 		metrics,
@@ -313,13 +314,14 @@ func TestRebalancer_rebalance(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 
-	metrics := NewMetrics()
-	directoryCache := newTestDirectoryCache()
-	connTracker := NewConnTracker()
-
 	// Use a custom time source for testing.
 	t0 := time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
 	timeSource := timeutil.NewManualTime(t0)
+
+	metrics := NewMetrics()
+	directoryCache := newTestDirectoryCache()
+	connTracker, err := NewConnTracker(ctx, stopper, timeSource)
+	require.NoError(t, err)
 
 	b, err := NewBalancer(
 		ctx,
@@ -358,7 +360,8 @@ func TestRebalancer_rebalance(t *testing.T) {
 		t.Helper()
 
 		directoryCache = newTestDirectoryCache()
-		connTracker = NewConnTracker()
+		connTracker, err = NewConnTracker(ctx, stopper, timeSource)
+		require.NoError(t, err)
 		b.directoryCache = directoryCache
 		b.connTracker = connTracker
 

--- a/pkg/ccl/sqlproxyccl/balancer/conn.go
+++ b/pkg/ccl/sqlproxyccl/balancer/conn.go
@@ -29,4 +29,7 @@ type ConnectionHandle interface {
 	// (e.g. 10.15.42.36:26257). This will be used to identify which pod the
 	// connection handle is attached to.
 	ServerRemoteAddr() string
+
+	// IsIdle returns true if the connection is idle, and false otherwise.
+	IsIdle() bool
 }

--- a/pkg/ccl/sqlproxyccl/balancer/conn_tracker.go
+++ b/pkg/ccl/sqlproxyccl/balancer/conn_tracker.go
@@ -10,28 +10,58 @@ package balancer
 
 import (
 	"context"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/logtags"
 )
+
+// cacheRefreshInterval refers to the interval that the tenant caches are
+// periodically refreshed. Note that the cache is also updated manually whenever
+// a connection gets added to or removed from the connection tracker.
+const cacheRefreshInterval = 15 * time.Second
 
 // ConnTracker tracks all connection handles associated with each tenant, and
 // handles are grouped by SQL pods.
 type ConnTracker struct {
+	// timeSource is the source of the time, and uses timeutil.DefaultTimeSource
+	// by default. This is often replaced in tests.
+	timeSource timeutil.TimeSource
+
+	// mu synchronizes access to the list of tenants.
 	mu struct {
 		syncutil.Mutex
+
+		// tenants refer to a list of tenant entries.
 		tenants map[roachpb.TenantID]*tenantEntry
 	}
 }
 
 // NewConnTracker returns a new instance of the connection tracker. All exposed
 // methods on the connection tracker are thread-safe.
-func NewConnTracker() *ConnTracker {
-	t := &ConnTracker{}
+func NewConnTracker(
+	ctx context.Context, stopper *stop.Stopper, timeSource timeutil.TimeSource,
+) (*ConnTracker, error) {
+	// Ensure that ctx gets cancelled on stopper's quiescing.
+	ctx, _ = stopper.WithCancelOnQuiesce(ctx)
+
+	if timeSource == nil {
+		timeSource = timeutil.DefaultTimeSource{}
+	}
+
+	t := &ConnTracker{timeSource: timeSource}
 	t.mu.tenants = make(map[roachpb.TenantID]*tenantEntry)
-	return t
+
+	if err := stopper.RunAsyncTask(
+		ctx, "refresh-tenant-cache", t.refreshTenantCachesLoop,
+	); err != nil {
+		return nil, err
+	}
+	return t, nil
 }
 
 // OnConnect registers the connection handle for tracking under the given
@@ -69,6 +99,24 @@ func (t *ConnTracker) GetConnsMap(tenantID roachpb.TenantID) map[string][]Connec
 	return e.getConnsMap()
 }
 
+// GetTenantCache returns the given tenant's cache that contains cached data
+// about the tenant (e.g. number of active/idle connections). This cache gets
+// refreshed with the current data periodically, and updated whenever a new
+// connection gets added to or removed from the connection tracker.
+// GetTenantCache returns nil if the tenant does not exist in the connection
+// tracker.
+//
+// TODO(jaylim-crl): Consider moving the connection map returned from
+// GetConnsMap into the tenant cache for a cleaner API. We'll revisit this
+// decision once we add the rebalancing logic to the balancer.
+func (t *ConnTracker) GetTenantCache(tenantID roachpb.TenantID) TenantCache {
+	e := t.getEntry(tenantID, false /* allowCreate */)
+	if e == nil {
+		return nil
+	}
+	return e.getCache()
+}
+
 // GetTenantIDs returns a list of tenant IDs that have at least one connection
 // registered with the connection tracker.
 func (t *ConnTracker) GetTenantIDs() []roachpb.TenantID {
@@ -101,6 +149,38 @@ func (t *ConnTracker) getEntry(tenantID roachpb.TenantID, allowCreate bool) *ten
 	return entry
 }
 
+// refreshTenantCachesLoop runs on a background goroutine to continuously
+// refresh all tenant caches in the connection tracker, once every
+// cacheRefreshInterval.
+func (t *ConnTracker) refreshTenantCachesLoop(ctx context.Context) {
+	timer := t.timeSource.NewTimer()
+	defer timer.Stop()
+	for {
+		timer.Reset(cacheRefreshInterval)
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.Ch():
+			timer.MarkRead()
+			t.refreshTenantCaches()
+		}
+	}
+}
+
+// refreshTenantCaches refreshes the cache for all the tenants associated with
+// the connection tracker.
+func (t *ConnTracker) refreshTenantCaches() {
+	tenantIDs := t.GetTenantIDs()
+	for _, tenantID := range tenantIDs {
+		e := t.getEntry(tenantID, false /* allowCreate */)
+		if e != nil {
+			e.refreshCache()
+		}
+	}
+}
+
+// logTrackerEvent logs an event based on the logtags attached to the connection
+// goroutine.
 func logTrackerEvent(event string, handle ConnectionHandle) {
 	// The right approach would be for the caller to pass in a ctx object. For
 	// simplicity, we'll just use a background context here since it's only used
@@ -113,17 +193,27 @@ func logTrackerEvent(event string, handle ConnectionHandle) {
 // tenantEntry is a connection tracker entry that stores connection information
 // for a single tenant. All methods on tenantEntry are thread-safe.
 type tenantEntry struct {
+	// cache corresponds to the tenant cache that is used to cache the number of
+	// active/idle connections by pod. A cache is used here to avoid frequent
+	// computations of such numbers (which would require iterating all
+	// connections for the given tenant).
+	cache *tenantCache
+
 	// mu synchronizes access to the list of connections associated with this
 	// tenant.
 	mu struct {
 		syncutil.Mutex
+
+		// conns refers to a set of connection handles.
 		conns map[ConnectionHandle]struct{}
 	}
 }
 
 // newTenantEntry returns a new instance of tenantEntry.
 func newTenantEntry() *tenantEntry {
-	e := &tenantEntry{}
+	e := &tenantEntry{
+		cache: newTenantCache(),
+	}
 	e.mu.conns = make(map[ConnectionHandle]struct{})
 	return e
 }
@@ -131,7 +221,7 @@ func newTenantEntry() *tenantEntry {
 // addHandle adds the handle to the entry based on the handle's active server
 // remote address. This returns true if the operation was successful, and false
 // otherwise.
-func (e *tenantEntry) addHandle(handle ConnectionHandle) bool {
+func (e *tenantEntry) addHandle(handle ConnectionHandle) (success bool) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -140,12 +230,15 @@ func (e *tenantEntry) addHandle(handle ConnectionHandle) bool {
 		return false
 	}
 	e.mu.conns[handle] = struct{}{}
+
+	// New connections are always active.
+	e.cache.updateActiveCount(handle.ServerRemoteAddr(), 1)
 	return true
 }
 
 // removeHandle deletes the handle from the tenant entry. This returns true if
 // the operation was successful, and false otherwise.
-func (e *tenantEntry) removeHandle(handle ConnectionHandle) bool {
+func (e *tenantEntry) removeHandle(handle ConnectionHandle) (success bool) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -154,6 +247,17 @@ func (e *tenantEntry) removeHandle(handle ConnectionHandle) bool {
 		return false
 	}
 	delete(e.mu.conns, handle)
+
+	// We'll update the cache based on the data that we have now. It is possible
+	// that the cache was computed using a different state (e.g. cache does not
+	// include this connection, or cache counted this connection as active, but
+	// is idle now), resulting in us decrementing from a different map here.
+	// Regardless, since this is a cache, accuracy does not matter.
+	if handle.IsIdle() {
+		e.cache.updateIdleCount(handle.ServerRemoteAddr(), -1)
+	} else {
+		e.cache.updateActiveCount(handle.ServerRemoteAddr(), -1)
+	}
 	return true
 }
 
@@ -191,4 +295,31 @@ func (e *tenantEntry) getConnsCount() int {
 	defer e.mu.Unlock()
 
 	return len(e.mu.conns)
+}
+
+// getCache returns the cache for the given tenant.
+func (e *tenantEntry) getCache() TenantCache {
+	return e.cache
+}
+
+// refreshCache updates the cache associated with the tenant. This iterates
+// through all connections for the tenant, so use with care.
+func (e *tenantEntry) refreshCache() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	// Construct cache based on current data.
+	cacheData := newTenantCacheData()
+	for handle := range e.mu.conns {
+		// Connection has been closed.
+		if handle.Context().Err() != nil {
+			continue
+		}
+		if handle.IsIdle() {
+			cacheData.idleConnsCount[handle.ServerRemoteAddr()]++
+		} else {
+			cacheData.activeConnsCount[handle.ServerRemoteAddr()]++
+		}
+	}
+	e.cache.refreshData(cacheData)
 }

--- a/pkg/ccl/sqlproxyccl/balancer/conn_tracker_test.go
+++ b/pkg/ccl/sqlproxyccl/balancer/conn_tracker_test.go
@@ -13,13 +13,17 @@ import (
 	"fmt"
 	"math/rand"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,11 +31,19 @@ func TestConnTracker(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	tracker := NewConnTracker()
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	tracker, err := NewConnTracker(ctx, stopper, nil /* timeSource */)
+	require.NoError(t, err)
 
 	tenantID, handle := makeConn(20, "127.0.0.10:8090")
 	require.True(t, tracker.OnConnect(tenantID, handle))
 	require.False(t, tracker.OnConnect(tenantID, handle))
+
+	cache := tracker.GetTenantCache(tenantID)
+	require.Equal(t, 1, cache.ActiveCountByAddr(handle.remoteAddr))
 
 	connsMap := tracker.GetConnsMap(tenantID)
 	require.Len(t, connsMap, 1)
@@ -44,11 +56,14 @@ func TestConnTracker(t *testing.T) {
 	require.Equal(t, tenantID, tenantIDs[0])
 
 	// Non-existent.
-	connsMap = tracker.GetConnsMap(roachpb.MakeTenantID(10))
+	connsMap = tracker.GetConnsMap(roachpb.MakeTenantID(42))
 	require.Empty(t, connsMap)
+	nilCache := tracker.GetTenantCache(roachpb.MakeTenantID(42))
+	require.Nil(t, nilCache)
 
 	require.True(t, tracker.OnDisconnect(tenantID, handle))
 	require.False(t, tracker.OnDisconnect(tenantID, handle))
+	require.Equal(t, 0, cache.ActiveCountByAddr(handle.remoteAddr))
 
 	// Once the handle gets disconnected, we shouldn't return that tenant since
 	// there are no active connections.
@@ -64,6 +79,8 @@ func TestConnTracker(t *testing.T) {
 			defer wg.Done()
 			tenantID, handle := makeConn(1+rand.Intn(5), fmt.Sprintf("127.0.0.10:%d", rand.Intn(5)))
 			require.True(t, tracker.OnConnect(tenantID, handle))
+			cache := tracker.GetTenantCache(tenantID)
+			require.True(t, cache.ActiveCountByAddr(handle.remoteAddr) >= 1)
 			time.Sleep(250 * time.Millisecond)
 			require.True(t, tracker.OnDisconnect(tenantID, handle))
 		}()
@@ -82,7 +99,12 @@ func TestConnTracker_GetConnsMap(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	tracker := NewConnTracker()
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	tracker, err := NewConnTracker(ctx, stopper, nil /* timeSource */)
+	require.NoError(t, err)
 
 	tenant10, handle1 := makeConn(10, "127.0.0.10:1010")
 	_, handle2 := makeConn(10, "127.0.0.10:1020")
@@ -130,34 +152,138 @@ func TestConnTracker_GetConnsMap(t *testing.T) {
 	require.Empty(t, connsMap)
 }
 
+func TestConnTrackerCacheRefresh(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	// Use a custom time source for testing.
+	t0 := time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
+	timeSource := timeutil.NewManualTime(t0)
+
+	tracker, err := NewConnTracker(ctx, stopper, timeSource)
+	require.NoError(t, err)
+
+	// Create three handles: two for tenant-10, and one for tenant-20. Use a
+	// dummy address for all of them.
+	const addr = "127.0.0.10:1020"
+	tenant10, h1 := makeConn(10, addr)
+	_, h2 := makeConn(10, addr)
+	tenant20, h3 := makeConn(20, addr)
+
+	require.Nil(t, tracker.GetTenantCache(tenant10))
+	require.Nil(t, tracker.GetTenantCache(tenant20))
+
+	// Connect all the handles.
+	require.True(t, tracker.OnConnect(tenant10, h1))
+	require.True(t, tracker.OnConnect(tenant10, h2))
+	require.True(t, tracker.OnConnect(tenant20, h3))
+
+	cache10 := tracker.GetTenantCache(tenant10)
+	cache20 := tracker.GetTenantCache(tenant20)
+	require.Equal(t, 2, cache10.ActiveCountByAddr(addr))
+	require.Equal(t, 1, cache20.ActiveCountByAddr(addr))
+	require.Equal(t, 0, cache10.IdleCountByAddr(addr))
+	require.Equal(t, 0, cache20.IdleCountByAddr(addr))
+
+	// Update idle state, and cache stays the same.
+	h1.setIdle(true)
+	h3.setIdle(true)
+	require.Equal(t, 2, cache10.ActiveCountByAddr(addr))
+	require.Equal(t, 1, cache20.ActiveCountByAddr(addr))
+	require.Equal(t, 0, cache10.IdleCountByAddr(addr))
+	require.Equal(t, 0, cache20.IdleCountByAddr(addr))
+
+	// Now advance the time, and cache should update after the timer fires.
+	// The manual time is a little flaky, so we'll continuously advance until
+	// the update fires. Without this loop, we may advance, but the timer does
+	// not get fired.
+	testutils.SucceedsSoon(t, func() error {
+		timeSource.Advance(cacheRefreshInterval)
+		if cache10.IdleCountByAddr(addr) == 1 && cache20.IdleCountByAddr(addr) == 1 {
+			return nil
+		}
+		return errors.New("idle count has not been updated yet")
+	})
+	require.Equal(t, 1, cache10.ActiveCountByAddr(addr))
+	require.Equal(t, 0, cache20.ActiveCountByAddr(addr))
+	require.Equal(t, 1, cache10.IdleCountByAddr(addr))
+	require.Equal(t, 1, cache20.IdleCountByAddr(addr))
+}
+
 func TestTenantEntry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	entry := newTenantEntry()
+	cache := entry.getCache()
 
-	h1 := newTestTrackerConnHandle("10.0.0.1:12345")
+	const addr = "10.0.0.1:12345"
+	h1 := newTestTrackerConnHandle(addr)
+
+	// Add a new handle.
 	require.True(t, entry.addHandle(h1))
 	require.False(t, entry.addHandle(h1))
 	require.Equal(t, 1, entry.getConnsCount())
-
+	require.Equal(t, 1, cache.ActiveCountByAddr(addr))
+	require.Equal(t, 0, cache.IdleCountByAddr(addr))
 	connsMap := entry.getConnsMap()
 	require.Len(t, connsMap, 1)
 
+	// Cache would still be a snapshot until refreshed.
+	h1.setIdle(true)
+	require.Equal(t, 1, cache.ActiveCountByAddr(addr))
+	require.Equal(t, 0, cache.IdleCountByAddr(addr))
+	entry.refreshCache()
+	require.Equal(t, 0, cache.ActiveCountByAddr(addr))
+	require.Equal(t, 1, cache.IdleCountByAddr(addr))
+
+	// Remove the handle.
 	require.True(t, entry.removeHandle(h1))
 	require.False(t, entry.removeHandle(h1))
 	require.Equal(t, 0, entry.getConnsCount())
-
 	require.Empty(t, entry.getConnsMap())
 	require.Len(t, connsMap, 1)
+
+	// The update should be made in the right partition.
+	require.Equal(t, 0, cache.ActiveCountByAddr(addr))
+	require.Equal(t, 0, cache.IdleCountByAddr(addr))
+
+	// Add two handles, one active (h2), and one idle (h1). New connections are
+	// always regarded as active until refreshed.
+	h2 := newTestTrackerConnHandle(addr)
+	require.True(t, entry.addHandle(h1))
+	require.True(t, entry.addHandle(h2))
+	require.Equal(t, 2, cache.ActiveCountByAddr(addr))
+	require.Equal(t, 0, cache.IdleCountByAddr(addr))
+	entry.refreshCache()
+	require.Equal(t, 1, cache.ActiveCountByAddr(addr))
+	require.Equal(t, 1, cache.IdleCountByAddr(addr))
+
+	// Reset h1's state back to active, and disconnect that handle. The cache
+	// should be stale.
+	h1.setIdle(false)
+	require.True(t, entry.removeHandle(h1))
+	require.Equal(t, 0, cache.ActiveCountByAddr(addr))
+	require.Equal(t, 1, cache.IdleCountByAddr(addr))
+	entry.refreshCache()
+	require.Equal(t, 1, cache.ActiveCountByAddr(addr))
+	require.Equal(t, 0, cache.IdleCountByAddr(addr))
 }
 
 // testTrackerConnHandle is a test connection handle that only implements a
 // small subset of methods used for testing.
 type testTrackerConnHandle struct {
 	ConnectionHandle
-	ctx               context.Context
-	remoteAddr        string
-	transferConnCount int32
+	ctx        context.Context
+	remoteAddr string
+
+	mu struct {
+		syncutil.Mutex
+		transferConnCount int
+		idle              bool
+	}
 }
 
 var _ ConnectionHandle = &testTrackerConnHandle{}
@@ -190,12 +316,29 @@ func (h *testTrackerConnHandle) TransferConnection() error {
 	if h.ctx != nil && h.ctx.Err() != nil {
 		return h.ctx.Err()
 	}
-	atomic.AddInt32(&h.transferConnCount, 1)
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.mu.transferConnCount++
 	return nil
 }
 
 func (h *testTrackerConnHandle) transferConnectionCount() int {
-	return int(atomic.LoadInt32(&h.transferConnCount))
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.mu.transferConnCount
+}
+
+// IsIdle implements the ConnectionHandle interface.
+func (h *testTrackerConnHandle) IsIdle() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.mu.idle
+}
+
+func (h *testTrackerConnHandle) setIdle(idle bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.mu.idle = idle
 }
 
 func makeConn(tenantID int, podAddr string) (roachpb.TenantID, *testTrackerConnHandle) {

--- a/pkg/ccl/sqlproxyccl/balancer/tenant_cache.go
+++ b/pkg/ccl/sqlproxyccl/balancer/tenant_cache.go
@@ -1,0 +1,113 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package balancer
+
+import (
+	"math"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// TenantCache represents the tenant cache that contains cached data about the
+// tenant's connections (e.g. number of active or idle connections).
+type TenantCache interface {
+	// ActiveCountByAddr returns the number of active connections based on the
+	// given pod's address for the tenant.
+	ActiveCountByAddr(podAddr string) int
+
+	// IdleCountByAddr returns the number of idle connections based on the
+	// given pod's address for the tenant.
+	IdleCountByAddr(podAddr string) int
+}
+
+// tenantCache represents an implementation of the TenantCache interface.
+type tenantCache struct {
+	mu   syncutil.Mutex
+	data *tenantCacheData
+}
+
+var _ TenantCache = &tenantCache{}
+
+// newTenantCache returns a new instance of tenantCache.
+func newTenantCache() *tenantCache {
+	return &tenantCache{data: newTenantCacheData()}
+}
+
+// ActiveCountByAddr returns the number of active connections based on the given
+// pod's address for the tenant. If the pod's address is invalid, 0 will be
+// returned.
+//
+// ActiveCountByAddr implements the TenantCache interface.
+func (c *tenantCache) ActiveCountByAddr(podAddr string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.data.activeConnsCount[podAddr]
+}
+
+// IdleCountByAddr returns the number of idle connections based on the given
+// pod's address for the tenant. If the pod's address is invalid, 0 will be
+// returned.
+//
+// IdleCountByAddr implements the TenantCache interface.
+func (c *tenantCache) IdleCountByAddr(podAddr string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.data.idleConnsCount[podAddr]
+}
+
+// updateActiveCount updates the activeConnsCount map by incrementing the pod's
+// number of connections by val. val may be negative, and updateActiveCount
+// ensures that the number of connections will never be negative.
+func (c *tenantCache) updateActiveCount(podAddr string, val int) {
+	if val == 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.data.activeConnsCount[podAddr] = int(math.Max(float64(c.data.activeConnsCount[podAddr]+val), 0))
+}
+
+// updateIdleCount updates the idleConnsCount map by incrementing the pod's
+// number of connections by val. val may be negative, and updateActiveCount
+// ensures that the number of connections will never be negative.
+func (c *tenantCache) updateIdleCount(podAddr string, val int) {
+	if val == 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.data.idleConnsCount[podAddr] = int(math.Max(float64(c.data.idleConnsCount[podAddr]+val), 0))
+}
+
+// refreshData replaces the cache data with the input data.
+func (c *tenantCache) refreshData(data *tenantCacheData) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.data = data
+}
+
+// tenantCacheData represents the data stored in the tenant cache. When working
+// with fields, it is assumed that a lock has been obtained.
+type tenantCacheData struct {
+	// activeConnsCount is the mapping of pod's address to the number of active
+	// connections in that pod.
+	activeConnsCount map[string]int
+
+	// idleConnsCount is the mapping of pod's address to the number of idle
+	// connections in that pod.
+	idleConnsCount map[string]int
+}
+
+// newTenantCacheData creates an empty instance of the tenantCacheData.
+func newTenantCacheData() *tenantCacheData {
+	return &tenantCacheData{
+		activeConnsCount: make(map[string]int),
+		idleConnsCount:   make(map[string]int),
+	}
+}

--- a/pkg/ccl/sqlproxyccl/balancer/tenant_cache_test.go
+++ b/pkg/ccl/sqlproxyccl/balancer/tenant_cache_test.go
@@ -1,0 +1,93 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package balancer
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTenantCache(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	cache := newTenantCache()
+	require.Equal(t, 0, cache.ActiveCountByAddr("foo"))
+	require.Equal(t, 0, cache.IdleCountByAddr("foo"))
+
+	// Refresh the cache's data.
+	data := newTenantCacheData()
+	data.activeConnsCount["foo"] = 5
+	data.activeConnsCount["bar"] = 10
+	data.idleConnsCount["bar"] = 2
+	cache.refreshData(data)
+
+	require.Equal(t, 0, cache.ActiveCountByAddr("baz"))
+	require.Equal(t, 5, cache.ActiveCountByAddr("foo"))
+	require.Equal(t, 10, cache.ActiveCountByAddr("bar"))
+	require.Equal(t, 0, cache.IdleCountByAddr("foo"))
+	require.Equal(t, 2, cache.IdleCountByAddr("bar"))
+
+	// Active counts can be updated, and won't drop below 0.
+	cache.updateActiveCount("foo", 3)
+	cache.updateActiveCount("foo", -2)
+	cache.updateActiveCount("foo", 0)
+	require.Equal(t, 6, cache.ActiveCountByAddr("foo"))
+	cache.updateActiveCount("foo", -10)
+	require.Equal(t, 0, cache.ActiveCountByAddr("foo"))
+
+	// Adding a new pod should work.
+	cache.updateActiveCount("carl", 3)
+	require.Equal(t, 3, cache.ActiveCountByAddr("carl"))
+
+	// Idle counts can be updated, and won't drop below 0.
+	cache.updateIdleCount("bar", 3)
+	cache.updateIdleCount("bar", -2)
+	cache.updateIdleCount("bar", 0)
+	require.Equal(t, 3, cache.IdleCountByAddr("bar"))
+	cache.updateIdleCount("bar", -10)
+	cache.updateIdleCount("bar", 10)
+	require.Equal(t, 10, cache.IdleCountByAddr("bar"))
+
+	// Adding a new pod should work.
+	cache.updateIdleCount("foo", 3)
+	require.Equal(t, 3, cache.IdleCountByAddr("foo"))
+
+	// Reset the cache to empty.
+	cache.refreshData(newTenantCacheData())
+	require.Equal(t, 0, cache.ActiveCountByAddr("foo"))
+	require.Equal(t, 0, cache.ActiveCountByAddr("bar"))
+	require.Equal(t, 0, cache.IdleCountByAddr("foo"))
+	require.Equal(t, 0, cache.IdleCountByAddr("bar"))
+
+	// Test concurrency on active and idle counts.
+	const runs = 100
+	var wg sync.WaitGroup
+	wg.Add(2 * runs)
+	for i := 0; i < runs; i++ {
+		go func() {
+			defer wg.Done()
+			cache.updateActiveCount("apple", 1)
+			cache.updateIdleCount("apple", 2)
+		}()
+
+		// At the same time try to read data.
+		go func() {
+			defer wg.Done()
+			_ = cache.ActiveCountByAddr("apple")
+			_ = cache.IdleCountByAddr("apple")
+		}()
+	}
+
+	wg.Wait()
+	require.Equal(t, 100, cache.ActiveCountByAddr("apple"))
+	require.Equal(t, 200, cache.IdleCountByAddr("apple"))
+}

--- a/pkg/ccl/sqlproxyccl/forwarder.go
+++ b/pkg/ccl/sqlproxyccl/forwarder.go
@@ -29,6 +29,10 @@ const idleTimeout = 30 * time.Second
 // forwarder is used to forward pgwire messages from the client to the server,
 // and vice-versa. The forwarder instance should always be constructed through
 // the forward function, which also starts the forwarder.
+//
+// WARNING: The forwarder implements balancer.ConnectionHandle, and one has to
+// ensure that implemented methods that hold locks do not end up calling methods
+// within the balancer package, or else a deadlock may occur.
 type forwarder struct {
 	// ctx is a single context used to control all goroutines spawned by the
 	// forwarder. An exception to this is that if the goroutines are blocked

--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -399,7 +399,7 @@ func (handler *proxyHandler) handle(ctx context.Context, incomingConn *proxyConn
 	}()
 
 	// Pass ownership of conn and crdbConn to the forwarder.
-	f, err := forward(ctx, connector, handler.metrics, fe.conn, crdbConn)
+	f, err := forward(ctx, connector, handler.metrics, fe.conn, crdbConn, nil /* timeSource */)
 	if err != nil {
 		// Don't send to the client here for the same reason below.
 		handler.metrics.updateForError(err)

--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -257,7 +257,12 @@ func newProxyHandler(
 	// Create the connection tracker and balancer components.
 	balancerMetrics := balancer.NewMetrics()
 	registry.AddMetricStruct(balancerMetrics)
-	handler.connTracker = balancer.NewConnTracker()
+
+	handler.connTracker, err = balancer.NewConnTracker(ctx, stopper, nil /* timeSource */)
+	if err != nil {
+		return nil, err
+	}
+
 	handler.balancer, err = balancer.NewBalancer(
 		ctx, stopper, balancerMetrics, handler.directoryCache, handler.connTracker,
 	)


### PR DESCRIPTION
#### ccl/sqlproxyccl: add IsIdle API to the forwarder component 

As part of the leastconns work, we need a mechanism that tells whether the
forwarder (or connection handle) is in an idle state. This commit adds an
IsIdle API to the forwarder component, which implements the ConnectionHandle
interface in the balancer component.

A forwarder instance is said to be idle if no messages have been received from
or sent to the client for the past 30 seconds since the last active timestamp.

#### ccl/sqlproxyccl: add a TenantCache to keep track of connection counts 

This commit adds a new TenantCache component to the balancer package which will
be used to keep track of connection counts in the next commit.

#### ccl/sqlproxyccl: update connection tracker to use the tenant cache 

This commit updates the connection tracker in the balancer package to use the
tenant cache introduced in the previous commit. Each tenant entry holds onto
a tenant cache, which gets refreshed with the current list of connections once
every 15 seconds. This cache will be used by the pod selection algorithm in
a future PR. To prevent thundering herd issues where connections are routed to
the same pod due to a stale cache, the cache is also updated manually whenever
a connection gets added or removed from the connection tracker.

Release note: None