### PR TITLE
release: run preflight without TTY

### DIFF
--- a/build/release/teamcity-publish-redhat-release.sh
+++ b/build/release/teamcity-publish-redhat-release.sh
@@ -68,7 +68,6 @@ tc_end_block "Push RedHat docker image"
 tc_start_block "Run preflight"
 mkdir -p artifacts
 docker run \
-  -it \
   --rm \
   --security-opt=label=disable \
   --env PFLT_LOGLEVEL=trace \


### PR DESCRIPTION
Previously, calling `preflight` with `-it` caused failures, because
docker tried to acquire a terminal, but TeamCity agents don't have a TTY
attached to the agent process.

This patch removes `-it` in order to make the call non-interactive.

Release note: None