### PR TITLE
sql: skip TestDropColumnAfterMutations

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -6958,6 +6958,7 @@ func TestRevertingJobsOnDatabasesAndSchemas(t *testing.T) {
 // after an existing mutation on the column.
 func TestDropColumnAfterMutations(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 76843, "flaky test")
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 	var jobControlMu syncutil.Mutex


### PR DESCRIPTION
Refs: #76843

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None