### PR TITLE
roachpb: surface more accurate bytes scattered in AdminScatterResponse

### DIFF
--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -392,13 +392,11 @@ func (b *BufferingAdder) createInitialSplits(ctx context.Context) error {
 			continue
 		}
 		b.sink.stats.scatters++
-		if resp.MVCCStats != nil {
-			moved := sz(resp.MVCCStats.Total())
-			b.sink.stats.scatterMoved += moved
-			if moved > 0 {
-				log.VEventf(ctx, 1, "pre-split scattered %s in non-empty range %s",
-					moved, resp.RangeInfos[0].Desc.KeySpan().AsRawSpanWithNoLocals())
-			}
+		moved := sz(resp.ReplicasScatteredBytes)
+		b.sink.stats.scatterMoved += moved
+		if moved > 0 {
+			log.VEventf(ctx, 1, "pre-split scattered %s in non-empty range %s",
+				moved, resp.RangeInfos[0].Desc.KeySpan().AsRawSpanWithNoLocals())
 		}
 	}
 	scattersWait := timeutil.Since(beforeScatters)

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -451,12 +451,10 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int) error {
 					log.Warningf(ctx, "%s failed to scatter	: %v", b.name, err)
 				} else {
 					b.stats.scatters++
-					if resp.MVCCStats != nil {
-						moved := sz(resp.MVCCStats.Total())
-						b.stats.scatterMoved += moved
-						if moved > 0 {
-							log.VEventf(ctx, 1, "%s split scattered %s in non-empty range %s", b.name, moved, resp.RangeInfos[0].Desc.KeySpan().AsRawSpanWithNoLocals())
-						}
+					moved := sz(resp.ReplicasScatteredBytes)
+					b.stats.scatterMoved += moved
+					if moved > 0 {
+						log.VEventf(ctx, 1, "%s split scattered %s in non-empty range %s", b.name, moved, resp.RangeInfos[0].Desc.KeySpan().AsRawSpanWithNoLocals())
 					}
 				}
 			}

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -434,6 +434,8 @@ func (r *AdminScatterResponse) combine(c combinable) error {
 		}
 
 		r.RangeInfos = append(r.RangeInfos, otherR.RangeInfos...)
+		r.MVCCStats.Add(otherR.MVCCStats)
+		r.ReplicasScatteredBytes += otherR.ReplicasScatteredBytes
 	}
 	return nil
 }

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -1590,7 +1590,15 @@ message AdminScatterResponse {
   }
   reserved 2;
   repeated RangeInfo range_infos = 3 [(gogoproto.nullable) = false];
-  storage.enginepb.MVCCStats mvcc_stats = 4 [(gogoproto.customname) = "MVCCStats"];
+  storage.enginepb.MVCCStats mvcc_stats = 4 [
+    (gogoproto.customname) = "MVCCStats",
+    (gogoproto.nullable) = false];
+
+  // ReplicasScatteredBytes specifies the byte size of the ranges that were
+  // scattered
+  int64 replicas_scattered_bytes = 5;
+
+  // NB: if you add a field here, don't forget to update combine().
 }
 
 // AdminVerifyProtectedTimestampRequest is the argument to the

--- a/pkg/roachpb/api_test.go
+++ b/pkg/roachpb/api_test.go
@@ -234,6 +234,51 @@ func TestCombinable(t *testing.T) {
 		}, v1)
 
 	})
+
+	t.Run("AdminScatter", func(t *testing.T) {
+
+		// Test that AdminScatterResponse properly implement it.
+		ar1 := &AdminScatterResponse{
+			RangeInfos: []RangeInfo{{Desc: RangeDescriptor{
+				RangeID: 1,
+			}}},
+			MVCCStats: enginepb.MVCCStats{
+				LiveBytes: 1,
+				LiveCount: 1,
+				KeyCount:  1,
+			},
+			ReplicasScatteredBytes: 42,
+		}
+
+		if _, ok := interface{}(ar1).(combinable); !ok {
+			t.Fatalf("AdminScatterResponse does not implement combinable")
+		}
+
+		ar2 := &AdminScatterResponse{
+			RangeInfos: []RangeInfo{{Desc: RangeDescriptor{
+				RangeID: 2,
+			}}},
+			MVCCStats: enginepb.MVCCStats{
+				LiveBytes: 2,
+				LiveCount: 2,
+				KeyCount:  2,
+			},
+			ReplicasScatteredBytes: 42,
+		}
+
+		wantedAR := &AdminScatterResponse{
+			RangeInfos:             []RangeInfo{{Desc: RangeDescriptor{RangeID: 1}}, {Desc: RangeDescriptor{RangeID: 2}}},
+			MVCCStats:              enginepb.MVCCStats{LiveBytes: 3, LiveCount: 3, KeyCount: 3},
+			ReplicasScatteredBytes: 84,
+		}
+
+		require.NoError(t, ar1.combine(ar2))
+		require.NoError(t, ar1.combine(&AdminScatterResponse{}))
+
+		if !reflect.DeepEqual(ar1, wantedAR) {
+			t.Errorf("wanted %v, got %v", wantedAR, ar1)
+		}
+	})
 }
 
 // TestMustSetInner makes sure that calls to MustSetInner correctly reset the


### PR DESCRIPTION
This change approximates the byte size of all the replicas that
were moved as part of an AdminScatter request by comparing their
store IDs before and after the replicas are passed through the
replicate queue.

This change also fixes a bug where MVCCStats returned as part of the
AdminScatterResponse were not being combined. This would cause
misrepresentation of the stats if the scatter key span covered
more than one range.

Release note: None