### PR TITLE
xform: hoist projection from join only for canonical scans/selects

### DIFF
--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -2011,6 +2011,13 @@ func (c *CustomFuncs) getfilteredCanonicalScan(
 	return scanExpr, filters, true
 }
 
+// IsCanonicalScanOrSelect returns true if `relation` is a canonical scan or a
+// select from a canonical scan.
+func (c *CustomFuncs) IsCanonicalScanOrSelect(relation memo.RelExpr) (ok bool) {
+	_, _, ok = c.getfilteredCanonicalScan(relation)
+	return ok
+}
+
 // findInterestingDisjunctionPairForJoin groups disjunction subexpressions into
 // an "interesting" pair of join predicates.
 //

--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -427,9 +427,9 @@
     )
 )
 
-# HoistProjectFromInnerJoin lifts a Project from under an InnerJoin; the join
-# can then be subject to other rules, most importantly allowing it to become a
-# lookup join.
+# HoistProjectFromInnerJoin lifts a Project of a canonical scan or of a select
+# from a canonical scan from under an InnerJoin; the join can then be subject to
+# other rules, most importantly allowing it to become a lookup join.
 #
 # As long as the projections are non-volatile, it is equivalent to calculate
 # them on every output row.
@@ -444,7 +444,7 @@
 (InnerJoin
     $left:*
     $proj:(Project
-        $right:*
+        $right:* & (IsCanonicalScanOrSelect $right)
         $projections:* & ^(HasVolatileProjection $projections)
         $passthrough:*
     )
@@ -462,9 +462,9 @@
     (UnionCols $passthrough (OutputCols $left))
 )
 
-# HoistProjectFromLeftJoin pulls a project from under an LeftJoin; the join can
-# then be subject to other rules, most importantly allowing it to become a
-# lookup join.
+# HoistProjectFromLeftJoin pulls a project of a canonical scan or of a select
+# from a canonical scan from under an LeftJoin; the join can then be subject to
+# other rules, most importantly allowing it to become a lookup join.
 #
 # This rule is similar to HoistProjectFromInnerJoin, except that we have to
 # handle "outer" rows correctly and make sure we project NULLs, regardless of
