### PR TITLE
colexecwindow: fix panic when lead or lag arguments are different types

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -1206,36 +1206,39 @@ func NewColOperator(
 				// We allocate the capacity for two extra types because of the temporary
 				// columns that can be appended below. Capacity is also allocated for
 				// each of the argument types in case casting is necessary.
-				typs := make([]*types.T, len(result.ColumnTypes), len(result.ColumnTypes)+len(wf.ArgsIdxs)+2)
+				numInputCols := len(result.ColumnTypes)
+				typs := make([]*types.T, numInputCols, numInputCols+len(wf.ArgsIdxs)+2)
 				copy(typs, result.ColumnTypes)
 
 				// Set any nil values in the window frame to their default values.
 				wf.Frame = colexecwindow.NormalizeWindowFrame(wf.Frame)
 
-				tempColOffset := uint32(0)
-				argTypes := make([]*types.T, len(wf.ArgsIdxs))
+				// Copy the argument indices into a mutable slice.
 				argIdxs := make([]int, len(wf.ArgsIdxs))
+				argTypes := make([]*types.T, len(wf.ArgsIdxs))
 				for i, idx := range wf.ArgsIdxs {
-					// Retrieve the type of each argument and perform any necessary casting.
-					needsCast, expectedType := colexecwindow.WindowFnArgNeedsCast(wf.Func, typs[idx], i)
-					if needsCast {
-						// We must cast to the expected argument type.
-						castIdx := len(typs)
-						input, err = colexecbase.GetCastOperator(
-							getStreamingAllocator(ctx, args), input, int(idx),
-							castIdx, typs[idx], expectedType, flowCtx.EvalCtx,
-						)
-						if err != nil {
-							colexecerror.InternalError(errors.AssertionFailedf(
-								"failed to cast window function argument to type %v", expectedType))
-						}
-						typs = append(typs, expectedType)
-						idx = uint32(castIdx)
-						tempColOffset++
-					}
-					argTypes[i] = expectedType
 					argIdxs[i] = int(idx)
+					argTypes[i] = typs[idx]
 				}
+
+				// Perform any necessary casts for the argument columns.
+				castTo := colexecwindow.WindowFnArgCasts(wf.Func, argTypes)
+				for i, typ := range castTo {
+					if typ == nil {
+						continue
+					}
+					castIdx := len(typs)
+					input, err = colexecbase.GetCastOperator(
+						getStreamingAllocator(ctx, args), input, argIdxs[i],
+						castIdx, argTypes[i], typ, flowCtx.EvalCtx,
+					)
+					if err != nil {
+						colexecerror.InternalError(err)
+					}
+					typs = append(typs, typ)
+					argIdxs[i] = castIdx
+				}
+
 				partitionColIdx := tree.NoColumnIdx
 				peersColIdx := tree.NoColumnIdx
 
@@ -1244,7 +1247,7 @@ func NewColOperator(
 					// (probably by leveraging hash routers once we can
 					// distribute). The decision about which kind of partitioner
 					// to use should come from the optimizer.
-					partitionColIdx = int(wf.OutputColIdx + tempColOffset)
+					partitionColIdx = len(typs)
 					input = colexecwindow.NewWindowSortingPartitioner(
 						getStreamingAllocator(ctx, args), input, typs,
 						core.Windower.PartitionBy, wf.Ordering.Columns, partitionColIdx,
@@ -1257,9 +1260,7 @@ func NewColOperator(
 						},
 					)
 					// Window partitioner will append a boolean column.
-					tempColOffset++
-					typs = typs[:len(typs)+1]
-					typs[len(typs)-1] = types.Bool
+					typs = append(typs, types.Bool)
 				} else {
 					if len(wf.Ordering.Columns) > 0 {
 						input = result.createDiskBackedSort(
@@ -1270,17 +1271,17 @@ func NewColOperator(
 					}
 				}
 				if colexecwindow.WindowFnNeedsPeersInfo(&wf) {
-					peersColIdx = int(wf.OutputColIdx + tempColOffset)
+					peersColIdx = len(typs)
 					input = colexecwindow.NewWindowPeerGrouper(
 						getStreamingAllocator(ctx, args), input, typs,
 						wf.Ordering.Columns, partitionColIdx, peersColIdx,
 					)
 					// Window peer grouper will append a boolean column.
-					tempColOffset++
-					typs = typs[:len(typs)+1]
-					typs[len(typs)-1] = types.Bool
+					typs = append(typs, types.Bool)
 				}
-				outputIdx := int(wf.OutputColIdx + tempColOffset)
+
+				// The output column is appended after any temporary columns.
+				outputColIdx := len(typs)
 
 				windowArgs := &colexecwindow.WindowArgs{
 					EvalCtx:         flowCtx.EvalCtx,
@@ -1289,7 +1290,7 @@ func NewColOperator(
 					FdSemaphore:     args.FDSemaphore,
 					Input:           input,
 					InputTypes:      typs,
-					OutputColIdx:    outputIdx,
+					OutputColIdx:    outputColIdx,
 					PartitionColIdx: partitionColIdx,
 					PeersColIdx:     peersColIdx,
 				}
@@ -1435,16 +1436,17 @@ func NewColOperator(
 					result.ToClose = append(result.ToClose, c)
 				}
 
-				if tempColOffset > 0 {
-					// We want to project out temporary columns (which have
-					// indices in the range [wf.OutputColIdx,
-					// wf.OutputColIdx+tempColOffset)).
-					projection := make([]uint32, 0, wf.OutputColIdx+tempColOffset)
-					for i := uint32(0); i < wf.OutputColIdx; i++ {
-						projection = append(projection, i)
+				if outputColIdx > numInputCols {
+					// We want to project out temporary columns (which have been added in
+					// between the input columns and output column) as well as include the
+					// new output column (which is located after any temporary columns).
+					numOutputCols := numInputCols + 1
+					projection := make([]uint32, numOutputCols)
+					for i := 0; i < numInputCols; i++ {
+						projection[i] = uint32(i)
 					}
-					projection = append(projection, wf.OutputColIdx+tempColOffset)
-					result.Root = colexecbase.NewSimpleProjectOp(result.Root, int(wf.OutputColIdx+tempColOffset), projection)
+					projection[numInputCols] = uint32(outputColIdx)
+					result.Root = colexecbase.NewSimpleProjectOp(result.Root, numOutputCols, projection)
 				}
 
 				result.ColumnTypes = appendOneType(result.ColumnTypes, returnType)

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -4338,3 +4338,10 @@ FROM t74087 WINDOW w AS (ORDER BY _int4);
 3  3  1  3  3  1  3  3  3  0.5   0.6  1
 4  4  1  4  4  1  4  4  4  0.75  0.8  1
 5  5  1  5  5  1  5  5  5  1     1    1
+
+# Regression test for panic in the vectorized engine when the first and third
+# arguments of lead or lag are different (but castable) types (#81285).
+query I
+SELECT lead(x, 10, y::INT4) OVER () FROM (VALUES (1, 2)) v(x, y);
+----
+2


### PR DESCRIPTION
This commit fixes an oversight in the planning code for lead and lag window
function operators, where calling `lead` or `lag` with different types for
the first and third arguments caused a panic during execution. According to
the spec for `lead` and `lag`, the `value` and `default` (first and third)
arguments can be different types as long as they are compatible. We now avoid
the panic by attempting to cast the third argument to the type of the first
argument in the case when they are different types.

Example of a query that would trigger the panic:
```
SELECT lead(x, 2, y::INT4) OVER () FROM (VALUES (1, 2)) v(x, y);
```

Fixes #81285

Release note (bug fix): Previously CockroachDB would encounter an
internal error when executing queries with lead or lag window functions
when the default argument had a different type than the first argument.