### PR TITLE
colmem: improve the behavior of ResetMaybeReallocate

### DIFF
--- a/pkg/sql/colexec/colexecjoin/crossjoiner.go
+++ b/pkg/sql/colexec/colexecjoin/crossjoiner.go
@@ -107,6 +107,7 @@ func (c *crossJoiner) Next() coldata.Batch {
 	}
 	c.output, _ = c.unlimitedAllocator.ResetMaybeReallocate(
 		c.outputTypes, c.output, willEmit, c.maxOutputBatchMemSize,
+		true, /* desiredCapacitySufficient */
 	)
 	if willEmit > c.output.Capacity() {
 		willEmit = c.output.Capacity()

--- a/pkg/sql/colexec/colexecjoin/hashjoiner.go
+++ b/pkg/sql/colexec/colexecjoin/hashjoiner.go
@@ -725,6 +725,7 @@ func (hj *hashJoiner) resetOutput(nResults int) {
 	const maxOutputBatchMemSize = math.MaxInt64
 	hj.output, _ = hj.outputUnlimitedAllocator.ResetMaybeReallocate(
 		hj.outputTypes, hj.output, nResults, maxOutputBatchMemSize,
+		true, /* desiredCapacitySufficient */
 	)
 }
 

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
@@ -14219,6 +14219,7 @@ func (o *mergeJoinExceptAllOp) buildFromBufferedGroup() (bufferedGroupComplete b
 func (o *mergeJoinExceptAllOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
@@ -15366,6 +15366,7 @@ func (o *mergeJoinFullOuterOp) buildFromBufferedGroup() (bufferedGroupComplete b
 func (o *mergeJoinFullOuterOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
@@ -10900,6 +10900,7 @@ func (o *mergeJoinInnerOp) buildFromBufferedGroup() (bufferedGroupComplete bool)
 func (o *mergeJoinInnerOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
@@ -11610,6 +11610,7 @@ func (o *mergeJoinIntersectAllOp) buildFromBufferedGroup() (bufferedGroupComplet
 func (o *mergeJoinIntersectAllOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
@@ -13129,6 +13129,7 @@ func (o *mergeJoinLeftAntiOp) buildFromBufferedGroup() (bufferedGroupComplete bo
 func (o *mergeJoinLeftAntiOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
@@ -13156,6 +13156,7 @@ func (o *mergeJoinLeftOuterOp) buildFromBufferedGroup() (bufferedGroupComplete b
 func (o *mergeJoinLeftOuterOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
@@ -10853,6 +10853,7 @@ func (o *mergeJoinLeftSemiOp) buildFromBufferedGroup() (bufferedGroupComplete bo
 func (o *mergeJoinLeftSemiOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
@@ -13060,6 +13060,7 @@ func (o *mergeJoinRightAntiOp) buildFromBufferedGroup() (bufferedGroupComplete b
 func (o *mergeJoinRightAntiOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
@@ -13110,6 +13110,7 @@ func (o *mergeJoinRightOuterOp) buildFromBufferedGroup() (bufferedGroupComplete 
 func (o *mergeJoinRightOuterOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
@@ -10813,6 +10813,7 @@ func (o *mergeJoinRightSemiOp) buildFromBufferedGroup() (bufferedGroupComplete b
 func (o *mergeJoinRightSemiOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
@@ -1355,6 +1355,7 @@ func _SOURCE_FINISHED_SWITCH(_JOIN_TYPE joinTypeInfo) { // */}}
 func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output

--- a/pkg/sql/colexec/colexecutils/deselector.go
+++ b/pkg/sql/colexec/colexecutils/deselector.go
@@ -62,6 +62,7 @@ func (p *deselectorOp) Next() coldata.Batch {
 	const maxBatchMemSize = math.MaxInt64
 	p.output, _ = p.unlimitedAllocator.ResetMaybeReallocate(
 		p.inputTypes, p.output, batch.Length(), maxBatchMemSize,
+		true, /* desiredCapacitySufficient */
 	)
 	sel := batch.Selection()
 	p.unlimitedAllocator.PerformOperation(p.output.ColVecs(), func() {

--- a/pkg/sql/colexec/colexecutils/spilling_queue.go
+++ b/pkg/sql/colexec/colexecutils/spilling_queue.go
@@ -193,6 +193,7 @@ func (q *SpillingQueue) Enqueue(ctx context.Context, batch coldata.Batch) {
 			const maxBatchMemSize = math.MaxInt64
 			q.diskQueueDeselectionScratch, _ = q.unlimitedAllocator.ResetMaybeReallocate(
 				q.typs, q.diskQueueDeselectionScratch, n, maxBatchMemSize,
+				true, /* desiredCapacitySufficient */
 			)
 			q.unlimitedAllocator.PerformOperation(q.diskQueueDeselectionScratch.ColVecs(), func() {
 				for i := range q.typs {
@@ -295,6 +296,7 @@ func (q *SpillingQueue) Enqueue(ctx context.Context, batch coldata.Batch) {
 		// attention to the memory registered with the unlimited allocator, and
 		// we will stop adding tuples into this batch and spill when needed.
 		math.MaxInt64, /* maxBatchMemSize */
+		true,          /* desiredCapacitySufficient */
 	)
 	q.unlimitedAllocator.PerformOperation(newBatch.ColVecs(), func() {
 		for i := range q.typs {

--- a/pkg/sql/colexec/colexecwindow/buffered_window.go
+++ b/pkg/sql/colexec/colexecwindow/buffered_window.go
@@ -251,6 +251,7 @@ func (b *bufferedWindowOp) Next() coldata.Batch {
 			const maxBatchMemSize = math.MaxInt64
 			b.currentBatch, _ = b.allocator.ResetMaybeReallocate(
 				b.outputTypes, b.currentBatch, batch.Length(), maxBatchMemSize,
+				true, /* desiredCapacitySufficient */
 			)
 			b.allocator.PerformOperation(b.currentBatch.ColVecs(), func() {
 				for colIdx, vec := range batch.ColVecs() {

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -198,7 +198,8 @@ func (c *Columnarizer) Next() coldata.Batch {
 	switch c.mode {
 	case columnarizerBufferingMode:
 		c.batch, reallocated = c.allocator.ResetMaybeReallocate(
-			c.typs, c.batch, 1 /* minDesiredCapacity */, c.maxBatchMemSize,
+			c.typs, c.batch, 1, /* minDesiredCapacity */
+			c.maxBatchMemSize, false, /* desiredCapacitySufficient */
 		)
 	case columnarizerStreamingMode:
 		// Note that we're not using ResetMaybeReallocate because we will

--- a/pkg/sql/colexec/hash_aggregator.eg.go
+++ b/pkg/sql/colexec/hash_aggregator.eg.go
@@ -459,6 +459,7 @@ func getNext_true(op *hashAggregator) coldata.Batch {
 			// len(op.buckets) capacity.
 			op.output, _ = op.accountingHelper.ResetMaybeReallocate(
 				op.outputTypes, op.output, len(op.buckets), op.maxOutputBatchMemSize,
+				true, /* desiredCapacitySufficient */
 			)
 			curOutputIdx := 0
 			for curOutputIdx < op.output.Capacity() &&
@@ -606,6 +607,7 @@ func getNext_false(op *hashAggregator) coldata.Batch {
 			// len(op.buckets) capacity.
 			op.output, _ = op.accountingHelper.ResetMaybeReallocate(
 				op.outputTypes, op.output, len(op.buckets), op.maxOutputBatchMemSize,
+				true, /* desiredCapacitySufficient */
 			)
 			curOutputIdx := 0
 			for curOutputIdx < op.output.Capacity() &&

--- a/pkg/sql/colexec/hash_aggregator_tmpl.go
+++ b/pkg/sql/colexec/hash_aggregator_tmpl.go
@@ -345,6 +345,7 @@ func getNext(op *hashAggregator, partialOrder bool) coldata.Batch {
 			// len(op.buckets) capacity.
 			op.output, _ = op.accountingHelper.ResetMaybeReallocate(
 				op.outputTypes, op.output, len(op.buckets), op.maxOutputBatchMemSize,
+				true, /* desiredCapacitySufficient */
 			)
 			curOutputIdx := 0
 			for curOutputIdx < op.output.Capacity() &&

--- a/pkg/sql/colexec/ordered_aggregator.go
+++ b/pkg/sql/colexec/ordered_aggregator.go
@@ -285,14 +285,16 @@ func (a *orderedAggregator) Next() coldata.Batch {
 				a.scratch.Batch = a.allocator.NewMemBatchWithFixedCapacity(a.outputTypes, newMinCapacity)
 			} else {
 				a.scratch.Batch, _ = a.allocator.ResetMaybeReallocate(
-					a.outputTypes, a.scratch.Batch, newMinCapacity, maxBatchMemSize,
+					a.outputTypes, a.scratch.Batch, newMinCapacity,
+					maxBatchMemSize, true, /* desiredCapacitySufficient */
 				)
 			}
 			// We will never copy more than coldata.BatchSize() into the
 			// temporary buffer, so a half of the scratch's capacity will always
 			// be sufficient.
 			a.scratch.tempBuffer, _ = a.allocator.ResetMaybeReallocate(
-				a.outputTypes, a.scratch.tempBuffer, newMinCapacity/2, maxBatchMemSize,
+				a.outputTypes, a.scratch.tempBuffer, newMinCapacity/2,
+				maxBatchMemSize, true, /* desiredCapacitySufficient */
 			)
 			for fnIdx, fn := range a.bucket.fns {
 				fn.SetOutput(a.scratch.ColVec(fnIdx))

--- a/pkg/sql/colexec/ordered_synchronizer.eg.go
+++ b/pkg/sql/colexec/ordered_synchronizer.eg.go
@@ -270,6 +270,7 @@ func (o *OrderedSynchronizer) resetOutput() {
 	var reallocated bool
 	o.output, reallocated = o.accountingHelper.ResetMaybeReallocate(
 		o.typs, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	if reallocated {
 		o.outVecs.SetBatch(o.output)

--- a/pkg/sql/colexec/ordered_synchronizer_tmpl.go
+++ b/pkg/sql/colexec/ordered_synchronizer_tmpl.go
@@ -220,6 +220,7 @@ func (o *OrderedSynchronizer) resetOutput() {
 	var reallocated bool
 	o.output, reallocated = o.accountingHelper.ResetMaybeReallocate(
 		o.typs, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	if reallocated {
 		o.outVecs.SetBatch(o.output)

--- a/pkg/sql/colexec/sort.go
+++ b/pkg/sql/colexec/sort.go
@@ -287,7 +287,10 @@ func (p *sortOp) Next() coldata.Batch {
 				p.state = sortDone
 				continue
 			}
-			p.output, _ = p.allocator.ResetMaybeReallocate(p.inputTypes, p.output, toEmit, p.maxOutputBatchMemSize)
+			p.output, _ = p.allocator.ResetMaybeReallocate(
+				p.inputTypes, p.output, toEmit, p.maxOutputBatchMemSize,
+				true, /* desiredCapacitySufficient */
+			)
 			if toEmit > p.output.Capacity() {
 				toEmit = p.output.Capacity()
 			}

--- a/pkg/sql/colexec/sorttopk.go
+++ b/pkg/sql/colexec/sorttopk.go
@@ -200,7 +200,10 @@ func (t *topKSorter) emit() coldata.Batch {
 		// We're done.
 		return coldata.ZeroBatch
 	}
-	t.output, _ = t.allocator.ResetMaybeReallocate(t.inputTypes, t.output, toEmit, t.maxOutputBatchMemSize)
+	t.output, _ = t.allocator.ResetMaybeReallocate(
+		t.inputTypes, t.output, toEmit, t.maxOutputBatchMemSize,
+		true, /* desiredCapacitySufficient */
+	)
 	if toEmit > t.output.Capacity() {
 		toEmit = t.output.Capacity()
 	}

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -325,6 +325,7 @@ func (cf *cFetcher) resetBatch() {
 	}
 	cf.machine.batch, reallocated = cf.accountingHelper.ResetMaybeReallocate(
 		cf.table.typs, cf.machine.batch, minDesiredCapacity, cf.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	if reallocated {
 		cf.machine.colvecs.SetBatch(cf.machine.batch)

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -429,7 +429,10 @@ func (i *Inbox) Next() coldata.Batch {
 		}
 		// We rely on the outboxes to produce reasonably sized batches.
 		const maxBatchMemSize = math.MaxInt64
-		i.scratch.b, _ = i.allocator.ResetMaybeReallocate(i.typs, i.scratch.b, batchLength, maxBatchMemSize)
+		i.scratch.b, _ = i.allocator.ResetMaybeReallocate(
+			i.typs, i.scratch.b, batchLength, maxBatchMemSize,
+			true, /* desiredCapacitySufficient */
+		)
 		i.allocator.PerformOperation(i.scratch.b.ColVecs(), func() {
 			if err := i.converter.ArrowToBatch(i.scratch.data, batchLength, i.scratch.b); err != nil {
 				colexecerror.InternalError(err)


### PR DESCRIPTION
Previously, `Allocator.ResetMaybeReallocate` would always grow the
capacity of the batch until `coldata.BatchSize()` (unless the memory
limit has been exceeded). This behavior allows us to have batches with
dynamic size when we don't know how many rows we need to process (for
example, in the `cFetcher` we start out with 1 row, then grow it
exponentially - 2, 4, 8, etc). However, in some cases we know exactly
how many rows we want to include into the batch, so that behavior can
result in us re-allocating a batch needlessly when the old batch already
have enough capacity.

This commit improves the situation by adding a knob to indicate that if
the desired capacity is satisfied by the old batch, then it should not
be re-allocated. All callers have been audited accordingly.

Release note: None