### PR TITLE
admission: change store write admission control to use byte tokens

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3673,7 +3673,8 @@ var _ KVAdmissionController = KVAdmissionControllerImpl{}
 type admissionHandle struct {
 	tenantID                           roachpb.TenantID
 	callAdmittedWorkDoneOnKVAdmissionQ bool
-	storeAdmissionQ                    *admission.WorkQueue
+	storeAdmissionQ                    *admission.StoreWorkQueue
+	storeWorkHandle                    admission.StoreWorkHandle
 }
 
 // MakeKVAdmissionController returns a KVAdmissionController. Both parameters
@@ -3730,10 +3731,13 @@ func (n KVAdmissionControllerImpl) AdmitKVWork(
 		}
 		admissionEnabled := true
 		if ah.storeAdmissionQ != nil {
-			if admissionEnabled, err = ah.storeAdmissionQ.Admit(ctx, admissionInfo); err != nil {
+			// TODO(sumeer): Plumb WriteBytes for ingest requests.
+			ah.storeWorkHandle, err = ah.storeAdmissionQ.Admit(
+				ctx, admission.StoreWriteWorkInfo{WorkInfo: admissionInfo})
+			if err != nil {
 				return admissionHandle{}, err
 			}
-			if !admissionEnabled {
+			if !ah.storeWorkHandle.AdmissionEnabled() {
 				// Set storeAdmissionQ to nil so that we don't call AdmittedWorkDone
 				// on it. Additionally, the code below will not call
 				// kvAdmissionQ.Admit, and so callAdmittedWorkDoneOnKVAdmissionQ will
@@ -3758,7 +3762,8 @@ func (n KVAdmissionControllerImpl) AdmittedKVWorkDone(handle interface{}) {
 		n.kvAdmissionQ.AdmittedWorkDone(ah.tenantID)
 	}
 	if ah.storeAdmissionQ != nil {
-		ah.storeAdmissionQ.AdmittedWorkDone(ah.tenantID)
+		// TODO(sumeer): Plumb ingestedIntoL0Bytes and handle error return value.
+		_ = ah.storeAdmissionQ.AdmittedWorkDone(ah.storeWorkHandle, 0)
 	}
 }
 

--- a/pkg/util/admission/testdata/granter
+++ b/pkg/util/admission/testdata/granter
@@ -6,7 +6,7 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: use
 
 try-get work=kv
 ----
-kv: tryGet returned true
+kv: tryGet(1) returned true
 GrantCoordinator:
 (chain: id: 1 active: false index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
@@ -14,7 +14,7 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: use
 # No more slots.
 try-get work=kv
 ----
-kv: tryGet returned false
+kv: tryGet(1) returned false
 GrantCoordinator:
 (chain: id: 1 active: false index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
@@ -28,7 +28,7 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: use
 # Since no more KV slots, couldn't get.
 try-get work=sql-kv-response
 ----
-sql-kv-response: tryGet returned false
+sql-kv-response: tryGet(1) returned false
 GrantCoordinator:
 (chain: id: 1 active: false index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
@@ -42,7 +42,7 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: use
 # Since no more KV slots, couldn't get.
 try-get work=sql-leaf-start
 ----
-sql-leaf-start: tryGet returned false
+sql-leaf-start: tryGet(1) returned false
 GrantCoordinator:
 (chain: id: 1 active: false index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
@@ -56,7 +56,7 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: use
 # Since no more KV slots, couldn't get.
 try-get work=sql-root-start
 ----
-sql-root-start: tryGet returned false
+sql-root-start: tryGet(1) returned false
 GrantCoordinator:
 (chain: id: 1 active: false index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
@@ -69,8 +69,8 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: use
 
 return-grant work=kv
 ----
-kv: returnGrant
-kv: granted in chain 1, and returning true
+kv: returnGrant(1)
+kv: granted in chain 1, and returning 1
 GrantCoordinator:
 (chain: id: 1 active: true index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
@@ -81,7 +81,7 @@ GrantCoordinator:
 (chain: id: 1 active: true index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
 
-set-return-value-from-granted work=kv v=false
+set-return-value-from-granted work=kv v=0
 ----
 GrantCoordinator:
 (chain: id: 1 active: true index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 2
@@ -98,8 +98,8 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: use
 # Grant to sql-kv-response consumes a token.
 return-grant work=kv
 ----
-kv: returnGrant
-sql-kv-response: granted in chain 2, and returning true
+kv: returnGrant(1)
+sql-kv-response: granted in chain 2, and returning 1
 GrantCoordinator:
 (chain: id: 2 active: true index: 1) kv: used: 0, total: 1 sql-kv-response: avail: 1
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
@@ -108,7 +108,7 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: use
 continue-grant-chain work=sql-kv-response
 ----
 sql-kv-response: continueGrantChain
-sql-kv-response: granted in chain 2, and returning true
+sql-kv-response: granted in chain 2, and returning 1
 GrantCoordinator:
 (chain: id: 2 active: true index: 1) kv: used: 0, total: 1 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
@@ -118,7 +118,7 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: use
 continue-grant-chain work=sql-kv-response
 ----
 sql-kv-response: continueGrantChain
-sql-leaf-start: granted in chain 2, and returning true
+sql-leaf-start: granted in chain 2, and returning 1
 GrantCoordinator:
 (chain: id: 2 active: true index: 3) kv: used: 0, total: 1 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 0, total: 1
@@ -126,7 +126,7 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: use
 continue-grant-chain work=sql-leaf-start
 ----
 sql-leaf-start: continueGrantChain
-sql-leaf-start: granted in chain 2, and returning true
+sql-leaf-start: granted in chain 2, and returning 1
 GrantCoordinator:
 (chain: id: 2 active: true index: 3) kv: used: 0, total: 1 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 0, total: 1
@@ -136,7 +136,7 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: use
 continue-grant-chain work=sql-leaf-start
 ----
 sql-leaf-start: continueGrantChain
-sql-root-start: granted in chain 2, and returning true
+sql-root-start: granted in chain 2, and returning 1
 GrantCoordinator:
 (chain: id: 2 active: true index: 4) kv: used: 0, total: 1 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 1, total: 1
@@ -153,8 +153,8 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: use
 # which will eventually find a free slot to give to sql-leaf-start.
 return-grant work=sql-leaf-start
 ----
-sql-leaf-start: returnGrant
-sql-leaf-start: granted in chain 3, and returning true
+sql-leaf-start: returnGrant(1)
+sql-leaf-start: granted in chain 3, and returning 1
 GrantCoordinator:
 (chain: id: 3 active: true index: 3) kv: used: 0, total: 1 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 1, total: 1
@@ -163,7 +163,7 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: use
 # not past this WorkKind, so no grant is done.
 return-grant work=sql-leaf-start
 ----
-sql-leaf-start: returnGrant
+sql-leaf-start: returnGrant(1)
 GrantCoordinator:
 (chain: id: 3 active: true index: 3) kv: used: 0, total: 1 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
@@ -171,7 +171,7 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: use
 # The kv slots are fully used after this tryGet, which succeeds.
 try-get work=kv
 ----
-kv: tryGet returned true
+kv: tryGet(1) returned true
 GrantCoordinator:
 (chain: id: 3 active: true index: 3) kv: used: 1, total: 1 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
@@ -179,7 +179,7 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: use
 # This tryGet for kv fails and forces termination of the grant chain.
 try-get work=kv
 ----
-kv: tryGet returned false
+kv: tryGet(1) returned false
 GrantCoordinator:
 (chain: id: 4 active: false index: 3) kv: used: 1, total: 1 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
@@ -209,7 +209,7 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: use
 # Some other kv work takes without permission.
 took-without-permission work=kv
 ----
-kv: tookWithoutPermission
+kv: tookWithoutPermission(1)
 GrantCoordinator:
 (chain: id: 4 active: false index: 3) kv: used: 2, total: 1 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
@@ -225,7 +225,7 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: use
 # to sql-kv-response and the grant chain is again active.
 cpu-load runnable=0 procs=1
 ----
-sql-kv-response: granted in chain 4, and returning true
+sql-kv-response: granted in chain 4, and returning 1
 GrantCoordinator:
 (chain: id: 4 active: true index: 1) kv: used: 2, total: 3 sql-kv-response: avail: 1
 sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
@@ -249,7 +249,7 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: use
 # are full.
 return-grant work=sql-leaf-start
 ----
-sql-leaf-start: returnGrant
+sql-leaf-start: returnGrant(1)
 GrantCoordinator:
 (chain: id: 5 active: false index: 1) kv: used: 2, total: 2 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 1, total: 1
@@ -259,10 +259,10 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: use
 # relevant to continuing the grant chain.
 cpu-load runnable=2 procs=4
 ----
-sql-kv-response: granted in chain 0, and returning true
-sql-kv-response: granted in chain 0, and returning true
-sql-leaf-start: granted in chain 0, and returning true
-sql-leaf-start: granted in chain 5, and returning true
+sql-kv-response: granted in chain 0, and returning 1
+sql-kv-response: granted in chain 0, and returning 1
+sql-leaf-start: granted in chain 0, and returning 1
+sql-leaf-start: granted in chain 5, and returning 1
 GrantCoordinator:
 (chain: id: 5 active: true index: 3) kv: used: 2, total: 3 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 1, total: 1
@@ -270,7 +270,7 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: use
 # There is now a free sql-root-start slot, which the grant chain will get to.
 return-grant work=sql-root-start
 ----
-sql-root-start: returnGrant
+sql-root-start: returnGrant(1)
 GrantCoordinator:
 (chain: id: 5 active: true index: 3) kv: used: 2, total: 3 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 0, total: 1
@@ -288,83 +288,9 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: use
 continue-grant-chain work=sql-leaf-start
 ----
 sql-leaf-start: continueGrantChain
-sql-root-start: granted in chain 0, and returning true
+sql-root-start: granted in chain 0, and returning 1
 GrantCoordinator:
 (chain: id: 6 active: false index: 5) kv: used: 2, total: 3 sql-kv-response: avail: 0
-sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 1, total: 1
-
-# Start restricting IO tokens for KV.
-set-io-tokens tokens=1
-----
-GrantCoordinator:
-(chain: id: 6 active: false index: 5) kv: used: 2, total: 3 io-avail: 1 sql-kv-response: avail: 0
-sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 1, total: 1
-
-# Return both slots currently used by KV, so that 3 slots are free, but there
-# is only 1 token.
-return-grant work=kv
-----
-kv: returnGrant
-GrantCoordinator:
-(chain: id: 6 active: false index: 5) kv: used: 1, total: 3 io-avail: 1 sql-kv-response: avail: 0
-sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 1, total: 1
-
-return-grant work=kv
-----
-kv: returnGrant
-GrantCoordinator:
-(chain: id: 6 active: false index: 5) kv: used: 0, total: 3 io-avail: 1 sql-kv-response: avail: 0
-sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 1, total: 1
-
-# Takes 1 slot and 1 token.
-try-get work=kv
-----
-kv: tryGet returned true
-GrantCoordinator:
-(chain: id: 6 active: false index: 5) kv: used: 1, total: 3 io-avail: 0 sql-kv-response: avail: 0
-sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 1, total: 1
-
-# There are 2 slots available, but no tokens, so fails.
-try-get work=kv
-----
-kv: tryGet returned false
-GrantCoordinator:
-(chain: id: 6 active: false index: 5) kv: used: 1, total: 3 io-avail: 0 sql-kv-response: avail: 0
-sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 1, total: 1
-
-set-has-waiting-requests work=kv v=true
-----
-GrantCoordinator:
-(chain: id: 6 active: false index: 5) kv: used: 1, total: 3 io-avail: 0 sql-kv-response: avail: 0
-sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 1, total: 1
-
-set-return-value-from-granted work=kv v=true
-----
-GrantCoordinator:
-(chain: id: 6 active: false index: 5) kv: used: 1, total: 3 io-avail: 0 sql-kv-response: avail: 0
-sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 1, total: 1
-
-# Tokens become negative.
-took-without-permission work=kv
-----
-kv: tookWithoutPermission
-GrantCoordinator:
-(chain: id: 6 active: false index: 5) kv: used: 2, total: 3 io-avail: -1 sql-kv-response: avail: 0
-sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 1, total: 1
-
-# Tokens are refilled, but since was at -1, the result is 0 tokens.
-set-io-tokens tokens=1
-----
-GrantCoordinator:
-(chain: id: 6 active: false index: 5) kv: used: 2, total: 3 io-avail: 0 sql-kv-response: avail: 0
-sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 1, total: 1
-
-# Refill again. The waiting KV work is granted.
-set-io-tokens tokens=1
-----
-kv: granted in chain 0, and returning true
-GrantCoordinator:
-(chain: id: 6 active: false index: 0) kv: used: 3, total: 3 io-avail: 0 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 1, total: 1
 
 #####################################################################
@@ -378,7 +304,7 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: use
 # No more slots after this slot is granted.
 try-get work=kv
 ----
-kv: tryGet returned true
+kv: tryGet(1) returned true
 GrantCoordinator:
 (chain: id: 1 active: false index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 1
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
@@ -386,7 +312,7 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: use
 # Since no more KV slots, cannot grant token to sql-kv-response.
 try-get work=sql-kv-response
 ----
-sql-kv-response: tryGet returned false
+sql-kv-response: tryGet(1) returned false
 GrantCoordinator:
 (chain: id: 1 active: false index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 1
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
@@ -394,7 +320,7 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: use
 # Since no more KV slots, cannot grant token to sql-sql-response.
 try-get work=sql-sql-response
 ----
-sql-sql-response: tryGet returned false
+sql-sql-response: tryGet(1) returned false
 GrantCoordinator:
 (chain: id: 1 active: false index: 0) kv: used: 1, total: 1 sql-kv-response: avail: 1
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
@@ -410,7 +336,7 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: use
 # sql-kv-response can get a token.
 try-get work=sql-kv-response
 ----
-sql-kv-response: tryGet returned true
+sql-kv-response: tryGet(1) returned true
 GrantCoordinator:
 (chain: id: 1 active: false index: 5) kv: used: 1, total: 1 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
@@ -418,7 +344,7 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: use
 # sql-kv-response can get another token, even though tokens are exhausted.
 try-get work=sql-kv-response
 ----
-sql-kv-response: tryGet returned true
+sql-kv-response: tryGet(1) returned true
 GrantCoordinator:
 (chain: id: 1 active: false index: 5) kv: used: 1, total: 1 sql-kv-response: avail: -1
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
@@ -426,7 +352,7 @@ sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: use
 # sql-sql-response can get a token.
 try-get work=sql-sql-response
 ----
-sql-sql-response: tryGet returned true
+sql-sql-response: tryGet(1) returned true
 GrantCoordinator:
 (chain: id: 1 active: false index: 5) kv: used: 1, total: 1 sql-kv-response: avail: -1
 sql-sql-response: avail: 0 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
@@ -434,7 +360,7 @@ sql-sql-response: avail: 0 sql-leaf-start: used: 0, total: 2 sql-root-start: use
 # sql-sql-response can get another token, even though tokens are exhausted.
 try-get work=sql-sql-response
 ----
-sql-sql-response: tryGet returned true
+sql-sql-response: tryGet(1) returned true
 GrantCoordinator:
 (chain: id: 1 active: false index: 5) kv: used: 1, total: 1 sql-kv-response: avail: -1
 sql-sql-response: avail: -1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
@@ -442,7 +368,96 @@ sql-sql-response: avail: -1 sql-leaf-start: used: 0, total: 2 sql-root-start: us
 # KV can get another slot even though slots are exhausted.
 try-get work=kv
 ----
-kv: tryGet returned true
+kv: tryGet(1) returned true
 GrantCoordinator:
 (chain: id: 1 active: false index: 5) kv: used: 2, total: 1 sql-kv-response: avail: -1
 sql-sql-response: avail: -1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
+
+#####################################################################
+# Test store grant coordinator.
+init-store-grant-coordinator
+----
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: 614891469123651720
+
+# Initial tokens are effectively unlimited.
+try-get work=kv v=10000
+----
+kv: tryGet(10000) returned true
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: 614891469123641720
+
+# Set the io tokens to a smaller value.
+set-io-tokens tokens=500
+----
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: 500
+
+# Subtract 100 tokens.
+took-without-permission work=kv v=100
+----
+kv: tookWithoutPermission(100)
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: 400
+
+# Add 200 tokens.
+return-grant work=kv v=200
+----
+kv: returnGrant(200)
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: 600
+
+# Setup waiting requests that want 400 tokens each.
+set-has-waiting-requests work=kv v=true
+----
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: 600
+
+set-return-value-from-granted work=kv v=400
+----
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: 600
+
+# Returning tokens triggers granting and 2 requests will be granted until the
+# tokens become <= 0.
+return-grant work=kv v=100
+----
+kv: returnGrant(100)
+kv: granted in chain 0, and returning 400
+kv: granted in chain 0, and returning 400
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: -100
+
+set-return-value-from-granted work=kv v=100
+----
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: -100
+
+# No tokens to give.
+try-get work=kv
+----
+kv: tryGet(1) returned false
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: -100
+
+# Increment by 50 tokens.
+set-io-tokens tokens=50
+----
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: -50
+
+# Return another 50 tokens. Since the number of tokens is 0, there is no
+# grant.
+return-grant work=kv v=50
+----
+kv: returnGrant(50)
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: 0
+
+# As soon as the tokens > 0, it will grant.
+return-grant work=kv v=1
+----
+kv: returnGrant(1)
+kv: granted in chain 0, and returning 100
+GrantCoordinator:
+(chain: id: 0 active: false index: 5) io-avail: -99

--- a/pkg/util/admission/testdata/io_load_listener
+++ b/pkg/util/admission/testdata/io_load_listener
@@ -1,8 +1,18 @@
+# Test cases where storeAdmissionStats only populate admittedCount. This is
+# the the case where the requests are not providing any byte information.
+
+init
+----
+
+prep-admission-stats admitted=0
+----
+{admittedCount:0 admittedWithBytesCount:0 admittedBytes:0 ingestedBytes:0 ingestedIntoL0Bytes:0}
+
 # Even though above the threshold, the first 60 ticks don't limit the tokens.
-set-state admitted=0 l0-bytes=10000 l0-added=1000 l0-files=21 l0-sublevels=21
+set-state l0-bytes=10000 l0-added=1000 l0-files=21 l0-sublevels=21
 ----
 admitted: 0, bytes: 10000, added-bytes: 1000,
-smoothed-removed: 0, smoothed-admit: 0, smoothed-bytes-added-per-work: 0,
+smoothed-removed: 0, smoothed-byte-tokens: 0, smoothed-bytes-unaccounted-per-work: 0,
 tokens: unlimited, tokens-allocated: 0
 tick: 0, setAvailableIOTokens: unlimited
 tick: 1, setAvailableIOTokens: unlimited
@@ -19,82 +29,127 @@ tick: 11, setAvailableIOTokens: unlimited
 tick: 12, setAvailableIOTokens: unlimited
 tick: 13, setAvailableIOTokens: unlimited
 tick: 14, setAvailableIOTokens: unlimited
+
+prep-admission-stats admitted=10000
+----
+{admittedCount:10000 admittedWithBytesCount:0 admittedBytes:0 ingestedBytes:0 ingestedIntoL0Bytes:0}
 
 # Delta added is 100,000. The l0-bytes are the same, so compactions removed
 # 100,000 bytes. Smoothed removed by compactions is 50,000. Each admitted is
 # expected to add 10 bytes. We want to add only 25,000 (half the smoothed
-# removed), which is 2500, but smoothing it drops it to 1250.
-set-state admitted=10000 l0-bytes=10000 l0-added=101000 l0-files=21 l0-sublevels=21
+# removed), but smoothing it drops the tokens to 12,500.
+set-state l0-bytes=10000 l0-added=101000 l0-files=21 l0-sublevels=21
 ----
 admitted: 10000, bytes: 10000, added-bytes: 101000,
-smoothed-removed: 50000, smoothed-admit: 1250, smoothed-bytes-added-per-work: 10,
-tokens: 1250, tokens-allocated: 0
-tick: 0, setAvailableIOTokens: 84
-tick: 1, setAvailableIOTokens: 84
-tick: 2, setAvailableIOTokens: 84
-tick: 3, setAvailableIOTokens: 84
-tick: 4, setAvailableIOTokens: 84
-tick: 5, setAvailableIOTokens: 84
-tick: 6, setAvailableIOTokens: 84
-tick: 7, setAvailableIOTokens: 84
-tick: 8, setAvailableIOTokens: 84
-tick: 9, setAvailableIOTokens: 84
-tick: 10, setAvailableIOTokens: 84
-tick: 11, setAvailableIOTokens: 84
-tick: 12, setAvailableIOTokens: 84
-tick: 13, setAvailableIOTokens: 84
-tick: 14, setAvailableIOTokens: 74
+smoothed-removed: 50000, smoothed-byte-tokens: 12500, smoothed-bytes-unaccounted-per-work: 10,
+tokens: 12500, tokens-allocated: 0
+store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 10
+tick: 0, setAvailableIOTokens: 834
+tick: 1, setAvailableIOTokens: 834
+tick: 2, setAvailableIOTokens: 834
+tick: 3, setAvailableIOTokens: 834
+tick: 4, setAvailableIOTokens: 834
+tick: 5, setAvailableIOTokens: 834
+tick: 6, setAvailableIOTokens: 834
+tick: 7, setAvailableIOTokens: 834
+tick: 8, setAvailableIOTokens: 834
+tick: 9, setAvailableIOTokens: 834
+tick: 10, setAvailableIOTokens: 834
+tick: 11, setAvailableIOTokens: 834
+tick: 12, setAvailableIOTokens: 834
+tick: 13, setAvailableIOTokens: 834
+tick: 14, setAvailableIOTokens: 824
 
-# Same delta as previous but smoothing bumps up the smoothed-admit to 2500.
-set-state admitted=20000 l0-bytes=10000 l0-added=201000 l0-files=21 l0-sublevels=21
+prep-admission-stats admitted=20000
+----
+{admittedCount:20000 admittedWithBytesCount:0 admittedBytes:0 ingestedBytes:0 ingestedIntoL0Bytes:0}
+
+# Same delta as previous but smoothing bumps up the tokens to 25,000.
+set-state l0-bytes=10000 l0-added=201000 l0-files=21 l0-sublevels=21
 ----
 admitted: 20000, bytes: 10000, added-bytes: 201000,
-smoothed-removed: 75000, smoothed-admit: 2500, smoothed-bytes-added-per-work: 10,
-tokens: 2500, tokens-allocated: 0
-tick: 0, setAvailableIOTokens: 167
-tick: 1, setAvailableIOTokens: 167
-tick: 2, setAvailableIOTokens: 167
-tick: 3, setAvailableIOTokens: 167
-tick: 4, setAvailableIOTokens: 167
-tick: 5, setAvailableIOTokens: 167
-tick: 6, setAvailableIOTokens: 167
-tick: 7, setAvailableIOTokens: 167
-tick: 8, setAvailableIOTokens: 167
-tick: 9, setAvailableIOTokens: 167
-tick: 10, setAvailableIOTokens: 167
-tick: 11, setAvailableIOTokens: 167
-tick: 12, setAvailableIOTokens: 167
-tick: 13, setAvailableIOTokens: 167
-tick: 14, setAvailableIOTokens: 162
+smoothed-removed: 75000, smoothed-byte-tokens: 25000, smoothed-bytes-unaccounted-per-work: 10,
+tokens: 25000, tokens-allocated: 0
+store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 10
+tick: 0, setAvailableIOTokens: 1667
+tick: 1, setAvailableIOTokens: 1667
+tick: 2, setAvailableIOTokens: 1667
+tick: 3, setAvailableIOTokens: 1667
+tick: 4, setAvailableIOTokens: 1667
+tick: 5, setAvailableIOTokens: 1667
+tick: 6, setAvailableIOTokens: 1667
+tick: 7, setAvailableIOTokens: 1667
+tick: 8, setAvailableIOTokens: 1667
+tick: 9, setAvailableIOTokens: 1667
+tick: 10, setAvailableIOTokens: 1667
+tick: 11, setAvailableIOTokens: 1667
+tick: 12, setAvailableIOTokens: 1667
+tick: 13, setAvailableIOTokens: 1667
+tick: 14, setAvailableIOTokens: 1662
 
 # No delta. This used to trigger an overflow bug.
-set-state admitted=20000 l0-bytes=10000 l0-added=201000 l0-files=21 l0-sublevels=21
+set-state l0-bytes=10000 l0-added=201000 l0-files=21 l0-sublevels=21
 ----
 admitted: 20000, bytes: 10000, added-bytes: 201000,
-smoothed-removed: 37500, smoothed-admit: 2187, smoothed-bytes-added-per-work: 10,
-tokens: 2187, tokens-allocated: 0
-tick: 0, setAvailableIOTokens: 146
-tick: 1, setAvailableIOTokens: 146
-tick: 2, setAvailableIOTokens: 146
-tick: 3, setAvailableIOTokens: 146
-tick: 4, setAvailableIOTokens: 146
-tick: 5, setAvailableIOTokens: 146
-tick: 6, setAvailableIOTokens: 146
-tick: 7, setAvailableIOTokens: 146
-tick: 8, setAvailableIOTokens: 146
-tick: 9, setAvailableIOTokens: 146
-tick: 10, setAvailableIOTokens: 146
-tick: 11, setAvailableIOTokens: 146
-tick: 12, setAvailableIOTokens: 146
-tick: 13, setAvailableIOTokens: 146
-tick: 14, setAvailableIOTokens: 143
+smoothed-removed: 37500, smoothed-byte-tokens: 21875, smoothed-bytes-unaccounted-per-work: 10,
+tokens: 21875, tokens-allocated: 0
+store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 10
+tick: 0, setAvailableIOTokens: 1459
+tick: 1, setAvailableIOTokens: 1459
+tick: 2, setAvailableIOTokens: 1459
+tick: 3, setAvailableIOTokens: 1459
+tick: 4, setAvailableIOTokens: 1459
+tick: 5, setAvailableIOTokens: 1459
+tick: 6, setAvailableIOTokens: 1459
+tick: 7, setAvailableIOTokens: 1459
+tick: 8, setAvailableIOTokens: 1459
+tick: 9, setAvailableIOTokens: 1459
+tick: 10, setAvailableIOTokens: 1459
+tick: 11, setAvailableIOTokens: 1459
+tick: 12, setAvailableIOTokens: 1459
+tick: 13, setAvailableIOTokens: 1459
+tick: 14, setAvailableIOTokens: 1449
+
+prep-admission-stats admitted=30000
+----
+{admittedCount:30000 admittedWithBytesCount:0 admittedBytes:0 ingestedBytes:0 ingestedIntoL0Bytes:0}
 
 # l0-sublevels drops below threshold. We calculate the smoothed values, but
 # don't limit the tokens.
-set-state admitted=30000 l0-bytes=10000 l0-added=501000 l0-files=21 l0-sublevels=20
+set-state l0-bytes=10000 l0-added=501000 l0-files=21 l0-sublevels=20
 ----
 admitted: 30000, bytes: 10000, added-bytes: 501000,
-smoothed-removed: 168750, smoothed-admit: 6093, smoothed-bytes-added-per-work: 20,
+smoothed-removed: 168750, smoothed-byte-tokens: 160937, smoothed-bytes-unaccounted-per-work: 20,
+tokens: unlimited, tokens-allocated: 0
+store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 20
+tick: 0, setAvailableIOTokens: unlimited
+tick: 1, setAvailableIOTokens: unlimited
+tick: 2, setAvailableIOTokens: unlimited
+tick: 3, setAvailableIOTokens: unlimited
+tick: 4, setAvailableIOTokens: unlimited
+tick: 5, setAvailableIOTokens: unlimited
+tick: 6, setAvailableIOTokens: unlimited
+tick: 7, setAvailableIOTokens: unlimited
+tick: 8, setAvailableIOTokens: unlimited
+tick: 9, setAvailableIOTokens: unlimited
+tick: 10, setAvailableIOTokens: unlimited
+tick: 11, setAvailableIOTokens: unlimited
+tick: 12, setAvailableIOTokens: unlimited
+tick: 13, setAvailableIOTokens: unlimited
+tick: 14, setAvailableIOTokens: unlimited
+
+# Test cases with more information in storeAdmissionStats.
+init
+----
+
+prep-admission-stats admitted=0
+----
+{admittedCount:0 admittedWithBytesCount:0 admittedBytes:0 ingestedBytes:0 ingestedIntoL0Bytes:0}
+
+set-state l0-bytes=1000 l0-added=1000 l0-files=21 l0-sublevels=21
+----
+admitted: 0, bytes: 1000, added-bytes: 1000,
+smoothed-removed: 0, smoothed-byte-tokens: 0, smoothed-bytes-unaccounted-per-work: 0,
 tokens: unlimited, tokens-allocated: 0
 tick: 0, setAvailableIOTokens: unlimited
 tick: 1, setAvailableIOTokens: unlimited
@@ -111,3 +166,87 @@ tick: 11, setAvailableIOTokens: unlimited
 tick: 12, setAvailableIOTokens: unlimited
 tick: 13, setAvailableIOTokens: unlimited
 tick: 14, setAvailableIOTokens: unlimited
+
+# L0 will see an addition of 200,000 bytes. 180,000 bytes were mentioned by
+# the admitted requests, but 30,000 went into levels below L0. So 150,000 are
+# accounted for.
+prep-admission-stats admitted=10 admitted-bytes=180000 ingested-bytes=50000 ingested-into-l0=20000
+----
+{admittedCount:10 admittedWithBytesCount:0 admittedBytes:180000 ingestedBytes:50000 ingestedIntoL0Bytes:20000}
+
+set-state l0-bytes=1000 l0-added=201000 l0-files=21 l0-sublevels=21
+----
+admitted: 10, bytes: 1000, added-bytes: 201000,
+smoothed-removed: 100000, smoothed-byte-tokens: 25000, smoothed-bytes-unaccounted-per-work: 5000,
+tokens: 25000, tokens-allocated: 0
+store-request-estimates: fractionOfIngestIntoL0: 0.45, workByteAddition: 5000
+tick: 0, setAvailableIOTokens: 1667
+tick: 1, setAvailableIOTokens: 1667
+tick: 2, setAvailableIOTokens: 1667
+tick: 3, setAvailableIOTokens: 1667
+tick: 4, setAvailableIOTokens: 1667
+tick: 5, setAvailableIOTokens: 1667
+tick: 6, setAvailableIOTokens: 1667
+tick: 7, setAvailableIOTokens: 1667
+tick: 8, setAvailableIOTokens: 1667
+tick: 9, setAvailableIOTokens: 1667
+tick: 10, setAvailableIOTokens: 1667
+tick: 11, setAvailableIOTokens: 1667
+tick: 12, setAvailableIOTokens: 1667
+tick: 13, setAvailableIOTokens: 1667
+tick: 14, setAvailableIOTokens: 1662
+
+# L0 will see an addition of 20,000 bytes, all of which are accounted for.
+prep-admission-stats admitted=20 admitted-bytes=200000 ingested-bytes=50000 ingested-into-l0=20000
+----
+{admittedCount:20 admittedWithBytesCount:0 admittedBytes:200000 ingestedBytes:50000 ingestedIntoL0Bytes:20000}
+
+set-state l0-bytes=1000 l0-added=221000 l0-files=21 l0-sublevels=21
+----
+admitted: 20, bytes: 1000, added-bytes: 221000,
+smoothed-removed: 60000, smoothed-byte-tokens: 27500, smoothed-bytes-unaccounted-per-work: 2500,
+tokens: 27500, tokens-allocated: 0
+store-request-estimates: fractionOfIngestIntoL0: 0.45, workByteAddition: 2500
+tick: 0, setAvailableIOTokens: 1834
+tick: 1, setAvailableIOTokens: 1834
+tick: 2, setAvailableIOTokens: 1834
+tick: 3, setAvailableIOTokens: 1834
+tick: 4, setAvailableIOTokens: 1834
+tick: 5, setAvailableIOTokens: 1834
+tick: 6, setAvailableIOTokens: 1834
+tick: 7, setAvailableIOTokens: 1834
+tick: 8, setAvailableIOTokens: 1834
+tick: 9, setAvailableIOTokens: 1834
+tick: 10, setAvailableIOTokens: 1834
+tick: 11, setAvailableIOTokens: 1834
+tick: 12, setAvailableIOTokens: 1834
+tick: 13, setAvailableIOTokens: 1834
+tick: 14, setAvailableIOTokens: 1824
+
+# L0 will see an addition of 20,000 bytes, but we think we have added 100,000
+# bytes to L0. We don't let unaccounted bytes become negative.
+prep-admission-stats admitted=30 admitted-bytes=300000 ingested-bytes=50000 ingested-into-l0=20000
+----
+{admittedCount:30 admittedWithBytesCount:0 admittedBytes:300000 ingestedBytes:50000 ingestedIntoL0Bytes:20000}
+
+set-state l0-bytes=1000 l0-added=241000 l0-files=21 l0-sublevels=21
+----
+admitted: 30, bytes: 1000, added-bytes: 241000,
+smoothed-removed: 40000, smoothed-byte-tokens: 23750, smoothed-bytes-unaccounted-per-work: 1250,
+tokens: 23750, tokens-allocated: 0
+store-request-estimates: fractionOfIngestIntoL0: 0.45, workByteAddition: 1250
+tick: 0, setAvailableIOTokens: 1584
+tick: 1, setAvailableIOTokens: 1584
+tick: 2, setAvailableIOTokens: 1584
+tick: 3, setAvailableIOTokens: 1584
+tick: 4, setAvailableIOTokens: 1584
+tick: 5, setAvailableIOTokens: 1584
+tick: 6, setAvailableIOTokens: 1584
+tick: 7, setAvailableIOTokens: 1584
+tick: 8, setAvailableIOTokens: 1584
+tick: 9, setAvailableIOTokens: 1584
+tick: 10, setAvailableIOTokens: 1584
+tick: 11, setAvailableIOTokens: 1584
+tick: 12, setAvailableIOTokens: 1584
+tick: 13, setAvailableIOTokens: 1584
+tick: 14, setAvailableIOTokens: 1574

--- a/pkg/util/admission/testdata/store_work_queue
+++ b/pkg/util/admission/testdata/store_work_queue
@@ -1,0 +1,103 @@
+init
+----
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+stats:{admittedCount:0 admittedWithBytesCount:0 admittedBytes:0 ingestedBytes:0 ingestedIntoL0Bytes:0}
+estimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1}
+
+set-try-get-return-value v=true
+----
+
+admit id=1 tenant=53 priority=0 create-time-millis=1 bypass=false
+----
+tryGet: returning true
+id 1: admit succeeded with handle {tenantID:{InternalValue:53} writeBytes:0 writeTokens:1 workByteAdditionTokens:1 ingestRequest:false admissionEnabled:true}
+
+work-done id=1
+----
+
+set-store-request-estimates percent-ingested-into-l0=20 work-bytes-addition=100
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 53 used: 1, w: 1, fifo: -128
+stats:{admittedCount:1 admittedWithBytesCount:0 admittedBytes:0 ingestedBytes:0 ingestedIntoL0Bytes:0}
+estimates:{fractionOfIngestIntoL0:0.2 workByteAddition:100}
+
+admit id=2 tenant=55 priority=0 create-time-millis=1 bypass=false
+----
+tryGet: returning true
+id 2: admit succeeded with handle {tenantID:{InternalValue:55} writeBytes:0 writeTokens:100 workByteAdditionTokens:100 ingestRequest:false admissionEnabled:true}
+
+admit id=3 tenant=53 priority=0 create-time-millis=1 bypass=false write-bytes=1000000 ingest-request=true
+----
+tryGet: returning true
+id 3: admit succeeded with handle {tenantID:{InternalValue:53} writeBytes:1000000 writeTokens:200100 workByteAdditionTokens:100 ingestRequest:true admissionEnabled:true}
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 53 used: 200101, w: 1, fifo: -128
+ tenant-id: 55 used: 100, w: 1, fifo: -128
+stats:{admittedCount:1 admittedWithBytesCount:0 admittedBytes:0 ingestedBytes:0 ingestedIntoL0Bytes:0}
+estimates:{fractionOfIngestIntoL0:0.2 workByteAddition:100}
+
+set-try-get-return-value v=false
+----
+
+admit id=4 tenant=57 priority=0 create-time-millis=1 bypass=false write-bytes=2000 ingest-request=false
+----
+tryGet: returning false
+
+work-done id=2
+----
+
+print
+----
+closed epoch: 0 tenantHeap len: 1 top tenant: 57
+ tenant-id: 53 used: 200101, w: 1, fifo: -128
+ tenant-id: 55 used: 100, w: 1, fifo: -128
+ tenant-id: 57 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 0]
+stats:{admittedCount:2 admittedWithBytesCount:0 admittedBytes:0 ingestedBytes:0 ingestedIntoL0Bytes:0}
+estimates:{fractionOfIngestIntoL0:0.2 workByteAddition:100}
+
+granted
+----
+continueGrantChain 0
+id 4: admit succeeded with handle {tenantID:{InternalValue:57} writeBytes:2000 writeTokens:2100 workByteAdditionTokens:100 ingestRequest:false admissionEnabled:true}
+granted: returned 2100
+
+work-done id=3 ingested-into-l0=20000
+----
+returnGrant 180000
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 53 used: 20101, w: 1, fifo: -128
+ tenant-id: 55 used: 100, w: 1, fifo: -128
+ tenant-id: 57 used: 2100, w: 1, fifo: -128
+stats:{admittedCount:3 admittedWithBytesCount:1 admittedBytes:1000000 ingestedBytes:1000000 ingestedIntoL0Bytes:20000}
+estimates:{fractionOfIngestIntoL0:0.2 workByteAddition:100}
+
+set-store-request-estimates percent-ingested-into-l0=10 work-bytes-addition=10000
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 53 used: 20101, w: 1, fifo: -128
+ tenant-id: 55 used: 100, w: 1, fifo: -128
+ tenant-id: 57 used: 2100, w: 1, fifo: -128
+stats:{admittedCount:3 admittedWithBytesCount:1 admittedBytes:1000000 ingestedBytes:1000000 ingestedIntoL0Bytes:20000}
+estimates:{fractionOfIngestIntoL0:0.1 workByteAddition:10000}
+
+work-done id=4
+----
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 53 used: 20101, w: 1, fifo: -128
+ tenant-id: 55 used: 100, w: 1, fifo: -128
+ tenant-id: 57 used: 2100, w: 1, fifo: -128
+stats:{admittedCount:4 admittedWithBytesCount:2 admittedBytes:1002000 ingestedBytes:1000000 ingestedIntoL0Bytes:20000}
+estimates:{fractionOfIngestIntoL0:0.1 workByteAddition:10000}

--- a/pkg/util/admission/testdata/work_queue
+++ b/pkg/util/admission/testdata/work_queue
@@ -58,7 +58,7 @@ granted chain-id=5
 ----
 continueGrantChain 5
 id 5: admit succeeded
-granted: returned true
+granted: returned 1
 
 # Both tenants are using 1 slot. The tie is broken arbitrarily in favor of
 # tenant 71.
@@ -82,7 +82,7 @@ closed epoch: 0 tenantHeap len: 2 top tenant: 71
 # The work admitted for tenant 53 is done.
 work-done id=1
 ----
-returnGrant
+returnGrant 1
 
 # Tenant 53 now using fewer slots so it becomes the top of the heap.
 print
@@ -95,7 +95,7 @@ closed epoch: 0 tenantHeap len: 2 top tenant: 53
 # reflected in the WorkQueue state.
 admit id=6 tenant=1 priority=0 create-time-millis=6 bypass=true
 ----
-tookWithoutPermission
+tookWithoutPermission 1
 id 6: admit succeeded
 
 print
@@ -109,13 +109,13 @@ granted chain-id=7
 ----
 continueGrantChain 7
 id 2: admit succeeded
-granted: returned true
+granted: returned 1
 
 granted chain-id=9
 ----
 continueGrantChain 9
 id 4: admit succeeded
-granted: returned true
+granted: returned 1
 
 # No more waiting requests.
 print
@@ -128,7 +128,7 @@ closed epoch: 0 tenantHeap len: 0
 # Granted returns false.
 granted chain-id=10
 ----
-granted: returned false
+granted: returned 0
 
 print
 ----
@@ -162,7 +162,7 @@ granted chain-id=5
 ----
 continueGrantChain 5
 id 1: admit succeeded
-granted: returned true
+granted: returned 1
 
 print
 ----
@@ -196,14 +196,14 @@ granted chain-id=6
 ----
 continueGrantChain 6
 id 3: admit succeeded
-granted: returned true
+granted: returned 1
 
 # Older request in closed epoch is granted.
 granted chain-id=7
 ----
 continueGrantChain 7
 id 2: admit succeeded
-granted: returned true
+granted: returned 1
 
 # Only request is in open epoch.
 print
@@ -247,13 +247,13 @@ granted chain-id=8
 ----
 continueGrantChain 8
 id 7: admit succeeded
-granted: returned true
+granted: returned 1
 
 granted chain-id=9
 ----
 continueGrantChain 9
 id 5: admit succeeded
-granted: returned true
+granted: returned 1
 
 # Add another request to closed epoch that is subject to LIFO ordering.
 admit id=8 tenant=53 priority=0 create-time-millis=350 bypass=false
@@ -274,7 +274,7 @@ granted chain-id=10
 ----
 continueGrantChain 10
 id 4: admit succeeded
-granted: returned true
+granted: returned 1
 
 print
 ----
@@ -285,7 +285,7 @@ granted chain-id=11
 ----
 continueGrantChain 11
 id 8: admit succeeded
-granted: returned true
+granted: returned 1
 
 print
 ----
@@ -297,7 +297,7 @@ granted chain-id=12
 ----
 continueGrantChain 12
 id 6: admit succeeded
-granted: returned true
+granted: returned 1
 
 print
 ----
@@ -334,7 +334,7 @@ granted chain-id=12
 ----
 continueGrantChain 12
 id 10: admit succeeded
-granted: returned true
+granted: returned 1
 
 print
 ----
@@ -365,7 +365,7 @@ granted chain-id=13
 ----
 continueGrantChain 13
 id 11: admit succeeded
-granted: returned true
+granted: returned 1
 
 # With the remaining two items, the priority is different, so higher priority
 # is preferred.
@@ -378,13 +378,13 @@ granted chain-id=14
 ----
 continueGrantChain 14
 id 9: admit succeeded
-granted: returned true
+granted: returned 1
 
 granted chain-id=15
 ----
 continueGrantChain 15
 id 12: admit succeeded
-granted: returned true
+granted: returned 1
 
 # Advance time again. Since one of the priority=0 requests experienced high
 # latency, switch that back to LIFO.
@@ -473,13 +473,13 @@ granted chain-id=1
 ----
 continueGrantChain 1
 id 1: admit succeeded
-granted: returned true
+granted: returned 1
 
 granted chain-id=2
 ----
 continueGrantChain 2
 id 2: admit succeeded
-granted: returned true
+granted: returned 1
 
 # Both tenants are using 1 slot.
 print
@@ -508,7 +508,7 @@ granted chain-id=3
 ----
 continueGrantChain 3
 id 4: admit succeeded
-granted: returned true
+granted: returned 1
 
 print
 ----
@@ -558,7 +558,7 @@ granted chain-id=4
 ----
 continueGrantChain 4
 id 5: admit succeeded
-granted: returned true
+granted: returned 1
 
 # Tenant 10 is using 3 slots and tenant 5 is using 1 slot. Tenant 5 is the top
 # of the heap.
@@ -580,13 +580,13 @@ granted chain-id=5
 ----
 continueGrantChain 5
 id 6: admit succeeded
-granted: returned true
+granted: returned 1
 
 granted chain-id=6
 ----
 continueGrantChain 6
 id 3: admit succeeded
-granted: returned true
+granted: returned 1
 
 # Test that batch update of tenant weights is working correctly.
 init
@@ -649,49 +649,49 @@ granted chain-id=1
 ----
 continueGrantChain 1
 id 1: admit succeeded
-granted: returned true
+granted: returned 1
 
 granted chain-id=2
 ----
 continueGrantChain 2
 id 8: admit succeeded
-granted: returned true
+granted: returned 1
 
 granted chain-id=3
 ----
 continueGrantChain 3
 id 7: admit succeeded
-granted: returned true
+granted: returned 1
 
 granted chain-id=4
 ----
 continueGrantChain 4
 id 6: admit succeeded
-granted: returned true
+granted: returned 1
 
 granted chain-id=5
 ----
 continueGrantChain 5
 id 5: admit succeeded
-granted: returned true
+granted: returned 1
 
 granted chain-id=6
 ----
 continueGrantChain 6
 id 4: admit succeeded
-granted: returned true
+granted: returned 1
 
 granted chain-id=7
 ----
 continueGrantChain 7
 id 3: admit succeeded
-granted: returned true
+granted: returned 1
 
 granted chain-id=8
 ----
 continueGrantChain 8
 id 2: admit succeeded
-granted: returned true
+granted: returned 1
 
 print
 ----


### PR DESCRIPTION
This switch to byte tokens will result in better accounting for
large writes, including ingests based on whether their bytes land
in L0 or elsewhere. It is also a precurson to taking into account
flush capacity (in bytes).

The store write admission control path now uses a StoreWorkQueue
which wraps a WorkQueue and provides additional functionality:
- Work can specify WriteBytes and whether it is an IngestRequest.
  This is used to decide how many byte tokens to consume.
- Done work specifies how many bytes were ingested into L0, so
  token consumption can be adjusted.

The main framework change is that a single work item can consume
multiple (byte) tokens, which ripples through the various
interfaces including requester, granter. There is associated
cleanup: kvGranter that was handling both slots and tokens is
eliminated since in practice it was only doing one or the other.
Instead, for the slot case the slotGranter is reused. For the token
case there is a new kvStoreTokenGranter.

The main logic change is in ioLoadListener which computes byte
tokens and various estimates. The change is (mostly) neutral if
no write provides WriteBytes, since the usual estimation will
take over. The integration changes in this PR are superficial in
that the requests don't provide WriteBytes. Improvements to the
integration, along with experimental results, will happen in
future PRs.

Informs #79092
Informs #77357

Release note: None