### PR TITLE
roachtest: declare encryption support as part of TestSpec

### DIFF
--- a/build/teamcity-nightly-roachtest.sh
+++ b/build/teamcity-nightly-roachtest.sh
@@ -27,7 +27,7 @@ build/builder/mkrelease.sh amd64-linux-gnu build bin/workload bin/roachtest \
 source $root/build/teamcity/util/roachtest_util.sh
 
 build/teamcity-roachtest-invoke.sh \
-  --encrypt=random \
+  --metamorphic-encryption-probability=0.5 \
   --cloud="${CLOUD}" \
   --count="${COUNT-1}" \
   --parallelism="${PARALLELISM}" \

--- a/build/teamcity-weekly-roachtest.sh
+++ b/build/teamcity-weekly-roachtest.sh
@@ -57,7 +57,7 @@ timeout -s INT $((7800*60)) bin/roachtest run \
   --workload "$PWD/bin/workload" \
   --artifacts "$artifacts" \
   --parallelism 5 \
-  --encrypt=random \
+  --metamorphic-encryption-probability=0.5 \
   --teamcity || exit_status=$?
 
 if [[ ${exit_status} -eq 10 ]]; then

--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
@@ -16,7 +16,7 @@ artifacts=/artifacts
 source $root/build/teamcity/util/roachtest_util.sh
 
 build/teamcity-roachtest-invoke.sh \
-  --encrypt=random \
+  --metamorphic-encryption-probability=0.5 \
   --cloud="${CLOUD}" \
   --count="${COUNT-1}" \
   --parallelism="${PARALLELISM}" \

--- a/build/teamcity/cockroach/nightlies/roachtest_weekly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_weekly_impl.sh
@@ -52,7 +52,7 @@ timeout -s INT $((7800*60)) bin/roachtest run \
   --artifacts "/artifacts/${artifacts_subdir}" \
   --artifacts-literal="${artifacts}" \
   --parallelism 5 \
-  --encrypt=random \
+  --metamorphic-encryption-probability=0.5 \
   --teamcity || exit_status=$?
 
 if [[ ${exit_status} -eq 10 ]]; then

--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//pkg/util/ctxgroup",
         "//pkg/util/log",
         "//pkg/util/quotapool",
