### PR TITLE
sql: skip TestTenantStatementTimeoutAdmissionQueueCancelation

### DIFF
--- a/pkg/sql/run_control_test.go
+++ b/pkg/sql/run_control_test.go
@@ -740,6 +740,7 @@ func getUserConn(t *testing.T, username string, server serverutils.TestServerInt
 // main statement with a timeout is blocked.
 func TestTenantStatementTimeoutAdmissionQueueCancelation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 78494, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	skip.UnderStress(t, "times out under stress")


### PR DESCRIPTION
Refs: #78494

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None