### PR TITLE
release-22.1: backupccl: add UX guardrails during backup subdirectory resolution

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -5,6 +5,7 @@ admission.epoch_lifo.epoch_duration	duration	100ms	the duration of an epoch, for
 admission.epoch_lifo.queue_delay_threshold_to_switch_to_lifo	duration	105ms	the queue delay encountered by a (tenant,priority) for switching to epoch-LIFO ordering
 admission.sql_kv_response.enabled	boolean	true	when true, work performed by the SQL layer when receiving a KV response is subject to admission control
 admission.sql_sql_response.enabled	boolean	true	when true, work performed by the SQL layer when receiving a DistSQL response is subject to admission control
+bulkio.backup.deprecated_full_backup_with_subdir.enabled	boolean	false	when true, a backup command with a user specified subdirectory will create a full backup at the subdirectory if no backup already exists at that subdirectory.
 bulkio.backup.file_size	byte size	128 MiB	target size for individual data files produced during BACKUP
 bulkio.backup.read_timeout	duration	5m0s	amount of time after which a read attempt is considered timed out, which causes the backup to fail
 bulkio.backup.read_with_priority_after	duration	1m0s	amount of time since the read-as-of time above which a BACKUP should use priority when retrying reads

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -10,6 +10,7 @@
 <tr><td><code>admission.kv.tenant_weights.enabled</code></td><td>boolean</td><td><code>false</code></td><td>when true, tenant weights are enabled for KV admission control</td></tr>
 <tr><td><code>admission.sql_kv_response.enabled</code></td><td>boolean</td><td><code>true</code></td><td>when true, work performed by the SQL layer when receiving a KV response is subject to admission control</td></tr>
 <tr><td><code>admission.sql_sql_response.enabled</code></td><td>boolean</td><td><code>true</code></td><td>when true, work performed by the SQL layer when receiving a DistSQL response is subject to admission control</td></tr>
+<tr><td><code>bulkio.backup.deprecated_full_backup_with_subdir.enabled</code></td><td>boolean</td><td><code>false</code></td><td>when true, a backup command with a user specified subdirectory will create a full backup at the subdirectory if no backup already exists at that subdirectory.</td></tr>
 <tr><td><code>bulkio.backup.file_size</code></td><td>byte size</td><td><code>128 MiB</code></td><td>target size for individual data files produced during BACKUP</td></tr>
 <tr><td><code>bulkio.backup.read_timeout</code></td><td>duration</td><td><code>5m0s</code></td><td>amount of time after which a read attempt is considered timed out, which causes the backup to fail</td></tr>
 <tr><td><code>bulkio.backup.read_with_priority_after</code></td><td>duration</td><td><code>1m0s</code></td><td>amount of time since the read-as-of time above which a BACKUP should use priority when retrying reads</td></tr>

