### PR TITLE
build,gcp: enable nightly config to run GCP unit tests

### DIFF
--- a/build/teamcity/cockroach/nightlies/cloud_unit_tests.sh
+++ b/build/teamcity/cockroach/nightlies/cloud_unit_tests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_start_block "Run cloud unit tests"
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e GITHUB_API_TOKEN -e GITHUB_REPO -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL -e GOOGLE_EPHEMERAL_CREDENTIALS -e GOOGLE_KMS_KEY_NAME" \
+  run_bazel build/teamcity/cockroach/nightlies/cloud_unit_tests_impl.sh "$@"
+tc_end_block "Run cloud unit tests"

--- a/build/teamcity/cockroach/nightlies/cloud_unit_tests_impl.sh
+++ b/build/teamcity/cockroach/nightlies/cloud_unit_tests_impl.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+source "$dir/teamcity-bazel-support.sh"  # For process_test_json
+source "$dir/teamcity-support.sh"  # For log_into_gcloud
+
+bazel build //pkg/cmd/bazci //pkg/cmd/github-post //pkg/cmd/testfilter --config=ci
+BAZEL_BIN=$(bazel info bazel-bin --config=ci)
+
+ARTIFACTS_DIR=/artifacts
+GO_TEST_JSON_OUTPUT_FILE=$ARTIFACTS_DIR/test.json.txt
+
+google_credentials="$GOOGLE_EPHEMERAL_CREDENTIALS"
+log_into_gcloud
+export GOOGLE_APPLICATION_CREDENTIALS="$PWD/.google-credentials.json"
+
+exit_status=0
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --config=ci \
+    test //pkg/cloud/gcp:gcp_test -- \
+    --test_env=GO_TEST_WRAP_TESTV=1 \
+    --test_env=GO_TEST_WRAP=1 \
+    --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE \
+    --test_env=GOOGLE_CREDENTIALS_JSON="$GOOGLE_EPHEMERAL_CREDENTIALS" \
+    --test_env=GOOGLE_APPLICATION_CREDENTIALS="$GOOGLE_APPLICATION_CREDENTIALS" \
+    --test_env=GOOGLE_BUCKET="nightly-cloud-unit-tests" \
+    --test_env=GOOGLE_KMS_KEY_NAME="$GOOGLE_KMS_KEY_NAME" \
+    --test_timeout=60 \
+    || exit_status=$?
+
+process_test_json \
+  $BAZEL_BIN/pkg/cmd/testfilter/testfilter_/testfilter \
+  $BAZEL_BIN/pkg/cmd/github-post/github-post_/github-post \
+  $ARTIFACTS_DIR \
+  $GO_TEST_JSON_OUTPUT_FILE \
+  $exit_status
+
+exit $exit_status

--- a/pkg/cloud/gcp/BUILD.bazel
+++ b/pkg/cloud/gcp/BUILD.bazel
@@ -49,6 +49,5 @@ go_test(
         "//pkg/util/leaktest",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
-        "@org_golang_x_oauth2//google",
     ],
 )

