### PR TITLE
sql: tests (and bugfix) for ? acceleration

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -1109,7 +1109,8 @@ INSERT INTO e VALUES
   (10, '3'),
   (11, NULL),
   (12, 'null'),
-  (13, 'true')
+  (13, 'true'),
+  (14, '{"aargh": 3, "b": 2, "c": 3}')
 
 query T
 SELECT j FROM e@i WHERE j ? 'a' ORDER BY k
@@ -1128,6 +1129,7 @@ SELECT j FROM e@i WHERE j ? 'aargh' OR j->'b' @> '{"a": "c"}' ORDER BY k
 ----
 {"b": {"a": "c"}}
 ["aargh"]
+{"aargh": 3, "b": 2, "c": 3}
 
 query T
 SELECT j FROM e@i WHERE j ?& ARRAY['a', 'b'] ORDER BY k
@@ -1148,6 +1150,7 @@ SELECT j FROM e@i WHERE j ?| ARRAY['a', 'b'] ORDER BY k
 ["b", "a", "c"]
 ["a"]
 "a"
+{"aargh": 3, "b": 2, "c": 3}
 
 subtest arrays
 

--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -872,3 +872,15 @@ query B
 SELECT json_valid(NULL)
 ----
 NULL
+
+# Regression tests for #81647 (false negatives for ? operator in some cases).
+subtest regression_81647
+
+statement ok
+CREATE TABLE t81647(j JSON);
+INSERT INTO t81647 VALUES ('["a", "b"]')
+
+query TBTB
+SELECT j, j ? 'a', j-1, (j-1) ? 'a' FROM t81647
+----
+["a", "b"]  true  ["a"]  true

