### PR TITLE
liveness: run sync disk write in a stopper task

### DIFF
--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -1273,7 +1273,10 @@ func (nl *NodeLiveness) updateLiveness(
 		for i, eng := range engines {
 			eng := eng // pin the loop variable
 			resultCs[i], _ = nl.engineSyncs.DoChan(strconv.Itoa(i), func() (interface{}, error) {
-				return nil, storage.WriteSyncNoop(eng)
+				return nil, nl.stopper.RunTaskWithErr(ctx, "liveness-hb-diskwrite",
+					func(ctx context.Context) error {
+						return storage.WriteSyncNoop(eng)
+					})
 			})
 		}
 		for _, resultC := range resultCs {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -400,6 +400,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 
 	nodeLiveness := liveness.NewNodeLiveness(liveness.NodeLivenessOptions{
 		AmbientCtx:              cfg.AmbientCtx,
+		Stopper:                 stopper,
 		Clock:                   clock,
 		DB:                      db,
 		Gossip:                  g,
@@ -1440,7 +1441,6 @@ func (s *Server) PreStart(ctx context.Context) error {
 	// store "last up" timestamp for every store whenever the liveness record is
 	// updated.
 	s.nodeLiveness.Start(ctx, liveness.NodeLivenessStartOptions{
-		Stopper: s.stopper,
 		Engines: s.engines,
 		OnSelfLive: func(ctx context.Context) {
 			now := s.clock.Now()

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -184,6 +184,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 	active, renewal := cfg.NodeLivenessDurations()
 	cfg.NodeLiveness = liveness.NewNodeLiveness(liveness.NodeLivenessOptions{
 		AmbientCtx:              cfg.AmbientCtx,
+		Stopper:                 ltc.stopper,
 		Clock:                   cfg.Clock,
 		DB:                      cfg.DB,
 		Gossip:                  cfg.Gossip,
@@ -272,7 +273,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 
 	if !ltc.DisableLivenessHeartbeat {
 		cfg.NodeLiveness.Start(ctx,
-			liveness.NodeLivenessStartOptions{Stopper: ltc.stopper, Engines: []storage.Engine{ltc.Eng}})
+			liveness.NodeLivenessStartOptions{Engines: []storage.Engine{ltc.Eng}})
 	}
 
 	if err := ltc.Store.Start(ctx, ltc.stopper); err != nil {


### PR DESCRIPTION
**liveness: move stopper to `NodeLivenessOptions`**

Release note: None

**liveness: run sync disk write in a stopper task**

This patch runs the sync disk write during node heartbeats in a stopper
task. The write is done in a goroutine, so that we can respect the
caller's context cancellation (even though the write itself won't).
However, this could race with engine shutdown when stopping the node,
violating the Pebble contract and triggering the race detector.  Running
it as a stopper task will cause the node to wait for the disk write to
complete before closing the engine.

Of course, if the disk stalls then node shutdown will now never
complete. This is very unfortunate, since stopping the node is often
the only mitigation to recover stuck ranges with stalled disks. This is
mitigated by Pebble panic'ing the node on stalled disks, and Kubernetes
and other orchestration tools killing the process after some time.

Touches #81786.
Resolves #81511.
Resolves #81827.

Release note: None