### PR TITLE
sql: change materialized view not to be created with fixed timestamp.

### DIFF
--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -236,7 +236,6 @@ func (n *createViewNode) startExec(params runParams) error {
 			// * use AllocateIDs to give the view descriptor a primary key
 			desc.IsMaterializedView = true
 			desc.State = descpb.DescriptorState_ADD
-			desc.CreateAsOfTime = params.p.Txn().ReadTimestamp()
 			version := params.ExecCfg().Settings.Version.ActiveVersion(params.ctx)
 			if err := desc.AllocateIDs(params.ctx, version); err != nil {
 				return err

--- a/pkg/sql/logictest/testdata/logic_test/materialized_view
+++ b/pkg/sql/logictest/testdata/logic_test/materialized_view
@@ -228,3 +228,21 @@ query I
 SELECT * FROM view_from_seq
 ----
 1
+
+# Regression test for #79015.
+user testuser
+
+statement ok
+BEGIN
+
+user root
+
+statement ok
+SELECT * FROM system.descriptor;
+
+user testuser
+
+statement ok
+CREATE SEQUENCE seq_2;
+CREATE MATERIALIZED VIEW view_from_seq_2 AS (SELECT nextval('seq_2'));
+COMMIT


### PR DESCRIPTION
Previously, a materialized view was created with fixed time timestamp (
namely, its `CreateAsOfTime` is initialized to transaction's read time).

If the transaction that created this materialized
view is pushed forward then `CreateAsOfTime` will be before other
descriptors created in the same transaction, causing the backfill job
for create materialized view to fail because the other, needed
descriptors are not visible at that early `CreatedAsOfTime`.

We address this by removing the line that sets `CreateAsOfTime` field
of the materalized view, and it instead will reply on the MVCC protocol
to populate this field based on the MVCC timestamp of the row containing
the needed descriptors when backfilling this materialized view.

fixes: #79015

Release note (bug fix): This PR fixes a bug where if a transaction's
commit time is pushed forward from its initial provisional time, a
enclosing `CREATE MATERIALIZED VIEW AS ...` might fail to find other
descriptors created in the same transaction during the view's backfill
stage. The detailed description of this bug is summarized in issue #79015.
