### PR TITLE
geomfn: check NaN coordinates for ST_MinimumBoundingCircle

### DIFF
--- a/pkg/geo/geomfn/topology_operations.go
+++ b/pkg/geo/geomfn/topology_operations.go
@@ -44,7 +44,7 @@ func Centroid(g geo.Geometry) (geo.Geometry, error) {
 
 // MinimumBoundingCircle returns minimum bounding circle of an EWKB
 func MinimumBoundingCircle(g geo.Geometry) (geo.Geometry, geo.Geometry, float64, error) {
-	if BoundingBoxHasInfiniteCoordinates(g) {
+	if BoundingBoxHasInfiniteCoordinates(g) || BoundingBoxHasNaNCoordinates(g) {
 		return geo.Geometry{}, geo.Geometry{}, 0, pgerror.Newf(pgcode.InvalidParameterValue, "value out of range: overflow")
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -5707,6 +5707,14 @@ SELECT ST_AsText(ST_SnapToGrid(ST_MinimumBoundingCircle(ST_GeomFromText('POINT(0
 ----
 POINT (0 0)
 
+statement error st_minimumboundingcircle\(\): value out of range: overflow
+SELECT st_astext(st_minimumboundingcircle(
+  st_makepoint(
+    (-0.23349138300862382)::FLOAT8,
+    (-1.0):::FLOAT8::FLOAT8 ^ (0.7478831141483115:::FLOAT8 - (0))::FLOAT8
+  )
+)) AS regression_81277
+
 query T
 SELECT ST_AsText(ST_SnapToGrid(ST_MinimumBoundingCircle(ST_GeomFromText('GEOMETRYCOLLECTION (LINESTRING(55 75,125 150), POINT(20 80))'), 4), 0.001));
 ----


### PR DESCRIPTION
Resolves #81277

Release note (bug fix): Fix a bug where ST_MinimumBoundingCircle with
NaN coordinates could panic.