### PR TITLE
kv/bulk: pull lastRange out of mu and always pass monitor

### DIFF
--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -437,6 +437,7 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 		disallowShadowingBelow,
 		writeAtBatchTS,
 		false, /* splitFilledRanges */
+		rd.flowCtx.Cfg.BackupMonitor.MakeBoundAccount(),
 	)
 	if err != nil {
 		return summary, err

--- a/pkg/ccl/backupccl/restore_data_processor_test.go
+++ b/pkg/ccl/backupccl/restore_data_processor_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
 )
@@ -239,8 +240,9 @@ func runTestIngest(t *testing.T, init func(*cluster.Settings)) {
 				return cloud.MakeExternalStorage(ctx, dest, base.ExternalIODirConfig{},
 					s.ClusterSettings(), blobs.TestBlobServiceClient(s.ClusterSettings().ExternalIODir), nil, nil, nil)
 			},
-			Settings: s.ClusterSettings(),
-			Codec:    keys.SystemSQLCodec,
+			Settings:      s.ClusterSettings(),
+			Codec:         keys.SystemSQLCodec,
+			BackupMonitor: mon.NewUnlimitedMonitor(ctx, "test", mon.MemoryResource, nil, nil, 0, s.ClusterSettings()),
 		},
 		EvalCtx: &tree.EvalContext{
 			Codec:    keys.SystemSQLCodec,

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -211,7 +211,7 @@ func (sip *streamIngestionProcessor) Start(ctx context.Context) {
 	evalCtx := sip.FlowCtx.EvalCtx
 	db := sip.FlowCtx.Cfg.DB
 	var err error
-	sip.batcher, err = bulk.MakeStreamSSTBatcher(ctx, db, evalCtx.Settings)
+	sip.batcher, err = bulk.MakeStreamSSTBatcher(ctx, db, evalCtx.Settings, sip.flowCtx.Cfg.BackupMonitor.MakeBoundAccount())
 	if err != nil {
 		sip.MoveToDraining(errors.Wrap(err, "creating stream sst batcher"))
 		return

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -146,6 +146,7 @@ func MakeSSTBatcher(
 	disallowShadowingBelow hlc.Timestamp,
 	writeAtBatchTs bool,
 	splitFilledRanges bool,
+	mem mon.BoundAccount,
 ) (*SSTBatcher, error) {
 	b := &SSTBatcher{
 		name:                   name,
@@ -154,6 +155,7 @@ func MakeSSTBatcher(
 		disallowShadowingBelow: disallowShadowingBelow,
 		writeAtBatchTS:         writeAtBatchTs,
 		disableSplits:          !splitFilledRanges,
+		mem:                    mem,
 	}
 	err := b.Reset(ctx)
 	return b, err
@@ -162,9 +164,9 @@ func MakeSSTBatcher(
 // MakeStreamSSTBatcher creates a batcher configured to ingest duplicate keys
 // that might be received from a cluster to cluster stream.
 func MakeStreamSSTBatcher(
-	ctx context.Context, db *kv.DB, settings *cluster.Settings,
+	ctx context.Context, db *kv.DB, settings *cluster.Settings, mem mon.BoundAccount,
 ) (*SSTBatcher, error) {
-	b := &SSTBatcher{db: db, settings: settings, ingestAll: true}
+	b := &SSTBatcher{db: db, settings: settings, ingestAll: true, mem: mem}
 	err := b.Reset(ctx)
 	return b, err
 }

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -114,6 +114,13 @@ type SSTBatcher struct {
 	batchEndValue   []byte
 	flushKeyChecked bool
 	flushKey        roachpb.Key
+	// lastRange is the span and remaining capacity of the last range added to,
+	// for checking if the next addition would overfill it.
+	lastRange struct {
+		span            roachpb.Span
+		remaining       sz
+		nextExistingKey roachpb.Key
+	}
 
 	// stores on-the-fly stats for the SST if disallowShadowingBelow is set.
 	ms enginepb.MVCCStats
@@ -127,14 +134,6 @@ type SSTBatcher struct {
 
 		maxWriteTS hlc.Timestamp
 		totalRows  roachpb.BulkOpSummary
-
-		// lastRange is the span and remaining capacity of the last range added to,
-		// for checking if the next addition would overfill it.
-		lastRange struct {
-			span            roachpb.Span
-			remaining       sz
-			nextExistingKey roachpb.Key
-		}
 	}
 }
 
@@ -396,19 +395,13 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int) error {
 	// than the size that range had when we last added to it, then we should split
 	// off the suffix of that range where this file starts and add it to that new
 	// range after scattering it.
-	b.mu.Lock()
-	shouldSplit := !b.disableSplits && b.mu.lastRange.span.ContainsKey(start) && size >= b.mu.lastRange.remaining
-	b.mu.Unlock()
-
-	if shouldSplit {
+	if !b.disableSplits && b.lastRange.span.ContainsKey(start) && size >= b.lastRange.remaining {
 		log.VEventf(ctx, 2, "%s batcher splitting full range before adding file starting at %s",
 			b.name, start)
 
 		expire := hlc.Timestamp{WallTime: timeutil.Now().Add(time.Minute * 10).UnixNano()}
 
-		b.mu.Lock()
-		nextKey := b.mu.lastRange.nextExistingKey.Clone()
-		b.mu.Unlock()
+		nextKey := b.lastRange.nextExistingKey
 
 		// If there was existing data as of last add that is above the file we are
 		// about to add, split there first, both since that could be why the range
@@ -480,8 +473,9 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int) error {
 	batchTS := b.batchTS
 	var reserved int64
 
+	updatesLastRange := reason != rangeFlush
 	fn := func(ctx context.Context) error {
-		if err := b.addSSTable(ctx, batchTS, start, end, data, stats); err != nil {
+		if err := b.addSSTable(ctx, batchTS, start, end, data, stats, updatesLastRange); err != nil {
 			b.mem.Shrink(ctx, reserved)
 			return err
 		}
@@ -563,6 +557,7 @@ func (b *SSTBatcher) addSSTable(
 	start, end roachpb.Key,
 	sstBytes []byte,
 	stats enginepb.MVCCStats,
+	updatesLastRange bool,
 ) error {
 	sendStart := timeutil.Now()
 	iter, err := storage.NewMemSSTIterator(sstBytes, true)
@@ -651,12 +646,19 @@ func (b *SSTBatcher) addSSTable(
 					if b.writeAtBatchTS {
 						b.mu.maxWriteTS.Forward(br.Timestamp)
 					}
-					b.mu.lastRange.span = resp.RangeSpan
-					if resp.RangeSpan.Valid() {
-						b.mu.lastRange.remaining = sz(resp.AvailableBytes)
-						b.mu.lastRange.nextExistingKey = resp.FollowingLikelyNonEmptySpanStart
-					}
 					b.mu.Unlock()
+					// If this was sent async then, by the time the reply gets back, it
+					// might not be the last range anymore. We can just discard the last
+					// range reply in this case though because async sends are only used
+					// for SSTs sent due to range boundaries, i.e. when we are done with
+					// with that range anyway.
+					if updatesLastRange {
+						b.lastRange.span = resp.RangeSpan
+						if resp.RangeSpan.Valid() {
+							b.lastRange.remaining = sz(resp.AvailableBytes)
+							b.lastRange.nextExistingKey = resp.FollowingLikelyNonEmptySpanStart
+						}
+					}
 					files++
 					log.VEventf(ctx, 3, "adding %s AddSSTable [%s,%s) took %v", sz(len(item.sstBytes)), item.start, item.end, sendTime)
 					return nil
@@ -705,9 +707,7 @@ func (b *SSTBatcher) addSSTable(
 		// top level SST which is kept around to iterate over.
 		item.sstBytes = nil
 	}
-	b.mu.Lock()
-	b.stats.splitRetries += files - 1
-	b.mu.Unlock()
+	atomic.AddInt64(&b.stats.splitRetriesAtomic, int64(files-1))
 
 	log.VEventf(ctx, 3, "AddSSTable [%v, %v) added %d files and took %v", start, end, files, timeutil.Since(sendStart))
 	return nil

--- a/pkg/kv/bulk/stats.go
+++ b/pkg/kv/bulk/stats.go
@@ -28,12 +28,12 @@ import (
 type ingestionPerformanceStats struct {
 	dataSizeAtomic int64
 
-	bufferFlushes     int // number of buffer flushes.
-	flushesDueToSize  int // number of buffer flushes due to buffer size.
-	batches           int // number of batches (addsstable calls) sent.
-	batchesDueToRange int // number of batches due to range bounds.
-	batchesDueToSize  int // number of batches due to batch size.
-	splitRetries      int // extra sub-batches created due to unexpected splits.
+	bufferFlushes      int   // number of buffer flushes.
+	flushesDueToSize   int   // number of buffer flushes due to buffer size.
+	batches            int   // number of batches (addsstable calls) sent.
+	batchesDueToRange  int   // number of batches due to range bounds.
+	batchesDueToSize   int   // number of batches due to batch size.
+	splitRetriesAtomic int64 // extra sub-batches created due to unexpected splits.
 
 	splits, scatters int // number of splits/scatters sent.
 	scatterMoved     sz  // total size moved by scatter calls.
@@ -94,7 +94,7 @@ func (s ingestionPerformanceStats) LogFlushes(
 		s.batches,
 		s.batchesDueToRange,
 		s.batchesDueToSize,
-		s.splitRetries,
+		atomic.LoadInt64(&s.splitRetriesAtomic),
 	)
 }
 


### PR DESCRIPTION
Follow-up work from https://github.com/cockroachdb/cockroach/pull/79967.

Pulling lastRange out of the mutex and only updating it on sync flushes simplifies the locking since we don't need its result anyway for range-flushes (as we flushed because were done with that range).

Additionally, the original patch added a mem monitor and used it unconditionally, however some external creators of batcher (restore, stream ingest) make their own batchers and were not populating it. Second commit fixes that.