### PR TITLE
release-21.2: backupccl: ensure AOST incremental backup ends after previous backup

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -1515,6 +1515,13 @@ func getBackupDetailAndManifest(
 		if err := requireEnterprise(execCfg, "incremental"); err != nil {
 			return jobspb.BackupDetails{}, BackupManifest{}, err
 		}
+		lastEndTime := prevBackups[len(prevBackups)-1].EndTime
+		if initialDetails.EndTime.Less(lastEndTime) {
+			return jobspb.BackupDetails{}, BackupManifest{},
+				errors.Newf("`AS OF SYSTEM TIME` %s must be greater than "+
+					"the previous backup's end time of %s.",
+					initialDetails.EndTime.GoTime(), lastEndTime.GoTime())
+		}
 		startTime = prevBackups[len(prevBackups)-1].EndTime
 	}
 

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -3863,8 +3863,18 @@ func TestBackupAsOfSystemTime(t *testing.T) {
 
 	beforeDir := LocalFoo + `/beforeTs`
 	sqlDB.Exec(t, fmt.Sprintf(`BACKUP DATABASE data TO '%s' AS OF SYSTEM TIME %s`, beforeDir, beforeTs))
+
 	equalDir := LocalFoo + `/equalTs`
 	sqlDB.Exec(t, fmt.Sprintf(`BACKUP DATABASE data TO '%s' AS OF SYSTEM TIME %s`, equalDir, equalTs))
+	{
+		// testing UX guardrails for AS OF SYSTEM TIME backups in collections
+		sqlDB.Exec(t, fmt.Sprintf(`BACKUP DATABASE data INTO '%s' AS OF SYSTEM TIME %s`, equalDir, equalTs))
+
+		sqlDB.ExpectErr(t, "`AS OF SYSTEM TIME` .* must be greater than the previous backup's end time of",
+			fmt.Sprintf(`BACKUP DATABASE data INTO LATEST IN '%s' AS OF SYSTEM TIME %s`,
+				equalDir,
+				beforeTs))
+	}
 
 	sqlDB.Exec(t, `DROP TABLE data.bank`)
 	sqlDB.Exec(t, `RESTORE data.* FROM $1`, beforeDir)


### PR DESCRIPTION
Backport 1/2 commits from #79799.

/cc @cockroachdb/release

---

Informs https://github.com/cockroachdb/cockroach/issues/79674

Release note (sql change): Previously, a user could run an AS OF SYSTEM TIME
incremental backup with an end time earlier than the previous backup's end time
, which could lead to an out of order incremental backup chain. This PR causes
the incremental backup to fail if the AS OF SYSTEM TIME is less than the
previous backup's end time.

Release justification: low risk bug fix