### PR TITLE
ci: fix optimizer_tests_impl.sh

### DIFF
--- a/build/teamcity/cockroach/nightlies/optimizer_tests_impl.sh
+++ b/build/teamcity/cockroach/nightlies/optimizer_tests_impl.sh
@@ -14,7 +14,7 @@ ARTIFACTS_DIR=/artifacts/fast_int_set_large
 mkdir $ARTIFACTS_DIR
 GO_TEST_JSON_OUTPUT_FILE=$ARTIFACTS_DIR/test.json.txt
 exit_status_large=0
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --config=ci --artifacts $ARTIFACTS_DIR \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --config=ci --artifacts_dir $ARTIFACTS_DIR \
     test //pkg/sql/opt:opt_test -- \
     --define gotags=bazel,crdb_test,fast_int_set_large \
     --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE || exit_status_large=$?


### PR DESCRIPTION
Confusingly bazci uses `--artifacts_dir` whereas roachtest uses `--artifacts`.
The recent refactoring of optimizer_tests_impl.sh erroneously used
the latter instead of the former.
Consequently, (sql) Optimizer Tests stopped working in CI.

Fixes: https://github.com/cockroachdb/cockroach/pull/77688
Release justification: ensure CI can run nightly (sql) Optimizer Tests
Release note: None