### PR TITLE
rowexec: use streamer for lookup joins with no ordering

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/results_buffer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/results_buffer_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 // TestInOrderResultsBuffer verifies that the inOrderResultsBuffer returns the
-// results in the correct order (with increasing 'position' values).
+// results in the correct order (with increasing 'Position' values).
 // Additionally, it randomly asks the buffer to spill to disk.
 func TestInOrderResultsBuffer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -73,7 +73,7 @@ func TestInOrderResultsBuffer(t *testing.T) {
 			// Randomly choose between Get and Scan responses.
 			if rng.Float64() < 0.5 {
 				get := makeResultWithGetResp(rng, rng.Float64() < 0.1 /* empty */)
-				get.position = i
+				get.Position = i
 				results = append(results, get)
 			} else {
 				scan := makeResultWithScanResp(rng)
@@ -81,7 +81,7 @@ func TestInOrderResultsBuffer(t *testing.T) {
 				// responses spanning multiple ranges for a single original Scan
 				// request.
 				scan.ScanResp.Complete = true
-				scan.position = i
+				scan.Position = i
 				results = append(results, scan)
 			}
 			results[len(results)-1].memoryTok.toRelease = rng.Int63n(100)
@@ -117,7 +117,7 @@ func TestInOrderResultsBuffer(t *testing.T) {
 				spillingPriority := rng.Intn(numExpectedResponses)
 				var spillableSize int64
 				for _, buffered := range b.(*inOrderResultsBuffer).buffered {
-					if !buffered.onDisk && buffered.position > spillingPriority {
+					if !buffered.onDisk && buffered.Position > spillingPriority {
 						spillableSize += buffered.memoryTok.toRelease
 					}
 				}

--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -107,16 +107,16 @@ type Result struct {
 		streamer  *Streamer
 		toRelease int64
 	}
-	// position tracks the ordinal among all originally enqueued requests that
+	// Position tracks the ordinal among all originally enqueued requests that
 	// this result satisfies. See singleRangeBatch.positions for more details.
 	//
 	// If Streamer.Enqueue() was called with nil enqueueKeys argument, then
-	// EnqueueKeysSatisfied will exactly contain position; if non-nil
-	// enqueueKeys argument was passed, then position is used as an ordinal to
+	// EnqueueKeysSatisfied will exactly contain Position; if non-nil
+	// enqueueKeys argument was passed, then Position is used as an ordinal to
 	// lookup into enqueueKeys to populate EnqueueKeysSatisfied.
 	// TODO(yuzefovich): this might need to be []int when non-unique requests
 	// are supported.
-	position int
+	Position int
 }
 
 // Hints provides different hints to the Streamer for optimization purposes.
@@ -1280,7 +1280,7 @@ func (w *workerCoordinator) processSingleRangeResults(
 					// This currently only works because all requests are
 					// unique.
 					EnqueueKeysSatisfied: []int{enqueueKey},
-					position:             position,
+					Position:             position,
 				}
 				result.memoryTok.streamer = w.s
 				result.memoryTok.toRelease = getResponseSize(get)
@@ -1313,7 +1313,7 @@ func (w *workerCoordinator) processSingleRangeResults(
 					// This currently only works because all requests
 					// are unique.
 					EnqueueKeysSatisfied: []int{enqueueKey},
-					position:             position,
+					Position:             position,
 				}
 				result.memoryTok.streamer = w.s
 				result.memoryTok.toRelease = scanResponseSize(scan)
@@ -1420,8 +1420,8 @@ func (w *workerCoordinator) finalizeSingleRangeResults(
 			if results[i].ScanResp.ScanResponse != nil {
 				if results[i].ScanResp.ResumeSpan == nil {
 					// The scan within the range is complete.
-					w.s.mu.numRangesLeftPerScanRequest[results[i].position]--
-					if w.s.mu.numRangesLeftPerScanRequest[results[i].position] == 0 {
+					w.s.mu.numRangesLeftPerScanRequest[results[i].Position]--
+					if w.s.mu.numRangesLeftPerScanRequest[results[i].Position] == 0 {
 						// The scan across all ranges is now complete too.
 						results[i].ScanResp.Complete = true
 					}

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -218,12 +218,15 @@ func (s *ColIndexJoin) Next() coldata.Batch {
 				continue
 			}
 
-			if !s.maintainOrdering {
+			if !s.usesStreamer && !s.maintainOrdering {
 				// Sort the spans when !maintainOrdering. This allows lower layers to
 				// optimize iteration over the data. Note that the looked up rows are
 				// output unchanged, in the retrieval order, so it is not safe to do
 				// this when maintainOrdering is true (the ordering to be maintained
 				// may be different than the ordering in the index).
+				//
+				// We don't want to sort the spans here if we're using the
+				// Streamer since it will perform the sort on its own.
 				sort.Sort(spans)
 			}
 

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -462,9 +462,10 @@ func (dsp *DistSQLPlanner) Run(
 	if row.CanUseStreamer(ctx, dsp.st) {
 		for _, proc := range plan.Processors {
 			if jr := proc.Spec.Core.JoinReader; jr != nil {
-				if jr.IsIndexJoin() {
-					// Index joins are executed via the Streamer API that has
-					// concurrency.
+				if jr.IsIndexJoin() || !jr.MaintainOrdering {
+					// Index joins with and without ordering as well as lookup
+					// joins without ordering are executed via the Streamer API
+					// that has concurrency.
 					localState.HasConcurrency = true
 					break
 				}

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_trace
@@ -32,7 +32,7 @@ SET tracing = on, kv; SELECT * FROM abc JOIN def ON d = c WHERE a > 1 AND e > 1;
 # We should not be fetching /def/def_pkey/1/1 key because it fails 'e > 1'
 # filter.
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader'
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader' AND message NOT LIKE 'querying next range%'
 ----
 Scan /Table/107/1/{1/2-2}
 fetched: /def/def_pkey/1/2 -> <undecoded>
@@ -147,7 +147,7 @@ SET tracing = off;
 # We should not be fetching the key with '2020-01-01 00:00:00+00:00' value for
 # the 'time' column since it doesn't satisfy the filter on 'time'.
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader'
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader' AND message NOT LIKE 'querying next range%'
 ----
 Scan /Table/109/1/{1/2020-01-01T00:00:00.000001Z-2}, /Table/109/1/{2/2020-01-01T00:00:00.000001Z-3}
 fetched: /metric_values/metric_values_pkey/1/'2020-01-01 00:00:01+00:00'/nullable/value -> /1/1
@@ -168,7 +168,7 @@ SET tracing = off;
 
 # The start boundary of the spans should exclude NULL values.
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader'
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader' AND message NOT LIKE 'querying next range%'
 ----
 Scan /Table/109/1/1/{!NULL-2020-01-01T00:00:00Z}, /Table/109/1/2/{!NULL-2020-01-01T00:00:00Z}
 
@@ -186,7 +186,7 @@ SET tracing = off;
 # We should not be fetching two keys with '2020-01-01 00:00:00+00:00' value for
 # the 'time' column since they don't satisfy the filter on 'time'.
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader'
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader' AND message NOT LIKE 'querying next range%'
 ----
 Scan /Table/110/1/1/{1920-01-01T23:59:59.000000999Z-!NULL}, /Table/110/1/2/{1920-01-01T23:59:59.000000999Z-!NULL}
 
@@ -205,7 +205,7 @@ SET tracing = off;
 # We should not be fetching /metric_values/secondary/1/1 key because it fails
 # 'nullable > 1' filter.
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader'
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader' AND message NOT LIKE 'querying next range%'
 ----
 Scan /Table/109/2/{1/2-2}, /Table/109/2/{2/2-3}
 fetched: /metric_values/secondary/2/2/'2020-01-01 00:00:01+00:00' -> <undecoded>
@@ -229,7 +229,7 @@ SET tracing = off;
 # We should not be fetching two keys with NULL values for the 'nullable' column
 # since they don't satisfy the filter on 'nullable'.
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader'
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader' AND message NOT LIKE 'querying next range%'
 ----
 Scan /Table/109/2/1/{!NULL--10}, /Table/109/2/2/{!NULL--10}
 fetched: /metric_values/secondary/2/-11/'2020-01-01 00:01:01+00:00' -> <undecoded>
@@ -253,7 +253,7 @@ SET tracing = off;
 # We should not be fetching two keys with NULL values for the 'nullable' column
 # since they don't satisfy the filter on 'nullable'.
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader'
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader' AND message NOT LIKE 'querying next range%'
 ----
 Scan /Table/109/2/1/{!NULL--9}, /Table/109/2/2/{!NULL--9}
 fetched: /metric_values/secondary/2/-11/'2020-01-01 00:01:01+00:00' -> <undecoded>
@@ -279,7 +279,7 @@ SET tracing = off;
 # We should not be fetching two keys with NULL values for the 'nullable' column
 # since they don't satisfy the filter on 'nullable'.
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader'
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader' AND message NOT LIKE 'querying next range%'
 ----
 Scan /Table/109/2/1/{!NULL--9}, /Table/109/2/2/{!NULL--9}
 fetched: /metric_values/secondary/2/-11/'2020-01-01 00:01:01+00:00' -> <undecoded>

--- a/pkg/sql/row/kv_batch_streamer.go
+++ b/pkg/sql/row/kv_batch_streamer.go
@@ -102,8 +102,7 @@ func (f *TxnKVStreamer) proceedWithLastResult(
 			f.releaseLastResult(ctx)
 			return true, kvBatchFetcherResponse{}, nil
 		}
-		pos := result.EnqueueKeysSatisfied[f.lastResultState.numEmitted]
-		origSpan := f.spans[pos]
+		origSpan := f.spans[result.Position]
 		f.lastResultState.numEmitted++
 		f.getResponseScratch[0] = roachpb.KeyValue{Key: origSpan.Key, Value: *get.Value}
 		ret.kvs = f.getResponseScratch[:]

--- a/pkg/sql/rowcontainer/kvstreamer_result_disk_buffer.go
+++ b/pkg/sql/rowcontainer/kvstreamer_result_disk_buffer.go
@@ -147,8 +147,8 @@ func (b *kvStreamerResultDiskBuffer) Close(ctx context.Context) {
 // kvstreamer.Result that is spilled to disk.
 //
 // It contains all the information except for 'ScanResp.Complete', 'memoryTok',
-// and 'position' fields which are kept in-memory (because they are allocated in
-// inOrderBufferedResult.Result anyway).
+// and 'Position' fields which are kept in-memory (because they are allocated in
+// kvstreamer.inOrderBufferedResult.Result anyway).
 var inOrderResultsBufferSpillTypeSchema = []*types.T{
 	types.Bool, // isGet
 	// GetResp.Value:

--- a/pkg/sql/rowexec/joinreader_blackbox_test.go
+++ b/pkg/sql/rowexec/joinreader_blackbox_test.go
@@ -56,6 +56,13 @@ func TestJoinReaderUsesBatchLimit(t *testing.T) {
 	})
 	defer s.Stopper().Stop(ctx)
 
+	// Disable the usage of the streamer since this test is designed for the old
+	// non-streamer code path.
+	// TODO(yuzefovich): remove the test altogether when the corresponding
+	// cluster setting is removed (i.e. only the streamer code path remains).
+	_, err := sqlDB.Exec("SET CLUSTER SETTING sql.distsql.use_streamer.enabled = false;")
+	require.NoError(t, err)
+
 	// We're going to create a table with enough rows to exceed a batch's memory
 	// limit. This table will represent the lookup side of a lookup join.
 	const numRows = 50


### PR DESCRIPTION
**row: fix the usage of Get requests with the streamer in some cases**

Previously, `TxnKVStreamer` processed the Get responses under the
assumption that `nil` `enqueueKeys` argument was provided. In such
a scenario, `EnqueueKeysSatisfied` contained an ordinal into the
original spans slice that is needed to process the Get response
correctly. We will shortly expand the usage of the Streamer to use
non-nil `enqueueKeys` argument which breaks that assumption. We go
around it by exporting `Result.Position` value which tracks exactly the
information we need.

Release note: None

**rowexec: use streamer for lookup joins with no ordering**

This commit expands the usage of the Streamer to lookup joins when
ordering doesn't have to be maintained. We can do so easily since the
join reader span generators de-duplicate spans, so the Streamer will
only be asked to process unique requests.

In theory, we should be able to do the same for the cases when ordering
needs to be maintained, but `InOrder` mode of the Streamer currently has
known bugs / limitations when a single request can result in multiple
rows - this wasn't an issue for the index joins since those are
guaranteed to get a single row for each request.

Also, we want to push the de-duplication logic from the join reader into
the Streamer (in order to inform the behavior of the yet-to-be-added
cache in the Streamer), but that will come after addressing the known
`InOrder` bugs mentioned above.

Some adjustments were needed:
- In order to improve the behavior with low `workmem` limit (in
particular, `regional_by_row` CCL logic test file was erroring out) of
the join reader we now make the batch size hint at most 1/12 of the
limit while giving the streamer the same three quarters - this allows
for other in-memory state of the join reader itself to have some space.
- One lookup join unit test is designed with the non-streamer code path
in mind, so we disable the usage of the streamer there.
- `lookup_join_trace` execbuilder file needed to filter out messages
produced by the range cache.

Out of curiosity, I decided to do a quick comparison of TPCH numbers
with the Streamer `off` (first column) and `on` (second column)
(negative numbers indicate the latency reduction, positive - latency
increase):
```
Q1:   3.78s  3.28s -13.36%
Q2:   0.19s  0.19s  2.11%
Q3:   1.72s  1.48s -13.89%
Q4:   1.57s  1.25s -20.54%
Q5:   2.74s  2.49s -9.06%
Q6:   6.36s  8.19s  28.74%
Q7:   6.97s  7.35s  5.42%
Q8:   1.00s  1.09s  8.68%
Q9:   6.52s  6.93s  6.32%
Q10:  1.93s  1.63s -15.60%
Q11:  0.52s  0.57s  9.06%
Q12:  7.16s  8.89s  24.17%
Q13:  1.17s  1.13s -3.43%
Q14:  0.57s  0.66s  13.91%
Q15:  4.83s  5.53s  14.34%
Q16:  0.81s  0.78s -4.08%
Q17:  0.48s  0.48s  0.84%
Q18:  5.61s  5.33s -4.96%
Q19:  3.86s  3.41s -11.83%
Q20: 12.00s 14.37s  19.79%
Q21:  9.33s  7.24s -22.38%
Q22:  0.57s  0.55s -4.03%
```
This mostly confirms our expectations - lookup joins should get faster
since we now parallelize the lookups. Index joins already get parallel
lookups in the old code path, so we have some regressions. Notably, Q6
and Q12 spend most of the time performing index joins and Q20 is
dominated by an index join and a parallelizable (when lookup columns
form a key) lookup joins.

Addresses: #54680

Release note: None

**sql: don't sort spans redundantly when using the streamer**

This commit makes it so that the lookup and index joins don't sort the
spans when the ordering doesn't have to be maintained and the Streamer
API is used - the Streamer itself performs the sort of spans within
single-range batches, so the caller's sort is redundant.

Release note: None