### PR TITLE
sql: allow CREATE EXTENSION "uuid-ossp"

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -868,13 +868,31 @@ available replica will error.</p>
 </span></td></tr>
 <tr><td><a name="gen_random_ulid"></a><code>gen_random_ulid() &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Generates a random ULID and returns it as a value of UUID type.</p>
 </span></td></tr>
-<tr><td><a name="gen_random_uuid"></a><code>gen_random_uuid() &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Generates a random UUID and returns it as a value of UUID type.</p>
+<tr><td><a name="gen_random_uuid"></a><code>gen_random_uuid() &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Generates a random version 4 UUID, and returns it as a value of UUID type.</p>
 </span></td></tr>
 <tr><td><a name="unique_rowid"></a><code>unique_rowid() &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns a unique ID used by CockroachDB to generate unique row IDs if a Primary Key isn’t defined for the table. The value is a combination of the insert timestamp and the ID of the node executing the statement, which guarantees this combination is globally unique. However, there can be gaps and the order is not completely guaranteed.</p>
 </span></td></tr>
 <tr><td><a name="unordered_unique_rowid"></a><code>unordered_unique_rowid() &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns a unique ID. The value is a combination of the insert timestamp and the ID of the node executing the statement, which guarantees this combination is globally unique. The way it is generated there is no ordering</p>
 </span></td></tr>
-<tr><td><a name="uuid_generate_v4"></a><code>uuid_generate_v4() &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Generates a random UUID and returns it as a value of UUID type.</p>
+<tr><td><a name="uuid_generate_v1"></a><code>uuid_generate_v1() &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Generates a version 1 UUID, and returns it as a value of UUID type. This uses the real MAC address of the server and a timestamp.</p>
+</span></td></tr>
+<tr><td><a name="uuid_generate_v1mc"></a><code>uuid_generate_v1mc() &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Generates a version 1 UUID, and returns it as a value of UUID type. This uses a random MAC address and a timestamp.</p>
+</span></td></tr>
+<tr><td><a name="uuid_generate_v3"></a><code>uuid_generate_v3(namespace: <a href="uuid.html">uuid</a>, name: <a href="string.html">string</a>) &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Generates a version 3 UUID in the given namespace using the specified input name, with md5 as the hashing method. The namespace should be one of the special constants produced by the uuid_ns_*() functions.</p>
+</span></td></tr>
+<tr><td><a name="uuid_generate_v4"></a><code>uuid_generate_v4() &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Generates a random version 4 UUID, and returns it as a value of UUID type.</p>
+</span></td></tr>
+<tr><td><a name="uuid_generate_v5"></a><code>uuid_generate_v5(namespace: <a href="uuid.html">uuid</a>, name: <a href="string.html">string</a>) &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Generates a version 5 UUID in the given namespace using the specified input name. This is similar to a version 3 UUID, except it uses SHA-1 for hashing.</p>
+</span></td></tr>
+<tr><td><a name="uuid_nil"></a><code>uuid_nil() &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Returns a nil UUID constant.</p>
+</span></td></tr>
+<tr><td><a name="uuid_ns_dns"></a><code>uuid_ns_dns() &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Returns a constant designating the DNS namespace for UUIDs.</p>
+</span></td></tr>
+<tr><td><a name="uuid_ns_oid"></a><code>uuid_ns_oid() &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Returns a constant designating the ISO object identifier (OID) namespace for UUIDs. These are unrelated to the OID type used internally in the database.</p>
+</span></td></tr>
+<tr><td><a name="uuid_ns_url"></a><code>uuid_ns_url() &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Returns a constant designating the URL namespace for UUIDs.</p>
+</span></td></tr>
+<tr><td><a name="uuid_ns_x500"></a><code>uuid_ns_x500() &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Returns a constant designating the X.500 distinguished name (DN) namespace for UUIDs.</p>
 </span></td></tr>
 <tr><td><a name="uuid_v4"></a><code>uuid_v4() &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Returns a UUID.</p>
 </span></td></tr></tbody>

