### PR TITLE
sql/queryvalidator: udf query validation prototype

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -361,6 +361,7 @@ ALL_TESTS = [
     "//pkg/sql/privilege:privilege_test",
     "//pkg/sql/protoreflect:protoreflect_test",
     "//pkg/sql/querycache:querycache_test",
+    "//pkg/sql/queryvalidator:queryvalidator_test",
     "//pkg/sql/randgen:randgen_test",
     "//pkg/sql/row:row_test",
     "//pkg/sql/rowcontainer:rowcontainer_test",

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/indexrec"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -2445,4 +2446,20 @@ func mapGeneratedAsIdentityType(inType catpb.GeneratedAsIdentityType) cat.Genera
 		catpb.GeneratedAsIdentityType_GENERATED_BY_DEFAULT: cat.GeneratedByDefaultAsIdentity,
 	}
 	return mapGeneratedAsIdentityType[inType]
+}
+
+// NewOptCatalog is only a convenience for tests to get a cat.Catalog.
+func NewOptCatalog(p interface{}) cat.Catalog {
+	return &optCatalog{
+		planner:     p.(*planner),
+		dataSources: make(map[catalog.TableDescriptor]cat.DataSource),
+	}
+}
+
+// NewNormFactory is only a convenience for tests to get a norm.Factory.
+func NewNormFactory(p interface{}) *norm.Factory {
+	planner := p.(*planner)
+	opc := &planner.optPlanningCtx
+	opc.reset()
+	return opc.optimizer.Factory()
 }

