### PR TITLE
ui: Improve Jobs page status when a high-water timestamp is present

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobStatusCell.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobStatusCell.tsx
@@ -12,7 +12,10 @@ import React from "react";
 import { cockroach } from "src/js/protos";
 import { HighwaterTimestamp } from "src/views/jobs/highwaterTimestamp";
 import { JobStatus } from "./jobStatus";
-import { isRetrying } from "src/views/jobs/jobStatusOptions";
+import {
+  isRetrying,
+  shouldShowHighwaterTimestamp,
+} from "src/views/jobs/jobStatusOptions";
 import { util } from "@cockroachlabs/cluster-ui";
 import { DATE_FORMAT_24_UTC } from "src/util/format";
 import { Tooltip } from "@cockroachlabs/ui-components";
@@ -29,15 +32,6 @@ export const JobStatusCell: React.FC<JobStatusCellProps> = ({
   lineWidth,
   compact = false,
 }) => {
-  if (job.highwater_timestamp) {
-    return (
-      <HighwaterTimestamp
-        highwater={job.highwater_timestamp}
-        tooltip={job.highwater_decimal}
-      />
-    );
-  }
-
   const jobStatus = (
     <JobStatus job={job} lineWidth={lineWidth} compact={compact} />
   );
@@ -58,5 +52,16 @@ export const JobStatusCell: React.FC<JobStatusCellProps> = ({
       </Tooltip>
     );
   }
-  return jobStatus;
+
+  return (
+    <>
+      {jobStatus}
+      {shouldShowHighwaterTimestamp(job) && (
+        <HighwaterTimestamp
+          highwater={job.highwater_timestamp}
+          tooltip={job.highwater_decimal}
+        />
+      )}
+    </>
+  );
 };

--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobStatusOptions.ts
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobStatusOptions.ts
@@ -56,7 +56,7 @@ export const JOB_STATUS_FAILED = "failed";
 export const JOB_STATUS_CANCELED = "canceled";
 export const JOB_STATUS_CANCEL_REQUESTED = "cancel-requested";
 export const JOB_STATUS_PAUSED = "paused";
-export const JOB_STATUS_PAUSE_REQUESTED = "paused-requested";
+export const JOB_STATUS_PAUSE_REQUESTED = "pause-requested";
 export const JOB_STATUS_RUNNING = "running";
 export const JOB_STATUS_RETRY_RUNNING = "retry-running";
 export const JOB_STATUS_PENDING = "pending";
