### PR TITLE
roachtest: fix crash when Run failure races with test end

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1936,9 +1936,16 @@ func (c *clusterImpl) RunE(ctx context.Context, node option.NodeListOption, args
 	if err := ctx.Err(); err != nil {
 		l.Printf("(note: incoming context was canceled: %s", err)
 	}
-	physicalFileName := l.File.Name()
+	// We need to protect ourselves from a race where cluster logger is
+	// concurrently closed before child logger is created. In that case child
+	// logger will have no log file but would write to stderr instead and we can't
+	// create a meaningful ".failed" file for it.
+	physicalFileName := ""
+	if l.File != nil {
+		physicalFileName = l.File.Name()
+	}
 	l.Close()
-	if err != nil {
+	if err != nil && len(physicalFileName) > 0 {
 		failedPhysicalFileName := strings.TrimSuffix(physicalFileName, ".log") + ".failed"
 		if failedFile, err2 := os.Create(failedPhysicalFileName); err2 != nil {
 			failedFile.Close()


### PR DESCRIPTION
Previously roachtest cluster could crash when trying to log failure
after unsuccessful RunE() if cluster is being concurrently closed.
This failure would hide the real test failure as it causes panic.
This patch adds a check for closed logger when creating a ".failed"
file that indicates a cluster process failure.

Release note: None