### PR TITLE
storage: specify and test iterator visibility semantics

### DIFF
--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -426,9 +426,25 @@ type Reader interface {
 	// timestamp of the end key; all MVCCKeys at end.Key are considered excluded
 	// in the iteration.
 	MVCCIterate(start, end roachpb.Key, iterKind MVCCIterKind, f func(MVCCKeyValue) error) error
-	// NewMVCCIterator returns a new instance of an MVCCIterator over this
-	// engine. The caller must invoke MVCCIterator.Close() when finished
-	// with the iterator to free resources.
+	// NewMVCCIterator returns a new instance of an MVCCIterator over this engine.
+	// The caller must invoke Close() on it when done to free resources.
+	//
+	// Write visibility semantics:
+	//
+	// 1. An iterator has a consistent view of the reader as of the time of its
+	//    creation. Subsequent writes are never visible to it.
+	//
+	// 2. All iterators on readers with ConsistentIterators=true have a consistent
+	//    view of the _engine_ (not reader) as of the time of the first iterator
+	//    creation or PinEngineStateForIterators call: newer engine writes are
+	//    never visible. The opposite holds for ConsistentIterators=false: new
+	//    iterators see the most recent engine state at the time of their creation.
+	//
+	// 3. Iterators on unindexed batches never see batch writes, but satisfy
+	//    ConsistentIterators for engine write visibility.
+	//
+	// 4. Iterators on indexed batches see all batch writes as of their creation
+	//    time, but they satisfy ConsistentIterators for engine writes.
 	NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions) MVCCIterator
 	// NewEngineIterator returns a new instance of an EngineIterator over this
 	// engine. The caller must invoke EngineIterator.Close() when finished

--- a/pkg/storage/mvcc_key_test.go
+++ b/pkg/storage/mvcc_key_test.go
@@ -381,3 +381,14 @@ func BenchmarkDecodeMVCCKey(b *testing.B) {
 	}
 	benchmarkDecodeMVCCKeyResult = mvccKey // avoid compiler optimizing away function call
 }
+
+func pointKey(key string, ts int) MVCCKey {
+	return MVCCKey{Key: roachpb.Key(key), Timestamp: hlc.Timestamp{WallTime: int64(ts)}}
+}
+
+func pointKV(key string, ts int, value string) MVCCKeyValue {
+	return MVCCKeyValue{
+		Key:   pointKey(key, ts),
+		Value: stringValueRaw(value),
+	}
+}

--- a/pkg/storage/mvcc_value_test.go
+++ b/pkg/storage/mvcc_value_test.go
@@ -235,3 +235,15 @@ func BenchmarkDecodeMVCCValue(b *testing.B) {
 		}
 	}
 }
+
+func stringValue(s string) MVCCValue {
+	return MVCCValue{Value: roachpb.MakeValueFromString(s)}
+}
+
+func stringValueRaw(s string) []byte {
+	b, err := EncodeMVCCValue(MVCCValue{Value: roachpb.MakeValueFromString(s)})
+	if err != nil {
+		panic(err)
+	}
+	return b
+}


### PR DESCRIPTION
@jbowens I split this out from the range key PR in #77417, since we'll need to audit/update existing code for the new point key batch semantics, and it seems cleaner/easier to do this separately. As you know, the test currently fails because existing batch iterators see concurrent batch writes.

This only covers point keys, but range keys should have identical semantics, and the tests will be extended for range keys in #77417.

---

This patch specifies and tests iterator visibility semantics. See
comment on `Engine.NewMVCCIterator` for details.

Release note: None