### PR TITLE
release-22.1: backupccl: add telemetry for deprecated forms of backupccl cmds

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/build"
@@ -1074,9 +1075,30 @@ func collectTelemetry(
 	}
 	if backupDetails.CollectionURI != "" {
 		countSource("backup.nested")
-		if initialDetails.Destination.Subdir == latestFileName {
-			countSource("backup.into-latest")
+		timeBaseSubdir := true
+		if _, err := time.Parse(DateBasedIntoFolderName,
+			initialDetails.Destination.Subdir); err != nil {
+			timeBaseSubdir = false
 		}
+		if backupDetails.StartTime.IsEmpty() {
+			if !timeBaseSubdir {
+				countSource("backup.deprecated-full-nontime-subdir")
+			} else if initialDetails.Destination.Exists {
+				countSource("backup.deprecated-full-time-subdir")
+			} else {
+				countSource("backup.full-no-subdir")
+			}
+		} else {
+			if initialDetails.Destination.Subdir == latestFileName {
+				countSource("backup.incremental-latest-subdir")
+			} else if !timeBaseSubdir {
+				countSource("backup.deprecated-incremental-nontime-subdir")
+			} else {
+				countSource("backup.incremental-explicit-subdir")
+			}
+		}
+	} else {
+		countSource("backup.deprecated-non-collection")
 	}
 	if backupManifest.DescriptorCoverage == tree.AllDescriptors {
 		countSource("backup.targets.full_cluster")

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1795,6 +1795,11 @@ func doRestorePlan(
 		if restoreStmt.DescriptorCoverage == tree.AllDescriptors {
 			telemetry.Count("restore.full-cluster")
 		}
+		if restoreStmt.Subdir == nil {
+			telemetry.Count("restore.deprecated-subdir-syntax")
+		} else {
+			telemetry.Count("restore.collection")
+		}
 	}
 
 	encodedTables := make([]*descpb.TableDescriptor, len(tables))


### PR DESCRIPTION
Backport 1/1 commits from #80303.

/cc @cockroachdb/release

---

Release note: None

Release Justification: only adding telemetry