### PR TITLE
opt: simplify lookup join constraint building

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
@@ -286,13 +286,13 @@ vectorized: true
 │           │ estimated row count: 0
 │           │ table: customer@primary
 │           │ equality cols are key
-│           │ lookup condition: (((column3 = c_w_id) AND (column2 = c_d_id)) AND (column1 = c_id)) AND (crdb_region IN ('ca-central-1', 'us-east-1'))
+│           │ lookup condition: (((crdb_region IN ('ca-central-1', 'us-east-1')) AND (column3 = c_w_id)) AND (column2 = c_d_id)) AND (column1 = c_id)
 │           │
 │           └── • lookup join (anti)
 │               │ estimated row count: 1
 │               │ table: customer@primary
 │               │ equality cols are key
-│               │ lookup condition: (((column3 = c_w_id) AND (column2 = c_d_id)) AND (column1 = c_id)) AND (crdb_region = 'ap-southeast-2')
+│               │ lookup condition: (((crdb_region = 'ap-southeast-2') AND (column3 = c_w_id)) AND (column2 = c_d_id)) AND (column1 = c_id)
 │               │
 │               └── • scan buffer
 │                     label: buffer 1
@@ -305,13 +305,13 @@ vectorized: true
             │ estimated row count: 0
             │ table: district@primary
             │ equality cols are key
-            │ lookup condition: ((column5 = d_w_id) AND (column4 = d_id)) AND (crdb_region IN ('ca-central-1', 'us-east-1'))
+            │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (column5 = d_w_id)) AND (column4 = d_id)
             │
             └── • lookup join (anti)
                 │ estimated row count: 1
                 │ table: district@primary
                 │ equality cols are key
-                │ lookup condition: ((column5 = d_w_id) AND (column4 = d_id)) AND (crdb_region = 'ap-southeast-2')
+                │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (column5 = d_w_id)) AND (column4 = d_id)
                 │
                 └── • scan buffer
                       label: buffer 1

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
@@ -34,9 +34,6 @@ CREATE TABLE t_child_partitioned (
    PARTITION us_east VALUES IN (('new york'))
 );
 
-# TODO(mgartner): In the FK check there is a lookup join that searches every
-# shard, but only one shard needs to be searched. Inlining the insert values in
-# the FK check should improve this plan.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_child VALUES (123, 321);
 ----
@@ -66,24 +63,30 @@ vectorized: true
     └── • error if rows
         │ columns: ()
         │
-        └── • lookup join (anti)
-            │ columns: (column2)
+        └── • project
+            │ columns: (pid)
             │ estimated row count: 0 (missing stats)
-            │ table: t_parent@t_parent_pkey
-            │ equality cols are key
-            │ lookup condition: ((column2 = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
             │
-            └── • project
-                │ columns: (column2)
-                │ estimated row count: 1
+            └── • lookup join (anti)
+                │ columns: (crdb_internal_id_shard_16_eq, pid)
+                │ table: t_parent@t_parent_pkey
+                │ equality cols are key
+                │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (pid = id)
                 │
-                └── • scan buffer
-                      columns: (column1, column2)
-                      label: buffer 1
+                └── • render
+                    │ columns: (crdb_internal_id_shard_16_eq, pid)
+                    │ estimated row count: 1
+                    │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
+                    │ render pid: column2
+                    │
+                    └── • project
+                        │ columns: (column2)
+                        │ estimated row count: 1
+                        │
+                        └── • scan buffer
+                              columns: (column1, column2)
+                              label: buffer 1
 
-# TODO(mgartner): In the FK check there is a lookup join that searches every
-# shard, but only one shard needs to be searched. Inlining the insert values in
-# the FK check should improve this plan.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_child_partitioned VALUES (123, 321, 'seattle');
 ----
@@ -140,20 +143,29 @@ vectorized: true
     └── • error if rows
         │ columns: ()
         │
-        └── • lookup join (anti)
-            │ columns: (column2)
+        └── • project
+            │ columns: (pid)
             │ estimated row count: 0 (missing stats)
-            │ table: t_parent@t_parent_pkey
-            │ equality cols are key
-            │ lookup condition: ((column2 = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
             │
-            └── • project
-                │ columns: (column2)
-                │ estimated row count: 1
+            └── • lookup join (anti)
+                │ columns: (crdb_internal_id_shard_16_eq, pid)
+                │ table: t_parent@t_parent_pkey
+                │ equality cols are key
+                │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (pid = id)
                 │
-                └── • scan buffer
-                      columns: (column1, column2, column3, check1)
-                      label: buffer 1
+                └── • render
+                    │ columns: (crdb_internal_id_shard_16_eq, pid)
+                    │ estimated row count: 1
+                    │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
+                    │ render pid: column2
+                    │
+                    └── • project
+                        │ columns: (column2)
+                        │ estimated row count: 1
+                        │
+                        └── • scan buffer
+                              columns: (column1, column2, column3, check1)
+                              label: buffer 1
 
 subtest test_uniqueness_check_uuid
 
@@ -230,32 +242,36 @@ vectorized: true
     │ render crdb_internal_user_id_shard_16_comp: crdb_internal_user_id_shard_16_comp
     │
     └── • distinct
-        │ columns: (crdb_internal_user_id_shard_16_comp, column2, val_cast, user_id_default)
+        │ columns: (column2, val_cast, user_id_default, crdb_internal_user_id_shard_16_comp)
         │ estimated row count: 0 (missing stats)
         │ distinct on: user_id_default
         │ nulls are distinct
         │
-        └── • lookup join (anti)
-            │ columns: (crdb_internal_user_id_shard_16_comp, column2, val_cast, user_id_default)
+        └── • project
+            │ columns: (column2, val_cast, user_id_default, crdb_internal_user_id_shard_16_comp)
             │ estimated row count: 0 (missing stats)
-            │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
-            │ equality cols are key
-            │ lookup condition: ((user_id_default = user_id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_user_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
             │
-            └── • render
-                │ columns: (crdb_internal_user_id_shard_16_comp, column2, val_cast, user_id_default)
-                │ estimated row count: 1
-                │ render crdb_internal_user_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
-                │ render column2: column2
-                │ render val_cast: val_cast
-                │ render user_id_default: user_id_default
+            └── • lookup join (anti)
+                │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, column2, val_cast, user_id_default)
+                │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
+                │ equality cols are key
+                │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
                 │
-                └── • values
-                      columns: (column2, val_cast, user_id_default)
-                      size: 3 columns, 1 row
-                      row 0, expr 0: 'seattle'
-                      row 0, expr 1: '4321'
-                      row 0, expr 2: gen_random_uuid()
+                └── • render
+                    │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, column2, val_cast, user_id_default)
+                    │ estimated row count: 1
+                    │ render crdb_internal_user_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
+                    │ render crdb_internal_user_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
+                    │ render column2: column2
+                    │ render val_cast: val_cast
+                    │ render user_id_default: user_id_default
+                    │
+                    └── • values
+                          columns: (column2, val_cast, user_id_default)
+                          size: 3 columns, 1 row
+                          row 0, expr 0: 'seattle'
+                          row 0, expr 1: '4321'
+                          row 0, expr 2: gen_random_uuid()
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_gen_random_uuid (val, part) VALUES (4321, 'seattle'), (8765, 'new york') ON CONFLICT DO NOTHING;
@@ -281,40 +297,44 @@ vectorized: true
     │ render crdb_internal_user_id_shard_16_comp: crdb_internal_user_id_shard_16_comp
     │
     └── • distinct
-        │ columns: (crdb_internal_user_id_shard_16_comp, column2, val_cast, user_id_default)
+        │ columns: (column2, val_cast, user_id_default, crdb_internal_user_id_shard_16_comp)
         │ estimated row count: 0 (missing stats)
         │ distinct on: user_id_default
         │ nulls are distinct
         │
-        └── • lookup join (anti)
-            │ columns: (crdb_internal_user_id_shard_16_comp, column2, val_cast, user_id_default)
+        └── • project
+            │ columns: (column2, val_cast, user_id_default, crdb_internal_user_id_shard_16_comp)
             │ estimated row count: 0 (missing stats)
-            │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
-            │ equality cols are key
-            │ lookup condition: ((user_id_default = user_id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_user_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
             │
-            └── • render
-                │ columns: (crdb_internal_user_id_shard_16_comp, column2, val_cast, user_id_default)
-                │ estimated row count: 2
-                │ render crdb_internal_user_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
-                │ render column2: column2
-                │ render val_cast: val_cast
-                │ render user_id_default: user_id_default
+            └── • lookup join (anti)
+                │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, column2, val_cast, user_id_default)
+                │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
+                │ equality cols are key
+                │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
                 │
                 └── • render
-                    │ columns: (user_id_default, column2, val_cast)
+                    │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, column2, val_cast, user_id_default)
                     │ estimated row count: 2
-                    │ render user_id_default: gen_random_uuid()
+                    │ render crdb_internal_user_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
+                    │ render crdb_internal_user_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
                     │ render column2: column2
                     │ render val_cast: val_cast
+                    │ render user_id_default: user_id_default
                     │
-                    └── • values
-                          columns: (val_cast, column2)
-                          size: 2 columns, 2 rows
-                          row 0, expr 0: '4321'
-                          row 0, expr 1: 'seattle'
-                          row 1, expr 0: '8765'
-                          row 1, expr 1: 'new york'
+                    └── • render
+                        │ columns: (user_id_default, column2, val_cast)
+                        │ estimated row count: 2
+                        │ render user_id_default: gen_random_uuid()
+                        │ render column2: column2
+                        │ render val_cast: val_cast
+                        │
+                        └── • values
+                              columns: (val_cast, column2)
+                              size: 2 columns, 2 rows
+                              row 0, expr 0: '4321'
+                              row 0, expr 1: 'seattle'
+                              row 1, expr 0: '8765'
+                              row 1, expr 1: 'new york'
 
 subtest test_uniqueness_check_pk
 
@@ -457,27 +477,31 @@ vectorized: true
     │ render column2: column2
     │ render crdb_internal_id_shard_16_comp: crdb_internal_id_shard_16_comp
     │
-    └── • lookup join (anti)
-        │ columns: (crdb_internal_id_shard_16_comp, column1, column2)
+    └── • project
+        │ columns: (column1, column2, crdb_internal_id_shard_16_comp)
         │ estimated row count: 0 (missing stats)
-        │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
-        │ equality cols are key
-        │ lookup condition: ((column1 = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
         │
-        └── • render
-            │ columns: (crdb_internal_id_shard_16_comp, column1, column2)
-            │ estimated row count: 2
-            │ render crdb_internal_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
-            │ render column1: column1
-            │ render column2: column2
+        └── • lookup join (anti)
+            │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, column1, column2)
+            │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+            │ equality cols are key
+            │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
             │
-            └── • values
-                  columns: (column1, column2)
-                  size: 2 columns, 2 rows
-                  row 0, expr 0: 4321
-                  row 0, expr 1: 'seattle'
-                  row 1, expr 0: 8765
-                  row 1, expr 1: 'new york'
+            └── • render
+                │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, column1, column2)
+                │ estimated row count: 2
+                │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
+                │ render crdb_internal_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
+                │ render column1: column1
+                │ render column2: column2
+                │
+                └── • values
+                      columns: (column1, column2)
+                      size: 2 columns, 2 rows
+                      row 0, expr 0: 4321
+                      row 0, expr 1: 'seattle'
+                      row 1, expr 0: 8765
+                      row 1, expr 1: 'new york'
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle') ON CONFLICT (id) DO NOTHING;
@@ -541,27 +565,31 @@ vectorized: true
     │ render column2: column2
     │ render crdb_internal_id_shard_16_comp: crdb_internal_id_shard_16_comp
     │
-    └── • lookup join (anti)
-        │ columns: (crdb_internal_id_shard_16_comp, column1, column2)
+    └── • project
+        │ columns: (column1, column2, crdb_internal_id_shard_16_comp)
         │ estimated row count: 0 (missing stats)
-        │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
-        │ equality cols are key
-        │ lookup condition: ((column1 = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
         │
-        └── • render
-            │ columns: (crdb_internal_id_shard_16_comp, column1, column2)
-            │ estimated row count: 2
-            │ render crdb_internal_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
-            │ render column1: column1
-            │ render column2: column2
+        └── • lookup join (anti)
+            │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, column1, column2)
+            │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+            │ equality cols are key
+            │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
             │
-            └── • values
-                  columns: (column1, column2)
-                  size: 2 columns, 2 rows
-                  row 0, expr 0: 4321
-                  row 0, expr 1: 'seattle'
-                  row 1, expr 0: 8765
-                  row 1, expr 1: 'new york'
+            └── • render
+                │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, column1, column2)
+                │ estimated row count: 2
+                │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
+                │ render crdb_internal_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
+                │ render column1: column1
+                │ render column2: column2
+                │
+                └── • values
+                      columns: (column1, column2)
+                      size: 2 columns, 2 rows
+                      row 0, expr 0: 4321
+                      row 0, expr 1: 'seattle'
+                      row 1, expr 0: 8765
+                      row 1, expr 1: 'new york'
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle') ON CONFLICT (id) DO UPDATE SET id = excluded.id
@@ -634,23 +662,34 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (column1)
+            │ columns: (id)
             │ estimated row count: 0 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (crdb_internal_id_shard_16_comp, column1, upsert_part)
+            └── • project
+                │ columns: (crdb_internal_id_shard_16, id, part)
                 │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
-                │ lookup condition: ((column1 = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                │ pred: (crdb_internal_id_shard_16_comp != crdb_internal_id_shard_16) OR (upsert_part != part)
                 │
-                └── • project
-                    │ columns: (crdb_internal_id_shard_16_comp, column1, upsert_part)
-                    │ estimated row count: 1 (missing stats)
+                └── • lookup join (semi)
+                    │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16, id, part)
+                    │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                    │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (id = id)
+                    │ pred: (crdb_internal_id_shard_16 != crdb_internal_id_shard_16) OR (part != part)
                     │
-                    └── • scan buffer
-                          columns: (crdb_internal_id_shard_16_comp, column1, column2, crdb_internal_id_shard_16, id, part, crdb_internal_id_shard_16_comp, column1, part, check1, check2, upsert_part)
-                          label: buffer 1
+                    └── • render
+                        │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16, id, part)
+                        │ estimated row count: 1 (missing stats)
+                        │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
+                        │ render crdb_internal_id_shard_16: crdb_internal_id_shard_16_comp
+                        │ render id: column1
+                        │ render part: upsert_part
+                        │
+                        └── • project
+                            │ columns: (crdb_internal_id_shard_16_comp, column1, upsert_part)
+                            │ estimated row count: 1 (missing stats)
+                            │
+                            └── • scan buffer
+                                  columns: (crdb_internal_id_shard_16_comp, column1, column2, crdb_internal_id_shard_16, id, part, crdb_internal_id_shard_16_comp, column1, part, check1, check2, upsert_part)
+                                  label: buffer 1
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle'), (8765, 'new york') ON CONFLICT (id) DO UPDATE SET id = excluded.id
@@ -698,28 +737,32 @@ vectorized: true
 │                   │ render id: id
 │                   │ render part: part
 │                   │
-│                   └── • lookup join (left outer)
-│                       │ columns: (crdb_internal_id_shard_16_comp, column1, column2, crdb_internal_id_shard_16, id, part)
+│                   └── • project
+│                       │ columns: (column1, column2, crdb_internal_id_shard_16_comp, crdb_internal_id_shard_16, id, part)
 │                       │ estimated row count: 2 (missing stats)
-│                       │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
-│                       │ equality cols are key
-│                       │ lookup condition: ((column1 = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-│                       │ locking strength: for update
 │                       │
-│                       └── • render
-│                           │ columns: (crdb_internal_id_shard_16_comp, column1, column2)
-│                           │ estimated row count: 2
-│                           │ render crdb_internal_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
-│                           │ render column1: column1
-│                           │ render column2: column2
+│                       └── • lookup join (left outer)
+│                           │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, column1, column2, crdb_internal_id_shard_16, id, part)
+│                           │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+│                           │ equality cols are key
+│                           │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
+│                           │ locking strength: for update
 │                           │
-│                           └── • values
-│                                 columns: (column1, column2)
-│                                 size: 2 columns, 2 rows
-│                                 row 0, expr 0: 4321
-│                                 row 0, expr 1: 'seattle'
-│                                 row 1, expr 0: 8765
-│                                 row 1, expr 1: 'new york'
+│                           └── • render
+│                               │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, column1, column2)
+│                               │ estimated row count: 2
+│                               │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
+│                               │ render crdb_internal_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
+│                               │ render column1: column1
+│                               │ render column2: column2
+│                               │
+│                               └── • values
+│                                     columns: (column1, column2)
+│                                     size: 2 columns, 2 rows
+│                                     row 0, expr 0: 4321
+│                                     row 0, expr 1: 'seattle'
+│                                     row 1, expr 0: 8765
+│                                     row 1, expr 1: 'new york'
 │
 └── • constraint-check
     │
@@ -727,23 +770,34 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (column1)
+            │ columns: (id)
             │ estimated row count: 1 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (crdb_internal_id_shard_16_comp, column1, upsert_part)
+            └── • project
+                │ columns: (crdb_internal_id_shard_16, id, part)
                 │ estimated row count: 1 (missing stats)
-                │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
-                │ lookup condition: ((column1 = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                │ pred: (crdb_internal_id_shard_16_comp != crdb_internal_id_shard_16) OR (upsert_part != part)
                 │
-                └── • project
-                    │ columns: (crdb_internal_id_shard_16_comp, column1, upsert_part)
-                    │ estimated row count: 2 (missing stats)
+                └── • lookup join (semi)
+                    │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16, id, part)
+                    │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                    │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (id = id)
+                    │ pred: (crdb_internal_id_shard_16 != crdb_internal_id_shard_16) OR (part != part)
                     │
-                    └── • scan buffer
-                          columns: (crdb_internal_id_shard_16_comp, column1, column2, crdb_internal_id_shard_16, id, part, crdb_internal_id_shard_16_comp, column1, part, check1, check2, upsert_part)
-                          label: buffer 1
+                    └── • render
+                        │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16, id, part)
+                        │ estimated row count: 2 (missing stats)
+                        │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
+                        │ render crdb_internal_id_shard_16: crdb_internal_id_shard_16_comp
+                        │ render id: column1
+                        │ render part: upsert_part
+                        │
+                        └── • project
+                            │ columns: (crdb_internal_id_shard_16_comp, column1, upsert_part)
+                            │ estimated row count: 2 (missing stats)
+                            │
+                            └── • scan buffer
+                                  columns: (crdb_internal_id_shard_16_comp, column1, column2, crdb_internal_id_shard_16, id, part, crdb_internal_id_shard_16_comp, column1, part, check1, check2, upsert_part)
+                                  label: buffer 1
 
 query T
 EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle');
@@ -820,28 +874,32 @@ vectorized: true
         │ render id: id
         │ render part: part
         │
-        └── • lookup join (left outer)
-            │ columns: (crdb_internal_id_shard_16_comp, column1, column2, crdb_internal_id_shard_16, id, part)
+        └── • project
+            │ columns: (column1, column2, crdb_internal_id_shard_16_comp, crdb_internal_id_shard_16, id, part)
             │ estimated row count: 2 (missing stats)
-            │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
-            │ equality cols are key
-            │ lookup condition: ((column1 = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-            │ locking strength: for update
             │
-            └── • render
-                │ columns: (crdb_internal_id_shard_16_comp, column1, column2)
-                │ estimated row count: 2
-                │ render crdb_internal_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
-                │ render column1: column1
-                │ render column2: column2
+            └── • lookup join (left outer)
+                │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, column1, column2, crdb_internal_id_shard_16, id, part)
+                │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                │ equality cols are key
+                │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
+                │ locking strength: for update
                 │
-                └── • values
-                      columns: (column1, column2)
-                      size: 2 columns, 2 rows
-                      row 0, expr 0: 4321
-                      row 0, expr 1: 'seattle'
-                      row 1, expr 0: 8765
-                      row 1, expr 1: 'new york'
+                └── • render
+                    │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, column1, column2)
+                    │ estimated row count: 2
+                    │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
+                    │ render crdb_internal_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
+                    │ render column1: column1
+                    │ render column2: column2
+                    │
+                    └── • values
+                          columns: (column1, column2)
+                          size: 2 columns, 2 rows
+                          row 0, expr 0: 4321
+                          row 0, expr 1: 'seattle'
+                          row 1, expr 0: 8765
+                          row 1, expr 1: 'new york'
 
 query T
 EXPLAIN (VERBOSE) UPDATE t_unique_hash_pk SET id = 1234 WHERE id = 4321;
@@ -886,23 +944,34 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (id_new)
+            │ columns: (id)
             │ estimated row count: 0 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (crdb_internal_id_shard_16_comp, id_new, part)
+            └── • project
+                │ columns: (crdb_internal_id_shard_16, id, part)
                 │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
-                │ lookup condition: ((id_new = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                │ pred: (crdb_internal_id_shard_16_comp != crdb_internal_id_shard_16) OR (part != part)
                 │
-                └── • project
-                    │ columns: (crdb_internal_id_shard_16_comp, id_new, part)
-                    │ estimated row count: 1 (missing stats)
+                └── • lookup join (semi)
+                    │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16, id, part)
+                    │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                    │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (id = id)
+                    │ pred: (crdb_internal_id_shard_16 != crdb_internal_id_shard_16) OR (part != part)
                     │
-                    └── • scan buffer
-                          columns: (crdb_internal_id_shard_16, id, part, crdb_internal_id_shard_16_comp, id_new, check2)
-                          label: buffer 1
+                    └── • render
+                        │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16, id, part)
+                        │ estimated row count: 1 (missing stats)
+                        │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(id_new)), 16)
+                        │ render crdb_internal_id_shard_16: crdb_internal_id_shard_16_comp
+                        │ render id: id_new
+                        │ render part: part
+                        │
+                        └── • project
+                            │ columns: (crdb_internal_id_shard_16_comp, id_new, part)
+                            │ estimated row count: 1 (missing stats)
+                            │
+                            └── • scan buffer
+                                  columns: (crdb_internal_id_shard_16, id, part, crdb_internal_id_shard_16_comp, id_new, check2)
+                                  label: buffer 1
 
 subtest test_uniqueness_check_sec_key
 
@@ -1042,35 +1111,47 @@ vectorized: true
     │ render column3: column3
     │ render crdb_internal_email_shard_16_comp: crdb_internal_email_shard_16_comp
     │
-    └── • lookup join (anti)
+    └── • project
         │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp)
         │ estimated row count: 0 (missing stats)
-        │ table: t_unique_hash_sec_key@idx_uniq_hash_email
-        │ equality cols are key
-        │ lookup condition: ((column2 = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
         │
-        └── • cross join (anti)
-            │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp)
-            │ estimated row count: 0 (missing stats)
+        └── • lookup join (anti)
+            │ columns: (crdb_internal_email_shard_16_eq, column1, column2, column3, crdb_internal_email_shard_16_comp)
+            │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+            │ equality cols are key
+            │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
             │
-            ├── • values
-            │     columns: (column1, column2, column3, crdb_internal_email_shard_16_comp)
-            │     size: 4 columns, 1 row
-            │     row 0, expr 0: 4321
-            │     row 0, expr 1: 'some_email'
-            │     row 0, expr 2: 'seattle'
-            │     row 0, expr 3: 13
-            │
-            └── • project
-                │ columns: ()
-                │ estimated row count: 1 (missing stats)
+            └── • render
+                │ columns: (crdb_internal_email_shard_16_eq, column1, column2, column3, crdb_internal_email_shard_16_comp)
+                │ estimated row count: 0 (missing stats)
+                │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
+                │ render column1: column1
+                │ render column2: column2
+                │ render column3: column3
+                │ render crdb_internal_email_shard_16_comp: crdb_internal_email_shard_16_comp
                 │
-                └── • scan
-                      columns: (id)
-                      estimated row count: 1 (missing stats)
-                      table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-                      spans: /"new york"/4321/0 /"seattle"/4321/0
-                      parallel
+                └── • cross join (anti)
+                    │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp)
+                    │ estimated row count: 0 (missing stats)
+                    │
+                    ├── • values
+                    │     columns: (column1, column2, column3, crdb_internal_email_shard_16_comp)
+                    │     size: 4 columns, 1 row
+                    │     row 0, expr 0: 4321
+                    │     row 0, expr 1: 'some_email'
+                    │     row 0, expr 2: 'seattle'
+                    │     row 0, expr 3: 13
+                    │
+                    └── • project
+                        │ columns: ()
+                        │ estimated row count: 1 (missing stats)
+                        │
+                        └── • scan
+                              columns: (id)
+                              estimated row count: 1 (missing stats)
+                              table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+                              spans: /"new york"/4321/0 /"seattle"/4321/0
+                              parallel
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email, part) VALUES (4321, 'some_email', 'seattle'), (8765, 'another_email', 'new york') ON CONFLICT DO NOTHING;
@@ -1096,36 +1177,40 @@ vectorized: true
     │ render crdb_internal_email_shard_16_comp: crdb_internal_email_shard_16_comp
     │
     └── • lookup join (anti)
-        │ columns: (crdb_internal_email_shard_16_comp, column1, column2, column3)
+        │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp)
         │ estimated row count: 0 (missing stats)
-        │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+        │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
         │ equality cols are key
-        │ lookup condition: ((column2 = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+        │ lookup condition: (part IN ('new york', 'seattle')) AND (column1 = id)
         │
-        └── • lookup join (anti)
-            │ columns: (crdb_internal_email_shard_16_comp, column1, column2, column3)
+        └── • project
+            │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp)
             │ estimated row count: 0 (missing stats)
-            │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-            │ equality cols are key
-            │ lookup condition: (column1 = id) AND (part IN ('new york', 'seattle'))
             │
-            └── • render
-                │ columns: (crdb_internal_email_shard_16_comp, column1, column2, column3)
-                │ estimated row count: 2
-                │ render crdb_internal_email_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
-                │ render column1: column1
-                │ render column2: column2
-                │ render column3: column3
+            └── • lookup join (anti)
+                │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, column1, column2, column3)
+                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                │ equality cols are key
+                │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
                 │
-                └── • values
-                      columns: (column1, column2, column3)
-                      size: 3 columns, 2 rows
-                      row 0, expr 0: 4321
-                      row 0, expr 1: 'some_email'
-                      row 0, expr 2: 'seattle'
-                      row 1, expr 0: 8765
-                      row 1, expr 1: 'another_email'
-                      row 1, expr 2: 'new york'
+                └── • render
+                    │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, column1, column2, column3)
+                    │ estimated row count: 2
+                    │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
+                    │ render crdb_internal_email_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
+                    │ render column1: column1
+                    │ render column2: column2
+                    │ render column3: column3
+                    │
+                    └── • values
+                          columns: (column1, column2, column3)
+                          size: 3 columns, 2 rows
+                          row 0, expr 0: 4321
+                          row 0, expr 1: 'some_email'
+                          row 0, expr 2: 'seattle'
+                          row 1, expr 0: 8765
+                          row 1, expr 1: 'another_email'
+                          row 1, expr 2: 'new york'
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email, part) VALUES (4321, 'some_email', 'seattle') ON CONFLICT (email) DO NOTHING;
@@ -1229,30 +1314,34 @@ vectorized: true
 │           │ render column3: column3
 │           │ render crdb_internal_email_shard_16_comp: crdb_internal_email_shard_16_comp
 │           │
-│           └── • lookup join (anti)
-│               │ columns: (crdb_internal_email_shard_16_comp, column1, column2, column3)
+│           └── • project
+│               │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp)
 │               │ estimated row count: 0 (missing stats)
-│               │ table: t_unique_hash_sec_key@idx_uniq_hash_email
-│               │ equality cols are key
-│               │ lookup condition: ((column2 = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
 │               │
-│               └── • render
-│                   │ columns: (crdb_internal_email_shard_16_comp, column1, column2, column3)
-│                   │ estimated row count: 2
-│                   │ render crdb_internal_email_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
-│                   │ render column1: column1
-│                   │ render column2: column2
-│                   │ render column3: column3
+│               └── • lookup join (anti)
+│                   │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, column1, column2, column3)
+│                   │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+│                   │ equality cols are key
+│                   │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
 │                   │
-│                   └── • values
-│                         columns: (column1, column2, column3)
-│                         size: 3 columns, 2 rows
-│                         row 0, expr 0: 4321
-│                         row 0, expr 1: 'some_email'
-│                         row 0, expr 2: 'seattle'
-│                         row 1, expr 0: 8765
-│                         row 1, expr 1: 'another_email'
-│                         row 1, expr 2: 'new york'
+│                   └── • render
+│                       │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, column1, column2, column3)
+│                       │ estimated row count: 2
+│                       │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
+│                       │ render crdb_internal_email_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
+│                       │ render column1: column1
+│                       │ render column2: column2
+│                       │ render column3: column3
+│                       │
+│                       └── • values
+│                             columns: (column1, column2, column3)
+│                             size: 3 columns, 2 rows
+│                             row 0, expr 0: 4321
+│                             row 0, expr 1: 'some_email'
+│                             row 0, expr 2: 'seattle'
+│                             row 1, expr 0: 8765
+│                             row 1, expr 1: 'another_email'
+│                             row 1, expr 2: 'new york'
 │
 └── • constraint-check
     │
@@ -1267,7 +1356,7 @@ vectorized: true
                 │ columns: (column1, column3)
                 │ estimated row count: 0 (missing stats)
                 │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-                │ lookup condition: (column1 = id) AND (part IN ('new york', 'seattle'))
+                │ lookup condition: (part IN ('new york', 'seattle')) AND (column1 = id)
                 │ pred: column3 != part
                 │
                 └── • project
@@ -1374,7 +1463,7 @@ vectorized: true
 │               │ columns: (upsert_id, upsert_part)
 │               │ estimated row count: 0 (missing stats)
 │               │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-│               │ lookup condition: (upsert_id = id) AND (part IN ('new york', 'seattle'))
+│               │ lookup condition: (part IN ('new york', 'seattle')) AND (upsert_id = id)
 │               │ pred: upsert_part != part
 │               │
 │               └── • project
@@ -1391,23 +1480,34 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (upsert_email)
+            │ columns: (email)
             │ estimated row count: 0 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (upsert_id, upsert_email, upsert_part)
+            └── • project
+                │ columns: (id, email, part)
                 │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
-                │ lookup condition: ((upsert_email = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                │ pred: (upsert_id != id) OR (upsert_part != part)
                 │
-                └── • project
-                    │ columns: (upsert_id, upsert_email, upsert_part)
-                    │ estimated row count: 1 (missing stats)
+                └── • lookup join (semi)
+                    │ columns: (crdb_internal_email_shard_16_eq, id, email, part)
+                    │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                    │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (email = email)
+                    │ pred: (id != id) OR (part != part)
                     │
-                    └── • scan buffer
-                          columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, part, check1, check2, upsert_id, upsert_part)
-                          label: buffer 1
+                    └── • render
+                        │ columns: (crdb_internal_email_shard_16_eq, id, email, part)
+                        │ estimated row count: 1 (missing stats)
+                        │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(upsert_email)), 16)
+                        │ render id: upsert_id
+                        │ render email: upsert_email
+                        │ render part: upsert_part
+                        │
+                        └── • project
+                            │ columns: (upsert_id, upsert_email, upsert_part)
+                            │ estimated row count: 1 (missing stats)
+                            │
+                            └── • scan buffer
+                                  columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, part, check1, check2, upsert_id, upsert_part)
+                                  label: buffer 1
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email, part) VALUES (4321, 'some_email', 'seattle'), (8765, 'another_email', 'new york') ON CONFLICT (email) DO UPDATE SET email = 'bad_email';
@@ -1481,31 +1581,35 @@ vectorized: true
 │                           │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part)
 │                           │ estimated row count: 2 (missing stats)
 │                           │
-│                           └── • lookup join (left outer)
-│                               │ columns: (crdb_internal_email_shard_16_comp, column1, column2, column3, id, email, part, crdb_internal_email_shard_16)
+│                           └── • project
+│                               │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part, crdb_internal_email_shard_16)
 │                               │ estimated row count: 2 (missing stats)
-│                               │ table: t_unique_hash_sec_key@idx_uniq_hash_email
-│                               │ equality cols are key
-│                               │ lookup condition: ((column2 = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-│                               │ locking strength: for update
 │                               │
-│                               └── • render
-│                                   │ columns: (crdb_internal_email_shard_16_comp, column1, column2, column3)
-│                                   │ estimated row count: 2
-│                                   │ render crdb_internal_email_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
-│                                   │ render column1: column1
-│                                   │ render column2: column2
-│                                   │ render column3: column3
+│                               └── • lookup join (left outer)
+│                                   │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, column1, column2, column3, id, email, part, crdb_internal_email_shard_16)
+│                                   │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+│                                   │ equality cols are key
+│                                   │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
+│                                   │ locking strength: for update
 │                                   │
-│                                   └── • values
-│                                         columns: (column1, column2, column3)
-│                                         size: 3 columns, 2 rows
-│                                         row 0, expr 0: 4321
-│                                         row 0, expr 1: 'some_email'
-│                                         row 0, expr 2: 'seattle'
-│                                         row 1, expr 0: 8765
-│                                         row 1, expr 1: 'another_email'
-│                                         row 1, expr 2: 'new york'
+│                                   └── • render
+│                                       │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, column1, column2, column3)
+│                                       │ estimated row count: 2
+│                                       │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
+│                                       │ render crdb_internal_email_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
+│                                       │ render column1: column1
+│                                       │ render column2: column2
+│                                       │ render column3: column3
+│                                       │
+│                                       └── • values
+│                                             columns: (column1, column2, column3)
+│                                             size: 3 columns, 2 rows
+│                                             row 0, expr 0: 4321
+│                                             row 0, expr 1: 'some_email'
+│                                             row 0, expr 2: 'seattle'
+│                                             row 1, expr 0: 8765
+│                                             row 1, expr 1: 'another_email'
+│                                             row 1, expr 2: 'new york'
 │
 ├── • constraint-check
 │   │
