### PR TITLE
sql: assign locking strength and wait policy in ZigzagJoinerSpec_Side

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2604,6 +2604,8 @@ func (dsp *DistSQLPlanner) planZigzagJoin(
 			s.EqColumns.Columns[j] = uint32(col)
 		}
 		s.FixedValues = *side.fixedValues
+		s.LockingStrength = side.lockingStrength
+		s.LockingWaitPolicy = side.lockingWaitPolicy
 	}
 
 	// The zigzag join node only represents inner joins, so hardcode Type to


### PR DESCRIPTION
This was missed in a8b951b. I didn't notice until trying to backport.

What would be the right level to add testing for this plumbing?