### PR TITLE
cluster-ui: fix storybook config

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/.storybook/main.js
+++ b/pkg/ui/workspaces/cluster-ui/.storybook/main.js
@@ -9,7 +9,7 @@
 // licenses/APL.txt.
 
 const path = require("path");
-const appConfig = require("../webpack.config")();
+const appConfig = require("../webpack.config");
 
 const customConfig = appConfig();
 


### PR DESCRIPTION
Previously there were two PRs merged that fixed
the broken storybook config. These commits had
clashing changes that ended up breaking the
config. This commit consolidates the two PRs
to fix storybook.

Release note: None