### PR TITLE
roachtest: fix connectionlatency tests

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -52,7 +52,7 @@ func TestAllRegisteredImportFixture(t *testing.T) {
 	for _, meta := range workload.Registered() {
 		meta := meta
 		gen := meta.New()
-		hasInitialData := true
+		hasInitialData := len(gen.Tables()) != 0
 		for _, table := range gen.Tables() {
 			if table.InitialRows.FillBatch == nil {
 				hasInitialData = false

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -52,7 +52,8 @@ func SupportsFixtures(gen Generator) bool {
 			return false
 		}
 	}
-	return true
+	// Don't use fixtures if there are no tables.
+	return len(gen.Tables()) != 0
 }
 
 // FlagMeta is metadata about a workload flag.


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/81427
fixes https://github.com/cockroachdb/cockroach/issues/81426
fixes https://github.com/cockroachdb/cockroach/issues/81425

Due to https://github.com/cockroachdb/cockroach/pull/80226 this
test started running IMPORT related queries. There's not actually any
data to load, so this extra check will prevent it from hitting
permission errors.

Release note: None