### PR TITLE
opt: consolidate duplicate join helper methods

### DIFF
--- a/pkg/sql/opt/lookupjoin/BUILD.bazel
+++ b/pkg/sql/opt/lookupjoin/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//pkg/sql/opt/props",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
-        "//pkg/sql/types",
     ],
 )
 

--- a/pkg/sql/opt/lookupjoin/BUILD.bazel
+++ b/pkg/sql/opt/lookupjoin/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "lookupjoin",
-    srcs = ["constraint_builder.go"],
+    srcs = [
+        "constraint_builder.go",
+        "filter.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/lookupjoin",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/sql/opt/lookupjoin/constraint_builder.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder.go
@@ -135,7 +135,7 @@ func (b *ConstraintBuilder) Build(
 	firstIdxCol := b.table.IndexColumnID(index, 0)
 	if _, ok := b.rightEq.Find(firstIdxCol); !ok {
 		if _, ok := b.findComputedColJoinEquality(b.table, firstIdxCol, b.rightEqSet); !ok {
-			if _, _, ok := b.findJoinFilterConstants(allFilters, firstIdxCol); !ok {
+			if _, _, ok := FindJoinFilterConstants(allFilters, firstIdxCol, b.evalCtx); !ok {
 				return Constraint{}
 			}
 		}
@@ -192,7 +192,7 @@ func (b *ConstraintBuilder) Build(
 		// constant values. We cannot use a NULL value because the lookup
 		// join implements logic equivalent to simple equality between
 		// columns (where NULL never equals anything).
-		foundVals, allIdx, ok := b.findJoinFilterConstants(allFilters, idxCol)
+		foundVals, allIdx, ok := FindJoinFilterConstants(allFilters, idxCol, b.evalCtx)
 		if ok && len(foundVals) == 1 {
 			// If a single constant value was found, project it in the input
 			// and use it as an equality column.
@@ -380,7 +380,7 @@ func (b *ConstraintBuilder) findFiltersForIndexLookup(
 		// constant values. We cannot use a NULL value because the lookup
 		// join implements logic equivalent to simple equality between
 		// columns (where NULL never equals anything).
-		values, allIdx, foundConstFilter := b.findJoinFilterConstants(filters, idxCol)
+		values, allIdx, foundConstFilter := FindJoinFilterConstants(filters, idxCol, b.evalCtx)
 		if !foundConstFilter {
 			// If there's no const filters look for an inequality range.
 			allIdx, foundRange = b.findJoinFilterRange(filters, idxCol)
@@ -441,43 +441,6 @@ func (b *ConstraintBuilder) makeConstFilter(col opt.ColumnID, values tree.Datums
 		b.f.ConstructVariable(col),
 		b.f.ConstructTuple(elems, types.MakeTuple(elemTypes)),
 	))
-}
-
-// findJoinFilterConstants tries to find a filter that is exactly equivalent to
-// constraining the given column to a constant value or a set of constant
-// values. If successful, the constant values and the index of the constraining
-// FiltersItem are returned. If multiple filters match, the one that minimizes
-// the number of returned values is chosen. Note that the returned constant
-// values do not contain NULL.
-func (b *ConstraintBuilder) findJoinFilterConstants(
-	filters memo.FiltersExpr, col opt.ColumnID,
-) (values tree.Datums, filterIdx int, ok bool) {
-	var bestValues tree.Datums
-	var bestFilterIdx int
-	for filterIdx := range filters {
-		props := filters[filterIdx].ScalarProps()
-		if props.TightConstraints {
-			constCol, constVals, ok := props.Constraints.HasSingleColumnConstValues(b.evalCtx)
-			if !ok || constCol != col {
-				continue
-			}
-			hasNull := false
-			for i := range constVals {
-				if constVals[i] == tree.DNull {
-					hasNull = true
-					break
-				}
-			}
-			if !hasNull && (bestValues == nil || len(bestValues) > len(constVals)) {
-				bestValues = constVals
-				bestFilterIdx = filterIdx
-			}
-		}
-	}
-	if bestValues == nil {
-		return nil, -1, false
-	}
-	return bestValues, bestFilterIdx, true
 }
 
 // findJoinFilterRange tries to find an inequality range for this column.

--- a/pkg/sql/opt/lookupjoin/filter.go
+++ b/pkg/sql/opt/lookupjoin/filter.go
@@ -1,0 +1,55 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package lookupjoin
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// FindJoinFilterConstants tries to find a filter that is exactly equivalent to
+// constraining the given column to a constant value or a set of constant
+// values. If successful, the constant values and the index of the constraining
+// FiltersItem are returned. If multiple filters match, the one that minimizes
+// the number of returned values is chosen. Note that the returned constant
+// values do not contain NULL.
+func FindJoinFilterConstants(
+	filters memo.FiltersExpr, col opt.ColumnID, evalCtx *eval.Context,
+) (values tree.Datums, filterIdx int, ok bool) {
+	var bestValues tree.Datums
+	var bestFilterIdx int
+	for filterIdx := range filters {
+		props := filters[filterIdx].ScalarProps()
+		if props.TightConstraints {
+			constCol, constVals, ok := props.Constraints.HasSingleColumnConstValues(evalCtx)
+			if !ok || constCol != col {
+				continue
+			}
+			hasNull := false
+			for i := range constVals {
+				if constVals[i] == tree.DNull {
+					hasNull = true
+					break
+				}
+			}
+			if !hasNull && (bestValues == nil || len(bestValues) > len(constVals)) {
+				bestValues = constVals
+				bestFilterIdx = filterIdx
+			}
+		}
+	}
+	if bestValues == nil {
+		return nil, -1, false
+	}
+	return bestValues, bestFilterIdx, true
+}

--- a/pkg/sql/opt/lookupjoin/testdata/lookup_expr
+++ b/pkg/sql/opt/lookupjoin/testdata/lookup_expr
@@ -88,6 +88,21 @@ optional: z IN (3, 4)
 lookup expression:
   ((y = b) AND (x = 1)) AND (z IN (3, 4))
 
+# The most restrictive IN filter should be chosen.
+lookup-constraints left=(a int, b int) right=(x int, y int) index=(x, y)
+x IN (1, 2) AND y = b
+optional: x IN (1, 2, 3)
+----
+lookup expression:
+  (y = b) AND (x IN (1, 2))
+
+lookup-constraints left=(a int, b int) right=(x int, y int) index=(x, y)
+x IN (1, 2, 3) AND y = b
+optional: x IN (1, 2)
+----
+lookup expression:
+  (y = b) AND (x IN (1, 2))
+
 
 # Test for range filters.
 


### PR DESCRIPTION
#### opt: consolidate duplicate findJoinFilterConstants methods

This commit consolidates duplicate methods
`CustomFuncs.findJoinFilterConstants` and
`ConstaintBuilder.findJoinFilterConstants` into the function
`lookupjoin.FindJoinFilterConstants`.

Also, a couple additional tests related to this function have been
added.

Release note: None

#### opt: move consolidate makeConstFilter methods

The duplicate methods `CustomFuncs.makeConstFilter` and
`ContraintBuilder.makeConstFilter` have been consolidated into
`Factory.ConstructConstFilter`.

Release note: None