### PR TITLE
cloud: remove deprecated arg from configmap

### DIFF
--- a/cloud/kubernetes/multiregion/eks/configmap.yaml
+++ b/cloud/kubernetes/multiregion/eks/configmap.yaml
@@ -11,7 +11,6 @@ data:
        health
        kubernetes cluster.local in-addr.arpa ip6.arpa {
             pods insecure
-            upstream
             fallthrough in-addr.arpa ip6.arpa
        }
        prometheus :9153


### PR DESCRIPTION
Previously we used the `upstream` argument for coredns but it has since
been deprecated so we can remove it. This PR accomplishes that.

Release note: None