### PR TITLE
release-22.1: skip network/sanity

### DIFF
--- a/pkg/cmd/roachtest/tests/network.go
+++ b/pkg/cmd/roachtest/tests/network.go
@@ -513,6 +513,7 @@ func registerNetwork(r registry.Registry) {
 		Name:    fmt.Sprintf("network/sanity/nodes=%d", numNodes),
 		Owner:   registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(numNodes),
+		Skip:    "deleted in 22.2",
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runNetworkSanity(ctx, t, c, numNodes)
 		},


### PR DESCRIPTION
This has been deleted on master (in a PR that has a merge conflict,
PR #80230).

Release justification: skips a test
Release note: None
