### PR TITLE
cockroach-sql: allow invocation via a `sql` sub-command

### DIFF
--- a/pkg/cmd/cockroach-sql/main.go
+++ b/pkg/cmd/cockroach-sql/main.go
@@ -65,6 +65,13 @@ func main() {
 	f.BoolVar(&cfg.ConnCtx.DebugMode, cliflags.CliDebugMode.Name, cfg.ConnCtx.DebugMode, cliflags.CliDebugMode.Description)
 	f.BoolVar(&cfg.ConnCtx.Echo, cliflags.EchoSQL.Name, cfg.ConnCtx.Echo, cliflags.EchoSQL.Description)
 
+	// We want to simplify tutorials, docs etc by allowing
+	// 'cockroach-sql' to be symlinked to 'cockroach' and
+	// ensure that the resulting symlink still works when invoked
+	// as 'cockroach sql' (with a 'sql' sub-command).
+	subCmd := *sqlCmd
+	sqlCmd.AddCommand(&subCmd)
+
 	errCode := exit.Success()
 	if err := sqlCmd.Execute(); err != nil {
 		clierror.OutputError(os.Stderr, err, true /*showSeverity*/, false /*verbose*/)


### PR DESCRIPTION
Requested by @ianjevans 
Fixes #79850.

We want to simplify tutorials, docs etc by allowing 'cockroach-sql' to
be symlinked to 'cockroach' and ensure that the resulting symlink
still works when invoked as 'cockroach sql' (with a 'sql'
sub-command).

Release note (cli change): The standalone SQL shell executable
`cockroach-sql` can now be installed (renamed/symlinked) as
`cockroach`, and invoked via `cockroach sql`. For example, the
following commands are all equivalent:

```
$ cockroach-sql -f foo.sql
$ cockroach-sql sql -f foo.sql
after running `ln -s cockroach-sql cockroach`:
$ cockroach sql -f foo.sql
```