### PR TITLE
metric: Add new alerting rules from docs

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -202,6 +202,7 @@ ALL_TESTS = [
     "//pkg/server/heapprofiler:heapprofiler_test",
     "//pkg/server/pgurl:pgurl_test",
     "//pkg/server/serverpb:serverpb_test",
+    "//pkg/server/serverrules:serverrules_test",
     "//pkg/server/settingswatcher:settingswatcher_test",
     "//pkg/server/status:status_test",
     "//pkg/server/systemconfigwatcher:systemconfigwatcher_test",

--- a/pkg/kv/kvserver/metric_rules.go
+++ b/pkg/kv/kvserver/metric_rules.go
@@ -32,6 +32,7 @@ const (
 	capacityAvailableRatioRuleName        = "capacity_available:ratio"
 	nodeCapacityAvailableRatioRuleName    = "node:capacity_available:ratio"
 	clusterCapacityAvailableRatioRuleName = "cluster:capacity_available:ratio"
+	nodeCapacityLowRuleName               = "NodeCapacityLow"
 )
 
 // CreateAndAddRules initializes all KV metric rules and adds them
@@ -50,6 +51,7 @@ func CreateAndAddRules(ctx context.Context, ruleRegistry *metric.RuleRegistry) {
 	createAndRegisterCapacityAvailableRatioRule(ctx, ruleRegistry)
 	createAndRegisterNodeCapacityAvailableRatioRule(ctx, ruleRegistry)
 	createAndRegisterClusterCapacityAvailableRatioRule(ctx, ruleRegistry)
+	createAndRegisterNodeCapacityLowRule(ctx, ruleRegistry)
 }
 
 func createAndRegisterUnavailableRangesRule(
@@ -65,7 +67,7 @@ func createAndRegisterUnavailableRangesRule(
 	help := "This check detects when the number of ranges with less than quorum replicas live are non-zero for too long"
 
 	rule, err := metric.NewAlertingRule(
-		trippedReplicaCircuitBreakersRuleName,
+		unavailableRangesRuleName,
 		expr,
 		annotations,
 		nil,
@@ -73,7 +75,7 @@ func createAndRegisterUnavailableRangesRule(
 		help,
 		true,
 	)
-	maybeAddRuleToRegistry(ctx, err, unavailableRangesRuleName, rule, ruleRegistry)
+	MaybeAddRuleToRegistry(ctx, err, unavailableRangesRuleName, rule, ruleRegistry)
 }
 
 func createAndRegisterTrippedReplicaCircuitBreakersRule(
@@ -88,8 +90,8 @@ func createAndRegisterTrippedReplicaCircuitBreakersRule(
 	recommendedHoldDuration := 10 * time.Minute
 	help := "This check detects when Replicas have stopped serving traffic as a result of KV health issues"
 
-	unavailableRanges, err := metric.NewAlertingRule(
-		unavailableRangesRuleName,
+	rule, err := metric.NewAlertingRule(
+		trippedReplicaCircuitBreakersRuleName,
 		expr,
 		annotations,
 		nil,
@@ -97,7 +99,7 @@ func createAndRegisterTrippedReplicaCircuitBreakersRule(
 		help,
 		true,
 	)
-	maybeAddRuleToRegistry(ctx, err, unavailableRangesRuleName, unavailableRanges, ruleRegistry)
+	MaybeAddRuleToRegistry(ctx, err, trippedReplicaCircuitBreakersRuleName, rule, ruleRegistry)
 }
 
 func createAndRegisterUnderReplicatedRangesRule(
@@ -121,7 +123,7 @@ func createAndRegisterUnderReplicatedRangesRule(
 		help,
 		true,
 	)
-	maybeAddRuleToRegistry(ctx, err, underreplicatedRangesRuleName, underreplicatedRanges, ruleRegistry)
+	MaybeAddRuleToRegistry(ctx, err, underreplicatedRangesRuleName, underreplicatedRanges, ruleRegistry)
 }
 
 func createAndRegisterRequestsStuckInRaftRule(
@@ -145,7 +147,7 @@ func createAndRegisterRequestsStuckInRaftRule(
 		help,
 		true,
 	)
-	maybeAddRuleToRegistry(ctx, err, requestsStuckInRaftRuleName, requestsStuckInRaft, ruleRegistry)
+	MaybeAddRuleToRegistry(ctx, err, requestsStuckInRaftRuleName, requestsStuckInRaft, ruleRegistry)
 }
 
 func createAndRegisterHighOpenFDCountRule(ctx context.Context, ruleRegistry *metric.RuleRegistry) {
@@ -167,7 +169,7 @@ func createAndRegisterHighOpenFDCountRule(ctx context.Context, ruleRegistry *met
 		help,
 		true,
 	)
-	maybeAddRuleToRegistry(ctx, err, highOpenFDCountRuleName, highOpenFDCount, ruleRegistry)
+	MaybeAddRuleToRegistry(ctx, err, highOpenFDCountRuleName, highOpenFDCount, ruleRegistry)
 }
 
 func createAndRegisterNodeCapacityRule(ctx context.Context, ruleRegistry *metric.RuleRegistry) {
@@ -180,7 +182,7 @@ func createAndRegisterNodeCapacityRule(ctx context.Context, ruleRegistry *metric
 		help,
 		true,
 	)
-	maybeAddRuleToRegistry(ctx, err, nodeCapacityRuleName, nodeCapacity, ruleRegistry)
+	MaybeAddRuleToRegistry(ctx, err, nodeCapacityRuleName, nodeCapacity, ruleRegistry)
 }
 
 func createAndRegisterClusterCapacityRule(ctx context.Context, ruleRegistry *metric.RuleRegistry) {
@@ -194,7 +196,7 @@ func createAndRegisterClusterCapacityRule(ctx context.Context, ruleRegistry *met
 		help,
 		true,
 	)
-	maybeAddRuleToRegistry(ctx, err, clusterCapacityRuleName, clusterCapacity, ruleRegistry)
+	MaybeAddRuleToRegistry(ctx, err, clusterCapacityRuleName, clusterCapacity, ruleRegistry)
 }
 
 func createAndRegisterNodeCapacityAvailableRule(
@@ -211,7 +213,7 @@ func createAndRegisterNodeCapacityAvailableRule(
 		help,
 		true,
 	)
-	maybeAddRuleToRegistry(ctx, err, nodeCapacityAvailableRuleName, nodeCapacityAvailable, ruleRegistry)
+	MaybeAddRuleToRegistry(ctx, err, nodeCapacityAvailableRuleName, nodeCapacityAvailable, ruleRegistry)
 }
 
 func createAndRegisterClusterCapacityAvailableRule(
@@ -227,7 +229,7 @@ func createAndRegisterClusterCapacityAvailableRule(
 		help,
 		true,
 	)
-	maybeAddRuleToRegistry(ctx, err, clusterCapacityAvailableRuleName, clusterCapacityAvailable, ruleRegistry)
+	MaybeAddRuleToRegistry(ctx, err, clusterCapacityAvailableRuleName, clusterCapacityAvailable, ruleRegistry)
 }
 
 func createAndRegisterCapacityAvailableRatioRule(
@@ -243,7 +245,7 @@ func createAndRegisterCapacityAvailableRatioRule(
 		help,
 		true,
 	)
-	maybeAddRuleToRegistry(ctx, err, capacityAvailableRatioRuleName, capacityAvailableRatio, ruleRegistry)
+	MaybeAddRuleToRegistry(ctx, err, capacityAvailableRatioRuleName, capacityAvailableRatio, ruleRegistry)
 }
 
 func createAndRegisterNodeCapacityAvailableRatioRule(
@@ -259,7 +261,7 @@ func createAndRegisterNodeCapacityAvailableRatioRule(
 		help,
 		true,
 	)
-	maybeAddRuleToRegistry(ctx, err, nodeCapacityAvailableRatioRuleName, nodeCapacityAvailableRatio, ruleRegistry)
+	MaybeAddRuleToRegistry(ctx, err, nodeCapacityAvailableRatioRuleName, nodeCapacityAvailableRatio, ruleRegistry)
 }
 
 func createAndRegisterClusterCapacityAvailableRatioRule(
@@ -275,10 +277,22 @@ func createAndRegisterClusterCapacityAvailableRatioRule(
 		help,
 		true,
 	)
-	maybeAddRuleToRegistry(ctx, err, clusterCapacityAvailableRatioRuleName, clusterCapacityAvailableRatio, ruleRegistry)
+	MaybeAddRuleToRegistry(ctx, err, clusterCapacityAvailableRatioRuleName, clusterCapacityAvailableRatio, ruleRegistry)
 }
 
-func maybeAddRuleToRegistry(
+func createAndRegisterNodeCapacityLowRule(ctx context.Context, ruleRegistry *metric.RuleRegistry) {
+	expr := "capacity_available:ratio < 0.15"
+	help := "Alert when a node has less than 15% space remaining"
+	annotations := []metric.LabelPair{{
+		Name:  proto.String("summary"),
+		Value: proto.String("Store {{ $labels.store }} on node {{ $labels.instance }} at {{ $value}} available disk fraction"),
+	}}
+	nodeCapacityLowRule, err := metric.NewAlertingRule(nodeCapacityLowRuleName, expr, annotations, nil, time.Duration(0), help, true)
+	MaybeAddRuleToRegistry(ctx, err, nodeCapacityLowRuleName, nodeCapacityLowRule, ruleRegistry)
+}
+
+// MaybeAddRuleToRegistry validates a rule and adds it to the rule registry.
+func MaybeAddRuleToRegistry(
 	ctx context.Context, err error, name string, rule metric.Rule, ruleRegistry *metric.RuleRegistry,
 ) {
 	if err != nil {

--- a/pkg/kv/kvserver/metric_rules_test.go
+++ b/pkg/kv/kvserver/metric_rules_test.go
@@ -40,5 +40,6 @@ func TestMetricRules(t *testing.T) {
 	require.NotNil(t, ruleRegistry.GetRuleForTest(capacityAvailableRatioRuleName))
 	require.NotNil(t, ruleRegistry.GetRuleForTest(nodeCapacityAvailableRatioRuleName))
 	require.NotNil(t, ruleRegistry.GetRuleForTest(clusterCapacityAvailableRatioRuleName))
-	require.Equal(t, 12, ruleRegistry.GetRuleCountForTest())
+	require.NotNil(t, ruleRegistry.GetRuleForTest(nodeCapacityLowRuleName))
+	require.Equal(t, 13, ruleRegistry.GetRuleCountForTest())
 }

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -127,6 +127,7 @@ go_library(
         "//pkg/server/goroutinedumper",
         "//pkg/server/heapprofiler",
         "//pkg/server/serverpb",
+        "//pkg/server/serverrules",
         "//pkg/server/settingswatcher",
         "//pkg/server/status",
         "//pkg/server/status/statuspb",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/debug"
 	"github.com/cockroachdb/cockroach/pkg/server/diagnostics"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/server/serverrules"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
 	"github.com/cockroachdb/cockroach/pkg/server/systemconfigwatcher"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
@@ -307,8 +308,10 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		log.Errorf(ctx, "unable to initialize periodic license metric update: %v", err)
 	}
 
-	// Create and add KV metric rules
+	// Create and add KV metric rules.
 	kvserver.CreateAndAddRules(ctx, ruleRegistry)
+	// Create and add server metric rules.
+	serverrules.CreateAndAddRules(ctx, ruleRegistry)
 
 	// A custom RetryOptions is created which uses stopper.ShouldQuiesce() as
 	// the Closer. This prevents infinite retry loops from occurring during

--- a/pkg/server/serverrules/BUILD.bazel
+++ b/pkg/server/serverrules/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "serverrules",
+    srcs = ["metric_rules.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/server/serverrules",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/kv/kvserver",
+        "//pkg/util/metric",
+        "@com_github_gogo_protobuf//proto",
+    ],
+)
+
+go_test(
+    name = "serverrules_test",
+    srcs = ["metric_rules_test.go"],
+    embed = [":serverrules"],
+    deps = [
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
+        "//pkg/util/metric",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/server/serverrules/metric_rules.go
+++ b/pkg/server/serverrules/metric_rules.go
@@ -1,0 +1,87 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package serverrules
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/gogo/protobuf/proto"
+)
+
+const (
+	nodeRestartRuleName      = "NodeRestart"
+	nodeCACertExpiryRuleName = "NodeCACertExpiry"
+	nodeCertExpiryRuleName   = "NodeCertExpiry"
+)
+
+// CreateAndAddRules initializes all server metric rules and adds them
+// to the rule registry for tracking. All rules are exported in the
+// YAML format.
+func CreateAndAddRules(ctx context.Context, ruleRegistry *metric.RuleRegistry) {
+	createAndRegisterNodeRestartRule(ctx, ruleRegistry)
+	createAndRegisterNodeCACertExpiryRule(ctx, ruleRegistry)
+	createAndRegisterNodeCertExpiryRule(ctx, ruleRegistry)
+}
+
+func createAndRegisterNodeRestartRule(ctx context.Context, ruleRegistry *metric.RuleRegistry) {
+	expr := "resets(sys_uptime[10m]) > 5"
+	annotations := []metric.LabelPair{{
+		Name:  proto.String("summary"),
+		Value: proto.String("Instance {{ $labels.instance }} restarted"),
+	}, {
+		Name:  proto.String("description"),
+		Value: proto.String("{{ $labels.instance }} for cluster {{ $labels.cluster }} restarted {{ $value }} time(s) in 10m"),
+	}}
+	help := "Alert if a node restarts multiple times in a short span of time."
+	nodeRestartRule, err := metric.NewAlertingRule(
+		nodeRestartRuleName,
+		expr,
+		annotations,
+		nil,
+		time.Duration(0),
+		help,
+		false,
+	)
+	kvserver.MaybeAddRuleToRegistry(ctx, err, nodeRestartRuleName, nodeRestartRule, ruleRegistry)
+}
+
+func createAndRegisterNodeCACertExpiryRule(ctx context.Context, ruleRegistry *metric.RuleRegistry) {
+	expr := "(security_certificate_expiration_ca > 0) and (security_certificate_expiration_ca - time()) < 86400 * 366"
+	help := "Alert when the CA certificate on a node will expire in less than a year"
+	annotations := []metric.LabelPair{{
+		Name:  proto.String("summary"),
+		Value: proto.String("CA certificate for {{ $labels.instance }} expires in less than a year"),
+	}}
+	labels := []metric.LabelPair{{
+		Name:  proto.String("frequency"),
+		Value: proto.String("daily"),
+	}}
+	nodeCACertExpiryRule, err := metric.NewAlertingRule(nodeCACertExpiryRuleName, expr, annotations, labels, time.Duration(0), help, false)
+	kvserver.MaybeAddRuleToRegistry(ctx, err, nodeCACertExpiryRuleName, nodeCACertExpiryRule, ruleRegistry)
+}
+
+func createAndRegisterNodeCertExpiryRule(ctx context.Context, ruleRegistry *metric.RuleRegistry) {
+	expr := "(security_certificate_expiration_node > 0) and (security_certificate_expiration_node - time()) < 86400 * 183"
+	help := "Alert when a node certificate will expire in 6 months"
+	annotations := []metric.LabelPair{{
+		Name:  proto.String("summary"),
+		Value: proto.String("Node certificate for {{ $labels.instance }} expires in less than 6 months"),
+	}}
+	labels := []metric.LabelPair{{
+		Name:  proto.String("frequency"),
+		Value: proto.String("daily"),
+	}}
+	nodeCertExpiryRule, err := metric.NewAlertingRule(nodeCertExpiryRuleName, expr, annotations, labels, time.Duration(0), help, false)
+	kvserver.MaybeAddRuleToRegistry(ctx, err, nodeCertExpiryRuleName, nodeCertExpiryRule, ruleRegistry)
+}

--- a/pkg/server/serverrules/metric_rules_test.go
+++ b/pkg/server/serverrules/metric_rules_test.go
@@ -1,0 +1,35 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package serverrules
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMetricRules tests the creation of metric rules related
+// to server metrics.
+func TestMetricRules(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ruleRegistry := metric.NewRuleRegistry()
+	CreateAndAddRules(context.Background(), ruleRegistry)
+	require.NotNil(t, ruleRegistry.GetRuleForTest(nodeRestartRuleName))
+	require.NotNil(t, ruleRegistry.GetRuleForTest(nodeCACertExpiryRuleName))
+	require.NotNil(t, ruleRegistry.GetRuleForTest(nodeCertExpiryRuleName))
+	require.Equal(t, 3, ruleRegistry.GetRuleCountForTest())
+}


### PR DESCRIPTION
Add alerting rules documented in our customer facing docs
to the new alerting and aggregation rules endpoint. This
endpoint is intended to be used as a guideline for configuring
alerts and aggregation rules for our customers. The alerts
outlined in the doc were added before this endpoint was created.
Now that we have a more structured way to communicate ways to
alert and aggregate our metrics, we should transition these alerts
to this endpoint and update our documentation to reference the
endpoint.

This PR also fixes a small bug which was causing the details
of the tripped circuit breakers rule to be flipped with the
unavailable ranges rule.

Release note (api change): Update api/v2/rules endpoint to include
alerts defined in our customer facing docs.

Release note (bug fix): Fix the bug which was causing the unavailable
ranges rule details to be flipped with the tripped circuit breakers.


Resolves https://github.com/cockroachdb/cockroach/issues/78051