### PR TITLE
opt: break memo's dependence on builtins

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -321,6 +321,7 @@ ALL_TESTS = [
     "//pkg/sql/opt/invertedexpr:invertedexpr_test",
     "//pkg/sql/opt/invertedidx:invertedidx_test",
     "//pkg/sql/opt/lookupjoin:lookupjoin_test",
+    "//pkg/sql/opt/memo:memo_disallowed_imports_test",
     "//pkg/sql/opt/memo:memo_test",
     "//pkg/sql/opt/norm:norm_test",
     "//pkg/sql/opt/opbench:opbench_test",

--- a/pkg/sql/opt/memo/BUILD.bazel
+++ b/pkg/sql/opt/memo/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//pkg/testutils/buildutil:buildutil.bzl", "disallowed_imports_test")
 
 go_library(
     name = "memo",
@@ -35,7 +36,6 @@ go_library(
         "//pkg/sql/opt/props/physical",
         "//pkg/sql/rowenc/keyside",
         "//pkg/sql/rowenc/valueside",
-        "//pkg/sql/sem/builtins",
         "//pkg/sql/sem/cast",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
@@ -116,4 +116,9 @@ genrule(
     """,
     exec_tools = ["//pkg/sql/opt/optgen/cmd/optgen"],
     visibility = ["//visibility:public"],
+)
+
+disallowed_imports_test(
+    "memo",
+    ["//pkg/sql/sem/builtins"],
 )

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -104,6 +105,12 @@ type Factory struct {
 // onMaxConstructorStackDepthExceeded method is called. This can result in an
 // expression that is not fully optimized.
 const maxConstructorStackDepth = 10_000
+
+// Injecting this builtins dependency in the init function allows the memo
+// package to access builtin properties without importing the builtins package.
+func init() {
+	memo.GetBuiltinProperties = builtins.GetBuiltinProperties
+}
 
 // Init initializes a Factory structure with a new, blank memo structure inside.
 // This must be called before the factory can be used (or reused).


### PR DESCRIPTION
This commit breaks the `memo` packages dependence on the `builtins`
package so that they can be compiled concurrently. Optimizer packages
are no longer on the critical path, for now.

Informs #79357

Release note: None