### PR TITLE
acceptance: skip TestComposeGSSPython

### DIFF
--- a/pkg/acceptance/compose_test.go
+++ b/pkg/acceptance/compose_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/pkg/build/bazel"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 )
 
 const composeDir = "compose"
@@ -29,6 +30,7 @@ func TestComposeGSS(t *testing.T) {
 }
 
 func TestComposeGSSPython(t *testing.T) {
+	skip.WithIssue(t, 81254)
 	testCompose(t, filepath.Join("gss", "docker-compose-python.yml"), "python")
 }
 


### PR DESCRIPTION
This is now broken due to a new version of `psql` being pulled in that
is more strict about cert ownership.

See https://github.com/cockroachdb/cockroach/issues/81254.

Release note: None