### PR TITLE
storage: allow multiple iterators in `pebbleReadOnly` and `pebbleBatch`

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1982,7 +1982,7 @@ func (p *pebbleReadOnly) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions
 		iter = &p.prefixIter
 	}
 	if iter.inuse {
-		panic("iterator already in use")
+		return newPebbleIterator(p.parent.db, p.iter, opts, p.durability)
 	}
 	// Ensures no timestamp hints etc.
 	checkOptionsForIterReuse(opts)
@@ -2018,7 +2018,7 @@ func (p *pebbleReadOnly) NewEngineIterator(opts IterOptions) EngineIterator {
 		iter = &p.prefixEngineIter
 	}
 	if iter.inuse {
-		panic("iterator already in use")
+		return newPebbleIterator(p.parent.db, p.iter, opts, p.durability)
 	}
 	// Ensures no timestamp hints etc.
 	checkOptionsForIterReuse(opts)

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -236,8 +236,12 @@ func (p *pebbleBatch) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions) M
 	if opts.Prefix {
 		iter = &p.prefixIter
 	}
+	handle := pebble.Reader(p.batch)
+	if !p.batch.Indexed() {
+		handle = p.db
+	}
 	if iter.inuse {
-		panic("iterator already in use")
+		return newPebbleIterator(handle, p.iter, opts, StandardDurability)
 	}
 	// Ensures no timestamp hints etc.
 	checkOptionsForIterReuse(opts)
