### PR TITLE
sql: minor sqlsmith and tlp cleanup

### DIFF
--- a/pkg/cmd/roachtest/tests/costfuzz.go
+++ b/pkg/cmd/roachtest/tests/costfuzz.go
@@ -145,7 +145,7 @@ func runOneRoundCostFuzz(
 
 	// Initialize a smither that generates only deterministic SELECT statements.
 	smither, err := sqlsmith.NewSmither(conn, rnd,
-		sqlsmith.DisableMutations(), sqlsmith.DisableImpureFuncs(), sqlsmith.DisableLimits(),
+		sqlsmith.DisableMutations(), sqlsmith.DisableImpureFns(), sqlsmith.DisableLimits(),
 		sqlsmith.SetComplexity(.3),
 	)
 	if err != nil {

--- a/pkg/cmd/roachtest/tests/tlp.go
+++ b/pkg/cmd/roachtest/tests/tlp.go
@@ -146,7 +146,8 @@ func runOneTLP(
 	defer mutSmither.Close()
 
 	// Initialize a smither that will never generate mutations.
-	tlpSmither, err := sqlsmith.NewSmither(conn, rnd, sqlsmith.DisableMutations())
+	tlpSmither, err := sqlsmith.NewSmither(conn, rnd,
+		sqlsmith.DisableMutations(), sqlsmith.DisableImpureFns())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -372,7 +372,7 @@ func makeFunc(s *Smither, ctx Context, typ *types.T, refs colRefs) (tree.TypedEx
 	if class == tree.WindowClass && s.d6() != 1 {
 		class = tree.NormalClass
 	}
-	fns := s.functions[class][typ.Oid()]
+	fns := functions[class][typ.Oid()]
 	if len(fns) == 0 {
 		return nil, false
 	}

--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treebin"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq/oid"
@@ -478,7 +477,7 @@ type function struct {
 	overload *tree.Overload
 }
 
-func functions(s *Smither) map[tree.FunctionClass]map[oid.Oid][]function {
+var functions = func() map[tree.FunctionClass]map[oid.Oid][]function {
 	m := map[tree.FunctionClass]map[oid.Oid][]function{}
 	for _, def := range tree.FunDefs {
 		switch def.Name {
@@ -510,19 +509,6 @@ func functions(s *Smither) map[tree.FunctionClass]map[oid.Oid][]function {
 		}
 		if skip {
 			continue
-		}
-		if s.disableImpureFuncs {
-			var impure bool
-			for _, def := range def.Definition {
-				overload := def.(*tree.Overload)
-				switch overload.Volatility {
-				case volatility.Stable, volatility.Volatile:
-					impure = true
-				}
-			}
-			if impure {
-				continue
-			}
 		}
 		if _, ok := m[def.Class]; !ok {
 			m[def.Class] = map[oid.Oid][]function{}
@@ -557,4 +543,4 @@ func functions(s *Smither) map[tree.FunctionClass]map[oid.Oid][]function {
 		}
 	}
 	return m
-}
+}()

--- a/pkg/internal/sqlsmith/tlp.go
+++ b/pkg/internal/sqlsmith/tlp.go
@@ -59,13 +59,6 @@ SELECT (SELECT count(*) FROM undiff), (SELECT count(*) FROM diff)`,
 // have all been implemented in SQLancer. See:
 // https://github.com/sqlancer/sqlancer/tree/1.1.0/src/sqlancer/cockroachdb/oracle/tlp.
 func (s *Smither) GenerateTLP() (unpartitioned, partitioned string, args []interface{}) {
-	// Set disableImpureFns to true so that generated predicates are immutable.
-	originalDisableImpureFns := s.disableImpureFns
-	s.disableImpureFns = true
-	defer func() {
-		s.disableImpureFns = originalDisableImpureFns
-	}()
-
 	switch tlpType := s.rnd.Intn(5); tlpType {
 	case 0:
 		partitioned, unpartitioned, args = s.generateWhereTLP()


### PR DESCRIPTION
#### sqlsmith: remove duplicate disableImpureFuncs

In #79973, `Smither.disableImpureFuncs` and `Smither.DisableImpureFuncs`
was added. The `Smither` already had `disableImpureFns` and
`DisableImpureFns` for disabling the generation of impure function
calls, so the newly added field and method are redundant. This commit
consolidates things.

Release note: None

#### tlp: use Smither.DisableImpureFns to disable impure functions

TLP now uses `Smither.DisableImpureFns` to disable the generation of
impure function calls, rather than writing to the internal
`Smither.disableImpureFns` field. Writing to the internal field directly
was preferred prior to #81017 when a single Smither was shared between
TLP query generation and mutation statement generation so that mutation
statements could use impure functions.

Release note: None
