### PR TITLE
[prototype]: don't omit system tenant prefix in SQLCodec

### DIFF
--- a/pkg/keys/sql.go
+++ b/pkg/keys/sql.go
@@ -21,7 +21,7 @@ import (
 
 // MakeTenantPrefix creates the key prefix associated with the specified tenant.
 func MakeTenantPrefix(tenID roachpb.TenantID) roachpb.Key {
-	if tenID == roachpb.SystemTenantID {
+	if false && tenID == roachpb.SystemTenantID {
 		return nil
 	}
 	return encoding.EncodeUvarintAscending(TenantPrefix, tenID.ToUint64())
@@ -81,6 +81,8 @@ func MakeSQLCodec(tenID roachpb.TenantID) SQLCodec {
 	}
 }
 
+var sysTenantPrefix = MakeTenantPrefix(roachpb.SystemTenantID)
+
 // SystemSQLCodec is a SQL key codec for the system tenant.
 var SystemSQLCodec = MakeSQLCodec(roachpb.SystemTenantID)
 
@@ -91,7 +93,8 @@ var TODOSQLCodec = MakeSQLCodec(roachpb.SystemTenantID)
 
 // ForSystemTenant returns whether the encoder is bound to the system tenant.
 func (e sqlEncoder) ForSystemTenant() bool {
-	return len(e.TenantPrefix()) == 0
+	// return len(e.TenantPrefix()) == 0
+	return e.TenantPrefix().Equal(sysTenantPrefix)
 }
 
 // TenantPrefix returns the key prefix used for the tenants's data.


### PR DESCRIPTION
```
roachprod create -n 5 local
roachprod start local
roachprod sql local:1
// Can do basic things (but note the pretty printing seems broken,
probably there is some hardcoded knowledge of the system tenant having
no prefix in `keys.PrettyPrint`)
root@localhost:26257/defaultdb> select start_key, start_pretty, end_pretty from crdb_internal.ranges_no_leases;
      start_key     |         start_pretty          |          end_pretty
--------------------+-------------------------------+--------------------------------
                    | /Min                          | /System/NodeLiveness
  \x04\x00liveness- | /System/NodeLiveness          | /System/NodeLivenessMax
  \x04\x00liveness. | /System/NodeLivenessMax       | /System/tsd
  \x04tsd           | /System/tsd                   | /System/"tse"
  \x04tse           | /System/"tse"                 | /Table/SystemConfigSpan/Start
  \xfe\x89\x88      | /Table/SystemConfigSpan/Start | /Table/!NULL/1/11
  \xfe\x89\x93      | /Table/!NULL/1/11             | /Table/!NULL/1/12
  \xfe\x89\x94      | /Table/!NULL/1/12             | /Table/!NULL/1/13
[...]
  \xfe\x89\xb6      | /Table/!NULL/1/46             | /Table/!NULL/1/47
  \xfe\x89\xb7      | /Table/!NULL/1/47             | /Table/!NULL/1/50
  \xfe\x89\xba      | /Table/!NULL/1/50             | /Max
```

At some point (within a minute) nodes will crash with:

> F220428 20:09:35.884296 173 kv/kvserver/reports/constraint_stats_report.go:397 ⋮ [n1,replication-reporter] 261  unexpected failure to compute max object id: ‹descriptor table not found in system config of 0 values›

Release note: None
