### PR TITLE
backupccl: speed up some tests

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -247,7 +247,6 @@ go_test(
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
-        "//pkg/util",
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",
         "//pkg/util/hlc",

--- a/pkg/ccl/backupccl/utils_test.go
+++ b/pkg/ccl/backupccl/utils_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
@@ -66,6 +67,9 @@ func backupRestoreTestSetupWithParams(
 	dir, dirCleanupFn := testutils.TempDir(t)
 	params.ServerArgs.ExternalIODir = dir
 	params.ServerArgs.UseDatabase = "data"
+	if params.ServerArgs.Knobs.JobsTestingKnobs == nil {
+		params.ServerArgs.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
+	}
 	if len(params.ServerArgsPerNode) > 0 {
 		for i := range params.ServerArgsPerNode {
 			param := params.ServerArgsPerNode[i]
@@ -197,6 +201,9 @@ func backupRestoreTestSetupEmptyWithParams(
 	ctx := logtags.AddTag(context.Background(), "backup-restore-test-setup-empty", nil)
 
 	params.ServerArgs.ExternalIODir = dir
+	if params.ServerArgs.Knobs.JobsTestingKnobs == nil {
+		params.ServerArgs.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
+	}
 	if len(params.ServerArgsPerNode) > 0 {
 		for i := range params.ServerArgsPerNode {
 			param := params.ServerArgsPerNode[i]


### PR DESCRIPTION
Some of the tests were not setting jobs adopt loop
to a short interval, this change fixes that. Additionally,
a couple of tests were creating ~1000 users to populate the
`system.users` table. This would queue up a 1000 schema change jobs,
instead we drop the number of users we create to 10 and wrap it in
a txn. The smaller number of users doesn't decrease test coverage but
does speed up tests:

Before:
--- PASS: TestFullClusterBackup (59.61s)
--- PASS: TestClusterRestoreFailCleanup (31.68s)

After:
--- PASS: TestFullClusterBackup (8.0s)
--- PASS: TestClusterRestoreFailCleanup (5.9s)

Release note: None