### PR TITLE
changefeedccl: cleanup catchup_scan_iterator_optimization setting

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -46,7 +46,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -90,20 +89,9 @@ type cdcTestArgs struct {
 func cdcClusterSettings(t test.Test, db *sqlutils.SQLRunner) {
 	// kv.rangefeed.enabled is required for changefeeds to run
 	db.Exec(t, "SET CLUSTER SETTING kv.rangefeed.enabled = true")
-	randomlyRun(t, db, "SET CLUSTER SETTING kv.rangefeed.catchup_scan_iterator_optimization.enabled = false")
 }
 
 const randomSettingPercent = 0.50
-
-var rng, _ = randutil.NewTestRand()
-
-func randomlyRun(t test.Test, db *sqlutils.SQLRunner, query string) {
-	if rng.Float64() < randomSettingPercent {
-		db.Exec(t, query)
-		t.L().Printf("setting non-default cluster setting: %s", query)
-	}
-
-}
 
 func cdcBasicTest(ctx context.Context, t test.Test, c cluster.Cluster, args cdcTestArgs) {
 	crdbNodes := c.Range(1, c.Spec().NodeCount-1)

--- a/pkg/kv/kvserver/rangefeed/catchup_scan.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan.go
@@ -29,10 +29,10 @@ type CatchUpIterator struct {
 }
 
 // NewCatchUpIterator returns a CatchUpIterator for the given Reader.
-// If useTBI is true, a time-bound iterator will be used if possible,
-// configured with a start time taken from the RangeFeedRequest.
+// A time-bound iterator will be used if possible, configured with a start time
+// taken from the RangeFeedRequest.
 func NewCatchUpIterator(
-	reader storage.Reader, args *roachpb.RangeFeedRequest, useTBI bool, closer func(),
+	reader storage.Reader, args *roachpb.RangeFeedRequest, closer func(),
 ) *CatchUpIterator {
 	ret := &CatchUpIterator{
 		close: closer,
@@ -42,7 +42,7 @@ func NewCatchUpIterator(
 	// previous value of a key. This is possible since the
 	// IncrementalIterator has a non-timebound iterator
 	// internally, but it is not yet implemented.
-	if useTBI && !args.WithDiff {
+	if !args.WithDiff {
 		ret.SimpleMVCCIterator = storage.NewMVCCIncrementalIterator(reader, storage.MVCCIncrementalIterOptions{
 			EnableTimeBoundIteratorOptimization: true,
 			EndKey:                              args.Span.EndKey,

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
@@ -52,7 +52,7 @@ func runCatchUpBenchmark(b *testing.B, emk engineMaker, opts benchOptions) {
 				},
 				WithDiff: opts.withDiff,
 				Span:     span,
-			}, opts.useTBI, func() {})
+			}, func() {})
 			defer iter.Close()
 			counter := 0
 			err := iter.CatchUpScan(storage.MakeMVCCMetadataKey(startKey), storage.MakeMVCCMetadataKey(endKey), opts.ts, opts.withDiff, func(*roachpb.RangeFeedEvent) error {
@@ -136,23 +136,18 @@ func BenchmarkCatchUpScan(b *testing.B) {
 
 	for name, do := range dataOpts {
 		b.Run(name, func(b *testing.B) {
-			for _, useTBI := range []bool{true, false} {
-				b.Run(fmt.Sprintf("useTBI=%v", useTBI), func(b *testing.B) {
-					// TODO(ssd): withDiff isn't currently supported by the TBI optimization.
-					for _, withDiff := range []bool{false} {
-						b.Run(fmt.Sprintf("withDiff=%v", withDiff), func(b *testing.B) {
-							for _, tsExcludePercent := range []float64{0.0, 0.50, 0.75, 0.95, 0.99} {
-								wallTime := int64((5 * (float64(numKeys)*tsExcludePercent + 1)))
-								ts := hlc.Timestamp{WallTime: wallTime}
-								b.Run(fmt.Sprintf("perc=%2.2f", tsExcludePercent*100), func(b *testing.B) {
-									runCatchUpBenchmark(b, setupMVCCPebble, benchOptions{
-										dataOpts: do,
-										ts:       ts,
-										useTBI:   useTBI,
-										withDiff: withDiff,
-									})
-								})
-							}
+			// TODO(ssd): withDiff isn't currently supported by the TBI optimization.
+			for _, withDiff := range []bool{false} {
+				b.Run(fmt.Sprintf("withDiff=%v", withDiff), func(b *testing.B) {
+					for _, tsExcludePercent := range []float64{0.0, 0.50, 0.75, 0.95, 0.99} {
+						wallTime := int64((5 * (float64(numKeys)*tsExcludePercent + 1)))
+						ts := hlc.Timestamp{WallTime: wallTime}
+						b.Run(fmt.Sprintf("perc=%2.2f", tsExcludePercent*100), func(b *testing.B) {
+							runCatchUpBenchmark(b, setupMVCCPebble, benchOptions{
+								dataOpts: do,
+								ts:       ts,
+								withDiff: withDiff,
+							})
 						})
 					}
 				})
@@ -171,7 +166,6 @@ type benchDataOptions struct {
 
 type benchOptions struct {
 	ts       hlc.Timestamp
-	useTBI   bool
 	withDiff bool
 	dataOpts benchDataOptions
 }


### PR DESCRIPTION
The catchup_scan_iterator_optimization option was defaulted to `true` in
22.1 and later patches of 21.2.  This change removes the option entirely
to avoid uncertainty during troubleshooting.

Release note (enterprise change): removed the
kv.rangefeed.catchup_scan_iterator_optimization.enabled option, treating
it as `true` at all times.