### PR TITLE
ci: update how the `tc_release_branch` check is performed

### DIFF
--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -34,9 +34,15 @@ run_bazel() {
         $BAZEL_IMAGE "$@"
 }
 
+# local copy of _tc_build_branch from teamcity-support.sh to avoid imports.
+_tc_build_branch() {
+    echo "${TC_BUILD_BRANCH#refs/heads/}"
+}
+
 # local copy of tc_release_branch from teamcity-support.sh to avoid imports.
 _tc_release_branch() {
-  [[ "$TC_BUILD_BRANCH" == master || "$TC_BUILD_BRANCH" == release-* || "$TC_BUILD_BRANCH" == provisional_* ]]
+  branch=$(_tc_build_branch)
+  [[ "$branch" == master || "$branch" == release-* || "$branch" == provisional_* ]]
 }
 
 # process_test_json processes logs and submits failures to GitHub

--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -282,12 +282,22 @@ changed_go_pkgs() {
     | { while read path; do if ls "$path"/*.go &>/dev/null; then echo -n "./$path "; fi; done; }
 }
 
+# tc_build_branch returns $TC_BUILD_BRANCH but with the optional refs/heads/
+# prefix stripped.
+tc_build_branch() {
+    echo "${TC_BUILD_BRANCH#refs/heads/}"
+}
+
+# NB: Update _tc_release_branch in teamcity-bazel-support.sh if you update this
+# function.
 tc_release_branch() {
-  [[ "$TC_BUILD_BRANCH" == master || "$TC_BUILD_BRANCH" == release-* || "$TC_BUILD_BRANCH" == provisional_* ]]
+  branch=$(tc_build_branch)
+  [[ "$branch" == master || "$branch" == release-* || "$branch" == provisional_* ]]
 }
 
 tc_bors_branch() {
-  [[ "$TC_BUILD_BRANCH" == staging ]]
+  branch=$(tc_build_branch)
+  [[ "$branch" == staging ]]
 }
 
 if_tc() {

--- a/build/teamcity/util/roachtest_util.sh
+++ b/build/teamcity/util/roachtest_util.sh
@@ -25,8 +25,9 @@ function upload_stats {
           bucket="cockroach-nightly"
       fi
 
-      remote_artifacts_dir="artifacts-${TC_BUILD_BRANCH}"
-      if [[ "${TC_BUILD_BRANCH}" == "master" ]]; then
+      branch=$(tc_build_branch)
+      remote_artifacts_dir="artifacts-${branch}"
+      if [[ "${branch}" == "master" ]]; then
         # The master branch is special, as roachperf hard-codes
         # the location.
         remote_artifacts_dir="artifacts"


### PR DESCRIPTION
How TeamCity sets the `TC_BUILD_BRANCH` environment variable is a bit
unpredictable. While we expect it to be a string like `master`, at times
(see #81546) this variable can be set to a ref like `refs/heads/master`.
This inconsistency means that we are sometimes not reporting issues to
GitHub as we should be. To be resilient to this I make sure we strip
off the `refs/heads/` prefix when performing the `tc_release_branch`
check.

Release note: None