### PR TITLE
kvserver: improve slow ready message

### DIFF
--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -50,11 +50,12 @@ import (
 //
 // TODO(ajwerner): add metrics to go with these stats.
 type applyCommittedEntriesStats struct {
-	batchesProcessed     int
-	entriesProcessed     int
-	stateAssertions      int
-	numEmptyEntries      int
-	numConfChangeEntries int
+	batchesProcessed      int
+	entriesProcessed      int
+	entriesProcessedBytes int64
+	stateAssertions       int
+	numEmptyEntries       int
+	numConfChangeEntries  int
 }
 
 // nonDeterministicFailure is an error type that indicates that a state machine
@@ -430,6 +431,7 @@ type replicaAppBatch struct {
 
 	// Statistics.
 	entries      int
+	entryBytes   int64
 	emptyEntries int
 	mutations    int
 	start        time.Time
@@ -542,7 +544,9 @@ func (b *replicaAppBatch) Stage(
 	// them in the batch) is sufficient.
 	b.stageTrivialReplicatedEvalResult(ctx, cmd)
 	b.entries++
-	if len(cmd.ent.Data) == 0 {
+	size := len(cmd.ent.Data)
+	b.entryBytes += int64(size)
+	if size == 0 {
 		b.emptyEntries++
 	}
 
@@ -1018,6 +1022,7 @@ func (b *replicaAppBatch) addAppliedStateKeyToBatch(ctx context.Context) error {
 
 func (b *replicaAppBatch) recordStatsOnCommit() {
 	b.sm.stats.entriesProcessed += b.entries
+	b.sm.stats.entriesProcessedBytes += b.entryBytes
 	b.sm.stats.numEmptyEntries += b.emptyEntries
 	b.sm.stats.batchesProcessed++
 

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -538,8 +538,84 @@ type handleSnapshotStats struct {
 }
 
 type handleRaftReadyStats struct {
-	applyCommittedEntriesStats
-	snap handleSnapshotStats
+	tBegin, tEnd time.Time
+
+	tApplicationBegin, tApplicationEnd time.Time
+	apply                              applyCommittedEntriesStats
+
+	tAppendBegin, tAppendEnd time.Time
+	appendedRegularCount     int
+	appendedSideloadedCount  int
+	appendedSideloadedBytes  int64
+	appendedRegularBytes     int64
+
+	tPebbleCommitBegin, tPebbleCommitEnd time.Time
+	pebbleBatchBytes                     int64
+
+	tSnapBegin, tSnapEnd time.Time
+	snap                 handleSnapshotStats
+	sync                 bool
+}
+
+// SafeFormat implements redact.SafeFormatter
+func (s handleRaftReadyStats) SafeFormat(p redact.SafePrinter, _ rune) {
+	dTotal := s.tEnd.Sub(s.tBegin)
+	dAppend := s.tAppendEnd.Sub(s.tAppendBegin)
+	dApply := s.tApplicationEnd.Sub(s.tApplicationBegin)
+	dPebble := s.tPebbleCommitEnd.Sub(s.tPebbleCommitBegin)
+	dSnap := s.tSnapEnd.Sub(s.tSnapBegin)
+	dUnaccounted := dTotal - dSnap - dAppend - dApply - dPebble
+
+	{
+		var sync redact.SafeString
+		if s.sync {
+			sync = "-sync"
+		}
+		p.Printf("raft ready handling: %.2fs [append=%.2fs, apply=%.2fs, commit-batch%s=%.2fs",
+			dTotal.Seconds(), dAppend.Seconds(), dApply.Seconds(), sync, dPebble.Seconds())
+	}
+	if dSnap > 0 {
+		p.Printf(", snap=%.2fs", dSnap.Seconds())
+	}
+	p.Printf(", other=%.2fs]", dUnaccounted.Seconds())
+
+	p.Printf(", wrote %s",
+		humanizeutil.IBytes(s.pebbleBatchBytes),
+	)
+	if s.sync {
+		p.SafeString(" sync")
+	}
+	p.SafeString(" [")
+
+	if b, n := s.appendedRegularBytes, s.appendedRegularCount; n > 0 || b > 0 {
+		p.Printf("append-ent=%s (%d), ", humanizeutil.IBytes(b), n)
+	}
+	if b, n := s.appendedSideloadedBytes, s.appendedSideloadedCount; n > 0 || b > 0 {
+		p.Printf("append-sst=%s (%d), ", humanizeutil.IBytes(b), n)
+	}
+	if b, n := s.apply.entriesProcessedBytes, s.apply.entriesProcessed; n > 0 || b > 0 {
+		p.Printf("apply=%s (%d", humanizeutil.IBytes(b), n)
+		if c := s.apply.batchesProcessed; c > 1 {
+			p.Printf(" in %d batches", c)
+		}
+		p.SafeString(")")
+	}
+	p.SafeString("]")
+
+	if n := s.apply.stateAssertions; n > 0 {
+		p.Printf(", state_assertions=%d", n)
+	}
+	if s.snap.offered {
+		if s.snap.applied {
+			p.Printf(", snapshot applied")
+		} else {
+			p.Printf(", snapshot ignored")
+		}
+	}
+}
+
+func (s handleRaftReadyStats) String() string {
+	return redact.StringWithoutMarkers(s)
 }
 
 // noSnap can be passed to handleRaftReady when no snapshot should be processed.
@@ -575,7 +651,9 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 			"handleRaftReadyRaftMuLocked cannot be called with a cancellable context")
 	}
 
-	var stats handleRaftReadyStats
+	stats := handleRaftReadyStats{
+		tBegin: timeutil.Now(),
+	}
 	if inSnap.Desc != nil {
 		stats.snap.offered = true
 	}
@@ -675,10 +753,12 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 			subsumedRepls, releaseMergeLock := r.maybeAcquireSnapshotMergeLock(ctx, inSnap)
 			defer releaseMergeLock()
 
+			stats.tSnapBegin = timeutil.Now()
 			if err := r.applySnapshot(ctx, inSnap, rd.Snapshot, rd.HardState, subsumedRepls); err != nil {
 				const expl = "while applying snapshot"
 				return stats, expl, errors.Wrap(err, expl)
 			}
+			stats.tSnapEnd = timeutil.Now()
 			stats.snap.applied = true
 
 			// r.mu.lastIndex, r.mu.lastTerm and r.mu.raftLogSize were updated in
@@ -810,9 +890,10 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 
 	prevLastIndex := lastIndex
 	if len(rd.Entries) > 0 {
+		stats.tAppendBegin = timeutil.Now()
 		// All of the entries are appended to distinct keys, returning a new
 		// last index.
-		thinEntries, sideLoadedEntriesSize, err := r.maybeSideloadEntriesRaftMuLocked(ctx, rd.Entries)
+		thinEntries, numSideloaded, sideLoadedEntriesSize, otherEntriesSize, err := r.maybeSideloadEntriesRaftMuLocked(ctx, rd.Entries)
 		if err != nil {
 			const expl = "during sideloading"
 			return stats, expl, errors.Wrap(err, expl)
@@ -824,7 +905,13 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 			const expl = "during append"
 			return stats, expl, errors.Wrap(err, expl)
 		}
+		stats.appendedRegularCount += len(thinEntries) - numSideloaded
+		stats.appendedRegularBytes += otherEntriesSize
+		stats.appendedSideloadedCount += numSideloaded
+		stats.appendedSideloadedBytes += sideLoadedEntriesSize
+		stats.tAppendEnd = timeutil.Now()
 	}
+
 	if !raft.IsEmptyHardState(rd.HardState) {
 		if !r.IsInitialized() && rd.HardState.Commit != 0 {
 			log.Fatalf(ctx, "setting non-zero HardState.Commit on uninitialized replica %s. HS=%+v", r, rd.HardState)
@@ -855,14 +942,18 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	// uncommitted log entries, and even if they did include log entries that
 	// were not persisted to disk, it wouldn't be a problem because raft does not
 	// infer the that entries are persisted on the node that sends a snapshot.
-	commitStart := timeutil.Now()
-	if err := batch.Commit(rd.MustSync && !disableSyncRaftLog.Get(&r.store.cfg.Settings.SV)); err != nil {
+	stats.tPebbleCommitBegin = timeutil.Now()
+	stats.pebbleBatchBytes = int64(batch.Len())
+	sync := rd.MustSync && !disableSyncRaftLog.Get(&r.store.cfg.Settings.SV)
+	if err := batch.Commit(sync); err != nil {
 		const expl = "while committing batch"
 		return stats, expl, errors.Wrap(err, expl)
 	}
+	stats.sync = sync
+	stats.tPebbleCommitEnd = timeutil.Now()
 	if rd.MustSync {
-		elapsed := timeutil.Since(commitStart)
-		r.store.metrics.RaftLogCommitLatency.RecordValue(elapsed.Nanoseconds())
+		r.store.metrics.RaftLogCommitLatency.RecordValue(
+			stats.tPebbleCommitEnd.Sub(stats.tPebbleCommitBegin).Nanoseconds())
 	}
 
 	if len(rd.Entries) > 0 {
@@ -914,10 +1005,10 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	r.sendRaftMessagesRaftMuLocked(ctx, otherMsgs)
 	r.traceEntries(rd.CommittedEntries, "committed, before applying any entries")
 
-	applicationStart := timeutil.Now()
+	stats.tApplicationBegin = timeutil.Now()
 	if len(rd.CommittedEntries) > 0 {
 		err := appTask.ApplyCommittedEntries(ctx)
-		stats.applyCommittedEntriesStats = sm.moveStats()
+		stats.apply = sm.moveStats()
 		if errors.Is(err, apply.ErrRemoved) {
 			// We know that our replica has been removed. All future calls to
 			// r.withRaftGroup() will return errRemoved so no future Ready objects
@@ -936,7 +1027,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 		// resubmit pending config changes, but it's hard to distinguish so we
 		// resubmit everything anyway). We delay resubmission until after we have
 		// processed the entire batch of entries.
-		if stats.numEmptyEntries > 0 {
+		if stats.apply.numEmptyEntries > 0 {
 			// Overwrite unconditionally since this is the most aggressive
 			// reproposal mode.
 			if !r.store.TestingKnobs().DisableRefreshReasonNewLeaderOrConfigChange {
@@ -944,7 +1035,8 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 			}
 		}
 	}
-	applicationElapsed := timeutil.Since(applicationStart).Nanoseconds()
+	stats.tApplicationEnd = timeutil.Now()
+	applicationElapsed := stats.tApplicationEnd.Sub(stats.tApplicationBegin).Nanoseconds()
 	r.store.metrics.RaftApplyCommittedLatency.RecordValue(applicationElapsed)
 	r.store.metrics.RaftCommandsApplied.Inc(int64(len(rd.CommittedEntries)))
 	if r.store.TestingKnobs().EnableUnconditionalRefreshesInRaftReady {
@@ -965,7 +1057,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	r.mu.Lock()
 	err = r.withRaftGroupLocked(true, func(raftGroup *raft.RawNode) (bool, error) {
 		raftGroup.Advance(rd)
-		if stats.numConfChangeEntries > 0 {
+		if stats.apply.numConfChangeEntries > 0 {
 			// If the raft leader got removed, campaign the first remaining voter.
 			//
 			// NB: this must be called after Advance() above since campaigning is
@@ -1001,6 +1093,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	// quota back at the end of handleRaftReadyRaftMuLocked, the next write will
 	// get blocked.
 	r.updateProposalQuotaRaftMuLocked(ctx, lastLeaderID)
+	stats.tEnd = timeutil.Now()
 	return stats, "", nil
 }
 

--- a/pkg/kv/kvserver/replica_sideload_test.go
+++ b/pkg/kv/kvserver/replica_sideload_test.go
@@ -580,25 +580,6 @@ func TestRaftSSTableSideloadingSideload(t *testing.T) {
 // TestRaftSSTableSideloadingProposal runs a straightforward application of an `AddSSTable` command.
 func TestRaftSSTableSideloadingProposal(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-
-	testutils.RunTrueAndFalse(t, "InMem", func(t *testing.T, engineInMem bool) {
-		var eng storage.Engine
-		if engineInMem {
-			eng = storage.NewDefaultInMemForTesting()
-		} else {
-			var cleanup func()
-			ctx := context.Background()
-			cleanup, eng = newOnDiskEngine(ctx, t)
-			defer cleanup()
-		}
-		defer eng.Close()
-		testRaftSSTableSideloadingProposal(t, eng)
-	})
-}
-
-// TestRaftSSTableSideloadingProposal runs a straightforward application of an `AddSSTable` command.
-func testRaftSSTableSideloadingProposal(t *testing.T, eng storage.Engine) {
-	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	defer SetMockAddSSTable()()
 

--- a/pkg/kv/kvserver/testdata/handle_raft_ready_stats.txt
+++ b/pkg/kv/kvserver/testdata/handle_raft_ready_stats.txt
@@ -1,0 +1,3 @@
+echo
+----
+raft ready handling: 5.00s [append=1.00s, apply=1.00s, commit-batch-sync=1.00s, snap=1.00s, other=1.00s], wrote 5.0 KiB sync [append-ent=1.0 KiB (7), append-sst=5.0 MiB (3), apply=3 B (2 in 9 batches)], state_assertions=4, snapshot applied


### PR DESCRIPTION
This has become significantly more informative, and notably includes a
breakdown of SSTs versus regular entries appended to the log, as well as
timings for the append/apply/commit/snap stages.

The one thing that is missing here that I think would be helpful would
be a sst/regular breakdown for entry *application*, perhaps with timings
for SST ingestion delays. However, these are rare in practice and have
their own logging, so this is more trouble than it's worth. Just knowing
what enters the raft log and at which rate entries are applied should
be more than enough to make an educated guess as to what's going on.

Real-world example from overloading a local cluster:

```
raft ready handling: 0.82s [append=0.00s, apply=0.22s, commit-batch-sync=0.59s, other=0.01s], wrote 30 KiB sync [append-ent=30 KiB (3), apply=3.0 MiB (313 in 3 batches)]; node might be overloaded
```

Release note: None
