### PR TITLE
opt: calculate lookup join remaining filters more accurately

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1121,7 +1121,7 @@ func (b *Builder) buildHashJoin(join memo.RelExpr) (execPlan, error) {
 		}
 	}
 
-	leftEq, rightEq := memo.ExtractJoinEqualityColumns(
+	leftEq, rightEq, _ := memo.ExtractJoinEqualityColumns(
 		leftExpr.Relational().OutputCols,
 		rightExpr.Relational().OutputCols,
 		*filters,

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_spans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_spans
@@ -920,7 +920,6 @@ vectorized: true
     │ estimated row count: 196 (missing stats)
     │ table: order_line@ol_io
     │ lookup condition: (s_i_id = ol_i_id) AND (ol_o_id IN (20, 21))
-    │ pred: (ol_o_id IN (19, 20, 21)) AND (ol_o_id >= 20)
     │
     └── • scan
           columns: (s_i_id)

--- a/pkg/sql/opt/lookupjoin/BUILD.bazel
+++ b/pkg/sql/opt/lookupjoin/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/sql/opt/props",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
+        "//pkg/util",
     ],
 )
 

--- a/pkg/sql/opt/lookupjoin/constraint_builder.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder.go
@@ -107,7 +107,7 @@ func (b *ConstraintBuilder) Init(
 	leftCols, rightCols opt.ColSet,
 	onFilters memo.FiltersExpr,
 ) (ok bool) {
-	leftEq, rightEq := memo.ExtractJoinEqualityColumns(leftCols, rightCols, onFilters)
+	leftEq, rightEq, _ := memo.ExtractJoinEqualityColumns(leftCols, rightCols, onFilters)
 	if len(leftEq) == 0 {
 		// Exploring a lookup join is only beneficial if there is at least one
 		// pair of equality columns.

--- a/pkg/sql/opt/lookupjoin/testdata/lookup_expr
+++ b/pkg/sql/opt/lookupjoin/testdata/lookup_expr
@@ -7,6 +7,12 @@ lookup expression:
   (y = b) AND (x IN (1, 2, 3))
 
 lookup-constraints left=(a int, b int) right=(x int, y int, z int) index=(x, y)
+(x = 1 OR x = 2) AND y = b
+----
+lookup expression:
+  (y = b) AND (x IN (1, 2))
+
+lookup-constraints left=(a int, b int) right=(x int, y int, z int) index=(x, y)
 x IN (1, 2, 3)
 ----
 lookup join not possible
@@ -245,3 +251,9 @@ optional: x IN (1, 2) AND z > 0
 ----
 lookup expression:
   (y = b) AND (x IN (1, 2))
+
+lookup-constraints left=(a int, b int) right=(x int, y int) index=(x, y)
+x IN (10, 20, 30, 40) AND y = b AND x > 10
+----
+lookup expression:
+  (y = b) AND (x IN (20, 30, 40))

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -251,7 +251,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		fmt.Fprintf(f.Buffer, "%v", e.Op())
 		if opt.IsJoinNonApplyOp(t) {
 			// All join ops that weren't handled above execute as a hash join.
-			if leftEqCols, _ := ExtractJoinEqualityColumns(
+			if leftEqCols, _, _ := ExtractJoinEqualityColumns(
 				e.Child(0).(RelExpr).Relational().OutputCols,
 				e.Child(1).(RelExpr).Relational().OutputCols,
 				*e.Child(2).(*FiltersExpr),

--- a/pkg/sql/opt/memo/extract.go
+++ b/pkg/sql/opt/memo/extract.go
@@ -158,10 +158,11 @@ func ExtractAggFirstVar(e opt.ScalarExpr) *VariableExpr {
 
 // ExtractJoinEqualityColumns returns pairs of columns (one from the left side,
 // one from the right side) which are constrained to be equal in a join (and
-// have equivalent types).
+// have equivalent types). The returned filterOrds contains ordinals of the on
+// filters where each column pair was found.
 func ExtractJoinEqualityColumns(
 	leftCols, rightCols opt.ColSet, on FiltersExpr,
-) (leftEq opt.ColList, rightEq opt.ColList) {
+) (leftEq opt.ColList, rightEq opt.ColList, filterOrds []int) {
 	for i := range on {
 		condition := on[i].Condition
 		ok, left, right := ExtractJoinEquality(leftCols, rightCols, condition)
@@ -181,9 +182,10 @@ func ExtractJoinEqualityColumns(
 		if !duplicate {
 			leftEq = append(leftEq, left)
 			rightEq = append(rightEq, right)
+			filterOrds = append(filterOrds, i)
 		}
 	}
-	return leftEq, rightEq
+	return leftEq, rightEq, filterOrds
 }
 
 // ExtractJoinEqualityFilters returns the filters containing pairs of columns

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -825,7 +825,7 @@ func (c *coster) computeHashJoinCost(join memo.RelExpr) memo.Cost {
 	// Compute filter cost. Fetch the equality columns so they can be
 	// ignored later.
 	on := join.Child(2).(*memo.FiltersExpr)
-	leftEq, rightEq := memo.ExtractJoinEqualityColumns(
+	leftEq, rightEq, _ := memo.ExtractJoinEqualityColumns(
 		join.Child(0).(memo.RelExpr).Relational().OutputCols,
 		join.Child(1).(memo.RelExpr).Relational().OutputCols,
 		*on,

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -43,7 +43,7 @@ func (c *CustomFuncs) GenerateMergeJoins(
 	leftProps := left.Relational()
 	rightProps := right.Relational()
 
-	leftEq, rightEq := memo.ExtractJoinEqualityColumns(
+	leftEq, rightEq, _ := memo.ExtractJoinEqualityColumns(
 		leftProps.OutputCols, rightProps.OutputCols, on,
 	)
 	n := len(leftEq)
@@ -652,7 +652,7 @@ func (c *CustomFuncs) GenerateInvertedJoins(
 			// filters if there is a multi-column inverted index.
 			if !eqColsAndOptionalFiltersCalculated {
 				inputProps := input.Relational()
-				leftEqCols, rightEqCols = memo.ExtractJoinEqualityColumns(inputProps.OutputCols, scanPrivate.Cols, onFilters)
+				leftEqCols, rightEqCols, _ = memo.ExtractJoinEqualityColumns(inputProps.OutputCols, scanPrivate.Cols, onFilters)
 
 				// Generate implicit filters from CHECK constraints and computed
 				// columns as optional filters. We build the computed column

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -1077,7 +1077,7 @@ func (c *CustomFuncs) GenerateZigzagJoins(
 
 			// If there are any equalities across the columns of the two indexes,
 			// push them into the zigzag join spec.
-			leftEq, rightEq := memo.ExtractJoinEqualityColumns(
+			leftEq, rightEq, _ := memo.ExtractJoinEqualityColumns(
 				leftCols, rightCols, innerFilters,
 			)
 			leftEqCols, rightEqCols := eqColsForZigzag(

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -1109,8 +1109,7 @@ top-k
       │    │    │    ├── cardinality: [2 - 2]
       │    │    │    ├── (42948, 3)
       │    │    │    └── (24924, 4)
-      │    │    └── filters
-      │    │         └── ((((dealerid:8 = 1) OR (dealerid:8 = 2)) OR (dealerid:8 = 3)) OR (dealerid:8 = 4)) OR (dealerid:8 = 5) [outer=(8), constraints=(/8: [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5]; tight)]
+      │    │    └── filters (true)
       │    └── projections
       │         └── CASE WHEN quantity:7 < inventorydetails.quantity:11 THEN quantity:7 ELSE inventorydetails.quantity:11 END [as=quantity:15, outer=(7,11)]
       └── aggregations

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -1113,8 +1113,7 @@ top-k
       │    │    │    ├── cardinality: [2 - 2]
       │    │    │    ├── (42948, 3)
       │    │    │    └── (24924, 4)
-      │    │    └── filters
-      │    │         └── ((((dealerid:8 = 1) OR (dealerid:8 = 2)) OR (dealerid:8 = 3)) OR (dealerid:8 = 4)) OR (dealerid:8 = 5) [outer=(8), constraints=(/8: [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5]; tight)]
+      │    │    └── filters (true)
       │    └── projections
       │         └── CASE WHEN quantity:7 < inventorydetails.quantity:11 THEN quantity:7 ELSE inventorydetails.quantity:11 END [as=quantity:17, outer=(7,11)]
       └── aggregations

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -3142,8 +3142,7 @@ left-join (lookup lookup_expr [as=t])
  │    │    ├── (1, 10)
  │    │    ├── (2, 20)
  │    │    └── (3, NULL)
- │    └── filters
- │         └── (u:5 = 1) OR (u:5 = 2) [outer=(5), constraints=(/5: [/1 - /1] [/2 - /2]; tight)]
+ │    └── filters (true)
  └── filters (true)
 
 # We can't build a lookup join with any of the indexes.
@@ -11658,8 +11657,7 @@ inner-join (lookup metric_values)
  │    ├── constraint: /7/6: [/'cpu' - /'cpu']
  │    ├── key: (6)
  │    └── fd: ()-->(7)
- └── filters
-      └── (time:2 IN ('2022-04-07 00:00:00+00:00', '2022-04-08 00:00:00+00:00', '2022-04-09 00:00:00+00:00')) AND (time:2 > '2022-04-07 00:00:00+00:00') [outer=(2), constraints=(/2: [/'2022-04-08 00:00:00+00:00' - /'2022-04-08 00:00:00+00:00'] [/'2022-04-09 00:00:00+00:00' - /'2022-04-09 00:00:00+00:00']; tight)]
+ └── filters (true)
 
 # We don't support turning LIKE into scans yet, test that we fall back to a
 # filter.


### PR DESCRIPTION
#### opt: return ordinals of equality filters from memo.ExtractJoinEqualityColumns

This is a prerequisite for future refactoring of
`lookupjoin.ConstraintBuilder`.

Release note: None

#### opt: calculate lookup join remaining filters more accurately

`lookupjoin.ConstraintBuilder` now determines the remaining filters for
a lookup join constraint more accurately by tracking the ordinals of
filters that are covered by the constraint, rather than trying to reduce
the filters original filters based on the key columns, lookup
expression, and constant expression.

Release note: None
