### PR TITLE
bazel: stamp when building w/ `dev` config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -77,7 +77,7 @@ build:crosslinuxarmbase --config=cross
 # NB: This is consumed in `BUILD` files (see build/toolchains/BUILD.bazel).
 build:devdarwinx86_64 --platforms=//build/toolchains:darwin_x86_64
 build:devdarwinx86_64 --config=dev
-build:dev --workspace_status_command=./build/bazelutil/stamp.sh
+build:dev --stamp --workspace_status_command=./build/bazelutil/stamp.sh
 build:dev --action_env=PATH
 build:dev --host_action_env=PATH
 


### PR DESCRIPTION
`roachprod` freaks out if the `cockroach` binary is not tagged.

Release note: None