### PR TITLE
streamingccl: refactor completeStreamIngestion into StreamIngestManager

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingest/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "streamingest",
     srcs = [
         "metrics.go",
+        "stream_ingest_manager.go",
         "stream_ingestion_frontier_processor.go",
         "stream_ingestion_job.go",
         "stream_ingestion_planning.go",
@@ -39,6 +40,7 @@ go_library(
         "//pkg/sql/rowenc",
         "//pkg/sql/rowexec",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/sessiondata",
         "//pkg/sql/types",
         "//pkg/storage",
         "//pkg/streaming",

--- a/pkg/ccl/streamingccl/streamingest/stream_ingest_manager.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingest_manager.go
@@ -1,0 +1,60 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package streamingest
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/streaming"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+)
+
+type streamIngestManagerImpl struct{}
+
+// CompleteStreamIngestion implements streaming.StreamIngestManager interface.
+func (r *streamIngestManagerImpl) CompleteStreamIngestion(
+	evalCtx *tree.EvalContext,
+	txn *kv.Txn,
+	streamID streaming.StreamID,
+	cutoverTimestamp hlc.Timestamp,
+) error {
+	return completeStreamIngestion(evalCtx, txn, streamID, cutoverTimestamp)
+}
+
+func newStreamIngestManagerWithPrivilegesCheck(
+	evalCtx *tree.EvalContext,
+) (streaming.StreamIngestManager, error) {
+	isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
+	if err != nil {
+		return nil, err
+	}
+
+	if !isAdmin {
+		return nil,
+			pgerror.New(pgcode.InsufficientPrivilege, "replication restricted to ADMIN role")
+	}
+
+	execCfg := evalCtx.Planner.ExecutorConfig().(*sql.ExecutorConfig)
+	enterpriseCheckErr := utilccl.CheckEnterpriseEnabled(
+		execCfg.Settings, execCfg.LogicalClusterID(), execCfg.Organization(), "REPLICATION")
+	if enterpriseCheckErr != nil {
+		return nil, pgerror.Wrap(enterpriseCheckErr,
+			pgcode.InsufficientPrivilege, "replication requires enterprise license")
+	}
+
+	return &streamIngestManagerImpl{}, nil
+}
+
+func init() {
+	streaming.GetStreamIngestManagerHook = newStreamIngestManagerWithPrivilegesCheck
+}

--- a/pkg/ccl/streamingccl/streamproducer/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamproducer/BUILD.bazel
@@ -29,7 +29,6 @@ go_library(
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/tree",
-        "//pkg/sql/sessiondata",
         "//pkg/sql/types",
         "//pkg/streaming",
         "//pkg/testutils",

--- a/pkg/ccl/streamingccl/streamproducer/replication_manager.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_manager.go
@@ -22,33 +22,21 @@ import (
 
 type replicationStreamManagerImpl struct{}
 
-// CompleteStreamIngestion implements ReplicationStreamManager interface.
-func (r *replicationStreamManagerImpl) CompleteStreamIngestion(
-	evalCtx *tree.EvalContext,
-	txn *kv.Txn,
-	streamID streaming.StreamID,
-	cutoverTimestamp hlc.Timestamp,
-) error {
-	return completeStreamIngestion(evalCtx, txn, streamID, cutoverTimestamp)
-}
-
-// StartReplicationStream implements ReplicationStreamManager interface.
+// StartReplicationStream implements streaming.ReplicationStreamManager interface.
 func (r *replicationStreamManagerImpl) StartReplicationStream(
 	evalCtx *tree.EvalContext, txn *kv.Txn, tenantID uint64,
 ) (streaming.StreamID, error) {
 	return startReplicationStreamJob(evalCtx, txn, tenantID)
 }
 
-// UpdateReplicationStreamProgress implements ReplicationStreamManager interface.
+// UpdateReplicationStreamProgress implements streaming.ReplicationStreamManager interface.
 func (r *replicationStreamManagerImpl) UpdateReplicationStreamProgress(
 	evalCtx *tree.EvalContext, streamID streaming.StreamID, frontier hlc.Timestamp, txn *kv.Txn,
 ) (streampb.StreamReplicationStatus, error) {
 	return heartbeatReplicationStream(evalCtx, streamID, frontier, txn)
 }
 
-// StreamPartition returns a value generator which yields events for the specified partition.
-// opaqueSpec contains streampb.PartitionSpec protocol message.
-// streamID specifies the streaming job this partition belongs too.
+// StreamPartition implements streaming.ReplicationStreamManager interface.
 func (r *replicationStreamManagerImpl) StreamPartition(
 	evalCtx *tree.EvalContext, streamID streaming.StreamID, opaqueSpec []byte,
 ) (tree.ValueGenerator, error) {

--- a/pkg/ccl/streamingccl/streamproducer/stream_lifetime.go
+++ b/pkg/ccl/streamingccl/streamproducer/stream_lifetime.go
@@ -23,84 +23,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/streaming"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 )
-
-// completeStreamIngestion terminates the stream as of specified time.
-func completeStreamIngestion(
-	evalCtx *tree.EvalContext,
-	txn *kv.Txn,
-	streamID streaming.StreamID,
-	cutoverTimestamp hlc.Timestamp,
-) error {
-	// Get the job payload for job_id.
-	const jobsQuery = `SELECT progress FROM system.jobs WHERE id=$1 FOR UPDATE`
-	row, err := evalCtx.Planner.QueryRowEx(evalCtx.Context,
-		"get-stream-ingestion-job-metadata",
-		txn, sessiondata.NodeUserSessionDataOverride, jobsQuery, streamID)
-	if err != nil {
-		return err
-	}
-	// If an entry does not exist for the provided job_id we return an
-	// error.
-	if row == nil {
-		return errors.Newf("job %d: not found in system.jobs table", streamID)
-	}
-
-	progress, err := jobs.UnmarshalProgress(row[0])
-	if err != nil {
-		return err
-	}
-	var sp *jobspb.Progress_StreamIngest
-	var ok bool
-	if sp, ok = progress.GetDetails().(*jobspb.Progress_StreamIngest); !ok {
-		return errors.Newf("job %d: not of expected type StreamIngest", streamID)
-	}
-
-	// Check that the supplied cutover time is a valid one.
-	// TODO(adityamaru): This will change once we allow a future cutover time to
-	// be specified.
-	hw := progress.GetHighWater()
-	if hw == nil || hw.Less(cutoverTimestamp) {
-		var highWaterTimestamp hlc.Timestamp
-		if hw != nil {
-			highWaterTimestamp = *hw
-		}
-		return errors.Newf("cannot cutover to a timestamp %s that is after the latest resolved time"+
-			" %s for job %d", cutoverTimestamp.String(), highWaterTimestamp.String(), streamID)
-	}
-
-	// Reject setting a cutover time, if an earlier request to cutover has already
-	// been set.
-	// TODO(adityamaru): This should change in the future, a user should be
-	// allowed to correct their cutover time if the process of reverting the job
-	// has not started.
-	if !sp.StreamIngest.CutoverTime.IsEmpty() {
-		return errors.Newf("cutover timestamp already set to %s, "+
-			"job %d is in the process of cutting over", sp.StreamIngest.CutoverTime.String(), streamID)
-	}
-
-	// Update the sentinel being polled by the stream ingestion job to
-	// check if a complete has been signaled.
-	sp.StreamIngest.CutoverTime = cutoverTimestamp
-	progress.ModifiedMicros = timeutil.ToUnixMicros(txn.ReadTimestamp().GoTime())
-	progressBytes, err := protoutil.Marshal(progress)
-	if err != nil {
-		return err
-	}
-	updateJobQuery := `UPDATE system.jobs SET progress=$1 WHERE id=$2`
-	_, err = evalCtx.Planner.QueryRowEx(evalCtx.Context,
-		"set-stream-ingestion-job-metadata", txn,
-		sessiondata.NodeUserSessionDataOverride, updateJobQuery, progressBytes, streamID)
-	return err
-}
 
 // startReplicationStreamJob initializes a replication stream producer job on the source cluster that
 // 1. Tracks the liveness of the replication stream consumption

--- a/pkg/sql/sem/builtins/replication_builtins.go
+++ b/pkg/sql/sem/builtins/replication_builtins.go
@@ -44,7 +44,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				mgr, err := streaming.GetReplicationStreamManager(evalCtx)
+				mgr, err := streaming.GetStreamIngestManager(evalCtx)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
Previously stream ingestion side APIs were located under streamproducer
package which doesn't make sense, this PR creates a new
StreamIngestManager under streamingest to represent ingestion side APIs.

Release note: None