### PR TITLE
security/password: trim down dependencies further

### DIFF
--- a/pkg/ccl/serverccl/role_authentication_test.go
+++ b/pkg/ccl/serverccl/role_authentication_test.go
@@ -166,7 +166,12 @@ func TestVerifyPassword(t *testing.T) {
 					)
 				}
 
-				pwCompare, err := password.CompareHashAndCleartextPassword(ctx, hashedPassword, tc.password)
+				pwCompare, err := password.CompareHashAndCleartextPassword(
+					ctx,
+					hashedPassword,
+					tc.password,
+					security.GetExpensiveHashComputeSem(ctx),
+				)
 				if err != nil {
 					t.Error(err)
 					valid = false

--- a/pkg/security/BUILD.bazel
+++ b/pkg/security/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/log/eventpb",
         "//pkg/util/metric",
+        "//pkg/util/quotapool",
         "//pkg/util/randutil",
         "//pkg/util/stop",
         "//pkg/util/syncutil",

--- a/pkg/security/auth.go
+++ b/pkg/security/auth.go
@@ -179,7 +179,8 @@ func UserAuthPasswordHook(
 		if len(passwordStr) == 0 {
 			return NewErrPasswordUserAuthFailed(systemIdentity)
 		}
-		ok, err := password.CompareHashAndCleartextPassword(ctx, hashedPassword, passwordStr)
+		ok, err := password.CompareHashAndCleartextPassword(ctx,
+			hashedPassword, passwordStr, GetExpensiveHashComputeSem(ctx))
 		if err != nil {
 			return err
 		}

--- a/pkg/security/password.go
+++ b/pkg/security/password.go
@@ -13,10 +13,15 @@ package security
 import (
 	"context"
 	"fmt"
+	"runtime"
+	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/security/password"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/errors"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -166,3 +171,52 @@ var AutoUpgradePasswordHashes = settings.RegisterBoolSetting(
 	"whether to automatically re-encode stored passwords using crdb-bcrypt to scram-sha-256",
 	true,
 ).WithPublic()
+
+// expensiveHashComputeSemOnce wraps a semaphore that limits the
+// number of concurrent calls to the bcrypt and sha256 hash
+// functions. This is needed to avoid the risk of a DoS attacks by
+// malicious users or broken client apps that would starve the server
+// of CPU resources just by computing hashes.
+//
+// We use a sync.Once to delay the creation of the semaphore to the
+// first time the password functions are used. This gives a chance to
+// the server process to update GOMAXPROCS before we compute the
+// maximum amount of concurrency for the semaphore.
+var expensiveHashComputeSemOnce struct {
+	sem  *quotapool.IntPool
+	once sync.Once
+}
+
+// envMaxHashComputeConcurrency allows a user to override the semaphore
+// configuration using an environment variable.
+// If the env var is set to a value >= 1, that value is used.
+// Otherwise, a default is computed from the configure GOMAXPROCS.
+var envMaxHashComputeConcurrency = envutil.EnvOrDefaultInt("COCKROACH_MAX_PW_HASH_COMPUTE_CONCURRENCY", 0)
+
+// GetExpensiveHashComputeSem retrieves the hashing semaphore.
+func GetExpensiveHashComputeSem(ctx context.Context) password.HashSemaphore {
+	expensiveHashComputeSemOnce.once.Do(func() {
+		var n int
+		if envMaxHashComputeConcurrency >= 1 {
+			// The operator knows better. Use what they tell us to use.
+			n = envMaxHashComputeConcurrency
+		} else {
+			// We divide by 8 so that the max CPU usage of hash checks
+			// never exceeds ~10% of total CPU resources allocated to this
+			// process.
+			n = runtime.GOMAXPROCS(-1) / 8
+		}
+		if n < 1 {
+			n = 1
+		}
+		log.VInfof(ctx, 1, "configured maximum hashing concurrency: %d", n)
+		expensiveHashComputeSemOnce.sem = quotapool.NewIntPool("password_hashes", uint64(n))
+	})
+	return func(ctx context.Context) (func(), error) {
+		alloc, err := expensiveHashComputeSemOnce.sem.Acquire(ctx, 1)
+		if err != nil {
+			return nil, err
+		}
+		return alloc.Release, nil
+	}
+}

--- a/pkg/security/password/BUILD.bazel
+++ b/pkg/security/password/BUILD.bazel
@@ -6,9 +6,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/security/password",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/util/envutil",
-        "//pkg/util/log",
-        "//pkg/util/quotapool",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_xdg_go_pbkdf2//:pbkdf2",
         "@com_github_xdg_go_scram//:scram",
@@ -25,6 +22,7 @@ go_test(
         "//pkg/security",
         "//pkg/settings/cluster",
         "//pkg/util/leaktest",
+        "//pkg/util/log",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_crypto//bcrypt",
     ],

--- a/pkg/security/password/password_test.go
+++ b/pkg/security/password/password_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/password"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -57,7 +58,7 @@ func TestBCryptToSCRAMConversion(t *testing.T) {
 			// Check conversion succeeds.
 			autoUpgradePasswordHashesBool := security.AutoUpgradePasswordHashes.Get(&s.SV)
 			method := security.GetConfiguredPasswordHashMethod(ctx, &s.SV)
-			converted, prevHash, newHashBytes, hashMethod, err := password.MaybeUpgradePasswordHash(ctx, autoUpgradePasswordHashesBool, method, cleartext, bh)
+			converted, prevHash, newHashBytes, hashMethod, err := password.MaybeUpgradePasswordHash(ctx, autoUpgradePasswordHashesBool, method, cleartext, bh, nil, log.Infof)
 			require.NoError(t, err)
 			require.True(t, converted)
 			require.Equal(t, "SCRAM-SHA-256", string(newHashBytes)[:13])
@@ -73,7 +74,7 @@ func TestBCryptToSCRAMConversion(t *testing.T) {
 			autoUpgradePasswordHashesBool = security.AutoUpgradePasswordHashes.Get(&s.SV)
 			method = security.GetConfiguredPasswordHashMethod(ctx, &s.SV)
 
-			ec, _, _, _, err := password.MaybeUpgradePasswordHash(ctx, autoUpgradePasswordHashesBool, method, cleartext, newHash)
+			ec, _, _, _, err := password.MaybeUpgradePasswordHash(ctx, autoUpgradePasswordHashesBool, method, cleartext, newHash, nil, log.Infof)
 			require.NoError(t, err)
 			require.False(t, ec)
 		})

--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -445,7 +445,7 @@ func (s *authenticationServer) verifyPasswordDBConsole(
 		return false, true, nil
 	}
 
-	ok, err := password.CompareHashAndCleartextPassword(ctx, hashedPassword, passwordStr)
+	ok, err := password.CompareHashAndCleartextPassword(ctx, hashedPassword, passwordStr, security.GetExpensiveHashComputeSem(ctx))
 	if ok && err == nil {
 		// Password authentication succeeded using cleartext.  If the
 		// stored hash was encoded using crdb-bcrypt, we might want to

--- a/pkg/sql/create_role.go
+++ b/pkg/sql/create_role.go
@@ -294,7 +294,8 @@ func (p *planner) checkPasswordAndGetHash(
 	default:
 		return nil, errors.Newf("unsupported hash method: %v", method)
 	}
-	hashedPassword, err = password.HashPassword(ctx, cost, method, passwordStr)
+	hashedPassword, err = password.HashPassword(ctx, cost, method, passwordStr,
+		security.GetExpensiveHashComputeSem(ctx))
 	if err != nil {
 		return hashedPassword, err
 	}

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -647,7 +647,9 @@ func MaybeUpgradeStoredPasswordHash(
 	autoUpgradePasswordHashesBool := security.AutoUpgradePasswordHashes.Get(&execCfg.Settings.SV)
 	hashMethod := security.GetConfiguredPasswordHashMethod(ctx, &execCfg.Settings.SV)
 
-	converted, prevHash, newHash, newMethod, err := password.MaybeUpgradePasswordHash(ctx, autoUpgradePasswordHashesBool, hashMethod, cleartext, currentHash)
+	converted, prevHash, newHash, newMethod, err := password.MaybeUpgradePasswordHash(ctx,
+		autoUpgradePasswordHashesBool, hashMethod, cleartext, currentHash,
+		security.GetExpensiveHashComputeSem(ctx), log.Infof)
 	if err != nil {
 		// We're not returning an error: clients should not be refused a
 		// session just because a password conversion failed.


### PR DESCRIPTION
This removes many more indirect dependencies by not requiring
quotapool and util/log.

Release note: None