### PR TITLE
server, cloud: plumb an ExternalStorage memory monitor

### DIFF
--- a/pkg/ccl/backupccl/backup_metadata_test.go
+++ b/pkg/ccl/backupccl/backup_metadata_test.go
@@ -75,7 +75,7 @@ func checkMetadata(
 		tc.Servers[0].ClusterSettings(),
 		blobs.TestEmptyBlobClientFactory,
 		username.RootUserName(),
-		tc.Servers[0].InternalExecutor().(*sql.InternalExecutor), tc.Servers[0].DB(), nil)
+		tc.Servers[0].InternalExecutor().(*sql.InternalExecutor), tc.Servers[0].DB(), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -571,7 +571,7 @@ func TestBackupRestoreAppend(t *testing.T) {
 				tc.Servers[0].ClusterSettings(),
 				blobs.TestEmptyBlobClientFactory,
 				username.RootUserName(),
-				tc.Servers[0].InternalExecutor().(*sql.InternalExecutor), tc.Servers[0].DB(), nil)
+				tc.Servers[0].InternalExecutor().(*sql.InternalExecutor), tc.Servers[0].DB(), nil, nil)
 			require.NoError(t, err)
 			defer store.Close()
 			var files []string
@@ -8030,7 +8030,7 @@ func TestReadBackupManifestMemoryMonitoring(t *testing.T) {
 		base.ExternalIODirConfig{},
 		st,
 		blobs.TestBlobServiceClient(dir),
-		username.RootUserName(), nil, nil, nil)
+		username.RootUserName(), nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	m := mon.NewMonitor("test-monitor", mon.MemoryResource, nil, nil, 0, 0, st)

--- a/pkg/ccl/backupccl/restore_data_processor_test.go
+++ b/pkg/ccl/backupccl/restore_data_processor_test.go
@@ -244,8 +244,8 @@ func runTestIngest(t *testing.T, init func(*cluster.Settings)) {
 		Cfg: &execinfra.ServerConfig{
 			DB: kvDB,
 			ExternalStorage: func(ctx context.Context, dest roachpb.ExternalStorage) (cloud.ExternalStorage, error) {
-				return cloud.MakeExternalStorage(ctx, dest, base.ExternalIODirConfig{},
-					s.ClusterSettings(), blobs.TestBlobServiceClient(s.ClusterSettings().ExternalIODir), nil, nil, nil)
+				return cloud.MakeExternalStorage(ctx, dest, base.ExternalIODirConfig{}, s.ClusterSettings(),
+					blobs.TestBlobServiceClient(s.ClusterSettings().ExternalIODir), nil, nil, nil, nil)
 			},
 			Settings:      s.ClusterSettings(),
 			Codec:         keys.SystemSQLCodec,

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -159,7 +159,7 @@ func TestCloudStorageSink(t *testing.T) {
 	externalStorageFromURI := func(ctx context.Context, uri string, user username.SQLUsername) (cloud.ExternalStorage,
 		error) {
 		return cloud.ExternalStorageFromURI(ctx, uri, base.ExternalIODirConfig{}, settings,
-			clientFactory, user, nil, nil, nil)
+			clientFactory, user, nil, nil, nil, nil)
 	}
 
 	user := username.RootUserName()

--- a/pkg/ccl/cliccl/debug_backup.go
+++ b/pkg/ccl/cliccl/debug_backup.go
@@ -284,8 +284,8 @@ func externalStorageFromURIFactory(
 ) (cloud.ExternalStorage, error) {
 	defaultSettings := &cluster.Settings{}
 	defaultSettings.SV.Init(ctx, nil /* opaque */)
-	return cloud.ExternalStorageFromURI(ctx, uri, base.ExternalIODirConfig{},
-		defaultSettings, newBlobFactory, user, nil /*Internal Executor*/, nil /*kvDB*/, nil)
+	return cloud.ExternalStorageFromURI(ctx, uri, base.ExternalIODirConfig{}, defaultSettings,
+		newBlobFactory, user, nil, nil, nil, nil)
 }
 
 func getManifestFromURI(ctx context.Context, path string) (backupccl.BackupManifest, error) {
@@ -581,7 +581,7 @@ func makeIters(
 		var err error
 		clusterSettings := cluster.MakeClusterSettings()
 		dirStorage[i], err = cloud.MakeExternalStorage(ctx, file.Dir, base.ExternalIODirConfig{},
-			clusterSettings, newBlobFactory, nil /*internal executor*/, nil /*kvDB*/, nil)
+			clusterSettings, newBlobFactory, nil, nil, nil, nil)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "making external storage")
 		}

--- a/pkg/ccl/workloadccl/storage.go
+++ b/pkg/ccl/workloadccl/storage.go
@@ -37,7 +37,7 @@ func GetStorage(ctx context.Context, cfg FixtureConfig) (cloud.ExternalStorage, 
 
 	s, err := cloud.ExternalStorageFromURI(ctx, cfg.ObjectPathToURI(),
 		base.ExternalIODirConfig{}, clustersettings.MakeClusterSettings(),
-		nil, username.SQLUsername{}, nil, nil, nil)
+		nil, username.SQLUsername{}, nil, nil, nil, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, storageError)
 	}

