### PR TITLE
release-22.1: ccl/sqlproxyccl: add server name indication (SNI) support

### DIFF
--- a/pkg/ccl/sqlproxyccl/frontend_admitter.go
+++ b/pkg/ccl/sqlproxyccl/frontend_admitter.go
@@ -17,9 +17,10 @@ import (
 
 // FrontendAdmitInfo contains the result of FrontendAdmit call.
 type FrontendAdmitInfo struct {
-	conn net.Conn
-	msg  *pgproto3.StartupMessage
-	err  error
+	conn          net.Conn
+	msg           *pgproto3.StartupMessage
+	err           error
+	sniServerName string
 }
 
 // FrontendAdmit is the default implementation of a frontend admitter. It can
@@ -34,7 +35,6 @@ var FrontendAdmit = func(
 	// `conn` could be replaced by `conn` embedded in a `tls.Conn` connection,
 	// hence it's important to close `conn` rather than `proxyConn` since closing
 	// the latter will not call `Close` method of `tls.Conn`.
-	var sniServerName string
 
 	// Read first message from client.
 	m, err := pgproto3.NewBackend(pgproto3.NewChunkReader(conn), conn).ReceiveStartupMessage()
@@ -51,6 +51,8 @@ var FrontendAdmit = func(
 	if _, ok := m.(*pgproto3.CancelRequest); ok {
 		return &FrontendAdmitInfo{conn: conn}
 	}
+
+	var sniServerName string
 
 	// If we have an incoming TLS Config, require that the client initiates with
 	// an SSLRequest message.
@@ -84,10 +86,6 @@ var FrontendAdmit = func(
 	}
 
 	if startup, ok := m.(*pgproto3.StartupMessage); ok {
-		// Add the sniServerName (if used) as parameter
-		if sniServerName != "" {
-			startup.Parameters["sni-server"] = sniServerName
-		}
 		// This forwards the remote addr to the backend.
 		startup.Parameters[remoteAddrStartupParam] = conn.RemoteAddr().String()
 		// The client is blocked from using session revival tokens; only the proxy
@@ -102,7 +100,7 @@ var FrontendAdmit = func(
 				),
 			}
 		}
-		return &FrontendAdmitInfo{conn: conn, msg: startup}
+		return &FrontendAdmitInfo{conn: conn, msg: startup, sniServerName: sniServerName}
 	}
 
 	code := codeUnexpectedStartupMessage

--- a/pkg/ccl/sqlproxyccl/frontend_admitter_test.go
+++ b/pkg/ccl/sqlproxyccl/frontend_admitter_test.go
@@ -80,6 +80,7 @@ func TestFrontendAdmitWithClientSSLRequire(t *testing.T) {
 
 	go func() {
 		cfg, err := pgconn.ParseConfig("postgres://localhost?sslmode=require")
+		cfg.TLSConfig.ServerName = "test"
 		require.NoError(t, err)
 		require.NotNil(t, cfg)
 		cfg.DialFunc = func(ctx context.Context, network, addr string) (net.Conn, error) {
@@ -96,6 +97,7 @@ func TestFrontendAdmitWithClientSSLRequire(t *testing.T) {
 	require.NotEqual(t, srv, fe.conn) // The connection was replaced by SSL
 	require.NotNil(t, fe.msg)
 	require.Contains(t, fe.msg.Parameters, remoteAddrStartupParam)
+	require.Equal(t, fe.sniServerName, "test")
 }
 
 // TestFrontendAdmitRequireEncryption sends StartupRequest when SSlRequest is

--- a/pkg/ccl/sqlproxyccl/frontend_admitter_test.go
+++ b/pkg/ccl/sqlproxyccl/frontend_admitter_test.go
@@ -59,13 +59,13 @@ func TestFrontendAdmitWithClientSSLDisableAndCustomParam(t *testing.T) {
 		fmt.Printf("Done\n")
 	}()
 
-	frontendCon, msg, err := FrontendAdmit(srv, nil)
-	require.NoError(t, err)
-	require.Equal(t, srv, frontendCon)
-	require.NotNil(t, msg)
-	require.Contains(t, msg.Parameters, "p1")
-	require.Equal(t, msg.Parameters["p1"], "a")
-	require.Contains(t, msg.Parameters, remoteAddrStartupParam)
+	fe := FrontendAdmit(srv, nil)
+	require.NoError(t, fe.err)
+	require.Equal(t, srv, fe.conn)
+	require.NotNil(t, fe.msg)
+	require.Contains(t, fe.msg.Parameters, "p1")
+	require.Equal(t, fe.msg.Parameters["p1"], "a")
+	require.Contains(t, fe.msg.Parameters, remoteAddrStartupParam)
 }
 
 func TestFrontendAdmitWithClientSSLRequire(t *testing.T) {
@@ -90,12 +90,12 @@ func TestFrontendAdmitWithClientSSLRequire(t *testing.T) {
 
 	tlsConfig, err := tlsConfig()
 	require.NoError(t, err)
-	frontendCon, msg, err := FrontendAdmit(srv, tlsConfig)
+	fe := FrontendAdmit(srv, tlsConfig)
 	require.NoError(t, err)
-	defer func() { _ = frontendCon.Close() }()
-	require.NotEqual(t, srv, frontendCon) // The connection was replaced by SSL
-	require.NotNil(t, msg)
-	require.Contains(t, msg.Parameters, remoteAddrStartupParam)
+	defer func() { _ = fe.conn.Close() }()
+	require.NotEqual(t, srv, fe.conn) // The connection was replaced by SSL
+	require.NotNil(t, fe.msg)
+	require.Contains(t, fe.msg.Parameters, remoteAddrStartupParam)
 }
 
 // TestFrontendAdmitRequireEncryption sends StartupRequest when SSlRequest is
@@ -118,12 +118,12 @@ func TestFrontendAdmitRequireEncryption(t *testing.T) {
 
 	tlsConfig, err := tlsConfig()
 	require.NoError(t, err)
-	frontendCon, msg, err := FrontendAdmit(srv, tlsConfig)
-	require.EqualError(t, err,
+	fe := FrontendAdmit(srv, tlsConfig)
+	require.EqualError(t, fe.err,
 		"codeUnexpectedInsecureStartupMessage: "+
 			"unsupported startup message: *pgproto3.StartupMessage")
-	require.NotNil(t, frontendCon)
-	require.Nil(t, msg)
+	require.NotNil(t, fe.conn)
+	require.Nil(t, fe.msg)
 }
 
 // TestFrontendAdmitWithCancel sends CancelRequest.
@@ -140,10 +140,10 @@ func TestFrontendAdmitWithCancel(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	frontendCon, msg, err := FrontendAdmit(srv, nil)
-	require.NoError(t, err)
-	require.NotNil(t, frontendCon)
-	require.Nil(t, msg)
+	fe := FrontendAdmit(srv, nil)
+	require.NoError(t, fe.err)
+	require.NotNil(t, fe.conn)
+	require.Nil(t, fe.msg)
 }
 
 // TestFrontendAdmitWithSSLAndCancel sends SSLRequest followed by CancelRequest.
@@ -170,13 +170,13 @@ func TestFrontendAdmitWithSSLAndCancel(t *testing.T) {
 
 	tlsConfig, err := tlsConfig()
 	require.NoError(t, err)
-	frontendCon, msg, err := FrontendAdmit(srv, tlsConfig)
-	require.EqualError(t, err,
+	fe := FrontendAdmit(srv, tlsConfig)
+	require.EqualError(t, fe.err,
 		"codeUnexpectedStartupMessage: "+
 			"unsupported post-TLS startup message: *pgproto3.CancelRequest",
 	)
-	require.NotNil(t, frontendCon)
-	require.Nil(t, msg)
+	require.NotNil(t, fe.conn)
+	require.Nil(t, fe.msg)
 }
 
 func TestFrontendAdmitSessionRevivalToken(t *testing.T) {
@@ -204,8 +204,8 @@ func TestFrontendAdmitSessionRevivalToken(t *testing.T) {
 		fmt.Printf("Done\n")
 	}()
 
-	frontendCon, msg, err := FrontendAdmit(srv, nil)
-	require.EqualError(t, err, "codeUnexpectedStartupMessage: parameter crdb:session_revival_token_base64 is not allowed")
-	require.NotNil(t, frontendCon)
-	require.Nil(t, msg)
+	fe := FrontendAdmit(srv, nil)
+	require.EqualError(t, fe.err, "codeUnexpectedStartupMessage: parameter crdb:session_revival_token_base64 is not allowed")
+	require.NotNil(t, fe.conn)
+	require.Nil(t, fe.msg)
 }

--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -262,27 +262,27 @@ func newProxyHandler(
 // handle is called by the proxy server to handle a single incoming client
 // connection.
 func (handler *proxyHandler) handle(ctx context.Context, incomingConn *proxyConn) error {
-	conn, msg, err := FrontendAdmit(incomingConn, handler.incomingTLSConfig())
-	defer func() { _ = conn.Close() }()
-	if err != nil {
-		SendErrToClient(conn, err)
-		return err
+	fe := FrontendAdmit(incomingConn, handler.incomingTLSConfig())
+	defer func() { _ = fe.conn.Close() }()
+	if fe.err != nil {
+		SendErrToClient(fe.conn, fe.err)
+		return fe.err
 	}
 
 	// This currently only happens for CancelRequest type of startup messages
 	// that we don't support. Return nil to the server, which simply closes the
 	// connection.
-	if msg == nil {
+	if fe.msg == nil {
 		return nil
 	}
 
 	// NOTE: Errors returned from this function are user-facing errors so we
 	// should be careful with the details that we want to expose.
-	backendStartupMsg, clusterName, tenID, err := clusterNameAndTenantFromParams(ctx, msg)
+	backendStartupMsg, clusterName, tenID, err := clusterNameAndTenantFromParams(ctx, fe)
 	if err != nil {
 		clientErr := &codeError{codeParamsRoutingFailed, err}
 		log.Errorf(ctx, "unable to extract cluster name and tenant id: %s", err.Error())
-		updateMetricsAndSendErrToClient(clientErr, conn, handler.metrics)
+		updateMetricsAndSendErrToClient(clientErr, fe.conn, handler.metrics)
 		return clientErr
 	}
 
@@ -291,11 +291,11 @@ func (handler *proxyHandler) handle(ctx context.Context, incomingConn *proxyConn
 
 	// Use an empty string as the default port as we only care about the
 	// correctly parsing the IP address here.
-	ipAddr, _, err := addr.SplitHostPort(conn.RemoteAddr().String(), "")
+	ipAddr, _, err := addr.SplitHostPort(fe.conn.RemoteAddr().String(), "")
 	if err != nil {
 		clientErr := newErrorf(codeParamsRoutingFailed, "unexpected connection address")
 		log.Errorf(ctx, "could not parse address: %v", err.Error())
-		updateMetricsAndSendErrToClient(clientErr, conn, handler.metrics)
+		updateMetricsAndSendErrToClient(clientErr, fe.conn, handler.metrics)
 		return clientErr
 	}
 
@@ -314,7 +314,7 @@ func (handler *proxyHandler) handle(ctx context.Context, incomingConn *proxyConn
 	if err != nil {
 		log.Errorf(ctx, "connection matched denylist: %v", err)
 		err = newErrorf(codeProxyRefusedConnection, "connection refused")
-		updateMetricsAndSendErrToClient(err, conn, handler.metrics)
+		updateMetricsAndSendErrToClient(err, fe.conn, handler.metrics)
 		return err
 	}
 	defer removeListener()
@@ -324,7 +324,7 @@ func (handler *proxyHandler) handle(ctx context.Context, incomingConn *proxyConn
 	if err != nil {
 		log.Errorf(ctx, "throttler refused connection: %v", err.Error())
 		err = throttledError
-		updateMetricsAndSendErrToClient(err, conn, handler.metrics)
+		updateMetricsAndSendErrToClient(err, fe.conn, handler.metrics)
 		return err
 	}
 
@@ -359,7 +359,7 @@ func (handler *proxyHandler) handle(ctx context.Context, incomingConn *proxyConn
 		}
 	}
 
-	crdbConn, sentToClient, err := connector.OpenTenantConnWithAuth(ctx, conn,
+	crdbConn, sentToClient, err := connector.OpenTenantConnWithAuth(ctx, fe.conn,
 		func(status throttler.AttemptStatus) error {
 			if err := handler.throttleService.ReportAttempt(
 				ctx, throttleTags, throttleTime, status,
@@ -375,7 +375,7 @@ func (handler *proxyHandler) handle(ctx context.Context, incomingConn *proxyConn
 		if sentToClient {
 			handler.metrics.updateForError(err)
 		} else {
-			updateMetricsAndSendErrToClient(err, conn, handler.metrics)
+			updateMetricsAndSendErrToClient(err, fe.conn, handler.metrics)
 		}
 		return err
 	}
@@ -390,7 +390,7 @@ func (handler *proxyHandler) handle(ctx context.Context, incomingConn *proxyConn
 	}()
 
 	// Pass ownership of conn and crdbConn to the forwarder.
-	f, err := forward(ctx, connector, handler.metrics, conn, crdbConn)
+	f, err := forward(ctx, connector, handler.metrics, fe.conn, crdbConn)
 	if err != nil {
 		// Don't send to the client here for the same reason below.
 		handler.metrics.updateForError(err)
@@ -516,23 +516,23 @@ func (handler *proxyHandler) setupIncomingCert(ctx context.Context) error {
 //   through its command-line options, i.e. "-c NAME=VALUE", "-cNAME=VALUE", and
 //   "--NAME=VALUE".
 func clusterNameAndTenantFromParams(
-	ctx context.Context, msg *pgproto3.StartupMessage,
+	ctx context.Context, fe *FrontendAdmitInfo,
 ) (*pgproto3.StartupMessage, string, roachpb.TenantID, error) {
-	clusterIdentifierDB, databaseName, err := parseDatabaseParam(msg.Parameters["database"])
+	clusterIdentifierDB, databaseName, err := parseDatabaseParam(fe.msg.Parameters["database"])
 	if err != nil {
-		return msg, "", roachpb.MaxTenantID, err
+		return fe.msg, "", roachpb.MaxTenantID, err
 	}
 
-	clusterIdentifierOpt, newOptionsParam, err := parseOptionsParam(msg.Parameters["options"])
+	clusterIdentifierOpt, newOptionsParam, err := parseOptionsParam(fe.msg.Parameters["options"])
 	if err != nil {
-		return msg, "", roachpb.MaxTenantID, err
+		return fe.msg, "", roachpb.MaxTenantID, err
 	}
 
 	// No cluster identifiers were specified.
 	if clusterIdentifierDB == "" && clusterIdentifierOpt == "" {
 		err := errors.New("missing cluster identifier")
 		err = errors.WithHint(err, clusterIdentifierHint)
-		return msg, "", roachpb.MaxTenantID, err
+		return fe.msg, "", roachpb.MaxTenantID, err
 	}
 
 	// Ambiguous cluster identifiers.
@@ -543,7 +543,7 @@ func clusterNameAndTenantFromParams(
 			"Is '%s' or '%s' the identifier for the cluster that you're connecting to?",
 			clusterIdentifierDB, clusterIdentifierOpt)
 		err = errors.WithHint(err, clusterIdentifierHint)
-		return msg, "", roachpb.MaxTenantID, err
+		return fe.msg, "", roachpb.MaxTenantID, err
 	}
 
 	if clusterIdentifierDB == "" {
@@ -557,7 +557,7 @@ func clusterNameAndTenantFromParams(
 		err := errors.Errorf("invalid cluster identifier '%s'", clusterIdentifierDB)
 		err = errors.WithHint(err, missingTenantIDHint)
 		err = errors.WithHint(err, clusterNameFormHint)
-		return msg, "", roachpb.MaxTenantID, err
+		return fe.msg, "", roachpb.MaxTenantID, err
 	}
 
 	clusterName, tenantIDStr := clusterIdentifierDB[:sepIdx], clusterIdentifierDB[sepIdx+1:]
@@ -567,7 +567,7 @@ func clusterNameAndTenantFromParams(
 		err := errors.Errorf("invalid cluster identifier '%s'", clusterIdentifierDB)
 		err = errors.WithHintf(err, "Is '%s' a valid cluster name?", clusterName)
 		err = errors.WithHint(err, clusterNameFormHint)
-		return msg, "", roachpb.MaxTenantID, err
+		return fe.msg, "", roachpb.MaxTenantID, err
 	}
 
 	// Tenant ID cannot be parsed.
@@ -578,7 +578,7 @@ func clusterNameAndTenantFromParams(
 		err := errors.Errorf("invalid cluster identifier '%s'", clusterIdentifierDB)
 		err = errors.WithHintf(err, "Is '%s' a valid tenant ID?", tenantIDStr)
 		err = errors.WithHint(err, clusterNameFormHint)
-		return msg, "", roachpb.MaxTenantID, err
+		return fe.msg, "", roachpb.MaxTenantID, err
 	}
 
 	// This case only happens if tenID is 0 or 1 (system tenant).
@@ -587,13 +587,13 @@ func clusterNameAndTenantFromParams(
 		log.Errorf(ctx, "%s contains an invalid tenant ID", clusterIdentifierDB)
 		err := errors.Errorf("invalid cluster identifier '%s'", clusterIdentifierDB)
 		err = errors.WithHintf(err, "Tenant ID %d is invalid.", tenID)
-		return msg, "", roachpb.MaxTenantID, err
+		return fe.msg, "", roachpb.MaxTenantID, err
 	}
 
 	// Make and return a copy of the startup msg so the original is not modified.
 	// We will rewrite database and options in the new startup message.
 	paramsOut := map[string]string{}
-	for key, value := range msg.Parameters {
+	for key, value := range fe.msg.Parameters {
 		if key == "database" {
 			paramsOut[key] = databaseName
 		} else if key == "options" {
@@ -606,7 +606,7 @@ func clusterNameAndTenantFromParams(
 	}
 
 	outMsg := &pgproto3.StartupMessage{
-		ProtocolVersion: msg.ProtocolVersion,
+		ProtocolVersion: fe.msg.ProtocolVersion,
 		Parameters:      paramsOut,
 	}
 	return outMsg, clusterName, roachpb.MakeTenantID(tenID), nil

--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -507,7 +507,10 @@ func (handler *proxyHandler) setupIncomingCert(ctx context.Context) error {
 // the connection parameters, and rewrites the database and options parameters,
 // if necessary.
 //
-// We currently support embedding the cluster identifier in two ways:
+// We currently support embedding the cluster identifier in three ways:
+//
+// - Through server name identification (SNI) when using TLS connections
+//   (e.g. serverless-101.5xj.gcp-us-central1.cockroachlabs.cloud)
 //
 // - Within the database param (e.g. "happy-koala-3.defaultdb")
 //
@@ -528,8 +531,13 @@ func clusterNameAndTenantFromParams(
 		return fe.msg, "", roachpb.MaxTenantID, err
 	}
 
+	sniTenID, sniPresent := parseSNI(fe.sniServerName)
+
 	// No cluster identifiers were specified.
 	if clusterIdentifierDB == "" && clusterIdentifierOpt == "" {
+		if sniPresent {
+			return fe.msg, "", sniTenID, nil
+		}
 		err := errors.New("missing cluster identifier")
 		err = errors.WithHint(err, clusterIdentifierHint)
 		return fe.msg, "", roachpb.MaxTenantID, err
@@ -605,11 +613,54 @@ func clusterNameAndTenantFromParams(
 		}
 	}
 
+	// Cluster ID provided through one of options or database (or both and the
+	// info is matching). If sni has been provided as well - check for match.
+	if sniPresent && tenID != sniTenID.InternalValue {
+		err := errors.New("multiple different tenant IDs provided")
+		err = errors.WithHintf(err,
+			"Is '%d' (SNI) or '%d' (database/options) the identifier for the cluster that you're connecting to?",
+			sniTenID.InternalValue, tenID)
+		err = errors.WithHint(err, clusterIdentifierHint)
+		return fe.msg, "", roachpb.MaxTenantID, err
+	}
+
 	outMsg := &pgproto3.StartupMessage{
 		ProtocolVersion: fe.msg.ProtocolVersion,
 		Parameters:      paramsOut,
 	}
 	return outMsg, clusterName, roachpb.MakeTenantID(tenID), nil
+}
+
+// parseSNI parses the sni server name parameter if provided and returns the
+// extracted tenant id. If the extraction was successful the second parameter
+// will be true. If not - false.
+func parseSNI(sniServerName string) (roachpb.TenantID, bool) {
+	if sniServerName == "" {
+		return roachpb.MaxTenantID, false
+	}
+
+	// Try to obtain tenant ID from SNI
+	parts := strings.Split(sniServerName, ".")
+	if len(parts) == 0 {
+		return roachpb.MaxTenantID, false
+	}
+
+	hostname := parts[0]
+	hostnameParts := strings.Split(hostname, "-")
+	// TODO serverless prefix may not be appropriate for all cases where the proxy
+	// is used so it needs to be mad configurable. A better design would be to pass
+	// the options (database, options, sni server name) to the tenant directory
+	// and get back a routing id.
+	if len(hostnameParts) != 2 || !strings.EqualFold("serverless", hostnameParts[0]) {
+		return roachpb.MaxTenantID, false
+	}
+
+	tenID, err := strconv.ParseUint(hostnameParts[1], 10, 64)
+	if err != nil || tenID < roachpb.MinTenantID.ToUint64() {
+		return roachpb.MaxTenantID, false
+	}
+
+	return roachpb.MakeTenantID(tenID), true
 }
 
 // parseDatabaseParam parses the database parameter from the PG connection
@@ -697,6 +748,11 @@ following methods:
 2) Options parameter:
    Use "--cluster=<cluster identifier>" as the options parameter.
    (e.g. options="--cluster=active-roach-42")
+
+3) Host name:
+   Use a driver that supports server name identification (SNI) with TLS 
+   connection and the hostname assigned to your cluster 
+   (e.g. serverless-101.5xj.gcp-us-central1.cockroachlabs.cloud)
 
 For more details, please visit our docs site at:
 	https://www.cockroachlabs.com/docs/cockroachcloud/connect-to-a-serverless-cluster

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -237,6 +237,8 @@ func TestProxyAgainstSecureCRDB(t *testing.T) {
 	s, addr := newSecureProxyServer(
 		ctx, t, sql.Stopper(), &ProxyOptions{RoutingRule: sql.ServingSQLAddr(), SkipVerify: true},
 	)
+	_, port, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
 
 	url := fmt.Sprintf("postgres://bob:wrong@%s/tenant-cluster-28.defaultdb?sslmode=require", addr)
 	te.TestConnectErr(ctx, t, url, 0, "failed SASL auth")
@@ -244,13 +246,43 @@ func TestProxyAgainstSecureCRDB(t *testing.T) {
 	url = fmt.Sprintf("postgres://bob@%s/tenant-cluster-28.defaultdb?sslmode=require", addr)
 	te.TestConnectErr(ctx, t, url, 0, "failed SASL auth")
 
+	url = fmt.Sprintf("postgres://bob:builder@toothless-28.blah:%s/defaultdb?sslmode=require", port)
+	te.TestConnectErr(ctx, t, url, codeParamsRoutingFailed, "server error")
+
+	url = fmt.Sprintf("postgres://bob:builder@tenant-cluster-28.blah:%s/defaultdb?sslmode=require", port)
+	te.TestConnectErr(ctx, t, url, codeParamsRoutingFailed, "server error")
+
 	url = fmt.Sprintf("postgres://bob:builder@%s/tenant-cluster-28.defaultdb?sslmode=require", addr)
 	te.TestConnect(ctx, t, url, func(conn *pgx.Conn) {
 		require.Equal(t, int64(1), s.metrics.CurConnCount.Value())
 		require.NoError(t, runTestQuery(ctx, conn))
 	})
-	require.Equal(t, int64(1), s.metrics.SuccessfulConnCount.Count())
+
+	// SNI provides tenant ID.
+	url = fmt.Sprintf("postgres://bob:builder@serverless-28.blah:%s/defaultdb?sslmode=require", port)
+	te.TestConnect(ctx, t, url, func(conn *pgx.Conn) {
+		require.Equal(t, int64(1), s.metrics.CurConnCount.Value())
+		require.NoError(t, runTestQuery(ctx, conn))
+	})
+
+	// SNI and database provide tenant IDs that match.
+	url = fmt.Sprintf(
+		"postgres://bob:builder@serverless-28.blah:%s/tenant-cluster-28.defaultdb?sslmode=require", port,
+	)
+	te.TestConnect(ctx, t, url, func(conn *pgx.Conn) {
+		require.Equal(t, int64(1), s.metrics.CurConnCount.Value())
+		require.NoError(t, runTestQuery(ctx, conn))
+	})
+
+	// SNI and database provide tenant IDs that don't match.
+	url = fmt.Sprintf(
+		"postgres://bob:builder@serverless-28.blah:%s/tenant-cluster-29.defaultdb?sslmode=require", port,
+	)
+	te.TestConnectErr(ctx, t, url, codeParamsRoutingFailed, "server error")
+
+	require.Equal(t, int64(3), s.metrics.SuccessfulConnCount.Count())
 	require.Equal(t, int64(2), s.metrics.AuthFailedCount.Count())
+	require.Equal(t, int64(3), s.metrics.RoutingErrCount.Count())
 }
 
 func TestProxyTLSConf(t *testing.T) {
@@ -1466,7 +1498,13 @@ func (te *tester) TestConnect(ctx context.Context, t *testing.T, url string, fn 
 	t.Helper()
 	te.setAuthenticated(false)
 	te.setErrToClient(nil)
-	conn, err := pgx.Connect(ctx, url)
+	connConfig, err := pgx.ParseConfig(url)
+	require.NoError(t, err)
+	if !strings.EqualFold(connConfig.Host, "127.0.0.1") {
+		connConfig.TLSConfig.ServerName = connConfig.Host
+		connConfig.Host = "127.0.0.1"
+	}
+	conn, err := pgx.ConnectConfig(ctx, connConfig)
 	require.NoError(t, err)
 	fn(conn)
 	require.NoError(t, conn.Close(ctx))
@@ -1487,6 +1525,10 @@ func (te *tester) TestConnectErr(
 
 	// Prevent pgx from tying to connect to the `::1` ipv6 address for localhost.
 	cfg.LookupFunc = func(ctx context.Context, s string) ([]string, error) { return []string{s}, nil }
+	if !strings.EqualFold(cfg.Host, "127.0.0.1") && cfg.TLSConfig != nil {
+		cfg.TLSConfig.ServerName = cfg.Host
+		cfg.Host = "127.0.0.1"
+	}
 	conn, err := pgx.ConnectConfig(ctx, cfg)
 	if err == nil {
 		_ = conn.Close(ctx)


### PR DESCRIPTION
Backport:
  * 1/1 commits from "ccl/sqlproxyccl: refactor FrontendAdmit return type" (#79475)
  * 1/1 commits from "ccl/sqlproxyccl: add server name indication (SNI) support" (#79477)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: Low risk, high reward changes to existing functionality