### PR TITLE
[WIP] sql: pass `descs.Collection` to `InternalExecutor` under planner context

### DIFF
--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -67,11 +67,11 @@ exp,benchmark
 2,ORMQueries/has_table_privilege_1
 4,ORMQueries/has_table_privilege_3
 6,ORMQueries/has_table_privilege_5
-15,ORMQueries/information_schema._pg_index_position
+3,ORMQueries/information_schema._pg_index_position
 2,ORMQueries/pg_attribute
 2,ORMQueries/pg_class
 11,ORMQueries/pg_is_other_temp_schema
-23,ORMQueries/pg_is_other_temp_schema_multiple_times
+18,ORMQueries/pg_is_other_temp_schema_multiple_times
 4,ORMQueries/pg_my_temp_schema
 4,ORMQueries/pg_my_temp_schema_multiple_times
 4,ORMQueries/pg_namespace

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -916,7 +916,13 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		collectionFactory,
 		&execCfg.Settings.SV,
 	)
-	execCfg.InternalExecutorFactory = ieFactory
+
+	execCfg.InternalExecutorProto = sql.MakeInternalExecutorProto(
+		ctx,
+		pgServer.SQLServer,
+		internalMemMetrics,
+		cfg.Settings,
+	)
 
 	distSQLServer.ServerConfig.ProtectedTimestampProvider = execCfg.ProtectedTimestampProvider
 

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -731,7 +731,7 @@ func (sc *SchemaChanger) validateConstraints(
 				ie := makeSessionBoundInternalExecutorFromProtoUnderPlanner(
 					sc.execCfg.InternalExecutorProto,
 					evalCtx.SessionData(),
-					extraTxnStateUnderPlanner{descCollection: evalCtx.Descs},
+					extraTxnStateUnderPlanner{descCollection: collection},
 				)
 
 				if c.IsCheck() {

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -173,6 +173,11 @@ func (tc *Collection) ReleaseLeases(ctx context.Context) {
 	tc.sqlLivenessSession = nil
 }
 
+// ResetSyntheticDescriptors clear all syntheticDescriptors.
+func (tc *Collection) ResetSyntheticDescriptors() {
+	tc.synthetic.reset()
+}
+
 // ReleaseAll releases all state currently held by the Collection.
 // ReleaseAll calls ReleaseLeases.
 func (tc *Collection) ReleaseAll(ctx context.Context) {

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -50,8 +50,8 @@ func makeCollection(
 	virtualSchemas catalog.VirtualSchemas,
 	temporarySchemaProvider TemporarySchemaProvider,
 	monitor *mon.BytesMonitor,
-) Collection {
-	return Collection{
+) *Collection {
+	return &Collection{
 		settings:       settings,
 		version:        settings.Version.ActiveVersion(ctx),
 		hydratedTables: hydratedTables,

--- a/pkg/sql/catalog/descs/factory.go
+++ b/pkg/sql/catalog/descs/factory.go
@@ -75,7 +75,7 @@ func NewBareBonesCollectionFactory(
 // MakeCollection constructs a Collection for the purposes of embedding.
 func (cf *CollectionFactory) MakeCollection(
 	ctx context.Context, temporarySchemaProvider TemporarySchemaProvider, monitor *mon.BytesMonitor,
-) Collection {
+) *Collection {
 	if monitor == nil {
 		// If an upstream monitor is not provided, the default, unlimited monitor will be used.
 		// All downstream resource allocation/releases on this default monitor will then be no-ops.
@@ -91,5 +91,5 @@ func (cf *CollectionFactory) NewCollection(
 	ctx context.Context, temporarySchemaProvider TemporarySchemaProvider,
 ) *Collection {
 	c := cf.MakeCollection(ctx, temporarySchemaProvider, nil /* monitor */)
-	return &c
+	return c
 }

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -922,7 +922,7 @@ func (s *Server) newConnExecutor(
 	}
 	ex.extraTxnState.prepStmtsNamespaceMemAcc = ex.sessionMon.MakeBoundAccount()
 	if descsCollection != nil {
-		ex.extraTxnState.descsCollectionInConnEx.descCollection = *descsCollection
+		ex.extraTxnState.descsCollectionInConnEx.descCollection = descsCollection
 		ex.extraTxnState.descsCollectionInConnEx.skipRelease = true
 	} else {
 		ex.extraTxnState.descsCollectionInConnEx.descCollection = s.cfg.CollectionFactory.MakeCollection(
@@ -1174,7 +1174,7 @@ type HasAdminRoleCache struct {
 
 type descsCollectionInConnEx struct {
 	// descCollection collects descriptors used by the current transaction.
-	descCollection descs.Collection
+	descCollection *descs.Collection
 	// skipRelease marks if the collection should be released when closing this
 	// conn executor. It should be set true when the descCollection is passed
 	// from a parent planner.
@@ -2696,7 +2696,7 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 		},
 		Tracing:                &ex.sessionTracing,
 		MemMetrics:             &ex.memMetrics,
-		Descs:                  &ex.extraTxnState.descsCollectionInConnEx.descCollection,
+		Descs:                  ex.extraTxnState.descsCollectionInConnEx.descCollection,
 		TxnModesSetter:         ex,
 		Jobs:                   &ex.extraTxnState.jobs,
 		SchemaChangeJobRecords: ex.extraTxnState.schemaChangeJobRecords,
@@ -3210,7 +3210,7 @@ func (ex *connExecutor) runPreCommitStages(ctx context.Context) error {
 		ex.planner.User(),
 		ex.server.cfg,
 		ex.planner.txn,
-		&ex.extraTxnState.descsCollectionInConnEx.descCollection,
+		ex.extraTxnState.descsCollectionInConnEx.descCollection,
 		ex.planner.EvalContext(),
 		ex.planner.ExtendedEvalContext().Tracing.KVTracingEnabled(),
 		scs.jobID,

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1662,6 +1662,8 @@ func (ex *connExecutor) resetExtraTxnState(ctx context.Context, ev txnEvent) err
 
 	if !ex.extraTxnState.descsCollectionInConnEx.skipRelease {
 		ex.extraTxnState.descsCollectionInConnEx.descCollection.ReleaseAll(ctx)
+	} else {
+		ex.extraTxnState.descsCollectionInConnEx.descCollection.ResetSyntheticDescriptors()
 	}
 
 	// Close all portals.

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -839,7 +839,7 @@ func (ex *connExecutor) checkDescriptorTwoVersionInvariant(ctx context.Context) 
 
 	if err := descs.CheckSpanCountLimit(
 		ctx,
-		&ex.extraTxnState.descsCollectionInConnEx.descCollection,
+		ex.extraTxnState.descsCollectionInConnEx.descCollection,
 		ex.server.cfg.SpanConfigSplitter,
 		ex.server.cfg.SpanConfigLimiter,
 		ex.state.mu.txn,
@@ -851,7 +851,7 @@ func (ex *connExecutor) checkDescriptorTwoVersionInvariant(ctx context.Context) 
 		ctx,
 		ex.server.cfg.Clock,
 		ex.server.cfg.InternalExecutor,
-		&ex.extraTxnState.descsCollectionInConnEx.descCollection,
+		ex.extraTxnState.descsCollectionInConnEx.descCollection,
 		ex.state.mu.txn,
 		inRetryBackoff,
 	)

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -89,7 +89,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessioninit"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -1318,10 +1317,10 @@ type ExecutorConfig struct {
 	// records.
 	SpanConfigKVAccessor spanconfig.KVAccessor
 
-	// InternalExecutorFactory is used to create an InternalExecutor binded with
-	// SessionData and other ExtraTxnState.
-	// This is currently only for builtin functions where we need to execute sql.
-	InternalExecutorFactory sqlutil.SessionBoundInternalExecutorFactory
+	// InternalExecutorProto is an incomplete internal executor, it cannot be
+	// used to execute queries without being bound to session data and extra
+	// transaction states.
+	InternalExecutorProto InternalExecutorProto
 
 	// ConsistencyChecker is to generate the results in calls to
 	// crdb_internal.check_consistency.

--- a/pkg/sql/execstats/traceanalyzer_test.go
+++ b/pkg/sql/execstats/traceanalyzer_test.go
@@ -108,14 +108,18 @@ func TestTraceAnalyzer(t *testing.T) {
 	for _, vectorizeMode := range []sessiondatapb.VectorizeExecMode{sessiondatapb.VectorizeOff, sessiondatapb.VectorizeOn} {
 		execCtx, finishAndCollect := tracing.ContextWithRecordingSpan(ctx, execCfg.AmbientCtx.Tracer, t.Name())
 		defer finishAndCollect()
-		ie := execCfg.InternalExecutorFactory(ctx, &sessiondata.SessionData{
-			SessionData: sessiondatapb.SessionData{
-				VectorizeMode: vectorizeMode,
+
+		ie := sql.MakeSessionBoundedInternalExecutorFromProto(execCfg.InternalExecutorProto,
+			&sessiondata.SessionData{
+				SessionData: sessiondatapb.SessionData{
+					VectorizeMode: vectorizeMode,
+				},
+				LocalOnlySessionData: sessiondatapb.LocalOnlySessionData{
+					DistSQLMode: sessiondatapb.DistSQLOn,
+				},
 			},
-			LocalOnlySessionData: sessiondatapb.LocalOnlySessionData{
-				DistSQLMode: sessiondatapb.DistSQLOn,
-			},
-		})
+		)
+
 		_, err := ie.ExecEx(
 			execCtx,
 			t.Name(),

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -1119,7 +1119,11 @@ func (*importResumer) checkVirtualConstraints(
 		}
 
 		if err := execCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-			ie := execCfg.InternalExecutorFactory(ctx, sql.NewFakeSessionData(execCfg.SV()))
+
+			ie := sql.MakeSessionBoundedInternalExecutorFromProto(execCfg.InternalExecutorProto,
+				sql.NewFakeSessionData(execCfg.SV()),
+			)
+
 			return ie.WithSyntheticDescriptors([]catalog.Descriptor{desc}, func() error {
 				return sql.RevalidateUniqueConstraintsInTable(ctx, txn, ie, desc)
 			})

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -323,9 +323,12 @@ func (ih *instrumentationHelper) Finish(
 
 	var bundle diagnosticsBundle
 	if ih.collectBundle {
-		ie := p.extendedEvalCtx.ExecCfg.InternalExecutorFactory(
-			p.EvalContext().Context,
+		ie := makeSessionBoundInternalExecutorFromProtoUnderPlanner(
+			p.ExecCfg().InternalExecutorProto,
 			p.SessionData(),
+			extraTxnStateUnderPlanner{
+				descCollection: p.Descriptors(),
+			},
 		)
 		phaseTimes := statsCollector.PhaseTimes()
 		if ih.stmtDiagnosticsRecorder.IsExecLatencyConditionMet(

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -792,6 +792,15 @@ func (ie *InternalExecutor) execInternal(
 	errCallback := func(err error) {
 		_ = rw.addResult(ctx, ieIteratorResult{err: err})
 	}
+
+	// TODO(janexing): for debugging, should be removed
+	//if txn != nil && ie.extraTxnState != nil {
+	//	if ie.extraTxnState.descCollection != nil {
+	//		fmt.Println("touched:", opName)
+	//		fmt.Printf("&wg:%p\n", &wg)
+	//	}
+	//}
+
 	ie.initConnEx(ctx, txn, rw, sd, stmtBuf, &wg, syncCallback, errCallback)
 
 	typeHints := make(tree.PlaceholderTypes, len(datums))

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -126,7 +126,7 @@ type InternalExecutor struct {
 }
 
 // WithSyntheticDescriptors sets the synthetic descriptors before running the
-// the provided closure and resets them afterward. Used for queries/statements
+// provided closure and resets them afterward. Used for queries/statements
 // that need to use in-memory synthetic descriptors different from descriptors
 // written to disk. These descriptors override all other descriptors on the
 // immutable resolution path.

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -355,7 +355,11 @@ CREATE TABLE IF NOT EXISTS user_checklist_items (
     create_date TIMESTAMPTZ NOT NULL,
     PRIMARY KEY (tenant_id, location_id, checklist_item_id, user_id)
 );
+
+statement ok
 CREATE INDEX IF NOT EXISTS userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem ON user_checklist_items (tenant_id, user_id, date_should_be_completed, location_name, title, order_item, checklist_item_id) USING HASH WITH (bucket_count=8);
+
+statement ok
 CREATE INDEX IF NOT EXISTS userchecklistitems_tenantid_locationid_configurationmaintenanceid_configurationmaintenanceitemid_dateshouldbecompleted ON user_checklist_items (tenant_id, location_id, configuration_maintenance_id, configuration_maintenance_item_id, date_should_be_completed) USING HASH WITH (bucket_count=8);
 
 statement ok

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1165,10 +1165,12 @@ func (e *urlOutputter) finish() (url.URL, error) {
 func (ef *execFactory) showEnv(plan string, envOpts exec.ExplainEnvData) (exec.Node, error) {
 	var out urlOutputter
 
-	ie := ef.planner.extendedEvalCtx.ExecCfg.InternalExecutorFactory(
-		ef.planner.EvalContext().Context,
+	ie := makeSessionBoundInternalExecutorFromProtoUnderPlanner(
+		ef.planner.ExecCfg().InternalExecutorProto,
 		ef.planner.SessionData(),
+		extraTxnStateUnderPlanner{descCollection: ef.planner.Descriptors()},
 	)
+
 	c := makeStmtEnvCollector(ef.planner.EvalContext().Context, ie.(*InternalExecutor))
 
 	// Show the version of Cockroach running.

--- a/pkg/sql/resolve_oid.go
+++ b/pkg/sql/resolve_oid.go
@@ -29,7 +29,11 @@ import (
 func (p *planner) ResolveOIDFromString(
 	ctx context.Context, resultType *types.T, toResolve *tree.DString,
 ) (*tree.DOid, error) {
-	ie := p.ExecCfg().InternalExecutorFactory(ctx, p.SessionData())
+	ie := makeSessionBoundInternalExecutorFromProtoUnderPlanner(
+		p.ExecCfg().InternalExecutorProto,
+		p.SessionData(),
+		extraTxnStateUnderPlanner{descCollection: p.Descriptors()},
+	)
 	return resolveOID(
 		ctx, p.Txn(),
 		ie,
@@ -41,7 +45,11 @@ func (p *planner) ResolveOIDFromString(
 func (p *planner) ResolveOIDFromOID(
 	ctx context.Context, resultType *types.T, toResolve *tree.DOid,
 ) (*tree.DOid, error) {
-	ie := p.ExecCfg().InternalExecutorFactory(ctx, p.SessionData())
+	ie := makeSessionBoundInternalExecutorFromProtoUnderPlanner(
+		p.ExecCfg().InternalExecutorProto,
+		p.SessionData(),
+		extraTxnStateUnderPlanner{descCollection: p.Descriptors()},
+	)
 	return resolveOID(
 		ctx, p.Txn(),
 		ie,

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -48,7 +48,11 @@ func (p *planner) DeclareCursor(ctx context.Context, s *tree.DeclareCursor) (pla
 				return nil, pgerror.Newf(pgcode.NoActiveSQLTransaction, "DECLARE CURSOR can only be used in transaction blocks")
 			}
 
-			ie := p.ExecCfg().InternalExecutorFactory(ctx, p.SessionData())
+			ie := makeSessionBoundInternalExecutorFromProtoUnderPlanner(
+				p.ExecCfg().InternalExecutorProto,
+				p.SessionData(),
+				extraTxnStateUnderPlanner{descCollection: p.Descriptors()},
+			)
 			cursorName := s.Name.String()
 			if cursor := p.sqlCursors.getCursor(cursorName); cursor != nil {
 				return nil, pgerror.Newf(pgcode.DuplicateCursor, "cursor %q already exists", cursorName)

--- a/pkg/sql/unsplit.go
+++ b/pkg/sql/unsplit.go
@@ -105,7 +105,13 @@ func (n *unsplitAllNode) startExec(params runParams) error {
 	if n.index.GetID() != n.tableDesc.GetPrimaryIndexID() {
 		indexName = n.index.GetName()
 	}
-	ie := params.p.ExecCfg().InternalExecutorFactory(params.ctx, params.SessionData())
+
+	ie := makeSessionBoundInternalExecutorFromProtoUnderPlanner(
+		params.p.ExecCfg().InternalExecutorProto,
+		params.p.SessionData(),
+		extraTxnStateUnderPlanner{descCollection: params.p.Descriptors()},
+	)
+
 	it, err := ie.QueryIteratorEx(
 		params.ctx, "split points query", params.p.txn, sessiondata.NoSessionDataOverride,
 		statement,


### PR DESCRIPTION
**WIP**

Currently, when an internal executor is used inside a transaction 
under a `planner` context, it always creates a new descriptor collection
rather than inheriting from the outer transaction. 

We'd like to pass `desc.Collection` to an internal executor **ONLY** when
the internal executor is used under the planner context. 
To do this, we
1. introduced a type `extraTxnStateUnderPlanner`, which is only accessible 
under the `sql` package;   
2. deprecate `ExecutorConfig.InternalExecutorFactory`, and break the internal
executor initialization into 2 steps:
    a. under `newSQLServer()`, we initialize an `InternalExecutorProto`, which 
        cannot be used to execute queries;
    b. initialize the true internal executor with `desc.Collection` via
        `extraTxnStateUnderPlanner`, if it's under the planner context.

Fixes https://github.com/cockroachdb/cockroach/issues/69495

Release note: None