### PR TITLE
storage: remove MVCCIterator.ValueProto

### DIFF
--- a/pkg/kv/kvserver/loqrecovery/record.go
+++ b/pkg/kv/kvserver/loqrecovery/record.go
@@ -93,7 +93,7 @@ func RegisterOfflineRecoveryEvents(
 		}
 
 		record := loqrecoverypb.ReplicaRecoveryRecord{}
-		if err := iter.ValueProto(&record); err != nil {
+		if err := protoutil.Unmarshal(iter.UnsafeValue(), &record); err != nil {
 			processingErrors = errors.CombineErrors(processingErrors, errors.Wrapf(err,
 				"failed to deserialize replica recovery event at key %s", iter.Key()))
 			continue

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -2978,7 +2978,7 @@ func TestReplicaTSCacheForwardsIntentTS(t *testing.T) {
 				var keyMeta enginepb.MVCCMetadata
 				if ok, err := iter.Valid(); !ok || !iter.UnsafeKey().Equal(mvccKey) {
 					t.Fatalf("missing mvcc metadata for %q: %+v", mvccKey, err)
-				} else if err := iter.ValueProto(&keyMeta); err != nil {
+				} else if err := protoutil.Unmarshal(iter.UnsafeValue(), &keyMeta); err != nil {
 					t.Fatalf("failed to unmarshal metadata for %q", mvccKey)
 				}
 				if tsNext := tsNew.Next(); keyMeta.Timestamp.ToTimestamp() != tsNext {

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -151,11 +151,6 @@ func (i *MVCCIterator) Value() []byte {
 	return i.i.Value()
 }
 
-// ValueProto is part of the storage.MVCCIterator interface.
-func (i *MVCCIterator) ValueProto(msg protoutil.Message) error {
-	return i.i.ValueProto(msg)
-}
-
 // UnsafeKey is part of the storage.MVCCIterator interface.
 func (i *MVCCIterator) UnsafeKey() storage.MVCCKey {
 	return i.i.UnsafeKey()

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -149,9 +149,6 @@ type MVCCIterator interface {
 	UnsafeRawMVCCKey() []byte
 	// Value returns the current value as a byte slice.
 	Value() []byte
-	// ValueProto unmarshals the value the iterator is currently
-	// pointing to using a protobuf decoder.
-	ValueProto(msg protoutil.Message) error
 	// ComputeStats scans the underlying engine from start to end keys and
 	// computes stats counters based on the values. This method is used after a
 	// range is split to recompute stats for each subrange. The start key is
@@ -447,7 +444,7 @@ type Reader interface {
 	// key and the value. Semantically, it behaves as if an iterator with
 	// MVCCKeyAndIntentsIterKind was used.
 	//
-	// Deprecated: use MVCCIterator.ValueProto instead.
+	// Deprecated: use storage.MVCCGetProto instead.
 	MVCCGetProto(key MVCCKey, msg protoutil.Message) (ok bool, keyBytes, valBytes int64, err error)
 	// MVCCIterate scans from the start key to the end key (exclusive), invoking the
 	// function f on each key value pair. If f returns an error or if the scan

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -325,7 +325,7 @@ func TestEngineBatch(t *testing.T) {
 					t.Errorf("%d: batch seek expected key %s, but got %s", i, key, iter.Key())
 				} else {
 					var m enginepb.MVCCMetadata
-					if err := iter.ValueProto(&m); err != nil {
+					if err := protoutil.Unmarshal(iter.UnsafeValue(), &m); err != nil {
 						t.Fatal(err)
 					}
 					valueBytes, err := MakeValue(m).GetBytes()

--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
@@ -935,11 +934,6 @@ func (i *intentInterleavingIter) UnsafeRawMVCCKey() []byte {
 		return i.intentKeyAsNoTimestampMVCCKey
 	}
 	return i.iter.UnsafeRawKey()
-}
-
-func (i *intentInterleavingIter) ValueProto(msg protoutil.Message) error {
-	value := i.UnsafeValue()
-	return protoutil.Unmarshal(value, msg)
 }
 
 func (i *intentInterleavingIter) ComputeStats(

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
@@ -590,13 +589,6 @@ func (p *pebbleIterator) Value() []byte {
 	valueCopy := make([]byte, len(value))
 	copy(valueCopy, value)
 	return valueCopy
-}
-
-// ValueProto implements the MVCCIterator interface.
-func (p *pebbleIterator) ValueProto(msg protoutil.Message) error {
-	value := p.UnsafeValue()
-
-	return protoutil.Unmarshal(value, msg)
 }
 
 // ComputeStats implements the MVCCIterator interface.

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/sstable"
 )
@@ -99,7 +100,7 @@ func CheckSSTConflicts(
 		}
 		if !extKey.IsValue() {
 			var mvccMeta enginepb.MVCCMetadata
-			if err = extIter.ValueProto(&mvccMeta); err != nil {
+			if err = protoutil.Unmarshal(extIter.UnsafeValue(), &mvccMeta); err != nil {
 				return enginepb.MVCCStats{}, err
 			}
 			if len(mvccMeta.RawBytes) > 0 {


### PR DESCRIPTION
The method is equivalent to `protoutil.Unmarshal(iter.UnsafeValue(), msg)`
and was only used by a few callers, so it was not worth the cost of forcing
all implementations of `MVCCIterator` to implement it.