### PR TITLE
evalctx: remove more usages of evalctx txn when possible

### DIFF
--- a/pkg/sql/alter_role.go
+++ b/pkg/sql/alter_role.go
@@ -599,7 +599,7 @@ func (n *alterRoleSetNode) getSessionVarVal(params runParams) (string, error) {
 	var strVal string
 	var err error
 	if n.sVar.GetStringVal != nil {
-		strVal, err = n.sVar.GetStringVal(params.ctx, params.extendedEvalCtx, n.typedValues)
+		strVal, err = n.sVar.GetStringVal(params.ctx, params.extendedEvalCtx, n.typedValues, params.p.Txn())
 	} else {
 		// No string converter defined, use the default one.
 		strVal, err = getStringVal(params.EvalContext(), n.varName, n.typedValues)

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -545,7 +545,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 				}
 				if err := validateCheckInTxn(
 					params.ctx, &params.p.semaCtx, params.ExecCfg().InternalExecutorFactory,
-					params.SessionData(), n.tableDesc, params.EvalContext().Txn, ck.Expr,
+					params.SessionData(), n.tableDesc, params.p.Txn(), ck.Expr,
 				); err != nil {
 					return err
 				}
@@ -571,7 +571,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 					params.ExecCfg().InternalExecutorFactory,
 					params.p.SessionData(),
 					n.tableDesc,
-					params.EvalContext().Txn,
+					params.p.Txn(),
 					params.p.Descriptors(),
 					name,
 				); err != nil {
@@ -598,7 +598,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 					if err := validateUniqueWithoutIndexConstraintInTxn(
 						params.ctx, params.ExecCfg().InternalExecutorFactory(
 							params.ctx, params.SessionData(),
-						), n.tableDesc, params.EvalContext().Txn, name,
+						), n.tableDesc, params.p.Txn(), name,
 					); err != nil {
 						return err
 					}
