### PR TITLE
release-22.1: kvserver: avoid races where replication changes can get interrupted

### DIFF
--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -481,7 +481,8 @@ func (v *validator) processOp(txnID *string, op Operation) {
 		var ignore bool
 		if err := errorFromResult(t.Result); err != nil {
 			ignore = kvserver.IsRetriableReplicationChangeError(err) ||
-				kvserver.IsIllegalReplicationChangeError(err)
+				kvserver.IsIllegalReplicationChangeError(err) ||
+				kvserver.IsReplicationChangeInProgressError(err)
 		}
 		if !ignore {
 			v.failIfError(op, t.Result)

--- a/pkg/kv/kvserver/markers.go
+++ b/pkg/kv/kvserver/markers.go
@@ -78,3 +78,12 @@ var errMarkInvalidReplicationChange = errors.New("invalid replication change")
 func IsIllegalReplicationChangeError(err error) bool {
 	return errors.Is(err, errMarkInvalidReplicationChange)
 }
+
+var errMarkReplicationChangeInProgress = errors.New("replication change in progress")
+
+// IsReplicationChangeInProgressError detects whether an error (assumed to have
+// been emitted a replication change) indicates that the replication change
+// failed because another replication change was in progress on the range.
+func IsReplicationChangeInProgressError(err error) bool {
+	return errors.Is(err, errMarkReplicationChangeInProgress)
+}

--- a/pkg/kv/kvserver/merge_queue.go
+++ b/pkg/kv/kvserver/merge_queue.go
@@ -296,8 +296,9 @@ func (mq *mergeQueue) process(
 		// performed by the LHS leaseholder, so it can easily do this for LHS.
 		// We deal with the RHS, whose leaseholder may be remote, further down.
 		var err error
-		lhsDesc, err =
-			lhsRepl.maybeLeaveAtomicChangeReplicasAndRemoveLearners(ctx, lhsDesc)
+		// TODO(aayush): Separately track metrics for how many learners were removed
+		// by the mergeQueue here.
+		lhsDesc, _, err = lhsRepl.maybeLeaveAtomicChangeReplicasAndRemoveLearners(ctx, lhsDesc)
 		if err != nil {
 			log.VEventf(ctx, 2, `%v`, err)
 			return false, err

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -139,13 +139,6 @@ const (
 	// Allow a limited number of Raft log truncations to be processed
 	// concurrently.
 	raftLogQueueConcurrency = 4
-	// RaftLogQueuePendingSnapshotGracePeriod indicates the grace period after an
-	// in-flight snapshot is marked completed. While a snapshot is in-flight we
-	// will not truncate past the snapshot's log index but we also don't want to
-	// do so the moment the in-flight snapshot completes, since it is only applied
-	// at the receiver a little later. This grace period reduces the probability
-	// of an ill-timed log truncation that would necessitate another snapshot.
-	RaftLogQueuePendingSnapshotGracePeriod = 3 * time.Second
 )
 
 // raftLogQueue manages a queue of replicas slated to have their raft logs
@@ -267,7 +260,7 @@ func newTruncateDecision(ctx context.Context, r *Replica) (truncateDecision, err
 	raftStatus := r.raftStatusRLocked()
 
 	const anyRecipientStore roachpb.StoreID = 0
-	pendingSnapshotIndex := r.getAndGCSnapshotLogTruncationConstraintsLocked(now, anyRecipientStore)
+	pendingSnapshotIndex := r.getSnapshotLogTruncationConstraintsLocked(anyRecipientStore)
 	lastIndex := r.mu.lastIndex
 	// NB: raftLogSize above adjusts for pending truncations that have already
 	// been successfully replicated via raft, but logSizeTrusted does not see if

--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	raft "go.etcd.io/etcd/raft/v3"
+	"go.etcd.io/etcd/raft/v3"
 	"go.etcd.io/etcd/raft/v3/tracker"
 )
 

--- a/pkg/kv/kvserver/raft_snapshot_queue.go
+++ b/pkg/kv/kvserver/raft_snapshot_queue.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"go.etcd.io/etcd/raft/v3/tracker"
 )
@@ -115,9 +114,7 @@ func (rq *raftSnapshotQueue) processRaftSnapshot(
 		if fn := repl.store.cfg.TestingKnobs.RaftSnapshotQueueSkipReplica; fn != nil && fn() {
 			return nil
 		}
-		if index := repl.getAndGCSnapshotLogTruncationConstraints(
-			timeutil.Now(), repDesc.StoreID,
-		); index > 0 {
+		if index := repl.getSnapshotLogTruncationConstraints(repDesc.StoreID); index > 0 {
 			// There is a snapshot being transferred. It's probably an INITIAL snap,
 			// so bail for now and try again later.
 			err := errors.Errorf(

--- a/pkg/kv/kvserver/raft_snapshot_queue.go
+++ b/pkg/kv/kvserver/raft_snapshot_queue.go
@@ -114,7 +114,7 @@ func (rq *raftSnapshotQueue) processRaftSnapshot(
 		if fn := repl.store.cfg.TestingKnobs.RaftSnapshotQueueSkipReplica; fn != nil && fn() {
 			return nil
 		}
-		if index := repl.getSnapshotLogTruncationConstraints(repDesc.StoreID); index > 0 {
+		if repl.hasOutstandingSnapshotInFlightToStore(repDesc.StoreID) {
 			// There is a snapshot being transferred. It's probably an INITIAL snap,
 			// so bail for now and try again later.
 			err := errors.Errorf(

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -1786,9 +1786,8 @@ func (r *Replica) lockLearnerSnapshot(
 		r.addSnapshotLogTruncationConstraint(ctx, lockUUID, 1, addition.StoreID)
 	}
 	return func() {
-		now := timeutil.Now()
 		for _, lockUUID := range lockUUIDs {
-			r.completeSnapshotLogTruncationConstraint(ctx, lockUUID, now)
+			r.completeSnapshotLogTruncationConstraint(lockUUID)
 		}
 	}
 }

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -1144,7 +1144,8 @@ func (r *Replica) changeReplicasImpl(
 		// If we demoted or swapped any voters with non-voters, we likely are in a
 		// joint config or have learners on the range. Let's exit the joint config
 		// and remove the learners.
-		return r.maybeLeaveAtomicChangeReplicasAndRemoveLearners(ctx, desc)
+		desc, _, err = r.maybeLeaveAtomicChangeReplicasAndRemoveLearners(ctx, desc)
+		return desc, err
 	}
 	return desc, nil
 }
@@ -1278,22 +1279,69 @@ func (r *Replica) maybeLeaveAtomicChangeReplicas(
 		})
 }
 
+// TestingRemoveLearner is used by tests to manually remove a learner replica.
+func (r *Replica) TestingRemoveLearner(
+	ctx context.Context, beforeDesc *roachpb.RangeDescriptor, target roachpb.ReplicationTarget,
+) (*roachpb.RangeDescriptor, error) {
+	desc, err := execChangeReplicasTxn(
+		ctx, beforeDesc, kvserverpb.ReasonAbandonedLearner, "",
+		[]internalReplicationChange{{target: target, typ: internalChangeTypeRemove}},
+		changeReplicasTxnArgs{
+			db:                                   r.store.DB(),
+			liveAndDeadReplicas:                  r.store.cfg.StorePool.liveAndDeadReplicas,
+			logChange:                            r.store.logChange,
+			testForceJointConfig:                 r.store.TestingKnobs().ReplicationAlwaysUseJointConfig,
+			testAllowDangerousReplicationChanges: r.store.TestingKnobs().AllowDangerousReplicationChanges,
+		},
+	)
+	if err != nil {
+		return nil, errors.Wrapf(err, `removing learners from %s`, beforeDesc)
+	}
+	return desc, err
+}
+
+// errCannotRemoveLearnerWhileSnapshotInFlight is returned when we cannot remove
+// a learner replica because it is in the process of receiving its initial
+// snapshot.
+var errCannotRemoveLearnerWhileSnapshotInFlight = errors.Mark(
+	errors.New("cannot remove learner while snapshot is in flight"),
+	errMarkReplicationChangeInProgress,
+)
+
 // maybeLeaveAtomicChangeReplicasAndRemoveLearners transitions out of the joint
 // config (if there is one), and then removes all learners. After this function
 // returns, all remaining replicas will be of type VOTER_FULL or NON_VOTER.
 func (r *Replica) maybeLeaveAtomicChangeReplicasAndRemoveLearners(
 	ctx context.Context, desc *roachpb.RangeDescriptor,
-) (rangeDesc *roachpb.RangeDescriptor, err error) {
+) (rangeDesc *roachpb.RangeDescriptor, learnersRemoved int64, err error) {
 	desc, err = r.maybeLeaveAtomicChangeReplicas(ctx, desc)
 	if err != nil {
-		return nil, err
+		return nil /* desc */, 0 /* learnersRemoved */, err
+	}
+
+	// If we detect that there are learners in the process of receiving their
+	// initial upreplication snapshot, we don't want to remove them and we bail
+	// out.
+	//
+	// Currently, the only callers of this method are the replicateQueue, the
+	// StoreRebalancer, the mergeQueue and SQL (which calls into
+	// `AdminRelocateRange` via the `EXPERIMENTAL_RELOCATE` syntax). All these
+	// callers will fail-fast when they encounter this error and move on to other
+	// ranges. This is intentional and desirable because we want to avoid
+	// head-of-line blocking scenarios where these callers are blocked for long
+	// periods of time on a single range without making progress, which can stall
+	// other operations that they are expected to perform (see
+	// https://github.com/cockroachdb/cockroach/issues/79249 for example).
+	if r.hasOutstandingLearnerSnapshotInFlight() {
+		return nil /* desc */, 0, /* learnersRemoved */
+			errCannotRemoveLearnerWhileSnapshotInFlight
 	}
 
 	// Now the config isn't joint any more, but we may have demoted some voters
-	// into learners. These learners should go as well.
+	// into learners. If so, we need to remove them.
 	learners := desc.Replicas().LearnerDescriptors()
 	if len(learners) == 0 {
-		return desc, nil
+		return desc, 0 /* learnersRemoved */, nil /* err */
 	}
 	targets := make([]roachpb.ReplicationTarget, len(learners))
 	for i := range learners {
@@ -1320,10 +1368,11 @@ func (r *Replica) maybeLeaveAtomicChangeReplicasAndRemoveLearners(
 			},
 		)
 		if err != nil {
-			return nil, errors.Wrapf(err, `removing learners from %s`, origDesc)
+			return desc, learnersRemoved, errors.Wrapf(err, `removing learners from %s`, origDesc)
 		}
+		learnersRemoved++
 	}
-	return desc, nil
+	return desc, learnersRemoved, nil
 }
 
 // validateAdditionsPerStore ensures that we're not trying to add the same type
@@ -1854,7 +1903,8 @@ func (r *Replica) execReplicationChangesForVoters(
 
 	// Leave the joint config if we entered one. Also, remove any learners we
 	// might have picked up due to removal-via-demotion.
-	return r.maybeLeaveAtomicChangeReplicasAndRemoveLearners(ctx, desc)
+	desc, _, err = r.maybeLeaveAtomicChangeReplicasAndRemoveLearners(ctx, desc)
+	return desc, err
 }
 
 // tryRollbackRaftLearner attempts to remove a learner specified by the target.
@@ -2767,8 +2817,7 @@ func (r *Replica) AdminRelocateRange(
 
 	// Remove learners so we don't have to think about relocating them, and leave
 	// the joint config if we're in one.
-	newDesc, err :=
-		r.maybeLeaveAtomicChangeReplicasAndRemoveLearners(ctx, &rangeDesc)
+	newDesc, _, err := r.maybeLeaveAtomicChangeReplicasAndRemoveLearners(ctx, &rangeDesc)
 	if err != nil {
 		log.Warningf(ctx, "%v", err)
 		return err

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -416,8 +416,6 @@ func testRaftSnapshotsToNonVoters(t *testing.T, drainReceivingNode bool) {
 	require.NoError(t, err)
 	require.NotNil(t, leaseholderRepl)
 
-	time.Sleep(kvserver.RaftLogQueuePendingSnapshotGracePeriod)
-
 	if drainReceivingNode {
 		// Draining nodes shouldn't reject raft snapshots, so this should have no
 		// effect on the outcome of this test.

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -1164,6 +1164,82 @@ func TestLearnerAndJointConfigAdminMerge(t *testing.T) {
 	checkFails()
 }
 
+// TestMergeQueueDoesNotInterruptReplicationChange verifies that the merge queue
+// will correctly ignore a range that has an in-flight snapshot to a learner
+// replica.
+func TestMergeQueueDoesNotInterruptReplicationChange(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	var activateSnapshotTestingKnob int64
+	blockSnapshot := make(chan struct{})
+	tc := testcluster.StartTestCluster(
+		t, 2, base.TestClusterArgs{
+			ReplicationMode: base.ReplicationManual,
+			ServerArgs: base.TestServerArgs{
+				Knobs: base.TestingKnobs{
+					Store: &kvserver.StoreTestingKnobs{
+						// Disable load-based splitting, so that the absence of sufficient
+						// QPS measurements do not prevent ranges from merging.
+						DisableLoadBasedSplitting: true,
+						ReceiveSnapshot: func(_ *kvserverpb.SnapshotRequest_Header) error {
+							if atomic.LoadInt64(&activateSnapshotTestingKnob) == 1 {
+								<-blockSnapshot
+							}
+							return nil
+						},
+					},
+				},
+			},
+		},
+	)
+	defer tc.Stopper().Stop(ctx)
+
+	scratchKey := tc.ScratchRange(t)
+	splitKey := scratchKey.Next()
+
+	// Split and then unsplit the range to clear the sticky bit, otherwise the
+	// mergeQueue will ignore the range.
+	tc.SplitRangeOrFatal(t, splitKey)
+	require.NoError(t, tc.Server(0).DB().AdminUnsplit(ctx, splitKey))
+
+	atomic.StoreInt64(&activateSnapshotTestingKnob, 1)
+	replicationChange := make(chan error)
+	err := tc.Stopper().RunAsyncTask(ctx, "test", func(ctx context.Context) {
+		_, err := tc.AddVoters(scratchKey, makeReplicationTargets(2)...)
+		replicationChange <- err
+	})
+	require.NoError(t, err)
+
+	select {
+	case <-time.After(100 * time.Millisecond):
+	// Continue.
+	case <-replicationChange:
+		t.Fatal("did not expect the replication change to complete")
+	}
+	defer func() {
+		// Unblock the replication change and ensure that it succeeds.
+		close(blockSnapshot)
+		require.NoError(t, <-replicationChange)
+	}()
+
+	db := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	// TestCluster currently overrides this when used with ReplicationManual.
+	db.Exec(t, `SET CLUSTER SETTING kv.range_merge.queue_enabled = true`)
+
+	testutils.SucceedsSoon(t, func() error {
+		// While this replication change is stalled, we'll trigger a merge and
+		// ensure that the merge correctly notices that there is a snapshot in
+		// flight and ignores the range.
+		store, repl := getFirstStoreReplica(t, tc.Server(0), scratchKey)
+		_, processErr, enqueueErr := store.ManuallyEnqueue(ctx, "merge", repl, true /* skipShouldQueue */)
+		require.NoError(t, enqueueErr)
+		require.True(t, kvserver.IsReplicationChangeInProgressError(processErr))
+		return nil
+	})
+}
+
 func TestMergeQueueSeesLearnerOrJointConfig(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1583,6 +1583,24 @@ func (r *Replica) getSnapshotLogTruncationConstraintsLocked(
 	return minSnapIndex
 }
 
+// hasOutstandingLearnerSnapshotInFlight returns true if there is a snapshot in
+// progress from this replica to a learner replica for this range.
+func (r *Replica) hasOutstandingLearnerSnapshotInFlight() bool {
+	learners := r.Desc().Replicas().LearnerDescriptors()
+	for _, repl := range learners {
+		if r.hasOutstandingSnapshotInFlightToStore(repl.StoreID) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasOutstandingSnapshotInFlightToStore returns true if there is a snapshot in
+// flight from this replica to the store with the given ID.
+func (r *Replica) hasOutstandingSnapshotInFlightToStore(storeID roachpb.StoreID) bool {
+	return r.getSnapshotLogTruncationConstraints(storeID) > 0
+}
+
 func isRaftLeader(raftStatus *raft.Status) bool {
 	return raftStatus != nil && raftStatus.SoftState.RaftState == raft.StateLeader
 }

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -449,8 +449,7 @@ func (r *Replica) GetSnapshot(
 	r.raftMu.Unlock()
 
 	release := func() {
-		now := timeutil.Now()
-		r.completeSnapshotLogTruncationConstraint(ctx, snapUUID, now)
+		r.completeSnapshotLogTruncationConstraint(snapUUID)
 	}
 
 	defer func() {

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -560,13 +560,6 @@ func (rq *replicateQueue) processOneChange(
 	action, _ := rq.allocator.ComputeAction(ctx, conf, desc)
 	log.VEventf(ctx, 1, "next replica action: %s", action)
 
-	// For simplicity, the first thing the allocator does is remove learners, so
-	// it can do all of its reasoning about only voters. We do the same here so
-	// the executions of the allocator's decisions can be in terms of voters.
-	if action == AllocatorRemoveLearner {
-		return rq.removeLearner(ctx, repl, dryRun)
-	}
-
 	switch action {
 	case AllocatorNoop, AllocatorRangeUnavailable:
 		// We're either missing liveness information or the range is known to have
@@ -667,8 +660,6 @@ func (rq *replicateQueue) processOneChange(
 	case AllocatorRemoveDeadNonVoter:
 		return rq.removeDead(ctx, repl, deadNonVoterReplicas, nonVoterTarget, dryRun)
 
-	case AllocatorRemoveLearner:
-		return rq.removeLearner(ctx, repl, dryRun)
 	case AllocatorConsiderRebalance:
 		return rq.considerRebalance(
 			ctx,
@@ -679,12 +670,15 @@ func (rq *replicateQueue) processOneChange(
 			scatter,
 			dryRun,
 		)
-	case AllocatorFinalizeAtomicReplicationChange:
-		_, err :=
-			repl.maybeLeaveAtomicChangeReplicasAndRemoveLearners(ctx, repl.Desc())
-		// Requeue because either we failed to transition out of a joint state
-		// (bad) or we did and there might be more to do for that range.
-		return true, err
+	case AllocatorFinalizeAtomicReplicationChange, AllocatorRemoveLearner:
+		_, learnersRemoved, err := repl.maybeLeaveAtomicChangeReplicasAndRemoveLearners(
+			ctx, repl.Desc(),
+		)
+		if err != nil {
+			return false, err
+		}
+		rq.metrics.RemoveLearnerReplicaCount.Inc(learnersRemoved)
+		return true, nil
 	default:
 		return false, errors.Errorf("unknown allocator action %v", action)
 	}
@@ -1244,43 +1238,6 @@ func (rq *replicateQueue) removeDead(
 		desc,
 		kvserverpb.SnapshotRequest_UNKNOWN, // unused
 		kvserverpb.ReasonStoreDead,
-		"",
-		dryRun,
-	); err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
-func (rq *replicateQueue) removeLearner(
-	ctx context.Context, repl *Replica, dryRun bool,
-) (requeue bool, _ error) {
-	desc := repl.Desc()
-	learnerReplicas := desc.Replicas().LearnerDescriptors()
-	if len(learnerReplicas) == 0 {
-		log.VEventf(ctx, 1, "range of replica %s was identified as having learner replicas, "+
-			"but no learner replicas were found", repl)
-		return true, nil
-	}
-	learnerReplica := learnerReplicas[0]
-	if !dryRun {
-		rq.metrics.RemoveLearnerReplicaCount.Inc(1)
-	}
-	log.VEventf(ctx, 1, "removing learner replica %+v from store", learnerReplica)
-	target := roachpb.ReplicationTarget{
-		NodeID:  learnerReplica.NodeID,
-		StoreID: learnerReplica.StoreID,
-	}
-	// NB: we don't check whether to transfer the lease away because we're very unlikely
-	// to be the learner (and if so, we don't have the lease any more, so after the removal
-	// fails the situation will have rectified itself).
-	if err := rq.changeReplicas(
-		ctx,
-		repl,
-		roachpb.MakeReplicationChanges(roachpb.REMOVE_VOTER, target),
-		desc,
-		kvserverpb.SnapshotRequest_UNKNOWN,
-		kvserverpb.ReasonAbandonedLearner,
 		"",
 		dryRun,
 	); err != nil {

--- a/pkg/sql/relocate_range.go
+++ b/pkg/sql/relocate_range.go
@@ -163,6 +163,10 @@ func relocate(params runParams, req relocateRequest) (*roachpb.RangeDescriptor, 
 			{ChangeType: roachpb.REMOVE_VOTER, Target: fromTarget},
 		},
 	)
+	// TODO(aayush): If the `AdminChangeReplicas`call failed because it found that
+	// the range was already in the process of being rebalanced, we currently fail
+	// the statement. We should consider instead force-removing these learners
+	// when `AdminChangeReplicas` calls are issued by SQL.
 	return rangeDesc, err
 }
 


### PR DESCRIPTION
Backport 2/2 commits from #79379.

/cc @cockroachdb/release

---

This commit adds a safeguard inside
`Replica.maybeLeaveAtomicChangeReplicasAndRemoveLearners()` to avoid removing
learner replicas _when we know_ that that learner replica is in the process of
receiving its initial snapshot (as indicated by an in-memory lock on log
truncations that we place while the snapshot is in-flight).

This change should considerably reduce the instances where `AdminRelocateRange`
calls are interrupted by the mergeQueue or the replicateQueue (and vice versa).

Fixes https://github.com/cockroachdb/cockroach/issues/57129
Relates to https://github.com/cockroachdb/cockroach/issues/79118

Release note: none

Release justification: Fixes a race condition that leads to wasted work / increases time to rebalance

Jira issue: CRDB-14769
