### PR TITLE
cluster-ui: fix storybook config

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/.storybook/main.js
+++ b/pkg/ui/workspaces/cluster-ui/.storybook/main.js
@@ -11,15 +11,17 @@
 const path = require("path");
 const appConfig = require("../webpack.config");
 
+const customConfig = appConfig();
+
 module.exports = {
-  stories: ['../src/**/*.stories.tsx'],
-  addons: ['@storybook/addon-actions', '@storybook/addon-links'],
+  stories: ["../src/**/*.stories.tsx"],
+  addons: ["@storybook/addon-actions", "@storybook/addon-links"],
+  typescript: { reactDocgen: false },
   webpackFinal: async config => {
-    config.module.rules = [
-      ...appConfig.module.rules,
-    ]
-    config.resolve.extensions.push('.ts', '.tsx');
-    config.resolve.alias.src = path.resolve(__dirname, "../src")
+    config.module.rules = [...customConfig.module.rules];
+    config.resolve.extensions.push(".ts", ".tsx");
+    config.resolve.alias.src = path.resolve(__dirname, "../src");
     return config;
   },
+  framework: "@storybook/react",
 };


### PR DESCRIPTION
Previously, we used the default export from the weback config
in the storybook config as an object to set loaders. At some
point, the export changed to a function and brokethe storybook
config. This commit fixes storybook in cluster-ui by properly
constructing the weback config prior to use in storybook.

Release note: None