### PR TITLE
roachtest: update activerecord adapter to v6.1.10

### DIFF
--- a/pkg/cmd/roachtest/tests/activerecord.go
+++ b/pkg/cmd/roachtest/tests/activerecord.go
@@ -27,8 +27,8 @@ import (
 
 var activerecordResultRegex = regexp.MustCompile(`^(?P<test>[^\s]+#[^\s]+) = (?P<timing>\d+\.\d+ s) = (?P<result>.)$`)
 var railsReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)\.?(?P<subpoint>\d*)$`)
-var supportedRailsVersion = "6.1.5"
-var activerecordAdapterVersion = "v6.1.8"
+var supportedRailsVersion = "6.1.6"
+var activerecordAdapterVersion = "v6.1.10"
 
 // This test runs activerecord's full test suite against a single cockroach node.
 


### PR DESCRIPTION
refs https://github.com/cockroachdb/cockroach/issues/67893
refs https://github.com/cockroachdb/cockroach/issues/80777

This version correctly disables supports_expression_index to
prevent `ON CONFLICT expression` from appearing in generated
SQL statements.

Release note: None