### PR TITLE
sql: inverted index accelerate json ? string, json ?& array, and json ?| array ops

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -767,7 +767,8 @@ INSERT INTO f VALUES
   (31, 'null'),
   (32, '{}'),
   (33, '[]'),
-  (34, '{"a": {"b": []}}')
+  (34, '{"a": {"b": []}}'),
+  (35, '["a"]')
 
 query T
 SELECT j FROM f@i WHERE j->'a' = '1' ORDER BY k
@@ -1087,6 +1088,46 @@ SELECT j FROM f@i WHERE j->'a'->'b' <@ '{"c": [1, 2], "d": 2}' OR j->'a'->'b' <@
 query T
 SELECT j FROM f@i WHERE j @> '{"a": "c"}' AND (j @> '{"a": "b"}' OR j @> '{"a": "c"}')
 ----
+
+subtest json_exists
+
+statement ok
+CREATE TABLE e (k int PRIMARY KEY, j JSON, INVERTED INDEX i(j))
+
+statement ok
+INSERT INTO e VALUES
+  (0, '{"a": "b"}'),
+  (1, '{"a": {}}'),
+  (2, '{"a": []}'),
+  (3, '{"b": {"a": "c"}}'),
+  (4, '["a", "b"]'),
+  (5, '["b", "a"]'),
+  (6, '["a"]'),
+  (7, '["aargh"]'),
+  (8, '"a"'),
+  (9, '[]'),
+  (10, '3'),
+  (11, NULL),
+  (12, 'null'),
+  (13, 'true')
+
+query T
+SELECT j FROM e@i WHERE j ? 'a' ORDER BY k
+----
+{"a": "b"}
+{"a": {}}
+{"a": []}
+["a", "b"]
+["b", "a"]
+["a"]
+"a"
+
+# Disjunctions containing exists operators use the inverted index.
+query T
+SELECT j FROM e@i WHERE j ? 'aargh' OR j->'b' @> '{"a": "c"}' ORDER BY k
+----
+{"b": {"a": "c"}}
+["aargh"]
 
 subtest arrays
 

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -1097,11 +1097,11 @@ CREATE TABLE e (k int PRIMARY KEY, j JSON, INVERTED INDEX i(j))
 statement ok
 INSERT INTO e VALUES
   (0, '{"a": "b"}'),
-  (1, '{"a": {}}'),
-  (2, '{"a": []}'),
+  (1, '{"a": {}, "b": null}'),
+  (2, '{"a": [], "b": 2, "c": 3}'),
   (3, '{"b": {"a": "c"}}'),
   (4, '["a", "b"]'),
-  (5, '["b", "a"]'),
+  (5, '["b", "a", "c"]'),
   (6, '["a"]'),
   (7, '["aargh"]'),
   (8, '"a"'),
@@ -1115,10 +1115,10 @@ query T
 SELECT j FROM e@i WHERE j ? 'a' ORDER BY k
 ----
 {"a": "b"}
-{"a": {}}
-{"a": []}
+{"a": {}, "b": null}
+{"a": [], "b": 2, "c": 3}
 ["a", "b"]
-["b", "a"]
+["b", "a", "c"]
 ["a"]
 "a"
 
@@ -1128,6 +1128,26 @@ SELECT j FROM e@i WHERE j ? 'aargh' OR j->'b' @> '{"a": "c"}' ORDER BY k
 ----
 {"b": {"a": "c"}}
 ["aargh"]
+
+query T
+SELECT j FROM e@i WHERE j ?& ARRAY['a', 'b'] ORDER BY k
+----
+{"a": {}, "b": null}
+{"a": [], "b": 2, "c": 3}
+["a", "b"]
+["b", "a", "c"]
+
+query T
+SELECT j FROM e@i WHERE j ?| ARRAY['a', 'b'] ORDER BY k
+----
+{"a": "b"}
+{"a": {}, "b": null}
+{"a": [], "b": 2, "c": 3}
+{"b": {"a": "c"}}
+["a", "b"]
+["b", "a", "c"]
+["a"]
+"a"
 
 subtest arrays
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -733,6 +733,91 @@ vectorized: true
               table: d@foo_inv
               spans: 2 spans
 
