### PR TITLE
sql/schemachanger: show default values in decomp test

### DIFF
--- a/pkg/ccl/schemachangerccl/testdata/decomp/multiregion
+++ b/pkg/ccl/schemachangerccl/testdata/decomp/multiregion
@@ -20,8 +20,10 @@ ElementState:
     databaseId: 104
   Status: PUBLIC
 - Namespace:
+    databaseId: 0
     descriptorId: 104
     name: multi_region_test_db
+    schemaId: 0
   Status: PUBLIC
 - Owner:
     descriptorId: 104
@@ -61,35 +63,52 @@ table_global
 BackReferencedIDs:
 ElementState:
 - Table:
+    isTemporary: false
     tableId: 110
   Status: PUBLIC
 - ColumnFamily:
+    familyId: 0
     name: primary
     tableId: 110
   Status: PUBLIC
 - Column:
     columnId: 1
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 1
     tableId: 110
   Status: PUBLIC
 - Column:
     columnId: 2
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
     isHidden: true
+    isInaccessible: false
     pgAttributeNum: 2
     tableId: 110
   Status: PUBLIC
 - PrimaryIndex:
     embeddedIndex:
+      compositeColumnIds: []
       constraintId: 1
       indexId: 1
+      isConcurrently: false
+      isCreatedExplicitly: false
+      isInverted: false
       isUnique: true
       keyColumnDirections:
       - ASC
       keyColumnIds:
       - 2
+      keySuffixColumnIds: []
+      sharding: null
+      sourceIndexId: 0
       storingColumnIds:
       - 1
       tableId: 110
+      temporaryIndexId: 0
   Status: PUBLIC
 - TableComment:
     comment: __placeholder_comment__
@@ -110,27 +129,64 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     columnId: 1
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: IntFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 20
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
         width: 64
+    familyId: 0
     isNullable: true
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 110
   Status: PUBLIC
 - ColumnType:
     columnId: 2
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: IntFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 20
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
         width: 64
+    familyId: 0
+    isNullable: false
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 110
   Status: PUBLIC
 - ColumnDefaultExpression:
     columnId: 2
     embeddedExpr:
       expr: unique_rowid()
+      usesSequenceIds: []
+      usesTypeIds: []
     tableId: 110
   Status: PUBLIC
 - ColumnComment:
@@ -186,35 +242,52 @@ table_regional_by_table
 BackReferencedIDs:
 ElementState:
 - Table:
+    isTemporary: false
     tableId: 109
   Status: PUBLIC
 - ColumnFamily:
+    familyId: 0
     name: primary
     tableId: 109
   Status: PUBLIC
 - Column:
     columnId: 1
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 1
     tableId: 109
   Status: PUBLIC
 - Column:
     columnId: 2
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
     isHidden: true
+    isInaccessible: false
     pgAttributeNum: 2
     tableId: 109
   Status: PUBLIC
 - PrimaryIndex:
     embeddedIndex:
+      compositeColumnIds: []
       constraintId: 1
       indexId: 1
+      isConcurrently: false
+      isCreatedExplicitly: false
+      isInverted: false
       isUnique: true
       keyColumnDirections:
       - ASC
       keyColumnIds:
       - 2
+      keySuffixColumnIds: []
+      sharding: null
+      sourceIndexId: 0
       storingColumnIds:
       - 1
       tableId: 109
+      temporaryIndexId: 0
   Status: PUBLIC
 - TableComment:
     comment: __placeholder_comment__
@@ -237,27 +310,64 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     columnId: 1
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: IntFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 20
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
         width: 64
+    familyId: 0
     isNullable: true
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 109
   Status: PUBLIC
 - ColumnType:
     columnId: 2
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: IntFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 20
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
         width: 64
+    familyId: 0
+    isNullable: false
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 109
   Status: PUBLIC
 - ColumnDefaultExpression:
     columnId: 2
     embeddedExpr:
       expr: unique_rowid()
+      usesSequenceIds: []
+      usesTypeIds: []
     tableId: 109
   Status: PUBLIC
 - ColumnComment:
@@ -313,32 +423,49 @@ table_regional_by_row
 BackReferencedIDs:
 ElementState:
 - Table:
+    isTemporary: false
     tableId: 108
   Status: PUBLIC
 - ColumnFamily:
+    familyId: 0
     name: primary
     tableId: 108
   Status: PUBLIC
 - Column:
     columnId: 1
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 1
     tableId: 108
   Status: PUBLIC
 - Column:
     columnId: 2
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 2
     tableId: 108
   Status: PUBLIC
 - Column:
     columnId: 3
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
     isHidden: true
