### PR TITLE
git: remove `distdir_files.bzl` from `git` text diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
+build/bazelutil/distdir_files.bzl -diff
 pkg/BUILD.bazel -diff


### PR DESCRIPTION
This file is generated and contains only URL's and hashes. Humans won't
need to review this stuff.

Release note: None