### PR TITLE
logictest: fix flake in distsql_event_log

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_event_log
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_event_log
@@ -19,10 +19,12 @@ CREATE STATISTICS s1 ON id FROM a
 statement ok
 CREATE STATISTICS __auto__ FROM a
 
+# Check explicitly for table id 106. System tables could trigger autostats
+# collections at any time.
 query IIT
 SELECT "targetID", "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID'
 FROM system.eventlog
-WHERE "eventType" = 'create_statistics' AND "targetID" <> 12
+WHERE "eventType" = 'create_statistics' AND "targetID" = 106
 ORDER BY "timestamp", info
 ----
 106  1  {"EventType": "create_statistics", "Statement": "CREATE STATISTICS s1 ON id FROM test.public.a", "TableName": "test.public.a", "Tag": "CREATE STATISTICS", "User": "root"}


### PR DESCRIPTION
Fixes a test flake introduced by #80887.

Check for an explicit table id in the output as autostats collection on
system tables may kick in at any time.

Release note: none