### PR TITLE
storage: add conflict handling for MVCC range tombstones

### DIFF
--- a/pkg/storage/testdata/mvcc_histories/range_key_iter
+++ b/pkg/storage/testdata/mvcc_histories/range_key_iter
@@ -14,23 +14,23 @@
 #
 run ok
 put_rangekey k=a end=k ts=1
-put_rangekey k=m end=n ts=3 localTs=2
-put_rangekey k=b end=d ts=3
-put_rangekey k=f end=h ts=3
-put_rangekey k=c end=g ts=5
 put k=a ts=2 v=a2
 del k=a ts=4
+put_rangekey k=b end=d ts=3
 del k=b ts=4
 put k=d ts=4 v=d4
 put k=e ts=3 v=e3
 put k=f ts=2 v=f2
-put k=f ts=4 v=f4
-put k=f ts=6 v=f6
 put k=g ts=2 v=g2
+put_rangekey k=f end=h ts=3
+put k=f ts=4 v=f4
 put k=g ts=4 v=g4
+put_rangekey k=c end=g ts=5
+put k=f ts=6 v=f6
 put k=h ts=3 v=h3
 del k=h ts=4
 put k=k ts=5 v=k5
+put_rangekey k=m end=n ts=3 localTs=2
 with t=A
   txn_begin ts=7
   put k=a v=a7

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_conflicts
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_conflicts
@@ -1,0 +1,334 @@
+# Set up some point keys, point tombstones x, range tombstones o--o,
+# and intents []. The initial state is:
+#
+# 7                         [g7]
+# 6
+# 5          o-------------------------------o
+# 4
+# 3  o---------------------------------------o
+# 2                  x
+# 1              d1  e1  f1  g1      1   1
+#    a   b   c   d   e   f   g   h   i   j   k
+run ok
+put k=d ts=1 v=d1
+put k=e ts=1 v=e1
+del k=e ts=2
+put k=f ts=1 v=f1
+put k=g ts=1 v=g1
+increment k=i ts=1
+increment k=j ts=1
+del_range_ts k=a end=k ts=3
+del_range_ts k=c end=k ts=5
+with t=A ts=7
+  txn_begin
+  put k=g v=7
+----
+inc: current value = 1
+inc: current value = 1
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
+rangekey: {a-c}/[3.000000000,0=/<empty>]
+rangekey: {c-k}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/2.000000000,0 -> /<empty>
+data: "e"/1.000000000,0 -> /BYTES/e1
+data: "f"/1.000000000,0 -> /BYTES/f1
+meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "g"/7.000000000,0 -> /BYTES/7
+data: "g"/1.000000000,0 -> /BYTES/g1
+data: "i"/1.000000000,0 -> /INT/1
+data: "j"/1.000000000,0 -> /INT/1
+
+# Inline value or tombstone below range tombstone should error.
+run error
+put k=b ts=0 v=b0
+----
+>> at end:
+rangekey: {a-c}/[3.000000000,0=/<empty>]
+rangekey: {c-k}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/2.000000000,0 -> /<empty>
+data: "e"/1.000000000,0 -> /BYTES/e1
+data: "f"/1.000000000,0 -> /BYTES/f1
+meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "g"/7.000000000,0 -> /BYTES/7
+data: "g"/1.000000000,0 -> /BYTES/g1
+data: "i"/1.000000000,0 -> /INT/1
+data: "j"/1.000000000,0 -> /INT/1
+error: (*withstack.withStack:) "b"/0,0: put is inline=true, but existing value is inline=false
+
+run error
+del k=b ts=0
+----
+>> at end:
+rangekey: {a-c}/[3.000000000,0=/<empty>]
+rangekey: {c-k}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/2.000000000,0 -> /<empty>
+data: "e"/1.000000000,0 -> /BYTES/e1
+data: "f"/1.000000000,0 -> /BYTES/f1
+meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "g"/7.000000000,0 -> /BYTES/7
+data: "g"/1.000000000,0 -> /BYTES/g1
+data: "i"/1.000000000,0 -> /INT/1
+data: "j"/1.000000000,0 -> /INT/1
+error: (*withstack.withStack:) "b"/0,0: put is inline=true, but existing value is inline=false
+
+# DeleteRange at ts=5 should error with WriteTooOldError.
+#
+# TODO(erikgrinaker): This should error on c rather than d, but won't do so
+# until MVCCScan respects MVCC range tombstones. Until it does, the
+# put will actually do a write at the new timestamp.
+run error
+del_range k=a end=f ts=5
+----
+>> at end:
+rangekey: {a-c}/[3.000000000,0=/<empty>]
+rangekey: {c-k}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "d"/5.000000000,1 -> /<empty>
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/2.000000000,0 -> /<empty>
+data: "e"/1.000000000,0 -> /BYTES/e1
+data: "f"/1.000000000,0 -> /BYTES/f1
+meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "g"/7.000000000,0 -> /BYTES/7
+data: "g"/1.000000000,0 -> /BYTES/g1
+data: "i"/1.000000000,0 -> /INT/1
+data: "j"/1.000000000,0 -> /INT/1
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "d" at timestamp 5.000000000,0 too old; wrote at 5.000000000,1
+
+# Point key below range tombstones should error, but is written anyway at a
+# higher timestamp.
+#
+# TODO(erikgrinaker): These should test stats too, once range tombstones are
+# correctly accounted for: "Stats are updated correctly, even when there are
+# existing point values and tombstones below the range tombstones".
+run error
+put k=c ts=3 v=c3
+----
+>> at end:
+rangekey: {a-c}/[3.000000000,0=/<empty>]
+rangekey: {c-k}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "c"/5.000000000,1 -> /BYTES/c3
+data: "d"/5.000000000,1 -> /<empty>
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/2.000000000,0 -> /<empty>
+data: "e"/1.000000000,0 -> /BYTES/e1
+data: "f"/1.000000000,0 -> /BYTES/f1
+meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "g"/7.000000000,0 -> /BYTES/7
+data: "g"/1.000000000,0 -> /BYTES/g1
+data: "i"/1.000000000,0 -> /INT/1
+data: "j"/1.000000000,0 -> /INT/1
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 3.000000000,0 too old; wrote at 5.000000000,1
+
+run error
+put k=d ts=3 v=d3
+----
+>> at end:
+rangekey: {a-c}/[3.000000000,0=/<empty>]
+rangekey: {c-k}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "c"/5.000000000,1 -> /BYTES/c3
+data: "d"/5.000000000,2 -> /BYTES/d3
+data: "d"/5.000000000,1 -> /<empty>
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/2.000000000,0 -> /<empty>
+data: "e"/1.000000000,0 -> /BYTES/e1
+data: "f"/1.000000000,0 -> /BYTES/f1
+meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "g"/7.000000000,0 -> /BYTES/7
+data: "g"/1.000000000,0 -> /BYTES/g1
+data: "i"/1.000000000,0 -> /INT/1
+data: "j"/1.000000000,0 -> /INT/1
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "d" at timestamp 3.000000000,0 too old; wrote at 5.000000000,2
+
+run error
+put k=e ts=3 v=e3
+----
+>> at end:
+rangekey: {a-c}/[3.000000000,0=/<empty>]
+rangekey: {c-k}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "c"/5.000000000,1 -> /BYTES/c3
+data: "d"/5.000000000,2 -> /BYTES/d3
+data: "d"/5.000000000,1 -> /<empty>
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/5.000000000,1 -> /BYTES/e3
+data: "e"/2.000000000,0 -> /<empty>
+data: "e"/1.000000000,0 -> /BYTES/e1
+data: "f"/1.000000000,0 -> /BYTES/f1
+meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "g"/7.000000000,0 -> /BYTES/7
+data: "g"/1.000000000,0 -> /BYTES/g1
+data: "i"/1.000000000,0 -> /INT/1
+data: "j"/1.000000000,0 -> /INT/1
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "e" at timestamp 3.000000000,0 too old; wrote at 5.000000000,1
+
+# CPuts expecting a value covered by a range tombstone should error.
+run error
+cput k=f ts=7 v=f7 cond=f1
+----
+>> at end:
+rangekey: {a-c}/[3.000000000,0=/<empty>]
+rangekey: {c-k}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "c"/5.000000000,1 -> /BYTES/c3
+data: "d"/5.000000000,2 -> /BYTES/d3
+data: "d"/5.000000000,1 -> /<empty>
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/5.000000000,1 -> /BYTES/e3
+data: "e"/2.000000000,0 -> /<empty>
+data: "e"/1.000000000,0 -> /BYTES/e1
+data: "f"/1.000000000,0 -> /BYTES/f1
+meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "g"/7.000000000,0 -> /BYTES/7
+data: "g"/1.000000000,0 -> /BYTES/g1
+data: "i"/1.000000000,0 -> /INT/1
+data: "j"/1.000000000,0 -> /INT/1
+error: (*roachpb.ConditionFailedError:) unexpected value: timestamp:<wall_time:5000000000 > 
+
+# A CPut replay of an intent expecting a value covered by a range tombstone
+# should error because of the range tombstone covering it.
+run error
+with t=A ts=7
+  cput k=g v=g7 cond=g1
+----
+>> at end:
+rangekey: {a-c}/[3.000000000,0=/<empty>]
+rangekey: {c-k}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "c"/5.000000000,1 -> /BYTES/c3
+data: "d"/5.000000000,2 -> /BYTES/d3
+data: "d"/5.000000000,1 -> /<empty>
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/5.000000000,1 -> /BYTES/e3
+data: "e"/2.000000000,0 -> /<empty>
+data: "e"/1.000000000,0 -> /BYTES/e1
+data: "f"/1.000000000,0 -> /BYTES/f1
+meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "g"/7.000000000,0 -> /BYTES/7
+data: "g"/1.000000000,0 -> /BYTES/g1
+data: "i"/1.000000000,0 -> /INT/1
+data: "j"/1.000000000,0 -> /INT/1
+error: (*roachpb.ConditionFailedError:) unexpected value: timestamp:<wall_time:5000000000 > 
+
+# A CPut replacing an existing but ignored intent expecting a value covered
+# by a range tombstone should error because of the range tombstone covering it.
+run error
+with t=A ts=7
+  txn_step
+  txn_ignore_seqs seqs=0-1
+  cput k=g v=g7 cond=g1
+----
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0 isn=1
+rangekey: {a-c}/[3.000000000,0=/<empty>]
+rangekey: {c-k}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "c"/5.000000000,1 -> /BYTES/c3
+data: "d"/5.000000000,2 -> /BYTES/d3
+data: "d"/5.000000000,1 -> /<empty>
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/5.000000000,1 -> /BYTES/e3
+data: "e"/2.000000000,0 -> /<empty>
+data: "e"/1.000000000,0 -> /BYTES/e1
+data: "f"/1.000000000,0 -> /BYTES/f1
+meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "g"/7.000000000,0 -> /BYTES/7
+data: "g"/1.000000000,0 -> /BYTES/g1
+data: "i"/1.000000000,0 -> /INT/1
+data: "j"/1.000000000,0 -> /INT/1
+error: (*roachpb.ConditionFailedError:) unexpected value: timestamp:<wall_time:5000000000 > 
+
+# An InitPut with failOnTombstones above a range tombstone should error.
+run error
+initput k=f ts=7 v=f7 failOnTombstones
+----
+>> at end:
+rangekey: {a-c}/[3.000000000,0=/<empty>]
+rangekey: {c-k}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "c"/5.000000000,1 -> /BYTES/c3
+data: "d"/5.000000000,2 -> /BYTES/d3
+data: "d"/5.000000000,1 -> /<empty>
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/5.000000000,1 -> /BYTES/e3
+data: "e"/2.000000000,0 -> /<empty>
+data: "e"/1.000000000,0 -> /BYTES/e1
+data: "f"/1.000000000,0 -> /BYTES/f1
+meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "g"/7.000000000,0 -> /BYTES/7
+data: "g"/1.000000000,0 -> /BYTES/g1
+data: "i"/1.000000000,0 -> /INT/1
+data: "j"/1.000000000,0 -> /INT/1
+error: (*roachpb.ConditionFailedError:) unexpected value: timestamp:<wall_time:5000000000 > 
+
+# An InitPut with a different value as an existing key should succeed when there's
+# a range tombstone covering the existing value.
+#
+# TODO(erikgrinaker): This should test stats too.
+run ok
+initput k=f ts=7 v=f7
+----
+>> at end:
+rangekey: {a-c}/[3.000000000,0=/<empty>]
+rangekey: {c-k}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "c"/5.000000000,1 -> /BYTES/c3
+data: "d"/5.000000000,2 -> /BYTES/d3
+data: "d"/5.000000000,1 -> /<empty>
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/5.000000000,1 -> /BYTES/e3
+data: "e"/2.000000000,0 -> /<empty>
+data: "e"/1.000000000,0 -> /BYTES/e1
+data: "f"/7.000000000,0 -> /BYTES/f7
+data: "f"/1.000000000,0 -> /BYTES/f1
+meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "g"/7.000000000,0 -> /BYTES/7
+data: "g"/1.000000000,0 -> /BYTES/g1
+data: "i"/1.000000000,0 -> /INT/1
+data: "j"/1.000000000,0 -> /INT/1
+
+# An increment below a range tombstone should reset to 1 and write above it with
+# a WriteTooOldError.
+run error
+increment k=i ts=2
+----
+>> at end:
+rangekey: {a-c}/[3.000000000,0=/<empty>]
+rangekey: {c-k}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "c"/5.000000000,1 -> /BYTES/c3
+data: "d"/5.000000000,2 -> /BYTES/d3
+data: "d"/5.000000000,1 -> /<empty>
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/5.000000000,1 -> /BYTES/e3
+data: "e"/2.000000000,0 -> /<empty>
+data: "e"/1.000000000,0 -> /BYTES/e1
+data: "f"/7.000000000,0 -> /BYTES/f7
+data: "f"/1.000000000,0 -> /BYTES/f1
+meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "g"/7.000000000,0 -> /BYTES/7
+data: "g"/1.000000000,0 -> /BYTES/g1
+data: "i"/5.000000000,1 -> /INT/1
+data: "i"/1.000000000,0 -> /INT/1
+data: "j"/1.000000000,0 -> /INT/1
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "i" at timestamp 2.000000000,0 too old; wrote at 5.000000000,1
+
+# An increment above a range tombstone should reset to 1.
+run ok
+increment k=j ts=7
+----
+inc: current value = 1
+>> at end:
+rangekey: {a-c}/[3.000000000,0=/<empty>]
+rangekey: {c-k}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "c"/5.000000000,1 -> /BYTES/c3
+data: "d"/5.000000000,2 -> /BYTES/d3
+data: "d"/5.000000000,1 -> /<empty>
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/5.000000000,1 -> /BYTES/e3
+data: "e"/2.000000000,0 -> /<empty>
+data: "e"/1.000000000,0 -> /BYTES/e1
+data: "f"/7.000000000,0 -> /BYTES/f7
+data: "f"/1.000000000,0 -> /BYTES/f1
+meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "g"/7.000000000,0 -> /BYTES/7
+data: "g"/1.000000000,0 -> /BYTES/g1
+data: "i"/5.000000000,1 -> /INT/1
+data: "i"/1.000000000,0 -> /INT/1
+data: "j"/7.000000000,0 -> /INT/1
+data: "j"/1.000000000,0 -> /INT/1


### PR DESCRIPTION
This patch takes MVCC range tombstones into account for all MVCC write
operations, i.e. for conflict checks and conditional writes.

MVCC stats updates are not covered here, but will be addressed in a
subsequent PR. This also adds more exhaustive tests, especially for the
intent handling in `mvccPutInternal()`.

Touches #70412.

Release note: None