### PR TITLE
sql: support expression indexes in SHOW EXPERIMENTAL_FINGERPRINTS

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/show_fingerprints
+++ b/pkg/sql/logictest/testdata/logic_test/show_fingerprints
@@ -138,3 +138,16 @@ t_pkey  1205834892498753533
 
 statement ok
 COMMIT
+
+statement ok
+CREATE TABLE t_w_expr_index (a INT PRIMARY KEY, b INT, c INT AS (b + 42) STORED, INDEX (c), INDEX ((b+42)))
+
+statement ok
+INSERT INTO t_w_expr_index VALUES (1, 1), (2, 2), (3, 3)
+
+query TT
+SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE t_w_expr_index
+----
+t_w_expr_index_pkey     -3347212893095932527
+t_w_expr_index_c_idx    -2777058403611971387
+t_w_expr_index_expr_idx -2777058403611971387


### PR DESCRIPTION
Previously, SHOW EXPERIMENTAL_FINGERPRINTS would fail with an error as
it tried to directly select the 'crdb_internal_idx_expr' column.

Now, we construct a selection expression using the computed
expression.

Note that the current implementation of experimental_fingerprints
still doesn't work for inverted indexes. Tools like those
outlined in https://github.com/cockroachdb/cockroach/issues/59549 would provide a more generic way forward.

Release note (sql change): SHOW EXPERIMENTAL_FINGERPRINTS now supports
table with expression indexes.