### PR TITLE
span: tighten up range based lookup spans

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -7,6 +7,14 @@ CREATE TABLE def (d INT, e INT, f INT, PRIMARY KEY (f, e));
 INSERT INTO def VALUES (1, 1, 2), (2, 1, 1), (NULL, 2, 1)
 
 statement ok
+CREATE TABLE def_e_desc (d INT, e INT, f INT, PRIMARY KEY (f, e DESC));
+INSERT INTO def_e_desc VALUES (1, 1, 2), (2, 1, 1), (NULL, 2, 1)
+
+statement ok
+CREATE TABLE def_e_decimal (d INT, e DECIMAL, f INT, PRIMARY KEY (f, e));
+INSERT INTO def_e_decimal VALUES (1, 1, 2), (2, 1, 1), (NULL, 2, 1)
+
+statement ok
 CREATE TABLE gh (g INT, h INT, INDEX g_idx (g));
 INSERT INTO gh VALUES (NULL, 1)
 
@@ -24,6 +32,26 @@ ALTER TABLE abc INJECT STATISTICS '[
 
 statement ok
 ALTER TABLE def INJECT STATISTICS '[
+  {
+    "columns": ["f"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 10000
+  }
+]'
+
+statement ok
+ALTER TABLE def_e_desc INJECT STATISTICS '[
+  {
+    "columns": ["f"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 10000
+  }
+]'
+
+statement ok
+ALTER TABLE def_e_decimal INJECT STATISTICS '[
   {
     "columns": ["f"],
     "created_at": "2018-01-01 1:00:00.00000+00:00",
@@ -66,6 +94,36 @@ SELECT * FROM abc JOIN def ON f = b AND a > 1 AND e > 1
 ----
 2  1  1  NULL  2  1
 
+query IIIIII
+SELECT * FROM abc JOIN def_e_desc ON f = b AND a > 1 AND e > 1
+----
+2  1  1  NULL  2  1
+
+query IIIIRI
+SELECT * FROM abc JOIN def_e_decimal ON f = b AND a > 1 AND e > 1
+----
+2  1  1  NULL  2  1
+
+# Filter on 'e' is a contradiction.
+query IIIIII
+SELECT * FROM abc JOIN def ON f = b AND a > 1 AND e < -9223372036854775808
+----
+
+# Filter on 'e' is a contradiction.
+query IIIIII
+SELECT * FROM abc JOIN def ON f = b AND a > 1 AND e > 9223372036854775807
+----
+
+# Filter on 'e' is a contradiction.
+query IIIIII
+SELECT * FROM abc JOIN def_e_desc ON f = b AND a > 1 AND e < -9223372036854775808
+----
+
+# Filter on 'e' is a contradiction.
+query IIIIII
+SELECT * FROM abc JOIN def_e_desc ON f = b AND a > 1 AND e > 9223372036854775807
+----
+
 # Filter right side of a lookup join with a restriction on an indexed column.
 query IIIIII rowsort
 SELECT * FROM abc JOIN def ON f = a WHERE f > 1
@@ -81,9 +139,37 @@ SELECT * FROM abc JOIN def ON f = b WHERE a >= e
 2  1  1  2  1  1
 2  1  1  NULL  2  1
 
+query IIIIII rowsort
+SELECT * FROM abc JOIN def_e_desc ON f = b WHERE a >= e
+----
+1  1  2  2  1  1
+2  1  1  2  1  1
+2  1  1  NULL  2  1
+
+query IIIIRI rowsort
+SELECT * FROM abc JOIN def_e_decimal ON f = b WHERE a >= e
+----
+1  1  2  2  1  1
+2  1  1  2  1  1
+2  1  1  NULL  2  1
+
 # Test lookup join with restriction relating the left and right side.
 query IIIIII rowsort
 SELECT * FROM abc JOIN def ON f = b AND a >= e
+----
+1  1  2  2  1  1
+2  1  1  2  1  1
+2  1  1  NULL  2  1
+
+query IIIIII rowsort
+SELECT * FROM abc JOIN def_e_desc ON f = b AND a >= e
+----
+1  1  2  2  1  1
+2  1  1  2  1  1
+2  1  1  NULL  2  1
+
+query IIIIRI rowsort
+SELECT * FROM abc JOIN def_e_decimal ON f = b AND a >= e
 ----
 1  1  2  2  1  1
 2  1  1  2  1  1

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -6,6 +6,9 @@ CREATE TABLE abc (a INT, b INT, c INT, PRIMARY KEY (a, c))
 statement ok
 CREATE TABLE def (d INT, e INT, f INT, PRIMARY KEY (f, e))
 
+statement ok
+CREATE TABLE def_e_decimal (d INT, e DECIMAL, f INT, PRIMARY KEY (f, e))
+
 # Set up the statistics as if the first table is much smaller than the second.
 # This will make lookup join into the second table be the best plan.
 statement ok
@@ -20,6 +23,16 @@ ALTER TABLE abc INJECT STATISTICS '[
 
 statement ok
 ALTER TABLE def INJECT STATISTICS '[
+  {
+    "columns": ["f"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 10000
+  }
+]'
+
+statement ok
+ALTER TABLE def_e_decimal INJECT STATISTICS '[
   {
     "columns": ["f"],
     "created_at": "2018-01-01 1:00:00.00000+00:00",
@@ -83,6 +96,49 @@ vectorized: true
       table: abc@abc_pkey
       spans: /2-
 
+# The filter on 'e' is a contradiction. At the moment, we're handling it as the
+# ON expression (the optimizer should be smart enough to avoid execution
+# altogether, #80402).
+query T
+EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b WHERE a > 1 AND e > 9223372036854775807
+----
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, c, d, e, f)
+│ estimated row count: 33
+│ table: def@def_pkey
+│ equality: (b) = (f)
+│ pred: e > 9223372036854775807
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 33 (33% of the table; stats collected <hidden> ago)
+      table: abc@abc_pkey
+      spans: /2-
+
+# Decimals don't support Next / Prev calls, so we handle the filter on 'e' as
+# the ON expression.
+query T
+EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def_e_decimal ON f = b WHERE a > 1 AND e > 1
+----
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, c, d, e, f)
+│ estimated row count: 33
+│ table: def_e_decimal@def_e_decimal_pkey
+│ equality: (b) = (f)
+│ pred: e > 1
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 33 (33% of the table; stats collected <hidden> ago)
+      table: abc@abc_pkey
+      spans: /2-
+
 query T
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = a WHERE f > 1
 ----
