### PR TITLE
sql: support partial indexes in EXPERIMENTAL FINGERPRINTS

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/show_fingerprints
+++ b/pkg/sql/logictest/testdata/logic_test/show_fingerprints
@@ -18,6 +18,22 @@ SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE t
 t_pkey   -7903300865687235210
 t_b_idx  -5073888452016928166
 
+# Test a partial index. We expect this index to have the same fingerprint
+# as t_b_idx since the predicate covers all values.
+statement ok
+CREATE INDEX ON t(b) STORING (d) WHERE b > 0
+
+query TT
+SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE t
+----
+t_pkey   -7903300865687235210
+t_b_idx  -5073888452016928166
+t_b_idx1  -5073888452016928166
+
+
+statement ok
+DROP INDEX t_b_idx1
+
 statement ok
 UPDATE t SET b = 9
 


### PR DESCRIPTION
Previously, `SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE t` would fail
on a table with a partial index.

Now, we handle the partial index by adding the required predicate to
the row selection query.

Release note (bug fix): `SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE`
now works on tables with partial indexes.