### PR TITLE
tests: don't call log.Fatal in ruby test

### DIFF
--- a/pkg/cmd/roachtest/tests/ruby_pg.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -195,7 +194,7 @@ func registerRubyPG(r registry.Registry) {
 				continue
 			}
 			if len(match) != 1 {
-				log.Fatalf(ctx, "expected one match for test name, found: %d", len(match))
+				t.Fatalf("expected one match for test name, found: %d", len(match))
 			}
 
 			// Take the first test name.
@@ -206,7 +205,7 @@ func registerRubyPG(r registry.Registry) {
 			// ie. test.rb:99 # TEST NAME.
 			strs := testFailureFilenameRegexp.Split(test, -1)
 			if len(strs) != 2 {
-				log.Fatalf(ctx, "expected test output line to be split into two strings")
+				t.Fatalf("expected test output line to be split into two strings")
 			}
 			test = strs[1]
 
@@ -229,7 +228,7 @@ func registerRubyPG(r registry.Registry) {
 		}
 
 		if totalTests == 0 {
-			log.Fatalf(ctx, "failed to find total number of tests run")
+			t.Fatalf("failed to find total number of tests run")
 		}
 		totalPasses := int(totalTests) - (results.failUnexpectedCount + results.failExpectedCount)
 		results.passUnexpectedCount = len(expectedFailures) - results.failExpectedCount


### PR DESCRIPTION
This was killing our nightly suit half-way through a few nights in a
row. We need to work on blocklisting import of the `log` package into
roachtest.

Release note: None