--- a/pkg/cloud/BUILD.bazel
+++ b/pkg/cloud/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/util/ctxgroup",
         "//pkg/util/ioctx",
         "//pkg/util/log",
+        "//pkg/util/mon",
         "//pkg/util/quotapool",
         "//pkg/util/retry",
         "//pkg/util/sysutil",

--- a/pkg/cloud/amazon/BUILD.bazel
+++ b/pkg/cloud/amazon/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/util/contextutil",
         "//pkg/util/ioctx",
         "//pkg/util/log",
+        "//pkg/util/mon",
         "//pkg/util/syncutil",
         "//pkg/util/tracing",
         "@com_github_aws_aws_sdk_go//aws",

--- a/pkg/cloud/amazon/s3_storage_test.go
+++ b/pkg/cloud/amazon/s3_storage_test.go
@@ -46,7 +46,7 @@ func makeS3Storage(
 	// Setup a sink for the given args.
 	clientFactory := blobs.TestBlobServiceClient(testSettings.ExternalIODir)
 	s, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{}, testSettings,
-		clientFactory, nil, nil, nil)
+		clientFactory, nil, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -75,8 +75,8 @@ func TestPutS3(t *testing.T) {
 	user := username.RootUserName()
 	t.Run("auth-empty-no-cred", func(t *testing.T) {
 		_, err := cloud.ExternalStorageFromURI(ctx, fmt.Sprintf("s3://%s/%s", bucket,
-			"backup-test-default"), base.ExternalIODirConfig{}, testSettings,
-			blobs.TestEmptyBlobClientFactory, user, nil, nil, nil)
+			"backup-test-default"), base.ExternalIODirConfig{}, testSettings, blobs.TestEmptyBlobClientFactory,
+			user, nil, nil, nil, nil)
 		require.EqualError(t, err, fmt.Sprintf(
 			`%s is set to '%s', but %s is not set`,
 			cloud.AuthParam,
@@ -161,7 +161,7 @@ func TestPutS3(t *testing.T) {
 			cloud.AuthParam, cloud.AuthParamImplicit, AWSServerSideEncryptionMode,
 			"unsupported-algorithm")
 
-		_, err = makeS3Storage(ctx, invalidSSEModeURI, user)
+		_, err = testingMakeS3Storage(ctx, invalidSSEModeURI, user)
 		require.True(t, testutils.IsError(err, "unsupported server encryption mode unsupported-algorithm. Supported values are `aws:kms` and `AES256"))
 
 		// Specify aws:kms encryption mode but don't specify kms ID.
@@ -170,7 +170,7 @@ func TestPutS3(t *testing.T) {
 			bucket, "backup-test-sse-256",
 			cloud.AuthParam, cloud.AuthParamImplicit, AWSServerSideEncryptionMode,
 			"aws:kms")
-		_, err = makeS3Storage(ctx, invalidKMSURI, user)
+		_, err = testingMakeS3Storage(ctx, invalidKMSURI, user)
 		require.True(t, testutils.IsError(err, "AWS_SERVER_KMS_ID param must be set when using aws:kms server side encryption mode."))
 	})
 }
