### PR TITLE
ui: Add table to Jobs page showing errors

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementsTable/activeStatementsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementsTable/activeStatementsTable.tsx
@@ -26,7 +26,7 @@ import {
   ExecutionsColumn,
 } from "../execTableCommon";
 
-interface ActiveStatementsTable {
+interface ActiveStatementsTableProps {
   data: ActiveStatement[];
   sortSetting: SortSetting;
   onChangeSortSetting: (ss: SortSetting) => void;
@@ -107,7 +107,7 @@ export function getColumnOptions(
     }));
 }
 
-export const ActiveStatementsTable: React.FC<ActiveStatementsTable> = props => {
+export const ActiveStatementsTable: React.FC<ActiveStatementsTableProps> = props => {
   const { selectedColumns, ...rest } = props;
   const columns = makeActiveStatementsColumns().filter(col =>
     isSelectedColumn(selectedColumns, col),

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeTransactionsTable/activeTransactionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeTransactionsTable/activeTransactionsTable.tsx
@@ -26,7 +26,7 @@ import {
   ExecutionsColumn,
 } from "../execTableCommon";
 
-interface ActiveTransactionsTable {
+interface ActiveTransactionsTableProps {
   data: ActiveTransaction[];
   sortSetting: SortSetting;
   onChangeSortSetting: (ss: SortSetting) => void;
@@ -121,7 +121,7 @@ export function getColumnOptions(
     }));
 }
 
-export const ActiveTransactionsTable: React.FC<ActiveTransactionsTable> = props => {
+export const ActiveTransactionsTable: React.FC<ActiveTransactionsTableProps> = props => {
   const { selectedColumns, ...rest } = props;
   const columns = makeActiveTransactionsColumns().filter(col =>
     isSelectedColumn(selectedColumns, col),

--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.stories.tsx
@@ -8,30 +8,66 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import React from "react";
+import React, { useState } from "react";
 import { storiesOf } from "@storybook/react";
 
-import { SortedTable } from "./";
+import { SortedTable, SortSetting } from "./";
+
+export function SortedTableWrapper(): React.ReactElement {
+  const [sortSetting, setSortSetting] = useState<SortSetting>({
+    ascending: true,
+    columnTitle: "col1",
+  });
+  const columns = [
+    {
+      name: "col1",
+      title: "Col 1",
+      cell: (idx: number) => `Col 1: row-${idx}`,
+      sort: (idx: number) => idx,
+    },
+    {
+      name: "col2",
+      title: "Col 2",
+      cell: (idx: number) => `Col 2: row-${idx}`,
+      sort: (idx: number) => idx,
+    },
+    {
+      name: "col3",
+      title: "Col 3",
+      cell: (idx: number) => `Col 3: row-${idx}`,
+      sort: (idx: number) => idx,
+    },
+  ];
+  return (
+    <SortedTable
+      columns={columns}
+      data={[1, 2, 3]}
+      sortSetting={sortSetting}
+      onChangeSortSetting={setSortSetting}
+    />
+  );
+}
 
 storiesOf("Sorted table", module)
   .add("Empty state", () => <SortedTable empty />)
-  .add("With data", () => {
+  .add("No sort", () => {
     const columns = [
       {
-        name: "Col 1",
+        name: "col1",
         title: "Col 1",
-        cell: (idx: number) => `row-${idx} col-1`,
+        cell: (idx: number) => `Col 1: row-${idx}`,
       },
       {
-        name: "Col 2",
+        name: "col2",
         title: "Col 2",
-        cell: (idx: number) => `row-${idx} col-2`,
+        cell: (idx: number) => `Col 2: row-${idx}`,
       },
       {
-        name: "Col 3",
+        name: "col3",
         title: "Col 3",
-        cell: (idx: number) => `row-${idx} col-3`,
+        cell: (idx: number) => `Col 3: row-${idx}`,
       },
     ];
     return <SortedTable columns={columns} data={[1, 2, 3]} />;
-  });
+  })
+  .add("With sort", () => <SortedTableWrapper />);

--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobDetails.fixture.ts
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobDetails.fixture.ts
@@ -1,0 +1,132 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { JobDetailsProps } from "src/views/jobs/jobDetails";
+import { cockroach } from "src/js/protos";
+import Job = cockroach.server.serverpb.JobResponse;
+type Timestamp = protos.google.protobuf.ITimestamp;
+import { createMemoryHistory } from "history";
+import Long from "long";
+import { defaultJobProperties } from "src/views/jobs/jobsShared.fixture";
+import * as protos from "src/js/protos";
+
+const history = createMemoryHistory({ initialEntries: ["/statements"] });
+
+export const getJobDetailsProps = (job: Job): JobDetailsProps => {
+  return {
+    history,
+    location: {
+      pathname: "/jobs/760621514586259457",
+      search: "",
+      hash: "",
+      state: undefined,
+    },
+    match: {
+      path: "/jobs/:id",
+      url: "/jobs/760621514586259457",
+      isExact: true,
+      params: { id: "/jobs/760621514586259457" },
+    },
+    sort: {
+      columnTitle: "startTime",
+      ascending: false,
+    },
+    setSort: () => {},
+    refreshJob: () => null,
+    job: job,
+  };
+};
+
+export const succeededJobProps = getJobDetailsProps(
+  new Job({
+    ...defaultJobProperties,
+    id: new Long(7003330561, 70312826),
+    type: "SCHEMA CHANGE",
+    description:
+      "ALTER TABLE movr.public.user_promo_codes ADD FOREIGN KEY (city, user_id) REFERENCES movr.public.users (city, id)",
+    status: "succeeded",
+  }),
+);
+
+export const failedJobProps = getJobDetailsProps(
+  new Job({
+    ...defaultJobProperties,
+    id: new Long(7003330561, 70312826),
+    type: "SCHEMA CHANGE",
+    description:
+      "ALTER TABLE movr.public.user_promo_codes ADD FOREIGN KEY (city, user_id) REFERENCES movr.public.users (city, id)",
+    status: "failed",
+    error:
+      "Mock very very very very very very very very very very very very very very very very very very very very very very very very very very very very very long failure message",
+    execution_failures: [], // no retriable errors
+  }),
+);
+
+const getDetaultStartPlusTime = (
+  seconds: number = 0,
+  nanos: number = 0,
+): Timestamp => {
+  return {
+    seconds: defaultJobProperties.started.seconds.add(seconds),
+    nanos: defaultJobProperties.started.nanos + nanos,
+  };
+};
+
+export const hypotheticalRunningWithRetriableErrorsJobProps = getJobDetailsProps(
+  new Job({
+    ...defaultJobProperties,
+    id: new Long(7003330561, 70312826),
+    type: "SCHEMA CHANGE",
+    description:
+      "ALTER TABLE movr.public.user_promo_codes ADD FOREIGN KEY (city, user_id) REFERENCES movr.public.users (city, id)",
+    status: "retrying",
+    error: "", // no final error
+    execution_failures: [
+      {
+        start: getDetaultStartPlusTime(60 * 2),
+        end: getDetaultStartPlusTime(60 * 4),
+        status: "running",
+        error: "First retriable error.",
+      },
+      {
+        start: getDetaultStartPlusTime(60 * 6),
+        end: getDetaultStartPlusTime(60 * 8),
+        status: "running",
+        error: "Second mock retriable error.",
+      },
+    ],
+  }),
+);
+
+export const hypotheticalFailedWithRetriableErrorsJobProps = getJobDetailsProps(
+  new Job({
+    ...defaultJobProperties,
+    id: new Long(7003330561, 70312826),
+    type: "SCHEMA CHANGE",
+    description:
+      "ALTER TABLE movr.public.user_promo_codes ADD FOREIGN KEY (city, user_id) REFERENCES movr.public.users (city, id)",
+    status: "failed",
+    error: "Mock final failure error message",
+    execution_failures: [
+      {
+        start: getDetaultStartPlusTime(60 * 2),
+        end: getDetaultStartPlusTime(60 * 4),
+        status: "running",
+        error: "First retriable error.",
+      },
+      {
+        start: getDetaultStartPlusTime(60 * 6),
+        end: getDetaultStartPlusTime(60 * 8),
+        status: "running",
+        error: "Second mock retriable error.",
+      },
+    ],
+  }),
+);

--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobDetails.module.styl
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobDetails.module.styl
@@ -1,0 +1,21 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+@require "~src/components/core/index"
+
+.no-errors
+  &__icon
+    vertical-align: middle
+    font-size: 20px
+    margin-right: 10px;
+
+  &__message
+    @extends $text--body-strong
+    font-family $font-family--semi-bold

--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobDetails.stories.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobDetails.stories.tsx
@@ -1,0 +1,47 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import React, { useState } from "react";
+import { storiesOf } from "@storybook/react";
+import { withRouterDecorator } from "src/util/decorators";
+
+import {
+  succeededJobProps,
+  failedJobProps,
+  hypotheticalRunningWithRetriableErrorsJobProps,
+  hypotheticalFailedWithRetriableErrorsJobProps,
+} from "./jobDetails.fixture";
+import {
+  JobDetails,
+  JobDetailsProps,
+  defaultSortSetting,
+} from "src/views/jobs/jobDetails";
+import { SortSetting } from "@cockroachlabs/cluster-ui";
+
+export function JobDetailsSortWrapper(
+  props: JobDetailsProps,
+): React.ReactElement {
+  const [sortSetting, setSortSetting] = useState<SortSetting>(
+    defaultSortSetting,
+  );
+  return <JobDetails {...props} sort={sortSetting} setSort={setSortSetting} />;
+}
+
+storiesOf("JobDetails", module)
+  .addDecorator(withRouterDecorator)
+  .add("Succeed", () => <JobDetailsSortWrapper {...succeededJobProps} />)
+  .add("Failed", () => <JobDetailsSortWrapper {...failedJobProps} />)
+  .add("Running with retriable errors", () => (
+    <JobDetailsSortWrapper
+      {...hypotheticalRunningWithRetriableErrorsJobProps}
+    />
+  ))
+  .add("Failed with retriable errors", () => (
+    <JobDetailsSortWrapper {...hypotheticalFailedWithRetriableErrorsJobProps} />
+  ));

--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobStatusOptions.ts
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobStatusOptions.ts
@@ -23,7 +23,12 @@ export enum JobStatusVisual {
 
 export function jobToVisual(job: Job): JobStatusVisual {
   if (job.type === "CHANGEFEED") {
-    return JobStatusVisual.BadgeOnly;
+    switch (job.status) {
+      case JOB_STATUS_FAILED:
+        return JobStatusVisual.BadgeWithErrorMessage;
+      default:
+        return JobStatusVisual.BadgeOnly;
+    }
   }
   switch (job.status) {
     case JOB_STATUS_SUCCEEDED:

--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobsShared.fixture.ts
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobsShared.fixture.ts
@@ -1,0 +1,43 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import Long from "long";
+import * as protos from "@cockroachlabs/crdb-protobuf-client";
+
+export const defaultJobProperties = {
+  username: "root",
+  descriptor_ids: [] as number[],
+  created: new protos.google.protobuf.Timestamp({
+    seconds: new Long(1634648118),
+    nanos: 200459000,
+  }),
+  started: new protos.google.protobuf.Timestamp({
+    seconds: new Long(1634648118),
+    nanos: 215527000,
+  }),
+  finished: new protos.google.protobuf.Timestamp({
+    seconds: new Long(1634648118),
+    nanos: 311522000,
+  }),
+  modified: new protos.google.protobuf.Timestamp({
+    seconds: new Long(1634648118),
+    nanos: 310899000,
+  }),
+  fraction_completed: 1,
+  last_run: new protos.google.protobuf.Timestamp({
+    seconds: new Long(1634648118),
+    nanos: 215527000,
+  }),
+  next_run: new protos.google.protobuf.Timestamp({
+    seconds: new Long(1634648118),
+    nanos: 215527100,
+  }),
+  num_runs: new Long(1),
+};

--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobsTable.fixture.ts
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobsTable.fixture.ts
@@ -17,39 +17,9 @@ import Job = cockroach.server.serverpb.IJobResponse;
 import Long from "long";
 import { createMemoryHistory } from "history";
 import { jobsTimeoutErrorMessage } from "src/util/api";
+import { defaultJobProperties } from "src/views/jobs/jobsShared.fixture";
 
-const defaultJobProperties = {
-  username: "root",
-  descriptor_ids: [] as number[],
-  created: new protos.google.protobuf.Timestamp({
-    seconds: new Long(1634648118),
-    nanos: 200459000,
-  }),
-  started: new protos.google.protobuf.Timestamp({
-    seconds: new Long(1634648118),
-    nanos: 215527000,
-  }),
-  finished: new protos.google.protobuf.Timestamp({
-    seconds: new Long(1634648118),
-    nanos: 311522000,
-  }),
-  modified: new protos.google.protobuf.Timestamp({
-    seconds: new Long(1634648118),
-    nanos: 310899000,
-  }),
-  fraction_completed: 1,
-  last_run: new protos.google.protobuf.Timestamp({
-    seconds: new Long(1634648118),
-    nanos: 215527000,
-  }),
-  next_run: new protos.google.protobuf.Timestamp({
-    seconds: new Long(1634648118),
-    nanos: 215527100,
-  }),
-  num_runs: new Long(1),
-};
-
-export const succeededJobFixture = {
+export const succeededJobFixture: Job = {
   ...defaultJobProperties,
   id: new Long(8136728577, 70289336),
   type: "AUTO SQL STATS COMPACTION",
@@ -58,7 +28,7 @@ export const succeededJobFixture = {
   status: "succeeded",
 };
 
-const failedJobFixture = {
+const failedJobFixture: Job = {
   ...defaultJobProperties,
   id: new Long(7003330561, 70312826),
   type: "SCHEMA CHANGE",
@@ -68,7 +38,7 @@ const failedJobFixture = {
   error: "mock failure message",
 };
 
-const canceledJobFixture = {
+const canceledJobFixture: Job = {
   ...defaultJobProperties,
   id: new Long(7002707969, 70312826),
   type: "UNSPECIFIED",
@@ -76,7 +46,7 @@ const canceledJobFixture = {
   status: "canceled",
 };
 
-const pausedJobFixture = {
+const pausedJobFixture: Job = {
   ...defaultJobProperties,
   id: new Long(6091954177, 70312826),
   type: "BACKUP",
@@ -85,7 +55,7 @@ const pausedJobFixture = {
   status: "paused",
 };
 
-const runningJobFixture = {
+const runningJobFixture: Job = {
   ...defaultJobProperties,
   id: new Long(3390625793, 70312826),
   type: "AUTO SPAN CONFIG RECONCILIATION",
@@ -94,7 +64,7 @@ const runningJobFixture = {
   fraction_completed: 0,
 };
 
-const runningWithMessageJobFixture = {
+const runningWithMessageJobFixture: Job = {
   ...defaultJobProperties,
   id: new Long(3390625793, 70312826),
   type: "AUTO SPAN CONFIG RECONCILIATION",
@@ -104,7 +74,7 @@ const runningWithMessageJobFixture = {
   running_status: "Waiting For GC TTL",
 };
 
-const runningWithRemainingJobFixture = {
+const runningWithRemainingJobFixture: Job = {
   ...defaultJobProperties,
   id: new Long(6093756417, 70312826),
   type: "RESTORE",
@@ -113,7 +83,7 @@ const runningWithRemainingJobFixture = {
   fraction_completed: 0.38,
 };
 
-const runningWithMessageRemainingJobFixture = {
+const runningWithMessageRemainingJobFixture: Job = {
   ...defaultJobProperties,
   id: new Long(3390625793, 70312826),
   type: "AUTO SPAN CONFIG RECONCILIATION",
@@ -123,7 +93,7 @@ const runningWithMessageRemainingJobFixture = {
   running_status: "performing garbage collection on index 2",
 };
 
-export const retryRunningJobFixture = {
+export const retryRunningJobFixture: Job = {
   ...defaultJobProperties,
   id: new Long(3390625793, 70312826),
   type: "STREAM INGESTION",
@@ -137,7 +107,7 @@ export const retryRunningJobFixture = {
   num_runs: new Long(3),
 };
 
-const retryRunningWithMessageJobFixture = {
+const retryRunningWithMessageJobFixture: Job = {
   ...defaultJobProperties,
   id: new Long(3390625793, 70312826),
   type: "AUTO SPAN CONFIG RECONCILIATION",
@@ -152,7 +122,7 @@ const retryRunningWithMessageJobFixture = {
   num_runs: new Long(2),
 };
 
-const retryRunningWithRemainingJobFixture = {
+const retryRunningWithRemainingJobFixture: Job = {
   ...defaultJobProperties,
   id: new Long(3390625793, 70312826),
   type: "STREAM INGESTION",
@@ -167,7 +137,7 @@ const retryRunningWithRemainingJobFixture = {
   num_runs: new Long(3),
 };
 
-const retryRunningWithMessageRemainingJobFixture = {
+const retryRunningWithMessageRemainingJobFixture: Job = {
   ...defaultJobProperties,
   id: new Long(3390625793, 70312826),
   type: "MIGRATION",
@@ -183,7 +153,7 @@ const retryRunningWithMessageRemainingJobFixture = {
   num_runs: new Long(2),
 };
 
-const pendingJobFixture = {
+const pendingJobFixture: Job = {
   ...defaultJobProperties,
   id: new Long(5247850497, 70312826),
   type: "IMPORT",
@@ -192,7 +162,7 @@ const pendingJobFixture = {
   status: "pending",
 };
 
-const revertingJobFixture = {
+const revertingJobFixture: Job = {
   ...defaultJobProperties,
   id: new Long(5246539777, 70312826),
   type: "CHANGEFEED",
@@ -200,7 +170,7 @@ const revertingJobFixture = {
   status: "reverting",
 };
 
-const retryRevertingJobFixture = {
+const retryRevertingJobFixture: Job = {
   ...defaultJobProperties,
   id: new Long(3390625793, 70312826),
   type: "NEW SCHEMA CHANGE",
@@ -213,7 +183,7 @@ const retryRevertingJobFixture = {
   num_runs: new Long(2),
 };
 
-const highwaterJobFixture = {
+const highwaterJobFixture: Job = {
   ...defaultJobProperties,
   id: new Long(3390625793, 70312826),
   type: "TYPEDESC SCHEMA CHANGE",
@@ -226,7 +196,7 @@ const highwaterJobFixture = {
   highwater_decimal: "test highwater decimal",
 };
 
-const cancelRequestedJobFixture = {
+const cancelRequestedJobFixture: Job = {
   ...defaultJobProperties,
   id: new Long(4337653761, 70312826),
   type: "CREATE STATS",
@@ -234,7 +204,7 @@ const cancelRequestedJobFixture = {
   status: "cancel-requested",
 };
 
-const pauseRequestedJobFixture = {
+const pauseRequestedJobFixture: Job = {
   ...defaultJobProperties,
   id: new Long(4338669569, 70312826),
   type: "AUTO CREATE STATS",
@@ -242,7 +212,7 @@ const pauseRequestedJobFixture = {
   status: "pause-requested",
 };
 
-const revertFailedJobFixture = {
+const revertFailedJobFixture: Job = {
   ...defaultJobProperties,
   id: new Long(3391379457, 70312826),
   type: "SCHEMA CHANGE GC",


### PR DESCRIPTION
Todo:
- Blocked on being able to inject, and thus simulate a retriable error, and thus understand how the endpoint behaves with the top-level `error` field: https://github.com/cockroachdb/cockroach/issues/81474

Fixes #69170

This commit adds a "Job errors" table to the Job Details page.

Currently this draft implementation shows both the message in the `error`
(string) field with the job start and end time as error start and end times,
and the errors in the `execution_failures` field.

Separately, this commit also
- Improves job and table stories
- Renames the active stmts/txn prop type to distinguish those types from their
  respective components

No errors:
<img width="1391" alt="image" src="https://user-images.githubusercontent.com/91907326/169550853-0929ffd8-cea9-4aaf-9e1f-29ec4142dae7.png">

Retriable errors: Image TBD. Blocked on https://github.com/cockroachdb/cockroach/issues/81474

Failed without retriable errors:
<img width="1255" alt="image" src="https://user-images.githubusercontent.com/91907326/169852089-22d4a170-2ccd-4873-bc55-7e666c432a2b.png">


Release note (ui): This commit adds a "Job errors" table to the Job Details
page.