### PR TITLE
ui: Use liveness info to populate decommissioned node lists

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/nodes.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/nodes.ts
@@ -303,6 +303,9 @@ function isNoConnection(
 
 // nodeDisplayNameByIDSelector provides a unique, human-readable display name
 // for each node.
+
+// This function will never be passed decommissioned nodes because
+// #56529 removed a node's status entry once it's decommissioned.
 export const nodeDisplayNameByIDSelector = createSelector(
   nodeStatusesSelector,
   livenessStatusByNodeIDSelector,

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodesOverview/index.tsx
@@ -49,6 +49,8 @@ import {
   VersionTooltip,
   StatusTooltip,
 } from "./tooltips";
+import { cockroach } from "src/js/protos";
+import MembershipStatus = cockroach.kv.kvserver.liveness.livenesspb.MembershipStatus;
 
 const liveNodesSortSetting = new LocalSetting<AdminUIState, SortSetting>(
   "nodes/live_sort_setting",
@@ -165,13 +167,24 @@ export const getLivenessStatusName = (status: LivenessStatus): string => {
 
 const NodeNameColumn: React.FC<{
   record: NodeStatusRow | DecommissionedNodeStatusRow;
-}> = ({ record }) => {
-  return (
-    <Link className="nodes-table__link" to={`/node/${record.nodeId}`}>
+  shouldLink?: boolean;
+}> = ({ record, shouldLink = true }) => {
+  const columnValue = (
+    <>
       <Text>{record.nodeName}</Text>
       <Text textType={TextTypes.BodyStrong}>{` (n${record.nodeId})`}</Text>
-    </Link>
+    </>
   );
+
+  if (shouldLink) {
+    return (
+      <Link className="nodes-table__link" to={`/node/${record.nodeId}`}>
+        {columnValue}
+      </Link>
+    );
+  }
+
+  return columnValue;
 };
 
 const NodeLocalityColumn: React.FC<{ record: NodeStatusRow }> = ({
@@ -418,14 +431,14 @@ class DecommissionedNodeList extends React.Component<
       key: "nodes",
       title: "decommissioned nodes",
       render: (_text: string, record: DecommissionedNodeStatusRow) => (
-        <NodeNameColumn record={record} />
+        <NodeNameColumn record={record} shouldLink={false} />
       ),
     },
     {
       key: "decommissionedSince",
       title: "decommissioned on",
       render: (_text: string, record: DecommissionedNodeStatusRow) =>
-        record.decommissionedDate.format("LL[ at ]h:mm a"),
+        record.decommissionedDate.format("LL[ at ]h:mm a UTC"),
     },
     {
       key: "status",
@@ -580,11 +593,8 @@ export const liveNodesTableDataSelector = createSelector(
 );
 
 export const decommissionedNodesTableDataSelector = createSelector(
-  partitionedStatuses,
   nodesSummarySelector,
-  (statuses, nodesSummary): DecommissionedNodeStatusRow[] => {
-    const decommissionedStatuses = statuses.decommissioned || [];
-
+  (nodesSummary): DecommissionedNodeStatusRow[] => {
     const getDecommissionedTime = (nodeId: number) => {
       const liveness = nodesSummary.livenessByNodeID[nodeId];
       if (!liveness) {
@@ -594,20 +604,24 @@ export const decommissionedNodesTableDataSelector = createSelector(
       return LongToMoment(deadTime);
     };
 
+    const decommissionedNodes = Object.values(
+      nodesSummary.livenessByNodeID,
+    ).filter(liveness => {
+      return liveness?.membership === MembershipStatus.DECOMMISSIONED;
+    });
+
     // DecommissionedNodeList displays 5 most recent nodes.
-    const data = _.chain(decommissionedStatuses)
-      .orderBy(
-        [(ns: INodeStatus) => getDecommissionedTime(ns.desc.node_id)],
-        ["desc"],
-      )
+    const data = _.chain(decommissionedNodes)
+      .orderBy([liveness => getDecommissionedTime(liveness.node_id)], ["desc"])
       .take(5)
-      .map((ns: INodeStatus, idx: number) => {
+      .map((liveness, idx: number) => {
+        const { node_id } = liveness;
         return {
           key: `${idx}`,
-          nodeId: ns.desc.node_id,
-          nodeName: ns.desc.address.address_field,
-          status: nodesSummary.livenessStatusByNodeID[ns.desc.node_id],
-          decommissionedDate: getDecommissionedTime(ns.desc.node_id),
+          nodeId: node_id,
+          nodeName: `${node_id}`,
+          status: nodesSummary.livenessStatusByNodeID[node_id],
+          decommissionedDate: getDecommissionedTime(node_id),
         };
       })
       .value();

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodesOverview/nodesOverview.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodesOverview/nodesOverview.spec.tsx
@@ -29,6 +29,7 @@ import { livenessByNodeIDSelector, LivenessStatus } from "src/redux/nodes";
 import { SortSetting } from "@cockroachlabs/cluster-ui";
 
 import NodeLivenessStatus = cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus;
+import MembershipStatus = cockroach.kv.kvserver.liveness.livenesspb.MembershipStatus;
 
 describe("Nodes Overview page", () => {
   describe("Live <NodeList/> section initial state", () => {
@@ -365,6 +366,7 @@ describe("Nodes Overview page", () => {
               {
                 node_id: 2,
                 expiration: { wall_time: Long.fromNumber(Date.now()) },
+                membership: MembershipStatus.DECOMMISSIONED,
               },
               { node_id: 3 },
               { node_id: 4 },
@@ -373,6 +375,7 @@ describe("Nodes Overview page", () => {
               {
                 node_id: 7,
                 expiration: { wall_time: Long.fromNumber(Date.now()) },
+                membership: MembershipStatus.DECOMMISSIONED,
               },
             ],
             statuses: {
@@ -421,7 +424,6 @@ describe("Nodes Overview page", () => {
       it("returns node records with 'decommissioned' status only", () => {
         const expectedDecommissionedNodeIds = [2, 7];
         const records = decommissionedNodesTableDataSelector.resultFunc(
-          partitionedNodes,
           nodeSummary,
         );
 
@@ -437,12 +439,10 @@ describe("Nodes Overview page", () => {
 
       it("returns correct node name", () => {
         const recordsGroupedByRegion = decommissionedNodesTableDataSelector.resultFunc(
-          partitionedNodes,
           nodeSummary,
         );
         recordsGroupedByRegion.forEach(record => {
-          const expectedName = `127.0.0.${record.nodeId}:50945`;
-          assert.equal(record.nodeName, expectedName);
+          assert.equal(record.nodeName, record.nodeId.toString());
         });
       });
     });


### PR DESCRIPTION
Backport 1/1 commits from https://github.com/cockroachdb/cockroach/pull/76538


Original Commit Message:

Previously, the decommissioned node lists considered node status entries
to determine decommissioning and decommissioned status. This changed in #56529,
resulting in empty lists. Now, the node's liveness entry is considered
and these lists are correctly populated.

Release note (bug fix): The list of recently decommissioned nodes
and the historical list of decommissioned nodes correctly display
decommissioned nodes.
