### PR TITLE
sql: add more tests for unknown database errors

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/database
+++ b/pkg/sql/logictest/testdata/logic_test/database
@@ -258,8 +258,14 @@ SET sql_safe_updates=false;
 statement ok
 DROP DATABASE db1;
 
-statement error pq: database "db1" does not exist
+statement error pgcode 3D000 pq: database "db1" does not exist
 SELECT * FROM crdb_internal.session_variables;
+
+statement error pgcode 3D000 pq: database "db1" does not exist
+SELECT * FROM pg_catalog.pg_attribute;
+
+statement error pgcode 3D000 pq: database "db1" does not exist
+SELECT * FROM unknown_table;
 
 subtest missing-schema-error-69713
 


### PR DESCRIPTION
When connected to an non-existent database in versions 21.1 and prior,
querying catalog tables resulted in an unknown database error code
(`3D000`), but querying non-catalog tables resulted in an unknown table
error code (`42P01`). In 21.2 we made the error codes the same for both
cases (`3D000`). I couldn't find any tests that verified this behavior,
so this commit adds them.

Release note: None