### PR TITLE
testutils: remove stack trace from SucceedsWithin

### DIFF
--- a/pkg/testutils/soon.go
+++ b/pkg/testutils/soon.go
@@ -12,7 +12,6 @@ package testutils
 
 import (
 	"context"
-	"runtime/debug"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -56,8 +55,7 @@ func SucceedsSoonError(fn func() error) error {
 func SucceedsWithin(t TB, fn func() error, duration time.Duration) {
 	t.Helper()
 	if err := SucceedsWithinError(fn, duration); err != nil {
-		t.Fatalf("condition failed to evaluate within %s: %s\n%s",
-			duration, err, string(debug.Stack()))
+		t.Fatalf("condition failed to evaluate within %s: %s", duration, err)
 	}
 }
 


### PR DESCRIPTION
It has `t.Helper()` so it will already show the caller.

Release note: None
