### PR TITLE
kvserver: track bytes size of raft receive queue

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -298,6 +298,7 @@ go_test(
         "split_trigger_helper_test.go",
         "stats_test.go",
         "store_pool_test.go",
+        "store_raft_test.go",
         "store_rebalancer_test.go",
         "store_replica_btree_test.go",
         "store_test.go",

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1181,6 +1181,16 @@ func NewStore(
 	}
 	s.replRankings = newReplicaRankings()
 
+	s.raftRecvQueues.mon = mon.NewUnlimitedMonitor(
+		ctx,
+		"raft-receive-queue",
+		mon.MemoryResource,
+		s.metrics.RaftRcvdQueuedBytes,
+		nil,
+		math.MaxInt64,
+		cfg.Settings,
+	)
+
 	s.draining.Store(false)
 	s.scheduler = newRaftScheduler(cfg.AmbientCtx, s.metrics, s, storeSchedulerConcurrency)
 

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -31,14 +32,17 @@ import (
 
 type raftRequestInfo struct {
 	req        *kvserverpb.RaftMessageRequest
+	size       int64 // size of req in bytes
 	respStream RaftMessageResponseStream
 }
 
 type raftReceiveQueue struct {
 	mu struct { // not to be locked directly
+		destroyed bool
 		syncutil.Mutex
 		infos []raftRequestInfo
 	}
+	acc mon.BoundAccount
 }
 
 // Len returns the number of requests in the queue.
@@ -62,7 +66,18 @@ func (q *raftReceiveQueue) drainLocked() ([]raftRequestInfo, bool) {
 	}
 	infos := q.mu.infos
 	q.mu.infos = nil
+	q.acc.Clear(context.Background())
 	return infos, true
+}
+
+func (q *raftReceiveQueue) Delete() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.drainLocked()
+	if err := q.acc.ResizeTo(context.Background(), 0); err != nil {
+		panic(err) // ResizeTo(., 0) always returns nil
+	}
+	q.mu.destroyed = true
 }
 
 // Recycle makes a slice that the caller knows will no longer be accessed
