### PR TITLE
stopper: dump stacks after 2 minutes of hung quiesce

### DIFF
--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -590,6 +590,9 @@ func (s *Stopper) Quiesce(ctx context.Context) {
 	defer time.AfterFunc(5*time.Second, func() {
 		log.Infof(ctx, "quiescing...")
 	}).Stop()
+	defer time.AfterFunc(2*time.Minute, func() {
+		log.DumpStacks(ctx, "slow quiesce")
+	}).Stop()
 	defer s.Recover(ctx)
 
 	func() {


### PR DESCRIPTION
Quiesce should never take two minutes. If it does, the stacks are what
will allow you to figure out where the problem (bug) is.

I was compelled to add this while looking at a test failure in
`TestChangefeedBackfillObservability` where

> I220428 07:19:47.969264 208992 util/stop/stopper.go:591 â‹® [-] 92  quiescing...

was the last thing printed before TeamCity terminated the test suite
approximately 45m later.

Release note: None
