### PR TITLE
sql: fix database resolution for GRANT ALL TABLES

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/grant_on_all_tables_in_schema
+++ b/pkg/sql/logictest/testdata/logic_test/grant_on_all_tables_in_schema
@@ -94,3 +94,21 @@ query TTTTT colnames
 SHOW GRANTS FOR testuser, testuser2
 ----
 database_name  schema_name  relation_name  grantee  privilege_type
+
+# Verify that the database name is resolved correctly if specified.
+statement ok
+CREATE DATABASE otherdb
+
+statement ok
+CREATE TABLE otherdb.public.tbl (a int)
+
+statement ok
+GRANT SELECT ON ALL TABLES IN SCHEMA otherdb.public TO testuser
+
+query TTTTTB colnames
+SHOW GRANTS ON TABLE otherdb.public.tbl
+----
+database_name  schema_name  table_name  grantee   privilege_type  is_grantable
+otherdb        public       tbl         admin     ALL             true
+otherdb        public       tbl         root      ALL             true
+otherdb        public       tbl         testuser  SELECT          false

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -447,12 +447,16 @@ func getDescriptorsFromTargetListForPrivilegeChange(
 		}
 		if targets.AllTablesInSchema {
 			// Get all the descriptors for the tables in the specified schemas.
-			db, err := p.Descriptors().GetMutableDatabaseByName(ctx, p.txn, p.CurrentDatabase(), flags)
-			if err != nil {
-				return nil, err
-			}
 			var descs []catalog.Descriptor
 			for _, sc := range targets.Schemas {
+				dbName := p.CurrentDatabase()
+				if sc.ExplicitCatalog {
+					dbName = sc.Catalog()
+				}
+				db, err := p.Descriptors().GetMutableDatabaseByName(ctx, p.txn, dbName, flags)
+				if err != nil {
+					return nil, err
+				}
 				_, objectIDs, err := resolver.GetObjectNamesAndIDs(
 					ctx, p.txn, p, p.ExecCfg().Codec, db, sc.Schema(), true, /* explicitPrefix */
 				)


### PR DESCRIPTION
fixes #81002

Release note (bug fix): Fixed a bug where GRANT ALL TABLES IN SCHEMA
would not resolve the correct database name if it was explicitly
specified.