### PR TITLE
kv/liveness: perform sync WAL write to each store in parallel

### DIFF
--- a/pkg/kv/kvserver/liveness/BUILD.bazel
+++ b/pkg/kv/kvserver/liveness/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
+        "@org_golang_x_sync//errgroup",
     ],
 )
 

--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -1259,7 +1259,7 @@ func (nl *NodeLiveness) updateLiveness(
 			// don't want any excessively slow disks to prevent leases from being
 			// shifted to other nodes. A slow/stalled disk would block here and cause
 			// the node to lose its leases.
-			if err := storage.WriteSyncNoop(ctx, eng); err != nil {
+			if err := storage.WriteSyncNoop(eng); err != nil {
 				return Record{}, errors.Wrapf(err, "couldn't update node liveness because disk write failed")
 			}
 		}

--- a/pkg/kv/kvserver/stores_server.go
+++ b/pkg/kv/kvserver/stores_server.go
@@ -118,7 +118,7 @@ func (is Server) WaitForApplication(
 				// everything up to this point to disk.
 				//
 				// https://github.com/cockroachdb/cockroach/issues/33120
-				return storage.WriteSyncNoop(ctx, s.engine)
+				return storage.WriteSyncNoop(s.engine)
 			}
 		}
 		if ctx.Err() == nil {

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -945,7 +945,7 @@ func ScanIntents(
 }
 
 // WriteSyncNoop carries out a synchronous no-op write to the engine.
-func WriteSyncNoop(ctx context.Context, eng Engine) error {
+func WriteSyncNoop(eng Engine) error {
 	batch := eng.NewBatch()
 	defer batch.Close()
 


### PR DESCRIPTION
This commit updates NodeLiveness to perform its no-op WAL write + sync in
parallel across each store. This feels valuable for systems that have many (8+)
stores per node. Without it, these systems can tolerate `1/num_stores_per_node`
the slowdown for writes that a single store node can tolerate. For instance, if
a node with a single store can tolerate writes as slow as 4s before failing its
liveness heartbeats, a node with eight stores can only tolerate writes as slow
as (on average) 500ms before failing its liveness heartbeats.