### PR TITLE
changefeedccl: Add a `single_version_descriptor_lease` system table

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -297,4 +297,4 @@ trace.jaeger.agent	string		the address of a Jaeger agent to receive traces using
 trace.opentelemetry.collector	string		address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.
 trace.span_registry.enabled	boolean	true	if set, ongoing traces can be seen at https://<ui>/#/debug/tracez
 trace.zipkin.collector	string		the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.
-version	version	1000022.2-14	set the active cluster version in the format '<major>.<minor>'
+version	version	1000022.2-16	set the active cluster version in the format '<major>.<minor>'

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -233,6 +233,6 @@
 <tr><td><code>trace.opentelemetry.collector</code></td><td>string</td><td><code></code></td><td>address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.</td></tr>
 <tr><td><code>trace.span_registry.enabled</code></td><td>boolean</td><td><code>true</code></td><td>if set, ongoing traces can be seen at https://<ui>/#/debug/tracez</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.</td></tr>
-<tr><td><code>version</code></td><td>version</td><td><code>1000022.2-14</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>version</td><td><code>1000022.2-16</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -350,6 +350,10 @@ const (
 	// ids in the role_members system table have been backfilled.
 	V23_1RoleMembersIDColumnsBackfilled
 
+	// V23_1SingleVersionDescriptorLeaseTable adds the single_version_descriptor_lease
+	// table.
+	V23_1SingleVersionDescriptorLeaseTable
+
 	// *************************************************
 	// Step (1): Add new versions here.
 	// Do not add new versions to a patch release.
@@ -603,6 +607,10 @@ var rawVersionsSingleton = keyedVersions{
 	{
 		Key:     V23_1RoleMembersIDColumnsBackfilled,
 		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 14},
+	},
+	{
+		Key:     V23_1SingleVersionDescriptorLeaseTable,
+		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 16},
 	},
 
 	// *************************************************

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -409,6 +409,9 @@ const (
 	CommentsTablePrimaryKeyIndexID           = 1
 	CommentsTableCommentColFamID             = 4
 
+	SingleVersionDescriptorLeasePrimaryKeyIndexID = 1
+	SingleVersionDescriptorLeasePrimaryColFamID   = 0
+
 	// Reserved IDs for other system tables. Note that some of these IDs refer
 	// to "Ranges" instead of a Table - these IDs are needed to store custom
 	// configuration for non-table ranges (e.g. Zone Configs).

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -1404,3 +1404,14 @@ func (tc *TxnCoordSender) hasPerformedReadsLocked() bool {
 func (tc *TxnCoordSender) hasPerformedWritesLocked() bool {
 	return tc.mu.txn.Sequence != 0
 }
+
+// ForwardWriteTimestamp is part of the TxnSender interface.
+func (tc *TxnCoordSender) ForwardWriteTimestamp(to hlc.Timestamp) error {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	if tc.mu.txnState != txnPending {
+		return errors.Errorf("cannot forward write timestamp for %v transaction", tc.mu.txnState)
+	}
+	tc.mu.txn.WriteTimestamp.Forward(to)
+	return nil
+}

--- a/pkg/kv/mock_transactional_sender.go
+++ b/pkg/kv/mock_transactional_sender.go
@@ -223,6 +223,12 @@ func (m *MockTransactionalSender) GetTxnRetryableErr(
 
 // ClearTxnRetryableErr is part of the TxnSender interface.
 func (m *MockTransactionalSender) ClearTxnRetryableErr(ctx context.Context) {
+	panic("unimplemented")
+}
+
+// ForwardWriteTimestamp is part of the TxnSender interface.
+func (m *MockTransactionalSender) ForwardWriteTimestamp(to hlc.Timestamp) error {
+	panic("unimplemented")
 }
 
 // HasPerformedReads is part of TxnSenderFactory.

--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -331,6 +331,11 @@ type TxnSender interface {
 
 	// HasPerformedWrites returns true if a write has been performed.
 	HasPerformedWrites() bool
+
+	// ForwardWriteTimestamp forwards the write timestamp of the transaction to
+	// the provided timestamp. It can be used to ensure that a transaction
+	// commits at a timestamp after some event detected out of band.
+	ForwardWriteTimestamp(to hlc.Timestamp) error
 }
 
 // SteppingMode is the argument type to ConfigureStepping.

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -1586,6 +1586,15 @@ func (txn *Txn) AdmissionHeader() roachpb.AdmissionHeader {
 	return h
 }
 
+// ForwardWriteTimestamp forwards the write timestamp of the transaction to
+// the provided timestamp. It can be used to ensure that a transaction
+// commits at a timestamp after some event detected out of band.
+func (txn *Txn) ForwardWriteTimestamp(to hlc.Timestamp) error {
+	txn.mu.Lock()
+	defer txn.mu.Unlock()
+	return txn.mu.sender.ForwardWriteTimestamp(to)
+}
+
 // OnePCNotAllowedError signifies that a request had the Require1PC flag set,
 // but 1PC evaluation was not possible for one reason or another.
 type OnePCNotAllowedError struct{}

--- a/pkg/sql/catalog/bootstrap/metadata.go
+++ b/pkg/sql/catalog/bootstrap/metadata.go
@@ -370,7 +370,7 @@ func addSystemDescriptorsToSchema(target *MetadataSchema) {
 // NumSystemTablesForSystemTenant is the number of system tables defined on
 // the system tenant. This constant is only defined to avoid having to manually
 // update auto stats tests every time a new system table is added.
-const NumSystemTablesForSystemTenant = 42
+const NumSystemTablesForSystemTenant = 43
 
 // addSplitIDs adds a split point for each of the PseudoTableIDs to the supplied
 // MetadataSchema.

--- a/pkg/sql/catalog/catprivilege/system.go
+++ b/pkg/sql/catalog/catprivilege/system.go
@@ -65,6 +65,7 @@ var (
 		catconstants.SystemPrivilegeTableName,
 		catconstants.SystemExternalConnectionsTableName,
 		catconstants.SystemJobInfoTableName,
+		catconstants.SingleVersionDescriptorLeasesTableName,
 	}
 
 	readWriteSystemSequences = []catconstants.SystemTableName{

--- a/pkg/sql/catalog/systemschema/system.go
+++ b/pkg/sql/catalog/systemschema/system.go
@@ -758,6 +758,16 @@ CREATE TABLE system.job_info (
 	CONSTRAINT "primary" PRIMARY KEY (job_id, info_key, written DESC),
 	FAMILY "primary" (job_id, info_key, written, value)
 );`
+	SingleVersionDescriptorLeasesTableSchema = `
+CREATE TABLE system.single_version_descriptor_leases (
+    action        STRING NOT NULL,
+    descriptor_id INT8 NOT NULL,
+    session_id    BYTES NOT NULL,
+
+    CONSTRAINT "primary" PRIMARY KEY (action, descriptor_id, session_id),
+    CONSTRAINT check_action CHECK (action IN ('notify', 'lease')),
+    FAMILY "primary" (action, descriptor_id, session_id)
+);`
 )
 
 func pk(name string) descpb.IndexDescriptor {
@@ -2866,6 +2876,44 @@ var (
 				KeyColumnIDs:        []descpb.ColumnID{1, 2, 3},
 			},
 		),
+	)
+
+	SingleVersionDescriptorLeaseTable = makeSystemTable(
+		SingleVersionDescriptorLeasesTableSchema,
+		systemTable(
+			catconstants.SingleVersionDescriptorLeasesTableName,
+			descpb.InvalidID, // dynamically assigned
+			[]descpb.ColumnDescriptor{
+				{Name: "action", ID: 1, Type: types.String},
+				{Name: "descriptor_id", ID: 2, Type: types.Int},
+				{Name: "session_id", ID: 3, Type: types.Bytes},
+			},
+			[]descpb.ColumnFamilyDescriptor{
+				{
+					Name:        "primary",
+					ID:          keys.SingleVersionDescriptorLeasePrimaryColFamID,
+					ColumnNames: []string{"action", "descriptor_id", "session_id"},
+					ColumnIDs:   []descpb.ColumnID{1, 2, 3},
+				},
+			},
+			descpb.IndexDescriptor{
+				Name:           "primary",
+				ID:             keys.SingleVersionDescriptorLeasePrimaryKeyIndexID,
+				Unique:         true,
+				KeyColumnNames: []string{"action", "descriptor_id", "session_id"},
+				KeyColumnDirections: []catpb.IndexColumn_Direction{
+					catpb.IndexColumn_ASC, catpb.IndexColumn_ASC, catpb.IndexColumn_ASC,
+				},
+				KeyColumnIDs: []descpb.ColumnID{1, 2, 3},
+			},
+		),
+		func(tbl *descpb.TableDescriptor) {
+			tbl.Checks = []*descpb.TableDescriptor_CheckConstraint{{
+				Name:      "check_action",
+				Expr:      "action IN ('notify':::STRING, 'lease':::STRING)",
+				ColumnIDs: []descpb.ColumnID{1},
+			}}
+		},
 	)
 )
 

--- a/pkg/sql/sem/catconstants/constants.go
+++ b/pkg/sql/sem/catconstants/constants.go
@@ -88,6 +88,7 @@ const (
 	SystemExternalConnectionsTableName     SystemTableName = "external_connections"
 	RoleIDSequenceName                     SystemTableName = "role_id_seq"
 	SystemJobInfoTableName                 SystemTableName = "job_info"
+	SingleVersionDescriptorLeasesTableName SystemTableName = "single_version_descriptor_leases"
 )
 
 // Oid for virtual database and table.

--- a/pkg/upgrade/upgrades/BUILD.bazel
+++ b/pkg/upgrade/upgrades/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "role_options_table_migration.go",
         "sampled_stmt_diagnostics_requests.go",
         "schema_changes.go",
+        "single_version_descriptor_lease_table.go",
         "system_external_connections.go",
         "system_job_info.go",
         "system_privileges.go",

--- a/pkg/upgrade/upgrades/single_version_descriptor_lease_table.go
+++ b/pkg/upgrade/upgrades/single_version_descriptor_lease_table.go
@@ -1,0 +1,25 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package upgrades
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
+	"github.com/cockroachdb/cockroach/pkg/upgrade"
+)
+
+func addSingleVersionDescriptorLeaseTable(
+	ctx context.Context, _ clusterversion.ClusterVersion, d upgrade.TenantDeps,
+) error {
+	return createSystemTable(ctx, d.DB, d.Settings, d.Codec, systemschema.SingleVersionDescriptorLeaseTable)
+}

--- a/pkg/upgrade/upgrades/upgrades.go
+++ b/pkg/upgrade/upgrades/upgrades.go
@@ -234,6 +234,11 @@ var upgrades = []upgradebase.Upgrade{
 		upgrade.NoPrecondition,
 		backfillSystemRoleMembersIDColumns,
 	),
+	upgrade.NewTenantUpgrade("add system.single_version_descriptor_lease",
+		toCV(clusterversion.V23_1SingleVersionDescriptorLeaseTable),
+		upgrade.NoPrecondition,
+		addSingleVersionDescriptorLeaseTable,
+	),
 }
 
 func init() {


### PR DESCRIPTION
Resuscitate low latency changefeed work by @ajwerner .

This PR includes cleaned up, and updated initial commits from the https://github.com/ajwerner/cockroach/tree/ajwerner/low-latency-impl branch. 

 Add a new `single_version_descriptor_lease` system table which intended to store
single version lease information.

Release Notes: None
