### PR TITLE
kvserver: only print header of big response when tracing evaluateCommand

### DIFF
--- a/pkg/kv/kvserver/replica_evaluate.go
+++ b/pkg/kv/kvserver/replica_evaluate.go
@@ -506,8 +506,16 @@ func evaluateCommand(
 			}
 			return s
 		}
+		var resp string
+		if reply.Size() > 1024 /* 1kb */ {
+			// Avoid printing the entire response before truncating.
+			header := reply.Header()
+			resp = trunc(header.String())
+		} else {
+			resp = trunc(reply.String())
+		}
 		log.VEventf(ctx, 2, "evaluated %s command %s, txn=%v : resp=%s, err=%v",
-			args.Method(), trunc(args.String()), h.Txn, trunc(reply.String()), err)
+			args.Method(), trunc(args.String()), h.Txn, resp, err)
 	}
 	return pd, err
 }


### PR DESCRIPTION
With expensive logging enabled, we were printing the entire body of
every response to a string before truncating it to 256 bytes. For large
ScanResponses, this could have been megabytes in size. This added a
significant amount of time to statement bundle collection and other uses
of tracing. Instead, if the response is larger than 1 KiB, only print
the response header.

Fixes: #80671

Release note: None