### PR TITLE
sql: do not drop physical shard column if not cascade.

### DIFF
--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -55,7 +55,7 @@ Query {"String": "DROP INDEX t_x_idx"}
 until crdb_only
 CommandComplete
 ----
-{"Severity":"NOTICE","SeverityUnlocalized":"","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":560,"Routine":"dropIndexByName","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":572,"Routine":"dropIndexByName","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 
 until noncrdb_only


### PR DESCRIPTION
Release note (sql change): Previously, when we drop a hash-sharded
index, we will also drop the accompanying shard column, if no other
index uses this shard column.

For hash-sharded index created in 21.2 and prior, this shard
column is a physical, `STORED` column. Dropping such a physical column
can be very expensive since it requires a full table rewrite. For
hash-sharded index craeted in 22.1 and later, this shard column is a
virtual, computed column and dropping a virtual column is no problem.

This PR introduces the sql change that, if the to-be-dropped
sharded index has a physical shard column (and no other index uses that
column), we will drop only the index if not CASCADE; we will drop both
the index and the column if CASCADE.

Fixed: #80181