### PR TITLE
kvserver: don't return lease when failing to acquire

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -873,6 +873,77 @@ func TestNoBackoffOnNotLeaseHolderErrorFromFollowerRead(t *testing.T) {
 	require.Equal(t, int64(0), ds.Metrics().InLeaseTransferBackoffs.Count())
 }
 
+// TestNoBackoffOnNotLeaseHolderErrorWithoutLease verifies that the DistSender
+// does not retry a replica using backoff upon receiving a NotLeaseHolderError
+// without lease information. This could e.g. indicate that the replica
+// was unable to acquire an expired lease for itself, because it wasn't
+// able to heartbeat.
+func TestNoBackoffOnNotLeaseHolderErrorWithoutLease(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	stopper := stop.NewStopper()
+	ctx := context.Background()
+	defer stopper.Stop(ctx)
+
+	// Lease starts on n1.
+	rangeDesc := testUserRangeDescriptor3Replicas
+	replicas := rangeDesc.InternalReplicas
+	lease := roachpb.Lease{
+		Replica:  replicas[0],
+		Sequence: 1,
+	}
+
+	// n1 and n2 return an NLHE without lease information, n3 returns success.
+	// Record which replicas the request was sent to.
+	var sentTo []roachpb.NodeID
+	sendFn := func(_ context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, error) {
+		sentTo = append(sentTo, ba.Replica.NodeID)
+		br := ba.CreateReply()
+		if ba.Replica != replicas[2] {
+			br.Error = roachpb.NewError(&roachpb.NotLeaseHolderError{
+				Replica: ba.Replica,
+			})
+		}
+		return br, nil
+	}
+
+	// Set up a DistSender stack.
+	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
+	g := makeGossip(t, stopper, rpcContext)
+	for _, r := range replicas {
+		require.NoError(t, g.AddInfoProto(
+			gossip.MakeNodeIDKey(r.NodeID),
+			newNodeDesc(r.NodeID),
+			gossip.NodeDescriptorTTL,
+		))
+	}
+	cfg := DistSenderConfig{
+		AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+		Clock:      clock,
+		NodeDescs:  g,
+		RPCContext: rpcContext,
+		TestingKnobs: ClientTestingKnobs{
+			TransportFactory: adaptSimpleTransport(sendFn),
+		},
+		RangeDescriptorDB: threeReplicaMockRangeDescriptorDB,
+		NodeDialer:        nodedialer.New(rpcContext, gossip.AddressResolver(g)),
+		Settings:          cluster.MakeTestingClusterSettings(),
+	}
+	ds := NewDistSender(cfg)
+	ds.rangeCache.Insert(ctx, roachpb.RangeInfo{
+		Desc:  rangeDesc,
+		Lease: lease,
+	})
+
+	// Send a request. It should try all three replicas once: the first two fail
+	// with NLHE, the third one succeeds. None of them should trigger backoffs.
+	_, pErr := kv.SendWrapped(ctx, ds, roachpb.NewGet(roachpb.Key("a"), false /* forUpdate */))
+	require.NoError(t, pErr.GoError())
+	require.Equal(t, []roachpb.NodeID{1, 2, 3}, sentTo)
+	require.Equal(t, int64(0), ds.Metrics().InLeaseTransferBackoffs.Count())
+}
+
 // Test a scenario where a lease indicates a replica that, when contacted,
 // claims to not have the lease and instead returns an older lease. In this
 // scenario, the DistSender detects the fact that the node returned an old lease

--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -1035,9 +1035,8 @@ func TestLeasesDontThrashWhenNodeBecomesSuspect(t *testing.T) {
 		for _, i := range []int{2, 3} {
 			repl := tc.GetFirstStoreFromServer(t, i).LookupReplica(roachpb.RKey(key))
 			require.NotNil(t, repl)
-			_, _, enqueueError := tc.GetFirstStoreFromServer(t, i).
-				ManuallyEnqueue(ctx, "replicate", repl, true)
-			require.NoError(t, enqueueError)
+			// We don't know who the leaseholder might be, so ignore errors.
+			_, _, _ = tc.GetFirstStoreFromServer(t, i).ManuallyEnqueue(ctx, "replicate", repl, true)
 		}
 	}
 

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3435,12 +3435,8 @@ func (s *Store) ManuallyEnqueue(
 	// Many queues are only meant to be run on leaseholder replicas, so attempt to
 	// take the lease here or bail out early if a different replica has it.
 	if needsLease {
-		hasLease, pErr := repl.getLeaseForGossip(ctx)
-		if pErr != nil {
-			return nil, nil, pErr.GoError()
-		}
-		if !hasLease {
-			return nil, errors.Newf("replica %v does not have the range lease", repl), nil
+		if _, pErr := repl.redirectOnOrAcquireLease(ctx); pErr != nil {
+			return nil, nil, errors.Wrapf(pErr.GoError(), "replica %v does not have the range lease", repl)
 		}
 	}
 


### PR DESCRIPTION
**kvserver: improve lease acquisition in `Store.ManuallyEnqueue()`**

Manually enqueuing a range through a queue may sometimes require
acquiring the lease first, since it can only be run on the leaseholder.
Previously this was done through `getLeaseForGossip`, which was meant
for acquiring the gossip lease and would hide certain errors from the
queue.

This patch instead uses `redirectOnOrAcquireLease` to acquire the lease,
and returns an error if the local replica failed to acquire the lease
(even if there is a valid leaseholder elsewhere).

Release note: None

**kvserver: don't return lease when failing to acquire**

This patch does not return the previous, expired lease when a replica
fails to acquire it for itself. In particular, this prevents the calling
DistSender from continually retrying the old leaseholder if it fails to
reacquire the lease (e.g. due to a stalled disk).

Touches #81100.

Release note: None