### PR TITLE
tracez: add latest trace toggle and refresh button

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/tracez/tracez.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/tracez/tracez.tsx
@@ -327,6 +327,18 @@ export const Tracez = () => {
 
   useEffect(refreshTracingSnapshots, []);
 
+  const refreshLive = () => {
+    getLiveTrace(
+      new GetTraceRequest({
+        trace_id: requestedSpan.trace_id,
+        recording_type: RecordingMode.VERBOSE,
+      }),
+    ).then(resp => {
+      setCurrentTrace(resp);
+      setShowTrace(true);
+    });
+  };
+
   useEffect(() => {
     if (showTrace) {
       if (showLiveTrace) {
@@ -387,9 +399,11 @@ export const Tracez = () => {
             setShowTrace(false);
             setShowLiveTrace(false);
           }}
-          showLive={() => {
-            setShowLiveTrace(true);
+          showLive={showLiveTrace}
+          setShowLive={(z: boolean) => {
+            setShowLiveTrace(z);
           }}
+          refreshLive={refreshLive}
           operation={requestedSpan.operation}
         />
       ) : (
@@ -414,7 +428,9 @@ export const Tracez = () => {
 interface TraceViewProps {
   currentTrace: IGetTraceResponse;
   cancel: () => void;
-  showLive: () => void;
+  showLive: boolean;
+  setShowLive: (l: boolean) => void;
+  refreshLive: () => void;
   operation: string;
 }
 
@@ -422,6 +438,8 @@ const TraceView = ({
   currentTrace,
   cancel,
   showLive,
+  setShowLive,
+  refreshLive,
   operation,
 }: TraceViewProps) => {
   return (
@@ -444,10 +462,20 @@ const TraceView = ({
           </Button>
         </PageConfigItem>
         <PageConfigItem>
-          <Button as={"button"} onClick={showLive}>
-            Switch to Latest
-          </Button>
+          <label style={{ marginRight: "10px" }}>Show Live</label>
+          <Switch
+            checked={showLive}
+            onClick={() => setShowLive(!showLive)}
+            title={"Show Live"}
+          />
         </PageConfigItem>
+        {showLive ? (
+          <PageConfigItem>
+            <Button as={"button"} onClick={refreshLive}>
+              Refresh
+            </Button>
+          </PageConfigItem>
+        ) : null}
       </PageConfig>
       <section className="section" style={{ maxWidth: "none" }}>
         <pre>{currentTrace.serialized_recording}</pre>


### PR DESCRIPTION
Previously, there was a single button a trace details page that let you
switch to the "latest" snapshot of that trace if it was recording in
verbose mode. This button was a "one time" load and wouldn't refresh the
trace as it continued to capture a long-running process.

This commit changes the button into a toggle that switches to "live"
mode for the trace. When in live mode, a "Refresh" button is now
available that can reload the live trace.

![Screenshot 2022-05-12 at 12-43-31 Cockroach Console](https://user-images.githubusercontent.com/986307/168126856-ff92d393-16cf-4d82-9667-643427040b9e.png)

Resolves #80138

Release note (ui change): The trace details view under "Active
Operations" in Advanced Debug can now refresh live traces that have
recording enabled.