+# Exists operators.
+
+query T
+EXPLAIN (VERBOSE) SELECT * from d where b ? 'foo'
+----
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (a, b)
+│ estimated row count: 111 (missing stats)
+│ table: d@d_pkey
+│ key columns: a
+│
+└── • project
+    │ columns: (a)
+    │ estimated row count: 111 (missing stats)
+    │
+    └── • inverted filter
+        │ columns: (a, b_inverted_key)
+        │ inverted column: b_inverted_key
+        │ num spans: 3
+        │
+        └── • scan
+              columns: (a, b_inverted_key)
+              estimated row count: 111 (missing stats)
+              table: d@foo_inv
+              spans: /"foo"-/"foo"/PrefixEnd /Arr/"foo"-/Arr/"foo"/PrefixEnd /???-/???
+
+# Note: we use an index hint here because we're unable to determine the
+# selectivity of the filter, which leads to a bad plan without the hint.
+query T
+EXPLAIN (VERBOSE) SELECT * from d@foo_inv where b ? 'foo' OR b @> '{"a": "b"}'
+----
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (a, b)
+│ estimated row count: 333 (missing stats)
+│ table: d@d_pkey
+│ key columns: a
+│
+└── • project
+    │ columns: (a)
+    │ estimated row count: 111 (missing stats)
+    │
+    └── • inverted filter
+        │ columns: (a, b_inverted_key)
+        │ inverted column: b_inverted_key
+        │ num spans: 4
+        │
+        └── • scan
+              columns: (a, b_inverted_key)
+              estimated row count: 111 (missing stats)
+              table: d@foo_inv
+              spans: /"foo"-/"foo"/PrefixEnd /Arr/"foo"-/Arr/"foo"/PrefixEnd /"a"/"b"-/"a"/"b"/PrefixEnd /???-/???
+
+query T
+EXPLAIN (VERBOSE) SELECT * from d where b ? 'foo' AND b->'b' @> '{"a": "b"}'
+----
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (a, b)
+│ estimated row count: 12 (missing stats)
+│ table: d@d_pkey
+│ key columns: a
+│
+└── • project
+    │ columns: (a)
+    │ estimated row count: 111 (missing stats)
+    │
+    └── • inverted filter
+        │ columns: (a, b_inverted_key)
+        │ inverted column: b_inverted_key
+        │ num spans: 4
+        │
+        └── • scan
+              columns: (a, b_inverted_key)
+              estimated row count: 111 (missing stats)
+              table: d@foo_inv
+              spans: /"foo"-/"foo"/PrefixEnd /Arr/"foo"-/Arr/"foo"/PrefixEnd /"b"/"a"/"b"-/"b"/"a"/"b"/PrefixEnd /???-/???
+
 # Multi-path contains queries. Should create zigzag joins.
 
 query T

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -818,6 +818,60 @@ vectorized: true
               table: d@foo_inv
               spans: /"foo"-/"foo"/PrefixEnd /Arr/"foo"-/Arr/"foo"/PrefixEnd /"b"/"a"/"b"-/"b"/"a"/"b"/PrefixEnd /???-/???
 
