### PR TITLE
release-22.1: roachtest: ignore flaky activerecord test

### DIFF
--- a/pkg/cmd/roachtest/tests/activerecord_blocklist.go
+++ b/pkg/cmd/roachtest/tests/activerecord_blocklist.go
@@ -42,6 +42,7 @@ var activeRecordIgnoreList22_1 = blocklist{
 	"FixturesTest#test_create_fixtures":                                    "flaky - FK constraint violated sometimes when loading all fixture data",
 	"IgnoreFixturesTest#test_ignores_books_fixtures":                       "flaky - FK constraint violated sometimes when loading all fixture data",
 	"IgnoreFixturesTest#test_ignores_parrots_fixtures":                     "flaky - FK constraint violated sometimes when loading all fixture data",
+	"PostgresqlIntervalTest#test_interval_type":                            "flaky",
 }
 
 var activeRecordIgnoreList21_2 = blocklist{


### PR DESCRIPTION
Backport 1/1 commits from #80489.

/cc @cockroachdb/release

fixes https://github.com/cockroachdb/cockroach/issues/80453

---

fixes https://github.com/cockroachdb/cockroach/issues/80220

Release note: None

Release justification: test only change