### PR TITLE
dev: bump version

### DIFF
--- a/dev
+++ b/dev
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=29
+DEV_VERSION=30
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions


### PR DESCRIPTION
Problems with `dev generate cgo` have been [noticed](https://github.com/cockroachdb/cockroach/pull/79455#issuecomment-1106548182)
that are resolved if you re-build.

Release note: None