### PR TITLE
workload/schemachanger: enable foreign key constraint support

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -3049,6 +3049,9 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.is_at_least_version"></a><code>crdb_internal.is_at_least_version(version: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if the cluster version is not older than the argument.</p>
 </span></td></tr>
+<tr><td><a name="crdb_internal.is_constraint_active"></a><code>crdb_internal.is_constraint_active(table_name: <a href="string.html">string</a>, constraint_name: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>This function is used to revalidate the given unique constraint in the given
+table. Returns an error if validation fails.</p>
+</span></td></tr>
 <tr><td><a name="crdb_internal.lease_holder"></a><code>crdb_internal.lease_holder(key: <a href="bytes.html">bytes</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used to fetch the leaseholder corresponding to a request key</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.list_sql_keys_in_range"></a><code>crdb_internal.list_sql_keys_in_range(range_id: <a href="int.html">int</a>) &rarr; tuple{string AS key, string AS value}</code></td><td><span class="funcdesc"><p>Returns all SQL K/V pairs within the requested range.</p>

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -3049,8 +3049,8 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.is_at_least_version"></a><code>crdb_internal.is_at_least_version(version: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if the cluster version is not older than the argument.</p>
 </span></td></tr>
-<tr><td><a name="crdb_internal.is_constraint_active"></a><code>crdb_internal.is_constraint_active(table_name: <a href="string.html">string</a>, constraint_name: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>This function is used to revalidate the given unique constraint in the given
-table. Returns an error if validation fails.</p>
+<tr><td><a name="crdb_internal.is_constraint_active"></a><code>crdb_internal.is_constraint_active(table_name: <a href="string.html">string</a>, constraint_name: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>This function is used to determine if a given constraint is currently.
+active for the current transaction.</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.lease_holder"></a><code>crdb_internal.lease_holder(key: <a href="bytes.html">bytes</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used to fetch the leaseholder corresponding to a request key</p>
 </span></td></tr>

--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/interval",
         "//pkg/util/iterutil",
+        "//pkg/util/log",
         "//pkg/util/protoutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -49,7 +49,6 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/interval",
         "//pkg/util/iterutil",
-        "//pkg/util/log",
         "//pkg/util/protoutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -210,7 +210,8 @@ func (p *planner) canRemoveFKBackreference(
 		return err
 	}
 	if behavior != tree.DropCascade {
-		return fmt.Errorf("%q is referenced by foreign key from table %q", from, table.Name)
+		return pgerror.Newf(pgcode.DependentObjectsStillExist,
+			"%q is referenced by foreign key from table %q", from, table.Name)
 	}
 	// Check to see whether we're allowed to edit the table that has a
 	// foreign key constraint on the table that we're dropping right now.

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -24,6 +24,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -271,6 +271,13 @@ func (*DummyEvalPlanner) RevalidateUniqueConstraint(
 	return errors.WithStack(errEvalPlanner)
 }
 
+// IsConstraintActive is part of the EvalPlanner interface.
+func (*DummyEvalPlanner) IsConstraintActive(
+	ctx context.Context, tableID int, constraintName string,
+) (bool, error) {
+	return false, errors.WithStack(errEvalPlanner)
+}
+
 // ValidateTTLScheduledJobsInCurrentDB is part of the Planner interface.
 func (*DummyEvalPlanner) ValidateTTLScheduledJobsInCurrentDB(ctx context.Context) error {
 	return errors.WithStack(errEvalPlanner)

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1257,7 +1257,6 @@ https://www.postgresql.org/docs/9.5/infoschema-table-constraints.html`,
 						return err
 					}
 				}
-
 				// Unlike with pg_catalog.pg_constraint, Postgres also includes NOT
 				// NULL column constraints in information_schema.check_constraints.
 				// Cockroach doesn't track these constraints as check constraints,

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -4102,3 +4102,20 @@ DELETE FROM p76852 WHERE i = 1;
 query B
 SELECT b FROM c76852@idx WHERE b
 ----
+
+# Tests the scenario where a foreign key constraint is added and the table
+# referencing it is dropped.
+subtest 79972
+
+statement ok
+CREATE TABLE drop_fk_during_addition (name INT8);
+CREATE TABLE drop_fk_during_addition_ref (name INT8 PRIMARY KEY);
+
+statement ok
+BEGIN;
+ALTER TABLE drop_fk_during_addition
+	ADD CONSTRAINT fk FOREIGN KEY (name) REFERENCES drop_fk_during_addition_ref (name);
+DROP TABLE drop_fk_during_addition_ref;
+
+statement error pgcode XXA00 pq: transaction committed but schema change aborted with error: \(42P01\): referenced relation \"drop_fk_during_addition_ref\" does not exist
+COMMIT;

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -6746,7 +6746,7 @@ table. Returns an error if validation fails.`,
 					return nil, err
 				}
 				active, err := evalCtx.Planner.IsConstraintActive(
-					evalCtx.Ctx(), int(dOid.DInt), string(constraintName),
+					evalCtx.Ctx(), int(dOid.Oid), string(constraintName),
 				)
 				if err != nil {
 					return nil, err

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -294,6 +294,10 @@ type Planner interface {
 	// constraint on the table.
 	RevalidateUniqueConstraint(ctx context.Context, tableID int, constraintName string) error
 
+	// IsConstraintActive returns if a given constraint is currently active,
+	// for the current transaction.
+	IsConstraintActive(ctx context.Context, tableID int, constraintName string) (bool, error)
+
 	// ValidateTTLScheduledJobsInCurrentDB checks scheduled jobs for each table
 	// in the database maps to a scheduled job.
 	ValidateTTLScheduledJobsInCurrentDB(ctx context.Context) error

--- a/pkg/sql/sqlerrors/BUILD.bazel
+++ b/pkg/sql/sqlerrors/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "//pkg/util/log",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -12,12 +12,16 @@
 package sqlerrors
 
 import (
+	"context"
+	"runtime/debug"
+
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
 
@@ -105,6 +109,7 @@ func NewInvalidSchemaDefinitionError(err error) error {
 // NewUndefinedSchemaError creates an error for an undefined schema.
 // TODO (lucy): Have this take a database name.
 func NewUndefinedSchemaError(name string) error {
+	log.Errorf(context.Background(), "MISSING SCHEMA: %s", debug.Stack())
 	return pgerror.Newf(pgcode.InvalidSchemaName, "unknown schema %q", name)
 }
 

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
+	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 )
 
@@ -47,9 +48,11 @@ type operationGeneratorParams struct {
 
 // The OperationBuilder has the sole responsibility of generating ops
 type operationGenerator struct {
-	params               *operationGeneratorParams
-	expectedExecErrors   errorCodeSet
-	expectedCommitErrors errorCodeSet
+	params                *operationGeneratorParams
+	expectedExecErrors    errorCodeSet
+	potentialExecErrors   errorCodeSet
+	expectedCommitErrors  errorCodeSet
+	potentialCommitErrors errorCodeSet
 
 	// This stores expected commit errors while an op statement
 	// is still being constructed. It is possible that one of the functions in opFuncs
@@ -97,6 +100,8 @@ func makeOperationGenerator(params *operationGeneratorParams) *operationGenerato
 		params:                        params,
 		expectedExecErrors:            makeExpectedErrorSet(),
 		expectedCommitErrors:          makeExpectedErrorSet(),
+		potentialExecErrors:           makeExpectedErrorSet(),
+		potentialCommitErrors:         makeExpectedErrorSet(),
 		candidateExpectedCommitErrors: makeExpectedErrorSet(),
 	}
 }
@@ -105,12 +110,14 @@ func makeOperationGenerator(params *operationGeneratorParams) *operationGenerato
 func (og *operationGenerator) resetOpState() {
 	og.expectedExecErrors.reset()
 	og.candidateExpectedCommitErrors.reset()
+	og.potentialExecErrors.reset()
 	og.opGenLog = strings.Builder{}
 }
 
 // Reset internal state used per transaction
 func (og *operationGenerator) resetTxnState() {
 	og.expectedCommitErrors.reset()
+	og.potentialCommitErrors.reset()
 	og.opsInTxn = nil
 	og.stmtsInTxt = nil
 }
@@ -215,7 +222,7 @@ func init() {
 var opWeights = []int{
 	addColumn:               1,
 	addConstraint:           0, // TODO(spaskob): unimplemented
-	addForeignKeyConstraint: 0,
+	addForeignKeyConstraint: 1,
 	addRegion:               1,
 	addUniqueConstraint:     0,
 	alterTableLocality:      1,
@@ -276,6 +283,7 @@ func (og *operationGenerator) randOp(ctx context.Context, tx pgx.Tx) (stmt strin
 		og.stmtsInTxt = append(og.stmtsInTxt, stmt)
 		// Add candidateExpectedCommitErrors to expectedCommitErrors
 		og.expectedCommitErrors.merge(og.candidateExpectedCommitErrors)
+		og.opsInTxn = append(og.opsInTxn, op)
 		break
 	}
 
@@ -785,7 +793,15 @@ func (og *operationGenerator) addForeignKeyConstraint(
 	if err != nil {
 		return "", err
 	}
-	childColumnIsComputed, err := og.columnIsComputed(ctx, tx, parentTable, parentColumn.name)
+	parentColumnIsVirtualComputed, err := og.columnIsVirtualComputed(ctx, tx, parentTable, parentColumn.name)
+	if err != nil {
+		return "", err
+	}
+	childColumnIsVirtualComputed, err := og.columnIsVirtualComputed(ctx, tx, childTable, childColumn.name)
+	if err != nil {
+		return "", err
+	}
+	childColumnIsStoredVirtual, err := og.columnIsStoredComputed(ctx, tx, childTable, childColumn.name)
 	if err != nil {
 		return "", err
 	}
@@ -793,21 +809,39 @@ func (og *operationGenerator) addForeignKeyConstraint(
 	if err != nil {
 		return "", err
 	}
-	rowsSatisfyConstraint, err := og.rowsSatisfyFkConstraint(ctx, tx, parentTable, parentColumn, childTable, childColumn)
-	if err != nil {
-		return "", err
+	// If we are intentionally using an invalid child type, then it doesn't make
+	// sense to validate if the rows validate the constraint.
+	rowsSatisfyConstraint := true
+	if !fetchInvalidChild {
+		rowsSatisfyConstraint, err = og.rowsSatisfyFkConstraint(ctx, tx, parentTable, parentColumn, childTable, childColumn)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	codesWithConditions{
 		{code: pgcode.ForeignKeyViolation, condition: !parentColumnHasUniqueConstraint},
-		{code: pgcode.FeatureNotSupported, condition: childColumnIsComputed},
+		{code: pgcode.FeatureNotSupported, condition: childColumnIsVirtualComputed},
+		{code: pgcode.FeatureNotSupported, condition: childColumnIsStoredVirtual},
+		{code: pgcode.FeatureNotSupported, condition: parentColumnIsVirtualComputed},
 		{code: pgcode.DuplicateObject, condition: constraintExists},
 		{code: pgcode.DatatypeMismatch, condition: !childColumn.typ.Equivalent(parentColumn.typ)},
 	}.add(og.expectedExecErrors)
+	codesWithConditions{}.add(og.expectedCommitErrors)
 
-	if !rowsSatisfyConstraint {
-		og.candidateExpectedCommitErrors.add(pgcode.ForeignKeyViolation)
-	}
+	// TODO(fqazi): We need to do after the fact validation for foreign key violations
+	// errors. Due to how adding foreign key constraints are implemented with a
+	// separate job validating the constraint, we can't at transaction time predict,
+	// perfectly if an error is expected. We can confirm post transaction with a time
+	// travel query.
+	_ = rowsSatisfyConstraint
+	og.potentialExecErrors.add(pgcode.ForeignKeyViolation)
+	og.potentialCommitErrors.add(pgcode.ForeignKeyViolation)
+
+	// It's possible for the table to be dropped concurrently, while we are running
+	// validation. In which case a potential commit error is an undefined table
+	// error.
+	og.potentialCommitErrors.add(pgcode.UndefinedTable)
 
 	return tree.Serialize(def), nil
 }
@@ -2284,7 +2318,7 @@ func (og *operationGenerator) insertRow(ctx context.Context, tx pgx.Tx) (sq stri
 	// Only evaluate these if we know that the inserted values are sane, since
 	// we will need to evaluate generated expressions below.
 	uniqueConstraintViolation := false
-	foreignKeyViolation := false
+	fkViolation := false
 	if !anyInvalidInserts {
 		// Verify if the new row will violate unique constraints by checking the constraints and
 		// existing rows in the database.
@@ -2299,7 +2333,7 @@ func (og *operationGenerator) insertRow(ctx context.Context, tx pgx.Tx) (sq stri
 
 		// Verify if the new row will violate fk constraints by checking the constraints and rows
 		// in the database.
-		foreignKeyViolation, err = og.violatesFkConstraints(ctx, tx, tableName, colNames, rows)
+		fkViolation, err = og.violatesFkConstraints(ctx, tx, tableName, colNames, rows)
 		if err != nil {
 			return "", err
 		}
@@ -2307,8 +2341,13 @@ func (og *operationGenerator) insertRow(ctx context.Context, tx pgx.Tx) (sq stri
 
 	codesWithConditions{
 		{code: pgcode.UniqueViolation, condition: uniqueConstraintViolation},
-		{code: pgcode.ForeignKeyViolation, condition: foreignKeyViolation},
 	}.add(og.expectedExecErrors)
+	codesWithConditions{
+		{code: pgcode.ForeignKeyViolation, condition: fkViolation},
+	}.add(og.potentialExecErrors)
+	codesWithConditions{
+		{code: pgcode.ForeignKeyViolation, condition: fkViolation},
+	}.add(og.expectedCommitErrors)
 
 	var formattedRows []string
 	for _, row := range rows {
@@ -2509,7 +2548,7 @@ func (og *operationGenerator) randChildColumnForFkRelation(
 	query.WriteString(`
     SELECT table_schema, table_name, column_name, crdb_sql_type, is_nullable
       FROM information_schema.columns
-		 WHERE table_name ~ 'table[0-9]+'
+		 WHERE table_name ~ 'table[0-9]+' AND column_name <> 'rowid'
   `)
 	query.WriteString(fmt.Sprintf(`
 			AND crdb_sql_type = '%s'
@@ -2562,6 +2601,7 @@ func (og *operationGenerator) randParentColumnForFkRelation(
         SELECT table_schema, table_name, column_name, crdb_sql_type, is_nullable, ordinal_position,
                concat(table_schema, '.', table_name)::REGCLASS::INT8 AS tableid
           FROM information_schema.columns
+					WHERE column_name <> 'rowid'
            ) AS cols
 		  JOIN (
 		        SELECT contype, conkey, conrelid
@@ -2588,11 +2628,39 @@ func (og *operationGenerator) randParentColumnForFkRelation(
 	var typName string
 	var nullable string
 
-	err := tx.QueryRow(ctx, fmt.Sprintf(`
+	for {
+		nestedTxn, err := tx.Begin(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+		err = nestedTxn.QueryRow(ctx, fmt.Sprintf(`
 	SELECT table_schema, table_name, column_name, crdb_sql_type, is_nullable FROM (
 		%s
 	)`, subQuery.String())).Scan(&tableSchema, &tableName, &columnName, &typName, &nullable)
-	if err != nil {
+		if err == nil {
+			err := nestedTxn.Commit(ctx)
+			if err != nil {
+				return nil, nil, err
+			}
+			break
+		}
+		pgErr := (*pgconn.PgError)(nil)
+		if !errors.As(err, &pgErr) {
+			return nil, nil, err
+		}
+		// Intermittent undefined table errors are valid for the query above, since
+		// we are not leasing out the tables, when picking our random table.
+		if code := pgcode.MakeCode(pgErr.Code); code == pgcode.UndefinedTable ||
+			code == pgcode.UndefinedSchema {
+			err := nestedTxn.Rollback(ctx)
+			if err != nil {
+				return nil, nil, err
+			}
+			continue
+		}
+		if rbErr := nestedTxn.Rollback(ctx); rbErr != nil {
+			err = errors.CombineErrors(err, rbErr)
+		}
 		return nil, nil, err
 	}
 
@@ -2605,6 +2673,7 @@ func (og *operationGenerator) randParentColumnForFkRelation(
 		ExplicitSchema: true,
 	}, tree.Name(tableName))
 
+	var err error
 	columnToReturn.typ, err = og.typeFromTypeName(ctx, tx, typName)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Currently, the schema changer workload has foreign key constraints disabled. This pull requests enable support for foreign key constraints in the workload, introduce fixes for FK addition rollback (when tables are being dropped) and a new crdb_internal to determine if an FK constraint is active (this will intentionally lease the descriptor). 