@@ -131,6 +187,25 @@ vectorized: true
 │ columns: (a, b, c, d, e, f)
 │ estimated row count: 33
 │ table: def@def_pkey
+│ equality: (b) = (f)
+│ pred: a >= e
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
+      table: abc@abc_pkey
+      spans: FULL SCAN
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def_e_decimal ON f = b AND a >= e
+----
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, c, d, e, f)
+│ estimated row count: 33
+│ table: def_e_decimal@def_e_decimal_pkey
 │ equality: (b) = (f)
 │ pred: a >= e
 │
@@ -1985,8 +2060,8 @@ INSERT INTO family_split_2 VALUES (1, 2, 3)
 query T kvtrace(Scan)
 SELECT family_split_2.x, family_split_2.z FROM family_split_1 INNER LOOKUP JOIN family_split_2 ON family_split_1.x = family_split_2.x; SET tracing = off
 ----
-Scan /Table/127/{1-2}
-Scan /Table/128/1/1/0, /Table/128/1/1/2/1
+Scan /Table/128/{1-2}
+Scan /Table/129/1/1/0, /Table/129/1/1/2/1
 
 statement ok
 CREATE TABLE family_index_join (x INT PRIMARY KEY, y INT, z INT, w INT, INDEX (y), FAMILY f1 (x), FAMILY f2 (y), FAMILY f3 (z), FAMILY f4(w))
@@ -1997,5 +2072,5 @@ INSERT INTO family_index_join VALUES (1, 2, 3, 4)
 query T kvtrace(Scan)
 SELECT y,w FROM family_index_join@family_index_join_y_idx WHERE y = 2
 ----
-Scan /Table/129/2/{2-3}
-Scan /Table/129/1/1/{0-1/2}, /Table/129/1/1/3/1
+Scan /Table/130/2/{2-3}
+Scan /Table/130/1/1/{0-1/2}, /Table/130/1/1/3/1

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_trace
@@ -34,8 +34,7 @@ SET tracing = on, kv; SELECT * FROM abc JOIN def ON d = c WHERE a > 1 AND e > 1;
 query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader'
 ----
