### PR TITLE
Added s390x support to Bazel's toolchain 

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -74,6 +74,10 @@ build:crosslinuxarm '--workspace_status_command=./build/bazelutil/stamp.sh aarch
 build:crosslinuxarm --config=crosslinuxarmbase
 build:crosslinuxarmbase --platforms=//build/toolchains:cross_linux_arm
 build:crosslinuxarmbase --config=cross
+build:crosslinuxs390x '--workspace_status_command=./build/bazelutil/stamp.sh s390x-unknown-linux-gnu'
+build:crosslinuxs390x --config=crosslinuxs390xbase
+build:crosslinuxs390xbase --platforms=//build/toolchains:cross_linux_s390x
+build:crosslinuxs390xbase --config=cross
 
 # Developer configurations. Add e.g. --config=devdarwinx86_64 to turn these on.
 # NB: This is consumed in `BUILD` files (see build/toolchains/BUILD.bazel).

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -458,11 +458,13 @@ toolchain_dependencies()
 register_toolchains(
     "//build/toolchains:cross_x86_64_linux_toolchain",
     "//build/toolchains:cross_x86_64_linux_arm_toolchain",
+    "//build/toolchains:cross_x86_64_s390x_toolchain",
     "//build/toolchains:cross_x86_64_macos_toolchain",
     "//build/toolchains:cross_x86_64_macos_arm_toolchain",
     "//build/toolchains:cross_x86_64_windows_toolchain",
     "//build/toolchains:cross_arm64_linux_toolchain",
     "//build/toolchains:cross_arm64_linux_arm_toolchain",
+    "//build/toolchains:cross_arm64_s390x_toolchain",
     "//build/toolchains:cross_arm64_windows_toolchain",
     "//build/toolchains:cross_arm64_macos_toolchain",
     "//build/toolchains:cross_arm64_macos_arm_toolchain",

--- a/c-deps/BUILD.bazel
+++ b/c-deps/BUILD.bazel
@@ -25,6 +25,7 @@ configure_make(
         ],
         "@io_bazel_rules_go//go/platform:linux_amd64": ["--host=x86_64-unknown-linux-gnu"],
         "@io_bazel_rules_go//go/platform:linux_arm64": ["--host=aarch64-unknown-linux-gnu"],
+        "@io_bazel_rules_go//go/platform:linux_s390x": ["--host=s390x-unknown-linux-gnu"],
         # NB: Normally host detection is handled by configure, but the version
         # of jemalloc we have vendored is pretty ancient and can't handle some
         # of the newer M1 Macs. This arm of the select() can probably be deleted


### PR DESCRIPTION
This PR is in reference to the issue https://github.com/cockroachdb/cockroach/issues/58676
It will enable s390x binaries to be built using Bazel's toolchain