### PR TITLE
roachtest: roachstress.sh uses bazel build

### DIFF
--- a/pkg/cmd/roachtest/roachstress.sh
+++ b/pkg/cmd/roachtest/roachstress.sh
@@ -20,7 +20,7 @@ function help {
   cat <<EOF
 Build and stress run roachtest
 Usage:
-  $(basename ${0}) [flags] <test name> [-- <roachtest flags>]
+  $(basename "${0}") [flags] <test name> [-- <roachtest flags>]
 
 flags:
   -c COUNT - number of test iterations to run
@@ -46,7 +46,7 @@ function fail {
 
 # Process command line flags
 force_build=
-short=short
+short=-short
 local=
 count=10
 while getopts ":c:lubh" o ; do
@@ -137,24 +137,24 @@ a="${abase}/$(date '+%H%M%S')"
 
 if [ ! -f "${cr}" ] || [ "${force_build}" = "y" ]; then
   if [ -z "${local}" ]; then
-    ./build/builder.sh mkrelease amd64-linux-gnu "build${short}"
-    cp "cockroach${short}-linux-2.6.32-gnu-amd64" "${cr}"
+    ./dev build "cockroach${short}" --cross=linux
+    cp "artifacts/cockroach${artifact_suffix}" "${cr}"
   else
-    make "build${short}"
+    ./dev build "cockroach${short}"
     cp "cockroach${short}" "${cr}"
   fi
 fi
 
 if [ ! -f "${wl}" ] || [ "${force_build}" = "y" ]; then
   if [ -z "${local}" ]; then
-    ./build/builder.sh mkrelease amd64-linux-gnu bin/workload
-    cp bin.docker_amd64/workload "${wl}"
+    ./dev build workload --cross=linux
+    cp "artifacts/workload" "${wl}"
   else
-    make bin/workload
-    cp bin/workload "${wl}"
+    ./dev build workload
+    cp "bin/workload" "${wl}"
   fi
-  make bin/roachtest
-  cp bin/roachtest "${rt}"
+  ./dev build roachtest
+  cp "bin/roachtest" "${rt}"
 fi
 
 # Creation of test data directory is deferred here to avoid spamming in
@@ -175,7 +175,7 @@ if [ -n "${local}" ]; then
 fi
 args+=("$@")
 
-echo "Running ${rt} ${args[@]}"
+echo "Running ${rt} " "${args[@]}"
 # Run roachtest. Use a random port so that multiple
 # tests can be stressed from the same workstation.
 "${rt}" "${args[@]}"


### PR DESCRIPTION
Previously roachteststress.sh was using make to build artifacts
prior to stressing. Since make build is being removed, this is
not good anymore.
This patch changes build to use bazel.

Release note: None