--- a/pkg/sql/queryvalidator/BUILD.bazel
+++ b/pkg/sql/queryvalidator/BUILD.bazel
@@ -1,0 +1,49 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "queryvalidator",
+    srcs = ["query_validator.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/queryvalidator",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/sql/opt",
+        "//pkg/sql/opt/memo",
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
+        "//pkg/sql/sem/cast",
+        "//pkg/sql/sem/tree",
+        "//pkg/sql/types",
+    ],
+)
+
+go_test(
+    name = "queryvalidator_test",
+    srcs = [
+        "main_test.go",
+        "query_validator_test.go",
+    ],
+    deps = [
+        ":queryvalidator",
+        "//pkg/base",
+        "//pkg/kv",
+        "//pkg/security",
+        "//pkg/security/securitytest",
+        "//pkg/security/username",
+        "//pkg/server",
+        "//pkg/sql",
+        "//pkg/sql/catalog/descs",
+        "//pkg/sql/opt/memo",
+        "//pkg/sql/opt/optbuilder",
+        "//pkg/sql/parser",
+        "//pkg/sql/sem/eval",
+        "//pkg/sql/sem/tree",
+        "//pkg/sql/sessiondatapb",
+        "//pkg/sql/types",
+        "//pkg/testutils/serverutils",
+        "//pkg/testutils/sqlutils",
+        "//pkg/testutils/testcluster",
+        "//pkg/util/protoutil",
+        "//pkg/util/randutil",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/sql/queryvalidator/main_test.go
+++ b/pkg/sql/queryvalidator/main_test.go
@@ -1,0 +1,33 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package queryvalidator_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+//go:generate ../../../util/leaktest/add-leaktest.sh *_test.go
+
+func TestMain(m *testing.M) {
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}

--- a/pkg/sql/queryvalidator/query_validator.go
+++ b/pkg/sql/queryvalidator/query_validator.go
@@ -1,0 +1,63 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package queryvalidator
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/cast"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+)
+
+type MemoFactory func(stmt tree.Statement) (*memo.Memo, error)
+
+type QueryValidator struct {
+	memoFactory MemoFactory
+}
+
+func New(optBuilderFactor MemoFactory) *QueryValidator {
+	return &QueryValidator{
+		memoFactory: optBuilderFactor,
+	}
+}
+
+func (v *QueryValidator) Validate(stmt tree.Statement, expectedTypes []*types.T) error {
+	stmtMemo, err := v.memoFactory(stmt)
+	if stmtMemo != nil && stmtMemo.RootExpr() != nil {
+		rootExpr := stmtMemo.RootExpr()
+		if _, ok := rootExpr.(memo.RelExpr); ok {
+			outputCols := stmtMemo.RootProps().Presentation
+			for i, col := range outputCols {
+				meta := stmtMemo.Metadata().ColumnMeta(col.ID)
+				colType := meta.Type
+				expectedType := expectedTypes[i]
+				if !expectedType.Equivalent(colType) && cast.ValidCast(colType, expectedTypes[0], cast.ContextImplicit) {
+					return pgerror.New(pgcode.WrongObjectType, "types do not match")
+				}
+			}
+		} else if scalarExpr, ok := stmtMemo.RootExpr().(opt.ScalarExpr); ok {
+			colType := scalarExpr.DataType()
+			if len(expectedTypes) != 1 || (!expectedTypes[0].Equivalent(colType) && cast.ValidCast(colType, expectedTypes[0], cast.ContextImplicit)) {
+				return pgerror.New(pgcode.WrongObjectType, "type do not match")
+			}
+		} else {
+			panic("unexpected memo expression")
+		}
+	}
+
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/sql/queryvalidator/query_validator_test.go
+++ b/pkg/sql/queryvalidator/query_validator_test.go
@@ -1,0 +1,96 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package queryvalidator_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/queryvalidator"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidator(t *testing.T) {
+	ctx := context.Background()
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	tDB := sqlutils.MakeSQLRunner(sqlDB)
+
+	tDB.Exec(t, `
+CREATE TABLE t (a INT PRIMARY KEY, b string);`,
+	)
+
+	var sessionData sessiondatapb.SessionData
+	{
+		var sessionSerialized []byte
+		tDB.QueryRow(t, "SELECT crdb_internal.serialize_session()").Scan(&sessionSerialized)
+		require.NoError(t, protoutil.Unmarshal(sessionSerialized, &sessionData))
+	}
+
+	err := sql.TestingDescsTxn(ctx, s, func(ctx context.Context, txn *kv.Txn, col *descs.Collection) error {
+		execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
+		planner, cleanup := sql.NewInternalPlanner(
+			"resolve-index", txn, username.RootUserName(), &sql.MemoryMetrics{},
+			&execCfg, sessionData, sql.WithDescCollection(col),
+		)
+		defer cleanup()
+
+		catalog := sql.NewOptCatalog(planner)
+		f := sql.NewNormFactory(planner)
+		ec := planner.(interface{ EvalContext() *eval.Context }).EvalContext()
+		sc := planner.(interface{ SemaCtx() *tree.SemaContext }).SemaCtx()
+
+		bldFactory := func(stmt tree.Statement) (*memo.Memo, error) {
+			bld := optbuilder.New(ctx, sc, ec, catalog, f, stmt)
+			err := bld.Build()
+			if err != nil {
+				return nil, err
+			}
+			return f.Memo(), nil
+		}
+
+		validator := queryvalidator.New(bldFactory)
+
+		stmts, err := parser.Parse("SELECT upper(a::string), b::int FROM defaultdb.public.t")
+		require.NoError(t, err)
+		err = validator.Validate(stmts[0].AST, []*types.T{types.String, types.Int})
+		require.NoError(t, err)
+
+		stmts, err = parser.Parse("SELECT row(a, b) FROM defaultdb.public.t")
+		require.NoError(t, err)
+		err = validator.Validate(stmts[0].AST, []*types.T{types.MakeTuple([]*types.T{types.Int, types.String})})
+		require.NoError(t, err)
+
+		stmts, err = parser.Parse("SELECT 'hello'")
+		require.NoError(t, err)
+		err = validator.Validate(stmts[0].AST, []*types.T{types.String})
+		require.NoError(t, err)
+
+		return nil
+	})
+
+	require.NoError(t, err)
+}


### PR DESCRIPTION
This is only a toy as a proof of concept.. we would need something better to validate return types of UDF function bodies.

Release note: None.