### PR TITLE
sql: optimize the common case where no cursor exists

### DIFF
--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -316,7 +316,7 @@ func (ex *connExecutor) execBind(
 			return retErr(pgerror.Newf(
 				pgcode.DuplicateCursor, "portal %q already exists", portalName))
 		}
-		if _, err := ex.getCursorAccessor().getCursor(portalName); err == nil {
+		if cursor := ex.getCursorAccessor().getCursor(portalName); cursor != nil {
 			return retErr(pgerror.Newf(
 				pgcode.DuplicateCursor, "portal %q already exists as cursor", portalName))
 		}
@@ -472,7 +472,7 @@ func (ex *connExecutor) addPortal(
 	if _, ok := ex.extraTxnState.prepStmtsNamespace.portals[portalName]; ok {
 		panic(errors.AssertionFailedf("portal already exists: %q", portalName))
 	}
-	if _, err := ex.getCursorAccessor().getCursor(portalName); err == nil {
+	if cursor := ex.getCursorAccessor().getCursor(portalName); cursor != nil {
 		panic(errors.AssertionFailedf("portal already exists as cursor: %q", portalName))
 	}
 

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -50,7 +50,7 @@ func (p *planner) DeclareCursor(ctx context.Context, s *tree.DeclareCursor) (pla
 
 			ie := p.ExecCfg().InternalExecutorFactory(ctx, p.SessionData())
 			cursorName := s.Name.String()
-			if cursor, _ := p.sqlCursors.getCursor(cursorName); cursor != nil {
+			if cursor := p.sqlCursors.getCursor(cursorName); cursor != nil {
 				return nil, pgerror.Newf(pgcode.DuplicateCursor, "cursor %q already exists", cursorName)
 			}
 
@@ -119,9 +119,12 @@ var errBackwardScan = pgerror.Newf(pgcode.ObjectNotInPrerequisiteState, "cursor 
 func (p *planner) FetchCursor(
 	_ context.Context, s *tree.CursorStmt, isMove bool,
 ) (planNode, error) {
-	cursor, err := p.sqlCursors.getCursor(s.Name.String())
-	if err != nil {
-		return nil, err
+	cursorName := s.Name.String()
+	cursor := p.sqlCursors.getCursor(cursorName)
+	if cursor == nil {
+		return nil, pgerror.Newf(
+			pgcode.InvalidCursorName, "cursor %q does not exist", cursorName,
+		)
 	}
 	if s.Count < 0 || s.FetchType == tree.FetchBackwardAll {
 		return nil, errBackwardScan
@@ -274,9 +277,9 @@ type sqlCursors interface {
 	// closeCursor closes the named cursor, returning an error if that cursor
 	// didn't exist in the set.
 	closeCursor(string) error
-	// getCursor returns the named cursor, returning an error if that cursor
+	// getCursor returns the named cursor, returning nil if that cursor
 	// didn't exist in the set.
-	getCursor(string) (*sqlCursor, error)
+	getCursor(string) *sqlCursor
 	// addCursor adds a new cursor with the given name to the set, returning an
 	// error if the cursor already existed in the set.
 	addCursor(string, *sqlCursor) error
@@ -306,12 +309,8 @@ func (c *cursorMap) closeCursor(s string) error {
 	return err
 }
 
-func (c *cursorMap) getCursor(s string) (*sqlCursor, error) {
-	cursor, ok := c.cursors[s]
-	if !ok {
-		return nil, pgerror.Newf(pgcode.InvalidCursorName, "cursor %q does not exist", s)
-	}
-	return cursor, nil
+func (c *cursorMap) getCursor(s string) *sqlCursor {
+	return c.cursors[s]
 }
 
 func (c *cursorMap) addCursor(s string, cursor *sqlCursor) error {
@@ -343,7 +342,7 @@ func (c connExCursorAccessor) closeCursor(s string) error {
 	return c.ex.extraTxnState.sqlCursors.closeCursor(s)
 }
 
-func (c connExCursorAccessor) getCursor(s string) (*sqlCursor, error) {
+func (c connExCursorAccessor) getCursor(s string) *sqlCursor {
 	return c.ex.extraTxnState.sqlCursors.getCursor(s)
 }
 


### PR DESCRIPTION
This was showing up big time in a profile I was looking at which was pretty
much just a KV0 workload.

<img width="1636" alt="Screen Shot 2022-05-04 at 5 35 25 PM" src="https://user-images.githubusercontent.com/1839234/166830954-163c7ce3-5d5f-4e78-9646-aab6e29e1769.png">

Release note: None