### PR TITLE
server: allow users with VIEWACTIVITY role access Hot ranges page

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2316,7 +2316,7 @@ type hotRangeReportMeta struct {
 func (s *statusServer) HotRangesV2(
 	ctx context.Context, req *serverpb.HotRangesRequest,
 ) (*serverpb.HotRangesResponseV2, error) {
-	if _, err := s.privilegeChecker.requireAdminUser(ctx); err != nil {
+	if err := s.privilegeChecker.requireViewActivityOrViewActivityRedactedPermission(ctx); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Initially, only users with admin role can access Hot ranges page
in Db Console.
Now, users with VIEWACTIVITY and VIEWACTIVITYREDACTED roles access
Hot Ranges page.

Release note: None

Resolves: #79953