### PR TITLE
sql/schemachange: handle errors properly in element UML generator

### DIFF
--- a/pkg/sql/schemachanger/scpb/element_uml_generator.go
+++ b/pkg/sql/schemachanger/scpb/element_uml_generator.go
@@ -83,6 +83,5 @@ func run(out string) error {
 	// the end.
 	buf.Write(parentRelations.Bytes())
 	buf.WriteString("@enduml\n")
-	ioutil.WriteFile(out, buf.Bytes(), 0777)
-	return nil
+	return ioutil.WriteFile(out, buf.Bytes(), 0777)
 }


### PR DESCRIPTION
Previously, the element UML generator did not properly deal
with errors from a WriteFile call, leading to linter errors
on master. This patch, address this issue by properly dealing
with the error from WriteFile.

Release note: None