### PR TITLE
backupccl: avoid quadradic behaviour in spansForAllTableIndexes

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -149,6 +149,7 @@ go_test(
         "backup_destination_test.go",
         "backup_intents_test.go",
         "backup_metadata_test.go",
+        "backup_planning_test.go",
         "backup_rand_test.go",
         "backup_tenant_test.go",
         "backup_test.go",

--- a/pkg/ccl/backupccl/backup_planning_test.go
+++ b/pkg/ccl/backupccl/backup_planning_test.go
@@ -1,0 +1,58 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package backupccl
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkSpansForAllTableIndexes(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+	execCfg := &sql.ExecutorConfig{
+		Codec: keys.SystemSQLCodec,
+	}
+	const descCount = 15000
+
+	primaryIndex := getMockIndexDesc(descpb.IndexID(1))
+	secondaryIndexes := make([]descpb.IndexDescriptor, descCount)
+	revs := make([]BackupManifest_DescriptorRevision, descCount)
+	for i := 0; i < descCount; i++ {
+		idxDesc := getMockIndexDesc(descpb.IndexID(i + 1))
+		secondaryIndexes[i] = idxDesc
+
+		tableRev := getMockTableDesc(descpb.ID(42), idxDesc, nil, nil, nil)
+		revs[i] = BackupManifest_DescriptorRevision{
+			Desc: tableRev.DescriptorProto(),
+		}
+	}
+
+	b.Run("secondaryIndexesCount=15000", func(b *testing.B) {
+		tableDesc := getMockTableDesc(descpb.ID(42), primaryIndex, secondaryIndexes, nil, nil)
+		b.ResetTimer()
+		for n := 0; n < b.N; n++ {
+			_, err := spansForAllTableIndexes(execCfg, []catalog.TableDescriptor{tableDesc}, nil /* revs */)
+			require.NoError(b, err)
+		}
+	})
+	b.Run("revisionCount=15000", func(b *testing.B) {
+		tableDesc := getMockTableDesc(descpb.ID(42), primaryIndex, nil, nil, nil)
+		b.ResetTimer()
+		for n := 0; n < b.N; n++ {
+			_, err := spansForAllTableIndexes(execCfg, []catalog.TableDescriptor{tableDesc}, revs)
+			require.NoError(b, err)
+		}
+	})
+}


### PR DESCRIPTION
The function spansForAllTableIndexes collects all index spans from the
current and past revisions of a table.

While doing this, it collects them into a slice and then adds the
members of that slice to a tree for later iteration.

Unfortunately, when searching for indexes for _revisions_ it appended
new spans to the same slice while also adding items to the tree from
the slice inside the core loop. Meaning that on each iteration, we
re-added all previously added nodes in the tree.

There are more improvements we can make in this function to reduce
allocations at the expense of readability, but this change is rather
impactful.

```
BEFORE: BenchmarkSpansForAllTableIndexes/revisionCount=15000-16                        1        86746688100 ns/op       5463305712 B/op 112733145 allocs/op
AFTER:  BenchmarkSpansForAllTableIndexes/revisionCount=15000-16                       16           62820672 ns/op        63661512 B/op     240618 allocs/op
```

Release note: None