### PR TITLE
release-22.1: sqlsmith: do not generate st_frechetdistance function calls

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -482,6 +482,11 @@ var functions = func() map[tree.FunctionClass]map[oid.Oid][]function {
 		switch def.Name {
 		case "pg_sleep":
 			continue
+		case "st_frechetdistance", "st_buffer":
+			// Some spatial functions can be very computationally expensive and
+			// run for a long time or never finish, so we avoid generating them.
+			// See #69213.
+			continue
 		}
 		skip := false
 		for _, substr := range []string{


### PR DESCRIPTION
Backport 1/1 commits from #79122.

/cc @cockroachdb/release

---

This commit prevents sqlsmith from generating `st_frechetdistance` and
`st_buffer` function calls. They can be very computationally expensive
and run for a long time or never finish, causing sqlsmith failures.
See #69213.

Release note: None

---

Release justification: This is a test-only change.