### PR TITLE
sqltelemetry: move record.go to `sql`

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -161,6 +161,7 @@ go_library(
         "render.go",
         "repair.go",
         "reparent_database.go",
+        "report.go",
         "resolve_oid.go",
         "resolver.go",
         "revert.go",

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1753,7 +1753,7 @@ func (ex *connExecutor) runShowSyntax(
 			commErr = res.AddRow(ctx, tree.Datums{tree.NewDString(field), tree.NewDString(msg)})
 		},
 		func(ctx context.Context, err error) {
-			sqltelemetry.RecordError(ctx, err, &ex.server.cfg.Settings.SV)
+			RecordError(ctx, err, &ex.server.cfg.Settings.SV)
 		},
 	)
 	return commErr

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -204,7 +203,7 @@ func (ie *InternalExecutor) initConnEx(
 	wg.Add(1)
 	go func() {
 		if err := ex.run(ctx, ie.mon, mon.BoundAccount{} /*reserved*/, nil /* cancel */); err != nil {
-			sqltelemetry.RecordError(ctx, err, &ex.server.cfg.Settings.SV)
+			RecordError(ctx, err, &ex.server.cfg.Settings.SV)
 			errCallback(err)
 		}
 		w.finish()

--- a/pkg/sql/pgwire/auth_methods.go
+++ b/pkg/sql/pgwire/auth_methods.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/identmap"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/errors"
@@ -352,7 +351,7 @@ func scramAuthenticator(
 				// We need to manually report the unimplemented error because it is not
 				// passed through to the client as-is (authn errors are hidden behind
 				// a generic "authn failed" error).
-				sqltelemetry.RecordError(ctx, err, &execCfg.Settings.SV)
+				sql.RecordError(ctx, err, &execCfg.Settings.SV)
 				return err
 			}
 			inputLen, err := rb.GetUint32()

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -1461,7 +1461,7 @@ func writeErr(
 	ctx context.Context, sv *settings.Values, err error, msgBuilder *writeBuffer, w io.Writer,
 ) error {
 	// Record telemetry for the error.
-	sqltelemetry.RecordError(ctx, err, sv)
+	sql.RecordError(ctx, err, sv)
 	msgBuilder.initMsg(pgwirebase.ServerMsgErrorResponse)
 	return writeErrFields(ctx, sv, err, msgBuilder, w)
 }

--- a/pkg/sql/report.go
+++ b/pkg/sql/report.go
@@ -8,10 +8,11 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package sqltelemetry
+package sql
 
 import (
 	"context"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -38,7 +39,7 @@ func RecordError(ctx context.Context, err error, sv *settings.Values) {
 		// qualified with a code).
 		//
 		// TODO(knz): figure out if this telemetry is still useful.
-		telemetry.Inc(UncategorizedErrorCounter)
+		telemetry.Inc(sqltelemetry.UncategorizedErrorCounter)
 
 	case code == pgcode.Internal || errors.HasAssertionFailure(err):
 		// This is an assertion failure / crash.

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -50,7 +50,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
@@ -744,7 +743,7 @@ func (sc *SchemaChanger) exec(ctx context.Context) error {
 			log.Warningf(ctx, "waiting to update leases: %+v", err)
 			// As we are dismissing the error, go through the recording motions.
 			// This ensures that any important error gets reported to Sentry, etc.
-			sqltelemetry.RecordError(ctx, err, &sc.settings.SV)
+			RecordError(ctx, err, &sc.settings.SV)
 		}
 		// We wait to trigger a stats refresh until we know the leases have been
 		// updated.
@@ -835,7 +834,7 @@ func (sc *SchemaChanger) exec(ctx context.Context) error {
 			log.Infof(ctx, "failed to update job status: %+v", err)
 		}
 		// Go through the recording motions. See comment above.
-		sqltelemetry.RecordError(ctx, err, &sc.settings.SV)
+		RecordError(ctx, err, &sc.settings.SV)
 		if jobs.IsPauseSelfError(err) {
 			// For testing only
 			return err
@@ -855,7 +854,7 @@ func (sc *SchemaChanger) exec(ctx context.Context) error {
 			log.Warningf(ctx, "unexpected error while waiting for leases to update: %+v", err)
 			// As we are dismissing the error, go through the recording motions.
 			// This ensures that any important error gets reported to Sentry, etc.
-			sqltelemetry.RecordError(ctx, err, &sc.settings.SV)
+			RecordError(ctx, err, &sc.settings.SV)
 		}
 	}()
 
@@ -901,7 +900,7 @@ func (sc *SchemaChanger) handlePermanentSchemaChangeError(
 		// From now on, the returned error will be a secondary error of the returned
 		// error, so we'll record the original error now.
 		secondary := errors.Wrap(err, "original error when rolling back mutations")
-		sqltelemetry.RecordError(ctx, secondary, &sc.settings.SV)
+		RecordError(ctx, secondary, &sc.settings.SV)
 		return errors.WithSecondaryError(rollbackErr, secondary)
 	}
 
@@ -918,7 +917,7 @@ func (sc *SchemaChanger) handlePermanentSchemaChangeError(
 			log.Warningf(ctx, "waiting to update leases: %+v", err)
 			// As we are dismissing the error, go through the recording motions.
 			// This ensures that any important error gets reported to Sentry, etc.
-			sqltelemetry.RecordError(ctx, err, &sc.settings.SV)
+			RecordError(ctx, err, &sc.settings.SV)
 		}
 		// We wait to trigger a stats refresh until we know the leases have been
 		// updated.
@@ -936,7 +935,7 @@ func (sc *SchemaChanger) handlePermanentSchemaChangeError(
 			log.Warningf(ctx, "unexpected error while waiting for leases to update: %+v", err)
 			// As we are dismissing the error, go through the recording motions.
 			// This ensures that any important error gets reported to Sentry, etc.
-			sqltelemetry.RecordError(ctx, err, &sc.settings.SV)
+			RecordError(ctx, err, &sc.settings.SV)
 		}
 	}()
 

--- a/pkg/sql/sqltelemetry/BUILD.bazel
+++ b/pkg/sql/sqltelemetry/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "pgwire.go",
         "planning.go",
         "reassign_owned_by.go",
-        "report.go",
         "scalar.go",
         "scheduled_backups.go",
         "schema.go",
@@ -31,11 +30,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/server/telemetry",
-        "//pkg/settings",
         "//pkg/sql/pgwire/pgcode",
-        "//pkg/sql/pgwire/pgerror",
-        "//pkg/util/log",
-        "//pkg/util/log/logcrash",
-        "@com_github_cockroachdb_errors//:errors",
     ],
 )


### PR DESCRIPTION
`RecordError` requires the import of `log` - but there's no reason it
should be in `sqltelemetry`. Moving that to the `sql` package.

Release note: None