### PR TITLE
sql: fix expandIndexName to return correct table mutable

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/rename_index
+++ b/pkg/sql/logictest/testdata/logic_test/rename_index
@@ -169,3 +169,19 @@ SELECT DISTINCT index_name FROM [SHOW INDEXES FROM users]
 pk
 ufo
 bar
+
+# Regression test for #81211
+statement ok
+CREATE TABLE t1(a int);
+
+statement ok
+BEGIN;
+
+statement ok
+CREATE INDEX i1 ON t1(a);
+
+statement ok
+ALTER INDEX i1 RENAME TO i2;
+
+statement ok
+COMMIT;

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -662,7 +662,7 @@ func expandMutableIndexName(
 func expandIndexName(
 	ctx context.Context,
 	txn *kv.Txn,
-	sc resolver.SchemaResolver,
+	p *planner,
 	codec keys.SQLCodec,
 	index *tree.TableIndexName,
 	requireTable bool,
@@ -670,7 +670,7 @@ func expandIndexName(
 	tn = &index.Table
 	if tn.Object() != "" {
 		// The index and its table prefix must exist already. Resolve the table.
-		_, desc, err = resolver.ResolveMutableExistingTableObject(ctx, sc, tn, requireTable, tree.ResolveRequireTableOrViewDesc)
+		_, desc, err = resolver.ResolveMutableExistingTableObject(ctx, p, tn, requireTable, tree.ResolveRequireTableOrViewDesc)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -681,7 +681,7 @@ func expandIndexName(
 		return tn, desc, nil
 	}
 
-	found, resolvedPrefix, tbl, _, err := resolver.ResolveIndex(ctx, sc, index, txn, codec, requireTable, false /*requireActiveIndex*/)
+	found, resolvedPrefix, tbl, _, err := resolver.ResolveIndex(ctx, p, index, txn, codec, requireTable, false /*requireActiveIndex*/)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -698,7 +698,10 @@ func expandIndexName(
 	// Memoize the table name that was found. tn is a reference to the table name
 	// stored in index.Table.
 	*tn = tableName
-	tblMutable := tbl.NewBuilder().BuildExistingMutable().(*tabledesc.Mutable)
+	tblMutable, err := p.Descriptors().GetMutableTableVersionByID(ctx, tbl.GetID(), p.Txn())
+	if err != nil {
+		return nil, nil, err
+	}
 	return &tableName, tblMutable, nil
 }
 


### PR DESCRIPTION
Fixes #81211
A regression was introduced with #80769 that the table mutable
got created from a uncommitted descriptor. This pr tries to fix
that.

Release note: None.