### PR TITLE
bulkio: remove ieFactory from IndexBackfillPlanner and IndexBackfillerMergePlanner

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -899,7 +899,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 
 	distSQLServer.ServerConfig.SessionBoundInternalExecutorFactory = ieFactory
 	jobRegistry.SetSessionBoundInternalExecutorFactory(ieFactory)
-	execCfg.IndexBackfiller = sql.NewIndexBackfiller(execCfg, ieFactory)
+	execCfg.IndexBackfiller = sql.NewIndexBackfiller(execCfg)
 	execCfg.IndexValidator = scdeps.NewIndexValidator(
 		execCfg.DB,
 		execCfg.Codec,

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -2694,7 +2694,7 @@ func (sc *SchemaChanger) distIndexMerge(
 	}
 
 	// TODO(rui): these can be initialized along with other new schema changer dependencies.
-	planner := NewIndexBackfillerMergePlanner(sc.execCfg, sc.execCfg.InternalExecutorFactory)
+	planner := NewIndexBackfillerMergePlanner(sc.execCfg)
 	rc := func(ctx context.Context, spans []roachpb.Span) (int, error) {
 		return numRangesInSpans(ctx, sc.db, sc.distSQLPlanner, spans)
 	}

--- a/pkg/sql/index_backfiller.go
+++ b/pkg/sql/index_backfiller.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
@@ -30,15 +29,12 @@ import (
 // IndexBackfillPlanner holds dependencies for an index backfiller
 // for use in the declarative schema changer.
 type IndexBackfillPlanner struct {
-	execCfg   *ExecutorConfig
-	ieFactory sqlutil.SessionBoundInternalExecutorFactory
+	execCfg *ExecutorConfig
 }
 
 // NewIndexBackfiller creates a new IndexBackfillPlanner.
-func NewIndexBackfiller(
-	execCfg *ExecutorConfig, ieFactory sqlutil.SessionBoundInternalExecutorFactory,
-) *IndexBackfillPlanner {
-	return &IndexBackfillPlanner{execCfg: execCfg, ieFactory: ieFactory}
+func NewIndexBackfiller(execCfg *ExecutorConfig) *IndexBackfillPlanner {
+	return &IndexBackfillPlanner{execCfg: execCfg}
 }
 
 // MaybePrepareDestIndexesForBackfill is part of the scexec.Backfiller interface.

--- a/pkg/sql/mvcc_backfiller.go
+++ b/pkg/sql/mvcc_backfiller.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scdeps"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
@@ -36,15 +35,12 @@ import (
 // IndexBackfillerMergePlanner holds dependencies for the merge step of the
 // index backfiller.
 type IndexBackfillerMergePlanner struct {
-	execCfg   *ExecutorConfig
-	ieFactory sqlutil.SessionBoundInternalExecutorFactory
+	execCfg *ExecutorConfig
 }
 
 // NewIndexBackfillerMergePlanner creates a new IndexBackfillerMergePlanner.
-func NewIndexBackfillerMergePlanner(
-	execCfg *ExecutorConfig, ieFactory sqlutil.SessionBoundInternalExecutorFactory,
-) *IndexBackfillerMergePlanner {
-	return &IndexBackfillerMergePlanner{execCfg: execCfg, ieFactory: ieFactory}
+func NewIndexBackfillerMergePlanner(execCfg *ExecutorConfig) *IndexBackfillerMergePlanner {
+	return &IndexBackfillerMergePlanner{execCfg: execCfg}
 }
 
 func (im *IndexBackfillerMergePlanner) plan(


### PR DESCRIPTION
The `ieFactory` field from both the `IndexBackfillPlanner` and
`IndexBackfillerMergePlanner` is never used. This commit is to remove it
from these 2 data structures, and the initializaton methods.

Release note: None