### PR TITLE
release-21.1: [CRDB-8488] ui: add alert banner on overview list page for staggered node versions

### DIFF
--- a/pkg/ui/src/redux/alerts.spec.ts
+++ b/pkg/ui/src/redux/alerts.spec.ts
@@ -148,8 +148,8 @@ describe("alerts", function () {
 
     describe("version mismatch warning", function () {
       it("requires versions to be loaded before displaying", function () {
-        const alert = staggeredVersionWarningSelector(state());
-        assert.isUndefined(alert);
+        const numAlert = staggeredVersionWarningSelector(state());
+        assert.isUndefined(numAlert);
       });
 
       it("does not display when versions match", function () {
@@ -167,8 +167,8 @@ describe("alerts", function () {
             },
           ]),
         );
-        const alert = staggeredVersionWarningSelector(state());
-        assert.isUndefined(alert);
+        const numAlert = staggeredVersionWarningSelector(state());
+        assert.isUndefined(numAlert);
       });
 
       it("displays when mismatch detected and not dismissed", function () {
@@ -190,10 +190,13 @@ describe("alerts", function () {
             },
           ]),
         );
-        const alert = staggeredVersionWarningSelector(state());
-        assert.isObject(alert);
-        assert.equal(alert.level, AlertLevel.WARNING);
-        assert.equal(alert.title, "Staggered Version");
+        const numAlert = staggeredVersionWarningSelector(state());
+        assert.isObject(numAlert);
+        assert.equal(numAlert.level, AlertLevel.WARNING);
+        assert.equal(
+          numAlert.title,
+          "Multiple versions of CockroachDB are running on this cluster.",
+        );
       });
 
       it("does not display if dismissed locally", function () {
@@ -212,8 +215,8 @@ describe("alerts", function () {
           ]),
         );
         dispatch(staggeredVersionDismissedSetting.set(true));
-        const alert = staggeredVersionWarningSelector(state());
-        assert.isUndefined(alert);
+        const numAlert = staggeredVersionWarningSelector(state());
+        assert.isUndefined(numAlert);
       });
 
       it("dismisses by setting local dismissal", function () {
@@ -231,8 +234,28 @@ describe("alerts", function () {
             },
           ]),
         );
-        const alert = staggeredVersionWarningSelector(state());
-        dispatch(alert.dismiss);
+        const numAlert = staggeredVersionWarningSelector(state());
+        numAlert.dismiss(dispatch, state);
+        assert.isTrue(staggeredVersionDismissedSetting.selector(state()));
+      });
+
+      it("num alert dismisses by setting local dismissal", function () {
+        dispatch(
+          nodesReducerObj.receiveData([
+            {
+              build_info: {
+                tag: "0.1",
+              },
+            },
+            {
+              build_info: {
+                tag: "0.2",
+              },
+            },
+          ]),
+        );
+        const numAlert = staggeredVersionWarningSelector(state());
+        numAlert.dismiss(dispatch, state);
         assert.isTrue(staggeredVersionDismissedSetting.selector(state()));
       });
     });

--- a/pkg/ui/src/redux/alerts.ts
+++ b/pkg/ui/src/redux/alerts.ts
@@ -35,7 +35,10 @@ import {
   refreshVersion,
   refreshHealth,
 } from "./apiReducers";
-import { singleVersionSelector, versionsSelector } from "src/redux/nodes";
+import {
+  singleVersionSelector,
+  numNodesByVersionsSelector,
+} from "src/redux/nodes";
 import { AdminUIState } from "./state";
 import * as docsURL from "src/util/docs";
 
