### PR TITLE
asim: add replica pacer

### DIFF
--- a/pkg/kv/kvserver/asim/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "asim.go",
         "config_loader.go",
         "load.go",
+        "pacer.go",
         "workload.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim",
@@ -14,6 +15,7 @@ go_library(
         "//pkg/kv/kvserver/allocator",
         "//pkg/kv/kvserver/allocator/allocatorimpl",
         "//pkg/roachpb",
+        "//pkg/util/shuffle",
         "//pkg/util/timeutil",
         "@com_github_google_btree//:btree",
     ],
@@ -24,6 +26,7 @@ go_test(
     srcs = [
         "asim_test.go",
         "config_loader_test.go",
+        "pacer_test.go",
         "workload_test.go",
     ],
     embed = [":asim"],

--- a/pkg/kv/kvserver/asim/asim.go
+++ b/pkg/kv/kvserver/asim/asim.go
@@ -118,6 +118,7 @@ type Replica struct {
 type Store struct {
 	Replicas  map[int]*Replica
 	allocator allocatorimpl.Allocator
+	pacer     ReplicaPacer
 }
 
 // Node represents a node within the cluster.
@@ -177,6 +178,21 @@ func (s *State) AddStore(node int) {
 		allocator: allocator,
 		Replicas:  make(map[int]*Replica),
 	}
+	nextReplsFn := func() []*Replica {
+		repls := make([]*Replica, 0, 1)
+		for _, repl := range store.Replicas {
+			repls = append(repls, repl)
+		}
+		return repls
+	}
+
+	store.pacer = NewScannerReplicaPacer(
+		nextReplsFn,
+		defaultLoopInterval,
+		defaultMinInterInterval,
+		defaultMaxIterInterval,
+	)
+
 	s.Nodes[node].Stores = append(s.Nodes[node].Stores, store)
 }
 
@@ -244,10 +260,6 @@ func (s *State) ApplyLoad(ctx context.Context, le LoadEvent) {
 	leaseHolder.ReplicaLoad.ApplyLoad(le)
 }
 
-func shouldRun(time.Time) bool {
-	return false
-}
-
 // RunAllocator runs the allocator code for some replicas as needed.
 func RunAllocator(
 	ctx context.Context,
@@ -255,16 +267,9 @@ func RunAllocator(
 	spanConf roachpb.SpanConfig,
 	desc *roachpb.RangeDescriptor,
 	tick time.Time,
-) (done bool, action allocatorimpl.AllocatorAction, priority float64) {
-	// TODO: we should pace the calls to ComputeAction. The replicate queue tries
-	// to call ComputeAction for all replicas at a steady pace, to complete a pass
-	// within 10 minutes. We should have similar logic here (using simulated
-	// time).
-	if !shouldRun(tick) {
-		return true, allocatorimpl.AllocatorNoop, 0
-	}
+) (action allocatorimpl.AllocatorAction, priority float64) {
 	action, priority = allocator.ComputeAction(ctx, spanConf, desc)
-	return false, action, priority
+	return action, priority
 }
 
 // Simulator simulates an entire cluster, and runs the allocators of each store
@@ -337,13 +342,23 @@ func (s *Simulator) RunSim(ctx context.Context) {
 
 		for _, node := range stateForAlloc.Nodes {
 			for _, store := range node.Stores {
-				for _, r := range store.Replicas {
-					// Run the real allocator code. Note that the input is from the
-					// "frozen" state which is not affected by rebalancing decisions.
-					done, action, priority := RunAllocator(ctx, store.allocator, *r.spanConf, r.rangeDesc, tick)
-					if done {
+				for {
+					r := store.pacer.Next(tick)
+
+					// No replicas to consider at this tick.
+					if r == nil {
 						break
 					}
+
+					// NB: Only the leaseholder replica for the range is
+					// considered in the allocator.
+					if !r.leaseHolder {
+						continue
+					}
+
+					// Run the real allocator code. Note that the input is from the
+					// "frozen" state which is not affected by rebalancing decisions.
+					action, priority := RunAllocator(ctx, store.allocator, *r.spanConf, r.rangeDesc, tick)
 
 					// The allocator ops are applied.
 					s.state.ApplyAllocatorAction(ctx, action, priority)

--- a/pkg/kv/kvserver/asim/pacer.go
+++ b/pkg/kv/kvserver/asim/pacer.go
@@ -1,0 +1,136 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package asim
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/shuffle"
+)
+
+const (
+	defaultLoopInterval     = 10 * time.Minute
+	defaultMinInterInterval = 10 * time.Millisecond
+	defaultMaxIterInterval  = 1 * time.Second
+)
+
+// ReplicaPacer controls the speed of considering a replica.
+type ReplicaPacer interface {
+
+	// Next returns the next replica for the current tick, if exists.
+	Next(tick time.Time) *Replica
+}
+
+// ReplicaScanner simulates store scanner replica pacing, iterating over
+// replicas at a rate sufficient to complete iteration in the specified scan
+// loop interval.
+type ReplicaScanner struct {
+	// TOOD(kvoli): make this a function which returns the store's current
+	// replicas.
+	nextReplsFn        func() []*Replica
+	repls              []*Replica
+	start              time.Time
+	lastLoop           time.Time
+	targetLoopInterval time.Duration
+	minIterInvterval   time.Duration
+	maxIterInvterval   time.Duration
+	iterInterval       time.Duration
+	visited            int
+}
+
+// NewScannerReplicaPacer returns a scanner replica pacer.
+func NewScannerReplicaPacer(
+	nextReplsFn func() []*Replica, targetLoopInterval, minIterInterval, maxIterInterval time.Duration,
+) *ReplicaScanner {
+	return &ReplicaScanner{
+		nextReplsFn:        nextReplsFn,
+		repls:              make([]*Replica, 0, 1),
+		targetLoopInterval: targetLoopInterval,
+		minIterInvterval:   minIterInterval,
+		maxIterInvterval:   maxIterInterval,
+	}
+}
+
+// Len implements sort.Interface.
+func (rp ReplicaScanner) Len() int { return len(rp.repls) }
+
+// Less implements sort.Interface.
+func (rp ReplicaScanner) Less(i, j int) bool {
+	return rp.repls[i].rangeDesc.RangeID < rp.repls[j].rangeDesc.RangeID
+}
+
+// Swap implements sort.Interface.
+func (rp ReplicaScanner) Swap(i, j int) {
+	rp.repls[i], rp.repls[j] = rp.repls[j], rp.repls[i]
+}
+
+// resetPacerLoop collects the current replicas on the store and sets the
+// pacing interval to complete iteration over all replicas in exactly target
+// loop interval.
+func (rp *ReplicaScanner) resetPacerLoop(tick time.Time) {
+	rp.repls = rp.nextReplsFn()
+
+	// Avoid the same replicas being processed in the same order in each
+	// iteration.
+	shuffle.Shuffle(rp)
+
+	// Reset the counter and tracker vars.
+	rp.visited = 0
+
+	// If there are no replicas, we cannot determine the correct iter interval,
+	// instead of waitng for the loop interval return early and try again on next
+	// check.
+	if len(rp.repls) == 0 {
+		return
+	}
+
+	iterInterval := time.Duration(rp.targetLoopInterval.Nanoseconds() / int64(len(rp.repls)))
+
+	// Adjust minimum and maximum times according to the min/max interval
+	// allowed.
+	if iterInterval < rp.minIterInvterval {
+		iterInterval = rp.minIterInvterval
+	}
+	if iterInterval > rp.maxIterInvterval {
+		iterInterval = rp.maxIterInvterval
+	}
+
+	// Set the start time on first loop, otherwise roll it over from the
+	// previous loop.
+	if rp.start == rp.lastLoop {
+		rp.start = tick
+	}
+
+	rp.lastLoop = tick
+	rp.iterInterval = iterInterval
+}
+
+// maybeResetPacerLoop checks whether we have completed iteration and resets
+// the pacing loop if so.
+func (rp *ReplicaScanner) maybeResetPacerLoop(tick time.Time) {
+	if rp.visited >= len(rp.repls) {
+		rp.resetPacerLoop(tick)
+	}
+}
+
+// Next returns the next replica for the current tick, if exists.
+func (rp *ReplicaScanner) Next(tick time.Time) *Replica {
+	rp.maybeResetPacerLoop(tick)
+
+	elapsed := tick.Sub(rp.start)
+	if elapsed >= rp.iterInterval && len(rp.repls) > 0 {
+		repl := rp.repls[rp.visited]
+		rp.visited++
+		rp.start = rp.start.Add(rp.iterInterval)
+		return repl
+	}
+	return nil
+}

--- a/pkg/kv/kvserver/asim/pacer_test.go
+++ b/pkg/kv/kvserver/asim/pacer_test.go
@@ -1,0 +1,112 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package asim
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestScannerReplicaPacer asserts that the replica scanner pacer keeps the
+// correct pacing, given the desired loop interval time and max/min intervals
+// set.
+func TestScannerReplicaPacer(t *testing.T) {
+	start := time.Date(2022, 03, 21, 11, 0, 0, 0, time.UTC)
+
+	makeTick := func(tick int64) time.Time {
+		return start.Add(time.Duration(tick) * time.Second)
+	}
+
+	testCases := []struct {
+		desc               string
+		loopInterval       time.Duration
+		minInterval        time.Duration
+		maxInterval        time.Duration
+		replCount          int
+		ticks              []int64
+		expectedReplCounts []int
+	}{
+		{
+			desc:               "one repl per tick",
+			loopInterval:       5 * time.Second,
+			minInterval:        time.Millisecond,
+			maxInterval:        time.Minute,
+			replCount:          5,
+			ticks:              []int64{0, 1, 2, 3, 4, 5},
+			expectedReplCounts: []int{0, 1, 1, 1, 1, 1},
+		},
+		{
+			desc:               "three repl per tick",
+			loopInterval:       5 * time.Second,
+			minInterval:        time.Millisecond,
+			maxInterval:        time.Minute,
+			replCount:          15,
+			ticks:              []int64{0, 1, 2, 3, 4, 5},
+			expectedReplCounts: []int{0, 3, 3, 3, 3, 3},
+		},
+		{
+			desc:               "one repl per tick, 2 loops",
+			loopInterval:       5 * time.Second,
+			minInterval:        time.Millisecond,
+			maxInterval:        time.Minute,
+			replCount:          5,
+			ticks:              []int64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			expectedReplCounts: []int{0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+		},
+		{
+			desc:               "maximum interval default",
+			loopInterval:       10 * time.Second,
+			minInterval:        time.Millisecond,
+			maxInterval:        time.Second,
+			replCount:          5,
+			ticks:              []int64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			expectedReplCounts: []int{0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+		},
+		{
+			desc:               "minimum interval default",
+			loopInterval:       5 * time.Second,
+			minInterval:        time.Second,
+			maxInterval:        time.Minute,
+			replCount:          10,
+			ticks:              []int64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			expectedReplCounts: []int{0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+		},
+	}
+
+	for _, tc := range testCases {
+		nextReplsFn := func() []*Replica {
+			repls := make([]*Replica, tc.replCount)
+			for i := range repls {
+				repls[i] = &Replica{}
+			}
+			return repls
+		}
+		t.Run(tc.desc, func(t *testing.T) {
+			pacer := NewScannerReplicaPacer(nextReplsFn, tc.loopInterval, tc.minInterval, tc.maxInterval)
+			results := make([]int, 0, 1)
+			for _, tick := range tc.ticks {
+				replsThisTick := 0
+				for {
+					if repl := pacer.Next(makeTick(tick)); repl == nil {
+						break
+					}
+
+					replsThisTick++
+				}
+				results = append(results, replsThisTick)
+			}
+			require.Equal(t, tc.expectedReplCounts, results)
+		})
+
+	}
+}


### PR DESCRIPTION
This patch adds a replica pacer, for controlling the speed of
compute action on replicas within a store. Replica pacer attempts to
simulate the logic of the store scanner, iterating over a snapshot of the
replicas in a store. After a full iteration, the pacer collects the
current replicas in a snapshot and loops.

The pacing is controlled by the target loop interval, the duration for one
loop over all snapshot replicas. Each replica is accordingly considered
in target loop interval / |replicas| interval.

Note that this pacer does not discriminate between leaseholder replicas,
which are the only type used in compute action. Rather, it applies to
all replica types, allowing more general use for other processing loops
such as the split queue.

Release note: None