### PR TITLE
ui: create TimeScaleDropdown wrapper for key vizualizer

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScaleDropdown.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScaleDropdown.tsx
@@ -37,6 +37,7 @@ export interface TimeScaleDropdownProps {
     curTimeScale: TimeScale,
     timeWindow: TimeWindow,
   ) => TimeScale;
+  hasCustomOption?: boolean;
 }
 
 export const getTimeLabel = (
@@ -125,6 +126,7 @@ export const TimeScaleDropdown: React.FC<TimeScaleDropdownProps> = ({
   options = defaultTimeScaleOptions,
   setTimeScale,
   adjustTimeScaleOnChange,
+  hasCustomOption = true,
 }): React.ReactElement => {
   const end = currentScale.fixedWindowEnd
     ? moment.utc(currentScale.fixedWindowEnd)
@@ -220,13 +222,15 @@ export const TimeScaleDropdown: React.FC<TimeScaleDropdownProps> = ({
       label: key,
       timeLabel: getTimeLabel(null, value.windowSize),
     }));
-    optionsList.push({
-      value: "Custom",
-      label: "Custom",
-      timeLabel: "--",
-    });
+    if (hasCustomOption) {
+      optionsList.push({
+        value: "Custom",
+        label: "Custom",
+        timeLabel: "--",
+      });
+    }
     return optionsList;
-  }, [options]);
+  }, [options, hasCustomOption]);
 
   const setDateRange = ([start, end]: [moment.Moment, moment.Moment]) => {
     const seconds = moment.duration(moment.utc(end).diff(start)).asSeconds();

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/timeScaleDropdownWithSearchParams/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/timeScaleDropdownWithSearchParams/index.tsx
@@ -60,7 +60,10 @@ const TimeScaleDropdownWithSearchParams = (
       // Find the closest time scale just by window size.
       // And temporarily assume the end is "now" with fixedWindowEnd=false.
       const timeScale: TimeScale = {
-        ...findClosestTimeScale(defaultTimeScaleOptions, seconds),
+        ...findClosestTimeScale(
+          props.options || defaultTimeScaleOptions,
+          seconds,
+        ),
         windowSize: moment.duration(end.diff(start)),
         fixedWindowEnd: false,
       };

--- a/pkg/ui/workspaces/db-console/src/views/keyVizualizer/timeWindow.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/keyVizualizer/timeWindow.tsx
@@ -1,0 +1,71 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { TimeScaleOptions } from "@cockroachlabs/cluster-ui";
+import TimeScaleDropdown from "src/views/cluster/containers/timeScaleDropdownWithSearchParams";
+import moment from "moment";
+
+export const KeyVizualizerTimeWindow = () => {
+  const keyVizualizerTimeScaleOptions: TimeScaleOptions = {
+    "Past 10 Minutes": {
+      windowSize: moment.duration(10, "minutes"),
+      windowValid: moment.duration(15, "minutes"),
+      sampleSize: moment.duration(10, "seconds"),
+    },
+    "Past 30 Minutes": {
+      windowSize: moment.duration(30, "minutes"),
+      windowValid: moment.duration(15, "minutes"),
+      sampleSize: moment.duration(30, "seconds"),
+    },
+    "Past 1 Hour": {
+      windowSize: moment.duration(1, "hour"),
+      windowValid: moment.duration(15, "minutes"),
+      sampleSize: moment.duration(30, "seconds"),
+    },
+    "Past 6 Hours": {
+      windowSize: moment.duration(6, "hours"),
+      windowValid: moment.duration(15, "minutes"),
+      sampleSize: moment.duration(1, "minutes"),
+    },
+    "Past 1 Day": {
+      windowSize: moment.duration(1, "day"),
+      windowValid: moment.duration(15, "minutes"),
+      sampleSize: moment.duration(5, "minutes"),
+    },
+    "Past 2 Days": {
+      windowSize: moment.duration(2, "day"),
+      windowValid: moment.duration(15, "minutes"),
+      sampleSize: moment.duration(5, "minutes"),
+    },
+    "Past 3 Days": {
+      windowSize: moment.duration(3, "day"),
+      windowValid: moment.duration(15, "minutes"),
+      sampleSize: moment.duration(5, "minutes"),
+    },
+    "Past Week": {
+      windowSize: moment.duration(7, "days"),
+      windowValid: moment.duration(15, "minutes"),
+      sampleSize: moment.duration(30, "minutes"),
+    },
+    "Past 2 Weeks": {
+      windowSize: moment.duration(14, "days"),
+      windowValid: moment.duration(15, "minutes"),
+      sampleSize: moment.duration(30, "minutes"),
+    },
+  };
+
+  return (
+    <TimeScaleDropdown
+      options={keyVizualizerTimeScaleOptions}
+      hasCustomOption={false}
+    />
+  );
+};


### PR DESCRIPTION
This patch introduces a new component to make the existing
TimeScaleDropdown component compatible with the wip key
vizualizer. Custom options and a new prop were provided to
make this compatability work.

Release note: None

![Screen Shot 2022-05-16 at 4 21 46 PM](https://user-images.githubusercontent.com/17861665/168680426-663f4b1d-d579-4ef5-8ac1-27cdc4cc6d9c.png)
