### PR TITLE
kv: don't consider skipped snapshots to be "processed" by queues

### DIFF
--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -195,7 +195,8 @@ func (s *Store) ManualReplicaGC(repl *Replica) error {
 
 // ManualRaftSnapshot will manually send a raft snapshot to the target replica.
 func (s *Store) ManualRaftSnapshot(repl *Replica, target roachpb.ReplicaID) error {
-	return s.raftSnapshotQueue.processRaftSnapshot(context.Background(), repl, target)
+	_, err := s.raftSnapshotQueue.processRaftSnapshot(context.Background(), repl, target)
+	return err
 }
 
 func (s *Store) ReservationCount() int {


### PR DESCRIPTION
In a support issue, we saw a very high rate of successful raftsnapshot
queue process attempts. This was confusing, as the rate of snapshots
sent was much lower. It turns out that this was because most snapshots
were being skipped on the "replica is likely in the process of being
added" path.

To avoid this confusion in the future, we no longer return `true` as the
value for `processed` from `raftSnapshotQueue.process` method in these
cases.