### PR TITLE
roachtest: do not fail costfuzz test on perturbed error

### DIFF
--- a/pkg/cmd/reduce/main.go
+++ b/pkg/cmd/reduce/main.go
@@ -58,6 +58,9 @@ var (
 	tlp             = flags.Bool("tlp", false, "last two non-empty lines in file are equivalent queries returning different results")
 )
 
+// TODO(michae2): Add -costfuzz mode which is aware that the last three
+// statements are two identical queries separated by a setting change.
+
 const description = `
 The reduce utility attempts to simplify SQL that produces an error in
 CockroachDB. The problematic SQL, specified via -file flag, is


### PR DESCRIPTION
The costfuzz test repeatedly executes a randomly generated query twice,
once with a normal plan and once with a perturbed-costs plan. We were
considering a successful first execution followed by an errored second
execution a test failure. But there are certain queries that
legitimately return errors nondeterministically depending on plan. For
example:

```sql
CREATE TABLE t (a INT PRIMARY KEY);
CREATE TABLE u (b INT PRIMARY KEY);
INSERT INTO t VALUES (0);
SELECT * FROM t INNER HASH JOIN u ON a = b + 1 WHERE 1 / a = 1;
SELECT * FROM u INNER HASH JOIN t ON a = b + 1 WHERE 1 / a = 1;
```

The first plan will successfully return 0 rows because the hash join can
short-circuit without evaluating 1 / a. The second plan will return a
divide-by-zero error because 1 / a is evaluated while building the hash
table. This is not a bug.

Internal errors are a little more interesting than normal SQL-level
errors, so we still consider this a test failure on internal errors.

Fixes: #81032

Release note: None