### PR TITLE
kvserver: deflake `TestInitRaftGroupOnRequest`

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -4263,15 +4263,13 @@ func TestInitRaftGroupOnRequest(t *testing.T) {
 		log.Errorf(ctx, "expected raft group to be uninitialized")
 	}
 	// Send an increment and verify that initializes the Raft group.
-	_, pErr := kv.SendWrapped(ctx,
-		followerStore.TestSender(), incrementArgs(splitKey, 1))
-	if pErr != nil {
-		t.Fatal(pErr)
-	}
+	//
+	// NB: We don't know who has the lease, so we ignore any errors (i.e.
+	// NotLeaseHolderError). We only care that it initializes the Raft group.
+	_, pErr := kv.SendWrapped(ctx, followerStore.TestSender(), incrementArgs(splitKey, 1))
+	_ = pErr // appease returncheck linter
 
-	if !repl.IsRaftGroupInitialized() {
-		t.Fatal("expected raft group to be initialized")
-	}
+	require.True(t, repl.IsRaftGroupInitialized(), "expected raft group to be initialized")
 }
 
 // TestFailedConfChange verifies correct behavior after a configuration change


### PR DESCRIPTION
This deflakes `TestInitRaftGroupOnRequest` by ignoring any request
errors -- typically a `NotLeaseHolderError` since we don't know who has
the lease. The test doesn't care about whether the request succeeds,
only that the Raft group gets initialized.

This error check and subsequent flake was introduced in
64cb8f23737e62eaab63d233cdff78c26d8f7432.

Resolves #80618.

Release note: None