### PR TITLE
ui: Fix the custom time picker reverting to the previously selected time, part 2

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/rangeSelect.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/rangeSelect.tsx
@@ -119,31 +119,46 @@ const RangeSelect = ({
   };
 
   const menu = (
-    <div
-      className={cx("range-selector", `${custom ? "__custom" : "__options"}`)}
-    >
-      {custom ? (
-        <div className={cx("custom-menu")}>
-          <DateRangeMenu
-            startInit={selected.timeWindow.start}
-            endInit={selected.timeWindow.end}
-            onSubmit={onChangeDate}
-            onCancel={() => setCustom(false)}
-          />
-        </div>
-      ) : (
-        <div className={cx("_quick-view")}>
-          {options.map(option => (
-            <OptionButton
-              key={option.label}
-              isSelected={selected.title === option.value}
-              option={option}
-              onClick={handleOptionButtonOnClick}
-            />
-          ))}
+    <>
+      {/**
+       * isVisible is used here to trigger a remount of DateRangeMenu and re-initialize the time in the custom menu. See
+       *  comments on DateRangeMenu.
+       * It is needed because passing isVisible to <Dropdown> merely causes a css change in visibility, and does not
+       *  re-mount the component.
+       * The coupling of setting isVisible to true with the need to re-initialize the time relies on the implicit
+       *  assumption that the dropdown is always in a closed state after a user-induced time change.
+       */
+      isVisible && (
+        <div
+          className={cx(
+            "range-selector",
+            `${custom ? "__custom" : "__options"}`,
+          )}
+        >
+          {custom ? (
+            <div className={cx("custom-menu")}>
+              <DateRangeMenu
+                startInit={selected.timeWindow.start}
+                endInit={selected.timeWindow.end}
+                onSubmit={onChangeDate}
+                onCancel={() => setCustom(false)}
+              />
+            </div>
+          ) : (
+            <div className={cx("_quick-view")}>
+              {options.map(option => (
+                <OptionButton
+                  key={option.label}
+                  isSelected={selected.title === option.value}
+                  option={option}
+                  onClick={handleOptionButtonOnClick}
+                />
+              ))}
+            </div>
+          )}
         </div>
       )}
-    </div>
+    </>
   );
 
   return (


### PR DESCRIPTION
Fixes a bug was introduced in #80660, where if a user selects a different time in the
custom time selection, the component may revert to the currently select
time. #81006 had fixed this bug for when a custom time was selected. However,
it had not fixed the bug for when a non-custom time, e.g. "Past 10 minutes", was
selected.

This commit fixes the bug for when a non-custom time is selected. The fix
implicitly relies on the (currently true) assumption that a user-induced time
change always closes the dropdown (sets `isVisible` to false) or occurs when
the dropdown is already closed (`isVisible` to already false).

Before, the bug is present when "Past 10 minutes" is selected. No bug when a custom time is selected:
https://user-images.githubusercontent.com/91907326/167907768-59f98662-8ca4-4ea3-ad2e-69e90e252800.mov

After, Statements Page: 
https://user-images.githubusercontent.com/91907326/167908454-1d5508ca-399b-4c39-9fdb-7362e06cc0f1.mov

After, Metrics Page: 
https://user-images.githubusercontent.com/91907326/167910508-2624c982-19b0-4b29-bc43-9518d055ecc2.mov

However, this implementation comes at the cost that temporary, un-applied
custom user selections will be lost when the user closes the custom picker.

Before, temporary, un-applied custom user selections (i.e. without clicking "Apply") would persist between show/hides of the picker:
https://user-images.githubusercontent.com/91907326/167913174-aa1b7478-2711-46a7-b837-b44feac2c9ef.mov

After, the cost of this fix's implementation is that un-applied custom selections no longer persist:
https://user-images.githubusercontent.com/91907326/167913291-b12af862-8f90-431b-9f18-695d12f440cb.mov


To explain motivation for the existing code, the `useEffect` was previously needed in the absence of triggering component re-mounting through `isVisible`. If one removed the `useEffect`s without adding the `isVisible` re-mounting trigger, the initial time would not update when the Dropdown visibility was changed (because the visibility change is implemented via a css change):

https://user-images.githubusercontent.com/91907326/167908109-0b1bc17d-43b8-45f0-ab0a-0b07ca33cb22.mov


Release note: None

Release justification: Category 2, UI bug fix