### PR TITLE
build: race-test only `pkg/server` on master/bors

### DIFF
--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -286,6 +286,9 @@ tc_release_branch() {
   [[ "$TC_BUILD_BRANCH" == master || "$TC_BUILD_BRANCH" == release-* || "$TC_BUILD_BRANCH" == provisional_* ]]
 }
 
+tc_bors_branch() {
+  [[ "$TC_BUILD_BRANCH" == staging ]]
+}
 
 if_tc() {
   if [[ "${TC_BUILD_ID-}" ]]; then

--- a/build/teamcity-testrace.sh
+++ b/build/teamcity-testrace.sh
@@ -10,9 +10,9 @@ export TMPDIR=$PWD/artifacts/testrace
 mkdir -p "$TMPDIR"
 
 tc_start_block "Determine changed packages"
-if tc_release_branch; then
-  pkgspec=./pkg/...
-  echo "On release branch ($TC_BUILD_BRANCH), so running testrace on all packages ($pkgspec)"
+if tc_release_branch || tc_bors_branch; then
+  pkgspec=./pkg/server
+  echo "On release or bors branch ($TC_BUILD_BRANCH), so running testrace canary only ($pkgspec)"
 else
   pkgspec=$(changed_go_pkgs)
   if [[ $(echo "$pkgspec" | wc -w) -gt 10 ]]; then


### PR DESCRIPTION
Having a highly variable race build on the merge path is not useful,
especially since these tests may time out when too many of them are
selected. Instead, run only a canary package under `stressrace` while
merging and on master.

The PR build continues its old behavior of racing changed packages. The
nightly builds continue to run `stressrace` on the entire unit test
suite.

See [internal discussion].

[internal discussion]: https://cockroachlabs.slack.com/archives/C023S0V4YEB/p1651171505172649

Release note: None
