### PR TITLE
bazel: disallow c-deps, cockroachdb/errors imports for dev

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -84,6 +84,7 @@ ALL_TESTS = [
     "//pkg/cmd/bazci:bazci_test",
     "//pkg/cmd/cmpconn:cmpconn_test",
     "//pkg/cmd/cockroach-oss:cockroach-oss_disallowed_imports_test",
+    "//pkg/cmd/dev:dev_disallowed_imports_test",
     "//pkg/cmd/dev:dev_test",
     "//pkg/cmd/docgen/extract:extract_test",
     "//pkg/cmd/docs-issue-generation:docs-issue-generation_test",

--- a/pkg/cmd/dev/BUILD.bazel
+++ b/pkg/cmd/dev/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("//pkg/testutils/buildutil:buildutil.bzl", "disallowed_imports_test")
 
 go_library(
     name = "dev_lib",
@@ -58,4 +59,12 @@ go_test(
         "@com_github_irfansharif_recorder//:recorder",
         "@com_github_stretchr_testify//require",
     ],
+)
+
+disallowed_imports_test(
+    "dev",
+    [
+        "@com_github_cockroachdb_errors//:errors",
+    ],
+    disallow_cdeps = True,
 )

--- a/pkg/testutils/buildutil/buildutil.bzl
+++ b/pkg/testutils/buildutil/buildutil.bzl
@@ -118,6 +118,7 @@ def disallowed_imports_test(src, disallowed_list = [], disallowed_prefixes = [],
   )
   native.sh_test(
     name = src.strip(":") + "_disallowed_imports_test",
+    size = "small",
     srcs = [":"+script],
     tags = ["local"],
   )


### PR DESCRIPTION
`errors` is a pretty heavy dependency, and we have no need for the
`c-deps` in `dev`.

Also set the size of all `disallowed_imports_test`s as `small`.

Release note: None