@@ -1520,7 +1624,7 @@ vectorized: true
 │               │ columns: (upsert_id, upsert_part)
 │               │ estimated row count: 1 (missing stats)
 │               │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-│               │ lookup condition: (upsert_id = id) AND (part IN ('new york', 'seattle'))
+│               │ lookup condition: (part IN ('new york', 'seattle')) AND (upsert_id = id)
 │               │ pred: upsert_part != part
 │               │
 │               └── • project
@@ -1537,23 +1641,34 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (upsert_email)
+            │ columns: (email)
             │ estimated row count: 1 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (upsert_id, upsert_email, upsert_part)
+            └── • project
+                │ columns: (id, email, part)
                 │ estimated row count: 1 (missing stats)
-                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
-                │ lookup condition: ((upsert_email = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                │ pred: (upsert_id != id) OR (upsert_part != part)
                 │
-                └── • project
-                    │ columns: (upsert_id, upsert_email, upsert_part)
-                    │ estimated row count: 2 (missing stats)
+                └── • lookup join (semi)
+                    │ columns: (crdb_internal_email_shard_16_eq, id, email, part)
+                    │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                    │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (email = email)
+                    │ pred: (id != id) OR (part != part)
                     │
-                    └── • scan buffer
-                          columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, part, check1, check2, upsert_id, upsert_part)
-                          label: buffer 1
+                    └── • render
+                        │ columns: (crdb_internal_email_shard_16_eq, id, email, part)
+                        │ estimated row count: 2 (missing stats)
+                        │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(upsert_email)), 16)
+                        │ render id: upsert_id
+                        │ render email: upsert_email
+                        │ render part: upsert_part
+                        │
+                        └── • project
+                            │ columns: (upsert_id, upsert_email, upsert_part)
+                            │ estimated row count: 2 (missing stats)
+                            │
+                            └── • scan buffer
+                                  columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, part, check1, check2, upsert_id, upsert_part)
+                                  label: buffer 1
 
 query T
 EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_sec_key VALUES (1, 'email1', 'seattle');
@@ -1625,23 +1740,34 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (column2)
+            │ columns: (email)
             │ estimated row count: 0 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (upsert_id, column2, column3)
+            └── • project
+                │ columns: (id, email, part)
                 │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
-                │ lookup condition: ((column2 = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                │ pred: (upsert_id != id) OR (column3 != part)
                 │
-                └── • project
-                    │ columns: (upsert_id, column2, column3)
-                    │ estimated row count: 1 (missing stats)
+                └── • lookup join (semi)
+                    │ columns: (crdb_internal_email_shard_16_eq, id, email, part)
+                    │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                    │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (email = email)
+                    │ pred: (id != id) OR (part != part)
                     │
-                    └── • scan buffer
-                          columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part, crdb_internal_email_shard_16, column2, column3, crdb_internal_email_shard_16_comp, part, check1, check2, upsert_id)
-                          label: buffer 1
+                    └── • render
+                        │ columns: (crdb_internal_email_shard_16_eq, id, email, part)
+                        │ estimated row count: 1 (missing stats)
+                        │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
+                        │ render id: upsert_id
+                        │ render email: column2
+                        │ render part: column3
+                        │
+                        └── • project
+                            │ columns: (upsert_id, column2, column3)
+                            │ estimated row count: 1 (missing stats)
+                            │
+                            └── • scan buffer
+                                  columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part, crdb_internal_email_shard_16, column2, column3, crdb_internal_email_shard_16_comp, part, check1, check2, upsert_id)
+                                  label: buffer 1
 
 query T
 EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_sec_key VALUES (1, 'email1', 'seattle'), (8765, 'email2', 'new york');
@@ -1697,7 +1823,7 @@ vectorized: true
 │                       │ estimated row count: 2 (missing stats)
 │                       │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
 │                       │ equality cols are key
-│                       │ lookup condition: (column1 = id) AND (part IN ('new york', 'seattle'))
+│                       │ lookup condition: (part IN ('new york', 'seattle')) AND (column1 = id)
 │                       │ locking strength: for update
 │                       │
 │                       └── • render
@@ -1724,23 +1850,34 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (column2)
+            │ columns: (email)
             │ estimated row count: 1 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (upsert_id, column2, column3)
+            └── • project
+                │ columns: (id, email, part)
                 │ estimated row count: 1 (missing stats)
-                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
-                │ lookup condition: ((column2 = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                │ pred: (upsert_id != id) OR (column3 != part)
                 │
-                └── • project
-                    │ columns: (upsert_id, column2, column3)
-                    │ estimated row count: 2 (missing stats)
+                └── • lookup join (semi)
+                    │ columns: (crdb_internal_email_shard_16_eq, id, email, part)
+                    │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                    │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (email = email)
+                    │ pred: (id != id) OR (part != part)
                     │
-                    └── • scan buffer
-                          columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part, crdb_internal_email_shard_16, column2, column3, crdb_internal_email_shard_16_comp, part, check1, check2, upsert_id)
-                          label: buffer 1
+                    └── • render
+                        │ columns: (crdb_internal_email_shard_16_eq, id, email, part)
+                        │ estimated row count: 2 (missing stats)
+                        │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
+                        │ render id: upsert_id
+                        │ render email: column2
+                        │ render part: column3
+                        │
+                        └── • project
+                            │ columns: (upsert_id, column2, column3)
+                            │ estimated row count: 2 (missing stats)
+                            │
+                            └── • scan buffer
+                                  columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part, crdb_internal_email_shard_16, column2, column3, crdb_internal_email_shard_16_comp, part, check1, check2, upsert_id)
+                                  label: buffer 1
 
 query T
 EXPLAIN (VERBOSE) UPDATE t_unique_hash_sec_key SET email = 'email1' WHERE id = 2;
@@ -1786,20 +1923,31 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (email_new)
+            │ columns: (email)
             │ estimated row count: 0 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (id, email_new, part)
+            └── • project
+                │ columns: (id, email, part)
                 │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
-                │ lookup condition: ((email_new = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                │ pred: (id != id) OR (part != part)
                 │
-                └── • project
-                    │ columns: (id, email_new, part)
-                    │ estimated row count: 1 (missing stats)
+                └── • lookup join (semi)
+                    │ columns: (crdb_internal_email_shard_16_eq, id, email, part)
+                    │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                    │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (email = email)
+                    │ pred: (id != id) OR (part != part)
                     │
-                    └── • scan buffer
-                          columns: (id, email, part, crdb_internal_email_shard_16, email_new, crdb_internal_email_shard_16_comp, check2)
-                          label: buffer 1
+                    └── • render
+                        │ columns: (crdb_internal_email_shard_16_eq, id, email, part)
+                        │ estimated row count: 1 (missing stats)
+                        │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(email_new)), 16)
+                        │ render id: id
+                        │ render email: email_new
+                        │ render part: part
+                        │
+                        └── • project
+                            │ columns: (id, email_new, part)
+                            │ estimated row count: 1 (missing stats)
+                            │
+                            └── • scan buffer
+                                  columns: (id, email, part, crdb_internal_email_shard_16, email_new, crdb_internal_email_shard_16_comp, check2)
+                                  label: buffer 1

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
@@ -35,9 +35,6 @@ CREATE TABLE t_child_regional (
   FAMILY fam_0 (id, pid)
 ) LOCALITY REGIONAL BY ROW;
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T retry
 EXPLAIN (VERBOSE) INSERT INTO t_child VALUES (123, 321)
 ----
@@ -67,31 +64,37 @@ vectorized: true
     └── • error if rows
         │ columns: ()
         │
-        └── • lookup join (anti)
-            │ columns: (column2)
+        └── • project
+            │ columns: (pid)
             │ estimated row count: 0 (missing stats)
