### PR TITLE
sql: correct error code for CopyFail message

### DIFF
--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -334,7 +334,7 @@ Loop:
 			}
 			break Loop
 		case pgwirebase.ClientMsgCopyFail:
-			return errors.Newf("client canceled COPY")
+			return pgerror.Newf(pgcode.QueryCanceled, "COPY from stdin failed: %s", string(readBuf.Msg))
 		case pgwirebase.ClientMsgFlush, pgwirebase.ClientMsgSync:
 			// Spec says to "ignore Flush and Sync messages received during copy-in mode".
 		default:

--- a/pkg/sql/pgwire/testdata/pgtest/copy
+++ b/pkg/sql/pgwire/testdata/pgtest/copy
@@ -174,6 +174,21 @@ ReadyForQuery
 {"Type":"CommandComplete","CommandTag":"SET"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
+# Test cancelling copy.
+
+send
+Query {"String": "COPY t FROM STDIN"}
+CopyFail { "Message": "client received an error" }
+----
+
+until keepErrMessage
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"CopyInResponse","ColumnFormatCodes":[0,0]}
+{"Type":"ErrorResponse","Code":"57014","Message":"COPY from stdin failed: client received an error"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
 # Invalid ESCAPE syntax.
 send
 Query {"String": "COPY t FROM STDIN ESCAPE 'xxx'"}

--- a/pkg/testutils/pgtest/datadriven.go
+++ b/pkg/testutils/pgtest/datadriven.go
@@ -274,6 +274,8 @@ func toMessage(typ string) interface{} {
 		return &pgproto3.CommandComplete{}
 	case "CopyData":
 		return &pgproto3.CopyData{}
+	case "CopyFail":
+		return &pgproto3.CopyFail{}
 	case "CopyDone":
 		return &pgproto3.CopyDone{}
 	case "CopyInResponse":


### PR DESCRIPTION
Resolves #81559.

Release note (bug fix): Previously, cancelling COPY commands would have
an XXUUU error, instead of 57014. This is now rectified.