### PR TITLE
cli: mark the `--multitenant` flag as hidden

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -849,7 +849,12 @@ func init() {
 				"For details, see: "+build.MakeIssueURL(53404))
 
 		boolFlag(f, &demoCtx.DisableLicenseAcquisition, cliflags.DemoNoLicense)
+
 		boolFlag(f, &demoCtx.Multitenant, cliflags.DemoMultitenant)
+		// TODO(knz): Currently the multitenant UX for 'demo' is not
+		// satisfying for end-users. Let's not advertise it too much.
+		_ = f.MarkHidden(cliflags.DemoMultitenant.Name)
+
 		boolFlag(f, &demoCtx.SimulateLatency, cliflags.Global)
 		// The --empty flag is only valid for the top level demo command,
 		// so we use the regular flag set.


### PR DESCRIPTION
As discussed with the docs team: we don't expect end-users to use
the `--multitenant` flag in this cycle and we'd rather keep it
undocumented.  This commit hides it from the output of `--help`.

Release note: None