### PR TITLE
sql: fix "no user specified" errors in statement bundles

### DIFF
--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -189,16 +189,25 @@ func checkBundle(t *testing.T, text, tableName string, expectedFiles ...string) 
 		}
 		files = append(files, f.Name)
 
+		r, err := f.Open()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer r.Close()
+		contents, err := ioutil.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if strings.Contains(string(contents), "-- error") {
+			t.Errorf(
+				"expected no errors in %s, file contents:\n%s",
+				f.Name,
+				string(contents),
+			)
+		}
+
 		if f.Name == "schema.sql" {
-			r, err := f.Open()
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer r.Close()
-			contents, err := ioutil.ReadAll(r)
-			if err != nil {
-				t.Fatal(err)
-			}
 			if !strings.Contains(string(contents), tableName) {
 				t.Errorf(
 					"expected table name to appear in schema.sql. tableName: %s\nfile contents:\n%s",

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -322,7 +322,10 @@ func (ih *instrumentationHelper) Finish(
 
 	var bundle diagnosticsBundle
 	if ih.collectBundle {
-		ie := p.extendedEvalCtx.ExecCfg.InternalExecutor
+		ie := p.extendedEvalCtx.ExecCfg.InternalExecutorFactory(
+			p.EvalContext().Context,
+			p.SessionData(),
+		)
 		phaseTimes := statsCollector.PhaseTimes()
 		if ih.stmtDiagnosticsRecorder.IsExecLatencyConditionMet(
 			ih.diagRequestID, ih.diagRequest, phaseTimes.GetServiceLatencyNoOverhead(),
@@ -334,7 +337,7 @@ func (ih *instrumentationHelper) Finish(
 				&queryLevelStats,
 			)
 			bundle = buildStatementBundle(
-				ih.origCtx, cfg.DB, ie, &p.curPlan, ob.BuildString(), trace, placeholders,
+				ih.origCtx, cfg.DB, ie.(*InternalExecutor), &p.curPlan, ob.BuildString(), trace, placeholders,
 			)
 			bundle.insert(ctx, ih.fingerprint, ast, cfg.StmtDiagnosticsRecorder, ih.diagRequestID)
 			ih.stmtDiagnosticsRecorder.RemoveOngoing(ih.diagRequestID, ih.diagRequest)


### PR DESCRIPTION
A regression was introduced in #71246 that caused errors when running
internal queries to populate files in statement bundles. As a result,
critical information was missing from the `env.sql`, `schema.sql`, and
`stats*.sql` files. This commit fixes the issue by using the internal
executor factory to create an internal executor with the current
session's session data.

Fixes #80396

Release note: None
