### PR TITLE
release-22.1: sqlsmith: skip crdb_internal.reset_multi_region_zone_configs_for_database

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -502,6 +502,7 @@ var functions = func() map[tree.FunctionClass]map[oid.Oid][]function {
 			"crdb_internal.reset_index_usage_stats",
 			"crdb_internal.start_replication_stream",
 			"crdb_internal.replication_stream_progress",
+			"crdb_internal.reset_multi_region_zone_configs_for_database",
 		} {
 			skip = skip || strings.Contains(def.Name, substr)
 		}


### PR DESCRIPTION
Backport 1/1 commits from #80111.

/cc @cockroachdb/release

Release justification: test-only change

---

Don't use crdb_internal.reset_multi_region_zone_configs_for_database when
generating sqlsmith queries, since it currently causes an internal error.

Informs #80023

Release note: None
