### PR TITLE
opt: remove outdated TODO

### DIFF
--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -34,7 +34,6 @@ import (
 
 // mutationBuilder is a helper struct that supports building Insert, Update,
 // Upsert, and Delete operators in stages.
-// TODO(andyk): Add support for Delete.
 type mutationBuilder struct {
 	b  *Builder
 	md *opt.Metadata


### PR DESCRIPTION
A TODO to add DELETE support to the cost-based optimizer has been
removed, because DELETE is already supported.

Release note: None