@@ -71,6 +71,17 @@ export function isRetrying(status: string): boolean {
 }
 export function isRunning(status: string): boolean {
   return [JOB_STATUS_RUNNING, JOB_STATUS_RETRY_RUNNING].includes(status);
+}
+
+export function shouldShowHighwaterTimestamp(job: Job): boolean {
+  return (
+    job.highwater_timestamp &&
+    [
+      JOB_STATUS_RUNNING,
+      JOB_STATUS_PAUSED,
+      JOB_STATUS_PAUSE_REQUESTED,
+    ].includes(job.status)
+  );
 }
 
 export const statusOptions = [

--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobsTable.fixture.ts
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobsTable.fixture.ts
@@ -74,6 +74,20 @@ const canceledJobFixture = {
   type: "UNSPECIFIED",
   description: "Unspecified",
   status: "canceled",
+  // highwater_timestamp is present, but it should not be shown
+  highwater_timestamp: new protos.google.protobuf.Timestamp({
+    seconds: new Long(1634648117),
+    nanos: 98294000,
+  }),
+  highwater_decimal: "1651674578050731000.0000000000",
+};
+
+const cancelRequestedJobFixture = {
+  ...defaultJobProperties,
+  id: new Long(4337653761, 70312826),
+  type: "CREATE STATS",
+  description: "SELECT job_id, job_type FROM [SHOW JOB 1]",
+  status: "cancel-requested",
 };
 
 const pausedJobFixture = {
@@ -83,6 +97,41 @@ const pausedJobFixture = {
   description:
     "BACKUP DATABASE bank TO 'gs://acme-co-backup/database-bank-2017-03-29-nightly' AS OF SYSTEM TIME '-10s' INCREMENTAL FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly', 'gs://acme-co-backup/database-bank-2017-03-28-nightly' WITH revision_history\n",
   status: "paused",
+};
+
+const pausedWithHighwaterJobFixture = {
+  ...defaultJobProperties,
+  id: new Long(6091954177, 70312826),
+  type: "BACKUP",
+  description:
+    "BACKUP DATABASE bank TO 'gs://acme-co-backup/database-bank-2017-03-29-nightly' AS OF SYSTEM TIME '-10s' INCREMENTAL FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly', 'gs://acme-co-backup/database-bank-2017-03-28-nightly' WITH revision_history\n",
+  status: "paused",
+  highwater_timestamp: new protos.google.protobuf.Timestamp({
+    seconds: new Long(1634648117),
+    nanos: 98294000,
+  }),
+  highwater_decimal: "1651674578050731000.0000000000",
+};
+
+const pauseRequestedJobFixture = {
+  ...defaultJobProperties,
+  id: new Long(4338669569, 70312826),
+  type: "AUTO CREATE STATS",
+  description: "SELECT job_id, job_type FROM [SHOW AUTOMATIC JOBS];",
+  status: "pause-requested",
+};
+
+const pauseRequestedWithHighwaterJobFixture = {
+  ...defaultJobProperties,
+  id: new Long(4338669569, 70312826),
+  type: "AUTO CREATE STATS",
+  description: "SELECT job_id, job_type FROM [SHOW AUTOMATIC JOBS];",
+  status: "pause-requested",
+  highwater_timestamp: new protos.google.protobuf.Timestamp({
+    seconds: new Long(1634648117),
+    nanos: 98294000,
+  }),
+  highwater_decimal: "1651674578050731000.0000000000",
 };
 
 const runningJobFixture = {
@@ -183,6 +232,49 @@ const retryRunningWithMessageRemainingJobFixture = {
   num_runs: new Long(2),
 };
 
+const runningWithHighwaterJobFixture = {
+  ...defaultJobProperties,
+  id: new Long(3390625793, 70312826),
+  type: "TYPEDESC SCHEMA CHANGE",
+  description: "ALTER TYPE status ADD VALUE 'pending';",
+  status: "running",
+  fraction_completed: 0.98,
+  highwater_timestamp: new protos.google.protobuf.Timestamp({
+    seconds: new Long(1634648117),
+    nanos: 98294000,
+  }),
+  highwater_decimal: "1651674578050731000.0000000000",
+};
+
+const runningChangefeedJobFixture = {
+  ...defaultJobProperties,
+  id: new Long(758919388643098625),
+  type: "CHANGEFEED",
+  description:
+    "CREATE CHANGEFEED FOR TABLE movr.vehicles INTO 'webhook-https://localhost:3000?insecure_tls_skip_verify=true' WITH updated",
+  username: "root",
+  descriptor_ids: [107],
+  status: "running",
+  running_status:
+    'retryable error: retryable changefeed error: Post "https://localhost:3000": http: server gave HTTP response to HTTPS client',
+  coordinator_id: "1",
+};
+
+const runningChangefeedWithHighwaterJobFixture = {
+  ...defaultJobProperties,
+  id: new Long(3390625793, 70312826),
+  type: "CHANGEFEED",
+  description:
+    "CREATE CHANGEFEED FOR TABLE movr.vehicles INTO 'webhook-https://localhost:3001?insecure_tls_skip_verify=true' WITH updated",
+  status: "running",
+  running_status: "running: resolved=1651674578.050731000,0",
+  highwater_timestamp: new protos.google.protobuf.Timestamp({
+    seconds: new Long(1634648117),
+    nanos: 98294000,
+  }),
+  highwater_decimal: "1651674578050731000.0000000000",
+};
+
 const pendingJobFixture = {
   ...defaultJobProperties,
   id: new Long(5247850497, 70312826),
@@ -195,8 +287,8 @@ const pendingJobFixture = {
 const revertingJobFixture = {
   ...defaultJobProperties,
   id: new Long(5246539777, 70312826),
-  type: "CHANGEFEED",
-  description: "CREATE CHANGEFEED FOR foo WITH updated, resolved, diff",
+  type: "NEW SCHEMA CHANGE",
+  description: "ALTER TABLE db.t ADD COLUMN b INT DEFAULT 1",
   status: "reverting",
 };
 
@@ -213,35 +305,6 @@ const retryRevertingJobFixture = {
   num_runs: new Long(2),
 };
 
-const highwaterJobFixture = {
-  ...defaultJobProperties,
-  id: new Long(3390625793, 70312826),
-  type: "TYPEDESC SCHEMA CHANGE",
-  description: "ALTER TYPE status ADD VALUE 'pending';",
-  status: "running",
-  highwater_timestamp: new protos.google.protobuf.Timestamp({
-    seconds: new Long(1634648117),
-    nanos: 98294000,
-  }),
-  highwater_decimal: "test highwater decimal",
-};
-
-const cancelRequestedJobFixture = {
-  ...defaultJobProperties,
-  id: new Long(4337653761, 70312826),
-  type: "CREATE STATS",
-  description: "SELECT job_id, job_type FROM [SHOW JOB 1]",
-  status: "cancel-requested",
-};
-
-const pauseRequestedJobFixture = {
-  ...defaultJobProperties,
-  id: new Long(4338669569, 70312826),
-  type: "AUTO CREATE STATS",
-  description: "SELECT job_id, job_type FROM [SHOW AUTOMATIC JOBS];",
-  status: "pause-requested",
-};
-
 const revertFailedJobFixture = {
   ...defaultJobProperties,
   id: new Long(3391379457, 70312826),
@@ -254,11 +317,18 @@ export const allJobsFixture = [
   succeededJobFixture,
   failedJobFixture,
   canceledJobFixture,
+  cancelRequestedJobFixture,
   pausedJobFixture,
+  pausedWithHighwaterJobFixture,
+  pauseRequestedJobFixture,
+  pauseRequestedWithHighwaterJobFixture,
   runningJobFixture,
   runningWithMessageJobFixture,
   runningWithRemainingJobFixture,
   runningWithMessageRemainingJobFixture,
+  runningWithHighwaterJobFixture,
+  runningChangefeedJobFixture,
+  runningChangefeedWithHighwaterJobFixture,
   retryRunningJobFixture,
   retryRunningWithMessageJobFixture,
   retryRunningWithRemainingJobFixture,
@@ -266,9 +336,6 @@ export const allJobsFixture = [
   pendingJobFixture,
   revertingJobFixture,
   retryRevertingJobFixture,
-  highwaterJobFixture,
-  cancelRequestedJobFixture,
-  pauseRequestedJobFixture,
   revertFailedJobFixture,
 ];
 


### PR DESCRIPTION
Todo:
Blocked on resolving the discussion in https://github.com/cockroachdb/cockroach/issues/80981 on whether we should make this change at all.

Fixes #80981

Previously, if a job had a high-water timestamp, the high-water timestamp would
always show, and the job status would be hidden.

This commit modifies the UI such that the high-water timestamp (if available) is
only shown when the job status is "running", "paused", or "pause-requested".
Additionally, these statuses are still shown even if there is a high-water
timestamp.

These are now the only possible statuses that show a high-water timestamp:
<img width="898" alt="image" src="https://user-images.githubusercontent.com/91907326/166717471-4892e3b7-81f7-45dd-b80b-2b138ad615ad.png">

Before:
<img width="1584" alt="image" src="https://user-images.githubusercontent.com/91907326/166717550-926b30ff-04d1-4768-8583-bcbe4eddee9a.png">

After:
<img width="1573" alt="image" src="https://user-images.githubusercontent.com/91907326/166717581-cbbdeb3c-fba3-4b78-b3bb-2c4763d461af.png">

Release note (ui): Previously, if a job had a high-water timestamp, the
high-water timestamp would always show, and the job status would be hidden.
Now, the high-water timestamp is only shown for jobs with the
status "running", "paused", or "pause-requested", and the status is shown in
addition to the high-water timestamp.