### PR TITLE
release-22.1: sql/catalog: stop hiding constraints on hidden columns

### DIFF
--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -316,24 +316,6 @@ func (desc *wrapper) collectConstraintInfo(
 				return nil, pgerror.Newf(pgcode.DuplicateObject,
 					"duplicate constraint name: %q", index.Name)
 			}
-			colHiddenMap := make(map[descpb.ColumnID]bool, len(desc.Columns))
-			for i := range desc.Columns {
-				col := &desc.Columns[i]
-				colHiddenMap[col.ID] = col.Hidden
-			}
-			// Don't include constraints against only hidden columns.
-			// This prevents the auto-created rowid primary key index from showing up
-			// in show constraints.
-			hidden := true
-			for _, id := range index.KeyColumnIDs {
-				if !colHiddenMap[id] {
-					hidden = false
-					break
-				}
-			}
-			if hidden {
-				continue
-			}
 			indexName := index.Name
 			// If a primary key swap is occurring, then the primary index name can
 			// be seen as being under the new name.

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -1175,6 +1175,9 @@ func TestValidateTableDesc(t *testing.T) {
 				},
 				NextColumnID: 2,
 				NextFamilyID: 1,
+				PrimaryIndex: descpb.IndexDescriptor{
+					ID: 1, ConstraintID: 1, Name: "primary", KeyColumnIDs: []descpb.ColumnID{1}, KeyColumnNames: []string{"bar"},
+					KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC}},
 				UniqueWithoutIndexConstraints: []descpb.UniqueWithoutIndexConstraint{
 					{
 						TableID:   2,
@@ -2675,9 +2678,12 @@ func TestValidateConstraintID(t *testing.T) {
 				Families: []descpb.ColumnFamilyDescriptor{
 					{ID: 0, Name: "primary", ColumnIDs: []descpb.ColumnID{1}, ColumnNames: []string{"bar"}},
 				},
+				PrimaryIndex: descpb.IndexDescriptor{
+					ID: 1, ConstraintID: 1, Name: "primary", KeyColumnIDs: []descpb.ColumnID{1}, KeyColumnNames: []string{"bar"},
+					KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC}},
 				Indexes: []descpb.IndexDescriptor{
 					{
-						ID: 1, Name: "secondary", KeyColumnIDs: []descpb.ColumnID{1}, KeyColumnNames: []string{"bar"},
+						ID: 2, Name: "secondary", KeyColumnIDs: []descpb.ColumnID{1}, KeyColumnNames: []string{"bar"},
 						KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC},
 						Unique:              true,
 					},
@@ -2702,6 +2708,9 @@ func TestValidateConstraintID(t *testing.T) {
 				Families: []descpb.ColumnFamilyDescriptor{
 					{ID: 0, Name: "primary", ColumnIDs: []descpb.ColumnID{1}, ColumnNames: []string{"bar"}},
 				},
+				PrimaryIndex: descpb.IndexDescriptor{
+					ID: 1, ConstraintID: 1, Name: "primary", KeyColumnIDs: []descpb.ColumnID{1}, KeyColumnNames: []string{"bar"},
+					KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC}},
 				UniqueWithoutIndexConstraints: []descpb.UniqueWithoutIndexConstraint{
 					{Name: "bad"},
 				},
@@ -2725,6 +2734,9 @@ func TestValidateConstraintID(t *testing.T) {
 				Families: []descpb.ColumnFamilyDescriptor{
 					{ID: 0, Name: "primary", ColumnIDs: []descpb.ColumnID{1}, ColumnNames: []string{"bar"}},
 				},
+				PrimaryIndex: descpb.IndexDescriptor{
+					ID: 1, ConstraintID: 1, Name: "primary", KeyColumnIDs: []descpb.ColumnID{1}, KeyColumnNames: []string{"bar"},
+					KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC}},
 				Checks: []*descpb.TableDescriptor_CheckConstraint{
 					{Name: "bad"},
 				},

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3202,6 +3202,10 @@ func (m *sessionDataMutator) SetExpectAndIgnoreNotVisibleColumnsInCopy(val bool)
 	m.data.ExpectAndIgnoreNotVisibleColumnsInCopy = val
 }
 
+func (m *sessionDataMutator) SetShowPrimaryKeyConstraintOnNotVisibleColumns(val bool) {
+	m.data.ShowPrimaryKeyConstraintOnNotVisibleColumns = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -840,7 +840,10 @@ END;
 
 				// Verify the constraint is unvalidated.
 				`SHOW CONSTRAINTS FROM weather
-				`: {{"weather", "weather_city_fkey", "FOREIGN KEY", "FOREIGN KEY (city) REFERENCES cities(city) NOT VALID", "false"}},
+				`: {
+					{"weather", "weather_city_fkey", "FOREIGN KEY", "FOREIGN KEY (city) REFERENCES cities(city) NOT VALID", "false"},
+					{"weather", "weather_pkey", "PRIMARY KEY", "PRIMARY KEY (rowid ASC)", "true"},
+				},
 			},
 		},
 		{
@@ -905,7 +908,9 @@ END;
 				},
 				// Verify the constraint is skipped.
 				`SELECT dependson_name FROM crdb_internal.backward_dependencies`: {},
-				`SHOW CONSTRAINTS FROM weather`:                                  {},
+				`SHOW CONSTRAINTS FROM weather`: {
+					{"weather", "weather_pkey", "PRIMARY KEY", "PRIMARY KEY (rowid ASC)", "true"},
+				},
 			},
 		},
 		{

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -957,6 +957,7 @@ INSERT INTO t VALUES (NULL)
 query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
+t  t_pkey  PRIMARY KEY  PRIMARY KEY (rowid ASC)  true
 
 statement ok
 ALTER TABLE t ALTER COLUMN a DROP NOT NULL
@@ -987,8 +988,9 @@ INSERT INTO t VALUES (NULL)
 query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
-t  a_auto_not_null   CHECK  CHECK ((a IS NOT NULL))  true
-t  a_auto_not_null1  CHECK  CHECK ((a IS NOT NULL))  true
+t  a_auto_not_null   CHECK        CHECK ((a IS NOT NULL))  true
+t  a_auto_not_null1  CHECK        CHECK ((a IS NOT NULL))  true
+t  t_pkey            PRIMARY KEY  PRIMARY KEY (rowid ASC)  true
 
 statement ok
 DROP TABLE t
@@ -1012,8 +1014,9 @@ ALTER TABLE t ADD CHECK (a < 16) NOT VALID
 query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
-t  check_a   CHECK  CHECK ((a < 100))           true
-t  check_a1  CHECK  CHECK ((a < 16)) NOT VALID  false
+t  check_a   CHECK        CHECK ((a < 100))           true
+t  check_a1  CHECK        CHECK ((a < 16)) NOT VALID  false
+t  t_pkey    PRIMARY KEY  PRIMARY KEY (rowid ASC)     true
 
 query error pq: failed to satisfy CHECK constraint \(a < 16:::INT8\)
 INSERT INTO t VALUES (20)
@@ -1030,8 +1033,9 @@ ALTER TABLE t VALIDATE CONSTRAINT check_a1
 query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
-t  check_a   CHECK  CHECK ((a < 100))  true
-t  check_a1  CHECK  CHECK ((a < 16))   true
+t  check_a   CHECK        CHECK ((a < 100))        true
+t  check_a1  CHECK        CHECK ((a < 16))         true
+t  t_pkey    PRIMARY KEY  PRIMARY KEY (rowid ASC)  true
 
 subtest regression_42858
 
@@ -1597,6 +1601,7 @@ unique_without_index  unique_c                    UNIQUE           UNIQUE WITHOU
 unique_without_index  unique_d                    UNIQUE           UNIQUE WITHOUT INDEX (d)                true
 unique_without_index  unique_d_e                  UNIQUE           UNIQUE WITHOUT INDEX (d, e)             true
 unique_without_index  unique_without_index_c_key  UNIQUE           UNIQUE (c ASC)                          true
+unique_without_index  unique_without_index_pkey   PRIMARY KEY      PRIMARY KEY (rowid ASC)                 true
 
 statement ok
 ALTER TABLE unique_without_index RENAME COLUMN a TO aa
@@ -1613,17 +1618,18 @@ ALTER TABLE unique_without_index RENAME CONSTRAINT unique_b TO unique_b_2
 query TTTTB
 SHOW CONSTRAINTS FROM unique_without_index
 ----
-unique_without_index  my_partial_unique_f         UNIQUE  UNIQUE WITHOUT INDEX (f) WHERE (f > 0)  true
-unique_without_index  my_unique_e                 UNIQUE  UNIQUE WITHOUT INDEX (e)                true
-unique_without_index  my_unique_e2                UNIQUE  UNIQUE WITHOUT INDEX (e) NOT VALID      false
-unique_without_index  my_unique_f                 UNIQUE  UNIQUE WITHOUT INDEX (f)                true
-unique_without_index  unique_a_b                  UNIQUE  UNIQUE WITHOUT INDEX (aa, b)            true
-unique_without_index  unique_b_1                  UNIQUE  UNIQUE WITHOUT INDEX (b)                true
-unique_without_index  unique_b_2                  UNIQUE  UNIQUE WITHOUT INDEX (b)                true
-unique_without_index  unique_c                    UNIQUE  UNIQUE WITHOUT INDEX (c)                true
-unique_without_index  unique_d                    UNIQUE  UNIQUE WITHOUT INDEX (d)                true
-unique_without_index  unique_d_e                  UNIQUE  UNIQUE WITHOUT INDEX (d, e)             true
-unique_without_index  unique_without_index_c_key  UNIQUE  UNIQUE (c ASC)                          true
+unique_without_index  my_partial_unique_f         UNIQUE       UNIQUE WITHOUT INDEX (f) WHERE (f > 0)  true
+unique_without_index  my_unique_e                 UNIQUE       UNIQUE WITHOUT INDEX (e)                true
+unique_without_index  my_unique_e2                UNIQUE       UNIQUE WITHOUT INDEX (e) NOT VALID      false
+unique_without_index  my_unique_f                 UNIQUE       UNIQUE WITHOUT INDEX (f)                true
+unique_without_index  unique_a_b                  UNIQUE       UNIQUE WITHOUT INDEX (aa, b)            true
+unique_without_index  unique_b_1                  UNIQUE       UNIQUE WITHOUT INDEX (b)                true
+unique_without_index  unique_b_2                  UNIQUE       UNIQUE WITHOUT INDEX (b)                true
+unique_without_index  unique_c                    UNIQUE       UNIQUE WITHOUT INDEX (c)                true
+unique_without_index  unique_d                    UNIQUE       UNIQUE WITHOUT INDEX (d)                true
+unique_without_index  unique_d_e                  UNIQUE       UNIQUE WITHOUT INDEX (d, e)             true
+unique_without_index  unique_without_index_c_key  UNIQUE       UNIQUE (c ASC)                          true
+unique_without_index  unique_without_index_pkey   PRIMARY KEY  PRIMARY KEY (rowid ASC)                 true
 
 statement error pgcode 0A000 cannot drop UNIQUE constraint \"unique_without_index_c_key\"
 ALTER TABLE unique_without_index DROP CONSTRAINT unique_without_index_c_key
@@ -1642,15 +1648,16 @@ ALTER TABLE unique_without_index DROP CONSTRAINT my_unique_e2
 query TTTTB
 SHOW CONSTRAINTS FROM unique_without_index
 ----
-unique_without_index  my_partial_unique_f         UNIQUE  UNIQUE WITHOUT INDEX (f) WHERE (f > 0)  true
-unique_without_index  my_unique_e                 UNIQUE  UNIQUE WITHOUT INDEX (e)                true
-unique_without_index  my_unique_f                 UNIQUE  UNIQUE WITHOUT INDEX (f)                true
-unique_without_index  unique_a_b                  UNIQUE  UNIQUE WITHOUT INDEX (aa, b)            true
-unique_without_index  unique_b_1                  UNIQUE  UNIQUE WITHOUT INDEX (b)                true
-unique_without_index  unique_c                    UNIQUE  UNIQUE WITHOUT INDEX (c)                true
-unique_without_index  unique_d                    UNIQUE  UNIQUE WITHOUT INDEX (d)                true
-unique_without_index  unique_d_e                  UNIQUE  UNIQUE WITHOUT INDEX (d, e)             true
-unique_without_index  unique_without_index_c_key  UNIQUE  UNIQUE (c ASC)                          true
+unique_without_index  my_partial_unique_f         UNIQUE       UNIQUE WITHOUT INDEX (f) WHERE (f > 0)  true
+unique_without_index  my_unique_e                 UNIQUE       UNIQUE WITHOUT INDEX (e)                true
+unique_without_index  my_unique_f                 UNIQUE       UNIQUE WITHOUT INDEX (f)                true
+unique_without_index  unique_a_b                  UNIQUE       UNIQUE WITHOUT INDEX (aa, b)            true
+unique_without_index  unique_b_1                  UNIQUE       UNIQUE WITHOUT INDEX (b)                true
+unique_without_index  unique_c                    UNIQUE       UNIQUE WITHOUT INDEX (c)                true
+unique_without_index  unique_d                    UNIQUE       UNIQUE WITHOUT INDEX (d)                true
+unique_without_index  unique_d_e                  UNIQUE       UNIQUE WITHOUT INDEX (d, e)             true
+unique_without_index  unique_without_index_c_key  UNIQUE       UNIQUE (c ASC)                          true
+unique_without_index  unique_without_index_pkey   PRIMARY KEY  PRIMARY KEY (rowid ASC)                 true
 
 # Dropping a column in a unique constraint drops the constraint.
 statement ok
@@ -1659,13 +1666,14 @@ ALTER TABLE unique_without_index DROP COLUMN b
 query TTTTB
 SHOW CONSTRAINTS FROM unique_without_index
 ----
-unique_without_index  my_partial_unique_f         UNIQUE  UNIQUE WITHOUT INDEX (f) WHERE (f > 0)  true
-unique_without_index  my_unique_e                 UNIQUE  UNIQUE WITHOUT INDEX (e)                true
-unique_without_index  my_unique_f                 UNIQUE  UNIQUE WITHOUT INDEX (f)                true
-unique_without_index  unique_c                    UNIQUE  UNIQUE WITHOUT INDEX (c)                true
-unique_without_index  unique_d                    UNIQUE  UNIQUE WITHOUT INDEX (d)                true
-unique_without_index  unique_d_e                  UNIQUE  UNIQUE WITHOUT INDEX (d, e)             true
-unique_without_index  unique_without_index_c_key  UNIQUE  UNIQUE (c ASC)                          true
+unique_without_index  my_partial_unique_f         UNIQUE       UNIQUE WITHOUT INDEX (f) WHERE (f > 0)  true
+unique_without_index  my_unique_e                 UNIQUE       UNIQUE WITHOUT INDEX (e)                true
+unique_without_index  my_unique_f                 UNIQUE       UNIQUE WITHOUT INDEX (f)                true
+unique_without_index  unique_c                    UNIQUE       UNIQUE WITHOUT INDEX (c)                true
+unique_without_index  unique_d                    UNIQUE       UNIQUE WITHOUT INDEX (d)                true
+unique_without_index  unique_d_e                  UNIQUE       UNIQUE WITHOUT INDEX (d, e)             true
+unique_without_index  unique_without_index_c_key  UNIQUE       UNIQUE (c ASC)                          true
+unique_without_index  unique_without_index_pkey   PRIMARY KEY  PRIMARY KEY (rowid ASC)                 true
 
 query TTTTB
 SHOW CONSTRAINTS FROM uwi_child
@@ -1673,6 +1681,7 @@ SHOW CONSTRAINTS FROM uwi_child
 uwi_child  fk_d_e            FOREIGN KEY  FOREIGN KEY (d, e) REFERENCES unique_without_index(d, e)  true
 uwi_child  fk_e_d            FOREIGN KEY  FOREIGN KEY (e, d) REFERENCES unique_without_index(e, d)  true
 uwi_child  uwi_child_d_fkey  FOREIGN KEY  FOREIGN KEY (d) REFERENCES unique_without_index(d)        true
+uwi_child  uwi_child_pkey    PRIMARY KEY  PRIMARY KEY (rowid ASC)                                   true
 
 # Attempting to drop a column with a foreign key reference fails.
 statement error pq: "unique_d" is referenced by foreign key from table "uwi_child"
@@ -1685,15 +1694,17 @@ ALTER TABLE unique_without_index DROP COLUMN d CASCADE
 query TTTTB
 SHOW CONSTRAINTS FROM unique_without_index
 ----
-unique_without_index  my_partial_unique_f         UNIQUE  UNIQUE WITHOUT INDEX (f) WHERE (f > 0)  true
-unique_without_index  my_unique_e                 UNIQUE  UNIQUE WITHOUT INDEX (e)                true
-unique_without_index  my_unique_f                 UNIQUE  UNIQUE WITHOUT INDEX (f)                true
-unique_without_index  unique_c                    UNIQUE  UNIQUE WITHOUT INDEX (c)                true
-unique_without_index  unique_without_index_c_key  UNIQUE  UNIQUE (c ASC)                          true
+unique_without_index  my_partial_unique_f         UNIQUE       UNIQUE WITHOUT INDEX (f) WHERE (f > 0)  true
+unique_without_index  my_unique_e                 UNIQUE       UNIQUE WITHOUT INDEX (e)                true
+unique_without_index  my_unique_f                 UNIQUE       UNIQUE WITHOUT INDEX (f)                true
+unique_without_index  unique_c                    UNIQUE       UNIQUE WITHOUT INDEX (c)                true
+unique_without_index  unique_without_index_c_key  UNIQUE       UNIQUE (c ASC)                          true
+unique_without_index  unique_without_index_pkey   PRIMARY KEY  PRIMARY KEY (rowid ASC)                 true
 
 query TTTTB
 SHOW CONSTRAINTS FROM uwi_child
 ----
+uwi_child  uwi_child_pkey  PRIMARY KEY  PRIMARY KEY (rowid ASC)  true
 
 # Regression for #54629.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2299,12 +2299,13 @@ SELECT pg_catalog.pg_get_constraintdef(oid)
 FROM pg_catalog.pg_constraint
 WHERE conrelid='pg_constraintdef_test'::regclass
 ----
+FOREIGN KEY (a) REFERENCES pg_indexdef_test(a) ON DELETE CASCADE
 FOREIGN KEY (c) REFERENCES pg_indexdef_test(a) NOT VALID
 CHECK ((c > a))
 CHECK ((c > 0)) NOT VALID
+PRIMARY KEY (rowid ASC)
 UNIQUE (b ASC)
 UNIQUE (a ASC) WHERE (d = 'foo'::STRING)
-FOREIGN KEY (a) REFERENCES pg_indexdef_test(a) ON DELETE CASCADE
 
 # These functions always return NULL since we don't support comments on vtable columns and databases.
 query TT

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -411,14 +411,16 @@ CREATE TABLE unique_without_index1 (a INT, b INT, CONSTRAINT ab UNIQUE WITHOUT I
 query TTTTB colnames
 SHOW CONSTRAINTS FROM unique_without_index
 ----
-table_name            constraint_name  constraint_type  details                   validated
-unique_without_index  unique_a         UNIQUE           UNIQUE WITHOUT INDEX (a)  true
+table_name            constraint_name            constraint_type  details                   validated
+unique_without_index  unique_a                   UNIQUE           UNIQUE WITHOUT INDEX (a)  true
+unique_without_index  unique_without_index_pkey  PRIMARY KEY      PRIMARY KEY (rowid ASC)   true
 
 query TTTTB colnames
 SHOW CONSTRAINTS FROM unique_without_index1
 ----
-table_name             constraint_name  constraint_type  details                      validated
-unique_without_index1  ab               UNIQUE           UNIQUE WITHOUT INDEX (a, b)  true
+table_name             constraint_name             constraint_type  details                      validated
+unique_without_index1  ab                          UNIQUE           UNIQUE WITHOUT INDEX (a, b)  true
+unique_without_index1  unique_without_index1_pkey  PRIMARY KEY      PRIMARY KEY (rowid ASC)      true
 
 # Unique constraints without an index use the same name generation logic as
 # check constraints. A named constraint following an anonymous constraint

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -557,6 +557,7 @@ query TTTTB
 SHOW CONSTRAINTS FROM delivery
 ----
 delivery  delivery_order_shipment_fkey  FOREIGN KEY  FOREIGN KEY ("order", shipment) REFERENCES orders(id, shipment)  true
+delivery  delivery_pkey                 PRIMARY KEY  PRIMARY KEY (rowid ASC)                                          true
 
 statement ok
 UPDATE products SET upc = '885155001450' WHERE sku = '780'
@@ -569,6 +570,7 @@ SHOW CONSTRAINTS FROM delivery
 ----
 delivery  delivery_item_fkey            FOREIGN KEY  FOREIGN KEY (item) REFERENCES products(upc)                      true
 delivery  delivery_order_shipment_fkey  FOREIGN KEY  FOREIGN KEY ("order", shipment) REFERENCES orders(id, shipment)  true
+delivery  delivery_pkey                 PRIMARY KEY  PRIMARY KEY (rowid ASC)                                          true
 
 statement ok
 ALTER TABLE "user content"."customer reviews"

--- a/pkg/sql/logictest/testdata/logic_test/hidden_columns
+++ b/pkg/sql/logictest/testdata/logic_test/hidden_columns
@@ -124,4 +124,5 @@ ALTER TABLE t4 ALTER PRIMARY KEY USING COLUMNS(e);
 query TTTTB
 SHOW CONSTRAINTS FROM t4
 ----
-t4 t4_d_key UNIQUE UNIQUE (d ASC) true
+t4  t4_d_key  UNIQUE       UNIQUE (d ASC)       true
+t4  t4_pkey   PRIMARY KEY  PRIMARY KEY (e ASC)  true

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -1941,6 +1941,7 @@ constraint_db       public             t1_pkey                    constraint_db 
 constraint_db       public             t1_a_key                   constraint_db  public        t1          UNIQUE           NO             NO
 constraint_db       public             3864823197_119_2_not_null  constraint_db  public        t2          CHECK            NO             NO
 constraint_db       public             fk                         constraint_db  public        t2          FOREIGN KEY      NO             NO
+constraint_db       public             t2_pkey                    constraint_db  public        t2          PRIMARY KEY      NO             NO
 
 query TTTT colnames
 SELECT *
@@ -1964,6 +1965,7 @@ constraint_db  public        t1          a            constraint_db       public
 constraint_db  public        t1          a            constraint_db       public             fk
 constraint_db  public        t1          a            constraint_db       public             t1_a_key
 constraint_db  public        t1          p            constraint_db       public             t1_pkey
+constraint_db  public        t2          rowid        constraint_db       public             t2_pkey
 
 # Query issued by jOOQ in PostgresDatabase.loadCheckConstraints.
 query TTTT colnames
@@ -2587,12 +2589,15 @@ constraint_column   public             fk               constraint_column  publi
 constraint_column   public             t2_pkey          constraint_column  public        t2          t1_id        1                 NULL
 constraint_column   public             fk2              constraint_column  public        t3          a            1                 1
 constraint_column   public             fk2              constraint_column  public        t3          b            2                 2
+constraint_column   public             t3_pkey          constraint_column  public        t3          rowid        1                 NULL
+constraint_column   public             t4_pkey          constraint_column  public        t4          rowid        1                 NULL
 constraint_column   public             unique_a         constraint_column  public        t4          a            1                 NULL
 constraint_column   public             unique_b_c       constraint_column  public        t4          b            1                 NULL
 constraint_column   public             unique_b_c       constraint_column  public        t4          c            2                 NULL
 constraint_column   public             fk3              constraint_column  public        t5          b            1                 1
 constraint_column   public             fk3              constraint_column  public        t5          c            2                 2
 constraint_column   public             t5_a_fkey        constraint_column  public        t5          a            1                 1
+constraint_column   public             t5_pkey          constraint_column  public        t5          rowid        1                 NULL
 
 query TTTTTTTTTTT colnames
 SELECT * FROM information_schema.referential_constraints WHERE constraint_schema = 'public' ORDER BY TABLE_NAME, CONSTRAINT_NAME
@@ -4776,6 +4781,7 @@ server_version                                        13.0.0
 server_version_num                                    130000
 session_authorization                                 root
 session_user                                          root
+show_primary_key_constraint_on_not_visible_columns    on
 sql_safe_updates                                      off
 ssl_renegotiation_limit                               0
 standard_conforming_strings                           on

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -235,6 +235,7 @@ SHOW CONSTRAINTS FROM t11
 table_name  constraint_name  constraint_type  details                       validated
 t11         t11_a_key        UNIQUE           UNIQUE (a ASC) WHERE (b > 0)  true
 t11         t11_b_key        UNIQUE           UNIQUE (b ASC) WHERE (a > 0)  true
+t11         t11_pkey         PRIMARY KEY      PRIMARY KEY (rowid ASC)       true
 
 # Update a non-indexed column referenced by the predicate.
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1269,15 +1269,21 @@ ORDER BY con.oid
 oid         conname        connamespace  contype  condef
 36403682    check_b        3082627813    c        CHECK ((b > 11))
 108480825   uwi_b_c        3082627813    u        UNIQUE WITHOUT INDEX (b, c)
+180431994   t5_pkey        3082627813    p        PRIMARY KEY (rowid ASC)
 192087236   fk_b_c         3082627813    f        FOREIGN KEY (b, c) REFERENCES t4(b, c) MATCH FULL ON UPDATE RESTRICT
 296187876   check_c        3082627813    c        CHECK ((c != ''::STRING))
 1002858066  t6_expr_key    3082627813    u        UNIQUE (lower(c) ASC)
 1034567609  uwi_b_partial  3082627813    u        UNIQUE WITHOUT INDEX (b) WHERE (c = 'foo'::STRING)
+1265772734  t2_pkey        3082627813    p        PRIMARY KEY (rowid ASC)
+1525509005  t3_pkey        3082627813    p        PRIMARY KEY (rowid ASC)
 1568726274  index_key      3082627813    u        UNIQUE (b ASC, c ASC)
 1568726275  t1_a_key       3082627813    u        UNIQUE (a ASC)
 1622172050  unique_a       3082627813    u        UNIQUE WITHOUT INDEX (a)
+2044981543  t6_pkey        3082627813    p        PRIMARY KEY (rowid ASC)
 2061447344  fk             3082627813    f        FOREIGN KEY (a, b) REFERENCES t1(b, c)
 2610849745  t1_pkey        3082627813    p        PRIMARY KEY (p ASC)
+3130322283  t4_pkey        3082627813    p        PRIMARY KEY (rowid ASC)
+3390058550  mv1_pkey       3082627813    p        PRIMARY KEY (rowid ASC)
 3764151187  t5_a_fkey      3082627813    f        FOREIGN KEY (a) REFERENCES t4(a) ON DELETE CASCADE
 3836426375  fk             3082627813    f        FOREIGN KEY (t1_id) REFERENCES t1(a)
 3955926752  primary        3082627813    p        PRIMARY KEY (value ASC)
@@ -1293,15 +1299,21 @@ ORDER BY con.oid
 conname        contype  condeferrable  condeferred  convalidated  conrelid  contypid  conindid
 check_b        c        false          false        true          114       0         0
 uwi_b_c        u        false          false        true          116       0         0
+t5_pkey        p        false          false        true          117       0         1869730585
 fk_b_c         f        false          false        true          117       0         0
 check_c        c        false          false        true          114       0         0
 t6_expr_key    u        false          false        true          120       0         2129466848
 uwi_b_partial  u        false          false        true          116       0         0
+t2_pkey        p        false          false        true          113       0         2955071325
+t3_pkey        p        false          false        true          114       0         2695335054
 index_key      u        false          false        true          110       0         3687884464
 t1_a_key       u        false          false        true          110       0         3687884465
 unique_a       u        false          false        true          116       0         0
+t6_pkey        p        false          false        true          120       0         2129466852
 fk             f        false          false        true          114       0         3687884464
 t1_pkey        p        false          false        true          110       0         3687884466
+t4_pkey        p        false          false        true          116       0         3214807592
+mv1_pkey       p        false          false        true          121       0         784389845
 t5_a_fkey      f        false          false        true          117       0         0
 fk             f        false          false        true          113       0         3687884465
 primary        p        false          false        true          111       0         2342807459
@@ -1325,13 +1337,19 @@ ORDER BY con.oid
 conname        confrelid  confupdtype  confdeltype  confmatchtype
 check_b        0          NULL         NULL         NULL
 uwi_b_c        0          NULL         NULL         NULL
+t5_pkey        0          NULL         NULL         NULL
 check_c        0          NULL         NULL         NULL
 t6_expr_key    0          NULL         NULL         NULL
 uwi_b_partial  0          NULL         NULL         NULL
+t2_pkey        0          NULL         NULL         NULL
+t3_pkey        0          NULL         NULL         NULL
 index_key      0          NULL         NULL         NULL
 t1_a_key       0          NULL         NULL         NULL
 unique_a       0          NULL         NULL         NULL
+t6_pkey        0          NULL         NULL         NULL
 t1_pkey        0          NULL         NULL         NULL
+t4_pkey        0          NULL         NULL         NULL
+mv1_pkey       0          NULL         NULL         NULL
 primary        0          NULL         NULL         NULL
 primary        0          NULL         NULL         NULL
 
@@ -1358,15 +1376,21 @@ ORDER BY con.oid
 conname        conislocal  coninhcount  connoinherit  conkey
 check_b        true        0            true          {2}
 uwi_b_c        true        0            true          NULL
+t5_pkey        true        0            true          {4}
 fk_b_c         true        0            true          {2,3}
 check_c        true        0            true          {3}
 t6_expr_key    true        0            true          {7}
 uwi_b_partial  true        0            true          NULL
+t2_pkey        true        0            true          {2}
+t3_pkey        true        0            true          {4}
 index_key      true        0            true          {3,4}
 t1_a_key       true        0            true          {2}
 unique_a       true        0            true          NULL
+t6_pkey        true        0            true          {6}
 fk             true        0            true          {1,2}
 t1_pkey        true        0            true          {1}
+t4_pkey        true        0            true          {4}
+mv1_pkey       true        0            true          {2}
 t5_a_fkey      true        0            true          {1}
 fk             true        0            true          {1}
 primary        true        0            true          {1}
@@ -1382,13 +1406,19 @@ ORDER BY con.oid
 conname        confkey  conpfeqop  conppeqop  conffeqop  conexclop  conbin             consrc             condef
 check_b        NULL     NULL       NULL       NULL       NULL       (b > 11)           (b > 11)           CHECK ((b > 11))
 uwi_b_c        NULL     NULL       NULL       NULL       NULL       NULL               NULL               UNIQUE WITHOUT INDEX (b, c)
+t5_pkey        NULL     NULL       NULL       NULL       NULL       NULL               NULL               PRIMARY KEY (rowid ASC)
 check_c        NULL     NULL       NULL       NULL       NULL       (c != ''::STRING)  (c != ''::STRING)  CHECK ((c != ''::STRING))
 t6_expr_key    NULL     NULL       NULL       NULL       NULL       NULL               NULL               UNIQUE (lower(c) ASC)
 uwi_b_partial  NULL     NULL       NULL       NULL       NULL       NULL               NULL               UNIQUE WITHOUT INDEX (b) WHERE (c = 'foo'::STRING)
+t2_pkey        NULL     NULL       NULL       NULL       NULL       NULL               NULL               PRIMARY KEY (rowid ASC)
+t3_pkey        NULL     NULL       NULL       NULL       NULL       NULL               NULL               PRIMARY KEY (rowid ASC)
 index_key      NULL     NULL       NULL       NULL       NULL       NULL               NULL               UNIQUE (b ASC, c ASC)
 t1_a_key       NULL     NULL       NULL       NULL       NULL       NULL               NULL               UNIQUE (a ASC)
 unique_a       NULL     NULL       NULL       NULL       NULL       NULL               NULL               UNIQUE WITHOUT INDEX (a)
+t6_pkey        NULL     NULL       NULL       NULL       NULL       NULL               NULL               PRIMARY KEY (rowid ASC)
 t1_pkey        NULL     NULL       NULL       NULL       NULL       NULL               NULL               PRIMARY KEY (p ASC)
+t4_pkey        NULL     NULL       NULL       NULL       NULL       NULL               NULL               PRIMARY KEY (rowid ASC)
+mv1_pkey       NULL     NULL       NULL       NULL       NULL       NULL               NULL               PRIMARY KEY (rowid ASC)
 primary        NULL     NULL       NULL       NULL       NULL       NULL               NULL               PRIMARY KEY (value ASC)
 primary        NULL     NULL       NULL       NULL       NULL       NULL               NULL               PRIMARY KEY (value ASC)
 
@@ -4152,6 +4182,7 @@ server_encoding                                       UTF8                NULL  
 server_version                                        13.0.0              NULL      NULL        NULL        string
 server_version_num                                    130000              NULL      NULL        NULL        string
 session_user                                          root                NULL      NULL        NULL        string
+show_primary_key_constraint_on_not_visible_columns    on                  NULL      NULL        NULL        string
 sql_safe_updates                                      off                 NULL      NULL        NULL        string
 standard_conforming_strings                           on                  NULL      NULL        NULL        string
 statement_timeout                                     0                   NULL      NULL        NULL        string
@@ -4272,6 +4303,7 @@ server_encoding                                       UTF8                NULL  
 server_version                                        13.0.0              NULL  user     NULL      13.0.0              13.0.0
 server_version_num                                    130000              NULL  user     NULL      130000              130000
 session_user                                          root                NULL  user     NULL      root                root
+show_primary_key_constraint_on_not_visible_columns    on                  NULL  user     NULL      on                  on
 sql_safe_updates                                      off                 NULL  user     NULL      off                 off
 standard_conforming_strings                           on                  NULL  user     NULL      on                  on
 statement_timeout                                     0                   NULL  user     NULL      0s                  0s
@@ -4389,6 +4421,7 @@ server_version                                        NULL    NULL     NULL     
 server_version_num                                    NULL    NULL     NULL     NULL        NULL
 session_id                                            NULL    NULL     NULL     NULL        NULL
 session_user                                          NULL    NULL     NULL     NULL        NULL
+show_primary_key_constraint_on_not_visible_columns    NULL    NULL     NULL     NULL        NULL
 sql_safe_updates                                      NULL    NULL     NULL     NULL        NULL
 standard_conforming_strings                           NULL    NULL     NULL     NULL        NULL
 statement_timeout                                     NULL    NULL     NULL     NULL        NULL
@@ -4797,6 +4830,7 @@ CREATE TABLE t(x INT UNIQUE);
 query TTT
 SELECT conname, confupdtype, confdeltype FROM pg_constraint ORDER BY conname
 ----
+t_pkey    NULL  NULL
 t_x_key   NULL  NULL
 u_a_fkey  a     a
 u_b_fkey  a     r
@@ -4809,6 +4843,7 @@ u_h_fkey  n     a
 u_i_fkey  d     a
 u_j_fkey  c     a
 u_k_fkey  n     r
+u_pkey    NULL  NULL
 
 statement ok
 DROP TABLE u; DROP TABLE t
@@ -4826,9 +4861,11 @@ CREATE TABLE w(
 query TT
 SELECT conname, confmatchtype FROM pg_constraint ORDER BY conname
 ----
+v_pkey      NULL
 v_x_y_key   NULL
 w_a_b_fkey  f
 w_c_d_fkey  s
+w_pkey      NULL
 
 statement ok
 DROP DATABASE d34862 CASCADE; SET database=test
@@ -4944,6 +4981,7 @@ ORDER BY conname
 conname                     condef
 partial_index_table_a_key   UNIQUE (a ASC) WHERE (a > 0)
 partial_index_table_a_key1  UNIQUE (a ASC) WHERE (b IN ('foo'::public.testenum, 'bar'::public.testenum))
+partial_index_table_pkey    PRIMARY KEY (rowid ASC)
 
 subtest regression_46799
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/rename_constraint
+++ b/pkg/sql/logictest/testdata/logic_test/rename_constraint
@@ -23,9 +23,10 @@ CREATE TABLE public.t (
 query TT
 SELECT conname, contype FROM pg_catalog.pg_constraint ORDER BY conname
 ----
-cc  c
-cf  f
-cu  u
+cc      c
+cf      f
+cu      u
+t_pkey  p
 
 subtest rename_works
 
@@ -50,9 +51,10 @@ CREATE TABLE public.t (
 query TT
 SELECT conname, contype FROM pg_catalog.pg_constraint ORDER BY conname
 ----
-cc2  c
-cf2  f
-cu2  u
+cc2     c
+cf2     f
+cu2     u
+t_pkey  p
 
 
 subtest duplicate_constraints
@@ -101,6 +103,23 @@ CREATE TABLE public.t (
 query TT
 SELECT conname, contype FROM pg_catalog.pg_constraint ORDER BY conname
 ----
-cc4  c
-cf4  f
-cu4  u
+cc4     c
+cf4     f
+cu4     u
+t_pkey  p
+
+# Allow renames of the implicit primary key.
+statement ok
+CREATE TABLE implicit (a int, b int)
+
+statement ok
+ALTER TABLE implicit RENAME CONSTRAINT implicit_pkey TO something_else
+
+query TTTTB colnames
+SHOW CONSTRAINTS FROM implicit
+----
+table_name  constraint_name  constraint_type  details                  validated
+implicit    something_else   PRIMARY KEY      PRIMARY KEY (rowid ASC)  true
+
+statement error duplicate constraint name: \"something_else\"
+ALTER TABLE implicit ADD CONSTRAINT something_else CHECK(b > 0)

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1136,9 +1136,10 @@ COMMIT
 query TTTTB
 SHOW CONSTRAINTS FROM check_table
 ----
-check_table  ck_a  CHECK  CHECK ((a = 0))  true
-check_table  ck_b  CHECK  CHECK ((b > 0))  true
-check_table  ck_c  CHECK  CHECK ((c > b))  true
+check_table  check_table_pkey  PRIMARY KEY  PRIMARY KEY (rowid ASC)  true
+check_table  ck_a              CHECK        CHECK ((a = 0))          true
+check_table  ck_b              CHECK        CHECK ((b > 0))          true
+check_table  ck_c              CHECK        CHECK ((c > b))          true
 
 # Also test insert/update to ensure constraint was added in a valid state (with correct column IDs, etc.)
 
@@ -1855,7 +1856,8 @@ COMMIT
 query TTTTB
 SHOW CONSTRAINTS FROM t_52501_valid
 ----
-t_52501_valid  a_auto_not_null  CHECK  CHECK ((a IS NOT NULL))  true
+t_52501_valid  a_auto_not_null     CHECK        CHECK ((a IS NOT NULL))  true
+t_52501_valid  t_52501_valid_pkey  PRIMARY KEY  PRIMARY KEY (rowid ASC)  true
 
 statement ok
 DROP TABLE t_52501_valid
@@ -1898,6 +1900,7 @@ query TTTTB
 SHOW CONSTRAINTS FROM child_54265
 ----
 child_54265  child_54265_a_fkey  FOREIGN KEY  FOREIGN KEY (a) REFERENCES parent_54265(a) NOT VALID  false
+child_54265  child_54265_pkey    PRIMARY KEY  PRIMARY KEY (rowid ASC)                               true
 
 # Test that dropping a unique index used by a foreign key reference causes the
 # foreign key addition to fail.

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -115,6 +115,7 @@ server_encoding                                       UTF8
 server_version                                        13.0.0
 server_version_num                                    130000
 session_user                                          root
+show_primary_key_constraint_on_not_visible_columns    on
 sql_safe_updates                                      off
 standard_conforming_strings                           on
 statement_timeout                                     0

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -255,11 +255,12 @@ CREATE TABLE test.dupe_generated (
 query TTTTB colnames
 SHOW CONSTRAINTS FROM test.dupe_generated
 ----
-table_name      constraint_name  constraint_type  details             validated
-dupe_generated  check_bar        CHECK            CHECK ((bar > 2))   true
-dupe_generated  check_foo        CHECK            CHECK ((foo > 2))   true
-dupe_generated  check_foo1       CHECK            CHECK ((foo < 10))  true
-dupe_generated  check_foo2       CHECK            CHECK ((foo > 1))   true
+table_name      constraint_name      constraint_type  details                  validated
+dupe_generated  check_bar            CHECK            CHECK ((bar > 2))        true
+dupe_generated  check_foo            CHECK            CHECK ((foo > 2))        true
+dupe_generated  check_foo1           CHECK            CHECK ((foo < 10))       true
+dupe_generated  check_foo2           CHECK            CHECK ((foo > 1))        true
+dupe_generated  dupe_generated_pkey  PRIMARY KEY      PRIMARY KEY (rowid ASC)  true
 
 statement ok
 CREATE TABLE test.named_constraints (

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -843,6 +843,23 @@ func populateTableConstraints(
 		var err error
 		switch con.Kind {
 		case descpb.ConstraintTypePK:
+			if !p.SessionData().ShowPrimaryKeyConstraintOnNotVisibleColumns {
+				colHiddenMap := make(map[descpb.ColumnID]bool, len(table.AllColumns()))
+				for i := range table.AllColumns() {
+					col := table.AllColumns()[i]
+					colHiddenMap[col.GetID()] = col.IsHidden()
+				}
+				allHidden := true
+				for _, colIdx := range con.Index.KeyColumnIDs {
+					if !colHiddenMap[colIdx] {
+						allHidden = false
+						break
+					}
+				}
+				if allHidden {
+					continue
+				}
+			}
 			oid = h.PrimaryKeyConstraintOid(db.GetID(), scName, table.GetID(), con.Index)
 			contype = conTypePKey
 			conindid = h.IndexOid(table.GetID(), con.Index.ID)

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -246,6 +246,10 @@ message LocalOnlySessionData {
   // (with no column name specifiers) to expect and ignore not visible column
   // fields.
   bool expect_and_ignore_not_visible_columns_in_copy = 67;
+  // ShowPrimaryKeyConstraintOnNotVisibleColumns controls whether SHOW
+  // CONSTRAINTS and pg_catalog.pg_constraint will include primary key
+  // constraints that only include hidden columns.
+  bool show_primary_key_constraint_on_not_visible_columns = 68;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2049,6 +2049,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalFalse,
 	},
+
+	// CockroachDB extension.
+	`show_primary_key_constraint_on_not_visible_columns`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`show_primary_key_constraint_on_not_visible_columns`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("show_primary_key_constraint_on_not_visible_columns", s)
+			if err != nil {
+				return err
+			}
+			m.SetShowPrimaryKeyConstraintOnNotVisibleColumns(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().ShowPrimaryKeyConstraintOnNotVisibleColumns), nil
+		},
+		GlobalDefault: globalTrue,
+	},
 }
 
 const compatErrMsg = "this parameter is currently recognized only for compatibility and has no effect in CockroachDB."


### PR DESCRIPTION
Backport 1/1 commits from #80154.

/cc @cockroachdb/release

---

fixes #80035

In 9d61c05 (from 2017), constraints that only included hidden columns
were excluded from all introspection. The rationale was that hidden
columns are not in SHOW COLUMNS or information_schema.columns, so
neither should the constraints.

However, that rationale is not true any more. Hidden columns are shown
in those places now. Also, we've seen that tools can get confused when
we don't report these constraints.

Release note (sql change): Constraints that only include hidden columns are
no longer excluded in SHOW CONSTRAINTS. This behavior can be changed
using the show_primary_key_constraint_on_not_visible_columns session
variable.

Release note (bug fix): Fixed a bug that allowed duplicate constraint
names for the same table if the constraints were on hidden columns.

Release justification: bug fix