@@ -134,23 +137,27 @@ export const staggeredVersionDismissedSetting = new LocalSetting(
  * This excludes decommissioned nodes.
  */
 export const staggeredVersionWarningSelector = createSelector(
-  versionsSelector,
+  numNodesByVersionsSelector,
   staggeredVersionDismissedSetting.selector,
-  (versions, versionMismatchDismissed): Alert => {
+  (versionsMap, versionMismatchDismissed): Alert => {
     if (versionMismatchDismissed) {
       return undefined;
     }
-
-    if (!versions || versions.length <= 1) {
+    if (!versionsMap || versionsMap.size < 2) {
       return undefined;
     }
-
+    const versionsText = Array.from(versionsMap)
+      .map(([k, v]) => `${v} nodes are running on ${k}`)
+      .join(" and ")
+      .concat(". ");
     return {
       level: AlertLevel.WARNING,
-      title: "Staggered Version",
-      text: `We have detected that multiple versions of CockroachDB are running
-      in this cluster. This may be part of a normal rolling upgrade process, but
-      should be investigated if this is unexpected.`,
+      title: "Multiple versions of CockroachDB are running on this cluster.",
+      text:
+        versionsText +
+        `You can see a list of all nodes and their versions below.
+        This may be part of a normal rolling upgrade process, but should be investigated
+        if unexpected.`,
       dismiss: (dispatch: Dispatch<Action, AdminUIState>) => {
         dispatch(staggeredVersionDismissedSetting.set(true));
         return Promise.resolve();
@@ -452,6 +459,18 @@ export const terminateQueryAlertSelector = createSelector(
         return Promise.resolve();
       },
     };
+  },
+);
+
+/**
+ * Selector which returns an array of all active alerts which should be
+ * displayed in the overview list page, these should be non-critical alerts.
+ */
+
+export const overviewListAlertsSelector = createSelector(
+  staggeredVersionWarningSelector,
+  (...alerts: Alert[]): Alert[] => {
+    return _.without(alerts, null, undefined);
   },
 );
 

--- a/pkg/ui/src/redux/nodes.spec.ts
+++ b/pkg/ui/src/redux/nodes.spec.ts
@@ -20,6 +20,7 @@ import {
   selectStoreIDsByNodeID,
   LivenessStatus,
   sumNodeStats,
+  numNodesByVersionsSelector,
 } from "./nodes";
 import { nodesReducerObj, livenessReducerObj } from "./apiReducers";
 import { createAdminUIStore } from "./state";
@@ -182,6 +183,39 @@ describe("node data selectors", function () {
         2: ["4"],
         3: ["5", "6"],
       });
+    });
+  });
+
+  describe("numNodesByVersionsSelector", () => {
+    it("correctly returns the different binary versions and the number of associated nodes", () => {
+      const data = [
+        {
+          desc: { node_id: 1 },
+          build_info: {
+            tag: "v22.1",
+          },
+        },
+        {
+          desc: { node_id: 2 },
+          build_info: {
+            tag: "v22.1",
+          },
+        },
+        {
+          desc: { node_id: 3 },
+          build_info: {
+            tag: "v21.1.7",
+          },
+        },
+      ];
+      const store = createAdminUIStore(createHashHistory());
+      store.dispatch(nodesReducerObj.receiveData(data));
+      const state = store.getState();
+      const expectedResult = new Map([
+        ["v22.1", 2],
+        ["v21.1.7", 1],
+      ]);
+      assert.deepEqual(numNodesByVersionsSelector(state), expectedResult);
     });
   });
 });

--- a/pkg/ui/src/redux/nodes.ts
+++ b/pkg/ui/src/redux/nodes.ts
@@ -434,28 +434,50 @@ export const clusterNameSelector = createSelector(
   },
 );
 
