### PR TITLE
kvserver: warn more aggressively about slow AddSST apply

### DIFF
--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -430,7 +430,7 @@ func (r *Replica) leasePostApplyLocked(
 var addSSTPreApplyWarn = struct {
 	threshold time.Duration
 	log.EveryN
-}{30 * time.Second, log.Every(5 * time.Second)}
+}{500 * time.Millisecond, log.Every(time.Second)}
 
 func addSSTablePreApply(
 	ctx context.Context,


### PR DESCRIPTION
AddSST application is "just" a hard-link on any kind of reasonable file system,
so it shouldn't take north of 30s ever. Anecdotally, during a recent spat of
experiments, I never saw this logging fire despite raft handling cycles taking
upward of 450s. So this is almost certainly too conservative.

Change the timeout to a 500ms cutoff, which matches the "slow raft ready"
message.

Release note: None
