### PR TITLE
kvclient: fix gRPC stream leak in rangefeed client

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -388,6 +388,10 @@ func (ds *DistSender) singleRangeFeed(
 	eventCh chan<- *roachpb.RangeFeedEvent,
 	onRangeEvent onRangeEventCb,
 ) (hlc.Timestamp, error) {
+	// Ensure context is cancelled on all errors, to prevent gRPC stream leaks.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	args := roachpb.RangeFeedRequest{
 		Span: span,
 		Header: roachpb.Header{


### PR DESCRIPTION
When the DistSender rangefeed client received a `RangeFeedError` message
and propagated a retryable error up the stack, it would fail to close
the existing gRPC stream, causing stream/goroutine leaks.

Release note (bug fix): Fixed a goroutine leak when internal rangefeed
clients received certain kinds of retriable errors.