### PR TITLE
opt: do not use placeholder fast path if types do not match

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -1393,3 +1393,30 @@ PREPARE q64765 as SELECT * FROM t64765 WHERE x = $1 AND y = $2
 
 statement ok
 EXECUTE q64765(1, 1)
+
+# Regression test for #81315.
+statement ok
+CREATE TABLE t81315 (a DECIMAL NOT NULL PRIMARY KEY, b INT);
+PREPARE q81315 AS SELECT * FROM t81315 WHERE a = $1::INT8;
+INSERT INTO t81315 VALUES (1, 100), (2, 200)
+
+query TI
+SELECT * FROM t81315 WHERE a = 1
+----
+1  100
+
+query TI
+EXECUTE q81315 (1)
+----
+1  100
+
+statement ok
+CREATE TABLE t81315_2 (
+  k INT PRIMARY KEY,
+  a INT
+);
+PREPARE q81315_2 AS SELECT * FROM t81315_2 WHERE k = $1;
+INSERT INTO t81315_2 VALUES (1, 1)
+
+statement error expected EXECUTE parameter expression to have type int
+EXECUTE q81315_2(1::DECIMAL)

--- a/pkg/sql/opt/xform/testdata/placeholder-fast-path/scan
+++ b/pkg/sql/opt/xform/testdata/placeholder-fast-path/scan
@@ -300,3 +300,29 @@ placeholder-fast-path
 SELECT * FROM xyz WHERE x = $1 AND y = $2
 ----
 no fast path
+
+# Regression test for #81315. Do not use the placeholder fast path
+# if the types do not match.
+exec-ddl
+CREATE TABLE t_dec (a DECIMAL NOT NULL PRIMARY KEY, b INT);
+----
+
+# TODO(rytaft): We may be able to use the placeholder fast path for
+# this case if we add logic similar to UnifyComparisonTypes.
+placeholder-fast-path
+SELECT * FROM t_dec WHERE a = $1::INT8;
+----
+no fast path
+
+placeholder-fast-path
+SELECT * FROM t_dec WHERE a = $1;
+----
+placeholder-scan t_dec
+ ├── columns: a:1!null b:2
+ ├── cardinality: [0 - 1]
+ ├── immutable, has-placeholder
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0, avgsize(1)=4]
+ ├── key: ()
+ ├── fd: ()-->(1,2)
+ └── span
+      └── $1


### PR DESCRIPTION
Fixed a bug where we were incorrectly using the placeholder fast
path if the type of the placholder did not match the type of the column.
We should disallow mixed-type comparisons for the placeholder fast path
because it results in incorrect encodings, and therefore incorrect results
from the scan. We now disable the placeholder fast path if the types do
not match.

Fixes #81315

Release note (bug fix): Fixed a bug in which some prepared statements
could result in incorrect results when executed. This could occur when
the prepared statement included an equality comparison between an index
column and a placeholder, and the placholder was cast to a type that was
different from the column type. For example, if column `a` was of type
`DECIMAL`, the following prepared query could produce incorrect results
when executed:
```
SELECT * FROM t_dec WHERE a = $1::INT8;
```