### PR TITLE
backupccl: reduce allocations in spansForAllTableIndexes 

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -180,7 +180,7 @@ func spansForAllTableIndexes(
 		}
 	}
 
-	var spans []roachpb.Span
+	spans := make([]roachpb.Span, 0, sstIntervalTree.Len())
 	_ = sstIntervalTree.Do(func(r interval.Interface) bool {
 		spans = append(spans, roachpb.Span{
 			Key:    roachpb.Key(r.Range().Start),

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -123,12 +123,16 @@ var featureFullBackupUserSubdir = settings.RegisterBoolSetting(
 	false,
 ).WithPublic()
 
-// getPublicIndexTableSpans returns all the public index spans of the
-// provided table.
-func getPublicIndexTableSpans(
-	table *descpb.TableDescriptor, added map[tableAndIndex]bool, codec keys.SQLCodec,
-) []roachpb.Span {
-	publicIndexSpans := make([]roachpb.Span, 0, len(table.Indexes)+1)
+// forEachPublicIndexTableSpan constructs a span for each public index of the
+// provided table and runs the given function on each of them. The added map is
+// used to track duplicates. Duplicate indexes are not passed to the provided
+// function.
+func forEachPublicIndexTableSpan(
+	table *descpb.TableDescriptor,
+	added map[tableAndIndex]bool,
+	codec keys.SQLCodec,
+	f func(span roachpb.Span),
+) {
 	table.ForEachPublicIndex(func(idx *descpb.IndexDescriptor) {
 		key := tableAndIndex{tableID: table.GetID(), indexID: idx.ID}
 		if added[key] {
@@ -136,9 +140,8 @@ func getPublicIndexTableSpans(
 		}
 		added[key] = true
 		prefix := roachpb.Key(rowenc.MakeIndexKeyPrefix(codec, table.GetID(), idx.ID))
-		publicIndexSpans = append(publicIndexSpans, roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()})
+		f(roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()})
 	})
-	return publicIndexSpans
 }
 
 // spansForAllTableIndexes returns non-overlapping spans for every index and
@@ -160,10 +163,7 @@ func spansForAllTableIndexes(
 	}
 
 	for _, table := range tables {
-		publicIndexSpans := getPublicIndexTableSpans(table.TableDesc(), added, execCfg.Codec)
-		for _, indexSpan := range publicIndexSpans {
-			insertSpan(indexSpan)
-		}
+		forEachPublicIndexTableSpan(table.TableDesc(), added, execCfg.Codec, insertSpan)
 	}
 
 	// If there are desc revisions, ensure that we also add any index spans
@@ -176,10 +176,7 @@ func spansForAllTableIndexes(
 		// entire interval. DROPPED tables should never later become PUBLIC.
 		rawTbl, _, _, _ := descpb.FromDescriptor(rev.Desc)
 		if rawTbl != nil && rawTbl.Public() {
-			publicIndexSpans := getPublicIndexTableSpans(rawTbl, added, execCfg.Codec)
-			for _, indexSpan := range publicIndexSpans {
-				insertSpan(indexSpan)
-			}
+			forEachPublicIndexTableSpan(rawTbl, added, execCfg.Codec, insertSpan)
 		}
 	}
 

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -157,7 +157,7 @@ func spansForAllTableIndexes(
 	added := make(map[tableAndIndex]bool, len(tables))
 	sstIntervalTree := interval.NewTree(interval.ExclusiveOverlapper)
 	insertSpan := func(indexSpan roachpb.Span) {
-		if err := sstIntervalTree.Insert(intervalSpan(indexSpan), false); err != nil {
+		if err := sstIntervalTree.Insert(intervalSpan(indexSpan), true); err != nil {
 			panic(errors.NewAssertionErrorWithWrappedErrf(err, "IndexSpan"))
 		}
 	}
@@ -180,6 +180,7 @@ func spansForAllTableIndexes(
 		}
 	}
 
+	sstIntervalTree.AdjustRanges()
 	spans := make([]roachpb.Span, 0, sstIntervalTree.Len())
 	_ = sstIntervalTree.Do(func(r interval.Interface) bool {
 		spans = append(spans, roachpb.Span{

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -49,6 +49,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
@@ -125,22 +126,19 @@ var featureFullBackupUserSubdir = settings.RegisterBoolSetting(
 // getPublicIndexTableSpans returns all the public index spans of the
 // provided table.
 func getPublicIndexTableSpans(
-	table catalog.TableDescriptor, added map[tableAndIndex]bool, codec keys.SQLCodec,
-) ([]roachpb.Span, error) {
-	publicIndexSpans := make([]roachpb.Span, 0)
-	if err := catalog.ForEachActiveIndex(table, func(idx catalog.Index) error {
-		key := tableAndIndex{tableID: table.GetID(), indexID: idx.GetID()}
+	table *descpb.TableDescriptor, added map[tableAndIndex]bool, codec keys.SQLCodec,
+) []roachpb.Span {
+	publicIndexSpans := make([]roachpb.Span, 0, len(table.Indexes)+1)
+	table.ForEachPublicIndex(func(idx *descpb.IndexDescriptor) {
+		key := tableAndIndex{tableID: table.GetID(), indexID: idx.ID}
 		if added[key] {
-			return nil
+			return
 		}
 		added[key] = true
-		publicIndexSpans = append(publicIndexSpans, table.IndexSpan(codec, idx.GetID()))
-		return nil
-	}); err != nil {
-		return nil, err
-	}
-
-	return publicIndexSpans, nil
+		prefix := roachpb.Key(rowenc.MakeIndexKeyPrefix(codec, table.GetID(), idx.ID))
+		publicIndexSpans = append(publicIndexSpans, roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()})
+	})
+	return publicIndexSpans
 }
 
 // spansForAllTableIndexes returns non-overlapping spans for every index and
@@ -155,25 +153,22 @@ func spansForAllTableIndexes(
 
 	added := make(map[tableAndIndex]bool, len(tables))
 	sstIntervalTree := interval.NewTree(interval.ExclusiveOverlapper)
-	var publicIndexSpans []roachpb.Span
-	var err error
+	insertSpan := func(indexSpan roachpb.Span) {
+		if err := sstIntervalTree.Insert(intervalSpan(indexSpan), false); err != nil {
+			panic(errors.NewAssertionErrorWithWrappedErrf(err, "IndexSpan"))
+		}
+	}
 
 	for _, table := range tables {
-		publicIndexSpans, err = getPublicIndexTableSpans(table, added, execCfg.Codec)
-		if err != nil {
-			return nil, err
-		}
+		publicIndexSpans := getPublicIndexTableSpans(table.TableDesc(), added, execCfg.Codec)
 		for _, indexSpan := range publicIndexSpans {
-			if err := sstIntervalTree.Insert(intervalSpan(indexSpan), false); err != nil {
-				panic(errors.NewAssertionErrorWithWrappedErrf(err, "IndexSpan"))
-			}
+			insertSpan(indexSpan)
 		}
 	}
 
 	// If there are desc revisions, ensure that we also add any index spans
 	// in them that we didn't already get above e.g. indexes or tables that are
 	// not in latest because they were dropped during the time window in question.
-	publicIndexSpans = nil
 	for _, rev := range revs {
 		// If the table was dropped during the last interval, it will have
 		// at least 2 revisions, and the first one should have the table in a PUBLIC
@@ -181,21 +176,13 @@ func spansForAllTableIndexes(
 		// entire interval. DROPPED tables should never later become PUBLIC.
 		rawTbl, _, _, _ := descpb.FromDescriptor(rev.Desc)
 		if rawTbl != nil && rawTbl.Public() {
-			tbl := tabledesc.NewBuilder(rawTbl).BuildImmutableTable()
-			revSpans, err := getPublicIndexTableSpans(tbl, added, execCfg.Codec)
-			if err != nil {
-				return nil, err
+			publicIndexSpans := getPublicIndexTableSpans(rawTbl, added, execCfg.Codec)
+			for _, indexSpan := range publicIndexSpans {
+				insertSpan(indexSpan)
 			}
-
-			publicIndexSpans = append(publicIndexSpans, revSpans...)
 		}
 	}
 
-	for _, indexSpan := range publicIndexSpans {
-		if err := sstIntervalTree.Insert(intervalSpan(indexSpan), false); err != nil {
-			panic(errors.NewAssertionErrorWithWrappedErrf(err, "IndexSpan"))
-		}
-	}
 	var spans []roachpb.Span
 	_ = sstIntervalTree.Do(func(r interval.Interface) bool {
 		spans = append(spans, roachpb.Span{

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -6233,7 +6233,7 @@ func getMockTableDesc(
 	return tabledesc.NewBuilder(&mockTableDescriptor).BuildImmutableTable()
 }
 
-// Unit tests for the spansForAllTableIndexes and getPublicIndexTableSpans()
+// Unit tests for the spansForAllTableIndexes and forEachPublicIndexTableSpan()
 // methods.
 func TestPublicIndexTableSpans(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -6331,8 +6331,11 @@ func TestPublicIndexTableSpans(t *testing.T) {
 	for _, test := range testCases {
 		tableDesc := getMockTableDesc(test.tableID, test.pkIndex,
 			test.indexes, test.addingIndexes, test.droppingIndexes)
-		t.Run(fmt.Sprintf("%s:%s", "getPublicIndexTableSpans", test.name), func(t *testing.T) {
-			spans := getPublicIndexTableSpans(tableDesc.TableDesc(), unusedMap, codec)
+		t.Run(fmt.Sprintf("%s:%s", "forEachPublicIndexTableSpan", test.name), func(t *testing.T) {
+			var spans []roachpb.Span
+			forEachPublicIndexTableSpan(tableDesc.TableDesc(), unusedMap, codec, func(sp roachpb.Span) {
+				spans = append(spans, sp)
+			})
 			var unmergedSpans []string
 			for _, span := range spans {
 				unmergedSpans = append(unmergedSpans, span.String())

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -6332,8 +6332,7 @@ func TestPublicIndexTableSpans(t *testing.T) {
 		tableDesc := getMockTableDesc(test.tableID, test.pkIndex,
 			test.indexes, test.addingIndexes, test.droppingIndexes)
 		t.Run(fmt.Sprintf("%s:%s", "getPublicIndexTableSpans", test.name), func(t *testing.T) {
-			spans, err := getPublicIndexTableSpans(tableDesc, unusedMap, codec)
-			require.NoError(t, err)
+			spans := getPublicIndexTableSpans(tableDesc.TableDesc(), unusedMap, codec)
 			var unmergedSpans []string
 			for _, span := range spans {
 				unmergedSpans = append(unmergedSpans, span.String())

--- a/pkg/sql/catalog/descpb/structured.go
+++ b/pkg/sql/catalog/descpb/structured.go
@@ -278,6 +278,17 @@ func (desc *TableDescriptor) Persistence() tree.Persistence {
 	return tree.PersistencePermanent
 }
 
+// ForEachPublicIndex is exported to provide low-overhead access to the set of
+// public indexes in a table descriptor for use in backup planning.
+//
+// Most users should prefer the methods provided by the catalog package.
+func (desc *TableDescriptor) ForEachPublicIndex(f func(*IndexDescriptor)) {
+	f(&desc.PrimaryIndex)
+	for i := range desc.Indexes {
+		f(&desc.Indexes[i])
+	}
+}
+
 // IsVirtualTable returns true if the TableDescriptor describes a
 // virtual Table (like the information_schema tables) and thus doesn't
 // need to be physically stored.


### PR DESCRIPTION
The table descriptor builder API copies the descriptor and does a
number of allocations so that it can answer any question one might
have about the table.

However, in this function, we only care about collecting the active
indexes and constructing spans for them.  Doing this manually is
straightforward and reduces the number of allocations considerably
when processing a large number of revisions.

```
BEFORE: BenchmarkSpansForAllTableIndexes/revisionCount=15000-16     16  62820672 ns/op  63661512 B/op     240618 allocs/op
AFTER:  BenchmarkSpansForAllTableIndexes/revisionCount=15000-16     49  22688142 ns/op   7289864 B/op      75030 allocs/op
```

This brings the benchmark case for a large number of revisions into
line with the case of a single table that just happens to have a large
number of indexes.

Release note: None