### PR TITLE
ccl/sqlproxyccl: split forward into newForwarder and run

### DIFF
--- a/pkg/ccl/sqlproxyccl/conn_migration.go
+++ b/pkg/ccl/sqlproxyccl/conn_migration.go
@@ -74,6 +74,11 @@ func (f *forwarder) tryBeginTransfer() (started bool, cleanupFn func()) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
+	// Forwarder hasn't been initialized.
+	if !f.isInitializedLocked() {
+		return false, nil
+	}
+
 	// Transfer is already in progress. No concurrent transfers are allowed.
 	if f.mu.isTransferring {
 		return false, nil

--- a/pkg/ccl/sqlproxyccl/conn_migration_test.go
+++ b/pkg/ccl/sqlproxyccl/conn_migration_test.go
@@ -57,6 +57,20 @@ func TestTransferContext(t *testing.T) {
 func TestForwarder_tryBeginTransfer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	t.Run("not_initialized", func(t *testing.T) {
+		defer testutils.TestingHook(&isSafeTransferPointLocked,
+			func(req *processor, res *processor) bool {
+				return false
+			},
+		)()
+
+		f := &forwarder{}
+
+		started, cleanupFn := f.tryBeginTransfer()
+		require.False(t, started)
+		require.Nil(t, cleanupFn)
+	})
+
 	t.Run("isTransferring=true", func(t *testing.T) {
 		f := &forwarder{}
 		f.mu.isTransferring = true


### PR DESCRIPTION
This commit is mostly mechanical as it splits the forward function into
newForwarder and run as discussed. Doing this allows us to create a forwarder
without having a server connection, which will prepare us for the new tracker
that tracks server connections instead of forwarders. If we don't do this,
we would end up having an awkward API to set the server connection's owner
(e.g. SetOwner) once the connection has been established.

Release note: None