### PR TITLE
kvserver: time upreplication with in-memory engine and without sync

### DIFF
--- a/pkg/server/admin_cluster_test.go
+++ b/pkg/server/admin_cluster_test.go
@@ -79,7 +79,7 @@ func TestAdminAPIDatabaseDetails(t *testing.T) {
 }
 
 func TestAdminAPITableStats(t *testing.T) {
-	defer leaktest.AfterTest(t)()
+	// defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
 	const nodeCount = 3
@@ -91,6 +91,9 @@ func TestAdminAPITableStats(t *testing.T) {
 			ScanMaxIdleTime: time.Millisecond,
 		},
 	})
+
+	return // HACK
+
 	defer tc.Stopper().Stop(context.Background())
 	server0 := tc.Server(0)
 

--- a/stderr.txt
+++ b/stderr.txt
@@ -1,0 +1,8 @@
+
+real	0m0.968s
+user	0m0.294s
+sys	0m0.094s
+
+real	0m2.672s
+user	0m1.354s
+sys	0m0.328s

--- a/stdout.txt
+++ b/stdout.txt
@@ -1,0 +1,21 @@
+local: stopping and waiting.
+local: wiping
+13:35:14 local.go:80: Deleting local cluster local
+13:35:14 roachprod.go:1117: OK
+13:35:15 roachprod.go:1240: Creating cluster local with 3 nodes
+13:35:15 cluster_synced.go:1212: [31mWARNING: Source file is a symlink.[0m
+13:35:15 cluster_synced.go:1213: [31mWARNING: Remote file will inherit the target permissions '-rwxr-xr-x'.[0m
+13:35:15 cluster_synced.go:1228: local: putting ./cockroach cockroach
+13:35:15 cockroach.go:166: local: starting nodes
+13:35:15 cockroach.go:204: local: initializing cluster
+13:35:15 cockroach.go:211: warning: --url specifies user/password, but command "init" does not accept user/password details - details ignored
+Cluster successfully initialized
+13:35:15 cockroach.go:218: local: setting cluster settings
+13:35:16 cockroach.go:224: SET CLUSTER SETTING
+SET CLUSTER SETTING
+SET CLUSTER SETTING
+SET CLUSTER SETTING
+crdb_internal.force_retry
+count
+44
+PASS

--- a/time-upreplication.sh
+++ b/time-upreplication.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+roachprod destroy local || true
+roachprod create -n 3 local
+roachprod put local ./cockroach
+
+mkdir -p $HOME/local/{1,2,3}/data
+
+roachprod start local -a --store=type=mem,size=1G -e COCKROACH_SCAN_INTERVAL=1ms -e COCKROACH_SCAN_MAX_IDLE_TIME=1ms -e COCKROACH_SCAN_MIN_IDLE_TIME=1ms
+
+time roachprod sql local:1 -- -e "
+set cluster setting kv.raft_log.disable_synchronization_unsafe=true;
+select crdb_internal.force_retry('3100ms') from crdb_internal.ranges_no_leases where array_length(replicas, 1) < 3;
+
+select count(range_id) from crdb_internal.ranges_no_leases where array_length(replicas, 1) >= 3;
+"
+
+go test -c ./pkg/server
+time ./server.test -test.run '^TestAdminAPITableStats'


### PR DESCRIPTION
This takes minutes with stock settings.

Release note: None
