### PR TITLE
kvserver: ignore errors encountered while removing live learners

### DIFF
--- a/pkg/kv/test_utils.go
+++ b/pkg/kv/test_utils.go
@@ -62,6 +62,9 @@ func IsExpectedRelocateError(err error) bool {
 		"cannot add placeholder",
 		"removing leaseholder not allowed since it isn't the Raft leader",
 		"could not find a better lease transfer target for",
+		// NB: Importing kvserver to use `errCannotRemoveLearnerWhileSnapshotInFlight`
+		// creates a dependency cycle.
+		"cannot remove learner while snapshot is in flight", // https://github.com/cockroachdb/cockroach/issues/79887
 	}
 	pattern := "(" + strings.Join(allowlist, "|") + ")"
 	return testutils.IsError(err, pattern)


### PR DESCRIPTION
This commit fixes a set of failures noticed in #79887 where a bunch of
`EXPERIMENTAL_RELOCATE` calls failed because they tried removing learner
replicas that are in the process of receiving their initial snapshot. The test simply
randomly issues these `RELOCATE` calls so this behavior is intentional.

Removing learners in this state is disallowed as of #79379. This commit fixes a
subset of those failures by making the `kv50/rangelookups` roachtest ignore
these errors.

Relates to https://github.com/cockroachdb/cockroach/issues/79887

Release note: None