### PR TITLE
roachtest: add costfuzz test

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "cluster_init.go",
         "connection_latency.go",
         "copy.go",
+        "costfuzz.go",
         "decommission.go",
         "decommission_self.go",
         "disk_full.go",

--- a/pkg/cmd/roachtest/tests/costfuzz.go
+++ b/pkg/cmd/roachtest/tests/costfuzz.go
@@ -1,0 +1,261 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/errors"
+)
+
+func registerCostFuzz(r registry.Registry) {
+	r.Add(registry.TestSpec{
+		Name:            "costfuzz",
+		Owner:           registry.OwnerSQLQueries,
+		Timeout:         time.Hour * 1,
+		RequiresLicense: true,
+		Tags:            nil,
+		Cluster:         r.MakeClusterSpec(1),
+		Run:             runCostFuzz,
+	})
+}
+
+func runCostFuzz(ctx context.Context, t test.Test, c cluster.Cluster) {
+	roundTimeout := 10 * time.Minute
+	// Run 10 minute iterations of costfuzz in a loop for about the entire test,
+	// giving 5 minutes at the end to allow the test to shut down cleanly.
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, t.Spec().(*registry.TestSpec).Timeout-5*time.Minute)
+	defer cancel()
+	done := ctx.Done()
+	shouldExit := func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}
+
+	c.Put(ctx, t.Cockroach(), "./cockroach")
+	if err := c.PutLibraries(ctx, "./lib"); err != nil {
+		t.Fatalf("could not initialize libraries: %v", err)
+	}
+
+	for i := 0; ; i++ {
+		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
+		if shouldExit() {
+			return
+		}
+
+		runOneRoundCostFuzz(ctx, i, roundTimeout, t, c)
+		// If this iteration of costfuzz was interrupted because the timeout of
+		// ctx has been reached, we want to cleanly exit from the test, without
+		// wiping out the cluster (if we tried that, we'd get an error because
+		// ctx is canceled).
+		if shouldExit() {
+			return
+		}
+		c.Stop(ctx, t.L(), option.DefaultStopOpts())
+		c.Wipe(ctx)
+	}
+}
+
+// runOneRoundCostFuzz creates a random schema, inserts random data, and then
+// executes costfuzz queries until the roundTimeout is reached.
+func runOneRoundCostFuzz(
+	ctx context.Context, iter int, roundTimeout time.Duration, t test.Test, c cluster.Cluster,
+) {
+	// Set up a statement logger for easy reproduction. We only
+	// want to log successful statements and statements that
+	// produced a final error or panic.
+	costFuzzLogPath := filepath.Join(t.ArtifactsDir(), fmt.Sprintf("costfuzz%03d.log", iter))
+	costFuzzLog, err := os.Create(costFuzzLogPath)
+	if err != nil {
+		t.Fatalf("could not create costfuzz.log: %v", err)
+	}
+	defer costFuzzLog.Close()
+	logStmt := func(stmt string) {
+		stmt = strings.TrimSpace(stmt)
+		if stmt == "" {
+			return
+		}
+		fmt.Fprint(costFuzzLog, stmt)
+		if !strings.HasSuffix(stmt, ";") {
+			fmt.Fprint(costFuzzLog, ";")
+		}
+		fmt.Fprint(costFuzzLog, "\n\n")
+	}
+
+	conn := c.Conn(ctx, t.L(), 1)
+
+	rnd, seed := randutil.NewTestRand()
+	t.L().Printf("seed: %d", seed)
+
+	setup := sqlsmith.Setups[sqlsmith.RandTableSetupName](rnd)
+
+	t.Status("executing setup")
+	t.L().Printf("setup:\n%s", strings.Join(setup, "\n"))
+	for _, stmt := range setup {
+		if _, err := conn.Exec(stmt); err != nil {
+			t.Fatal(err)
+		} else {
+			logStmt(stmt)
+		}
+	}
+
+	setStmtTimeout := fmt.Sprintf("SET statement_timeout='%s';", statementTimeout.String())
+	t.Status("setting statement_timeout")
+	t.L().Printf("statement timeout:\n%s", setStmtTimeout)
+	if _, err := conn.Exec(setStmtTimeout); err != nil {
+		t.Fatal(err)
+	}
+	logStmt(setStmtTimeout)
+
+	// Initialize a smither that generates only INSERT, UPDATE, and DELETE
+	// statements with the MutationsOnly option.
+	mutatingSmither, err := sqlsmith.NewSmither(conn, rnd, sqlsmith.MutationsOnly())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mutatingSmither.Close()
+
+	// Initialize a smither that generates only deterministic SELECT statements.
+	smither, err := sqlsmith.NewSmither(conn, rnd,
+		sqlsmith.DisableMutations(), sqlsmith.DisableImpureFuncs(), sqlsmith.DisableLimits(),
+		sqlsmith.SetComplexity(.3),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer smither.Close()
+
+	t.Status("running costfuzz")
+	until := time.After(roundTimeout)
+	done := ctx.Done()
+	for i := 1; ; i++ {
+		select {
+		case <-until:
+			return
+		case <-done:
+			return
+		default:
+		}
+
+		if i%1000 == 0 {
+			t.Status("running costfuzz: ", i, " statements completed")
+		}
+
+		// Run 1000 mutations first so that the tables have rows. Run a mutation for
+		// a tenth of the iterations after that to continually change the state of
+		// the database.
+		if i < 1000 || i%10 == 0 {
+			runMutationStatement(conn, mutatingSmither, logStmt)
+			continue
+		}
+
+		if err := runCostFuzzQuery(conn, smither, rnd, logStmt); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// runCostFuzzQuery executes the same query two times, once with normal costs
+// and once with randomly perturbed costs. If the results of the two executions
+// are not equal an error is returned.
+func runCostFuzzQuery(
+	conn *gosql.DB, smither *sqlsmith.Smither, rnd *rand.Rand, logStmt func(string),
+) error {
+	// Ignore panics from Generate.
+	defer func() {
+		if r := recover(); r != nil {
+			return
+		}
+	}()
+
+	stmt := smither.Generate()
+
+	// First, run the statement without cost perturbation.
+	rows, err := conn.Query(stmt)
+	if err != nil {
+		// Skip statements that fail with an error.
+		//nolint:returnerrcheck
+		return nil
+	}
+	defer rows.Close()
+	unperturbedRows, err := sqlutils.RowsToStrMatrix(rows)
+	if err != nil {
+		// Skip statements whose results cannot be printed.
+		//nolint:returnerrcheck
+		return nil
+	}
+
+	seedStmt := fmt.Sprintf("SET testing_optimizer_random_cost_seed = %d", rnd.Int63())
+	if _, err := conn.Exec(seedStmt); err != nil {
+		logStmt(stmt)
+		logStmt(seedStmt)
+		return errors.Wrap(err, "failed to perturb costs")
+	}
+
+	// Then, rerun the statement with cost perturbation.
+	rows2, err := conn.Query(stmt)
+	if err != nil {
+		logStmt(seedStmt)
+		logStmt(stmt)
+		return errors.Wrap(err, "error while running perturbed statement")
+	}
+	defer rows2.Close()
+	perturbedRows, err := sqlutils.RowsToStrMatrix(rows2)
+	if err != nil {
+		logStmt(stmt)
+		logStmt(seedStmt)
+		logStmt(stmt)
+		return errors.Wrap(err, "error while printing perturbed statement results")
+	}
+	if diff := unsortedMatricesDiff(unperturbedRows, perturbedRows); diff != "" {
+		// We have a mismatch in the perturbed vs non-perturbed query outputs.
+		// Output the real plan and the perturbed plan, along with the seed, so
+		// that the perturbed query is reproducible.
+		logStmt(stmt)
+		logStmt(seedStmt)
+		logStmt(stmt)
+		return errors.Newf(
+			"expected unperturbed and perturbed results to be equal\n%s\nsql: %s",
+			diff, stmt,
+		)
+	}
+
+	// Finally, disable cost perturbation for the next statement.
+	resetSeedStmt := "RESET testing_optimizer_random_cost_seed"
+	if _, err := conn.Exec(resetSeedStmt); err != nil {
+		logStmt(stmt)
+		logStmt(seedStmt)
+		logStmt(stmt)
+		logStmt(resetSeedStmt)
+		return errors.Wrap(err, "failed to disable cost perturbation")
+	}
+	return nil
+}

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -31,6 +31,7 @@ func RegisterTests(r registry.Registry) {
 	registerClockMonotonicTests(r)
 	registerConnectionLatencyTest(r)
 	registerCopy(r)
+	registerCostFuzz(r)
 	registerDecommission(r)
 	registerDiskFull(r)
 	RegisterDiskStalledDetection(r)

--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -372,7 +372,7 @@ func makeFunc(s *Smither, ctx Context, typ *types.T, refs colRefs) (tree.TypedEx
 	if class == tree.WindowClass && s.d6() != 1 {
 		class = tree.NormalClass
 	}
-	fns := functions[class][typ.Oid()]
+	fns := s.functions[class][typ.Oid()]
 	if len(fns) == 0 {
 		return nil, false
 	}

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/lib/pq/oid"
 )
 
 // sqlsmith-go
@@ -68,6 +69,7 @@ type Smither struct {
 	nameCounts       map[string]int
 	activeSavepoints []string
 	types            *typeInfo
+	functions        map[tree.FunctionClass]map[oid.Oid][]function
 
 	stmtWeights, alterWeights          []statementWeight
 	stmtSampler, alterSampler          *statementSampler
@@ -82,6 +84,7 @@ type Smither struct {
 	disableImpureFns   bool
 	disableLimits      bool
 	disableWindowFuncs bool
+	disableImpureFuncs bool
 	simpleDatums       bool
 	avoidConsts        bool
 	outputSort         bool
@@ -122,6 +125,7 @@ func NewSmither(db *gosql.DB, rnd *rand.Rand, opts ...SmitherOption) (*Smither, 
 	for _, opt := range opts {
 		opt.Apply(s)
 	}
+	s.functions = functions(s)
 	s.stmtSampler = newWeightedStatementSampler(s.stmtWeights, rnd.Int63())
 	s.alterSampler = newWeightedStatementSampler(s.alterWeights, rnd.Int63())
 	s.tableExprSampler = newWeightedTableExprSampler(s.tableExprWeights, rnd.Int63())
@@ -238,6 +242,24 @@ var DisableMutations = simpleOption("disable mutations", func(s *Smither) {
 	s.stmtWeights = nonMutatingStatements
 	s.tableExprWeights = nonMutatingTableExprs
 })
+
+// DisableImpureFuncs causes the Smither to not emit statements that contain
+// impure builtins (aka builtins that don't always return the same result).
+var DisableImpureFuncs = simpleOption("disable impure funcs", func(s *Smither) {
+	s.disableImpureFuncs = true
+})
+
+// SetComplexity configures the Smither's complexity, in other words the
+// likelihood that at any given node the Smither will recurse and create a
+// deeper query true. The default is .2.
+func SetComplexity(complexity float64) SmitherOption {
+	return option{
+		name: "set complexity (likelihood of making a deeper random tree)",
+		apply: func(s *Smither) {
+			s.complexity = complexity
+		},
+	}
+}
 
 // DisableDDLs causes the Smither to not emit statements that change table
 // schema (CREATE, DROP, ALTER, etc.)

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3235,6 +3235,10 @@ func (m *sessionDataMutator) SetShowPrimaryKeyConstraintOnNotVisibleColumns(val 
 	m.data.ShowPrimaryKeyConstraintOnNotVisibleColumns = val
 }
 
+func (m *sessionDataMutator) SetTestingOptimizerRandomCostSeed(val int64) {
+	m.data.TestingOptimizerRandomCostSeed = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4814,6 +4814,7 @@ statement_timeout                                     0
 stub_catalog_tables                                   on
 synchronize_seqscans                                  on
 synchronous_commit                                    on
+testing_optimizer_random_cost_seed                    0
 testing_vectorize_inject_panics                       off
 timezone                                              UTC
 tracing                                               off

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4203,6 +4203,7 @@ statement_timeout                                     0                   NULL  
 stub_catalog_tables                                   on                  NULL      NULL        NULL        string
 synchronize_seqscans                                  on                  NULL      NULL        NULL        string
 synchronous_commit                                    on                  NULL      NULL        NULL        string
+testing_optimizer_random_cost_seed                    0                   NULL      NULL        NULL        string
 testing_vectorize_inject_panics                       off                 NULL      NULL        NULL        string
 timezone                                              UTC                 NULL      NULL        NULL        string
 tracing                                               off                 NULL      NULL        NULL        string
@@ -4324,6 +4325,7 @@ statement_timeout                                     0                   NULL  
 stub_catalog_tables                                   on                  NULL  user     NULL      on                  on
 synchronize_seqscans                                  on                  NULL  user     NULL      on                  on
 synchronous_commit                                    on                  NULL  user     NULL      on                  on
+testing_optimizer_random_cost_seed                    0                   NULL  user     NULL      0                   0
 testing_vectorize_inject_panics                       off                 NULL  user     NULL      off                 off
 timezone                                              UTC                 NULL  user     NULL      UTC                 UTC
 tracing                                               off                 NULL  user     NULL      off                 off
@@ -4443,6 +4445,7 @@ statement_timeout                                     NULL    NULL     NULL     
 stub_catalog_tables                                   NULL    NULL     NULL     NULL        NULL
 synchronize_seqscans                                  NULL    NULL     NULL     NULL        NULL
 synchronous_commit                                    NULL    NULL     NULL     NULL        NULL
+testing_optimizer_random_cost_seed                    NULL    NULL     NULL     NULL        NULL
 testing_vectorize_inject_panics                       NULL    NULL     NULL     NULL        NULL
 timezone                                              NULL    NULL     NULL     NULL        NULL
 tracing                                               NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -122,6 +122,7 @@ statement_timeout                                     0
 stub_catalog_tables                                   on
 synchronize_seqscans                                  on
 synchronous_commit                                    on
+testing_optimizer_random_cost_seed                    0
 testing_vectorize_inject_panics                       off
 timezone                                              UTC
 tracing                                               off

--- a/pkg/sql/opt/xform/BUILD.bazel
+++ b/pkg/sql/opt/xform/BUILD.bazel
@@ -50,6 +50,7 @@ go_library(
         "//pkg/util/buildutil",
         "//pkg/util/errorutil",
         "//pkg/util/log",
+        "//pkg/util/randutil",
         "//pkg/util/treeprinter",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -254,6 +254,10 @@ message LocalOnlySessionData {
   // CONSTRAINTS and pg_catalog.pg_constraint will include primary key
   // constraints that only include hidden columns.
   bool show_primary_key_constraint_on_not_visible_columns = 69;
+  // TestingOptimizerRandomCostSeed is non-zero when the coster should randomly
+  // perturb costs with an rng seeded to the given integer. This should only be
+  // used in test scenarios and is very much a non-production setting.
+  int64 testing_optimizer_random_cost_seed = 70;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2089,6 +2089,25 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalTrue,
 	},
+
+	// CockroachDB extension.
+	`testing_optimizer_random_cost_seed`: {
+		GetStringVal: makeIntGetStringValFn(`testing_optimizer_random_cost_seed`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			i, err := strconv.ParseInt(s, 10, 64)
+			if err != nil {
+				return err
+			}
+			m.SetTestingOptimizerRandomCostSeed(i)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return strconv.FormatInt(evalCtx.SessionData().TestingOptimizerRandomCostSeed, 10), nil
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return strconv.FormatInt(0, 10)
+		},
+	},
 }
 
 const compatErrMsg = "this parameter is currently recognized only for compatibility and has no effect in CockroachDB."


### PR DESCRIPTION
Add a new roachtest that leverages the optimizer's cost perturbation
mode and SQLSmith statement generation. The test repeatedly creates a
random statement, runs it as normal, and then runs it again with
perturbed optimizer costs. If the results of the two executions are not
identical, it likely indicates a bug in the optimizer or execution
engine.

This test is similar in structure to the TLP test, and much of the code
is copied from the TLP test (which was in turn copied from the SQLSmith
tests).

Release note: None

Co-authored-by: Jordan Lewis <jordanthelewis@gmail.com>