### PR TITLE
release-21.1: kvserver: increase `Migrate` application timeout to 1 minute

### DIFF
--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -56,6 +56,11 @@ import (
 var sendSnapshotTimeout = envutil.EnvOrDefaultDuration(
 	"COCKROACH_RAFT_SEND_SNAPSHOT_TIMEOUT", 1*time.Hour)
 
+// mergeApplicationTimeout is the timeout when waiting for a merge command to be
+// applied on all range replicas. There doesn't appear to be any strong reason
+// why this value was chosen in particular, but it seems to work.
+const mergeApplicationTimeout = 5 * time.Second
+
 // AdminSplit divides the range into into two ranges using args.SplitKey.
 func (r *Replica) AdminSplit(
 	ctx context.Context, args roachpb.AdminSplitRequest, reason string,
@@ -746,9 +751,11 @@ func (r *Replica) AdminMerge(
 		}
 		rhsSnapshotRes := br.(*roachpb.SubsumeResponse)
 
-		err = waitForApplication(
-			ctx, r.store.cfg.NodeDialer, rightDesc.RangeID, mergeReplicas,
-			rhsSnapshotRes.LeaseAppliedIndex)
+		err = contextutil.RunWithTimeout(ctx, "waiting for merge application", mergeApplicationTimeout,
+			func(ctx context.Context) error {
+				return waitForApplication(ctx, r.store.cfg.NodeDialer, rightDesc.RangeID, mergeReplicas,
+					rhsSnapshotRes.LeaseAppliedIndex)
+			})
 		if err != nil {
 			return errors.Wrap(err, "waiting for all right-hand replicas to catch up")
 		}
@@ -813,25 +820,28 @@ func waitForApplication(
 	replicas []roachpb.ReplicaDescriptor,
 	leaseIndex uint64,
 ) error {
-	return contextutil.RunWithTimeout(ctx, "wait for application", 5*time.Second, func(ctx context.Context) error {
-		g := ctxgroup.WithContext(ctx)
-		for _, repl := range replicas {
-			repl := repl // copy for goroutine
-			g.GoCtx(func(ctx context.Context) error {
-				conn, err := dialer.Dial(ctx, repl.NodeID, rpc.DefaultClass)
-				if err != nil {
-					return errors.Wrapf(err, "could not dial n%d", repl.NodeID)
-				}
-				_, err = NewPerReplicaClient(conn).WaitForApplication(ctx, &WaitForApplicationRequest{
-					StoreRequestHeader: StoreRequestHeader{NodeID: repl.NodeID, StoreID: repl.StoreID},
-					RangeID:            rangeID,
-					LeaseIndex:         leaseIndex,
-				})
-				return err
+	if dialer == nil && len(replicas) == 1 {
+		// This early return supports unit tests (testContext{}) that also
+		// want to perform merges.
+		return nil
+	}
+	g := ctxgroup.WithContext(ctx)
+	for _, repl := range replicas {
+		repl := repl // copy for goroutine
+		g.GoCtx(func(ctx context.Context) error {
+			conn, err := dialer.Dial(ctx, repl.NodeID, rpc.DefaultClass)
+			if err != nil {
+				return errors.Wrapf(err, "could not dial n%d", repl.NodeID)
+			}
+			_, err = NewPerReplicaClient(conn).WaitForApplication(ctx, &WaitForApplicationRequest{
+				StoreRequestHeader: StoreRequestHeader{NodeID: repl.NodeID, StoreID: repl.StoreID},
+				RangeID:            rangeID,
+				LeaseIndex:         leaseIndex,
 			})
-		}
-		return g.Wait()
-	})
+			return err
+		})
+	}
+	return g.Wait()
 }
 
 // waitForReplicasInit blocks until it has proof that the replicas listed in

--- a/pkg/settings/duration.go
+++ b/pkg/settings/duration.go
@@ -202,3 +202,11 @@ func NonNegativeDurationWithMaximum(maxValue time.Duration) func(time.Duration) 
 		return nil
 	}
 }
+
+// PositiveDuration can be passed to RegisterDurationSetting.
+func PositiveDuration(v time.Duration) error {
+	if v <= 0 {
+		return errors.Errorf("cannot be set to a non-positive duration: %s", v)
+	}
+	return nil
+}


### PR DESCRIPTION
Backport 1/2 commits from #72987.

/cc @cockroachdb/release

---

**kvserver: increase Migrate application timeout to 1 minute**

This increases the timeout when waiting for application of a `Migrate`
command on all range replicas to 1 minute, up from 5 seconds. It also
adds a cluster setting `kv.migration.migrate_application.timeout` to
control this.

When encountering a range that's e.g. undergoing rebalancing, it can
take a long time for a learner replica to receive a snapshot and respond
to this request, which would cause the timeout to trigger. This is
especially likely in clusters with many ranges and frequent rebalancing
activity.

Touches #72931.

Release note (bug fix): The timeout when checking for Raft application
of upgrade migrations has been increased from 5 seconds to 1 minute, and
is now controllable via the cluster setting
`kv.migration.migrate_application_timeout`. This makes migrations much
less likely to fail in clusters with ongoing rebalancing activity during
upgrade migrations.

Release justification: low risk change that unlocks stuck migrations