### PR TITLE
release-21.2: parser: disallow 'SET tracing' in some contexts

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1141,6 +1141,7 @@ unreserved_keyword ::=
 	| 'TEXT'
 	| 'TIES'
 	| 'TRACE'
+	| 'TRACING'
 	| 'TRANSACTION'
 	| 'TRANSACTIONS'
 	| 'TRIGGER'

--- a/pkg/sql/alter_role.go
+++ b/pkg/sql/alter_role.go
@@ -382,7 +382,9 @@ func (p *planner) processSetOrResetClause(
 	// default settings are stored per-database.
 	// The "role" setting can't be configured here, since we are already
 	// that role.
-	case "database", "role":
+	// The "tracing" setting is handled specially in the grammar, so we skip it
+	// here since it doesn't make sense to set as a default anyway.
+	case "database", "role", "tracing":
 		return unknown, "", sessionVar{}, nil, newCannotChangeParameterError(varName)
 	}
 	_, sVar, err = getSessionVar(varName, false /* missingOk */)

--- a/pkg/sql/lexbase/predicates.go
+++ b/pkg/sql/lexbase/predicates.go
@@ -59,6 +59,8 @@ func init() {
 		"role",
 		"user",
 		"on",
+		"tenant",
+		"set",
 	} {
 		reservedOrLookaheadKeywords[s] = struct{}{}
 	}

--- a/pkg/sql/logictest/testdata/logic_test/alter_role_set
+++ b/pkg/sql/logictest/testdata/logic_test/alter_role_set
@@ -209,3 +209,7 @@ query OTT colnames
 SELECT database_id, role_name, settings FROM system.database_role_settings ORDER BY 1, 2
 ----
 database_id  role_name  settings
+
+# Regression test for the special "tracing" variable.
+query error parameter \"tracing\" cannot be changed
+ALTER ROLE ALL SET tracing = 'off'

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -620,3 +620,8 @@ SET LC_NUMERIC = 'en_US.UTF-8'
 
 statement error invalid value for parameter "lc_time": "en_US.UTF-8"
 SET LC_TIME = 'en_US.UTF-8'
+
+query T
+SHOW tracing
+----
+off

--- a/pkg/sql/logictest/testdata/logic_test/set_local
+++ b/pkg/sql/logictest/testdata/logic_test/set_local
@@ -508,3 +508,7 @@ query TT
 SELECT * FROM tbl
 ----
 2020-08-25 15:16:17.123456 +0000 UTC  1 day 15:16:17.123456
