### PR TITLE
sql: use wildcard to show grants for all schemas in a database

### DIFF
--- a/docs/generated/sql/bnf/show_grants_stmt.bnf
+++ b/docs/generated/sql/bnf/show_grants_stmt.bnf
@@ -3,6 +3,8 @@ show_grants_stmt ::=
 	| 'SHOW' 'GRANTS' 'ON' 'ROLE' role_spec_list 
 	| 'SHOW' 'GRANTS' 'ON' 'SCHEMA' schema_name ( ( ',' schema_name ) )* 'FOR' role_spec_list
 	| 'SHOW' 'GRANTS' 'ON' 'SCHEMA' schema_name ( ( ',' schema_name ) )* 
+	| 'SHOW' 'GRANTS' 'ON' 'SCHEMA' schema_wildcard 'FOR' role_spec_list
+	| 'SHOW' 'GRANTS' 'ON' 'SCHEMA' schema_wildcard 
 	| 'SHOW' 'GRANTS' 'ON' 'TYPE' type_name ( ( ',' type_name ) )* 'FOR' role_spec_list
 	| 'SHOW' 'GRANTS' 'ON' 'TYPE' type_name ( ( ',' type_name ) )* 
 	| 'SHOW' 'GRANTS' 'ON' ( | 'TABLE' table_name ( ( ',' table_name ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FOR' role_spec_list

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -2377,6 +2377,7 @@ extra_var_value ::=
 targets_roles ::=
 	'ROLE' role_spec_list
 	| 'SCHEMA' schema_name_list
+	| 'SCHEMA' schema_wildcard
 	| 'TYPE' type_name_list
 	| targets
 
@@ -2844,6 +2845,9 @@ for_locking_item ::=
 var_list ::=
 	( var_value ) ( ( ',' var_value ) )*
 
+schema_wildcard ::=
+	wildcard_pattern
+
 opt_ordinality ::=
 	'WITH' 'ORDINALITY'
 	| 
@@ -3176,6 +3180,9 @@ opt_locked_rels ::=
 opt_nowait_or_skip ::=
 	'SKIP' 'LOCKED'
 	| 'NOWAIT'
+
+wildcard_pattern ::=
+	name '.' '*'
 
 opt_join_hint ::=
 	'HASH'

--- a/pkg/sql/logictest/testdata/logic_test/grant_schema
+++ b/pkg/sql/logictest/testdata/logic_test/grant_schema
@@ -4,6 +4,9 @@ statement ok
 GRANT CREATE ON DATABASE test TO testuser;
 CREATE USER testuser2
 
+statement ok
+CREATE SCHEMA IF NOT EXISTS derp
+
 # Don't run these tests as an admin.
 user testuser
 
@@ -26,6 +29,17 @@ query TTTTB colnames
 SHOW GRANTS ON SCHEMA public
 ----
 database_name  schema_name  grantee  privilege_type  is_grantable
+test           public       admin    ALL             true
+test           public       public   CREATE          false
+test           public       public   USAGE           false
+test           public       root     ALL             true
+
+query TTTTB colnames
+SHOW GRANTS ON SCHEMA test.*
+----
+database_name  schema_name  grantee  privilege_type  is_grantable
+test           derp         admin    ALL             true
+test           derp         root     ALL             true
 test           public       admin    ALL             true
 test           public       public   CREATE          false
 test           public       public   USAGE           false
@@ -75,6 +89,8 @@ FROM information_schema.schema_privileges
 ----
 grantee    table_catalog  table_schema        privilege_type  is_grantable
 public     test           crdb_internal       USAGE           NO
+admin      test           derp                ALL             YES
+root       test           derp                ALL             YES
 public     test           information_schema  USAGE           NO
 public     test           pg_catalog          USAGE           NO
 public     test           pg_extension        USAGE           NO
@@ -103,6 +119,7 @@ FROM schema_names
 ----
 schema_name         has_create  has_usage
 crdb_internal       false       true
+derp                false       false
 information_schema  false       true
 pg_catalog          false       true
 pg_extension        false       true

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -86,6 +86,9 @@ type Catalog interface {
 	// be safely copied or used across goroutines.
 	ResolveSchema(ctx context.Context, flags Flags, name *SchemaName) (Schema, SchemaName, error)
 
+	// GetAllSchemaNamesForDB Gets all the SchemaNames for a database.
+	GetAllSchemaNamesForDB(ctx context.Context, dbName string) ([]SchemaName, error)
+
 	// ResolveDataSource locates a data source with the given name and returns it
 	// along with the resolved DataSourceName.
 	//

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -108,6 +108,21 @@ func (tc *Catalog) ResolveSchema(
 	return tc.resolveSchema(&toResolve)
 }
 
+// GetAllSchemaNamesForDB is part of the cat.Catalog interface.
+func (tc *Catalog) GetAllSchemaNamesForDB(
+	ctx context.Context, dbName string,
+) ([]cat.SchemaName, error) {
+	var schemaNames []cat.SchemaName
+	var scName cat.SchemaName
+	scName.SchemaName = tree.PublicSchemaName
+	scName.ExplicitSchema = true
+	scName.CatalogName = tree.Name(dbName)
+	scName.ExplicitCatalog = true
+	schemaNames = append(schemaNames, scName)
+
+	return schemaNames, nil
+}
+
 // ResolveDataSource is part of the cat.Catalog interface.
 func (tc *Catalog) ResolveDataSource(
 	_ context.Context, _ cat.Flags, name *cat.DataSourceName,

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -192,6 +192,28 @@ func (oc *optCatalog) ResolveSchema(
 	}, oc.tn.ObjectNamePrefix, nil
 }
 
+// GetAllSchemaNamesForDB is part of the cat.Catalog interface.
+func (oc *optCatalog) GetAllSchemaNamesForDB(
+	ctx context.Context, dbName string,
+) ([]cat.SchemaName, error) {
+	schemas, err := oc.planner.GetSchemasForDB(ctx, dbName)
+	if err != nil {
+		return nil, err
+	}
+
+	var schemaNames []cat.SchemaName
+	for _, name := range schemas {
+		var scName cat.SchemaName
+		scName.SchemaName = tree.Name(name)
+		scName.ExplicitSchema = true
+		scName.CatalogName = tree.Name(dbName)
+		scName.ExplicitCatalog = true
+		schemaNames = append(schemaNames, scName)
+	}
+
+	return schemaNames, nil
+}
+
 // ResolveDataSource is part of the cat.Catalog interface.
 func (oc *optCatalog) ResolveDataSource(
 	ctx context.Context, flags cat.Flags, name *cat.DataSourceName,

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1250,8 +1250,9 @@ func (u *sqlSymUnion) asTenantClause() tree.TenantID {
 %type <*tree.UnresolvedObjectName> table_name db_name standalone_index_name sequence_name type_name view_name db_object_name simple_db_object_name complex_db_object_name
 %type <[]*tree.UnresolvedObjectName> type_name_list
 %type <str> schema_name opt_in_schema
-%type <tree.ObjectNamePrefix>  qualifiable_schema_name opt_schema_name
+%type <tree.ObjectNamePrefix>  qualifiable_schema_name opt_schema_name wildcard_pattern
 %type <tree.ObjectNamePrefixList> schema_name_list
+%type <tree.ObjectNamePrefixList> schema_wildcard
 %type <*tree.UnresolvedName> table_pattern complex_table_pattern
 %type <*tree.UnresolvedName> column_path prefixed_column_path column_path_with_star
 %type <tree.TableExpr> insert_target create_stats_target analyze_target
@@ -6863,11 +6864,16 @@ targets_roles:
   {
      $$.val = tree.TargetList{Schemas: $2.objectNamePrefixList()}
   }
+| SCHEMA schema_wildcard
+   {
+     $$.val = tree.TargetList{Schemas: $2.objectNamePrefixList()}
+   }
 | TYPE type_name_list
   {
     $$.val = tree.TargetList{Types: $2.unresolvedObjectNames()}
   }
 | targets
+
 
 for_grantee_clause:
   FOR role_spec_list
@@ -13763,6 +13769,17 @@ schema_name_list:
     $$.val = append($1.objectNamePrefixList(), $3.objectNamePrefix())
   }
 
+schema_wildcard:
+	wildcard_pattern
+	{
+    $$.val = tree.ObjectNamePrefixList{$1.objectNamePrefix()}
+	}
+
+wildcard_pattern:
+	name '.' '*'
+	{
+		$$.val = tree.ObjectNamePrefix{CatalogName: tree.Name($1), SchemaName: tree.Name('*'), ExplicitCatalog: true, ExplicitSchema: true}
+	}
 
 opt_schema_name:
 	qualifiable_schema_name

--- a/pkg/sql/parser/testdata/show
+++ b/pkg/sql/parser/testdata/show
@@ -1468,6 +1468,14 @@ SHOW GRANTS ON SCHEMA foo.bar -- literals removed
 SHOW GRANTS ON SCHEMA _._ -- identifiers removed
 
 parse
+SHOW GRANTS ON SCHEMA foo.*
+----
+SHOW GRANTS ON SCHEMA foo."*" -- normalized!
+SHOW GRANTS ON SCHEMA foo."*" -- fully parenthesized
+SHOW GRANTS ON SCHEMA foo."*" -- literals removed
+SHOW GRANTS ON SCHEMA _._ -- identifiers removed
+
+parse
 SHOW GRANTS ON SCHEMA foo, bar
 ----
 SHOW GRANTS ON SCHEMA foo, bar

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -112,6 +112,24 @@ func (p *planner) ResolveTargetObject(
 	return prefix.Database, prefix.Schema, namePrefix, err
 }
 
+// GetSchemasForDB gets all the schemas for a database.
+func (p *planner) GetSchemasForDB(
+	ctx context.Context, dbName string,
+) (map[descpb.ID]string, error) {
+	dbDesc, err := p.Descriptors().GetImmutableDatabaseByName(ctx, p.txn, dbName,
+		tree.DatabaseLookupFlags{AvoidLeased: true})
+	if err != nil {
+		return nil, err
+	}
+
+	schemas, err := p.Descriptors().GetSchemasForDatabase(ctx, p.Txn(), dbDesc)
+	if err != nil {
+		return nil, err
+	}
+
+	return schemas, nil
+}
+
 // SchemaExists implements the eval.DatabaseCatalog interface.
 func (p *planner) SchemaExists(ctx context.Context, dbName, scName string) (found bool, err error) {
 	found, _, err = p.LookupSchema(ctx, dbName, scName)


### PR DESCRIPTION
Fixes [#80253](https://github.com/cockroachdb/cockroach/issues/80253)

Release note: 
Allow the use wildcard to show grants for all schemas in a database.
```
> show grants on schema foo.*;
  database_name | schema_name | grantee | privilege_type | is_grantable
----------------+-------------+---------+----------------+---------------
  foo           | bar         | admin   | ALL            |     true
  foo           | bar         | root    | ALL            |     true
  foo           | baz         | admin   | ALL            |     true
  foo           | baz         | root    | ALL            |     true
  foo           | public      | admin   | ALL            |     true
  foo           | public      | public  | CREATE         |    false
  foo           | public      | public  | USAGE          |    false
  foo           | public      | root    | ALL            |     true
```