### PR TITLE
outliers: collect statement fingerprint id

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -6083,9 +6083,10 @@ CREATE TABLE crdb_internal.cluster_locks (
 var crdbInternalNodeExecutionOutliersTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE crdb_internal.node_execution_outliers (
-	session_id     STRING NOT NULL,
-	transaction_id UUID NOT NULL,
-	statement_id   STRING NOT NULL
+	session_id               STRING NOT NULL,
+	transaction_id           UUID NOT NULL,
+	statement_id             STRING NOT NULL,
+	statement_fingerprint_id BYTES NOT NULL
 );`,
 	populate: func(ctx context.Context, p *planner, db catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) (err error) {
 		p.extendedEvalCtx.statsProvider.IterateOutliers(ctx, func(
@@ -6095,6 +6096,7 @@ CREATE TABLE crdb_internal.node_execution_outliers (
 				tree.NewDString(hex.EncodeToString(o.Session.ID)),
 				tree.NewDUuid(tree.DUuid{UUID: *o.Transaction.ID}),
 				tree.NewDString(hex.EncodeToString(o.Statement.ID)),
+				tree.NewDBytes(tree.DBytes(sqlstatsutil.EncodeUint64ToBytes(uint64(o.Statement.FingerprintID)))),
 			))
 		})
 		return err

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -870,11 +870,13 @@ CREATE TABLE crdb_internal.node_distsql_flows (
 CREATE TABLE crdb_internal.node_execution_outliers (
    session_id STRING NOT NULL,
    transaction_id UUID NOT NULL,
-   statement_id STRING NOT NULL
+   statement_id STRING NOT NULL,
+   statement_fingerprint_id BYTES NOT NULL
 )  CREATE TABLE crdb_internal.node_execution_outliers (
    session_id STRING NOT NULL,
    transaction_id UUID NOT NULL,
-   statement_id STRING NOT NULL
+   statement_id STRING NOT NULL,
+   statement_fingerprint_id BYTES NOT NULL
 )  {}  {}
 CREATE TABLE crdb_internal.node_inflight_trace_spans (
    trace_id INT8 NOT NULL,

--- a/pkg/sql/sqlstats/outliers/BUILD.bazel
+++ b/pkg/sql/sqlstats/outliers/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/sqlstats/outliers",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql/clusterunique",
@@ -30,6 +31,7 @@ go_test(
     ],
     embed = [":outliers"],
     deps = [
+        "//pkg/roachpb",
         "//pkg/settings/cluster",
         "//pkg/sql/clusterunique",
         "//pkg/util/uuid",

--- a/pkg/sql/sqlstats/outliers/outliers.go
+++ b/pkg/sql/sqlstats/outliers/outliers.go
@@ -13,6 +13,7 @@ package outliers
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
@@ -73,7 +74,10 @@ func New(st *cluster.Settings) *Registry {
 
 // ObserveStatement notifies the registry of a statement execution.
 func (r *Registry) ObserveStatement(
-	sessionID clusterunique.ID, statementID clusterunique.ID, latencyInSeconds float64,
+	sessionID clusterunique.ID,
+	statementID clusterunique.ID,
+	statementFingerprintID roachpb.StmtFingerprintID,
+	latencyInSeconds float64,
 ) {
 	if !r.enabled() {
 		return
@@ -82,6 +86,7 @@ func (r *Registry) ObserveStatement(
 	defer r.mu.Unlock()
 	r.mu.statements[sessionID] = append(r.mu.statements[sessionID], &Outlier_Statement{
 		ID:               statementID.GetBytes(),
+		FingerprintID:    statementFingerprintID,
 		LatencyInSeconds: latencyInSeconds,
 	})
 }

--- a/pkg/sql/sqlstats/outliers/outliers.proto
+++ b/pkg/sql/sqlstats/outliers/outliers.proto
@@ -26,7 +26,9 @@ message Outlier {
 
   message Statement {
     bytes id = 1 [(gogoproto.customname) = "ID"];
-    double latency_in_seconds = 2;
+    uint64 fingerprint_id = 2 [(gogoproto.customname) = "FingerprintID",
+      (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.StmtFingerprintID"];
+    double latency_in_seconds = 3;
   }
 
   Session session = 1;

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -159,7 +159,7 @@ func (s *Container) RecordStatement(
 		}
 	}
 
-	s.outliersRegistry.ObserveStatement(value.SessionID, value.StatementID, value.ServiceLatency)
+	s.outliersRegistry.ObserveStatement(value.SessionID, value.StatementID, stmtFingerprintID, value.ServiceLatency)
 
 	return stats.ID, nil
 }


### PR DESCRIPTION
This change also helps set us up for #79451, where we'll be working with
per-fingerprint statement latencies.

Release note: None