+
+# Regression test for the special "tracing" variable.
+query error parameter \"tracing\" cannot be changed
+SET LOCAL tracing = 'off'

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -870,7 +870,7 @@ func (u *sqlSymUnion) setVar() *tree.SetVar {
 // to differentiate `RESET var` from `RESET ALL`. ROLE_ALL and USER_ALL are
 // used in ALTER ROLE statements that affect all roles.
 %token NOT_LA NULLS_LA WITH_LA AS_LA GENERATED_ALWAYS GENERATED_BY_DEFAULT RESET_ALL ROLE_ALL
-%token USER_ALL ON_LA
+%token USER_ALL ON_LA SET_TRACING
 
 %union {
   id    int32
@@ -4605,7 +4605,19 @@ set_exprs_internal:
 // %SeeAlso: SHOW SESSION, RESET, DISCARD, SHOW, SET CLUSTER SETTING, SET TRANSACTION, SET LOCAL
 // WEBDOCS/set-vars.html
 set_session_stmt:
-  SET SESSION set_rest_more
+  SET_TRACING TRACING to_or_eq var_list
+	{
+    /* SKIP DOC */
+    // We need to recognize the "set tracing" specially here using syntax lookahead.
+    $$.val = &tree.SetTracing{Values: $4.exprs()}
+	}
+| SET_TRACING SESSION TRACING to_or_eq var_list
+	{
+    /* SKIP DOC */
+    // We need to recognize the "set tracing" specially here using syntax lookahead.
+    $$.val = &tree.SetTracing{Values: $5.exprs()}
+	}
+| SET SESSION set_rest_more
   {
     $$.val = $3.stmt()
   }
@@ -4666,14 +4678,7 @@ set_transaction_stmt:
 generic_set:
   var_name to_or_eq var_list
   {
-    // We need to recognize the "set tracing" specially here; couldn't make "set
-    // tracing" a different grammar rule because of ambiguity.
-    varName := $1.strs()
-    if len(varName) == 1 && varName[0] == "tracing" {
-      $$.val = &tree.SetTracing{Values: $3.exprs()}
-    } else {
-      $$.val = &tree.SetVar{Name: strings.Join($1.strs(), "."), Values: $3.exprs()}
-    }
+    $$.val = &tree.SetVar{Name: strings.Join($1.strs(), "."), Values: $3.exprs()}
   }
 
 set_rest:
@@ -4948,7 +4953,7 @@ show_session_stmt:
 
 session_var:
   IDENT
-// Although ALL, SESSION_USER, DATABASE, LC_COLLATE, and LC_CTYPE are
+// Although ALL, SESSION_USER, DATABASE, LC_COLLATE, LC_CTYPE, and TRACING are
 // identifiers for the purpose of SHOW, they lex as separate token types, so
 // they need separate rules.
 | ALL
@@ -4960,6 +4965,7 @@ session_var:
 | SESSION_USER
 | LC_COLLATE
 | LC_CTYPE
+| TRACING { /* SKIP DOC */ }
 // TIME ZONE is special: it is two tokens, but is really the identifier "TIME ZONE".
 | TIME ZONE { $$ = "timezone" }
 | TIME error // SHOW HELP: SHOW SESSION
@@ -7403,9 +7409,18 @@ opt_in_database:
     $$ = ""
   }
 
+// This rule is used when SET is used as a clause in another statement,
+// like ALTER ROLE ... SET.
 set_or_reset_clause:
   SET set_rest
   {
+    $$.val = $2.setVar()
+  }
+| SET_TRACING set_rest
+  {
+    /* SKIP DOC */
+    // We need to recognize the "set tracing" specially here since we do a
+    // syntax lookahead and use a different token.
     $$.val = $2.setVar()
   }
 | RESET_ALL ALL
@@ -13423,6 +13438,7 @@ unreserved_keyword:
 | TEXT
 | TIES
 | TRACE
+| TRACING
 | TRANSACTION
 | TRANSACTIONS
 | TRIGGER

--- a/pkg/sql/parser/testdata/alter_user
+++ b/pkg/sql/parser/testdata/alter_user
@@ -321,3 +321,11 @@ ALTER ROLE ALL IN DATABASE d SET application_name = 'app' -- normalized!
 ALTER ROLE ALL IN DATABASE d SET application_name = ('app') -- fully parenthesized
 ALTER ROLE ALL IN DATABASE d SET application_name = '_' -- literals removed
 ALTER ROLE ALL IN DATABASE _ SET application_name = 'app' -- identifiers removed
+
+parse
+ALTER USER foo SET tracing = 'off'
+----
+ALTER USER 'foo' SET tracing = 'off' -- normalized!
+ALTER USER ('foo') SET tracing = ('off') -- fully parenthesized
+ALTER USER '_' SET tracing = '_' -- literals removed
+ALTER USER 'foo' SET tracing = 'off' -- identifiers removed

--- a/pkg/sql/parser/testdata/set
+++ b/pkg/sql/parser/testdata/set
@@ -547,3 +547,11 @@ SET LOCAL intervalstyle = 'postgres' -- normalized!
 SET LOCAL intervalstyle = ('postgres') -- fully parenthesized
 SET LOCAL intervalstyle = '_' -- literals removed
 SET LOCAL intervalstyle = 'postgres' -- identifiers removed
+
+parse
+SET LOCAL tracing = 'off'
+----
+SET LOCAL tracing = 'off'
+SET LOCAL tracing = ('off') -- fully parenthesized
+SET LOCAL tracing = '_' -- literals removed
+SET LOCAL tracing = 'off' -- identifiers removed


### PR DESCRIPTION
Backport 1/1 commits from #81420.

/cc @cockroachdb/release

---

fixes https://github.com/cockroachdb/cockroach/issues/81410

Release note (bug fix): Fixed a panic that was caused by setting the
"tracing" session variable using SET LOCAL or ALTER ROLE ... SET.

Release justification: fixes a panic