### PR TITLE
backupccl: add ignore-notice to datadriven test framework

### DIFF
--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -235,6 +235,9 @@ func (d *datadrivenTestState) getSQLDB(t *testing.T, server string, user string)
 //   + expect-error-ignore: expects the query to return an error, but we will
 //   ignore it.
 //
+//   + ignore-notice: does not print out the notice that is buffered during
+//   query execution.
+//
 // - "query-sql [server=<name>] [user=<name>]"
 //   Executes the input SQL query and print the results.
 //
@@ -378,6 +381,10 @@ func TestDataDriven(t *testing.T) {
 				d.Input = strings.ReplaceAll(d.Input, "http://COCKROACH_TEST_HTTP_SERVER/", httpAddr)
 				_, err := ds.getSQLDB(t, server, user).Exec(d.Input)
 				ret := ds.noticeBuffer
+
+				if d.HasArg("ignore-notice") {
+					ret = nil
+				}
 
 				// Check if we are expecting a pausepoint error.
 				if d.HasArg("expect-pausepoint") {

--- a/pkg/ccl/backupccl/testdata/backup-restore/multiregion
+++ b/pkg/ccl/backupccl/testdata/backup-restore/multiregion
@@ -92,11 +92,9 @@ exec-sql
 DROP DATABASE no_region_db_2;
 ----
 
-exec-sql
+exec-sql ignore-notice
 SET CLUSTER SETTING sql.defaults.primary_region = 'non-existent-region';
 ----
-NOTICE: setting global default sql.defaults.primary_region is not recommended
-HINT: use the `ALTER ROLE ... SET` syntax to control session variable defaults at a finer-grained level. See: https://www.cockroachlabs.com/docs/v22.1/alter-role.html#set-default-session-variable-values-for-a-role
 
 exec-sql
 RESTORE DATABASE no_region_db FROM LATEST IN 'nodelocal://1/no_region_database_backup/';
@@ -106,11 +104,9 @@ HINT: valid regions: eu-central-1, eu-north-1
 --
 set the default PRIMARY REGION to a region that exists (see SHOW REGIONS FROM CLUSTER) then using SET CLUSTER SETTING sql.defaults.primary_region = 'region'
 
-exec-sql
+exec-sql ignore-notice
 SET CLUSTER SETTING sql.defaults.primary_region = 'eu-central-1';
 ----
-NOTICE: setting global default sql.defaults.primary_region is not recommended
-HINT: use the `ALTER ROLE ... SET` syntax to control session variable defaults at a finer-grained level. See: https://www.cockroachlabs.com/docs/v22.1/alter-role.html#set-default-session-variable-values-for-a-role
 
 exec-sql
 RESTORE DATABASE no_region_db FROM LATEST IN 'nodelocal://1/no_region_database_backup/';
@@ -147,11 +143,9 @@ BACKUP DATABASE eu_central_db INTO 'nodelocal://1/eu_central_database_backup/';
 new-server name=s4 share-io-dir=s1 allow-implicit-access localities=eu-central-1,eu-north-1
 ----
 
-exec-sql
+exec-sql ignore-notice
 SET CLUSTER SETTING sql.defaults.primary_region = 'eu-north-1';
 ----
-NOTICE: setting global default sql.defaults.primary_region is not recommended
-HINT: use the `ALTER ROLE ... SET` syntax to control session variable defaults at a finer-grained level. See: https://www.cockroachlabs.com/docs/v22.1/alter-role.html#set-default-session-variable-values-for-a-role
 
 exec-sql
 RESTORE FROM LATEST IN 'nodelocal://1/no_region_cluster_backup/';


### PR DESCRIPTION
`exec-sql` now supports an `ignore-notice` option that does not
print out the notice buffer on query execution. The motivation
for this change is dubious:

1) Datadriven output does not support regex matching.

2) Some notices contain docs URLs that in turn contain the
BUILD_TAG baked in their URL. This will change everytime the docs
version associated with the binary changes making the test flaky.

The correct way of fixing this might be to switchover from using
the deprecated `SET CLUSTER SETTING sql.default.primary_region` to using
an `ALTER ROLE SET sql.default.primary_region` but I want to leave this
to someone who makes the switch across tests.

Release note: None