### PR TITLE
sql: support des, xdes, md5, bf pgcrypto gen_salt algos

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -382,6 +382,10 @@
 </span></td></tr>
 <tr><td><a name="digest"></a><code>digest(data: <a href="string.html">string</a>, type: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Computes a binary hash of the given <code>data</code>. <code>type</code> is the algorithm to use (md5, sha1, sha224, sha256, sha384, or sha512).</p>
 </span></td></tr>
+<tr><td><a name="gen_salt"></a><code>gen_salt(type: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Generates a salt for input into the <code>crypt</code> function using the default number of rounds.</p>
+</span></td></tr>
+<tr><td><a name="gen_salt"></a><code>gen_salt(type: <a href="string.html">string</a>, iter_count: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Generates a salt for input into the <code>crypt</code> function using <code>iter_count</code> number of rounds.</p>
+</span></td></tr>
 <tr><td><a name="hmac"></a><code>hmac(data: <a href="bytes.html">bytes</a>, key: <a href="bytes.html">bytes</a>, type: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Calculates hashed MAC for <code>data</code> with key <code>key</code>. <code>type</code> is the same as in <code>digest()</code>.</p>
 </span></td></tr>
 <tr><td><a name="hmac"></a><code>hmac(data: <a href="string.html">string</a>, key: <a href="string.html">string</a>, type: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Calculates hashed MAC for <code>data</code> with key <code>key</code>. <code>type</code> is the same as in <code>digest()</code>.</p>

--- a/pkg/sql/logictest/testdata/logic_test/pgcrypto_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pgcrypto_builtins
@@ -61,3 +61,95 @@ query IB
 SELECT length(gen_random_uuid()::BYTES), gen_random_uuid() = gen_random_uuid()
 ----
 16 false
+
+
+subtest gen_salt_invalid_algo
+
+statement error pgcode 22023 unknown salt algorithm
+SELECT gen_salt('invalid')
+
+statement error pgcode 22023 unknown salt algorithm
+SELECT gen_salt('invalid', 0)
+
+subtest gen_salt_des
+
+query I
+SELECT char_length(gen_salt('des'))
+----
+2
+
+query I
+SELECT char_length(gen_salt('des', rounds))
+FROM (VALUES (0), (25)) AS t (rounds)
+----
+2
+2
+
+# invalid rounds
+statement error pgcode 22023 incorrect number of rounds
+SELECT gen_salt('des', 1)
+
+subtest gen_salt_xdes
+
+query TI
+SELECT substr(salt, 1, 5), char_length(salt)
+FROM (SELECT gen_salt('xdes') AS salt)
+----
+_J9..  9
+
+query TI
+SELECT substr(salt, 1, 5), char_length(salt)
+FROM (SELECT gen_salt('xdes', rounds) AS salt FROM (VALUES (0), (1), (16777215)) AS t (rounds))
+----
+_J9..  9
+_/...  9
+_zzzz  9
+
+# invalid even rounds
+statement error pgcode 22023 incorrect number of rounds
+SELECT gen_salt('xdes', 2)
+
+# invalid min rounds
+statement error pgcode 22023 incorrect number of rounds
+SELECT gen_salt('xdes', -1)
+
+# invalid max rounds
+statement error pgcode 22023 incorrect number of rounds
+SELECT gen_salt('xdes', 16777216)
+
+subtest gen_salt_md5
+
+query TI
+SELECT substr(salt, 1, 3), char_length(salt)
+FROM (SELECT gen_salt('md5') AS salt)
+----
+$1$ 11
+
+query TI
+SELECT substr(salt, 1, 3), char_length(salt)
+FROM (SELECT gen_salt('md5', rounds) AS salt FROM (VALUES (0), (1000)) AS t (rounds))
+----
+$1$ 11
+$1$ 11
+
+# invalid rounds
+statement error pgcode 22023 incorrect number of rounds
+SELECT gen_salt('md5', 1)
+
+subtest gen_salt_bf
+
+query TI
+SELECT substr(salt, 1, 7), char_length(salt)
+FROM (SELECT gen_salt('bf', rounds) AS salt FROM (VALUES (0), (4), (31)) AS t (rounds))
+----
+$2a$06$ 29
+$2a$04$ 29
+$2a$31$ 29
+
+# invalid min rounds
+statement error pgcode 22023 incorrect number of rounds
+SELECT gen_salt('bf', 3)
+
+# invalid max rounds
+statement error pgcode 22023 incorrect number of rounds
+SELECT gen_salt('bf', 32)

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -8106,27 +8106,6 @@ func bitsOverload2(
 	}
 }
 
-// getHashFunc returns a function that will create a new hash.Hash using the
-// given algorithm.
-func getHashFunc(alg string) (func() hash.Hash, error) {
-	switch strings.ToLower(alg) {
-	case "md5":
-		return md5.New, nil
-	case "sha1":
-		return sha1.New, nil
-	case "sha224":
-		return sha256.New224, nil
-	case "sha256":
-		return sha256.New, nil
-	case "sha384":
-		return sha512.New384, nil
-	case "sha512":
-		return sha512.New, nil
-	default:
-		return nil, pgerror.Newf(pgcode.InvalidParameterValue, "cannot use %q, no such hash algorithm", alg)
-	}
-}
-
 // feedHash returns true if it encounters any non-Null datum.
 func feedHash(h hash.Hash, args tree.Datums) (bool, error) {
 	var nonNullSeen bool

--- a/pkg/sql/sem/builtins/pgcrypto_builtins.go
+++ b/pkg/sql/sem/builtins/pgcrypto_builtins.go
@@ -12,11 +12,22 @@ package builtins
 
 import (
 	"crypto/hmac"
+	"crypto/md5"
+	"crypto/rand"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/base64"
+	"hash"
+	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/errors"
 )
 
 func initPgcryptoBuiltins() {
@@ -74,6 +85,39 @@ var pgcryptoBuiltins = map[string]builtinDefinition{
 
 	"gen_random_uuid": generateRandomUUID4Impl,
 
+	"gen_salt": makeBuiltin(
+		tree.FunctionProperties{Category: categoryCrypto},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"type", types.String}},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+				typ := tree.MustBeDString(args[0])
+				salt, err := genSalt(string(typ), 0)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDString(salt), nil
+			},
+			Info:       "Generates a salt for input into the `crypt` function using the default number of rounds.",
+			Volatility: volatility.Volatile,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"type", types.String}, {"iter_count", types.Int}},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+				typ := tree.MustBeDString(args[0])
+				rounds := tree.MustBeDInt(args[1])
+				salt, err := genSalt(string(typ), int(rounds))
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDString(salt), nil
+			},
+			Info:       "Generates a salt for input into the `crypt` function using `iter_count` number of rounds.",
+			Volatility: volatility.Volatile,
+		},
+	),
+
 	"hmac": makeBuiltin(
 		tree.FunctionProperties{Category: categoryCrypto},
 		tree.Overload{
@@ -115,4 +159,233 @@ var pgcryptoBuiltins = map[string]builtinDefinition{
 			Volatility: volatility.Immutable,
 		},
 	),
+}
+
+// getHashFunc returns a function that will create a new hash.Hash using the
+// given algorithm.
+func getHashFunc(alg string) (func() hash.Hash, error) {
+	switch strings.ToLower(alg) {
+	case "md5":
+		return md5.New, nil
+	case "sha1":
+		return sha1.New, nil
+	case "sha224":
+		return sha256.New224, nil
+	case "sha256":
+		return sha256.New, nil
+	case "sha384":
+		return sha512.New384, nil
+	case "sha512":
+		return sha512.New, nil
+	default:
+		return nil, pgerror.Newf(pgcode.InvalidParameterValue, "cannot use %q, no such hash algorithm", alg)
+	}
+}
+
+const (
+	defaultRounds = 0 // converted to cost that was defaulted to in output if applicable
+	itoa64        = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+)
+
+var saltFuncMap = map[string]func(int) ([]byte, error){
+	"des":  genSaltTraditional,
+	"xdes": genSaltExtended,
+	"md5":  genSaltMd5,
+	"bf":   genSaltBlowfish,
+}
+
+// see https://github.com/postgres/postgres/blob/586955dddecc95e0003262a3954ae83b68ce0372/contrib/pgcrypto/px-crypt.c#L132
+func genSalt(saltType string, rounds int) (string, error) {
+
+	saltType = strings.ToLower(saltType)
+
+	saltFunc, found := saltFuncMap[saltType]
+	if !found {
+		keys := make([]string, len(saltFuncMap))
+		i := 0
+		for k := range saltFuncMap {
+			keys[i] = k
+			i++
+		}
+		return "", errors.WithHintf(
+			pgerror.Newf(pgcode.InvalidParameterValue, "unknown salt algorithm %q", saltType),
+			"supported algorithms: %s",
+			keys,
+		)
+	}
+
+	salt, err := saltFunc(rounds)
+	if err != nil {
+		return "", err
+	}
+
+	return string(salt), nil
+}
+
+func getRandomBytes(length int) ([]byte, error) {
+	result := make([]byte, length)
+	_, err := rand.Read(result)
+	return result, err
+}
+
+func checkFixedRounds(rounds int, requiredRounds int) error {
+	if rounds != defaultRounds && rounds != requiredRounds {
+		return errors.WithHintf(
+			pgerror.Newf(pgcode.InvalidParameterValue, "incorrect number of rounds %d", rounds),
+			"supported values: %d, %d",
+			defaultRounds, requiredRounds,
+		)
+	}
+	return nil
+}
+
+// genSaltTraditional generates a salt in the form ss
+// "ss" - random salt (base64 encoded using itoa64)
+// des algorithm is implied by having no prefix and does not appear in output
+// hashing cost is hard coded to 25 rounds and does not appear in output
+// see https://github.com/postgres/postgres/blob/586955dddecc95e0003262a3954ae83b68ce0372/contrib/pgcrypto/crypt-gensalt.c#L25
+func genSaltTraditional(rounds int) ([]byte, error) {
+
+	// can only be 25
+	if err := checkFixedRounds(rounds, 25); err != nil {
+		return nil, err
+	}
+
+	input, err := getRandomBytes(2)
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte{
+		itoa64[input[0]&0x3f],
+		itoa64[input[1]&0x3f],
+	}, nil
+}
+
+const (
+	minRoundsExtended = 1
+	maxRoundsExtended = 0xffffff
+)
+
+// genSaltExtended generates a salt in the form _rrrrssss
+// "_" - xdes algorithm
+// "rrrr" - hashing cost (base64 encoded using itoa64) - number of rounds odd number between 1 inclusive and 16777215 inclusive
+// "ssss" - random salt (base64 encoded using itoa64)
+// see https://github.com/postgres/postgres/blob/586955dddecc95e0003262a3954ae83b68ce0372/contrib/pgcrypto/crypt-gensalt.c#L43
+func genSaltExtended(rounds int) ([]byte, error) {
+
+	if rounds == defaultRounds {
+		rounds = 29 * 25 // default
+	} else if rounds < minRoundsExtended || rounds > maxRoundsExtended || rounds%2 == 0 {
+		// Even iteration counts make it easier to detect weak DES keys from a look at the hash, so they should be avoided.
+		return nil, errors.WithHintf(
+			pgerror.Newf(pgcode.InvalidParameterValue, "incorrect number of rounds %d", rounds),
+			"supported values: %d or odd number between %d inclusive and %d inclusive",
+			defaultRounds, minRoundsExtended, maxRoundsExtended)
+	}
+
+	output := make([]byte, 9)
+
+	output[0] = '_'
+	output[1] = itoa64[rounds&0x3f]
+	output[2] = itoa64[(rounds>>6)&0x3f]
+	output[3] = itoa64[(rounds>>12)&0x3f]
+	output[4] = itoa64[(rounds>>18)&0x3f]
+
+	input, err := getRandomBytes(3)
+	if err != nil {
+		return nil, err
+	}
+
+	value := uint32(input[0]) | uint32(input[1])<<8 | uint32(input[2])<<16
+	output[5] = itoa64[value&0x3f]
+	output[6] = itoa64[(value>>6)&0x3f]
+	output[7] = itoa64[(value>>12)&0x3f]
+	output[8] = itoa64[(value>>18)&0x3f]
+
+	return output, nil
+}
+
+// genSaltMd5 generates a salt in the form $1$ssssssss
+// "1" - md5 algorithm
+// "ssssssss" - random salt (base64 encoded using itoa64)
+// hashing cost is hard coded to 1000 rounds and does not appear in output
+// see https://github.com/postgres/postgres/blob/586955dddecc95e0003262a3954ae83b68ce0372/contrib/pgcrypto/crypt-gensalt.c#L79
+func genSaltMd5(rounds int) ([]byte, error) {
+
+	// can only be 1000
+	if err := checkFixedRounds(rounds, 1000); err != nil {
+		return nil, err
+	}
+
+	input, err := getRandomBytes(6)
+	if err != nil {
+		return nil, err
+	}
+
+	output := make([]byte, 11)
+
+	output[0] = '$'
+	output[1] = '1'
+	output[2] = '$'
+
+	value := uint32(input[0]) | uint32(input[1])<<8 | uint32(input[2])<<16
+	output[3] = itoa64[value&0x3f]
+	output[4] = itoa64[(value>>6)&0x3f]
+	output[5] = itoa64[(value>>12)&0x3f]
+	output[6] = itoa64[(value>>18)&0x3f]
+
+	value = uint32(input[3]) | uint32(input[4])<<8 | uint32(input[5])<<16
+	output[7] = itoa64[value&0x3f]
+	output[8] = itoa64[(value>>6)&0x3f]
+	output[9] = itoa64[(value>>12)&0x3f]
+	output[10] = itoa64[(value>>18)&0x3f]
+
+	return output, nil
+}
+
+const (
+	itoa64Blowfish    = "./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+	minRoundsBlowfish = 4
+	maxRoundsBlowfish = 31
+)
+
+var encodingBlowfish = base64.NewEncoding(itoa64Blowfish).WithPadding(base64.NoPadding)
+
+// genSaltBlowfish generates a salt in the form $2a$rr$ssssssssssssssssssssss
+// "2a" - blowfish algorithm
+// "rr" - hashing cost (decimal encoded) - 2^rr number of rounds between 04 inclusive and 31 inclusive
+// "ssssssssssssssssssssss" - random salt (base64 encoded using itoa64Blowfish)
+// see https://github.com/postgres/postgres/blob/586955dddecc95e0003262a3954ae83b68ce0372/contrib/pgcrypto/crypt-gensalt.c#L161
+// see bcrypt.newFromPassword (the go implementation generates the salt internally)
+func genSaltBlowfish(rounds int) ([]byte, error) {
+
+	if rounds == defaultRounds {
+		rounds = 6 // default
+	} else if rounds < minRoundsBlowfish || rounds > maxRoundsBlowfish {
+		return nil, errors.WithHintf(
+			pgerror.Newf(pgcode.InvalidParameterValue, "incorrect number of rounds %d", rounds),
+			"supported values: %d or odd number between %d inclusive and %d inclusive",
+			defaultRounds, minRoundsBlowfish, maxRoundsBlowfish)
+	}
+
+	input, err := getRandomBytes(16)
+	if err != nil {
+		return nil, err
+	}
+
+	saltLength := encodingBlowfish.EncodedLen(len(input))
+
+	output := make([]byte, 7+saltLength)
+	output[0] = '$'
+	output[1] = '2'
+	output[2] = 'a'
+	output[3] = '$'
+	output[4] = '0' + byte(rounds/10)
+	output[5] = '0' + byte(rounds%10)
+	output[6] = '$'
+
+	encodingBlowfish.Encode(output[7:], input)
+
+	return output, nil
 }


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/73868

Release note (sql change): Add the pgcrypto gen_salt builtin with
support for the des, xdes, md5, bf algos.