### PR TITLE
ci: fail if `redact_safe.md` is not up-to-date

### DIFF
--- a/build/teamcity/cockroach/ci/builds/build_linux_x86_64.sh
+++ b/build/teamcity/cockroach/ci/builds/build_linux_x86_64.sh
@@ -77,6 +77,7 @@ RESULT=$(diff <(echo "$REAL_REDACT_SAFE") $root/docs/generated/redact_safe.md)
 if [[ ! $? -eq 0 ]]
 then
     echo "docs/generated/redact_safe.md is not up-to-date. Run './dev generate docs'"
+    FAILED=1
 fi
 
 if [[ ! -z "$FAILED" ]]


### PR DESCRIPTION
Release note: None