### PR TITLE
tree: extend disallow_imports_test

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -341,6 +341,7 @@ ALL_TESTS = [
     "//pkg/sql/opt/testutils:testutils_test",
     "//pkg/sql/opt/xform:xform_test",
     "//pkg/sql/opt:opt_test",
+    "//pkg/sql/parser:parser_disallowed_imports_test",
     "//pkg/sql/parser:parser_test",
     "//pkg/sql/pgwire/hba:hba_test",
     "//pkg/sql/pgwire/identmap:identmap_test",

--- a/pkg/sql/parser/BUILD.bazel
+++ b/pkg/sql/parser/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//pkg/testutils/buildutil:buildutil.bzl", "disallowed_imports_test")
 
 go_library(
     name = "parser",
@@ -144,4 +145,20 @@ exports_files(
         "help.awk",
     ],
     visibility = ["//visibility:public"],
+)
+
+disallowed_imports_test(
+    "parser",
+    disallowed_list = [
+        "//pkg/kv",
+        "//pkg/roachpb",
+        "//pkg/security",
+        "//pkg/server",
+        "//pkg/sql/sessiondata",
+        "//pkg/storage",
+        "//pkg/util/log",
+    ],
+    disallowed_prefixes = [
+        "pkg/sql/catalog",
+    ],
 )

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -276,10 +276,12 @@ disallowed_imports_test(
     "tree",
     disallowed_list = [
         "//pkg/kv",
+        "//pkg/roachpb",
         "//pkg/security",
         "//pkg/server",
         "//pkg/sql/sessiondata",
         "//pkg/storage",
+        "//pkg/util/log",
     ],
     disallowed_prefixes = [
         "pkg/sql/catalog",


### PR DESCRIPTION
Now blocking roachpb and util/log.

Release note: None