### PR TITLE
release-22.1: sql: add logic test config for legacy schema changer

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/drop_database
+++ b/pkg/sql/logictest/testdata/logic_test/drop_database
@@ -38,6 +38,7 @@ postgres   root  NULL  {}  NULL
 system     node  NULL  {}  NULL
 test       root  NULL  {}  NULL
 
+skipif config local-legacy-schema-changer
 query TT
 SELECT job_type, status FROM [SHOW JOBS] WHERE user_name = 'root'
 ----
@@ -218,6 +219,7 @@ CREATE TABLE constraint_db.t2 (
 statement ok
 DROP DATABASE constraint_db CASCADE
 
+skipif config local-legacy-schema-changer
 query TTT
 WITH cte AS (
   SELECT job_type, description, status

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -1,3 +1,14 @@
+# Legacy schema changer is also skipped because mutation IDs throughout log
+# entries will differ.
+# LogicTest: !local-legacy-schema-changer
+
+# For some reason, some of the queries produce non-deterministic results if
+# distsql_workmem value is randomized, so we'll override it to the production
+# value.
+# TODO(yuzefovich): figure it out.
+statement ok
+SET distsql_workmem = '64MiB'
+
 ##################
 # TABLE DDL
 ##################

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -657,10 +657,24 @@ ALTER TABLE delivery DROP COLUMN "item"
 statement ok
 DROP INDEX products@products_upc_key CASCADE
 
+skipif config local-legacy-schema-changer
 statement error "products" is referenced by foreign key from table "customer reviews"
 DROP TABLE products
 
+# Legacy schema changer orders dependent fks differently, but
+# semantically the same error.
+onlyif config local-legacy-schema-changer
+statement error "products" is referenced by foreign key from table "orders"
+DROP TABLE products
+
+skipif config local-legacy-schema-changer
 statement error referenced by foreign key from table "customer reviews"
+DROP TABLE products RESTRICT
+
+# Legacy schema changer orders dependent fks differently, but
+# semantically the same error.
+onlyif config local-legacy-schema-changer
+statement error "products" is referenced by foreign key from table "orders"
 DROP TABLE products RESTRICT
 
 statement error referenced by foreign key from table "customer reviews"
@@ -1003,6 +1017,7 @@ statement ok
 DROP TABLE a
 
 # Check proper GC job description formatting when removing FK back-references when dropping a table (#59221).
+skipif config local-legacy-schema-changer
 query TT
 SELECT job_type, description FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE GC' AND
  description LIKE 'GC for DROP TABLE test.public.a';

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -1,6 +1,8 @@
 # 3node-tenant is blocked from running this file because of the absence of
-# the tenant table for tenants.
-# LogicTest: !3node-tenant
+# the tenant table for tenants. Legacy schema changer is also skipped, because
+# some of the queries relating internal state will be impacted in terms of
+# descriptor versions, etc..
+# LogicTest: !3node-tenant !local-legacy-schema-changer
 
 # Verify information_schema database handles mutation statements correctly.
 

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -327,7 +327,14 @@ DROP TABLE v1
 statement error pgcode 42809 "t" is not a view
 DROP VIEW t
 
+skipif config local-legacy-schema-changer
 statement error cannot drop relation "v1" because view "v7" depends on it
+DROP VIEW v1
+
+# Legacy schema changer orders dependent views differently, but
+# semantically the same error.
+onlyif config local-legacy-schema-changer
+statement error cannot drop relation "v1" because view "v6" depends on it
 DROP VIEW v1
 
 statement error cannot drop relation "v2" because view "test2.public.v1" depends on it


### PR DESCRIPTION
Backport 1/1 commits from #81528.

/cc @cockroachdb/release

---

Fixes: #81454

Previously, when we enabled the declarative schema changer
by default we implicitly eliminated test coverage for the
legacy schema changer. This was inadequate because we run
the risk of now introducing regressions inside the legacy
code which can still be exercised in scenarios like explicit
transactions. To address this, this patch adds back a config
inside logictest for covering the legacy schema changer.

Release note: None
Release justification: No risk only extends testing for the schema changer inside logic test, no functional change.