### PR TITLE
build: remove remnants of pkg/ui/dist_vendor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1442,7 +1442,6 @@ ui-clean: ## Remove build artifacts.
 	$(info $(yellow)NOTE: consider using `./dev ui clean` instead of `make ui-clean`$(term-reset))
 	find pkg/ui/distccl/assets pkg/ui/distoss/assets -mindepth 1 -not -name .gitkeep -delete
 	rm -rf pkg/ui/assets.ccl.installed pkg/ui/assets.oss.installed
-	rm -rf pkg/ui/dist_vendor/*
 	rm -f $(UI_PROTOS_CCL) $(UI_PROTOS_OSS)
 	rm -f pkg/ui/workspaces/db-console/*manifest.json
 	rm -rf pkg/ui/workspaces/cluster-ui/dist

--- a/pkg/ui/BUILD.bazel
+++ b/pkg/ui/BUILD.bazel
@@ -5,16 +5,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "ui",
     srcs = ["ui.go"],
-    # keep
-    embedsrcs = select({
-        "//pkg/ui:with_ui": [
-            "dist_vendor/list.min.js",
-            "dist_vendor/.gitkeep",
-        ],
-        "//conditions:default": [
-            "dist_vendor/.gitkeep",
-        ],
-    }),
     importpath = "github.com/cockroachdb/cockroach/pkg/ui",
     visibility = ["//visibility:public"],
     deps = [
@@ -53,14 +43,6 @@ Binary built without web UI.
 EOF
 """,
     visibility = ["//pkg/ui:__subpackages__"],
-)
-
-genrule(
-    name = "listjs",
-    srcs = ["@npm//:node_modules/list.js/dist/list.min.js"],
-    outs = ["dist_vendor/list.min.js"],
-    cmd = "cp ./$(location @npm//:node_modules/list.js/dist/list.min.js) $@",
-    tools = ["@npm//list.js"],
 )
 
 test_suite(

--- a/pkg/ui/workspaces/db-console/webpack.app.js
+++ b/pkg/ui/workspaces/db-console/webpack.app.js
@@ -53,14 +53,6 @@ module.exports = (env, argv) => {
     new RemoveBrokenDependenciesPlugin(),
     new CopyWebpackPlugin([
       { from: path.resolve(__dirname, "favicon.ico"), to: "favicon.ico" },
-      {
-        from: path.resolve(
-          !isBazelBuild ? __dirname : "",
-          !isBazelBuild ? "../.." : "",
-          "node_modules/list.js/dist/list.min.js",
-        ),
-        to: path.resolve(__dirname, "../../dist_vendor/list.min.js"),
-      },
     ]),
     // use WebpackBar instead of webpack dashboard to fit multiple webpack dev server outputs (db-console and cluster-ui)
     new WebpackBar({


### PR DESCRIPTION
The pkg/ui/dist_vendor tree was originally used as part of the standalone /debug/tracez page [1], and that page was integrated into the main React-based db-console app shortly after its introduction [2]. A few remnants of that page remained in the build system since, but they were unused. Remove remaining references to pkg/ui/dist_vendor to simplify the build.

[1] f87695ef74 (tracing: add /debug/tracez rendering the active spans, 2021-12-21)
[2] 97278c6de3 (ui: switch the /debug/tracez page to React, 2022-01-14)

Release note: None