### PR TITLE
/schemachange/random-load: upload libGEOS library

### DIFF
--- a/pkg/cmd/roachtest/tests/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/tests/schemachange_random_load.go
@@ -136,6 +136,9 @@ func runSchemaChangeRandomLoad(
 	t.Status("copying binaries")
 	c.Put(ctx, t.Cockroach(), "./cockroach", roachNodes)
 	c.Put(ctx, t.DeprecatedWorkload(), "./workload", loadNode)
+	if err := c.PutLibraries(ctx, "./lib"); err != nil {
+		t.Fatal(err)
+	}
 
 	t.Status("starting cockroach nodes")
 	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), roachNodes)


### PR DESCRIPTION
Fixes: #80964

Previously, the libGEOS was not uploaded inside the
schemachange/random-load workload, which could lead to
failures once geometric functionality was used. To
address this, this patch will update workload to upload
the any libraries needed by cockroach like libGEOS.

Release note: None