### PR TITLE
kvserver: introduce methods on `raftRecvQueue{,s}`

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -916,7 +916,7 @@ type Store struct {
 	// avoid reworking the locking in getOrCreateReplica which requires
 	// Replica.raftMu to be held while a replica is being inserted into
 	// Store.mu.replicas.
-	raftRecvQueues syncutil.IntMap // map[roachpb.RangeID]*raftReceiveQueue
+	raftRecvQueues raftReceiveQueues
 
 	scheduler *raftScheduler
 

--- a/pkg/kv/kvserver/store_remove_replica.go
+++ b/pkg/kv/kvserver/store_remove_replica.go
@@ -299,9 +299,9 @@ func (s *Store) unlinkReplicaByRangeIDLocked(ctx context.Context, rangeID roachp
 	delete(s.unquiescedReplicas.m, rangeID)
 	s.unquiescedReplicas.Unlock()
 	delete(s.mu.uninitReplicas, rangeID)
-	s.raftRecvQueues.Delete(int64(rangeID))
 	s.mu.replicasByRangeID.Delete(rangeID)
 	s.unregisterLeaseholderByID(ctx, rangeID)
+	s.raftRecvQueues.Delete(rangeID)
 }
 
 // removePlaceholder removes a placeholder for the specified range.


### PR DESCRIPTION
This removes ad-hoc `sync.Map`-ish code from the various callers.
This commit also gives `raftRecvQueue` (note: no `s`) methods which
are now used instead of directly reaching into the struct.

Together this paves the way for tracking the size of the raft receive
queue.  Since the `sync.Map` synchronization is very loose, before this
commit it was difficult to avoid leaking memory when queues were dropped
and accessed concurrently. And similarly, reaching directly into
individual queues will make it difficult to get things right.

Now there's more synchronization around dropping queues and correct
tracking of the sizes (& making sure there aren't leaks) is more
straightforward. (The actual tracking will be added in a follow-up).

Release note: None
