### PR TITLE
kvstreamer: support lookup joins with ordering

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/requests_provider_test.go
+++ b/pkg/kv/kvclient/kvstreamer/requests_provider_test.go
@@ -33,8 +33,8 @@ func TestInOrderRequestsProvider(t *testing.T) {
 	requests := make([]singleRangeBatch, rng.Intn(maxNumRequests)+1)
 	priorities := make([]int, len(requests))
 	for i := range requests {
-		requests[i].priority = rng.Intn(maxNumRequests)
-		priorities[i] = requests[i].priority
+		requests[i].positions = []int{rng.Intn(maxNumRequests)}
+		priorities[i] = requests[i].priority()
 	}
 	sort.Ints(priorities)
 
@@ -47,17 +47,17 @@ func TestInOrderRequestsProvider(t *testing.T) {
 		first := p.firstLocked()
 		p.removeFirstLocked()
 		p.Unlock()
-		require.Equal(t, priorities[0], first.priority)
+		require.Equal(t, priorities[0], first.priority())
 		priorities = priorities[1:]
 		// With 50% probability simulate that a resume request with random
 		// priority is added.
 		if rng.Float64() < 0.5 {
-			// Note that in reality the priority of the resume request cannot
+			// Note that in reality the position of the resume request cannot
 			// have lower value than of the original request, but it's ok for
 			// the test.
-			first.priority = rng.Intn(maxNumRequests)
+			first.positions[0] = rng.Intn(maxNumRequests)
 			p.add(first)
-			priorities = append(priorities, first.priority)
+			priorities = append(priorities, first.priority())
 			sort.Ints(priorities)
 		}
 	}

--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -118,6 +118,20 @@ type Result struct {
 	// TODO(yuzefovich): this might need to be []int when non-unique requests
 	// are supported.
 	Position int
+	// subRequestIdx allows us to order two Results that come for the same
+	// original Scan request but from different ranges. It is non-zero only in
+	// InOrder mode when Hints.SingleRowLookup is false, in all other cases it
+	// will remain zero. See singleRangeBatch.subRequestIdx for more details.
+	subRequestIdx int
+	// subRequestDone is true if the current Result is the last one for the
+	// corresponding sub-request. For all Get requests and for Scan requests
+	// contained within a single range, it is always true since those can only
+	// have a single sub-request.
+	//
+	// Note that for correctness, it is only necessary that this value is set
+	// properly if this Result is a Scan response and Hints.SingleRowLookup is
+	// false.
+	subRequestDone bool
 }
 
 // Hints provides different hints to the Streamer for optimization purposes.
@@ -241,12 +255,18 @@ type Streamer struct {
 
 		avgResponseEstimator avgResponseEstimator
 
-		// numRangesLeftPerScanRequest tracks how many ranges a particular
-		// originally enqueued ScanRequest touches, but scanning of those ranges
-		// isn't complete. It is allocated lazily if Hints.SingleRowLookup is
-		// false when the first ScanRequest is encountered in Enqueue.
+		// In OutOfOrder mode, numRangesPerScanRequest tracks how many
+		// ranges a particular originally enqueued ScanRequest touches, but
+		// scanning of those ranges isn't complete.
+		//
+		// In InOrder mode, it tracks how many ranges a particular originally
+		// enqueued ScanRequest touches. In other words, it contains how many
+		// "sub-requests" the original Scan request was broken down into.
+		//
+		// It is allocated lazily if Hints.SingleRowLookup is false when the
+		// first ScanRequest is encountered in Enqueue.
 		// TODO(yuzefovich): perform memory accounting for this.
-		numRangesLeftPerScanRequest []int
+		numRangesPerScanRequest []int
 
 		// numRequestsInFlight tracks the number of single-range batches that
 		// are currently being served asynchronously (i.e. those that have
@@ -348,7 +368,7 @@ func (s *Streamer) Init(
 		s.results = newOutOfOrderResultsBuffer(s.budget)
 	} else {
 		s.requestsToServe = newInOrderRequestsProvider()
-		s.results = newInOrderResultsBuffer(s.budget, diskBuffer)
+		s.results = newInOrderResultsBuffer(s.budget, diskBuffer, hints.SingleRowLookup)
 	}
 	if !hints.UniqueRequests {
 		panic(errors.AssertionFailedf("only unique requests are currently supported"))
@@ -466,28 +486,35 @@ func (s *Streamer) Enqueue(
 		if err != nil {
 			return err
 		}
+		var subRequestIdx []int
 		if !s.hints.SingleRowLookup {
-			for _, pos := range positions {
+			for i, pos := range positions {
 				if _, isScan := reqs[pos].GetInner().(*roachpb.ScanRequest); isScan {
 					if firstScanRequest {
 						// We have some ScanRequests, and each might touch
 						// multiple ranges, so we have to set up
-						// numRangesLeftPerScanRequest.
+						// numRangesPerScanRequest.
 						streamerLocked = true
 						s.mu.Lock()
-						if cap(s.mu.numRangesLeftPerScanRequest) < len(reqs) {
-							s.mu.numRangesLeftPerScanRequest = make([]int, len(reqs))
+						if cap(s.mu.numRangesPerScanRequest) < len(reqs) {
+							s.mu.numRangesPerScanRequest = make([]int, len(reqs))
 						} else {
-							// We can reuse numRangesLeftPerScanRequest
-							// allocated on the previous call to Enqueue after
-							// we zero it out.
-							s.mu.numRangesLeftPerScanRequest = s.mu.numRangesLeftPerScanRequest[:len(reqs)]
-							for n := 0; n < len(s.mu.numRangesLeftPerScanRequest); {
-								n += copy(s.mu.numRangesLeftPerScanRequest[n:], zeroIntSlice)
+							// We can reuse numRangesPerScanRequest allocated on
+							// the previous call to Enqueue after we zero it
+							// out.
+							s.mu.numRangesPerScanRequest = s.mu.numRangesPerScanRequest[:len(reqs)]
+							for n := 0; n < len(s.mu.numRangesPerScanRequest); {
+								n += copy(s.mu.numRangesPerScanRequest[n:], zeroIntSlice)
 							}
 						}
 					}
-					s.mu.numRangesLeftPerScanRequest[pos]++
+					if s.mode == InOrder {
+						if subRequestIdx == nil {
+							subRequestIdx = make([]int, len(singleRangeReqs))
+						}
+						subRequestIdx[i] = s.mu.numRangesPerScanRequest[pos]
+					}
+					s.mu.numRangesPerScanRequest[pos]++
 					firstScanRequest = false
 				}
 			}
@@ -500,8 +527,8 @@ func (s *Streamer) Enqueue(
 		r := singleRangeBatch{
 			reqs:              singleRangeReqs,
 			positions:         positions,
+			subRequestIdx:     subRequestIdx,
 			reqsReservedBytes: requestsMemUsage(singleRangeReqs),
-			priority:          positions[0],
 		}
 		totalReqsMemUsage += r.reqsReservedBytes
 
@@ -571,7 +598,8 @@ func (s *Streamer) GetResults(ctx context.Context) ([]Result, error) {
 		if len(results) > 0 || allComplete || err != nil {
 			if debug {
 				if len(results) > 0 {
-					fmt.Printf("returning %s to the client\n", resultsToString(results))
+					printSubRequestIdx := s.mode == InOrder && !s.hints.SingleRowLookup
+					fmt.Printf("returning %s to the client\n", resultsToString(results, printSubRequestIdx))
 				} else {
 					suffix := "all requests have been responded to"
 					if !allComplete {
@@ -685,7 +713,7 @@ func (w *workerCoordinator) mainLoop(ctx context.Context) {
 			// The first request has the highest urgency among all current
 			// requests to serve, so we use its priority to spill everything
 			// with less urgency when necessary to free up the budget.
-			spillingPriority = w.s.requestsToServe.firstLocked().priority
+			spillingPriority = w.s.requestsToServe.firstLocked().priority()
 		}
 		w.s.requestsToServe.Unlock()
 
@@ -1229,12 +1257,11 @@ func (w *workerCoordinator) processSingleRangeResults(
 	// We have to allocate the new slice for requests, but we can reuse the
 	// positions slice.
 	resumeReq.reqs = make([]roachpb.RequestUnion, numIncompleteRequests)
-	// numIncompleteRequests will never exceed the number of requests in req.
-	resumeReq.positions = req.positions[:numIncompleteRequests]
+	resumeReq.positions = req.positions[:0]
+	resumeReq.subRequestIdx = req.subRequestIdx[:0]
 	// We've already reconciled the budget with the actual reservation for the
 	// requests with the ResumeSpans.
 	resumeReq.reqsReservedBytes = resumeReqsMemUsage
-	resumeReq.priority = math.MaxInt
 	gets := make([]struct {
 		req   roachpb.GetRequest
 		union roachpb.RequestUnion_Get
@@ -1257,6 +1284,10 @@ func (w *workerCoordinator) processSingleRangeResults(
 		if w.s.enqueueKeys != nil {
 			enqueueKey = w.s.enqueueKeys[position]
 		}
+		var subRequestIdx int
+		if req.subRequestIdx != nil {
+			subRequestIdx = req.subRequestIdx[i]
+		}
 		reply := resp.GetInner()
 		switch origRequest := req.reqs[i].GetInner().(type) {
 		case *roachpb.GetRequest:
@@ -1271,12 +1302,12 @@ func (w *workerCoordinator) processSingleRangeResults(
 				newGet.req.KeyLocking = origRequest.KeyLocking
 				newGet.union.Get = &newGet.req
 				resumeReq.reqs[resumeReqIdx].Value = &newGet.union
-				resumeReq.positions[resumeReqIdx] = req.positions[i]
+				resumeReq.positions = append(resumeReq.positions, position)
+				if req.subRequestIdx != nil {
+					resumeReq.subRequestIdx = append(resumeReq.subRequestIdx, subRequestIdx)
+				}
 				if resumeReq.minTargetBytes == 0 {
 					resumeReq.minTargetBytes = get.ResumeNextBytes
-				}
-				if position < resumeReq.priority {
-					resumeReq.priority = position
 				}
 				resumeReqIdx++
 			} else {
@@ -1292,6 +1323,8 @@ func (w *workerCoordinator) processSingleRangeResults(
 					// unique.
 					EnqueueKeysSatisfied: []int{enqueueKey},
 					Position:             position,
+					subRequestIdx:        subRequestIdx,
+					subRequestDone:       true,
 				}
 				result.memoryTok.streamer = w.s
 				result.memoryTok.toRelease = getResponseSize(get)
@@ -1325,6 +1358,8 @@ func (w *workerCoordinator) processSingleRangeResults(
 					// are unique.
 					EnqueueKeysSatisfied: []int{enqueueKey},
 					Position:             position,
+					subRequestIdx:        subRequestIdx,
+					subRequestDone:       scan.ResumeSpan == nil,
 				}
 				result.memoryTok.streamer = w.s
 				result.memoryTok.toRelease = scanResponseSize(scan)
@@ -1349,12 +1384,12 @@ func (w *workerCoordinator) processSingleRangeResults(
 				newScan.req.KeyLocking = origRequest.KeyLocking
 				newScan.union.Scan = &newScan.req
 				resumeReq.reqs[resumeReqIdx].Value = &newScan.union
-				resumeReq.positions[resumeReqIdx] = req.positions[i]
+				resumeReq.positions = append(resumeReq.positions, position)
+				if req.subRequestIdx != nil {
+					resumeReq.subRequestIdx = append(resumeReq.subRequestIdx, subRequestIdx)
+				}
 				if resumeReq.minTargetBytes == 0 {
 					resumeReq.minTargetBytes = scan.ResumeNextBytes
-				}
-				if position < resumeReq.priority {
-					resumeReq.priority = position
 				}
 				resumeReqIdx++
 
@@ -1450,10 +1485,21 @@ func (w *workerCoordinator) finalizeSingleRangeResults(
 			if results[i].ScanResp.ScanResponse != nil {
 				if results[i].ScanResp.ResumeSpan == nil {
 					// The scan within the range is complete.
-					w.s.mu.numRangesLeftPerScanRequest[results[i].Position]--
-					if w.s.mu.numRangesLeftPerScanRequest[results[i].Position] == 0 {
-						// The scan across all ranges is now complete too.
-						results[i].ScanResp.Complete = true
+					if w.s.mode == OutOfOrder {
+						w.s.mu.numRangesPerScanRequest[results[i].Position]--
+						if w.s.mu.numRangesPerScanRequest[results[i].Position] == 0 {
+							// The scan across all ranges is now complete too.
+							results[i].ScanResp.Complete = true
+						}
+					} else {
+						// In InOrder mode, the scan is marked as complete when
+						// the last sub-request is satisfied. Note that it is ok
+						// if the previous sub-requests haven't been satisfied
+						// yet - the inOrderResultsBuffer will not emit this
+						// Result until the previous sub-requests are responded
+						// to.
+						numSubRequests := w.s.mu.numRangesPerScanRequest[results[i].Position]
+						results[i].ScanResp.Complete = results[i].subRequestIdx+1 == numSubRequests
 					}
 				} else {
 					// Unset the ResumeSpan on the result in order to not
@@ -1472,7 +1518,8 @@ func (w *workerCoordinator) finalizeSingleRangeResults(
 	// partial one. Think more about this.
 	w.s.mu.avgResponseEstimator.update(actualMemoryReservation, int64(len(results)))
 	if debug {
-		fmt.Printf("created %s with total size %d\n", resultsToString(results), actualMemoryReservation)
+		printSubRequestIdx := w.s.mode == InOrder && !w.s.hints.SingleRowLookup
+		fmt.Printf("created %s with total size %d\n", resultsToString(results, printSubRequestIdx), actualMemoryReservation)
 	}
 	w.s.results.add(results)
 }

--- a/pkg/kv/kvclient/kvstreamer/streamer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors"
 	"github.com/dustin/go-humanize"
 	"github.com/stretchr/testify/require"
@@ -462,5 +463,67 @@ func TestStreamerEmptyScans(t *testing.T) {
 	})
 }
 
-// TODO(yuzefovich): once lookup joins are supported, add a test for InOrder
-// mode where Scan requests span multiple ranges.
+// TestStreamerMultiRangeScan verifies that the Streamer correctly handles scan
+// requests that span multiple ranges.
+func TestStreamerMultiRangeScan(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	ctx := context.Background()
+	defer s.Stopper().Stop(ctx)
+
+	rng, _ := randutil.NewTestRand()
+	numRows := rng.Intn(100) + 2
+
+	// We set up two tables such that we'll use the value from the smaller one
+	// to lookup into a secondary index in the larger table.
+	_, err := db.Exec("CREATE TABLE small (n PRIMARY KEY) AS SELECT 1")
+	require.NoError(t, err)
+	_, err = db.Exec("CREATE TABLE large (k INT PRIMARY KEY, n INT, s STRING, INDEX (n, k) STORING (s))")
+	require.NoError(t, err)
+	_, err = db.Exec(fmt.Sprintf("INSERT INTO large SELECT i, 1, repeat('a', i) FROM generate_series(1, %d) AS i", numRows))
+	require.NoError(t, err)
+
+	// Split the range for the secondary index into multiple.
+	numRanges := 2
+	if numRows > 2 {
+		numRanges = rng.Intn(numRows-2) + 2
+	}
+	kValues := make([]int, numRows)
+	for i := range kValues {
+		kValues[i] = i + 1
+	}
+	rng.Shuffle(numRows, func(i, j int) {
+		kValues[i], kValues[j] = kValues[j], kValues[i]
+	})
+	splitKValues := kValues[:numRanges]
+	for _, kValue := range splitKValues {
+		_, err = db.Exec(fmt.Sprintf("ALTER INDEX large_n_k_idx SPLIT AT VALUES (1, %d)", kValue))
+		require.NoError(t, err)
+	}
+
+	// Populate the range cache.
+	_, err = db.Exec("SELECT * FROM large@large_n_k_idx")
+	require.NoError(t, err)
+
+	// The crux of the test - run a query that performs a lookup join when
+	// ordering needs to be maintained and then confirm that the results of the
+	// parallel lookups are served in the right order.
+	r := db.QueryRow("SELECT array_agg(s) FROM small INNER LOOKUP JOIN large ON small.n = large.n GROUP BY small.n ORDER BY small.n")
+	var result string
+	err = r.Scan(&result)
+	require.NoError(t, err)
+	// The expected result is of the form: {a,aa,aaa,...}.
+	expected := "{"
+	for i := 1; i <= numRows; i++ {
+		if i > 1 {
+			expected += ","
+		}
+		for j := 0; j < i; j++ {
+			expected += "a"
+		}
+	}
+	expected += "}"
+	require.Equal(t, expected, result)
+}

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -162,7 +162,10 @@ func (s *ColIndexJoin) Init(ctx context.Context) {
 		}
 		s.streamerInfo.Streamer.Init(
 			mode,
-			kvstreamer.Hints{UniqueRequests: true},
+			kvstreamer.Hints{
+				UniqueRequests:  true,
+				SingleRowLookup: true,
+			},
 			int(s.cf.table.spec.MaxKeysPerRow),
 			s.streamerInfo.diskBuffer,
 		)

--- a/pkg/sql/rowcontainer/kvstreamer_result_disk_buffer.go
+++ b/pkg/sql/rowcontainer/kvstreamer_result_disk_buffer.go
@@ -147,7 +147,8 @@ func (b *kvStreamerResultDiskBuffer) Close(ctx context.Context) {
 // kvstreamer.Result that is spilled to disk.
 //
 // It contains all the information except for 'ScanResp.Complete', 'memoryTok',
-// and 'Position' fields which are kept in-memory (because they are allocated in
+// 'Position', 'subRequestIdx', and 'subRequestDone' fields which are kept
+// in-memory (because they are allocated in
 // kvstreamer.inOrderBufferedResult.Result anyway).
 var inOrderResultsBufferSpillTypeSchema = []*types.T{
 	types.Bool, // isGet


### PR DESCRIPTION
**kvstreamer: introduce SingleRowLookup hint**

This commit introduces `SingleRowLookup` hint to the Streamer which
indicates that a single request can result in at most a single SQL row
lookup. This is obviously true and not very interesting for all
GetRequests, but it's quite helpful for the ScanRequests that can span
ranges IFF multiple rows might get scanned. The hint is `true` for index
joins and for lookup joins when lookup columns form a key.

When the hint is `true`, then the Streamer can avoid some extra
bookkeeping about how many sub-requests have already been responded to
for a particular original Scan request. In this commit, the
simplification is relatively minor, but the follow-up commit for
supporting InOrder mode for lookup joins will introduce much more
bookkeeping that this hint allows us to avoid.

Release note: None

**kvstreamer: fully support InOrder mode**

This commit extends the Streamer library to support Scan requests that
can span multiple ranges in the InOrder mode which allows us to use the
Streamer for the lookup joins when ordering needs to be maintained. As
with the lookup joins w/o ordering, this is a "poor man's" support which
relies on the de-duplication of requests in the join reader's span
generators as well as doesn't remove the disk-backed row container that
buffers all looked up rows in the join reader ordering strategy. Those
caveats will be addressed in the follow-up commits.

The contribution of this commit is such that the in-order results buffer
can now correctly return the results when a single original Scan request
touches multiple ranges as well as when each sub-request (against
a single range) can get an arbitrary number of partial responses.

Previously, we only had one axis for ordering the results - `Position`
values which identify the original request that a particular Result is
a response to. This was sufficient for index joins (as well as lookup
joins when `SingleRowLookup` hint is `true`); however, when a Scan
request can touch multiple ranges, that single axis is no longer
sufficient since the results buffer could order two Results for a single
Scan request arbitrarily. We go around this limitation by introducing
a second dimension for ordering - "sub-request index" which is the
ordinal of a particular single-range request within the multi-range Scan
request.

Consider the following example: original Scan request is `Scan(b, f)`,
and we have three ranges: `[a, c)`, `[c, e)`, `[e, g)`. In
`Streamer.Enqueue`, the original Scan is broken down into three
single-range Scan requests:
```
  singleRangeReq[0]:
    reqs          = [Scan(b, c)]
    positions     = [0]
    subRequestIdx = [0]
  singleRangeReq[1]:
    reqs          = [Scan(c, e)]
    positions     = [0]
    subRequestIdx = [1]
  singleRangeReq[2]:
    reqs          = [Scan(e, f)]
    positions     = [0]
    subRequestIdx = [2]
```
Note that `positions` values are the same (indicating that each
single-range request is a part of the same original multi-range request),
but values of `subRequestIdx` are different - they will allow us to order
the responses to these single-range requests (which might come back in
any order) correctly when returning the results. This information is
plumbed into the requests as well as the results.

There is yet another complication though - what if a single-range Scan
request results in multiple partial responses? To make sure that these
partial results are ordered correctly, we need yet another dimension,
but at least that dimension can be fully hidden inside of the in-order
results buffer. This is possible due to the fact that partial response
for the same single-range Scan request will be added into the buffer at
different times, so we'll assign the results "add epochs".

Consider the following example: we have the original Scan request as
`Scan(a, c)` which goes to a single range `[a, c)` containing keys `a`
and `b`. Imagine that the Scan response can only contain a single key,
so we first get a partial `ScanResponse('a')` with `ResumeSpan(b, c)`,
and then we get a partial `ScanResponse('b')` with an empty `ResumeSpan`.
The first response will be added to the buffer when during the first
`add` call, so its "epoch" is 0 whereas the second response is added
during "epoch" 1 - thus, we can correctly return `a` before `b`
although the `Position` and sub-request values of two `Result`s are the
same.

Addresses: #54680.

Release note: None