--- a/pkg/sql/create_extension.go
+++ b/pkg/sql/create_extension.go
@@ -43,7 +43,8 @@ func (n *createExtensionNode) unimplementedExtensionError(issue int) error {
 
 func (n *createExtensionNode) startExec(params runParams) error {
 	switch n.CreateExtension.Name {
-	case "postgis":
+	case "postgis",
+		"uuid-ossp":
 		telemetry.Inc(sqltelemetry.CreateExtensionCounter(n.CreateExtension.Name))
 		return nil
 	case "postgis_raster",
@@ -102,7 +103,6 @@ func (n *createExtensionNode) startExec(params runParams) error {
 		"tsm_system_rows",
 		"tsm_system_time",
 		"unaccent",
-		"uuid-ossp",
 		"xml2":
 		return n.unimplementedExtensionError(54516)
 	}

--- a/pkg/sql/logictest/testdata/logic_test/uuid
+++ b/pkg/sql/logictest/testdata/logic_test/uuid
@@ -116,3 +116,28 @@ query T
 SELECT ('63616665-6630-3064-6465-616462656562' COLLATE en)::uuid
 ----
 63616665-6630-3064-6465-616462656562
+
+query T
+SELECT uuid_nil()
+----
+00000000-0000-0000-0000-000000000000
+
+query T
+SELECT uuid_ns_dns()
+----
+6ba7b810-9dad-11d1-80b4-00c04fd430c8
+
+query T
+SELECT uuid_ns_url()
+----
+6ba7b811-9dad-11d1-80b4-00c04fd430c8
+
+query T
+SELECT uuid_ns_oid()
+----
+6ba7b812-9dad-11d1-80b4-00c04fd430c8
+
+query T
+SELECT uuid_ns_x500()
+----
+6ba7b814-9dad-11d1-80b4-00c04fd430c8

--- a/pkg/sql/logictest/testdata/logic_test/uuid
+++ b/pkg/sql/logictest/testdata/logic_test/uuid
@@ -141,3 +141,24 @@ query T
 SELECT uuid_ns_x500()
 ----
 6ba7b814-9dad-11d1-80b4-00c04fd430c8
+
+query B
+SELECT uuid_generate_v1() = uuid_generate_v1()
+----
+false
+
+query B
+SELECT uuid_generate_v1mc() = uuid_generate_v1mc()
+----
+false
+
+query T
+SELECT uuid_generate_v3(uuid_ns_x500(), 'cat')
+----
+6505abc6-6166-351d-b8f6-ce179e9cf79d
+
+query T
+SELECT uuid_generate_v5(uuid_ns_oid(), 'dog')
+----
+9a8b57c4-73a4-5dfb-b888-6fff478edf63
+

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -679,8 +679,8 @@ var builtins = map[string]builtinDefinition{
 			Volatility: tree.VolatilityImmutable,
 		}),
 
-	"gen_random_uuid":  generateRandomUUIDImpl,
-	"uuid_generate_v4": generateRandomUUIDImpl,
+	"gen_random_uuid":  generateRandomUUID4Impl,
+	"uuid_generate_v4": generateRandomUUID4Impl,
 
 	"uuid_nil": generateConstantUUIDImpl(
 		uuid.Nil, "Returns a nil UUID constant.",
@@ -698,6 +698,86 @@ var builtins = map[string]builtinDefinition{
 	),
 	"uuid_ns_x500": generateConstantUUIDImpl(
 		uuid.NamespaceX500, "Returns a constant designating the X.500 distinguished name (DN) namespace for UUIDs.",
+	),
+
+	"uuid_generate_v1": makeBuiltin(
+		tree.FunctionProperties{
+			Category: categoryIDGeneration,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{},
+			ReturnType: tree.FixedReturnType(types.Uuid),
+			Fn: func(_ *tree.EvalContext, _ tree.Datums) (tree.Datum, error) {
+				uv, err := uuid.NewV1()
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDUuid(tree.DUuid{UUID: uv}), nil
+			},
+			Info: "Generates a version 1 UUID, and returns it as a value of UUID type. " +
+				"This uses the real MAC address of the server and a timestamp.",
+			Volatility: tree.VolatilityVolatile,
+		},
+	),
+
+	"uuid_generate_v1mc": makeBuiltin(
+		tree.FunctionProperties{
+			Category: categoryIDGeneration,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{},
+			ReturnType: tree.FixedReturnType(types.Uuid),
+			Fn: func(_ *tree.EvalContext, _ tree.Datums) (tree.Datum, error) {
+				gen := uuid.NewGenWithHWAF(uuid.RandomHardwareAddrFunc)
+				uv, err := gen.NewV1()
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDUuid(tree.DUuid{UUID: uv}), nil
+			},
+			Info: "Generates a version 1 UUID, and returns it as a value of UUID type. " +
+				"This uses a random MAC address and a timestamp.",
+			Volatility: tree.VolatilityVolatile,
+		},
+	),
+
+	"uuid_generate_v3": makeBuiltin(
+		tree.FunctionProperties{
+			Category: categoryIDGeneration,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"namespace", types.Uuid}, {"name", types.String}},
+			ReturnType: tree.FixedReturnType(types.Uuid),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				namespace := tree.MustBeDUuid(args[0])
+				name := tree.MustBeDString(args[1])
+				uv := uuid.NewV3(namespace.UUID, string(name))
+				return tree.NewDUuid(tree.DUuid{UUID: uv}), nil
+			},
+			Info: "Generates a version 3 UUID in the given namespace using the specified input name, " +
+				"with md5 as the hashing method. " +
+				"The namespace should be one of the special constants produced by the uuid_ns_*() functions.",
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
+
+	"uuid_generate_v5": makeBuiltin(
+		tree.FunctionProperties{
+			Category: categoryIDGeneration,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"namespace", types.Uuid}, {"name", types.String}},
+			ReturnType: tree.FixedReturnType(types.Uuid),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				namespace := tree.MustBeDUuid(args[0])
+				name := tree.MustBeDString(args[1])
+				uv := uuid.NewV5(namespace.UUID, string(name))
+				return tree.NewDUuid(tree.DUuid{UUID: uv}), nil
+			},
+			Info: "Generates a version 5 UUID in the given namespace using the specified input name. " +
+				"This is similar to a version 3 UUID, except it uses SHA-1 for hashing.",
+			Volatility: tree.VolatilityImmutable,
+		},
 	),
 
 	"to_uuid": makeBuiltin(defProps(),
@@ -7162,7 +7242,7 @@ func getSubstringFromIndexOfLengthBytes(str, errMsg string, start, length int) (
 	return string(bytes[start:end]), nil
 }
 
-var generateRandomUUIDImpl = makeBuiltin(
+var generateRandomUUID4Impl = makeBuiltin(
 	tree.FunctionProperties{
 		Category: categoryIDGeneration,
 	},
@@ -7170,10 +7250,13 @@ var generateRandomUUIDImpl = makeBuiltin(
 		Types:      tree.ArgTypes{},
 		ReturnType: tree.FixedReturnType(types.Uuid),
 		Fn: func(_ *tree.EvalContext, _ tree.Datums) (tree.Datum, error) {
-			uv := uuid.MakeV4()
+			uv, err := uuid.NewV4()
+			if err != nil {
+				return nil, err
+			}
 			return tree.NewDUuid(tree.DUuid{UUID: uv}), nil
 		},
-		Info:       "Generates a random UUID and returns it as a value of UUID type.",
+		Info:       "Generates a random version 4 UUID, and returns it as a value of UUID type.",
 		Volatility: tree.VolatilityVolatile,
 	},
 )

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -682,6 +682,24 @@ var builtins = map[string]builtinDefinition{
 	"gen_random_uuid":  generateRandomUUIDImpl,
 	"uuid_generate_v4": generateRandomUUIDImpl,
 
+	"uuid_nil": generateConstantUUIDImpl(
+		uuid.Nil, "Returns a nil UUID constant.",
+	),
+	"uuid_ns_dns": generateConstantUUIDImpl(
+		uuid.NamespaceDNS, "Returns a constant designating the DNS namespace for UUIDs.",
+	),
+	"uuid_ns_url": generateConstantUUIDImpl(
+		uuid.NamespaceURL, "Returns a constant designating the URL namespace for UUIDs.",
+	),
+	"uuid_ns_oid": generateConstantUUIDImpl(
+		uuid.NamespaceOID,
+		"Returns a constant designating the ISO object identifier (OID) namespace for UUIDs. "+
+			"These are unrelated to the OID type used internally in the database.",
+	),
+	"uuid_ns_x500": generateConstantUUIDImpl(
+		uuid.NamespaceX500, "Returns a constant designating the X.500 distinguished name (DN) namespace for UUIDs.",
+	),
+
 	"to_uuid": makeBuiltin(defProps(),
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.String}},
@@ -7174,6 +7192,23 @@ var uuidV4Impl = makeBuiltin(
 		Volatility: tree.VolatilityVolatile,
 	},
 )
+
+func generateConstantUUIDImpl(id uuid.UUID, info string) builtinDefinition {
+	return makeBuiltin(
+		tree.FunctionProperties{
+			Category: categoryIDGeneration,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{},
+			ReturnType: tree.FixedReturnType(types.Uuid),
+			Fn: func(_ *tree.EvalContext, _ tree.Datums) (tree.Datum, error) {
+				return tree.NewDUuid(tree.DUuid{UUID: id}), nil
+			},
+			Info:       info,
+			Volatility: tree.VolatilityImmutable,
+		},
+	)
+}
 
 const txnTSContextDoc = `
 

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1644,6 +1644,26 @@ func NewDUuid(d DUuid) *DUuid {
 	return &d
 }
 
+// AsDUuid attempts to retrieve a DUuid from an Expr, returning a DUuid and
+// a flag signifying whether the assertion was successful.
+func AsDUuid(e Expr) (DUuid, bool) {
+	switch t := e.(type) {
+	case *DUuid:
+		return *t, true
+	}
+	return DUuid{}, false
+}
+
+// MustBeDUuid attempts to retrieve a DUuid from an Expr, panicking if the
+// assertion fails.
+func MustBeDUuid(e Expr) DUuid {
+	i, ok := AsDUuid(e)
+	if !ok {
+		panic(errors.AssertionFailedf("expected *DUuid, found %T", e))
+	}
+	return i
+}
+
 // ResolvedType implements the TypedExpr interface.
 func (*DUuid) ResolvedType() *types.T {
 	return types.Uuid

--- a/pkg/util/uuid/generator.go
+++ b/pkg/util/uuid/generator.go
@@ -285,3 +285,16 @@ func defaultHWAddrFunc() (net.HardwareAddr, error) {
 	}
 	return []byte{}, fmt.Errorf("uuid: no HW address found")
 }
+
+// RandomHardwareAddrFunc rReturns a random hardware address, with the multicast
+// and local-admin bits set as per the IEEE802 spec.
+func RandomHardwareAddrFunc() (net.HardwareAddr, error) {
+	var err error
+	var hardwareAddr = make(net.HardwareAddr, 6)
+	if _, err = io.ReadFull(rand.Reader, hardwareAddr[:]); err != nil {
+		return []byte{}, err
+	}
+	// Set multicast bit and local-admin bit to match Postgres.
+	hardwareAddr[0] |= 0x03
+	return hardwareAddr, nil
+}

--- a/pkg/util/uuid/generator.go
+++ b/pkg/util/uuid/generator.go
@@ -286,7 +286,7 @@ func defaultHWAddrFunc() (net.HardwareAddr, error) {
 	return []byte{}, fmt.Errorf("uuid: no HW address found")
 }
 
-// RandomHardwareAddrFunc rReturns a random hardware address, with the multicast
+// RandomHardwareAddrFunc returns a random hardware address, with the multicast
 // and local-admin bits set as per the IEEE802 spec.
 func RandomHardwareAddrFunc() (net.HardwareAddr, error) {
 	var err error

--- a/pkg/util/uuid/generator_test.go
+++ b/pkg/util/uuid/generator_test.go
@@ -92,7 +92,7 @@ func TestNewGenWithRandomHWAF(t *testing.T) {
 		node := uuid[10:]
 		leadingBits := node[0] & 0x03
 
-		if 0x03 != leadingBits {
+		if leadingBits != 0x03 {
 			t.Fatalf("node leading bits = %b, want %b", leadingBits, 0x03)
 		}
 	}

--- a/pkg/util/uuid/generator_test.go
+++ b/pkg/util/uuid/generator_test.go
@@ -72,6 +72,32 @@ func TestNewGenWithHWAF(t *testing.T) {
 	}
 }
 
+func TestNewGenWithRandomHWAF(t *testing.T) {
+	var g *Gen
+	var err error
+	var uuid UUID
+
+	g = NewGenWithHWAF(RandomHardwareAddrFunc)
+
+	if g == nil {
+		t.Fatal("g is unexpectedly nil")
+	}
+
+	for i := 0; i < 100; i++ {
+		uuid, err = g.NewV1()
+		if err != nil {
+			t.Fatalf("g.NewV1() err = %v, want <nil>", err)
+		}
+
+		node := uuid[10:]
+		leadingBits := node[0] & 0x03
+
+		if 0x03 != leadingBits {
+			t.Fatalf("node leading bits = %b, want %b", leadingBits, 0x03)
+		}
+	}
+}
+
 func testNewV1Basic(t *testing.T) {
 	u, err := NewV1()
 	if err != nil {


### PR DESCRIPTION
fixes #80118

Release note (sql change): Added the builtin functions: uuid_nil, uuid_ns_dns,
uuid_ns_url, uuid_ns_oid, and uuid_ns_x500.

Release note (sql change): The builtin functions uuid_generate_v1,
uuid_generate_v1mc, uuid_generate_v3, and uuid_generate_v5 were added.

Release note (sql change): The command CREATE EXTENSION "uuid-ossp" no
longer fails, since CockroachDB now includes all the builtin functions from
this extension.