### PR TITLE
release-22.1: kvserver: don't transfer leases to draining nodes during scatters

### DIFF
--- a/pkg/kv/kvclient/kvcoord/replica_slice.go
+++ b/pkg/kv/kvclient/kvcoord/replica_slice.go
@@ -81,7 +81,7 @@ func NewReplicaSlice(
 		}
 	}
 	canReceiveLease := func(rDesc roachpb.ReplicaDescriptor) bool {
-		if err := roachpb.CheckCanReceiveLease(rDesc, desc); err != nil {
+		if err := roachpb.CheckCanReceiveLease(rDesc, desc.Replicas()); err != nil {
 			return false
 		}
 		return true

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -290,6 +290,7 @@ go_test(
         "replicate_test.go",
         "reset_quorum_test.go",
         "scanner_test.go",
+        "scatter_test.go",
         "scheduler_test.go",
         "single_key_test.go",
         "split_delay_helper_test.go",

--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -1874,7 +1874,7 @@ func (a *Allocator) ShouldTransferLease(
 	sl, _, _ := a.storePool.getStoreList(storeFilterSuspect)
 	sl = sl.excludeInvalid(conf.Constraints)
 	sl = sl.excludeInvalid(conf.VoterConstraints)
-	log.VEventf(ctx, 3, "ShouldTransferLease (lease-holder=%d):\n%s", leaseRepl, sl)
+	log.VEventf(ctx, 3, "ShouldTransferLease (lease-holder=s%d):\n%s", leaseRepl.StoreID(), sl)
 
 	transferDec, _ := a.shouldTransferLeaseForAccessLocality(
 		ctx,

--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -1474,6 +1474,120 @@ func (a *Allocator) scorerOptionsForScatter() *scatterScorerOptions {
 	}
 }
 
+// ValidLeaseTargets returns a set of candidate stores that are suitable to be
+// transferred a lease for the given range.
+//
+// - It excludes stores that are dead, or marked draining or suspect.
+// - If the range has lease_preferences, and there are any non-draining,
+// non-suspect nodes that match those preferences, it excludes stores that don't
+// match those preferences.
+// - It excludes replicas that may need snapshots. If replica calling this
+// method is not the Raft leader (meaning that it doesn't know whether follower
+// replicas need a snapshot or not), produces no results.
+func (a *Allocator) ValidLeaseTargets(
+	ctx context.Context,
+	conf roachpb.SpanConfig,
+	existing []roachpb.ReplicaDescriptor,
+	leaseRepl interface {
+		RaftStatus() *raft.Status
+		StoreID() roachpb.StoreID
+	},
+	// excludeLeaseRepl dictates whether the result set can include the source
+	// replica.
+	excludeLeaseRepl bool,
+) []roachpb.ReplicaDescriptor {
+	candidates := make([]roachpb.ReplicaDescriptor, 0, len(existing))
+	for i := range existing {
+		if existing[i].GetType() != roachpb.VOTER_FULL {
+			continue
+		}
+		// If we're not allowed to include the current replica, remove it from
+		// consideration here.
+		if existing[i].StoreID == leaseRepl.StoreID() && excludeLeaseRepl {
+			continue
+		}
+		candidates = append(candidates, existing[i])
+	}
+	candidates, _ = a.storePool.liveAndDeadReplicas(
+		candidates, false, /* includeSuspectAndDrainingStores */
+	)
+
+	if a.knobs == nil || !a.knobs.AllowLeaseTransfersToReplicasNeedingSnapshots {
+		// Only proceed with the lease transfer if we are also the raft leader (we
+		// already know we are the leaseholder at this point), and only consider
+		// replicas that are in `StateReplicate` as potential candidates.
+		//
+		// NB: The RaftStatus() only returns a non-empty and non-nil result on the
+		// Raft leader (since Raft followers do not track the progress of other
+		// replicas, only the leader does).
+		//
+		// NB: On every Raft tick, we try to ensure that leadership is collocated with
+		// leaseholdership (see
+		// Replica.maybeTransferRaftLeadershipToLeaseholderLocked()). This means that
+		// on a range that is not already borked (i.e. can accept writes), periods of
+		// leader/leaseholder misalignment should be ephemeral and rare. We choose to
+		// be pessimistic here and choose to bail on the lease transfer, as opposed to
+		// potentially transferring the lease to a replica that may be waiting for a
+		// snapshot (which will wedge the range until the replica applies that
+		// snapshot).
+		candidates = excludeReplicasInNeedOfSnapshots(ctx, leaseRepl.RaftStatus(), candidates)
+	}
+
+	// Determine which store(s) is preferred based on user-specified preferences.
+	// If any stores match, only consider those stores as candidates.
+	preferred := a.preferredLeaseholders(conf, candidates)
+	if len(preferred) > 0 {
+		candidates = preferred
+	}
+	return candidates
+}
+
+// leaseholderShouldMoveDueToPreferences returns true if the current leaseholder
+// is in violation of lease preferences _that can otherwise be satisfied_ by
+// some existing replica.
+//
+// INVARIANT: This method should only be called with an `allExistingReplicas`
+// slice that contains `leaseRepl`.
+func (a *Allocator) leaseholderShouldMoveDueToPreferences(
+	ctx context.Context,
+	conf roachpb.SpanConfig,
+	leaseRepl interface {
+		RaftStatus() *raft.Status
+		StoreID() roachpb.StoreID
+	},
+	allExistingReplicas []roachpb.ReplicaDescriptor,
+) bool {
+	// Defensive check to ensure that this is never called with a replica set that
+	// does not contain the leaseholder.
+	var leaseholderInExisting bool
+	for _, repl := range allExistingReplicas {
+		if repl.StoreID == leaseRepl.StoreID() {
+			leaseholderInExisting = true
+			break
+		}
+	}
+	if !leaseholderInExisting {
+		log.Errorf(ctx, "programming error: expected leaseholder store to be in the slice of existing replicas")
+	}
+
+	// Exclude suspect/draining/dead stores.
+	candidates, _ := a.storePool.liveAndDeadReplicas(
+		allExistingReplicas, false, /* includeSuspectAndDrainingStores */
+	)
+	// If there are any replicas that do match lease preferences, then we check if
+	// the existing leaseholder is one of them.
+	preferred := a.preferredLeaseholders(conf, candidates)
+	if len(preferred) == 0 {
+		return false
+	}
+	for _, repl := range preferred {
+		if repl.StoreID == leaseRepl.StoreID() {
+			return false
+		}
+	}
+	return true
+}
+
 // TransferLeaseTarget returns a suitable replica to transfer the range lease
 // to from the provided list. It excludes the current lease holder replica
 // unless asked to do otherwise by the checkTransferLeaseSource parameter.
@@ -1501,13 +1615,19 @@ func (a *Allocator) TransferLeaseTarget(
 	forceDecisionWithoutStats bool,
 	opts transferLeaseOptions,
 ) roachpb.ReplicaDescriptor {
+	excludeLeaseRepl := !opts.checkTransferLeaseSource
+	if a.leaseholderShouldMoveDueToPreferences(ctx, conf, leaseRepl, existing) {
+		// Explicitly exclude the current leaseholder from the result set if it is
+		// in violation of lease preferences that can be satisfied by some other
+		// replica.
+		excludeLeaseRepl = true
+	}
+
 	allStoresList, _, _ := a.storePool.getStoreList(storeFilterNone)
 	storeDescMap := storeListToMap(allStoresList)
-
 	sl, _, _ := a.storePool.getStoreList(storeFilterSuspect)
 	sl = sl.excludeInvalid(conf.Constraints)
 	sl = sl.excludeInvalid(conf.VoterConstraints)
-
 	candidateLeasesMean := sl.candidateLeases.mean
 
 	source, ok := a.storePool.getStoreDescriptor(leaseRepl.StoreID())
@@ -1515,69 +1635,7 @@ func (a *Allocator) TransferLeaseTarget(
 		return roachpb.ReplicaDescriptor{}
 	}
 
-	// Determine which store(s) is preferred based on user-specified preferences.
-	// If any stores match, only consider those stores as candidates. If only one
-	// store matches, it's where the lease should be (unless the preferred store
-	// is the current one and checkTransferLeaseSource is false).
-	var preferred []roachpb.ReplicaDescriptor
-	checkTransferLeaseSource := opts.checkTransferLeaseSource
-	if checkTransferLeaseSource {
-		preferred = a.preferredLeaseholders(conf, existing)
-	} else {
-		// TODO(a-robinson): Should we just always remove the source store from
-		// existing when checkTransferLeaseSource is false? I'd do it now, but
-		// it's too big a change to make right before a major release.
-		var candidates []roachpb.ReplicaDescriptor
-		for _, repl := range existing {
-			if repl.StoreID != leaseRepl.StoreID() {
-				candidates = append(candidates, repl)
-			}
-		}
-		preferred = a.preferredLeaseholders(conf, candidates)
-	}
-	if len(preferred) == 1 {
-		if preferred[0].StoreID == leaseRepl.StoreID() {
-			return roachpb.ReplicaDescriptor{}
-		}
-		// Verify that the preferred replica is eligible to receive the lease.
-		preferred, _ = a.storePool.liveAndDeadReplicas(preferred, false /* includeSuspectAndDrainingStores */)
-		if len(preferred) == 1 {
-			return preferred[0]
-		}
-		return roachpb.ReplicaDescriptor{}
-	} else if len(preferred) > 1 {
-		// If the current leaseholder is not preferred, set checkTransferLeaseSource
-		// to false to motivate the below logic to transfer the lease.
-		existing = preferred
-		if !storeHasReplica(leaseRepl.StoreID(), roachpb.MakeReplicaSet(preferred).ReplicationTargets()) {
-			checkTransferLeaseSource = false
-		}
-	}
-
-	// Only consider live, non-draining, non-suspect replicas.
-	existing, _ = a.storePool.liveAndDeadReplicas(existing, false /* includeSuspectAndDrainingStores */)
-
-	if a.knobs == nil || !a.knobs.AllowLeaseTransfersToReplicasNeedingSnapshots {
-		// Only proceed with the lease transfer if we are also the raft leader (we
-		// already know we are the leaseholder at this point), and only consider
-		// replicas that are in `StateReplicate` as potential candidates.
-		//
-		// NB: The RaftStatus() only returns a non-empty and non-nil result on the
-		// Raft leader (since Raft followers do not track the progress of other
-		// replicas, only the leader does).
-		//
-		// NB: On every Raft tick, we try to ensure that leadership is collocated with
-		// leaseholdership (see
-		// Replica.maybeTransferRaftLeadershipToLeaseholderLocked()). This means that
-		// on a range that is not already borked (i.e. can accept writes), periods of
-		// leader/leaseholder misalignment should be ephemeral and rare. We choose to
-		// be pessimistic here and choose to bail on the lease transfer, as opposed to
-		// potentially transferring the lease to a replica that may be waiting for a
-		// snapshot (which will wedge the range until the replica applies that
-		// snapshot).
-		existing = excludeReplicasInNeedOfSnapshots(ctx, leaseRepl.RaftStatus(), existing)
-	}
-
+	existing = a.ValidLeaseTargets(ctx, conf, existing, leaseRepl, excludeLeaseRepl)
 	// Short-circuit if there are no valid targets out there.
 	if len(existing) == 0 || (len(existing) == 1 && existing[0].StoreID == leaseRepl.StoreID()) {
 		log.VEventf(ctx, 2, "no lease transfer target found for r%d", leaseRepl.GetRangeID())
@@ -1592,7 +1650,7 @@ func (a *Allocator) TransferLeaseTarget(
 		transferDec, repl := a.shouldTransferLeaseForAccessLocality(
 			ctx, source, existing, stats, nil, candidateLeasesMean,
 		)
-		if checkTransferLeaseSource {
+		if !excludeLeaseRepl {
 			switch transferDec {
 			case shouldNotTransfer:
 				if !forceDecisionWithoutStats {
@@ -1611,13 +1669,21 @@ func (a *Allocator) TransferLeaseTarget(
 		if repl != (roachpb.ReplicaDescriptor{}) {
 			return repl
 		}
+		// Fall back to logic that doesn't take request counts and latency into
+		// account if the counts/latency-based logic couldn't pick a best replica.
 		fallthrough
 
 	case leaseCountConvergence:
-		// Fall back to logic that doesn't take request counts and latency into
-		// account if the counts/latency-based logic couldn't pick a best replica.
-		candidates := make([]roachpb.ReplicaDescriptor, 0, len(existing))
+		// If we want to ignore the existing lease counts on replicas, just do a
+		// random transfer.
+		if !opts.checkCandidateFullness {
+			a.randGen.Lock()
+			defer a.randGen.Unlock()
+			return existing[a.randGen.Intn(len(existing))]
+		}
+
 		var bestOption roachpb.ReplicaDescriptor
+		candidates := make([]roachpb.ReplicaDescriptor, 0, len(existing))
 		bestOptionLeaseCount := int32(math.MaxInt32)
 		for _, repl := range existing {
 			if leaseRepl.StoreID() == repl.StoreID {
@@ -1627,18 +1693,19 @@ func (a *Allocator) TransferLeaseTarget(
 			if !ok {
 				continue
 			}
-			if !opts.checkCandidateFullness || float64(storeDesc.Capacity.LeaseCount) < candidateLeasesMean-0.5 {
+			if float64(storeDesc.Capacity.LeaseCount) < candidateLeasesMean-0.5 {
 				candidates = append(candidates, repl)
-			} else if storeDesc.Capacity.LeaseCount < bestOptionLeaseCount {
+			}
+			if storeDesc.Capacity.LeaseCount < bestOptionLeaseCount {
 				bestOption = repl
 				bestOptionLeaseCount = storeDesc.Capacity.LeaseCount
 			}
 		}
 		if len(candidates) == 0 {
-			// If we aren't supposed to be considering the current leaseholder (e.g.
-			// because we need to remove this replica for some reason), return
-			// our best option if we otherwise wouldn't want to do anything.
-			if !checkTransferLeaseSource {
+			// If there were no existing replicas on stores with less-than-mean
+			// leases, and we _must_ move the lease away (indicated by
+			// `opts.excludeLeaseRepl`), just return the best possible option.
+			if excludeLeaseRepl {
 				return bestOption
 			}
 			return roachpb.ReplicaDescriptor{}
@@ -1784,41 +1851,30 @@ func (a *Allocator) ShouldTransferLease(
 	ctx context.Context,
 	conf roachpb.SpanConfig,
 	existing []roachpb.ReplicaDescriptor,
-	leaseStoreID roachpb.StoreID,
+	leaseRepl interface {
+		RaftStatus() *raft.Status
+		StoreID() roachpb.StoreID
+	},
 	stats *replicaStats,
 ) bool {
-	source, ok := a.storePool.getStoreDescriptor(leaseStoreID)
-	if !ok {
+	if a.leaseholderShouldMoveDueToPreferences(ctx, conf, leaseRepl, existing) {
+		return true
+	}
+	existing = a.ValidLeaseTargets(ctx, conf, existing, leaseRepl, false /* excludeLeaseRepl */)
+
+	// Short-circuit if there are no valid targets out there.
+	if len(existing) == 0 || (len(existing) == 1 && existing[0].StoreID == leaseRepl.StoreID()) {
 		return false
 	}
-
-	// Determine which store(s) is preferred based on user-specified preferences.
-	// If any stores match, only consider those stores as options. If only one
-	// store matches, it's where the lease should be.
-	preferred := a.preferredLeaseholders(conf, existing)
-	if len(preferred) == 1 {
-		return preferred[0].StoreID != leaseStoreID
-	} else if len(preferred) > 1 {
-		existing = preferred
-		// If the current leaseholder isn't one of the preferred stores, then we
-		// should try to transfer the lease.
-		if !storeHasReplica(leaseStoreID, roachpb.MakeReplicaSet(existing).ReplicationTargets()) {
-			return true
-		}
+	source, ok := a.storePool.getStoreDescriptor(leaseRepl.StoreID())
+	if !ok {
+		return false
 	}
 
 	sl, _, _ := a.storePool.getStoreList(storeFilterSuspect)
 	sl = sl.excludeInvalid(conf.Constraints)
 	sl = sl.excludeInvalid(conf.VoterConstraints)
-	log.VEventf(ctx, 3, "ShouldTransferLease (lease-holder=%d):\n%s", leaseStoreID, sl)
-
-	// Only consider live, non-draining, non-suspect replicas.
-	existing, _ = a.storePool.liveAndDeadReplicas(existing, false /* includeSuspectNodes */)
-
-	// Short-circuit if there are no valid targets out there.
-	if len(existing) == 0 || (len(existing) == 1 && existing[0].StoreID == source.StoreID) {
-		return false
-	}
+	log.VEventf(ctx, 3, "ShouldTransferLease (lease-holder=%d):\n%s", leaseRepl, sl)
 
 	transferDec, _ := a.shouldTransferLeaseForAccessLocality(
 		ctx,
@@ -1840,7 +1896,9 @@ func (a *Allocator) ShouldTransferLease(
 		log.Fatalf(ctx, "unexpected transfer decision %d", transferDec)
 	}
 
-	log.VEventf(ctx, 3, "ShouldTransferLease decision (lease-holder=%d): %t", leaseStoreID, result)
+	log.VEventf(
+		ctx, 3, "ShouldTransferLease decision (lease-holder=s%d): %t", leaseRepl.StoreID(), result,
+	)
 	return result
 }
 

--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -1589,8 +1589,8 @@ func (a *Allocator) leaseholderShouldMoveDueToPreferences(
 }
 
 // TransferLeaseTarget returns a suitable replica to transfer the range lease
-// to from the provided list. It excludes the current lease holder replica
-// unless asked to do otherwise by the checkTransferLeaseSource parameter.
+// to from the provided list. It includes the current lease holder replica
+// unless asked to do otherwise by the excludeLeaseRepl parameter.
 //
 // Returns an empty descriptor if no target is found.
 //
@@ -1615,7 +1615,7 @@ func (a *Allocator) TransferLeaseTarget(
 	forceDecisionWithoutStats bool,
 	opts transferLeaseOptions,
 ) roachpb.ReplicaDescriptor {
-	excludeLeaseRepl := !opts.checkTransferLeaseSource
+	excludeLeaseRepl := opts.excludeLeaseRepl
 	if a.leaseholderShouldMoveDueToPreferences(ctx, conf, leaseRepl, existing) {
 		// Explicitly exclude the current leaseholder from the result set if it is
 		// in violation of lease preferences that can be satisfied by some other

--- a/pkg/kv/kvserver/allocator_test.go
+++ b/pkg/kv/kvserver/allocator_test.go
@@ -1741,22 +1741,22 @@ func TestAllocatorTransferLeaseTarget(t *testing.T) {
 
 	// TODO(peter): Add test cases for non-empty constraints.
 	testCases := []struct {
-		existing    []roachpb.ReplicaDescriptor
-		leaseholder roachpb.StoreID
-		check       bool
-		expected    roachpb.StoreID
+		existing       []roachpb.ReplicaDescriptor
+		leaseholder    roachpb.StoreID
+		allowLeaseRepl bool
+		expected       roachpb.StoreID
 	}{
 		// No existing lease holder, nothing to do.
-		{existing: existing, leaseholder: 0, check: true, expected: 0},
+		{existing: existing, leaseholder: 0, allowLeaseRepl: true, expected: 0},
 		// Store 1 is not a lease transfer source.
-		{existing: existing, leaseholder: 1, check: true, expected: 0},
-		{existing: existing, leaseholder: 1, check: false, expected: 2},
+		{existing: existing, leaseholder: 1, allowLeaseRepl: true, expected: 0},
+		{existing: existing, leaseholder: 1, allowLeaseRepl: false, expected: 2},
 		// Store 2 is not a lease transfer source.
-		{existing: existing, leaseholder: 2, check: true, expected: 0},
-		{existing: existing, leaseholder: 2, check: false, expected: 1},
+		{existing: existing, leaseholder: 2, allowLeaseRepl: true, expected: 0},
+		{existing: existing, leaseholder: 2, allowLeaseRepl: false, expected: 1},
 		// Store 3 is a lease transfer source.
-		{existing: existing, leaseholder: 3, check: true, expected: 1},
-		{existing: existing, leaseholder: 3, check: false, expected: 1},
+		{existing: existing, leaseholder: 3, allowLeaseRepl: true, expected: 1},
+		{existing: existing, leaseholder: 3, allowLeaseRepl: false, expected: 1},
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
@@ -1771,8 +1771,8 @@ func TestAllocatorTransferLeaseTarget(t *testing.T) {
 				nil,   /* stats */
 				false, /* forceDecisionWithoutStats */
 				transferLeaseOptions{
-					checkTransferLeaseSource: c.check,
-					checkCandidateFullness:   true,
+					excludeLeaseRepl:       !c.allowLeaseRepl,
+					checkCandidateFullness: true,
 				},
 			)
 			if c.expected != target.StoreID {
@@ -1813,56 +1813,56 @@ func TestAllocatorTransferLeaseToReplicasNeedingSnapshot(t *testing.T) {
 		existing          []roachpb.ReplicaDescriptor
 		replsNeedingSnaps []roachpb.ReplicaID
 		leaseholder       roachpb.StoreID
-		checkSource       bool
+		allowLeaseRepl    bool
 		transferTarget    roachpb.StoreID
 	}{
 		{
 			existing:          existing,
 			replsNeedingSnaps: []roachpb.ReplicaID{1},
 			leaseholder:       3,
-			checkSource:       true,
+			allowLeaseRepl:    true,
 			transferTarget:    0,
 		},
 		{
 			existing:          existing,
 			replsNeedingSnaps: []roachpb.ReplicaID{1},
 			leaseholder:       3,
-			checkSource:       false,
+			allowLeaseRepl:    false,
 			transferTarget:    2,
 		},
 		{
 			existing:          existing,
 			replsNeedingSnaps: []roachpb.ReplicaID{1},
 			leaseholder:       4,
-			checkSource:       true,
+			allowLeaseRepl:    true,
 			transferTarget:    2,
 		},
 		{
 			existing:          existing,
 			replsNeedingSnaps: []roachpb.ReplicaID{1},
 			leaseholder:       4,
-			checkSource:       false,
+			allowLeaseRepl:    false,
 			transferTarget:    2,
 		},
 		{
 			existing:          existing,
 			replsNeedingSnaps: []roachpb.ReplicaID{1, 2},
 			leaseholder:       4,
-			checkSource:       false,
+			allowLeaseRepl:    false,
 			transferTarget:    3,
 		},
 		{
 			existing:          existing,
 			replsNeedingSnaps: []roachpb.ReplicaID{1, 2},
 			leaseholder:       4,
-			checkSource:       true,
+			allowLeaseRepl:    true,
 			transferTarget:    0,
 		},
 		{
 			existing:          existing,
 			replsNeedingSnaps: []roachpb.ReplicaID{1, 2, 3},
 			leaseholder:       4,
-			checkSource:       true,
+			allowLeaseRepl:    true,
 			transferTarget:    0,
 		},
 	}
@@ -1884,8 +1884,8 @@ func TestAllocatorTransferLeaseToReplicasNeedingSnapshot(t *testing.T) {
 				nil,
 				false, /* alwaysAllowDecisionWithoutStats */
 				transferLeaseOptions{
-					checkTransferLeaseSource: c.checkSource,
-					checkCandidateFullness:   true,
+					excludeLeaseRepl:       !c.allowLeaseRepl,
+					checkCandidateFullness: true,
 				},
 			)
 			if c.transferTarget != target.StoreID {
@@ -1978,8 +1978,8 @@ func TestAllocatorTransferLeaseTargetConstraints(t *testing.T) {
 				nil,   /* stats */
 				false, /* forceDecisionWithoutStats */
 				transferLeaseOptions{
-					checkTransferLeaseSource: true,
-					checkCandidateFullness:   true,
+					excludeLeaseRepl:       false,
+					checkCandidateFullness: true,
 				},
 			)
 			if c.expected != target.StoreID {
@@ -2046,36 +2046,36 @@ func TestAllocatorTransferLeaseTargetDraining(t *testing.T) {
 	}
 
 	testCases := []struct {
-		existing    []roachpb.ReplicaDescriptor
-		leaseholder roachpb.StoreID
-		check       bool
-		expected    roachpb.StoreID
-		conf        roachpb.SpanConfig
+		existing       []roachpb.ReplicaDescriptor
+		leaseholder    roachpb.StoreID
+		allowLeaseRepl bool
+		expected       roachpb.StoreID
+		conf           roachpb.SpanConfig
 	}{
 		// No existing lease holder, nothing to do.
-		{existing: existing, leaseholder: 0, check: true, expected: 0, conf: emptySpanConfig()},
+		{existing: existing, leaseholder: 0, allowLeaseRepl: true, expected: 0, conf: emptySpanConfig()},
 		// Store 1 is draining, so it will try to transfer its lease if
-		// checkTransferLeaseSource is false. This behavior isn't relied upon,
+		// excludeLeaseRepl is false. This behavior isn't relied upon,
 		// though; leases are manually transferred when draining.
-		{existing: existing, leaseholder: 1, check: true, expected: 0, conf: emptySpanConfig()},
-		{existing: existing, leaseholder: 1, check: false, expected: 2, conf: emptySpanConfig()},
+		{existing: existing, leaseholder: 1, allowLeaseRepl: true, expected: 0, conf: emptySpanConfig()},
+		{existing: existing, leaseholder: 1, allowLeaseRepl: false, expected: 2, conf: emptySpanConfig()},
 		// Store 2 is not a lease transfer source.
-		{existing: existing, leaseholder: 2, check: true, expected: 0, conf: emptySpanConfig()},
-		{existing: existing, leaseholder: 2, check: false, expected: 3, conf: emptySpanConfig()},
+		{existing: existing, leaseholder: 2, allowLeaseRepl: true, expected: 0, conf: emptySpanConfig()},
+		{existing: existing, leaseholder: 2, allowLeaseRepl: false, expected: 3, conf: emptySpanConfig()},
 		// Store 3 is a lease transfer source, but won't transfer to
 		// node 1 because it's draining.
-		{existing: existing, leaseholder: 3, check: true, expected: 2, conf: emptySpanConfig()},
-		{existing: existing, leaseholder: 3, check: false, expected: 2, conf: emptySpanConfig()},
+		{existing: existing, leaseholder: 3, allowLeaseRepl: true, expected: 2, conf: emptySpanConfig()},
+		{existing: existing, leaseholder: 3, allowLeaseRepl: false, expected: 2, conf: emptySpanConfig()},
 		// Verify that lease preferences dont impact draining.
 		// If the store that is within the lease preferences (store 1) is draining,
 		// we'd like the lease to stay on the next best store (which is store 2).
-		{existing: existing, leaseholder: 2, check: true, expected: 0, conf: roachpb.SpanConfig{LeasePreferences: preferDC1}},
+		{existing: existing, leaseholder: 2, allowLeaseRepl: true, expected: 0, conf: roachpb.SpanConfig{LeasePreferences: preferDC1}},
 		// If the current lease on store 2 needs to be shed (indicated by
-		// checkTransferLeaseSource = false), and store 1 is draining, then store 3
+		// excludeLeaseRepl = false), and store 1 is draining, then store 3
 		// is the only reasonable lease transfer target.
-		{existing: existing, leaseholder: 2, check: false, expected: 3, conf: roachpb.SpanConfig{LeasePreferences: preferDC1}},
-		{existing: existing, leaseholder: 2, check: true, expected: 3, conf: roachpb.SpanConfig{LeasePreferences: preferRegion1}},
-		{existing: existing, leaseholder: 2, check: false, expected: 3, conf: roachpb.SpanConfig{LeasePreferences: preferRegion1}},
+		{existing: existing, leaseholder: 2, allowLeaseRepl: false, expected: 3, conf: roachpb.SpanConfig{LeasePreferences: preferDC1}},
+		{existing: existing, leaseholder: 2, allowLeaseRepl: true, expected: 3, conf: roachpb.SpanConfig{LeasePreferences: preferRegion1}},
+		{existing: existing, leaseholder: 2, allowLeaseRepl: false, expected: 3, conf: roachpb.SpanConfig{LeasePreferences: preferRegion1}},
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
@@ -2090,8 +2090,8 @@ func TestAllocatorTransferLeaseTargetDraining(t *testing.T) {
 				nil,   /* stats */
 				false, /* forceDecisionWithoutStats */
 				transferLeaseOptions{
-					checkTransferLeaseSource: c.check,
-					checkCandidateFullness:   true,
+					excludeLeaseRepl:       !c.allowLeaseRepl,
+					checkCandidateFullness: true,
 				},
 			)
 			if c.expected != target.StoreID {
@@ -2557,11 +2557,11 @@ func TestAllocatorLeasePreferences(t *testing.T) {
 	}
 
 	testCases := []struct {
-		leaseholder        roachpb.StoreID
-		existing           []roachpb.ReplicaDescriptor
-		preferences        []roachpb.LeasePreference
-		expectedCheckTrue  roachpb.StoreID /* checkTransferLeaseSource = true */
-		expectedCheckFalse roachpb.StoreID /* checkTransferLeaseSource = false */
+		leaseholder            roachpb.StoreID
+		existing               []roachpb.ReplicaDescriptor
+		preferences            []roachpb.LeasePreference
+		expectAllowLeaseRepl   roachpb.StoreID /* excludeLeaseRepl = false */
+		expectExcludeLeaseRepl roachpb.StoreID /* excludeLeaseRepl = true */
 	}{
 		{1, nil, preferDC1, 0, 0},
 		{1, replicas(1, 2, 3, 4), preferDC1, 0, 2},
@@ -2625,7 +2625,7 @@ func TestAllocatorLeasePreferences(t *testing.T) {
 				},
 				nil, /* replicaStats */
 			)
-			expectTransfer := c.expectedCheckTrue != 0
+			expectTransfer := c.expectAllowLeaseRepl != 0
 			if expectTransfer != result {
 				t.Errorf("expected %v, but found %v", expectTransfer, result)
 			}
@@ -2640,12 +2640,12 @@ func TestAllocatorLeasePreferences(t *testing.T) {
 				nil,   /* stats */
 				false, /* forceDecisionWithoutStats */
 				transferLeaseOptions{
-					checkTransferLeaseSource: true,
-					checkCandidateFullness:   true,
+					excludeLeaseRepl:       false,
+					checkCandidateFullness: true,
 				},
 			)
-			if c.expectedCheckTrue != target.StoreID {
-				t.Errorf("expected s%d for check=true, but found %v", c.expectedCheckTrue, target)
+			if c.expectAllowLeaseRepl != target.StoreID {
+				t.Errorf("expected s%d for excludeLeaseRepl=false, but found %v", c.expectAllowLeaseRepl, target)
 			}
 			target = a.TransferLeaseTarget(
 				ctx,
@@ -2658,12 +2658,12 @@ func TestAllocatorLeasePreferences(t *testing.T) {
 				nil,   /* stats */
 				false, /* forceDecisionWithoutStats */
 				transferLeaseOptions{
-					checkTransferLeaseSource: false,
-					checkCandidateFullness:   true,
+					excludeLeaseRepl:       true,
+					checkCandidateFullness: true,
 				},
 			)
-			if c.expectedCheckFalse != target.StoreID {
-				t.Errorf("expected s%d for check=false, but found %v", c.expectedCheckFalse, target)
+			if c.expectExcludeLeaseRepl != target.StoreID {
+				t.Errorf("expected s%d for excludeLeaseRepl=true, but found %v", c.expectExcludeLeaseRepl, target)
 			}
 		})
 	}
@@ -2715,14 +2715,14 @@ func TestAllocatorLeasePreferencesMultipleStoresPerLocality(t *testing.T) {
 	}
 
 	testCases := []struct {
-		leaseholder        roachpb.StoreID
-		existing           []roachpb.ReplicaDescriptor
-		preferences        []roachpb.LeasePreference
-		expectedCheckTrue  roachpb.StoreID /* checkTransferLeaseSource = true */
-		expectedCheckFalse roachpb.StoreID /* checkTransferLeaseSource = false */
+		leaseholder              roachpb.StoreID
+		existing                 []roachpb.ReplicaDescriptor
+		preferences              []roachpb.LeasePreference
+		expectedAllowLeaseRepl   roachpb.StoreID /* excludeLeaseRepl = false */
+		expectedExcludeLeaseRepl roachpb.StoreID /* excludeLeaseRepl = true */
 	}{
 		{1, replicas(1, 3, 5), preferEast, 0, 3},
-		// When `checkTransferLeaseSource` = false, we'd expect either store 2 or 3
+		// When `excludeLeaseRepl` = false, we'd expect either store 2 or 3
 		// to be produced by `TransferLeaseTarget` (since both of them have
 		// less-than-mean leases). In this case, the rng should produce 3.
 		{1, replicas(1, 2, 3), preferEast, 0, 3},
@@ -2750,13 +2750,14 @@ func TestAllocatorLeasePreferencesMultipleStoresPerLocality(t *testing.T) {
 				nil,   /* stats */
 				false, /* forceDecisionWithoutStats */
 				transferLeaseOptions{
-					checkTransferLeaseSource: true,
-					checkCandidateFullness:   true,
+					excludeLeaseRepl:       false,
+					checkCandidateFullness: true,
 				},
 			)
-			if c.expectedCheckTrue != target.StoreID {
-				t.Errorf("expected s%d for check=true, but found %v", c.expectedCheckTrue, target)
+			if c.expectedAllowLeaseRepl != target.StoreID {
+				t.Errorf("expected s%d for excludeLeaseRepl=false, but found %v", c.expectedAllowLeaseRepl, target)
 			}
+
 			target = a.TransferLeaseTarget(
 				ctx,
 				conf,
@@ -2768,12 +2769,12 @@ func TestAllocatorLeasePreferencesMultipleStoresPerLocality(t *testing.T) {
 				nil,   /* stats */
 				false, /* forceDecisionWithoutStats */
 				transferLeaseOptions{
-					checkTransferLeaseSource: false,
-					checkCandidateFullness:   true,
+					excludeLeaseRepl:       true,
+					checkCandidateFullness: true,
 				},
 			)
-			if c.expectedCheckFalse != target.StoreID {
-				t.Errorf("expected s%d for check=false, but found %v", c.expectedCheckFalse, target)
+			if c.expectedExcludeLeaseRepl != target.StoreID {
+				t.Errorf("expected s%d for excludeLeaseRepl=true, but found %v", c.expectedExcludeLeaseRepl, target)
 			}
 		})
 	}
@@ -5171,69 +5172,69 @@ func TestAllocatorTransferLeaseTargetLoadBased(t *testing.T) {
 	}
 
 	testCases := []struct {
-		leaseholder roachpb.StoreID
-		latency     map[string]time.Duration
-		stats       *replicaStats
-		check       bool
-		expected    roachpb.StoreID
+		leaseholder    roachpb.StoreID
+		latency        map[string]time.Duration
+		stats          *replicaStats
+		allowLeaseRepl bool
+		expected       roachpb.StoreID
 	}{
 		// No existing lease holder, nothing to do.
-		{leaseholder: 0, latency: noLatency, stats: evenlyBalanced, check: true, expected: 0},
-		{leaseholder: 1, latency: noLatency, stats: evenlyBalanced, check: true, expected: 0},
-		{leaseholder: 1, latency: noLatency, stats: evenlyBalanced, check: false, expected: 2},
-		{leaseholder: 2, latency: noLatency, stats: evenlyBalanced, check: true, expected: 1},
-		{leaseholder: 2, latency: noLatency, stats: evenlyBalanced, check: false, expected: 1},
-		{leaseholder: 3, latency: noLatency, stats: evenlyBalanced, check: true, expected: 1},
-		{leaseholder: 3, latency: noLatency, stats: evenlyBalanced, check: false, expected: 1},
-		{leaseholder: 0, latency: noLatency, stats: imbalanced1, check: true, expected: 0},
-		{leaseholder: 1, latency: noLatency, stats: imbalanced1, check: true, expected: 0},
-		{leaseholder: 1, latency: noLatency, stats: imbalanced1, check: false, expected: 2},
-		{leaseholder: 2, latency: noLatency, stats: imbalanced1, check: true, expected: 1},
-		{leaseholder: 2, latency: noLatency, stats: imbalanced1, check: false, expected: 1},
-		{leaseholder: 3, latency: noLatency, stats: imbalanced1, check: true, expected: 1},
-		{leaseholder: 3, latency: noLatency, stats: imbalanced1, check: false, expected: 1},
-		{leaseholder: 0, latency: noLatency, stats: imbalanced2, check: true, expected: 0},
-		{leaseholder: 1, latency: noLatency, stats: imbalanced2, check: true, expected: 0},
-		{leaseholder: 1, latency: noLatency, stats: imbalanced2, check: false, expected: 2},
-		{leaseholder: 2, latency: noLatency, stats: imbalanced2, check: true, expected: 1},
-		{leaseholder: 2, latency: noLatency, stats: imbalanced2, check: false, expected: 1},
-		{leaseholder: 3, latency: noLatency, stats: imbalanced2, check: true, expected: 1},
-		{leaseholder: 3, latency: noLatency, stats: imbalanced2, check: false, expected: 1},
-		{leaseholder: 0, latency: noLatency, stats: imbalanced3, check: true, expected: 0},
-		{leaseholder: 1, latency: noLatency, stats: imbalanced3, check: true, expected: 0},
-		{leaseholder: 1, latency: noLatency, stats: imbalanced3, check: false, expected: 2},
-		{leaseholder: 2, latency: noLatency, stats: imbalanced3, check: true, expected: 1},
-		{leaseholder: 2, latency: noLatency, stats: imbalanced3, check: false, expected: 1},
-		{leaseholder: 3, latency: noLatency, stats: imbalanced3, check: true, expected: 1},
-		{leaseholder: 3, latency: noLatency, stats: imbalanced3, check: false, expected: 1},
-		{leaseholder: 0, latency: highLatency, stats: evenlyBalanced, check: true, expected: 0},
-		{leaseholder: 1, latency: highLatency, stats: evenlyBalanced, check: true, expected: 0},
-		{leaseholder: 1, latency: highLatency, stats: evenlyBalanced, check: false, expected: 2},
-		{leaseholder: 2, latency: highLatency, stats: evenlyBalanced, check: true, expected: 1},
-		{leaseholder: 2, latency: highLatency, stats: evenlyBalanced, check: false, expected: 1},
-		{leaseholder: 3, latency: highLatency, stats: evenlyBalanced, check: true, expected: 1},
-		{leaseholder: 3, latency: highLatency, stats: evenlyBalanced, check: false, expected: 1},
-		{leaseholder: 0, latency: highLatency, stats: imbalanced1, check: true, expected: 0},
-		{leaseholder: 1, latency: highLatency, stats: imbalanced1, check: true, expected: 0},
-		{leaseholder: 1, latency: highLatency, stats: imbalanced1, check: false, expected: 2},
-		{leaseholder: 2, latency: highLatency, stats: imbalanced1, check: true, expected: 1},
-		{leaseholder: 2, latency: highLatency, stats: imbalanced1, check: false, expected: 1},
-		{leaseholder: 3, latency: highLatency, stats: imbalanced1, check: true, expected: 1},
-		{leaseholder: 3, latency: highLatency, stats: imbalanced1, check: false, expected: 1},
-		{leaseholder: 0, latency: highLatency, stats: imbalanced2, check: true, expected: 0},
-		{leaseholder: 1, latency: highLatency, stats: imbalanced2, check: true, expected: 2},
-		{leaseholder: 1, latency: highLatency, stats: imbalanced2, check: false, expected: 2},
-		{leaseholder: 2, latency: highLatency, stats: imbalanced2, check: true, expected: 0},
-		{leaseholder: 2, latency: highLatency, stats: imbalanced2, check: false, expected: 1},
-		{leaseholder: 3, latency: highLatency, stats: imbalanced2, check: true, expected: 2},
-		{leaseholder: 3, latency: highLatency, stats: imbalanced2, check: false, expected: 2},
-		{leaseholder: 0, latency: highLatency, stats: imbalanced3, check: true, expected: 0},
-		{leaseholder: 1, latency: highLatency, stats: imbalanced3, check: true, expected: 3},
-		{leaseholder: 1, latency: highLatency, stats: imbalanced3, check: false, expected: 3},
-		{leaseholder: 2, latency: highLatency, stats: imbalanced3, check: true, expected: 3},
-		{leaseholder: 2, latency: highLatency, stats: imbalanced3, check: false, expected: 3},
-		{leaseholder: 3, latency: highLatency, stats: imbalanced3, check: true, expected: 0},
-		{leaseholder: 3, latency: highLatency, stats: imbalanced3, check: false, expected: 1},
+		{leaseholder: 0, latency: noLatency, stats: evenlyBalanced, allowLeaseRepl: true, expected: 0},
+		{leaseholder: 1, latency: noLatency, stats: evenlyBalanced, allowLeaseRepl: true, expected: 0},
+		{leaseholder: 1, latency: noLatency, stats: evenlyBalanced, allowLeaseRepl: false, expected: 2},
+		{leaseholder: 2, latency: noLatency, stats: evenlyBalanced, allowLeaseRepl: true, expected: 1},
+		{leaseholder: 2, latency: noLatency, stats: evenlyBalanced, allowLeaseRepl: false, expected: 1},
+		{leaseholder: 3, latency: noLatency, stats: evenlyBalanced, allowLeaseRepl: true, expected: 1},
+		{leaseholder: 3, latency: noLatency, stats: evenlyBalanced, allowLeaseRepl: false, expected: 1},
+		{leaseholder: 0, latency: noLatency, stats: imbalanced1, allowLeaseRepl: true, expected: 0},
+		{leaseholder: 1, latency: noLatency, stats: imbalanced1, allowLeaseRepl: true, expected: 0},
+		{leaseholder: 1, latency: noLatency, stats: imbalanced1, allowLeaseRepl: false, expected: 2},
+		{leaseholder: 2, latency: noLatency, stats: imbalanced1, allowLeaseRepl: true, expected: 1},
+		{leaseholder: 2, latency: noLatency, stats: imbalanced1, allowLeaseRepl: false, expected: 1},
+		{leaseholder: 3, latency: noLatency, stats: imbalanced1, allowLeaseRepl: true, expected: 1},
+		{leaseholder: 3, latency: noLatency, stats: imbalanced1, allowLeaseRepl: false, expected: 1},
+		{leaseholder: 0, latency: noLatency, stats: imbalanced2, allowLeaseRepl: true, expected: 0},
+		{leaseholder: 1, latency: noLatency, stats: imbalanced2, allowLeaseRepl: true, expected: 0},
+		{leaseholder: 1, latency: noLatency, stats: imbalanced2, allowLeaseRepl: false, expected: 2},
+		{leaseholder: 2, latency: noLatency, stats: imbalanced2, allowLeaseRepl: true, expected: 1},
+		{leaseholder: 2, latency: noLatency, stats: imbalanced2, allowLeaseRepl: false, expected: 1},
+		{leaseholder: 3, latency: noLatency, stats: imbalanced2, allowLeaseRepl: true, expected: 1},
+		{leaseholder: 3, latency: noLatency, stats: imbalanced2, allowLeaseRepl: false, expected: 1},
+		{leaseholder: 0, latency: noLatency, stats: imbalanced3, allowLeaseRepl: true, expected: 0},
+		{leaseholder: 1, latency: noLatency, stats: imbalanced3, allowLeaseRepl: true, expected: 0},
+		{leaseholder: 1, latency: noLatency, stats: imbalanced3, allowLeaseRepl: false, expected: 2},
+		{leaseholder: 2, latency: noLatency, stats: imbalanced3, allowLeaseRepl: true, expected: 1},
+		{leaseholder: 2, latency: noLatency, stats: imbalanced3, allowLeaseRepl: false, expected: 1},
+		{leaseholder: 3, latency: noLatency, stats: imbalanced3, allowLeaseRepl: true, expected: 1},
+		{leaseholder: 3, latency: noLatency, stats: imbalanced3, allowLeaseRepl: false, expected: 1},
+		{leaseholder: 0, latency: highLatency, stats: evenlyBalanced, allowLeaseRepl: true, expected: 0},
+		{leaseholder: 1, latency: highLatency, stats: evenlyBalanced, allowLeaseRepl: true, expected: 0},
+		{leaseholder: 1, latency: highLatency, stats: evenlyBalanced, allowLeaseRepl: false, expected: 2},
+		{leaseholder: 2, latency: highLatency, stats: evenlyBalanced, allowLeaseRepl: true, expected: 1},
+		{leaseholder: 2, latency: highLatency, stats: evenlyBalanced, allowLeaseRepl: false, expected: 1},
+		{leaseholder: 3, latency: highLatency, stats: evenlyBalanced, allowLeaseRepl: true, expected: 1},
+		{leaseholder: 3, latency: highLatency, stats: evenlyBalanced, allowLeaseRepl: false, expected: 1},
+		{leaseholder: 0, latency: highLatency, stats: imbalanced1, allowLeaseRepl: true, expected: 0},
+		{leaseholder: 1, latency: highLatency, stats: imbalanced1, allowLeaseRepl: true, expected: 0},
+		{leaseholder: 1, latency: highLatency, stats: imbalanced1, allowLeaseRepl: false, expected: 2},
+		{leaseholder: 2, latency: highLatency, stats: imbalanced1, allowLeaseRepl: true, expected: 1},
+		{leaseholder: 2, latency: highLatency, stats: imbalanced1, allowLeaseRepl: false, expected: 1},
+		{leaseholder: 3, latency: highLatency, stats: imbalanced1, allowLeaseRepl: true, expected: 1},
+		{leaseholder: 3, latency: highLatency, stats: imbalanced1, allowLeaseRepl: false, expected: 1},
+		{leaseholder: 0, latency: highLatency, stats: imbalanced2, allowLeaseRepl: true, expected: 0},
+		{leaseholder: 1, latency: highLatency, stats: imbalanced2, allowLeaseRepl: true, expected: 2},
+		{leaseholder: 1, latency: highLatency, stats: imbalanced2, allowLeaseRepl: false, expected: 2},
+		{leaseholder: 2, latency: highLatency, stats: imbalanced2, allowLeaseRepl: true, expected: 0},
+		{leaseholder: 2, latency: highLatency, stats: imbalanced2, allowLeaseRepl: false, expected: 1},
+		{leaseholder: 3, latency: highLatency, stats: imbalanced2, allowLeaseRepl: true, expected: 2},
+		{leaseholder: 3, latency: highLatency, stats: imbalanced2, allowLeaseRepl: false, expected: 2},
+		{leaseholder: 0, latency: highLatency, stats: imbalanced3, allowLeaseRepl: true, expected: 0},
+		{leaseholder: 1, latency: highLatency, stats: imbalanced3, allowLeaseRepl: true, expected: 3},
+		{leaseholder: 1, latency: highLatency, stats: imbalanced3, allowLeaseRepl: false, expected: 3},
+		{leaseholder: 2, latency: highLatency, stats: imbalanced3, allowLeaseRepl: true, expected: 3},
+		{leaseholder: 2, latency: highLatency, stats: imbalanced3, allowLeaseRepl: false, expected: 3},
+		{leaseholder: 3, latency: highLatency, stats: imbalanced3, allowLeaseRepl: true, expected: 0},
+		{leaseholder: 3, latency: highLatency, stats: imbalanced3, allowLeaseRepl: false, expected: 1},
 	}
 
 	for _, c := range testCases {
@@ -5254,9 +5255,9 @@ func TestAllocatorTransferLeaseTargetLoadBased(t *testing.T) {
 				c.stats,
 				false,
 				transferLeaseOptions{
-					checkTransferLeaseSource: c.check,
-					checkCandidateFullness:   true,
-					dryRun:                   false,
+					excludeLeaseRepl:       !c.allowLeaseRepl,
+					checkCandidateFullness: true,
+					dryRun:                 false,
 				},
 			)
 			if c.expected != target.StoreID {

--- a/pkg/kv/kvserver/batcheval/cmd_lease_request.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_request.go
@@ -69,7 +69,7 @@ func RequestLease(
 
 	// If this check is removed at some point, the filtering of learners on the
 	// sending side would have to be removed as well.
-	if err := roachpb.CheckCanReceiveLease(args.Lease.Replica, cArgs.EvalCtx.Desc()); err != nil {
+	if err := roachpb.CheckCanReceiveLease(args.Lease.Replica, cArgs.EvalCtx.Desc().Replicas()); err != nil {
 		rErr.Message = err.Error()
 		return newFailedLeaseTrigger(false /* isTransfer */), rErr
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_lease_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_test.go
@@ -285,7 +285,7 @@ func TestCheckCanReceiveLease(t *testing.T) {
 			rngDesc := roachpb.RangeDescriptor{
 				InternalReplicas: []roachpb.ReplicaDescriptor{repDesc},
 			}
-			err := roachpb.CheckCanReceiveLease(rngDesc.InternalReplicas[0], &rngDesc)
+			err := roachpb.CheckCanReceiveLease(rngDesc.InternalReplicas[0], rngDesc.Replicas())
 			require.Equal(t, tc.eligible, err == nil, "err: %v", err)
 		})
 	}
@@ -293,6 +293,6 @@ func TestCheckCanReceiveLease(t *testing.T) {
 	t.Run("replica not in range desc", func(t *testing.T) {
 		repDesc := roachpb.ReplicaDescriptor{ReplicaID: 1}
 		rngDesc := roachpb.RangeDescriptor{}
-		require.Regexp(t, "replica.*not found", roachpb.CheckCanReceiveLease(repDesc, &rngDesc))
+		require.Regexp(t, "replica.*not found", roachpb.CheckCanReceiveLease(repDesc, rngDesc.Replicas()))
 	})
 }

--- a/pkg/kv/kvserver/batcheval/cmd_lease_transfer.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_transfer.go
@@ -78,7 +78,7 @@ func TransferLease(
 
 	// If this check is removed at some point, the filtering of learners on the
 	// sending side would have to be removed as well.
-	if err := roachpb.CheckCanReceiveLease(newLease.Replica, cArgs.EvalCtx.Desc()); err != nil {
+	if err := roachpb.CheckCanReceiveLease(newLease.Replica, cArgs.EvalCtx.Desc().Replicas()); err != nil {
 		return newFailedLeaseTrigger(true /* isTransfer */), err
 	}
 

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -54,7 +54,7 @@ func (s *Store) FindTargetAndTransferLease(
 	ctx context.Context, repl *Replica, desc *roachpb.RangeDescriptor, conf roachpb.SpanConfig,
 ) (bool, error) {
 	transferStatus, err := s.replicateQueue.shedLease(
-		ctx, repl, desc, conf, transferLeaseOptions{},
+		ctx, repl, desc, conf, transferLeaseOptions{excludeLeaseRepl: true},
 	)
 	return transferStatus == transferOK, err
 }

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -3369,14 +3369,17 @@ func (r *Replica) adminScatter(
 	// probability 1/N of choosing each.
 	if args.RandomizeLeases && r.OwnsValidLease(ctx, r.store.Clock().NowAsClockTimestamp()) {
 		desc := r.Desc()
-		// Learner replicas aren't allowed to become the leaseholder or raft leader,
-		// so only consider the `VoterDescriptors` replicas.
-		voterReplicas := desc.Replicas().VoterDescriptors()
-		newLeaseholderIdx := rand.Intn(len(voterReplicas))
-		targetStoreID := voterReplicas[newLeaseholderIdx].StoreID
-		if targetStoreID != r.store.StoreID() {
-			if err := r.AdminTransferLease(ctx, targetStoreID); err != nil {
-				log.Warningf(ctx, "failed to scatter lease to s%d: %+v", targetStoreID, err)
+		potentialLeaseTargets := r.store.allocator.ValidLeaseTargets(
+			ctx, r.SpanConfig(), desc.Replicas().VoterDescriptors(), r, false, /* excludeLeaseRepl */
+		)
+		if len(potentialLeaseTargets) > 0 {
+			newLeaseholderIdx := rand.Intn(len(potentialLeaseTargets))
+			targetStoreID := potentialLeaseTargets[newLeaseholderIdx].StoreID
+			if targetStoreID != r.store.StoreID() {
+				log.VEventf(ctx, 2, "randomly transferring lease to s%d", targetStoreID)
+				if err := r.AdminTransferLease(ctx, targetStoreID); err != nil {
+					log.Warningf(ctx, "failed to scatter lease to s%d: %+v", targetStoreID, err)
+				}
 			}
 		}
 	}

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -1062,7 +1062,7 @@ func (rp *replicaProposer) leaderStatusRLocked(raftGroup proposerRaft) rangeLead
 			// lease again, and by then hopefully we will have caught up.
 			leaderEligibleForLease = true
 		} else {
-			err := roachpb.CheckCanReceiveLease(leaderRep, rangeDesc)
+			err := roachpb.CheckCanReceiveLease(leaderRep, rangeDesc.Replicas())
 			leaderEligibleForLease = err == nil
 		}
 	}

--- a/pkg/kv/kvserver/replica_proposal_buf_test.go
+++ b/pkg/kv/kvserver/replica_proposal_buf_test.go
@@ -182,7 +182,7 @@ func (t *testProposer) leaderStatusRLocked(raftGroup proposerRaft) rangeLeaderIn
 			rngDesc := roachpb.RangeDescriptor{
 				InternalReplicas: []roachpb.ReplicaDescriptor{repDesc},
 			}
-			err := roachpb.CheckCanReceiveLease(repDesc, &rngDesc)
+			err := roachpb.CheckCanReceiveLease(repDesc, rngDesc.Replicas())
 			leaderEligibleForLease = err == nil
 		} else {
 			// This matches replicaProposed.leaderStatusRLocked().

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -458,7 +458,7 @@ func (rq *replicateQueue) shouldQueue(
 	status := repl.LeaseStatusAt(ctx, now)
 	if status.IsValid() &&
 		rq.canTransferLeaseFrom(ctx, repl) &&
-		rq.allocator.ShouldTransferLease(ctx, conf, voterReplicas, status.Lease.Replica.StoreID, repl.leaseholderStats) {
+		rq.allocator.ShouldTransferLease(ctx, conf, voterReplicas, repl, repl.leaseholderStats) {
 
 		log.VEventf(ctx, 2, "lease transfer needed, enqueuing")
 		return true, 0

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -1047,7 +1047,7 @@ func (rq *replicateQueue) maybeTransferLeaseAway(
 			dryRun: dryRun,
 			// NB: This option means that the allocator is asked to not consider the
 			// current replica in its set of potential candidates.
-			checkTransferLeaseSource: false,
+			excludeLeaseRepl: true,
 		},
 	)
 	return transferred == transferOK, err
@@ -1368,10 +1368,10 @@ func (rq *replicateQueue) considerRebalance(
 		desc,
 		conf,
 		transferLeaseOptions{
-			goal:                     followTheWorkload,
-			checkTransferLeaseSource: true,
-			checkCandidateFullness:   true,
-			dryRun:                   dryRun,
+			goal:                   followTheWorkload,
+			excludeLeaseRepl:       false,
+			checkCandidateFullness: true,
+			dryRun:                 dryRun,
 		},
 	)
 	return false, err
@@ -1489,10 +1489,10 @@ const (
 
 type transferLeaseOptions struct {
 	goal transferLeaseGoal
-	// checkTransferLeaseSource, when false, tells `TransferLeaseTarget` to
-	// exclude the current leaseholder from consideration as a potential target
-	// (i.e. when the caller explicitly wants to shed its lease away).
-	checkTransferLeaseSource bool
+	// excludeLeaseRepl, when true, tells `TransferLeaseTarget` to exclude the
+	// current leaseholder from consideration as a potential target (i.e. when the
+	// caller explicitly wants to shed its lease away).
+	excludeLeaseRepl bool
 	// checkCandidateFullness, when false, tells `TransferLeaseTarget`
 	// to disregard the existing lease counts on candidates.
 	checkCandidateFullness bool

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -1043,7 +1043,11 @@ func (rq *replicateQueue) maybeTransferLeaseAway(
 		desc,
 		conf,
 		transferLeaseOptions{
+			goal:   leaseCountConvergence,
 			dryRun: dryRun,
+			// NB: This option means that the allocator is asked to not consider the
+			// current replica in its set of potential candidates.
+			checkTransferLeaseSource: false,
 		},
 	)
 	return transferred == transferOK, err

--- a/pkg/kv/kvserver/scatter_test.go
+++ b/pkg/kv/kvserver/scatter_test.go
@@ -1,0 +1,92 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvserver_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func adminScatterArgs(key roachpb.Key, randomizeLeases bool) *roachpb.AdminScatterRequest {
+	return &roachpb.AdminScatterRequest{
+		RequestHeader: roachpb.RequestHeader{
+			Key:    key,
+			EndKey: key.Next(),
+		},
+		RandomizeLeases: randomizeLeases,
+	}
+}
+
+// TestAdminScatterWithDrainingNodes tests that when `AdminScatter` is called
+// with the `RandomizeLeases` option, it does not transfer leases to draining
+// nodes.
+func TestAdminScatterWithDrainingNodes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	// We set up a scratch range on 2 nodes, and then drain the second node.
+	const drainingServerIdx = 1
+	const drainingNodeID = drainingServerIdx + 1
+	tc := testcluster.StartTestCluster(
+		t, 2, base.TestClusterArgs{
+			ReplicationMode: base.ReplicationManual,
+		},
+	)
+	defer tc.Stopper().Stop(ctx)
+	scratchKey := tc.ScratchRange(t)
+	tc.AddVotersOrFatal(t, scratchKey, tc.Target(drainingServerIdx))
+
+	client, err := tc.GetAdminClient(ctx, t, drainingServerIdx)
+	require.NoError(t, err)
+	drain(ctx, t, client, drainingNodeID)
+
+	nonDrainingStore := tc.GetFirstStoreFromServer(t, 0)
+	drainingStore := tc.GetFirstStoreFromServer(t, drainingServerIdx)
+
+	// Wait until the non-draining node is aware of the draining node.
+	testutils.SucceedsSoon(t, tc.Servers[drainingServerIdx].HeartbeatNodeLiveness)
+	testutils.SucceedsSoon(t, func() error {
+		isDraining, err := nonDrainingStore.GetStoreConfig().StorePool.IsDraining(drainingStore.StoreID())
+		if err != nil {
+			return err
+		}
+		if !isDraining {
+			return errors.Newf("expected s%d to be in draining state", drainingStore.StoreID())
+		}
+		return nil
+	})
+
+	// Now, we repeatedly call `AdminScatter` with the `RandomizeLeases` option on
+	// this scratch range, and ensure that the lease is never transferred to the
+	// draining node.
+	const numIterations = 50
+	for i := 0; i < numIterations; i++ {
+		_, pErr := kv.SendWrapped(
+			ctx, nonDrainingStore.TestSender(), adminScatterArgs(scratchKey, true /* randomizeLeases */),
+		)
+		require.Nil(t, pErr)
+		leaseHolder, err := tc.FindRangeLeaseHolder(tc.LookupRangeOrFatal(t, scratchKey), nil /* hint */)
+		require.NoError(t, err)
+		require.NotEqual(t, drainingStore.StoreID(), leaseHolder.StoreID)
+	}
+}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1510,7 +1510,7 @@ func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString), v
 						r,
 						desc,
 						conf,
-						transferLeaseOptions{},
+						transferLeaseOptions{excludeLeaseRepl: true},
 					)
 					duration := timeutil.Since(start).Microseconds()
 

--- a/pkg/kv/kvserver/store_pool.go
+++ b/pkg/kv/kvserver/store_pool.go
@@ -645,6 +645,16 @@ func (sp *StorePool) IsUnknown(storeID roachpb.StoreID) (bool, error) {
 	return status == storeStatusUnknown, nil
 }
 
+// IsDraining returns true if the given store's status is `storeStatusDraining`
+// or an error if the store is not found in the pool.
+func (sp *StorePool) IsDraining(storeID roachpb.StoreID) (bool, error) {
+	status, err := sp.storeStatus(storeID)
+	if err != nil {
+		return false, err
+	}
+	return status == storeStatusDraining, nil
+}
+
 // IsLive returns true if the node is considered alive by the store pool or an error
 // if the store is not found in the pool.
 func (sp *StorePool) IsLive(storeID roachpb.StoreID) (bool, error) {

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -514,8 +514,7 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 			replWithStats.repl.leaseholderStats,
 			true, /* forceDecisionWithoutStats */
 			transferLeaseOptions{
-				goal:                     qpsConvergence,
-				checkTransferLeaseSource: true,
+				goal: qpsConvergence,
 			},
 		)
 

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -514,7 +514,8 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 			replWithStats.repl.leaseholderStats,
 			true, /* forceDecisionWithoutStats */
 			transferLeaseOptions{
-				goal: qpsConvergence,
+				goal:             qpsConvergence,
+				excludeLeaseRepl: false,
 			},
 		)
 

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -316,15 +316,10 @@ func (r *RangeDescriptor) GetReplicaDescriptor(storeID StoreID) (ReplicaDescript
 	return ReplicaDescriptor{}, false
 }
 
-// GetReplicaDescriptorByID returns the replica which matches the specified store
-// ID.
+// GetReplicaDescriptorByID returns the replica which matches the specified
+// replica ID.
 func (r *RangeDescriptor) GetReplicaDescriptorByID(replicaID ReplicaID) (ReplicaDescriptor, bool) {
-	for _, repDesc := range r.Replicas().Descriptors() {
-		if repDesc.ReplicaID == replicaID {
-			return repDesc, true
-		}
-	}
-	return ReplicaDescriptor{}, false
+	return r.Replicas().GetReplicaDescriptorByID(replicaID)
 }
 
 // ContainsVoterIncoming returns true if the descriptor contains a VOTER_INCOMING replica.
@@ -468,6 +463,17 @@ func (r ReplicaDescriptor) GetType() ReplicaType {
 
 // SafeValue implements the redact.SafeValue interface.
 func (r ReplicaType) SafeValue() {}
+
+// GetReplicaDescriptorByID returns the replica which matches the specified
+// replica ID.
+func (r ReplicaSet) GetReplicaDescriptorByID(id ReplicaID) (repDesc ReplicaDescriptor, found bool) {
+	for i := range r.wrapped {
+		if r.wrapped[i].ReplicaID == id {
+			return r.wrapped[i], true
+		}
+	}
+	return ReplicaDescriptor{}, false
+}
 
 // IsVoterOldConfig returns true if the replica is a voter in the outgoing
 // config (or, simply is a voter if the range is not in a joint-config state).

--- a/pkg/roachpb/metadata_replicas.go
+++ b/pkg/roachpb/metadata_replicas.go
@@ -516,17 +516,9 @@ var errReplicaCannotHoldLease = errors.Errorf("replica cannot hold lease")
 // CheckCanReceiveLease checks whether `wouldbeLeaseholder` can receive a lease.
 // Returns an error if the respective replica is not eligible.
 //
-// An error is also returned is the replica is not part of `rngDesc`.
-//
-// For now, don't allow replicas of type LEARNER to be leaseholders. There's
-// no reason this wouldn't work in principle, but it seems inadvisable. In
-// particular, learners can't become raft leaders, so we wouldn't be able to
-// co-locate the leaseholder + raft leader, which is going to affect tail
-// latencies. Additionally, as of the time of writing, learner replicas are
-// only used for a short time in replica addition, so it's not worth working
-// out the edge cases.
-func CheckCanReceiveLease(wouldbeLeaseholder ReplicaDescriptor, rngDesc *RangeDescriptor) error {
-	repDesc, ok := rngDesc.GetReplicaDescriptorByID(wouldbeLeaseholder.ReplicaID)
+// An error is also returned is the replica is not part of `replDescs`.
+func CheckCanReceiveLease(wouldbeLeaseholder ReplicaDescriptor, replDescs ReplicaSet) error {
+	repDesc, ok := replDescs.GetReplicaDescriptorByID(wouldbeLeaseholder.ReplicaID)
 	if !ok {
 		return errReplicaNotFound
 	} else if !repDesc.IsVoterNewConfig() {


### PR DESCRIPTION
Backport 4/4 commits from #79295.

Backport 1/1 commit from #79581.

Backport 1/1 commit from #81403.

/cc @cockroachdb/release

---

**kvserver: introduce Allocator.ValidLeaseTargets()**

This commit is a minor refactor of the `Allocator.TransferLeaseTarget` logic in
order to make it more readable and, to abstract out a new exported `Allocator`
method called `ValidLeaseTargets()`.

The contract of `ValidLeaseTargets()` is as follows:
```
// ValidLeaseTargets returns a set of candidate stores that are suitable to be
// transferred a lease for the given range.
//
// - It excludes stores that are dead, or marked draining or suspect.
// - If the range has lease_preferences, and there are any non-draining,
// non-suspect nodes that match those preferences, it excludes stores that don't
// match those preferences.
// - It excludes replicas that may need snapshots. If replica calling this
// method is not the Raft leader (meaning that it doesn't know whether follower
// replicas need a snapshot or not), produces no results.

```

Previously, there were multiple places where we were performing the logic
that's encapsulated by `ValidLeaseTargets()`, which was a potential source of
bugs. This is an attempt to unify this logic in one place that's relatively
well-tested. This commit is only a refactor, and does not attempt to change any
behavior. As such, no existing tests have been changed, with the exception of a
subtest inside `TestAllocatorTransferLeaseTargetDraining`. See the comment over
that subtest to understand why the behavior change made by this patch is
desirable.

The next commit in this PR uses this method to fix (at least part of) https://github.com/cockroachdb/cockroach/issues/74691.

Release note: none

**kvserver: don't transfer leases to draining nodes during scatters**

Previously, `AdminScatter` called with the `RandomizeLeases` option could
potentially transfer leases to nodes marked draining.  This commit leverages
the refactor from the last commit to fix this bug by first filtering the set of
candidates down to a set of valid candidates that meet lease preferences and
are not marked suspect or draining.

Relates to and fixes a part of https://github.com/cockroachdb/cockroach/issues/74691.

Release note (bug fix): Fixes a bug where draining / drained nodes could
re-acquire leases during an import or an index backfill.

Release justification: bug fix.
