### PR TITLE
acceptance: update how we build the `python` compose image

### DIFF
--- a/pkg/acceptance/compose/gss/python/Dockerfile
+++ b/pkg/acceptance/compose/gss/python/Dockerfile
@@ -1,10 +1,12 @@
 FROM python:3
 ENV PYTHONUNBUFFERED 1
 
-RUN apt-get update && \
+RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+  echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" | tee  /etc/apt/sources.list.d/pgdg.list && \
+  apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
   krb5-user \
-  postgresql-client
+  postgresql-client-11
 
 RUN mkdir /code
 WORKDIR /code

--- a/pkg/acceptance/compose_test.go
+++ b/pkg/acceptance/compose_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/pkg/build/bazel"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 )
 
 const composeDir = "compose"
@@ -30,7 +29,6 @@ func TestComposeGSS(t *testing.T) {
 }
 
 func TestComposeGSSPython(t *testing.T) {
-	skip.WithIssue(t, 81254)
 	testCompose(t, filepath.Join("gss", "docker-compose-python.yml"), "python")
 }
 


### PR DESCRIPTION
Up until this point we were using `apt install postgresql-client` to
install the `psql` binary in this image. Because the `postgresql-client`
`apt` package was apparently updated to a later version of `postgres`
last week that includes [this change](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=a59c79564bdc209a5bc7b02d706f0d7352eb82fa),
the `TestComposeGSSPython` `acceptance` test started failing with the
following error:

```
psql: error: private key file "/certs/client.root.key" must be owned by the current user or root
```

Less recent versions of `psql` are more permissive about cert
permissions, so we work around this by simply copying a less recent
version of `psql` from the older `postgres:11` image.

Release note: None
Release justification: Test-only change