### PR TITLE
backupccl: Introduce Cabinet concept as a collection Files. Stream cabinets to disk during backup.

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "backup_processor.go",
         "backup_processor_planning.go",
         "backup_span_coverage.go",
+        "cabinet_sst_sink.go",
         "create_scheduled_backup.go",
         "encryption.go",
         "file_sst_sink.go",

--- a/pkg/ccl/backupccl/backup.proto
+++ b/pkg/ccl/backupccl/backup.proto
@@ -85,7 +85,18 @@ message BackupManifest {
 
   repeated DescriptorRevision descriptor_changes = 16  [(gogoproto.nullable) = false];
 
+  // TODO(benbardin): Deprecate when Backup and Restore no longer use this.
   repeated File files = 4 [(gogoproto.nullable) = false];
+
+  // A "cabinet" is an SST containing File objects.
+  // A cabinet ID can be interpolated to determine the path to that cabinet,
+  // using cabinetPathFromID() in cabinet_sst_sink.go
+  // At the end of a backup job, these paths are written to the backup
+  // metadata table.
+  // In the near future, we will store this information in a jobs state table
+  // and remove it from the manifest entirely.
+  repeated int64 cabinet_ids = 27 [(gogoproto.customname) = "CabinetIDs"];
+
   repeated sql.sqlbase.Descriptor descriptors = 5 [(gogoproto.nullable) = false];
   repeated sql.sqlbase.TenantInfoWithUsage tenants = 26 [(gogoproto.nullable) = false];
   // This field is deprecated; it is only retained to allow restoring older
@@ -125,7 +136,7 @@ message BackupManifest {
   int32 descriptor_coverage = 22 [
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/tree.DescriptorCoverage"];
 
-  // NEXT ID: 27
+  // NEXT ID: 28
 }
 
 message BackupPartitionDescriptor{

--- a/pkg/ccl/backupccl/cabinet_sst_sink.go
+++ b/pkg/ccl/backupccl/cabinet_sst_sink.go
@@ -1,0 +1,201 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package backupccl
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
+)
+
+type cabinetSSTSinkConf struct {
+	enc      *jobspb.BackupEncryptionOptions
+	id       base.SQLInstanceID
+	settings *settings.Values
+}
+
+type cabinetSSTSink struct {
+	dest cloud.ExternalStorage
+	conf cabinetSSTSinkConf
+
+	queue queue
+
+	ctx context.Context
+
+	memAcc struct {
+		ba            *mon.BoundAccount
+		reservedBytes int64
+	}
+}
+
+type queue struct {
+	// The information in keys[i] will be contained in values[i].
+	// But we want to marshall values early to save memory, so store keys
+	// separately to sort the list without unmarshalling.
+	keys   []*roachpb.Key
+	values []*[]byte
+
+	// The current byte size of the queue.
+	size int
+
+	sort.Interface
+}
+
+func (q queue) Len() int {
+	return len(q.keys)
+}
+
+func (q queue) Swap(i int, j int) {
+	q.keys[i], q.keys[j] = q.keys[j], q.keys[i]
+	q.values[i], q.values[j] = q.values[j], q.values[i]
+}
+
+func (q queue) Less(i, j int) bool {
+	return q.keys[i].Compare(*q.keys[j]) < 0
+}
+
+func (q *queue) add(key *roachpb.Key, value *[]byte) {
+	q.keys = append(q.keys, key)
+	q.values = append(q.values, value)
+	q.size += len(*key) + len(*value)
+}
+
+func (q *queue) reset() {
+	q.keys = make([]*roachpb.Key, 0)
+	q.values = make([]*[]byte, 0)
+	q.size = 0
+}
+
+func makeCabinetSSTSink(
+	ctx context.Context,
+	conf cabinetSSTSinkConf,
+	dest cloud.ExternalStorage,
+	backupMem *mon.BoundAccount,
+) (*cabinetSSTSink, error) {
+	s := &cabinetSSTSink{conf: conf, dest: dest, ctx: ctx}
+	s.memAcc.ba = backupMem
+
+	// Reserve memory for the file buffer. Incrementally reserve memory in chunks
+	// upto a maximum of the `smallFileBuffer` cluster setting value. If we fail
+	// to grow the bound account at any stage, use the buffer size we arrived at
+	// prior to the error.
+	incrementSize := int64(32 << 20)
+	maxSize := smallFileBuffer.Get(s.conf.settings)
+	for {
+		if s.memAcc.reservedBytes >= maxSize {
+			break
+		}
+
+		if incrementSize > maxSize-s.memAcc.reservedBytes {
+			incrementSize = maxSize - s.memAcc.reservedBytes
+		}
+
+		if err := s.memAcc.ba.Grow(ctx, incrementSize); err != nil {
+			log.Infof(ctx,
+				"failed to grow file queue by %d bytes, running backup with queue size %d bytes: %+v",
+				incrementSize, s.memAcc.reservedBytes, err)
+			break
+		}
+		s.memAcc.reservedBytes += incrementSize
+	}
+	if s.memAcc.reservedBytes == 0 {
+		return nil, errors.New("failed to reserve memory for cabinetSSTSink queue")
+	}
+
+	return s, nil
+}
+
+func (s *cabinetSSTSink) close() {
+	if s.queue.size > 0 {
+		s.queue.reset()
+		log.Errorf(s.ctx, "Cabinet queue non-empty on close.")
+	}
+	// Release the memory reserved for the file buffer.
+	s.memAcc.ba.Shrink(s.ctx, s.memAcc.reservedBytes)
+	s.memAcc.reservedBytes = 0
+}
+
+func (s *cabinetSSTSink) push(file BackupManifest_File) (*int64, error) {
+	encodedFile, err := protoutil.Marshal(&file)
+	if err != nil {
+		return nil, err
+	}
+	key := encodeFileSSTKey(file.Span.Key, file.Path)
+	s.queue.add(&key, &encodedFile)
+
+	if s.queue.size < int(s.memAcc.reservedBytes) {
+		return nil, nil
+	}
+
+	cabinetID, err := s.writeQueue()
+	if err != nil {
+		return nil, err
+	}
+
+	return &cabinetID, nil
+}
+
+func (s *cabinetSSTSink) writeQueue() (int64, error) {
+	sort.Sort(s.queue)
+
+	cabinetID := int64(builtins.GenerateUniqueInt(s.conf.id))
+
+	cabinetPath := cabinetPathFromID(cabinetID)
+
+	w, err := makeWriter(s.ctx, s.dest, cabinetPath, s.conf.enc)
+	if err != nil {
+		return 0, err
+	}
+	defer w.Close()
+	fileSST := storage.MakeBackupSSTWriter(s.ctx, s.dest.Settings(), w)
+	defer fileSST.Close()
+
+	for i, key := range s.queue.keys {
+		value := s.queue.values[i]
+		if err := fileSST.PutUnversioned(*key, *value); err != nil {
+			return 0, err
+		}
+	}
+	err = fileSST.Finish()
+	if err != nil {
+		return 0, err
+	}
+	err = w.Close()
+	if err != nil {
+		return 0, err
+	}
+
+	s.queue.reset()
+
+	return cabinetID, nil
+}
+
+func cabinetPathFromID(ID int64) string {
+	return path.Join(cabinetDirectory, fmt.Sprintf("%d.sst", ID))
+}
+
+func encodeFileSSTKey(spanStart roachpb.Key, filename string) roachpb.Key {
+	buf := make([]byte, 0)
+	buf = encoding.EncodeBytesAscending(buf, spanStart)
+	return roachpb.Key(encoding.EncodeStringAscending(buf, filename))
+}

--- a/pkg/ccl/backupccl/file_sst_sink.go
+++ b/pkg/ccl/backupccl/file_sst_sink.go
@@ -31,7 +31,7 @@ import (
 	"github.com/kr/pretty"
 )
 
-type sstSinkConf struct {
+type fileSSTSinkConf struct {
 	progCh   chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress
 	enc      *roachpb.FileEncryptionOptions
 	id       base.SQLInstanceID
@@ -40,9 +40,10 @@ type sstSinkConf struct {
 
 type fileSSTSink struct {
 	dest cloud.ExternalStorage
-	conf sstSinkConf
+	conf fileSSTSinkConf
 
 	queue []exportedSpan
+
 	// queueCap is the maximum byte size that the queue can grow to.
 	queueCap int64
 	// queueSize is the current byte size of the queue.
@@ -74,7 +75,10 @@ type fileSSTSink struct {
 }
 
 func makeFileSSTSink(
-	ctx context.Context, conf sstSinkConf, dest cloud.ExternalStorage, backupMem *mon.BoundAccount,
+	ctx context.Context,
+	conf fileSSTSinkConf,
+	dest cloud.ExternalStorage,
+	backupMem *mon.BoundAccount,
 ) (*fileSSTSink, error) {
 	s := &fileSSTSink{conf: conf, dest: dest}
 	s.memAcc.ba = backupMem

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -77,6 +77,18 @@ func ConstantWithMetamorphicTestValue(name string, defaultValue, metamorphicValu
 	return defaultValue
 }
 
+// ConstantWithTestValue will always return a specific different value in test builds.
+func ConstantWithTestValue(name string, defaultValue, testValue int) int {
+	var value int
+	if buildutil.CrdbTestBuild && !disableMetamorphicTesting {
+		value = testValue
+		fmt.Fprintf(os.Stderr, "initialized constant %q with value %v\n", name, value)
+	} else {
+		value = defaultValue
+	}
+	return value
+}
+
 // rng is initialized to a rand.Rand if crdbTestBuild is enabled.
 var rng struct {
 	r *rand.Rand


### PR DESCRIPTION
Introduces the concept of the Cabinet, a collection of Files. This is necessary because "FileFile" (what I now call a "cabinet") is an incomprehensible term, as is FileFileFile (as in the main metadata sst).

This PR Adds a "cabinet sink" that buffers and writes out File objects to cabinet files. Backups now stream out cabinets throughout the backup. backup_metadata is updated to use the new terminology and functionality.

Does NOT read these cabinet files yet, neither on Restore nor Backup-Resume. That functionality will follow in subsequent diffs (and will include backwards compatibility for fileinfo.sst in Restore).

Release note: None