### PR TITLE
logictest: fix flake in distsql_stats

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -1351,7 +1351,7 @@ statement ok
 ANALYZE system.locations
 
 # EXPLAIN output should indicate stats collected on system.locations.
-query T
+query T retry
 SELECT * FROM [EXPLAIN SELECT * FROM system.locations] OFFSET 2
 ----
 ·


### PR DESCRIPTION
This commit fixes a test flake in distsql_stats from #80761.

Release note: none