### PR TITLE
sql: enable streamer for lookup joins

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -477,12 +477,10 @@ func (dsp *DistSQLPlanner) Run(
 		if row.CanUseStreamer(ctx, dsp.st) {
 			for _, proc := range plan.Processors {
 				if jr := proc.Spec.Core.JoinReader; jr != nil {
-					if jr.IsIndexJoin() {
-						// Index joins with and without ordering are executed
-						// via the Streamer API that has concurrency.
-						localState.HasConcurrency = true
-						break
-					}
+					// Both index and lookup joins, with and without ordering,
+					// are executed via the Streamer API that has concurrency.
+					localState.HasConcurrency = true
+					break
 				}
 			}
 		}

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -308,7 +308,6 @@ func newJoinReader(
 		shouldLimitBatches = false
 	}
 	useStreamer := flowCtx.Txn != nil && flowCtx.Txn.Type() == kv.LeafTxn &&
-		readerType == indexJoinReaderType &&
 		row.CanUseStreamer(flowCtx.EvalCtx.Ctx(), flowCtx.EvalCtx.Settings)
 
 	jr := &joinReader{


### PR DESCRIPTION
We've just fixed an issue with incorrectly using leaf txns for mutations
because of the streamer, so I think it is ok to fully enable the
streamer. I expect that there might be some fallout, so I'm curious to
see the run of nightlies.

Release note: None