### PR TITLE
ccl/sqlproxyccl: export all fields in the FrontendAdmitInfo struct

### DIFF
--- a/pkg/ccl/sqlproxyccl/backend_dialer.go
+++ b/pkg/ccl/sqlproxyccl/backend_dialer.go
@@ -25,7 +25,9 @@ import (
 // BackendDial uses a dial timeout of 5 seconds to mitigate network black
 // holes.
 //
-// TODO(jaylim-crl): Move dialer into connector in the future.
+// TODO(jaylim-crl): Move dialer into connector in the future. When moving this
+// into the connector, we should be careful as this is also used by CC's
+// codebase.
 var BackendDial = func(
 	msg *pgproto3.StartupMessage, serverAddress string, tlsConfig *tls.Config,
 ) (_ net.Conn, retErr error) {

--- a/pkg/ccl/sqlproxyccl/frontend_admitter_test.go
+++ b/pkg/ccl/sqlproxyccl/frontend_admitter_test.go
@@ -60,12 +60,12 @@ func TestFrontendAdmitWithClientSSLDisableAndCustomParam(t *testing.T) {
 	}()
 
 	fe := FrontendAdmit(srv, nil)
-	require.NoError(t, fe.err)
-	require.Equal(t, srv, fe.conn)
-	require.NotNil(t, fe.msg)
-	require.Contains(t, fe.msg.Parameters, "p1")
-	require.Equal(t, fe.msg.Parameters["p1"], "a")
-	require.Contains(t, fe.msg.Parameters, remoteAddrStartupParam)
+	require.NoError(t, fe.Err)
+	require.Equal(t, srv, fe.Conn)
+	require.NotNil(t, fe.Msg)
+	require.Contains(t, fe.Msg.Parameters, "p1")
+	require.Equal(t, fe.Msg.Parameters["p1"], "a")
+	require.Contains(t, fe.Msg.Parameters, remoteAddrStartupParam)
 }
 
 func TestFrontendAdmitWithClientSSLRequire(t *testing.T) {
@@ -93,11 +93,11 @@ func TestFrontendAdmitWithClientSSLRequire(t *testing.T) {
 	require.NoError(t, err)
 	fe := FrontendAdmit(srv, tlsConfig)
 	require.NoError(t, err)
-	defer func() { _ = fe.conn.Close() }()
-	require.NotEqual(t, srv, fe.conn) // The connection was replaced by SSL
-	require.NotNil(t, fe.msg)
-	require.Contains(t, fe.msg.Parameters, remoteAddrStartupParam)
-	require.Equal(t, fe.sniServerName, "test")
+	defer func() { _ = fe.Conn.Close() }()
+	require.NotEqual(t, srv, fe.Conn) // The connection was replaced by SSL
+	require.NotNil(t, fe.Msg)
+	require.Contains(t, fe.Msg.Parameters, remoteAddrStartupParam)
+	require.Equal(t, fe.SniServerName, "test")
 }
 
 // TestFrontendAdmitRequireEncryption sends StartupRequest when SSlRequest is
@@ -121,11 +121,11 @@ func TestFrontendAdmitRequireEncryption(t *testing.T) {
 	tlsConfig, err := tlsConfig()
 	require.NoError(t, err)
 	fe := FrontendAdmit(srv, tlsConfig)
-	require.EqualError(t, fe.err,
+	require.EqualError(t, fe.Err,
 		"codeUnexpectedInsecureStartupMessage: "+
 			"unsupported startup message: *pgproto3.StartupMessage")
-	require.NotNil(t, fe.conn)
-	require.Nil(t, fe.msg)
+	require.NotNil(t, fe.Conn)
+	require.Nil(t, fe.Msg)
 }
 
 // TestFrontendAdmitWithCancel sends CancelRequest.
@@ -143,9 +143,9 @@ func TestFrontendAdmitWithCancel(t *testing.T) {
 	}()
 
 	fe := FrontendAdmit(srv, nil)
-	require.NoError(t, fe.err)
-	require.NotNil(t, fe.conn)
-	require.Nil(t, fe.msg)
+	require.NoError(t, fe.Err)
+	require.NotNil(t, fe.Conn)
+	require.Nil(t, fe.Msg)
 }
 
 // TestFrontendAdmitWithSSLAndCancel sends SSLRequest followed by CancelRequest.
@@ -173,12 +173,12 @@ func TestFrontendAdmitWithSSLAndCancel(t *testing.T) {
 	tlsConfig, err := tlsConfig()
 	require.NoError(t, err)
 	fe := FrontendAdmit(srv, tlsConfig)
-	require.EqualError(t, fe.err,
+	require.EqualError(t, fe.Err,
 		"codeUnexpectedStartupMessage: "+
 			"unsupported post-TLS startup message: *pgproto3.CancelRequest",
 	)
-	require.NotNil(t, fe.conn)
-	require.Nil(t, fe.msg)
+	require.NotNil(t, fe.Conn)
+	require.Nil(t, fe.Msg)
 }
 
 func TestFrontendAdmitSessionRevivalToken(t *testing.T) {
@@ -207,7 +207,7 @@ func TestFrontendAdmitSessionRevivalToken(t *testing.T) {
 	}()
 
 	fe := FrontendAdmit(srv, nil)
-	require.EqualError(t, fe.err, "codeUnexpectedStartupMessage: parameter crdb:session_revival_token_base64 is not allowed")
-	require.NotNil(t, fe.conn)
-	require.Nil(t, fe.msg)
+	require.EqualError(t, fe.Err, "codeUnexpectedStartupMessage: parameter crdb:session_revival_token_base64 is not allowed")
+	require.NotNil(t, fe.Conn)
+	require.Nil(t, fe.Msg)
 }

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -193,7 +193,7 @@ func TestUnexpectedError(t *testing.T) {
 		conn net.Conn, incomingTLSConfig *tls.Config,
 	) *FrontendAdmitInfo {
 		log.Infof(context.Background(), "frontend admitter returning unexpected error")
-		return &FrontendAdmitInfo{conn: conn, err: errors.New("unexpected error")}
+		return &FrontendAdmitInfo{Conn: conn, Err: errors.New("unexpected error")}
 	})()
 
 	stopper := stop.NewStopper()
@@ -515,7 +515,7 @@ func TestErroneousFrontend(t *testing.T) {
 	defer testutils.TestingHook(&FrontendAdmit, func(
 		conn net.Conn, incomingTLSConfig *tls.Config,
 	) *FrontendAdmitInfo {
-		return &FrontendAdmitInfo{conn: conn, err: errors.New(frontendError)}
+		return &FrontendAdmitInfo{Conn: conn, Err: errors.New(frontendError)}
 	})()
 
 	stopper := stop.NewStopper()
@@ -1406,7 +1406,7 @@ func TestClusterNameAndTenantFromParams(t *testing.T) {
 				originalParams[k] = v
 			}
 
-			fe := &FrontendAdmitInfo{msg: msg}
+			fe := &FrontendAdmitInfo{Msg: msg}
 			outMsg, clusterName, tenantID, err := clusterNameAndTenantFromParams(ctx, fe)
 			if tc.expectedError == "" {
 				require.NoErrorf(t, err, "failed test case\n%+v", tc)


### PR DESCRIPTION
Previously, we refactored the FrontendAdmit call in #79475 to return a struct.
However, fields in those struct were unexported. CockroachCloud (CC) currently
relies on the FrontendAdmit call, and this commit exports all fields in the
FrontendAdmitInfo struct to allow us to bump the dependency in CC.

Release note: None