-export const versionsSelector = createSelector(
+export const validateNodesSelector = createSelector(
   nodeStatusesSelector,
   livenessByNodeIDSelector,
-  (nodeStatuses, livenessStatusByNodeID) =>
-    _.chain(nodeStatuses)
-      // Ignore nodes for which we don't have any build info.
-      .filter((status) => !!status.build_info)
-      // Exclude this node if it's known to be decommissioning.
-      .filter(
-        (status) =>
-          !status.desc ||
-          !livenessStatusByNodeID[status.desc.node_id] ||
-          !livenessStatusByNodeID[status.desc.node_id].membership ||
-          !(
-            livenessStatusByNodeID[status.desc.node_id].membership !==
-            MembershipStatus.ACTIVE
-          ),
-      )
-      // Collect the surviving nodes' build tags.
-      .map((status) => status.build_info.tag)
-      .uniq()
-      .value(),
+  (nodeStatuses, livenessStatusByNodeID) => {
+    if (!nodeStatuses) {
+      return undefined;
+    }
+    return (
+      nodeStatuses
+        // Ignore nodes for which we don't have any build info.
+        .filter((status) => !!status.build_info)
+        // Exclude this node if it's known to be decommissioning.
+        .filter(
+          (status) =>
+            !status.desc ||
+            !livenessStatusByNodeID[status.desc.node_id] ||
+            !livenessStatusByNodeID[status.desc.node_id].membership ||
+            !(
+              livenessStatusByNodeID[status.desc.node_id].membership !==
+              MembershipStatus.ACTIVE
+            ),
+        )
+    );
+  },
+);
+
+export const versionsSelector = createSelector(validateNodesSelector, (nodes) =>
+  _.chain(nodes)
+    // Collect the surviving nodes' build tags.
+    .map((status) => status.build_info.tag)
+    .uniq()
+    .value(),
+);
+
+export const numNodesByVersionsSelector = createSelector(
+  validateNodesSelector,
+  (nodes) => {
+    if (!nodes) {
+      return new Map();
+    }
+    return new Map(
+      Object.entries(_.countBy(nodes, (node) => node?.build_info?.tag)),
+    );
+  },
 );
 
 // Select the current build version of the cluster, returning undefined if the

--- a/pkg/ui/src/views/cluster/containers/clusterOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/clusterOverview/index.tsx
@@ -22,6 +22,7 @@ import createChartComponent from "src/views/shared/util/d3-react";
 import capacityChart from "./capacity";
 import spinner from "assets/spinner.gif";
 import { refreshNodes, refreshLiveness } from "src/redux/apiReducers";
+import OverviewListAlerts from "src/views/shared/containers/alerts/overviewListAlerts";
 import EmailSubscription from "src/views/dashboard/emailSubscription";
 import "./cluster.styl";
 import {
@@ -311,6 +312,7 @@ export default class ClusterOverview extends React.Component<any, any> {
       <div className="cluster-page">
         <Helmet title="Cluster Overview" />
         <EmailSubscription />
+        <OverviewListAlerts />
         <section className="section cluster-overview">
           <ClusterSummaryConnected />
         </section>

--- a/pkg/ui/src/views/shared/containers/alerts/overviewListAlerts.tsx
+++ b/pkg/ui/src/views/shared/containers/alerts/overviewListAlerts.tsx
@@ -1,0 +1,63 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import _ from "lodash";
+import { Dispatch, Action, bindActionCreators } from "redux";
+import { connect } from "react-redux";
+
+import { AlertBox } from "src/views/shared/components/alertBox";
+import { AdminUIState } from "src/redux/state";
+import { Alert, overviewListAlertsSelector } from "src/redux/alerts";
+
+interface AlertSectionProps {
+  /**
+   * List of alerts to display in the alert section.
+   */
+  alerts: Alert[];
+  /**
+   * Raw dispatch method for the current store, will be used to dispatch
+   * alert dismissal callbacks.
+   */
+  dispatch: Dispatch<Action, AdminUIState>;
+}
+
+class OverviewAlertListSection extends React.Component<AlertSectionProps, {}> {
+  render() {
+    const { alerts, dispatch } = this.props;
+    if (alerts.length === 0) {
+      return null;
+    }
+    return (
+      <section className="section">
+        {_.map(alerts, (a, i) => {
+          const { dismiss, ...alertProps } = a;
+          const boundDismiss = bindActionCreators(() => a.dismiss, dispatch);
+          return <AlertBox key={i} dismiss={boundDismiss} {...alertProps} />;
+        })}
+      </section>
+    );
+  }
+}
+
+const overviewAlertListSectionConnected = connect(
+  (state: AdminUIState) => {
+    return {
+      alerts: overviewListAlertsSelector(state),
+    };
+  },
+  (dispatch) => {
+    return {
+      dispatch: dispatch,
+    };
+  },
+)(OverviewAlertListSection);
+
+export default overviewAlertListSectionConnected;


### PR DESCRIPTION
Backport 1/1 commits from #76932.

/cc @cockroachdb/release

---

Users wish to see more info related to how the progress of a cluster upgrade
is going. Since we do not have a cluster upgrade status to use we are
instead showing an alert banner on the overview page when there are more
than one node versions detected. This alert banner lists the node versions
detected and how many nodes are on each version. This is a non-critical
alert and can be dismissed.

Release note (ui change): add alert banner on overview list page for
staggered node versions

Related issue: https://github.com/cockroachdb/cockroach/issues/67330

Release justification: Low risk ui changes with improved QoL results

![Screen Shot 2022-02-23 at 2 16 34 PM](https://user-images.githubusercontent.com/17861665/155395098-0c060962-aa6a-4e38-b0fe-e27ec309366f.png)
