### PR TITLE
cmd/roachtest: add first version roachtest for tenant streaming 

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -189,6 +189,9 @@ func initFlags() {
 		"skip-init", startOpts.SkipInit, "skip initializing the cluster")
 	startCmd.Flags().IntVar(&startOpts.StoreCount,
 		"store-count", startOpts.StoreCount, "number of stores to start each node with")
+	// TODO(during review): should we add flags here?
+	startCmd.Flags().IntVar(&startOpts.InitTarget,
+		"init-target", startOpts.InitTarget, "target node to initialize the cluster on")
 
 	startTenantCmd.Flags().StringVarP(&hostCluster,
 		"host-cluster", "H", "", "host cluster")

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -190,7 +190,7 @@ func initBinariesAndLibraries() {
 	// If we're running against an existing "local" cluster, force the local flag
 	// to true in order to get the "local" test configurations.
 	if clusterName == "local" {
-		local = true
+		 local = true
 	}
 	if local {
 		cloud = spec.Local

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -50,6 +50,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/codahale/hdrhistogram"
+	"github.com/stretchr/testify/require"
 )
 
 type workloadType string
@@ -150,10 +151,11 @@ func cdcBasicTest(ctx context.Context, t test.Test, c cluster.Cluster, args cdcT
 	m := c.NewMonitor(ctx, crdbNodes)
 	workloadCompleteCh := make(chan struct{}, 1)
 
+	var wl cdcWorkload
 	workloadStart := timeutil.Now()
+	t.Status(fmt.Sprintf("installing workload: %s", args.workloadType))
 	if args.workloadType == tpccWorkloadType {
-		t.Status("installing TPCC")
-		tpcc := tpccWorkload{
+		wl = &tpccWorkload{
 			sqlNodes:           crdbNodes,
 			workloadNodes:      workloadNode,
 			tpccWarehouseCount: args.tpccWarehouseCount,
@@ -161,32 +163,26 @@ func cdcBasicTest(ctx context.Context, t test.Test, c cluster.Cluster, args cdcT
 			// if it attempts to use the node which was brought down by chaos.
 			tolerateErrors: args.crdbChaos,
 		}
-
-		tpcc.install(ctx, c)
-		// TODO(dan,ajwerner): sleeping momentarily before running the workload
-		// mitigates errors like "error in newOrder: missing stock row" from tpcc.
-		time.Sleep(2 * time.Second)
-		t.Status("initiating workload")
-		m.Go(func(ctx context.Context) error {
-			defer func() { close(workloadCompleteCh) }()
-			tpcc.run(ctx, c, args.workloadDuration)
-			return nil
-		})
-	} else {
-		t.Status("installing Ledger Workload")
-		lw := ledgerWorkload{
-			sqlNodes:      crdbNodes,
+	} else if args.workloadType == ledgerWorkloadType {
+		wl = &ledgerWorkload{
+			sqlNodes:      c.Node(1),
 			workloadNodes: workloadNode,
 		}
-		lw.install(ctx, c)
-
-		t.Status("initiating workload")
-		m.Go(func(ctx context.Context) error {
-			defer func() { close(workloadCompleteCh) }()
-			lw.run(ctx, c, args.workloadDuration)
-			return nil
-		})
 	}
+
+	wl.install(ctx, c)
+
+	// TODO(dan,ajwerner): sleeping momentarily before running the workload
+	// mitigates errors like "error in newOrder: missing stock row" from tpcc.
+	if args.workloadType == tpccWorkloadType {
+		time.Sleep(2 * time.Second)
+	}
+	t.Status("initiating workload")
+	m.Go(func(ctx context.Context) error {
+		defer func() { close(workloadCompleteCh) }()
+		wl.run(ctx, c, args.workloadDuration)
+		return nil
+	})
 
 	changefeedLogger, err := t.L().ChildLogger("changefeed")
 	if err != nil {
@@ -1541,17 +1537,30 @@ func (k kafkaManager) consumer(ctx context.Context, topic string) (*topicConsume
 type tpccWorkload struct {
 	workloadNodes      option.NodeListOption
 	sqlNodes           option.NodeListOption
+	sqlPgUrl           string
 	tpccWarehouseCount int
 	tolerateErrors     bool
+	t                  test.Test
 }
 
+type cdcWorkload interface {
+	install(ctx context.Context, c cluster.Cluster)
+	run(ctx context.Context, c cluster.Cluster, workloadDuration string)
+}
+
+func pgUrl(sqlPgUrl string, sqlNodes option.NodeListOption) string {
+	if len(sqlPgUrl) == 0 {
+		return fmt.Sprintf("{pgurl%s}", sqlNodes.RandNode())
+	}
+	return sqlPgUrl
+}
 func (tw *tpccWorkload) install(ctx context.Context, c cluster.Cluster) {
 	// For fixtures import, use the version built into the cockroach binary so
 	// the tpcc workload-versions match on release branches.
 	c.Run(ctx, tw.workloadNodes, fmt.Sprintf(
-		`./cockroach workload fixtures import tpcc --warehouses=%d --checks=false {pgurl%s}`,
+		`./cockroach workload fixtures import tpcc --warehouses=%d --checks=false %s`,
 		tw.tpccWarehouseCount,
-		tw.sqlNodes.RandNode(),
+		pgUrl(tw.sqlPgUrl, tw.sqlNodes),
 	))
 }
 
@@ -1560,10 +1569,16 @@ func (tw *tpccWorkload) run(ctx context.Context, c cluster.Cluster, workloadDura
 	if tw.tolerateErrors {
 		tolerateErrors = "--tolerate-errors"
 	}
-	c.Run(ctx, tw.workloadNodes, fmt.Sprintf(
-		`./workload run tpcc --warehouses=%d --duration=%s %s {pgurl%s} `,
-		tw.tpccWarehouseCount, workloadDuration, tolerateErrors, tw.sqlNodes,
+	fmt.Printf("run a tpcc workload with pgurl: %s\n", fmt.Sprintf(
+		`./workload run tpcc --warehouses=%d --duration=%s %s %s `,
+		tw.tpccWarehouseCount, workloadDuration, tolerateErrors, pgUrl(tw.sqlPgUrl, tw.sqlNodes),
 	))
+	res, err := c.RunWithDetailsSingleNode(ctx, tw.t.L(), tw.workloadNodes, fmt.Sprintf(
+		`./workload run tpcc --warehouses=%d --duration=%s %s %s `,
+		tw.tpccWarehouseCount, workloadDuration, tolerateErrors, pgUrl(tw.sqlPgUrl, tw.sqlNodes),
+	))
+	require.NoError(tw.t, err)
+	log.Infof(ctx, "workload run res: %s\n", res.Stdout)
 }
 
 type ledgerWorkload struct {

--- a/pkg/cmd/roachtest/tests/multitenant_utils.go
+++ b/pkg/cmd/roachtest/tests/multitenant_utils.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -162,6 +163,14 @@ func (tn *tenantNode) secureURL() string {
 	return tn.relativeSecureURL
 }
 
+func (tn *tenantNode) sqlRunner() (*sqlutils.SQLRunner, error) {
+	db, err := gosql.Open("postgres", tn.pgURL)
+	if err != nil {
+		return nil, err
+	}
+	return sqlutils.MakeSQLRunner(db), nil
+}
+
 func (tn *tenantNode) start(ctx context.Context, t test.Test, c cluster.Cluster, binary string) {
 	require.True(t, c.IsSecure())
 
@@ -191,7 +200,8 @@ func (tn *tenantNode) start(ctx context.Context, t test.Test, c cluster.Cluster,
 	// pgURL has full paths to local certs embedded, i.e.
 	// /tmp/roachtest-certs3630333874/certs, on the cluster we want just certs
 	// (i.e. to run workload on the tenant).
-	secureUrls, err := roachprod.PgURL(ctx, t.L(), c.MakeNodes(c.Node(tn.node)), "certs", false /*external*/, true /* secure */)
+	secureUrls, err := roachprod.PgURL(ctx, t.L(), c.MakeNodes(c.Node(tn.node)),
+		"certs", false /*external*/, true /* secure */)
 	require.NoError(t, err)
 	u, err = url.Parse(strings.Trim(secureUrls[0], "'"))
 	require.NoError(t, err)

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -113,6 +113,7 @@ func RegisterTests(r registry.Registry) {
 	registerSSTableCorruption(r)
 	registerSyncTest(r)
 	registerSysbench(r)
+	registerTenantStreaming(r)
 	registerTLP(r)
 	registerTPCC(r)
 	registerTPCDSVec(r)

--- a/pkg/cmd/roachtest/tests/tenant_streaming.go
+++ b/pkg/cmd/roachtest/tests/tenant_streaming.go
@@ -1,0 +1,294 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+type streamTestArgs struct {
+	workloadType     workloadType
+	workloadDuration string
+	crdbChaos        bool
+}
+
+func srcClusterSettings(t test.Test, db *sqlutils.SQLRunner) {
+	db.ExecMultiple(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true;`,
+		`SET CLUSTER SETTING kv.closed_timestamp.target_duration = '1s';`,
+		`SET CLUSTER SETTING changefeed.experimental_poll_interval = '10ms';`,
+		`SET CLUSTER SETTING stream_replication.job_liveness_timeout = '20s';`,
+		`SET CLUSTER SETTING stream_replication.stream_liveness_track_frequency = '2s';`,
+		`SET CLUSTER SETTING stream_replication.min_checkpoint_frequency = '1s';`,
+		`SET CLUSTER SETTING jobs.registry.interval.adopt = '1s'`)
+}
+
+func destClusterSettings(t test.Test, db *sqlutils.SQLRunner) {
+	db.ExecMultiple(t, `SET enable_experimental_stream_replication = true;`,
+		`SET CLUSTER SETTING stream_replication.consumer_heartbeat_frequency = '100ms';`,
+		`SET CLUSTER SETTING bulkio.stream_ingestion.minimum_flush_interval = '10ms';`,
+		`SET CLUSTER SETTING bulkio.stream_ingestion.cutover_signal_poll_interval = '100ms';`,
+		`SET CLUSTER SETTING jobs.registry.interval.adopt = '1s'`)
+}
+
+// Returns the ingestion job ID and the stream ID.
+func startReplicationStream(t test.Test, srcSQL *sqlutils.SQLRunner, destSQL *sqlutils.SQLRunner, url string, srcTenant int, destTenant int) (int, int, error) {
+	// With initial scan
+	streamReplStmt := fmt.Sprintf("RESTORE TENANT %d FROM REPLICATION STREAM FROM '%s' AS TENANT %d",
+		srcTenant, url, destTenant)
+
+	fmt.Println("restore statement", streamReplStmt)
+	var ingestionJobID, streamProducerJobID int
+	destSQL.QueryRow(t, streamReplStmt).Scan(&ingestionJobID)
+	t.Status(fmt.Sprintf("created stream ingestion job %d\n", ingestionJobID))
+	srcSQL.SucceedsSoonDuration = 5 * time.Minute
+	defer func() {
+		srcSQL.SucceedsSoonDuration = testutils.DefaultSucceedsSoonDuration
+	}()
+
+	srcSQL.CheckQueryResultsRetry(t,
+		"SELECT count(*) FROM [SHOW JOBS] WHERE job_type = 'STREAM REPLICATION'", [][]string{{"1"}})
+	srcSQL.QueryRow(t, "SELECT job_id FROM [SHOW JOBS] WHERE job_type = 'STREAM REPLICATION'").
+		Scan(&streamProducerJobID)
+	t.Status(fmt.Sprintf("created stream producer job %d\n", streamProducerJobID))
+	return ingestionJobID, streamProducerJobID, nil
+}
+
+func stopReplicationStream(t test.Test, srcSQL *sqlutils.SQLRunner, destSQL *sqlutils.SQLRunner, ingestionJob int, producerJob int) {
+	var cutoverTime time.Time
+	srcSQL.QueryRow(t, "SELECT clock_timestamp()").Scan(&cutoverTime)
+
+	// Cut over the ingestion job and the job will stop eventually.
+	destSQL.Exec(t, `SELECT crdb_internal.complete_stream_ingestion_job($1, $2)`, ingestionJob, cutoverTime)
+
+	destSQL.SucceedsSoonDuration = 5 * time.Minute
+	srcSQL.SucceedsSoonDuration = 5 * time.Minute
+	defer func() {
+		destSQL.SucceedsSoonDuration = testutils.DefaultSucceedsSoonDuration
+		srcSQL.SucceedsSoonDuration = testutils.DefaultSucceedsSoonDuration
+	}()
+	destSQL.CheckQueryResultsRetry(t,
+		fmt.Sprintf("SELECT status FROM [SHOW JOBS] WHERE job_id = %d", ingestionJob), [][]string{{"succeeded"}})
+	srcSQL.CheckQueryResultsRetry(t,
+		fmt.Sprintf("SELECT status FROM [SHOW JOBS] WHERE job_id = %d", producerJob), [][]string{{"succeeded"}})
+}
+
+func verifyContent(t test.Test, srcSQL *sqlutils.SQLRunner, destSQL *sqlutils.SQLRunner, targets []string) int {
+	verifiedRows := 0
+	for _, target := range targets {
+		// TODO(casper): make this iterative using cursor to avoid using too much memory
+		query := fmt.Sprintf("SELECT * FROM %s LIMIT 10000", target)
+		srcData := srcSQL.QueryStr(t, query)
+		destData := destSQL.QueryStr(t, query)
+		require.Equal(t, srcData, destData)
+		verifiedRows += len(srcData)
+	}
+	return verifiedRows
+}
+
+// One tenant SQL node for source and dest cluster respectively and a workload node.
+// At least one KV node for source host cluster and destination host cluster respectively.
+const requiredNodeCount = 3
+
+func convertPGUrlInline(ctx context.Context, t test.Test, c cluster.Cluster, node option.NodeListOption,
+	pgUrlDir string, urlString string) string {
+	// Copy the cert from source into dest
+	tmpLocalDir, err := filepath.Abs("./certs")
+	require.NoError(t, err)
+	require.NoError(t, c.Get(ctx, t.L(), pgUrlDir, tmpLocalDir, node))
+	pgUrl, err := url.Parse(urlString)
+	require.NoError(t, err)
+	options := pgUrl.Query()
+	setKeyInline := func(key string, fileName string) {
+		content, err := os.ReadFile(fmt.Sprintf("%s/certs/%s", tmpLocalDir, fileName))
+		require.NoError(t, err)
+		options.Set(key, string(content))
+	}
+	options.Set("sslinline", "true")
+	options.Set("sslmode", "verify-full")
+	setKeyInline("sslrootcert", "ca.crt")
+	setKeyInline("sslcert", "client.root.crt")
+	setKeyInline("sslkey", "client.root.key")
+	pgUrl.RawQuery = options.Encode()
+	return pgUrl.String()
+}
+
+func tenantStreamingTest(ctx context.Context, t test.Test, c cluster.Cluster, args streamTestArgs) {
+	if nodeCount := c.Spec().NodeCount; nodeCount < requiredNodeCount {
+		t.Fatal(errors.Errorf("tenant streaming tests require %d nodes at minimum but only have %d nodes",
+			requiredNodeCount, nodeCount))
+	}
+
+	_, srcCrdbNodes := c.Node(1), c.Range(1, c.Spec().NodeCount/2)
+	_, destCrdbNodes := c.Node(c.Spec().NodeCount/2+1), c.Range(c.Spec().NodeCount/2+1, c.Spec().NodeCount-1)
+	workloadNode := c.Node(c.Spec().NodeCount)
+	c.Put(ctx, t.DeprecatedWorkload(), "./workload", workloadNode)
+
+	c.Put(ctx, t.Cockroach(), "./cockroach")
+	c.Put(ctx, t.Cockroach(), "./cockroach")
+
+	// Create a source CRDB cluster
+	srcStartOps := option.DefaultStartOpts()
+	srcStartOps.RoachprodOpts.InitTarget = 1
+	srcClusterSetting := install.MakeClusterSettings(install.SecureOption(true))
+	c.Start(ctx, t.L(), srcStartOps, srcClusterSetting, srcCrdbNodes)
+
+	addr, err := c.ExternalPGUrl(ctx, t.L(), srcCrdbNodes)
+	if err != nil {
+		t.Fatalf("error in retrieving source cluster PG URL: %s", err)
+	}
+
+	t.Status("converting pg url into sslinline mode")
+	pgUrl := convertPGUrlInline(ctx, t, c, c.Node(1), srcClusterSetting.PGUrlCertsDir, addr[0])
+	destStartOps := option.DefaultStartOpts()
+	destStartOps.RoachprodOpts.InitTarget = c.Spec().NodeCount/2 + 1
+	destClusterSetting := install.MakeClusterSettings(install.SecureOption(true))
+	c.Start(ctx, t.L(), destStartOps, destClusterSetting, destCrdbNodes)
+
+	srcSQL, destSQL := sqlutils.MakeSQLRunner(c.Conn(ctx, t.L(), 1)),
+		sqlutils.MakeSQLRunner(c.Conn(ctx, t.L(), c.Spec().NodeCount/2+1))
+	srcClusterSettings(t, srcSQL)
+	destClusterSettings(t, destSQL)
+
+	srcTenantID, destTenantID := 10, 20
+	const (
+		tenantHTTPPort = 8081
+		tenantSQLPort  = 30258
+	)
+	// Create source tenant
+	srcSQL.Exec(t, `SELECT crdb_internal.create_tenant($1)`, srcTenantID)
+	srcTenant := createTenantNode(ctx, t, c, srcCrdbNodes, srcTenantID, 1, tenantHTTPPort, tenantSQLPort)
+	srcTenant.start(ctx, t, c, "./cockroach")
+	defer srcTenant.stop(ctx, t, c)
+
+	// Create dest tenant
+	destSQL.Exec(t, `SELECT crdb_internal.create_tenant($1)`, destTenantID)
+	destTenant := createTenantNode(ctx, t, c, destCrdbNodes, destTenantID, c.Spec().NodeCount/2+1, tenantHTTPPort, tenantSQLPort)
+	destTenant.start(ctx, t, c, "./cockroach")
+	defer destTenant.stop(ctx, t, c)
+
+	srcTenantSQL, err := srcTenant.sqlRunner()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	destTenantSQL, err := destTenant.sqlRunner()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	//fmt.Printf("SRC TENANTS JOBS: %s\n", srcTenantSQL.QueryStr(t, "SHOW JOBS"))
+	//fmt.Printf("DEST TENANTS JOBS: %s\n", destTenantSQL.QueryStr(t, "SHOW JOBS"))
+
+	m := c.NewMonitor(ctx, srcCrdbNodes)
+	workloadCompleteCh := make(chan struct{}, 1)
+
+	var wl cdcWorkload
+	t.Status(fmt.Sprintf("installing workload: %s", args.workloadType))
+	if args.workloadType == tpccWorkloadType {
+		wl = &tpccWorkload{
+			sqlNodes:           c.Node(1), // TODO(casper): cannot use this node to get pgurl
+			sqlPgUrl:           srcTenant.pgURL,
+			workloadNodes:      workloadNode,
+			tpccWarehouseCount: 20,
+			// TolerateErrors if crdbChaos is true; otherwise, the workload will fail
+			// if it attempts to use the node which was brought down by chaos.
+			// TODO(casper): introduce chaos into both clusters
+			tolerateErrors: args.crdbChaos,
+			t:              t,
+		}
+	} else if args.workloadType == ledgerWorkloadType {
+		wl = &ledgerWorkload{
+			sqlNodes:      c.Node(1),
+			workloadNodes: workloadNode,
+		}
+	}
+
+	wl.install(ctx, c)
+
+	// TODO(dan,ajwerner): sleeping momentarily before running the workload
+	// mitigates errors like "error in newOrder: missing stock row" from tpcc.
+	if args.workloadType == tpccWorkloadType {
+		time.Sleep(2 * time.Second)
+	}
+	t.Status("initiating workload")
+	m.Go(func(ctx context.Context) error {
+		now := timeutil.Now()
+		defer func() {
+			close(workloadCompleteCh)
+			fmt.Printf("workload duration %s\n", timeutil.Since(now))
+		}()
+		wl.run(ctx, c, args.workloadDuration)
+		return nil
+	})
+
+	m.Go(func(ctx context.Context) error {
+		t.Status("starting stream replication")
+		ingestionJob, producerJob, err := startReplicationStream(t, srcSQL, destSQL, pgUrl, srcTenantID, destTenantID)
+		if err != nil {
+			t.Fatalf("error in creating replication stream: %s", err)
+		}
+		// Wait for workload to complete
+		<-workloadCompleteCh
+
+		t.Status("workload completed, stopping stream replication")
+		stopReplicationStream(t, srcSQL, destSQL, ingestionJob, producerJob)
+
+		var targets []string
+		if args.workloadType == tpccWorkloadType {
+			targets = []string{"tpcc.warehouse", "tpcc.district", "tpcc.customer",
+				"tpcc.history", "tpcc.order", "tpcc.new_order", "tpcc.item", "tpcc.stock", "tpcc.order_line"}
+		} else if args.workloadType == ledgerWorkloadType {
+			targets = []string{"ledger.customer", "ledger.transaction", "ledger.entry", "ledger.session"}
+		}
+
+		// verify correctness
+		t.Status("verifying content between source cluster and destination cluster")
+		verifiedRows := verifyContent(t, srcTenantSQL, destTenantSQL, targets)
+		t.Status(fmt.Sprintf("finished verifying %d rows of data", verifiedRows))
+		return nil
+	})
+
+	m.Wait()
+}
+
+func registerTenantStreaming(r registry.Registry) {
+	r.Add(registry.TestSpec{
+		Name:            "cdc/tenant-streaming-tpcc",
+		Owner:           registry.OwnerCDC,
+		Cluster:         r.MakeClusterSpec(3, spec.CPU(8)),
+		RequiresLicense: true,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			tenantStreamingTest(ctx, t, c, streamTestArgs{
+				workloadType:     tpccWorkloadType,
+				workloadDuration: "20s",
+			})
+		},
+	})
+
+	r.Add(registry.TestSpec{
+		Name:            "cdc/tenant-streaming-ledger",
+		Owner:           registry.OwnerCDC,
+		Cluster:         r.MakeClusterSpec(5, spec.CPU(8)),
+		RequiresLicense: true,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			tenantStreamingTest(ctx, t, c, streamTestArgs{
+				workloadDuration: "20s",
+				workloadType:     ledgerWorkloadType,
+			})
+		},
+	})
+}

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -2281,27 +2281,31 @@ func (c *SyncedCluster) ParallelE(
 // to maintain parity with auto-init behavior of `roachprod start` (when
 // --skip-init) is not specified. The implementation should be kept in
 // sync with Start().
-func (c *SyncedCluster) Init(ctx context.Context, l *logger.Logger) error {
+func (c *SyncedCluster) Init(ctx context.Context, l *logger.Logger, allNodesSpecified bool) error {
 	// See Start(). We reserve a few special operations for the first node, so we
 	// strive to maintain the same here for interoperability.
-	const firstNodeIdx = 0
+	initNodes := 1
+	if !allNodesSpecified {
+		initNodes = len(c.Nodes)
+	}
+	return c.Parallel(l, "", initNodes, 1 /* concurrency */, func(nodeIdx int) ([]byte, error) {
+		l.Printf("%s: initializing cluster\n", c.Name)
+		initOut, err := c.initializeCluster(ctx, Node(nodeIdx))
+		if err != nil {
+			return nil, errors.WithDetail(err, "install.Init() failed: unable to initialize cluster.")
+		}
+		if initOut != "" {
+			l.Printf(initOut)
+		}
 
-	l.Printf("%s: initializing cluster\n", c.Name)
-	initOut, err := c.initializeCluster(ctx, firstNodeIdx)
-	if err != nil {
-		return errors.WithDetail(err, "install.Init() failed: unable to initialize cluster.")
-	}
-	if initOut != "" {
-		l.Printf(initOut)
-	}
-
-	l.Printf("%s: setting cluster settings", c.Name)
-	clusterSettingsOut, err := c.setClusterSettings(ctx, l, firstNodeIdx)
-	if err != nil {
-		return errors.WithDetail(err, "install.Init() failed: unable to set cluster settings.")
-	}
-	if clusterSettingsOut != "" {
-		l.Printf(clusterSettingsOut)
-	}
-	return nil
+		l.Printf("%s: setting cluster settings", c.Name)
+		clusterSettingsOut, err := c.setClusterSettings(ctx, l, Node(nodeIdx))
+		if err != nil {
+			return nil, errors.WithDetail(err, "install.Init() failed: unable to set cluster settings.")
+		}
+		if clusterSettingsOut != "" {
+			l.Printf(clusterSettingsOut)
+		}
+		return nil, err
+	})
 }

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -85,7 +85,10 @@ func argExists(args []string, target string) int {
 type StartOpts struct {
 	Target     StartTarget
 	Sequential bool
-	ExtraArgs  []string
+
+	// TODO(during review): should we use --join in ExtraArgs instead?
+	// don't know how to find node address port before Start().
+	ExtraArgs []string
 
 	// systemd limits on resources.
 	NumFilesLimit int64
@@ -95,6 +98,14 @@ type StartOpts struct {
 	SkipInit        bool
 	StoreCount      int
 	EncryptedStores bool
+
+	// Target node that we run Init on, which creates a new CRDB cluster.
+	// It is ignored is SkipInit is true.
+	InitTarget int
+
+	// TODO(durint review): do we need this, use --join in extra args insead?
+	//// Target node that starting nodes will join.
+	//JoinTarget int
 
 	// -- Options that apply only to StartTenantSQL target --
 	TenantID  int
@@ -166,12 +177,6 @@ func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts S
 			return nil, nil
 		}
 
-		// We reserve a few special operations (bootstrapping, and setting
-		// cluster settings) for node 1.
-		if node != 1 {
-			return nil, nil
-		}
-
 		// NB: The code blocks below are not parallelized, so it's safe for us
 		// to use fmt.Printf style logging.
 
@@ -182,10 +187,16 @@ func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts S
 			return nil, nil
 		}
 
+		// We reserve a few special operations (bootstrapping, and setting
+		// cluster settings) for node 1.
+		if node != Node(startOpts.InitTarget) {
+			return nil, nil
+		}
+
 		shouldInit := !c.useStartSingleNode()
 		if shouldInit {
 			l.Printf("%s: initializing cluster", c.Name)
-			initOut, err := c.initializeCluster(ctx, node)
+			initOut, err := c.initializeCluster(ctx, node) // what does this do?
 			if err != nil {
 				return nil, errors.WithDetail(err, "unable to initialize cluster")
 			}
@@ -514,7 +525,8 @@ func (c *SyncedCluster) generateStartArgs(
 
 	// --join flags are unsupported/unnecessary in `cockroach start-single-node`.
 	if startOpts.Target == StartDefault && !c.useStartSingleNode() {
-		args = append(args, fmt.Sprintf("--join=%s:%d", c.Host(1), c.NodePort(1)))
+		args = append(args, fmt.Sprintf("--join=%s:%d",
+			c.Host(Node(startOpts.InitTarget)), c.NodePort(Node(startOpts.InitTarget))))
 	}
 	if startOpts.Target == StartTenantSQL {
 		args = append(args, fmt.Sprintf("--kv-addrs=%s", startOpts.KVAddrs))
@@ -673,7 +685,7 @@ func (c *SyncedCluster) generateClusterSettingCmd(l *logger.Logger, node Node) s
 func (c *SyncedCluster) generateInitCmd(node Node) string {
 	var initCmd string
 	if c.IsLocal() {
-		initCmd = fmt.Sprintf(`cd %s ; `, c.localVMDir(1))
+		initCmd = fmt.Sprintf(`cd %s ; `, c.localVMDir(node))
 	}
 
 	path := fmt.Sprintf("%s/%s", c.NodeDir(node, 1 /* storeIndex */), "cluster-bootstrapped")

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -134,14 +134,10 @@ func sortedClusters() []string {
 	return r
 }
 
-// newCluster initializes a SyncedCluster for the given cluster name.
-//
-// The cluster name can include a node selector (e.g. "foo:1-3").
-func newCluster(
-	l *logger.Logger, name string, opts ...install.ClusterSettingOption,
-) (*install.SyncedCluster, error) {
-	clusterSettings := install.MakeClusterSettings(opts...)
-	nodeSelector := "all"
+const allNodesSelector = "all"
+
+func parseClusterAndNodesName(name string) (string, string, error) {
+	nodeSelector := allNodesSelector
 	{
 		parts := strings.Split(name, ":")
 		switch len(parts) {
@@ -151,12 +147,26 @@ func newCluster(
 		case 1:
 			name = parts[0]
 		case 0:
-			return nil, fmt.Errorf("no cluster specified")
+			return "", "", fmt.Errorf("no cluster specified")
 		default:
-			return nil, fmt.Errorf("invalid cluster name: %s", name)
+			return "", "", fmt.Errorf("invalid cluster name: %s", name)
 		}
 	}
+	return name, nodeSelector, nil
+}
 
+// newCluster initializes a SyncedCluster for the given cluster name.
+//
+// The cluster name can include a node selector (e.g. "foo:1-3").
+func newCluster(
+	l *logger.Logger, name string, opts ...install.ClusterSettingOption,
+) (*install.SyncedCluster, error) {
+	clusterSettings := install.MakeClusterSettings(opts...)
+	name, nodeSelector, err := parseClusterAndNodesName(name)
+	if err != nil {
+		return nil, err
+	}
+	l.Printf("creating a new cluster %s, %s\n", name, nodeSelector)
 	metadata, ok := readSyncedClusters(name)
 	if !ok {
 		err := errors.Newf(`unknown cluster: %s`, name)
@@ -169,6 +179,7 @@ func newCluster(
 		clusterSettings.DebugDir = os.ExpandEnv(config.DefaultDebugDir)
 	}
 
+	l.Printf("really creating a new cluster\n")
 	c, err := install.NewSyncedCluster(metadata, nodeSelector, clusterSettings)
 	if err != nil {
 		return nil, err
@@ -640,6 +651,7 @@ func DefaultStartOpts() install.StartOpts {
 		SkipInit:        false,
 		StoreCount:      1,
 		TenantID:        2,
+		InitTarget:      1,
 	}
 }
 
@@ -711,11 +723,15 @@ func Init(ctx context.Context, l *logger.Logger, clusterName string) error {
 	if err := LoadClusters(); err != nil {
 		return err
 	}
+	_, nodeNames, err := parseClusterAndNodesName(clusterName)
+	if err != nil {
+		return err
+	}
 	c, err := newCluster(l, clusterName)
 	if err != nil {
 		return err
 	}
-	return c.Init(ctx, l)
+	return c.Init(ctx, l, nodeNames == allNodesSelector)
 }
 
 // Wipe wipes the nodes in a cluster.

--- a/pkg/workload/connection.go
+++ b/pkg/workload/connection.go
@@ -51,6 +51,7 @@ func NewConnFlags(genFlags *Flags) *ConnFlags {
 // SQL database set, rewriting them in place if necessary. This database name is
 // returned.
 func SanitizeUrls(gen Generator, dbOverride string, urls []string) (string, error) {
+	fmt.Printf("SanitizeUrls %s\n", urls)
 	dbName := gen.Meta().Name
 	if dbOverride != `` {
 		dbName = dbOverride


### PR DESCRIPTION
This initial version of roachtest creates two crdb clusters,
and sets up stream replication between the two, runs tpcc or
ledge workload on the source, and verify if two tenants are
identical after the stream replication.

This PR also adds InitTarget as roachprod cluster option to
support multiple crdb clusters in roachprod.

Release note: None