### PR TITLE
sql/schemachanger: respect user type for computed columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1777,6 +1777,18 @@ ALTER TABLE t61762 ADD COLUMN v OIDVECTOR
 statement error VECTOR column types are unsupported
 ALTER TABLE t61762 ADD COLUMN v INT2VECTOR
 
+statement error VECTOR column types are unsupported
+ALTER TABLE t61762 ADD COLUMN v OIDVECTOR AS (ARRAY[1]) STORED
+
+statement error VECTOR column types are unsupported
+ALTER TABLE t61762 ADD COLUMN v OIDVECTOR AS (ARRAY[1]) VIRTUAL
+
+statement error VECTOR column types are unsupported
+ALTER TABLE t61762 ADD COLUMN v INT2VECTOR AS (ARRAY[1]) STORED
+
+statement error VECTOR column types are unsupported
+ALTER TABLE t61762 ADD COLUMN v INT2VECTOR AS (ARRAY[1]) VIRTUAL
+
 # Regression test for #60786. Handle in-transaction constraint ADD+DROP correctly.
 subtest regression_60786
 

--- a/pkg/sql/logictest/testdata/logic_test/virtual_columns
+++ b/pkg/sql/logictest/testdata/logic_test/virtual_columns
@@ -1256,3 +1256,59 @@ JOIN t75147 AS t2 ON
   AND t1.v1 = t2.v1
   AND t1.b = t2.b
 JOIN t75147 AS t3 ON t1.a = t3.a;
+
+
+# This tests that the type of a computed expression properly reflects the
+# user's intention. Before this test was added, the declarative schema changer
+# would not apply the proper type.
+subtest computed_column_type
+
+statement ok
+CREATE TABLE t_added (i INT PRIMARY KEY);
+INSERT INTO t_added VALUES (1);
+
+statement ok
+ALTER TABLE t_added ADD COLUMN i4n INT4 GENERATED ALWAYS AS (NULL) VIRTUAL;
+
+statement ok
+ALTER TABLE t_added ADD COLUMN dn DECIMAL(5, 2) GENERATED ALWAYS AS (NULL) VIRTUAL;
+
+# Note that we really should not be able to add this column as the expression
+# does not fit into the type. See #81698.
+statement ok
+ALTER TABLE t_added ADD COLUMN d DECIMAL(5, 2) GENERATED ALWAYS AS (123456.000000::DECIMAL) VIRTUAL;
+
+statement ok
+ALTER TABLE t_added ADD COLUMN i4 INT4 GENERATED ALWAYS AS (4) VIRTUAL;
+
+statement ok
+ALTER TABLE t_added ADD COLUMN i2 INT2 GENERATED ALWAYS AS (2) VIRTUAL;
+
+
+# Before the PR which introduced this test, the below query would output:
+#
+# CREATE TABLE public.t_added (
+#    i INT8 NOT NULL,
+#    i4n UNKNOWN NULL AS (NULL) VIRTUAL,
+#    dn UNKNOWN NULL AS (NULL) VIRTUAL,
+#    d DECIMAL NULL AS (123456.000000:::DECIMAL) VIRTUAL,
+#    i4 INT8 NULL AS (4:::INT8) VIRTUAL,
+#    i2 INT8 NULL AS (2:::INT8) VIRTUAL,
+#    CONSTRAINT t_added_pkey PRIMARY KEY (i ASC)
+# )
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t_added]
+----
+CREATE TABLE public.t_added (
+   i INT8 NOT NULL,
+   i4n INT4 NULL AS (NULL) VIRTUAL,
+   dn DECIMAL(5,2) NULL AS (NULL) VIRTUAL,
+   d DECIMAL(5,2) NULL AS (123456.000000:::DECIMAL) VIRTUAL,
+   i4 INT4 NULL AS (4:::INT8) VIRTUAL,
+   i2 INT2 NULL AS (2:::INT8) VIRTUAL,
+   CONSTRAINT t_added_pkey PRIMARY KEY (i ASC)
+)
+
+statement ok
+DROP TABLE t_added

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -416,14 +416,12 @@ func (b *builderState) WrapExpression(parentID catid.DescID, expr tree.Expr) *sc
 }
 
 // ComputedColumnExpression implements the scbuildstmt.TableHelpers interface.
-func (b *builderState) ComputedColumnExpression(
-	tbl *scpb.Table, d *tree.ColumnTableDef,
-) (tree.Expr, scpb.TypeT) {
+func (b *builderState) ComputedColumnExpression(tbl *scpb.Table, d *tree.ColumnTableDef) tree.Expr {
 	_, _, ns := scpb.FindNamespace(b.QueryByID(tbl.TableID))
 	tn := tree.MakeTableNameFromPrefix(b.NamePrefix(tbl), tree.Name(ns.Name))
 	b.ensureDescriptor(tbl.TableID)
 	// TODO(postamar): this doesn't work when referencing newly added columns.
-	expr, typ, err := schemaexpr.ValidateComputedColumnExpression(
+	expr, _, err := schemaexpr.ValidateComputedColumnExpression(
 		b.ctx,
 		b.descCache[tbl.TableID].desc.(catalog.TableDescriptor),
 		d,
@@ -441,7 +439,7 @@ func (b *builderState) ComputedColumnExpression(
 	if err != nil {
 		panic(err)
 	}
-	return parsedExpr, newTypeT(typ)
+	return parsedExpr
 }
 
 var _ scbuildstmt.ElementReferences = (*builderState)(nil)

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
@@ -200,7 +200,7 @@ type TableHelpers interface {
 	// ComputedColumnExpression returns a validated computed column expression
 	// and its type.
 	// TODO(postamar): make this more low-level instead of consuming an AST
-	ComputedColumnExpression(tbl *scpb.Table, d *tree.ColumnTableDef) (tree.Expr, scpb.TypeT)
+	ComputedColumnExpression(tbl *scpb.Table, d *tree.ColumnTableDef) tree.Expr
 
 	// IsTableEmpty returns if the table is empty or not.
 	IsTableEmpty(tbl *scpb.Table) bool


### PR DESCRIPTION
Before this change, we'd use the inferred type of the expression to determine
the type of the column. This is wrong, we must use the type provided by the
user. Fortunately, we've never shipped this code.

Along the way, this also fixes a bug whereby unsupported vector types could be
added as computed columns.

Release note: None