### PR TITLE
storage: make key/value printing explicitly redactable

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -2488,7 +2488,9 @@ var _ = (SequencedWriteBySeq{}).Find
 
 func init() {
 	// Inject the format dependency into the enginepb package.
-	enginepb.FormatBytesAsKey = func(k []byte) string { return Key(k).String() }
+	enginepb.FormatBytesAsKey = func(k []byte) redact.RedactableString {
+		return redact.Sprint(Key(k))
+	}
 }
 
 // SafeValue implements the redact.SafeValue interface.

--- a/pkg/storage/enginepb/BUILD.bazel
+++ b/pkg/storage/enginepb/BUILD.bazel
@@ -66,5 +66,6 @@ go_test(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/storage/enginepb/mvcc.go
+++ b/pkg/storage/enginepb/mvcc.go
@@ -341,13 +341,11 @@ func (t TxnMeta) SafeFormat(w redact.SafePrinter, _ rune) {
 }
 
 // FormatBytesAsKey is injected by module roachpb as dependency upon initialization.
-// TODO(sarkesian): Make this explicitly redactable.  See #70288
-var FormatBytesAsKey = func(k []byte) string {
-	return string(k)
+var FormatBytesAsKey = func(k []byte) redact.RedactableString {
+	return redact.Sprint(string(k))
 }
 
 // FormatBytesAsValue is injected by module roachpb as dependency upon initialization.
-// TODO(sarkesian): Make this explicitly redactable.  See #70288
-var FormatBytesAsValue = func(v []byte) string {
-	return string(v)
+var FormatBytesAsValue = func(v []byte) redact.RedactableString {
+	return redact.Sprint(string(v))
 }

--- a/pkg/storage/enginepb/mvcc_test.go
+++ b/pkg/storage/enginepb/mvcc_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/redact"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFormatMVCCMetadata(t *testing.T) {
@@ -104,4 +105,15 @@ func TestTxnSeqIsIgnored(t *testing.T) {
 			assert.False(t, enginepb.TxnSeqIsIgnored(notIgn, tc.list))
 		}
 	}
+}
+
+func TestFormatBytesAsKeyAndValue(t *testing.T) {
+	// Injected by roachpb
+	require.Equal(t, string(enginepb.FormatBytesAsKey([]byte("foo"))), "‹\"foo\"›")
+	require.Equal(t, string(enginepb.FormatBytesAsKey([]byte("foo")).Redact()), "‹×›")
+
+	// Injected by storage
+	encodedIntVal := []byte{0x0, 0x0, 0x0, 0x0, 0x1, 0xf}
+	require.Equal(t, string(enginepb.FormatBytesAsValue(encodedIntVal)), "‹/INT/-8›")
+	require.Equal(t, string(enginepb.FormatBytesAsValue(encodedIntVal).Redact()), "‹×›")
 }

--- a/pkg/storage/mvcc_value.go
+++ b/pkg/storage/mvcc_value.go
@@ -12,7 +12,6 @@ package storage
 
 import (
 	"encoding/binary"
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -279,11 +278,11 @@ func decodeExtendedMVCCValue(buf []byte) (MVCCValue, error) {
 
 func init() {
 	// Inject the format dependency into the enginepb package.
-	enginepb.FormatBytesAsValue = func(v []byte) string {
+	enginepb.FormatBytesAsValue = func(v []byte) redact.RedactableString {
 		val, err := DecodeMVCCValue(v)
 		if err != nil {
-			return fmt.Sprintf("err=%v", err)
+			return redact.Sprintf("err=%v", err)
 		}
-		return val.String()
+		return redact.Sprint(val)
 	}
 }


### PR DESCRIPTION
This commit makes the formatting functions in storage/enginepb
return explicitly redactable strings.

Resolve #70288.

Release note: None