### PR TITLE
release-21.2: opt: disable normalization rules when building lookup expressions

### DIFF
--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -159,6 +159,17 @@ func (f *Factory) DisableOptimizations() {
 	f.NotifyOnMatchedRule(func(opt.RuleName) bool { return false })
 }
 
+// DisableOptimizationsTemporarily disables all transformation rules during the
+// execution of the given function fn. A MatchedRuleFunc previously set by
+// NotifyOnMatchedRule is not invoked during execution of fn, but will be
+// invoked for future rule matches after fn returns.
+func (f *Factory) DisableOptimizationsTemporarily(fn func()) {
+	originalMatchedRule := f.matchedRule
+	f.DisableOptimizations()
+	fn()
+	f.matchedRule = originalMatchedRule
+}
+
 // NotifyOnMatchedRule sets a callback function which is invoked each time a
 // normalize rule has been matched by the factory. If matchedRule is nil, then
 // no further notifications are sent, and all rules are applied by default. In

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -717,9 +717,13 @@ func (c *CustomFuncs) findFiltersForIndexLookup(
 		constFilter := filters[allIdx]
 		if !c.isCanonicalLookupJoinFilter(constFilter) {
 			if len(values) > 0 {
-				constFilter = c.makeConstFilter(idxCol, values)
+				c.e.f.DisableOptimizationsTemporarily(func() {
+					constFilter = c.makeConstFilter(idxCol, values)
+				})
 			} else if foundRange {
-				constFilter = c.makeRangeFilter(idxCol, constFilter)
+				c.e.f.DisableOptimizationsTemporarily(func() {
+					constFilter = c.makeRangeFilter(idxCol, constFilter)
+				})
 			}
 		}
 		constFilters = append(constFilters, constFilter)

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -849,7 +849,7 @@ project
  │    │         │    │    │    └── filters
  │    │         │    │    │         ├── transactiondetails.cardid:23 = id:1 [outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ]), fd=(1)==(23), (23)==(1)]
  │    │         │    │    │         ├── transactiondetails.dealerid:20 = 1 [outer=(20), constraints=(/20: [/1 - /1]; tight), fd=()-->(20)]
- │    │         │    │    │         ├── NOT isbuy:21 [outer=(21), constraints=(/21: [/false - /false]; tight), fd=()-->(21)]
+ │    │         │    │    │         ├── isbuy:21 = false [outer=(21), constraints=(/21: [/false - /false]; tight), fd=()-->(21)]
  │    │         │    │    │         └── (transactiondate:22 >= '2020-02-28 00:00:00+00:00') AND (transactiondate:22 <= '2020-03-01 00:00:00+00:00') [outer=(22), constraints=(/22: [/'2020-02-28 00:00:00+00:00' - /'2020-03-01 00:00:00+00:00']; tight)]
  │    │         │    │    ├── immutable
  │    │         │    │    ├── stats: [rows=3543333.33, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0, distinct(5)=829, null(5)=0, distinct(6)=5601.15328, null(6)=0, distinct(23)=19000, null(23)=0]
@@ -871,7 +871,8 @@ project
  │    │         │    │    │    │    └── ordering: +1
  │    │         │    │    │    └── filters
  │    │         │    │    │         └── (name:2, setname:4, number:5) > ('Shock', '7E', 248) [outer=(2,4,5), immutable, constraints=(/2/4/5: [/'Shock'/'7E'/249 - ]; tight)]
- │    │         │    │    └── filters (true)
+ │    │         │    │    └── filters
+ │    │         │    │         └── NOT isbuy:21 [outer=(21), constraints=(/21: [/false - /false]; tight), fd=()-->(21)]
  │    │         │    └── filters (true)
  │    │         └── aggregations
  │    │              ├── sum [as=sum:30, outer=(24)]

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -853,7 +853,7 @@ project
  │    │         │    │    │    └── filters
  │    │         │    │    │         ├── transactiondetails.cardid:27 = id:1 [outer=(1,27), constraints=(/1: (/NULL - ]; /27: (/NULL - ]), fd=(1)==(27), (27)==(1)]
  │    │         │    │    │         ├── transactiondetails.dealerid:24 = 1 [outer=(24), constraints=(/24: [/1 - /1]; tight), fd=()-->(24)]