--- a/pkg/ccl/backupccl/backup_destination.go
+++ b/pkg/ccl/backupccl/backup_destination.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/featureflag"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
@@ -137,7 +138,46 @@ func resolveDest(
 	if err != nil {
 		return "", "", "", nil, nil, err
 	}
-	if !exists {
+	if exists && !dest.Exists && chosenSuffix != "" && execCfg.Settings.Version.IsActive(ctx,
+		clusterversion.Start22_1) {
+		// We disallow a user from writing a full backup to a path in a collection containing an
+		// existing backup iff we're 99.9% confident this backup was planned on a 22.1 node.
+		return "",
+			"",
+			"",
+			nil,
+			nil,
+			errors.Newf("A full backup already exists in %s. "+
+				"Consider running an incremental backup to this full backup via `BACKUP INTO '%s' IN '%s'`",
+				plannedBackupDefaultURI, chosenSuffix, dest.To[0])
+
+	} else if !exists {
+		if dest.Exists {
+			// Implies the user passed a subdirectory in their backup command, either
+			// explicitly or using LATEST; however, we could not find an existing
+			// backup in that subdirectory.
+			// - Pre 22.1: this was fine. we created a full backup in their specified subdirectory.
+			// - 22.1: throw an error: full backups with an explicit subdirectory are deprecated.
+			// User can use old behavior by switching the 'bulkio.backup.full_backup_with_subdir.
+			// enabled' to true.
+			// - 22.2+: the backup will fail unconditionally.
+			// TODO (msbutler): throw error in 22.2
+			if err := featureflag.CheckEnabled(
+				ctx,
+				execCfg,
+				featureFullBackupUserSubdir,
+				"'Full Backup with user defined subdirectory'",
+			); err != nil {
+				return "", "", "", nil, nil, errors.Wrapf(err,
+					"The full backup cannot get written to '%s', a user defined subdirectory. "+
+						"To take a full backup, remove the subdirectory from the backup command, "+
+						"(i.e. run 'BACKUP ... INTO <collectionURI>'). "+
+						"Or, to take a full backup at a specific subdirectory, "+
+						"enable the deprecated syntax by switching the 'bulkio.backup."+
+						"deprecated_full_backup_with_subdir.enable' cluster setting to true; "+
+						"however, note this deprecated syntax will not be available in a future release.", chosenSuffix)
+			}
+		}
 		// There's no full backup in the resolved subdirectory; therefore, we're conducting a full backup.
 		return collectionURI, plannedBackupDefaultURI, chosenSuffix, urisByLocalityKV, prevBackupURIs, nil
 	}

--- a/pkg/ccl/backupccl/backup_destination_test.go
+++ b/pkg/ccl/backupccl/backup_destination_test.go
@@ -344,9 +344,14 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 						require.NoError(t, err)
 					}
 
+					fullBackupExists := false
+					if expectedIncDir != "" {
+						fullBackupExists = true
+					}
 					collectionURI, defaultURI, chosenSuffix, urisByLocalityKV, prevBackupURIs, err := resolveDest(
 						ctx, security.RootUserName(),
-						jobspb.BackupDetails_Destination{To: collectionTo, Subdir: subdir, IncrementalStorage: incrementalTo},
+						jobspb.BackupDetails_Destination{To: collectionTo, Subdir: subdir,
+							IncrementalStorage: incrementalTo, Exists: fullBackupExists},
 						endTime,
 						incrementalFrom,
 						&execCfg,

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -931,7 +931,6 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 	sqlDB.Exec(t, "BACKUP TO ($1, $2, $3)", backups...)
 	sqlDB.Exec(t, "BACKUP INTO ($1, $2, $3)", collections...)
 	sqlDB.Exec(t, "BACKUP INTO LATEST IN ($1, $2, $3)", collections...)
-	sqlDB.Exec(t, "BACKUP INTO $4 IN ($1, $2, $3)", append(collections, "subdir")...)
 	sqlDB.Exec(t, "BACKUP INTO LATEST IN ($1, $2, $3) WITH incremental_location = ($4, $5, $6)",
 		append(collections, incrementals...)...)
 
@@ -939,16 +938,24 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 		"BACKUP INTO LATEST IN $4 WITH incremental_location = ($1, $2, $3)",
 		append(incrementals, collections[0])...)
 
+	sqlDB.ExpectErr(t, "The full backup cannot get written to '/subdir', a user defined subdirectory. To take a full backup, remove the subdirectory from the backup command",
+		"BACKUP INTO $4 IN ($1, $2, $3)", append(collections, "subdir")...)
+
+	time.Sleep(time.Second + 2)
+	sqlDB.Exec(t, "BACKUP INTO ($1, $2, $3) AS OF SYSTEM TIME '-1s'", collections...)
+
 	// Find the subdirectory created by the full BACKUP INTO statement.
 	matches, err := filepath.Glob(path.Join(tmpDir, "full/*/*/*/"+backupManifestName))
 	require.NoError(t, err)
-	require.Equal(t, 1, len(matches))
+	require.Equal(t, 2, len(matches))
 	for i := range matches {
 		matches[i] = strings.TrimPrefix(filepath.Dir(matches[i]), tmpDir)
 	}
 	full1 := strings.TrimPrefix(matches[0], "/full")
+	asOf1 := strings.TrimPrefix(matches[1], "/full")
+
 	sqlDB.CheckQueryResults(
-		t, "SELECT description FROM [SHOW JOBS]",
+		t, "SELECT description FROM [SHOW JOBS] WHERE status != 'failed'",
 		[][]string{
 			{fmt.Sprintf("BACKUP TO ('%s', '%s', '%s')", backups[0].(string), backups[1].(string),
 				backups[2].(string))},
@@ -956,13 +963,16 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 				collections[1], collections[2])},
 			{fmt.Sprintf("BACKUP INTO '%s' IN ('%s', '%s', '%s')", full1,
 				collections[0], collections[1], collections[2])},
-			{fmt.Sprintf("BACKUP INTO '%s' IN ('%s', '%s', '%s')", "/subdir",
-				collections[0], collections[1], collections[2])},
 			{fmt.Sprintf("BACKUP INTO '%s' IN ('%s', '%s', '%s') WITH incremental_location = ('%s', '%s', '%s')",
-				"/subdir", collections[0], collections[1], collections[2], incrementals[0],
+				full1, collections[0], collections[1], collections[2], incrementals[0],
 				incrementals[1], incrementals[2])},
+			{fmt.Sprintf("BACKUP INTO '%s' IN ('%s', '%s', '%s') AS OF SYSTEM TIME '-1s'", asOf1, collections[0],
+				collections[1], collections[2])},
 		},
 	)
