### PR TITLE
kvserver: avoid spanset assertion in MVCCGarbageCollect

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -338,7 +338,7 @@ func EvalAddSSTable(
 	// addition, and instead just use this key-only iterator. If a caller actually
 	// needs to know what data is there, it must issue its own real Scan.
 	if args.ReturnFollowingLikelyNonEmptySpanStart {
-		existingIter := spanset.DisableReaderAssertions(readWriter).NewMVCCIterator(
+		existingIter := storage.DisableReaderAssertions(readWriter).NewMVCCIterator(
 			storage.MVCCKeyIterKind, // don't care if it is committed or not, just that it isn't empty.
 			storage.IterOptions{UpperBound: reply.RangeSpan.EndKey},
 		)

--- a/pkg/kv/kvserver/batcheval/cmd_recompute_stats.go
+++ b/pkg/kv/kvserver/batcheval/cmd_recompute_stats.go
@@ -71,7 +71,7 @@ func RecomputeStats(
 
 	// Disable the assertions which check that all reads were previously declared.
 	// See the comment in `declareKeysRecomputeStats` for details on this.
-	reader = spanset.DisableReaderAssertions(reader)
+	reader = storage.DisableReaderAssertions(reader)
 
 	actualMS, err := rditer.ComputeStatsForRange(desc, reader, cArgs.Header.Timestamp.WallTime)
 	if err != nil {

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "pebble_merge.go",
         "pebble_mvcc_scanner.go",
         "read_as_of_iterator.go",
+        "reader_assertions.go",
         "replicas_storage.go",
         "resource_limiter.go",
         "row_counter.go",

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -3546,7 +3546,9 @@ func MVCCGarbageCollect(
 
 	// Bound the iterator appropriately for the set of keys we'll be garbage
 	// collecting.
-	iter := rw.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+	// Disable spanset assertions as we intentionally (but safely) call SeekLT(key)
+	// where we only own a point latch for `key`.
+	iter := DisableReaderAssertions(rw).NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
 		LowerBound: keys[0].Key,
 		UpperBound: keys[len(keys)-1].Key.Next(),
 	})

--- a/pkg/storage/reader_assertions.go
+++ b/pkg/storage/reader_assertions.go
@@ -1,0 +1,28 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+//
+
+package storage
+
+// DisableReaderAssertionsI is optionally implemented by arguments to DisableReaderAssertions.
+type DisableReaderAssertionsI interface {
+	DisableReaderAssertions() (wrapped Reader)
+}
+
+// DisableReaderAssertions unwraps any storage.Reader implementations that may
+// assert access against a given SpanSet.
+func DisableReaderAssertions(reader Reader) Reader {
+	switch v := reader.(type) {
+	case DisableReaderAssertionsI:
+		return DisableReaderAssertions(v.DisableReaderAssertions())
+	default:
+		return reader
+	}
+}


### PR DESCRIPTION
See
https://github.com/cockroachdb/cockroach/pull/80619#issuecomment-1110994494.

My understanding is that in `MVCCGarbageCollect`, we look at each `key`.
First, we seek the iterator to construct the `MVCCMetadata` (if there is
one), so we're here:

```
key @ ts=100   <-- iter
key @ ts=099
...
key @ ts=007
key @ ts=006
key @ ts=005
```

If we want to GC at timestamp, say, 6, we need to iterate forwards. To
avoid calling `Next()` too many times, eventually we'll instead
`SeekLT(key @ 6)`.

But we only hold the latch for `key`, so we can't seek into `[/Min,
key)`.

Release note: None
