### PR TITLE
release-21.2: kv: send AddSSTable with BulkNormalPri

### DIFF
--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -668,6 +669,12 @@ func (db *DB) AddSSTable(
 	batchTs hlc.Timestamp,
 ) error {
 	b := &Batch{Header: roachpb.Header{Timestamp: batchTs}}
+	b.AdmissionHeader = roachpb.AdmissionHeader{
+		Priority:                 int32(admission.BulkNormalPri),
+		CreateTime:               timeutil.Now().UnixNano(),
+		Source:                   roachpb.AdmissionHeader_FROM_SQL,
+		NoMemoryReservedAtSource: true,
+	}
 	b.addSSTable(begin, end, data, disallowShadowing, stats, ingestAsWrites)
 	return getOneErr(db.Run(ctx, b), b)
 }


### PR DESCRIPTION
Manual backport of https://github.com/cockroachdb/cockroach/pull/79086.

Release note (bug fix): Bulk data sent to the KV storage layer is now sent at reduced admission control priority.

Release justification: bug fix.

Epic CRDB-2264