### PR TITLE
opt: add remaining filters to lookupjoin.Constraint and minor refactoring

### DIFF
--- a/pkg/sql/opt/lookupjoin/constraint_builder.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder.go
@@ -58,6 +58,11 @@ type Constraint struct {
 	// LookupExpr that are used to aid selectivity estimation. See
 	// memo.LookupJoinPrivate.ConstFilters.
 	ConstFilters memo.FiltersExpr
+
+	// RemainingFilters contains explicit ON filters that are not represented by
+	// KeyCols or LookupExpr. These filters must be included as ON filters in
+	// the lookup join.
+	RemainingFilters memo.FiltersExpr
 }
 
 // IsUnconstrained returns true if the constraint does not constrain a lookup
@@ -230,6 +235,7 @@ func (b *ConstraintBuilder) Build(
 		break
 	}
 
+	var c Constraint
 	if shouldBuildMultiSpanLookupJoin {
 		// Some of the index columns were constrained to multiple constant
 		// values or a range expression, so we cannot build a lookup join
@@ -260,21 +266,37 @@ func (b *ConstraintBuilder) Build(
 
 		// A multi-span lookup join with a lookup expression has no key columns
 		// and requires no projections on the input.
-		return Constraint{
+		c = Constraint{
 			RightSideCols: rightSideCols,
 			LookupExpr:    lookupExpr,
 			ConstFilters:  constFilters,
 		}
+	} else {
+		// If we did not build a lookup expression, use the key columns we
+		// found, if any.
+		c = Constraint{
+			KeyCols:          keyCols,
+			RightSideCols:    rightSideCols,
+			InputProjections: inputProjections,
+			ConstFilters:     constFilters,
+		}
 	}
 
-	// If we did not build a lookup expression, return the key columns we found,
-	// if any.
-	return Constraint{
-		KeyCols:          keyCols,
-		RightSideCols:    rightSideCols,
-		InputProjections: inputProjections,
-		ConstFilters:     constFilters,
+	// We have not found a valid constraint, so there is no need to calculate
+	// the remaining filters.
+	if c.IsUnconstrained() {
+		return c
 	}
+
+	// Reduce the remaining filters.
+	c.RemainingFilters = onFilters
+	if len(c.KeyCols) > 0 {
+		c.RemainingFilters = memo.ExtractRemainingJoinFilters(c.RemainingFilters, keyCols, rightSideCols)
+	}
+	c.RemainingFilters = c.RemainingFilters.Difference(lookupExpr)
+	c.RemainingFilters = c.RemainingFilters.Difference(constFilters)
+
+	return c
 }
 
 // findComputedColJoinEquality returns the computed column expression of col and

--- a/pkg/sql/opt/lookupjoin/constraint_builder_test.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder_test.go
@@ -178,6 +178,11 @@ func TestLookupConstraints(t *testing.T) {
 					b.WriteString(formatScalar(&lookupConstraint.LookupExpr, &f, &evalCtx))
 					b.WriteString("\n")
 				}
+				if len(lookupConstraint.RemainingFilters) > 0 {
+					b.WriteString("remaining filters:\n  ")
+					b.WriteString(formatScalar(&lookupConstraint.RemainingFilters, &f, &evalCtx))
+					b.WriteString("\n")
+				}
 				return b.String()
 
 			default:

--- a/pkg/sql/opt/lookupjoin/constraint_builder_test.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder_test.go
@@ -140,13 +140,12 @@ func TestLookupConstraints(t *testing.T) {
 					d.Fatalf(t, "%v", err)
 				}
 
-				leftEq, rightEq := memo.ExtractJoinEqualityColumns(leftCols, rightCols, filters)
-				if len(leftEq) == 0 {
-					return "lookup join requires equality columns"
+				var cb lookupjoin.ConstraintBuilder
+				ok := cb.Init(&f, md, f.EvalContext(), rightTable, leftCols, rightCols, filters)
+				if !ok {
+					return "lookup join not possible"
 				}
 
-				var cb lookupjoin.ConstraintBuilder
-				cb.Init(&f, md, f.EvalContext(), rightTable, leftCols, rightCols, leftEq, rightEq)
 				lookupConstraint := cb.Build(index, filters, optionalFilters)
 				var b strings.Builder
 				if lookupConstraint.IsUnconstrained() {

--- a/pkg/sql/opt/lookupjoin/testdata/computed
+++ b/pkg/sql/opt/lookupjoin/testdata/computed
@@ -18,6 +18,58 @@ key cols:
 input projections:
   v_eq = a + 10
 
+# TODO(mgartner): The x=a remaining filter is not necessary.
+lookup-constraints left=(a int, b int) right=(x int, y INT, v int not null as (x + 10) virtual) index=(v, y)
+x = a AND y = 10
+----
+key cols:
+  v = v_eq
+  y = lookup_join_const_col_@7
+input projections:
+  v_eq = a + 10
+  lookup_join_const_col_@7 = 10
+remaining filters:
+  x = a
+
+# TODO(mgartner): The x=a remaining filter is not necessary.
+lookup-constraints left=(a int, b int) right=(x int, y INT, v int not null as (x + 10) virtual) index=(v, y)
+x = a
+optional: y = 10
+----
+key cols:
+  v = v_eq
+  y = lookup_join_const_col_@7
+input projections:
+  v_eq = a + 10
+  lookup_join_const_col_@7 = 10
+remaining filters:
+  x = a
+
+lookup-constraints left=(a int, b int) right=(x int, v int not null as (x + 10) virtual, y INT, z INT) index=(v, x, y)
+x = a AND y = 0 AND z = 3
+----
+key cols:
+  v = v_eq
+  x = a
+  y = lookup_join_const_col_@8
+input projections:
+  v_eq = a + 10
+  lookup_join_const_col_@8 = 0
+remaining filters:
+  z = 3
+
+lookup-constraints left=(a int, b int) right=(x int, y int, z int, v int not null as (x + 10) virtual) index=(v, x, y)
+x = a
+optional: y = 0 AND z = 3
+----
+key cols:
+  v = v_eq
+  x = a
+  y = lookup_join_const_col_@7
+input projections:
+  v_eq = a + 10
+  lookup_join_const_col_@7 = 0
+
 # TODO(mgartner): We should be able to generate a lookup join by determining
 # that v is not null because the filter demands that x is not null, and v is
 # calculated from x.

--- a/pkg/sql/opt/lookupjoin/testdata/computed
+++ b/pkg/sql/opt/lookupjoin/testdata/computed
@@ -45,6 +45,12 @@ input projections:
 remaining filters:
   x = a
 
+lookup-constraints left=(a int, b int) right=(x int, y INT, v int not null as (x + 10) virtual) index=(v, y)
+y = 10
+optional: x = 1
+----
+lookup join not possible
+
 lookup-constraints left=(a int, b int) right=(x int, v int not null as (x + 10) virtual, y INT, z INT) index=(v, x, y)
 x = a AND y = 0 AND z = 3
 ----

--- a/pkg/sql/opt/lookupjoin/testdata/key_cols
+++ b/pkg/sql/opt/lookupjoin/testdata/key_cols
@@ -14,6 +14,11 @@ remaining filters:
   (y > 10) OR (y IN (1, 5))
 
 lookup-constraints left=(a int) right=(x int, y int) index=(x)
+x = 1
+----
+lookup join not possible
+
+lookup-constraints left=(a int) right=(x int, y int) index=(x)
 y = a
 ----
 lookup join not possible

--- a/pkg/sql/opt/lookupjoin/testdata/key_cols
+++ b/pkg/sql/opt/lookupjoin/testdata/key_cols
@@ -6,6 +6,14 @@ key cols:
   x = a
 
 lookup-constraints left=(a int) right=(x int, y int) index=(x)
+x = a AND (y > 10 OR y IN (1, 5))
+----
+key cols:
+  x = a
+remaining filters:
+  (y > 10) OR (y IN (1, 5))
+
+lookup-constraints left=(a int) right=(x int, y int) index=(x)
 y = a
 ----
 lookup join not possible
@@ -28,6 +36,15 @@ x = a AND z = b
 ----
 key cols:
   x = a
+remaining filters:
+  z = b
+
+lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y, z)
+x = a
+optional: z = 1
+----
+key cols:
+  x = a
 
 lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y, z)
 x = a AND y = b AND z = c
@@ -43,6 +60,27 @@ x = a AND y = b AND z = c
 key cols:
   x = a
   y = b
+remaining filters:
+  z = c
+
+lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y)
+x = a AND y = b AND z > 20
+----
+key cols:
+  x = a
+  y = b
+remaining filters:
+  z > 20
+
+lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y)
+x = a
+optional: y = 1 AND z > 20
+----
+key cols:
+  x = a
+  y = lookup_join_const_col_@8
+input projections:
+  lookup_join_const_col_@8 = 1
 
 lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y, z)
 y = b AND z = c
