### PR TITLE
changefeedccl: tolerate "no inbound stream connection" error

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -3266,6 +3266,58 @@ func TestChangefeedRetryableError(t *testing.T) {
 	t.Run(`pubsub`, pubsubTest(testFn))
 }
 
+func TestChangefeedJobRetryOnNoInboundStream(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	skip.UnderRace(t)
+	skip.UnderStress(t)
+
+	cluster, db, cleanup := startTestCluster(t)
+	defer cleanup()
+	sqlDB := sqlutils.MakeSQLRunner(db)
+
+	// force fast "no inbound stream" error
+	var oldMaxRunningFlows int
+	var oldTimeout string
+	sqlDB.QueryRow(t, "SHOW CLUSTER SETTING sql.distsql.max_running_flows").Scan(&oldMaxRunningFlows)
+	sqlDB.QueryRow(t, "SHOW CLUSTER SETTING sql.distsql.flow_stream_timeout").Scan(&oldTimeout)
+	serverutils.SetClusterSetting(t, cluster, "sql.distsql.max_running_flows", 0)
+	serverutils.SetClusterSetting(t, cluster, "sql.distsql.flow_stream_timeout", "1s")
+
+	sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+	sqlDB.Exec(t, `INSERT INTO foo VALUES (1)`)
+
+	// Connect to a non-leaseholder node so that a DistSQL flow is required
+	var leaseHolder int
+	sqlDB.QueryRow(t, `SELECT lease_holder FROM [SHOW RANGES FROM TABLE foo] LIMIT 1`).Scan(&leaseHolder)
+	feedServerID := ((leaseHolder - 1) + 1) % 3
+	db = cluster.ServerConn(feedServerID)
+	sqlDB = sqlutils.MakeSQLRunner(db)
+	f := makeKafkaFeedFactoryForCluster(cluster, db)
+	foo := feed(t, f, `CREATE CHANGEFEED FOR foo`)
+	defer closeFeed(t, foo)
+
+	// Verify job progress contains retryable error status.
+	registry := f.Server().JobRegistry().(*jobs.Registry)
+	jobID := foo.(cdctest.EnterpriseTestFeed).JobID()
+	testutils.SucceedsSoon(t, func() error {
+		job, err := registry.LoadJob(context.Background(), jobID)
+		require.NoError(t, err)
+		if strings.Contains(job.Progress().RunningStatus, "retryable error") {
+			return nil
+		}
+		return errors.Newf("job status was %s", job.Progress().RunningStatus)
+	})
+
+	// Fix the error. Job should retry successfully.
+	sqlDB.Exec(t, "SET CLUSTER SETTING sql.distsql.max_running_flows=$1", oldMaxRunningFlows)
+	sqlDB.Exec(t, "SET CLUSTER SETTING sql.distsql.flow_stream_timeout=$1", oldTimeout)
+	assertPayloads(t, foo, []string{
+		`foo: [1]->{"after": {"a": 1}}`,
+	})
+
+}
+
 func TestChangefeedJobUpdateFailsIfNotClaimed(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/settings",
         "//pkg/sql",
         "//pkg/sql/catalog",
+        "//pkg/sql/flowinfra",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/ccl/changefeedccl/changefeedbase/errors.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/errors.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/joberror"
+	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/errors"
 )
 
@@ -116,7 +117,7 @@ func IsRetryableError(err error) bool {
 		return true
 	}
 
-	return joberror.IsDistSQLRetryableError(err)
+	return (joberror.IsDistSQLRetryableError(err) || flowinfra.IsNoInboundStreamConnectionError(err))
 }
 
 // MaybeStripRetryableErrorMarker performs some minimal attempt to clean the


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/81318
by marking such errors as retryable.

Release note (bug fix): Fixed a bug where changefeeds could fail permanently if encountering an error while planning their distribution, even though such errors are usually transient.