### PR TITLE
sql: generate `crdb_internal.cluster_locks` using worker and memory accounting

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -5839,9 +5839,9 @@ var crdbInternalClusterLocksTable = virtualSchemaTable{
 CREATE TABLE crdb_internal.cluster_locks (
     range_id            INT NOT NULL,
     table_id            INT NOT NULL,
-    database_name       STRING,
+    database_name       STRING NOT NULL,
     schema_name         STRING,
-    table_name          STRING,
+    table_name          STRING NOT NULL,
     index_name          STRING,
     lock_key            BYTES NOT NULL,
     lock_key_pretty     STRING NOT NULL,
@@ -5850,11 +5850,57 @@ CREATE TABLE crdb_internal.cluster_locks (
     lock_strength       STRING,
     durability          STRING,
     granted             BOOL,
-    contended           BOOL,
-    duration            INTERVAL
+    contended           BOOL NOT NULL,
+    duration            INTERVAL,
+    INDEX(table_id),
+    INDEX(database_name),
+    INDEX(table_name),
+    INDEX(contended)
 );`,
-	indexes: nil,
-	generator: func(ctx context.Context, p *planner, db catalog.DatabaseDescriptor, stopper *stop.Stopper) (virtualTableGenerator, cleanupFunc, error) {
+	indexes: []virtualIndex{
+		{
+			populate: genPopulateClusterLocksWithIndex("table_id" /* idxColumnName */, func(filters *clusterLocksFilters, idxConstraint tree.Datum) {
+				if tableID, ok := tree.AsDInt(idxConstraint); ok {
+					filters.tableID = (*int64)(&tableID)
+				}
+			}),
+		},
+		{
+			populate: genPopulateClusterLocksWithIndex("database_name" /* idxColumnName */, func(filters *clusterLocksFilters, idxConstraint tree.Datum) {
+				if dbName, ok := tree.AsDString(idxConstraint); ok {
+					filters.databaseName = (*string)(&dbName)
+				}
+			}),
+		},
+		{
+			populate: genPopulateClusterLocksWithIndex("table_name" /* idxColumnName */, func(filters *clusterLocksFilters, idxConstraint tree.Datum) {
+				if tableName, ok := tree.AsDString(idxConstraint); ok {
+					filters.tableName = (*string)(&tableName)
+				}
+			}),
+		},
+		{
+			populate: genPopulateClusterLocksWithIndex("contended" /* idxColumnName */, func(filters *clusterLocksFilters, idxConstraint tree.Datum) {
+				if contended, ok := tree.AsDBool(idxConstraint); ok {
+					filters.contended = (*bool)(&contended)
+				}
+			}),
+		},
+	},
+	generator: genClusterLocksGenerator(clusterLocksFilters{}),
+}
+
+type clusterLocksFilters struct {
+	tableID      *int64
+	databaseName *string
+	tableName    *string
+	contended    *bool
+}
+
+func genClusterLocksGenerator(
+	filters clusterLocksFilters,
+) func(ctx context.Context, p *planner, db catalog.DatabaseDescriptor, stopper *stop.Stopper) (virtualTableGenerator, cleanupFunc, error) {
+	return func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, _ *stop.Stopper) (virtualTableGenerator, cleanupFunc, error) {
 		// TODO(sarkesian): remove gate for 22.2 release
 		if !p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.ClusterLocksVirtualTable) {
 			return nil, nil, pgerror.New(pgcode.FeatureNotSupported,
@@ -5904,6 +5950,15 @@ CREATE TABLE crdb_internal.cluster_locks (
 			}
 			switch desc := desc.(type) {
 			case catalog.TableDescriptor:
+				if filters.tableName != nil && *filters.tableName != desc.GetName() {
+					continue
+				}
+				if filters.tableID != nil && descpb.ID(*filters.tableID) != desc.GetID() {
+					continue
+				}
+				if filters.databaseName != nil && *filters.databaseName != dbNames[uint32(desc.GetParentID())] {
+					continue
+				}
 				spansToQuery = append(spansToQuery, desc.TableSpan(p.execCfg.Codec))
 			}
 		}
@@ -5935,6 +5990,10 @@ CREATE TABLE crdb_internal.cluster_locks (
 				},
 				IncludeUncontended: true,
 			}
+			if filters.contended != nil && *filters.contended {
+				queryLocksRequest.IncludeUncontended = false
+			}
+
 			b.AddRawRequest(queryLocksRequest)
 
 			b.Header.MaxSpanRequestKeys = int64(rowinfra.ProductionKVBatchSize)
@@ -6072,5 +6131,47 @@ CREATE TABLE crdb_internal.cluster_locks (
 			}, nil
 
 		}, nil, nil
-	},
+	}
+}
+
+func genPopulateClusterLocksWithIndex(
+	idxColumnName string, setFilters func(filters *clusterLocksFilters, idxConstraint tree.Datum),
+) func(context.Context, tree.Datum, *planner, catalog.DatabaseDescriptor, func(...tree.Datum) error) (bool, error) {
+	return func(ctx context.Context, idxConstraint tree.Datum, p *planner, db catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) (matched bool, err error) {
+		var filters clusterLocksFilters
+		setFilters(&filters, idxConstraint)
+
+		if filters.tableID == nil && filters.databaseName == nil && filters.tableName == nil && filters.contended == nil {
+			return false, errors.AssertionFailedf("unexpected type %T for %s column in virtual table crdb_internal.cluster_locks", idxConstraint, idxColumnName)
+		}
+
+		return populateClusterLocksWithFilter(ctx, p, db, addRow, filters)
+	}
+}
+
+func populateClusterLocksWithFilter(
+	ctx context.Context,
+	p *planner,
+	db catalog.DatabaseDescriptor,
+	addRow func(...tree.Datum) error,
+	filters clusterLocksFilters,
+) (matched bool, err error) {
+	var rowGenerator virtualTableGenerator
+	generator := genClusterLocksGenerator(filters)
+	rowGenerator, _, err = generator(ctx, p, db, nil /* stopper */)
+	if err != nil {
+		return false, err
+	}
+	var row tree.Datums
+	row, err = rowGenerator()
+	for row != nil && err == nil {
+		err = addRow(row...)
+		if err != nil {
+			break
+		}
+		matched = true
+
+		row, err = rowGenerator()
+	}
+	return matched, err
 }

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -5889,7 +5889,10 @@ CREATE TABLE crdb_internal.cluster_locks (
 	},
 	generator: func(ctx context.Context, p *planner, db catalog.DatabaseDescriptor, stopper *stop.Stopper) (virtualTableGenerator, cleanupFunc, error) {
 		worker := func(wCtx context.Context, pusher rowPusher) error {
-			nextRow, err := clusterLocksTableGenerator(wCtx, p, clusterLocksFilters{})
+			acct := p.EvalContext().Mon.MakeBoundAccount()
+			defer acct.Close(wCtx)
+
+			nextRow, err := clusterLocksTableGenerator(wCtx, p, &acct, clusterLocksFilters{})
 			if err != nil {
 				return err
 			}
@@ -5920,7 +5923,7 @@ type clusterLocksFilters struct {
 }
 
 func clusterLocksTableGenerator(
-	ctx context.Context, p *planner, filters clusterLocksFilters,
+	ctx context.Context, p *planner, acct *mon.BoundAccount, filters clusterLocksFilters,
 ) (virtualTableGenerator, error) {
 	// TODO(sarkesian): remove gate for 22.2 release
 	if !p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.ClusterLocksVirtualTable) {
@@ -6020,6 +6023,10 @@ func clusterLocksTableGenerator(
 		b.Header.MaxSpanRequestKeys = int64(rowinfra.ProductionKVBatchSize)
 		b.Header.TargetBytes = int64(rowinfra.GetDefaultBatchBytesLimit(p.extendedEvalCtx.TestingKnobs.ForceProductionValues))
 
+		if resp != nil && resp.Size() > 0 {
+			acct.Shrink(ctx, int64(resp.Size()))
+		}
+
 		err := p.txn.Run(ctx, &b)
 		if err != nil {
 			return err
@@ -6034,6 +6041,11 @@ func clusterLocksTableGenerator(
 		resp = b.RawResponse().Responses[0].GetQueryLocks()
 		locks = resp.Locks
 		resumeSpan = resp.ResumeSpan
+
+		if err = acct.Grow(ctx, int64(resp.Size())); err != nil {
+			return err
+		}
+
 		return nil
 	}
 
@@ -6173,8 +6185,11 @@ func genPopulateClusterLocksWithIndex(
 func populateClusterLocksWithFilter(
 	ctx context.Context, p *planner, addRow func(...tree.Datum) error, filters clusterLocksFilters,
 ) (matched bool, err error) {
+	acct := p.EvalContext().Mon.MakeBoundAccount()
+	defer acct.Close(ctx)
+
 	var nextRow virtualTableGenerator
-	nextRow, err = clusterLocksTableGenerator(ctx, p, filters)
+	nextRow, err = clusterLocksTableGenerator(ctx, p, &acct, filters)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/cluster_locks
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_locks
@@ -145,6 +145,35 @@ test          public      t           ·                   Exclusive       Repli
 
 user root
 
+query TTTTTTBB colnames,retry
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, granted, contended FROM crdb_internal.cluster_locks WHERE database_name='test'
+----
+database_name schema_name table_name  lock_key_pretty     lock_strength   durability    granted contended
+test          public      t           /Table/106/1/"b"/0  Exclusive       Replicated    true    true
+test          public      t           /Table/106/1/"b"/0  None            Replicated    false   true
+test          public      t           /Table/106/1/"c"/0  Exclusive       Replicated    true    false
+
+query TTTTTTBB colnames,retry
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, granted, contended FROM crdb_internal.cluster_locks WHERE table_id='t'::regclass::oid::int
+----
+database_name schema_name table_name  lock_key_pretty     lock_strength   durability    granted contended
+test          public      t           /Table/106/1/"b"/0  Exclusive       Replicated    true    true
+test          public      t           /Table/106/1/"b"/0  None            Replicated    false   true
+test          public      t           /Table/106/1/"c"/0  Exclusive       Replicated    true    false
+
+query TTTTTTBB colnames,retry
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, granted, contended FROM crdb_internal.cluster_locks WHERE contended=true
+----
+database_name schema_name table_name  lock_key_pretty     lock_strength   durability    granted contended
+test          public      t           /Table/106/1/"b"/0  Exclusive       Replicated    true    true
+test          public      t           /Table/106/1/"b"/0  None            Replicated    false   true
+
+query TTTTTTBB colnames,retry
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, granted, contended FROM crdb_internal.cluster_locks WHERE contended=false
+----
+database_name schema_name table_name  lock_key_pretty     lock_strength   durability    granted contended
+test          public      t           /Table/106/1/"c"/0  Exclusive       Replicated    true    false
+
 query I
 SELECT count(*) FROM crdb_internal.cluster_locks WHERE table_name = 't'
 ----

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -253,9 +253,9 @@ CREATE TABLE crdb_internal.cluster_inflight_traces (
 CREATE TABLE crdb_internal.cluster_locks (
    range_id INT8 NOT NULL,
    table_id INT8 NOT NULL,
-   database_name STRING NULL,
+   database_name STRING NOT NULL,
    schema_name STRING NULL,
-   table_name STRING NULL,
+   table_name STRING NOT NULL,
    index_name STRING NULL,
    lock_key BYTES NOT NULL,
    lock_key_pretty STRING NOT NULL,
@@ -264,14 +264,18 @@ CREATE TABLE crdb_internal.cluster_locks (
    lock_strength STRING NULL,
    durability STRING NULL,
    granted BOOL NULL,
-   contended BOOL NULL,
-   duration INTERVAL NULL
+   contended BOOL NOT NULL,
+   duration INTERVAL NULL,
+   INDEX cluster_locks_table_id_idx (table_id ASC) STORING (range_id, database_name, schema_name, table_name, index_name, lock_key, lock_key_pretty, txn_id, ts, lock_strength, durability, granted, contended, duration),
+   INDEX cluster_locks_database_name_idx (database_name ASC) STORING (range_id, table_id, schema_name, table_name, index_name, lock_key, lock_key_pretty, txn_id, ts, lock_strength, durability, granted, contended, duration),
+   INDEX cluster_locks_table_name_idx (table_name ASC) STORING (range_id, table_id, database_name, schema_name, index_name, lock_key, lock_key_pretty, txn_id, ts, lock_strength, durability, granted, contended, duration),
+   INDEX cluster_locks_contended_idx (contended ASC) STORING (range_id, table_id, database_name, schema_name, table_name, index_name, lock_key, lock_key_pretty, txn_id, ts, lock_strength, durability, granted, duration)
 )  CREATE TABLE crdb_internal.cluster_locks (
    range_id INT8 NOT NULL,
    table_id INT8 NOT NULL,
-   database_name STRING NULL,
+   database_name STRING NOT NULL,
    schema_name STRING NULL,
-   table_name STRING NULL,
+   table_name STRING NOT NULL,
    index_name STRING NULL,
    lock_key BYTES NOT NULL,
    lock_key_pretty STRING NOT NULL,
@@ -280,8 +284,12 @@ CREATE TABLE crdb_internal.cluster_locks (
    lock_strength STRING NULL,
    durability STRING NULL,
    granted BOOL NULL,
-   contended BOOL NULL,
-   duration INTERVAL NULL
+   contended BOOL NOT NULL,
+   duration INTERVAL NULL,
+   INDEX cluster_locks_table_id_idx (table_id ASC) STORING (range_id, database_name, schema_name, table_name, index_name, lock_key, lock_key_pretty, txn_id, ts, lock_strength, durability, granted, contended, duration),
+   INDEX cluster_locks_database_name_idx (database_name ASC) STORING (range_id, table_id, schema_name, table_name, index_name, lock_key, lock_key_pretty, txn_id, ts, lock_strength, durability, granted, contended, duration),
+   INDEX cluster_locks_table_name_idx (table_name ASC) STORING (range_id, table_id, database_name, schema_name, index_name, lock_key, lock_key_pretty, txn_id, ts, lock_strength, durability, granted, contended, duration),
+   INDEX cluster_locks_contended_idx (contended ASC) STORING (range_id, table_id, database_name, schema_name, table_name, index_name, lock_key, lock_key_pretty, txn_id, ts, lock_strength, durability, granted, duration)
 )  {}  {}
 CREATE TABLE crdb_internal.cluster_queries (
    query_id STRING NULL,

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -232,6 +232,38 @@ func (t virtualSchemaTable) isUnimplemented() bool {
 	return t.unimplemented
 }
 
+// preferIndexOverGenerator defines the cases in which we are able to use a
+// virtual index's populate function when we have a virtual table defined with
+// a generator function instead of a populate function. Specifically, use of a
+// virtual index is supported when we have only single key constraints, and are
+// not using a partial index, and therefore do not need to fallback on an
+// undefined populate function.
+func (t virtualSchemaTable) preferIndexOverGenerator(
+	p *planner, index catalog.Index, idxConstraint *constraint.Constraint,
+) bool {
+	if idxConstraint == nil || idxConstraint.IsUnconstrained() {
+		return false
+	}
+
+	if index.GetID() == 1 {
+		return false
+	}
+
+	virtualIdx := t.getIndex(index.GetID())
+	if virtualIdx.partial {
+		return false
+	}
+
+	for i := 0; i < idxConstraint.Spans.Count(); i++ {
+		constraintSpan := idxConstraint.Spans.Get(i)
+		if !constraintSpan.HasSingleKey(p.EvalContext()) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // getSchema is part of the virtualSchemaDef interface.
 func (v virtualSchemaView) getSchema() string {
 	return v.schema
@@ -526,7 +558,7 @@ func (e *virtualDefEntry) getPlanInfo(
 				return nil, newInvalidVirtualSchemaError()
 			}
 
-			if def.generator != nil {
+			if def.generator != nil && !def.preferIndexOverGenerator(p, index, idxConstraint) {
 				next, cleanup, err := def.generator(ctx, p, dbDesc, stopper)
 				if err != nil {
 					return nil, err
@@ -664,6 +696,13 @@ func (e *virtualDefEntry) makeConstrainedRowsGenerator(
 		newConstraint.Spans.Alloc(nSpans)
 		for ; currentSpan < idxConstraint.Spans.Count(); currentSpan++ {
 			newConstraint.Spans.Append(idxConstraint.Spans.Get(currentSpan))
+		}
+
+		// NB: If we allow virtualSchemaTables with generator to perform a constrained scan,
+		// we then need to ensure that we don't call populate without checking, as it may be nil.
+		if def.populate == nil {
+			return errors.AssertionFailedf(
+				"programming error: can't fall back to unconstrained scan on generated vtables")
 		}
 		return def.populate(ctx, p, dbDesc, addRowIfPassesFilter(&newConstraint))
 	}


### PR DESCRIPTION
**sql: convert `crdb_internal.cluster_locks` virtual table to use worker**

This change updates the generator for the `crdb_internal.cluster_locks`
virtual table to be able to wrap it in a worker Goroutine by calling
`setupGenerator`. While previously the virtual table generator did not
run in a separate Goroutine, wrapping it as a worker running in a
separate Goroutine allows for cancellation during table generation,
eliminating potentially unnecessary RPCs. This follows the pattern set
by other virtual tables within `crb_internal`.

**sql: account for memory used in generating `crdb_internal.cluster_locks`**

This change adds memory monitoring to the memory used in generating the
virtual table `crdb_internal.cluster_locks`. Utilizing the
`BoundAccount` as part of the planner's `EvalContext`, it accounts for
the memory used by the `QueryLocksResponse` returned from the RPC fanout
needed to generate the table. As such, if the memory budget allocated
has been reached, the call to `acct.Grow()` will be denied and return an
error that will stop row generation, thus ensuring that the memory used
in the generation of this table will not cause memory exhaustion.

Release justification: Minor improvements.

Depends on #77876, #80422, #79623