### PR TITLE
cloud: add settings to limit external IO writes

### DIFF
--- a/pkg/ccl/backupccl/backup_metadata_test.go
+++ b/pkg/ccl/backupccl/backup_metadata_test.go
@@ -75,7 +75,7 @@ func checkMetadata(
 		tc.Servers[0].ClusterSettings(),
 		blobs.TestEmptyBlobClientFactory,
 		security.RootUserName(),
-		tc.Servers[0].InternalExecutor().(*sql.InternalExecutor), tc.Servers[0].DB())
+		tc.Servers[0].InternalExecutor().(*sql.InternalExecutor), tc.Servers[0].DB(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -570,7 +570,7 @@ func TestBackupRestoreAppend(t *testing.T) {
 				tc.Servers[0].ClusterSettings(),
 				blobs.TestEmptyBlobClientFactory,
 				security.RootUserName(),
-				tc.Servers[0].InternalExecutor().(*sql.InternalExecutor), tc.Servers[0].DB())
+				tc.Servers[0].InternalExecutor().(*sql.InternalExecutor), tc.Servers[0].DB(), nil)
 			require.NoError(t, err)
 			defer store.Close()
 			var files []string
@@ -8040,7 +8040,7 @@ func TestReadBackupManifestMemoryMonitoring(t *testing.T) {
 		base.ExternalIODirConfig{},
 		st,
 		blobs.TestBlobServiceClient(dir),
-		security.RootUserName(), nil, nil)
+		security.RootUserName(), nil, nil, nil)
 	require.NoError(t, err)
 
 	m := mon.NewMonitor("test-monitor", mon.MemoryResource, nil, nil, 0, 0, st)

--- a/pkg/ccl/backupccl/restore_data_processor_test.go
+++ b/pkg/ccl/backupccl/restore_data_processor_test.go
@@ -237,7 +237,7 @@ func runTestIngest(t *testing.T, init func(*cluster.Settings)) {
 			DB: kvDB,
 			ExternalStorage: func(ctx context.Context, dest roachpb.ExternalStorage) (cloud.ExternalStorage, error) {
 				return cloud.MakeExternalStorage(ctx, dest, base.ExternalIODirConfig{},
-					s.ClusterSettings(), blobs.TestBlobServiceClient(s.ClusterSettings().ExternalIODir), nil, nil)
+					s.ClusterSettings(), blobs.TestBlobServiceClient(s.ClusterSettings().ExternalIODir), nil, nil, nil)
 			},
 			Settings: s.ClusterSettings(),
 			Codec:    keys.SystemSQLCodec,

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -159,7 +159,7 @@ func TestCloudStorageSink(t *testing.T) {
 	externalStorageFromURI := func(ctx context.Context, uri string, user security.SQLUsername) (cloud.ExternalStorage,
 		error) {
 		return cloud.ExternalStorageFromURI(ctx, uri, base.ExternalIODirConfig{}, settings,
-			clientFactory, user, nil, nil)
+			clientFactory, user, nil, nil, nil)
 	}
 
 	user := security.RootUserName()

--- a/pkg/ccl/cliccl/debug_backup.go
+++ b/pkg/ccl/cliccl/debug_backup.go
@@ -284,7 +284,7 @@ func externalStorageFromURIFactory(
 	defaultSettings := &cluster.Settings{}
 	defaultSettings.SV.Init(ctx, nil /* opaque */)
 	return cloud.ExternalStorageFromURI(ctx, uri, base.ExternalIODirConfig{},
-		defaultSettings, newBlobFactory, user, nil /*Internal Executor*/, nil /*kvDB*/)
+		defaultSettings, newBlobFactory, user, nil /*Internal Executor*/, nil /*kvDB*/, nil)
 }
 
 func getManifestFromURI(ctx context.Context, path string) (backupccl.BackupManifest, error) {
@@ -580,7 +580,7 @@ func makeIters(
 		var err error
 		clusterSettings := cluster.MakeClusterSettings()
 		dirStorage[i], err = cloud.MakeExternalStorage(ctx, file.Dir, base.ExternalIODirConfig{},
-			clusterSettings, newBlobFactory, nil /*internal executor*/, nil /*kvDB*/)
+			clusterSettings, newBlobFactory, nil /*internal executor*/, nil /*kvDB*/, nil)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "making external storage")
 		}

