### PR TITLE
backupccl: use correct option name in error message

### DIFF
--- a/pkg/ccl/backupccl/backup_destination.go
+++ b/pkg/ccl/backupccl/backup_destination.go
@@ -168,13 +168,13 @@ func resolveDest(
 				"'Full Backup with user defined subdirectory'",
 			); err != nil {
 				return "", "", "", nil, nil, errors.Wrapf(err,
-					"The full backup cannot get written to '%s', a user defined subdirectory. "+
+					"The full backup cannot get written to %q, a user defined subdirectory. "+
 						"To take a full backup, remove the subdirectory from the backup command, "+
 						"(i.e. run 'BACKUP ... INTO <collectionURI>'). "+
 						"Or, to take a full backup at a specific subdirectory, "+
-						"enable the deprecated syntax by switching the 'bulkio.backup."+
-						"deprecated_full_backup_with_subdir.enable' cluster setting to true; "+
-						"however, note this deprecated syntax will not be available in a future release.", chosenSuffix)
+						"enable the deprecated syntax by switching the %q cluster setting to true; "+
+						"however, note this deprecated syntax will not be available in a future release.",
+					chosenSuffix, featureFullBackupUserSubdir.Key())
 			}
 		}
 		// There's no full backup in the resolved subdirectory; therefore, we're conducting a full backup.

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -661,7 +661,7 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 		"BACKUP INTO LATEST IN $4 WITH incremental_location = ($1, $2, $3)",
 		append(incrementals, collections[0])...)
 
-	sqlDB.ExpectErr(t, "The full backup cannot get written to '/subdir', a user defined subdirectory. To take a full backup, remove the subdirectory from the backup command",
+	sqlDB.ExpectErr(t, "A full backup cannot be written to \"/subdir\", a user defined subdirectory. To take a full backup, remove the subdirectory from the backup command",
 		"BACKUP INTO $4 IN ($1, $2, $3)", append(collections, "subdir")...)
 
 	time.Sleep(time.Second + 2)


### PR DESCRIPTION
Previously, this error message referred to

    bulkio.backup.deprecated_full_backup_with_subdir.enable

but the actual option name is

    bulkio.backup.deprecated_full_backup_with_subdir.enabled

Release note (bug fix): An error message that referred to a
non-existent cluster setting no refers to the correct cluster setting:
bulkio.backup.deprecated_full_backup_with_subdir.enabled.