### PR TITLE
sql/schemachanger/scplan/internal/opgen: optimize allocations

### DIFF
--- a/pkg/sql/schemachanger/scplan/internal/opgen/op_gen.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/op_gen.go
@@ -74,7 +74,7 @@ func (r *registry) buildGraph(cs scpb.CurrentState) (_ *scgraph.Graph, err error
 		for _, e := range edgesToAdd {
 			var ops []scop.Op
 			if e.ops != nil {
-				ops = e.ops(e.n.Element(), md)
+				ops = e.ops(e.n.Element(), &md)
 			}
 			if err := g.AddOpEdges(
 				e.n.Target, e.from, e.to, e.revertible, e.minPhase, ops...,

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_alias_type.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_alias_type.go
@@ -47,7 +47,7 @@ func init() {
 			),
 			to(scpb.Status_ABSENT,
 				minPhase(scop.PostCommitPhase),
-				emit(func(this *scpb.AliasType, md targetsWithElementMap) scop.Op {
+				emit(func(this *scpb.AliasType, md *targetsWithElementMap) scop.Op {
 					return newLogEventOp(this, md)
 				}),
 				emit(func(this *scpb.AliasType) scop.Op {

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_column.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_column.go
@@ -27,7 +27,7 @@ func init() {
 						Column: *protoutil.Clone(this).(*scpb.Column),
 					}
 				}),
-				emit(func(this *scpb.Column, md targetsWithElementMap) scop.Op {
+				emit(func(this *scpb.Column, md *targetsWithElementMap) scop.Op {
 					return newLogEventOp(this, md)
 				}),
 			),
@@ -59,7 +59,7 @@ func init() {
 						ColumnID: this.ColumnID,
 					}
 				}),
-				emit(func(this *scpb.Column, md targetsWithElementMap) scop.Op {
+				emit(func(this *scpb.Column, md *targetsWithElementMap) scop.Op {
 					return newLogEventOp(this, md)
 				}),
 			),

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_database.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_database.go
@@ -47,10 +47,10 @@ func init() {
 			),
 			to(scpb.Status_ABSENT,
 				minPhase(scop.PostCommitPhase),
-				emit(func(this *scpb.Database, md targetsWithElementMap) scop.Op {
+				emit(func(this *scpb.Database, md *targetsWithElementMap) scop.Op {
 					return newLogEventOp(this, md)
 				}),
-				emit(func(this *scpb.Database, md targetsWithElementMap) scop.Op {
+				emit(func(this *scpb.Database, md *targetsWithElementMap) scop.Op {
 					return &scop.CreateGcJobForDatabase{
 						DatabaseID:          this.DatabaseID,
 						StatementForDropJob: statementForDropJob(this, md),

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_enum_type.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_enum_type.go
@@ -47,7 +47,7 @@ func init() {
 			),
 			to(scpb.Status_ABSENT,
 				minPhase(scop.PostCommitPhase),
-				emit(func(this *scpb.EnumType, md targetsWithElementMap) scop.Op {
+				emit(func(this *scpb.EnumType, md *targetsWithElementMap) scop.Op {
 					return newLogEventOp(this, md)
 				}),
 				emit(func(this *scpb.EnumType) scop.Op {

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_primary_index.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_primary_index.go
@@ -89,7 +89,7 @@ func init() {
 				}),
 			),
 			to(scpb.Status_ABSENT,
-				emit(func(this *scpb.PrimaryIndex, md targetsWithElementMap) scop.Op {
+				emit(func(this *scpb.PrimaryIndex, md *targetsWithElementMap) scop.Op {
 					return &scop.CreateGcJobForIndex{
 						TableID:             this.TableID,
 						IndexID:             this.IndexID,

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_schema.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_schema.go
@@ -46,7 +46,7 @@ func init() {
 			),
 			to(scpb.Status_ABSENT,
 				minPhase(scop.PostCommitPhase),
-				emit(func(this *scpb.Schema, md targetsWithElementMap) scop.Op {
+				emit(func(this *scpb.Schema, md *targetsWithElementMap) scop.Op {
 					return newLogEventOp(this, md)
 				}),
 				emit(func(this *scpb.Schema) scop.Op {

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_sequence.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_sequence.go
@@ -52,10 +52,10 @@ func init() {
 			),
 			to(scpb.Status_ABSENT,
 				minPhase(scop.PostCommitPhase),
-				emit(func(this *scpb.Sequence, md targetsWithElementMap) scop.Op {
+				emit(func(this *scpb.Sequence, md *targetsWithElementMap) scop.Op {
 					return newLogEventOp(this, md)
 				}),
-				emit(func(this *scpb.Sequence, md targetsWithElementMap) scop.Op {
+				emit(func(this *scpb.Sequence, md *targetsWithElementMap) scop.Op {
 					return &scop.CreateGcJobForTable{
 						TableID:             this.SequenceID,
 						StatementForDropJob: statementForDropJob(this, md),

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_table.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_table.go
@@ -52,10 +52,10 @@ func init() {
 			),
 			to(scpb.Status_ABSENT,
 				minPhase(scop.PostCommitPhase),
-				emit(func(this *scpb.Table, md targetsWithElementMap) scop.Op {
+				emit(func(this *scpb.Table, md *targetsWithElementMap) scop.Op {
 					return newLogEventOp(this, md)
 				}),
-				emit(func(this *scpb.Table, md targetsWithElementMap) scop.Op {
+				emit(func(this *scpb.Table, md *targetsWithElementMap) scop.Op {
 					return &scop.CreateGcJobForTable{
 						TableID:             this.TableID,
 						StatementForDropJob: statementForDropJob(this, md),

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_view.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_view.go
@@ -70,10 +70,10 @@ func init() {
 			),
 			to(scpb.Status_ABSENT,
 				minPhase(scop.PostCommitPhase),
-				emit(func(this *scpb.View, md targetsWithElementMap) scop.Op {
+				emit(func(this *scpb.View, md *targetsWithElementMap) scop.Op {
 					return newLogEventOp(this, md)
 				}),
-				emit(func(this *scpb.View, md targetsWithElementMap) scop.Op {
+				emit(func(this *scpb.View, md *targetsWithElementMap) scop.Op {
 					if !this.IsMaterialized {
 						return nil
 


### PR DESCRIPTION
We were allocating the metadata every time we called a function because
of the way reflection works. It's not a huge optimization, but it's small enough that I'll take it. 

```
name                                                                old time/op    new time/op    delta
DropLargeDatabase/tables=4,columns=8,depth=2,declarative=true-16      77.0ms ± 6%    84.0ms ±18%    ~     (p=0.128 n=7+7)
DropLargeDatabase/tables=4,columns=16,depth=2,declarative=true-16     96.8ms ± 9%    99.7ms ± 2%    ~     (p=0.138 n=7+6)
DropLargeDatabase/tables=6,columns=12,depth=3,declarative=true-16      106ms ± 4%     103ms ± 3%    ~     (p=0.073 n=7+7)
DropLargeDatabase/tables=6,columns=24,depth=3,declarative=true-16      154ms ± 4%     150ms ± 4%    ~     (p=0.138 n=7+6)
DropLargeDatabase/tables=8,columns=16,depth=4,declarative=true-16      164ms ± 7%     162ms ± 4%    ~     (p=0.620 n=7+7)
DropLargeDatabase/tables=8,columns=32,depth=4,declarative=true-16      266ms ± 3%     264ms ± 3%    ~     (p=0.805 n=7+7)
DropLargeDatabase/tables=8,columns=16,depth=2,declarative=true-16      206ms ± 5%     205ms ± 5%    ~     (p=0.710 n=7+7)
DropLargeDatabase/tables=8,columns=32,depth=2,declarative=true-16      344ms ± 1%     338ms ± 3%    ~     (p=0.234 n=6+7)
DropLargeDatabase/tables=12,columns=24,depth=3,declarative=true-16     644ms ± 5%     633ms ± 1%    ~     (p=0.181 n=7+6)
DropLargeDatabase/tables=12,columns=48,depth=3,declarative=true-16     1.33s ±10%     1.23s ± 4%    ~     (p=0.053 n=7+7)
DropLargeDatabase/tables=16,columns=32,depth=4,declarative=true-16     2.84s ± 2%     2.60s ± 3%  -8.54%  (p=0.003 n=5+7)
DropLargeDatabase/tables=16,columns=64,depth=4,declarative=true-16     5.62s ± 3%     5.46s ± 1%  -2.89%  (p=0.011 n=7+7)

name                                                                old alloc/op   new alloc/op   delta
DropLargeDatabase/tables=4,columns=8,depth=2,declarative=true-16      17.4MB ± 1%    17.2MB ± 2%  -1.37%  (p=0.017 n=7+7)
DropLargeDatabase/tables=4,columns=16,depth=2,declarative=true-16     24.6MB ± 1%    24.5MB ± 1%    ~     (p=0.620 n=7+7)
DropLargeDatabase/tables=6,columns=12,depth=3,declarative=true-16     27.8MB ± 1%    27.5MB ± 0%  -0.92%  (p=0.001 n=7+6)
DropLargeDatabase/tables=6,columns=24,depth=3,declarative=true-16     43.3MB ± 1%    43.0MB ± 1%  -0.85%  (p=0.001 n=7+7)
DropLargeDatabase/tables=8,columns=16,depth=4,declarative=true-16     46.3MB ± 1%    46.2MB ± 1%    ~     (p=0.165 n=7+7)
DropLargeDatabase/tables=8,columns=32,depth=4,declarative=true-16     78.0MB ± 1%    77.7MB ± 1%    ~     (p=0.165 n=7+7)
DropLargeDatabase/tables=8,columns=16,depth=2,declarative=true-16     58.9MB ± 1%    58.6MB ± 0%  -0.58%  (p=0.008 n=7+6)
DropLargeDatabase/tables=8,columns=32,depth=2,declarative=true-16      103MB ± 0%     102MB ± 0%  -0.69%  (p=0.004 n=5+6)
DropLargeDatabase/tables=12,columns=24,depth=3,declarative=true-16     200MB ± 1%     199MB ± 0%  -0.80%  (p=0.001 n=7+7)
DropLargeDatabase/tables=12,columns=48,depth=3,declarative=true-16     369MB ± 0%     367MB ± 0%  -0.60%  (p=0.002 n=6+6)
DropLargeDatabase/tables=16,columns=32,depth=4,declarative=true-16     845MB ± 4%     814MB ± 0%  -3.62%  (p=0.001 n=7+7)
DropLargeDatabase/tables=16,columns=64,depth=4,declarative=true-16    1.73GB ± 0%    1.72GB ± 0%  -0.65%  (p=0.001 n=7+7)

name                                                                old allocs/op  new allocs/op  delta
DropLargeDatabase/tables=4,columns=8,depth=2,declarative=true-16        126k ± 0%      125k ± 0%  -0.84%  (p=0.001 n=7+6)
DropLargeDatabase/tables=4,columns=16,depth=2,declarative=true-16       172k ± 0%      170k ± 0%  -0.80%  (p=0.001 n=7+7)
DropLargeDatabase/tables=6,columns=12,depth=3,declarative=true-16       189k ± 0%      188k ± 0%  -0.82%  (p=0.001 n=7+7)
DropLargeDatabase/tables=6,columns=24,depth=3,declarative=true-16       286k ± 0%      284k ± 0%  -0.95%  (p=0.001 n=7+7)
DropLargeDatabase/tables=8,columns=16,depth=4,declarative=true-16       303k ± 0%      301k ± 0%  -0.83%  (p=0.001 n=7+7)
DropLargeDatabase/tables=8,columns=32,depth=4,declarative=true-16       504k ± 0%      499k ± 0%  -0.90%  (p=0.001 n=7+7)
DropLargeDatabase/tables=8,columns=16,depth=2,declarative=true-16       392k ± 0%      389k ± 0%  -0.89%  (p=0.001 n=6+7)
DropLargeDatabase/tables=8,columns=32,depth=2,declarative=true-16       663k ± 0%      657k ± 0%  -1.01%  (p=0.001 n=7+7)
DropLargeDatabase/tables=12,columns=24,depth=3,declarative=true-16     1.24M ± 0%     1.23M ± 0%  -1.04%  (p=0.001 n=6+7)
DropLargeDatabase/tables=12,columns=48,depth=3,declarative=true-16     2.36M ± 0%     2.33M ± 0%  -1.06%  (p=0.001 n=7+6)
DropLargeDatabase/tables=16,columns=32,depth=4,declarative=true-16     4.65M ± 2%     4.54M ± 0%  -2.35%  (p=0.001 n=7+7)
DropLargeDatabase/tables=16,columns=64,depth=4,declarative=true-16     9.30M ± 1%     9.18M ± 0%  -1.30%  (p=0.001 n=7+7)
```

Release note: None