### PR TITLE
asim: apply workload to simulator state

### DIFF
--- a/pkg/kv/kvserver/asim/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
     ],
     embed = [":asim"],
     deps = [
+        "//pkg/roachpb",
         "//pkg/util/timeutil",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/kv/kvserver/asim/asim.go
+++ b/pkg/kv/kvserver/asim/asim.go
@@ -12,6 +12,7 @@ package asim
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/allocatorimpl"
@@ -22,7 +23,9 @@ import (
 // Range spans keys greater or equal to MinKey and smaller than the MinKey of
 // the next range.
 type Range struct {
-	MinKey string
+	MinKey      string
+	Leaseholder *Replica
+	Desc        *roachpb.RangeDescriptor
 }
 
 // Less is part of the btree.Item interface.
@@ -32,7 +35,15 @@ func (r *Range) Less(than btree.Item) bool {
 
 // RangeMap (unlike a regular map) can return the Range responsible for a key.
 type RangeMap struct {
-	ranges *btree.BTree
+	ranges      *btree.BTree
+	lastRangeID int
+}
+
+// nextRangeID returns the next available ID to assign to a new range, updating
+// it's counter. Calls to this method are monotonic.
+func (rm *RangeMap) nextRangeID() int {
+	rm.lastRangeID++
+	return rm.lastRangeID
 }
 
 // NewRangeMap returns a valid empty RangeMap.
@@ -40,36 +51,96 @@ func NewRangeMap() *RangeMap {
 	return &RangeMap{ranges: btree.New(8)}
 }
 
-// AddRange adds a range to the RangeMap.
-func (r *RangeMap) AddRange(repl *Range) {
-	// TODO: should we panic/fail if the range exists?
-	r.ranges.ReplaceOrInsert(repl)
+// AddRange adds a range to the RangeMap. The inserted range has it's end key
+// updated with it's successor min key if exists. Likewise, updating the
+// predecessor range's end key with it's own min key, if a predecessor exists.
+// This operation is the same as splitting a range at min key [start, end) into
+// [start,minKey) [minKey, end).
+func (rm *RangeMap) AddRange(minKey string) *Range {
+	r := &Range{MinKey: minKey, Desc: &roachpb.RangeDescriptor{RangeID: roachpb.RangeID(rm.nextRangeID())}}
+
+	endKey := roachpb.RKeyMax
+	// Find the sucessor range in the range map, to determine the endkey.
+	rm.ranges.AscendGreaterOrEqual(r, func(i btree.Item) bool {
+		// The min key already exists in the range map, we cannot return a new
+		// range. Instead crash here as this is a bug.
+		if i.Less(r) {
+			panic(fmt.Sprintf("Range with minKey: %s already exists within the range map, unable to add new range", r.MinKey))
+		}
+
+		successorRange, _ := i.(*Range)
+		endKey = roachpb.RKey(successorRange.MinKey)
+
+		return false
+	})
+
+	// Find the predecessor range, to update it's endkey to the new range's min
+	// key.
+	rm.ranges.DescendLessOrEqual(r, func(i btree.Item) bool {
+		// The case where the min key already exists cannot occur here, as a
+		// panic will have fired in the above iteration.
+		predecessorRange, _ := i.(*Range)
+		predecessorRange.Desc.EndKey = roachpb.RKey(r.MinKey)
+		return false
+	})
+
+	r.Desc.EndKey = endKey
+	r.Desc.StartKey = roachpb.RKey(r.MinKey)
+	rm.ranges.ReplaceOrInsert(r)
+	return r
 }
 
 // GetRange returns the range that should own the key.
 // TODO: guarantee that we have a minimum key, otherwise we might return nil.
-func (r *RangeMap) GetRange(key string) *Range {
+func (rm *RangeMap) GetRange(key string) *Range {
 	keyToFind := &Range{MinKey: key}
 	var rng *Range
 
 	// If keyToFind equals to MinKey of the range, we found the right range, if
 	// the range is Less than keyToFind then this is the right range also.
-	r.ranges.DescendLessOrEqual(keyToFind, func(i btree.Item) bool {
+	rm.ranges.DescendLessOrEqual(keyToFind, func(i btree.Item) bool {
 		rng = i.(*Range)
 		return false
 	})
 	return rng
 }
 
+// ReplicaLoad is the sum of all key accesses and size of bytes, both written
+// and read.
+// TODO(kvoli): In the non-simulated code, replica_stats currently maintains
+// this structure, which is rated. This datastructure needs to be adapated by
+// the user to be rated over time. In the future we should introduce a better
+// general pupose stucture that enables rating.
+type ReplicaLoad struct {
+	WriteKeys  int64
+	WriteBytes int64
+	ReadKeys   int64
+	ReadBytes  int64
+}
+
+// applyReplicaLoad applies a load event onto a replica.
+func (r *Replica) applyReplicaLoad(le LoadEvent) {
+	if le.isWrite {
+		r.ReplicaLoad.WriteBytes += le.size
+		r.ReplicaLoad.WriteKeys++
+	} else {
+		r.ReplicaLoad.ReadBytes += le.size
+		r.ReplicaLoad.ReadKeys++
+	}
+}
+
 // Replica represents a replica of a range.
 type Replica struct {
-	spanConf *roachpb.SpanConfig
-	desc     *roachpb.RangeDescriptor
+	spanConf    *roachpb.SpanConfig
+	rangeDesc   *roachpb.RangeDescriptor
+	replDesc    *roachpb.ReplicaDescriptor
+	ReplicaLoad ReplicaLoad
+	leaseHolder bool
 }
 
 // Store simulates a store within a node.
 type Store struct {
-	replicas  map[int]*Replica
+	Replicas  map[int]*Replica
 	allocator allocatorimpl.Allocator
 }
 
@@ -96,7 +167,7 @@ type State struct {
 	Cluster    *ClusterInfo
 
 	// This is the entire key space.
-	Ranges RangeMap
+	Ranges *RangeMap
 }
 
 // NewState constructs a valid empty state.
@@ -116,6 +187,8 @@ func (s *State) AddNode() (nodeID int) {
 }
 
 // AddStore adds a store to an existing node.
+// TODO(lidorcarmel,kvoli): Add storeID parameter to support multi-store
+// configurations.
 func (s *State) AddStore(node int) {
 	allocator := allocatorimpl.MakeAllocator(
 		nil,
@@ -124,7 +197,86 @@ func (s *State) AddStore(node int) {
 		},
 		nil,
 	)
-	s.Nodes[node].Stores = append(s.Nodes[node].Stores, &Store{allocator: allocator})
+	store := &Store{
+		allocator: allocator,
+		Replicas:  make(map[int]*Replica),
+	}
+	s.Nodes[node].Stores = append(s.Nodes[node].Stores, store)
+}
+
+// AddReplica adds a new replica for a range to the first store on the node.
+// TODO: support multiple stores per node.
+func (s *State) AddReplica(r *Range, node int) int {
+	// The node doesn't exist, we are unable to add a replica to a store on
+	// that node.
+	if _, ok := s.Nodes[node]; !ok {
+		panic(fmt.Sprintf("No node: %d exists, unable to add a replica on range %s", node, r.Desc.RangeID.String()))
+	}
+
+	nodeImpl := s.Nodes[node]
+	// Initially we assume that there is one store per node.
+	desc := r.Desc.AddReplica(roachpb.NodeID(node), roachpb.StoreID(node), roachpb.VOTER_FULL)
+
+	repl := &Replica{
+		spanConf:    &roachpb.SpanConfig{},
+		rangeDesc:   r.Desc,
+		replDesc:    &desc,
+		ReplicaLoad: ReplicaLoad{},
+	}
+
+	store := nodeImpl.Stores[0]
+	// NB: The store map of replicas is the key value pair range id -> replica.
+	//     Adding more than one replica for a range, per store should fail.
+	if existing, ok := store.Replicas[int(r.Desc.RangeID)]; ok {
+		panic(fmt.Sprintf(
+			"replica for range %s already exists on node %d with"+
+				"replicaID %s, unable to add a replica",
+			r.Desc.RangeID,
+			node, existing.replDesc.ReplicaID,
+		))
+	}
+
+	store.Replicas[int(r.Desc.RangeID)] = repl
+
+	// We set the replica to be the leaseholder if one doesn't already
+	// exist.
+	if r.Leaseholder == nil {
+		r.Leaseholder = repl
+		repl.leaseHolder = true
+	}
+	return int(desc.ReplicaID)
+}
+
+// StoreLoad represents the current load of the store.
+type StoreLoad struct {
+	WriteKeys  int64
+	WriteBytes int64
+	ReadKeys   int64
+	ReadBytes  int64
+	RangeCount int64
+	LeaseCount int64
+}
+
+// GetStoreLoad returns the current store load. The values in Write(Read)
+// Bytes(Keys) represent the aggregation across all leaseholder replicas on
+// this store. These values are not rated, instead they are counters.
+// TODO(kvoli): We should separate out recording of workload against
+// replicas and stores into a separate file. The internal capture datastructure
+// is less important. Then define an interface that transforms the recorded
+// load into store descriptors and range usage info.
+func (s *Store) GetStoreLoad() StoreLoad {
+	storeLoad := StoreLoad{}
+	for _, repl := range s.Replicas {
+		if repl.leaseHolder {
+			storeLoad.LeaseCount++
+		}
+		storeLoad.RangeCount++
+		storeLoad.ReadKeys += repl.ReplicaLoad.ReadKeys
+		storeLoad.WriteKeys += repl.ReplicaLoad.WriteKeys
+		storeLoad.WriteBytes += repl.ReplicaLoad.WriteBytes
+		storeLoad.ReadBytes += repl.ReplicaLoad.ReadBytes
+	}
+	return storeLoad
 }
 
 // ApplyAllocatorAction updates the state with allocator ops such as
@@ -139,6 +291,15 @@ func (s *State) ApplyAllocatorAction(
 // as QPS for replicas. Note that this means we don't store which keys were
 // written and therefore reads never fail.
 func (s *State) ApplyLoad(ctx context.Context, le LoadEvent) {
+	r := s.Ranges.GetRange(fmt.Sprintf("%d", le.Key))
+
+	// Apply the load event to the leaseholder replica of the range this key is contained in.
+	//
+	//NB: Reads may occur in practice across follower replicas, however these
+	// statistics are not currently considered in allocation decisions.
+	// Initially we ignore workload on followers.
+	// TODO(kvoli): Apply write/read load to followers.
+	r.Leaseholder.applyReplicaLoad(le)
 }
 
 func shouldRun(time.Time) bool {
@@ -234,10 +395,10 @@ func (s *Simulator) RunSim(ctx context.Context) {
 
 		for _, node := range stateForAlloc.Nodes {
 			for _, store := range node.Stores {
-				for _, r := range store.replicas {
+				for _, r := range store.Replicas {
 					// Run the real allocator code. Note that the input is from the
 					// "frozen" state which is not affected by rebalancing decisions.
-					done, action, priority := RunAllocator(ctx, store.allocator, *r.spanConf, r.desc, tick)
+					done, action, priority := RunAllocator(ctx, store.allocator, *r.spanConf, r.rangeDesc, tick)
 					if done {
 						break
 					}

--- a/pkg/kv/kvserver/asim/asim_test.go
+++ b/pkg/kv/kvserver/asim/asim_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,16 +42,90 @@ func TestRunAllocatorSimulator(t *testing.T) {
 func TestRangeMap(t *testing.T) {
 	m := asim.NewRangeMap()
 
-	r1 := asim.Range{MinKey: "b"}
-	r2 := asim.Range{MinKey: "f"}
-	r3 := asim.Range{MinKey: "x"}
+	r1 := m.AddRange("b")
+	r2 := m.AddRange("f")
+	r3 := m.AddRange("x")
 
-	m.AddRange(&r1)
-	m.AddRange(&r2)
-	m.AddRange(&r3)
+	// Assert that the range is segmented into [minKey, EndKey) intervals.
+	require.Equal(t, roachpb.RKey("f"), r1.Desc.EndKey)
+	require.Equal(t, roachpb.RKey("x"), r2.Desc.EndKey)
+	require.Equal(t, roachpb.RKeyMax, r3.Desc.EndKey)
 
 	require.Equal(t, (*asim.Range)(nil), m.GetRange("a"))
-	require.Equal(t, &r1, m.GetRange("b"))
-	require.Equal(t, &r1, m.GetRange("c"))
-	require.Equal(t, &r3, m.GetRange("z"))
+	require.Equal(t, r1.MinKey, m.GetRange("b").MinKey)
+	require.Equal(t, r1.MinKey, m.GetRange("c").MinKey)
+	require.Equal(t, r2.MinKey, m.GetRange("g").MinKey)
+	require.Equal(t, r3.MinKey, m.GetRange("z").MinKey)
+}
+
+func TestAddReplica(t *testing.T) {
+	s := asim.NewState()
+	s.Ranges = asim.NewRangeMap()
+	rm := s.Ranges
+
+	r1 := rm.AddRange("b")
+	r2 := rm.AddRange("h")
+
+	n1 := s.AddNode()
+	n2 := s.AddNode()
+
+	// Add two replicas on s1, one on s2.
+	r1repl0 := s.AddReplica(r1, n1)
+	r2repl0 := s.AddReplica(r2, n1)
+	r1repl1 := s.AddReplica(r2, n2)
+
+	require.Equal(t, 0, r1repl0)
+	require.Equal(t, 0, r2repl0)
+	require.Equal(t, 1, r1repl1)
+
+	s1 := s.Nodes[n1].Stores[0]
+	s2 := s.Nodes[n2].Stores[0]
+
+	require.Len(t, s1.Replicas, 2)
+	require.Len(t, s2.Replicas, 1)
+}
+
+// TestWorkloadApply asserts that applying workload on a key, will be reflected
+// on the leaseholder for the range that key is contained within.
+func TestWorkloadApply(t *testing.T) {
+	ctx := context.Background()
+
+	s := asim.NewState()
+	s.Ranges = asim.NewRangeMap()
+	n1 := s.AddNode()
+	n2 := s.AddNode()
+	n3 := s.AddNode()
+
+	r1 := s.Ranges.AddRange("100")
+	r2 := s.Ranges.AddRange("1000")
+	r3 := s.Ranges.AddRange("10000")
+
+	s.AddReplica(r1, n1)
+	s.AddReplica(r2, n2)
+	s.AddReplica(r3, n3)
+
+	applyLoadToStats := func(key int64, count int) {
+		for i := 0; i < count; i++ {
+			s.ApplyLoad(ctx, asim.LoadEvent{Key: key})
+		}
+	}
+
+	applyLoadToStats(100, 100)
+	applyLoadToStats(1000, 1000)
+	applyLoadToStats(10000, 10000)
+
+	// Assert that the leaseholder replica load correctly matches the number of
+	// requests made.
+	require.Equal(t, int64(100), r1.Leaseholder.ReplicaLoad.ReadKeys)
+	require.Equal(t, int64(1000), r2.Leaseholder.ReplicaLoad.ReadKeys)
+	require.Equal(t, int64(10000), r3.Leaseholder.ReplicaLoad.ReadKeys)
+
+	expectedLoad := asim.StoreLoad{ReadKeys: 100, LeaseCount: 1, RangeCount: 1}
+
+	// Assert that the store load is also updated upon request GetStoreLoad.
+	require.Equal(t, expectedLoad, s.Nodes[n1].Stores[0].GetStoreLoad())
+	expectedLoad.ReadKeys *= 10
+	require.Equal(t, expectedLoad, s.Nodes[n2].Stores[0].GetStoreLoad())
+	expectedLoad.ReadKeys *= 10
+	require.Equal(t, expectedLoad, s.Nodes[n3].Stores[0].GetStoreLoad())
 }

--- a/pkg/kv/kvserver/asim/workload.go
+++ b/pkg/kv/kvserver/asim/workload.go
@@ -22,7 +22,7 @@ import (
 type LoadEvent struct {
 	isWrite bool
 	size    int64
-	key     int64
+	Key     int64
 }
 
 // WorkloadGenerator generates workload where each op contains: key,
@@ -94,7 +94,7 @@ func (rwg *RandomWorkloadGenerator) maybeUpdateBuffer(maxTime time.Time) {
 			LoadEvent{
 				size:    int64(rwg.rand.Intn(rwg.maxSize-rwg.minSize+1) + rwg.minSize),
 				isWrite: false,
-				key:     rwg.keyGenerator.readKey(),
+				Key:     rwg.keyGenerator.readKey(),
 			})
 	}
 	for write := 0; write < writes; write++ {
@@ -102,7 +102,7 @@ func (rwg *RandomWorkloadGenerator) maybeUpdateBuffer(maxTime time.Time) {
 			LoadEvent{
 				size:    int64(rwg.rand.Intn(rwg.maxSize-rwg.minSize+1) + rwg.minSize),
 				isWrite: true,
-				key:     rwg.keyGenerator.writeKey(),
+				Key:     rwg.keyGenerator.writeKey(),
 			})
 	}
 	rwg.lastRun = maxTime

--- a/pkg/kv/kvserver/asim/workload_test.go
+++ b/pkg/kv/kvserver/asim/workload_test.go
@@ -41,7 +41,7 @@ func summary(ops []LoadEvent, cycleLength int) summaryStats {
 	distribution := make([]int, len(ops))
 	for i, op := range ops {
 		sizeSum += int(op.size)
-		distribution[i] = int(op.key)
+		distribution[i] = int(op.Key)
 		if op.isWrite {
 			writes++
 		} else {


### PR DESCRIPTION
This patch applies load events to the state of replicas. The load state
of replicas may then be aggregated by the store it resides on. In
addition, a method to add a replica to a range is introduced.

The load representations that allocator uses are loosely defined as
separate structures: ReplicaLoad and StoreLoad. These correspond to
RangeUsage and StoreCapacity in roachpb, however notably do not rate
any values e.g. QPS. The intention is for an adapter to perform this
translation when necessary, calling allocator actions.

Release note: None