### PR TITLE
ui: update width of timescale component

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScale.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScale.module.scss
@@ -2,6 +2,7 @@
 
 .timescale {
   display: flex;
+  width: 590px;
 }
 
 .trigger {


### PR DESCRIPTION
Previously, there was no width assigned to timescale,
making it have different size on CC Console.
This commit adds the correct width so both DB and CC
Console are aligned.

Partially addresses: #77982

Release note: None