### PR TITLE
ui: Improve UX when jobs page times out

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/delayed/delayed.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/delayed/delayed.tsx
@@ -1,0 +1,33 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import moment from "moment";
+import React, { useState, useEffect } from "react";
+
+type Props = {
+  children: React.ReactElement;
+  delay?: moment.Duration;
+};
+
+export const Delayed = ({
+  children,
+  delay = moment.duration(10, "s"),
+}: Props): React.ReactElement => {
+  const [isShown, setIsShown] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsShown(true);
+    }, delay.asMilliseconds());
+    return () => clearTimeout(timer);
+  }, [delay]);
+
+  return isShown ? children : null;
+};

--- a/pkg/ui/workspaces/cluster-ui/src/delayed/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/delayed/index.ts
@@ -1,0 +1,11 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+export * from "./delayed";

--- a/pkg/ui/workspaces/cluster-ui/src/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/index.ts
@@ -19,6 +19,7 @@ export * from "./common";
 export * from "./databaseDetailsPage";
 export * from "./databaseTablePage";
 export * from "./databasesPage";
+export * from "./delayed";
 export * from "./downloadFile";
 export * from "./dropdown";
 export * from "./empty";

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.fixture.ts
@@ -21,7 +21,7 @@ import {
   CancelSessionRequestMessage,
 } from "src/api/terminateQueryApi";
 
-import Status = cockroach.server.serverpb.Session.Status;
+const Status = cockroach.server.serverpb.Session.Status;
 
 const history = createMemoryHistory({ initialEntries: ["/sessions"] });
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -13,6 +13,7 @@ import { RouteComponentProps } from "react-router-dom";
 import { isNil, merge } from "lodash";
 import classNames from "classnames/bind";
 import { getValidErrorsList, Loading } from "src/loading";
