### PR TITLE
stats: enable optimizer stats use on system tables for query planning

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -173,6 +173,7 @@ sql.stats.multi_column_collection.enabled	boolean	true	multi-column statistics c
 sql.stats.persisted_rows.max	integer	1000000	maximum number of rows of statement and transaction statistics that will be persisted in the system tables
 sql.stats.post_events.enabled	boolean	false	if set, an event is logged for every CREATE STATISTICS job
 sql.stats.response.max	integer	20000	the maximum number of statements and transaction stats returned in a CombinedStatements request
+sql.stats.system_tables.enabled	boolean	true	when true, enables use of statistics on system tables by the query optimizer
 sql.telemetry.query_sampling.enabled	boolean	false	when set to true, executed queries will emit an event on the telemetry logging channel
 sql.temp_object_cleaner.cleanup_interval	duration	30m0s	how often to clean up orphaned temporary objects
 sql.temp_object_cleaner.wait_interval	duration	30m0s	how long after creation a temporary object will be cleaned up

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -189,6 +189,7 @@
 <tr><td><code>sql.stats.persisted_rows.max</code></td><td>integer</td><td><code>1000000</code></td><td>maximum number of rows of statement and transaction statistics that will be persisted in the system tables</td></tr>
 <tr><td><code>sql.stats.post_events.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if set, an event is logged for every CREATE STATISTICS job</td></tr>
 <tr><td><code>sql.stats.response.max</code></td><td>integer</td><td><code>20000</code></td><td>the maximum number of statements and transaction stats returned in a CombinedStatements request</td></tr>
+<tr><td><code>sql.stats.system_tables.enabled</code></td><td>boolean</td><td><code>true</code></td><td>when true, enables use of statistics on system tables by the query optimizer</td></tr>
 <tr><td><code>sql.telemetry.query_sampling.enabled</code></td><td>boolean</td><td><code>false</code></td><td>when set to true, executed queries will emit an event on the telemetry logging channel</td></tr>
 <tr><td><code>sql.temp_object_cleaner.cleanup_interval</code></td><td>duration</td><td><code>30m0s</code></td><td>how often to clean up orphaned temporary objects</td></tr>
 <tr><td><code>sql.temp_object_cleaner.wait_interval</code></td><td>duration</td><td><code>30m0s</code></td><td>how long after creation a temporary object will be cleaned up</td></tr>

--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -18,6 +18,7 @@ SELECT node_id, name FROM crdb_internal.leases ORDER BY name
 0  scheduled_jobs
 0  settings
 0  statement_diagnostics_requests
+0  table_statistics
 0  test
 0  users
 

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/featureflag"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -226,6 +227,18 @@ func (n *createStatsNode) makeJobRecord(ctx context.Context) (*jobs.Record, erro
 	if tableDesc.IsView() {
 		return nil, pgerror.New(
 			pgcode.WrongObjectType, "cannot create statistics on views",
+		)
+	}
+
+	if tableDesc.GetID() == keys.TableStatisticsTableID {
+		return nil, pgerror.New(
+			pgcode.WrongObjectType, "cannot create statistics on system.table_statistics",
+		)
+	}
+
+	if tableDesc.GetID() == keys.LeaseTableID {
+		return nil, pgerror.New(
+			pgcode.WrongObjectType, "cannot create statistics on system.lease",
 		)
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -1345,3 +1345,25 @@ CREATE TABLE t76867 (
 
 statement ok
 ANALYZE t76867
+
+# Regression tests for #80123. Collecting stats on system tables is allowed.
+statement ok
+ANALYZE system.locations
+
+# EXPLAIN output should indicate stats collected on system.locations.
+query T
+SELECT * FROM [EXPLAIN SELECT * FROM system.locations] OFFSET 2
+----
+·
+• scan
+  estimated row count: 5 (100% of the table; stats collected <hidden> ago)
+  table: locations@primary
+  spans: FULL SCAN
+
+# Collecting stats on system.lease is disallowed.
+statement error pq: cannot create statistics on system.lease
+ANALYZE system.lease
+
+# Collecting stats on system.table_statistics is disallowed.
+statement error pq: cannot create statistics on system.table_statistics
+ANALYZE system.table_statistics

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -38,12 +38,26 @@ import (
 // cluster setting.
 const AutoStatsClusterSettingName = "sql.stats.automatic_collection.enabled"
 
+// UseStatsOnSystemTables is the name of the use statistics on system tables
+// cluster setting.
+const UseStatsOnSystemTables = "sql.stats.system_tables.enabled"
+
 // AutomaticStatisticsClusterMode controls the cluster setting for enabling
 // automatic table statistics collection.
 var AutomaticStatisticsClusterMode = settings.RegisterBoolSetting(
 	settings.TenantWritable,
 	AutoStatsClusterSettingName,
 	"automatic statistics collection mode",
+	true,
+).WithPublic()
+
+// UseStatisticsOnSystemTables controls the cluster setting for enabling
+// statistics usage by the optimizer for planning queries involving system
+// tables.
+var UseStatisticsOnSystemTables = settings.RegisterBoolSetting(
+	settings.TenantWritable,
+	UseStatsOnSystemTables,
+	"when true, enables use of statistics on system tables by the query optimizer",
 	true,
 ).WithPublic()
 
@@ -389,7 +403,7 @@ func (r *Refresher) NotifyMutation(table catalog.TableDescriptor, rowsAffected i
 		// Automatic stats are disabled.
 		return
 	}
-	if !hasStatistics(table) {
+	if !autostatsCollectionAllowed(table) {
 		// Don't collect stats for this kind of table: system, virtual, view, etc.
 		return
 	}


### PR DESCRIPTION
Informs #80123

Previously, statistics could be collected on system tables, but their
use in the optimizer for planning queries was disabled.

This was inadequate because without stats, full table scan might be
chosen by the optimizer for queries involving system tables in cases
where index access is actually cheaper. Also, it is confusing that one
could ANALYZE a system table, but the collected statistics would not be
used when querying the table, as shown in the EXPLAIN output.

To address this, this patch enables stats usage on all system tables
except system.table_statistics and system.lease, as doing so may cause
hangs. A new tenant-writable cluster setting is added,
`sql.stats.system_tables.enabled`, which when true allows statistics on
system tables to be used by the optimizer for costing and planning
queries. The default value of this setting is `true`. Collection of
statistics on `system.table_statistics` and `system.lease` has been
disabled because it would be confusing to allow stats to be collected
that would never be used by the optimizer.

Release note: none