### PR TITLE
ui: use metric name as custom chart title

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/index.tsx
@@ -206,7 +206,7 @@ export class CustomChart extends React.Component<
         setTimeScale={this.props.setTimeScale}
         history={this.props.history}
       >
-        <LineGraph>
+        <LineGraph title={metrics.map(m => m.metric).join(", ")}>
           <Axis units={units} label={AxisUnits[units]}>
             {metrics.map((m, i) => {
               if (m.metric !== "") {


### PR DESCRIPTION
Custom charts were previously difficult to read because the graph didn't
include any indication of what was being graphed. This is now rectified
by printing the metrics name. This isn't the most user friendly thing
(ideally we would also include the actual title, and make the help text
available) but with my limited TSX knowledge this is solving 90% of the
problem with a 61 character change.

Related to https://github.com/cockroachdb/cockroach/issues/81035.

Release note: None
