### PR TITLE
geomfn: ensure NaN never intersects/covers/within

### DIFF
--- a/pkg/geo/geomfn/point_polygon_optimization.go
+++ b/pkg/geo/geomfn/point_polygon_optimization.go
@@ -161,6 +161,10 @@ func PointKindWithinPolygonKind(pointKind geo.Geometry, polygonKind geo.Geometry
 func pointKindRelatesToPolygonKind(
 	pointKind geo.Geometry, polygonKind geo.Geometry, eventListener PointInPolygonEventListener,
 ) (bool, error) {
+	// Nothing can relate to a NaN coordinate.
+	if BoundingBoxHasNaNCoordinates(pointKind) || BoundingBoxHasNaNCoordinates(polygonKind) {
+		return false, nil
+	}
 	pointKindBaseT, err := pointKind.AsGeomT()
 	if err != nil {
 		return false, err

--- a/pkg/geo/geomfn/topology_operations.go
+++ b/pkg/geo/geomfn/topology_operations.go
@@ -208,17 +208,36 @@ func MinimumRotatedRectangle(g geo.Geometry) (geo.Geometry, error) {
 	return gm, nil
 }
 
-// CheckBoundingBoxInfiniteCoordinates checks if the bounding box of a Geometry
-// has infinite coordinate.
-func CheckBoundingBoxInfiniteCoordinates(g geo.Geometry) bool {
+// BoundingBoxHasInfiniteCoordinates checks if the bounding box of a Geometry
+// has an infinite coordinate.
+func BoundingBoxHasInfiniteCoordinates(g geo.Geometry) bool {
 	boundingBox := g.BoundingBoxRef()
 	if boundingBox == nil {
 		return false
 	}
-	for _, coord := range []float64{boundingBox.LoX, boundingBox.LoY, boundingBox.HiX, boundingBox.HiY} {
-		if math.IsInf(coord, 0) {
-			return true
-		}
+	// Don't use `:= range []float64{...}` to avoid memory allocation.
+	isInf := func(ord float64) bool {
+		return math.IsInf(ord, 0)
+	}
+	if isInf(boundingBox.LoX) || isInf(boundingBox.LoY) || isInf(boundingBox.HiX) || isInf(boundingBox.HiY) {
+		return true
+	}
+	return false
+}
+
+// BoundingBoxHasNaNCoordinates checks if the bounding box of a Geometry
+// has a NaN coordinate.
+func BoundingBoxHasNaNCoordinates(g geo.Geometry) bool {
+	boundingBox := g.BoundingBoxRef()
+	if boundingBox == nil {
+		return false
+	}
+	// Don't use `:= range []float64{...}` to avoid memory allocation.
+	isNaN := func(ord float64) bool {
+		return math.IsNaN(ord)
+	}
+	if isNaN(boundingBox.LoX) || isNaN(boundingBox.LoY) || isNaN(boundingBox.HiX) || isNaN(boundingBox.HiY) {
+		return true
 	}
 	return false
 }

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -5878,3 +5878,14 @@ SELECT ST_LineCrossingDirection(line1, line2), ST_LineCrossingDirection(line2, l
 -1  1
 2   -2
 -2  2
+
+# NaN coordinates do not work with PIP.
+query BBB
+SELECT ST_Intersects(point, polygon), ST_Within(point, polygon), ST_Contains(polygon, point)
+FROM ( VALUES
+  (ST_MakePoint('NaN', 1), 'POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry),
+  (ST_MakePoint(0, 1), ST_MakePolygon(ST_AddPoint(ST_AddPoint('LINESTRING(0 0, 1 0)', ST_MakePoint(0, 'NaN')), ST_MakePoint(0, 0))))
+) t(point, polygon)
+----
+false  false  false
+false  false  false

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -3181,7 +3181,7 @@ Note If the result has zero or one points, it will be returned as a POINT. If it
 		defProps(),
 		geometryOverload1(
 			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
-				if geomfn.CheckBoundingBoxInfiniteCoordinates(g.Geometry) {
+				if geomfn.BoundingBoxHasInfiniteCoordinates(g.Geometry) {
 					return nil, pgerror.Newf(pgcode.InvalidParameterValue, "value out of range: overflow")
 				}
 				line, err := geomfn.LineMerge(g.Geometry)
@@ -6471,7 +6471,7 @@ The parent_only boolean is always ignored.`,
 	"st_minimumboundingcircle": makeBuiltin(defProps(),
 		geometryOverload1(
 			func(evalContext *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
-				if geomfn.CheckBoundingBoxInfiniteCoordinates(g.Geometry) {
+				if geomfn.BoundingBoxHasInfiniteCoordinates(g.Geometry) {
 					return nil, pgerror.Newf(pgcode.InvalidParameterValue, "value out of range: overflow")
 				}
 				polygon, _, _, err := geomfn.MinimumBoundingCircle(g.Geometry)


### PR DESCRIPTION
Resolves #79992

Release note (bug fix): Fixed a bug where NaN coordinates when using
ST_Intersects/ST_Within/ST_Covers would return true instead of false for
point in polygon operations.