### PR TITLE
workload: prefer import data loader if possible

### DIFF
--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -342,12 +342,10 @@ func ImportFixture(
 	injectStats bool,
 	csvServer string,
 ) (int64, error) {
-	for _, t := range gen.Tables() {
-		if t.InitialRows.FillBatch == nil {
-			return 0, errors.Errorf(
-				`import fixture is not supported for workload %s`, gen.Meta().Name,
-			)
-		}
+	if !workload.SupportsFixtures(gen) {
+		return 0, errors.Errorf(
+			`import fixture is not supported for workload %s`, gen.Meta().Name,
+		)
 	}
 
 	var numNodes int

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -44,6 +44,17 @@ type Generator interface {
 	Tables() []Table
 }
 
+// SupportsFixtures returns whether the Generator supports initialization
+// via fixtures.
+func SupportsFixtures(gen Generator) bool {
+	for _, t := range gen.Tables() {
+		if t.InitialRows.FillBatch == nil {
+			return false
+		}
+	}
+	return true
+}
+
 // FlagMeta is metadata about a workload flag.
 type FlagMeta struct {
 	// RuntimeOnly may be set to true only if the corresponding flag has no


### PR DESCRIPTION
Import is always going to be faster than INSERT in terms of loading
appreciable amounts of data. Yet, the `--data-loader` flag defaulted to
`INSERT`, likely because not all workloads (e.g. `kv`) support `IMPORT` and
error out. At the same time, it was hard for users to realize a faster option
was available when it was (e.g. for `tpcc`).

Add a flag value `AUTO` that uses `IMPORT` if available and `INSERT`
otherwise.

Release note: None
