### PR TITLE
backupccl: add 'check_files' option to SHOW BACKUP

### DIFF
--- a/pkg/ccl/backupccl/backup.proto
+++ b/pkg/ccl/backupccl/backup.proto
@@ -32,8 +32,9 @@ enum MVCCFilter {
 // ranges in a backup is the same, but the start may vary (to allow individual
 // tables to be backed up on different schedules).
 message BackupManifest {
-  // BackupManifest_File represents a file that contains the diff for a key
-  // range between two timestamps.
+  // BackupManifest_File represents a diff for a key range between two
+  // timestamps. Note that many BackupManifest_File spans can get written to a
+  // single SST.
   message File {
     roachpb.Span span = 1 [(gogoproto.nullable) = false];
     string path = 2;

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -72,6 +72,7 @@ const (
 	defaultLocalityValue      = "default"
 	backupOptDebugMetadataSST = "debug_dump_metadata_sst"
 	backupOptEncDir           = "encryption_info_dir"
+	backupOptCheckFiles       = "check_files"
 )
 
 type tableAndIndex struct {

--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -658,6 +658,14 @@ func getLocalityInfo(
 		}
 		found := false
 		for i, store := range stores {
+			// Iterate through the available stores in case the user moved a locality
+			// partition, guarding against stale backup manifest info. In addition,
+			// two locality aware URIs may end up writing to the same location (e.g.
+			// in testing, 'nodelocal://0/foo?COCKROACH_LOCALITY=default' and
+			// 'nodelocal://1/foo?COCKROACH_LOCALITY=dc=d1' will write to the same
+			// tempdir), implying that it is possible for files that the manifest
+			// claims are stored in two different localities, are actually stored in
+			// the same place.
 			if desc, _, err := readBackupPartitionDescriptor(ctx, nil /*mem*/, store, filename, encryption); err == nil {
 				if desc.BackupID != mainBackupManifest.ID {
 					return info, errors.Errorf(

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -218,6 +218,7 @@ func showBackupPlanHook(
 		backupOptIncStorage:       sql.KVStringOptRequireValue,
 		backupOptDebugMetadataSST: sql.KVStringOptRequireNoValue,
 		backupOptEncDir:           sql.KVStringOptRequireValue,
+		backupOptCheckFiles:       sql.KVStringOptRequireNoValue,
 	}
 	optsFn, err := p.TypeAsStringOpts(ctx, backup.Options, expected)
 	if err != nil {
@@ -401,6 +402,7 @@ you must pass the 'encryption_info_dir' parameter that points to the directory o
 			info        backupInfo
 			memReserved int64
 		)
+		info.collectionURI = dest[0]
 		info.subdir = computedSubdir
 
 		mkStore := p.ExecCfg().DistSQLSrv.ExternalStorageFromURI
@@ -449,6 +451,15 @@ you must pass the 'encryption_info_dir' parameter that points to the directory o
 						len(dest)))
 			}
 		}
+		if _, ok := opts[backupOptCheckFiles]; ok {
+			fileSizes, err := checkBackupFiles(ctx, info,
+				p.ExecCfg().DistSQLSrv.ExternalStorageFromURI,
+				p.User())
+			if err != nil {
+				return err
+			}
+			info.fileSizes = fileSizes
+		}
 		if err := infoReader.showBackup(ctx, &mem, mkStore, info, p.User(), resultsCh); err != nil {
 			return err
 		}
@@ -463,12 +474,99 @@ you must pass the 'encryption_info_dir' parameter that points to the directory o
 	return fn, infoReader.header(), nil, false, nil
 }
 
+// checkBackupFiles validates that each SST is in its expected storage location
+func checkBackupFiles(
+	ctx context.Context,
+	info backupInfo,
+	storeFactory cloud.ExternalStorageFromURIFactory,
+	user username.SQLUsername,
+) ([][]int64, error) {
+
+	checkLayer := func(layer int) ([]int64, error) {
+		// TODO (msbutler): Right now, checkLayer opens stores for each backup layer. In 22.2,
+		// once a backup chain cannot have mixed localities, only create stores for full backup
+		// and first incremental backup.
+		defaultStore, err := storeFactory(ctx, info.defaultURIs[layer], user)
+		if err != nil {
+			return nil, err
+		}
+		localityStores := make(map[string]cloud.ExternalStorage)
+
+		defer func() {
+			if err := defaultStore.Close(); err != nil {
+				log.Warningf(ctx, "close export storage failed %v", err)
+			}
+			for _, store := range localityStores {
+				if err := store.Close(); err != nil {
+					log.Warningf(ctx, "close export storage failed %v", err)
+				}
+			}
+		}()
+		// Check metadata files. Note: we do not check locality aware backup
+		// metadata files ( prefixed with `backupPartitionDescriptorPrefix`) , as
+		// they're validated in resolveBackupManifests.
+		for _, metaFile := range []string{
+			fileInfoPath,
+			metadataSSTName,
+			backupManifestName + backupManifestChecksumSuffix} {
+			if _, err := defaultStore.Size(ctx, metaFile); err != nil {
+				return nil, errors.Wrapf(err, "Error checking metadata file %s/%s",
+					info.defaultURIs[layer], metaFile)
+			}
+		}
+		// Check stat files.
+		for _, statFile := range info.manifests[layer].StatisticsFilenames {
+			if _, err := defaultStore.Size(ctx, statFile); err != nil {
+				return nil, errors.Wrapf(err, "Error checking metadata file %s/%s",
+					info.defaultURIs[layer], statFile)
+			}
+		}
+
+		for locality, uri := range info.localityInfo[layer].URIsByOriginalLocalityKV {
+			store, err := storeFactory(ctx, uri, user)
+			if err != nil {
+				return nil, err
+			}
+			localityStores[locality] = store
+		}
+
+		// Check all backup SSTs.
+		fileSizes := make([]int64, len(info.manifests[layer].Files))
+		for i, f := range info.manifests[layer].Files {
+			store := defaultStore
+			uri := info.defaultURIs[layer]
+			if _, ok := localityStores[f.LocalityKV]; ok {
+				store = localityStores[f.LocalityKV]
+				uri = info.localityInfo[layer].URIsByOriginalLocalityKV[f.LocalityKV]
+			}
+			sz, err := store.Size(ctx, f.Path)
+			if err != nil {
+				return nil, errors.Wrapf(err, "Error checking file %s in %s", f.Path, uri)
+			}
+			fileSizes[i] = sz
+		}
+		return fileSizes, nil
+	}
+
+	manifestFileSizes := make([][]int64, len(info.manifests))
+	for layer := range info.manifests {
+		layerFileSizes, err := checkLayer(layer)
+		if err != nil {
+			return nil, err
+		}
+		manifestFileSizes[layer] = layerFileSizes
+	}
+	return manifestFileSizes, nil
+}
+
 type backupInfo struct {
-	defaultURIs  []string
-	manifests    []BackupManifest
-	subdir       string
-	localityInfo []jobspb.RestoreDetails_BackupLocalityInfo
-	enc          *jobspb.BackupEncryptionOptions
+	collectionURI string
+	defaultURIs   []string
+	manifests     []BackupManifest
+	subdir        string
+	localityInfo  []jobspb.RestoreDetails_BackupLocalityInfo
+	enc           *jobspb.BackupEncryptionOptions
+	fileSizes     [][]int64
 }
 
 type backupShower struct {
@@ -501,7 +599,9 @@ func backupShowerHeaders(showSchemas bool, opts map[string]string) colinfo.Resul
 		baseHeaders = append(baseHeaders, colinfo.ResultColumn{Name: "privileges", Typ: types.String})
 		baseHeaders = append(baseHeaders, colinfo.ResultColumn{Name: "owner", Typ: types.String})
 	}
-
+	if _, checkFiles := opts[backupOptCheckFiles]; checkFiles {
+		baseHeaders = append(baseHeaders, colinfo.ResultColumn{Name: "file_bytes", Typ: types.Int})
+	}
 	if _, shouldShowIDs := opts[backupOptWithDebugIDs]; shouldShowIDs {
 		baseHeaders = append(
 			colinfo.ResultColumns{
@@ -525,7 +625,7 @@ func backupShowerDefault(
 		header: backupShowerHeaders(showSchemas, opts),
 		fn: func(info backupInfo) ([]tree.Datums, error) {
 			var rows []tree.Datums
-			for _, manifest := range info.manifests {
+			for layer, manifest := range info.manifests {
 				// Map database ID to descriptor name.
 				dbIDToName := make(map[descpb.ID]string)
 				schemaIDToName := make(map[descpb.ID]string)
@@ -542,7 +642,11 @@ func backupShowerDefault(
 						}
 					}
 				}
-				tableSizes, err := getTableSizes(manifest.Files)
+				var fileSizes []int64
+				if len(info.fileSizes) > 0 {
+					fileSizes = info.fileSizes[layer]
+				}
+				tableSizes, err := getTableSizes(manifest.Files, fileSizes)
 				if err != nil {
 					return nil, err
 				}
@@ -575,6 +679,7 @@ func backupShowerDefault(
 					createStmtDatum := tree.DNull
 					dataSizeDatum := tree.DNull
 					rowCountDatum := tree.DNull
+					fileSizeDatum := tree.DNull
 
 					desc := descbuilder.NewBuilder(descriptor).BuildExistingMutable()
 
@@ -599,8 +704,9 @@ func backupShowerDefault(
 						parentSchemaName = schemaIDToName[desc.GetParentSchemaID()]
 						parentSchemaID = desc.GetParentSchemaID()
 						tableSize := tableSizes[desc.GetID()]
-						dataSizeDatum = tree.NewDInt(tree.DInt(tableSize.DataSize))
-						rowCountDatum = tree.NewDInt(tree.DInt(tableSize.Rows))
+						dataSizeDatum = tree.NewDInt(tree.DInt(tableSize.rowCount.DataSize))
+						rowCountDatum = tree.NewDInt(tree.DInt(tableSize.rowCount.Rows))
+						fileSizeDatum = tree.NewDInt(tree.DInt(tableSize.fileSize))
 
 						displayOptions := sql.ShowCreateDisplayOptions{
 							FKDisplayMode:  sql.OmitMissingFKClausesFromCreate,
@@ -638,6 +744,9 @@ func backupShowerDefault(
 						owner := desc.GetPrivileges().Owner().SQLIdentifier()
 						row = append(row, tree.NewDString(owner))
 					}
+					if _, checkFiles := opts[backupOptCheckFiles]; checkFiles {
+						row = append(row, fileSizeDatum)
+					}
 					if _, shouldShowIDs := opts[backupOptWithDebugIDs]; shouldShowIDs {
 						// If showing debug IDs, interleave the IDs with the corresponding object names.
 						row = append(
@@ -673,6 +782,9 @@ func backupShowerDefault(
 					if _, shouldShowPrivileges := opts[backupOptWithPrivileges]; shouldShowPrivileges {
 						row = append(row, tree.DNull)
 					}
+					if _, checkFiles := opts[backupOptCheckFiles]; checkFiles {
+						row = append(row, tree.DNull)
+					}
 					if _, shouldShowIDs := opts[backupOptWithDebugIDs]; shouldShowIDs {
 						// If showing debug IDs, interleave the IDs with the corresponding object names.
 						row = append(
@@ -695,9 +807,34 @@ func backupShowerDefault(
 	}
 }
 
+type descriptorSize struct {
+	rowCount roachpb.RowCount
+	fileSize int64
+}
+
+// getLogicalSSTSize gets the total logical bytes stored in each SST. Note that a
+// BackupManifest_File identifies a span in an SST and there can be multiple
+// spans stored in an SST.
+func getLogicalSSTSize(files []BackupManifest_File) map[string]int64 {
+	sstDataSize := make(map[string]int64)
+	for _, file := range files {
+		sstDataSize[file.Path] += file.EntryCounts.DataSize
+	}
+	return sstDataSize
+}
+
+// approximateTablePhysicalSize approximates the number bytes written to disk for the table.
+func approximateTablePhysicalSize(
+	logicalTableSize int64, logicalFileSize int64, sstFileSize int64,
+) int64 {
+	return int64(float64(sstFileSize) * (float64(logicalTableSize) / float64(logicalFileSize)))
+}
+
 // getTableSizes gathers row and size count for each table in the manifest
-func getTableSizes(files []BackupManifest_File) (map[descpb.ID]roachpb.RowCount, error) {
-	tableSizes := make(map[descpb.ID]roachpb.RowCount)
+func getTableSizes(
+	files []BackupManifest_File, fileSizes []int64,
+) (map[descpb.ID]descriptorSize, error) {
+	tableSizes := make(map[descpb.ID]descriptorSize)
 	if len(files) == 0 {
 		return tableSizes, nil
 	}
@@ -707,7 +844,9 @@ func getTableSizes(files []BackupManifest_File) (map[descpb.ID]roachpb.RowCount,
 	}
 	showCodec := keys.MakeSQLCodec(tenantID)
 
-	for _, file := range files {
+	logicalSSTSize := getLogicalSSTSize(files)
+
+	for i, file := range files {
 		// TODO(dan): This assumes each file in the backup only
 		// contains data from a single table, which is usually but
 		// not always correct. It does not account for a BACKUP that
@@ -722,7 +861,10 @@ func getTableSizes(files []BackupManifest_File) (map[descpb.ID]roachpb.RowCount,
 			continue
 		}
 		s := tableSizes[descpb.ID(tableID)]
-		s.Add(file.EntryCounts)
+		s.rowCount.Add(file.EntryCounts)
+		if len(fileSizes) > 0 {
+			s.fileSize = approximateTablePhysicalSize(s.rowCount.DataSize, logicalSSTSize[file.Path], fileSizes[i])
+		}
 		tableSizes[descpb.ID(tableID)] = s
 	}
 	return tableSizes, nil
@@ -823,6 +965,7 @@ func backupShowerFileSetup(inCol tree.StringOrPlaceholderOptList) backupShower {
 		{Name: "size_bytes", Typ: types.Int},
 		{Name: "rows", Typ: types.Int},
 		{Name: "locality", Typ: types.String},
+		{Name: "file_bytes", Typ: types.Int},
 	},
 
 		fn: func(info backupInfo) (rows []tree.Datums, err error) {
@@ -844,20 +987,23 @@ func backupShowerFileSetup(inCol tree.StringOrPlaceholderOptList) backupShower {
 				if manifest.isIncremental() {
 					backupType = "incremental"
 				}
-				for _, file := range manifest.Files {
+
+				sstDataSize := getLogicalSSTSize(manifest.Files)
+				for j, file := range manifest.Files {
 					filePath := file.Path
 					if inCol != nil {
 						filePath = path.Join(manifestDirs[i], filePath)
 					}
 					locality := "NULL"
 					if localityAware {
-						locality = file.LocalityKV
-
-						// A file stored in the default locality has file.LocalityKV == NULL.
-						// For the SHOW FILES display, set the locality to default.
-						if file.LocalityKV == "NULL" {
-							locality = "default"
+						locality = "default"
+						if _, ok := info.localityInfo[i].URIsByOriginalLocalityKV[file.LocalityKV]; ok {
+							locality = file.LocalityKV
 						}
+					}
+					sz := int64(-1)
+					if len(info.fileSizes) > 0 {
+						sz = approximateTablePhysicalSize(info.fileSizes[i][j], file.EntryCounts.DataSize, sstDataSize[file.Path])
 					}
 					rows = append(rows, tree.Datums{
 						tree.NewDString(filePath),
@@ -869,6 +1015,7 @@ func backupShowerFileSetup(inCol tree.StringOrPlaceholderOptList) backupShower {
 						tree.NewDInt(tree.DInt(file.EntryCounts.DataSize)),
 						tree.NewDInt(tree.DInt(file.EntryCounts.Rows)),
 						tree.NewDString(locality),
+						tree.NewDInt(tree.DInt(sz)),
 					})
 				}
 			}
@@ -899,11 +1046,6 @@ func getRootURI(defaultURI string, subdir string) (string, error) {
 // to the incremental backup manifest's directory
 // '/incrementals/fullSubdir/incrementalSubdir'.
 func getManifestDirs(fullSubdir string, defaultUris []string) ([]string, error) {
-	fullCollectionRoot, err := getRootURI(defaultUris[0], fullSubdir)
-	if err != nil {
-		return nil, err
-	}
-
 	manifestDirs := make([]string, len(defaultUris))
 
 	// The full backup manifest path is always in the fullSubdir.
@@ -918,10 +1060,10 @@ func getManifestDirs(fullSubdir string, defaultUris []string) ([]string, error) 
 	}
 
 	var incSubdir string
-	if path.Join(fullCollectionRoot, DefaultIncrementalsSubdir) == incRoot {
+	if strings.HasSuffix(incRoot, DefaultIncrementalsSubdir) {
 		// The incremental backup is stored in the default incremental
 		// directory (i.e. collectionURI/incrementals/fullSubdir)
-		incSubdir = path.Join(DefaultIncrementalsSubdir, fullSubdir)
+		incSubdir = path.Join("/"+DefaultIncrementalsSubdir, fullSubdir)
 	} else {
 		// Implies one of two scenarios:
 		// 1) the incremental chain is stored in the pre 22.1
@@ -939,8 +1081,17 @@ func getManifestDirs(fullSubdir string, defaultUris []string) ([]string, error) 
 		if i == 0 {
 			continue
 		}
-		incDir := strings.Split(incURI, incSubdir)[1]
-		manifestDirs[i] = path.Join(incSubdir, incDir)
+		// the manifestDir for an incremental backup will have the following structure:
+		// 'incSubdir/incSubSubSubDir', where incSubdir is resolved above,
+		// and incSubSubDir corresponds to the path to the incremental backup within
+		// the subdirectory.
+
+		// remove locality info from URI
+		incURI = strings.Split(incURI, "?")[0]
+
+		// get the subdirectory within the incSubdir
+		incSubSubDir := strings.Split(incURI, incSubdir)[1]
+		manifestDirs[i] = path.Join(incSubdir, incSubSubDir)
 	}
 	return manifestDirs, nil
 }

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -836,4 +837,164 @@ func TestShowBackupPathIsCollectionRoot(t *testing.T) {
 	// Ensure proper error gets returned from back SHOW BACKUP Path
 	sqlDB.ExpectErr(t, "The specified path is the root of a backup collection.",
 		"SHOW BACKUP $1", localFoo)
+}
+
+// TestShowBackupCheckFiles verifies the check_files option catches a corrupt backup file
+// in 3 scenarios: 1. SST from a full backup; 2. SST from a default incremental backup; 3.
+// SST from an incremental backup created with the incremental_location parameter.
+// The first two scenarios also get checked with locality aware backups.
+func TestShowBackupCheckFiles(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const numAccounts = 11
+	skip.UnderStressRace(t, "multinode cluster setup times out under stressrace, likely due to resource starvation.")
+
+	_, sqlDB, tempDir, cleanupFn := backupRestoreTestSetup(t, multiNode, numAccounts,
+		InitManualReplication)
+	defer cleanupFn()
+
+	collectionRoot := "full"
+	incLocRoot := "inc"
+	const c1, c2, c3 = `nodelocal://0/full`, `nodelocal://1/full`, `nodelocal://2/full`
+	const i1, i2, i3 = `nodelocal://0/inc`, `nodelocal://1/inc`, `nodelocal://2/inc`
+	localities := []string{"default", "dc=dc1", "dc=dc2"}
+
+	collections := []string{
+		fmt.Sprintf("'%s?COCKROACH_LOCALITY=%s'", c1, url.QueryEscape(localities[0])),
+		fmt.Sprintf("'%s?COCKROACH_LOCALITY=%s'", c2, url.QueryEscape(localities[1])),
+		fmt.Sprintf("'%s?COCKROACH_LOCALITY=%s'", c3, url.QueryEscape(localities[2])),
+	}
+
+	incrementals := []string{
+		fmt.Sprintf("'%s?COCKROACH_LOCALITY=%s'", i1, url.QueryEscape(localities[0])),
+		fmt.Sprintf("'%s?COCKROACH_LOCALITY=%s'", i2, url.QueryEscape(localities[1])),
+		fmt.Sprintf("'%s?COCKROACH_LOCALITY=%s'", i3, url.QueryEscape(localities[2])),
+	}
+	tests := []struct {
+		dest       []string
+		inc        []string
+		localities []string
+	}{
+		{dest: []string{collections[0]}, inc: []string{incrementals[0]}},
+		{dest: collections, inc: incrementals, localities: localities},
+	}
+
+	// create db
+	sqlDB.Exec(t, `CREATE DATABASE fkdb`)
+	sqlDB.Exec(t, `CREATE TABLE fkdb.fk (ind INT)`)
+
+	for _, test := range tests {
+		dest := strings.Join(test.dest, ", ")
+		inc := strings.Join(test.inc, ", ")
+
+		if len(test.dest) > 1 {
+			dest = "(" + dest + ")"
+			inc = "(" + inc + ")"
+		}
+
+		for i := 0; i < 10; i++ {
+			sqlDB.Exec(t, `INSERT INTO fkdb.fk (ind) VALUES ($1)`, i)
+		}
+		fb := fmt.Sprintf("BACKUP DATABASE fkdb INTO %s", dest)
+		sqlDB.Exec(t, fb)
+
+		sqlDB.Exec(t, `INSERT INTO fkdb.fk (ind) VALUES ($1)`, 200)
+
+		sib := fmt.Sprintf("BACKUP DATABASE fkdb INTO LATEST IN %s WITH incremental_location = %s", dest, inc)
+		sqlDB.Exec(t, sib)
+
+		sqlDB.Exec(t, fmt.Sprintf("BACKUP DATABASE fkdb INTO LATEST IN %s", dest))
+
+		breakCheckFiles := func(
+			rootDir string,
+			backupDest []string,
+			file string,
+			fileLocality string,
+			checkQuery string) {
+
+			// Ensure no errors first
+			sqlDB.Exec(t, checkQuery)
+
+			fullPath := filepath.Join(tempDir, rootDir, file)
+			badPath := fullPath + "t"
+			if err := os.Rename(fullPath, badPath); err != nil {
+				require.NoError(t, err, "failed to corrupt SST")
+			}
+
+			// To validate the checkFiles error message, resolve the full path of the missing file.
+			// For locality aware backups, it may not live at the default URI (e.g. backupDest[0]).
+			var fileDest string
+			if fileLocality == "NULL" {
+				fileDest = backupDest[0]
+			} else {
+				fileLocality = url.QueryEscape(fileLocality)
+				for _, destURI := range backupDest {
+					// Locality aware URIs have the following structure:
+					// `someURI?COCKROACH_LOCALITY='locality'`. Given the fileLocality, we
+					// match for the proper URI.
+					destLocality := strings.Split(destURI, "?")
+					if strings.Contains(destLocality[1], fileLocality) {
+						fileDest = destURI
+						break
+					}
+				}
+			}
+			require.NotEmpty(t, fileDest, "could not find file locality")
+
+			// The full error message looks like "Error checking file
+			// data/756930828574818306.sst in nodelocal://0/full/2022/04/27-134916.90".
+			//
+			// Note that the expected error message excludes the path to the data file
+			// to avoid a test flake for locality aware backups where two different
+			// nodelocal URI's read to the same place. In this scenario, the test
+			// expects the backup to be in nodelocal://1/foo and the actual error
+			// message resolves the uri to nodelocal://0/foo. While both are correct,
+			// the test fails.
+
+			// Get Path after /data dir
+			toFile := "data" + strings.Split(file, "/data")[1]
+			errorMsg := fmt.Sprintf("Error checking file %s", toFile)
+			sqlDB.ExpectErr(t, errorMsg, checkQuery)
+
+			if err := os.Rename(badPath, fullPath); err != nil {
+				require.NoError(t, err, "failed to de-corrupt SST")
+			}
+		}
+
+		fileInfo := sqlDB.QueryStr(t,
+			fmt.Sprintf(`SELECT path, locality, file_bytes FROM [SHOW BACKUP FILES FROM LATEST IN %s with check_files]`, dest))
+
+		checkQuery := fmt.Sprintf(`SHOW BACKUP FROM LATEST IN %s WITH check_files`, dest)
+
+		// break on full backup
+		breakCheckFiles(collectionRoot, test.dest, fileInfo[0][0], fileInfo[0][1], checkQuery)
+
+		// break on default inc backup
+		breakCheckFiles(collectionRoot, test.dest, fileInfo[len(fileInfo)-1][0], fileInfo[len(fileInfo)-1][1], checkQuery)
+
+		// check that each file size is positive
+		for _, file := range fileInfo {
+			sz, err := strconv.Atoi(file[2])
+			require.NoError(t, err, "could not get file size")
+			require.Greater(t, sz, 0, "file size is not positive")
+		}
+
+		// check that returned file size is consistent across flavors of SHOW BACKUP
+		fileSum := sqlDB.QueryStr(t,
+			fmt.Sprintf(`SELECT sum(file_bytes) FROM [SHOW BACKUP FILES FROM LATEST IN %s with check_files]`, dest))
+
+		sqlDB.CheckQueryResults(t,
+			fmt.Sprintf(`SELECT sum(file_bytes) FROM [SHOW BACKUP FROM LATEST IN %s with check_files]`, dest),
+			fileSum)
+
+		if len(test.dest) == 1 {
+			// break on an incremental backup stored at incremental_location
+			fileInfo := sqlDB.QueryStr(t,
+				fmt.Sprintf(`SELECT path, locality FROM [SHOW BACKUP FILES FROM LATEST IN %s WITH incremental_location = %s]`,
+					dest, inc))
+
+			incCheckQuery := fmt.Sprintf(`SHOW BACKUP FROM LATEST IN %s WITH check_files, incremental_location = %s`, dest, inc)
+			breakCheckFiles(incLocRoot, test.inc, fileInfo[len(fileInfo)-1][0], fileInfo[len(fileInfo)-1][1], incCheckQuery)
+		}
+	}
 }

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -175,7 +175,7 @@ message BackupDetails {
   Destination destination = 11 [(gogoproto.nullable) = false];
 
   // URIsByLocalityKV is a map of locality KVs to store URIs, used for
-  // partitioned backups.
+  // partitioned backups. The map does not include the default locality.
   map<string, string> uris_by_locality_kv = 5 [(gogoproto.customname) = "URIsByLocalityKV"];
   bytes deprecated_backup_manifest = 4;
   BackupEncryptionOptions encryption_options = 6;


### PR DESCRIPTION
Fixes #77694
Informs #80328

Release note (sql change): Previously, the user did not have an easy way to
check that all SSTs and metadata belonging to a backup were in the expected
place in external storage. This patch adds the 'check_files' option to
SHOW BACKUP which checks that all SSTs and metadata in a backup chain are in
their expected location in external storage. If SHOW BACKUP cant read from a
file, an error message with the problematic file path gets returned to the
user.

A successful SHOW BACKUP with check_files will also return the additional
`file_bytes` column which indicates the actual size, in bytes, of the SST in
external storage corresponding to each table object in the backup, analogous to
the return pattern of the 'rows' and 'size_bytes' columns. Note that
'size_bytes' indicates the logical size of the table, the sum of the size
of each key value pair, while 'file_bytes' represents the physical size of the
SST that the table is stored in, which may be compressed. For small tables,
'file_bytes' may be larger than 'size_bytes' because of the overhead required
to create an SST.

Lastly, it's worth noting that there isn't always a 1 to 1 mapping between SST
to table (e.g. a new table hadn't split into its own range yet at the time of
backup), implying the 'rows','size_bytes', and 'file_bytes' fields should be
interpreted as an approximation, at least on the per table level.