### PR TITLE
ccl/sqlproxyccl: revert change to support destination in TransferConnection

### DIFF
--- a/pkg/ccl/sqlproxyccl/balancer/balancer.go
+++ b/pkg/ccl/sqlproxyccl/balancer/balancer.go
@@ -48,8 +48,6 @@ const (
 	// an unsafe transfer point). Note that each transfer attempt currently has
 	// a timeout of 15 seconds, so retrying up to 3 times may hold onto
 	// processSem up to 45 seconds for each rebalance request.
-	//
-	// TODO(jaylim-crl): Reduce transfer timeout to 5 seconds.
 	maxTransferAttempts = 3
 )
 
@@ -238,9 +236,7 @@ func (b *Balancer) processQueue(ctx context.Context) {
 
 			// Each request is retried up to maxTransferAttempts.
 			for i := 0; i < maxTransferAttempts && ctx.Err() == nil; i++ {
-				// TODO(jaylim-crl): Once the TransferConnection API accepts a
-				// destination, we could update this code, and pass along dst.
-				err := req.conn.TransferConnection( /* req.dst */ )
+				err := req.conn.TransferConnection()
 				if err == nil || errors.Is(err, context.Canceled) ||
 					req.dst == req.conn.ServerRemoteAddr() {
 					break

--- a/pkg/ccl/sqlproxyccl/balancer/balancer.go
+++ b/pkg/ccl/sqlproxyccl/balancer/balancer.go
@@ -48,6 +48,8 @@ const (
 	// an unsafe transfer point). Note that each transfer attempt currently has
 	// a timeout of 15 seconds, so retrying up to 3 times may hold onto
 	// processSem up to 45 seconds for each rebalance request.
+	//
+	// TODO(jaylim-crl): Reduce transfer timeout to 5 seconds.
 	maxTransferAttempts = 3
 )
 
@@ -236,7 +238,9 @@ func (b *Balancer) processQueue(ctx context.Context) {
 
 			// Each request is retried up to maxTransferAttempts.
 			for i := 0; i < maxTransferAttempts && ctx.Err() == nil; i++ {
-				err := req.conn.TransferConnection(req.dst)
+				// TODO(jaylim-crl): Once the TransferConnection API accepts a
+				// destination, we could update this code, and pass along dst.
+				err := req.conn.TransferConnection( /* req.dst */ )
 				if err == nil || errors.Is(err, context.Canceled) ||
 					req.dst == req.conn.ServerRemoteAddr() {
 					break

--- a/pkg/ccl/sqlproxyccl/balancer/conn.go
+++ b/pkg/ccl/sqlproxyccl/balancer/conn.go
@@ -20,13 +20,9 @@ type ConnectionHandle interface {
 	Close()
 
 	// TransferConnection performs a connection migration on the connection
-	// handle to the given SQL pod at the dstAddr address. Invoking this blocks
-	// until the connection migration process has been completed.
-	//
-	// NOTE: dstAddr, if not empty, has to be a valid RUNNING address for the
-	// tenant associated with the connection handle, or else an error will be
-	// returned.
-	TransferConnection(dstAddr string) error
+	// handle. Invoking this blocks until the connection migration process has
+	// been completed.
+	TransferConnection() error
 
 	// ServerRemoteAddr returns the remote address of the connection between
 	// the proxy and the server, which is basically the SQL pod's address

--- a/pkg/ccl/sqlproxyccl/balancer/conn_tracker_test.go
+++ b/pkg/ccl/sqlproxyccl/balancer/conn_tracker_test.go
@@ -312,7 +312,7 @@ func (h *testTrackerConnHandle) ServerRemoteAddr() string {
 }
 
 // TransferConnection implements the ConnectionHandle interface.
-func (h *testTrackerConnHandle) TransferConnection(dstAddr string) error {
+func (h *testTrackerConnHandle) TransferConnection() error {
 	if h.ctx != nil && h.ctx.Err() != nil {
 		return h.ctx.Err()
 	}

--- a/pkg/ccl/sqlproxyccl/conn_migration.go
+++ b/pkg/ccl/sqlproxyccl/conn_migration.go
@@ -35,7 +35,7 @@ import (
 var defaultTransferTimeout = 15 * time.Second
 
 // Used in testing.
-var transferConnectionConnectorTestHook func(context.Context, string, string) (net.Conn, error) = nil
+var transferConnectionConnectorTestHook func(context.Context, string) (net.Conn, error) = nil
 
 type transferContext struct {
 	context.Context
@@ -105,15 +105,12 @@ func (f *forwarder) tryBeginTransfer() (started bool, cleanupFn func()) {
 
 var errTransferCannotStart = errors.New("transfer cannot be started")
 
-// TransferConnection attempts a best-effort connection migration to the SQL pod
-// with dstAddr as address. dstAddr, if not empty, has to be an address of a
-// RUNNING pod for the associated tenant. On the other hand, if the connection
-// is already connected to dstAddr, TransferConnection will succeed implicitly.
-//
-// If a transfer has already been started, or the forwarder has been closed,
-// this returns an error. This is a best-effort process because there could be a
-// situation where the forwarder is not in a state that is eligible for a
-// connection migration.
+// TransferConnection attempts a best-effort connection migration to an
+// available SQL pod based on the load-balancing algorithm. If a transfer has
+// already been started, or the forwarder has been closed, this returns an
+// error. This is a best-effort process because there could be a situation
+// where the forwarder is not in a state that is eligible for a connection
+// migration.
 //
 // NOTE: If the forwarder hasn't been closed, runTransfer has an invariant
 // where the processors have been resumed prior to calling this method. When
@@ -121,17 +118,17 @@ var errTransferCannotStart = errors.New("transfer cannot be started")
 // re-resumed, or the forwarder will be closed (in the case of a non-recoverable
 // error).
 //
+// TODO(jaylim-crl): It would be nice to introduce transfer policies in the
+// future. That way, we could either transfer to another random SQL pod, or to
+// a specific SQL pod. If we do that, TransferConnection would take in some kind
+// of policy parameter(s).
+//
 // TransferConnection implements the balancer.ConnectionHandle interface.
-func (f *forwarder) TransferConnection(dstAddr string) (retErr error) {
+func (f *forwarder) TransferConnection() (retErr error) {
 	// A previous non-recoverable transfer would have closed the forwarder, so
 	// return right away.
 	if f.ctx.Err() != nil {
 		return f.ctx.Err()
-	}
-
-	// Transfer succeeded implicitly since the connection is already at dstAddr.
-	if f.ServerRemoteAddr() == dstAddr {
-		return nil
 	}
 
 	started, cleanupFn := f.tryBeginTransfer()
@@ -210,7 +207,7 @@ func (f *forwarder) TransferConnection(dstAddr string) (retErr error) {
 
 	// Transfer the connection.
 	clientConn, serverConn := f.getConns()
-	newServerConn, err := transferConnection(ctx, f.connector, f.metrics, clientConn, serverConn, dstAddr)
+	newServerConn, err := transferConnection(ctx, f.connector, f.metrics, clientConn, serverConn)
 	if err != nil {
 		return errors.Wrap(err, "transferring connection")
 	}
@@ -227,9 +224,7 @@ func transferConnection(
 	ctx *transferContext,
 	connector *connector,
 	metrics *metrics,
-	clientConn *interceptor.PGConn,
-	serverConn *interceptor.PGConn,
-	dstAddr string,
+	clientConn, serverConn *interceptor.PGConn,
 ) (_ *interceptor.PGConn, retErr error) {
 	ctx.markRecoverable(true)
 
@@ -267,12 +262,19 @@ func transferConnection(
 		return nil, errors.Newf("%s", transferErr)
 	}
 
-	// Connect to the SQL pod at dstAddr.
+	// Connect to a new SQL pod.
+	//
+	// TODO(jaylim-crl): There is a possibility where the same pod will get
+	// selected. Some ideas to solve this: pass in the remote address of
+	// serverConn to avoid choosing that pod, or maybe a filter callback?
+	// We can also consider adding a target pod as an argument to
+	// TransferConnection. That way a central component gets to choose where the
+	// connections go.
 	connectFn := connector.OpenTenantConnWithToken
 	if transferConnectionConnectorTestHook != nil {
 		connectFn = transferConnectionConnectorTestHook
 	}
-	netConn, err := connectFn(ctx, revivalToken, dstAddr)
+	netConn, err := connectFn(ctx, revivalToken)
 	if err != nil {
 		return nil, errors.Wrap(err, "opening connection")
 	}

--- a/pkg/ccl/sqlproxyccl/conn_migration.go
+++ b/pkg/ccl/sqlproxyccl/conn_migration.go
@@ -118,11 +118,6 @@ var errTransferCannotStart = errors.New("transfer cannot be started")
 // re-resumed, or the forwarder will be closed (in the case of a non-recoverable
 // error).
 //
-// TODO(jaylim-crl): It would be nice to introduce transfer policies in the
-// future. That way, we could either transfer to another random SQL pod, or to
-// a specific SQL pod. If we do that, TransferConnection would take in some kind
-// of policy parameter(s).
-//
 // TransferConnection implements the balancer.ConnectionHandle interface.
 func (f *forwarder) TransferConnection() (retErr error) {
 	// A previous non-recoverable transfer would have closed the forwarder, so
@@ -263,13 +258,6 @@ func transferConnection(
 	}
 
 	// Connect to a new SQL pod.
-	//
-	// TODO(jaylim-crl): There is a possibility where the same pod will get
-	// selected. Some ideas to solve this: pass in the remote address of
-	// serverConn to avoid choosing that pod, or maybe a filter callback?
-	// We can also consider adding a target pod as an argument to
-	// TransferConnection. That way a central component gets to choose where the
-	// connections go.
 	connectFn := connector.OpenTenantConnWithToken
 	if transferConnectionConnectorTestHook != nil {
 		connectFn = transferConnectionConnectorTestHook

--- a/pkg/ccl/sqlproxyccl/conn_migration_test.go
+++ b/pkg/ccl/sqlproxyccl/conn_migration_test.go
@@ -114,7 +114,7 @@ func TestTransferConnection(t *testing.T) {
 		ctx, cancel := newTransferContext(context.Background())
 		cancel()
 
-		conn, err := transferConnection(ctx, nil, nil, nil, nil, "")
+		conn, err := transferConnection(ctx, nil, nil, nil, nil)
 		require.EqualError(t, err, context.Canceled.Error())
 		require.Nil(t, conn)
 		require.True(t, ctx.isRecoverable())
@@ -138,7 +138,6 @@ func TestTransferConnection(t *testing.T) {
 			nil,
 			interceptor.NewPGConn(p1),
 			interceptor.NewPGConn(p2),
-			"dst-addr",
 		)
 		require.Regexp(t, "foo", err)
 		require.Nil(t, conn)
@@ -179,7 +178,6 @@ func TestTransferConnection(t *testing.T) {
 			nil,
 			interceptor.NewPGConn(p1),
 			interceptor.NewPGConn(p2),
-			"dst-addr",
 		)
 		require.Regexp(t, "foobar", err)
 		require.Nil(t, conn)
@@ -220,7 +218,6 @@ func TestTransferConnection(t *testing.T) {
 			nil,
 			interceptor.NewPGConn(p1),
 			interceptor.NewPGConn(p2),
-			"dst-addr",
 		)
 		require.Regexp(t, "foobaz", err)
 		require.Nil(t, conn)
@@ -259,11 +256,9 @@ func TestTransferConnection(t *testing.T) {
 			func(
 				tCtx context.Context,
 				token string,
-				dstAddr string,
 			) (net.Conn, error) {
 				require.Equal(t, ctx, tCtx)
 				require.Equal(t, "token", token)
-				require.Equal(t, "dst-addr", dstAddr)
 				return nil, errors.New("foobarbaz")
 			},
 		)()
@@ -274,7 +269,6 @@ func TestTransferConnection(t *testing.T) {
 			nil,
 			interceptor.NewPGConn(p1),
 			interceptor.NewPGConn(p2),
-			"dst-addr",
 		)
 		require.Regexp(t, "foobarbaz", err)
 		require.Nil(t, conn)
@@ -316,11 +310,9 @@ func TestTransferConnection(t *testing.T) {
 			func(
 				tCtx context.Context,
 				token string,
-				dstAddr string,
 			) (net.Conn, error) {
 				require.Equal(t, ctx, tCtx)
 				require.Equal(t, "token", token)
-				require.Equal(t, "dst-addr", dstAddr)
 				return netConn, nil
 			},
 		)()
@@ -344,7 +336,6 @@ func TestTransferConnection(t *testing.T) {
 			nil,
 			interceptor.NewPGConn(p1),
 			interceptor.NewPGConn(p2),
-			"dst-addr",
 		)
 		require.Regexp(t, "foobar", err)
 		require.Nil(t, conn)
@@ -390,11 +381,9 @@ func TestTransferConnection(t *testing.T) {
 			func(
 				tCtx context.Context,
 				token string,
-				dstAddr string,
 			) (net.Conn, error) {
 				require.Equal(t, ctx, tCtx)
 				require.Equal(t, "token", token)
-				require.Equal(t, "dst-addr", dstAddr)
 				return netConn, nil
 			},
 		)()
@@ -418,7 +407,6 @@ func TestTransferConnection(t *testing.T) {
 			nil,
 			interceptor.NewPGConn(p1),
 			interceptor.NewPGConn(p2),
-			"dst-addr",
 		)
 		require.NoError(t, err)
 		require.NotNil(t, conn)

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -901,10 +901,7 @@ func TestConnectionMigration(t *testing.T) {
 		// Set up forwarder hooks.
 		prevTenant1 := true
 		var lookupAddrDelayDuration time.Duration
-		f.connector.testingKnobs.lookupValidAddr = func(ctx context.Context, dstAddr string) (string, error) {
-			if dstAddr != "dst-addr" {
-				return "", errors.Newf("invalid dstAddr '%s'", dstAddr)
-			}
+		f.connector.testingKnobs.lookupAddr = func(ctx context.Context) (string, error) {
 			if lookupAddrDelayDuration != 0 {
 				select {
 				case <-ctx.Done():
@@ -927,13 +924,7 @@ func TestConnectionMigration(t *testing.T) {
 			require.NoError(t, err)
 
 			// Show that we get alternating SQL pods when we transfer.
-			require.NoError(t, f.TransferConnection("dst-addr"))
-			require.Equal(t, int64(1), f.metrics.ConnMigrationSuccessCount.Count())
-			require.Equal(t, tenant2.SQLAddr(), queryAddr(t, tCtx, db))
-
-			// Trying to transfer to the same destination should be a no-op.
-			// Metrics do not get incremented.
-			require.NoError(t, f.TransferConnection(tenant2.SQLAddr()))
+			require.NoError(t, f.TransferConnection())
 			require.Equal(t, int64(1), f.metrics.ConnMigrationSuccessCount.Count())
 			require.Equal(t, tenant2.SQLAddr(), queryAddr(t, tCtx, db))
 
@@ -944,7 +935,7 @@ func TestConnectionMigration(t *testing.T) {
 			_, err = db.Exec("SET application_name = 'bar'")
 			require.NoError(t, err)
 
-			require.NoError(t, f.TransferConnection("dst-addr"))
+			require.NoError(t, f.TransferConnection())
 			require.Equal(t, int64(2), f.metrics.ConnMigrationSuccessCount.Count())
 			require.Equal(t, tenant1.SQLAddr(), queryAddr(t, tCtx, db))
 
@@ -961,7 +952,7 @@ func TestConnectionMigration(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				for subCtx.Err() == nil {
-					_ = f.TransferConnection("dst-addr")
+					_ = f.TransferConnection()
 					time.Sleep(100 * time.Millisecond)
 				}
 			}()
@@ -1007,7 +998,7 @@ func TestConnectionMigration(t *testing.T) {
 			err = crdb.ExecuteTx(tCtx, db, nil /* txopts */, func(tx *gosql.Tx) error {
 				// Run multiple times to ensure that connection isn't closed.
 				for i := 0; i < 5; i++ {
-					err := f.TransferConnection("dst-addr")
+					err := f.TransferConnection()
 					if err == nil {
 						return errors.New("no error")
 					}
@@ -1035,7 +1026,7 @@ func TestConnectionMigration(t *testing.T) {
 			require.Equal(t, int64(0), f.metrics.ConnMigrationErrorFatalCount.Count())
 
 			// Once the transaction is closed, transfers should work.
-			require.NoError(t, f.TransferConnection("dst-addr"))
+			require.NoError(t, f.TransferConnection())
 			require.NotEqual(t, initAddr, queryAddr(t, tCtx, db))
 			require.Nil(t, f.ctx.Err())
 			require.Equal(t, initSuccessCount+1, f.metrics.ConnMigrationSuccessCount.Count())
@@ -1057,7 +1048,7 @@ func TestConnectionMigration(t *testing.T) {
 			lookupAddrDelayDuration = 10 * time.Second
 			defer testutils.TestingHook(&defaultTransferTimeout, 3*time.Second)()
 
-			err := f.TransferConnection("dst-addr")
+			err := f.TransferConnection()
 			require.Error(t, err)
 			require.Regexp(t, "injected delays", err.Error())
 			require.Equal(t, initAddr, queryAddr(t, tCtx, db))
@@ -1122,10 +1113,7 @@ func TestConnectionMigration(t *testing.T) {
 
 		// Set up forwarder hooks.
 		prevTenant1 := true
-		f.connector.testingKnobs.lookupValidAddr = func(ctx context.Context, dstAddr string) (string, error) {
-			if dstAddr != "dst-addr" {
-				return "", errors.Newf("invalid dstAddr '%s'", dstAddr)
-			}
+		f.connector.testingKnobs.lookupAddr = func(ctx context.Context) (string, error) {
 			if prevTenant1 {
 				prevTenant1 = false
 				return tenant2.SQLAddr(), nil
@@ -1157,7 +1145,7 @@ func TestConnectionMigration(t *testing.T) {
 		<-goCh
 		time.Sleep(2 * time.Second)
 		// This should be an error because the transfer timed out.
-		require.Error(t, f.TransferConnection("dst-addr"))
+		require.Error(t, f.TransferConnection())
 
 		// Connection should be closed because this is a non-recoverable error,
 		// i.e. timeout after sending the request, but before fully receiving


### PR DESCRIPTION
#### ccl/sqlproxyccl: revert change to support destination in TransferConnection

This reverts commit 0db1b8f. We have decided
to push all the pod selection logic into the connector. Adding a destination
address support to the TransferConnection complicates a lot of operations.

#### ccl/sqlproxyccl: remove TODOs that will not be addressed 

It was a mistake to support a destination in the TransferConnection API at
the moment. This commit removes all TODOs related to such ideas.

Release note: None