### PR TITLE
asim: fix uniqueness invariant on adding ranges

### DIFF
--- a/pkg/kv/kvserver/asim/asim.go
+++ b/pkg/kv/kvserver/asim/asim.go
@@ -64,7 +64,7 @@ func (rm *RangeMap) AddRange(minKey string) *Range {
 	rm.ranges.AscendGreaterOrEqual(r, func(i btree.Item) bool {
 		// The min key already exists in the range map, we cannot return a new
 		// range. Instead crash here as this is a bug.
-		if i.Less(r) {
+		if !r.Less(i) {
 			panic(fmt.Sprintf("Range with minKey: %s already exists within the range map, unable to add new range", r.MinKey))
 		}
 

--- a/pkg/kv/kvserver/asim/asim_test.go
+++ b/pkg/kv/kvserver/asim/asim_test.go
@@ -56,6 +56,10 @@ func TestRangeMap(t *testing.T) {
 	require.Equal(t, r1.MinKey, m.GetRange("c").MinKey)
 	require.Equal(t, r2.MinKey, m.GetRange("g").MinKey)
 	require.Equal(t, r3.MinKey, m.GetRange("z").MinKey)
+
+	require.Panics(t, func() { m.AddRange("b") }, "Adding a range with the same minKey twice should panic")
+	require.Panics(t, func() { m.AddRange("f") }, "Adding a range with the same minKey twice should panic")
+	require.Panics(t, func() { m.AddRange("x") }, "Adding a range with the same minKey twice should panic")
 }
 
 func TestAddReplica(t *testing.T) {


### PR DESCRIPTION
Previously adding a new range would be not hold the invariant that
minKey [minKey,endKey) must be unique. This patch updates the assertion
and adds testing for this invariant.

Release note: None