+    isInaccessible: false
     pgAttributeNum: 3
     tableId: 108
   Status: PUBLIC
 - PrimaryIndex:
     embeddedIndex:
+      compositeColumnIds: []
       constraintId: 1
       indexId: 1
+      isConcurrently: false
+      isCreatedExplicitly: false
+      isInverted: false
       isUnique: true
       keyColumnDirections:
       - ASC
@@ -346,15 +473,20 @@ ElementState:
       keyColumnIds:
       - 3
       - 1
+      keySuffixColumnIds: []
+      sharding: null
+      sourceIndexId: 0
       storingColumnIds:
       - 2
       tableId: 108
+      temporaryIndexId: 0
   Status: PUBLIC
 - TableComment:
     comment: __placeholder_comment__
     tableId: 108
   Status: PUBLIC
 - TableLocalityRegionalByRow:
+    as: ""
     tableId: 108
   Status: PUBLIC
 - ColumnName:
@@ -374,39 +506,93 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     columnId: 1
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: IntFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 20
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
         width: 64
+    familyId: 0
+    isNullable: false
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 108
   Status: PUBLIC
 - ColumnType:
     columnId: 2
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: StringFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 25
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
+        width: 0
+    familyId: 0
     isNullable: true
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 108
   Status: PUBLIC
 - ColumnType:
     columnId: 3
+    computeExpr: null
     embeddedTypeT:
       closedTypeIds:
       - 105
       - 107
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: EnumFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 100105
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
         udtMetadata:
           arrayTypeOid: 100107
+        visibleType: 0
+        width: 0
+    familyId: 0
+    isNullable: false
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 108
   Status: PUBLIC
 - ColumnDefaultExpression:
     columnId: 3
     embeddedExpr:
       expr: default_to_database_primary_region(gateway_region())::@100105
+      usesSequenceIds: []
       usesTypeIds:
       - 105
       - 107
@@ -440,19 +626,32 @@ ElementState:
     partitioning:
       list:
       - name: us-east1
-        subpartitioning: {}
+        subpartitioning:
+          list: []
+          numColumns: 0
+          numImplicitColumns: 0
+          range: []
         values:
         - BgFA
       - name: us-east2
-        subpartitioning: {}
+        subpartitioning:
+          list: []
+          numColumns: 0
+          numImplicitColumns: 0
+          range: []
         values:
         - BgGA
       - name: us-east3
-        subpartitioning: {}
+        subpartitioning:
+          list: []
+          numColumns: 0
+          numImplicitColumns: 0
+          range: []
         values:
         - BgHA
       numColumns: 1
       numImplicitColumns: 1
+      range: []
     tableId: 108
   Status: PUBLIC
 - IndexComment:

--- a/pkg/ccl/schemachangerccl/testdata/decomp/partitioning
+++ b/pkg/ccl/schemachangerccl/testdata/decomp/partitioning
@@ -27,31 +27,49 @@ table_implicit
 BackReferencedIDs:
 ElementState:
 - Table:
+    isTemporary: false
     tableId: 104
   Status: PUBLIC
 - ColumnFamily:
+    familyId: 0
     name: fam_0_pk_a_j
     tableId: 104
   Status: PUBLIC
 - Column:
     columnId: 1
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 1
     tableId: 104
   Status: PUBLIC
 - Column:
     columnId: 2
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 2
     tableId: 104
   Status: PUBLIC
 - Column:
     columnId: 3
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 3
     tableId: 104
   Status: PUBLIC
 - PrimaryIndex:
     embeddedIndex:
+      compositeColumnIds: []
       constraintId: 1
       indexId: 1
+      isConcurrently: false
+      isCreatedExplicitly: false
+      isInverted: false
       isUnique: true
       keyColumnDirections:
       - ASC
@@ -59,14 +77,23 @@ ElementState:
       keyColumnIds:
       - 2
       - 1
+      keySuffixColumnIds: []
+      sharding: null
+      sourceIndexId: 0
       storingColumnIds:
       - 3
       tableId: 104
+      temporaryIndexId: 0
   Status: PUBLIC
 - SecondaryIndex:
     embeddedIndex:
+      compositeColumnIds: []
+      constraintId: 0
       indexId: 2
+      isConcurrently: false
+      isCreatedExplicitly: false
       isInverted: true
+      isUnique: false
       keyColumnDirections:
       - ASC
       - ASC
@@ -75,7 +102,11 @@ ElementState:
       - 3
       keySuffixColumnIds:
       - 1
+      sharding: null
+      sourceIndexId: 0
+      storingColumnIds: []
       tableId: 104
+      temporaryIndexId: 0
   Status: PUBLIC
 - TableComment:
     comment: __placeholder_comment__
