### PR TITLE
asim: load cluster configuration to be simulated

### DIFF
--- a/pkg/kv/kvserver/asim/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "asim",
     srcs = [
         "asim.go",
+        "config_loader.go",
         "workload.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim",
@@ -20,6 +21,7 @@ go_test(
     name = "asim_test",
     srcs = [
         "asim_test.go",
+        "config_loader_test.go",
         "workload_test.go",
     ],
     embed = [":asim"],

--- a/pkg/kv/kvserver/asim/asim_test.go
+++ b/pkg/kv/kvserver/asim/asim_test.go
@@ -20,26 +20,21 @@ import (
 )
 
 func TestStateUpdates(t *testing.T) {
-	ctx := context.Background()
-
 	s := asim.NewState()
-	s.AddNode(ctx)
+	s.AddNode()
 	require.Equal(t, 1, len(s.Nodes))
-
-	s.AddStore(ctx, 1)
 	require.Equal(t, 1, len(s.Nodes[1].Stores))
 }
 
 func TestRunAllocatorSimulator(t *testing.T) {
 	ctx := context.Background()
-
 	rwg := make([]asim.WorkloadGenerator, 1)
 	rwg[0] = &asim.RandomWorkloadGenerator{}
-	scl := &asim.ConfigLoader{}
 	start := time.Date(2022, 03, 21, 11, 0, 0, 0, time.UTC)
 	end := start.Add(25 * time.Second)
 	interval := 10 * time.Second
-	sim := asim.NewSimulator(start, end, interval, rwg, scl)
+	s := asim.LoadConfig(asim.SingleRegionConfig)
+	sim := asim.NewSimulator(start, end, interval, rwg, s)
 	sim.RunSim(ctx)
 }
 

--- a/pkg/kv/kvserver/asim/config_loader.go
+++ b/pkg/kv/kvserver/asim/config_loader.go
@@ -1,0 +1,124 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package asim
+
+// SingleRegionConfig is a simple cluster config with a single region and 3
+// zones, all have the same number of nodes.
+var SingleRegionConfig = ClusterInfo{
+	DiskCapacityGB: 1024,
+	Regions: []Region{
+		{
+			Name: "US",
+			Zones: []Zone{
+				{Name: "US_1", NodeCount: 5},
+				{Name: "US_2", NodeCount: 5},
+				{Name: "US_3", NodeCount: 5},
+			},
+		},
+	},
+}
+
+// MultiRegionConfig is a perfectly balanced cluster config with 3 regions.
+var MultiRegionConfig = ClusterInfo{
+	DiskCapacityGB: 2048,
+	Regions: []Region{
+		{
+			Name: "US_East",
+			Zones: []Zone{
+				{Name: "US_East_1", NodeCount: 4},
+				{Name: "US_East_2", NodeCount: 4},
+				{Name: "US_East_3", NodeCount: 4},
+			},
+		},
+		{
+			Name: "US_West",
+			Zones: []Zone{
+				{Name: "US_West_1", NodeCount: 4},
+				{Name: "US_West_2", NodeCount: 4},
+				{Name: "US_West_3", NodeCount: 4},
+			},
+		},
+		{
+			Name: "EU",
+			Zones: []Zone{
+				{Name: "EU_1", NodeCount: 4},
+				{Name: "EU_2", NodeCount: 4},
+				{Name: "EU_3", NodeCount: 4},
+			},
+		},
+	},
+}
+
+// ComplexConfig is an imbalanced multi-region cluster config.
+var ComplexConfig = ClusterInfo{
+	DiskCapacityGB: 2048,
+	Regions: []Region{
+		{
+			Name: "US_East",
+			Zones: []Zone{
+				{Name: "US_East_1", NodeCount: 1},
+				{Name: "US_East_2", NodeCount: 2},
+				{Name: "US_East_3", NodeCount: 3},
+				{Name: "US_East_3", NodeCount: 10},
+			},
+		},
+		{
+			Name: "US_West",
+			Zones: []Zone{
+				{Name: "US_West_1", NodeCount: 2},
+			},
+		},
+		{
+			Name: "EU",
+			Zones: []Zone{
+				{Name: "EU_1", NodeCount: 3},
+				{Name: "EU_2", NodeCount: 3},
+				{Name: "EU_3", NodeCount: 4},
+			},
+		},
+	},
+}
+
+// Zone is a simulated availability zone.
+type Zone struct {
+	Name      string
+	NodeCount int
+}
+
+// Region is a simulated region which contains one or more zones.
+type Region struct {
+	Name  string
+	Zones []Zone
+}
+
+// ClusterInfo contains cluster information needed for allocation decisions.
+// TODO(lidor): add cross region network latencies.
+type ClusterInfo struct {
+	DiskCapacityGB int
+	Regions        []Region
+}
+
+// LoadConfig loads a predefined configuration which contains cluster
+// information such as regions, zones, etc.
+func LoadConfig(c ClusterInfo) *State {
+	s := NewState()
+	s.Cluster = &c
+	// TODO(lidor): load locality info to be used by the allocator. Do we need a
+	// NodeDescriptor and higher level localities? or can we simulate those?
+	for _, r := range c.Regions {
+		for _, z := range r.Zones {
+			for i := 0; i < z.NodeCount; i++ {
+				s.AddNode()
+			}
+		}
+	}
+	return s
+}

--- a/pkg/kv/kvserver/asim/config_loader_test.go
+++ b/pkg/kv/kvserver/asim/config_loader_test.go
@@ -1,0 +1,43 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package asim_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfig(t *testing.T) {
+	testCases := []struct {
+		clusterInfo       asim.ClusterInfo
+		expectedNodeCount int
+	}{
+		{
+			clusterInfo:       asim.SingleRegionConfig,
+			expectedNodeCount: 15,
+		},
+		{
+			clusterInfo:       asim.MultiRegionConfig,
+			expectedNodeCount: 36,
+		},
+		{
+			clusterInfo:       asim.ComplexConfig,
+			expectedNodeCount: 28,
+		},
+	}
+
+	for _, tc := range testCases {
+		state := asim.LoadConfig(tc.clusterInfo)
+		require.Equal(t, tc.expectedNodeCount, len(state.Nodes))
+	}
+}


### PR DESCRIPTION
Adding a few cluster configurations and a way to load those configs to be
simulated.

Note that this is somewhat different from what I had in mind initially: with
this implementation there is no way to change the configuration mid-run (we
will add that later).

Release note: None