### PR TITLE
kvserver: add raft.quota_pool.percent_used histogram

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3118,6 +3118,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 			}
 		}
 		if metrics.Leaseholder {
+			s.metrics.RaftQuotaPoolPercentUsed.RecordValue(metrics.QuotaPoolPercentUsed)
 			leaseHolderCount++
 			switch metrics.LeaseType {
 			case roachpb.LeaseNone:

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1532,6 +1532,10 @@ var charts = []sectionDescription{
 		Organization: [][]string{{ReplicationLayer, "Raft", "Overview"}},
 		Charts: []chartDescription{
 			{
+				Title:   "Quota Pool Utilization (0-100)",
+				Metrics: []string{"raft.quota_pool.percent_used"},
+			},
+			{
 				Title:   "Commands Count",
 				Metrics: []string{"raft.commandsapplied"},
 			},

--- a/pkg/ts/catalog/metrics.go
+++ b/pkg/ts/catalog/metrics.go
@@ -86,6 +86,7 @@ var histogramMetricsNames = map[string]struct{}{
 	"raft.process.handleready.latency":          {},
 	"raft.process.commandcommit.latency":        {},
 	"raft.process.logcommit.latency":            {},
+	"raft.quota_pool.percent_used":              {},
 	"raft.scheduler.latency":                    {},
 	"txnwaitqueue.pusher.wait_time":             {},
 	"txnwaitqueue.query.wait_time":              {},


### PR DESCRIPTION
This gives a good idea of the quota pool utilization across the stores,
and in particular quickly lets us determine whether any replicas are
throttling on the quota pool (with the limitation that the histogram
only updates every 10s, so we would only be guaranteed to observe
throttling if it isn't intermittent).

The below graph was taken on a five-node local roachprod cluster running

```
roachprod run local:1 -- ./cockroach workload run kv \
  --min-block-bytes 10000 --max-block-bytes 10000 --concurrency 1000 {pgurl}
```

<img width="966" alt="image" src="https://user-images.githubusercontent.com/5076964/165758155-f0d4eb22-47c4-4709-8a4b-7446ca8e08de.png">

Release note: None