--- a/pkg/ccl/workloadccl/storage.go
+++ b/pkg/ccl/workloadccl/storage.go
@@ -37,7 +37,7 @@ func GetStorage(ctx context.Context, cfg FixtureConfig) (cloud.ExternalStorage, 
 
 	s, err := cloud.ExternalStorageFromURI(ctx, cfg.ObjectPathToURI(),
 		base.ExternalIODirConfig{}, clustersettings.MakeClusterSettings(),
-		nil, security.SQLUsername{}, nil, nil)
+		nil, security.SQLUsername{}, nil, nil, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, storageError)
 	}

--- a/pkg/cloud/BUILD.bazel
+++ b/pkg/cloud/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/util/ctxgroup",
         "//pkg/util/ioctx",
         "//pkg/util/log",
+        "//pkg/util/quotapool",
         "//pkg/util/retry",
         "//pkg/util/sysutil",
         "//pkg/util/tracing",

--- a/pkg/cloud/amazon/s3_storage_test.go
+++ b/pkg/cloud/amazon/s3_storage_test.go
@@ -46,7 +46,7 @@ func makeS3Storage(
 	// Setup a sink for the given args.
 	clientFactory := blobs.TestBlobServiceClient(testSettings.ExternalIODir)
 	s, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{}, testSettings,
-		clientFactory, nil, nil)
+		clientFactory, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func TestPutS3(t *testing.T) {
 	t.Run("auth-empty-no-cred", func(t *testing.T) {
 		_, err := cloud.ExternalStorageFromURI(ctx, fmt.Sprintf("s3://%s/%s", bucket,
 			"backup-test-default"), base.ExternalIODirConfig{}, testSettings,
-			blobs.TestEmptyBlobClientFactory, user, nil, nil)
+			blobs.TestEmptyBlobClientFactory, user, nil, nil, nil)
 		require.EqualError(t, err, fmt.Sprintf(
 			`%s is set to '%s', but %s is not set`,
 			cloud.AuthParam,
@@ -285,7 +285,7 @@ func TestS3BucketDoesNotExist(t *testing.T) {
 	// Setup a sink for the given args.
 	clientFactory := blobs.TestBlobServiceClient(testSettings.ExternalIODir)
 	s, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{}, testSettings,
-		clientFactory, nil, nil)
+		clientFactory, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cloud/cloudtestutils/cloud_test_helpers.go
+++ b/pkg/cloud/cloudtestutils/cloud_test_helpers.go
@@ -117,7 +117,7 @@ func storeFromURI(
 	}
 	// Setup a sink for the given args.
 	s, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{}, testSettings,
-		clientFactory, ie, kvDB)
+		clientFactory, ie, kvDB, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +144,7 @@ func CheckExportStore(
 
 	// Setup a sink for the given args.
 	clientFactory := blobs.TestBlobServiceClient(testSettings.ExternalIODir)
-	s, err := cloud.MakeExternalStorage(ctx, conf, ioConf, testSettings, clientFactory, ie, kvDB)
+	s, err := cloud.MakeExternalStorage(ctx, conf, ioConf, testSettings, clientFactory, ie, kvDB, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -495,7 +495,7 @@ func uploadData(
 
 	s, err := cloud.MakeExternalStorage(
 		ctx, dest, base.ExternalIODirConfig{}, testSettings,
-		nil, nil, nil)
+		nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, cloud.WriteFile(ctx, s, basename, bytes.NewReader(data)))
 	return data, func() {
@@ -536,7 +536,7 @@ func CheckAntagonisticRead(
 	ctx := context.Background()
 	s, err := cloud.MakeExternalStorage(
 		ctx, conf, base.ExternalIODirConfig{}, testSettings,
-		nil, nil, nil)
+		nil, nil, nil, nil)
 	require.NoError(t, err)
 	defer s.Close()
 

--- a/pkg/cloud/gcp/gcs_storage_test.go
+++ b/pkg/cloud/gcp/gcs_storage_test.go
@@ -130,7 +130,7 @@ func TestFileDoesNotExist(t *testing.T) {
 
 		s, err := cloud.MakeExternalStorage(
 			context.Background(), conf, base.ExternalIODirConfig{}, testSettings,
-			nil, nil, nil)
+			nil, nil, nil, nil)
 		require.NoError(t, err)
 		_, err = s.ReadFile(context.Background(), "")
 		require.Error(t, err, "")
@@ -145,7 +145,7 @@ func TestFileDoesNotExist(t *testing.T) {
 
 		s, err := cloud.MakeExternalStorage(
 			context.Background(), conf, base.ExternalIODirConfig{}, testSettings, nil,
-			nil, nil)
+			nil, nil, nil)
 		require.NoError(t, err)
 		_, err = s.ReadFile(context.Background(), "")
 		require.Error(t, err, "")
@@ -173,9 +173,9 @@ func TestCompressedGCS(t *testing.T) {
 	conf2, err := cloud.ExternalStorageConfFromURI(gsFile2, user)
 	require.NoError(t, err)
 
-	s1, err := cloud.MakeExternalStorage(ctx, conf1, base.ExternalIODirConfig{}, testSettings, nil, nil, nil)
+	s1, err := cloud.MakeExternalStorage(ctx, conf1, base.ExternalIODirConfig{}, testSettings, nil, nil, nil, nil)
 	require.NoError(t, err)
-	s2, err := cloud.MakeExternalStorage(ctx, conf2, base.ExternalIODirConfig{}, testSettings, nil, nil, nil)
+	s2, err := cloud.MakeExternalStorage(ctx, conf2, base.ExternalIODirConfig{}, testSettings, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	reader1, err := s1.ReadFile(context.Background(), "")

--- a/pkg/cloud/httpsink/http_storage_test.go
+++ b/pkg/cloud/httpsink/http_storage_test.go
@@ -162,7 +162,7 @@ func TestPutHttp(t *testing.T) {
 			t.Fatal(err)
 		}
 		s, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{},
-			testSettings, blobs.TestEmptyBlobClientFactory, nil, nil)
+			testSettings, blobs.TestEmptyBlobClientFactory, nil, nil, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -318,7 +318,7 @@ func TestCanDisableHttp(t *testing.T) {
 	s, err := cloud.MakeExternalStorage(
 		context.Background(),
 		roachpb.ExternalStorage{Provider: roachpb.ExternalStorageProvider_http},
-		conf, testSettings, blobs.TestEmptyBlobClientFactory, nil, nil)
+		conf, testSettings, blobs.TestEmptyBlobClientFactory, nil, nil, nil)
 	require.Nil(t, s)
 	require.Error(t, err)
 }
@@ -339,7 +339,7 @@ func TestCanDisableOutbound(t *testing.T) {
 		s, err := cloud.MakeExternalStorage(
 			context.Background(),
 			roachpb.ExternalStorage{Provider: provider},
-			conf, testSettings, blobs.TestEmptyBlobClientFactory, nil, nil)
+			conf, testSettings, blobs.TestEmptyBlobClientFactory, nil, nil, nil)
 		require.Nil(t, s)
 		require.Error(t, err)
 	}
@@ -370,7 +370,7 @@ func TestExternalStorageCanUseHTTPProxy(t *testing.T) {
 	require.NoError(t, err)
 	s, err := cloud.MakeExternalStorage(
 		context.Background(), conf, base.ExternalIODirConfig{}, testSettings, nil,
-		nil, nil)
+		nil, nil, nil)
 	require.NoError(t, err)
 	stream, err := s.ReadFile(context.Background(), "file")
 	require.NoError(t, err)

--- a/pkg/cloud/nullsink/nullsink_storage_test.go
+++ b/pkg/cloud/nullsink/nullsink_storage_test.go
@@ -36,7 +36,7 @@ func TestNullSinkReadAndWrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{}, nil, nil, nil, nil)
+	s, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cloud/userfile/file_table_storage_test.go
+++ b/pkg/cloud/userfile/file_table_storage_test.go
@@ -69,7 +69,7 @@ func TestPutUserFileTable(t *testing.T) {
 
 		store, err := cloud.ExternalStorageFromURI(ctx, userfileURL.String()+"/",
 			base.ExternalIODirConfig{}, cluster.NoSettings, blobs.TestEmptyBlobClientFactory,
-			security.RootUserName(), ie, kvDB)
+			security.RootUserName(), ie, kvDB, nil)
 		require.NoError(t, err)
 		defer store.Close()
 
@@ -116,13 +116,13 @@ func TestUserScoping(t *testing.T) {
 
 	// Write file as user1.
 	fileTableSystem1, err := cloud.ExternalStorageFromURI(ctx, dest, base.ExternalIODirConfig{},
-		cluster.NoSettings, blobs.TestEmptyBlobClientFactory, user1, ie, kvDB)
+		cluster.NoSettings, blobs.TestEmptyBlobClientFactory, user1, ie, kvDB, nil)
 	require.NoError(t, err)
 	require.NoError(t, cloud.WriteFile(ctx, fileTableSystem1, filename, bytes.NewReader([]byte("aaa"))))
 
 	// Attempt to read/write file as user2 and expect to fail.
 	fileTableSystem2, err := cloud.ExternalStorageFromURI(ctx, dest, base.ExternalIODirConfig{},
-		cluster.NoSettings, blobs.TestEmptyBlobClientFactory, user2, ie, kvDB)
+		cluster.NoSettings, blobs.TestEmptyBlobClientFactory, user2, ie, kvDB, nil)
 	require.NoError(t, err)
 	_, err = fileTableSystem2.ReadFile(ctx, filename)
 	require.Error(t, err)
@@ -130,7 +130,7 @@ func TestUserScoping(t *testing.T) {
 
 	// Read file as root and expect to succeed.
 	fileTableSystem3, err := cloud.ExternalStorageFromURI(ctx, dest, base.ExternalIODirConfig{},
-		cluster.NoSettings, blobs.TestEmptyBlobClientFactory, security.RootUserName(), ie, kvDB)
+		cluster.NoSettings, blobs.TestEmptyBlobClientFactory, security.RootUserName(), ie, kvDB, nil)
 	require.NoError(t, err)
 	_, err = fileTableSystem3.ReadFile(ctx, filename)
 	require.NoError(t, err)

--- a/pkg/server/external_storage_builder.go
+++ b/pkg/server/external_storage_builder.go
@@ -37,9 +37,11 @@ type externalStorageBuilder struct {
 	initCalled        bool
 	ie                *sql.InternalExecutor
 	db                *kv.DB
+	limiters          cloud.Limiters
 }
 
 func (e *externalStorageBuilder) init(
+	ctx context.Context,
 	conf base.ExternalIODirConfig,
 	settings *cluster.Settings,
 	nodeIDContainer *base.NodeIDContainer,
@@ -61,6 +63,8 @@ func (e *externalStorageBuilder) init(
 	e.initCalled = true
 	e.ie = ie
 	e.db = db
+	e.limiters = cloud.MakeLimiters(ctx, &settings.SV)
+
 }
 
 func (e *externalStorageBuilder) makeExternalStorage(
@@ -70,7 +74,7 @@ func (e *externalStorageBuilder) makeExternalStorage(
 		return nil, errors.New("cannot create external storage before init")
 	}
 	return cloud.MakeExternalStorage(ctx, dest, e.conf, e.settings, e.blobClientFactory, e.ie,
-		e.db)
+		e.db, e.limiters)
 }
 
 func (e *externalStorageBuilder) makeExternalStorageFromURI(
@@ -79,5 +83,5 @@ func (e *externalStorageBuilder) makeExternalStorageFromURI(
 	if !e.initCalled {
 		return nil, errors.New("cannot create external storage before init")
 	}
-	return cloud.ExternalStorageFromURI(ctx, uri, e.conf, e.settings, e.blobClientFactory, user, e.ie, e.db)
+	return cloud.ExternalStorageFromURI(ctx, uri, e.conf, e.settings, e.blobClientFactory, user, e.ie, e.db, e.limiters)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -976,6 +976,7 @@ func (s *Server) PreStart(ctx context.Context) error {
 	// objects hereafter.
 	fileTableInternalExecutor := sql.MakeInternalExecutor(ctx, s.PGServer().SQLServer, sql.MemoryMetrics{}, s.st)
 	s.externalStorageBuilder.init(
+		ctx,
 		s.cfg.ExternalIODirConfig,
 		s.st,
 		s.nodeIDContainer,

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -511,6 +511,7 @@ func makeTenantSQLServerArgs(
 	externalStorageFromURI := esb.makeExternalStorageFromURI
 
 	esb.init(
+		startupCtx,
 		sqlCfg.ExternalIODirConfig,
 		baseCfg.Settings,
 		baseCfg.IDContainer,

--- a/pkg/sql/importer/import_processor_test.go
+++ b/pkg/sql/importer/import_processor_test.go
@@ -888,7 +888,7 @@ func externalStorageFactory(
 		return nil, err
 	}
 	return cloud.MakeExternalStorage(ctx, dest, base.ExternalIODirConfig{},
-		nil, blobs.TestBlobServiceClient(workdir), nil, nil)
+		nil, blobs.TestBlobServiceClient(workdir), nil, nil, nil)
 }
 
 // Helper to create and initialize testSpec.

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -2549,7 +2549,7 @@ func TestImportObjectLevelRBAC(t *testing.T) {
 		// Write to userfile storage now that testuser has CREATE privileges.
 		ie := tc.Server(0).InternalExecutor().(*sql.InternalExecutor)
 		fileTableSystem1, err := cloud.ExternalStorageFromURI(ctx, dest, base.ExternalIODirConfig{},
-			cluster.NoSettings, blobs.TestEmptyBlobClientFactory, security.TestUserName(), ie, tc.Server(0).DB())
+			cluster.NoSettings, blobs.TestEmptyBlobClientFactory, security.TestUserName(), ie, tc.Server(0).DB(), nil)
 		require.NoError(t, err)
 		require.NoError(t, cloud.WriteFile(ctx, fileTableSystem1, filename, bytes.NewReader([]byte(data))))
 	}
@@ -5730,7 +5730,7 @@ func TestImportPgDumpIgnoredStmts(t *testing.T) {
 			tc.Server(0).ClusterSettings(),
 			blobs.TestEmptyBlobClientFactory,
 			security.RootUserName(),
-			tc.Server(0).InternalExecutor().(*sql.InternalExecutor), tc.Server(0).DB())
+			tc.Server(0).InternalExecutor().(*sql.InternalExecutor), tc.Server(0).DB(), nil)
 		require.NoError(t, err)
 		defer store.Close()
 


### PR DESCRIPTION
Release note (sql change): the new settings cloudstorage.<provider>.write.node_rate_limit and cloudstorage.<provider>.write.node_burst_limit
allow limiting the rate at which bulk operations write to the designated cloud storage provider.

Addresses https://github.com/cockroachdb/cockroach/issues/79588