### PR TITLE
scripts: use https URL scheme in tag-custom-build.sh, not SSH

### DIFF
--- a/scripts/tag-custom-build.sh
+++ b/scripts/tag-custom-build.sh
@@ -47,7 +47,7 @@ ID="$(git describe --tags --match=v[0-9]* "$SHA")"
 TAG="custombuild-$ID"
 
 git tag "$TAG" "$SHA"
-git push git@github.com:cockroachdb/cockroach.git "$TAG"
+git push https://github.com/cockroachdb/cockroach.git "$TAG"
 
 TAG_URL="https://github.com/cockroachdb/cockroach/releases/tag/${TAG}"
 TEAMCITY_URL="https://teamcity.cockroachdb.com/buildConfiguration/Internal_Release_Process_TestingMakeAndPublishBuildV221?mode=builds&branch=${TAG}"


### PR DESCRIPTION
This removes a requirement that users of this script have a public SSH key for their current system in their GitHub account. I don't think there's any meaningful downside to this change, but I could be missing something.