### PR TITLE
backupccl: Fix SHOW BACKUPS on a bucket's base directory.

### DIFF
--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -101,6 +102,11 @@ const (
 	// collection is stored. In v22.1 it contains the latest directory.
 	backupMetadataDirectory = "metadata"
 )
+
+// On some cloud storage platforms (i.e. GS, S3), backups in a base bucket may
+// omit a leading slash. However, backups in a subdirectory of a base bucket
+// will contain one.
+var backupPathRE = regexp.MustCompile("^/?[^\\/]+/[^\\/]+/[^\\/]+/" + backupManifestName + "$")
 
 var writeMetadataSST = settings.RegisterBoolSetting(
 	settings.TenantWritable,
@@ -1126,13 +1132,12 @@ func ListFullBackupsInCollection(
 ) ([]string, error) {
 	var backupPaths []string
 	if err := store.List(ctx, "", listingDelimDataSlash, func(f string) error {
-		if ok, err := path.Match("/*/*/*/"+backupManifestName, f); err != nil {
-			return err
-		} else if ok {
+		if backupPathRE.MatchString(f) {
 			backupPaths = append(backupPaths, f)
 		}
 		return nil
 	}); err != nil {
+		// Can't happen, just required to handle the error for lint.
 		return nil, err
 	}
 	for i, backupPath := range backupPaths {


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/77930. Tested on GS and AWS.

Release note (enterprise change): Fix bug where backups in the base directory of a cloud storage bucket would not be discovered by SHOW BACKUPS. These backups will now appear correctly.