### PR TITLE
sql: Collapse sequential % characters in LIKE statements

### DIFF
--- a/pkg/sql/colexec/colexeccmp/BUILD.bazel
+++ b/pkg/sql/colexec/colexeccmp/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     # Pin the dependencies used in auto-generated code.
     deps = [
         "//pkg/sql/sem/tree",  # keep
+        "//pkg/util",
         "@com_github_cockroachdb_errors//:errors",  # keep
     ],
 )

--- a/pkg/sql/colexec/colexeccmp/like_ops.go
+++ b/pkg/sql/colexec/colexeccmp/like_ops.go
@@ -13,6 +13,8 @@ package colexeccmp
 import (
 	"bytes"
 	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 // LikeOpType is an enum that describes all of the different variants of LIKE
@@ -65,6 +67,7 @@ const (
 // The second return parameter always contains a single []byte, unless
 // "skeleton" LikeOpType is returned.
 func GetLikeOperatorType(pattern string, negate bool) (LikeOpType, [][]byte, error) {
+	pattern = util.CollapseDupeChar(pattern, '%')
 	if pattern == "" {
 		if negate {
 			return LikeConstantNegate, [][]byte{{}}, nil

--- a/pkg/sql/colexec/colexecsel/BUILD.bazel
+++ b/pkg/sql/colexec/colexecsel/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/sql/types",  # keep
         "//pkg/util/duration",  # keep
         "//pkg/util/json",  # keep
+        "//pkg/util",
         "@com_github_cockroachdb_apd_v3//:apd",  # keep
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/sql/colexec/colexecsel/like_ops.go
+++ b/pkg/sql/colexec/colexecsel/like_ops.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexeccmp"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/errors"
 )
 
@@ -23,6 +24,7 @@ import (
 func GetLikeOperator(
 	ctx *tree.EvalContext, input colexecop.Operator, colIdx int, pattern string, negate bool,
 ) (colexecop.Operator, error) {
+	pattern = util.CollapseDupeChar(pattern, '%')
 	likeOpType, patterns, err := colexeccmp.GetLikeOperatorType(pattern, negate)
 	if err != nil {
 		return nil, err

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -138,3 +138,37 @@ func (b *StringListBuilder) Finish(w io.Writer) {
 		_, _ = w.Write([]byte(b.end))
 	}
 }
+
+// CollapseDupeChar will take the given string and given character
+// and collapse any repeating instances of this character to a
+// single instance.
+// E.g. CollapseDupeChar("wwwhy hello there", 'w') returns "why hello there"
+func CollapseDupeChar(toCollapse string, collapseChar rune) string {
+	var builder strings.Builder
+	hadPrevious := false
+	begIndx := 0
+	for i, r := range toCollapse {
+		if r != collapseChar {
+			hadPrevious = false
+			continue
+		}
+
+		if !hadPrevious {
+			hadPrevious = true
+			continue
+		}
+
+		if begIndx != i {
+			builder.WriteString(toCollapse[begIndx:i])
+		}
+		begIndx = i + 1
+	}
+
+	if begIndx == 0 {
+		return toCollapse
+	}
+
+	builder.WriteString(toCollapse[begIndx:])
+
+	return builder.String()
+}

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -12,6 +12,10 @@ package util
 
 import (
 	"bytes"
+	"fmt"
+	"reflect"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -140,4 +144,79 @@ func TestStringListBuilder(t *testing.T) {
 	b.Addf(&buf, "%s", "two")
 	b.Finish(&buf)
 	expect("[one, two]")
+}
+
+func TestCollapseDupeChar(t *testing.T) {
+	type StringTest struct {
+		ToTest   string
+		DupeChar rune
+		Expected string
+	}
+
+	tests := []StringTest{
+		{"%test%", '%', "%test%"},
+		{"%test%%%%", '%', "%test%"},
+		{"%%%test%%%%", '%', "%test%"},
+		{"%%%test1%%%test2%%%test3%%%", '%', "%test1%test2%test3%"},
+		{"I work on ddddddifferent characters", 'd', "I work on different characters"},
+	}
+
+	for _, test := range tests {
+		result := CollapseDupeChar(test.ToTest, test.DupeChar)
+
+		if result != test.Expected {
+			t.Errorf("expected %s but got %s", test.Expected, result)
+		}
+	}
+}
+
+func BenchmarkCollapseDupeChar(b *testing.B) {
+	for _, runFn := range []func(*testing.B){
+		runBenchmarkNoDupe,
+		runBenchmarkSingleDupe,
+		runBenchmarkMultipleDupe,
+		runBenchmarkSpacedDupe,
+	} {
+		fnName := runtime.FuncForPC(reflect.ValueOf(runFn).Pointer()).Name()
+		fnName = strings.TrimPrefix(fnName, "github.com/cockroachdb/cockroach/pkg/util.runBenchmark")
+		b.Run(fnName, func(b *testing.B) {
+			for _, count := range []int{1, 10, 100, 1000} {
+				b.Run(fmt.Sprintf("count=%d", count), func(b *testing.B) {
+					runFn(b)
+				})
+			}
+		})
+	}
+}
+
+func runBenchmarkNoDupe(b *testing.B) {
+	toTest := "%test%"
+
+	for n := 0; n < b.N; n++ {
+		CollapseDupeChar(toTest, '%')
+	}
+}
+
+func runBenchmarkSingleDupe(b *testing.B) {
+	toTest := "%test%%%%"
+
+	for n := 0; n < b.N; n++ {
+		CollapseDupeChar(toTest, '%')
+	}
+}
+
+func runBenchmarkMultipleDupe(b *testing.B) {
+	toTest := "%%%%%test%%%%"
+
+	for n := 0; n < b.N; n++ {
+		CollapseDupeChar(toTest, '%')
+	}
+}
+
+func runBenchmarkSpacedDupe(b *testing.B) {
+	toTest := "%%%spaced%%%dupe%%%"
+
+	for n := 0; n < b.N; n++ {
+		CollapseDupeChar(toTest, '%')
+	}
 }


### PR DESCRIPTION
Fixes #80192

util: Add a function for collapsing a certain character in strings as well as tests and benchmarks for the function. As mentioned above it will take "%%%hello%" -> given that string and '%' will produce "%hello%".

sql: Before the pattern passed to like_ops in both `colexeccmp` and `colexecsel` might contain repeating %, but these optimizer functions couldn't make use of them and the multiple "%%%" translate to just a single %. This change calls a utility function to cleanup the pattern string and collapse the % character to a single one if a repeating pattern of them are found.

Release note (performance optimization): SQL LIKE statements will now normalize statements including multiple "%" operators to a single character. E.g. "%foo%%%" -> "%foo%".