@@ -1228,7 +1228,7 @@ func injectTableStats(
 	if _ /* rows */, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.Exec(
 		params.ctx,
 		"delete-stats",
-		params.EvalContext().Txn,
+		params.p.Txn(),
 		`DELETE FROM system.table_statistics WHERE "tableID" = $1`, desc.GetID(),
 	); err != nil {
 		return errors.Wrapf(err, "failed to delete old stats")
@@ -1290,7 +1290,7 @@ func insertJSONStatistic(
 	var (
 		ctx      = params.ctx
 		ie       = params.ExecCfg().InternalExecutor
-		txn      = params.EvalContext().Txn
+		txn      = params.p.Txn()
 		settings = params.ExecCfg().Settings
 	)
 

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -978,7 +978,7 @@ func (ex *connExecutor) createJobs(ctx context.Context) error {
 	for _, record := range ex.extraTxnState.schemaChangeJobRecords {
 		records = append(records, record)
 	}
-	jobIDs, err := ex.server.cfg.JobRegistry.CreateJobsWithTxn(ctx, ex.planner.extendedEvalCtx.Txn, records)
+	jobIDs, err := ex.server.cfg.JobRegistry.CreateJobsWithTxn(ctx, ex.planner.Txn(), records)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/control_schedules.go
+++ b/pkg/sql/control_schedules.go
@@ -67,7 +67,7 @@ func loadSchedule(params runParams, scheduleID tree.Datum) (*jobs.ScheduledJob, 
 	datums, cols, err := params.ExecCfg().InternalExecutor.QueryRowExWithCols(
 		params.ctx,
 		"load-schedule",
-		params.EvalContext().Txn, sessiondata.InternalExecutorOverride{User: security.RootUserName()},
+		params.p.Txn(), sessiondata.InternalExecutorOverride{User: security.RootUserName()},
 		fmt.Sprintf(
 			"SELECT schedule_id, next_run, schedule_expr, executor_type, execution_args FROM %s WHERE schedule_id = $1",
 			env.ScheduledJobsTableName(),
@@ -93,7 +93,7 @@ func updateSchedule(params runParams, schedule *jobs.ScheduledJob) error {
 	return schedule.Update(
 		params.ctx,
 		params.ExecCfg().InternalExecutor,
-		params.EvalContext().Txn,
+		params.p.Txn(),
 	)
 }
 

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1589,7 +1589,7 @@ CREATE TABLE crdb_internal.session_variables (
 	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		for _, vName := range varNames {
 			gen := varGen[vName]
-			value, err := gen.Get(&p.extendedEvalCtx)
+			value, err := gen.Get(&p.extendedEvalCtx, p.Txn())
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -760,7 +760,7 @@ func (pb *ProcessorBase) InitWithEvalCtx(
 	pb.MemMonitor = memMonitor
 
 	// Hydrate all types used in the processor.
-	resolver := flowCtx.NewTypeResolver(evalCtx.Txn)
+	resolver := flowCtx.NewTypeResolver(flowCtx.Txn)
 	if err := resolver.HydrateTypeSlice(evalCtx.Context, coreOutputTypes); err != nil {
 		return err
 	}

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1550,7 +1550,7 @@ var informationSchemaSessionVariables = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		for _, vName := range varNames {
 			gen := varGen[vName]
-			value, err := gen.Get(&p.extendedEvalCtx)
+			value, err := gen.Get(&p.extendedEvalCtx, p.Txn())
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1493,7 +1493,7 @@ func getComments(ctx context.Context, p *planner) ([]tree.Datums, error) {
 	return p.extendedEvalCtx.ExecCfg.InternalExecutor.QueryBuffered(
 		ctx,
 		"select-comments",
-		p.EvalContext().Txn,
+		p.Txn(),
 		`SELECT COALESCE(pc.object_id, sc.object_id) AS object_id,
               COALESCE(pc.sub_id, sc.sub_id) AS sub_id,
               COALESCE(pc.comment, sc.comment) AS comment,
@@ -3160,7 +3160,7 @@ https://www.postgresql.org/docs/13/catalog-pg-db-role-setting.html`,
 		rows, err := p.extendedEvalCtx.ExecCfg.InternalExecutor.QueryBufferedEx(
 			ctx,
 			"select-db-role-settings",
-			p.EvalContext().Txn,
+			p.Txn(),
 			sessiondata.InternalExecutorOverride{User: security.RootUserName()},
 			`SELECT database_id, role_name, settings FROM system.public.database_role_settings`,
 		)

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2505,7 +2505,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-settings.html`,
 			if gen.Hidden {
 				continue
 			}
-			value, err := gen.Get(&p.extendedEvalCtx)
+			value, err := gen.Get(&p.extendedEvalCtx, p.Txn())
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/rowexec/project_set.go
+++ b/pkg/sql/rowexec/project_set.go
@@ -105,7 +105,7 @@ func newProjectSetProcessor(
 	}
 
 	// Initialize exprHelpers.
-	semaCtx := ps.FlowCtx.NewSemaContext(ps.EvalCtx.Txn)
+	semaCtx := ps.FlowCtx.NewSemaContext(ps.FlowCtx.Txn)
 	for i, expr := range ps.spec.Exprs {
 		var helper execinfrapb.ExprHelper
 		err := helper.Init(expr, ps.input.OutputTypes(), semaCtx, ps.EvalCtx)

--- a/pkg/sql/rowflow/row_based_flow.go
+++ b/pkg/sql/rowflow/row_based_flow.go
@@ -286,7 +286,7 @@ func (f *rowBasedFlow) setupInputSyncs(
 			// than processors that scan over tables get their inputs from here, so
 			// this is a convenient place to do the hydration. Processors that scan
 			// over tables will have their hydration performed in ProcessorBase.Init.
-			resolver := f.NewTypeResolver(f.EvalCtx.Txn)
+			resolver := f.NewTypeResolver(f.FlowCtx.Txn)
 			if err := resolver.HydrateTypeSlice(ctx, is.ColumnTypes); err != nil {
 				return nil, err
 			}

--- a/pkg/sql/show_create_schedule.go
+++ b/pkg/sql/show_create_schedule.go
@@ -52,7 +52,7 @@ func loadSchedules(params runParams, n *tree.ShowCreateSchedules) ([]*jobs.Sched
 		datums, columns, err := params.ExecCfg().InternalExecutor.QueryRowExWithCols(
 			params.ctx,
 			"load-schedules",
-			params.EvalContext().Txn, sessiondata.InternalExecutorOverride{User: security.RootUserName()},
+			params.p.Txn(), sessiondata.InternalExecutorOverride{User: security.RootUserName()},
 			fmt.Sprintf("SELECT * FROM %s WHERE schedule_id = $1", env.ScheduledJobsTableName()),
 			tree.NewDInt(tree.DInt(sjID)))
 		if err != nil {
@@ -64,7 +64,7 @@ func loadSchedules(params runParams, n *tree.ShowCreateSchedules) ([]*jobs.Sched
 		datums, columns, err := params.ExecCfg().InternalExecutor.QueryBufferedExWithCols(
 			params.ctx,
 			"load-schedules",
-			params.EvalContext().Txn, sessiondata.InternalExecutorOverride{User: security.RootUserName()},
+			params.p.Txn(), sessiondata.InternalExecutorOverride{User: security.RootUserName()},
 			fmt.Sprintf("SELECT * FROM %s", env.ScheduledJobsTableName()))
 		if err != nil {
 			return nil, err

--- a/pkg/sql/show_var.go
+++ b/pkg/sql/show_var.go
@@ -39,7 +39,7 @@ func (s *showVarNode) Next(params runParams) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	s.val, err = v.Get(params.extendedEvalCtx)
+	s.val, err = v.Get(params.extendedEvalCtx, params.p.Txn())
 	return true, err
 }
 

--- a/pkg/sql/unsupported_vars.go
+++ b/pkg/sql/unsupported_vars.go
@@ -10,7 +10,10 @@
 
 package sql
 
-import "github.com/cockroachdb/cockroach/pkg/settings"
+import (
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+)
 
 // DummyVars contains a list of dummy vars we do not support that
 // PostgreSQL does, but are required as an easy fix to make certain
@@ -19,7 +22,7 @@ import "github.com/cockroachdb/cockroach/pkg/settings"
 var DummyVars = map[string]sessionVar{
 	"enable_seqscan": makeDummyBooleanSessionVar(
 		"enable_seqscan",
-		func(evalCtx *extendedEvalContext) (string, error) {
+		func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
 			return formatBoolAsPostgresSetting(evalCtx.SessionData().EnableSeqScan), nil
 		},
 		func(m sessionDataMutator, v bool) {
@@ -29,7 +32,7 @@ var DummyVars = map[string]sessionVar{
 	),
 	"synchronous_commit": makeDummyBooleanSessionVar(
 		"synchronous_commit",
-		func(evalCtx *extendedEvalContext) (string, error) {
+		func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
 			return formatBoolAsPostgresSetting(evalCtx.SessionData().SynchronousCommit), nil
 		},
 		func(m sessionDataMutator, v bool) {


### PR DESCRIPTION
evalctx: remove more instances of redundant evalctx Txn usage

Release note: None

evalctx: use Flow's Txn instead of EvalContext when possible

Release note: None

evalctx: remove usage of EvalContext txn from vars

Release note: None