+import { Delayed } from "src/delayed";
 import { PageConfig, PageConfigItem } from "src/pageConfig";
 import {
   handleSortSettingFromQueryString,
@@ -78,6 +79,7 @@ import { commonStyles } from "../common";
 import { flattenTreeAttributes, planNodeToString } from "../statementDetails";
 import { isSelectedColumn } from "src/columnsSelector/utils";
 import { StatementViewType } from "./statementPageTypes";
+import moment from "moment";
 const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
 
@@ -617,16 +619,14 @@ export class StatementsPage extends React.Component<
       : unique(nodes.map(node => nodeRegions[node.toString()])).sort();
     const { filters, activeFilters } = this.state;
 
-    const timeNow = new Date();
-    const timeWaitingResponse =
-      (timeNow.getTime() - this.state.startRequest.getTime()) / 1000;
     const longLoadingMessage = isNil(this.props.statements) &&
-      timeWaitingResponse > 2 &&
       isNil(getValidErrorsList(this.props.statementsError)) && (
-        <InlineAlert
-          intent="info"
-          title="If the selected time period contains a large amount of data, this page might take a few minutes to load."
-        />
+        <Delayed delay={moment.duration(2, "s")}>
+          <InlineAlert
+            intent="info"
+            title="If the selected time period contains a large amount of data, this page might take a few minutes to load."
+          />
+        </Delayed>
       );
 
     return (

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -39,6 +39,7 @@ import { merge } from "lodash";
 import { unique, syncHistory } from "src/util";
 import { EmptyTransactionsPlaceholder } from "./emptyTransactionsPlaceholder";
 import { Loading } from "../loading";
+import { Delayed } from "../delayed";
 import { PageConfig, PageConfigItem } from "../pageConfig";
 import { Search } from "../search";
 import {
@@ -67,6 +68,7 @@ import {
 import { InlineAlert } from "@cockroachlabs/ui-components";
 import { TransactionViewType } from "./transactionsPageTypes";
 import { isSelectedColumn } from "../columnsSelector/utils";
+import moment from "moment";
 
 type IStatementsResponse = protos.cockroach.server.serverpb.IStatementsResponse;
 
@@ -375,10 +377,12 @@ export class TransactionsPage extends React.Component<
       internal_app_name_prefix,
     );
     const longLoadingMessage = !this.props?.data && (
-      <InlineAlert
-        intent="info"
-        title="If the selected time period contains a large amount of data, this page might take a few minutes to load."
-      />
+      <Delayed delay={moment.duration(2, "s")}>
+        <InlineAlert
+          intent="info"
+          title="If the selected time period contains a large amount of data, this page might take a few minutes to load."
+        />
+      </Delayed>
     );
 
     return (

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -192,6 +192,7 @@ const jobsReducerObj = new KeyedCachedDataReducer(
   "jobs",
   jobsRequestKey,
   moment.duration(10, "s"),
+  moment.duration(1, "minute"),
 );
 export const refreshJobs = jobsReducerObj.refresh;
 

--- a/pkg/ui/workspaces/db-console/src/views/jobs/index.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/index.spec.tsx
@@ -16,7 +16,7 @@ import { JobsTable, JobsTableProps } from "src/views/jobs/index";
 import {
   allJobsFixture,
   retryRunningJobFixture,
-} from "src/views/jobs/jobTable.fixture";
+} from "src/views/jobs/jobsTable.fixture";
 import { refreshJobs } from "src/redux/apiReducers";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/pkg/ui/workspaces/db-console/src/views/jobs/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/index.tsx
@@ -20,7 +20,8 @@ import { CachedDataReducerState } from "src/redux/cachedDataReducer";
 import { LocalSetting } from "src/redux/localsettings";
 import { AdminUIState } from "src/redux/state";
 import Dropdown, { DropdownOption } from "src/views/shared/components/dropdown";
-import { Loading, util, SortSetting } from "@cockroachlabs/cluster-ui";
+import { Loading, Delayed, util, SortSetting } from "@cockroachlabs/cluster-ui";
+import { InlineAlert } from "@cockroachlabs/ui-components";
 import {
   PageConfig,
   PageConfigItem,
@@ -234,6 +235,8 @@ export class JobsTable extends React.Component<JobsTableProps> {
   };
 
   render() {
+    const isLoading = !this.props.jobs || !this.props.jobs.data;
+    const error = this.props.jobs && this.props.jobs.lastError;
     return (
       <div className="jobs-page">
         <Helmet title="Jobs" />
@@ -268,9 +271,9 @@ export class JobsTable extends React.Component<JobsTableProps> {
         </div>
         <section className="section">
           <Loading
-            loading={!this.props.jobs || !this.props.jobs.data}
+            loading={isLoading}
             page={"jobs"}
-            error={this.props.jobs && this.props.jobs.lastError}
+            error={error}
             render={() => (
               <JobTable
                 isUsedFilter={
@@ -282,6 +285,14 @@ export class JobsTable extends React.Component<JobsTableProps> {
               />
             )}
           />
+          {isLoading && !error && (
+            <Delayed delay={moment.duration(2, "s")}>
+              <InlineAlert
+                intent="info"
+                title="If the Jobs table contains a large amount of data, this page might take a while to load. To reduce the amount of data, try filtering the table."
+              />
+            </Delayed>
+          )}
         </section>
       </div>
     );

--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobsTable.fixture.ts
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobsTable.fixture.ts
@@ -1,4 +1,4 @@
-// Copyright 2021 The Cockroach Authors.
+// Copyright 2022 The Cockroach Authors.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.
@@ -8,13 +8,15 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { JobTableProps } from "./jobTable";
+import { JobsTableProps } from "src/views/jobs/index";
 import moment from "moment";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
 import { cockroach } from "src/js/protos";
 import JobsResponse = cockroach.server.serverpb.JobsResponse;
 import Job = cockroach.server.serverpb.IJobResponse;
 import Long from "long";
+import { createMemoryHistory } from "history";
+import { jobsTimeoutErrorMessage } from "src/util/api";
 
 const defaultJobProperties = {
   username: "root",
@@ -270,13 +272,52 @@ export const allJobsFixture = [
   revertFailedJobFixture,
 ];
 
-const getJobTableProps = (jobs: Array<Job>): JobTableProps => ({
+const history = createMemoryHistory({ initialEntries: ["/statements"] });
+
+const staticJobProps: Pick<
+  JobsTableProps,
+  | "history"
+  | "location"
+  | "match"
+  | "sort"
+  | "status"
+  | "show"
+  | "type"
+  | "setSort"
+  | "setStatus"
+  | "setShow"
+  | "setType"
+  | "refreshJobs"
+> = {
+  history,
+  location: {
+    pathname: "/jobs",
+    search: "",
+    hash: "",
+    state: null,
+  },
+  match: {
+    path: "/jobs",
+    url: "/jobs",
+    isExact: true,
+    params: "{}",
+  },
   sort: {
     columnTitle: "creationTime",
     ascending: false,
   },
-  isUsedFilter: false,
-  setSort: (() => {}) as any,
+  status: "",
+  show: "50",
+  type: 0,
+  setSort: () => {},
+  setStatus: () => {},
+  setShow: () => {},
+  setType: () => {},
+  refreshJobs: () => null,
+};
+
+const getJobsTableProps = (jobs: Array<Job>): JobsTableProps => ({
+  ...staticJobProps,
   jobs: {
     inFlight: false,
     valid: false,
@@ -291,5 +332,27 @@ const getJobTableProps = (jobs: Array<Job>): JobTableProps => ({
   },
 });
 
-export const withData: JobTableProps = getJobTableProps(allJobsFixture);
-export const empty: JobTableProps = getJobTableProps([]);
+export const withData: JobsTableProps = getJobsTableProps(allJobsFixture);
+export const empty: JobsTableProps = getJobsTableProps([]);
+export const loading: JobsTableProps = {
+  ...staticJobProps,
+  jobs: {
+    inFlight: true,
+    valid: false,
+    requestedAt: moment(
+      "Mon Oct 18 2021 14:01:45 GMT-0400 (Eastern Daylight Time)",
+    ),
+  },
+};
+
+export const error: JobsTableProps = {
+  ...staticJobProps,
+  jobs: {
+    inFlight: false,
+    valid: false,
+    requestedAt: moment(
+      "Mon Oct 18 2021 14:01:45 GMT-0400 (Eastern Daylight Time)",
+    ),
+    lastError: new Error(jobsTimeoutErrorMessage),
+  },
+};

--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobsTable.stories.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobsTable.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021 The Cockroach Authors.
+// Copyright 2022 The Cockroach Authors.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.
@@ -11,10 +11,12 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import { withRouterDecorator } from "src/util/decorators";
 
-import { JobTable } from "./jobTable";
-import { withData, empty } from "./jobTable.fixture";
+import { JobsTable } from "./index";
+import { withData, empty, loading, error } from "./jobsTable.fixture";
 
-storiesOf("JobTable", module)
+storiesOf("JobsTable", module)
   .addDecorator(withRouterDecorator)
-  .add("with data", () => <JobTable {...withData} />)
-  .add("empty", () => <JobTable {...empty} />);
+  .add("With data", () => <JobsTable {...withData} />)
+  .add("Empty", () => <JobsTable {...empty} />)
+  .add("Loading; with delayed message", () => <JobsTable {...loading} />)
+  .add("Timeout error", () => <JobsTable {...error} />);


### PR DESCRIPTION
Partially fixes #66607 and #71343.

This commit:
- Increases the Jobs page API timeout from 30 seconds to 1 minute.
- Adds an informational message after 2 seconds of loading indicating that
  loading might take a while, and that filtering can help.
- Improves the timeout error message, and suggests that filtering can help.
- Adds a more informative console.error, that will log to DataDog after the Jobs
  page is added to CC Console.
- Moves stories to the parent `JobsTable` component and adds stories for loading
  and error states.

Unrelated to the Jobs page, this commit also:
- Adds a previously intended but missing 2 second delay to the information
  message in the Transactions table, to make it similar to that of the
  Statements table.
- Fixes broken cluster-ui storybook.

Release note (ui): Previously, when the Jobs page timed out, it would have the
message "Promise timed out after 30000 ms". Now, it has a more helpful error
message, and an information message that appears after 2 seconds of loading and
indicates that the loading might take a while.

Before:
![image](https://user-images.githubusercontent.com/91907326/165836334-800c7c8f-0705-4b2d-9edf-c1c66d2b69a0.png)

After:
First 2 seconds
<img width="1074" alt="image" src="https://user-images.githubusercontent.com/91907326/165841393-0fc4454d-cfb2-4e2d-80f1-9313f1570570.png">

2s - 1min
<img width="1090" alt="image" src="https://user-images.githubusercontent.com/91907326/165841424-8bf0f991-cf0e-486c-9126-a3c5a24cdf31.png">

After 1 min timeout
<img width="1088" alt="image" src="https://user-images.githubusercontent.com/91907326/165841758-848ea80f-4164-48e0-b6e1-27aed0daba7f.png">
