### PR TITLE
ccl/sqlproxyccl: update load balancing algorithm to use leastconns

### DIFF
--- a/pkg/ccl/sqlproxyccl/balancer/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/balancer/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//pkg/roachpb",
         "//pkg/util/log",
         "//pkg/util/metric",
-        "//pkg/util/randutil",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",

--- a/pkg/ccl/sqlproxyccl/balancer/balancer_test.go
+++ b/pkg/ccl/sqlproxyccl/balancer/balancer_test.go
@@ -50,7 +50,10 @@ func TestBalancer_SelectTenantPod(t *testing.T) {
 	})
 
 	t.Run("few pods", func(t *testing.T) {
-		pod, err := b.SelectTenantPod([]*tenant.Pod{{Addr: "1"}, {Addr: "2"}})
+		pod, err := b.SelectTenantPod([]*tenant.Pod{
+			{TenantID: 10, Addr: "1"},
+			{TenantID: 10, Addr: "2"}},
+		)
 		require.NoError(t, err)
 		require.Contains(t, []string{"1", "2"}, pod.Addr)
 	})


### PR DESCRIPTION
This commit replaces the existing load balancing algorithm within sqlproxy
(i.e. weighted CPU load) with a leastconns approach as discussed. The idea
behind this replacement is that CPU metrics are often stale, and we should be
able to reasonably make routing decisions based on local data.

Release note: None