### PR TITLE
sql: add cluster setting to tune sql stats cleanup job behavior

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/cluster_settings.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/cluster_settings.go
@@ -117,3 +117,14 @@ var SQLStatsAggregationInterval = settings.RegisterDurationSetting(
 	time.Hour,
 	settings.NonNegativeDurationWithMaximum(time.Hour*24),
 )
+
+// CompactionJobRowsToDeletePerTxn is the cluster setting that controls
+// how many rows in the statement/transaction_statistics tables gets deleted
+// per transaction in the Automatic SQL Stats Compaction Job.
+var CompactionJobRowsToDeletePerTxn = settings.RegisterIntSetting(
+	settings.TenantWritable,
+	"sql.stats.cleanup.rows_to_delete_per_txn",
+	"number of rows the compaction job deletes from system table per iteration",
+	1024,
+	settings.NonNegativeInt,
+)

--- a/pkg/sql/sqlstats/persistedsqlstats/compaction_exec.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/compaction_exec.go
@@ -26,11 +26,6 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// maxDeleteRowsPerTxn limits max number of rows StatsCompactor deletes
-// per transaction. This is to avoid having large transaction which can
-// have negative impact on the overall system performance.
-const maxDeleteRowsPerTxn = 128
-
 // StatsCompactor is responsible for compacting older SQL Stats. It is
 // executed by sql.sqlStatsCompactionResumer.
 type StatsCompactor struct {
@@ -163,6 +158,7 @@ func (c *StatsCompactor) removeStaleRowsForShard(
 	shardIdx int,
 	existingRowCountPerShard, maxRowLimitPerShard int64,
 ) error {
+	maxDeleteRowsPerTxn := CompactionJobRowsToDeletePerTxn.Get(&c.st.SV)
 	if rowsToRemove := existingRowCountPerShard - maxRowLimitPerShard; rowsToRemove > 0 {
 		for remainToBeRemoved := rowsToRemove; remainToBeRemoved > 0; {
 			rowsToRemovePerTxn := remainToBeRemoved


### PR DESCRIPTION
Related to #79548

Previously, SQL Stats cleanup job was configured to break the
delete operation into many small transactions. Each transaction could
only delete up to 128 rows. This number was hardcoded and has shown to
be problematic when there are large number of MVCC garbages.
This commit changes this value into a new non-public cluster
settings `sql.stats.cleanup.rows_to_delete_per_txn` with default value
being 1024. The higher default value is bumped higher in order to
amortize the cost of scanning over large amount of MVCC garbage.

Release note: None