### PR TITLE
ccl/sqlproxyccl: implement active/idle partitions for tenantEntry

### DIFF
--- a/pkg/ccl/sqlproxyccl/balancer/assignment.go
+++ b/pkg/ccl/sqlproxyccl/balancer/assignment.go
@@ -31,6 +31,9 @@ func NewServerAssignment(
 ) *ServerAssignment {
 	sa := &ServerAssignment{owner: owner, addr: addr}
 	sa.onClose.closerFn = func() {
+		// Since closerFn is used within Close, operations in closerFn should
+		// not invoke Close on the server assignment, or else a cyclic call may
+		// occur, which will result in a deadlock.
 		tracker.unregisterAssignment(tenantID, sa)
 	}
 	tracker.registerAssignment(tenantID, sa)

--- a/pkg/ccl/sqlproxyccl/balancer/conn_test.go
+++ b/pkg/ccl/sqlproxyccl/balancer/conn_test.go
@@ -25,6 +25,8 @@ type testConnHandle struct {
 
 	mu struct {
 		syncutil.Mutex
+		// Connection handles are active by default (i.e. idle = false).
+		idle                      bool
 		onTransferConnectionCount int
 	}
 }
@@ -54,6 +56,20 @@ func (h *testConnHandle) TransferConnection() error {
 		return h.ctx.Err()
 	}
 	return h.onTransferConnection()
+}
+
+// IsIdle implements the ConnectionHandle interface.
+func (h *testConnHandle) IsIdle() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.mu.idle
+}
+
+// setIdle updates the idle state of the connection handle.
+func (h *testConnHandle) setIdle(idle bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.mu.idle = idle
 }
 
 // transferConnectionCount returns the number of times TransferConnection is

--- a/pkg/ccl/sqlproxyccl/balancer/conn_tracker.go
+++ b/pkg/ccl/sqlproxyccl/balancer/conn_tracker.go
@@ -10,6 +10,7 @@ package balancer
 
 import (
 	"context"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -18,6 +19,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/logtags"
 )
+
+// partitionsRefreshInterval refers to the interval that the assignment states are
+// periodically refreshed.
+const partitionsRefreshInterval = 15 * time.Second
 
 // ConnTracker tracks all connection handles associated with each tenant, and
 // handles are grouped by SQL pods.
