### PR TITLE
release-21.1: release-21.2: backupccl: ensure AOST incremental backup ends after previous backup

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -725,6 +725,12 @@ func backupPlanHook(
 			if err := requireEnterprise("incremental"); err != nil {
 				return err
 			}
+			lastEndTime := prevBackups[len(prevBackups)-1].EndTime
+			if endTime.Less(lastEndTime) {
+				return errors.Newf("`AS OF SYSTEM TIME` %s must be greater than "+
+					"the previous backup's end time of %s.",
+					endTime.GoTime(), lastEndTime.GoTime())
+			}
 			startTime = prevBackups[len(prevBackups)-1].EndTime
 		}
 


### PR DESCRIPTION
Backport 1/1 commits from #80287.

/cc @cockroachdb/release

---

Backport 1/2 commits from #79799.

/cc @cockroachdb/release

---

Informs https://github.com/cockroachdb/cockroach/issues/79674

Release note (sql change): Previously, a user could run an AS OF SYSTEM TIME
incremental backup with an end time earlier than the previous backup's end time
, which could lead to an out of order incremental backup chain. This PR causes
the incremental backup to fail if the AS OF SYSTEM TIME is less than the
previous backup's end time.

Release justification: low risk bug fix
