### PR TITLE
backupccl,roachpb: introduce Aggregator to listen for StructuredEvents

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -112,6 +112,7 @@ go_library(
         "//pkg/storage",
         "//pkg/util",
         "//pkg/util/admission/admissionpb",
+        "//pkg/util/bulk",
         "//pkg/util/contextutil",
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",

--- a/pkg/ccl/backupccl/backup.proto
+++ b/pkg/ccl/backupccl/backup.proto
@@ -193,22 +193,3 @@ message BackupProgressTraceEvent {
   util.hlc.Timestamp revision_start_time = 3 [(gogoproto.nullable) = false];
 }
 
-// BackupExportTraceRequestEvent is the trace event recorded when an
-// ExportRequest has been sent.
-message BackupExportTraceRequestEvent {
-  string span = 1;
-  int32 attempt = 2;
-  string priority = 3;
-  string req_sent_time = 4;
-}
-
-// BackupExportTraceResponseEvent is the trace event recorded when we receive a
-// response from the ExportRequest.
-message BackupExportTraceResponseEvent {
-  string duration = 1;
-  int32 num_files = 2;
-  repeated roachpb.RowCount file_summaries = 3 [(gogoproto.nullable) = false];
-  reserved 4 ;
-  string retryable_error = 5;
-}
-

--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//pkg/storage/enginepb",
         "//pkg/util",
         "//pkg/util/bitarray",
+        "//pkg/util/bulk",
         "//pkg/util/caller",
         "//pkg/util/duration",
         "//pkg/util/encoding",
@@ -60,6 +61,7 @@ go_library(
         "@com_github_gogo_protobuf//proto",
         "@com_github_golang_mock//gomock",  # keep
         "@io_etcd_go_etcd_raft_v3//raftpb",
+        "@io_opentelemetry_go_otel//attribute",
         "@org_golang_google_grpc//metadata",  # keep
     ],
 )

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -3020,3 +3020,28 @@ message ScanStats {
   uint64 point_count = 9;
   uint64 points_covered_by_range_tombstones = 10;
 }
+
+// ExportStats is a message containing information about each
+// Export{Request,Response}.
+message ExportStats {
+  // NumFiles is the number of SST files produced by the ExportRequest.
+  int64 num_files = 1;
+  // DataSize is the byte size of all the SST files produced by the
+  // ExportRequest.
+  int64 data_size = 2;
+
+
+  // SentPerNode is a mapping from NodeID to the number of ExportRequests sent
+  // by the node for evaluation.
+  map <int32, int32> sent_per_node = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.castkey) = "NodeID"
+  ];
+
+  // EvaluatedPerNode is a mapping from NodeID to the number of ExportRequests
+  // evaluated by the node.
+  map <int32, int32> evaluated_per_node = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.castkey) = "NodeID"
+  ];
+}

--- a/pkg/util/bulk/BUILD.bazel
+++ b/pkg/util/bulk/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "bulk",
+    srcs = ["aggregator.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/util/bulk",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/util/syncutil",
+        "//pkg/util/tracing",
+    ],
+)

--- a/pkg/util/bulk/aggregator.go
+++ b/pkg/util/bulk/aggregator.go
@@ -1,0 +1,90 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package bulk
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+)
+
+// AggregatorEvent describes an event that can be aggregated and stored by the
+// Aggregator. An AggregatorEvent also implements the tracing.LazyTag interface
+// to render its information on the associated tracing span.
+type AggregatorEvent interface {
+	tracing.LazyTag
+
+	// Combine combines two AggregatorEvents together.
+	Combine(other AggregatorEvent)
+	// Tag returns a string used to identify the AggregatorEvent.
+	Tag() string
+}
+
+// Aggregator implements the tracing.EventListener interface.
+//
+// An Aggregator when registered as an EventListener with a tracing span, will
+// aggregate all AggregatorEvents that are emitted in the span's recording.
+//
+// Each AggregatorEvent will set itself as a LazyTag on the associated span and
+// thereby Render() its aggregated information whenever the span's recording is
+// pulled.
+type Aggregator struct {
+	mu struct {
+		syncutil.Mutex
+		// aggregatedEvents is a mapping from the tag identifying the
+		// AggregatorEvent to the running aggregate of the AggregatorEvent.
+		aggregatedEvents map[string]AggregatorEvent
+		// sp is the tracing span associated with the Aggregator.
+		sp *tracing.Span
+	}
+}
+
+// Notify implements the tracing.EventListener interface.
+func (b *Aggregator) Notify(event tracing.Structured) {
+	bulkEvent, ok := event.(AggregatorEvent)
+	if !ok {
+		return
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.mu.sp == nil {
+		panic("Init not called on Aggregator before use")
+	}
+
+	// If this is the first AggregatorEvent with this tag, set it as a LazyTag on
+	// the associated tracing span. This way the AggregatorEvent will be
+	// dynamically Render()ed everytime we pull the tracing for the associated
+	// span.
+	if _, ok := b.mu.aggregatedEvents[bulkEvent.Tag()]; !ok {
+		b.mu.aggregatedEvents[bulkEvent.Tag()] = bulkEvent
+		b.mu.sp.SetLazyTag(bulkEvent.Tag(), b.mu.aggregatedEvents[bulkEvent.Tag()])
+	} else {
+		b.mu.aggregatedEvents[bulkEvent.Tag()].Combine(bulkEvent)
+	}
+}
+
+// Init initializes the Aggregator. The Aggregator is only ready to use after
+// Init has been called.
+func (b *Aggregator) Init(sp *tracing.Span) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.mu.sp = sp
+}
+
+var _ tracing.EventListener = &Aggregator{}
+
+// MakeAggregator returns an instance of an Aggregator.
+func MakeAggregator() *Aggregator {
+	agg := &Aggregator{}
+	agg.mu.aggregatedEvents = make(map[string]AggregatorEvent)
+	return agg
+}


### PR DESCRIPTION
This change introduces an Aggregator that can be registered as an EventListener
and LazyTag on a tracing span. The Aggregator will be notified on every
StructuredEvent emitted in the span's recording, and will subsume the event
into a running aggregate stored in memory.
This running aggregate will be rendered on the span's recording as a LazyTag
that can be consumed via the `tracez` page on the debug console.

Currently, the backup processor is the only bulk processor that creates and
registers an Aggregator. As an initial prototype this change teaches every
ExportRequest to emit ExportStats that will be aggregated by the Aggregator.

Note, this change also removes various StructuredEvents that were emitted by
the backup processor but have never proved useful. These were added as part of
the `cockroach debug job-trace` command which we hope to replace with this Aggregator.

Informs: https://github.com/cockroachdb/cockroach/issues/80388

Release note: None