@@ -41,7 +46,7 @@ func NewConnTracker(
 	ctx context.Context, stopper *stop.Stopper, timeSource timeutil.TimeSource,
 ) (*ConnTracker, error) {
 	// Ensure that ctx gets cancelled on stopper's quiescing.
-	// ctx, _ = stopper.WithCancelOnQuiesce(ctx)
+	ctx, _ = stopper.WithCancelOnQuiesce(ctx)
 
 	if timeSource == nil {
 		timeSource = timeutil.DefaultTimeSource{}
@@ -49,8 +54,12 @@ func NewConnTracker(
 
 	t := &ConnTracker{timeSource: timeSource}
 	t.mu.tenants = make(map[roachpb.TenantID]*tenantEntry)
-	// TODO(jaylim-crl): add a background goroutine here to refresh active/idle
-	// partitions.
+
+	if err := stopper.RunAsyncTask(
+		ctx, "refresh-partitions", t.refreshPartitionsLoop,
+	); err != nil {
+		return nil, err
+	}
 	return t, nil
 }
 
@@ -94,7 +103,7 @@ func (t *ConnTracker) getTenantIDs() []roachpb.TenantID {
 
 	tenants := make([]roachpb.TenantID, 0, len(t.mu.tenants))
 	for tenantID, entry := range t.mu.tenants {
-		if entry.getConnsCount() > 0 {
+		if entry.assignmentsCount() > 0 {
 			tenants = append(tenants, tenantID)
 		}
 	}
@@ -134,59 +143,129 @@ func logTrackerEvent(event string, sa *ServerAssignment) {
 	log.Infof(logCtx, "%s: %s", event, sa.Addr())
 }
 
-// tenantEntry is a connection tracker entry that stores connection information
-// for a single tenant. All methods on tenantEntry are thread-safe.
-type tenantEntry struct {
-	// mu synchronizes access to the list of connections associated with this
-	// tenant.
-	mu struct {
-		syncutil.Mutex
+// refreshPartitionsLoop runs on a background goroutine to continuously refresh
+// partitions of assignments in the tracker.
+func (t *ConnTracker) refreshPartitionsLoop(ctx context.Context) {
+	timer := t.timeSource.NewTimer()
+	defer timer.Stop()
+	for {
+		timer.Reset(partitionsRefreshInterval)
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.Ch():
+			timer.MarkRead()
+			t.refreshPartitions()
+		}
+	}
+}
 
-		// assignments refers to a set of ServerAssignment objects.
-		//
-		// TODO(jaylim-crl): Break this into active and idle partitions.
-		assignments map[*ServerAssignment]struct{}
+// refreshPartitions refreshes the partitions of all assignments for all tenants
+// associated with the tracker.
+func (t *ConnTracker) refreshPartitions() {
+	tenantIDs := t.getTenantIDs()
+	for _, tenantID := range tenantIDs {
+		e := t.getEntry(tenantID, false /* allowCreate */)
+		if e != nil {
+			e.refreshPartitions()
+		}
+	}
+}
+
+// tenantEntry is a tracker entry that stores server assignments for a single
+// tenant. All methods on tenantEntry are thread-safe.
+//
+// There are two partitions for server assignments: active and idle. New
+// assignments are placed in the active partition. A background goroutine in the
+// tracker will attempt to move assignments around based on the state of the
+// assignment's owner (i.e. through the owner's IsIdle method).
+type tenantEntry struct {
+	mu          syncutil.Mutex
+	assignments struct {
+		active map[*ServerAssignment]struct{}
+		idle   map[*ServerAssignment]struct{}
 	}
 }
 
 // newTenantEntry returns a new instance of tenantEntry.
 func newTenantEntry() *tenantEntry {
 	e := &tenantEntry{}
-	e.mu.assignments = make(map[*ServerAssignment]struct{})
+	e.assignments.active = make(map[*ServerAssignment]struct{})
+	e.assignments.idle = make(map[*ServerAssignment]struct{})
 	return e
 }
 
-// addAssignment adds the given ServerAssignment to the tenant entry. This
-// returns true if the operation was successful, and false otherwise.
+// addAssignment adds the given ServerAssignment instance to the active
+// partition. If the instance already exists in the tenant entry, this returns
+// false.
 func (e *tenantEntry) addAssignment(sa *ServerAssignment) bool {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
 	// Assignment already exists.
-	if _, ok := e.mu.assignments[sa]; ok {
+	_, isActive := e.assignments.active[sa]
+	_, isIdle := e.assignments.idle[sa]
+	if isActive || isIdle {
 		return false
 	}
-	e.mu.assignments[sa] = struct{}{}
+
+	e.assignments.active[sa] = struct{}{}
 	return true
 }
 
-// removeAssignment deletes the given ServerAssignment from the tenant entry.
-// This returns true if the operation was successful, and false otherwise.
+// removeAssignment deletes the given ServerAssignment instance from the tenant
+// entry. If the instance is not present in the entry, this returns false.
 func (e *tenantEntry) removeAssignment(sa *ServerAssignment) bool {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	// Assignment does not exists.
-	if _, ok := e.mu.assignments[sa]; !ok {
+	// Assignment does not exist.
+	_, isActive := e.assignments.active[sa]
+	_, isIdle := e.assignments.idle[sa]
+	if !isActive && !isIdle {
 		return false
 	}
-	delete(e.mu.assignments, sa)
+
+	if isActive {
+		delete(e.assignments.active, sa)
+	} else {
+		delete(e.assignments.idle, sa)
+	}
 	return true
+}
+
+// listAssignments returns a snapshot of both the active and idle partitions
+// that contain ServerAssignment instances.
+func (e *tenantEntry) listAssignments() (activeList, idleList []*ServerAssignment) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	// Note that when returning assignment snapshots, it is important that
+	// snapshots for all partitions are taken together while holding the lock
+	// because assignments will be moved around. If we don't do this, an
+	// assignment may end up in both of the returned slices, assuming that
+	// listAssignments was called during a refresh.
+	//
+	// Iterating 50K entries (the number of connections that we plan to support
+	// in each proxy) would be a few ms (< 5ms). Since listAssignments will only
+	// be mainly used during rebalancing (which isn't very frequent), holding
+	// onto the lock while doing the copy is fine.
+	activeList = make([]*ServerAssignment, 0, len(e.assignments.active))
+	for a := range e.assignments.active {
+		activeList = append(activeList, a)
+	}
+	idleList = make([]*ServerAssignment, 0, len(e.assignments.idle))
+	for a := range e.assignments.idle {
+		idleList = append(idleList, a)
+	}
+	return
 }
 
 // getConnsMap returns a snapshot of connections, indexed by server's address.
 // Since this a snapshot, the mappings may be stale, if the connection was
 // transferred to a different pod after the snapshot was made.
+//
+// TODO(jaylim-crl): Replace usages of getConnsMap with listAssignments.
 func (e *tenantEntry) getConnsMap() map[string][]ConnectionHandle {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -199,16 +278,65 @@ func (e *tenantEntry) getConnsMap() map[string][]ConnectionHandle {
 	// Note that holding onto the lock for a long time will affect latency of
 	// incoming connections.
 	conns := make(map[string][]ConnectionHandle)
-	for sa := range e.mu.assignments {
-		conns[sa.Addr()] = append(conns[sa.Addr()], sa.Owner())
+	for sa := range e.assignments.active {
+		if sa.Owner() != nil {
+			conns[sa.Addr()] = append(conns[sa.Addr()], sa.Owner())
+		}
+	}
+	for sa := range e.assignments.idle {
+		if sa.Owner() != nil {
+			conns[sa.Addr()] = append(conns[sa.Addr()], sa.Owner())
+		}
 	}
 	return conns
 }
 
-// getConnsCount returns the number of connections associated with the tenant.
-func (e *tenantEntry) getConnsCount() int {
+// assignmentsCount returns the number of assignments associated with the tenant.
+func (e *tenantEntry) assignmentsCount() int {
 	e.mu.Lock()
 	defer e.mu.Unlock()
+	return len(e.assignments.active) + len(e.assignments.idle)
+}
 
-	return len(e.mu.assignments)
+// refreshPartitions updates the partitions of the server assignments associated
+// with this tenant. Assignments with active owners will be moved to the active
+// partition, and a similar argument can be made for the idle partition with
+// idle owners.
+func (e *tenantEntry) refreshPartitions() {
+	// moveToActive moves server assignment instances from the idle->active, and
+	// active->idle partitions. If toActive is true, the given server assignment
+	// is moved from the idle partition to the active partition only if the
+	// assignment is present in the idle partition. If the assignment is no
+	// longer present in the existing partition, this will be a no-op. A similar
+	// argument can be made for toActive=false.
+	moveToActive := func(toActive bool, sa *ServerAssignment) {
+		e.mu.Lock()
+		defer e.mu.Unlock()
+
+		// When moving an assignment to the active partition, the assignment
+		// has to exist in the idle partition. A similar argument can be made
+		// when moving to the idle partition. We check this to ensure that an
+		// assignment doesn't get re-added back to the tracker whenever the
+		// assignment has been closed.
+		if _, isIdle := e.assignments.idle[sa]; toActive && isIdle {
+			delete(e.assignments.idle, sa)
+			e.assignments.active[sa] = struct{}{}
+		}
+		if _, isActive := e.assignments.active[sa]; !toActive && isActive {
+			delete(e.assignments.active, sa)
+			e.assignments.idle[sa] = struct{}{}
+		}
+	}
+
+	activeList, idleList := e.listAssignments()
+	for _, sa := range activeList {
+		if sa.Owner() != nil && sa.Owner().IsIdle() {
+			moveToActive(false, sa)
+		}
+	}
+	for _, sa := range idleList {
+		if sa.Owner() != nil && !sa.Owner().IsIdle() {
+			moveToActive(true, sa)
+		}
+	}
 }


### PR DESCRIPTION
This commit splits the assignments store in each tenant entry into two
partitions: active and idle. We also update the tracker to refresh these
partitions periodically (i.e. every 15 seconds). This will prepare us for
connection rebalancing. When routing new connections, only the active
partition will be used.

Release note: None