### PR TITLE
colexec: add optimized implementation of LIKE '%foo%bar%' patterns

### DIFF
--- a/pkg/sql/colexec/colexecprojconst/proj_like_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_like_ops.eg.go
@@ -251,6 +251,132 @@ func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 	return batch
 }
 
+type projSkeletonBytesBytesConstOp struct {
+	projConstOpBase
+	constArg [][]byte
+}
+
+func (p projSkeletonBytesBytesConstOp) Next() coldata.Batch {
+	batch := p.Input.Next()
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	vec := batch.ColVec(p.colIdx)
+	var col *coldata.Bytes
+	col = vec.Bytes()
+	projVec := batch.ColVec(p.outputIdx)
+	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
+		projCol := projVec.Bool()
+		// Some operators can result in NULL with non-NULL inputs, like the JSON
+		// fetch value operator, ->. Therefore, _outNulls is defined to allow
+		// updating the output Nulls from within _ASSIGN functions when the result
+		// of a projection is Null.
+		_outNulls := projVec.Nulls()
+		if vec.Nulls().MaybeHasNulls() {
+			colNulls := vec.Nulls()
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					if !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						arg := col.Get(i)
+
+						{
+							var idx, skeletonIdx int
+							for skeletonIdx < len(p.constArg) {
+								idx = bytes.Index(arg, p.constArg[skeletonIdx])
+								if idx < 0 {
+									break
+								}
+								arg = arg[idx+len(p.constArg[skeletonIdx]):]
+								skeletonIdx++
+							}
+							projCol[i] = skeletonIdx == len(p.constArg)
+						}
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					if !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						arg := col.Get(i)
+
+						{
+							var idx, skeletonIdx int
+							for skeletonIdx < len(p.constArg) {
+								idx = bytes.Index(arg, p.constArg[skeletonIdx])
+								if idx < 0 {
+									break
+								}
+								arg = arg[idx+len(p.constArg[skeletonIdx]):]
+								skeletonIdx++
+							}
+							projCol[i] = skeletonIdx == len(p.constArg)
+						}
+					}
+				}
+			}
+			// _outNulls has been updated from within the _ASSIGN function to include
+			// any NULLs that resulted from the projection.
+			// If $hasNulls is true, union _outNulls with the set of input Nulls.
+			// If $hasNulls is false, then there are no input Nulls. _outNulls is
+			// projVec.Nulls() so there is no need to call projVec.SetNulls().
+			projVec.SetNulls(_outNulls.Or(*colNulls))
+		} else {
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					arg := col.Get(i)
+
+					{
+						var idx, skeletonIdx int
+						for skeletonIdx < len(p.constArg) {
+							idx = bytes.Index(arg, p.constArg[skeletonIdx])
+							if idx < 0 {
+								break
+							}
+							arg = arg[idx+len(p.constArg[skeletonIdx]):]
+							skeletonIdx++
+						}
+						projCol[i] = skeletonIdx == len(p.constArg)
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					arg := col.Get(i)
+
+					{
+						var idx, skeletonIdx int
+						for skeletonIdx < len(p.constArg) {
+							idx = bytes.Index(arg, p.constArg[skeletonIdx])
+							if idx < 0 {
+								break
+							}
+							arg = arg[idx+len(p.constArg[skeletonIdx]):]
+							skeletonIdx++
+						}
+						projCol[i] = skeletonIdx == len(p.constArg)
+					}
+				}
+			}
+			// _outNulls has been updated from within the _ASSIGN function to include
+			// any NULLs that resulted from the projection.
+			// If $hasNulls is true, union _outNulls with the set of input Nulls.
+			// If $hasNulls is false, then there are no input Nulls. _outNulls is
+			// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		}
+	})
+	return batch
+}
+
 type projRegexpBytesBytesConstOp struct {
 	projConstOpBase
 	constArg *regexp.Regexp
@@ -551,6 +677,132 @@ func (p projNotContainsBytesBytesConstOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 					projCol[i] = !bytes.Contains(arg, p.constArg)
+				}
+			}
+			// _outNulls has been updated from within the _ASSIGN function to include
+			// any NULLs that resulted from the projection.
+			// If $hasNulls is true, union _outNulls with the set of input Nulls.
+			// If $hasNulls is false, then there are no input Nulls. _outNulls is
+			// projVec.Nulls() so there is no need to call projVec.SetNulls().
+		}
+	})
+	return batch
+}
+
+type projNotSkeletonBytesBytesConstOp struct {
+	projConstOpBase
+	constArg [][]byte
+}
+
+func (p projNotSkeletonBytesBytesConstOp) Next() coldata.Batch {
+	batch := p.Input.Next()
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	vec := batch.ColVec(p.colIdx)
+	var col *coldata.Bytes
+	col = vec.Bytes()
+	projVec := batch.ColVec(p.outputIdx)
+	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
+		projCol := projVec.Bool()
+		// Some operators can result in NULL with non-NULL inputs, like the JSON
+		// fetch value operator, ->. Therefore, _outNulls is defined to allow
+		// updating the output Nulls from within _ASSIGN functions when the result
+		// of a projection is Null.
+		_outNulls := projVec.Nulls()
+		if vec.Nulls().MaybeHasNulls() {
+			colNulls := vec.Nulls()
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					if !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						arg := col.Get(i)
+
+						{
+							var idx, skeletonIdx int
+							for skeletonIdx < len(p.constArg) {
+								idx = bytes.Index(arg, p.constArg[skeletonIdx])
+								if idx < 0 {
+									break
+								}
+								arg = arg[idx+len(p.constArg[skeletonIdx]):]
+								skeletonIdx++
+							}
+							projCol[i] = skeletonIdx != len(p.constArg)
+						}
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					if !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						arg := col.Get(i)
+
+						{
+							var idx, skeletonIdx int
+							for skeletonIdx < len(p.constArg) {
+								idx = bytes.Index(arg, p.constArg[skeletonIdx])
+								if idx < 0 {
+									break
+								}
+								arg = arg[idx+len(p.constArg[skeletonIdx]):]
+								skeletonIdx++
+							}
+							projCol[i] = skeletonIdx != len(p.constArg)
+						}
+					}
+				}
+			}
+			// _outNulls has been updated from within the _ASSIGN function to include
+			// any NULLs that resulted from the projection.
+			// If $hasNulls is true, union _outNulls with the set of input Nulls.
+			// If $hasNulls is false, then there are no input Nulls. _outNulls is
+			// projVec.Nulls() so there is no need to call projVec.SetNulls().
+			projVec.SetNulls(_outNulls.Or(*colNulls))
+		} else {
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					arg := col.Get(i)
+
+					{
+						var idx, skeletonIdx int
+						for skeletonIdx < len(p.constArg) {
+							idx = bytes.Index(arg, p.constArg[skeletonIdx])
+							if idx < 0 {
+								break
+							}
+							arg = arg[idx+len(p.constArg[skeletonIdx]):]
+							skeletonIdx++
+						}
+						projCol[i] = skeletonIdx != len(p.constArg)
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					arg := col.Get(i)
+
+					{
+						var idx, skeletonIdx int
+						for skeletonIdx < len(p.constArg) {
+							idx = bytes.Index(arg, p.constArg[skeletonIdx])
+							if idx < 0 {
+								break
+							}
+							arg = arg[idx+len(p.constArg[skeletonIdx]):]
+							skeletonIdx++
+						}
+						projCol[i] = skeletonIdx != len(p.constArg)
+					}
 				}
 			}
 			// _outNulls has been updated from within the _ASSIGN function to include

