### PR TITLE
release-22.1.0: backport TTL bug fixes and usability improvements

### DIFF
--- a/pkg/sql/ttl/ttljob/ttljob.go
+++ b/pkg/sql/ttl/ttljob/ttljob.go
@@ -284,12 +284,11 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) err
 
 	var initialVersion descpb.DescriptorVersion
 
-	// TODO(#75428): feature flag check, ttl pause check.
 	var ttlSettings catpb.RowLevelTTL
 	var pkColumns []string
 	var pkTypes []*types.T
 	var relationName string
-	var rangeSpan roachpb.Span
+	var rangeSpan, entirePKSpan roachpb.Span
 	if err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		desc, err := descsCol.GetImmutableTableByID(
 			ctx,
@@ -333,7 +332,8 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) err
 		}
 
 		relationName = tn.FQString()
-		rangeSpan = desc.TableSpan(p.ExecCfg().Codec)
+		entirePKSpan = desc.IndexSpan(p.ExecCfg().Codec, desc.GetPrimaryIndex().GetID())
+		rangeSpan = entirePKSpan
 		ttlSettings = *ttl
 		return nil
 	}); err != nil {
@@ -459,15 +459,40 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) err
 				if err := r.ValueProto(&rangeDesc); err != nil {
 					return err
 				}
-				rangeSpan.Key = rangeDesc.EndKey.AsRawKey()
 				var nextRange rangeToProcess
-				nextRange.startPK, err = keyToDatums(rangeDesc.StartKey, p.ExecCfg().Codec, pkTypes, &alloc)
-				if err != nil {
-					return errors.Wrapf(err, "error decoding starting PRIMARY KEY for range ID %d", rangeDesc.RangeID)
+				// A single range can contain multiple tables or indexes.
+				// If this is the case, the rangeDesc.StartKey would be less than entirePKSpan.Key
+				// or the rangeDesc.EndKey would be greater than the entirePKSpan.EndKey, meaning
+				// the range contains the start or the end of the range respectively.
+				// Trying to decode keys outside the PK range will lead to a decoding error.
+				// As such, only populate nextRange.startPK and nextRange.endPK if this is the case
+				// (by default, a 0 element startPK or endPK means the beginning or end).
+				if rangeDesc.StartKey.AsRawKey().Compare(entirePKSpan.Key) > 0 {
+					nextRange.startPK, err = keyToDatums(rangeDesc.StartKey, p.ExecCfg().Codec, pkTypes, &alloc)
+					if err != nil {
+						return errors.Wrapf(
+							err,
+							"error decoding starting PRIMARY KEY for range ID %d (start key %x, table start key %x)",
+							rangeDesc.RangeID,
+							rangeDesc.StartKey.AsRawKey(),
+							entirePKSpan.Key,
+						)
+					}
 				}
-				nextRange.endPK, err = keyToDatums(rangeDesc.EndKey, p.ExecCfg().Codec, pkTypes, &alloc)
-				if err != nil {
-					return errors.Wrapf(err, "error decoding ending PRIMARY KEY for range ID %d", rangeDesc.RangeID)
+				if rangeDesc.EndKey.AsRawKey().Compare(entirePKSpan.EndKey) < 0 {
+					rangeSpan.Key = rangeDesc.EndKey.AsRawKey()
+					nextRange.endPK, err = keyToDatums(rangeDesc.EndKey, p.ExecCfg().Codec, pkTypes, &alloc)
+					if err != nil {
+						return errors.Wrapf(
+							err,
+							"error decoding ending PRIMARY KEY for range ID %d (end key %x, table end key %x)",
+							rangeDesc.RangeID,
+							rangeDesc.EndKey.AsRawKey(),
+							entirePKSpan.EndKey,
+						)
+					}
+				} else {
+					done = true
 				}
 				ch <- nextRange
 			}

--- a/pkg/sql/ttl/ttljob/ttljob_query_builder_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_query_builder_test.go
@@ -44,6 +44,7 @@ func TestSelectQueryBuilder(t *testing.T) {
 				1,
 				mockTime,
 				[]string{"col1", "col2"},
+				"relation_name",
 				tree.Datums{tree.NewDInt(100), tree.NewDInt(5)},
 				tree.Datums{tree.NewDInt(200), tree.NewDInt(15)},
 				*mockTimestampTZ,
@@ -103,6 +104,7 @@ LIMIT 2`,
 				1,
 				mockTime,
 				[]string{"col1", "col2"},
+				"table_name",
 				nil,
 				nil,
 				*mockTimestampTZ,
@@ -158,6 +160,7 @@ LIMIT 2`,
 				1,
 				mockTime,
 				[]string{"col1", "col2"},
+				"table_name",
 				tree.Datums{tree.NewDInt(100)},
 				tree.Datums{tree.NewDInt(181)},
 				*mockTimestampTZ,
@@ -217,6 +220,7 @@ LIMIT 2`,
 				1,
 				mockTime,
 				[]string{"col1", "col2"},
+				"table_name",
 				nil,
 				tree.Datums{tree.NewDInt(200), tree.NewDInt(15)},
 				*mockTimestampTZ,
@@ -275,6 +279,7 @@ LIMIT 2`,
 				1,
 				mockTime,
 				[]string{"col1", "col2"},
+				"table_name",
 				tree.Datums{tree.NewDInt(100), tree.NewDInt(5)},
 				nil,
 				*mockTimestampTZ,
@@ -361,7 +366,7 @@ func TestDeleteQueryBuilder(t *testing.T) {
 	}{
 		{
 			desc: "single delete less than batch size",
-			b:    makeDeleteQueryBuilder(1, mockTime, []string{"col1", "col2"}, 3),
+			b:    makeDeleteQueryBuilder(1, mockTime, []string{"col1", "col2"}, "table_name", 3),
 			iterations: []iteration{
 				{
 					rows: []tree.Datums{
@@ -379,7 +384,7 @@ func TestDeleteQueryBuilder(t *testing.T) {
 		},
 		{
 			desc: "multiple deletes",
-			b:    makeDeleteQueryBuilder(1, mockTime, []string{"col1", "col2"}, 3),
+			b:    makeDeleteQueryBuilder(1, mockTime, []string{"col1", "col2"}, "table_name", 3),
 			iterations: []iteration{
 				{
 					rows: []tree.Datums{


### PR DESCRIPTION
Backport:
  * 3/3 commits from "ttlschedule: include table name when creating the TTL job" (#79927)
  * 2/2 commits from "ttljob: fix a range edge case" (#81207)

Please see individual PRs for details.

Refs: #81207

/cc @cockroachdb/release

Release justification: contains critical bug fix + useful obs features for new functionality
