### PR TITLE
sql: add interface for ForceRetryError for crdb_internal.force_retry

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -376,6 +376,7 @@ go_library(
         "//pkg/sql/schemachanger/scrun",
         "//pkg/sql/scrub",
         "//pkg/sql/sem/builtins",
+        "//pkg/sql/sem/builtins/kvinterfaces",
         "//pkg/sql/sem/transform",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sem/tree/treebin",

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirecancel"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scrun"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins/kvinterfaces"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
@@ -2674,6 +2675,7 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 			ReCache:                   ex.server.reCache,
 			SQLStatsController:        ex.server.sqlStatsController,
 			IndexUsageStatsController: ex.server.indexUsageStatsController,
+			ForceRetryRunner:          kvinterfaces.NewForceRetryableError(p.Txn()),
 		},
 		Tracing:                &ex.sessionTracing,
 		MemMetrics:             &ex.memMetrics,
@@ -2717,6 +2719,7 @@ func (ex *connExecutor) resetEvalCtx(evalCtx *extendedEvalContext, txn *kv.Txn, 
 	evalCtx.PrepareOnly = false
 	evalCtx.SkipNormalize = false
 	evalCtx.SchemaChangerState = &ex.extraTxnState.schemaChangerState
+	evalCtx.ForceRetryRunner = kvinterfaces.NewForceRetryableError(txn)
 
 	// If we are retrying due to an unsatisfiable timestamp bound which is
 	// retriable, it means we were unable to serve the previous minimum timestamp

--- a/pkg/sql/distsql/BUILD.bazel
+++ b/pkg/sql/distsql/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/sql/faketreeeval",
         "//pkg/sql/flowinfra",
         "//pkg/sql/rowflow",
+        "//pkg/sql/sem/builtins/kvinterfaces",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/faketreeeval"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowflow"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins/kvinterfaces"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
@@ -317,6 +318,7 @@ func (ds *ServerImpl) setupFlow(
 			// Update the Txn field early (before f.SetTxn() below) since some
 			// processors capture the field in their constructor (see #41992).
 			evalCtx.Txn = leafTxn
+			evalCtx.ForceRetryRunner = kvinterfaces.NewForceRetryableError(leafTxn)
 		}
 	} else {
 		if localState.IsLocal {
@@ -361,6 +363,7 @@ func (ds *ServerImpl) setupFlow(
 			SQLLivenessReader:         ds.ServerConfig.SQLLivenessReader,
 			SQLStatsController:        ds.ServerConfig.SQLStatsController,
 			IndexUsageStatsController: ds.ServerConfig.IndexUsageStatsController,
+			ForceRetryRunner:          kvinterfaces.NewForceRetryableError(leafTxn),
 		}
 		evalCtx.SetStmtTimestamp(timeutil.Unix(0 /* sec */, req.EvalContext.StmtTimestampNanos))
 		evalCtx.SetTxnTimestamp(timeutil.Unix(0 /* sec */, req.EvalContext.TxnTimestampNanos))

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/querycache"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins/kvinterfaces"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -483,6 +484,7 @@ func internalExtendedEvalCtx(
 			TxnTimestamp:              txnTimestamp,
 			SQLStatsController:        sqlStatsController,
 			IndexUsageStatsController: indexUsageStatsController,
+			ForceRetryRunner:          kvinterfaces.NewForceRetryableError(txn),
 		},
 		Tracing:         &SessionTracing{},
 		Descs:           tables,

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -5226,8 +5226,9 @@ value if you rely on the HLC for accuracy.`,
 				minDuration := args[0].(*tree.DInterval).Duration
 				elapsed := duration.MakeDuration(int64(ctx.StmtTimestamp.Sub(ctx.TxnTimestamp)), 0, 0)
 				if elapsed.Compare(minDuration) < 0 {
-					return nil, ctx.Txn.GenerateForcedRetryableError(
-						ctx.Ctx(), "forced by crdb_internal.force_retry()")
+					return nil, ctx.ForceRetryRunner.GenerateForcedRetryableError(
+						ctx.Ctx(), "forced by crdb_internal.force_retry()",
+					)
 				}
 				return tree.DZero, nil
 			},

--- a/pkg/sql/sem/builtins/kvinterfaces/BUILD.bazel
+++ b/pkg/sql/sem/builtins/kvinterfaces/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "kvinterfaces",
+    srcs = ["force_retry.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/sem/builtins/kvinterfaces",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/kv"],
+)

--- a/pkg/sql/sem/builtins/kvinterfaces/force_retry.go
+++ b/pkg/sql/sem/builtins/kvinterfaces/force_retry.go
@@ -1,0 +1,35 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvinterfaces
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/kv"
+)
+
+// ForceRetryableError implements tree.ForceRetryableError.
+type ForceRetryableError struct {
+	txn *kv.Txn
+}
+
+// NewForceRetryableError returns a new instance of
+// ForceRetryableError.
+func NewForceRetryableError(txn *kv.Txn) *ForceRetryableError {
+	return &ForceRetryableError{
+		txn: txn,
+	}
+}
+
+// GenerateForcedRetryableError implements the tree.ForceRetryRunner interface.
+func (r *ForceRetryableError) GenerateForcedRetryableError(ctx context.Context, msg string) error {
+	return r.txn.GenerateForcedRetryableError(ctx, msg)
+}

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -64,6 +64,7 @@ go_library(
         "indexed_vars.go",
         "insert.go",
         "interval.go",
+        "kv_builtin_interfaces.go",
         "name_part.go",
         "name_resolution.go",
         "normalize.go",

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3742,6 +3742,11 @@ type EvalContext struct {
 	// KVStoresIterator is used by various crdb_internal builtins to directly
 	// access stores on this node.
 	KVStoresIterator kvserverbase.StoresIterator
+
+	// The following fields are used to interface with KV for builtins.
+
+	// ForceRetryRunner is used by crdb_internal.force_retry.
+	ForceRetryRunner ForceRetryRunner
 }
 
 // MakeTestingEvalContext returns an EvalContext that includes a MemoryMonitor.

--- a/pkg/sql/sem/tree/kv_builtin_interfaces.go
+++ b/pkg/sql/sem/tree/kv_builtin_interfaces.go
@@ -1,0 +1,19 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tree
+
+import "context"
+
+// ForceRetryRunner is an interface embedded in EvalCtx used by
+// crdb_internal.force_retry.
+type ForceRetryRunner interface {
+	GenerateForcedRetryableError(ctx context.Context, msg string) error
+}


### PR DESCRIPTION
Start of effort for creating an interface whenever builtins need
to interact with KV.

Release note: None