### PR TITLE
roachprod: improve store attributes

### DIFF
--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -577,9 +577,12 @@ func (c *SyncedCluster) generateStartFlagsKV(
 			storeDir := c.NodeDir(node, i)
 			storeDirs = append(storeDirs, storeDir)
 			// Place a store{i} attribute on each store to allow for zone configs
-			// that use specific stores.
+			// that use specific stores. Note that `i` is 1 most of the time, since
+			// it's the i-th store on the *current* node. This isn't always useful,
+			// for example it doesn't let one single out a specific node. We add
+			// nodeX-flavor attributes for that.
 			args = append(args, `--store`,
-				`path=`+storeDir+`,attrs=`+fmt.Sprintf("store%d", i))
+				fmt.Sprintf(`path=%s,attrs=store%d:node%d:node%dstore%d`, storeDir, i, node, node, i))
 		}
 	} else {
 		storeDir := strings.TrimPrefix(startOpts.ExtraArgs[idx], "--store=")


### PR DESCRIPTION
They would previously be `store1` since we mostly run single-store
deployments. It's often helpful to target a particular node, for
example for lease preferences.

Before:

```
 select node_id, attrs from crdb_internal.kv_store_status;
  node_id |               attrs
----------+-------------------------------------
        1 | ["store1"]
```

After:

```
  node_id |               attrs
        1 | ["node1", "node1store1", "store1"]
```

Release note: None
