### PR TITLE
roachtest: roachstress.sh - fix for ${short} build

### DIFF
--- a/pkg/cmd/roachtest/roachstress.sh
+++ b/pkg/cmd/roachtest/roachstress.sh
@@ -138,7 +138,7 @@ a="${abase}/$(date '+%H%M%S')"
 if [ ! -f "${cr}" ] || [ "${force_build}" = "y" ]; then
   if [ -z "${local}" ]; then
     ./dev build "cockroach${short}" --cross=linux
-    cp "artifacts/cockroach${artifact_suffix}" "${cr}"
+    cp "artifacts/cockroach${short}" "${cr}"
   else
     ./dev build "cockroach${short}"
     cp "cockroach${short}" "${cr}"


### PR DESCRIPTION
Non local stress build was not working because of incorrect variable naming.
Stress run script used ${artifact_suffix} instead of ${short} which is the
remnant from bazel migration.

Release note: None

Fixes bug mentioned in #80222.