### PR TITLE
ui: Re-introduce polling in the Statements and Transactions pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -327,6 +327,7 @@ export class StatementsPage extends React.Component<
 
   componentDidUpdate = (): void => {
     this.updateQueryParams();
+    this.refreshStatements();
     if (!this.props.isTenant && !this.props.hasViewActivityRedactedRole) {
       this.props.refreshStatementDiagnosticsRequests();
     }

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -221,6 +221,7 @@ export class TransactionsPage extends React.Component<
 
   componentDidUpdate(): void {
     this.updateQueryParams();
+    this.refreshData();
   }
 
   onChangeSortSetting = (ss: SortSetting): void => {


### PR DESCRIPTION
This is a draft, blocked on understanding whether this code is a good idea.

@xinhaoz, was polling removed in these pages on purpose? The statements and transactions pages no longer poll, and I noticed that these two lines were removed in https://github.com/cockroachdb/cockroach/pull/75458. The PR description didn't seem to mention changing the polling, and the PR date was close to when you were [discussing](https://app.slack.com/client/T03GD9U3D/search/search-eyJkIjoiaW50ZXJlc3RpbmclMjBpbiUzQSUyM3NxbC1vYnNlcnZhYmlsaXR5LXRlYW0lMjBmcm9tJTNBJTNDJTQwVTAyRzBQSExaNTMlN0MlNDBKb3NlcGhpbmUlMjBMZWUlM0UiLCJvIjoxLCJxIjoiVTAyRzBQSExaNTMiLCJyIjoiaW50ZXJlc3RpbmclMjBpbiUzQSUzQyUyM0cwMVE5RDAxTlRVJTdDc3FsLW9ic2VydmFiaWxpdHktdGVhbSUzRSUyMGZyb20lM0ElM0MlNDBVMDJHMFBITFo1MyUzRSJ9/thread/G01Q9D01NTU-1642715585.137500) cleaning up the polling. So I was just wondering if it might have been a accidently committed left over code 😅.