### PR TITLE
cloud/gcp: include object path in missing object error

### DIFF
--- a/pkg/cloud/gcp/gcs_storage.go
+++ b/pkg/cloud/gcp/gcs_storage.go
@@ -203,7 +203,7 @@ func (g *gcsStorage) ReadFileAt(
 			// return our internal ErrFileDoesNotExist.
 			// nolint:errwrap
 			err = errors.Wrapf(
-				errors.Wrap(cloud.ErrFileDoesNotExist, "gcs object does not exist"),
+				errors.Wrapf(cloud.ErrFileDoesNotExist, "gcs object %q does not exist", object),
 				"%v",
 				err.Error(),
 			)


### PR DESCRIPTION
Release note: none.