### PR TITLE
sql,stmtdiagnostics: remove some version gates

### DIFF
--- a/pkg/sql/row/BUILD.bazel
+++ b/pkg/sql/row/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/row",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/keys",

--- a/pkg/sql/row/kv_batch_streamer.go
+++ b/pkg/sql/row/kv_batch_streamer.go
@@ -13,7 +13,6 @@ package row
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvstreamer"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -24,13 +23,11 @@ import (
 
 // CanUseStreamer returns whether the kvstreamer.Streamer API should be used.
 func CanUseStreamer(ctx context.Context, settings *cluster.Settings) bool {
-	// TODO(yuzefovich): remove the version gate in 22.2 cycle.
-	return settings.Version.IsActive(ctx, clusterversion.ScanWholeRows) &&
-		useStreamerEnabled.Get(&settings.SV)
+	return useStreamerEnabled.Get(&settings.SV)
 }
 
 // useStreamerEnabled determines whether the Streamer API should be used.
-// TODO(yuzefovich): remove this in 22.2.
+// TODO(yuzefovich): remove this in 23.1.
 var useStreamerEnabled = settings.RegisterBoolSetting(
 	settings.TenantReadOnly,
 	"sql.distsql.use_streamer.enabled",

--- a/pkg/sql/stmtdiagnostics/BUILD.bazel
+++ b/pkg/sql/stmtdiagnostics/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/clusterversion",
         "//pkg/gossip",
         "//pkg/kv",
         "//pkg/roachpb",


### PR DESCRIPTION
This commit addresses several TODOs with my name on them about removing
the version gates, mostly around the conditional statement diagnostics
introduced in 22.1 cycle.

Release note: None