### PR TITLE
release-21.2: changefeedccl: tolerate "no inbound stream connection" error

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/settings",
         "//pkg/sql",
         "//pkg/sql/catalog",
+        "//pkg/sql/flowinfra",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/ccl/changefeedccl/changefeedbase/errors.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/errors.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/errors"
 )
 
@@ -62,7 +63,7 @@ func IsRetryableError(err error) bool {
 		return true
 	}
 
-	return utilccl.IsDistSQLRetryableError(err)
+	return (utilccl.IsDistSQLRetryableError(err) || flowinfra.IsNoInboundStreamConnectionError(err))
 }
 
 // MaybeStripRetryableErrorMarker performs some minimal attempt to clean the


### PR DESCRIPTION
Backport 1/1 commits from #81480.

/cc @cockroachdb/release

---

Fixes https://github.com/cockroachdb/cockroach/issues/81318
by marking such errors as retryable.

Release note (bug fix): Fixed a bug where changefeeds could fail permanently if encountering an error while planning their distribution, even though such errors are usually transient.

Release justification: Bug fix.
