### PR TITLE
cli: enable sstable Writer parallelism for manual compactions

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -832,7 +832,13 @@ func runDebugCompact(cmd *cobra.Command, args []string) error {
 	db, err := OpenEngine(args[0], stopper,
 		storage.MustExist,
 		storage.DisableAutomaticCompactions,
-		storage.MaxConcurrentCompactions(debugCompactOpts.maxConcurrency))
+		storage.MaxConcurrentCompactions(debugCompactOpts.maxConcurrency),
+		// Currently, any concurrency over 0 enables Writer parallelism.
+		storage.MaxWriterConcurrency(1),
+		// Force Writer Parallelism will allow Writer parallelism to
+		// be enabled without checking the CPU.
+		storage.ForceWriterParallelism,
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -55,6 +55,13 @@ var DisableAutomaticCompactions ConfigOption = func(cfg *engineConfig) error {
 	return nil
 }
 
+// ForceWriterParallelism configures an engine to be opened with disabled
+// automatic compactions. Used primarily for debugCompactCmd.
+var ForceWriterParallelism ConfigOption = func(cfg *engineConfig) error {
+	cfg.Opts.Experimental.ForceWriterParallelism = true
+	return nil
+}
+
 // DisableFilesystemMiddlewareTODO configures an engine to not include
 // filesystem middleware like disk-health checking and ENOSPC-detection. This is
 // a temporary option while some units leak file descriptors, and by extension,
@@ -99,6 +106,17 @@ func Attributes(attrs roachpb.Attributes) ConfigOption {
 func MaxSize(size int64) ConfigOption {
 	return func(cfg *engineConfig) error {
 		cfg.MaxSize = size
+		return nil
+	}
+}
+
+// MaxWriterConcurrency sets the concurrency of the sstable Writers. A concurrency
+// of 0 implies no parallelism in the Writer, and a concurrency of 1 or more implies
+// parallelism in the Writer. Currently, there's no difference between a concurrency
+// of 1 or more.
+func MaxWriterConcurrency(concurrency int) ConfigOption {
+	return func(cfg *engineConfig) error {
+		cfg.Opts.Experimental.MaxWriterConcurrency = concurrency
 		return nil
 	}
 }


### PR DESCRIPTION
Since we can afford to use more system resources during manual compactions,
this pr always enables sstable parallelism for offline manual compactions.

This is especially useful for the compaction out of L0 which often has poor
concurrency.

Lsm start state which was copied into two directories:
```

approximate reported database size before compaction: 130 GiB
__level_____count____size___score______in__ingest(sz_cnt)____move(sz_cnt)___write(sz_cnt)____read___r-amp___w-amp
    WAL         1     0 B       -     0 B       -       -       -       -     0 B       -       -       -     0.0
      0     51398    66 G    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B     742     0.0
      1         0     0 B    0.00     0 B     0 B       0     0 B       0     0 B       0     0 B       0     0.0
      2      2177   8.5 G   46.69     0 B     0 B       0     0 B       0     0 B       0     0 B       1     0.0
      3      1677    10 G    5.35     0 B     0 B       0     0 B       0     0 B       0     0 B       1     0.0
      4      1229    13 G    5.32     0 B     0 B       0     0 B       0     0 B       0     0 B       1     0.0
      5       868    16 G    0.90     0 B     0 B       0     0 B       0     0 B       0     0 B       1     0.0
      6       667    15 G       -     0 B     0 B       0     0 B       0     0 B       0     0 B       1     0.0
  total     58016   130 G       -     0 B     0 B       0     0 B       0     0 B       0     0 B     747     0.0
  flush         0
compact         0   475 G    12 G       1          (size == estimated-debt, score = in-progress-bytes, in = num-in-progress)
  ctype         0       0       0       0       0       0  (default, delete, elision, move, read, rewrite)
 memtbl         1   256 K
zmemtbl         0     0 B
   ztbl         0     0 B
 bcache     9.4 K   128 M    0.1%  (score == hit-rate)
 tcache      58 K    38 M   51.6%  (score == hit-rate)
  snaps         0       -       0  (score == earliest seq num)
 titers       743
 filter         -       -    0.0%  (score == utility)
```

The compaction took 21 minutes vs 15 minutes for no parallel compression and parallel compression. Additional graphs
will be posted in the pr comments.

Release note: None