### PR TITLE
release-22.1: logictest: support async queries in logictests

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cluster_locks
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_locks
@@ -33,8 +33,18 @@ user testuser
 statement ok
 BEGIN
 
-statement async readReq ok
+query TT async,rowsort readReq
 SELECT * FROM t
+----
+a   val1
+b   val2_updated
+c   val3_updated
+l   val4_updated
+m   val5_updated
+p   val6_updated
+s   val7_updated
+t   val8_updated
+z   val9
 
 user root
 
@@ -49,7 +59,51 @@ COMMIT
 
 user testuser
 
-awaitstatement readReq
+awaitquery readReq
+
+statement ok
+COMMIT
+
+user root
+
+statement ok
+BEGIN
+
+query TT rowsort
+SELECT * FROM t FOR UPDATE
+----
+a   val1
+b   val2_updated
+c   val3_updated
+l   val4_updated
+m   val5_updated
+p   val6_updated
+s   val7_updated
+t   val8_updated
+z   val9
+
+user testuser
+
+statement ok
+BEGIN
+
+statement async deleteReq count 7
+DELETE FROM t WHERE k >= 'b' AND k < 'z'
+
+user root
+
+query TTT colnames,retry
+SELECT user_name, query, phase FROM crdb_internal.cluster_queries WHERE user_name='testuser'
+----
+user_name   query                                           phase
+testuser    DELETE FROM t WHERE (k >= 'b') AND (k < 'z')    executing
+
+statement ok
+COMMIT
+
+user testuser
+
+awaitstatement deleteReq
 
 statement ok
 COMMIT


### PR DESCRIPTION
Backport 1/1 commits from #79871.

/cc @cockroachdb/release

---

This change adds support for asynchronous queries in logictests, which
will execute the query in a separate goroutine, prior to awaiting and
validating the results when unblocked by any contending operations.
While previously logictests had supported asynchronous statements as
introduced in #79010, the `query` execution, which returns rows to be
validated, is now supported in asynchronous mode with this change.

This feature is supported with the following syntax:
```
query <typestring> async,<options...> namedQuery
<some query that may block during execution>
----
<expected query results>
...
<operations that would free the locks namedQuery is waiting on>
...
awaitquery namedQuery
<waits on namedQuery to complete and validate the results>
```

While this feature is not supported in conjunction with some query
options such as `retry`, or when placed in a `repeat` block, it does
support being run with the `--rewrite` flag. This change also fixes a
bug with asynchronous statements that could cause a race condition in
testing.

Release note: None

Release Justification: Test-only change.