### PR TITLE
democluster: fix `cockroach demo movr --geo-partitioned-replicas --multi-region`

### DIFF
--- a/pkg/cli/democluster/BUILD.bazel
+++ b/pkg/cli/democluster/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/server/pgurl",
         "//pkg/server/serverpb",
         "//pkg/server/status",
+        "//pkg/sql",
         "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/distsql",
         "//pkg/sql/sem/catconstants",


### PR DESCRIPTION
Prereq to #81737.

When using `--geo-partitioned-replicas`, some secondary regions are
added, which is only supported with multitenancy if a cluster setting
is also set. So this commit ensures the cluster setting is set.

NB: no unit tests in this commit because the next commit will ensure
this gets tested.

Release note: None