+query T
+EXPLAIN (VERBOSE) SELECT * from d where b ?| ARRAY['foo', 'bar']
+----
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (a, b)
+│ estimated row count: 12 (missing stats)
+│ table: d@d_pkey
+│ key columns: a
+│
+└── • project
+    │ columns: (a)
+    │ estimated row count: 111 (missing stats)
+    │
+    └── • inverted filter
+        │ columns: (a, b_inverted_key)
+        │ inverted column: b_inverted_key
+        │ num spans: 6
+        │
+        └── • scan
+              columns: (a, b_inverted_key)
+              estimated row count: 111 (missing stats)
+              table: d@foo_inv
+              spans: /"bar"-/"bar"/PrefixEnd /"foo"-/"foo"/PrefixEnd /Arr/"bar"-/Arr/"bar"/PrefixEnd /Arr/"foo"-/Arr/"foo"/PrefixEnd /???-/??? /???-/???
+
+query T
+EXPLAIN (VERBOSE) SELECT * from d where b ?& ARRAY['foo', 'bar']
+----
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (a, b)
+│ estimated row count: 12 (missing stats)
+│ table: d@d_pkey
+│ key columns: a
+│
+└── • project
+    │ columns: (a)
+    │ estimated row count: 111 (missing stats)
+    │
+    └── • inverted filter
+        │ columns: (a, b_inverted_key)
+        │ inverted column: b_inverted_key
+        │ num spans: 6
+        │
+        └── • scan
+              columns: (a, b_inverted_key)
+              estimated row count: 111 (missing stats)
+              table: d@foo_inv
+              spans: /"bar"-/"bar"/PrefixEnd /"foo"-/"foo"/PrefixEnd /Arr/"bar"-/Arr/"bar"/PrefixEnd /Arr/"foo"-/Arr/"foo"/PrefixEnd /???-/??? /???-/???
+
 # Multi-path contains queries. Should create zigzag joins.
 
 query T

--- a/pkg/sql/opt/invertedidx/json_array.go
+++ b/pkg/sql/opt/invertedidx/json_array.go
@@ -150,6 +150,18 @@ func getInvertedExprForJSONOrArrayIndexForContainedBy(
 	return invertedExpr
 }
 
+// getInvertedExprForJSONIndexForExists gets an inverted.Expression that
+// constrains a JSON index according to the given constant. This results in a
+// span expression representing all objects that have the input string datum
+// as a top level key.
+func getInvertedExprForJSONIndexForExists(evalCtx *eval.Context, d tree.Datum) inverted.Expression {
+	invertedExpr, err := rowenc.EncodeExistsInvertedIndexSpans(evalCtx, d)
+	if err != nil {
+		panic(err)
+	}
+	return invertedExpr
+}
+
 // getInvertedExprForArrayIndexForOverlaps gets an inverted.Expression
 // that constrains an Array index according to the given constant.
 // This results in a span expression representing the union of all paths
@@ -248,6 +260,8 @@ func NewJSONOrArrayDatumsToInvertedExpr(
 					invertedExpr = getInvertedExprForJSONOrArrayIndexForContaining(evalCtx, d)
 				case treecmp.Overlaps:
 					invertedExpr = getInvertedExprForArrayIndexForOverlaps(evalCtx, d)
+				case treecmp.JSONExists:
+					invertedExpr = getInvertedExprForJSONIndexForExists(evalCtx, d)
 				default:
 					return nil, fmt.Errorf("%s cannot be index-accelerated", t)
 				}
