### PR TITLE
release-21.2: sqlsmith: skip crdb_internal.reset_multi_region_zone_configs_for_database

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -490,7 +490,8 @@ var functions = func() map[tree.FunctionClass]map[oid.Oid][]function {
 		}
 		if strings.Contains(def.Name, "crdb_internal.force_") ||
 			strings.Contains(def.Name, "crdb_internal.unsafe_") ||
-			strings.Contains(def.Name, "crdb_internal.create_join_token") {
+			strings.Contains(def.Name, "crdb_internal.create_join_token") ||
+			strings.Contains(def.Name, "crdb_internal.reset_multi_region_zone_configs_for_database") {
 			continue
 		}
 		if _, ok := m[def.Class]; !ok {


### PR DESCRIPTION
Backport 1/1 commits from #80111.

/cc @cockroachdb/release

Release justification: test-only change

---

Don't use crdb_internal.reset_multi_region_zone_configs_for_database when
generating sqlsmith queries, since it currently causes an internal error.

Informs #80023

Release note: None
