### PR TITLE
sql/schemachanger/rel: rework indexes and values

### DIFF
--- a/pkg/sql/schemachanger/rel/BUILD.bazel
+++ b/pkg/sql/schemachanger/rel/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "attribute.go",
         "compare.go",
         "database.go",
+        "database_entity_set.go",
         "database_items.go",
         "doc.go",
         "entity.go",

--- a/pkg/sql/schemachanger/rel/bench_test.go
+++ b/pkg/sql/schemachanger/rel/bench_test.go
@@ -100,10 +100,10 @@ func BenchmarkLinkedList(b *testing.B) {
 	// ID, next, prev. Then we want to define A set of queries for the
 	// specified depth.
 	const numQueries = 16
-	runDepth := func(b *testing.B, lists, depth int, attrs [][]rel.Attr) {
+	runDepth := func(b *testing.B, lists, depth int, indexes []rel.Index) {
 		links := rand.Perm(lists + depth)
 		p := rand.Perm(lists)[:numQueries]
-		db, err := rel.NewDatabase(sc, attrs)
+		db, err := rel.NewDatabase(sc, indexes...)
 		require.NoError(b, err)
 		for i, j := range links {
 			require.NoError(b, db.Insert(&ListNode{ID: i, Next: j}))
@@ -133,13 +133,16 @@ func BenchmarkLinkedList(b *testing.B) {
 		}
 	}
 
-	for _, attrs := range [][][]rel.Attr{
-		{{nextAttr}, {idAttr}},
-		nil,
+	for _, indexes := range [][]rel.Index{
+		{
+			{Attrs: []rel.Attr{nextAttr}},
+			{Attrs: []rel.Attr{idAttr}},
+		},
+		{{}},
 	} {
 		forEachListDepth(func(lists, depth int) {
-			b.Run(fmt.Sprintf("lists=%d,depth=%d,%s", lists, depth, attrs), func(b *testing.B) {
-				runDepth(b, lists, depth, attrs)
+			b.Run(fmt.Sprintf("lists=%d,depth=%d,%v", lists, depth, indexes), func(b *testing.B) {
+				runDepth(b, lists, depth, indexes)
 			})
 		})
 	}

--- a/pkg/sql/schemachanger/rel/database.go
+++ b/pkg/sql/schemachanger/rel/database.go
@@ -20,19 +20,17 @@ import (
 
 // Database is a data structure for indexing entities.
 type Database struct {
-	schema *Schema
+	entitySet
 
 	// indexes store the entities, ordered by a specified set of attributes.
-	// When an entity is inserted, it is inserted into each of the indexes. The
-	// first entry in the list is the "primary index" which compares entities
-	// based on all attributes.
+	// When an entity is inserted, it is inserted into each of the indexes
+	// for which it satisfies the relevant attribute existence and predicate
+	// filters.
 	//
 	// Note that the use of btree-tree backed indexes is far from fundamental.
 	// One could easily envision a map-backed indexing structure which may well
 	// perform much better.
 	indexes []index
-	// entities stores all the entities keyed on its pointer value.
-	entities map[interface{}]*entity
 }
 
 // Schema returns the schema associated with the tree.
@@ -40,43 +38,141 @@ func (t *Database) Schema() *Schema {
 	return t.schema
 }
 
-// NewDatabase constructs a new Database with the specified indexes.
-// Note that the schema must not contain more than 64 attributes.
-func NewDatabase(sc *Schema, indexes [][]Attr) (*Database, error) {
-	t := &Database{
-		schema:   sc,
-		indexes:  make([]index, len(indexes)+1),
-		entities: make(map[interface{}]*entity),
-	}
-	// Index everything by all the attributes. This serves as the "primary"
+// IndexWhere is a partial index predicate for a rel index.
+// It constrains the index to only contain entities which have a value
+// equal to the provided value for the attribute in question.
+type IndexWhere struct {
+	Attr Attr
+	Eq   interface{}
+}
+
+// Index defines an index over the stored entities.
+type Index struct {
+	// Attrs defines the ordering for the index. All entities will be sorted
+	// first by these attributes and then by the canonical ordering of the
+	// attributes as defined by the schema. Note that not all entities in the
+	// index must have defined values for these attrs.
+	Attrs []Attr
+
+	// Where defines specific attribute-values which must be met for
+	// entities to be included in this index. When queries are run, if the
+	// predicate is searching for a different attribute value, this index
+	// will be skipped. Where are one tool to prune the size of an
 	// index.
-	const degree = 8
-	fl := btree.NewFreeList(len(indexes) + 1)
-	{
-		var primaryIndex index
-		primaryIndex.s = sc
-		primaryIndex.tree = btree.NewWithFreeList(degree, fl)
-		t.indexes[0] = primaryIndex
+	Where []IndexWhere
+
+	// Exists defines requirements for the existence of attributes in entities
+	// which are indexed. Note that for queries to take advantage of this index,
+	// the fact that the entity being queried is expected to have an attribute
+	// must be stated explicitly. This generally requires binding a variable to
+	// the attribute, even if you have no use for it beyond to enable the index
+	// choice.
+	//
+	// TODO(ajwerner): add a HasAttr method to Var to hide this internal
+	// attribute existence from the query itself and to free the query-writer
+	// from needing to define a bogus Var.
+	Exists []Attr
+}
+
+// NewDatabase constructs a new Database with the specified indexes.
+func NewDatabase(sc *Schema, indexes ...Index) (*Database, error) {
+	t := &Database{
+		entitySet: entitySet{
+			schema:  sc,
+			hash:    map[interface{}]int{},
+			strings: map[string]int{},
+		},
+		indexes: make([]index, len(indexes)),
 	}
-	secondaryIndexes := t.indexes[1:]
-	for i, attrs := range indexes {
-		var set ordinalSet
-		ords := make([]ordinal, len(attrs))
-		for i, a := range attrs {
+	for i, di := range indexes {
+		var set, exists ordinalSet
+		ords := make([]ordinal, len(di.Attrs))
+		for i, a := range di.Attrs {
 			ord, err := sc.getOrdinal(a)
 			if err != nil {
-				return nil, err
+				return nil, errors.Wrap(err, "invalid index attribute")
 			}
 			set = set.add(ord)
 			ords[i] = ord
 		}
-		spec := indexSpec{mask: set, attrs: ords, s: sc}
-		secondaryIndexes[i] = index{
+		for _, a := range di.Exists {
+			ord, err := sc.getOrdinal(a)
+			if err != nil {
+				return nil, errors.Wrap(err, "invalid index exists attribute")
+			}
+			exists = exists.add(ord)
+		}
+		var predicate values
+		for _, w := range di.Where {
+			ord, err := sc.getOrdinal(w.Attr)
+			if err != nil {
+				return nil, errors.Wrapf(err,
+					"invalid index predicate attribute = %T(%v)", w.Attr, w.Attr)
+			}
+			if predicate.attrs.contains(ord) {
+				return nil, errors.Errorf(
+					"invalid index predicate: duplicate entries for attribute %v", w.Attr)
+			}
+			// Here we need to check whether this is a scalar or what, and then
+			// deal with it accordingly.
+			rv := reflect.ValueOf(w.Eq)
+			if !rv.IsValid() || rv.Kind() == reflect.Ptr && rv.IsNil() {
+				return nil, errors.Errorf(
+					"invalid index predicate: nil entry for attribute %v", w.Attr)
+			}
+			if w.Attr == Self {
+				return nil, errors.Errorf(
+					"invalid index predicate: cannot populate self entry")
+			}
+			val, err := t.makeInlineValue(ord, rv)
+			if err != nil {
+				return nil, errors.Wrap(err, "invalid index predicate")
+			}
+			if !predicate.add(ord, val) {
+				return nil, errors.Errorf(
+					"invalid index predicate %v with more than %d attributes",
+					di.Where, numAttrs,
+				)
+			}
+		}
+
+		spec := indexSpec{mask: set, attrs: ords, s: &t.entitySet, exists: exists, where: predicate}
+		t.indexes[i] = index{
 			indexSpec: spec,
-			tree:      btree.NewWithFreeList(degree, fl),
+			tree:      btree.New(32),
 		}
 	}
 	return t, nil
+}
+
+// entityStore is an abstraction to permit the relevant recursion of interning
+// and indexing entities and their referenced children. The database delegates
+// first to its entitySet, but the entitySet, when decomposing, may need to
+// delegate back to the database. This interface enables that mutual delegation
+// without needing to collect the intermediate elements into some data
+// structure.
+type entityStore interface {
+	insert(v interface{}, set entityStore) (id int, err error)
+}
+
+// insert implements entityStore.
+func (t *Database) insert(v interface{}, es entityStore) (id int, err error) {
+	id, err = t.entitySet.insert(v, es)
+	if err != nil {
+		return 0, err
+	}
+	e := (*values)(&t.entitySet.entities[id])
+	for i := range t.indexes {
+		idx := &t.indexes[i]
+		if !idx.matchesPredicate(e) {
+			continue
+		}
+		if idx.exists != 0 && !idx.exists.isContainedIn(e.attrs) {
+			continue
+		}
+		idx.tree.ReplaceOrInsert(&valuesItem{values: *e, idx: &idx.indexSpec})
+	}
+	return id, nil
 }
 
 // Insert inserts an entity. Note that entities are defined
@@ -90,49 +186,8 @@ func NewDatabase(sc *Schema, indexes [][]Attr) (*Database, error) {
 // It is a no-op and not an error to insert an entity which
 // already exists.
 func (t *Database) Insert(v interface{}) error {
-	e, err := toEntity(t.schema, v)
-	if err != nil {
-		return err
-	}
-	if err := t.insert(e); err != nil {
-		return err
-	}
-	for _, v := range e.m {
-		_, isEntity := t.schema.entityTypeSchemas[reflect.TypeOf(v)]
-		_, alreadyDefined := t.entities[v]
-		if isEntity && !alreadyDefined {
-			if err := t.Insert(v); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-func (t *Database) insert(e *entity) error {
-	self := e.getComparableValue(t.schema, Self)
-	if existing, exists := t.entities[self]; exists {
-		// Sanity check that the entities really are equal.
-		if _, eq := compareEntities(e, existing); !eq {
-			return errors.AssertionFailedf(
-				"expected entity %v to equal its already inserted value", self,
-			)
-		}
-		return nil
-	}
-	t.entities[self] = e
-	for i := range t.indexes {
-		idx := &t.indexes[i]
-		if g := idx.tree.ReplaceOrInsert(&containerItem{
-			entity:    e,
-			indexSpec: &idx.indexSpec,
-		}); g != nil {
-			return errors.AssertionFailedf(
-				"expected entity %T(%v) to not exist", self, self,
-			)
-		}
-	}
-	return nil
+	_, err := t.insert(v, t)
+	return err
 }
 
 type index struct {
@@ -141,44 +196,51 @@ type index struct {
 }
 
 type indexSpec struct {
-	s     *Schema
-	mask  ordinalSet
-	attrs []ordinal
+	s      *entitySet
+	mask   ordinalSet
+	attrs  []ordinal
+	exists ordinalSet
+	where  values
 }
 
 // entityIterator is used to iterate Entities.
 type entityIterator interface {
 	// Visit visits an entity. If iterutil.StopIteration
 	// is returned, iteration will stop but no error is returned.
-	visit(*entity) error
+	visit(entity) error
 }
 
 // Iterate will iterate the containers which match the specified valuesMap.
-func (t *Database) iterate(where *valuesMap, f entityIterator) (err error) {
-	idx, toCheck := t.chooseIndex(where.attrs)
-	from, to := getValuesItems(&idx.indexSpec, where, where.attrs)
+func (t *Database) iterate(where values, hasAttrs ordinalSet, f entityIterator) error {
+	idx, toCheck, err := t.chooseIndex(where, hasAttrs)
+	if err != nil {
+		return err
+	}
+	from, to := getValuesItems(&idx.indexSpec, where)
 	defer putValuesItems(from, to)
-	idx.tree.AscendRange(from, to, func(i btree.Item) (wantMore bool) {
-		c := i.(*containerItem)
+	idx.tree.AscendRange(from, to, func(i btree.Item) bool {
+		cv := i.(*valuesItem)
 		// We want to skip items which do not have values set for
 		// all members of the where clause.
-		if where.attrs.without(c.entity.attrs) != 0 {
+		if where.attrs.without(cv.attrs) != 0 {
 			return true
 		}
 		var failed bool
 		toCheck.forEach(func(a ordinal) (wantMore bool) {
-			_, eq := compareOn(a, (*valuesMap)(c.entity), where)
+			_, eq := t.compareOn(a, &cv.values, &where)
 			failed = !eq
 			return !failed
 		})
 		if !failed {
-			err = f.visit(c.entity)
+			if err = f.visit((entity)(cv.values)); err != nil {
+				if iterutil.Done(err) {
+					err = nil
+				}
+				return false
+			}
 		}
-		return err == nil
+		return true
 	})
-	if iterutil.Done(err) {
-		err = nil
-	}
 	return err
 }
 
@@ -187,18 +249,46 @@ func (t *Database) iterate(where *valuesMap, f entityIterator) (err error) {
 // attributes which are not covered by the index prefix.
 //
 // TODO(ajwerner): Consider something about selectivity by tracking the number
-// of entries under each index (i.variable. which have non-NULL valuesMap)
-// for the given dimension.
-func (t *Database) chooseIndex(m ordinalSet) (_ *index, toCheck ordinalSet) {
-	// Default to the "primary" index.
-	best, bestOverlap := 0, ordinalSet(0)
-	dims := t.indexes[1:]
+// of entries under each index.
+func (t *Database) chooseIndex(
+	where values, hasAttrs ordinalSet,
+) (_ *index, toCheck ordinalSet, _ error) {
+	m := where.attrs
+	best, bestOverlap := -1, ordinalSet(0)
+	dims := t.indexes
 	for i := range dims {
-		if overlap := dims[i].overlap(m); overlap.len() > bestOverlap.len() {
-			best, bestOverlap = i+1, overlap
+		overlap := dims[i].overlap(m)
+		if best >= 0 && overlap.len() <= bestOverlap.len() {
+			continue
 		}
+		if !dims[i].exists.isContainedIn(m.union(hasAttrs)) {
+			continue
+		}
+		if !dims[i].matchesPredicate(&where) {
+			continue
+		}
+		best, bestOverlap = i, overlap
 	}
-	return &t.indexes[best], m.without(bestOverlap)
+	if best == -1 {
+		return nil, 0, errors.AssertionFailedf(
+			"failed to find index to satisfy query",
+		)
+	}
+	return &t.indexes[best], m.without(bestOverlap), nil
+}
+
+func (s indexSpec) matchesPredicate(v *values) bool {
+	if s.where.attrs.empty() {
+		return true
+	}
+	matches := true
+	s.where.attrs.forEach(func(a ordinal) (wantMore bool) {
+		av, aOk := s.where.get(a)
+		bv, bOk := v.get(a)
+		matches = av == bv && aOk == bOk
+		return matches
+	})
+	return matches
 }
 
 // overlap returns the ordinals from m which overlap with a prefix of

--- a/pkg/sql/schemachanger/rel/database_entity_set.go
+++ b/pkg/sql/schemachanger/rel/database_entity_set.go
@@ -1,0 +1,183 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rel
+
+import (
+	"reflect"
+	"unsafe"
+
+	"github.com/cockroachdb/errors"
+)
+
+// entitySet is an interning of entities. Its use provides a means to represent
+// entities and strings as integers in the context of a database.
+//
+// TODO(ajwerner): Consider reworking the interning such that the values are
+// self-describing and don't need the entitySet to be dereferenced. In
+// particular, consider storing pointers in the inline values. For the strings,
+// this is straightforward. For the entities, we may want to store a pointer
+// to the entity itself in the inline value and then somewhere in the entity
+// store the pointer to the raw value with a new system attribute.
+type entitySet struct {
+	schema *Schema
+
+	stringIntern []string
+	strings      map[string]int
+
+	entities []entity
+	objs     []interface{}
+	hash     map[interface{}]int
+}
+
+// insert implements the entityStore interface. It inserts the entity if it
+// does not already exist. If it does it exist, it inserts the children
+// entities recursively into the passed entityStore before inserting the
+// passed entity and returning its id.
+func (t *entitySet) insert(v interface{}, es entityStore) (int, error) {
+	if id, exists := t.hash[v]; exists {
+		return id, nil
+	}
+	ti, value, err := getEntityValueInfo(t.schema, v)
+	if err != nil {
+		return 0, err
+	}
+	id := len(t.objs)
+	t.objs = append(t.objs, v)
+	t.hash[v] = id
+	t.entities = append(t.entities, entity{})
+	var ev values
+	vp := unsafe.Pointer(value.Pointer())
+	ev.add(t.schema.selfOrdinal, uintptr(id))
+	ev.add(t.schema.typeOrdinal, ti.typID)
+	for _, field := range ti.fields {
+		var val uintptr
+		switch {
+		case field.isStruct():
+			fv := field.value(vp)
+			if fv == nil {
+				continue
+			}
+			fieldID, err := es.insert(fv, es)
+			if err != nil {
+				return 0, err
+			}
+			val = uintptr(fieldID)
+		case field.isIntLike():
+			var ok bool
+			val, ok = field.inline(vp)
+			if !ok {
+				continue
+			}
+		case field.isString():
+			s, ok := field.comparableValue(vp).(*string)
+			if !ok {
+				continue
+			}
+			val = t.internString(*s)
+		default:
+			return 0, errors.AssertionFailedf("invalid field in %v mapping for %v", field.path, ti.typ)
+		}
+		if !ev.add(field.attr, val) {
+			var attrs []Attr
+			ev.attrs.forEach(func(a ordinal) (wantMore bool) {
+				attrs = append(attrs, t.schema.attrs[a])
+				return true
+			})
+			attrs = append(attrs, t.schema.attrs[field.attr])
+			return 0, errors.AssertionFailedf(
+				"invalid entity %T has too many attributes: maximum allowed is 8, have at least %v",
+				v, attrs)
+		}
+	}
+	t.entities[id] = entity(ev)
+	return id, nil
+}
+
+func (t *entitySet) compareOnAttrs(attrs ordinalSet, a, b *values) (less, eq bool) {
+	attrs.forEach(func(attr ordinal) (wantMore bool) {
+		less, eq = t.compareOn(attr, a, b)
+		return eq
+	})
+	return less, eq
+}
+
+func (t *entitySet) compareOn(o ordinal, a, b *values) (less, eq bool) {
+	av, aOk := a.get(o)
+	bv, bOk := b.get(o)
+	if aOk != bOk {
+		return bOk, false
+	}
+	if t.schema.stringAttrs.contains(o) {
+		as, bs := t.stringIntern[av], t.stringIntern[bv]
+		return as < bs, as == bs
+	}
+	return av < bv, av == bv
+}
+
+func (t *entitySet) internString(s string) uintptr {
+	id, exists := t.strings[s]
+	if !exists {
+		id = len(t.stringIntern)
+		t.stringIntern = append(t.stringIntern, s)
+		t.strings[s] = id
+	}
+	return uintptr(id)
+}
+
+// TODO(ajwerner): Does this really need to know about the ordinal?
+// I guess the use case is about figuring out whether we want the
+// type itself or the type-type.
+func (t *entitySet) makeInlineValue(attr ordinal, vv reflect.Value) (uintptr, error) {
+	if err := checkNotNil(vv); err != nil {
+		return 0, err
+	}
+	typ := vv.Type()
+	// TODO(ajwerner): Do we ever need to type check here?
+	/*
+		if err := checkType(typ, attrTyp); err != nil {
+			return 0, err
+		}
+	*/
+	switch {
+	case attr == t.schema.typeOrdinal:
+		typVal, ok := vv.Interface().(reflect.Type)
+		if !ok {
+			return 0, errors.Errorf(
+				"cannot build value for type with non-type value of type %v", vv.Type(),
+			)
+		}
+		ti, ok := t.schema.entityTypeSchemas[typVal]
+		if !ok {
+			return 0, errors.Errorf(
+				"cannot build value for type %v not in database", typVal,
+			)
+		}
+		return ti.typID, nil
+	case typ.Kind() == reflect.Ptr && typ.Elem().Kind() == reflect.Struct:
+		id, ok := t.hash[vv.Interface()]
+		if !ok {
+			return 0, errors.Errorf(
+				"cannot build value for entity object not in database",
+			)
+		}
+		return uintptr(id), nil
+	case isIntKind(typ.Kind()):
+		return uintptr(vv.Int()), nil
+	case isUintKind(typ.Kind()):
+		return uintptr(vv.Uint()), nil
+	case typ.Kind() == reflect.String:
+		return t.internString(vv.String()), nil
+	default:
+		return 0, errors.Errorf(
+			"unsupported query attribute for type %v", typ,
+		)
+	}
+}

--- a/pkg/sql/schemachanger/rel/internal/cyclegraphtest/tests.go
+++ b/pkg/sql/schemachanger/rel/internal/cyclegraphtest/tests.go
@@ -45,9 +45,13 @@ var (
 	databaseTests = []reltest.DatabaseTest{
 		{
 			Data: []string{"container1"}, // recursively will add it all, test that
-			Indexes: [][][]rel.Attr{
-				nil,
-				{{s}, {c}, {name}},
+			Indexes: [][]rel.Index{
+				{{}},
+				{
+					{Attrs: []rel.Attr{s}},
+					{Attrs: []rel.Attr{c}},
+					{Attrs: []rel.Attr{name}},
+				},
 			},
 			QueryCases: []reltest.QueryTest{
 				{

--- a/pkg/sql/schemachanger/rel/ordinal_set.go
+++ b/pkg/sql/schemachanger/rel/ordinal_set.go
@@ -14,11 +14,11 @@ import "math/bits"
 
 // ordinal is used to correlate attributes in a schema.
 // It enables use of the ordinalSet.
-type ordinal uint64
+type ordinal uint8
 
 // ordinalSet represents A bitmask over ordinals.
-// Note that it cannot contain attributes with ordinals greater than 64.
-type ordinalSet uint64
+// Note that it cannot contain attributes with ordinals greater than 15.
+type ordinalSet uint16
 
 // ForEach iterates the set of attributes.
 func (m ordinalSet) forEach(f func(a ordinal) (wantMore bool)) {
@@ -64,5 +64,19 @@ func (m ordinalSet) union(other ordinalSet) ordinalSet {
 
 // len returns the number of ordinals in the set.
 func (m ordinalSet) len() int {
-	return bits.OnesCount64(uint64(m))
+	return bits.OnesCount16(uint16(m))
+}
+
+// rank returns the rank in the set of the passed ordinal.
+func (m ordinalSet) rank(a ordinal) int {
+	return bits.OnesCount16(uint16(m & ((1 << a) - 1)))
+}
+
+// isContainedIn returns true of m contains every element of other.
+func (m ordinalSet) isContainedIn(other ordinalSet) bool {
+	return other.intersection(m) == m
+}
+
+func (m ordinalSet) empty() bool {
+	return m == 0
 }

--- a/pkg/sql/schemachanger/rel/query_data.go
+++ b/pkg/sql/schemachanger/rel/query_data.go
@@ -45,19 +45,41 @@ type slot struct {
 type typedValue struct {
 	typ   reflect.Type
 	value interface{}
+
+	// inline can be populated for all data types. It is set lazily.
+	// Not all data types are directly comparable based solely on the inline
+	// value.
+	inline    uintptr
+	inlineSet bool
 }
 
-func (tv typedValue) toInterface() interface{} {
+func (tv typedValue) toValue() reflect.Value {
 	if tv.typ == reflectTypeType {
-		return tv.value.(reflect.Type)
+		return reflect.ValueOf(tv.value)
 	}
 	if tv.typ.Kind() == reflect.Ptr {
 		if tv.typ.Elem().Kind() == reflect.Struct {
-			return tv.value
+			return reflect.ValueOf(tv.value)
 		}
-		return reflect.ValueOf(tv.value).Convert(tv.typ).Interface()
+		return reflect.ValueOf(tv.value).Convert(tv.typ)
 	}
-	return reflect.ValueOf(tv.value).Convert(reflect.PtrTo(tv.typ)).Elem().Interface()
+	return reflect.ValueOf(tv.value).Convert(reflect.PtrTo(tv.typ)).Elem()
+}
+
+func (tv typedValue) toInterface() interface{} {
+	return tv.toValue().Interface()
+}
+
+func (tv *typedValue) inlineValue(es *entitySet, attr ordinal) (uintptr, error) {
+	if tv.inlineSet {
+		return tv.inline, nil
+	}
+	v, err := es.makeInlineValue(attr, tv.toValue())
+	if err != nil {
+		return 0, err
+	}
+	tv.inline, tv.inlineSet = v, true
+	return tv.inline, nil
 }
 
 func (s *slot) eq(other slot) bool {
@@ -71,7 +93,7 @@ func (s *slot) eq(other slot) bool {
 	case other.value == nil:
 		return false
 	default:
-		_, eq := compare(s.value, other.value)
+		_, eq := compareNotNil(s.value, other.value)
 		return eq
 	}
 }
@@ -86,7 +108,7 @@ func maybeSet(
 	s := &slots[idx]
 	check := func() (shouldSet, foundContradiction bool) {
 		if !s.empty() {
-			if _, eq := compare(s.value, tv.value); !eq {
+			if _, eq := compareNotNil(s.value, tv.value); !eq {
 				return false, true
 			}
 			return false, false
@@ -98,7 +120,7 @@ func maybeSet(
 				if tv.typ != v.typ {
 					continue
 				}
-				if _, foundMatch = compare(v.value, tv.value); foundMatch {
+				if _, foundMatch = compareNotNil(v.value, tv.value); foundMatch {
 					break
 				}
 			}

--- a/pkg/sql/schemachanger/rel/rel_test.go
+++ b/pkg/sql/schemachanger/rel/rel_test.go
@@ -145,8 +145,8 @@ func TestInvalidData(t *testing.T) {
 		}
 	})
 	t.Run("bad attributes in database", func(t *testing.T) {
-		_, err := rel.NewDatabase(schema, [][]rel.Attr{{stringAttr("not-exists")}})
-		require.EqualError(t, err, `unknown attribute not-exists in schema junk`)
+		_, err := rel.NewDatabase(schema, rel.Index{Attrs: []rel.Attr{stringAttr("not-exists")}})
+		require.EqualError(t, err, `invalid index attribute: unknown attribute not-exists in schema junk`)
 	})
 	t.Run("oneOf with more than one value", func(t *testing.T) {
 		type oneOf struct {
@@ -176,3 +176,102 @@ func TestInvalidData(t *testing.T) {
 type stringAttr string
 
 func (sa stringAttr) String() string { return string(sa) }
+
+// TestTooManyAttributes tests that errors are returned whenever a predicate
+// is constructed with too many attributes. One could imagine disallowing this
+// altogether in the schema, but it's somewhat onerous to do so.
+func TestTooManyAttributes(t *testing.T) {
+	type tooManyAttrs struct {
+		F1, F2, F3, F4, F5, F6, F7, F8 *uint32
+	}
+	sc := rel.MustSchema("too_many",
+		rel.EntityMapping(reflect.TypeOf((*tooManyAttrs)(nil)),
+			rel.EntityAttr(stringAttr("A1"), "F1"),
+			rel.EntityAttr(stringAttr("A2"), "F2"),
+			rel.EntityAttr(stringAttr("A3"), "F3"),
+			rel.EntityAttr(stringAttr("A4"), "F4"),
+			rel.EntityAttr(stringAttr("A5"), "F5"),
+			rel.EntityAttr(stringAttr("A6"), "F6"),
+			rel.EntityAttr(stringAttr("A7"), "F7"),
+			rel.EntityAttr(stringAttr("A8"), "F8"),
+		),
+	)
+	one := uint32(1)
+	t.Run("predicate too large", func(t *testing.T) {
+		_, err := rel.NewDatabase(sc, rel.Index{
+			Where: []rel.IndexWhere{
+				{Attr: stringAttr("A1"), Eq: one},
+				{Attr: stringAttr("A2"), Eq: one},
+				{Attr: stringAttr("A3"), Eq: one},
+				{Attr: stringAttr("A4"), Eq: one},
+				{Attr: stringAttr("A5"), Eq: one},
+				{Attr: stringAttr("A6"), Eq: one},
+				{Attr: stringAttr("A7"), Eq: one},
+				{Attr: stringAttr("A8"), Eq: one},
+				{Attr: rel.Type, Eq: reflect.TypeOf((*tooManyAttrs)(nil))},
+			},
+		})
+		require.EqualError(t, err, `invalid index predicate [{A1 1} {A2 1} {A3 1} {A4 1} {A5 1} {A6 1} {A7 1} {A8 1} {Type *rel_test.tooManyAttrs}] with more than 8 attributes`)
+	})
+	db, err := rel.NewDatabase(sc, rel.Index{})
+	require.NoError(t, err)
+	t.Run("index predicate too large", func(t *testing.T) {
+		require.Regexp(t, `invalid entity \*rel_test.tooManyAttrs has too many attributes: maximum allowed is 8, have at least \[A1 A2 A3 A4 A5 A6 Self Type A7\]`, db.Insert(&tooManyAttrs{
+			F1: &one,
+			F2: &one,
+			F3: &one,
+			F4: &one,
+			F5: &one,
+			F6: &one,
+			F7: &one,
+			F8: &one,
+		}))
+
+	})
+	t.Run("query join predicate too large", func(t *testing.T) {
+		require.NoError(t, db.Insert(&tooManyAttrs{
+			F1: &one,
+			F2: &one,
+			F3: &one,
+			F4: &one,
+		}))
+		require.NoError(t, db.Insert(&tooManyAttrs{
+			F5: &one,
+			F6: &one,
+			F7: &one,
+			F8: &one,
+		}))
+		var a, b, c rel.Var = "a", "b", "c"
+		base := []rel.Clause{
+			a.Type((*tooManyAttrs)(nil)),
+			b.Type((*tooManyAttrs)(nil)),
+			c.Type((*tooManyAttrs)(nil)),
+			rel.Var("f1").Entities(stringAttr("A1"), a, c),
+			rel.Var("f2").Entities(stringAttr("A2"), a, c),
+			rel.Var("f3").Entities(stringAttr("A3"), a, c),
+			rel.Var("f4").Entities(stringAttr("A4"), a, c),
+			rel.Var("f5").Entities(stringAttr("A5"), b, c),
+			rel.Var("f6").Entities(stringAttr("A6"), b, c),
+			rel.Var("f7").Entities(stringAttr("A7"), b, c),
+			rel.Var("f8").Entities(stringAttr("A8"), b, c),
+		}
+		{
+			q, err := rel.NewQuery(sc, append(base, c.Type((*tooManyAttrs)(nil)))...)
+			require.NoError(t, err)
+			require.Regexp(t, "failed to create predicate with more than 8 attributes", q.Iterate(db, func(r rel.Result) error {
+				return nil
+			}))
+		}
+		{
+			{
+				q, err := rel.NewQuery(sc, append(
+					base, c.Type((*tooManyAttrs)(nil), (*rel.Schema)(nil)),
+				)...)
+				require.NoError(t, err)
+				require.Regexp(t, "failed to create predicate with more than 8 attributes", q.Iterate(db, func(r rel.Result) error {
+					return nil
+				}))
+			}
+		}
+	})
+}

--- a/pkg/sql/schemachanger/rel/reltest/BUILD.bazel
+++ b/pkg/sql/schemachanger/rel/reltest/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//pkg/sql/schemachanger/rel",
         "//pkg/testutils",
+        "//pkg/util",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v3//:yaml_v3",

--- a/pkg/sql/schemachanger/rel/schema.go
+++ b/pkg/sql/schemachanger/rel/schema.go
@@ -21,12 +21,30 @@ import (
 
 // Schema defines a mapping of entities to their attributes and decomposition.
 type Schema struct {
-	name              string
-	attrs             []Attr
-	attrTypes         []reflect.Type
-	attrToOrdinal     map[Attr]ordinal
-	entityTypeSchemas map[reflect.Type]*entityTypeSchema
+	name                     string
+	attrs                    []Attr
+	attrTypes                []reflect.Type
+	attrToOrdinal            map[Attr]ordinal
+	entityTypes              []*entityTypeSchema
+	entityTypeSchemas        map[reflect.Type]*entityTypeSchema
+	typeOrdinal, selfOrdinal ordinal
+	stringAttrs              ordinalSet
 }
+
+type entityTypeSchemaSort Schema
+
+func (e entityTypeSchemaSort) Len() int { return len(e.entityTypeSchemas) }
+func (e entityTypeSchemaSort) Less(i, j int) bool {
+	less, _ := compareTypes(e.entityTypes[i].typ, e.entityTypes[j].typ)
+	return less
+}
+func (e entityTypeSchemaSort) Swap(i, j int) {
+	e.entityTypes[i].typID = uintptr(j)
+	e.entityTypes[j].typID = uintptr(i)
+	e.entityTypes[i], e.entityTypes[j] = e.entityTypes[j], e.entityTypes[i]
+}
+
+var _ sort.Interface = (*entityTypeSchemaSort)(nil)
 
 // NewSchema constructs a new schema from mappings.
 // The name parameter is just used for debugging and error messages.
@@ -54,6 +72,9 @@ type entityTypeSchema struct {
 	typ        reflect.Type
 	fields     []fieldInfo
 	attrFields map[ordinal][]fieldInfo
+
+	// typID is the rank of the type of this entity in the schema.
+	typID uintptr
 }
 
 type fieldInfo struct {
@@ -62,8 +83,27 @@ type fieldInfo struct {
 	attr            ordinal
 	comparableValue func(unsafe.Pointer) interface{}
 	value           func(unsafe.Pointer) interface{}
-	isPtr, isEntity bool
+	inline          func(unsafe.Pointer) (uintptr, bool)
+	fieldFlags
 }
+
+type fieldFlags int8
+
+func (f fieldFlags) isPtr() bool     { return f&pointerField != 0 }
+func (f fieldFlags) isScalar() bool  { return f&(intField|stringField|uintField) != 0 }
+func (f fieldFlags) isStruct() bool  { return f&structField != 0 }
+func (f fieldFlags) isInt() bool     { return f&intField != 0 }
+func (f fieldFlags) isUint() bool    { return f&uintField != 0 }
+func (f fieldFlags) isIntLike() bool { return f&(intField|uintField) != 0 }
+func (f fieldFlags) isString() bool  { return f&stringField != 0 }
+
+const (
+	intField fieldFlags = 1 << iota
+	uintField
+	stringField
+	structField
+	pointerField
+)
 
 func buildSchema(name string, opts ...SchemaOption) *Schema {
 	var m schemaMappings
@@ -79,8 +119,6 @@ func buildSchema(name string, opts ...SchemaOption) *Schema {
 		m: m,
 	}
 
-	sb.maybeAddAttribute(Self, emptyInterfaceType)
-	sb.maybeAddAttribute(Type, reflectTypeType)
 	for _, t := range m.attrTypes {
 		sb.maybeAddAttribute(t.a, t.typ)
 	}
@@ -89,6 +127,13 @@ func buildSchema(name string, opts ...SchemaOption) *Schema {
 	for _, tm := range m.entityMappings {
 		sb.maybeAddTypeMapping(tm.typ, tm.attrMappings)
 	}
+
+	sb.maybeAddAttribute(Self, emptyInterfaceType)
+	sb.selfOrdinal = sb.mustGetOrdinal(Self)
+	sb.maybeAddAttribute(Type, reflectTypeType)
+	sb.typeOrdinal = sb.mustGetOrdinal(Type)
+	sort.Sort((*entityTypeSchemaSort)(sb.Schema))
+
 	return sb.Schema
 }
 
@@ -165,42 +210,59 @@ func (sb *schemaBuilder) maybeAddTypeMapping(t reflect.Type, attributeMappings [
 		attributeFields[cur] = fieldInfos[i:j]
 		i = j
 	}
-	sb.entityTypeSchemas[t] = &entityTypeSchema{
+	ts := &entityTypeSchema{
 		typ:        t,
 		fields:     fieldInfos,
 		attrFields: attributeFields,
+		typID:      uintptr(len(sb.entityTypes)),
 	}
+	sb.entityTypeSchemas[t] = ts
+	sb.entityTypes = append(sb.entityTypes, ts)
+}
+
+func makeFieldFlags(t reflect.Type) (fieldFlags, bool) {
+	var f fieldFlags
+	if t.Kind() == reflect.Ptr {
+		f |= pointerField
+		t = t.Elem()
+	}
+	kind := t.Kind()
+	switch {
+	case kind == reflect.Struct && f.isPtr():
+		f |= structField
+	case kind == reflect.String:
+		f |= stringField
+	case isIntKind(kind):
+		f |= intField
+	case isUintKind(kind):
+		f |= uintField
+	default:
+		return 0, false
+	}
+	return f, true
 }
 
 func (sb *schemaBuilder) addTypeAttrMapping(a Attr, t reflect.Type, sel string) fieldInfo {
 	offset, cur := getOffsetAndTypeFromSelector(t, sel)
 
-	// TODO(ajwerner): Deal with making entities out of structs themselves.
-	// This gets complicated given the pointer equality used to determine
-	// whether entities exist. We'd otherwise need some mechanism for interning
-	// structs or something like that.
-	isPtr := cur.Kind() == reflect.Ptr
-	isStructPtr := isPtr && cur.Elem().Kind() == reflect.Struct
-	isScalarPtr := isPtr && isSupportScalarKind(cur.Elem().Kind())
-	if !isScalarPtr && !isStructPtr && !isSupportScalarKind(cur.Kind()) {
+	flags, ok := makeFieldFlags(cur)
+	if !ok {
 		panic(errors.Errorf(
 			"selector %q of %v has unsupported type %v",
 			sel, t, cur,
 		))
 	}
-
 	typ := cur
-	if isScalarPtr {
+	if flags.isPtr() && flags.isScalar() {
 		typ = cur.Elem()
 	}
 	ord := sb.maybeAddAttribute(a, typ)
 
 	f := fieldInfo{
-		path:     sel,
-		attr:     ord,
-		isEntity: isStructPtr,
-		isPtr:    isPtr,
-		typ:      typ,
+		fieldFlags: flags,
+		path:       sel,
+		attr:       ord,
+		typ:        typ,
 	}
 	makeValueGetter := func(t reflect.Type, offset uintptr) func(u unsafe.Pointer) reflect.Value {
 		return func(u unsafe.Pointer) reflect.Value {
@@ -218,34 +280,63 @@ func (sb *schemaBuilder) addTypeAttrMapping(a Attr, t reflect.Type, sel string) 
 	}
 	{
 		vg := makeValueGetter(cur, offset)
-		if isStructPtr {
+		if f.isPtr() && f.isStruct() {
 			f.value = getPtrValue(vg)
+		} else if f.isPtr() && f.isScalar() {
+			f.value = func(u unsafe.Pointer) interface{} {
+				got := vg(u)
+				ge := got.Elem()
+				if ge.IsNil() {
+					return nil
+				}
+				return ge.Elem().Interface()
+			}
 		} else {
-			if isScalarPtr {
-				f.value = func(u unsafe.Pointer) interface{} {
-					got := vg(u)
-					if got.Elem().IsNil() {
-						return nil
-					}
-					return got.Elem().Elem().Interface()
+			f.value = func(u unsafe.Pointer) interface{} {
+				return vg(u).Elem().Interface()
+			}
+		}
+		switch {
+		case f.isPtr() && f.isInt():
+			f.inline = func(u unsafe.Pointer) (uintptr, bool) {
+				got := vg(u)
+				if got.Elem().IsNil() {
+					return 0, false
 				}
-			} else {
-				f.value = func(u unsafe.Pointer) interface{} {
-					return vg(u).Elem().Interface()
+				return uintptr(got.Elem().Elem().Int()), true
+			}
+		case f.isPtr() && f.isUint():
+			f.inline = func(u unsafe.Pointer) (uintptr, bool) {
+				got := vg(u)
+				if got.Elem().IsNil() {
+					return 0, false
 				}
+				return uintptr(got.Elem().Elem().Uint()), true
+			}
+		case f.isInt():
+			f.inline = func(u unsafe.Pointer) (uintptr, bool) {
+				return uintptr(vg(u).Elem().Int()), true
+			}
+		case f.isUint():
+			f.inline = func(u unsafe.Pointer) (uintptr, bool) {
+				return uintptr(vg(u).Elem().Uint()), true
+			}
+		case f.isString(), f.isStruct():
+			f.inline = func(u unsafe.Pointer) (uintptr, bool) {
+				return 0, false
 			}
 		}
 	}
 	{
-		if isStructPtr {
+		if f.isStruct() {
 			f.comparableValue = getPtrValue(makeValueGetter(cur, offset))
 		} else {
 			compType := getComparableType(typ)
-			if isScalarPtr {
+			if f.isPtr() && f.isScalar() {
 				compType = reflect.PtrTo(compType)
 			}
 			vg := makeValueGetter(compType, offset)
-			if isScalarPtr {
+			if f.isPtr() && f.isScalar() {
 				f.comparableValue = getPtrValue(vg)
 			} else {
 				f.comparableValue = func(u unsafe.Pointer) interface{} {

--- a/pkg/sql/schemachanger/rel/schema_value.go
+++ b/pkg/sql/schemachanger/rel/schema_value.go
@@ -34,7 +34,7 @@ func makeComparableValue(val interface{}) (typedValue, error) {
 	}
 	typ := vv.Type()
 	switch {
-	case isSupportScalarKind(typ.Kind()):
+	case isIntKind(typ.Kind()):
 		// We need to allocate a new pointer.
 		compType := getComparableType(typ)
 		vvNew := reflect.New(vv.Type())
@@ -45,7 +45,7 @@ func makeComparableValue(val interface{}) (typedValue, error) {
 		}, nil
 	case typ.Kind() == reflect.Ptr:
 		switch {
-		case isSupportScalarKind(typ.Elem().Kind()):
+		case isIntKind(typ.Elem().Kind()):
 			compType := getComparableType(typ.Elem())
 			return typedValue{
 				typ:   vv.Type().Elem(),

--- a/pkg/sql/schemachanger/rel/system_attributes.go
+++ b/pkg/sql/schemachanger/rel/system_attributes.go
@@ -34,9 +34,4 @@ const (
 	maxUserAttribute ordinal = 64 - iota
 )
 
-func isSystemAttribute(a Attr) bool {
-	_, isSystemAttr := a.(systemAttribute)
-	return isSystemAttr
-}
-
 var _ Attr = systemAttribute(0)

--- a/pkg/sql/schemachanger/rel/testdata/cyclegraph
+++ b/pkg/sql/schemachanger/rel/testdata/cyclegraph
@@ -7,8 +7,12 @@ data:
 attributes: {}
 queries:
     - indexes:
-        - []
-        - [[s], [c], [name]]
+        0:
+            - {attrs: []}
+        1:
+            - {attrs: [s]}
+            - {attrs: [c]}
+            - {attrs: [name]}
       data: [container1]
       queries:
         oneOf member:

--- a/pkg/sql/schemachanger/rel/testdata/entitynode
+++ b/pkg/sql/schemachanger/rel/testdata/entitynode
@@ -15,10 +15,27 @@ attributes:
     nc: {right: nb, value: c}
 queries:
     - indexes:
-        - []
-        - [[value], [pi8], [i8, i16]]
-        - [[Type], [Self]]
-        - [[Self]]
+        0:
+            - {attrs: []}
+        1:
+            - {attrs: [value]}
+            - {attrs: [pi8]}
+            - {attrs: [i8, i16]}
+        2:
+            - {attrs: [value], where: {Type: '*entitynodetest.node'}}
+            - {attrs: [pi8], where: {Type: '*entitynodetest.entity'}}
+            - {attrs: [i8, i16], where: {Type: '*entitynodetest.entity'}}
+        3:
+            - {attrs: [value], where: {Type: '*entitynodetest.node'}}
+            - {attrs: [pi8], exists: [pi8]}
+            - {attrs: [i8, i16], where: {Type: '*entitynodetest.entity'}}
+        4:
+            - {attrs: [Type]}
+            - {attrs: [Self]}
+        5:
+            - {attrs: [Self]}
+        6:
+            - {attrs: [Self], exists: [Self]}
       data: [a, b, c, na, nb, nc]
       queries:
         a fields:
@@ -30,6 +47,7 @@ queries:
             result-vars: [$a, $ai8, $api8]
             results:
                 - [a, 1, 1]
+            unsatisfiableIndexes: [2]
         a-c-b join:
             query:
                 - $a[i8] = 1
@@ -41,6 +59,7 @@ queries:
             result-vars: [$a, $b, $c]
             results:
                 - [a, b, c]
+            unsatisfiableIndexes: [2, 3]
         nil values don't show up:
             query:
                 - $value[pi8] = 1
@@ -48,6 +67,7 @@ queries:
             result-vars: [$value]
             results:
                 - [a]
+            unsatisfiableIndexes: [2]
         nil values don't show up, scalar pointers same as pointers:
             query:
                 - $value[pi8] = 1
@@ -55,9 +75,21 @@ queries:
             result-vars: [$value]
             results:
                 - [a]
+            unsatisfiableIndexes: [2]
         list all the values:
             query:
                 - $value[i8] = $i8
+            entities: [$value]
+            result-vars: [$value, $i8]
+            results:
+                - [a, 1]
+                - [b, 2]
+                - [c, 2]
+            unsatisfiableIndexes: [2, 3]
+        list all the values with type constraint:
+            query:
+                - $value[i8] = $i8
+                - $value[Type] = '*entitynodetest.entity'
             entities: [$value]
             result-vars: [$value, $i8]
             results:
@@ -74,9 +106,11 @@ queries:
             results:
                 - [nb, b]
                 - [nc, c]
+            unsatisfiableIndexes: [2, 3]
         list all the i8 values:
             query:
                 - $value[i8] = $i8
+                - $value[Type] = '*entitynodetest.entity'
             entities: [$value]
             result-vars: [$i8]
             results:
@@ -91,6 +125,7 @@ queries:
             result-vars: [$value]
             results:
                 - [a]
+            unsatisfiableIndexes: [2, 3]
         types of all the entities:
             query:
                 - $value[Type] = $typ
@@ -103,6 +138,7 @@ queries:
                 - [na, '*entitynodetest.node']
                 - [nb, '*entitynodetest.node']
                 - [nc, '*entitynodetest.node']
+            unsatisfiableIndexes: [2, 3]
         nodes by type:
             query:
                 - $na[Type] = '*entitynodetest.node'
@@ -113,7 +149,8 @@ queries:
             result-vars: [$na, $nb, $nc, $a]
             results:
                 - [na, nb, nc, a]
-        nodes by type:
+            unsatisfiableIndexes: [2, 3]
+        list nodes:
             query:
                 - $n[Type] = '*entitynodetest.node'
             entities: [$n]
@@ -141,6 +178,7 @@ queries:
             result-vars: [$entity]
             results:
                 - [c]
+            unsatisfiableIndexes: [2, 3]
         contradiction due to missing attribute:
             query:
                 - '$entity[Self] = {i8: 2, pi8: null, i16: 1}'
@@ -148,6 +186,7 @@ queries:
             entities: [$entity]
             result-vars: [$entity, $pi8]
             results: []
+            unsatisfiableIndexes: [2]
         self eq self:
             query:
                 - $entity[Self] = $entity
@@ -160,6 +199,7 @@ queries:
                 - [na]
                 - [nb]
                 - [nc]
+            unsatisfiableIndexes: [2, 3]
         variable type mismatch:
             query:
                 - $entity[pi8] = 0
@@ -176,6 +216,7 @@ queries:
             results:
                 - [na, a, na, a]
                 - [na, a, nc, c]
+            unsatisfiableIndexes: [2, 3]
         entity bound via variable with ne filter:
             query:
                 - $n1[value] = $e1
@@ -188,6 +229,7 @@ queries:
             result-vars: [$n1, $e1, $n2, $e2]
             results:
                 - [na, a, nc, c]
+            unsatisfiableIndexes: [2, 3]
         any value type mismatch:
             query:
                 - $value[i8] IN [1, 2, 1]
@@ -199,6 +241,7 @@ queries:
             entities: [$e]
             result-vars: [$e, $i8]
             results: []
+            unsatisfiableIndexes: [2, 3]
         pointer scalar values any:
             query:
                 - $e[i8] IN [1, 2]
@@ -208,6 +251,7 @@ queries:
                 - [a]
                 - [b]
                 - [c]
+            unsatisfiableIndexes: [2, 3]
         pointer scalar values:
             query:
                 - $e[i8] = 1
@@ -215,6 +259,7 @@ queries:
             result-vars: [$e]
             results:
                 - [a]
+            unsatisfiableIndexes: [2, 3]
         nil pointer scalar values any:
             query:
                 - $e[i8] IN [1, 1, null]
@@ -229,6 +274,7 @@ queries:
             entities: [$e]
             result-vars: [$e]
             results: []
+            unsatisfiableIndexes: [2, 3]
         any clause no match on variable eq:
             query:
                 - $e[i8] = $i8
@@ -236,4 +282,5 @@ queries:
             entities: [$e]
             result-vars: [$e, $i8]
             results: []
+            unsatisfiableIndexes: [2, 3]
 comparisons: []

--- a/pkg/sql/schemachanger/rel/values.go
+++ b/pkg/sql/schemachanger/rel/values.go
@@ -10,7 +10,15 @@
 
 package rel
 
-import "sync"
+import (
+	"reflect"
+	"unsafe"
+)
+
+// numAttrs is the number of attributes we allow ourselves to store inline.
+// Schemas with entities which have more than this many attributes will need to
+// increase this number.
+const numAttrs = 8
 
 // valuesMap is a container for attributes.
 //
@@ -19,42 +27,74 @@ import "sync"
 // you need to use a Schema to retrieve that data. Note that the library
 // expects all values to be stored in the map in the comparable, primitive
 // form and not in the strongly typed format.
-type valuesMap struct {
+type values struct {
 	attrs ordinalSet
-	m     map[ordinal]interface{}
-}
-
-var valuesSyncPool = sync.Pool{
-	New: func() interface{} {
-		return &valuesMap{
-			m: make(map[ordinal]interface{}),
-		}
-	},
-}
-
-func getValues() *valuesMap {
-	return valuesSyncPool.Get().(*valuesMap)
-}
-
-func putValues(v *valuesMap) {
-	v.clear()
-	valuesSyncPool.Put(v)
-}
-
-func (vm *valuesMap) clear() {
-	for k := range vm.m {
-		delete(vm.m, k)
-	}
-	vm.attrs = 0
+	m     [numAttrs]uintptr
 }
 
 // get retrieves the primitive valuesMap stores in the valuesMap
 // struct.
-func (vm valuesMap) get(a ordinal) interface{} {
-	return vm.m[a]
+func (vm *values) get(a ordinal) (uintptr, bool) {
+	if !vm.attrs.contains(a) {
+		return 0, false
+	}
+	return vm.m[vm.attrs.rank(a)], true
 }
 
-func (vm *valuesMap) add(ord ordinal, v interface{}) {
-	vm.attrs = vm.attrs.add(ord)
-	vm.m[ord] = v
+// add returns false if the value was not added because the array is full.
+func (vm *values) add(a ordinal, v uintptr) (full bool) {
+	rank := vm.attrs.rank(a)
+	if !vm.attrs.contains(a) {
+		if vm.attrs.len() == numAttrs {
+			return false
+		}
+		if l := vm.attrs.len(); rank < l {
+			copy(vm.m[rank+1:l+1], vm.m[rank:l])
+		}
+		vm.attrs = vm.attrs.add(a)
+	}
+	vm.m[rank] = v
+	return true
+}
+
+// entity is the internal representation of a struct pointer.
+// The idea is that ptr is the pointer itself and typ is a
+// pointer to the entityTypeSchema.
+type entity values
+
+func (e *entity) getTypeInfo(es *entitySet) *entityTypeSchema {
+	tv, _ := (*values)(e).get(es.schema.typeOrdinal)
+	return es.schema.entityTypes[tv]
+}
+
+func (e *entity) getSelf(es *entitySet) interface{} {
+	sv, _ := (*values)(e).get(es.schema.selfOrdinal)
+	return es.objs[sv]
+}
+
+// getTypedValue returns the typedValue for the attribute of the entity.
+// Recall that the entity stores in its values type-erased primitive values
+// for comparison (so-called comparableValues). We annotate these comparable
+// values in typedValue.
+func (e *entity) getTypedValue(es *entitySet, attr ordinal) (typedValue, bool) {
+	ti := e.getTypeInfo(es)
+	if es.schema.attrs[attr] == Type {
+		return typedValue{typ: reflectTypeType, value: ti.typ}, true
+	}
+	sv := e.getSelf(es)
+	if es.schema.attrs[attr] == Self {
+		return typedValue{
+			typ:   ti.typ,
+			value: e.getSelf(es),
+		}, true
+	}
+	for _, f := range ti.attrFields[attr] {
+		if v := f.comparableValue(unsafe.Pointer(reflect.ValueOf(sv).Pointer())); v != nil {
+			return typedValue{
+				typ:   f.typ,
+				value: v,
+			}, true
+		}
+	}
+	return typedValue{}, false
 }

--- a/pkg/sql/schemachanger/scplan/internal/opgen/target.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/target.go
@@ -52,6 +52,7 @@ func makeTarget(e scpb.Element, spec targetSpec) (t target, err error) {
 	var element, target, node, targetStatus rel.Var = "element", "target", "node", "target-status"
 	q, err := rel.NewQuery(screl.Schema,
 		element.Type(e),
+		element.AttrEqVar(screl.DescID, "descID"), // this is to allow the index on elements to work
 		targetStatus.Eq(spec.to),
 		screl.JoinTargetNode(element, target, node),
 		target.AttrEqVar(screl.TargetStatus, targetStatus),

--- a/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
@@ -111,6 +111,10 @@ func (d depRuleSpec) register() {
 		v := rel.Var("joined-from-ref-desc-id-with-to-desc-id-var")
 		c = append(c, from.AttrEqVar(screl.ReferencedDescID, v), to.AttrEqVar(screl.DescID, v))
 	}
+
+	c = append(c, from.AttrEqVar(screl.DescID, "var-to-tell-rel-from-is-an-element"))
+	c = append(c, to.AttrEqVar(screl.DescID, "var-to-tell-rel-to-is-an-element"))
+
 	if d.filter != nil {
 		c = append(c, rel.Filter(d.filterLabel, from, to)(d.filter))
 	}

--- a/pkg/sql/schemachanger/scplan/internal/rules/op_drop.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/op_drop.go
@@ -198,7 +198,7 @@ func init() {
 				(*scpb.ConstraintName)(nil),
 			),
 
-			relationID.Entities(screl.DescID, relation, constraint),
+			relationID.Entities(screl.DescID, relation, constraint, dep),
 			constraintID.Entities(screl.ConstraintID, constraint, dep),
 
 			screl.JoinTarget(relation, relationTarget),

--- a/pkg/sql/schemachanger/scplan/internal/rules/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/testdata/deprules
@@ -19,6 +19,8 @@ deprules
     - $to-target[Element] = $to
     - $to-node[Type] = '*screl.Node'
     - $to-node[Target] = $to-target
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
     - view-depends-on(*scpb.View, scpb.Element)($from, $to)
 - name: alias type drops before the types it depends on
   from: from-node
@@ -39,6 +41,8 @@ deprules
     - $to-target[Element] = $to
     - $to-node[Type] = '*screl.Node'
     - $to-node[Target] = $to-target
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
     - alias-type-depends-on(*scpb.AliasType, scpb.Element)($from, $to)
 - name: array type drops right before its element enum type
   from: from-node
@@ -59,6 +63,8 @@ deprules
     - $to-target[Element] = $to
     - $to-node[Type] = '*screl.Node'
     - $to-node[Target] = $to-target
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
     - join-array-type-with-element-type(*scpb.AliasType, *scpb.EnumType)($from, $to)
 - name: schema dropped before parent database
   from: from-node
@@ -81,6 +87,8 @@ deprules
     - $to-node[Target] = $to-target
     - $from[ReferencedDescID] = $joined-from-ref-desc-id-with-to-desc-id-var
     - $to[DescID] = $joined-from-ref-desc-id-with-to-desc-id-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
 - name: object dropped before parent schema
   from: from-node
   kind: Precedence
@@ -102,6 +110,8 @@ deprules
     - $to-node[Target] = $to-target
     - $from[ReferencedDescID] = $joined-from-ref-desc-id-with-to-desc-id-var
     - $to[DescID] = $joined-from-ref-desc-id-with-to-desc-id-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
 - name: secondary region locality removed before dropping multi-region enum type
   from: from-node
   kind: Precedence
@@ -123,6 +133,8 @@ deprules
     - $to-node[Target] = $to-target
     - $from[ReferencedDescID] = $joined-from-ref-desc-id-with-to-desc-id-var
     - $to[DescID] = $joined-from-ref-desc-id-with-to-desc-id-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
 - name: check constraint removed before dropping dependent types and sequences
   from: from-node
   kind: Precedence
@@ -142,6 +154,8 @@ deprules
     - $to-target[Element] = $to
     - $to-node[Type] = '*screl.Node'
     - $to-node[Target] = $to-target
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
     - check-constraint-depends-on(*scpb.CheckConstraint, scpb.Element)($from, $to)
 - name: FK removed before dropping dependent table
   from: from-node
@@ -164,6 +178,8 @@ deprules
     - $to-node[Target] = $to-target
     - $from[ReferencedDescID] = $joined-from-ref-desc-id-with-to-desc-id-var
     - $to[DescID] = $joined-from-ref-desc-id-with-to-desc-id-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
 - name: index partial predicate removed before dropping dependent types
   from: from-node
   kind: Precedence
@@ -183,6 +199,8 @@ deprules
     - $to-target[Element] = $to
     - $to-node[Type] = '*screl.Node'
     - $to-node[Target] = $to-target
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
     - index-partial-depends-on(*scpb.SecondaryIndexPartial, scpb.Element)($from, $to)
 - name: column type removed before dropping dependent types
   from: from-node
@@ -203,6 +221,8 @@ deprules
     - $to-target[Element] = $to
     - $to-node[Type] = '*screl.Node'
     - $to-node[Target] = $to-target
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
     - column-type-depends-on(*scpb.ColumnType, scpb.Element)($from, $to)
 - name: column DEFAULT removed before dropping dependent types and sequences
   from: from-node
@@ -223,6 +243,8 @@ deprules
     - $to-target[Element] = $to
     - $to-node[Type] = '*screl.Node'
     - $to-node[Target] = $to-target
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
     - column-default-depends-on(*scpb.ColumnDefaultExpression, scpb.Element)($from, $to)
 - name: column ON UPDATE removed before dropping dependent types and sequences
   from: from-node
@@ -243,6 +265,8 @@ deprules
     - $to-target[Element] = $to
     - $to-node[Type] = '*screl.Node'
     - $to-node[Target] = $to-target
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
     - column-on-update-depends-on(*scpb.ColumnOnUpdateExpression, scpb.Element)($from, $to)
 - name: sequence ownership removed before dropping sequence
   from: from-node
@@ -265,6 +289,8 @@ deprules
     - $to-node[Target] = $to-target
     - $from[ReferencedDescID] = $joined-from-ref-desc-id-with-to-desc-id-var
     - $to[DescID] = $joined-from-ref-desc-id-with-to-desc-id-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
 - name: database region config removed before dropping multi-region enum type
   from: from-node
   kind: Precedence
@@ -286,6 +312,8 @@ deprules
     - $to-node[Target] = $to-target
     - $from[ReferencedDescID] = $joined-from-ref-desc-id-with-to-desc-id-var
     - $to[DescID] = $joined-from-ref-desc-id-with-to-desc-id-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
 - name: dependent element removal before descriptor drop
   from: from-node
   kind: Precedence
@@ -307,6 +335,8 @@ deprules
     - $to-node[Target] = $to-target
     - $from[DescID] = $DescID-join-var
     - $to[DescID] = $DescID-join-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
 - name: dependent element removal right after descriptor removal
   from: from-node
   kind: SameStagePrecedence
@@ -328,6 +358,8 @@ deprules
     - $to-node[Target] = $to-target
     - $from[DescID] = $DescID-join-var
     - $to[DescID] = $DescID-join-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
 - name: primary index swap
   from: old-index-node
   kind: SameStagePrecedence
@@ -373,6 +405,8 @@ deprules
     - $to[DescID] = $DescID-join-var
     - $from[IndexID] = $IndexID-join-var
     - $to[IndexID] = $IndexID-join-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
 - name: partial predicate set right after secondary index existence
   from: from-node
   kind: SameStagePrecedence
@@ -396,6 +430,8 @@ deprules
     - $to[DescID] = $DescID-join-var
     - $from[IndexID] = $IndexID-join-var
     - $to[IndexID] = $IndexID-join-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
 - name: dependents existence precedes writes to index
   from: from-node
   kind: Precedence
@@ -419,6 +455,8 @@ deprules
     - $to[DescID] = $DescID-join-var
     - $from[IndexID] = $IndexID-join-var
     - $to[IndexID] = $IndexID-join-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
 - name: index named right before index becomes public
   from: from-node
   kind: SameStagePrecedence
@@ -442,6 +480,8 @@ deprules
     - $to[DescID] = $DescID-join-var
     - $from[IndexID] = $IndexID-join-var
     - $to[IndexID] = $IndexID-join-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
 - name: dependents removed after index no longer public
   from: from-node
   kind: Precedence
@@ -465,6 +505,8 @@ deprules
     - $to[DescID] = $DescID-join-var
     - $from[IndexID] = $IndexID-join-var
     - $to[IndexID] = $IndexID-join-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
 - name: dependents removed before index
   from: from-node
   kind: Precedence
@@ -488,6 +530,8 @@ deprules
     - $to[DescID] = $DescID-join-var
     - $from[IndexID] = $IndexID-join-var
     - $to[IndexID] = $IndexID-join-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
 - name: column type set right after column existence
   from: from-node
   kind: SameStagePrecedence
@@ -511,6 +555,8 @@ deprules
     - $to[DescID] = $DescID-join-var
     - $from[ColumnID] = $ColumnID-join-var
     - $to[ColumnID] = $ColumnID-join-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
 - name: column existence precedes column dependents
   from: from-node
   kind: Precedence
@@ -534,6 +580,8 @@ deprules
     - $to[DescID] = $DescID-join-var
     - $from[ColumnID] = $ColumnID-join-var
     - $to[ColumnID] = $ColumnID-join-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
 - name: column existence precedes column comment
   from: from-node
   kind: Precedence
@@ -557,6 +605,8 @@ deprules
     - $to[DescID] = $DescID-join-var
     - $from[PgAttributeNum] = $PgAttributeNum-join-var
     - $to[PgAttributeNum] = $PgAttributeNum-join-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
 - name: DEFAULT or ON UPDATE existence precedes writes to column
   from: from-node
   kind: Precedence
@@ -580,6 +630,8 @@ deprules
     - $to[DescID] = $DescID-join-var
     - $from[ColumnID] = $ColumnID-join-var
     - $to[ColumnID] = $ColumnID-join-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
 - name: column named right before column becomes public
   from: from-node
   kind: SameStagePrecedence
@@ -603,6 +655,8 @@ deprules
     - $to[DescID] = $DescID-join-var
     - $from[ColumnID] = $ColumnID-join-var
     - $to[ColumnID] = $ColumnID-join-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
 - name: column dependents exist before column becomes public
   from: from-node
   kind: Precedence
@@ -626,6 +680,8 @@ deprules
     - $to[DescID] = $DescID-join-var
     - $from[PgAttributeNum] = $PgAttributeNum-join-var
     - $to[PgAttributeNum] = $PgAttributeNum-join-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
 - name: column dependents removed after column no longer public
   from: from-node
   kind: Precedence
@@ -649,6 +705,8 @@ deprules
     - $to[DescID] = $DescID-join-var
     - $from[ColumnID] = $ColumnID-join-var
     - $to[ColumnID] = $ColumnID-join-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
 - name: column comments removed after column no longer public
   from: from-node
   kind: Precedence
@@ -672,6 +730,8 @@ deprules
     - $to[DescID] = $DescID-join-var
     - $from[PgAttributeNum] = $PgAttributeNum-join-var
     - $to[PgAttributeNum] = $PgAttributeNum-join-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
 - name: column type dependents removed right before column type
   from: from-node
   kind: SameStagePrecedence
@@ -695,6 +755,8 @@ deprules
     - $to[DescID] = $DescID-join-var
     - $from[ColumnID] = $ColumnID-join-var
     - $to[ColumnID] = $ColumnID-join-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
 - name: dependents removed before column
   from: from-node
   kind: Precedence
@@ -718,6 +780,8 @@ deprules
     - $to[DescID] = $DescID-join-var
     - $from[ColumnID] = $ColumnID-join-var
     - $to[ColumnID] = $ColumnID-join-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
 - name: column comment removed before column
   from: from-node
   kind: Precedence
@@ -741,6 +805,8 @@ deprules
     - $to[DescID] = $DescID-join-var
     - $from[PgAttributeNum] = $PgAttributeNum-join-var
     - $to[PgAttributeNum] = $PgAttributeNum-join-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
 - name: column type removed right before column when not dropping relation
   from: from-node
   kind: SameStagePrecedence
@@ -764,6 +830,8 @@ deprules
     - $to[DescID] = $DescID-join-var
     - $from[ColumnID] = $ColumnID-join-var
     - $to[ColumnID] = $ColumnID-join-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
     - parent-relation-is-not-dropped(*scpb.ColumnType, *scpb.Column)($from, $to)
 - name: partial predicate removed right before secondary index when not dropping relation
   from: from-node
@@ -788,6 +856,8 @@ deprules
     - $to[DescID] = $DescID-join-var
     - $from[IndexID] = $IndexID-join-var
     - $to[IndexID] = $IndexID-join-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
     - parent-relation-is-not-dropped(*scpb.SecondaryIndexPartial, *scpb.SecondaryIndex)($from, $to)
 - name: column depends on primary index
   from: index-node
@@ -834,4 +904,6 @@ deprules
     - $to-node[Target] = $to-target
     - $from[DescID] = $DescID-join-var
     - $to[DescID] = $DescID-join-var
+    - $from[DescID] = $var-to-tell-rel-from-is-an-element
+    - $to[DescID] = $var-to-tell-rel-to-is-an-element
     - column-featured-in-index(*scpb.Column, scpb.Element)($from, $to)

--- a/pkg/sql/schemachanger/scplan/internal/rules/testdata/oprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/testdata/oprules
@@ -98,6 +98,7 @@ oprules
     - $constraint-dep[Type] = '*scpb.ConstraintName'
     - $relation[DescID] = $relation-id
     - $constraint[DescID] = $relation-id
+    - $constraint-dep[DescID] = $relation-id
     - $constraint[ConstraintID] = $constraint-id
     - $constraint-dep[ConstraintID] = $constraint-id
     - $relation-target[Type] = '*scpb.Target'

--- a/pkg/sql/schemachanger/screl/query_test.go
+++ b/pkg/sql/schemachanger/screl/query_test.go
@@ -144,9 +144,10 @@ func TestQueryBasic(t *testing.T) {
 		},
 	} {
 		t.Run("", func(t *testing.T) {
-			tr, err := rel.NewDatabase(screl.Schema, [][]rel.Attr{
-				{screl.ColumnID},
-			})
+			tr, err := rel.NewDatabase(screl.Schema, []rel.Index{
+				{}, // an everything index
+				{Attrs: []rel.Attr{screl.ColumnID}},
+			}...)
 			require.NoError(t, err)
 			for _, n := range c.nodes {
 				require.NoError(t, tr.Insert(n))


### PR DESCRIPTION
This change is a major reworking of the rel library. It does two things:

1) It makes indexes partial leading to much smaller data structures
2) It inlines values to avoid so many cache misses during comparisons

Release note: None