### PR TITLE
bazel: use `exec_tools` in `pkg/sql/sem/tree/BUILD.bazel`, not `tools`

### DIFF
--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -265,7 +265,7 @@ genrule(
     ),
     outs = eval_generated,
     cmd = "$(location //pkg/sql/sem/tree/evalgen) --out $(@D) $(SRCS)",
-    tools = ["//pkg/sql/sem/tree/evalgen"],
+    exec_tools = ["//pkg/sql/sem/tree/evalgen"],
     visibility = [
         ":__pkg__",
         "//pkg/gen:__pkg__",


### PR DESCRIPTION
Release note: None