### PR TITLE
lint: un-skip `CODEOWNERS` check for bazel

### DIFF
--- a/pkg/cmd/github-pull-request-make/main.go
+++ b/pkg/cmd/github-pull-request-make/main.go
@@ -296,11 +296,18 @@ func main() {
 				if err != nil {
 					log.Fatal(err)
 				}
+				numTargets := 0
 				for _, target := range strings.Split(string(out), "\n") {
 					target = strings.TrimSpace(target)
 					if target != "" {
 						args = append(args, target)
+						numTargets++
 					}
+				}
+				if numTargets == 0 {
+					// In this case there's nothing to test, so we can bail out early.
+					log.Printf("found no targets to test under package %s\n", name)
+					continue
 				}
 				args = append(args, "--")
 				if target == "stressrace" {

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2208,7 +2208,6 @@ func TestLint(t *testing.T) {
 	})
 
 	t.Run("CODEOWNERS", func(t *testing.T) {
-		skip.UnderBazel(t, "doesn't work under bazel")
 		co, err := codeowners.DefaultLoadCodeOwners()
 		require.NoError(t, err)
 		const verbose = false

--- a/pkg/testutils/skip/skip.go
+++ b/pkg/testutils/skip/skip.go
@@ -89,14 +89,6 @@ func UnderRaceWithIssue(t SkippableTest, githubIssueID int, args ...interface{})
 	}
 }
 
-// UnderBazel skips this test if run under bazel.
-func UnderBazel(t SkippableTest, args ...interface{}) {
-	t.Helper()
-	if bazel.BuiltWithBazel() {
-		t.Skip(append([]interface{}{"disabled under bazel"}, args...))
-	}
-}
-
 // UnderBazelWithIssue skips this test if we are building inside bazel,
 // logging the given issue ID as the reason.
 func UnderBazelWithIssue(t SkippableTest, githubIssueID int, args ...interface{}) {


### PR DESCRIPTION
Release note: None