### PR TITLE
storageccl: Don't disable data key rotation after restart

### DIFF
--- a/pkg/ccl/storageccl/engineccl/pebble_key_manager.go
+++ b/pkg/ccl/storageccl/engineccl/pebble_key_manager.go
@@ -300,6 +300,8 @@ func (m *DataKeyManager) SetActiveStoreKeyInfo(
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	// Enable data key rotation regardless of what case we go into.
+	m.mu.rotationEnabled = true
 	prevActiveStoreKey, found := m.mu.keyRegistry.StoreKeys[m.mu.keyRegistry.ActiveStoreKeyId]
 	if found && prevActiveStoreKey.KeyId == storeKeyInfo.KeyId && m.mu.activeKey != nil {
 		// The active store key has not changed and we already have an active data key,

--- a/pkg/ccl/storageccl/engineccl/pebble_key_manager_test.go
+++ b/pkg/ccl/storageccl/engineccl/pebble_key_manager_test.go
@@ -209,7 +209,10 @@ func setActiveStoreKeyInProto(dkr *enginepbccl.DataKeysRegistry, id string) {
 func setActiveDataKeyInProto(dkr *enginepbccl.DataKeysRegistry, id string) {
 	dkr.DataKeys[id] = &enginepbccl.SecretKey{
 		Info: &enginepbccl.KeyInfo{
-			EncryptionType: enginepbccl.EncryptionType_AES192_CTR, KeyId: id},
+			EncryptionType: enginepbccl.EncryptionType_AES192_CTR,
+			KeyId:          id,
+			CreationTime:   kmTimeNow().Unix(),
+		},
 		Key: []byte("some key"),
 	}
 	dkr.ActiveDataKeyId = id

--- a/pkg/ccl/storageccl/engineccl/testdata/data_key_manager
+++ b/pkg/ccl/storageccl/engineccl/testdata/data_key_manager
@@ -70,7 +70,7 @@ load
 
 get-active-data-key
 ----
-encryption_type:AES192_CTR
+encryption_type:AES192_CTR creation_time:6
 
 get-active-store-key
 ----
@@ -178,7 +178,7 @@ check-exposed val=false
 
 get-active-data-key
 ----
-encryption_type:AES192_CTR
+encryption_type:AES192_CTR creation_time:16
 
 set-active-store-key-plain id=bar
 ----
@@ -190,3 +190,58 @@ get-active-data-key
 ----
 creation_time:16 source:"data key manager" was_exposed:true parent_key_id:"bar"
 
+
+# Test that starts with one active data and store key. Checks that data key is
+# not immediately rotated after the call to SetActiveStoreKeyInfo with the same
+# store key, but after the rotation period elapses, it gets rotated.
+
+init
+dir2
+5
+active-store-key foo
+active-data-key data1
+----
+
+load
+----
+
+get-active-data-key
+----
+encryption_type:AES192_CTR creation_time:16
+
+get-active-store-key
+----
+foo
+
+record-active-data-key
+----
+
+compare-active-data-key
+----
+same
+
+get-active-data-key
+----
+encryption_type:AES192_CTR creation_time:16
+
+record-active-data-key
+----
+
+set-active-store-key id=foo
+----
+
+compare-active-data-key
+----
+same
+
+get-active-data-key
+----
+encryption_type:AES192_CTR creation_time:16
+
+wait
+10
+----
+
+compare-active-data-key
+----
+different


### PR DESCRIPTION
Currently, there's a bug in encryption-at-rest FS initialization
code that unintentionally disables automaticdata key rotation unless
the store key was updated since the last start of the node.
This change fixes that.

Fixes #79066

Release note (bug fix): Address issue where automatic encryption-at-rest
data key rotation would get disabled after a node restart without
a store key rotation.