### PR TITLE
scbuildstmt: DROP DATABASE support for empty public schemas

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/drop_database
+++ b/pkg/sql/logictest/testdata/logic_test/drop_database
@@ -340,6 +340,14 @@ SELECT count(*) FROM system.namespace WHERE name LIKE 'seq50997'
 ----
 1
 
+subtest regression_73323
+
+statement ok
+CREATE DATABASE db_73323
+
+statement ok
+DROP DATABASE db_73323 RESTRICT
+
 subtest regression_51782
 
 statement ok


### PR DESCRIPTION
The declarative schema changer did not correctly support DROP DATABASE
RESTRICT for databases which only contain an empty public schema. This
commit fixes this.

Fixes #73323.

Release note: None