-Scan /Table/107/1/{1/1/NULL-2}
-fetched: /def/def_pkey/1/1/f -> /2
+Scan /Table/107/1/{1/2-2}
 fetched: /def/def_pkey/1/2 -> <undecoded>
 
 statement ok
@@ -150,10 +149,8 @@ SET tracing = off;
 query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader'
 ----
-Scan /Table/109/1/{1/2020-01-01T00:00:00Z/NULL-2}, /Table/109/1/{2/2020-01-01T00:00:00Z/NULL-3}
-fetched: /metric_values/metric_values_pkey/1/'2020-01-01 00:00:00+00:00'/value -> /0
+Scan /Table/109/1/{1/2020-01-01T00:00:00.000001Z-2}, /Table/109/1/{2/2020-01-01T00:00:00.000001Z-3}
 fetched: /metric_values/metric_values_pkey/1/'2020-01-01 00:00:01+00:00'/nullable/value -> /1/1
-fetched: /metric_values/metric_values_pkey/2/'2020-01-01 00:00:00+00:00'/value -> /2
 fetched: /metric_values/metric_values_pkey/2/'2020-01-01 00:00:01+00:00'/nullable/value -> /2/3
 fetched: /metric_values/metric_values_pkey/2/'2020-01-01 00:01:01+00:00'/nullable/value -> /-11/4
 fetched: /metric_values/metric_values_pkey/2/'2020-01-01 00:01:02+00:00'/nullable/value -> /-10/5
@@ -173,7 +170,7 @@ SET tracing = off;
 query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader'
 ----
-Scan /Table/109/1/1/{NULL/NULL-2020-01-01T00:00:00Z}, /Table/109/1/2/{NULL/NULL-2020-01-01T00:00:00Z}
+Scan /Table/109/1/1/{!NULL-2020-01-01T00:00:00Z}, /Table/109/1/2/{!NULL-2020-01-01T00:00:00Z}
 
 statement ok
 SET tracing = on, kv;
@@ -191,9 +188,7 @@ SET tracing = off;
 query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader'
 ----
-Scan /Table/110/1/1/{1920-01-01T23:59:58.999999999Z/NULL-NULL}, /Table/110/1/2/{1920-01-01T23:59:58.999999999Z/NULL-NULL}
-fetched: /metric_values_desc/metric_values_desc_pkey/1/'2020-01-01 00:00:00+00:00'/value -> /0
-fetched: /metric_values_desc/metric_values_desc_pkey/2/'2020-01-01 00:00:00+00:00'/value -> /2
+Scan /Table/110/1/1/{1920-01-01T23:59:59.000000999Z-!NULL}, /Table/110/1/2/{1920-01-01T23:59:59.000000999Z-!NULL}
 
 statement ok
 SET tracing = on, kv;
@@ -212,8 +207,7 @@ SET tracing = off;
 query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader'
 ----
-Scan /Table/109/2/{1/1/NULL-2}, /Table/109/2/{2/1/NULL-3}
-fetched: /metric_values/secondary/1/1/'2020-01-01 00:00:01+00:00' -> <undecoded>
+Scan /Table/109/2/{1/2-2}, /Table/109/2/{2/2-3}
 fetched: /metric_values/secondary/2/2/'2020-01-01 00:00:01+00:00' -> <undecoded>
 Scan /Table/109/1/2/2020-01-01T00:00:01Z/0
 fetched: /metric_values/metric_values_pkey/?/?/value -> /3
@@ -237,9 +231,7 @@ SET tracing = off;
 query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader'
 ----
-Scan /Table/109/2/1/{NULL/NULL--10}, /Table/109/2/2/{NULL/NULL--10}
-fetched: /metric_values/secondary/1/NULL/'2020-01-01 00:00:00+00:00' -> <undecoded>
-fetched: /metric_values/secondary/2/NULL/'2020-01-01 00:00:00+00:00' -> <undecoded>
+Scan /Table/109/2/1/{!NULL--10}, /Table/109/2/2/{!NULL--10}
 fetched: /metric_values/secondary/2/-11/'2020-01-01 00:01:01+00:00' -> <undecoded>
 Scan /Table/109/1/2/2020-01-01T00:01:01Z/0
 fetched: /metric_values/metric_values_pkey/?/?/value -> /4
@@ -263,9 +255,7 @@ SET tracing = off;
 query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader'
 ----
