### PR TITLE
release-21.1: roachtest: update django to 4.0.1

### DIFF
--- a/pkg/cmd/roachtest/django.go
+++ b/pkg/cmd/roachtest/django.go
@@ -19,8 +19,8 @@ import (
 var djangoReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<point>\d+))?$`)
 var djangoCockroachDBReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)$`)
 
-var djangoSupportedTag = "cockroach-3.2.x"
-var djangoCockroachDBSupportedTag = "3.2.1"
+var djangoSupportedTag = "cockroach-4.0.x"
+var djangoCockroachDBSupportedTag = "4.0.1"
 
 func registerDjango(r *testRegistry) {
 	runDjango := func(


### PR DESCRIPTION
Backport 1/1 commits from #80183.

/cc @cockroachdb/release

---

Fixes https://github.com/cockroachdb/cockroach/issues/80079

Release note: None

Release justification: justification for this backport.\n