### PR TITLE
sql, server: surface full scan and last retry reason properties for active queries

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -2132,6 +2132,7 @@ ActiveQuery represents a query in flight on some Session.
 | progress | [float](#cockroach.server.serverpb.ListSessionsResponse-float) |  | progress is an estimate of the fraction of this query that has been processed. | [reserved](#support-status) |
 | sql_no_constants | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The SQL statement fingerprint, compatible with StatementStatisticsKey. | [reserved](#support-status) |
 | sql_summary | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | A summarized version of the sql query. | [reserved](#support-status) |
+| is_full_scan | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | True if the query contains a full table or index scan. Note that this field is only valid if the query is in the EXECUTING phase. | [reserved](#support-status) |
 
 
 
@@ -2266,6 +2267,7 @@ ActiveQuery represents a query in flight on some Session.
 | progress | [float](#cockroach.server.serverpb.ListSessionsResponse-float) |  | progress is an estimate of the fraction of this query that has been processed. | [reserved](#support-status) |
 | sql_no_constants | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The SQL statement fingerprint, compatible with StatementStatisticsKey. | [reserved](#support-status) |
 | sql_summary | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | A summarized version of the sql query. | [reserved](#support-status) |
+| is_full_scan | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | True if the query contains a full table or index scan. Note that this field is only valid if the query is in the EXECUTING phase. | [reserved](#support-status) |
 
 
 

--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -2159,6 +2159,7 @@ TxnInfo represents an in flight user transaction on some Session.
 | is_historical | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  |  | [reserved](#support-status) |
 | priority | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  |  | [reserved](#support-status) |
 | quality_of_service | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  |  | [reserved](#support-status) |
+| last_auto_retry_reason | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Error message describing the cause for the txn's last automatic retry. | [reserved](#support-status) |
 
 
 
@@ -2294,6 +2295,7 @@ TxnInfo represents an in flight user transaction on some Session.
 | is_historical | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  |  | [reserved](#support-status) |
 | priority | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  |  | [reserved](#support-status) |
 | quality_of_service | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  |  | [reserved](#support-status) |
+| last_auto_retry_reason | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Error message describing the cause for the txn's last automatic retry. | [reserved](#support-status) |
 
 
 

--- a/docs/generated/swagger/spec.json
+++ b/docs/generated/swagger/spec.json
@@ -1526,6 +1526,11 @@
           "type": "boolean",
           "x-go-name": "IsHistorical"
         },
+        "last_auto_retry_reason": {
+          "description": "Error message describing the cause for the txn's last automatic retry.",
+          "type": "string",
+          "x-go-name": "LastAutoRetryReason"
+        },
         "max_alloc_bytes": {
           "description": "High water mark of allocated bytes in the txn memory monitor.",
           "type": "integer",

--- a/docs/generated/swagger/spec.json
+++ b/docs/generated/swagger/spec.json
@@ -628,6 +628,11 @@
           "type": "boolean",
           "x-go-name": "IsDistributed"
         },
+        "is_full_scan": {
+          "description": "True if the query contains a full table or index scan. Note that this\nfield is only valid if the query is in the EXECUTING phase.",
+          "type": "boolean",
+          "x-go-name": "IsFullScan"
+        },
         "phase": {
           "$ref": "#/definitions/ActiveQuery_Phase"
         },

--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -235,15 +235,15 @@ SELECT * FROM crdb_internal.cluster_queries WHERE node_id < 0
 ----
 query_id  txn_id  node_id  session_id user_name  start  query  client_address  application_name  distributed  phase  full_scan
 
-query TITTTTIII colnames
+query TITTTTIIIT colnames
 SELECT  * FROM crdb_internal.node_transactions WHERE node_id < 0
 ----
-id  node_id  session_id  start  txn_string  application_name  num_stmts  num_retries  num_auto_retries
+id  node_id  session_id  start  txn_string  application_name  num_stmts  num_retries  num_auto_retries  last_auto_retry_reason
 
-query TITTTTIII colnames
+query TITTTTIIIT colnames
 SELECT  * FROM crdb_internal.cluster_transactions WHERE node_id < 0
 ----
-id  node_id  session_id  start  txn_string  application_name  num_stmts  num_retries  num_auto_retries
+id  node_id  session_id  start  txn_string  application_name  num_stmts  num_retries  num_auto_retries  last_auto_retry_reason
 
 query ITTTTTTTTTTTTT colnames
 SELECT * FROM crdb_internal.node_sessions WHERE node_id < 0

--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -225,15 +225,15 @@ SELECT * FROM crdb_internal.session_variables WHERE variable = ''
 ----
 variable  value  hidden
 
-query TTITTTTTTBT colnames
+query TTITTTTTTBTB colnames
 SELECT * FROM crdb_internal.node_queries WHERE node_id < 0
 ----
-query_id  txn_id  node_id  session_id user_name  start  query  client_address  application_name  distributed  phase
+query_id  txn_id  node_id  session_id user_name  start  query  client_address  application_name  distributed  phase  full_scan
 
-query TTITTTTTTBT colnames
+query TTITTTTTTBTB colnames
 SELECT * FROM crdb_internal.cluster_queries WHERE node_id < 0
 ----
-query_id  txn_id  node_id  session_id user_name  start  query  client_address  application_name  distributed  phase
+query_id  txn_id  node_id  session_id user_name  start  query  client_address  application_name  distributed  phase  full_scan
 
 query TITTTTIII colnames
 SELECT  * FROM crdb_internal.node_transactions WHERE node_id < 0

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -896,6 +896,11 @@ message ActiveQuery {
 
   // A summarized version of the sql query.
   string sql_summary = 9;
+
+  // True if the query contains a full table or index scan. Note that this
+  // field is only valid if the query is in the EXECUTING phase.
+  bool is_full_scan = 10;
+
 }
 
 // Request object for ListSessions and ListLocalSessions.
@@ -955,6 +960,7 @@ message Session {
   // Timestamp of session's end.
   google.protobuf.Timestamp end = 15
       [ (gogoproto.nullable) = true, (gogoproto.stdtime) = true ];
+
 }
 
 // An error wrapper object for ListSessionsResponse.

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -858,6 +858,9 @@ message TxnInfo {
   string priority = 13;
 
   string quality_of_service = 14;
+
+  // Error message describing the cause for the txn's last automatic retry.
+  string last_auto_retry_reason = 15;
 }
 
 // ActiveQuery represents a query in flight on some Session.
@@ -960,7 +963,6 @@ message Session {
   // Timestamp of session's end.
   google.protobuf.Timestamp end = 15
       [ (gogoproto.nullable) = true, (gogoproto.stdtime) = true ];
-
 }
 
 // An error wrapper object for ListSessionsResponse.

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3052,6 +3052,7 @@ func (ex *connExecutor) serialize() serverpb.Session {
 
 	var activeTxnInfo *serverpb.TxnInfo
 	txn := ex.state.mu.txn
+
 	if txn != nil {
 		id := txn.ID()
 		activeTxnInfo = &serverpb.TxnInfo{
@@ -3108,6 +3109,7 @@ func (ex *connExecutor) serialize() serverpb.Session {
 			IsDistributed:  query.isDistributed,
 			Phase:          (serverpb.ActiveQuery_Phase)(query.phase),
 			Progress:       float32(progress),
+			IsFullScan:     query.isFullScan,
 		})
 	}
 	lastActiveQuery := ""

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3053,6 +3053,12 @@ func (ex *connExecutor) serialize() serverpb.Session {
 	var activeTxnInfo *serverpb.TxnInfo
 	txn := ex.state.mu.txn
 
+	var autoRetryReasonStr string
+
+	if ex.extraTxnState.autoRetryReason != nil {
+		autoRetryReasonStr = ex.extraTxnState.autoRetryReason.Error()
+	}
+
 	if txn != nil {
 		id := txn.ID()
 		activeTxnInfo = &serverpb.TxnInfo{
@@ -3069,6 +3075,7 @@ func (ex *connExecutor) serialize() serverpb.Session {
 			ReadOnly:              ex.state.readOnly,
 			Priority:              ex.state.priority.String(),
 			QualityOfService:      sessiondatapb.ToQoSLevelString(txn.AdmissionHeader().Priority),
+			LastAutoRetryReason:   autoRetryReasonStr,
 		}
 	}
 

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1110,6 +1110,8 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	// TODO(yuzefovich): introduce ternary PlanDistribution into queryMeta.
 	queryMeta.isDistributed = distributePlan.WillDistribute()
 	progAtomic := &queryMeta.progressAtomic
+	flags := planner.curPlan.flags
+	queryMeta.isFullScan = flags.IsSet(planFlagContainsFullIndexScan) || flags.IsSet(planFlagContainsFullTableScan)
 	ex.mu.Unlock()
 
 	// We need to set the "exec done" flag early because
@@ -2018,6 +2020,7 @@ func (ex *connExecutor) addActiveQuery(
 		rawStmt:       rawStmt,
 		phase:         preparing,
 		isDistributed: false,
+		isFullScan:    false,
 		ctxCancel:     cancelFun,
 		hidden:        hidden,
 	}

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1615,15 +1615,16 @@ CREATE TABLE crdb_internal.session_variables (
 
 const txnsSchemaPattern = `
 CREATE TABLE crdb_internal.%s (
-  id UUID,                 -- the unique ID of the transaction
-  node_id INT,             -- the ID of the node running the transaction
-  session_id STRING,       -- the ID of the session
-  start TIMESTAMP,         -- the start time of the transaction
-  txn_string STRING,       -- the string representation of the transcation
-  application_name STRING, -- the name of the application as per SET application_name
-  num_stmts INT,           -- the number of statements executed so far
-  num_retries INT,         -- the number of times the transaction was restarted
-  num_auto_retries INT     -- the number of times the transaction was automatically restarted
+  id UUID,                         -- the unique ID of the transaction
+  node_id INT,                     -- the ID of the node running the transaction
+  session_id STRING,               -- the ID of the session
+  start TIMESTAMP,                 -- the start time of the transaction
+  txn_string STRING,               -- the string representation of the transcation
+  application_name STRING,         -- the name of the application as per SET application_name
+  num_stmts INT,                   -- the number of statements executed so far
+  num_retries INT,                 -- the number of times the transaction was restarted
+  num_auto_retries INT,            -- the number of times the transaction was automatically restarted
+  last_auto_retry_reason STRING    -- the error causing the last automatic retry for this txn
 )`
 
 var crdbInternalLocalTxnsTable = virtualSchemaTable{
@@ -1684,6 +1685,7 @@ func populateTransactionsTable(
 				tree.NewDInt(tree.DInt(txn.NumStatementsExecuted)),
 				tree.NewDInt(tree.DInt(txn.NumRetries)),
 				tree.NewDInt(tree.DInt(txn.NumAutoRetries)),
+				tree.NewDString(txn.LastAutoRetryReason),
 			); err != nil {
 				return err
 			}
@@ -1704,6 +1706,7 @@ func populateTransactionsTable(
 				tree.DNull,                             // NumStatementsExecuted
 				tree.DNull,                             // NumRetries
 				tree.DNull,                             // NumAutoRetries
+				tree.DNull,                             // LastAutoRetryReason
 			); err != nil {
 				return err
 			}

--- a/pkg/sql/delegate/show_queries.go
+++ b/pkg/sql/delegate/show_queries.go
@@ -18,7 +18,20 @@ import (
 
 func (d *delegator) delegateShowQueries(n *tree.ShowQueries) (tree.Statement, error) {
 	sqltelemetry.IncrementShowCounter(sqltelemetry.Queries)
-	const query = `SELECT query_id, node_id, session_id, user_name, start, query, client_address, application_name, distributed, phase FROM crdb_internal.`
+	const query = `
+SELECT
+  query_id,
+  node_id,
+  session_id,
+  user_name,
+  start,
+  query,
+  client_address,
+  application_name,
+  distributed,
+  full_scan,
+  phase
+FROM crdb_internal.`
 	table := `node_queries`
 	if n.Cluster {
 		table = `cluster_queries`

--- a/pkg/sql/delegate/show_transactions.go
+++ b/pkg/sql/delegate/show_transactions.go
@@ -16,7 +16,16 @@ import (
 )
 
 func (d *delegator) delegateShowTransactions(n *tree.ShowTransactions) (tree.Statement, error) {
-	const query = `SELECT node_id, id AS txn_id, application_name, num_stmts, num_retries, num_auto_retries FROM `
+	const query = `
+SELECT
+  node_id,
+  id AS txn_id,
+  application_name,
+  num_stmts,
+  num_retries,
+  num_auto_retries, 
+  last_auto_retry_reason
+FROM `
 	table := `"".crdb_internal.node_transactions`
 	if n.Cluster {
 		table = `"".crdb_internal.cluster_transactions`

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1894,6 +1894,12 @@ type queryMeta struct {
 	// to determine whether this query has entered execution yet.
 	isDistributed bool
 
+	// States whether this query is a full scan. As with isDistributed, this field
+	// will be set to false for all queries until the start of execution, at which
+	// point we can determine whether a full scan will occur. Use the phase variable
+	// to determine whether this query has entered execution.
+	isFullScan bool
+
 	// Current phase of execution of query.
 	phase queryPhase
 

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -355,15 +355,15 @@ SELECT * FROM crdb_internal.cluster_queries WHERE node_id < 0
 ----
 query_id  txn_id  node_id  session_id user_name  start  query  client_address  application_name  distributed  phase  full_scan
 
-query TITTTTIII colnames
+query TITTTTIIIT colnames
 SELECT  * FROM crdb_internal.node_transactions WHERE node_id < 0
 ----
-id  node_id  session_id  start  txn_string  application_name  num_stmts  num_retries  num_auto_retries
+id  node_id  session_id  start  txn_string  application_name  num_stmts  num_retries  num_auto_retries  last_auto_retry_reason
 
-query TITTTTIII colnames
+query TITTTTIIIT colnames
 SELECT  * FROM crdb_internal.cluster_transactions WHERE node_id < 0
 ----
-id  node_id  session_id  start  txn_string  application_name  num_stmts  num_retries  num_auto_retries
+id  node_id  session_id  start  txn_string  application_name  num_stmts  num_retries  num_auto_retries  last_auto_retry_reason
 
 query ITTTTTTTTTTTTT colnames
 SELECT * FROM crdb_internal.node_sessions WHERE node_id < 0

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -345,15 +345,15 @@ SELECT * FROM crdb_internal.session_variables WHERE variable = ''
 ----
 variable  value  hidden
 
-query TTITTTTTTBT colnames
+query TTITTTTTTBTB colnames
 SELECT * FROM crdb_internal.node_queries WHERE node_id < 0
 ----
-query_id  txn_id  node_id  session_id user_name  start  query  client_address  application_name  distributed  phase
+query_id  txn_id  node_id  session_id user_name  start  query  client_address  application_name  distributed  phase  full_scan
 
-query TTITTTTTTBT colnames
+query TTITTTTTTBTB colnames
 SELECT * FROM crdb_internal.cluster_queries WHERE node_id < 0
 ----
-query_id  txn_id  node_id  session_id user_name  start  query  client_address  application_name  distributed  phase
+query_id  txn_id  node_id  session_id user_name  start  query  client_address  application_name  distributed  phase  full_scan
 
 query TITTTTIII colnames
 SELECT  * FROM crdb_internal.node_transactions WHERE node_id < 0

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -407,7 +407,8 @@ CREATE TABLE crdb_internal.cluster_transactions (
    application_name STRING NULL,
    num_stmts INT8 NULL,
    num_retries INT8 NULL,
-   num_auto_retries INT8 NULL
+   num_auto_retries INT8 NULL,
+   last_auto_retry_reason STRING NULL
 )  CREATE TABLE crdb_internal.cluster_transactions (
    id UUID NULL,
    node_id INT8 NULL,
@@ -417,7 +418,8 @@ CREATE TABLE crdb_internal.cluster_transactions (
    application_name STRING NULL,
    num_stmts INT8 NULL,
    num_retries INT8 NULL,
-   num_auto_retries INT8 NULL
+   num_auto_retries INT8 NULL,
+   last_auto_retry_reason STRING NULL
 )  {}  {}
 CREATE TABLE crdb_internal.create_schema_statements (
    database_id INT8 NULL,
@@ -1130,7 +1132,8 @@ CREATE TABLE crdb_internal.node_transactions (
    application_name STRING NULL,
    num_stmts INT8 NULL,
    num_retries INT8 NULL,
-   num_auto_retries INT8 NULL
+   num_auto_retries INT8 NULL,
+   last_auto_retry_reason STRING NULL
 )  CREATE TABLE crdb_internal.node_transactions (
    id UUID NULL,
    node_id INT8 NULL,
@@ -1140,7 +1143,8 @@ CREATE TABLE crdb_internal.node_transactions (
    application_name STRING NULL,
    num_stmts INT8 NULL,
    num_retries INT8 NULL,
-   num_auto_retries INT8 NULL
+   num_auto_retries INT8 NULL,
+   last_auto_retry_reason STRING NULL
 )  {}  {}
 CREATE TABLE crdb_internal.node_txn_stats (
    node_id INT8 NOT NULL,

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -302,7 +302,8 @@ CREATE TABLE crdb_internal.cluster_queries (
    client_address STRING NULL,
    application_name STRING NULL,
    distributed BOOL NULL,
-   phase STRING NULL
+   phase STRING NULL,
+   full_scan BOOL NULL
 )  CREATE TABLE crdb_internal.cluster_queries (
    query_id STRING NULL,
    txn_id UUID NULL,
@@ -314,7 +315,8 @@ CREATE TABLE crdb_internal.cluster_queries (
    client_address STRING NULL,
    application_name STRING NULL,
    distributed BOOL NULL,
-   phase STRING NULL
+   phase STRING NULL,
+   full_scan BOOL NULL
 )  {}  {}
 CREATE TABLE crdb_internal.cluster_sessions (
    node_id INT8 NOT NULL,
@@ -925,7 +927,8 @@ CREATE TABLE crdb_internal.node_queries (
    client_address STRING NULL,
    application_name STRING NULL,
    distributed BOOL NULL,
-   phase STRING NULL
+   phase STRING NULL,
+   full_scan BOOL NULL
 )  CREATE TABLE crdb_internal.node_queries (
    query_id STRING NULL,
    txn_id UUID NULL,
@@ -937,7 +940,8 @@ CREATE TABLE crdb_internal.node_queries (
    client_address STRING NULL,
    application_name STRING NULL,
    distributed BOOL NULL,
-   phase STRING NULL
+   phase STRING NULL,
+   full_scan BOOL NULL
 )  {}  {}
 CREATE TABLE crdb_internal.node_runtime_info (
    node_id INT8 NOT NULL,


### PR DESCRIPTION
### Commit 1: sql, server: add IsFullScan to active query meta
Part of https://github.com/cockroachdb/cockroach/issues/79124

This commit adds additional ways to observe whether or not a
running query contains a full table or index scan.

The property isFullScan is now tracked in the queryMeta struct
for active queries. The field is included in the ListSessions
api response for the active query in a session under the field
`IsFullScan`. The column `full_scan` is also added to the
{cluster,node}_queries virtual tables and is also added to
the `SHOW QUERIES` command.

Release note (sql change, api change): Information has been
added describing whether a query contains a full table or
index scan. Note that this information is only valid when
the query is in the `executing` phase.

The `ListSessions` api includes this info under the field
`is_full_scan` in the active query for a session.

The `crdb_internal.{cluster,node}_queries` has a new column
`full_scan`. This column is included in the `SHOW QUERIES`
command.

### Commit 2: server: add LastAutoRetryReason to ListSessions response
Closes https://github.com/cockroachdb/cockroach/issues/79124

This commit adds additional ways to observe the reason for an
automatic retry for a currently running transaction. The field
`LastAutoRetryReason` is added to the `ListSessions` response
under the field `LastAutoRetryReason` which is accessible through
the session's `ActiveTxn` field. This field is a string describing
the error causing an automatic retry  for the current transaction.
The same information is also added to the `{cluster,node}_transactions`
virtual tables and the `SHOW TRANSACTIONS` command under the column
`last_auto_retry_reason`.

Release note (api change, sql change): The ListSessions api has a new
field `last_auto_retry_reason` under the `active_txn` field for a
session. This field contains the string describing the retry
reason or nil if none exists.

This is also surfaced in the `crdb_internal.{cluster,node}_transactions`
tables and the `SHOW TRANSACTIONS` command under the `last_auto_retry_reason`
column.