### PR TITLE
storage,kvserver: Improve SST collision checking for wide SSTs

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -662,147 +662,160 @@ func TestEvalAddSSTable(t *testing.T) {
 	}
 	testutils.RunTrueAndFalse(t, "IngestAsWrites", func(t *testing.T, ingestAsWrites bool) {
 		testutils.RunValues(t, "RewriteConcurrency", []interface{}{0, 8}, func(t *testing.T, c interface{}) {
-			for name, tc := range testcases {
-				t.Run(name, func(t *testing.T) {
-					ctx := context.Background()
-					st := cluster.MakeTestingClusterSettings()
-					batcheval.AddSSTableRewriteConcurrency.Override(ctx, &st.SV, int64(c.(int)))
-					batcheval.AddSSTableRequireAtRequestTimestamp.Override(ctx, &st.SV, tc.requireReqTS)
+			testutils.RunValues(t, "ApproximateDiskBytes", []interface{}{0, 1000000}, func(t *testing.T, approxBytes interface{}) {
+				approxDiskBytes := uint64(approxBytes.(int))
+				for name, tc := range testcases {
+					t.Run(name, func(t *testing.T) {
+						ctx := context.Background()
+						st := cluster.MakeTestingClusterSettings()
+						batcheval.AddSSTableRewriteConcurrency.Override(ctx, &st.SV, int64(c.(int)))
+						batcheval.AddSSTableRequireAtRequestTimestamp.Override(ctx, &st.SV, tc.requireReqTS)
 
-					dir := t.TempDir()
-					engine, err := storage.Open(ctx, storage.Filesystem(filepath.Join(dir, "db")), storage.Settings(st))
-					require.NoError(t, err)
-					defer engine.Close()
-
-					// Write initial data.
-					intentTxn := roachpb.MakeTransaction("intentTxn", nil, 0, hlc.Timestamp{WallTime: intentTS}, 0, 1)
-					b := engine.NewBatch()
-					for i := len(tc.data) - 1; i >= 0; i-- { // reverse, older timestamps first
-						kv := tc.data[i]
-						var txn *roachpb.Transaction
-						if kv.WallTimestamp == intentTS {
-							txn = &intentTxn
-						}
-						require.NoError(t, storage.MVCCPut(ctx, b, nil, kv.Key(), kv.Timestamp(), hlc.ClockTimestamp{}, kv.Value(), txn))
-					}
-					require.NoError(t, b.Commit(false))
-					stats := engineStats(t, engine, 0)
-
-					// Build and add SST.
-					if tc.toReqTS != 0 && tc.reqTS == 0 && tc.expectErr == nil {
-						t.Fatal("can't set toReqTS without reqTS")
-					}
-					sst, start, end := sstutil.MakeSST(t, st, tc.sst)
-					resp := &roachpb.AddSSTableResponse{}
-					result, err := batcheval.EvalAddSSTable(ctx, engine, batcheval.CommandArgs{
-						EvalCtx: (&batcheval.MockEvalCtx{ClusterSettings: st, Desc: &roachpb.RangeDescriptor{}}).EvalContext(),
-						Stats:   stats,
-						Header: roachpb.Header{
-							Timestamp: hlc.Timestamp{WallTime: tc.reqTS},
-						},
-						Args: &roachpb.AddSSTableRequest{
-							RequestHeader:                  roachpb.RequestHeader{Key: start, EndKey: end},
-							Data:                           sst,
-							MVCCStats:                      sstutil.ComputeStats(t, sst),
-							DisallowConflicts:              tc.noConflict,
-							DisallowShadowing:              tc.noShadow,
-							DisallowShadowingBelow:         hlc.Timestamp{WallTime: tc.noShadowBelow},
-							SSTTimestampToRequestTimestamp: hlc.Timestamp{WallTime: tc.toReqTS},
-							IngestAsWrites:                 ingestAsWrites,
-						},
-					}, resp)
-
-					expectErr := tc.expectErr
-					if tc.expectErrRace != nil && util.RaceEnabled {
-						expectErr = tc.expectErrRace
-					}
-					if expectErr != nil {
-						require.Error(t, err)
-						if b, ok := expectErr.(bool); ok && b {
-							// any error is fine
-						} else if expectMsg, ok := expectErr.(string); ok {
-							require.Contains(t, err.Error(), expectMsg)
-						} else if expectMsgs, ok := expectErr.([]string); ok {
-							var found bool
-							for _, msg := range expectMsgs {
-								if strings.Contains(err.Error(), msg) {
-									found = true
-									break
-								}
-							}
-							if !found {
-								t.Fatalf("%q does not contain any of %q", err, expectMsgs)
-							}
-						} else if e, ok := expectErr.(error); ok {
-							require.True(t, errors.HasType(err, e), "expected %T, got %v", e, err)
-						} else {
-							require.Fail(t, "invalid expectErr", "expectErr=%v", expectErr)
-						}
-						return
-					}
-					require.NoError(t, err)
-
-					if ingestAsWrites {
-						require.Nil(t, result.Replicated.AddSSTable)
-					} else {
-						require.NotNil(t, result.Replicated.AddSSTable)
-						sstPath := filepath.Join(dir, "sst")
-						require.NoError(t, engine.WriteFile(sstPath, result.Replicated.AddSSTable.Data))
-						require.NoError(t, engine.IngestExternalFiles(ctx, []string{sstPath}))
-					}
-
-					// Scan resulting data from engine.
-					iter := storage.NewMVCCIncrementalIterator(engine, storage.MVCCIncrementalIterOptions{
-						EndKey:       keys.MaxKey,
-						StartTime:    hlc.MinTimestamp,
-						EndTime:      hlc.MaxTimestamp,
-						IntentPolicy: storage.MVCCIncrementalIterIntentPolicyEmit,
-						InlinePolicy: storage.MVCCIncrementalIterInlinePolicyEmit,
-					})
-					defer iter.Close()
-					iter.SeekGE(storage.MVCCKey{Key: keys.SystemPrefix})
-					scan := []sstutil.KV{}
-					for {
-						ok, err := iter.Valid()
+						dir := t.TempDir()
+						engine, err := storage.Open(ctx, storage.Filesystem(filepath.Join(dir, "db")), storage.Settings(st))
 						require.NoError(t, err)
-						if !ok {
-							break
+						defer engine.Close()
+
+						// Write initial data.
+						intentTxn := roachpb.MakeTransaction("intentTxn", nil, 0, hlc.Timestamp{WallTime: intentTS}, 0, 1)
+						b := engine.NewBatch()
+						for i := len(tc.data) - 1; i >= 0; i-- { // reverse, older timestamps first
+							kv := tc.data[i]
+							var txn *roachpb.Transaction
+							if kv.WallTimestamp == intentTS {
+								txn = &intentTxn
+							}
+							require.NoError(t, storage.MVCCPut(ctx, b, nil, kv.Key(), kv.Timestamp(), hlc.ClockTimestamp{}, kv.Value(), txn))
 						}
-						key := string(iter.Key().Key)
-						ts := iter.Key().Timestamp.WallTime
-						var value []byte
-						if iter.Key().IsValue() {
-							mvccVal, err := storage.DecodeMVCCValue(iter.Value())
+						require.NoError(t, b.Commit(false))
+						stats := engineStats(t, engine, 0)
+
+						// Build and add SST.
+						if tc.toReqTS != 0 && tc.reqTS == 0 && tc.expectErr == nil {
+							t.Fatal("can't set toReqTS without reqTS")
+						}
+						sst, start, end := sstutil.MakeSST(t, st, tc.sst)
+						resp := &roachpb.AddSSTableResponse{}
+						var mvccStats *enginepb.MVCCStats
+						// In the no-overlap case i.e. approxDiskBytes == 0, force a regular
+						// non-prefix Seek in the conflict check. Sending in nil stats
+						// makes this easier as that forces the function to rely exclusively
+						// on ApproxDiskBytes, otherwise EvalAddSSTable will always use
+						// prefix seeks since the test cases have too few keys in the
+						// sstable.
+						if approxDiskBytes != 0 {
+							mvccStats = sstutil.ComputeStats(t, sst)
+						}
+						result, err := batcheval.EvalAddSSTable(ctx, engine, batcheval.CommandArgs{
+							EvalCtx: (&batcheval.MockEvalCtx{ClusterSettings: st, Desc: &roachpb.RangeDescriptor{}, ApproxDiskBytes: approxDiskBytes}).EvalContext(),
+							Stats:   stats,
+							Header: roachpb.Header{
+								Timestamp: hlc.Timestamp{WallTime: tc.reqTS},
+							},
+							Args: &roachpb.AddSSTableRequest{
+								RequestHeader:                  roachpb.RequestHeader{Key: start, EndKey: end},
+								Data:                           sst,
+								MVCCStats:                      mvccStats,
+								DisallowConflicts:              tc.noConflict,
+								DisallowShadowing:              tc.noShadow,
+								DisallowShadowingBelow:         hlc.Timestamp{WallTime: tc.noShadowBelow},
+								SSTTimestampToRequestTimestamp: hlc.Timestamp{WallTime: tc.toReqTS},
+								IngestAsWrites:                 ingestAsWrites,
+							},
+						}, resp)
+
+						expectErr := tc.expectErr
+						if tc.expectErrRace != nil && util.RaceEnabled {
+							expectErr = tc.expectErrRace
+						}
+						if expectErr != nil {
+							require.Error(t, err)
+							if b, ok := expectErr.(bool); ok && b {
+								// any error is fine
+							} else if expectMsg, ok := expectErr.(string); ok {
+								require.Contains(t, err.Error(), expectMsg)
+							} else if expectMsgs, ok := expectErr.([]string); ok {
+								var found bool
+								for _, msg := range expectMsgs {
+									if strings.Contains(err.Error(), msg) {
+										found = true
+										break
+									}
+								}
+								if !found {
+									t.Fatalf("%q does not contain any of %q", err, expectMsgs)
+								}
+							} else if e, ok := expectErr.(error); ok {
+								require.True(t, errors.HasType(err, e), "expected %T, got %v", e, err)
+							} else {
+								require.Fail(t, "invalid expectErr", "expectErr=%v", expectErr)
+							}
+							return
+						}
+						require.NoError(t, err)
+
+						if ingestAsWrites {
+							require.Nil(t, result.Replicated.AddSSTable)
+						} else {
+							require.NotNil(t, result.Replicated.AddSSTable)
+							sstPath := filepath.Join(dir, "sst")
+							require.NoError(t, engine.WriteFile(sstPath, result.Replicated.AddSSTable.Data))
+							require.NoError(t, engine.IngestExternalFiles(ctx, []string{sstPath}))
+						}
+
+						// Scan resulting data from engine.
+						iter := storage.NewMVCCIncrementalIterator(engine, storage.MVCCIncrementalIterOptions{
+							EndKey:       keys.MaxKey,
+							StartTime:    hlc.MinTimestamp,
+							EndTime:      hlc.MaxTimestamp,
+							IntentPolicy: storage.MVCCIncrementalIterIntentPolicyEmit,
+							InlinePolicy: storage.MVCCIncrementalIterInlinePolicyEmit,
+						})
+						defer iter.Close()
+						iter.SeekGE(storage.MVCCKey{Key: keys.SystemPrefix})
+						scan := []sstutil.KV{}
+						for {
+							ok, err := iter.Valid()
 							require.NoError(t, err)
-							if !mvccVal.IsTombstone() {
-								value, err = mvccVal.Value.GetBytes()
+							if !ok {
+								break
+							}
+							key := string(iter.Key().Key)
+							ts := iter.Key().Timestamp.WallTime
+							var value []byte
+							if iter.Key().IsValue() {
+								mvccVal, err := storage.DecodeMVCCValue(iter.Value())
+								require.NoError(t, err)
+								if !mvccVal.IsTombstone() {
+									value, err = mvccVal.Value.GetBytes()
+									require.NoError(t, err)
+								}
+							} else {
+								var meta enginepb.MVCCMetadata
+								require.NoError(t, protoutil.Unmarshal(iter.UnsafeValue(), &meta))
+								if meta.RawBytes == nil {
+									// Skip intent metadata records (value emitted separately).
+									iter.Next()
+									continue
+								}
+								value, err = roachpb.Value{RawBytes: meta.RawBytes}.GetBytes()
 								require.NoError(t, err)
 							}
-						} else {
-							var meta enginepb.MVCCMetadata
-							require.NoError(t, protoutil.Unmarshal(iter.UnsafeValue(), &meta))
-							if meta.RawBytes == nil {
-								// Skip intent metadata records (value emitted separately).
-								iter.Next()
-								continue
-							}
-							value, err = roachpb.Value{RawBytes: meta.RawBytes}.GetBytes()
-							require.NoError(t, err)
+							scan = append(scan, sstutil.KV{key, ts, string(value)})
+							iter.Next()
 						}
-						scan = append(scan, sstutil.KV{key, ts, string(value)})
-						iter.Next()
-					}
-					require.Equal(t, tc.expect, scan)
+						require.Equal(t, tc.expect, scan)
 
-					// Check that stats were updated correctly.
-					if tc.expectStatsEst {
-						require.True(t, stats.ContainsEstimates > 0, "expected stats to be estimated")
-					} else {
-						require.False(t, stats.ContainsEstimates > 0, "found estimated stats")
-						require.Equal(t, stats, engineStats(t, engine, stats.LastUpdateNanos))
-					}
-				})
-			}
+						// Check that stats were updated correctly.
+						if tc.expectStatsEst {
+							require.True(t, stats.ContainsEstimates > 0, "expected stats to be estimated")
+						} else {
+							require.False(t, stats.ContainsEstimates > 0, "found estimated stats")
+							require.Equal(t, stats, engineStats(t, engine, stats.LastUpdateNanos))
+						}
+					})
+				}
+			})
 		})
 	})
 }

--- a/pkg/kv/kvserver/batcheval/eval_context.go
+++ b/pkg/kv/kvserver/batcheval/eval_context.go
@@ -138,6 +138,10 @@ type EvalContext interface {
 	// StoreCapacity fields not related to engine capacity are not populated.
 	GetEngineCapacity() (roachpb.StoreCapacity, error)
 
+	// GetApproximateDiskBytes returns an approximate measure of bytes in the store
+	// in the specified key range.
+	GetApproximateDiskBytes(from, to roachpb.Key) (uint64, error)
+
 	// GetCurrentClosedTimestamp returns the current closed timestamp on the
 	// range. It is expected that a caller will have performed some action (either
 	// calling RevokeLease or WatchForMerge) to freeze further progression of the
@@ -176,6 +180,7 @@ type MockEvalCtx struct {
 	ClosedTimestamp    hlc.Timestamp
 	RevokedLeaseSeq    roachpb.LeaseSequence
 	MaxBytes           int64
+	ApproxDiskBytes    uint64
 }
 
 // EvalContext returns the MockEvalCtx as an EvalContext. It will reflect future
@@ -304,5 +309,8 @@ func (m *mockEvalCtxImpl) GetMaxBytes() int64 {
 }
 func (m *mockEvalCtxImpl) GetEngineCapacity() (roachpb.StoreCapacity, error) {
 	return roachpb.StoreCapacity{Available: 1, Capacity: 1}, nil
+}
+func (m *mockEvalCtxImpl) GetApproximateDiskBytes(from, to roachpb.Key) (uint64, error) {
+	return m.ApproxDiskBytes, nil
 }
 func (m *mockEvalCtxImpl) Release() {}

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -2028,6 +2028,12 @@ func (r *Replica) GetEngineCapacity() (roachpb.StoreCapacity, error) {
 	return r.store.Engine().Capacity()
 }
 
+// GetApproximateDiskBytes returns an approximate measure of bytes in the store
+// in the specified key range.
+func (r *Replica) GetApproximateDiskBytes(from, to roachpb.Key) (uint64, error) {
+	return r.store.Engine().ApproximateDiskBytes(from, to)
+}
+
 func init() {
 	tracing.RegisterTagRemapping("r", "range")
 }

--- a/pkg/kv/kvserver/replica_eval_context_span.go
+++ b/pkg/kv/kvserver/replica_eval_context_span.go
@@ -274,5 +274,12 @@ func (rec *SpanSetReplicaEvalContext) GetEngineCapacity() (roachpb.StoreCapacity
 	return rec.i.GetEngineCapacity()
 }
 
+// GetApproximateDiskBytes implements the batcheval.EvalContext interface.
+func (rec *SpanSetReplicaEvalContext) GetApproximateDiskBytes(
+	from, to roachpb.Key,
+) (uint64, error) {
+	return rec.i.GetApproximateDiskBytes(from, to)
+}
+
 // Release implements the batcheval.EvalContext interface.
 func (rec *SpanSetReplicaEvalContext) Release() { rec.i.Release() }

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -253,6 +253,7 @@ go_library(
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_pebble//:pebble",
+        "@com_github_cockroachdb_pebble//bloom",
         "@com_github_cockroachdb_pebble//vfs",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_getsentry_sentry_go//:sentry-go",

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/redact"
 )
@@ -628,7 +629,17 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 			pebbleConfig.Opts.MaxOpenFiles = int(openFileLimitPerStore)
 			// If the spec contains Pebble options, set those too.
 			if len(spec.PebbleOptions) > 0 {
-				err := pebbleConfig.Opts.Parse(spec.PebbleOptions, &pebble.ParseHooks{})
+				err := pebbleConfig.Opts.Parse(spec.PebbleOptions, &pebble.ParseHooks{
+					NewFilterPolicy: func(name string) (pebble.FilterPolicy, error) {
+						switch name {
+						case "none":
+							return nil, nil
+						case "rocksdb.BuiltinBloomFilter":
+							return bloom.FilterPolicy(10), nil
+						}
+						return nil, nil
+					},
+				})
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/storage/bench_pebble_test.go
+++ b/pkg/storage/bench_pebble_test.go
@@ -398,13 +398,13 @@ func BenchmarkBatchBuilderPut(b *testing.B) {
 func BenchmarkCheckSSTConflicts(b *testing.B) {
 	for _, numKeys := range []int{1000, 10000, 100000} {
 		b.Run(fmt.Sprintf("keys=%d", numKeys), func(b *testing.B) {
-			for _, numVersions := range []int{8, 64} {
-				b.Run(fmt.Sprintf("versions=%d", numVersions), func(b *testing.B) {
-					for _, numSstKeys := range []int{1000, 10000} {
-						b.Run(fmt.Sprintf("sstKeys=%d", numSstKeys), func(b *testing.B) {
-							for _, overlap := range []bool{false, true} {
-								b.Run(fmt.Sprintf("overlap=%t", overlap), func(b *testing.B) {
-									runCheckSSTConflicts(b, numKeys, numVersions, numSstKeys, overlap)
+			for _, numSstKeys := range []int{10, 100, 1000, 10000, 100000} {
+				b.Run(fmt.Sprintf("sstKeys=%d", numSstKeys), func(b *testing.B) {
+					for _, overlap := range []bool{false, true} {
+						b.Run(fmt.Sprintf("overlap=%t", overlap), func(b *testing.B) {
+							for _, usePrefixSeek := range []bool{false, true} {
+								b.Run(fmt.Sprintf("prefixSeek=%t", usePrefixSeek), func(b *testing.B) {
+									runCheckSSTConflicts(b, numKeys, 1 /* numVersions */, numSstKeys, overlap, usePrefixSeek)
 								})
 							}
 						})

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -1546,7 +1546,9 @@ type noopWriter struct{}
 func (noopWriter) Close() error                { return nil }
 func (noopWriter) Write(p []byte) (int, error) { return len(p), nil }
 
-func runCheckSSTConflicts(b *testing.B, numEngineKeys, numVersions, numSstKeys int, overlap bool) {
+func runCheckSSTConflicts(
+	b *testing.B, numEngineKeys, numVersions, numSstKeys int, overlap, usePrefixSeek bool,
+) {
 	keyBuf := append(make([]byte, 0, 64), []byte("key-")...)
 	valueBuf := make([]byte, 128)
 	for i := range valueBuf {
@@ -1576,12 +1578,18 @@ func runCheckSSTConflicts(b *testing.B, numEngineKeys, numVersions, numSstKeys i
 	sstFile := &MemFile{}
 	sstWriter := MakeIngestionSSTWriter(ctx, st, sstFile)
 	var sstStart, sstEnd MVCCKey
+	lastKeyNum := -1
+	lastKeyCounter := 0
 	for i := 0; i < numSstKeys; i++ {
 		keyNum := int((float64(i) / float64(numSstKeys)) * float64(numEngineKeys))
 		if !overlap {
 			keyNum = i + numEngineKeys
+		} else if lastKeyNum == keyNum {
+			lastKeyCounter++
+		} else {
+			lastKeyCounter = 0
 		}
-		key := roachpb.Key(encoding.EncodeUvarintAscending(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(keyNum)), 1))
+		key := roachpb.Key(encoding.EncodeUvarintAscending(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(keyNum)), uint64(1+lastKeyCounter)))
 		mvccKey := MVCCKey{Key: key, Timestamp: hlc.Timestamp{WallTime: int64(numVersions + 3)}}
 		if i == 0 {
 			sstStart.Key = append([]byte(nil), mvccKey.Key...)
@@ -1591,12 +1599,13 @@ func runCheckSSTConflicts(b *testing.B, numEngineKeys, numVersions, numSstKeys i
 			sstEnd.Timestamp = mvccKey.Timestamp
 		}
 		require.NoError(b, sstWriter.PutMVCC(mvccKey, value))
+		lastKeyNum = keyNum
 	}
 	sstWriter.Close()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := CheckSSTConflicts(context.Background(), sstFile.Data(), eng, sstStart, sstEnd, false, hlc.Timestamp{}, math.MaxInt64)
+		_, err := CheckSSTConflicts(context.Background(), sstFile.Data(), eng, sstStart, sstEnd, false, hlc.Timestamp{}, math.MaxInt64, usePrefixSeek)
 		require.NoError(b, err)
 	}
 }

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -278,6 +278,14 @@ type IterOptions struct {
 	// use such an iterator is to use it in concert with an iterator without
 	// timestamp hints, as done by MVCCIncrementalIterator.
 	MinTimestampHint, MaxTimestampHint hlc.Timestamp
+	// useL6Filters allows the caller to opt into reading filter blocks for
+	// L6 sstables. Only for use with Prefix = true. Helpful if a lot of prefix
+	// Seeks are expected in quick succession, that are also likely to not
+	// yield a single key. Filter blocks in L6 can be relatively large, often
+	// larger than data blocks, so the benefit of loading them in the cache
+	// is minimized if the probability of the key existing is not low or if
+	// this is a one-time Seek (where loading the data block directly is better).
+	useL6Filters bool
 }
 
 // MVCCIterKind is used to inform Reader about the kind of iteration desired

--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -323,6 +323,12 @@ func (i *intentInterleavingIter) SeekGE(key MVCCKey) {
 		// so don't expect to ever see the intent. NB: intentSeekKey is nil.
 		i.intentKey = nil
 	}
+	if !i.iterValid && i.prefix {
+		// The prefix seek below will also certainly fail, as we didn't find an
+		// MVCC value here.
+		intentSeekKey = nil
+		i.intentKey = nil
+	}
 	if intentSeekKey != nil {
 		var limitKey roachpb.Key
 		if i.iterValid && !i.prefix {

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -625,17 +625,6 @@ func DefaultPebbleOptions() *pebble.Options {
 		l.EnsureDefaults()
 	}
 
-	// Do not create bloom filters for the last level (i.e. the largest level
-	// which contains data in the LSM store). This configuration reduces the size
-	// of the bloom filters by 10x. This is significant given that bloom filters
-	// require 1.25 bytes (10 bits) per key which can translate into gigabytes of
-	// memory given typical key and value sizes. The downside is that bloom
-	// filters will only be usable on the higher levels, but that seems
-	// acceptable. We typically see read amplification of 5-6x on clusters
-	// (i.e. there are 5-6 levels of sstables) which means we'll achieve 80-90%
-	// of the benefit of having bloom filters on every level for only 10% of the
-	// memory cost.
-	opts.Levels[6].FilterPolicy = nil
 	return opts
 }
 

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -141,6 +141,7 @@ func (p *pebbleIterator) setOptions(opts IterOptions, durability DurabilityRequi
 	// Generate new Pebble iterator options.
 	p.options = pebble.IterOptions{
 		OnlyReadGuaranteedDurable: durability == GuaranteedDurability,
+		UseL6Filters:              opts.useL6Filters,
 	}
 	p.prefix = opts.Prefix
 

--- a/pkg/storage/sst_test.go
+++ b/pkg/storage/sst_test.go
@@ -84,19 +84,23 @@ func TestCheckSSTConflictsMaxIntents(t *testing.T) {
 
 			for _, tc := range testcases {
 				t.Run(fmt.Sprintf("maxIntents=%d", tc.maxIntents), func(t *testing.T) {
-					// Provoke and check WriteIntentErrors.
-					startKey, endKey := MVCCKey{Key: roachpb.Key(start)}, MVCCKey{Key: roachpb.Key(end)}
-					_, err := CheckSSTConflicts(ctx, sstFile.Bytes(), engine, startKey, endKey,
-						false /*disallowShadowing*/, hlc.Timestamp{} /*disallowShadowingBelow*/, tc.maxIntents)
-					require.Error(t, err)
-					writeIntentErr := &roachpb.WriteIntentError{}
-					require.ErrorAs(t, err, &writeIntentErr)
+					for _, usePrefixSeek := range []bool{false, true} {
+						t.Run(fmt.Sprintf("usePrefixSeek=%v", usePrefixSeek), func(t *testing.T) {
+							// Provoke and check WriteIntentErrors.
+							startKey, endKey := MVCCKey{Key: roachpb.Key(start)}, MVCCKey{Key: roachpb.Key(end)}
+							_, err := CheckSSTConflicts(ctx, sstFile.Bytes(), engine, startKey, endKey,
+								false /*disallowShadowing*/, hlc.Timestamp{} /*disallowShadowingBelow*/, tc.maxIntents, usePrefixSeek)
+							require.Error(t, err)
+							writeIntentErr := &roachpb.WriteIntentError{}
+							require.ErrorAs(t, err, &writeIntentErr)
 
-					actual := []string{}
-					for _, i := range writeIntentErr.Intents {
-						actual = append(actual, string(i.Key))
+							actual := []string{}
+							for _, i := range writeIntentErr.Intents {
+								actual = append(actual, string(i.Key))
+							}
+							require.Equal(t, tc.expectIntents, actual)
+						})
 					}
-					require.Equal(t, tc.expectIntents, actual)
 				})
 			}
 		})


### PR DESCRIPTION
This change includes 4 changes to significantly improve
the performance of CheckSSTCollisions (and by extension,
AddSSTable) for cases where we add very wide sstables
relative to the engine:

1) Check if we're adding an sstable that has a small number of
keys, or has a 100x greater overlap with the engine relative
to its own size. In that case, switch to doing prefix seeks
inside CheckSSTCollisions, similar to what we did in #73514
and then reverted later).
2) Write bloom filters in L6 by default, to help speed up 1.
Also thread a new IterOption to only optionally read these
filter blocks in prefix iteration, defaulting to not reading
them. This iterator option hooks into the one added in
Pebble in cockroachdb/pebble#1685 ).
3) Add a ParseHook to allow command-line pebble options to
allow configuring the writing of bloom filters.
4) Update intentInterleavingIter to not prefix-seek the
intent/lock table iterator if we are in prefix seek mode and
the MVCC iterator returned nothing.

Fixes #80980.

Release note (performance improvement): Significantly improve
performance of IMPORTs when the source is producing data
not sorted by the destination table's primary key, especially
if the destination table has a very large primary key with
lots of columns.