### PR TITLE
kv/bulk: warn instead of fail on failed initial split

### DIFF
--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -368,9 +368,10 @@ func (b *BufferingAdder) createInitialSplits(ctx context.Context) error {
 			if strings.Contains(err.Error(), "predicate") {
 				log.VEventf(ctx, 1, "%s adder split at %s rejected, had previously split and no longer included %s",
 					b.name, splitKey, predicateKey)
-				continue
+			} else {
+				log.Warningf(ctx, "failed to create initial split %s: %s", splitKey, err)
 			}
-			return err
+			continue
 		}
 		toScatter = append(toScatter, splitKey)
 	}


### PR DESCRIPTION
splits can fail for various reasons and it probably isn't worth failing the whole import over.

Release note (bug fix): Errors encountered when sending rebalancing hints to the storage layer during IMPORTs and index creation are now only logged and no longer cause the job to fail.