### PR TITLE
roachtest: configure ORM tests to use SCRAM

### DIFF
--- a/pkg/cmd/roachtest/tests/orm_helpers.go
+++ b/pkg/cmd/roachtest/tests/orm_helpers.go
@@ -49,6 +49,9 @@ func alterZoneConfigAndClusterSettings(
 		`SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;`,
 		`SET CLUSTER SETTING kv.range_split.by_load_merge_delay = '5s';`,
 
+		// Test with SCRAM password authentication.
+		`SET CLUSTER SETTING server.user_login.password_encryption = 'scram-sha-256';`,
+
 		// Enable experimental features.
 		`SET CLUSTER SETTING sql.defaults.experimental_temporary_tables.enabled = 'true';`,
 		`SET CLUSTER SETTING sql.defaults.datestyle.enabled = true`,


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/80369
fixes https://github.com/cockroachdb/cockroach/issues/80367
fixes https://github.com/cockroachdb/cockroach/issues/80373
fixes https://github.com/cockroachdb/cockroach/issues/80370
fixes https://github.com/cockroachdb/cockroach/issues/80368
fixes https://github.com/cockroachdb/cockroach/issues/80371

SCRAM was disabled by default in the release-22.1 branch. This change
sets the setting explicitly so that we enable SCRAM testing
intentionally.

Release note: None