-            │ table: t_parent@t_parent_pkey
-            │ equality cols are key
-            │ lookup condition: ((column2 = id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
             │
             └── • lookup join (anti)
-                │ columns: (column2)
-                │ estimated row count: 1 (missing stats)
+                │ columns: (crdb_internal_id_shard_16_eq, pid)
                 │ table: t_parent@t_parent_pkey
                 │ equality cols are key
-                │ lookup condition: ((column2 = id) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (pid = id)
                 │
-                └── • project
-                    │ columns: (column2)
-                    │ estimated row count: 1
+                └── • lookup join (anti)
+                    │ columns: (crdb_internal_id_shard_16_eq, pid)
+                    │ estimated row count: 1 (missing stats)
+                    │ table: t_parent@t_parent_pkey
+                    │ equality cols are key
+                    │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (pid = id)
                     │
-                    └── • scan buffer
-                          columns: (column1, column2)
-                          label: buffer 1
+                    └── • render
+                        │ columns: (crdb_internal_id_shard_16_eq, pid)
+                        │ estimated row count: 1
+                        │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
+                        │ render pid: column2
+                        │
+                        └── • project
+                            │ columns: (column2)
+                            │ estimated row count: 1
+                            │
+                            └── • scan buffer
+                                  columns: (column1, column2)
+                                  label: buffer 1
 
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_child_regional VALUES (123, 321)
 ----
@@ -148,27 +151,36 @@ vectorized: true
     └── • error if rows
         │ columns: ()
         │
-        └── • lookup join (anti)
-            │ columns: (column2)
+        └── • project
+            │ columns: (pid)
             │ estimated row count: 0 (missing stats)
-            │ table: t_parent@t_parent_pkey
-            │ equality cols are key
-            │ lookup condition: ((column2 = id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
             │
             └── • lookup join (anti)
-                │ columns: (column2)
-                │ estimated row count: 1 (missing stats)
+                │ columns: (crdb_internal_id_shard_16_eq, pid)
                 │ table: t_parent@t_parent_pkey
                 │ equality cols are key
-                │ lookup condition: ((column2 = id) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (pid = id)
                 │
-                └── • project
-                    │ columns: (column2)
-                    │ estimated row count: 1
+                └── • lookup join (anti)
+                    │ columns: (crdb_internal_id_shard_16_eq, pid)
+                    │ estimated row count: 1 (missing stats)
+                    │ table: t_parent@t_parent_pkey
+                    │ equality cols are key
+                    │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (pid = id)
                     │
-                    └── • scan buffer
-                          columns: (column1, column2, crdb_region_default, check1)
-                          label: buffer 1
+                    └── • render
+                        │ columns: (crdb_internal_id_shard_16_eq, pid)
+                        │ estimated row count: 1
+                        │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
+                        │ render pid: column2
+                        │
+                        └── • project
+                            │ columns: (column2)
+                            │ estimated row count: 1
+                            │
+                            └── • scan buffer
+                                  columns: (column1, column2, crdb_region_default, check1)
+                                  label: buffer 1
 
 subtest test_uniqueness_check_uuid
 
@@ -241,39 +253,43 @@ vectorized: true
     │ render crdb_internal_user_id_shard_16_comp: crdb_internal_user_id_shard_16_comp
     │
     └── • distinct
-        │ columns: (crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
+        │ columns: (val_cast, user_id_default, crdb_region_default, crdb_internal_user_id_shard_16_comp)
         │ estimated row count: 0 (missing stats)
         │ distinct on: user_id_default
         │ nulls are distinct
         │
-        └── • lookup join (anti)
-            │ columns: (crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
+        └── • project
+            │ columns: (val_cast, user_id_default, crdb_region_default, crdb_internal_user_id_shard_16_comp)
             │ estimated row count: 0 (missing stats)
-            │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
-            │ equality cols are key
-            │ lookup condition: ((user_id_default = user_id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_user_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
             │
             └── • lookup join (anti)
-                │ columns: (crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
-                │ estimated row count: 1 (missing stats)
+                │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
                 │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
                 │ equality cols are key
-                │ lookup condition: ((user_id_default = user_id) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_user_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
                 │
-                └── • render
-                    │ columns: (crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
-                    │ estimated row count: 1
-                    │ render crdb_internal_user_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
-                    │ render val_cast: val_cast
-                    │ render user_id_default: user_id_default
-                    │ render crdb_region_default: crdb_region_default
+                └── • lookup join (anti)
+                    │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
+                    │ estimated row count: 1 (missing stats)
+                    │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
+                    │ equality cols are key
+                    │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
                     │
-                    └── • values
-                          columns: (val_cast, user_id_default, crdb_region_default)
-                          size: 3 columns, 1 row
-                          row 0, expr 0: '4321'
-                          row 0, expr 1: gen_random_uuid()
-                          row 0, expr 2: 'ap-southeast-2'
+                    └── • render
+                        │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
+                        │ estimated row count: 1
+                        │ render crdb_internal_user_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
+                        │ render crdb_internal_user_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
+                        │ render val_cast: val_cast
+                        │ render user_id_default: user_id_default
+                        │ render crdb_region_default: crdb_region_default
+                        │
+                        └── • values
+                              columns: (val_cast, user_id_default, crdb_region_default)
+                              size: 3 columns, 1 row
+                              row 0, expr 0: '4321'
+                              row 0, expr 1: gen_random_uuid()
+                              row 0, expr 2: 'ap-southeast-2'
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_gen_random_uuid (val) VALUES (4321), (8765) ON CONFLICT DO NOTHING;
@@ -299,45 +315,49 @@ vectorized: true
     │ render crdb_internal_user_id_shard_16_comp: crdb_internal_user_id_shard_16_comp
     │
     └── • distinct
-        │ columns: (crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
+        │ columns: (val_cast, user_id_default, crdb_region_default, crdb_internal_user_id_shard_16_comp)
         │ estimated row count: 0 (missing stats)
         │ distinct on: user_id_default
         │ nulls are distinct
         │
-        └── • lookup join (anti)
-            │ columns: (crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
+        └── • project
+            │ columns: (val_cast, user_id_default, crdb_region_default, crdb_internal_user_id_shard_16_comp)
             │ estimated row count: 0 (missing stats)
-            │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
-            │ equality cols are key
-            │ lookup condition: ((user_id_default = user_id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_user_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
             │
             └── • lookup join (anti)
-                │ columns: (crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
-                │ estimated row count: 2 (missing stats)
+                │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
                 │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
                 │ equality cols are key
-                │ lookup condition: ((user_id_default = user_id) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_user_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
                 │
-                └── • render
-                    │ columns: (crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
-                    │ estimated row count: 2
-                    │ render crdb_internal_user_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
-                    │ render val_cast: val_cast
-                    │ render user_id_default: user_id_default
-                    │ render crdb_region_default: crdb_region_default
+                └── • lookup join (anti)
+                    │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
+                    │ estimated row count: 1 (missing stats)
+                    │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
+                    │ equality cols are key
+                    │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
                     │
                     └── • render
-                        │ columns: (user_id_default, crdb_region_default, val_cast)
+                        │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
                         │ estimated row count: 2
-                        │ render user_id_default: gen_random_uuid()
-                        │ render crdb_region_default: 'ap-southeast-2'
+                        │ render crdb_internal_user_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
+                        │ render crdb_internal_user_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
                         │ render val_cast: val_cast
+                        │ render user_id_default: user_id_default
+                        │ render crdb_region_default: crdb_region_default
                         │
-                        └── • values
-                              columns: (val_cast)
-                              size: 1 column, 2 rows
-                              row 0, expr 0: '4321'
-                              row 1, expr 0: '8765'
+                        └── • render
+                            │ columns: (user_id_default, crdb_region_default, val_cast)
+                            │ estimated row count: 2
+                            │ render user_id_default: gen_random_uuid()
+                            │ render crdb_region_default: 'ap-southeast-2'
+                            │ render val_cast: val_cast
+                            │
+                            └── • values
+                                  columns: (val_cast)
+                                  size: 1 column, 2 rows
+                                  row 0, expr 0: '4321'
+                                  row 1, expr 0: '8765'
 
 subtest test_uniqueness_check_pk
 
@@ -487,32 +507,36 @@ vectorized: true
     │ render crdb_region_default: crdb_region_default
     │ render crdb_internal_id_shard_16_comp: crdb_internal_id_shard_16_comp
     │
-    └── • lookup join (anti)
-        │ columns: (crdb_internal_id_shard_16_comp, crdb_region_default, column1)
+    └── • project
+        │ columns: (column1, crdb_region_default, crdb_internal_id_shard_16_comp)
         │ estimated row count: 0 (missing stats)
-        │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
-        │ equality cols are key
-        │ lookup condition: ((column1 = id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
         │
         └── • lookup join (anti)
-            │ columns: (crdb_internal_id_shard_16_comp, crdb_region_default, column1)
-            │ estimated row count: 2 (missing stats)
+            │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, crdb_region_default, column1)
             │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
             │ equality cols are key
-            │ lookup condition: ((column1 = id) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+            │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
             │
-            └── • render
-                │ columns: (crdb_internal_id_shard_16_comp, crdb_region_default, column1)
-                │ estimated row count: 2
-                │ render crdb_internal_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
-                │ render crdb_region_default: 'ap-southeast-2'
-                │ render column1: column1
+            └── • lookup join (anti)
+                │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, crdb_region_default, column1)
+                │ estimated row count: 1 (missing stats)
+                │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                │ equality cols are key
+                │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
                 │
-                └── • values
-                      columns: (column1)
-                      size: 1 column, 2 rows
-                      row 0, expr 0: 4321
-                      row 1, expr 0: 8765
+                └── • render
+                    │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, crdb_region_default, column1)
+                    │ estimated row count: 2
+                    │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
+                    │ render crdb_internal_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
+                    │ render crdb_region_default: 'ap-southeast-2'
+                    │ render column1: column1
+                    │
+                    └── • values
+                          columns: (column1)
+                          size: 1 column, 2 rows
+                          row 0, expr 0: 4321
+                          row 1, expr 0: 8765
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id) VALUES (4321) ON CONFLICT (id) DO NOTHING;
@@ -587,32 +611,36 @@ vectorized: true
     │ render crdb_region_default: crdb_region_default
     │ render crdb_internal_id_shard_16_comp: crdb_internal_id_shard_16_comp
     │
-    └── • lookup join (anti)
-        │ columns: (crdb_internal_id_shard_16_comp, crdb_region_default, column1)
+    └── • project
+        │ columns: (column1, crdb_region_default, crdb_internal_id_shard_16_comp)
         │ estimated row count: 0 (missing stats)
-        │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
-        │ equality cols are key
-        │ lookup condition: ((column1 = id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
         │
         └── • lookup join (anti)
-            │ columns: (crdb_internal_id_shard_16_comp, crdb_region_default, column1)
-            │ estimated row count: 2 (missing stats)
+            │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, crdb_region_default, column1)
             │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
             │ equality cols are key
-            │ lookup condition: ((column1 = id) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+            │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
             │
-            └── • render
-                │ columns: (crdb_internal_id_shard_16_comp, crdb_region_default, column1)
-                │ estimated row count: 2
-                │ render crdb_internal_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
-                │ render crdb_region_default: 'ap-southeast-2'
-                │ render column1: column1
+            └── • lookup join (anti)
+                │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, crdb_region_default, column1)
+                │ estimated row count: 1 (missing stats)
+                │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                │ equality cols are key
+                │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
                 │
-                └── • values
-                      columns: (column1)
-                      size: 1 column, 2 rows
-                      row 0, expr 0: 4321
-                      row 1, expr 0: 8765
+                └── • render
+                    │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, crdb_region_default, column1)
+                    │ estimated row count: 2
+                    │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
+                    │ render crdb_internal_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
+                    │ render crdb_region_default: 'ap-southeast-2'
+                    │ render column1: column1
+                    │
+                    └── • values
+                          columns: (column1)
+                          size: 1 column, 2 rows
+                          row 0, expr 0: 4321
+                          row 1, expr 0: 8765
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id) VALUES (4321) ON CONFLICT (id) DO UPDATE SET id = excluded.id
@@ -695,23 +723,34 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (column1)
+            │ columns: (id)
             │ estimated row count: 0 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (crdb_internal_id_shard_16_comp, column1, upsert_crdb_region)
+            └── • project
+                │ columns: (crdb_internal_id_shard_16, id, crdb_region)
                 │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
-                │ lookup condition: ((column1 = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                │ pred: (crdb_internal_id_shard_16_comp != crdb_internal_id_shard_16) OR (upsert_crdb_region != crdb_region)
                 │
-                └── • project
-                    │ columns: (crdb_internal_id_shard_16_comp, column1, upsert_crdb_region)
-                    │ estimated row count: 1 (missing stats)
+                └── • lookup join (semi)
+                    │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16, id, crdb_region)
+                    │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                    │ lookup condition: ((crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (id = id)
+                    │ pred: (crdb_internal_id_shard_16 != crdb_internal_id_shard_16) OR (crdb_region != crdb_region)
                     │
-                    └── • scan buffer
-                          columns: (crdb_internal_id_shard_16_comp, column1, crdb_region_default, crdb_internal_id_shard_16, id, crdb_region, crdb_internal_id_shard_16_comp, column1, crdb_region, check1, check2, upsert_crdb_region)
-                          label: buffer 1
+                    └── • render
+                        │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16, id, crdb_region)
+                        │ estimated row count: 1 (missing stats)
+                        │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
+                        │ render crdb_internal_id_shard_16: crdb_internal_id_shard_16_comp
+                        │ render id: column1
+                        │ render crdb_region: upsert_crdb_region
+                        │
+                        └── • project
+                            │ columns: (crdb_internal_id_shard_16_comp, column1, upsert_crdb_region)
+                            │ estimated row count: 1 (missing stats)
+                            │
+                            └── • scan buffer
+                                  columns: (crdb_internal_id_shard_16_comp, column1, crdb_region_default, crdb_internal_id_shard_16, id, crdb_region, crdb_internal_id_shard_16_comp, column1, crdb_region, check1, check2, upsert_crdb_region)
+                                  label: buffer 1
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id) VALUES (4321), (8765) ON CONFLICT (id) DO UPDATE SET id = excluded.id
@@ -759,27 +798,31 @@ vectorized: true
 │                   │ render id: id
 │                   │ render crdb_region: crdb_region
 │                   │
-│                   └── • lookup join (left outer)
-│                       │ columns: (crdb_internal_id_shard_16_comp, crdb_region_default, column1, crdb_internal_id_shard_16, id, crdb_region)
+│                   └── • project
+│                       │ columns: (column1, crdb_region_default, crdb_internal_id_shard_16_comp, crdb_internal_id_shard_16, id, crdb_region)
 │                       │ estimated row count: 2 (missing stats)
-│                       │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
-│                       │ equality cols are key
-│                       │ lookup condition: ((column1 = id) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-│                       │ remote lookup condition: ((column1 = id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-│                       │ locking strength: for update
 │                       │
-│                       └── • render
-│                           │ columns: (crdb_internal_id_shard_16_comp, crdb_region_default, column1)
-│                           │ estimated row count: 2
-│                           │ render crdb_internal_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
-│                           │ render crdb_region_default: 'ap-southeast-2'
-│                           │ render column1: column1
+│                       └── • lookup join (left outer)
+│                           │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, crdb_region_default, column1, crdb_internal_id_shard_16, id, crdb_region)
+│                           │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+│                           │ equality cols are key
+│                           │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
+│                           │ remote lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
+│                           │ locking strength: for update
 │                           │
-│                           └── • values
-│                                 columns: (column1)
-│                                 size: 1 column, 2 rows
-│                                 row 0, expr 0: 4321
-│                                 row 1, expr 0: 8765
+│                           └── • render
+│                               │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, crdb_region_default, column1)
+│                               │ estimated row count: 2
+│                               │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
+│                               │ render crdb_internal_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
+│                               │ render crdb_region_default: 'ap-southeast-2'
+│                               │ render column1: column1
+│                               │
+│                               └── • values
+│                                     columns: (column1)
+│                                     size: 1 column, 2 rows
+│                                     row 0, expr 0: 4321
+│                                     row 1, expr 0: 8765
 │
 └── • constraint-check
     │
@@ -787,23 +830,34 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (column1)
+            │ columns: (id)
             │ estimated row count: 1 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (crdb_internal_id_shard_16_comp, column1, upsert_crdb_region)
+            └── • project
+                │ columns: (crdb_internal_id_shard_16, id, crdb_region)
                 │ estimated row count: 1 (missing stats)
-                │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
-                │ lookup condition: ((column1 = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                │ pred: (crdb_internal_id_shard_16_comp != crdb_internal_id_shard_16) OR (upsert_crdb_region != crdb_region)
                 │
-                └── • project
-                    │ columns: (crdb_internal_id_shard_16_comp, column1, upsert_crdb_region)
-                    │ estimated row count: 2 (missing stats)
+                └── • lookup join (semi)
+                    │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16, id, crdb_region)
+                    │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                    │ lookup condition: ((crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (id = id)
+                    │ pred: (crdb_internal_id_shard_16 != crdb_internal_id_shard_16) OR (crdb_region != crdb_region)
                     │
-                    └── • scan buffer
-                          columns: (crdb_internal_id_shard_16_comp, column1, crdb_region_default, crdb_internal_id_shard_16, id, crdb_region, crdb_internal_id_shard_16_comp, column1, crdb_region, check1, check2, upsert_crdb_region)
-                          label: buffer 1
+                    └── • render
+                        │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16, id, crdb_region)
+                        │ estimated row count: 2 (missing stats)
+                        │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
+                        │ render crdb_internal_id_shard_16: crdb_internal_id_shard_16_comp
+                        │ render id: column1
+                        │ render crdb_region: upsert_crdb_region
+                        │
+                        └── • project
+                            │ columns: (crdb_internal_id_shard_16_comp, column1, upsert_crdb_region)
+                            │ estimated row count: 2 (missing stats)
+                            │
+                            └── • scan buffer
+                                  columns: (crdb_internal_id_shard_16_comp, column1, crdb_region_default, crdb_internal_id_shard_16, id, crdb_region, crdb_internal_id_shard_16_comp, column1, crdb_region, check1, check2, upsert_crdb_region)
+                                  label: buffer 1
 
 query T
 EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_pk (id) VALUES (4321);
@@ -880,27 +934,31 @@ vectorized: true
     │ render crdb_internal_id_shard_16_comp: crdb_internal_id_shard_16_comp
     │ render crdb_region: crdb_region
     │
-    └── • lookup join (left outer)
-        │ columns: (crdb_internal_id_shard_16_comp, crdb_region_default, column1, crdb_internal_id_shard_16, id, crdb_region)
+    └── • project
+        │ columns: (column1, crdb_region_default, crdb_internal_id_shard_16_comp, crdb_internal_id_shard_16, id, crdb_region)
         │ estimated row count: 2 (missing stats)
-        │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
-        │ equality cols are key
-        │ lookup condition: ((column1 = id) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-        │ remote lookup condition: ((column1 = id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-        │ locking strength: for update
         │
-        └── • render
-            │ columns: (crdb_internal_id_shard_16_comp, crdb_region_default, column1)
-            │ estimated row count: 2
-            │ render crdb_internal_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
-            │ render crdb_region_default: 'ap-southeast-2'
-            │ render column1: column1
+        └── • lookup join (left outer)
+            │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, crdb_region_default, column1, crdb_internal_id_shard_16, id, crdb_region)
+            │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+            │ equality cols are key
+            │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
+            │ remote lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
+            │ locking strength: for update
             │
-            └── • values
-                  columns: (column1)
-                  size: 1 column, 2 rows
-                  row 0, expr 0: 4321
-                  row 1, expr 0: 8765
+            └── • render
+                │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, crdb_region_default, column1)
+                │ estimated row count: 2
+                │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
+                │ render crdb_internal_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
+                │ render crdb_region_default: 'ap-southeast-2'
+                │ render column1: column1
+                │
+                └── • values
+                      columns: (column1)
+                      size: 1 column, 2 rows
+                      row 0, expr 0: 4321
+                      row 1, expr 0: 8765
 
 query T
 EXPLAIN (VERBOSE) UPDATE t_unique_hash_pk SET id = 1234 WHERE id = 4321;
@@ -955,23 +1013,34 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (id_new)
+            │ columns: (id)
             │ estimated row count: 0 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (crdb_internal_id_shard_16_comp, id_new, crdb_region)
+            └── • project
+                │ columns: (crdb_internal_id_shard_16, id, crdb_region)
                 │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
-                │ lookup condition: ((id_new = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                │ pred: (crdb_internal_id_shard_16_comp != crdb_internal_id_shard_16) OR (crdb_region != crdb_region)
                 │
-                └── • project
-                    │ columns: (crdb_internal_id_shard_16_comp, id_new, crdb_region)
-                    │ estimated row count: 1 (missing stats)
+                └── • lookup join (semi)
+                    │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16, id, crdb_region)
+                    │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                    │ lookup condition: ((crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (id = id)
+                    │ pred: (crdb_internal_id_shard_16 != crdb_internal_id_shard_16) OR (crdb_region != crdb_region)
                     │
-                    └── • scan buffer
-                          columns: (crdb_internal_id_shard_16, id, crdb_region, crdb_internal_id_shard_16_comp, id_new, check1)
-                          label: buffer 1
+                    └── • render
+                        │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16, id, crdb_region)
+                        │ estimated row count: 1 (missing stats)
+                        │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(id_new)), 16)
+                        │ render crdb_internal_id_shard_16: crdb_internal_id_shard_16_comp
+                        │ render id: id_new
+                        │ render crdb_region: crdb_region
+                        │
+                        └── • project
+                            │ columns: (crdb_internal_id_shard_16_comp, id_new, crdb_region)
+                            │ estimated row count: 1 (missing stats)
+                            │
+                            └── • scan buffer
+                                  columns: (crdb_internal_id_shard_16, id, crdb_region, crdb_internal_id_shard_16_comp, id_new, check1)
+                                  label: buffer 1
 
 subtest test_uniqueness_check_sec_key
 
@@ -1118,46 +1187,58 @@ vectorized: true
     │ render crdb_region_default: crdb_region_default
     │ render crdb_internal_email_shard_16_comp: crdb_internal_email_shard_16_comp
     │
-    └── • lookup join (anti)
+    └── • project
         │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
         │ estimated row count: 0 (missing stats)
-        │ table: t_unique_hash_sec_key@idx_uniq_hash_email
-        │ equality cols are key
-        │ lookup condition: ((column2 = email) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
         │
-        └── • cross join (anti)
-            │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
-            │ estimated row count: 0 (missing stats)
+        └── • lookup join (anti)
+            │ columns: (crdb_internal_email_shard_16_eq, column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
+            │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+            │ equality cols are key
+            │ lookup condition: ((crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
             │
-            ├── • values
-            │     columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
-            │     size: 4 columns, 1 row
-            │     row 0, expr 0: 4321
-            │     row 0, expr 1: 'some_email'
-            │     row 0, expr 2: 'ap-southeast-2'
-            │     row 0, expr 3: 13
-            │
-            └── • project
-                │ columns: ()
-                │ estimated row count: 1 (missing stats)
+            └── • render
+                │ columns: (crdb_internal_email_shard_16_eq, column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
+                │ estimated row count: 0 (missing stats)
+                │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
+                │ render column1: column1
+                │ render column2: column2
+                │ render crdb_region_default: crdb_region_default
+                │ render crdb_internal_email_shard_16_comp: crdb_internal_email_shard_16_comp
                 │
-                └── • union all
-                    │ columns: (id)
-                    │ estimated row count: 1 (missing stats)
-                    │ limit: 1
+                └── • cross join (anti)
+                    │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
+                    │ estimated row count: 0 (missing stats)
                     │
-                    ├── • scan
-                    │     columns: (id)
-                    │     estimated row count: 1 (missing stats)
-                    │     table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-                    │     spans: /"@"/4321/0
+                    ├── • values
+                    │     columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
+                    │     size: 4 columns, 1 row
+                    │     row 0, expr 0: 4321
+                    │     row 0, expr 1: 'some_email'
+                    │     row 0, expr 2: 'ap-southeast-2'
+                    │     row 0, expr 3: 13
                     │
-                    └── • scan
-                          columns: (id)
-                          estimated row count: 1 (missing stats)
-                          table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-                          spans: /"\x80"/4321/0 /"\xc0"/4321/0
-                          parallel
+                    └── • project
+                        │ columns: ()
+                        │ estimated row count: 1 (missing stats)
+                        │
+                        └── • union all
+                            │ columns: (id)
+                            │ estimated row count: 1 (missing stats)
+                            │ limit: 1
+                            │
+                            ├── • scan
+                            │     columns: (id)
+                            │     estimated row count: 1 (missing stats)
+                            │     table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+                            │     spans: /"@"/4321/0
+                            │
+                            └── • scan
+                                  columns: (id)
+                                  estimated row count: 1 (missing stats)
+                                  table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+                                  spans: /"\x80"/4321/0 /"\xc0"/4321/0
+                                  parallel
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email'), (8765, 'another_email') ON CONFLICT DO NOTHING;
@@ -1183,41 +1264,45 @@ vectorized: true
     │ render crdb_internal_email_shard_16_comp: crdb_internal_email_shard_16_comp
     │
     └── • lookup join (anti)
-        │ columns: (crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
+        │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
         │ estimated row count: 0 (missing stats)
         │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
         │ equality cols are key
-        │ lookup condition: (column1 = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+        │ lookup condition: (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (column1 = id)
         │
-        └── • lookup join (anti)
-            │ columns: (crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
+        └── • project
+            │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
             │ estimated row count: 0 (missing stats)
-            │ table: t_unique_hash_sec_key@idx_uniq_hash_email
-            │ equality cols are key
-            │ lookup condition: ((column2 = email) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
             │
             └── • lookup join (anti)
-                │ columns: (crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
-                │ estimated row count: 2 (missing stats)
+                │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
                 │ table: t_unique_hash_sec_key@idx_uniq_hash_email
                 │ equality cols are key
-                │ lookup condition: ((column2 = email) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
                 │
-                └── • render
-                    │ columns: (crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
-                    │ estimated row count: 2
-                    │ render crdb_internal_email_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
-                    │ render crdb_region_default: 'ap-southeast-2'
-                    │ render column1: column1
-                    │ render column2: column2
+                └── • lookup join (anti)
+                    │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
+                    │ estimated row count: 1 (missing stats)
+                    │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                    │ equality cols are key
+                    │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
                     │
-                    └── • values
-                          columns: (column1, column2)
-                          size: 2 columns, 2 rows
-                          row 0, expr 0: 4321
-                          row 0, expr 1: 'some_email'
-                          row 1, expr 0: 8765
-                          row 1, expr 1: 'another_email'
+                    └── • render
+                        │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
+                        │ estimated row count: 2
+                        │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
+                        │ render crdb_internal_email_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
+                        │ render crdb_region_default: 'ap-southeast-2'
+                        │ render column1: column1
+                        │ render column2: column2
+                        │
+                        └── • values
+                              columns: (column1, column2)
+                              size: 2 columns, 2 rows
+                              row 0, expr 0: 4321
+                              row 0, expr 1: 'some_email'
+                              row 1, expr 0: 8765
+                              row 1, expr 1: 'another_email'
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email') ON CONFLICT (email) DO NOTHING;
@@ -1332,35 +1417,39 @@ vectorized: true
 │           │ render crdb_region_default: crdb_region_default
 │           │ render crdb_internal_email_shard_16_comp: crdb_internal_email_shard_16_comp
 │           │
-│           └── • lookup join (anti)
-│               │ columns: (crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
+│           └── • project
+│               │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
 │               │ estimated row count: 0 (missing stats)
-│               │ table: t_unique_hash_sec_key@idx_uniq_hash_email
-│               │ equality cols are key
-│               │ lookup condition: ((column2 = email) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
 │               │
 │               └── • lookup join (anti)
-│                   │ columns: (crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
-│                   │ estimated row count: 2 (missing stats)
+│                   │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
 │                   │ table: t_unique_hash_sec_key@idx_uniq_hash_email
 │                   │ equality cols are key
-│                   │ lookup condition: ((column2 = email) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+│                   │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
 │                   │
-│                   └── • render
-│                       │ columns: (crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
-│                       │ estimated row count: 2
-│                       │ render crdb_internal_email_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
-│                       │ render crdb_region_default: 'ap-southeast-2'
-│                       │ render column1: column1
-│                       │ render column2: column2
+│                   └── • lookup join (anti)
+│                       │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
+│                       │ estimated row count: 1 (missing stats)
+│                       │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+│                       │ equality cols are key
+│                       │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
 │                       │
-│                       └── • values
-│                             columns: (column1, column2)
-│                             size: 2 columns, 2 rows
-│                             row 0, expr 0: 4321
-│                             row 0, expr 1: 'some_email'
-│                             row 1, expr 0: 8765
-│                             row 1, expr 1: 'another_email'
+│                       └── • render
+│                           │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
+│                           │ estimated row count: 2
+│                           │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
+│                           │ render crdb_internal_email_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
+│                           │ render crdb_region_default: 'ap-southeast-2'
+│                           │ render column1: column1
+│                           │ render column2: column2
+│                           │
+│                           └── • values
+│                                 columns: (column1, column2)
+│                                 size: 2 columns, 2 rows
+│                                 row 0, expr 0: 4321
+│                                 row 0, expr 1: 'some_email'
+│                                 row 1, expr 0: 8765
+│                                 row 1, expr 1: 'another_email'
 │
 └── • constraint-check
     │
@@ -1375,7 +1464,7 @@ vectorized: true
                 │ columns: (column1, crdb_region_default)
                 │ estimated row count: 0 (missing stats)
                 │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-                │ lookup condition: (column1 = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+                │ lookup condition: (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (column1 = id)
                 │ pred: crdb_region_default != crdb_region
                 │
                 └── • project
@@ -1493,7 +1582,7 @@ vectorized: true
 │               │ columns: (upsert_id, upsert_crdb_region)
 │               │ estimated row count: 0 (missing stats)
 │               │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-│               │ lookup condition: (upsert_id = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+│               │ lookup condition: (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (upsert_id = id)
 │               │ pred: upsert_crdb_region != crdb_region
 │               │
 │               └── • project
@@ -1510,23 +1599,34 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (upsert_email)
+            │ columns: (email)
             │ estimated row count: 0 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (upsert_id, upsert_email, upsert_crdb_region)
+            └── • project
+                │ columns: (id, email, crdb_region)
                 │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
-                │ lookup condition: ((upsert_email = email) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                │ pred: (upsert_id != id) OR (upsert_crdb_region != crdb_region)
                 │
-                └── • project
-                    │ columns: (upsert_id, upsert_email, upsert_crdb_region)
-                    │ estimated row count: 1 (missing stats)
+                └── • lookup join (semi)
+                    │ columns: (crdb_internal_email_shard_16_eq, id, email, crdb_region)
+                    │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                    │ lookup condition: ((crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (email = email)
+                    │ pred: (id != id) OR (crdb_region != crdb_region)
                     │
-                    └── • scan buffer
-                          columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, crdb_region, check1, check2, upsert_id, upsert_crdb_region)
-                          label: buffer 1
+                    └── • render
+                        │ columns: (crdb_internal_email_shard_16_eq, id, email, crdb_region)
+                        │ estimated row count: 1 (missing stats)
+                        │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(upsert_email)), 16)
+                        │ render id: upsert_id
+                        │ render email: upsert_email
+                        │ render crdb_region: upsert_crdb_region
+                        │
+                        └── • project
+                            │ columns: (upsert_id, upsert_email, upsert_crdb_region)
+                            │ estimated row count: 1 (missing stats)
+                            │
+                            └── • scan buffer
+                                  columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, crdb_region, check1, check2, upsert_id, upsert_crdb_region)
+                                  label: buffer 1
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email'), (8765, 'another_email') ON CONFLICT (email) DO UPDATE SET email = 'bad_email';
@@ -1600,30 +1700,34 @@ vectorized: true
 │                           │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region)
 │                           │ estimated row count: 2 (missing stats)
 │                           │
-│                           └── • lookup join (left outer)
-│                               │ columns: (crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2, id, email, crdb_region, crdb_internal_email_shard_16)
+│                           └── • project
+│                               │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region, crdb_internal_email_shard_16)
 │                               │ estimated row count: 2 (missing stats)
-│                               │ table: t_unique_hash_sec_key@idx_uniq_hash_email
-│                               │ equality cols are key
-│                               │ lookup condition: ((column2 = email) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-│                               │ remote lookup condition: ((column2 = email) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-│                               │ locking strength: for update
 │                               │
-│                               └── • render
-│                                   │ columns: (crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
-│                                   │ estimated row count: 2
-│                                   │ render crdb_internal_email_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
-│                                   │ render crdb_region_default: 'ap-southeast-2'
-│                                   │ render column1: column1
-│                                   │ render column2: column2
+│                               └── • lookup join (left outer)
+│                                   │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2, id, email, crdb_region, crdb_internal_email_shard_16)
+│                                   │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+│                                   │ equality cols are key
+│                                   │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
+│                                   │ remote lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
+│                                   │ locking strength: for update
 │                                   │
-│                                   └── • values
-│                                         columns: (column1, column2)
-│                                         size: 2 columns, 2 rows
-│                                         row 0, expr 0: 4321
-│                                         row 0, expr 1: 'some_email'
-│                                         row 1, expr 0: 8765
-│                                         row 1, expr 1: 'another_email'
+│                                   └── • render
+│                                       │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
+│                                       │ estimated row count: 2
+│                                       │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
+│                                       │ render crdb_internal_email_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
+│                                       │ render crdb_region_default: 'ap-southeast-2'
+│                                       │ render column1: column1
+│                                       │ render column2: column2
+│                                       │
+│                                       └── • values
+│                                             columns: (column1, column2)
+│                                             size: 2 columns, 2 rows
+│                                             row 0, expr 0: 4321
+│                                             row 0, expr 1: 'some_email'
+│                                             row 1, expr 0: 8765
+│                                             row 1, expr 1: 'another_email'
 │
 ├── • constraint-check
 │   │
@@ -1638,7 +1742,7 @@ vectorized: true
 │               │ columns: (upsert_id, upsert_crdb_region)
 │               │ estimated row count: 1 (missing stats)
 │               │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-│               │ lookup condition: (upsert_id = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+│               │ lookup condition: (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (upsert_id = id)
 │               │ pred: upsert_crdb_region != crdb_region
 │               │
 │               └── • project
@@ -1655,23 +1759,34 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (upsert_email)
+            │ columns: (email)
             │ estimated row count: 1 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (upsert_id, upsert_email, upsert_crdb_region)
+            └── • project
+                │ columns: (id, email, crdb_region)
                 │ estimated row count: 1 (missing stats)
-                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
-                │ lookup condition: ((upsert_email = email) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                │ pred: (upsert_id != id) OR (upsert_crdb_region != crdb_region)
                 │
-                └── • project
-                    │ columns: (upsert_id, upsert_email, upsert_crdb_region)
-                    │ estimated row count: 2 (missing stats)
+                └── • lookup join (semi)
+                    │ columns: (crdb_internal_email_shard_16_eq, id, email, crdb_region)
+                    │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                    │ lookup condition: ((crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (email = email)
+                    │ pred: (id != id) OR (crdb_region != crdb_region)
                     │
-                    └── • scan buffer
-                          columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, crdb_region, check1, check2, upsert_id, upsert_crdb_region)
-                          label: buffer 1
+                    └── • render
+                        │ columns: (crdb_internal_email_shard_16_eq, id, email, crdb_region)
+                        │ estimated row count: 2 (missing stats)
+                        │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(upsert_email)), 16)
+                        │ render id: upsert_id
+                        │ render email: upsert_email
+                        │ render crdb_region: upsert_crdb_region
+                        │
+                        └── • project
+                            │ columns: (upsert_id, upsert_email, upsert_crdb_region)
+                            │ estimated row count: 2 (missing stats)
+                            │
+                            └── • scan buffer
+                                  columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, crdb_region, check1, check2, upsert_id, upsert_crdb_region)
+                                  label: buffer 1
 
 query T
 EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_sec_key VALUES (1, 'email1');
@@ -1754,23 +1869,34 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (column2)
+            │ columns: (email)
             │ estimated row count: 0 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (upsert_id, column2, crdb_region_default)
+            └── • project
+                │ columns: (id, email, crdb_region)
                 │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
-                │ lookup condition: ((column2 = email) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                │ pred: (upsert_id != id) OR (crdb_region_default != crdb_region)
                 │
-                └── • project
-                    │ columns: (upsert_id, column2, crdb_region_default)
-                    │ estimated row count: 1 (missing stats)
+                └── • lookup join (semi)
+                    │ columns: (crdb_internal_email_shard_16_eq, id, email, crdb_region)
+                    │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                    │ lookup condition: ((crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (email = email)
+                    │ pred: (id != id) OR (crdb_region != crdb_region)
                     │
-                    └── • scan buffer
-                          columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region, crdb_internal_email_shard_16, column2, crdb_region_default, crdb_internal_email_shard_16_comp, crdb_region, check1, check2, upsert_id)
-                          label: buffer 1
+                    └── • render
+                        │ columns: (crdb_internal_email_shard_16_eq, id, email, crdb_region)
+                        │ estimated row count: 1 (missing stats)
+                        │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
+                        │ render id: upsert_id
+                        │ render email: column2
+                        │ render crdb_region: crdb_region_default
+                        │
+                        └── • project
+                            │ columns: (upsert_id, column2, crdb_region_default)
+                            │ estimated row count: 1 (missing stats)
+                            │
+                            └── • scan buffer
+                                  columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region, crdb_internal_email_shard_16, column2, crdb_region_default, crdb_internal_email_shard_16_comp, crdb_region, check1, check2, upsert_id)
+                                  label: buffer 1
 
 query T
 EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_sec_key VALUES (1, 'email1'), (8765, 'email2');
@@ -1826,8 +1952,8 @@ vectorized: true
 │                       │ estimated row count: 2 (missing stats)
 │                       │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
 │                       │ equality cols are key
-│                       │ lookup condition: (column1 = id) AND (crdb_region = 'ap-southeast-2')
-│                       │ remote lookup condition: (column1 = id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))
+│                       │ lookup condition: (crdb_region = 'ap-southeast-2') AND (column1 = id)
+│                       │ remote lookup condition: (crdb_region IN ('ca-central-1', 'us-east-1')) AND (column1 = id)
 │                       │ locking strength: for update
 │                       │
 │                       └── • render
@@ -1852,23 +1978,34 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (column2)
+            │ columns: (email)
             │ estimated row count: 1 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (upsert_id, column2, crdb_region_default)
+            └── • project
+                │ columns: (id, email, crdb_region)
                 │ estimated row count: 1 (missing stats)
-                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
-                │ lookup condition: ((column2 = email) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                │ pred: (upsert_id != id) OR (crdb_region_default != crdb_region)
                 │
-                └── • project
-                    │ columns: (upsert_id, column2, crdb_region_default)
-                    │ estimated row count: 2 (missing stats)
+                └── • lookup join (semi)
+                    │ columns: (crdb_internal_email_shard_16_eq, id, email, crdb_region)
+                    │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                    │ lookup condition: ((crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (email = email)
+                    │ pred: (id != id) OR (crdb_region != crdb_region)
                     │
-                    └── • scan buffer
-                          columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region, crdb_internal_email_shard_16, column2, crdb_region_default, crdb_internal_email_shard_16_comp, crdb_region, check1, check2, upsert_id)
-                          label: buffer 1
+                    └── • render
+                        │ columns: (crdb_internal_email_shard_16_eq, id, email, crdb_region)
+                        │ estimated row count: 2 (missing stats)
+                        │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
+                        │ render id: upsert_id
+                        │ render email: column2
+                        │ render crdb_region: crdb_region_default
+                        │
+                        └── • project
+                            │ columns: (upsert_id, column2, crdb_region_default)
+                            │ estimated row count: 2 (missing stats)
+                            │
+                            └── • scan buffer
+                                  columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region, crdb_internal_email_shard_16, column2, crdb_region_default, crdb_internal_email_shard_16_comp, crdb_region, check1, check2, upsert_id)
+                                  label: buffer 1
 
 query T
 EXPLAIN (VERBOSE) UPDATE t_unique_hash_sec_key SET email = 'email1' WHERE id = 2;
@@ -1924,20 +2061,31 @@ vectorized: true
         │ columns: ()
         │
         └── • project
-            │ columns: (email_new)
+            │ columns: (email)
             │ estimated row count: 0 (missing stats)
             │
-            └── • lookup join (semi)
-                │ columns: (id, email_new, crdb_region)
+            └── • project
+                │ columns: (id, email, crdb_region)
                 │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
-                │ lookup condition: ((email_new = email) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                │ pred: (id != id) OR (crdb_region != crdb_region)
                 │
-                └── • project
-                    │ columns: (id, email_new, crdb_region)
-                    │ estimated row count: 1 (missing stats)
+                └── • lookup join (semi)
+                    │ columns: (crdb_internal_email_shard_16_eq, id, email, crdb_region)
+                    │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                    │ lookup condition: ((crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (email = email)
+                    │ pred: (id != id) OR (crdb_region != crdb_region)
                     │
-                    └── • scan buffer
-                          columns: (id, email, crdb_region, crdb_internal_email_shard_16, email_new, crdb_internal_email_shard_16_comp, check1)
-                          label: buffer 1
+                    └── • render
+                        │ columns: (crdb_internal_email_shard_16_eq, id, email, crdb_region)
+                        │ estimated row count: 1 (missing stats)
+                        │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(email_new)), 16)
+                        │ render id: id
+                        │ render email: email_new
+                        │ render crdb_region: crdb_region
+                        │
+                        └── • project
+                            │ columns: (id, email_new, crdb_region)
+                            │ estimated row count: 1 (missing stats)
+                            │
+                            └── • scan buffer
+                                  columns: (id, email, crdb_region, crdb_internal_email_shard_16, email_new, crdb_internal_email_shard_16_comp, check1)
+                                  label: buffer 1

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -357,13 +357,13 @@ SELECT * FROM [
             │
             └── • lookup join (anti)
                 │ table: regional_by_row_table@uniq_idx (partial index)
-                │ lookup condition: (column4 = a) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+                │ lookup condition: (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (column4 = a)
                 │ pred: column5 > 0
                 │
                 └── • lookup join (anti)
                     │ table: regional_by_row_table@regional_by_row_table_b_key
                     │ equality cols are key
-                    │ lookup condition: (column5 = b) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+                    │ lookup condition: (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (column5 = b)
                     │
                     └── • cross join (anti)
                         │
@@ -658,7 +658,7 @@ SELECT * FROM [EXPLAIN SELECT * FROM child WHERE NOT EXISTS (SELECT * FROM paren
 • lookup join (anti)
 │ table: parent@parent_pkey
 │ equality cols are key
-│ lookup condition: (p_id = c_p_id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+│ lookup condition: (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (c_p_id = p_id)
 │
 └── • scan
       missing stats
@@ -688,7 +688,7 @@ SELECT * FROM [EXPLAIN SELECT * FROM child WHERE EXISTS (SELECT * FROM parent WH
 • lookup join (semi)
 │ table: parent@parent_pkey
 │ equality cols are key
-│ lookup condition: (p_id = c_p_id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+│ lookup condition: (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (c_p_id = p_id)
 │
 └── • scan
       missing stats
@@ -719,7 +719,7 @@ SELECT * FROM [EXPLAIN SELECT * FROM child INNER JOIN parent ON p_id = c_p_id WH
 • lookup join
 │ table: parent@parent_pkey
 │ equality cols are key
-│ lookup condition: (p_id = c_p_id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+│ lookup condition: (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (c_p_id = p_id)
 │
 └── • scan
       missing stats
@@ -750,7 +750,7 @@ SELECT * FROM [EXPLAIN SELECT * FROM child LEFT JOIN parent ON p_id = c_p_id WHE
 • lookup join (left outer)
 │ table: parent@parent_pkey
 │ equality cols are key
-│ lookup condition: (p_id = c_p_id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+│ lookup condition: (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (c_p_id = p_id)
 │
 └── • scan
       missing stats
@@ -784,12 +784,12 @@ SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM child WHERE NOT EXISTS (SELECT * 
 • lookup join (anti)
 │ table: parent@parent_pkey
 │ equality cols are key
-│ lookup condition: (p_id = c_p_id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))
+│ lookup condition: (crdb_region IN ('ca-central-1', 'us-east-1')) AND (c_p_id = p_id)
 │
 └── • lookup join (anti)
     │ table: parent@parent_pkey
     │ equality cols are key
-    │ lookup condition: (p_id = c_p_id) AND (crdb_region = 'ap-southeast-2')
+    │ lookup condition: (crdb_region = 'ap-southeast-2') AND (c_p_id = p_id)
     │
     └── • union all
         │ limit: 1
@@ -804,7 +804,7 @@ SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM child WHERE NOT EXISTS (SELECT * 
               table: child@child_pkey
               spans: [/'ca-central-1'/10 - /'ca-central-1'/10] [/'us-east-1'/10 - /'us-east-1'/10]
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJy0k2Fro04Qxt__P8Uwb5L82SOr8biyULC0hrN4ppcIV2gkWHdovdpdb1VIKfnuh5qjMVwCzd29UXd2Hvf3DM--YvkjR4ELL_AuI_gfpvPZF7jzbm-CCz-E4ZW_iBZfgxH0G9LHLJfw7bM392AYziLwbptGGPbbisSQqrZ9xSqTcA7pqvkYjeAivIJh2hUtPophNp0uvAhsZKi0pDB5phLFHVoYMyyMTqkstWlKr22DL9coOMNMFXXVlGOGqTaE4hWrrMoJBUbJfU5zSiSZMUeGkqoky9vfth7c9rkqnugFGV7qvH5WpYAGi21RkeGiSJrqeInL5fqML3Fs8TGHREmwQFePZDDeMNR19UZSVskDobA27DRa6y_QulvSg3T2Qbo3qJJMluRQK20kGZI9rnjzGxuh_qCLsd03EGTPWQXWQRT-nkFd60xt5zTpHxO9FCQg8KYRXISRD9czP0SGXRLd7vVrgIHWT3UB33WmQCsBQ3cC5-Da22y6DpzDeuDwgRDCtTi3-KfR7tyLbu5G3q8MPWRaHTQ3OdGc8y_NNfd7PTjbtcdgPUh7fk807LzH8JzKQquS9pJ1KCcxQ5IP1KW01LVJ6cbotD2mW85aXVuQVFbdrt0tfNVutfdyV2z9idg-Kp70xHxfPDkqdo6LnaPij3viePPfzwAAAP__dhHiVw==
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJysk2Fro04Qxt__P8Uwb5L82SOr8biyULC0hrN4ppcIV2gkWHdovdpdb1VIKfnuh5qjMVwC7eWNurPzuL9nePYVy185Clx4gXcZwf8wnc--wZ13exNc-CEMr_xFtPgejKDfkD5muYQfX725B8NwFoF32zTCsN9WJIZUte0rVpmEc0hXzcdoBBfhFQzTrmjxUQyz6XThRWAjQ6UlhckzlSju0MKYYWF0SmWpTVN6bRt8uUbBGWaqqKumHDNMtSEUr1hlVU4oMEruc5pTIsmMOTKUVCVZ3v629eC2z1XxRC_I8FLn9bMqBTRYbIuKDBdF0lTHS1wu12d8iWOLjzkkSoIFunokg_GGoa6rN5KySh4IhbVhH6O1TkDrbkkP0tkH6d6gSjJZkkOttJFkSPa44s1fbIT6ky7Gdt9AkD1nFVgHUfh7BnWtM7Wd06R_TPRSkIDAm0ZwEUY-XM_8EBl2SXS7158BBlo_1QX81JkCrQQMXQfOYT1w-EAI4VqcW_zLNqiuDefgTka7cy-6uRt5vzL0kGl10Nzkg-ac05prbvR6cLZrj8F6kPb8nsSw8x7DcyoLrUraS9ahnMQMST5Ql9JS1yalG6PT9phuOWt1bUFSWXW7drfwVbvV3stdsfUvYvuoeNIT833x5KjYOS52joo_74njzX-_AwAA__-DDeJX
 
 statement ok
 SET vectorize=on
@@ -865,8 +865,8 @@ SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM child WHERE EXISTS (SELECT * FROM
 • lookup join (semi)
 │ table: parent@parent_pkey
 │ equality cols are key
-│ lookup condition: (p_id = c_p_id) AND (crdb_region = 'ap-southeast-2')
-│ remote lookup condition: (p_id = c_p_id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))
+│ lookup condition: (crdb_region = 'ap-southeast-2') AND (c_p_id = p_id)
+│ remote lookup condition: (crdb_region IN ('ca-central-1', 'us-east-1')) AND (c_p_id = p_id)
 │
 └── • union all
     │ limit: 1
@@ -881,7 +881,7 @@ SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM child WHERE EXISTS (SELECT * FROM
           table: child@child_pkey
           spans: [/'ca-central-1'/10 - /'ca-central-1'/10] [/'us-east-1'/10 - /'us-east-1'/10]
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJysk1Fr2zAQx9_3KY57STI0IjuBFUHApXWYi5t0sWGFxgTXOlKvjuTJNqSEfPdhO6NxWDq67cW2TveXfve_8w6LHxkKDFzfvQrhI0wX81t4cO_v_EtvBv1rLwiDr_4AugnJU5pJ-PbFXbjg3tc50O9m5LEhVR5S8lUqYQLJqv4YwOXsGvpJG7P4IIL5dBq4IdjIUGlJs3hDBYoHtDBimBudUFFoU4d2TYIntyg4w1TlVVmHI4aJNoRih2VaZoQCw_gxowXFksyQI0NJZZxmzbENvdM8V_kzvSDDK51VG1UIqLHYgRQZBnlcR4dLXC63F3yJQ4sPOcRKggW6fCKD0Z6hrspXkqKM14TC2rO_o7X-A61zID1LZ5-le4UqyKRxBpXSRpIh2eGK9r8pY6Y_6Xxodwvw001agnUWhb_HqBudqoNPo-414UtOAnx3GkLg3npwM_dmyLAdRKd9_TLQ1_q5yuG7ThVoJaDvjGACjn2YTWcME9j2xrwnhHAszi3-eYAMF7TRJUH2R3X962x7F8d6Btte0jlwcNzJvO2kkY8rQ-tUq7N2jd5j14KKXKuCTlp3rhERQ5Jraseg0JVJ6M7opLmmXc4bXROQVJTtrt0uPNVsNYN_LLb-RWy_KR51xPxUPHpTPD4RR_sPPwMAAP__OaSYJA==
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJysk1Fr2zAQx9_3KY57STI0IjuBFUHApXWYi5t0sWGFxgTXOlKvjuTJNqSEfPdhO1vrrCl024ttne5_-ul_5x0WPzIUGLi-exHCR5gu5tdw597e-OfeDPqXXhAGX_0BdBOShzST8O2Lu3DBva1zoN_NyGNDqjyk5KtUwgSSVf0xgPPZJfSTNmbxQQTz6TRwQ7CRodKSZvGGChR3aGHEMDc6oaLQpg7tmgRPblFwhqnKq7IORwwTbQjFDsu0zAgFhvF9RguKJZkhR4aSyjjNmrINvdM8V_kjPSHDC51VG1UIqLHYgRQZBnlcR4dLXC63Z3yJQ4sPOcRKggW6fCCD0Z6hrspnkqKM14TC2rO_o7X-A61zID1JZ5-ke4YqyKRxBpXSRpIh2eGK9q9cY6Y_6Xxody_gp5u0BOskCn-PUVc6VQefRt1jwqecBPjuNITAvfbgau7NkGE7iE77-mWgr_VjlcN3nSrQSkDfGcMEtr0x7wkhHItzi38-DKpjwwSc0QAZLmijS4LsFXX9s2x7Zy_1DLa9pFPwz4q_O5m3nTTyfmVonWp10q7Re-xaUJFrVdBR6041ImJIck3tGBS6MgndGJ00x7TLeaNrApKKst2124Wnmq1m8F-KrX8R22-KRx0xPxaP3hSPj8TR_sPPAAAA__9GoJgk
 
 statement ok
 SET vectorize=on
@@ -943,8 +943,8 @@ SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM child INNER JOIN parent ON p_id =
 • lookup join
 │ table: parent@parent_pkey
 │ equality cols are key
-│ lookup condition: (p_id = c_p_id) AND (crdb_region = 'ap-southeast-2')
-│ remote lookup condition: (p_id = c_p_id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))
+│ lookup condition: (crdb_region = 'ap-southeast-2') AND (c_p_id = p_id)
+│ remote lookup condition: (crdb_region IN ('ca-central-1', 'us-east-1')) AND (c_p_id = p_id)
 │
 └── • union all
     │ limit: 1
@@ -959,7 +959,7 @@ SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM child INNER JOIN parent ON p_id =
           table: child@child_pkey
           spans: [/'ca-central-1'/10 - /'ca-central-1'/10] [/'us-east-1'/10 - /'us-east-1'/10]
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJysk2Fr2zwQgL-_v-K4L2leNCLbhRVBwKV1mEtmd05gg8YE1zpSr47kyTJkhPz3ETujcVg6uu2LbZ30SI_uzlusv5UocBZMg5s5_A-TJP4ID8GX--l1GMHFbTibzz5Nh9BfkD8VpYQwioIE7uIwgiozpCzEEVTLQsIY8mX78flDkASQdzGHpxBPJrNgDi4yVFpSlK2pRvGADqYMK6Nzqmtt9qFtuyCUGxScYaGqxu7DKcNcG0KxRVvYklDgPHssKaFMkhlxZCjJZkXZbtuK-u1zWT3Td2R4o8tmrWrRWrGDKDKcVdk-OlrgYrG54gscOXzEIVMSHND2iQymO4a6sS8mtc1WhMLZsT-zdf6BrX8wPWvnnrV7karJFFkJjdJGkiHZ80p3v7hGpN_pauT2LzAt1oUF56wKf0ui7nShDnny-sd03eZ3r5-Zmmr93FTwVRcKtBJw4XswBt8dwnV0Cxf-JYxhM7jkAyGE73Du8PdDZJjQWluC8rf0_nfYDK6OeQabQd7bcHhcsqormZGPS0OrQitkGDdWgO8w32W-dzZP3lvylFBdaVXTSc3OVSBlSHJFXf1r3Zic7o3O22O6YdxybUBSbbtZtxuEqp1qO_4Ydv4Gdl-FvR7MT2HvVfjyBE53__0IAAD__5JOkJo=
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJysk2Fr2zwQgL-_v-K4L2lfNCLbgRVBwKV1mEtmd05gg8YE1zpSr47kyTJkhPz3ETtb66wpdNsX2zrpOT26k7dYfytR4CyYBldz-B8mSfwR7oIvt9PLMIKz63A2n32ankN_Qf5QlBLCKAoSuInDCKrMkLIQR1AtCwljyJftx-cPQRJA3sUcnkI8mcyCObjIUGlJUbamGsUdOpgyrIzOqa612Ye27YJQblBwhoWqGrsPpwxzbQjFFm1hS0KB8-y-pIQySWbIkaEkmxVlm7YV9dvnsnqk78jwSpfNWtWitWIHUWQ4q7J9dLjAxWJzwRc4dPiQQ6YkOKDtAxlMdwx1Y59MaputCIWzY39m6_wDW_9getLOPWn3JFWTKbISGqWNJEOy55XuXjhGpN_pauj2DzAt1oUF56QKf0uhbnShDnXy-tt0t83vXj8rNdX6sangqy4UaCXgzB_BGDaDER8IIXyHc4e_P4fL6BrOfBfG4HvnyDChtbYE5Qv0_gfYDC6e8ww2g7yX8PeMv1pWdS0z8n5paFVohQzjxgrwHea7zPdO1sl7S50Sqiutajrq2akOpAxJrqjrf60bk9Ot0Xm7TTeMW64NSKptN-t2g1C1U-2Nfw47fwO7r8JeD-bHsPcqPDqC091_PwIAAP__n0qQmg==
 
 statement ok
 SET vectorize=on
@@ -1021,8 +1021,8 @@ SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM child LEFT JOIN parent ON p_id = 
 • lookup join (left outer)
 │ table: parent@parent_pkey
 │ equality cols are key
-│ lookup condition: (p_id = c_p_id) AND (crdb_region = 'ap-southeast-2')
-│ remote lookup condition: (p_id = c_p_id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))
+│ lookup condition: (crdb_region = 'ap-southeast-2') AND (c_p_id = p_id)
+│ remote lookup condition: (crdb_region IN ('ca-central-1', 'us-east-1')) AND (c_p_id = p_id)
 │
 └── • union all
     │ limit: 1
@@ -1037,7 +1037,7 @@ SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM child LEFT JOIN parent ON p_id = 
           table: child@child_pkey
           spans: [/'ca-central-1'/10 - /'ca-central-1'/10] [/'us-east-1'/10 - /'us-east-1'/10]
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJysk2Fr2zwQgL-_v-K4L2leNCI7hRVBwaV1WIpnd47HBo0JrnW0Xh3Jk2VIKfnvI3JH67B0dNuXxDrpkR7dnR6x_V6jwEUYhecZ_A-zNPkI1-HXq-hsHsPRxXyRLT5FYxguKO-qWkIUzjK4TOYxNIUhZSGJoVlVEk6hXLmPLx_CNISyj3k8h2Q2W4QZ-MhQaUlxsaYWxTV6mDNsjC6pbbXZhR7dgrncoOAMK9V0dhfOGZbaEIpHtJWtCQVmxU1NKRWSzIQjQ0m2qGq3rfMM3O-quacHZHiu626tWuGs2JMoMlw0xS46WeJyuTnhS5x4fMKhUBI80PaODOZbhrqzzyatLW4Jhbdlf2br_QPb4Mn0oJ1_0O5ZqiVTFTV0ShtJhuTAK9_-4hqxfqebiT-8QFStKwveQRX-lkRd6ko95Wk6PCZ7aEj03Zd8zsLU9SAy7Lsw6P9-ZjDS-r5r4JuuFGgl4CiYwikE_hjO4gs4Co7hFDajYz4SQgQe5x5_P0aGKa21Jah_S-9eyWZ08pJnsBmVgw3HL0vZ9KU08mZl6LbSChkmnRUQeCzwWTA9mL_pW_KXUtto1dJeLQ9VJmdI8pb6vmh1Z0q6Mrp0x_TDxHEuIKm1_azfD-bKTbmX8BL2_gb2X4WnA5jvw9NX4eM9ON_-9yMAAP__uiqW3w==
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJysk2Fr2zwQx98_n-K4N2kfNCI7hRVBwaV1WIpnd47HBo0JrnW0Xh3Jk2VIKfnuI3K31llT6LY3tnTS__TT_04P2H6vUeA8jMKzDP6HaZp8hKvw62V0Oovh4Hw2z-afokMYbihvq1pCFE4zuEhmMTSFIWUhiaFZVhJOoFy6wZcPYRpC2cc8nkMync7DDHxkqLSkuFhRi-IKPcwZNkaX1LbabEMPbsNMrlFwhpVqOrsN5wxLbQjFA9rK1oQCs-K6ppQKSWbMkaEkW1S1S-s4A_ddNnd0jwzPdN2tVCscFXsERYbzpthGxwtcLNbHfIFjj485FEqCB9reksF8w1B39omktcUNofA27M9ovX9AGzyS7qXz99I9QbVkqqKGTmkjyZAccOWbF64R63e6GfvDC0TVqrLg7UXhbzHqQlfq0afJ8JjsviHRd1_yOQtT14PIsO_CoP_9dDDS-q5r4JuuFGgl4CA4ghNYj474SAgReJx7_P0hnMbncBD4cALB5BAZprTSlqB-Qb19F-vR8XM9g_WoHCT8PeOvUjZ9KY28Xhq6qbRChklnBQQeC3wWTPb6N3mLfym1jVYt7dRyX2VyhiRvqO-LVnempEujS3dMP02czgUktbZf9fvJTLkl9xKei72_EfuviicDMd8VT14VH-2I881_PwIAAP__xyaW3w==
 
 statement ok
 SET vectorize=on
@@ -1128,12 +1128,12 @@ SELECT * FROM [EXPLAIN INSERT INTO child VALUES (1, 1)] OFFSET 2
         └── • lookup join (anti)
             │ table: parent@parent_pkey
             │ equality cols are key
-            │ lookup condition: (column2 = p_id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))
+            │ lookup condition: (crdb_region IN ('ca-central-1', 'us-east-1')) AND (column2 = p_id)
             │
             └── • lookup join (anti)
                 │ table: parent@parent_pkey
                 │ equality cols are key
-                │ lookup condition: (column2 = p_id) AND (crdb_region = 'ap-southeast-2')
+                │ lookup condition: (crdb_region = 'ap-southeast-2') AND (column2 = p_id)
                 │
                 └── • scan buffer
                       label: buffer 1
@@ -1164,7 +1164,7 @@ SELECT * FROM [EXPLAIN INSERT INTO child VALUES (1, 1), (2, 2)] OFFSET 2
 │       │
 │       └── • lookup join (semi)
 │           │ table: child@child_pkey
-│           │ lookup condition: (column1 = c_id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+│           │ lookup condition: (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (column1 = c_id)
 │           │ pred: crdb_region_default != crdb_region
 │           │
 │           └── • scan buffer
@@ -1177,12 +1177,12 @@ SELECT * FROM [EXPLAIN INSERT INTO child VALUES (1, 1), (2, 2)] OFFSET 2
         └── • lookup join (anti)
             │ table: parent@parent_pkey
             │ equality cols are key
-            │ lookup condition: (column2 = p_id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))
+            │ lookup condition: (crdb_region IN ('ca-central-1', 'us-east-1')) AND (column2 = p_id)
             │
             └── • lookup join (anti)
                 │ table: parent@parent_pkey
                 │ equality cols are key
-                │ lookup condition: (column2 = p_id) AND (crdb_region = 'ap-southeast-2')
+                │ lookup condition: (crdb_region = 'ap-southeast-2') AND (column2 = p_id)
                 │
                 └── • scan buffer
                       label: buffer 1
@@ -1227,12 +1227,12 @@ SELECT * FROM [EXPLAIN UPSERT INTO child VALUES (1, 1)] OFFSET 2
         └── • lookup join (anti)
             │ table: parent@parent_pkey
             │ equality cols are key
-            │ lookup condition: (column2 = p_id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))
+            │ lookup condition: (crdb_region IN ('ca-central-1', 'us-east-1')) AND (column2 = p_id)
             │
             └── • lookup join (anti)
                 │ table: parent@parent_pkey
                 │ equality cols are key
-                │ lookup condition: (column2 = p_id) AND (crdb_region = 'ap-southeast-2')
+                │ lookup condition: (crdb_region = 'ap-southeast-2') AND (column2 = p_id)
                 │
                 └── • scan buffer
                       label: buffer 1
@@ -1268,8 +1268,8 @@ SELECT * FROM [EXPLAIN DELETE FROM parent WHERE p_id = 1] OFFSET 2
         │
         └── • lookup join (semi)
             │ table: child@child_c_p_id_idx
-            │ lookup condition: (p_id = c_p_id) AND (crdb_region = 'ap-southeast-2')
-            │ remote lookup condition: (p_id = c_p_id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))
+            │ lookup condition: (crdb_region = 'ap-southeast-2') AND (p_id = c_p_id)
+            │ remote lookup condition: (crdb_region IN ('ca-central-1', 'us-east-1')) AND (p_id = c_p_id)
             │
             └── • scan buffer
                   label: buffer 1
@@ -1682,7 +1682,7 @@ SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table (crdb_region, pk, pk2, 
 │       │
 │       └── • lookup join (semi)
 │           │ table: regional_by_row_table@regional_by_row_table_b_key
-│           │ lookup condition: (column5 = b) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+│           │ lookup condition: (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (column5 = b)
 │           │ pred: (upsert_pk != pk) OR (column1 != crdb_region)
 │           │
 │           └── • scan buffer
@@ -1694,7 +1694,7 @@ SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table (crdb_region, pk, pk2, 
 │       │
 │       └── • lookup join (semi)
 │           │ table: regional_by_row_table@new_idx
-│           │ lookup condition: ((column4 = a) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (b > 0)
+│           │ lookup condition: ((crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (column4 = a)) AND (b > 0)
 │           │ pred: (upsert_pk != pk) OR (column1 != crdb_region)
 │           │
 │           └── • filter
@@ -1709,7 +1709,7 @@ SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table (crdb_region, pk, pk2, 
         │
         └── • lookup join (semi)
             │ table: regional_by_row_table@new_idx
-            │ lookup condition: ((column4 = a) AND (column5 = b)) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+            │ lookup condition: ((crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (column4 = a)) AND (column5 = b)
             │ pred: (upsert_pk != pk) OR (column1 != crdb_region)
             │
             └── • scan buffer
@@ -1737,8 +1737,8 @@ VALUES ('us-east-1', 23, 24, 25, 26), ('ca-central-1', 30, 30, 31, 32)] OFFSET 2
 │           └── • lookup join (left outer)
 │               │ table: regional_by_row_table@regional_by_row_table_pkey
 │               │ equality cols are key
-│               │ lookup condition: (column2 = pk) AND (crdb_region = 'ap-southeast-2')
-│               │ remote lookup condition: (column2 = pk) AND (crdb_region IN ('ca-central-1', 'us-east-1'))
+│               │ lookup condition: (crdb_region = 'ap-southeast-2') AND (column2 = pk)
+│               │ remote lookup condition: (crdb_region IN ('ca-central-1', 'us-east-1')) AND (column2 = pk)
 │               │ locking strength: for update
 │               │
 │               └── • render
@@ -1753,7 +1753,7 @@ VALUES ('us-east-1', 23, 24, 25, 26), ('ca-central-1', 30, 30, 31, 32)] OFFSET 2
 │       │
 │       └── • lookup join (semi)
 │           │ table: regional_by_row_table@regional_by_row_table_b_key
-│           │ lookup condition: (column5 = b) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+│           │ lookup condition: (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (column5 = b)
 │           │ pred: (upsert_pk != pk) OR (column1 != crdb_region)
 │           │
 │           └── • scan buffer
@@ -1765,7 +1765,7 @@ VALUES ('us-east-1', 23, 24, 25, 26), ('ca-central-1', 30, 30, 31, 32)] OFFSET 2
 │       │
 │       └── • lookup join (semi)
 │           │ table: regional_by_row_table@new_idx
-│           │ lookup condition: ((column4 = a) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (b > 0)
+│           │ lookup condition: ((crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (column4 = a)) AND (b > 0)
 │           │ pred: (upsert_pk != pk) OR (column1 != crdb_region)
 │           │
 │           └── • filter
@@ -1780,7 +1780,7 @@ VALUES ('us-east-1', 23, 24, 25, 26), ('ca-central-1', 30, 30, 31, 32)] OFFSET 2
         │
         └── • lookup join (semi)
             │ table: regional_by_row_table@new_idx
-            │ lookup condition: ((column4 = a) AND (column5 = b)) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+            │ lookup condition: ((crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (column4 = a)) AND (column5 = b)
             │ pred: (upsert_pk != pk) OR (column1 != crdb_region)
             │
             └── • scan buffer
@@ -2082,7 +2082,7 @@ SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table_virt (pk, a, b) VALUES 
 │       │
 │       └── • lookup join (semi)
 │           │ table: regional_by_row_table_virt@regional_by_row_table_virt_v_key
-│           │ lookup condition: (v_comp = v) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+│           │ lookup condition: (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (v_comp = v)
 │           │ pred: (upsert_pk != pk) OR (upsert_crdb_region != crdb_region)
 │           │
 │           └── • scan buffer
@@ -2094,7 +2094,7 @@ SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table_virt (pk, a, b) VALUES 
         │
         └── • lookup join (semi)
             │ table: regional_by_row_table_virt@regional_by_row_table_virt_expr_key
-            │ lookup condition: (crdb_internal_idx_expr_comp = crdb_internal_idx_expr) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+            │ lookup condition: (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (crdb_internal_idx_expr_comp = crdb_internal_idx_expr)
             │ pred: (upsert_pk != pk) OR (upsert_crdb_region != crdb_region)
             │
             └── • scan buffer
@@ -2260,7 +2260,7 @@ SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table_virt_partial (pk, a, b)
 │       │
 │       └── • lookup join (semi)
 │           │ table: regional_by_row_table_virt_partial@v_a_gt_0 (partial index)
-│           │ lookup condition: (v_comp = v) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+│           │ lookup condition: (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (v_comp = v)
 │           │ pred: (upsert_pk != pk) OR (upsert_crdb_region != crdb_region)
 │           │
 │           └── • filter
@@ -2275,7 +2275,7 @@ SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table_virt_partial (pk, a, b)
 │       │
 │       └── • lookup join (semi)
 │           │ table: regional_by_row_table_virt_partial@v_v_gt_0 (partial index)
-│           │ lookup condition: (v_comp = v) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+│           │ lookup condition: (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (v_comp = v)
 │           │ pred: (upsert_pk != pk) OR (upsert_crdb_region != crdb_region)
 │           │
 │           └── • filter
@@ -2290,7 +2290,7 @@ SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table_virt_partial (pk, a, b)
         │
         └── • lookup join (semi)
             │ table: regional_by_row_table_virt_partial@a_plus_10_v_gt_0 (partial index)
-            │ lookup condition: (crdb_internal_idx_expr_comp = crdb_internal_idx_expr) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+            │ lookup condition: (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (crdb_internal_idx_expr_comp = crdb_internal_idx_expr)
             │ pred: (upsert_pk != pk) OR (upsert_crdb_region != crdb_region)
             │
             └── • filter
@@ -2941,7 +2941,7 @@ vectorized: true
         │
         └── • lookup join (semi)
             │ table: users@users_email_key
-            │ lookup condition: (column2 = email) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+            │ lookup condition: (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (column2 = email)
             │ pred: (id_default != id) OR (crdb_region_default != crdb_region)
             │
             └── • scan buffer

--- a/pkg/sql/logictest/testdata/logic_test/cast
+++ b/pkg/sql/logictest/testdata/logic_test/cast
@@ -1223,7 +1223,7 @@ statement ok
 CREATE TABLE t66067_a (
   a INT,
   c CHAR(26),
-  CONSTRAINT c UNIQUE (c)
+  INDEX (c, a)
 );
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -88,7 +88,7 @@ vectorized: true
 │ columns: (a, b, c, d, e, f)
 │ estimated row count: 33
 │ table: def@def_pkey
-│ lookup condition: (f = b) AND (e > 1)
+│ lookup condition: (b = f) AND (e > 1)
 │
 └── • scan
       columns: (a, b, c)
@@ -1972,12 +1972,12 @@ vectorized: true
 ·
 • lookup join (left outer)
 │ table: t59615@t59615_pkey
-│ lookup condition: (column1 = y) AND (x IN (1, 3))
+│ lookup condition: (x IN (1, 3)) AND (column1 = y)
 │
 └── • values
       size: 1 column, 2 rows
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyUkdFr1EAQxt_9K4Z52pWlvb1a0YXCnW0KKTGpSVoECRKSocZLd2N2FxqP-98lWUErnOhTMvPtN9_-Zvdov_WoMPp4m2zjFNhVXJTFh4RDESXRZQkv4TrP3gO73yZ3UQFMcgFszTlsC_DAJg5JdF3CTRan4M7fvpbns-IgS8GfTHAB7mRCgdq0lNaPZFF9QomVwGE0DVlrxrm1Xw7E7ROqlcBOD97N7UpgY0ZCtUfXuZ5Q4X3de7KnKxTYkqu7fpn4Ct4BW0Pzxeud5VgdBBrvfk2xrn4gVKuD-PekG9PpnOqWxlP5PK2cBlKBO7sro3yhR4GBfxM-n4cdzeSJMTs_wFfTaTBaAdtIuIDNGYdtegVss4Z57VIpFaflGwFnP_84R4GXpveP2ip4EjAJ-H6UTP4PWU52MNrSM6rjO6sEUvtA4Z2s8WNDt6NplphQZotvabRkXVBlKGIdpPmCv5vlX83rP8zV4cWPAAAA__8OI9Dj
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyUkdFr1TAUxt_9Kw7nKZWw3XRONDDodeugo7az7YYgRUp7mPV2SW0SWL3c_13aCDrhij6155x858vvyx7NtwElxh9v022SAbtKyqr8kAZQxml8WcFLuC7y98Dut-ldXAITAQcWBgFsS3DA5gDS-LqCmzzJwJ6_fS3Ol4mFPAN3MsMF2JMZOSrdUdY8kkH5CQXWHMdJt2SMnpbWfj2QdE8oNxx7NTq7tGuOrZ4I5R5tbwdCiffN4MicbpBjR7bph3XjK3gHLIT2i1M7E2B94Kid_bXF2OaBUG4O_N-dbnSvCmo6mk7Fc7dqHkl67vyuiouVHjl6_sh_Po87WshTrXduhK-6V6CVBBaFsAQtpJRJVr3hcPbzbwk1uwIWCbiA6CxAjpd6cI_KSHjiMHP4fpRM_A9ZQWbUytAzquOZ1RypeyD_Tka7qaXbSberjS_zVbc2OjLWT4UvEuVHywV_F4u_isM_xPXhxY8AAAD__xke0OM=
 
 query T
 EXPLAIN (DISTSQL) SELECT * FROM (VALUES (1), (2)) AS u(y) WHERE NOT EXISTS (
@@ -1989,12 +1989,12 @@ vectorized: true
 ·
 • lookup join (anti)
 │ table: t59615@t59615_pkey
-│ lookup condition: (column1 = y) AND (x IN (1, 3))
+│ lookup condition: (x IN (1, 3)) AND (column1 = y)
 │
 └── • values
       size: 1 column, 2 rows
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyUkW9r1EAQxt_7KYZ5tStLe3u1oguFi-0WU2KuXmItSJCQDDVeuhuzu9Bw3HeXJAU94URfJfPnN7PPMzt0P1pUqO9vkyhOgV3FWZ59TDhkOtGXObyE6836A7C7KPmkM2CSC2BLziHKIAAbOHx-rzca0nUO-n6EgR2i_vzta3k-9vvn3nAywAX4k4GjQGNrSstHcqi-oMRCYNfbipyz_ZjaTQ1x_YRqIbAxXfBjuhBY2Z5Q7dA3viVUeFe2gdzpAgXW5MumnSa-gnfAllB9C2brOBZ7gTb4X1OcLx8I1WIv_n3TjW3Mhsqa-lN5uC0fOlKQ6OscojSP4WYdpyhwtmA1f752WxpQYGLtNnTw3TYGrFHAVhIuYHXGIUqvgK2WMN5DKqXiNH8j4Oz5j4-uXdo2PBqn4EnAcFSV_B9VG3KdNY4OFB33qxBI9QPNN3I29BXd9raa1szheuKmRE3Oz1U5B7GZS-MDf4flX-HlH3Cxf_EzAAD__xtm1ng=
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyUkW9r1EAQxt_7KYZ5tZGlvb1a0YXCne0WU2KuJrEWJEhIhhov3Y3ZXWg47rvLJgU94URfJfPnN7PPMzu0PzqUqO5vk3WcAruK8yL_mESQq0RdFvASrrPNB2B36-STyoGJiANbRhGsc_DAxgg-v1eZgnRTgLoPMLBD1J2_fS3OQ7977vUnI1yAOxkj5KhNQ2n1SBblFxRYcuwHU5O1Zgip3dQQN08oFxxb3XsX0iXH2gyEcoeudR2hxLuq82RPF8ixIVe13TTxFbwDtoT6m9dbG2G552i8-zXFuuqBUC72_N833ZhWZ1Q1NJyKw23F2JOERF0XsE6LGG42cYocZwtW8-drv6UROSbGbH0P302rwWgJbLWEcAEhpYzT4g2Hs-e_4HZ6BWwl4AJWZ8G1S9P5R20lPHEYj6oS_6MqI9sbbelA0XG_So7UPNB8I2v8UNPtYOppzRxuJm5KNGTdXBVzEOu5FB74Oyz-Ci__gMv9i58BAAD__yZh1ng=
 
 statement ok
 CREATE TABLE lookup_expr (
@@ -2017,12 +2017,15 @@ vectorized: true
 ·
 • lookup join (left outer)
 │ table: lookup_expr@lookup_expr_r_x_y_z_w_idx
-│ lookup condition: ((((column2 = x) AND (column1 = w)) AND (r IN ('east', 'west'))) AND (y IN (10, 20))) AND (z = 5)
+│ lookup condition: ((((r IN ('east', 'west')) AND (column2 = x)) AND (y IN (10, 20))) AND ("lookup_join_const_col_@8" = z)) AND (column1 = w)
 │
-└── • values
-      size: 2 columns, 3 rows
+└── • render
+    │ estimated row count: 3
+    │
+    └── • values
+          size: 2 columns, 3 rows
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyUUtFq20AQfO9XLPuSU1kSn03acGCwmyhFQZVTSw6FYoSwllSNolN1p0qO8b8XSUnjFFLat53ZmVsxox2aHzkqdL9c-3MvAHHhhVH42XcgdH33PIK3cLlcfAJxM_dXbghCEsiRQyDGBON-mBAEK993HJiHUINoCFoHfPcygquFF0Cu9V1dxtyWVaewsAhA1McNTMEeNw7Mg4sOtz1uHSQsdMpBcs8G1VeUuCYsK71hY3TVUbte4KUtqhFhVpS17eg14UZXjGqHNrM5o8KbJK_ZnIyQMGWbZPnwooQPICaw-VYXd8bB9Z5Q1_b5GWOTW0Y12tO_n7rSWbHkJOXqRL48F21LVkMei1XkLvtUkPAgl9nBHFdxG2_jh7iJs7RFQr_fwXedFaALBUIIMRvDFGbvHsObyQ6dOk9wAl2TR5wYe6SUCqOlF3wkOGr4kHB-69_3ejlSSnlBdNYV-zg-a85gCqdPLBKe67y-L4yCiuAnQVc6wZbg4dU45f_EuWRT6sLwiyhfL2pNyOktD3-H0XW14etKb_ozA1z0vp5I2dhhKwfgFcOq-8BDs_yrefyHeb1_8ysAAP__I_P-dw==
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyUkm9rnEAQxt_3UwzzJlqG5PTydyGw18QUg9VUvVAoh8g5pDbGta72vBz33YvaXi-FlPbdPDPz7Ay_nQ3qbwUKdD7deTPXB-PajeLoo2dC5HjOVQxv4SYMPoBxP_PmTgSGRWBNTALDJrCHYErgzz3PNGEWQQvGiqAzwXNuYrgNXB8KpR7bKuGuqvuOBgIfjPZwBZfQHK5MmPnXve4G3ZlIWKqM_fSJNYrPaOGCsKrVkrVWdZ_aDA1u1qGYEOZl1TZ9ekG4VDWj2GCTNwWjwPu0aFkfTZAw4ybNi_FFC96BMYXll7Z81P3AkMuMawEnQgjXj88JpEUgbVxsCVXb_J6gm_SBUUy29O9b3Kq8DDnNuD6yXm4SrysWI6pgHjvhAAwJ95DJvTipky5ZJ8_JKsmzDgm9oQZfVV6CKgUYhmHIY-j_8YBT3RwIIaI4dP33BAcr3k-YP8HLKVyCPNvJ88FtTXYk7F-hueuxesvFTtq9PO05XqmifSq1gJrgO0F_CQRrgmckDNpGgLRJTkkekzwheUryjOQ5yYtXOVv_wzlkXalS8wvGr__ggpCzBx4vSqu2XvJdrZbDmFEGg29IZKybsWqNwi3HUr_gvtn6q9n-w7zYvvkRAAD__74CCoU=
 
 query T
 EXPLAIN (DISTSQL) SELECT * FROM (VALUES (1, 10), (2, 20), (3, NULL)) AS u(w, x) WHERE NOT EXISTS (
@@ -2034,12 +2037,15 @@ vectorized: true
 ·
 • lookup join (anti)
 │ table: lookup_expr@lookup_expr_r_x_y_z_w_idx
-│ lookup condition: ((((column2 = x) AND (column1 = w)) AND (r IN ('east', 'west'))) AND (y IN (10, 20))) AND (z = 5)
+│ lookup condition: ((((r IN ('east', 'west')) AND (column2 = x)) AND (y IN (10, 20))) AND ("lookup_join_const_col_@8" = z)) AND (column1 = w)
 │
-└── • values
-      size: 2 columns, 3 rows
+└── • render
+    │ estimated row count: 3
+    │
+    └── • values
+          size: 2 columns, 3 rows
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyUUtFq20AQfO9XDPuSu3Iklt205cBgN1FaBVVOLSUNFCOEdaRqFJ2qk7Ac438vJzmNXUhp33Zmd2aP2duQ-ZmTJPf2yp96Adi5F0bhF58jdH33LMJrXMxnn8Fupv61G4I5As6AC7ChwLArRgLBte9zjmmIBmwl0HJ8_eTOXQSzCO6ttQQ7NMy1vm_KWLVlZXX1TsCa4xXGqI9XHNPg3OK2wy3nJKjQqQqSB2VIfiOHFoLKSi-VMbqy1KYb8NKW5EBQVpRNbemFoKWuFMkN1VmdK5J0k-SNMicDEpSqOsny3tHBB7ARlt-b4t5wWmwF6aZ-tjF1cqdIDrbi31dd6qyYqyRV1YlzuC5al0rCdy8iTIPIw-XMC0jQXjSTvTqu4jZex4_xKs7SlgT5XQ8_dFZAFxKMMTYZYozJ6S68iWPRG_4ER7AnPlKJqY-klGE094KPAkcrtU_w3_Nvu3lnIKX0gui9vfiufJ55hzFOn1gSdKbz5qEwEpWA_QoCa4HHF6N0_ifKuTKlLow6iPHlIy0EqfRO9T_D6KZaqqtKL7s1PZx1uo5Ilan7rtMDr-hb9oH7Yuev4uEf4sX21a8AAAD__6FsBBs=
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyUklFrnEAQx9_7KYZ5yVqG5PSaNiwEvCamNVgvVZMGyiFyDqmNca2rnMlx372spte7Qkr7Nv-Z_c0M_5016h8lSvRur4KZH4I49-Mk_hxYEHuBd5bAa7iI5p9A3MyCay8GYRPYE4tAOATOEEwJwusgsCyYxdCBWBH0Fnz56EUehPMEvFvTEsR-w1Kp-65Oua8bw7XPgOgOV3AK7eHKgll4bnQ_6N6ykLBSOYfZA2uUX9HGBWHdqCVrrRqTWg8P_LxHOSEsqrprTXpBuFQNo1xjW7Qlo8SbrOxYH02QMOc2K8qxow3vQUxh-a2r7rUZGHGVcyPhWErph8kJgWsTuA4uNoSqa39P0G12xygnG_r3LS5VUUWc5dwc2fubJI81Swi8iwRmYeLD5dwPkXDHNXcnTpu0Tx_Tp3SVFnmPhMFQg--qqEBVEoQQwn0D5oMPONPtgZQyTiI__EBwsOLdhPVsvDuFU3DfbuW7gbYnWyOcX6G1fWMb5GQrHSOPjY1nquweKi2hITD3QfBI8ISE866V4DrkTl901P4fRyPWtao077n58l8tCDm_4_F2tOqaJV81ajmMGeV84IZEzrodq_Yo_GosmQV3YfuvsPMHvNi8-hkAAP__j1EMSw==
 
 # The following tests check that if the joiners can separate a row request
 # into separate families that it does, and generates spans for each family

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_spans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_spans
@@ -125,7 +125,7 @@ vectorized: true
 └── • lookup join
     │ estimated row count: 33
     │ table: metric_values@metric_values_pkey
-    │ lookup condition: (metric_id = id) AND ("time" > '2020-01-01 00:00:00+00:00')
+    │ lookup condition: (id = metric_id) AND ("time" > '2020-01-01 00:00:00+00:00')
     │
     └── • index join
         │ estimated row count: 1
@@ -155,7 +155,7 @@ vectorized: true
 │
 └── • lookup join
     │ table: metric_values_desc@metric_values_desc_pkey
-    │ lookup condition: (metric_id = id) AND ("time" > '2020-01-01 00:00:00+00:00')
+    │ lookup condition: (id = metric_id) AND ("time" > '2020-01-01 00:00:00+00:00')
     │
     └── • index join
         │ estimated row count: 1
@@ -187,7 +187,7 @@ vectorized: true
 └── • lookup join
     │ estimated row count: 33
     │ table: metric_values@metric_values_pkey
-    │ lookup condition: (metric_id = id) AND ("time" >= '2020-01-01 00:00:00+00:00')
+    │ lookup condition: (id = metric_id) AND ("time" >= '2020-01-01 00:00:00+00:00')
     │
     └── • index join
         │ estimated row count: 1
@@ -217,7 +217,7 @@ vectorized: true
 │
 └── • lookup join
     │ table: metric_values_desc@metric_values_desc_pkey
-    │ lookup condition: (metric_id = id) AND ("time" >= '2020-01-01 00:00:00+00:00')
+    │ lookup condition: (id = metric_id) AND ("time" >= '2020-01-01 00:00:00+00:00')
     │
     └── • index join
         │ estimated row count: 1
@@ -244,7 +244,7 @@ vectorized: true
 • lookup join
 │ estimated row count: 33
 │ table: metric_values@metric_values_pkey
-│ lookup condition: (metric_id = id) AND ("time" < '2020-01-01 00:00:00+00:00')
+│ lookup condition: (id = metric_id) AND ("time" < '2020-01-01 00:00:00+00:00')
 │
 └── • index join
     │ estimated row count: 1
@@ -270,7 +270,7 @@ vectorized: true
 ·
 • lookup join
 │ table: metric_values_desc@metric_values_desc_pkey
-│ lookup condition: (metric_id = id) AND ("time" < '2020-01-01 00:00:00+00:00')
+│ lookup condition: (id = metric_id) AND ("time" < '2020-01-01 00:00:00+00:00')
 │
 └── • index join
     │ estimated row count: 1
@@ -302,7 +302,7 @@ vectorized: true
 └── • lookup join
     │ estimated row count: 33
     │ table: metric_values@metric_values_pkey
-    │ lookup condition: (metric_id = id) AND ("time" <= '2020-01-01 00:00:00+00:00')
+    │ lookup condition: (id = metric_id) AND ("time" <= '2020-01-01 00:00:00+00:00')
     │
     └── • index join
         │ estimated row count: 1
@@ -332,7 +332,7 @@ vectorized: true
 │
 └── • lookup join
     │ table: metric_values_desc@metric_values_desc_pkey
-    │ lookup condition: (metric_id = id) AND ("time" <= '2020-01-01 00:00:00+00:00')
+    │ lookup condition: (id = metric_id) AND ("time" <= '2020-01-01 00:00:00+00:00')
     │
     └── • index join
         │ estimated row count: 1
@@ -364,7 +364,7 @@ vectorized: true
 └── • lookup join
     │ estimated row count: 33
     │ table: metric_values@metric_values_pkey
-    │ lookup condition: (metric_id = id) AND ("time" < '2020-01-01 00:00:10+00:00')
+    │ lookup condition: (id = metric_id) AND ("time" < '2020-01-01 00:00:10+00:00')
     │
     └── • index join
         │ estimated row count: 1
@@ -394,7 +394,7 @@ vectorized: true
 │
 └── • lookup join
     │ table: metric_values_desc@metric_values_desc_pkey
-    │ lookup condition: (metric_id = id) AND ("time" < '2020-01-01 00:00:10+00:00')
+    │ lookup condition: (id = metric_id) AND ("time" < '2020-01-01 00:00:10+00:00')
     │
     └── • index join
         │ estimated row count: 1
@@ -426,7 +426,7 @@ vectorized: true
 └── • lookup join
     │ estimated row count: 11
     │ table: metric_values@metric_values_pkey
-    │ lookup condition: (metric_id = id) AND (("time" >= '2020-01-01 00:00:00+00:00') AND ("time" <= '2020-01-01 00:10:00+00:00'))
+    │ lookup condition: (id = metric_id) AND (("time" >= '2020-01-01 00:00:00+00:00') AND ("time" <= '2020-01-01 00:10:00+00:00'))
     │
     └── • index join
         │ estimated row count: 1
@@ -456,7 +456,7 @@ vectorized: true
 │
 └── • lookup join
     │ table: metric_values_desc@metric_values_desc_pkey
-    │ lookup condition: (metric_id = id) AND (("time" >= '2020-01-01 00:00:00+00:00') AND ("time" <= '2020-01-01 00:10:00+00:00'))
+    │ lookup condition: (id = metric_id) AND (("time" >= '2020-01-01 00:00:00+00:00') AND ("time" <= '2020-01-01 00:10:00+00:00'))
     │
     └── • index join
         │ estimated row count: 1
@@ -488,7 +488,7 @@ vectorized: true
 └── • lookup join (left outer)
     │ estimated row count: 11
     │ table: metric_values@metric_values_pkey
-    │ lookup condition: (metric_id = id) AND (("time" >= '2020-01-01 00:00:00+00:00') AND ("time" <= '2020-01-01 00:10:00+00:00'))
+    │ lookup condition: (id = metric_id) AND (("time" >= '2020-01-01 00:00:00+00:00') AND ("time" <= '2020-01-01 00:10:00+00:00'))
     │ pred: name = 'cpu'
     │
     └── • scan
@@ -510,7 +510,7 @@ vectorized: true
 • lookup join (semi)
 │ estimated row count: 10
 │ table: metric_values@metric_values_pkey
-│ lookup condition: (metric_id = id) AND (("time" >= '2020-01-01 00:00:00+00:00') AND ("time" <= '2020-01-01 00:10:00+00:00'))
+│ lookup condition: (id = metric_id) AND (("time" >= '2020-01-01 00:00:00+00:00') AND ("time" <= '2020-01-01 00:10:00+00:00'))
 │
 └── • scan
       estimated row count: 10 (100% of the table; stats collected <hidden> ago)
@@ -546,7 +546,7 @@ vectorized: true
     └── • lookup join
         │ estimated row count: 3
         │ table: metric_values@secondary
-        │ lookup condition: ((metric_id = id) AND (nullable = nullable)) AND ("time" > '2020-01-01 00:00:00+00:00')
+        │ lookup condition: ((id = metric_id) AND (nullable = nullable)) AND ("time" > '2020-01-01 00:00:00+00:00')
         │
         └── • index join
             │ estimated row count: 1
@@ -591,7 +591,7 @@ vectorized: true
         └── • lookup join
             │ estimated row count: 0
             │ table: metric_values@secondary
-            │ lookup condition: (metric_id = id) AND ((nullable >= -20) AND (nullable <= -10))
+            │ lookup condition: (id = metric_id) AND ((nullable >= -20) AND (nullable <= -10))
             │
             └── • scan
                   estimated row count: 1 (10% of the table; stats collected <hidden> ago)
@@ -632,7 +632,7 @@ vectorized: true
         └── • lookup join
             │ estimated row count: 0
             │ table: metric_values@secondary
-            │ lookup condition: (metric_id = id) AND (nullable > 1)
+            │ lookup condition: (id = metric_id) AND (nullable > 1)
             │
             └── • scan
                   estimated row count: 1 (10% of the table; stats collected <hidden> ago)
@@ -673,7 +673,7 @@ vectorized: true
         └── • lookup join
             │ estimated row count: 0
             │ table: metric_values@secondary
-            │ lookup condition: (metric_id = id) AND (nullable >= 1)
+            │ lookup condition: (id = metric_id) AND (nullable >= 1)
             │
             └── • scan
                   estimated row count: 1 (10% of the table; stats collected <hidden> ago)
@@ -715,7 +715,7 @@ vectorized: true
         └── • lookup join
             │ estimated row count: 0
             │ table: metric_values@secondary
-            │ lookup condition: (metric_id = id) AND (nullable < -10)
+            │ lookup condition: (id = metric_id) AND (nullable < -10)
             │
             └── • scan
                   estimated row count: 1 (10% of the table; stats collected <hidden> ago)
@@ -756,7 +756,7 @@ vectorized: true
         └── • lookup join
             │ estimated row count: 0
             │ table: metric_values@secondary
-            │ lookup condition: (metric_id = id) AND (nullable <= -10)
+            │ lookup condition: (id = metric_id) AND (nullable <= -10)
             │
             └── • scan
                   estimated row count: 1 (10% of the table; stats collected <hidden> ago)
@@ -792,7 +792,7 @@ vectorized: true
     └── • lookup join
         │ estimated row count: 3
         │ table: metric_values@secondary
-        │ lookup condition: ((metric_id = id) AND (nullable = nullable)) AND ("time" < '2020-01-01 00:00:10+00:00')
+        │ lookup condition: ((id = metric_id) AND (nullable = nullable)) AND ("time" < '2020-01-01 00:00:10+00:00')
         │
         └── • index join
             │ estimated row count: 1
@@ -837,14 +837,16 @@ vectorized: true
         │ equality cols are key
         │
         └── • lookup join
-            │ estimated row count: 0
             │ table: metric_values@secondary
-            │ lookup condition: ((metric_id = id) AND (nullable = 1)) AND ("time" < '2020-01-01 00:00:10+00:00')
+            │ lookup condition: ((id = metric_id) AND ("lookup_join_const_col_@3" = nullable)) AND ("time" < '2020-01-01 00:00:10+00:00')
             │
-            └── • scan
-                  estimated row count: 1 (10% of the table; stats collected <hidden> ago)
-                  table: metrics@name_index
-                  spans: [/'cpu' - /'cpu']
+            └── • render
+                │ estimated row count: 1
+                │
+                └── • scan
+                      estimated row count: 1 (10% of the table; stats collected <hidden> ago)
+                      table: metrics@name_index
+                      spans: [/'cpu' - /'cpu']
 
 
 # Regression test for issue #68200.  This ensures that we properly construct the

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -751,7 +751,7 @@ vectorized: true
 │               │ columns: (column1, column3)
 │               │ estimated row count: 1 (missing stats)
 │               │ table: uniq_enum@uniq_enum_pkey
-│               │ lookup condition: (column3 = i) AND (r IN ('us-east', 'us-west', 'eu-west'))
+│               │ lookup condition: (r IN ('us-east', 'us-west', 'eu-west')) AND (column3 = i)
 │               │ pred: column1 != r
 │               │
 │               └── • project
@@ -775,7 +775,7 @@ vectorized: true
                 │ columns: (column1, column2, column3, column4)
                 │ estimated row count: 1 (missing stats)
                 │ table: uniq_enum@uniq_enum_r_s_j_key
-                │ lookup condition: ((column2 = s) AND (column4 = j)) AND (r IN ('us-east', 'us-west', 'eu-west'))
+                │ lookup condition: ((r IN ('us-east', 'us-west', 'eu-west')) AND (column2 = s)) AND (column4 = j)
                 │ pred: (column1 != r) OR (column3 != i)
                 │
                 └── • project
@@ -844,7 +844,7 @@ vectorized: true
                 │ columns: (r_default, column2)
                 │ estimated row count: 1 (missing stats)
                 │ table: uniq_enum@uniq_enum_pkey
-                │ lookup condition: (column2 = i) AND (r IN ('us-east', 'us-west', 'eu-west'))
+                │ lookup condition: (r IN ('us-east', 'us-west', 'eu-west')) AND (column2 = i)
                 │ pred: r_default != r
                 │
                 └── • project
@@ -885,14 +885,14 @@ vectorized: true
         │ estimated row count: 0 (missing stats)
         │ table: uniq_enum@uniq_enum_pkey
         │ equality cols are key
-        │ lookup condition: (column3 = i) AND (r IN ('us-east', 'us-west', 'eu-west'))
+        │ lookup condition: (r IN ('us-east', 'us-west', 'eu-west')) AND (column3 = i)
         │
         └── • lookup join (anti)
             │ columns: (column1, column2, column3, column4)
             │ estimated row count: 0 (missing stats)
             │ table: uniq_enum@uniq_enum_r_s_j_key
             │ equality cols are key
-            │ lookup condition: ((column2 = s) AND (column4 = j)) AND (r IN ('us-east', 'us-west', 'eu-west'))
+            │ lookup condition: ((r IN ('us-east', 'us-west', 'eu-west')) AND (column2 = s)) AND (column4 = j)
             │
             └── • values
                   columns: (column1, column2, column3, column4)
@@ -1288,7 +1288,7 @@ vectorized: true
                 │ columns: (column1, column2, column3, column4)
                 │ estimated row count: 1
                 │ table: uniq_partial_enum@uniq_partial_enum_r_b_idx (partial index)
-                │ lookup condition: (column3 = b) AND (r IN ('us-east', 'us-west', 'eu-west'))
+                │ lookup condition: (r IN ('us-east', 'us-west', 'eu-west')) AND (column3 = b)
                 │ pred: (column1 != r) OR (column2 != a)
                 │
                 └── • filter
@@ -1350,7 +1350,7 @@ vectorized: true
                 │ columns: (column1, column2, column3, column4)
                 │ estimated row count: 0
                 │ table: uniq_partial_enum@uniq_partial_enum_r_b_idx (partial index)
-                │ lookup condition: (column3 = b) AND (r IN ('us-east', 'us-west', 'eu-west'))
+                │ lookup condition: (r IN ('us-east', 'us-west', 'eu-west')) AND (column3 = b)
                 │ pred: column4 IN ('bar', 'baz', 'foo')
                 │
                 └── • lookup join (anti)
@@ -2130,7 +2130,7 @@ vectorized: true
 │               │ columns: (r_new, i_new)
 │               │ estimated row count: 3 (missing stats)
 │               │ table: uniq_enum@uniq_enum_pkey
-│               │ lookup condition: (i_new = i) AND (r IN ('us-east', 'us-west', 'eu-west'))
+│               │ lookup condition: (r IN ('us-east', 'us-west', 'eu-west')) AND (i_new = i)
 │               │ pred: r_new != r
 │               │
 │               └── • project
@@ -2154,7 +2154,7 @@ vectorized: true
                 │ columns: (r_new, s_new, i_new, j)
                 │ estimated row count: 3 (missing stats)
                 │ table: uniq_enum@uniq_enum_r_s_j_key
-                │ lookup condition: ((s_new = s) AND (j = j)) AND (r IN ('us-east', 'us-west', 'eu-west'))
+                │ lookup condition: ((r IN ('us-east', 'us-west', 'eu-west')) AND (s_new = s)) AND (j = j)
                 │ pred: (r_new != r) OR (i_new != i)
                 │
                 └── • project
@@ -2422,7 +2422,7 @@ vectorized: true
                 │ columns: (r, a, b_new, c)
                 │ estimated row count: 0
                 │ table: uniq_partial_enum@uniq_partial_enum_r_b_idx (partial index)
-                │ lookup condition: (b_new = b) AND (r IN ('us-east', 'us-west', 'eu-west'))
+                │ lookup condition: (r IN ('us-east', 'us-west', 'eu-west')) AND (b_new = b)
                 │ pred: (r != r) OR (a != a)
                 │
                 └── • filter
@@ -3304,7 +3304,7 @@ vectorized: true
 │               │ columns: (upsert_r, upsert_i)
 │               │ estimated row count: 1 (missing stats)
 │               │ table: uniq_enum@uniq_enum_pkey
-│               │ lookup condition: (upsert_i = i) AND (r IN ('us-east', 'us-west', 'eu-west'))
+│               │ lookup condition: (r IN ('us-east', 'us-west', 'eu-west')) AND (upsert_i = i)
 │               │ pred: upsert_r != r
 │               │
 │               └── • project
@@ -3328,7 +3328,7 @@ vectorized: true
                 │ columns: (upsert_r, column2, upsert_i, column4)
                 │ estimated row count: 1 (missing stats)
                 │ table: uniq_enum@uniq_enum_r_s_j_key
-                │ lookup condition: ((column2 = s) AND (column4 = j)) AND (r IN ('us-east', 'us-west', 'eu-west'))
+                │ lookup condition: ((r IN ('us-east', 'us-west', 'eu-west')) AND (column2 = s)) AND (column4 = j)
                 │ pred: (upsert_r != r) OR (upsert_i != i)
                 │
                 └── • project
@@ -3397,7 +3397,7 @@ vectorized: true
 │                       │ estimated row count: 2 (missing stats)
 │                       │ table: uniq_enum@uniq_enum_r_s_j_key
 │                       │ equality cols are key
-│                       │ lookup condition: ((column2 = s) AND (column4 = j)) AND (r IN ('us-east', 'us-west', 'eu-west'))
+│                       │ lookup condition: ((r IN ('us-east', 'us-west', 'eu-west')) AND (column2 = s)) AND (column4 = j)
 │                       │ locking strength: for update
 │                       │
 │                       └── • values
@@ -3425,7 +3425,7 @@ vectorized: true
                 │ columns: (upsert_r, upsert_i)
                 │ estimated row count: 1 (missing stats)
                 │ table: uniq_enum@uniq_enum_pkey
-                │ lookup condition: (upsert_i = i) AND (r IN ('us-east', 'us-west', 'eu-west'))
+                │ lookup condition: (r IN ('us-east', 'us-west', 'eu-west')) AND (upsert_i = i)
                 │ pred: upsert_r != r
                 │
                 └── • project
@@ -3939,7 +3939,7 @@ vectorized: true
                 │ columns: (upsert_r, upsert_a, column3, column4)
                 │ estimated row count: 1
                 │ table: uniq_partial_enum@uniq_partial_enum_r_b_idx (partial index)
-                │ lookup condition: (column3 = b) AND (r IN ('us-east', 'us-west', 'eu-west'))
+                │ lookup condition: (r IN ('us-east', 'us-west', 'eu-west')) AND (column3 = b)
                 │ pred: (upsert_r != r) OR (upsert_a != a)
                 │
                 └── • filter
@@ -4001,7 +4001,7 @@ vectorized: true
                 │ columns: (arbiter_unique_b_distinct, column1, column2, column3, column4, r, a, b)
                 │ estimated row count: 2
                 │ table: uniq_partial_enum@uniq_partial_enum_r_b_idx (partial index)
-                │ lookup condition: (column3 = b) AND (r IN ('us-east', 'us-west', 'eu-west'))
+                │ lookup condition: (r IN ('us-east', 'us-west', 'eu-west')) AND (column3 = b)
                 │ pred: column4 IN ('bar', 'baz', 'foo')
                 │
                 └── • distinct

--- a/pkg/sql/opt/exec/explain/testdata/gists_tpce
+++ b/pkg/sql/opt/exec/explain/testdata/gists_tpce
@@ -37,7 +37,7 @@ explain(shape):
             └── • lookup join
                 │ table: broker@broker_b_name_idx
                 │ equality cols are key
-                │ lookup condition: (tr_b_id = b_id) AND (b_name IN _)
+                │ lookup condition: (b_name IN _) AND (tr_b_id = b_id)
                 │
                 └── • hash join
                     │ equality: (tr_s_symb) = (s_symb)

--- a/pkg/sql/opt/lookupjoin/BUILD.bazel
+++ b/pkg/sql/opt/lookupjoin/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/util",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 

--- a/pkg/sql/opt/lookupjoin/testdata/computed
+++ b/pkg/sql/opt/lookupjoin/testdata/computed
@@ -105,16 +105,18 @@ input projections:
   v_eq = a + 10
   lookup_join_const_col_@7 = 1
 
-# TODO(mgartner): We should be able to generate a lookup join constraint by
-# projecting an expression for v.
 lookup-constraints left=(a int, b int) right=(x int, y int, v int not null as (x + 10) virtual) index=(v, x, y)
 x = a AND y IN (1, 2)
 ----
-lookup join not possible
+input projections:
+  v_eq = a + 10
+lookup expression:
+  ((v_eq = v) AND (a = x)) AND (y IN (1, 2))
 
-# TODO(mgartner): We should be able to generate a lookup join constraint by
-# projecting an expression for v.
 lookup-constraints left=(a int, b int) right=(x int, y int, v int not null as (x + 10) virtual) index=(v, x, y)
 x = a AND y > 0
 ----
-lookup join not possible
+input projections:
+  v_eq = a + 10
+lookup expression:
+  ((v_eq = v) AND (a = x)) AND (y > 0)

--- a/pkg/sql/opt/lookupjoin/testdata/lookup_expr
+++ b/pkg/sql/opt/lookupjoin/testdata/lookup_expr
@@ -4,13 +4,13 @@ lookup-constraints left=(a int, b int) right=(x int, y int, z int) index=(x, y)
 x IN (1, 2, 3) AND y = b
 ----
 lookup expression:
-  (y = b) AND (x IN (1, 2, 3))
+  (x IN (1, 2, 3)) AND (b = y)
 
 lookup-constraints left=(a int, b int) right=(x int, y int, z int) index=(x, y)
 (x = 1 OR x = 2) AND y = b
 ----
 lookup expression:
-  (y = b) AND (x IN (1, 2))
+  (x IN (1, 2)) AND (b = y)
 
 lookup-constraints left=(a int, b int) right=(x int, y int, z int) index=(x, y)
 x IN (1, 2, 3)
@@ -21,13 +21,13 @@ lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=
 x IN (1, 2, 3) AND y = b AND z = c
 ----
 lookup expression:
-  ((y = b) AND (z = c)) AND (x IN (1, 2, 3))
+  ((x IN (1, 2, 3)) AND (b = y)) AND (c = z)
 
 lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y, z)
 x IN (1, 2, 3) AND y = b AND (z > 10 OR z IN (1, 2, 3))
 ----
 lookup expression:
-  (y = b) AND (x IN (1, 2, 3))
+  (x IN (1, 2, 3)) AND (b = y)
 remaining filters:
   (z > 10) OR (z IN (1, 2, 3))
 
@@ -35,54 +35,58 @@ lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=
 x IN (1, 2, 3) AND y = b AND z = c
 ----
 lookup expression:
-  (y = b) AND (x IN (1, 2, 3))
+  (x IN (1, 2, 3)) AND (b = y)
 remaining filters:
   z = c
 
 lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y, z)
 x IN (1, 2, 3) AND y = 4 AND z = c
 ----
+input projections:
+  lookup_join_const_col_@8 = 4
 lookup expression:
-  ((z = c) AND (x IN (1, 2, 3))) AND (y = 4)
+  ((x IN (1, 2, 3)) AND (lookup_join_const_col_@8 = y)) AND (c = z)
 
 lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y, z)
 x IN (1, 2, 3) AND y = b AND z = 1
 ----
+input projections:
+  lookup_join_const_col_@9 = 1
 lookup expression:
-  ((y = b) AND (x IN (1, 2, 3))) AND (z = 1)
+  ((x IN (1, 2, 3)) AND (b = y)) AND (lookup_join_const_col_@9 = z)
 
 lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y, z)
 x IN (1, 2, 3) AND y = b AND z IN (4, 5, 6)
 ----
 lookup expression:
-  ((y = b) AND (x IN (1, 2, 3))) AND (z IN (4, 5, 6))
+  ((x IN (1, 2, 3)) AND (b = y)) AND (z IN (4, 5, 6))
 
 lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y, z)
 x IN (1, 2, 3) AND y = b AND z IN (4, 5, 6)
 ----
 lookup expression:
-  ((y = b) AND (x IN (1, 2, 3))) AND (z IN (4, 5, 6))
+  ((x IN (1, 2, 3)) AND (b = y)) AND (z IN (4, 5, 6))
 
 lookup-constraints left=(a int, b int) right=(x int, y int) index=(x, y)
 y = b
 optional: x IN (1, 2, 3)
 ----
 lookup expression:
-  (y = b) AND (x IN (1, 2, 3))
+  (x IN (1, 2, 3)) AND (b = y)
 
 lookup-constraints left=(a int, b int) right=(x int, y int) index=(x, y)
 x = a
 optional: y IN (1, 2, 3)
 ----
 lookup expression:
-  (x = a) AND (y IN (1, 2, 3))
+  (a = x) AND (y IN (1, 2, 3))
 
 lookup-constraints left=(a int, b int) right=(x int, y int, z int) index=(x, y)
 x = a AND z = 1
 optional: y IN (1, 2, 3)
 ----
 lookup expression:
-  (x = a) AND (y IN (1, 2, 3))
+  (a = x) AND (y IN (1, 2, 3))
 remaining filters:
   z = 1
 
@@ -91,28 +95,30 @@ x = a
 optional: y IN (1, 2, 3) AND z = 1
 ----
 lookup expression:
-  (x = a) AND (y IN (1, 2, 3))
+  (a = x) AND (y IN (1, 2, 3))
 
 lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y, z)
 x = 1 AND z = c
 optional: y IN (3, 4)
 ----
+input projections:
+  lookup_join_const_col_@7 = 1
 lookup expression:
-  ((z = c) AND (x = 1)) AND (y IN (3, 4))
+  ((lookup_join_const_col_@7 = x) AND (y IN (3, 4))) AND (c = z)
 
 lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y, z)
 z = c
 optional: x IN (1, 2) AND y IN (3, 4)
 ----
 lookup expression:
-  ((z = c) AND (x IN (1, 2))) AND (y IN (3, 4))
+  ((x IN (1, 2)) AND (y IN (3, 4))) AND (c = z)
 
 lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y, z)
 y = b
 optional: x IN (1, 2) AND z IN (3, 4)
 ----
 lookup expression:
-  ((y = b) AND (x IN (1, 2))) AND (z IN (3, 4))
+  ((x IN (1, 2)) AND (b = y)) AND (z IN (3, 4))
 
 # TODO(#75596): The lookup expression should not contain (z IN (3, 4)) because
 # it is an optional filter from a CHECK constraint. It will only increase the
@@ -122,8 +128,10 @@ lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=
 x = 1 AND y = b
 optional: z IN (3, 4)
 ----
+input projections:
+  lookup_join_const_col_@7 = 1
 lookup expression:
-  ((y = b) AND (x = 1)) AND (z IN (3, 4))
+  ((lookup_join_const_col_@7 = x) AND (b = y)) AND (z IN (3, 4))
 
 # The most restrictive IN filter should be chosen.
 lookup-constraints left=(a int, b int) right=(x int, y int) index=(x, y)
@@ -131,14 +139,14 @@ x IN (1, 2) AND y = b
 optional: x IN (1, 2, 3)
 ----
 lookup expression:
-  (y = b) AND (x IN (1, 2))
+  (x IN (1, 2)) AND (b = y)
 
 lookup-constraints left=(a int, b int) right=(x int, y int) index=(x, y)
 x IN (1, 2, 3) AND y = b
 optional: x IN (1, 2)
 ----
 lookup expression:
-  (y = b) AND (x IN (1, 2))
+  (x IN (1, 2)) AND (b = y)
 remaining filters:
   x IN (1, 2, 3)
 
@@ -146,8 +154,10 @@ remaining filters:
 lookup-constraints left=(a int) right=(x int, y bool, z int) index=(x, y, z)
 x = a AND y = false AND z > 0
 ----
+input projections:
+  lookup_join_const_col_@6 = false
 lookup expression:
-  ((x = a) AND (y = false)) AND (z > 0)
+  ((a = x) AND (lookup_join_const_col_@6 = y)) AND (z > 0)
 
 
 # Test for range filters.
@@ -156,13 +166,13 @@ lookup-constraints left=(a int, b int) right=(x int, y int) index=(x, y)
 x = a AND y > 0
 ----
 lookup expression:
-  (x = a) AND (y > 0)
+  (a = x) AND (y > 0)
 
 lookup-constraints left=(a int, b int) right=(x int, y int) index=(x desc, y desc)
 x = a AND y > 0
 ----
 lookup expression:
-  (x = a) AND (y > 0)
+  (a = x) AND (y > 0)
 
 lookup-constraints left=(a int, b int) right=(x int, y int) index=(x, y)
 x > 0
@@ -179,39 +189,45 @@ x = a
 optional: y > 0
 ----
 lookup expression:
-  (x = a) AND (y > 0)
+  (a = x) AND (y > 0)
 
 lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y, z)
 x = a AND y = b AND z > 0
 ----
 lookup expression:
-  ((x = a) AND (y = b)) AND (z > 0)
+  ((a = x) AND (b = y)) AND (z > 0)
 
 lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y, z)
 x = 1 AND y = b AND z > 0
 ----
+input projections:
+  lookup_join_const_col_@7 = 1
 lookup expression:
-  ((y = b) AND (x = 1)) AND (z > 0)
+  ((lookup_join_const_col_@7 = x) AND (b = y)) AND (z > 0)
 
 lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y, z)
 x = a AND y = 1 AND z > 0
 ----
+input projections:
+  lookup_join_const_col_@8 = 1
 lookup expression:
-  ((x = a) AND (y = 1)) AND (z > 0)
+  ((a = x) AND (lookup_join_const_col_@8 = y)) AND (z > 0)
 
 lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y, z)
 x = 1 AND y = b
 optional: z > 0
 ----
+input projections:
+  lookup_join_const_col_@7 = 1
 lookup expression:
-  ((y = b) AND (x = 1)) AND (z > 0)
+  ((lookup_join_const_col_@7 = x) AND (b = y)) AND (z > 0)
 
 lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y)
 x = a AND z = 1
 optional: y > 0
 ----
 lookup expression:
-  (x = a) AND (y > 0)
+  (a = x) AND (y > 0)
 remaining filters:
   z = 1
 
@@ -220,7 +236,7 @@ x = a
 optional: y > 0 AND z = 1
 ----
 lookup expression:
-  (x = a) AND (y > 0)
+  (a = x) AND (y > 0)
 
 
 # Test for range filters and IN filters.
@@ -229,7 +245,7 @@ lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=
 x IN (1, 2) AND y = b AND z > 0
 ----
 lookup expression:
-  ((y = b) AND (x IN (1, 2))) AND (z > 0)
+  ((x IN (1, 2)) AND (b = y)) AND (z > 0)
 
 lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y, z)
 x IN (1, 2) AND y > 0 AND z = c
@@ -241,14 +257,14 @@ y = b AND z > 0
 optional: x IN (1, 2)
 ----
 lookup expression:
-  ((y = b) AND (x IN (1, 2))) AND (z > 0)
+  ((x IN (1, 2)) AND (b = y)) AND (z > 0)
 
 lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y)
 y = b AND z > 0
 optional: x IN (1, 2)
 ----
 lookup expression:
-  (y = b) AND (x IN (1, 2))
+  (x IN (1, 2)) AND (b = y)
 remaining filters:
   z > 0
 
@@ -257,10 +273,10 @@ y = b
 optional: x IN (1, 2) AND z > 0
 ----
 lookup expression:
-  (y = b) AND (x IN (1, 2))
+  (x IN (1, 2)) AND (b = y)
 
 lookup-constraints left=(a int, b int) right=(x int, y int) index=(x, y)
 x IN (10, 20, 30, 40) AND y = b AND x > 10
 ----
 lookup expression:
-  (y = b) AND (x IN (20, 30, 40))
+  (x IN (20, 30, 40)) AND (b = y)

--- a/pkg/sql/opt/memo/testdata/logprops/lookup-join
+++ b/pkg/sql/opt/memo/testdata/logprops/lookup-join
@@ -88,8 +88,8 @@ inner-join (lookup abcd)
  │    ├── lookup expression
  │    │    └── filters
  │    │         ├── eq [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
- │    │         │    ├── variable: a:6 [type=int]
- │    │         │    └── variable: m:1 [type=int]
+ │    │         │    ├── variable: m:1 [type=int]
+ │    │         │    └── variable: a:6 [type=int]
  │    │         └── gt [type=bool, outer=(7), constraints=(/7: [/3 - ]; tight)]
  │    │              ├── variable: b:7 [type=int]
  │    │              └── const: 2 [type=int]

--- a/pkg/sql/opt/memo/testdata/stats/lookup-join
+++ b/pkg/sql/opt/memo/testdata/stats/lookup-join
@@ -84,7 +84,7 @@ inner-join (lookup abcd)
  │    ├── columns: m:1(int!null) n:2(int) a:6(int!null) b:7(int!null) abcd.rowid:9(int!null)
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── a:6 = m:1 [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │    │         ├── m:1 = a:6 [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    │         └── b:7 > 2 [type=bool, outer=(7), constraints=(/7: [/3 - ]; tight)]
  │    ├── stats: [rows=33, distinct(1)=10, null(1)=0, avgsize(1)=2, distinct(6)=10, null(6)=0, avgsize(6)=4, distinct(7)=33, null(7)=0, avgsize(7)=4]
  │    ├── fd: (9)-->(6,7), (1)==(6), (6)==(1)

--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -611,10 +611,11 @@
     (LookupJoin
         $input
         $on
-        (CreateLocalityOptimizedLookupJoinPrivate
+        (CreateLocalityOptimizedLookupJoinPrivateIncludingCols
             $localExpr
             (EmptyFiltersExpr)
             $private
+            (OutputCols $input)
         )
     )
     $on

--- a/pkg/sql/opt/xform/testdata/coster/zone
+++ b/pkg/sql/opt/xform/testdata/coster/zone
@@ -846,8 +846,8 @@ anti-join (lookup abc_part@bc_idx [as=a2])
  ├── columns: r:1!null a:2!null b:3!null c:4!null
  ├── lookup expression
  │    └── filters
- │         ├── a1.a:2 = a2.b:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
- │         └── a2.r:7 = 'west' [outer=(7), constraints=(/7: [/'west' - /'west']; tight), fd=()-->(7)]
+ │         ├── a2.r:7 = 'west' [outer=(7), constraints=(/7: [/'west' - /'west']; tight), fd=()-->(7)]
+ │         └── a1.a:2 = a2.b:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
  ├── cardinality: [0 - 1]
  ├── stats: [rows=1e-10]
  ├── cost: 18.1443257
@@ -858,8 +858,8 @@ anti-join (lookup abc_part@bc_idx [as=a2])
  │    ├── columns: a1.r:1!null a1.a:2!null a1.b:3!null a1.c:4!null
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── a1.a:2 = a2.b:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
- │    │         └── a2.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+ │    │         ├── a2.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+ │    │         └── a1.a:2 = a2.b:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
  │    ├── cardinality: [0 - 1]
  │    ├── stats: [rows=0.9009, distinct(1)=0.897389, null(1)=0, avgsize(1)=4, distinct(2)=0.9009, null(2)=0, avgsize(2)=4, distinct(3)=0.9009, null(3)=0, avgsize(3)=4, distinct(4)=0.9009, null(4)=0, avgsize(4)=4]
  │    ├── cost: 10.8432087

--- a/pkg/sql/opt/xform/testdata/external/tpce
+++ b/pkg/sql/opt/xform/testdata/external/tpce
@@ -84,8 +84,8 @@ sort
       │    │    │    │    │    │    │    ├── columns: tr_s_symb:41!null tr_qty:42!null tr_bid_price:43!null tr_b_id:44!null b_id:47!null b_name:49!null
       │    │    │    │    │    │    │    ├── lookup expression
       │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │    │         ├── tr_b_id:44 = b_id:47 [outer=(44,47), constraints=(/44: (/NULL - ]; /47: (/NULL - ]), fd=(44)==(47), (47)==(44)]
-      │    │    │    │    │    │    │    │         └── b_name:49 IN ('Broker1', 'Broker10', 'Broker11', 'Broker12', 'Broker13', 'Broker14', 'Broker15', 'Broker16', 'Broker17', 'Broker18', 'Broker19', 'Broker2', 'Broker20', 'Broker21', 'Broker22', 'Broker23', 'Broker24', 'Broker25', 'Broker26', 'Broker27', 'Broker28', 'Broker29', 'Broker3', 'Broker30', 'Broker4', 'Broker5', 'Broker6', 'Broker7', 'Broker8', 'Broker9') [outer=(49), constraints=(/49: [/'Broker1' - /'Broker1'] [/'Broker10' - /'Broker10'] [/'Broker11' - /'Broker11'] [/'Broker12' - /'Broker12'] [/'Broker13' - /'Broker13'] [/'Broker14' - /'Broker14'] [/'Broker15' - /'Broker15'] [/'Broker16' - /'Broker16'] [/'Broker17' - /'Broker17'] [/'Broker18' - /'Broker18'] [/'Broker19' - /'Broker19'] [/'Broker2' - /'Broker2'] [/'Broker20' - /'Broker20'] [/'Broker21' - /'Broker21'] [/'Broker22' - /'Broker22'] [/'Broker23' - /'Broker23'] [/'Broker24' - /'Broker24'] [/'Broker25' - /'Broker25'] [/'Broker26' - /'Broker26'] [/'Broker27' - /'Broker27'] [/'Broker28' - /'Broker28'] [/'Broker29' - /'Broker29'] [/'Broker3' - /'Broker3'] [/'Broker30' - /'Broker30'] [/'Broker4' - /'Broker4'] [/'Broker5' - /'Broker5'] [/'Broker6' - /'Broker6'] [/'Broker7' - /'Broker7'] [/'Broker8' - /'Broker8'] [/'Broker9' - /'Broker9']; tight)]
+      │    │    │    │    │    │    │    │         ├── b_name:49 IN ('Broker1', 'Broker10', 'Broker11', 'Broker12', 'Broker13', 'Broker14', 'Broker15', 'Broker16', 'Broker17', 'Broker18', 'Broker19', 'Broker2', 'Broker20', 'Broker21', 'Broker22', 'Broker23', 'Broker24', 'Broker25', 'Broker26', 'Broker27', 'Broker28', 'Broker29', 'Broker3', 'Broker30', 'Broker4', 'Broker5', 'Broker6', 'Broker7', 'Broker8', 'Broker9') [outer=(49), constraints=(/49: [/'Broker1' - /'Broker1'] [/'Broker10' - /'Broker10'] [/'Broker11' - /'Broker11'] [/'Broker12' - /'Broker12'] [/'Broker13' - /'Broker13'] [/'Broker14' - /'Broker14'] [/'Broker15' - /'Broker15'] [/'Broker16' - /'Broker16'] [/'Broker17' - /'Broker17'] [/'Broker18' - /'Broker18'] [/'Broker19' - /'Broker19'] [/'Broker2' - /'Broker2'] [/'Broker20' - /'Broker20'] [/'Broker21' - /'Broker21'] [/'Broker22' - /'Broker22'] [/'Broker23' - /'Broker23'] [/'Broker24' - /'Broker24'] [/'Broker25' - /'Broker25'] [/'Broker26' - /'Broker26'] [/'Broker27' - /'Broker27'] [/'Broker28' - /'Broker28'] [/'Broker29' - /'Broker29'] [/'Broker3' - /'Broker3'] [/'Broker30' - /'Broker30'] [/'Broker4' - /'Broker4'] [/'Broker5' - /'Broker5'] [/'Broker6' - /'Broker6'] [/'Broker7' - /'Broker7'] [/'Broker8' - /'Broker8'] [/'Broker9' - /'Broker9']; tight)]
+      │    │    │    │    │    │    │    │         └── tr_b_id:44 = b_id:47 [outer=(44,47), constraints=(/44: (/NULL - ]; /47: (/NULL - ]), fd=(44)==(47), (47)==(44)]
       │    │    │    │    │    │    │    ├── lookup columns are key
       │    │    │    │    │    │    │    ├── fd: (47)-->(49), (44)==(47), (47)==(44)
       │    │    │    │    │    │    │    ├── scan trade_request@trade_request_tr_b_id_tr_s_symb_idx
@@ -1129,7 +1129,7 @@ project
  │    │    │    │    │    │    │    │    ├── flags: force lookup join (into right side)
  │    │    │    │    │    │    │    │    ├── lookup expression
  │    │    │    │    │    │    │    │    │    └── filters
- │    │    │    │    │    │    │    │    │         ├── co_in_id:9 = in_id:1 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
+ │    │    │    │    │    │    │    │    │         ├── in_id:1 = co_in_id:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
  │    │    │    │    │    │    │    │    │         └── (co_id:6 >= 1) AND (co_id:6 <= 5000) [outer=(6), constraints=(/6: [/1 - /5000]; tight)]
  │    │    │    │    │    │    │    │    ├── cardinality: [0 - 5000]
  │    │    │    │    │    │    │    │    ├── key: (6)
@@ -4034,18 +4034,25 @@ project
  │    │    │    ├── columns: s_symb:27!null s_name:30!null s_ex_id:31!null cr_c_tier:45!null cr_tt_id:46!null cr_ex_id:47!null cr_from_qty:48!null cr_to_qty:49!null commission_rate.cr_rate:50!null
  │    │    │    ├── lookup expression
  │    │    │    │    └── filters
- │    │    │    │         ├── cr_ex_id:47 = s_ex_id:31 [outer=(31,47), constraints=(/31: (/NULL - ]; /47: (/NULL - ]), fd=(31)==(47), (47)==(31)]
  │    │    │    │         ├── cr_c_tier:45 IN (1, 2, 3) [outer=(45), constraints=(/45: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
- │    │    │    │         ├── cr_tt_id:46 = 'TLS' [outer=(46), constraints=(/46: [/'TLS' - /'TLS']; tight), fd=()-->(46)]
+ │    │    │    │         ├── "lookup_join_const_col_@46":54 = cr_tt_id:46 [outer=(46,54), constraints=(/46: (/NULL - ]; /54: (/NULL - ]), fd=(46)==(54), (54)==(46)]
+ │    │    │    │         ├── s_ex_id:31 = cr_ex_id:47 [outer=(31,47), constraints=(/31: (/NULL - ]; /47: (/NULL - ]), fd=(31)==(47), (47)==(31)]
  │    │    │    │         └── cr_from_qty:48 <= 100 [outer=(48), constraints=(/48: (/NULL - /100]; tight)]
  │    │    │    ├── key: (45,48)
  │    │    │    ├── fd: ()-->(27,30,31,46,47), (45,48)-->(49,50), (31)==(47), (47)==(31)
- │    │    │    ├── scan security
- │    │    │    │    ├── columns: s_symb:27!null s_name:30!null s_ex_id:31!null
- │    │    │    │    ├── constraint: /27: [/'ROACH' - /'ROACH']
+ │    │    │    ├── project
+ │    │    │    │    ├── columns: "lookup_join_const_col_@46":54!null s_symb:27!null s_name:30!null s_ex_id:31!null
  │    │    │    │    ├── cardinality: [0 - 1]
  │    │    │    │    ├── key: ()
- │    │    │    │    └── fd: ()-->(27,30,31)
+ │    │    │    │    ├── fd: ()-->(27,30,31,54)
+ │    │    │    │    ├── scan security
+ │    │    │    │    │    ├── columns: s_symb:27!null s_name:30!null s_ex_id:31!null
+ │    │    │    │    │    ├── constraint: /27: [/'ROACH' - /'ROACH']
+ │    │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    │    ├── key: ()
+ │    │    │    │    │    └── fd: ()-->(27,30,31)
+ │    │    │    │    └── projections
+ │    │    │    │         └── 'TLS' [as="lookup_join_const_col_@46":54]
  │    │    │    └── filters
  │    │    │         └── cr_to_qty:49 >= 200 [outer=(49), constraints=(/49: [/200 - ]; tight)]
  │    │    ├── scan customer
@@ -4089,33 +4096,41 @@ project
  │    │    ├── flags: force lookup join (into right side)
  │    │    ├── lookup expression
  │    │    │    └── filters
- │    │    │         ├── cr_c_tier:45 = c_tier:8 [outer=(8,45), constraints=(/8: (/NULL - ]; /45: (/NULL - ]), fd=(8)==(45), (45)==(8)]
- │    │    │         ├── cr_ex_id:47 = s_ex_id:31 [outer=(31,47), constraints=(/31: (/NULL - ]; /47: (/NULL - ]), fd=(31)==(47), (47)==(31)]
- │    │    │         ├── cr_tt_id:46 = 'TLS' [outer=(46), constraints=(/46: [/'TLS' - /'TLS']; tight), fd=()-->(46)]
+ │    │    │         ├── c_tier:8 = cr_c_tier:45 [outer=(8,45), constraints=(/8: (/NULL - ]; /45: (/NULL - ]), fd=(8)==(45), (45)==(8)]
+ │    │    │         ├── "lookup_join_const_col_@46":54 = cr_tt_id:46 [outer=(46,54), constraints=(/46: (/NULL - ]; /54: (/NULL - ]), fd=(46)==(54), (54)==(46)]
+ │    │    │         ├── s_ex_id:31 = cr_ex_id:47 [outer=(31,47), constraints=(/31: (/NULL - ]; /47: (/NULL - ]), fd=(31)==(47), (47)==(31)]
  │    │    │         └── cr_from_qty:48 <= 100 [outer=(48), constraints=(/48: (/NULL - /100]; tight)]
  │    │    ├── key: (48)
  │    │    ├── fd: ()-->(1,8,27,30,31,45-47), (48)-->(49,50), (8)==(45), (45)==(8), (31)==(47), (47)==(31)
  │    │    ├── limit hint: 1.00
- │    │    ├── inner-join (cross)
- │    │    │    ├── columns: c_id:1!null c_tier:8!null s_symb:27!null s_name:30!null s_ex_id:31!null
+ │    │    ├── project
+ │    │    │    ├── columns: "lookup_join_const_col_@46":54!null c_id:1!null c_tier:8!null s_symb:27!null s_name:30!null s_ex_id:31!null
  │    │    │    ├── cardinality: [0 - 1]
- │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
  │    │    │    ├── key: ()
- │    │    │    ├── fd: ()-->(1,8,27,30,31)
+ │    │    │    ├── fd: ()-->(1,8,27,30,31,54)
  │    │    │    ├── limit hint: 1.00
- │    │    │    ├── scan customer
- │    │    │    │    ├── columns: c_id:1!null c_tier:8!null
- │    │    │    │    ├── constraint: /1: [/0 - /0]
+ │    │    │    ├── inner-join (cross)
+ │    │    │    │    ├── columns: c_id:1!null c_tier:8!null s_symb:27!null s_name:30!null s_ex_id:31!null
  │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
  │    │    │    │    ├── key: ()
- │    │    │    │    └── fd: ()-->(1,8)
- │    │    │    ├── scan security
- │    │    │    │    ├── columns: s_symb:27!null s_name:30!null s_ex_id:31!null
- │    │    │    │    ├── constraint: /27: [/'ROACH' - /'ROACH']
- │    │    │    │    ├── cardinality: [0 - 1]
- │    │    │    │    ├── key: ()
- │    │    │    │    └── fd: ()-->(27,30,31)
- │    │    │    └── filters (true)
+ │    │    │    │    ├── fd: ()-->(1,8,27,30,31)
+ │    │    │    │    ├── limit hint: 1.00
+ │    │    │    │    ├── scan customer
+ │    │    │    │    │    ├── columns: c_id:1!null c_tier:8!null
+ │    │    │    │    │    ├── constraint: /1: [/0 - /0]
+ │    │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    │    ├── key: ()
+ │    │    │    │    │    └── fd: ()-->(1,8)
+ │    │    │    │    ├── scan security
+ │    │    │    │    │    ├── columns: s_symb:27!null s_name:30!null s_ex_id:31!null
+ │    │    │    │    │    ├── constraint: /27: [/'ROACH' - /'ROACH']
+ │    │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    │    ├── key: ()
+ │    │    │    │    │    └── fd: ()-->(27,30,31)
+ │    │    │    │    └── filters (true)
+ │    │    │    └── projections
+ │    │    │         └── 'TLS' [as="lookup_join_const_col_@46":54]
  │    │    └── filters
  │    │         └── cr_to_qty:49 >= 200 [outer=(49), constraints=(/49: [/200 - ]; tight)]
  │    └── 1
@@ -6070,7 +6085,7 @@ limit
  │    │         ├── columns: wi_wl_id:19!null wi_s_symb:20!null wl_id:23!null wl_c_id:24!null
  │    │         ├── lookup expression
  │    │         │    └── filters
- │    │         │         ├── wi_wl_id:19 = wl_id:23 [outer=(19,23), constraints=(/19: (/NULL - ]; /23: (/NULL - ]), fd=(19)==(23), (23)==(19)]
+ │    │         │         ├── wl_id:23 = wi_wl_id:19 [outer=(19,23), constraints=(/19: (/NULL - ]; /23: (/NULL - ]), fd=(19)==(23), (23)==(19)]
  │    │         │         └── wi_s_symb:20 > 'GOOG' [outer=(20), constraints=(/20: [/e'GOOG\x00' - ]; tight)]
  │    │         ├── key: (20,23)
  │    │         ├── fd: ()-->(24), (19)==(23), (23)==(19)

--- a/pkg/sql/opt/xform/testdata/external/tpce-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpce-no-stats
@@ -56,8 +56,8 @@ sort
       │    │    │    ├── columns: sc_id:1!null sc_name:2!null in_id:5!null in_sc_id:7!null co_id:10!null co_in_id:13!null s_symb:21!null s_co_id:26!null tr_s_symb:41!null tr_qty:42!null tr_bid_price:43!null tr_b_id:44!null b_id:47!null b_name:49!null
       │    │    │    ├── lookup expression
       │    │    │    │    └── filters
-      │    │    │    │         ├── tr_b_id:44 = b_id:47 [outer=(44,47), constraints=(/44: (/NULL - ]; /47: (/NULL - ]), fd=(44)==(47), (47)==(44)]
-      │    │    │    │         └── b_name:49 IN ('Broker1', 'Broker10', 'Broker11', 'Broker12', 'Broker13', 'Broker14', 'Broker15', 'Broker16', 'Broker17', 'Broker18', 'Broker19', 'Broker2', 'Broker20', 'Broker21', 'Broker22', 'Broker23', 'Broker24', 'Broker25', 'Broker26', 'Broker27', 'Broker28', 'Broker29', 'Broker3', 'Broker30', 'Broker4', 'Broker5', 'Broker6', 'Broker7', 'Broker8', 'Broker9') [outer=(49), constraints=(/49: [/'Broker1' - /'Broker1'] [/'Broker10' - /'Broker10'] [/'Broker11' - /'Broker11'] [/'Broker12' - /'Broker12'] [/'Broker13' - /'Broker13'] [/'Broker14' - /'Broker14'] [/'Broker15' - /'Broker15'] [/'Broker16' - /'Broker16'] [/'Broker17' - /'Broker17'] [/'Broker18' - /'Broker18'] [/'Broker19' - /'Broker19'] [/'Broker2' - /'Broker2'] [/'Broker20' - /'Broker20'] [/'Broker21' - /'Broker21'] [/'Broker22' - /'Broker22'] [/'Broker23' - /'Broker23'] [/'Broker24' - /'Broker24'] [/'Broker25' - /'Broker25'] [/'Broker26' - /'Broker26'] [/'Broker27' - /'Broker27'] [/'Broker28' - /'Broker28'] [/'Broker29' - /'Broker29'] [/'Broker3' - /'Broker3'] [/'Broker30' - /'Broker30'] [/'Broker4' - /'Broker4'] [/'Broker5' - /'Broker5'] [/'Broker6' - /'Broker6'] [/'Broker7' - /'Broker7'] [/'Broker8' - /'Broker8'] [/'Broker9' - /'Broker9']; tight)]
+      │    │    │    │         ├── b_name:49 IN ('Broker1', 'Broker10', 'Broker11', 'Broker12', 'Broker13', 'Broker14', 'Broker15', 'Broker16', 'Broker17', 'Broker18', 'Broker19', 'Broker2', 'Broker20', 'Broker21', 'Broker22', 'Broker23', 'Broker24', 'Broker25', 'Broker26', 'Broker27', 'Broker28', 'Broker29', 'Broker3', 'Broker30', 'Broker4', 'Broker5', 'Broker6', 'Broker7', 'Broker8', 'Broker9') [outer=(49), constraints=(/49: [/'Broker1' - /'Broker1'] [/'Broker10' - /'Broker10'] [/'Broker11' - /'Broker11'] [/'Broker12' - /'Broker12'] [/'Broker13' - /'Broker13'] [/'Broker14' - /'Broker14'] [/'Broker15' - /'Broker15'] [/'Broker16' - /'Broker16'] [/'Broker17' - /'Broker17'] [/'Broker18' - /'Broker18'] [/'Broker19' - /'Broker19'] [/'Broker2' - /'Broker2'] [/'Broker20' - /'Broker20'] [/'Broker21' - /'Broker21'] [/'Broker22' - /'Broker22'] [/'Broker23' - /'Broker23'] [/'Broker24' - /'Broker24'] [/'Broker25' - /'Broker25'] [/'Broker26' - /'Broker26'] [/'Broker27' - /'Broker27'] [/'Broker28' - /'Broker28'] [/'Broker29' - /'Broker29'] [/'Broker3' - /'Broker3'] [/'Broker30' - /'Broker30'] [/'Broker4' - /'Broker4'] [/'Broker5' - /'Broker5'] [/'Broker6' - /'Broker6'] [/'Broker7' - /'Broker7'] [/'Broker8' - /'Broker8'] [/'Broker9' - /'Broker9']; tight)]
+      │    │    │    │         └── tr_b_id:44 = b_id:47 [outer=(44,47), constraints=(/44: (/NULL - ]; /47: (/NULL - ]), fd=(44)==(47), (47)==(44)]
       │    │    │    ├── lookup columns are key
       │    │    │    ├── fd: ()-->(1,2,7), (10)-->(13), (21)-->(26), (47)-->(49), (44)==(47), (47)==(44), (21)==(41), (41)==(21), (10)==(26), (26)==(10), (5)==(13), (13)==(5), (1)==(7), (7)==(1)
       │    │    │    ├── inner-join (hash)
@@ -1038,7 +1038,7 @@ project
  │    │    │    │    │    │    ├── columns: in_id:1!null in_name:2!null co_id:6!null co_in_id:9!null
  │    │    │    │    │    │    ├── lookup expression
  │    │    │    │    │    │    │    └── filters
- │    │    │    │    │    │    │         ├── co_in_id:9 = in_id:1 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
+ │    │    │    │    │    │    │         ├── in_id:1 = co_in_id:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
  │    │    │    │    │    │    │         └── (co_id:6 >= 1) AND (co_id:6 <= 5000) [outer=(6), constraints=(/6: [/1 - /5000]; tight)]
  │    │    │    │    │    │    ├── cardinality: [0 - 5000]
  │    │    │    │    │    │    ├── key: (6)
@@ -1156,7 +1156,7 @@ project
  │    │    │    │    │    │    │    │    ├── flags: force lookup join (into right side)
  │    │    │    │    │    │    │    │    ├── lookup expression
  │    │    │    │    │    │    │    │    │    └── filters
- │    │    │    │    │    │    │    │    │         ├── co_in_id:9 = in_id:1 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
+ │    │    │    │    │    │    │    │    │         ├── in_id:1 = co_in_id:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
  │    │    │    │    │    │    │    │    │         └── (co_id:6 >= 1) AND (co_id:6 <= 5000) [outer=(6), constraints=(/6: [/1 - /5000]; tight)]
  │    │    │    │    │    │    │    │    ├── cardinality: [0 - 5000]
  │    │    │    │    │    │    │    │    ├── key: (6)
@@ -4062,31 +4062,34 @@ project
  │    │    ├── fd: ()-->(1,8,27,30,31,45-47), (48)-->(49,50), (31)==(47), (47)==(31), (8)==(45), (45)==(8)
  │    │    ├── limit hint: 1.00
  │    │    ├── inner-join (lookup commission_rate)
- │    │    │    ├── columns: s_symb:27!null s_name:30!null s_ex_id:31!null cr_c_tier:45!null cr_tt_id:46!null cr_ex_id:47!null cr_from_qty:48!null cr_to_qty:49!null commission_rate.cr_rate:50!null
- │    │    │    ├── lookup expression
- │    │    │    │    └── filters
- │    │    │    │         ├── cr_ex_id:47 = s_ex_id:31 [outer=(31,47), constraints=(/31: (/NULL - ]; /47: (/NULL - ]), fd=(31)==(47), (47)==(31)]
- │    │    │    │         ├── cr_c_tier:45 IN (1, 2, 3) [outer=(45), constraints=(/45: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
- │    │    │    │         ├── cr_tt_id:46 = 'TLS' [outer=(46), constraints=(/46: [/'TLS' - /'TLS']; tight), fd=()-->(46)]
- │    │    │    │         └── cr_from_qty:48 <= 100 [outer=(48), constraints=(/48: (/NULL - /100]; tight)]
- │    │    │    ├── key: (45,48)
- │    │    │    ├── fd: ()-->(27,30,31,46,47), (45,48)-->(49,50), (31)==(47), (47)==(31)
- │    │    │    ├── scan security
- │    │    │    │    ├── columns: s_symb:27!null s_name:30!null s_ex_id:31!null
- │    │    │    │    ├── constraint: /27: [/'ROACH' - /'ROACH']
+ │    │    │    ├── columns: c_id:1!null c_tier:8!null cr_c_tier:45!null cr_tt_id:46!null cr_ex_id:47!null cr_from_qty:48!null cr_to_qty:49!null commission_rate.cr_rate:50!null
+ │    │    │    ├── key columns: [8 56] = [45 46]
+ │    │    │    ├── key: (47,48)
+ │    │    │    ├── fd: ()-->(1,8,45,46), (47,48)-->(49,50), (8)==(45), (45)==(8)
+ │    │    │    ├── project
+ │    │    │    │    ├── columns: "lookup_join_const_col_@46":56!null c_id:1!null c_tier:8!null
  │    │    │    │    ├── cardinality: [0 - 1]
  │    │    │    │    ├── key: ()
- │    │    │    │    └── fd: ()-->(27,30,31)
+ │    │    │    │    ├── fd: ()-->(1,8,56)
+ │    │    │    │    ├── scan customer
+ │    │    │    │    │    ├── columns: c_id:1!null c_tier:8!null
+ │    │    │    │    │    ├── constraint: /1: [/0 - /0]
+ │    │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    │    ├── key: ()
+ │    │    │    │    │    └── fd: ()-->(1,8)
+ │    │    │    │    └── projections
+ │    │    │    │         └── 'TLS' [as="lookup_join_const_col_@46":56]
  │    │    │    └── filters
+ │    │    │         ├── cr_from_qty:48 <= 100 [outer=(48), constraints=(/48: (/NULL - /100]; tight)]
  │    │    │         └── cr_to_qty:49 >= 200 [outer=(49), constraints=(/49: [/200 - ]; tight)]
- │    │    ├── scan customer
- │    │    │    ├── columns: c_id:1!null c_tier:8!null
- │    │    │    ├── constraint: /1: [/0 - /0]
+ │    │    ├── scan security
+ │    │    │    ├── columns: s_symb:27!null s_name:30!null s_ex_id:31!null
+ │    │    │    ├── constraint: /27: [/'ROACH' - /'ROACH']
  │    │    │    ├── cardinality: [0 - 1]
  │    │    │    ├── key: ()
- │    │    │    └── fd: ()-->(1,8)
+ │    │    │    └── fd: ()-->(27,30,31)
  │    │    └── filters
- │    │         └── cr_c_tier:45 = c_tier:8 [outer=(8,45), constraints=(/8: (/NULL - ]; /45: (/NULL - ]), fd=(8)==(45), (45)==(8)]
+ │    │         └── cr_ex_id:47 = s_ex_id:31 [outer=(31,47), constraints=(/31: (/NULL - ]; /47: (/NULL - ]), fd=(31)==(47), (47)==(31)]
  │    └── 1
  └── projections
       └── commission_rate.cr_rate:50::FLOAT8 [as=cr_rate:53, outer=(50), immutable]
@@ -4120,32 +4123,39 @@ project
  │    │    ├── flags: force lookup join (into right side)
  │    │    ├── lookup expression
  │    │    │    └── filters
- │    │    │         ├── cr_c_tier:45 = c_tier:8 [outer=(8,45), constraints=(/8: (/NULL - ]; /45: (/NULL - ]), fd=(8)==(45), (45)==(8)]
- │    │    │         ├── cr_ex_id:47 = s_ex_id:31 [outer=(31,47), constraints=(/31: (/NULL - ]; /47: (/NULL - ]), fd=(31)==(47), (47)==(31)]
- │    │    │         ├── cr_tt_id:46 = 'TLS' [outer=(46), constraints=(/46: [/'TLS' - /'TLS']; tight), fd=()-->(46)]
+ │    │    │         ├── c_tier:8 = cr_c_tier:45 [outer=(8,45), constraints=(/8: (/NULL - ]; /45: (/NULL - ]), fd=(8)==(45), (45)==(8)]
+ │    │    │         ├── "lookup_join_const_col_@46":54 = cr_tt_id:46 [outer=(46,54), constraints=(/46: (/NULL - ]; /54: (/NULL - ]), fd=(46)==(54), (54)==(46)]
+ │    │    │         ├── s_ex_id:31 = cr_ex_id:47 [outer=(31,47), constraints=(/31: (/NULL - ]; /47: (/NULL - ]), fd=(31)==(47), (47)==(31)]
  │    │    │         └── cr_from_qty:48 <= 100 [outer=(48), constraints=(/48: (/NULL - /100]; tight)]
  │    │    ├── key: (48)
  │    │    ├── fd: ()-->(1,8,27,30,31,45-47), (48)-->(49,50), (8)==(45), (45)==(8), (31)==(47), (47)==(31)
  │    │    ├── limit hint: 1.00
- │    │    ├── inner-join (cross)
- │    │    │    ├── columns: c_id:1!null c_tier:8!null s_symb:27!null s_name:30!null s_ex_id:31!null
+ │    │    ├── project
+ │    │    │    ├── columns: "lookup_join_const_col_@46":54!null c_id:1!null c_tier:8!null s_symb:27!null s_name:30!null s_ex_id:31!null
  │    │    │    ├── cardinality: [0 - 1]
- │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
  │    │    │    ├── key: ()
- │    │    │    ├── fd: ()-->(1,8,27,30,31)
- │    │    │    ├── scan customer
- │    │    │    │    ├── columns: c_id:1!null c_tier:8!null
- │    │    │    │    ├── constraint: /1: [/0 - /0]
+ │    │    │    ├── fd: ()-->(1,8,27,30,31,54)
+ │    │    │    ├── inner-join (cross)
+ │    │    │    │    ├── columns: c_id:1!null c_tier:8!null s_symb:27!null s_name:30!null s_ex_id:31!null
  │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
  │    │    │    │    ├── key: ()
- │    │    │    │    └── fd: ()-->(1,8)
- │    │    │    ├── scan security
- │    │    │    │    ├── columns: s_symb:27!null s_name:30!null s_ex_id:31!null
- │    │    │    │    ├── constraint: /27: [/'ROACH' - /'ROACH']
- │    │    │    │    ├── cardinality: [0 - 1]
- │    │    │    │    ├── key: ()
- │    │    │    │    └── fd: ()-->(27,30,31)
- │    │    │    └── filters (true)
+ │    │    │    │    ├── fd: ()-->(1,8,27,30,31)
+ │    │    │    │    ├── scan customer
+ │    │    │    │    │    ├── columns: c_id:1!null c_tier:8!null
+ │    │    │    │    │    ├── constraint: /1: [/0 - /0]
+ │    │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    │    ├── key: ()
+ │    │    │    │    │    └── fd: ()-->(1,8)
+ │    │    │    │    ├── scan security
+ │    │    │    │    │    ├── columns: s_symb:27!null s_name:30!null s_ex_id:31!null
+ │    │    │    │    │    ├── constraint: /27: [/'ROACH' - /'ROACH']
+ │    │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    │    ├── key: ()
+ │    │    │    │    │    └── fd: ()-->(27,30,31)
+ │    │    │    │    └── filters (true)
+ │    │    │    └── projections
+ │    │    │         └── 'TLS' [as="lookup_join_const_col_@46":54]
  │    │    └── filters
  │    │         └── cr_to_qty:49 >= 200 [outer=(49), constraints=(/49: [/200 - ]; tight)]
  │    └── 1
@@ -6091,7 +6101,7 @@ limit
  │    │         ├── columns: wi_wl_id:19!null wi_s_symb:20!null wl_id:23!null wl_c_id:24!null
  │    │         ├── lookup expression
  │    │         │    └── filters
- │    │         │         ├── wi_wl_id:19 = wl_id:23 [outer=(19,23), constraints=(/19: (/NULL - ]; /23: (/NULL - ]), fd=(19)==(23), (23)==(19)]
+ │    │         │         ├── wl_id:23 = wi_wl_id:19 [outer=(19,23), constraints=(/19: (/NULL - ]; /23: (/NULL - ]), fd=(19)==(23), (23)==(19)]
  │    │         │         └── wi_s_symb:20 > 'GOOG' [outer=(20), constraints=(/20: [/e'GOOG\x00' - ]; tight)]
  │    │         ├── key: (20,23)
  │    │         ├── fd: ()-->(24), (19)==(23), (23)==(19)

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -833,30 +833,40 @@ project
  │         │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null transactiondetails.dealerid:20 isbuy:21 transactiondate:22 transactiondetails.cardid:23 quantity:24
  │         │    │    ├── lookup expression
  │         │    │    │    └── filters
- │         │    │    │         ├── transactiondetails.cardid:23 = id:1 [outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ]), fd=(1)==(23), (23)==(1)]
- │         │    │    │         ├── transactiondetails.dealerid:20 = 1 [outer=(20), constraints=(/20: [/1 - /1]; tight), fd=()-->(20)]
- │         │    │    │         ├── isbuy:21 = false [outer=(21), constraints=(/21: [/false - /false]; tight), fd=()-->(21)]
+ │         │    │    │         ├── "lookup_join_const_col_@20":42 = transactiondetails.dealerid:20 [outer=(20,42), constraints=(/20: (/NULL - ]; /42: (/NULL - ]), fd=(20)==(42), (42)==(20)]
+ │         │    │    │         ├── "lookup_join_const_col_@21":43 = isbuy:21 [outer=(21,43), constraints=(/21: (/NULL - ]; /43: (/NULL - ]), fd=(21)==(43), (43)==(21)]
+ │         │    │    │         ├── id:1 = transactiondetails.cardid:23 [outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ]), fd=(1)==(23), (23)==(1)]
  │         │    │    │         └── (transactiondate:22 >= '2020-02-28 00:00:00+00:00') AND (transactiondate:22 <= '2020-03-01 00:00:00+00:00') [outer=(22), constraints=(/22: [/'2020-02-28 00:00:00+00:00' - /'2020-03-01 00:00:00+00:00']; tight)]
  │         │    │    ├── immutable
  │         │    │    ├── stats: [rows=423333.3, distinct(1)=19000, null(1)=0, avgsize(1)=4, distinct(2)=13000, null(2)=0, avgsize(2)=4, distinct(5)=829, null(5)=0, avgsize(5)=4, distinct(6)=5601.15, null(6)=0, avgsize(6)=4, distinct(23)=19000, null(23)=0, avgsize(23)=4]
  │         │    │    ├── key: (1,22-24)
  │         │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6), (1,22-24)-->(20,21)
  │         │    │    ├── ordering: +1
- │         │    │    ├── select
- │         │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
+ │         │    │    ├── project
+ │         │    │    │    ├── columns: "lookup_join_const_col_@20":42!null "lookup_join_const_col_@21":43!null id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
  │         │    │    │    ├── immutable
- │         │    │    │    ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, avgsize(1)=4, distinct(2)=13000, null(2)=0, avgsize(2)=4, distinct(5)=829, null(5)=0, avgsize(5)=4, distinct(6)=5601.15, null(6)=0, avgsize(6)=4]
+ │         │    │    │    ├── stats: [rows=19000]
  │         │    │    │    ├── key: (1)
- │         │    │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6)
- │         │    │    │    ├── ordering: +1
- │         │    │    │    ├── scan cards
+ │         │    │    │    ├── fd: ()-->(42,43), (1)-->(2-6), (2,4,5)~~>(1,3,6)
+ │         │    │    │    ├── ordering: +1 opt(42,43) [actual: +1]
+ │         │    │    │    ├── select
  │         │    │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
- │         │    │    │    │    ├── stats: [rows=57000, distinct(1)=57000, null(1)=0, avgsize(1)=4, distinct(2)=39000, null(2)=0, avgsize(2)=4, distinct(5)=829, null(5)=0, avgsize(5)=4, distinct(6)=5700, null(6)=0, avgsize(6)=4]
+ │         │    │    │    │    ├── immutable
+ │         │    │    │    │    ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, avgsize(1)=4, distinct(2)=13000, null(2)=0, avgsize(2)=4, distinct(5)=829, null(5)=0, avgsize(5)=4, distinct(6)=5601.15, null(6)=0, avgsize(6)=4]
  │         │    │    │    │    ├── key: (1)
  │         │    │    │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6)
- │         │    │    │    │    └── ordering: +1
- │         │    │    │    └── filters
- │         │    │    │         └── (name:2, setname:4, number:5) > ('Shock', '7E', 248) [outer=(2,4,5), immutable, constraints=(/2/4/5: [/'Shock'/'7E'/249 - ]; tight)]
+ │         │    │    │    │    ├── ordering: +1
+ │         │    │    │    │    ├── scan cards
+ │         │    │    │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
+ │         │    │    │    │    │    ├── stats: [rows=57000, distinct(1)=57000, null(1)=0, avgsize(1)=4, distinct(2)=39000, null(2)=0, avgsize(2)=4, distinct(5)=829, null(5)=0, avgsize(5)=4, distinct(6)=5700, null(6)=0, avgsize(6)=4]
+ │         │    │    │    │    │    ├── key: (1)
+ │         │    │    │    │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6)
+ │         │    │    │    │    │    └── ordering: +1
+ │         │    │    │    │    └── filters
+ │         │    │    │    │         └── (name:2, setname:4, number:5) > ('Shock', '7E', 248) [outer=(2,4,5), immutable, constraints=(/2/4/5: [/'Shock'/'7E'/249 - ]; tight)]
+ │         │    │    │    └── projections
+ │         │    │    │         ├── 1 [as="lookup_join_const_col_@20":42]
+ │         │    │    │         └── false [as="lookup_join_const_col_@21":43]
  │         │    │    └── filters (true)
  │         │    ├── scan cardsinfo
  │         │    │    ├── columns: cardsinfo.dealerid:9!null cardsinfo.cardid:10!null cardsinfo.buyprice:11!null cardsinfo.sellprice:12!null discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null cardsinfo.version:17!null
@@ -1100,8 +1110,8 @@ top-k
       │    │    ├── columns: id:6!null quantity:7!null dealerid:8!null cardid:9!null accountname:10!null inventorydetails.quantity:11!null
       │    │    ├── lookup expression
       │    │    │    └── filters
-      │    │    │         ├── cardid:9 = id:6 [outer=(6,9), constraints=(/6: (/NULL - ]; /9: (/NULL - ]), fd=(6)==(9), (9)==(6)]
       │    │    │         ├── dealerid:8 IN (1, 2, 3, 4, 5) [outer=(8), constraints=(/8: [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5]; tight)]
+      │    │    │         ├── id:6 = cardid:9 [outer=(6,9), constraints=(/6: (/NULL - ]; /9: (/NULL - ]), fd=(6)==(9), (9)==(6)]
       │    │    │         └── accountname:10 IN ('account-1', 'account-2', 'account-3') [outer=(10), constraints=(/10: [/'account-1' - /'account-1'] [/'account-2' - /'account-2'] [/'account-3' - /'account-3']; tight)]
       │    │    ├── fd: (8-10)-->(11), (6)==(9), (9)==(6)
       │    │    ├── values

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -837,30 +837,40 @@ project
  │         │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null transactiondetails.dealerid:24 isbuy:25 transactiondate:26 transactiondetails.cardid:27 quantity:28
  │         │    │    ├── lookup expression
  │         │    │    │    └── filters
- │         │    │    │         ├── transactiondetails.cardid:27 = id:1 [outer=(1,27), constraints=(/1: (/NULL - ]; /27: (/NULL - ]), fd=(1)==(27), (27)==(1)]
- │         │    │    │         ├── transactiondetails.dealerid:24 = 1 [outer=(24), constraints=(/24: [/1 - /1]; tight), fd=()-->(24)]
- │         │    │    │         ├── isbuy:25 = false [outer=(25), constraints=(/25: [/false - /false]; tight), fd=()-->(25)]
+ │         │    │    │         ├── "lookup_join_const_col_@24":48 = transactiondetails.dealerid:24 [outer=(24,48), constraints=(/24: (/NULL - ]; /48: (/NULL - ]), fd=(24)==(48), (48)==(24)]
+ │         │    │    │         ├── "lookup_join_const_col_@25":49 = isbuy:25 [outer=(25,49), constraints=(/25: (/NULL - ]; /49: (/NULL - ]), fd=(25)==(49), (49)==(25)]
+ │         │    │    │         ├── id:1 = transactiondetails.cardid:27 [outer=(1,27), constraints=(/1: (/NULL - ]; /27: (/NULL - ]), fd=(1)==(27), (27)==(1)]
  │         │    │    │         └── (transactiondate:26 >= '2020-02-28 00:00:00+00:00') AND (transactiondate:26 <= '2020-03-01 00:00:00+00:00') [outer=(26), constraints=(/26: [/'2020-02-28 00:00:00+00:00' - /'2020-03-01 00:00:00+00:00']; tight)]
  │         │    │    ├── immutable
  │         │    │    ├── stats: [rows=423333.3, distinct(1)=19000, null(1)=0, avgsize(1)=4, distinct(2)=13000, null(2)=0, avgsize(2)=4, distinct(5)=829, null(5)=0, avgsize(5)=4, distinct(6)=5601.15, null(6)=0, avgsize(6)=4, distinct(27)=19000, null(27)=0, avgsize(27)=4]
  │         │    │    ├── key: (1,26-28)
  │         │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6), (1,26-28)-->(24,25)
  │         │    │    ├── ordering: +1
- │         │    │    ├── select
- │         │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
+ │         │    │    ├── project
+ │         │    │    │    ├── columns: "lookup_join_const_col_@24":48!null "lookup_join_const_col_@25":49!null id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
  │         │    │    │    ├── immutable
- │         │    │    │    ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, avgsize(1)=4, distinct(2)=13000, null(2)=0, avgsize(2)=4, distinct(5)=829, null(5)=0, avgsize(5)=4, distinct(6)=5601.15, null(6)=0, avgsize(6)=4]
+ │         │    │    │    ├── stats: [rows=19000]
  │         │    │    │    ├── key: (1)
- │         │    │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6)
- │         │    │    │    ├── ordering: +1
- │         │    │    │    ├── scan cards
+ │         │    │    │    ├── fd: ()-->(48,49), (1)-->(2-6), (2,4,5)~~>(1,3,6)
+ │         │    │    │    ├── ordering: +1 opt(48,49) [actual: +1]
+ │         │    │    │    ├── select
  │         │    │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
- │         │    │    │    │    ├── stats: [rows=57000, distinct(1)=57000, null(1)=0, avgsize(1)=4, distinct(2)=39000, null(2)=0, avgsize(2)=4, distinct(5)=829, null(5)=0, avgsize(5)=4, distinct(6)=5700, null(6)=0, avgsize(6)=4]
+ │         │    │    │    │    ├── immutable
+ │         │    │    │    │    ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, avgsize(1)=4, distinct(2)=13000, null(2)=0, avgsize(2)=4, distinct(5)=829, null(5)=0, avgsize(5)=4, distinct(6)=5601.15, null(6)=0, avgsize(6)=4]
  │         │    │    │    │    ├── key: (1)
  │         │    │    │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6)
- │         │    │    │    │    └── ordering: +1
- │         │    │    │    └── filters
- │         │    │    │         └── (name:2, setname:4, number:5) > ('Shock', '7E', 248) [outer=(2,4,5), immutable, constraints=(/2/4/5: [/'Shock'/'7E'/249 - ]; tight)]
+ │         │    │    │    │    ├── ordering: +1
+ │         │    │    │    │    ├── scan cards
+ │         │    │    │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
+ │         │    │    │    │    │    ├── stats: [rows=57000, distinct(1)=57000, null(1)=0, avgsize(1)=4, distinct(2)=39000, null(2)=0, avgsize(2)=4, distinct(5)=829, null(5)=0, avgsize(5)=4, distinct(6)=5700, null(6)=0, avgsize(6)=4]
+ │         │    │    │    │    │    ├── key: (1)
+ │         │    │    │    │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6)
+ │         │    │    │    │    │    └── ordering: +1
+ │         │    │    │    │    └── filters
+ │         │    │    │    │         └── (name:2, setname:4, number:5) > ('Shock', '7E', 248) [outer=(2,4,5), immutable, constraints=(/2/4/5: [/'Shock'/'7E'/249 - ]; tight)]
+ │         │    │    │    └── projections
+ │         │    │    │         ├── 1 [as="lookup_join_const_col_@24":48]
+ │         │    │    │         └── false [as="lookup_join_const_col_@25":49]
  │         │    │    └── filters (true)
  │         │    ├── scan cardsinfo
  │         │    │    ├── columns: cardsinfo.dealerid:9!null cardsinfo.cardid:10!null cardsinfo.buyprice:11!null cardsinfo.sellprice:12!null cardsinfo.discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null cardsinfo.version:17!null
@@ -1104,8 +1114,8 @@ top-k
       │    │    ├── columns: id:6!null quantity:7!null dealerid:8!null cardid:9!null accountname:10!null inventorydetails.quantity:11!null
       │    │    ├── lookup expression
       │    │    │    └── filters
-      │    │    │         ├── cardid:9 = id:6 [outer=(6,9), constraints=(/6: (/NULL - ]; /9: (/NULL - ]), fd=(6)==(9), (9)==(6)]
       │    │    │         ├── dealerid:8 IN (1, 2, 3, 4, 5) [outer=(8), constraints=(/8: [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5]; tight)]
+      │    │    │         ├── id:6 = cardid:9 [outer=(6,9), constraints=(/6: (/NULL - ]; /9: (/NULL - ]), fd=(6)==(9), (9)==(6)]
       │    │    │         └── accountname:10 IN ('account-1', 'account-2', 'account-3') [outer=(10), constraints=(/10: [/'account-1' - /'account-1'] [/'account-2' - /'account-2'] [/'account-3' - /'account-3']; tight)]
       │    │    ├── fd: (8-10)-->(11), (6)==(9), (9)==(6)
       │    │    ├── values

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -2172,7 +2172,7 @@ memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
 memo
 SELECT (SELECT w FROM kuvw WHERE v=1 AND x=u) FROM xyz ORDER BY x+1, x
 ----
-memo (optimized, ~29KB, required=[presentation: w:12] [ordering: +13,+1])
+memo (optimized, ~24KB, required=[presentation: w:12] [ordering: +13,+1])
  ├── G1: (project G2 G3 x)
  │    ├── [presentation: w:12] [ordering: +13,+1]
  │    │    ├── best: (sort G1)
@@ -2185,16 +2185,16 @@ memo (optimized, ~29KB, required=[presentation: w:12] [ordering: +13,+1])
  │         ├── best: (ensure-distinct-on G4="[ordering: +1]" G5 cols=(1),ordering=+1)
  │         └── cost: 1129.38
  ├── G3: (projections G6 G7)
- ├── G4: (left-join G8 G9 G10) (right-join G9 G8 G10) (merge-join G8 G9 G11 left-join,+1,+7) (lookup-join G12 G11 kuvw@uvw,keyCols=[1 14],outCols=(1,7-9)) (lookup-join G13 G10 kuvw@vw,keyCols=[15],outCols=(1,7-9)) (merge-join G9 G8 G11 right-join,+7,+1)
+ ├── G4: (left-join G8 G9 G10) (right-join G9 G8 G10) (merge-join G8 G9 G11 left-join,+1,+7) (lookup-join G12 G11 kuvw@uvw,keyCols=[1 14],outCols=(1,7-9)) (merge-join G9 G8 G11 right-join,+7,+1)
  │    ├── [ordering: +1]
  │    │    ├── best: (merge-join G8="[ordering: +1]" G9="[ordering: +7 opt(8)]" G11 left-join,+1,+7)
  │    │    └── cost: 1099.35
  │    └── []
  │         ├── best: (merge-join G8="[ordering: +1]" G9="[ordering: +7 opt(8)]" G11 left-join,+1,+7)
  │         └── cost: 1099.35
- ├── G5: (aggregations G14)
+ ├── G5: (aggregations G13)
  ├── G6: (variable kuvw.w)
- ├── G7: (plus G15 G16)
+ ├── G7: (plus G14 G15)
  ├── G8: (scan xyz,cols=(1)) (scan xyz@xy,cols=(1)) (scan xyz@zyx,cols=(1)) (scan xyz@yy,cols=(1))
  │    ├── [ordering: +1]
  │    │    ├── best: (scan xyz@xy,cols=(1))
@@ -2202,45 +2202,38 @@ memo (optimized, ~29KB, required=[presentation: w:12] [ordering: +13,+1])
  │    └── []
  │         ├── best: (scan xyz@xy,cols=(1))
  │         └── cost: 1054.32
- ├── G9: (select G17 G18) (scan kuvw@vw,cols=(7-9),constrained)
+ ├── G9: (select G16 G17) (scan kuvw@vw,cols=(7-9),constrained)
  │    ├── [ordering: +7 opt(8)]
  │    │    ├── best: (sort G9)
  │    │    └── cost: 25.90
  │    └── []
  │         ├── best: (scan kuvw@vw,cols=(7-9),constrained)
  │         └── cost: 24.72
- ├── G10: (filters G19)
+ ├── G10: (filters G18)
  ├── G11: (filters)
- ├── G12: (project G8 G20 x)
+ ├── G12: (project G8 G19 x)
  │    ├── [ordering: +1 opt(14)]
- │    │    ├── best: (project G8="[ordering: +1]" G20 x)
+ │    │    ├── best: (project G8="[ordering: +1]" G19 x)
  │    │    └── cost: 1074.34
  │    └── []
- │         ├── best: (project G8 G20 x)
+ │         ├── best: (project G8 G19 x)
  │         └── cost: 1074.34
- ├── G13: (project G8 G20 x)
- │    ├── [ordering: +1 opt(15)]
- │    │    ├── best: (project G8="[ordering: +1]" G20 x)
- │    │    └── cost: 1074.34
- │    └── []
- │         ├── best: (project G8 G20 x)
- │         └── cost: 1074.34
- ├── G14: (const-agg G6)
- ├── G15: (variable x)
- ├── G16: (const 1)
- ├── G17: (scan kuvw,cols=(7-9)) (scan kuvw@uvw,cols=(7-9)) (scan kuvw@wvu,cols=(7-9)) (scan kuvw@vw,cols=(7-9)) (scan kuvw@w,cols=(7-9))
+ ├── G13: (const-agg G6)
+ ├── G14: (variable x)
+ ├── G15: (const 1)
+ ├── G16: (scan kuvw,cols=(7-9)) (scan kuvw@uvw,cols=(7-9)) (scan kuvw@wvu,cols=(7-9)) (scan kuvw@vw,cols=(7-9)) (scan kuvw@w,cols=(7-9))
  │    ├── [ordering: +7]
  │    │    ├── best: (scan kuvw@uvw,cols=(7-9))
  │    │    └── cost: 1094.72
  │    └── []
  │         ├── best: (scan kuvw,cols=(7-9))
  │         └── cost: 1094.72
- ├── G18: (filters G21)
- ├── G19: (eq G15 G22)
- ├── G20: (projections G16)
- ├── G21: (eq G23 G16)
- ├── G22: (variable u)
- └── G23: (variable v)
+ ├── G17: (filters G20)
+ ├── G18: (eq G14 G21)
+ ├── G19: (projections G15)
+ ├── G20: (eq G22 G15)
+ ├── G21: (variable u)
+ └── G22: (variable v)
 
 # Ensure that streaming upsert-distinct-on will be used.
 memo

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -5149,8 +5149,7 @@ exec-ddl
 CREATE INDEX j_v1 ON virt (j, v1)
 ----
 
-# Covering case with a cross join for multiple constant values based on optional
-# filters.
+# Covering case with a set of possible values based on optional filters.
 opt
 SELECT m, virt.k, virt.v1 FROM small INNER LOOKUP JOIN virt ON m = virt.v1
 ----
@@ -5170,8 +5169,7 @@ project
       │    └── columns: m:1
       └── filters (true)
 
-# Non-covering case with a cross join for multiple constant values based on optional
-# filters.
+# Non-covering case with a set of possible values based on optional filters.
 opt
 SELECT m, virt.i, virt.k, virt.v1 FROM small INNER LOOKUP JOIN virt ON m = virt.v1
 ----
@@ -5239,8 +5237,7 @@ left-join (lookup virt)
  │    └── filters (true)
  └── filters (true)
 
-# Semi-join with a cross join for multiple constant values based on optional
-# filters.
+# Semi-join with a set of possible values based on optional filters.
 opt expect=GenerateLookupJoinsWithVirtualCols
 SELECT m FROM small WHERE EXISTS (SELECT * FROM virt WHERE m = virt.v1)
 ----
@@ -5650,8 +5647,7 @@ project
       │    └── filters (true)
       └── filters (true)
 
-# Covering case with a cross join for multiple constant values for the leading
-# lookup column.
+# Covering case with a set of possible values for the leading lookup column.
 opt expect=GenerateLookupJoinsWithVirtualColsAndFilter
 SELECT m, virt.k, virt.v1 FROM small INNER LOOKUP JOIN virt ON virt.i IN (1, 2, 3) AND m = virt.v1
 ----
@@ -5671,8 +5667,7 @@ project
       │    └── columns: m:1
       └── filters (true)
 
-# Non-covering case with a cross join for multiple constant values for the
-# leading lookup column.
+# Non-covering case with a set of possible values for the leading lookup column.
 opt expect=GenerateLookupJoinsWithVirtualColsAndFilter
 SELECT m, virt.j, virt.v1 FROM small INNER LOOKUP JOIN virt ON virt.i IN (1, 2, 3) AND m = virt.v1
 ----

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -2898,8 +2898,8 @@ left-join (lookup t59615 [as=t])
  ├── columns: y:1!null x:2 y:3 z:4
  ├── lookup expression
  │    └── filters
- │         ├── column1:1 = y:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
- │         └── x:2 IN (1, 3) [outer=(2), constraints=(/2: [/1 - /1] [/3 - /3]; tight)]
+ │         ├── x:2 IN (1, 3) [outer=(2), constraints=(/2: [/1 - /1] [/3 - /3]; tight)]
+ │         └── column1:1 = y:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
  ├── cardinality: [2 - ]
  ├── fd: (2,3)-->(4)
  ├── values
@@ -2919,8 +2919,8 @@ semi-join (lookup t59615 [as=t])
  ├── columns: y:1!null
  ├── lookup expression
  │    └── filters
- │         ├── column1:1 = y:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
- │         └── x:2 IN (1, 3) [outer=(2), constraints=(/2: [/1 - /1] [/3 - /3]; tight)]
+ │         ├── x:2 IN (1, 3) [outer=(2), constraints=(/2: [/1 - /1] [/3 - /3]; tight)]
+ │         └── column1:1 = y:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
  ├── cardinality: [0 - 2]
  ├── values
  │    ├── columns: column1:1!null
@@ -2938,8 +2938,8 @@ anti-join (lookup t59615 [as=t])
  ├── columns: y:1!null
  ├── lookup expression
  │    └── filters
- │         ├── column1:1 = y:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
- │         └── x:2 IN (1, 3) [outer=(2), constraints=(/2: [/1 - /1] [/3 - /3]; tight)]
+ │         ├── x:2 IN (1, 3) [outer=(2), constraints=(/2: [/1 - /1] [/3 - /3]; tight)]
+ │         └── column1:1 = y:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
  ├── cardinality: [0 - 2]
  ├── values
  │    ├── columns: column1:1!null
@@ -2982,8 +2982,8 @@ project
            ├── columns: column1:1!null r:3 k:4
            ├── lookup expression
            │    └── filters
-           │         ├── column1:1 = k:4 [outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
-           │         └── r:3 IN ('east', 'west') [outer=(3), constraints=(/3: [/'east' - /'east'] [/'west' - /'west']; tight)]
+           │         ├── r:3 IN ('east', 'west') [outer=(3), constraints=(/3: [/'east' - /'east'] [/'west' - /'west']; tight)]
+           │         └── column1:1 = k:4 [outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
            ├── cardinality: [3 - ]
            ├── values
            │    ├── columns: column1:1!null
@@ -3003,8 +3003,8 @@ anti-join (lookup lookup_expr [as=t])
  ├── columns: k:1!null
  ├── lookup expression
  │    └── filters
- │         ├── column1:1 = k:4 [outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
- │         └── r:3 IN ('east', 'west') [outer=(3), constraints=(/3: [/'east' - /'east'] [/'west' - /'west']; tight)]
+ │         ├── r:3 IN ('east', 'west') [outer=(3), constraints=(/3: [/'east' - /'east'] [/'west' - /'west']; tight)]
+ │         └── column1:1 = k:4 [outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
  ├── cardinality: [0 - 3]
  ├── values
  │    ├── columns: column1:1!null
@@ -3030,19 +3030,25 @@ left-join (lookup lookup_expr [as=t])
  │    ├── columns: column1:1!null column2:2 r:3 k:4 w:7 x:8 y:9 z:10
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── column2:2 = x:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
- │    │         ├── column1:1 = w:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
  │    │         ├── r:3 IN ('east', 'west') [outer=(3), constraints=(/3: [/'east' - /'east'] [/'west' - /'west']; tight)]
+ │    │         ├── column2:2 = x:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
  │    │         ├── y:9 IN (10, 20) [outer=(9), constraints=(/9: [/10 - /10] [/20 - /20]; tight)]
- │    │         └── z:10 = 5 [outer=(10), constraints=(/10: [/5 - /5]; tight), fd=()-->(10)]
+ │    │         ├── "lookup_join_const_col_@10":13 = z:10 [outer=(10,13), constraints=(/10: (/NULL - ]; /13: (/NULL - ]), fd=(10)==(13), (13)==(10)]
+ │    │         └── column1:1 = w:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
  │    ├── cardinality: [3 - ]
  │    ├── fd: (3,4)-->(7-10)
- │    ├── values
- │    │    ├── columns: column1:1!null column2:2
+ │    ├── project
+ │    │    ├── columns: "lookup_join_const_col_@10":13!null column1:1!null column2:2
  │    │    ├── cardinality: [3 - 3]
- │    │    ├── (1, 10)
- │    │    ├── (2, 20)
- │    │    └── (3, NULL)
+ │    │    ├── fd: ()-->(13)
+ │    │    ├── values
+ │    │    │    ├── columns: column1:1!null column2:2
+ │    │    │    ├── cardinality: [3 - 3]
+ │    │    │    ├── (1, 10)
+ │    │    │    ├── (2, 20)
+ │    │    │    └── (3, NULL)
+ │    │    └── projections
+ │    │         └── 5 [as="lookup_join_const_col_@10":13]
  │    └── filters (true)
  └── filters (true)
 
@@ -3062,8 +3068,8 @@ left-join (lookup lookup_expr [as=t])
  │    ├── columns: column1:1!null column2:2 r:3 k:4 u:5 v:6 w:7 y:9 z:10
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── column2:2 = u:5 [outer=(2,5), constraints=(/2: (/NULL - ]; /5: (/NULL - ]), fd=(2)==(5), (5)==(2)]
  │    │         ├── r:3 IN ('east', 'west') [outer=(3), constraints=(/3: [/'east' - /'east'] [/'west' - /'west']; tight)]
+ │    │         ├── column2:2 = u:5 [outer=(2,5), constraints=(/2: (/NULL - ]; /5: (/NULL - ]), fd=(2)==(5), (5)==(2)]
  │    │         └── y:9 IN (10, 20) [outer=(9), constraints=(/9: [/10 - /10] [/20 - /20]; tight)]
  │    ├── cardinality: [3 - ]
  │    ├── fd: (3,4)-->(5-7,9,10)
@@ -3093,8 +3099,8 @@ left-join (lookup lookup_expr [as=t])
  │    ├── lookup expression
  │    │    └── filters
  │    │         ├── column1:1 = v:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
- │    │         ├── column2:2 = w:7 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
- │    │         └── r:3 IN ('east', 'west') [outer=(3), constraints=(/3: [/'east' - /'east'] [/'west' - /'west']; tight)]
+ │    │         ├── r:3 IN ('east', 'west') [outer=(3), constraints=(/3: [/'east' - /'east'] [/'west' - /'west']; tight)]
+ │    │         └── column2:2 = w:7 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
  │    ├── cardinality: [3 - ]
  │    ├── fd: (3,4)-->(6,7)
  │    ├── values
@@ -3129,19 +3135,25 @@ left-join (lookup lookup_expr [as=t])
  │    ├── flags: force lookup join (into right side)
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── column2:2 = v:6 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
  │    │         ├── r:3 IN ('east', 'west') [outer=(3), constraints=(/3: [/'east' - /'east'] [/'west' - /'west']; tight)]
  │    │         ├── u:5 IN (1, 2) [outer=(5), constraints=(/5: [/1 - /1] [/2 - /2]; tight)]
  │    │         ├── y:9 IN (10, 20) [outer=(9), constraints=(/9: [/10 - /10] [/20 - /20]; tight)]
- │    │         └── z:10 = 5 [outer=(10), constraints=(/10: [/5 - /5]; tight), fd=()-->(10)]
+ │    │         ├── column2:2 = v:6 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
+ │    │         └── "lookup_join_const_col_@10":13 = z:10 [outer=(10,13), constraints=(/10: (/NULL - ]; /13: (/NULL - ]), fd=(10)==(13), (13)==(10)]
  │    ├── cardinality: [3 - ]
  │    ├── fd: (3,4)-->(5-7,9,10)
- │    ├── values
- │    │    ├── columns: column1:1!null column2:2
+ │    ├── project
+ │    │    ├── columns: "lookup_join_const_col_@10":13!null column1:1!null column2:2
  │    │    ├── cardinality: [3 - 3]
- │    │    ├── (1, 10)
- │    │    ├── (2, 20)
- │    │    └── (3, NULL)
+ │    │    ├── fd: ()-->(13)
+ │    │    ├── values
+ │    │    │    ├── columns: column1:1!null column2:2
+ │    │    │    ├── cardinality: [3 - 3]
+ │    │    │    ├── (1, 10)
+ │    │    │    ├── (2, 20)
+ │    │    │    └── (3, NULL)
+ │    │    └── projections
+ │    │         └── 5 [as="lookup_join_const_col_@10":13]
  │    └── filters (true)
  └── filters (true)
 
@@ -3282,7 +3294,7 @@ inner-join (lookup abcd@abcd_a_b_idx)
  ├── columns: a:6!null b:7!null n:2 m:1!null
  ├── lookup expression
  │    └── filters
- │         ├── a:6 = m:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │         ├── m:1 = a:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │         └── b:7 > 1 [outer=(7), constraints=(/7: [/2 - ]; tight)]
  ├── fd: (1)==(6), (6)==(1)
  ├── scan small
@@ -3297,7 +3309,7 @@ left-join (lookup abcd@abcd_a_b_idx)
  ├── columns: a:6 b:7 n:2 m:1
  ├── lookup expression
  │    └── filters
- │         ├── a:6 = m:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │         ├── m:1 = a:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │         └── b:7 > 1 [outer=(7), constraints=(/7: [/2 - ]; tight)]
  ├── scan small
  │    └── columns: m:1 n:2
@@ -3316,7 +3328,7 @@ inner-join (lookup abcd)
  │    ├── columns: m:1!null n:2 a:6!null b:7!null abcd.rowid:9!null
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── a:6 = m:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │    │         ├── m:1 = a:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    │         └── b:7 > 1 [outer=(7), constraints=(/7: [/2 - ]; tight)]
  │    ├── fd: (9)-->(6,7), (1)==(6), (6)==(1)
  │    ├── scan small
@@ -3336,7 +3348,7 @@ left-join (lookup abcd)
  │    ├── columns: m:1 n:2 a:6 b:7 abcd.rowid:9
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── a:6 = m:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │    │         ├── m:1 = a:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    │         └── b:7 > 1 [outer=(7), constraints=(/7: [/2 - ]; tight)]
  │    ├── fd: (9)-->(6,7)
  │    ├── scan small
@@ -3357,7 +3369,7 @@ inner-join (lookup abcd)
  │    ├── columns: m:1!null n:2!null a:6!null b:7!null abcd.rowid:9!null
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── a:6 = m:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │    │         ├── m:1 = a:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    │         └── b:7 > 1 [outer=(7), constraints=(/7: [/2 - ]; tight)]
  │    ├── fd: (9)-->(6,7), (1)==(6), (6)==(1)
  │    ├── scan small
@@ -3378,7 +3390,7 @@ left-join (lookup abcd)
  │    ├── columns: m:1 n:2 a:6 b:7 abcd.rowid:9
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── a:6 = m:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │    │         ├── m:1 = a:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    │         └── b:7 > 1 [outer=(7), constraints=(/7: [/2 - ]; tight)]
  │    ├── fd: (9)-->(6,7)
  │    ├── scan small
@@ -3400,7 +3412,7 @@ inner-join (lookup abcd)
  │    ├── columns: m:1!null n:2 a:6!null b:7!null abcd.rowid:9!null
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── a:6 = m:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │    │         ├── m:1 = a:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    │         └── b:7 > 1 [outer=(7), constraints=(/7: [/2 - ]; tight)]
  │    ├── fd: (9)-->(6,7), (1)==(6), (6)==(1)
  │    ├── scan small
@@ -3423,7 +3435,7 @@ left-join (lookup abcd)
  │    ├── columns: m:1 n:2 a:12 b:13 abcd.rowid:15 continuation:18
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── a:12 = m:1 [outer=(1,12), constraints=(/1: (/NULL - ]; /12: (/NULL - ]), fd=(1)==(12), (12)==(1)]
+ │    │         ├── m:1 = a:12 [outer=(1,12), constraints=(/1: (/NULL - ]; /12: (/NULL - ]), fd=(1)==(12), (12)==(1)]
  │    │         └── b:13 > 1 [outer=(13), constraints=(/13: [/2 - ]; tight)]
  │    ├── first join in paired joiner; continuation column: continuation:18
  │    ├── fd: (15)-->(12,13,18)
@@ -3512,7 +3524,7 @@ inner-join (lookup abcde)
  │    ├── columns: m:1!null n:2 a:6!null b:7!null c:8 abcde.rowid:11!null
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── a:6 = m:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │    │         ├── m:1 = a:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    │         └── b:7 IN (10, 20, 30) [outer=(7), constraints=(/7: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
  │    ├── fd: (11)-->(6-8), (1)==(6), (6)==(1)
  │    ├── scan small
@@ -3534,12 +3546,17 @@ inner-join (lookup abcde)
  │    ├── columns: m:1!null n:2 a:6!null b:7!null c:8!null abcde.rowid:11!null
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── a:6 = m:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │    │         ├── m:1 = a:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    │         ├── b:7 IN (10, 20, 30) [outer=(7), constraints=(/7: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
- │    │         └── c:8 = 10 [outer=(8), constraints=(/8: [/10 - /10]; tight), fd=()-->(8)]
+ │    │         └── "lookup_join_const_col_@8":14 = c:8 [outer=(8,14), constraints=(/8: (/NULL - ]; /14: (/NULL - ]), fd=(8)==(14), (14)==(8)]
  │    ├── fd: ()-->(8), (11)-->(6,7), (1)==(6), (6)==(1)
- │    ├── scan small
- │    │    └── columns: m:1 n:2
+ │    ├── project
+ │    │    ├── columns: "lookup_join_const_col_@8":14!null m:1 n:2
+ │    │    ├── fd: ()-->(14)
+ │    │    ├── scan small
+ │    │    │    └── columns: m:1 n:2
+ │    │    └── projections
+ │    │         └── 10 [as="lookup_join_const_col_@8":14]
  │    └── filters (true)
  └── filters (true)
 
@@ -3558,12 +3575,17 @@ inner-join (lookup abcde)
  │    ├── columns: m:1!null n:2 a:6!null b:7!null c:8!null abcde.rowid:11!null
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── a:6 = m:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
- │    │         ├── b:7 = 10 [outer=(7), constraints=(/7: [/10 - /10]; tight), fd=()-->(7)]
+ │    │         ├── m:1 = a:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │    │         ├── "lookup_join_const_col_@7":14 = b:7 [outer=(7,14), constraints=(/7: (/NULL - ]; /14: (/NULL - ]), fd=(7)==(14), (14)==(7)]
  │    │         └── c:8 IN (10, 20, 30) [outer=(8), constraints=(/8: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
  │    ├── fd: ()-->(7), (11)-->(6,8), (1)==(6), (6)==(1)
- │    ├── scan small
- │    │    └── columns: m:1 n:2
+ │    ├── project
+ │    │    ├── columns: "lookup_join_const_col_@7":14!null m:1 n:2
+ │    │    ├── fd: ()-->(14)
+ │    │    ├── scan small
+ │    │    │    └── columns: m:1 n:2
+ │    │    └── projections
+ │    │         └── 10 [as="lookup_join_const_col_@7":14]
  │    └── filters (true)
  └── filters (true)
 
@@ -3580,7 +3602,7 @@ inner-join (lookup abcde)
  │    ├── columns: m:1!null n:2 a:6!null b:7!null c:8!null abcde.rowid:11!null
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── a:6 = m:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │    │         ├── m:1 = a:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    │         ├── b:7 IN (10, 20) [outer=(7), constraints=(/7: [/10 - /10] [/20 - /20]; tight)]
  │    │         └── c:8 IN (30, 40) [outer=(8), constraints=(/8: [/30 - /30] [/40 - /40]; tight)]
  │    ├── fd: (11)-->(6-8), (1)==(6), (6)==(1)
@@ -3627,7 +3649,7 @@ inner-join (lookup abcde)
  │    ├── columns: m:1!null n:2 a:6!null b:7!null c:8 abcde.rowid:11!null
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── a:6 = m:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │    │         ├── m:1 = a:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    │         └── b:7 < 10 [outer=(7), constraints=(/7: (/NULL - /9]; tight)]
  │    ├── fd: (11)-->(6-8), (1)==(6), (6)==(1)
  │    ├── scan small
@@ -3761,7 +3783,7 @@ inner-join (lookup abcd_check)
  │    ├── columns: m:1!null n:2 a:6!null b:7!null c:8 abcd_check.rowid:10!null
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── a:6 = m:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │    │         ├── m:1 = a:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    │         └── b:7 IN (10, 20) [outer=(7), constraints=(/7: [/10 - /10] [/20 - /20]; tight)]
  │    ├── fd: (10)-->(6-8), (1)==(6), (6)==(1)
  │    ├── scan small
@@ -3781,12 +3803,17 @@ inner-join (lookup abcd_check)
  │    ├── columns: m:1!null n:2 a:6!null b:7!null c:8!null abcd_check.rowid:10!null
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── a:6 = m:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │    │         ├── m:1 = a:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    │         ├── b:7 IN (10, 20) [outer=(7), constraints=(/7: [/10 - /10] [/20 - /20]; tight)]
- │    │         └── c:8 = 30 [outer=(8), constraints=(/8: [/30 - /30]; tight), fd=()-->(8)]
+ │    │         └── "lookup_join_const_col_@8":13 = c:8 [outer=(8,13), constraints=(/8: (/NULL - ]; /13: (/NULL - ]), fd=(8)==(13), (13)==(8)]
  │    ├── fd: ()-->(8), (10)-->(6,7), (1)==(6), (6)==(1)
- │    ├── scan small
- │    │    └── columns: m:1 n:2
+ │    ├── project
+ │    │    ├── columns: "lookup_join_const_col_@8":13!null m:1 n:2
+ │    │    ├── fd: ()-->(13)
+ │    │    ├── scan small
+ │    │    │    └── columns: m:1 n:2
+ │    │    └── projections
+ │    │         └── 30 [as="lookup_join_const_col_@8":13]
  │    └── filters (true)
  └── filters (true)
 
@@ -4010,12 +4037,17 @@ inner-join (lookup t80525_bcd@t80525_bcd_b_c_d_idx)
  ├── flags: force lookup join (into right side)
  ├── lookup expression
  │    └── filters
- │         ├── b:5 = a:1 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
- │         ├── c:6 = false [outer=(6), constraints=(/6: [/false - /false]; tight), fd=()-->(6)]
+ │         ├── a:1 = b:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+ │         ├── "lookup_join_const_col_@6":11 = c:6 [outer=(6,11), constraints=(/6: (/NULL - ]; /11: (/NULL - ]), fd=(6)==(11), (11)==(6)]
  │         └── d:7 > 0 [outer=(7), constraints=(/7: [/1 - ]; tight)]
  ├── fd: ()-->(6), (1)==(5), (5)==(1)
- ├── scan t80525_a
- │    └── columns: a:1
+ ├── project
+ │    ├── columns: "lookup_join_const_col_@6":11!null a:1
+ │    ├── fd: ()-->(11)
+ │    ├── scan t80525_a
+ │    │    └── columns: a:1
+ │    └── projections
+ │         └── false [as="lookup_join_const_col_@6":11]
  └── filters (true)
 
 
@@ -5131,8 +5163,8 @@ project
       ├── flags: force lookup join (into right side)
       ├── lookup expression
       │    └── filters
-      │         ├── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
-      │         └── j:8 IN (10, 20, 30) [outer=(8), constraints=(/8: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
+      │         ├── j:8 IN (10, 20, 30) [outer=(8), constraints=(/8: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
+      │         └── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
       ├── fd: (6)-->(8,9), (1)==(9), (9)==(1)
       ├── scan small
       │    └── columns: m:1
@@ -5154,8 +5186,8 @@ inner-join (lookup virt)
  │    ├── flags: force lookup join (into right side)
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
- │    │         └── j:8 IN (10, 20, 30) [outer=(8), constraints=(/8: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
+ │    │         ├── j:8 IN (10, 20, 30) [outer=(8), constraints=(/8: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
+ │    │         └── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
  │    ├── fd: (6)-->(8,9), (1)==(9), (9)==(1)
  │    ├── scan small
  │    │    └── columns: m:1
@@ -5176,8 +5208,8 @@ project
       ├── flags: force lookup join (into right side)
       ├── lookup expression
       │    └── filters
-      │         ├── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
-      │         └── j:8 IN (10, 20, 30) [outer=(8), constraints=(/8: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
+      │         ├── j:8 IN (10, 20, 30) [outer=(8), constraints=(/8: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
+      │         └── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
       ├── fd: (6)-->(8,9)
       ├── scan small
       │    └── columns: m:1
@@ -5199,8 +5231,8 @@ left-join (lookup virt)
  │    ├── flags: force lookup join (into right side)
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
- │    │         └── j:8 IN (10, 20, 30) [outer=(8), constraints=(/8: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
+ │    │         ├── j:8 IN (10, 20, 30) [outer=(8), constraints=(/8: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
+ │    │         └── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
  │    ├── fd: (6)-->(8,9)
  │    ├── scan small
  │    │    └── columns: m:1
@@ -5216,8 +5248,8 @@ semi-join (lookup virt@j_v1)
  ├── columns: m:1
  ├── lookup expression
  │    └── filters
- │         ├── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
- │         └── j:8 IN (10, 20, 30) [outer=(8), constraints=(/8: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
+ │         ├── j:8 IN (10, 20, 30) [outer=(8), constraints=(/8: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
+ │         └── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
  ├── immutable
  ├── scan small
  │    └── columns: m:1
@@ -5231,8 +5263,8 @@ anti-join (lookup virt@j_v1)
  ├── columns: m:1
  ├── lookup expression
  │    └── filters
- │         ├── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
- │         └── j:8 IN (10, 20, 30) [outer=(8), constraints=(/8: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
+ │         ├── j:8 IN (10, 20, 30) [outer=(8), constraints=(/8: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
+ │         └── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
  ├── immutable
  ├── scan small
  │    └── columns: m:1
@@ -5632,8 +5664,8 @@ project
       ├── flags: force lookup join (into right side)
       ├── lookup expression
       │    └── filters
-      │         ├── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
-      │         └── i:7 IN (1, 2, 3) [outer=(7), constraints=(/7: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
+      │         ├── i:7 IN (1, 2, 3) [outer=(7), constraints=(/7: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
+      │         └── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
       ├── fd: (6)-->(7,9), (7)-->(9), (1)==(9), (9)==(1)
       ├── scan small
       │    └── columns: m:1
@@ -5655,8 +5687,8 @@ inner-join (lookup virt)
  │    ├── flags: force lookup join (into right side)
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
- │    │         └── i:7 IN (1, 2, 3) [outer=(7), constraints=(/7: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
+ │    │         ├── i:7 IN (1, 2, 3) [outer=(7), constraints=(/7: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
+ │    │         └── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
  │    ├── fd: (6)-->(7,9), (7)-->(9), (1)==(9), (9)==(1)
  │    ├── scan small
  │    │    └── columns: m:1
@@ -5722,8 +5754,8 @@ project
       ├── flags: force lookup join (into right side)
       ├── lookup expression
       │    └── filters
-      │         ├── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
-      │         └── i:7 IN (1, 2, 3) [outer=(7), constraints=(/7: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
+      │         ├── i:7 IN (1, 2, 3) [outer=(7), constraints=(/7: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
+      │         └── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
       ├── fd: (6)-->(7,9), (7)~~>(9)
       ├── scan small
       │    └── columns: m:1
@@ -5744,8 +5776,8 @@ left-join (lookup virt)
  │    ├── flags: force lookup join (into right side)
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
- │    │         └── i:7 IN (1, 2, 3) [outer=(7), constraints=(/7: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
+ │    │         ├── i:7 IN (1, 2, 3) [outer=(7), constraints=(/7: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
+ │    │         └── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
  │    ├── fd: (6)-->(7,9), (7)~~>(9)
  │    ├── scan small
  │    │    └── columns: m:1
@@ -5840,8 +5872,8 @@ semi-join (lookup virt@l_v1)
  ├── columns: m:1
  ├── lookup expression
  │    └── filters
- │         ├── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
- │         └── l:13 IN (1, 2, 3) [outer=(13), constraints=(/13: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
+ │         ├── l:13 IN (1, 2, 3) [outer=(13), constraints=(/13: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
+ │         └── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
  ├── immutable
  ├── scan small
  │    └── columns: m:1
@@ -5897,15 +5929,17 @@ anti-join (lookup virt@l_v1)
  └── filters (true)
 
 # Anti-join with multiple constant values for the leading lookup column.
-opt expect=GenerateLookupJoinsWithVirtualColsAndFilter
+# TODO
+# opt expect=GenerateLookupJoinsWithVirtualColsAndFilter
+opt
 SELECT m FROM small WHERE NOT EXISTS (SELECT * FROM virt WHERE virt.l IN (1, 2, 3) AND m = virt.v1)
 ----
 anti-join (lookup virt@l_v1)
  ├── columns: m:1
  ├── lookup expression
  │    └── filters
- │         ├── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
- │         └── l:13 IN (1, 2, 3) [outer=(13), constraints=(/13: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
+ │         ├── l:13 IN (1, 2, 3) [outer=(13), constraints=(/13: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
+ │         └── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
  ├── immutable
  ├── scan small
  │    └── columns: m:1
@@ -10464,6 +10498,11 @@ CREATE TABLE abc_part (
       PARTITION east VALUES IN (('east')),
       PARTITION west VALUES IN (('west')),
       PARTITION central VALUES IN (('central'))
+    ),
+    INDEX c_b_idx (r, c, b) PARTITION BY LIST (r) (
+      PARTITION east VALUES IN (('east')),
+      PARTITION west VALUES IN (('west')),
+      PARTITION central VALUES IN (('central'))
     )
 ) PARTITION BY LIST (r) (
   PARTITION east VALUES IN (('east')),
@@ -10530,6 +10569,27 @@ ALTER PARTITION "west" OF INDEX abc_part@c_idx CONFIGURE ZONE USING
 
 exec-ddl
 ALTER PARTITION "central" OF INDEX abc_part@c_idx CONFIGURE ZONE USING
+  num_voters = 5,
+  voter_constraints = '{+region=central: 2}',
+  lease_preferences = '[[+region=central]]';
+----
+
+exec-ddl
+ALTER PARTITION "east" OF INDEX abc_part@c_b_idx CONFIGURE ZONE USING
+  num_voters = 5,
+  voter_constraints = '{+region=east: 2}',
+  lease_preferences = '[[+region=east]]'
+----
+
+exec-ddl
+ALTER PARTITION "west" OF INDEX abc_part@c_b_idx CONFIGURE ZONE USING
+  num_voters = 5,
+  voter_constraints = '{+region=west: 2}',
+  lease_preferences = '[[+region=west]]';
+----
+
+exec-ddl
+ALTER PARTITION "central" OF INDEX abc_part@c_b_idx CONFIGURE ZONE USING
   num_voters = 5,
   voter_constraints = '{+region=central: 2}',
   lease_preferences = '[[+region=central]]';
@@ -10632,8 +10692,8 @@ anti-join (lookup abc_part)
  ├── columns: r:1!null d:2!null e:3 f:4
  ├── lookup expression
  │    └── filters
- │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
- │         └── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
+ │         ├── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
+ │         └── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
  ├── lookup columns are key
  ├── cardinality: [0 - 1]
  ├── key: ()
@@ -10643,8 +10703,8 @@ anti-join (lookup abc_part)
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
- │    │         └── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+ │    │         ├── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+ │    │         └── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
  │    ├── lookup columns are key
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
@@ -10683,8 +10743,8 @@ anti-join (lookup abc_part)
  ├── columns: r:1!null d:2!null e:3 f:4
  ├── lookup expression
  │    └── filters
- │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
- │         └── abc_part.r:7 IN ('central', 'east') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'east' - /'east']; tight)]
+ │         ├── abc_part.r:7 IN ('central', 'east') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'east' - /'east']; tight)]
+ │         └── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
  ├── lookup columns are key
  ├── cardinality: [0 - 1]
  ├── key: ()
@@ -10694,8 +10754,8 @@ anti-join (lookup abc_part)
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
- │    │         └── abc_part.r:7 = 'west' [outer=(7), constraints=(/7: [/'west' - /'west']; tight), fd=()-->(7)]
+ │    │         ├── abc_part.r:7 = 'west' [outer=(7), constraints=(/7: [/'west' - /'west']; tight), fd=()-->(7)]
+ │    │         └── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
  │    ├── lookup columns are key
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
@@ -10734,8 +10794,8 @@ anti-join (lookup abc_part@b_idx)
  ├── columns: r:1!null d:2!null e:3 f:4
  ├── lookup expression
  │    └── filters
- │         ├── f:4 = b:9 [outer=(4,9), constraints=(/4: (/NULL - ]; /9: (/NULL - ]), fd=(4)==(9), (9)==(4)]
- │         └── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
+ │         ├── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
+ │         └── f:4 = b:9 [outer=(4,9), constraints=(/4: (/NULL - ]; /9: (/NULL - ]), fd=(4)==(9), (9)==(4)]
  ├── lookup columns are key
  ├── cardinality: [0 - 1]
  ├── key: ()
@@ -10745,8 +10805,8 @@ anti-join (lookup abc_part@b_idx)
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── f:4 = b:9 [outer=(4,9), constraints=(/4: (/NULL - ]; /9: (/NULL - ]), fd=(4)==(9), (9)==(4)]
- │    │         └── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+ │    │         ├── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+ │    │         └── f:4 = b:9 [outer=(4,9), constraints=(/4: (/NULL - ]; /9: (/NULL - ]), fd=(4)==(9), (9)==(4)]
  │    ├── lookup columns are key
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
@@ -10785,8 +10845,8 @@ anti-join (lookup abc_part)
  ├── columns: r:1!null d:2!null e:3 f:4
  ├── lookup expression
  │    └── filters
- │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
- │         └── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
+ │         ├── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
+ │         └── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
  ├── lookup columns are key
  ├── cardinality: [0 - 1]
  ├── key: ()
@@ -10796,8 +10856,8 @@ anti-join (lookup abc_part)
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
- │    │         └── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+ │    │         ├── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+ │    │         └── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
  │    ├── lookup columns are key
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
@@ -10844,8 +10904,8 @@ distribute
       ├── columns: def_part.r:1!null d:2!null e:3 f:4!null
       ├── lookup expression
       │    └── filters
-      │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
-      │         └── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
+      │         ├── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
+      │         └── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
       ├── lookup columns are key
       ├── key: (2)
       ├── fd: ()-->(4), (2)-->(1,3), (3)~~>(1,2)
@@ -10853,8 +10913,8 @@ distribute
       │    ├── columns: def_part.r:1!null d:2!null e:3 f:4!null
       │    ├── lookup expression
       │    │    └── filters
-      │    │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
-      │    │         └── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+      │    │         ├── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+      │    │         └── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
       │    ├── lookup columns are key
       │    ├── key: (2)
       │    ├── fd: ()-->(4), (2)-->(1,3), (3)~~>(1,2)
@@ -10882,8 +10942,8 @@ anti-join (lookup abc_part@c_idx)
  ├── columns: r:1!null d:2!null e:3 f:4
  ├── lookup expression
  │    └── filters
- │         ├── f:4 = c:10 [outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ]), fd=(4)==(10), (10)==(4)]
- │         └── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
+ │         ├── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
+ │         └── f:4 = c:10 [outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ]), fd=(4)==(10), (10)==(4)]
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-4)
@@ -10892,8 +10952,8 @@ anti-join (lookup abc_part@c_idx)
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── f:4 = c:10 [outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ]), fd=(4)==(10), (10)==(4)]
- │    │         └── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+ │    │         ├── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+ │    │         └── f:4 = c:10 [outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ]), fd=(4)==(10), (10)==(4)]
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)
@@ -10932,8 +10992,8 @@ anti-join (lookup abc_part@c_idx)
  ├── columns: r:1!null d:2!null e:3 f:4
  ├── lookup expression
  │    └── filters
- │         ├── f:4 = c:10 [outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ]), fd=(4)==(10), (10)==(4)]
- │         └── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
+ │         ├── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
+ │         └── f:4 = c:10 [outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ]), fd=(4)==(10), (10)==(4)]
  ├── cardinality: [0 - 1]
  ├── immutable
  ├── key: ()
@@ -10943,8 +11003,8 @@ anti-join (lookup abc_part@c_idx)
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── f:4 = c:10 [outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ]), fd=(4)==(10), (10)==(4)]
- │    │         └── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+ │    │         ├── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+ │    │         └── f:4 = c:10 [outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ]), fd=(4)==(10), (10)==(4)]
  │    ├── cardinality: [0 - 1]
  │    ├── immutable
  │    ├── key: ()
@@ -10977,6 +11037,48 @@ anti-join (lookup abc_part@c_idx)
  └── filters
       └── (e:3 % a:8) = 0 [outer=(3,8), immutable]
 
+# The inner anti-join must produce the projected "lookup_join_const_col" because
+# it is referenced in both lookup expressions.
+opt locality=(region=east)
+SELECT * FROM (VALUES (2), (4)) v(i) WHERE NOT EXISTS (SELECT * FROM abc_part WHERE c = 1 AND b = i)
+----
+anti-join (lookup abc_part@c_b_idx)
+ ├── columns: i:1!null
+ ├── lookup expression
+ │    └── filters
+ │         ├── r:2 IN ('central', 'west') [outer=(2), constraints=(/2: [/'central' - /'central'] [/'west' - /'west']; tight)]
+ │         ├── "lookup_join_const_col_@5":18 = c:5 [outer=(5,18), constraints=(/5: (/NULL - ]; /18: (/NULL - ]), fd=(5)==(18), (18)==(5)]
+ │         └── column1:1 = b:4 [outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
+ ├── lookup columns are key
+ ├── cardinality: [0 - 2]
+ ├── distribution: east
+ ├── anti-join (lookup abc_part@c_b_idx)
+ │    ├── columns: column1:1!null "lookup_join_const_col_@5":18!null
+ │    ├── lookup expression
+ │    │    └── filters
+ │    │         ├── r:2 = 'east' [outer=(2), constraints=(/2: [/'east' - /'east']; tight), fd=()-->(2)]
+ │    │         ├── "lookup_join_const_col_@5":18 = c:5 [outer=(5,18), constraints=(/5: (/NULL - ]; /18: (/NULL - ]), fd=(5)==(18), (18)==(5)]
+ │    │         └── column1:1 = b:4 [outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
+ │    ├── lookup columns are key
+ │    ├── cardinality: [0 - 2]
+ │    ├── fd: ()-->(18)
+ │    ├── distribution: east
+ │    ├── project
+ │    │    ├── columns: "lookup_join_const_col_@5":18!null column1:1!null
+ │    │    ├── cardinality: [2 - 2]
+ │    │    ├── fd: ()-->(18)
+ │    │    ├── distribution: east
+ │    │    ├── values
+ │    │    │    ├── columns: column1:1!null
+ │    │    │    ├── cardinality: [2 - 2]
+ │    │    │    ├── distribution: east
+ │    │    │    ├── (2,)
+ │    │    │    └── (4,)
+ │    │    └── projections
+ │    │         └── 1 [as="lookup_join_const_col_@5":18]
+ │    └── filters (true)
+ └── filters (true)
+
 # Optimization does not apply for semi join.
 opt locality=(region=central) expect-not=GenerateLocalityOptimizedAntiJoin
 SELECT * FROM def_part WHERE EXISTS (SELECT * FROM abc_part WHERE e = a) AND d = 1
@@ -10985,12 +11087,12 @@ semi-join (lookup abc_part)
  ├── columns: r:1!null d:2!null e:3 f:4
  ├── lookup expression
  │    └── filters
- │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
- │         └── abc_part.r:7 = 'central' [outer=(7), constraints=(/7: [/'central' - /'central']; tight), fd=()-->(7)]
+ │         ├── abc_part.r:7 = 'central' [outer=(7), constraints=(/7: [/'central' - /'central']; tight), fd=()-->(7)]
+ │         └── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
  ├── remote lookup expression
  │    └── filters
- │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
- │         └── abc_part.r:7 IN ('east', 'west') [outer=(7), constraints=(/7: [/'east' - /'east'] [/'west' - /'west']; tight)]
+ │         ├── abc_part.r:7 IN ('east', 'west') [outer=(7), constraints=(/7: [/'east' - /'east'] [/'west' - /'west']; tight)]
+ │         └── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
  ├── lookup columns are key
  ├── cardinality: [0 - 1]
  ├── key: ()
@@ -11020,6 +11122,10 @@ semi-join (lookup abc_part)
  │         └── fd: ()-->(20-23)
  └── filters (true)
 
+exec-ddl
+DROP INDEX c_b_idx
+----
+
 # --------------------------------------------------
 # GenerateLocalityOptimizedLookupJoin
 # --------------------------------------------------
@@ -11039,12 +11145,12 @@ project
  │    ├── columns: def_part.r:1!null d:2!null e:3!null f:4 abc_part.r:7!null a:8!null b:9 c:10
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
- │    │         └── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+ │    │         ├── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+ │    │         └── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
  │    ├── remote lookup expression
  │    │    └── filters
- │    │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
- │    │         └── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
+ │    │         ├── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
+ │    │         └── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
  │    ├── lookup columns are key
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
@@ -11091,12 +11197,12 @@ project
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4 abc_part.r:7 a:8 b:9 c:10
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
- │    │         └── abc_part.r:7 = 'west' [outer=(7), constraints=(/7: [/'west' - /'west']; tight), fd=()-->(7)]
+ │    │         ├── abc_part.r:7 = 'west' [outer=(7), constraints=(/7: [/'west' - /'west']; tight), fd=()-->(7)]
+ │    │         └── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
  │    ├── remote lookup expression
  │    │    └── filters
- │    │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
- │    │         └── abc_part.r:7 IN ('central', 'east') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'east' - /'east']; tight)]
+ │    │         ├── abc_part.r:7 IN ('central', 'east') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'east' - /'east']; tight)]
+ │    │         └── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
  │    ├── lookup columns are key
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
@@ -11136,12 +11242,12 @@ semi-join (lookup abc_part)
  ├── columns: r:1!null d:2!null e:3 f:4
  ├── lookup expression
  │    └── filters
- │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
- │         └── abc_part.r:7 = 'central' [outer=(7), constraints=(/7: [/'central' - /'central']; tight), fd=()-->(7)]
+ │         ├── abc_part.r:7 = 'central' [outer=(7), constraints=(/7: [/'central' - /'central']; tight), fd=()-->(7)]
+ │         └── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
  ├── remote lookup expression
  │    └── filters
- │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
- │         └── abc_part.r:7 IN ('east', 'west') [outer=(7), constraints=(/7: [/'east' - /'east'] [/'west' - /'west']; tight)]
+ │         ├── abc_part.r:7 IN ('east', 'west') [outer=(7), constraints=(/7: [/'east' - /'east'] [/'west' - /'west']; tight)]
+ │         └── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
  ├── lookup columns are key
  ├── cardinality: [0 - 1]
  ├── key: ()
@@ -11179,12 +11285,12 @@ semi-join (lookup abc_part)
  ├── columns: r:1!null d:2!null e:3 f:4
  ├── lookup expression
  │    └── filters
- │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
- │         └── abc_part.r:7 = 'west' [outer=(7), constraints=(/7: [/'west' - /'west']; tight), fd=()-->(7)]
+ │         ├── abc_part.r:7 = 'west' [outer=(7), constraints=(/7: [/'west' - /'west']; tight), fd=()-->(7)]
+ │         └── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
  ├── remote lookup expression
  │    └── filters
- │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
- │         └── abc_part.r:7 IN ('central', 'east') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'east' - /'east']; tight)]
+ │         ├── abc_part.r:7 IN ('central', 'east') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'east' - /'east']; tight)]
+ │         └── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
  ├── lookup columns are key
  ├── cardinality: [0 - 1]
  ├── key: ()
@@ -11238,12 +11344,12 @@ project
  │    │    ├── columns: def_part.r:1!null d:2!null e:3 f:4!null abc_part.r:7!null a:8!null b:9!null
  │    │    ├── lookup expression
  │    │    │    └── filters
- │    │    │         ├── f:4 = b:9 [outer=(4,9), constraints=(/4: (/NULL - ]; /9: (/NULL - ]), fd=(4)==(9), (9)==(4)]
- │    │    │         └── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+ │    │    │         ├── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+ │    │    │         └── f:4 = b:9 [outer=(4,9), constraints=(/4: (/NULL - ]; /9: (/NULL - ]), fd=(4)==(9), (9)==(4)]
  │    │    ├── remote lookup expression
  │    │    │    └── filters
- │    │    │         ├── f:4 = b:9 [outer=(4,9), constraints=(/4: (/NULL - ]; /9: (/NULL - ]), fd=(4)==(9), (9)==(4)]
- │    │    │         └── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
+ │    │    │         ├── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
+ │    │    │         └── f:4 = b:9 [outer=(4,9), constraints=(/4: (/NULL - ]; /9: (/NULL - ]), fd=(4)==(9), (9)==(4)]
  │    │    ├── lookup columns are key
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
@@ -11291,12 +11397,12 @@ project
  │    ├── columns: def_part.r:1!null d:2!null e:3!null f:4!null abc_part.r:7!null a:8!null b:9!null c:10
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
- │    │         └── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+ │    │         ├── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+ │    │         └── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
  │    ├── remote lookup expression
  │    │    └── filters
- │    │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
- │    │         └── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
+ │    │         ├── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
+ │    │         └── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
  │    ├── lookup columns are key
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
@@ -11349,12 +11455,12 @@ distribute
       │    ├── columns: def_part.r:1!null d:2!null e:3!null f:4!null abc_part.r:7!null a:8!null b:9 c:10
       │    ├── lookup expression
       │    │    └── filters
-      │    │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
-      │    │         └── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+      │    │         ├── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+      │    │         └── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
       │    ├── remote lookup expression
       │    │    └── filters
-      │    │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
-      │    │         └── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
+      │    │         ├── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
+      │    │         └── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
       │    ├── lookup columns are key
       │    ├── key: (2)
       │    ├── fd: ()-->(4), (2)-->(1,3), (3)-->(1,2), (8)-->(7,9,10), (9)~~>(7,8,10), (3)==(8), (8)==(3)
@@ -11383,12 +11489,12 @@ semi-join (lookup abc_part@c_idx)
  ├── columns: r:1!null d:2!null e:3 f:4
  ├── lookup expression
  │    └── filters
- │         ├── f:4 = c:10 [outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ]), fd=(4)==(10), (10)==(4)]
- │         └── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+ │         ├── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+ │         └── f:4 = c:10 [outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ]), fd=(4)==(10), (10)==(4)]
  ├── remote lookup expression
  │    └── filters
- │         ├── f:4 = c:10 [outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ]), fd=(4)==(10), (10)==(4)]
- │         └── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
+ │         ├── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
+ │         └── f:4 = c:10 [outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ]), fd=(4)==(10), (10)==(4)]
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-4)
@@ -11419,15 +11525,18 @@ semi-join (lookup abc_part@c_idx)
 
 # Optimization does not apply for a semi join that may have more than one
 # matching row when there is an ON condition.
-opt locality=(region=east) expect-not=GenerateLocalityOptimizedLookupJoin
+# NOTE: A locality optimized lookup join is possible here after the join has
+# been reordered (because d is a lax key), so we prevent reordering to test this
+# case and ensure the expect-not holds.
+opt locality=(region=east) expect-not=GenerateLocalityOptimizedLookupJoin join-limit=0
 SELECT * FROM def_part WHERE EXISTS (SELECT * FROM abc_part WHERE f = c AND e % a = 0) AND d = 10
 ----
 semi-join (lookup abc_part@c_idx)
  ├── columns: r:1!null d:2!null e:3 f:4
  ├── lookup expression
  │    └── filters
- │         ├── f:4 = c:10 [outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ]), fd=(4)==(10), (10)==(4)]
- │         └── abc_part.r:7 IN ('central', 'east', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'east' - /'east'] [/'west' - /'west']; tight)]
+ │         ├── abc_part.r:7 IN ('central', 'east', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'east' - /'east'] [/'west' - /'west']; tight)]
+ │         └── f:4 = c:10 [outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ]), fd=(4)==(10), (10)==(4)]
  ├── cardinality: [0 - 1]
  ├── immutable
  ├── key: ()
@@ -11460,7 +11569,10 @@ semi-join (lookup abc_part@c_idx)
 
 # Optimization does not apply for an inner join since the lookup join may have more than one
 # matching row.
-opt locality=(region=east) expect-not=GenerateLocalityOptimizedLookupJoin
+# NOTE: A locality optimized lookup join is possible here after the join has
+# been reordered (because d is a lax key), so we prevent reordering to test this
+# case and ensure the expect-not holds.
+opt locality=(region=east) expect-not=GenerateLocalityOptimizedLookupJoin join-limit=0
 SELECT * FROM def_part INNER JOIN abc_part ON f = c WHERE d = 10
 ----
 project
@@ -11480,8 +11592,8 @@ project
  │    │    ├── columns: def_part.r:1!null d:2!null e:3 f:4!null abc_part.r:7!null a:8!null c:10!null
  │    │    ├── lookup expression
  │    │    │    └── filters
- │    │    │         ├── f:4 = c:10 [outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ]), fd=(4)==(10), (10)==(4)]
- │    │    │         └── abc_part.r:7 IN ('central', 'east', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'east' - /'east'] [/'west' - /'west']; tight)]
+ │    │    │         ├── abc_part.r:7 IN ('central', 'east', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'east' - /'east'] [/'west' - /'west']; tight)]
+ │    │    │         └── f:4 = c:10 [outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ]), fd=(4)==(10), (10)==(4)]
  │    │    ├── key: (8)
  │    │    ├── fd: ()-->(1-4,10), (8)-->(7), (4)==(10), (10)==(4)
  │    │    ├── distribution: east
@@ -11520,8 +11632,8 @@ anti-join (lookup abc_part)
  ├── columns: r:1!null d:2!null e:3 f:4
  ├── lookup expression
  │    └── filters
- │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
- │         └── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
+ │         ├── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
+ │         └── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
  ├── lookup columns are key
  ├── cardinality: [0 - 1]
  ├── key: ()
@@ -11531,8 +11643,8 @@ anti-join (lookup abc_part)
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
- │    │         └── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+ │    │         ├── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+ │    │         └── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
  │    ├── lookup columns are key
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
@@ -11565,7 +11677,10 @@ anti-join (lookup abc_part)
 
 # We do not currently support locality optimized lookup joins on indexes with
 # virtual columns.
-opt locality=(region=east) expect-not=GenerateLocalityOptimizedLookupJoin
+# NOTE: A locality optimized lookup join is possible here after the join has
+# been reordered, so we prevent reordering to test this case and ensure the
+# expect-not holds.
+opt locality=(region=east) expect-not=GenerateLocalityOptimizedLookupJoin join-limit=0
 SELECT * FROM def_part INNER JOIN abc_part ON f = v WHERE d = 1
 ----
 inner-join (lookup abc_part)
@@ -11580,8 +11695,8 @@ inner-join (lookup abc_part)
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4!null abc_part.r:7!null a:8!null v:11!null
  │    ├── lookup expression
  │    │    └── filters
- │    │         ├── f:4 = v:11 [outer=(4,11), constraints=(/4: (/NULL - ]; /11: (/NULL - ]), fd=(4)==(11), (11)==(4)]
- │    │         └── abc_part.r:7 IN ('central', 'east', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'east' - /'east'] [/'west' - /'west']; tight)]
+ │    │         ├── abc_part.r:7 IN ('central', 'east', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'east' - /'east'] [/'west' - /'west']; tight)]
+ │    │         └── f:4 = v:11 [outer=(4,11), constraints=(/4: (/NULL - ]; /11: (/NULL - ]), fd=(4)==(11), (11)==(4)]
  │    ├── lookup columns are key
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
@@ -11686,7 +11801,7 @@ inner-join (lookup metric_values)
  ├── columns: metric_id:1!null time:2!null value:3 id:6!null name:7!null
  ├── lookup expression
  │    └── filters
- │         ├── metric_id:1 = id:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │         ├── id:6 = metric_id:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │         └── (time:2 >= '2020-01-01 00:00:00+00:00') AND (time:2 <= '2020-01-01 00:10:00+00:00') [outer=(2), constraints=(/2: [/'2020-01-01 00:00:00+00:00' - /'2020-01-01 00:10:00+00:00']; tight)]
  ├── key: (2,6)
  ├── fd: ()-->(7), (1,2)-->(3), (1)==(6), (6)==(1)
@@ -11710,7 +11825,7 @@ inner-join (lookup metric_values)
  ├── columns: metric_id:1!null time:2!null value:3 id:6!null name:7!null
  ├── lookup expression
  │    └── filters
- │         ├── metric_id:1 = id:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │         ├── id:6 = metric_id:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │         └── (time:2 >= '2020-01-01 00:00:00+00:00') AND (time:2 <= '2020-01-01 00:10:00+00:00') [outer=(2), constraints=(/2: [/'2020-01-01 00:00:00+00:00' - /'2020-01-01 00:10:00+00:00']; tight)]
  ├── key: (2,6)
  ├── fd: (1,2)-->(3), (6)-->(7), (1)==(6), (6)==(1)
@@ -11740,7 +11855,7 @@ inner-join (lookup metric_values)
  ├── columns: metric_id:1!null time:2!null value:3 id:6!null name:7!null
  ├── lookup expression
  │    └── filters
- │         ├── metric_id:1 = id:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │         ├── id:6 = metric_id:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │         └── time:2 IN ('2022-04-08 00:00:00+00:00', '2022-04-09 00:00:00+00:00') [outer=(2), constraints=(/2: [/'2022-04-08 00:00:00+00:00' - /'2022-04-08 00:00:00+00:00'] [/'2022-04-09 00:00:00+00:00' - /'2022-04-09 00:00:00+00:00']; tight)]
  ├── key: (2,6)
  ├── fd: ()-->(7), (1,2)-->(3), (1)==(6), (6)==(1)
@@ -11788,7 +11903,7 @@ left-join (lookup metric_values)
  ├── columns: id:1!null name:2 metric_id:5 time:6 value:7
  ├── lookup expression
  │    └── filters
- │         ├── metric_id:5 = id:1 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+ │         ├── id:1 = metric_id:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
  │         └── (time:6 >= '2020-01-01 00:00:00+00:00') AND (time:6 <= '2020-01-01 00:10:00+00:00') [outer=(6), constraints=(/6: [/'2020-01-01 00:00:00+00:00' - /'2020-01-01 00:10:00+00:00']; tight)]
  ├── key: (1,5,6)
  ├── fd: (1)-->(2), (5,6)-->(7)

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -312,7 +312,7 @@ New expression 3 of 3:
 memo join-limit=0 expect-not=ReorderJoins
 SELECT * FROM bx, cy, abc WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
-memo (optimized, ~27KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12])
+memo (optimized, ~22KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12])
  ├── G1: (inner-join G2 G3 G4) (merge-join G2 G3 G5 inner-join,+1,+10)
  │    └── [presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12]
  │         ├── best: (merge-join G2="[ordering: +1]" G3 G5 inner-join,+1,+10)
@@ -324,11 +324,11 @@ memo (optimized, ~27KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:
  │    └── []
  │         ├── best: (scan bx,cols=(1,2))
  │         └── cost: 1064.42
- ├── G3: (inner-join G6 G7 G8) (merge-join G6 G7 G5 inner-join,+5,+11) (lookup-join G9 G8 abc,keyCols=[15],outCols=(5,6,9-12))
+ ├── G3: (inner-join G6 G7 G8) (merge-join G6 G7 G5 inner-join,+5,+11)
  │    └── []
  │         ├── best: (merge-join G6="[ordering: +5]" G7 G5 inner-join,+5,+11)
  │         └── cost: 1078.54
- ├── G4: (filters G10)
+ ├── G4: (filters G9)
  ├── G5: (filters)
  ├── G6: (scan cy,cols=(5,6))
  │    ├── [ordering: +5]
@@ -337,35 +337,30 @@ memo (optimized, ~27KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:
  │    └── []
  │         ├── best: (scan cy,cols=(5,6))
  │         └── cost: 1064.42
- ├── G7: (select G11 G12) (scan abc,cols=(9-12),constrained)
+ ├── G7: (select G10 G11) (scan abc,cols=(9-12),constrained)
  │    └── []
  │         ├── best: (scan abc,cols=(9-12),constrained)
  │         └── cost: 5.09
- ├── G8: (filters G13)
- ├── G9: (project G6 G14 c y)
- │    └── []
- │         ├── best: (project G6 G14 c y)
- │         └── cost: 1084.44
- ├── G10: (eq G15 G16)
- ├── G11: (scan abc,cols=(9-12))
+ ├── G8: (filters G12)
+ ├── G9: (eq G13 G14)
+ ├── G10: (scan abc,cols=(9-12))
  │    └── []
  │         ├── best: (scan abc,cols=(9-12))
  │         └── cost: 1104.82
- ├── G12: (filters G17)
- ├── G13: (eq G18 G19)
- ├── G14: (projections G20)
- ├── G15: (variable abc.b)
- ├── G16: (variable bx.b)
- ├── G17: (eq G21 G20)
- ├── G18: (variable abc.c)
- ├── G19: (variable cy.c)
- ├── G20: (const 1)
- └── G21: (variable a)
+ ├── G11: (filters G15)
+ ├── G12: (eq G16 G17)
+ ├── G13: (variable abc.b)
+ ├── G14: (variable bx.b)
+ ├── G15: (eq G18 G19)
+ ├── G16: (variable abc.c)
+ ├── G17: (variable cy.c)
+ ├── G18: (variable a)
+ └── G19: (const 1)
 
 memo join-limit=2
 SELECT * FROM bx, cy, abc WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
-memo (optimized, ~43KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12])
+memo (optimized, ~33KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G7) (inner-join G6 G5 G7) (merge-join G2 G3 G8 inner-join,+1,+10) (merge-join G3 G2 G8 inner-join,+10,+1) (lookup-join G3 G8 bx,keyCols=[10],outCols=(1,2,5,6,9-12)) (merge-join G5 G6 G8 inner-join,+5,+11) (merge-join G6 G5 G8 inner-join,+11,+5) (lookup-join G6 G8 cy,keyCols=[11],outCols=(1,2,5,6,9-12))
  │    └── [presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12]
  │         ├── best: (lookup-join G3 G8 bx,keyCols=[10],outCols=(1,2,5,6,9-12))
@@ -377,11 +372,11 @@ memo (optimized, ~43KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:
  │    └── []
  │         ├── best: (scan bx,cols=(1,2))
  │         └── cost: 1064.42
- ├── G3: (inner-join G5 G9 G7) (inner-join G9 G5 G7) (merge-join G5 G9 G8 inner-join,+5,+11) (lookup-join G10 G7 abc,keyCols=[15],outCols=(5,6,9-12)) (merge-join G9 G5 G8 inner-join,+11,+5) (lookup-join G9 G8 cy,keyCols=[11],outCols=(5,6,9-12))
+ ├── G3: (inner-join G5 G9 G7) (inner-join G9 G5 G7) (merge-join G5 G9 G8 inner-join,+5,+11) (merge-join G9 G5 G8 inner-join,+11,+5) (lookup-join G9 G8 cy,keyCols=[11],outCols=(5,6,9-12))
  │    └── []
  │         ├── best: (lookup-join G9 G8 cy,keyCols=[11],outCols=(5,6,9-12))
  │         └── cost: 11.13
- ├── G4: (filters G11)
+ ├── G4: (filters G10)
  ├── G5: (scan cy,cols=(5,6))
  │    ├── [ordering: +5]
  │    │    ├── best: (scan cy,cols=(5,6))
@@ -389,39 +384,30 @@ memo (optimized, ~43KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:
  │    └── []
  │         ├── best: (scan cy,cols=(5,6))
  │         └── cost: 1064.42
- ├── G6: (inner-join G2 G9 G4) (inner-join G9 G2 G4) (merge-join G2 G9 G8 inner-join,+1,+10) (lookup-join G12 G4 abc,keyCols=[16],outCols=(1,2,9-12)) (merge-join G9 G2 G8 inner-join,+10,+1) (lookup-join G9 G8 bx,keyCols=[10],outCols=(1,2,9-12))
+ ├── G6: (inner-join G2 G9 G4) (inner-join G9 G2 G4) (merge-join G2 G9 G8 inner-join,+1,+10) (merge-join G9 G2 G8 inner-join,+10,+1) (lookup-join G9 G8 bx,keyCols=[10],outCols=(1,2,9-12))
  │    └── []
  │         ├── best: (lookup-join G9 G8 bx,keyCols=[10],outCols=(1,2,9-12))
  │         └── cost: 11.13
- ├── G7: (filters G13)
+ ├── G7: (filters G11)
  ├── G8: (filters)
- ├── G9: (select G14 G15) (scan abc,cols=(9-12),constrained)
+ ├── G9: (select G12 G13) (scan abc,cols=(9-12),constrained)
  │    └── []
  │         ├── best: (scan abc,cols=(9-12),constrained)
  │         └── cost: 5.09
- ├── G10: (project G5 G16 c y)
- │    └── []
- │         ├── best: (project G5 G16 c y)
- │         └── cost: 1084.44
- ├── G11: (eq G17 G18)
- ├── G12: (project G2 G16 b x)
- │    └── []
- │         ├── best: (project G2 G16 b x)
- │         └── cost: 1084.44
- ├── G13: (eq G19 G20)
- ├── G14: (scan abc,cols=(9-12))
+ ├── G10: (eq G14 G15)
+ ├── G11: (eq G16 G17)
+ ├── G12: (scan abc,cols=(9-12))
  │    └── []
  │         ├── best: (scan abc,cols=(9-12))
  │         └── cost: 1104.82
- ├── G15: (filters G21)
- ├── G16: (projections G22)
- ├── G17: (variable abc.b)
- ├── G18: (variable bx.b)
- ├── G19: (variable abc.c)
- ├── G20: (variable cy.c)
- ├── G21: (eq G23 G22)
- ├── G22: (const 1)
- └── G23: (variable a)
+ ├── G13: (filters G18)
+ ├── G14: (variable abc.b)
+ ├── G15: (variable bx.b)
+ ├── G16: (variable abc.c)
+ ├── G17: (variable cy.c)
+ ├── G18: (eq G19 G20)
+ ├── G19: (variable a)
+ └── G20: (const 1)
 
 opt join-limit=3 expect=ReorderJoins
 SELECT * FROM bx, cy, dz, abc WHERE a = 1


### PR DESCRIPTION
#### opt: simplify lookup join constraint building

The lookup join constraint builder has been simplified so that it builds
constraints in a single pass over an index's columns. This is in
contrast to the previous method which would require a second pass over
the index's columns after it was discovered that a multi-span lookup
join with a lookup expression would be required. This change has a
number of consequences:

  1. Lookup joins can be planned in more cases. As an example, a lookup
     join can now be planned when there is an equality filter on a
     indexed computed column and a range filter on another indexed
     column.
  2. Constant value filters, like `x = 1`, are no longer included in
     lookup expressions. Instead, the constant value will be projected
     and the lookup expression will contain an equality and the
     projected column, like `x = projected_col`. This should have
     little, if any, effect on the performance of lookup joins.

This change required a minor change to the
`GenerateLocalityOptimizedAntiJoin` rule to ensure that projected
constant values are produced by the the inner anti-join. This is
necessary because the outer anti-join's lookup expression references the
projected column. This wasn't previously necessary because constant
values weren't projected and referenced in lookup expressions - they
were inlined directly in lookup expressions.

Release note: None

#### opt: remove "cross-join" from some tests

As of #79586, we no longer plan cross-joins as inputs of lookup joins.
This commit updates some test comments to reflect this.

Release note: None
