### PR TITLE
bazel,dev: provide opt-out for building w/ `nogo`

### DIFF
--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -412,6 +412,7 @@ config_setting(
     name = "nogo",
     flag_values = {
         ":nogo_flag": "true",
+        ":nogo_disable_flag": "false",
     },
 )
 
@@ -431,6 +432,14 @@ config_setting(
         ":nonogo_explicit_flag": "true",
     },
     visibility = ["//build/bazelutil:__pkg__"],
+)
+
+# Note: nogo_disable can be set to force nogo checks off even if
+# `build --config lintonbuild` is set in .bazelrc.
+bool_flag(
+    name = "nogo_disable_flag",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
 )
 
 bool_flag(

--- a/dev
+++ b/dev
@@ -16,8 +16,8 @@ fi
 if [[ ! -f "$BINARY_PATH" ]]; then
     echo "$BINARY_PATH not found, building..."
     mkdir -p $BINARY_DIR
-    bazel build //pkg/cmd/dev --//build/toolchains:nogo_flag
-    cp $(bazel info bazel-bin --//build/toolchains:nogo_flag)/pkg/cmd/dev/dev_/dev $BINARY_PATH
+    bazel build //pkg/cmd/dev --//build/toolchains:nogo_disable_flag
+    cp $(bazel info bazel-bin --//build/toolchains:nogo_disable_flag)/pkg/cmd/dev/dev_/dev $BINARY_PATH
     # The Bazel-built binary won't have write permissions.
     chmod a+w $BINARY_PATH
 fi

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -28,7 +28,8 @@ import (
 )
 
 const (
-	crossFlag = "cross"
+	crossFlag       = "cross"
+	nogoDisableFlag = "--//build/toolchains:nogo_disable_flag"
 )
 
 type buildTarget struct {
@@ -298,6 +299,7 @@ func (d *dev) getBasicBuildArgs(
 		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
 	}
 
+	canDisableNogo := true
 	shouldBuildWithTestConfig := false
 	for _, target := range targets {
 		target = strings.TrimPrefix(target, "./")
@@ -320,6 +322,9 @@ func (d *dev) getBasicBuildArgs(
 				if typ == "go_test" || typ == "go_transition_test" || typ == "test_suite" {
 					shouldBuildWithTestConfig = true
 				}
+				if strings.HasPrefix(fullTargetName, "//") {
+					canDisableNogo = false
+				}
 			}
 			continue
 		}
@@ -336,6 +341,9 @@ func (d *dev) getBasicBuildArgs(
 		} else {
 			buildTargets = append(buildTargets, buildTarget{fullName: aliased, kind: "go_binary"})
 		}
+		if strings.HasPrefix(aliased, "//") {
+			canDisableNogo = false
+		}
 	}
 
 	// Add --config=with_ui iff we're building a target that needs it.
@@ -347,6 +355,9 @@ func (d *dev) getBasicBuildArgs(
 	}
 	if shouldBuildWithTestConfig {
 		args = append(args, "--config=test")
+	}
+	if canDisableNogo {
+		args = append(args, nogoDisableFlag)
 	}
 	return args, buildTargets, nil
 }

--- a/pkg/cmd/dev/cache.go
+++ b/pkg/cmd/dev/cache.go
@@ -136,11 +136,11 @@ func (d *dev) setUpCache(ctx context.Context) (string, error) {
 
 	log.Printf("Configuring cache...\n")
 
-	err := d.exec.CommandContextInheritingStdStreams(ctx, "bazel", "build", bazelRemoteTarget, "--//build/toolchains:nonogo_explicit_flag")
+	err := d.exec.CommandContextInheritingStdStreams(ctx, "bazel", "build", bazelRemoteTarget, nogoDisableFlag)
 	if err != nil {
 		return "", err
 	}
-	bazelRemoteLoc, err := d.exec.CommandContextSilent(ctx, "bazel", "run", bazelRemoteTarget, "--//build/toolchains:nonogo_explicit_flag", "--run_under=//build/bazelutil/whereis")
+	bazelRemoteLoc, err := d.exec.CommandContextSilent(ctx, "bazel", "run", bazelRemoteTarget, nogoDisableFlag, "--run_under=//build/bazelutil/whereis")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cmd/dev/testdata/datadriven/dev-build
+++ b/pkg/cmd/dev/testdata/datadriven/dev-build
@@ -60,7 +60,7 @@ cp sandbox/pkg/cmd/cockroach/cockroach_/cockroach crdb-checkout/cockroach
 exec
 dev build stress
 ----
-bazel build @com_github_cockroachdb_stress//:stress
+bazel build @com_github_cockroachdb_stress//:stress --//build/toolchains:nogo_disable_flag
 bazel info workspace --color=no
 mkdir crdb-checkout/bin
 bazel info bazel-bin --color=no


### PR DESCRIPTION
Now we provide `--//build/toolchains:nogo_disable` as an option which
will force `nogo` checks OFF even if you have globally configured
`lintonbuild`. This can be used by end users for builds but primarily I
want a way to force builds to finish faster when `nogo` checks are not
particularly useful: namely, when building `dev` for the first time (via
the `dev` script) and when building the `bazel-remote` binary. Also have
`dev build` infer when passing `nogo_disable` will be OK and pass it in
when appropriate.

Release note: None