### PR TITLE
rowexec: use opaque keys to identify looked-up rows in lookup joins

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -975,7 +975,7 @@ func (c *kvEventToRowConsumer) eventToRow(
 		return r, err
 	}
 
-	r.datums, err = rf.NextRow(ctx)
+	r.datums, _, err = rf.NextRow(ctx)
 	if err != nil {
 		return r, err
 	}
@@ -992,7 +992,7 @@ func (c *kvEventToRowConsumer) eventToRow(
 	nextRow := encodeRow{
 		tableDesc: desc,
 	}
-	nextRow.datums, err = rf.NextRow(ctx)
+	nextRow.datums, _, err = rf.NextRow(ctx)
 	if err != nil {
 		return r, err
 	}
@@ -1032,7 +1032,7 @@ func (c *kvEventToRowConsumer) eventToRow(
 		if err := prevRF.StartScanFrom(ctx, &c.kvFetcher, false /* traceKV */); err != nil {
 			return r, err
 		}
-		r.prevDatums, err = prevRF.NextRow(ctx)
+		r.prevDatums, _, err = prevRF.NextRow(ctx)
 		if err != nil {
 			return r, err
 		}
@@ -1047,7 +1047,7 @@ func (c *kvEventToRowConsumer) eventToRow(
 		nextRow := encodeRow{
 			prevTableDesc: r.prevTableDesc,
 		}
-		nextRow.prevDatums, err = prevRF.NextRow(ctx)
+		nextRow.prevDatums, _, err = prevRF.NextRow(ctx)
 		if err != nil {
 			return r, err
 		}

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -309,7 +309,7 @@ func (cb *ColumnBackfiller) RunColumnBackfillChunk(
 	// populated and deleted by the OLTP commands but not otherwise
 	// read or used
 	if err := cb.fetcher.StartScan(
-		ctx, txn, []roachpb.Span{sp},
+		ctx, txn, []roachpb.Span{sp}, nil, /* spanIDs */
 		rowinfra.GetDefaultBatchBytesLimit(false /* forceProductionValue */),
 		chunkSize, traceKV, false, /* forceProductionKVBatchSize */
 	); err != nil {
@@ -858,7 +858,7 @@ func (ib *IndexBackfiller) BuildIndexEntriesChunk(
 	}
 	defer fetcher.Close(ctx)
 	if err := fetcher.StartScan(
-		ctx, txn, []roachpb.Span{sp},
+		ctx, txn, []roachpb.Span{sp}, nil, /* spanIDs */
 		rowinfra.GetDefaultBatchBytesLimit(false /* forceProductionValue */),
 		initBufferSize, traceKV, false, /* forceProductionKVBatchSize */
 	); err != nil {

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -547,6 +547,7 @@ func (cf *cFetcher) StartScan(
 		ctx,
 		txn,
 		spans,
+		nil, /* spanIDs */
 		bsHeader,
 		cf.reverse,
 		batchBytesLimit,
@@ -578,7 +579,7 @@ func (cf *cFetcher) StartScanStreaming(
 	spans roachpb.Spans,
 	limitHint rowinfra.RowLimit,
 ) error {
-	kvBatchFetcher, err := row.NewTxnKVStreamer(ctx, streamer, spans, cf.lockStrength)
+	kvBatchFetcher, err := row.NewTxnKVStreamer(ctx, streamer, spans, nil /* spanIDs */, cf.lockStrength)
 	if err != nil {
 		return err
 	}
@@ -697,7 +698,7 @@ func (cf *cFetcher) NextBatch(ctx context.Context) (coldata.Batch, error) {
 		case stateInvalid:
 			return nil, errors.New("invalid fetcher state")
 		case stateInitFetch:
-			moreKVs, kv, finalReferenceToBatch, err := cf.fetcher.NextKV(ctx, cf.mvccDecodeStrategy)
+			moreKVs, kv, _, finalReferenceToBatch, err := cf.fetcher.NextKV(ctx, cf.mvccDecodeStrategy)
 			if err != nil {
 				return nil, cf.convertFetchError(ctx, err)
 			}
@@ -847,7 +848,7 @@ func (cf *cFetcher) NextBatch(ctx context.Context) (coldata.Batch, error) {
 			cf.machine.state[0] = stateFetchNextKVWithUnfinishedRow
 
 		case stateFetchNextKVWithUnfinishedRow:
-			moreKVs, kv, finalReferenceToBatch, err := cf.fetcher.NextKV(ctx, cf.mvccDecodeStrategy)
+			moreKVs, kv, _, finalReferenceToBatch, err := cf.fetcher.NextKV(ctx, cf.mvccDecodeStrategy)
 			if err != nil {
 				return nil, cf.convertFetchError(ctx, err)
 			}

--- a/pkg/sql/delete_preserving_index_test.go
+++ b/pkg/sql/delete_preserving_index_test.go
@@ -786,7 +786,7 @@ func fetchIndex(
 	))
 
 	require.NoError(t, fetcher.StartScan(
-		ctx, txn, spans, rowinfra.NoBytesLimit, 0, true, false, /* forceProductionBatchSize */
+		ctx, txn, spans, nil /* spanIDs */, rowinfra.NoBytesLimit, 0, true, false, /* forceProductionBatchSize */
 	))
 	var rows []tree.Datums
 	for {

--- a/pkg/sql/indexbackfiller_test.go
+++ b/pkg/sql/indexbackfiller_test.go
@@ -416,7 +416,7 @@ INSERT INTO foo VALUES (1), (10), (100);
 		))
 
 		require.NoError(t, fetcher.StartScan(
-			ctx, txn, spans, rowinfra.NoBytesLimit, 0, true, false, /* forceProductionBatchSize */
+			ctx, txn, spans, nil /* spanIDs */, rowinfra.NoBytesLimit, 0, true, false, /* forceProductionBatchSize */
 		))
 		var rows []tree.Datums
 		for {

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -33,15 +33,18 @@ type singleKVFetcher struct {
 	done bool
 }
 
+var _ KVBatchFetcher = &singleKVFetcher{}
+
 // nextBatch implements the KVBatchFetcher interface.
-func (f *singleKVFetcher) nextBatch(
-	ctx context.Context,
-) (ok bool, kvs []roachpb.KeyValue, batchResponse []byte, err error) {
+func (f *singleKVFetcher) nextBatch(ctx context.Context) (kvBatchFetcherResponse, error) {
 	if f.done {
-		return false, nil, nil, nil
+		return kvBatchFetcherResponse{moreKVs: false}, nil
 	}
 	f.done = true
-	return true, f.kvs[:], nil, nil
+	return kvBatchFetcherResponse{
+		moreKVs: true,
+		kvs:     f.kvs[:],
+	}, nil
 }
 
 // ConvertBatchError attempts to map a key-value error generated during a

--- a/pkg/sql/row/fetcher_test.go
+++ b/pkg/sql/row/fetcher_test.go
@@ -153,6 +153,7 @@ func TestNextRowSingle(t *testing.T) {
 				context.Background(),
 				kv.NewTxn(ctx, kvDB, 0),
 				roachpb.Spans{tableDesc.IndexSpan(keys.SystemSQLCodec, tableDesc.GetPrimaryIndexID())},
+				nil, /* spanIDs */
 				rowinfra.NoBytesLimit,
 				rowinfra.NoRowLimit,
 				false, /*traceKV*/
@@ -257,6 +258,7 @@ func TestNextRowBatchLimiting(t *testing.T) {
 				context.Background(),
 				kv.NewTxn(ctx, kvDB, 0),
 				roachpb.Spans{tableDesc.IndexSpan(keys.SystemSQLCodec, tableDesc.GetPrimaryIndexID())},
+				nil, /* spanIDs */
 				rowinfra.GetDefaultBatchBytesLimit(false /* forceProductionValue */),
 				10,    /*limitHint*/
 				false, /*traceKV*/
@@ -351,6 +353,7 @@ func TestRowFetcherMemoryLimits(t *testing.T) {
 		context.Background(),
 		kv.NewTxn(ctx, kvDB, 0),
 		roachpb.Spans{tableDesc.IndexSpan(keys.SystemSQLCodec, tableDesc.GetPrimaryIndexID())},
+		nil, /* spanIDs */
 		rowinfra.NoBytesLimit,
 		rowinfra.NoRowLimit,
 		false, /*traceKV*/
@@ -428,6 +431,7 @@ INDEX(c)
 		roachpb.Spans{indexSpan,
 			roachpb.Span{Key: midKey, EndKey: endKey},
 		},
+		nil, /* spanIDs */
 		rowinfra.GetDefaultBatchBytesLimit(false /* forceProductionValue */),
 		// Set a limitHint of 1 to more quickly end the first batch, causing a
 		// batch that ends between rows.
@@ -586,6 +590,7 @@ func TestNextRowSecondaryIndex(t *testing.T) {
 				context.Background(),
 				kv.NewTxn(ctx, kvDB, 0),
 				roachpb.Spans{tableDesc.IndexSpan(keys.SystemSQLCodec, tableDesc.PublicNonPrimaryIndexes()[0].GetID())},
+				nil, /* spanIDs */
 				rowinfra.NoBytesLimit,
 				rowinfra.NoRowLimit,
 				false, /*traceKV*/

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -55,6 +55,49 @@ type sendFunc func(
 	ctx context.Context, ba roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, error)
 
+// identifiableSpans is a helper for keeping track of the roachpb.Spans with the
+// corresponding spanIDs (when necessary).
+type identifiableSpans struct {
+	roachpb.Spans
+	spanIDs []int
+}
+
+// swap swaps two spans as well as their span IDs.
+func (s *identifiableSpans) swap(i, j int) {
+	s.Spans.Swap(i, j)
+	if s.spanIDs != nil {
+		s.spanIDs[i], s.spanIDs[j] = s.spanIDs[j], s.spanIDs[i]
+	}
+}
+
+// pop removes the first span as well as its span ID from s and returns them.
+func (s *identifiableSpans) pop() (roachpb.Span, int) {
+	origSpan := s.Spans[0]
+	s.Spans[0] = roachpb.Span{}
+	s.Spans = s.Spans[1:]
+	var spanID int
+	if s.spanIDs != nil {
+		spanID = s.spanIDs[0]
+		s.spanIDs = s.spanIDs[1:]
+	}
+	return origSpan, spanID
+}
+
+// push appends the given span as well as its span ID to s.
+func (s *identifiableSpans) push(span roachpb.Span, spanID int) {
+	s.Spans = append(s.Spans, span)
+	if s.spanIDs != nil {
+		s.spanIDs = append(s.spanIDs, spanID)
+	}
+}
+
+// reset sets up s for reuse - the underlying slices will be overwritten with
+// future calls to push().
+func (s *identifiableSpans) reset() {
+	s.Spans = s.Spans[:0]
+	s.spanIDs = s.spanIDs[:0]
+}
+
 // txnKVFetcher handles retrieval of key/values.
 type txnKVFetcher struct {
 	// "Constant" fields, provided by the caller.
@@ -62,15 +105,17 @@ type txnKVFetcher struct {
 	// spans is the list of Spans that will be read by this KV Fetcher. If an
 	// individual Span has only a start key, it will be interpreted as a
 	// single-key fetch and may use a GetRequest under the hood.
-	spans roachpb.Spans
+	spans identifiableSpans
 	// spansScratch is the initial state of spans (given to the fetcher when
-	// starting the scan) that we need to hold on to since we're slicing off
-	// spans in nextBatch(). Any resume spans are copied into this slice when
+	// starting the scan) that we need to hold on to since we're poping off
+	// spans in nextBatch(). Any resume spans are copied into this struct when
 	// processing each response.
-	spansScratch roachpb.Spans
-	// newFetchSpansIdx tracks the number of resume spans we have copied into
-	// spansScratch after the last fetch.
-	newFetchSpansIdx int
+	//
+	// scratchSpans.Len() is the number of resume spans we have accumulated
+	// during the last fetch.
+	scratchSpans identifiableSpans
+
+	curSpanID int
 
 	// If firstBatchKeyLimit is set, the first batch is limited in number of keys
 	// to this value and subsequent batches are larger (up to a limit, see
@@ -105,6 +150,9 @@ type txnKVFetcher struct {
 
 	responses        []roachpb.ResponseUnion
 	remainingBatches [][]byte
+
+	// getResponseScratch is reused to return the result of Get requests.
+	getResponseScratch [1]roachpb.KeyValue
 
 	acc *mon.BoundAccount
 	// spansAccountedFor and batchResponseAccountedFor track the number of bytes
@@ -189,6 +237,7 @@ func makeKVBatchFetcherDefaultSendFunc(txn *kv.Txn) sendFunc {
 type kvBatchFetcherArgs struct {
 	sendFn                     sendFunc
 	spans                      roachpb.Spans
+	spanIDs                    []int
 	reverse                    bool
 	batchBytesLimit            rowinfra.BytesLimit
 	firstBatchKeyLimit         rowinfra.KeyLimit
@@ -210,6 +259,14 @@ type kvBatchFetcherArgs struct {
 // will perform the memory accounting accordingly (if acc is non-nil). The
 // caller can only reuse the spans slice after the fetcher has been closed, and
 // if the caller does, it becomes responsible for the memory accounting.
+//
+// The fetcher also takes ownership of the spanIDs slice - it can modify the
+// slice, but it will **not** perform the memory accounting. It is the caller's
+// responsibility to track the memory under the spanIDs slice, and the slice
+// can only be reused once the fetcher has been closed. Notably, the capacity of
+// the slice will not be increased by the fetcher.
+//
+// If spanIDs is non-nil, then it must be of the same length as spans.
 //
 // Batch limits can only be used if the spans are ordered.
 //
@@ -287,24 +344,31 @@ func makeKVBatchFetcher(ctx context.Context, args kvBatchFetcherArgs) (txnKVFetc
 		}
 	}
 
+	if args.spanIDs != nil && len(args.spans) != len(args.spanIDs) {
+		return txnKVFetcher{}, errors.AssertionFailedf("unexpectedly non-nil spanIDs slice has a different length than spans")
+	}
+
 	// Since the fetcher takes ownership of the spans slice, we don't need to
 	// perform the deep copy. Notably, the spans might be modified (when the
 	// fetcher receives the resume spans), but the fetcher will always keep the
 	// memory accounting up to date.
-	f.spans = args.spans
+	f.spans = identifiableSpans{
+		Spans:   args.spans,
+		spanIDs: args.spanIDs,
+	}
 	if args.reverse {
 		// Reverse scans receive the spans in decreasing order. Note that we
-		// need to be this tricky since we're updating the spans slice in place.
-		i, j := 0, len(args.spans)-1
+		// need to be this tricky since we're updating the spans in place.
+		i, j := 0, f.spans.Len()-1
 		for i < j {
-			f.spans[i], f.spans[j] = f.spans[j], f.spans[i]
+			f.spans.swap(i, j)
 			i++
 			j--
 		}
 	}
-	// Keep the reference to the full spans slice. We will never need larger
-	// slice for the resume spans.
-	f.spansScratch = f.spans
+	// Keep the reference to the full identifiable spans. We will never need
+	// larger slices when processing the resume spans.
+	f.scratchSpans = f.spans
 
 	return f, nil
 }
@@ -317,7 +381,7 @@ func (f *txnKVFetcher) fetch(ctx context.Context) error {
 	ba.Header.TargetBytes = int64(f.batchBytesLimit)
 	ba.Header.MaxSpanRequestKeys = int64(f.getBatchKeyLimit())
 	ba.AdmissionHeader = f.requestAdmissionHeader
-	ba.Requests = spansToRequests(f.spans, f.reverse, f.lockStrength)
+	ba.Requests = spansToRequests(f.spans.Spans, f.reverse, f.lockStrength)
 
 	if log.ExpensiveLogEnabled(ctx, 2) {
 		log.VEventf(ctx, 2, "Scan %s", f.spans)
@@ -392,7 +456,7 @@ func (f *txnKVFetcher) fetch(ctx context.Context) error {
 	}
 
 	f.batchIdx++
-	f.newFetchSpansIdx = 0
+	f.scratchSpans.reset()
 	f.alreadyFetched = true
 
 	// TODO(radu): We should fetch the next chunk in the background instead of waiting for the next
@@ -410,13 +474,8 @@ func popBatch(batches [][]byte) (batch []byte, remainingBatches [][]byte) {
 	return batch, remainingBatches
 }
 
-// nextBatch returns the next batch of key/value pairs. If there are none
-// available, a fetch is initiated. When there are no more keys, ok is false.
-// atBatchBoundary indicates whether the next call to nextBatch will request
-// another fetch from the KV system.
-func (f *txnKVFetcher) nextBatch(
-	ctx context.Context,
-) (ok bool, kvs []roachpb.KeyValue, batchResp []byte, err error) {
+// nextBatch implements the KVBatchFetcher interface.
+func (f *txnKVFetcher) nextBatch(ctx context.Context) (resp kvBatchFetcherResponse, err error) {
 	// The purpose of this loop is to unpack the two-level batch structure that is
 	// returned from the KV layer.
 	//
@@ -429,8 +488,13 @@ func (f *txnKVFetcher) nextBatch(
 	if len(f.remainingBatches) > 0 {
 		// Are there remaining data batches? If so, just pop one off from the
 		// list and return it.
+		var batchResp []byte
 		batchResp, f.remainingBatches = popBatch(f.remainingBatches)
-		return true, nil, batchResp, nil
+		return kvBatchFetcherResponse{
+			moreKVs:       true,
+			batchResponse: batchResp,
+			spanID:        f.curSpanID,
+		}, nil
 	}
 	// There are no remaining data batches. Find the first non-empty ResponseUnion
 	// in the list of unprocessed responses from the last BatchResponse we sent,
@@ -441,93 +505,98 @@ func (f *txnKVFetcher) nextBatch(
 		f.responses = f.responses[1:]
 		// Get the original span right away since we might overwrite it with the
 		// resume span below.
-		origSpan := f.spans[0]
-		f.spans[0] = roachpb.Span{}
-		f.spans = f.spans[1:]
+		var origSpan roachpb.Span
+		origSpan, f.curSpanID = f.spans.pop()
 
 		// Check whether we need to resume scanning this span.
 		header := reply.Header()
-		if header.NumKeys > 0 && f.newFetchSpansIdx > 0 {
-			return false, nil, nil, errors.Errorf(
+		if header.NumKeys > 0 && f.scratchSpans.Len() > 0 {
+			return kvBatchFetcherResponse{}, errors.Errorf(
 				"span with results after resume span; it shouldn't happen given that "+
 					"we're only scanning non-overlapping spans. New spans: %s",
-				catalogkeys.PrettySpans(nil, f.spans, 0 /* skip */))
+				catalogkeys.PrettySpans(nil, f.spans.Spans, 0 /* skip */))
 		}
 
 		// Any requests that were not fully completed will have the ResumeSpan set.
 		// Here we accumulate all of them.
 		if resumeSpan := header.ResumeSpan; resumeSpan != nil {
-			f.spansScratch[f.newFetchSpansIdx] = *resumeSpan
-			f.newFetchSpansIdx++
+			f.scratchSpans.push(*resumeSpan, f.curSpanID)
+		}
+
+		ret := kvBatchFetcherResponse{
+			moreKVs: true,
+			spanID:  f.curSpanID,
 		}
 
 		switch t := reply.(type) {
 		case *roachpb.ScanResponse:
 			if len(t.BatchResponses) > 0 {
-				batchResp, f.remainingBatches = popBatch(t.BatchResponses)
+				ret.batchResponse, f.remainingBatches = popBatch(t.BatchResponses)
 			}
 			if len(t.Rows) > 0 {
-				return false, nil, nil, errors.AssertionFailedf(
+				return kvBatchFetcherResponse{}, errors.AssertionFailedf(
 					"unexpectedly got a ScanResponse using KEY_VALUES response format",
 				)
 			}
 			if len(t.IntentRows) > 0 {
-				return false, nil, nil, errors.AssertionFailedf(
+				return kvBatchFetcherResponse{}, errors.AssertionFailedf(
 					"unexpectedly got a ScanResponse with non-nil IntentRows",
 				)
 			}
-			// Note that batchResp might be nil when the ScanResponse is empty,
-			// and the caller (the KVFetcher) will skip over it.
-			return true, nil, batchResp, nil
+			// Note that ret.batchResponse might be nil when the ScanResponse is
+			// empty, and the caller (the KVFetcher) will skip over it.
+			return ret, nil
 		case *roachpb.ReverseScanResponse:
 			if len(t.BatchResponses) > 0 {
-				batchResp, f.remainingBatches = popBatch(t.BatchResponses)
+				ret.batchResponse, f.remainingBatches = popBatch(t.BatchResponses)
 			}
 			if len(t.Rows) > 0 {
-				return false, nil, nil, errors.AssertionFailedf(
-					"unexpectedly got a ReverseScanResponse using KEY_VALUES response format",
+				return kvBatchFetcherResponse{}, errors.AssertionFailedf(
+					"unexpectedly got a ScanResponse using KEY_VALUES response format",
 				)
 			}
 			if len(t.IntentRows) > 0 {
-				return false, nil, nil, errors.AssertionFailedf(
-					"unexpectedly got a ReverseScanResponse with non-nil IntentRows",
+				return kvBatchFetcherResponse{}, errors.AssertionFailedf(
+					"unexpectedly got a ScanResponse with non-nil IntentRows",
 				)
 			}
-			// Note that batchResp might be nil when the ReverseScanResponse is
+			// Note that ret.batchResponse might be nil when the ScanResponse is
 			// empty, and the caller (the KVFetcher) will skip over it.
-			return true, nil, batchResp, nil
+			return ret, nil
 		case *roachpb.GetResponse:
 			if t.IntentValue != nil {
-				return false, nil, nil, errors.AssertionFailedf("unexpectedly got an IntentValue back from a SQL GetRequest %v", *t.IntentValue)
+				return kvBatchFetcherResponse{}, errors.AssertionFailedf("unexpectedly got an IntentValue back from a SQL GetRequest %v", *t.IntentValue)
 			}
 			if t.Value == nil {
 				// Nothing found in this particular response, let's continue to the next
 				// one.
 				continue
 			}
-			return true, []roachpb.KeyValue{{Key: origSpan.Key, Value: *t.Value}}, nil, nil
+			f.getResponseScratch[0] = roachpb.KeyValue{Key: origSpan.Key, Value: *t.Value}
+			ret.kvs = f.getResponseScratch[:]
+			return ret, nil
 		}
 	}
 	// No more responses from the last BatchRequest.
 	if f.alreadyFetched {
-		if f.newFetchSpansIdx == 0 {
+		if f.scratchSpans.Len() == 0 {
 			// If we are out of keys, we can return and we're finished with the
 			// fetch.
-			return false, nil, nil, nil
+			return kvBatchFetcherResponse{moreKVs: false}, nil
 		}
 		// We have some resume spans.
-		f.spans = f.spansScratch[:f.newFetchSpansIdx]
+		f.spans = f.scratchSpans
 		if f.acc != nil {
 			newSpansMemUsage := f.spans.MemUsage()
 			if err := f.acc.Resize(ctx, f.spansAccountedFor, newSpansMemUsage); err != nil {
-				return false, nil, nil, err
+				return kvBatchFetcherResponse{}, err
 			}
 			f.spansAccountedFor = newSpansMemUsage
 		}
 	}
 	// We have more work to do. Ask the KV layer to continue where it left off.
 	if err := f.fetch(ctx); err != nil {
-		return false, nil, nil, err
+		return kvBatchFetcherResponse{}, err
 	}
 	// We've got more data to process, recurse and process it.
 	return f.nextBatch(ctx)
@@ -537,8 +606,8 @@ func (f *txnKVFetcher) nextBatch(
 func (f *txnKVFetcher) close(ctx context.Context) {
 	f.responses = nil
 	f.remainingBatches = nil
-	f.spans = nil
-	f.spansScratch = nil
+	f.spans = identifiableSpans{}
+	f.scratchSpans = identifiableSpans{}
 	// Release only the allocations made by this fetcher.
 	f.acc.Shrink(ctx, f.batchResponseAccountedFor+f.spansAccountedFor)
 }

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -510,7 +510,7 @@ func (ij *invertedJoiner) performScan() (invertedJoinerState, *execinfrapb.Produ
 	// Read the entire set of rows that are part of the scan.
 	for {
 		// Fetch the next row and copy it into the row container.
-		fetchedRow, err := ij.fetcher.NextRow(ij.Ctx)
+		fetchedRow, _, err := ij.fetcher.NextRow(ij.Ctx)
 		if err != nil {
 			ij.MoveToDraining(scrub.UnwrapScrubError(err))
 			return ijStateUnknown, ij.DrainHelper()

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -494,7 +494,8 @@ func (ij *invertedJoiner) readInput() (invertedJoinerState, *execinfrapb.Produce
 
 	log.VEventf(ij.Ctx, 1, "scanning %d spans", len(ij.indexSpans))
 	if err = ij.fetcher.StartScan(
-		ij.Ctx, ij.FlowCtx.Txn, ij.indexSpans, rowinfra.NoBytesLimit, rowinfra.NoRowLimit,
+		ij.Ctx, ij.FlowCtx.Txn, ij.indexSpans, nil, /* spanIDs */
+		rowinfra.NoBytesLimit, rowinfra.NoRowLimit,
 		ij.FlowCtx.TraceKV, ij.EvalCtx.TestingKnobs.ForceProductionValues,
 	); err != nil {
 		ij.MoveToDraining(err)

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -491,19 +491,13 @@ func (jr *joinReader) initJoinReaderStrategy(
 	spanGeneratorMemAcc := jr.MemMonitor.MakeBoundAccount()
 	var generator joinReaderSpanGenerator
 	if jr.lookupExpr.Expr == nil {
-		var keyToInputRowIndices map[string][]int
-		// See the comment in defaultSpanGenerator on why we don't need
-		// this map for index joins.
-		if readerType != indexJoinReaderType {
-			keyToInputRowIndices = make(map[string][]int)
-		}
 		defGen := &defaultSpanGenerator{}
 		if err := defGen.init(
 			flowCtx.EvalCtx,
 			flowCtx.Codec(),
 			&jr.fetchSpec,
 			jr.splitFamilyIDs,
-			keyToInputRowIndices,
+			readerType == indexJoinReaderType, /* uniqueRows */
 			jr.lookupCols,
 			&spanGeneratorMemAcc,
 		); err != nil {
@@ -681,6 +675,40 @@ func addWorkmemHint(err error) error {
 	)
 }
 
+type spansWithSpanIDs struct {
+	spans   roachpb.Spans
+	spanIDs []int
+}
+
+var _ sort.Interface = &spansWithSpanIDs{}
+
+func (s spansWithSpanIDs) Len() int {
+	return len(s.spans)
+}
+
+func (s spansWithSpanIDs) Less(i, j int) bool {
+	return s.spans[i].Key.Compare(s.spans[j].Key) < 0
+}
+
+func (s spansWithSpanIDs) Swap(i, j int) {
+	s.spans[i], s.spans[j] = s.spans[j], s.spans[i]
+	s.spanIDs[i], s.spanIDs[j] = s.spanIDs[j], s.spanIDs[i]
+}
+
+// sortSpans sorts the given spans while maintaining the spanIDs mapping (if it
+// is non-nil).
+func sortSpans(spans roachpb.Spans, spanIDs []int) {
+	if spanIDs != nil {
+		s := spansWithSpanIDs{
+			spans:   spans,
+			spanIDs: spanIDs,
+		}
+		sort.Sort(&s)
+	} else {
+		sort.Sort(spans)
+	}
+}
+
 // readInput reads the next batch of input rows and starts an index scan.
 // It can sometimes emit a single row on behalf of the previous batch.
 func (jr *joinReader) readInput() (
@@ -816,7 +844,7 @@ func (jr *joinReader) readInput() (
 	}
 
 	// Figure out what key spans we need to lookup.
-	spans, err := jr.strategy.processLookupRows(jr.scratchInputRows)
+	spans, spanIDs, err := jr.strategy.processLookupRows(jr.scratchInputRows)
 	if err != nil {
 		jr.MoveToDraining(err)
 		return jrStateUnknown, nil, jr.DrainHelper()
@@ -852,7 +880,7 @@ func (jr *joinReader) readInput() (
 			return jrStateUnknown, nil, jr.DrainHelper()
 		}
 	} else {
-		sort.Sort(spans)
+		sortSpans(spans, spanIDs)
 	}
 
 	log.VEventf(jr.Ctx, 1, "scanning %d spans", len(spans))
@@ -864,7 +892,7 @@ func (jr *joinReader) readInput() (
 	if jr.usesStreamer {
 		var kvBatchFetcher *row.TxnKVStreamer
 		kvBatchFetcher, err = row.NewTxnKVStreamer(
-			jr.Ctx, jr.streamerInfo.Streamer, spans, nil /* spanIDs */, jr.keyLocking,
+			jr.Ctx, jr.streamerInfo.Streamer, spans, spanIDs, jr.keyLocking,
 		)
 		if err != nil {
 			jr.MoveToDraining(err)
@@ -882,7 +910,7 @@ func (jr *joinReader) readInput() (
 			}
 		}
 		err = jr.fetcher.StartScan(
-			jr.Ctx, jr.FlowCtx.Txn, spans, nil /* spanIDs */, bytesLimit, rowinfra.NoRowLimit,
+			jr.Ctx, jr.FlowCtx.Txn, spans, spanIDs, bytesLimit, rowinfra.NoRowLimit,
 			jr.FlowCtx.TraceKV, jr.EvalCtx.TestingKnobs.ForceProductionValues,
 		)
 	}
@@ -897,23 +925,8 @@ func (jr *joinReader) readInput() (
 // performLookup reads the next batch of index rows.
 func (jr *joinReader) performLookup() (joinReaderState, *execinfrapb.ProducerMetadata) {
 	for {
-		// Construct a "partial key" of nCols, so we can match the key format that
-		// was stored in our keyToInputRowIndices map. This matches the format that
-		// is output in jr.generateSpan.
-		var key roachpb.Key
-		// Index joins do not look at this key parameter so don't bother populating
-		// it, since it is not cheap for long keys.
-		if jr.readerType != indexJoinReaderType {
-			var err error
-			key, err = jr.fetcher.PartialKey(jr.strategy.getMaxLookupKeyCols())
-			if err != nil {
-				jr.MoveToDraining(err)
-				return jrStateUnknown, jr.DrainHelper()
-			}
-		}
-
 		// Fetch the next row and tell the strategy to process it.
-		lookedUpRow, err := jr.fetcher.NextRow(jr.Ctx)
+		lookedUpRow, spanID, err := jr.fetcher.NextRow(jr.Ctx)
 		if err != nil {
 			jr.MoveToDraining(scrub.UnwrapScrubError(err))
 			return jrStateUnknown, jr.DrainHelper()
@@ -925,7 +938,7 @@ func (jr *joinReader) performLookup() (joinReaderState, *execinfrapb.ProducerMet
 		jr.rowsRead++
 		jr.curBatchRowsRead++
 
-		if nextState, err := jr.strategy.processLookedUpRow(jr.Ctx, lookedUpRow, key); err != nil {
+		if nextState, err := jr.strategy.processLookedUpRow(jr.Ctx, lookedUpRow, spanID); err != nil {
 			jr.MoveToDraining(err)
 			return jrStateUnknown, jr.DrainHelper()
 		} else if nextState != jrPerformingLookup {
@@ -939,7 +952,7 @@ func (jr *joinReader) performLookup() (joinReaderState, *execinfrapb.ProducerMet
 	// the remote nodes for the current batch.
 	if jr.remoteLookupExpr.Expr != nil && !jr.strategy.generatedRemoteSpans() &&
 		jr.curBatchRowsRead != jr.curBatchInputRowCount {
-		spans, err := jr.strategy.generateRemoteSpans()
+		spans, spanIDs, err := jr.strategy.generateRemoteSpans()
 		if err != nil {
 			jr.MoveToDraining(err)
 			return jrStateUnknown, jr.DrainHelper()
@@ -950,7 +963,7 @@ func (jr *joinReader) performLookup() (joinReaderState, *execinfrapb.ProducerMet
 			// of results per batch. It's safe to reorder the spans here because we
 			// already restore the original order of the output during the output
 			// collection phase.
-			sort.Sort(spans)
+			sortSpans(spans, spanIDs)
 
 			log.VEventf(jr.Ctx, 1, "scanning %d remote spans", len(spans))
 			bytesLimit := rowinfra.GetDefaultBatchBytesLimit(jr.EvalCtx.TestingKnobs.ForceProductionValues)
@@ -958,7 +971,7 @@ func (jr *joinReader) performLookup() (joinReaderState, *execinfrapb.ProducerMet
 				bytesLimit = rowinfra.NoBytesLimit
 			}
 			if err := jr.fetcher.StartScan(
-				jr.Ctx, jr.FlowCtx.Txn, spans, nil /* spanIDs */, bytesLimit, rowinfra.NoRowLimit,
+				jr.Ctx, jr.FlowCtx.Txn, spans, spanIDs, bytesLimit, rowinfra.NoRowLimit,
 				jr.FlowCtx.TraceKV, jr.EvalCtx.TestingKnobs.ForceProductionValues,
 			); err != nil {
 				jr.MoveToDraining(err)

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -863,7 +863,9 @@ func (jr *joinReader) readInput() (
 	// joinReaderStrategy doesn't account for any memory used by the spans.
 	if jr.usesStreamer {
 		var kvBatchFetcher *row.TxnKVStreamer
-		kvBatchFetcher, err = row.NewTxnKVStreamer(jr.Ctx, jr.streamerInfo.Streamer, spans, jr.keyLocking)
+		kvBatchFetcher, err = row.NewTxnKVStreamer(
+			jr.Ctx, jr.streamerInfo.Streamer, spans, nil /* spanIDs */, jr.keyLocking,
+		)
 		if err != nil {
 			jr.MoveToDraining(err)
 			return jrStateUnknown, nil, jr.DrainHelper()
@@ -880,7 +882,7 @@ func (jr *joinReader) readInput() (
 			}
 		}
 		err = jr.fetcher.StartScan(
-			jr.Ctx, jr.FlowCtx.Txn, spans, bytesLimit, rowinfra.NoRowLimit,
+			jr.Ctx, jr.FlowCtx.Txn, spans, nil /* spanIDs */, bytesLimit, rowinfra.NoRowLimit,
 			jr.FlowCtx.TraceKV, jr.EvalCtx.TestingKnobs.ForceProductionValues,
 		)
 	}
@@ -956,7 +958,7 @@ func (jr *joinReader) performLookup() (joinReaderState, *execinfrapb.ProducerMet
 				bytesLimit = rowinfra.NoBytesLimit
 			}
 			if err := jr.fetcher.StartScan(
-				jr.Ctx, jr.FlowCtx.Txn, spans, bytesLimit, rowinfra.NoRowLimit,
+				jr.Ctx, jr.FlowCtx.Txn, spans, nil /* spanIDs */, bytesLimit, rowinfra.NoRowLimit,
 				jr.FlowCtx.TraceKV, jr.EvalCtx.TestingKnobs.ForceProductionValues,
 			); err != nil {
 				jr.MoveToDraining(err)

--- a/pkg/sql/rowexec/joinreader_span_generator.go
+++ b/pkg/sql/rowexec/joinreader_span_generator.go
@@ -13,8 +13,6 @@ package rowexec
 import (
 	"context"
 	"fmt"
-	"sort"
-	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -43,17 +41,12 @@ type joinReaderSpanGenerator interface {
 	// The returned spans are not accounted for, so it is the caller's
 	// responsibility to register the spans memory usage with our memory
 	// accounting system.
-	generateSpans(ctx context.Context, rows []rowenc.EncDatumRow) (roachpb.Spans, error)
+	generateSpans(ctx context.Context, rows []rowenc.EncDatumRow) (roachpb.Spans, []int, error)
 
-	// getMatchingRowIndices returns the indices of the input rows that desire
-	// the given key (i.e., the indices of the rows passed to generateSpans that
-	// generated spans containing the given key). An error is returned if no
-	// span among returned by generateSpans() contains the given key.
-	getMatchingRowIndices(key roachpb.Key) ([]int, error)
-
-	// maxLookupCols returns the maximum number of index columns used as the key
-	// for each lookup.
-	maxLookupCols() int
+	// getMatchingRowIndices returns the indices of the input rows that are
+	// associated with the given span ID (i.e., the indices of the rows passed
+	// to generateSpans that resulted in the spanID'th generated span).
+	getMatchingRowIndices(spanID int) []int
 
 	// close releases any resources associated with the joinReaderSpanGenerator.
 	close(context.Context)
@@ -63,19 +56,100 @@ var _ joinReaderSpanGenerator = &defaultSpanGenerator{}
 var _ joinReaderSpanGenerator = &multiSpanGenerator{}
 var _ joinReaderSpanGenerator = &localityOptimizedSpanGenerator{}
 
+// spanIDHelper helps joinReaderSpanGenerators in maintaining a mapping between
+// spans returned by generateSpans() and input rows that need the result of each
+// span. This is needed in order to join the looked up rows with the input rows
+// later.
+type spanIDHelper struct {
+	// spanKeyToSpanID maps a lookup span key to the span ID. This is used for
+	// de-duping spans for lookup joins.
+	//
+	// Index joins already have unique rows that generate unique spans to fetch,
+	// so they don't need this map.
+	spanKeyToSpanID map[string]int
+	// spanIDToInputRowIndices maps a span ID to the input row indices that
+	// desire the lookup of the span corresponding to that span ID.
+	//
+	// Index joins simply output the fetched rows, so they don't need this
+	// mapping.
+	spanIDToInputRowIndices [][]int
+
+	scratchSpanIDs []int
+}
+
+// reset sets up the helper for reuse.
+func (h *spanIDHelper) reset() {
+	// This loop gets optimized to a runtime.mapclear call.
+	for k := range h.spanKeyToSpanID {
+		delete(h.spanKeyToSpanID, k)
+	}
+	h.spanIDToInputRowIndices = h.spanIDToInputRowIndices[:0]
+	h.scratchSpanIDs = h.scratchSpanIDs[:0]
+}
+
+// addInputRowIdxForSpan adds the given input row index to the list of indices
+// corresponding to the given span (identified by the span key). Span ID of the
+// span as well as a boolean indicating whether this span key is seen for the
+// first time are returned.
+func (h *spanIDHelper) addInputRowIdxForSpan(
+	spanKey string, inputRowIdx int,
+) (spanID int, newSpanKey bool) {
+	spanID, ok := h.spanKeyToSpanID[spanKey]
+	if !ok {
+		spanID = len(h.spanKeyToSpanID)
+		h.spanKeyToSpanID[spanKey] = spanID
+		if cap(h.spanIDToInputRowIndices) > spanID {
+			h.spanIDToInputRowIndices = h.spanIDToInputRowIndices[:spanID+1]
+			h.spanIDToInputRowIndices[spanID] = h.spanIDToInputRowIndices[spanID][:0]
+		} else {
+			h.spanIDToInputRowIndices = append(h.spanIDToInputRowIndices, nil)
+		}
+	}
+	h.spanIDToInputRowIndices[spanID] = append(h.spanIDToInputRowIndices[spanID], inputRowIdx)
+	return spanID, !ok
+}
+
+// addedSpans notifies the helper that 'count' number of spans were created that
+// correspond to the given spanID.
+func (h *spanIDHelper) addedSpans(spanID int, count int) {
+	for i := 0; i < count; i++ {
+		h.scratchSpanIDs = append(h.scratchSpanIDs, spanID)
+	}
+}
+
+func (h *spanIDHelper) getMatchingRowIndices(spanID int) []int {
+	return h.spanIDToInputRowIndices[spanID]
+}
+
+// memUsage returns the size of the data structures in the spanIDHelper for
+// memory accounting purposes.
+func (h *spanIDHelper) memUsage() int64 {
+	var size int64
+	// Account for spanKeyToSpanID map.
+	size += int64(len(h.spanKeyToSpanID)) * (memsize.MapEntryOverhead + memsize.Int)
+	// Account for each key in the map since it can be arbitrarily large.
+	for k := range h.spanKeyToSpanID {
+		size += memsize.String + int64(len(k))
+	}
+	// Account for the two-dimensional spanIDToInputRowIndices.
+	size += int64(cap(h.spanIDToInputRowIndices)) * memsize.IntSliceOverhead
+	// Account for each one-dimensional int slice in spanIDToInputRowIndices.
+	for _, slice := range h.spanIDToInputRowIndices[:cap(h.spanIDToInputRowIndices)] {
+		size += int64(cap(slice)) * memsize.Int64
+	}
+	// Account for scratchSpanIDs.
+	size += int64(cap(h.scratchSpanIDs)) * memsize.Int64
+	return size
+}
+
 type defaultSpanGenerator struct {
 	spanBuilder  span.Builder
 	spanSplitter span.Splitter
 	lookupCols   []uint32
 
 	indexKeyRow rowenc.EncDatumRow
-	// keyToInputRowIndices maps a lookup span key to the input row indices that
-	// desire that span. This is used for joins other than index joins, for
-	// de-duping spans, and to map the fetched rows to the input rows that need
-	// to join with them. Index joins already have unique rows in the input that
-	// generate unique spans for fetch, and simply output the fetched rows, do
-	// do not use this map.
-	keyToInputRowIndices map[string][]int
+
+	spanIDHelper
 
 	scratchSpans roachpb.Spans
 
@@ -89,7 +163,7 @@ func (g *defaultSpanGenerator) init(
 	codec keys.SQLCodec,
 	fetchSpec *descpb.IndexFetchSpec,
 	splitFamilyIDs []descpb.FamilyID,
-	keyToInputRowIndices map[string][]int,
+	uniqueRows bool,
 	lookupCols []uint32,
 	memAcc *mon.BoundAccount,
 ) error {
@@ -102,8 +176,9 @@ func (g *defaultSpanGenerator) init(
 		)
 	}
 	g.indexKeyRow = nil
-	g.keyToInputRowIndices = keyToInputRowIndices
-	g.scratchSpans = nil
+	if !uniqueRows {
+		g.spanIDHelper.spanKeyToSpanID = make(map[string]int)
+	}
 	g.memAcc = memAcc
 	return nil
 }
@@ -136,14 +211,11 @@ func (g *defaultSpanGenerator) hasNullLookupColumn(row rowenc.EncDatumRow) bool 
 // generateSpans is part of the joinReaderSpanGenerator interface.
 func (g *defaultSpanGenerator) generateSpans(
 	ctx context.Context, rows []rowenc.EncDatumRow,
-) (roachpb.Spans, error) {
-	// This loop gets optimized to a runtime.mapclear call.
-	for k := range g.keyToInputRowIndices {
-		delete(g.keyToInputRowIndices, k)
+) (roachpb.Spans, []int, error) {
+	isIndexJoin := g.spanKeyToSpanID == nil
+	if !isIndexJoin {
+		g.spanIDHelper.reset()
 	}
-
-	// We maintain a map from index key to the corresponding input rows so we can
-	// join the index results to the inputs.
 	g.scratchSpans = g.scratchSpans[:0]
 	for i, inputRow := range rows {
 		if g.hasNullLookupColumn(inputRow) {
@@ -151,85 +223,39 @@ func (g *defaultSpanGenerator) generateSpans(
 		}
 		generatedSpan, containsNull, err := g.generateSpan(inputRow)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		if g.keyToInputRowIndices == nil {
-			// Index join.
+		if isIndexJoin {
 			g.scratchSpans = g.spanSplitter.MaybeSplitSpanIntoSeparateFamilies(
-				g.scratchSpans, generatedSpan, len(g.lookupCols), containsNull)
+				g.scratchSpans, generatedSpan, len(g.lookupCols), containsNull,
+			)
 		} else {
-			inputRowIndices := g.keyToInputRowIndices[string(generatedSpan.Key)]
-			if inputRowIndices == nil {
+			spanID, newSpanKey := g.addInputRowIdxForSpan(string(generatedSpan.Key), i)
+			if newSpanKey {
+				numOldSpans := len(g.scratchSpans)
 				g.scratchSpans = g.spanSplitter.MaybeSplitSpanIntoSeparateFamilies(
-					g.scratchSpans, generatedSpan, len(g.lookupCols), containsNull)
+					g.scratchSpans, generatedSpan, len(g.lookupCols), containsNull,
+				)
+				g.addedSpans(spanID, len(g.scratchSpans)-numOldSpans)
 			}
-			g.keyToInputRowIndices[string(generatedSpan.Key)] = append(inputRowIndices, i)
 		}
 	}
 
 	// Memory accounting.
+	//
+	// NOTE: this does not account for scratchSpans because the joinReader
+	// passes the ownership of spans to the fetcher which will account for it
+	// accordingly.
 	if err := g.memAcc.ResizeTo(ctx, g.memUsage()); err != nil {
-		return nil, addWorkmemHint(err)
+		return nil, nil, addWorkmemHint(err)
 	}
 
-	return g.scratchSpans, nil
-}
-
-// getMatchingRowIndices is part of the joinReaderSpanGenerator interface.
-func (g *defaultSpanGenerator) getMatchingRowIndices(key roachpb.Key) ([]int, error) {
-	return g.keyToInputRowIndices[string(key)], nil
-}
-
-// maxLookupCols is part of the joinReaderSpanGenerator interface.
-func (g *defaultSpanGenerator) maxLookupCols() int {
-	return len(g.lookupCols)
-}
-
-// memUsage returns the size of the data structures in the defaultSpanGenerator
-// for memory accounting purposes.
-// NOTE: this does not account for scratchSpans because the joinReader passes
-// the ownership of spans to the fetcher which will account for it accordingly.
-func (g *defaultSpanGenerator) memUsage() int64 {
-	// Account for keyToInputRowIndices.
-	var size int64
-	for k, v := range g.keyToInputRowIndices {
-		size += memsize.MapEntryOverhead
-		size += memsize.String + int64(len(k))
-		size += memsize.IntSliceOverhead + memsize.Int*int64(cap(v))
-	}
-	return size
+	return g.scratchSpans, g.scratchSpanIDs, nil
 }
 
 func (g *defaultSpanGenerator) close(ctx context.Context) {
 	g.memAcc.Close(ctx)
 	*g = defaultSpanGenerator{}
-}
-
-type spanRowIndex struct {
-	span       roachpb.Span
-	rowIndices []int
-}
-
-type spanRowIndices []spanRowIndex
-
-func (s spanRowIndices) Len() int           { return len(s) }
-func (s spanRowIndices) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
-func (s spanRowIndices) Less(i, j int) bool { return s[i].span.Key.Compare(s[j].span.Key) < 0 }
-
-var _ sort.Interface = &spanRowIndices{}
-
-// memUsage returns the size of the spanRowIndices for memory accounting
-// purposes.
-func (s spanRowIndices) memUsage() int64 {
-	// Slice the full capacity of s so we can account for the memory
-	// used past the length of s.
-	sCap := s[:cap(s)]
-	size := int64(unsafe.Sizeof(spanRowIndices{}))
-	for i := range sCap {
-		size += sCap[i].span.MemUsage()
-		size += memsize.IntSliceOverhead + memsize.Int*int64(cap(sCap[i].rowIndices))
-	}
-	return size
 }
 
 // multiSpanGenerator is the joinReaderSpanGenerator used when each lookup will
@@ -256,19 +282,7 @@ type multiSpanGenerator struct {
 	indexKeyRows  []rowenc.EncDatumRow
 	indexKeySpans roachpb.Spans
 
-	// keyToInputRowIndices maps a lookup span key to the input row indices that
-	// desire that span. This is used for de-duping spans, and to map the fetched
-	// rows to the input rows that need to join with them. If we have inequality
-	// exprs we can't use this from getMatchingRowIndices because the spans are
-	// ranges and not point spans so we build this map using the start keys and
-	// then convert it into a spanToInputRowIndices.
-	keyToInputRowIndices map[string][]int
-
-	// spanToInputRowIndices maps a lookup span to the input row indices that
-	// desire that span. This is a range based equivalent of the
-	// keyToInputRowIndices that is only used when there are range based, i.e.
-	// inequality conditions. This is a sorted set we do binary searches on.
-	spanToInputRowIndices spanRowIndices
+	spanIDHelper
 
 	// spansCount is the number of spans generated for each input row.
 	spansCount int
@@ -357,11 +371,6 @@ var _ multiSpanGeneratorColInfo = &multiSpanGeneratorValuesColInfo{}
 var _ multiSpanGeneratorColInfo = &multiSpanGeneratorIndexVarColInfo{}
 var _ multiSpanGeneratorColInfo = &multiSpanGeneratorInequalityColInfo{}
 
-// maxLookupCols is part of the joinReaderSpanGenerator interface.
-func (g *multiSpanGenerator) maxLookupCols() int {
-	return len(g.indexColInfos)
-}
-
 // init must be called before the multiSpanGenerator can be used to generate
 // spans.
 func (g *multiSpanGenerator) init(
@@ -377,7 +386,7 @@ func (g *multiSpanGenerator) init(
 	g.spanBuilder.InitWithFetchSpec(evalCtx, codec, fetchSpec)
 	g.spanSplitter = span.MakeSplitterWithFamilyIDs(len(fetchSpec.KeyFullColumns()), splitFamilyIDs)
 	g.numInputCols = numInputCols
-	g.keyToInputRowIndices = make(map[string][]int)
+	g.spanKeyToSpanID = make(map[string]int)
 	g.fetchedOrdToIndexKeyOrd = fetchedOrdToIndexKeyOrd
 	g.inequalityColIdx = -1
 	g.memAcc = memAcc
@@ -648,48 +657,22 @@ func (g *multiSpanGenerator) generateNonNullSpans(row rowenc.EncDatumRow) (roach
 	return g.indexKeySpans, nil
 }
 
-// findInputRowIndicesByKey does a binary search to find the span that contains
-// the given key.
-func (s *spanRowIndices) findInputRowIndicesByKey(key roachpb.Key) ([]int, error) {
-	i, j := 0, s.Len()
-	for i < j {
-		h := (i + j) >> 1
-		sp := (*s)[h]
-		switch sp.span.CompareKey(key) {
-		case 0:
-			return sp.rowIndices, nil
-		case -1:
-			j = h
-		case 1:
-			i = h + 1
-		}
-	}
-
-	return nil, errors.AssertionFailedf("didn't find a span containing the key %s", key)
-}
-
 // generateSpans is part of the joinReaderSpanGenerator interface.
 func (g *multiSpanGenerator) generateSpans(
 	ctx context.Context, rows []rowenc.EncDatumRow,
-) (roachpb.Spans, error) {
-	// This loop gets optimized to a runtime.mapclear call.
-	for k := range g.keyToInputRowIndices {
-		delete(g.keyToInputRowIndices, k)
-	}
-	g.spanToInputRowIndices = g.spanToInputRowIndices[:0]
-
-	// We maintain a map from index key to the corresponding input rows so we can
-	// join the index results to the inputs.
+) (roachpb.Spans, []int, error) {
+	g.spanIDHelper.reset()
 	g.scratchSpans = g.scratchSpans[:0]
 	for i, inputRow := range rows {
 		generatedSpans, err := g.generateNonNullSpans(inputRow)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		for j := range generatedSpans {
 			generatedSpan := &generatedSpans[j]
-			inputRowIndices := g.keyToInputRowIndices[string(generatedSpan.Key)]
-			if inputRowIndices == nil {
+			spanID, newSpanKey := g.spanIDHelper.addInputRowIdxForSpan(string(generatedSpan.Key), i)
+			if newSpanKey {
+				numOldSpans := len(g.scratchSpans)
 				// MaybeSplitSpanIntoSeparateFamilies is an optimization for doing more
 				// efficient point lookups when the span hits multiple column families.
 				// It doesn't work with inequality ranges because they aren't point lookups.
@@ -697,59 +680,24 @@ func (g *multiSpanGenerator) generateSpans(
 					g.scratchSpans = append(g.scratchSpans, *generatedSpan)
 				} else {
 					g.scratchSpans = g.spanSplitter.MaybeSplitSpanIntoSeparateFamilies(
-						g.scratchSpans, *generatedSpan, len(g.indexColInfos), false /* containsNull */)
+						g.scratchSpans, *generatedSpan, len(g.indexColInfos), false, /* containsNull */
+					)
 				}
+				g.addedSpans(spanID, len(g.scratchSpans)-numOldSpans)
 			}
-
-			g.keyToInputRowIndices[string(generatedSpan.Key)] = append(inputRowIndices, i)
-		}
-	}
-
-	// If we need to map against range spans instead of point spans convert the
-	// map into a sorted set of spans we can binary search against.
-	if g.inequalityColIdx != -1 {
-		for _, s := range g.scratchSpans {
-			g.spanToInputRowIndices = append(g.spanToInputRowIndices, spanRowIndex{span: s, rowIndices: g.keyToInputRowIndices[string(s.Key)]})
-		}
-		sort.Sort(g.spanToInputRowIndices)
-		// We don't need this anymore.
-		for k := range g.keyToInputRowIndices {
-			delete(g.keyToInputRowIndices, k)
 		}
 	}
 
 	// Memory accounting.
+	//
+	// NOTE: this does not account for scratchSpans because the joinReader
+	// passes the ownership of spans to the fetcher which will account for it
+	// accordingly.
 	if err := g.memAcc.ResizeTo(ctx, g.memUsage()); err != nil {
-		return nil, addWorkmemHint(err)
+		return nil, nil, addWorkmemHint(err)
 	}
 
-	return g.scratchSpans, nil
-}
-
-// getMatchingRowIndices is part of the joinReaderSpanGenerator interface.
-func (g *multiSpanGenerator) getMatchingRowIndices(key roachpb.Key) ([]int, error) {
-	if g.inequalityColIdx != -1 {
-		return g.spanToInputRowIndices.findInputRowIndicesByKey(key)
-	}
-	return g.keyToInputRowIndices[string(key)], nil
-}
-
-// memUsage returns the size of the data structures in the multiSpanGenerator
-// for memory accounting purposes.
-// NOTE: this does not account for scratchSpans because the joinReader passes
-// the ownership of spans to the fetcher which will account for it accordingly.
-func (g *multiSpanGenerator) memUsage() int64 {
-	// Account for keyToInputRowIndices.
-	var size int64
-	for k, v := range g.keyToInputRowIndices {
-		size += memsize.MapEntryOverhead
-		size += memsize.String + int64(len(k))
-		size += memsize.IntSliceOverhead + memsize.Int*int64(cap(v))
-	}
-
-	// Account for spanToInputRowIndices.
-	size += g.spanToInputRowIndices.memUsage()
-	return size
+	return g.scratchSpans, g.scratchSpanIDs, nil
 }
 
 func (g *multiSpanGenerator) close(ctx context.Context) {
@@ -798,8 +746,8 @@ func (g *localityOptimizedSpanGenerator) init(
 		return err
 	}
 	// Check that the resulting span generators have the same lookup columns.
-	localLookupCols := g.localSpanGen.maxLookupCols()
-	remoteLookupCols := g.remoteSpanGen.maxLookupCols()
+	localLookupCols := len(g.localSpanGen.indexColInfos)
+	remoteLookupCols := len(g.remoteSpanGen.indexColInfos)
 	if localLookupCols != remoteLookupCols {
 		return errors.AssertionFailedf(
 			"local lookup cols (%d) != remote lookup cols (%d)", localLookupCols, remoteLookupCols,
@@ -808,17 +756,10 @@ func (g *localityOptimizedSpanGenerator) init(
 	return nil
 }
 
-// maxLookupCols is part of the joinReaderSpanGenerator interface.
-func (g *localityOptimizedSpanGenerator) maxLookupCols() int {
-	// We already asserted in init that maxLookupCols is the same for both the
-	// local and remote span generators.
-	return g.localSpanGen.maxLookupCols()
-}
-
 // generateSpans is part of the joinReaderSpanGenerator interface.
 func (g *localityOptimizedSpanGenerator) generateSpans(
 	ctx context.Context, rows []rowenc.EncDatumRow,
-) (roachpb.Spans, error) {
+) (roachpb.Spans, []int, error) {
 	g.localSpanGenUsedLast = true
 	return g.localSpanGen.generateSpans(ctx, rows)
 }
@@ -827,17 +768,17 @@ func (g *localityOptimizedSpanGenerator) generateSpans(
 // batch of input rows.
 func (g *localityOptimizedSpanGenerator) generateRemoteSpans(
 	ctx context.Context, rows []rowenc.EncDatumRow,
-) (roachpb.Spans, error) {
+) (roachpb.Spans, []int, error) {
 	g.localSpanGenUsedLast = false
 	return g.remoteSpanGen.generateSpans(ctx, rows)
 }
 
 // getMatchingRowIndices is part of the joinReaderSpanGenerator interface.
-func (g *localityOptimizedSpanGenerator) getMatchingRowIndices(key roachpb.Key) ([]int, error) {
+func (g *localityOptimizedSpanGenerator) getMatchingRowIndices(spanID int) []int {
 	if g.localSpanGenUsedLast {
-		return g.localSpanGen.getMatchingRowIndices(key)
+		return g.localSpanGen.getMatchingRowIndices(spanID)
 	}
-	return g.remoteSpanGen.getMatchingRowIndices(key)
+	return g.remoteSpanGen.getMatchingRowIndices(spanID)
 }
 
 func (g *localityOptimizedSpanGenerator) close(ctx context.Context) {

--- a/pkg/sql/rowexec/rowfetcher.go
+++ b/pkg/sql/rowexec/rowfetcher.go
@@ -28,7 +28,7 @@ import (
 // collector wrapper can be plugged in.
 type rowFetcher interface {
 	StartScan(
-		_ context.Context, _ *kv.Txn, _ roachpb.Spans, batchBytesLimit rowinfra.BytesLimit,
+		_ context.Context, _ *kv.Txn, _ roachpb.Spans, spanIDs []int, batchBytesLimit rowinfra.BytesLimit,
 		rowLimitHint rowinfra.RowLimit, traceKV bool, forceProductionKVBatchSize bool,
 	) error
 	StartScanFrom(_ context.Context, _ row.KVBatchFetcher, traceKV bool) error

--- a/pkg/sql/rowexec/rowfetcher.go
+++ b/pkg/sql/rowexec/rowfetcher.go
@@ -45,13 +45,11 @@ type rowFetcher interface {
 		qualityOfService sessiondatapb.QoSLevel,
 	) error
 
-	NextRow(ctx context.Context) (rowenc.EncDatumRow, error)
+	NextRow(ctx context.Context) (_ rowenc.EncDatumRow, spanID int, _ error)
 	NextRowInto(
 		ctx context.Context, destination rowenc.EncDatumRow, colIdxMap catalog.TableColMap,
 	) (ok bool, err error)
 
-	// PartialKey is not stat-related but needs to be supported.
-	PartialKey(nCols int) (roachpb.Key, error)
 	Reset()
 	GetBytesRead() int64
 	// Close releases any resources held by this fetcher.

--- a/pkg/sql/rowexec/stats.go
+++ b/pkg/sql/rowexec/stats.go
@@ -96,13 +96,14 @@ func (c *rowFetcherStatCollector) StartScan(
 	ctx context.Context,
 	txn *kv.Txn,
 	spans roachpb.Spans,
+	spanIDs []int,
 	batchBytesLimit rowinfra.BytesLimit,
 	limitHint rowinfra.RowLimit,
 	traceKV bool,
 	forceProductionKVBatchSize bool,
 ) error {
 	start := timeutil.Now()
-	err := c.fetcher.StartScan(ctx, txn, spans, batchBytesLimit, limitHint, traceKV, forceProductionKVBatchSize)
+	err := c.fetcher.StartScan(ctx, txn, spans, spanIDs, batchBytesLimit, limitHint, traceKV, forceProductionKVBatchSize)
 	c.startScanStallTime += timeutil.Since(start)
 	return err
 }

--- a/pkg/sql/rowexec/stats.go
+++ b/pkg/sql/rowexec/stats.go
@@ -141,14 +141,14 @@ func (c *rowFetcherStatCollector) StartInconsistentScan(
 }
 
 // NextRow is part of the rowFetcher interface.
-func (c *rowFetcherStatCollector) NextRow(ctx context.Context) (rowenc.EncDatumRow, error) {
+func (c *rowFetcherStatCollector) NextRow(ctx context.Context) (rowenc.EncDatumRow, int, error) {
 	start := timeutil.Now()
-	row, err := c.fetcher.NextRow(ctx)
+	row, spanID, err := c.fetcher.NextRow(ctx)
 	if row != nil {
 		c.stats.NumTuples.Add(1)
 	}
 	c.stats.WaitTime.Add(timeutil.Since(start))
-	return row, err
+	return row, spanID, err
 }
 
 // NextRowInto is part of the rowFetcher interface.
@@ -162,11 +162,6 @@ func (c *rowFetcherStatCollector) NextRowInto(
 	}
 	c.stats.WaitTime.Add(timeutil.Since(start))
 	return ok, err
-}
-
-// PartialKey is part of the rowFetcher interface.
-func (c *rowFetcherStatCollector) PartialKey(nCols int) (roachpb.Key, error) {
-	return c.fetcher.PartialKey(nCols)
 }
 
 func (c *rowFetcherStatCollector) Reset() {

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -270,7 +270,7 @@ func (tr *tableReader) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata
 			return nil, meta
 		}
 
-		row, err := tr.fetcher.NextRow(tr.Ctx)
+		row, _, err := tr.fetcher.NextRow(tr.Ctx)
 		if row == nil || err != nil {
 			tr.MoveToDraining(err)
 			break

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -209,8 +209,8 @@ func (tr *tableReader) startScan(ctx context.Context) error {
 	var err error
 	if tr.maxTimestampAge == 0 {
 		err = tr.fetcher.StartScan(
-			ctx, tr.FlowCtx.Txn, tr.Spans, bytesLimit, tr.limitHint,
-			tr.FlowCtx.TraceKV,
+			ctx, tr.FlowCtx.Txn, tr.Spans, nil /* spanIDs */, bytesLimit,
+			tr.limitHint, tr.FlowCtx.TraceKV,
 			tr.EvalCtx.TestingKnobs.ForceProductionValues,
 		)
 	} else {

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -647,6 +647,7 @@ func (z *zigzagJoiner) nextRow(ctx context.Context, txn *kv.Txn) (rowenc.EncDatu
 			ctx,
 			txn,
 			roachpb.Spans{roachpb.Span{Key: curInfo.key, EndKey: curInfo.endKey}},
+			nil, /* spanIDs */
 			rowinfra.GetDefaultBatchBytesLimit(z.EvalCtx.TestingKnobs.ForceProductionValues),
 			zigzagJoinerBatchSize,
 			z.FlowCtx.TraceKV,
@@ -789,6 +790,7 @@ func (z *zigzagJoiner) maybeFetchInitialRow() error {
 			z.Ctx,
 			z.FlowCtx.Txn,
 			roachpb.Spans{roachpb.Span{Key: curInfo.key, EndKey: curInfo.endKey}},
+			nil, /* spanIDs */
 			rowinfra.GetDefaultBatchBytesLimit(z.EvalCtx.TestingKnobs.ForceProductionValues),
 			zigzagJoinerBatchSize,
 			z.FlowCtx.TraceKV,

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -514,7 +514,7 @@ func (z *zigzagJoiner) fetchRowFromSide(
 		return false
 	}
 	for {
-		fetchedRow, err := info.fetcher.NextRow(ctx)
+		fetchedRow, _, err := info.fetcher.NextRow(ctx)
 		if err != nil || fetchedRow == nil {
 			return nil, err
 		}


### PR DESCRIPTION
**sql: add span IDs to fetchers**

This commit implements the idea of Jordan's
78223b921c2ec073667cf2baf920636f24bd2900 to add opaque keys to fetchers.
This allows the fetchers' users to identify the input `roachpb.Span`
that a particular kv was fetched for. I decided to call these keys as
"span IDs" since it seems less ambiguous in general, and especially so
in the streamer world where too many "keys" are flying around already.

Some additional improvements:
- extract the return arguments of a function call into a helper struct
- remove an allocation for `GetResponse`s in the non-streamer code path.

Release note: None

**rowexec: use opaque keys to identify looked-up rows in lookup joins**

This commit refactors the span generators of the lookup joins to use the
span IDs ("opaque keys") for matching between the looked-up rows and the
input rows that correspond to them. Previously, we were maintaining
a map from the span key (bytes value) and had to construct a partial key
for each looked up row to get the matching input row indices. This
commit makes it so that we now assign each span to lookup a unique span
ID that is later used as an index into a two-dimensional slice of ints
to get the matching indices. We still keep a map from the span key for
the de-duplication purposes.

This change is beneficial in several ways:
- removes the need to construct the partial key for each looked up row
- replaces a map lookup based on the partial key into a slice access
- removes the need for the binary search among lookup spans in
range-based lookup joins.

This results in noticeable performance improvements in
[microbenchmarks](https://gist.github.com/yuzefovich/3e5316e0a5ff32fd1b591b0583d78ced).

Here is the difference on all TPCH queries (average over 20 runs of
`tpchvec/perf` roachtest, negative number indicates reduction in
latency):
```
Q2:   0.20s  0.20s  0.49%
Q3:   1.96s  1.66s -14.86%
Q4:   1.67s  1.62s -3.14%
Q5:   2.82s  2.55s -9.55%
Q7:   6.48s  6.93s  6.82%
Q8:   1.08s  0.99s -8.34%
Q9:   7.08s  6.36s -10.13%
Q10:  2.16s  1.94s -9.99%
Q11:  0.55s  0.51s -6.81%
Q12:  8.78s  8.59s -2.13%
Q16:  0.84s  0.82s -2.68%
Q17:  0.49s  0.46s -6.80%
Q20: 14.34s 13.43s -6.36%
Q21:  9.95s  9.28s -6.76%
Q22:  0.58s  0.54s -6.93%
```
(Queries that don't use lookup joins were ignored.)

However, the main motivation behind this change was unblocking (or at
least making it easier) to support lookup joins by the streamer. There,
we want the streamer to operate with these "opaque keys" as well as take
over the span de-duplication logic.

Release note: None