### PR TITLE
cloud/amazon: retry errors during s3 bucket region lookup

### DIFF
--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -16,6 +16,7 @@ import (
 	"math"
 	"math/rand"
 	"net/url"
+	"os"
 	"reflect"
 	"regexp"
 	"sort"
@@ -40,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -751,4 +753,21 @@ func checkChangefeedFailedLogs(t *testing.T, startTime int64) []eventpb.Changefe
 	}
 
 	return matchingEntries
+}
+
+func checkS3Credentials(t *testing.T) (bucket string, accessKey string, secretKey string) {
+	accessKey = os.Getenv("AWS_ACCESS_KEY_ID")
+	if accessKey == "" {
+		skip.IgnoreLint(t, "AWS_ACCESS_KEY_ID env var must be set")
+	}
+	secretKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
+	if secretKey == "" {
+		skip.IgnoreLint(t, "AWS_SECRET_ACCESS_KEY env var must be set")
+	}
+	bucket = os.Getenv("AWS_S3_BUCKET")
+	if bucket == "" {
+		skip.IgnoreLint(t, "AWS_S3_BUCKET env var must be set")
+	}
+
+	return bucket, accessKey, secretKey
 }

--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -344,7 +344,7 @@ func newClient(
 	if region == "" {
 		if err := cloud.DelayedRetry(ctx, "s3manager.GetBucketRegion", s3ErrDelay, func() error {
 			region, err = s3manager.GetBucketRegion(ctx, sess, conf.bucket, "us-east-1")
-			return nil
+			return err
 		}); err != nil {
 			return s3Client{}, "", errors.Wrap(err, "could not find s3 bucket's region")
 		}

--- a/pkg/cloud/amazon/s3_storage_test.go
+++ b/pkg/cloud/amazon/s3_storage_test.go
@@ -323,3 +323,21 @@ func TestAntagonisticS3Read(t *testing.T) {
 
 	cloudtestutils.CheckAntagonisticRead(t, conf, testSettings)
 }
+
+func TestNewClientErrorsOnBucketRegion(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	_, err := session.NewSession()
+	if err != nil {
+		skip.IgnoreLint(t, "No AWS credentials")
+	}
+
+	testSettings := cluster.MakeTestingClusterSettings()
+	ctx := context.Background()
+	cfg := s3ClientConfig{
+		bucket: "bucket-does-not-exist-v1i3m",
+		auth:   cloud.AuthParamImplicit,
+	}
+	_, _, err = newClient(ctx, cfg, testSettings)
+	require.Regexp(t, "could not find s3 bucket's region", err)
+}

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -431,6 +431,7 @@ func TestLint(t *testing.T) {
 					":!ccl/backupccl/backup_cloud_test.go",
 					// KMS requires AWS credentials from environment variables.
 					":!ccl/backupccl/backup_test.go",
+					":!ccl/changefeedccl/helpers_test.go",
 					":!cloud",
 					":!ccl/workloadccl/fixture_test.go",
 					":!internal/reporoot/reporoot.go",


### PR DESCRIPTION
Currently errors encountered during s3 bucket region lookup is swallowed. If
there is an error during this step then a client is created with an empty
region, which will then issue invalid requests with an empty region. This
patch fixes the bug.

Fixes #79435

Release note: None