### PR TITLE
cdc: tolerate permission failure on create topic

### DIFF
--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -1572,6 +1572,10 @@ func (p *fakePubsubSink) Flush(ctx context.Context) error {
 	return p.Sink.Flush(ctx)
 }
 
+func (p *fakePubsubClient) connectivityError() error {
+	return nil
+}
+
 type pubsubFeedFactory struct {
 	enterpriseFeedFactory
 }


### PR DESCRIPTION
We try to create a topic optimistically, but were
treating getting a permissions error as fatal, when
it's possible we don't have permission to create a
topic but the topic exists and we have permission
to write to it. To support least-privilege roles
for service accounts, this PR adds tolerance for
permission issues. Also improves error messages
for this and in general by making recording errors
blocking to make sure they're available by the time
something bubbles up to the top.

Release note (enterprise change): Changefeeds to gcp no longer require topic creation permission if all topics being written to already exist.
Release justification: Low impact observability and authorization improvement to beta feature.