### PR TITLE
release-22.1: tree: fix SET/RESET storage parameter to use the correct telemetry tag 

### DIFF
--- a/pkg/sql/sem/tree/alter_table.go
+++ b/pkg/sql/sem/tree/alter_table.go
@@ -617,7 +617,7 @@ type AlterTableSetStorageParams struct {
 // TelemetryCounter returns the telemetry counter to increment
 // when this command is used.
 func (node *AlterTableSetStorageParams) TelemetryCounter() telemetry.Counter {
-	return sqltelemetry.SchemaChangeAlterCounter("set_storage_param")
+	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "set_storage_param")
 }
 
 // Format implements the NodeFormatter interface.
@@ -635,7 +635,7 @@ type AlterTableResetStorageParams struct {
 // TelemetryCounter returns the telemetry counter to increment
 // when this command is used.
 func (node *AlterTableResetStorageParams) TelemetryCounter() telemetry.Counter {
-	return sqltelemetry.SchemaChangeAlterCounter("set_storage_param")
+	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "set_storage_param")
 }
 
 // Format implements the NodeFormatter interface.

--- a/pkg/sql/testdata/telemetry/ttl
+++ b/pkg/sql/testdata/telemetry/ttl
@@ -1,4 +1,5 @@
 feature-allowlist
+sql.schema.alter_table\..*
 sql.schema.table_storage_parameter.*
 sql.row_level_ttl.created
 sql.row_level_ttl.dropped
@@ -14,21 +15,25 @@ sql.schema.table_storage_parameter.ttl_select_batch_size.set
 feature-usage
 ALTER TABLE tbl SET (ttl_delete_batch_size = 200)
 ----
+sql.schema.alter_table.set_storage_param
 sql.schema.table_storage_parameter.ttl_delete_batch_size.set
 
 feature-usage
 ALTER TABLE tbl RESET (ttl_select_batch_size)
 ----
+sql.schema.alter_table.set_storage_param
 sql.schema.table_storage_parameter.ttl_select_batch_size.reset
 
 feature-usage
 ALTER TABLE tbl RESET (ttl)
 ----
 sql.row_level_ttl.dropped
+sql.schema.alter_table.set_storage_param
 sql.schema.table_storage_parameter.ttl.reset
 
 feature-usage
 ALTER TABLE tbl SET (ttl_expire_after = '10 hours')
 ----
 sql.row_level_ttl.created
+sql.schema.alter_table.set_storage_param
 sql.schema.table_storage_parameter.ttl_expire_after.set


### PR DESCRIPTION
Backport 1/9 commits from #80771.

/cc @cockroachdb/release

---

Individual commits should be fairly easy to review by themselves!

There are still indirect references as of writing, but this removes the direct ones!

Release justification: small fix to new functionality