@@ -486,7 +486,7 @@
 (LeftJoin
     $left:*
     (Project
-        $right:*
+        $right:* & (IsCanonicalScanOrSelect $right)
         $projections:* & ^(HasVolatileProjection $projections)
         $passthrough:*
     )

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -2005,14 +2005,13 @@ project
  │    ├── immutable
  │    ├── key: (8)
  │    ├── fd: ()-->(1-3,6,7), (8)-->(1-3,6,7,9,25)
- │    ├── project
- │    │    ├── columns: column24:24 order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9 li.customerid:12 li.ordernumber:13
+ │    ├── right-join (hash)
+ │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9 li.customerid:12 li.ordernumber:13 column24:24
  │    │    ├── immutable
  │    │    ├── fd: ()-->(1-3,6,7), (8)-->(9)
- │    │    ├── right-join (hash)
- │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9 li.customerid:12 li.ordernumber:13 li.productid:14 li.quantity:15 p.productid:18 cost:20
- │    │    │    ├── key: (8,12,13,18)
- │    │    │    ├── fd: ()-->(1-3,6,7), (8)-->(9), (12-14)-->(15), (18)-->(20), (14)==(18), (18)==(14)
+ │    │    ├── project
+ │    │    │    ├── columns: column24:24 li.customerid:12!null li.ordernumber:13!null
+ │    │    │    ├── immutable
  │    │    │    ├── inner-join (hash)
  │    │    │    │    ├── columns: li.customerid:12!null li.ordernumber:13!null li.productid:14!null li.quantity:15 p.productid:18!null cost:20
  │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
@@ -2028,29 +2027,29 @@ project
  │    │    │    │    │    └── fd: (18)-->(20)
  │    │    │    │    └── filters
  │    │    │    │         └── li.productid:14 = p.productid:18 [outer=(14,18), constraints=(/14: (/NULL - ]; /18: (/NULL - ]), fd=(14)==(18), (18)==(14)]
- │    │    │    ├── left-join (merge)
- │    │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9
- │    │    │    │    ├── left ordering: +1,+2
- │    │    │    │    ├── right ordering: +6,+7
+ │    │    │    └── projections
+ │    │    │         └── li.quantity:15::INT8 * cost:20::DECIMAL [as=column24:24, outer=(15,20), immutable]
+ │    │    ├── left-join (merge)
+ │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9
+ │    │    │    ├── left ordering: +1,+2
+ │    │    │    ├── right ordering: +6,+7
+ │    │    │    ├── key: (8)
+ │    │    │    ├── fd: ()-->(1-3,6,7), (8)-->(9)
+ │    │    │    ├── scan customerorder [as=order0_]
+ │    │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null
+ │    │    │    │    ├── constraint: /1/2: [/'c111'/0 - /'c111'/0]
+ │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    ├── key: ()
+ │    │    │    │    └── fd: ()-->(1-3)
+ │    │    │    ├── scan lineitem [as=lineitems1_]
+ │    │    │    │    ├── columns: lineitems1_.customerid:6!null lineitems1_.ordernumber:7!null lineitems1_.productid:8!null lineitems1_.quantity:9
+ │    │    │    │    ├── constraint: /6/7/8: [/'c111'/0 - /'c111'/0]
  │    │    │    │    ├── key: (8)
- │    │    │    │    ├── fd: ()-->(1-3,6,7), (8)-->(9)
- │    │    │    │    ├── scan customerorder [as=order0_]
- │    │    │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null
- │    │    │    │    │    ├── constraint: /1/2: [/'c111'/0 - /'c111'/0]
- │    │    │    │    │    ├── cardinality: [0 - 1]
- │    │    │    │    │    ├── key: ()
- │    │    │    │    │    └── fd: ()-->(1-3)
- │    │    │    │    ├── scan lineitem [as=lineitems1_]
- │    │    │    │    │    ├── columns: lineitems1_.customerid:6!null lineitems1_.ordernumber:7!null lineitems1_.productid:8!null lineitems1_.quantity:9
- │    │    │    │    │    ├── constraint: /6/7/8: [/'c111'/0 - /'c111'/0]
- │    │    │    │    │    ├── key: (8)
- │    │    │    │    │    └── fd: ()-->(6,7), (8)-->(9)
- │    │    │    │    └── filters (true)
- │    │    │    └── filters
- │    │    │         ├── li.customerid:12 = order0_.customerid:1 [outer=(1,12), constraints=(/1: (/NULL - ]; /12: (/NULL - ]), fd=(1)==(12), (12)==(1)]
- │    │    │         └── li.ordernumber:13 = order0_.ordernumber:2 [outer=(2,13), constraints=(/2: (/NULL - ]; /13: (/NULL - ]), fd=(2)==(13), (13)==(2)]
- │    │    └── projections
- │    │         └── CASE li.customerid:12 IS NULL WHEN true THEN CAST(NULL AS DECIMAL) ELSE li.quantity:15::INT8 * cost:20::DECIMAL END [as=column24:24, outer=(12,15,20), immutable]
+ │    │    │    │    └── fd: ()-->(6,7), (8)-->(9)
+ │    │    │    └── filters (true)
+ │    │    └── filters
+ │    │         ├── li.customerid:12 = order0_.customerid:1 [outer=(1,12), constraints=(/1: (/NULL - ]; /12: (/NULL - ]), fd=(1)==(12), (12)==(1)]
+ │    │         └── li.ordernumber:13 = order0_.ordernumber:2 [outer=(2,13), constraints=(/2: (/NULL - ]; /13: (/NULL - ]), fd=(2)==(13), (13)==(2)]
  │    └── aggregations
  │         ├── sum [as=sum:25, outer=(24)]
  │         │    └── column24:24
@@ -2301,14 +2300,13 @@ project
  │    ├── immutable
  │    ├── key: (8)
  │    ├── fd: ()-->(1-3,6,7), (8)-->(1-3,6,7,9,25)
- │    ├── project
- │    │    ├── columns: column24:24 order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9 li.customerid:12 li.ordernumber:13
+ │    ├── right-join (hash)
+ │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9 li.customerid:12 li.ordernumber:13 column24:24
  │    │    ├── immutable
  │    │    ├── fd: ()-->(1-3,6,7), (8)-->(9)
- │    │    ├── right-join (hash)
- │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9 li.customerid:12 li.ordernumber:13 li.productid:14 li.quantity:15 p.productid:18 cost:20
- │    │    │    ├── key: (8,12,13,18)
- │    │    │    ├── fd: ()-->(1-3,6,7), (8)-->(9), (12-14)-->(15), (18)-->(20), (14)==(18), (18)==(14)
+ │    │    ├── project
+ │    │    │    ├── columns: column24:24 li.customerid:12!null li.ordernumber:13!null
+ │    │    │    ├── immutable
  │    │    │    ├── inner-join (hash)
  │    │    │    │    ├── columns: li.customerid:12!null li.ordernumber:13!null li.productid:14!null li.quantity:15 p.productid:18!null cost:20
  │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
@@ -2324,29 +2322,29 @@ project
  │    │    │    │    │    └── fd: (18)-->(20)
  │    │    │    │    └── filters
  │    │    │    │         └── li.productid:14 = p.productid:18 [outer=(14,18), constraints=(/14: (/NULL - ]; /18: (/NULL - ]), fd=(14)==(18), (18)==(14)]
- │    │    │    ├── left-join (merge)
- │    │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9
- │    │    │    │    ├── left ordering: +1,+2
- │    │    │    │    ├── right ordering: +6,+7
+ │    │    │    └── projections
+ │    │    │         └── li.quantity:15::INT8 * cost:20::DECIMAL [as=column24:24, outer=(15,20), immutable]
+ │    │    ├── left-join (merge)
+ │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9
+ │    │    │    ├── left ordering: +1,+2
+ │    │    │    ├── right ordering: +6,+7
+ │    │    │    ├── key: (8)
+ │    │    │    ├── fd: ()-->(1-3,6,7), (8)-->(9)
+ │    │    │    ├── scan customerorder [as=order0_]
+ │    │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null
+ │    │    │    │    ├── constraint: /1/2: [/'c111'/0 - /'c111'/0]
+ │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    ├── key: ()
+ │    │    │    │    └── fd: ()-->(1-3)
+ │    │    │    ├── scan lineitem [as=lineitems1_]
+ │    │    │    │    ├── columns: lineitems1_.customerid:6!null lineitems1_.ordernumber:7!null lineitems1_.productid:8!null lineitems1_.quantity:9
+ │    │    │    │    ├── constraint: /6/7/8: [/'c111'/0 - /'c111'/0]
  │    │    │    │    ├── key: (8)
- │    │    │    │    ├── fd: ()-->(1-3,6,7), (8)-->(9)
- │    │    │    │    ├── scan customerorder [as=order0_]
- │    │    │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null
- │    │    │    │    │    ├── constraint: /1/2: [/'c111'/0 - /'c111'/0]
- │    │    │    │    │    ├── cardinality: [0 - 1]
- │    │    │    │    │    ├── key: ()
- │    │    │    │    │    └── fd: ()-->(1-3)
- │    │    │    │    ├── scan lineitem [as=lineitems1_]
- │    │    │    │    │    ├── columns: lineitems1_.customerid:6!null lineitems1_.ordernumber:7!null lineitems1_.productid:8!null lineitems1_.quantity:9
- │    │    │    │    │    ├── constraint: /6/7/8: [/'c111'/0 - /'c111'/0]
- │    │    │    │    │    ├── key: (8)
- │    │    │    │    │    └── fd: ()-->(6,7), (8)-->(9)
- │    │    │    │    └── filters (true)
- │    │    │    └── filters
- │    │    │         ├── li.customerid:12 = order0_.customerid:1 [outer=(1,12), constraints=(/1: (/NULL - ]; /12: (/NULL - ]), fd=(1)==(12), (12)==(1)]
- │    │    │         └── li.ordernumber:13 = order0_.ordernumber:2 [outer=(2,13), constraints=(/2: (/NULL - ]; /13: (/NULL - ]), fd=(2)==(13), (13)==(2)]
- │    │    └── projections
- │    │         └── CASE li.customerid:12 IS NULL WHEN true THEN CAST(NULL AS DECIMAL) ELSE li.quantity:15::INT8 * cost:20::DECIMAL END [as=column24:24, outer=(12,15,20), immutable]
+ │    │    │    │    └── fd: ()-->(6,7), (8)-->(9)
+ │    │    │    └── filters (true)
+ │    │    └── filters
+ │    │         ├── li.customerid:12 = order0_.customerid:1 [outer=(1,12), constraints=(/1: (/NULL - ]; /12: (/NULL - ]), fd=(1)==(12), (12)==(1)]
+ │    │         └── li.ordernumber:13 = order0_.ordernumber:2 [outer=(2,13), constraints=(/2: (/NULL - ]; /13: (/NULL - ]), fd=(2)==(13), (13)==(2)]
  │    └── aggregations
  │         ├── sum [as=sum:25, outer=(24)]
  │         │    └── column24:24

--- a/pkg/sql/opt/xform/testdata/rules/disjunction_in_join
+++ b/pkg/sql/opt/xform/testdata/rules/disjunction_in_join
@@ -2431,65 +2431,63 @@ project
       ├── key: (1,3,4,11)
       ├── fd: (11)-->(7-10), (2)==(8), (8)==(2), (1,3,4,11)-->(2,7-10)
       ├── inner-join (hash)
-      │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null c1:7!null c2:8!null c3:9 c4:10 c.rowid:11!null b1:14 b2:15 b.rowid:18!null
-      │    ├── key: (1,3,4,11,18)
-      │    ├── fd: (11,18)-->(7-10,14,15), (2)==(8), (8)==(2)
-      │    ├── scan a
-      │    │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
-      │    │    └── key: (1-4)
-      │    ├── distinct-on
-      │    │    ├── columns: c1:7!null c2:8 c3:9 c4:10 c.rowid:11!null b1:14 b2:15 b.rowid:18!null
-      │    │    ├── grouping columns: c.rowid:11!null b.rowid:18!null
-      │    │    ├── key: (11,18)
-      │    │    ├── fd: (11,18)-->(7-10,14,15)
-      │    │    ├── union-all
-      │    │    │    ├── columns: c1:7!null c2:8 c3:9 c4:10 c.rowid:11!null b1:14 b2:15 b.rowid:18!null
-      │    │    │    ├── left columns: c1:24 c2:25 c3:26 c4:27 c.rowid:28 b1:31 b2:32 b.rowid:35
-      │    │    │    ├── right columns: c1:38 c2:39 c3:40 c4:41 c.rowid:42 b1:45 b2:46 b.rowid:49
-      │    │    │    ├── inner-join (hash)
-      │    │    │    │    ├── columns: c1:24!null c2:25 c3:26 c4:27 c.rowid:28!null b1:31!null b2:32 b.rowid:35!null
-      │    │    │    │    ├── key: (28,35)
-      │    │    │    │    ├── fd: (28)-->(24-27), (35)-->(31,32), (24)==(31), (31)==(24)
-      │    │    │    │    ├── scan c
-      │    │    │    │    │    ├── columns: c1:24 c2:25 c3:26 c4:27 c.rowid:28!null
-      │    │    │    │    │    ├── key: (28)
-      │    │    │    │    │    └── fd: (28)-->(24-27)
-      │    │    │    │    ├── scan b
-      │    │    │    │    │    ├── columns: b1:31 b2:32 b.rowid:35!null
-      │    │    │    │    │    ├── key: (35)
-      │    │    │    │    │    └── fd: (35)-->(31,32)
-      │    │    │    │    └── filters
-      │    │    │    │         └── c1:24 = b1:31 [outer=(24,31), constraints=(/24: (/NULL - ]; /31: (/NULL - ]), fd=(24)==(31), (31)==(24)]
-      │    │    │    └── inner-join (hash)
-      │    │    │         ├── columns: c1:38!null c2:39 c3:40 c4:41 c.rowid:42!null b1:45 b2:46!null b.rowid:49!null
-      │    │    │         ├── key: (42,49)
-      │    │    │         ├── fd: (42)-->(38-41), (49)-->(45,46), (38)==(46), (46)==(38)
-      │    │    │         ├── scan c
-      │    │    │         │    ├── columns: c1:38 c2:39 c3:40 c4:41 c.rowid:42!null
-      │    │    │         │    ├── key: (42)
-      │    │    │         │    └── fd: (42)-->(38-41)
-      │    │    │         ├── scan b
-      │    │    │         │    ├── columns: b1:45 b2:46 b.rowid:49!null
-      │    │    │         │    ├── key: (49)
-      │    │    │         │    └── fd: (49)-->(45,46)
-      │    │    │         └── filters
-      │    │    │              └── c1:38 = b2:46 [outer=(38,46), constraints=(/38: (/NULL - ]; /46: (/NULL - ]), fd=(38)==(46), (46)==(38)]
-      │    │    └── aggregations
-      │    │         ├── const-agg [as=c1:7, outer=(7)]
-      │    │         │    └── c1:7
-      │    │         ├── const-agg [as=c2:8, outer=(8)]
-      │    │         │    └── c2:8
-      │    │         ├── const-agg [as=c3:9, outer=(9)]
-      │    │         │    └── c3:9
-      │    │         ├── const-agg [as=c4:10, outer=(10)]
-      │    │         │    └── c4:10
-      │    │         ├── const-agg [as=b1:14, outer=(14)]
-      │    │         │    └── b1:14
-      │    │         └── const-agg [as=b2:15, outer=(15)]
-      │    │              └── b2:15
+      │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null c1:7!null c2:8!null c3:9 c4:10 c.rowid:11!null b1:14 b2:15
+      │    ├── fd: (11)-->(7-10), (2)==(8), (8)==(2)
+      │    ├── project
+      │    │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:14 b2:15
+      │    │    └── distinct-on
+      │    │         ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:14 b2:15 b.rowid:18!null
+      │    │         ├── grouping columns: a1:1!null a2:2!null a3:3!null a4:4!null b.rowid:18!null
+      │    │         ├── key: (1-4,18)
+      │    │         ├── fd: (1-4,18)-->(14,15)
+      │    │         ├── union-all
+      │    │         │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:14 b2:15 b.rowid:18!null
+      │    │         │    ├── left columns: a1:80 a2:81 a3:82 a4:83 b1:86 b2:87 b.rowid:90
+      │    │         │    ├── right columns: a1:93 a2:94 a3:95 a4:96 b1:99 b2:100 b.rowid:103
+      │    │         │    ├── inner-join (merge)
+      │    │         │    │    ├── columns: a1:80!null a2:81!null a3:82!null a4:83!null b1:86!null b2:87 b.rowid:90!null
+      │    │         │    │    ├── left ordering: +80
+      │    │         │    │    ├── right ordering: +86
+      │    │         │    │    ├── key: (81-83,90)
+      │    │         │    │    ├── fd: (90)-->(86,87), (80)==(86), (86)==(80)
+      │    │         │    │    ├── scan a
+      │    │         │    │    │    ├── columns: a1:80!null a2:81!null a3:82!null a4:83!null
+      │    │         │    │    │    ├── key: (80-83)
+      │    │         │    │    │    └── ordering: +80
+      │    │         │    │    ├── scan b@b_b1_b2_idx
+      │    │         │    │    │    ├── columns: b1:86 b2:87 b.rowid:90!null
+      │    │         │    │    │    ├── key: (90)
+      │    │         │    │    │    ├── fd: (90)-->(86,87)
+      │    │         │    │    │    └── ordering: +86
+      │    │         │    │    └── filters (true)
+      │    │         │    └── inner-join (merge)
+      │    │         │         ├── columns: a1:93!null a2:94!null a3:95!null a4:96!null b1:99 b2:100!null b.rowid:103!null
+      │    │         │         ├── left ordering: +93
+      │    │         │         ├── right ordering: +100
+      │    │         │         ├── key: (94-96,103)
+      │    │         │         ├── fd: (103)-->(99,100), (93)==(100), (100)==(93)
+      │    │         │         ├── scan a
+      │    │         │         │    ├── columns: a1:93!null a2:94!null a3:95!null a4:96!null
+      │    │         │         │    ├── key: (93-96)
+      │    │         │         │    └── ordering: +93
+      │    │         │         ├── scan b@b_b2_idx
+      │    │         │         │    ├── columns: b1:99 b2:100 b.rowid:103!null
+      │    │         │         │    ├── key: (103)
+      │    │         │         │    ├── fd: (103)-->(99,100)
+      │    │         │         │    └── ordering: +100
+      │    │         │         └── filters (true)
+      │    │         └── aggregations
+      │    │              ├── const-agg [as=b1:14, outer=(14)]
+      │    │              │    └── b1:14
+      │    │              └── const-agg [as=b2:15, outer=(15)]
+      │    │                   └── b2:15
+      │    ├── scan c
+      │    │    ├── columns: c1:7 c2:8 c3:9 c4:10 c.rowid:11!null
+      │    │    ├── key: (11)
+      │    │    └── fd: (11)-->(7-10)
       │    └── filters
-      │         ├── (a1:1 = b1:14) OR (a1:1 = b2:15) [outer=(1,14,15), constraints=(/1: (/NULL - ])]
-      │         └── a2:2 = c2:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+      │         ├── a2:2 = c2:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+      │         └── (c1:7 = b1:14) OR (c1:7 = b2:15) [outer=(7,14,15), constraints=(/7: (/NULL - ])]
       └── aggregations
            ├── const-agg [as=c1:7, outer=(7)]
            │    └── c1:7
@@ -2560,62 +2558,63 @@ project
            ├── grouping columns: a1:1!null a2:2!null a3:3!null a4:4!null
            ├── key: (1-4)
            └── inner-join (hash)
-                ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7!null b2:8 b.rowid:11!null c1:14!null
-                ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
-                ├── key: (1-4,11)
-                ├── fd: (1-4,11)-->(7,8), (7)==(14), (14)==(7)
+                ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7!null b2:8 c1:14!null
+                ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+                ├── fd: (7)==(14), (14)==(7)
+                ├── project
+                │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7 b2:8
+                │    └── distinct-on
+                │         ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7 b2:8 b.rowid:11!null
+                │         ├── grouping columns: a1:1!null a2:2!null a3:3!null a4:4!null b.rowid:11!null
+                │         ├── key: (1-4,11)
+                │         ├── fd: (1-4,11)-->(7,8)
+                │         ├── union-all
+                │         │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7 b2:8 b.rowid:11!null
+                │         │    ├── left columns: a1:22 a2:23 a3:24 a4:25 b1:28 b2:29 b.rowid:32
+                │         │    ├── right columns: a1:35 a2:36 a3:37 a4:38 b1:41 b2:42 b.rowid:45
+                │         │    ├── inner-join (merge)
+                │         │    │    ├── columns: a1:22!null a2:23!null a3:24!null a4:25!null b1:28!null b2:29 b.rowid:32!null
+                │         │    │    ├── left ordering: +22
+                │         │    │    ├── right ordering: +28
+                │         │    │    ├── key: (23-25,32)
+                │         │    │    ├── fd: (32)-->(28,29), (22)==(28), (28)==(22)
+                │         │    │    ├── scan a
+                │         │    │    │    ├── columns: a1:22!null a2:23!null a3:24!null a4:25!null
+                │         │    │    │    ├── key: (22-25)
+                │         │    │    │    └── ordering: +22
+                │         │    │    ├── scan b@b_b1_b2_idx
+                │         │    │    │    ├── columns: b1:28 b2:29 b.rowid:32!null
+                │         │    │    │    ├── key: (32)
+                │         │    │    │    ├── fd: (32)-->(28,29)
+                │         │    │    │    └── ordering: +28
+                │         │    │    └── filters (true)
+                │         │    └── inner-join (merge)
+                │         │         ├── columns: a1:35!null a2:36!null a3:37!null a4:38!null b1:41 b2:42!null b.rowid:45!null
+                │         │         ├── left ordering: +35
+                │         │         ├── right ordering: +42
+                │         │         ├── key: (36-38,45)
+                │         │         ├── fd: (45)-->(41,42), (35)==(42), (42)==(35)
+                │         │         ├── scan a
+                │         │         │    ├── columns: a1:35!null a2:36!null a3:37!null a4:38!null
+                │         │         │    ├── key: (35-38)
+                │         │         │    └── ordering: +35
+                │         │         ├── scan b@b_b2_idx
+                │         │         │    ├── columns: b1:41 b2:42 b.rowid:45!null
+                │         │         │    ├── key: (45)
+                │         │         │    ├── fd: (45)-->(41,42)
+                │         │         │    └── ordering: +42
+                │         │         └── filters (true)
+                │         └── aggregations
+                │              ├── const-agg [as=b1:7, outer=(7)]
+                │              │    └── b1:7
+                │              └── const-agg [as=b2:8, outer=(8)]
+                │                   └── b2:8
                 ├── distinct-on
                 │    ├── columns: c1:14
                 │    ├── grouping columns: c1:14
                 │    ├── key: (14)
                 │    └── scan c
                 │         └── columns: c1:14
-                ├── distinct-on
-                │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7 b2:8 b.rowid:11!null
-                │    ├── grouping columns: a1:1!null a2:2!null a3:3!null a4:4!null b.rowid:11!null
-                │    ├── key: (1-4,11)
-                │    ├── fd: (1-4,11)-->(7,8)
-                │    ├── union-all
-                │    │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7 b2:8 b.rowid:11!null
-                │    │    ├── left columns: a1:22 a2:23 a3:24 a4:25 b1:28 b2:29 b.rowid:32
-                │    │    ├── right columns: a1:35 a2:36 a3:37 a4:38 b1:41 b2:42 b.rowid:45
-                │    │    ├── inner-join (merge)
-                │    │    │    ├── columns: a1:22!null a2:23!null a3:24!null a4:25!null b1:28!null b2:29 b.rowid:32!null
-                │    │    │    ├── left ordering: +22
-                │    │    │    ├── right ordering: +28
-                │    │    │    ├── key: (23-25,32)
-                │    │    │    ├── fd: (32)-->(28,29), (22)==(28), (28)==(22)
-                │    │    │    ├── scan a
-                │    │    │    │    ├── columns: a1:22!null a2:23!null a3:24!null a4:25!null
-                │    │    │    │    ├── key: (22-25)
-                │    │    │    │    └── ordering: +22
-                │    │    │    ├── scan b@b_b1_b2_idx
-                │    │    │    │    ├── columns: b1:28 b2:29 b.rowid:32!null
-                │    │    │    │    ├── key: (32)
-                │    │    │    │    ├── fd: (32)-->(28,29)
-                │    │    │    │    └── ordering: +28
-                │    │    │    └── filters (true)
-                │    │    └── inner-join (merge)
-                │    │         ├── columns: a1:35!null a2:36!null a3:37!null a4:38!null b1:41 b2:42!null b.rowid:45!null
-                │    │         ├── left ordering: +35
-                │    │         ├── right ordering: +42
-                │    │         ├── key: (36-38,45)
-                │    │         ├── fd: (45)-->(41,42), (35)==(42), (42)==(35)
-                │    │         ├── scan a
-                │    │         │    ├── columns: a1:35!null a2:36!null a3:37!null a4:38!null
-                │    │         │    ├── key: (35-38)
-                │    │         │    └── ordering: +35
-                │    │         ├── scan b@b_b2_idx
-                │    │         │    ├── columns: b1:41 b2:42 b.rowid:45!null
-                │    │         │    ├── key: (45)
-                │    │         │    ├── fd: (45)-->(41,42)
-                │    │         │    └── ordering: +42
-                │    │         └── filters (true)
-                │    └── aggregations
-                │         ├── const-agg [as=b1:7, outer=(7)]
-                │         │    └── b1:7
-                │         └── const-agg [as=b2:8, outer=(8)]
-                │              └── b2:8
                 └── filters
                      └── b1:7 = c1:14 [outer=(7,14), constraints=(/7: (/NULL - ]; /14: (/NULL - ]), fd=(7)==(14), (14)==(7)]
 
@@ -2825,75 +2824,73 @@ SELECT * FROM a JOIN (SELECT * FROM b WHERE b1 > 0 AND EXISTS (SELECT 1 FROM c W
 ----
 project
  ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7!null b2:8 b3:9 b4:10
- └── project
+ └── inner-join (hash)
       ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7!null b2:8 b3:9 b4:10 c1:14!null
+      ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
       ├── fd: (7)==(14), (14)==(7)
-      └── inner-join (hash)
-           ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7!null b2:8 b3:9 b4:10 b.rowid:11!null c1:14!null
-           ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
-           ├── key: (1-4,11)
-           ├── fd: (1-4,11)-->(7-10), (7)==(14), (14)==(7)
-           ├── distinct-on
-           │    ├── columns: c1:14!null
-           │    ├── grouping columns: c1:14!null
-           │    ├── key: (14)
-           │    └── select
-           │         ├── columns: c1:14!null
-           │         ├── scan c
-           │         │    └── columns: c1:14
-           │         └── filters
-           │              └── c1:14 > 0 [outer=(14), constraints=(/14: [/1 - ]; tight)]
-           ├── distinct-on
-           │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7!null b2:8 b3:9 b4:10 b.rowid:11!null
-           │    ├── grouping columns: a1:1!null a2:2!null a3:3!null a4:4!null b.rowid:11!null
-           │    ├── key: (1-4,11)
-           │    ├── fd: (1-4,11)-->(7-10)
-           │    ├── union-all
-           │    │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7!null b2:8 b3:9 b4:10 b.rowid:11!null
-           │    │    ├── left columns: a1:22 a2:23 a3:24 a4:25 b1:28 b2:29 b3:30 b4:31 b.rowid:32
-           │    │    ├── right columns: a1:35 a2:36 a3:37 a4:38 b1:41 b2:42 b3:43 b4:44 b.rowid:45
-           │    │    ├── inner-join (merge)
-           │    │    │    ├── columns: a1:22!null a2:23!null a3:24!null a4:25!null b1:28!null b2:29 b3:30 b4:31 b.rowid:32!null
-           │    │    │    ├── left ordering: +22
-           │    │    │    ├── right ordering: +28
-           │    │    │    ├── key: (23-25,32)
-           │    │    │    ├── fd: (32)-->(28-31), (22)==(28), (28)==(22)
-           │    │    │    ├── scan a
-           │    │    │    │    ├── columns: a1:22!null a2:23!null a3:24!null a4:25!null
-           │    │    │    │    ├── key: (22-25)
-           │    │    │    │    └── ordering: +22
-           │    │    │    ├── scan b@b_b1_b2_idx
-           │    │    │    │    ├── columns: b1:28!null b2:29 b3:30 b4:31 b.rowid:32!null
-           │    │    │    │    ├── constraint: /28/29/32: [/1 - ]
-           │    │    │    │    ├── key: (32)
-           │    │    │    │    ├── fd: (32)-->(28-31)
-           │    │    │    │    └── ordering: +28
-           │    │    │    └── filters (true)
-           │    │    └── inner-join (hash)
-           │    │         ├── columns: a1:35!null a2:36!null a3:37!null a4:38!null b1:41!null b2:42!null b3:43 b4:44 b.rowid:45!null
-           │    │         ├── key: (35,37,38,45)
-           │    │         ├── fd: (45)-->(41-44), (36)==(42), (42)==(36)
-           │    │         ├── scan a
-           │    │         │    ├── columns: a1:35!null a2:36!null a3:37!null a4:38!null
-           │    │         │    └── key: (35-38)
-           │    │         ├── scan b@b_b1_b2_idx
-           │    │         │    ├── columns: b1:41!null b2:42 b3:43 b4:44 b.rowid:45!null
-           │    │         │    ├── constraint: /41/42/45: [/1 - ]
-           │    │         │    ├── key: (45)
-           │    │         │    └── fd: (45)-->(41-44)
-           │    │         └── filters
-           │    │              └── a2:36 = b2:42 [outer=(36,42), constraints=(/36: (/NULL - ]; /42: (/NULL - ]), fd=(36)==(42), (42)==(36)]
-           │    └── aggregations
-           │         ├── const-agg [as=b1:7, outer=(7)]
-           │         │    └── b1:7
-           │         ├── const-agg [as=b2:8, outer=(8)]
-           │         │    └── b2:8
-           │         ├── const-agg [as=b3:9, outer=(9)]
-           │         │    └── b3:9
-           │         └── const-agg [as=b4:10, outer=(10)]
-           │              └── b4:10
-           └── filters
-                └── c1:14 = b1:7 [outer=(7,14), constraints=(/7: (/NULL - ]; /14: (/NULL - ]), fd=(7)==(14), (14)==(7)]
+      ├── project
+      │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7!null b2:8 b3:9 b4:10
+      │    └── distinct-on
+      │         ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7!null b2:8 b3:9 b4:10 b.rowid:11!null
+      │         ├── grouping columns: a1:1!null a2:2!null a3:3!null a4:4!null b.rowid:11!null
+      │         ├── key: (1-4,11)
+      │         ├── fd: (1-4,11)-->(7-10)
+      │         ├── union-all
+      │         │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7!null b2:8 b3:9 b4:10 b.rowid:11!null
+      │         │    ├── left columns: a1:22 a2:23 a3:24 a4:25 b1:28 b2:29 b3:30 b4:31 b.rowid:32
+      │         │    ├── right columns: a1:35 a2:36 a3:37 a4:38 b1:41 b2:42 b3:43 b4:44 b.rowid:45
+      │         │    ├── inner-join (merge)
+      │         │    │    ├── columns: a1:22!null a2:23!null a3:24!null a4:25!null b1:28!null b2:29 b3:30 b4:31 b.rowid:32!null
+      │         │    │    ├── left ordering: +22
+      │         │    │    ├── right ordering: +28
+      │         │    │    ├── key: (23-25,32)
+      │         │    │    ├── fd: (32)-->(28-31), (22)==(28), (28)==(22)
+      │         │    │    ├── scan a
+      │         │    │    │    ├── columns: a1:22!null a2:23!null a3:24!null a4:25!null
+      │         │    │    │    ├── key: (22-25)
+      │         │    │    │    └── ordering: +22
+      │         │    │    ├── scan b@b_b1_b2_idx
+      │         │    │    │    ├── columns: b1:28!null b2:29 b3:30 b4:31 b.rowid:32!null
+      │         │    │    │    ├── constraint: /28/29/32: [/1 - ]
+      │         │    │    │    ├── key: (32)
+      │         │    │    │    ├── fd: (32)-->(28-31)
+      │         │    │    │    └── ordering: +28
+      │         │    │    └── filters (true)
+      │         │    └── inner-join (hash)
+      │         │         ├── columns: a1:35!null a2:36!null a3:37!null a4:38!null b1:41!null b2:42!null b3:43 b4:44 b.rowid:45!null
+      │         │         ├── key: (35,37,38,45)
+      │         │         ├── fd: (45)-->(41-44), (36)==(42), (42)==(36)
+      │         │         ├── scan a
+      │         │         │    ├── columns: a1:35!null a2:36!null a3:37!null a4:38!null
+      │         │         │    └── key: (35-38)
+      │         │         ├── scan b@b_b1_b2_idx
+      │         │         │    ├── columns: b1:41!null b2:42 b3:43 b4:44 b.rowid:45!null
+      │         │         │    ├── constraint: /41/42/45: [/1 - ]
+      │         │         │    ├── key: (45)
+      │         │         │    └── fd: (45)-->(41-44)
+      │         │         └── filters
+      │         │              └── a2:36 = b2:42 [outer=(36,42), constraints=(/36: (/NULL - ]; /42: (/NULL - ]), fd=(36)==(42), (42)==(36)]
+      │         └── aggregations
+      │              ├── const-agg [as=b1:7, outer=(7)]
+      │              │    └── b1:7
+      │              ├── const-agg [as=b2:8, outer=(8)]
+      │              │    └── b2:8
+      │              ├── const-agg [as=b3:9, outer=(9)]
+      │              │    └── b3:9
+      │              └── const-agg [as=b4:10, outer=(10)]
+      │                   └── b4:10
+      ├── distinct-on
+      │    ├── columns: c1:14!null
+      │    ├── grouping columns: c1:14!null
+      │    ├── key: (14)
+      │    └── select
+      │         ├── columns: c1:14!null
+      │         ├── scan c
+      │         │    └── columns: c1:14
+      │         └── filters
+      │              └── c1:14 > 0 [outer=(14), constraints=(/14: [/1 - ]; tight)]
+      └── filters
+           └── c1:14 = b1:7 [outer=(7,14), constraints=(/7: (/NULL - ]; /14: (/NULL - ]), fd=(7)==(14), (14)==(7)]
 
 opt expect=SplitDisjunctionOfJoinTerms
 SELECT * FROM a JOIN (SELECT * FROM b WHERE b1 > 0 AND EXISTS (SELECT 1 FROM c WHERE c1=b1 or c2=b2))

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -10063,6 +10063,103 @@ inner-join (merge)
  │         └── columns: m:1 n:2
  └── filters (true)
 
+# The rule should not fire when the projection is from a join.
+opt expect-not=HoistProjectFromInnerJoin
+SELECT * FROM (SELECT a, a+b FROM (SELECT tab1.* from abcd tab1, abcd tab2)) JOIN small ON a=m
+----
+inner-join (hash)
+ ├── columns: a:1!null "?column?":13 m:14!null n:15
+ ├── immutable
+ ├── fd: (1)==(14), (14)==(1)
+ ├── project
+ │    ├── columns: "?column?":13 tab1.a:1
+ │    ├── immutable
+ │    ├── inner-join (cross)
+ │    │    ├── columns: tab1.a:1 tab1.b:2
+ │    │    ├── scan abcd@abcd_a_b_idx [as=tab1]
+ │    │    │    └── columns: tab1.a:1 tab1.b:2
+ │    │    ├── scan abcd@abcd_a_b_idx [as=tab2]
+ │    │    └── filters (true)
+ │    └── projections
+ │         └── tab1.a:1 + tab1.b:2 [as="?column?":13, outer=(1,2), immutable]
+ ├── scan small
+ │    └── columns: m:14 n:15
+ └── filters
+      └── tab1.a:1 = m:14 [outer=(1,14), constraints=(/1: (/NULL - ]; /14: (/NULL - ]), fd=(1)==(14), (14)==(1)]
+
+# Regression test for #79943.
+exec-ddl
+CREATE TABLE table1 (
+col1_0 GEOGRAPHY NULL,
+col1_1 TIMETZ NOT NULL,
+col1_2 INTERVAL[],
+col1_3 REGCLASS NULL,
+col1_4 REGPROCEDURE,
+col1_5 STRING AS (CASE WHEN col1_2 IS NULL THEN 'abc' ELSE 'def' END) VIRTUAL,
+col1_6 STRING NULL AS (lower(CAST(col1_0 AS STRING))) VIRTUAL,
+col1_7 STRING AS (CASE WHEN col1_4 IS NULL THEN 'foo' ELSE 'bar' END) VIRTUAL,
+INDEX (col1_5 DESC, col1_3, col1_6 DESC, col1_4 ASC) STORING (col1_0, col1_2),
+UNIQUE (col1_1 ASC, lower(CAST(col1_0 AS STRING)) DESC))
+----
+
+exec-ddl
+CREATE TABLE table2 (
+col2_0 FLOAT4,
+col2_1 INT8[] NULL,
+col2_2 OID NULL,
+col2_3 FLOAT4 NOT NULL,
+col2_4 DECIMAL NULL,
+col2_5 INT2,
+col2_6 BYTES,
+col2_7 TIME,
+col2_8 INT8 NULL,
+col2_9 REGPROC,
+col2_10 NAME,
+col2_11 FLOAT4 AS (col2_3 + col2_0) STORED,
+col2_12 INT8 NULL AS (col2_8 + col2_5) VIRTUAL,
+col2_13 INT8 NULL AS (col2_8 + col2_5) VIRTUAL,
+col2_14 INT2 AS (col2_5 + col2_8) VIRTUAL,
+col2_15 INT2 AS (col2_5 + col2_8) VIRTUAL,
+col2_16 FLOAT4 AS (col2_3 + col2_0) VIRTUAL,
+col2_17 INT2 AS (col2_5 + col2_8) VIRTUAL)
+----
+
+# Regression test for #79943.
+# HoistProjectFromInnerJoin should fire, but not fire in so many cases that
+# query optimization never finishes.
+check-size rule-limit=100000 group-limit=10000 suppress-report expect=HoistProjectFromInnerJoin
+SELECT *
+FROM
+    table2 tab_69833
+    JOIN table1@[0] AS tab_69836
+        JOIN table1 AS tab_69837 ON (tab_69836.col1_5) = (tab_69837.col1_5)
+        JOIN table1@[0] AS tab_69838 ON
+                (tab_69836.col1_5) = (tab_69838.col1_6)
+                AND (tab_69837.col1_6) = (tab_69838.col1_7)
+                AND (tab_69837.col1_5) = (tab_69838.col1_7)
+        JOIN table2@[0] AS tab_69839
+            JOIN table2@[0] AS tab_69840 ON
+                    (tab_69839.col2_13) = (tab_69840.col2_8) AND
+                    (tab_69839.col2_13) = (tab_69840.col2_12) ON
+                (tab_69837.tableoid) = (tab_69840.col2_2)
+                AND (tab_69838.crdb_internal_mvcc_timestamp) = (tab_69839.col2_4)
+        JOIN table2@[0] AS tab_69841 ON (tab_69839.tableoid) = (tab_69841.col2_2)
+        JOIN table1 AS tab_69842
+            JOIN table1 AS tab_69843 ON (tab_69842.col1_5) = (tab_69843.col1_5) ON
+                (tab_69838.col1_6) = (tab_69842.col1_5) AND (tab_69837.col1_6) = (tab_69843.col1_5)
+        JOIN table1 AS tab_69844 ON
+                (tab_69838.col1_6) = (tab_69844.col1_5) ON
+            (tab_69833.col2_2) = (tab_69838.tableoid)
+            AND (tab_69833.crdb_internal_mvcc_timestamp) = (tab_69839.crdb_internal_mvcc_timestamp)
+            AND (tab_69833.crdb_internal_mvcc_timestamp) = (tab_69840.crdb_internal_mvcc_timestamp)
+            AND (tab_69833.col2_4) = (tab_69838.crdb_internal_mvcc_timestamp)
+            AND (tab_69833.crdb_internal_mvcc_timestamp) = (tab_69838.crdb_internal_mvcc_timestamp)
+ORDER BY
+    tab_69844.col1_6 DESC, tab_69833.crdb_internal_mvcc_timestamp
+LIMIT
+    51:::INT8
+----
+
 # --------------------------------------------------
 # HoistProjectFromLeftJoin
 # --------------------------------------------------
@@ -10186,6 +10283,65 @@ right-join (hash)
  │    └── columns: m:1 n:2
  └── filters
       └── p:6 = m:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+
+# The rule should not fire when the projection is from a join.
+opt expect-not=HoistProjectFromLeftJoin
+SELECT * FROM (SELECT a, a+b FROM (SELECT tab1.* from abcd tab1, abcd tab2)) LEFT OUTER JOIN small ON a=m
+----
+left-join (hash)
+ ├── columns: a:1 "?column?":13 m:14 n:15
+ ├── immutable
+ ├── project
+ │    ├── columns: "?column?":13 tab1.a:1
+ │    ├── immutable
+ │    ├── inner-join (cross)
+ │    │    ├── columns: tab1.a:1 tab1.b:2
+ │    │    ├── scan abcd@abcd_a_b_idx [as=tab1]
+ │    │    │    └── columns: tab1.a:1 tab1.b:2
+ │    │    ├── scan abcd@abcd_a_b_idx [as=tab2]
+ │    │    └── filters (true)
+ │    └── projections
+ │         └── tab1.a:1 + tab1.b:2 [as="?column?":13, outer=(1,2), immutable]
+ ├── scan small
+ │    └── columns: m:14 n:15
+ └── filters
+      └── tab1.a:1 = m:14 [outer=(1,14), constraints=(/1: (/NULL - ]; /14: (/NULL - ]), fd=(1)==(14), (14)==(1)]
+
+# Regression test for #79943.
+# HoistProjectFromLeftJoin should fire, but not fire in so many cases that
+# query optimization never finishes.
+check-size rule-limit=100000 group-limit=10000 suppress-report expect=HoistProjectFromLeftJoin
+SELECT *
+FROM
+    table2 tab_69833
+    LEFT OUTER JOIN table1@[0] AS tab_69836
+        LEFT OUTER JOIN table1 AS tab_69837 ON (tab_69836.col1_5) = (tab_69837.col1_5)
+        LEFT OUTER JOIN table1@[0] AS tab_69838 ON
+                (tab_69836.col1_5) = (tab_69838.col1_6)
+                AND (tab_69837.col1_6) = (tab_69838.col1_7)
+                AND (tab_69837.col1_5) = (tab_69838.col1_7)
+        LEFT OUTER JOIN table2@[0] AS tab_69839
+            LEFT OUTER JOIN table2@[0] AS tab_69840 ON
+                    (tab_69839.col2_13) = (tab_69840.col2_8) AND
+                    (tab_69839.col2_13) = (tab_69840.col2_12) ON
+                (tab_69837.tableoid) = (tab_69840.col2_2)
+                AND (tab_69838.crdb_internal_mvcc_timestamp) = (tab_69839.col2_4)
+        LEFT OUTER JOIN table2@[0] AS tab_69841 ON (tab_69839.tableoid) = (tab_69841.col2_2)
+        LEFT OUTER JOIN table1 AS tab_69842
+            LEFT OUTER JOIN table1 AS tab_69843 ON (tab_69842.col1_5) = (tab_69843.col1_5) ON
+                (tab_69838.col1_6) = (tab_69842.col1_5) AND (tab_69837.col1_6) = (tab_69843.col1_5)
+        LEFT OUTER JOIN table1 AS tab_69844 ON
+                (tab_69838.col1_6) = (tab_69844.col1_5) ON
+            (tab_69833.col2_2) = (tab_69838.tableoid)
+            AND (tab_69833.crdb_internal_mvcc_timestamp) = (tab_69839.crdb_internal_mvcc_timestamp)
+            AND (tab_69833.crdb_internal_mvcc_timestamp) = (tab_69840.crdb_internal_mvcc_timestamp)
+            AND (tab_69833.col2_4) = (tab_69838.crdb_internal_mvcc_timestamp)
+            AND (tab_69833.crdb_internal_mvcc_timestamp) = (tab_69838.crdb_internal_mvcc_timestamp)
+ORDER BY
+    tab_69844.col1_6 DESC, tab_69833.crdb_internal_mvcc_timestamp
+LIMIT
+    51:::INT8
+----
 
 # --------------------------------------------------
 # GenerateLocalityOptimizedAntiJoin

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -2061,42 +2061,6 @@ Joins Considered: 6
 Join Tree #4
 --------------------------------------------------------------------------------
   inner-join (hash)
-   ├── scan abc [as=a1]
-   ├── inner-join (hash)
-   │    ├── scan abc [as=a2]
-   │    ├── distinct-on
-   │    │    └── scan abc [as=a5]
-   │    └── filters
-   │         └── a2.c = a5.c
-   └── filters
-        └── a1.a = a2.a
-Vertexes
-  C:
-    scan abc [as=a1]
-  A:
-    scan abc [as=a2]
-  B:
-    distinct-on
-     └── scan abc [as=a5]
-Edges
-  a2.c = a5.c [inner, ses=AB, tes=AB, rules=()]
-  a1.a = a2.a [inner, ses=CA, tes=CA, rules=()]
-Joining CA
-  C A [inner, refs=CA]
-  A C [inner, refs=CA]
-Joining AB
-  A B [inner, refs=AB]
-  B A [inner, refs=AB]
-Joining CAB
-  C AB [inner, refs=CA]
-  AB C [inner, refs=CA]
-  CA B [inner, refs=AB]
-  B CA [inner, refs=AB]
-Joins Considered: 8
---------------------------------------------------------------------------------
-Join Tree #5
---------------------------------------------------------------------------------
-  inner-join (hash)
    ├── inner-join (hash)
    │    ├── scan abc [as=a1]
    │    ├── semi-join (hash)
@@ -2136,7 +2100,7 @@ Joining CAD
   D CA [inner, refs=AD]
 Joins Considered: 8
 --------------------------------------------------------------------------------
-Join Tree #6
+Join Tree #5
 --------------------------------------------------------------------------------
   inner-join (hash)
    ├── inner-join (hash)
@@ -2456,8 +2420,8 @@ WHERE EXISTS (SELECT 1 FROM dz WHERE z = y)
 AND EXISTS (SELECT 1 FROM bx WHERE x = y)
 AND EXISTS (SELECT 1 FROM abc WHERE a = y)
 ----
-Rules Applied: 148
-Groups Added: 80
+Rules Applied: 134
+Groups Added: 73
 
 
 # Regression test for #76522. Do not produce query plans where some of the


### PR DESCRIPTION
Fixes #79943

Previously, HoistProjectFromInnerJoin would explore joins with the right
input projection pulled up to the parent of the join, no matter the type
of relation underneath the projection.

This was inadequate because queries involving many joins may invoke the
ReorderJoins rule many times, which creates many new join expressions
(orders of magnitude greater than the number of joins in the query),
which need to be explored. Each of those may trigger projection pull-up,
adding a new join expression to a memo group, further increasing the
search space. Each of those added join expressions may themselves have a
subtree of joins below them involving projections which may fire the
rule again, leading to an explosion of rule firings and a query which
never completes optimization (hangs).

To address this, this patch alters the conditions required to fire
HoistProjectFromInnerJoin so that when the right input of the join is a
projection, the input to the projection must be a canonical scan or a
select from a canonical scan.

HoistProjectFromInnerJoin, added through #59780, is meant to enable more
lookup joins because converting a projection on the right side of a join
into a canonical scan allows GenerateLookupJoins to fire. Likewise,
other join transformations such as SplitDisjunctionOfJoinTerms may
require either a canonical scan or a select from a canonical scan as
join inputs in order to fire.  Other cases are unlikely to cause any new
join transformations to fire since those rules check for canonical scans
as input, so skipping their exploration will not result in any missed
optimizations.

Release note (bug fix): Prior to this fix, queries with many joins and
projections of multicolumn expressions, e.g. col1 + col2, either
present in the query or within a virtual column definition, could
experience very long optimization times or hangs, where the query is
never sent for execution.