### PR TITLE
row: mark sql.distsql.use_streamer.enabled as TenantReadOnly setting

### DIFF
--- a/pkg/sql/row/kv_batch_streamer.go
+++ b/pkg/sql/row/kv_batch_streamer.go
@@ -32,7 +32,7 @@ func CanUseStreamer(ctx context.Context, settings *cluster.Settings) bool {
 // useStreamerEnabled determines whether the Streamer API should be used.
 // TODO(yuzefovich): remove this in 22.2.
 var useStreamerEnabled = settings.RegisterBoolSetting(
-	settings.TenantWritable,
+	settings.TenantReadOnly,
 	"sql.distsql.use_streamer.enabled",
 	"determines whether the usage of the Streamer API is allowed. "+
 		"Enabling this will increase the speed of lookup/index joins "+


### PR DESCRIPTION
The streamer breaks the cost model we have for serverless, so this
commit modifies the `sql.distsql.use_streamer.enabled` cluster setting
to be tenant read-only.

The default value on 22.1 branch is `off`, but once serverless clusters
are upgraded to 22.1.x, users could change the setting, and the RU
consumption would be unpredictable (and we could under- and over-
charge).

Release note: None