+	sqlDB.CheckQueryResults(t, "SELECT description FROM [SHOW JOBS] WHERE status = 'failed'",
+		[][]string{{fmt.Sprintf("BACKUP INTO '%s' IN ('%s', '%s', '%s')", "/subdir", collections[0],
+			collections[1], collections[2])}})
 
 	sqlDB.Exec(t, "DROP DATABASE data CASCADE")
 	sqlDB.Exec(t, "RESTORE DATABASE data FROM ($1, $2, $3)", backups...)
@@ -971,15 +981,16 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 	sqlDB.Exec(t, "RESTORE DATABASE data FROM $4 IN ($1, $2, $3)", append(collections, full1)...)
 
 	sqlDB.Exec(t, "DROP DATABASE data CASCADE")
-	sqlDB.Exec(t, "RESTORE DATABASE data FROM $4 IN ($1, $2, $3)", append(collections, "subdir")...)
+	sqlDB.Exec(t, "RESTORE DATABASE data FROM $7 IN ($1, $2, "+
+		"$3) WITH incremental_location = ($4, $5, $6)",
+		append(collections, incrementals[0], incrementals[1], incrementals[2], full1)...)
 
+	// Test restoring from the AOST backup
 	sqlDB.Exec(t, "DROP DATABASE data CASCADE")
 	sqlDB.Exec(t, "RESTORE DATABASE data FROM LATEST IN ($1, $2, $3)", collections...)
 
 	sqlDB.Exec(t, "DROP DATABASE data CASCADE")
-	sqlDB.Exec(t, "RESTORE DATABASE data FROM LATEST IN ($1, $2, "+
-		"$3) WITH incremental_location = ($4, $5, $6)",
-		append(collections, incrementals[0], incrementals[1], incrementals[2])...)
+	sqlDB.Exec(t, "RESTORE DATABASE data FROM $4 IN ($1, $2, $3)", append(collections, asOf1)...)
 
 	// The flavors of BACKUP and RESTORE which automatically resolve the right
 	// directory to read/write data to, have URIs with the resolved path written
@@ -997,8 +1008,8 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 	}
 
 	resolvedCollectionURIs := getResolvedCollectionURIs(collections, full1)
-	resolvedSubdirURIs := getResolvedCollectionURIs(collections, "subdir")
-	resolvedIncURIs := getResolvedCollectionURIs(incrementals, "subdir")
+	resolvedIncURIs := getResolvedCollectionURIs(incrementals, full1)
+	resolvedAsOfCollectionURIs := getResolvedCollectionURIs(collections, asOf1)
 
 	sqlDB.CheckQueryResults(
 		t, "SELECT description FROM [SHOW JOBS] WHERE job_type='RESTORE'",
@@ -1008,16 +1019,16 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 			{fmt.Sprintf("RESTORE DATABASE data FROM ('%s', '%s', '%s')",
 				resolvedCollectionURIs[0], resolvedCollectionURIs[1],
 				resolvedCollectionURIs[2])},
+			{fmt.Sprintf("RESTORE DATABASE data FROM ('%s', '%s', '%s') WITH incremental_location = ('%s', '%s', '%s')",
+				resolvedCollectionURIs[0], resolvedCollectionURIs[1], resolvedCollectionURIs[2],
+				resolvedIncURIs[0], resolvedIncURIs[1], resolvedIncURIs[2])},
 			{fmt.Sprintf("RESTORE DATABASE data FROM ('%s', '%s', '%s')",
-				resolvedSubdirURIs[0], resolvedSubdirURIs[1],
-				resolvedSubdirURIs[2])},
+				resolvedAsOfCollectionURIs[0], resolvedAsOfCollectionURIs[1],
+				resolvedAsOfCollectionURIs[2])},
 			// and again from LATEST IN...
 			{fmt.Sprintf("RESTORE DATABASE data FROM ('%s', '%s', '%s')",
-				resolvedSubdirURIs[0], resolvedSubdirURIs[1],
-				resolvedSubdirURIs[2])},
-			{fmt.Sprintf("RESTORE DATABASE data FROM ('%s', '%s', '%s') WITH incremental_location = ('%s', '%s', '%s')",
-				resolvedSubdirURIs[0], resolvedSubdirURIs[1], resolvedSubdirURIs[2],
-				resolvedIncURIs[0], resolvedIncURIs[1], resolvedIncURIs[2])},
+				resolvedAsOfCollectionURIs[0], resolvedAsOfCollectionURIs[1],
+				resolvedAsOfCollectionURIs[2])},
 		},
 	)
 }
