### PR TITLE
security: remove unnecessary calls to os.ExpandEnv

### DIFF
--- a/pkg/security/certificate_manager.go
+++ b/pkg/security/certificate_manager.go
@@ -257,12 +257,12 @@ func (cm *CertificateManager) RegisterSignalHandler(stopper *stop.Stopper) {
 
 // A CertsLocator provides locations to certificates.
 type CertsLocator struct {
-	certsDir string // os.ExpandEnv'ed
+	certsDir string
 }
 
 // MakeCertsLocator initializes a CertsLocator.
 func MakeCertsLocator(certsDir string) CertsLocator {
-	return CertsLocator{certsDir: os.ExpandEnv(certsDir)}
+	return CertsLocator{certsDir: certsDir}
 }
 
 // CACertPath returns the expected file path for the CA certificate.

--- a/pkg/security/certs.go
+++ b/pkg/security/certs.go
@@ -158,10 +158,6 @@ func createCACertAndKey(
 			CAPem, ClientCAPem, UICAPem, caType)
 	}
 
-	// The certificate manager expands the env for the certs directory.
-	// For consistency, we need to do this for the key as well.
-	caKeyPath = os.ExpandEnv(caKeyPath)
-
 	// Create a certificate manager with "create dir if not exist".
 	cm, err := NewCertificateManagerFirstRun(certsDir, CommandTLSSettings{})
 	if err != nil {
@@ -269,10 +265,6 @@ func CreateNodePair(
 		return errors.New("the path to the certs directory is required")
 	}
 
-	// The certificate manager expands the env for the certs directory.
-	// For consistency, we need to do this for the key as well.
-	caKeyPath = os.ExpandEnv(caKeyPath)
-
 	// Create a certificate manager with "create dir if not exist".
 	cm, err := NewCertificateManagerFirstRun(certsDir, CommandTLSSettings{})
 	if err != nil {
@@ -331,10 +323,6 @@ func CreateUIPair(
 		return errors.New("the path to the certs directory is required")
 	}
 
-	// The certificate manager expands the env for the certs directory.
-	// For consistency, we need to do this for the key as well.
-	caKeyPath = os.ExpandEnv(caKeyPath)
-
 	// Create a certificate manager with "create dir if not exist".
 	cm, err := NewCertificateManagerFirstRun(certsDir, CommandTLSSettings{})
 	if err != nil {
@@ -392,10 +380,6 @@ func CreateClientPair(
 	if len(certsDir) == 0 {
 		return errors.New("the path to the certs directory is required")
 	}
-
-	// The certificate manager expands the env for the certs directory.
-	// For consistency, we need to do this for the key as well.
-	caKeyPath = os.ExpandEnv(caKeyPath)
 
 	// Create a certificate manager with "create dir if not exist".
 	cm, err := NewCertificateManagerFirstRun(certsDir, CommandTLSSettings{})
@@ -477,10 +461,6 @@ func CreateTenantPair(
 	if len(certsDir) == 0 {
 		return nil, errors.New("the path to the certs directory is required")
 	}
-
-	// The certificate manager expands the env for the certs directory.
-	// For consistency, we need to do this for the key as well.
-	caKeyPath = os.ExpandEnv(caKeyPath)
 
 	// Create a certificate manager with "create dir if not exist".
 	cm, err := NewCertificateManagerFirstRun(certsDir, CommandTLSSettings{})


### PR DESCRIPTION
Fixes #69412.


Previously to this patch, the code in the pkg/security package
interpreted the `--certs-dir` command-line flag using the Go function
`os.ExpandEnv`.

This mades it possible to indirectly use environment variables when
specifying the value of `--certs-dir`. For example, the user could type
`--certs-dir='$HOME/.certs'`. Note the single quotes: the expansion is
performed inside the process (by Go), not by the shell.

There are several problems with this approach:

- it is surprising -- this type of expansion is extremely uncommon for
  the command-line flags of server services, and generally only used
  when parsing configuration files. The reason why it is uncommon is
  that there is already another mechanism that can do this, namely the
  shell's own expansion facilities, and therefore this double expansion
  is not really needed.

- it makes it difficult/impossible to use in the (albeit unusual) case
  where the directory name on disk contains a dollar sign.

- it may constitute a security vulnerability, as it enables the flag
  expansion to access arbitrary environment variables in the shell that
  launches crdb and observe their value by looking at the error messages
  upon certificate loads. For example, a malicious user that can
  indirectly control the flag can specify
  `--certs-dir=$COCKROACH_LICENSE_KEY` and discover the env var value in
  the error message even if they don't have access to env vars
  otherwise.

Finally, this functionality is probably never used. We do not mention
it in docs, and experience reading deployment scripts suggests it is
not being used in practice.

Release note (backward-incompatible change): CockroachDB does not
perform env var expansion in the parameter `--certs-dir` anymore. This
was an undocumented feature.  Uses like
`--certs-dir='$HOME/path'` (expansion by CockroachDB) can be
replaced by `--certs-dir="$HOME/path"` (expansion by the unix shell).