--- a/pkg/sql/colexec/colexecsel/sel_like_ops.eg.go
+++ b/pkg/sql/colexec/colexecsel/sel_like_ops.eg.go
@@ -266,6 +266,137 @@ func (p *selContainsBytesBytesConstOp) Next() coldata.Batch {
 	}
 }
 
+type selSkeletonBytesBytesConstOp struct {
+	selConstOpBase
+	constArg [][]byte
+}
+
+func (p *selSkeletonBytesBytesConstOp) Next() coldata.Batch {
+	for {
+		batch := p.Input.Next()
+		if batch.Length() == 0 {
+			return batch
+		}
+
+		vec := batch.ColVec(p.colIdx)
+		col := vec.Bytes()
+		var idx int
+		n := batch.Length()
+		if vec.MaybeHasNulls() {
+			nulls := vec.Nulls()
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					if nulls.NullAt(i) {
+						continue
+					}
+					var cmp bool
+					arg := col.Get(i)
+
+					{
+						var idx, skeletonIdx int
+						for skeletonIdx < len(p.constArg) {
+							idx = bytes.Index(arg, p.constArg[skeletonIdx])
+							if idx < 0 {
+								break
+							}
+							arg = arg[idx+len(p.constArg[skeletonIdx]):]
+							skeletonIdx++
+						}
+						cmp = skeletonIdx == len(p.constArg)
+					}
+					if cmp {
+						sel[idx] = i
+						idx++
+					}
+				}
+			} else {
+				batch.SetSelection(true)
+				sel := batch.Selection()
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					if nulls.NullAt(i) {
+						continue
+					}
+					var cmp bool
+					arg := col.Get(i)
+
+					{
+						var idx, skeletonIdx int
+						for skeletonIdx < len(p.constArg) {
+							idx = bytes.Index(arg, p.constArg[skeletonIdx])
+							if idx < 0 {
+								break
+							}
+							arg = arg[idx+len(p.constArg[skeletonIdx]):]
+							skeletonIdx++
+						}
+						cmp = skeletonIdx == len(p.constArg)
+					}
+					if cmp {
+						sel[idx] = i
+						idx++
+					}
+				}
+			}
+		} else {
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					var cmp bool
+					arg := col.Get(i)
+
+					{
+						var idx, skeletonIdx int
+						for skeletonIdx < len(p.constArg) {
+							idx = bytes.Index(arg, p.constArg[skeletonIdx])
+							if idx < 0 {
+								break
+							}
+							arg = arg[idx+len(p.constArg[skeletonIdx]):]
+							skeletonIdx++
+						}
+						cmp = skeletonIdx == len(p.constArg)
+					}
+					if cmp {
+						sel[idx] = i
+						idx++
+					}
+				}
+			} else {
+				batch.SetSelection(true)
+				sel := batch.Selection()
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					var cmp bool
+					arg := col.Get(i)
+
+					{
+						var idx, skeletonIdx int
+						for skeletonIdx < len(p.constArg) {
+							idx = bytes.Index(arg, p.constArg[skeletonIdx])
+							if idx < 0 {
+								break
+							}
+							arg = arg[idx+len(p.constArg[skeletonIdx]):]
+							skeletonIdx++
+						}
+						cmp = skeletonIdx == len(p.constArg)
+					}
+					if cmp {
+						sel[idx] = i
+						idx++
+					}
+				}
+			}
+		}
+		if idx > 0 {
+			batch.SetLength(idx)
+			return batch
+		}
+	}
+}
+
 type selRegexpBytesBytesConstOp struct {
 	selConstOpBase
 	constArg *regexp.Regexp
@@ -584,6 +715,137 @@ func (p *selNotContainsBytesBytesConstOp) Next() coldata.Batch {
 					var cmp bool
 					arg := col.Get(i)
 					cmp = !bytes.Contains(arg, p.constArg)
+					if cmp {
+						sel[idx] = i
+						idx++
+					}
+				}
+			}
+		}
+		if idx > 0 {
+			batch.SetLength(idx)
+			return batch
+		}
+	}
+}
+
+type selNotSkeletonBytesBytesConstOp struct {
+	selConstOpBase
+	constArg [][]byte
+}
+
+func (p *selNotSkeletonBytesBytesConstOp) Next() coldata.Batch {
+	for {
+		batch := p.Input.Next()
+		if batch.Length() == 0 {
+			return batch
+		}
+
+		vec := batch.ColVec(p.colIdx)
+		col := vec.Bytes()
+		var idx int
+		n := batch.Length()
+		if vec.MaybeHasNulls() {
+			nulls := vec.Nulls()
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					if nulls.NullAt(i) {
+						continue
+					}
+					var cmp bool
+					arg := col.Get(i)
+
+					{
+						var idx, skeletonIdx int
+						for skeletonIdx < len(p.constArg) {
+							idx = bytes.Index(arg, p.constArg[skeletonIdx])
+							if idx < 0 {
+								break
+							}
+							arg = arg[idx+len(p.constArg[skeletonIdx]):]
+							skeletonIdx++
+						}
+						cmp = skeletonIdx != len(p.constArg)
+					}
+					if cmp {
+						sel[idx] = i
+						idx++
+					}
+				}
+			} else {
+				batch.SetSelection(true)
+				sel := batch.Selection()
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					if nulls.NullAt(i) {
+						continue
+					}
+					var cmp bool
+					arg := col.Get(i)
+
+					{
+						var idx, skeletonIdx int
+						for skeletonIdx < len(p.constArg) {
+							idx = bytes.Index(arg, p.constArg[skeletonIdx])
+							if idx < 0 {
+								break
+							}
+							arg = arg[idx+len(p.constArg[skeletonIdx]):]
+							skeletonIdx++
+						}
+						cmp = skeletonIdx != len(p.constArg)
+					}
+					if cmp {
+						sel[idx] = i
+						idx++
+					}
+				}
+			}
+		} else {
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					var cmp bool
+					arg := col.Get(i)
+
+					{
+						var idx, skeletonIdx int
+						for skeletonIdx < len(p.constArg) {
+							idx = bytes.Index(arg, p.constArg[skeletonIdx])
+							if idx < 0 {
+								break
+							}
+							arg = arg[idx+len(p.constArg[skeletonIdx]):]
+							skeletonIdx++
+						}
+						cmp = skeletonIdx != len(p.constArg)
+					}
+					if cmp {
+						sel[idx] = i
+						idx++
+					}
+				}
+			} else {
+				batch.SetSelection(true)
+				sel := batch.Selection()
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					var cmp bool
+					arg := col.Get(i)
+
+					{
+						var idx, skeletonIdx int
+						for skeletonIdx < len(p.constArg) {
+							idx = bytes.Index(arg, p.constArg[skeletonIdx])
+							if idx < 0 {
+								break
+							}
+							arg = arg[idx+len(p.constArg[skeletonIdx]):]
+							skeletonIdx++
+						}
+						cmp = skeletonIdx != len(p.constArg)
+					}
 					if cmp {
 						sel[idx] = i
 						idx++

--- a/pkg/sql/opt/exec/execbuilder/testdata/tpch_vec
+++ b/pkg/sql/opt/exec/execbuilder/testdata/tpch_vec
@@ -20790,7 +20790,7 @@ EXPLAIN (VEC) SELECT c_count, count(*) AS custdist FROM ( SELECT c_custkey, coun
     └ *colexec.hashAggregator
       └ *colexec.hashAggregator
         └ *colexecjoin.hashJoiner
-          ├ *colexecsel.selNotRegexpBytesBytesConstOp
+          ├ *colexecsel.selNotSkeletonBytesBytesConstOp
           │ └ *colfetcher.ColBatchScan
           └ *colfetcher.ColBatchScan
 
@@ -20857,7 +20857,7 @@ EXPLAIN (VEC) SELECT p_brand, p_type, p_size, count(distinct ps_suppkey) AS supp
           │   └ *colexecsel.selNotPrefixBytesBytesConstOp
           │     └ *colexecsel.selNEBytesBytesConstOp
           │       └ *colfetcher.ColBatchScan
-          └ *colexecsel.selRegexpBytesBytesConstOp
+          └ *colexecsel.selSkeletonBytesBytesConstOp
             └ *colfetcher.ColBatchScan
 
 # Query 17


### PR DESCRIPTION
This commit introduces optimized implementation of LIKE patterns of the
form `%foo%bar%` with any number of "skeleton" words in between. There
are two TPCH queries that use this pattern, and this commit speeds Q13
by about 2x on a single node on my laptop.

The logic for evaluating such pattern is that for each "skeleton" words
we find its first occurrence in the unprocessed part of the input
string. If it is not found, then the pattern doesn't match, if it is
found, then we advance the input string right past that first
occurrence.

Here is the comparison of the microbenchmarks of the optimized version
and the default unoptimized version on the same pattern:
```
BenchmarkLikeOps/selSkeletonBytesBytesConstOp-16       	   37070	     32054 ns/op	2044.58 MB/s
BenchmarkLikeOps/selRegexpSkeleton-16                  	    1797	    668154 ns/op	  98.09 MB/s
```

Release note: None