### PR TITLE
release-21.2: vendor: bump Pebble to 94b9fe11ee99

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -733,8 +733,8 @@ def go_deps():
         name = "com_github_cockroachdb_pebble",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/pebble",
-        sum = "h1:4Q2hcUylCXvPk0UqCBzs0K1qYZTy33ylye2LnyRxsVw=",
-        version = "v0.0.0-20220407171955-f9d4931a5fd2",
+        sum = "h1:AIFjLZ7uPtUKeIjl5V9LOVyueMDeYMRdxbJIehvKzWs=",
+        version = "v0.0.0-20220524164224-94b9fe11ee99",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f
-	github.com/cockroachdb/pebble v0.0.0-20220407171955-f9d4931a5fd2
+	github.com/cockroachdb/pebble v0.0.0-20220524164224-94b9fe11ee99
 	github.com/cockroachdb/redact v1.1.3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/stress v0.0.0-20170808184505-29b5d31b4c3a

--- a/go.sum
+++ b/go.sum
@@ -305,8 +305,8 @@ github.com/cockroachdb/gostdlib v1.13.0/go.mod h1:eXX95p9QDrYwJfJ6AgeN9QnRa/lqqi
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f h1:6jduT9Hfc0njg5jJ1DdKCFPdMBrp/mdZfCpa5h+WM74=
 github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f/go.mod h1:Vz9DsVWQQhf3vs21MhPMZpMGSht7O/2vFW2xusFUVOs=
-github.com/cockroachdb/pebble v0.0.0-20220407171955-f9d4931a5fd2 h1:4Q2hcUylCXvPk0UqCBzs0K1qYZTy33ylye2LnyRxsVw=
-github.com/cockroachdb/pebble v0.0.0-20220407171955-f9d4931a5fd2/go.mod h1:JXfQr3d+XO4bL1pxGwKKo09xylQSdZ/mpZ9b2wfVcPs=
+github.com/cockroachdb/pebble v0.0.0-20220524164224-94b9fe11ee99 h1:AIFjLZ7uPtUKeIjl5V9LOVyueMDeYMRdxbJIehvKzWs=
+github.com/cockroachdb/pebble v0.0.0-20220524164224-94b9fe11ee99/go.mod h1:JXfQr3d+XO4bL1pxGwKKo09xylQSdZ/mpZ9b2wfVcPs=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=
 github.com/cockroachdb/redact v1.1.3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=

--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -165,11 +165,7 @@ type Location struct {
 func Filesystem(dir string) Location {
 	return Location{
 		dir: dir,
-		// fs is left nil intentionally, so that it will be left as the
-		// default of vfs.Default wrapped in vfs.WithDiskHealthChecks
-		// (initialized by DefaultPebbleOptions).
-		// TODO(jackson): Refactor to make it harder to accidentially remove
-		// disk health checks by setting your own VFS in a call to NewPebble.
+		fs:  vfs.Default,
 	}
 }
 
@@ -197,9 +193,7 @@ func Open(ctx context.Context, loc Location, opts ...ConfigOption) (*Pebble, err
 	var cfg engineConfig
 	cfg.Dir = loc.dir
 	cfg.Opts = DefaultPebbleOptions()
-	if loc.fs != nil {
-		cfg.Opts.FS = loc.fs
-	}
+	cfg.Opts.FS = loc.fs
 	for _, opt := range opts {
 		if err := opt(&cfg); err != nil {
 			return nil, err


### PR DESCRIPTION
```
94b9fe11 db: fix data race in SeekPrefixGE
6c99bd8a db: ensure Open closes opened directories on error
57b59875 vfs: extend disk-health checking to filesystem metadata operations
83eed2bd db: check ordering invariant for sublevel compactions
06d1d632 db: use sublevels for l0 manual compactions
f9d4931a compaction: add L0CompactionFileThreshold compaction trigger
```

Release note (bug fix): Fix a gap in disk-stall detection. Previously,
disk stalls during filesystem metadata operations could go undetected,
inducing deadlocks. Now stalls during these types of operations will
correctly fatal the process.

Release justification: Fixes a bug that could induce deadlock in the
presence of disk stalls.