### PR TITLE
util: create HottestRangesAggregated

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -441,6 +441,7 @@ ALL_TESTS = [
     "//pkg/util/goschedstats:goschedstats_test",
     "//pkg/util/grpcutil:grpcutil_test",
     "//pkg/util/hlc:hlc_test",
+    "//pkg/util/hotranges:hotranges_test",
     "//pkg/util/httputil:httputil_test",
     "//pkg/util/humanizeutil:humanizeutil_test",
     "//pkg/util/interval/generic:generic_test",

--- a/pkg/util/hotranges/BUILD.bazel
+++ b/pkg/util/hotranges/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "hotranges",
+    srcs = ["hot_ranges.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/util/hotranges",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "hotranges_test",
+    size = "small",
+    srcs = ["hot_ranges_test.go"],
+    embed = [":hotranges"],
+    deps = [
+        "//pkg/util/timeutil",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/util/hotranges/hot_ranges.go
+++ b/pkg/util/hotranges/hot_ranges.go
@@ -1,0 +1,133 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package hotranges
+
+import "sort"
+
+// SampleKeySpan defines the structure of the key spans that are received by HottestKeySpansAggregated.
+type SampleKeySpan struct {
+	qps      float64
+	startKey string
+	endKey   string
+}
+
+// HottestKeySpansAggregated is the main function which implements key span aggregation
+// for historical hot ranges.
+func HottestKeySpansAggregated(keySpans []SampleKeySpan, budget int) []SampleKeySpan {
+
+	// If we are under budget simply return the key spans.
+	if len(keySpans) <= budget {
+		return keySpans
+	}
+	var nonZeroKeySpans []SampleKeySpan
+	// Filter out all zeroed qps key spans first to see if we can get at or under the budget.
+	for _, r := range keySpans {
+		if r.qps != 0 {
+			nonZeroKeySpans = append(nonZeroKeySpans, r)
+		}
+	}
+	if len(nonZeroKeySpans) <= budget {
+		return nonZeroKeySpans
+	}
+
+	// Group the non zero key spans we can potentially aggregate.
+	adjacentKeySpans := make([][]SampleKeySpan, 0)
+	var prevEndKey string
+	groupIdx := -1
+	for _, r := range nonZeroKeySpans {
+		// If starting out or the start key doesn't match the previous end key then
+		// create a new group.
+		if prevEndKey == "" || r.startKey != prevEndKey {
+			groupIdx++
+			adjacentKeySpans = append(adjacentKeySpans, make([]SampleKeySpan, 0))
+		}
+		adjacentKeySpans[groupIdx] = append(adjacentKeySpans[groupIdx], r)
+		prevEndKey = r.endKey
+	}
+
+	// Order the groups by lowest QPS.
+	sort.Slice(adjacentKeySpans, func(i, j int) bool {
+		var iQPS float64
+		var jQPS float64
+		for _, v := range adjacentKeySpans[i] {
+			iQPS += v.qps
+		}
+		iQPS /= float64(len(adjacentKeySpans[i]))
+		for _, v := range adjacentKeySpans[j] {
+			jQPS += v.qps
+		}
+		jQPS /= float64(len(adjacentKeySpans[j]))
+		return iQPS < jQPS
+	})
+	aggregatedKeySpans := findAggregatedKeySpans(adjacentKeySpans, budget, len(nonZeroKeySpans))
+	// If we exhausted all candidates and are still over budget, then take the hottest key spans within budget.
+	if len(aggregatedKeySpans) > budget {
+		sort.Slice(aggregatedKeySpans, func(i, j int) bool {
+			return aggregatedKeySpans[i].qps > aggregatedKeySpans[j].qps
+		})
+		return aggregatedKeySpans[:budget]
+	}
+	return aggregatedKeySpans
+}
+
+func findAggregatedKeySpans(
+	groupedKeySpans [][]SampleKeySpan, targetBudget int, currentBudget int,
+) []SampleKeySpan {
+	aggregatedKeySpans := make([]SampleKeySpan, 0)
+	for _, group := range groupedKeySpans {
+		// If we already meet the budget or have a case where the slice is too small and the median would be equal to the mean,
+		// simply append the current slice to the aggregatedKeySpans slice.
+		if currentBudget <= targetBudget || len(group) == 1 || len(group) == 2 {
+			aggregatedKeySpans = append(aggregatedKeySpans, group...)
+			continue
+		}
+		// Calculate the mean qps of the group.
+		var meanQPS float64
+		for _, v := range group {
+			meanQPS += v.qps
+		}
+		meanQPS /= float64(len(group))
+		// See if it is a valid group to aggregate, otherwise just add the group un-aggregated.
+		if shouldMergeAdjacentKeySpans(group, meanQPS) {
+			aggregatedKeySpan := SampleKeySpan{
+				qps:      meanQPS,
+				startKey: group[0].startKey,
+				endKey:   group[len(group)-1].endKey,
+			}
+			aggregatedKeySpans = append(aggregatedKeySpans, aggregatedKeySpan)
+			// Reduce the current budget by number of key spans in the group + 1 since we add a new resulting key span.
+			currentBudget = currentBudget - len(group) + 1
+		} else {
+			aggregatedKeySpans = append(aggregatedKeySpans, group...)
+		}
+	}
+	return aggregatedKeySpans
+}
+
+// shouldMergeAdjacentKeySpans is a helper function which determines whether the given
+// mean QPS of the candidate key spans group is less than that groups' median QPS.
+func shouldMergeAdjacentKeySpans(candidateKeySpans []SampleKeySpan, meanQPS float64) bool {
+	arrLen := len(candidateKeySpans)
+	copyCandidateKeySpans := make([]SampleKeySpan, len(candidateKeySpans))
+	copy(copyCandidateKeySpans, candidateKeySpans)
+	// Sort the key spans by qps.
+	sort.Slice(copyCandidateKeySpans, func(i, j int) bool {
+		return copyCandidateKeySpans[i].qps < copyCandidateKeySpans[j].qps
+	})
+	// Median calculation for even length array of key spans.
+	if arrLen%2 == 0 {
+		medianQPS := (copyCandidateKeySpans[arrLen/2].qps + copyCandidateKeySpans[(arrLen/2)-1].qps) / 2
+		return meanQPS < medianQPS
+	}
+	// Median calculation for odd length array of key spans.
+	medianCandidate := copyCandidateKeySpans[(arrLen-1)/2]
+	return meanQPS < medianCandidate.qps
+}

--- a/pkg/util/hotranges/hot_ranges_test.go
+++ b/pkg/util/hotranges/hot_ranges_test.go
@@ -1,0 +1,243 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package hotranges
+
+import (
+	"math/rand"
+	"strconv"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
+)
+
+// constructHotKeySpans generates a slice of random SampleKeySpans
+// based on the inputted size. It should be used for performance testing.
+func constructHotKeySpans(amount int) []SampleKeySpan {
+	hotKeySpans := make([]SampleKeySpan, 0)
+	key := 0
+	for len(hotKeySpans) < amount {
+		qps := rand.Float64() * 100
+		if qps > 50 {
+			key++
+		}
+		hotKeySpans = append(hotKeySpans, SampleKeySpan{
+			qps:      qps,
+			startKey: strconv.Itoa(key),
+			endKey:   strconv.Itoa(key + 1),
+		})
+		key++
+	}
+	return hotKeySpans
+}
+
+func TestShouldMergeAdjacentKeySpans(t *testing.T) {
+	candidate := []SampleKeySpan{
+		{
+			qps:      20,
+			startKey: "1",
+			endKey:   "2",
+		},
+		{
+			qps:      10,
+			startKey: "2",
+			endKey:   "3",
+		},
+		{
+			qps:      30,
+			startKey: "3",
+			endKey:   "4",
+		},
+	}
+	// Verify odd calculation.
+	require.Equal(t, false, shouldMergeAdjacentKeySpans(candidate, 21))
+	require.Equal(t, true, shouldMergeAdjacentKeySpans(candidate, 19))
+
+	candidate = append(candidate, SampleKeySpan{qps: 15, startKey: "4", endKey: "5"})
+
+	// Verify even calculation.
+	require.Equal(t, false, shouldMergeAdjacentKeySpans(candidate, 18))
+	require.Equal(t, false, shouldMergeAdjacentKeySpans(candidate, 19))
+	// Ensure the original order of slice is maintained
+	require.Equal(t, SampleKeySpan{qps: 20, startKey: "1", endKey: "2"}, candidate[0])
+}
+
+func TestFindAggregatedKeySpans(t *testing.T) {
+	keySpans := []SampleKeySpan{
+		{
+			qps:      35,
+			startKey: "1",
+			endKey:   "2",
+		},
+		{
+			qps:      30,
+			startKey: "2",
+			endKey:   "3",
+		},
+		{
+			qps:      20,
+			startKey: "3",
+			endKey:   "4",
+		},
+		{
+			qps:      50,
+			startKey: "5",
+			endKey:   "6",
+		},
+		{
+			qps:      60,
+			startKey: "6",
+			endKey:   "7",
+		},
+		{
+			qps:      10,
+			startKey: "7",
+			endKey:   "8",
+		},
+		{
+			qps:      65,
+			startKey: "9",
+			endKey:   "10",
+		},
+		{
+			qps:      90,
+			startKey: "10",
+			endKey:   "11",
+		},
+		{
+			qps:      75,
+			startKey: "12",
+			endKey:   "13",
+		},
+	}
+	group := [][]SampleKeySpan{
+		{
+			keySpans[0],
+			keySpans[1],
+			keySpans[2],
+		},
+		{
+			keySpans[3],
+			keySpans[4],
+			keySpans[5],
+		},
+		{
+			keySpans[8],
+		},
+		{
+			keySpans[6],
+			keySpans[7],
+		},
+	}
+	resKeySpans := findAggregatedKeySpans(group, 5, len(keySpans))
+	// Verify the ideal case where key spans can be aggregated to at or under the budget.
+	require.Equal(t, 5, len(resKeySpans))
+	require.Equal(t, []SampleKeySpan{
+		{
+			qps:      float64(85) / float64(3),
+			startKey: "1",
+			endKey:   "4",
+		},
+		{
+			qps:      float64(40),
+			startKey: "5",
+			endKey:   "8",
+		},
+		keySpans[8],
+		keySpans[6],
+		keySpans[7],
+	}, resKeySpans)
+	// Verify the non-ideal case where partially aggregated but ran out of valid canididates to merge.
+	resKeySpans = findAggregatedKeySpans(group, 4, len(keySpans))
+	require.Equal(t, 5, len(resKeySpans))
+
+	group[0][1].qps = 25
+	group[1][0].qps = 35
+
+	// Verify worst case where no aggregation occurs due to all invalid candidates.
+	resKeySpans = findAggregatedKeySpans(group, 5, len(keySpans))
+	require.Equal(t, 9, len(resKeySpans))
+}
+
+func TestHottestKeySpansAggregated(t *testing.T) {
+	keySpans := []SampleKeySpan{
+		{
+			qps:      35,
+			startKey: "1",
+			endKey:   "2",
+		},
+		{
+			qps:      30,
+			startKey: "2",
+			endKey:   "3",
+		},
+		{
+			qps:      20,
+			startKey: "3",
+			endKey:   "4",
+		},
+		{
+			qps:      50,
+			startKey: "5",
+			endKey:   "6",
+		},
+		{
+			qps:      60,
+			startKey: "6",
+			endKey:   "7",
+		},
+		{
+			qps:      10,
+			startKey: "7",
+			endKey:   "8",
+		},
+		{
+			qps:      65,
+			startKey: "9",
+			endKey:   "10",
+		},
+		{
+			qps:      90,
+			startKey: "10",
+			endKey:   "11",
+		},
+		{
+			qps:      75,
+			startKey: "12",
+			endKey:   "13",
+		},
+	}
+	// Verify case where key spans are within budget and do not need to be aggregated.
+	resKeySpans := HottestKeySpansAggregated(keySpans, 10)
+	require.Equal(t, keySpans, resKeySpans)
+
+	// Verify case where returned key spans are still over budget and we return by highest
+	// qps up to the budget.
+	resKeySpans = HottestKeySpansAggregated(keySpans, 4)
+	require.Equal(t, []SampleKeySpan{
+		keySpans[7],
+		keySpans[8],
+		keySpans[6],
+		{
+			qps:      float64(40),
+			startKey: "5",
+			endKey:   "8",
+		},
+	}, resKeySpans)
+
+	//Verify performance.
+	// TODO @santamaura: Set to proper value for testing after optimization.
+	keySpans = constructHotKeySpans(100000)
+	tBegin := timeutil.Now()
+	HottestKeySpansAggregated(keySpans, 1000)
+	latency := timeutil.Since(tBegin).Seconds()
+	require.True(t, latency < 60)
+}


### PR DESCRIPTION
This patch introduces the function that will aggregate
ranges based on the provided budget. If the budget cannot be
reached, ranges will be aggregated for all valid candidate
groups and prioritize highest qps values.

Release note: None

Performance profiler for aggregating 100k -> 1k:
![Screen Shot 2022-05-04 at 10 58 16 AM](https://user-images.githubusercontent.com/17861665/166715363-b06d03a0-47b4-4255-b828-1cde953cfa9b.png)

