### PR TITLE
roachtest: make roachtest recognize 22.2

### DIFF
--- a/pkg/cmd/roachtest/tests/activerecord_blocklist.go
+++ b/pkg/cmd/roachtest/tests/activerecord_blocklist.go
@@ -15,6 +15,7 @@ var activeRecordBlocklists = blocklistsForVersion{
 	{"v21.1", "activeRecordBlockList21_1", activeRecordBlockList21_1, "activeRecordIgnoreList21_1", activeRecordIgnoreList21_1},
 	{"v21.2", "activeRecordBlockList21_2", activeRecordBlockList21_2, "activeRecordIgnoreList21_2", activeRecordIgnoreList21_2},
 	{"v22.1", "activeRecordBlockList22_1", activeRecordBlockList22_1, "activeRecordIgnoreList22_1", activeRecordIgnoreList22_1},
+	{"v22.2", "activeRecordBlockList22_2", activeRecordBlockList22_2, "activeRecordIgnoreList22_2", activeRecordIgnoreList22_2},
 }
 
 // These are lists of known activerecord test errors and failures.
@@ -28,6 +29,8 @@ var activeRecordBlocklists = blocklistsForVersion{
 // Please keep these lists alphabetized for easy diffing.
 // After a failed run, an updated version of this blocklist should be available
 // in the test log.
+var activeRecordBlockList22_2 = blocklist{}
+
 var activeRecordBlockList22_1 = blocklist{}
 
 var activeRecordBlockList21_2 = blocklist{}
@@ -35,6 +38,8 @@ var activeRecordBlockList21_2 = blocklist{}
 var activeRecordBlockList21_1 = blocklist{}
 
 var activeRecordBlockList20_2 = blocklist{}
+
+var activeRecordIgnoreList22_2 = activeRecordIgnoreList22_1
 
 var activeRecordIgnoreList22_1 = blocklist{
 	"CockroachDB::PostgresqlIntervalTest#test_interval_type":               "flaky",

--- a/pkg/cmd/roachtest/tests/asyncpg_blocklist.go
+++ b/pkg/cmd/roachtest/tests/asyncpg_blocklist.go
@@ -13,6 +13,7 @@ package tests
 var asyncpgBlocklists = blocklistsForVersion{
 	{"v21.2", "asyncpgBlocklist21_2", asyncpgBlocklist21_2, "asyncpgIgnoreList21_2", asyncpgIgnoreList21_2},
 	{"v22.1", "asyncpgBlocklist22_1", asyncpgBlocklist22_1, "asyncpgIgnoreList22_1", asyncpgIgnoreList22_1},
+	{"v22.2", "asyncpgBlocklist22_2", asyncpgBlocklist22_2, "asyncpgIgnoreList22_2", asyncpgIgnoreList22_2},
 }
 
 // These are lists of known asyncpg test errors and failures.
@@ -23,6 +24,8 @@ var asyncpgBlocklists = blocklistsForVersion{
 // Please keep these lists alphabetized for easy diffing.
 // After a failed run, an updated version of this blocklist should be available
 // in the test log.
+var asyncpgBlocklist22_2 = asyncpgBlocklist22_1
+
 var asyncpgBlocklist22_1 = blocklist{
 	"test_cache_invalidation.TestCacheInvalidation.test_prepare_cache_invalidation_in_pool":               "unknown",
 	"test_cache_invalidation.TestCacheInvalidation.test_prepare_cache_invalidation_in_transaction":        "unknown",
@@ -201,5 +204,6 @@ var asyncpgBlocklist21_2 = blocklist{
 	"test_utils.TestUtils.test_mogrify_simple":                                                            "unknown",
 }
 
+var asyncpgIgnoreList22_2 = asyncpgIgnoreList22_1
 var asyncpgIgnoreList22_1 = asyncpgIgnoreList21_2
 var asyncpgIgnoreList21_2 = blocklist{}

--- a/pkg/cmd/roachtest/tests/django_blocklist.go
+++ b/pkg/cmd/roachtest/tests/django_blocklist.go
@@ -166,9 +166,12 @@ var djangoBlocklists = blocklistsForVersion{
 	{"v21.1", "djangoBlocklist21_1", djangoBlocklist21_1, "djangoIgnoreList21_1", djangoIgnoreList21_1},
 	{"v21.2", "djangoBlocklist21_2", djangoBlocklist21_2, "djangoIgnoreList21_2", djangoIgnoreList21_2},
 	{"v22.1", "djangoBlocklist22_1", djangoBlocklist22_1, "djangoIgnoreList22_1", djangoIgnoreList22_1},
+	{"v22.2", "djangoBlocklist22_2", djangoBlocklist22_2, "djangoIgnoreList22_2", djangoIgnoreList22_2},
 }
 
 // Maintain that this list is alphabetized.
+var djangoBlocklist22_2 = djangoBlocklist22_1
+
 var djangoBlocklist22_1 = djangoBlocklist21_2
 
 var djangoBlocklist21_2 = djangoBlocklist21_1
@@ -176,6 +179,8 @@ var djangoBlocklist21_2 = djangoBlocklist21_1
 var djangoBlocklist21_1 = djangoBlocklist20_2
 
 var djangoBlocklist20_2 = blocklist{}
+
+var djangoIgnoreList22_2 = djangoIgnoreList22_1
 
 var djangoIgnoreList22_1 = djangoIgnoreList21_2
 

--- a/pkg/cmd/roachtest/tests/gopg_blocklist.go
+++ b/pkg/cmd/roachtest/tests/gopg_blocklist.go
@@ -15,6 +15,7 @@ var gopgBlocklists = blocklistsForVersion{
 	{"v21.1", "gopgBlockList21_1", gopgBlockList21_1, "gopgIgnoreList21_1", gopgIgnoreList21_1},
 	{"v21.2", "gopgBlockList21_2", gopgBlockList21_2, "gopgIgnoreList21_2", gopgIgnoreList21_2},
 	{"v22.1", "gopgBlockList22_1", gopgBlockList22_1, "gopgIgnoreList22_1", gopgIgnoreList22_1},
+	{"v22.2", "gopgBlockList22_2", gopgBlockList22_2, "gopgIgnoreList22_2", gopgIgnoreList22_2},
 }
 
 // These are lists of known gopg test errors and failures.
@@ -25,6 +26,8 @@ var gopgBlocklists = blocklistsForVersion{
 // Please keep these lists alphabetized for easy diffing.
 // After a failed run, an updated version of this blocklist should be available
 // in the test log.
+
+var gopgBlockList22_2 = gopgBlockList22_1
 
 var gopgBlockList22_1 = gopgBlockList21_2
 
@@ -77,6 +80,8 @@ var gopgBlockList20_2 = blocklist{
 	"v10.TestReadColumnValue":                                         "26925",
 	"v10.TestUnixSocket":                                              "31113",
 }
+
+var gopgIgnoreList22_2 = gopgIgnoreList22_1
 
 var gopgIgnoreList22_1 = gopgIgnoreList21_2
 

--- a/pkg/cmd/roachtest/tests/gorm_blocklist.go
+++ b/pkg/cmd/roachtest/tests/gorm_blocklist.go
@@ -15,7 +15,10 @@ var gormBlocklists = blocklistsForVersion{
 	{"v21.1", "gormBlocklist21_1", gormBlocklist21_1, "gormIgnorelist21_1", gormIgnorelist21_1},
 	{"v21.2", "gormBlocklist21_2", gormBlocklist21_2, "gormIgnorelist21_2", gormIgnorelist21_2},
 	{"v22.1", "gormBlocklist22_1", gormBlocklist22_1, "gormIgnorelist22_1", gormIgnorelist22_1},
+	{"v22.2", "gormBlocklist22_2", gormBlocklist22_2, "gormIgnorelist22_2", gormIgnorelist22_2},
 }
+
+var gormBlocklist22_2 = gormBlocklist22_1
 
 var gormBlocklist22_1 = gormBlocklist21_2
 
@@ -24,6 +27,8 @@ var gormBlocklist21_2 = gormBlocklist21_1
 var gormBlocklist21_1 = gormBlocklist20_2
 
 var gormBlocklist20_2 = blocklist{}
+
+var gormIgnorelist22_2 = gormIgnorelist22_1
 
 var gormIgnorelist22_1 = gormIgnorelist21_2
 

--- a/pkg/cmd/roachtest/tests/hibernate_blocklist.go
+++ b/pkg/cmd/roachtest/tests/hibernate_blocklist.go
@@ -15,22 +15,28 @@ var hibernateBlocklists = blocklistsForVersion{
 	{"v21.1", "hibernateBlockList21_1", hibernateBlockList21_1, "hibernateIgnoreList21_1", hibernateIgnoreList21_1},
 	{"v21.2", "hibernateBlockList21_2", hibernateBlockList21_2, "hibernateIgnoreList21_2", hibernateIgnoreList21_2},
 	{"v22.1", "hibernateBlockList22_1", hibernateBlockList22_1, "hibernateIgnoreList22_1", hibernateIgnoreList22_1},
+	{"v22.2", "hibernateBlockList22_2", hibernateBlockList22_2, "hibernateIgnoreList22_2", hibernateIgnoreList22_2},
 }
 
 var hibernateSpatialBlocklists = blocklistsForVersion{
 	{"v21.1", "hibernateSpatialBlockList21_1", hibernateSpatialBlockList21_1, "", nil},
 	{"v21.2", "hibernateSpatialBlockList21_2", hibernateSpatialBlockList21_2, "", nil},
 	{"v22.1", "hibernateSpatialBlockList22_1", hibernateSpatialBlockList22_1, "", nil},
+	{"v22.2", "hibernateSpatialBlockList22_2", hibernateSpatialBlockList22_2, "", nil},
 }
 
 // Please keep these lists alphabetized for easy diffing.
 // After a failed run, an updated version of this blocklist should be available
 // in the test log.
+var hibernateSpatialBlockList22_2 = blocklist{}
+
 var hibernateSpatialBlockList22_1 = blocklist{}
 
 var hibernateSpatialBlockList21_2 = blocklist{}
 
 var hibernateSpatialBlockList21_1 = blocklist{}
+
+var hibernateBlockList22_2 = hibernateBlockList22_1
 
 var hibernateBlockList22_1 = blocklist{
 	"org.hibernate.jpa.test.graphs.FetchGraphTest.testCollectionEntityGraph":                                                "unknown",
@@ -231,6 +237,8 @@ var hibernateBlockList20_2 = blocklist{
 	"org.hibernate.test.naturalid.inheritance.cache.InheritedNaturalIdNoCacheTest.testLoadExtendedByNormal":                                                                                      "unknown",
 	"org.hibernate.test.where.annotations.EagerManyToOneFetchModeSelectWhereTest.testAssociatedWhereClause":                                                                                      "unknown",
 }
+
+var hibernateIgnoreList22_2 = hibernateIgnoreList22_1
 
 var hibernateIgnoreList22_1 = hibernateIgnoreList21_2
 

--- a/pkg/cmd/roachtest/tests/jasyncsql_blocklist.go
+++ b/pkg/cmd/roachtest/tests/jasyncsql_blocklist.go
@@ -12,7 +12,10 @@ package tests
 
 var jasyncsqlBlocklists = blocklistsForVersion{
 	{"v22.1", "jasyncsqlBlocklist22_1", jasyncBlocklist22_1, "jasyncsqlIgnoreList22_1", jasyncsqlIgnoreList22_1},
+	{"v22.2", "jasyncsqlBlocklist22_2", jasyncBlocklist22_2, "jasyncsqlIgnoreList22_2", jasyncsqlIgnoreList22_2},
 }
+
+var jasyncBlocklist22_2 = jasyncBlocklist22_1
 
 var jasyncBlocklist22_1 = blocklist{
 	"com.github.aysnc.sql.db.integration.ArrayTypesSpec.connection should correctly parse the array type":                                                           "unknown",
@@ -71,5 +74,7 @@ var jasyncBlocklist22_1 = blocklist{
 	"com.github.aysnc.sql.db.integration.pool.SuspendingPoolSpec.transactions should commit simple inserts , prepared statements":                                   "unknown",
 	"com.github.aysnc.sql.db.integration.pool.SuspendingPoolSpec.transactions with pool should commit simple inserts , prepared statements":                         "unknown",
 }
+
+var jasyncsqlIgnoreList22_2 = jasyncsqlIgnoreList22_1
 
 var jasyncsqlIgnoreList22_1 = blocklist{}

--- a/pkg/cmd/roachtest/tests/libpq_blocklist.go
+++ b/pkg/cmd/roachtest/tests/libpq_blocklist.go
@@ -15,7 +15,10 @@ var libPQBlocklists = blocklistsForVersion{
 	{"v21.1", "libPQBlocklist21_1", libPQBlocklist21_1, "libPQIgnorelist21_1", libPQIgnorelist21_1},
 	{"v21.2", "libPQBlocklist21_2", libPQBlocklist21_2, "libPQIgnorelist21_2", libPQIgnorelist21_2},
 	{"v22.1", "libPQBlocklist22_1", libPQBlocklist22_1, "libPQIgnorelist22_1", libPQIgnorelist22_1},
+	{"v22.2", "libPQBlocklist22_2", libPQBlocklist22_2, "libPQIgnorelist22_2", libPQIgnorelist22_2},
 }
+
+var libPQBlocklist22_2 = libPQBlocklist22_1
 
 var libPQBlocklist22_1 = blocklist{
 	"pq.ExampleConnectorWithNoticeHandler":           "unknown",
@@ -122,6 +125,8 @@ var libPQBlocklist20_2 = blocklist{
 	"pq.TestRuntimeParameters":                       "12137",
 	"pq.TestStringWithNul":                           "26366",
 }
+
+var libPQIgnorelist22_2 = libPQIgnorelist22_1
 
 var libPQIgnorelist22_1 = libPQIgnorelist21_2
 

--- a/pkg/cmd/roachtest/tests/liquibase_blocklist.go
+++ b/pkg/cmd/roachtest/tests/liquibase_blocklist.go
@@ -15,7 +15,10 @@ var liquibaseBlocklists = blocklistsForVersion{
 	{"v21.1", "liquibaseBlocklist21_1", liquibaseBlocklist21_1, "liquibaseIgnorelist21_1", liquibaseIgnorelist21_1},
 	{"v21.2", "liquibaseBlocklist21_2", liquibaseBlocklist21_2, "liquibaseIgnorelist21_2", liquibaseIgnorelist21_2},
 	{"v22.1", "liquibaseBlocklist22_1", liquibaseBlocklist22_1, "liquibaseIgnorelist21_2", liquibaseIgnorelist22_1},
+	{"v22.2", "liquibaseBlocklist22_2", liquibaseBlocklist22_2, "liquibaseIgnorelist21_2", liquibaseIgnorelist22_2},
 }
+
+var liquibaseBlocklist22_2 = liquibaseBlocklist22_1
 
 var liquibaseBlocklist22_1 = blocklist{
 	"liquibase.harness.change.ChangeObjectTests.apply addCheckConstraint against cockroachdb 20.2":  "unknown",
@@ -30,6 +33,8 @@ var liquibaseBlocklist21_2 = blocklist{
 var liquibaseBlocklist21_1 = liquibaseBlocklist20_2
 
 var liquibaseBlocklist20_2 = blocklist{}
+
+var liquibaseIgnorelist22_2 = liquibaseIgnorelist22_1
 
 var liquibaseIgnorelist22_1 = liquibaseIgnorelist21_2
 

--- a/pkg/cmd/roachtest/tests/pgjdbc_blocklist.go
+++ b/pkg/cmd/roachtest/tests/pgjdbc_blocklist.go
@@ -15,11 +15,14 @@ var pgjdbcBlocklists = blocklistsForVersion{
 	{"v21.1", "pgjdbcBlockList21_1", pgjdbcBlockList21_1, "pgjdbcIgnoreList21_1", pgjdbcIgnoreList21_1},
 	{"v21.2", "pgjdbcBlockList21_2", pgjdbcBlockList21_2, "pgjdbcIgnoreList21_2", pgjdbcIgnoreList21_2},
 	{"v22.1", "pgjdbcBlockList22_1", pgjdbcBlockList22_1, "pgjdbcIgnoreList22_1", pgjdbcIgnoreList22_1},
+	{"v22.2", "pgjdbcBlockList22_2", pgjdbcBlockList22_2, "pgjdbcIgnoreList22_2", pgjdbcIgnoreList22_2},
 }
 
 // Please keep these lists alphabetized for easy diffing.
 // After a failed run, an updated version of this blocklist should be available
 // in the test log.
+var pgjdbcBlockList22_2 = pgjdbcBlockList22_1
+
 var pgjdbcBlockList22_1 = blocklist{
 	"org.postgresql.core.OidValuesCorrectnessTest.testValue[oidName=BOX, oidValue=603]":                                                                                        "unknown",
 	"org.postgresql.core.OidValuesCorrectnessTest.testValue[oidName=CIDR, oidValue=650]":                                                                                       "unknown",
@@ -3344,6 +3347,8 @@ var pgjdbcBlockList20_2 = blocklist{
 	"org.postgresql.test.xa.XADataSourceTest.testTwoPhaseCommit":                                                                                                               "22329",
 	"org.postgresql.test.xa.XADataSourceTest.testWrapperEquals":                                                                                                                "22329",
 }
+
+var pgjdbcIgnoreList22_2 = pgjdbcIgnoreList22_1
 
 var pgjdbcIgnoreList22_1 = pgjdbcIgnoreList21_2
 

--- a/pkg/cmd/roachtest/tests/pgx_blocklist.go
+++ b/pkg/cmd/roachtest/tests/pgx_blocklist.go
@@ -15,11 +15,14 @@ var pgxBlocklists = blocklistsForVersion{
 	{"v21.1", "pgxBlocklist21_1", pgxBlocklist21_1, "pgxIgnorelist21_1", pgxIgnorelist21_1},
 	{"v21.2", "pgxBlocklist21_2", pgxBlocklist21_2, "pgxIgnorelist21_2", pgxIgnorelist21_2},
 	{"v22.1", "pgxBlocklist22_1", pgxBlocklist22_1, "pgxIgnorelist22_1", pgxIgnorelist22_1},
+	{"v22.2", "pgxBlocklist22_2", pgxBlocklist22_2, "pgxIgnorelist22_2", pgxIgnorelist22_2},
 }
 
 // Please keep these lists alphabetized for easy diffing.
 // After a failed run, an updated version of this blocklist should be available
 // in the test log.
+var pgxBlocklist22_2 = blocklist{}
+
 var pgxBlocklist22_1 = blocklist{}
 
 var pgxBlocklist21_2 = blocklist{}
@@ -27,6 +30,8 @@ var pgxBlocklist21_2 = blocklist{}
 var pgxBlocklist21_1 = blocklist{}
 
 var pgxBlocklist20_2 = blocklist{}
+
+var pgxIgnorelist22_2 = pgxIgnorelist22_1
 
 var pgxIgnorelist22_1 = pgxIgnorelist21_2
 

--- a/pkg/cmd/roachtest/tests/psycopg_blocklist.go
+++ b/pkg/cmd/roachtest/tests/psycopg_blocklist.go
@@ -15,6 +15,7 @@ var psycopgBlocklists = blocklistsForVersion{
 	{"v21.1", "psycopgBlockList21_1", psycopgBlockList21_1, "psycopgIgnoreList21_1", psycopgIgnoreList21_1},
 	{"v21.2", "psycopgBlockList21_2", psycopgBlockList21_2, "psycopgIgnoreList21_2", psycopgIgnoreList21_2},
 	{"v22.1", "psycopgBlockList22_1", psycopgBlockList22_1, "psycopgIgnoreList22_1", psycopgIgnoreList22_1},
+	{"v22.2", "psycopgBlockList22_2", psycopgBlockList22_2, "psycopgIgnoreList22_2", psycopgIgnoreList22_2},
 }
 
 // These are lists of known psycopg test errors and failures.
@@ -28,6 +29,8 @@ var psycopgBlocklists = blocklistsForVersion{
 // Please keep these lists alphabetized for easy diffing.
 // After a failed run, an updated version of this blocklist should be available
 // in the test log.
+var psycopgBlockList22_2 = blocklist{}
+
 var psycopgBlockList22_1 = blocklist{}
 
 var psycopgBlockList21_2 = blocklist{
@@ -46,6 +49,8 @@ var psycopgBlockList21_1 = blocklist{
 var psycopgBlockList20_2 = blocklist{
 	"tests.test_async_keyword.CancelTests.test_async_cancel": "41335",
 }
+
+var psycopgIgnoreList22_2 = psycopgIgnoreList22_1
 
 var psycopgIgnoreList22_1 = psycopgIgnoreList21_2
 

--- a/pkg/cmd/roachtest/tests/ruby_pg_blocklist.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg_blocklist.go
@@ -15,7 +15,10 @@ var rubyPGBlocklist = blocklistsForVersion{
 	{"v21.1", "rubyPGBlockList21_1", rubyPGBlockList21_1, "rubyPGIgnoreList21_1", rubyPGIgnoreList21_1},
 	{"v21.2", "rubyPGBlockList21_2", rubyPGBlockList21_2, "rubyPGIgnoreList21_2", rubyPGIgnoreList21_2},
 	{"v22.1", "rubyPGBlockList22_1", rubyPGBlockList22_1, "rubyPGIgnoreList21_2", rubyPGIgnoreList22_1},
+	{"v22.2", "rubyPGBlockList22_2", rubyPGBlockList22_2, "rubyPGIgnoreList21_2", rubyPGIgnoreList22_2},
 }
+
+var rubyPGBlockList22_2 = rubyPGBlockList22_1
 
 var rubyPGBlockList22_1 = blocklist{
 	"Basic type mapping PG::BasicTypeMapBasedOnResult with usage of result oids for bind params encoder selection can do JSON conversions":                                                                                      "unknown",
@@ -529,6 +532,8 @@ var rubyPGBlockList20_2 = blocklist{
 	"PG::Connection deprecated forms of methods should forward send_query to send_query_params":                                                                                                     "unknown",
 	"PG::Connection deprecated forms of methods should forward exec to exec_params":                                                                                                                 "unknown",
 }
+
+var rubyPGIgnoreList22_2 = rubyPGIgnoreList22_1
 
 var rubyPGIgnoreList22_1 = rubyPGIgnoreList21_2
 

--- a/pkg/cmd/roachtest/tests/sqlalchemy_blocklist.go
+++ b/pkg/cmd/roachtest/tests/sqlalchemy_blocklist.go
@@ -15,7 +15,10 @@ var sqlAlchemyBlocklists = blocklistsForVersion{
 	{"v21.1", "sqlAlchemyBlocklist21_1", sqlAlchemyBlocklist21_1, "sqlAlchemyIgnoreList21_1", sqlAlchemyIgnoreList21_1},
 	{"v21.2", "sqlAlchemyBlocklist21_2", sqlAlchemyBlocklist21_2, "sqlAlchemyIgnoreList21_2", sqlAlchemyIgnoreList21_2},
 	{"v22.1", "sqlAlchemyBlocklist22_1", sqlAlchemyBlocklist22_1, "sqlAlchemyIgnoreList22_1", sqlAlchemyIgnoreList22_1},
+	{"v22.2", "sqlAlchemyBlocklist22_2", sqlAlchemyBlocklist22_2, "sqlAlchemyIgnoreList22_2", sqlAlchemyIgnoreList22_2},
 }
+
+var sqlAlchemyBlocklist22_2 = blocklist{}
 
 var sqlAlchemyBlocklist22_1 = blocklist{}
 
@@ -24,6 +27,8 @@ var sqlAlchemyBlocklist21_2 = blocklist{}
 var sqlAlchemyBlocklist21_1 = blocklist{}
 
 var sqlAlchemyBlocklist20_2 = blocklist{}
+
+var sqlAlchemyIgnoreList22_2 = sqlAlchemyIgnoreList22_1
 
 var sqlAlchemyIgnoreList22_1 = sqlAlchemyIgnoreList21_2
 


### PR DESCRIPTION
Configure roachtest block and ignore lists for 22.2

fixes https://github.com/cockroachdb/cockroach/issues/81626
fixes https://github.com/cockroachdb/cockroach/issues/81625
fixes https://github.com/cockroachdb/cockroach/issues/81624
fixes https://github.com/cockroachdb/cockroach/issues/81623
fixes https://github.com/cockroachdb/cockroach/issues/81623
fixes https://github.com/cockroachdb/cockroach/issues/81622
fixes https://github.com/cockroachdb/cockroach/issues/81621
fixes https://github.com/cockroachdb/cockroach/issues/81620
fixes https://github.com/cockroachdb/cockroach/issues/81619
fixes https://github.com/cockroachdb/cockroach/issues/81617
fixes https://github.com/cockroachdb/cockroach/issues/81616
fixes https://github.com/cockroachdb/cockroach/issues/81615
fixes https://github.com/cockroachdb/cockroach/issues/81613
fixes https://github.com/cockroachdb/cockroach/issues/81612
fixes https://github.com/cockroachdb/cockroach/issues/81611
fixes https://github.com/cockroachdb/cockroach/issues/81608
fixes https://github.com/cockroachdb/cockroach/issues/81607

Release note: None