### PR TITLE
release-21.1: roachtest: fix django nightly test

### DIFF
--- a/pkg/cmd/roachtest/django.go
+++ b/pkg/cmd/roachtest/django.go
@@ -62,15 +62,15 @@ func registerDjango(r *testRegistry) {
 			c,
 			node,
 			"install dependencies",
-			`sudo apt-get -qq install make python3.7 libpq-dev python3.7-dev gcc python3-setuptools python-setuptools build-essential`,
+			`sudo apt-get -qq install make python3.8 libpq-dev python3.8-dev gcc python3-virtualenv python3-setuptools python-setuptools build-essential python3.8-distutils python3-apt libmemcached-dev`,
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		if err := repeatRunE(
-			ctx, c, node, "set python3.7 as default", `
+			ctx, c, node, "set python3.8 as default", `
     		sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.5 1
-    		sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 2
+    		sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 2
     		sudo update-alternatives --config python3`,
 		); err != nil {
 			t.Fatal(err)
@@ -78,7 +78,15 @@ func registerDjango(r *testRegistry) {
 
 		if err := repeatRunE(
 			ctx, c, node, "install pip",
-			`curl https://bootstrap.pypa.io/get-pip.py | sudo -H python3.7`,
+			`curl https://bootstrap.pypa.io/get-pip.py | sudo -H python3.8`,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repeatRunE(
+			ctx, c, node, "create virtualenv",
+			`virtualenv venv &&
+				source venv/bin/activate`,
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -88,7 +96,7 @@ func registerDjango(r *testRegistry) {
 			c,
 			node,
 			"install pytest",
-			`sudo pip3 install pytest pytest-xdist psycopg2`,
+			`pip3 install pytest pytest-xdist psycopg2`,
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -144,9 +152,9 @@ func registerDjango(r *testRegistry) {
 		if err := repeatRunE(
 			ctx, c, node, "install django's dependencies", `
 				cd /mnt/data1/django/tests &&
-				sudo pip3 install -e .. &&
-				sudo pip3 install -r requirements/py3.txt &&
-				sudo pip3 install -r requirements/postgres.txt`,
+				pip3 install -e .. &&
+				pip3 install -r requirements/py3.txt &&
+				pip3 install -r requirements/postgres.txt`,
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -154,7 +162,7 @@ func registerDjango(r *testRegistry) {
 		if err := repeatRunE(
 			ctx, c, node, "install django-cockroachdb", `
 					cd /mnt/data1/django/tests/django-cockroachdb/ &&
-					sudo pip3 install .`,
+					pip3 install .`,
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -261,4 +269,6 @@ class NonDescribingDiscoverRunner(DiscoverRunner):
             'verbosity': self.verbosity,
             'descriptions': False,
         }
+
+USE_TZ = False
 `


### PR DESCRIPTION
Backport 1/1 commits from #80458

/cc @cockroachdb/release

- Enable pip installation.
- Upgrade to Python 3.8 to match django-cockroach 4.0.x requirements.
- Modify the test to run on a virtual env to avoid sudo pip3.

Fixes #80298

Release note: None

Release justification: None\n