### PR TITLE
colfetcher: tiny optimization

### DIFF
--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -1207,7 +1207,10 @@ func (cf *cFetcher) processValueBytes(
 	)
 	// Continue reading data until there's none left or we've finished
 	// populating the data for all of the requested columns.
-	for len(valueBytes) > 0 && cf.machine.remainingValueColsByIdx.Len() > 0 {
+	// Keep track of the number of remaining values columns separately, because
+	// it's expensive to keep calling .Len() in the loop.
+	remainingValueCols := cf.machine.remainingValueColsByIdx.Len()
+	for len(valueBytes) > 0 && remainingValueCols > 0 {
 		_, dataOffset, colIDDiff, typ, err = encoding.DecodeValueTag(valueBytes)
 		if err != nil {
 			return "", "", err
@@ -1255,6 +1258,7 @@ func (cf *cFetcher) processValueBytes(
 			return "", "", err
 		}
 		cf.machine.remainingValueColsByIdx.Remove(vecIdx)
+		remainingValueCols--
 		if cf.traceKV {
 			dVal := cf.getDatumAt(vecIdx, cf.machine.rowIdx)
 			if _, err := fmt.Fprintf(cf.machine.prettyValueBuf, "/%v", dVal.String()); err != nil {


### PR DESCRIPTION
I noticed the call to .Len() in this loop was showing up as 3% in the
profile Yahor created of the TPCH query. This is an easy fix.

Ideally we'd be able to microbenchmark this, so I filed #80302. 

Release note: None