@@ -4082,8 +4093,23 @@ func TestBackupAsOfSystemTime(t *testing.T) {
 
 	beforeDir := localFoo + `/beforeTs`
 	sqlDB.Exec(t, fmt.Sprintf(`BACKUP DATABASE data TO '%s' AS OF SYSTEM TIME %s`, beforeDir, beforeTs))
+
 	equalDir := localFoo + `/equalTs`
 	sqlDB.Exec(t, fmt.Sprintf(`BACKUP DATABASE data TO '%s' AS OF SYSTEM TIME %s`, equalDir, equalTs))
+	{
+		// testing UX guardrails for AS OF SYSTEM TIME backups in collections
+		sqlDB.Exec(t, fmt.Sprintf(`BACKUP DATABASE data INTO '%s' AS OF SYSTEM TIME %s`, equalDir, equalTs))
+
+		sqlDB.ExpectErr(t, "`AS OF SYSTEM TIME` .* must be greater than the previous backup's end time of",
+			fmt.Sprintf(`BACKUP DATABASE data INTO LATEST IN '%s' AS OF SYSTEM TIME %s`,
+				equalDir,
+				beforeTs))
+
+		sqlDB.ExpectErr(t, "A full backup already exists in .* Consider running an incremental backup"+
+			" to this full backup via `BACKUP INTO ",
+			fmt.Sprintf(`BACKUP DATABASE data INTO '%s' AS OF SYSTEM TIME %s`, equalDir,
+				equalTs))
+	}
 
 	sqlDB.Exec(t, `DROP TABLE data.bank`)
 	sqlDB.Exec(t, `RESTORE data.* FROM $1`, beforeDir)

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -156,6 +156,8 @@ message BackupDetails {
     // Subdir is the path within the collection path in to to backup to.
     string subdir = 2;
     repeated string incremental_storage = 3;
+    // Exists is true if a backup should already exist at the destination
+    bool exists = 4;
   }
 
   util.hlc.Timestamp start_time = 1 [(gogoproto.nullable) = false];


### PR DESCRIPTION
Backport 1/2 commits from #79799.

/cc @cockroachdb/release

---

Informs https://github.com/cockroachdb/cockroach/issues/79674, https://github.com/cockroachdb/cockroach/issues/79672

The changes in this PR sprang out of discussions in https://github.com/cockroachdb/cockroach/pull/79447 which deprecated the
ability to pass an explicit subdirectory in any backup command. This PR tweaks
that deprecation warning and adds further UX guardrails.

Release note (backward-incompatible change): This patch introduces a few UX guardrails, including
one breaking change:

[breaking]: After further discussion, we realized explicit subdirectories were
useful for running incremental backups, but not for full backups. To that end,
this pr throws an error if: a) a user passes a subdirectory; b)
there does not already exist a full backup in that subdirectory. The user can
enable this deprecated syntax by switching the new
bulkio.backup.deprecated_full_backup_with_subdir cluster setting to true.

Discussion in https://github.com/cockroachdb/cockroach/pull/79447 also lead to a discovery of two
bugs for backups with AS OF SYSTEM TIME:

Previously, a user could run an AS OF SYSTEM TIME
incremental backup with an end time earlier than the previous backup's end time
, which could lead to an out of order incremental backup chain. This PR causes
the incremental backup to fail if the AS OF SYSTEM TIME is less than the
previous backup's end time.

Previously, if a user ran `BACKUP INTO dest AS OF SYSTEM TIME t` and a full
backup subdirectory already existed at t, the backup would mistakingly increment
on that full backup instead of failing. Without the IN keyword, the user expects
a full backup, not an incremental backup. In this patch, the full backup fails
when it detects a full backup already exists at the resolved subdirectory.

Release justification: sufficiently tested, high reward bug fixes