### PR TITLE
Revert "sqlsmith: skip crdb_internal.reset_multi_region_zone_configs_for_database"

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -503,7 +503,6 @@ var functions = func() map[tree.FunctionClass]map[oid.Oid][]function {
 			"crdb_internal.start_replication_stream",
 			"crdb_internal.replication_stream_progress",
 			"crdb_internal.complete_replication_stream",
-			"crdb_internal.reset_multi_region_zone_configs_for_database",
 		} {
 			skip = skip || strings.Contains(def.Name, substr)
 		}


### PR DESCRIPTION
This reverts commit c1a959a9eb165c11e8cba95df0f23d54aa66e35d.
That commit was unnecessary because
`crdb_internal.reset_multi_region_zone_configs_for_database` already
existed in the list of functions to skip.

Release note: None