### PR TITLE
sql/schemachanger: turn on COMMENT ON in declarative schema changer

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/privileges_comments
+++ b/pkg/sql/logictest/testdata/logic_test/privileges_comments
@@ -23,10 +23,20 @@ SET DATABASE = d45707
 statement error user testuser does not have CREATE privilege on database d45707
 COMMENT ON DATABASE d45707 IS 'd45707'
 
+onlyif config local-legacy-schema-changer
 statement error user testuser does not have CREATE privilege on relation t45707
 COMMENT ON TABLE d45707.t45707 IS 't45707'
 
+skipif config local-legacy-schema-changer
+statement error must be owner of table t45707 or have CREATE privilege on table t45707
+COMMENT ON TABLE d45707.t45707 IS 't45707'
+
+onlyif config local-legacy-schema-changer
 statement error user testuser does not have CREATE privilege on relation t45707
+COMMENT ON COLUMN d45707.t45707.x IS 'x45707'
+
+skipif config local-legacy-schema-changer
+statement error must be owner of table t45707 or have CREATE privilege on table t45707
 COMMENT ON COLUMN d45707.t45707.x IS 'x45707'
 
 statement error user testuser does not have CREATE privilege on relation t45707

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -751,6 +751,7 @@ func (b *builderState) ResolveTableIndexBestEffort(
 	}
 	tableIndexName.Table.CatalogName = tree.Name(prefix.Database.GetName())
 	tableIndexName.Table.SchemaName = tree.Name(prefix.Schema.GetName())
