### PR TITLE
sql: enforce nullability when evaluating expressions in index backfills

### DIFF
--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -847,6 +847,11 @@ func (ib *IndexBackfiller) BuildIndexEntriesChunk(
 					colID, tableDesc.GetID(),
 				)
 			}
+			// Note that if this is a computed expr which is not being added,
+			// then this should generally be an assertion failure.
+			if val == tree.DNull && !cols[i].IsNullable() {
+				return sqlerrors.NewNonNullViolationError(cols[i].GetName())
+			}
 			ib.rowVals[colIdx] = val
 		}
 		return nil

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -2563,3 +2563,33 @@ tbl  CREATE TABLE public.tbl (
      j INT8 NOT NULL DEFAULT nextval('public.s2'::REGCLASS) ON UPDATE nextval('public.s1'::REGCLASS),
      CONSTRAINT tbl_pkey PRIMARY KEY (i ASC)
 )
+
+# Verify that adding not-null physical column with a default or computed expression
+# fails if the expression evaluates to NULL.
+subtest add_column_not_null
+
+statement ok
+CREATE TABLE t_add_column_not_null (i INT PRIMARY KEY);
+INSERT INTO t_add_column_not_null VALUES (1), (2), (3)
+
+statement error pgcode 23502 null value in column "j" violates not-null constraint
+ALTER TABLE t_add_column_not_null ADD COLUMN j INT NOT NULL DEFAULT (NULL:::INT)
+
+statement error pgcode 23502 null value in column "j" violates not-null constraint
+ALTER TABLE t_add_column_not_null ADD COLUMN j INT GENERATED ALWAYS AS (NULL:::INT) STORED NOT NULL;
+
+# Note that the UNIQUE here leads to a secondary index being built which will fail.
+statement error pgcode 23502 null value in column "j" violates not-null constraint
+ALTER TABLE t_add_column_not_null ADD COLUMN j INT GENERATED ALWAYS AS (NULL::INT) VIRTUAL NOT NULL UNIQUE;
+
+# Note that this should absolutely not succeed, but it does because of #81675.
+# We'll rely on that in order to test that the subsequent index build fails.
+# When addressing #81675, this portion of this test will need to be removed.
+statement ok
+ALTER TABLE t_add_column_not_null ADD COLUMN j INT GENERATED ALWAYS AS (NULL::INT) VIRTUAL NOT NULL;
+
+statement error pgcode 23502 null value in column "j" violates not-null constraint
+CREATE INDEX idx_j ON t_add_column_not_null (j);
+
+statement ok
+DROP TABLE t_add_column_not_null


### PR DESCRIPTION
Prior to this change, we never enforced nullability of values when performing
index backfills. Up until #76983, all column additions used the legacy schema
changer and its column backfill protocol. The column backfiller indeed checks
on nullability violations for columns [here](https://github.com/cockroachdb/cockroach/blob/d5313438aaa61a71a5a66c5718963bbb0fd7268b/pkg/sql/backfill/backfill.go#L355-L357).

Release note (bug fix): Prior to this change, virtual computed columns which
were marked as NOT NULL could be added to new secondary index. After this
change, attempts to add such columns to a secondary index will result in an
error. Note that such invalid columns can still be added to tables. Work to
resolve that bug is tracked in #81675.