### PR TITLE
sql: include gist in sentry reports

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2660,6 +2660,8 @@ The swap_ordinate_string parameter is a 2-character string naming the ordinates 
 </span></td></tr>
 <tr><td><a name="convert_to"></a><code>convert_to(str: <a href="string.html">string</a>, enc: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Encode the string <code>str</code> as a byte array using encoding <code>enc</code>. Supports encodings ‘UTF8’ and ‘LATIN1’.</p>
 </span></td></tr>
+<tr><td><a name="crdb_internal.decode_external_plan_gist"></a><code>crdb_internal.decode_external_plan_gist(gist: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns rows of output similar to EXPLAIN from a gist such as those found in planGists element of the statistics column of the statement_statistics table without attempting to resolve tables or indexes.</p>
+</span></td></tr>
 <tr><td><a name="crdb_internal.decode_plan_gist"></a><code>crdb_internal.decode_plan_gist(gist: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns rows of output similar to EXPLAIN from a gist such as those found in planGists element of the statistics column of the statement_statistics table.</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.show_create_all_schemas"></a><code>crdb_internal.show_create_all_schemas(database_name: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns rows of CREATE schema statements.

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3450,6 +3450,25 @@ func statementFromCtx(ctx context.Context) tree.Statement {
 	return stmt.(tree.Statement)
 }
 
+// contextGistKey is an empty type for the handle associated with the
+// gist value (see context.Value).
+type contextPlanGistKey struct{}
+
+func withPlanGist(ctx context.Context, gist string) context.Context {
+	if gist == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, contextPlanGistKey{}, gist)
+}
+
+func planGistFromCtx(ctx context.Context) string {
+	val := ctx.Value(contextPlanGistKey{})
+	if val != nil {
+		return val.(string)
+	}
+	return ""
+}
+
 func init() {
 	// Register a function to include the anonymized statement in crash reports.
 	logcrash.RegisterTagFn("statement", func(ctx context.Context) string {
@@ -3459,5 +3478,8 @@ func init() {
 		}
 		// Anonymize the statement for reporting.
 		return anonymizeStmtAndConstants(stmt, nil /* VirtualTabler */)
+	})
+	logcrash.RegisterTagFn("gist", func(ctx context.Context) string {
+		return planGistFromCtx(ctx)
 	})
 }

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1043,6 +1043,9 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	// defer is a catch-all in case some other return path is taken.
 	defer planner.curPlan.close(ctx)
 
+	// include gist in error reports
+	ctx = withPlanGist(ctx, planner.instrumentation.planGist.String())
+
 	if planner.autoCommit {
 		planner.curPlan.flags.Set(planFlagImplicitTxn)
 	}

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -235,7 +235,7 @@ func (*DummyEvalPlanner) ExternalWriteFile(ctx context.Context, uri string, cont
 }
 
 // DecodeGist is part of the Planner interface.
-func (*DummyEvalPlanner) DecodeGist(gist string) ([]string, error) {
+func (*DummyEvalPlanner) DecodeGist(gist string, external bool) ([]string, error) {
 	return nil, errors.WithStack(errEvalPlanner)
 }
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
@@ -20,6 +20,12 @@ SELECT crdb_internal.decode_plan_gist('$gist')
   table: t@t_pkey
   spans: FULL SCAN
 
+query T
+SELECT crdb_internal.decode_external_plan_gist('$gist')
+----
+• scan
+  table: ?@?
+
 # Test that EXPLAIN (GIST) still works if automatic gists are disabled.
 statement ok
 SET disable_plan_gists = 'true'
@@ -44,6 +50,14 @@ SELECT crdb_internal.decode_plan_gist('$gist')
 └── • scan
       table: t@t_pkey
       spans: FULL SCAN
+
+query T
+SELECT crdb_internal.decode_external_plan_gist('$gist')
+----
+• group (scalar)
+│
+└── • scan
+      table: ?@?
 
 statement error pq: unknown signature: crdb_internal\.decode_plan_gist\(int\)
 SELECT * FROM crdb_internal.decode_plan_gist(10)
@@ -84,3 +98,9 @@ SELECT crdb_internal.decode_plan_gist('$gist')
 • scan
   table: t2@t2_pkey
   spans: FULL SCAN
+
+query T
+SELECT crdb_internal.decode_external_plan_gist('$gist')
+----
+• scan
+  table: ?@?

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -181,7 +181,7 @@ func (e *emitter) nodeName(n *Node) (string, error) {
 	case scanOp:
 		a := n.args.(*scanArgs)
 		if a.Table == nil {
-			return "unknown table", nil
+			return "scan", nil
 		}
 		if a.Table.IsVirtualTable() {
 			return "virtual table", nil

--- a/pkg/sql/opt/exec/explain/result_columns.go
+++ b/pkg/sql/opt/exec/explain/result_columns.go
@@ -199,6 +199,9 @@ func getResultColumns(
 }
 
 func tableColumns(table cat.Table, ordinals exec.TableColumnOrdinalSet) colinfo.ResultColumns {
+	if table == nil {
+		return nil
+	}
 	cols := make(colinfo.ResultColumns, 0, ordinals.Len())
 	for i, ok := ordinals.Next(0); ok; i, ok = ordinals.Next(i + 1) {
 		// Be defensive about bitset values because they may come from cached

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/execbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/explain"
@@ -673,9 +674,14 @@ func (opc *optPlanningCtx) runExecBuilder(
 	return nil
 }
 
-// DecodeGist Avoid an import cycle by keeping the cat out of the tree.
-func (p *planner) DecodeGist(gist string) ([]string, error) {
-	return explain.DecodePlanGistToRows(gist, &p.optPlanningCtx.catalog)
+// DecodeGist Avoid an import cycle by keeping the cat out of the tree. If
+// external is true gist is from a foreign database and we use nil catalog.
+func (p *planner) DecodeGist(gist string, external bool) ([]string, error) {
+	var cat cat.Catalog
+	if !external {
+		cat = &p.optPlanningCtx.catalog
+	}
+	return explain.DecodePlanGistToRows(gist, cat)
 }
 
 // makeQueryIndexRecommendation builds a statement and walks through it to find

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -410,7 +410,7 @@ var generators = map[string]builtinDefinition{
 			},
 			showCreateAllSchemasGeneratorType,
 			makeShowCreateAllSchemasGenerator,
-			`Returns rows of CREATE schema statements. 
+			`Returns rows of CREATE schema statements.
 The output can be used to recreate a database.'
 `,
 			volatility.Volatile,
@@ -426,11 +426,11 @@ The output can be used to recreate a database.'
 			},
 			showCreateAllTablesGeneratorType,
 			makeShowCreateAllTablesGenerator,
-			`Returns rows of CREATE table statements followed by 
+			`Returns rows of CREATE table statements followed by
 ALTER table statements that add table constraints. The rows are ordered
 by dependencies. All foreign keys are added after the creation of the table
 in the alter statements.
-It is not recommended to perform this operation on a database with many 
+It is not recommended to perform this operation on a database with many
 tables.
 The output can be used to recreate a database.'
 `,
@@ -447,7 +447,7 @@ The output can be used to recreate a database.'
 			},
 			showCreateAllTypesGeneratorType,
 			makeShowCreateAllTypesGenerator,
-			`Returns rows of CREATE type statements. 
+			`Returns rows of CREATE type statements.
 The output can be used to recreate a database.'
 `,
 			volatility.Volatile,
@@ -468,15 +468,31 @@ The output can be used to recreate a database.'
 			volatility.Volatile,
 		),
 	),
+	"crdb_internal.decode_external_plan_gist": makeBuiltin(
+		tree.FunctionProperties{
+			Class: tree.GeneratorClass,
+		},
+		makeGeneratorOverload(
+			tree.ArgTypes{
+				{"gist", types.String},
+			},
+			decodePlanGistGeneratorType,
+			makeDecodeExternalPlanGistGenerator,
+			`Returns rows of output similar to EXPLAIN from a gist such as those found in planGists element of the statistics column of the statement_statistics table without attempting to resolve tables or indexes.
+			`,
+			volatility.Volatile,
+		),
+	),
 }
 
 var decodePlanGistGeneratorType = types.String
 
 type gistPlanGenerator struct {
-	gist  string
-	index int
-	rows  []string
-	p     eval.Planner
+	gist     string
+	index    int
+	rows     []string
+	evalCtx  *eval.Context
+	external bool
 }
 
 var _ eval.ValueGenerator = &gistPlanGenerator{}
@@ -486,7 +502,7 @@ func (g *gistPlanGenerator) ResolvedType() *types.T {
 }
 
 func (g *gistPlanGenerator) Start(_ context.Context, _ *kv.Txn) error {
-	rows, err := g.p.DecodeGist(g.gist)
+	rows, err := g.evalCtx.Planner.DecodeGist(g.gist, g.external)
 	if err != nil {
 		return err
 	}
@@ -509,7 +525,14 @@ func (g *gistPlanGenerator) Values() (tree.Datums, error) {
 
 func makeDecodePlanGistGenerator(ctx *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
 	gist := string(tree.MustBeDString(args[0]))
-	return &gistPlanGenerator{gist: gist, p: ctx.Planner}, nil
+	return &gistPlanGenerator{gist: gist, evalCtx: ctx, external: false}, nil
+}
+
+func makeDecodeExternalPlanGistGenerator(
+	ctx *eval.Context, args tree.Datums,
+) (eval.ValueGenerator, error) {
+	gist := string(tree.MustBeDString(args[0]))
+	return &gistPlanGenerator{gist: gist, evalCtx: ctx, external: true}, nil
 }
 
 func makeGeneratorOverload(
@@ -1956,7 +1979,7 @@ func makePayloadsForTraceGenerator(
 									SELECT span_id
   	 							FROM crdb_internal.node_inflight_trace_spans
  		 							WHERE trace_id = $1
-									) SELECT * 
+									) SELECT *
 										FROM spans, LATERAL crdb_internal.payloads_for_span(spans.span_id)`
 
 	it, err := ctx.Planner.QueryIteratorEx(

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -213,7 +213,7 @@ type Planner interface {
 	ExternalWriteFile(ctx context.Context, uri string, content []byte) error
 
 	// DecodeGist exposes gist functionality to the builtin functions.
-	DecodeGist(gist string) ([]string, error)
+	DecodeGist(gist string, external bool) ([]string, error)
 
 	// SerializeSessionState serializes the variables in the current session
 	// and returns a state, in bytes form.


### PR DESCRIPTION
**sql: include gist in sentry reports**

Fixes: #80628

Release note: None


**sql: add new builtin to decode foreign gists**

Before we assumed the gist was being decoded in the same or similar db
as where the gist was created. With gists being added to sentry reports
its important to support decoding foreign gists. We do this by using
an nil catalog.

Informs: https://github.com/cockroachdb/cockroach/issues/80628

Release note: None