### PR TITLE
release-21.2: sqlsmith: do not generate st_frechetdistance function calls

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -481,6 +481,11 @@ var functions = func() map[tree.FunctionClass]map[oid.Oid][]function {
 		switch def.Name {
 		case "pg_sleep":
 			continue
+		case "st_frechetdistance", "st_buffer":
+			// Some spatial functions can be very computationally expensive and
+			// run for a long time or never finish, so we avoid generating them.
+			// See #69213.
+			continue
 		}
 		if strings.Contains(def.Name, "stream_ingestion") {
 			// crdb_internal.complete_stream_ingestion_job is a stateful function that


### PR DESCRIPTION
Backport 1/1 commits from #79122.

/cc @cockroachdb/release

---

This commit prevents sqlsmith from generating `st_frechetdistance` and
`st_buffer` function calls. They can be very computationally expensive
and run for a long time or never finish, causing sqlsmith failures.
See #69213.

Release note: None

---

Release justification: This is a test-only change.
