### PR TITLE
release-22.1: lease: Remove descriptors from cache if not found during lease refresh

### DIFF
--- a/pkg/sql/catalog/lease/helpers_test.go
+++ b/pkg/sql/catalog/lease/helpers_test.go
@@ -286,3 +286,11 @@ func (m *Manager) Publish(
 	}
 	return results[id], nil
 }
+
+func (m *Manager) TestingRefreshSomeLeases(ctx context.Context) {
+	m.refreshSomeLeases(ctx)
+}
+
+func (m *Manager) TestingDescriptorStateIsNil(id descpb.ID) bool {
+	return m.findDescriptorState(id, false /* create */) == nil
+}

--- a/pkg/sql/catalog/lease/testutils.go
+++ b/pkg/sql/catalog/lease/testutils.go
@@ -52,6 +52,10 @@ type ManagerTestingKnobs struct {
 	// ignored.
 	TestingDescriptorUpdateEvent func(descriptor *descpb.Descriptor) error
 
+	// TestingBeforeAcquireLeaseDuringRefresh is a callback right before
+	// the lease manager attempts to acquire a lease for descriptor `id`.
+	TestingBeforeAcquireLeaseDuringRefresh func(id descpb.ID) error
+
 	// To disable the deletion of orphaned leases at server startup.
 	DisableDeleteOrphanedLeases bool
 


### PR DESCRIPTION
Backport 1/1 commits from #77609.

/cc @cockroachdb/release

---

Previously, when a descriptor is not found, we just log it and move on. This is inadequate because the no-longer-exist descriptor still exists in cache (i.e. in-memory objects managed by `lease.Manager`). To address this, this PR added logic that removes the descriptor when this situation occurred.

Fixes #67364

Release justification: handling support issues like https://github.com/cockroachlabs/support/issues/1584
Release note: None