+        "//pkg/util/randutil",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -18,7 +18,6 @@ import (
 	"io"
 	"io/fs"
 	"io/ioutil"
-	"math/rand"
 	"net"
 	"net/url"
 	"os"
@@ -62,10 +61,18 @@ var (
 	// alias for `--cloud=local` and remove this variable.
 	local bool
 
-	cockroach                 string
-	libraryFilePaths          []string
-	cloud                                  = spec.GCE
-	encrypt                   encryptValue = "false"
+	cockroach        string
+	libraryFilePaths []string
+	cloud            = spec.GCE
+	// encryptionProbability controls when encryption-at-rest is enabled
+	// in a cluster for tests that have opted-in to metamorphic
+	// encryption (EncryptionMetamorphic).
+	//
+	// Tests that have opted-in to metamorphic encryption will run with
+	// encryption enabled by default (probability 1). In order to run
+	// them with encryption disabled (perhaps to reproduce a test
+	// failure), roachtest can be invoked with --metamorphic-encryption-probability=0
+	encryptionProbability     float64
 	instanceType              string
 	localSSDArg               bool
 	workload                  string
@@ -87,39 +94,9 @@ var (
 	disableIssue     bool
 )
 
-type encryptValue string
-
-func (v *encryptValue) String() string {
-	return string(*v)
-}
-
-func (v *encryptValue) Set(s string) error {
-	if s == "random" {
-		*v = encryptValue(s)
-		return nil
-	}
-	t, err := strconv.ParseBool(s)
-	if err != nil {
-		return err
-	}
-	*v = encryptValue(fmt.Sprint(t))
-	return nil
-}
-
-func (v *encryptValue) asBool() bool {
-	if *v == "random" {
-		return rand.Intn(2) == 0
-	}
-	t, err := strconv.ParseBool(string(*v))
-	if err != nil {
-		return false
-	}
-	return t
-}
-
-func (v *encryptValue) Type() string {
-	return "string"
-}
+const (
+	defaultEncryptionProbability = 1
+)
 
 type errBinaryOrLibraryNotFound struct {
 	binary string

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -132,9 +132,10 @@ func main() {
 		&cockroach, "cockroach", "", "path to cockroach binary to use")
 	rootCmd.PersistentFlags().StringVar(
 		&workload, "workload", "", "path to workload binary to use")
-	f := rootCmd.PersistentFlags().VarPF(
-		&encrypt, "encrypt", "", "start cluster with encryption at rest turned on")
-	f.NoOptDefVal = "true"
+	rootCmd.PersistentFlags().Float64Var(
+		&encryptionProbability, "metamorphic-encryption-probability", defaultEncryptionProbability,
+		"probability that clusters will be created with encryption-at-rest enabled "+
+			"for tests that support metamorphic encryption (default 1.0)")
 
 	rootCmd.AddCommand(&cobra.Command{
 		Use:   `version`,

--- a/pkg/cmd/roachtest/option/options.go
+++ b/pkg/cmd/roachtest/option/options.go
@@ -19,8 +19,7 @@ import (
 type StartOpts struct {
 	RoachprodOpts install.StartOpts
 	RoachtestOpts struct {
-		Worker      bool
-		DontEncrypt bool
+		Worker bool
 	}
 }
 

--- a/pkg/cmd/roachtest/registry/BUILD.bazel
+++ b/pkg/cmd/roachtest/registry/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "registry",
     srcs = [
+        "encryption.go",
         "filter.go",
         "owners.go",
         "registry_interface.go",

--- a/pkg/cmd/roachtest/registry/encryption.go
+++ b/pkg/cmd/roachtest/registry/encryption.go
@@ -1,0 +1,48 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package registry
+
+import "fmt"
+
+// EncryptionSupport encodes the relationship of a test with
+// encryption-at-rest. Tests can either opt-in to metamorphic
+// encryption, or require that encryption is always on or always off
+// (default).
+type EncryptionSupport int
+
+func (es EncryptionSupport) String() string {
+	switch es {
+	case EncryptionAlwaysEnabled:
+		return "always-enabled"
+	case EncryptionAlwaysDisabled:
+		return "always-disabled"
+	case EncryptionMetamorphic:
+		return "metamorphic"
+	default:
+		return fmt.Sprintf("unknown-%d", es)
+	}
+}
+
+const (
+	// EncryptionAlwaysDisabled indicates that the test requires
+	// encryption to be disabled. The test will only run on clusters
+	// with encryption disabled.
+	EncryptionAlwaysDisabled = EncryptionSupport(iota)
+	// EncryptionAlwaysEnabled indicates that the test requires
+	// encryption to be enabled. The test will only run on clusters
+	// with encryption enabled.
+	EncryptionAlwaysEnabled
+	// EncryptionMetamorphic indicates that a test opted-in to
+	// metamorphic encryption. Whether the test runs on a cluster with
+	// encryption enabled depends on the probability passed to
+	// --metamorphic-encryption-probability.
+	EncryptionMetamorphic
+)

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -67,10 +67,12 @@ type TestSpec struct {
 	// in the environment.
 	RequiresLicense bool
 
-	// EncryptAtRandom specifies that even when roachtest is invoked without the
-	// `--encrypt` flag, clusters handed to this test will randomly have
-	// encryption-at-rest enabled.
-	EncryptAtRandom bool
+	// EncryptionSupport encodes to what extent tests supports
+	// encryption-at-rest. See the EncryptionSupport type for details.
+	// Encryption support is opt-in -- i.e., if the TestSpec does not
+	// pass a value to this field, it will be assumed that the test
+	// cannot be run with encryption enabled.
+	EncryptionSupport EncryptionSupport
 
 	// Run is the test function.
 	Run func(ctx context.Context, t test.Test, c cluster.Cluster)

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -453,6 +454,9 @@ func (r *testRunner) runWorker(
 			l.PrintfCtx(ctx, "Worker exiting with canceled ctx. Not destroying cluster.")
 		}
 	}()
+
+	prng, _ := randutil.NewPseudoRand()
+
 	// Loop until there's no more work in the pool, we get interrupted, or an
 	// error occurs.
 	for {
@@ -599,13 +603,17 @@ func (r *testRunner) runWorker(
 			c.status("running test")
 			c.setTest(t)
 
-			// Populate encryption at rest from the --encrypt flag.
-			encAtRest := encrypt.asBool()
-			if encrypt.String() == "random" && !t.Spec().(*registry.TestSpec).EncryptAtRandom {
-				// In random mode, enable enc-at-rest only if tests opted into it.
-				encAtRest = false
+			switch t.Spec().(*registry.TestSpec).EncryptionSupport {
+			case registry.EncryptionAlwaysEnabled:
+				c.encAtRest = true
+			case registry.EncryptionAlwaysDisabled:
+				c.encAtRest = false
+			case registry.EncryptionMetamorphic:
+				// when tests opted-in to metamorphic testing, encryption will
+				// be enabled according to the probability passed to
+				// --metamorphic-encryption-probability
+				c.encAtRest = prng.Float64() < encryptionProbability
 			}
-			c.encAtRest = encAtRest
 
 			wStatus.SetCluster(c)
 			wStatus.SetTest(t, testToRun)

--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -21,13 +21,13 @@ import (
 
 func registerAcceptance(r registry.Registry) {
 	testCases := map[registry.Owner][]struct {
-		name            string
-		fn              func(ctx context.Context, t test.Test, c cluster.Cluster)
-		skip            string
-		minVersion      string
-		numNodes        int
-		timeout         time.Duration
-		encryptAtRandom bool
+		name              string
+		fn                func(ctx context.Context, t test.Test, c cluster.Cluster)
+		skip              string
+		minVersion        string
+		numNodes          int
+		timeout           time.Duration
+		encryptionSupport registry.EncryptionSupport
 	}{
 		registry.OwnerKV: {
 			{name: "decommission-self", fn: runDecommissionSelf},
@@ -35,8 +35,9 @@ func registerAcceptance(r registry.Registry) {
 			{name: "gossip/peerings", fn: runGossipPeerings},
 			{name: "gossip/restart", fn: runGossipRestart},
 			{
-				name: "gossip/restart-node-one",
-				fn:   runGossipRestartNodeOne,
+				name:              "gossip/restart-node-one",
+				fn:                runGossipRestartNodeOne,
+				encryptionSupport: registry.EncryptionAlwaysDisabled,
 			},
 			{name: "gossip/locality-address", fn: runCheckLocalityIPAddress},
 			{
@@ -47,8 +48,8 @@ func registerAcceptance(r registry.Registry) {
 			{name: "reset-quorum", fn: runResetQuorum, numNodes: 8},
 			{
 				name: "many-splits", fn: runManySplits,
-				minVersion:      "v19.2.0", // SQL syntax unsupported on 19.1.x
-				encryptAtRandom: true,
+				minVersion:        "v19.2.0", // SQL syntax unsupported on 19.1.x
+				encryptionSupport: registry.EncryptionMetamorphic,
 			},
 			{
 				name: "version-upgrade",
@@ -102,7 +103,7 @@ func registerAcceptance(r registry.Registry) {
 			if tc.timeout != 0 {
 				spec.Timeout = tc.timeout
 			}
-			spec.EncryptAtRandom = tc.encryptAtRandom
+			spec.EncryptionSupport = tc.encryptionSupport
 			spec.Run = func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				tc.fn(ctx, t, c)
 			}

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -127,10 +127,10 @@ func registerBackupNodeShutdown(r registry.Registry) {
 	}
 
 	r.Add(registry.TestSpec{
-		Name:            fmt.Sprintf("backup/nodeShutdown/worker/%s", backupNodeRestartSpec),
-		Owner:           registry.OwnerBulkIO,
-		Cluster:         backupNodeRestartSpec,
-		EncryptAtRandom: true,
+		Name:              fmt.Sprintf("backup/nodeShutdown/worker/%s", backupNodeRestartSpec),
+		Owner:             registry.OwnerBulkIO,
+		Cluster:           backupNodeRestartSpec,
+		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			gatewayNode := 2
 			nodeToShutdown := 3
@@ -148,10 +148,10 @@ func registerBackupNodeShutdown(r registry.Registry) {
 		},
 	})
 	r.Add(registry.TestSpec{
-		Name:            fmt.Sprintf("backup/nodeShutdown/coordinator/%s", backupNodeRestartSpec),
-		Owner:           registry.OwnerBulkIO,
-		Cluster:         backupNodeRestartSpec,
-		EncryptAtRandom: true,
+		Name:              fmt.Sprintf("backup/nodeShutdown/coordinator/%s", backupNodeRestartSpec),
+		Owner:             registry.OwnerBulkIO,
+		Cluster:           backupNodeRestartSpec,
+		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			gatewayNode := 2
 			nodeToShutdown := 2
@@ -428,11 +428,11 @@ func registerBackupMixedVersion(r registry.Registry) {
 	// This test can serve as a template for more targeted testing of features
 	// that require careful consideration of mixed version states.
 	r.Add(registry.TestSpec{
-		Name:            "backup/mixed-version-basic",
-		Owner:           registry.OwnerBulkIO,
-		Cluster:         r.MakeClusterSpec(4),
-		EncryptAtRandom: true,
-		RequiresLicense: true,
+		Name:              "backup/mixed-version-basic",
+		Owner:             registry.OwnerBulkIO,
+		Cluster:           r.MakeClusterSpec(4),
+		EncryptionSupport: registry.EncryptionMetamorphic,
+		RequiresLicense:   true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			// An empty string means that the cockroach binary specified by flag
 			// `cockroach` will be used.
@@ -601,10 +601,10 @@ func registerBackup(r registry.Registry) {
 
 	backup2TBSpec := r.MakeClusterSpec(10)
 	r.Add(registry.TestSpec{
-		Name:            fmt.Sprintf("backup/2TB/%s", backup2TBSpec),
-		Owner:           registry.OwnerBulkIO,
-		Cluster:         backup2TBSpec,
-		EncryptAtRandom: true,
+		Name:              fmt.Sprintf("backup/2TB/%s", backup2TBSpec),
+		Owner:             registry.OwnerBulkIO,
+		Cluster:           backup2TBSpec,
+		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			rows := rows2TiB
 			if c.IsLocal() {
@@ -640,10 +640,10 @@ func registerBackup(r registry.Registry) {
 	})
 
 	r.Add(registry.TestSpec{
-		Name:            "backup/assume-role/AWS",
-		Owner:           registry.OwnerBulkIO,
-		Cluster:         r.MakeClusterSpec(3),
-		EncryptAtRandom: true,
+		Name:              "backup/assume-role/AWS",
+		Owner:             registry.OwnerBulkIO,
+		Cluster:           r.MakeClusterSpec(3),
+		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.Spec().Cloud != spec.AWS {
 				t.Skip("backup assumeRole is only configured to run on "+spec.AWS, "")
@@ -694,10 +694,10 @@ func registerBackup(r registry.Registry) {
 	} {
 		item := item
 		r.Add(registry.TestSpec{
-			Name:            fmt.Sprintf("backup/KMS/%s/%s", item.kmsProvider, KMSSpec.String()),
-			Owner:           registry.OwnerBulkIO,
-			Cluster:         KMSSpec,
-			EncryptAtRandom: true,
+			Name:              fmt.Sprintf("backup/KMS/%s/%s", item.kmsProvider, KMSSpec.String()),
+			Owner:             registry.OwnerBulkIO,
+			Cluster:           KMSSpec,
+			EncryptionSupport: registry.EncryptionMetamorphic,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				if c.Spec().Cloud != item.machine {
 					t.Skip("backupKMS roachtest is only configured to run on "+item.machine, "")
@@ -827,11 +827,11 @@ func registerBackup(r registry.Registry) {
 	// and incremental after more time. It then restores the two backups and
 	// verifies them with a fingerprint.
 	r.Add(registry.TestSpec{
-		Name:            `backupTPCC`,
-		Owner:           registry.OwnerBulkIO,
-		Cluster:         r.MakeClusterSpec(3),
-		Timeout:         1 * time.Hour,
-		EncryptAtRandom: true,
+		Name:              `backupTPCC`,
+		Owner:             registry.OwnerBulkIO,
+		Cluster:           r.MakeClusterSpec(3),
+		Timeout:           1 * time.Hour,
+		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			c.Put(ctx, t.Cockroach(), "./cockroach")
 			c.Put(ctx, t.DeprecatedWorkload(), "./workload")

--- a/pkg/cmd/roachtest/tests/clearrange.go
+++ b/pkg/cmd/roachtest/tests/clearrange.go
@@ -49,9 +49,9 @@ func registerClearRange(r registry.Registry) {
 			Owner: registry.OwnerStorage,
 			// 5h for import, 120 for the test. The import should take closer
 			// to <3:30h but it varies.
-			Timeout:         5*time.Hour + 120*time.Minute,
-			Cluster:         r.MakeClusterSpec(10, spec.CPU(16), spec.SetFileSystem(spec.Zfs)),
-			EncryptAtRandom: true,
+			Timeout:           5*time.Hour + 120*time.Minute,
+			Cluster:           r.MakeClusterSpec(10, spec.CPU(16), spec.SetFileSystem(spec.Zfs)),
+			EncryptionSupport: registry.EncryptionMetamorphic,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runClearRange(ctx, t, c, checks)
 			},

--- a/pkg/cmd/roachtest/tests/encryption.go
+++ b/pkg/cmd/roachtest/tests/encryption.go
@@ -29,9 +29,7 @@ func registerEncryption(r registry.Registry) {
 	runEncryption := func(ctx context.Context, t test.Test, c cluster.Cluster) {
 		nodes := c.Spec().NodeCount
 		c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
-		startOpts := option.DefaultStartOpts()
-		startOpts.RoachprodOpts.EncryptedStores = true
-		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.Range(1, nodes))
+		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Range(1, nodes))
 
 		// Check that /_status/stores/local endpoint has encryption status.
 		adminAddrs, err := c.InternalAdminUIAddr(ctx, t.L(), c.Range(1, nodes))
@@ -51,7 +49,7 @@ func registerEncryption(r registry.Registry) {
 		}
 
 		// Restart node with encryption turned on to verify old key works.
-		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.Range(1, nodes))
+		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Range(1, nodes))
 
 		testCLIGenKey := func(size int) error {
 			// Generate encryption store key through `./cockroach gen encryption-key -s=size aes-size.key`.
@@ -86,10 +84,10 @@ func registerEncryption(r registry.Registry) {
 
 	for _, n := range []int{1} {
 		r.Add(registry.TestSpec{
-			Name:    fmt.Sprintf("encryption/nodes=%d", n),
-			Skip:    "Blocked on #79265.",
-			Owner:   registry.OwnerStorage,
-			Cluster: r.MakeClusterSpec(n),
+			Name:              fmt.Sprintf("encryption/nodes=%d", n),
+			EncryptionSupport: registry.EncryptionAlwaysEnabled,
+			Owner:             registry.OwnerStorage,
+			Cluster:           r.MakeClusterSpec(n),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runEncryption(ctx, t, c)
 			},

--- a/pkg/cmd/roachtest/tests/gossip.go
+++ b/pkg/cmd/roachtest/tests/gossip.go
@@ -357,9 +357,7 @@ func runGossipRestartNodeOne(ctx context.Context, t test.Test, c cluster.Cluster
 	settings := install.MakeClusterSettings(install.NumRacksOption(c.Spec().NodeCount))
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=5ms")
 
-	startOpts := option.DefaultStartOpts()
-	startOpts.RoachprodOpts.EncryptedStores = false
-	c.Start(ctx, t.L(), startOpts, settings)
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), settings)
 
 	db := c.Conn(ctx, t.L(), 1)
 	defer db.Close()
@@ -468,7 +466,7 @@ SELECT count(replicas)
 	// incoming gossip info in order to determine where range 1 is.
 	settings = install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=5ms")
-	c.Start(ctx, t.L(), startOpts, settings, c.Range(2, c.Spec().NodeCount))
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), settings, c.Range(2, c.Spec().NodeCount))
 
 	// We need to override DB connection creation to use the correct port for
 	// node 1. This is more complicated than it should be and a limitation of the

--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -159,11 +159,11 @@ func registerImportTPCC(r registry.Registry) {
 		testName := fmt.Sprintf("import/tpcc/warehouses=%d/nodes=%d", warehouses, numNodes)
 		timeout := 5 * time.Hour
 		r.Add(registry.TestSpec{
-			Name:            testName,
-			Owner:           registry.OwnerBulkIO,
-			Cluster:         r.MakeClusterSpec(numNodes),
-			Timeout:         timeout,
-			EncryptAtRandom: true,
+			Name:              testName,
+			Owner:             registry.OwnerBulkIO,
+			Cluster:           r.MakeClusterSpec(numNodes),
+			Timeout:           timeout,
+			EncryptionSupport: registry.EncryptionMetamorphic,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runImportTPCC(ctx, t, c, testName, timeout, warehouses)
 			},
@@ -172,11 +172,11 @@ func registerImportTPCC(r registry.Registry) {
 	const geoWarehouses = 4000
 	const geoZones = "europe-west2-b,europe-west4-b,asia-northeast1-b,us-west1-b"
 	r.Add(registry.TestSpec{
-		Name:            fmt.Sprintf("import/tpcc/warehouses=%d/geo", geoWarehouses),
-		Owner:           registry.OwnerBulkIO,
-		Cluster:         r.MakeClusterSpec(8, spec.CPU(16), spec.Geo(), spec.Zones(geoZones)),
-		Timeout:         5 * time.Hour,
-		EncryptAtRandom: true,
+		Name:              fmt.Sprintf("import/tpcc/warehouses=%d/geo", geoWarehouses),
+		Owner:             registry.OwnerBulkIO,
+		Cluster:           r.MakeClusterSpec(8, spec.CPU(16), spec.Geo(), spec.Zones(geoZones)),
+		Timeout:           5 * time.Hour,
+		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runImportTPCC(ctx, t, c, fmt.Sprintf("import/tpcc/warehouses=%d/geo", geoWarehouses),
 				5*time.Hour, geoWarehouses)
@@ -204,11 +204,11 @@ func registerImportTPCH(r registry.Registry) {
 	} {
 		item := item
 		r.Add(registry.TestSpec{
-			Name:            fmt.Sprintf(`import/tpch/nodes=%d`, item.nodes),
-			Owner:           registry.OwnerBulkIO,
-			Cluster:         r.MakeClusterSpec(item.nodes),
-			Timeout:         item.timeout,
-			EncryptAtRandom: true,
+			Name:              fmt.Sprintf(`import/tpch/nodes=%d`, item.nodes),
+			Owner:             registry.OwnerBulkIO,
+			Cluster:           r.MakeClusterSpec(item.nodes),
+			Timeout:           item.timeout,
+			EncryptionSupport: registry.EncryptionMetamorphic,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				tick, perfBuf := initBulkJobPerfArtifacts(t.Name(), item.timeout)
 

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -81,7 +81,6 @@ func registerKV(r registry.Registry) {
 		c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))
 		startOpts := option.DefaultStartOpts()
-		startOpts.RoachprodOpts.EncryptedStores = opts.encryption
 		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.Range(1, nodes))
 
 		db := c.Conn(ctx, t.L(), 1)
@@ -262,6 +261,10 @@ func registerKV(r registry.Registry) {
 		if opts.owner != "" {
 			owner = opts.owner
 		}
+		encryption := registry.EncryptionAlwaysDisabled
+		if opts.encryption {
+			encryption = registry.EncryptionAlwaysEnabled
+		}
 		r.Add(registry.TestSpec{
 			Name:    strings.Join(nameParts, "/"),
 			Owner:   owner,
@@ -269,7 +272,8 @@ func registerKV(r registry.Registry) {
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runKV(ctx, t, c, opts)
 			},
-			Tags: opts.tags,
+			Tags:              opts.tags,
+			EncryptionSupport: encryption,
 		})
 	}
 }

--- a/pkg/cmd/roachtest/tests/overload_tpcc_olap.go
+++ b/pkg/cmd/roachtest/tests/overload_tpcc_olap.go
@@ -125,12 +125,12 @@ func registerTPCCOverloadSpec(r registry.Registry, s tpccOLAPSpec) {
 	name := fmt.Sprintf("overload/tpcc_olap/nodes=%d/cpu=%d/w=%d/c=%d",
 		s.Nodes, s.CPUs, s.Warehouses, s.Concurrency)
 	r.Add(registry.TestSpec{
-		Name:            name,
-		Owner:           registry.OwnerKV,
-		Cluster:         r.MakeClusterSpec(s.Nodes+1, spec.CPU(s.CPUs)),
-		Run:             s.run,
-		EncryptAtRandom: true,
-		Timeout:         20 * time.Minute,
+		Name:              name,
+		Owner:             registry.OwnerKV,
+		Cluster:           r.MakeClusterSpec(s.Nodes+1, spec.CPU(s.CPUs)),
+		Run:               s.run,
+		EncryptionSupport: registry.EncryptionMetamorphic,
+		Timeout:           20 * time.Minute,
 	})
 }
 

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -388,11 +388,11 @@ func registerRestore(r registry.Registry) {
 		}
 
 		r.Add(registry.TestSpec{
-			Name:            testName,
-			Owner:           registry.OwnerBulkIO,
-			Cluster:         r.MakeClusterSpec(item.nodes, clusterOpts...),
-			Timeout:         item.timeout,
-			EncryptAtRandom: true,
+			Name:              testName,
+			Owner:             registry.OwnerBulkIO,
+			Cluster:           r.MakeClusterSpec(item.nodes, clusterOpts...),
+			Timeout:           item.timeout,
+			EncryptionSupport: registry.EncryptionMetamorphic,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				c.Put(ctx, t.Cockroach(), "./cockroach")
 				c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -321,11 +321,11 @@ func registerTPCC(r registry.Registry) {
 		// w=headroom runs tpcc for a semi-extended period with some amount of
 		// headroom, more closely mirroring a real production deployment than
 		// running with the max supported warehouses.
-		Name:            "tpcc/headroom/" + headroomSpec.String(),
-		Owner:           registry.OwnerKV,
-		Tags:            []string{`default`, `release_qualification`},
-		Cluster:         headroomSpec,
-		EncryptAtRandom: true,
+		Name:              "tpcc/headroom/" + headroomSpec.String(),
+		Owner:             registry.OwnerKV,
+		Tags:              []string{`default`, `release_qualification`},
+		Cluster:           headroomSpec,
+		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			maxWarehouses := maxSupportedTPCCWarehouses(*t.BuildVersion(), cloud, t.Spec().(*registry.TestSpec).Cluster)
 			headroomWarehouses := int(float64(maxWarehouses) * 0.7)
@@ -349,9 +349,9 @@ func registerTPCC(r registry.Registry) {
 		Owner: registry.OwnerKV,
 		// TODO(tbg): add release_qualification tag once we know the test isn't
 		// buggy.
-		Tags:            []string{`default`},
-		Cluster:         mixedHeadroomSpec,
-		EncryptAtRandom: true,
+		Tags:              []string{`default`},
+		Cluster:           mixedHeadroomSpec,
+		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			crdbNodes := c.Range(1, 4)
 			workloadNode := c.Node(5)
@@ -428,10 +428,10 @@ func registerTPCC(r registry.Registry) {
 		},
 	})
 	r.Add(registry.TestSpec{
-		Name:            "tpcc-nowait/nodes=3/w=1",
-		Owner:           registry.OwnerKV,
-		Cluster:         r.MakeClusterSpec(4, spec.CPU(16)),
-		EncryptAtRandom: true,
+		Name:              "tpcc-nowait/nodes=3/w=1",
+		Owner:             registry.OwnerKV,
+		Cluster:           r.MakeClusterSpec(4, spec.CPU(16)),
+		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses:   1,
@@ -448,8 +448,8 @@ func registerTPCC(r registry.Registry) {
 		Cluster: r.MakeClusterSpec(4, spec.CPU(16)),
 		// Give the test a generous extra 10 hours to load the dataset and
 		// slowly ramp up the load.
-		Timeout:         4*24*time.Hour + 10*time.Hour,
-		EncryptAtRandom: true,
+		Timeout:           4*24*time.Hour + 10*time.Hour,
+		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			warehouses := 1000
 			runTPCC(ctx, t, c, tpccOptions{
@@ -566,8 +566,8 @@ func registerTPCC(r registry.Registry) {
 				Name:  tc.name,
 				Owner: registry.OwnerMultiRegion,
 				// Add an extra node which serves as the workload nodes.
-				Cluster:         r.MakeClusterSpec(len(regions)*nodesPerRegion+1, spec.Geo(), spec.Zones(strings.Join(zs, ","))),
-				EncryptAtRandom: true,
+				Cluster:           r.MakeClusterSpec(len(regions)*nodesPerRegion+1, spec.Geo(), spec.Zones(strings.Join(zs, ","))),
+				EncryptionSupport: registry.EncryptionMetamorphic,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					t.Status(tc.desc)
 					duration := 90 * time.Minute
@@ -648,10 +648,10 @@ func registerTPCC(r registry.Registry) {
 	}
 
 	r.Add(registry.TestSpec{
-		Name:            "tpcc/w=100/nodes=3/chaos=true",
-		Owner:           registry.OwnerKV,
-		Cluster:         r.MakeClusterSpec(4),
-		EncryptAtRandom: true,
+		Name:              "tpcc/w=100/nodes=3/chaos=true",
+		Owner:             registry.OwnerKV,
+		Cluster:           r.MakeClusterSpec(4),
+		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			duration := 30 * time.Minute
 			runTPCC(ctx, t, c, tpccOptions{
@@ -676,11 +676,11 @@ func registerTPCC(r registry.Registry) {
 		},
 	})
 	r.Add(registry.TestSpec{
-		Name:            "tpcc/interleaved/nodes=3/cpu=16/w=500",
-		Owner:           registry.OwnerSQLQueries,
-		Cluster:         r.MakeClusterSpec(4, spec.CPU(16)),
-		Timeout:         6 * time.Hour,
-		EncryptAtRandom: true,
+		Name:              "tpcc/interleaved/nodes=3/cpu=16/w=500",
+		Owner:             registry.OwnerSQLQueries,
+		Cluster:           r.MakeClusterSpec(4, spec.CPU(16)),
+		Timeout:           6 * time.Hour,
+		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			skip.WithIssue(t, 53886)
 			runTPCC(ctx, t, c, tpccOptions{
@@ -926,7 +926,7 @@ func registerTPCCBenchSpec(r registry.Registry, b tpccBenchSpec) {
 		Tags:    b.Tags,
 		// NB: intentionally not enabling encryption-at-rest to produce
 		// consistent results.
-		EncryptAtRandom: false,
+		EncryptionSupport: registry.EncryptionAlwaysDisabled,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCCBench(ctx, t, c, b)
 		},


### PR DESCRIPTION
This commit introduces the `EncryptionSupport` field to `TestSpec`. By
setting this field, tests can declare whether they support being run
in a cluster with encryption enabled. Three options are available:

- EncryptionAllowed: test can run with or without encryption.
- EncryptionRequired: test can only run if encryption is enabled.
- EncryptionDisabled: test can only run if encryption is disabled (default).

This replaces the `EncryptAtRandom` field added earlier, which only
allowed tests to opt-in to random encryption.

In addition to this change, the values accepted by the `--encrypt`
flag in roachtest also changes. The only two valid values are:

- `--encrypt=auto` (default). Tests that support encryption
(EncryptionAllowed) will run with encryption enabled.
- `--encrypt=random` (CI). Tests that support encryption
(EncryptionAllowed) will run on a cluster which may or may
not have encryption enabled.

The `EncryptionSupport` field should be the only way tests indicate
their relationship with encryption. The `DontEncrypt` field was
removed (it was not being used anymore at the time of this commit),
and all tests that set `EncryptedStores` directly were updated to use
`EncryptionSupport` accordingly.

Resolves: #79265.

Release note: None

****

This commit should be sufficient for us to re-enable @nicktrav's tests that originated this issue (#79265). Should I do it in this commit/PR or is that generally done separately once the fix is merged?