### PR TITLE
ccl/sqlproxyccl: add --disable-connection-rebalancing flag to "mt start-proxy"

### DIFF
--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -54,7 +54,7 @@ go_library(
 
 go_test(
     name = "sqlproxyccl_test",
-    size = "small",
+    size = "medium",
     srcs = [
         "authentication_test.go",
         "conn_migration_test.go",

--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -98,6 +98,8 @@ type ProxyOptions struct {
 	// ThrottleBaseDelay is the initial exponential backoff triggered in
 	// response to the first connection failure.
 	ThrottleBaseDelay time.Duration
+	// DisableConnectionRebalancing disables connection rebalancing for tenants.
+	DisableConnectionRebalancing bool
 
 	// testingKnobs are knobs used for testing.
 	testingKnobs struct {
@@ -263,6 +265,9 @@ func newProxyHandler(
 	balancerMetrics := balancer.NewMetrics()
 	registry.AddMetricStruct(balancerMetrics)
 	var balancerOpts []balancer.Option
+	if handler.DisableConnectionRebalancing {
+		balancerOpts = append(balancerOpts, balancer.DisableRebalancing())
+	}
 	if handler.testingKnobs.balancerOpts != nil {
 		balancerOpts = append(balancerOpts, handler.testingKnobs.balancerOpts...)
 	}

--- a/pkg/cli/cliflags/flags_mt.go
+++ b/pkg/cli/cliflags/flags_mt.go
@@ -76,6 +76,11 @@ var (
 		Description: "If true, use insecure connection to the backend.",
 	}
 
+	DisableConnectionRebalancing = FlagInfo{
+		Name:        "disable-connection-rebalancing",
+		Description: "If true, proxy will not attempt to rebalance connections.",
+	}
+
 	RatelimitBaseDelay = FlagInfo{
 		Name:        "ratelimit-base-delay",
 		Description: "Initial backoff after a failed login attempt. Set to 0 to disable rate limiting.",

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -650,6 +650,7 @@ func setProxyContextDefaults() {
 	proxyContext.ValidateAccessInterval = 30 * time.Second
 	proxyContext.PollConfigInterval = 30 * time.Second
 	proxyContext.ThrottleBaseDelay = time.Second
+	proxyContext.DisableConnectionRebalancing = false
 }
 
 var testDirectorySvrContext struct {

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -1033,7 +1033,9 @@ func init() {
 		durationFlag(f, &proxyContext.ValidateAccessInterval, cliflags.ValidateAccessInterval)
 		durationFlag(f, &proxyContext.PollConfigInterval, cliflags.PollConfigInterval)
 		durationFlag(f, &proxyContext.ThrottleBaseDelay, cliflags.ThrottleBaseDelay)
+		boolFlag(f, &proxyContext.DisableConnectionRebalancing, cliflags.DisableConnectionRebalancing)
 	}
+
 	// Multi-tenancy test directory command flags.
 	{
 		f := mtTestDirectorySvr.Flags()


### PR DESCRIPTION
Previously, we added the connection rebalancing feature to the proxy, and that
gets enabled automatically. This feature will not work with < v22.1 clusters
since it relies on the session migration work that was added recently. In
theory, the proxy will still work, but the balancer will constantly attempt
to rebalance connection when we know that it will fail, and this adds to the
overall latency of the connection since we suspend the processors during
connection migration.

To allow us to transition to v22.1 nicely, we will introduce a new flag
`--disable-connection-rebalancing` to the `mt start-proxy` subcommand. When
that flag is set, all connection rebalancing operations will be disabled. We
have to roll out sqlproxy to CC before the clusters get their major upgrade
since it contains some auth work that is a pre-req to v22.1. To avoid these
latency issues, sqlproxy will be rolled out with the flag set. Once clusters
have been upgraded to v22.1, the flag will be removed during startup.

No release notes since `mt start-proxy` is internal only.

Release note: None
