### PR TITLE
release-22.1: colexecdisk: make sure to release resources in all cases

### DIFF
--- a/pkg/sql/colexec/disk_spiller.go
+++ b/pkg/sql/colexec/disk_spiller.go
@@ -239,8 +239,17 @@ func (d *diskSpillerBase) Close(ctx context.Context) error {
 		return nil
 	}
 	var retErr error
+	for _, input := range d.inputs {
+		if c, ok := input.(colexecop.Closer); ok {
+			if err := c.Close(ctx); err != nil {
+				retErr = err
+			}
+		}
+	}
 	if c, ok := d.inMemoryOp.(colexecop.Closer); ok {
-		retErr = c.Close(ctx)
+		if err := c.Close(ctx); err != nil {
+			retErr = err
+		}
 	}
 	if c, ok := d.diskBackedOp.(colexecop.Closer); ok {
 		if err := c.Close(ctx); err != nil {

--- a/pkg/sql/colexec/external_distinct_test.go
+++ b/pkg/sql/colexec/external_distinct_test.go
@@ -91,14 +91,8 @@ func TestExternalDistinct(t *testing.T) {
 				require.Equal(t, numExpectedClosers, len(closers))
 				return distinct, err
 			})
-			if tc.errorOnDup == "" || tc.noError {
-				// We don't check that all FDs were released if an error is
-				// expected to be returned because our utility closeIfCloser()
-				// doesn't handle multiple closers (which is always the case for
-				// the external distinct).
-				for i, sem := range semsToCheck {
-					require.Equal(t, 0, sem.GetCount(), "sem still reports open FDs at index %d", i)
-				}
+			for i, sem := range semsToCheck {
+				require.Equal(t, 0, sem.GetCount(), "sem still reports open FDs at index %d", i)
 			}
 		}
 	}

--- a/pkg/sql/colexec/parallel_unordered_synchronizer.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer.go
@@ -477,9 +477,10 @@ func (s *ParallelUnorderedSynchronizer) Close(ctx context.Context) error {
 	// Note that at this point we know that the input goroutines won't be
 	// spawned up (our consumer won't call Next/DrainMeta after calling Close),
 	// so it is safe to close all closers from this goroutine.
-	for _, span := range s.tracingSpans {
+	for i, span := range s.tracingSpans {
 		if span != nil {
 			span.Finish()
+			s.tracingSpans[i] = nil
 		}
 	}
 	var lastErr error

--- a/pkg/sql/colexec/serial_unordered_synchronizer.go
+++ b/pkg/sql/colexec/serial_unordered_synchronizer.go
@@ -120,6 +120,7 @@ func (s *SerialUnorderedSynchronizer) Close(context.Context) error {
 	}
 	if s.span != nil {
 		s.span.Finish()
+		s.span = nil
 	}
 	return lastErr
 }

--- a/pkg/sql/colexecop/operator.go
+++ b/pkg/sql/colexecop/operator.go
@@ -143,7 +143,9 @@ type BufferingInMemoryOperator interface {
 type Closer interface {
 	// Close releases the resources associated with this Closer. If this Closer
 	// is an Operator, the implementation of Close must be safe to execute even
-	// if Operator.Init wasn't called.
+	// if Operator.Init wasn't called. Multiple calls to Close() are allowed,
+	// and most of the implementations should make all calls except for the
+	// first one no-ops.
 	//
 	// Unless the Closer derives its own context with a separate tracing span,
 	// the argument context rather than the one from Init() must be used


### PR DESCRIPTION
Backport 1/1 commits from #81419.

/cc @cockroachdb/release

---

Previously, it was possible to not release some resources when external
distinct or external hash aggregator short circuit their execution
(either because of an error or because of the LIMIT on the query) in
some cases (namely, when a sort is planned on top of the external
operation to restore the desired ordering). This was the case because
the hash-based partitioner (which abstracts away the disk-backed
algorithm) wasn't added to `OpWithMetaInfo.ToClose` slice since there is
a sort on top of it nor was it closed by that sort.

Here is an example diagram for all the infra that is set up for the
disk-backed distinct when ordering needs to be maintained:
```
         diskSpillerBase (disk-backed distinct)
           |                      |
UnorderedDistinct     diskSpillerBase [1] (disk-backed sort)
                      |              |                  |
                in-mem sorter   external sorter   hash-based partitioner [2]
```
In this diagram, `hash-based partitioner [2]` is the external distinct
that is the input to the `diskSpillerBase [1]`. In the happy path (when
`[2]` is exhausted), it is `Close`d automatically. However, if its
execution is short-circuited, `[2]` will never be closed because:
- due to the way the infra was created, it was never added to the
`ToClose` slice (so it will not be closed on the flow cleanup)
- `diskSpillerBase [1]` doesn't close its inputs
- `external sorter` nor the in-memory sorter end up closing `[2]` either
because there are other utility operators that don't implement
`Closer` interface between the sorters and `[2]`.

As a result of not closing `[2]`, some disk resources might be leaked.
This commit fixes the issue by making `diskSpillerBase` close all of its
inputs (which is a single input in the case of the disk-backed distinct
and disk-backed hash aggregator). `Close` is allowed to be called
multiple time, so it is ok if there happen to be other codepaths
calling it.

Fixes: #81413.

Release note: None

Release justification: low risk bug fix.