### PR TITLE
ccl/sqlproxyccl: update load balancing algorithm to use weighted leastconns

### DIFF
--- a/pkg/ccl/sqlproxyccl/balancer/pod.go
+++ b/pkg/ccl/sqlproxyccl/balancer/pod.go
@@ -11,16 +11,17 @@ package balancer
 import "github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenant"
 
 // selectTenantPod selects a tenant pod from the given list to receive incoming
-// traffic. Pods are weighted by their reported CPU load. rand must be a pseudo
-// random number within the bounds [0, 1). It is suggested to use Float32() of a
-// PseudoRand instance that is guarded by a mutex.
+// traffic. Pods are weighted by their number of connections based on the given
+// counts map. rand must be a pseudo random number within the bounds [0, 1). It
+// is suggested to use Float32() of a PseudoRand instance that is guarded by a
+// mutex.
 //
-//	rngMu.Lock()
-//	rand := rng.Float32()
-//	rngMu.Unlock()
-//	selectTenantPod(rand, pods)
-func selectTenantPod(rand float32, pods []*tenant.Pod) *tenant.Pod {
-	if len(pods) == 0 {
+//  rngMu.Lock()
+//  rand := rng.Float32()
+//  rngMu.Unlock()
+//  selectTenantPod(rand, pods, counts)
+func selectTenantPod(rand float32, pods []*tenant.Pod, counts map[string]int) *tenant.Pod {
+	if len(pods) == 0 || counts == nil {
 		return nil
 	}
 
@@ -28,22 +29,71 @@ func selectTenantPod(rand float32, pods []*tenant.Pod) *tenant.Pod {
 		return pods[0]
 	}
 
-	totalLoad := float32(0)
-	for _, pod := range pods {
-		totalLoad += 1 - pod.Load
-	}
+	weights := constructPodWeights(pods, counts)
 
-	totalLoad *= rand
-
+	w := float32(0)
 	for _, pod := range pods {
-		totalLoad -= 1 - pod.Load
-		if totalLoad < 0 {
+		w += weights[pod.Addr]
+		if rand <= w {
 			return pod
 		}
 	}
 
-	// This is unreachable provided that Load is [0, 1] and rand is [0, 1). We
-	// fallback to the final pod in the list to prevent complications if we've
-	// received malformed .Loads.
+	// This is unreachable since constructPodWeights guarantee that the sum of
+	// weights would be 1. We will fallback to the final pod in the list to
+	// prevent complications if we've received malformed inputs.
 	return pods[len(pods)-1]
+}
+
+// constructPodWeights constructs a weights map for the input list of pods.
+// Weights are assigned proportionally based on the number of connections to
+// the given pod. It is guaranteed that the sum of weights returned will be 1
+// (or <= 1 due to float32).
+//
+// Here are some examples:
+// - c1: 0, c2: 0, c3: 0 => w1: 1/3, w2: 1/3, w3: 1/3
+// - c1: 100, c2: 100 => w1: 1/2, w2: 1/2
+// - c1: 1, c2: 4, c3: 8 => w1: 8/11, w2: 2/11, w3: 1/11
+// - c1: 0, c2: 10 => w1: 10/11, w2: 1/11
+func constructPodWeights(pods []*tenant.Pod, counts map[string]int) map[string]float32 {
+	// gcd returns the greatest common denominator of two positive numbers.
+	gcd := func(x, y int) int {
+		for y != 0 {
+			x, y = y, x%y
+		}
+		return x
+	}
+
+	// lcm returns the lowest common multiple of two positive numbers.
+	lcm := func(x, y int) int {
+		return (x * y) / gcd(x, y)
+	}
+
+	// Find the lowest common multiple of all the individual connection counts.
+	weights := make(map[string]float32)
+	cumulativeLCM := 1
+	for _, pod := range pods {
+		val := counts[pod.Addr]
+		weights[pod.Addr] = float32(val)
+		if val > 0 {
+			cumulativeLCM = lcm(cumulativeLCM, val)
+		}
+	}
+
+	// Assign actual weights to pods.
+	totalWeights := float32(0)
+	for addr, w := range weights {
+		if w == 0 {
+			weights[addr] = float32(cumulativeLCM)
+		} else {
+			weights[addr] = float32(cumulativeLCM) / w
+		}
+		totalWeights += weights[addr]
+	}
+
+	// Normalize the weights so that all of them are between [0, 1].
+	for addr := range weights {
+		weights[addr] /= totalWeights
+	}
+	return weights
 }

--- a/pkg/ccl/sqlproxyccl/balancer/pod_test.go
+++ b/pkg/ccl/sqlproxyccl/balancer/pod_test.go
@@ -9,6 +9,7 @@
 package balancer
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
 
@@ -21,34 +22,128 @@ func TestSelectTenantPods(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	t.Run("no pods", func(t *testing.T) {
-		require.Nil(t, selectTenantPod(0, nil))
+		require.Nil(t, selectTenantPod(0, nil, map[string]int{}))
+	})
+
+	t.Run("nil counts map", func(t *testing.T) {
+		require.Nil(t, selectTenantPod(0, nil, nil))
 	})
 
 	t.Run("one pod", func(t *testing.T) {
-		pod := selectTenantPod(0, []*tenant.Pod{{Addr: "1"}})
+		pod := selectTenantPod(
+			0, []*tenant.Pod{{TenantID: 3, Addr: "1"}}, map[string]int{},
+		)
 		require.Equal(t, "1", pod.Addr)
 	})
 
 	t.Run("many pods", func(t *testing.T) {
-		pods := []*tenant.Pod{
-			{Addr: "1", Load: 0.0},
-			{Addr: "2", Load: 0.5},
-			{Addr: "3", Load: 0.9},
+		for _, update := range []bool{true, false} {
+			t.Run(fmt.Sprintf("update=%v", update), func(t *testing.T) {
+				counts := map[string]int{
+					"1": 0,
+					"2": 5,
+					"3": 9,
+				}
+
+				pods := []*tenant.Pod{
+					{TenantID: 10, Addr: "1"},
+					{TenantID: 10, Addr: "2"},
+					{TenantID: 10, Addr: "3"},
+				}
+
+				distribution := map[string]int{}
+				rng := rand.New(rand.NewSource(0))
+
+				for i := 0; i < 10000; i++ {
+					pod := selectTenantPod(rng.Float32(), pods, counts)
+					if update {
+						// Simulate the case where the cache gets updated after.
+						counts[pod.Addr] += 1
+					}
+					distribution[pod.Addr]++
+				}
+
+				if update {
+					// Distribution should eventually converge to ~3333 each.
+					require.Equal(t, map[string]int{
+						"1": 3334,
+						"2": 3272,
+						"3": 3394,
+					}, distribution)
+				} else {
+					// Assert that the distribution is a roughly based on the
+					// following weights:
+					// - w1: 45/59 (7627)
+					// - w2: 9/59 (1525)
+					// - w3: 5/59 (847)
+					require.Equal(t, map[string]int{
+						"1": 7507,
+						"2": 1594,
+						"3": 899,
+					}, distribution)
+				}
+			})
 		}
-
-		distribution := map[string]int{}
-		rng := rand.New(rand.NewSource(0))
-
-		for i := 0; i < 10000; i++ {
-			pod := selectTenantPod(rng.Float32(), pods)
-			distribution[pod.Addr]++
-		}
-
-		// Assert that the distribution is a roughly function of 1 - Load.
-		require.Equal(t, map[string]int{
-			"1": 6121,
-			"2": 3214,
-			"3": 665,
-		}, distribution)
 	})
+}
+
+func TestConstructPodWeights(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	for _, tc := range []struct {
+		name     string
+		counts   []int
+		expected []float32
+	}{
+		{
+			name:     "single pod with zero weight",
+			counts:   []int{0},
+			expected: []float32{1},
+		},
+		{
+			name:     "single pod",
+			counts:   []int{100},
+			expected: []float32{1},
+		},
+		{
+			name:     "equal zero weights",
+			counts:   []int{0, 0, 0},
+			expected: []float32{0.333, 0.333, 0.333},
+		},
+		{
+			name:     "equal weights",
+			counts:   []int{1000, 1000},
+			expected: []float32{0.5, 0.5},
+		},
+		{
+			name:     "imbalance",
+			counts:   []int{1, 4, 8},
+			expected: []float32{0.727, 0.182, 0.091},
+		},
+		{
+			name:     "new pod added",
+			counts:   []int{10, 0},
+			expected: []float32{0.091, 0.909},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if len(tc.counts) != len(tc.expected) {
+				t.Fatalf("counts != expected")
+			}
+
+			podCount := len(tc.counts)
+			var pods []*tenant.Pod
+			counts := make(map[string]int)
+			expectedWeights := make(map[string]float32)
+			for i := 0; i < podCount; i++ {
+				addr := fmt.Sprintf("%d", i)
+				counts[addr] = tc.counts[i]
+				expectedWeights[addr] = tc.expected[i]
+				pods = append(pods, &tenant.Pod{TenantID: 42, Addr: addr})
+			}
+
+			weights := constructPodWeights(pods, counts)
+			require.InDeltaMapValues(t, expectedWeights, weights, 0.05)
+		})
+	}
 }


### PR DESCRIPTION
This commit replaces the existing load balancing algorithm within sqlproxy
(i.e. weighted CPU load) with a weighted leastconns approach as discussed.
This builds on top of the recently merged TenantCache work that keeps track of
a list of active and idle connections. For new connections, we only care about
active connections.

The idea behind this replacement is that CPU metrics are often stale, and we
should be able to reasonably make routing decisions based on local data.

Release note: None