### PR TITLE
release-21.2: kvserver: avoid lease transfers to draining nodes

### DIFF
--- a/pkg/kv/kvserver/scatter_test.go
+++ b/pkg/kv/kvserver/scatter_test.go
@@ -1,0 +1,91 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvserver_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func adminScatterArgs(key roachpb.Key, randomizeLeases bool) *roachpb.AdminScatterRequest {
+	return &roachpb.AdminScatterRequest{
+		RequestHeader: roachpb.RequestHeader{
+			Key:    key,
+			EndKey: key.Next(),
+		},
+		RandomizeLeases: randomizeLeases,
+	}
+}
+
+// TestAdminScatterWithDrainingNodes tests that when `AdminScatter` is called
+// with the `RandomizeLeases` option, it does not transfer leases to draining
+// nodes.
+func TestAdminScatterWithDrainingNodes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	// We set up a scratch range on 2 nodes, and then drain the second node.
+	const drainingServerIdx = 1
+	tc := testcluster.StartTestCluster(
+		t, 2, base.TestClusterArgs{
+			ReplicationMode: base.ReplicationManual,
+		},
+	)
+	defer tc.Stopper().Stop(ctx)
+	scratchKey := tc.ScratchRange(t)
+	tc.AddVotersOrFatal(t, scratchKey, tc.Target(drainingServerIdx))
+
+	client, err := tc.GetAdminClient(ctx, t, drainingServerIdx)
+	require.NoError(t, err)
+	drain(ctx, t, client)
+
+	nonDrainingStore := tc.GetFirstStoreFromServer(t, 0)
+	drainingStore := tc.GetFirstStoreFromServer(t, drainingServerIdx)
+
+	// Wait until the non-draining node is aware of the draining node.
+	testutils.SucceedsSoon(t, tc.Servers[drainingServerIdx].HeartbeatNodeLiveness)
+	testutils.SucceedsSoon(t, func() error {
+		isDraining, err := nonDrainingStore.GetStoreConfig().StorePool.IsDraining(drainingStore.StoreID())
+		if err != nil {
+			return err
+		}
+		if !isDraining {
+			return errors.Newf("expected s%d to be in draining state", drainingStore.StoreID())
+		}
+		return nil
+	})
+
+	// Now, we repeatedly call `AdminScatter` with the `RandomizeLeases` option on
+	// this scratch range, and ensure that the lease is never transferred to the
+	// draining node.
+	const numIterations = 50
+	for i := 0; i < numIterations; i++ {
+		_, pErr := kv.SendWrapped(
+			ctx, nonDrainingStore.TestSender(), adminScatterArgs(scratchKey, true /* randomizeLeases */),
+		)
+		require.Nil(t, pErr)
+		leaseHolder, err := tc.FindRangeLeaseHolder(tc.LookupRangeOrFatal(t, scratchKey), nil /* hint */)
+		require.NoError(t, err)
+		require.NotEqual(t, drainingStore.StoreID(), leaseHolder.StoreID)
+	}
+}

--- a/pkg/kv/kvserver/store_pool.go
+++ b/pkg/kv/kvserver/store_pool.go
@@ -643,6 +643,15 @@ func (sp *StorePool) IsUnknown(storeID roachpb.StoreID) (bool, error) {
 	return status == storeStatusUnknown, nil
 }
 
+// IsDraining returns true if the given store's status is `storeStatusDraining`.
+func (sp *StorePool) IsDraining(storeID roachpb.StoreID) (bool, error) {
+	status, err := sp.storeStatus(storeID)
+	if err != nil {
+		return false, err
+	}
+	return status == storeStatusDraining, nil
+}
+
 // IsLive returns true if the node is considered alive by the store pool or an error
 // if the store is not found in the pool.
 func (sp *StorePool) IsLive(storeID roachpb.StoreID) (bool, error) {


### PR DESCRIPTION
This patch is a more targetted fix for what #79295 does, for the
purposes of backporting to release-21.2.

Release note (bug fix): Draining nodes could previously re-acquire
leases during an import or an index backfill. This bug is now fixed.

Release justification: bug fix.