--- a/pkg/cloud/gcp/gcs_kms_test.go
+++ b/pkg/cloud/gcp/gcs_kms_test.go
@@ -10,6 +10,7 @@
 package gcp
 
 import (
+	"encoding/base64"
 	"fmt"
 	"net/url"
 	"os"
@@ -28,88 +29,89 @@ func TestEncryptDecryptGCS(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	q := make(url.Values)
-	expect := map[string]string{
-		"CREDENTIALS":                    CredentialsParam,
-		"GOOGLE_APPLICATION_CREDENTIALS": "GOOGLE_APPLICATION_CREDENTIALS",
-	}
-	for env, param := range expect {
-		v := os.Getenv(env)
-		if v == "" {
-			skip.IgnoreLintf(t, "%s env var must be set", env)
-		}
-		q.Add(param, v)
-	}
 
 	// The KeyID for GCS is the following format:
 	// projects/{project name}/locations/{key region}/keyRings/{keyring name}/cryptoKeys/{key name}
-	// It can be specified as the following:
-	// - GCS_KEY_ID
-	// - GCS_KEY_NAME
-	for _, id := range []string{"GCS_KEY_ID", "GCS_KEY_NAME"} {
-		// Get GCS Key identifier from env variable.
-		keyID := os.Getenv(id)
-		if keyID == "" {
-			skip.IgnoreLint(t, fmt.Sprintf("%s env var must be set", id))
+	//
+	// Get GCS Key identifier from env variable.
+	keyID := os.Getenv("GOOGLE_KMS_KEY_NAME")
+	if keyID == "" {
+		skip.IgnoreLint(t, "GOOGLE_KMS_KEY_NAME env var must be set")
+	}
+
+	t.Run("auth-empty-no-cred", func(t *testing.T) {
+		// Set AUTH to specified but don't provide CREDENTIALS params.
+		params := make(url.Values)
+		params.Add(cloud.AuthParam, cloud.AuthParamSpecified)
+
+		uri := fmt.Sprintf("gs:///%s?%s", keyID, params.Encode())
+
+		_, err := cloud.KMSFromURI(uri, &cloud.TestKMSEnv{ExternalIOConfig: &base.ExternalIODirConfig{}})
+		require.EqualError(t, err, fmt.Sprintf(
+			`%s is set to '%s', but %s is not set`,
+			cloud.AuthParam,
+			cloud.AuthParamSpecified,
+			CredentialsParam,
+		))
+	})
+
+	t.Run("auth-implicit", func(t *testing.T) {
+		if !isImplicitAuthConfigured() {
+			skip.IgnoreLint(t, "implicit auth is not configured")
 		}
 
-		t.Run(fmt.Sprintf("auth-empty-no-cred-%s", id), func(t *testing.T) {
-			// Set AUTH to specified but don't provide CREDENTIALS params.
-			params := make(url.Values)
-			params.Add(cloud.AuthParam, cloud.AuthParamSpecified)
+		// Set the AUTH to implicit.
+		params := make(url.Values)
+		params.Add(cloud.AuthParam, cloud.AuthParamImplicit)
 
-			uri := fmt.Sprintf("gs:///%s?%s", keyID, params.Encode())
-
-			_, err := cloud.KMSFromURI(uri, &cloud.TestKMSEnv{ExternalIOConfig: &base.ExternalIODirConfig{}})
-			require.EqualError(t, err, fmt.Sprintf(
-				`%s is set to '%s', but %s is not set`,
-				cloud.AuthParam,
-				cloud.AuthParamSpecified,
-				CredentialsParam,
-			))
+		uri := fmt.Sprintf("gs:///%s?%s", keyID, params.Encode())
+		cloud.KMSEncryptDecrypt(t, uri, cloud.TestKMSEnv{
+			Settings:         cluster.NoSettings,
+			ExternalIOConfig: &base.ExternalIODirConfig{},
 		})
+	})
 
-		t.Run(fmt.Sprintf("auth-implicit-%s", id), func(t *testing.T) {
-			// Set the AUTH params.
-			params := make(url.Values)
-			params.Add(cloud.AuthParam, cloud.AuthParamImplicit)
+	t.Run("auth-specified", func(t *testing.T) {
+		// Fetch the base64 encoded JSON credentials.
+		credentials := os.Getenv("GOOGLE_CREDENTIALS_JSON")
+		if credentials == "" {
+			skip.IgnoreLint(t, "GOOGLE_CREDENTIALS_JSON env var must be set")
+		}
+		encoded := base64.StdEncoding.EncodeToString([]byte(credentials))
+		q.Set(CredentialsParam, url.QueryEscape(encoded))
 
-			uri := fmt.Sprintf("gs:///%s?%s", keyID, params.Encode())
-			cloud.KMSEncryptDecrypt(t, uri, cloud.TestKMSEnv{
-				Settings:         cluster.NoSettings,
-				ExternalIOConfig: &base.ExternalIODirConfig{},
-			})
+		// Set AUTH to specified.
+		q.Set(cloud.AuthParam, cloud.AuthParamSpecified)
+
+		uri := fmt.Sprintf("gs:///%s?%s", keyID, q.Encode())
+		cloud.KMSEncryptDecrypt(t, uri, cloud.TestKMSEnv{
+			Settings:         cluster.NoSettings,
+			ExternalIOConfig: &base.ExternalIODirConfig{},
 		})
-
-		t.Run(fmt.Sprintf("auth-specified-%s", id), func(t *testing.T) {
-			// Set AUTH to specified.
-			q.Set(cloud.AuthParam, cloud.AuthParamSpecified)
-			uri := fmt.Sprintf("gs:///%s?%s", keyID, q.Encode())
-
-			cloud.KMSEncryptDecrypt(t, uri, cloud.TestKMSEnv{
-				Settings:         cluster.NoSettings,
-				ExternalIOConfig: &base.ExternalIODirConfig{},
-			})
-		})
-	}
+	})
 }
 
 func TestGCSKMSDisallowImplicitCredentials(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	if !isImplicitAuthConfigured() {
+		skip.IgnoreLint(t, "implicit auth is not configured")
+	}
+
 	q := make(url.Values)
 
 	// Set AUTH to implicit.
 	q.Add(cloud.AuthParam, cloud.AuthParamImplicit)
-	for _, id := range []string{"GCS_KEY_ID", "GCS_KEY_NAME"} {
-		keyID := os.Getenv(id)
-		if keyID == "" {
-			skip.IgnoreLint(t, "%s env var must be set", id)
-		}
-		uri := fmt.Sprintf("gs:///%s?%s", keyID, q.Encode())
-		_, err := cloud.KMSFromURI(uri, &cloud.TestKMSEnv{
-			Settings:         cluster.NoSettings,
-			ExternalIOConfig: &base.ExternalIODirConfig{DisableImplicitCredentials: true}})
-		require.True(t, testutils.IsError(err,
-			"implicit credentials disallowed for gcs due to --external-io-implicit-credentials flag"),
-		)
+	keyID := os.Getenv("GOOGLE_KMS_KEY_NAME")
+	if keyID == "" {
+		skip.IgnoreLint(t, "GOOGLE_KMS_KEY_NAME env var must be set")
 	}
+
+	uri := fmt.Sprintf("gs:///%s?%s", keyID, q.Encode())
+	_, err := cloud.KMSFromURI(uri, &cloud.TestKMSEnv{
+		Settings:         cluster.NoSettings,
+		ExternalIOConfig: &base.ExternalIODirConfig{DisableImplicitCredentials: true}})
+	require.True(t, testutils.IsError(err,
+		"implicit credentials disallowed for gcs due to --external-io-implicit-credentials flag"),
+	)
 }


### PR DESCRIPTION
Previously, the `pkg/cloud/gcp` tests package was skipped on CI
because most of the tests require credentials, and we risked exfiltration
of these secrets when running on public teamcity agents.

With the ability to run tests on agents that are not part of the public
pool we now have a `Cloud Unit Test` config that runs these tests nightly.
This change adds the script invoked by the config and cleans up the unit
tests to be more uniform in their authentication and environment variable
checks.

Informs: https://github.com/cockroachdb/cockroach/issues/80877

Release note: None