### PR TITLE
release-21.1: acceptance: comply with openssl key size restrictions

### DIFF
--- a/pkg/acceptance/cluster/certs.go
+++ b/pkg/acceptance/cluster/certs.go
@@ -23,7 +23,11 @@ import (
 
 const certsDir = ".localcluster.certs"
 
-// keyLen is the length (in bits) of the generated CA and node certs.
+// keyLen is the length (in bits) of the generated TLS certs.
+//
+// This needs to be at least 2048 since the newer versions of openssl
+// (used by some tests) produce an error 'ee key too small' for
+// smaller values.
 const keyLen = 2048
 
 // GenerateCerts generates CA and client certificates and private keys to be
@@ -39,12 +43,12 @@ func GenerateCerts(ctx context.Context) func() {
 	// Root user.
 	maybePanic(security.CreateClientPair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
-		1024, 48*time.Hour, false, security.RootUserName(), true /* generate pk8 key */))
+		keyLen, 48*time.Hour, false, security.RootUserName(), true /* generate pk8 key */))
 
 	// Test user.
 	maybePanic(security.CreateClientPair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
-		1024, 48*time.Hour, false, security.TestUserName(), true /* generate pk8 key */))
+		keyLen, 48*time.Hour, false, security.TestUserName(), true /* generate pk8 key */))
 
 	// Certs for starting a cockroach server. Key size is from cli/cert.go:defaultKeySize.
 	maybePanic(security.CreateNodePair(


### PR DESCRIPTION
Backport 1/1 commits from #81727.

/cc @cockroachdb/release

---

The RSA key size used by TLS certs for acceptance tests must be at
least 2048 to please OpenSSL (which is used by libpq in tests).

The previous PR #71134 had improved this for some cases but the
chance was hidden in-between other things. This commit makes
it clearer what is going on.

Release note: None

---

Release justification: chances to test-only code

