### PR TITLE
ui: display closed sessions, add username and session status filter

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.spec.tsx
@@ -21,7 +21,9 @@ describe("Test filter functions", (): void => {
         sqlType: "",
         database: "",
         regions: "",
+        sessionStatus: "",
         nodes: "",
+        username: "",
       };
       const resultFilters = getFiltersFromQueryString("");
       expect(resultFilters).toEqual(expectedFilters);
@@ -37,10 +39,12 @@ describe("Test filter functions", (): void => {
       sqlType: "DML",
       database: "movr",
       regions: "us-central",
+      sessionStatus: "idle",
       nodes: "n1,n2",
+      username: "root",
     };
     const resultFilters = getFiltersFromQueryString(
-      "app=%24+internal&timeNumber=1&timeUnit=milliseconds&fullScan=true&sqlType=DML&database=movr&regions=us-central&nodes=n1,n2",
+      "app=%24+internal&timeNumber=1&timeUnit=milliseconds&fullScan=true&sqlType=DML&database=movr&sessionStatus=idle&username=root&regions=us-central&nodes=n1,n2",
     );
     expect(resultFilters).toEqual(expectedFilters);
   });
@@ -54,7 +58,9 @@ describe("Test filter functions", (): void => {
       sqlType: "",
       database: "",
       regions: "",
+      sessionStatus: "",
       nodes: "",
+      username: "",
     };
     const resultFilters = getFiltersFromQueryString("fullScan=true");
     expect(resultFilters).toEqual(expectedFilters);
@@ -69,9 +75,62 @@ describe("Test filter functions", (): void => {
       sqlType: "",
       database: "",
       regions: "",
+      sessionStatus: "",
       nodes: "",
+      username: "",
     };
     const resultFilters = getFiltersFromQueryString("fullScan=false");
+    expect(resultFilters).toEqual(expectedFilters);
+  });
+
+  it("testing open sessions", (): void => {
+    const expectedFilters: Filters = {
+      app: "",
+      timeNumber: "0",
+      timeUnit: "seconds",
+      fullScan: false,
+      sqlType: "",
+      database: "",
+      regions: "",
+      sessionStatus: "open",
+      nodes: "",
+      username: "",
+    };
+    const resultFilters = getFiltersFromQueryString("sessionStatus=open");
+    expect(resultFilters).toEqual(expectedFilters);
+  });
+
+  it("testing idle sessions", (): void => {
+    const expectedFilters: Filters = {
+      app: "",
+      timeNumber: "0",
+      timeUnit: "seconds",
+      fullScan: false,
+      sqlType: "",
+      database: "",
+      regions: "",
+      sessionStatus: "idle",
+      nodes: "",
+      username: "",
+    };
+    const resultFilters = getFiltersFromQueryString("sessionStatus=idle");
+    expect(resultFilters).toEqual(expectedFilters);
+  });
+
+  it("testing closed sessions", (): void => {
+    const expectedFilters: Filters = {
+      app: "",
+      timeNumber: "0",
+      timeUnit: "seconds",
+      fullScan: false,
+      sqlType: "",
+      database: "",
+      regions: "",
+      sessionStatus: "closed",
+      nodes: "",
+      username: "",
+    };
+    const resultFilters = getFiltersFromQueryString("sessionStatus=closed");
     expect(resultFilters).toEqual(expectedFilters);
   });
 });

