### PR TITLE
storage: fix accounting for orig LiveBytes in updateStatsOnResolve

### DIFF
--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -430,7 +430,7 @@ func updateStatsOnResolve(
 	// the new intent/value.
 	if !meta.Deleted {
 		ms.LiveBytes -= origMetaKeySize + origMetaValSize
-		ms.LiveBytes -= orig.KeyBytes + meta.ValBytes
+		ms.LiveBytes -= orig.KeyBytes + orig.ValBytes
 	}
 
 	// IntentAge is always accrued from the intent's own timestamp on.


### PR DESCRIPTION
This commit fixes a latent bug where `updateStatsOnResolve`'s attempt to
discount the effect of the previous intent's key and value size on the
stats' `LiveBytes` field used the new value's size instead of the old
value's size. I've tracked this back to 92cad17.

This is currently harmless because intent value sizes never change
during intent resolution. However, this may not be the case in the
future. For instance, this will not be the case if we store local
timestamps in an `MVCCValue` wrapper object, as is being explored
in #77342.