+	tableIndexName.Table.ObjectName = tree.Name(tbl.GetName())
 	return b.ResolveIndex(tbl.GetID(), tree.Name(idx.GetName()), p)
 }
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/comment_on.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/comment_on.go
@@ -76,6 +76,14 @@ func CommentOnSchema(b BuildCtx, n *tree.CommentOnSchema) {
 // CommentOnTable implements COMMENT ON TABLE xxx IS xxx statement.
 func CommentOnTable(b BuildCtx, n *tree.CommentOnTable) {
 	tableElements := b.ResolveTable(n.Table, commentResolveParams)
+	_, _, tbl := scpb.FindTable(tableElements)
+	tbn := n.Table.ToTableName()
+	if tbl == nil {
+		b.MarkNameAsNonExistent(&tbn)
+		return
+	}
+	tbn.ObjectNamePrefix = b.NamePrefix(tbl)
+	n.Table = tbn.ToUnresolvedObjectName()
 
 	if n.Comment == nil {
 		_, _, tableComment := scpb.FindTableComment(tableElements)

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
@@ -46,21 +46,20 @@ var supportedStatements = map[reflect.Type]supportedStatement{
 	// Alter table will have commands individually whitelisted via the
 	// supportedAlterTableStatements list, so wwe will consider it fully supported
 	// here.
-	reflect.TypeOf((*tree.AlterTable)(nil)):   {AlterTable, true},
-	reflect.TypeOf((*tree.CreateIndex)(nil)):  {CreateIndex, false},
-	reflect.TypeOf((*tree.DropDatabase)(nil)): {DropDatabase, true},
-	reflect.TypeOf((*tree.DropSchema)(nil)):   {DropSchema, true},
-	reflect.TypeOf((*tree.DropSequence)(nil)): {DropSequence, true},
-	reflect.TypeOf((*tree.DropTable)(nil)):    {DropTable, true},
-	reflect.TypeOf((*tree.DropType)(nil)):     {DropType, true},
-	reflect.TypeOf((*tree.DropView)(nil)):     {DropView, true},
-	// TODO (Chengxiong) turn on `COMMENT ON` with version gating after 22.1 release.
-	reflect.TypeOf((*tree.CommentOnDatabase)(nil)):   {CommentOnDatabase, false},
-	reflect.TypeOf((*tree.CommentOnSchema)(nil)):     {CommentOnSchema, false},
-	reflect.TypeOf((*tree.CommentOnTable)(nil)):      {CommentOnTable, false},
-	reflect.TypeOf((*tree.CommentOnColumn)(nil)):     {CommentOnColumn, false},
-	reflect.TypeOf((*tree.CommentOnIndex)(nil)):      {CommentOnIndex, false},
-	reflect.TypeOf((*tree.CommentOnConstraint)(nil)): {CommentOnConstraint, false},
+	reflect.TypeOf((*tree.AlterTable)(nil)):          {AlterTable, true},
+	reflect.TypeOf((*tree.CreateIndex)(nil)):         {CreateIndex, false},
+	reflect.TypeOf((*tree.DropDatabase)(nil)):        {DropDatabase, true},
+	reflect.TypeOf((*tree.DropSchema)(nil)):          {DropSchema, true},
+	reflect.TypeOf((*tree.DropSequence)(nil)):        {DropSequence, true},
+	reflect.TypeOf((*tree.DropTable)(nil)):           {DropTable, true},
+	reflect.TypeOf((*tree.DropType)(nil)):            {DropType, true},
+	reflect.TypeOf((*tree.DropView)(nil)):            {DropView, true},
+	reflect.TypeOf((*tree.CommentOnDatabase)(nil)):   {CommentOnDatabase, true},
+	reflect.TypeOf((*tree.CommentOnSchema)(nil)):     {CommentOnSchema, true},
+	reflect.TypeOf((*tree.CommentOnTable)(nil)):      {CommentOnTable, true},
+	reflect.TypeOf((*tree.CommentOnColumn)(nil)):     {CommentOnColumn, true},
+	reflect.TypeOf((*tree.CommentOnIndex)(nil)):      {CommentOnIndex, true},
+	reflect.TypeOf((*tree.CommentOnConstraint)(nil)): {CommentOnConstraint, true},
 }
 
 func init() {

--- a/pkg/sql/schemachanger/scplan/testdata/comment_on
+++ b/pkg/sql/schemachanger/scplan/testdata/comment_on
@@ -132,7 +132,7 @@ StatementPhase stage 1 of 1 with 2 MutationType ops
       EventBase:
         Authorization:
           UserName: root
-        Statement: COMMENT ON INDEX ‹db1›.‹sc1›.‹t1_pkey› IS 'pkey is good'
+        Statement: COMMENT ON INDEX ‹db1›.‹sc1›.‹t1›@‹t1_pkey› IS 'pkey is good'
         StatementTag: COMMENT ON INDEX
         TargetMetadata:
           SourceElementID: 1
@@ -281,7 +281,7 @@ PreCommitPhase stage 1 of 1 with 2 MutationType ops
       EventBase:
         Authorization:
           UserName: root
-        Statement: COMMENT ON INDEX ‹db1›.‹sc1›.‹t1_pkey› IS NULL
+        Statement: COMMENT ON INDEX ‹db1›.‹sc1›.‹t1›@‹t1_pkey› IS NULL
         StatementTag: COMMENT ON INDEX
         TargetMetadata:
           SourceElementID: 1

--- a/pkg/sql/sem/tree/schema_feature_name.go
+++ b/pkg/sql/sem/tree/schema_feature_name.go
@@ -21,6 +21,12 @@ type SchemaFeatureName string
 func GetSchemaFeatureNameFromStmt(stmt Statement) SchemaFeatureName {
 	statementTag := stmt.StatementTag()
 	statementInfo := strings.Split(statementTag, " ")
+
+	switch stmt.(type) {
+	case *CommentOnDatabase, *CommentOnSchema, *CommentOnTable,
+		*CommentOnColumn, *CommentOnIndex, *CommentOnConstraint:
+		return SchemaFeatureName(statementTag)
+	}
 	// Only grab the first two words (i.e. ALTER TABLE, etc..).
 	if len(statementInfo) >= 2 {
 		return SchemaFeatureName(statementInfo[0] + " " + statementInfo[1])


### PR DESCRIPTION
Resolves #77327
Turn the fully supported flags on. There're a few differences on
error or logging output which should be legit.

Release note: None.