### PR TITLE
server: proactively rebalance decommissioning nodes' replicas

### DIFF
--- a/pkg/ccl/backupccl/utils_test.go
+++ b/pkg/ccl/backupccl/utils_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
-	roachpb "github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -569,7 +569,7 @@ WHERE start_pretty LIKE '%s' ORDER BY start_key ASC`, startPretty)).Scan(&startK
 	lhServer := tc.Server(int(l.Replica.NodeID) - 1)
 	s, repl := getFirstStoreReplica(t, lhServer, startKey)
 	testutils.SucceedsSoon(t, func() error {
-		trace, _, err := s.ManuallyEnqueue(ctx, "mvccGC", repl, skipShouldQueue)
+		trace, _, err := s.Enqueue(ctx, "mvccGC", repl, skipShouldQueue, false /* async */)
 		require.NoError(t, err)
 		return checkGCTrace(trace.String())
 	})

--- a/pkg/ccl/changefeedccl/helpers_tenant_shim_test.go
+++ b/pkg/ccl/changefeedccl/helpers_tenant_shim_test.go
@@ -116,6 +116,7 @@ func (t *testServerShim) MetricsRecorder() *status.MetricsRecorder { panic(unsup
 func (t *testServerShim) CollectionFactory() interface{}           { panic(unsupportedShimMethod) }
 func (t *testServerShim) SystemTableIDResolver() interface{}       { panic(unsupportedShimMethod) }
 func (t *testServerShim) SpanConfigKVSubscriber() interface{}      { panic(unsupportedShimMethod) }
+func (t *testServerShim) DecommissionMonitor() interface{}         { panic(unsupportedShimMethod) }
 func (t *testServerShim) SystemConfigProvider() config.SystemConfigProvider {
 	panic(unsupportedShimMethod)
 }

--- a/pkg/ccl/multiregionccl/datadriven_test.go
+++ b/pkg/ccl/multiregionccl/datadriven_test.go
@@ -315,8 +315,9 @@ SET CLUSTER SETTING kv.closed_timestamp.propagation_slack = '0.5s'
 						return errors.New(`could not find replica`)
 					}
 					for _, queueName := range []string{"split", "replicate", "raftsnapshot"} {
-						_, processErr, err := store.ManuallyEnqueue(ctx, queueName, repl,
-							true /* skipShouldQueue */)
+						_, processErr, err := store.Enqueue(
+							ctx, queueName, repl, true /* skipShouldQueue */, false, /* async */
+						)
 						if processErr != nil {
 							return processErr
 						}

--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -837,7 +837,7 @@ func TestLeasePreferencesDuringOutage(t *testing.T) {
 		return nil
 	})
 	_, _, enqueueError := tc.GetFirstStoreFromServer(t, 0).
-		ManuallyEnqueue(ctx, "replicate", repl, true)
+		Enqueue(ctx, "replicate", repl, true /* skipShouldQueue */, false /* async */)
 
 	require.NoError(t, enqueueError)
 
@@ -1036,7 +1036,7 @@ func TestLeasesDontThrashWhenNodeBecomesSuspect(t *testing.T) {
 			repl := tc.GetFirstStoreFromServer(t, i).LookupReplica(roachpb.RKey(key))
 			require.NotNil(t, repl)
 			_, _, enqueueError := tc.GetFirstStoreFromServer(t, i).
-				ManuallyEnqueue(ctx, "replicate", repl, true)
+				Enqueue(ctx, "replicate", repl, true /* skipShouldQueue */, false /* async */)
 			require.NoError(t, enqueueError)
 		}
 	}