-Scan /Table/109/2/1/{NULL/NULL--9}, /Table/109/2/2/{NULL/NULL--9}
-fetched: /metric_values/secondary/1/NULL/'2020-01-01 00:00:00+00:00' -> <undecoded>
-fetched: /metric_values/secondary/2/NULL/'2020-01-01 00:00:00+00:00' -> <undecoded>
+Scan /Table/109/2/1/{!NULL--9}, /Table/109/2/2/{!NULL--9}
 fetched: /metric_values/secondary/2/-11/'2020-01-01 00:01:01+00:00' -> <undecoded>
 fetched: /metric_values/secondary/2/-10/'2020-01-01 00:01:02+00:00' -> <undecoded>
 Scan /Table/109/1/2/2020-01-01T00:01:01Z/0, /Table/109/1/2/2020-01-01T00:01:02Z/0
@@ -291,9 +281,7 @@ SET tracing = off;
 query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader'
 ----
-Scan /Table/109/2/1/{NULL/NULL--9}, /Table/109/2/2/{NULL/NULL--9}
-fetched: /metric_values/secondary/1/NULL/'2020-01-01 00:00:00+00:00' -> <undecoded>
-fetched: /metric_values/secondary/2/NULL/'2020-01-01 00:00:00+00:00' -> <undecoded>
+Scan /Table/109/2/1/{!NULL--9}, /Table/109/2/2/{!NULL--9}
 fetched: /metric_values/secondary/2/-11/'2020-01-01 00:01:01+00:00' -> <undecoded>
 fetched: /metric_values/secondary/2/-10/'2020-01-01 00:01:02+00:00' -> <undecoded>
 Scan /Table/109/1/2/2020-01-01T00:01:01Z/0, /Table/109/1/2/2020-01-01T00:01:02Z/0

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_trace
@@ -1,0 +1,303 @@
+# LogicTest: local
+
+statement ok
+CREATE TABLE abc (a INT, b INT, c INT, PRIMARY KEY (a, b), FAMILY (a, b, c));
+INSERT INTO abc VALUES (1, 2, 1), (2, 1, 1), (2, 2, NULL);
+CREATE TABLE def (d INT, e INT, f INT, PRIMARY KEY (d, e), FAMILY (d, e, f));
+INSERT INTO def VALUES (2, 1, 1), (1, 1, 2), (1, 2, NULL);
+
+statement ok
+ALTER TABLE abc INJECT STATISTICS '[
+  {
+    "columns": ["a"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 100,
+    "distinct_count": 100
+  }
+]'
+
+statement ok
+ALTER TABLE def INJECT STATISTICS '[
+  {
+    "columns": ["d"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 10000
+  }
+]'
+
+statement ok
+SET tracing = on, kv; SELECT * FROM abc JOIN def ON d = c WHERE a > 1 AND e > 1; SET tracing = off
+
+# We should not be fetching /def/def_pkey/1/1 key because it fails 'e > 1'
+# filter.
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader'
+----
+Scan /Table/107/1/{1/1/NULL-2}
+fetched: /def/def_pkey/1/1/f -> /2
+fetched: /def/def_pkey/1/2 -> <undecoded>
+
+statement ok
+CREATE TABLE metrics (
+  id       SERIAL PRIMARY KEY,
+  nullable INT,
+  name     STRING,
+  INDEX    name_index (name),
+  FAMILY (id, nullable, name)
+);
+INSERT INTO metrics (id,nullable,name) VALUES (1, NULL, 'cpu'), (2, 1, 'cpu'), (3, NULL, 'mem'), (4, 2, 'disk');
+CREATE TABLE metric_values (
+  metric_id INT8,
+  time      TIMESTAMPTZ,
+  nullable  INT,
+  value     INT8,
+  PRIMARY KEY (metric_id, time),
+  INDEX secondary (metric_id, nullable, time),
+  FAMILY (metric_id, time, nullable, value)
+);
+INSERT INTO metric_values (metric_id, time, nullable, value) VALUES
+ (1,'2020-01-01 00:00:00+00:00',NULL,0),
+ (1,'2020-01-01 00:00:01+00:00',1,1),
+ (2,'2020-01-01 00:00:00+00:00',NULL,2),
+ (2,'2020-01-01 00:00:01+00:00',2,3),
+ (2,'2020-01-01 00:01:01+00:00',-11,4),
+ (2,'2020-01-01 00:01:02+00:00',-10,5),
+ (3,'2020-01-01 00:01:00+00:00',NULL,6),
+ (3,'2020-01-01 00:01:01+00:00',3,7);
+CREATE TABLE metric_values_desc (
+  metric_id INT8,
+  time      TIMESTAMPTZ,
+  nullable  INT,
+  value     INT8,
+  PRIMARY KEY (metric_id, time DESC),
+  INDEX secondary (metric_id, nullable DESC, time DESC),
+  FAMILY (metric_id, time, nullable, value)
+);
+INSERT INTO metric_values_desc SELECT * FROM metric_values;
+
+statement ok
+ALTER TABLE metric_values INJECT STATISTICS
+'[
+ {
+   "columns": ["metric_id"],
+   "created_at": "2018-01-01 1:00:00.00000+00:00",
+   "row_count": 1000,
+   "distinct_count": 10
+ },
+ {
+   "columns": ["time"],
+   "created_at": "2018-01-01 1:30:00.00000+00:00",
+   "row_count": 1000,
+   "distinct_count": 1000
+ },
+ {
+   "columns": ["nullable"],
+   "created_at": "2018-01-01 1:30:00.00000+00:00",
+   "row_count": 1000,
+   "distinct_count": 10,
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "-10"},
+      {"num_eq": 0, "num_range": 1000, "distinct_range": 10, "upper_bound": "0"}
+    ],
+    "histo_col_type": "INT"
+ },
+ {
+    "columns": ["value"],
+    "created_at": "2018-01-01 1:30:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 1000
+  }
+]'
+
+statement ok
+ALTER TABLE metrics INJECT STATISTICS
+'[
+ {
+   "columns": ["id"],
+   "created_at": "2018-01-01 1:00:00.00000+00:00",
+   "row_count": 10,
+   "distinct_count": 10
+ },
+ {
+   "columns": ["nullable"],
+   "created_at": "2018-01-01 1:30:00.00000+00:00",
+   "row_count": 10,
+   "distinct_count": 10
+ },
+ {
+   "columns": ["name"],
+   "created_at": "2018-01-01 1:30:00.00000+00:00",
+   "row_count": 10,
+   "distinct_count": 10
+ }
+]'
+
+statement ok
+SET tracing = on, kv;
+SELECT *
+FROM metric_values as v
+INNER JOIN metrics as m
+ON metric_id=id
+WHERE
+  time > '2020-01-01 00:00:00+00:00' AND
+  name='cpu'
+ORDER BY value;
+SET tracing = off;
+
+# We should not be fetching the key with '2020-01-01 00:00:00+00:00' value for
+# the 'time' column since it doesn't satisfy the filter on 'time'.
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader'
+----
+Scan /Table/109/1/{1/2020-01-01T00:00:00Z/NULL-2}, /Table/109/1/{2/2020-01-01T00:00:00Z/NULL-3}
+fetched: /metric_values/metric_values_pkey/1/'2020-01-01 00:00:00+00:00'/value -> /0
+fetched: /metric_values/metric_values_pkey/1/'2020-01-01 00:00:01+00:00'/nullable/value -> /1/1
+fetched: /metric_values/metric_values_pkey/2/'2020-01-01 00:00:00+00:00'/value -> /2
+fetched: /metric_values/metric_values_pkey/2/'2020-01-01 00:00:01+00:00'/nullable/value -> /2/3
+fetched: /metric_values/metric_values_pkey/2/'2020-01-01 00:01:01+00:00'/nullable/value -> /-11/4
+fetched: /metric_values/metric_values_pkey/2/'2020-01-01 00:01:02+00:00'/nullable/value -> /-10/5
+
+statement ok
+SET tracing = on, kv;
+SELECT *
+FROM metric_values
+INNER JOIN metrics
+ON metric_id=id
+WHERE
+  time < '2020-01-01 00:00:00+00:00' AND
+  name='cpu';
+SET tracing = off;
+
+# The start boundary of the spans should exclude NULL values.
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader'
+----
+Scan /Table/109/1/1/{NULL/NULL-2020-01-01T00:00:00Z}, /Table/109/1/2/{NULL/NULL-2020-01-01T00:00:00Z}
+
+statement ok
+SET tracing = on, kv;
+SELECT *
+FROM metric_values_desc
+INNER JOIN metrics
+ON metric_id=id
+WHERE
+  time < '2020-01-01 00:00:00+00:00' AND
+  name='cpu';
+SET tracing = off;
+
+# We should not be fetching two keys with '2020-01-01 00:00:00+00:00' value for
+# the 'time' column since they don't satisfy the filter on 'time'.
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader'
+----
+Scan /Table/110/1/1/{1920-01-01T23:59:58.999999999Z/NULL-NULL}, /Table/110/1/2/{1920-01-01T23:59:58.999999999Z/NULL-NULL}
+fetched: /metric_values_desc/metric_values_desc_pkey/1/'2020-01-01 00:00:00+00:00'/value -> /0
+fetched: /metric_values_desc/metric_values_desc_pkey/2/'2020-01-01 00:00:00+00:00'/value -> /2
+
+statement ok
+SET tracing = on, kv;
+SELECT *
+FROM metric_values as v
+INNER JOIN metrics as m
+ON metric_id=id
+WHERE
+  v.nullable > 1 AND
+  name='cpu'
+ORDER BY value;
+SET tracing = off;
+
+# We should not be fetching /metric_values/secondary/1/1 key because it fails
+# 'nullable > 1' filter.
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader'
+----
+Scan /Table/109/2/{1/1/NULL-2}, /Table/109/2/{2/1/NULL-3}
+fetched: /metric_values/secondary/1/1/'2020-01-01 00:00:01+00:00' -> <undecoded>
+fetched: /metric_values/secondary/2/2/'2020-01-01 00:00:01+00:00' -> <undecoded>
+Scan /Table/109/1/2/2020-01-01T00:00:01Z/0
+fetched: /metric_values/metric_values_pkey/?/?/value -> /3
+Scan /Table/108/1/2/0
+fetched: /metrics/metrics_pkey/?/nullable -> /1
+
+statement ok
+SET tracing = on, kv;
+SELECT *
+FROM metric_values as v
+INNER JOIN metrics as m
+ON metric_id=id
+WHERE
+  v.nullable < -10 AND
+  name='cpu'
+ORDER BY value;
+SET tracing = off;
+
+# We should not be fetching two keys with NULL values for the 'nullable' column
+# since they don't satisfy the filter on 'nullable'.
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader'
+----
+Scan /Table/109/2/1/{NULL/NULL--10}, /Table/109/2/2/{NULL/NULL--10}
+fetched: /metric_values/secondary/1/NULL/'2020-01-01 00:00:00+00:00' -> <undecoded>
+fetched: /metric_values/secondary/2/NULL/'2020-01-01 00:00:00+00:00' -> <undecoded>
+fetched: /metric_values/secondary/2/-11/'2020-01-01 00:01:01+00:00' -> <undecoded>
+Scan /Table/109/1/2/2020-01-01T00:01:01Z/0
+fetched: /metric_values/metric_values_pkey/?/?/value -> /4
+Scan /Table/108/1/2/0
+fetched: /metrics/metrics_pkey/?/nullable -> /1
+
+statement ok
+SET tracing = on, kv;
+SELECT *
+FROM metric_values as v
+INNER JOIN metrics as m
+ON metric_id=id
+WHERE
+  v.nullable <= -10 AND
+  name='cpu'
+ORDER BY value;
+SET tracing = off;
+
+# We should not be fetching two keys with NULL values for the 'nullable' column
+# since they don't satisfy the filter on 'nullable'.
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader'
+----
+Scan /Table/109/2/1/{NULL/NULL--9}, /Table/109/2/2/{NULL/NULL--9}
+fetched: /metric_values/secondary/1/NULL/'2020-01-01 00:00:00+00:00' -> <undecoded>
+fetched: /metric_values/secondary/2/NULL/'2020-01-01 00:00:00+00:00' -> <undecoded>
+fetched: /metric_values/secondary/2/-11/'2020-01-01 00:01:01+00:00' -> <undecoded>
+fetched: /metric_values/secondary/2/-10/'2020-01-01 00:01:02+00:00' -> <undecoded>
+Scan /Table/109/1/2/2020-01-01T00:01:01Z/0, /Table/109/1/2/2020-01-01T00:01:02Z/0
+fetched: /metric_values/metric_values_pkey/?/?/value -> /4
+fetched: /metric_values/metric_values_pkey/?/?/value -> /5
+Scan /Table/108/1/2/0
+fetched: /metrics/metrics_pkey/?/nullable -> /1
+
+statement ok
+SET tracing = on, kv;
+SELECT *
+FROM metric_values as v
+INNER JOIN metrics as m
+ON metric_id=id
+WHERE
+  v.nullable <= -10 AND
+  name='cpu'
+ORDER BY value;
+SET tracing = off;
+
+# We should not be fetching two keys with NULL values for the 'nullable' column
+# since they don't satisfy the filter on 'nullable'.
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader'
+----
+Scan /Table/109/2/1/{NULL/NULL--9}, /Table/109/2/2/{NULL/NULL--9}
+fetched: /metric_values/secondary/1/NULL/'2020-01-01 00:00:00+00:00' -> <undecoded>
+fetched: /metric_values/secondary/2/NULL/'2020-01-01 00:00:00+00:00' -> <undecoded>
+fetched: /metric_values/secondary/2/-11/'2020-01-01 00:01:01+00:00' -> <undecoded>
+fetched: /metric_values/secondary/2/-10/'2020-01-01 00:01:02+00:00' -> <undecoded>
+Scan /Table/109/1/2/2020-01-01T00:01:01Z/0, /Table/109/1/2/2020-01-01T00:01:02Z/0
+fetched: /metric_values/metric_values_pkey/?/?/value -> /4
+fetched: /metric_values/metric_values_pkey/?/?/value -> /5
+Scan /Table/108/1/2/0
+fetched: /metrics/metrics_pkey/?/nullable -> /1

