### PR TITLE
release-21.2: colexecwindow: fix panic when lead or lag arguments are different types

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -1238,35 +1238,40 @@ func NewColOperator(
 				// We allocate the capacity for two extra types because of the temporary
 				// columns that can be appended below. Capacity is also allocated for
 				// each of the argument types in case casting is necessary.
-				typs := make([]*types.T, len(result.ColumnTypes), len(result.ColumnTypes)+len(wf.ArgsIdxs)+2)
+				numInputCols := len(result.ColumnTypes)
+				typs := make([]*types.T, numInputCols, numInputCols+len(wf.ArgsIdxs)+2)
 				copy(typs, result.ColumnTypes)
 
 				// Set any nil values in the window frame to their default values.
 				wf.Frame = colexecwindow.NormalizeWindowFrame(wf.Frame)
 
-				tempColOffset := uint32(0)
-				argTypes := make([]*types.T, len(wf.ArgsIdxs))
+				// Copy the argument indices into a mutable slice.
 				argIdxs := make([]int, len(wf.ArgsIdxs))
+				argTypes := make([]*types.T, len(wf.ArgsIdxs))
 				for i, idx := range wf.ArgsIdxs {
-					// Retrieve the type of each argument and perform any necessary casting.
-					needsCast, expectedType := colexecwindow.WindowFnArgNeedsCast(wf.Func, typs[idx], i)
-					if needsCast {
-						// We must cast to the expected argument type.
-						castIdx := len(typs)
-						input, err = colexecbase.GetCastOperator(
-							streamingAllocator, input, int(idx), castIdx, typs[idx], expectedType, evalCtx,
-						)
-						if err != nil {
-							colexecerror.InternalError(errors.AssertionFailedf(
-								"failed to cast window function argument to type %v", expectedType))
-						}
-						typs = append(typs, expectedType)
-						idx = uint32(castIdx)
-						tempColOffset++
-					}
-					argTypes[i] = expectedType
 					argIdxs[i] = int(idx)
+					argTypes[i] = typs[idx]
 				}
+
+				// Perform any necessary casts for the argument columns.
+				castTo := colexecwindow.WindowFnArgCasts(wf.Func, argTypes)
+				for i, typ := range castTo {
+					if typ == nil {
+						continue
+					}
+					castIdx := len(typs)
+					input, err = colexecbase.GetCastOperator(
+						streamingAllocator, input, argIdxs[i],
+						castIdx, argTypes[i], typ, flowCtx.EvalCtx,
+					)
+					if err != nil {
+						colexecerror.InternalError(err)
+					}
+					typs = append(typs, typ)
+					argIdxs[i] = castIdx
+					argTypes[i] = typ
+				}
+
 				partitionColIdx := tree.NoColumnIdx
 				peersColIdx := tree.NoColumnIdx
 
@@ -1275,7 +1280,7 @@ func NewColOperator(
 					// (probably by leveraging hash routers once we can
 					// distribute). The decision about which kind of partitioner
 					// to use should come from the optimizer.
-					partitionColIdx = int(wf.OutputColIdx + tempColOffset)
+					partitionColIdx = len(typs)
 					input, err = colexecwindow.NewWindowSortingPartitioner(
 						streamingAllocator, input, typs,
 						core.Windower.PartitionBy, wf.Ordering.Columns, partitionColIdx,
@@ -1288,9 +1293,7 @@ func NewColOperator(
 						},
 					)
 					// Window partitioner will append a boolean column.
-					tempColOffset++
-					typs = typs[:len(typs)+1]
-					typs[len(typs)-1] = types.Bool
+					typs = append(typs, types.Bool)
 				} else {
 					if len(wf.Ordering.Columns) > 0 {
 						input, err = result.createDiskBackedSort(
@@ -1304,17 +1307,17 @@ func NewColOperator(
 					return r, err
 				}
 				if colexecwindow.WindowFnNeedsPeersInfo(&wf) {
-					peersColIdx = int(wf.OutputColIdx + tempColOffset)
+					peersColIdx = len(typs)
 					input, err = colexecwindow.NewWindowPeerGrouper(
-						streamingAllocator, input, typs, wf.Ordering.Columns,
-						partitionColIdx, peersColIdx,
+						streamingAllocator, input, typs,
+						wf.Ordering.Columns, partitionColIdx, peersColIdx,
 					)
 					// Window peer grouper will append a boolean column.
-					tempColOffset++
-					typs = typs[:len(typs)+1]
-					typs[len(typs)-1] = types.Bool
+					typs = append(typs, types.Bool)
 				}
-				outputIdx := int(wf.OutputColIdx + tempColOffset)
+
+				// The output column is appended after any temporary columns.
+				outputColIdx := len(typs)
 
 				windowArgs := &colexecwindow.WindowArgs{
 					EvalCtx:         evalCtx,
@@ -1323,7 +1326,7 @@ func NewColOperator(
 					FdSemaphore:     args.FDSemaphore,
 					Input:           input,
 					InputTypes:      typs,
-					OutputColIdx:    outputIdx,
+					OutputColIdx:    outputColIdx,
 					PartitionColIdx: partitionColIdx,
 					PeersColIdx:     peersColIdx,
 				}
@@ -1452,16 +1455,17 @@ func NewColOperator(
 					result.ToClose = append(result.ToClose, c)
 				}
 
-				if tempColOffset > 0 {
-					// We want to project out temporary columns (which have
-					// indices in the range [wf.OutputColIdx,
-					// wf.OutputColIdx+tempColOffset)).
-					projection := make([]uint32, 0, wf.OutputColIdx+tempColOffset)
-					for i := uint32(0); i < wf.OutputColIdx; i++ {
-						projection = append(projection, i)
+				if outputColIdx > numInputCols {
+					// We want to project out temporary columns (which have been added in
+					// between the input columns and output column) as well as include the
+					// new output column (which is located after any temporary columns).
+					numOutputCols := numInputCols + 1
+					projection := make([]uint32, numOutputCols)
+					for i := 0; i < numInputCols; i++ {
+						projection[i] = uint32(i)
 					}
-					projection = append(projection, wf.OutputColIdx+tempColOffset)
-					result.Root = colexecbase.NewSimpleProjectOp(result.Root, int(wf.OutputColIdx+tempColOffset), projection)
+					projection[numInputCols] = uint32(outputColIdx)
+					result.Root = colexecbase.NewSimpleProjectOp(result.Root, numOutputCols, projection)
 				}
 
 				result.ColumnTypes = appendOneType(result.ColumnTypes, returnType)

--- a/pkg/sql/colexec/colexecwindow/window_functions_util.go
+++ b/pkg/sql/colexec/colexecwindow/window_functions_util.go
@@ -128,63 +128,66 @@ func windowFrameNeedsPeersInfo(
 	return false
 }
 
-// WindowFnArgNeedsCast returns true if the given argument type requires a cast,
-// as well as the expected type (if the cast is needed). If the cast is not
-// needed, the provided type is returned.
-func WindowFnArgNeedsCast(
-	windowFn execinfrapb.WindowerSpec_Func, provided *types.T, idx int,
-) (needsCast bool, expectedType *types.T) {
+// WindowFnArgCasts returns a list of types to which the given window function
+// arguments should be cast. For arguments that do not require a cast, the
+// corresponding types in the list are nil.
+func WindowFnArgCasts(windowFn execinfrapb.WindowerSpec_Func, argTypes []*types.T) []*types.T {
+	castTo := make([]*types.T, len(argTypes))
+
+	// Only window functions require casts.
 	if windowFn.WindowFunc != nil {
 		switch *windowFn.WindowFunc {
 		case execinfrapb.WindowerSpec_NTILE:
 			// NTile expects a single int64 argument.
-			if idx != 0 {
-				colexecerror.InternalError(errors.AssertionFailedf("ntile expects exactly one argument"))
+			if len(argTypes) != 1 {
+				colexecerror.InternalError(
+					errors.AssertionFailedf("ntile expects exactly one argument"))
 			}
-			return !types.Int.Identical(provided), types.Int
+			if !argTypes[0].Identical(types.Int) {
+				castTo[0] = types.Int
+			}
 		case
 			execinfrapb.WindowerSpec_LAG,
 			execinfrapb.WindowerSpec_LEAD:
-			if idx == 0 || idx == 2 {
-				// The first and third arguments can have any type. No casting necessary.
-				return false, provided
+			if len(argTypes) < 1 || len(argTypes) > 3 {
+				colexecerror.InternalError(
+					errors.AssertionFailedf("lead and lag expect between one and three arguments"))
 			}
-			if idx == 1 {
+			if len(argTypes) >= 2 && !argTypes[1].Identical(types.Int) {
 				// The second argument is an integer offset that must be an int64.
-				return !types.Int.Identical(provided), types.Int
+				castTo[1] = types.Int
 			}
-			colexecerror.InternalError(errors.AssertionFailedf("lag and lead expect between one and three arguments"))
+			if len(argTypes) == 3 && !argTypes[0].Identical(argTypes[2]) {
+				// The third argument must have the same type as the first argument.
+				castTo[2] = argTypes[0]
+			}
 		case
 			execinfrapb.WindowerSpec_FIRST_VALUE,
 			execinfrapb.WindowerSpec_LAST_VALUE:
-			if idx > 0 {
+			if len(argTypes) != 1 {
 				colexecerror.InternalError(errors.AssertionFailedf("first_value and last_value expect exactly one argument"))
 			}
-			// These window functions can take any argument type.
-			return false, provided
+			// Any argument type is allowed, so no casts necessary.
 		case execinfrapb.WindowerSpec_NTH_VALUE:
 			// The first argument can be any type, but the second must be an integer.
-			if idx > 1 {
+			if len(argTypes) != 2 {
 				colexecerror.InternalError(errors.AssertionFailedf("nth_value expects exactly two arguments"))
 			}
-			if idx == 0 {
-				return false, provided
+			if !argTypes[1].Identical(types.Int) {
+				castTo[1] = types.Int
 			}
-			return !types.Int.Identical(provided), types.Int
 		case
 			execinfrapb.WindowerSpec_ROW_NUMBER,
 			execinfrapb.WindowerSpec_RANK,
 			execinfrapb.WindowerSpec_DENSE_RANK,
 			execinfrapb.WindowerSpec_PERCENT_RANK,
 			execinfrapb.WindowerSpec_CUME_DIST:
-			colexecerror.InternalError(errors.AssertionFailedf("window function %s does not expect an argument", windowFn.WindowFunc.String()))
-			// This code is unreachable, but the compiler cannot infer that.
-			return false, nil
+			// No arguments expected.
+		default:
+			colexecerror.InternalError(errors.AssertionFailedf("unknown window function: %v", windowFn.WindowFunc))
 		}
-		colexecerror.InternalError(errors.AssertionFailedf("unknown window function: %v", windowFn.WindowFunc))
 	}
-	// Aggregate functions do not require casts.
-	return false, provided
+	return castTo
 }
 
 // NormalizeWindowFrame returns a frame that is identical to the given one

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -4332,3 +4332,10 @@ FROM t74087 WINDOW w AS (ORDER BY _int4);
 3  3  1  3  3  1  3  3  3  0.5   0.6  1
 4  4  1  4  4  1  4  4  4  0.75  0.8  1
 5  5  1  5  5  1  5  5  5  1     1    1
+
+# Regression test for panic in the vectorized engine when the first and third
+# arguments of lead or lag are different (but castable) types (#81285).
+query I
+SELECT lead(x, 10, y::INT4) OVER () FROM (VALUES (1, 2)) v(x, y);
+----
+2


### PR DESCRIPTION
Backport 1/1 commits from #81681.

/cc @cockroachdb/release

---

This commit fixes an oversight in the planning code for lead and lag window
function operators, where calling `lead` or `lag` with different types for
the first and third arguments caused a panic during execution. According to
the spec for `lead` and `lag`, the `value` and `default` (first and third)
arguments can be different types as long as they are compatible. We now avoid
the panic by attempting to cast the third argument to the type of the first
argument in the case when they are different types.

Example of a query that would trigger the panic:
```
SELECT lead(x, 2, y::INT4) OVER () FROM (VALUES (1, 2)) v(x, y);
```

Fixes #81285

Release note (bug fix): Previously CockroachDB would encounter an
internal error when executing queries with lead or lag window functions
when the default argument had a different type than the first argument.

Release justification: bug fix.