### PR TITLE
[DNM] tests: add qos roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -90,6 +90,7 @@ go_library(
         "psycopg.go",
         "psycopg_blocklist.go",
         "python_helpers.go",
+        "qos_tpcc_background_olap.go",
         "queue.go",
         "quit.go",
         "rapid_restart.go",

--- a/pkg/cmd/roachtest/tests/qos_tpcc_background_olap.go
+++ b/pkg/cmd/roachtest/tests/qos_tpcc_background_olap.go
@@ -1,0 +1,406 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
+	"github.com/cockroachdb/cockroach/pkg/workload/tpcc"
+	"github.com/cockroachdb/ttycolor"
+)
+
+type tpccQoSBackgroundOLAPSpec struct {
+	Nodes           int
+	CPUs            int
+	Warehouses      int
+	Concurrency     int
+	OLAPConcurrency int
+	Duration        time.Duration
+	Ramp            time.Duration
+	numRuns         int
+}
+
+// run sets up TPCC then runs both TPCC plus TPCH OLAP queries concurrently,
+// first with the OLAP queries using `background` transaction quality of
+// service, then with OLAP queries using `regular` transaction quality of
+// service.  The results are logged and compared. The test fails if using
+// `background` QoS doesn't result in a tpmC score from TPCC which is at least a
+// certain percentage higher than that when OLAP queries are run with `regular`
+// QoS.
+func (s tpccQoSBackgroundOLAPSpec) run(ctx context.Context, t test.Test, c cluster.Cluster) {
+
+	histogramsPath := t.PerfArtifactsDir() + "/stats.json"
+	histogramsPathQoS := t.PerfArtifactsDir() + "/stats_qos.json"
+
+	var throttledOLAPTpmC, throttledOLAPTPCCEfficiency []float64
+	var noThrottleTpmC, noThrottleTPCCEfficiency []float64
+	throttledOLAPTpmC = make([]float64, 0, s.numRuns)
+	throttledOLAPTPCCEfficiency = make([]float64, 0, s.numRuns)
+	noThrottleTpmC = make([]float64, 0, s.numRuns)
+	noThrottleTPCCEfficiency = make([]float64, 0, s.numRuns)
+	var tpmCQoS, tpmCNoQoS float64
+	var efficiencyCQoS, efficiencyNoQoS float64
+	//var baselineTpmC, baselineEfficiency float64
+
+	for i := 0; i < s.numRuns; i++ {
+		crdbNodes, workloadNode := s.setupDatabases(ctx, t, c)
+
+		//s.runTPCC(ctx, t, c, crdbNodes, workloadNode, histogramsPath, false /* useBackgroundQoS */)
+		//baselineTpmC, baselineEfficiency, _ =
+		//	s.getTpmcAndEfficiency(ctx, t, c, workloadNode, histogramsPath, true /* withQoS */)
+
+		startQoS := timeutil.Now()
+		s.runTPCCAndOLAPQueries(ctx, t, c, crdbNodes, workloadNode, histogramsPathQoS, true /* useBackgroundQoS */)
+		endQoS := timeutil.Now()
+		// Get the TPCC perf and efficiency when other OLAP queries are run with
+		// background QoS.
+		tpmC, efficiency, throttledResult :=
+			s.getTpmcAndEfficiency(ctx, t, c, workloadNode, histogramsPathQoS, true /* withQoS */)
+		tpmCQoS += tpmC
+		efficiencyCQoS += efficiency
+		throttledOLAPTpmC = append(throttledOLAPTpmC, tpmC)
+		throttledOLAPTPCCEfficiency = append(throttledOLAPTPCCEfficiency, efficiency)
+
+		startNoQoS := timeutil.Now()
+		s.runTPCCAndOLAPQueries(ctx, t, c, crdbNodes, workloadNode, histogramsPath, false /* useBackgroundQoS */)
+		endNoQoS := timeutil.Now()
+
+		// Get the TPCC perf and efficiency when other OLAP queries are run with
+		// regular QoS.
+		tpmC, efficiency, noThrottleResult :=
+			s.getTpmcAndEfficiency(ctx, t, c, workloadNode, histogramsPath, false /* withQoS */)
+		tpmCNoQoS += tpmC
+		efficiencyNoQoS += efficiency
+		noThrottleTpmC = append(noThrottleTpmC, tpmC)
+		noThrottleTPCCEfficiency = append(noThrottleTPCCEfficiency, efficiency)
+
+		printResults(throttledResult, noThrottleResult, t)
+
+		t.L().Printf("\n")
+		t.L().Printf("Admission control metrics without QoS\n")
+		t.L().Printf("-------------------------------------\n")
+		printAdmissionMetrics(ctx, c, t, c.Node(1), startNoQoS, endNoQoS)
+		t.L().Printf("\n")
+		t.L().Printf("Admission control metrics with QoS\n")
+		t.L().Printf("----------------------------------\n")
+		printAdmissionMetrics(ctx, c, t, c.Node(1), startQoS, endQoS)
+		t.L().Printf("\n")
+	}
+	efficiencyNoQoS /= float64(s.numRuns)
+	efficiencyCQoS /= float64(s.numRuns)
+	tpmCNoQoS /= float64(s.numRuns)
+	tpmCQoS /= float64(s.numRuns)
+
+	// Test results vary. Allow at most a 5% regression or random variance in the
+	// run using background QoS.
+	const maxAllowedRegression = -5.0
+	percentImprovement := 100.0 * (tpmCQoS - tpmCNoQoS) / tpmCNoQoS
+	//t.L().Printf("tpmC_No_Tpch:         %.2f   Efficiency: %.4v\n",
+	//	baselineTpmC, baselineEfficiency)
+	t.L().Printf("tpmC_No_QoS:         %.2f   Efficiency: %.4v\n",
+		tpmCNoQoS, efficiencyNoQoS)
+	t.L().Printf("tpmC_Background_QoS: %.2f   Efficiency: %.4v\n",
+		tpmCQoS, efficiencyCQoS)
+	var scoreDelta string
+	if percentImprovement < 0.0 {
+		scoreDelta = fmt.Sprintf("%.1f%% lower", -percentImprovement)
+	} else {
+		scoreDelta = fmt.Sprintf("%.1f%% higher", percentImprovement)
+	}
+	message := fmt.Sprintf(
+		`TPCC run in parallel with OLAP queries using background QoS
+                                                   had a tpmC score %s than with regular QoS.`,
+		scoreDelta)
+	if percentImprovement < maxAllowedRegression {
+		ttycolor.Stdout(ttycolor.Red)
+		failMessage := fmt.Sprintf("FAIL: %s\n", message)
+		t.L().Printf(failMessage)
+		ttycolor.Stdout(ttycolor.Reset)
+		t.Fatalf(failMessage)
+	} else {
+		ttycolor.Stdout(ttycolor.Green)
+		t.L().Printf("SUCCESS: %s\n", message)
+	}
+	ttycolor.Stdout(ttycolor.Reset)
+}
+
+func printAdmissionMetrics(
+	ctx context.Context,
+	c cluster.Cluster,
+	t test.Test,
+	adminNode option.NodeListOption,
+	start, end time.Time,
+) {
+	// Query needed information over the timespan of the query.
+	adminUIAddrs, err := c.ExternalAdminUIAddr(ctx, t.L(), adminNode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var admissionMetrics = []tsQuery{
+		// Work Queue Admission Counter
+		{name: "admission.requested.kv", queryType: total},
+		{name: "admission.admitted.kv", queryType: total},
+		{name: "admission.errored", queryType: total},
+		{name: "admission.requested.kv-stores", queryType: total},
+		{name: "admission.admitted.kv-stores", queryType: total},
+		{name: "admission.errored.kv-stores", queryType: total},
+		{name: "admission.requested.sql-kv-response", queryType: total},
+		{name: "admission.admitted.sql-kv-response", queryType: total},
+		{name: "admission.errored.sql-kv-response", queryType: total},
+		{name: "admission.requested.sql-sql-response", queryType: total},
+		{name: "admission.admitted.sql-sql-response", queryType: total},
+		{name: "admission.errored.sql-sql-response", queryType: total},
+		{name: "admission.requested.sql-leaf-start", queryType: total},
+		{name: "admission.admitted.sql-leaf-start", queryType: total},
+		{name: "admission.errored.sql-leaf-start", queryType: total},
+		{name: "admission.requested.sql-root-start", queryType: total},
+		{name: "admission.admitted.sql-root-start", queryType: total},
+		{name: "admission.errored.sql-root-start", queryType: total},
+		// Work Queue Length
+		{name: "admission.wait_queue_length.kv", queryType: total},
+		{name: "admission.wait_queue_length.kv-stores", queryType: total},
+		{name: "admission.wait_queue_length.sql-kv-response", queryType: total},
+		{name: "admission.wait_queue_length.sql-sql-response", queryType: total},
+		{name: "admission.wait_queue_length.sql-leaf-start", queryType: total},
+		{name: "admission.wait_queue_length.sql-root-start", queryType: total},
+
+		// Work Queue Admission Latency Sum
+		{name: "admission.wait_sum.kv", queryType: total},
+		{name: "admission.wait_sum.kv-stores", queryType: total},
+		{name: "admission.wait_sum.sql-kv-response", queryType: total},
+		{name: "admission.wait_sum.sql-sql-response", queryType: total},
+		{name: "admission.wait_sum.sql-leaf-start", queryType: total},
+		{name: "admission.wait_sum.sql-root-start", queryType: total},
+		// Granter
+		{name: "admission.granter.total_slots.kv", queryType: total},
+		{name: "admission.granter.used_slots.kv", queryType: total},
+		{name: "admission.granter.used_slots.sql-leaf-start", queryType: total},
+		{name: "admission.granter.used_slots.sql-root-start", queryType: total},
+
+		// IO Tokens Exhausted Duration Sum
+		{name: "admission.granter.io_tokens_exhausted_duration.kv", queryType: total},
+	}
+
+	adminURL := adminUIAddrs[0]
+	response := mustGetMetrics(t, adminURL, start, end, admissionMetrics)
+
+	// Drop the first two minutes of datapoints as a "ramp-up" period.
+	//perMinute := response.Results[0].Datapoints[2:]
+	//cumulative := response.Results[1].Datapoints[2:]  // msirek-temp
+
+	t.L().Printf("\n")
+	for i, metric := range admissionMetrics {
+		lastIdx := len(response.Results[i].Datapoints) - 1
+		if lastIdx < 1 {
+			continue
+		}
+		dataPoints := response.Results[i].Datapoints
+		totalCount := dataPoints[lastIdx].Value - dataPoints[0].Value
+		t.L().Printf("s: %f\n", metric.name, totalCount)
+	}
+	t.L().Printf("\n")
+}
+
+func (s tpccQoSBackgroundOLAPSpec) setupDatabases(
+	ctx context.Context, t test.Test, c cluster.Cluster,
+) (crdbNodes, workloadNode option.NodeListOption) {
+	// Set up TPCC tables.
+	crdbNodes, workloadNode = setupTPCC(
+		ctx, t, c, tpccOptions{
+			Warehouses: s.Warehouses, SetupType: usingImport, DontOverrideWarehouses: true,
+		})
+	m := c.NewMonitor(ctx, crdbNodes)
+	// Set up TPCH tables.
+	m.Go(func(ctx context.Context) error {
+		t.Status("loading TPCH tables")
+		cmd := fmt.Sprintf(
+			"./workload init tpch {pgurl:1-%d} --data-loader=import",
+			c.Spec().NodeCount-1,
+		)
+		c.Run(ctx, workloadNode, cmd)
+		return nil
+	})
+	m.Wait()
+	return crdbNodes, workloadNode
+}
+
+func (s tpccQoSBackgroundOLAPSpec) runTPCCAndOLAPQueries(
+	ctx context.Context,
+	t test.Test,
+	c cluster.Cluster,
+	crdbNodes, workloadNode option.NodeListOption,
+	histogramsPath string,
+	useBackgroundQoS bool,
+) {
+	m := c.NewMonitor(ctx, crdbNodes)
+	// Kick off TPC-H with concurrency.
+	m.Go(func(ctx context.Context) error {
+		var backgroundQoSOpt string
+		message := fmt.Sprintf("running TPCH with concurrency of %d", s.OLAPConcurrency)
+		if useBackgroundQoS {
+			message += " with background quality of service"
+			backgroundQoSOpt = "--background-qos"
+		}
+		t.Status(message)
+		cmd := fmt.Sprintf(
+			"./cockroach workload run tpch {pgurl:1-%d} --tolerate-errors "+
+				"--concurrency=%d --duration=%s %s",
+			c.Spec().NodeCount-1, s.OLAPConcurrency, s.Duration+s.Ramp, backgroundQoSOpt,
+		)
+		c.Run(ctx, workloadNode, cmd)
+		return nil
+	})
+	s.runTPCC(ctx, t, c, crdbNodes, workloadNode, histogramsPath, useBackgroundQoS)
+	m.Wait()
+}
+
+func (s tpccQoSBackgroundOLAPSpec) runTPCC(
+	ctx context.Context,
+	t test.Test,
+	c cluster.Cluster,
+	crdbNodes, workloadNode option.NodeListOption,
+	histogramsPath string,
+	useBackgroundQoS bool,
+) {
+	// Kick off TPC-C
+	m := c.NewMonitor(ctx, crdbNodes)
+	m.Go(func(ctx context.Context) error {
+		message := "running tpcc"
+		t.WorkerStatus(message)
+		cmd := fmt.Sprintf(
+			"./cockroach workload run tpcc"+
+				" --tolerate-errors"+
+				" --max-rate=0"+
+				" --wait=0"+
+				" --warehouses=%d"+
+				" --concurrency=%d"+
+				" --histograms=%s "+
+				" --ramp=%s "+
+				" --duration=%s {pgurl:1-%d}",
+			s.Warehouses, s.Concurrency, histogramsPath, s.Ramp, s.Duration, c.Spec().NodeCount-1)
+		c.Run(ctx, workloadNode, cmd)
+		return nil
+	})
+	m.Wait()
+}
+
+func (s tpccQoSBackgroundOLAPSpec) getTpmcAndEfficiency(
+	ctx context.Context,
+	t test.Test,
+	c cluster.Cluster,
+	workloadNode option.NodeListOption,
+	histogramsPath string,
+	withQoS bool,
+) (tpmC float64, efficiency float64, result *tpcc.Result) {
+	var fileName string
+	if withQoS {
+		fileName = "stats_qos.json"
+	} else {
+		fileName = "stats.json"
+	}
+	localHistPath := filepath.Join(t.ArtifactsDir(), fileName)
+	// Copy the performance results from the workloadNode to the local system
+	// where roachtest is being run.
+	if err := c.Get(ctx, t.L(), histogramsPath, localHistPath, workloadNode); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshots, err := histogram.DecodeSnapshots(localHistPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result = tpcc.NewResultWithSnapshots(s.Warehouses, 0, snapshots)
+	tpmC = result.TpmC()
+	efficiency = result.Efficiency()
+	return tpmC, efficiency, result
+}
+
+func printResults(throttledResult *tpcc.Result, noThrottleResult *tpcc.Result, t test.Test) {
+	t.L().Printf("\n")
+	t.L().Printf("TPCC results with OLAP queries running simultaneously\n")
+	t.L().Printf("-----------------------------------------------------\n")
+	printOneResult(noThrottleResult, t)
+	t.L().Printf("\n\n")
+	t.L().Printf("TPCC results with OLAP queries running simultaneously with background QoS\n")
+	t.L().Printf("-------------------------------------------------------------------------\n")
+	printOneResult(throttledResult, t)
+	t.L().Printf("\n\n")
+}
+
+func printOneResult(res *tpcc.Result, t test.Test) {
+	t.L().Printf("Duration: %.5v, Warehouses: %v, Efficiency: %.4v, tpmC: %.2f\n",
+		res.Elapsed, res.ActiveWarehouses, res.Efficiency(), res.TpmC())
+	t.L().Printf("_elapsed___ops/sec(cum)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)\n")
+
+	var queries []string
+	for query := range res.Cumulative {
+		queries = append(queries, query)
+	}
+	sort.Strings(queries)
+	for _, query := range queries {
+		hist := res.Cumulative[query]
+		t.L().Printf("%7.1fs %14.1f %8.1f %8.1f %8.1f %8.1f %8.1f %s\n",
+			res.Elapsed.Seconds(),
+			float64(hist.TotalCount())/res.Elapsed.Seconds(),
+			time.Duration(hist.ValueAtQuantile(50)).Seconds()*1000,
+			time.Duration(hist.ValueAtQuantile(90)).Seconds()*1000,
+			time.Duration(hist.ValueAtQuantile(95)).Seconds()*1000,
+			time.Duration(hist.ValueAtQuantile(99)).Seconds()*1000,
+			time.Duration(hist.ValueAtQuantile(100)).Seconds()*1000,
+			query,
+		)
+	}
+}
+
+func (s tpccQoSBackgroundOLAPSpec) getArtifactsPath() string {
+	return fmt.Sprintf("qos/tpcc_background_olap/nodes=%d/cpu=%d/w=%d/c=%d",
+		s.Nodes, s.CPUs, s.Warehouses, s.Concurrency)
+}
+
+func registerTPCCQoSBackgroundOLAPSpec(r registry.Registry, s tpccQoSBackgroundOLAPSpec) {
+	name := s.getArtifactsPath()
+	r.Add(registry.TestSpec{
+		Name:    name,
+		Owner:   registry.OwnerSQLQueries,
+		Cluster: r.MakeClusterSpec(s.Nodes+1, spec.CPU(s.CPUs)),
+		Run:     s.run,
+		Timeout: 1 * time.Hour,
+	})
+}
+
+func registerTPCCQoSBackgroundOLAP(r registry.Registry) {
+	specs := []tpccQoSBackgroundOLAPSpec{
+		{
+			CPUs:            4,
+			Concurrency:     200,
+			OLAPConcurrency: 64,
+			Nodes:           3,
+			Warehouses:      30,
+			Duration:        15 * time.Minute,
+			Ramp:            1 * time.Minute,
+			numRuns:         1,
+		},
+	}
+	for _, s := range specs {
+		registerTPCCQoSBackgroundOLAPSpec(r, s)
+	}
+}

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -123,6 +123,7 @@ func RegisterTests(r registry.Registry) {
 	registerYCSB(r)
 	registerTPCHBench(r)
 	registerOverload(r)
+	registerTPCCQoSBackgroundOLAP(r)
 	registerMultiTenantUpgrade(r)
 	registerVersionUpgradePublicSchema(r)
 	registerRemoveInvalidDatabasePrivileges(r)

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -52,13 +52,14 @@ const (
 )
 
 type tpccOptions struct {
-	Warehouses     int
-	ExtraRunArgs   string
-	ExtraSetupArgs string
-	Chaos          func() Chaos                // for late binding of stopper
-	During         func(context.Context) error // for running a function during the test
-	Duration       time.Duration               // if zero, TPCC is not invoked
-	SetupType      tpccSetupType
+	Warehouses             int
+	DontOverrideWarehouses bool // Don't force Warehouses=1 for local clusters during setup.
+	ExtraRunArgs           string
+	ExtraSetupArgs         string
+	Chaos                  func() Chaos                // for late binding of stopper
+	During                 func(context.Context) error // for running a function during the test
+	Duration               time.Duration               // if zero, TPCC is not invoked
+	SetupType              tpccSetupType
 	// PrometheusConfig, if set, overwrites the default prometheus config settings.
 	PrometheusConfig *prometheus.Config
 	// DisablePrometheus will force prometheus to not start up.
@@ -126,7 +127,7 @@ func setupTPCC(
 	// Randomize starting with encryption-at-rest enabled.
 	crdbNodes = c.Range(1, c.Spec().NodeCount-1)
 	workloadNode = c.Node(c.Spec().NodeCount)
-	if c.IsLocal() {
+	if c.IsLocal() && !opts.DontOverrideWarehouses {
 		opts.Warehouses = 1
 	}
 

--- a/pkg/workload/tpch/tpch.go
+++ b/pkg/workload/tpch/tpch.go
@@ -65,6 +65,7 @@ type tpch struct {
 	vectorize                  string
 	useClusterVectorizeSetting bool
 	verbose                    bool
+	useBackgroundTxnQoS        bool
 
 	queriesRaw      string
 	selectedQueries []int
@@ -113,6 +114,8 @@ var tpchMeta = workload.Meta{
 			`Ignore vectorize option and use the current cluster setting sql.defaults.vectorize`)
 		g.flags.BoolVar(&g.verbose, `verbose`, false,
 			`Prints out the queries being run as well as histograms`)
+		g.flags.BoolVar(&g.useBackgroundTxnQoS, `background-qos`, false,
+			`Set default_transaction_quality_of_service session variable to "background".`)
 		g.connFlags = workload.NewConnFlags(&g.flags)
 		return g
 	},
@@ -341,6 +344,9 @@ func (w *worker) run(ctx context.Context) error {
 	var prefix string
 	if !w.config.useClusterVectorizeSetting {
 		prefix = fmt.Sprintf("SET vectorize = '%s';", w.config.vectorize)
+	}
+	if w.config.useBackgroundTxnQoS {
+		prefix += " SET default_transaction_quality_of_service = background;"
 	}
 	query := fmt.Sprintf("%s %s", prefix, QueriesByNumber[queryNum])
 


### PR DESCRIPTION
This commit adds a new roachtest which tests admission control QoS by
running TPC-C concurrently with TPC-H OLAP queries, once with the OLAP
session having session variable `default_transaction_quality_of_service`
set to `background` and once with it set to `regular`. More often than
not this test should show a slight improvement using `background` QoS,
but since results are variable, the test passes if the TPC-C
transactions per minute regresses no more than 5% when the OLAP session
has `background` QoS.

The test can be run with the commands:
```
    make bin/workload
    make bin/roachtest
    build/builder.sh mkrelease
    roachtest run qos
```
Example abbreviated output:
```diff
...
15:56:34 util.go:52: up-replication complete
15:56:34 tpcc.go:160: test status: loading fixture
15:57:02 tpcc.go:176: test status:
15:57:02 qos_tpcc_background_olap.go:135: test status: loading TPCH tables
15:58:12 qos_tpcc_background_olap.go:181: test worker status: running tpcc
15:58:12 qos_tpcc_background_olap.go:166: test status: running TPCH with concurrency of 16 with background quality of service
16:02:15 cluster.go:659: test status: getting perf/stats_qos.json
16:02:15 cluster_synced.go:1595: msirek-1650297118-01-n4cpu8: getting (scp) perf/stats_qos.json artifacts/qos/tpcc_background_olap/nodes=3/cpu=8/w=30/c=8/run_1/stats_qos.json
16:02:17 cluster.go:659: test status:
16:02:17 qos_tpcc_background_olap.go:181: test worker status: running tpcc
16:02:17 qos_tpcc_background_olap.go:166: test status: running TPCH with concurrency of 16
16:06:20 cluster.go:659: test status: getting perf/stats.json
16:06:20 cluster_synced.go:1595: msirek-1650297118-01-n4cpu8: getting (scp) perf/stats.json artifacts/qos/tpcc_background_olap/nodes=3/cpu=8/w=30/c=8/run_1/stats.json
16:06:22 cluster.go:659: test status:
16:06:22 qos_tpcc_background_olap.go:231:
16:06:22 qos_tpcc_background_olap.go:232: TPCC results with OLAP queries running simultaneously
16:06:22 qos_tpcc_background_olap.go:233: -----------------------------------------------------
16:06:22 qos_tpcc_background_olap.go:243: Duration: 2m59., Warehouses: 30, Efficiency: 96.88, tpmC: 366.33
16:06:22 qos_tpcc_background_olap.go:245: _elapsed___ops/sec(cum)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)
16:06:22 qos_tpcc_background_olap.go:254:   180.0s            0.6    939.5   2550.1   2818.6   3623.9   5368.7 delivery
16:06:22 qos_tpcc_background_olap.go:254:   180.0s            6.1    570.4   1476.4   1811.9   2415.9   4026.5 newOrder
16:06:22 qos_tpcc_background_olap.go:254:   180.0s            0.5    176.2    385.9    453.0    637.5    738.2 orderStatus
16:06:22 qos_tpcc_background_olap.go:254:   180.0s            6.2    335.5    906.0   1208.0   1610.6   2550.1 payment
16:06:22 qos_tpcc_background_olap.go:254:   180.0s            0.6     96.5    419.4    536.9   1140.9   1811.9 stockLevel
16:06:22 qos_tpcc_background_olap.go:235:

16:06:22 qos_tpcc_background_olap.go:236: TPCC results with OLAP queries running simultaneously with background QoS
16:06:22 qos_tpcc_background_olap.go:237: -------------------------------------------------------------------------
16:06:22 qos_tpcc_background_olap.go:243: Duration: 2m59., Warehouses: 30, Efficiency: 98.11, tpmC: 371.00
16:06:22 qos_tpcc_background_olap.go:245: _elapsed___ops/sec(cum)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)
16:06:22 qos_tpcc_background_olap.go:254:   180.0s            0.6   1476.4   3489.7   4026.5   5100.3   6710.9 delivery
16:06:22 qos_tpcc_background_olap.go:254:   180.0s            6.2    805.3   1946.2   2281.7   3087.0   4295.0 newOrder
16:06:22 qos_tpcc_background_olap.go:254:   180.0s            0.5    209.7    436.2    570.4    704.6    872.4 orderStatus
16:06:22 qos_tpcc_background_olap.go:254:   180.0s            6.0    503.3   1275.1   1543.5   2080.4   4295.0 payment
16:06:22 qos_tpcc_background_olap.go:254:   180.0s            0.6    192.9    453.0    486.5   1476.4   2013.3 stockLevel
16:06:22 qos_tpcc_background_olap.go:239:

16:06:22 qos_tpcc_background_olap.go:96: tpmC_No_QoS:         366.33   Efficiency: 96.88
16:06:22 qos_tpcc_background_olap.go:98: tpmC_Background_QoS: 371.00   Efficiency: 98.11
+ 16:06:22 qos_tpcc_background_olap.go:119: SUCCESS: TPCC run in parallel with OLAP queries using background QoS
+                                                    had a tpmC score 1.3% higher than with regular QoS.
16:06:22 test_runner.go:886: tearing down after success; see teardown.log
 --- PASS: qos/tpcc_background_olap/nodes=3/cpu=8/w=30/c=8 (751.23s)
16:06:22 test_runner.go:628: [w0] test passed: qos/tpcc_background_olap/nodes=3/cpu=8/w=30/c=8 (run 1)
...
```

Release note: none