### PR TITLE
security: move logic in `security/password.go` to `security/password`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -140,6 +140,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/twpayne/go-geom v1.4.1
 	github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad
+	github.com/xdg-go/pbkdf2 v1.0.0
 	github.com/xdg-go/scram v1.0.2
 	github.com/xdg-go/stringprep v1.0.2
 	github.com/zabawaba99/go-gitignore v0.0.0-20200117185801-39e6bddfb292
@@ -316,7 +317,6 @@ require (
 	github.com/twitchtv/twirp v8.1.0+incompatible // indirect
 	github.com/twpayne/go-kml v1.5.2 // indirect
 	github.com/urfave/cli/v2 v2.3.0 // indirect
-	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.mongodb.org/mongo-driver v1.5.1 // indirect
 	go.opencensus.io v0.23.0 // indirect

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -190,6 +190,7 @@ ALL_TESTS = [
     "//pkg/rpc/nodedialer:nodedialer_test",
     "//pkg/rpc:rpc_test",
     "//pkg/security/certmgr:certmgr_test",
+    "//pkg/security/password:password_test",
     "//pkg/security/sessionrevival:sessionrevival_test",
     "//pkg/security:security_test",
     "//pkg/server/debug/goroutineui:goroutineui_test",

--- a/pkg/ccl/serverccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/roachpb",
         "//pkg/security",
+        "//pkg/security/password",
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/server/serverpb",

--- a/pkg/ccl/serverccl/role_authentication_test.go
+++ b/pkg/ccl/serverccl/role_authentication_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/password"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -154,7 +155,7 @@ func TestVerifyPassword(t *testing.T) {
 				validDBConsole = false
 			}
 			if exists && (canLoginSQL || canLoginDBConsole) {
-				var hashedPassword security.PasswordHash
+				var hashedPassword password.PasswordHash
 				expired, hashedPassword, err = pwRetrieveFn(ctx)
 				if err != nil {
 					t.Errorf(
@@ -165,7 +166,7 @@ func TestVerifyPassword(t *testing.T) {
 					)
 				}
 
-				pwCompare, err := security.CompareHashAndCleartextPassword(ctx, hashedPassword, tc.password)
+				pwCompare, err := password.CompareHashAndCleartextPassword(ctx, hashedPassword, tc.password)
 				if err != nil {
 					t.Error(err)
 					valid = false

--- a/pkg/security/BUILD.bazel
+++ b/pkg/security/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/clusterversion",
+        "//pkg/security/password",
         "//pkg/server/telemetry",
         "//pkg/settings",
         "//pkg/settings/cluster",
@@ -33,7 +34,6 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/log/eventpb",
         "//pkg/util/metric",
-        "//pkg/util/quotapool",
         "//pkg/util/randutil",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
@@ -43,11 +43,8 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_cockroachdb_redact//:redact",
-        "@com_github_xdg_go_scram//:scram",
-        "@com_github_xdg_go_stringprep//:stringprep",
         "@org_golang_x_crypto//bcrypt",
         "@org_golang_x_crypto//ocsp",
-        "@org_golang_x_crypto//pbkdf2",
         "@org_golang_x_sync//errgroup",
     ],
 )
@@ -65,7 +62,6 @@ go_test(
         "certs_test.go",
         "join_token_test.go",
         "main_test.go",
-        "password_test.go",
         "permission_check_test.go",
         "tls_test.go",
         "username_test.go",
@@ -78,7 +74,6 @@ go_test(
         "//pkg/rpc",
         "//pkg/security/securitytest",
         "//pkg/server",
-        "//pkg/settings/cluster",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/util/envutil",
@@ -89,7 +84,6 @@ go_test(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
-        "@org_golang_x_crypto//bcrypt",
         "@org_golang_x_exp//rand",
     ] + select({
         "@io_bazel_rules_go//go/platform:aix": [

--- a/pkg/security/password.go
+++ b/pkg/security/password.go
@@ -11,31 +11,14 @@
 package security
 
 import (
-	"bytes"
 	"context"
-	"crypto/hmac"
-	"crypto/rand"
-	"crypto/sha256"
-	"encoding/base64"
 	"fmt"
-	"io"
-	"math"
-	"regexp"
-	"runtime"
-	"strconv"
-	"sync"
-	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/security/password"
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/util/envutil"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/errors"
-	"github.com/xdg-go/scram"
-	"github.com/xdg-go/stringprep"
 	"golang.org/x/crypto/bcrypt"
-	"golang.org/x/crypto/pbkdf2"
 )
 
 // BcryptCost is the cost to use when hashing passwords.
@@ -56,7 +39,7 @@ var BcryptCost = settings.RegisterIntSetting(
 	// The default value 10 is equal to bcrypt.DefaultCost.
 	// It incurs a password check latency of ~60ms on AMD 3950X 3.7GHz.
 	// For reference, value 11 incurs ~110ms latency on the same hw, value 12 incurs ~390ms.
-	10,
+	password.DefaultBcryptCost,
 	func(i int64) error {
 		if i < int64(bcrypt.MinCost) || i > int64(bcrypt.MaxCost) {
 			return bcrypt.InvalidCostError(int(i))
@@ -76,7 +59,7 @@ var SCRAMCost = settings.RegisterIntSetting(
 	fmt.Sprintf(
 		"the hashing cost to use when storing passwords supplied as cleartext by SQL clients "+
 			"with the hashing method scram-sha-256 (allowed range: %d-%d)",
-		scramMinCost, scramMaxCost),
+		password.ScramMinCost, password.ScramMaxCost),
 	// The minimum value 4096 incurs a password check latency of ~2ms on AMD 3950X 3.7GHz.
 	//
 	// The default value 119680 incurs ~60ms latency on the same hw.
@@ -87,16 +70,13 @@ var SCRAMCost = settings.RegisterIntSetting(
 	//
 	// For reference, value 250000 incurs ~125ms latency on the same hw,
 	// value 1000000 incurs ~500ms.
-	119680,
+	password.DefaultSCRAMCost,
 	func(i int64) error {
-		if i < scramMinCost || i > scramMaxCost {
-			return errors.Newf("cost not in allowed range (%d,%d)", scramMinCost, scramMaxCost)
+		if i < password.ScramMinCost || i > password.ScramMaxCost {
+			return errors.Newf("cost not in allowed range (%d,%d)", password.ScramMinCost, password.ScramMaxCost)
 		}
 		return nil
 	}).WithPublic()
-
-const scramMinCost = 4096         // as per RFC 5802.
-const scramMaxCost = 240000000000 // arbitrary value to prevent unreasonably long logins
 
 // SCRAMCostSettingName is the name of the cluster setting SCRAMCost.
 const SCRAMCostSettingName = "server.user_login.password_hashes.default_cost.scram_sha_256"
@@ -111,256 +91,6 @@ var ErrPasswordTooShort = errors.New("password too short")
 // ErrUnknownHashMethod is returned by LoadPasswordHash if the hash encoding
 // method is not supported.
 var ErrUnknownHashMethod = errors.New("unknown hash method")
-
-// HashMethod indicates which password hash method to use.
-type HashMethod int8
-
-const (
-	// HashInvalidMethod represents invalid hashes.
-	// This always fails authentication.
-	HashInvalidMethod HashMethod = 0
-	// HashMissingPassword represents a virtual hash when there was
-	// no password.  This too always fails authentication.
-	// We need a different method here than HashInvalidMethod because
-	// the authentication code distinguishes the two cases when reporting
-	// why authentication fails in audit logs.
-	HashMissingPassword HashMethod = 1
-	// HashBCrypt indicates CockroachDB's bespoke bcrypt-based method.
-	// NB: Do not renumber this constant; it is used as value
-	// in cluster setting enums.
-	HashBCrypt HashMethod = 2
-	// HashSCRAMSHA256 indicates SCRAM-SHA-256.
-	// NB: Do not renumber this constant; it is used as value
-	// in cluster setting enums.
-	HashSCRAMSHA256 HashMethod = 3
-)
-
-func (h HashMethod) String() string {
-	switch h {
-	case HashInvalidMethod:
-		return "<invalid>"
-	case HashMissingPassword:
-		return "<missing password>"
-	case HashBCrypt:
-		return "crdb-bcrypt"
-	case HashSCRAMSHA256:
-		return "scram-sha-256"
-	default:
-		panic(errors.AssertionFailedf("programming errof: unknown hash method %d", int(h)))
-	}
-}
-
-// PasswordHash represents the type of a password hash loaded from a credential store.
-type PasswordHash interface {
-	fmt.Stringer
-	// Method report which hashing method was used.
-	Method() HashMethod
-	// Size is the size of the in-memory representation of this hash. This
-	// is used for memory accounting.
-	Size() int
-	// compareWithCleartextPassword checks a cleartext password against
-	// the hash.
-	compareWithCleartextPassword(ctx context.Context, cleartext string) (ok bool, err error)
-}
-
-var _ PasswordHash = emptyPassword{}
-var _ PasswordHash = invalidHash(nil)
-var _ PasswordHash = bcryptHash(nil)
-var _ PasswordHash = (*scramHash)(nil)
-
-// emptyPassword represents a virtual hash when there was no password
-// to start with.
-type emptyPassword struct{}
-
-// String implements fmt.Stringer.
-func (e emptyPassword) String() string { return "<missing>" }
-
-// Method is part of the PasswordHash interface.
-func (e emptyPassword) Method() HashMethod { return HashMissingPassword }
-
-// Size is part of the PasswordHash interface.
-func (e emptyPassword) Size() int { return 0 }
-
-// compareWithCleartextPassword is part of the PasswordHash interface.
-func (e emptyPassword) compareWithCleartextPassword(
-	ctx context.Context, cleartext string,
-) (ok bool, err error) {
-	return false, nil
-}
-
-// MissingPasswordHash represents the virtual hash when there is no password
-// to start with.
-var MissingPasswordHash PasswordHash = emptyPassword{}
-
-// invalidHash represents a byte slice that's in an unknown hash format.
-// We keep the byte slice around so that it can be passed through
-// and re-stored as-is.
-type invalidHash []byte
-
-// String implements fmt.Stringer.
-func (n invalidHash) String() string { return string(n) }
-
-// Method is part of the PasswordHash interface.
-func (n invalidHash) Method() HashMethod { return HashInvalidMethod }
-
-// Size is part of the PasswordHash interface.
-func (n invalidHash) Size() int { return len(n) }
-
-// compareWithCleartextPassword is part of the PasswordHash interface.
-func (n invalidHash) compareWithCleartextPassword(
-	ctx context.Context, cleartext string,
-) (ok bool, err error) {
-	return false, nil
-}
-
-// bcryptHash represents a bcrypt-based hashed password.
-// The type is simple since we're offloading the decoding
-// of the parameters to the go standard bcrypt package.
-type bcryptHash []byte
-
-// String implements fmt.Stringer.
-func (b bcryptHash) String() string { return string(b) }
-
-// Method is part of the PasswordHash interface.
-func (b bcryptHash) Method() HashMethod { return HashBCrypt }
-
-// Size is part of the PasswordHash interface.
-func (b bcryptHash) Size() int { return len(b) }
-
-// scramHash represents a SCRAM-SHA-256 password hash.
-type scramHash struct {
-	bytes   []byte
-	decoded scram.StoredCredentials
-}
-
-// String implements fmt.Stringer.
-func (s *scramHash) String() string { return string(s.bytes) }
-
-// Method is part of the PasswordHash interface.
-func (s *scramHash) Method() HashMethod { return HashSCRAMSHA256 }
-
-// Size is part of the PasswordHash interface.
-func (s *scramHash) Size() int {
-	return int(unsafe.Sizeof(*s)) + len(s.bytes) + len(s.decoded.Salt) + len(s.decoded.StoredKey) + len(s.decoded.ServerKey)
-}
-
-// GetSCRAMStoredCredentials retrieves the SCRAM credential parts.
-// The caller is responsible for ensuring the hash has method SCRAM-SHA-256.
-func GetSCRAMStoredCredentials(hash PasswordHash) (ok bool, creds scram.StoredCredentials) {
-	h, ok := hash.(*scramHash)
-	if ok {
-		return ok, h.decoded
-	}
-	return false, creds
-}
-
-// LoadPasswordHash decodes a password hash loaded as bytes from a credential store.
-func LoadPasswordHash(ctx context.Context, storedHash []byte) (res PasswordHash) {
-	res = invalidHash(storedHash)
-	if len(storedHash) == 0 {
-		return emptyPassword{}
-	}
-	if isBcryptHash(storedHash, false /* strict */) {
-		return bcryptHash(storedHash)
-	}
-	if ok, parts := isSCRAMHash(storedHash); ok {
-		return makeSCRAMHash(storedHash, parts, res)
-	}
-	// Fallthrough: keep the hash, but mark the method as unknown.
-	return res
-}
-
-var sha256NewSum = sha256.New().Sum(nil)
-
-// TODO(mjibson): properly apply SHA-256 to the password. The current code
-// erroneously appends the SHA-256 of the empty hash to the unhashed password
-// instead of actually hashing the password. Fixing this requires a somewhat
-// complicated backwards compatibility dance. This is not a security issue
-// because the round of SHA-256 was only intended to achieve a fixed-length
-// input to bcrypt; it is bcrypt that provides the cryptographic security, and
-// bcrypt is correctly applied.
-func appendEmptySha256(password string) []byte {
-	// In the past we incorrectly called the hash.Hash.Sum method. That
-	// method uses its argument as a place to put the current hash:
-	// it does not add its argument to the current hash. Thus, using
-	// h.Sum([]byte(password))) is the equivalent to the below append.
-	return append([]byte(password), sha256NewSum...)
-}
-
-// CompareHashAndCleartextPassword tests that the provided bytes are equivalent to the
-// hash of the supplied password. If the hash is valid but the password does not match,
-// no error is returned but the ok boolean is false.
-// If an error was detected while using the hash, an error is returned.
-func CompareHashAndCleartextPassword(
-	ctx context.Context, hashedPassword PasswordHash, password string,
-) (ok bool, err error) {
-	return hashedPassword.compareWithCleartextPassword(ctx, password)
-}
-
-// compareWithCleartextPassword is part of the PasswordHash interface.
-func (b bcryptHash) compareWithCleartextPassword(
-	ctx context.Context, cleartext string,
-) (ok bool, err error) {
-	sem := getExpensiveHashComputeSem(ctx)
-	alloc, err := sem.Acquire(ctx, 1)
-	if err != nil {
-		return false, err
-	}
-	defer alloc.Release()
-
-	err = bcrypt.CompareHashAndPassword([]byte(b), appendEmptySha256(cleartext))
-	if err != nil {
-		if errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
-}
-
-// compareWithCleartextPassword is part of the PasswordHash interface.
-func (s *scramHash) compareWithCleartextPassword(
-	ctx context.Context, cleartext string,
-) (ok bool, err error) {
-	sem := getExpensiveHashComputeSem(ctx)
-	alloc, err := sem.Acquire(ctx, 1)
-	if err != nil {
-		return false, err
-	}
-	defer alloc.Release()
-
-	// Server-side verification of a plaintext password
-	// against a pre-computed stored SCRAM server key.
-	//
-	// Code inspired from pg's scram_verify_plain_password(),
-	// src/backend/libpq/auth-scram.c.
-	//
-	prepared, err := stringprep.SASLprep.Prepare(cleartext)
-	if err != nil {
-		// Special PostgreSQL case, quoth comment at the top of
-		// auth-scram.c:
-		//
-		// * - If the password isn't valid UTF-8, or contains characters prohibited
-		// *	 by the SASLprep profile, we skip the SASLprep pre-processing and use
-		// *	 the raw bytes in calculating the hash.
-		prepared = cleartext
-	}
-
-	saltedPassword := pbkdf2.Key([]byte(prepared), []byte(s.decoded.Salt), s.decoded.Iters, sha256.Size, sha256.New)
-	// As per xdg-go/scram and pg's scram_ServerKey().
-	// Note: the string "Server Key" is part of the SCRAM algorithm,
-	// see IETF RFC 5802.
-	serverKey := computeHMAC(scram.SHA256, saltedPassword, []byte("Server Key"))
-	return bytes.Equal(serverKey, s.decoded.ServerKey), nil
-}
-
-// computeHMAC is taken from xdg-go/scram; sadly it is not exported
-// from that package.
-func computeHMAC(hg scram.HashGeneratorFcn, key, data []byte) []byte {
-	mac := hmac.New(hg, key)
-	mac.Write(data)
-	return mac.Sum(nil)
-}
 
 // PasswordHashMethod is the cluster setting that configures which
 // hash method to use when clients request to store a cleartext password.
@@ -377,8 +107,8 @@ var PasswordHashMethod = settings.RegisterEnumSetting(
 	// in the GetConfiguredPasswordHashMethod() function.
 	"scram-sha-256",
 	map[int64]string{
-		int64(HashBCrypt):      HashBCrypt.String(),
-		int64(HashSCRAMSHA256): HashSCRAMSHA256.String(),
+		int64(password.HashBCrypt):      password.HashBCrypt.String(),
+		int64(password.HashSCRAMSHA256): password.HashSCRAMSHA256.String(),
 	},
 ).WithPublic()
 
@@ -396,105 +126,16 @@ func hasClusterVersion(
 
 // GetConfiguredPasswordHashMethod returns the configured hash method
 // to use before storing passwords provided in cleartext from clients.
-func GetConfiguredPasswordHashMethod(ctx context.Context, sv *settings.Values) (method HashMethod) {
-	method = HashMethod(PasswordHashMethod.Get(sv))
-	if method == HashSCRAMSHA256 && !hasClusterVersion(ctx, sv, clusterversion.SCRAMAuthentication) {
+func GetConfiguredPasswordHashMethod(
+	ctx context.Context, sv *settings.Values,
+) (method password.HashMethod) {
+	method = password.HashMethod(PasswordHashMethod.Get(sv))
+	if method == password.HashSCRAMSHA256 && !hasClusterVersion(ctx, sv, clusterversion.SCRAMAuthentication) {
 		// Not all nodes are upgraded to understand SCRAM yet. Force
 		// Bcrypt for now, otherwise previous-version nodes will get confused.
-		method = HashBCrypt
+		method = password.HashBCrypt
 	}
 	return method
-}
-
-// HashPassword takes a raw password and returns a hashed password, hashed
-// using the currently configured method.
-func HashPassword(ctx context.Context, sv *settings.Values, password string) ([]byte, error) {
-	method := GetConfiguredPasswordHashMethod(ctx, sv)
-	switch method {
-	case HashBCrypt:
-		sem := getExpensiveHashComputeSem(ctx)
-		alloc, err := sem.Acquire(ctx, 1)
-		if err != nil {
-			return nil, err
-		}
-		defer alloc.Release()
-		return bcrypt.GenerateFromPassword(appendEmptySha256(password), int(BcryptCost.Get(sv)))
-
-	case HashSCRAMSHA256:
-		cost := int(SCRAMCost.Get(sv))
-		return hashPasswordUsingSCRAM(ctx, cost, password)
-
-	default:
-		return nil, errors.Newf("unsupported hash method: %v", method)
-	}
-}
-
-func hashPasswordUsingSCRAM(ctx context.Context, cost int, cleartext string) ([]byte, error) {
-	prepared, err := stringprep.SASLprep.Prepare(cleartext)
-	if err != nil {
-		// Special PostgreSQL case, quoth comment at the top of
-		// auth-scram.c:
-		//
-		// * - If the password isn't valid UTF-8, or contains characters prohibited
-		// *	 by the SASLprep profile, we skip the SASLprep pre-processing and use
-		// *	 the raw bytes in calculating the hash.
-		prepared = cleartext
-	}
-
-	// The computation of ServerKey and StoredKey is conveniently provided
-	// to us by xdg/scram in the Client method GetStoredCredentials().
-	// To use it, we need a client.
-	client, err := scram.SHA256.NewClientUnprepped("" /* username: unused */, prepared, "" /* authzID: unused */)
-	if err != nil {
-		return nil, errors.AssertionFailedf("programming error: client construction should never fail")
-	}
-
-	// We also need to generate a random salt ourselves.
-	const scramSaltSize = 16 // postgres: SCRAM_DEFAULT_SALT_LEN.
-	salt := make([]byte, scramSaltSize)
-	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
-		return nil, errors.Wrap(err, "generating random salt")
-	}
-
-	// The computation of the SCRAM hash is expensive. Use the shared
-	// semaphore for it. We reuse the same pattern as the bcrypt case above.
-	sem := getExpensiveHashComputeSem(ctx)
-	alloc, err := sem.Acquire(ctx, 1)
-	if err != nil {
-		return nil, err
-	}
-	defer alloc.Release()
-	// Compute the credentials.
-	creds := client.GetStoredCredentials(scram.KeyFactors{Iters: cost, Salt: string(salt)})
-	// Encode them in our standard hash format.
-	return encodeScramHash(salt, creds), nil
-}
-
-// encodeScramHash encodes the provided SCRAM credentials using the
-// standard PostgreSQL / RFC5802 representation.
-func encodeScramHash(saltBytes []byte, sc scram.StoredCredentials) []byte {
-	b64enc := base64.StdEncoding
-	saltLen := b64enc.EncodedLen(len(saltBytes))
-	storedKeyLen := b64enc.EncodedLen(len(sc.StoredKey))
-	serverKeyLen := b64enc.EncodedLen(len(sc.ServerKey))
-	// The representation is:
-	//    SCRAM-SHA-256$<iters>:<salt>$<stored key>:<server key>
-	// We use a capacity-based slice extension instead of a size-based fill
-	// so as to automatically support iteration counts with more than 4 digits.
-	res := make([]byte, 0, len(scramPrefix)+1+4 /*iters*/ +1+saltLen+1+storedKeyLen+1+serverKeyLen)
-	res = append(res, scramPrefix...)
-	res = append(res, '$')
-	res = strconv.AppendInt(res, int64(sc.Iters), 10)
-	res = append(res, ':')
-	res = append(res, make([]byte, saltLen)...)
-	b64enc.Encode(res[len(res)-saltLen:], saltBytes)
-	res = append(res, '$')
-	res = append(res, make([]byte, storedKeyLen)...)
-	b64enc.Encode(res[len(res)-storedKeyLen:], sc.StoredKey)
-	res = append(res, ':')
-	res = append(res, make([]byte, serverKeyLen)...)
-	b64enc.Encode(res[len(res)-serverKeyLen:], sc.ServerKey)
-	return res
 }
 
 // AutoDetectPasswordHashes is the cluster setting that configures whether
@@ -505,175 +146,6 @@ var AutoDetectPasswordHashes = settings.RegisterBoolSetting(
 	"whether the server accepts to store passwords pre-hashed by clients",
 	true,
 )
-
-const crdbBcryptPrefix = "CRDB-BCRYPT"
-
-// bcryptHashRe matches the lexical structure of the bcrypt hash
-// format supported by CockroachDB. The base64 encoding of the hash
-// uses the alphabet used by the bcrypt package:
-// "./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
-var bcryptHashRe = regexp.MustCompile(`^(` + crdbBcryptPrefix + `)?\$\d[a-z]?\$\d\d\$[0-9A-Za-z\./]{22}[0-9A-Za-z\./]+$`)
-
-// isBcryptHash determines whether hashedPassword is in the CockroachDB bcrypt format.
-// If the script parameter is true, then the special "CRDB-BCRYPT" prefix is required.
-// This is used e.g. when accepting password hashes in the SQL ALTER USER statement.
-// When loading a hash from storage, typically we do not enforce this so as to
-// support password hashes stored in earlier versions of CockroachDB.
-func isBcryptHash(inputPassword []byte, strict bool) bool {
-	if !bcryptHashRe.Match(inputPassword) {
-		return false
-	}
-	if strict && !bytes.HasPrefix(inputPassword, []byte(crdbBcryptPrefix+`$`)) {
-		return false
-	}
-	return true
-}
-
-func checkBcryptHash(inputPassword []byte) (ok bool, hashedPassword []byte, err error) {
-	if !isBcryptHash(inputPassword, true /* strict */) {
-		return false, nil, nil
-	}
-	// Trim the "CRDB-BCRYPT" prefix. We trim this because previous version
-	// CockroachDB nodes do not understand the prefix when stored.
-	hashedPassword = inputPassword[len(crdbBcryptPrefix):]
-	// The bcrypt.Cost() function parses the hash and checks its syntax.
-	_, err = bcrypt.Cost(hashedPassword)
-	return true, hashedPassword, err
-}
-
-const scramPrefix = "SCRAM-SHA-256"
-
-// scramHashRe matches the lexical structure of PostgreSQL's
-// pre-computed SCRAM hashes.
-//
-// This structure is inspired from PosgreSQL's parse_scram_secret() function.
-// The base64 encoding uses the alphabet used by pg_b64_encode():
-// "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
-// The salt must have size >0; the server key pair is two times 32 bytes,
-// which always encode to 44 base64 characters.
-var scramHashRe = regexp.MustCompile(`^` + scramPrefix + `\$(\d+):([A-Za-z0-9+/]+=*)\$([A-Za-z0-9+/]{43}=):([A-Za-z0-9+/]{43}=)$`)
-
-// scramParts is an intermediate type to connect the output of
-// isSCRAMHash() to makeSCRAMHash(), so that the latter cannot be
-// legitimately used without the former.
-type scramParts [][]byte
-
-func (sp scramParts) getIters() (int, error) {
-	return strconv.Atoi(string(sp[1]))
-}
-
-func (sp scramParts) getSalt() ([]byte, error) {
-	return base64.StdEncoding.DecodeString(string(sp[2]))
-}
-
-func (sp scramParts) getStoredKey() ([]byte, error) {
-	return base64.StdEncoding.DecodeString(string(sp[3]))
-}
-
-func (sp scramParts) getServerKey() ([]byte, error) {
-	return base64.StdEncoding.DecodeString(string(sp[4]))
-}
-
-func isSCRAMHash(inputPassword []byte) (bool, scramParts) {
-	parts := scramHashRe.FindSubmatch(inputPassword)
-	if parts == nil {
-		return false, nil
-	}
-	if len(parts) != 5 {
-		panic(errors.AssertionFailedf("programming error: scramParts type must have same length as regexp groups"))
-	}
-	return true, scramParts(parts)
-}
-
-func checkSCRAMHash(inputPassword []byte) (ok bool, hashedPassword []byte, err error) {
-	ok, parts := isSCRAMHash(inputPassword)
-	if !ok {
-		return false, nil, nil
-	}
-	iters, err := strconv.ParseInt(string(parts[1]), 10, 64)
-	if err != nil {
-		return true, nil, errors.Wrap(err, "invalid scram-sha-256 iteration count")
-	}
-
-	if iters < scramMinCost || iters > scramMaxCost {
-		return true, nil, errors.Newf("scram-sha-256 iteration count not in allowed range (%d,%d)", scramMinCost, scramMaxCost)
-	}
-	return true, inputPassword, nil
-}
-
-// makeSCRAMHash constructs a PasswordHash using the output of a
-// previous call to isSCRAMHash().
-func makeSCRAMHash(storedHash []byte, parts scramParts, invalidHash PasswordHash) PasswordHash {
-	iters, err := parts.getIters()
-	if err != nil || iters < scramMinCost {
-		return invalidHash //nolint:returnerrcheck
-	}
-	salt, err := parts.getSalt()
-	if err != nil {
-		return invalidHash //nolint:returnerrcheck
-	}
-	storedKey, err := parts.getStoredKey()
-	if err != nil {
-		return invalidHash //nolint:returnerrcheck
-	}
-	serverKey, err := parts.getServerKey()
-	if err != nil {
-		return invalidHash //nolint:returnerrcheck
-	}
-	return &scramHash{
-		bytes: storedHash,
-		decoded: scram.StoredCredentials{
-			KeyFactors: scram.KeyFactors{
-				Salt:  string(salt),
-				Iters: iters,
-			},
-			StoredKey: storedKey,
-			ServerKey: serverKey,
-		},
-	}
-}
-
-func isMD5Hash(hashedPassword []byte) bool {
-	// This logic is inspired from PostgreSQL's get_password_type() function.
-	return bytes.HasPrefix(hashedPassword, []byte("md5")) &&
-		len(hashedPassword) == 35 &&
-		len(bytes.Trim(hashedPassword[3:], "0123456789abcdef")) == 0
-}
-
-// CheckPasswordHashValidity determines whether a (user-provided)
-// password is already hashed, and if already hashed, verifies whether
-// the hash is recognized as a valid hash.
-// Return values:
-// - isPreHashed indicates whether the password is already hashed.
-// - supportedScheme indicates whether the scheme is currently supported
-//   for authentication. If false, issueNum indicates which github
-//   issue to report in the error message.
-// - schemeName is the name of the hashing scheme, for inclusion
-//   in error messages (no guarantee is made of stability of this string).
-// - hashedPassword is a translated version from the input,
-//   suitable for storage in the password database.
-func CheckPasswordHashValidity(
-	ctx context.Context, inputPassword []byte,
-) (
-	isPreHashed, supportedScheme bool,
-	issueNum int,
-	schemeName string,
-	hashedPassword []byte,
-	err error,
-) {
-	if ok, hashedPassword, err := checkBcryptHash(inputPassword); ok {
-		return true, true, 0, "crdb-bcrypt", hashedPassword, err
-	}
-	if ok, hashedPassword, err := checkSCRAMHash(inputPassword); ok {
-		return true, true, 0, "scram-sha-256", hashedPassword, err
-	}
-	if isMD5Hash(inputPassword) {
-		// See: https://github.com/cockroachdb/cockroach/issues/73337
-		return true, false /* not supported */, 73337 /* issueNum */, "md5", inputPassword, nil
-	}
-
-	return false, false, 0, "", inputPassword, nil
-}
 
 // MinPasswordLength is the cluster setting that configures the
 // minimum SQL password length.
@@ -686,224 +158,11 @@ var MinPasswordLength = settings.RegisterIntSetting(
 	settings.NonNegativeInt,
 ).WithPublic()
 
-// expensiveHashComputeSemOnce wraps a semaphore that limits the
-// number of concurrent calls to the bcrypt and sha256 hash
-// functions. This is needed to avoid the risk of a DoS attacks by
-// malicious users or broken client apps that would starve the server
-// of CPU resources just by computing hashes.
-//
-// We use a sync.Once to delay the creation of the semaphore to the
-// first time the password functions are used. This gives a chance to
-// the server process to update GOMAXPROCS before we compute the
-// maximum amount of concurrency for the semaphore.
-var expensiveHashComputeSemOnce struct {
-	sem  *quotapool.IntPool
-	once sync.Once
-}
-
-// envMaxHashComputeConcurrency allows a user to override the semaphore
-// configuration using an environment variable.
-// If the env var is set to a value >= 1, that value is used.
-// Otherwise, a default is computed from the configure GOMAXPROCS.
-var envMaxHashComputeConcurrency = envutil.EnvOrDefaultInt("COCKROACH_MAX_PW_HASH_COMPUTE_CONCURRENCY", 0)
-
-// getExpensiveHashComputeSem retrieves the hashing semaphore.
-func getExpensiveHashComputeSem(ctx context.Context) *quotapool.IntPool {
-	expensiveHashComputeSemOnce.once.Do(func() {
-		var n int
-		if envMaxHashComputeConcurrency >= 1 {
-			// The operator knows better. Use what they tell us to use.
-			n = envMaxHashComputeConcurrency
-		} else {
-			// We divide by 8 so that the max CPU usage of hash checks
-			// never exceeds ~10% of total CPU resources allocated to this
-			// process.
-			n = runtime.GOMAXPROCS(-1) / 8
-		}
-		if n < 1 {
-			n = 1
-		}
-		log.VInfof(ctx, 1, "configured maximum hashing concurrency: %d", n)
-		expensiveHashComputeSemOnce.sem = quotapool.NewIntPool("password_hashes", uint64(n))
-	})
-	return expensiveHashComputeSemOnce.sem
-}
-
-// bcryptCostToSCRAMIterCount maps the bcrypt cost in a pre-hashed
-// password using the crdb-bcrypt method to an “equivalent” cost
-// (iteration count) for the scram-sha-256 method. This is used to
-// automatically upgrade clusters from crdb-bcrypt to scram-sha-256.
-//
-// This mapping was computed so that given a starting bcrypt cost, the
-// latency of authentication using SCRAM-SHA-256 with an iter count
-// computed by this mapping would be comparable to that when using bcrypt.
-//
-// For example, with bcrypt cost 10, if the authn latency is ~60ms
-// (an actual measurement on current hardware as of this writing),
-// the mapping gives SCRAM authn latency of ~60ms too.
-//
-// The actual values were computed as follows:
-// 1. measure the bcrypt authentication cost for costs 1-19.
-// 2. assuming the bcrypt latency is a_bcrypt*2^c + b_bcrypt, where c
-//    is the bcrypt cost, use statistical regression to derive
-//    a_bcrypt and b_bcrypt. (we found b_bcrypt to be negligible.)
-// 3. measure the SCRAM authn cost for iter counts 4096-1000000,
-//    *on the same hardware*.
-// 4. assuming the SCRAM latency is a_scram*c + b_scram,
-//    where c is the SCRAM iter count, use stat regression
-//    to derive a_scram and b_scram. (we found b_scram to be negligible).
-// 5. for each bcrypt cost, compute scram iter count = a_bcrypt * 2^cost_bcrypt / a_scram.
-//
-// The speed of the CPU used for the measurements is equally
-// represented in a_bcrypt and a_scram, so the formula eliminates any
-// CPU-specific factor.
-//
-// An alternative approach would have been to choose a SCRAM-SHA-256
-// mapping that gives equivalent difficulty at bruteforcing passwords
-// given access to the hashes and access to ASICs/GPUs. If that was
-// the goal, we would derive higher iteration counts by a factor of at
-// least 10x.
-// (From bdarnell's analysis: In 1 second, a CPU can do 1M iterations
-// of hmac-sha256 or 16k iterations of bcrypt, a ratio of 60:1. A GPU
-// can do 2G iterations of hmac-sha256 or 3M iterations of 600:1.)
-//
-// However, this would also increase the user login
-// latency by a factor of 10x, which we consider unacceptable from a
-// usability perspective for a *default* mapping.
-// Instead, for CockroachDB we will recommend in docs that
-// users define passwords with a high complexity, so that
-// the entropy of the password itself compounds with the complexity
-// of the SCRAM hash.
-// As of this writing this is already the approach taken in
-// CockroachCloud, where passwords are auto-generated.
-//
-// Meanwhile, we are also announcing this trade-off in release notes:
-// an operator who lets their end-users select their own passwords,
-// and wishes to prioritize bruteforcing hardness at the
-// expense of login latency, will be free to adjust the setting
-// server.user_login.password_hashes.default_cost.scram_sha_256 and
-// re-encode their passwords.
-var bcryptCostToSCRAMIterCount = []int64{
-	0,            // 0-3 are not valid bcrypt costs.
-	0,            // 0-3 are not valid bcrypt costs.
-	0,            // 0-3 are not valid bcrypt costs.
-	0,            // 0-3 are not valid bcrypt costs.
-	4096,         // 4 - special case to select lowest cost possible. Model would predict 7000.
-	9420,         // 5
-	12977,        // 6
-	20090,        // 7
-	34318,        // 8
-	62772,        // 9
-	119680,       // 10 - common default, 50-100ms login latency on 2021 hardware
-	233497,       // 11
-	461131,       // 12
-	916398,       // 13
-	1826932,      // 14
-	3648001,      // 15
-	7290139,      // 16
-	14574415,     // 17
-	29142967,     // 18
-	58280072,     // 19
-	116554280,    // 20
-	233102696,    // 21
-	466199529,    // 22
-	932393195,    // 23
-	1864780528,   // 24
-	3729555192,   // 25
-	7459104520,   // 26
-	14918203177,  // 27
-	29836400491,  // 28
-	59672795119,  // 29
-	119345584374, // 30
-	238691162884, // 31
-}
-
-var autoUpgradePasswordHashes = settings.RegisterBoolSetting(
+// AutoUpgradePasswordHashes is the cluster setting that configures whether to
+// automatically re-encode stored passwords using crdb-bcrypt to scram-sha-256.
+var AutoUpgradePasswordHashes = settings.RegisterBoolSetting(
 	settings.TenantWritable,
 	"server.user_login.upgrade_bcrypt_stored_passwords_to_scram.enabled",
 	"whether to automatically re-encode stored passwords using crdb-bcrypt to scram-sha-256",
 	true,
 ).WithPublic()
-
-// MaybeUpgradePasswordHash looks at the cleartext and the hashed
-// password and determines whether the hash can be upgraded from
-// crdb-bcrypt to scram-sha-256. If it can, it computes an equivalent
-// SCRAM hash and returns it.
-//
-// See the documentation on bcryptCostToSCRAMIterCount[] for details.
-func MaybeUpgradePasswordHash(
-	ctx context.Context, sv *settings.Values, cleartext string, hashed PasswordHash,
-) (converted bool, prevHashBytes, newHashBytes []byte, newMethod string, err error) {
-	bh, isBcrypt := hashed.(bcryptHash)
-
-	// Do we want to perform the conversion?
-	//
-	// We stop here in the following cases:
-	// - password not currently hashed using crdb-bcrypt: we can't convert.
-	// - conversion disabled by cluster setting.
-	// - some nodes don't know about SCRAM just yet during an upgrade.
-	//   (checked in GetConfiguredPasswordHashMethod)
-	// - the configured default method is not scram-sha-256.
-	if !isBcrypt || !autoUpgradePasswordHashes.Get(sv) ||
-		GetConfiguredPasswordHashMethod(ctx, sv) != HashSCRAMSHA256 {
-		// Nothing to do.
-		return false, nil, nil, "", nil
-	}
-
-	bcryptCost, err := bcrypt.Cost([]byte(bh))
-	if err != nil {
-		// The caller should only call this function after authentication
-		// has succeeded, so the bcrypt cost should have been validated
-		// already.
-		return false, nil, nil, "", errors.NewAssertionErrorWithWrappedErrf(err, "programming error: authn succeeded but invalid bcrypt hash")
-	}
-	if bcryptCost < 0 || bcryptCost >= len(bcryptCostToSCRAMIterCount) || bcryptCostToSCRAMIterCount[bcryptCost] == 0 {
-		// The bcryptCost was smaller than 4 or greater than 31? That's a violation of a bcrypt invariant.
-		// Or perhaps the bcryptCostToSCRAMIterCount was incorrectly modified and there's a hole with value zero.
-		return false, nil, nil, "", errors.AssertionFailedf("unexpected: bcrypt cost %d is out of bounds or has no mapping", bcryptCost)
-	}
-
-	scramIterCount := bcryptCostToSCRAMIterCount[bcryptCost]
-	if scramIterCount > math.MaxInt {
-		// scramIterCount is an int64. However, the SCRAM library we're using (xdg/scram) uses
-		// an int for the iteration count. This is not an issue when this code is running
-		// on a 64-bit platform, where sizeof(int) == sizeof(int64). However, when running
-		// on 32-bit, we can't allow a conversion to proceed because it would potentially
-		// truncate the iter count to a low value.
-		// However, this situation is not an error. The hash could still be converted later
-		// when the system is upgraded to 64-bit.
-		return false, nil, nil, "", nil
-	}
-
-	if bcryptCost > 10 {
-		// Tell the logs that we're doing a conversion. This is important
-		// if the new cost is high and the operation takes a long time, so
-		// the operator knows what's up.
-		//
-		// Note: this is an informational message for troubleshooting
-		// purposes, and therefore is best sent to the DEV channel. The
-		// structured event that reports that the conversion has completed
-		// (and the new credentials were stored) is sent by the SQL code
-		// that also owns the storing of the new credentials.
-		log.Infof(ctx, "hash conversion: computing a SCRAM hash with iteration count %d (from bcrypt cost %d)", scramIterCount, bcryptCost)
-	}
-
-	rawHash, err := hashPasswordUsingSCRAM(ctx, int(scramIterCount), cleartext)
-	if err != nil {
-		// This call only fail with hard errors.
-		return false, nil, nil, "", err
-	}
-
-	// Check the raw hash can be decoded using our decoder.
-	// This checks that we're able to re-parse what we just generated,
-	// which is a safety mechanism to ensure the result is valid.
-	expectedMethod := HashSCRAMSHA256
-	newHash := LoadPasswordHash(ctx, rawHash)
-	if newHash.Method() != expectedMethod {
-		// The conversion failed? That is very strange.
-		log.Errorf(ctx, "unexpected hash contents during bcrypt->scram conversion: %T %+v -> %T %+v", hashed, hashed, newHash, newHash)
-		// In contrast to logs, we don't want the details of the hash in the error with %+v.
-		return false, nil, nil, "", errors.AssertionFailedf("programming error: re-hash failed to produce SCRAM hash, produced %T instead", newHash)
-	}
-	return true, []byte(bh), rawHash, expectedMethod.String(), nil
-}

--- a/pkg/security/password/BUILD.bazel
+++ b/pkg/security/password/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "password",
+    srcs = ["password.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/security/password",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/util/envutil",
+        "//pkg/util/log",
+        "//pkg/util/quotapool",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_xdg_go_pbkdf2//:pbkdf2",
+        "@com_github_xdg_go_scram//:scram",
+        "@com_github_xdg_go_stringprep//:stringprep",
+        "@org_golang_x_crypto//bcrypt",
+    ],
+)
+
+go_test(
+    name = "password_test",
+    srcs = ["password_test.go"],
+    deps = [
+        ":password",
+        "//pkg/security",
+        "//pkg/settings/cluster",
+        "//pkg/util/leaktest",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_x_crypto//bcrypt",
+    ],
+)

--- a/pkg/security/password/password.go
+++ b/pkg/security/password/password.go
@@ -1,0 +1,780 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package password
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"math"
+	"regexp"
+	"runtime"
+	"strconv"
+	"sync"
+	"unsafe"
+
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
+	"github.com/cockroachdb/errors"
+	"github.com/xdg-go/pbkdf2"
+	"github.com/xdg-go/scram"
+	"github.com/xdg-go/stringprep"
+	"golang.org/x/crypto/bcrypt"
+)
+
+const (
+	// DefaultBcryptCost is the hashing cost for the hashing method crdb-bcrypt.
+	DefaultBcryptCost = 10
+	// DefaultSCRAMCost is the hashing cost for the hashing method SCRAM.
+	DefaultSCRAMCost = 119680
+	// ScramMinCost is as per RFC 5802.
+	ScramMinCost = 4096
+	// ScramMaxCost is an arbitrary value to prevent unreasonably long logins
+	ScramMaxCost = 240000000000
+)
+
+const (
+	crdbBcryptPrefix = "CRDB-BCRYPT"
+	scramPrefix      = "SCRAM-SHA-256"
+)
+
+// HashMethod indicates which password hash method to use.
+type HashMethod int8
+
+const (
+	// HashInvalidMethod represents invalid hashes.
+	// This always fails authentication.
+	HashInvalidMethod HashMethod = 0
+	// HashMissingPassword represents a virtual hash when there was
+	// no password.  This too always fails authentication.
+	// We need a different method here than HashInvalidMethod because
+	// the authentication code distinguishes the two cases when reporting
+	// why authentication fails in audit logs.
+	HashMissingPassword HashMethod = 1
+	// HashBCrypt indicates CockroachDB's bespoke bcrypt-based method.
+	// NB: Do not renumber this constant; it is used as value
+	// in cluster setting enums.
+	HashBCrypt HashMethod = 2
+	// HashSCRAMSHA256 indicates SCRAM-SHA-256.
+	// NB: Do not renumber this constant; it is used as value
+	// in cluster setting enums.
+	HashSCRAMSHA256 HashMethod = 3
+)
+
+func (h HashMethod) String() string {
+	switch h {
+	case HashInvalidMethod:
+		return "<invalid>"
+	case HashMissingPassword:
+		return "<missing password>"
+	case HashBCrypt:
+		return "crdb-bcrypt"
+	case HashSCRAMSHA256:
+		return "scram-sha-256"
+	default:
+		panic(errors.AssertionFailedf("programming errof: unknown hash method %d", int(h)))
+	}
+}
+
+// PasswordHash represents the type of a password hash loaded from a credential store.
+type PasswordHash interface {
+	fmt.Stringer
+	// Method report which hashing method was used.
+	Method() HashMethod
+	// Size is the size of the in-memory representation of this hash. This
+	// is used for memory accounting.
+	Size() int
+	// compareWithCleartextPassword checks a cleartext password against
+	// the hash.
+	compareWithCleartextPassword(ctx context.Context, cleartext string) (ok bool, err error)
+}
+
+var _ PasswordHash = emptyPassword{}
+var _ PasswordHash = invalidHash(nil)
+var _ PasswordHash = bcryptHash(nil)
+var _ PasswordHash = (*scramHash)(nil)
+
+// emptyPassword represents a virtual hash when there was no password
+// to start with.
+type emptyPassword struct{}
+
+// String implements fmt.Stringer.
+func (e emptyPassword) String() string { return "<missing>" }
+
+// Method is part of the PasswordHash interface.
+func (e emptyPassword) Method() HashMethod { return HashMissingPassword }
+
+// Size is part of the PasswordHash interface.
+func (e emptyPassword) Size() int { return 0 }
+
+// compareWithCleartextPassword is part of the PasswordHash interface.
+func (e emptyPassword) compareWithCleartextPassword(
+	ctx context.Context, cleartext string,
+) (ok bool, err error) {
+	return false, nil
+}
+
+// MissingPasswordHash represents the virtual hash when there is no password
+// to start with.
+var MissingPasswordHash PasswordHash = emptyPassword{}
+
+// invalidHash represents a byte slice that's in an unknown hash format.
+// We keep the byte slice around so that it can be passed through
+// and re-stored as-is.
+type invalidHash []byte
+
+// String implements fmt.Stringer.
+func (n invalidHash) String() string { return string(n) }
+
+// Method is part of the PasswordHash interface.
+func (n invalidHash) Method() HashMethod { return HashInvalidMethod }
+
+// Size is part of the PasswordHash interface.
+func (n invalidHash) Size() int { return len(n) }
+
+// compareWithCleartextPassword is part of the PasswordHash interface.
+func (n invalidHash) compareWithCleartextPassword(
+	ctx context.Context, cleartext string,
+) (ok bool, err error) {
+	return false, nil
+}
+
+// bcryptHash represents a bcrypt-based hashed password.
+// The type is simple since we're offloading the decoding
+// of the parameters to the go standard bcrypt package.
+type bcryptHash []byte
+
+// String implements fmt.Stringer.
+func (b bcryptHash) String() string { return string(b) }
+
+// Method is part of the PasswordHash interface.
+func (b bcryptHash) Method() HashMethod { return HashBCrypt }
+
+// Size is part of the PasswordHash interface.
+func (b bcryptHash) Size() int { return len(b) }
+
+// scramHash represents a SCRAM-SHA-256 password hash.
+type scramHash struct {
+	bytes   []byte
+	decoded scram.StoredCredentials
+}
+
+// String implements fmt.Stringer.
+func (s *scramHash) String() string { return string(s.bytes) }
+
+// Method is part of the PasswordHash interface.
+func (s *scramHash) Method() HashMethod { return HashSCRAMSHA256 }
+
+// Size is part of the PasswordHash interface.
+func (s *scramHash) Size() int {
+	return int(unsafe.Sizeof(*s)) + len(s.bytes) + len(s.decoded.Salt) + len(s.decoded.StoredKey) + len(s.decoded.ServerKey)
+}
+
+// GetSCRAMStoredCredentials retrieves the SCRAM credential parts.
+// The caller is responsible for ensuring the hash has method SCRAM-SHA-256.
+func GetSCRAMStoredCredentials(hash PasswordHash) (ok bool, creds scram.StoredCredentials) {
+	h, ok := hash.(*scramHash)
+	if ok {
+		return ok, h.decoded
+	}
+	return false, creds
+}
+
+// LoadPasswordHash decodes a password hash loaded as bytes from a credential store.
+func LoadPasswordHash(ctx context.Context, storedHash []byte) (res PasswordHash) {
+	res = invalidHash(storedHash)
+	if len(storedHash) == 0 {
+		return emptyPassword{}
+	}
+	if isBcryptHash(storedHash, false /* strict */) {
+		return bcryptHash(storedHash)
+	}
+	if ok, parts := isSCRAMHash(storedHash); ok {
+		return makeSCRAMHash(storedHash, parts, res)
+	}
+	// Fallthrough: keep the hash, but mark the method as unknown.
+	return res
+}
+
+var sha256NewSum = sha256.New().Sum(nil)
+
+// AppendEmptySha256 is to append the SHA-256 of the empty hash to the unhashed
+// password.
+// TODO(mjibson): properly apply SHA-256 to the password. The current code
+// erroneously appends the SHA-256 of the empty hash to the unhashed password
+// instead of actually hashing the password. Fixing this requires a somewhat
+// complicated backwards compatibility dance. This is not a security issue
+// because the round of SHA-256 was only intended to achieve a fixed-length
+// input to bcrypt; it is bcrypt that provides the cryptographic security, and
+// bcrypt is correctly applied.
+func AppendEmptySha256(password string) []byte {
+	// In the past we incorrectly called the hash.Hash.Sum method. That
+	// method uses its argument as a place to put the current hash:
+	// it does not add its argument to the current hash. Thus, using
+	// h.Sum([]byte(password))) is the equivalent to the below append.
+	return append([]byte(password), sha256NewSum...)
+}
+
+// CompareHashAndCleartextPassword tests that the provided bytes are equivalent to the
+// hash of the supplied password. If the hash is valid but the password does not match,
+// no error is returned but the ok boolean is false.
+// If an error was detected while using the hash, an error is returned.
+func CompareHashAndCleartextPassword(
+	ctx context.Context, hashedPassword PasswordHash, password string,
+) (ok bool, err error) {
+	return hashedPassword.compareWithCleartextPassword(ctx, password)
+}
+
+// compareWithCleartextPassword is part of the PasswordHash interface.
+func (b bcryptHash) compareWithCleartextPassword(
+	ctx context.Context, cleartext string,
+) (ok bool, err error) {
+	sem := getExpensiveHashComputeSem(ctx)
+	alloc, err := sem.Acquire(ctx, 1)
+	if err != nil {
+		return false, err
+	}
+	defer alloc.Release()
+
+	err = bcrypt.CompareHashAndPassword([]byte(b), AppendEmptySha256(cleartext))
+	if err != nil {
+		if errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// compareWithCleartextPassword is part of the PasswordHash interface.
+func (s *scramHash) compareWithCleartextPassword(
+	ctx context.Context, cleartext string,
+) (ok bool, err error) {
+	sem := getExpensiveHashComputeSem(ctx)
+	alloc, err := sem.Acquire(ctx, 1)
+	if err != nil {
+		return false, err
+	}
+	defer alloc.Release()
+
+	// Server-side verification of a plaintext password
+	// against a pre-computed stored SCRAM server key.
+	//
+	// Code inspired from pg's scram_verify_plain_password(),
+	// src/backend/libpq/auth-scram.c.
+	//
+	prepared, err := stringprep.SASLprep.Prepare(cleartext)
+	if err != nil {
+		// Special PostgreSQL case, quoth comment at the top of
+		// auth-scram.c:
+		//
+		// * - If the password isn't valid UTF-8, or contains characters prohibited
+		// *	 by the SASLprep profile, we skip the SASLprep pre-processing and use
+		// *	 the raw bytes in calculating the hash.
+		prepared = cleartext
+	}
+
+	saltedPassword := pbkdf2.Key([]byte(prepared), []byte(s.decoded.Salt), s.decoded.Iters, sha256.Size, sha256.New)
+	// As per xdg-go/scram and pg's scram_ServerKey().
+	// Note: the string "Server Key" is part of the SCRAM algorithm,
+	// see IETF RFC 5802.
+	serverKey := computeHMAC(scram.SHA256, saltedPassword, []byte("Server Key"))
+	return bytes.Equal(serverKey, s.decoded.ServerKey), nil
+}
+
+// computeHMAC is taken from xdg-go/scram; sadly it is not exported
+// from that package.
+func computeHMAC(hg scram.HashGeneratorFcn, key, data []byte) []byte {
+	mac := hmac.New(hg, key)
+	mac.Write(data)
+	return mac.Sum(nil)
+}
+
+// HashPassword takes a raw password and returns a hashed password, hashed
+// using the currently configured method.
+func HashPassword(
+	ctx context.Context, cost int, hashMethod HashMethod, password string,
+) ([]byte, error) {
+	switch hashMethod {
+	case HashBCrypt:
+		sem := getExpensiveHashComputeSem(ctx)
+		alloc, err := sem.Acquire(ctx, 1)
+		if err != nil {
+			return nil, err
+		}
+		defer alloc.Release()
+		return bcrypt.GenerateFromPassword(AppendEmptySha256(password), cost)
+
+	case HashSCRAMSHA256:
+		return hashPasswordUsingSCRAM(ctx, cost, password)
+
+	default:
+		return nil, errors.Newf("unsupported hash method: %v", hashMethod)
+	}
+}
+
+func hashPasswordUsingSCRAM(ctx context.Context, cost int, cleartext string) ([]byte, error) {
+	prepared, err := stringprep.SASLprep.Prepare(cleartext)
+	if err != nil {
+		// Special PostgreSQL case, quoth comment at the top of
+		// auth-scram.c:
+		//
+		// * - If the password isn't valid UTF-8, or contains characters prohibited
+		// *	 by the SASLprep profile, we skip the SASLprep pre-processing and use
+		// *	 the raw bytes in calculating the hash.
+		prepared = cleartext
+	}
+
+	// The computation of ServerKey and StoredKey is conveniently provided
+	// to us by xdg/scram in the Client method GetStoredCredentials().
+	// To use it, we need a client.
+	client, err := scram.SHA256.NewClientUnprepped("" /* username: unused */, prepared, "" /* authzID: unused */)
+	if err != nil {
+		return nil, errors.AssertionFailedf("programming error: client construction should never fail")
+	}
+
+	// We also need to generate a random salt ourselves.
+	const scramSaltSize = 16 // postgres: SCRAM_DEFAULT_SALT_LEN.
+	salt := make([]byte, scramSaltSize)
+	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+		return nil, errors.Wrap(err, "generating random salt")
+	}
+
+	// The computation of the SCRAM hash is expensive. Use the shared
+	// semaphore for it. We reuse the same pattern as the bcrypt case above.
+	sem := getExpensiveHashComputeSem(ctx)
+	alloc, err := sem.Acquire(ctx, 1)
+	if err != nil {
+		return nil, err
+	}
+	defer alloc.Release()
+	// Compute the credentials.
+	creds := client.GetStoredCredentials(scram.KeyFactors{Iters: cost, Salt: string(salt)})
+	// Encode them in our standard hash format.
+	return encodeScramHash(salt, creds), nil
+}
+
+// encodeScramHash encodes the provided SCRAM credentials using the
+// standard PostgreSQL / RFC5802 representation.
+func encodeScramHash(saltBytes []byte, sc scram.StoredCredentials) []byte {
+	b64enc := base64.StdEncoding
+	saltLen := b64enc.EncodedLen(len(saltBytes))
+	storedKeyLen := b64enc.EncodedLen(len(sc.StoredKey))
+	serverKeyLen := b64enc.EncodedLen(len(sc.ServerKey))
+	// The representation is:
+	//    SCRAM-SHA-256$<iters>:<salt>$<stored key>:<server key>
+	// We use a capacity-based slice extension instead of a size-based fill
+	// so as to automatically support iteration counts with more than 4 digits.
+	res := make([]byte, 0, len(scramPrefix)+1+4 /*iters*/ +1+saltLen+1+storedKeyLen+1+serverKeyLen)
+	res = append(res, scramPrefix...)
+	res = append(res, '$')
+	res = strconv.AppendInt(res, int64(sc.Iters), 10)
+	res = append(res, ':')
+	res = append(res, make([]byte, saltLen)...)
+	b64enc.Encode(res[len(res)-saltLen:], saltBytes)
+	res = append(res, '$')
+	res = append(res, make([]byte, storedKeyLen)...)
+	b64enc.Encode(res[len(res)-storedKeyLen:], sc.StoredKey)
+	res = append(res, ':')
+	res = append(res, make([]byte, serverKeyLen)...)
+	b64enc.Encode(res[len(res)-serverKeyLen:], sc.ServerKey)
+	return res
+}
+
+// bcryptHashRe matches the lexical structure of the bcrypt hash
+// format supported by CockroachDB. The base64 encoding of the hash
+// uses the alphabet used by the bcrypt package:
+// "./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+var bcryptHashRe = regexp.MustCompile(`^(` + crdbBcryptPrefix + `)?\$\d[a-z]?\$\d\d\$[0-9A-Za-z\./]{22}[0-9A-Za-z\./]+$`)
+
+// isBcryptHash determines whether hashedPassword is in the CockroachDB bcrypt format.
+// If the script parameter is true, then the special "CRDB-BCRYPT" prefix is required.
+// This is used e.g. when accepting password hashes in the SQL ALTER USER statement.
+// When loading a hash from storage, typically we do not enforce this so as to
+// support password hashes stored in earlier versions of CockroachDB.
+func isBcryptHash(inputPassword []byte, strict bool) bool {
+	if !bcryptHashRe.Match(inputPassword) {
+		return false
+	}
+	if strict && !bytes.HasPrefix(inputPassword, []byte(crdbBcryptPrefix+`$`)) {
+		return false
+	}
+	return true
+}
+
+func checkBcryptHash(inputPassword []byte) (ok bool, hashedPassword []byte, err error) {
+	if !isBcryptHash(inputPassword, true /* strict */) {
+		return false, nil, nil
+	}
+	// Trim the "CRDB-BCRYPT" prefix. We trim this because previous version
+	// CockroachDB nodes do not understand the prefix when stored.
+	hashedPassword = inputPassword[len(crdbBcryptPrefix):]
+	// The bcrypt.Cost() function parses the hash and checks its syntax.
+	_, err = bcrypt.Cost(hashedPassword)
+	return true, hashedPassword, err
+}
+
+// scramHashRe matches the lexical structure of PostgreSQL's
+// pre-computed SCRAM hashes.
+//
+// This structure is inspired from PosgreSQL's parse_scram_secret() function.
+// The base64 encoding uses the alphabet used by pg_b64_encode():
+// "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+// The salt must have size >0; the server key pair is two times 32 bytes,
+// which always encode to 44 base64 characters.
+var scramHashRe = regexp.MustCompile(`^` + scramPrefix + `\$(\d+):([A-Za-z0-9+/]+=*)\$([A-Za-z0-9+/]{43}=):([A-Za-z0-9+/]{43}=)$`)
+
+// scramParts is an intermediate type to connect the output of
+// isSCRAMHash() to makeSCRAMHash(), so that the latter cannot be
+// legitimately used without the former.
+type scramParts [][]byte
+
+func (sp scramParts) getIters() (int, error) {
+	return strconv.Atoi(string(sp[1]))
+}
+
+func (sp scramParts) getSalt() ([]byte, error) {
+	return base64.StdEncoding.DecodeString(string(sp[2]))
+}
+
+func (sp scramParts) getStoredKey() ([]byte, error) {
+	return base64.StdEncoding.DecodeString(string(sp[3]))
+}
+
+func (sp scramParts) getServerKey() ([]byte, error) {
+	return base64.StdEncoding.DecodeString(string(sp[4]))
+}
+
+func isSCRAMHash(inputPassword []byte) (bool, scramParts) {
+	parts := scramHashRe.FindSubmatch(inputPassword)
+	if parts == nil {
+		return false, nil
+	}
+	if len(parts) != 5 {
+		panic(errors.AssertionFailedf("programming error: scramParts type must have same length as regexp groups"))
+	}
+	return true, scramParts(parts)
+}
+
+func checkSCRAMHash(inputPassword []byte) (ok bool, hashedPassword []byte, err error) {
+	ok, parts := isSCRAMHash(inputPassword)
+	if !ok {
+		return false, nil, nil
+	}
+	iters, err := strconv.ParseInt(string(parts[1]), 10, 64)
+	if err != nil {
+		return true, nil, errors.Wrap(err, "invalid scram-sha-256 iteration count")
+	}
+
+	if iters < ScramMinCost || iters > ScramMaxCost {
+		return true, nil, errors.Newf("scram-sha-256 iteration count not in allowed range (%d,%d)", ScramMinCost, ScramMaxCost)
+	}
+	return true, inputPassword, nil
+}
+
+// makeSCRAMHash constructs a PasswordHash using the output of a
+// previous call to isSCRAMHash().
+func makeSCRAMHash(storedHash []byte, parts scramParts, invalidHash PasswordHash) PasswordHash {
+	iters, err := parts.getIters()
+	if err != nil || iters < ScramMinCost {
+		return invalidHash //nolint:returnerrcheck
+	}
+	salt, err := parts.getSalt()
+	if err != nil {
+		return invalidHash //nolint:returnerrcheck
+	}
+	storedKey, err := parts.getStoredKey()
+	if err != nil {
+		return invalidHash //nolint:returnerrcheck
+	}
+	serverKey, err := parts.getServerKey()
+	if err != nil {
+		return invalidHash //nolint:returnerrcheck
+	}
+	return &scramHash{
+		bytes: storedHash,
+		decoded: scram.StoredCredentials{
+			KeyFactors: scram.KeyFactors{
+				Salt:  string(salt),
+				Iters: iters,
+			},
+			StoredKey: storedKey,
+			ServerKey: serverKey,
+		},
+	}
+}
+
+func isMD5Hash(hashedPassword []byte) bool {
+	// This logic is inspired from PostgreSQL's get_password_type() function.
+	return bytes.HasPrefix(hashedPassword, []byte("md5")) &&
+		len(hashedPassword) == 35 &&
+		len(bytes.Trim(hashedPassword[3:], "0123456789abcdef")) == 0
+}
+
+// CheckPasswordHashValidity determines whether a (user-provided)
+// password is already hashed, and if already hashed, verifies whether
+// the hash is recognized as a valid hash.
+// Return values:
+// - isPreHashed indicates whether the password is already hashed.
+// - supportedScheme indicates whether the scheme is currently supported
+//   for authentication. If false, issueNum indicates which github
+//   issue to report in the error message.
+// - schemeName is the name of the hashing scheme, for inclusion
+//   in error messages (no guarantee is made of stability of this string).
+// - hashedPassword is a translated version from the input,
+//   suitable for storage in the password database.
+func CheckPasswordHashValidity(
+	ctx context.Context, inputPassword []byte,
+) (
+	isPreHashed, supportedScheme bool,
+	issueNum int,
+	schemeName string,
+	hashedPassword []byte,
+	err error,
+) {
+	if ok, hashedPassword, err := checkBcryptHash(inputPassword); ok {
+		return true, true, 0, "crdb-bcrypt", hashedPassword, err
+	}
+	if ok, hashedPassword, err := checkSCRAMHash(inputPassword); ok {
+		return true, true, 0, "scram-sha-256", hashedPassword, err
+	}
+	if isMD5Hash(inputPassword) {
+		// See: https://github.com/cockroachdb/cockroach/issues/73337
+		return true, false /* not supported */, 73337 /* issueNum */, "md5", inputPassword, nil
+	}
+
+	return false, false, 0, "", inputPassword, nil
+}
+
+// expensiveHashComputeSemOnce wraps a semaphore that limits the
+// number of concurrent calls to the bcrypt and sha256 hash
+// functions. This is needed to avoid the risk of a DoS attacks by
+// malicious users or broken client apps that would starve the server
+// of CPU resources just by computing hashes.
+//
+// We use a sync.Once to delay the creation of the semaphore to the
+// first time the password functions are used. This gives a chance to
+// the server process to update GOMAXPROCS before we compute the
+// maximum amount of concurrency for the semaphore.
+var expensiveHashComputeSemOnce struct {
+	sem  *quotapool.IntPool
+	once sync.Once
+}
+
+// envMaxHashComputeConcurrency allows a user to override the semaphore
+// configuration using an environment variable.
+// If the env var is set to a value >= 1, that value is used.
+// Otherwise, a default is computed from the configure GOMAXPROCS.
+var envMaxHashComputeConcurrency = envutil.EnvOrDefaultInt("COCKROACH_MAX_PW_HASH_COMPUTE_CONCURRENCY", 0)
+
+// getExpensiveHashComputeSem retrieves the hashing semaphore.
+func getExpensiveHashComputeSem(ctx context.Context) *quotapool.IntPool {
+	expensiveHashComputeSemOnce.once.Do(func() {
+		var n int
+		if envMaxHashComputeConcurrency >= 1 {
+			// The operator knows better. Use what they tell us to use.
+			n = envMaxHashComputeConcurrency
+		} else {
+			// We divide by 8 so that the max CPU usage of hash checks
+			// never exceeds ~10% of total CPU resources allocated to this
+			// process.
+			n = runtime.GOMAXPROCS(-1) / 8
+		}
+		if n < 1 {
+			n = 1
+		}
+		log.VInfof(ctx, 1, "configured maximum hashing concurrency: %d", n)
+		expensiveHashComputeSemOnce.sem = quotapool.NewIntPool("password_hashes", uint64(n))
+	})
+	return expensiveHashComputeSemOnce.sem
+}
+
+// BcryptCostToSCRAMIterCount maps the bcrypt cost in a pre-hashed
+// password using the crdb-bcrypt method to an “equivalent” cost
+// (iteration count) for the scram-sha-256 method. This is used to
+// automatically upgrade clusters from crdb-bcrypt to scram-sha-256.
+//
+// This mapping was computed so that given a starting bcrypt cost, the
+// latency of authentication using SCRAM-SHA-256 with an iter count
+// computed by this mapping would be comparable to that when using bcrypt.
+//
+// For example, with bcrypt cost 10, if the authn latency is ~60ms
+// (an actual measurement on current hardware as of this writing),
+// the mapping gives SCRAM authn latency of ~60ms too.
+//
+// The actual values were computed as follows:
+// 1. measure the bcrypt authentication cost for costs 1-19.
+// 2. assuming the bcrypt latency is a_bcrypt*2^c + b_bcrypt, where c
+//    is the bcrypt cost, use statistical regression to derive
+//    a_bcrypt and b_bcrypt. (we found b_bcrypt to be negligible.)
+// 3. measure the SCRAM authn cost for iter counts 4096-1000000,
+//    *on the same hardware*.
+// 4. assuming the SCRAM latency is a_scram*c + b_scram,
+//    where c is the SCRAM iter count, use stat regression
+//    to derive a_scram and b_scram. (we found b_scram to be negligible).
+// 5. for each bcrypt cost, compute scram iter count = a_bcrypt * 2^cost_bcrypt / a_scram.
+//
+// The speed of the CPU used for the measurements is equally
+// represented in a_bcrypt and a_scram, so the formula eliminates any
+// CPU-specific factor.
+//
+// An alternative approach would have been to choose a SCRAM-SHA-256
+// mapping that gives equivalent difficulty at bruteforcing passwords
+// given access to the hashes and access to ASICs/GPUs. If that was
+// the goal, we would derive higher iteration counts by a factor of at
+// least 10x.
+// (From bdarnell's analysis: In 1 second, a CPU can do 1M iterations
+// of hmac-sha256 or 16k iterations of bcrypt, a ratio of 60:1. A GPU
+// can do 2G iterations of hmac-sha256 or 3M iterations of 600:1.)
+//
+// However, this would also increase the user login
+// latency by a factor of 10x, which we consider unacceptable from a
+// usability perspective for a *default* mapping.
+// Instead, for CockroachDB we will recommend in docs that
+// users define passwords with a high complexity, so that
+// the entropy of the password itself compounds with the complexity
+// of the SCRAM hash.
+// As of this writing this is already the approach taken in
+// CockroachCloud, where passwords are auto-generated.
+//
+// Meanwhile, we are also announcing this trade-off in release notes:
+// an operator who lets their end-users select their own passwords,
+// and wishes to prioritize bruteforcing hardness at the
+// expense of login latency, will be free to adjust the setting
+// server.user_login.password_hashes.default_cost.scram_sha_256 and
+// re-encode their passwords.
+var BcryptCostToSCRAMIterCount = []int64{
+	0,            // 0-3 are not valid bcrypt costs.
+	0,            // 0-3 are not valid bcrypt costs.
+	0,            // 0-3 are not valid bcrypt costs.
+	0,            // 0-3 are not valid bcrypt costs.
+	4096,         // 4 - special case to select lowest cost possible. Model would predict 7000.
+	9420,         // 5
+	12977,        // 6
+	20090,        // 7
+	34318,        // 8
+	62772,        // 9
+	119680,       // 10 - common default, 50-100ms login latency on 2021 hardware
+	233497,       // 11
+	461131,       // 12
+	916398,       // 13
+	1826932,      // 14
+	3648001,      // 15
+	7290139,      // 16
+	14574415,     // 17
+	29142967,     // 18
+	58280072,     // 19
+	116554280,    // 20
+	233102696,    // 21
+	466199529,    // 22
+	932393195,    // 23
+	1864780528,   // 24
+	3729555192,   // 25
+	7459104520,   // 26
+	14918203177,  // 27
+	29836400491,  // 28
+	59672795119,  // 29
+	119345584374, // 30
+	238691162884, // 31
+}
+
+// MaybeUpgradePasswordHash looks at the cleartext and the hashed
+// password and determines whether the hash can be upgraded from
+// crdb-bcrypt to scram-sha-256. If it can, it computes an equivalent
+// SCRAM hash and returns it.
+//
+// See the documentation on BcryptCostToSCRAMIterCount[] for details.
+func MaybeUpgradePasswordHash(
+	ctx context.Context,
+	autoUpgradePasswordHashes bool,
+	PasswordHashMethod HashMethod,
+	cleartext string,
+	hashed PasswordHash,
+) (converted bool, prevHashBytes, newHashBytes []byte, newMethod string, err error) {
+	bh, isBcrypt := hashed.(bcryptHash)
+
+	// Do we want to perform the conversion?
+	//
+	// We stop here in the following cases:
+	// - password not currently hashed using crdb-bcrypt: we can't convert.
+	// - conversion disabled by cluster setting.
+	// - some nodes don't know about SCRAM just yet during an upgrade.
+	//   (checked in GetConfiguredPasswordHashMethod)
+	// - the configured default method is not scram-sha-256.
+	if !isBcrypt || !autoUpgradePasswordHashes ||
+		PasswordHashMethod != HashSCRAMSHA256 {
+		// Nothing to do.
+		return false, nil, nil, "", nil
+	}
+
+	bcryptCost, err := bcrypt.Cost([]byte(bh))
+	if err != nil {
+		// The caller should only call this function after authentication
+		// has succeeded, so the bcrypt cost should have been validated
+		// already.
+		return false, nil, nil, "", errors.NewAssertionErrorWithWrappedErrf(err, "programming error: authn succeeded but invalid bcrypt hash")
+	}
+	if bcryptCost < 0 || bcryptCost >= len(BcryptCostToSCRAMIterCount) || BcryptCostToSCRAMIterCount[bcryptCost] == 0 {
+		// The bcryptCost was smaller than 4 or greater than 31? That's a violation of a bcrypt invariant.
+		// Or perhaps the BcryptCostToSCRAMIterCount was incorrectly modified and there's a hole with value zero.
+		return false, nil, nil, "", errors.AssertionFailedf("unexpected: bcrypt cost %d is out of bounds or has no mapping", bcryptCost)
+	}
+
+	scramIterCount := BcryptCostToSCRAMIterCount[bcryptCost]
+	if scramIterCount > math.MaxInt {
+		// scramIterCount is an int64. However, the SCRAM library we're using (xdg/scram) uses
+		// an int for the iteration count. This is not an issue when this code is running
+		// on a 64-bit platform, where sizeof(int) == sizeof(int64). However, when running
+		// on 32-bit, we can't allow a conversion to proceed because it would potentially
+		// truncate the iter count to a low value.
+		// However, this situation is not an error. The hash could still be converted later
+		// when the system is upgraded to 64-bit.
+		return false, nil, nil, "", nil
+	}
+
+	if bcryptCost > 10 {
+		// Tell the logs that we're doing a conversion. This is important
+		// if the new cost is high and the operation takes a long time, so
+		// the operator knows what's up.
+		//
+		// Note: this is an informational message for troubleshooting
+		// purposes, and therefore is best sent to the DEV channel. The
+		// structured event that reports that the conversion has completed
+		// (and the new credentials were stored) is sent by the SQL code
+		// that also owns the storing of the new credentials.
+		log.Infof(ctx, "hash conversion: computing a SCRAM hash with iteration count %d (from bcrypt cost %d)", scramIterCount, bcryptCost)
+	}
+
+	rawHash, err := hashPasswordUsingSCRAM(ctx, int(scramIterCount), cleartext)
+	if err != nil {
+		// This call only fail with hard errors.
+		return false, nil, nil, "", err
+	}
+
+	// Check the raw hash can be decoded using our decoder.
+	// This checks that we're able to re-parse what we just generated,
+	// which is a safety mechanism to ensure the result is valid.
+	expectedMethod := HashSCRAMSHA256
+	newHash := LoadPasswordHash(ctx, rawHash)
+	if newHash.Method() != expectedMethod {
+		// The conversion failed? That is very strange.
+		log.Errorf(ctx, "unexpected hash contents during bcrypt->scram conversion: %T %+v -> %T %+v", hashed, hashed, newHash, newHash)
+		// In contrast to logs, we don't want the details of the hash in the error with %+v.
+		return false, nil, nil, "", errors.AssertionFailedf("programming error: re-hash failed to produce SCRAM hash, produced %T instead", newHash)
+	}
+	return true, []byte(bh), rawHash, expectedMethod.String(), nil
+}

--- a/pkg/security/password/password_test.go
+++ b/pkg/security/password/password_test.go
@@ -8,13 +8,15 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package security
+package password_test
 
 import (
 	"context"
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/password"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/stretchr/testify/require"
@@ -26,12 +28,12 @@ func TestBCryptCostToSCRAMIterCountTable(t *testing.T) {
 
 	// This test mainly checks that the conversion table properly starts
 	// at bcrypt.MinCost, and that no lines are accidentally added or removed.
-	require.Equal(t, bcrypt.MaxCost+1, len(bcryptCostToSCRAMIterCount))
+	require.Equal(t, bcrypt.MaxCost+1, len(password.BcryptCostToSCRAMIterCount))
 	for i := 0; i < bcrypt.MinCost; i++ {
-		require.Equal(t, int64(0), bcryptCostToSCRAMIterCount[i])
+		require.Equal(t, int64(0), password.BcryptCostToSCRAMIterCount[i])
 	}
-	require.Equal(t, int64(4096), bcryptCostToSCRAMIterCount[bcrypt.MinCost])
-	require.Equal(t, int64(119680), bcryptCostToSCRAMIterCount[10])
+	require.Equal(t, int64(4096), password.BcryptCostToSCRAMIterCount[bcrypt.MinCost])
+	require.Equal(t, int64(119680), password.BcryptCostToSCRAMIterCount[10])
 }
 
 func TestBCryptToSCRAMConversion(t *testing.T) {
@@ -41,32 +43,37 @@ func TestBCryptToSCRAMConversion(t *testing.T) {
 
 	const cleartext = "hello"
 
-	ourDefault := int(BcryptCost.Get(&s.SV))
+	ourDefault := int(security.BcryptCost.Get(&s.SV))
 
 	// Don't iterate all the way to 31: the larger values
 	// incur incredibly large hashing times.
 	for i := bcrypt.MinCost; i < ourDefault+3; i++ {
 		t.Run(fmt.Sprintf("bcrypt=%d", i), func(t *testing.T) {
-			bcryptRaw, err := bcrypt.GenerateFromPassword(appendEmptySha256(cleartext), i)
+			bcryptRaw, err := bcrypt.GenerateFromPassword(password.AppendEmptySha256(cleartext), i)
 			require.NoError(t, err)
-			bh := LoadPasswordHash(ctx, bcryptRaw)
-			require.Equal(t, HashBCrypt, bh.Method())
+			bh := password.LoadPasswordHash(ctx, bcryptRaw)
+			require.Equal(t, password.HashBCrypt, bh.Method())
 
 			// Check conversion succeeds.
-			converted, prevHash, newHashBytes, hashMethod, err := MaybeUpgradePasswordHash(ctx, &s.SV, cleartext, bh)
+			autoUpgradePasswordHashesBool := security.AutoUpgradePasswordHashes.Get(&s.SV)
+			method := security.GetConfiguredPasswordHashMethod(ctx, &s.SV)
+			converted, prevHash, newHashBytes, hashMethod, err := password.MaybeUpgradePasswordHash(ctx, autoUpgradePasswordHashesBool, method, cleartext, bh)
 			require.NoError(t, err)
 			require.True(t, converted)
 			require.Equal(t, "SCRAM-SHA-256", string(newHashBytes)[:13])
-			require.Equal(t, HashSCRAMSHA256.String(), hashMethod)
+			require.Equal(t, password.HashSCRAMSHA256.String(), hashMethod)
 			require.Equal(t, bcryptRaw, prevHash)
 
-			newHash := LoadPasswordHash(ctx, newHashBytes)
-			ok, creds := GetSCRAMStoredCredentials(newHash)
+			newHash := password.LoadPasswordHash(ctx, newHashBytes)
+			ok, creds := password.GetSCRAMStoredCredentials(newHash)
 			require.True(t, ok)
-			require.Equal(t, bcryptCostToSCRAMIterCount[i], int64(creds.Iters))
+			require.Equal(t, password.BcryptCostToSCRAMIterCount[i], int64(creds.Iters))
 
 			// Check that converted hash can't be converted further.
-			ec, _, _, _, err := MaybeUpgradePasswordHash(ctx, &s.SV, cleartext, newHash)
+			autoUpgradePasswordHashesBool = security.AutoUpgradePasswordHashes.Get(&s.SV)
+			method = security.GetConfiguredPasswordHashMethod(ctx, &s.SV)
+
+			ec, _, _, _, err := password.MaybeUpgradePasswordHash(ctx, autoUpgradePasswordHashesBool, method, cleartext, newHash)
 			require.NoError(t, err)
 			require.False(t, ec)
 		})

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -120,6 +120,7 @@ go_library(
         "//pkg/rpc/nodedialer",
         "//pkg/scheduledjobs",
         "//pkg/security",
+        "//pkg/security/password",
         "//pkg/server/debug",
         "//pkg/server/diagnostics",
         "//pkg/server/diagnostics/diagnosticspb",

--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/password"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -420,7 +421,7 @@ WHERE id = $1`
 // The caller is responsible for ensuring that the username is normalized.
 // (CockroachDB has case-insensitive usernames, unlike PostgreSQL.)
 func (s *authenticationServer) verifyPasswordDBConsole(
-	ctx context.Context, username security.SQLUsername, password string,
+	ctx context.Context, username security.SQLUsername, passwordStr string,
 ) (valid bool, expired bool, err error) {
 	exists, _, canLoginDBConsole, _, _, pwRetrieveFn, err := sql.GetUserSessionInitInfo(
 		ctx,
@@ -444,7 +445,7 @@ func (s *authenticationServer) verifyPasswordDBConsole(
 		return false, true, nil
 	}
 
-	ok, err := security.CompareHashAndCleartextPassword(ctx, hashedPassword, password)
+	ok, err := password.CompareHashAndCleartextPassword(ctx, hashedPassword, passwordStr)
 	if ok && err == nil {
 		// Password authentication succeeded using cleartext.  If the
 		// stored hash was encoded using crdb-bcrypt, we might want to
@@ -456,7 +457,7 @@ func (s *authenticationServer) verifyPasswordDBConsole(
 		sql.MaybeUpgradeStoredPasswordHash(ctx,
 			s.sqlServer.execCfg,
 			username,
-			password, hashedPassword)
+			passwordStr, hashedPassword)
 	}
 	return ok, false, err
 }

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -282,6 +282,7 @@ go_library(
         "//pkg/rpc/nodedialer",
         "//pkg/scheduledjobs",
         "//pkg/security",
+        "//pkg/security/password",
         "//pkg/security/sessionrevival",
         "//pkg/server/pgurl",
         "//pkg/server/serverpb",

--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/clusterversion",
         "//pkg/col/coldata",
         "//pkg/security",
+        "//pkg/security/password",
         "//pkg/security/sessionrevival",
         "//pkg/server/serverpb",
         "//pkg/server/telemetry",

--- a/pkg/sql/pgwire/authenticator.go
+++ b/pkg/sql/pgwire/authenticator.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/password"
 )
 
 // Authenticator is a component of an AuthMethod that determines if the
@@ -31,6 +32,6 @@ type Authenticator = func(
 // authentication.
 type PasswordRetrievalFn = func(context.Context) (
 	expired bool,
-	pwHash security.PasswordHash,
+	pwHash password.PasswordHash,
 	_ error,
 )

--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -44,6 +44,7 @@ go_library(
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/roachpb",
         "//pkg/security",
+        "//pkg/security/password",
         "//pkg/server/telemetry",
         "//pkg/settings",
         "//pkg/settings/cluster",

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -43,7 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/password"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -6624,7 +6624,7 @@ table's zone configuration this will return NULL.`,
 			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				arg := []byte(tree.MustBeDBytes(args[0]))
 				ctx := evalCtx.Ctx()
-				isHashed, _, _, schemeName, _, err := security.CheckPasswordHashValidity(ctx, arg)
+				isHashed, _, _, schemeName, _, err := password.CheckPasswordHashValidity(ctx, arg)
 				if err != nil {
 					return tree.DNull, pgerror.WithCandidateCode(err, pgcode.Syntax)
 				}

--- a/pkg/sql/sessioninit/BUILD.bazel
+++ b/pkg/sql/sessioninit/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//pkg/kv",
         "//pkg/security",
+        "//pkg/security/password",
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog",

--- a/pkg/sql/sessioninit/cache.go
+++ b/pkg/sql/sessioninit/cache.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/password"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -72,7 +73,7 @@ type AuthInfo struct {
 	// CanLoginDBConsole is set to false if the user has NOLOGIN role option.
 	CanLoginDBConsole bool
 	// HashedPassword is the hashed password and can be nil.
-	HashedPassword security.PasswordHash
+	HashedPassword password.PasswordHash
 	// ValidUntil is the VALID UNTIL role option.
 	ValidUntil *tree.DTimestamp
 }

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/password"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
@@ -82,7 +83,7 @@ func GetUserSessionInitInfo(
 	canLoginDBConsole bool,
 	isSuperuser bool,
 	defaultSettings []sessioninit.SettingsCacheEntry,
-	pwRetrieveFn func(ctx context.Context) (expired bool, hashedPassword security.PasswordHash, err error),
+	pwRetrieveFn func(ctx context.Context) (expired bool, hashedPassword password.PasswordHash, err error),
 	err error,
 ) {
 	runFn := getUserInfoRunFn(execCfg, username, "get-user-timeout")
@@ -91,7 +92,7 @@ func GetUserSessionInitInfo(
 		// As explained above, for root we report that the user exists
 		// immediately, and delay retrieving the password until strictly
 		// necessary.
-		rootFn := func(ctx context.Context) (expired bool, ret security.PasswordHash, err error) {
+		rootFn := func(ctx context.Context) (expired bool, ret password.PasswordHash, err error) {
 			err = runFn(ctx, func(ctx context.Context) error {
 				authInfo, _, err := retrieveSessionInitInfoWithCache(ctx, execCfg, ie, username, databaseName)
 				if err != nil {
@@ -101,7 +102,7 @@ func GetUserSessionInitInfo(
 				return nil
 			})
 			if ret == nil {
-				ret = security.MissingPasswordHash
+				ret = password.MissingPasswordHash
 			}
 			// NB: Root user password does not expire.
 			return false /* expired */, ret, err
@@ -156,7 +157,7 @@ func GetUserSessionInitInfo(
 		authInfo.CanLoginDBConsole,
 		isSuperuser,
 		settingsEntries,
-		func(ctx context.Context) (expired bool, ret security.PasswordHash, err error) {
+		func(ctx context.Context) (expired bool, ret password.PasswordHash, err error) {
 			ret = authInfo.HashedPassword
 			if authInfo.ValidUntil != nil {
 				// NB: we compute the expiration as late as possible,
@@ -169,7 +170,7 @@ func GetUserSessionInitInfo(
 				}
 			}
 			if ret == nil {
-				ret = security.MissingPasswordHash
+				ret = password.MissingPasswordHash
 			}
 			return expired, ret, nil
 		},
@@ -262,7 +263,7 @@ func retrieveAuthInfo(
 			hashedPassword = []byte(*(v.(*tree.DBytes)))
 		}
 	}
-	aInfo.HashedPassword = security.LoadPasswordHash(ctx, hashedPassword)
+	aInfo.HashedPassword = password.LoadPasswordHash(ctx, hashedPassword)
 
 	if !aInfo.UserExists {
 		return aInfo, nil
@@ -638,11 +639,15 @@ func MaybeUpgradeStoredPasswordHash(
 	execCfg *ExecutorConfig,
 	username security.SQLUsername,
 	cleartext string,
-	currentHash security.PasswordHash,
+	currentHash password.PasswordHash,
 ) {
 	// This call also checks whether the conversion has been disabled by
 	// configuration.
-	converted, prevHash, newHash, newMethod, err := security.MaybeUpgradePasswordHash(ctx, &execCfg.Settings.SV, cleartext, currentHash)
+
+	autoUpgradePasswordHashesBool := security.AutoUpgradePasswordHashes.Get(&execCfg.Settings.SV)
+	hashMethod := security.GetConfiguredPasswordHashMethod(ctx, &execCfg.Settings.SV)
+
+	converted, prevHash, newHash, newMethod, err := password.MaybeUpgradePasswordHash(ctx, autoUpgradePasswordHashesBool, hashMethod, cleartext, currentHash)
 	if err != nil {
 		// We're not returning an error: clients should not be refused a
 		// session just because a password conversion failed.

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1666,6 +1666,7 @@ func TestLint(t *testing.T) {
 
 				stream.GrepNot("type name will be used as row.RowLimit by other packages, and that stutters; consider calling this Limit"),
 				stream.GrepNot("type name will be used as tracing.TracingMode by other packages, and that stutters; consider calling this Mode"),
+				stream.GrepNot("type name will be used as password.PasswordHash by other packages, and that stutters; consider calling this Hash"),
 			), func(s string) {
 				t.Errorf("\n%s", s)
 			}); err != nil {


### PR DESCRIPTION
This commit is to host the password logic in a separate package,
`security/password/`.

Release note: None