--- a/pkg/kv/kvserver/client_migration_test.go
+++ b/pkg/kv/kvserver/client_migration_test.go
@@ -180,7 +180,7 @@ func TestMigrateWithInflightSnapshot(t *testing.T) {
 	repl, err := store.GetReplica(desc.RangeID)
 	require.NoError(t, err)
 	testutils.SucceedsSoon(t, func() error {
-		trace, processErr, err := store.ManuallyEnqueue(ctx, "raftsnapshot", repl, true /* skipShouldQueue */)
+		trace, processErr, err := store.Enqueue(ctx, "raftsnapshot", repl, true /* skipShouldQueue */, false /* async */)
 		if err != nil {
 			return err
 		}

--- a/pkg/kv/kvserver/client_protectedts_test.go
+++ b/pkg/kv/kvserver/client_protectedts_test.go
@@ -156,7 +156,7 @@ func TestProtectedTimestamps(t *testing.T) {
 		testutils.SucceedsSoon(t, func() error {
 			upsertUntilBackpressure()
 			s, repl := getStoreAndReplica()
-			trace, _, err := s.ManuallyEnqueue(ctx, "mvccGC", repl, false)
+			trace, _, err := s.Enqueue(ctx, "mvccGC", repl, false /* skipShouldQueue */, false /* async */)
 			require.NoError(t, err)
 			if !processedRegexp.MatchString(trace.String()) {
 				return errors.Errorf("%q does not match %q", trace.String(), processedRegexp)
@@ -200,13 +200,13 @@ func TestProtectedTimestamps(t *testing.T) {
 	s, repl := getStoreAndReplica()
 	// The protectedts record will prevent us from aging the MVCC garbage bytes
 	// past the oldest record so shouldQueue should be false. Verify that.
-	trace, _, err := s.ManuallyEnqueue(ctx, "mvccGC", repl, false /* skipShouldQueue */)
+	trace, _, err := s.Enqueue(ctx, "mvccGC", repl, false /* skipShouldQueue */, false /* async */)
 	require.NoError(t, err)
 	require.Regexp(t, "(?s)shouldQueue=false", trace.String())
 
 	// If we skipShouldQueue then gc will run but it should only run up to the
 	// timestamp of our record at the latest.
-	trace, _, err = s.ManuallyEnqueue(ctx, "mvccGC", repl, true /* skipShouldQueue */)
+	trace, _, err = s.Enqueue(ctx, "mvccGC", repl, true /* skipShouldQueue */, false /* async */)
 	require.NoError(t, err)
 	require.Regexp(t, "(?s)done with GC evaluation for 0 keys", trace.String())
 	thresh := thresholdFromTrace(trace)
@@ -258,7 +258,7 @@ func TestProtectedTimestamps(t *testing.T) {
 	// happens up to the protected timestamp of the new record.
 	require.NoError(t, ptsWithDB.Release(ctx, nil, ptsRec.ID.GetUUID()))
 	testutils.SucceedsSoon(t, func() error {
-		trace, _, err = s.ManuallyEnqueue(ctx, "mvccGC", repl, false)
+		trace, _, err = s.Enqueue(ctx, "mvccGC", repl, false /* skipShouldQueue */, false /* async */)
 		require.NoError(t, err)
 		if !processedRegexp.MatchString(trace.String()) {
 			return errors.Errorf("%q does not match %q", trace.String(), processedRegexp)

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -534,8 +534,12 @@ func testRaftSnapshotsToNonVoters(t *testing.T, drainReceivingNode bool) {
 		// Manually enqueue the leaseholder replica into its store's raft snapshot
 		// queue. We expect it to pick up on the fact that the non-voter on its range
 		// needs a snapshot.
-		recording, pErr, err := leaseholderStore.ManuallyEnqueue(
-			ctx, "raftsnapshot", leaseholderRepl, false, /* skipShouldQueue */
+		recording, pErr, err := leaseholderStore.Enqueue(
+			ctx,
+			"raftsnapshot",
+			leaseholderRepl,
+			false, /* skipShouldQueue */
+			false, /* async */
 		)
 		if pErr != nil {
 			return pErr
@@ -686,7 +690,9 @@ func TestReplicateQueueSeesLearnerOrJointConfig(t *testing.T) {
 	store, repl := getFirstStoreReplica(t, tc.Server(0), scratchStartKey)
 	{
 		require.Equal(t, int64(0), getFirstStoreMetric(t, tc.Server(0), `queue.replicate.removelearnerreplica`))
-		_, processErr, err := store.ManuallyEnqueue(ctx, "replicate", repl, true /* skipShouldQueue */)
+		_, processErr, err := store.Enqueue(
+			ctx, "replicate", repl, true /* skipShouldQueue */, false, /* async */
+		)
 		require.NoError(t, err)
 		require.NoError(t, processErr)
 		require.Equal(t, int64(1), getFirstStoreMetric(t, tc.Server(0), `queue.replicate.removelearnerreplica`))
@@ -704,7 +710,9 @@ func TestReplicateQueueSeesLearnerOrJointConfig(t *testing.T) {
 	ltk.withStopAfterJointConfig(func() {
 		desc := tc.RemoveVotersOrFatal(t, scratchStartKey, tc.Target(2))
 		require.True(t, desc.Replicas().InAtomicReplicationChange(), desc)
-		trace, processErr, err := store.ManuallyEnqueue(ctx, "replicate", repl, true /* skipShouldQueue */)
+		trace, processErr, err := store.Enqueue(
+			ctx, "replicate", repl, true /* skipShouldQueue */, false, /* async */
+		)
 		require.NoError(t, err)
 		require.NoError(t, processErr)
 		formattedTrace := trace.String()
@@ -743,7 +751,9 @@ func TestReplicaGCQueueSeesLearnerOrJointConfig(t *testing.T) {
 	// Run the replicaGC queue.
 	checkNoGC := func() roachpb.RangeDescriptor {
 		store, repl := getFirstStoreReplica(t, tc.Server(1), scratchStartKey)
-		trace, processErr, err := store.ManuallyEnqueue(ctx, "replicaGC", repl, true /* skipShouldQueue */)
+		trace, processErr, err := store.Enqueue(
+			ctx, "replicaGC", repl, true /* skipShouldQueue */, false, /* async */
+		)
 		require.NoError(t, err)
 		require.NoError(t, processErr)
 		const msg = `not gc'able, replica is still in range descriptor: (n2,s2):`
@@ -803,7 +813,9 @@ func TestRaftSnapshotQueueSeesLearner(t *testing.T) {
 	// raft to figure out that the replica needs a snapshot.
 	store, repl := getFirstStoreReplica(t, tc.Server(0), scratchStartKey)
 	testutils.SucceedsSoon(t, func() error {
-		trace, processErr, err := store.ManuallyEnqueue(ctx, "raftsnapshot", repl, true /* skipShouldQueue */)
+		trace, processErr, err := store.Enqueue(
+			ctx, "raftsnapshot", repl, true /* skipShouldQueue */, false, /* async */
+		)
 		if err != nil {
 			return err
 		}
@@ -939,7 +951,9 @@ func TestLearnerReplicateQueueRace(t *testing.T) {
 	queue1ErrCh := make(chan error, 1)
 	go func() {
 		queue1ErrCh <- func() error {
-			trace, processErr, err := store.ManuallyEnqueue(ctx, "replicate", repl, true /* skipShouldQueue */)
+			trace, processErr, err := store.Enqueue(
+				ctx, "replicate", repl, true /* skipShouldQueue */, false, /* async */
+			)
 			if err != nil {
 				return err
 			}
@@ -1419,7 +1433,9 @@ func TestMergeQueueDoesNotInterruptReplicationChange(t *testing.T) {
 		// ensure that the merge correctly notices that there is a snapshot in
 		// flight and ignores the range.
 		store, repl := getFirstStoreReplica(t, tc.Server(0), scratchKey)
-		_, processErr, enqueueErr := store.ManuallyEnqueue(ctx, "merge", repl, true /* skipShouldQueue */)
+		_, processErr, enqueueErr := store.Enqueue(
+			ctx, "merge", repl, true /* skipShouldQueue */, false, /* async */
+		)
 		require.NoError(t, enqueueErr)
 		require.True(t, kvserver.IsReplicationChangeInProgressError(processErr))
 		return nil
@@ -1464,7 +1480,9 @@ func TestMergeQueueSeesLearnerOrJointConfig(t *testing.T) {
 		})
 
 		store, repl := getFirstStoreReplica(t, tc.Server(0), scratchStartKey)
-		trace, processErr, err := store.ManuallyEnqueue(ctx, "merge", repl, true /* skipShouldQueue */)
+		trace, processErr, err := store.Enqueue(
+			ctx, "merge", repl, true /* skipShouldQueue */, false, /* async */
+		)
 		require.NoError(t, err)
 		require.NoError(t, processErr)
 		formattedTrace := trace.String()
@@ -1499,7 +1517,9 @@ func TestMergeQueueSeesLearnerOrJointConfig(t *testing.T) {
 		checkTransitioningOut := func() {
 			t.Helper()
 			store, repl := getFirstStoreReplica(t, tc.Server(0), scratchStartKey)
-			trace, processErr, err := store.ManuallyEnqueue(ctx, "merge", repl, true /* skipShouldQueue */)
+			trace, processErr, err := store.Enqueue(
+				ctx, "merge", repl, true /* skipShouldQueue */, false, /* async */
+			)
 			require.NoError(t, err)
 			require.NoError(t, processErr)
 			formattedTrace := trace.String()

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -1204,11 +1204,8 @@ func TestReplicateQueueShouldQueueNonVoter(t *testing.T) {
 		// because we know that it is the leaseholder (since it is the only voting
 		// replica).
 		store, repl := getFirstStoreReplica(t, tc.Server(0), scratchStartKey)
-		recording, processErr, err := store.ManuallyEnqueue(
-			ctx,
-			"replicate",
-			repl,
-			false, /* skipShouldQueue */
+		recording, processErr, err := store.Enqueue(
+			ctx, "replicate", repl, false /* skipShouldQueue */, false, /* async */
 		)
 		if err != nil {
 			log.Errorf(ctx, "err: %s", err.Error())

--- a/pkg/kv/kvserver/scanner.go
+++ b/pkg/kv/kvserver/scanner.go
@@ -35,6 +35,9 @@ type replicaQueue interface {
 	// the queue's inclusion criteria and the queue is not already
 	// too full, etc.
 	MaybeAddAsync(context.Context, replicaInQueue, hlc.ClockTimestamp)
+	// AddAsync adds the replica to the queue without checking if the replica
+	// meets the queue's inclusion criteria.
+	AddAsync(context.Context, replicaInQueue, float64)
 	// MaybeRemove removes the replica from the queue if it is present.
 	MaybeRemove(roachpb.RangeID)
 	// Name returns the name of the queue.

--- a/pkg/kv/kvserver/scanner_test.go
+++ b/pkg/kv/kvserver/scanner_test.go
@@ -159,6 +159,17 @@ func (tq *testQueue) MaybeAddAsync(
 	}
 }
 
+// NB: AddAsync on a testQueue is actually synchronous.
+func (tq *testQueue) AddAsync(ctx context.Context, replI replicaInQueue, prio float64) {
+	repl := replI.(*Replica)
+
+	tq.Lock()
+	defer tq.Unlock()
+	if index := tq.indexOf(repl.RangeID); index == -1 {
+		tq.ranges = append(tq.ranges, repl)
+	}
+}
+
 func (tq *testQueue) MaybeRemove(rangeID roachpb.RangeID) {
 	tq.Lock()
 	defer tq.Unlock()

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3374,12 +3374,14 @@ func (s *Store) AllocatorDryRun(ctx context.Context, repl *Replica) (tracing.Rec
 	return collectAndFinish(), nil
 }
 
-// ManuallyEnqueue runs the given replica through the requested queue,
-// returning all trace events collected along the way as well as the error
-// message returned from the queue's process method, if any.  Intended to help
-// power an admin debug endpoint.
-func (s *Store) ManuallyEnqueue(
-	ctx context.Context, queueName string, repl *Replica, skipShouldQueue bool,
+// Enqueue runs the given replica through the requested queue. If `async` is
+// specified, the replica is enqueued into the requested queue for asynchronous
+// processing and this method returns nothing. Otherwise, it returns all trace
+// events collected along the way as well as the error message returned from the
+// queue's process method, if any. Intended to help power the
+// server.decommissionMonitor and an admin debug endpoint.
+func (s *Store) Enqueue(
+	ctx context.Context, queueName string, repl *Replica, skipShouldQueue bool, async bool,
 ) (recording tracing.Recording, processError error, enqueueError error) {
 	ctx = repl.AnnotateCtx(ctx)
 
@@ -3390,12 +3392,14 @@ func (s *Store) ManuallyEnqueue(
 		return nil, nil, errors.Errorf("not enqueueing uninitialized replica %s", repl)
 	}
 
-	var queue queueImpl
+	var queue replicaQueue
+	var qImpl queueImpl
 	var needsLease bool
-	for _, replicaQueue := range s.scanner.queues {
-		if strings.EqualFold(replicaQueue.Name(), queueName) {
-			queue = replicaQueue.(queueImpl)
-			needsLease = replicaQueue.NeedsLease()
+	for _, q := range s.scanner.queues {
+		if strings.EqualFold(q.Name(), queueName) {
+			queue = q
+			qImpl = q.(queueImpl)
+			needsLease = q.NeedsLease()
 		}
 	}
 	if queue == nil {
@@ -3421,13 +3425,22 @@ func (s *Store) ManuallyEnqueue(
 		}
 	}
 
+	if async {
+		// NB: 1e6 is a placeholder for now. We want to use a high enough priority
+		// to ensure that these replicas are priority-ordered first.
+		//
+		// FIXME: Do something more accurate?
+		queue.AddAsync(ctx, repl, 1e6 /* prio */)
+		return nil, nil, nil
+	}
+
 	ctx, collectAndFinish := tracing.ContextWithRecordingSpan(
 		ctx, s.cfg.AmbientCtx.Tracer, fmt.Sprintf("manual %s queue run", queueName))
 	defer collectAndFinish()
 
 	if !skipShouldQueue {
 		log.Eventf(ctx, "running %s.shouldQueue", queueName)
-		shouldQueue, priority := queue.shouldQueue(ctx, s.cfg.Clock.NowAsClockTimestamp(), repl, confReader)
+		shouldQueue, priority := qImpl.shouldQueue(ctx, s.cfg.Clock.NowAsClockTimestamp(), repl, confReader)
 		log.Eventf(ctx, "shouldQueue=%v, priority=%f", shouldQueue, priority)
 		if !shouldQueue {
 			return collectAndFinish(), nil, nil
@@ -3435,7 +3448,7 @@ func (s *Store) ManuallyEnqueue(
 	}
 
 	log.Eventf(ctx, "running %s.process", queueName)
-	processed, processErr := queue.process(ctx, repl, confReader)
+	processed, processErr := qImpl.process(ctx, repl, confReader)
 	log.Eventf(ctx, "processed: %t (err: %v)", processed, processErr)
 	return collectAndFinish(), processErr, nil
 }

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -2369,6 +2369,10 @@ func (fq *fakeRangeQueue) MaybeAddAsync(context.Context, replicaInQueue, hlc.Clo
 	// Do nothing
 }
 
+func (fq *fakeRangeQueue) AddAsync(context.Context, replicaInQueue, float64) {
+	// Do nothing
+}
+
 func (fq *fakeRangeQueue) MaybeRemove(rangeID roachpb.RangeID) {
 	fq.maybeRemovedRngs <- rangeID
 }

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -60,7 +60,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
-	raft "go.etcd.io/etcd/raft/v3"
+	"go.etcd.io/etcd/raft/v3"
 	"go.etcd.io/etcd/raft/v3/raftpb"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/time/rate"
@@ -3088,7 +3088,9 @@ func TestManuallyEnqueueUninitializedReplica(t *testing.T) {
 		StoreID:   tc.store.StoreID(),
 		ReplicaID: 7,
 	})
-	_, _, err := tc.store.ManuallyEnqueue(ctx, "replicaGC", repl, true)
+	_, _, err := tc.store.Enqueue(
+		ctx, "replicaGC", repl, true /* skipShouldQueue */, false, /* async */
+	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not enqueueing uninitialized replica")
 }

--- a/pkg/kv/kvserver/stores_base.go
+++ b/pkg/kv/kvserver/stores_base.go
@@ -65,7 +65,7 @@ func (s *baseStore) Enqueue(
 		return nil, err
 	}
 
-	trace, processErr, enqueueErr := store.ManuallyEnqueue(ctx, queue, repl, skipShouldQueue)
+	trace, processErr, enqueueErr := store.Enqueue(ctx, queue, repl, skipShouldQueue, false /* async */)
 	if processErr != nil {
 		return nil, processErr
 	}

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -351,6 +351,9 @@ type StoreTestingKnobs struct {
 	// PurgeOutdatedReplicasInterceptor intercepts attempts to purge outdated
 	// replicas in the store.
 	PurgeOutdatedReplicasInterceptor func()
+	// EnqueueReplicaInterceptor intercepts calls to store.Enqueue() made to
+	// enqueue a particular replica into a particular queue.
+	EnqueueReplicaInterceptor func(queueName string, repl *Replica)
 	// SpanConfigUpdateInterceptor is called after the store hears about a span
 	// config update.
 	SpanConfigUpdateInterceptor func(spanconfig.Update)

--- a/pkg/roachpb/metadata_replicas.go
+++ b/pkg/roachpb/metadata_replicas.go
@@ -393,6 +393,17 @@ func (d ReplicaSet) ConfState() raftpb.ConfState {
 	return cs
 }
 
+// HasReplicaOnNode returns true iff the given nodeID is present in the
+// ReplicaSet.
+func (d ReplicaSet) HasReplicaOnNode(nodeID NodeID) bool {
+	for _, rep := range d.wrapped {
+		if rep.NodeID == nodeID {
+			return true
+		}
+	}
+	return false
+}
+
 // CanMakeProgress reports whether the given descriptors can make progress at
 // the replication layer. This is more complicated than just counting the number
 // of replicas due to the existence of joint quorums.

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2873,7 +2873,7 @@ func (s *adminServer) enqueueRangeLocal(
 		queueName = "mvccGC"
 	}
 
-	traceSpans, processErr, err := store.Enqueue(ctx, queueName, repl, req.SkipShouldQueue, req.Async)
+	traceSpans, processErr, err := store.Enqueue(ctx, queueName, repl, req.SkipShouldQueue, false /* async */)
 	if err != nil {
 		response.Details[0].Error = err.Error()
 		return response, nil

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2873,7 +2873,7 @@ func (s *adminServer) enqueueRangeLocal(
 		queueName = "mvccGC"
 	}
 
-	traceSpans, processErr, err := store.ManuallyEnqueue(ctx, queueName, repl, req.SkipShouldQueue)
+	traceSpans, processErr, err := store.Enqueue(ctx, queueName, repl, req.SkipShouldQueue, req.Async)
 	if err != nil {
 		response.Details[0].Error = err.Error()
 		return response, nil

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -2374,6 +2374,143 @@ func TestDecommissionSelf(t *testing.T) {
 	}
 }
 
+// TestDecommissionMonitorBasic tests that we spin up exactly one
+// `nodeDecommissionNudger` goroutine per decomissioning node and that once a
+// decommissioning node is marked `DECOMMISSIONED`, we wind down its nudger.
+func TestDecommissionMonitorBasic(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	skip.UnderRace(t) // too slow with 5-node clusters
+
+	// Set up test cluster.
+	ctx := context.Background()
+	tc := serverutils.StartNewTestCluster(t, 5, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	// Decommission several nodes, including the node we're submitting the
+	// decommission request to.
+	adminSrv := tc.Server(4)
+	conn, err := adminSrv.RPCContext().GRPCDialNode(
+		adminSrv.RPCAddr(), adminSrv.NodeID(), rpc.DefaultClass).Connect(ctx)
+	require.NoError(t, err)
+	adminClient := serverpb.NewAdminClient(conn)
+	decomNodeIDs := []roachpb.NodeID{
+		tc.Server(2).NodeID(),
+		tc.Server(3).NodeID(),
+		tc.Server(4).NodeID(),
+	}
+
+	// The DECOMMISSIONING call should return a full status response.
+	resp, err := adminClient.Decommission(ctx, &serverpb.DecommissionRequest{
+		NodeIDs:          decomNodeIDs,
+		TargetMembership: livenesspb.MembershipStatus_DECOMMISSIONING,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Status, len(decomNodeIDs))
+	for i, nodeID := range decomNodeIDs {
+		status := resp.Status[i]
+		require.Equal(t, nodeID, status.NodeID)
+		// Liveness entries may not have been updated yet.
+		require.Contains(t, []livenesspb.MembershipStatus{
+			livenesspb.MembershipStatus_ACTIVE,
+			livenesspb.MembershipStatus_DECOMMISSIONING,
+		}, status.Membership, "unexpected membership status %v for node %v", status, nodeID)
+	}
+
+	// We should have 3 active nudgers running on node 1.
+	monitor := tc.Server(1).DecommissionMonitor().(*decommissionMonitor)
+	testutils.SucceedsSoon(t, func() error {
+		active := monitor.getActiveDecommissionNudgers()
+		if len(decomNodeIDs) != len(active) {
+			return errors.Errorf("expected %d nudgers, got %d", len(decomNodeIDs), len(active))
+		}
+		if !reflect.DeepEqual(decomNodeIDs, active) {
+			return errors.Errorf("expected %v, got %v", decomNodeIDs, active)
+		}
+		return nil
+	})
+
+	// Decommission node 5 again and ensure that we still only see one active
+	// nudger for it.
+	resp, err = adminClient.Decommission(ctx, &serverpb.DecommissionRequest{
+		NodeIDs:          []roachpb.NodeID{tc.Server(4).NodeID()},
+		TargetMembership: livenesspb.MembershipStatus_DECOMMISSIONING,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Status, 1)
+	require.Equal(t, resp.Status[0].NodeID, tc.Server(4).NodeID())
+	require.ElementsMatch(t, []roachpb.NodeID{3, 4, 5}, monitor.getActiveDecommissionNudgers())
+
+	// Finally, mark all the `DECOMMISSIONING` nodes as `DECOMMISSIONED` and
+	// ensure that the nudgers are stopped.
+	resp, err = adminClient.Decommission(ctx, &serverpb.DecommissionRequest{
+		NodeIDs:          decomNodeIDs,
+		TargetMembership: livenesspb.MembershipStatus_DECOMMISSIONED,
+	})
+	require.NoError(t, err)
+	require.Empty(t, resp.Status)
+
+	require.Eventually(t, func() bool {
+		return len(monitor.getActiveDecommissionNudgers()) == 0
+	}, 10*time.Second, 100*time.Millisecond)
+}
+
+// TestDecommissionMonitorEnqueueReplicas tests that a decommissioning node's
+// replicas proactively enqueued into their replicateQueues by the other nodes
+// in the system.
+func TestDecommissionMonitorEnqueueReplicas(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	enqueueCh := make(chan roachpb.RangeID, 1)
+	tc := serverutils.StartNewTestCluster(t, 3, base.TestClusterArgs{
+		// Disable the replicateQueue so that the only way a decommissioning node
+		// can finish decommissioning is through the `decommissionMonitor`.
+		ReplicationMode: base.ReplicationManual,
+		ServerArgs: base.TestServerArgs{
+			Insecure: true, // allows admin client without setting up certs
+			Knobs: base.TestingKnobs{
+				Store: &kvserver.StoreTestingKnobs{
+					EnqueueReplicaInterceptor: func(
+						queueName string, repl *kvserver.Replica,
+					) {
+						require.Equal(t, queueName, "replicate")
+						enqueueCh <- repl.GetRangeID()
+					},
+				},
+			},
+		},
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	// Add a scratch range's replica to a node we will decommission later.
+	scratchKey := tc.ScratchRange(t)
+	const decommissioningSrvIdx = 2
+	decommissioningSrv := tc.Server(decommissioningSrvIdx)
+	tc.AddVotersOrFatal(t, scratchKey, tc.Target(decommissioningSrvIdx))
+
+	conn, err := decommissioningSrv.RPCContext().GRPCDialNode(
+		decommissioningSrv.RPCAddr(), decommissioningSrv.NodeID(), rpc.DefaultClass,
+	).Connect(ctx)
+	require.NoError(t, err)
+	adminClient := serverpb.NewAdminClient(conn)
+	decomNodeIDs := []roachpb.NodeID{tc.Server(decommissioningSrvIdx).NodeID()}
+	_, err = adminClient.Decommission(
+		ctx,
+		&serverpb.DecommissionRequest{
+			NodeIDs:          decomNodeIDs,
+			TargetMembership: livenesspb.MembershipStatus_DECOMMISSIONING,
+		},
+	)
+	require.NoError(t, err)
+
+	// Ensure that the scratch range's replica was proactively enqueued.
+	require.Equal(t, tc.LookupRangeOrFatal(t, scratchKey).RangeID, <-enqueueCh)
+}
+
 func TestAdminDecommissionedOperations(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/server/decommission.go
+++ b/pkg/server/decommission.go
@@ -12,21 +12,199 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"sort"
+	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 )
+
+// decommissionMonitor keeps track of the state associated with each
+// `nodeDecommissionNudger` and is incharge of initializing and closing them.
+type decommissionMonitor struct {
+	log.AmbientContext
+	stopper              *stop.Stopper
+	localNodeIDContainer *base.NodeIDContainer
+	localStores          *kvserver.Stores
+	mu                   struct {
+		syncutil.RWMutex
+		nudgersByNodeID map[roachpb.NodeID]*nodeDecommissionNudger
+	}
+	nudgerSem *quotapool.IntPool
+}
+
+// makeOnNodeDecommissionCallback returns a function that needs to be called
+// every time a node is detected to be decommissioning. It initializes and
+// starts a `nodeDecommissionNudger` if one doesn't exist for the node. We only
+// ever spin up one nodeDecommissionNudger for each decommissioning node, so
+// this function is idempotent.
+func (ms *decommissionMonitor) makeOnNodeDecommissioningCallback() liveness.OnNodeDecommissionCallback {
+	ctx := context.Background()
+	return func(decommissioningNodeID roachpb.NodeID) {
+		ms.mu.Lock()
+		defer ms.mu.Unlock()
+		if _, ok := ms.mu.nudgersByNodeID[decommissioningNodeID]; ok {
+			// We've already have an active nudger for this decommissioning node.
+			// Nothing to do.
+			return
+		}
+
+		// TODO(aayush): In a cluster with a ton of nodes, we may want to consider
+		// limiting the maximum number of decommissionNudgers that can be spun up.
+		nudger := &nodeDecommissionNudger{
+			stopper:               ms.stopper,
+			localStores:           ms.localStores,
+			nodeDecommissionedCh:  make(chan struct{}),
+			logLimiter:            log.Every(10 * time.Second),
+			localNodeID:           ms.localNodeIDContainer.Get(),
+			decommissioningNodeID: decommissioningNodeID,
+			nudgeInterval:         1 * time.Minute,
+			sem:                   ms.nudgerSem,
+		}
+		nudger.start(ctx)
+		ms.mu.nudgersByNodeID[decommissioningNodeID] = nudger
+	}
+}
+
+func (ms *decommissionMonitor) onNodeDecommissioned(nodeID roachpb.NodeID) {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+
+	nudger, ok := ms.mu.nudgersByNodeID[nodeID]
+	if !ok {
+		// We don't have an active nudger for this decommissioning node, which means
+		// we already shut it down.
+		return
+	}
+	nudger.stop()
+	delete(ms.mu.nudgersByNodeID, nodeID)
+}
+
+// getActiveDecommissionNudgers returns the set of nodeIds for which we have a
+// currently active nudger task.
+func (ms *decommissionMonitor) getActiveDecommissionNudgers() []roachpb.NodeID {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
+	var nodeIDs []roachpb.NodeID
+	for nodeID := range ms.mu.nudgersByNodeID {
+		nodeIDs = append(nodeIDs, nodeID)
+	}
+	return nodeIDs
+}
+
+// nodeDecommissioningNudger is responsible for proactively enqueuing a given
+// decommissioning node's replicas into the local node's replicateQueues. Then,
+// it periodically nudges the decommissioning node's straggling replicas (i.e.
+// replicas that still haven't been rebalanced after the given interval).
+type nodeDecommissionNudger struct {
+	log.AmbientContext
+	stopper              *stop.Stopper
+	localStores          *kvserver.Stores
+	nodeDecommissionedCh chan struct{}
+	logLimiter           log.EveryN // avoid log spam
+
+	localNodeID, decommissioningNodeID roachpb.NodeID
+	nudgeInterval                      time.Duration
+	sem                                *quotapool.IntPool
+}
+
+// start starts the nodeDecommissionNudger.
+func (n *nodeDecommissionNudger) start(ctx context.Context) {
+	n.AddLogTag(fmt.Sprintf("n%d", n.localNodeID), nil)
+	ctx = n.AnnotateCtx(ctx)
+
+	taskName := fmt.Sprintf("decommission-nudger-for-n%d", n.decommissioningNodeID)
+	if err := n.stopper.RunAsyncTask(ctx, taskName, func(ctx context.Context) {
+		alloc, err := n.sem.Acquire(ctx, 1)
+		if err != nil {
+			log.Fatalf(ctx, "error while trying to acquire quota to start nodeDecommissionNudger: %v", err)
+			return
+		}
+		defer n.sem.Release(alloc)
+		log.Infof(
+			ctx, "n%d is decommissioning; enqueueing its replicas for rebalancing", n.decommissioningNodeID,
+		)
+		n.enqueueReplicas(ctx)
+
+		for {
+			select {
+			case <-time.After(n.nudgeInterval):
+				n.enqueueReplicas(ctx)
+			case <-n.stopper.ShouldQuiesce():
+				return
+			case <-n.nodeDecommissionedCh:
+				log.Infof(ctx, "n%d fully decommissioned; stopping", n.decommissioningNodeID)
+				return
+			}
+		}
+	},
+	); err != nil && n.logLimiter.ShouldLog() {
+		log.Warningf(
+			ctx, "could not start decommission nudger for node n%d: %s", n.decommissioningNodeID, err,
+		)
+	}
+}
+
+func (n *nodeDecommissionNudger) stop() {
+	// TODO(aayush): Should we instead block here until the nudger actually stops?
+	close(n.nodeDecommissionedCh)
+}
+
+func (n *nodeDecommissionNudger) enqueueReplicas(ctx context.Context) {
+	if err := n.localStores.VisitStores(func(store *kvserver.Store) error {
+		// For each range that we have a lease for, check if it has a replica
+		// on the decommissioning node. If so, proactively enqueue this replica
+		// into our local replicateQueue.
+		store.VisitReplicas(
+			func(replica *kvserver.Replica) (wantMore bool) {
+				if !replica.Desc().Replicas().HasReplicaOnNode(n.decommissioningNodeID) &&
+					// Only bother enqueuing if we own the lease for this replica.
+					replica.OwnsValidLease(ctx, replica.Clock().NowAsClockTimestamp()) {
+					return true
+				}
+				_, processErr, enqueueErr := store.Enqueue(
+					// NB: We elide the shouldQueue check since we _know_ that the range
+					// being enqueued has replicas on a decommissioning node.
+					// Unfortunately, until https://github.com/cockroachdb/cockroach/issues/79266
+					// is fixed, the shouldQueue() method can return false negatives (i.e.
+					// it would return false when it really shouldn't).
+					ctx, "replicate", replica, true /* skipShouldQueue */, true, /* async */
+				)
+				if processErr != nil && n.logLimiter.ShouldLog() {
+					// When we enqueue a replica into the queue async, we don't
+					// expect to see any processing errors (since we are not waiting
+					// for the replica to be processed at all).
+					log.Warningf(ctx, "unexpected error processing replica: %s", processErr)
+				}
+				if enqueueErr != nil && n.logLimiter.ShouldLog() {
+					log.Warningf(ctx, "unable to enqueue replica: %s", enqueueErr)
+				}
+				return true /* wantMore */
+			})
+		return nil
+	}); err != nil {
+		// We're swallowing any errors above, so this shouldn't ever happen.
+		log.Fatalf(
+			ctx, "error while nudging replicas for decommissioning node n%d", n.decommissioningNodeID,
+		)
+	}
+}
 
 func getPingCheckDecommissionFn(
 	engines Engines,

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -234,6 +234,8 @@ type Node struct {
 	// COCKROACH_DEBUG_TS_IMPORT_FILE env var.
 	suppressNodeStatus syncutil.AtomicBool
 
+	decommissionMonitor *decommissionMonitor
+
 	testingErrorEvent func(context.Context, *roachpb.BatchRequest, error)
 }
 
@@ -359,6 +361,7 @@ func NewNode(
 	tenantUsage multitenant.TenantUsageServer,
 	tenantSettingsWatcher *tenantsettingswatcher.Watcher,
 	spanConfigAccessor spanconfig.KVAccessor,
+	decommissionMonitor *decommissionMonitor,
 ) *Node {
 	var sqlExec *sql.InternalExecutor
 	if execCfg != nil {
@@ -378,6 +381,7 @@ func NewNode(
 		tenantUsage:           tenantUsage,
 		tenantSettingsWatcher: tenantSettingsWatcher,
 		spanConfigAccessor:    spanConfigAccessor,
+		decommissionMonitor:   decommissionMonitor,
 		testingErrorEvent:     cfg.TestingKnobs.TestingResponseErrorEvent,
 	}
 	n.storeCfg.KVAdmissionController = n.admissionController

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1365,6 +1365,11 @@ func (ts *TestServer) SpanConfigKVSubscriber() interface{} {
 	return ts.node.storeCfg.SpanConfigSubscriber
 }
 
+// DecommissionMonitor is part of the TestServerInterface.
+func (ts *TestServer) DecommissionMonitor() interface{} {
+	return ts.node.decommissionMonitor
+}
+
 // SystemConfigProvider is part of the TestServerInterface.
 func (ts *TestServer) SystemConfigProvider() config.SystemConfigProvider {
 	return ts.node.storeCfg.SystemConfigProvider

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_client_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_client_test.go
@@ -67,7 +67,9 @@ func TestBlockedKVSubscriberDisablesMerges(t *testing.T) {
 	})
 
 	{
-		trace, processErr, err := store.ManuallyEnqueue(ctx, "merge", repl, true /* skipShouldQueue */)
+		trace, processErr, err := store.Enqueue(
+			ctx, "merge", repl, true /* skipShouldQueue */, false, /* async */
+		)
 		require.NoError(t, err)
 		require.NoError(t, processErr)
 		require.NoError(t, testutils.MatchInOrder(trace.String(), `skipping merge: queue has been disabled`))
@@ -82,7 +84,9 @@ func TestBlockedKVSubscriberDisablesMerges(t *testing.T) {
 	})
 
 	{
-		trace, processErr, err := store.ManuallyEnqueue(ctx, "merge", repl, true /* skipShouldQueue */)
+		trace, processErr, err := store.Enqueue(
+			ctx, "merge", repl, true /* skipShouldQueue */, false, /* async */
+		)
 		require.NoError(t, err)
 		require.NoError(t, processErr)
 		require.Error(t, testutils.MatchInOrder(trace.String(), `skipping merge: queue has been disabled`))

--- a/pkg/sql/importer/import_into_test.go
+++ b/pkg/sql/importer/import_into_test.go
@@ -129,7 +129,7 @@ func TestProtectedTimestampsDuringImportInto(t *testing.T) {
 			require.NoError(t, err)
 			lhServer := tc.Server(int(l.Replica.NodeID) - 1)
 			s, repl := getFirstStoreReplica(t, lhServer, startKey)
-			trace, _, err := s.ManuallyEnqueue(ctx, "mvccGC", repl, skipShouldQueue)
+			trace, _, err := s.Enqueue(ctx, "mvccGC", repl, skipShouldQueue, false /* async */)
 			require.NoError(t, err)
 			fmt.Fprintf(&traceBuf, "%s\n", trace.String())
 		}

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -199,6 +199,9 @@ type TestServerInterface interface {
 	// SpanConfigKVSubscriber returns the embedded spanconfig.KVSubscriber for
 	// the server.
 	SpanConfigKVSubscriber() interface{}
+
+	// DecommissionMonitor returns the DecommissionMonitor for the server.
+	DecommissionMonitor() interface{}
 }
 
 // TestServerFactory encompasses the actual implementation of the shim


### PR DESCRIPTION
Previously, when a node was marked `DECOMMISSIONING`, other nodes in the
system would learn about it via gossip but wouldn't do much in the way
of reacting to it. They'd rely on their `replicaScanner` to gradually
run into the decommissioning node's ranges and rely on their
`replicateQueue` to then rebalance them.

This had a few issues:
1. It meant that even when decommissioning a mostly empty node, our
   worst case lower bound for marking that node fully decommissioned was
   _one full scanner interval_ (which is 10 minutes by default).
2. If the replicateQueue ran into an error while rebalancing a
   decommissioning replica (see #79266 for instance), it would only
   retry that replica after either one full scanner interval or after
   the purgatory interval. This meant that decommissioning could take
   excessively long towards the tail end of the process. 

This patch improves this behavior by installing an idempotent callback
that is invoked every time a node is detected to be `DECOMMISSIONING`.
This callback spins up an async task that will first proactively enqueue
all of the decommissioning nodes ranges (that have a replica on the
local node) into the local node's replicateQueues. Then, this task will
periodically nudge the decommissioning node's straggling replicas in
order to requeue them (to alleviate (2) from above).

All this is managed by a lightweight `decommissionMonitor`, which is
responsible for managing the lifecycle of these async tasks.

Note: This PR is an alternative to, but subsumes, #80695. The main
difference between this patch and 80695 is that, here, _every_ node that
learns about a decommissioning node will spin up a local nudger goroutine
for it, whereas in 80695, only the node that sent the `DecommissionRequest`
will spin up a nudger goroutine that _then_ sends RPCs to other nodes in the
system to enqueue the decommissioning node's replicas.

Resolves https://github.com/cockroachdb/cockroach/issues/79453

Release note: None