### PR TITLE
server,netutil: add missing context argument

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -958,6 +958,9 @@ func (s *Server) PreStart(ctx context.Context) error {
 		return err
 	}
 
+	// Start a context for the asynchronous network workers.
+	workersCtx := s.AnnotateCtx(context.Background())
+
 	// connManager tracks incoming connections accepted via listeners
 	// and automatically closes them when the stopper indicates a
 	// shutdown.
@@ -966,10 +969,7 @@ func (s *Server) PreStart(ctx context.Context) error {
 	// - SQL client connections with a TLS handshake over TCP.
 	// (gRPC connections are handled separately via s.grpc and perform
 	// their TLS handshake on their own)
-	connManager := netutil.MakeServer(s.stopper, uiTLSConfig, http.HandlerFunc(s.http.baseHandler))
-
-	// Start a context for the asynchronous network workers.
-	workersCtx := s.AnnotateCtx(context.Background())
+	connManager := netutil.MakeServer(workersCtx, s.stopper, uiTLSConfig, http.HandlerFunc(s.http.baseHandler))
 
 	// Start the admin UI server. This opens the HTTP listen socket,
 	// optionally sets up TLS, and dispatches the server worker for the

--- a/pkg/server/server_http.go
+++ b/pkg/server/server_http.go
@@ -256,7 +256,7 @@ func (s *httpServer) start(
 			})
 			mux.Handle(healthPath, http.HandlerFunc(s.baseHandler))
 
-			plainRedirectServer := netutil.MakeServer(stopper, uiTLSConfig, mux)
+			plainRedirectServer := netutil.MakeServer(workersCtx, stopper, uiTLSConfig, mux)
 
 			netutil.FatalIfUnexpected(plainRedirectServer.Serve(clearL))
 		}); err != nil {

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -286,7 +286,7 @@ func startTenantInternal(
 		return nil, nil, nil, "", "", err
 	}
 
-	connManager := netutil.MakeServer(
+	connManager := netutil.MakeServer(ctx,
 		args.stopper,
 		serverTLSConfig,                          // tlsConfig
 		http.HandlerFunc(httpServer.baseHandler), // handler

--- a/pkg/util/netutil/net.go
+++ b/pkg/util/netutil/net.go
@@ -80,7 +80,9 @@ type Server struct {
 // When the HTTP facility is not used, the Go HTTP server object is
 // still used internally to maintain/register the connections via the
 // ConnState() method, for convenience.
-func MakeServer(stopper *stop.Stopper, tlsConfig *tls.Config, handler http.Handler) Server {
+func MakeServer(
+	ctx context.Context, stopper *stop.Stopper, tlsConfig *tls.Config, handler http.Handler,
+) Server {
 	var mu syncutil.Mutex
 	activeConns := make(map[net.Conn]struct{})
 	server := Server{
@@ -100,8 +102,6 @@ func MakeServer(stopper *stop.Stopper, tlsConfig *tls.Config, handler http.Handl
 			ErrorLog: httpLogger,
 		},
 	}
-
-	ctx := context.TODO()
 
 	// net/http.(*Server).Serve/http2.ConfigureServer are not thread safe with
 	// respect to net/http.(*Server).TLSConfig, so we call it synchronously here.


### PR DESCRIPTION
Fixes #79996.

Release note: None