### PR TITLE
security: require Ed25519 for session revival token validation

### DIFF
--- a/pkg/security/sessionrevival/token.go
+++ b/pkg/security/sessionrevival/token.go
@@ -12,6 +12,7 @@ package sessionrevival
 
 import (
 	"crypto/ed25519"
+	"crypto/x509"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
@@ -97,8 +98,16 @@ func ValidateSessionRevivalToken(
 	if err := validatePayloadContents(payload, user); err != nil {
 		return err
 	}
+
+	var signatureAlg x509.SignatureAlgorithm
+	switch payload.Algorithm {
+	case x509.Ed25519.String():
+		signatureAlg = x509.PureEd25519
+	default:
+		return errors.Newf("unsupported algorithm %s", payload.Algorithm)
+	}
 	for _, c := range cert.ParsedCertificates {
-		if err := c.CheckSignature(c.SignatureAlgorithm, token.Payload, token.Signature); err == nil {
+		if err := c.CheckSignature(signatureAlg, token.Payload, token.Signature); err == nil {
 			return nil
 		}
 	}


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/81138

This allows the session revival pubic key to not be self-signed by the
corresponding private key. This fixes a bug where the certificate
authority's signature algorithm was used to validate signatures rather
than the private key's signing algorithm.

No release note, since this is internal only.

Release note: None