### PR TITLE
ui: update statement key on ui

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
@@ -267,14 +267,11 @@ export const getSearchParams = (searchParams: string) => {
 
 // This function returns a key based on all parameters
 // that should be used to group statements.
-// Parameters being used: query, implicit_txn, database,
-// aggregated_ts and aggregation_interval.
+// Currently, using only statement_fingerprint_id
+// (created by ConstructStatementFingerprintID using:
+// query, implicit_txn, database, failed).
 export function statementKey(stmt: ExecutionStatistics): string {
-  return (
-    stmt.statement_fingerprint_id?.toString() +
-    stmt.aggregated_ts +
-    stmt.aggregation_interval
-  );
+  return stmt.statement_fingerprint_id?.toString();
 }
 
 // transactionScopedStatementKey is similar to statementKey, except that


### PR DESCRIPTION
Previously, we were displaying statement separated
by the aggreation timestamp. Now that we don't show the
aggregation timestamp column, we want to group all
statements with same fingerprint id into a single row,
no longer using the aggregation as part of a key.
Aligning with the results we show for Statement Details
page.

Release note (ui change): Statements are not longer separated
by aggregation interval on Statement Page. Now all statements
with same fingerprint show as a single row.