### PR TITLE
storage: improve `MVCCValue` handling for `TestMVCCHistories`

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -1098,7 +1098,7 @@ func runTestDBAddSSTable(
 func TestAddSSTableMVCCStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	storage.SkipIfSimpleValueEncodingDisabled(t)
+	storage.DisableMetamorphicSimpleValueEncoding(t)
 
 	const max = 1 << 10
 	ctx := context.Background()
@@ -1214,7 +1214,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 func TestAddSSTableMVCCStatsDisallowShadowing(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	storage.SkipIfSimpleValueEncodingDisabled(t)
+	storage.DisableMetamorphicSimpleValueEncoding(t)
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()

--- a/pkg/kv/kvserver/batcheval/cmd_export_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export_test.go
@@ -674,7 +674,7 @@ func assertEqualKVs(
 
 func TestRandomKeyAndTimestampExport(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	storage.SkipIfSimpleValueEncodingDisabled(t)
+	storage.DisableMetamorphicSimpleValueEncoding(t)
 
 	ctx := context.Background()
 

--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -238,7 +238,7 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 	defer log.TestingSetRedactable(true)()
 
 	// Test expects simple MVCC value encoding.
-	storage.SkipIfSimpleValueEncodingDisabled(t)
+	storage.DisableMetamorphicSimpleValueEncoding(t)
 
 	// Test uses sticky registry to have persistent pebble state that could
 	// be analyzed for existence of snapshots and to verify snapshot content

--- a/pkg/kv/kvserver/gc/gc_iterator_test.go
+++ b/pkg/kv/kvserver/gc/gc_iterator_test.go
@@ -28,7 +28,7 @@ import (
 // engine and then validating the state of the iterator as it iterates that
 // data.
 func TestGCIterator(t *testing.T) {
-	storage.SkipIfSimpleValueEncodingDisabled(t)
+	storage.DisableMetamorphicSimpleValueEncoding(t)
 	// dataItem represents a version in the storage engine and optionally a
 	// corresponding transaction which will make the MVCCKeyValue an intent.
 	type dataItem struct {

--- a/pkg/kv/kvserver/mvcc_gc_queue_test.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue_test.go
@@ -356,7 +356,7 @@ func (cws *cachedWriteSimulator) shouldQueue(
 func TestMVCCGCQueueMakeGCScoreRealistic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	storage.SkipIfSimpleValueEncodingDisabled(t)
+	storage.DisableMetamorphicSimpleValueEncoding(t)
 
 	cws := newCachedWriteSimulator(t)
 
@@ -464,7 +464,7 @@ func TestMVCCGCQueueMakeGCScoreRealistic(t *testing.T) {
 func TestMVCCGCQueueProcess(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	storage.SkipIfSimpleValueEncodingDisabled(t)
+	storage.DisableMetamorphicSimpleValueEncoding(t)
 	ctx := context.Background()
 	tc := testContext{}
 	stopper := stop.NewStopper()

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -6177,7 +6177,7 @@ func verifyRangeStats(
 func TestRangeStatsComputation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	storage.SkipIfSimpleValueEncodingDisabled(t)
+	storage.DisableMetamorphicSimpleValueEncoding(t)
 	ctx := context.Background()
 	tc := testContext{}
 	stopper := stop.NewStopper()

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -59,7 +59,6 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/storage/enginepb",
         "//pkg/storage/fs",
-        "//pkg/testutils/skip",
         "//pkg/util",
         "//pkg/util/bufalloc",
         "//pkg/util/encoding",

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -108,7 +108,7 @@ import (
 func TestMVCCHistories(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	SkipIfSimpleValueEncodingDisabled(t)
+	DisableMetamorphicSimpleValueEncoding(t)
 
 	ctx := context.Background()
 

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -497,7 +497,7 @@ func assertEqualKVs(
 func TestMVCCIncrementalIteratorNextIgnoringTime(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	SkipIfSimpleValueEncodingDisabled(t)
+	DisableMetamorphicSimpleValueEncoding(t)
 	ctx := context.Background()
 
 	var (
@@ -635,7 +635,7 @@ func TestMVCCIncrementalIteratorNextIgnoringTime(t *testing.T) {
 func TestMVCCIncrementalIteratorNextKeyIgnoringTime(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	SkipIfSimpleValueEncodingDisabled(t)
+	DisableMetamorphicSimpleValueEncoding(t)
 	ctx := context.Background()
 
 	var (
@@ -766,7 +766,7 @@ func TestMVCCIncrementalIteratorNextKeyIgnoringTime(t *testing.T) {
 func TestMVCCIncrementalIteratorInlinePolicy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	SkipIfSimpleValueEncodingDisabled(t)
+	DisableMetamorphicSimpleValueEncoding(t)
 	ctx := context.Background()
 
 	var (
@@ -835,7 +835,7 @@ func TestMVCCIncrementalIteratorInlinePolicy(t *testing.T) {
 func TestMVCCIncrementalIteratorIntentPolicy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	SkipIfSimpleValueEncodingDisabled(t)
+	DisableMetamorphicSimpleValueEncoding(t)
 	ctx := context.Background()
 
 	var (
@@ -998,7 +998,7 @@ func expectIntent(t *testing.T, iter SimpleMVCCIterator, intent roachpb.Intent) 
 func TestMVCCIncrementalIterator(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	SkipIfSimpleValueEncodingDisabled(t)
+	DisableMetamorphicSimpleValueEncoding(t)
 	ctx := context.Background()
 
 	var (
@@ -1279,7 +1279,7 @@ func TestMVCCIncrementalIteratorIntentRewrittenConcurrently(t *testing.T) {
 func TestMVCCIncrementalIteratorIntentDeletion(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	SkipIfSimpleValueEncodingDisabled(t)
+	DisableMetamorphicSimpleValueEncoding(t)
 
 	txn := func(key roachpb.Key, ts hlc.Timestamp) *roachpb.Transaction {
 		return &roachpb.Transaction{
@@ -1497,7 +1497,7 @@ func TestMVCCIncrementalIteratorIntentStraddlesSStables(t *testing.T) {
 func TestMVCCIterateTimeBound(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	SkipIfSimpleValueEncodingDisabled(t)
+	DisableMetamorphicSimpleValueEncoding(t)
 
 	dir, cleanupFn := testutils.TempDir(t)
 	defer cleanupFn()

--- a/pkg/storage/mvcc_value.go
+++ b/pkg/storage/mvcc_value.go
@@ -131,11 +131,11 @@ func (v MVCCValue) String() string {
 // SafeFormat implements the redact.SafeFormatter interface.
 func (v MVCCValue) SafeFormat(w redact.SafePrinter, _ rune) {
 	if v.MVCCValueHeader != (enginepb.MVCCValueHeader{}) {
-		w.Printf("vheader{")
+		w.Printf("{")
 		if !v.LocalTimestamp.IsEmpty() {
-			w.Printf(" localTs=%s", v.LocalTimestamp)
+			w.Printf("localTs=%s", v.LocalTimestamp)
 		}
-		w.Printf(" } ")
+		w.Printf("}")
 	}
 	w.Print(v.Value.PrettyPrint())
 }

--- a/pkg/storage/mvcc_value.go
+++ b/pkg/storage/mvcc_value.go
@@ -12,10 +12,10 @@ package storage
 
 import (
 	"encoding/binary"
+	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
@@ -146,12 +146,20 @@ func (v MVCCValue) SafeFormat(w redact.SafePrinter, _ rune) {
 var disableSimpleValueEncoding = util.ConstantWithMetamorphicTestBool(
 	"mvcc-value-disable-simple-encoding", false)
 
-// SkipIfSimpleValueEncodingDisabled skips this test during metamorphic runs
-// that have disabled the simple MVCC value encoding.
-func SkipIfSimpleValueEncodingDisabled(t skip.SkippableTest) {
+// DisableMetamorphicSimpleValueEncoding disables the disableSimpleValueEncoding
+// metamorphic bool and emptyValueHeader value for the duration of a test,
+// resetting it at the end.
+func DisableMetamorphicSimpleValueEncoding(t *testing.T) {
 	t.Helper()
 	if disableSimpleValueEncoding {
-		skip.IgnoreLint(t, "disabled under metamorphic")
+		disableSimpleValueEncoding = false
+		oldHeader := emptyValueHeader
+		emptyValueHeader = enginepb.MVCCValueHeader{}
+
+		t.Cleanup(func() {
+			disableSimpleValueEncoding = true
+			emptyValueHeader = oldHeader
+		})
 	}
 }
 

--- a/pkg/storage/mvcc_value_test.go
+++ b/pkg/storage/mvcc_value_test.go
@@ -95,9 +95,9 @@ func TestMVCCValueFormat(t *testing.T) {
 		"tombstone":        {val: MVCCValue{}, expect: "/<empty>"},
 		"bytes":            {val: MVCCValue{Value: strVal}, expect: "/BYTES/foo"},
 		"int":              {val: MVCCValue{Value: intVal}, expect: "/INT/17"},
-		"header+tombstone": {val: MVCCValue{MVCCValueHeader: valHeader}, expect: "vheader{ localTs=0.000000009,0 } /<empty>"},
-		"header+bytes":     {val: MVCCValue{MVCCValueHeader: valHeader, Value: strVal}, expect: "vheader{ localTs=0.000000009,0 } /BYTES/foo"},
-		"header+int":       {val: MVCCValue{MVCCValueHeader: valHeader, Value: intVal}, expect: "vheader{ localTs=0.000000009,0 } /INT/17"},
+		"header+tombstone": {val: MVCCValue{MVCCValueHeader: valHeader}, expect: "{localTs=0.000000009,0}/<empty>"},
+		"header+bytes":     {val: MVCCValue{MVCCValueHeader: valHeader, Value: strVal}, expect: "{localTs=0.000000009,0}/BYTES/foo"},
+		"header+int":       {val: MVCCValue{MVCCValueHeader: valHeader, Value: intVal}, expect: "{localTs=0.000000009,0}/INT/17"},
 	}
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/storage/mvcc_value_test.go
+++ b/pkg/storage/mvcc_value_test.go
@@ -108,7 +108,7 @@ func TestMVCCValueFormat(t *testing.T) {
 
 func TestEncodeDecodeMVCCValue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	SkipIfSimpleValueEncodingDisabled(t)
+	DisableMetamorphicSimpleValueEncoding(t)
 
 	var strVal, intVal roachpb.Value
 	strVal.SetString("foo")

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -1080,7 +1080,7 @@ func TestPebbleMVCCTimeIntervalCollectorAndFilter(t *testing.T) {
 
 func TestPebbleFlushCallbackAndDurabilityRequirement(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	SkipIfSimpleValueEncodingDisabled(t)
+	DisableMetamorphicSimpleValueEncoding(t)
 
 	eng := createTestPebbleEngine()
 	defer eng.Close()

--- a/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn_enable_separated
@@ -62,7 +62,7 @@ with t=A
 >> resolve_intent k=k t=A
 stats: val_bytes=-38 live_bytes=-38 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=+23
 >> at end:
-data: "k"/124.000000000,0 -> vheader{ localTs=123.000000000,0 } /BYTES/v3
+data: "k"/124.000000000,0 -> {localTs=123.000000000,0}/BYTES/v3
 stats: key_count=1 key_bytes=14 val_count=1 val_bytes=21 live_count=1 live_bytes=35
 
 # Write value4 with an old timestamp without txn...should get a write
@@ -73,7 +73,7 @@ cput k=k v=v4 cond=v3 ts=123
 ----
 >> at end:
 data: "k"/124.000000000,1 -> /BYTES/v4
-data: "k"/124.000000000,0 -> vheader{ localTs=123.000000000,0 } /BYTES/v3
+data: "k"/124.000000000,0 -> {localTs=123.000000000,0}/BYTES/v3
 error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 123.000000000,0 too old; wrote at 124.000000000,1
 
 # Reset for next test

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums
@@ -166,7 +166,7 @@ get: "k" -> /BYTES/b @14.000000000,0
 >> at end:
 txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=32} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=20} ts=14.000000000,0 del=false klen=12 vlen=19 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
-data: "k"/14.000000000,0 -> vheader{ localTs=11.000000000,0 } /BYTES/b
+data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
 meta: "k/20"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -229,7 +229,7 @@ meta: "k" -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=14.000000000,0 mi
 get: "k" -> /BYTES/b @14.000000000,0
 >> at end:
 txn: "B" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
-data: "k"/14.000000000,0 -> vheader{ localTs=11.000000000,0 } /BYTES/b
+data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
 meta: "k/20"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -255,7 +255,7 @@ meta: "l" -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=20.000000000,0 mi
 get: "l" -> /BYTES/c @20.000000000,0
 >> at end:
 txn: "B" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
-data: "k"/14.000000000,0 -> vheader{ localTs=11.000000000,0 } /BYTES/b
+data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
 meta: "k/20"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -282,7 +282,7 @@ meta: "l" -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=20.000000000,0 mi
 get: "l" -> <no data>
 >> at end:
 txn: "B" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=35} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0 isn=1
-data: "k"/14.000000000,0 -> vheader{ localTs=11.000000000,0 } /BYTES/b
+data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
 meta: "k/20"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -320,7 +320,7 @@ meta: "m" -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 mi
 get: "m" -> /BYTES/c @30.000000000,0
 >> at end:
 txn: "C" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=30.000000000,0 wto=false gul=0,0
-data: "k"/14.000000000,0 -> vheader{ localTs=11.000000000,0 } /BYTES/b
+data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
 meta: "k/20"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -342,7 +342,7 @@ meta: "m" -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 mi
 get: "m" -> /BYTES/a @30.000000000,0
 >> at end:
 txn: "C" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=30.000000000,0 wto=false gul=0,0 isn=1
-data: "k"/14.000000000,0 -> vheader{ localTs=11.000000000,0 } /BYTES/b
+data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
 meta: "k/20"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -370,7 +370,7 @@ meta: "n" -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=40.000000000,0 mi
 get: "n" -> /BYTES/c @40.000000000,0
 >> at end:
 txn: "D" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=40.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=40.000000000,0 wto=false gul=0,0
-data: "k"/14.000000000,0 -> vheader{ localTs=11.000000000,0 } /BYTES/b
+data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
 meta: "k/20"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -398,7 +398,7 @@ meta: "n" -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=45.000000000,0 mi
 get: "n" -> /BYTES/c @45.000000000,0
 >> at end:
 txn: "D" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=45.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=40.000000000,0 wto=false gul=0,0
-data: "k"/14.000000000,0 -> vheader{ localTs=11.000000000,0 } /BYTES/b
+data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
 meta: "k/20"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -407,7 +407,7 @@ meta: "k/30"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.0000000
 data: "k/30"/11.000000000,0 -> /BYTES/30
 data: "m"/30.000000000,0 -> /BYTES/a
 meta: "n"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=45.000000000,0 min=0,0 seq=30} ts=45.000000000,0 del=false klen=12 vlen=20 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
-data: "n"/45.000000000,0 -> vheader{ localTs=40.000000000,0 } /BYTES/c
+data: "n"/45.000000000,0 -> {localTs=40.000000000,0}/BYTES/c
 
 # Ignore sequence numbers other than the current one, then commit. The value
 # shouldn't change.
@@ -426,7 +426,7 @@ get: "n" -> /BYTES/c @45.000000000,0
 get: "n" -> /BYTES/c @45.000000000,0
 >> at end:
 txn: "E" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0
-data: "k"/14.000000000,0 -> vheader{ localTs=11.000000000,0 } /BYTES/b
+data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
 meta: "k/20"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -434,7 +434,7 @@ data: "k/20"/11.000000000,0 -> /BYTES/20
 meta: "k/30"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/30"/11.000000000,0 -> /BYTES/30
 data: "m"/30.000000000,0 -> /BYTES/a
-data: "n"/45.000000000,0 -> vheader{ localTs=40.000000000,0 } /BYTES/c
+data: "n"/45.000000000,0 -> {localTs=40.000000000,0}/BYTES/c
 
 # Write a couple values at different sequence numbers on this key, then ignore
 # them all, then do a resolve_intent while the txn is pending. The intent should
@@ -458,7 +458,7 @@ get: "n" -> /BYTES/c @45.000000000,0
 get: "o" -> <no data>
 >> at end:
 txn: "E" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0
-data: "k"/14.000000000,0 -> vheader{ localTs=11.000000000,0 } /BYTES/b
+data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
 meta: "k/20"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -468,7 +468,7 @@ data: "k/30"/11.000000000,0 -> /BYTES/30
 data: "m"/30.000000000,0 -> /BYTES/a
 meta: "n"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "n"/50.000000000,0 -> /BYTES/c
-data: "n"/45.000000000,0 -> vheader{ localTs=40.000000000,0 } /BYTES/c
+data: "n"/45.000000000,0 -> {localTs=40.000000000,0}/BYTES/c
 meta: "o"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "o"/50.000000000,0 -> /BYTES/c
 
@@ -485,7 +485,7 @@ get: "n" -> /BYTES/c @45.000000000,0
 get: "o" -> <no data>
 >> at end:
 txn: "E" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0 isn=1
-data: "k"/14.000000000,0 -> vheader{ localTs=11.000000000,0 } /BYTES/b
+data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
 meta: "k/20"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -493,7 +493,7 @@ data: "k/20"/11.000000000,0 -> /BYTES/20
 meta: "k/30"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/30"/11.000000000,0 -> /BYTES/30
 data: "m"/30.000000000,0 -> /BYTES/a
-data: "n"/45.000000000,0 -> vheader{ localTs=40.000000000,0 } /BYTES/c
+data: "n"/45.000000000,0 -> {localTs=40.000000000,0}/BYTES/c
 
 run ok
 with t=E
@@ -533,7 +533,7 @@ with t=E
 meta: "o" -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
 >> at end:
 txn: "E" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0 isn=1
-data: "k"/14.000000000,0 -> vheader{ localTs=11.000000000,0 } /BYTES/b
+data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
 meta: "k/20"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -541,7 +541,7 @@ data: "k/20"/11.000000000,0 -> /BYTES/20
 meta: "k/30"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/30"/11.000000000,0 -> /BYTES/30
 data: "m"/30.000000000,0 -> /BYTES/a
-data: "n"/45.000000000,0 -> vheader{ localTs=40.000000000,0 } /BYTES/c
+data: "n"/45.000000000,0 -> {localTs=40.000000000,0}/BYTES/c
 meta: "o"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "o"/50.000000000,0 -> /BYTES/c
 
@@ -556,7 +556,7 @@ with t=E
 get: "o" -> <no data>
 >> at end:
 txn: "E" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=55.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0 isn=1
-data: "k"/14.000000000,0 -> vheader{ localTs=11.000000000,0 } /BYTES/b
+data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
 meta: "k/20"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -564,7 +564,7 @@ data: "k/20"/11.000000000,0 -> /BYTES/20
 meta: "k/30"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/30"/11.000000000,0 -> /BYTES/30
 data: "m"/30.000000000,0 -> /BYTES/a
-data: "n"/45.000000000,0 -> vheader{ localTs=40.000000000,0 } /BYTES/c
+data: "n"/45.000000000,0 -> {localTs=40.000000000,0}/BYTES/c
 
 
 run error
@@ -589,7 +589,7 @@ meta: "o" -> txn={id=00000000 key="o" pri=0.00000000 epo=0 ts=50.000000000,0 min
 get: "o" -> /BYTES/b @50.000000000,0
 >> at end:
 txn: "F" meta={id=00000000 key="o" pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=40.000000000,0 wto=false gul=0,0
-data: "k"/14.000000000,0 -> vheader{ localTs=11.000000000,0 } /BYTES/b
+data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
 meta: "k/20"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -597,7 +597,7 @@ data: "k/20"/11.000000000,0 -> /BYTES/20
 meta: "k/30"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/30"/11.000000000,0 -> /BYTES/30
 data: "m"/30.000000000,0 -> /BYTES/a
-data: "n"/45.000000000,0 -> vheader{ localTs=40.000000000,0 } /BYTES/c
+data: "n"/45.000000000,0 -> {localTs=40.000000000,0}/BYTES/c
 meta: "o"/0,0 -> txn={id=00000000 key="o" pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "o"/50.000000000,0 -> /BYTES/b
 
@@ -618,7 +618,7 @@ meta: "o" -> txn={id=00000000 key="o" pri=0.00000000 epo=0 ts=50.000000000,0 min
 get: "o" -> /BYTES/a @50.000000000,0
 >> at end:
 txn: "F" meta={id=00000000 key="o" pri=0.00000000 epo=0 ts=45.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=40.000000000,0 wto=false gul=0,0 isn=1
-data: "k"/14.000000000,0 -> vheader{ localTs=11.000000000,0 } /BYTES/b
+data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
 meta: "k/20"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -626,6 +626,6 @@ data: "k/20"/11.000000000,0 -> /BYTES/20
 meta: "k/30"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/30"/11.000000000,0 -> /BYTES/30
 data: "m"/30.000000000,0 -> /BYTES/a
-data: "n"/45.000000000,0 -> vheader{ localTs=40.000000000,0 } /BYTES/c
+data: "n"/45.000000000,0 -> {localTs=40.000000000,0}/BYTES/c
 meta: "o"/0,0 -> txn={id=00000000 key="o" pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=10} ts=50.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "o"/50.000000000,0 -> /BYTES/a

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_with_local_timestamps
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_with_local_timestamps
@@ -12,8 +12,8 @@ with t=A
 ----
 >> at end:
 txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=25} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0
-meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=25} ts=50.000000000,0 del=false klen=12 vlen=19 ih={{15 vheader{ localTs=15.000000000,0 } /BYTES/a}{20 vheader{ localTs=20.000000000,0 } /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
-data: "k"/50.000000000,0 -> vheader{ localTs=25.000000000,0 } /BYTES/c
+meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=25} ts=50.000000000,0 del=false klen=12 vlen=19 ih={{15 {localTs=15.000000000,0}/BYTES/a}{20 {localTs=20.000000000,0}/BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k"/50.000000000,0 -> {localTs=25.000000000,0}/BYTES/c
 
 # Rollback to a previous sequence number. Should be able to read before and
 # after resolving the intent.
@@ -29,8 +29,8 @@ get: "k" -> /BYTES/b @50.000000000,0
 get: "k" -> /BYTES/b @50.000000000,0
 >> at end:
 txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=25} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0 isn=1
-meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20} ts=50.000000000,0 del=false klen=12 vlen=19 ih={{15 vheader{ localTs=15.000000000,0 } /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
-data: "k"/50.000000000,0 -> vheader{ localTs=20.000000000,0 } /BYTES/b
+meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20} ts=50.000000000,0 del=false klen=12 vlen=19 ih={{15 {localTs=15.000000000,0}/BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k"/50.000000000,0 -> {localTs=20.000000000,0}/BYTES/b
 
 # Rollback and commit at a previous sequence number. Committed value should have
 # original local timestamp. This is important to avoid losing the local timestamp
@@ -43,4 +43,4 @@ with t=A
 ----
 >> at end:
 txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=25} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0 isn=1
-data: "k"/50.000000000,0 -> vheader{ localTs=15.000000000,0 } /BYTES/a
+data: "k"/50.000000000,0 -> {localTs=15.000000000,0}/BYTES/a

--- a/pkg/storage/testdata/mvcc_histories/local_timestamp
+++ b/pkg/storage/testdata/mvcc_histories/local_timestamp
@@ -13,7 +13,7 @@ stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+6 live_count=+1 live_b
 >> put localTs=30 k=k3 v=v ts=20
 stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+6 live_count=+1 live_bytes=+21
 >> at end:
-data: "k1"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v
+data: "k1"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v
 data: "k2"/20.000000000,0 -> /BYTES/v
 data: "k3"/20.000000000,0 -> /BYTES/v
 stats: key_count=3 key_bytes=45 val_count=3 val_bytes=31 live_count=3 live_bytes=76
@@ -32,10 +32,10 @@ stats: key_bytes=+12 val_count=+1 val_bytes=+6 gc_bytes_age=+1260
 stats: key_bytes=+12 val_count=+1 val_bytes=+19 live_bytes=+13 gc_bytes_age=+1260
 >> at end:
 data: "k1"/30.000000000,0 -> /BYTES/v
-data: "k1"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v
+data: "k1"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v
 data: "k2"/30.000000000,0 -> /BYTES/v
 data: "k2"/20.000000000,0 -> /BYTES/v
-data: "k3"/30.000000000,0 -> vheader{ localTs=20.000000000,0 } /BYTES/v
+data: "k3"/30.000000000,0 -> {localTs=20.000000000,0}/BYTES/v
 data: "k3"/20.000000000,0 -> /BYTES/v
 stats: key_count=3 key_bytes=81 val_count=6 val_bytes=62 live_count=3 live_bytes=76 gc_bytes_age=4690
 
@@ -52,14 +52,14 @@ stats: key_bytes=+12 val_count=+1 live_count=-1 live_bytes=-21 gc_bytes_age=+198
 >> del localTs=50 k=k3 ts=40
 stats: key_bytes=+12 val_count=+1 live_count=-1 live_bytes=-34 gc_bytes_age=+2760
 >> at end:
-data: "k1"/40.000000000,0 -> vheader{ localTs=30.000000000,0 } /<empty>
+data: "k1"/40.000000000,0 -> {localTs=30.000000000,0}/<empty>
 data: "k1"/30.000000000,0 -> /BYTES/v
-data: "k1"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v
+data: "k1"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v
 data: "k2"/40.000000000,0 -> /<empty>
 data: "k2"/30.000000000,0 -> /BYTES/v
 data: "k2"/20.000000000,0 -> /BYTES/v
 data: "k3"/40.000000000,0 -> /<empty>
-data: "k3"/30.000000000,0 -> vheader{ localTs=20.000000000,0 } /BYTES/v
+data: "k3"/30.000000000,0 -> {localTs=20.000000000,0}/BYTES/v
 data: "k3"/20.000000000,0 -> /BYTES/v
 stats: key_count=3 key_bytes=117 val_count=9 val_bytes=75 gc_bytes_age=12190
 
@@ -80,16 +80,16 @@ inc: current value = 1
 stats: key_bytes=+12 val_count=+1 val_bytes=+20 live_count=+1 live_bytes=+35 gc_bytes_age=-180
 >> at end:
 data: "k1"/50.000000000,0 -> /INT/1
-data: "k1"/40.000000000,0 -> vheader{ localTs=30.000000000,0 } /<empty>
+data: "k1"/40.000000000,0 -> {localTs=30.000000000,0}/<empty>
 data: "k1"/30.000000000,0 -> /BYTES/v
-data: "k1"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v
+data: "k1"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v
 data: "k2"/50.000000000,0 -> /INT/1
 data: "k2"/40.000000000,0 -> /<empty>
 data: "k2"/30.000000000,0 -> /BYTES/v
 data: "k2"/20.000000000,0 -> /BYTES/v
-data: "k3"/50.000000000,0 -> vheader{ localTs=40.000000000,0 } /INT/1
+data: "k3"/50.000000000,0 -> {localTs=40.000000000,0}/INT/1
 data: "k3"/40.000000000,0 -> /<empty>
-data: "k3"/30.000000000,0 -> vheader{ localTs=20.000000000,0 } /BYTES/v
+data: "k3"/30.000000000,0 -> {localTs=20.000000000,0}/BYTES/v
 data: "k3"/20.000000000,0 -> /BYTES/v
 stats: key_count=3 key_bytes=153 val_count=12 val_bytes=107 live_count=3 live_bytes=77 gc_bytes_age=11650
 
@@ -109,20 +109,20 @@ stats: key_bytes=+12 val_count=+1 live_count=-1 live_bytes=-21 gc_bytes_age=+132
 del_range: "k3"-"k4" -> deleted 1 key(s)
 stats: key_bytes=+12 val_count=+1 live_count=-1 live_bytes=-35 gc_bytes_age=+1880
 >> at end:
-data: "k1"/60.000000000,0 -> vheader{ localTs=50.000000000,0 } /<empty>
+data: "k1"/60.000000000,0 -> {localTs=50.000000000,0}/<empty>
 data: "k1"/50.000000000,0 -> /INT/1
-data: "k1"/40.000000000,0 -> vheader{ localTs=30.000000000,0 } /<empty>
+data: "k1"/40.000000000,0 -> {localTs=30.000000000,0}/<empty>
 data: "k1"/30.000000000,0 -> /BYTES/v
-data: "k1"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v
+data: "k1"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v
 data: "k2"/60.000000000,0 -> /<empty>
 data: "k2"/50.000000000,0 -> /INT/1
 data: "k2"/40.000000000,0 -> /<empty>
 data: "k2"/30.000000000,0 -> /BYTES/v
 data: "k2"/20.000000000,0 -> /BYTES/v
 data: "k3"/60.000000000,0 -> /<empty>
-data: "k3"/50.000000000,0 -> vheader{ localTs=40.000000000,0 } /INT/1
+data: "k3"/50.000000000,0 -> {localTs=40.000000000,0}/INT/1
 data: "k3"/40.000000000,0 -> /<empty>
-data: "k3"/30.000000000,0 -> vheader{ localTs=20.000000000,0 } /BYTES/v
+data: "k3"/30.000000000,0 -> {localTs=20.000000000,0}/BYTES/v
 data: "k3"/20.000000000,0 -> /BYTES/v
 stats: key_count=3 key_bytes=189 val_count=15 val_bytes=121 gc_bytes_age=16730
 
@@ -278,29 +278,29 @@ stats: key_count=+1 key_bytes=+16 val_count=+1 val_bytes=+67 live_count=+1 live_
 >> at end:
 txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
 meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=19 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "k1"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v
+data: "k1"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v
 meta: "k10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=19 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "k10"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v
+data: "k10"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v
 meta: "k11"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=19 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "k11"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v
+data: "k11"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v
 meta: "k12"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=19 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "k12"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v
+data: "k12"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v
 meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=19 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "k2"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v
+data: "k2"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v
 meta: "k3"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=19 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "k3"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v
+data: "k3"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v
 meta: "k4"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=19 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "k4"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v
+data: "k4"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v
 meta: "k5"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=19 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "k5"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v
+data: "k5"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v
 meta: "k6"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=19 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "k6"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v
+data: "k6"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v
 meta: "k7"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=19 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "k7"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v
+data: "k7"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v
 meta: "k8"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=19 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "k8"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v
+data: "k8"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v
 meta: "k9"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=19 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "k9"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v
+data: "k9"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v
 stats: key_count=12 key_bytes=183 val_count=12 val_bytes=804 live_count=12 live_bytes=987 intent_count=12 intent_bytes=372 separated_intent_count=12 intent_age=960
 
 run ok
@@ -351,30 +351,30 @@ stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 intent_age=-10
 >> put k=k12 v=v2 t=A localTs=20
 stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 intent_age=-10
 >> at end:
-meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 vheader{ localTs=10.000000000,0 } /BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
-data: "k1"/30.000000000,0 -> vheader{ localTs=20.000000000,0 } /BYTES/v2
-meta: "k10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 vheader{ localTs=10.000000000,0 } /BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
-data: "k10"/30.000000000,0 -> vheader{ localTs=20.000000000,0 } /BYTES/v2
-meta: "k11"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 vheader{ localTs=10.000000000,0 } /BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
-data: "k11"/30.000000000,0 -> vheader{ localTs=20.000000000,0 } /BYTES/v2
-meta: "k12"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 vheader{ localTs=10.000000000,0 } /BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
-data: "k12"/30.000000000,0 -> vheader{ localTs=20.000000000,0 } /BYTES/v2
-meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 vheader{ localTs=10.000000000,0 } /BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
-data: "k2"/30.000000000,0 -> vheader{ localTs=20.000000000,0 } /BYTES/v2
-meta: "k3"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 vheader{ localTs=10.000000000,0 } /BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
-data: "k3"/30.000000000,0 -> vheader{ localTs=20.000000000,0 } /BYTES/v2
-meta: "k4"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 vheader{ localTs=10.000000000,0 } /BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
-data: "k4"/30.000000000,0 -> vheader{ localTs=20.000000000,0 } /BYTES/v2
-meta: "k5"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 vheader{ localTs=10.000000000,0 } /BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
-data: "k5"/30.000000000,0 -> vheader{ localTs=20.000000000,0 } /BYTES/v2
-meta: "k6"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 vheader{ localTs=10.000000000,0 } /BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
-data: "k6"/30.000000000,0 -> vheader{ localTs=20.000000000,0 } /BYTES/v2
-meta: "k7"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 vheader{ localTs=10.000000000,0 } /BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
-data: "k7"/30.000000000,0 -> vheader{ localTs=20.000000000,0 } /BYTES/v2
-meta: "k8"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 vheader{ localTs=10.000000000,0 } /BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
-data: "k8"/30.000000000,0 -> vheader{ localTs=20.000000000,0 } /BYTES/v2
-meta: "k9"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 vheader{ localTs=10.000000000,0 } /BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
-data: "k9"/30.000000000,0 -> vheader{ localTs=20.000000000,0 } /BYTES/v2
+meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 {localTs=10.000000000,0}/BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k1"/30.000000000,0 -> {localTs=20.000000000,0}/BYTES/v2
+meta: "k10"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 {localTs=10.000000000,0}/BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k10"/30.000000000,0 -> {localTs=20.000000000,0}/BYTES/v2
+meta: "k11"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 {localTs=10.000000000,0}/BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k11"/30.000000000,0 -> {localTs=20.000000000,0}/BYTES/v2
+meta: "k12"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 {localTs=10.000000000,0}/BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k12"/30.000000000,0 -> {localTs=20.000000000,0}/BYTES/v2
+meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 {localTs=10.000000000,0}/BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k2"/30.000000000,0 -> {localTs=20.000000000,0}/BYTES/v2
+meta: "k3"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 {localTs=10.000000000,0}/BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k3"/30.000000000,0 -> {localTs=20.000000000,0}/BYTES/v2
+meta: "k4"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 {localTs=10.000000000,0}/BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k4"/30.000000000,0 -> {localTs=20.000000000,0}/BYTES/v2
+meta: "k5"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 {localTs=10.000000000,0}/BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k5"/30.000000000,0 -> {localTs=20.000000000,0}/BYTES/v2
+meta: "k6"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 {localTs=10.000000000,0}/BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k6"/30.000000000,0 -> {localTs=20.000000000,0}/BYTES/v2
+meta: "k7"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 {localTs=10.000000000,0}/BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k7"/30.000000000,0 -> {localTs=20.000000000,0}/BYTES/v2
+meta: "k8"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 {localTs=10.000000000,0}/BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k8"/30.000000000,0 -> {localTs=20.000000000,0}/BYTES/v2
+meta: "k9"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 {localTs=10.000000000,0}/BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k9"/30.000000000,0 -> {localTs=20.000000000,0}/BYTES/v2
 stats: key_count=12 key_bytes=183 val_count=12 val_bytes=1116 live_count=12 live_bytes=1299 intent_count=12 intent_bytes=384 separated_intent_count=12 intent_age=840
 
 run stats ok
@@ -419,16 +419,16 @@ stats: val_bytes=-73 live_bytes=-73 intent_count=-1 intent_bytes=-32 separated_i
 stats: val_bytes=-86 live_bytes=-86 intent_count=-1 intent_bytes=-32 separated_intent_count=-1 intent_age=-70
 >> at end:
 txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=40.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
-data: "k10"/40.000000000,0 -> vheader{ localTs=20.000000000,0 } /BYTES/v2
-data: "k11"/40.000000000,0 -> vheader{ localTs=30.000000000,0 } /BYTES/v2
+data: "k10"/40.000000000,0 -> {localTs=20.000000000,0}/BYTES/v2
+data: "k11"/40.000000000,0 -> {localTs=30.000000000,0}/BYTES/v2
 data: "k12"/40.000000000,0 -> /BYTES/v2
-meta: "k5"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=40.000000000,0 min=0,0 seq=1} ts=40.000000000,0 del=false klen=12 vlen=20 ih={{0 vheader{ localTs=10.000000000,0 } /BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
-data: "k5"/40.000000000,0 -> vheader{ localTs=20.000000000,0 } /BYTES/v2
-meta: "k6"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=40.000000000,0 min=0,0 seq=1} ts=40.000000000,0 del=false klen=12 vlen=20 ih={{0 vheader{ localTs=10.000000000,0 } /BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
-data: "k6"/40.000000000,0 -> vheader{ localTs=20.000000000,0 } /BYTES/v2
-meta: "k7"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=40.000000000,0 min=0,0 seq=1} ts=40.000000000,0 del=false klen=12 vlen=20 ih={{0 vheader{ localTs=10.000000000,0 } /BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
-data: "k7"/40.000000000,0 -> vheader{ localTs=30.000000000,0 } /BYTES/v2
-meta: "k8"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=40.000000000,0 min=0,0 seq=1} ts=40.000000000,0 del=false klen=12 vlen=7 ih={{0 vheader{ localTs=10.000000000,0 } /BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
+meta: "k5"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=40.000000000,0 min=0,0 seq=1} ts=40.000000000,0 del=false klen=12 vlen=20 ih={{0 {localTs=10.000000000,0}/BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k5"/40.000000000,0 -> {localTs=20.000000000,0}/BYTES/v2
+meta: "k6"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=40.000000000,0 min=0,0 seq=1} ts=40.000000000,0 del=false klen=12 vlen=20 ih={{0 {localTs=10.000000000,0}/BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k6"/40.000000000,0 -> {localTs=20.000000000,0}/BYTES/v2
+meta: "k7"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=40.000000000,0 min=0,0 seq=1} ts=40.000000000,0 del=false klen=12 vlen=20 ih={{0 {localTs=10.000000000,0}/BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k7"/40.000000000,0 -> {localTs=30.000000000,0}/BYTES/v2
+meta: "k8"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=40.000000000,0 min=0,0 seq=1} ts=40.000000000,0 del=false klen=12 vlen=7 ih={{0 {localTs=10.000000000,0}/BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k8"/40.000000000,0 -> /BYTES/v2
-data: "k9"/40.000000000,0 -> vheader{ localTs=20.000000000,0 } /BYTES/v2
+data: "k9"/40.000000000,0 -> {localTs=20.000000000,0}/BYTES/v2
 stats: key_count=8 key_bytes=123 val_count=8 val_bytes=434 live_count=8 live_bytes=557 intent_count=4 intent_bytes=115 separated_intent_count=4 intent_age=240

--- a/pkg/storage/testdata/mvcc_histories/range_key_iter
+++ b/pkg/storage/testdata/mvcc_histories/range_key_iter
@@ -49,7 +49,7 @@ rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
 rangekey: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 rangekey: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 rangekey: {h-k}/[1.000000000,0=/<empty>]
-rangekey: {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/7.000000000,0 -> /BYTES/a7
 data: "a"/4.000000000,0 -> /<empty>
@@ -142,8 +142,8 @@ iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "k"/5.000000000,0=/BYTES/k5
 iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "l"/7.000000000,0=/BYTES/l7
-iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
-iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "o"/7.000000000,0=/BYTES/n7
 iter_scan: .
@@ -161,7 +161,7 @@ iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: {h-k}/[1.000000000,0=/<empty>]
-iter_scan: {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_scan: .
 
 run ok
@@ -194,8 +194,8 @@ iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "k"/5.000000000,0=/BYTES/k5
 iter_scan: "l"/7.000000000,0=/BYTES/l7
-iter_scan: {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
-iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_scan: "o"/7.000000000,0=/BYTES/n7
 iter_scan: .
 
@@ -241,8 +241,8 @@ iter_scan reverse
 iter_seek_lt: "o"/7.000000000,0=/BYTES/n7
 iter_scan: "o"/7.000000000,0=/BYTES/n7
 iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
-iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
-iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_scan: "l"/7.000000000,0=/BYTES/l7
 iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "k"/5.000000000,0=/BYTES/k5
@@ -276,8 +276,8 @@ iter_new types=rangesOnly
 iter_seek_lt k=z
 iter_scan reverse
 ----
-iter_seek_lt: {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
-iter_scan: {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_seek_lt: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_scan: {h-k}/[1.000000000,0=/<empty>]
 iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
@@ -294,8 +294,8 @@ iter_scan reverse
 ----
 iter_seek_lt: "o"/7.000000000,0=/BYTES/n7
 iter_scan: "o"/7.000000000,0=/BYTES/n7
-iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
-iter_scan: {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_scan: "l"/7.000000000,0=/BYTES/l7
 iter_scan: "k"/5.000000000,0=/BYTES/k5
 iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
@@ -485,9 +485,9 @@ iter_new prefix types=pointsAndRanges
 iter_seek_ge k=m
 iter_scan
 ----
-iter_seek_ge: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
-iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
-iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_seek_ge: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_scan: .
 
 run ok
@@ -689,19 +689,19 @@ iter_seek_ge k=m ts=6
 iter_prev
 iter_prev
 ----
-iter_seek_ge: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_seek_ge: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_prev: "l"/7.000000000,0=/BYTES/l7
-iter_next: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
-iter_next: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
-iter_prev: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_next: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_next: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_prev: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_prev: "l"/7.000000000,0=/BYTES/l7
-iter_seek_ge: {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
-iter_prev: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
-iter_seek_ge: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
-iter_prev: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
-iter_seek_ge: {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
-iter_prev: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
-iter_prev: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_seek_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_prev: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_seek_ge: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_prev: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_seek_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_prev: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_prev: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 
 run ok
 iter_new types=pointsAndRanges
@@ -713,11 +713,11 @@ iter_prev
 iter_prev
 ----
 iter_seek_ge: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
-iter_prev: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_prev: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_next: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_next: "o"/7.000000000,0=/BYTES/n7
 iter_prev: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
-iter_prev: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_prev: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 
 run ok
 iter_new types=pointsAndRanges
@@ -757,8 +757,8 @@ iter_new types=pointsAndRanges k=l end=o
 iter_seek_ge k=m
 iter_scan reverse
 ----
-iter_seek_ge: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
-iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_seek_ge: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_scan: "l"/7.000000000,0=/BYTES/l7
 iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: .
@@ -768,9 +768,9 @@ iter_new types=pointsAndRanges k=l end=p
 iter_seek_lt k=m ts=7
 iter_scan
 ----
-iter_seek_lt: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
-iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
-iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_seek_lt: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "o"/7.000000000,0=/BYTES/n7
 iter_scan: .
@@ -805,15 +805,15 @@ iter_prev
 iter_prev
 iter_prev
 ----
-iter_seek_ge: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
-iter_next: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_seek_ge: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_next: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_next: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_next: "o"/7.000000000,0=/BYTES/n7
 iter_next: .
 iter_prev: "o"/7.000000000,0=/BYTES/n7
 iter_prev: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
-iter_prev: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
-iter_prev: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_prev: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_prev: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_prev: "l"/7.000000000,0=/BYTES/l7
 
 # Test NextKey() with and without intents/range keys, and with some seeks.
@@ -845,7 +845,7 @@ iter_next_key: {h-k}/[1.000000000,0=/<empty>]
 iter_next_key: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
 iter_next_key: "k"/5.000000000,0=/BYTES/k5
 iter_next_key: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
-iter_next_key: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_next_key: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_next_key: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_next_key: .
 
@@ -877,7 +877,7 @@ iter_next_key: {h-k}/[1.000000000,0=/<empty>]
 iter_next_key: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
 iter_next_key: "k"/5.000000000,0=/BYTES/k5
 iter_next_key: "l"/7.000000000,0=/BYTES/l7
-iter_next_key: {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_next_key: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_next_key: "o"/7.000000000,0=/BYTES/n7
 iter_next_key: .
 
@@ -930,7 +930,7 @@ iter_next_key: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_next_key: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_next_key: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_next_key: {h-k}/[1.000000000,0=/<empty>]
-iter_next_key: {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_next_key: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_next_key: .
 
 # Test NextKey() during seeks.
@@ -1001,7 +1001,7 @@ iter_seek_intent_ge: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_seek_intent_ge: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_seek_intent_ge: {h-k}/[1.000000000,0=/<empty>]
 iter_seek_intent_ge: {h-k}/[1.000000000,0=/<empty>]
-iter_seek_intent_ge: {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_seek_intent_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 
 # Try some masked scans at increasing timestamps.
 run ok
@@ -1036,8 +1036,8 @@ iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "k"/5.000000000,0=/BYTES/k5
 iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "l"/7.000000000,0=/BYTES/l7
-iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
-iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "o"/7.000000000,0=/BYTES/n7
 iter_scan: .
@@ -1074,8 +1074,8 @@ iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "k"/5.000000000,0=/BYTES/k5
 iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "l"/7.000000000,0=/BYTES/l7
-iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
-iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "o"/7.000000000,0=/BYTES/n7
 iter_scan: .
@@ -1110,8 +1110,8 @@ iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "k"/5.000000000,0=/BYTES/k5
 iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "l"/7.000000000,0=/BYTES/l7
-iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
-iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "o"/7.000000000,0=/BYTES/n7
 iter_scan: .
@@ -1146,8 +1146,8 @@ iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "k"/5.000000000,0=/BYTES/k5
 iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "l"/7.000000000,0=/BYTES/l7
-iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
-iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "o"/7.000000000,0=/BYTES/n7
 iter_scan: .
@@ -1179,8 +1179,8 @@ iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "k"/5.000000000,0=/BYTES/k5
 iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "l"/7.000000000,0=/BYTES/l7
-iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
-iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "o"/7.000000000,0=/BYTES/n7
 iter_scan: .
@@ -1212,8 +1212,8 @@ iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "k"/5.000000000,0=/BYTES/k5
 iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "l"/7.000000000,0=/BYTES/l7
-iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
-iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "o"/7.000000000,0=/BYTES/n7
 iter_scan: .

--- a/pkg/storage/testdata/mvcc_histories/range_key_point_synthesis
+++ b/pkg/storage/testdata/mvcc_histories/range_key_point_synthesis
@@ -43,8 +43,8 @@ rangekey: {a-b}/[1.000000000,0=/<empty>]
 rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-rangekey: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=vheader{ localTs=4.000000000,0 } /<empty>]
-rangekey: {g-h}/[3.000000000,0=vheader{ localTs=4.000000000,0 } /<empty>]
+rangekey: {f-g}/[5.000000000,0=/<empty> 3.000000000,0={localTs=4.000000000,0}/<empty>]
+rangekey: {g-h}/[3.000000000,0={localTs=4.000000000,0}/<empty>]
 rangekey: {h-k}/[1.000000000,0=/<empty>]
 rangekey: {l-n}/[5.000000000,0=/<empty>]
 rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -92,10 +92,10 @@ iter_scan: "e"/1.000000000,0=/<empty>
 iter_scan: "f"/6.000000000,0=/BYTES/f6
 iter_scan: "f"/5.000000000,0=/<empty>
 iter_scan: "f"/4.000000000,0=/BYTES/f4
-iter_scan: "f"/3.000000000,0=vheader{ localTs=4.000000000,0 } /<empty>
+iter_scan: "f"/3.000000000,0={localTs=4.000000000,0}/<empty>
 iter_scan: "f"/2.000000000,0=/BYTES/f2
 iter_scan: "g"/4.000000000,0=/BYTES/g4
-iter_scan: "g"/3.000000000,0=vheader{ localTs=4.000000000,0 } /<empty>
+iter_scan: "g"/3.000000000,0={localTs=4.000000000,0}/<empty>
 iter_scan: "g"/2.000000000,0=/BYTES/g2
 iter_scan: "h"/3.000000000,0=/BYTES/h3
 iter_scan: "h"/1.000000000,0=/<empty>
@@ -124,10 +124,10 @@ iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000
 iter_scan: "h"/1.000000000,0=/<empty>
 iter_scan: "h"/3.000000000,0=/BYTES/h3
 iter_scan: "g"/2.000000000,0=/BYTES/g2
-iter_scan: "g"/3.000000000,0=vheader{ localTs=4.000000000,0 } /<empty>
+iter_scan: "g"/3.000000000,0={localTs=4.000000000,0}/<empty>
 iter_scan: "g"/4.000000000,0=/BYTES/g4
 iter_scan: "f"/2.000000000,0=/BYTES/f2
-iter_scan: "f"/3.000000000,0=vheader{ localTs=4.000000000,0 } /<empty>
+iter_scan: "f"/3.000000000,0={localTs=4.000000000,0}/<empty>
 iter_scan: "f"/4.000000000,0=/BYTES/f4
 iter_scan: "f"/5.000000000,0=/<empty>
 iter_scan: "f"/6.000000000,0=/BYTES/f6
@@ -449,7 +449,7 @@ iter_seek_ge: "f"/6.000000000,0=/BYTES/f6
 iter_seek_ge: "f"/6.000000000,0=/BYTES/f6
 iter_seek_ge: "f"/5.000000000,0=/<empty>
 iter_seek_ge: "f"/4.000000000,0=/BYTES/f4
-iter_seek_ge: "f"/3.000000000,0=vheader{ localTs=4.000000000,0 } /<empty>
+iter_seek_ge: "f"/3.000000000,0={localTs=4.000000000,0}/<empty>
 iter_seek_ge: "f"/2.000000000,0=/BYTES/f2
 iter_seek_ge: "g"/4.000000000,0=/BYTES/g4
 
@@ -465,7 +465,7 @@ iter_seek_ge k=g ts=1
 iter_seek_ge: "g"/4.000000000,0=/BYTES/g4
 iter_seek_ge: "g"/4.000000000,0=/BYTES/g4
 iter_seek_ge: "g"/4.000000000,0=/BYTES/g4
-iter_seek_ge: "g"/3.000000000,0=vheader{ localTs=4.000000000,0 } /<empty>
+iter_seek_ge: "g"/3.000000000,0={localTs=4.000000000,0}/<empty>
 iter_seek_ge: "g"/2.000000000,0=/BYTES/g2
 iter_seek_ge: "h"/3.000000000,0=/BYTES/h3
 
@@ -692,7 +692,7 @@ iter_seek_lt k=f ts=6
 iter_seek_lt k=f ts=7
 ----
 iter_seek_lt: "f"/2.000000000,0=/BYTES/f2
-iter_seek_lt: "f"/3.000000000,0=vheader{ localTs=4.000000000,0 } /<empty>
+iter_seek_lt: "f"/3.000000000,0={localTs=4.000000000,0}/<empty>
 iter_seek_lt: "f"/4.000000000,0=/BYTES/f4
 iter_seek_lt: "f"/5.000000000,0=/<empty>
 iter_seek_lt: "f"/6.000000000,0=/BYTES/f6
@@ -709,7 +709,7 @@ iter_seek_lt k=g ts=5
 iter_seek_lt k=g ts=6
 ----
 iter_seek_lt: "g"/2.000000000,0=/BYTES/g2
-iter_seek_lt: "g"/3.000000000,0=vheader{ localTs=4.000000000,0 } /<empty>
+iter_seek_lt: "g"/3.000000000,0={localTs=4.000000000,0}/<empty>
 iter_seek_lt: "g"/4.000000000,0=/BYTES/g4
 iter_seek_lt: "f"/2.000000000,0=/BYTES/f2
 iter_seek_lt: "f"/2.000000000,0=/BYTES/f2
@@ -856,7 +856,7 @@ iter_scan
 iter_seek_lt: "f"/2.000000000,0=/BYTES/f2
 iter_scan: "f"/2.000000000,0=/BYTES/f2
 iter_scan: "g"/4.000000000,0=/BYTES/g4
-iter_scan: "g"/3.000000000,0=vheader{ localTs=4.000000000,0 } /<empty>
+iter_scan: "g"/3.000000000,0={localTs=4.000000000,0}/<empty>
 iter_scan: "g"/2.000000000,0=/BYTES/g2
 iter_scan: "h"/3.000000000,0=/BYTES/h3
 iter_scan: "h"/1.000000000,0=/<empty>
@@ -874,8 +874,8 @@ iter_new types=pointsAndRanges pointSynthesis
 iter_seek_lt k=g ts=2
 iter_scan
 ----
-iter_seek_lt: "g"/3.000000000,0=vheader{ localTs=4.000000000,0 } /<empty>
-iter_scan: "g"/3.000000000,0=vheader{ localTs=4.000000000,0 } /<empty>
+iter_seek_lt: "g"/3.000000000,0={localTs=4.000000000,0}/<empty>
+iter_scan: "g"/3.000000000,0={localTs=4.000000000,0}/<empty>
 iter_scan: "g"/2.000000000,0=/BYTES/g2
 iter_scan: "h"/3.000000000,0=/BYTES/h3
 iter_scan: "h"/1.000000000,0=/<empty>

--- a/pkg/storage/testdata/mvcc_histories/range_key_put
+++ b/pkg/storage/testdata/mvcc_histories/range_key_put
@@ -57,7 +57,7 @@ put_rangekey k=c end=e ts=2 localTs=1
 ----
 >> at end:
 rangekey: {a-c}/[2.000000000,0=/<empty> 1.000000000,0=/<empty>]
-rangekey: {c-e}/[2.000000000,0=vheader{ localTs=1.000000000,0 } /<empty> 1.000000000,0=/<empty>]
+rangekey: {c-e}/[2.000000000,0={localTs=1.000000000,0}/<empty> 1.000000000,0=/<empty>]
 rangekey: {e-k}/[2.000000000,0=/<empty> 1.000000000,0=/<empty>]
 
 # Write the original value again to unfragment everything.

--- a/pkg/storage/testdata/mvcc_histories/uncertainty_interval_with_local_uncertainty_limit
+++ b/pkg/storage/testdata/mvcc_histories/uncertainty_interval_with_local_uncertainty_limit
@@ -43,7 +43,7 @@ with k=k2
 data: "k1"/20.000000000,0 -> /BYTES/v2
 data: "k1"/10.000000000,0 -> /BYTES/v1
 data: "k2"/20.000000000,0 -> /BYTES/v4
-data: "k2"/10.000000000,0 -> vheader{ localTs=5.000000000,0 } /BYTES/v3
+data: "k2"/10.000000000,0 -> {localTs=5.000000000,0}/BYTES/v3
 
 run ok
 with k=k3
@@ -54,8 +54,8 @@ with k=k3
 data: "k1"/20.000000000,0 -> /BYTES/v2
 data: "k1"/10.000000000,0 -> /BYTES/v1
 data: "k2"/20.000000000,0 -> /BYTES/v4
-data: "k2"/10.000000000,0 -> vheader{ localTs=5.000000000,0 } /BYTES/v3
-data: "k3"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v6
+data: "k2"/10.000000000,0 -> {localTs=5.000000000,0}/BYTES/v3
+data: "k3"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v6
 data: "k3"/10.000000000,0 -> /BYTES/v5
 
 run ok
@@ -67,11 +67,11 @@ with k=k4
 data: "k1"/20.000000000,0 -> /BYTES/v2
 data: "k1"/10.000000000,0 -> /BYTES/v1
 data: "k2"/20.000000000,0 -> /BYTES/v4
-data: "k2"/10.000000000,0 -> vheader{ localTs=5.000000000,0 } /BYTES/v3
-data: "k3"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v6
+data: "k2"/10.000000000,0 -> {localTs=5.000000000,0}/BYTES/v3
+data: "k3"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v6
 data: "k3"/10.000000000,0 -> /BYTES/v5
-data: "k4"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v8
-data: "k4"/10.000000000,0 -> vheader{ localTs=5.000000000,0 } /BYTES/v7
+data: "k4"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v8
+data: "k4"/10.000000000,0 -> {localTs=5.000000000,0}/BYTES/v7
 
 run ok
 with k=k5
@@ -84,11 +84,11 @@ txn: "A" meta={id=00000000 key="k5" pri=0.00000000 epo=0 ts=20.000000000,0 min=0
 data: "k1"/20.000000000,0 -> /BYTES/v2
 data: "k1"/10.000000000,0 -> /BYTES/v1
 data: "k2"/20.000000000,0 -> /BYTES/v4
-data: "k2"/10.000000000,0 -> vheader{ localTs=5.000000000,0 } /BYTES/v3
-data: "k3"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v6
+data: "k2"/10.000000000,0 -> {localTs=5.000000000,0}/BYTES/v3
+data: "k3"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v6
 data: "k3"/10.000000000,0 -> /BYTES/v5
-data: "k4"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v8
-data: "k4"/10.000000000,0 -> vheader{ localTs=5.000000000,0 } /BYTES/v7
+data: "k4"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v8
+data: "k4"/10.000000000,0 -> {localTs=5.000000000,0}/BYTES/v7
 meta: "k5"/0,0 -> txn={id=00000000 key="k5" pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k5"/20.000000000,0 -> /BYTES/v10
 data: "k5"/10.000000000,0 -> /BYTES/v9
@@ -104,17 +104,17 @@ txn: "B" meta={id=00000000 key="k6" pri=0.00000000 epo=0 ts=20.000000000,0 min=0
 data: "k1"/20.000000000,0 -> /BYTES/v2
 data: "k1"/10.000000000,0 -> /BYTES/v1
 data: "k2"/20.000000000,0 -> /BYTES/v4
-data: "k2"/10.000000000,0 -> vheader{ localTs=5.000000000,0 } /BYTES/v3
-data: "k3"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v6
+data: "k2"/10.000000000,0 -> {localTs=5.000000000,0}/BYTES/v3
+data: "k3"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v6
 data: "k3"/10.000000000,0 -> /BYTES/v5
-data: "k4"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v8
-data: "k4"/10.000000000,0 -> vheader{ localTs=5.000000000,0 } /BYTES/v7
+data: "k4"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v8
+data: "k4"/10.000000000,0 -> {localTs=5.000000000,0}/BYTES/v7
 meta: "k5"/0,0 -> txn={id=00000000 key="k5" pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k5"/20.000000000,0 -> /BYTES/v10
 data: "k5"/10.000000000,0 -> /BYTES/v9
 meta: "k6"/0,0 -> txn={id=00000000 key="k6" pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k6"/20.000000000,0 -> /BYTES/v12
-data: "k6"/10.000000000,0 -> vheader{ localTs=5.000000000,0 } /BYTES/v11
+data: "k6"/10.000000000,0 -> {localTs=5.000000000,0}/BYTES/v11
 
 run ok
 with k=k7
@@ -127,19 +127,19 @@ txn: "C" meta={id=00000000 key="k7" pri=0.00000000 epo=0 ts=20.000000000,0 min=0
 data: "k1"/20.000000000,0 -> /BYTES/v2
 data: "k1"/10.000000000,0 -> /BYTES/v1
 data: "k2"/20.000000000,0 -> /BYTES/v4
-data: "k2"/10.000000000,0 -> vheader{ localTs=5.000000000,0 } /BYTES/v3
-data: "k3"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v6
+data: "k2"/10.000000000,0 -> {localTs=5.000000000,0}/BYTES/v3
+data: "k3"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v6
 data: "k3"/10.000000000,0 -> /BYTES/v5
-data: "k4"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v8
-data: "k4"/10.000000000,0 -> vheader{ localTs=5.000000000,0 } /BYTES/v7
+data: "k4"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v8
+data: "k4"/10.000000000,0 -> {localTs=5.000000000,0}/BYTES/v7
 meta: "k5"/0,0 -> txn={id=00000000 key="k5" pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k5"/20.000000000,0 -> /BYTES/v10
 data: "k5"/10.000000000,0 -> /BYTES/v9
 meta: "k6"/0,0 -> txn={id=00000000 key="k6" pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k6"/20.000000000,0 -> /BYTES/v12
-data: "k6"/10.000000000,0 -> vheader{ localTs=5.000000000,0 } /BYTES/v11
+data: "k6"/10.000000000,0 -> {localTs=5.000000000,0}/BYTES/v11
 meta: "k7"/0,0 -> txn={id=00000000 key="k7" pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=21 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "k7"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v14
+data: "k7"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v14
 data: "k7"/10.000000000,0 -> /BYTES/v13
 
 run ok
@@ -153,23 +153,23 @@ txn: "D" meta={id=00000000 key="k8" pri=0.00000000 epo=0 ts=20.000000000,0 min=0
 data: "k1"/20.000000000,0 -> /BYTES/v2
 data: "k1"/10.000000000,0 -> /BYTES/v1
 data: "k2"/20.000000000,0 -> /BYTES/v4
-data: "k2"/10.000000000,0 -> vheader{ localTs=5.000000000,0 } /BYTES/v3
-data: "k3"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v6
+data: "k2"/10.000000000,0 -> {localTs=5.000000000,0}/BYTES/v3
+data: "k3"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v6
 data: "k3"/10.000000000,0 -> /BYTES/v5
-data: "k4"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v8
-data: "k4"/10.000000000,0 -> vheader{ localTs=5.000000000,0 } /BYTES/v7
+data: "k4"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v8
+data: "k4"/10.000000000,0 -> {localTs=5.000000000,0}/BYTES/v7
 meta: "k5"/0,0 -> txn={id=00000000 key="k5" pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k5"/20.000000000,0 -> /BYTES/v10
 data: "k5"/10.000000000,0 -> /BYTES/v9
 meta: "k6"/0,0 -> txn={id=00000000 key="k6" pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k6"/20.000000000,0 -> /BYTES/v12
-data: "k6"/10.000000000,0 -> vheader{ localTs=5.000000000,0 } /BYTES/v11
+data: "k6"/10.000000000,0 -> {localTs=5.000000000,0}/BYTES/v11
 meta: "k7"/0,0 -> txn={id=00000000 key="k7" pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=21 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "k7"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v14
+data: "k7"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v14
 data: "k7"/10.000000000,0 -> /BYTES/v13
 meta: "k8"/0,0 -> txn={id=00000000 key="k8" pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=21 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "k8"/20.000000000,0 -> vheader{ localTs=10.000000000,0 } /BYTES/v16
-data: "k8"/10.000000000,0 -> vheader{ localTs=5.000000000,0 } /BYTES/v15
+data: "k8"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v16
+data: "k8"/10.000000000,0 -> {localTs=5.000000000,0}/BYTES/v15
 
 # Test cases:
 #


### PR DESCRIPTION
**storage: allow disabling simple value encoding metamorphism**

The `disableSimpleValueEncoding` metamorphic test parameter can
interfere with certain tests that expect deterministic encoding. These
tests could be skipped under metamorphic tests via
`SkipIfSimpleValueEncodingDisabled()`.

However, the `dev test` tool will always enable test metamorphism, so
this approach would often skip these tests under `dev test`.

This patch instead changes the function to
`DisableMetamorphicSimpleValueEncoding()` which will disable the
metamorphic parameter for the duration of the test. This allows these
tests to run as normal under metamorphic tests.

Release note: None

**storage: make MVCCValue formatting more concise**

This patch makes the `MVCCValue` string formatting slightly more
concise. This formatting is consistent with e.g. txn/intent metadata,
but also removes the header prefix since this can be deduced from the
context.

This will be particularly helpful for `TestMVCCHistories` with range
keys, where multiple range key values in a single range key fragment
stack will be presented on a single line. For example, the range keys
`[c-e)@2` and `[c-e)@1` would be formatted as:

```
rangekey: {c-e}/[2.000000000,0=vheader{ localTs=1.000000000,0 } /<empty> 1.000000000,0=/<empty>]
```

After this change, they are formatted as:

```
rangekey: {c-e}/[2.000000000,0={localTs=1.000000000,0}/<empty> 1.000000000,0=/<empty>]
```

Release note: None