### PR TITLE
release-22.1: ui: fix sizing of table area

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
@@ -48,7 +48,8 @@
 
 .table-area {
   position: relative;
-  width: fit-content;
+  overflow-x: scroll;
+  min-height: 480px;
 }
 
 .reset-btn-area {


### PR DESCRIPTION
Backport 1/1 commits from https://github.com/cockroachdb/cockroach/pull/81049 on behalf of @maryliag.

/cc https://github.com/orgs/cockroachdb/teams/release

----


Previously, the table area was cutting the columns selector
and filters. This commit adds a min height to the area to
be able to fit.
This commit also removed the page config from inside the
table-area on Transactions page that was not suppose to be there
and was cutting part of the table area.

Fixes #79621

Release note (ui change): Fix the size of table area on Statement
and Transactions pages to not cut the columns selector and filters.


----

Release justification: Bug fix