### PR TITLE
kv: prioritize snapshots to leaseholders, then voters, then learners

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -256,6 +256,7 @@ go_test(
         "queue_test.go",
         "raft_log_queue_test.go",
         "raft_log_truncator_test.go",
+        "raft_snapshot_queue_test.go",
         "raft_test.go",
         "raft_transport_test.go",
         "raft_transport_unit_test.go",

--- a/pkg/kv/kvserver/raft_snapshot_queue.go
+++ b/pkg/kv/kvserver/raft_snapshot_queue.go
@@ -12,6 +12,7 @@ package kvserver
 
 import (
 	"context"
+	"math"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
@@ -20,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"go.etcd.io/etcd/raft/v3"
 	"go.etcd.io/etcd/raft/v3/tracker"
 )
 
@@ -28,7 +30,9 @@ const (
 	// queued replicas.
 	raftSnapshotQueueTimerDuration = 0 // zero duration to process Raft snapshots greedily
 
-	raftSnapshotPriority float64 = 0
+	raftSnapshotToLeaseholderPriority float64 = 3
+	raftSnapshotToVoterPriority       float64 = 2
+	raftSnapshotToLearnerPriority     float64 = 1
 )
 
 // raftSnapshotQueue manages a queue of replicas which may need to catch a
@@ -60,22 +64,55 @@ func newRaftSnapshotQueue(store *Store) *raftSnapshotQueue {
 	return rq
 }
 
-func (rq *raftSnapshotQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ spanconfig.StoreReader,
-) (shouldQueue bool, priority float64) {
-	// If a follower needs a snapshot, enqueue at the highest priority.
-	if status := repl.RaftStatus(); status != nil {
-		// raft.Status.Progress is only populated on the Raft group leader.
-		for _, p := range status.Progress {
-			if p.State == tracker.StateSnapshot {
-				if log.V(2) {
-					log.Infof(ctx, "raft snapshot needed, enqueuing")
-				}
-				return true, raftSnapshotPriority
+type snapshoter interface {
+	raftWithProgressIfLeader(withProgressVisitor)
+	getLeaseRLocked() (cur, next roachpb.Lease)
+}
+
+// raftSnapshotQueuePriority returns the priority for the replica to send a
+// snapshot. If followers do need snapshots, the priority is a function of the
+// types of followers that need snapshots. Returns -1 if the replica is not the
+// leader or if no snapshots are needed.
+func raftSnapshotQueuePriority(repl snapshoter) float64 {
+	priority := -1.0
+	repl.raftWithProgressIfLeader(func(id uint64, _ raft.ProgressType, pr tracker.Progress) {
+		if pr.State == tracker.StateSnapshot {
+			var curPriority float64
+			// NB: repl.mu.RLock()'d by raftWithProgress.
+			lease, _ := repl.getLeaseRLocked()
+			if roachpb.ReplicaID(id) == lease.Replica.ReplicaID {
+				// If a leaseholder needs a snapshot, give it priority over all other
+				// snapshots. The leaseholder may be so far behind on its log that it
+				// does not even realize that it holds the lease. In such cases, the
+				// range is unavailable for reads and writes until the leaseholder
+				// receives its snapshot, so send one ASAP. We don't bother to check the
+				// lease validity.
+				curPriority = raftSnapshotToLeaseholderPriority
+			} else if !pr.IsLearner {
+				// If a voter needs a snapshot, give it priority over learners because a
+				// voter in need of a snapshot can not vote for new proposals, so it may
+				// be needed to achieve quorum on the range for write availability.
+				curPriority = raftSnapshotToVoterPriority
+			} else {
+				curPriority = raftSnapshotToLearnerPriority
 			}
+			priority = math.Max(priority, curPriority)
 		}
+	})
+	return priority
+}
+
+func (rq *raftSnapshotQueue) shouldQueue(
+	ctx context.Context, _ hlc.ClockTimestamp, repl *Replica, _ spanconfig.StoreReader,
+) (shouldQueue bool, priority float64) {
+	priority = raftSnapshotQueuePriority(repl)
+	if priority < 0 {
+		return false, 0
 	}
-	return false, 0
+	if log.V(2) {
+		log.Infof(ctx, "raft snapshot needed, enqueuing with priority %f", priority)
+	}
+	return true, priority
 }
 
 func (rq *raftSnapshotQueue) process(

--- a/pkg/kv/kvserver/raft_snapshot_queue_test.go
+++ b/pkg/kv/kvserver/raft_snapshot_queue_test.go
@@ -1,0 +1,111 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvserver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/raft/v3"
+	"go.etcd.io/etcd/raft/v3/tracker"
+)
+
+type testSnapshoter struct {
+	progress map[uint64]tracker.Progress
+	lease    roachpb.Lease
+}
+
+func (s testSnapshoter) raftWithProgressIfLeader(f withProgressVisitor) {
+	for id, pr := range s.progress {
+		typ := raft.ProgressTypePeer
+		if pr.IsLearner {
+			typ = raft.ProgressTypeLearner
+		}
+		f(id, typ, pr)
+	}
+}
+
+func (s testSnapshoter) getLeaseRLocked() (cur, next roachpb.Lease) {
+	return s.lease, roachpb.Lease{}
+}
+
+func TestRaftSnapshotQueuePriority(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testCases := []struct {
+		// if true, needs snapshot
+		leaseholder bool
+		voter       bool
+		learner     bool
+		// expected priority
+		expected float64
+	}{
+		{false, false, false, -1},
+		{false, false, true, raftSnapshotToLearnerPriority},
+		{false, true, false, raftSnapshotToVoterPriority},
+		{false, true, true, raftSnapshotToVoterPriority},
+		{true, false, false, raftSnapshotToLeaseholderPriority},
+		{true, false, true, raftSnapshotToLeaseholderPriority},
+		{true, true, false, raftSnapshotToLeaseholderPriority},
+		{true, true, true, raftSnapshotToLeaseholderPriority},
+	}
+	for _, c := range testCases {
+		var parts []string
+		if c.leaseholder {
+			parts = append(parts, "leaseholder")
+		}
+		if c.voter {
+			parts = append(parts, "voter")
+		}
+		if c.learner {
+			parts = append(parts, "learner")
+		}
+		name := strings.Join(parts, "+")
+		if name == "" {
+			name = "none"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			leaderState := tracker.StateReplicate
+			leaseholderState := tracker.StateReplicate
+			voterState := tracker.StateReplicate
+			learnerState := tracker.StateReplicate
+			if c.leaseholder {
+				leaseholderState = tracker.StateSnapshot
+			}
+			if c.voter {
+				voterState = tracker.StateSnapshot
+			}
+			if c.learner {
+				learnerState = tracker.StateSnapshot
+			}
+			s := testSnapshoter{
+				progress: map[uint64]tracker.Progress{
+					1: {State: leaderState},
+					2: {State: leaseholderState},
+					3: {State: voterState},
+					4: {State: learnerState, IsLearner: true},
+				},
+				lease: roachpb.Lease{
+					Replica: roachpb.ReplicaDescriptor{ReplicaID: 2},
+				},
+			}
+
+			priority := raftSnapshotQueuePriority(s)
+			require.Equal(t, c.expected, priority)
+		})
+	}
+}

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -56,6 +56,7 @@ import (
 	"github.com/cockroachdb/redact"
 	"github.com/kr/pretty"
 	"go.etcd.io/etcd/raft/v3"
+	"go.etcd.io/etcd/raft/v3/tracker"
 )
 
 const (
@@ -1224,6 +1225,28 @@ func (r *Replica) raftBasicStatusRLocked() raft.BasicStatus {
 		return rg.BasicStatus()
 	}
 	return raft.BasicStatus{}
+}
+
+type withProgressVisitor func(id uint64, typ raft.ProgressType, pr tracker.Progress)
+
+// raftWithProgressIfLeader is a helper to efficiently introspect the Progress
+// for each member of the replica's Raft group. The visitor is never called if
+// the Raft group has not been initialized yet or if the replica is not the
+// current Raft leader. The visitor is called while holding Replica.mu in read
+// mode.
+func (r *Replica) raftWithProgressIfLeader(f withProgressVisitor) {
+	r.mu.RLock()
+	r.raftWithProgressIfLeaderRLocked(f)
+	r.mu.RUnlock()
+}
+
+func (r *Replica) raftWithProgressIfLeaderRLocked(f withProgressVisitor) {
+	if rg := r.mu.internalRaftGroup; rg != nil {
+		s := r.mu.internalRaftGroup.BasicStatus()
+		if s.RaftState == raft.StateLeader {
+			r.mu.internalRaftGroup.WithProgress(f)
+		}
+	}
 }
 
 // State returns a copy of the internal state of the Replica, along with some

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1529,7 +1529,7 @@ func (r *Replica) sendRaftMessageRaftMuLocked(ctx context.Context, msg raftpb.Me
 
 	// Raft-initiated snapshots are handled by the Raft snapshot queue.
 	if msg.Type == raftpb.MsgSnap {
-		r.store.raftSnapshotQueue.AddAsync(ctx, r, raftSnapshotPriority)
+		r.store.raftSnapshotQueue.AddAsync(ctx, r, raftSnapshotQueuePriority(r))
 		return
 	}
 


### PR DESCRIPTION
This commit adds prioritization to the `raftSnapshotQueue` so that it sends
Raft snapshots to the replicas that are most in need of snapshots first. The
prioritization order is to first send snapshots to leaseholder replicas, then
voter replicas, then learner replicas.

Prioritizing snapshots to leaseholders is an important availability improvement.
The leaseholder may be so far behind on its log that it does not even realize
that it holds the lease. In such cases, the range is unavailable for reads and
writes until the leaseholder receives its snapshot, so send one ASAP.

Beyond leaseholders, we prioritize snapshots to voter replicas because a voter
in need of a snapshot can not vote for new proposals, so it may be needed to
achieve quorum on its range for write availability.

There's room to go further here. For instance, we could make a determination
about the relative importance of a given voter snapshot based on whether its
range is unavailable or not. This commit does not try to do something like this.

Release note (bug fix): Raft snapshots to replicas are now prioritized based on
their relative importance for availability. Snapshots to leaseholders are given
the highest priority, followed by snapshots to voter replicas, followed by
snapshots to learner replicas.