### PR TITLE
release-21.2: migration: fix node race in pebble file registry migration

### DIFF
--- a/pkg/migration/migrations/records_based_registry.go
+++ b/pkg/migration/migrations/records_based_registry.go
@@ -22,9 +22,11 @@ import (
 func recordsBasedRegistryMigration(
 	ctx context.Context, cv clusterversion.ClusterVersion, deps migration.SystemDeps, _ *jobs.Job,
 ) error {
-	return deps.Cluster.ForEveryNode(ctx, "deprecate-base-encryption-registry", func(ctx context.Context, client serverpb.MigrationClient) error {
-		req := &serverpb.DeprecateBaseEncryptionRegistryRequest{Version: &cv.Version}
-		_, err := client.DeprecateBaseEncryptionRegistry(ctx, req)
-		return err
+	return deps.Cluster.UntilClusterStable(ctx, func() error {
+		return deps.Cluster.ForEveryNode(ctx, "deprecate-base-encryption-registry", func(ctx context.Context, client serverpb.MigrationClient) error {
+			req := &serverpb.DeprecateBaseEncryptionRegistryRequest{Version: &cv.Version}
+			_, err := client.DeprecateBaseEncryptionRegistry(ctx, req)
+			return err
+		})
 	})
 }


### PR DESCRIPTION
Currently, the Pebble file registry system migration is vulnerable to a
race condition where new nodes added in the middle of a migration will
fail to have their stores migrated.

Surround the migration block with a `UntilClusterStable` call, to ensure
that new nodes added during the system migration are also migrated.

Fix #74263.

Release note: None.

Release justification: fix for a low probability bug in a system migration.