### PR TITLE
streamingccl: make completeStreamIngestion use jobs.Update API

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingest/BUILD.bazel
@@ -41,7 +41,6 @@ go_library(
         "//pkg/sql/rowexec",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
-        "//pkg/sql/sessiondata",
         "//pkg/sql/types",
         "//pkg/storage",
         "//pkg/streaming",

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -56,19 +56,6 @@ func completeStreamIngestion(
 		return errors.Newf("job %d: not of expected type StreamIngest", ingestionJobID)
 	}
 
-	// Check that the supplied cutover time is a valid one.
-	// TODO(adityamaru): This will change once we allow a future cutover time to
-	// be specified.
-	hw := progress.GetHighWater()
-	if hw == nil || hw.Less(cutoverTimestamp) {
-		var highWaterTimestamp hlc.Timestamp
-		if hw != nil {
-			highWaterTimestamp = *hw
-		}
-		return errors.Newf("cannot cutover to a timestamp %s that is after the latest resolved time"+
-			" %s for job %d", cutoverTimestamp.String(), highWaterTimestamp.String(), ingestionJobID)
-	}
-
 	// Reject setting a cutover time, if an earlier request to cutover has already
 	// been set.
 	// TODO(adityamaru): This should change in the future, a user should be

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -21,11 +21,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
-	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/streaming"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -33,52 +30,23 @@ import (
 func completeStreamIngestion(
 	evalCtx *eval.Context, txn *kv.Txn, ingestionJobID jobspb.JobID, cutoverTimestamp hlc.Timestamp,
 ) error {
-	// Get the job payload for job_id.
-	const jobsQuery = `SELECT progress FROM system.jobs WHERE id=$1 FOR UPDATE`
-	row, err := evalCtx.Planner.QueryRowEx(evalCtx.Context,
-		"get-stream-ingestion-job-metadata", sessiondata.NodeUserSessionDataOverride, jobsQuery, ingestionJobID)
-	if err != nil {
-		return err
-	}
-	// If an entry does not exist for the provided job_id we return an
-	// error.
-	if row == nil {
-		return errors.Newf("job %d: not found in system.jobs table", ingestionJobID)
-	}
+	jobRegistry := evalCtx.Planner.ExecutorConfig().(*sql.ExecutorConfig).JobRegistry
+	return jobRegistry.UpdateJobWithTxn(evalCtx.Ctx(), ingestionJobID, txn, false, /* useReadLock */
+		func(txn *kv.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+			// TODO(adityamaru): This should change in the future, a user should be
+			// allowed to correct their cutover time if the process of reverting the job
+			// has not started.
+			if jobCutoverTime := md.Progress.GetStreamIngest().CutoverTime; !jobCutoverTime.IsEmpty() {
+				return errors.Newf("cutover timestamp already set to %s, "+
+					"job %d is in the process of cutting over", jobCutoverTime.String(), ingestionJobID)
+			}
 
-	progress, err := jobs.UnmarshalProgress(row[0])
-	if err != nil {
-		return err
-	}
-	var sp *jobspb.Progress_StreamIngest
-	var ok bool
-	if sp, ok = progress.GetDetails().(*jobspb.Progress_StreamIngest); !ok {
-		return errors.Newf("job %d: not of expected type StreamIngest", ingestionJobID)
-	}
-
-	// Reject setting a cutover time, if an earlier request to cutover has already
-	// been set.
-	// TODO(adityamaru): This should change in the future, a user should be
-	// allowed to correct their cutover time if the process of reverting the job
-	// has not started.
-	if !sp.StreamIngest.CutoverTime.IsEmpty() {
-		return errors.Newf("cutover timestamp already set to %s, "+
-			"job %d is in the process of cutting over", sp.StreamIngest.CutoverTime.String(), ingestionJobID)
-	}
-
-	// Update the sentinel being polled by the stream ingestion job to
-	// check if a complete has been signaled.
-	sp.StreamIngest.CutoverTime = cutoverTimestamp
-	progress.ModifiedMicros = timeutil.ToUnixMicros(txn.ReadTimestamp().GoTime())
-	progressBytes, err := protoutil.Marshal(progress)
-	if err != nil {
-		return err
-	}
-	updateJobQuery := `UPDATE system.jobs SET progress=$1 WHERE id=$2`
-	_, err = evalCtx.Planner.QueryRowEx(evalCtx.Context,
-		"set-stream-ingestion-job-metadata",
-		sessiondata.NodeUserSessionDataOverride, updateJobQuery, progressBytes, ingestionJobID)
-	return err
+			// Update the sentinel being polled by the stream ingestion job to
+			// check if a complete has been signaled.
+			md.Progress.GetStreamIngest().CutoverTime = cutoverTimestamp
+			ju.UpdateProgress(md.Progress)
+			return nil
+		})
 }
 
 func getStreamIngestionStats(

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -374,22 +374,8 @@ func (sip *streamIngestionProcessor) checkForCutoverSignal(
 					j.Progress().Progress, jobID)
 			}
 			// Job has been signaled to complete.
-			if !sp.StreamIngest.CutoverTime.IsEmpty() {
-				// Sanity check that the requested cutover time is less than equal to
-				// the resolved ts recorded in the job progress. This should already
-				// have been enforced when the cutover was signaled via the builtin.
-				// TODO(adityamaru): Remove this when we allow users to specify a
-				// cutover time in the future.
-				resolvedTimestamp := progress.GetHighWater()
-				if resolvedTimestamp == nil {
-					return errors.AssertionFailedf("cutover has been requested before job %d has had a chance to"+
-						" record a resolved ts", jobID)
-				}
-				if resolvedTimestamp.Less(sp.StreamIngest.CutoverTime) {
-					return errors.AssertionFailedf("requested cutover time %s is before the resolved time %s recorded"+
-						" in job %d", sp.StreamIngest.CutoverTime.String(), resolvedTimestamp.String(),
-						jobID)
-				}
+			if resolvedTimestamp := progress.GetHighWater(); !sp.StreamIngest.CutoverTime.IsEmpty() &&
+				resolvedTimestamp != nil && sp.StreamIngest.CutoverTime.Less(*resolvedTimestamp) {
 				sip.cutoverCh <- struct{}{}
 				return nil
 			}

--- a/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
-	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -32,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -68,21 +66,6 @@ func (c *tenantStreamingClusters) compareResult(query string) {
 func (c *tenantStreamingClusters) cutover(
 	producerJobID, ingestionJobID int, cutoverTime time.Time,
 ) {
-	// Wait for the job high watermark to reach the given cutover time.
-	testutils.SucceedsSoon(c.t, func() error {
-		progress := jobutils.GetJobProgress(c.t, c.destSysSQL, jobspb.JobID(ingestionJobID))
-		if progress.GetHighWater() == nil {
-			return errors.Newf("stream ingestion has not recorded any progress yet, waiting to advance pos %s",
-				cutoverTime.String())
-		}
-		highwater := *progress.GetHighWater()
-		if highwater.GoTime().Before(cutoverTime) {
-			return errors.Newf("waiting for stream ingestion job progress %s to advance beyond %s",
-				highwater.String(), cutoverTime.String())
-		}
-		return nil
-	})
-
 	// Cut over the ingestion job and the job will stop eventually.
 	c.destSysSQL.Exec(c.t, `SELECT crdb_internal.complete_stream_ingestion_job($1, $2)`, ingestionJobID, cutoverTime)
 	jobutils.WaitForJobToSucceed(c.t, c.destSysSQL, jobspb.JobID(ingestionJobID))


### PR DESCRIPTION
Currently, completeStreamIngestion uses direct queries against
jobs table to select the job, and update the job record.
Now we are using jobs.Update api.

Release note: None

Closes: https://github.com/cockroachdb/cockroach/issues/78415
