### PR TITLE
backupccl: remove broken handling of inline values in `slurpSSTablesLatestKey`

### DIFF
--- a/pkg/ccl/backupccl/restore_data_processor_test.go
+++ b/pkg/ccl/backupccl/restore_data_processor_test.go
@@ -93,17 +93,8 @@ func slurpSSTablesLatestKey(
 			v := roachpb.Value{RawBytes: newKv.Value}
 			v.ClearChecksum()
 			v.InitChecksum(newKv.Key.Key)
-			// NB: import data does not contain intents, so data with no timestamps
-			// is inline meta and not intents. Therefore this is not affected by the
-			// choice of interleaved or separated intents.
-			if newKv.Key.Timestamp.IsEmpty() {
-				if err := batch.PutUnversioned(newKv.Key.Key, v.RawBytes); err != nil {
-					t.Fatal(err)
-				}
-			} else {
-				if err := batch.PutMVCC(newKv.Key, v.RawBytes); err != nil {
-					t.Fatal(err)
-				}
+			if err := batch.PutMVCC(newKv.Key, v.RawBytes); err != nil {
+				t.Fatal(err)
 			}
 			sst.Next()
 		}


### PR DESCRIPTION
This was unnecessary and also incorrect, as inline values use the `enginepb.MVCCMetadata` value encoding, not the `roachpb.Value` value encoding.