@@ -360,6 +374,8 @@ func (j *jsonOrArrayFilterPlanner) extractInvertedFilterConditionFromLeaf(
 		invertedExpr = j.extractJSONOrArrayContainsCondition(evalCtx, t.Left, t.Right, false /* containedBy */)
 	case *memo.ContainedByExpr:
 		invertedExpr = j.extractJSONOrArrayContainsCondition(evalCtx, t.Left, t.Right, true /* containedBy */)
+	case *memo.JsonExistsExpr:
+		invertedExpr = j.extractJSONExistsCondition(evalCtx, t.Left, t.Right)
 	case *memo.EqExpr:
 		if fetch, ok := t.Left.(*memo.FetchValExpr); ok {
 			invertedExpr = j.extractJSONFetchValEqCondition(evalCtx, fetch, t.Right)
@@ -455,6 +471,25 @@ func (j *jsonOrArrayFilterPlanner) extractJSONOrArrayContainsCondition(
 		return getInvertedExprForJSONOrArrayIndexForContainedBy(evalCtx, d)
 	}
 	return getInvertedExprForJSONOrArrayIndexForContaining(evalCtx, d)
+}
+
+// extractJSONExistsCondition extracts an InvertedExpression representing an
+// inverted filter with the JSONExists (?) operator over the planner's inverted
+// index, based on the given left and right expression arguments. Returns an
+// empty InvertedExpression if no inverted filter could be extracted.
+func (j *jsonOrArrayFilterPlanner) extractJSONExistsCondition(
+	evalCtx *eval.Context, left, right opt.ScalarExpr,
+) inverted.Expression {
+	if isIndexColumn(j.tabID, j.index, left, j.computedColumns) && memo.CanExtractConstDatum(right) {
+		// When the first argument is a variable or expression corresponding to the
+		// index column and the second argument is a constant, we get the
+		// InvertedExpression for left ? right.
+		constantVal := right
+		d := memo.ExtractConstDatum(constantVal)
+		return getInvertedExprForJSONIndexForExists(evalCtx, d)
+	}
+	// If none of the conditions are met, we cannot create an InvertedExpression.
+	return inverted.NonInvertedColExpression{}
 }
 
 // extractJSONFetchValEqCondition extracts an InvertedExpression representing an

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -2916,6 +2916,10 @@ func countPaths(conjunct *FiltersItem) int {
 		return 1
 	}
 
+	if conjunct.Condition.Op() == opt.JsonExistsOp {
+		return 1
+	}
+
 	rhs := conjunct.Condition.Child(1)
 	if !CanExtractConstDatum(rhs) {
 		return 0
@@ -3069,6 +3073,7 @@ func (sb *statisticsBuilder) applyFiltersItem(
 	// we can't get to the JSON or Array datum or enumerate its paths, count
 	// the whole operator as one conjunct.
 	if filter.Condition.Op() == opt.ContainsOp ||
+		filter.Condition.Op() == opt.JsonExistsOp ||
 		(filter.Condition.Op() == opt.EqOp && filter.Condition.Child(0).Op() == opt.FetchValOp) {
 		numPaths := countPaths(filter)
 		if numPaths == 0 {

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -648,10 +648,13 @@ func EncodeContainedInvertedIndexSpans(
 // string datum. These spans should be used to find the objects in the index
 // that have the string datum as a top-level key.
 //
+// If val is an array, then the inverted expression is a conjunction if all is
+// true, and a disjunction otherwise.
+//
 // The spans are returned in an inverted.SpanExpression, which represents the
 // set operations that must be applied on the spans read during execution.
 func EncodeExistsInvertedIndexSpans(
-	evalCtx *eval.Context, val tree.Datum,
+	evalCtx *eval.Context, val tree.Datum, all bool,
 ) (invertedExpr inverted.Expression, err error) {
 	if val == tree.DNull {
 		return nil, nil
@@ -661,6 +664,28 @@ func EncodeExistsInvertedIndexSpans(
 	case types.StringFamily:
 		s := string(*val.(*tree.DString))
 		return json.EncodeExistsInvertedIndexSpans(nil /* inKey */, s)
+	case types.ArrayFamily:
+		if val.ResolvedType().ArrayContents().Family() != types.StringFamily {
+			return nil, errors.AssertionFailedf(
+				"trying to apply inverted index to unsupported type %s", datum.ResolvedType(),
+			)
+		}
+		var expr inverted.Expression
+		for _, d := range val.(*tree.DArray).Array {
+			s := string(*d.(*tree.DString))
+			newExpr, err := json.EncodeExistsInvertedIndexSpans(nil /* inKey */, s)
+			if err != nil {
+				return nil, err
+			}
+			if expr == nil {
+				expr = newExpr
+			} else if all {
+				expr = inverted.And(expr, newExpr)
+			} else {
+				expr = inverted.Or(expr, newExpr)
+			}
+		}
+		return expr, nil
 	default:
 		return nil, errors.AssertionFailedf(
 			"trying to apply inverted index to unsupported type %s", datum.ResolvedType(),


### PR DESCRIPTION
Closes #81114

This commit adds support for accelerating the json ? string operator
when the json argument is a column that has an inverted index over it.

Release note (sql change): the json ? string operator is now index
accelerated if there is an inverted index over the json column referred
to on the left hand side of the expression.