### PR TITLE
sql: disable streamer for lookup joins for now

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -462,10 +462,9 @@ func (dsp *DistSQLPlanner) Run(
 	if row.CanUseStreamer(ctx, dsp.st) {
 		for _, proc := range plan.Processors {
 			if jr := proc.Spec.Core.JoinReader; jr != nil {
-				if jr.IsIndexJoin() || !jr.MaintainOrdering {
-					// Index joins with and without ordering as well as lookup
-					// joins without ordering are executed via the Streamer API
-					// that has concurrency.
+				if jr.IsIndexJoin() {
+					// Index joins with and without ordering are executed via
+					// the Streamer API that has concurrency.
 					localState.HasConcurrency = true
 					break
 				}

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -307,7 +307,7 @@ func newJoinReader(
 		shouldLimitBatches = false
 	}
 	useStreamer := flowCtx.Txn != nil && flowCtx.Txn.Type() == kv.LeafTxn &&
-		(readerType == indexJoinReaderType || !spec.MaintainOrdering) &&
+		readerType == indexJoinReaderType &&
 		row.CanUseStreamer(flowCtx.EvalCtx.Ctx(), flowCtx.EvalCtx.Settings)
 
 	jr := &joinReader{


### PR DESCRIPTION
There is some fallout in the roachtests from using the streamer for the
lookup join without ordering, so let's disable it for now while we're
figuring things out.

Informs: #80823.
Informs: https://github.com/cockroachdb/cockroach/issues/79870#issuecomment-1115565015.

Release note: None