### PR TITLE
parser: remove roachpb from tree

### DIFF
--- a/pkg/sql/parser/BUILD.bazel
+++ b/pkg/sql/parser/BUILD.bazel
@@ -22,7 +22,6 @@ go_library(
     deps = [
         "//pkg/docs",
         "//pkg/geo/geopb",  # keep
-        "//pkg/roachpb",  # keep
         "//pkg/security",  # keep
         "//pkg/sql/lexbase",
         "//pkg/sql/pgwire/pgcode",


### PR DESCRIPTION
Reacting on an [earlier comment](https://github.com/cockroachdb/cockroach/pull/80684#pullrequestreview-957921837) which I misunderstood. Delete roachpb
from parser as it is no longer a dependency.

Refs: #79357

Release note: None