### PR TITLE
roachprod: support InitTarget when starting nodes in roachprod cluster

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -185,6 +185,9 @@ func initFlags() {
 		"skip-init", startOpts.SkipInit, "skip initializing the cluster")
 	startCmd.Flags().IntVar(&startOpts.StoreCount,
 		"store-count", startOpts.StoreCount, "number of stores to start each node with")
+	// TODO(during review): should we add flags here?
+	startCmd.Flags().IntVar(&startOpts.InitTarget,
+		"init-target", startOpts.InitTarget, "target node to initialize the cluster on")
 
 	startTenantCmd.Flags().StringVarP(&hostCluster,
 		"host-cluster", "H", "", "host cluster")

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -2048,27 +2048,31 @@ func (c *SyncedCluster) ParallelE(
 // to maintain parity with auto-init behavior of `roachprod start` (when
 // --skip-init) is not specified. The implementation should be kept in
 // sync with Start().
-func (c *SyncedCluster) Init(ctx context.Context, l *logger.Logger) error {
+func (c *SyncedCluster) Init(ctx context.Context, l *logger.Logger, allNodesSpecified bool) error {
 	// See Start(). We reserve a few special operations for the first node, so we
 	// strive to maintain the same here for interoperability.
-	const firstNodeIdx = 0
+	initNodes := 1
+	if !allNodesSpecified {
+		initNodes = len(c.Nodes)
+	}
+	return c.Parallel(l, "", initNodes, 1 /* concurrency */, func(nodeIdx int) ([]byte, error) {
+		l.Printf("%s: initializing cluster\n", c.Name)
+		initOut, err := c.initializeCluster(ctx, Node(nodeIdx))
+		if err != nil {
+			return nil, errors.WithDetail(err, "install.Init() failed: unable to initialize cluster.")
+		}
+		if initOut != "" {
+			l.Printf(initOut)
+		}
 
-	l.Printf("%s: initializing cluster\n", c.Name)
-	initOut, err := c.initializeCluster(ctx, firstNodeIdx)
-	if err != nil {
-		return errors.WithDetail(err, "install.Init() failed: unable to initialize cluster.")
-	}
-	if initOut != "" {
-		l.Printf(initOut)
-	}
-
-	l.Printf("%s: setting cluster settings", c.Name)
-	clusterSettingsOut, err := c.setClusterSettings(ctx, l, firstNodeIdx)
-	if err != nil {
-		return errors.WithDetail(err, "install.Init() failed: unable to set cluster settings.")
-	}
-	if clusterSettingsOut != "" {
-		l.Printf(clusterSettingsOut)
-	}
-	return nil
+		l.Printf("%s: setting cluster settings", c.Name)
+		clusterSettingsOut, err := c.setClusterSettings(ctx, l, Node(nodeIdx))
+		if err != nil {
+			return nil, errors.WithDetail(err, "install.Init() failed: unable to set cluster settings.")
+		}
+		if clusterSettingsOut != "" {
+			l.Printf(clusterSettingsOut)
+		}
+		return nil, err
+	})
 }

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -105,7 +105,10 @@ func argExists(args []string, target string) int {
 type StartOpts struct {
 	Target     StartTarget
 	Sequential bool
-	ExtraArgs  []string
+
+	// TODO(during review): should we use --join in ExtraArgs instead?
+	// don't know how to find node address port before Start().
+	ExtraArgs []string
 
 	// systemd limits on resources.
 	NumFilesLimit int64
@@ -115,6 +118,14 @@ type StartOpts struct {
 	SkipInit        bool
 	StoreCount      int
 	EncryptedStores bool
+
+	// Target node that we run Init on, which creates a new CRDB cluster.
+	// It is ignored is SkipInit is true.
+	InitTarget int
+
+	// TODO(durint review): do we need this, use --join in extra args insead?
+	//// Target node that starting nodes will join.
+	//JoinTarget int
 
 	// -- Options that apply only to StartTenantSQL target --
 	TenantID int
@@ -182,12 +193,6 @@ func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts S
 			return nil, nil
 		}
 
-		// We reserve a few special operations (bootstrapping, and setting
-		// cluster settings) for node 1.
-		if node != 1 {
-			return nil, nil
-		}
-
 		// NB: The code blocks below are not parallelized, so it's safe for us
 		// to use fmt.Printf style logging.
 
@@ -198,10 +203,16 @@ func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts S
 			return nil, nil
 		}
 
+		// We reserve a few special operations (bootstrapping, and setting
+		// cluster settings) for node 1.
+		if node != Node(startOpts.InitTarget) {
+			return nil, nil
+		}
+
 		shouldInit := !c.useStartSingleNode()
 		if shouldInit {
 			l.Printf("%s: initializing cluster", c.Name)
-			initOut, err := c.initializeCluster(ctx, node)
+			initOut, err := c.initializeCluster(ctx, node) // what does this do?
 			if err != nil {
 				return nil, errors.WithDetail(err, "unable to initialize cluster")
 			}
@@ -534,7 +545,8 @@ func (c *SyncedCluster) generateStartArgs(
 
 	// --join flags are unsupported/unnecessary in `cockroach start-single-node`.
 	if startOpts.Target == StartDefault && !c.useStartSingleNode() {
-		args = append(args, fmt.Sprintf("--join=%s:%d", c.Host(1), c.NodePort(1)))
+		args = append(args, fmt.Sprintf("--join=%s:%d",
+			c.Host(Node(startOpts.InitTarget)), c.NodePort(Node(startOpts.InitTarget))))
 	}
 	if startOpts.Target == StartTenantSQL {
 		args = append(args, fmt.Sprintf("--kv-addrs=%s", startOpts.KVAddrs))
@@ -694,7 +706,7 @@ func (c *SyncedCluster) generateClusterSettingCmd(l *logger.Logger, node Node) s
 func (c *SyncedCluster) generateInitCmd(node Node) string {
 	var initCmd string
 	if c.IsLocal() {
-		initCmd = fmt.Sprintf(`cd %s ; `, c.localVMDir(1))
+		initCmd = fmt.Sprintf(`cd %s ; `, c.localVMDir(node))
 	}
 
 	path := fmt.Sprintf("%s/%s", c.NodeDir(node, 1 /* storeIndex */), "cluster-bootstrapped")


### PR DESCRIPTION
Release note (cli change): add init-target flag in roachprod start
and change roachprod init to init per node.