### PR TITLE
sql: fix duplicated schema change job descriptions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -216,6 +216,23 @@ SHOW TABLES
 ----
 public  users  table  root  0  NULL
 
+# Test that schema change job description is correct #80889
+statement ok
+CREATE TABLE tbl (c string);
+
+statement ok
+CREATE INDEX expr_idx ON tbl(lower(c));
+
+statement ok
+DROP INDEX expr_idx;
+
+query T colnames
+SELECT description FROM [show jobs] ORDER BY created DESC LIMIT 2;
+----
+description
+GC for DROP INDEX test.public.tbl@expr_idx
+DROP INDEX test.public.tbl@expr_idx
+
 # Test the syntax without a '@'
 
 statement ok

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -217,7 +217,9 @@ func (p *planner) createOrUpdateSchemaChangeJob(
 		}
 	}
 	record.Details = newDetails
-	record.AppendDescription(jobDesc)
+	if record.Description != jobDesc {
+		record.AppendDescription(jobDesc)
+	}
 	log.Infof(ctx, "job %d: updated with schema change for table %d, mutation %d",
 		record.JobID, tableDesc.ID, mutationID)
 	return nil


### PR DESCRIPTION
Fixes #80889 
 
Release note(bug fix):
Fixed a bug that caused duplicated schema change job description messages.