### PR TITLE
roachtest: fix costfuzz log on error while running perturbed statement

### DIFF
--- a/pkg/cmd/roachtest/tests/costfuzz.go
+++ b/pkg/cmd/roachtest/tests/costfuzz.go
@@ -223,6 +223,7 @@ func runCostFuzzQuery(
 	// Then, rerun the statement with cost perturbation.
 	rows2, err := conn.Query(stmt)
 	if err != nil {
+		logStmt(stmt)
 		logStmt(seedStmt)
 		logStmt(stmt)
 		return errors.Wrap(err, "error while running perturbed statement")


### PR DESCRIPTION
Also log the unperturbed statement when the costfuzz test encounters an
error executing the perturbed statement.

This can be fixed by hand, but it's easier if the costfuzz log is
correct.

Informs: #81032

Release note: None