### PR TITLE
kvserver: downgrade spammy "skipping snapshot" message

### DIFF
--- a/pkg/kv/kvserver/raft_snapshot_queue.go
+++ b/pkg/kv/kvserver/raft_snapshot_queue.go
@@ -109,7 +109,6 @@ func (rq *raftSnapshotQueue) processRaftSnapshot(
 		return errors.Errorf("%s: replica %d not present in %v", repl, id, desc.Replicas())
 	}
 	snapType := kvserverpb.SnapshotRequest_VIA_SNAPSHOT_QUEUE
-	skipSnapLogLimiter := log.Every(10 * time.Second)
 
 	if typ := repDesc.GetType(); typ == roachpb.LEARNER || typ == roachpb.NON_VOTER {
 		if fn := repl.store.cfg.TestingKnobs.RaftSnapshotQueueSkipReplica; fn != nil && fn() {
@@ -125,11 +124,7 @@ func (rq *raftSnapshotQueue) processRaftSnapshot(
 				typ,
 				repDesc,
 			)
-			if skipSnapLogLimiter.ShouldLog() {
-				log.Infof(ctx, "%v", err)
-			} else {
-				log.VEventf(ctx, 3, "%v", err)
-			}
+			log.VEventf(ctx, 2, "%v", err)
 			// TODO(dan): This is super brittle and non-obvious. In the common case,
 			// this check avoids duplicate work, but in rare cases, we send the
 			// learner snap at an index before the one raft wanted here. The raft


### PR DESCRIPTION
This message wasn't useful, as it is always logged when a LEARNER upreplication
is occurring. Nothing is lost by moving it behind `V(2)`.

Release note: None
