### PR TITLE
roachprod: log stdout/stderr to provided logger in `run`

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -580,8 +580,10 @@ func runCmdOnSingleNode(
 
 	sess.SetWithExitStatus(true)
 	var stdoutBuffer, stderrBuffer bytes.Buffer
-	sess.SetStdout(&stdoutBuffer)
-	sess.SetStderr(&stderrBuffer)
+	multStdout := io.MultiWriter(&stdoutBuffer, l.Stdout)
+	multStderr := io.MultiWriter(&stderrBuffer, l.Stderr)
+	sess.SetStdout(multStdout)
+	sess.SetStderr(multStderr)
 
 	// Argument template expansion is node specific (e.g. for {store-dir}).
 	e := expander{


### PR DESCRIPTION
See [here] for motivation.

The problem was that `run` would not be guaranteed to put the output
into the file, but that is where it needs to go.

[here]: https://github.com/cockroachdb/cockroach/issues/72083#issuecomment-1124946183

Release note: None
