### PR TITLE
sql: Allow DEFAULT/ON UPDATE types that can be assignment-cast

### DIFF
--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -116,7 +116,7 @@ func parseValues(tableDesc catalog.TableDescriptor, values string) ([]rowenc.Enc
 		for colIdx, expr := range rowTuple {
 			col := tableDesc.PublicColumns()[colIdx]
 			typedExpr, err := schemaexpr.SanitizeVarFreeExpr(
-				ctx, expr, col.GetType(), "avro", &semaCtx, volatility.Stable)
+				ctx, expr, col.GetType(), "avro", &semaCtx, volatility.Stable, false /*allowAssignmentCast*/)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/ccl/changefeedccl/cdceval/expr_eval.go
+++ b/pkg/ccl/changefeedccl/cdceval/expr_eval.go
@@ -374,7 +374,7 @@ func (e *exprEval) typeCheck(
 ) (tree.TypedExpr, error) {
 	// If we have variable free immutable expressions, then we can just evaluate it right away.
 	typedExpr, err := schemaexpr.SanitizeVarFreeExpr(
-		ctx, expr, targetType, "cdc", &e.semaCtx, volatility.Immutable)
+		ctx, expr, targetType, "cdc", &e.semaCtx, volatility.Immutable, false)
 	if err == nil {
 		d, err := eval.Expr(e.evalCtx, typedExpr)
 		if err != nil {

--- a/pkg/ccl/partitionccl/partition.go
+++ b/pkg/ccl/partitionccl/partition.go
@@ -105,6 +105,7 @@ func valueEncodePartitionTuple(
 		typedExpr, err := schemaexpr.SanitizeVarFreeExpr(evalCtx.Context, expr, cols[i].GetType(), "partition",
 			&semaCtx,
 			volatility.Immutable,
+			false, /*allowAssignmentCast*/
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1138,7 +1138,7 @@ func sanitizeColumnExpression(
 ) (tree.TypedExpr, string, error) {
 	colDatumType := col.GetType()
 	typedExpr, err := schemaexpr.SanitizeVarFreeExpr(
-		p.ctx, expr, colDatumType, opName, &p.p.semaCtx, volatility.Volatile,
+		p.ctx, expr, colDatumType, opName, &p.p.semaCtx, volatility.Volatile, false, /*allowAssignmentCast*/
 	)
 	if err != nil {
 		return nil, "", pgerror.WithCandidateCode(err, pgcode.DatatypeMismatch)

--- a/pkg/sql/alter_table_locality.go
+++ b/pkg/sql/alter_table_locality.go
@@ -373,6 +373,7 @@ func (n *alterTableSetLocalityNode) alterTableLocalityToRegionalByRow(
 			"REGIONAL BY ROW DEFAULT",
 			params.p.SemaCtx(),
 			volatility.Volatile,
+			false, /*allowAssignmentCast*/
 		)
 		if err != nil {
 			return err

--- a/pkg/sql/analyze_expr.go
+++ b/pkg/sql/analyze_expr.go
@@ -50,8 +50,7 @@ func (p *planner) analyzeExpr(
 	var err error
 	p.semaCtx.IVarContainer = iVarHelper.Container()
 	if requireType {
-		typedExpr, err = tree.TypeCheckAndRequire(ctx, resolved, &p.semaCtx,
-			expectedType, typingContext)
+		typedExpr, err = tree.TypeCheckAndRequire(ctx, resolved, &p.semaCtx, expectedType, typingContext)
 	} else {
 		typedExpr, err = tree.TypeCheck(ctx, resolved, &p.semaCtx, expectedType)
 	}

--- a/pkg/sql/catalog/schemaexpr/BUILD.bazel
+++ b/pkg/sql/catalog/schemaexpr/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
+        "//pkg/sql/sem/cast",
         "//pkg/sql/sem/catid",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/transform",

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/cast"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
@@ -158,13 +159,22 @@ func MakeColumnDefDescs(
 	col.Type = resType
 
 	if d.HasDefaultExpr() {
+		var innerErr error
 		// Verify the default expression type is compatible with the column type
 		// and does not contain invalid functions.
 		ret.DefaultExpr, err = schemaexpr.SanitizeVarFreeExpr(
 			ctx, d.DefaultExpr.Expr, resType, "DEFAULT", semaCtx, volatility.Volatile,
 		)
 		if err != nil {
-			return nil, err
+			// Check if the default expression type can be assignment-cast into the
+			// column type. If it can allow the default and column type to differ.
+			ret.DefaultExpr, innerErr = d.DefaultExpr.Expr.TypeCheck(ctx, semaCtx, types.Any)
+			if innerErr != nil {
+				return nil, err
+			}
+			if ok := cast.ValidCast(ret.DefaultExpr.ResolvedType(), resType, cast.ContextAssignment); !ok {
+				return nil, err
+			}
 		}
 
 		// Keep the type checked expression so that the type annotation gets
@@ -180,10 +190,20 @@ func MakeColumnDefDescs(
 	if d.HasOnUpdateExpr() {
 		// Verify the on update expression type is compatible with the column type
 		// and does not contain invalid functions.
+		var innerErr error
 		ret.OnUpdateExpr, err = schemaexpr.SanitizeVarFreeExpr(
 			ctx, d.OnUpdateExpr.Expr, resType, "ON UPDATE", semaCtx, volatility.Volatile,
 		)
 		if err != nil {
+			// Check if the on update expression type can be assignment-cast into the
+			// column type. If it can allow the on update expr and column type to differ.
+			ret.OnUpdateExpr, innerErr = d.OnUpdateExpr.Expr.TypeCheck(ctx, semaCtx, types.Any)
+			if innerErr != nil {
+				return nil, err
+			}
+			if ok := cast.ValidCast(ret.OnUpdateExpr.ResolvedType(), resType, cast.ContextAssignment); !ok {
+				return nil, err
+			}
 			return nil, err
 		}
 

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/cast"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
@@ -159,22 +158,13 @@ func MakeColumnDefDescs(
 	col.Type = resType
 
 	if d.HasDefaultExpr() {
-		var innerErr error
 		// Verify the default expression type is compatible with the column type
 		// and does not contain invalid functions.
 		ret.DefaultExpr, err = schemaexpr.SanitizeVarFreeExpr(
-			ctx, d.DefaultExpr.Expr, resType, "DEFAULT", semaCtx, volatility.Volatile,
+			ctx, d.DefaultExpr.Expr, resType, "DEFAULT", semaCtx, volatility.Volatile, true, /*allowAssignmentCast*/
 		)
 		if err != nil {
-			// Check if the default expression type can be assignment-cast into the
-			// column type. If it can allow the default and column type to differ.
-			ret.DefaultExpr, innerErr = d.DefaultExpr.Expr.TypeCheck(ctx, semaCtx, types.Any)
-			if innerErr != nil {
-				return nil, err
-			}
-			if ok := cast.ValidCast(ret.DefaultExpr.ResolvedType(), resType, cast.ContextAssignment); !ok {
-				return nil, err
-			}
+			return nil, err
 		}
 
 		// Keep the type checked expression so that the type annotation gets
@@ -190,20 +180,10 @@ func MakeColumnDefDescs(
 	if d.HasOnUpdateExpr() {
 		// Verify the on update expression type is compatible with the column type
 		// and does not contain invalid functions.
-		var innerErr error
 		ret.OnUpdateExpr, err = schemaexpr.SanitizeVarFreeExpr(
-			ctx, d.OnUpdateExpr.Expr, resType, "ON UPDATE", semaCtx, volatility.Volatile,
+			ctx, d.OnUpdateExpr.Expr, resType, "ON UPDATE", semaCtx, volatility.Volatile, true, /*allowAssignmentCast*/
 		)
 		if err != nil {
-			// Check if the on update expression type can be assignment-cast into the
-			// column type. If it can allow the on update expr and column type to differ.
-			ret.OnUpdateExpr, innerErr = d.OnUpdateExpr.Expr.TypeCheck(ctx, semaCtx, types.Any)
-			if innerErr != nil {
-				return nil, err
-			}
-			if ok := cast.ValidCast(ret.OnUpdateExpr.ResolvedType(), resType, cast.ContextAssignment); !ok {
-				return nil, err
-			}
 			return nil, err
 		}
 
@@ -286,7 +266,7 @@ func EvalShardBucketCount(
 			shardBuckets = paramVal
 		}
 		typedExpr, err := schemaexpr.SanitizeVarFreeExpr(
-			ctx, shardBuckets, types.Int, "BUCKET_COUNT", semaCtx, volatility.Volatile,
+			ctx, shardBuckets, types.Int, "BUCKET_COUNT", semaCtx, volatility.Volatile, false, /*allowAssignmentCast*/
 		)
 		if err != nil {
 			return 0, err

--- a/pkg/sql/execute.go
+++ b/pkg/sql/execute.go
@@ -54,7 +54,7 @@ func (p *planner) fillInPlaceholders(
 			}
 		}
 		typedExpr, err := schemaexpr.SanitizeVarFreeExpr(
-			ctx, e, typ, "EXECUTE parameter" /* context */, &semaCtx, volatility.Volatile,
+			ctx, e, typ, "EXECUTE parameter" /* context */, &semaCtx, volatility.Volatile, false, /*allowAssignmentCast*/
 		)
 		if err != nil {
 			return nil, pgerror.WithCandidateCode(err, pgcode.WrongObjectType)

--- a/pkg/sql/logictest/testdata/logic_test/cast
+++ b/pkg/sql/logictest/testdata/logic_test/cast
@@ -1418,28 +1418,71 @@ query TT
 SELECT (-1/3.0)::float4::text, (1/3.0)::float8::text
 ----
 -0.3  0.3
-=======
 
-# Test that default/on update expression differing from column type
+# Test that default/on update expression is allowed to differ from column type
 statement ok
 CREATE TABLE def_assn_cast (
-a INT4 DEFAULT 1.0::FLOAT4,
-b VARCHAR DEFAULT 'true'::BOOL,
-c NAME DEFAULT 'foo'::BPCHAR,
-d JSONB DEFAULT 'null'::CHAR,
+  id INT4,
+  a INT4 DEFAULT 1.0::FLOAT4,
+  b VARCHAR DEFAULT 'true'::BOOL,
+  c NAME DEFAULT 'foo'::BPCHAR
 )
 
-statement error pq: could not parse . as type .: invalid . value
+statement ok
+CREATE TABLE upd_assn_cast (
+  id INT4,
+  a TEXT ON UPDATE 'POINT(2.0 2.0)'::GEOMETRY,
+  b FLOAT8 ON UPDATE 6::INT4,
+  c VARCHAR ON UPDATE '{ "customer": "John Doe"}'::JSONB
+)
+
+# Ensure insertions are allowed
+statement ok
+INSERT INTO def_assn_cast(id) VALUES (1)
+
+statement ok
+INSERT INTO upd_assn_cast(id) VALUES (1)
+
+statement ok
+UPDATE upd_assn_cast SET id = 2
+
+query IITT
+SELECT * from def_assn_cast
+----
+1  1  true  f
+
+query ITFT
+SELECT * from upd_assn_cast
+----
+2  010100000000000000000000400000000000000040  6  {"customer": "John Doe"}
+
+
+statement error pq: could not parse .* as type .*: invalid .* value
 CREATE TABLE fail_assn_cast (
-a BOOL DEFAULT 'foo'
+  a BOOL DEFAULT 'foo'
 )
 
-statement error pq: could not parse . as type .: invalid . value
+statement error pq: expected DEFAULT expression to have type .*, but .* has type .*
 CREATE TABLE fail_assn_cast (
-b JSONB DEFAULT 'null'::CHAR
+  a DATE DEFAULT 1.0::FLOAT4
 )
 
-statement error pq: expected DEFAULT expression to have type ., but . has type .
-CREATE TABLE def_assn_cast (
-a INT4 DEFAULT 1.0::BOOL
+statement error pq: expected DEFAULT expression to have type .*, but .* has type .*
+CREATE TABLE fail_assn_cast (
+  b JSONB DEFAULT 'null'::CHAR
+)
+
+statement error pq: expected ON UPDATE expression to have type .*, but .* has type .*
+CREATE TABLE fail_assn_cast (
+  a INT4 ON UPDATE 1.0::BOOL
+)
+
+statement error pq: expected ON UPDATE expression to have type .*, but .* has type .*
+CREATE TABLE fail_assn_cast (
+  a FLOAT4 ON UPDATE '01/02/03'::DATE
+)
+
+statement error pq: expected ON UPDATE expression to have type .*, but .* has type .*
+CREATE TABLE fail_assn_cast (
+  a NUMERIC ON UPDATE '1-2'::INTERVAL
 )

--- a/pkg/sql/logictest/testdata/logic_test/cast
+++ b/pkg/sql/logictest/testdata/logic_test/cast
@@ -1418,3 +1418,28 @@ query TT
 SELECT (-1/3.0)::float4::text, (1/3.0)::float8::text
 ----
 -0.3  0.3
+=======
+
+# Test that default/on update expression differing from column type
+statement ok
+CREATE TABLE def_assn_cast (
+a INT4 DEFAULT 1.0::FLOAT4,
+b VARCHAR DEFAULT 'true'::BOOL,
+c NAME DEFAULT 'foo'::BPCHAR,
+d JSONB DEFAULT 'null'::CHAR,
+)
+
+statement error pq: could not parse . as type .: invalid . value
+CREATE TABLE fail_assn_cast (
+a BOOL DEFAULT 'foo'
+)
+
+statement error pq: could not parse . as type .: invalid . value
+CREATE TABLE fail_assn_cast (
+b JSONB DEFAULT 'null'::CHAR
+)
+
+statement error pq: expected DEFAULT expression to have type ., but . has type .
+CREATE TABLE def_assn_cast (
+a INT4 DEFAULT 1.0::BOOL
+)

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -429,6 +429,7 @@ func newHarness(tb testing.TB, query benchQuery) *harness {
 			"", /* context */
 			&h.semaCtx,
 			volatility.Volatile,
+			false, /*allowAssignmentCast*/
 		)
 		if err != nil {
 			tb.Fatalf("%v", err)

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -1219,6 +1219,7 @@ func (ot *OptTester) AssignPlaceholders(
 			"", /* context */
 			&ot.semaCtx,
 			volatility.Volatile,
+			false, /*allowAssignmentCast*/
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/opt/testutils/testcat/alter_table.go
+++ b/pkg/sql/opt/testutils/testcat/alter_table.go
@@ -60,9 +60,7 @@ func injectTableStats(tt *Table, statsExpr tree.Expr) {
 	ctx := context.Background()
 	semaCtx := tree.MakeSemaContext()
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
-	typedExpr, err := tree.TypeCheckAndRequire(
-		ctx, statsExpr, &semaCtx, types.Jsonb, "INJECT STATISTICS",
-	)
+	typedExpr, err := tree.TypeCheckAndRequire(ctx, statsExpr, &semaCtx, types.Jsonb, "INJECT STATISTICS")
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/sql/row/expr_walker.go
+++ b/pkg/sql/row/expr_walker.go
@@ -784,7 +784,7 @@ func sanitizeExprsForImport(
 
 	// If we have immutable expressions, then we can just return it right away.
 	typedExpr, err := schemaexpr.SanitizeVarFreeExpr(
-		ctx, expr, targetType, "import_default", &semaCtx, volatility.Immutable)
+		ctx, expr, targetType, "import_default", &semaCtx, volatility.Immutable, false /*allowAssignmentCast*/)
 	if err == nil {
 		return typedExpr, overrideImmutable, nil
 	}


### PR DESCRIPTION
Resolves #74854

postgres:
```
postgres=# create table casts (b BOOL DEFAULT 'foo'::VARCHAR);
 ERROR:  column "b" is of type boolean but default expression is of type character varying>
HINT:  You will need to rewrite or cast the expression.
```
crdb:
  ```
demo@127.0.0.1:26257/movr> CREATE TABLE t (b BOOL DEFAULT 'foo'::VARCHAR);
CREATE TABLE

Time: 8ms total (execution 8ms / network 0ms)
```

Release note (sql change): A column's DEFAULT/ON UPDATE clause
can now have a type that differs from the column type, as long as
that type can be assignment-cast into the column's type. This
increases our PostgreSQL compatibility.