### PR TITLE
json: bugfix to jsonArray.Exists

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -872,3 +872,15 @@ query B
 SELECT json_valid(NULL)
 ----
 NULL
+
+# Regression tests for #81647 (false negatives for ? operator in some cases).
+subtest regression_81647
+
+statement ok
+CREATE TABLE t81647(j JSON);
+INSERT INTO t81647 VALUES ('["a", "b"]')
+
+query TBTB
+SELECT j, j ? 'a', j-1, (j-1) ? 'a' FROM t81647
+----
+["a", "b"]  true  ["a"]  true

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -2249,8 +2249,15 @@ func (j jsonString) Exists(s string) (bool, error) {
 
 func (j jsonArray) Exists(s string) (bool, error) {
 	for i := 0; i < len(j); i++ {
-		if elem, ok := j[i].(jsonString); ok && string(elem) == s {
-			return true, nil
+		switch elem := j[i].(type) {
+		case jsonString:
+			if string(elem) == s {
+				return true, nil
+			}
+		case *jsonEncoded:
+			if elem.typ == StringJSONType && string(elem.value) == s {
+				return true, nil
+			}
 		}
 	}
 	return false, nil

--- a/pkg/util/json/json_test.go
+++ b/pkg/util/json/json_test.go
@@ -803,6 +803,30 @@ func TestJSONExists(t *testing.T) {
 			})
 		}
 	}
+
+	// Run a set of randomly generated test cases.
+	rng, _ := randutil.NewTestRand()
+	for i := 0; i < 100; i++ {
+		left, err := Random(20, rng)
+		require.NoError(t, err)
+		right := randomJSONString(rng).(string)
+		require.NoError(t, err)
+
+		var exists bool
+		exists, err = left.Exists(right)
+		require.NoError(t, err)
+
+		// Test that we get the same result with the encoded form of the JSON.
+		b, err := EncodeJSON(nil, left)
+		require.NoError(t, err)
+		j, err := FromEncoding(b)
+		require.NoError(t, err)
+
+		existsEncoded, err := j.Exists(right)
+		require.NoError(t, err)
+
+		require.Equal(t, exists, existsEncoded, "expected encoded/non-encoded Exists to match but didn't: %s %s", left, right)
+	}
 }
 
 func TestJSONStripNulls(t *testing.T) {


### PR DESCRIPTION
Closes #81647

Previously, the JSON Exists method (the `?` operator in SQL) could
return false negatives if invoked on a JSON array that had been
shallowDecoded to a single level.

Release note (bug fix): fix false negatives produced by the JSON `?`
operator when invoked on a JSON array with the vectorized engine set
explicitly to off.