### PR TITLE
rowexec: hydrate all types from IndexFetchSpec in some processors

### DIFF
--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra/execopnode"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra/execreleasable"
@@ -105,6 +106,17 @@ func newTableReader(
 	tr.parallelize = spec.Parallelize
 	tr.batchBytesLimit = batchBytesLimit
 	tr.maxTimestampAge = time.Duration(spec.MaxTimestampAgeNanos)
+
+	// Make sure the key column types are hydrated. The fetched column types
+	// will be hydrated in ProcessorBase.Init below.
+	resolver := flowCtx.NewTypeResolver(flowCtx.Txn)
+	for i := range spec.FetchSpec.KeyAndSuffixColumns {
+		if err := typedesc.EnsureTypeIsHydrated(
+			flowCtx.EvalCtx.Ctx(), spec.FetchSpec.KeyAndSuffixColumns[i].Type, &resolver,
+		); err != nil {
+			return nil, err
+		}
+	}
 
 	resultTypes := make([]*types.T, len(spec.FetchSpec.FetchedColumns))
 	for i := range resultTypes {


### PR DESCRIPTION
Previously, we forgot to hydrate the types of the index columns coming
from `IndexFetchSpec.KeyAndSuffixColumns`. Usually, this wasn't
a problem since the same types are being fetched, and those are hydrated
in `ProcessorBase.Init`. However, in some cases an index column might
need to be decoded, yet it's not being returned (one example I ran into
was the table reader when tracing is enabled). This is now fixed by
safely hydrating all index column types.

Release note: None