### PR TITLE
planner: remove unneeded txn arg for planner Query* methods

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -35,8 +35,7 @@ func completeStreamIngestion(
 	// Get the job payload for job_id.
 	const jobsQuery = `SELECT progress FROM system.jobs WHERE id=$1 FOR UPDATE`
 	row, err := evalCtx.Planner.QueryRowEx(evalCtx.Context,
-		"get-stream-ingestion-job-metadata",
-		txn, sessiondata.NodeUserSessionDataOverride, jobsQuery, streamID)
+		"get-stream-ingestion-job-metadata", sessiondata.NodeUserSessionDataOverride, jobsQuery, streamID)
 	if err != nil {
 		return err
 	}
@@ -89,7 +88,7 @@ func completeStreamIngestion(
 	}
 	updateJobQuery := `UPDATE system.jobs SET progress=$1 WHERE id=$2`
 	_, err = evalCtx.Planner.QueryRowEx(evalCtx.Context,
-		"set-stream-ingestion-job-metadata", txn,
+		"set-stream-ingestion-job-metadata",
 		sessiondata.NodeUserSessionDataOverride, updateJobQuery, progressBytes, streamID)
 	return err
 }

--- a/pkg/sql/faketreeeval/BUILD.bazel
+++ b/pkg/sql/faketreeeval/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/faketreeeval",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/kv",
         "//pkg/security",
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -394,7 +393,6 @@ func (ep *DummyEvalPlanner) ResolveType(
 func (ep *DummyEvalPlanner) QueryRowEx(
 	ctx context.Context,
 	opName string,
-	txn *kv.Txn,
 	session sessiondata.InternalExecutorOverride,
 	stmt string,
 	qargs ...interface{},
@@ -406,7 +404,6 @@ func (ep *DummyEvalPlanner) QueryRowEx(
 func (ep *DummyEvalPlanner) QueryIteratorEx(
 	ctx context.Context,
 	opName string,
-	txn *kv.Txn,
 	session sessiondata.InternalExecutorOverride,
 	stmt string,
 	qargs ...interface{},

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -872,13 +872,12 @@ func validateDescriptor(ctx context.Context, p *planner, descriptor catalog.Desc
 func (p *planner) QueryRowEx(
 	ctx context.Context,
 	opName string,
-	txn *kv.Txn,
 	override sessiondata.InternalExecutorOverride,
 	stmt string,
 	qargs ...interface{},
 ) (tree.Datums, error) {
 	ie := p.ExecCfg().InternalExecutorFactory(ctx, p.SessionData())
-	return ie.QueryRowEx(ctx, opName, txn, override, stmt, qargs...)
+	return ie.QueryRowEx(ctx, opName, p.Txn(), override, stmt, qargs...)
 }
 
 // QueryIteratorEx executes the query, returning an iterator that can be used
@@ -890,12 +889,11 @@ func (p *planner) QueryRowEx(
 func (p *planner) QueryIteratorEx(
 	ctx context.Context,
 	opName string,
-	txn *kv.Txn,
 	override sessiondata.InternalExecutorOverride,
 	stmt string,
 	qargs ...interface{},
 ) (eval.InternalRows, error) {
 	ie := p.ExecCfg().InternalExecutorFactory(ctx, p.SessionData())
-	rows, err := ie.QueryIteratorEx(ctx, opName, txn, override, stmt, qargs...)
+	rows, err := ie.QueryIteratorEx(ctx, opName, p.Txn(), override, stmt, qargs...)
 	return rows.(eval.InternalRows), err
 }

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -1975,7 +1975,6 @@ func makePayloadsForTraceGenerator(
 	it, err := ctx.Planner.QueryIteratorEx(
 		ctx.Ctx(),
 		"crdb_internal.payloads_for_trace",
-		ctx.Txn,
 		sessiondata.NoSessionDataOverride,
 		query,
 		traceID,

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -235,7 +235,6 @@ func makePGGetIndexDef(argTypes tree.ArgTypes) tree.Overload {
 			}
 			r, err := ctx.Planner.QueryRowEx(
 				ctx.Ctx(), "pg_get_indexdef",
-				ctx.Txn,
 				sessiondata.NoSessionDataOverride,
 				"SELECT indexdef FROM pg_catalog.pg_indexes WHERE crdb_oid = $1", args[0])
 			if err != nil {
@@ -252,7 +251,6 @@ func makePGGetIndexDef(argTypes tree.ArgTypes) tree.Overload {
 			// The 3 argument variant for column number other than 0 returns the column name.
 			r, err = ctx.Planner.QueryRowEx(
 				ctx.Ctx(), "pg_get_indexdef",
-				ctx.Txn,
 				sessiondata.NoSessionDataOverride,
 				`SELECT ischema.column_name as pg_get_indexdef 
 		               FROM information_schema.statistics AS ischema 
@@ -287,7 +285,6 @@ func makePGGetViewDef(argTypes tree.ArgTypes) tree.Overload {
 		Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
 			r, err := ctx.Planner.QueryRowEx(
 				ctx.Ctx(), "pg_get_viewdef",
-				ctx.Txn,
 				sessiondata.NoSessionDataOverride,
 				"SELECT definition FROM pg_catalog.pg_views v JOIN pg_catalog.pg_class c ON "+
 					"c.relname=v.viewname WHERE oid=$1", args[0])
@@ -312,7 +309,6 @@ func makePGGetConstraintDef(argTypes tree.ArgTypes) tree.Overload {
 		Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
 			r, err := ctx.Planner.QueryRowEx(
 				ctx.Ctx(), "pg_get_constraintdef",
-				ctx.Txn,
 				sessiondata.NoSessionDataOverride,
 				"SELECT condef FROM pg_catalog.pg_constraint WHERE oid=$1", args[0])
 			if err != nil {
@@ -465,7 +461,7 @@ func getNameForArg(ctx *eval.Context, arg tree.Datum, pgTable, pgCol string) (st
 		return "", errors.AssertionFailedf("unexpected arg type %T", t)
 	}
 	r, err := ctx.Planner.QueryRowEx(ctx.Ctx(), "get-name-for-arg",
-		ctx.Txn, sessiondata.NoSessionDataOverride, query, arg)
+		sessiondata.NoSessionDataOverride, query, arg)
 	if err != nil || r == nil {
 		return "", err
 	}
@@ -674,7 +670,6 @@ var pgBuiltins = map[string]builtinDefinition{
 				funcOid := tree.MustBeDOid(args[0])
 				t, err := ctx.Planner.QueryRowEx(
 					ctx.Ctx(), "pg_get_function_result",
-					ctx.Txn,
 					sessiondata.NoSessionDataOverride,
 					`SELECT prorettype::REGTYPE::TEXT FROM pg_proc WHERE oid=$1`, int(funcOid.DInt))
 				if err != nil {
@@ -702,7 +697,6 @@ var pgBuiltins = map[string]builtinDefinition{
 				funcOid := tree.MustBeDOid(args[0])
 				t, err := ctx.Planner.QueryRowEx(
 					ctx.Ctx(), "pg_get_function_identity_arguments",
-					ctx.Txn,
 					sessiondata.NoSessionDataOverride,
 					`SELECT array_agg(unnest(proargtypes)::REGTYPE::TEXT) FROM pg_proc WHERE oid=$1`, int(funcOid.DInt))
 				if err != nil {
@@ -893,7 +887,6 @@ var pgBuiltins = map[string]builtinDefinition{
 				oid := args[0]
 				t, err := ctx.Planner.QueryRowEx(
 					ctx.Ctx(), "pg_get_userbyid",
-					ctx.Txn,
 					sessiondata.NoSessionDataOverride,
 					"SELECT rolname FROM pg_catalog.pg_roles WHERE oid=$1", oid)
 				if err != nil {
@@ -922,7 +915,6 @@ var pgBuiltins = map[string]builtinDefinition{
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				r, err := ctx.Planner.QueryRowEx(
 					ctx.Ctx(), "pg_sequence_parameters",
-					ctx.Txn,
 					sessiondata.NoSessionDataOverride,
 					`SELECT seqstart, seqmin, seqmax, seqincrement, seqcycle, seqcache, seqtypid `+
 						`FROM pg_catalog.pg_sequence WHERE seqrelid=$1`, args[0])
@@ -1009,7 +1001,6 @@ var pgBuiltins = map[string]builtinDefinition{
 				// on pg_description and let predicate push-down do its job.
 				r, err := ctx.Planner.QueryRowEx(
 					ctx.Ctx(), "pg_get_coldesc",
-					ctx.Txn,
 					sessiondata.NoSessionDataOverride,
 					`
 SELECT COALESCE(c.comment, pc.comment) FROM system.comments c
@@ -1081,7 +1072,7 @@ WHERE c.type=$1::int AND c.object_id=$2::int AND c.sub_id=$3::int LIMIT 1
 				}
 
 				r, err := ctx.Planner.QueryRowEx(
-					ctx.Ctx(), "pg_get_shobjdesc", ctx.Txn,
+					ctx.Ctx(), "pg_get_shobjdesc",
 					sessiondata.NoSessionDataOverride,
 					fmt.Sprintf(`
 SELECT description
@@ -1156,7 +1147,6 @@ SELECT description
 				oid := tree.MustBeDOid(args[0])
 				t, err := ctx.Planner.QueryRowEx(
 					ctx.Ctx(), "pg_function_is_visible",
-					ctx.Txn,
 					sessiondata.NoSessionDataOverride,
 					"SELECT * from pg_proc WHERE oid=$1 LIMIT 1", int(oid.DInt))
 				if err != nil {
@@ -2058,7 +2048,6 @@ SELECT description
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				r, err := ctx.Planner.QueryRowEx(
 					ctx.Ctx(), "information_schema._pg_index_position",
-					ctx.Txn,
 					sessiondata.NoSessionDataOverride,
 					`SELECT (ss.a).n FROM
 					  (SELECT information_schema._pg_expandarray(indkey) AS a
@@ -2223,7 +2212,7 @@ func getPgObjDesc(ctx *eval.Context, catalogName string, oid int) (tree.Datum, e
 		classOidFilter = fmt.Sprintf("AND classoid = %d", classOid)
 	}
 	r, err := ctx.Planner.QueryRowEx(
-		ctx.Ctx(), "pg_get_objdesc", ctx.Txn,
+		ctx.Ctx(), "pg_get_objdesc",
 		sessiondata.NoSessionDataOverride,
 		fmt.Sprintf(`
 SELECT description

--- a/pkg/sql/sem/builtins/show_create_all_schemas_builtin.go
+++ b/pkg/sql/sem/builtins/show_create_all_schemas_builtin.go
@@ -35,7 +35,6 @@ func getSchemaIDs(
 	it, err := evalPlanner.QueryIteratorEx(
 		ctx,
 		"crdb_internal.show_create_all_schemas",
-		txn,
 		sessiondata.NoSessionDataOverride,
 		query,
 		dbName,
@@ -76,7 +75,6 @@ func getSchemaCreateStatement(
 	row, err := evalPlanner.QueryRowEx(
 		ctx,
 		"crdb_internal.show_create_all_schemas",
-		txn,
 		sessiondata.NoSessionDataOverride,
 		query,
 		id,

--- a/pkg/sql/sem/builtins/show_create_all_tables_builtin.go
+++ b/pkg/sql/sem/builtins/show_create_all_tables_builtin.go
@@ -74,7 +74,6 @@ func getTopologicallySortedTableIDs(
 		it, err := evalPlanner.QueryIteratorEx(
 			ctx,
 			"crdb_internal.show_create_all_tables",
-			txn,
 			sessiondata.NoSessionDataOverride,
 			query,
 			tid,
@@ -161,7 +160,6 @@ func getTableIDs(
 	it, err := evalPlanner.QueryIteratorEx(
 		ctx,
 		"crdb_internal.show_create_all_tables",
-		txn,
 		sessiondata.NoSessionDataOverride,
 		query,
 		dbName,
@@ -250,7 +248,6 @@ func getCreateStatement(
 	row, err := evalPlanner.QueryRowEx(
 		ctx,
 		"crdb_internal.show_create_all_tables",
-		txn,
 		sessiondata.NoSessionDataOverride,
 		query,
 		id,
@@ -281,7 +278,6 @@ func getAlterStatements(
 	row, err := evalPlanner.QueryRowEx(
 		ctx,
 		"crdb_internal.show_create_all_tables",
-		txn,
 		sessiondata.NoSessionDataOverride,
 		query,
 		id,

--- a/pkg/sql/sem/builtins/show_create_all_types_builtin.go
+++ b/pkg/sql/sem/builtins/show_create_all_types_builtin.go
@@ -35,7 +35,6 @@ func getTypeIDs(
 	it, err := evalPlanner.QueryIteratorEx(
 		ctx,
 		"crdb_internal.show_create_all_types",
-		txn,
 		sessiondata.NoSessionDataOverride,
 		query,
 		dbName,
@@ -76,7 +75,6 @@ func getTypeCreateStatement(
 	row, err := evalPlanner.QueryRowEx(
 		ctx,
 		"crdb_internal.show_create_all_types",
-		txn,
 		sessiondata.NoSessionDataOverride,
 		query,
 		id,

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -267,7 +266,6 @@ type Planner interface {
 	QueryRowEx(
 		ctx context.Context,
 		opName string,
-		txn *kv.Txn,
 		override sessiondata.InternalExecutorOverride,
 		stmt string,
 		qargs ...interface{}) (tree.Datums, error)
@@ -281,7 +279,6 @@ type Planner interface {
 	QueryIteratorEx(
 		ctx context.Context,
 		opName string,
-		txn *kv.Txn,
 		override sessiondata.InternalExecutorOverride,
 		stmt string,
 		qargs ...interface{},


### PR DESCRIPTION
Release note: None

Every call to Query* methods on the `EvalPlanner` use the planners transaction.