### PR TITLE
colbuilder: address a minor nit in a recent fix

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -1237,6 +1237,7 @@ func NewColOperator(
 					}
 					typs = append(typs, typ)
 					argIdxs[i] = castIdx
+					argTypes[i] = typ
 				}
 
 				partitionColIdx := tree.NoColumnIdx


### PR DESCRIPTION
In 7ad29c34e02e70c0134cd42b34170ee98fa0a9b3 we made some changes about
how argument to window functions are being cast to the same type in some
cases. After the cast we now update the column index but forgot to
update the type to the new one. However, this doesn't lead to problems
since `argTypes` is only used by the aggregate window functions, and the
casts can only be needed for non-aggregate window functions. Still, it's
better to update the types to avoid confusion.

Release note: None