### PR TITLE
release-21.2: cli: add --advertise-http-addr flag

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -553,6 +553,33 @@ An IPv6 address can also be specified with the notation [...], for
 example [::1]:8080 or [fe80::f6f2:::]:8080.`,
 	}
 
+	HTTPAdvertiseAddr = FlagInfo{
+		Name: "advertise-http-addr",
+		Description: `
+The HTTP address/hostname and port to advertise to nodes in the cluster
+for reporting the DB Console address and proxying of HTTP connections.
+It must resolve and be routable from other nodes in the cluster for
+proxying to work in DB Console.
+<PRE>
+
+</PRE>
+If left unspecified, it defaults to the host setting of --advertise-addr
+and the port of --http-addr, which is 8080 by default. If advertise-addr
+is left unspecified, it defaults to the setting of http-addr. If the
+flag is unspecified as well as fallbacks, it defaults to the hostname as
+reported by the OS.
+<PRE>
+
+</PRE>
+An IPv6 address can also be specified with the notation [...], for
+example [::1]:26257 or [fe80::f6f2:::]:26257.
+<PRE>
+
+</PRE>
+The port number should be the same as in --http-addr unless port
+forwarding is set up on an intermediate firewall/router.`,
+	}
+
 	UnencryptedLocalhostHTTP = FlagInfo{
 		Name: "unencrypted-localhost-http",
 		Description: `

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1005,6 +1006,112 @@ func TestClientConnSettings(t *testing.T) {
 			t.Errorf("%d. serverCfg.Addr expected '%s', but got '%s'. td.args was '%#v'.",
 				i, td.expectedAddr, serverCfg.Addr, td.args)
 		}
+	}
+}
+
+func TestHttpAdvertiseAddrFlagValue(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	defer initCLIDefaults()
+
+	// Prepare some reference strings that will be checked in the
+	// test below.
+	hostname, err := os.Hostname()
+	if err != nil {
+		t.Fatal(err)
+	}
+	hostAddr, err := base.LookupAddr(context.Background(), net.DefaultResolver, hostname)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(hostAddr, ":") {
+		hostAddr = "[" + hostAddr + "]"
+	}
+
+	f := startCmd.Flags()
+	for i, tc := range []struct {
+		args                        []string
+		expected                    string
+		expectedAfterAddrValidation string
+		expectedServerHTTPAddr      string
+		tlsEnabled                  bool
+	}{
+		{[]string{"start"},
+			":" + base.DefaultHTTPPort,
+			hostname + ":" + base.DefaultHTTPPort,
+			":" + base.DefaultHTTPPort,
+			true},
+		{[]string{"start", "--http-addr", hostAddr},
+			hostAddr + ":" + base.DefaultHTTPPort,
+			hostAddr + ":" + base.DefaultHTTPPort,
+			hostAddr + ":" + base.DefaultHTTPPort,
+			true},
+		{[]string{"start", "--advertise-addr", "adv.example.com", "--http-addr", "http.example.com"},
+			"adv.example.com:" + base.DefaultHTTPPort,
+			"adv.example.com:" + base.DefaultHTTPPort,
+			"http.example.com:" + base.DefaultHTTPPort,
+			true},
+		{[]string{"start", "--advertise-addr", "adv.example.com:2345", "--http-addr", "http.example.com:1234"},
+			"adv.example.com:1234",
+			"adv.example.com:1234",
+			"http.example.com:1234",
+			true},
+		{[]string{"start", "--advertise-addr", "example.com"},
+			"example.com:" + base.DefaultHTTPPort,
+			"example.com:" + base.DefaultHTTPPort,
+			":" + base.DefaultHTTPPort,
+			true},
+		{[]string{"start", "--advertise-http-addr", "example.com"},
+			"example.com:" + base.DefaultHTTPPort,
+			"example.com:" + base.DefaultHTTPPort,
+			":" + base.DefaultHTTPPort,
+			true},
+		{[]string{"start", "--http-addr", "http.example.com", "--advertise-http-addr", "example.com"},
+			"example.com:" + base.DefaultHTTPPort,
+			"example.com:" + base.DefaultHTTPPort,
+			"http.example.com:" + base.DefaultHTTPPort,
+			true},
+		{[]string{"start", "--advertise-addr", "adv.example.com", "--advertise-http-addr", "example.com"},
+			"example.com:" + base.DefaultHTTPPort,
+			"example.com:" + base.DefaultHTTPPort,
+			":" + base.DefaultHTTPPort,
+
+			true},
+		{[]string{"start", "--advertise-addr", "adv.example.com:1234", "--http-addr", "http.example.com:2345", "--advertise-http-addr", "example.com:3456"},
+			"example.com:3456",
+			"example.com:3456",
+			"http.example.com:2345",
+			true},
+	} {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			initCLIDefaults()
+			require.NoError(t, f.Parse(tc.args))
+
+			err := extraServerFlagInit(startCmd)
+			require.NoError(t, err)
+
+			exp := "http"
+			if tc.tlsEnabled {
+				exp = "https"
+			}
+			require.Equal(t, tc.expected, serverCfg.HTTPAdvertiseAddr,
+				"serverCfg.HTTPAdvertiseAddr expected '%s', but got '%s'. td.args was '%#v'.",
+				tc.expected, serverCfg.HTTPAdvertiseAddr, tc.args)
+			require.Equal(t, exp, serverCfg.HTTPRequestScheme(),
+				"TLS config expected %s, got %s. td.args was '%#v'.", exp, serverCfg.HTTPRequestScheme(), tc.args)
+
+			ctx := context.Background()
+			err = serverCfg.ValidateAddrs(ctx)
+			if err != nil {
+				// Don't care about resolution failures
+				if !strings.Contains(err.Error(), "invalid --http-addr") {
+					t.Errorf("unexpected error: %s", err)
+				}
+			}
+			require.Equal(t, tc.expectedAfterAddrValidation, serverCfg.HTTPAdvertiseAddr, "http advertise addr after validation")
+			require.Equal(t, tc.expectedServerHTTPAddr, serverCfg.HTTPAddr, "http addr after validation")
+		})
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #79966.

/cc @cockroachdb/release

Release justification: This is a new CLI flag that allows for finer grained configuration of a config var that was previously inferred only from other CLI flags. It can help with the setup of HTTP proxy behavior between nodes in a cluster. In particular, our cloud configuration needs the modified configuration to enable proxying in DB Console.

---

Previously, the HTTP Advertise Address was derived from either the OS
hostname, the SQL advertise address, or the `--http-addr` flag.

This commit adds an explicit flag for setting this field in order to
provide control over it for scenarios where node to node proxying
requires hostnames different from the ones the HTTP server is listening
on.

Resolves https://github.com/cockroachdb/cockroach/issues/79164

Release note (cli change): A new flag `--advertise-http-addr` is
available for setting the HTTP advertise address explicitly. Previously,
this address was derived from the OS hostname, the `--advertise-addr`
and the `--http-addr` flags in that order. The new logic will override
the HTTP advertise host with the host from `--advertise-addr` first if
set, and then the host from `--http-addr`. The port will *never* inherit
from `--advertise-host` and only from `--http-addr`, which is 8080 by
default. The HTTP advertise address is used to report the DB Console
address to access on a cluster and by nodes to proxy HTTP connections as
described in https://github.com/cockroachdb/cockroach/issues/73285. It may be necessary to set this flag in order for
that feature to work correctly in some deployments.