- │    │         │    │    │         ├── NOT isbuy:25 [outer=(25), constraints=(/25: [/false - /false]; tight), fd=()-->(25)]
+ │    │         │    │    │         ├── isbuy:25 = false [outer=(25), constraints=(/25: [/false - /false]; tight), fd=()-->(25)]
  │    │         │    │    │         └── (transactiondate:26 >= '2020-02-28 00:00:00+00:00') AND (transactiondate:26 <= '2020-03-01 00:00:00+00:00') [outer=(26), constraints=(/26: [/'2020-02-28 00:00:00+00:00' - /'2020-03-01 00:00:00+00:00']; tight)]
  │    │         │    │    ├── immutable
  │    │         │    │    ├── stats: [rows=3543333.33, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0, distinct(5)=829, null(5)=0, distinct(6)=5601.15328, null(6)=0, distinct(27)=19000, null(27)=0]
@@ -875,7 +875,8 @@ project
  │    │         │    │    │    │    └── ordering: +1
  │    │         │    │    │    └── filters
  │    │         │    │    │         └── (name:2, setname:4, number:5) > ('Shock', '7E', 248) [outer=(2,4,5), immutable, constraints=(/2/4/5: [/'Shock'/'7E'/249 - ]; tight)]
- │    │         │    │    └── filters (true)
+ │    │         │    │    └── filters
+ │    │         │    │         └── NOT isbuy:25 [outer=(25), constraints=(/25: [/false - /false]; tight), fd=()-->(25)]
  │    │         │    └── filters (true)
  │    │         └── aggregations
  │    │              ├── sum [as=sum:36, outer=(28)]

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -3854,6 +3854,34 @@ project
       │    └── columns: m:1
       └── filters (true)
 
+# Regression test for #80525. Do not normalize c = false to NOT c in lookup
+# expression.
+exec-ddl
+CREATE TABLE t80525_a (a INT, INDEX (a))
+----
+
+exec-ddl
+CREATE TABLE t80525_bcd (b INT, c BOOL, d INT, INDEX (b, c, d))
+----
+
+opt expect=GenerateLookupJoinsWithFilter
+SELECT * FROM t80525_a INNER LOOKUP JOIN t80525_bcd ON b = a AND c = false AND d > 0
+----
+inner-join (lookup t80525_bcd@secondary)
+ ├── columns: a:1!null b:5!null c:6!null d:7!null
+ ├── flags: force lookup join (into right side)
+ ├── lookup expression
+ │    └── filters
+ │         ├── b:5 = a:1 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+ │         ├── c:6 = false [outer=(6), constraints=(/6: [/false - /false]; tight), fd=()-->(6)]
+ │         └── d:7 > 0 [outer=(7), constraints=(/7: [/1 - ]; tight)]
+ ├── fd: ()-->(6), (1)==(5), (5)==(1)
+ ├── scan t80525_a
+ │    └── columns: a:1
+ └── filters
+      └── NOT c:6 [outer=(6), constraints=(/6: [/false - /false]; tight), fd=()-->(6)]
+
+
 # --------------------------------------------------
 # GenerateLookupJoinsWithFilter + Partial Indexes
 # --------------------------------------------------


### PR DESCRIPTION
Backport 1/1 commits from #81104.

/cc @cockroachdb/release

---

Previously, normalization rules applied during construction of lookup
expression could result in non-canonical lookup expressions. The
execution is unable to generate lookup spans for non-canonical lookup
expressions, so the query resulted in an internal error "unable to
vectorize execution plan: unhandled expression type".

For example, when building the canonical equality `col = false`, the
normalization rule `FoldEqFalse` transforms it into `NOT col`, which is
non-canonical.

This commit fixes the issue by disabling normalization rules when
building lookup expressions.

Fixes #80525

Release note (bug fix): A bug has been fixed that caused errors with the
message "unable to vectorize execution plan: unhandled expression type"
in rare cases. This bug has been present since version 21.2.0.

---

Release justification: This fixes a rare internal error in the optimizer.