@@ -80,8 +118,33 @@ input projections:
   lookup_join_const_col_@7 = 1
   lookup_join_const_col_@9 = 3
 
+lookup-constraints left=(a int, b int, c int, d int) right=(x int, y int, z int) index=(x, y, z)
+d > 4 AND x = 1 AND y = b AND z = 3
+----
+key cols:
+  x = lookup_join_const_col_@8
+  y = b
+  z = lookup_join_const_col_@10
+input projections:
+  lookup_join_const_col_@8 = 1
+  lookup_join_const_col_@10 = 3
+remaining filters:
+  d > 4
+
 lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y)
 x = 1 AND y = b AND z = 3
+----
+key cols:
+  x = lookup_join_const_col_@7
+  y = b
+input projections:
+  lookup_join_const_col_@7 = 1
+remaining filters:
+  z = 3
+
+lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y)
+y = b
+optional: x = 1 AND z = 3
 ----
 key cols:
   x = lookup_join_const_col_@7

--- a/pkg/sql/opt/lookupjoin/testdata/lookup_expr
+++ b/pkg/sql/opt/lookupjoin/testdata/lookup_expr
@@ -12,11 +12,21 @@ x IN (1, 2, 3) AND y = b AND z = c
 lookup expression:
   ((y = b) AND (z = c)) AND (x IN (1, 2, 3))
 
+lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y, z)
+x IN (1, 2, 3) AND y = b AND (z > 10 OR z IN (1, 2, 3))
+----
+lookup expression:
+  (y = b) AND (x IN (1, 2, 3))
+remaining filters:
+  (z > 10) OR (z IN (1, 2, 3))
+
 lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y)
 x IN (1, 2, 3) AND y = b AND z = c
 ----
 lookup expression:
   (y = b) AND (x IN (1, 2, 3))
+remaining filters:
+  z = c
 
 lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y, z)
 x IN (1, 2, 3) AND y = 4 AND z = c
@@ -52,6 +62,22 @@ lookup expression:
 lookup-constraints left=(a int, b int) right=(x int, y int) index=(x, y)
 x = a
 optional: y IN (1, 2, 3)
+----
+lookup expression:
+  (x = a) AND (y IN (1, 2, 3))
+
+lookup-constraints left=(a int, b int) right=(x int, y int, z int) index=(x, y)
+x = a AND z = 1
+optional: y IN (1, 2, 3)
+----
+lookup expression:
+  (x = a) AND (y IN (1, 2, 3))
+remaining filters:
+  z = 1
+
+lookup-constraints left=(a int, b int) right=(x int, y int, z int) index=(x, y)
+x = a
+optional: y IN (1, 2, 3) AND z = 1
 ----
 lookup expression:
   (x = a) AND (y IN (1, 2, 3))
@@ -102,6 +128,8 @@ optional: x IN (1, 2)
 ----
 lookup expression:
   (y = b) AND (x IN (1, 2))
+remaining filters:
+  x IN (1, 2, 3)
 
 
 # Test for range filters.
@@ -155,6 +183,22 @@ optional: z > 0
 lookup expression:
   ((y = b) AND (x = 1)) AND (z > 0)
 
+lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y)
+x = a AND z = 1
+optional: y > 0
+----
+lookup expression:
+  (x = a) AND (y > 0)
+remaining filters:
+  z = 1
+
+lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y)
+x = a
+optional: y > 0 AND z = 1
+----
+lookup expression:
+  (x = a) AND (y > 0)
+
 
 # Test for range filters and IN filters.
 
@@ -175,3 +219,19 @@ optional: x IN (1, 2)
 ----
 lookup expression:
   ((y = b) AND (x IN (1, 2))) AND (z > 0)
+
+lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y)
+y = b AND z > 0
+optional: x IN (1, 2)
+----
+lookup expression:
+  (y = b) AND (x IN (1, 2))
+remaining filters:
+  z > 0
+
+lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y)
+y = b
+optional: x IN (1, 2) AND z > 0
+----
+lookup expression:
+  (y = b) AND (x IN (1, 2))

--- a/pkg/sql/opt/lookupjoin/testdata/lookup_expr
+++ b/pkg/sql/opt/lookupjoin/testdata/lookup_expr
@@ -6,6 +6,11 @@ x IN (1, 2, 3) AND y = b
 lookup expression:
   (y = b) AND (x IN (1, 2, 3))
 
+lookup-constraints left=(a int, b int) right=(x int, y int, z int) index=(x, y)
+x IN (1, 2, 3)
+----
+lookup join not possible
+
 lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y, z)
 x IN (1, 2, 3) AND y = b AND z = c
 ----
@@ -145,6 +150,11 @@ x = a AND y > 0
 ----
 lookup expression:
   (x = a) AND (y > 0)
+
+lookup-constraints left=(a int, b int) right=(x int, y int) index=(x, y)
+x > 0
+----
+lookup join not possible
 
 lookup-constraints left=(a int, b int) right=(x int, y int) index=(x, y)
 x > 0 AND y = b


### PR DESCRIPTION
#### opt: add remaining filters to lookupjoin.Constraint

The remaining ON filters of a lookup join are now calculated by
`lookupjoin.ConstraintBuilder` and included in `lookupjoin.Constraint`.
The lookup join constraint tests have been expanded to include more
cases with remaining filters. This minor change will facilitate further
cleanup of `lookupjoin.ConstraintBuilder`.

Release note: None

#### opt: move equality column search into lookupjoin.ConstraintBuiler

Logic that searches for pairs of equality columns from the left and
right side of a join, which is a requirement for a lookup join, has been
moved to `lookupjoin.ConstraintBuilder`. This will facilitate further
refactoring of `lookupjoin.ConstraintBuilder`.

Release note: None
