### PR TITLE
kv/kvserver: log RHS size when skipping merge because of RHS size

### DIFF
--- a/pkg/kv/kvserver/merge_queue.go
+++ b/pkg/kv/kvserver/merge_queue.go
@@ -231,7 +231,7 @@ func (mq *mergeQueue) process(
 	}
 	if rhsStats.Total() >= minBytes {
 		log.VEventf(ctx, 2, "skipping merge: RHS meets minimum size threshold %d with %d bytes",
-			minBytes, lhsStats.Total())
+			minBytes, rhsStats.Total())
 		return false, nil
 	}
 


### PR DESCRIPTION
Previously, this was logging the size of the LHS rather than the size
of the RHS which was actually being compared. Now we log the size of
the right side.

Release note: None