### PR TITLE
dev: make top-level dev runnable from anywhere

### DIFF
--- a/dev
+++ b/dev
@@ -22,4 +22,5 @@ if [[ ! -f "$BINARY_PATH" ]]; then
     chmod a+w $BINARY_PATH
 fi
 
+cd $THIS_DIR
 exec $BINARY_PATH "$@"


### PR DESCRIPTION
This should obviate the need to run dev from the top-level checkout; as
long as it's in your path or have an alias to the script, you should be
able to run dev wherever you are. It'll save you the need for the
leading './' when invoking things.

Release note: None