### PR TITLE
settings: Prevent new sql.defaults cluster settings from being added

### DIFF
--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -13,6 +13,7 @@ package settings
 import (
 	"fmt"
 	"sort"
+	"strings"
 	"unicode"
 	"unicode/utf8"
 )
@@ -127,6 +128,58 @@ var retiredSettings = map[string]struct{}{
 	"kv.rangefeed.separated_intent_scan.enabled":                       {},
 }
 
+var sqlDefaultSettings = map[string]struct{}{
+	"sql.defaults.cost_scans_with_default_col_size.enabled":                     {},
+	"sql.defaults.datestyle":                                                    {},
+	"sql.defaults.datestyle.enabled":                                            {},
+	"sql.defaults.default_hash_sharded_index_bucket_count":                      {},
+	"sql.defaults.default_int_size":                                             {},
+	"sql.defaults.disallow_full_table_scans.enabled":                            {},
+	"sql.defaults.distsql":                                                      {},
+	"sql.defaults.experimental_alter_column_type.enabled":                       {},
+	"sql.defaults.experimental_auto_rehoming.enabled":                           {},
+	"sql.defaults.experimental_computed_column_rewrites":                        {},
+	"sql.defaults.experimental_distsql_planning":                                {},
+	"sql.defaults.experimental_enable_unique_without_index_constraints.enabled": {},
+	"sql.defaults.experimental_implicit_column_partitioning.enabled":            {},
+	"sql.defaults.experimental_stream_replication.enabled":                      {},
+	"sql.defaults.experimental_temporary_tables.enabled":                        {},
+	"sql.defaults.foreign_key_cascades_limit":                                   {},
+	"sql.defaults.idle_in_session_timeout":                                      {},
+	"sql.defaults.idle_in_transaction_session_timeout":                          {},
+	"sql.defaults.implicit_select_for_update.enabled":                           {},
+	"sql.defaults.insert_fast_path.enabled":                                     {},
+	"sql.defaults.intervalstyle":                                                {},
+	"sql.defaults.intervalstyle.enabled":                                        {},
+	"sql.defaults.large_full_scan_rows":                                         {},
+	"sql.defaults.locality_optimized_partitioned_index_scan.enabled":            {},
+	"sql.defaults.lock_timeout":                                                 {},
+	"sql.defaults.multiregion_placement_policy.enabled":                         {},
+	"sql.defaults.on_update_rehome_row.enabled":                                 {},
+	"sql.defaults.optimizer_use_histograms.enabled":                             {},
+	"sql.defaults.optimizer_use_multicol_stats.enabled":                         {},
+	"sql.defaults.override_alter_primary_region_in_super_region.enabled":        {},
+	"sql.defaults.override_multi_region_zone_config.enabled":                    {},
+	"sql.defaults.prefer_lookup_joins_for_fks.enabled":                          {},
+	"sql.defaults.primary_region":                                               {},
+	"sql.defaults.propagate_input_ordering.enabled":                             {},
+	"sql.defaults.reorder_joins_limit":                                          {},
+	"sql.defaults.require_explicit_primary_keys.enabled":                        {},
+	"sql.defaults.results_buffer.size":                                          {},
+	"sql.defaults.serial_normalization":                                         {},
+	"sql.defaults.serial_sequences_cache_size":                                  {},
+	"sql.defaults.statement_timeout":                                            {},
+	"sql.defaults.stub_catalog_tables.enabled":                                  {},
+	"sql.defaults.super_regions.enabled":                                        {},
+	"sql.defaults.transaction_rows_read_err":                                    {},
+	"sql.defaults.transaction_rows_read_log":                                    {},
+	"sql.defaults.transaction_rows_written_err":                                 {},
+	"sql.defaults.transaction_rows_written_log":                                 {},
+	"sql.defaults.use_declarative_schema_changer":                               {},
+	"sql.defaults.vectorize":                                                    {},
+	"sql.defaults.zigzag_join.enabled":                                          {},
+}
+
 // register adds a setting to the registry.
 func register(class Class, key, desc string, s internalSetting) {
 	if _, ok := retiredSettings[key]; ok {
@@ -134,6 +187,12 @@ func register(class Class, key, desc string, s internalSetting) {
 	}
 	if _, ok := registry[key]; ok {
 		panic(fmt.Sprintf("setting already defined: %s", key))
+	}
+	if strings.Contains(key, "sql.defaults") {
+		if _, ok := sqlDefaultSettings[key]; !ok {
+			panic(fmt.Sprintf(
+				"new sql.defaults cluster settings: %s is not needed now that `ALTER ROLE ... SET` syntax is supported", key))
+		}
 	}
 	if len(desc) == 0 {
 		panic(fmt.Sprintf("setting missing description: %s", key))


### PR DESCRIPTION
Resolves #80324

In order to encourage the use of `ALTER ROLE` this commit adds
a panic that prevents new sql.default cluster settings from being
added.

Release note: None