### PR TITLE
roachprod: add --gce-terminateOnMigration to ensure VMs are terminated on live migration

### DIFF
--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -168,6 +168,17 @@ func PreferSSD() Option {
 	return &preferSSDOption{}
 }
 
+type terminateOnMigrationOption struct{}
+
+func (o terminateOnMigrationOption) apply(spec *ClusterSpec) {
+	spec.TerminateOnMigration = true
+}
+
+// TerminateOnMigration ensures VM is terminated in case GCE triggers a live migration.
+func TerminateOnMigration() Option {
+	return &terminateOnMigrationOption{}
+}
+
 type setFileSystem struct {
 	fs fileSystemType
 }

--- a/pkg/cmd/roachtest/test_registry_test.go
+++ b/pkg/cmd/roachtest/test_registry_test.go
@@ -34,6 +34,12 @@ func TestMakeTestRegistry(t *testing.T) {
 		require.Equal(t, "zone99", s.Zones)
 		require.EqualValues(t, 12, s.CPUs)
 		require.True(t, s.PreferLocalSSD)
+
+		s = r.MakeClusterSpec(100, spec.CPU(4), spec.TerminateOnMigration())
+		require.EqualValues(t, 100, s.NodeCount)
+		require.Equal(t, "foo", s.InstanceType)
+		require.EqualValues(t, 4, s.CPUs)
+		require.True(t, s.TerminateOnMigration)
 	})
 
 }

--- a/pkg/cmd/roachtest/tests/clock_jump_crash.go
+++ b/pkg/cmd/roachtest/tests/clock_jump_crash.go
@@ -138,7 +138,7 @@ func registerClockJumpTests(r registry.Registry) {
 			Owner: registry.OwnerKV,
 			// These tests muck with NTP, therefore we don't want the cluster reused
 			// by others.
-			Cluster: r.MakeClusterSpec(1, spec.ReuseTagged("offset-injector")),
+			Cluster: r.MakeClusterSpec(1, spec.ReuseTagged("offset-injector"), spec.TerminateOnMigration()),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runClockJump(ctx, t, c, tc)
 			},

--- a/pkg/cmd/roachtest/tests/clock_monotonic.go
+++ b/pkg/cmd/roachtest/tests/clock_monotonic.go
@@ -140,7 +140,7 @@ func registerClockMonotonicTests(r registry.Registry) {
 			Owner: registry.OwnerKV,
 			// These tests muck with NTP, therefor we don't want the cluster reused by
 			// others.
-			Cluster: r.MakeClusterSpec(1, spec.ReuseTagged("offset-injector")),
+			Cluster: r.MakeClusterSpec(1, spec.ReuseTagged("offset-injector"), spec.TerminateOnMigration()),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runClockMonotonicity(ctx, t, c, tc)
 			},


### PR DESCRIPTION
Certain roachtests (clock_jump_crash.go, clock_monotonic.go) manipulate the system clock
using 'bumptime' (https://github.com/cockroachdb/jepsen/blob/master/cockroachdb/resources/bumptime.c).
These tests typically inject a forward jump to verify system invariants; e.g., panic when
server.clock.forward_jump_check_enabled = true.
To reduce flakiness, we execute these tests only on VMs with the 'TERMINATE' maintenance-policy; i.e.,
a VM is terminated when a live migration is triggered.
The reason this reduces the flakiness is that a live migration can result in up-to 5 second forward jump.
Thus, when the test enables server.clock.forward_jump_check_enabled,
the panic may happen _before_ the test has a chance to inject its own forward jump.

Release note: None
Informs: https://github.com/cockroachdb/cockroach/issues/80152