### PR TITLE
sql: add a cluster setting to require pre-hashing

### DIFF
--- a/pkg/security/password.go
+++ b/pkg/security/password.go
@@ -147,6 +147,15 @@ var AutoDetectPasswordHashes = settings.RegisterBoolSetting(
 	true,
 )
 
+// RequirePasswordHashes is the cluster setting that configures whether
+// new password credentials submitted via SQL must be pre-hashed.
+var RequirePasswordHashes = settings.RegisterBoolSetting(
+	settings.TenantWritable,
+	"server.user_login.require_pre_hashed_passwords.enabled",
+	"whether the server requires the client to pre-hash passwords",
+	false,
+)
+
 // MinPasswordLength is the cluster setting that configures the
 // minimum SQL password length.
 var MinPasswordLength = settings.RegisterIntSetting(

--- a/pkg/sql/create_role.go
+++ b/pkg/sql/create_role.go
@@ -263,7 +263,7 @@ func (p *planner) checkPasswordAndGetHash(
 	}
 
 	st := p.ExecCfg().Settings
-	if security.AutoDetectPasswordHashes.Get(&st.SV) {
+	if autoDetect, requireHash := security.AutoDetectPasswordHashes.Get(&st.SV), security.RequirePasswordHashes.Get(&st.SV); autoDetect || requireHash {
 		var isPreHashed, schemeSupported bool
 		var schemeName string
 		var issueNum int
@@ -276,6 +276,8 @@ func (p *planner) checkPasswordAndGetHash(
 				return hashedPassword, unimplemented.NewWithIssueDetailf(issueNum, schemeName, "the password hash scheme %q is not supported", schemeName)
 			}
 			return hashedPassword, nil
+		} else /* !isPreHashed */ if requireHash {
+			return hashedPassword, errors.New("password must be pre-hashed by client")
 		}
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -1550,3 +1550,37 @@ RESET CLUSTER SETTING server.user_login.password_encryption;
 
 statement ok
 RESET CLUSTER SETTING server.user_login.password_hashes.default_cost.scram_sha_256
+
+
+subtest require_hash
+
+statement ok
+SET CLUSTER SETTING server.user_login.require_pre_hashed_passwords.enabled = true
+
+# Password hash recognized
+statement ok
+CREATE USER hash9 WITH PASSWORD '$bcrypt_pw'
+
+# Password hash recognized (albeit with method not supported)
+statement error the password hash scheme "md5" is not supported
+CREATE USER hash10 WITH PASSWORD 'md5aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
+# Password hash recognized
+statement ok
+CREATE USER hasha WITH PASSWORD '$scram_pw'
+
+# Error: password not pre-hashed.
+statement error password must be pre-hashed by client
+CREATE USER hashb WITH PASSWORD 'abc'
+
+query TTB
+SELECT username, substr("hashedPassword", 1, 7), 'CRDB-BCRYPT'||"hashedPassword" = '$bcrypt_pw' FROM system.users WHERE username LIKE 'hash%' ORDER BY 1 DESC LIMIT 3
+----
+hasha  SCRAM-S  false
+hash9  $2a$10$  true
+hash8  SCRAM-S  false
+
+# Reset cluster setting after test completion.
+statement ok
+RESET CLUSTER SETTING server.user_login.require_pre_hashed_passwords.enabled;
+


### PR DESCRIPTION
Fixes #80362.

Release note (security note): It is now possible to require
the client to pre-hash passwords using the new cluster setting
`server.user_login.require_pre_hashed_passwords.enabled`. When
enabled, the server reports an error if a non-pre-hashed password
is submitted to CREATE/ALTER USER/ROLE WITH PASSWORD.

This feature is useful in IT deployments that require the DB server
to remain blind to user credentials at all times.