### PR TITLE
server: collect in-memory historical hot ranges

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -3541,6 +3541,8 @@ HotRange message describes a single hot range, ie its QPS, node ID it belongs to
 | leaseholder_node_id | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  | leaseholder_node_id indicates the Node ID that is the current leaseholder for the given range. | [reserved](#support-status) |
 | schema_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | schema_name provides the name of schema (if exists) for table in current range. | [reserved](#support-status) |
 | store_id | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  | store_id indicates the Store ID where range is stored. | [reserved](#support-status) |
+| start_key | [bytes](#cockroach.server.serverpb.HotRangesResponseV2-bytes) |  | start_key is the first key which may be contained by this range. | [reserved](#support-status) |
+| end_key | [bytes](#cockroach.server.serverpb.HotRangesResponseV2-bytes) |  | end_key marks the end of the range's possible keys. | [reserved](#support-status) |
 
 
 
@@ -3555,6 +3557,96 @@ HotRange message describes a single hot range, ie its QPS, node ID it belongs to
 | ----- | ---- | ----- | ----------- | -------------- |
 | key | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  |  |  |
 | value | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  |  |  |
+
+
+
+
+
+
+## HistoricalHotRanges
+
+`GET /_status/histhotranges`
+
+
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+
+
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| samples | [HistoricalHotRangesResponse.HHRSample](#cockroach.server.serverpb.HistoricalHotRangesResponse-cockroach.server.serverpb.HistoricalHotRangesResponse.HHRSample) | repeated |  | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.HistoricalHotRangesResponse-cockroach.server.serverpb.HistoricalHotRangesResponse.HHRSample"></a>
+#### HistoricalHotRangesResponse.HHRSample
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| hotranges | [HistoricalHotRangesResponse.HHRSample.HotRange](#cockroach.server.serverpb.HistoricalHotRangesResponse-cockroach.server.serverpb.HistoricalHotRangesResponse.HHRSample.HotRange) | repeated |  | [reserved](#support-status) |
+| timestamp | [google.protobuf.Timestamp](#cockroach.server.serverpb.HistoricalHotRangesResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.HistoricalHotRangesResponse-cockroach.server.serverpb.HistoricalHotRangesResponse.HHRSample.HotRange"></a>
+#### HistoricalHotRangesResponse.HHRSample.HotRange
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| range_id | [int32](#cockroach.server.serverpb.HistoricalHotRangesResponse-int32) |  |  | [reserved](#support-status) |
+| replica_id | [int32](#cockroach.server.serverpb.HistoricalHotRangesResponse-int32) |  |  | [reserved](#support-status) |
+| qps | [double](#cockroach.server.serverpb.HistoricalHotRangesResponse-double) |  |  | [reserved](#support-status) |
+| start_key | [string](#cockroach.server.serverpb.HistoricalHotRangesResponse-string) |  |  | [reserved](#support-status) |
+| end_key | [string](#cockroach.server.serverpb.HistoricalHotRangesResponse-string) |  |  | [reserved](#support-status) |
+| node_ids | [int32](#cockroach.server.serverpb.HistoricalHotRangesResponse-int32) | repeated |  | [reserved](#support-status) |
+| store_ids | [int32](#cockroach.server.serverpb.HistoricalHotRangesResponse-int32) | repeated |  | [reserved](#support-status) |
+| schema | [HistoricalHotRangesResponse.HHRSample.HotRange.Schema](#cockroach.server.serverpb.HistoricalHotRangesResponse-cockroach.server.serverpb.HistoricalHotRangesResponse.HHRSample.HotRange.Schema) | repeated |  | [reserved](#support-status) |
+| locality | [string](#cockroach.server.serverpb.HistoricalHotRangesResponse-string) |  |  | [reserved](#support-status) |
+| key_bytes | [sfixed64](#cockroach.server.serverpb.HistoricalHotRangesResponse-sfixed64) |  |  | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.HistoricalHotRangesResponse-cockroach.server.serverpb.HistoricalHotRangesResponse.HHRSample.HotRange.Schema"></a>
+#### HistoricalHotRangesResponse.HHRSample.HotRange.Schema
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| database | [string](#cockroach.server.serverpb.HistoricalHotRangesResponse-string) |  |  | [reserved](#support-status) |
+| tables | [string](#cockroach.server.serverpb.HistoricalHotRangesResponse-string) | repeated |  | [reserved](#support-status) |
 
 
 

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "grpc_gateway.go",
         "grpc_server.go",
         "gzip_response_writer.go",
+        "histhotrangesworker.go",
         "import_ts.go",
         "index_usage_stats.go",
         "init.go",

--- a/pkg/server/histhotrangesworker.go
+++ b/pkg/server/histhotrangesworker.go
@@ -1,0 +1,85 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+var cache = serverpb.HistoricalHotRangesResponse{Samples: nil}
+
+// GetHistoricalHotRangesCached returns cached historical hot ranges
+func GetHistoricalHotRangesCached() (*serverpb.HistoricalHotRangesResponse, error) {
+	if len(cache.Samples) == 0 {
+		return nil, fmt.Errorf("no historical hot ranges available yet")
+	}
+	return &cache, nil
+}
+
+// collectHistoricalHotRanges periodically (once per 15 seconds) queries hot ranges and preserves to local cache
+func (s *Server) collectHistoricalHotRanges() error {
+	ctx := s.AnnotateCtx(context.Background())
+	ticker := time.NewTicker(15 * time.Second)
+	return s.stopper.RunAsyncTask(ctx, "collect-historical-hot-ranges", func(ctx context.Context) {
+		for {
+			select {
+			case t := <-ticker.C:
+				// TODO: request multiple times because of pagination
+				resp, err := s.status.HotRangesV2(ctx, &serverpb.HotRangesRequest{})
+				if err != nil {
+					log.Warningf(ctx, "status.HotRangesV2 request failed: %+v", err)
+				}
+				hhr := make([]*serverpb.HistoricalHotRangesResponse_HHRSample_HotRange, len(resp.Ranges))
+				for i, hr := range resp.Ranges {
+					hhr[i] = &serverpb.HistoricalHotRangesResponse_HHRSample_HotRange{
+						RangeID:   hr.RangeID,
+						ReplicaId: hr.LeaseholderNodeID,
+						Qps:       hr.QPS,
+						StartKey:  hr.StartKey.String(),
+						EndKey:    hr.EndKey.String(),
+						NodeIds:   hr.ReplicaNodeIds,
+						StoreIds:  []roachpb.StoreID{hr.StoreID},
+						Schema: []*serverpb.HistoricalHotRangesResponse_HHRSample_HotRange_Schema{
+							{
+								Database: hr.DatabaseName,
+								Tables:   []string{hr.TableName},
+							},
+						},
+						Locality: "", // it can be computed on front-end side
+						KeyBytes: 0,  // TODO: don't know how to get this info
+					}
+				}
+				sample := &serverpb.HistoricalHotRangesResponse_HHRSample{
+					Hotranges: hhr,
+				}
+				const samplesPerTwoWeeks = 1344
+				// clean up old cached data to keep only most recent records for "2 weeks" time window
+				if len(cache.Samples) >= samplesPerTwoWeeks {
+					cache.Samples = cache.Samples[len(cache.Samples)-samplesPerTwoWeeks+1:]
+				}
+				cache.Samples = append(cache.Samples, sample)
+				// update timestamps to most recent dates, it emulates moving time window.
+				for i := len(cache.Samples) - 1; i >= 0; i-- {
+					cache.Samples[i].Timestamp = t
+					t = t.Add(-15 * time.Minute)
+				}
+			case <-s.stopper.ShouldQuiesce():
+				return
+			}
+		}
+	})
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -73,6 +73,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/goschedstats"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -1212,6 +1213,12 @@ func (s *Server) PreStart(ctx context.Context) error {
 		ctx, keys.SystemSQLCodec, s.st.MakeUpdater(), state.initialSettingsKVs,
 	); err != nil {
 		return errors.Wrap(err, "during initializing settings updater")
+	}
+
+	if envutil.EnvOrDefaultBool("COCKROACH_FAKE_HISTORICAL_HOT_RANGES", false) {
+		if err := s.collectHistoricalHotRanges(); err != nil {
+			return errors.Wrap(err, "during initializing historical hot ranges collector")
+		}
 	}
 
 	// TODO(irfansharif): Let's make this unconditional. We could avoid

--- a/pkg/server/serverpb/status.pb.gw.go
+++ b/pkg/server/serverpb/status.pb.gw.go
@@ -1645,6 +1645,24 @@ func local_request_Status_HotRangesV2_0(ctx context.Context, marshaler runtime.M
 
 }
 
+func request_Status_HistoricalHotRanges_0(ctx context.Context, marshaler runtime.Marshaler, client StatusClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq HistoricalHotRangesRequest
+	var metadata runtime.ServerMetadata
+
+	msg, err := client.HistoricalHotRanges(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Status_HistoricalHotRanges_0(ctx context.Context, marshaler runtime.Marshaler, server StatusServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq HistoricalHotRangesRequest
+	var metadata runtime.ServerMetadata
+
+	msg, err := server.HistoricalHotRanges(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 func request_Status_Range_0(ctx context.Context, marshaler runtime.Marshaler, client StatusClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq RangeRequest
 	var metadata runtime.ServerMetadata
@@ -3221,6 +3239,29 @@ func RegisterStatusHandlerServer(ctx context.Context, mux *runtime.ServeMux, ser
 
 	})
 
+	mux.Handle("GET", pattern_Status_HistoricalHotRanges_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Status_HistoricalHotRanges_0(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Status_HistoricalHotRanges_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	mux.Handle("GET", pattern_Status_Range_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -4356,6 +4397,26 @@ func RegisterStatusHandlerClient(ctx context.Context, mux *runtime.ServeMux, cli
 
 	})
 
+	mux.Handle("GET", pattern_Status_HistoricalHotRanges_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Status_HistoricalHotRanges_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Status_HistoricalHotRanges_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	mux.Handle("GET", pattern_Status_Range_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -4788,6 +4849,8 @@ var (
 
 	pattern_Status_HotRangesV2_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"_status", "v2", "hotranges"}, "", runtime.AssumeColonVerbOpt(true)))
 
+	pattern_Status_HistoricalHotRanges_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"_status", "histhotranges"}, "", runtime.AssumeColonVerbOpt(true)))
+
 	pattern_Status_Range_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"_status", "range", "range_id"}, "", runtime.AssumeColonVerbOpt(true)))
 
 	pattern_Status_Diagnostics_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"_status", "diagnostics", "node_id"}, "", runtime.AssumeColonVerbOpt(true)))
@@ -4893,6 +4956,8 @@ var (
 	forward_Status_HotRanges_0 = runtime.ForwardResponseMessage
 
 	forward_Status_HotRangesV2_0 = runtime.ForwardResponseMessage
+
+	forward_Status_HistoricalHotRanges_0 = runtime.ForwardResponseMessage
 
 	forward_Status_Range_0 = runtime.ForwardResponseMessage
 

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1376,6 +1376,16 @@ message HotRangesResponseV2 {
       (gogoproto.casttype) =
         "github.com/cockroachdb/cockroach/pkg/roachpb.StoreID"
     ];
+    // start_key is the first key which may be contained by this range.
+    bytes start_key = 11 [
+      (gogoproto.customname) = "StartKey",
+      (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.RKey"
+    ];
+    // end_key marks the end of the range's possible keys.
+    bytes end_key = 12 [
+      (gogoproto.customname) = "EndKey",
+      (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.RKey"
+    ];
   }
   // Ranges contain list of hot ranges info that has highest number of QPS.
   repeated HotRange ranges = 1;
@@ -1387,6 +1397,48 @@ message HotRangesResponseV2 {
   ];
   // NextPageToken represents next pagination token to request next slice of data.
   string next_page_token = 3 [(gogoproto.nullable) = true];
+}
+
+message HistoricalHotRangesRequest {}
+
+message HistoricalHotRangesResponse {
+  message HHRSample {
+    message HotRange {
+      message Schema {
+        string database = 1;
+        repeated string tables = 2;
+      }
+      int32 range_id = 1[
+        (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.RangeID",
+        (gogoproto.customname) = "RangeID"
+      ];
+      int32 replica_id = 2[
+        (gogoproto.casttype) =
+          "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"
+      ];
+      double qps = 3;
+      string start_key = 4;
+      string end_key = 5;
+      repeated int32 node_ids = 6[
+        (gogoproto.casttype) =
+          "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"
+      ];
+      repeated int32 store_ids = 7[
+        (gogoproto.casttype) =
+          "github.com/cockroachdb/cockroach/pkg/roachpb.StoreID"
+      ];
+      repeated Schema schema = 8;
+      string locality = 9;
+      sfixed64 key_bytes = 10;
+    }
+    repeated HotRange hotranges = 1;
+    google.protobuf.Timestamp timestamp = 2 [
+      (gogoproto.nullable) = false,
+      (gogoproto.stdtime) = true
+    ];
+  }
+
+  repeated HHRSample samples = 1;
 }
 
 message RangeRequest {
@@ -2086,6 +2138,12 @@ service Status {
     option (google.api.http) = {
       post : "/_status/v2/hotranges"
       body : "*"
+    };
+  }
+
+  rpc HistoricalHotRanges(HistoricalHotRangesRequest) returns (HistoricalHotRangesResponse) {
+    option (google.api.http) = {
+      get : "/_status/histhotranges"
     };
   }
 

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2426,12 +2426,14 @@ func (s *statusServer) HotRangesV2(
 						NodeID:            nodeID,
 						QPS:               r.QueriesPerSecond,
 						TableName:         tableName,
-						SchemaName:        schemaName,
 						DatabaseName:      dbName,
 						IndexName:         indexName,
 						ReplicaNodeIds:    replicaNodeIDs,
 						LeaseholderNodeID: r.LeaseholderNodeID,
+						SchemaName:        schemaName,
 						StoreID:           store.StoreID,
+						StartKey:          r.Desc.StartKey,
+						EndKey:            r.Desc.EndKey,
 					})
 				}
 			}
@@ -2462,6 +2464,12 @@ func (s *statusServer) HotRangesV2(
 	}
 	response.NextPageToken = string(nextBytes)
 	return response, nil
+}
+
+func (s *statusServer) HistoricalHotRanges(
+	ctx context.Context, req *serverpb.HistoricalHotRangesRequest,
+) (*serverpb.HistoricalHotRangesResponse, error) {
+	return GetHistoricalHotRangesCached()
 }
 
 func (s *statusServer) localHotRanges(ctx context.Context) serverpb.HotRangesResponse_NodeResponse {

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
@@ -513,6 +513,11 @@ export default function Debug() {
             url="#/debug/hotranges/local"
             note="#/debug/hotranges/[node_id]"
           />
+          <DebugTableLink
+            name="Historical hot ranges"
+            url="_status/histhotranges"
+            note="_status/histhotranges"
+          />
         </DebugTableRow>
         <DebugTableRow title="Hot Ranges (legacy)">
           <DebugTableLink


### PR DESCRIPTION
This patch adds a lightweight implementation to collect
historical hot ranges in memory to avoid changes in
database schema before it's finalized.
This change mostly needed to provide a source with real
data to build front-end part and figure out the best way
how to visualize hot ranges.

This functionality is protected by env variable to make
sure it is not exposed to production environment.
To start cluster with historical hot ranges collector:
```
COCKROACH_FAKE_HISTORICAL_HOT_RANGES=true cockroach demo movr
```

Release note: None

<img width="1079" alt="Screen Shot 2022-05-05 at 16 45 19" src="https://user-images.githubusercontent.com/3106437/166936813-85be4b43-eb46-4c2a-8cb2-cffc85ece317.png">