@@ -98,29 +129,83 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     columnId: 1
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: IntFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 20
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
         width: 64
+    familyId: 0
+    isNullable: false
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 104
   Status: PUBLIC
 - ColumnType:
     columnId: 2
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: IntFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 20
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
         width: 64
+    familyId: 0
+    isNullable: false
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 104
   Status: PUBLIC
 - ColumnType:
     columnId: 3
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: JsonFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 3802
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
+        width: 0
+    familyId: 0
     isNullable: true
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 104
   Status: PUBLIC
 - ColumnComment:
@@ -156,11 +241,16 @@ ElementState:
     partitioning:
       list:
       - name: pk_implicit
-        subpartitioning: {}
+        subpartitioning:
+          list: []
+          numColumns: 0
+          numImplicitColumns: 0
+          range: []
         values:
         - AwI=
       numColumns: 1
       numImplicitColumns: 1
+      range: []
     tableId: 104
   Status: PUBLIC
 - IndexPartitioning:
@@ -168,11 +258,16 @@ ElementState:
     partitioning:
       list:
       - name: j_implicit
-        subpartitioning: {}
+        subpartitioning:
+          list: []
+          numColumns: 0
+          numImplicitColumns: 0
+          range: []
         values:
         - Awo=
       numColumns: 1
       numImplicitColumns: 1
+      range: []
     tableId: 104
   Status: PUBLIC
 - IndexComment:
@@ -216,39 +311,61 @@ table_partitioned_index
 BackReferencedIDs:
 ElementState:
 - Table:
+    isTemporary: false
     tableId: 105
   Status: PUBLIC
 - ColumnFamily:
+    familyId: 0
     name: primary
     tableId: 105
   Status: PUBLIC
 - Column:
     columnId: 1
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 1
     tableId: 105
   Status: PUBLIC
 - Column:
     columnId: 2
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 2
     tableId: 105
   Status: PUBLIC
 - PrimaryIndex:
     embeddedIndex:
+      compositeColumnIds: []
       constraintId: 2
       indexId: 1
+      isConcurrently: false
+      isCreatedExplicitly: false
+      isInverted: false
       isUnique: true
       keyColumnDirections:
       - ASC
       keyColumnIds:
       - 1
+      keySuffixColumnIds: []
+      sharding: null
+      sourceIndexId: 0
       storingColumnIds:
       - 2
       tableId: 105
+      temporaryIndexId: 0
   Status: PUBLIC
 - SecondaryIndex:
     embeddedIndex:
+      compositeColumnIds: []
       constraintId: 1
       indexId: 2
+      isConcurrently: false
+      isCreatedExplicitly: false
+      isInverted: false
       isUnique: true
       keyColumnDirections:
       - ASC
@@ -256,7 +373,11 @@ ElementState:
       - 2
       keySuffixColumnIds:
       - 1
+      sharding: null
+      sourceIndexId: 0
+      storingColumnIds: []
       tableId: 105
+      temporaryIndexId: 0
   Status: PUBLIC
 - TableComment:
     comment: __placeholder_comment__
@@ -274,21 +395,56 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     columnId: 1
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: IntFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 20
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
         width: 64
+    familyId: 0
+    isNullable: false
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 105
   Status: PUBLIC
 - ColumnType:
     columnId: 2
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: IntFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 20
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
         width: 64
+    familyId: 0
     isNullable: true
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 105
   Status: PUBLIC
 - ColumnComment:
@@ -318,10 +474,16 @@ ElementState:
     partitioning:
       list:
       - name: p1
-        subpartitioning: {}
+        subpartitioning:
+          list: []
+          numColumns: 0
+          numImplicitColumns: 0
+          range: []
         values:
         - AwI=
       numColumns: 1
+      numImplicitColumns: 0
+      range: []
     tableId: 105
   Status: PUBLIC
 - IndexComment:

