### PR TITLE
roleoption: remove sqltelemetry dependency

### DIFF
--- a/pkg/sql/alter_role.go
+++ b/pkg/sql/alter_role.go
@@ -215,7 +215,9 @@ func (n *alterRoleNode) startExec(params runParams) error {
 	}
 
 	// Get a map of statements to execute for role options and their values.
-	stmts, err := n.roleOptions.GetSQLStmts(sqltelemetry.AlterRole)
+	stmts, err := n.roleOptions.GetSQLStmts(func(o roleoption.Option) {
+		sqltelemetry.IncIAMOptionCounter(sqltelemetry.AlterRole, strings.ToLower(o.String()))
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/create_role.go
+++ b/pkg/sql/create_role.go
@@ -13,6 +13,7 @@ package sql
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/password"
@@ -168,7 +169,9 @@ func (n *CreateRoleNode) startExec(params runParams) error {
 	}
 
 	// Get a map of statements to execute for role options and their values.
-	stmts, err := n.roleOptions.GetSQLStmts(sqltelemetry.CreateRole)
+	stmts, err := n.roleOptions.GetSQLStmts(func(o roleoption.Option) {
+		sqltelemetry.IncIAMOptionCounter(sqltelemetry.CreateRole, strings.ToLower(o.String()))
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/roleoption/BUILD.bazel
+++ b/pkg/sql/roleoption/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
     deps = [
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
-        "//pkg/sql/sqltelemetry",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )


### PR DESCRIPTION
For GetStmts, instead use a function hook to inject any necessary
telemetry calls. This is one more step towards removing `util/log`
dependencies from the `tree` package.

Release note: None