### PR TITLE
changefeedccl: refactor to stop passing around untyped string maps

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -18,6 +18,7 @@ ALL_TESTS = [
     "//pkg/ccl/changefeedccl/cdcevent:cdcevent_test",
     "//pkg/ccl/changefeedccl/cdctest:cdctest_test",
     "//pkg/ccl/changefeedccl/cdcutils:cdcutils_test",
+    "//pkg/ccl/changefeedccl/changefeedbase:changefeedbase_test",
     "//pkg/ccl/changefeedccl/kvevent:kvevent_test",
     "//pkg/ccl/changefeedccl/kvfeed:kvfeed_test",
     "//pkg/ccl/changefeedccl/schemafeed:schemafeed_test",

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
         "//pkg/ccl/changefeedccl/cdcutils",
         "//pkg/ccl/changefeedccl/changefeedbase",
         "//pkg/ccl/changefeedccl/changefeeddist",
+        "//pkg/ccl/changefeedccl/changefeedvalidators",
         "//pkg/ccl/changefeedccl/kvevent",
         "//pkg/ccl/changefeedccl/kvfeed",
         "//pkg/ccl/changefeedccl/schemafeed",

--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -774,15 +774,6 @@ func tableToAvroSchema(
 	return newSchemaForRow(row.ForEachColumn(), sqlName, namespace)
 }
 
-// textualFromRow encodes the given row data into avro's defined JSON format.
-func (r *avroDataRecord) textualFromRow(row cdcevent.Row) ([]byte, error) {
-	native, err := r.nativeFromRow(row.ForEachColumn())
-	if err != nil {
-		return nil, err
-	}
-	return r.codec.TextualFromNative(nil /* buf */, native)
-}
-
 // BinaryFromRow encodes the given row data into avro's defined binary format.
 func (r *avroDataRecord) BinaryFromRow(buf []byte, it cdcevent.Iterator) ([]byte, error) {
 	native, err := r.nativeFromRow(it)
@@ -802,6 +793,15 @@ func (r *avroDataRecord) rowFromTextual(buf []byte) (rowenc.EncDatumRow, error) 
 		return nil, errors.New(`only one row was expected`)
 	}
 	return r.rowFromNative(native)
+}
+
+// textualFromRow encodes the given row data into avro's defined JSON format.
+func (r *avroDataRecord) textualFromRow(row cdcevent.Row) ([]byte, error) {
+	native, err := r.nativeFromRow(row.ForEachColumn())
+	if err != nil {
+		return nil, err
+	}
+	return r.codec.TextualFromNative(nil /* buf */, native)
 }
 
 // RowFromBinary decodes the given row data from avro's defined binary format.

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcevent"
-	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -166,7 +165,7 @@ func parseAvroSchema(t *testing.T, j string) (*avroDataRecord, error) {
 	return tableToAvroSchema(
 		cdcevent.TestingMakeEventRow(
 			tabledesc.NewBuilder(&tableDesc).BuildImmutableTable(), 0, nil, false,
-		), "", string(changefeedbase.OptVirtualColumnsOmitted))
+		), "", "")
 }
 
 func avroFieldMetadataToColDesc(metadata string) (*descpb.ColumnDescriptor, error) {
@@ -664,13 +663,13 @@ func TestAvroSchema(t *testing.T) {
 			schema, err := tableToAvroSchema(
 				row, avroSchemaNoSuffix, "")
 			require.NoError(t, err)
-			textual, err := schema.textualFromRow(row)
 			if test.numRawBytes > 0 {
 				overhead := 4
 				binary, err := schema.BinaryFromRow(make([]byte, 0, test.numRawBytes+20), row.ForEachColumn())
 				require.NoError(t, err)
 				require.Equal(t, test.numRawBytes, len(binary)-overhead)
 			}
+			textual, err := schema.textualFromRow(row)
 			require.NoError(t, err)
 			// Trim the outermost {}.
 			value := string(textual[1 : len(textual)-1])

--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -205,15 +205,11 @@ func createBenchmarkChangefeed(
 	tableDesc := desctestutils.TestingGetPublicTableDescriptor(s.DB(), keys.SystemSQLCodec, database, table)
 	spans := []roachpb.Span{tableDesc.PrimaryIndexSpan(keys.SystemSQLCodec)}
 	details := jobspb.ChangefeedDetails{
-		Tables: jobspb.ChangefeedTargets{tableDesc.GetID(): jobspb.ChangefeedTargetTable{
-			StatementTimeName: tableDesc.GetName(),
-		}},
-		Opts: map[string]string{
-			changefeedbase.OptEnvelope: string(changefeedbase.OptEnvelopeRow),
-		},
+		Tables: jobspb.ChangefeedTargets{tableDesc.GetID(): jobspb.ChangefeedTargetTable{StatementTimeName: tableDesc.GetName()}},
 	}
 	initialHighWater := hlc.Timestamp{}
-	encoder, err := makeJSONEncoder(details.Opts, AllTargets(details))
+	encodingOpts := changefeedbase.EncodingOptions{Format: changefeedbase.OptFormatJSON, Envelope: changefeedbase.OptEnvelopeRow}
+	encoder, err := makeJSONEncoder(encodingOpts, AllTargets(details))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -230,7 +226,6 @@ func createBenchmarkChangefeed(
 	if needsInitialScan {
 		initialHighWater = details.StatementTime
 	}
-	_, withDiff := details.Opts[changefeedbase.OptDiff]
 	kvfeedCfg := kvfeed.Config{
 		Settings:         settings,
 		DB:               s.DB(),
@@ -242,7 +237,7 @@ func createBenchmarkChangefeed(
 		Metrics:          &metrics.KVFeedMetrics,
 		MM:               mm,
 		InitialHighWater: initialHighWater,
-		WithDiff:         withDiff,
+		WithDiff:         false,
 		NeedsInitialScan: needsInitialScan,
 		SchemaFeed:       schemafeed.DoNothingSchemaFeed,
 	}

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -162,12 +162,18 @@ func newChangeAggregatorProcessor(
 		return nil, err
 	}
 
+	opts := changefeedbase.MakeStatementOptions(ca.spec.Feed.Opts)
+
 	var err error
-	if ca.encoder, err = getEncoder(ca.spec.Feed.Opts, AllTargets(ca.spec.Feed)); err != nil {
+	encodingOpts, err := opts.GetEncodingOptions()
+	if err != nil {
+		return nil, err
+	}
+	if ca.encoder, err = getEncoder(encodingOpts, AllTargets(ca.spec.Feed)); err != nil {
 		return nil, err
 	}
 
-	if _, needTopics := ca.spec.Feed.Opts[changefeedbase.OptTopicInValue]; needTopics {
+	if encodingOpts.TopicInValue {
 		ca.topicNamer, err = MakeTopicNamer(AllTargets(ca.spec.Feed))
 		if err != nil {
 			return nil, err
@@ -189,11 +195,12 @@ func newChangeAggregatorProcessor(
 	// not changing), then this is sufficient and we don't have to do anything
 	// fancy with timers.
 	// // TODO(casper): add test for OptMinCheckpointFrequency.
-	if r, ok := ca.spec.Feed.Opts[changefeedbase.OptMinCheckpointFrequency]; ok && r != `` {
-		ca.flushFrequency, err = time.ParseDuration(r)
-		if err != nil {
-			return nil, err
-		}
+	checkpointFreq, err := opts.GetMinCheckpointFrequency()
+	if err != nil {
+		return nil, err
+	}
+	if checkpointFreq != nil {
+		ca.flushFrequency = *checkpointFreq
 	} else {
 		ca.flushFrequency = changefeedbase.DefaultMinCheckpointFrequency
 	}
@@ -219,6 +226,7 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 	spans, err := ca.setupSpansAndFrontier()
 
 	endTime := ca.spec.Feed.EndTime
+	opts := changefeedbase.MakeStatementOptions(ca.spec.Feed.Opts)
 
 	if err != nil {
 		ca.MoveToDraining(err)
@@ -249,7 +257,8 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 	// runs. They're all stored as the `metric.Struct` interface because of
 	// dependency cycles.
 	ca.metrics = ca.flowCtx.Cfg.JobRegistry.MetricsStruct().Changefeed.(*Metrics)
-	ca.sliMetrics, err = ca.metrics.getSLIMetrics(ca.spec.Feed.Opts[changefeedbase.OptMetricsScope])
+	scope, _ := opts.GetMetricScope()
+	ca.sliMetrics, err = ca.metrics.getSLIMetrics(scope)
 	if err != nil {
 		ca.MoveToDraining(err)
 		ca.cancel()
@@ -320,7 +329,10 @@ func (ca *changeAggregator) startKVFeed(
 
 	// KVFeed takes ownership of the kvevent.Writer portion of the buffer, while
 	// we return the kvevent.Reader part to the caller.
-	kvfeedCfg := ca.makeKVFeedCfg(ctx, spans, buf, initialHighWater, needsInitialScan, endTime)
+	kvfeedCfg, err := ca.makeKVFeedCfg(ctx, spans, buf, initialHighWater, needsInitialScan, endTime)
+	if err != nil {
+		return nil, err
+	}
 
 	// Give errCh enough buffer both possible errors from supporting goroutines,
 	// but only the first one is ever used.
@@ -352,23 +364,24 @@ func (ca *changeAggregator) makeKVFeedCfg(
 	initialHighWater hlc.Timestamp,
 	needsInitialScan bool,
 	endTime hlc.Timestamp,
-) kvfeed.Config {
-	schemaChangeEvents := changefeedbase.SchemaChangeEventClass(
-		ca.spec.Feed.Opts[changefeedbase.OptSchemaChangeEvents])
-	schemaChangePolicy := changefeedbase.SchemaChangePolicy(
-		ca.spec.Feed.Opts[changefeedbase.OptSchemaChangePolicy])
-	_, withDiff := ca.spec.Feed.Opts[changefeedbase.OptDiff]
+) (kvfeed.Config, error) {
+	opts := changefeedbase.MakeStatementOptions(ca.spec.Feed.Opts)
+	schemaChange, err := opts.GetSchemaChangeHandlingOptions()
+	if err != nil {
+		return kvfeed.Config{}, err
+	}
+	filters := opts.GetFilters()
 	cfg := ca.flowCtx.Cfg
 
 	var sf schemafeed.SchemaFeed
 
 	initialScanOnly := endTime.EqOrdering(initialHighWater)
 
-	if schemaChangePolicy == changefeedbase.OptSchemaChangePolicyIgnore || initialScanOnly {
+	if schemaChange.Policy == changefeedbase.OptSchemaChangePolicyIgnore || initialScanOnly {
 		sf = schemafeed.DoNothingSchemaFeed
 	} else {
-		sf = schemafeed.New(ctx, cfg, schemaChangeEvents, AllTargets(ca.spec.Feed),
-			initialHighWater, &ca.metrics.SchemaFeedMetrics, ca.spec.Feed.Opts)
+		sf = schemafeed.New(ctx, cfg, schemaChange.EventClass, AllTargets(ca.spec.Feed),
+			initialHighWater, &ca.metrics.SchemaFeedMetrics, opts.GetCanHandle())
 	}
 
 	return kvfeed.Config{
@@ -388,13 +401,13 @@ func (ca *changeAggregator) makeKVFeedCfg(
 		MM:                      ca.kvFeedMemMon,
 		InitialHighWater:        initialHighWater,
 		EndTime:                 endTime,
-		WithDiff:                withDiff,
+		WithDiff:                filters.WithDiff,
 		NeedsInitialScan:        needsInitialScan,
-		SchemaChangeEvents:      schemaChangeEvents,
-		SchemaChangePolicy:      schemaChangePolicy,
+		SchemaChangeEvents:      schemaChange.EventClass,
+		SchemaChangePolicy:      schemaChange.Policy,
 		SchemaFeed:              sf,
 		Knobs:                   ca.knobs.FeedKnobs,
-	}
+	}, nil
 }
 
 // setupSpans is called on start to extract the spans for this changefeed as a
@@ -843,20 +856,28 @@ func newChangeFrontierProcessor(
 	); err != nil {
 		return nil, err
 	}
+	opts := changefeedbase.MakeStatementOptions(cf.spec.Feed.Opts)
 
-	if r, ok := cf.spec.Feed.Opts[changefeedbase.OptResolvedTimestamps]; ok {
-		var err error
-		if r == `` {
+	freq, emitResolved, err := opts.GetResolvedTimestampInterval()
+	if err != nil {
+		return nil, err
+	}
+	if emitResolved {
+		if freq == nil {
 			// Empty means emit them as often as we have them.
 			cf.freqEmitResolved = emitAllResolved
-		} else if cf.freqEmitResolved, err = time.ParseDuration(r); err != nil {
-			return nil, err
+		} else {
+			cf.freqEmitResolved = *freq
 		}
 	} else {
 		cf.freqEmitResolved = emitNoResolved
 	}
 
-	if cf.encoder, err = getEncoder(spec.Feed.Opts, AllTargets(spec.Feed)); err != nil {
+	encodingOpts, err := opts.GetEncodingOptions()
+	if err != nil {
+		return nil, err
+	}
+	if cf.encoder, err = getEncoder(encodingOpts, AllTargets(spec.Feed)); err != nil {
 		return nil, err
 	}
 

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupresolver"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedvalidators"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/docs"
@@ -129,8 +130,7 @@ func changefeedPlanHook(
 		}
 	}
 
-	// TODO: We're passing around the full output of optsFn a lot, make it a type.
-	optsFn, err := p.TypeAsStringOpts(ctx, changefeedStmt.Options, changefeedbase.ChangefeedOptionExpectValues)
+	optsFn, err := p.TypeAsStringOpts(ctx, changefeedStmt.Options, changefeedvalidators.CreateOptionValidations)
 	if err != nil {
 		return nil, nil, nil, false, err
 	}
@@ -155,10 +155,11 @@ func changefeedPlanHook(
 			return errors.New(`omit the SINK clause for inline results`)
 		}
 
-		opts, err := optsFn()
+		rawOpts, err := optsFn()
 		if err != nil {
 			return err
 		}
+		opts := changefeedbase.MakeStatementOptions(rawOpts)
 
 		jr, err := createChangefeedJobRecord(
 			ctx,
@@ -216,7 +217,7 @@ func changefeedPlanHook(
 			codec := p.ExecCfg().Codec
 
 			activeTimestampProtection := changefeedbase.ActiveProtectedTimestampsEnabled.Get(&p.ExecCfg().Settings.SV)
-			initialScanType, err := initialScanTypeFromOpts(details.Opts)
+			initialScanType, err := opts.GetInitialScanType()
 			if err != nil {
 				return err
 			}
@@ -277,33 +278,18 @@ func createChangefeedJobRecord(
 	p sql.PlanHookState,
 	changefeedStmt *annotatedChangefeedStatement,
 	sinkURI string,
-	opts map[string]string,
+	opts changefeedbase.StatementOptions,
 	jobID jobspb.JobID,
 	telemetryPath string,
 ) (*jobs.Record, error) {
 	unspecifiedSink := changefeedStmt.SinkURI == nil
 
-	for key, value := range opts {
-		if clusterVersion, ok := changefeedbase.VersionGateOptions[key]; ok {
-			if !p.ExecCfg().Settings.Version.IsActive(ctx, clusterVersion) {
-				return nil, errors.Newf(
-					`option %s is not supported until upgrade to version %s or higher is finalized`,
-					key, clusterVersion.String(),
-				)
-			}
-		}
-		// if option is case insensitive then convert its value to lower case
-		if _, ok := changefeedbase.CaseInsensitiveOpts[key]; ok {
-			opts[key] = strings.ToLower(value)
-		}
+	if err := opts.CheckVersionGates(ctx, p.ExecCfg().Settings.Version); err != nil {
+		return nil, err
 	}
 
-	if newFormat, ok := changefeedbase.NoLongerExperimental[opts[changefeedbase.OptFormat]]; ok {
-		p.BufferClientNotice(ctx, pgnotice.Newf(
-			`%[1]s is no longer experimental, use %[2]s=%[1]s`,
-			newFormat, changefeedbase.OptFormat),
-		)
-		// Still serialize the experimental_ form for backwards compatibility
+	for _, warning := range opts.DeprecationWarnings() {
+		p.BufferClientNotice(ctx, pgnotice.Newf("%s", warning))
 	}
 
 	jobDescription, err := changefeedJobDescription(p, changefeedStmt.CreateChangefeed, sinkURI, opts)
@@ -315,20 +301,26 @@ func createChangefeedJobRecord(
 		WallTime: p.ExtendedEvalContext().GetStmtTimestamp().UnixNano(),
 	}
 	var initialHighWater hlc.Timestamp
-	if cursor, ok := opts[changefeedbase.OptCursor]; ok {
-		asOfClause := tree.AsOfClause{Expr: tree.NewStrVal(cursor)}
-		var err error
+	evalTimestamp := func(s string) (hlc.Timestamp, error) {
+		asOfClause := tree.AsOfClause{Expr: tree.NewStrVal(s)}
 		asOf, err := p.EvalAsOfTimestamp(ctx, asOfClause)
+		if err != nil {
+			return hlc.Timestamp{}, err
+		}
+		return asOf.Timestamp, nil
+	}
+	if opts.HasStartCursor() {
+		initialHighWater, err = evalTimestamp(opts.GetCursor())
 		if err != nil {
 			return nil, err
 		}
-		initialHighWater = asOf.Timestamp
 		statementTime = initialHighWater
 	}
 
 	endTime := hlc.Timestamp{}
-	if endTimeOpt, ok := opts[changefeedbase.OptEndTime]; ok {
-		asOfClause := tree.AsOfClause{Expr: tree.NewStrVal(endTimeOpt)}
+
+	if opts.HasEndTime() {
+		asOfClause := tree.AsOfClause{Expr: tree.NewStrVal(opts.GetEndTime())}
 		asOf, err := asof.Eval(ctx, asOfClause, p.SemaCtx(), &p.ExtendedEvalContext().Context)
 		if err != nil {
 			return nil, err
@@ -337,10 +329,12 @@ func createChangefeedJobRecord(
 	}
 
 	{
-		initialScanType, err := initialScanTypeFromOpts(opts)
+		initialScanType, err := opts.GetInitialScanType()
 		if err != nil {
 			return nil, err
 		}
+		// TODO (zinger): Should we error or take the minimum
+		// if endTime is already set?
 		if initialScanType == changefeedbase.OnlyInitialScan {
 			endTime = statementTime
 		}
@@ -357,16 +351,17 @@ func createChangefeedJobRecord(
 		return nil, err
 	}
 
-	targets, tables, err := getTargetsAndTables(ctx, p, targetDescs, changefeedStmt.Targets, changefeedStmt.originalSpecs, opts)
+	targets, tables, err := getTargetsAndTables(ctx, p, targetDescs, changefeedStmt.Targets, changefeedStmt.originalSpecs, opts.ShouldUseFullStatementTimeName())
 	if err != nil {
 		return nil, err
 	}
+	tolerances := opts.GetCanHandle()
 	for _, desc := range targetDescs {
 		if table, isTable := desc.(catalog.TableDescriptor); isTable {
-			if err := changefeedbase.ValidateTable(targets, table, opts); err != nil {
+			if err := changefeedvalidators.ValidateTable(targets, table, tolerances); err != nil {
 				return nil, err
 			}
-			for _, warning := range changefeedbase.WarningsForTable(tables, table, opts) {
+			for _, warning := range changefeedvalidators.WarningsForTable(table, tolerances) {
 				p.BufferClientNotice(ctx, pgnotice.Newf("%s", warning))
 			}
 		}
@@ -374,42 +369,12 @@ func createChangefeedJobRecord(
 
 	details := jobspb.ChangefeedDetails{
 		Tables:               tables,
-		Opts:                 opts,
 		SinkURI:              sinkURI,
 		StatementTime:        statementTime,
 		EndTime:              endTime,
 		TargetSpecifications: targets,
 	}
 
-	// TODO(dan): In an attempt to present the most helpful error message to the
-	// user, the ordering requirements between all these usage validations have
-	// become extremely fragile and non-obvious.
-	//
-	// - `validateDetails` has to run first to fill in defaults for `envelope`
-	//   and `format` if the user didn't specify them.
-	// - Then `getEncoder` is run to return any configuration errors.
-	// - Then the changefeed is opted in to `OptKeyInValue` for any cloud
-	//   storage sink or webhook sink. Kafka etc have a key and value field in
-	//   each message but cloud storage sinks and webhook sinks don't have
-	//   anywhere to put the key. So if the key is not in the value, then for
-	//   DELETEs there is no way to recover which key was deleted. We could make
-	//   the user explicitly pass this option for every cloud storage sink/
-	//   webhook sink and error if they don't, but that seems user-hostile for
-	//   insufficient reason. We can't do this any earlier, because we might
-	//   return errors about `key_in_value` being incompatible which is
-	//   confusing when the user didn't type that option.
-	//   This is the same for the topic and webhook sink, which uses
-	//   `topic_in_value` to embed the topic in the value by default, since it
-	//   has no other avenue to express the topic.
-	// - Finally, we create a "canary" sink to test sink configuration and
-	//   connectivity. This has to go last because it is strange to return sink
-	//   connectivity errors before we've finished validating all the other
-	//   options. We should probably split sink configuration checking and sink
-	//   connectivity checking into separate methods.
-	//
-	// The only upside in all this nonsense is the tests are decent. I've tuned
-	// this particular order simply by rearranging stuff until the changefeedccl
-	// tests all pass.
 	parsedSink, err := url.Parse(sinkURI)
 	if err != nil {
 		return nil, err
@@ -421,31 +386,59 @@ func createChangefeedJobRecord(
 		)
 	}
 
-	if details, err = validateDetails(details); err != nil {
+	if err = validateDetailsAndOptions(details, opts); err != nil {
 		return nil, err
 	}
 
-	if filterExpr, isSet := details.Opts[changefeedbase.OptPrimaryKeyFilter]; isSet {
-		policy := changefeedbase.SchemaChangePolicy(details.Opts[changefeedbase.OptSchemaChangePolicy])
-		if policy != changefeedbase.OptSchemaChangePolicyStop {
+	filters := opts.GetFilters()
+
+	if filters.WithPredicate {
+		policy, err := opts.GetSchemaChangeHandlingOptions()
+		if err != nil {
+			return nil, err
+		}
+		if policy.Policy != changefeedbase.OptSchemaChangePolicyStop {
 			return nil, errors.Newf("option %s can only be used with %s=%s",
 				changefeedbase.OptPrimaryKeyFilter, changefeedbase.OptSchemaChangePolicy,
 				changefeedbase.OptSchemaChangePolicyStop)
 		}
-		if err := validatePrimaryKeyFilterExpression(ctx, p, filterExpr, targetDescs); err != nil {
+		if err := validatePrimaryKeyFilterExpression(ctx, p, filters.PrimaryKeyFilter, targetDescs); err != nil {
 			return nil, err
 		}
 	}
 
-	if _, err := getEncoder(details.Opts, AllTargets(details)); err != nil {
+	encodingOpts, err := opts.GetEncodingOptions()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := getEncoder(encodingOpts, AllTargets(details)); err != nil {
 		return nil, err
 	}
 
+	//	 The changefeed is opted in to `OptKeyInValue` for any cloud
+	//   storage sink or webhook sink. Kafka etc have a key and value field in
+	//   each message but cloud storage sinks and webhook sinks don't have
+	//   anywhere to put the key. So if the key is not in the value, then for
+	//   DELETEs there is no way to recover which key was deleted. We could make
+	//   the user explicitly pass this option for every cloud storage sink/
+	//   webhook sink and error if they don't, but that seems user-hostile for
+	//   insufficient reason.
+	//   This is the same for the topic and webhook sink, which uses
+	//   `topic_in_value` to embed the topic in the value by default, since it
+	//   has no other avenue to express the topic.
+	//   If this results in an overall invalid encoding, we need to override
+	//   the default error to avoid claiming the user set an option they didn't
+	//   explicitly set. Fortunately we know the only way to cause this is to
+	//   set envelope.
 	if isCloudStorageSink(parsedSink) || isWebhookSink(parsedSink) {
-		details.Opts[changefeedbase.OptKeyInValue] = ``
+		if err = opts.ForceKeyInValue(); err != nil {
+			return nil, errors.Errorf(`this sink is incompatible with envelope=%s`, encodingOpts.Envelope)
+		}
 	}
 	if isWebhookSink(parsedSink) {
-		details.Opts[changefeedbase.OptTopicInValue] = ``
+		if err = opts.ForceTopicInValue(); err != nil {
+			return nil, errors.Errorf(`this sink is incompatible with envelope=%s`, encodingOpts.Envelope)
+		}
 	}
 
 	if !unspecifiedSink && p.ExecCfg().ExternalIODirConfig.DisableOutbound {
@@ -459,11 +452,11 @@ func createChangefeedJobRecord(
 			telemetrySink = `sinkless`
 		}
 		telemetry.Count(telemetryPath + `.sink.` + telemetrySink)
-		telemetry.Count(telemetryPath + `.format.` + details.Opts[changefeedbase.OptFormat])
+		telemetry.Count(telemetryPath + `.format.` + string(encodingOpts.Format))
 		telemetry.CountBucketed(telemetryPath+`.num_tables`, int64(len(tables)))
 	}
 
-	if scope, ok := opts[changefeedbase.OptMetricsScope]; ok {
+	if scope, ok := opts.GetMetricScope(); ok {
 		if err := utilccl.CheckEnterpriseEnabled(
 			p.ExecCfg().Settings, p.ExecCfg().LogicalClusterID(), p.ExecCfg().Organization(), "CHANGEFEED",
 		); err != nil {
@@ -481,6 +474,8 @@ func createChangefeedJobRecord(
 				changefeedbase.OptMetricsScope, defaultSLIScope)
 		}
 	}
+
+	details.Opts = opts.AsMap()
 
 	if details.SinkURI == `` {
 		// Jobs should not be created for sinkless changefeeds. However, note that
@@ -510,6 +505,10 @@ func createChangefeedJobRecord(
 	// that the user has not made any obvious errors when specifying the sink in
 	// the CREATE CHANGEFEED statement. To do this, we create a "canary" sink,
 	// which will be immediately closed, only to check for errors.
+	// We also check here for any options that have passed previous validations
+	// but are inappropriate for the provided sink.
+	// TODO: Ideally those option validations would happen in validateDetails()
+	// earlier, like the others.
 	err = validateSink(ctx, p, jobID, details, opts)
 
 	jr := &jobs.Record{
@@ -603,7 +602,7 @@ func getTargetsAndTables(
 	targetDescs map[tree.TablePattern]catalog.Descriptor,
 	rawTargets tree.ChangefeedTargets,
 	originalSpecs map[tree.ChangefeedTarget]jobspb.ChangefeedTargetSpecification,
-	opts map[string]string,
+	fullTableName bool,
 ) ([]jobspb.ChangefeedTargetSpecification, jobspb.ChangefeedTargets, error) {
 	tables := make(jobspb.ChangefeedTargets, len(targetDescs))
 	targets := make([]jobspb.ChangefeedTargetSpecification, len(rawTargets))
@@ -637,8 +636,9 @@ func getTargetsAndTables(
 				}
 			}
 		} else {
-			_, qualified := opts[changefeedbase.OptFullTableName]
-			name, err := getChangefeedTargetName(ctx, td, p.ExecCfg(), p.Txn(), qualified)
+
+			name, err := getChangefeedTargetName(ctx, td, p.ExecCfg(), p.Txn(), fullTableName)
+
 			if err != nil {
 				return nil, nil, err
 			}
@@ -677,10 +677,11 @@ func validateSink(
 	p sql.PlanHookState,
 	jobID jobspb.JobID,
 	details jobspb.ChangefeedDetails,
-	opts map[string]string,
+	opts changefeedbase.StatementOptions,
 ) error {
 	metrics := p.ExecCfg().JobRegistry.MetricsStruct().Changefeed.(*Metrics)
-	sli, err := metrics.getSLIMetrics(opts[changefeedbase.OptMetricsScope])
+	scope, _ := opts.GetMetricScope()
+	sli, err := metrics.getSLIMetrics(scope)
 	if err != nil {
 		return err
 	}
@@ -694,9 +695,8 @@ func validateSink(
 		return err
 	}
 	if sink, ok := canarySink.(SinkWithTopics); ok {
-		_, resolved := opts[changefeedbase.OptResolvedTimestamps]
-		_, split := opts[changefeedbase.OptSplitColumnFamilies]
-		if resolved && split {
+		if opts.IsSet(changefeedbase.OptResolvedTimestamps) &&
+			opts.IsSet(changefeedbase.OptSplitColumnFamilies) {
 			return errors.Newf("Resolved timestamps are not currently supported with %s for this sink"+
 				" as the set of topics to fan them out to may change. Instead, use TABLE tablename FAMILY familyname"+
 				" to specify individual families to watch.", changefeedbase.OptSplitColumnFamilies)
@@ -712,7 +712,10 @@ func validateSink(
 }
 
 func changefeedJobDescription(
-	p sql.PlanHookState, changefeed *tree.CreateChangefeed, sinkURI string, opts map[string]string,
+	p sql.PlanHookState,
+	changefeed *tree.CreateChangefeed,
+	sinkURI string,
+	opts changefeedbase.StatementOptions,
 ) (string, error) {
 	cleanedSinkURI, err := cloud.SanitizeExternalStorageURI(sinkURI, []string{
 		changefeedbase.SinkParamSASLPassword,
@@ -730,16 +733,13 @@ func changefeedJobDescription(
 		Targets: changefeed.Targets,
 		SinkURI: tree.NewDString(cleanedSinkURI),
 	}
-	for k, v := range opts {
-		if k == changefeedbase.OptWebhookAuthHeader {
-			v = redactWebhookAuthHeader(v)
-		}
+	opts.ForEachWithRedaction(func(k string, v string) {
 		opt := tree.KVOption{Key: tree.Name(k)}
 		if len(v) > 0 {
 			opt.Value = tree.NewDString(v)
 		}
 		c.Options = append(c.Options, opt)
-	}
+	})
 	sort.Slice(c.Options, func(i, j int) bool { return c.Options[i].Key < c.Options[j].Key })
 	ann := p.ExtendedEvalContext().Annotations
 	return tree.AsStringWithFQNames(c, ann), nil
@@ -753,149 +753,33 @@ func redactUser(uri string) string {
 	return u.String()
 }
 
-// validateNonNegativeDuration returns a nil error if optValue can be
-// parsed as a duration and is non-negative; otherwise, an error is
-// returned.
-func validateNonNegativeDuration(optName string, optValue string) error {
-	if d, err := time.ParseDuration(optValue); err != nil {
+func validateDetailsAndOptions(
+	details jobspb.ChangefeedDetails, opts changefeedbase.StatementOptions,
+) error {
+	if err := opts.ValidateForCreateChangefeed(); err != nil {
 		return err
-	} else if d < 0 {
-		return errors.Errorf("negative durations are not accepted: %s='%s'", optName, optValue)
 	}
-	return nil
-}
 
-func validateDetails(details jobspb.ChangefeedDetails) (jobspb.ChangefeedDetails, error) {
-	if details.Opts == nil {
-		// The proto MarshalTo method omits the Opts field if the map is empty.
-		// So, if no options were specified by the user, Opts will be nil when
-		// the job gets restarted.
-		details.Opts = map[string]string{}
-	}
-	initialScanType, err := initialScanTypeFromOpts(details.Opts)
-	if err != nil {
-		return jobspb.ChangefeedDetails{}, err
-	}
-	{
-		const opt = changefeedbase.OptResolvedTimestamps
-		if o, ok := details.Opts[opt]; ok && o != `` {
-			if err := validateNonNegativeDuration(opt, o); err != nil {
-				return jobspb.ChangefeedDetails{}, err
-			}
+	if opts.HasEndTime() {
+		scanType, err := opts.GetInitialScanType()
+		if err != nil {
+			return err
 		}
-	}
-	{
-		const opt = changefeedbase.OptMinCheckpointFrequency
-		if o, ok := details.Opts[opt]; ok && o != `` {
-			if err := validateNonNegativeDuration(opt, o); err != nil {
-				return jobspb.ChangefeedDetails{}, err
-			}
-		}
-	}
-	{
-		const opt = changefeedbase.OptSchemaChangeEvents
-		switch v := changefeedbase.SchemaChangeEventClass(details.Opts[opt]); v {
-		case ``, changefeedbase.OptSchemaChangeEventClassDefault:
-			details.Opts[opt] = string(changefeedbase.OptSchemaChangeEventClassDefault)
-		case changefeedbase.OptSchemaChangeEventClassColumnChange:
-			// No-op
-		default:
-			return jobspb.ChangefeedDetails{}, errors.Errorf(
-				`unknown %s: %s`, opt, v)
-		}
-	}
-	{
-		const opt = changefeedbase.OptSchemaChangePolicy
-		switch v := changefeedbase.SchemaChangePolicy(details.Opts[opt]); v {
-		case ``, changefeedbase.OptSchemaChangePolicyBackfill:
-			details.Opts[opt] = string(changefeedbase.OptSchemaChangePolicyBackfill)
-		case changefeedbase.OptSchemaChangePolicyNoBackfill:
-			// No-op
-		case changefeedbase.OptSchemaChangePolicyStop:
-			// No-op
-		default:
-			return jobspb.ChangefeedDetails{}, errors.Errorf(
-				`unknown %s: %s`, opt, v)
-		}
-	}
-	{
-		const opt = changefeedbase.OptEnvelope
-		switch v := changefeedbase.EnvelopeType(details.Opts[opt]); v {
-		case changefeedbase.OptEnvelopeRow, changefeedbase.OptEnvelopeDeprecatedRow:
-			details.Opts[opt] = string(changefeedbase.OptEnvelopeRow)
-		case changefeedbase.OptEnvelopeKeyOnly:
-			details.Opts[opt] = string(changefeedbase.OptEnvelopeKeyOnly)
-		case ``, changefeedbase.OptEnvelopeWrapped:
-			details.Opts[opt] = string(changefeedbase.OptEnvelopeWrapped)
-		default:
-			return jobspb.ChangefeedDetails{}, errors.Errorf(
-				`unknown %s: %s`, opt, v)
-		}
-	}
-	{
-		const opt = changefeedbase.OptFormat
-		switch v := changefeedbase.FormatType(details.Opts[opt]); v {
-		case ``, changefeedbase.OptFormatJSON:
-			details.Opts[opt] = string(changefeedbase.OptFormatJSON)
-		case changefeedbase.OptFormatCSV:
-			if initialScanType != changefeedbase.OnlyInitialScan {
-				return jobspb.ChangefeedDetails{}, errors.Errorf(
-					`%s=%s is only usable with %s='only'`,
-					changefeedbase.OptFormat, changefeedbase.OptFormatCSV, changefeedbase.OptInitialScan)
-			}
-			details.Opts[opt] = string(changefeedbase.OptFormatCSV)
-		case changefeedbase.OptFormatAvro, changefeedbase.DeprecatedOptFormatAvro:
-			// No-op.
-		default:
-			return jobspb.ChangefeedDetails{}, errors.Errorf(
-				`unknown %s: %s`, opt, v)
-		}
-	}
-	{
-		const opt = changefeedbase.OptOnError
-		switch v := changefeedbase.OnErrorType(details.Opts[opt]); v {
-		case ``, changefeedbase.OptOnErrorFail:
-			details.Opts[opt] = string(changefeedbase.OptOnErrorFail)
-		case changefeedbase.OptOnErrorPause:
-			// No-op.
-		default:
-			return jobspb.ChangefeedDetails{}, errors.Errorf(
-				`unknown %s: %s, valid values are '%s' and '%s'`, opt, v,
-				changefeedbase.OptOnErrorPause,
-				changefeedbase.OptOnErrorFail)
-		}
-	}
-	{
-		const opt = changefeedbase.OptVirtualColumns
-		switch v := changefeedbase.VirtualColumnVisibility(details.Opts[opt]); v {
-		case ``, changefeedbase.OptVirtualColumnsOmitted:
-			details.Opts[opt] = string(changefeedbase.OptVirtualColumnsOmitted)
-		case changefeedbase.OptVirtualColumnsNull:
-			details.Opts[opt] = string(changefeedbase.OptVirtualColumnsNull)
-		default:
-			return jobspb.ChangefeedDetails{}, errors.Errorf(
-				`unknown %s: %s`, opt, v)
-		}
-	}
-	{
-		if initialScanType == changefeedbase.OnlyInitialScan {
-			for opt := range changefeedbase.InitialScanOnlyUnsupportedOptions {
-				if _, ok := details.Opts[opt]; ok {
-					return jobspb.ChangefeedDetails{}, errors.Errorf(
-						`cannot specify both %s='only' and %s`, changefeedbase.OptInitialScan, opt)
-				}
-			}
+		if scanType == changefeedbase.OnlyInitialScan {
+			return errors.Errorf(
+				`cannot specify both %s and %s`, changefeedbase.OptInitialScanOnly,
+				changefeedbase.OptEndTime)
 		}
 
-		if !details.EndTime.IsEmpty() && details.EndTime.Less(details.StatementTime) {
-			return jobspb.ChangefeedDetails{}, errors.Errorf(
+		if details.EndTime.Less(details.StatementTime) {
+			return errors.Errorf(
 				`specified end time %s cannot be less than statement time %s`,
 				details.EndTime.AsOfSystemTime(),
 				details.StatementTime.AsOfSystemTime(),
 			)
 		}
 	}
-	return details, nil
+	return nil
 }
 
 func validatePrimaryKeyFilterExpression(
@@ -964,7 +848,12 @@ func (b *changefeedResumer) handleChangefeedError(
 	details jobspb.ChangefeedDetails,
 	jobExec sql.JobExecContext,
 ) error {
-	switch onError := changefeedbase.OnErrorType(details.Opts[changefeedbase.OptOnError]); onError {
+	opts := changefeedbase.MakeStatementOptions(details.Opts)
+	onError, errErr := opts.GetOnError()
+	if errErr != nil {
+		return errors.CombineErrors(changefeedErr, errErr)
+	}
+	switch onError {
 	// default behavior
 	case changefeedbase.OptOnErrorFail:
 		return changefeedErr
@@ -988,7 +877,7 @@ func (b *changefeedResumer) handleChangefeedError(
 			return nil
 		}, errorMessage)
 	default:
-		return errors.Errorf("unrecognized option value: %s=%s",
+		return errors.Wrapf(changefeedErr, "unrecognized option value: %s=%s for handling error",
 			changefeedbase.OptOnError, details.Opts[changefeedbase.OptOnError])
 	}
 }

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -3492,6 +3492,7 @@ func TestChangefeedErrors(t *testing.T) {
 		t, `time: invalid duration "bar"`,
 		`EXPERIMENTAL CHANGEFEED FOR foo WITH resolved='bar'`,
 	)
+
 	sqlDB.ExpectErr(
 		t, `negative durations are not accepted: resolved='-1s'`,
 		`EXPERIMENTAL CHANGEFEED FOR foo WITH resolved='-1s'`,
@@ -3710,7 +3711,7 @@ func TestChangefeedErrors(t *testing.T) {
 	)
 	sqlDB.ExpectErr(
 		t, `this sink is incompatible with option webhook_client_timeout`,
-		`CREATE CHANGEFEED FOR foo INTO $1 WITH webhook_client_timeout=''`,
+		`CREATE CHANGEFEED FOR foo INTO $1 WITH webhook_client_timeout='1s'`,
 		`kafka://nope/`,
 	)
 	// The avro format doesn't support key_in_value or topic_in_value yet.
@@ -3807,40 +3808,40 @@ func TestChangefeedErrors(t *testing.T) {
 
 	// WITH only_initial_scan and end_time disallowed
 	sqlDB.ExpectErr(
-		t, `cannot specify both initial_scan='only' and end_time`,
+		t, `cannot specify both initial_scan_only and end_time`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH initial_scan_only, end_time = '1'`, `kafka://nope`,
 	)
 	sqlDB.ExpectErr(
-		t, `cannot specify both initial_scan='only' and end_time`,
+		t, `cannot specify both initial_scan_only and end_time`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH end_time = '1', initial_scan_only`, `kafka://nope`,
 	)
 
 	sqlDB.ExpectErr(
-		t, `cannot specify both initial_scan='only' and end_time`,
+		t, `cannot specify both initial_scan_only and end_time`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH end_time = '1', initial_scan = 'only'`, `kafka://nope`,
 	)
 	sqlDB.ExpectErr(
-		t, `cannot specify both initial_scan='only' and end_time`,
+		t, `cannot specify both initial_scan_only and end_time`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH initial_scan = 'only', end_time = '1'`, `kafka://nope`,
 	)
 
 	sqlDB.ExpectErr(
-		t, `cannot specify both initial_scan='only' and resolved`,
+		t, `cannot specify both initial_scan_only and resolved`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH resolved, initial_scan = 'only'`, `kafka://nope`,
 	)
 
 	sqlDB.ExpectErr(
-		t, `cannot specify both initial_scan='only' and diff`,
+		t, `cannot specify both initial_scan_only and diff`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH diff, initial_scan = 'only'`, `kafka://nope`,
 	)
 
 	sqlDB.ExpectErr(
-		t, `cannot specify both initial_scan='only' and mvcc_timestamp`,
+		t, `cannot specify both initial_scan_only and mvcc_timestamp`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH mvcc_timestamp, initial_scan = 'only'`, `kafka://nope`,
 	)
 
 	sqlDB.ExpectErr(
-		t, `cannot specify both initial_scan='only' and updated`,
+		t, `cannot specify both initial_scan_only and updated`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH updated, initial_scan = 'only'`, `kafka://nope`,
 	)
 
@@ -3858,7 +3859,7 @@ func TestChangefeedErrors(t *testing.T) {
 	)
 
 	sqlDB.ExpectErr(
-		t, `format=csv is only usable with initial_scan='only'`,
+		t, `format=csv is only usable with initial_scan_only`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH format = csv`, `kafka://nope`,
 	)
 
@@ -3910,11 +3911,11 @@ func TestChangefeedErrors(t *testing.T) {
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH webhook_client_timeout='not_an_integer'`, `webhook-https://fake-host`,
 	)
 	sqlDB.ExpectErr(
-		t, `option webhook_client_timeout must be a positive duration`,
+		t, `option webhook_client_timeout must be a duration greater than 0`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH webhook_client_timeout='0s'`, `webhook-https://fake-host`,
 	)
 	sqlDB.ExpectErr(
-		t, `option webhook_client_timeout must be a positive duration`,
+		t, `negative durations are not accepted: webhook_client_timeout='-500s'`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH webhook_client_timeout='-500s'`, `webhook-https://fake-host`,
 	)
 	sqlDB.ExpectErr(
@@ -5992,7 +5993,7 @@ func TestChangefeedPrimaryKeyFilter(t *testing.T) {
 		sqlDB.Exec(t, "INSERT INTO foo SELECT * FROM generate_series(1, 20)")
 
 		sqlDB.ExpectErr(t, "can only be used with schema_change_policy=stop",
-			`CREATE CHANGEFEED FOR foo, bar WITH primary_key_filter='a < 5 OR a > 18'`)
+			`CREATE CHANGEFEED FOR foo WITH primary_key_filter='a < 5 OR a > 18'`)
 
 		sqlDB.ExpectErr(t, `option primary_key_filter can only be used with 1 changefeed target`,
 			`CREATE CHANGEFEED FOR foo, bar WITH schema_change_policy='stop', primary_key_filter='a < 5 OR a > 18'`)

--- a/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "changefeedbase",
@@ -7,19 +7,26 @@ go_library(
         "errors.go",
         "options.go",
         "settings.go",
-        "validate.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/clusterversion",
         "//pkg/jobs/joberror",
-        "//pkg/jobs/jobspb",
         "//pkg/roachpb",
         "//pkg/settings",
-        "//pkg/sql",
-        "//pkg/sql/catalog",
         "//pkg/sql/flowinfra",
         "@com_github_cockroachdb_errors//:errors",
+    ],
+)
+
+go_test(
+    name = "changefeedbase_test",
+    srcs = ["options_test.go"],
+    embed = [":changefeedbase"],
+    deps = [
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -9,9 +9,30 @@
 package changefeedbase
 
 import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
-	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/errors"
 )
+
+// StatementOptions provides friendlier access to the options map from the WITH
+// part of a changefeed statement and smaller bundles to pass around.
+// Construct it by calling MakeStatementOptions on the raw options map.
+// Where possible, it will error when retrieving an invalid value.
+type StatementOptions struct {
+	m map[string]string
+
+	// TODO (zinger): Structs are created lazily in order to keep validations
+	// and options munging in the same order.
+	// Rework changefeed_stmt.go so that we can have one static StatementOptions
+	// that validates everything at once and don't need this cache.
+	cache struct {
+		EncodingOptions
+	}
+}
 
 // EnvelopeType configures the information in the changefeed events for a row.
 type EnvelopeType string
@@ -37,6 +58,10 @@ type VirtualColumnVisibility string
 // InitialScanType configures whether the changefeed will perform an
 // initial scan, and the type of initial scan that it will perform
 type InitialScanType int
+
+// SinkSpecificJSONConfig is a JSON string that the sink is responsible
+// for parsing, validating, and honoring.
+type SinkSpecificJSONConfig string
 
 // Constants for the initial scan types
 const (
@@ -177,47 +202,118 @@ const (
 	Topics = `topics`
 )
 
-// ChangefeedOptionExpectValues is used to parse changefeed options using
-// PlanHookState.TypeAsStringOpts().
-var ChangefeedOptionExpectValues = map[string]sql.KVStringOptValidate{
-	OptAvroSchemaPrefix:         sql.KVStringOptRequireValue,
-	OptConfluentSchemaRegistry:  sql.KVStringOptRequireValue,
-	OptCursor:                   sql.KVStringOptRequireValue,
-	OptEndTime:                  sql.KVStringOptRequireValue,
-	OptEnvelope:                 sql.KVStringOptRequireValue,
-	OptFormat:                   sql.KVStringOptRequireValue,
-	OptFullTableName:            sql.KVStringOptRequireNoValue,
-	OptKeyInValue:               sql.KVStringOptRequireNoValue,
-	OptTopicInValue:             sql.KVStringOptRequireNoValue,
-	OptResolvedTimestamps:       sql.KVStringOptAny,
-	OptMinCheckpointFrequency:   sql.KVStringOptRequireValue,
-	OptUpdatedTimestamps:        sql.KVStringOptRequireNoValue,
-	OptMVCCTimestamps:           sql.KVStringOptRequireNoValue,
-	OptDiff:                     sql.KVStringOptRequireNoValue,
-	OptCompression:              sql.KVStringOptRequireValue,
-	OptSchemaChangeEvents:       sql.KVStringOptRequireValue,
-	OptSchemaChangePolicy:       sql.KVStringOptRequireValue,
-	OptSplitColumnFamilies:      sql.KVStringOptRequireNoValue,
-	OptInitialScan:              sql.KVStringOptAny,
-	OptNoInitialScan:            sql.KVStringOptRequireNoValue,
-	OptInitialScanOnly:          sql.KVStringOptRequireNoValue,
-	OptProtectDataFromGCOnPause: sql.KVStringOptRequireNoValue,
-	OptKafkaSinkConfig:          sql.KVStringOptRequireValue,
-	OptWebhookSinkConfig:        sql.KVStringOptRequireValue,
-	OptWebhookAuthHeader:        sql.KVStringOptRequireValue,
-	OptWebhookClientTimeout:     sql.KVStringOptRequireValue,
-	OptOnError:                  sql.KVStringOptRequireValue,
-	OptMetricsScope:             sql.KVStringOptRequireValue,
-	OptVirtualColumns:           sql.KVStringOptRequireValue,
-	OptPrimaryKeyFilter:         sql.KVStringOptRequireValue,
-}
-
 func makeStringSet(opts ...string) map[string]struct{} {
 	res := make(map[string]struct{}, len(opts))
 	for _, opt := range opts {
 		res[opt] = struct{}{}
 	}
 	return res
+}
+
+// OptionType is an enum of the ways changefeed options can be provided in WITH.
+type OptionType int
+
+// Constants defining OptionTypes.
+const (
+	// OptionTypeString is a catch-all for options needing a value.
+	OptionTypeString OptionType = iota
+
+	OptionTypeTimestamp
+
+	OptionTypeDuration
+
+	// Boolean options set to true if present, false if absent.
+	OptionTypeFlag
+
+	OptionTypeEnum
+
+	OptionTypeJSON
+)
+
+// OptionPermittedValues is used in validations and is meant to be self-documenting.
+// TODO (zinger): Also use this in docgen.
+type OptionPermittedValues struct {
+	// Type is what this option will eventually be parsed as.
+	Type OptionType
+
+	// EnumValues lists all possible values for OptionTypeEnum.
+	// Empty for non-enums.
+	EnumValues map[string]struct{}
+
+	// CanBeEmpty describes an option that can be provided either as a key with no value,
+	// or a key/value pair.
+	CanBeEmpty bool
+
+	// CanBeEmpty describes an option for which an explicit '0' is allowed.
+	CanBeZero bool
+
+	// IfEmpty gives the semantic meaning of the empty form of a CanBeEmpty option.
+	// Blank for other kinds of options. This is not the same as the default value.
+	IfEmpty string
+
+	desc string
+}
+
+func enum(strs ...string) OptionPermittedValues {
+	return OptionPermittedValues{
+		Type:       OptionTypeEnum,
+		EnumValues: makeStringSet(strs...),
+		desc:       describeEnum(strs...),
+	}
+}
+
+func (o OptionPermittedValues) orEmptyMeans(def string) OptionPermittedValues {
+	o2 := o
+	o2.CanBeEmpty = true
+	o2.IfEmpty = def
+	return o2
+}
+
+func (o OptionPermittedValues) thatCanBeZero() OptionPermittedValues {
+	o2 := o
+	o2.CanBeZero = true
+	return o2
+}
+
+var stringOption = OptionPermittedValues{Type: OptionTypeString}
+var durationOption = OptionPermittedValues{Type: OptionTypeDuration}
+var timestampOption = OptionPermittedValues{Type: OptionTypeTimestamp}
+var flagOption = OptionPermittedValues{Type: OptionTypeFlag}
+var jsonOption = OptionPermittedValues{Type: OptionTypeJSON}
+
+// ChangefeedOptionExpectValues is used to parse changefeed options using
+// PlanHookState.TypeAsStringOpts().
+var ChangefeedOptionExpectValues = map[string]OptionPermittedValues{
+	OptAvroSchemaPrefix:         stringOption,
+	OptConfluentSchemaRegistry:  stringOption,
+	OptCursor:                   timestampOption,
+	OptEndTime:                  timestampOption,
+	OptEnvelope:                 enum("row", "key_only", "wrapped", "deprecated_row"),
+	OptFormat:                   enum("json", "avro", "csv", "experimental_avro"),
+	OptFullTableName:            flagOption,
+	OptKeyInValue:               flagOption,
+	OptTopicInValue:             flagOption,
+	OptResolvedTimestamps:       durationOption.thatCanBeZero().orEmptyMeans("0"),
+	OptMinCheckpointFrequency:   durationOption.thatCanBeZero(),
+	OptUpdatedTimestamps:        flagOption,
+	OptMVCCTimestamps:           flagOption,
+	OptDiff:                     flagOption,
+	OptCompression:              enum("gzip"),
+	OptSchemaChangeEvents:       enum("column_changes", "default"),
+	OptSchemaChangePolicy:       enum("backfill", "nobackfill", "stop", "ignore"),
+	OptSplitColumnFamilies:      flagOption,
+	OptInitialScan:              enum("yes", "no", "only").orEmptyMeans("yes"),
+	OptNoInitialScan:            flagOption,
+	OptInitialScanOnly:          flagOption,
+	OptProtectDataFromGCOnPause: flagOption,
+	OptKafkaSinkConfig:          jsonOption,
+	OptWebhookSinkConfig:        jsonOption,
+	OptWebhookAuthHeader:        stringOption,
+	OptWebhookClientTimeout:     durationOption,
+	OptOnError:                  enum("pause", "fail"),
+	OptMetricsScope:             stringOption,
+	OptVirtualColumns:           enum("omitted", "null"),
+	OptPrimaryKeyFilter:         stringOption,
 }
 
 // CommonOptions is options common to all sinks
@@ -243,11 +339,15 @@ var CloudStorageValidOptions = makeStringSet(OptCompression)
 // WebhookValidOptions is options exclusive to webhook sink
 var WebhookValidOptions = makeStringSet(OptWebhookAuthHeader, OptWebhookClientTimeout, OptWebhookSinkConfig)
 
-// PubsubValidOptions is options exclusice to pubsub sink
+// PubsubValidOptions is options exclusive to pubsub sink
 var PubsubValidOptions = makeStringSet()
 
 // CaseInsensitiveOpts options which supports case Insensitive value
-var CaseInsensitiveOpts = makeStringSet(OptFormat, OptEnvelope, OptCompression, OptSchemaChangeEvents, OptSchemaChangePolicy, OptOnError)
+var CaseInsensitiveOpts = makeStringSet(OptFormat, OptEnvelope, OptCompression, OptSchemaChangeEvents,
+	OptSchemaChangePolicy, OptOnError, OptInitialScan)
+
+// RedactedOptions are options whose values should be replaced with "redacted" in job descriptions and errors.
+var RedactedOptions = makeStringSet(OptWebhookAuthHeader, SinkParamClientKey)
 
 // NoLongerExperimental aliases options prefixed with experimental that no longer need to be
 var NoLongerExperimental = map[string]string{
@@ -276,20 +376,20 @@ var AlterChangefeedUnsupportedOptions = makeStringSet(OptCursor, OptInitialScan,
 
 // AlterChangefeedOptionExpectValues is used to parse alter changefeed options
 // using PlanHookState.TypeAsStringOpts().
-var AlterChangefeedOptionExpectValues = func() map[string]sql.KVStringOptValidate {
-	alterChangefeedOptions := make(map[string]sql.KVStringOptValidate, len(ChangefeedOptionExpectValues)+1)
+var AlterChangefeedOptionExpectValues = func() map[string]OptionPermittedValues {
+	alterChangefeedOptions := make(map[string]OptionPermittedValues, len(ChangefeedOptionExpectValues)+1)
 	for key, value := range ChangefeedOptionExpectValues {
 		alterChangefeedOptions[key] = value
 	}
-	alterChangefeedOptions[OptSink] = sql.KVStringOptRequireValue
+	alterChangefeedOptions[OptSink] = stringOption
 	return alterChangefeedOptions
 }()
 
 // AlterChangefeedTargetOptions is used to parse target specific alter
 // changefeed options using PlanHookState.TypeAsStringOpts().
-var AlterChangefeedTargetOptions = map[string]sql.KVStringOptValidate{
-	OptInitialScan:   sql.KVStringOptRequireNoValue,
-	OptNoInitialScan: sql.KVStringOptRequireNoValue,
+var AlterChangefeedTargetOptions = map[string]OptionPermittedValues{
+	OptInitialScan:   flagOption,
+	OptNoInitialScan: flagOption,
 }
 
 // VersionGateOptions is a mapping between an option and its minimum supported
@@ -298,4 +398,526 @@ var VersionGateOptions = map[string]clusterversion.Key{
 	OptEndTime:         clusterversion.EnableNewChangefeedOptions,
 	OptInitialScanOnly: clusterversion.EnableNewChangefeedOptions,
 	OptInitialScan:     clusterversion.EnableNewChangefeedOptions,
+}
+
+// MakeStatementOptions wraps and canonicalizes the options we get
+// from TypeAsStringOpts or the job record.
+func MakeStatementOptions(opts map[string]string) StatementOptions {
+	if opts == nil {
+		return MakeDefaultOptions()
+	}
+	for key, value := range opts {
+		if _, ok := CaseInsensitiveOpts[key]; ok {
+			opts[key] = strings.ToLower(value)
+		}
+	}
+	return StatementOptions{m: opts}
+}
+
+// MakeDefaultOptions creates the StatementOptions you'd get from
+// a changefeed statement with no WITH.
+func MakeDefaultOptions() StatementOptions {
+	return StatementOptions{m: make(map[string]string)}
+}
+
+// AsMap gets the untyped version of a StatementOptions we serialize
+// in a jobspb.ChangefeedDetails. This can't be automagically cast
+// without introducing a dependency.
+func (s StatementOptions) AsMap() map[string]string {
+	return s.m
+}
+
+// IsSet checks whether the given key was set explicitly.
+func (s StatementOptions) IsSet(key string) bool {
+	_, ok := s.m[key]
+	return ok
+}
+
+// CheckVersionGates verifies that all options are supported by the
+// active cluster version.
+func (s StatementOptions) CheckVersionGates(
+	ctx context.Context, version clusterversion.Handle,
+) error {
+	for key := range s.m {
+		if clusterVersion, ok := VersionGateOptions[key]; ok {
+			if !version.IsActive(ctx, clusterVersion) {
+				return errors.Newf(
+					`option %s is not supported until upgrade to version %s or higher is finalized`,
+					key, clusterVersion.String(),
+				)
+			}
+		}
+	}
+	return nil
+}
+
+// DeprecationWarnings checks for options in forms we still support and serialize,
+// but should be replaced with a new form. Currently hardcoded to just check format.
+func (s StatementOptions) DeprecationWarnings() []string {
+	if newFormat, ok := NoLongerExperimental[s.m[OptFormat]]; ok {
+		return []string{fmt.Sprintf(`%[1]s is no longer experimental, use %[2]s=%[1]s`,
+			newFormat, OptFormat)}
+	}
+
+	return []string{}
+}
+
+var redacted string = "redacted"
+
+// ForEachWithRedaction iterates a function over the raw key/value pairs.
+// Meant for serialization.
+func (s StatementOptions) ForEachWithRedaction(fn func(k string, v string)) {
+	for k, v := range s.m {
+		if _, redact := RedactedOptions[k]; redact {
+			fn(k, redacted)
+		} else {
+			fn(k, v)
+		}
+	}
+}
+
+// HasStartCursor returns true if we're starting from a
+// user-provided timestamp.
+func (s StatementOptions) HasStartCursor() bool {
+	_, ok := s.m[OptCursor]
+	return ok
+}
+
+// GetCursor returns the user-provided cursor.
+func (s StatementOptions) GetCursor() string {
+	return s.m[OptCursor]
+}
+
+// HasEndTime returns true if an end time was provided.
+func (s StatementOptions) HasEndTime() bool {
+	_, ok := s.m[OptEndTime]
+	return ok
+}
+
+// GetEndTime returns the user-provided end time.
+func (s StatementOptions) GetEndTime() string {
+	return s.m[OptEndTime]
+}
+
+func (s StatementOptions) getEnumValue(k string) (string, error) {
+	enumOptions := ChangefeedOptionExpectValues[k]
+	rawVal, present := s.m[k]
+	if !present {
+		return ``, nil
+	}
+	if rawVal == `` {
+		return enumOptions.IfEmpty, nil
+	}
+
+	if _, ok := enumOptions.EnumValues[rawVal]; !ok {
+		return ``, errors.Errorf(
+			`unknown %s: %s, %s`, k, rawVal, enumOptions.desc)
+	}
+
+	return rawVal, nil
+}
+
+func (s StatementOptions) getDurationValue(k string) (*time.Duration, error) {
+	v, ok := s.m[k]
+	if !ok {
+		return nil, nil
+	}
+	if v == `` {
+		v = ChangefeedOptionExpectValues[k].IfEmpty
+	}
+	if d, err := time.ParseDuration(v); err != nil {
+		return nil, errors.Wrapf(err, "problem parsing option %s", k)
+	} else if d < 0 {
+		return nil, errors.Errorf("negative durations are not accepted: %s='%s'", k, v)
+	} else if d == 0 && !ChangefeedOptionExpectValues[k].CanBeZero {
+		return nil, errors.Errorf("option %s must be a duration greater than 0", k)
+	} else {
+		return &d, nil
+	}
+}
+
+func (s StatementOptions) getJSONValue(k string) SinkSpecificJSONConfig {
+	return SinkSpecificJSONConfig(s.m[k])
+}
+
+// GetInitialScanType determines the type of initial scan the changefeed
+// should perform on the first run given the options provided from the user.
+func (s StatementOptions) GetInitialScanType() (InitialScanType, error) {
+	_, initialScanSet := s.m[OptInitialScan]
+	_, initialScanOnlySet := s.m[OptInitialScanOnly]
+	_, noInitialScanSet := s.m[OptNoInitialScan]
+
+	if initialScanSet && noInitialScanSet {
+		return InitialScan, errors.Errorf(
+			`cannot specify both %s and %s`, OptInitialScan,
+			OptNoInitialScan)
+	}
+
+	if initialScanSet && initialScanOnlySet {
+		return InitialScan, errors.Errorf(
+			`cannot specify both %s and %s`, OptInitialScan,
+			OptInitialScanOnly)
+	}
+
+	if noInitialScanSet && initialScanOnlySet {
+		return InitialScan, errors.Errorf(
+			`cannot specify both %s and %s`, OptInitialScanOnly,
+			OptNoInitialScan)
+	}
+
+	if initialScanSet {
+		const opt = OptInitialScan
+		v, err := s.getEnumValue(opt)
+		if err != nil {
+			return InitialScan, err
+		}
+		switch v {
+		case `yes`:
+			return InitialScan, nil
+		case `no`:
+			return NoInitialScan, nil
+		case `only`:
+			return OnlyInitialScan, nil
+		}
+	}
+
+	if initialScanOnlySet {
+		return OnlyInitialScan, nil
+	}
+
+	if noInitialScanSet {
+		return NoInitialScan, nil
+	}
+
+	// If we reach this point, this implies that the user did not specify any initial scan
+	// options. In this case the default behaviour is to perform an initial scan if the
+	// cursor is not specified.
+	if !s.HasStartCursor() {
+		return InitialScan, nil
+	}
+
+	return NoInitialScan, nil
+}
+
+// ShouldUseFullStatementTimeName returns true if references to the table should be in db.schema.table
+// format (e.g. in Kafka topics).
+func (s StatementOptions) ShouldUseFullStatementTimeName() bool {
+	_, qualified := s.m[OptFullTableName]
+	return qualified
+}
+
+// CanHandle tracks whether users have explicitly specificed how to handle
+// unusual table schemas.
+type CanHandle struct {
+	MultipleColumnFamilies bool
+	VirtualColumns         bool
+}
+
+// GetCanHandle returns a populated CanHandle.
+func (s StatementOptions) GetCanHandle() CanHandle {
+	_, families := s.m[OptSplitColumnFamilies]
+	_, virtual := s.m[OptVirtualColumns]
+	return CanHandle{
+		MultipleColumnFamilies: families,
+		VirtualColumns:         virtual,
+	}
+}
+
+// EncodingOptions describe how events are encoded when
+// sent to the sink.
+type EncodingOptions struct {
+	Format            FormatType
+	VirtualColumns    VirtualColumnVisibility
+	Envelope          EnvelopeType
+	KeyInValue        bool
+	TopicInValue      bool
+	UpdatedTimestamps bool
+	MVCCTimestamps    bool
+	Diff              bool
+	AvroSchemaPrefix  string
+	SchemaRegistryURI string
+	Compression       string
+}
+
+// GetEncodingOptions populates and validates an EncodingOptions.
+func (s StatementOptions) GetEncodingOptions() (EncodingOptions, error) {
+	o := EncodingOptions{}
+	if s.cache.EncodingOptions != o {
+		return s.cache.EncodingOptions, nil
+	}
+	format, err := s.getEnumValue(OptFormat)
+	if err != nil {
+		return o, err
+	}
+	if format == `` {
+		o.Format = OptFormatJSON
+	} else {
+		o.Format = FormatType(format)
+	}
+	virt, err := s.getEnumValue(OptVirtualColumns)
+	if err != nil {
+		return o, err
+	}
+	if virt == `` {
+		o.VirtualColumns = OptVirtualColumnsOmitted
+	} else {
+		o.VirtualColumns = VirtualColumnVisibility(virt)
+	}
+	envelope, err := s.getEnumValue(OptEnvelope)
+	if err != nil {
+		return o, err
+	}
+	if envelope == `` {
+		o.Envelope = OptEnvelopeWrapped
+	} else {
+		o.Envelope = EnvelopeType(envelope)
+	}
+
+	_, o.KeyInValue = s.m[OptKeyInValue]
+	_, o.TopicInValue = s.m[OptTopicInValue]
+	_, o.UpdatedTimestamps = s.m[OptUpdatedTimestamps]
+	_, o.MVCCTimestamps = s.m[OptMVCCTimestamps]
+	_, o.Diff = s.m[OptDiff]
+
+	o.SchemaRegistryURI = s.m[OptConfluentSchemaRegistry]
+	o.AvroSchemaPrefix = s.m[OptAvroSchemaPrefix]
+	o.Compression = s.m[OptCompression]
+
+	s.cache.EncodingOptions = o
+	return o, o.Validate()
+}
+
+// Validate checks for incompatible encoding options.
+func (e EncodingOptions) Validate() error {
+	if e.Envelope == OptEnvelopeRow && e.Format == OptFormatAvro {
+		return errors.Errorf(`%s=%s is not supported with %s=%s`,
+			OptEnvelope, OptEnvelopeRow, OptFormat, OptFormatAvro,
+		)
+	}
+	if e.Envelope != OptEnvelopeWrapped {
+		requiresWrap := []struct {
+			k string
+			b bool
+		}{
+			{OptKeyInValue, e.KeyInValue},
+			{OptTopicInValue, e.TopicInValue},
+			{OptUpdatedTimestamps, e.UpdatedTimestamps},
+			{OptMVCCTimestamps, e.MVCCTimestamps},
+			{OptDiff, e.Diff},
+		}
+		if e.Format == OptFormatJSON {
+			requiresWrap = []struct {
+				k string
+				b bool
+			}{{OptDiff, e.Diff}}
+		}
+		for _, v := range requiresWrap {
+			if v.b {
+				return errors.Errorf(`%s is only usable with %s=%s`,
+					v.k, OptEnvelope, OptEnvelopeWrapped)
+			}
+		}
+	}
+	return nil
+}
+
+// SchemaChangeHandlingOptions specify how the feed should
+// behave when a target is affected by a schema change.
+type SchemaChangeHandlingOptions struct {
+	EventClass SchemaChangeEventClass
+	Policy     SchemaChangePolicy
+}
+
+// GetSchemaChangeHandlingOptions populates and validates a SchemaChangeHandlingOptions.
+func (s StatementOptions) GetSchemaChangeHandlingOptions() (SchemaChangeHandlingOptions, error) {
+	o := SchemaChangeHandlingOptions{}
+	ec, err := s.getEnumValue(OptSchemaChangeEvents)
+	if err != nil {
+		return o, err
+	}
+	if ec == `` {
+		o.EventClass = OptSchemaChangeEventClassDefault
+	} else {
+		o.EventClass = SchemaChangeEventClass(ec)
+	}
+
+	p, err := s.getEnumValue(OptSchemaChangePolicy)
+	if err != nil {
+		return o, err
+	}
+	if p == `` {
+		o.Policy = OptSchemaChangePolicyBackfill
+	} else {
+		o.Policy = SchemaChangePolicy(p)
+	}
+
+	return o, nil
+
+}
+
+// Filters are aspects of the feed that the backing
+// kvfeed or rangefeed want to know about.
+type Filters struct {
+	WithDiff         bool
+	WithPredicate    bool
+	PrimaryKeyFilter string
+}
+
+// GetFilters returns a populated Filters.
+func (s StatementOptions) GetFilters() Filters {
+	_, withDiff := s.m[OptDiff]
+	filter, withPredicate := s.m[OptPrimaryKeyFilter]
+	return Filters{
+		WithDiff:         withDiff,
+		WithPredicate:    withPredicate,
+		PrimaryKeyFilter: filter,
+	}
+}
+
+// WebhookSinkOptions are passed in WITH args but
+// are specific to the webhook sink.
+// ClientTimeout is nil if not set as the default
+// is different from 0.
+type WebhookSinkOptions struct {
+	JSONConfig    SinkSpecificJSONConfig
+	AuthHeader    string
+	ClientTimeout *time.Duration
+}
+
+// GetWebhookSinkOptions includes arbitrary json to be interpreted
+// by the webhook sink.
+func (s StatementOptions) GetWebhookSinkOptions() (WebhookSinkOptions, error) {
+	o := WebhookSinkOptions{JSONConfig: s.getJSONValue(OptWebhookSinkConfig), AuthHeader: s.m[OptWebhookAuthHeader]}
+	timeout, err := s.getDurationValue(OptWebhookClientTimeout)
+	if err != nil {
+		return o, err
+	}
+	o.ClientTimeout = timeout
+	return o, nil
+}
+
+// GetKafkaConfigJSON returns arbitrary json to be interpreted
+// by the kafka sink.
+func (s StatementOptions) GetKafkaConfigJSON() SinkSpecificJSONConfig {
+	return s.getJSONValue(OptKafkaSinkConfig)
+}
+
+// GetResolvedTimestampInterval gets the best-effort interval at which resolved timestamps
+// should be emitted. Nil or 0 means emit as often as possible. False means do not emit at all.
+// Returns an error for negative or invalid duration value.
+func (s StatementOptions) GetResolvedTimestampInterval() (*time.Duration, bool, error) {
+	str, ok := s.m[OptResolvedTimestamps]
+	if ok && str == OptEmitAllResolvedTimestamps {
+		return nil, true, nil
+	}
+	d, err := s.getDurationValue(OptResolvedTimestamps)
+	return d, d != nil, err
+}
+
+// GetMetricScope returns a namespace for metrics affected by this changefeed, or
+// false if none has been provided.
+func (s StatementOptions) GetMetricScope() (string, bool) {
+	v, ok := s.m[OptMetricsScope]
+	return v, ok
+}
+
+// GetMinCheckpointFrequency returns the minimum frequency with which checkpoints should be
+// recorded. Returns nil if not set, and an error if invalid.
+func (s StatementOptions) GetMinCheckpointFrequency() (*time.Duration, error) {
+	return s.getDurationValue(OptMinCheckpointFrequency)
+}
+
+// ForceKeyInValue sets the encoding option KeyInValue to true and then validates the
+// resoluting encoding options.
+func (s StatementOptions) ForceKeyInValue() error {
+	s.m[OptKeyInValue] = ``
+	s.cache.EncodingOptions = EncodingOptions{}
+	_, err := s.GetEncodingOptions()
+	return err
+}
+
+// ForceTopicInValue sets the encoding option TopicInValue to true and then validates the
+// resoluting encoding options.
+func (s StatementOptions) ForceTopicInValue() error {
+	s.m[OptTopicInValue] = ``
+	s.cache.EncodingOptions = EncodingOptions{}
+	_, err := s.GetEncodingOptions()
+	return err
+}
+
+// GetOnError validates and returns the desired behavior when a non-retriable error is encountered.
+func (s StatementOptions) GetOnError() (OnErrorType, error) {
+	v, err := s.getEnumValue(OptOnError)
+	if err != nil || v == `` {
+		return OptOnErrorFail, err
+	}
+	return OnErrorType(v), nil
+}
+
+func describeEnum(strs ...string) string {
+	switch len(strs) {
+	case 1:
+		return fmt.Sprintf("the only valid value is '%s'", strs[0])
+	case 2:
+		return fmt.Sprintf("valid values are '%s' and '%s'", strs[0], strs[1])
+	default:
+		s := "valid values are "
+		for i, v := range strs {
+			if i > 0 {
+				s = s + ", "
+			}
+			if i == len(strs)-1 {
+				s = s + " and "
+			}
+			s = s + fmt.Sprintf("'%s'", v)
+		}
+		return s
+	}
+}
+
+// ValidateForCreateChangefeed checks that the provided options are
+// valid for a CREATE CHANGEFEED statement using the type assertions
+// in ChangefeedOptionExpectValues.
+func (s StatementOptions) ValidateForCreateChangefeed() error {
+	err := s.validateAgainst(ChangefeedOptionExpectValues)
+	if err != nil {
+		return err
+	}
+	scanType, err := s.GetInitialScanType()
+	if err != nil {
+		return err
+	}
+	if scanType == OnlyInitialScan {
+		for o := range InitialScanOnlyUnsupportedOptions {
+			if _, ok := s.m[o]; ok {
+				return errors.Newf(`cannot specify both %s and %s`, OptInitialScanOnly, o)
+			}
+		}
+	} else {
+		if s.m[OptFormat] == string(OptFormatCSV) {
+			return errors.Newf(`%s=%s is only usable with %s`, OptFormat, OptFormatCSV, OptInitialScanOnly)
+		}
+	}
+	return nil
+}
+
+func (s StatementOptions) validateAgainst(m map[string]OptionPermittedValues) error {
+	for k := range ChangefeedOptionExpectValues {
+		permitted := m[k]
+		switch permitted.Type {
+		case OptionTypeFlag:
+			// No value to validate
+		case OptionTypeString, OptionTypeTimestamp, OptionTypeJSON:
+			// Consumer (usually a sink) must parse and validate these
+		case OptionTypeDuration:
+			if _, err := s.getDurationValue(k); err != nil {
+				return err
+			}
+		case OptionTypeEnum:
+			if _, err := s.getEnumValue(k); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/ccl/changefeedccl/changefeedbase/options_test.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options_test.go
@@ -1,0 +1,42 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedbase
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOptionsValidations(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	require.NoError(t, MakeDefaultOptions().ValidateForCreateChangefeed(),
+		"Default options should be valid")
+
+	tests := []struct {
+		input map[string]string
+		err   string
+	}{
+		{map[string]string{"format": "txt"}, "unknown format"},
+		{map[string]string{"initial_scan": "", "no_initial_scan": ""}, "cannot specify both"},
+	}
+
+	for _, test := range tests {
+		o := MakeStatementOptions(test.input)
+		err := o.ValidateForCreateChangefeed()
+		require.Error(t, err, fmt.Sprintf("%v should not be valid", test.input))
+		require.Contains(t, err.Error(), test.err)
+	}
+
+}

--- a/pkg/ccl/changefeedccl/changefeedvalidators/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/changefeedvalidators/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "changefeedvalidators",
+    srcs = [
+        "options_sql_validator.go",
+        "table_validator.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedvalidators",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/ccl/changefeedccl/changefeedbase",
+        "//pkg/jobs/jobspb",
+        "//pkg/sql",
+        "//pkg/sql/catalog",
+        "@com_github_cockroachdb_errors//:errors",
+    ],
+)

--- a/pkg/ccl/changefeedccl/changefeedvalidators/options_sql_validator.go
+++ b/pkg/ccl/changefeedccl/changefeedvalidators/options_sql_validator.go
@@ -1,0 +1,39 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedvalidators
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+)
+
+func makeValMap(
+	src map[string]changefeedbase.OptionPermittedValues,
+) map[string]sql.KVStringOptValidate {
+	dst := make(map[string]sql.KVStringOptValidate, len(src))
+	for k, v := range src {
+		if v.CanBeEmpty {
+			dst[k] = sql.KVStringOptAny
+		} else if v.Type == changefeedbase.OptionTypeFlag {
+			dst[k] = sql.KVStringOptRequireNoValue
+		} else {
+			dst[k] = sql.KVStringOptRequireValue
+		}
+	}
+	return dst
+}
+
+// CreateOptionValidations do a basic check on the WITH options in a CREATE CHANGEFEED.
+var CreateOptionValidations = makeValMap(changefeedbase.ChangefeedOptionExpectValues)
+
+// AlterOptionValidations do a basic check on the options in an ALTER CHANGEFEED.
+var AlterOptionValidations = makeValMap(changefeedbase.AlterChangefeedOptionExpectValues)
+
+// AlterTargetOptionValidations do a basic check on the target-level options in an ALTER CHANGEFEED.
+var AlterTargetOptionValidations = makeValMap(changefeedbase.AlterChangefeedTargetOptions)

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -43,16 +43,16 @@ type Encoder interface {
 }
 
 func getEncoder(
-	opts map[string]string, targets []jobspb.ChangefeedTargetSpecification,
+	opts changefeedbase.EncodingOptions, targets []jobspb.ChangefeedTargetSpecification,
 ) (Encoder, error) {
-	switch changefeedbase.FormatType(opts[changefeedbase.OptFormat]) {
-	case ``, changefeedbase.OptFormatJSON:
+	switch opts.Format {
+	case changefeedbase.OptFormatJSON:
 		return makeJSONEncoder(opts, targets)
 	case changefeedbase.OptFormatAvro, changefeedbase.DeprecatedOptFormatAvro:
 		return newConfluentAvroEncoder(opts, targets)
 	case changefeedbase.OptFormatCSV:
 		return newCSVEncoder(opts), nil
 	default:
-		return nil, errors.Errorf(`unknown %s: %s`, changefeedbase.OptFormat, opts[changefeedbase.OptFormat])
+		return nil, errors.AssertionFailedf(`unknown format: %s`, opts.Format)
 	}
 }

--- a/pkg/ccl/changefeedccl/encoder_avro.go
+++ b/pkg/ccl/changefeedccl/encoder_avro.go
@@ -34,7 +34,7 @@ type confluentAvroEncoder struct {
 	schemaRegistry                     schemaRegistry
 	schemaPrefix                       string
 	updatedField, beforeField, keyOnly bool
-	virtualColumnVisibility            string
+	virtualColumnVisibility            changefeedbase.VirtualColumnVisibility
 	targets                            []jobspb.ChangefeedTargetSpecification
 
 	keyCache   *cache.UnorderedCache // [tableIDAndVersion]confluentRegisteredKeySchema
@@ -73,47 +73,47 @@ var encoderCacheConfig = cache.Config{
 }
 
 func newConfluentAvroEncoder(
-	opts map[string]string, targets []jobspb.ChangefeedTargetSpecification,
+	opts changefeedbase.EncodingOptions, targets []jobspb.ChangefeedTargetSpecification,
 ) (*confluentAvroEncoder, error) {
 	e := &confluentAvroEncoder{
-		schemaPrefix:            opts[changefeedbase.OptAvroSchemaPrefix],
+		schemaPrefix:            opts.AvroSchemaPrefix,
 		targets:                 targets,
-		virtualColumnVisibility: opts[changefeedbase.OptVirtualColumns],
+		virtualColumnVisibility: opts.VirtualColumns,
 	}
 
-	switch opts[changefeedbase.OptEnvelope] {
-	case string(changefeedbase.OptEnvelopeKeyOnly):
+	switch opts.Envelope {
+	case changefeedbase.OptEnvelopeKeyOnly:
 		e.keyOnly = true
-	case string(changefeedbase.OptEnvelopeWrapped):
+	case changefeedbase.OptEnvelopeWrapped:
 	default:
 		return nil, errors.Errorf(`%s=%s is not supported with %s=%s`,
-			changefeedbase.OptEnvelope, opts[changefeedbase.OptEnvelope], changefeedbase.OptFormat, changefeedbase.OptFormatAvro)
+			changefeedbase.OptEnvelope, opts.Envelope, changefeedbase.OptFormat, changefeedbase.OptFormatAvro)
 	}
-	_, e.updatedField = opts[changefeedbase.OptUpdatedTimestamps]
+	e.updatedField = opts.UpdatedTimestamps
 	if e.updatedField && e.keyOnly {
 		return nil, errors.Errorf(`%s is only usable with %s=%s`,
 			changefeedbase.OptUpdatedTimestamps, changefeedbase.OptEnvelope, changefeedbase.OptEnvelopeWrapped)
 	}
-	_, e.beforeField = opts[changefeedbase.OptDiff]
+	e.beforeField = opts.Diff
 	if e.beforeField && e.keyOnly {
 		return nil, errors.Errorf(`%s is only usable with %s=%s`,
 			changefeedbase.OptDiff, changefeedbase.OptEnvelope, changefeedbase.OptEnvelopeWrapped)
 	}
 
-	if _, ok := opts[changefeedbase.OptKeyInValue]; ok {
+	if opts.KeyInValue {
 		return nil, errors.Errorf(`%s is not supported with %s=%s`,
 			changefeedbase.OptKeyInValue, changefeedbase.OptFormat, changefeedbase.OptFormatAvro)
 	}
-	if _, ok := opts[changefeedbase.OptTopicInValue]; ok {
+	if opts.TopicInValue {
 		return nil, errors.Errorf(`%s is not supported with %s=%s`,
 			changefeedbase.OptTopicInValue, changefeedbase.OptFormat, changefeedbase.OptFormatAvro)
 	}
-	if len(opts[changefeedbase.OptConfluentSchemaRegistry]) == 0 {
+	if len(opts.SchemaRegistryURI) == 0 {
 		return nil, errors.Errorf(`WITH option %s is required for %s=%s`,
 			changefeedbase.OptConfluentSchemaRegistry, changefeedbase.OptFormat, changefeedbase.OptFormatAvro)
 	}
 
-	reg, err := newConfluentSchemaRegistry(opts[changefeedbase.OptConfluentSchemaRegistry])
+	reg, err := newConfluentSchemaRegistry(opts.SchemaRegistryURI)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/changefeedccl/encoder_csv.go
+++ b/pkg/ccl/changefeedccl/encoder_csv.go
@@ -21,8 +21,6 @@ import (
 )
 
 type csvEncoder struct {
-	virtualColumnVisibility string
-
 	csvRow []string
 	buf    *bytes.Buffer
 	writer *csv.Writer
@@ -30,12 +28,11 @@ type csvEncoder struct {
 
 var _ Encoder = &csvEncoder{}
 
-func newCSVEncoder(opts map[string]string) *csvEncoder {
+func newCSVEncoder(opts changefeedbase.EncodingOptions) *csvEncoder {
 	newBuf := bytes.NewBuffer([]byte{})
 	newEncoder := &csvEncoder{
-		virtualColumnVisibility: opts[changefeedbase.OptVirtualColumns],
-		buf:                     newBuf,
-		writer:                  csv.NewWriter(newBuf),
+		buf:    newBuf,
+		writer: csv.NewWriter(newBuf),
 	}
 	newEncoder.writer.SkipNewline = true
 	return newEncoder

--- a/pkg/ccl/changefeedccl/schemafeed/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/schemafeed/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ccl/changefeedccl/changefeedbase",
+        "//pkg/ccl/changefeedccl/changefeedvalidators",
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",

--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -329,7 +329,7 @@ func makeCloudStorageSink(
 	u sinkURL,
 	srcID base.SQLInstanceID,
 	settings *cluster.Settings,
-	opts map[string]string,
+	encodingOpts changefeedbase.EncodingOptions,
 	timestampOracle timestampLowerBoundOracle,
 	makeExternalStorageFromURI cloud.ExternalStorageFromURIFactory,
 	user username.SQLUsername,
@@ -385,7 +385,7 @@ func makeCloudStorageSink(
 		s.dataFilePartition = s.timestampOracle.inclusiveLowerBoundTS().GoTime().Format(s.partitionFormat)
 	}
 
-	switch changefeedbase.FormatType(opts[changefeedbase.OptFormat]) {
+	switch encodingOpts.Format {
 	case changefeedbase.OptFormatJSON:
 		// TODO(dan): It seems like these should be on the encoder, but that
 		// would require a bit of refactoring.
@@ -398,21 +398,21 @@ func makeCloudStorageSink(
 		s.rowDelimiter = []byte{'\n'}
 	default:
 		return nil, errors.Errorf(`this sink is incompatible with %s=%s`,
-			changefeedbase.OptFormat, opts[changefeedbase.OptFormat])
+			changefeedbase.OptFormat, encodingOpts.Format)
 	}
 
-	switch changefeedbase.EnvelopeType(opts[changefeedbase.OptEnvelope]) {
+	switch encodingOpts.Envelope {
 	case changefeedbase.OptEnvelopeWrapped:
 	default:
 		return nil, errors.Errorf(`this sink is incompatible with %s=%s`,
-			changefeedbase.OptEnvelope, opts[changefeedbase.OptEnvelope])
+			changefeedbase.OptEnvelope, encodingOpts.Envelope)
 	}
 
-	if _, ok := opts[changefeedbase.OptKeyInValue]; !ok {
+	if !encodingOpts.KeyInValue {
 		return nil, errors.Errorf(`this sink requires the WITH %s option`, changefeedbase.OptKeyInValue)
 	}
 
-	if codec, ok := opts[changefeedbase.OptCompression]; ok && codec != "" {
+	if codec := encodingOpts.Compression; codec != "" {
 		if strings.EqualFold(codec, "gzip") {
 			s.compression = sinkCompressionGzip
 			s.ext = s.ext + ".gz"

--- a/pkg/ccl/changefeedccl/sink_pubsub.go
+++ b/pkg/ccl/changefeedccl/sink_pubsub.go
@@ -151,7 +151,7 @@ func getGCPCredentials(ctx context.Context, u sinkURL) (*google.Credentials, err
 func MakePubsubSink(
 	ctx context.Context,
 	u *url.URL,
-	opts map[string]string,
+	encodingOpts changefeedbase.EncodingOptions,
 	targets []jobspb.ChangefeedTargetSpecification,
 ) (Sink, error) {
 
@@ -159,21 +159,21 @@ func MakePubsubSink(
 	pubsubTopicName := pubsubURL.consumeParam(changefeedbase.SinkParamTopicName)
 
 	var formatType changefeedbase.FormatType
-	switch changefeedbase.FormatType(opts[changefeedbase.OptFormat]) {
+	switch encodingOpts.Format {
 	case changefeedbase.OptFormatJSON:
 		formatType = changefeedbase.OptFormatJSON
 	case changefeedbase.OptFormatCSV:
 		formatType = changefeedbase.OptFormatCSV
 	default:
 		return nil, errors.Errorf(`this sink is incompatible with %s=%s`,
-			changefeedbase.OptFormat, opts[changefeedbase.OptFormat])
+			changefeedbase.OptFormat, encodingOpts.Format)
 	}
 
-	switch changefeedbase.EnvelopeType(opts[changefeedbase.OptEnvelope]) {
+	switch encodingOpts.Envelope {
 	case changefeedbase.OptEnvelopeWrapped:
 	default:
 		return nil, errors.Errorf(`this sink is incompatible with %s=%s`,
-			changefeedbase.OptEnvelope, opts[changefeedbase.OptEnvelope])
+			changefeedbase.OptEnvelope, encodingOpts.Envelope)
 	}
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -531,7 +531,7 @@ func TestSaramaConfigOptionParsing(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	t.Run("defaults returned if not option set", func(t *testing.T) {
-		opts := make(map[string]string)
+		opts := changefeedbase.SinkSpecificJSONConfig("")
 
 		expected := defaultSaramaConfig()
 
@@ -540,8 +540,7 @@ func TestSaramaConfigOptionParsing(t *testing.T) {
 		require.Equal(t, expected, cfg)
 	})
 	t.Run("options overlay defaults", func(t *testing.T) {
-		opts := make(map[string]string)
-		opts[changefeedbase.OptKafkaSinkConfig] = `{"Flush": {"MaxMessages": 1000, "Frequency": "1s"}}`
+		opts := changefeedbase.SinkSpecificJSONConfig(`{"Flush": {"MaxMessages": 1000, "Frequency": "1s"}}`)
 
 		expected := defaultSaramaConfig()
 		expected.Flush.MaxMessages = 1000
@@ -552,34 +551,31 @@ func TestSaramaConfigOptionParsing(t *testing.T) {
 		require.Equal(t, expected, cfg)
 	})
 	t.Run("validate returns nil for valid flush configuration", func(t *testing.T) {
-		opts := make(map[string]string)
+		opts := changefeedbase.SinkSpecificJSONConfig(`{"Flush": {"Messages": 1000, "Frequency": "1s"}}`)
 
-		opts[changefeedbase.OptKafkaSinkConfig] = `{"Flush": {"Messages": 1000, "Frequency": "1s"}}`
 		cfg, err := getSaramaConfig(opts)
 		require.NoError(t, err)
 		require.NoError(t, cfg.Validate())
 
-		opts[changefeedbase.OptKafkaSinkConfig] = `{"Flush": {"Messages": 1}}`
+		opts = `{"Flush": {"Messages": 1}}`
 		cfg, err = getSaramaConfig(opts)
 		require.NoError(t, err)
 		require.NoError(t, cfg.Validate())
 	})
 	t.Run("validate returns error for bad flush configuration", func(t *testing.T) {
-		opts := make(map[string]string)
-		opts[changefeedbase.OptKafkaSinkConfig] = `{"Flush": {"Messages": 1000}}`
+		opts := changefeedbase.SinkSpecificJSONConfig(`{"Flush": {"Messages": 1000}}`)
 
 		cfg, err := getSaramaConfig(opts)
 		require.NoError(t, err)
 		require.Error(t, cfg.Validate())
 
-		opts[changefeedbase.OptKafkaSinkConfig] = `{"Flush": {"Bytes": 10}}`
+		opts = `{"Flush": {"Bytes": 10}}`
 		cfg, err = getSaramaConfig(opts)
 		require.NoError(t, err)
 		require.Error(t, cfg.Validate())
 	})
 	t.Run("apply parses valid version", func(t *testing.T) {
-		opts := make(map[string]string)
-		opts[changefeedbase.OptKafkaSinkConfig] = `{"version": "0.8.2.0"}`
+		opts := changefeedbase.SinkSpecificJSONConfig(`{"version": "0.8.2.0"}`)
 
 		cfg, err := getSaramaConfig(opts)
 		require.NoError(t, err)
@@ -590,8 +586,7 @@ func TestSaramaConfigOptionParsing(t *testing.T) {
 		require.Equal(t, sarama.V0_8_2_0, saramaCfg.Version)
 	})
 	t.Run("apply parses valid version with capitalized key", func(t *testing.T) {
-		opts := make(map[string]string)
-		opts[changefeedbase.OptKafkaSinkConfig] = `{"Version": "0.8.2.0"}`
+		opts := changefeedbase.SinkSpecificJSONConfig(`{"Version": "0.8.2.0"}`)
 
 		cfg, err := getSaramaConfig(opts)
 		require.NoError(t, err)
@@ -602,8 +597,7 @@ func TestSaramaConfigOptionParsing(t *testing.T) {
 		require.Equal(t, sarama.V0_8_2_0, saramaCfg.Version)
 	})
 	t.Run("apply allows for unset version", func(t *testing.T) {
-		opts := make(map[string]string)
-		opts[changefeedbase.OptKafkaSinkConfig] = `{}`
+		opts := changefeedbase.SinkSpecificJSONConfig(`{}`)
 
 		cfg, err := getSaramaConfig(opts)
 		require.NoError(t, err)
@@ -614,8 +608,7 @@ func TestSaramaConfigOptionParsing(t *testing.T) {
 		require.Equal(t, sarama.KafkaVersion{}, saramaCfg.Version)
 	})
 	t.Run("apply errors if version is invalid", func(t *testing.T) {
-		opts := make(map[string]string)
-		opts[changefeedbase.OptKafkaSinkConfig] = `{"version": "invalid"}`
+		opts := changefeedbase.SinkSpecificJSONConfig(`{"version": "invalid"}`)
 
 		cfg, err := getSaramaConfig(opts)
 		require.NoError(t, err)
@@ -625,8 +618,7 @@ func TestSaramaConfigOptionParsing(t *testing.T) {
 		require.Error(t, err)
 	})
 	t.Run("apply parses RequiredAcks", func(t *testing.T) {
-		opts := make(map[string]string)
-		opts[changefeedbase.OptKafkaSinkConfig] = `{"RequiredAcks": "ALL"}`
+		opts := changefeedbase.SinkSpecificJSONConfig(`{"RequiredAcks": "ALL"}`)
 
 		cfg, err := getSaramaConfig(opts)
 		require.NoError(t, err)
@@ -636,7 +628,7 @@ func TestSaramaConfigOptionParsing(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, sarama.WaitForAll, saramaCfg.Producer.RequiredAcks)
 
-		opts[changefeedbase.OptKafkaSinkConfig] = `{"RequiredAcks": "-1"}`
+		opts = changefeedbase.SinkSpecificJSONConfig(`{"RequiredAcks": "-1"}`)
 
 		cfg, err = getSaramaConfig(opts)
 		require.NoError(t, err)
@@ -648,8 +640,7 @@ func TestSaramaConfigOptionParsing(t *testing.T) {
 
 	})
 	t.Run("apply errors if RequiredAcks is invalid", func(t *testing.T) {
-		opts := make(map[string]string)
-		opts[changefeedbase.OptKafkaSinkConfig] = `{"RequiredAcks": "LocalQuorum"}`
+		opts := changefeedbase.SinkSpecificJSONConfig(`{"RequiredAcks": "LocalQuorum"}`)
 
 		cfg, err := getSaramaConfig(opts)
 		require.NoError(t, err)

--- a/pkg/ccl/changefeedccl/sink_webhook.go
+++ b/pkg/ccl/changefeedccl/sink_webhook.go
@@ -236,16 +236,16 @@ type webhookSinkConfig struct {
 }
 
 func (s *webhookSink) getWebhookSinkConfig(
-	opts map[string]string,
+	jsonStr changefeedbase.SinkSpecificJSONConfig,
 ) (batchCfg batchConfig, retryCfg retry.Options, err error) {
 	retryCfg = defaultRetryConfig()
 
 	var cfg webhookSinkConfig
 	cfg.Retry.Max = jsonMaxRetries(retryCfg.MaxRetries)
 	cfg.Retry.Backoff = jsonDuration(retryCfg.InitialBackoff)
-	if configStr, ok := opts[changefeedbase.OptWebhookSinkConfig]; ok {
+	if jsonStr != `` {
 		// set retry defaults to be overridden if included in JSON
-		if err = json.Unmarshal([]byte(configStr), &cfg); err != nil {
+		if err = json.Unmarshal([]byte(jsonStr), &cfg); err != nil {
 			return batchCfg, retryCfg, errors.Wrapf(err, "error unmarshalling json")
 		}
 	}
@@ -269,7 +269,8 @@ func (s *webhookSink) getWebhookSinkConfig(
 func makeWebhookSink(
 	ctx context.Context,
 	u sinkURL,
-	opts map[string]string,
+	encodingOpts changefeedbase.EncodingOptions,
+	opts changefeedbase.WebhookSinkOptions,
 	parallelism int,
 	source timeutil.TimeSource,
 	mb metricsRecorderBuilder,
@@ -279,66 +280,55 @@ func makeWebhookSink(
 	}
 	u.Scheme = strings.TrimPrefix(u.Scheme, `webhook-`)
 
-	var formatType changefeedbase.FormatType
-	switch changefeedbase.FormatType(opts[changefeedbase.OptFormat]) {
-	// only JSON and CSV supported at this time for webhook sink
+	switch encodingOpts.Format {
 	case changefeedbase.OptFormatJSON:
-		formatType = changefeedbase.OptFormatJSON
 	case changefeedbase.OptFormatCSV:
-		formatType = changefeedbase.OptFormatCSV
 	default:
 		return nil, errors.Errorf(`this sink is incompatible with %s=%s`,
-			changefeedbase.OptFormat, opts[changefeedbase.OptFormat])
+			changefeedbase.OptFormat, encodingOpts.Format)
 	}
 
-	switch changefeedbase.EnvelopeType(opts[changefeedbase.OptEnvelope]) {
+	switch encodingOpts.Envelope {
 	case changefeedbase.OptEnvelopeWrapped:
 	default:
 		return nil, errors.Errorf(`this sink is incompatible with %s=%s`,
-			changefeedbase.OptEnvelope, opts[changefeedbase.OptEnvelope])
+			changefeedbase.OptEnvelope, encodingOpts.Envelope)
 	}
 
-	if _, ok := opts[changefeedbase.OptKeyInValue]; !ok {
+	if !encodingOpts.KeyInValue {
 		return nil, errors.Errorf(`this sink requires the WITH %s option`, changefeedbase.OptKeyInValue)
 	}
 
-	if _, ok := opts[changefeedbase.OptTopicInValue]; !ok {
+	if !encodingOpts.TopicInValue {
 		return nil, errors.Errorf(`this sink requires the WITH %s option`, changefeedbase.OptTopicInValue)
 	}
 
-	var connTimeout time.Duration
-	if timeout, ok := opts[changefeedbase.OptWebhookClientTimeout]; ok {
-		var err error
-		connTimeout, err = time.ParseDuration(timeout)
-		if err != nil {
-			return nil, errors.Wrapf(err, "problem parsing option %s", changefeedbase.OptWebhookClientTimeout)
-		} else if connTimeout <= time.Duration(0) {
-			return nil, fmt.Errorf("option %s must be a positive duration", changefeedbase.OptWebhookClientTimeout)
-		}
-	} else {
-		connTimeout = defaultConnTimeout
+	connTimeout := opts.ClientTimeout
+	if connTimeout == nil {
+		t := defaultConnTimeout
+		connTimeout = &t
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
 
 	sink := &webhookSink{
 		workerCtx:   ctx,
-		authHeader:  opts[changefeedbase.OptWebhookAuthHeader],
-		format:      formatType,
+		authHeader:  opts.AuthHeader,
 		exitWorkers: cancel,
 		parallelism: parallelism,
 		ts:          source,
 		metrics:     mb(requiresResourceAccounting),
+		format:      encodingOpts.Format,
 	}
 
 	var err error
-	sink.batchCfg, sink.retryCfg, err = sink.getWebhookSinkConfig(opts)
+	sink.batchCfg, sink.retryCfg, err = sink.getWebhookSinkConfig(opts.JSONConfig)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error processing option %s", changefeedbase.OptWebhookSinkConfig)
 	}
 
 	// TODO(yevgeniy): Establish HTTP connection in Dial().
-	sink.client, err = makeWebhookClient(u, connTimeout)
+	sink.client, err = makeWebhookClient(u, *connTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -788,12 +778,4 @@ func (s *webhookSink) Close() error {
 	}
 	s.client.CloseIdleConnections()
 	return nil
-}
-
-// redactWebhookAuthHeader redacts sensitive information from `auth`, which
-// should be the value of the HTTP header `Authorization:`. The entire header
-// should be redacted here. Wrapped in a function so we can change the
-// redaction strategy if needed.
-func redactWebhookAuthHeader(_ string) string {
-	return "redacted"
 }

--- a/pkg/ccl/changefeedccl/sink_webhook_test.go
+++ b/pkg/ccl/changefeedccl/sink_webhook_test.go
@@ -29,7 +29,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func getGenericWebhookSinkOptions() map[string]string {
+func getGenericWebhookSinkOptions(
+	overrides ...struct {
+		key   string
+		value string
+	},
+) changefeedbase.StatementOptions {
+
 	opts := make(map[string]string)
 	opts[changefeedbase.OptFormat] = string(changefeedbase.OptFormatJSON)
 	opts[changefeedbase.OptKeyInValue] = ``
@@ -37,7 +43,12 @@ func getGenericWebhookSinkOptions() map[string]string {
 	opts[changefeedbase.OptTopicInValue] = ``
 	// speed up test by using faster backoff times
 	opts[changefeedbase.OptWebhookSinkConfig] = `{"Retry":{"Backoff": "5ms"}}`
-	return opts
+
+	for _, o := range overrides {
+		opts[o.key] = o.value
+	}
+
+	return changefeedbase.MakeStatementOptions(opts)
 }
 
 // repeatStatusCode returns an array of status codes that the mock
@@ -62,7 +73,17 @@ func setupWebhookSinkWithDetails(
 		return nil, err
 	}
 
-	sinkSrc, err := makeWebhookSink(ctx, sinkURL{URL: u}, details.Opts, parallelism, source, nilMetricsRecorderBuilder)
+	opts := changefeedbase.MakeStatementOptions(details.Opts)
+
+	encodingOpts, err := opts.GetEncodingOptions()
+	if err != nil {
+		return nil, err
+	}
+	sinkOpts, err := opts.GetWebhookSinkOptions()
+	if err != nil {
+		return nil, err
+	}
+	sinkSrc, err := makeWebhookSink(ctx, sinkURL{URL: u}, encodingOpts, sinkOpts, parallelism, source, nilMetricsRecorderBuilder)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +120,9 @@ func testSendAndReceiveRows(t *testing.T, sinkSrc Sink, sinkDest *cdctest.MockWe
 		"sink %s expected to receive message %s", sinkDest.URL(),
 		"{\"payload\":[{\"after\":null,\"key\":[1002],\"topic:\":\"foo\"}],\"length\":1}")
 
-	enc, err := makeJSONEncoder(getGenericWebhookSinkOptions(), []jobspb.ChangefeedTargetSpecification{})
+	opts, err := getGenericWebhookSinkOptions().GetEncodingOptions()
+	require.NoError(t, err)
+	enc, err := makeJSONEncoder(opts, []jobspb.ChangefeedTargetSpecification{})
 	require.NoError(t, err)
 
 	// test a resolved timestamp entry
@@ -224,11 +247,15 @@ func TestWebhookSink(t *testing.T) {
 
 	// run tests with parallelism from 1-4
 	opts := getGenericWebhookSinkOptions()
-	optsZeroValueConfig := getGenericWebhookSinkOptions()
-	optsZeroValueConfig[changefeedbase.OptWebhookSinkConfig] = `{"Retry":{"Backoff": "5ms"},"Flush":{"Bytes": 0, "Frequency": "0s", "Messages": 0}}`
+	optsZeroValueConfig := getGenericWebhookSinkOptions(
+		struct {
+			key   string
+			value string
+		}{changefeedbase.OptWebhookSinkConfig,
+			`{"Retry":{"Backoff": "5ms"},"Flush":{"Bytes": 0, "Frequency": "0s", "Messages": 0}}`})
 	for i := 1; i <= 4; i++ {
-		webhookSinkTestfn(i, opts)
-		webhookSinkTestfn(i, optsZeroValueConfig)
+		webhookSinkTestfn(i, opts.AsMap())
+		webhookSinkTestfn(i, optsZeroValueConfig.AsMap())
 	}
 }
 
@@ -247,8 +274,13 @@ func TestWebhookSinkWithAuthOptions(t *testing.T) {
 		sinkDest, err := cdctest.StartMockWebhookSinkWithBasicAuth(cert, username, password)
 		require.NoError(t, err)
 
-		opts := getGenericWebhookSinkOptions()
-		opts[changefeedbase.OptWebhookAuthHeader] = fmt.Sprintf("Basic %s", authHeader)
+		opts := getGenericWebhookSinkOptions(struct {
+			key   string
+			value string
+		}{
+			key:   changefeedbase.OptWebhookAuthHeader,
+			value: fmt.Sprintf("Basic %s", authHeader),
+		})
 
 		sinkDestHost, err := url.Parse(sinkDest.URL())
 		require.NoError(t, err)
@@ -259,7 +291,7 @@ func TestWebhookSinkWithAuthOptions(t *testing.T) {
 
 		details := jobspb.ChangefeedDetails{
 			SinkURI: fmt.Sprintf("webhook-%s", sinkDestHost.String()),
-			Opts:    opts,
+			Opts:    opts.AsMap(),
 		}
 
 		sinkSrc, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, timeutil.DefaultTimeSource{})
@@ -268,7 +300,7 @@ func TestWebhookSinkWithAuthOptions(t *testing.T) {
 		testSendAndReceiveRows(t, sinkSrc, sinkDest)
 
 		// no credentials should result in a 401
-		delete(opts, changefeedbase.OptWebhookAuthHeader)
+		delete(details.Opts, changefeedbase.OptWebhookAuthHeader)
 		sinkSrcNoCreds, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, timeutil.DefaultTimeSource{})
 		require.NoError(t, err)
 		require.NoError(t, sinkSrcNoCreds.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, zeroAlloc))
@@ -280,7 +312,7 @@ func TestWebhookSinkWithAuthOptions(t *testing.T) {
 		// wrong credentials should result in a 401 as well
 		var wrongAuthHeader string
 		cdctest.EncodeBase64ToString([]byte(fmt.Sprintf("%s:%s", username, "wrong-password")), &wrongAuthHeader)
-		opts[changefeedbase.OptWebhookAuthHeader] = fmt.Sprintf("Basic %s", wrongAuthHeader)
+		details.Opts[changefeedbase.OptWebhookAuthHeader] = fmt.Sprintf("Basic %s", wrongAuthHeader)
 		sinkSrcWrongCreds, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, timeutil.DefaultTimeSource{})
 		require.NoError(t, err)
 
@@ -307,8 +339,13 @@ func TestWebhookSinkConfig(t *testing.T) {
 
 	var pool testAllocPool
 	retryThenSuccessFn := func(parallelism int) {
-		opts := getGenericWebhookSinkOptions()
-		opts[changefeedbase.OptWebhookSinkConfig] = `{"Retry":{"Backoff": "5ms", "Max": 6}}`
+		opts := getGenericWebhookSinkOptions(struct {
+			key   string
+			value string
+		}{
+			key:   changefeedbase.OptWebhookSinkConfig,
+			value: `{"Retry":{"Backoff": "5ms", "Max": 6}}`,
+		})
 		cert, certEncoded, err := cdctest.NewCACertBase64Encoded()
 		require.NoError(t, err)
 		sinkDest, err := cdctest.StartMockWebhookSink(cert)
@@ -327,7 +364,7 @@ func TestWebhookSinkConfig(t *testing.T) {
 
 		details := jobspb.ChangefeedDetails{
 			SinkURI: fmt.Sprintf("webhook-%s", sinkDestHost.String()),
-			Opts:    opts,
+			Opts:    opts.AsMap(),
 		}
 
 		sinkSrc, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, timeutil.DefaultTimeSource{})
@@ -362,7 +399,7 @@ func TestWebhookSinkConfig(t *testing.T) {
 
 		details := jobspb.ChangefeedDetails{
 			SinkURI: fmt.Sprintf("webhook-%s", sinkDestHost.String()),
-			Opts:    opts,
+			Opts:    opts.AsMap(),
 		}
 
 		sinkSrc, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, timeutil.DefaultTimeSource{})
@@ -381,8 +418,12 @@ func TestWebhookSinkConfig(t *testing.T) {
 	}
 
 	retryThenFailureCustomFn := func(parallelism int) {
-		opts := getGenericWebhookSinkOptions()
-		opts[changefeedbase.OptWebhookSinkConfig] = `{"Retry":{"Backoff": "5ms", "Max": "6"}}`
+		opts := getGenericWebhookSinkOptions(struct {
+			key   string
+			value string
+		}{
+			key:   changefeedbase.OptWebhookSinkConfig,
+			value: `{"Retry":{"Backoff": "5ms", "Max": "6"}}`})
 		cert, certEncoded, err := cdctest.NewCACertBase64Encoded()
 		require.NoError(t, err)
 		sinkDest, err := cdctest.StartMockWebhookSink(cert)
@@ -400,7 +441,7 @@ func TestWebhookSinkConfig(t *testing.T) {
 
 		details := jobspb.ChangefeedDetails{
 			SinkURI: fmt.Sprintf("webhook-%s", sinkDestHost.String()),
-			Opts:    opts,
+			Opts:    opts.AsMap(),
 		}
 
 		sinkSrc, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, timeutil.DefaultTimeSource{})
@@ -419,8 +460,13 @@ func TestWebhookSinkConfig(t *testing.T) {
 	}
 
 	largeBatchSizeFn := func(parallelism int) {
-		opts := getGenericWebhookSinkOptions()
-		opts[changefeedbase.OptWebhookSinkConfig] = `{"Retry":{"Backoff": "5ms"},"Flush":{"Messages": 5, "Frequency": "1h"}}`
+		opts := getGenericWebhookSinkOptions(struct {
+			key   string
+			value string
+		}{
+			key:   changefeedbase.OptWebhookSinkConfig,
+			value: `{"Retry":{"Backoff": "5ms"},"Flush":{"Messages": 5, "Frequency": "1h"}}`,
+		})
 		cert, certEncoded, err := cdctest.NewCACertBase64Encoded()
 		require.NoError(t, err)
 		sinkDest, err := cdctest.StartMockWebhookSink(cert)
@@ -435,7 +481,7 @@ func TestWebhookSinkConfig(t *testing.T) {
 
 		details := jobspb.ChangefeedDetails{
 			SinkURI: fmt.Sprintf("webhook-%s", sinkDestHost.String()),
-			Opts:    opts,
+			Opts:    opts.AsMap(),
 		}
 
 		mt := timeutil.NewManualTime(timeutil.Now())
@@ -479,8 +525,13 @@ func TestWebhookSinkConfig(t *testing.T) {
 	}
 
 	largeBatchBytesFn := func(parallelism int) {
-		opts := getGenericWebhookSinkOptions()
-		opts[changefeedbase.OptWebhookSinkConfig] = `{"Retry":{"Backoff": "5ms"},"Flush":{"Bytes": 330, "Frequency": "1h"}}`
+		opts := getGenericWebhookSinkOptions(struct {
+			key   string
+			value string
+		}{
+			key:   changefeedbase.OptWebhookSinkConfig,
+			value: `{"Retry":{"Backoff": "5ms"},"Flush":{"Bytes": 330, "Frequency": "1h"}}`,
+		})
 		cert, certEncoded, err := cdctest.NewCACertBase64Encoded()
 		require.NoError(t, err)
 		sinkDest, err := cdctest.StartMockWebhookSink(cert)
@@ -495,7 +546,7 @@ func TestWebhookSinkConfig(t *testing.T) {
 
 		details := jobspb.ChangefeedDetails{
 			SinkURI: fmt.Sprintf("webhook-%s", sinkDestHost.String()),
-			Opts:    opts,
+			Opts:    opts.AsMap(),
 		}
 
 		sinkSrc, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, timeutil.DefaultTimeSource{})
@@ -524,8 +575,13 @@ func TestWebhookSinkConfig(t *testing.T) {
 	}
 
 	largeBatchFrequencyFn := func(parallelism int) {
-		opts := getGenericWebhookSinkOptions()
-		opts[changefeedbase.OptWebhookSinkConfig] = `{"Retry":{"Backoff": "5ms"},"Flush":{"Messages": 10, "Frequency": "1h"}}`
+		opts := getGenericWebhookSinkOptions(struct {
+			key   string
+			value string
+		}{
+			key:   changefeedbase.OptWebhookSinkConfig,
+			value: `{"Retry":{"Backoff": "5ms"},"Flush":{"Messages": 10, "Frequency": "1h"}}`,
+		})
 		cert, certEncoded, err := cdctest.NewCACertBase64Encoded()
 		require.NoError(t, err)
 		sinkDest, err := cdctest.StartMockWebhookSink(cert)
@@ -540,7 +596,7 @@ func TestWebhookSinkConfig(t *testing.T) {
 
 		details := jobspb.ChangefeedDetails{
 			SinkURI: fmt.Sprintf("webhook-%s", sinkDestHost.String()),
-			Opts:    opts,
+			Opts:    opts.AsMap(),
 		}
 
 		mt := timeutil.NewManualTime(timeutil.Now())
@@ -612,7 +668,7 @@ func TestWebhookSinkShutsDownOnError(t *testing.T) {
 
 		details := jobspb.ChangefeedDetails{
 			SinkURI: fmt.Sprintf("webhook-%s", sinkDestHost.String()),
-			Opts:    opts,
+			Opts:    opts.AsMap(),
 		}
 
 		sinkSrc, err := setupWebhookSinkWithDetails(ctx, details, parallelism, timeutil.DefaultTimeSource{})

--- a/pkg/sql/delegate/show_changefeed_jobs.go
+++ b/pkg/sql/delegate/show_changefeed_jobs.go
@@ -63,7 +63,7 @@ SELECT
       table_id = ANY (descriptor_ids)
   ) AS full_table_names, 
   changefeed_details->'opts'->>'topics' AS topics,
-  changefeed_details->'opts'->>'format' AS format 
+  COALESCE(changefeed_details->'opts'->>'format','json') AS format 
 FROM 
   crdb_internal.jobs 
   INNER JOIN payload ON id = job_id`


### PR DESCRIPTION
Why did I think this would be a quick win. This was slow and boring
and might be too big a diff to do in one go.

This PR makes the WITH options map into a typed object,
and moves a lot of the parsing and validation code into methods on
that object so that sinks, encoders, and so on can take small
typed objects instead of the whole giant untyped map. The only
time we still treat it as a giant map is input validation.

I've kept the parsing of JSON WITH options in the individual sinks
to go along with the 'quick and dirty add anything' vibe they have.

There's still work to do here: the protos used to communicate
state live outside of ccl, so we're still passing around the
untyped map a lot. And some more logic that could be moved into
options.go . But the diff is big enough already.

Release note: None

Closes https://github.com/cockroachdb/cockroach/issues/80105