### PR TITLE
util,kvserver: add sliding window aggregator for l0 max

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -494,6 +494,7 @@ ALL_TESTS = [
     "//pkg/util/sdnotify:sdnotify_test",
     "//pkg/util/search:search_test",
     "//pkg/util/shuffle:shuffle_test",
+    "//pkg/util/slidingwindow:slidingwindow_test",
     "//pkg/util/span:span_test",
     "//pkg/util/stop:stop_test",
     "//pkg/util/stringarena:stringarena_test",

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -188,6 +188,7 @@ go_library(
         "//pkg/util/quotapool",
         "//pkg/util/retry",
         "//pkg/util/shuffle",
+        "//pkg/util/slidingwindow",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer.go
@@ -79,7 +79,7 @@ const (
 
 	// L0SublevelInterval is the period over which to accumulate statistics on
 	// the number of L0 sublevels within a store.
-	L0SublevelInterval = time.Minute * 5
+	L0SublevelInterval = time.Minute * 2
 
 	// L0SublevelMaxSampled is maximum number of L0 sub-levels that may exist
 	// in a sample. This setting limits the extreme skew that could occur by

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -28,7 +28,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/metric/aggmetric"
+	"github.com/cockroachdb/cockroach/pkg/util/slidingwindow"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"go.etcd.io/etcd/raft/v3/raftpb"
 )
 
@@ -293,12 +295,6 @@ var (
 		Name:        "rebalancing.writespersecond",
 		Help:        "Number of keys written (i.e. applied by raft) per second to the store, averaged over a large time period as used in rebalancing decisions",
 		Measurement: "Keys/Sec",
-		Unit:        metric.Unit_COUNT,
-	}
-	metaL0SubLevelHistogram = metric.Metadata{
-		Name:        "rebalancing.l0_sublevels_histogram",
-		Help:        "The summary view of sub levels in level 0 of the stores LSM",
-		Measurement: "Storage",
 		Unit:        metric.Unit_COUNT,
 	}
 	metaAverageRequestsPerSecond = metric.Metadata{
@@ -1453,13 +1449,19 @@ type StoreMetrics struct {
 	Reserved           *metric.Gauge
 
 	// Rebalancing metrics.
-	L0SubLevelsHistogram       *metric.Histogram
 	AverageQueriesPerSecond    *metric.GaugeFloat64
 	AverageWritesPerSecond     *metric.GaugeFloat64
 	AverageReadsPerSecond      *metric.GaugeFloat64
 	AverageRequestsPerSecond   *metric.GaugeFloat64
 	AverageWriteBytesPerSecond *metric.GaugeFloat64
 	AverageReadBytesPerSecond  *metric.GaugeFloat64
+	// l0SublevelsWindowedMax doesn't get recorded to metrics itself, it maintains
+	// an ad-hoc history for gosipping information for allocator use.
+	l0SublevelsWindowedMax syncutil.AtomicFloat64
+	l0SublevelsTracker     struct {
+		syncutil.Mutex
+		swag *slidingwindow.Swag
+	}
 
 	// Follower read metrics.
 	FollowerReadsCount *metric.Counter
@@ -1879,6 +1881,7 @@ func newTenantsStorageMetrics() *TenantsStorageMetrics {
 func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 	storeRegistry := metric.NewRegistry()
 	rdbBytesIngested := storageLevelGaugeSlice(metaRdbBytesIngested)
+
 	sm := &StoreMetrics{
 		registry:              storeRegistry,
 		TenantsStorageMetrics: newTenantsStorageMetrics(),
@@ -1917,15 +1920,8 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		Reserved:  metric.NewGauge(metaReserved),
 
 		// Rebalancing metrics.
-		AverageQueriesPerSecond: metric.NewGaugeFloat64(metaAverageQueriesPerSecond),
-		AverageWritesPerSecond:  metric.NewGaugeFloat64(metaAverageWritesPerSecond),
-		// TODO(tbg): this histogram seems bogus? What are we tracking here?
-		L0SubLevelsHistogram: metric.NewHistogram(
-			metaL0SubLevelHistogram,
-			allocatorimpl.L0SublevelInterval,
-			allocatorimpl.L0SublevelMaxSampled,
-			1, /* sig figures (integer) */
-		),
+		AverageQueriesPerSecond:    metric.NewGaugeFloat64(metaAverageQueriesPerSecond),
+		AverageWritesPerSecond:     metric.NewGaugeFloat64(metaAverageWritesPerSecond),
 		AverageRequestsPerSecond:   metric.NewGaugeFloat64(metaAverageRequestsPerSecond),
 		AverageReadsPerSecond:      metric.NewGaugeFloat64(metaAverageReadsPerSecond),
 		AverageWriteBytesPerSecond: metric.NewGaugeFloat64(metaAverageWriteBytesPerSecond),
@@ -2127,8 +2123,21 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		ReplicaCircuitBreakerCurTripped: metric.NewGauge(metaReplicaCircuitBreakerCurTripped),
 		ReplicaCircuitBreakerCumTripped: metric.NewCounter(metaReplicaCircuitBreakerCumTripped),
 	}
-	storeRegistry.AddMetricStruct(sm)
 
+	{
+		// Track the maximum L0 sublevels seen in the last 10 minutes. backed
+		// by a sliding window, which we  record and query indirectly in
+		// L0SublevelsMax. this is not exported to as metric.
+		sm.l0SublevelsTracker.swag = slidingwindow.NewMaxSwag(
+			timeutil.Now(),
+			allocatorimpl.L0SublevelInterval,
+			// 5 sliding windows, by the default interval (2 mins) will track the
+			// maximum for up to 10 minutes. Selected experimentally.
+			5,
+		)
+	}
+
+	storeRegistry.AddMetricStruct(sm)
 	return sm
 }
 
@@ -2193,11 +2202,17 @@ func (sm *StoreMetrics) updateEngineMetrics(m storage.Metrics) {
 	sm.RdbReadAmplification.Update(int64(m.ReadAmp()))
 	sm.RdbPendingCompaction.Update(int64(m.Compact.EstimatedDebt))
 	sm.RdbMarkedForCompactionFiles.Update(int64(m.Compact.MarkedFiles))
-	sm.L0SubLevelsHistogram.RecordValue(int64(m.Levels[0].Sublevels))
 	sm.RdbNumSSTables.Update(m.NumSSTables())
 	sm.RdbWriteStalls.Update(m.WriteStallCount)
 	sm.DiskSlow.Update(m.DiskSlowCount)
 	sm.DiskStalled.Update(m.DiskStallCount)
+
+	// Update the maximum number of L0 sub-levels seen.
+	sm.l0SublevelsTracker.Lock()
+	sm.l0SublevelsTracker.swag.Record(timeutil.Now(), float64(m.Levels[0].Sublevels))
+	curMax, _ := sm.l0SublevelsTracker.swag.Query(timeutil.Now())
+	sm.l0SublevelsTracker.Unlock()
+	syncutil.StoreFloat64(&sm.l0SublevelsWindowedMax, curMax)
 
 	sm.RdbL0Sublevels.Update(int64(m.Levels[0].Sublevels))
 	sm.RdbL0NumFiles.Update(m.Levels[0].NumFiles)

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -665,17 +665,6 @@ var charts = []sectionDescription{
 	{
 		Organization: [][]string{
 			{DistributionLayer, "Rebalancing"},
-		},
-		Charts: []chartDescription{
-			{
-				Title:   "L0 sub-level rebalancing",
-				Metrics: []string{"rebalancing.l0_sublevels_histogram"},
-			},
-		},
-	},
-	{
-		Organization: [][]string{
-			{DistributionLayer, "Rebalancing"},
 			{ReplicationLayer, "Leases"},
 		},
 		Charts: []chartDescription{

--- a/pkg/util/slidingwindow/BUILD.bazel
+++ b/pkg/util/slidingwindow/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "slidingwindow",
+    srcs = [
+        "helpers.go",
+        "sliding_window.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/util/slidingwindow",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "slidingwindow_test",
+    srcs = ["sliding_window_test.go"],
+    embed = [":slidingwindow"],
+    deps = ["@com_github_stretchr_testify//require"],
+)

--- a/pkg/util/slidingwindow/helpers.go
+++ b/pkg/util/slidingwindow/helpers.go
@@ -1,0 +1,28 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package slidingwindow
+
+import "time"
+
+// NewMaxSwag returns a sliding window aggregator with a maximum aggregator.
+func NewMaxSwag(now time.Time, interval time.Duration, size int) *Swag {
+	return NewSwag(
+		now,
+		interval,
+		size,
+		func(acc, val float64) float64 {
+			if acc > val {
+				return acc
+			}
+			return val
+		},
+	)
+}

--- a/pkg/util/slidingwindow/sliding_window.go
+++ b/pkg/util/slidingwindow/sliding_window.go
@@ -1,0 +1,118 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package slidingwindow
+
+import "time"
+
+// Swag represents a sliding window aggregator over a binary operation.
+// The aggregator will aggregate recorded values in two ways:
+// (1) Within each window, the binary operation is applied when recording a new
+//     value into the current window.
+// (2) On Query, the binary operation is accumulated over every window, from
+//     most to least recent.
+// The binary operator function must therefore be:
+//     associative :: binOp(binOp(a,b), c) = binOp(a,binOp(b,c))
+// In order to have correct results. Note that this does not allow for a more
+// general class of aggregators that may be  associative, such as geometric
+// mean, bloom filters etc. These require special treatment with user defined
+// functions for lift(e), lower(a) and combine(v1,v2)
+// (https://dl.acm.org/doi/pdf/10.1145/3093742.3093925).
+//
+// query: O(k), append: O(k), space O(k), k = |windows|.
+// The average case append is O(1), when no windows
+// require rotating; the size requirement is 32 + 8k bytes.
+type Swag struct {
+	curIdx         int
+	windows        []*float64
+	lastRotate     time.Time
+	rotateInterval time.Duration
+	binOp          func(acc, val float64) float64
+}
+
+// NewSwag returns a new sliding window aggregator.
+func NewSwag(
+	now time.Time, interval time.Duration, size int, binOp func(acc, val float64) float64,
+) *Swag {
+	windows := make([]*float64, size)
+	var first float64
+	windows[0] = &first
+	return &Swag{
+		curIdx:         0,
+		windows:        windows,
+		lastRotate:     now,
+		rotateInterval: interval,
+		binOp:          binOp,
+	}
+}
+
+// Record takes a value and applies the binary operation with the current
+// bucket and the value.
+func (s *Swag) Record(now time.Time, val float64) {
+	s.maybeRotate(now)
+	*s.windows[s.curIdx] = s.binOp(*s.windows[s.curIdx], val)
+}
+
+// maybeRotate checks the passed in time with the last rotate time. If the
+// duration elapsed is greater than the rotate interval, it will rotate the
+// windows, adding the interval to the last rotate time. This continues until
+// the duration elapsed no longer greater last rotate +  interval.
+func (s *Swag) maybeRotate(now time.Time) {
+	sinceLastRotate := now.Sub(s.lastRotate)
+	if sinceLastRotate < s.rotateInterval {
+		return
+	}
+
+	size := len(s.windows)
+	shift := int(sinceLastRotate / s.rotateInterval)
+	for i := 0; i < shift; i++ {
+		s.curIdx = (s.curIdx + 1) % size
+		s.lastRotate = s.lastRotate.Add(s.rotateInterval)
+		var next float64
+		s.windows[s.curIdx] = &next
+	}
+}
+
+// Query applies the binOp across each window accumulated, from most recent to
+// least recent window. This requires that the binOp fn is associative.
+func (s *Swag) Query(now time.Time) (float64, time.Duration) {
+	windows := s.Windows(now)
+	timeSinceRotate := now.Sub(s.lastRotate)
+
+	var accumulator float64
+	var duration time.Duration
+	for i, next := range windows {
+		accumulator = s.binOp(accumulator, next)
+		if i == 0 {
+			duration += time.Duration(float64(timeSinceRotate))
+		} else {
+			duration += time.Duration(float64(s.rotateInterval))
+		}
+	}
+	return accumulator, duration
+}
+
+// Windows returns the currently populated windows, in most recent to least
+// recent order. It will not return unpopulated windows, if total duration is
+// less than size * rotateInterval.
+func (s *Swag) Windows(now time.Time) []float64 {
+	s.maybeRotate(now)
+	size := len(s.windows)
+	ret := make([]float64, 0, 1)
+
+	for i := 0; i < size; i++ {
+		next := s.windows[(s.curIdx+size-i)%size]
+		if next == nil {
+			break
+		}
+		ret = append(ret, *next)
+	}
+	return ret
+}

--- a/pkg/util/slidingwindow/sliding_window_test.go
+++ b/pkg/util/slidingwindow/sliding_window_test.go
@@ -1,0 +1,120 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package slidingwindow
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSlidingWindow asserts that the sliding windows correctly rotate old
+// windows; report the correct aggregate query and duration.
+func TestSlidingWindow(t *testing.T) {
+	startTime := time.Date(1, 2, 3, 4, 5, 6, 7, time.UTC)
+	interval := time.Second * 1
+
+	max := func(a, b float64) float64 {
+		if a > b {
+			return a
+		}
+		return b
+	}
+	sum := func(a, b float64) float64 {
+		return a + b
+	}
+
+	testCases := []struct {
+		desc             string
+		recordedTicks    [][]float64
+		binOp            func(a, b float64) float64
+		expectedWindows  []float64
+		expectedAgg      float64
+		expectedDuration time.Duration
+	}{
+		{
+			desc:             "every window, no overlap max",
+			recordedTicks:    [][]float64{{1}, {2}, {3}, {4}},
+			binOp:            max,
+			expectedWindows:  []float64{4, 3, 2, 1},
+			expectedAgg:      4,
+			expectedDuration: interval * 4,
+		},
+		{
+			desc:             "every window, no overlap sum",
+			recordedTicks:    [][]float64{{1}, {2}, {3}, {4}},
+			binOp:            sum,
+			expectedWindows:  []float64{4, 3, 2, 1},
+			expectedAgg:      10,
+			expectedDuration: interval * 4,
+		},
+		{
+			desc:             "partial windows, overlap max",
+			recordedTicks:    [][]float64{{}, {1}, {}, {2}, {}, {3}, {}, {4}},
+			binOp:            max,
+			expectedWindows:  []float64{4, 0, 3, 0},
+			expectedAgg:      4,
+			expectedDuration: interval * 4,
+		},
+		{
+			desc:             "partial windows, overlap sum",
+			recordedTicks:    [][]float64{{}, {1}, {}, {2}, {}, {3}, {}, {4}},
+			binOp:            sum,
+			expectedWindows:  []float64{4, 0, 3, 0},
+			expectedAgg:      7,
+			expectedDuration: interval * 4,
+		},
+		{
+			desc:             "empty windows",
+			recordedTicks:    [][]float64{{}, {}, {}, {}, {}, {}, {}, {}},
+			binOp:            sum,
+			expectedWindows:  []float64{0, 0, 0, 0},
+			expectedAgg:      0,
+			expectedDuration: interval * 4,
+		},
+		{
+			desc:          "2 windows, max",
+			recordedTicks: [][]float64{{100, 200, 300}, {200, 400, 600}},
+			binOp:         max,
+			// We increment the query time by a second below, so we expect the
+			// duration to be rounded up to 3.
+			expectedWindows:  []float64{600, 300, 0},
+			expectedAgg:      600,
+			expectedDuration: interval * 3,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			swag := NewSwag(startTime, interval, 4, tc.binOp)
+
+			curTime := startTime
+			for _, records := range tc.recordedTicks {
+				curTime = curTime.Add(swag.rotateInterval)
+				for _, record := range records {
+					swag.Record(curTime, record)
+				}
+			}
+
+			// Add another interval to the query time, just shy of the rotate
+			// interval - to round up the duration returned from query and
+			// avoid nasty decimals.
+			curTime = curTime.Add(swag.rotateInterval - time.Microsecond)
+			agg, duration := swag.Query(curTime)
+
+			require.EqualValues(t, tc.expectedWindows, swag.Windows(curTime))
+			require.Equal(t, tc.expectedAgg, agg)
+			require.Equal(t, tc.expectedDuration, duration.Round(time.Second))
+		})
+	}
+
+}


### PR DESCRIPTION
resolves: https://github.com/cockroachdb/cockroach/issues/81045

This patch introduces a sliding window aggregator (swag) as a utility
data structure and uses it for maintaining the maximum number of L0 
sub-levels seen in the past 10 minutes.

Swag represents a sliding window aggregator over a binary operation.
The aggregator will aggregate recorded values in two ways:
(1) Within each window, the binary operation is applied when recording a new
    value into the current window.
(2) On Query, the binary operation is accumulated over every window, from
    most to least recent.
The binary operator function must therefore be:
    associative :: binOp(binOp(a,b), c) = binOp(a,binOp(b,c))
In order to have correct results. Note that this does not allow for a more
general class of aggregators that are associative. As we are per-aggregating
the value in each window, to reduce the size requirement. In order to support a
more general class of sliding window associative aggregators, we need to
maintain every recorded value such that the size of the window is equivalent to
the number of elements seen in the interval defined. These also require special
treatment with user defined functions for lift(e), lower(a) and combine(v1,v2)
    (https://dl.acm.org/doi/pdf/10.1145/3093742.3093925).


query: O(k), append: O(k), space O(k), k = |windows|.
The average case append is O(1), when no windows
require rotating; the size requirement is 32 + 8k bytes.
