### PR TITLE
release: use preflight tool for RedHat images

### DIFF
--- a/build/release/teamcity-publish-redhat-release.sh
+++ b/build/release/teamcity-publish-redhat-release.sh
@@ -33,6 +33,7 @@ fi
 # Hard coded release number used only by the RedHat images
 rhel_release=1
 rhel_registry="scan.connect.redhat.com"
+rhel_project_id=5e61ea74fe2231a0c2860382
 rhel_repository="${rhel_registry}/p194808216984433e18e6e90dd859cb1ea7c738ec50/cockroach"
 dockerhub_repository="cockroachdb/cockroach"
 
@@ -63,3 +64,23 @@ tc_end_block "Rebuild docker image"
 tc_start_block "Push RedHat docker image"
 retry docker push "${rhel_repository}:${build_name}"
 tc_end_block "Push RedHat docker image"
+
+tc_start_block "Run preflight"
+mkdir -p artifacts
+docker run \
+  -it \
+  --rm \
+  --security-opt=label=disable \
+  --env PFLT_LOGLEVEL=trace \
+  --env PFLT_ARTIFACTS=/artifacts \
+  --env PFLT_LOGFILE=/artifacts/preflight.log \
+  --env PFLT_CERTIFICATION_PROJECT_ID="$rhel_project_id" \
+  --env PFLT_PYXIS_API_TOKEN="$REDHAT_API_TOKEN" \
+  --env PFLT_DOCKERCONFIG=/temp-authfile.json \
+  --env DOCKER_CONFIG=/tmp/docker \
+  -v $PWD/artifacts:/artifacts \
+  -v ~/.docker/config.json:/temp-authfile.json:ro \
+  -v ~/.docker/config.json:/tmp/docker/config.json:ro \
+  quay.io/opdev/preflight:1.1.0 check container \
+  "${rhel_repository}:${build_name}" --submit
+tc_end_block "Run preflight"


### PR DESCRIPTION
RedHat Connect has introduced a new certification workflow, which
requires running some tests locally and submit the results back to
RedHat.

This patch runs the `preflight` tool to address the new workflow
changes.

Fixes #80633

Release note: None