### PR TITLE
release-21.2: log: make fluentSink thread safe

### DIFF
--- a/pkg/util/log/http_sink.go
+++ b/pkg/util/log/http_sink.go
@@ -25,6 +25,8 @@ import (
 // TODO: HTTP requests should be bound to context via http.NewRequestWithContext
 // Proper logging context to be decided/designed.
 
+// httpSinkOptions is safe to use concurrently due to the delegation of
+// operations to `http.Client` which is safe to use concurrently.
 type httpSinkOptions struct {
 	unsafeTLS         bool
 	timeout           time.Duration


### PR DESCRIPTION
Backport 1/1 commits from #81225.

/cc @cockroachdb/release

---

Previously, the fluentSink implementation was not thread-safe. On
configurations with multiple `loggerT` instances the fluentSink
interface would be shared between them and could cause panics at
runtime.

This commit adds a mutex to the fluentSink implementation that is locked
during output.

NB: httpSink is already thread safe by construction and interceptorSink
already has a mutex that manages concurrent access.

Resolves #81112

Release note: None

Release justification: fixes a panic-causing problem in the fluent logger