### PR TITLE
ui: fix sizing of table area

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
@@ -49,6 +49,7 @@
 .table-area {
   position: relative;
   overflow-x: scroll;
+  min-height: 480px;
 }
 
 .reset-btn-area {

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -382,7 +382,7 @@ export class TransactionsPage extends React.Component<
     );
 
     return (
-      <div className={cx("table-area")}>
+      <>
         <PageConfig>
           <PageConfigItem>
             <Search
@@ -417,105 +417,107 @@ export class TransactionsPage extends React.Component<
             />
           </PageConfigItem>
         </PageConfig>
-        <Loading
-          loading={!this.props?.data}
-          page={"transactions"}
-          error={this.props?.error}
-          render={() => {
-            const { pagination } = this.state;
-            const transactionsToDisplay: TransactionInfo[] = aggregateAcrossNodeIDs(
-              filteredTransactions,
-              statements,
-            ).map(t => ({
-              stats_data: t.stats_data,
-              node_id: t.node_id,
-              regionNodes: isTenant
-                ? []
-                : generateRegionNode(t, statements, nodeRegions),
-            }));
-            const { current, pageSize } = pagination;
-            const hasData = data.transactions?.length > 0;
-            const isUsedFilter = search?.length > 0;
+        <div className={cx("table-area")}>
+          <Loading
+            loading={!this.props?.data}
+            page={"transactions"}
+            error={this.props?.error}
+            render={() => {
+              const { pagination } = this.state;
+              const transactionsToDisplay: TransactionInfo[] = aggregateAcrossNodeIDs(
+                filteredTransactions,
+                statements,
+              ).map(t => ({
+                stats_data: t.stats_data,
+                node_id: t.node_id,
+                regionNodes: isTenant
+                  ? []
+                  : generateRegionNode(t, statements, nodeRegions),
+              }));
+              const { current, pageSize } = pagination;
+              const hasData = data.transactions?.length > 0;
+              const isUsedFilter = search?.length > 0;
 
-            // Creates a list of all possible columns,
-            // hiding nodeRegions if is not multi-region and
-            // hiding columns that won't be displayed for tenants.
-            const columns = makeTransactionsColumns(
-              transactionsToDisplay,
-              statements,
-              isTenant,
-              search,
-            )
-              .filter(c => !(c.name === "regionNodes" && regions.length < 2))
-              .filter(c => !(isTenant && c.hideIfTenant));
+              // Creates a list of all possible columns,
+              // hiding nodeRegions if is not multi-region and
+              // hiding columns that won't be displayed for tenants.
+              const columns = makeTransactionsColumns(
+                transactionsToDisplay,
+                statements,
+                isTenant,
+                search,
+              )
+                .filter(c => !(c.name === "regionNodes" && regions.length < 2))
+                .filter(c => !(isTenant && c.hideIfTenant));
 
-            // Iterate over all available columns and create list of SelectOptions with initial selection
-            // values based on stored user selections in local storage and default column configs.
-            // Columns that are set to alwaysShow are filtered from the list.
-            const tableColumns = columns
-              .filter(c => !c.alwaysShow)
-              .map(
-                (c): SelectOption => ({
-                  label: getLabel(
-                    c.name as StatisticTableColumnKeys,
-                    "transaction",
-                  ),
-                  value: c.name,
-                  isSelected: isSelectedColumn(userSelectedColumnsToShow, c),
-                }),
+              // Iterate over all available columns and create list of SelectOptions with initial selection
+              // values based on stored user selections in local storage and default column configs.
+              // Columns that are set to alwaysShow are filtered from the list.
+              const tableColumns = columns
+                .filter(c => !c.alwaysShow)
+                .map(
+                  (c): SelectOption => ({
+                    label: getLabel(
+                      c.name as StatisticTableColumnKeys,
+                      "transaction",
+                    ),
+                    value: c.name,
+                    isSelected: isSelectedColumn(userSelectedColumnsToShow, c),
+                  }),
+                );
+
+              // List of all columns that will be displayed based on the column selection.
+              const displayColumns = columns.filter(c =>
+                isSelectedColumn(userSelectedColumnsToShow, c),
               );
 
-            // List of all columns that will be displayed based on the column selection.
-            const displayColumns = columns.filter(c =>
-              isSelectedColumn(userSelectedColumnsToShow, c),
-            );
-
-            return (
-              <>
-                <section className={statisticsClasses.tableContainerClass}>
-                  <ColumnsSelector
-                    options={tableColumns}
-                    onSubmitColumns={onColumnsChange}
+              return (
+                <>
+                  <section className={statisticsClasses.tableContainerClass}>
+                    <ColumnsSelector
+                      options={tableColumns}
+                      onSubmitColumns={onColumnsChange}
+                    />
+                    <TableStatistics
+                      pagination={pagination}
+                      search={search}
+                      totalCount={transactionsToDisplay.length}
+                      arrayItemName="transactions"
+                      activeFilters={activeFilters}
+                      onClearFilters={this.onClearFilters}
+                    />
+                    <TransactionsTable
+                      columns={displayColumns}
+                      transactions={transactionsToDisplay}
+                      sortSetting={sortSetting}
+                      onChangeSortSetting={this.onChangeSortSetting}
+                      pagination={pagination}
+                      renderNoResult={
+                        <EmptyTransactionsPlaceholder
+                          transactionView={TransactionViewType.FINGERPRINTS}
+                          isEmptySearchResults={hasData && isUsedFilter}
+                        />
+                      }
+                    />
+                  </section>
+                  <Pagination
+                    pageSize={pageSize}
+                    current={current}
+                    total={transactionsToDisplay.length}
+                    onChange={this.onChangePage}
                   />
-                  <TableStatistics
-                    pagination={pagination}
-                    search={search}
-                    totalCount={transactionsToDisplay.length}
-                    arrayItemName="transactions"
-                    activeFilters={activeFilters}
-                    onClearFilters={this.onClearFilters}
-                  />
-                  <TransactionsTable
-                    columns={displayColumns}
-                    transactions={transactionsToDisplay}
-                    sortSetting={sortSetting}
-                    onChangeSortSetting={this.onChangeSortSetting}
-                    pagination={pagination}
-                    renderNoResult={
-                      <EmptyTransactionsPlaceholder
-                        transactionView={TransactionViewType.FINGERPRINTS}
-                        isEmptySearchResults={hasData && isUsedFilter}
-                      />
-                    }
-                  />
-                </section>
-                <Pagination
-                  pageSize={pageSize}
-                  current={current}
-                  total={transactionsToDisplay.length}
-                  onChange={this.onChangePage}
-                />
-              </>
-            );
-          }}
-          renderError={() =>
-            SQLActivityError({
-              statsType: "transactions",
-            })
-          }
-        />
-        {longLoadingMessage}
-      </div>
+                </>
+              );
+            }}
+            renderError={() =>
+              SQLActivityError({
+                statsType: "transactions",
+              })
+            }
+          />
+          {longLoadingMessage}
+        </div>
+      </>
     );
   }
 }


