### PR TITLE
ccl/sqlproxyccl: update connection tracker to track ServerAssignment instances

### DIFF
--- a/pkg/ccl/sqlproxyccl/balancer/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/balancer/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "balancer",
     srcs = [
+        "assignment.go",
         "balancer.go",
         "conn.go",
         "conn_tracker.go",
@@ -29,6 +30,7 @@ go_library(
 go_test(
     name = "balancer_test",
     srcs = [
+        "assignment_test.go",
         "balancer_test.go",
         "conn_tracker_test.go",
         "pod_test.go",

--- a/pkg/ccl/sqlproxyccl/balancer/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/balancer/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
     srcs = [
         "assignment_test.go",
         "balancer_test.go",
+        "conn_test.go",
         "conn_tracker_test.go",
         "pod_test.go",
     ],

--- a/pkg/ccl/sqlproxyccl/balancer/assignment.go
+++ b/pkg/ccl/sqlproxyccl/balancer/assignment.go
@@ -52,5 +52,8 @@ func (sa *ServerAssignment) Addr() string {
 // Close cleans up the server assignment and deregisters it from the connection
 // tracker. This is idempotent.
 func (sa *ServerAssignment) Close() {
-	sa.onClose.Do(sa.onClose.closerFn)
+	// Tests may create a ServerAssignment without a closerFn.
+	if sa.onClose.closerFn != nil {
+		sa.onClose.Do(sa.onClose.closerFn)
+	}
 }

--- a/pkg/ccl/sqlproxyccl/balancer/assignment.go
+++ b/pkg/ccl/sqlproxyccl/balancer/assignment.go
@@ -1,0 +1,56 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package balancer
+
+import (
+	"sync"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+)
+
+// ServerAssignment represents an assignment to a SQL pod.
+type ServerAssignment struct {
+	owner   ConnectionHandle
+	addr    string
+	onClose struct {
+		sync.Once
+		closerFn func()
+	}
+}
+
+// NewServerAssignment returns a new instance of ServerAssignment. Instances of
+// ServerAssignment must be closed through Close once no longer in use.
+func NewServerAssignment(
+	tenantID roachpb.TenantID, tracker *ConnTracker, owner ConnectionHandle, addr string,
+) *ServerAssignment {
+	sa := &ServerAssignment{owner: owner, addr: addr}
+	sa.onClose.closerFn = func() {
+		tracker.unregisterAssignment(tenantID, sa)
+	}
+	tracker.registerAssignment(tenantID, sa)
+	return sa
+}
+
+// Owner returns the connection handle associated with the server assignment.
+// The connection handle may not be initialized yet, so callers will need to
+// check for that where necessary.
+func (sa *ServerAssignment) Owner() ConnectionHandle {
+	return sa.owner
+}
+
+// Addr returns the address of the server assignment.
+func (sa *ServerAssignment) Addr() string {
+	return sa.addr
+}
+
+// Close cleans up the server assignment and deregisters it from the connection
+// tracker. This is idempotent.
+func (sa *ServerAssignment) Close() {
+	sa.onClose.Do(sa.onClose.closerFn)
+}

--- a/pkg/ccl/sqlproxyccl/balancer/assignment_test.go
+++ b/pkg/ccl/sqlproxyccl/balancer/assignment_test.go
@@ -1,0 +1,36 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package balancer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerAssignment(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	tracker, err := NewConnTracker(ctx, stopper, nil /* timeSource */)
+	require.NoError(t, err)
+	tenantID, handle := makeConn(10, "foo-bar-baz")
+
+	sa := NewServerAssignment(tenantID, tracker, handle, "127.0.0.10")
+	require.Equal(t, handle, sa.Owner())
+	require.Equal(t, "127.0.0.10", sa.Addr())
+	// TODO(jaylim-crl): test Close once {register,unregister}Assignment gets
+	// implemented.
+}

--- a/pkg/ccl/sqlproxyccl/balancer/balancer.go
+++ b/pkg/ccl/sqlproxyccl/balancer/balancer.go
@@ -111,6 +111,8 @@ type Balancer struct {
 	directoryCache tenant.DirectoryCache
 
 	// connTracker is used to track connections within the proxy.
+	//
+	// TODO(jaylim-crl): Rename connTracker to tracker.
 	connTracker *ConnTracker
 
 	// queue represents the rebalancer queue. All transfer requests should be
@@ -134,7 +136,6 @@ func NewBalancer(
 	stopper *stop.Stopper,
 	metrics *Metrics,
 	directoryCache tenant.DirectoryCache,
-	connTracker *ConnTracker,
 	opts ...Option,
 ) (*Balancer, error) {
 	// Handle options.
@@ -160,12 +161,16 @@ func NewBalancer(
 	b := &Balancer{
 		stopper:        stopper,
 		metrics:        metrics,
-		connTracker:    connTracker,
 		directoryCache: directoryCache,
 		queue:          q,
 		processSem:     semaphore.New(options.maxConcurrentRebalances),
 		timeSource:     options.timeSource,
 	}
+	b.connTracker, err = NewConnTracker(ctx, b.stopper, b.timeSource)
+	if err != nil {
+		return nil, err
+	}
+
 	b.mu.rng, _ = randutil.NewPseudoRand()
 
 	// Run queue processor to handle rebalance requests.
@@ -186,12 +191,23 @@ func NewBalancer(
 // SelectTenantPod selects a tenant pod from the given list based on a weighted
 // CPU load algorithm. It is expected that all pods within the list belongs to
 // the same tenant. If no pods are available, this returns ErrNoAvailablePods.
+//
+// TODO(jaylim-crl): Rename this to SelectSQLServer(requester, tenantID, clusterName)
+// which returns a ServerAssignment.
 func (b *Balancer) SelectTenantPod(pods []*tenant.Pod) (*tenant.Pod, error) {
 	pod := selectTenantPod(b.randFloat32(), pods)
 	if pod == nil {
 		return nil, ErrNoAvailablePods
 	}
 	return pod, nil
+}
+
+// GetTracker returns the tracker associated with the balancer.
+//
+// TODO(jaylim-crl): Remove GetTracker entirely once SelectTenantPod returns
+// a ServerAssignment instead of a pod.
+func (b *Balancer) GetTracker() *ConnTracker {
+	return b.connTracker
 }
 
 // randFloat32 generates a random float32 within the bounds [0, 1) and is
@@ -237,13 +253,11 @@ func (b *Balancer) processQueue(ctx context.Context) {
 			// Each request is retried up to maxTransferAttempts.
 			for i := 0; i < maxTransferAttempts && ctx.Err() == nil; i++ {
 				err := req.conn.TransferConnection()
-				if err == nil || errors.Is(err, context.Canceled) ||
-					req.dst == req.conn.ServerRemoteAddr() {
+				if err == nil || errors.Is(err, context.Canceled) {
 					break
 				}
 
-				// Retry again if the connection hasn't been closed or
-				// transferred to the destination.
+				// Retry again if the connection hasn't been closed.
 				time.Sleep(250 * time.Millisecond)
 			}
 		}); err != nil {
@@ -281,8 +295,8 @@ func (b *Balancer) rebalanceLoop(ctx context.Context) {
 // also want to rate limit the number of rebalances per tenant for requests
 // coming from the pod watcher.
 func (b *Balancer) rebalance(ctx context.Context) {
-	// GetTenantIDs ensures that tenants will have at least one connection.
-	tenantIDs := b.connTracker.GetTenantIDs()
+	// getTenantIDs ensures that tenants will have at least one connection.
+	tenantIDs := b.connTracker.getTenantIDs()
 
 	for _, tenantID := range tenantIDs {
 		tenantPods, err := b.directoryCache.TryLookupTenantPods(ctx, tenantID)
@@ -346,10 +360,6 @@ func (b *Balancer) rebalance(ctx context.Context) {
 			}
 
 			for _, c := range podConns {
-				// TODO(jaylim-crl): We currently transfer without a dest, which
-				// will result in using the weighted CPU algorithm to assign
-				// pods. Once we start using a leastconns algorithm, we can make
-				// better decisions here, and specify a destination.
 				b.queue.enqueue(&rebalanceRequest{
 					createdAt: b.timeSource.Now(),
 					conn:      c,
@@ -359,16 +369,10 @@ func (b *Balancer) rebalance(ctx context.Context) {
 	}
 }
 
-// rebalanceRequest corresponds to a rebalance request. For now, this only
-// indicates where the connection should be transferred to through dst.
-//
-// TODO(jaylim-crl): Consider adding src, and evaluating that before invoking
-// the transfer operation to handle the case where a transfer was in progress
-// when a new request was added to the queue.
+// rebalanceRequest corresponds to a rebalance request.
 type rebalanceRequest struct {
 	createdAt time.Time
 	conn      ConnectionHandle
-	dst       string
 }
 
 // balancerQueue represents the balancer's internal queue which is used for

--- a/pkg/ccl/sqlproxyccl/balancer/balancer_test.go
+++ b/pkg/ccl/sqlproxyccl/balancer/balancer_test.go
@@ -10,7 +10,6 @@ package balancer
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"sync"
 	"sync/atomic"
@@ -40,7 +39,6 @@ func TestBalancer_SelectTenantPod(t *testing.T) {
 		stopper,
 		nil, /* metrics */
 		nil, /* directoryCache */
-		nil, /* connTracker */
 		NoRebalanceLoop(),
 	)
 	require.NoError(t, err)
@@ -70,7 +68,6 @@ func TestRebalancer_processQueue(t *testing.T) {
 		stopper,
 		NewMetrics(),
 		nil, /* directoryCache */
-		nil, /* connTracker */
 		MaxConcurrentRebalances(1),
 		NoRebalanceLoop(),
 	)
@@ -85,13 +82,12 @@ func TestRebalancer_processQueue(t *testing.T) {
 	syncCh := make(chan struct{})
 	syncReq := &rebalanceRequest{
 		createdAt: timeSource.Now(),
-		conn: &testBalancerConnHandle{
+		conn: &testConnHandle{
 			onTransferConnection: func() error {
 				syncCh <- struct{}{}
 				return nil
 			},
 		},
-		dst: "foo",
 	}
 
 	// assertNoRunningRequests asserts that the rebalance loop isn't processing
@@ -110,14 +106,13 @@ func TestRebalancer_processQueue(t *testing.T) {
 		count := 0
 		req := &rebalanceRequest{
 			createdAt: timeSource.Now(),
-			conn: &testBalancerConnHandle{
+			conn: &testConnHandle{
 				onTransferConnection: func() error {
 					count++
 					require.Equal(t, int64(1), b.metrics.rebalanceReqRunning.Value())
 					return errors.New("cannot transfer")
 				},
 			},
-			dst: "foo",
 		}
 		b.queue.enqueue(req)
 
@@ -131,46 +126,17 @@ func TestRebalancer_processQueue(t *testing.T) {
 		require.Equal(t, 3, count)
 	})
 
-	t.Run("conn_was_transferred_by_other", func(t *testing.T) {
-		count := 0
-		conn := &testBalancerConnHandle{}
-		conn.onTransferConnection = func() error {
-			count++
-			// Simulate that connection was transferred by someone else.
-			conn.remoteAddr = "foo"
-			require.Equal(t, int64(1), b.metrics.rebalanceReqRunning.Value())
-			return errors.New("cannot transfer")
-		}
-		req := &rebalanceRequest{
-			createdAt: timeSource.Now(),
-			conn:      conn,
-			dst:       "foo",
-		}
-		b.queue.enqueue(req)
-
-		// Wait until the item has been processed.
-		b.queue.enqueue(syncReq)
-		<-syncCh
-
-		assertNoRunningRequests(t)
-
-		// We should only retry once.
-		require.Equal(t, 1, count)
-	})
-
 	t.Run("conn_was_transferred", func(t *testing.T) {
 		count := 0
-		conn := &testBalancerConnHandle{}
-		conn.onTransferConnection = func() error {
-			count++
-			conn.remoteAddr = "foo"
-			require.Equal(t, int64(1), b.metrics.rebalanceReqRunning.Value())
-			return nil
-		}
 		req := &rebalanceRequest{
 			createdAt: timeSource.Now(),
-			conn:      conn,
-			dst:       "foo",
+			conn: &testConnHandle{
+				onTransferConnection: func() error {
+					count++
+					require.Equal(t, int64(1), b.metrics.rebalanceReqRunning.Value())
+					return nil
+				},
+			},
 		}
 		b.queue.enqueue(req)
 
@@ -186,16 +152,15 @@ func TestRebalancer_processQueue(t *testing.T) {
 
 	t.Run("conn_was_closed", func(t *testing.T) {
 		count := 0
-		conn := &testBalancerConnHandle{}
-		conn.onTransferConnection = func() error {
-			count++
-			require.Equal(t, int64(1), b.metrics.rebalanceReqRunning.Value())
-			return context.Canceled
-		}
 		req := &rebalanceRequest{
 			createdAt: timeSource.Now(),
-			conn:      conn,
-			dst:       "foo",
+			conn: &testConnHandle{
+				onTransferConnection: func() error {
+					count++
+					require.Equal(t, int64(1), b.metrics.rebalanceReqRunning.Value())
+					return context.Canceled
+				},
+			},
 		}
 		b.queue.enqueue(req)
 
@@ -231,7 +196,7 @@ func TestRebalancer_processQueue(t *testing.T) {
 		for i := 0; i < reqCount; i++ {
 			req := &rebalanceRequest{
 				createdAt: timeSource.Now(),
-				conn: &testBalancerConnHandle{
+				conn: &testConnHandle{
 					onTransferConnection: func() error {
 						// Block until all requests are enqueued.
 						<-waitCh
@@ -250,7 +215,6 @@ func TestRebalancer_processQueue(t *testing.T) {
 						return nil
 					},
 				},
-				dst: "foo",
 			}
 			b.queue.enqueue(req)
 		}
@@ -284,15 +248,13 @@ func TestRebalancer_rebalanceLoop(t *testing.T) {
 
 	metrics := NewMetrics()
 	directoryCache := newTestDirectoryCache()
-	connTracker, err := NewConnTracker(ctx, stopper, timeSource)
-	require.NoError(t, err)
 
-	_, err = NewBalancer(
+	b, err := NewBalancer(
 		ctx,
 		stopper,
 		metrics,
 		directoryCache,
-		connTracker,
+		MaxConcurrentRebalances(1),
 		TimeSource(timeSource),
 	)
 	require.NoError(t, err)
@@ -305,8 +267,16 @@ func TestRebalancer_rebalanceLoop(t *testing.T) {
 		require.True(t, directoryCache.upsertPod(pod))
 	}
 
-	h := newTestTrackerConnHandle(pods[0].Addr)
-	require.True(t, connTracker.OnConnect(roachpb.MakeTenantID(30), h))
+	// Manually assign a pod to the tracker in the balancer.
+	h := &testConnHandle{
+		onTransferConnection: func() error {
+			return nil
+		},
+	}
+	b.connTracker.registerAssignment(roachpb.MakeTenantID(30), &ServerAssignment{
+		addr:  pods[0].Addr,
+		owner: h,
+	})
 
 	// Wait until rebalance queue gets processed.
 	runs := 0
@@ -336,15 +306,12 @@ func TestRebalancer_rebalance(t *testing.T) {
 
 	metrics := NewMetrics()
 	directoryCache := newTestDirectoryCache()
-	connTracker, err := NewConnTracker(ctx, stopper, timeSource)
-	require.NoError(t, err)
 
 	b, err := NewBalancer(
 		ctx,
 		stopper,
 		metrics,
 		directoryCache,
-		connTracker,
 		NoRebalanceLoop(),
 		TimeSource(timeSource),
 	)
@@ -371,21 +338,28 @@ func TestRebalancer_rebalance(t *testing.T) {
 		{TenantID: 50, Addr: "127.0.0.50:80", State: tenant.RUNNING},
 	}
 
-	// reset resets the directory cache and connection tracker.
+	// reset recreates the directory cache.
 	reset := func(t *testing.T) {
 		t.Helper()
 
 		directoryCache = newTestDirectoryCache()
-		connTracker, err = NewConnTracker(ctx, stopper, timeSource)
-		require.NoError(t, err)
 		b.directoryCache = directoryCache
-		b.connTracker = connTracker
 
 		// Set it such that when the rebalance occurs, the pod goes into the
 		// DRAINING state.
 		recentlyDrainedPod.StateTimestamp = timeSource.Now().Add(rebalanceInterval)
 		for _, pod := range pods {
 			require.True(t, directoryCache.upsertPod(pod))
+		}
+	}
+
+	// makeHandle returns a handle that doesn't panic when TransferConnection
+	// is called.
+	makeHandle := func() *testConnHandle {
+		return &testConnHandle{
+			onTransferConnection: func() error {
+				return nil
+			},
 		}
 	}
 
@@ -400,10 +374,13 @@ func TestRebalancer_rebalance(t *testing.T) {
 			// been removed from the cache.
 			name: "no pods",
 			handlesFn: func(t *testing.T) []ConnectionHandle {
+				tenant10 := roachpb.MakeTenantID(10)
+
 				// Use a random IP since tenant-10 doesn't have a pod, and it
 				// does not matter.
-				tenant10, handle := makeConn(10, "foo-bar-baz")
-				require.True(t, connTracker.OnConnect(tenant10, handle))
+				handle := makeHandle()
+				sa := NewServerAssignment(tenant10, b.connTracker, handle, "foobarip")
+				handle.onClose = sa.Close
 				return []ConnectionHandle{handle}
 			},
 			expectedCounts: []int{0},
@@ -413,10 +390,11 @@ func TestRebalancer_rebalance(t *testing.T) {
 			// there's nothing to transfer to.
 			name: "no running pods",
 			handlesFn: func(t *testing.T) []ConnectionHandle {
-				// Use a random IP since tenant-10 doesn't have a pod, and it
-				// does not matter.
-				tenant20, handle := makeConn(20, pods[0].Addr)
-				require.True(t, connTracker.OnConnect(tenant20, handle))
+				tenant20 := roachpb.MakeTenantID(20)
+
+				handle := makeHandle()
+				sa := NewServerAssignment(tenant20, b.connTracker, handle, pods[0].Addr)
+				handle.onClose = sa.Close
 				return []ConnectionHandle{handle}
 			},
 			expectedCounts: []int{0},
@@ -426,11 +404,14 @@ func TestRebalancer_rebalance(t *testing.T) {
 			// a transfer. Use tenant-30's DRAINING pod here.
 			name: "connection closed",
 			handlesFn: func(t *testing.T) []ConnectionHandle {
+				tenant30 := roachpb.MakeTenantID(30)
 				cancelledCtx, cancel := context.WithCancel(context.Background())
 				cancel()
 
-				handle := newTestTrackerConnHandleWithContext(cancelledCtx, pods[1].Addr)
-				require.True(t, connTracker.OnConnect(roachpb.MakeTenantID(30), handle))
+				handle := makeHandle()
+				handle.ctx = cancelledCtx
+				sa := NewServerAssignment(tenant30, b.connTracker, handle, pods[1].Addr)
+				handle.onClose = sa.Close
 				return []ConnectionHandle{handle}
 			},
 			expectedCounts: []int{0},
@@ -440,9 +421,11 @@ func TestRebalancer_rebalance(t *testing.T) {
 			// because minDrainPeriod hasn't elapsed.
 			name: "recently drained pod",
 			handlesFn: func(t *testing.T) []ConnectionHandle {
+				tenant30 := roachpb.MakeTenantID(30)
 
-				tenant30, handle := makeConn(30, recentlyDrainedPod.Addr)
-				require.True(t, connTracker.OnConnect(tenant30, handle))
+				handle := makeHandle()
+				sa := NewServerAssignment(tenant30, b.connTracker, handle, recentlyDrainedPod.Addr)
+				handle.onClose = sa.Close
 				return []ConnectionHandle{handle}
 			},
 			expectedCounts: []int{0},
@@ -470,9 +453,15 @@ func TestRebalancer_rebalance(t *testing.T) {
 				}
 				var handles []ConnectionHandle
 				for _, c := range conns {
-					h := newTestTrackerConnHandle(c.Addr)
-					handles = append(handles, h)
-					require.True(t, connTracker.OnConnect(roachpb.MakeTenantID(c.TenantID), h))
+					handle := makeHandle()
+					sa := NewServerAssignment(
+						roachpb.MakeTenantID(c.TenantID),
+						b.connTracker,
+						handle,
+						c.Addr,
+					)
+					handle.onClose = sa.Close
+					handles = append(handles, handle)
 				}
 				return handles
 			},
@@ -490,13 +479,18 @@ func TestRebalancer_rebalance(t *testing.T) {
 			testutils.SucceedsSoon(t, func() error {
 				var counts []int
 				for _, h := range handles {
-					counts = append(counts, h.(*testTrackerConnHandle).transferConnectionCount())
+					counts = append(counts, h.(*testConnHandle).transferConnectionCount())
 				}
 				if !reflect.DeepEqual(tc.expectedCounts, counts) {
 					return errors.Newf("require %v, but got %v", tc.expectedCounts, counts)
 				}
 				return nil
 			})
+
+			// Clean up the handles.
+			for _, h := range handles {
+				h.Close()
+			}
 		})
 	}
 }
@@ -515,23 +509,20 @@ func TestRebalancerQueue(t *testing.T) {
 	timeSource := timeutil.NewManualTime(t0)
 
 	// Create rebalance requests for the same connection handle.
-	conn1 := &testBalancerConnHandle{}
+	conn1 := &testConnHandle{}
 	req1 := &rebalanceRequest{
 		createdAt: timeSource.Now(),
 		conn:      conn1,
-		dst:       "foo1",
 	}
 	timeSource.Advance(5 * time.Second)
 	req2 := &rebalanceRequest{
 		createdAt: timeSource.Now(),
 		conn:      conn1,
-		dst:       "foo2",
 	}
 	timeSource.Advance(5 * time.Second)
 	req3 := &rebalanceRequest{
 		createdAt: timeSource.Now(),
 		conn:      conn1,
-		dst:       "foo3",
 	}
 
 	// Enqueue in a specific order. req3 overrides req1; req2 is a no-op.
@@ -545,11 +536,10 @@ func TestRebalancerQueue(t *testing.T) {
 	require.Equal(t, int64(1), q.metrics.rebalanceReqQueued.Value())
 
 	// Create another request.
-	conn2 := &testBalancerConnHandle{}
+	conn2 := &testConnHandle{}
 	req4 := &rebalanceRequest{
 		createdAt: timeSource.Now(),
 		conn:      conn2,
-		dst:       "bar1",
 	}
 	q.enqueue(req4)
 	require.Equal(t, int64(2), q.metrics.rebalanceReqQueued.Value())
@@ -576,6 +566,8 @@ func TestRebalancerQueue(t *testing.T) {
 	require.Equal(t, int64(0), q.metrics.rebalanceReqQueued.Value())
 }
 
+// TestRebalancerQueueBlocking tests the blocking behavior when invoking
+// dequeue.
 func TestRebalancerQueueBlocking(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -604,8 +596,7 @@ func TestRebalancerQueueBlocking(t *testing.T) {
 	for i := 0; i < reqCount; i++ {
 		req := &rebalanceRequest{
 			createdAt: timeSource.Now(),
-			conn:      &testBalancerConnHandle{},
-			dst:       fmt.Sprint(i),
+			conn:      &testConnHandle{id: i},
 		}
 		q.enqueue(req)
 		timeSource.Advance(1 * time.Second)
@@ -613,28 +604,8 @@ func TestRebalancerQueueBlocking(t *testing.T) {
 
 	for i := 0; i < reqCount; i++ {
 		req := <-reqCh
-		require.Equal(t, fmt.Sprint(i), req.dst)
+		require.Equal(t, i, (req.conn.(*testConnHandle)).id)
 	}
-}
-
-// testBalancerConnHandle is a test connection handle that is used for testing
-// the balancer.
-type testBalancerConnHandle struct {
-	ConnectionHandle
-	remoteAddr           string
-	onTransferConnection func() error
-}
-
-var _ ConnectionHandle = &testBalancerConnHandle{}
-
-// TransferConnection implements the ConnectionHandle interface.
-func (h *testBalancerConnHandle) TransferConnection() error {
-	return h.onTransferConnection()
-}
-
-// ServerRemoteAddr implements the ConnectionHandle interface.
-func (h *testBalancerConnHandle) ServerRemoteAddr() string {
-	return h.remoteAddr
 }
 
 // testDirectoryCache is a test implementation of the tenant directory cache.

--- a/pkg/ccl/sqlproxyccl/balancer/conn.go
+++ b/pkg/ccl/sqlproxyccl/balancer/conn.go
@@ -24,12 +24,6 @@ type ConnectionHandle interface {
 	// been completed.
 	TransferConnection() error
 
-	// ServerRemoteAddr returns the remote address of the connection between
-	// the proxy and the server, which is basically the SQL pod's address
-	// (e.g. 10.15.42.36:26257). This will be used to identify which pod the
-	// connection handle is attached to.
-	ServerRemoteAddr() string
-
 	// IsIdle returns true if the connection is idle, and false otherwise.
 	IsIdle() bool
 }

--- a/pkg/ccl/sqlproxyccl/balancer/conn_test.go
+++ b/pkg/ccl/sqlproxyccl/balancer/conn_test.go
@@ -1,0 +1,65 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package balancer
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// testConnHandle is a test connection handle that only implements a small
+// subset of methods used for testing.
+type testConnHandle struct {
+	ConnectionHandle
+	id                   int
+	ctx                  context.Context
+	onClose              func()
+	onTransferConnection func() error
+
+	mu struct {
+		syncutil.Mutex
+		onTransferConnectionCount int
+	}
+}
+
+var _ ConnectionHandle = &testConnHandle{}
+
+// Context implements the ConnectionHandle interface.
+func (h *testConnHandle) Context() context.Context {
+	if h.ctx != nil {
+		return h.ctx
+	}
+	return context.Background()
+}
+
+// Close implements the ConnectionHandle interface.
+func (h *testConnHandle) Close() {
+	h.onClose()
+}
+
+// TransferConnection implements the ConnectionHandle interface.
+func (h *testConnHandle) TransferConnection() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.mu.onTransferConnectionCount++
+
+	if h.ctx != nil && h.ctx.Err() != nil {
+		return h.ctx.Err()
+	}
+	return h.onTransferConnection()
+}
+
+// transferConnectionCount returns the number of times TransferConnection is
+// called.
+func (h *testConnHandle) transferConnectionCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.mu.onTransferConnectionCount
+}

--- a/pkg/ccl/sqlproxyccl/balancer/conn_tracker.go
+++ b/pkg/ccl/sqlproxyccl/balancer/conn_tracker.go
@@ -54,33 +54,12 @@ func NewConnTracker(
 	return t, nil
 }
 
-// OnConnect registers the connection handle for tracking under the given
-// tenant. If the handler has already been registered, this returns false.
-func (t *ConnTracker) OnConnect(tenantID roachpb.TenantID, handle ConnectionHandle) bool {
-	e := t.getEntry(tenantID, true /* allowCreate */)
-	success := e.addHandle(handle)
-	if success {
-		logTrackerEvent("OnConnect", handle)
-	}
-	return success
-}
-
-// OnDisconnect unregisters the connection handle under the given tenant. If
-// the handler cannot be found, this returns false.
-func (t *ConnTracker) OnDisconnect(tenantID roachpb.TenantID, handle ConnectionHandle) bool {
-	e := t.getEntry(tenantID, false /* allowCreate */)
-	if e == nil {
-		return false
-	}
-	success := e.removeHandle(handle)
-	if success {
-		logTrackerEvent("OnDisconnect", handle)
-	}
-	return success
-}
-
 // GetConnsMap returns a snapshot of connections indexed by the pod's address
 // that the connection is in for the given tenant.
+//
+// TODO(jaylim-crl): This is currently exposed for forwarder_test.go to retrieve
+// the connections. This has to be unexposed once the balancer has methods that
+// will return such assignments.
 func (t *ConnTracker) GetConnsMap(tenantID roachpb.TenantID) map[string][]ConnectionHandle {
 	e := t.getEntry(tenantID, false /* allowCreate */)
 	if e == nil {
@@ -89,9 +68,27 @@ func (t *ConnTracker) GetConnsMap(tenantID roachpb.TenantID) map[string][]Connec
 	return e.getConnsMap()
 }
 
-// GetTenantIDs returns a list of tenant IDs that have at least one connection
+// registerAssignment registers the server assignment for tracking under the
+// given tenant. If the assignment has already been registered, this is a no-op.
+func (t *ConnTracker) registerAssignment(tenantID roachpb.TenantID, sa *ServerAssignment) {
+	e := t.getEntry(tenantID, true /* allowCreate */)
+	if e.addAssignment(sa) {
+		logTrackerEvent("registerAssignment", sa)
+	}
+}
+
+// unregisterAssignment unregisters the server assignment under the given
+// tenant. If the assignment cannot be found, this is a no-op.
+func (t *ConnTracker) unregisterAssignment(tenantID roachpb.TenantID, sa *ServerAssignment) {
+	e := t.getEntry(tenantID, false /* allowCreate */)
+	if e != nil && e.removeAssignment(sa) {
+		logTrackerEvent("unregisterAssignment", sa)
+	}
+}
+
+// getTenantIDs returns a list of tenant IDs that have at least one connection
 // registered with the connection tracker.
-func (t *ConnTracker) GetTenantIDs() []roachpb.TenantID {
+func (t *ConnTracker) getTenantIDs() []roachpb.TenantID {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -102,18 +99,6 @@ func (t *ConnTracker) GetTenantIDs() []roachpb.TenantID {
 		}
 	}
 	return tenants
-}
-
-// registerAssignment registers the server assignment for tracking under the
-// given tenant. If the assignment has already been registered, this is a no-op.
-func (t *ConnTracker) registerAssignment(tenantID roachpb.TenantID, sa *ServerAssignment) {
-	// TODO(jaylim-crl): implementation.
-}
-
-// unregisterAssignment unregisters the server assignment under the given
-// tenant. If the assignment cannot be found, this is a no-op.
-func (t *ConnTracker) unregisterAssignment(tenantID roachpb.TenantID, sa *ServerAssignment) {
-	// TODO(jaylim-crl): implementation.
 }
 
 // getEntry retrieves the tenantEntry instance for the given tenant. If
@@ -135,13 +120,18 @@ func (t *ConnTracker) getEntry(tenantID roachpb.TenantID, allowCreate bool) *ten
 
 // logTrackerEvent logs an event based on the logtags attached to the connection
 // goroutine.
-func logTrackerEvent(event string, handle ConnectionHandle) {
+func logTrackerEvent(event string, sa *ServerAssignment) {
+	// Tests may create an assignment without an owner.
+	owner := sa.Owner()
+	if owner == nil {
+		return
+	}
 	// The right approach would be for the caller to pass in a ctx object. For
 	// simplicity, we'll just use a background context here since it's only used
 	// for logging. Since we want logs to tie back to the connection, we'll copy
-	// the logtags associated with the handle's context.
-	logCtx := logtags.WithTags(context.Background(), logtags.FromContext(handle.Context()))
-	log.Infof(logCtx, "%s: %s", event, handle.ServerRemoteAddr())
+	// the logtags associated with the owner's context.
+	logCtx := logtags.WithTags(context.Background(), logtags.FromContext(owner.Context()))
+	log.Infof(logCtx, "%s: %s", event, sa.Addr())
 }
 
 // tenantEntry is a connection tracker entry that stores connection information
@@ -152,44 +142,45 @@ type tenantEntry struct {
 	mu struct {
 		syncutil.Mutex
 
-		// conns refers to a set of connection handles.
-		conns map[ConnectionHandle]struct{}
+		// assignments refers to a set of ServerAssignment objects.
+		//
+		// TODO(jaylim-crl): Break this into active and idle partitions.
+		assignments map[*ServerAssignment]struct{}
 	}
 }
 
 // newTenantEntry returns a new instance of tenantEntry.
 func newTenantEntry() *tenantEntry {
 	e := &tenantEntry{}
-	e.mu.conns = make(map[ConnectionHandle]struct{})
+	e.mu.assignments = make(map[*ServerAssignment]struct{})
 	return e
 }
 
-// addHandle adds the handle to the entry based on the handle's active server
-// remote address. This returns true if the operation was successful, and false
-// otherwise.
-func (e *tenantEntry) addHandle(handle ConnectionHandle) (success bool) {
+// addAssignment adds the given ServerAssignment to the tenant entry. This
+// returns true if the operation was successful, and false otherwise.
+func (e *tenantEntry) addAssignment(sa *ServerAssignment) bool {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	// Handle already exists.
-	if _, ok := e.mu.conns[handle]; ok {
+	// Assignment already exists.
+	if _, ok := e.mu.assignments[sa]; ok {
 		return false
 	}
-	e.mu.conns[handle] = struct{}{}
+	e.mu.assignments[sa] = struct{}{}
 	return true
 }
 
-// removeHandle deletes the handle from the tenant entry. This returns true if
-// the operation was successful, and false otherwise.
-func (e *tenantEntry) removeHandle(handle ConnectionHandle) (success bool) {
+// removeAssignment deletes the given ServerAssignment from the tenant entry.
+// This returns true if the operation was successful, and false otherwise.
+func (e *tenantEntry) removeAssignment(sa *ServerAssignment) bool {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	// Handle does not exists.
-	if _, ok := e.mu.conns[handle]; !ok {
+	// Assignment does not exists.
+	if _, ok := e.mu.assignments[sa]; !ok {
 		return false
 	}
-	delete(e.mu.conns, handle)
+	delete(e.mu.assignments, sa)
 	return true
 }
 
@@ -201,22 +192,15 @@ func (e *tenantEntry) getConnsMap() map[string][]ConnectionHandle {
 	defer e.mu.Unlock()
 
 	// Iterating 50K entries (the number of conns that we plan to support in
-	// each proxy) would be a few ms (< 10ms). Since getConnsMap will only be
-	// used during rebalancing, holding onto the lock while doing the below is
-	// fine. Connection goroutines that invoke addHandle or removeHandle would
-	// not have the forwarding affected, so this will not affect latency on the
-	// user's end. Regardless, if we'd like to improve this, we could first
-	// perform a copy of e.mu.conns, followed by releasing the lock before
-	// calling ServerRemoteAddr (that uses a forwarder-specific lock under the
-	// hood).
+	// each proxy) would be a few ms (< 5ms). Since getConnsMap will only be
+	// used during rebalancing (which isn't very frequent), holding onto the
+	// lock while doing the below is fine.
+	//
+	// Note that holding onto the lock for a long time will affect latency of
+	// incoming connections.
 	conns := make(map[string][]ConnectionHandle)
-	for handle := range e.mu.conns {
-		// Connection has been closed.
-		if handle.Context().Err() != nil {
-			continue
-		}
-		addr := handle.ServerRemoteAddr()
-		conns[addr] = append(conns[addr], handle)
+	for sa := range e.mu.assignments {
+		conns[sa.Addr()] = append(conns[sa.Addr()], sa.Owner())
 	}
 	return conns
 }
@@ -226,5 +210,5 @@ func (e *tenantEntry) getConnsCount() int {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	return len(e.mu.conns)
+	return len(e.mu.assignments)
 }

--- a/pkg/ccl/sqlproxyccl/balancer/conn_tracker.go
+++ b/pkg/ccl/sqlproxyccl/balancer/conn_tracker.go
@@ -104,6 +104,18 @@ func (t *ConnTracker) GetTenantIDs() []roachpb.TenantID {
 	return tenants
 }
 
+// registerAssignment registers the server assignment for tracking under the
+// given tenant. If the assignment has already been registered, this is a no-op.
+func (t *ConnTracker) registerAssignment(tenantID roachpb.TenantID, sa *ServerAssignment) {
+	// TODO(jaylim-crl): implementation.
+}
+
+// unregisterAssignment unregisters the server assignment under the given
+// tenant. If the assignment cannot be found, this is a no-op.
+func (t *ConnTracker) unregisterAssignment(tenantID roachpb.TenantID, sa *ServerAssignment) {
+	// TODO(jaylim-crl): implementation.
+}
+
 // getEntry retrieves the tenantEntry instance for the given tenant. If
 // allowCreate is set to false, getEntry returns nil if the entry does not
 // exist for the given tenant. On the other hand, if allowCreate is set to

--- a/pkg/ccl/sqlproxyccl/conn_migration.go
+++ b/pkg/ccl/sqlproxyccl/conn_migration.go
@@ -16,6 +16,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/balancer"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/interceptor"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -35,7 +36,9 @@ import (
 var defaultTransferTimeout = 15 * time.Second
 
 // Used in testing.
-var transferConnectionConnectorTestHook func(context.Context, string) (net.Conn, error) = nil
+var transferConnectionConnectorTestHook func(
+	context.Context, balancer.ConnectionHandle, string,
+) (net.Conn, error) = nil
 
 type transferContext struct {
 	context.Context
@@ -207,7 +210,7 @@ func (f *forwarder) TransferConnection() (retErr error) {
 
 	// Transfer the connection.
 	clientConn, serverConn := f.getConns()
-	newServerConn, err := transferConnection(ctx, f.connector, f.metrics, clientConn, serverConn)
+	newServerConn, err := transferConnection(ctx, f, f.connector, f.metrics, clientConn, serverConn)
 	if err != nil {
 		return errors.Wrap(err, "transferring connection")
 	}
@@ -222,6 +225,7 @@ func (f *forwarder) TransferConnection() (retErr error) {
 // connection got transferred to.
 func transferConnection(
 	ctx *transferContext,
+	requester balancer.ConnectionHandle,
 	connector *connector,
 	metrics *metrics,
 	clientConn, serverConn *interceptor.PGConn,
@@ -267,7 +271,7 @@ func transferConnection(
 	if transferConnectionConnectorTestHook != nil {
 		connectFn = transferConnectionConnectorTestHook
 	}
-	netConn, err := connectFn(ctx, revivalToken)
+	netConn, err := connectFn(ctx, requester, revivalToken)
 	if err != nil {
 		return nil, errors.Wrap(err, "opening connection")
 	}

--- a/pkg/ccl/sqlproxyccl/conn_migration_test.go
+++ b/pkg/ccl/sqlproxyccl/conn_migration_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/balancer"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/interceptor"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -128,7 +129,7 @@ func TestTransferConnection(t *testing.T) {
 		ctx, cancel := newTransferContext(context.Background())
 		cancel()
 
-		conn, err := transferConnection(ctx, nil, nil, nil, nil)
+		conn, err := transferConnection(ctx, nil, nil, nil, nil, nil)
 		require.EqualError(t, err, context.Canceled.Error())
 		require.Nil(t, conn)
 		require.True(t, ctx.isRecoverable())
@@ -148,6 +149,7 @@ func TestTransferConnection(t *testing.T) {
 
 		conn, err := transferConnection(
 			ctx,
+			nil,
 			nil,
 			nil,
 			interceptor.NewPGConn(p1),
@@ -190,6 +192,7 @@ func TestTransferConnection(t *testing.T) {
 			ctx,
 			nil,
 			nil,
+			nil,
 			interceptor.NewPGConn(p1),
 			interceptor.NewPGConn(p2),
 		)
@@ -228,6 +231,7 @@ func TestTransferConnection(t *testing.T) {
 
 		conn, err := transferConnection(
 			ctx,
+			nil,
 			nil,
 			nil,
 			interceptor.NewPGConn(p1),
@@ -269,6 +273,7 @@ func TestTransferConnection(t *testing.T) {
 		defer testutils.TestingHook(&transferConnectionConnectorTestHook,
 			func(
 				tCtx context.Context,
+				requestor balancer.ConnectionHandle,
 				token string,
 			) (net.Conn, error) {
 				require.Equal(t, ctx, tCtx)
@@ -279,6 +284,7 @@ func TestTransferConnection(t *testing.T) {
 
 		conn, err := transferConnection(
 			ctx,
+			nil,
 			&connector{},
 			nil,
 			interceptor.NewPGConn(p1),
@@ -323,6 +329,7 @@ func TestTransferConnection(t *testing.T) {
 		defer testutils.TestingHook(&transferConnectionConnectorTestHook,
 			func(
 				tCtx context.Context,
+				requestor balancer.ConnectionHandle,
 				token string,
 			) (net.Conn, error) {
 				require.Equal(t, ctx, tCtx)
@@ -346,6 +353,7 @@ func TestTransferConnection(t *testing.T) {
 
 		conn, err := transferConnection(
 			ctx,
+			nil,
 			&connector{},
 			nil,
 			interceptor.NewPGConn(p1),
@@ -394,6 +402,7 @@ func TestTransferConnection(t *testing.T) {
 		defer testutils.TestingHook(&transferConnectionConnectorTestHook,
 			func(
 				tCtx context.Context,
+				requestor balancer.ConnectionHandle,
 				token string,
 			) (net.Conn, error) {
 				require.Equal(t, ctx, tCtx)
@@ -417,6 +426,7 @@ func TestTransferConnection(t *testing.T) {
 
 		conn, err := transferConnection(
 			ctx,
+			nil,
 			&connector{},
 			nil,
 			interceptor.NewPGConn(p1),

--- a/pkg/ccl/sqlproxyccl/connector.go
+++ b/pkg/ccl/sqlproxyccl/connector.go
@@ -58,6 +58,14 @@ type connector struct {
 	// NOTE: This field is required.
 	Balancer *balancer.Balancer
 
+	// ConnTracker is used to track connections within the proxy.
+	//
+	// NOTE: This field is required.
+	//
+	// TODO(jaylim-crl): This field can be removed once we move the lookup logic
+	// into the balancer component.
+	ConnTracker *balancer.ConnTracker
+
 	// StartupMsg represents the startup message associated with the client.
 	// This will be used when establishing a pgwire connection with the SQL pod.
 	//
@@ -85,16 +93,16 @@ type connector struct {
 	// Testing knobs for internal connector calls. If specified, these will
 	// be called instead of the actual logic.
 	testingKnobs struct {
-		dialTenantCluster func(ctx context.Context) (net.Conn, error)
+		dialTenantCluster func(ctx context.Context, requester balancer.ConnectionHandle) (net.Conn, error)
 		lookupAddr        func(ctx context.Context) (string, error)
-		dialSQLServer     func(serverAddr string) (net.Conn, error)
+		dialSQLServer     func(serverAssignment *balancer.ServerAssignment) (net.Conn, error)
 	}
 }
 
 // OpenTenantConnWithToken opens a connection to the tenant cluster using the
 // token-based authentication during connection migration.
 func (c *connector) OpenTenantConnWithToken(
-	ctx context.Context, token string,
+	ctx context.Context, requester balancer.ConnectionHandle, token string,
 ) (retServerConn net.Conn, retErr error) {
 	c.StartupMsg.Parameters[sessionRevivalTokenStartupParam] = token
 	defer func() {
@@ -102,7 +110,7 @@ func (c *connector) OpenTenantConnWithToken(
 		delete(c.StartupMsg.Parameters, sessionRevivalTokenStartupParam)
 	}()
 
-	serverConn, err := c.dialTenantCluster(ctx)
+	serverConn, err := c.dialTenantCluster(ctx, requester)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +148,10 @@ func (c *connector) OpenTenantConnWithToken(
 // sentToClient will be set to true if an error occurred during the
 // authenticator phase since errors would have already been sent to the client.
 func (c *connector) OpenTenantConnWithAuth(
-	ctx context.Context, clientConn net.Conn, throttleHook func(throttler.AttemptStatus) error,
+	ctx context.Context,
+	requester balancer.ConnectionHandle,
+	clientConn net.Conn,
+	throttleHook func(throttler.AttemptStatus) error,
 ) (retServerConn net.Conn, sentToClient bool, retErr error) {
 	// Just a safety check, but this shouldn't happen since we will block the
 	// startup param in the frontend admitter. The only case where we actually
@@ -148,7 +159,7 @@ func (c *connector) OpenTenantConnWithAuth(
 	// previously, but that wouldn't happen based on the current proxy logic.
 	delete(c.StartupMsg.Parameters, sessionRevivalTokenStartupParam)
 
-	serverConn, err := c.dialTenantCluster(ctx)
+	serverConn, err := c.dialTenantCluster(ctx, requester)
 	if err != nil {
 		return nil, false, err
 	}
@@ -174,9 +185,11 @@ func (c *connector) OpenTenantConnWithAuth(
 // dialTenantCluster returns a connection to the tenant cluster associated
 // with the connector. Once a connection has been established, the pgwire
 // startup message will be relayed to the server.
-func (c *connector) dialTenantCluster(ctx context.Context) (net.Conn, error) {
+func (c *connector) dialTenantCluster(
+	ctx context.Context, requester balancer.ConnectionHandle,
+) (net.Conn, error) {
 	if c.testingKnobs.dialTenantCluster != nil {
-		return c.testingKnobs.dialTenantCluster(ctx)
+		return c.testingKnobs.dialTenantCluster(ctx, requester)
 	}
 
 	// Repeatedly try to make a connection until context is canceled, or until
@@ -211,9 +224,20 @@ func (c *connector) dialTenantCluster(ctx context.Context) (net.Conn, error) {
 			}
 			return nil, err
 		}
+
 		// Make a connection to the SQL pod.
-		crdbConn, err = c.dialSQLServer(serverAddr)
+		//
+		// TODO(jaylim-crl): See comment above about moving lookupValidAddr into
+		// the balancer.
+		serverAssignment := balancer.NewServerAssignment(
+			c.TenantID, c.ConnTracker, requester, serverAddr,
+		)
+		crdbConn, err = c.dialSQLServer(serverAssignment)
 		if err != nil {
+			// Clean up the server assignment in case of an error. If there
+			// was no error, the cleanup process is merged with net.Conn.Close().
+			serverAssignment.Close()
+
 			if isRetriableConnectorError(err) {
 				dialSQLServerErrs++
 				if dialSQLServerErr.ShouldLog() {
@@ -226,7 +250,7 @@ func (c *connector) dialTenantCluster(ctx context.Context) (net.Conn, error) {
 				// refresh any stale information that may have caused the
 				// problem.
 				if err = reportFailureToDirectoryCache(
-					ctx, c.TenantID, serverAddr, c.DirectoryCache,
+					ctx, c.TenantID, serverAssignment.Addr(), c.DirectoryCache,
 				); err != nil {
 					reportFailureErrs++
 					if reportFailureErr.ShouldLog() {
@@ -305,25 +329,27 @@ func (c *connector) lookupAddr(ctx context.Context) (string, error) {
 	}
 }
 
-// dialSQLServer dials the given address for the SQL pod, and forwards the
-// startup message to it. If the connector specifies a TLS connection, it will
-// also attempt to upgrade the PG connection to use TLS.
+// dialSQLServer dials a SQL pod based on the given server assignment, and
+// forwards the startup message to the server. If the connector specifies a TLS
+// connection, it will also attempt to upgrade the PG connection to use TLS.
 //
 // This will be called within an infinite backoff loop. If an error is
 // transient, this will return an error that has been marked with
 // errRetryConnectorSentinel (i.e. markAsRetriableConnectorError).
-func (c *connector) dialSQLServer(serverAddr string) (net.Conn, error) {
+func (c *connector) dialSQLServer(
+	serverAssignment *balancer.ServerAssignment,
+) (_ net.Conn, retErr error) {
 	if c.testingKnobs.dialSQLServer != nil {
-		return c.testingKnobs.dialSQLServer(serverAddr)
+		return c.testingKnobs.dialSQLServer(serverAssignment)
 	}
 
 	// Use a TLS config if one was provided. If TLSConfig is nil, Clone will
 	// return nil.
 	tlsConf := c.TLSConfig.Clone()
 	if tlsConf != nil {
-		// serverAddr will always have a port. We use an empty string as the
-		// default port as we only care about extracting the host.
-		outgoingHost, _, err := addr.SplitHostPort(serverAddr, "" /* defaultPort */)
+		// serverAssignment.Addr() will always have a port. We use an empty
+		// string as the default port as we only care about extracting the host.
+		outgoingHost, _, err := addr.SplitHostPort(serverAssignment.Addr(), "" /* defaultPort */)
 		if err != nil {
 			return nil, err
 		}
@@ -332,7 +358,7 @@ func (c *connector) dialSQLServer(serverAddr string) (net.Conn, error) {
 		tlsConf.ServerName = outgoingHost
 	}
 
-	conn, err := BackendDial(c.StartupMsg, serverAddr, tlsConf)
+	conn, err := BackendDial(c.StartupMsg, serverAssignment.Addr(), tlsConf)
 	if err != nil {
 		var codeErr *codeError
 		if errors.As(err, &codeErr) && codeErr.code == codeBackendDown {
@@ -340,7 +366,27 @@ func (c *connector) dialSQLServer(serverAddr string) (net.Conn, error) {
 		}
 		return nil, err
 	}
-	return conn, nil
+
+	return &onConnectionClose{
+		Conn:     conn,
+		closerFn: serverAssignment.Close,
+	}, nil
+}
+
+// onConnectionClose is a net.Conn wrapper to ensure that our custom closerFn
+// gets invoked whenever Close is called. closerFn must be idempotent.
+type onConnectionClose struct {
+	net.Conn
+	closerFn func()
+}
+
+// Close invokes our custom closer function before closing the underlying
+// net.Conn instance.
+//
+// Close implements the net.Conn interface.
+func (cc *onConnectionClose) Close() error {
+	cc.closerFn()
+	return cc.Conn.Close()
 }
 
 // errRetryConnectorSentinel exists to allow more robust retection of retry

--- a/pkg/ccl/sqlproxyccl/connector.go
+++ b/pkg/ccl/sqlproxyccl/connector.go
@@ -58,14 +58,6 @@ type connector struct {
 	// NOTE: This field is required.
 	Balancer *balancer.Balancer
 
-	// ConnTracker is used to track connections within the proxy.
-	//
-	// NOTE: This field is required.
-	//
-	// TODO(jaylim-crl): This field can be removed once we move the lookup logic
-	// into the balancer component.
-	ConnTracker *balancer.ConnTracker
-
 	// StartupMsg represents the startup message associated with the client.
 	// This will be used when establishing a pgwire connection with the SQL pod.
 	//
@@ -227,10 +219,10 @@ func (c *connector) dialTenantCluster(
 
 		// Make a connection to the SQL pod.
 		//
-		// TODO(jaylim-crl): See comment above about moving lookupValidAddr into
+		// TODO(jaylim-crl): See comment above about moving lookupAddr into
 		// the balancer.
 		serverAssignment := balancer.NewServerAssignment(
-			c.TenantID, c.ConnTracker, requester, serverAddr,
+			c.TenantID, c.Balancer.GetTracker(), requester, serverAddr,
 		)
 		crdbConn, err = c.dialSQLServer(serverAssignment)
 		if err != nil {

--- a/pkg/ccl/sqlproxyccl/forwarder.go
+++ b/pkg/ccl/sqlproxyccl/forwarder.go
@@ -227,23 +227,6 @@ func (f *forwarder) Close() {
 	}
 }
 
-// ServerRemoteAddr returns the remote address associated with serverConn, i.e.
-// the address of the SQL pod.
-//
-// ServerRemoteAddr implements the balancer.ConnectionHandle interface.
-func (f *forwarder) ServerRemoteAddr() string {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-
-	// TODO(jaylim-crl): Remove ServerRemoteAddr. Note that this case will never
-	// run since we only add the forwarder to the connection tracker once it
-	// has been started.
-	if !f.isInitializedLocked() {
-		return ""
-	}
-	return f.mu.serverConn.RemoteAddr().String()
-}
-
 // IsIdle returns true if the forwarder is idle, and false otherwise.
 //
 // IsIdle implements the balancer.ConnectionHandle interface.

--- a/pkg/ccl/sqlproxyccl/forwarder_test.go
+++ b/pkg/ccl/sqlproxyccl/forwarder_test.go
@@ -345,23 +345,6 @@ func TestForwarder_Close(t *testing.T) {
 	}
 }
 
-func TestForwarder_ServerRemoteAddr(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	ctx := context.Background()
-	p1, p2 := net.Pipe()
-
-	f := newForwarder(ctx, nil /* connector */, nil /* metrics */, nil /* timeSource */)
-	defer f.Close()
-
-	require.Equal(t, "", f.ServerRemoteAddr())
-
-	err := f.run(p1, p2)
-	require.NoError(t, err)
-
-	require.Equal(t, "pipe", f.ServerRemoteAddr())
-}
-
 func TestForwarder_tryReportError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -888,7 +888,7 @@ func TestConnectionMigration(t *testing.T) {
 
 		var f *forwarder
 		require.Eventually(t, func() bool {
-			connsMap := proxy.handler.connTracker.GetConnsMap(tenantID)
+			connsMap := proxy.handler.balancer.GetTracker().GetConnsMap(tenantID)
 			for _, conns := range connsMap {
 				if len(conns) != 0 {
 					f = conns[0].(*forwarder)
@@ -1098,7 +1098,7 @@ func TestConnectionMigration(t *testing.T) {
 
 		var f *forwarder
 		require.Eventually(t, func() bool {
-			connsMap := proxy.handler.connTracker.GetConnsMap(tenantID)
+			connsMap := proxy.handler.balancer.GetTracker().GetConnsMap(tenantID)
 			for _, conns := range connsMap {
 				if len(conns) != 0 {
 					f = conns[0].(*forwarder)
@@ -1181,7 +1181,7 @@ func TestConnectionMigration(t *testing.T) {
 
 	// All connections should eventually be terminated.
 	require.Eventually(t, func() bool {
-		connsMap := proxy.handler.connTracker.GetConnsMap(tenantID)
+		connsMap := proxy.handler.balancer.GetTracker().GetConnsMap(tenantID)
 		return len(connsMap) == 0
 	}, 10*time.Second, 100*time.Millisecond)
 }


### PR DESCRIPTION
#### ccl/sqlproxyccl: introduce a new ServerAssignment struct 

This commit introduces a new ServerAssignment struct that will be tracked by
the connection tracker through {register,unregister}Assignment. At the moment,
those functions do nothing. The plan is to update the connection tracker to
track these assignments instead of the forwarder instances. This helps in two
ways:
1. We can now update the counts map the moment a SQL pod is assigned to an
   incoming request, rather than waiting until a forwarder has been created.
2. TenantCache can be removed since we can easily maintain an up-to-date count
   map. (Previously, with the forwarder approach, we would need to keep that
   updated everytime we move the connection around. With this approach, once
   an assignment is handed out, the destination does not change. A transfer
   operation just requests for a new assignment.)
  
#### ccl/sqlproxyccl: update conn_tracker to track ServerAssignment instances 

Previously, the connection tracker was tracking forwarder instances. This
commit updates that behavior to track ServerAssignment instances. At the same
time, the connection tracker is moved into the balancer, and is now owned by
it. The plan is to rename `ConnTracker` to `tracker` or `assignmentTracker`
to denote that this is internal to the balancer only. Finally, we remove the
destination field from rebalanceRequest, and clean up the tests.

Release note: None
