### PR TITLE
ci: ensure nightlies have all the env vars they need to post issues

### DIFF
--- a/build/teamcity/cockroach/nightlies/lint_urls.sh
+++ b/build/teamcity/cockroach/nightlies/lint_urls.sh
@@ -8,5 +8,6 @@ source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
 tc_start_block "lint urls"
-run_bazel build/teamcity/cockroach/nightlies/lint_urls_impl.sh
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e BUILD_VCS_NUMBER -e GITHUB_API_TOKEN -e GITHUB_REPO -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL" \
+                               run_bazel build/teamcity/cockroach/nightlies/lint_urls_impl.sh
 tc_end_block "lint urls"

--- a/build/teamcity/cockroach/nightlies/optimizer_tests.sh
+++ b/build/teamcity/cockroach/nightlies/optimizer_tests.sh
@@ -7,4 +7,5 @@ dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
 source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
-run_bazel build/teamcity/cockroach/nightlies/optimizer_tests_impl.sh
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e BUILD_VCS_NUMBER -e GITHUB_API_TOKEN -e GITHUB_REPO -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL" \
+                               run_bazel build/teamcity/cockroach/nightlies/optimizer_tests_impl.sh

--- a/build/teamcity/cockroach/nightlies/random_syntax_tests.sh
+++ b/build/teamcity/cockroach/nightlies/random_syntax_tests.sh
@@ -8,5 +8,6 @@ source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
 tc_start_block "Run random syntax tests"
-run_bazel build/teamcity/cockroach/nightlies/random_syntax_tests_impl.sh
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e BUILD_VCS_NUMBER -e GITHUB_API_TOKEN -e GITHUB_REPO -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL" \
+                               run_bazel build/teamcity/cockroach/nightlies/random_syntax_tests_impl.sh
 tc_end_block "Run random syntax tests"

--- a/build/teamcity/cockroach/nightlies/sqlite_logic_test.sh
+++ b/build/teamcity/cockroach/nightlies/sqlite_logic_test.sh
@@ -8,5 +8,6 @@ source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
 tc_start_block "Run SQLite logic tests"
-run_bazel build/teamcity/cockroach/nightlies/sqlite_logic_test_impl.sh
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e BUILD_VCS_NUMBER -e GITHUB_API_TOKEN -e GITHUB_REPO -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL" \
+                               run_bazel build/teamcity/cockroach/nightlies/sqlite_logic_test_impl.sh
 tc_end_block "Run SQLite logic tests"


### PR DESCRIPTION
Without these environment variables, these nightlies won't be able to
run `process_test_json` or post GitHub issues.

Closes #79403.

Release note: None