### PR TITLE
roachtest: temporarily skip encryption test

### DIFF
--- a/pkg/cmd/roachtest/tests/encryption.go
+++ b/pkg/cmd/roachtest/tests/encryption.go
@@ -87,6 +87,7 @@ func registerEncryption(r registry.Registry) {
 	for _, n := range []int{1} {
 		r.Add(registry.TestSpec{
 			Name:    fmt.Sprintf("encryption/nodes=%d", n),
+			Skip:    "Blocked on #79265.",
 			Owner:   registry.OwnerStorage,
 			Cluster: r.MakeClusterSpec(n),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {


### PR DESCRIPTION
The encryption roachtests are consistently failing, due to the issues
mentioned in #79265.

Mark as skipped until that issue is resolved.

Release note: None.