### PR TITLE
build: use bazel for roachtest stress

### DIFF
--- a/build/teamcity-roachtest-stress.sh
+++ b/build/teamcity-roachtest-stress.sh
@@ -1,33 +1,9 @@
 #!/usr/bin/env bash
-set -euo pipefail
+
+set -exuo pipefail
 
 source "$(dirname "${0}")/teamcity-support.sh"
+source "$(dirname "${0}")/teamcity-bazel-support.sh" # For run_bazel
 
-google_credentials="$GOOGLE_CREDENTIALS"
-generate_ssh_key
-log_into_gcloud
-
-set -x
-
-export ROACHPROD_USER=teamcity
-export GCE_PROJECT=${GCE_PROJECT-cockroach-roachstress}
-
-mkdir -p artifacts
-
-build/builder/mkrelease.sh amd64-linux-gnu build bin/workload bin/roachtest \
-  > artifacts/build.txt 2>&1 || (cat artifacts/build.txt; false)
-
-build/teamcity-roachtest-invoke.sh \
-  --cloud=gce \
-  --zones="${GCE_ZONES-us-east4-b,us-west4-a,europe-west4-c}" \
-  --debug="${DEBUG-false}" \
-  --count="${COUNT-16}" \
-  --parallelism="${PARALLELISM-16}" \
-  --cpu-quota="${CPUQUOTA-1024}" \
-  --cluster-id="${TC_BUILD_ID}" \
-  --build-tag="${BUILD_TAG}" \
-  --lifetime="36h" \
-  --cockroach="${PWD}/cockroach-linux-2.6.32-gnu-amd64" \
-  --artifacts="${PWD}/artifacts" \
-  --disable-issue \
-  "${TESTS}"
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e LITERAL_ARTIFACTS_DIR=$root/artifacts -e BUILD_TAG -e BUILD_VCS_NUMBER -e CLOUD -e COCKROACH_DEV_LICENSE -e TESTS -e COUNT -e GITHUB_API_TOKEN -e GITHUB_ORG -e GITHUB_REPO -e GOOGLE_CREDENTIALS -e GOOGLE_KMS_KEY_A -e GOOGLE_KMS_KEY_B -e SLACK_TOKEN -e TC_BUILDTYPE_ID -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL" \
+  run_bazel build/teamcity/cockroach/ci/tests/roachtest_stress_impl.sh

--- a/build/teamcity/cockroach/ci/tests/roachtest_stress_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/roachtest_stress_impl.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+source "$dir/../../../../teamcity-support.sh"
+
+if [[ ! -f ~/.ssh/id_rsa.pub ]]; then
+  ssh-keygen -q -C "roachtest-stress $(date)" -N "" -f ~/.ssh/id_rsa
+fi
+
+source "$root/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh"
+
+# NOTE: we use the GOOGLE_CREDENTIALS environment here, rather than the
+# "ephemeral" variant. The former is specific to the roachtest stress job,
+# whereas the latter (which is an inherited parameter) does not have the
+# requisite permissions to create instance in the cockroach-roachstress GCP
+# project.
+google_credentials="$GOOGLE_CREDENTIALS"
+generate_ssh_key
+log_into_gcloud
+
+export GCE_PROJECT=${GCE_PROJECT-cockroach-roachstress}
+
+build/teamcity-roachtest-invoke.sh \
+  --cloud=gce \
+  --zones="${GCE_ZONES-us-east4-b,us-west4-a,europe-west4-c}" \
+  --debug="${DEBUG-false}" \
+  --count="${COUNT-16}" \
+  --parallelism="${PARALLELISM-16}" \
+  --cpu-quota="${CPUQUOTA-1024}" \
+  --cluster-id="${TC_BUILD_ID}" \
+  --build-tag="${BUILD_TAG}" \
+  --lifetime="36h" \
+  --cockroach="${PWD}/bin/cockroach" \
+  --artifacts="${PWD}/artifacts" \
+  --disable-issue \
+  "${TESTS}"


### PR DESCRIPTION
Currently, the Roachtest Stress TeamCity job uses `make` (via the
`mkrelease.sh` script) for building the required binaries. Recently, the
pipeline started hanging while building the binary. Rather than
investigating and fixing the existing `make`-based pipeline, convert the
job to using Bazel for building the binaries.

Retain the existing entrypoint to the job, converting it to use [the
existing pattern][1] of calling `run_bazel` with the required
environment variables, invoking an `_impl.sh` script. The existing logic
is moved into the new `_impl.sh` script, with some minor additions to
source some additional scripts.

Additionally, the TeamCity job itself was updated to set pass in the
`TARGET_CLOUD` environment variable (set to `gce`), and remove the need
to build within a container (instead deferring to Bazel to manage the
build environment). The diff for the TeamCity pipeline is as follows
(for posterity):

```diff
18c18
<
---
>       <param name="env.TARGET_CLOUD" value="gce" />
24c24
<           <param name="plugin.docker.imageId" value="%builder.dockerImage%" />
---
>
28,29c28,29
< export BUILD_TAG="$(git describe --abbrev=0 --tags --match=v[0-9]*)"
< ./build/teamcity-roachtest-stress.sh]]></param>
---
> build_tag="$(git describe --abbrev=0 --tags --match=v[0-9]*)"
> CLOUD=${TARGET_CLOUD} BUILD_TAG="${build_tag}" ./build/teamcity-roachtest-stress.sh]]></param>
```

Release note: None.

[1]: https://github.com/cockroachdb/cockroach/blob/12198a51408e7333cd4f96b221e6734239479765/build/teamcity/cockroach/nightlies/roachtest_nightly_gce.sh#L10-L11