### PR TITLE
sql: re-enable public schema migration test

### DIFF
--- a/pkg/migration/migrations/public_schema_migration_external_test.go
+++ b/pkg/migration/migrations/public_schema_migration_external_test.go
@@ -229,17 +229,16 @@ SELECT "parentSchemaID" FROM system.namespace WHERE name = $1
 	}
 }
 
-func TestPublicSchemaMigration500Tables(t *testing.T) {
-	skip.WithIssue(t, 78947)
+func TestPublicSchemaMigration250Tables(t *testing.T) {
 	skip.UnderRace(t, "takes >1min under race")
+	skip.UnderStress(t, "slow under stress")
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
-	publicSchemaMigrationTest(t, ctx, 500)
+	publicSchemaMigrationTest(t, ctx, 250)
 }
 
 func TestPublicSchemaMigration10Tables(t *testing.T) {
-	skip.WithIssue(t, 78947)
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 


### PR DESCRIPTION
Release note: None

Fixes https://github.com/cockroachdb/cockroach/issues/78947

I couldn't reproduce this with 250 tables under stress for 6h.

I ran for 500 tables as well but it took too long for test completions under stress to find the error.

For 250 tables:
```
4177 runs so far, 0 failures, over 5h58m45s
4177 runs so far, 0 failures, over 5h58m50s
4179 runs so far, 0 failures, over 5h58m55s
4179 runs so far, 0 failures, over 5h59m0s
4179 runs so far, 0 failures, over 5h59m5s
4180 runs so far, 0 failures, over 5h59m10s
4180 runs so far, 0 failures, over 5h59m15s
4180 runs so far, 0 failures, over 5h59m20s
4181 runs so far, 0 failures, over 5h59m25s
4182 runs so far, 0 failures, over 5h59m30s
4183 runs so far, 0 failures, over 5h59m35s
4183 runs so far, 0 failures, over 5h59m40s
4183 runs so far, 0 failures, over 5h59m45s
4183 runs so far, 0 failures, over 5h59m50s
4184 runs so far, 0 failures, over 5h59m55s
4184 runs so far, 0 failures, over 6h0m0s
4184 runs so far, 0 failures, over 6h0m5s
4184 runs so far, 0 failures, over 6h0m10s
4184 runs so far, 0 failures, over 6h0m15s
4184 runs so far, 0 failures, over 6h0m20s
4184 runs so far, 0 failures, over 6h0m25s
4184 runs so far, 0 failures, over 6h0m30s
4184 runs so far, 0 failures, over 6h0m35s
4185 runs so far, 0 failures, over 6h0m40s
4186 runs so far, 0 failures, over 6h0m45s
4186 runs so far, 0 failures, over 6h0m50s
4186 runs so far, 0 failures, over 6h0m55s
4186 runs so far, 0 failures, over 6h1m0s
4187 runs so far, 0 failures, over 6h1m5s
4187 runs so far, 0 failures, over 6h1m10s
4187 runs so far, 0 failures, over 6h1m15s
4187 runs so far, 0 failures, over 6h1m20s
4187 runs so far, 0 failures, over 6h1m25s
4188 runs so far, 0 failures, over 6h1m30s
4188 runs so far, 0 failures, over 6h1m35s
4188 runs so far, 0 failures, over 6h1m40s
4188 runs so far, 0 failures, over 6h1m45s
4188 runs so far, 0 failures, over 6h1m50s
4188 runs so far, 0 failures, over 6h1m55s
4189 runs so far, 0 failures, over 6h2m0s
4190 runs so far, 0 failures, over 6h2m5s
4190 runs so far, 0 failures, over 6h2m10s
4190 runs so far, 0 failures, over 6h2m15s
4190 runs so far, 0 failures, over 6h2m20s
4190 runs so far, 0 failures, over 6h2m25s
4190 runs so far, 0 failures, over 6h2m30s
```