--- a/pkg/sql/schemachanger/scbuild/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/BUILD.bazel
@@ -66,6 +66,7 @@ go_test(
         "//pkg/server",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/parser",
+        "//pkg/sql/protoreflect",
         "//pkg/sql/schemachanger/scdeps/sctestdeps",
         "//pkg/sql/schemachanger/scdeps/sctestutils",
         "//pkg/sql/schemachanger/scerrors",

--- a/pkg/sql/schemachanger/scbuild/builder_test.go
+++ b/pkg/sql/schemachanger/scbuild/builder_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/protoreflect"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scbuild"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scdeps/sctestdeps"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scdeps/sctestutils"
@@ -196,7 +197,7 @@ func marshalState(t *testing.T, state scpb.CurrentState) string {
 			Target:        &state.Targets[i],
 			CurrentStatus: status,
 		}
-		yaml, err := sctestutils.ProtoToYAML(node.Target.Element())
+		yaml, err := sctestutils.ProtoToYAML(node.Target.Element(), protoreflect.FmtFlags{})
 		require.NoError(t, err)
 		entry := strings.Builder{}
 		entry.WriteString("- ")

--- a/pkg/sql/schemachanger/scdecomp/testdata/other
+++ b/pkg/sql/schemachanger/scdecomp/testdata/other
@@ -15,12 +15,16 @@ sc1
 BackReferencedIDs:
 ElementState:
 - Schema:
+    isPublic: false
+    isTemporary: false
+    isVirtual: false
     schemaId: 106
   Status: PUBLIC
 - Namespace:
     databaseId: 104
     descriptorId: 106
     name: sc1
+    schemaId: 0
   Status: PUBLIC
 - Owner:
     descriptorId: 106
@@ -52,12 +56,15 @@ BackReferencedIDs:
 ElementState:
 - Schema:
     isPublic: true
+    isTemporary: false
+    isVirtual: false
     schemaId: 105
   Status: PUBLIC
 - Namespace:
     databaseId: 104
     descriptorId: 105
     name: public
+    schemaId: 0
   Status: PUBLIC
 - Owner:
     descriptorId: 105
@@ -98,8 +105,10 @@ ElementState:
     databaseId: 104
   Status: PUBLIC
 - Namespace:
+    databaseId: 0
     descriptorId: 104
     name: db1
+    schemaId: 0
   Status: PUBLIC
 - Owner:
     descriptorId: 104
@@ -137,6 +146,7 @@ BackReferencedIDs:
 ElementState:
 - EnumType:
     arrayTypeId: 111
+    isMultiRegion: false
     typeId: 110
   Status: PUBLIC
 - Namespace:
@@ -176,12 +186,19 @@ BackReferencedIDs:
   - 113
 ElementState:
 - View:
+    isMaterialized: false
+    isTemporary: false
     usesRelationIds:
     - 109
+    usesTypeIds: []
     viewId: 112
   Status: PUBLIC
 - Column:
     columnId: 1
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 1
     tableId: 112
   Status: PUBLIC
@@ -196,12 +213,29 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     columnId: 1
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: IntFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 20
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
         width: 64
+    familyId: 0
     isNullable: true
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 112
   Status: PUBLIC
 - ColumnComment:
@@ -241,6 +275,8 @@ v2
 BackReferencedIDs:
 ElementState:
 - View:
+    isMaterialized: false
+    isTemporary: false
     usesRelationIds:
     - 112
     usesTypeIds:
@@ -250,11 +286,19 @@ ElementState:
   Status: PUBLIC
 - Column:
     columnId: 1
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 1
     tableId: 113
   Status: PUBLIC
 - Column:
     columnId: 2
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 2
     tableId: 113
   Status: PUBLIC
@@ -274,21 +318,56 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     columnId: 1
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: StringFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 25
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
+        width: 0
+    familyId: 0
     isNullable: true
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 113
   Status: PUBLIC
 - ColumnType:
     columnId: 2
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: IntFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 20
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
         width: 64
+    familyId: 0
     isNullable: true
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 113
   Status: PUBLIC
 - ColumnComment:

--- a/pkg/sql/schemachanger/scdecomp/testdata/sequence
+++ b/pkg/sql/schemachanger/scdecomp/testdata/sequence
@@ -13,6 +13,7 @@ BackReferencedIDs:
   - 105
 ElementState:
 - Sequence:
+    isTemporary: false
     sequenceId: 104
   Status: PUBLIC
 - TableComment:
@@ -55,6 +56,7 @@ BackReferencedIDs:
   - 105
 ElementState:
 - Sequence:
+    isTemporary: false
     sequenceId: 106
   Status: PUBLIC
 - TableComment:
@@ -92,34 +94,52 @@ tbl
 BackReferencedIDs:
 ElementState:
 - Table:
+    isTemporary: false
     tableId: 105
   Status: PUBLIC
 - ColumnFamily:
+    familyId: 0
     name: primary
     tableId: 105
   Status: PUBLIC
 - Column:
     columnId: 1
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 1
     tableId: 105
   Status: PUBLIC
 - Column:
     columnId: 2
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 2
     tableId: 105
   Status: PUBLIC
 - PrimaryIndex:
     embeddedIndex:
+      compositeColumnIds: []
       constraintId: 1
       indexId: 1
+      isConcurrently: false
+      isCreatedExplicitly: false
+      isInverted: false
       isUnique: true
       keyColumnDirections:
       - ASC
       keyColumnIds:
       - 1
+      keySuffixColumnIds: []
+      sharding: null
+      sourceIndexId: 0
       storingColumnIds:
       - 2
       tableId: 105
+      temporaryIndexId: 0
   Status: PUBLIC
 - TableComment:
     comment: __placeholder_comment__
@@ -137,21 +157,56 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     columnId: 1
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: IntFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 20
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
         width: 64
+    familyId: 0
+    isNullable: false
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 105
   Status: PUBLIC
 - ColumnType:
     columnId: 2
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: IntFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 20
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
         width: 64
+    familyId: 0
     isNullable: true
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 105
   Status: PUBLIC
 - ColumnDefaultExpression:
@@ -160,12 +215,15 @@ ElementState:
       expr: nextval(104:::REGCLASS)
       usesSequenceIds:
       - 104
+      usesTypeIds: []
     tableId: 105
   Status: PUBLIC
 - ColumnOnUpdateExpression:
     columnId: 2
     embeddedExpr:
       expr: 123:::INT8
+      usesSequenceIds: []
+      usesTypeIds: []
     tableId: 105
   Status: PUBLIC
 - SequenceOwner:
@@ -232,34 +290,52 @@ tbl
 BackReferencedIDs:
 ElementState:
 - Table:
+    isTemporary: false
     tableId: 105
   Status: PUBLIC
 - ColumnFamily:
+    familyId: 0
     name: primary
     tableId: 105
   Status: PUBLIC
 - Column:
     columnId: 1
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 1
     tableId: 105
   Status: PUBLIC
 - Column:
     columnId: 2
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 2
     tableId: 105
   Status: PUBLIC
 - PrimaryIndex:
     embeddedIndex:
+      compositeColumnIds: []
       constraintId: 1
       indexId: 1
+      isConcurrently: false
+      isCreatedExplicitly: false
+      isInverted: false
       isUnique: true
       keyColumnDirections:
       - ASC
       keyColumnIds:
       - 1
+      keySuffixColumnIds: []
+      sharding: null
+      sourceIndexId: 0
       storingColumnIds:
       - 2
       tableId: 105
+      temporaryIndexId: 0
   Status: PUBLIC
 - TableComment:
     comment: __placeholder_comment__
@@ -277,21 +353,56 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     columnId: 1
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: IntFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 20
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
         width: 64
+    familyId: 0
+    isNullable: false
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 105
   Status: PUBLIC
 - ColumnType:
     columnId: 2
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: IntFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 20
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
         width: 64
+    familyId: 0
     isNullable: true
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 105
   Status: PUBLIC
 - ColumnComment:
@@ -347,6 +458,7 @@ seq
 BackReferencedIDs:
 ElementState:
 - Sequence:
+    isTemporary: false
     sequenceId: 104
   Status: PUBLIC
 - TableComment:

--- a/pkg/sql/schemachanger/scdecomp/testdata/table
+++ b/pkg/sql/schemachanger/scdecomp/testdata/table
@@ -16,27 +16,42 @@ BackReferencedIDs:
   - 105
 ElementState:
 - Table:
+    isTemporary: false
     tableId: 104
   Status: PUBLIC
 - ColumnFamily:
+    familyId: 0
     name: primary
     tableId: 104
   Status: PUBLIC
 - Column:
     columnId: 1
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 1
     tableId: 104
   Status: PUBLIC
 - PrimaryIndex:
     embeddedIndex:
+      compositeColumnIds: []
       constraintId: 1
       indexId: 1
+      isConcurrently: false
+      isCreatedExplicitly: false
+      isInverted: false
       isUnique: true
       keyColumnDirections:
       - ASC
       keyColumnIds:
       - 1
+      keySuffixColumnIds: []
+      sharding: null
+      sourceIndexId: 0
+      storingColumnIds: []
       tableId: 104
+      temporaryIndexId: 0
   Status: PUBLIC
 - TableComment:
     comment: __placeholder_comment__
@@ -49,11 +64,29 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     columnId: 1
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: IntFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 20
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
         width: 64
+    familyId: 0
+    isNullable: false
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 104
   Status: PUBLIC
 - ColumnComment:
@@ -103,53 +136,84 @@ tbl
 BackReferencedIDs:
 ElementState:
 - Table:
+    isTemporary: false
     tableId: 105
   Status: PUBLIC
 - ColumnFamily:
+    familyId: 0
     name: primary
     tableId: 105
   Status: PUBLIC
 - Column:
     columnId: 1
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 1
     tableId: 105
   Status: PUBLIC
 - Column:
     columnId: 2
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 2
     tableId: 105
   Status: PUBLIC
 - Column:
     columnId: 3
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 3
     tableId: 105
   Status: PUBLIC
 - PrimaryIndex:
     embeddedIndex:
+      compositeColumnIds: []
       constraintId: 1
       indexId: 1
+      isConcurrently: false
+      isCreatedExplicitly: false
+      isInverted: false
       isUnique: true
       keyColumnDirections:
       - ASC
       keyColumnIds:
       - 1
+      keySuffixColumnIds: []
+      sharding: null
+      sourceIndexId: 0
       storingColumnIds:
       - 2
       - 3
       tableId: 105
+      temporaryIndexId: 0
   Status: PUBLIC
 - SecondaryIndex:
     embeddedIndex:
+      compositeColumnIds: []
+      constraintId: 0
       indexId: 2
+      isConcurrently: false
+      isCreatedExplicitly: false
+      isInverted: false
+      isUnique: false
       keyColumnDirections:
       - ASC
       keyColumnIds:
       - 2
       keySuffixColumnIds:
       - 1
+      sharding: null
+      sourceIndexId: 0
       storingColumnIds:
       - 3
       tableId: 105
+      temporaryIndexId: 0
   Status: PUBLIC
 - ForeignKeyConstraint:
     columnIds:
@@ -181,30 +245,83 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     columnId: 1
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: IntFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 20
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
         width: 64
+    familyId: 0
+    isNullable: false
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 105
   Status: PUBLIC
 - ColumnType:
     columnId: 2
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: StringFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 25
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
+        width: 0
+    familyId: 0
+    isNullable: false
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 105
   Status: PUBLIC
 - ColumnType:
     columnId: 3
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: DecimalFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 1700
         precision: 8
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
         width: 2
+    familyId: 0
     isNullable: true
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 105
   Status: PUBLIC
 - ColumnComment:
@@ -238,7 +355,10 @@ ElementState:
 - SecondaryIndexPartial:
     embeddedExpr:
       expr: id > 0:::INT8
+      usesSequenceIds: []
+      usesTypeIds: []
     indexId: 2
+    isRelationBeingDropped: false
     tableId: 105
   Status: PUBLIC
 - IndexComment:
@@ -297,6 +417,12 @@ BackReferencedIDs:
   - 105
 ElementState:
 - Table:
+    isTemporary: false
+    tableId: 104
+  Status: PUBLIC
+- ColumnFamily:
+    familyId: 0
+    name: primary
     tableId: 104
   Status: PUBLIC
 - ColumnFamily:
@@ -304,32 +430,44 @@ ElementState:
     name: f2
     tableId: 104
   Status: PUBLIC
-- ColumnFamily:
-    name: primary
-    tableId: 104
-  Status: PUBLIC
 - Column:
     columnId: 1
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 1
     tableId: 104
   Status: PUBLIC
 - Column:
     columnId: 2
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 2
     tableId: 104
   Status: PUBLIC
 - PrimaryIndex:
     embeddedIndex:
+      compositeColumnIds: []
       constraintId: 1
       indexId: 1
+      isConcurrently: false
+      isCreatedExplicitly: false
+      isInverted: false
       isUnique: true
       keyColumnDirections:
       - ASC
       keyColumnIds:
       - 1
+      keySuffixColumnIds: []
+      sharding: null
+      sourceIndexId: 0
       storingColumnIds:
       - 2
       tableId: 104
+      temporaryIndexId: 0
   Status: PUBLIC
 - TableComment:
     comment: __placeholder_comment__
@@ -347,22 +485,56 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     columnId: 1
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: IntFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 20
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
         width: 64
+    familyId: 0
+    isNullable: false
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 104
   Status: PUBLIC
 - ColumnType:
     columnId: 2
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: IntFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 20
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
         width: 64
     familyId: 1
     isNullable: true
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 104
   Status: PUBLIC
 - ColumnComment:
@@ -423,35 +595,52 @@ greeter
 BackReferencedIDs:
 ElementState:
 - Table:
+    isTemporary: false
     tableId: 108
   Status: PUBLIC
 - ColumnFamily:
+    familyId: 0
     name: primary
     tableId: 108
   Status: PUBLIC
 - Column:
     columnId: 1
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 1
     tableId: 108
   Status: PUBLIC
 - Column:
     columnId: 2
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
     isHidden: true
+    isInaccessible: false
     pgAttributeNum: 2
     tableId: 108
   Status: PUBLIC
 - PrimaryIndex:
     embeddedIndex:
+      compositeColumnIds: []
       constraintId: 1
       indexId: 1
+      isConcurrently: false
+      isCreatedExplicitly: false
+      isInverted: false
       isUnique: true
       keyColumnDirections:
       - ASC
       keyColumnIds:
       - 2
+      keySuffixColumnIds: []
+      sharding: null
+      sourceIndexId: 0
       storingColumnIds:
       - 1
       tableId: 108
+      temporaryIndexId: 0
   Status: PUBLIC
 - TableComment:
     comment: __placeholder_comment__
@@ -471,29 +660,67 @@ ElementState:
     columnId: 1
     computeExpr:
       expr: x'80':::@100106::STRING
+      usesSequenceIds: []
       usesTypeIds:
       - 106
       - 107
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: StringFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 25
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
+        width: 0
+    familyId: 0
     isNullable: true
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 108
   Status: PUBLIC
 - ColumnType:
     columnId: 2
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: IntFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 20
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
         width: 64
+    familyId: 0
+    isNullable: false
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 108
   Status: PUBLIC
 - ColumnDefaultExpression:
     columnId: 2
     embeddedExpr:
       expr: unique_rowid()
+      usesSequenceIds: []
+      usesTypeIds: []
     tableId: 108
   Status: PUBLIC
 - ColumnComment:

--- a/pkg/sql/schemachanger/scdecomp/testdata/type
+++ b/pkg/sql/schemachanger/scdecomp/testdata/type
@@ -20,6 +20,7 @@ BackReferencedIDs:
 ElementState:
 - EnumType:
     arrayTypeId: 105
+    isMultiRegion: false
     typeId: 104
   Status: PUBLIC
 - Namespace:
@@ -58,62 +59,102 @@ tbl
 BackReferencedIDs:
 ElementState:
 - Table:
+    isTemporary: false
     tableId: 108
   Status: PUBLIC
 - ColumnFamily:
+    familyId: 0
     name: primary
     tableId: 108
   Status: PUBLIC
 - Column:
     columnId: 1
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 1
     tableId: 108
   Status: PUBLIC
 - Column:
     columnId: 2
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 2
     tableId: 108
   Status: PUBLIC
 - Column:
     columnId: 3
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 3
     tableId: 108
   Status: PUBLIC
 - Column:
     columnId: 4
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 4
     tableId: 108
   Status: PUBLIC
 - Column:
     columnId: 5
+    generatedAsIdentitySequenceOption: ""
+    generatedAsIdentityType: 0
+    isHidden: false
+    isInaccessible: false
     pgAttributeNum: 5
     tableId: 108
   Status: PUBLIC
 - PrimaryIndex:
     embeddedIndex:
+      compositeColumnIds: []
       constraintId: 1
       indexId: 1
+      isConcurrently: false
+      isCreatedExplicitly: false
+      isInverted: false
       isUnique: true
       keyColumnDirections:
       - ASC
       keyColumnIds:
       - 1
+      keySuffixColumnIds: []
+      sharding: null
+      sourceIndexId: 0
       storingColumnIds:
       - 2
       - 4
       - 5
       tableId: 108
+      temporaryIndexId: 0
   Status: PUBLIC
 - SecondaryIndex:
     embeddedIndex:
+      compositeColumnIds: []
+      constraintId: 0
       indexId: 2
+      isConcurrently: false
+      isCreatedExplicitly: false
+      isInverted: false
+      isUnique: false
       keyColumnDirections:
       - ASC
       keyColumnIds:
       - 2
       keySuffixColumnIds:
       - 1
+      sharding: null
+      sourceIndexId: 0
+      storingColumnIds: []
       tableId: 108
+      temporaryIndexId: 0
   Status: PUBLIC
 - CheckConstraint:
     columnIds:
@@ -122,6 +163,8 @@ ElementState:
     constraintId: 2
     embeddedExpr:
       expr: s::STRING = name
+      usesSequenceIds: []
+      usesTypeIds: []
     tableId: 108
   Status: PUBLIC
 - TableComment:
@@ -155,17 +198,36 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     columnId: 1
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: IntFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 20
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
         width: 64
+    familyId: 0
+    isNullable: false
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 108
   Status: PUBLIC
 - ColumnType:
     columnId: 2
     computeExpr:
       expr: x'80':::@100104
+      usesSequenceIds: []
       usesTypeIds:
       - 104
       - 105
@@ -174,17 +236,33 @@ ElementState:
       - 104
       - 105
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: EnumFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 100104
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
         udtMetadata:
           arrayTypeOid: 100105
+        visibleType: 0
+        width: 0
+    familyId: 0
     isNullable: true
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 108
   Status: PUBLIC
 - ColumnType:
     columnId: 3
     computeExpr:
       expr: x'80':::@100106
+      usesSequenceIds: []
       usesTypeIds:
       - 106
       - 107
@@ -193,38 +271,98 @@ ElementState:
       - 106
       - 107
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: EnumFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 100106
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
         udtMetadata:
           arrayTypeOid: 100107
+        visibleType: 0
+        width: 0
+    familyId: 0
     isNullable: true
+    isRelationBeingDropped: false
     isVirtual: true
     tableId: 108
   Status: PUBLIC
 - ColumnType:
     columnId: 4
+    computeExpr: null
     embeddedTypeT:
       closedTypeIds:
       - 104
       - 105
       type:
         arrayContents:
+          arrayContents: null
+          arrayDimensions: []
+          arrayElemType: null
           family: EnumFamily
+          geoMetadata: null
+          intervalDurationField: null
+          locale: null
           oid: 100104
+          precision: 0
+          timePrecisionIsSet: false
+          tupleContents: []
+          tupleLabels: []
           udtMetadata:
             arrayTypeOid: 100105
+          visibleType: 0
+          width: 0
+        arrayDimensions: []
         arrayElemType: EnumFamily
         family: ArrayFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 100105
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
+        width: 0
+    familyId: 0
     isNullable: true
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 108
   Status: PUBLIC
 - ColumnType:
     columnId: 5
+    computeExpr: null
     embeddedTypeT:
+      closedTypeIds: []
       type:
+        arrayContents: null
+        arrayDimensions: []
+        arrayElemType: null
         family: StringFamily
+        geoMetadata: null
+        intervalDurationField: null
+        locale: null
         oid: 25
+        precision: 0
+        timePrecisionIsSet: false
+        tupleContents: []
+        tupleLabels: []
+        udtMetadata: null
+        visibleType: 0
+        width: 0
+    familyId: 0
+    isNullable: false
+    isRelationBeingDropped: false
+    isVirtual: false
     tableId: 108
   Status: PUBLIC
 - ColumnComment:
@@ -270,7 +408,10 @@ ElementState:
 - SecondaryIndexPartial:
     embeddedExpr:
       expr: g::STRING = 'hi':::STRING
+      usesSequenceIds: []
+      usesTypeIds: []
     indexId: 2
+    isRelationBeingDropped: false
     tableId: 108
   Status: PUBLIC
 - IndexComment:

--- a/pkg/sql/schemachanger/scdeps/sctestutils/sctestutils.go
+++ b/pkg/sql/schemachanger/scdeps/sctestutils/sctestutils.go
@@ -85,8 +85,8 @@ func WithBuilderDependenciesFromTestServer(
 }
 
 // ProtoToYAML marshals a protobuf to YAML in a roundabout way.
-func ProtoToYAML(m protoutil.Message) (string, error) {
-	js, err := protoreflect.MessageToJSON(m, protoreflect.FmtFlags{})
+func ProtoToYAML(m protoutil.Message, fmtFlags protoreflect.FmtFlags) (string, error) {
+	js, err := protoreflect.MessageToJSON(m, fmtFlags)
 	if err != nil {
 		return "", err
 	}
@@ -152,7 +152,7 @@ func ProtoDiff(a, b protoutil.Message, args DiffArgs) string {
 		if m == nil {
 			return ""
 		}
-		str, err := ProtoToYAML(m)
+		str, err := ProtoToYAML(m, protoreflect.FmtFlags{})
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/sql/schemachanger/sctest/BUILD.bazel
+++ b/pkg/sql/schemachanger/sctest/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/keys",
         "//pkg/sql/catalog",
         "//pkg/sql/parser",
+        "//pkg/sql/protoreflect",
         "//pkg/sql/schemachanger/scbuild",
         "//pkg/sql/schemachanger/scdecomp",
         "//pkg/sql/schemachanger/scdeps/sctestdeps",

--- a/pkg/sql/schemachanger/sctest/decomp.go
+++ b/pkg/sql/schemachanger/sctest/decomp.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/protoreflect"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scdecomp"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scdeps/sctestdeps"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scdeps/sctestutils"
@@ -111,7 +112,7 @@ func marshalResult(
 			}
 		}
 		elts = append(elts, e)
-		yaml, err := sctestutils.ProtoToYAML(e)
+		yaml, err := sctestutils.ProtoToYAML(e, protoreflect.FmtFlags{EmitDefaults: true})
 		require.NoError(t, err)
 		str[e] = yaml
 	}


### PR DESCRIPTION
Previously we hide zero values in decomp test, this makes new people
confused when adding a new field because the new field won't show up
if it's not set to a non-zero value. This also hides bad signs that a
field is not set correctly.

Release note: None