### PR TITLE
bazel: bump size of `rangefeed` test

### DIFF
--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -40,7 +40,7 @@ go_library(
 
 go_test(
     name = "rangefeed_test",
-    size = "medium",
+    size = "large",
     srcs = [
         "budget_test.go",
         "catchup_scan_bench_test.go",


### PR DESCRIPTION
This has timed out in CI.

Release note: None