### PR TITLE
ui: Fix the custom time picker reverting to the previously selected time

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/dateRange/dateRange.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/dateRange/dateRange.tsx
@@ -17,6 +17,7 @@ import { Button } from "src/button";
 import { Text, TextTypes } from "src/text";
 
 import styles from "./dateRange.module.scss";
+import { usePrevious } from "../util/hooks";
 
 const cx = classNames.bind(styles);
 
@@ -51,14 +52,26 @@ export function DateRangeMenu({
     startInit || moment.utc(),
   );
   const [endMoment, setEndMoment] = useState<Moment>(endInit || moment.utc());
+  const prevStartInit = usePrevious(startInit);
+  const prevEndInit = usePrevious(endInit);
 
   useEffect(() => {
-    setStartMoment(startInit);
-  }, [startInit]);
+    // .unix() is needed compare the actual time value instead of referential equality of the Moment object.
+    // Otherwise, triggering `setStartMoment` unnecessarily can cause a bug where the selection jumps back to the
+    // currently selected time while the user is in the middle of making a different selection.
+    if (startInit?.unix() != prevStartInit?.unix()) {
+      setStartMoment(startInit);
+    }
+  }, [startInit, prevStartInit]);
 
   useEffect(() => {
-    setEndMoment(endInit);
-  }, [endInit]);
+    // .unix() is needed compare the actual time value instead of referential equality of the Moment object.
+    // Otherwise, triggering `setEndMoment` unnecessarily can cause a bug where the selection jumps back to the
+    // currently selected time while the user is in the middle of making a different selection.
+    if (endInit?.unix() != prevEndInit?.unix()) {
+      setEndMoment(endInit);
+    }
+  }, [endInit, prevEndInit]);
 
   const onChangeStart = (m?: Moment) => {
     m && setStartMoment(m);

--- a/pkg/ui/workspaces/cluster-ui/src/util/hooks.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/hooks.ts
@@ -1,0 +1,19 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { useEffect, useRef } from "react";
+
+export const usePrevious = <T>(value: T): T | undefined => {
+  const ref = useRef<T>();
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+};


### PR DESCRIPTION
This commit fixes a bug introduced by
https://github.com/cockroachdb/cockroach/pull/80660; where if a user selects a
different time in the custom time selection, the component may revert to the
currently select time.

Before:

https://user-images.githubusercontent.com/91907326/166824410-5ab5e6f1-51ed-44a2-afe4-fffdfc8f955a.mov

After:

https://user-images.githubusercontent.com/91907326/166831351-ae0deee5-a116-4ed1-b2ca-c85160339bd3.mov


Release note: None

Release justification: Category 2, UI bug fix