### PR TITLE
release-21.2: acceptance: run `python`, `psql` containers as current uid

### DIFF
--- a/pkg/acceptance/compose/gss/docker-compose-python.yml
+++ b/pkg/acceptance/compose/gss/docker-compose-python.yml
@@ -18,6 +18,7 @@ services:
       - ../../../../cockroach-linux-2.6.32-gnu-amd64:/cockroach/cockroach
   python:
     build: ./python
+    user: "${UID}:${GID}"
     depends_on:
       - cockroach
     environment:

--- a/pkg/acceptance/compose/gss/docker-compose.yml
+++ b/pkg/acceptance/compose/gss/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - ../../../../cockroach-linux-2.6.32-gnu-amd64:/cockroach/cockroach
   psql:
     build: ./psql
+    user: "${UID}:${GID}"
     depends_on:
       - cockroach
     environment:

--- a/pkg/acceptance/compose/gss/psql/Dockerfile
+++ b/pkg/acceptance/compose/gss/psql/Dockerfile
@@ -7,12 +7,19 @@ RUN GO111MODULE=off go get -d -t -tags gss_compose
 RUN GO111MODULE=off go test -v -c -tags gss_compose -o gss.test
 
 # Copy the test binary to an image with psql and krb installed.
-FROM postgres:11.15
+FROM postgres:11
 
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+  ca-certificates \
+  curl \
   krb5-user
 
 COPY --from=builder /workspace/gss.test .
 
-ENTRYPOINT ["/start.sh"]
+RUN curl -fsSL "https://github.com/benesch/autouseradd/releases/download/1.3.0/autouseradd-1.3.0-amd64.tar.gz" -o autouseradd.tar.gz \
+  && echo "442dae58b727a79f81368127fac141d7f95501ffa05f8c48943d27c4e807deb7 autouseradd.tar.gz" | sha256sum -c - \
+  && tar xzf autouseradd.tar.gz --strip-components 1 \
+  && rm autouseradd.tar.gz
+
+ENTRYPOINT ["autouseradd", "--user", "roach", "--no-create-home", "/start.sh"]

--- a/pkg/acceptance/compose/gss/psql/start.sh
+++ b/pkg/acceptance/compose/gss/psql/start.sh
@@ -15,7 +15,7 @@ echo "Preparing SQL user ahead of test"
 env \
     PGSSLKEY=/certs/client.root.key \
     PGSSLCERT=/certs/client.root.crt \
-    psql -c "ALTER USER root WITH PASSWORD rootpw"
+    psql -U root -c "ALTER USER root WITH PASSWORD rootpw"
 
 echo "Running test"
 ./gss.test

--- a/pkg/acceptance/compose/gss/python/Dockerfile
+++ b/pkg/acceptance/compose/gss/python/Dockerfile
@@ -5,8 +5,14 @@ RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-k
   echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" | tee  /etc/apt/sources.list.d/pgdg.list && \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+  curl \
   krb5-user \
   postgresql-client-11
+
+RUN curl -fsSL "https://github.com/benesch/autouseradd/releases/download/1.3.0/autouseradd-1.3.0-amd64.tar.gz" -o autouseradd.tar.gz \
+  && echo "442dae58b727a79f81368127fac141d7f95501ffa05f8c48943d27c4e807deb7 autouseradd.tar.gz" | sha256sum -c - \
+  && tar xzf autouseradd.tar.gz --strip-components 1 \
+  && rm autouseradd.tar.gz
 
 RUN mkdir /code
 WORKDIR /code
@@ -14,4 +20,4 @@ COPY requirements.txt /code/
 RUN pip install -r requirements.txt
 COPY . /code/
 
-ENTRYPOINT ["/start.sh"]
+ENTRYPOINT ["autouseradd", "--user", "roach", "--no-create-home", "/start.sh"]

--- a/pkg/acceptance/compose_test.go
+++ b/pkg/acceptance/compose_test.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"testing"
 )
 
@@ -32,6 +33,16 @@ func TestComposeFlyway(t *testing.T) {
 }
 
 func testCompose(t *testing.T, path string, exitCodeFrom string) {
+	uid := os.Getuid()
+	err := os.Setenv("UID", strconv.Itoa(uid))
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	gid := os.Getgid()
+	err = os.Setenv("GID", strconv.Itoa(gid))
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
 	cmd := exec.Command(
 		"docker-compose",
 		"--no-ansi",


### PR DESCRIPTION
Backport from #81460.

`postgres`'s permission checking for certificates has gotten more
rigorous since [this commit](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=a59c79564bdc209a5bc7b02d706f0d7352eb82fa).
This has broken a couple `acceptance` tests which do not pin to any
specific `postgres` version (see #81313, #81437).

Here we attempt to solve the problem "once and for all" by ensuring that
these containers run with a UID that is equal to the one that created
the certificates.

Release note: None
Release justification: Test-only change