--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
@@ -36,9 +36,13 @@ interface QueryFilter {
   activeFilters: number;
   filters: Filters;
   dbNames?: string[];
+  usernames?: string[];
+  sessionStatuses?: string[];
   regions?: string[];
   nodes?: string[];
   showDB?: boolean;
+  showUsername?: boolean;
+  showSessionStatus?: boolean;
   showSqlType?: boolean;
   showScan?: boolean;
   showRegions?: boolean;
@@ -64,6 +68,8 @@ export interface Filters extends Record<string, string | boolean> {
   fullScan?: boolean;
   regions?: string;
   nodes?: string;
+  username?: string;
+  sessionStatus?: string;
 }
 
 const timeUnit = [
@@ -81,6 +87,8 @@ export const defaultFilters: Required<Filters> = {
   database: "",
   regions: "",
   nodes: "",
+  username: "",
+  sessionStatus: "",
 };
 
 // getFullFiltersObject returns Filters with every field defined as
@@ -372,6 +380,8 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
     const {
       appNames,
       dbNames,
+      usernames,
+      sessionStatuses,
       regions,
       nodes,
       activeFilters,
@@ -381,6 +391,8 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
       showRegions,
       showNodes,
       timeLabel,
+      showUsername,
+      showSessionStatus,
     } = this.props;
     const dropdownArea = hide ? hidden : dropdown;
     const customStyles = {
@@ -456,6 +468,55 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
           field="database"
           parent={this}
           value={databaseValue}
+        />
+      </div>
+    );
+
+    const usernameOptions = showUsername
+      ? usernames.map(username => ({
+          label: username,
+          value: username,
+          isSelected: this.isOptionSelected(username, filters.username),
+        }))
+      : [];
+    const usernameValue = usernameOptions.filter(option => {
+      return filters.username.split(",").includes(option.label);
+    });
+    const usernameFilter = (
+      <div>
+        <div className={filterLabel.margin}>Username</div>
+        <MultiSelectCheckbox
+          options={usernameOptions}
+          placeholder="All"
+          field="username"
+          parent={this}
+          value={usernameValue}
+        />
+      </div>
+    );
+
+    const sessionStatusOptions = showSessionStatus
+      ? sessionStatuses.map(sessionStatus => ({
+          label: sessionStatus,
+          value: sessionStatus,
+          isSelected: this.isOptionSelected(
+            sessionStatus,
+            filters.sessionStatus,
+          ),
+        }))
+      : [];
+    const sessionStatusValue = sessionStatusOptions.filter(option => {
+      return filters.sessionStatus.split(",").includes(option.label);
+    });
+    const sessionStatusFilter = (
+      <div>
+        <div className={filterLabel.margin}>Session Status</div>
+        <MultiSelectCheckbox
+          options={sessionStatusOptions}
+          placeholder="All"
+          field="sessionStatus"
+          parent={this}
+          value={sessionStatusValue}
         />
       </div>
     );
@@ -573,6 +634,8 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
           <div className={dropdownContentWrapper}>
             {appFilter}
             {showDB ? dbFilter : ""}
+            {showUsername ? usernameFilter : ""}
+            {showSessionStatus ? sessionStatusFilter : ""}
             {showSqlType ? sqlTypeFilter : ""}
             {showRegions ? regionsFilter : ""}
             {showNodes ? nodesFilter : ""}

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.module.scss
@@ -68,4 +68,10 @@
     width: 20px;
     fill: $colors--functional-orange-3;
   }
+
+  &__closed {
+    height: 10px;
+    width: 20px;
+    fill: $colors--neutral-4;
+  }
 }

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -16,7 +16,11 @@ import { Loading } from "../loading";
 import _ from "lodash";
 import { Link, RouteComponentProps } from "react-router-dom";
 
-import { SessionInfo } from "./sessionsTable";
+import {
+  getStatusClassname,
+  getStatusString,
+  SessionInfo,
+} from "./sessionsTable";
 
 import { SummaryCard, SummaryCardItem } from "../summaryCard";
 import SQLActivityError from "../sqlActivity/errorComponent";
@@ -394,15 +398,9 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
                 value={
                   <div>
                     <CircleFilled
-                      className={cx(
-                        session.active_queries.length > 0
-                          ? "session-status-icon__active"
-                          : "session-status-icon__idle",
-                      )}
+                      className={cx(getStatusClassname(session.status))}
                     />
-                    <span>
-                      {session.active_queries.length > 0 ? "Active" : "Idle"}
-                    </span>
+                    <span>{getStatusString(session.status)}</span>
                   </div>
                 }
                 className={cx("details-item")}

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetailsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetailsPage.fixture.ts
@@ -12,6 +12,7 @@ import { createMemoryHistory } from "history";
 import { SessionDetailsProps } from "./sessionDetails";
 import {
   activeSession,
+  closedSession,
   idleSession,
   idleTransactionSession,
 } from "./sessionsPage.fixture";