@@ -245,11 +249,7 @@ func (p *pebbleBatch) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions) M
 	if iter.iter != nil {
 		iter.setBounds(opts.LowerBound, opts.UpperBound)
 	} else {
-		if p.batch.Indexed() {
-			iter.init(p.batch, p.iter, p.iterUnused, opts, StandardDurability)
-		} else {
-			iter.init(p.db, p.iter, p.iterUnused, opts, StandardDurability)
-		}
+		iter.init(handle, p.iter, p.iterUnused, opts, StandardDurability)
 		if p.iter == nil {
 			// For future cloning.
 			p.iter = iter.iter
@@ -279,8 +279,12 @@ func (p *pebbleBatch) NewEngineIterator(opts IterOptions) EngineIterator {
 	if opts.Prefix {
 		iter = &p.prefixEngineIter
 	}
+	handle := pebble.Reader(p.batch)
+	if !p.batch.Indexed() {
+		handle = p.db
+	}
 	if iter.inuse {
-		panic("iterator already in use")
+		return newPebbleIterator(handle, p.iter, opts, StandardDurability)
 	}
 	// Ensures no timestamp hints etc.
 	checkOptionsForIterReuse(opts)
@@ -288,11 +292,7 @@ func (p *pebbleBatch) NewEngineIterator(opts IterOptions) EngineIterator {
 	if iter.iter != nil {
 		iter.setBounds(opts.LowerBound, opts.UpperBound)
 	} else {
-		if p.batch.Indexed() {
-			iter.init(p.batch, p.iter, p.iterUnused, opts, StandardDurability)
-		} else {
-			iter.init(p.db, p.iter, p.iterUnused, opts, StandardDurability)
-		}
+		iter.init(handle, p.iter, p.iterUnused, opts, StandardDurability)
 		if p.iter == nil {
 			// For future cloning.
 			p.iter = iter.iter

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -1268,4 +1269,90 @@ func TestPebbleFlushCallbackAndDurabilityRequirement(t *testing.T) {
 	roGuaranteed2 := eng.NewReadOnly(GuaranteedDurability)
 	defer roGuaranteed2.Close()
 	require.Equal(t, v.Value.RawBytes, checkGetAndIter(roGuaranteed2))
+}
+
+// TestPebbleReaderMultipleIterators tests that all Pebble readers support
+// multiple concurrent iterators of the same type.
+func TestPebbleReaderMultipleIterators(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	eng := NewDefaultInMemForTesting()
+	defer eng.Close()
+
+	a1 := MVCCKey{Key: roachpb.Key("a"), Timestamp: hlc.Timestamp{WallTime: 1}}
+	b1 := MVCCKey{Key: roachpb.Key("b"), Timestamp: hlc.Timestamp{WallTime: 1}}
+	c1 := MVCCKey{Key: roachpb.Key("c"), Timestamp: hlc.Timestamp{WallTime: 1}}
+
+	v1 := MVCCValue{Value: roachpb.MakeValueFromString("1")}
+	v2 := MVCCValue{Value: roachpb.MakeValueFromString("2")}
+	v3 := MVCCValue{Value: roachpb.MakeValueFromString("3")}
+	vx := MVCCValue{Value: roachpb.MakeValueFromString("x")}
+
+	decodeValue := func(encoded []byte) MVCCValue {
+		value, err := DecodeMVCCValue(encoded)
+		require.NoError(t, err)
+		return value
+	}
+
+	require.NoError(t, eng.PutMVCC(a1, v1))
+	require.NoError(t, eng.PutMVCC(b1, v2))
+	require.NoError(t, eng.PutMVCC(c1, v3))
+
+	readOnly := eng.NewReadOnly(StandardDurability)
+	defer readOnly.Close()
+	require.NoError(t, readOnly.PinEngineStateForIterators())
+
+	snapshot := eng.NewSnapshot()
+	defer snapshot.Close()
+	require.NoError(t, snapshot.PinEngineStateForIterators())
+
+	batch := eng.NewBatch()
+	defer batch.Close()
+	require.NoError(t, batch.PinEngineStateForIterators())
+
+	// These writes should not be visible to any of the pinned iterators.
+	require.NoError(t, eng.PutMVCC(a1, vx))
+	require.NoError(t, eng.PutMVCC(b1, vx))
+	require.NoError(t, eng.PutMVCC(c1, vx))
+
+	testcases := map[string]Reader{
+		"Engine":   eng,
+		"ReadOnly": readOnly,
+		"Snapshot": snapshot,
+		"Batch":    batch,
+	}
+	for name, r := range testcases {
+		t.Run(name, func(t *testing.T) {
+			// Make sure we can create two iterators of the same type.
+			i1 := r.NewMVCCIterator(MVCCKeyIterKind, IterOptions{LowerBound: a1.Key, UpperBound: keys.MaxKey})
+			i2 := r.NewMVCCIterator(MVCCKeyIterKind, IterOptions{LowerBound: b1.Key, UpperBound: keys.MaxKey})
+
+			// Make sure the iterators are independent.
+			i1.SeekGE(a1)
+			i2.SeekGE(a1)
+			require.Equal(t, a1, i1.UnsafeKey())
+			require.Equal(t, b1, i2.UnsafeKey()) // b1 because of LowerBound
+
+			// Check iterator consistency.
+			if r.ConsistentIterators() {
+				require.Equal(t, v1, decodeValue(i1.UnsafeValue()))
+				require.Equal(t, v2, decodeValue(i2.UnsafeValue()))
+			} else {
+				require.Equal(t, vx, decodeValue(i1.UnsafeValue()))
+				require.Equal(t, vx, decodeValue(i2.UnsafeValue()))
+			}
+
+			// Closing one iterator shouldn't affect the other.
+			i1.Close()
+			i2.Next()
+			require.Equal(t, c1, i2.UnsafeKey())
+			i2.Close()
+
+			// Quick check for engine iterators too.
+			e1 := r.NewEngineIterator(IterOptions{UpperBound: keys.MaxKey})
+			defer e1.Close()
+			e2 := r.NewEngineIterator(IterOptions{UpperBound: keys.MaxKey})
+			defer e2.Close()
+		})
+	}
 }


### PR DESCRIPTION
Partial resubmit of #79291, which was merged into the mvcc-range-tombstones branch.

---

Previously, `pebbleReadOnly` and `pebbleBatch` only supported a single
concurrent iterator of a given type, as this iterator was reused between
`NewMVCCIterator` calls. Attempts to create an additional iterator would
panic with "iterator already in use".

Time-bound iterators were excluded from this reuse, and always created
from scratch, so they sidestepped this limitation. However, we will soon
make these iterators reusable too via a new `SetOptions()` method in
Pebble. When TBIs also become reusable, this will cause
`MVCCIncrementalIterator` to panic with "iterator already in use",
because it always creates two concurrent iterators: one regular and one
time-bound.

This patch therefore ensures all `Reader` implementations support
multiple concurrent iterators, by cloning the existing cached iterator
if it is already in use. This also preserves the pinned engine state for
the new iterator.

Release note: None