### PR TITLE
kvserver: detect (and fail on) races during learner replica removals

### DIFF
--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -1310,19 +1310,19 @@ func (r *Replica) maybeLeaveAtomicChangeReplicasAndRemoveLearners(
 		return nil, err
 	}
 
-	if fn := r.store.TestingKnobs().BeforeRemovingDemotedLearner; fn != nil {
+	if fn := r.store.TestingKnobs().BeforeRemovingLearners; fn != nil {
 		fn()
 	}
 	// Now the config isn't joint any more, but we may have demoted some voters
 	// into learners. These learners should go as well.
-	learners := desc.Replicas().LearnerDescriptors()
-	if len(learners) == 0 {
+	expectedLearners := desc.Replicas().LearnerDescriptors()
+	if len(expectedLearners) == 0 {
 		return desc, nil
 	}
-	targets := make([]roachpb.ReplicationTarget, len(learners))
-	for i := range learners {
-		targets[i].NodeID = learners[i].NodeID
-		targets[i].StoreID = learners[i].StoreID
+	targets := make([]roachpb.ReplicationTarget, len(expectedLearners))
+	for i := range expectedLearners {
+		targets[i].NodeID = expectedLearners[i].NodeID
+		targets[i].StoreID = expectedLearners[i].StoreID
 	}
 	log.VEventf(ctx, 2, `removing learner replicas %v from %v`, targets, desc)
 	// NB: unroll the removals because at the time of writing, we can't atomically
@@ -1346,6 +1346,16 @@ func (r *Replica) maybeLeaveAtomicChangeReplicasAndRemoveLearners(
 		if err != nil {
 			return nil, errors.Wrapf(err, `removing learners from %s`, origDesc)
 		}
+	}
+	// NB: Ensure that there are no new learners that we didn't initially find
+	// above (due to intervening replication changes). Also ensure that we are
+	// indeed no longer in a joint config. If so, we want to fail this operation
+	// since we've raced with a concurrent change.
+	if len(desc.Replicas().VoterFullAndNonVoterDescriptors()) != len(desc.Replicas().Descriptors()) {
+		return desc, errors.Mark(errors.Newf(
+			"failing because this operation raced with a concurrent replication change; found desc: %v",
+			desc,
+		), errMarkCanRetryReplicationChangeWithUpdatedDesc)
 	}
 	return desc, nil
 }

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -1096,7 +1096,7 @@ func TestDemotedLearnerRemovalHandlesRace(t *testing.T) {
 			ServerArgs: base.TestServerArgs{
 				Knobs: base.TestingKnobs{
 					Store: &kvserver.StoreTestingKnobs{
-						BeforeRemovingDemotedLearner: func() {
+						BeforeRemovingLearners: func() {
 							if atomic.LoadInt64(&activateTestingKnob) == 1 {
 								// Signal to the test that the rebalance is now trying to remove
 								// the demoted learner.

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -304,9 +304,9 @@ type StoreTestingKnobs struct {
 	// through a joint configuration, even when this isn't necessary (because
 	// the replication change affects only one replica).
 	ReplicationAlwaysUseJointConfig func() bool
-	// BeforeRemovingDemotedLearner is run before a demoted learner (i.e. a
-	// learner that results from a range exiting its joint config) is removed.
-	BeforeRemovingDemotedLearner func()
+	// BeforeRemovingLearners is run before a demoted learner (i.e. a learner that
+	// results from a range exiting its joint config) is removed.
+	BeforeRemovingLearners func()
 	// BeforeSnapshotSSTIngestion is run just before the SSTs are ingested when
 	// applying a snapshot.
 	BeforeSnapshotSSTIngestion func(IncomingSnapshot, kvserverpb.SnapshotRequest_Type, []string) error

--- a/pkg/kv/test_utils.go
+++ b/pkg/kv/test_utils.go
@@ -49,6 +49,7 @@ func OnlyFollowerReads(rec tracing.Recording) bool {
 func IsExpectedRelocateError(err error) bool {
 	allowlist := []string{
 		"descriptor changed",
+		"raced with a concurrent replication change",
 		"unable to remove replica .* which is not present",
 		"unable to add replica .* which is already present",
 		"none of the remaining voters .* are legal additions", // https://github.com/cockroachdb/cockroach/issues/74902


### PR DESCRIPTION
This commit is an alternative to #80205.

In https://github.com/cockroachdb/cockroach/pull/79405, we relaxed the check
that `AdminChangeReplicas` performs comparing the expected range descriptor
state against the range descriptor in KV when we were performing single learner
removals. This was because these learner removals are performed at the end of a
replication change (i.e. after its already completed) and thus, could be made
idempotent.

The above change messed with a subtle part of the contract of
`maybeLeaveAtomicChangeReplicasAndRemoveLearners()` since now it was no longer
guaranteed to always successfully return with a range desc that did not contain
learners (due to intervening replication changes that were now no longer
detected because of the relaxation mentioned above).

This commit fixes this regression by making
`maybeLeaveAtomicChangeReplicasAndRemoveLearners` check at the end if we've
raced with another replication change. If so, we return an error instead of
incorrectly returning a successful response with a descriptor that could still
have learners or be in a joint config.

Release note: None
