### PR TITLE
changefeedccl: Add a placeholder option.

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -876,6 +876,14 @@ func validateDetails(details jobspb.ChangefeedDetails) (jobspb.ChangefeedDetails
 			)
 		}
 	}
+	{
+		_, isSet := details.Opts[changefeedbase.OptPrimaryKeyFilter]
+		if isSet {
+			return jobspb.ChangefeedDetails{}, pgerror.Newf(pgcode.FeatureNotSupported,
+				"option %s is not currently supported", changefeedbase.OptPrimaryKeyFilter,
+			)
+		}
+	}
 	return details, nil
 }
 

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -71,6 +71,7 @@ const (
 	OptOnError                  = `on_error`
 	OptMetricsScope             = `metrics_label`
 	OptVirtualColumns           = `virtual_columns`
+	OptPrimaryKeyFilter         = `primary_key_filter`
 
 	OptVirtualColumnsOmitted VirtualColumnVisibility = `omitted`
 	OptVirtualColumnsNull    VirtualColumnVisibility = `null`
@@ -209,6 +210,7 @@ var ChangefeedOptionExpectValues = map[string]sql.KVStringOptValidate{
 	OptOnError:                  sql.KVStringOptRequireValue,
 	OptMetricsScope:             sql.KVStringOptRequireValue,
 	OptVirtualColumns:           sql.KVStringOptRequireValue,
+	OptPrimaryKeyFilter:         sql.KVStringOptRequireValue,
 }
 
 func makeStringSet(opts ...string) map[string]struct{} {
@@ -228,7 +230,7 @@ var CommonOptions = makeStringSet(OptCursor, OptEndTime, OptEnvelope,
 	OptSchemaChangeEvents, OptSchemaChangePolicy,
 	OptProtectDataFromGCOnPause, OptOnError,
 	OptInitialScan, OptNoInitialScan, OptInitialScanOnly,
-	OptMinCheckpointFrequency, OptMetricsScope, OptVirtualColumns, Topics)
+	OptMinCheckpointFrequency, OptMetricsScope, OptVirtualColumns, Topics, OptPrimaryKeyFilter)
 
 // SQLValidOptions is options exclusive to SQL sink
 var SQLValidOptions map[string]struct{} = nil
@@ -292,4 +294,9 @@ var VersionGateOptions = map[string]clusterversion.Key{
 	OptEndTime:         clusterversion.EnableNewChangefeedOptions,
 	OptInitialScanOnly: clusterversion.EnableNewChangefeedOptions,
 	OptInitialScan:     clusterversion.EnableNewChangefeedOptions,
+
+	// OptPrimaryKeyFilter option define a filter over table primary key.
+	// This option is currently unsupported, but is added now so that
+	// implementation can be backported later if necessary.
+	OptPrimaryKeyFilter: clusterversion.EnableNewChangefeedOptions,
 }


### PR DESCRIPTION
Add a cluster version gated placeholder option for
potential backports of span constrained changefeeds.

Release Notes: None
Release Justification: low danger, no functionality change.