### PR TITLE
obsservice: initial commit

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -291,6 +291,7 @@
 /pkg/util/stop               @cockroachdb/server-prs
 /pkg/util/tracing            @cockroachdb/obs-inf-prs
 /pkg/workload/               @cockroachdb/sql-experience-noreview
+/pkg/obsservice/             @cockroachdb/obs-inf-prs
 
 # Allow the security team to have insight into changes to
 # authn/authz code.

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ work-Fuzz*
 *-fuzz.zip
 # vendoring by `go mod vendor` may produce this file temporarily
 /.vendor.tmp.*
+# The Observability Service binary.
+/obsservice
 
 # Custom or private env vars (e.g. internal keys, access tokens, etc).
 customenv.mk

--- a/pkg/obsservice/README.md
+++ b/pkg/obsservice/README.md
@@ -1,0 +1,68 @@
+# CockroachDB Observability Service
+
+This directory contains the source code of the CRDB Observability Service - a
+service that collects monitoring and observability functionality from CRDB and
+serves a web console that exposes the data.
+
+The Obs Service is developed as a library (in the `obslib` package) and a binary
+(the `cmd\obsservice` package). The idea is for other binaries to be able to
+embed and extend the library (for example we imagine CockroachCloud doing so in
+the future).
+
+## Building the Obs Service
+
+Build with
+
+```shell
+go build ./pkg/obsservice/cmd/obsservice
+```
+
+or
+
+```shell
+./dev build pkg/obsservice/cmd/obsservice
+```
+
+## Running
+
+```shell
+obsservice --http-addr=localhost:8081 --crdb-http-url=http://localhost:8080 --ui-cert=certs/cert.pem --ui-cert-key=certs/key.pem --ca-cert=certs/ca.crt
+```
+
+- `--crdb-http-url` is CRDB's HTTP address. For a multi-node CRDB cluster, this
+  can point to a load-balancer. It can be either a HTTP or an HTTPS address,
+  depending on whether the CRDB cluster is running as `--insecure`.
+- `--ui-cert` and `--ui-cert-key` are the paths to the certificate
+  presented by the Obs Service to its HTTPS clients, and the private key
+  corresponding to the certificate. If no certificates are configured, the Obs
+  Service will not use TLS. Certificates need to be specified if the CRDB
+  cluster is not running in `--insecure` mode: i.e. the Obs Service will refuse
+  to forward HTTP requests over HTTPS. The reverse is allowed, though: the Obs
+  Service can be configured with certificates even if CRDB is running in
+  `--insecure`. In this case, the Obs Service will terminate TLS connections and
+  forward HTTPS requests over HTTP.
+
+  If configured with certificates, HTTP requests will be redirected to HTTPS.  
+
+  For testing, self-signed certificates can be generated, for example, with the
+  [`generate_cert.go`](https://go.dev/src/crypto/tls/generate_cert.go) utility in
+  the Golang standard library: `go run ./crypto/tls/generate_cert.go
+  --host=localhost`.
+- `--ca-cert` is the path to a certificate authority certificate file (perhaps
+  one created with `cockroach cert create-ca`). If specified, HTTP requests are
+  only proxied to CRDB nodes that present certificates signed by this CA. If not
+  specified, the system's CA list is used.
+
+## Functionality
+
+_This is the very beginning of the Obs Service; it doesn't have any
+functionality yet. Hopefully we'll keep this up to date as it evolves._
+
+The Obs Service will reverse-proxy all HTTP routes it doesn't handle itself to
+CRDB. Currently the Obs Service doesn't handle any routes (other than
+`/debug/pprof/*`, which exposes the Obs Service's own pprof endpoints), so all
+requests are forwarded.
+
+## Licensing
+
+The Observability Service is licensed as Apache 2.0.

--- a/pkg/obsservice/cmd/obsservice/BUILD.bazel
+++ b/pkg/obsservice/cmd/obsservice/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "obsservice_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/obsservice/cmd/obsservice",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//pkg/cli/exit",
+        "//pkg/obsservice/obslib",
+        "@com_github_spf13_cobra//:cobra",
+    ],
+)
+
+go_binary(
+    name = "obsservice",
+    embed = [":obsservice_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/obsservice/cmd/obsservice/main.go
+++ b/pkg/obsservice/cmd/obsservice/main.go
@@ -1,0 +1,83 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/cli/exit"
+	"github.com/cockroachdb/cockroach/pkg/obsservice/obslib"
+	"github.com/spf13/cobra"
+)
+
+// RootCmd represents the base command when called without any subcommands
+var RootCmd = &cobra.Command{
+	Use:   "obsservice",
+	Short: "An observability service for CockroachDB",
+	Long: `The Observability Service ingests monitoring and observability data 
+from one or more CockroachDB clusters.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := context.Background()
+		cfg := obslib.ReverseHTTPProxyConfig{
+			HTTPAddr:      httpAddr,
+			TargetURL:     targetURL,
+			CACertPath:    caCertPath,
+			UICertPath:    uiCertPath,
+			UICertKeyPath: uiCertKeyPath,
+		}
+
+		// Block forever running the proxy.
+		<-obslib.NewReverseHTTPProxy(ctx, cfg).RunAsync(ctx)
+	},
+}
+
+// Flags.
+var (
+	httpAddr                  string
+	targetURL                 string
+	caCertPath                string
+	uiCertPath, uiCertKeyPath string
+)
+
+func main() {
+	RootCmd.PersistentFlags().StringVar(
+		&httpAddr,
+		"http-addr",
+		"localhost:8081",
+		"The address on which to listen for HTTP requests.")
+	RootCmd.PersistentFlags().StringVar(
+		&targetURL,
+		"crdb-http-url",
+		"http://localhost:8080",
+		"The base URL to which HTTP requests are proxied.")
+	RootCmd.PersistentFlags().StringVar(
+		&caCertPath,
+		"ca-cert",
+		"",
+		"Path to the certificate authority certificate file. If specified,"+
+			" HTTP requests are only proxied to CRDB nodes that present certificates signed by this CA."+
+			" If not specified, the system's CA list is used.")
+	RootCmd.PersistentFlags().StringVar(
+		&uiCertPath,
+		"ui-cert",
+		"",
+		"Path to the certificate used used by the Observability Service.")
+	RootCmd.PersistentFlags().StringVar(
+		&uiCertKeyPath,
+		"ui-cert-key",
+		"",
+		"Path to the private key used by the Observability Service. "+
+			"This is the key corresponding to the --ui-cert certificate.")
+
+	if err := RootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		exit.WithCode(exit.UnspecifiedError())
+	}
+}

--- a/pkg/obsservice/obslib/BUILD.bazel
+++ b/pkg/obsservice/obslib/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "obslib",
+    srcs = ["lib.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/obsservice/obslib",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/util/log",
+        "//pkg/util/syncutil",
+        "@com_github_cockroachdb_cmux//:cmux",
+        "@com_github_cockroachdb_errors//:errors",
+    ],
+)

--- a/pkg/obsservice/obslib/lib.go
+++ b/pkg/obsservice/obslib/lib.go
@@ -1,0 +1,325 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package obslib
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/http/pprof"
+	"net/url"
+	"time"
+
+	"github.com/cockroachdb/cmux"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
+)
+
+// ReverseHTTPProxyConfig groups the configuration for ReverseHTTPProxy.
+//
+// See RunAsync().
+type ReverseHTTPProxyConfig struct {
+	// HttpAddr represents the address on which the proxy will listen.
+	HTTPAddr string
+	// TargetURL represents the URL to which requests will be forwarded.
+	TargetURL string
+	// CACertPath represents the path to a file containing a certificate authority
+	// cert. This CA will be the only one trusted to sign CRDB's certificates. If
+	// not specified, the system's CAs are trusted.
+	CACertPath string
+	// UICertPath and UICertKeyPath represent paths to the certificate the proxy
+	// will use for autheticating itself to clients. If not specified, the proxy
+	// will just speak HTTP. If specified, the proxy will redirect any HTTP
+	// requests to HTTPS.
+	UICertPath, UICertKeyPath string
+}
+
+// ReverseHTTPProxy proxies HTTP requests to a given target (assumed to be
+// CRDB).
+type ReverseHTTPProxy struct {
+	listenAddr string
+	proxy      *httputil.ReverseProxy
+	certs      certificates
+}
+
+// NewReverseHTTPProxy creates a ReverseHTTPProxy.
+func NewReverseHTTPProxy(ctx context.Context, cfg ReverseHTTPProxyConfig) *ReverseHTTPProxy {
+	certs, err := loadCerts(cfg.UICertPath, cfg.UICertKeyPath, cfg.CACertPath)
+	if err != nil {
+		log.Fatalf(ctx, "%s", err)
+	}
+
+	url, err := url.Parse(cfg.TargetURL)
+	if err != nil {
+		log.Fatalf(ctx, "Invalid CRDB UI target: %s", cfg.TargetURL)
+	}
+	if certs.CAPool != nil && url.Scheme != "https" {
+		log.Fatalf(ctx, "HTTPS is required for CRDB target when --ca-cert is specified.")
+	}
+	if url.Path != "" {
+		// Supporting a path would require extra code in the proxy to join a
+		// particular request's path with it.
+		log.Fatalf(ctx, "Specifying a path in --crdb-http-url is not supported.")
+	}
+
+	// If the proxy is not configured for HTTP, remember to refuse redirects to
+	// HTTPS from Cockroach.
+	var HTTPToHTTPSErr error
+	if certs.UICert == nil {
+		HTTPToHTTPSErr = errors.New(`The CockroachDB cluster is configured to only serve HTTPS, 
+but the Observability Service has not been configured for HTTPS.
+Set the --ui-cert and --ui-cert-key flags to configure the Observability Service to serve HTTPS,
+set the scheme in the --crdb-http-url URL to "https://", and perhaps set --ca-cert
+to trust the certificate presented by CockroachDB.`)
+	}
+
+	return &ReverseHTTPProxy{
+		listenAddr: cfg.HTTPAddr,
+		proxy:      newProxy(url, certs.CAPool, HTTPToHTTPSErr),
+		certs:      certs,
+	}
+}
+
+// RunAsync runs an HTTP proxy server in a goroutine. The returned channel is
+// closed when the server terminates.
+//
+// TODO(andrei): Currently the server never terminates. Figure out a closing
+// signal.
+func (p *ReverseHTTPProxy) RunAsync(ctx context.Context) <-chan struct{} {
+	ch := make(chan struct{})
+
+	https := p.certs.UICert != nil
+	go func() {
+		defer close(ch)
+		var err error
+
+		listener, err := net.Listen("tcp", p.listenAddr)
+		if err != nil {
+			log.Fatalf(ctx, "%s", err)
+		}
+		defer func() {
+			_ = listener.Close()
+		}()
+
+		// Create the HTTP mux. Requests will generally be forwarded to p.proxy,
+		// except the /debug/pprof ones which will be served locally.
+		mux := http.NewServeMux()
+		mux.Handle("/", p.proxy)
+		// This seems to be the minimal set of handlers that we need to register in
+		// order to get all the pprof functionality. The pprof.Index handler handles
+		// some types of profiles itself.
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+		if !https {
+			// The Observability Service is not configured with certs, so it can only
+			// serve HTTP.
+			err = (&http.Server{Handler: mux}).Serve(listener)
+		} else {
+			// We're configured to serve HTTPS. We'll also listen for HTTP requests, and redirect them
+			// to HTTPS.
+
+			// Separate HTTP traffic from HTTPS traffic.
+			protocolMux := cmux.New(listener)
+			clearL := protocolMux.Match(cmux.HTTP1()) // Note that adding this matcher first gives it priority.
+			tlsL := protocolMux.Match(cmux.Any())
+			// Redirect HTTP to HTTPS.
+			redirectHandler := http.NewServeMux()
+			redirectHandler.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+				// TODO(andrei): Consider dealing with HSTS headers. Probably drop HSTS
+				// headers coming from CRDB, and set our own headers.
+				http.Redirect(w, r, "https://"+r.Host+r.RequestURI, http.StatusTemporaryRedirect)
+			})
+			redirectServer := http.Server{Handler: redirectHandler}
+			go func() {
+				_ = redirectServer.Serve(clearL)
+			}()
+
+			// Serve HTTPS traffic by delegating it to the proxy.
+			tlsServer := &http.Server{Handler: mux}
+			go func() {
+				_ = tlsServer.ServeTLS(tlsL, p.certs.UICertPath, p.certs.UICertKeyPath)
+			}()
+			err = protocolMux.Serve()
+		}
+		if !errors.Is(err, http.ErrServerClosed) {
+			fmt.Println(err.Error())
+		}
+	}()
+
+	scheme := "http"
+	if https {
+		scheme = "https"
+	}
+	fmt.Printf("Listening for HTTP requests on %s://%s.\n", scheme, p.listenAddr)
+
+	return ch
+}
+
+// certificates groups together all the certificates relevant to the proxy
+// server.
+type certificates struct {
+	UICertPath, UICertKeyPath string
+	UICert                    *tls.Certificate
+	CAPool                    *x509.CertPool
+}
+
+func loadCerts(uiCert, uiKey, caCert string) (certificates, error) {
+	var certs certificates
+	certs.UICertPath = uiCert
+	certs.UICertKeyPath = uiKey
+	if uiCert != "" {
+		if uiKey == "" {
+			return certificates{}, errors.New("--ui-cert-key needs to be specified if --ui-cert is specified")
+		}
+		cert, err := tls.LoadX509KeyPair(uiCert, uiKey)
+		if err != nil {
+			return certificates{}, errors.Wrap(err, "error parsing UI certificate")
+		}
+		certs.UICert = &cert
+	}
+
+	if caCert != "" {
+		data, err := ioutil.ReadFile(caCert)
+		if err != nil {
+			return certificates{}, errors.Wrap(err, "error reading CA cert")
+		}
+		block, rest := pem.Decode(data)
+		if len(rest) != 0 {
+			return certificates{}, errors.Newf("More than one certificate present in %s. Not sure how to deal with that.", caCert)
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return certificates{}, errors.Wrap(err, "error parsing CA cert")
+		}
+		certs.CAPool = x509.NewCertPool()
+		certs.CAPool.AddCert(cert)
+	}
+	return certs, nil
+}
+
+// atomicURL is a thread-safe URL.
+type atomicURL struct {
+	mu struct {
+		syncutil.Mutex // this could be a RWMutex, but it's not worth it as the critical sections are small
+		url            *url.URL
+	}
+}
+
+func newAtomicURL(url *url.URL) *atomicURL {
+	u := &atomicURL{}
+	u.mu.url = url
+	return u
+}
+
+func (u *atomicURL) Get() *url.URL {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.mu.url
+}
+
+func (u *atomicURL) ReplaceScheme(newScheme string) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.mu.url.Scheme = newScheme
+}
+
+// newProxy creates a proxy that can forward requests to a CRDB cluster
+// identified by url. If CRDB ever returns a redirect, then the redirect target
+// will be used by subsequent requests.
+//
+// caCerts, if not nil, specifies what CA is trusted to sign CRDB's certs. If
+// nil, the system defaults are used.
+//
+// HTTPToHTTPSErr, if set, will cause the proxy to detect when CRDB performs a
+// HTTP to HTTPS redirection and return this error instead of proceeding to talk
+// HTTPS to CRDB. The idea is that, if the Obs Service is not prepared to talk
+// HTTPS to its clients, but CRDB insists on talking HTTPS to its clients, we'd
+// rather return errors and ask people to configure the Obs Service for HTTPS
+// than downgrade the security that CRDB insists on.
+func newProxy(url *url.URL, caCerts *x509.CertPool, HTTPToHTTPSErr error) *httputil.ReverseProxy {
+	atomicTarget := newAtomicURL(url)
+	director := func(req *http.Request) {
+		target := atomicTarget.Get()
+		req.URL.Scheme = target.Scheme
+		req.URL.Host = target.Host
+		targetQuery := target.RawQuery
+		if targetQuery == "" || req.URL.RawQuery == "" {
+			req.URL.RawQuery = targetQuery + req.URL.RawQuery
+		} else {
+			req.URL.RawQuery = targetQuery + "&" + req.URL.RawQuery
+		}
+		if _, ok := req.Header["User-Agent"]; !ok {
+			// explicitly disable User-Agent so it's not set to default value
+			req.Header.Set("User-Agent", "")
+		}
+	}
+	modifyResponse := func(r *http.Response) error {
+		// We deal with redirects specifically: we detect when CRDB wants us to
+		// switch from HTTP to HTTPS and remember that.
+		if r.StatusCode != http.StatusTemporaryRedirect &&
+			r.StatusCode != http.StatusPermanentRedirect &&
+			r.StatusCode != http.StatusMovedPermanently {
+			return nil
+		}
+
+		// Check if CRDB is asking to switch from HTTP to HTTPS. If it is, switch
+		// future requests to use HTTPS.
+		redirectTarget := r.Header.Get("Location")
+		newURL, err := url.Parse(redirectTarget)
+		if err != nil {
+			return errors.Wrap(err, "invalid redirection")
+		}
+		if r.Request.URL.Scheme != newURL.Scheme {
+			if r.Request.URL.Scheme == "http" && newURL.Scheme == "https" {
+				// If we're not prepared to server HTTPS, error out.
+				if HTTPToHTTPSErr != nil {
+					return HTTPToHTTPSErr
+				}
+			}
+			// From now on, go to https directly.
+			atomicTarget.ReplaceScheme(newURL.Scheme)
+			// We'll continue returning this redirect to the client. It will appear to
+			// the client as a redirection to the same URL that it already requested;
+			// that's fine. On the retry, we'll forward to the updated CRDB url.
+		}
+		return nil
+	}
+	proxy := &httputil.ReverseProxy{
+		Director:       director,
+		ModifyResponse: modifyResponse,
+		// Overwrite the default error handler so that we render errors produced by
+		// ModifyResponse. The default handler only logs them on the server and
+		// doesn't return them to the client.
+		ErrorHandler: func(rw http.ResponseWriter, req *http.Request, err error) {
+			rw.WriteHeader(http.StatusInternalServerError)
+			_, _ = rw.Write([]byte(err.Error()))
+		},
+	}
+	if caCerts != nil {
+		// Accept only the specified roots.
+		proxy.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: caCerts,
+			},
+			TLSHandshakeTimeout: 10 * time.Second,
+		}
+	}
+	return proxy
+}

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -194,6 +194,15 @@ func TestLint(t *testing.T) {
 //     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
 `)
 
+		apacheHeader := regexp.MustCompile(`// Copyright 20\d\d The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 \(the "License"\);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+`)
+
 		// These extensions identify source files that should have copyright headers.
 		extensions := []string{
 			"*.go", "*.cc", "*.h", "*.js", "*.ts", "*.tsx", "*.s", "*.S", "*.styl", "*.proto", "*.rl",
@@ -219,14 +228,6 @@ func TestLint(t *testing.T) {
 			stream.GrepNot(`geo/geographiclib/geodesic\.c$`),
 			stream.GrepNot(`geo/geographiclib/geodesic\.h$`),
 		), func(filename string) {
-			isCCL := strings.Contains(filename, "ccl/")
-			var expHeader *regexp.Regexp
-			if isCCL {
-				expHeader = cclHeader
-			} else {
-				expHeader = bslHeader
-			}
-
 			file, err := os.Open(filepath.Join(pkgDir, filename))
 			if err != nil {
 				t.Error(err)
@@ -240,8 +241,30 @@ func TestLint(t *testing.T) {
 			}
 			data = data[0:n]
 
-			if expHeader.Find(data) == nil {
-				t.Errorf("did not find expected license header (ccl=%v) in %s", isCCL, filename)
+			isCCL := strings.Contains(filename, "ccl/")
+			isApache := strings.HasPrefix(filename, "obsservice")
+			switch {
+			case isCCL:
+				if cclHeader.Find(data) == nil {
+					t.Errorf("did not find expected CCL license header in %s", filename)
+				}
+			case isApache:
+				if apacheHeader.Find(data) == nil {
+					t.Errorf("did not find expected Apache license header in %s", filename)
+				}
+			default:
+				if bslHeader.Find(data) == nil {
+					t.Errorf("did not find expected BSL license header in %s", filename)
+				}
+			}
+			if isCCL {
+				if cclHeader.Find(data) == nil {
+					t.Errorf("did not find expected license header (ccl=%t) in %s", isCCL, filename)
+				}
+			} else {
+				if bslHeader.Find(data) == nil && apacheHeader.Find(data) == nil {
+					t.Errorf("did not find expected license header (ccl=%t) in %s", isCCL, filename)
+				}
 			}
 		}); err != nil {
 			t.Fatal(err)
@@ -1665,6 +1688,10 @@ func TestLint(t *testing.T) {
 				stream.GrepNot("pkg/sql/oidext/oidext.go.*don't use underscores in Go names; const T_"),
 				stream.GrepNot("server/api_v2.go.*package comment should be of the form"),
 				stream.GrepNot("pkg/util/timeutil/time_zone_util.go.*error strings should not be capitalized or end with punctuation or a newline"),
+
+				// The Observability Service doesn't want this blunt rule.
+				stream.GrepNot("pkg/obsservice.*error strings should not be capitalized or end with punctuation or a newline"),
+
 				stream.GrepNot("pkg/sql/job_exec_context_test_util.go.*exported method ExtendedEvalContext returns unexported type"),
 				stream.GrepNot("pkg/sql/job_exec_context_test_util.go.*exported method SessionDataMutatorIterator returns unexported type"),
 


### PR DESCRIPTION
These are the humble beginnings of an Observability Service for CRDB. In
time, this is meant to take over a lot of the observability
functionality, extracting it from the database itself. For now, all
there is here is an HTTP reverse proxy, able to route HTTP requests to a
CRDB node (or cluster, through a load balancer). At least for the
transitioning period, if not forever, the Obs Service will route HTTP
paths that it doesn't understand to the Cockroach cluster being
monitored.

The HTTP proxy accepts its own certificates and can serve HTTPS
independently of CRDB (which might be running in --insecure mode and not
serving HTTPS). However, if CRDB is serving HTTPS, then the Obs Service
must also be configured with a certificate so it can also serve HTTPS.

The code of the Obs Service is split in between a binary (minimal
shell), and a library. The idea is to keep the door open for other repos
to extend the Obs Service with extra functionality (e.g. the CC managed
service might want to add cloud-specific observability features). For
such purposes, I've considered making a dedicated Go module for the Obs
Service so that source-level imports of the Obs Service would be as
ergonomic as Go wants them to be. I've put a decent amount of work in
playing with this but, ultimately, I've decided against it, at least for
now. The problem is that the Obs Service wants to take minor code
dependencies on random CRDB libraries (syncutil, log, etc.) and the
cockroach Go module is fairly broken (our git tags look like we do
semantic versioning, but we don't actually do it). The go tooling has a
terrible time with the cockroach module. Also, our code is generally not
`go build`-able. If the obs service was a dedicated module, it would
need to take a dependency on the cockroach module, which would negate
the win for people who want to import it (in fact, it'd make matters
worse for importers because the nasty cockroach dependency would be more
hidden). An alternative I've considered was to start creating modules
for all of the dependencies of the Obs Service. But, if CRDB would then
need to depend on these modules, there's all sorts of problems.

Release note: None