### PR TITLE
ui: Incorrect link on CC SQL activity page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/emptyTransactionsPlaceholder.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/emptyTransactionsPlaceholder.tsx
@@ -21,7 +21,7 @@ import { commonStyles } from "src/common";
 
 const footer = (
   <Anchor href={transactionsTable} target="_blank">
-    Learn more about statements
+    Learn more about transactions
   </Anchor>
 );
 


### PR DESCRIPTION
Before, in SQL Activity -> Transactions: when empty, the "Learn more about statements" link sends one to the transactions page

Now, the text has been changed to "Learn more about transactions"

Release note: None