### PR TITLE
release-21.2: joberror: add ConnectionReset/ConnectionRefused to retryable err allow list

### DIFF
--- a/pkg/ccl/utilccl/errors.go
+++ b/pkg/ccl/utilccl/errors.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
+	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -43,9 +44,9 @@ func isBreakerOpenError(err error) bool {
 }
 
 // IsPermanentBulkJobError returns true if the error results in a permanent
-// failure of a bulk job (IMPORT, BACKUP, RESTORE). This function is a allowlist
-// instead of a blocklist: only known safe errors are confirmed to not be
-// permanent errors. Anything unknown is assumed to be permanent.
+// failure of a bulk job (IMPORT, BACKUP, RESTORE). This function is an
+// allowlist instead of a blocklist: only known safe errors are confirmed to not
+// be permanent errors. Anything unknown is assumed to be permanent.
 func IsPermanentBulkJobError(err error) bool {
 	if err == nil {
 		return false
@@ -55,5 +56,7 @@ func IsPermanentBulkJobError(err error) bool {
 		!grpcutil.IsClosedConnection(err) &&
 		!flowinfra.IsNoInboundStreamConnectionError(err) &&
 		!kvcoord.IsSendError(err) &&
-		!isBreakerOpenError(err)
+		!isBreakerOpenError(err) &&
+		!sysutil.IsErrConnectionReset(err) &&
+		!sysutil.IsErrConnectionRefused(err)
 }


### PR DESCRIPTION
Backport 1/1 commits from #80762.

/cc @cockroachdb/release

---

Bulk jobs will no longer treat `sysutil.IsErrConnectionReset`
and `sysutil.IsErrConnectionRefused` as permanent errors. IMPORT,
RESTORE and BACKUP will treat this error as transient and retry.

Release note: None

Release justification: low risk high impact fix that makes bulk jobs more resilient to transient errors