### PR TITLE
sql: return error message instead of panicking when altering default privileges on virtual schema

### DIFF
--- a/pkg/sql/alter_default_privileges.go
+++ b/pkg/sql/alter_default_privileges.go
@@ -80,7 +80,11 @@ func (p *planner) alterDefaultPrivileges(
 		if err != nil {
 			return nil, err
 		}
-		schemaDescs = append(schemaDescs, schemaDesc.(*schemadesc.Mutable))
+		mutableSchemaDesc, ok := schemaDesc.(*schemadesc.Mutable)
+		if !ok {
+			return nil, pgerror.Newf(pgcode.InvalidParameterValue, "%s is not a physical schema", schemaDesc.GetName())
+		}
+		schemaDescs = append(schemaDescs, mutableSchemaDesc)
 	}
 
 	return &alterDefaultPrivilegesNode{

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_in_schema
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_in_schema
@@ -3,6 +3,9 @@
 statement error pq: cannot use IN SCHEMA clause when using GRANT/REVOKE ON SCHEMAS
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE ON SCHEMAS TO root
 
+statement error pq: crdb_internal is not a physical schema
+ALTER DEFAULT PRIVILEGES IN SCHEMA crdb_internal GRANT SELECT ON TABLES TO root
+
 statement ok
 CREATE USER testuser2
 


### PR DESCRIPTION
Release note (sql change): Previously when one did
ALTER DEFAULT PRIVILEGES IN SCHEMA <virtual schema> a panic occured.

Now this returns the error message <virtual schema> is not a physical schema.

Fixes https://github.com/cockroachdb/cockroach/issues/81328