@@ -67,6 +68,11 @@ export const sessionDetailsActiveTxnPropsFixture: SessionDetailsProps = {
 export const sessionDetailsActiveStmtPropsFixture: SessionDetailsProps = {
   ...sessionDetailsPropsBase,
   session: activeSession,
+};
+
+export const sessionDetailsClosedPropsFixture: SessionDetailsProps = {
+  ...sessionDetailsPropsBase,
+  session: closedSession,
 };
 
 export const sessionDetailsNotFound: SessionDetailsProps = {

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetailsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetailsPage.stories.tsx
@@ -16,6 +16,7 @@ import { SessionDetails } from "./sessionDetails";
 import {
   sessionDetailsActiveStmtPropsFixture,
   sessionDetailsActiveTxnPropsFixture,
+  sessionDetailsClosedPropsFixture,
   sessionDetailsIdlePropsFixture,
   sessionDetailsNotFound,
 } from "./sessionDetailsPage.fixture";
@@ -31,6 +32,9 @@ storiesOf("Session Details Page", module)
   ))
   .add("Session", () => (
     <SessionDetails {...sessionDetailsActiveStmtPropsFixture} />
+  ))
+  .add("Closed Session", () => (
+    <SessionDetails {...sessionDetailsClosedPropsFixture} />
   ))
   .add("Session Not Found", () => (
     <SessionDetails {...sessionDetailsNotFound} />

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.fixture.ts
@@ -47,7 +47,7 @@ export const idleSession: SessionInfo = {
     alloc_bytes: Long.fromNumber(0),
     max_alloc_bytes: Long.fromNumber(10240),
     active_queries: [],
-    status: Status.ACTIVE,
+    status: Status.IDLE,
     toJSON: () => ({}),
   },
 };
@@ -85,7 +85,7 @@ export const idleTransactionSession: SessionInfo = {
     },
     last_active_query_no_constants: "SHOW database",
     active_queries: [],
-    status: Status.ACTIVE,
+    status: Status.IDLE,
     toJSON: () => ({}),
   },
 };
@@ -142,10 +142,36 @@ export const activeSession: SessionInfo = {
   },
 };
 
+export const closedSession: SessionInfo = {
+  session: {
+    node_id: 1,
+    username: "root",
+    client_address: "127.0.0.1:57618",
+    application_name: "$ cockroach sql",
+    start: {
+      seconds: Long.fromNumber(1596816670),
+      nanos: 369989000,
+    },
+    last_active_query: "SHOW database",
+    id: toUuid("FekiTsjUZoAAAAAAAAAAAQ=="),
+    last_active_query_no_constants: "SHOW database",
+    alloc_bytes: Long.fromNumber(0),
+    max_alloc_bytes: Long.fromNumber(10240),
+    active_queries: [],
+    end: {
+      seconds: Long.fromNumber(1596819870),
+      nanos: 369989000,
+    },
+    status: Status.CLOSED,
+    toJSON: () => ({}),
+  },
+};
+
 const sessionsList: SessionInfo[] = [
   idleSession,
   idleTransactionSession,
   activeSession,
+  closedSession,
 ];
 
 export const filters: Filters = {

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.module.scss
@@ -64,6 +64,12 @@
     width: 20px;
     fill: $colors--functional-orange-3;
   }
+
+  &__closed {
+        height: 10px;
+        width: 20px;
+        fill: $colors--neutral-4;
+      }
 }
 
 .code {

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
@@ -20,6 +20,7 @@ import moment from "moment";
 
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 type ISession = cockroach.server.serverpb.Session;
+type Status = cockroach.server.serverpb.Session.Status;
 
 import { TerminateSessionModalRef } from "./terminateSessionModal";
 import { TerminateQueryModalRef } from "./terminateQueryModal";
@@ -117,13 +118,33 @@ function formatStatementStart(session: ISession): string {
 
   return start.format(formatStr);
 }
+
+export function getStatusString(status: Status): string {
+  switch (status) {
+    case 0:
+      return "Active";
+    case 1:
+      return "Closed";
+    case 2:
+      return "Idle";
+  }
+}
+
+export function getStatusClassname(status: Status): string {
+  switch (status) {
+    case 0:
+      return "session-status-icon__active";
+    case 1:
+      return "session-status-icon__closed";
+    case 2:
+      return "session-status-icon__idle";
+  }
+}
+
 const SessionStatus = (props: { session: ISession }) => {
   const { session } = props;
-  const status = session.active_queries.length > 0 ? "Active" : "Idle";
-  const classname =
-    session.active_queries.length > 0
-      ? "session-status-icon__active"
-      : "session-status-icon__idle";
+  const status = getStatusString(session.status);
+  const classname = getStatusClassname(session.status);
   return (
     <div>
       <CircleFilled className={cx(classname)} />


### PR DESCRIPTION
Fixes #67888, #79914.

Previously, the sessions page UI did not support displaying closed
sessions and did not support the ability to filter by username or
session status. This commit adds the "Closed" session status to closed
sessions and adds the ability to filter by username and session status.

Session Status:
https://user-images.githubusercontent.com/35943354/164794955-5a48d6c2-589d-4f05-b476-b30b114662ee.mov

Usernames:
https://user-images.githubusercontent.com/35943354/164797165-f00f9760-7127-4f2a-96bd-88f691395693.mov

Release note (ui change): sessions overview and session details pages now
display closed sessions; sessions overview page now has username and session
status filters