--- a/pkg/sql/opt/invertedidx/json_array_test.go
+++ b/pkg/sql/opt/invertedidx/json_array_test.go
@@ -707,6 +707,49 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 			remainingFilters: "",
 		},
 		{
+			// JSONExists is supported. Unique is false for all Exists predicates
+			// because they check containment within arrays as well.
+			filters:          "j ? 'foo'",
+			indexOrd:         jsonOrd,
+			ok:               true,
+			tight:            true,
+			unique:           false,
+			remainingFilters: "",
+		},
+		{
+			// JSONSomeExists is supported.
+			filters:          "j ?| ARRAY['foo','bar']",
+			indexOrd:         jsonOrd,
+			ok:               true,
+			tight:            true,
+			unique:           false,
+			remainingFilters: "",
+		},
+		{
+			// JSONAllExists is supported.
+			filters:          "j ?& ARRAY['foo','bar']",
+			indexOrd:         jsonOrd,
+			ok:               true,
+			tight:            true,
+			unique:           false,
+			remainingFilters: "",
+		},
+		{
+			// JSONExists with boolean expressions are supported.
+			filters:          "j ?& ARRAY['foo','bar'] AND j ? 'qux' OR j ?| ARRAY['a','b']",
+			indexOrd:         jsonOrd,
+			ok:               true,
+			tight:            true,
+			unique:           false,
+			remainingFilters: "",
+		},
+		{
+			// FetchVal + Exists isn't supported yet.
+			filters:  "j->'foo' ? 'bar'",
+			indexOrd: jsonOrd,
+			ok:       false,
+		},
+		{
 			// Overlaps is supported for arrays.
 			// Overlaps with a single element array produces
 			// unique inverted span expression.

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -821,6 +821,11 @@ func AddJSONPathTerminator(b []byte) []byte {
 	return append(b, escape, escapedTerm)
 }
 
+// AddJSONPathSeparator adds a json path separator to a byte array.
+func AddJSONPathSeparator(b []byte) []byte {
+	return append(b, escape, escapedJSONObjectKeyTerm)
+}
+
 // EncodeJSONEmptyObject returns a byte array b with a byte to signify an empty JSON object.
 func EncodeJSONEmptyObject(b []byte) []byte {
 	return append(b, escape, escapedTerm, jsonEmptyObject)

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -2249,8 +2249,15 @@ func (j jsonString) Exists(s string) (bool, error) {
 
 func (j jsonArray) Exists(s string) (bool, error) {
 	for i := 0; i < len(j); i++ {
-		if elem, ok := j[i].(jsonString); ok && string(elem) == s {
-			return true, nil
+		switch elem := j[i].(type) {
+		case jsonString:
+			if string(elem) == s {
+				return true, nil
+			}
+		case *jsonEncoded:
+			if elem.typ == StringJSONType && string(elem.value) == s {
+				return true, nil
+			}
 		}
 	}
 	return false, nil

--- a/pkg/util/json/json_test.go
+++ b/pkg/util/json/json_test.go
@@ -1720,6 +1720,112 @@ func TestEncodeContainedJSONInvertedIndexSpans(t *testing.T) {
 	}
 }
 
+func TestEncodeExistsJSONInvertedIndexSpans(t *testing.T) {
+	testCases := []struct {
+		indexedValue string
+		value        string
+		expected     bool
+	}{
+		// This test uses EncodeInvertedIndexKeys and EncodeExistsInvertedIndexSpans
+		// to determine if the spans produced from the string key will include or
+		// excludes the keys produced by the JSON value, indicated by exists.
+		// Then, if indexedValue ? value, expected is true.
+
+		// First we test that the spans will include expected results.
+		{`{"a": "a"}`, `a`, true},
+		{`{"a": null}`, `a`, true},
+		{`{"a": []}`, `a`, true},
+		{`{"a": {}}`, `a`, true},
+		{`{"a": 3}`, `a`, true},
+		{`["a"]`, `a`, true},
+		{`["a", "a"]`, `a`, true},
+		{`["b", "a"]`, `a`, true},
+		{`"a"`, `a`, true},
+
+		// Test negative cases.
+		// The number 1 doesn't have key string-1.
+		{`1`, `1`, false},
+		// Null doesn't have key string-null.
+		{`null`, `null`, false},
+		// [] doesn't have key string-null.
+		{`[]`, `null`, false},
+		{`["a"]`, `argh`, false},
+		{`["argh"]`, `a`, false},
+		{`{}`, `null`, false},
+		{`{}`, `a`, false},
+		{`{"a":"a"}`, `argh`, false},
+		{`{"argh":"a"}`, `a`, false},
+	}
+
+	runTest := func(indexedValue JSON, value string, expected bool) {
+		keys, err := EncodeInvertedIndexKeys(nil, indexedValue)
+		require.NoError(t, err)
+
+		invertedExpr, err := EncodeExistsInvertedIndexSpans(nil, value)
+		require.NoError(t, err)
+
+		spanExpr, ok := invertedExpr.(*inverted.SpanExpression)
+		if !ok {
+			t.Fatalf("invertedExpr %v is not a SpanExpression", invertedExpr)
+		}
+
+		// Spans should always be tight for exists.
+		if !spanExpr.Tight {
+			t.Errorf("For %s, expected tight=true, but got false", value)
+		}
+
+		// Spans should never be unique for exists.
+		if spanExpr.Unique {
+			t.Errorf("For %s, expected unique=false, but got true", value)
+		}
+
+		containsKeys, err := spanExpr.ContainsKeys(keys)
+		require.NoError(t, err)
+
+		if containsKeys != expected {
+			if expected {
+				t.Errorf("expected spans of %s to include %s but they did not", value, indexedValue)
+			} else {
+				t.Errorf("expected spans of %s not to include %s but they did", value, indexedValue)
+			}
+		}
+	}
+
+	// Run pre-defined test cases from above.
+	for _, c := range testCases {
+		indexedValue, value := jsonTestShorthand(c.indexedValue), c.value
+
+		// First check that evaluating `indexedValue ? value` matches the expected
+		// result.
+		actual, err := indexedValue.Exists(value)
+		require.NoError(t, err)
+		if actual != c.expected {
+			t.Fatalf(
+				"expected value of %s ? %s did not match actual value. Expected: %v. Got: %v",
+				c.indexedValue, c.value, c.expected, actual,
+			)
+		}
+		runTest(indexedValue, value, c.expected)
+	}
+
+	// Run a set of randomly generated test cases.
+	rng, _ := randutil.NewTestRand()
+	for i := 0; i < 100; i++ {
+		// Generate two random JSONs and evaluate the result of `left ? right`.
+		left, err := Random(20, rng)
+		require.NoError(t, err)
+		right := randomJSONString(rng).(string)
+		require.NoError(t, err)
+
+		var exists bool
+		exists, err = left.Exists(right)
+		require.NoError(t, err)
+
+		// Now check that we get the same result with the inverted index spans.
+		runTest(left, right, exists)
+	}
+}
+
 func TestNumInvertedIndexEntries(t *testing.T) {
 	testCases := []struct {
 		value    string

--- a/pkg/util/json/json_test.go
+++ b/pkg/util/json/json_test.go
@@ -803,6 +803,30 @@ func TestJSONExists(t *testing.T) {
 			})
 		}
 	}
+
+	// Run a set of randomly generated test cases.
+	rng, _ := randutil.NewTestRand()
+	for i := 0; i < 100; i++ {
+		left, err := Random(20, rng)
+		require.NoError(t, err)
+		right := randomJSONString(rng).(string)
+		require.NoError(t, err)
+
+		var exists bool
+		exists, err = left.Exists(right)
+		require.NoError(t, err)
+
+		// Test that we get the same result with the encoded form of the JSON.
+		b, err := EncodeJSON(nil, left)
+		require.NoError(t, err)
+		j, err := FromEncoding(b)
+		require.NoError(t, err)
+
+		existsEncoded, err := j.Exists(right)
+		require.NoError(t, err)
+
+		require.Equal(t, exists, existsEncoded, "expected encoded/non-encoded Exists to match but didn't: %s %s", left, right)
+	}
 }
 
 func TestJSONStripNulls(t *testing.T) {


### PR DESCRIPTION
This commit adds more unit testing for ? acceleration, and fixes a bug
that wasn't caught by existing tests: a ? search against an object that
contains a key that has the search term as a prefix was incorrectly
returning that object.

The bug is fixed by using a more precise span to search: instead of
searching for all keys with the search key as a prefix, search for the
span that starts with the search key and ends with PrefixEnd of the
search key plus the path separator. This includes only keys that are
precisely the search key (in the case of keys that point to empty
objects or arrays) or keys that don't end an object path (due to the
separator after them).

Release note: None (bug was not in released version)