### PR TITLE
release-21.2: roachtest: ignore flaky activerecord test

### DIFF
--- a/pkg/cmd/roachtest/tests/activerecord_blocklist.go
+++ b/pkg/cmd/roachtest/tests/activerecord_blocklist.go
@@ -35,10 +35,12 @@ var activeRecordBlockList20_2 = blocklist{}
 
 var activeRecordIgnoreList21_2 = blocklist{
 	"ActiveRecord::CockroachDB::UnloggedTablesTest#test_gracefully_handles_temporary_tables": "modified to pass on 20.2",
-	"FixturesTest#test_create_fixtures":                                    "flaky - FK constraint violated sometimes when loading all fixture data",
-	"IgnoreFixturesTest#test_ignores_books_fixtures":                       "flaky - FK constraint violated sometimes when loading all fixture data",
-	"IgnoreFixturesTest#test_ignores_parrots_fixtures":                     "flaky - FK constraint violated sometimes when loading all fixture data",
-	"ConcurrentTransactionTest#test_transaction_isolation__read_committed": "flaky - https://github.com/cockroachdb/activerecord-cockroachdb-adapter/issues/237",
+	"CockroachDB::PostgresqlIntervalTest#test_interval_type":                                 "flaky",
+	"FixturesTest#test_create_fixtures":                                                      "flaky - FK constraint violated sometimes when loading all fixture data",
+	"IgnoreFixturesTest#test_ignores_books_fixtures":                                         "flaky - FK constraint violated sometimes when loading all fixture data",
+	"IgnoreFixturesTest#test_ignores_parrots_fixtures":                                       "flaky - FK constraint violated sometimes when loading all fixture data",
+	"ConcurrentTransactionTest#test_transaction_isolation__read_committed":                   "flaky - https://github.com/cockroachdb/activerecord-cockroachdb-adapter/issues/237",
+	"PostgresqlIntervalTest#test_interval_type":                                              "flaky",
 }
 
 var activeRecordIgnoreList21_1 = blocklist{


### PR DESCRIPTION
Backport 1/1 commits from #80489.

/cc @cockroachdb/release

fixes https://github.com/cockroachdb/cockroach/issues/79646

---

fixes https://github.com/cockroachdb/cockroach/issues/80220

Release note: None

Release justification: test only change