### PR TITLE
storage: remove `Engine.SetUpperBound`

### DIFF
--- a/pkg/kv/kvserver/abortspan/abortspan.go
+++ b/pkg/kv/kvserver/abortspan/abortspan.go
@@ -76,13 +76,9 @@ func (sc *AbortSpan) max() roachpb.Key {
 
 // ClearData removes all persisted items stored in the cache.
 func (sc *AbortSpan) ClearData(e storage.Engine) error {
-	// NB: The abort span is a Range-ID local key which has no versions or intents.
-	iter := e.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{UpperBound: sc.max()})
-	defer iter.Close()
-	b := e.NewUnindexedBatch(true /* writeOnly */)
+	b := e.NewUnindexedBatch(false /* writeOnly */)
 	defer b.Close()
-	err := b.ClearIterRange(iter, sc.min(), sc.max())
-	if err != nil {
+	if err := b.ClearIterRange(sc.min(), sc.max()); err != nil {
 		return err
 	}
 	return b.Commit(false /* sync */)

--- a/pkg/kv/kvserver/batch_spanset_test.go
+++ b/pkg/kv/kvserver/batch_spanset_test.go
@@ -78,9 +78,7 @@ func TestSpanSetBatchBoundaries(t *testing.T) {
 			t.Errorf("ClearRange: unexpected error %v", err)
 		}
 		{
-			iter := batch.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
-			err := batch.ClearIterRange(iter, outsideKey.Key, outsideKey2.Key)
-			iter.Close()
+			err := batch.ClearIterRange(outsideKey.Key, outsideKey2.Key)
 			if !isWriteSpanErr(err) {
 				t.Errorf("ClearIterRange: unexpected error %v", err)
 			}
@@ -101,9 +99,7 @@ func TestSpanSetBatchBoundaries(t *testing.T) {
 			t.Errorf("ClearRange: unexpected error %v", err)
 		}
 		{
-			iter := batch.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
-			err := batch.ClearIterRange(iter, insideKey2.Key, outsideKey4.Key)
-			iter.Close()
+			err := batch.ClearIterRange(outsideKey2.Key, outsideKey4.Key)
 			if !isWriteSpanErr(err) {
 				t.Errorf("ClearIterRange: unexpected error %v", err)
 			}
@@ -325,9 +321,7 @@ func TestSpanSetBatchTimestamps(t *testing.T) {
 			t.Errorf("Clear: unexpected error %v", err)
 		}
 		{
-			iter := batch.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
-			err := batch.ClearIterRange(iter, wkey.Key, wkey.Key)
-			iter.Close()
+			err := batch.ClearIterRange(wkey.Key, wkey.Key)
 			if !isWriteSpanErr(err) {
 				t.Errorf("ClearIterRange: unexpected error %v", err)
 			}

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range.go
@@ -116,12 +116,7 @@ func ClearRange(
 	if statsDelta.ContainsEstimates == 0 && statsDelta.Total() < ClearRangeBytesThreshold {
 		log.VEventf(ctx, 2, "delta=%d < threshold=%d; using non-range clear",
 			statsDelta.Total(), ClearRangeBytesThreshold)
-		iter := readWriter.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
-			LowerBound: from,
-			UpperBound: to,
-		})
-		defer iter.Close()
-		if err = readWriter.ClearIterRange(iter, from, to); err != nil {
+		if err = readWriter.ClearIterRange(from, to); err != nil {
 			return result.Result{}, err
 		}
 		return pd, nil

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
@@ -35,9 +35,9 @@ type wrappedBatch struct {
 	clearRangeCount int
 }
 
-func (wb *wrappedBatch) ClearIterRange(iter storage.MVCCIterator, start, end roachpb.Key) error {
+func (wb *wrappedBatch) ClearIterRange(start, end roachpb.Key) error {
 	wb.clearIterCount++
-	return wb.Batch.ClearIterRange(iter, start, end)
+	return wb.Batch.ClearIterRange(start, end)
 }
 
 func (wb *wrappedBatch) ClearMVCCRangeAndIntents(start, end roachpb.Key) error {

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -592,11 +592,11 @@ func (s spanSetWriter) ClearMVCCRange(start, end storage.MVCCKey) error {
 	return s.w.ClearMVCCRange(start, end)
 }
 
-func (s spanSetWriter) ClearIterRange(iter storage.MVCCIterator, start, end roachpb.Key) error {
+func (s spanSetWriter) ClearIterRange(start, end roachpb.Key) error {
 	if err := s.checkAllowedRange(start, end); err != nil {
 		return err
 	}
-	return s.w.ClearIterRange(iter, start, end)
+	return s.w.ClearIterRange(start, end)
 }
 
 func (s spanSetWriter) Merge(key storage.MVCCKey, value []byte) error {

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -208,11 +208,6 @@ func (i *MVCCIterator) FindSplitKey(
 	return i.i.FindSplitKey(start, end, minSplitKey, targetSize)
 }
 
-// SetUpperBound is part of the storage.MVCCIterator interface.
-func (i *MVCCIterator) SetUpperBound(key roachpb.Key) {
-	i.i.SetUpperBound(key)
-}
-
 // Stats is part of the storage.MVCCIterator interface.
 func (i *MVCCIterator) Stats() storage.IteratorStats {
 	return i.i.Stats()
@@ -372,11 +367,6 @@ func (i *EngineIterator) Value() []byte {
 // UnsafeRawEngineKey is part of the storage.EngineIterator interface.
 func (i *EngineIterator) UnsafeRawEngineKey() []byte {
 	return i.i.UnsafeRawEngineKey()
-}
-
-// SetUpperBound is part of the storage.EngineIterator interface.
-func (i *EngineIterator) SetUpperBound(key roachpb.Key) {
-	i.i.SetUpperBound(key)
 }
 
 // GetRawIter is part of the storage.EngineIterator interface.

--- a/pkg/storage/bench_pebble_test.go
+++ b/pkg/storage/bench_pebble_test.go
@@ -340,9 +340,7 @@ func BenchmarkClearMVCCRange_Pebble(b *testing.B) {
 func BenchmarkClearIterRange_Pebble(b *testing.B) {
 	ctx := context.Background()
 	runClearRange(ctx, b, setupMVCCPebble, func(eng Engine, batch Batch, start, end MVCCKey) error {
-		iter := eng.NewMVCCIterator(MVCCKeyIterKind, IterOptions{UpperBound: roachpb.KeyMax})
-		defer iter.Close()
-		return batch.ClearIterRange(iter, start.Key, end.Key)
+		return batch.ClearIterRange(start.Key, end.Key)
 	})
 }
 

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -556,17 +556,11 @@ type Writer interface {
 	// It is safe to modify the contents of the arguments after it returns.
 	ClearMVCCRange(start, end MVCCKey) error
 
-	// ClearIterRange removes a set of entries, from start (inclusive) to end
-	// (exclusive). Similar to Clear and ClearRange, this method actually
-	// removes entries from the storage engine. Unlike ClearRange, the entries
-	// to remove are determined by iterating over iter and per-key storage
-	// tombstones (not MVCC tombstones) are generated. If the MVCCIterator was
-	// constructed using MVCCKeyAndIntentsIterKind, any separated intents/locks
-	// will also be cleared.
-	//
-	// It is safe to modify the contents of the arguments after ClearIterRange
-	// returns.
-	ClearIterRange(iter MVCCIterator, start, end roachpb.Key) error
+	// ClearIterRange removes all keys in the given span using an iterator to
+	// iterate over point keys and remove them from the storage engine using
+	// per-key storage tombstones (not MVCC tombstones). Any separated
+	// intents/locks will also be cleared.
+	ClearIterRange(start, end roachpb.Key) error
 
 	// Merge is a high-performance write operation used for values which are
 	// accumulated over several writes. Multiple values can be merged

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -162,26 +162,6 @@ type MVCCIterator interface {
 	// package-level MVCCFindSplitKey instead. For correct operation, the caller
 	// must set the upper bound on the iterator before calling this method.
 	FindSplitKey(start, end, minSplitKey roachpb.Key, targetSize int64) (MVCCKey, error)
-	// SetUpperBound installs a new upper bound for this iterator. The caller
-	// can modify the parameter after this function returns. This must not be a
-	// nil key. When Reader.ConsistentIterators is true, prefer creating a new
-	// iterator.
-	//
-	// Due to the rare use, we are limiting this method to not switch an
-	// iterator from a global key upper-bound to a local key upper-bound (it
-	// simplifies some code in intentInterleavingIter) or vice versa. Iterator
-	// reuse already happens under-the-covers for most Reader implementations
-	// when constructing a new iterator, and that is a much cleaner solution.
-	//
-	// TODO(sumeer): this method is rarely used and is a source of complexity
-	// since intentInterleavingIter needs to fiddle with the bounds of its
-	// underlying iterators when this is called. Currently only used by
-	// pebbleBatch.ClearIterRange to modify the upper bound of the iterator it
-	// is given: this use is unprincipled and there is a comment in that code
-	// about it. The caller is already usually setting the bounds accurately,
-	// and in some cases the callee is tightening the upper bound. Remove that
-	// use case and remove this from the interface.
-	SetUpperBound(roachpb.Key)
 	// Stats returns statistics about the iterator.
 	Stats() IteratorStats
 	// SupportsPrev returns true if MVCCIterator implementation supports reverse
@@ -232,10 +212,6 @@ type EngineIterator interface {
 	// Value returns the current value as a byte slice.
 	// REQUIRES: latest positioning function returned valid=true.
 	Value() []byte
-	// SetUpperBound installs a new upper bound for this iterator. When
-	// Reader.ConsistentIterators is true, prefer creating a new iterator.
-	// TODO(sumeer): remove this method.
-	SetUpperBound(roachpb.Key)
 	// GetRawIter is a low-level method only for use in the storage package,
 	// that returns the underlying pebble Iterator.
 	GetRawIter() *pebble.Iterator
@@ -319,8 +295,8 @@ const (
 	// Specifically:
 	// - If both bounds are set they must not span from local to global.
 	// - Any bound (lower or upper), constrains the iterator for its lifetime to
-	//   one of local or global keys. The iterator will not tolerate a seek or
-	//   SetUpperBound call that violates this constraint.
+	//   one of local or global keys. The iterator will not tolerate a seek that
+	//   violates this constraint.
 	// We could, with significant code complexity, not constrain an iterator for
 	// its lifetime, and allow a seek that specifies a global (local) key to
 	// change the constraint to global (local). This would allow reuse of the

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1012,9 +1012,7 @@ func TestEngineDeleteIterRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	testEngineDeleteRange(t, func(engine Engine, start, end MVCCKey) error {
-		iter := engine.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: roachpb.KeyMax})
-		defer iter.Close()
-		return engine.ClearIterRange(iter, start.Key, end.Key)
+		return engine.ClearIterRange(start.Key, end.Key)
 	})
 }
 

--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -80,7 +80,7 @@ const (
 // bounds, the call to newIntentInterleavingIter must have specified at least
 // one of the lower or upper bound. We use that to "constrain" the iterator as
 // either a local key iterator or global key iterator and panic if a caller
-// violates that in a subsequent SeekGE/SeekLT/SetUpperBound call.
+// violates that in a subsequent SeekGE/SeekLT call.
 type intentInterleavingIter struct {
 	prefix     bool
 	constraint intentInterleavingIterConstraint
@@ -952,17 +952,6 @@ func (i *intentInterleavingIter) FindSplitKey(
 	start, end, minSplitKey roachpb.Key, targetSize int64,
 ) (MVCCKey, error) {
 	return findSplitKeyUsingIterator(i, start, end, minSplitKey, targetSize)
-}
-
-func (i *intentInterleavingIter) SetUpperBound(key roachpb.Key) {
-	i.iter.SetUpperBound(key)
-	// Preceding call to SetUpperBound has confirmed that key != nil.
-	if i.constraint != notConstrained {
-		i.checkConstraint(key, true)
-	}
-	var intentUpperBound roachpb.Key
-	intentUpperBound, i.intentKeyBuf = keys.LockTableSingleKey(key, i.intentKeyBuf)
-	i.intentIter.SetUpperBound(intentUpperBound)
 }
 
 func (i *intentInterleavingIter) Stats() IteratorStats {

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1226,12 +1226,12 @@ func (p *Pebble) clearRange(start, end MVCCKey) error {
 }
 
 // ClearIterRange implements the Engine interface.
-func (p *Pebble) ClearIterRange(iter MVCCIterator, start, end roachpb.Key) error {
+func (p *Pebble) ClearIterRange(start, end roachpb.Key) error {
 	// Write all the tombstones in one batch.
-	batch := p.NewUnindexedBatch(true /* writeOnly */)
+	batch := p.NewUnindexedBatch(false /* writeOnly */)
 	defer batch.Close()
 
-	if err := batch.ClearIterRange(iter, start, end); err != nil {
+	if err := batch.ClearIterRange(start, end); err != nil {
 		return err
 	}
 	return batch.Commit(true)
@@ -2114,7 +2114,7 @@ func (p *pebbleReadOnly) ClearMVCCRange(start, end MVCCKey) error {
 	panic("not implemented")
 }
 
-func (p *pebbleReadOnly) ClearIterRange(iter MVCCIterator, start, end roachpb.Key) error {
+func (p *pebbleReadOnly) ClearIterRange(start, end roachpb.Key) error {
 	panic("not implemented")
 }
 

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -274,7 +274,6 @@ func TestPebbleIterBoundSliceStabilityAndNoop(t *testing.T) {
 
 	tc := []struct {
 		expectSetBounds bool
-		setUpperOnly    bool
 		lb              roachpb.Key
 		ub              roachpb.Key
 	}{
@@ -289,12 +288,6 @@ func TestPebbleIterBoundSliceStabilityAndNoop(t *testing.T) {
 			ub:              roachpb.Key("www"),
 		},
 		{
-			// [nil, www)
-			expectSetBounds: false,
-			setUpperOnly:    true,
-			ub:              roachpb.Key("www"),
-		},
-		{
 			// [ddd, www)
 			expectSetBounds: true,
 			lb:              roachpb.Key("ddd"),
@@ -303,14 +296,8 @@ func TestPebbleIterBoundSliceStabilityAndNoop(t *testing.T) {
 		{
 			// [ddd, www)
 			expectSetBounds: false,
-			setUpperOnly:    true,
+			lb:              roachpb.Key("ddd"),
 			ub:              roachpb.Key("www"),
-		},
-		{
-			// [ddd, xxx)
-			expectSetBounds: true,
-			setUpperOnly:    true,
-			ub:              roachpb.Key("xxx"),
 		},
 		{
 			// [aaa, bbb)
@@ -340,13 +327,8 @@ func TestPebbleIterBoundSliceStabilityAndNoop(t *testing.T) {
 		t.Run(fmt.Sprintf("%v", c), func(t *testing.T) {
 			checker.expectSetBounds = c.expectSetBounds
 			checker.t = t
-			if c.setUpperOnly {
-				iter.SetUpperBound(c.ub)
-				ub = c.ub
-			} else {
-				iter.setBounds(c.lb, c.ub)
-				lb, ub = c.lb, c.ub
-			}
+			iter.setBounds(c.lb, c.ub)
+			lb, ub = c.lb, c.ub
 			require.False(t, checker.expectSetBounds)
 			for i, bound := range [][]byte{lb, ub} {
 				if (bound == nil) != (checker.boundsSlicesCopied[i] == nil) {

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -295,7 +295,7 @@ func (fw *SSTWriter) SingleClearEngineKey(key EngineKey) error {
 }
 
 // ClearIterRange implements the Writer interface.
-func (fw *SSTWriter) ClearIterRange(iter MVCCIterator, start, end roachpb.Key) error {
+func (fw *SSTWriter) ClearIterRange(start, end roachpb.Key) error {
 	panic("ClearIterRange is unsupported")
 }
 

--- a/pkg/storage/testdata/intent_interleaving_iter/basic
+++ b/pkg/storage/testdata/intent_interleaving_iter/basic
@@ -40,7 +40,6 @@ prev
 prev
 prev
 stats
-set-upper k=c
 seek-ge k=b
 stats
 next
@@ -75,16 +74,15 @@ prev: output: value k=a ts=20.000000000,0 v=a20
 prev: output: meta k=a ts=20.000000000,0 txn=1
 prev: output: .
 stats: (interface (dir, seek, step): (fwd, 2, 7), (rev, 0, 13)), (internal (dir, seek, step): (fwd, 2, 7), (rev, 2, 7))
-set-upper c
 seek-ge "b"/0,0: output: meta k=b ts=30.000000000,0 txn=2
 stats: (interface (dir, seek, step): (fwd, 4, 7), (rev, 0, 13)), (internal (dir, seek, step): (fwd, 4, 7), (rev, 2, 7))
 next: output: value k=b ts=30.000000000,0 v=b30
-next: output: .
+next: output: meta k=c
 prev: output: value k=b ts=30.000000000,0 v=b30
 prev: output: meta k=b ts=30.000000000,0 txn=2
 prev: output: value k=a ts=10.000000000,0 v=a10
 seek-lt "b"/0,0: output: value k=a ts=10.000000000,0 v=a10
-stats: (interface (dir, seek, step): (fwd, 4, 9), (rev, 2, 19)), (internal (dir, seek, step): (fwd, 4, 9), (rev, 6, 13))
+stats: (interface (dir, seek, step): (fwd, 4, 9), (rev, 2, 20)), (internal (dir, seek, step): (fwd, 4, 9), (rev, 5, 14))
 next: output: meta k=b ts=30.000000000,0 txn=2
 prev: output: value k=a ts=10.000000000,0 v=a10
 prev: output: value k=a ts=20.000000000,0 v=a20


### PR DESCRIPTION
Partial resubmit of #79291, which was merged into the `mvcc-range-tombstones` branch.

---

**storage: make `Engine.ClearIterRange` construct iterator internally**

`Engine.ClearIterRange` now creates the iterator itself, instead of
having it passed in. This ensures the iterator is created with
appropriate bounds and options, which becomes even more important with
the introduction of range keys. It will also allow removal of
`Engine.SetUpperBound` in a subsequent commit.

If further flexibility is needed, we can consider passing an
`IterOptions` struct with appropriate bounds instead of a key span.

Release note: None

**storage: remove `Engine.SetUpperBound`**

This patch removes the `Engine.SetUpperBound` method, as it is no longer
in use.

Release note: None