### PR TITLE
bazel: rename @cockroach to @com_github_cockroachdb_cockroach

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -49,11 +49,11 @@ exports_files([
 # gazelle:resolve proto io/prometheus/client/metrics.proto @com_github_prometheus_client_model//io/prometheus/client:client_proto
 # gazelle:resolve proto go io/prometheus/client/metrics.proto @com_github_prometheus_client_model//go
 # gazelle:resolve go github.com/prometheus/client_model/go @com_github_prometheus_client_model//go
-# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/ccl/gssapiccl @cockroach//pkg/ccl/gssapiccl
-# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/cli_test @cockroach//pkg/cli:cli_test
-# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/sql/colflow_test @cockroach//pkg/sql/colflow:colflow_test
-# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/util/caller_test @cockroach//pkg/util/caller:caller_test
-# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/util/json_test @cockroach//pkg/util/json:json_test
+# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/ccl/gssapiccl @com_github_cockroachdb_cockroach//pkg/ccl/gssapiccl
+# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/cli_test @com_github_cockroachdb_cockroach//pkg/cli:cli_test
+# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/sql/colflow_test @com_github_cockroachdb_cockroach//pkg/sql/colflow:colflow_test
+# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/util/caller_test @com_github_cockroachdb_cockroach//pkg/util/caller:caller_test
+# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/util/json_test @com_github_cockroachdb_cockroach//pkg/util/json:json_test
 # gazelle:resolve go google.golang.org/genproto/googleapis/pubsub/v1 @org_golang_google_genproto//googleapis/pubsub/v1:pubsub
 # gazelle:resolve go google.golang.org/genproto/googleapis/cloud/kms/v1 @org_golang_google_genproto//googleapis/cloud/kms/v1:kms
 

--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -896,7 +896,7 @@ def go_deps():
         importpath = "github.com/buchgr/bazel-remote",
         patch_args = ["-p1"],
         patches = [
-            "@cockroach//build/patches:com_github_buchgr_bazel_remote.patch",
+            "@com_github_cockroachdb_cockroach//build/patches:com_github_buchgr_bazel_remote.patch",
         ],
         sha256 = "7ab70784fddbc59e956501b2bc15a30c36baedb34df0d26009607d80c9e129e2",
         strip_prefix = "github.com/buchgr/bazel-remote@v1.3.3",
@@ -1300,7 +1300,7 @@ def go_deps():
         importpath = "github.com/cockroachdb/errors",
         patch_args = ["-p1"],
         patches = [
-            "@cockroach//build/patches:com_github_cockroachdb_errors.patch",
+            "@com_github_cockroachdb_cockroach//build/patches:com_github_cockroachdb_errors.patch",
         ],
         sha256 = "ff3814544271799c80da14dadfe408efc4f66e02cbdf17b73e81614ed9f7ae43",
         strip_prefix = "github.com/cockroachdb/errors@v1.9.0",
@@ -1345,7 +1345,7 @@ def go_deps():
         importpath = "github.com/cockroachdb/pebble",
         patch_args = ["-p1"],
         patches = [
-            "@cockroach//build/patches:com_github_cockroachdb_pebble.patch",
+            "@com_github_cockroachdb_cockroach//build/patches:com_github_cockroachdb_pebble.patch",
         ],
         sha256 = "5b3237c6bcbfc1085831ddf636ce4b4243211f754ceabe9b8fd9bf8962629a12",
         strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20220322040433-6164579cf2cb",
@@ -3240,7 +3240,7 @@ def go_deps():
         importpath = "github.com/gogo/protobuf",
         patch_args = ["-p1"],
         patches = [
-            "@cockroach//build/patches:com_github_gogo_protobuf.patch",
+            "@com_github_cockroachdb_cockroach//build/patches:com_github_gogo_protobuf.patch",
         ],
         sha256 = "dd2b73f163c8183941626360196c8f844addd95423d341a0412e1b22d0104ff7",
         strip_prefix = "github.com/gogo/protobuf@v1.3.2",
@@ -3384,7 +3384,7 @@ def go_deps():
         importpath = "github.com/golang/protobuf",
         patch_args = ["-p1"],
         patches = [
-            "@cockroach//build/patches:com_github_golang_protobuf.patch",
+            "@com_github_cockroachdb_cockroach//build/patches:com_github_golang_protobuf.patch",
         ],
         sha256 = "5d1c817bebc1202ab3b42a418e584e0008e8027baf212ce69c2ae3e9e7b8c64b",
         strip_prefix = "github.com/golang/protobuf@v1.5.2",
@@ -3749,7 +3749,7 @@ def go_deps():
         importpath = "github.com/grpc-ecosystem/grpc-gateway",
         patch_args = ["-p1"],
         patches = [
-            "@cockroach//build/patches:com_github_grpc_ecosystem_grpc_gateway.patch",
+            "@com_github_cockroachdb_cockroach//build/patches:com_github_grpc_ecosystem_grpc_gateway.patch",
         ],
         sha256 = "377b03aef288b34ed894449d3ddba40d525dd7fb55de6e79045cdf499e7fe565",
         strip_prefix = "github.com/grpc-ecosystem/grpc-gateway@v1.16.0",
@@ -4873,7 +4873,7 @@ def go_deps():
         importpath = "github.com/kisielk/errcheck",
         patch_args = ["-p1"],
         patches = [
-            "@cockroach//build/patches:com_github_kisielk_errcheck.patch",
+            "@com_github_cockroachdb_cockroach//build/patches:com_github_kisielk_errcheck.patch",
         ],
         sha256 = "99d3220891162cb684f8e05d54f3d0dc58abdd496a2f0cfda7fd4a28917a719e",
         strip_prefix = "github.com/kisielk/errcheck@v1.6.1-0.20210625163953-8ddee489636a",
@@ -4957,7 +4957,7 @@ def go_deps():
         importpath = "github.com/knz/go-libedit",
         patch_args = ["-p1"],
         patches = [
-            "@cockroach//build/patches:com_github_knz_go_libedit.patch",
+            "@com_github_cockroachdb_cockroach//build/patches:com_github_knz_go_libedit.patch",
         ],
         sha256 = "d2ae0f8e43c49f917a2cadf52178c0efe1336fda5b8410a3d0f1270ae05d2532",
         strip_prefix = "github.com/otan-cockroach/go-libedit@v1.10.2-0.20201030151939-7cced08450e7",
@@ -6651,7 +6651,7 @@ def go_deps():
         importpath = "github.com/prometheus/client_model",
         patch_args = ["-p1"],
         patches = [
-            "@cockroach//build/patches:com_github_prometheus_client_model.patch",
+            "@com_github_cockroachdb_cockroach//build/patches:com_github_prometheus_client_model.patch",
         ],
         sha256 = "44fc58fe25ed9b122b6755e8d356d5f199592f959af3b87a3b636c6eb82b43c5",
         strip_prefix = "github.com/prometheus/client_model@v0.2.1-0.20210607210712-147c58e9608a",
@@ -6735,7 +6735,7 @@ def go_deps():
         importpath = "github.com/pseudomuto/protoc-gen-doc",
         patch_args = ["-p1"],
         patches = [
-            "@cockroach//build/patches:com_github_pseudomuto_protoc_gen_doc.patch",
+            "@com_github_cockroachdb_cockroach//build/patches:com_github_pseudomuto_protoc_gen_doc.patch",
         ],
         sha256 = "ecf627d6f5b4e55d4844dda45612cbd152f0bc4dbe2ba182c7bc3ad1dc63ce5f",
         strip_prefix = "github.com/pseudomuto/protoc-gen-doc@v1.3.2",
@@ -8579,7 +8579,7 @@ def go_deps():
         importpath = "go.etcd.io/etcd/raft/v3",
         patch_args = ["-p1"],
         patches = [
-            "@cockroach//build/patches:io_etcd_go_etcd_raft_v3.patch",
+            "@com_github_cockroachdb_cockroach//build/patches:io_etcd_go_etcd_raft_v3.patch",
         ],
         sha256 = "62faedd81e10061a4e0d7476865a62b84121ea462514afeaa1b9d66cc53b5a4b",
         strip_prefix = "go.etcd.io/etcd/raft/v3@v3.0.0-20210320072418-e51c697ec6e8",
@@ -8913,7 +8913,7 @@ def go_deps():
         importpath = "go.opentelemetry.io/proto/otlp",
         patch_args = ["-p1"],
         patches = [
-            "@cockroach//build/patches:io_opentelemetry_go_proto_otlp.patch",
+            "@com_github_cockroachdb_cockroach//build/patches:io_opentelemetry_go_proto_otlp.patch",
         ],
         sha256 = "1a91376c923da07bee23439e8430c32736f6330532df85d3bd1ada90305097d7",
         strip_prefix = "go.opentelemetry.io/proto/otlp@v0.9.0",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,7 +1,7 @@
 # Define the top level namespace. This lets everything be addressable using
-# `@cockroach//...`.
+# `@com_github_cockroachdb_cockroach//...`.
 workspace(
-    name = "cockroach",
+    name = "com_github_cockroachdb_cockroach",
     managed_directories = {
         "@npm": ["pkg/ui/node_modules"],
     },
@@ -123,7 +123,7 @@ http_archive(
         "@io_bazel_rules_go//third_party:go_googleapis-deletebuild.patch",
         "@io_bazel_rules_go//third_party:go_googleapis-directives.patch",
         "@io_bazel_rules_go//third_party:go_googleapis-gazelle.patch",
-        "@cockroach//build/patches:go_googleapis.patch",
+        "@com_github_cockroachdb_cockroach//build/patches:go_googleapis.patch",
     ],
     sha256 = "a85c6a00e9cf0f004992ebea1d10688e3beea9f8e1a5a04ee53f367e72ee85af",
     strip_prefix = "googleapis-409e134ffaacc243052b08e6fb8e2d458014ed37",
@@ -168,7 +168,7 @@ go_download_sdk(
 
 go_rules_dependencies()
 
-go_register_toolchains(nogo = "@cockroach//:crdb_nogo")
+go_register_toolchains(nogo = "@com_github_cockroachdb_cockroach//:crdb_nogo")
 
 ###############################
 # end rules_go dependencies #

--- a/build/bazelutil/lint.bzl
+++ b/build/bazelutil/lint.bzl
@@ -29,7 +29,7 @@ _gen_script = rule(
     attrs = {
         "test": attr.label(mandatory = True),
         "_template": attr.label(
-            default = "@cockroach//build/bazelutil:lint.sh.in",
+            default = "@com_github_cockroachdb_cockroach//build/bazelutil:lint.sh.in",
             allow_single_file = True,
         ),
     },

--- a/build/bazelutil/lint.sh.in
+++ b/build/bazelutil/lint.sh.in
@@ -25,11 +25,11 @@ rlocation_ck () {
     echo $loc
 }
 
-test_bin="$(rlocation_ck cockroach/$PACKAGE/${NAME}_/$NAME)"
+test_bin="$(rlocation_ck com_github_cockroachdb_cockroach/$PACKAGE/${NAME}_/$NAME)"
 go_bin="$(rlocation_ck go_sdk/bin/go)"
 crlfmt_bin="$(rlocation_ck com_github_cockroachdb_crlfmt/crlfmt_/crlfmt)"
 golint_bin="$(rlocation_ck org_golang_x_lint/golint/golint_/golint)"
-optfmt_bin="$(rlocation_ck cockroach/pkg/sql/opt/optgen/cmd/optfmt/optfmt_/optfmt)"
+optfmt_bin="$(rlocation_ck com_github_cockroachdb_cockroach/pkg/sql/opt/optgen/cmd/optfmt/optfmt_/optfmt)"
 
 # Need to run this so that Go can find the runfiles.
 runfiles_export_envvars
@@ -41,7 +41,7 @@ fi
 
 cd "$BUILD_WORKSPACE_DIRECTORY/$PACKAGE"
 
-TEST_WORKSPACE=cockroach \
+TEST_WORKSPACE=com_github_cockroachdb_cockroach \
     PATH="$(dirname $go_bin):$(dirname $crlfmt_bin):$(dirname $golint_bin):$(dirname $optfmt_bin):$PATH" \
     GOROOT="$(dirname $(dirname $go_bin))" \
     "$test_bin" "$@"

--- a/build/toolchains/crosstool-ng/toolchain.bzl
+++ b/build/toolchains/crosstool-ng/toolchain.bzl
@@ -13,7 +13,7 @@ def _impl(rctx):
 
     rctx.template(
         "BUILD",
-        Label("@cockroach//build:toolchains/crosstool-ng/BUILD.tmpl"),
+        Label("@com_github_cockroachdb_cockroach//build:toolchains/crosstool-ng/BUILD.tmpl"),
         substitutions = {
             "%{host}": rctx.attr.host,
             "%{target}": rctx.attr.target,
@@ -22,7 +22,7 @@ def _impl(rctx):
     )
     rctx.template(
         "cc_toolchain_config.bzl",
-        Label("@cockroach//build:toolchains/crosstool-ng/cc_toolchain_config.bzl.tmpl"),
+        Label("@com_github_cockroachdb_cockroach//build:toolchains/crosstool-ng/cc_toolchain_config.bzl.tmpl"),
         substitutions = {
             "%{target}": rctx.attr.target,
             "%{host}": rctx.attr.host,

--- a/build/toolchains/darwin/toolchain.bzl
+++ b/build/toolchains/darwin/toolchain.bzl
@@ -15,7 +15,7 @@ def _impl(rctx):
 
     rctx.template(
         "BUILD",
-        Label("@cockroach//build:toolchains/darwin/BUILD.tmpl"),
+        Label("@com_github_cockroachdb_cockroach//build:toolchains/darwin/BUILD.tmpl"),
         substitutions = {
             "%{host}": rctx.attr.host,
             "%{target}": rctx.attr.target,
@@ -24,7 +24,7 @@ def _impl(rctx):
     )
     rctx.template(
         "cc_toolchain_config.bzl",
-        Label("@cockroach//build:toolchains/darwin/cc_toolchain_config.bzl.tmpl"),
+        Label("@com_github_cockroachdb_cockroach//build:toolchains/darwin/cc_toolchain_config.bzl.tmpl"),
         substitutions = {
             "%{host}": rctx.attr.host,
             "%{repo_path}": repo_path,

--- a/build/toolchains/dev/darwin-x86_64/toolchain.bzl
+++ b/build/toolchains/dev/darwin-x86_64/toolchain.bzl
@@ -27,12 +27,12 @@ def _impl(rctx):
 
     rctx.template(
         "BUILD",
-        Label("@cockroach//build:toolchains/dev/darwin-x86_64/BUILD.darwin-x86_64"),
+        Label("@com_github_cockroachdb_cockroach//build:toolchains/dev/darwin-x86_64/BUILD.darwin-x86_64"),
         executable = False,
     )
     rctx.template(
         "cc_toolchain_config.bzl",
-        Label("@cockroach//build:toolchains/dev/darwin-x86_64/cc_toolchain_config.bzl.tmpl"),
+        Label("@com_github_cockroachdb_cockroach//build:toolchains/dev/darwin-x86_64/cc_toolchain_config.bzl.tmpl"),
         substitutions = {
             "%{repo_path}": repo_path,
             "%{sdk_path}": sdk_path,

--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -179,7 +179,7 @@ go_test(
         "split_and_scatter_processor_test.go",
         "system_schema_test.go",
     ],
-    data = glob(["testdata/**"]) + ["@cockroach//c-deps:libgeos"],
+    data = glob(["testdata/**"]) + ["@com_github_cockroachdb_cockroach//c-deps:libgeos"],
     embed = [":backupccl"],
     shard_count = 16,
     deps = [

--- a/pkg/ccl/gssapiccl/BUILD.bazel
+++ b/pkg/ccl/gssapiccl/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
         "//conditions:default": ["empty.go"],
     }),
     cdeps = select({
-        "@io_bazel_rules_go//go/platform:linux_amd64": ["@cockroach//c-deps:libkrb5"],
+        "@io_bazel_rules_go//go/platform:linux_amd64": ["@com_github_cockroachdb_cockroach//c-deps:libkrb5"],
         "//conditions:default": [],
     }),
     cgo = True,

--- a/pkg/ccl/importerccl/BUILD.bazel
+++ b/pkg/ccl/importerccl/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
     ],
     data = [
         "//pkg/sql/importer:testdata",
-        "@cockroach//c-deps:libgeos",
+        "@com_github_cockroachdb_cockroach//c-deps:libgeos",
     ],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/BUILD.bazel
+++ b/pkg/ccl/logictestccl/BUILD.bazel
@@ -16,7 +16,7 @@ go_test(
     ],
     data = glob(["testdata/**"]) + [
         "//pkg/sql/logictest:testdata",
-        "@cockroach//c-deps:libgeos",
+        "@com_github_cockroachdb_cockroach//c-deps:libgeos",
     ],
     embed = [":logictestccl"],
     deps = [

--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -68,7 +68,7 @@ go_library(
     ],
     # keep
     cdeps = [
-        "@cockroach//c-deps:libjemalloc",
+        "@com_github_cockroachdb_cockroach//c-deps:libjemalloc",
     ],
     cgo = True,
     # keep

--- a/pkg/cmd/mirror/mirror.go
+++ b/pkg/cmd/mirror/mirror.go
@@ -370,7 +370,7 @@ func dumpPatchArgsForRepo(repoName string) error {
 	if _, err := os.Stat(candidate); err == nil {
 		fmt.Printf(`        patch_args = ["-p1"],
         patches = [
-            "@cockroach//build/patches:%s.patch",
+            "@com_github_cockroachdb_cockroach//build/patches:%s.patch",
         ],
 `, repoName)
 	} else if !os.IsNotExist(err) {

--- a/pkg/geo/geogfn/BUILD.bazel
+++ b/pkg/geo/geogfn/BUILD.bazel
@@ -48,7 +48,7 @@ go_test(
         "topology_operations_test.go",
         "unary_operators_test.go",
     ],
-    data = ["@cockroach//c-deps:libgeos"],
+    data = ["@com_github_cockroachdb_cockroach//c-deps:libgeos"],
     embed = [":geogfn"],
     deps = [
         "//pkg/geo",

--- a/pkg/geo/geoindex/BUILD.bazel
+++ b/pkg/geo/geoindex/BUILD.bazel
@@ -36,7 +36,7 @@ go_test(
         "s2_geometry_index_test.go",
         "utils_test.go",
     ],
-    data = glob(["testdata/**"]) + ["@cockroach//c-deps:libgeos"],
+    data = glob(["testdata/**"]) + ["@com_github_cockroachdb_cockroach//c-deps:libgeos"],
     embed = [":geoindex"],
     deps = [
         "//pkg/geo",

--- a/pkg/geo/geomfn/BUILD.bazel
+++ b/pkg/geo/geomfn/BUILD.bazel
@@ -99,7 +99,7 @@ go_test(
         "validity_check_test.go",
         "voronoi_test.go",
     ],
-    data = ["@cockroach//c-deps:libgeos"],
+    data = ["@com_github_cockroachdb_cockroach//c-deps:libgeos"],
     embed = [":geomfn"],
     deps = [
         "//pkg/geo",

--- a/pkg/geo/geoproj/BUILD.bazel
+++ b/pkg/geo/geoproj/BUILD.bazel
@@ -13,7 +13,7 @@ go_library(
     # autogenerating them.
     #
     # keep
-    cdeps = ["@cockroach//c-deps:libproj"],
+    cdeps = ["@com_github_cockroachdb_cockroach//c-deps:libproj"],
     cgo = True,
     # keep
     clinkopts = select({

--- a/pkg/geo/geos/BUILD.bazel
+++ b/pkg/geo/geos/BUILD.bazel
@@ -67,7 +67,7 @@ go_test(
     name = "geos_test",
     size = "small",
     srcs = ["geos_test.go"],
-    data = ["@cockroach//c-deps:libgeos"],
+    data = ["@com_github_cockroachdb_cockroach//c-deps:libgeos"],
     embed = [":geos"],
     deps = [
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/internal/sqlsmith/BUILD.bazel
+++ b/pkg/internal/sqlsmith/BUILD.bazel
@@ -44,7 +44,7 @@ go_test(
         "main_test.go",
         "sqlsmith_test.go",
     ],
-    data = ["@cockroach//c-deps:libgeos"],
+    data = ["@com_github_cockroachdb_cockroach//c-deps:libgeos"],
     embed = [":sqlsmith"],
     deps = [
         "//pkg/base",

--- a/pkg/server/status/BUILD.bazel
+++ b/pkg/server/status/BUILD.bazel
@@ -14,7 +14,7 @@ go_library(
     ],
     # keep
     cdeps = [
-        "@cockroach//c-deps:libjemalloc",
+        "@com_github_cockroachdb_cockroach//c-deps:libjemalloc",
     ],
     cgo = True,
     # keep

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -573,7 +573,7 @@ go_test(
         "zone_test.go",
     ],
     data = glob(["testdata/**"]) + [
-        "@cockroach//c-deps:libgeos",
+        "@com_github_cockroachdb_cockroach//c-deps:libgeos",
         "//pkg/sql:information_schema.go",
         "//pkg/sql:pg_catalog.go",
         "//pkg/sql/vtable:information_schema.go",

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -146,7 +146,7 @@ go_test(
         "testutils_test.go",
     ],
     data = glob(["testdata/**"]) + [
-        "@cockroach//c-deps:libgeos",
+        "@com_github_cockroachdb_cockroach//c-deps:libgeos",
     ],
     embed = [":importer"],
     # It's a large test, so use 16 shards to run test cases.

--- a/pkg/sql/logictest/BUILD.bazel
+++ b/pkg/sql/logictest/BUILD.bazel
@@ -64,7 +64,7 @@ go_test(
     ],
     data = [
         ":testdata",
-        "@cockroach//c-deps:libgeos",
+        "@com_github_cockroachdb_cockroach//c-deps:libgeos",
         "@com_github_cockroachdb_sqllogictest//:testfiles",
     ],
     embed = [":logictest"],

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -61,7 +61,7 @@ go_test(
         "mutation_test.go",
     ],
     data = glob(["testdata/**"]) + [
-        "@cockroach//c-deps:libgeos",
+        "@com_github_cockroachdb_cockroach//c-deps:libgeos",
     ],
     embed = [":execbuilder"],
     shard_count = 16,

--- a/pkg/sql/opt/memo/BUILD.bazel
+++ b/pkg/sql/opt/memo/BUILD.bazel
@@ -67,7 +67,7 @@ go_test(
         "typing_test.go",
     ],
     data = glob(["testdata/**"]) + [
-        "@cockroach//c-deps:libgeos",
+        "@com_github_cockroachdb_cockroach//c-deps:libgeos",
         "//pkg/sql/opt/testutils/opttester:testfixtures",
     ],
     embed = [":memo"],

--- a/pkg/sql/opt/norm/BUILD.bazel
+++ b/pkg/sql/opt/norm/BUILD.bazel
@@ -67,7 +67,7 @@ go_test(
         "norm_test.go",
     ],
     data = glob(["testdata/**"]) + [
-        "@cockroach//c-deps:libgeos",
+        "@com_github_cockroachdb_cockroach//c-deps:libgeos",
         "//pkg/sql/opt/testutils/opttester:testfixtures",
     ],
     embed = [":norm"],

--- a/pkg/sql/opt/xform/BUILD.bazel
+++ b/pkg/sql/opt/xform/BUILD.bazel
@@ -69,7 +69,7 @@ go_test(
         "physical_props_test.go",
     ],
     data = glob(["testdata/**"]) + [
-        "@cockroach//c-deps:libgeos",
+        "@com_github_cockroachdb_cockroach//c-deps:libgeos",
         "//pkg/sql/opt/testutils/opttester:testfixtures",
     ],
     embed = [":xform"],

--- a/pkg/util/fsm/gen/REPORTS.bzl
+++ b/pkg/util/fsm/gen/REPORTS.bzl
@@ -22,7 +22,7 @@ _gen_template = rule(
         "transitions_variable": attr.string(mandatory = True),
         "starting_state_name": attr.string(mandatory = True),
         "_template": attr.label(
-            default = Label("@cockroach//pkg/util/fsm/gen:write_reports.go.tmpl"),
+            default = Label("@com_github_cockroachdb_cockroach//pkg/util/fsm/gen:write_reports.go.tmpl"),
             allow_single_file = True,
         ),
     },

--- a/pkg/util/interval/generic/gen.bzl
+++ b/pkg/util/interval/generic/gen.bzl
@@ -4,7 +4,7 @@ def gen_interval_btree(name, type, package):
     test_out = munged_type + "_interval_btree_test.go"
     native.genrule(
         name = name,
-        srcs = ["@cockroach//pkg/util/interval/generic:gen_srcs"],
+        srcs = ["@com_github_cockroachdb_cockroach//pkg/util/interval/generic:gen_srcs"],
         outs = [src_out, test_out],
         tools = [
             "@com_github_cockroachdb_crlfmt//:crlfmt",
@@ -12,7 +12,7 @@ def gen_interval_btree(name, type, package):
         ],
         cmd = """
         export PATH=$$(dirname $(location @com_github_cockroachdb_crlfmt//:crlfmt)):$$(dirname $(location @com_github_mmatczuk_go_generics//cmd/go_generics)):$$PATH
-        SCRIPT_LOC=$$(echo $(locations @cockroach//pkg/util/interval/generic:gen_srcs) | grep -o '[^ ]*\\.sh')
+        SCRIPT_LOC=$$(echo $(locations @com_github_cockroachdb_cockroach//pkg/util/interval/generic:gen_srcs) | grep -o '[^ ]*\\.sh')
         $$SCRIPT_LOC {type} {package}
         mv {src_out} $(location {src_out})
         mv {test_out} $(location {test_out})


### PR DESCRIPTION
This further complies with how other repos may import CockroachDB using
bazel.

Release note: None