### PR TITLE
Resolve AutoBuild failure in GO

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'cpp', 'go', 'javascript', 'python', 'ruby' ]
+        language: [ 'go' ]
+        #language: [ 'cpp', 'go', 'javascript', 'python', 'ruby' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 
@@ -52,7 +53,8 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
+    - if: matrix.language == 'cpp'
+      name: Autobuild
       uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
@@ -65,6 +67,13 @@ jobs:
     #- run: |
     #   make bootstrap
     #   make release
+    
+    # Go Build Limit GOGC as per LGTM: https://lgtm.com/projects/g/cockroachdb/cockroach/logs/languages/lang:go
+    - if: matrix.language == 'go'        
+      name: Setup Go Environment
+      shell: bash
+      run: |
+        echo "GOGC=50" >> $GITHUB_ENV
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,9 +31,8 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-        language: [ 'go' ]
-        #language: [ 'cpp', 'go', 'javascript', 'python', 'ruby' ]
+      matrix:        
+        language: [ 'cpp', 'go', 'javascript', 'python', 'ruby' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 


### PR DESCRIPTION
👋  @emnet-crl 

This PR to your branch adds GOGC environment variable to resolve errors seen during initial CodeQL action run for the `Go` language: https://github.com/cockroachdb/cockroach/actions/runs/2187097942 .  With this change, CodeQL is able to scan the pkg folders and surfaces `Code Scanning` alerts very similar to [LGTM](https://lgtm.com/projects/g/cockroachdb/cockroach/alerts/?mode=list).

```
2022-04-19T02:55:22.6766782Z [2022-04-19 02:55:22] [build-stderr] 2022/04/19 02:55:22 Extraction failed: signal: killed
2022-04-19T02:55:22.8087671Z [2022-04-19 02:55:22] [ERROR] Spawned process exited abnormally (code 1; tried to run: [/opt/hostedtoolcache/CodeQL/0.0.0-20220401/x64/codeql/tools/linux64/preload_tracer, /opt/hostedtoolcache/CodeQL/0.0.0-20220401/x64/codeql/go/tools/autobuild.sh])
```

There still appears to be a bit of Go Build makefile errors that prevent a successful build. I would recommend setting up the action with the expected environment variables and path configuration as needed to compile.

- "Makefile:248: *** GOPATH is not set and could not be automatically determined.  Stop."
    
```YAML
    # Makefile:248: *** GOPATH is not set and could not be automatically determined.  Stop.   
    - name: setup env
      shell: bash
      run: |
        echo "GOPATH=${{ github.workspace }}/go" >> $GITHUB_ENV
```

  -  The makefile appears to also preset further restrictions on the path configuration of the build, which can be addressed with: 

```YAML
    #** Current directory "/home/runner/work/cockroach/cockroach" is not within GOPATH "/home/runner/work/cockroach/cockroach/go".  Stop. 
    - name: Checkout repository
      uses: actions/checkout@v3
      with:
        path: go/src/github.com/cockroachdb/cockroach
```

