### PR TITLE
ccl/sqlproxyccl: support destination address in TransferConnection API

### DIFF
--- a/pkg/ccl/sqlproxyccl/balancer/balancer.go
+++ b/pkg/ccl/sqlproxyccl/balancer/balancer.go
@@ -48,8 +48,6 @@ const (
 	// an unsafe transfer point). Note that each transfer attempt currently has
 	// a timeout of 15 seconds, so retrying up to 3 times may hold onto
 	// processSem up to 45 seconds for each rebalance request.
-	//
-	// TODO(jaylim-crl): Reduce transfer timeout to 5 seconds.
 	maxTransferAttempts = 3
 )
 
@@ -238,9 +236,7 @@ func (b *Balancer) processQueue(ctx context.Context) {
 
 			// Each request is retried up to maxTransferAttempts.
 			for i := 0; i < maxTransferAttempts && ctx.Err() == nil; i++ {
-				// TODO(jaylim-crl): Once the TransferConnection API accepts a
-				// destination, we could update this code, and pass along dst.
-				err := req.conn.TransferConnection( /* req.dst */ )
+				err := req.conn.TransferConnection(req.dst)
 				if err == nil || errors.Is(err, context.Canceled) ||
 					req.dst == req.conn.ServerRemoteAddr() {
 					break

--- a/pkg/ccl/sqlproxyccl/balancer/balancer_test.go
+++ b/pkg/ccl/sqlproxyccl/balancer/balancer_test.go
@@ -86,7 +86,7 @@ func TestRebalancer_processQueue(t *testing.T) {
 	syncReq := &rebalanceRequest{
 		createdAt: timeSource.Now(),
 		conn: &testBalancerConnHandle{
-			onTransferConnection: func() error {
+			onTransferConnection: func(dstAddr string) error {
 				syncCh <- struct{}{}
 				return nil
 			},
@@ -99,7 +99,8 @@ func TestRebalancer_processQueue(t *testing.T) {
 		req := &rebalanceRequest{
 			createdAt: timeSource.Now(),
 			conn: &testBalancerConnHandle{
-				onTransferConnection: func() error {
+				onTransferConnection: func(dstAddr string) error {
+					require.Equal(t, "foo", dstAddr)
 					count++
 					require.Equal(t, int64(1), b.metrics.rebalanceReqRunning.Value())
 					return errors.New("cannot transfer")
@@ -121,7 +122,8 @@ func TestRebalancer_processQueue(t *testing.T) {
 	t.Run("conn_was_transferred_by_other", func(t *testing.T) {
 		count := 0
 		conn := &testBalancerConnHandle{}
-		conn.onTransferConnection = func() error {
+		conn.onTransferConnection = func(dstAddr string) error {
+			require.Equal(t, "foo", dstAddr)
 			count++
 			// Simulate that connection was transferred by someone else.
 			conn.remoteAddr = "foo"
@@ -147,7 +149,8 @@ func TestRebalancer_processQueue(t *testing.T) {
 	t.Run("conn_was_transferred", func(t *testing.T) {
 		count := 0
 		conn := &testBalancerConnHandle{}
-		conn.onTransferConnection = func() error {
+		conn.onTransferConnection = func(dstAddr string) error {
+			require.Equal(t, "foo", dstAddr)
 			count++
 			conn.remoteAddr = "foo"
 			require.Equal(t, int64(1), b.metrics.rebalanceReqRunning.Value())
@@ -172,7 +175,8 @@ func TestRebalancer_processQueue(t *testing.T) {
 	t.Run("conn_was_closed", func(t *testing.T) {
 		count := 0
 		conn := &testBalancerConnHandle{}
-		conn.onTransferConnection = func() error {
+		conn.onTransferConnection = func(dstAddr string) error {
+			require.Equal(t, "foo", dstAddr)
 			count++
 			require.Equal(t, int64(1), b.metrics.rebalanceReqRunning.Value())
 			return context.Canceled
@@ -216,7 +220,9 @@ func TestRebalancer_processQueue(t *testing.T) {
 			req := &rebalanceRequest{
 				createdAt: timeSource.Now(),
 				conn: &testBalancerConnHandle{
-					onTransferConnection: func() error {
+					onTransferConnection: func(dstAddr string) error {
+						require.Equal(t, "foo", dstAddr)
+
 						// Block until all requests are enqueued.
 						<-waitCh
 
@@ -603,14 +609,14 @@ func TestRebalancerQueueBlocking(t *testing.T) {
 type testBalancerConnHandle struct {
 	ConnectionHandle
 	remoteAddr           string
-	onTransferConnection func() error
+	onTransferConnection func(dstAddr string) error
 }
 
 var _ ConnectionHandle = &testBalancerConnHandle{}
 
 // TransferConnection implements the ConnectionHandle interface.
-func (h *testBalancerConnHandle) TransferConnection() error {
-	return h.onTransferConnection()
+func (h *testBalancerConnHandle) TransferConnection(dstAddr string) error {
+	return h.onTransferConnection(dstAddr)
 }
 
 // ServerRemoteAddr implements the ConnectionHandle interface.

--- a/pkg/ccl/sqlproxyccl/balancer/conn.go
+++ b/pkg/ccl/sqlproxyccl/balancer/conn.go
@@ -20,9 +20,13 @@ type ConnectionHandle interface {
 	Close()
 
 	// TransferConnection performs a connection migration on the connection
-	// handle. Invoking this blocks until the connection migration process has
-	// been completed.
-	TransferConnection() error
+	// handle to the given SQL pod at the dstAddr address. Invoking this blocks
+	// until the connection migration process has been completed.
+	//
+	// NOTE: dstAddr, if not empty, has to be a valid RUNNING address for the
+	// tenant associated with the connection handle, or else an error will be
+	// returned.
+	TransferConnection(dstAddr string) error
 
 	// ServerRemoteAddr returns the remote address of the connection between
 	// the proxy and the server, which is basically the SQL pod's address

--- a/pkg/ccl/sqlproxyccl/balancer/conn_tracker_test.go
+++ b/pkg/ccl/sqlproxyccl/balancer/conn_tracker_test.go
@@ -186,7 +186,7 @@ func (h *testTrackerConnHandle) ServerRemoteAddr() string {
 }
 
 // TransferConnection implements the ConnectionHandle interface.
-func (h *testTrackerConnHandle) TransferConnection() error {
+func (h *testTrackerConnHandle) TransferConnection(dstAddr string) error {
 	if h.ctx != nil && h.ctx.Err() != nil {
 		return h.ctx.Err()
 	}

--- a/pkg/ccl/sqlproxyccl/conn_migration.go
+++ b/pkg/ccl/sqlproxyccl/conn_migration.go
@@ -35,7 +35,7 @@ import (
 var defaultTransferTimeout = 15 * time.Second
 
 // Used in testing.
-var transferConnectionConnectorTestHook func(context.Context, string) (net.Conn, error) = nil
+var transferConnectionConnectorTestHook func(context.Context, string, string) (net.Conn, error) = nil
 
 type transferContext struct {
 	context.Context
@@ -105,12 +105,15 @@ func (f *forwarder) tryBeginTransfer() (started bool, cleanupFn func()) {
 
 var errTransferCannotStart = errors.New("transfer cannot be started")
 
-// TransferConnection attempts a best-effort connection migration to an
-// available SQL pod based on the load-balancing algorithm. If a transfer has
-// already been started, or the forwarder has been closed, this returns an
-// error. This is a best-effort process because there could be a situation
-// where the forwarder is not in a state that is eligible for a connection
-// migration.
+// TransferConnection attempts a best-effort connection migration to the SQL pod
+// with dstAddr as address. dstAddr, if not empty, has to be an address of a
+// RUNNING pod for the associated tenant. On the other hand, if the connection
+// is already connected to dstAddr, TransferConnection will succeed implicitly.
+//
+// If a transfer has already been started, or the forwarder has been closed,
+// this returns an error. This is a best-effort process because there could be a
+// situation where the forwarder is not in a state that is eligible for a
+// connection migration.
 //
 // NOTE: If the forwarder hasn't been closed, runTransfer has an invariant
 // where the processors have been resumed prior to calling this method. When
@@ -118,17 +121,17 @@ var errTransferCannotStart = errors.New("transfer cannot be started")
 // re-resumed, or the forwarder will be closed (in the case of a non-recoverable
 // error).
 //
-// TODO(jaylim-crl): It would be nice to introduce transfer policies in the
-// future. That way, we could either transfer to another random SQL pod, or to
-// a specific SQL pod. If we do that, TransferConnection would take in some kind
-// of policy parameter(s).
-//
 // TransferConnection implements the balancer.ConnectionHandle interface.
-func (f *forwarder) TransferConnection() (retErr error) {
+func (f *forwarder) TransferConnection(dstAddr string) (retErr error) {
 	// A previous non-recoverable transfer would have closed the forwarder, so
 	// return right away.
 	if f.ctx.Err() != nil {
 		return f.ctx.Err()
+	}
+
+	// Transfer succeeded implicitly since the connection is already at dstAddr.
+	if f.ServerRemoteAddr() == dstAddr {
+		return nil
 	}
 
 	started, cleanupFn := f.tryBeginTransfer()
@@ -207,7 +210,7 @@ func (f *forwarder) TransferConnection() (retErr error) {
 
 	// Transfer the connection.
 	clientConn, serverConn := f.getConns()
-	newServerConn, err := transferConnection(ctx, f.connector, f.metrics, clientConn, serverConn)
+	newServerConn, err := transferConnection(ctx, f.connector, f.metrics, clientConn, serverConn, dstAddr)
 	if err != nil {
 		return errors.Wrap(err, "transferring connection")
 	}
@@ -224,7 +227,9 @@ func transferConnection(
 	ctx *transferContext,
 	connector *connector,
 	metrics *metrics,
-	clientConn, serverConn *interceptor.PGConn,
+	clientConn *interceptor.PGConn,
+	serverConn *interceptor.PGConn,
+	dstAddr string,
 ) (_ *interceptor.PGConn, retErr error) {
 	ctx.markRecoverable(true)
 
@@ -262,19 +267,12 @@ func transferConnection(
 		return nil, errors.Newf("%s", transferErr)
 	}
 
-	// Connect to a new SQL pod.
-	//
-	// TODO(jaylim-crl): There is a possibility where the same pod will get
-	// selected. Some ideas to solve this: pass in the remote address of
-	// serverConn to avoid choosing that pod, or maybe a filter callback?
-	// We can also consider adding a target pod as an argument to
-	// TransferConnection. That way a central component gets to choose where the
-	// connections go.
+	// Connect to the SQL pod at dstAddr.
 	connectFn := connector.OpenTenantConnWithToken
 	if transferConnectionConnectorTestHook != nil {
 		connectFn = transferConnectionConnectorTestHook
 	}
-	netConn, err := connectFn(ctx, revivalToken)
+	netConn, err := connectFn(ctx, revivalToken, dstAddr)
 	if err != nil {
 		return nil, errors.Wrap(err, "opening connection")
 	}

--- a/pkg/ccl/sqlproxyccl/conn_migration_test.go
+++ b/pkg/ccl/sqlproxyccl/conn_migration_test.go
@@ -114,7 +114,7 @@ func TestTransferConnection(t *testing.T) {
 		ctx, cancel := newTransferContext(context.Background())
 		cancel()
 
-		conn, err := transferConnection(ctx, nil, nil, nil, nil)
+		conn, err := transferConnection(ctx, nil, nil, nil, nil, "")
 		require.EqualError(t, err, context.Canceled.Error())
 		require.Nil(t, conn)
 		require.True(t, ctx.isRecoverable())
@@ -138,6 +138,7 @@ func TestTransferConnection(t *testing.T) {
 			nil,
 			interceptor.NewPGConn(p1),
 			interceptor.NewPGConn(p2),
+			"dst-addr",
 		)
 		require.Regexp(t, "foo", err)
 		require.Nil(t, conn)
@@ -178,6 +179,7 @@ func TestTransferConnection(t *testing.T) {
 			nil,
 			interceptor.NewPGConn(p1),
 			interceptor.NewPGConn(p2),
+			"dst-addr",
 		)
 		require.Regexp(t, "foobar", err)
 		require.Nil(t, conn)
@@ -218,6 +220,7 @@ func TestTransferConnection(t *testing.T) {
 			nil,
 			interceptor.NewPGConn(p1),
 			interceptor.NewPGConn(p2),
+			"dst-addr",
 		)
 		require.Regexp(t, "foobaz", err)
 		require.Nil(t, conn)
@@ -256,9 +259,11 @@ func TestTransferConnection(t *testing.T) {
 			func(
 				tCtx context.Context,
 				token string,
+				dstAddr string,
 			) (net.Conn, error) {
 				require.Equal(t, ctx, tCtx)
 				require.Equal(t, "token", token)
+				require.Equal(t, "dst-addr", dstAddr)
 				return nil, errors.New("foobarbaz")
 			},
 		)()
@@ -269,6 +274,7 @@ func TestTransferConnection(t *testing.T) {
 			nil,
 			interceptor.NewPGConn(p1),
 			interceptor.NewPGConn(p2),
+			"dst-addr",
 		)
 		require.Regexp(t, "foobarbaz", err)
 		require.Nil(t, conn)
@@ -310,9 +316,11 @@ func TestTransferConnection(t *testing.T) {
 			func(
 				tCtx context.Context,
 				token string,
+				dstAddr string,
 			) (net.Conn, error) {
 				require.Equal(t, ctx, tCtx)
 				require.Equal(t, "token", token)
+				require.Equal(t, "dst-addr", dstAddr)
 				return netConn, nil
 			},
 		)()
@@ -336,6 +344,7 @@ func TestTransferConnection(t *testing.T) {
 			nil,
 			interceptor.NewPGConn(p1),
 			interceptor.NewPGConn(p2),
+			"dst-addr",
 		)
 		require.Regexp(t, "foobar", err)
 		require.Nil(t, conn)
@@ -381,9 +390,11 @@ func TestTransferConnection(t *testing.T) {
 			func(
 				tCtx context.Context,
 				token string,
+				dstAddr string,
 			) (net.Conn, error) {
 				require.Equal(t, ctx, tCtx)
 				require.Equal(t, "token", token)
+				require.Equal(t, "dst-addr", dstAddr)
 				return netConn, nil
 			},
 		)()
@@ -407,6 +418,7 @@ func TestTransferConnection(t *testing.T) {
 			nil,
 			interceptor.NewPGConn(p1),
 			interceptor.NewPGConn(p2),
+			"dst-addr",
 		)
 		require.NoError(t, err)
 		require.NotNil(t, conn)


### PR DESCRIPTION
Replaces #78593.

This commit modifies the TransferConnection API on the forwarder to take in a
destination address. If non-empty, the destination address has to point to a
RUNNING pod of the associated tenant, or else the transfer process will fail.
If an empty destination address was used, the existing pod selection algorithm
will be used instead. This would allow us to move connections to specific pods
during the rebalancing process.

Release note: None