### PR TITLE
server: introduce a decommission monitor task

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -6711,6 +6711,7 @@ Support status: [reserved](#support-status)
 | queue | [string](#cockroach.server.serverpb.EnqueueRangeRequest-string) |  | The name of the replica queue to run the range through. Matched against each queue's name field. See the implementation of baseQueue for details. | [reserved](#support-status) |
 | range_id | [int32](#cockroach.server.serverpb.EnqueueRangeRequest-int32) |  | The ID of the range to run through the queue. | [reserved](#support-status) |
 | skip_should_queue | [bool](#cockroach.server.serverpb.EnqueueRangeRequest-bool) |  | If set, run the queue's process method without first checking whether the replica should be processed by calling shouldQueue. | [reserved](#support-status) |
+| async | [bool](#cockroach.server.serverpb.EnqueueRangeRequest-bool) |  | If set, the replica will be enqueued asynchronously and a successful response will be empty. | [reserved](#support-status) |
 
 
 

--- a/pkg/ccl/backupccl/testutils.go
+++ b/pkg/ccl/backupccl/testutils.go
@@ -28,7 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
-	roachpb "github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -567,7 +567,7 @@ WHERE start_pretty LIKE '%s' ORDER BY start_key ASC`, startPretty)).Scan(&startK
 	lhServer := tc.Server(int(l.Replica.NodeID) - 1)
 	s, repl := getFirstStoreReplica(t, lhServer, startKey)
 	testutils.SucceedsSoon(t, func() error {
-		trace, _, err := s.ManuallyEnqueue(ctx, "mvccGC", repl, skipShouldQueue)
+		trace, _, err := s.Enqueue(ctx, "mvccGC", repl, skipShouldQueue, false /* async */)
 		require.NoError(t, err)
 		return checkGCTrace(trace.String())
 	})
@@ -602,7 +602,7 @@ ORDER BY start_key ASC`, tableName, databaseName).Scan(&startKey)
 	lhServer := tc.Server(int(l.Replica.NodeID) - 1)
 	s, repl := getFirstStoreReplica(t, lhServer, startKey)
 	testutils.SucceedsSoon(t, func() error {
-		trace, _, err := s.ManuallyEnqueue(ctx, "mvccGC", repl, skipShouldQueue)
+		trace, _, err := s.Enqueue(ctx, "mvccGC", repl, skipShouldQueue, false /* async */)
 		require.NoError(t, err)
 		return checkGCTrace(trace.String())
 	})

--- a/pkg/ccl/multiregionccl/datadriven_test.go
+++ b/pkg/ccl/multiregionccl/datadriven_test.go
@@ -315,8 +315,9 @@ SET CLUSTER SETTING kv.closed_timestamp.propagation_slack = '0.5s'
 						return errors.New(`could not find replica`)
 					}
 					for _, queueName := range []string{"split", "replicate", "raftsnapshot"} {
-						_, processErr, err := store.ManuallyEnqueue(ctx, queueName, repl,
-							true /* skipShouldQueue */)
+						_, processErr, err := store.Enqueue(
+							ctx, queueName, repl, true /* skipShouldQueue */, false, /* async */
+						)
 						if processErr != nil {
 							return processErr
 						}

--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -837,7 +837,7 @@ func TestLeasePreferencesDuringOutage(t *testing.T) {
 		return nil
 	})
 	_, _, enqueueError := tc.GetFirstStoreFromServer(t, 0).
-		ManuallyEnqueue(ctx, "replicate", repl, true)
+		Enqueue(ctx, "replicate", repl, true /* skipShouldQueue */, false /* async */)
 
 	require.NoError(t, enqueueError)
 
@@ -1036,7 +1036,7 @@ func TestLeasesDontThrashWhenNodeBecomesSuspect(t *testing.T) {
 			repl := tc.GetFirstStoreFromServer(t, i).LookupReplica(roachpb.RKey(key))
 			require.NotNil(t, repl)
 			_, _, enqueueError := tc.GetFirstStoreFromServer(t, i).
-				ManuallyEnqueue(ctx, "replicate", repl, true)
+				Enqueue(ctx, "replicate", repl, true /* skipShouldQueue */, false /* async */)
 			require.NoError(t, enqueueError)
 		}
 	}

--- a/pkg/kv/kvserver/client_migration_test.go
+++ b/pkg/kv/kvserver/client_migration_test.go
@@ -180,7 +180,7 @@ func TestMigrateWithInflightSnapshot(t *testing.T) {
 	repl, err := store.GetReplica(desc.RangeID)
 	require.NoError(t, err)
 	testutils.SucceedsSoon(t, func() error {
-		trace, processErr, err := store.ManuallyEnqueue(ctx, "raftsnapshot", repl, true /* skipShouldQueue */)
+		trace, processErr, err := store.Enqueue(ctx, "raftsnapshot", repl, true /* skipShouldQueue */, false /* async */)
 		if err != nil {
 			return err
 		}

--- a/pkg/kv/kvserver/client_protectedts_test.go
+++ b/pkg/kv/kvserver/client_protectedts_test.go
@@ -156,7 +156,7 @@ func TestProtectedTimestamps(t *testing.T) {
 		testutils.SucceedsSoon(t, func() error {
 			upsertUntilBackpressure()
 			s, repl := getStoreAndReplica()
-			trace, _, err := s.ManuallyEnqueue(ctx, "mvccGC", repl, false)
+			trace, _, err := s.Enqueue(ctx, "mvccGC", repl, false /* skipShouldQueue */, false /* async */)
 			require.NoError(t, err)
 			if !processedRegexp.MatchString(trace.String()) {
 				return errors.Errorf("%q does not match %q", trace.String(), processedRegexp)
@@ -200,13 +200,13 @@ func TestProtectedTimestamps(t *testing.T) {
 	s, repl := getStoreAndReplica()
 	// The protectedts record will prevent us from aging the MVCC garbage bytes
 	// past the oldest record so shouldQueue should be false. Verify that.
-	trace, _, err := s.ManuallyEnqueue(ctx, "mvccGC", repl, false /* skipShouldQueue */)
+	trace, _, err := s.Enqueue(ctx, "mvccGC", repl, false /* skipShouldQueue */, false /* async */)
 	require.NoError(t, err)
 	require.Regexp(t, "(?s)shouldQueue=false", trace.String())
 
 	// If we skipShouldQueue then gc will run but it should only run up to the
 	// timestamp of our record at the latest.
-	trace, _, err = s.ManuallyEnqueue(ctx, "mvccGC", repl, true /* skipShouldQueue */)
+	trace, _, err = s.Enqueue(ctx, "mvccGC", repl, true /* skipShouldQueue */, false /* async */)
 	require.NoError(t, err)
 	require.Regexp(t, "(?s)done with GC evaluation for 0 keys", trace.String())
 	thresh := thresholdFromTrace(trace)
@@ -258,7 +258,7 @@ func TestProtectedTimestamps(t *testing.T) {
 	// happens up to the protected timestamp of the new record.
 	require.NoError(t, ptsWithDB.Release(ctx, nil, ptsRec.ID.GetUUID()))
 	testutils.SucceedsSoon(t, func() error {
-		trace, _, err = s.ManuallyEnqueue(ctx, "mvccGC", repl, false)
+		trace, _, err = s.Enqueue(ctx, "mvccGC", repl, false /* skipShouldQueue */, false /* async */)
 		require.NoError(t, err)
 		if !processedRegexp.MatchString(trace.String()) {
 			return errors.Errorf("%q does not match %q", trace.String(), processedRegexp)

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -430,8 +430,12 @@ func testRaftSnapshotsToNonVoters(t *testing.T, drainReceivingNode bool) {
 		// Manually enqueue the leaseholder replica into its store's raft snapshot
 		// queue. We expect it to pick up on the fact that the non-voter on its range
 		// needs a snapshot.
-		recording, pErr, err := leaseholderStore.ManuallyEnqueue(
-			ctx, "raftsnapshot", leaseholderRepl, false, /* skipShouldQueue */
+		recording, pErr, err := leaseholderStore.Enqueue(
+			ctx,
+			"raftsnapshot",
+			leaseholderRepl,
+			false, /* skipShouldQueue */
+			false, /* async */
 		)
 		if pErr != nil {
 			return pErr
@@ -582,7 +586,9 @@ func TestReplicateQueueSeesLearnerOrJointConfig(t *testing.T) {
 	store, repl := getFirstStoreReplica(t, tc.Server(0), scratchStartKey)
 	{
 		require.Equal(t, int64(0), getFirstStoreMetric(t, tc.Server(0), `queue.replicate.removelearnerreplica`))
-		_, processErr, err := store.ManuallyEnqueue(ctx, "replicate", repl, true /* skipShouldQueue */)
+		_, processErr, err := store.Enqueue(
+			ctx, "replicate", repl, true /* skipShouldQueue */, false, /* async */
+		)
 		require.NoError(t, err)
 		require.NoError(t, processErr)
 		require.Equal(t, int64(1), getFirstStoreMetric(t, tc.Server(0), `queue.replicate.removelearnerreplica`))
@@ -600,7 +606,9 @@ func TestReplicateQueueSeesLearnerOrJointConfig(t *testing.T) {
 	ltk.withStopAfterJointConfig(func() {
 		desc := tc.RemoveVotersOrFatal(t, scratchStartKey, tc.Target(2))
 		require.True(t, desc.Replicas().InAtomicReplicationChange(), desc)
-		trace, processErr, err := store.ManuallyEnqueue(ctx, "replicate", repl, true /* skipShouldQueue */)
+		trace, processErr, err := store.Enqueue(
+			ctx, "replicate", repl, true /* skipShouldQueue */, false, /* async */
+		)
 		require.NoError(t, err)
 		require.NoError(t, processErr)
 		formattedTrace := trace.String()
@@ -639,7 +647,9 @@ func TestReplicaGCQueueSeesLearnerOrJointConfig(t *testing.T) {
 	// Run the replicaGC queue.
 	checkNoGC := func() roachpb.RangeDescriptor {
 		store, repl := getFirstStoreReplica(t, tc.Server(1), scratchStartKey)
-		trace, processErr, err := store.ManuallyEnqueue(ctx, "replicaGC", repl, true /* skipShouldQueue */)
+		trace, processErr, err := store.Enqueue(
+			ctx, "replicaGC", repl, true /* skipShouldQueue */, false, /* async */
+		)
 		require.NoError(t, err)
 		require.NoError(t, processErr)
 		const msg = `not gc'able, replica is still in range descriptor: (n2,s2):`
@@ -699,7 +709,9 @@ func TestRaftSnapshotQueueSeesLearner(t *testing.T) {
 	// raft to figure out that the replica needs a snapshot.
 	store, repl := getFirstStoreReplica(t, tc.Server(0), scratchStartKey)
 	testutils.SucceedsSoon(t, func() error {
-		trace, processErr, err := store.ManuallyEnqueue(ctx, "raftsnapshot", repl, true /* skipShouldQueue */)
+		trace, processErr, err := store.Enqueue(
+			ctx, "raftsnapshot", repl, true /* skipShouldQueue */, false, /* async */
+		)
 		if err != nil {
 			return err
 		}
@@ -835,7 +847,9 @@ func TestLearnerReplicateQueueRace(t *testing.T) {
 	queue1ErrCh := make(chan error, 1)
 	go func() {
 		queue1ErrCh <- func() error {
-			trace, processErr, err := store.ManuallyEnqueue(ctx, "replicate", repl, true /* skipShouldQueue */)
+			trace, processErr, err := store.Enqueue(
+				ctx, "replicate", repl, true /* skipShouldQueue */, false, /* async */
+			)
 			if err != nil {
 				return err
 			}
@@ -1315,7 +1329,9 @@ func TestMergeQueueDoesNotInterruptReplicationChange(t *testing.T) {
 		// ensure that the merge correctly notices that there is a snapshot in
 		// flight and ignores the range.
 		store, repl := getFirstStoreReplica(t, tc.Server(0), scratchKey)
-		_, processErr, enqueueErr := store.ManuallyEnqueue(ctx, "merge", repl, true /* skipShouldQueue */)
+		_, processErr, enqueueErr := store.Enqueue(
+			ctx, "merge", repl, true /* skipShouldQueue */, false, /* async */
+		)
 		require.NoError(t, enqueueErr)
 		require.True(t, kvserver.IsReplicationChangeInProgressError(processErr))
 		return nil
@@ -1360,7 +1376,9 @@ func TestMergeQueueSeesLearnerOrJointConfig(t *testing.T) {
 		})
 
 		store, repl := getFirstStoreReplica(t, tc.Server(0), scratchStartKey)
-		trace, processErr, err := store.ManuallyEnqueue(ctx, "merge", repl, true /* skipShouldQueue */)
+		trace, processErr, err := store.Enqueue(
+			ctx, "merge", repl, true /* skipShouldQueue */, false, /* async */
+		)
 		require.NoError(t, err)
 		require.NoError(t, processErr)
 		formattedTrace := trace.String()
@@ -1395,7 +1413,9 @@ func TestMergeQueueSeesLearnerOrJointConfig(t *testing.T) {
 		checkTransitioningOut := func() {
 			t.Helper()
 			store, repl := getFirstStoreReplica(t, tc.Server(0), scratchStartKey)
-			trace, processErr, err := store.ManuallyEnqueue(ctx, "merge", repl, true /* skipShouldQueue */)
+			trace, processErr, err := store.Enqueue(
+				ctx, "merge", repl, true /* skipShouldQueue */, false, /* async */
+			)
 			require.NoError(t, err)
 			require.NoError(t, processErr)
 			formattedTrace := trace.String()

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -1204,11 +1204,8 @@ func TestReplicateQueueShouldQueueNonVoter(t *testing.T) {
 		// because we know that it is the leaseholder (since it is the only voting
 		// replica).
 		store, repl := getFirstStoreReplica(t, tc.Server(0), scratchStartKey)
-		recording, processErr, err := store.ManuallyEnqueue(
-			ctx,
-			"replicate",
-			repl,
-			false, /* skipShouldQueue */
+		recording, processErr, err := store.Enqueue(
+			ctx, "replicate", repl, false /* skipShouldQueue */, false, /* async */
 		)
 		if err != nil {
 			log.Errorf(ctx, "err: %s", err.Error())

--- a/pkg/kv/kvserver/scanner.go
+++ b/pkg/kv/kvserver/scanner.go
@@ -35,6 +35,9 @@ type replicaQueue interface {
 	// the queue's inclusion criteria and the queue is not already
 	// too full, etc.
 	MaybeAddAsync(context.Context, replicaInQueue, hlc.ClockTimestamp)
+	// AddAsync adds the replica to the queue without checking if it meets
+	// inclusion criteria.
+	AddAsync(context.Context, replicaInQueue, float64)
 	// MaybeRemove removes the replica from the queue if it is present.
 	MaybeRemove(roachpb.RangeID)
 	// Name returns the name of the queue.

--- a/pkg/kv/kvserver/scanner_test.go
+++ b/pkg/kv/kvserver/scanner_test.go
@@ -159,6 +159,17 @@ func (tq *testQueue) MaybeAddAsync(
 	}
 }
 
+// NB: AddAsync on a testQueue is actually synchronous.
+func (tq *testQueue) AddAsync(ctx context.Context, replI replicaInQueue, prio float64) {
+	repl := replI.(*Replica)
+
+	tq.Lock()
+	defer tq.Unlock()
+	if index := tq.indexOf(repl.RangeID); index == -1 {
+		tq.ranges = append(tq.ranges, repl)
+	}
+}
+
 func (tq *testQueue) MaybeRemove(rangeID roachpb.RangeID) {
 	tq.Lock()
 	defer tq.Unlock()

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3415,7 +3415,7 @@ func (s *Store) Enqueue(
 		// NB: 1e6 is a placeholder for now. We want to use a high enough priority
 		// to ensure that these replicas are priority-ordered first.
 		//
-		// FIXME: Do something more accurate?
+		// TODO(aayush): Do something more accurate for the enqueue priority.
 		queue.AddAsync(ctx, repl, 1e6 /* prio */)
 		return nil, nil, nil
 	}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3360,12 +3360,14 @@ func (s *Store) AllocatorDryRun(ctx context.Context, repl *Replica) (tracing.Rec
 	return collectAndFinish(), nil
 }
 
-// ManuallyEnqueue runs the given replica through the requested queue,
-// returning all trace events collected along the way as well as the error
-// message returned from the queue's process method, if any.  Intended to help
-// power an admin debug endpoint.
-func (s *Store) ManuallyEnqueue(
-	ctx context.Context, queueName string, repl *Replica, skipShouldQueue bool,
+// Enqueue runs the given replica through the requested queue. If `async` is
+// specified, the replica is enqueued into the requested queue for asynchronous
+// processing and this method returns nothing. Otherwise, it returns all trace
+// events collected along the way as well as the error message returned from the
+// queue's process method, if any. Intended to help power the
+// server.decommissionMonitor and an admin debug endpoint.
+func (s *Store) Enqueue(
+	ctx context.Context, queueName string, repl *Replica, skipShouldQueue bool, async bool,
 ) (recording tracing.Recording, processError error, enqueueError error) {
 	ctx = repl.AnnotateCtx(ctx)
 
@@ -3376,12 +3378,14 @@ func (s *Store) ManuallyEnqueue(
 		return nil, nil, errors.Errorf("not enqueueing uninitialized replica %s", repl)
 	}
 
-	var queue queueImpl
+	var queue replicaQueue
+	var qImpl queueImpl
 	var needsLease bool
-	for _, replicaQueue := range s.scanner.queues {
-		if strings.EqualFold(replicaQueue.Name(), queueName) {
-			queue = replicaQueue.(queueImpl)
-			needsLease = replicaQueue.NeedsLease()
+	for _, q := range s.scanner.queues {
+		if strings.EqualFold(q.Name(), queueName) {
+			queue = q
+			qImpl = q.(queueImpl)
+			needsLease = q.NeedsLease()
 		}
 	}
 	if queue == nil {
@@ -3407,13 +3411,22 @@ func (s *Store) ManuallyEnqueue(
 		}
 	}
 
+	if async {
+		// NB: 1e6 is a placeholder for now. We want to use a high enough priority
+		// to ensure that these replicas are priority-ordered first.
+		//
+		// FIXME: Do something more accurate?
+		queue.AddAsync(ctx, repl, 1e6 /* prio */)
+		return nil, nil, nil
+	}
+
 	ctx, collectAndFinish := tracing.ContextWithRecordingSpan(
 		ctx, s.cfg.AmbientCtx.Tracer, fmt.Sprintf("manual %s queue run", queueName))
 	defer collectAndFinish()
 
 	if !skipShouldQueue {
 		log.Eventf(ctx, "running %s.shouldQueue", queueName)
-		shouldQueue, priority := queue.shouldQueue(ctx, s.cfg.Clock.NowAsClockTimestamp(), repl, confReader)
+		shouldQueue, priority := qImpl.shouldQueue(ctx, s.cfg.Clock.NowAsClockTimestamp(), repl, confReader)
 		log.Eventf(ctx, "shouldQueue=%v, priority=%f", shouldQueue, priority)
 		if !shouldQueue {
 			return collectAndFinish(), nil, nil
@@ -3421,7 +3434,7 @@ func (s *Store) ManuallyEnqueue(
 	}
 
 	log.Eventf(ctx, "running %s.process", queueName)
-	processed, processErr := queue.process(ctx, repl, confReader)
+	processed, processErr := qImpl.process(ctx, repl, confReader)
 	log.Eventf(ctx, "processed: %t (err: %v)", processed, processErr)
 	return collectAndFinish(), processErr, nil
 }

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -60,7 +60,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
-	raft "go.etcd.io/etcd/raft/v3"
+	"go.etcd.io/etcd/raft/v3"
 	"go.etcd.io/etcd/raft/v3/raftpb"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/time/rate"
@@ -3088,7 +3088,9 @@ func TestManuallyEnqueueUninitializedReplica(t *testing.T) {
 		StoreID:   tc.store.StoreID(),
 		ReplicaID: 7,
 	})
-	_, _, err := tc.store.ManuallyEnqueue(ctx, "replicaGC", repl, true)
+	_, _, err := tc.store.Enqueue(
+		ctx, "replicaGC", repl, true /* skipShouldQueue */, false, /* async */
+	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not enqueueing uninitialized replica")
 }

--- a/pkg/kv/kvserver/stores_base.go
+++ b/pkg/kv/kvserver/stores_base.go
@@ -64,7 +64,7 @@ func (s *baseStore) Enqueue(
 		return err
 	}
 
-	_, processErr, enqueueErr := store.ManuallyEnqueue(ctx, queue, repl, skipShouldQueue)
+	_, processErr, enqueueErr := store.Enqueue(ctx, queue, repl, skipShouldQueue, false /* async */)
 	if processErr != nil {
 		return processErr
 	}

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "config.go",
         "config_unix.go",
         "config_windows.go",
+        "decommision_monitor.go",
         "decommission.go",
         "doc.go",
         "drain.go",

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2873,7 +2873,7 @@ func (s *adminServer) enqueueRangeLocal(
 		queueName = "mvccGC"
 	}
 
-	traceSpans, processErr, err := store.ManuallyEnqueue(ctx, queueName, repl, req.SkipShouldQueue)
+	traceSpans, processErr, err := store.Enqueue(ctx, queueName, repl, req.SkipShouldQueue, req.Async)
 	if err != nil {
 		response.Details[0].Error = err.Error()
 		return response, nil

--- a/pkg/server/decommision_monitor.go
+++ b/pkg/server/decommision_monitor.go
@@ -1,0 +1,133 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+)
+
+// decommissionMonitor is responsible for telling other nodes in the system to
+// proactively enqueue the decommissioning node's ranges into their
+// replicateQueues for decommissioning.
+type decommissionMonitor struct {
+	log.AmbientContext
+	adminServer   *adminServer
+	stopper       *stop.Stopper
+	stores        *kvserver.Stores
+	nudgeInterval time.Duration
+
+	// sem is used to ensure that only one decommission monitor task is ever
+	// running.
+	sem    *quotapool.IntPool
+	logger log.EveryN
+}
+
+func newDecommissionMonitor(
+	ambient log.AmbientContext, server *adminServer, stopper *stop.Stopper, stores *kvserver.Stores,
+) *decommissionMonitor {
+	sem := quotapool.NewIntPool("decommission monitor", 1 /* capacity */)
+	dm := &decommissionMonitor{
+		AmbientContext: ambient,
+		adminServer:    server,
+		stopper:        stopper,
+		stores:         stores,
+		// TODO(aayush): This nudge interval should be configurable. We set a very
+		// high default for now, effectively disabling the nudging.
+		nudgeInterval: 1e6 * time.Minute,
+		sem:           sem,
+		logger:        log.Every(1 * time.Second),
+	}
+	dm.AddLogTag("decom-monitor", nil)
+
+	return dm
+}
+
+// start starts the decommission monitor async task that proactively enqueues
+// this node's ranges into their leaseholders' `replicateQueue`s. start is
+// idempotent in that subsequent calls to start don't spin up more async tasks.
+func (m *decommissionMonitor) start() error {
+	ctx := m.AnnotateCtx(context.Background())
+
+	// Ensure that only one decommission monitor task is ever started.
+	alloc, err := m.sem.TryAcquire(ctx, 1)
+	if err != nil {
+		return err
+	}
+	defer m.sem.Release(alloc)
+
+	log.Infof(ctx, "starting decommission monitor")
+	err = m.stopper.RunAsyncTask(ctx, "decommission-monitor", func(ctx context.Context) {
+		m.enqueueAllReplicas(ctx)
+
+		for {
+			select {
+			case <-time.After(m.nudgeInterval):
+				// TODO(aayush): This is a placeholder. We probably want to do something
+				// more verbose (i.e. get a trace) and synchronous when we hit our nudge
+				// interval.
+				m.enqueueAllReplicas(ctx)
+			case <-m.stopper.ShouldQuiesce():
+				return
+			}
+		}
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *decommissionMonitor) enqueueAllReplicas(ctx context.Context) {
+	if err := m.stores.VisitStores(func(s *kvserver.Store) error {
+		// For each range on this node, we try to enqueue all its replicas into
+		// their respective stores' replicateQueues. However, only the leaseholder
+		// will actually end up processing the range, and the rest of the stores
+		// will simply ignore this `EnqueueRangeRequest`.
+		//
+		// TODO(aayush): This races with the gossip propagation of this node's
+		// DECOMMISSIONING status, so it is possible that the ranges enqueued
+		// below aren't immediately acted upon by the replicateQueues of other
+		// nodes. Consider introducing a new AdminServer / StatusServer RPC that
+		// let's us ask a node for its (gossip-driven) understanding of a node's
+		// decommissioning status. We could then wait for the gossip update to
+		// propagate fully before we fire these EnqueueRangeRequests off.
+		s.VisitReplicas(func(r *kvserver.Replica) bool {
+			for _, repl := range r.Desc().Replicas().Descriptors() {
+				if _, err := m.adminServer.EnqueueRange(ctx, &serverpb.EnqueueRangeRequest{
+					NodeID:  repl.NodeID,
+					Queue:   "replicate",
+					RangeID: r.RangeID,
+					Async:   true,
+				}); err != nil {
+					if m.logger.ShouldLog() {
+						log.Errorf(
+							ctx, "failed to enqueue decommissioning replica for r%d: %s", r.RangeID, err,
+						)
+					}
+					return true
+				}
+			}
+			return true
+		})
+		return nil
+	}); err != nil {
+		// We're swallowing any errors above, so we shouldn't see any error
+		// bubbled up to here.
+		panic(err)
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -148,6 +148,8 @@ type Server struct {
 	// layer.
 	kvMemoryMonitor *mon.BytesMonitor
 
+	decommissionMonitor *decommissionMonitor
+
 	// The following fields are populated at start time, i.e. in `(*Server).Start`.
 	startTime time.Time
 }
@@ -792,6 +794,8 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	drain := newDrainServer(cfg.BaseConfig, stopper, grpcServer, sqlServer)
 	drain.setNode(node, nodeLiveness)
 
+	decomMonitor := newDecommissionMonitor(cfg.AmbientCtx, sAdmin, stopper, stores)
+
 	*lateBoundServer = Server{
 		nodeIDContainer:        nodeIDContainer,
 		cfg:                    cfg,
@@ -834,6 +838,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		externalStorageBuilder: externalStorageBuilder,
 		storeGrantCoords:       gcoords.Stores,
 		kvMemoryMonitor:        kvMemoryMonitor,
+		decommissionMonitor:    decomMonitor,
 	}
 
 	// Begin an async task to periodically purge old sessions in the system.web_sessions table.

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -785,6 +785,9 @@ message EnqueueRangeRequest {
   // If set, run the queue's process method without first checking whether the
   // replica should be processed by calling shouldQueue.
   bool skip_should_queue = 4;
+  // If set, the replica will be enqueued asynchronously and a successful
+  // response will be empty.
+  bool async = 5;
 }
 
 message EnqueueRangeResponse {

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_client_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_client_test.go
@@ -67,7 +67,9 @@ func TestBlockedKVSubscriberDisablesMerges(t *testing.T) {
 	})
 
 	{
-		trace, processErr, err := store.ManuallyEnqueue(ctx, "merge", repl, true /* skipShouldQueue */)
+		trace, processErr, err := store.Enqueue(
+			ctx, "merge", repl, true /* skipShouldQueue */, false, /* async */
+		)
 		require.NoError(t, err)
 		require.NoError(t, processErr)
 		require.NoError(t, testutils.MatchInOrder(trace.String(), `skipping merge: queue has been disabled`))
@@ -82,7 +84,9 @@ func TestBlockedKVSubscriberDisablesMerges(t *testing.T) {
 	})
 
 	{
-		trace, processErr, err := store.ManuallyEnqueue(ctx, "merge", repl, true /* skipShouldQueue */)
+		trace, processErr, err := store.Enqueue(
+			ctx, "merge", repl, true /* skipShouldQueue */, false, /* async */
+		)
 		require.NoError(t, err)
 		require.NoError(t, processErr)
 		require.Error(t, testutils.MatchInOrder(trace.String(), `skipping merge: queue has been disabled`))

--- a/pkg/sql/importer/import_into_test.go
+++ b/pkg/sql/importer/import_into_test.go
@@ -129,7 +129,7 @@ func TestProtectedTimestampsDuringImportInto(t *testing.T) {
 			require.NoError(t, err)
 			lhServer := tc.Server(int(l.Replica.NodeID) - 1)
 			s, repl := getFirstStoreReplica(t, lhServer, startKey)
-			trace, _, err := s.ManuallyEnqueue(ctx, "mvccGC", repl, skipShouldQueue)
+			trace, _, err := s.Enqueue(ctx, "mvccGC", repl, skipShouldQueue, false /* async */)
 			require.NoError(t, err)
 			fmt.Fprintf(&traceBuf, "%s\n", trace.String())
 		}


### PR DESCRIPTION
NOTE: This is a WIP. Don't review / look yet.

This commit introduces a `decommissionMonitor` that is responsible for a few
key things:

- When a node begins decommissioning, its `decommissionMonitor` is spun up,
which proactively tells other nodes in the system to enqueue its ranges into
the `replicateQueue`. This means that a decommission process no longer has the
worst case lower bound of 10 mins (i.e. the default replica scanner interval).

- In a future patch, this `decommissionMonitor` will selectively nudge some of
its straggling replicas' ranges to be re-enqueued into their leaseholder
store's replicateQueues. This will be done with the intention of collecting and
persisting (or dumping, initially) traces from these enqueue operations. This
should help reduce our time to RCA a slow decommission process.

Comparing the time taken to decommission a node out of a 6 node cluster
containing a 200-warehouse TPC-C dataset:

With this patch:
```
time rp ssh aayushs-test:1 -- "./cockroach node decommission --insecure --self";
...
roachprod ssh aayushs-test:1 --   0.07s user 0.07s system 0% cpu 59.125 total
```

Without this patch:
```
time rp ssh aayushs-test-wo:1 -- "./cockroach node decommission --insecure --self";
...
roachprod ssh aayushs-test-wo:1 --   0.17s user 0.15s system 0% cpu 3:47.34 total
```

Resolves https://github.com/cockroachdb/cockroach/issues/79453

Release note: None
