### PR TITLE
tracing: introduce a StructuredEvent listener

### DIFF
--- a/pkg/util/tracing/bench_test.go
+++ b/pkg/util/tracing/bench_test.go
@@ -31,18 +31,26 @@ func BenchmarkTracer_StartSpanCtx(b *testing.B) {
 
 	staticLogTags := logtags.Buffer{}
 	staticLogTags.Add("foo", "bar")
+	mockListener := []EventListener{&mockEventListener{}}
 
 	for _, tc := range []struct {
-		name        string
-		defaultMode TracingMode
-		parent      bool
-		opts        []SpanOption
+		name              string
+		defaultMode       TracingMode
+		parent            bool
+		withEventListener bool
+		opts              []SpanOption
 	}{
-		{"none", TracingModeOnDemand, false, nil},
-		{"real", TracingModeActiveSpansRegistry, false, nil},
-		{"real,logtag", TracingModeActiveSpansRegistry, false, []SpanOption{WithLogTags(&staticLogTags)}},
-		{"real,autoparent", TracingModeActiveSpansRegistry, true, nil},
-		{"real,manualparent", TracingModeActiveSpansRegistry, true, []SpanOption{WithDetachedRecording()}},
+		{name: "none", defaultMode: TracingModeOnDemand},
+		{name: "real", defaultMode: TracingModeActiveSpansRegistry},
+		{name: "real,logtag", defaultMode: TracingModeActiveSpansRegistry,
+			opts: []SpanOption{WithLogTags(&staticLogTags)}},
+		{name: "real,autoparent", defaultMode: TracingModeActiveSpansRegistry, parent: true},
+		{name: "real,manualparent", defaultMode: TracingModeActiveSpansRegistry, parent: true,
+			opts: []SpanOption{WithDetachedRecording()}},
+		{name: "real,autoparent,withEventListener", defaultMode: TracingModeActiveSpansRegistry,
+			parent: true, withEventListener: true},
+		{name: "real,manualparent,withEventListener", defaultMode: TracingModeActiveSpansRegistry, parent: true,
+			withEventListener: true, opts: []SpanOption{WithDetachedRecording()}},
 	} {
 		b.Run(fmt.Sprintf("opts=%s", tc.name), func(b *testing.B) {
 			tr := NewTracerWithOpt(ctx,
@@ -53,7 +61,11 @@ func BenchmarkTracer_StartSpanCtx(b *testing.B) {
 			var parent *Span
 			var numOpts = len(tc.opts)
 			if tc.parent {
-				parent = tr.StartSpan("one-off")
+				if tc.withEventListener {
+					parent = tr.StartSpan("one-off", WithEventListeners(mockListener))
+				} else {
+					parent = tr.StartSpan("one-off")
+				}
 				defer parent.Finish()
 				numOpts++
 			}
@@ -106,19 +118,40 @@ func BenchmarkSpan_GetRecording(b *testing.B) {
 
 func BenchmarkRecordingWithStructuredEvent(b *testing.B) {
 	skip.UnderDeadlock(b, "span reuse triggers false-positives in the deadlock detector")
-	tr := NewTracerWithOpt(context.Background(),
-		WithTracingMode(TracingModeActiveSpansRegistry),
-		WithSpanReusePercent(100))
-
 	ev := &types.Int32Value{Value: 5}
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		root := tr.StartSpan("foo", WithRecording(RecordingStructured))
-		root.RecordStructured(ev)
-		child := tr.StartSpan("bar", WithParent(root))
-		child.RecordStructured(ev)
-		child.Finish()
-		_ = root.FinishAndGetRecording(RecordingStructured)
+	mockListener := []EventListener{&mockEventListener{}}
+
+	for _, tc := range []struct {
+		name              string
+		withEventListener bool
+	}{
+		{name: "with-event-listener", withEventListener: true},
+		{name: "without-event-listener"},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			tr := NewTracerWithOpt(context.Background(),
+				WithTracingMode(TracingModeActiveSpansRegistry),
+				WithSpanReusePercent(100))
+
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var root *Span
+				if tc.withEventListener {
+					root = tr.StartSpan("foo", WithRecording(RecordingStructured),
+						WithEventListeners(mockListener))
+				} else {
+					root = tr.StartSpan("foo", WithRecording(RecordingStructured))
+				}
+
+				root.RecordStructured(ev)
+
+				// The child span will also inherit the root span's event listener.
+				child := tr.StartSpan("bar", WithParent(root))
+				child.RecordStructured(ev)
+				child.Finish()
+				_ = root.FinishAndGetRecording(RecordingStructured)
+			}
+		})
 	}
 }
 

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -476,6 +476,19 @@ func (sp *Span) GetLazyTag(key string) (interface{}, bool) {
 	return sp.i.GetLazyTag(key)
 }
 
+// EventListener is an object that can be registered to listen for Structured
+// events recorded by the span and its children.
+type EventListener interface {
+	// Notify is invoked on every Structured event recorded by the span and its
+	// children, recursively.
+	//
+	// Note that this method should not run for a long time as it will hold up the
+	// span recording Structured events during traced operations.
+	//
+	// Notify will not be called concurrently on the same span.
+	Notify(event Structured)
+}
+
 // TraceID retrieves a span's trace ID.
 func (sp *Span) TraceID() tracingpb.TraceID {
 	if sp.detectUseAfterFinish() {
@@ -546,6 +559,7 @@ func (sp *Span) reset(
 	goroutineID uint64,
 	startTime time.Time,
 	logTags *logtags.Buffer,
+	eventListeners []EventListener,
 	kind oteltrace.SpanKind,
 	otelSpan oteltrace.Span,
 	netTr trace.Trace,
@@ -625,6 +639,9 @@ func (sp *Span) reset(
 		if c.mu.recording.logs.Len() != 0 {
 			panic("unexpected logs in span being reset")
 		}
+		if len(c.mu.eventListeners) != 0 {
+			panic(fmt.Sprintf("unexpected event listeners in span being reset: %v", c.mu.eventListeners))
+		}
 
 		h := sp.helper
 		c.mu.crdbSpanMu = crdbSpanMu{
@@ -635,7 +652,8 @@ func (sp *Span) reset(
 				logs:       makeSizeLimitedBuffer(maxLogBytesPerSpan, nil /* scratch */),
 				structured: makeSizeLimitedBuffer(maxStructuredBytesPerSpan, h.structuredEventsAlloc[:]),
 			},
-			tags: h.tagsAlloc[:0],
+			tags:           h.tagsAlloc[:0],
+			eventListeners: eventListeners,
 		}
 
 		if kind != oteltrace.SpanKindUnspecified {


### PR DESCRIPTION
This change adds an option `WithEventListeners(...)` that allows for
specifying an EventListener during span creation. An EventListener will
be notified on every StructuredEvent recorded by the span and its children.
The event listeners will be removed once the span is Finish()'ed and will no
longer receive StructuredEvent notifications. Remote spans will notify
the registerd event listeners when the remote span recording is imported into
the span with the event listeners.

The motivation for this change was to allow higher level aggregators
to watch every event without relying on periodically pulling their
root span's Recording. This way the aggregator can be sure not to
miss "important" events that may be rotated out of the underlying
ring buffer due to memory constraints.

Informs: https://github.com/cockroachdb/cockroach/issues/80395

Release note: None