### PR TITLE
ui: fix resizing issue on Hot ranges page

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRanges.module.styl
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRanges.module.styl
@@ -15,9 +15,6 @@
   justify-content space-between
   margin-top 16px
 
-.hotranges-table
-  width 100%
-
 .light-anchor
   color $colors--primary-blue-2
   &:hover


### PR DESCRIPTION
This change fixes an issue when Hot ranges page
is resized to small width (when all table columns
cannot fit on the window) and then table borders
overlap borders of parent elements.

Release note (ui change): fix resizing of table on
Hot Ranges page

Resolves: [CRDB-2323](https://cockroachlabs.atlassian.net/browse/CRDB-2323)