### PR TITLE
sql: assert that table writers use root txns

### DIFF
--- a/pkg/sql/tablewriter_delete.go
+++ b/pkg/sql/tablewriter_delete.go
@@ -44,8 +44,7 @@ func (td *tableDeleter) walkExprs(_ func(desc string, index int, expr tree.Typed
 func (td *tableDeleter) init(
 	_ context.Context, txn *kv.Txn, evalCtx *eval.Context, sv *settings.Values,
 ) error {
-	td.tableWriterBase.init(txn, td.tableDesc(), evalCtx, sv)
-	return nil
+	return td.tableWriterBase.init(txn, td.tableDesc(), evalCtx, sv)
 }
 
 // row is part of the tableWriter interface.

--- a/pkg/sql/tablewriter_insert.go
+++ b/pkg/sql/tablewriter_insert.go
@@ -36,8 +36,7 @@ func (*tableInserter) desc() string { return "inserter" }
 func (ti *tableInserter) init(
 	_ context.Context, txn *kv.Txn, evalCtx *eval.Context, sv *settings.Values,
 ) error {
-	ti.tableWriterBase.init(txn, ti.tableDesc(), evalCtx, sv)
-	return nil
+	return ti.tableWriterBase.init(txn, ti.tableDesc(), evalCtx, sv)
 }
 
 // row is part of the tableWriter interface.

--- a/pkg/sql/tablewriter_update.go
+++ b/pkg/sql/tablewriter_update.go
@@ -36,8 +36,7 @@ func (*tableUpdater) desc() string { return "updater" }
 func (tu *tableUpdater) init(
 	_ context.Context, txn *kv.Txn, evalCtx *eval.Context, sv *settings.Values,
 ) error {
-	tu.tableWriterBase.init(txn, tu.tableDesc(), evalCtx, sv)
-	return nil
+	return tu.tableWriterBase.init(txn, tu.tableDesc(), evalCtx, sv)
 }
 
 // row is part of the tableWriter interface.

--- a/pkg/sql/tablewriter_upsert_opt.go
+++ b/pkg/sql/tablewriter_upsert_opt.go
@@ -101,7 +101,9 @@ var _ tableWriter = &optTableUpserter{}
 func (tu *optTableUpserter) init(
 	ctx context.Context, txn *kv.Txn, evalCtx *eval.Context, sv *settings.Values,
 ) error {
-	tu.tableWriterBase.init(txn, tu.ri.Helper.TableDesc, evalCtx, sv)
+	if err := tu.tableWriterBase.init(txn, tu.ri.Helper.TableDesc, evalCtx, sv); err != nil {
+		return err
+	}
 
 	// rowsNeeded, set upon initialization, indicates pkg/sql/backfill.gowhether or not we want
 	// rows returned from the operation.


### PR DESCRIPTION
We assume that all mutation statements use the Root txn, but this was
never enforced in practice. This commit adds an explicit check when
initializing the table writer that the root txn is provided.

Release note: None