### PR TITLE
release: skip bincheck for placeholder -alpha.0000* tag pushes

### DIFF
--- a/.github/workflows/bincheck.yml
+++ b/.github/workflows/bincheck.yml
@@ -2,7 +2,9 @@ name: bincheck
 
 on:
   push:
-    tags: [ v* ]
+    tags: 
+    - v*
+    - !v*-alpha.0000*
 
 jobs:
 


### PR DESCRIPTION
Skip bincheck workflow for -alpha.0000* tags.

Currently, when we publish a new CRDB release version binary,
we trigger this bincheck workflow by detecting the creation
of a new release tag.

This PR adds a rule to skip `${vNEXT}-alpha.00000000` tags,
since these don't map to a published binary, but are used
in order for the master branch to self-identify as the
next/new development release.

See New major version checklist runbook:
https://cockroachlabs.atlassian.net/wiki/spaces/ENG/pages/1522270228/New+major+version+checklist

This should fix https://github.com/cockroachdb/cockroach/actions/runs/2360215076

Release note: None