### PR TITLE
release-21.2: [CRDB-13531] ui: enable dropdown filtering on node diagnostics page

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/nodes/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/nodes/index.tsx
@@ -19,7 +19,11 @@ import { withRouter, RouteComponentProps } from "react-router-dom";
 
 import * as protos from "src/js/protos";
 import { refreshLiveness, refreshNodes } from "src/redux/apiReducers";
-import { nodesSummarySelector, NodesSummary } from "src/redux/nodes";
+import {
+  nodesSummarySelector,
+  NodesSummary,
+  LivenessStatus,
+} from "src/redux/nodes";
 import { AdminUIState } from "src/redux/state";
 import { LongToMoment } from "src/util/convert";
 import { FixLong } from "src/util/fixLong";
@@ -28,7 +32,11 @@ import {
   localityToString,
   NodeFilterList,
 } from "src/views/reports/components/nodeFilterList";
-
+import {
+  PageConfig,
+  PageConfigItem,
+} from "src/views/shared/components/pageconfig";
+import Dropdown, { DropdownOption } from "src/views/shared/components/dropdown";
 interface NodesOwnProps {
   nodesSummary: NodesSummary;
   refreshNodes: typeof refreshNodes;
@@ -261,10 +269,20 @@ const nodesTableRows: NodesTableRowParams[] = [
   },
 ];
 
+type LocalNodeState = { selectFilter: number | null };
 /**
  * Renders the Nodes Diagnostics Report page.
  */
-export class Nodes extends React.Component<NodesProps, {}> {
+export class Nodes extends React.Component<NodesProps, LocalNodeState> {
+  constructor(props: NodesProps) {
+    super(props);
+
+    this.state = {
+      selectFilter: _.isEmpty(getFilters(this.props.location))
+        ? LivenessStatus.NODE_STATUS_LIVE
+        : null,
+    };
+  }
   refresh(props = this.props) {
     props.refreshLiveness();
     props.refreshNodes();
@@ -327,7 +345,7 @@ export class Nodes extends React.Component<NodesProps, {}> {
 
   render() {
     const { nodesSummary } = this.props;
-    const { nodeStatusByID } = nodesSummary;
+    const { nodeStatusByID, livenessStatusByNodeID } = nodesSummary;
     if (_.isEmpty(nodesSummary.nodeIDs)) {
       return loading;
     }
@@ -349,6 +367,24 @@ export class Nodes extends React.Component<NodesProps, {}> {
         ),
       );
     }
+    if (this.state.selectFilter !== null) {
+      nodeIDsContext = nodeIDsContext.filter(nodeID => {
+        // For this context, if the user chooses active nodes,
+        // only include nodes with a liveness status of DEAD, LIVE
+        // or UNAVAILABLE (suspect).
+        if (this.state.selectFilter === LivenessStatus.NODE_STATUS_LIVE) {
+          return [
+            LivenessStatus.NODE_STATUS_DEAD,
+            LivenessStatus.NODE_STATUS_LIVE,
+            LivenessStatus.NODE_STATUS_UNAVAILABLE,
+          ].includes(livenessStatusByNodeID[nodeID]);
+        }
+        return (
+          livenessStatusByNodeID[nodeID] ===
+          LivenessStatus.NODE_STATUS_DECOMMISSIONED
+        );
+      });
+    }
 
     // Sort the node IDs and then convert them back to string for lookups.
     const orderedNodeIDs = nodeIDsContext
@@ -356,18 +392,17 @@ export class Nodes extends React.Component<NodesProps, {}> {
       .map(nodeID => nodeID.toString())
       .value();
 
-    if (_.isEmpty(orderedNodeIDs)) {
-      return (
-        <section className="section">
-          <h1 className="base-heading">Node Diagnostics</h1>
-          <NodeFilterList
-            nodeIDs={filters.nodeIDs}
-            localityRegex={filters.localityRegex}
-          />
-          <h2 className="base-heading">No nodes match the filters</h2>
-        </section>
-      );
-    }
+    const dropdownOptions: DropdownOption[] = [
+      {
+        value: LivenessStatus.NODE_STATUS_LIVE.toString(),
+        label: "Active Nodes",
+      },
+      {
+        value: LivenessStatus.NODE_STATUS_DECOMMISSIONED.toString(),
+        label: "Decommissioned Nodes",
+      },
+      { value: "", label: "All Nodes" },
+    ];
 
     return (
       <section className="section">
@@ -377,21 +412,52 @@ export class Nodes extends React.Component<NodesProps, {}> {
           nodeIDs={filters.nodeIDs}
           localityRegex={filters.localityRegex}
         />
-        <h2 className="base-heading">Nodes</h2>
-        <table className="nodes-table">
-          <tbody>
-            {_.map(nodesTableRows, (row, key) => {
-              return this.renderNodesTableRow(
-                orderedNodeIDs,
-                key,
-                row.title,
-                row.extract,
-                row.equality,
-                row.cellTitle,
-              );
-            })}
-          </tbody>
-        </table>
+        {!_.isEmpty(orderedNodeIDs) && <h2 className="base-heading">Nodes</h2>}
+        {_.isEmpty(filters) && (
+          <PageConfig>
+            <PageConfigItem>
+              <Dropdown
+                title="Node Selection"
+                options={dropdownOptions}
+                selected={
+                  this.state.selectFilter === null
+                    ? ""
+                    : this.state.selectFilter.toString()
+                }
+                onChange={selected =>
+                  this.setState({
+                    selectFilter:
+                      selected.value === "" ? null : parseInt(selected.value),
+                  })
+                }
+              />
+            </PageConfigItem>
+          </PageConfig>
+        )}
+        {_.isEmpty(orderedNodeIDs) ? (
+          <section className="section">
+            <NodeFilterList
+              nodeIDs={filters.nodeIDs}
+              localityRegex={filters.localityRegex}
+            />
+            <h2 className="base-heading">No nodes match the filters</h2>
+          </section>
+        ) : (
+          <table className="nodes-table">
+            <tbody>
+              {_.map(nodesTableRows, (row, key) => {
+                return this.renderNodesTableRow(
+                  orderedNodeIDs,
+                  key,
+                  row.title,
+                  row.extract,
+                  row.equality,
+                  row.cellTitle,
+                );
+              })}
+            </tbody>
+          </table>
+        )}
       </section>
     );
   }


### PR DESCRIPTION
Previosuly, when a user navigated to the node diagnostics
page all node regardless of status were listed. This is
inconvenient when the user only wants to see active nodes.
Therefore, this patch add a dropdown filter to allow users
to view active nodes, decomissioned nodes, or all nodes.

resolves #77333

Release note (ui change): add dropdown filter on the node
diagnostics page to view by active, decomissioned or all nodes.

Release justification: low risk, high benefit changes to existing functionality