### PR DESCRIPTION
Previously, the table area was cutting the columns selector
and filters. This commit adds a min height to the area to
be able to fit.
This commit also removed the page config from inside the
table-area on Transactions page that was not suppose to be there
and was cutting part of the table area.

Fixes #79621

Before
<img width="808" alt="Screen Shot 2022-05-05 at 10 22 14 AM" src="https://user-images.githubusercontent.com/1017486/166944682-db76f5a4-5774-4576-ab91-6f301b04612d.png">

After
<img width="1159" alt="Screen Shot 2022-05-05 at 10 16 39 AM" src="https://user-images.githubusercontent.com/1017486/166944613-457bfdbf-2258-41c5-9cb1-906cbdb4c031.png">


Before
<img width="747" alt="Screen Shot 2022-05-05 at 10 22 25 AM" src="https://user-images.githubusercontent.com/1017486/166944718-2a69c253-1ee4-4079-a7aa-77318bda218a.png">


After
<img width="1000" alt="Screen Shot 2022-05-05 at 10 16 53 AM" src="https://user-images.githubusercontent.com/1017486/166944631-00c67e41-b725-4a24-a158-18d105300151.png">


Before
<img width="467" alt="Screen Shot 2022-05-05 at 10 22 34 AM" src="https://user-images.githubusercontent.com/1017486/166944749-f38da269-cc39-4e04-8b30-cca474878806.png">

After
<img width="528" alt="Screen Shot 2022-05-05 at 10 17 05 AM" src="https://user-images.githubusercontent.com/1017486/166944658-9e90e0f7-d3d9-4e1a-b061-e106e7ad5f1a.png">


Release note (ui change): Fix the size of table area on Statement
and Transactions pages to not cut the columns selector and filters.