### PR TITLE
cli: add --advertise-http-addr flag

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -574,6 +574,33 @@ An IPv6 address can also be specified with the notation [...], for
 example [::1]:8080 or [fe80::f6f2:::]:8080.`,
 	}
 
+	HTTPAdvertiseAddr = FlagInfo{
+		Name: "advertise-http-addr",
+		Description: `
+The HTTP address/hostname and port to advertise to nodes in the cluster
+for reporting the DB Console address and proxying of HTTP connections.
+It must resolve and be routable from other nodes in the cluster for
+proxying to work in DB Console.
+<PRE>
+
+</PRE>
+If left unspecified, it defaults to the host setting of --advertise-addr
+and the port of --http-addr, which is 8080 by default. If advertise-addr
+is left unspecified, it defaults to the setting of http-addr. If the
+flag is unspecified as well as fallbacks, it defaults to the hostname as
+reported by the OS.
+<PRE>
+
+</PRE>
+An IPv6 address can also be specified with the notation [...], for
+example [::1]:26257 or [fe80::f6f2:::]:26257.
+<PRE>
+
+</PRE>
+The port number should be the same as in --http-addr unless port
+forwarding is set up on an intermediate firewall/router.`,
+	}
+
 	UnencryptedLocalhostHTTP = FlagInfo{
 		Name: "unencrypted-localhost-http",
 		Description: `

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -52,6 +52,7 @@ var serverAdvertiseAddr, serverAdvertisePort string
 var serverSQLAddr, serverSQLPort string
 var serverSQLAdvertiseAddr, serverSQLAdvertisePort string
 var serverHTTPAddr, serverHTTPPort string
+var serverHTTPAdvertiseAddr, serverHTTPAdvertisePort string
 var localityAdvertiseHosts localityList
 var startBackground bool
 var storeSpecs base.StoreSpecList
@@ -71,6 +72,12 @@ func initPreFlagsDefaults() {
 
 	serverHTTPAddr = ""
 	serverHTTPPort = base.DefaultHTTPPort
+
+	serverHTTPAdvertiseAddr = ""
+	// We do not set `base.DefaultHTTPPort` on the advertise flag because
+	// we want to override it with the `serverHTTPPort` if it's unset by
+	// the user.
+	serverHTTPAdvertisePort = ""
 
 	localityAdvertiseHosts = localityList{}
 
@@ -409,6 +416,7 @@ func init() {
 		varFlag(f, addrSetter{&serverSQLAddr, &serverSQLPort}, cliflags.ListenSQLAddr)
 		varFlag(f, addrSetter{&serverSQLAdvertiseAddr, &serverSQLAdvertisePort}, cliflags.SQLAdvertiseAddr)
 		varFlag(f, addrSetter{&serverHTTPAddr, &serverHTTPPort}, cliflags.ListenHTTPAddr)
+		varFlag(f, addrSetter{&serverHTTPAdvertiseAddr, &serverHTTPAdvertisePort}, cliflags.HTTPAdvertiseAddr)
 
 		// Certificates directory. Use a server-specific flag and value to ignore environment
 		// variables, but share the same default.
@@ -979,6 +987,7 @@ func init() {
 		// NB: this also gets PreRun treatment via extraServerFlagInit to populate BaseCfg.SQLAddr.
 		varFlag(f, addrSetter{&serverSQLAddr, &serverSQLPort}, cliflags.ListenSQLAddr)
 		varFlag(f, addrSetter{&serverHTTPAddr, &serverHTTPPort}, cliflags.ListenHTTPAddr)
+		varFlag(f, addrSetter{&serverHTTPAdvertiseAddr, &serverHTTPAdvertisePort}, cliflags.HTTPAdvertiseAddr)
 		varFlag(f, addrSetter{&serverAdvertiseAddr, &serverAdvertisePort}, cliflags.AdvertiseAddr)
 
 		varFlag(f, &serverCfg.Locality, cliflags.Locality)
@@ -1220,6 +1229,22 @@ func extraServerFlagInit(cmd *cobra.Command) error {
 		serverCfg.DisableTLSForHTTP = true
 	}
 	serverCfg.HTTPAddr = net.JoinHostPort(serverHTTPAddr, serverHTTPPort)
+
+	if serverHTTPAdvertiseAddr == "" {
+		if advSpecified {
+			serverHTTPAdvertiseAddr = serverAdvertiseAddr
+		} else {
+			serverHTTPAdvertiseAddr = serverHTTPAddr
+		}
+	}
+	if serverHTTPAdvertisePort == "" {
+		// We do not include the `if advSpecified` clause to mirror the
+		// logic above for `SQLAdvertiseAddr` which overrides the port from
+		// `serverAdvertisePort` because that port is *never* correct here,
+		// since it refers to SQL/gRPC connections.
+		serverHTTPAdvertisePort = serverHTTPPort
+	}
+	serverCfg.HTTPAdvertiseAddr = net.JoinHostPort(serverHTTPAdvertiseAddr, serverHTTPAdvertisePort)
 
 	// Fill the advertise port into the locality advertise addresses.
 	for i, a := range localityAdvertiseHosts {


### PR DESCRIPTION
Previously, the HTTP Advertise Address was derived from either the OS
hostname, the SQL advertise address, or the `--http-addr` flag.

This commit adds an explicit flag for setting this field in order to
provide control over it for scenarios where node to node proxying
requires hostnames different from the ones the HTTP server is listening
on.

Resolves https://github.com/cockroachdb/cockroach/issues/79164

Release note (cli change): A new flag `--advertise-http-addr` is
available for setting the HTTP advertise address explicitly. Previously,
this address was derived from the OS hostname, the `--advertise-addr`
and the `--http-addr` flags in that order. The new logic will override
the HTTP advertise host with the host from `--advertise-addr` first if
set, and then the host from `--http-addr`. The port will *never* inherit
from `--advertise-host` and only from `--http-addr`, which is 8080 by
default. The HTTP advertise address is used to report the DB Console
address to access on a cluster and by nodes to proxy HTTP connections as
described in https://github.com/cockroachdb/cockroach/issues/73285. It may be necessary to set this flag in order for
that feature to work correctly in some deployments.