### PR TITLE
ui: Add time frame shown to Jobs Page table

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -5911,6 +5911,7 @@ JobsResponse contains the job record for each matching job.
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
 | jobs | [JobResponse](#cockroach.server.serverpb.JobsResponse-cockroach.server.serverpb.JobResponse) | repeated |  | [reserved](#support-status) |
+| earliest_retained_time | [google.protobuf.Timestamp](#cockroach.server.serverpb.JobsResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
 
 
 

--- a/pkg/jobs/config.go
+++ b/pkg/jobs/config.go
@@ -109,7 +109,8 @@ var (
 		settings.PositiveDuration,
 	)
 
-	retentionTimeSetting = settings.RegisterDurationSetting(
+	// RetentionTimeSetting wraps "jobs.retention_timehelpers_test.go".
+	RetentionTimeSetting = settings.RegisterDurationSetting(
 		settings.TenantWritable,
 		retentionTimeSettingKey,
 		"the amount of time to retain records for completed jobs before",

--- a/pkg/jobs/helpers_test.go
+++ b/pkg/jobs/helpers_test.go
@@ -139,5 +139,4 @@ var (
 	CancelIntervalSetting           = cancelIntervalSetting
 	CancellationsUpdateLimitSetting = cancellationsUpdateLimitSetting
 	GcIntervalSetting               = gcIntervalSetting
-	RetentionTimeSetting            = retentionTimeSetting
 )

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -827,7 +827,7 @@ func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) error {
 			if r.knobs.IntervalOverrides.RetentionTime != nil {
 				return *r.knobs.IntervalOverrides.RetentionTime
 			}
-			return retentionTimeSetting.Get(&r.settings.SV)
+			return RetentionTimeSetting.Get(&r.settings.SV)
 		}
 
 		for {

--- a/pkg/jobs/testing_knobs.go
+++ b/pkg/jobs/testing_knobs.go
@@ -88,7 +88,7 @@ type TestingIntervalOverrides struct {
 	// Gc overrides the gcIntervalSetting cluster setting.
 	Gc *time.Duration
 
-	// RetentionTime overrides the retentionTimeSetting cluster setting.
+	// RetentionTime overrides the RetentionTimeSetting cluster setting.
 	RetentionTime *time.Duration
 
 	// RetryInitialDelay overrides retryInitialDelaySetting cluster setting.

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2042,6 +2042,21 @@ func (s *adminServer) jobsHelper(
 	}
 
 	var resp serverpb.JobsResponse
+
+	now := timeutil.Now()
+	if s.server.cfg.TestingKnobs.Server != nil &&
+		s.server.cfg.TestingKnobs.Server.(*TestingKnobs).StubTimeNow != nil {
+		now = s.server.cfg.TestingKnobs.Server.(*TestingKnobs).StubTimeNow()
+	}
+	retentionDuration := func() time.Duration {
+		if s.server.cfg.TestingKnobs.Server != nil &&
+			s.server.cfg.TestingKnobs.JobsTestingKnobs.(*jobs.TestingKnobs).IntervalOverrides.RetentionTime != nil {
+			return *s.server.cfg.TestingKnobs.JobsTestingKnobs.(*jobs.TestingKnobs).IntervalOverrides.RetentionTime
+		}
+		return jobs.RetentionTimeSetting.Get(&s.server.st.SV)
+	}
+	resp.EarliestRetainedTime = now.Add(-retentionDuration())
+
 	if !ok {
 		// The query returned 0 rows.
 		return &resp, nil

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -24,6 +24,7 @@ import "ts/catalog/chart_catalog.proto";
 import "util/metric/metric.proto";
 import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
+import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
 // ZoneConfigurationLevel indicates, for objects with a Zone Configuration,
@@ -604,6 +605,7 @@ message JobsRequest {
 // JobsResponse contains the job record for each matching job.
 message JobsResponse {
   repeated JobResponse jobs = 1 [(gogoproto.nullable) = false];
+  google.protobuf.Timestamp earliest_retained_time = 2 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
 }
 
 // JobRequest requests system job information for the given job_id.

--- a/pkg/server/testing_knobs.go
+++ b/pkg/server/testing_knobs.go
@@ -105,6 +105,10 @@ type TestingKnobs struct {
 	// BlobClientFactory supplies a BlobClientFactory for
 	// use by servers.
 	BlobClientFactory blobs.BlobClientFactory
+
+	// StubTimeNow allows tests to override the timeutil.Now() function used
+	// in the jobs endpoint to calculate earliest_retained_time.
+	StubTimeNow func() time.Time
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/ui/workspaces/db-console/src/views/jobs/index.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/index.spec.tsx
@@ -15,6 +15,7 @@ import { formatDuration } from ".";
 import { JobsTable, JobsTableProps } from "src/views/jobs/index";
 import {
   allJobsFixture,
+  earliestRetainedTime,
   retryRunningJobFixture,
 } from "src/views/jobs/jobsTable.fixture";
 import { refreshJobs } from "src/redux/apiReducers";
@@ -42,6 +43,7 @@ const getMockJobsTableProps = (jobs: Array<Job>): JobsTableProps => {
     jobs: {
       data: {
         jobs: jobs,
+        earliest_retained_time: earliestRetainedTime,
         toJSON: () => ({}),
       },
       inFlight: false,
@@ -89,6 +91,22 @@ describe("Jobs", () => {
 
     for (const columnTitle of expectedColumnTitles) {
       getByText(columnTitle);
+    }
+  });
+
+  it("renders a message when the table is empty", () => {
+    const { getByText } = render(
+      <MemoryRouter>
+        <JobsTable {...getMockJobsTableProps([])} />
+      </MemoryRouter>,
+    );
+    const expectedText = [
+      "No jobs to show",
+      "The jobs page provides details about backup/restore jobs, schema changes, user-created table statistics, automatic table statistics jobs and changefeeds.",
+    ];
+
+    for (const text of expectedText) {
+      getByText(text);
     }
   });
 

--- a/pkg/ui/workspaces/db-console/src/views/jobs/index.styl
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/index.styl
@@ -21,6 +21,10 @@
   justify-content center
   height 100%
 
+.jobs-table-summary
+  &__retention-divider
+    padding-right 7px
+    padding-left 7px
 
 .jobs-table
   h3

--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobTable.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobTable.spec.tsx
@@ -14,6 +14,7 @@ import { assert } from "chai";
 import { JobTable, JobTableProps } from "src/views/jobs/jobTable";
 
 import "src/enzymeInit";
+import { earliestRetainedTime } from "src/views/jobs/jobsTable.fixture";
 
 describe("<JobTable>", () => {
   it("should reset page to 1 after job list prop changes", () => {
@@ -24,7 +25,11 @@ describe("<JobTable>", () => {
       sort: { columnTitle: null, ascending: true },
       setSort: () => {},
       jobs: {
-        data: { jobs: [{}, {}, {}, {}], toJSON },
+        data: {
+          jobs: [{}, {}, {}, {}],
+          earliest_retained_time: earliestRetainedTime,
+          toJSON,
+        },
         inFlight: false,
         valid: true,
       },

--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobTable.tsx
@@ -10,6 +10,7 @@
 
 import React, { MouseEvent } from "react";
 import { cockroach } from "src/js/protos";
+import * as protos from "@cockroachlabs/crdb-protobuf-client";
 import { DATE_FORMAT_24_UTC } from "src/util/format";
 import { JobStatusCell } from "src/views/jobs/jobStatusCell";
 import { CachedDataReducerState } from "src/redux/cachedDataReducer";
@@ -19,9 +20,11 @@ import Job = cockroach.server.serverpb.IJobResponse;
 import JobsResponse = cockroach.server.serverpb.JobsResponse;
 import {
   ColumnDescriptor,
+  EmptyTable,
   Pagination,
   ResultsPerPageLabel,
   SortSetting,
+  SortedTable,
   util,
 } from "@cockroachlabs/cluster-ui";
 import {
@@ -32,7 +35,6 @@ import {
   jobTable,
 } from "src/util/docs";
 import { trackDocsLink } from "src/util/analytics";
-import { EmptyTable, SortedTable } from "@cockroachlabs/cluster-ui";
 import { Anchor } from "src/components";
 import emptyTableResultsIcon from "assets/emptyState/empty-table-results.svg";
 import magnifyingGlassIcon from "assets/emptyState/magnifying-glass.svg";
@@ -246,16 +248,6 @@ export class JobTable extends React.Component<JobTableProps, JobTableState> {
     this.setState({ pagination: { ...pagination, current } });
   };
 
-  renderCounts = () => {
-    const {
-      pagination: { current, pageSize },
-    } = this.state;
-    const total = this.props.jobs.data.jobs.length;
-    const pageCount = current * pageSize > total ? total : current * pageSize;
-    const count = total > 10 ? pageCount : current * total;
-    return `${count} of ${total} jobs`;
-  };
-
   renderEmptyState = () => {
     const { isUsedFilter, jobs } = this.props;
     const hasData = jobs?.data?.jobs?.length > 0;
@@ -304,18 +296,34 @@ export class JobTable extends React.Component<JobTableProps, JobTableState> {
     trackDocsLink(e.currentTarget.text);
   };
 
+  formatJobsRetentionMessage = (
+    earliestRetainedTime: protos.google.protobuf.ITimestamp,
+  ): string => {
+    return `Since ${util
+      .TimestampToMoment(earliestRetainedTime)
+      .format(DATE_FORMAT_24_UTC)}`;
+  };
+
   render() {
     const jobs = this.props.jobs.data.jobs;
     const { pagination } = this.state;
 
     return (
       <React.Fragment>
-        <div className="cl-table-statistic">
+        <div className="cl-table-statistic jobs-table-summary">
           <h4 className="cl-count-title">
             <ResultsPerPageLabel
               pagination={{ ...pagination, total: jobs.length }}
               pageName="jobs"
             />
+            {this.props.jobs.data.earliest_retained_time && (
+              <>
+                <span className="jobs-table-summary__retention-divider">|</span>
+                {this.formatJobsRetentionMessage(
+                  this.props.jobs.data.earliest_retained_time,
+                )}
+              </>
+            )}
           </h4>
         </div>
         <JobsSortedTable

--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobsTable.fixture.ts
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobsTable.fixture.ts
@@ -316,18 +316,23 @@ const staticJobProps: Pick<
   refreshJobs: () => null,
 };
 
+const now = moment("Mon Oct 21 2021 14:01:45 GMT-0400 (Eastern Daylight Time)");
+export const earliestRetainedTime = new protos.google.protobuf.Timestamp({
+  seconds: new Long(1633611318),
+  nanos: 200459000,
+});
+
 const getJobsTableProps = (jobs: Array<Job>): JobsTableProps => ({
   ...staticJobProps,
   jobs: {
     inFlight: false,
     valid: false,
-    requestedAt: moment(
-      "Mon Oct 18 2021 14:01:45 GMT-0400 (Eastern Daylight Time)",
-    ),
-    setAt: moment("Mon Oct 18 2021 14:01:50 GMT-0400 (Eastern Daylight Time)"),
+    requestedAt: now,
+    setAt: moment("Mon Oct 21 2021 14:01:50 GMT-0400 (Eastern Daylight Time)"),
     lastError: null,
     data: JobsResponse.create({
       jobs: jobs,
+      earliest_retained_time: earliestRetainedTime,
     }),
   },
 });
@@ -339,9 +344,7 @@ export const loading: JobsTableProps = {
   jobs: {
     inFlight: true,
     valid: false,
-    requestedAt: moment(
-      "Mon Oct 18 2021 14:01:45 GMT-0400 (Eastern Daylight Time)",
-    ),
+    requestedAt: now,
   },
 };
 
@@ -350,9 +353,7 @@ export const error: JobsTableProps = {
   jobs: {
     inFlight: false,
     valid: false,
-    requestedAt: moment(
-      "Mon Oct 18 2021 14:01:45 GMT-0400 (Eastern Daylight Time)",
-    ),
+    requestedAt: now,
     lastError: new Error(jobsTimeoutErrorMessage),
   },
 };


### PR DESCRIPTION
Fixes #71563

This commit adds a message in the Jobs Page table indicating the oldest time
(in UTC) that jobs are shown for. This oldest time is calculated as `now - the
duration of the jobs.retention_time cluster setting`.

Before:
<img width="576" alt="image" src="https://user-images.githubusercontent.com/91907326/167450903-f88c8dc9-eb1a-44b9-8b09-5e3c329dd764.png">

After:
<img width="519" alt="image" src="https://user-images.githubusercontent.com/91907326/167472135-d6eb5515-5f56-4e35-baf3-a3691624a932.png">

Release note (ui): The Jobs Page now shows the oldest time (in UTC) that jobs
are shown for.