### PR TITLE
sql: add higher-order functions

### DIFF
--- a/pkg/cli/clisqlshell/BUILD.bazel
+++ b/pkg/cli/clisqlshell/BUILD.bazel
@@ -28,8 +28,8 @@ go_library(
         "//pkg/util/envutil",
         "//pkg/util/errorutil/unimplemented",
         "//pkg/util/syncutil",
+        "//temp_vendor/github.com/knz/go-libedit",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_knz_go_libedit//:go-libedit",
     ],
 )
 

--- a/pkg/sql/lex/BUILD.bazel
+++ b/pkg/sql/lex/BUILD.bazel
@@ -5,7 +5,12 @@ load("//pkg/testutils/buildutil:buildutil.bzl", "disallowed_imports_test")
 
 go_library(
     name = "lex",
-    srcs = ["encode.go"],
+    srcs = [
+        "encode.go",
+        "keywords.go",
+        "reserved_keywords.go",
+        "tokens.go",
+    ],
     embed = [":lex_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/lex",
     visibility = ["//visibility:public"],

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -803,7 +803,7 @@ func (u *sqlSymUnion) asTenantClause() tree.TenantID {
 %token <str> ASENSITIVE ASYMMETRIC AT ATTRIBUTE AUTHORIZATION AUTOMATIC AVAILABILITY
 
 %token <str> BACKUP BACKUPS BACKWARD BEFORE BEGIN BETWEEN BIGINT BIGSERIAL BINARY BIT
-%token <str> BUCKET_COUNT
+%token <str> BUCKET_COUNT BUILTIN
 %token <str> BOOLEAN BOTH BOX2D BUNDLE BY
 
 %token <str> CACHE CANCEL CANCELQUERY CASCADE CASE CAST CBRT CHANGEFEED CHAR
@@ -12298,6 +12298,11 @@ c_expr:
 | EXISTS select_with_parens
   {
     $$.val = &tree.Subquery{Select: $2.selectStmt(), Exists: true}
+  }
+|
+func_name '(' '@' ')'
+  {   
+    $$.val = &tree.FirstClassFunctionExpr{Func: $1.resolvableFuncRefFromName()}
   }
 
 // Productions that can be followed by a postfix operator.

--- a/pkg/sql/rowenc/valueside/encode.go
+++ b/pkg/sql/rowenc/valueside/encode.go
@@ -96,6 +96,8 @@ func Encode(appendTo []byte, colID ColumnIDDelta, val tree.Datum, scratch []byte
 		return encoding.EncodeBytesValue(appendTo, uint32(colID), t.PhysicalRep), nil
 	case *tree.DVoid:
 		return encoding.EncodeVoidValue(appendTo, uint32(colID)), nil
+	case *tree.DFunction:
+		return encoding.EncodeBytesValue(appendTo, uint32(colID), []byte(t.Name)), nil
 	default:
 		return nil, errors.Errorf("unable to encode table value: %T", t)
 	}

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -181,6 +181,7 @@ go_library(
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_google_go_cmp//cmp",
         "@com_github_lib_pq//oid",
+        "@com_github_pkg_errors//:errors",
         "@org_golang_x_text//collate",
         "@org_golang_x_text//language",
     ],

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1561,6 +1561,97 @@ func (d *DBytes) Size() uintptr {
 	return unsafe.Sizeof(*d) + uintptr(len(*d))
 }
 
+// DFunction is the function datum. It exists only as an expression.
+type DFunction FunctionDefinition
+
+// NewDFunction is a helper routine to create a *DFunction initialized from its
+// argument.
+func NewDFunction(fd FunctionDefinition) *DFunction {
+	df := DFunction(fd)
+	return &df
+}
+
+// MustBeDBytes attempts to convert an Expr into a DFunction, panicking if unsuccessful.
+func MustBeDFunction(e Expr) DFunction {
+	i, ok := AsDFunction(e)
+	if !ok {
+		panic(errors.AssertionFailedf("expected *DFunction, found %T", e))
+	}
+	return i
+}
+
+// AsDFunction attempts to convert an Expr into a DFunction, returning a flag indicating
+// whether it was successful.
+func AsDFunction(e Expr) (DFunction, bool) {
+	switch t := e.(type) {
+	case *DFunction:
+		return *t, true
+	}
+	return DFunction{}, false
+}
+
+// ResolvedType implements the TypedExpr interface.
+func (*DFunction) ResolvedType() *types.T {
+	return types.Function
+}
+
+// Compare implements the Datum interface.
+func (d *DFunction) Compare(ctx *EvalContext, other Datum) int {
+	res, err := d.CompareError(ctx, other)
+	if err != nil {
+		panic(err)
+	}
+	return res
+}
+
+// CompareError implements the Datum interface.
+func (d *DFunction) CompareError(ctx *EvalContext, other Datum) (int, error) {
+	return 0, makeUnsupportedComparisonMessage(d, other)
+}
+
+// Prev implements the Datum interface.
+func (d *DFunction) Prev(_ *EvalContext) (Datum, bool) {
+	return nil, false
+}
+
+// Next implements the Datum interface.
+func (d *DFunction) Next(_ *EvalContext) (Datum, bool) {
+	return nil, false
+}
+
+// IsMax implements the Datum interface.
+func (*DFunction) IsMax(_ *EvalContext) bool {
+	return false
+}
+
+// IsMin implements the Datum interface.
+func (d *DFunction) IsMin(_ *EvalContext) bool {
+	return false
+}
+
+// Min implements the Datum interface.
+func (d *DFunction) Min(_ *EvalContext) (Datum, bool) {
+	return nil, false
+}
+
+// Max implements the Datum interface.
+func (d *DFunction) Max(_ *EvalContext) (Datum, bool) {
+	return nil, false
+}
+
+// AmbiguousFormat implements the Datum interface.
+func (*DFunction) AmbiguousFormat() bool { return false }
+
+// Format implements the NodeFormatter interface.
+func (d *DFunction) Format(ctx *FmtCtx) {
+	ctx.WriteString(d.Name)
+}
+
+// Size implements the Datum interface.
+func (d *DFunction) Size() uintptr {
+	return unsafe.Sizeof(*d)
+}
+
 // DEncodedKey is a special Datum of types.EncodedKey type, used to pass through
 // encoded key data. It is similar to DBytes, except when it comes to
 // encoding/decoding. It is currently used to pass around inverted index keys,

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -4714,6 +4714,11 @@ func (t *DBytes) Eval(_ *EvalContext) (Datum, error) {
 }
 
 // Eval implements the TypedExpr interface.
+func (t *DFunction) Eval(_ *EvalContext) (Datum, error) {
+	return t, nil
+}
+
+// Eval implements the TypedExpr interface.
 func (t *DEncodedKey) Eval(_ *EvalContext) (Datum, error) {
 	return t, nil
 }

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -180,6 +180,8 @@ func StarSelectExpr() SelectExpr {
 
 // Format implements the NodeFormatter interface.
 func (node *SelectExpr) Format(ctx *FmtCtx) {
+	if node.Expr == nil {
+	}
 	ctx.FormatNode(node.Expr)
 	if node.As != "" {
 		ctx.WriteString(" AS ")

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1711,6 +1711,12 @@ func (d *DUuid) TypeCheck(_ context.Context, _ *SemaContext, _ *types.T) (TypedE
 
 // TypeCheck implements the Expr interface. It is implemented as an idempotent
 // identity function for Datum.
+func (d *DFunction) TypeCheck(_ context.Context, _ *SemaContext, _ *types.T) (TypedExpr, error) {
+	return d, nil
+}
+
+// TypeCheck implements the Expr interface. It is implemented as an idempotent
+// identity function for Datum.
 func (d *DIPAddr) TypeCheck(_ context.Context, _ *SemaContext, _ *types.T) (TypedExpr, error) {
 	return d, nil
 }

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -768,6 +768,9 @@ func (expr *DJSON) Walk(_ Visitor) Expr { return expr }
 func (expr *DUuid) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
+func (expr *DFunction) Walk(_ Visitor) Expr { return expr }
+
+// Walk implements the Expr interface.
 func (expr *DIPAddr) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -475,6 +475,15 @@ var (
 		},
 	}
 
+	// Function is a special type used only in expressions.
+	Function = &T{
+		InternalType: InternalType{
+			Family: FunctionFamily,
+			Oid:    oid.T_regproc,
+			Locale: &emptyLocale,
+		},
+	}
+
 	// Scalar contains all types that meet this criteria:
 	//
 	//   1. Scalar type (no ArrayFamily or TupleFamily types).
@@ -1405,6 +1414,7 @@ var familyNames = map[Family]string{
 	UuidFamily:           "uuid",
 	VoidFamily:           "void",
 	EncodedKeyFamily:     "encodedkey",
+	FunctionFamily:       "function",
 }
 
 // Name returns a user-friendly word indicating the family type.

--- a/pkg/sql/types/types.proto
+++ b/pkg/sql/types/types.proto
@@ -378,6 +378,14 @@ enum Family {
     // index keys, which do not fully encode an object.
     EncodedKeyFamily = 27;
 
+    // FunctionFamily is a special type family used in function function
+    // signatures within expressions.
+    //   Oid      : T_regproc
+    //
+    // Examples:
+    //   Function
+    FunctionFamily = 28;
+
     // AnyFamily is a special type family used during static analysis as a
     // wildcard type that matches any other type, including scalar, array, and
     // tuple types. Execution-time values should never have this type. As an


### PR DESCRIPTION
Probably just a fun flex-friday project that never gets merged.
Adds support for array_apply, a function that takes an array
of type t and any function that can be called on a single t,
and returns an array of equal length by iterating the function
over the array. For example,

```sql
select strs, array_apply(strs, char_length(@)) from hasarrs;
          strs         | array_apply
-----------------------+--------------
  {apple,banana}       | {5,6}
  {apple,banana,apple} | {5,6,5}
  {apple}              | {5}
  {}                   | {}
```

In order to pass functions as arguments, we need function
literals and/or functions that return functions. The
`char_length(@)` syntax above is my stab at a function literal,
but right now it doesn't get parsed correctly inside column
qualifications and I don't know if that's fixable without
introducing other conflicts (also don't know if this syntax
introduces a conflict elsewhere which is why I'm pushing to run
CI). So to help development I added a builtin called builtin
that takes a string and returns the builtin with that name, e.g.

```sql
select strs, array_apply(strs, builtin('char_length') from hasarrs;
```

I don't think we should actually enable that, though: people will
programmatically build string arguments or read them from columns
and it'll be too much like adding an eval() function. A literal
format like `char_length(@)` or `BUILTIN(char_length)` wouldn't be
as abusable.

In order to get higher-arity functions into array_apply, I've also
added curry. That might be misnamed, it maybe should be called
papply or something. It takes a function, replaces one of its
arguments at an index with a constant, and returns a new function
with one less arity. You can nest n calls to curry to get a function
with arity n+1 to arity 1. For example,

```sql
select array_apply(Array['radiogram', 'pizza'],curry(curry(builtin('substr'), 2, 3),1,4));
  array_apply
---------------
  {iog,za}
(1 row)
```

This expression calls substr(elt, 4, 3) on each element.

WHY??

Motivation was seeing issues like
https://github.com/cockroachdb/cockroach/issues/76477 and
https://github.com/cockroachdb/cockroach/issues/41285.

Without custom functions, extensions, or plugins, a lot
of things just can't be implemented at the database level.
Higher-order functions give motivated users a tool to solve
their problems, without us having to implement anything
particularly elaborate or low-level ourselves. They can
be reasoned about statically, and it's possible to prevent
them from being Turing-complete, although I haven't put
that in yet: the idea is to give functions an order integer
and disallow it from getting above a configured number,
so that you can't curry a curry to get a y combinator unless
somebody's enabled that for your tenant.

As proof that they're powerful enough to solve actual problems,
here's an array unique check constraint:

```sql
create table uniqarrs (strs string[], CHECK (array_remove(array_apply(array_apply(strs, curry(builtin('array_positions'),0,strs)),builtin('cardinality')),1) = Array[]:::int[]));
```

It's not pretty and we'd rather have an array_distinct builtin,
but we'll never have every builtin someone wants.

Implementation

This is implemented at a high level:
We define a DFunction datum type that, like multidimensional arrays,
can't be returned or stored but can be an intermediate value in any
sql expression. It wraps a tree.FunctionDefinition and can be
resolved to by a FirstClassFunctionExpr.

array_apply performs overload resolution on the function dynamically.
If its return type is checked after the function has been resolved,
it can tell you the type of the resulting array, otherwise it can
only promise types.AnyArray. Right now it doesn't error on ambiguous
overloads, but it probably should.

curry takes an overloaded function and can return an overloaded
function: any overload for which the curried argument makes sense
gets curried.

Release note (sql change): Added array_apply and curry functions.