### PR TITLE
kvserver: export bytes read/written from reqs

### DIFF
--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -312,6 +312,18 @@ var (
 		Measurement: "Keys/Sec",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaAverageWriteBytesPerSecond = metric.Metadata{
+		Name:        "rebalancing.writebytespersecond",
+		Help:        "Average number of bytes read recently per second.",
+		Measurement: "Bytes/Sec",
+		Unit:        metric.Unit_BYTES,
+	}
+	metaAverageReadBytesPerSecond = metric.Metadata{
+		Name:        "rebalancing.readbytespersecond",
+		Help:        "Average number of bytes written recently per second.",
+		Measurement: "Bytes/Sec",
+		Unit:        metric.Unit_BYTES,
+	}
 
 	// Metric for tracking follower reads.
 	metaFollowerReadsCount = metric.Metadata{
@@ -1390,11 +1402,13 @@ type StoreMetrics struct {
 	Reserved           *metric.Gauge
 
 	// Rebalancing metrics.
-	L0SubLevelsHistogram     *metric.Histogram
-	AverageQueriesPerSecond  *metric.GaugeFloat64
-	AverageWritesPerSecond   *metric.GaugeFloat64
-	AverageReadsPerSecond    *metric.GaugeFloat64
-	AverageRequestsPerSecond *metric.GaugeFloat64
+	L0SubLevelsHistogram       *metric.Histogram
+	AverageQueriesPerSecond    *metric.GaugeFloat64
+	AverageWritesPerSecond     *metric.GaugeFloat64
+	AverageReadsPerSecond      *metric.GaugeFloat64
+	AverageRequestsPerSecond   *metric.GaugeFloat64
+	AverageWriteBytesPerSecond *metric.GaugeFloat64
+	AverageReadBytesPerSecond  *metric.GaugeFloat64
 
 	// Follower read metrics.
 	FollowerReadsCount *metric.Counter
@@ -1848,8 +1862,10 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 			allocatorimpl.L0SublevelMaxSampled,
 			1, /* sig figures (integer) */
 		),
-		AverageRequestsPerSecond: metric.NewGaugeFloat64(metaAverageRequestsPerSecond),
-		AverageReadsPerSecond:    metric.NewGaugeFloat64(metaAverageReadsPerSecond),
+		AverageRequestsPerSecond:   metric.NewGaugeFloat64(metaAverageRequestsPerSecond),
+		AverageReadsPerSecond:      metric.NewGaugeFloat64(metaAverageReadsPerSecond),
+		AverageWriteBytesPerSecond: metric.NewGaugeFloat64(metaAverageWriteBytesPerSecond),
+		AverageReadBytesPerSecond:  metric.NewGaugeFloat64(metaAverageReadBytesPerSecond),
 
 		// Follower reads metrics.
 		FollowerReadsCount: metric.NewCounter(metaFollowerReadsCount),

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3093,6 +3093,8 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 		averageRequestsPerSecond      float64
 		averageReadsPerSecond         float64
 		averageWritesPerSecond        float64
+		averageReadBytesPerSecond     float64
+		averageWriteBytesPerSecond    float64
 
 		rangeCount                int64
 		unavailableRangeCount     int64
@@ -3170,6 +3172,12 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 		if rps, dur := rep.loadStats.readKeys.AverageRatePerSecond(); dur >= replicastats.MinStatsDuration {
 			averageReadsPerSecond += rps
 		}
+		if rbps, dur := rep.loadStats.readBytes.AverageRatePerSecond(); dur >= replicastats.MinStatsDuration {
+			averageReadBytesPerSecond += rbps
+		}
+		if wbps, dur := rep.loadStats.writeBytes.AverageRatePerSecond(); dur >= replicastats.MinStatsDuration {
+			averageWriteBytesPerSecond += wbps
+		}
 		locks += metrics.LockTableMetrics.Locks
 		totalLockHoldDurationNanos += metrics.LockTableMetrics.TotalLockHoldDurationNanos
 		locksWithWaitQueues += metrics.LockTableMetrics.LocksWithWaitQueues
@@ -3202,6 +3210,8 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 	s.metrics.AverageRequestsPerSecond.Update(averageRequestsPerSecond)
 	s.metrics.AverageWritesPerSecond.Update(averageWritesPerSecond)
 	s.metrics.AverageReadsPerSecond.Update(averageReadsPerSecond)
+	s.metrics.AverageReadBytesPerSecond.Update(averageReadBytesPerSecond)
+	s.metrics.AverageWriteBytesPerSecond.Update(averageWriteBytesPerSecond)
 	s.recordNewPerSecondStats(averageQueriesPerSecond, averageWritesPerSecond)
 
 	s.metrics.RangeCount.Update(rangeCount)

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -654,6 +654,14 @@ var charts = []sectionDescription{
 				Title:   "Keys Read Per Second",
 				Metrics: []string{"rebalancing.readspersecond"},
 			},
+			{
+				Title:   "Bytes Read Per Second",
+				Metrics: []string{"rebalancing.readbytespersecond"},
+			},
+			{
+				Title:   "Bytes Written Per Second",
+				Metrics: []string{"rebalancing.writebytespersecond"},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
We currently export timeseries metrics on system IO (net/disk). This
patch introduces bytes read per second and bytes written per second
attributable to request evaluations. These are aggregated from request
evaluations per replica.

resolves: https://github.com/cockroachdb/cockroach/issues/80240

Release note (ops): Add `rebalancing.writebytespersecond` and
`rebalancing.readbytespersecond` timeseries metrics. These metrics
reflect the average number of bytes written and read across all replicas
per store, over the last 30 minutes of time.