### PR TITLE
sql/catalog/descs,sql: tweak WaitForOneVersion backoff

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1264,7 +1264,7 @@ func WaitToUpdateLeases(
 	// Aggressively retry because there might be a user waiting for the
 	// schema change to complete.
 	retryOpts := retry.Options{
-		InitialBackoff: 5 * time.Millisecond,
+		InitialBackoff: time.Millisecond,
 		MaxBackoff:     time.Second,
 		Multiplier:     1.5,
 	}


### PR DESCRIPTION
After analyzing runtimes of some schema changes as used in an example workload,
much time was being spent in this backoff, wasting on the order of 50ms per
iteration. This is the difference between old behavior and new behavior.

Release note: None