### PR TITLE
ui: Plot circuit breaker tripped events as a rate values

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips.tsx
@@ -161,7 +161,7 @@ export const CircuitBreakerTrippedReplicasTooltip: React.FC = () => (
 
 export const CircuitBreakerTrippedEventsTooltip: React.FC = () => (
   <div>
-    Number of times the per-Replica circuit breakers tripped since process
-    start.
+    The number of circuit breaker events occurred per second across all nodes
+    since the process started.
   </div>
 );

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -218,7 +218,7 @@ export default function(props: GraphDashboardProps) {
             name="cr.store.kv.replica_circuit_breaker.num_tripped_events"
             title={nodeDisplayName(nodesSummary, nid)}
             sources={storeIDsForNode(nodesSummary, nid)}
-            downsampler={TimeSeriesQueryAggregator.MAX}
+            nonNegativeRate
           />
         ))}
       </Axis>


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/78939

Before, Circuit Breaker Tripped events chart displayed the accumulated number
of events since the process started.

Now, it displays the number of events per aggregated interval of time.

Release note (ui change): Circuit Breaker Tripped events chart displays
rate of events per interval instead of the accumulated number of events.

<img width="988" alt="Screen Shot 2022-05-18 at 16 03 22" src="https://user-images.githubusercontent.com/3106437/169045058-b0424e72-08ef-4ceb-a1d1-f0f094048bd1.png">
