### PR TITLE
backupccl: Cosmetic changes to backup_processor.go to improve clarity.

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "backup_span_coverage.go",
         "create_scheduled_backup.go",
         "encryption.go",
+        "file_sst_sink.go",
         "incrementals.go",
         "key_rewriter.go",
         "manifest_handling.go",

--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -11,14 +11,9 @@ package backupccl
 import (
 	"context"
 	"fmt"
-	"io"
-	"sort"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
@@ -30,9 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
@@ -45,7 +38,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
-	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/kr/pretty"
 )
 
@@ -247,9 +239,9 @@ type spanAndTime struct {
 	lastTried  time.Time
 }
 
-type returnedSST struct {
-	f              BackupManifest_File
-	sst            []byte
+type exportedSpan struct {
+	metadata       BackupManifest_File
+	dataSST        []byte
 	revStart       hlc.Timestamp
 	completedSpans int32
 	atKeyBoundary  bool
@@ -318,15 +310,15 @@ func runBackupProcessor(
 		return err
 	}
 
-	returnedSSTs := make(chan returnedSST, 1)
+	returnedSpansChan := make(chan exportedSpan, 1)
 
 	grp := ctxgroup.WithContext(ctx)
 	// Start a goroutine that will then start a group of goroutines which each
 	// pull spans off of `todo` and send export requests. Any resume spans are put
-	// back on `todo`. Any returned SSTs are put on a  `returnedSSTs` to be routed
+	// back on `todo`. Any returned SSTs are put on a  `returnedSpansChan` to be routed
 	// to a buffered sink that merges them until they are large enough to flush.
 	grp.GoCtx(func(ctx context.Context) error {
-		defer close(returnedSSTs)
+		defer close(returnedSpansChan)
 		// TODO(pbardea): Check to see if this benefits from any tuning (e.g. +1, or
 		//  *2). See #49798.
 		numSenders := int(kvserver.ExportRequestsLimit.Get(&clusterSettings.SV)) * 2
@@ -417,7 +409,7 @@ func runBackupProcessor(
 					}
 					log.Infof(ctx, "sending ExportRequest for span %s (attempt %d, priority %s)",
 						span.span, span.attempts+1, header.UserPriority.String())
-					var rawRes roachpb.Response
+					var rawResp roachpb.Response
 					var pErr *roachpb.Error
 					var reqSentTime time.Time
 					var respReceivedTime time.Time
@@ -432,7 +424,7 @@ func runBackupProcessor(
 								ReqSentTime: reqSentTime.String(),
 							})
 
-							rawRes, pErr = kv.SendWrappedWithAdmission(
+							rawResp, pErr = kv.SendWrappedWithAdmission(
 								ctx, flowCtx.Cfg.DB.NonTransactionalSender(), header, admissionHeader, req)
 							respReceivedTime = timeutil.Now()
 							if pErr != nil {
@@ -471,23 +463,23 @@ func runBackupProcessor(
 						return errors.Wrapf(exportRequestErr, "exporting %s", span.span)
 					}
 
-					res := rawRes.(*roachpb.ExportResponse)
+					resp := rawResp.(*roachpb.ExportResponse)
 
 					// If the reply has a resume span, put the remaining span on
 					// todo to be picked up again in the next round.
-					if res.ResumeSpan != nil {
-						if !res.ResumeSpan.Valid() {
-							return errors.Errorf("invalid resume span: %s", res.ResumeSpan)
+					if resp.ResumeSpan != nil {
+						if !resp.ResumeSpan.Valid() {
+							return errors.Errorf("invalid resume span: %s", resp.ResumeSpan)
 						}
 
 						resumeTS := hlc.Timestamp{}
 						// Taking resume timestamp from the last file of response since files must
 						// always be consecutive even if we currently expect only one.
-						if fileCount := len(res.Files); fileCount > 0 {
-							resumeTS = res.Files[fileCount-1].EndKeyTS
+						if fileCount := len(resp.Files); fileCount > 0 {
+							resumeTS = resp.Files[fileCount-1].EndKeyTS
 						}
 						resumeSpan := spanAndTime{
-							span:       *res.ResumeSpan,
+							span:       *resp.ResumeSpan,
 							firstKeyTS: resumeTS,
 							start:      span.start,
 							end:        span.end,
@@ -499,12 +491,12 @@ func runBackupProcessor(
 
 					if backupKnobs, ok := flowCtx.TestingKnobs().BackupRestoreTestingKnobs.(*sql.BackupRestoreTestingKnobs); ok {
 						if backupKnobs.RunAfterExportingSpanEntry != nil {
-							backupKnobs.RunAfterExportingSpanEntry(ctx, res)
+							backupKnobs.RunAfterExportingSpanEntry(ctx, resp)
 						}
 					}
 
 					var completedSpans int32
-					if res.ResumeSpan == nil {
+					if resp.ResumeSpan == nil {
 						completedSpans = 1
 					}
 
@@ -514,34 +506,42 @@ func runBackupProcessor(
 						FileSummaries: make([]roachpb.RowCount, 0),
 					}
 
-					if len(res.Files) > 1 {
+					if len(resp.Files) > 1 {
 						log.Warning(ctx, "unexpected multi-file response using header.TargetBytes = 1")
 					}
 
-					for i, file := range res.Files {
-						f := BackupManifest_File{
-							Span:        file.Span,
-							Path:        file.Path,
-							EntryCounts: countRows(file.Exported, spec.PKIDs),
-						}
-						exportResponseTraceEvent.FileSummaries = append(exportResponseTraceEvent.FileSummaries, f.EntryCounts)
+					for i, file := range resp.Files {
+						entryCounts := countRows(file.Exported, spec.PKIDs)
+						exportResponseTraceEvent.FileSummaries = append(exportResponseTraceEvent.FileSummaries, entryCounts)
+
+						ret := exportedSpan{
+							// BackupManifest_File just happens to contain the exact fields
+							// to store the metadata we need, but there's no actual File
+							// on-disk anywhere yet.
+							metadata: BackupManifest_File{
+								Span:        file.Span,
+								Path:        file.Path,
+								EntryCounts: entryCounts,
+							},
+							dataSST:       file.SST,
+							revStart:      resp.StartTime,
+							atKeyBoundary: file.EndKeyTS.IsEmpty()}
 						if span.start != spec.BackupStartTime {
-							f.StartTime = span.start
-							f.EndTime = span.end
+							ret.metadata.StartTime = span.start
+							ret.metadata.EndTime = span.end
 						}
-						ret := returnedSST{f: f, sst: file.SST, revStart: res.StartTime, atKeyBoundary: file.EndKeyTS.IsEmpty()}
 						// If multiple files were returned for this span, only one -- the
 						// last -- should count as completing the requested span.
-						if i == len(res.Files)-1 {
+						if i == len(resp.Files)-1 {
 							ret.completedSpans = completedSpans
 						}
 						select {
-						case returnedSSTs <- ret:
+						case returnedSpansChan <- ret:
 						case <-ctxDone:
 							return ctx.Err()
 						}
 					}
-					exportResponseTraceEvent.NumFiles = int32(len(res.Files))
+					exportResponseTraceEvent.NumFiles = int32(len(resp.Files))
 					backupProcessorSpan.RecordStructured(exportResponseTraceEvent)
 
 				default:
@@ -555,8 +555,8 @@ func runBackupProcessor(
 		})
 	})
 
-	// Start another goroutine which will read from returnedSSTs ch and push
-	// ssts from it into an sstSink responsible for actually writing their
+	// Start another goroutine which will read from returnedSpansChan ch and push
+	// ssts from it into an fileSSTSink responsible for actually writing their
 	// contents to cloud storage.
 	grp.GoCtx(func(ctx context.Context) error {
 		sinkConf := sstSinkConf{
@@ -571,7 +571,7 @@ func runBackupProcessor(
 			return err
 		}
 
-		sink, err := makeSSTSink(ctx, sinkConf, storage, memAcc)
+		sink, err := makeFileSSTSink(ctx, sinkConf, storage, memAcc)
 		if err != nil {
 			return err
 		}
@@ -584,9 +584,9 @@ func runBackupProcessor(
 			}
 		}()
 
-		for res := range returnedSSTs {
-			res.f.LocalityKV = destLocalityKV
-			if err := sink.push(ctx, res); err != nil {
+		for returnedSpans := range returnedSpansChan {
+			returnedSpans.metadata.LocalityKV = destLocalityKV
+			if err := sink.push(ctx, returnedSpans); err != nil {
 				return err
 			}
 		}
@@ -594,301 +594,6 @@ func runBackupProcessor(
 	})
 
 	return grp.Wait()
-}
-
-type sstSinkConf struct {
-	progCh   chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress
-	enc      *roachpb.FileEncryptionOptions
-	id       base.SQLInstanceID
-	settings *settings.Values
-}
-
-type sstSink struct {
-	dest cloud.ExternalStorage
-	conf sstSinkConf
-
-	queue []returnedSST
-	// queueCap is the maximum byte size that the queue can grow to.
-	queueCap int64
-	// queueSize is the current byte size of the queue.
-	queueSize int
-
-	sst     storage.SSTWriter
-	ctx     context.Context
-	cancel  func()
-	out     io.WriteCloser
-	outName string
-
-	flushedFiles    []BackupManifest_File
-	flushedSize     int64
-	flushedRevStart hlc.Timestamp
-	completedSpans  int32
-
-	stats struct {
-		files       int
-		flushes     int
-		oooFlushes  int
-		sizeFlushes int
-		spanGrows   int
-	}
-
-	memAcc struct {
-		ba            *mon.BoundAccount
-		reservedBytes int64
-	}
-}
-
-func makeSSTSink(
-	ctx context.Context, conf sstSinkConf, dest cloud.ExternalStorage, backupMem *mon.BoundAccount,
-) (*sstSink, error) {
-	s := &sstSink{conf: conf, dest: dest}
-	s.memAcc.ba = backupMem
-
-	// Reserve memory for the file buffer. Incrementally reserve memory in chunks
-	// upto a maximum of the `smallFileBuffer` cluster setting value. If we fail
-	// to grow the bound account at any stage, use the buffer size we arrived at
-	// prior to the error.
-	incrementSize := int64(32 << 20)
-	maxSize := smallFileBuffer.Get(s.conf.settings)
-	for {
-		if s.queueCap >= maxSize {
-			break
-		}
-
-		if incrementSize > maxSize-s.queueCap {
-			incrementSize = maxSize - s.queueCap
-		}
-
-		if err := s.memAcc.ba.Grow(ctx, incrementSize); err != nil {
-			log.Infof(ctx, "failed to grow file queue by %d bytes, running backup with queue size %d bytes: %+v", incrementSize, s.queueCap, err)
-			break
-		}
-		s.queueCap += incrementSize
-	}
-	if s.queueCap == 0 {
-		return nil, errors.New("failed to reserve memory for sstSink queue")
-	}
-
-	s.memAcc.reservedBytes += s.queueCap
-	return s, nil
-}
-
-func (s *sstSink) Close() error {
-	if log.V(1) && s.ctx != nil {
-		log.Infof(s.ctx, "backup sst sink recv'd %d files, wrote %d (%d due to size, %d due to re-ordering), %d recv files extended prior span",
-			s.stats.files, s.stats.flushes, s.stats.sizeFlushes, s.stats.oooFlushes, s.stats.spanGrows)
-	}
-	if s.cancel != nil {
-		s.cancel()
-	}
-
-	// Release the memory reserved for the file buffer.
-	s.memAcc.ba.Shrink(s.ctx, s.memAcc.reservedBytes)
-	s.memAcc.reservedBytes = 0
-	if s.out != nil {
-		return s.out.Close()
-	}
-	return nil
-}
-
-// push pushes one returned backup file into the sink. Returned files can arrive
-// out of order, but must be written to an underlying file in-order or else a
-// new underlying file has to be opened. The queue allows buffering up files and
-// sorting them before pushing them to the underlying file to try to avoid this.
-// When the queue length or sum of the data sizes in it exceeds thresholds the
-// queue is sorted and the first half is flushed.
-func (s *sstSink) push(ctx context.Context, resp returnedSST) error {
-	s.queue = append(s.queue, resp)
-	s.queueSize += len(resp.sst)
-
-	if s.queueSize >= int(s.queueCap) {
-		sort.Slice(s.queue, func(i, j int) bool { return s.queue[i].f.Span.Key.Compare(s.queue[j].f.Span.Key) < 0 })
-
-		// Drain the first half.
-		drain := len(s.queue) / 2
-		if drain < 1 {
-			drain = 1
-		}
-		for i := range s.queue[:drain] {
-			if err := s.write(ctx, s.queue[i]); err != nil {
-				return err
-			}
-			s.queueSize -= len(s.queue[i].sst)
-		}
-
-		// Shift down the remainder of the queue and slice off the tail.
-		copy(s.queue, s.queue[drain:])
-		s.queue = s.queue[:len(s.queue)-drain]
-	}
-	return nil
-}
-
-func (s *sstSink) flush(ctx context.Context) error {
-	for i := range s.queue {
-		if err := s.write(ctx, s.queue[i]); err != nil {
-			return err
-		}
-	}
-	s.queue = nil
-	return s.flushFile(ctx)
-}
-
-func (s *sstSink) flushFile(ctx context.Context) error {
-	if s.out == nil {
-		return nil
-	}
-	s.stats.flushes++
-
-	if err := s.sst.Finish(); err != nil {
-		return err
-	}
-	if err := s.out.Close(); err != nil {
-		log.Warningf(ctx, "failed to close write in sstSink: % #v", pretty.Formatter(err))
-		return errors.Wrap(err, "writing SST")
-	}
-	s.outName = ""
-	s.out = nil
-
-	progDetails := BackupManifest_Progress{
-		RevStartTime:   s.flushedRevStart,
-		Files:          s.flushedFiles,
-		CompletedSpans: s.completedSpans,
-	}
-	var prog execinfrapb.RemoteProducerMetadata_BulkProcessorProgress
-	details, err := gogotypes.MarshalAny(&progDetails)
-	if err != nil {
-		return err
-	}
-	prog.ProgressDetails = *details
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case s.conf.progCh <- prog:
-	}
-
-	s.flushedFiles = nil
-	s.flushedSize = 0
-	s.flushedRevStart.Reset()
-	s.completedSpans = 0
-
-	return nil
-}
-
-func (s *sstSink) open(ctx context.Context) error {
-	s.outName = generateUniqueSSTName(s.conf.id)
-	if s.ctx == nil {
-		s.ctx, s.cancel = context.WithCancel(ctx)
-	}
-	w, err := s.dest.Writer(s.ctx, s.outName)
-	if err != nil {
-		return err
-	}
-	if s.conf.enc != nil {
-		var err error
-		w, err = storageccl.EncryptingWriter(w, s.conf.enc.Key)
-		if err != nil {
-			return err
-		}
-	}
-	s.out = w
-	s.sst = storage.MakeBackupSSTWriter(ctx, s.dest.Settings(), s.out)
-
-	return nil
-}
-
-func (s *sstSink) write(ctx context.Context, resp returnedSST) error {
-	s.stats.files++
-
-	span := resp.f.Span
-
-	// If this span starts before the last buffered span ended, we need to flush
-	// since it overlaps but SSTWriter demands writes in-order.
-	if len(s.flushedFiles) > 0 {
-		last := s.flushedFiles[len(s.flushedFiles)-1].Span.EndKey
-		if span.Key.Compare(last) < 0 {
-			log.VEventf(ctx, 1, "flushing backup file %s of size %d because span %s cannot append before %s",
-				s.outName, s.flushedSize, span, last,
-			)
-			s.stats.oooFlushes++
-			if err := s.flushFile(ctx); err != nil {
-				return err
-			}
-		}
-	}
-
-	// Initialize the writer if needed.
-	if s.out == nil {
-		if err := s.open(ctx); err != nil {
-			return err
-		}
-	}
-
-	log.VEventf(ctx, 2, "writing %s to backup file %s", span, s.outName)
-
-	// Copy SST content.
-	sst, err := storage.NewMemSSTIterator(resp.sst, false)
-	if err != nil {
-		return err
-	}
-	defer sst.Close()
-
-	sst.SeekGE(storage.MVCCKey{Key: keys.MinKey})
-	for {
-		if valid, err := sst.Valid(); !valid || err != nil {
-			if err != nil {
-				return err
-			}
-			break
-		}
-		k := sst.UnsafeKey()
-		if k.Timestamp.IsEmpty() {
-			if err := s.sst.PutUnversioned(k.Key, sst.UnsafeValue()); err != nil {
-				return err
-			}
-		} else {
-			if err := s.sst.PutRawMVCC(sst.UnsafeKey(), sst.UnsafeValue()); err != nil {
-				return err
-			}
-		}
-		sst.Next()
-	}
-
-	// If this span extended the last span added -- that is, picked up where it
-	// ended and has the same time-bounds -- then we can simply extend that span
-	// and add to its entry counts. Otherwise we need to record it separately.
-	if l := len(s.flushedFiles) - 1; l > 0 && s.flushedFiles[l].Span.EndKey.Equal(span.Key) &&
-		s.flushedFiles[l].EndTime.EqOrdering(resp.f.EndTime) &&
-		s.flushedFiles[l].StartTime.EqOrdering(resp.f.StartTime) {
-		s.flushedFiles[l].Span.EndKey = span.EndKey
-		s.flushedFiles[l].EntryCounts.Add(resp.f.EntryCounts)
-		s.stats.spanGrows++
-	} else {
-		f := resp.f
-		f.Path = s.outName
-		s.flushedFiles = append(s.flushedFiles, f)
-	}
-	s.flushedRevStart.Forward(resp.revStart)
-	s.completedSpans += resp.completedSpans
-	s.flushedSize += int64(len(resp.sst))
-
-	// If our accumulated SST is now big enough, and we are positioned at the end
-	// of a range flush it.
-	if s.flushedSize > targetFileSize.Get(s.conf.settings) && resp.atKeyBoundary {
-		s.stats.sizeFlushes++
-		log.VEventf(ctx, 2, "flushing backup file %s with size %d", s.outName, s.flushedSize)
-		if err := s.flushFile(ctx); err != nil {
-			return err
-		}
-	} else {
-		log.VEventf(ctx, 3, "continuing to write to backup file %s of size %d", s.outName, s.flushedSize)
-	}
-	return nil
-}
-
-func generateUniqueSSTName(nodeID base.SQLInstanceID) string {
-	// The data/ prefix, including a /, is intended to group SSTs in most of the
-	// common file/bucket browse UIs.
-	return fmt.Sprintf("data/%d.sst", builtins.GenerateUniqueInt(nodeID))
 }
 
 func init() {

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -9058,9 +9058,9 @@ func TestBackupMemMonitorSSTSinkQueueSize(t *testing.T) {
 		InitManualReplication, params)
 	defer cleanup()
 
-	// Run a backup and expect the Grow() for the sstSink to return a memory error
+	// Run a backup and expect the Grow() for the fileSSTSink to return a memory error
 	// since the default queue byte size is 16MiB.
-	sqlDB.ExpectErr(t, "failed to reserve memory for sstSink queue", `BACKUP INTO 'nodelocal://0/foo'`)
+	sqlDB.ExpectErr(t, "failed to reserve memory for fileSSTSink queue", `BACKUP INTO 'nodelocal://0/foo'`)
 
 	// Reduce the queue byte size cluster setting.
 	sqlDB.Exec(t, `SET CLUSTER SETTING bulkio.backup.merge_file_buffer_size = '13MiB'`)

--- a/pkg/ccl/backupccl/file_sst_sink.go
+++ b/pkg/ccl/backupccl/file_sst_sink.go
@@ -1,0 +1,329 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package backupccl
+
+import (
+	"context"
+	"fmt"
+	io "io"
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
+	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	hlc "github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/errors"
+	gogotypes "github.com/gogo/protobuf/types"
+	"github.com/kr/pretty"
+)
+
+type sstSinkConf struct {
+	progCh   chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress
+	enc      *roachpb.FileEncryptionOptions
+	id       base.SQLInstanceID
+	settings *settings.Values
+}
+
+type fileSSTSink struct {
+	dest cloud.ExternalStorage
+	conf sstSinkConf
+
+	queue []exportedSpan
+	// queueCap is the maximum byte size that the queue can grow to.
+	queueCap int64
+	// queueSize is the current byte size of the queue.
+	queueSize int
+
+	sst     storage.SSTWriter
+	ctx     context.Context
+	cancel  func()
+	out     io.WriteCloser
+	outName string
+
+	flushedFiles    []BackupManifest_File
+	flushedSize     int64
+	flushedRevStart hlc.Timestamp
+	completedSpans  int32
+
+	stats struct {
+		files       int
+		flushes     int
+		oooFlushes  int
+		sizeFlushes int
+		spanGrows   int
+	}
+
+	memAcc struct {
+		ba            *mon.BoundAccount
+		reservedBytes int64
+	}
+}
+
+func makeFileSSTSink(
+	ctx context.Context, conf sstSinkConf, dest cloud.ExternalStorage, backupMem *mon.BoundAccount,
+) (*fileSSTSink, error) {
+	s := &fileSSTSink{conf: conf, dest: dest}
+	s.memAcc.ba = backupMem
+
+	// Reserve memory for the file buffer. Incrementally reserve memory in chunks
+	// upto a maximum of the `smallFileBuffer` cluster setting value. If we fail
+	// to grow the bound account at any stage, use the buffer size we arrived at
+	// prior to the error.
+	incrementSize := int64(32 << 20)
+	maxSize := smallFileBuffer.Get(s.conf.settings)
+	for {
+		if s.queueCap >= maxSize {
+			break
+		}
+
+		if incrementSize > maxSize-s.queueCap {
+			incrementSize = maxSize - s.queueCap
+		}
+
+		if err := s.memAcc.ba.Grow(ctx, incrementSize); err != nil {
+			log.Infof(ctx, "failed to grow file queue by %d bytes, running backup with queue size %d bytes: %+v", incrementSize, s.queueCap, err)
+			break
+		}
+		s.queueCap += incrementSize
+	}
+	if s.queueCap == 0 {
+		return nil, errors.New("failed to reserve memory for fileSSTSink queue")
+	}
+
+	s.memAcc.reservedBytes += s.queueCap
+	return s, nil
+}
+
+func (s *fileSSTSink) Close() error {
+	if log.V(1) && s.ctx != nil {
+		log.Infof(s.ctx, "backup sst sink recv'd %d files, wrote %d (%d due to size, %d due to re-ordering), %d recv files extended prior span",
+			s.stats.files, s.stats.flushes, s.stats.sizeFlushes, s.stats.oooFlushes, s.stats.spanGrows)
+	}
+	if s.cancel != nil {
+		s.cancel()
+	}
+
+	// Release the memory reserved for the file buffer.
+	s.memAcc.ba.Shrink(s.ctx, s.memAcc.reservedBytes)
+	s.memAcc.reservedBytes = 0
+	if s.out != nil {
+		return s.out.Close()
+	}
+	return nil
+}
+
+// push pushes one returned backup file into the sink. Returned files can arrive
+// out of order, but must be written to an underlying file in-order or else a
+// new underlying file has to be opened. The queue allows buffering up files and
+// sorting them before pushing them to the underlying file to try to avoid this.
+// When the queue length or sum of the data sizes in it exceeds thresholds the
+// queue is sorted and the first half is flushed.
+func (s *fileSSTSink) push(ctx context.Context, resp exportedSpan) error {
+	s.queue = append(s.queue, resp)
+	s.queueSize += len(resp.dataSST)
+
+	if s.queueSize >= int(s.queueCap) {
+		sort.Slice(s.queue, func(i, j int) bool {
+			return s.queue[i].metadata.Span.Key.Compare(s.queue[j].metadata.Span.Key) < 0
+		})
+
+		// Drain the first half.
+		drain := len(s.queue) / 2
+		if drain < 1 {
+			drain = 1
+		}
+		for i := range s.queue[:drain] {
+			if err := s.write(ctx, s.queue[i]); err != nil {
+				return err
+			}
+			s.queueSize -= len(s.queue[i].dataSST)
+		}
+
+		// Shift down the remainder of the queue and slice off the tail.
+		copy(s.queue, s.queue[drain:])
+		s.queue = s.queue[:len(s.queue)-drain]
+	}
+	return nil
+}
+
+func (s *fileSSTSink) flush(ctx context.Context) error {
+	for i := range s.queue {
+		if err := s.write(ctx, s.queue[i]); err != nil {
+			return err
+		}
+	}
+	s.queue = nil
+	return s.flushFile(ctx)
+}
+
+func (s *fileSSTSink) flushFile(ctx context.Context) error {
+	if s.out == nil {
+		return nil
+	}
+	s.stats.flushes++
+
+	if err := s.sst.Finish(); err != nil {
+		return err
+	}
+	if err := s.out.Close(); err != nil {
+		log.Warningf(ctx, "failed to close write in fileSSTSink: % #v", pretty.Formatter(err))
+		return errors.Wrap(err, "writing SST")
+	}
+	s.outName = ""
+	s.out = nil
+
+	progDetails := BackupManifest_Progress{
+		RevStartTime:   s.flushedRevStart,
+		Files:          s.flushedFiles,
+		CompletedSpans: s.completedSpans,
+	}
+	var prog execinfrapb.RemoteProducerMetadata_BulkProcessorProgress
+	details, err := gogotypes.MarshalAny(&progDetails)
+	if err != nil {
+		return err
+	}
+	prog.ProgressDetails = *details
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case s.conf.progCh <- prog:
+	}
+
+	s.flushedFiles = nil
+	s.flushedSize = 0
+	s.flushedRevStart.Reset()
+	s.completedSpans = 0
+
+	return nil
+}
+
+func (s *fileSSTSink) open(ctx context.Context) error {
+	s.outName = generateUniqueSSTName(s.conf.id)
+	if s.ctx == nil {
+		s.ctx, s.cancel = context.WithCancel(ctx)
+	}
+	w, err := s.dest.Writer(s.ctx, s.outName)
+	if err != nil {
+		return err
+	}
+	if s.conf.enc != nil {
+		var err error
+		w, err = storageccl.EncryptingWriter(w, s.conf.enc.Key)
+		if err != nil {
+			return err
+		}
+	}
+	s.out = w
+	s.sst = storage.MakeBackupSSTWriter(ctx, s.dest.Settings(), s.out)
+
+	return nil
+}
+
+func (s *fileSSTSink) write(ctx context.Context, resp exportedSpan) error {
+	s.stats.files++
+
+	span := resp.metadata.Span
+
+	// If this span starts before the last buffered span ended, we need to flush
+	// since it overlaps but SSTWriter demands writes in-order.
+	if len(s.flushedFiles) > 0 {
+		last := s.flushedFiles[len(s.flushedFiles)-1].Span.EndKey
+		if span.Key.Compare(last) < 0 {
+			log.VEventf(ctx, 1, "flushing backup file %s of size %d because span %s cannot append before %s",
+				s.outName, s.flushedSize, span, last,
+			)
+			s.stats.oooFlushes++
+			if err := s.flushFile(ctx); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Initialize the writer if needed.
+	if s.out == nil {
+		if err := s.open(ctx); err != nil {
+			return err
+		}
+	}
+
+	log.VEventf(ctx, 2, "writing %s to backup file %s", span, s.outName)
+
+	// Copy SST content.
+	sst, err := storage.NewMemSSTIterator(resp.dataSST, false)
+	if err != nil {
+		return err
+	}
+	defer sst.Close()
+
+	sst.SeekGE(storage.MVCCKey{Key: keys.MinKey})
+	for {
+		if valid, err := sst.Valid(); !valid || err != nil {
+			if err != nil {
+				return err
+			}
+			break
+		}
+		k := sst.UnsafeKey()
+		if k.Timestamp.IsEmpty() {
+			if err := s.sst.PutUnversioned(k.Key, sst.UnsafeValue()); err != nil {
+				return err
+			}
+		} else {
+			if err := s.sst.PutRawMVCC(sst.UnsafeKey(), sst.UnsafeValue()); err != nil {
+				return err
+			}
+		}
+		sst.Next()
+	}
+
+	// If this span extended the last span added -- that is, picked up where it
+	// ended and has the same time-bounds -- then we can simply extend that span
+	// and add to its entry counts. Otherwise we need to record it separately.
+	if l := len(s.flushedFiles) - 1; l > 0 && s.flushedFiles[l].Span.EndKey.Equal(span.Key) &&
+		s.flushedFiles[l].EndTime.EqOrdering(resp.metadata.EndTime) &&
+		s.flushedFiles[l].StartTime.EqOrdering(resp.metadata.StartTime) {
+		s.flushedFiles[l].Span.EndKey = span.EndKey
+		s.flushedFiles[l].EntryCounts.Add(resp.metadata.EntryCounts)
+		s.stats.spanGrows++
+	} else {
+		f := resp.metadata
+		f.Path = s.outName
+		s.flushedFiles = append(s.flushedFiles, f)
+	}
+	s.flushedRevStart.Forward(resp.revStart)
+	s.completedSpans += resp.completedSpans
+	s.flushedSize += int64(len(resp.dataSST))
+
+	// If our accumulated SST is now big enough, and we are positioned at the end
+	// of a range flush it.
+	if s.flushedSize > targetFileSize.Get(s.conf.settings) && resp.atKeyBoundary {
+		s.stats.sizeFlushes++
+		log.VEventf(ctx, 2, "flushing backup file %s with size %d", s.outName, s.flushedSize)
+		if err := s.flushFile(ctx); err != nil {
+			return err
+		}
+	} else {
+		log.VEventf(ctx, 3, "continuing to write to backup file %s of size %d", s.outName, s.flushedSize)
+	}
+	return nil
+}
+
+func generateUniqueSSTName(nodeID base.SQLInstanceID) string {
+	// The data/ prefix, including a /, is intended to group SSTs in most of the
+	// common file/bucket browse UIs.
+	return fmt.Sprintf("data/%d.sst", builtins.GenerateUniqueInt(nodeID))
+}


### PR DESCRIPTION
Release note: None

Renames a few things, and moves the sstsink into its own file.