### PR TITLE
opt: disable index recommendations for system tables

### DIFF
--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -41,6 +41,9 @@ type Table interface {
 	// information_schema tables.
 	IsVirtualTable() bool
 
+	// IsSystemTable returns true if this table is a special system table.
+	IsSystemTable() bool
+
 	// IsMaterializedView returns true if this table is actually a materialized
 	// view. Materialized views are the same as tables in all aspects, other than
 	// that they cannot be mutated.

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -974,6 +974,22 @@ vectorized: true
 statement ok
 SET index_recommendations_enabled = 'true'
 
+# Regression test for #80910. There should be no index recommendations for
+# system tables.
+query T
+EXPLAIN SELECT * FROM system.table_statistics WHERE name = 'foo'
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: name = 'foo'
+│
+└── • scan
+      missing stats
+      table: table_statistics@primary
+      spans: FULL SCAN
+
 query T
 EXPLAIN (TYPES) INSERT INTO t VALUES (1, 2)
 ----

--- a/pkg/sql/opt/indexrec/index_candidate_set.go
+++ b/pkg/sql/opt/indexrec/index_candidate_set.go
@@ -368,8 +368,8 @@ func addIndexToCandidates(
 	currTable cat.Table,
 	indexCandidates map[cat.Table][][]cat.IndexColumn,
 ) {
-	// Do not add candidates from virtual tables.
-	if currTable.IsVirtualTable() {
+	// Do not add candidates from system or virtual tables.
+	if currTable.IsVirtualTable() || currTable.IsSystemTable() {
 		return
 	}
 

--- a/pkg/sql/opt/indexrec/testdata/index-candidates-recommendations
+++ b/pkg/sql/opt/indexrec/testdata/index-candidates-recommendations
@@ -31,6 +31,11 @@ WHERE information_schema.schemata.SCHEMA_NAME='public' AND t1.k > 3
 t1:
  (k)
 
+# Ensure that index candidates are not created for system tables.
+index-candidates
+SELECT * FROM system.table_statistics WHERE name = 'foo'
+----
+
 # Ensure that new indexes do not get recommended if an identical existing
 # index exists.
 

--- a/pkg/sql/opt/testutils/testcat/BUILD.bazel
+++ b/pkg/sql/opt/testutils/testcat/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/systemschema",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/catalog/typedesc",
         "//pkg/sql/enum",

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -296,6 +296,7 @@ func (tc *Catalog) createVirtualTable(stmt *tree.CreateTable) *Table {
 		TabName:   stmt.Table,
 		Catalog:   tc,
 		IsVirtual: true,
+		IsSystem:  true,
 	}
 
 	// Add the dummy PK column.

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -595,6 +595,7 @@ type Table struct {
 	Checks     []cat.CheckConstraint
 	Families   []*Family
 	IsVirtual  bool
+	IsSystem   bool
 	Catalog    *Catalog
 
 	// If Revoked is true, then the user has had privileges on the table revoked.
@@ -653,6 +654,11 @@ func (tt *Table) fqName() cat.DataSourceName {
 // IsVirtualTable is part of the cat.Table interface.
 func (tt *Table) IsVirtualTable() bool {
 	return tt.IsVirtual
+}
+
+// IsSystemTable is part of the cat.Table interface.
+func (tt *Table) IsSystemTable() bool {
+	return tt.IsSystem
 }
 
 // IsMaterializedView is part of the cat.Table interface.

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -1053,6 +1053,11 @@ func (ot *optTable) IsVirtualTable() bool {
 	return false
 }
 
+// IsSystemTable is part of the cat.Table interface.
+func (ot *optTable) IsSystemTable() bool {
+	return catalog.IsSystemDescriptor(ot.desc)
+}
+
 // IsMaterializedView implements the cat.Table interface.
 func (ot *optTable) IsMaterializedView() bool {
 	return ot.desc.MaterializedView()
@@ -1970,6 +1975,11 @@ func (ot *optVirtualTable) Name() tree.Name {
 // IsVirtualTable is part of the cat.Table interface.
 func (ot *optVirtualTable) IsVirtualTable() bool {
 	return true
+}
+
+// IsSystemTable is part of the cat.Table interface.
+func (ot *optVirtualTable) IsSystemTable() bool {
+	return false
 }
 
 // IsMaterializedView implements the cat.Table interface.

--- a/pkg/sql/sqlstats/persistedsqlstats/testdata/virtual_view_no_full_scans
+++ b/pkg/sql/sqlstats/persistedsqlstats/testdata/virtual_view_no_full_scans
@@ -34,9 +34,5 @@ vectorized: true
               missing stats
               table: transaction_statistics@primary
               spans: [/0/'2022-01-18 00:00:00+00:00' - /0/'2022-01-20 00:00:00+00:00'] [/1/'2022-01-18 00:00:00+00:00' - /1/'2022-01-20 00:00:00+00:00'] [/2/'2022-01-18 00:00:00+00:00' - /2/'2022-01-20 00:00:00+00:00'] [/3/'2022-01-18 00:00:00+00:00' - /3/'2022-01-20 00:00:00+00:00'] … (4 more)
-
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON transaction_statistics (aggregated_ts) STORING (agg_interval, metadata, statistics);
 ----
 ----


### PR DESCRIPTION
#### opt: add system tables to testcat

Release note: None

#### opt: disable index recommendations for system tables

Fixes #80910

Release note (bug fix): Index recommendations are no longer presented
for system tables in the output of `EXPLAIN` statements.