### PR TITLE
release-21.1: acceptance: skip `TestComposeGSSPython`

### DIFF
--- a/pkg/acceptance/compose_test.go
+++ b/pkg/acceptance/compose_test.go
@@ -17,6 +17,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 )
 
 func TestComposeGSS(t *testing.T) {
@@ -24,6 +26,7 @@ func TestComposeGSS(t *testing.T) {
 }
 
 func TestComposeGSSPython(t *testing.T) {
+	skip.WithIssue(t, 81254)
 	testCompose(t, filepath.Join("compose", "gss", "docker-compose-python.yml"), "python")
 }
 


### PR DESCRIPTION
Cherry-pick from #81244.

This is now broken due to a new version of `psql` being pulled in that
is more strict about cert ownership.

See #81254.

Release note: None
Release justification: Un-breaks build