### PR TITLE
sqlsmith: explicitly allow updates and deletes without where clauses

### DIFF
--- a/pkg/internal/sqlsmith/setup.go
+++ b/pkg/internal/sqlsmith/setup.go
@@ -40,7 +40,9 @@ var Setups = map[string]Setup{
 // specific setup passed in.
 func wrapCommonSetup(setupFn Setup) Setup {
 	return func(r *rand.Rand) []string {
-		return setupFn(r)
+		return append([]string{
+			"SET sql_safe_updates = false;",
+		}, setupFn(r)...)
 	}
 }
 


### PR DESCRIPTION
SQLsmith often generates UPDATE and DELETE statements without WHERE
clauses. If sql_safe_updates is true, these will fail with an error.

I believe sql_safe_updates is usually false when executing SQLsmith
queries in roachtest (where false is the default). This is not true,
however, when using cockroach demo to reproduce SQLsmith failures (where
true is the default). So let's explicitly set it to false and log this
to simplify reproductions.

Informs: #81032

Release note: None