@@ -83,28 +98,29 @@ func (q *raftReceiveQueue) Recycle(processed []raftRequestInfo) {
 
 func (q *raftReceiveQueue) Append(
 	req *kvserverpb.RaftMessageRequest, s RaftMessageResponseStream,
-) (shouldQueue, appended bool) {
+) (shouldQueue bool, size int64, appended bool) {
+	size = int64(req.Size())
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	if len(q.mu.infos) >= replicaRequestQueueSize {
-		return false, false
+	if q.mu.destroyed || len(q.mu.infos) >= replicaRequestQueueSize {
+		return false, size, false
+	}
+	if q.acc.Grow(context.Background(), size) != nil {
+		return false, size, false
 	}
 	q.mu.infos = append(q.mu.infos, raftRequestInfo{
 		req:        req,
 		respStream: s,
+		size:       size,
 	})
 	// The operation that enqueues the first message will
 	// be put in charge of triggering a drain of the queue.
-	return len(q.mu.infos) == 1, true
+	return len(q.mu.infos) == 1, size, true
 }
 
 type raftReceiveQueues struct {
-	m syncutil.IntMap // RangeID -> *raftReceiveQueue
-	// delMu is held while deleting an entry from `m`. This
-	// is necessary since `IntMap` does not return the element
-	// being removed (if any) and we want stronger synchronization
-	// to prevent memory accounting leaks.
-	delMu syncutil.Mutex
+	mon *mon.BytesMonitor
+	m   syncutil.IntMap // RangeID -> *raftReceiveQueue
 }
 
 func (qs *raftReceiveQueues) Load(rangeID roachpb.RangeID) (*raftReceiveQueue, bool) {
@@ -115,28 +131,22 @@ func (qs *raftReceiveQueues) Load(rangeID roachpb.RangeID) (*raftReceiveQueue, b
 func (qs *raftReceiveQueues) LoadOrCreate(
 	rangeID roachpb.RangeID,
 ) (_ *raftReceiveQueue, loaded bool) {
+
 	if q, ok := qs.Load(rangeID); ok {
 		return q, ok // fast path
 	}
 	q := &raftReceiveQueue{}
+	q.acc.Init(context.Background(), qs.mon)
 	value, loaded := qs.m.LoadOrStore(int64(rangeID), unsafe.Pointer(q))
 	return (*raftReceiveQueue)(value), loaded
 }
 
+// Delete drains the queue and marks it as deleted. Future Appends
+// will result in appended=false.
 func (qs *raftReceiveQueues) Delete(rangeID roachpb.RangeID) {
-	qs.delMu.Lock()
-	defer qs.delMu.Unlock()
 	if q, ok := qs.Load(rangeID); ok {
+		q.Delete()
 		qs.m.Delete(int64(rangeID))
-		// NB: this is inconsequential today but in the future will
-		// allow for sane memory accounting.
-		// Also, we want to make `q` refuse further additions, since
-		// `Delete` is called from the replica removal path which is
-		// not under the raft scheduler. So we may delete this queue
-		// but the scheduler may be adding a request to it after due
-		// to loose synchronization. This would similarly upset mem
-		// accounting (and also today it leaks memory when it happens).
-		q.Drain()
 	}
 }
 
@@ -292,11 +302,12 @@ func (s *Store) HandleRaftUncoalescedRequest(
 	s.metrics.RaftRcvdMessages[req.Message.Type].Inc(1)
 
 	q, _ := s.raftRecvQueues.LoadOrCreate(req.RangeID)
-	enqueue, appended := q.Append(req, respStream)
+	enqueue, size, appended := q.Append(req, respStream)
 	if !appended {
 		// TODO(peter): Return an error indicating the request was dropped. Note
 		// that dropping the request is safe. Raft will retry.
-		s.metrics.RaftRcvdMsgDropped.Inc(1)
+		s.metrics.RaftRcvdDropped.Inc(1)
+		s.metrics.RaftRcvdDroppedBytes.Inc(size)
 		return false
 	}
 	return enqueue
@@ -551,6 +562,7 @@ func (s *Store) enqueueRaftUpdateCheck(rangeID roachpb.RangeID) {
 	s.scheduler.EnqueueRaftReady(rangeID)
 }
 
+// TODO(tbg): rename this to processRecvQueue.
 func (s *Store) processRequestQueue(ctx context.Context, rangeID roachpb.RangeID) bool {
 	q, ok := s.raftRecvQueues.Load(rangeID)
 	if !ok {
@@ -577,6 +589,8 @@ func (s *Store) processRequestQueue(ctx context.Context, rangeID roachpb.RangeID
 				log.VEventf(ctx, 1, "error sending error: %s", err)
 			}
 		}
+		s.metrics.RaftRcvdSteppedBytes.Inc(info.size)
+		infos[i] = raftRequestInfo{}
 	}
 
 	if hadError {
@@ -590,6 +604,14 @@ func (s *Store) processRequestQueue(ctx context.Context, rangeID roachpb.RangeID
 		// forgiving.
 		//
 		// See https://github.com/cockroachdb/cockroach/issues/30951#issuecomment-428010411.
+		//
+		// TODO(tbg): for adding actual memory accounting, we need more clarity about
+		// the contract. For example, it would be a problem if the queue got deleted
+		// (as a result of the replica getting deleted) but then getting recreated errantly.
+		// In that case, we would "permanently" leak an allocation, which over time could
+		// eat up the budget. We must ensure, essentially, that we create a queue only
+		// when the replica is alive (according to its destroyStatus) and ensure it is
+		// destroyed once that changes.
 		if _, exists := s.mu.replicasByRangeID.Load(rangeID); !exists && q.Len() == 0 {
 			s.raftRecvQueues.Delete(rangeID)
 		}

--- a/pkg/kv/kvserver/store_raft_test.go
+++ b/pkg/kv/kvserver/store_raft_test.go
@@ -1,0 +1,126 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+//
+
+package kvserver
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/raft/v3/raftpb"
+)
+
+func TestRaftReceiveQueue(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	st := cluster.MakeTestingClusterSettings()
+	g := metric.NewGauge(metric.Metadata{})
+	m := mon.NewUnlimitedMonitor(
+		context.Background(), "test", mon.MemoryResource, g,
+		nil, math.MaxInt64, st,
+	)
+	qs := raftReceiveQueues{mon: m}
+
+	const r1 = roachpb.RangeID(1)
+	const r5 = roachpb.RangeID(5)
+
+	qs.Load(r1)
+	qs.Load(r5)
+	require.Zero(t, m.AllocBytes())
+
+	q1, loaded := qs.LoadOrCreate(r1)
+	require.Zero(t, m.AllocBytes())
+	require.False(t, loaded)
+	{
+		q1x, loadedx := qs.LoadOrCreate(r1)
+		require.True(t, loadedx)
+		require.Equal(t, q1, q1x)
+	}
+	require.Zero(t, m.AllocBytes())
+
+	e1 := &kvserverpb.RaftMessageRequest{Message: raftpb.Message{Entries: []raftpb.Entry{
+		{Data: []byte("foo bar baz")}}}}
+	e5 := &kvserverpb.RaftMessageRequest{Message: raftpb.Message{Entries: []raftpb.Entry{
+		{Data: []byte("xxxxlxlxlxlxllxlxlxlxlxxlxllxlxlxlxlxl")}}}}
+	n1 := int64(e1.Size())
+	n5 := int64(e5.Size())
+
+	// Append an entry.
+	{
+		shouldQ, size, appended := q1.Append(e1, nil /* stream */)
+		require.True(t, appended)
+		require.True(t, shouldQ)
+		require.Equal(t, n1, size)
+		require.Equal(t, n1, q1.acc.Used())
+		// NB: the monitor allocates in chunks so it will have allocated more than n1.
+		// We don't check these going forward, as we've now verified that they're hooked up.
+		require.GreaterOrEqual(t, m.AllocBytes(), n1)
+		require.Equal(t, m.AllocBytes(), g.Value())
+	}
+
+	{
+		sl, ok := q1.Drain()
+		require.True(t, ok)
+		require.Len(t, sl, 1)
+		require.Equal(t, e1, sl[0].req)
+		require.Zero(t, q1.acc.Used())
+	}
+
+	// Append a first element (again).
+	{
+		shouldQ, _, appended := q1.Append(e1, nil /* stream */)
+		require.True(t, shouldQ)
+		require.True(t, appended)
+		require.Equal(t, n1, q1.acc.Used())
+	}
+
+	// Add a second element.
+	{
+		shouldQ, _, appended := q1.Append(e1, nil /* stream */)
+		require.False(t, shouldQ) // not first entry in queue
+		require.True(t, appended)
+		require.Equal(t, 2*n1, q1.acc.Used())
+	}
+
+	// Now interleave creation of a second queue.
+	q5, loaded := qs.LoadOrCreate(r5)
+	{
+		require.False(t, loaded)
+		require.Zero(t, q5.acc.Used())
+		shouldQ, _, appended := q5.Append(e5, nil /* stream */)
+		require.True(t, appended)
+		require.True(t, shouldQ)
+
+		// No accidental misattribution of bytes between the queues.
+		require.Equal(t, 2*n1, q1.acc.Used())
+		require.Equal(t, n5, q5.acc.Used())
+	}
+
+	// Delete the queue. Post deletion, even if someone still has a handle
+	// to the deleted queue, the queue is empty and refuses appends. In other
+	// words, we're not going to leak requests into abandoned queues.
+	{
+		qs.Delete(r1)
+		shouldQ, _, appended := q1.Append(e1, nil /* stream */)
+		require.False(t, appended)
+		require.False(t, shouldQ)
+		require.Zero(t, q1.acc.Used())
+		require.Equal(t, n5, q5.acc.Used()) // we didn't touch q5
+	}
+}

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1620,12 +1620,37 @@ var charts = []sectionDescription{
 		},
 	},
 	{
-		Organization: [][]string{{ReplicationLayer, "Raft", "Received"}},
+		Organization: [][]string{{ReplicationLayer, "Raft", "Receive Queue"}},
 		Charts: []chartDescription{
 			{
-				Title:   "Dropped",
-				Metrics: []string{"raft.rcvd.dropped"},
+				Title: "Dropped Entry Count",
+				Metrics: []string{
+					"raft.rcvd.dropped",
+				},
 			},
+			{
+				Title: "Dropped Entry Bytes",
+				Metrics: []string{
+					"raft.rcvd.dropped_bytes",
+				},
+			},
+			{
+				Title: "Entry Bytes in Queue",
+				Metrics: []string{
+					"raft.rcvd.queued_bytes",
+				},
+			},
+			{
+				Title: "Entry Bytes Stepped into Raft",
+				Metrics: []string{
+					"raft.rcvd.stepped_bytes",
+				},
+			},
+		},
+	},
+	{
+		Organization: [][]string{{ReplicationLayer, "Raft", "Received"}},
+		Charts: []chartDescription{
 			{
 				Title:   "Heartbeat Count",
 				Metrics: []string{"raft.rcvd.heartbeat"},


### PR DESCRIPTION
This commit adds a few new metrics that should be helpful in diagnosing
OOMs such as seen in #80155, and, down the road, for experimenting with (and ultimately implementing) solutions to #79215.

`cr.store.raft.rcvd.queued_bytes`: gauge (sum of size of all entries waiting to be handed to raft)
`cr.store.raft.rcvd.stepped_bytes`: counter (sum of size of all entries handed to RawNode.Step)
`cr.store.raft.rcvd.dropped_bytes`: counter (sum of size of all entries that were dropped because recv queue filled up)

Release note: None