### PR TITLE
sql: ensure SQL Stats cleanup job to not interfere with foreground traffic

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/sql_activity_stats_compaction
+++ b/pkg/sql/opt/exec/execbuilder/testdata/sql_activity_stats_compaction
@@ -1,0 +1,287 @@
+# LogicTest: local
+
+# Ensure we can run DELETE statement on system.statement_statistics and
+# system.transaction_statistics table.
+statement ok
+INSERT INTO system.users VALUES ('node', NULL, true);
+
+statement ok
+GRANT node TO root;
+
+# Constructing TIMESTAMPTZ expression that can be used later in the queries.
+let $last_agg_ts
+SELECT concat('''', date_trunc('hour', '2022-05-04 16:10'::TIMESTAMPTZ - '2h'::INTERVAL)::STRING, '''::TIMESTAMPTZ')
+
+let $current_agg_ts
+SELECT concat('''', date_trunc('hour', '2022-05-04 16:10'::TIMESTAMPTZ)::STRING, '''::TIMESTAMPTZ')
+
+query T
+EXPLAIN (VERBOSE)
+DELETE FROM system.statement_statistics
+WHERE (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id) IN (
+  SELECT aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
+  FROM system.statement_statistics
+  WHERE crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8 = 0
+    AND aggregated_ts < $current_agg_ts
+  ORDER BY aggregated_ts ASC
+  LIMIT 1024
+) RETURNING aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id)
+│ estimated row count: 0 (missing stats)
+│
+└── • delete
+    │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
+    │ estimated row count: 0 (missing stats)
+    │ from: statement_statistics
+    │ auto commit
+    │
+    └── • project
+        │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
+        │ estimated row count: 0 (missing stats)
+        │
+        └── • project
+            │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id)
+            │ estimated row count: 0 (missing stats)
+            │
+            └── • project
+                │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
+                │ estimated row count: 0 (missing stats)
+                │
+                └── • lookup join (inner)
+                    │ columns: (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8_eq, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
+                    │ table: statement_statistics@fingerprint_stats_idx
+                    │ equality: (fingerprint_id, transaction_fingerprint_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8_eq, aggregated_ts, plan_hash, app_name, node_id) = (fingerprint_id,transaction_fingerprint_id,crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8,aggregated_ts,plan_hash,app_name,node_id)
+                    │ equality cols are key
+                    │
+                    └── • render
+                        │ columns: (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8_eq, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
+                        │ estimated row count: 9 (missing stats)
+                        │ render crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8_eq: mod(fnv32(crdb_internal.datums_to_bytes(aggregated_ts, app_name, fingerprint_id, node_id, plan_hash, transaction_fingerprint_id)), 8)
+                        │ render aggregated_ts: aggregated_ts
+                        │ render fingerprint_id: fingerprint_id
+                        │ render transaction_fingerprint_id: transaction_fingerprint_id
+                        │ render plan_hash: plan_hash
+                        │ render app_name: app_name
+                        │ render node_id: node_id
+                        │ render crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8
+                        │
+                        └── • scan
+                              columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
+                              estimated row count: 9 (missing stats)
+                              table: statement_statistics@primary
+                              spans: /0-/0/2022-05-04T15:59:59.999999001Z
+                              limit: 1024
+
+query T
+EXPLAIN (VERBOSE)
+DELETE FROM system.transaction_statistics
+WHERE (aggregated_ts, fingerprint_id, app_name, node_id) IN (
+  SELECT aggregated_ts, fingerprint_id, app_name, node_id
+  FROM system.transaction_statistics
+  WHERE crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8 = 0
+    AND aggregated_ts < $current_agg_ts
+  ORDER BY aggregated_ts ASC
+  LIMIT 1024
+) RETURNING aggregated_ts, fingerprint_id, app_name, node_id
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (aggregated_ts, fingerprint_id, app_name, node_id)
+│ estimated row count: 0 (missing stats)
+│
+└── • delete
+    │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
+    │ estimated row count: 0 (missing stats)
+    │ from: transaction_statistics
+    │ auto commit
+    │
+    └── • project
+        │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
+        │ estimated row count: 0 (missing stats)
+        │
+        └── • project
+            │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id)
+            │ estimated row count: 0 (missing stats)
+            │
+            └── • project
+                │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
+                │ estimated row count: 0 (missing stats)
+                │
+                └── • lookup join (inner)
+                    │ columns: (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8_eq, aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
+                    │ table: transaction_statistics@fingerprint_stats_idx
+                    │ equality: (fingerprint_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8_eq, aggregated_ts, app_name, node_id) = (fingerprint_id,crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8,aggregated_ts,app_name,node_id)
+                    │ equality cols are key
+                    │
+                    └── • render
+                        │ columns: (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8_eq, aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
+                        │ estimated row count: 9 (missing stats)
+                        │ render crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8_eq: mod(fnv32(crdb_internal.datums_to_bytes(aggregated_ts, app_name, fingerprint_id, node_id)), 8)
+                        │ render aggregated_ts: aggregated_ts
+                        │ render fingerprint_id: fingerprint_id
+                        │ render app_name: app_name
+                        │ render node_id: node_id
+                        │ render crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8
+                        │
+                        └── • scan
+                              columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
+                              estimated row count: 9 (missing stats)
+                              table: transaction_statistics@primary
+                              spans: /0-/0/2022-05-04T15:59:59.999999001Z
+                              limit: 1024
+
+query T
+EXPLAIN (VERBOSE)
+DELETE FROM system.statement_statistics
+WHERE (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id) IN (
+SELECT aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
+FROM system.statement_statistics
+WHERE crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8 = 0
+AND (
+  (
+    aggregated_ts,
+    fingerprint_id,
+    transaction_fingerprint_id,
+    plan_hash,
+    app_name,
+    node_id
+    ) >= ($last_agg_ts, b'123', b'234', b'345', 'test', 1)
+  )
+    AND aggregated_ts < $current_agg_ts
+  ORDER BY aggregated_ts ASC
+  LIMIT 1024
+) RETURNING aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id)
+│ estimated row count: 0 (missing stats)
+│
+└── • delete
+    │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
+    │ estimated row count: 0 (missing stats)
+    │ from: statement_statistics
+    │ auto commit
+    │
+    └── • project
+        │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
+        │ estimated row count: 0 (missing stats)
+        │
+        └── • project
+            │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id)
+            │ estimated row count: 0 (missing stats)
+            │
+            └── • project
+                │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
+                │ estimated row count: 0 (missing stats)
+                │
+                └── • lookup join (inner)
+                    │ columns: (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8_eq, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
+                    │ table: statement_statistics@fingerprint_stats_idx
+                    │ equality: (fingerprint_id, transaction_fingerprint_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8_eq, aggregated_ts, plan_hash, app_name, node_id) = (fingerprint_id,transaction_fingerprint_id,crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8,aggregated_ts,plan_hash,app_name,node_id)
+                    │ equality cols are key
+                    │
+                    └── • render
+                        │ columns: (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8_eq, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
+                        │ estimated row count: 9 (missing stats)
+                        │ render crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8_eq: mod(fnv32(crdb_internal.datums_to_bytes(aggregated_ts, app_name, fingerprint_id, node_id, plan_hash, transaction_fingerprint_id)), 8)
+                        │ render aggregated_ts: aggregated_ts
+                        │ render fingerprint_id: fingerprint_id
+                        │ render transaction_fingerprint_id: transaction_fingerprint_id
+                        │ render plan_hash: plan_hash
+                        │ render app_name: app_name
+                        │ render node_id: node_id
+                        │ render crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8
+                        │
+                        └── • scan
+                              columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
+                              estimated row count: 9 (missing stats)
+                              table: statement_statistics@primary
+                              spans: /0/2022-05-04T14:00:00Z/"123"/"234"/"345"/"test"/1-/0/2022-05-04T15:59:59.999999001Z
+                              limit: 1024
+
+query T
+EXPLAIN (VERBOSE)
+DELETE FROM system.transaction_statistics
+      WHERE (aggregated_ts, fingerprint_id, app_name, node_id) IN (
+      SELECT aggregated_ts, fingerprint_id, app_name, node_id
+      FROM system.transaction_statistics
+      WHERE crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8 = 0
+      AND (
+        (
+        aggregated_ts,
+        fingerprint_id,
+        app_name,
+        node_id
+        ) >= ($last_agg_ts, b'123', 'test', 2)
+      )
+        AND aggregated_ts < $current_agg_ts
+      ORDER BY aggregated_ts ASC
+      LIMIT 1024
+    ) RETURNING aggregated_ts, fingerprint_id, app_name, node_id
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (aggregated_ts, fingerprint_id, app_name, node_id)
+│ estimated row count: 0 (missing stats)
+│
+└── • delete
+    │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
+    │ estimated row count: 0 (missing stats)
+    │ from: transaction_statistics
+    │ auto commit
+    │
+    └── • project
+        │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
+        │ estimated row count: 0 (missing stats)
+        │
+        └── • project
+            │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id)
+            │ estimated row count: 0 (missing stats)
+            │
+            └── • project
+                │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
+                │ estimated row count: 0 (missing stats)
+                │
+                └── • lookup join (inner)
+                    │ columns: (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8_eq, aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
+                    │ table: transaction_statistics@fingerprint_stats_idx
+                    │ equality: (fingerprint_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8_eq, aggregated_ts, app_name, node_id) = (fingerprint_id,crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8,aggregated_ts,app_name,node_id)
+                    │ equality cols are key
+                    │
+                    └── • render
+                        │ columns: (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8_eq, aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
+                        │ estimated row count: 9 (missing stats)
+                        │ render crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8_eq: mod(fnv32(crdb_internal.datums_to_bytes(aggregated_ts, app_name, fingerprint_id, node_id)), 8)
+                        │ render aggregated_ts: aggregated_ts
+                        │ render fingerprint_id: fingerprint_id
+                        │ render app_name: app_name
+                        │ render node_id: node_id
+                        │ render crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8
+                        │
+                        └── • scan
+                              columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
+                              estimated row count: 9 (missing stats)
+                              table: transaction_statistics@primary
+                              spans: /0/2022-05-04T14:00:00Z/"123"/"test"/2-/0/2022-05-04T15:59:59.999999001Z
+                              limit: 1024
+
+statement ok
+RESET CLUSTER SETTING sql.stats.flush.interval
+
+statement ok
+REVOKE node FROM root;
+
+statement ok
+DELETE FROM system.users WHERE username = 'node';

--- a/pkg/sql/sqlstats/persistedsqlstats/compaction_exec.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/compaction_exec.go
@@ -13,6 +13,7 @@ package persistedsqlstats
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
@@ -23,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -163,6 +165,7 @@ func (c *StatsCompactor) removeStaleRowsForShard(
 ) error {
 	var err error
 	var lastDeletedRow tree.Datums
+	var qargs []interface{}
 	maxDeleteRowsPerTxn := CompactionJobRowsToDeletePerTxn.Get(&c.st.SV)
 
 	if rowsToRemove := existingRowCountPerShard - maxRowLimitPerShard; rowsToRemove > 0 {
@@ -173,7 +176,11 @@ func (c *StatsCompactor) removeStaleRowsForShard(
 			}
 
 			stmt := ops.getDeleteStmt(lastDeletedRow)
-			qargs := c.getQargs(shardIdx, rowsToRemovePerTxn, lastDeletedRow)
+			qargs, err = c.getQargs(shardIdx, rowsToRemovePerTxn, lastDeletedRow)
+			if err != nil {
+				return err
+			}
+
 			var rowsRemoved int64
 
 			lastDeletedRow, rowsRemoved, err = c.executeDeleteStmt(
@@ -228,7 +235,9 @@ func (c *StatsCompactor) executeDeleteStmt(
 	return lastRow, rowsDeleted, err
 }
 
-func (c *StatsCompactor) getQargs(shardIdx, limit int64, lastDeletedRow tree.Datums) []interface{} {
+func (c *StatsCompactor) getQargs(
+	shardIdx, limit int64, lastDeletedRow tree.Datums,
+) ([]interface{}, error) {
 	size := len(lastDeletedRow) + 2
 	if cap(c.scratch.qargs) < size {
 		c.scratch.qargs = make([]interface{}, 0, size)
@@ -238,11 +247,23 @@ func (c *StatsCompactor) getQargs(shardIdx, limit int64, lastDeletedRow tree.Dat
 	c.scratch.qargs = append(c.scratch.qargs, tree.NewDInt(tree.DInt(shardIdx)))
 	c.scratch.qargs = append(c.scratch.qargs, tree.NewDInt(tree.DInt(limit)))
 
+	now := timeutil.Now()
+	if c.knobs != nil && c.knobs.StubTimeNow != nil {
+		now = c.knobs.StubTimeNow()
+	}
+	aggInterval := SQLStatsAggregationInterval.Get(&c.st.SV)
+	aggTs := now.Truncate(aggInterval)
+	datum, err := tree.MakeDTimestampTZ(aggTs, time.Microsecond)
+	if err != nil {
+		return nil, err
+	}
+	c.scratch.qargs = append(c.scratch.qargs, datum)
+
 	for _, value := range lastDeletedRow {
 		c.scratch.qargs = append(c.scratch.qargs, value)
 	}
 
-	return c.scratch.qargs
+	return c.scratch.qargs, nil
 }
 
 type cleanupOperations struct {
@@ -251,6 +272,8 @@ type cleanupOperations struct {
 	constrainedDeleteStmt   string
 }
 
+// N.B. when changing the constraint queries below, make sure also change
+//      the test file in pkg/sql/opt/exec/execbuilder/testdata/sql_activity_stats_compaction.
 var (
 	stmtStatsCleanupOps = &cleanupOperations{
 		initialScanStmtTemplate: `
@@ -264,6 +287,7 @@ var (
         SELECT aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
         FROM system.statement_statistics
         WHERE crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8 = $1
+          AND aggregated_ts < $3
         ORDER BY aggregated_ts ASC
         LIMIT $2
       ) RETURNING aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id`,
@@ -281,8 +305,9 @@ var (
         plan_hash,
         app_name,
         node_id
-        ) >= ($3, $4, $5, $6, $7, $8)
+        ) >= ($4, $5, $6, $7, $8, $9)
       )
+        AND aggregated_ts < $3
       ORDER BY aggregated_ts ASC
       LIMIT $2
     ) RETURNING aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id`,
@@ -299,6 +324,7 @@ var (
       SELECT aggregated_ts, fingerprint_id, app_name, node_id
       FROM system.transaction_statistics
       WHERE crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8 = $1
+        AND aggregated_ts < $3
       ORDER BY aggregated_ts ASC
       LIMIT $2
     ) RETURNING aggregated_ts, fingerprint_id, app_name, node_id`,
@@ -314,8 +340,9 @@ var (
         fingerprint_id,
         app_name,
         node_id
-        ) >= ($3, $4, $5, $6)
+        ) >= ($4, $5, $6, $7)
       )
+        AND aggregated_ts < $3
       ORDER BY aggregated_ts ASC
       LIMIT $2
     ) RETURNING aggregated_ts, fingerprint_id, app_name, node_id`,


### PR DESCRIPTION
Related to https://github.com/cockroachdb/cockroach/issues/79548

Previously, if a workload generated large amount of unique
statement/transaction fingerprints, the number of distinct fingerprint
within the latest aggregation interval can become so large that it would
exceed the limit defined by `sql.stats.persisted_rows.max` When this
happened, the background SQL Stats cleanup job would be issuing DELETE
query that contended with the flush traffic, which could lead to spiking
query latencies.

This commit ensured that the background SQL Stats cleanup job completely
avoids scanning over the overlapping key ranges touched by the SQL Stats
flush.

Release note: None