### PR TITLE
roachtest: lower kv.transaction.max_refresh_span_bytes in tpch-concurrency

### DIFF
--- a/pkg/cmd/roachtest/tests/tpch_concurrency.go
+++ b/pkg/cmd/roachtest/tests/tpch_concurrency.go
@@ -32,6 +32,7 @@ func registerTPCHConcurrency(r registry.Registry) {
 		ctx context.Context,
 		t test.Test,
 		c cluster.Cluster,
+		lowerRefreshSpanBytes bool,
 	) {
 		c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, numNodes-1))
 		c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(numNodes))
@@ -45,6 +46,16 @@ func registerTPCHConcurrency(r registry.Registry) {
 		}
 		if _, err := conn.Exec("SET CLUSTER SETTING kv.range_merge.queue_enabled = false;"); err != nil {
 			t.Fatal(err)
+		}
+
+		if lowerRefreshSpanBytes {
+			// Temporarily lower a KV setting to its previous default to confirm
+			// that the new value of 4MiB is, indeed, the root cause of the
+			// regression in the highest concurrency.
+			// TODO(yuzefovich): remove this.
+			if _, err := conn.Exec("SET CLUSTER SETTING kv.transaction.max_refresh_span_bytes = 256000"); err != nil {
+				t.Fatal(err)
+			}
 		}
 
 		if err := loadTPCHDataset(ctx, t, c, 1 /* sf */, c.NewMonitor(ctx, c.Range(1, numNodes-1)), c.Range(1, numNodes-1)); err != nil {
@@ -167,8 +178,9 @@ func registerTPCHConcurrency(r registry.Registry) {
 		ctx context.Context,
 		t test.Test,
 		c cluster.Cluster,
+		lowerRefreshSpanBytes bool,
 	) {
-		setupCluster(ctx, t, c)
+		setupCluster(ctx, t, c, lowerRefreshSpanBytes)
 		// TODO(yuzefovich): once we have a good grasp on the expected value for
 		// max supported concurrency, we should use search.Searcher instead of
 		// the binary search here. Additionally, we should introduce an
@@ -176,6 +188,9 @@ func registerTPCHConcurrency(r registry.Registry) {
 		// supported concurrency is always sustained and fail the test if it
 		// isn't.
 		minConcurrency, maxConcurrency := 48, 160
+		if !lowerRefreshSpanBytes {
+			minConcurrency, maxConcurrency = 4, 64
+		}
 		// Run the binary search to find the largest concurrency that doesn't
 		// crash a node in the cluster. The current range is represented by
 		// [minConcurrency, maxConcurrency).
@@ -206,7 +221,23 @@ func registerTPCHConcurrency(r registry.Registry) {
 		Owner:   registry.OwnerSQLQueries,
 		Cluster: r.MakeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			runTPCHConcurrency(ctx, t, c)
+			runTPCHConcurrency(ctx, t, c, true /* lowerRefreshSpanBytes */)
+		},
+		// By default, the timeout is 10 hours which might not be sufficient
+		// given that a single iteration of checkConcurrency might take on the
+		// order of an hour and a half, so in order to let each test run to
+		// complete, we'll give it 12 hours. Successful runs typically take
+		// less, around 8 hours.
+		Timeout: 12 * time.Hour,
+	})
+
+	// TODO(yuzefovich): remove this once the regression is understood.
+	r.Add(registry.TestSpec{
+		Name:    "tpch_concurrency/high_refresh_span_bytes",
+		Owner:   registry.OwnerSQLQueries,
+		Cluster: r.MakeClusterSpec(numNodes),
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runTPCHConcurrency(ctx, t, c, false /* lowerRefreshSpanBytes */)
 		},
 		// By default, the timeout is 10 hours which might not be sufficient
 		// given that a single iteration of checkConcurrency might take on the


### PR DESCRIPTION
The default value of the setting has been increased from 256KB to 4MiB,
and I believe it is the cause of the regression in the highest
concurrency in `tpch-concurrency` roachtest, so lower it (possibly
temporarily).

In order to check this hypothesis, this commit adjusts the test so that
we now run with the previous default of 256KB (this will be shown on the
roachperf dashboard) as well as with the new default of 4MiB. We can
then examine the numbers from the latter config.

Release note: None