### PR TITLE
bazel: remove unnecessary `@com_github_cockroachdb_cockroach` prefix

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -49,11 +49,11 @@ exports_files([
 # gazelle:resolve proto io/prometheus/client/metrics.proto @com_github_prometheus_client_model//io/prometheus/client:client_proto
 # gazelle:resolve proto go io/prometheus/client/metrics.proto @com_github_prometheus_client_model//go
 # gazelle:resolve go github.com/prometheus/client_model/go @com_github_prometheus_client_model//go
-# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/ccl/gssapiccl @com_github_cockroachdb_cockroach//pkg/ccl/gssapiccl
-# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/cli_test @com_github_cockroachdb_cockroach//pkg/cli:cli_test
-# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/sql/colflow_test @com_github_cockroachdb_cockroach//pkg/sql/colflow:colflow_test
-# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/util/caller_test @com_github_cockroachdb_cockroach//pkg/util/caller:caller_test
-# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/util/json_test @com_github_cockroachdb_cockroach//pkg/util/json:json_test
+# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/ccl/gssapiccl //pkg/ccl/gssapiccl
+# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/cli_test //pkg/cli:cli_test
+# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/sql/colflow_test //pkg/sql/colflow:colflow_test
+# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/util/caller_test //pkg/util/caller:caller_test
+# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/util/json_test //pkg/util/json:json_test
 # gazelle:resolve go google.golang.org/genproto/googleapis/pubsub/v1 @org_golang_google_genproto//googleapis/pubsub/v1:pubsub
 # gazelle:resolve go google.golang.org/genproto/googleapis/cloud/kms/v1 @org_golang_google_genproto//googleapis/cloud/kms/v1:kms
 

--- a/build/bazelutil/lint.bzl
+++ b/build/bazelutil/lint.bzl
@@ -29,7 +29,7 @@ _gen_script = rule(
     attrs = {
         "test": attr.label(mandatory = True),
         "_template": attr.label(
-            default = "@com_github_cockroachdb_cockroach//build/bazelutil:lint.sh.in",
+            default = "//build/bazelutil:lint.sh.in",
             allow_single_file = True,
         ),
     },

--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -179,7 +179,7 @@ go_test(
         "split_and_scatter_processor_test.go",
         "system_schema_test.go",
     ],
-    data = glob(["testdata/**"]) + ["@com_github_cockroachdb_cockroach//c-deps:libgeos"],
+    data = glob(["testdata/**"]) + ["//c-deps:libgeos"],
     embed = [":backupccl"],
     shard_count = 16,
     deps = [

--- a/pkg/ccl/gssapiccl/BUILD.bazel
+++ b/pkg/ccl/gssapiccl/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
         "//conditions:default": ["empty.go"],
     }),
     cdeps = select({
-        "@io_bazel_rules_go//go/platform:linux_amd64": ["@com_github_cockroachdb_cockroach//c-deps:libkrb5"],
+        "@io_bazel_rules_go//go/platform:linux_amd64": ["//c-deps:libkrb5"],
         "//conditions:default": [],
     }),
     cgo = True,

--- a/pkg/ccl/importerccl/BUILD.bazel
+++ b/pkg/ccl/importerccl/BUILD.bazel
@@ -7,8 +7,8 @@ go_test(
         "main_test.go",
     ],
     data = [
+        "//c-deps:libgeos",
         "//pkg/sql/importer:testdata",
-        "@com_github_cockroachdb_cockroach//c-deps:libgeos",
     ],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/BUILD.bazel
+++ b/pkg/ccl/logictestccl/BUILD.bazel
@@ -16,7 +16,7 @@ go_test(
     ],
     data = glob(["testdata/**"]) + [
         "//pkg/sql/logictest:testdata",
-        "@com_github_cockroachdb_cockroach//c-deps:libgeos",
+        "//c-deps:libgeos",
     ],
     embed = [":logictestccl"],
     deps = [

--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -68,7 +68,7 @@ go_library(
     ],
     # keep
     cdeps = [
-        "@com_github_cockroachdb_cockroach//c-deps:libjemalloc",
+        "//c-deps:libjemalloc",
     ],
     cgo = True,
     # keep

--- a/pkg/geo/geogfn/BUILD.bazel
+++ b/pkg/geo/geogfn/BUILD.bazel
@@ -48,7 +48,7 @@ go_test(
         "topology_operations_test.go",
         "unary_operators_test.go",
     ],
-    data = ["@com_github_cockroachdb_cockroach//c-deps:libgeos"],
+    data = ["//c-deps:libgeos"],
     embed = [":geogfn"],
     deps = [
         "//pkg/geo",

--- a/pkg/geo/geoindex/BUILD.bazel
+++ b/pkg/geo/geoindex/BUILD.bazel
@@ -36,7 +36,7 @@ go_test(
         "s2_geometry_index_test.go",
         "utils_test.go",
     ],
-    data = glob(["testdata/**"]) + ["@com_github_cockroachdb_cockroach//c-deps:libgeos"],
+    data = glob(["testdata/**"]) + ["//c-deps:libgeos"],
     embed = [":geoindex"],
     deps = [
         "//pkg/geo",

--- a/pkg/geo/geomfn/BUILD.bazel
+++ b/pkg/geo/geomfn/BUILD.bazel
@@ -99,7 +99,7 @@ go_test(
         "validity_check_test.go",
         "voronoi_test.go",
     ],
-    data = ["@com_github_cockroachdb_cockroach//c-deps:libgeos"],
+    data = ["//c-deps:libgeos"],
     embed = [":geomfn"],
     deps = [
         "//pkg/geo",

--- a/pkg/geo/geoproj/BUILD.bazel
+++ b/pkg/geo/geoproj/BUILD.bazel
@@ -13,7 +13,7 @@ go_library(
     # autogenerating them.
     #
     # keep
-    cdeps = ["@com_github_cockroachdb_cockroach//c-deps:libproj"],
+    cdeps = ["//c-deps:libproj"],
     cgo = True,
     # keep
     clinkopts = select({

--- a/pkg/geo/geos/BUILD.bazel
+++ b/pkg/geo/geos/BUILD.bazel
@@ -67,7 +67,7 @@ go_test(
     name = "geos_test",
     size = "small",
     srcs = ["geos_test.go"],
-    data = ["@com_github_cockroachdb_cockroach//c-deps:libgeos"],
+    data = ["//c-deps:libgeos"],
     embed = [":geos"],
     deps = [
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/internal/sqlsmith/BUILD.bazel
+++ b/pkg/internal/sqlsmith/BUILD.bazel
@@ -44,7 +44,7 @@ go_test(
         "main_test.go",
         "sqlsmith_test.go",
     ],
-    data = ["@com_github_cockroachdb_cockroach//c-deps:libgeos"],
+    data = ["//c-deps:libgeos"],
     embed = [":sqlsmith"],
     deps = [
         "//pkg/base",

--- a/pkg/server/status/BUILD.bazel
+++ b/pkg/server/status/BUILD.bazel
@@ -14,7 +14,7 @@ go_library(
     ],
     # keep
     cdeps = [
-        "@com_github_cockroachdb_cockroach//c-deps:libjemalloc",
+        "//c-deps:libjemalloc",
     ],
     cgo = True,
     # keep

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -573,7 +573,7 @@ go_test(
         "zone_test.go",
     ],
     data = glob(["testdata/**"]) + [
-        "@com_github_cockroachdb_cockroach//c-deps:libgeos",
+        "//c-deps:libgeos",
         "//pkg/sql:information_schema.go",
         "//pkg/sql:pg_catalog.go",
         "//pkg/sql/vtable:information_schema.go",

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -145,9 +145,7 @@ go_test(
         "read_import_pgdump_test.go",
         "testutils_test.go",
     ],
-    data = glob(["testdata/**"]) + [
-        "@com_github_cockroachdb_cockroach//c-deps:libgeos",
-    ],
+    data = glob(["testdata/**"]) + ["//c-deps:libgeos"],
     embed = [":importer"],
     # It's a large test, so use 16 shards to run test cases.
     # See https://docs.bazel.build/versions/master/be/common-definitions.html#test.shard_count

--- a/pkg/sql/logictest/BUILD.bazel
+++ b/pkg/sql/logictest/BUILD.bazel
@@ -64,7 +64,7 @@ go_test(
     ],
     data = [
         ":testdata",
-        "@com_github_cockroachdb_cockroach//c-deps:libgeos",
+        "//c-deps:libgeos",
         "@com_github_cockroachdb_sqllogictest//:testfiles",
     ],
     embed = [":logictest"],

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -60,9 +60,7 @@ go_test(
         "main_test.go",
         "mutation_test.go",
     ],
-    data = glob(["testdata/**"]) + [
-        "@com_github_cockroachdb_cockroach//c-deps:libgeos",
-    ],
+    data = glob(["testdata/**"]) + ["//c-deps:libgeos"],
     embed = [":execbuilder"],
     shard_count = 16,
     deps = [

--- a/pkg/sql/opt/memo/BUILD.bazel
+++ b/pkg/sql/opt/memo/BUILD.bazel
@@ -67,7 +67,7 @@ go_test(
         "typing_test.go",
     ],
     data = glob(["testdata/**"]) + [
-        "@com_github_cockroachdb_cockroach//c-deps:libgeos",
+        "//c-deps:libgeos",
         "//pkg/sql/opt/testutils/opttester:testfixtures",
     ],
     embed = [":memo"],

--- a/pkg/sql/opt/norm/BUILD.bazel
+++ b/pkg/sql/opt/norm/BUILD.bazel
@@ -67,7 +67,7 @@ go_test(
         "norm_test.go",
     ],
     data = glob(["testdata/**"]) + [
-        "@com_github_cockroachdb_cockroach//c-deps:libgeos",
+        "//c-deps:libgeos",
         "//pkg/sql/opt/testutils/opttester:testfixtures",
     ],
     embed = [":norm"],

--- a/pkg/sql/opt/xform/BUILD.bazel
+++ b/pkg/sql/opt/xform/BUILD.bazel
@@ -69,7 +69,7 @@ go_test(
         "physical_props_test.go",
     ],
     data = glob(["testdata/**"]) + [
-        "@com_github_cockroachdb_cockroach//c-deps:libgeos",
+        "//c-deps:libgeos",
         "//pkg/sql/opt/testutils/opttester:testfixtures",
     ],
     embed = [":xform"],

--- a/pkg/util/fsm/gen/REPORTS.bzl
+++ b/pkg/util/fsm/gen/REPORTS.bzl
@@ -22,7 +22,7 @@ _gen_template = rule(
         "transitions_variable": attr.string(mandatory = True),
         "starting_state_name": attr.string(mandatory = True),
         "_template": attr.label(
-            default = Label("@com_github_cockroachdb_cockroach//pkg/util/fsm/gen:write_reports.go.tmpl"),
+            default = Label("//pkg/util/fsm/gen:write_reports.go.tmpl"),
             allow_single_file = True,
         ),
     },

--- a/pkg/util/interval/generic/gen.bzl
+++ b/pkg/util/interval/generic/gen.bzl
@@ -4,7 +4,7 @@ def gen_interval_btree(name, type, package):
     test_out = munged_type + "_interval_btree_test.go"
     native.genrule(
         name = name,
-        srcs = ["@com_github_cockroachdb_cockroach//pkg/util/interval/generic:gen_srcs"],
+        srcs = ["//pkg/util/interval/generic:gen_srcs"],
         outs = [src_out, test_out],
         tools = [
             "@com_github_cockroachdb_crlfmt//:crlfmt",
@@ -12,7 +12,7 @@ def gen_interval_btree(name, type, package):
         ],
         cmd = """
         export PATH=$$(dirname $(location @com_github_cockroachdb_crlfmt//:crlfmt)):$$(dirname $(location @com_github_mmatczuk_go_generics//cmd/go_generics)):$$PATH
-        SCRIPT_LOC=$$(echo $(locations @com_github_cockroachdb_cockroach//pkg/util/interval/generic:gen_srcs) | grep -o '[^ ]*\\.sh')
+        SCRIPT_LOC=$$(echo $(locations //pkg/util/interval/generic:gen_srcs) | grep -o '[^ ]*\\.sh')
         $$SCRIPT_LOC {type} {package}
         mv {src_out} $(location {src_out})
         mv {test_out} $(location {test_out})


### PR DESCRIPTION
Release note: None