### PR TITLE
opt: fix performance regression due to getEnv in Optimizer.Init

### DIFF
--- a/pkg/sql/opt/xform/BUILD.bazel
+++ b/pkg/sql/opt/xform/BUILD.bazel
@@ -50,7 +50,6 @@ go_library(
         "//pkg/util/buildutil",
         "//pkg/util/errorutil",
         "//pkg/util/log",
-        "//pkg/util/randutil",
         "//pkg/util/treeprinter",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -559,7 +559,12 @@ func (c *coster) ComputeCost(candidate memo.RelExpr, required *physical.Required
 		// Don't perturb the cost if we are forcing an index.
 		if cost < hugeCost {
 			// Get a random value in the range [-1.0, 1.0)
-			multiplier := 2*c.rng.Float64() - 1
+			var multiplier float64
+			if c.rng == nil {
+				multiplier = 2*rand.Float64() - 1
+			} else {
+				multiplier = 2*c.rng.Float64() - 1
+			}
 
 			// If perturbation is p, and the estimated cost of an expression is c,
 			// the new cost is in the range [max(0, c - pc), c + pc). For example,

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -127,9 +126,8 @@ func (o *Optimizer) Init(evalCtx *eval.Context, catalog cat.Catalog) {
 	o.mem = o.f.Memo()
 	o.explorer.init(o)
 	seed := evalCtx.SessionData().TestingOptimizerRandomCostSeed
-	o.rng, _ = randutil.NewPseudoRand()
 	if seed != 0 {
-		o.rng.Seed(seed)
+		o.rng = rand.New(rand.NewSource(seed))
 		// If we've been initialized with a random seed but not an explicit
 		// perturbation value, use the max perturbation. This is used for tests
 		// that set the seed with testing_optimizer_random_cost_seed, and will allow


### PR DESCRIPTION
In f2092b6 I added a call to `randutil.NewPseudoRand` in
`Optimizer.Init`. This was more expensive than I realized, because it
checks the value of environment variable `COCKROACH_RANDOM_SEED` using
`envutil.getEnv`, which takes a global lock.

Instead, only create this rng when `testing_optimizer_random_cost_seed`
is set, and seed it directly with that value to avoid the env check
altogether.

Fixes: #81519

Release note: None