### PR TITLE
util/cache: remove dependency on util/log

### DIFF
--- a/pkg/kv/kvserver/tscache/tree_impl.go
+++ b/pkg/kv/kvserver/tscache/tree_impl.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/cache"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
@@ -79,7 +80,7 @@ var _ Cache = &treeImpl{}
 // newTreeImpl returns a new treeImpl with the supplied hybrid clock.
 func newTreeImpl(clock *hlc.Clock) *treeImpl {
 	tc := &treeImpl{
-		cache:    cache.NewIntervalCache(cache.Config{Policy: cache.CacheFIFO}),
+		cache:    cache.NewIntervalCache(cache.Config{Policy: cache.CacheFIFO}, log.Errorf),
 		maxBytes: uint64(defaultTreeImplSize),
 		metrics:  makeMetrics(),
 	}

--- a/pkg/util/cache/BUILD.bazel
+++ b/pkg/util/cache/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/util/interval",
-        "//pkg/util/log",
         "@com_github_biogo_store//llrb",
     ],
 )

--- a/pkg/util/cache/cache.go
+++ b/pkg/util/cache/cache.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/biogo/store/llrb"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // EvictionPolicy is the cache eviction policy enum.
@@ -540,7 +539,8 @@ func (oc *OrderedCache) DoRange(f func(k, v interface{}) bool, from, to interfac
 // IntervalCache is not safe for concurrent access.
 type IntervalCache struct {
 	baseCache
-	tree interval.Tree
+	tree      interval.Tree
+	logErrorf IntervalCacheLogErrorf
 
 	// The fields below are used to avoid allocations during get, del and
 	// GetOverlaps.
@@ -549,6 +549,10 @@ type IntervalCache struct {
 	overlapKey IntervalKey
 	overlaps   []*Entry
 }
+
+// IntervalCacheLogErrorf is a hook that is called on certain errors in the IntervalCache.
+// This is used to prevent and import to util/log.
+type IntervalCacheLogErrorf func(ctx context.Context, format string, args ...interface{})
 
 // IntervalKey provides uniqueness as well as key interval.
 type IntervalKey struct {
@@ -564,9 +568,10 @@ func (ik IntervalKey) String() string {
 
 // NewIntervalCache creates a new Cache backed by an interval tree.
 // See NewCache() for details on parameters.
-func NewIntervalCache(config Config) *IntervalCache {
+func NewIntervalCache(config Config, logErrorf IntervalCacheLogErrorf) *IntervalCache {
 	ic := &IntervalCache{
 		baseCache: newBaseCache(config),
+		logErrorf: logErrorf,
 	}
 	ic.baseCache.init(ic)
 	return ic
@@ -617,13 +622,13 @@ func (ic *IntervalCache) doGet(i interval.Interface) bool {
 
 func (ic *IntervalCache) add(e *Entry) {
 	if err := ic.tree.Insert(e, false); err != nil {
-		log.Errorf(context.TODO(), "%v", err)
+		ic.logErrorf(context.TODO(), "%v", err)
 	}
 }
 
 func (ic *IntervalCache) del(e *Entry) {
 	if err := ic.tree.Delete(e, false); err != nil {
-		log.Errorf(context.TODO(), "%v", err)
+		ic.logErrorf(context.TODO(), "%v", err)
 	}
 }
 

--- a/pkg/util/cache/cache_test.go
+++ b/pkg/util/cache/cache_test.go
@@ -14,6 +14,7 @@ package cache
 
 import (
 	"bytes"
+	"context"
 	"reflect"
 	"testing"
 
@@ -26,6 +27,12 @@ type testKey string
 // Compare implements llrb.Comparable.
 func (tk testKey) Compare(b llrb.Comparable) int {
 	return bytes.Compare([]byte(tk), []byte(b.(testKey)))
+}
+
+func intervalLogErrorf(t testing.TB) IntervalCacheLogErrorf {
+	return func(_ context.Context, f string, args ...interface{}) {
+		t.Logf(f, args...)
+	}
 }
 
 var getTests = []struct {
@@ -261,7 +268,7 @@ func TestOrderedCacheClear(t *testing.T) {
 }
 
 func TestIntervalCache(t *testing.T) {
-	ic := NewIntervalCache(Config{Policy: CacheLRU, ShouldEvict: noEviction})
+	ic := NewIntervalCache(Config{Policy: CacheLRU, ShouldEvict: noEviction}, intervalLogErrorf(t))
 	key1 := ic.NewKey([]byte("a"), []byte("b"))
 	key2 := ic.NewKey([]byte("a"), []byte("c"))
 	key3 := ic.NewKey([]byte("d"), []byte("d\x00"))
@@ -291,7 +298,7 @@ func TestIntervalCache(t *testing.T) {
 }
 
 func TestIntervalCacheOverlap(t *testing.T) {
-	ic := NewIntervalCache(Config{Policy: CacheLRU, ShouldEvict: noEviction})
+	ic := NewIntervalCache(Config{Policy: CacheLRU, ShouldEvict: noEviction}, intervalLogErrorf(t))
 	ic.Add(ic.NewKey([]byte("a"), []byte("c")), 1)
 	ic.Add(ic.NewKey([]byte("c"), []byte("e")), 2)
 	ic.Add(ic.NewKey([]byte("b"), []byte("g")), 3)
@@ -314,7 +321,7 @@ func TestIntervalCacheOverlap(t *testing.T) {
 }
 
 func TestIntervalCacheClear(t *testing.T) {
-	ic := NewIntervalCache(Config{Policy: CacheLRU, ShouldEvict: noEviction})
+	ic := NewIntervalCache(Config{Policy: CacheLRU, ShouldEvict: noEviction}, intervalLogErrorf(t))
 	key1 := ic.NewKey([]byte("a"), []byte("c"))
 	key2 := ic.NewKey([]byte("c"), []byte("e"))
 	ic.Add(key1, 1)
@@ -336,7 +343,7 @@ func TestIntervalCacheClear(t *testing.T) {
 }
 
 func TestIntervalCacheClearWithAdjustedBounds(t *testing.T) {
-	ic := NewIntervalCache(Config{Policy: CacheLRU, ShouldEvict: noEviction})
+	ic := NewIntervalCache(Config{Policy: CacheLRU, ShouldEvict: noEviction}, intervalLogErrorf(t))
 	entry1 := &Entry{Key: ic.NewKey([]byte("a"), []byte("bb")), Value: 1}
 	ic.AddEntry(entry1)
 	entry1.Key.(*IntervalKey).End = []byte("b")
@@ -388,7 +395,7 @@ func BenchmarkOrderedCache(b *testing.B) {
 }
 
 func BenchmarkIntervalCache(b *testing.B) {
-	ic := NewIntervalCache(Config{Policy: CacheLRU, ShouldEvict: noEviction})
+	ic := NewIntervalCache(Config{Policy: CacheLRU, ShouldEvict: noEviction}, intervalLogErrorf(b))
 	testKeys := []interface{}{
 		ic.NewKey([]byte("a"), []byte("c")),
 		ic.NewKey([]byte("b"), []byte("d")),


### PR DESCRIPTION
Use a hook in IntervalCache to log any errors instead.

Release note: None