--- a/pkg/sql/rowexec/joinreader_span_generator.go
+++ b/pkg/sql/rowexec/joinreader_span_generator.go
@@ -46,8 +46,9 @@ type joinReaderSpanGenerator interface {
 
 	// getMatchingRowIndices returns the indices of the input rows that desire
 	// the given key (i.e., the indices of the rows passed to generateSpans that
-	// generated spans containing the given key).
-	getMatchingRowIndices(key roachpb.Key) []int
+	// generated spans containing the given key). An error is returned if no
+	// span among returned by generateSpans() contains the given key.
+	getMatchingRowIndices(key roachpb.Key) ([]int, error)
 
 	// maxLookupCols returns the maximum number of index columns used as the key
 	// for each lookup.
@@ -174,8 +175,8 @@ func (g *defaultSpanGenerator) generateSpans(
 }
 
 // getMatchingRowIndices is part of the joinReaderSpanGenerator interface.
-func (g *defaultSpanGenerator) getMatchingRowIndices(key roachpb.Key) []int {
-	return g.keyToInputRowIndices[string(key)]
+func (g *defaultSpanGenerator) getMatchingRowIndices(key roachpb.Key) ([]int, error) {
+	return g.keyToInputRowIndices[string(key)], nil
 }
 
 // maxLookupCols is part of the joinReaderSpanGenerator interface.
@@ -648,14 +649,14 @@ func (g *multiSpanGenerator) generateNonNullSpans(row rowenc.EncDatumRow) (roach
 
 // findInputRowIndicesByKey does a binary search to find the span that contains
 // the given key.
-func (s *spanRowIndices) findInputRowIndicesByKey(key roachpb.Key) []int {
+func (s *spanRowIndices) findInputRowIndicesByKey(key roachpb.Key) ([]int, error) {
 	i, j := 0, s.Len()
 	for i < j {
 		h := (i + j) >> 1
 		sp := (*s)[h]
 		switch sp.span.CompareKey(key) {
 		case 0:
-			return sp.rowIndices
+			return sp.rowIndices, nil
 		case -1:
 			j = h
 		case 1:
@@ -663,7 +664,7 @@ func (s *spanRowIndices) findInputRowIndicesByKey(key roachpb.Key) []int {
 		}
 	}
 
-	return nil
+	return nil, errors.AssertionFailedf("didn't find a span containing the key %s", key)
 }
 
 // generateSpans is part of the joinReaderSpanGenerator interface.
@@ -725,11 +726,11 @@ func (g *multiSpanGenerator) generateSpans(
 }
 
 // getMatchingRowIndices is part of the joinReaderSpanGenerator interface.
-func (g *multiSpanGenerator) getMatchingRowIndices(key roachpb.Key) []int {
+func (g *multiSpanGenerator) getMatchingRowIndices(key roachpb.Key) ([]int, error) {
 	if g.inequalityColIdx != -1 {
 		return g.spanToInputRowIndices.findInputRowIndicesByKey(key)
 	}
-	return g.keyToInputRowIndices[string(key)]
+	return g.keyToInputRowIndices[string(key)], nil
 }
 
 // memUsage returns the size of the data structures in the multiSpanGenerator
@@ -831,7 +832,7 @@ func (g *localityOptimizedSpanGenerator) generateRemoteSpans(
 }
 
 // getMatchingRowIndices is part of the joinReaderSpanGenerator interface.
-func (g *localityOptimizedSpanGenerator) getMatchingRowIndices(key roachpb.Key) []int {
+func (g *localityOptimizedSpanGenerator) getMatchingRowIndices(key roachpb.Key) ([]int, error) {
 	if g.localSpanGenUsedLast {
 		return g.localSpanGen.getMatchingRowIndices(key)
 	}

--- a/pkg/sql/rowexec/joinreader_strategies.go
+++ b/pkg/sql/rowexec/joinreader_strategies.go
@@ -187,7 +187,10 @@ func (s *joinReaderNoOrderingStrategy) processLookupRows(
 func (s *joinReaderNoOrderingStrategy) processLookedUpRow(
 	_ context.Context, row rowenc.EncDatumRow, key roachpb.Key,
 ) (joinReaderState, error) {
-	matchingInputRowIndices := s.getMatchingRowIndices(key)
+	matchingInputRowIndices, err := s.getMatchingRowIndices(key)
+	if err != nil {
+		return jrStateUnknown, err
+	}
 	if s.isPartialJoin {
 		// In the case of partial joins, only process input rows that have not been
 		// matched yet. Make a copy of the matching input row indices to avoid
@@ -604,7 +607,10 @@ func (s *joinReaderOrderingStrategy) processLookupRows(
 func (s *joinReaderOrderingStrategy) processLookedUpRow(
 	ctx context.Context, row rowenc.EncDatumRow, key roachpb.Key,
 ) (joinReaderState, error) {
-	matchingInputRowIndices := s.getMatchingRowIndices(key)
+	matchingInputRowIndices, err := s.getMatchingRowIndices(key)
+	if err != nil {
+		return jrStateUnknown, err
+	}
 	var containerIdx int
 	if !s.isPartialJoin {
 		// Replace missing values with nulls to appease the row container.


### PR DESCRIPTION
**rowexec: clean up locality optimized span generator**

Previously, the locality optimized span generator would always check
whether the local span generator has any matching rows for the given
key, and if that returned nothing, then it would check the remote span
generator. This works ok because for all remotely looked up rows the
prefix of the key would be different from all prefixes of the local
spans.

However, this can be improved if we take advantage of the way the join
reader uses the lookup spans and processes the looked rows. Namely, in
case of a locality optimized search it does the following:
- generate local spans
- lookup all local spans
- process all returned rows (here we will get the matching input row
indices from the span generator)
- if some input rows didn't get a match, then generate remote spans
- lookup all remote spans
- process all returned rows (getting the matching indices again).

This outline makes it clear that the span generator is aware of what
spans (local or remote) were returned last when it is asked for the
matching row indices, so this commit makes the corresponding change.

This makes the code cleaner and avoids an unnecessary map lookup for
remotely looked up rows.

Release note: None

**execbuilder: add some tests exposing inefficiencies in lookup join spans**

This commit adds some tests that examine the trace of the lookup joins
to expose that some keys are fetched when they don't pass the inequality
filter. In other words, the tests expose that the lookup join spans are
not as tight as possible which results in unnecessary fetches.

Release note: None

**span: tighten up range based lookup spans**

This commit tightens up the spans produced for range-based lookup joins
(where we have a single inequality) in some cases. Previously, we could
lookup more rows that needed, and they would get discarded later because
the partial key for not-needed looked up rows would not be contained by
the lookup spans.

This commit makes the following adjustments:
- if we have a start datum and we want it to be excluded, then we
"advance" the datum using `Next`/`Prev`.
- we now correctly skip the nulls.

The complication is that `Next`/`Prev` are invalid for some datums (for
example, for the "max"/"min" of their type or for some types - like
decimals - altogether). In order to go around this problem the optimizer
will no longer use range-based lookups when these functions cannot be
used on the span boundary datums.

I believe this limitation is acceptable given that it effectively
disables range-based lookups and falls back to the ON expression
evaluation in very limited set of circumstances, but it will allow us to
clean up and speed up the lookup join execution in the follow-up
commits.

Release note: None