### PR TITLE
kvserver: IsCompleteTransaction might panic with certain batch sequences

### DIFF
--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -358,6 +358,7 @@ func (ba *BatchRequest) IsCompleteTransaction() bool {
 	// Check whether any sequence numbers were skipped between 1 and the
 	// EndTxn's sequence number. A Batch is only a complete transaction
 	// if it contains every write that the transaction performed.
+	// Sequence numbers are assigned to requests in txnSeqNumAllocator.
 	nextSeq := enginepb.TxnSeq(1)
 	for _, args := range ba.Requests {
 		req := args.GetInner()
@@ -375,7 +376,15 @@ func (ba *BatchRequest) IsCompleteTransaction() bool {
 			}
 		}
 	}
-	panic("unreachable")
+	// Unreachable.
+	var sb strings.Builder
+	for i, args := range ba.Requests {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(args.String())
+	}
+	panic(fmt.Sprintf("unreachable. Batch requests: %s", sb.String()))
 }
 
 // hasFlag returns true iff one of the requests within the batch contains the


### PR DESCRIPTION
It's unclear how this panic happened. One possibility is that EntTxn had a negative sequence number. Another hypothesis is that ba.Requests was concurrently mutated due to a data race. This happened once, so for now adding more info to the panic.

Release note: None

Jira issue: https://cockroachlabs.atlassian.net/browse/CRDB-14627