### PR TITLE
release-21.2: builder: install a newer version of node

### DIFF
--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -141,7 +141,7 @@ RUN echo "add-auto-load-safe-path $(go env GOROOT)/src/runtime/runtime-gdb.py" >
 # chrome - ui
 # unzip - for installing awscli
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
- && echo 'deb https://deb.nodesource.com/node_12.x focal main' | tee /etc/apt/sources.list.d/nodesource.list \
+ && echo 'deb https://deb.nodesource.com/node_16.x focal main' | tee /etc/apt/sources.list.d/nodesource.list \
  && curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
  && echo 'deb https://dl.yarnpkg.com/debian/ stable main' | tee /etc/apt/sources.list.d/yarn.list \
  && curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \


### PR DESCRIPTION
This is a manual cherry-pick of #81471 (it can't be directly
cherry-picked due to differences in the Docker image between 22.1 and
21.2). This version of `node` can OOM under certain circumstances.

Release note: None
Release justification: Build-only change