### PR TITLE
sql : sequence value out of bounds

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -2253,3 +2253,61 @@ SELECT nextval('restart_txn_seq')
 
 statement ok
 END
+
+# Regression test for #74127. Assert that out-of-range sequence values are not returned.
+
+# The value value(12) is out-of-bounds
+statement ok
+CREATE SEQUENCE customer_seq_check_cache_and_bounds_1 INCREMENT  BY 3  MINVALUE 6 MAXVALUE 10
+
+query I
+SELECT nextval('customer_seq_check_cache_and_bounds_1')
+----
+6
+
+query I
+SELECT nextval('customer_seq_check_cache_and_bounds_1')
+----
+9
+
+statement error pgcode 2200H pq: nextval\(\): reached maximum value of sequence "customer_seq_check_cache_and_bounds_1" \(10\)
+SELECT nextval('customer_seq_check_cache_and_bounds_1')
+
+# Set the cache to 5
+statement ok
+CREATE SEQUENCE customer_seq_check_cache_and_bounds_2 MINVALUE -2 MAXVALUE 2 START WITH 1 CACHE 5 INCREMENT BY -2
+
+query I
+SELECT nextval('customer_seq_check_cache_and_bounds_2')
+----
+1
+
+query I
+SELECT nextval('customer_seq_check_cache_and_bounds_2')
+----
+-1
+
+statement error pgcode 2200H pq: nextval\(\): reached minimum value of sequence "customer_seq_check_cache_and_bounds_2" \(-2\)
+SELECT nextval('customer_seq_check_cache_and_bounds_2')
+
+# The value value(12) is equal with MAXVALUE(12)
+statement ok
+CREATE SEQUENCE customer_seq_check_cache_and_bounds_3 INCREMENT  BY 3  MINVALUE 6 MAXVALUE 12
+
+query I
+SELECT nextval('customer_seq_check_cache_and_bounds_3')
+----
+6
+
+query I
+SELECT nextval('customer_seq_check_cache_and_bounds_3')
+----
+9
+
+query I
+SELECT nextval('customer_seq_check_cache_and_bounds_3')
+----
+12
+
+statement error pgcode 2200H pq: nextval\(\): reached maximum value of sequence "customer_seq_check_cache_and_bounds_3" \(12\)
+SELECT nextval('customer_seq_check_cache_and_bounds_3')

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -186,8 +186,8 @@ func (p *planner) incrementSequenceUsingCache(
 		// This sequence has exceeded its bounds after performing this increment.
 		if endValue > seqOpts.MaxValue || endValue < seqOpts.MinValue {
 			// If the sequence exceeded its bounds prior to the increment, then return an error.
-			if (seqOpts.Increment > 0 && endValue-seqOpts.Increment*cacheSize >= seqOpts.MaxValue) ||
-				(seqOpts.Increment < 0 && endValue-seqOpts.Increment*cacheSize <= seqOpts.MinValue) {
+			if (seqOpts.Increment > 0 && endValue-seqOpts.Increment*(cacheSize-1) > seqOpts.MaxValue) ||
+				(seqOpts.Increment < 0 && endValue-seqOpts.Increment*(cacheSize-1) < seqOpts.MinValue) {
 				return 0, 0, 0, boundsExceededError(descriptor)
 			}
 			// Otherwise, values between the limit and the value prior to incrementing can be cached.


### PR DESCRIPTION
Previously, an additional out-of-range sequence value may have been
generated.
The original criterion was whether the previous endSequence value exceeded the limit.
However, when the current endSequence is 1, the increment is 2 and the MaxValue is 2,
the previous endSequence value is 1 and the program does not report an error.
However, when the current endSequenceValue 3 exceeds the limit, an error should be reported

In incrementSequenceUsingCache, the criterion for determining whether a cache's data is eligible is modified to whether the first data that may be stored in the cache exceeds the limit.

Fixes #74127.

Release note (bug fix): Fixed a bug where sequences could return values that are out-of-bounds in some cases.