### PR TITLE
storage: use provisional version value to determine uncertainty of intents

### DIFF
--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -655,12 +655,10 @@ func (p *pebbleMVCCScanner) getAndAdvance(ctx context.Context) bool {
 		// we want to read the intent regardless of our read timestamp and fall
 		// into case 11 below.
 		if p.checkUncertainty {
-			if p.uncertainty.IsUncertain(metaTS) {
-				return p.uncertaintyError(metaTS)
-			}
-			// The intent is not within the uncertainty window, but there could
-			// be an uncertain committed value, so seek and check uncertainty
-			// using the uncertainty interval's GlobalLimit.
+			// The intent's provisional value may be within the uncertainty window. Or
+			// there could be a different, uncertain committed value in the window. To
+			// detect either case, seek to and past the uncertainty interval's global
+			// limit and check uncertainty as we scan.
 			return p.seekVersion(ctx, p.uncertainty.GlobalLimit, true)
 		}
 		return p.seekVersion(ctx, p.ts, false)


### PR DESCRIPTION
Related to #80706.
Related to #66485.

This commit makes a slight modification to `pebbleMVCCScanner` that changes how it determines whether an intent is uncertain or not. Instead of consulting the version timestamp in the `MVCCMetadata` struct and comparing that against the scan's uncertainty interval, the `pebbleMVCCScanner` now scans through the uncertainty interval and uses the intent's provisional value's timestamp to determine uncertainty.

The `pebbleMVCCScanner` was actually already doing this scan to compute uncertainty for other committed values in its uncertainty interval if it found that the intent was not uncertain. However, after this change, it also relies on the scan to compute uncertainty for the intent itself. This is safe, because the calling code knows that the intent has a higher timestamp than the scan, so there is no risk that the scan adds the provisional value to its result set.

This change is important for two reasons:
1. it avoids the need to store the `local_timestamp` field (introduced in #80706) in the `MVCCMetadata` struct.
2. it moves us closer in the direction of using `MVCCMetadata` values (ts=0, essentially locks protecting provisional values) to determine read-write conflicts but then using versioned provisional values to determine uncertainty. Doing so allows us to decompose a KV scan into a separate lock table scan to detect read-write conflicts and a MVCC scan to accumulate a result set while checking for uncertainty. This will be important for #66485.