### PR TITLE
release-21.1: acceptance: run `python`, `psql` containers as current uid

### DIFF
--- a/pkg/acceptance/cluster/certs.go
+++ b/pkg/acceptance/cluster/certs.go
@@ -23,7 +23,11 @@ import (
 
 const certsDir = ".localcluster.certs"
 
-// keyLen is the length (in bits) of the generated CA and node certs.
+// keyLen is the length (in bits) of the generated TLS certs.
+//
+// This needs to be at least 2048 since the newer versions of openssl
+// (used by some tests) produce an error 'ee key too small' for
+// smaller values.
 const keyLen = 2048
 
 // GenerateCerts generates CA and client certificates and private keys to be
@@ -39,12 +43,12 @@ func GenerateCerts(ctx context.Context) func() {
 	// Root user.
 	maybePanic(security.CreateClientPair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
-		1024, 48*time.Hour, false, security.RootUserName(), true /* generate pk8 key */))
+		keyLen, 48*time.Hour, false, security.RootUserName(), true /* generate pk8 key */))
 
 	// Test user.
 	maybePanic(security.CreateClientPair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
-		1024, 48*time.Hour, false, security.TestUserName(), true /* generate pk8 key */))
+		keyLen, 48*time.Hour, false, security.TestUserName(), true /* generate pk8 key */))
 
 	// Certs for starting a cockroach server. Key size is from cli/cert.go:defaultKeySize.
 	maybePanic(security.CreateNodePair(

--- a/pkg/acceptance/compose/gss/docker-compose-python.yml
+++ b/pkg/acceptance/compose/gss/docker-compose-python.yml
@@ -18,6 +18,7 @@ services:
       - ../../../../cockroach-linux-2.6.32-gnu-amd64:/cockroach/cockroach
   python:
     build: ./python
+    user: "${UID}:${GID}"
     depends_on:
       - cockroach
     command: /start.sh

--- a/pkg/acceptance/compose/gss/docker-compose.yml
+++ b/pkg/acceptance/compose/gss/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - ../../../../cockroach-linux-2.6.32-gnu-amd64:/cockroach/cockroach
   psql:
     build: ./psql
+    user: "${UID}:${GID}"
     depends_on:
       - cockroach
     environment:

--- a/pkg/acceptance/compose/gss/psql/Dockerfile
+++ b/pkg/acceptance/compose/gss/psql/Dockerfile
@@ -10,8 +10,15 @@ FROM postgres:11
 
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+  ca-certificates \
+  curl \
   krb5-user
 
 COPY --from=builder /workspace/gss.test .
 
-ENTRYPOINT ["/start.sh"]
+RUN curl -fsSL "https://github.com/benesch/autouseradd/releases/download/1.3.0/autouseradd-1.3.0-amd64.tar.gz" -o autouseradd.tar.gz \
+  && echo "442dae58b727a79f81368127fac141d7f95501ffa05f8c48943d27c4e807deb7 autouseradd.tar.gz" | sha256sum -c - \
+  && tar xzf autouseradd.tar.gz --strip-components 1 \
+  && rm autouseradd.tar.gz
+
+ENTRYPOINT ["autouseradd", "--user", "roach", "--no-create-home", "/start.sh"]

--- a/pkg/acceptance/compose/gss/psql/gss_test.go
+++ b/pkg/acceptance/compose/gss/psql/gss_test.go
@@ -35,7 +35,7 @@ func init() {
 }
 
 func TestGSS(t *testing.T) {
-	connector, err := pq.NewConnector("user=root sslmode=require")
+	connector, err := pq.NewConnector("user=root password=rootpw sslmode=require")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/acceptance/compose/gss/psql/start.sh
+++ b/pkg/acceptance/compose/gss/psql/start.sh
@@ -4,4 +4,11 @@ set -e
 
 echo psql | kinit tester@MY.EX
 
+echo "Preparing SQL user ahead of test"
+env \
+    PGSSLKEY=/certs/client.root.key \
+    PGSSLCERT=/certs/client.root.crt \
+    psql -U root -c "ALTER USER root WITH PASSWORD rootpw"
+
+echo "Running test"
 ./gss.test

--- a/pkg/acceptance/compose/gss/python/Dockerfile
+++ b/pkg/acceptance/compose/gss/python/Dockerfile
@@ -5,11 +5,19 @@ RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-k
   echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" | tee  /etc/apt/sources.list.d/pgdg.list && \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+  curl \
   krb5-user \
   postgresql-client-11
+
+RUN curl -fsSL "https://github.com/benesch/autouseradd/releases/download/1.3.0/autouseradd-1.3.0-amd64.tar.gz" -o autouseradd.tar.gz \
+  && echo "442dae58b727a79f81368127fac141d7f95501ffa05f8c48943d27c4e807deb7 autouseradd.tar.gz" | sha256sum -c - \
+  && tar xzf autouseradd.tar.gz --strip-components 1 \
+  && rm autouseradd.tar.gz
 
 RUN mkdir /code
 WORKDIR /code
 COPY requirements.txt /code/
 RUN pip install -r requirements.txt
 COPY . /code/
+
+ENTRYPOINT ["autouseradd", "--user", "roach", "--no-create-home", "/start.sh"]

--- a/pkg/acceptance/compose/gss/python/start.sh
+++ b/pkg/acceptance/compose/gss/python/start.sh
@@ -2,10 +2,18 @@
 
 set -e
 
+echo psql | kinit tester@MY.EX
+
+export PGSSLKEY=/certs/client.root.key
+export PGSSLCERT=/certs/client.root.crt
+export PGUSER=root
+
 psql -c "SET CLUSTER SETTING server.host_based_authentication.configuration = 'host all all all gss include_realm=0'"
 psql -c "CREATE USER tester"
 
-echo psql | kinit tester@MY.EX
+unset PGSSLKEY
+unset PGSSLCERT
+export PGUSER=tester
 
 # Exit with error unless we find the expected error message.
 python manage.py inspectdb 2>&1 | grep 'use of GSS authentication requires an enterprise license'

--- a/pkg/acceptance/compose_test.go
+++ b/pkg/acceptance/compose_test.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"testing"
 )
 
@@ -32,6 +33,16 @@ func TestComposeFlyway(t *testing.T) {
 }
 
 func testCompose(t *testing.T, path string, exitCodeFrom string) {
+	uid := os.Getuid()
+	err := os.Setenv("UID", strconv.Itoa(uid))
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	gid := os.Getgid()
+	err = os.Setenv("GID", strconv.Itoa(gid))
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
 	cmd := exec.Command(
 		"docker-compose",
 		"--no-ansi",


### PR DESCRIPTION
Manual cherry-pick from #81460.

`postgres`'s permission checking for certificates has gotten more
rigorous since [this commit](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=a59c79564bdc209a5bc7b02d706f0d7352eb82fa).
This has broken a couple `acceptance` tests which do not pin to any
specific `postgres` version (see #81313, #81437).

Here we attempt to solve the problem "once and for all" by ensuring that
these containers run with a UID that is equal to the one that created
the certificates.

Release note: None
Release justification: Test-only change