### PR TITLE
[dnm] kvserver: subject MsgApp to admission control

### DIFF
--- a/pkg/cmd/roachtest/tests/roachtest.go
+++ b/pkg/cmd/roachtest/tests/roachtest.go
@@ -24,6 +24,20 @@ import (
 
 func registerRoachtest(r registry.Registry) {
 	r.Add(registry.TestSpec{
+		Name:  "setup-prometheus",
+		Tags:  []string{"setup-prometheus"},
+		Owner: registry.OwnerTestEng,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			setupPrometheus(ctx, t, c, tpccOptions{}, []workloadInstance{
+				{
+					nodes:          c.Node(c.Spec().NodeCount),
+					prometheusPort: 2112,
+				},
+			})
+		},
+		Cluster: r.MakeClusterSpec(4),
+	})
+	r.Add(registry.TestSpec{
 		Name:    "roachtest/noop",
 		Tags:    []string{"roachtest"},
 		Owner:   registry.OwnerTestEng,

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -596,6 +596,13 @@ is located starts following the recovery.`,
 		Unit: metric.Unit_COUNT,
 	}
 
+	metaRaftRcvdAdmissionWait = metric.Metadata{
+		Name:        "raft.rcvd.admission_wait",
+		Help:        `TODO`,
+		Measurement: "Seconds",
+		Unit:        metric.Unit_SECONDS,
+	}
+
 	// Raft processing metrics.
 	metaRaftTicks = metric.Metadata{
 		Name:        "raft.ticks",
@@ -1526,6 +1533,7 @@ type StoreMetrics struct {
 	// Raft processing metrics.
 	RaftTicks                 *metric.Counter
 	RaftQuotaPoolPercentUsed  *metric.Histogram
+	RaftRcvdAdmissionWait     *metric.Counter
 	RaftWorkingDurationNanos  *metric.Counter
 	RaftTickingDurationNanos  *metric.Counter
 	RaftCommandsApplied       *metric.Counter
@@ -1986,6 +1994,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 			// NB: this results in 64 buckets (i.e. 64 timeseries in prometheus).
 			metaRaftQuotaPoolPercentUsed, histogramWindow, 100 /* maxVal */, 1, /* sigFigs */
 		),
+		RaftRcvdAdmissionWait:     metric.NewCounter(metaRaftRcvdAdmissionWait),
 		RaftWorkingDurationNanos:  metric.NewCounter(metaRaftWorkingDurationNanos),
 		RaftTickingDurationNanos:  metric.NewCounter(metaRaftTickingDurationNanos),
 		RaftCommandsApplied:       metric.NewCounter(metaRaftCommandsApplied),

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -681,7 +681,8 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 		panic(err)
 	}
 	if admissionHandle != nil {
-		defer r.store.cfg.KVAdmissionController.AdmittedKVWorkDone(admissionHandle)
+		r.store.metrics.RaftRcvdAdmissionWait.Inc(int64(timeutil.Since(stats.tBegin)))
+		r.store.cfg.KVAdmissionController.AdmittedKVWorkDone(admissionHandle)
 	}
 
 	if inSnap.Desc != nil {

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -672,7 +672,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 
 	admissionHandle, err := func() (interface{}, error) {
 		c := r.store.cfg.KVAdmissionController
-		if c == nil || !enableRaftFollowerAdmissionControl || r.RangeID < 45 {
+		if r.store.StoreID() != 3 || c == nil || !enableRaftFollowerAdmissionControl || r.RangeID < 45 {
 			return nil, nil
 		}
 		return c.AdmitKVWork(ctx, roachpb.SystemTenantID, &ba)

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -577,9 +577,11 @@ func (c *SyncedCluster) generateStartFlagsKV(
 			storeDir := c.NodeDir(node, i)
 			storeDirs = append(storeDirs, storeDir)
 			// Place a store{i} attribute on each store to allow for zone configs
-			// that use specific stores.
+			// that use specific stores. Allow targeting either the i-th store
+			// across nodes, or all stores on a specific node, or a specific store
+			// in the cluster (identified by its <nodeID,storeID> pair).
 			args = append(args, `--store`,
-				`path=`+storeDir+`,attrs=`+fmt.Sprintf("store%d", i))
+				fmt.Sprintf(`path=%s,attrs=store%d:node%d:node%dstore%d`, storeDir, i, node, node, i))
 		}
 	} else {
 		storeDir := strings.TrimPrefix(startOpts.ExtraArgs[idx], "--store=")

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/index.tsx
@@ -206,7 +206,7 @@ export class CustomChart extends React.Component<
         setTimeScale={this.props.setTimeScale}
         history={this.props.history}
       >
-        <LineGraph>
+        <LineGraph title={metrics.map(m => m.metric).join(", ")}>
           <Axis units={units} label={AxisUnits[units]}>
             {metrics.map((m, i) => {
               if (m.metric !== "") {


### PR DESCRIPTION
Context: https://github.com/cockroachdb/cockroach/issues/79215#issuecomment-1126093924

- [ ] block on raft receive queue (first commit)
- [ ] block in handleRaftReady (second commit)
- [ ] treat followers with high r-amp as probing (TBD)
- [ ] delay ready handling until admission control passed (TBD)

Release note: None