@@ -260,7 +260,7 @@ func TestPutS3Endpoint(t *testing.T) {
 func TestS3DisallowCustomEndpoints(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	dest := roachpb.ExternalStorage{S3Config: &roachpb.ExternalStorage_S3{Endpoint: "http://do.not.go.there/"}}
-	s3, err := MakeS3Storage(context.Background(),
+	s3, err := makeS3Storage(context.Background(),
 		cloud.ExternalStorageContext{
 			IOConf: base.ExternalIODirConfig{DisableHTTP: true},
 		},
@@ -276,7 +276,7 @@ func TestS3DisallowImplicitCredentials(t *testing.T) {
 
 	testSettings := cluster.MakeTestingClusterSettings()
 
-	s3, err := MakeS3Storage(context.Background(),
+	s3, err := makeS3Storage(context.Background(),
 		cloud.ExternalStorageContext{
 			IOConf:   base.ExternalIODirConfig{DisableImplicitCredentials: true},
 			Settings: testSettings,
@@ -329,8 +329,8 @@ func TestS3BucketDoesNotExist(t *testing.T) {
 
 	// Setup a sink for the given args.
 	clientFactory := blobs.TestBlobServiceClient(testSettings.ExternalIODir)
-	s, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{}, testSettings,
-		clientFactory, nil, nil, nil)
+	s, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{},
+		testSettings, clientFactory, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cloud/azure/BUILD.bazel
+++ b/pkg/cloud/azure/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/util/contextutil",
         "//pkg/util/ioctx",
+        "//pkg/util/mon",
         "//pkg/util/tracing",
         "@com_github_azure_azure_storage_blob_go//azblob",
         "@com_github_azure_go_autorest_autorest//azure",

--- a/pkg/cloud/azure/azure_storage.go
+++ b/pkg/cloud/azure/azure_storage.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/gogo/protobuf/types"
@@ -73,9 +74,26 @@ type azureStorage struct {
 	container azblob.ContainerURL
 	prefix    string
 	settings  *cluster.Settings
+	mon       *mon.BytesMonitor
 }
 
 var _ cloud.ExternalStorage = &azureStorage{}
+
+// azureStorageWriter wraps the underlying azure cloud storage writer.
+type azureStorageWriter struct {
+	io.WriteCloser
+
+	ctx    context.Context
+	memAcc *mon.BoundAccount
+}
+
+// Close implements the WriteCloser interface.
+func (w *azureStorageWriter) Close() error {
+	if w.memAcc != nil {
+		w.memAcc.Close(w.ctx)
+	}
+	return w.WriteCloser.Close()
+}
 
 func makeAzureStorage(
 	_ context.Context, args cloud.ExternalStorageContext, dest roachpb.ExternalStorage,
@@ -133,15 +151,36 @@ func (s *azureStorage) Writer(ctx context.Context, basename string) (io.WriteClo
 	sp.RecordStructured(&types.StringValue{Value: fmt.Sprintf("azure.Writer: %s",
 		path.Join(s.prefix, basename))})
 	blob := s.getBlob(basename)
-	return cloud.BackgroundPipe(ctx, func(ctx context.Context, r io.Reader) error {
+
+	// The BufferSize determines how much the client will buffer while uploading
+	// chunks to storage. This buffering is to enable retrying uploads in the face
+	// of transient errors. We should account for this buffer size in our memory
+	// monitor.
+	var memAcc *mon.BoundAccount
+	bufferSize := int(cloud.WriteChunkSize.Get(&s.settings.SV))
+	if s.mon != nil {
+		acc := s.mon.MakeBoundAccount()
+		memAcc = &acc
+		if err := memAcc.Grow(ctx, int64(bufferSize)); err != nil {
+			return nil, err
+		}
+	}
+
+	w := cloud.BackgroundPipe(ctx, func(ctx context.Context, r io.Reader) error {
 		defer sp.Finish()
 		_, err := azblob.UploadStreamToBlockBlob(
 			ctx, r, blob, azblob.UploadStreamToBlockBlobOptions{
-				BufferSize: int(cloud.WriteChunkSize.Get(&s.settings.SV)),
+				BufferSize: bufferSize,
 			},
 		)
 		return err
-	}), nil
+	})
+
+	return &azureStorageWriter{
+		WriteCloser: w,
+		ctx:         ctx,
+		memAcc:      memAcc,
+	}, nil
 }
 
 // ReadFile is shorthand for ReadFileAt with offset 0.

--- a/pkg/cloud/cloudtestutils/cloud_test_helpers.go
+++ b/pkg/cloud/cloudtestutils/cloud_test_helpers.go
@@ -117,7 +117,7 @@ func storeFromURI(
 	}
 	// Setup a sink for the given args.
 	s, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{}, testSettings,
-		clientFactory, ie, kvDB, nil)
+		clientFactory, ie, kvDB, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +144,8 @@ func CheckExportStore(
 
 	// Setup a sink for the given args.
 	clientFactory := blobs.TestBlobServiceClient(testSettings.ExternalIODir)
-	s, err := cloud.MakeExternalStorage(ctx, conf, ioConf, testSettings, clientFactory, ie, kvDB, nil)
+	s, err := cloud.MakeExternalStorage(ctx, conf, ioConf, testSettings, clientFactory, ie, kvDB,
+		nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -493,9 +494,8 @@ func uploadData(
 	data := randutil.RandBytes(rnd, 16<<20)
 	ctx := context.Background()
 
-	s, err := cloud.MakeExternalStorage(
-		ctx, dest, base.ExternalIODirConfig{}, testSettings,
-		nil, nil, nil, nil)
+	s, err := cloud.MakeExternalStorage(ctx, dest, base.ExternalIODirConfig{}, testSettings,
+		nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, cloud.WriteFile(ctx, s, basename, bytes.NewReader(data)))
 	return data, func() {
@@ -536,7 +536,7 @@ func CheckAntagonisticRead(
 	ctx := context.Background()
 	s, err := cloud.MakeExternalStorage(
 		ctx, conf, base.ExternalIODirConfig{}, testSettings,
-		nil, nil, nil, nil)
+		nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	defer s.Close()
 

--- a/pkg/cloud/external_storage.go
+++ b/pkg/cloud/external_storage.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/errors"
 )
 
@@ -149,6 +150,7 @@ type ExternalStorageContext struct {
 	BlobClientFactory blobs.BlobClientFactory
 	InternalExecutor  sqlutil.InternalExecutor
 	DB                *kv.DB
+	Mon               *mon.BytesMonitor
 }
 
 // ExternalStorageConstructor is a function registered to create instances

--- a/pkg/cloud/gcp/BUILD.bazel
+++ b/pkg/cloud/gcp/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/util/contextutil",
         "//pkg/util/ioctx",
+        "//pkg/util/mon",
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_gogo_protobuf//types",

--- a/pkg/cloud/gcp/gcs_storage_test.go
+++ b/pkg/cloud/gcp/gcs_storage_test.go
@@ -128,9 +128,8 @@ func TestFileDoesNotExist(t *testing.T) {
 		conf, err := cloud.ExternalStorageConfFromURI(gsFile, user)
 		require.NoError(t, err)
 
-		s, err := cloud.MakeExternalStorage(
-			context.Background(), conf, base.ExternalIODirConfig{}, testSettings,
-			nil, nil, nil, nil)
+		s, err := cloud.MakeExternalStorage(context.Background(), conf, base.ExternalIODirConfig{},
+			testSettings, nil, nil, nil, nil, nil)
 		require.NoError(t, err)
 		_, err = s.ReadFile(context.Background(), "")
 		require.Error(t, err, "")
@@ -143,9 +142,8 @@ func TestFileDoesNotExist(t *testing.T) {
 		conf, err := cloud.ExternalStorageConfFromURI(gsFile, user)
 		require.NoError(t, err)
 
-		s, err := cloud.MakeExternalStorage(
-			context.Background(), conf, base.ExternalIODirConfig{}, testSettings, nil,
-			nil, nil, nil)
+		s, err := cloud.MakeExternalStorage(context.Background(), conf, base.ExternalIODirConfig{},
+			testSettings, nil, nil, nil, nil, nil)
 		require.NoError(t, err)
 		_, err = s.ReadFile(context.Background(), "")
 		require.Error(t, err, "")
@@ -173,9 +171,11 @@ func TestCompressedGCS(t *testing.T) {
 	conf2, err := cloud.ExternalStorageConfFromURI(gsFile2, user)
 	require.NoError(t, err)
 
-	s1, err := cloud.MakeExternalStorage(ctx, conf1, base.ExternalIODirConfig{}, testSettings, nil, nil, nil, nil)
+	s1, err := cloud.MakeExternalStorage(ctx, conf1, base.ExternalIODirConfig{}, testSettings,
+		nil, nil, nil, nil, nil)
 	require.NoError(t, err)
-	s2, err := cloud.MakeExternalStorage(ctx, conf2, base.ExternalIODirConfig{}, testSettings, nil, nil, nil, nil)
+	s2, err := cloud.MakeExternalStorage(ctx, conf2, base.ExternalIODirConfig{}, testSettings,
+		nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	reader1, err := s1.ReadFile(context.Background(), "")

--- a/pkg/cloud/httpsink/http_storage_test.go
+++ b/pkg/cloud/httpsink/http_storage_test.go
@@ -161,8 +161,8 @@ func TestPutHttp(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		s, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{},
-			testSettings, blobs.TestEmptyBlobClientFactory, nil, nil, nil)
+		s, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{}, testSettings,
+			blobs.TestEmptyBlobClientFactory, nil, nil, nil, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -315,10 +315,9 @@ func TestCanDisableHttp(t *testing.T) {
 	}
 	testSettings := cluster.MakeTestingClusterSettings()
 
-	s, err := cloud.MakeExternalStorage(
-		context.Background(),
-		roachpb.ExternalStorage{Provider: roachpb.ExternalStorageProvider_http},
-		conf, testSettings, blobs.TestEmptyBlobClientFactory, nil, nil, nil)
+	s, err := cloud.MakeExternalStorage(context.Background(),
+		roachpb.ExternalStorage{Provider: roachpb.ExternalStorageProvider_http}, conf,
+		testSettings, blobs.TestEmptyBlobClientFactory, nil, nil, nil, nil)
 	require.Nil(t, s)
 	require.Error(t, err)
 }
@@ -336,10 +335,8 @@ func TestCanDisableOutbound(t *testing.T) {
 		roachpb.ExternalStorageProvider_gs,
 		roachpb.ExternalStorageProvider_nodelocal,
 	} {
-		s, err := cloud.MakeExternalStorage(
-			context.Background(),
-			roachpb.ExternalStorage{Provider: provider},
-			conf, testSettings, blobs.TestEmptyBlobClientFactory, nil, nil, nil)
+		s, err := cloud.MakeExternalStorage(context.Background(), roachpb.ExternalStorage{Provider: provider},
+			conf, testSettings, blobs.TestEmptyBlobClientFactory, nil, nil, nil, nil)
 		require.Nil(t, s)
 		require.Error(t, err)
 	}
@@ -368,9 +365,8 @@ func TestExternalStorageCanUseHTTPProxy(t *testing.T) {
 
 	conf, err := cloud.ExternalStorageConfFromURI("http://my-server", username.RootUserName())
 	require.NoError(t, err)
-	s, err := cloud.MakeExternalStorage(
-		context.Background(), conf, base.ExternalIODirConfig{}, testSettings, nil,
-		nil, nil, nil)
+	s, err := cloud.MakeExternalStorage(context.Background(), conf, base.ExternalIODirConfig{},
+		testSettings, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	stream, err := s.ReadFile(context.Background(), "file")
 	require.NoError(t, err)

--- a/pkg/cloud/nodelocal/nodelocal_storage.go
+++ b/pkg/cloud/nodelocal/nodelocal_storage.go
@@ -73,18 +73,6 @@ func MakeLocalStorageURI(path string) string {
 	return fmt.Sprintf("nodelocal://0/%s", path)
 }
 
-// TestingMakeLocalStorage is used by tests.
-func TestingMakeLocalStorage(
-	ctx context.Context,
-	cfg roachpb.ExternalStorage_LocalFilePath,
-	settings *cluster.Settings,
-	blobClientFactory blobs.BlobClientFactory,
-	ioConf base.ExternalIODirConfig,
-) (cloud.ExternalStorage, error) {
-	args := cloud.ExternalStorageContext{IOConf: ioConf, BlobClientFactory: blobClientFactory, Settings: settings}
-	return makeLocalStorage(ctx, args, roachpb.ExternalStorage{LocalFile: cfg})
-}
-
 func makeLocalStorage(
 	ctx context.Context, args cloud.ExternalStorageContext, dest roachpb.ExternalStorage,
 ) (cloud.ExternalStorage, error) {

--- a/pkg/cloud/nullsink/nullsink_storage_test.go
+++ b/pkg/cloud/nullsink/nullsink_storage_test.go
@@ -36,7 +36,7 @@ func TestNullSinkReadAndWrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{}, nil, nil, nil, nil, nil)
+	s, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{}, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cloud/userfile/file_table_storage_test.go
+++ b/pkg/cloud/userfile/file_table_storage_test.go
@@ -69,7 +69,7 @@ func TestPutUserFileTable(t *testing.T) {
 
 		store, err := cloud.ExternalStorageFromURI(ctx, userfileURL.String()+"/",
 			base.ExternalIODirConfig{}, cluster.NoSettings, blobs.TestEmptyBlobClientFactory,
-			username.RootUserName(), ie, kvDB, nil)
+			username.RootUserName(), ie, kvDB, nil, nil)
 		require.NoError(t, err)
 		defer store.Close()
 
@@ -116,13 +116,13 @@ func TestUserScoping(t *testing.T) {
 
 	// Write file as user1.
 	fileTableSystem1, err := cloud.ExternalStorageFromURI(ctx, dest, base.ExternalIODirConfig{},
-		cluster.NoSettings, blobs.TestEmptyBlobClientFactory, user1, ie, kvDB, nil)
+		cluster.NoSettings, blobs.TestEmptyBlobClientFactory, user1, ie, kvDB, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, cloud.WriteFile(ctx, fileTableSystem1, filename, bytes.NewReader([]byte("aaa"))))
 
 	// Attempt to read/write file as user2 and expect to fail.
 	fileTableSystem2, err := cloud.ExternalStorageFromURI(ctx, dest, base.ExternalIODirConfig{},
-		cluster.NoSettings, blobs.TestEmptyBlobClientFactory, user2, ie, kvDB, nil)
+		cluster.NoSettings, blobs.TestEmptyBlobClientFactory, user2, ie, kvDB, nil, nil)
 	require.NoError(t, err)
 	_, err = fileTableSystem2.ReadFile(ctx, filename)
 	require.Error(t, err)
@@ -130,7 +130,7 @@ func TestUserScoping(t *testing.T) {
 
 	// Read file as root and expect to succeed.
 	fileTableSystem3, err := cloud.ExternalStorageFromURI(ctx, dest, base.ExternalIODirConfig{},
-		cluster.NoSettings, blobs.TestEmptyBlobClientFactory, username.RootUserName(), ie, kvDB, nil)
+		cluster.NoSettings, blobs.TestEmptyBlobClientFactory, username.RootUserName(), ie, kvDB, nil, nil)
 	require.NoError(t, err)
 	_, err = fileTableSystem3.ReadFile(ctx, filename)
 	require.NoError(t, err)

--- a/pkg/server/external_storage_builder.go
+++ b/pkg/server/external_storage_builder.go
@@ -22,14 +22,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/errors"
 )
 
 // externalStorageBuilder is a wrapper around the ExternalStorage factory
 // methods. It allows us to separate the creation and initialization of the
 // builder between NewServer() and Start() respectively.
-// TODO(adityamaru): Consider moving this to pkg/cloud/impl at a future
-// stage of the ongoing refactor.
+//
+// TODO(adityamaru): Consider moving this to pkg/cloud/impl.
 type externalStorageBuilder struct {
 	conf              base.ExternalIODirConfig
 	settings          *cluster.Settings
@@ -38,33 +39,39 @@ type externalStorageBuilder struct {
 	ie                *sql.InternalExecutor
 	db                *kv.DB
 	limiters          cloud.Limiters
+	mon               *mon.BytesMonitor
 }
 
-func (e *externalStorageBuilder) init(
-	ctx context.Context,
-	conf base.ExternalIODirConfig,
-	settings *cluster.Settings,
-	nodeIDContainer *base.NodeIDContainer,
-	nodeDialer *nodedialer.Dialer,
-	testingKnobs base.TestingKnobs,
-	ie *sql.InternalExecutor,
-	db *kv.DB,
-) {
+// externalStorageBuilderConfig contains the information needed to initialize an
+// externalStorageBuilder.
+type externalStorageBuilderConfig struct {
+	conf            base.ExternalIODirConfig
+	settings        *cluster.Settings
+	nodeIDContainer *base.NodeIDContainer
+	nodeDialer      *nodedialer.Dialer
+	ie              *sql.InternalExecutor
+	db              *kv.DB
+	mon             *mon.BytesMonitor
+	knobs           base.TestingKnobs
+}
+
+func (e *externalStorageBuilder) init(ctx context.Context, cfg *externalStorageBuilderConfig) {
 	var blobClientFactory blobs.BlobClientFactory
-	if p, ok := testingKnobs.Server.(*TestingKnobs); ok && p.BlobClientFactory != nil {
+	if p, ok := cfg.knobs.Server.(*TestingKnobs); ok && p.BlobClientFactory != nil {
 		blobClientFactory = p.BlobClientFactory
 	}
 	if blobClientFactory == nil {
-		blobClientFactory = blobs.NewBlobClientFactory(nodeIDContainer, nodeDialer, settings.ExternalIODir)
+		blobClientFactory = blobs.NewBlobClientFactory(cfg.nodeIDContainer,
+			cfg.nodeDialer, cfg.settings.ExternalIODir)
 	}
-	e.conf = conf
-	e.settings = settings
+	e.conf = cfg.conf
+	e.settings = cfg.settings
 	e.blobClientFactory = blobClientFactory
 	e.initCalled = true
-	e.ie = ie
-	e.db = db
-	e.limiters = cloud.MakeLimiters(ctx, &settings.SV)
-
+	e.ie = cfg.ie
+	e.db = cfg.db
+	e.limiters = cloud.MakeLimiters(ctx, &cfg.settings.SV)
+	e.mon = cfg.mon
 }
 
 func (e *externalStorageBuilder) makeExternalStorage(
@@ -74,7 +81,7 @@ func (e *externalStorageBuilder) makeExternalStorage(
 		return nil, errors.New("cannot create external storage before init")
 	}
 	return cloud.MakeExternalStorage(ctx, dest, e.conf, e.settings, e.blobClientFactory, e.ie,
-		e.db, e.limiters)
+		e.db, e.limiters, e.mon)
 }
 
 func (e *externalStorageBuilder) makeExternalStorageFromURI(
@@ -83,5 +90,6 @@ func (e *externalStorageBuilder) makeExternalStorageFromURI(
 	if !e.initCalled {
 		return nil, errors.New("cannot create external storage before init")
 	}
-	return cloud.ExternalStorageFromURI(ctx, uri, e.conf, e.settings, e.blobClientFactory, user, e.ie, e.db, e.limiters)
+	return cloud.ExternalStorageFromURI(ctx, uri, e.conf, e.settings, e.blobClientFactory, user,
+		e.ie, e.db, e.limiters, e.mon)
 }

--- a/pkg/sql/importer/import_processor_test.go
+++ b/pkg/sql/importer/import_processor_test.go
@@ -892,8 +892,7 @@ func externalStorageFactory(
 	if err != nil {
 		return nil, err
 	}
-	return cloud.MakeExternalStorage(ctx, dest, base.ExternalIODirConfig{},
-		nil, blobs.TestBlobServiceClient(workdir), nil, nil, nil)
+	return cloud.MakeExternalStorage(ctx, dest, base.ExternalIODirConfig{}, nil, blobs.TestBlobServiceClient(workdir), nil, nil, nil, nil)
 }
 
 // Helper to create and initialize testSpec.

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -2555,7 +2555,7 @@ func TestImportObjectLevelRBAC(t *testing.T) {
 		// Write to userfile storage now that testuser has CREATE privileges.
 		ie := tc.Server(0).InternalExecutor().(*sql.InternalExecutor)
 		fileTableSystem1, err := cloud.ExternalStorageFromURI(ctx, dest, base.ExternalIODirConfig{},
-			cluster.NoSettings, blobs.TestEmptyBlobClientFactory, username.TestUserName(), ie, tc.Server(0).DB(), nil)
+			cluster.NoSettings, blobs.TestEmptyBlobClientFactory, username.TestUserName(), ie, tc.Server(0).DB(), nil, nil)
 		require.NoError(t, err)
 		require.NoError(t, cloud.WriteFile(ctx, fileTableSystem1, filename, bytes.NewReader([]byte(data))))
 	}
@@ -5742,7 +5742,7 @@ func TestImportPgDumpIgnoredStmts(t *testing.T) {
 			tc.Server(0).ClusterSettings(),
 			blobs.TestEmptyBlobClientFactory,
 			username.RootUserName(),
-			tc.Server(0).InternalExecutor().(*sql.InternalExecutor), tc.Server(0).DB(), nil)
+			tc.Server(0).InternalExecutor().(*sql.InternalExecutor), tc.Server(0).DB(), nil, nil)
 		require.NoError(t, err)
 		defer store.Close()
 


### PR DESCRIPTION
This change adds a dedicated ExternalStorage memory monitor
as a child of the root memory monitor. This can be used to memory
monitor ExternalStorage operations.

As a start, we memory monitor the ChunkSize that every Azure,S3 and GCS
Writer will buffer when uploading file chunks to storage. During a backup
this could be num nodes * ChunkSize of memory which was previously
unmonitored.

Release note: None