### PR TITLE
release-22.1: sql: add is_grantable column to SHOW GRANTS FOR role

### DIFF
--- a/pkg/sql/delegate/show_grants.go
+++ b/pkg/sql/delegate/show_grants.go
@@ -205,20 +205,20 @@ FROM "".information_schema.type_privileges`
 		} else {
 			// No target: only look at types, tables and schemas in the current database.
 			source.WriteString(
-				`SELECT database_name, schema_name, table_name AS relation_name, grantee, privilege_type FROM (`,
+				`SELECT database_name, schema_name, table_name AS relation_name, grantee, privilege_type, is_grantable FROM (`,
 			)
 			source.WriteString(tablePrivQuery)
 			source.WriteByte(')')
 			source.WriteString(` UNION ALL ` +
-				`SELECT database_name, schema_name, NULL::STRING AS relation_name, grantee, privilege_type FROM (`)
+				`SELECT database_name, schema_name, NULL::STRING AS relation_name, grantee, privilege_type, is_grantable FROM (`)
 			source.WriteString(schemaPrivQuery)
 			source.WriteByte(')')
 			source.WriteString(` UNION ALL ` +
-				`SELECT database_name, NULL::STRING AS schema_name, NULL::STRING AS relation_name, grantee, privilege_type FROM (`)
+				`SELECT database_name, NULL::STRING AS schema_name, NULL::STRING AS relation_name, grantee, privilege_type, is_grantable FROM (`)
 			source.WriteString(dbPrivQuery)
 			source.WriteByte(')')
 			source.WriteString(` UNION ALL ` +
-				`SELECT database_name, schema_name, type_name AS relation_name, grantee, privilege_type FROM (`)
+				`SELECT database_name, schema_name, type_name AS relation_name, grantee, privilege_type, is_grantable FROM (`)
 			source.WriteString(typePrivQuery)
 			source.WriteByte(')')
 			// If the current database is set, restrict the command to it.

--- a/pkg/sql/logictest/testdata/logic_test/grant_on_all_tables_in_schema
+++ b/pkg/sql/logictest/testdata/logic_test/grant_on_all_tables_in_schema
@@ -9,10 +9,10 @@ CREATE SCHEMA s2;
 statement ok
 GRANT SELECT ON ALL TABLES IN SCHEMA s TO testuser
 
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee  privilege_type
+database_name  schema_name  relation_name  grantee  privilege_type  is_grantable
 
 statement ok
 CREATE TABLE s.t();
@@ -21,79 +21,79 @@ CREATE TABLE s2.t();
 statement ok
 GRANT SELECT ON ALL TABLES IN SCHEMA s TO testuser
 
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee   privilege_type
-test           s            t              testuser  SELECT
+database_name  schema_name  relation_name  grantee   privilege_type  is_grantable
+test           s            t              testuser  SELECT          false
 
 statement ok
 GRANT SELECT ON ALL TABLES IN SCHEMA s, s2 TO testuser, testuser2
 
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR testuser, testuser2
 ----
-database_name  schema_name  relation_name  grantee    privilege_type
-test           s            t              testuser   SELECT
-test           s            t              testuser2  SELECT
-test           s2           t              testuser   SELECT
-test           s2           t              testuser2  SELECT
+database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
+test           s            t              testuser   SELECT          false
+test           s            t              testuser2  SELECT          false
+test           s2           t              testuser   SELECT          false
+test           s2           t              testuser2  SELECT          false
 
 statement ok
 GRANT ALL ON ALL TABLES IN SCHEMA s, s2 TO testuser, testuser2
 
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR testuser, testuser2
 ----
-database_name  schema_name  relation_name  grantee    privilege_type
-test           s            t              testuser   ALL
-test           s            t              testuser2  ALL
-test           s2           t              testuser   ALL
-test           s2           t              testuser2  ALL
+database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
+test           s            t              testuser   ALL             true
+test           s            t              testuser2  ALL             true
+test           s2           t              testuser   ALL             true
+test           s2           t              testuser2  ALL             true
 
 statement ok
 REVOKE SELECT ON ALL TABLES IN SCHEMA s, s2 FROM testuser, testuser2
 
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR testuser, testuser2
 ----
-database_name  schema_name  relation_name  grantee    privilege_type
-test           s            t              testuser   CREATE
-test           s            t              testuser   DELETE
-test           s            t              testuser   DROP
-test           s            t              testuser   GRANT
-test           s            t              testuser   INSERT
-test           s            t              testuser   UPDATE
-test           s            t              testuser   ZONECONFIG
-test           s            t              testuser2  CREATE
-test           s            t              testuser2  DELETE
-test           s            t              testuser2  DROP
-test           s            t              testuser2  GRANT
-test           s            t              testuser2  INSERT
-test           s            t              testuser2  UPDATE
-test           s            t              testuser2  ZONECONFIG
-test           s2           t              testuser   CREATE
-test           s2           t              testuser   DELETE
-test           s2           t              testuser   DROP
-test           s2           t              testuser   GRANT
-test           s2           t              testuser   INSERT
-test           s2           t              testuser   UPDATE
-test           s2           t              testuser   ZONECONFIG
-test           s2           t              testuser2  CREATE
-test           s2           t              testuser2  DELETE
-test           s2           t              testuser2  DROP
-test           s2           t              testuser2  GRANT
-test           s2           t              testuser2  INSERT
-test           s2           t              testuser2  UPDATE
-test           s2           t              testuser2  ZONECONFIG
+database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
+test           s            t              testuser   CREATE          true
+test           s            t              testuser   DELETE          true
+test           s            t              testuser   DROP            true
+test           s            t              testuser   GRANT           true
+test           s            t              testuser   INSERT          true
+test           s            t              testuser   UPDATE          true
+test           s            t              testuser   ZONECONFIG      true
+test           s            t              testuser2  CREATE          true
+test           s            t              testuser2  DELETE          true
+test           s            t              testuser2  DROP            true
+test           s            t              testuser2  GRANT           true
+test           s            t              testuser2  INSERT          true
+test           s            t              testuser2  UPDATE          true
+test           s            t              testuser2  ZONECONFIG      true
+test           s2           t              testuser   CREATE          true
+test           s2           t              testuser   DELETE          true
+test           s2           t              testuser   DROP            true
+test           s2           t              testuser   GRANT           true
+test           s2           t              testuser   INSERT          true
+test           s2           t              testuser   UPDATE          true
+test           s2           t              testuser   ZONECONFIG      true
+test           s2           t              testuser2  CREATE          true
+test           s2           t              testuser2  DELETE          true
+test           s2           t              testuser2  DROP            true
+test           s2           t              testuser2  GRANT           true
+test           s2           t              testuser2  INSERT          true
+test           s2           t              testuser2  UPDATE          true
+test           s2           t              testuser2  ZONECONFIG      true
 
 statement ok
 REVOKE ALL ON ALL TABLES IN SCHEMA s, s2 FROM testuser, testuser2
 
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR testuser, testuser2
 ----
-database_name  schema_name  relation_name  grantee  privilege_type
+database_name  schema_name  relation_name  grantee  privilege_type  is_grantable
 
 # Verify that the database name is resolved correctly if specified.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option
+++ b/pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option
@@ -63,12 +63,12 @@ user testuser
 statement ok
 GRANT SELECT, INSERT ON TABLE t TO testuser2
 
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR testuser2
 ----
-database_name  schema_name  relation_name  grantee    privilege_type
-test           public       t              testuser2  INSERT
-test           public       t              testuser2  SELECT
+database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
+test           public       t              testuser2  INSERT          false
+test           public       t              testuser2  SELECT          false
 
 user testuser2
 
@@ -83,13 +83,13 @@ GRANT GRANT ON TABLE t TO testuser2
 NOTICE: the GRANT privilege is deprecated
 HINT: please use WITH GRANT OPTION
 
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR testuser2
 ----
-database_name  schema_name  relation_name  grantee    privilege_type
-test           public       t              testuser2  GRANT
-test           public       t              testuser2  INSERT
-test           public       t              testuser2  SELECT
+database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
+test           public       t              testuser2  GRANT           true
+test           public       t              testuser2  INSERT          true
+test           public       t              testuser2  SELECT          true
 
 user testuser2
 
@@ -121,27 +121,27 @@ GRANT DELETE, UPDATE ON TABLE t TO testuser2 WITH GRANT OPTION
 statement ok
 REVOKE INSERT ON TABLE t FROM testuser2
 
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR testuser2
 ----
-database_name  schema_name  relation_name  grantee    privilege_type
-test           public       t              testuser2  DELETE
-test           public       t              testuser2  GRANT
-test           public       t              testuser2  SELECT
-test           public       t              testuser2  UPDATE
+database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
+test           public       t              testuser2  DELETE          true
+test           public       t              testuser2  GRANT           true
+test           public       t              testuser2  SELECT          true
+test           public       t              testuser2  UPDATE          true
 
 statement ok
 REVOKE GRANT OPTION FOR SELECT ON TABLE t FROM testuser2
 
 # revoking GRANT OPTION FOR does not take away the privilege for the user
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR testuser2
 ----
-database_name  schema_name  relation_name  grantee    privilege_type
-test           public       t              testuser2  DELETE
-test           public       t              testuser2  GRANT
-test           public       t              testuser2  SELECT
-test           public       t              testuser2  UPDATE
+database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
+test           public       t              testuser2  DELETE          true
+test           public       t              testuser2  GRANT           true
+test           public       t              testuser2  SELECT          false
+test           public       t              testuser2  UPDATE          true
 
 user testuser2
 
@@ -223,11 +223,11 @@ REVOKE GRANT OPTION FOR ALL PRIVILEGES ON TABLE t FROM testuser2
 statement ok
 REVOKE GRANT OPTION FOR ALL PRIVILEGES ON TABLE t FROM testuser
 
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee    privilege_type
-test           public       t              testuser   ALL
+database_name  schema_name  relation_name  grantee   privilege_type  is_grantable
+test           public       t              testuser  ALL             false
 
 user testuser
 
@@ -239,30 +239,30 @@ user root
 statement ok
 REVOKE ALL PRIVILEGES ON TABLE t FROM testuser
 
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee    privilege_type
+database_name  schema_name  relation_name  grantee  privilege_type  is_grantable
 
 statement ok
 GRANT UPDATE, DELETE ON TABLE t to testuser WITH GRANT OPTION
 
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee    privilege_type
-test           public       t              testuser   DELETE
-test           public       t              testuser   UPDATE
+database_name  schema_name  relation_name  grantee   privilege_type  is_grantable
+test           public       t              testuser  DELETE          true
+test           public       t              testuser  UPDATE          true
 
 # test applying repeat privileges (ALL replaces individual privileges)
 statement ok
 GRANT ALL PRIVILEGES ON TABLE t to testuser WITH GRANT OPTION
 
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee    privilege_type
-test           public       t              testuser   ALL
+database_name  schema_name  relation_name  grantee   privilege_type  is_grantable
+test           public       t              testuser  ALL             true
 
 user testuser
 
@@ -274,11 +274,11 @@ user root
 statement ok
 REVOKE GRANT OPTION FOR UPDATE, DELETE ON TABLE t FROM testuser
 
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee    privilege_type
-test           public       t              testuser   ALL
+database_name  schema_name  relation_name  grantee   privilege_type  is_grantable
+test           public       t              testuser  ALL             false
 
 user testuser
 
@@ -291,15 +291,15 @@ GRANT UPDATE ON TABLE t TO testuser2 WITH GRANT OPTION
 statement error user testuser missing WITH GRANT OPTION privilege on DELETE
 GRANT DELETE ON TABLE t TO testuser2 WITH GRANT OPTION
 
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR testuser2
 ----
-database_name  schema_name  relation_name  grantee    privilege_type
-test           public       t              testuser2  DELETE
-test           public       t              testuser2  GRANT
-test           public       t              testuser2  INSERT
-test           public       t              testuser2  SELECT
-test           public       t              testuser2  UPDATE
+database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
+test           public       t              testuser2  DELETE          false
+test           public       t              testuser2  GRANT           false
+test           public       t              testuser2  INSERT          false
+test           public       t              testuser2  SELECT          true
+test           public       t              testuser2  UPDATE          false
 
 user testuser2
 
@@ -338,17 +338,17 @@ GRANT DELETE ON TABLE t TO testuser
 statement ok
 REVOKE DELETE ON TABLE t FROM testuser
 
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee    privilege_type
-test           public       t              testuser   CREATE
-test           public       t              testuser   DROP
-test           public       t              testuser   GRANT
-test           public       t              testuser   INSERT
-test           public       t              testuser   SELECT
-test           public       t              testuser   UPDATE
-test           public       t              testuser   ZONECONFIG
+database_name  schema_name  relation_name  grantee   privilege_type  is_grantable
+test           public       t              testuser  CREATE          true
+test           public       t              testuser  DROP            true
+test           public       t              testuser  GRANT           true
+test           public       t              testuser  INSERT          true
+test           public       t              testuser  SELECT          true
+test           public       t              testuser  UPDATE          true
+test           public       t              testuser  ZONECONFIG      true
 
 statement ok
 GRANT SELECT ON TABLE t TO target
@@ -380,10 +380,10 @@ GRANT ALL PRIVILEGES ON TABLE t TO testuser WITH GRANT OPTION
 statement ok
 REVOKE ALL PRIVILEGES ON TABLE t FROM testuser
 
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee    privilege_type
+database_name  schema_name  relation_name  grantee  privilege_type  is_grantable
 
 # revoking grant from ALL privileges means you lose grant options on
 # all the other privileges
@@ -395,17 +395,17 @@ GRANT ALL PRIVILEGES ON TABLE t TO testuser
 statement ok
 REVOKE GRANT ON TABLE t FROM testuser
 
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee   privilege_type
-test           public       t              testuser  CREATE
-test           public       t              testuser  DELETE
-test           public       t              testuser  DROP
-test           public       t              testuser  INSERT
-test           public       t              testuser  SELECT
-test           public       t              testuser  UPDATE
-test           public       t              testuser  ZONECONFIG
+database_name  schema_name  relation_name  grantee   privilege_type  is_grantable
+test           public       t              testuser  CREATE          false
+test           public       t              testuser  DELETE          false
+test           public       t              testuser  DROP            false
+test           public       t              testuser  INSERT          false
+test           public       t              testuser  SELECT          false
+test           public       t              testuser  UPDATE          false
+test           public       t              testuser  ZONECONFIG      false
 
 user testuser
 
@@ -424,15 +424,15 @@ REVOKE ALL PRIVILEGES ON TABLE t FROM testuser
 statement ok
 REVOKE ALL PRIVILEGES ON TABLE t FROM testuser2
 
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee    privilege_type
+database_name  schema_name  relation_name  grantee  privilege_type  is_grantable
 
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR testuser2
 ----
-database_name  schema_name  relation_name  grantee    privilege_type
+database_name  schema_name  relation_name  grantee  privilege_type  is_grantable
 
 statement ok
 CREATE SCHEMA s
@@ -440,11 +440,11 @@ CREATE SCHEMA s
 statement ok
 GRANT ALL PRIVILEGES ON SCHEMA s TO testuser WITH GRANT OPTION
 
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee    privilege_type
-test           s            NULL           testuser   ALL
+database_name  schema_name  relation_name  grantee   privilege_type  is_grantable
+test           s            NULL           testuser  ALL             true
 
 user testuser
 
@@ -453,20 +453,20 @@ GRANT CREATE ON SCHEMA s TO testuser2 WITH GRANT OPTION
 
 user root
 
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR testuser2
 ----
-database_name  schema_name  relation_name  grantee    privilege_type
-test           s            NULL           testuser2  CREATE
+database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
+test           s            NULL           testuser2  CREATE          true
 
 statement ok
 REVOKE GRANT OPTION FOR ALL PRIVILEGES ON SCHEMA s FROM testuser
 
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee    privilege_type
-test           s            NULL           testuser   ALL
+database_name  schema_name  relation_name  grantee   privilege_type  is_grantable
+test           s            NULL           testuser  ALL             false
 
 user testuser
 

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -19,1575 +19,1575 @@ a              readwrite  ALL             true
 a              root       ALL             true
 
 # Show that by default GRANT is restricted to the current database
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS
 ----
-database_name  schema_name         relation_name                          grantee  privilege_type
-test           NULL                NULL                                   admin    ALL
-test           NULL                NULL                                   public   CONNECT
-test           NULL                NULL                                   root     ALL
-test           crdb_internal       NULL                                   public   USAGE
-test           crdb_internal       active_range_feeds                     public   SELECT
-test           crdb_internal       backward_dependencies                  public   SELECT
-test           crdb_internal       builtin_functions                      public   SELECT
-test           crdb_internal       cluster_contended_indexes              public   SELECT
-test           crdb_internal       cluster_contended_keys                 public   SELECT
-test           crdb_internal       cluster_contended_tables               public   SELECT
-test           crdb_internal       cluster_contention_events              public   SELECT
-test           crdb_internal       cluster_database_privileges            public   SELECT
-test           crdb_internal       cluster_distsql_flows                  public   SELECT
-test           crdb_internal       cluster_inflight_traces                public   SELECT
-test           crdb_internal       cluster_locks                          public   SELECT
-test           crdb_internal       cluster_queries                        public   SELECT
-test           crdb_internal       cluster_sessions                       public   SELECT
-test           crdb_internal       cluster_settings                       public   SELECT
-test           crdb_internal       cluster_statement_statistics           public   SELECT
-test           crdb_internal       cluster_transaction_statistics         public   SELECT
-test           crdb_internal       cluster_transactions                   public   SELECT
-test           crdb_internal       create_schema_statements               public   SELECT
-test           crdb_internal       create_statements                      public   SELECT
-test           crdb_internal       create_type_statements                 public   SELECT
-test           crdb_internal       cross_db_references                    public   SELECT
-test           crdb_internal       databases                              public   SELECT
-test           crdb_internal       default_privileges                     public   SELECT
-test           crdb_internal       feature_usage                          public   SELECT
-test           crdb_internal       forward_dependencies                   public   SELECT
-test           crdb_internal       gossip_alerts                          public   SELECT
-test           crdb_internal       gossip_liveness                        public   SELECT
-test           crdb_internal       gossip_network                         public   SELECT
-test           crdb_internal       gossip_nodes                           public   SELECT
-test           crdb_internal       index_columns                          public   SELECT
-test           crdb_internal       index_usage_statistics                 public   SELECT
-test           crdb_internal       invalid_objects                        public   SELECT
-test           crdb_internal       jobs                                   public   SELECT
-test           crdb_internal       kv_node_liveness                       public   SELECT
-test           crdb_internal       kv_node_status                         public   SELECT
-test           crdb_internal       kv_store_status                        public   SELECT
-test           crdb_internal       leases                                 public   SELECT
-test           crdb_internal       lost_descriptors_with_data             public   SELECT
-test           crdb_internal       node_build_info                        public   SELECT
-test           crdb_internal       node_contention_events                 public   SELECT
-test           crdb_internal       node_distsql_flows                     public   SELECT
-test           crdb_internal       node_inflight_trace_spans              public   SELECT
-test           crdb_internal       node_metrics                           public   SELECT
-test           crdb_internal       node_queries                           public   SELECT
-test           crdb_internal       node_runtime_info                      public   SELECT
-test           crdb_internal       node_sessions                          public   SELECT
-test           crdb_internal       node_statement_statistics              public   SELECT
-test           crdb_internal       node_transaction_statistics            public   SELECT
-test           crdb_internal       node_transactions                      public   SELECT
-test           crdb_internal       node_txn_stats                         public   SELECT
-test           crdb_internal       partitions                             public   SELECT
-test           crdb_internal       pg_catalog_table_is_implemented        public   SELECT
-test           crdb_internal       predefined_comments                    public   SELECT
-test           crdb_internal       ranges                                 public   SELECT
-test           crdb_internal       ranges_no_leases                       public   SELECT
-test           crdb_internal       regions                                public   SELECT
-test           crdb_internal       schema_changes                         public   SELECT
-test           crdb_internal       session_trace                          public   SELECT
-test           crdb_internal       session_variables                      public   SELECT
-test           crdb_internal       statement_statistics                   public   SELECT
-test           crdb_internal       super_regions                          public   SELECT
-test           crdb_internal       table_columns                          public   SELECT
-test           crdb_internal       table_indexes                          public   SELECT
-test           crdb_internal       table_row_statistics                   public   SELECT
-test           crdb_internal       tables                                 public   SELECT
-test           crdb_internal       tenant_usage_details                   public   SELECT
-test           crdb_internal       transaction_contention_events          public   SELECT
-test           crdb_internal       transaction_statistics                 public   SELECT
-test           crdb_internal       zones                                  public   SELECT
-test           information_schema  NULL                                   public   USAGE
-test           information_schema  administrable_role_authorizations      public   SELECT
-test           information_schema  applicable_roles                       public   SELECT
-test           information_schema  attributes                             public   SELECT
-test           information_schema  character_sets                         public   SELECT
-test           information_schema  check_constraint_routine_usage         public   SELECT
-test           information_schema  check_constraints                      public   SELECT
-test           information_schema  collation_character_set_applicability  public   SELECT
-test           information_schema  collations                             public   SELECT
-test           information_schema  column_column_usage                    public   SELECT
-test           information_schema  column_domain_usage                    public   SELECT
-test           information_schema  column_options                         public   SELECT
-test           information_schema  column_privileges                      public   SELECT
-test           information_schema  column_statistics                      public   SELECT
-test           information_schema  column_udt_usage                       public   SELECT
-test           information_schema  columns                                public   SELECT
-test           information_schema  columns_extensions                     public   SELECT
-test           information_schema  constraint_column_usage                public   SELECT
-test           information_schema  constraint_table_usage                 public   SELECT
-test           information_schema  data_type_privileges                   public   SELECT
-test           information_schema  domain_constraints                     public   SELECT
-test           information_schema  domain_udt_usage                       public   SELECT
-test           information_schema  domains                                public   SELECT
-test           information_schema  element_types                          public   SELECT
-test           information_schema  enabled_roles                          public   SELECT
-test           information_schema  engines                                public   SELECT
-test           information_schema  events                                 public   SELECT
-test           information_schema  files                                  public   SELECT
-test           information_schema  foreign_data_wrapper_options           public   SELECT
-test           information_schema  foreign_data_wrappers                  public   SELECT
-test           information_schema  foreign_server_options                 public   SELECT
-test           information_schema  foreign_servers                        public   SELECT
-test           information_schema  foreign_table_options                  public   SELECT
-test           information_schema  foreign_tables                         public   SELECT
-test           information_schema  information_schema_catalog_name        public   SELECT
-test           information_schema  key_column_usage                       public   SELECT
-test           information_schema  keywords                               public   SELECT
-test           information_schema  optimizer_trace                        public   SELECT
-test           information_schema  parameters                             public   SELECT
-test           information_schema  partitions                             public   SELECT
-test           information_schema  plugins                                public   SELECT
-test           information_schema  processlist                            public   SELECT
-test           information_schema  profiling                              public   SELECT
-test           information_schema  referential_constraints                public   SELECT
-test           information_schema  resource_groups                        public   SELECT
-test           information_schema  role_column_grants                     public   SELECT
-test           information_schema  role_routine_grants                    public   SELECT
-test           information_schema  role_table_grants                      public   SELECT
-test           information_schema  role_udt_grants                        public   SELECT
-test           information_schema  role_usage_grants                      public   SELECT
-test           information_schema  routine_privileges                     public   SELECT
-test           information_schema  routines                               public   SELECT
-test           information_schema  schema_privileges                      public   SELECT
-test           information_schema  schemata                               public   SELECT
-test           information_schema  schemata_extensions                    public   SELECT
-test           information_schema  sequences                              public   SELECT
-test           information_schema  session_variables                      public   SELECT
-test           information_schema  sql_features                           public   SELECT
-test           information_schema  sql_implementation_info                public   SELECT
-test           information_schema  sql_parts                              public   SELECT
-test           information_schema  sql_sizing                             public   SELECT
-test           information_schema  st_geometry_columns                    public   SELECT
-test           information_schema  st_spatial_reference_systems           public   SELECT
-test           information_schema  st_units_of_measure                    public   SELECT
-test           information_schema  statistics                             public   SELECT
-test           information_schema  table_constraints                      public   SELECT
-test           information_schema  table_constraints_extensions           public   SELECT
-test           information_schema  table_privileges                       public   SELECT
-test           information_schema  tables                                 public   SELECT
-test           information_schema  tables_extensions                      public   SELECT
-test           information_schema  tablespaces                            public   SELECT
-test           information_schema  tablespaces_extensions                 public   SELECT
-test           information_schema  transforms                             public   SELECT
-test           information_schema  triggered_update_columns               public   SELECT
-test           information_schema  triggers                               public   SELECT
-test           information_schema  type_privileges                        public   SELECT
-test           information_schema  udt_privileges                         public   SELECT
-test           information_schema  usage_privileges                       public   SELECT
-test           information_schema  user_attributes                        public   SELECT
-test           information_schema  user_defined_types                     public   SELECT
-test           information_schema  user_mapping_options                   public   SELECT
-test           information_schema  user_mappings                          public   SELECT
-test           information_schema  user_privileges                        public   SELECT
-test           information_schema  view_column_usage                      public   SELECT
-test           information_schema  view_routine_usage                     public   SELECT
-test           information_schema  view_table_usage                       public   SELECT
-test           information_schema  views                                  public   SELECT
-test           pg_catalog          NULL                                   public   USAGE
-test           pg_catalog          "char"                                 admin    ALL
-test           pg_catalog          "char"                                 public   USAGE
-test           pg_catalog          "char"                                 root     ALL
-test           pg_catalog          "char"[]                               admin    ALL
-test           pg_catalog          "char"[]                               public   USAGE
-test           pg_catalog          "char"[]                               root     ALL
-test           pg_catalog          anyelement                             admin    ALL
-test           pg_catalog          anyelement                             public   USAGE
-test           pg_catalog          anyelement                             root     ALL
-test           pg_catalog          anyelement[]                           admin    ALL
-test           pg_catalog          anyelement[]                           public   USAGE
-test           pg_catalog          anyelement[]                           root     ALL
-test           pg_catalog          bit                                    admin    ALL
-test           pg_catalog          bit                                    public   USAGE
-test           pg_catalog          bit                                    root     ALL
-test           pg_catalog          bit[]                                  admin    ALL
-test           pg_catalog          bit[]                                  public   USAGE
-test           pg_catalog          bit[]                                  root     ALL
-test           pg_catalog          bool                                   admin    ALL
-test           pg_catalog          bool                                   public   USAGE
-test           pg_catalog          bool                                   root     ALL
-test           pg_catalog          bool[]                                 admin    ALL
-test           pg_catalog          bool[]                                 public   USAGE
-test           pg_catalog          bool[]                                 root     ALL
-test           pg_catalog          box2d                                  admin    ALL
-test           pg_catalog          box2d                                  public   USAGE
-test           pg_catalog          box2d                                  root     ALL
-test           pg_catalog          box2d[]                                admin    ALL
-test           pg_catalog          box2d[]                                public   USAGE
-test           pg_catalog          box2d[]                                root     ALL
-test           pg_catalog          bytes                                  admin    ALL
-test           pg_catalog          bytes                                  public   USAGE
-test           pg_catalog          bytes                                  root     ALL
-test           pg_catalog          bytes[]                                admin    ALL
-test           pg_catalog          bytes[]                                public   USAGE
-test           pg_catalog          bytes[]                                root     ALL
-test           pg_catalog          char                                   admin    ALL
-test           pg_catalog          char                                   public   USAGE
-test           pg_catalog          char                                   root     ALL
-test           pg_catalog          char[]                                 admin    ALL
-test           pg_catalog          char[]                                 public   USAGE
-test           pg_catalog          char[]                                 root     ALL
-test           pg_catalog          date                                   admin    ALL
-test           pg_catalog          date                                   public   USAGE
-test           pg_catalog          date                                   root     ALL
-test           pg_catalog          date[]                                 admin    ALL
-test           pg_catalog          date[]                                 public   USAGE
-test           pg_catalog          date[]                                 root     ALL
-test           pg_catalog          decimal                                admin    ALL
-test           pg_catalog          decimal                                public   USAGE
-test           pg_catalog          decimal                                root     ALL
-test           pg_catalog          decimal[]                              admin    ALL
-test           pg_catalog          decimal[]                              public   USAGE
-test           pg_catalog          decimal[]                              root     ALL
-test           pg_catalog          float                                  admin    ALL
-test           pg_catalog          float                                  public   USAGE
-test           pg_catalog          float                                  root     ALL
-test           pg_catalog          float4                                 admin    ALL
-test           pg_catalog          float4                                 public   USAGE
-test           pg_catalog          float4                                 root     ALL
-test           pg_catalog          float4[]                               admin    ALL
-test           pg_catalog          float4[]                               public   USAGE
-test           pg_catalog          float4[]                               root     ALL
-test           pg_catalog          float[]                                admin    ALL
-test           pg_catalog          float[]                                public   USAGE
-test           pg_catalog          float[]                                root     ALL
-test           pg_catalog          geography                              admin    ALL
-test           pg_catalog          geography                              public   USAGE
-test           pg_catalog          geography                              root     ALL
-test           pg_catalog          geography[]                            admin    ALL
-test           pg_catalog          geography[]                            public   USAGE
-test           pg_catalog          geography[]                            root     ALL
-test           pg_catalog          geometry                               admin    ALL
-test           pg_catalog          geometry                               public   USAGE
-test           pg_catalog          geometry                               root     ALL
-test           pg_catalog          geometry[]                             admin    ALL
-test           pg_catalog          geometry[]                             public   USAGE
-test           pg_catalog          geometry[]                             root     ALL
-test           pg_catalog          inet                                   admin    ALL
-test           pg_catalog          inet                                   public   USAGE
-test           pg_catalog          inet                                   root     ALL
-test           pg_catalog          inet[]                                 admin    ALL
-test           pg_catalog          inet[]                                 public   USAGE
-test           pg_catalog          inet[]                                 root     ALL
-test           pg_catalog          int                                    admin    ALL
-test           pg_catalog          int                                    public   USAGE
-test           pg_catalog          int                                    root     ALL
-test           pg_catalog          int2                                   admin    ALL
-test           pg_catalog          int2                                   public   USAGE
-test           pg_catalog          int2                                   root     ALL
-test           pg_catalog          int2[]                                 admin    ALL
-test           pg_catalog          int2[]                                 public   USAGE
-test           pg_catalog          int2[]                                 root     ALL
-test           pg_catalog          int2vector                             admin    ALL
-test           pg_catalog          int2vector                             public   USAGE
-test           pg_catalog          int2vector                             root     ALL
-test           pg_catalog          int2vector[]                           admin    ALL
-test           pg_catalog          int2vector[]                           public   USAGE
-test           pg_catalog          int2vector[]                           root     ALL
-test           pg_catalog          int4                                   admin    ALL
-test           pg_catalog          int4                                   public   USAGE
-test           pg_catalog          int4                                   root     ALL
-test           pg_catalog          int4[]                                 admin    ALL
-test           pg_catalog          int4[]                                 public   USAGE
-test           pg_catalog          int4[]                                 root     ALL
-test           pg_catalog          int[]                                  admin    ALL
-test           pg_catalog          int[]                                  public   USAGE
-test           pg_catalog          int[]                                  root     ALL
-test           pg_catalog          interval                               admin    ALL
-test           pg_catalog          interval                               public   USAGE
-test           pg_catalog          interval                               root     ALL
-test           pg_catalog          interval[]                             admin    ALL
-test           pg_catalog          interval[]                             public   USAGE
-test           pg_catalog          interval[]                             root     ALL
-test           pg_catalog          jsonb                                  admin    ALL
-test           pg_catalog          jsonb                                  public   USAGE
-test           pg_catalog          jsonb                                  root     ALL
-test           pg_catalog          jsonb[]                                admin    ALL
-test           pg_catalog          jsonb[]                                public   USAGE
-test           pg_catalog          jsonb[]                                root     ALL
-test           pg_catalog          name                                   admin    ALL
-test           pg_catalog          name                                   public   USAGE
-test           pg_catalog          name                                   root     ALL
-test           pg_catalog          name[]                                 admin    ALL
-test           pg_catalog          name[]                                 public   USAGE
-test           pg_catalog          name[]                                 root     ALL
-test           pg_catalog          oid                                    admin    ALL
-test           pg_catalog          oid                                    public   USAGE
-test           pg_catalog          oid                                    root     ALL
-test           pg_catalog          oid[]                                  admin    ALL
-test           pg_catalog          oid[]                                  public   USAGE
-test           pg_catalog          oid[]                                  root     ALL
-test           pg_catalog          oidvector                              admin    ALL
-test           pg_catalog          oidvector                              public   USAGE
-test           pg_catalog          oidvector                              root     ALL
-test           pg_catalog          oidvector[]                            admin    ALL
-test           pg_catalog          oidvector[]                            public   USAGE
-test           pg_catalog          oidvector[]                            root     ALL
-test           pg_catalog          pg_aggregate                           public   SELECT
-test           pg_catalog          pg_am                                  public   SELECT
-test           pg_catalog          pg_amop                                public   SELECT
-test           pg_catalog          pg_amproc                              public   SELECT
-test           pg_catalog          pg_attrdef                             public   SELECT
-test           pg_catalog          pg_attribute                           public   SELECT
-test           pg_catalog          pg_auth_members                        public   SELECT
-test           pg_catalog          pg_authid                              public   SELECT
-test           pg_catalog          pg_available_extension_versions        public   SELECT
-test           pg_catalog          pg_available_extensions                public   SELECT
-test           pg_catalog          pg_cast                                public   SELECT
-test           pg_catalog          pg_class                               public   SELECT
-test           pg_catalog          pg_collation                           public   SELECT
-test           pg_catalog          pg_config                              public   SELECT
-test           pg_catalog          pg_constraint                          public   SELECT
-test           pg_catalog          pg_conversion                          public   SELECT
-test           pg_catalog          pg_cursors                             public   SELECT
-test           pg_catalog          pg_database                            public   SELECT
-test           pg_catalog          pg_db_role_setting                     public   SELECT
-test           pg_catalog          pg_default_acl                         public   SELECT
-test           pg_catalog          pg_depend                              public   SELECT
-test           pg_catalog          pg_description                         public   SELECT
-test           pg_catalog          pg_enum                                public   SELECT
-test           pg_catalog          pg_event_trigger                       public   SELECT
-test           pg_catalog          pg_extension                           public   SELECT
-test           pg_catalog          pg_file_settings                       public   SELECT
-test           pg_catalog          pg_foreign_data_wrapper                public   SELECT
-test           pg_catalog          pg_foreign_server                      public   SELECT
-test           pg_catalog          pg_foreign_table                       public   SELECT
-test           pg_catalog          pg_group                               public   SELECT
-test           pg_catalog          pg_hba_file_rules                      public   SELECT
-test           pg_catalog          pg_index                               public   SELECT
-test           pg_catalog          pg_indexes                             public   SELECT
-test           pg_catalog          pg_inherits                            public   SELECT
-test           pg_catalog          pg_init_privs                          public   SELECT
-test           pg_catalog          pg_language                            public   SELECT
-test           pg_catalog          pg_largeobject                         public   SELECT
-test           pg_catalog          pg_largeobject_metadata                public   SELECT
-test           pg_catalog          pg_locks                               public   SELECT
-test           pg_catalog          pg_matviews                            public   SELECT
-test           pg_catalog          pg_namespace                           public   SELECT
-test           pg_catalog          pg_opclass                             public   SELECT
-test           pg_catalog          pg_operator                            public   SELECT
-test           pg_catalog          pg_opfamily                            public   SELECT
-test           pg_catalog          pg_partitioned_table                   public   SELECT
-test           pg_catalog          pg_policies                            public   SELECT
-test           pg_catalog          pg_policy                              public   SELECT
-test           pg_catalog          pg_prepared_statements                 public   SELECT
-test           pg_catalog          pg_prepared_xacts                      public   SELECT
-test           pg_catalog          pg_proc                                public   SELECT
-test           pg_catalog          pg_publication                         public   SELECT
-test           pg_catalog          pg_publication_rel                     public   SELECT
-test           pg_catalog          pg_publication_tables                  public   SELECT
-test           pg_catalog          pg_range                               public   SELECT
-test           pg_catalog          pg_replication_origin                  public   SELECT
-test           pg_catalog          pg_replication_origin_status           public   SELECT
-test           pg_catalog          pg_replication_slots                   public   SELECT
-test           pg_catalog          pg_rewrite                             public   SELECT
-test           pg_catalog          pg_roles                               public   SELECT
-test           pg_catalog          pg_rules                               public   SELECT
-test           pg_catalog          pg_seclabel                            public   SELECT
-test           pg_catalog          pg_seclabels                           public   SELECT
-test           pg_catalog          pg_sequence                            public   SELECT
-test           pg_catalog          pg_sequences                           public   SELECT
-test           pg_catalog          pg_settings                            public   SELECT
-test           pg_catalog          pg_shadow                              public   SELECT
-test           pg_catalog          pg_shdepend                            public   SELECT
-test           pg_catalog          pg_shdescription                       public   SELECT
-test           pg_catalog          pg_shmem_allocations                   public   SELECT
-test           pg_catalog          pg_shseclabel                          public   SELECT
-test           pg_catalog          pg_stat_activity                       public   SELECT
-test           pg_catalog          pg_stat_all_indexes                    public   SELECT
-test           pg_catalog          pg_stat_all_tables                     public   SELECT
-test           pg_catalog          pg_stat_archiver                       public   SELECT
-test           pg_catalog          pg_stat_bgwriter                       public   SELECT
-test           pg_catalog          pg_stat_database                       public   SELECT
-test           pg_catalog          pg_stat_database_conflicts             public   SELECT
-test           pg_catalog          pg_stat_gssapi                         public   SELECT
-test           pg_catalog          pg_stat_progress_analyze               public   SELECT
-test           pg_catalog          pg_stat_progress_basebackup            public   SELECT
-test           pg_catalog          pg_stat_progress_cluster               public   SELECT
-test           pg_catalog          pg_stat_progress_create_index          public   SELECT
-test           pg_catalog          pg_stat_progress_vacuum                public   SELECT
-test           pg_catalog          pg_stat_replication                    public   SELECT
-test           pg_catalog          pg_stat_slru                           public   SELECT
-test           pg_catalog          pg_stat_ssl                            public   SELECT
-test           pg_catalog          pg_stat_subscription                   public   SELECT
-test           pg_catalog          pg_stat_sys_indexes                    public   SELECT
-test           pg_catalog          pg_stat_sys_tables                     public   SELECT
-test           pg_catalog          pg_stat_user_functions                 public   SELECT
-test           pg_catalog          pg_stat_user_indexes                   public   SELECT
-test           pg_catalog          pg_stat_user_tables                    public   SELECT
-test           pg_catalog          pg_stat_wal_receiver                   public   SELECT
-test           pg_catalog          pg_stat_xact_all_tables                public   SELECT
-test           pg_catalog          pg_stat_xact_sys_tables                public   SELECT
-test           pg_catalog          pg_stat_xact_user_functions            public   SELECT
-test           pg_catalog          pg_stat_xact_user_tables               public   SELECT
-test           pg_catalog          pg_statio_all_indexes                  public   SELECT
-test           pg_catalog          pg_statio_all_sequences                public   SELECT
-test           pg_catalog          pg_statio_all_tables                   public   SELECT
-test           pg_catalog          pg_statio_sys_indexes                  public   SELECT
-test           pg_catalog          pg_statio_sys_sequences                public   SELECT
-test           pg_catalog          pg_statio_sys_tables                   public   SELECT
-test           pg_catalog          pg_statio_user_indexes                 public   SELECT
-test           pg_catalog          pg_statio_user_sequences               public   SELECT
-test           pg_catalog          pg_statio_user_tables                  public   SELECT
-test           pg_catalog          pg_statistic                           public   SELECT
-test           pg_catalog          pg_statistic_ext                       public   SELECT
-test           pg_catalog          pg_statistic_ext_data                  public   SELECT
-test           pg_catalog          pg_stats                               public   SELECT
-test           pg_catalog          pg_stats_ext                           public   SELECT
-test           pg_catalog          pg_subscription                        public   SELECT
-test           pg_catalog          pg_subscription_rel                    public   SELECT
-test           pg_catalog          pg_tables                              public   SELECT
-test           pg_catalog          pg_tablespace                          public   SELECT
-test           pg_catalog          pg_timezone_abbrevs                    public   SELECT
-test           pg_catalog          pg_timezone_names                      public   SELECT
-test           pg_catalog          pg_transform                           public   SELECT
-test           pg_catalog          pg_trigger                             public   SELECT
-test           pg_catalog          pg_ts_config                           public   SELECT
-test           pg_catalog          pg_ts_config_map                       public   SELECT
-test           pg_catalog          pg_ts_dict                             public   SELECT
-test           pg_catalog          pg_ts_parser                           public   SELECT
-test           pg_catalog          pg_ts_template                         public   SELECT
-test           pg_catalog          pg_type                                public   SELECT
-test           pg_catalog          pg_user                                public   SELECT
-test           pg_catalog          pg_user_mapping                        public   SELECT
-test           pg_catalog          pg_user_mappings                       public   SELECT
-test           pg_catalog          pg_views                               public   SELECT
-test           pg_catalog          record                                 admin    ALL
-test           pg_catalog          record                                 public   USAGE
-test           pg_catalog          record                                 root     ALL
-test           pg_catalog          record[]                               admin    ALL
-test           pg_catalog          record[]                               public   USAGE
-test           pg_catalog          record[]                               root     ALL
-test           pg_catalog          regclass                               admin    ALL
-test           pg_catalog          regclass                               public   USAGE
-test           pg_catalog          regclass                               root     ALL
-test           pg_catalog          regclass[]                             admin    ALL
-test           pg_catalog          regclass[]                             public   USAGE
-test           pg_catalog          regclass[]                             root     ALL
-test           pg_catalog          regnamespace                           admin    ALL
-test           pg_catalog          regnamespace                           public   USAGE
-test           pg_catalog          regnamespace                           root     ALL
-test           pg_catalog          regnamespace[]                         admin    ALL
-test           pg_catalog          regnamespace[]                         public   USAGE
-test           pg_catalog          regnamespace[]                         root     ALL
-test           pg_catalog          regproc                                admin    ALL
-test           pg_catalog          regproc                                public   USAGE
-test           pg_catalog          regproc                                root     ALL
-test           pg_catalog          regproc[]                              admin    ALL
-test           pg_catalog          regproc[]                              public   USAGE
-test           pg_catalog          regproc[]                              root     ALL
-test           pg_catalog          regprocedure                           admin    ALL
-test           pg_catalog          regprocedure                           public   USAGE
-test           pg_catalog          regprocedure                           root     ALL
-test           pg_catalog          regprocedure[]                         admin    ALL
-test           pg_catalog          regprocedure[]                         public   USAGE
-test           pg_catalog          regprocedure[]                         root     ALL
-test           pg_catalog          regrole                                admin    ALL
-test           pg_catalog          regrole                                public   USAGE
-test           pg_catalog          regrole                                root     ALL
-test           pg_catalog          regrole[]                              admin    ALL
-test           pg_catalog          regrole[]                              public   USAGE
-test           pg_catalog          regrole[]                              root     ALL
-test           pg_catalog          regtype                                admin    ALL
-test           pg_catalog          regtype                                public   USAGE
-test           pg_catalog          regtype                                root     ALL
-test           pg_catalog          regtype[]                              admin    ALL
-test           pg_catalog          regtype[]                              public   USAGE
-test           pg_catalog          regtype[]                              root     ALL
-test           pg_catalog          string                                 admin    ALL
-test           pg_catalog          string                                 public   USAGE
-test           pg_catalog          string                                 root     ALL
-test           pg_catalog          string[]                               admin    ALL
-test           pg_catalog          string[]                               public   USAGE
-test           pg_catalog          string[]                               root     ALL
-test           pg_catalog          time                                   admin    ALL
-test           pg_catalog          time                                   public   USAGE
-test           pg_catalog          time                                   root     ALL
-test           pg_catalog          time[]                                 admin    ALL
-test           pg_catalog          time[]                                 public   USAGE
-test           pg_catalog          time[]                                 root     ALL
-test           pg_catalog          timestamp                              admin    ALL
-test           pg_catalog          timestamp                              public   USAGE
-test           pg_catalog          timestamp                              root     ALL
-test           pg_catalog          timestamp[]                            admin    ALL
-test           pg_catalog          timestamp[]                            public   USAGE
-test           pg_catalog          timestamp[]                            root     ALL
-test           pg_catalog          timestamptz                            admin    ALL
-test           pg_catalog          timestamptz                            public   USAGE
-test           pg_catalog          timestamptz                            root     ALL
-test           pg_catalog          timestamptz[]                          admin    ALL
-test           pg_catalog          timestamptz[]                          public   USAGE
-test           pg_catalog          timestamptz[]                          root     ALL
-test           pg_catalog          timetz                                 admin    ALL
-test           pg_catalog          timetz                                 public   USAGE
-test           pg_catalog          timetz                                 root     ALL
-test           pg_catalog          timetz[]                               admin    ALL
-test           pg_catalog          timetz[]                               public   USAGE
-test           pg_catalog          timetz[]                               root     ALL
-test           pg_catalog          unknown                                admin    ALL
-test           pg_catalog          unknown                                public   USAGE
-test           pg_catalog          unknown                                root     ALL
-test           pg_catalog          uuid                                   admin    ALL
-test           pg_catalog          uuid                                   public   USAGE
-test           pg_catalog          uuid                                   root     ALL
-test           pg_catalog          uuid[]                                 admin    ALL
-test           pg_catalog          uuid[]                                 public   USAGE
-test           pg_catalog          uuid[]                                 root     ALL
-test           pg_catalog          varbit                                 admin    ALL
-test           pg_catalog          varbit                                 public   USAGE
-test           pg_catalog          varbit                                 root     ALL
-test           pg_catalog          varbit[]                               admin    ALL
-test           pg_catalog          varbit[]                               public   USAGE
-test           pg_catalog          varbit[]                               root     ALL
-test           pg_catalog          varchar                                admin    ALL
-test           pg_catalog          varchar                                public   USAGE
-test           pg_catalog          varchar                                root     ALL
-test           pg_catalog          varchar[]                              admin    ALL
-test           pg_catalog          varchar[]                              public   USAGE
-test           pg_catalog          varchar[]                              root     ALL
-test           pg_catalog          void                                   admin    ALL
-test           pg_catalog          void                                   public   USAGE
-test           pg_catalog          void                                   root     ALL
-test           pg_extension        NULL                                   public   USAGE
-test           pg_extension        geography_columns                      public   SELECT
-test           pg_extension        geometry_columns                       public   SELECT
-test           pg_extension        spatial_ref_sys                        public   SELECT
-test           public              NULL                                   admin    ALL
-test           public              NULL                                   public   CREATE
-test           public              NULL                                   public   USAGE
-test           public              NULL                                   root     ALL
+database_name  schema_name         relation_name                          grantee  privilege_type  is_grantable
+test           NULL                NULL                                   admin    ALL             true
+test           NULL                NULL                                   public   CONNECT         false
+test           NULL                NULL                                   root     ALL             true
+test           crdb_internal       NULL                                   public   USAGE           false
+test           crdb_internal       active_range_feeds                     public   SELECT          false
+test           crdb_internal       backward_dependencies                  public   SELECT          false
+test           crdb_internal       builtin_functions                      public   SELECT          false
+test           crdb_internal       cluster_contended_indexes              public   SELECT          false
+test           crdb_internal       cluster_contended_keys                 public   SELECT          false
+test           crdb_internal       cluster_contended_tables               public   SELECT          false
+test           crdb_internal       cluster_contention_events              public   SELECT          false
+test           crdb_internal       cluster_database_privileges            public   SELECT          false
+test           crdb_internal       cluster_distsql_flows                  public   SELECT          false
+test           crdb_internal       cluster_inflight_traces                public   SELECT          false
+test           crdb_internal       cluster_locks                          public   SELECT          false
+test           crdb_internal       cluster_queries                        public   SELECT          false
+test           crdb_internal       cluster_sessions                       public   SELECT          false
+test           crdb_internal       cluster_settings                       public   SELECT          false
+test           crdb_internal       cluster_statement_statistics           public   SELECT          false
+test           crdb_internal       cluster_transaction_statistics         public   SELECT          false
+test           crdb_internal       cluster_transactions                   public   SELECT          false
+test           crdb_internal       create_schema_statements               public   SELECT          false
+test           crdb_internal       create_statements                      public   SELECT          false
+test           crdb_internal       create_type_statements                 public   SELECT          false
+test           crdb_internal       cross_db_references                    public   SELECT          false
+test           crdb_internal       databases                              public   SELECT          false
+test           crdb_internal       default_privileges                     public   SELECT          false
+test           crdb_internal       feature_usage                          public   SELECT          false
+test           crdb_internal       forward_dependencies                   public   SELECT          false
+test           crdb_internal       gossip_alerts                          public   SELECT          false
+test           crdb_internal       gossip_liveness                        public   SELECT          false
+test           crdb_internal       gossip_network                         public   SELECT          false
+test           crdb_internal       gossip_nodes                           public   SELECT          false
+test           crdb_internal       index_columns                          public   SELECT          false
+test           crdb_internal       index_usage_statistics                 public   SELECT          false
+test           crdb_internal       invalid_objects                        public   SELECT          false
+test           crdb_internal       jobs                                   public   SELECT          false
+test           crdb_internal       kv_node_liveness                       public   SELECT          false
+test           crdb_internal       kv_node_status                         public   SELECT          false
+test           crdb_internal       kv_store_status                        public   SELECT          false
+test           crdb_internal       leases                                 public   SELECT          false
+test           crdb_internal       lost_descriptors_with_data             public   SELECT          false
+test           crdb_internal       node_build_info                        public   SELECT          false
+test           crdb_internal       node_contention_events                 public   SELECT          false
+test           crdb_internal       node_distsql_flows                     public   SELECT          false
+test           crdb_internal       node_inflight_trace_spans              public   SELECT          false
+test           crdb_internal       node_metrics                           public   SELECT          false
+test           crdb_internal       node_queries                           public   SELECT          false
+test           crdb_internal       node_runtime_info                      public   SELECT          false
+test           crdb_internal       node_sessions                          public   SELECT          false
+test           crdb_internal       node_statement_statistics              public   SELECT          false
+test           crdb_internal       node_transaction_statistics            public   SELECT          false
+test           crdb_internal       node_transactions                      public   SELECT          false
+test           crdb_internal       node_txn_stats                         public   SELECT          false
+test           crdb_internal       partitions                             public   SELECT          false
+test           crdb_internal       pg_catalog_table_is_implemented        public   SELECT          false
+test           crdb_internal       predefined_comments                    public   SELECT          false
+test           crdb_internal       ranges                                 public   SELECT          false
+test           crdb_internal       ranges_no_leases                       public   SELECT          false
+test           crdb_internal       regions                                public   SELECT          false
+test           crdb_internal       schema_changes                         public   SELECT          false
+test           crdb_internal       session_trace                          public   SELECT          false
+test           crdb_internal       session_variables                      public   SELECT          false
+test           crdb_internal       statement_statistics                   public   SELECT          false
+test           crdb_internal       super_regions                          public   SELECT          false
+test           crdb_internal       table_columns                          public   SELECT          false
+test           crdb_internal       table_indexes                          public   SELECT          false
+test           crdb_internal       table_row_statistics                   public   SELECT          false
+test           crdb_internal       tables                                 public   SELECT          false
+test           crdb_internal       tenant_usage_details                   public   SELECT          false
+test           crdb_internal       transaction_contention_events          public   SELECT          false
+test           crdb_internal       transaction_statistics                 public   SELECT          false
+test           crdb_internal       zones                                  public   SELECT          false
+test           information_schema  NULL                                   public   USAGE           false
+test           information_schema  administrable_role_authorizations      public   SELECT          false
+test           information_schema  applicable_roles                       public   SELECT          false
+test           information_schema  attributes                             public   SELECT          false
+test           information_schema  character_sets                         public   SELECT          false
+test           information_schema  check_constraint_routine_usage         public   SELECT          false
+test           information_schema  check_constraints                      public   SELECT          false
+test           information_schema  collation_character_set_applicability  public   SELECT          false
+test           information_schema  collations                             public   SELECT          false
+test           information_schema  column_column_usage                    public   SELECT          false
+test           information_schema  column_domain_usage                    public   SELECT          false
+test           information_schema  column_options                         public   SELECT          false
+test           information_schema  column_privileges                      public   SELECT          false
+test           information_schema  column_statistics                      public   SELECT          false
+test           information_schema  column_udt_usage                       public   SELECT          false
+test           information_schema  columns                                public   SELECT          false
+test           information_schema  columns_extensions                     public   SELECT          false
+test           information_schema  constraint_column_usage                public   SELECT          false
+test           information_schema  constraint_table_usage                 public   SELECT          false
+test           information_schema  data_type_privileges                   public   SELECT          false
+test           information_schema  domain_constraints                     public   SELECT          false
+test           information_schema  domain_udt_usage                       public   SELECT          false
+test           information_schema  domains                                public   SELECT          false
+test           information_schema  element_types                          public   SELECT          false
+test           information_schema  enabled_roles                          public   SELECT          false
+test           information_schema  engines                                public   SELECT          false
+test           information_schema  events                                 public   SELECT          false
+test           information_schema  files                                  public   SELECT          false
+test           information_schema  foreign_data_wrapper_options           public   SELECT          false
+test           information_schema  foreign_data_wrappers                  public   SELECT          false
+test           information_schema  foreign_server_options                 public   SELECT          false
+test           information_schema  foreign_servers                        public   SELECT          false
+test           information_schema  foreign_table_options                  public   SELECT          false
+test           information_schema  foreign_tables                         public   SELECT          false
+test           information_schema  information_schema_catalog_name        public   SELECT          false
+test           information_schema  key_column_usage                       public   SELECT          false
+test           information_schema  keywords                               public   SELECT          false
+test           information_schema  optimizer_trace                        public   SELECT          false
+test           information_schema  parameters                             public   SELECT          false
+test           information_schema  partitions                             public   SELECT          false
+test           information_schema  plugins                                public   SELECT          false
+test           information_schema  processlist                            public   SELECT          false
+test           information_schema  profiling                              public   SELECT          false
+test           information_schema  referential_constraints                public   SELECT          false
+test           information_schema  resource_groups                        public   SELECT          false
+test           information_schema  role_column_grants                     public   SELECT          false
+test           information_schema  role_routine_grants                    public   SELECT          false
+test           information_schema  role_table_grants                      public   SELECT          false
+test           information_schema  role_udt_grants                        public   SELECT          false
+test           information_schema  role_usage_grants                      public   SELECT          false
+test           information_schema  routine_privileges                     public   SELECT          false
+test           information_schema  routines                               public   SELECT          false
+test           information_schema  schema_privileges                      public   SELECT          false
+test           information_schema  schemata                               public   SELECT          false
+test           information_schema  schemata_extensions                    public   SELECT          false
+test           information_schema  sequences                              public   SELECT          false
+test           information_schema  session_variables                      public   SELECT          false
+test           information_schema  sql_features                           public   SELECT          false
+test           information_schema  sql_implementation_info                public   SELECT          false
+test           information_schema  sql_parts                              public   SELECT          false
+test           information_schema  sql_sizing                             public   SELECT          false
+test           information_schema  st_geometry_columns                    public   SELECT          false
+test           information_schema  st_spatial_reference_systems           public   SELECT          false
+test           information_schema  st_units_of_measure                    public   SELECT          false
+test           information_schema  statistics                             public   SELECT          false
+test           information_schema  table_constraints                      public   SELECT          false
+test           information_schema  table_constraints_extensions           public   SELECT          false
+test           information_schema  table_privileges                       public   SELECT          false
+test           information_schema  tables                                 public   SELECT          false
+test           information_schema  tables_extensions                      public   SELECT          false
+test           information_schema  tablespaces                            public   SELECT          false
+test           information_schema  tablespaces_extensions                 public   SELECT          false
+test           information_schema  transforms                             public   SELECT          false
+test           information_schema  triggered_update_columns               public   SELECT          false
+test           information_schema  triggers                               public   SELECT          false
+test           information_schema  type_privileges                        public   SELECT          false
+test           information_schema  udt_privileges                         public   SELECT          false
+test           information_schema  usage_privileges                       public   SELECT          false
+test           information_schema  user_attributes                        public   SELECT          false
+test           information_schema  user_defined_types                     public   SELECT          false
+test           information_schema  user_mapping_options                   public   SELECT          false
+test           information_schema  user_mappings                          public   SELECT          false
+test           information_schema  user_privileges                        public   SELECT          false
+test           information_schema  view_column_usage                      public   SELECT          false
+test           information_schema  view_routine_usage                     public   SELECT          false
+test           information_schema  view_table_usage                       public   SELECT          false
+test           information_schema  views                                  public   SELECT          false
+test           pg_catalog          NULL                                   public   USAGE           false
+test           pg_catalog          "char"                                 admin    ALL             false
+test           pg_catalog          "char"                                 public   USAGE           false
+test           pg_catalog          "char"                                 root     ALL             false
+test           pg_catalog          "char"[]                               admin    ALL             false
+test           pg_catalog          "char"[]                               public   USAGE           false
+test           pg_catalog          "char"[]                               root     ALL             false
+test           pg_catalog          anyelement                             admin    ALL             false
+test           pg_catalog          anyelement                             public   USAGE           false
+test           pg_catalog          anyelement                             root     ALL             false
+test           pg_catalog          anyelement[]                           admin    ALL             false
+test           pg_catalog          anyelement[]                           public   USAGE           false
+test           pg_catalog          anyelement[]                           root     ALL             false
+test           pg_catalog          bit                                    admin    ALL             false
+test           pg_catalog          bit                                    public   USAGE           false
+test           pg_catalog          bit                                    root     ALL             false
+test           pg_catalog          bit[]                                  admin    ALL             false
+test           pg_catalog          bit[]                                  public   USAGE           false
+test           pg_catalog          bit[]                                  root     ALL             false
+test           pg_catalog          bool                                   admin    ALL             false
+test           pg_catalog          bool                                   public   USAGE           false
+test           pg_catalog          bool                                   root     ALL             false
+test           pg_catalog          bool[]                                 admin    ALL             false
+test           pg_catalog          bool[]                                 public   USAGE           false
+test           pg_catalog          bool[]                                 root     ALL             false
+test           pg_catalog          box2d                                  admin    ALL             false
+test           pg_catalog          box2d                                  public   USAGE           false
+test           pg_catalog          box2d                                  root     ALL             false
+test           pg_catalog          box2d[]                                admin    ALL             false
+test           pg_catalog          box2d[]                                public   USAGE           false
+test           pg_catalog          box2d[]                                root     ALL             false
+test           pg_catalog          bytes                                  admin    ALL             false
+test           pg_catalog          bytes                                  public   USAGE           false
+test           pg_catalog          bytes                                  root     ALL             false
+test           pg_catalog          bytes[]                                admin    ALL             false
+test           pg_catalog          bytes[]                                public   USAGE           false
+test           pg_catalog          bytes[]                                root     ALL             false
+test           pg_catalog          char                                   admin    ALL             false
+test           pg_catalog          char                                   public   USAGE           false
+test           pg_catalog          char                                   root     ALL             false
+test           pg_catalog          char[]                                 admin    ALL             false
+test           pg_catalog          char[]                                 public   USAGE           false
+test           pg_catalog          char[]                                 root     ALL             false
+test           pg_catalog          date                                   admin    ALL             false
+test           pg_catalog          date                                   public   USAGE           false
+test           pg_catalog          date                                   root     ALL             false
+test           pg_catalog          date[]                                 admin    ALL             false
+test           pg_catalog          date[]                                 public   USAGE           false
+test           pg_catalog          date[]                                 root     ALL             false
+test           pg_catalog          decimal                                admin    ALL             false
+test           pg_catalog          decimal                                public   USAGE           false
+test           pg_catalog          decimal                                root     ALL             false
+test           pg_catalog          decimal[]                              admin    ALL             false
+test           pg_catalog          decimal[]                              public   USAGE           false
+test           pg_catalog          decimal[]                              root     ALL             false
+test           pg_catalog          float                                  admin    ALL             false
+test           pg_catalog          float                                  public   USAGE           false
+test           pg_catalog          float                                  root     ALL             false
+test           pg_catalog          float4                                 admin    ALL             false
+test           pg_catalog          float4                                 public   USAGE           false
+test           pg_catalog          float4                                 root     ALL             false
+test           pg_catalog          float4[]                               admin    ALL             false
+test           pg_catalog          float4[]                               public   USAGE           false
+test           pg_catalog          float4[]                               root     ALL             false
+test           pg_catalog          float[]                                admin    ALL             false
+test           pg_catalog          float[]                                public   USAGE           false
+test           pg_catalog          float[]                                root     ALL             false
+test           pg_catalog          geography                              admin    ALL             false
+test           pg_catalog          geography                              public   USAGE           false
+test           pg_catalog          geography                              root     ALL             false
+test           pg_catalog          geography[]                            admin    ALL             false
+test           pg_catalog          geography[]                            public   USAGE           false
+test           pg_catalog          geography[]                            root     ALL             false
+test           pg_catalog          geometry                               admin    ALL             false
+test           pg_catalog          geometry                               public   USAGE           false
+test           pg_catalog          geometry                               root     ALL             false
+test           pg_catalog          geometry[]                             admin    ALL             false
+test           pg_catalog          geometry[]                             public   USAGE           false
+test           pg_catalog          geometry[]                             root     ALL             false
+test           pg_catalog          inet                                   admin    ALL             false
+test           pg_catalog          inet                                   public   USAGE           false
+test           pg_catalog          inet                                   root     ALL             false
+test           pg_catalog          inet[]                                 admin    ALL             false
+test           pg_catalog          inet[]                                 public   USAGE           false
+test           pg_catalog          inet[]                                 root     ALL             false
+test           pg_catalog          int                                    admin    ALL             false
+test           pg_catalog          int                                    public   USAGE           false
+test           pg_catalog          int                                    root     ALL             false
+test           pg_catalog          int2                                   admin    ALL             false
+test           pg_catalog          int2                                   public   USAGE           false
+test           pg_catalog          int2                                   root     ALL             false
+test           pg_catalog          int2[]                                 admin    ALL             false
+test           pg_catalog          int2[]                                 public   USAGE           false
+test           pg_catalog          int2[]                                 root     ALL             false
+test           pg_catalog          int2vector                             admin    ALL             false
+test           pg_catalog          int2vector                             public   USAGE           false
+test           pg_catalog          int2vector                             root     ALL             false
+test           pg_catalog          int2vector[]                           admin    ALL             false
+test           pg_catalog          int2vector[]                           public   USAGE           false
+test           pg_catalog          int2vector[]                           root     ALL             false
+test           pg_catalog          int4                                   admin    ALL             false
+test           pg_catalog          int4                                   public   USAGE           false
+test           pg_catalog          int4                                   root     ALL             false
+test           pg_catalog          int4[]                                 admin    ALL             false
+test           pg_catalog          int4[]                                 public   USAGE           false
+test           pg_catalog          int4[]                                 root     ALL             false
+test           pg_catalog          int[]                                  admin    ALL             false
+test           pg_catalog          int[]                                  public   USAGE           false
+test           pg_catalog          int[]                                  root     ALL             false
+test           pg_catalog          interval                               admin    ALL             false
+test           pg_catalog          interval                               public   USAGE           false
+test           pg_catalog          interval                               root     ALL             false
+test           pg_catalog          interval[]                             admin    ALL             false
+test           pg_catalog          interval[]                             public   USAGE           false
+test           pg_catalog          interval[]                             root     ALL             false
+test           pg_catalog          jsonb                                  admin    ALL             false
+test           pg_catalog          jsonb                                  public   USAGE           false
+test           pg_catalog          jsonb                                  root     ALL             false
+test           pg_catalog          jsonb[]                                admin    ALL             false
+test           pg_catalog          jsonb[]                                public   USAGE           false
+test           pg_catalog          jsonb[]                                root     ALL             false
+test           pg_catalog          name                                   admin    ALL             false
+test           pg_catalog          name                                   public   USAGE           false
+test           pg_catalog          name                                   root     ALL             false
+test           pg_catalog          name[]                                 admin    ALL             false
+test           pg_catalog          name[]                                 public   USAGE           false
+test           pg_catalog          name[]                                 root     ALL             false
+test           pg_catalog          oid                                    admin    ALL             false
+test           pg_catalog          oid                                    public   USAGE           false
+test           pg_catalog          oid                                    root     ALL             false
+test           pg_catalog          oid[]                                  admin    ALL             false
+test           pg_catalog          oid[]                                  public   USAGE           false
+test           pg_catalog          oid[]                                  root     ALL             false
+test           pg_catalog          oidvector                              admin    ALL             false
+test           pg_catalog          oidvector                              public   USAGE           false
+test           pg_catalog          oidvector                              root     ALL             false
+test           pg_catalog          oidvector[]                            admin    ALL             false
+test           pg_catalog          oidvector[]                            public   USAGE           false
+test           pg_catalog          oidvector[]                            root     ALL             false
+test           pg_catalog          pg_aggregate                           public   SELECT          false
+test           pg_catalog          pg_am                                  public   SELECT          false
+test           pg_catalog          pg_amop                                public   SELECT          false
+test           pg_catalog          pg_amproc                              public   SELECT          false
+test           pg_catalog          pg_attrdef                             public   SELECT          false
+test           pg_catalog          pg_attribute                           public   SELECT          false
+test           pg_catalog          pg_auth_members                        public   SELECT          false
+test           pg_catalog          pg_authid                              public   SELECT          false
+test           pg_catalog          pg_available_extension_versions        public   SELECT          false
+test           pg_catalog          pg_available_extensions                public   SELECT          false
+test           pg_catalog          pg_cast                                public   SELECT          false
+test           pg_catalog          pg_class                               public   SELECT          false
+test           pg_catalog          pg_collation                           public   SELECT          false
+test           pg_catalog          pg_config                              public   SELECT          false
+test           pg_catalog          pg_constraint                          public   SELECT          false
+test           pg_catalog          pg_conversion                          public   SELECT          false
+test           pg_catalog          pg_cursors                             public   SELECT          false
+test           pg_catalog          pg_database                            public   SELECT          false
+test           pg_catalog          pg_db_role_setting                     public   SELECT          false
+test           pg_catalog          pg_default_acl                         public   SELECT          false
+test           pg_catalog          pg_depend                              public   SELECT          false
+test           pg_catalog          pg_description                         public   SELECT          false
+test           pg_catalog          pg_enum                                public   SELECT          false
+test           pg_catalog          pg_event_trigger                       public   SELECT          false
+test           pg_catalog          pg_extension                           public   SELECT          false
+test           pg_catalog          pg_file_settings                       public   SELECT          false
+test           pg_catalog          pg_foreign_data_wrapper                public   SELECT          false
+test           pg_catalog          pg_foreign_server                      public   SELECT          false
+test           pg_catalog          pg_foreign_table                       public   SELECT          false
+test           pg_catalog          pg_group                               public   SELECT          false
+test           pg_catalog          pg_hba_file_rules                      public   SELECT          false
+test           pg_catalog          pg_index                               public   SELECT          false
+test           pg_catalog          pg_indexes                             public   SELECT          false
+test           pg_catalog          pg_inherits                            public   SELECT          false
+test           pg_catalog          pg_init_privs                          public   SELECT          false
+test           pg_catalog          pg_language                            public   SELECT          false
+test           pg_catalog          pg_largeobject                         public   SELECT          false
+test           pg_catalog          pg_largeobject_metadata                public   SELECT          false
+test           pg_catalog          pg_locks                               public   SELECT          false
+test           pg_catalog          pg_matviews                            public   SELECT          false
+test           pg_catalog          pg_namespace                           public   SELECT          false
+test           pg_catalog          pg_opclass                             public   SELECT          false
+test           pg_catalog          pg_operator                            public   SELECT          false
+test           pg_catalog          pg_opfamily                            public   SELECT          false
+test           pg_catalog          pg_partitioned_table                   public   SELECT          false
+test           pg_catalog          pg_policies                            public   SELECT          false
+test           pg_catalog          pg_policy                              public   SELECT          false
+test           pg_catalog          pg_prepared_statements                 public   SELECT          false
+test           pg_catalog          pg_prepared_xacts                      public   SELECT          false
+test           pg_catalog          pg_proc                                public   SELECT          false
+test           pg_catalog          pg_publication                         public   SELECT          false
+test           pg_catalog          pg_publication_rel                     public   SELECT          false
+test           pg_catalog          pg_publication_tables                  public   SELECT          false
+test           pg_catalog          pg_range                               public   SELECT          false
+test           pg_catalog          pg_replication_origin                  public   SELECT          false
+test           pg_catalog          pg_replication_origin_status           public   SELECT          false
+test           pg_catalog          pg_replication_slots                   public   SELECT          false
+test           pg_catalog          pg_rewrite                             public   SELECT          false
+test           pg_catalog          pg_roles                               public   SELECT          false
+test           pg_catalog          pg_rules                               public   SELECT          false
+test           pg_catalog          pg_seclabel                            public   SELECT          false
+test           pg_catalog          pg_seclabels                           public   SELECT          false
+test           pg_catalog          pg_sequence                            public   SELECT          false
+test           pg_catalog          pg_sequences                           public   SELECT          false
+test           pg_catalog          pg_settings                            public   SELECT          false
+test           pg_catalog          pg_shadow                              public   SELECT          false
+test           pg_catalog          pg_shdepend                            public   SELECT          false
+test           pg_catalog          pg_shdescription                       public   SELECT          false
+test           pg_catalog          pg_shmem_allocations                   public   SELECT          false
+test           pg_catalog          pg_shseclabel                          public   SELECT          false
+test           pg_catalog          pg_stat_activity                       public   SELECT          false
+test           pg_catalog          pg_stat_all_indexes                    public   SELECT          false
+test           pg_catalog          pg_stat_all_tables                     public   SELECT          false
+test           pg_catalog          pg_stat_archiver                       public   SELECT          false
+test           pg_catalog          pg_stat_bgwriter                       public   SELECT          false
+test           pg_catalog          pg_stat_database                       public   SELECT          false
+test           pg_catalog          pg_stat_database_conflicts             public   SELECT          false
+test           pg_catalog          pg_stat_gssapi                         public   SELECT          false
+test           pg_catalog          pg_stat_progress_analyze               public   SELECT          false
+test           pg_catalog          pg_stat_progress_basebackup            public   SELECT          false
+test           pg_catalog          pg_stat_progress_cluster               public   SELECT          false
+test           pg_catalog          pg_stat_progress_create_index          public   SELECT          false
+test           pg_catalog          pg_stat_progress_vacuum                public   SELECT          false
+test           pg_catalog          pg_stat_replication                    public   SELECT          false
+test           pg_catalog          pg_stat_slru                           public   SELECT          false
+test           pg_catalog          pg_stat_ssl                            public   SELECT          false
+test           pg_catalog          pg_stat_subscription                   public   SELECT          false
+test           pg_catalog          pg_stat_sys_indexes                    public   SELECT          false
+test           pg_catalog          pg_stat_sys_tables                     public   SELECT          false
+test           pg_catalog          pg_stat_user_functions                 public   SELECT          false
+test           pg_catalog          pg_stat_user_indexes                   public   SELECT          false
+test           pg_catalog          pg_stat_user_tables                    public   SELECT          false
+test           pg_catalog          pg_stat_wal_receiver                   public   SELECT          false
+test           pg_catalog          pg_stat_xact_all_tables                public   SELECT          false
+test           pg_catalog          pg_stat_xact_sys_tables                public   SELECT          false
+test           pg_catalog          pg_stat_xact_user_functions            public   SELECT          false
+test           pg_catalog          pg_stat_xact_user_tables               public   SELECT          false
+test           pg_catalog          pg_statio_all_indexes                  public   SELECT          false
+test           pg_catalog          pg_statio_all_sequences                public   SELECT          false
+test           pg_catalog          pg_statio_all_tables                   public   SELECT          false
+test           pg_catalog          pg_statio_sys_indexes                  public   SELECT          false
+test           pg_catalog          pg_statio_sys_sequences                public   SELECT          false
+test           pg_catalog          pg_statio_sys_tables                   public   SELECT          false
+test           pg_catalog          pg_statio_user_indexes                 public   SELECT          false
+test           pg_catalog          pg_statio_user_sequences               public   SELECT          false
+test           pg_catalog          pg_statio_user_tables                  public   SELECT          false
+test           pg_catalog          pg_statistic                           public   SELECT          false
+test           pg_catalog          pg_statistic_ext                       public   SELECT          false
+test           pg_catalog          pg_statistic_ext_data                  public   SELECT          false
+test           pg_catalog          pg_stats                               public   SELECT          false
+test           pg_catalog          pg_stats_ext                           public   SELECT          false
+test           pg_catalog          pg_subscription                        public   SELECT          false
+test           pg_catalog          pg_subscription_rel                    public   SELECT          false
+test           pg_catalog          pg_tables                              public   SELECT          false
+test           pg_catalog          pg_tablespace                          public   SELECT          false
+test           pg_catalog          pg_timezone_abbrevs                    public   SELECT          false
+test           pg_catalog          pg_timezone_names                      public   SELECT          false
+test           pg_catalog          pg_transform                           public   SELECT          false
+test           pg_catalog          pg_trigger                             public   SELECT          false
+test           pg_catalog          pg_ts_config                           public   SELECT          false
+test           pg_catalog          pg_ts_config_map                       public   SELECT          false
+test           pg_catalog          pg_ts_dict                             public   SELECT          false
+test           pg_catalog          pg_ts_parser                           public   SELECT          false
+test           pg_catalog          pg_ts_template                         public   SELECT          false
+test           pg_catalog          pg_type                                public   SELECT          false
+test           pg_catalog          pg_user                                public   SELECT          false
+test           pg_catalog          pg_user_mapping                        public   SELECT          false
+test           pg_catalog          pg_user_mappings                       public   SELECT          false
+test           pg_catalog          pg_views                               public   SELECT          false
+test           pg_catalog          record                                 admin    ALL             false
+test           pg_catalog          record                                 public   USAGE           false
+test           pg_catalog          record                                 root     ALL             false
+test           pg_catalog          record[]                               admin    ALL             false
+test           pg_catalog          record[]                               public   USAGE           false
+test           pg_catalog          record[]                               root     ALL             false
+test           pg_catalog          regclass                               admin    ALL             false
+test           pg_catalog          regclass                               public   USAGE           false
+test           pg_catalog          regclass                               root     ALL             false
+test           pg_catalog          regclass[]                             admin    ALL             false
+test           pg_catalog          regclass[]                             public   USAGE           false
+test           pg_catalog          regclass[]                             root     ALL             false
+test           pg_catalog          regnamespace                           admin    ALL             false
+test           pg_catalog          regnamespace                           public   USAGE           false
+test           pg_catalog          regnamespace                           root     ALL             false
+test           pg_catalog          regnamespace[]                         admin    ALL             false
+test           pg_catalog          regnamespace[]                         public   USAGE           false
+test           pg_catalog          regnamespace[]                         root     ALL             false
+test           pg_catalog          regproc                                admin    ALL             false
+test           pg_catalog          regproc                                public   USAGE           false
+test           pg_catalog          regproc                                root     ALL             false
+test           pg_catalog          regproc[]                              admin    ALL             false
+test           pg_catalog          regproc[]                              public   USAGE           false
+test           pg_catalog          regproc[]                              root     ALL             false
+test           pg_catalog          regprocedure                           admin    ALL             false
+test           pg_catalog          regprocedure                           public   USAGE           false
+test           pg_catalog          regprocedure                           root     ALL             false
+test           pg_catalog          regprocedure[]                         admin    ALL             false
+test           pg_catalog          regprocedure[]                         public   USAGE           false
+test           pg_catalog          regprocedure[]                         root     ALL             false
+test           pg_catalog          regrole                                admin    ALL             false
+test           pg_catalog          regrole                                public   USAGE           false
+test           pg_catalog          regrole                                root     ALL             false
+test           pg_catalog          regrole[]                              admin    ALL             false
+test           pg_catalog          regrole[]                              public   USAGE           false
+test           pg_catalog          regrole[]                              root     ALL             false
+test           pg_catalog          regtype                                admin    ALL             false
+test           pg_catalog          regtype                                public   USAGE           false
+test           pg_catalog          regtype                                root     ALL             false
+test           pg_catalog          regtype[]                              admin    ALL             false
+test           pg_catalog          regtype[]                              public   USAGE           false
+test           pg_catalog          regtype[]                              root     ALL             false
+test           pg_catalog          string                                 admin    ALL             false
+test           pg_catalog          string                                 public   USAGE           false
+test           pg_catalog          string                                 root     ALL             false
+test           pg_catalog          string[]                               admin    ALL             false
+test           pg_catalog          string[]                               public   USAGE           false
+test           pg_catalog          string[]                               root     ALL             false
+test           pg_catalog          time                                   admin    ALL             false
+test           pg_catalog          time                                   public   USAGE           false
+test           pg_catalog          time                                   root     ALL             false
+test           pg_catalog          time[]                                 admin    ALL             false
+test           pg_catalog          time[]                                 public   USAGE           false
+test           pg_catalog          time[]                                 root     ALL             false
+test           pg_catalog          timestamp                              admin    ALL             false
+test           pg_catalog          timestamp                              public   USAGE           false
+test           pg_catalog          timestamp                              root     ALL             false
+test           pg_catalog          timestamp[]                            admin    ALL             false
+test           pg_catalog          timestamp[]                            public   USAGE           false
+test           pg_catalog          timestamp[]                            root     ALL             false
+test           pg_catalog          timestamptz                            admin    ALL             false
+test           pg_catalog          timestamptz                            public   USAGE           false
+test           pg_catalog          timestamptz                            root     ALL             false
+test           pg_catalog          timestamptz[]                          admin    ALL             false
+test           pg_catalog          timestamptz[]                          public   USAGE           false
+test           pg_catalog          timestamptz[]                          root     ALL             false
+test           pg_catalog          timetz                                 admin    ALL             false
+test           pg_catalog          timetz                                 public   USAGE           false
+test           pg_catalog          timetz                                 root     ALL             false
+test           pg_catalog          timetz[]                               admin    ALL             false
+test           pg_catalog          timetz[]                               public   USAGE           false
+test           pg_catalog          timetz[]                               root     ALL             false
+test           pg_catalog          unknown                                admin    ALL             false
+test           pg_catalog          unknown                                public   USAGE           false
+test           pg_catalog          unknown                                root     ALL             false
+test           pg_catalog          uuid                                   admin    ALL             false
+test           pg_catalog          uuid                                   public   USAGE           false
+test           pg_catalog          uuid                                   root     ALL             false
+test           pg_catalog          uuid[]                                 admin    ALL             false
+test           pg_catalog          uuid[]                                 public   USAGE           false
+test           pg_catalog          uuid[]                                 root     ALL             false
+test           pg_catalog          varbit                                 admin    ALL             false
+test           pg_catalog          varbit                                 public   USAGE           false
+test           pg_catalog          varbit                                 root     ALL             false
+test           pg_catalog          varbit[]                               admin    ALL             false
+test           pg_catalog          varbit[]                               public   USAGE           false
+test           pg_catalog          varbit[]                               root     ALL             false
+test           pg_catalog          varchar                                admin    ALL             false
+test           pg_catalog          varchar                                public   USAGE           false
+test           pg_catalog          varchar                                root     ALL             false
+test           pg_catalog          varchar[]                              admin    ALL             false
+test           pg_catalog          varchar[]                              public   USAGE           false
+test           pg_catalog          varchar[]                              root     ALL             false
+test           pg_catalog          void                                   admin    ALL             false
+test           pg_catalog          void                                   public   USAGE           false
+test           pg_catalog          void                                   root     ALL             false
+test           pg_extension        NULL                                   public   USAGE           false
+test           pg_extension        geography_columns                      public   SELECT          false
+test           pg_extension        geometry_columns                       public   SELECT          false
+test           pg_extension        spatial_ref_sys                        public   SELECT          false
+test           public              NULL                                   admin    ALL             true
+test           public              NULL                                   public   CREATE          false
+test           public              NULL                                   public   USAGE           false
+test           public              NULL                                   root     ALL             true
 
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR root
 ----
-database_name  schema_name  relation_name   grantee  privilege_type
-test           NULL         NULL            root     ALL
-test           pg_catalog   "char"          root     ALL
-test           pg_catalog   "char"[]        root     ALL
-test           pg_catalog   anyelement      root     ALL
-test           pg_catalog   anyelement[]    root     ALL
-test           pg_catalog   bit             root     ALL
-test           pg_catalog   bit[]           root     ALL
-test           pg_catalog   bool            root     ALL
-test           pg_catalog   bool[]          root     ALL
-test           pg_catalog   box2d           root     ALL
-test           pg_catalog   box2d[]         root     ALL
-test           pg_catalog   bytes           root     ALL
-test           pg_catalog   bytes[]         root     ALL
-test           pg_catalog   char            root     ALL
-test           pg_catalog   char[]          root     ALL
-test           pg_catalog   date            root     ALL
-test           pg_catalog   date[]          root     ALL
-test           pg_catalog   decimal         root     ALL
-test           pg_catalog   decimal[]       root     ALL
-test           pg_catalog   float           root     ALL
-test           pg_catalog   float4          root     ALL
-test           pg_catalog   float4[]        root     ALL
-test           pg_catalog   float[]         root     ALL
-test           pg_catalog   geography       root     ALL
-test           pg_catalog   geography[]     root     ALL
-test           pg_catalog   geometry        root     ALL
-test           pg_catalog   geometry[]      root     ALL
-test           pg_catalog   inet            root     ALL
-test           pg_catalog   inet[]          root     ALL
-test           pg_catalog   int             root     ALL
-test           pg_catalog   int2            root     ALL
-test           pg_catalog   int2[]          root     ALL
-test           pg_catalog   int2vector      root     ALL
-test           pg_catalog   int2vector[]    root     ALL
-test           pg_catalog   int4            root     ALL
-test           pg_catalog   int4[]          root     ALL
-test           pg_catalog   int[]           root     ALL
-test           pg_catalog   interval        root     ALL
-test           pg_catalog   interval[]      root     ALL
-test           pg_catalog   jsonb           root     ALL
-test           pg_catalog   jsonb[]         root     ALL
-test           pg_catalog   name            root     ALL
-test           pg_catalog   name[]          root     ALL
-test           pg_catalog   oid             root     ALL
-test           pg_catalog   oid[]           root     ALL
-test           pg_catalog   oidvector       root     ALL
-test           pg_catalog   oidvector[]     root     ALL
-test           pg_catalog   record          root     ALL
-test           pg_catalog   record[]        root     ALL
-test           pg_catalog   regclass        root     ALL
-test           pg_catalog   regclass[]      root     ALL
-test           pg_catalog   regnamespace    root     ALL
-test           pg_catalog   regnamespace[]  root     ALL
-test           pg_catalog   regproc         root     ALL
-test           pg_catalog   regproc[]       root     ALL
-test           pg_catalog   regprocedure    root     ALL
-test           pg_catalog   regprocedure[]  root     ALL
-test           pg_catalog   regrole         root     ALL
-test           pg_catalog   regrole[]       root     ALL
-test           pg_catalog   regtype         root     ALL
-test           pg_catalog   regtype[]       root     ALL
-test           pg_catalog   string          root     ALL
-test           pg_catalog   string[]        root     ALL
-test           pg_catalog   time            root     ALL
-test           pg_catalog   time[]          root     ALL
-test           pg_catalog   timestamp       root     ALL
-test           pg_catalog   timestamp[]     root     ALL
-test           pg_catalog   timestamptz     root     ALL
-test           pg_catalog   timestamptz[]   root     ALL
-test           pg_catalog   timetz          root     ALL
-test           pg_catalog   timetz[]        root     ALL
-test           pg_catalog   unknown         root     ALL
-test           pg_catalog   uuid            root     ALL
-test           pg_catalog   uuid[]          root     ALL
-test           pg_catalog   varbit          root     ALL
-test           pg_catalog   varbit[]        root     ALL
-test           pg_catalog   varchar         root     ALL
-test           pg_catalog   varchar[]       root     ALL
-test           pg_catalog   void            root     ALL
-test           public       NULL            root     ALL
+database_name  schema_name  relation_name   grantee  privilege_type  is_grantable
+test           NULL         NULL            root     ALL             true
+test           pg_catalog   "char"          root     ALL             false
+test           pg_catalog   "char"[]        root     ALL             false
+test           pg_catalog   anyelement      root     ALL             false
+test           pg_catalog   anyelement[]    root     ALL             false
+test           pg_catalog   bit             root     ALL             false
+test           pg_catalog   bit[]           root     ALL             false
+test           pg_catalog   bool            root     ALL             false
+test           pg_catalog   bool[]          root     ALL             false
+test           pg_catalog   box2d           root     ALL             false
+test           pg_catalog   box2d[]         root     ALL             false
+test           pg_catalog   bytes           root     ALL             false
+test           pg_catalog   bytes[]         root     ALL             false
+test           pg_catalog   char            root     ALL             false
+test           pg_catalog   char[]          root     ALL             false
+test           pg_catalog   date            root     ALL             false
+test           pg_catalog   date[]          root     ALL             false
+test           pg_catalog   decimal         root     ALL             false
+test           pg_catalog   decimal[]       root     ALL             false
+test           pg_catalog   float           root     ALL             false
+test           pg_catalog   float4          root     ALL             false
+test           pg_catalog   float4[]        root     ALL             false
+test           pg_catalog   float[]         root     ALL             false
+test           pg_catalog   geography       root     ALL             false
+test           pg_catalog   geography[]     root     ALL             false
+test           pg_catalog   geometry        root     ALL             false
+test           pg_catalog   geometry[]      root     ALL             false
+test           pg_catalog   inet            root     ALL             false
+test           pg_catalog   inet[]          root     ALL             false
+test           pg_catalog   int             root     ALL             false
+test           pg_catalog   int2            root     ALL             false
+test           pg_catalog   int2[]          root     ALL             false
+test           pg_catalog   int2vector      root     ALL             false
+test           pg_catalog   int2vector[]    root     ALL             false
+test           pg_catalog   int4            root     ALL             false
+test           pg_catalog   int4[]          root     ALL             false
+test           pg_catalog   int[]           root     ALL             false
+test           pg_catalog   interval        root     ALL             false
+test           pg_catalog   interval[]      root     ALL             false
+test           pg_catalog   jsonb           root     ALL             false
+test           pg_catalog   jsonb[]         root     ALL             false
+test           pg_catalog   name            root     ALL             false
+test           pg_catalog   name[]          root     ALL             false
+test           pg_catalog   oid             root     ALL             false
+test           pg_catalog   oid[]           root     ALL             false
+test           pg_catalog   oidvector       root     ALL             false
+test           pg_catalog   oidvector[]     root     ALL             false
+test           pg_catalog   record          root     ALL             false
+test           pg_catalog   record[]        root     ALL             false
+test           pg_catalog   regclass        root     ALL             false
+test           pg_catalog   regclass[]      root     ALL             false
+test           pg_catalog   regnamespace    root     ALL             false
+test           pg_catalog   regnamespace[]  root     ALL             false
+test           pg_catalog   regproc         root     ALL             false
+test           pg_catalog   regproc[]       root     ALL             false
+test           pg_catalog   regprocedure    root     ALL             false
+test           pg_catalog   regprocedure[]  root     ALL             false
+test           pg_catalog   regrole         root     ALL             false
+test           pg_catalog   regrole[]       root     ALL             false
+test           pg_catalog   regtype         root     ALL             false
+test           pg_catalog   regtype[]       root     ALL             false
+test           pg_catalog   string          root     ALL             false
+test           pg_catalog   string[]        root     ALL             false
+test           pg_catalog   time            root     ALL             false
+test           pg_catalog   time[]          root     ALL             false
+test           pg_catalog   timestamp       root     ALL             false
+test           pg_catalog   timestamp[]     root     ALL             false
+test           pg_catalog   timestamptz     root     ALL             false
+test           pg_catalog   timestamptz[]   root     ALL             false
+test           pg_catalog   timetz          root     ALL             false
+test           pg_catalog   timetz[]        root     ALL             false
+test           pg_catalog   unknown         root     ALL             false
+test           pg_catalog   uuid            root     ALL             false
+test           pg_catalog   uuid[]          root     ALL             false
+test           pg_catalog   varbit          root     ALL             false
+test           pg_catalog   varbit[]        root     ALL             false
+test           pg_catalog   varchar         root     ALL             false
+test           pg_catalog   varchar[]       root     ALL             false
+test           pg_catalog   void            root     ALL             false
+test           public       NULL            root     ALL             true
 
 # With no database set, we show the grants everywhere
 statement ok
 SET DATABASE = ''
 
-query TTTTT colnames,rowsort
+query TTTTTB colnames,rowsort
 SELECT * FROM [SHOW GRANTS]
  WHERE schema_name NOT IN ('crdb_internal', 'pg_catalog', 'information_schema')
 ----
-database_name  schema_name   relation_name                    grantee  privilege_type
-system         pg_extension  geography_columns                public   SELECT
-system         pg_extension  geometry_columns                 public   SELECT
-system         pg_extension  spatial_ref_sys                  public   SELECT
-defaultdb      pg_extension  geography_columns                public   SELECT
-defaultdb      pg_extension  geometry_columns                 public   SELECT
-defaultdb      pg_extension  spatial_ref_sys                  public   SELECT
-postgres       pg_extension  geography_columns                public   SELECT
-postgres       pg_extension  geometry_columns                 public   SELECT
-postgres       pg_extension  spatial_ref_sys                  public   SELECT
-test           pg_extension  geography_columns                public   SELECT
-test           pg_extension  geometry_columns                 public   SELECT
-test           pg_extension  spatial_ref_sys                  public   SELECT
-a              pg_extension  geography_columns                public   SELECT
-a              pg_extension  geometry_columns                 public   SELECT
-a              pg_extension  spatial_ref_sys                  public   SELECT
-system         public        descriptor                       admin    GRANT
-system         public        descriptor                       admin    SELECT
-system         public        descriptor                       root     GRANT
-system         public        descriptor                       root     SELECT
-system         public        users                            admin    DELETE
-system         public        users                            admin    GRANT
-system         public        users                            admin    INSERT
-system         public        users                            admin    SELECT
-system         public        users                            admin    UPDATE
-system         public        users                            root     DELETE
-system         public        users                            root     GRANT
-system         public        users                            root     INSERT
-system         public        users                            root     SELECT
-system         public        users                            root     UPDATE
-system         public        zones                            admin    DELETE
-system         public        zones                            admin    GRANT
-system         public        zones                            admin    INSERT
-system         public        zones                            admin    SELECT
-system         public        zones                            admin    UPDATE
-system         public        zones                            root     DELETE
-system         public        zones                            root     GRANT
-system         public        zones                            root     INSERT
-system         public        zones                            root     SELECT
-system         public        zones                            root     UPDATE
-system         public        settings                         admin    DELETE
-system         public        settings                         admin    GRANT
-system         public        settings                         admin    INSERT
-system         public        settings                         admin    SELECT
-system         public        settings                         admin    UPDATE
-system         public        settings                         root     DELETE
-system         public        settings                         root     GRANT
-system         public        settings                         root     INSERT
-system         public        settings                         root     SELECT
-system         public        settings                         root     UPDATE
-system         public        tenants                          admin    GRANT
-system         public        tenants                          admin    SELECT
-system         public        tenants                          root     GRANT
-system         public        tenants                          root     SELECT
-system         public        lease                            admin    DELETE
-system         public        lease                            admin    GRANT
-system         public        lease                            admin    INSERT
-system         public        lease                            admin    SELECT
-system         public        lease                            admin    UPDATE
-system         public        lease                            root     DELETE
-system         public        lease                            root     GRANT
-system         public        lease                            root     INSERT
-system         public        lease                            root     SELECT
-system         public        lease                            root     UPDATE
-system         public        eventlog                         admin    DELETE
-system         public        eventlog                         admin    GRANT
-system         public        eventlog                         admin    INSERT
-system         public        eventlog                         admin    SELECT
-system         public        eventlog                         admin    UPDATE
-system         public        eventlog                         root     DELETE
-system         public        eventlog                         root     GRANT
-system         public        eventlog                         root     INSERT
-system         public        eventlog                         root     SELECT
-system         public        eventlog                         root     UPDATE
-system         public        rangelog                         admin    DELETE
-system         public        rangelog                         admin    GRANT
-system         public        rangelog                         admin    INSERT
-system         public        rangelog                         admin    SELECT
-system         public        rangelog                         admin    UPDATE
-system         public        rangelog                         root     DELETE
-system         public        rangelog                         root     GRANT
-system         public        rangelog                         root     INSERT
-system         public        rangelog                         root     SELECT
-system         public        rangelog                         root     UPDATE
-system         public        ui                               admin    DELETE
-system         public        ui                               admin    GRANT
-system         public        ui                               admin    INSERT
-system         public        ui                               admin    SELECT
-system         public        ui                               admin    UPDATE
-system         public        ui                               root     DELETE
-system         public        ui                               root     GRANT
-system         public        ui                               root     INSERT
-system         public        ui                               root     SELECT
-system         public        ui                               root     UPDATE
-system         public        jobs                             admin    DELETE
-system         public        jobs                             admin    GRANT
-system         public        jobs                             admin    INSERT
-system         public        jobs                             admin    SELECT
-system         public        jobs                             admin    UPDATE
-system         public        jobs                             root     DELETE
-system         public        jobs                             root     GRANT
-system         public        jobs                             root     INSERT
-system         public        jobs                             root     SELECT
-system         public        jobs                             root     UPDATE
-system         public        web_sessions                     admin    DELETE
-system         public        web_sessions                     admin    GRANT
-system         public        web_sessions                     admin    INSERT
-system         public        web_sessions                     admin    SELECT
-system         public        web_sessions                     admin    UPDATE
-system         public        web_sessions                     root     DELETE
-system         public        web_sessions                     root     GRANT
-system         public        web_sessions                     root     INSERT
-system         public        web_sessions                     root     SELECT
-system         public        web_sessions                     root     UPDATE
-system         public        table_statistics                 admin    DELETE
-system         public        table_statistics                 admin    GRANT
-system         public        table_statistics                 admin    INSERT
-system         public        table_statistics                 admin    SELECT
-system         public        table_statistics                 admin    UPDATE
-system         public        table_statistics                 root     DELETE
-system         public        table_statistics                 root     GRANT
-system         public        table_statistics                 root     INSERT
-system         public        table_statistics                 root     SELECT
-system         public        table_statistics                 root     UPDATE
-system         public        locations                        admin    DELETE
-system         public        locations                        admin    GRANT
-system         public        locations                        admin    INSERT
-system         public        locations                        admin    SELECT
-system         public        locations                        admin    UPDATE
-system         public        locations                        root     DELETE
-system         public        locations                        root     GRANT
-system         public        locations                        root     INSERT
-system         public        locations                        root     SELECT
-system         public        locations                        root     UPDATE
-system         public        role_members                     admin    DELETE
-system         public        role_members                     admin    GRANT
-system         public        role_members                     admin    INSERT
-system         public        role_members                     admin    SELECT
-system         public        role_members                     admin    UPDATE
-system         public        role_members                     root     DELETE
-system         public        role_members                     root     GRANT
-system         public        role_members                     root     INSERT
-system         public        role_members                     root     SELECT
-system         public        role_members                     root     UPDATE
-system         public        comments                         admin    DELETE
-system         public        comments                         admin    GRANT
-system         public        comments                         admin    INSERT
-system         public        comments                         admin    SELECT
-system         public        comments                         admin    UPDATE
-system         public        comments                         public   SELECT
-system         public        comments                         root     DELETE
-system         public        comments                         root     GRANT
-system         public        comments                         root     INSERT
-system         public        comments                         root     SELECT
-system         public        comments                         root     UPDATE
-system         public        replication_constraint_stats     admin    DELETE
-system         public        replication_constraint_stats     admin    GRANT
-system         public        replication_constraint_stats     admin    INSERT
-system         public        replication_constraint_stats     admin    SELECT
-system         public        replication_constraint_stats     admin    UPDATE
-system         public        replication_constraint_stats     root     DELETE
-system         public        replication_constraint_stats     root     GRANT
-system         public        replication_constraint_stats     root     INSERT
-system         public        replication_constraint_stats     root     SELECT
-system         public        replication_constraint_stats     root     UPDATE
-system         public        replication_critical_localities  admin    DELETE
-system         public        replication_critical_localities  admin    GRANT
-system         public        replication_critical_localities  admin    INSERT
-system         public        replication_critical_localities  admin    SELECT
-system         public        replication_critical_localities  admin    UPDATE
-system         public        replication_critical_localities  root     DELETE
-system         public        replication_critical_localities  root     GRANT
-system         public        replication_critical_localities  root     INSERT
-system         public        replication_critical_localities  root     SELECT
-system         public        replication_critical_localities  root     UPDATE
-system         public        replication_stats                admin    DELETE
-system         public        replication_stats                admin    GRANT
-system         public        replication_stats                admin    INSERT
-system         public        replication_stats                admin    SELECT
-system         public        replication_stats                admin    UPDATE
-system         public        replication_stats                root     DELETE
-system         public        replication_stats                root     GRANT
-system         public        replication_stats                root     INSERT
-system         public        replication_stats                root     SELECT
-system         public        replication_stats                root     UPDATE
-system         public        reports_meta                     admin    DELETE
-system         public        reports_meta                     admin    GRANT
-system         public        reports_meta                     admin    INSERT
-system         public        reports_meta                     admin    SELECT
-system         public        reports_meta                     admin    UPDATE
-system         public        reports_meta                     root     DELETE
-system         public        reports_meta                     root     GRANT
-system         public        reports_meta                     root     INSERT
-system         public        reports_meta                     root     SELECT
-system         public        reports_meta                     root     UPDATE
-system         public        namespace                        admin    GRANT
-system         public        namespace                        admin    SELECT
-system         public        namespace                        root     GRANT
-system         public        namespace                        root     SELECT
-system         public        protected_ts_meta                admin    GRANT
-system         public        protected_ts_meta                admin    SELECT
-system         public        protected_ts_meta                root     GRANT
-system         public        protected_ts_meta                root     SELECT
-system         public        protected_ts_records             admin    GRANT
-system         public        protected_ts_records             admin    SELECT
-system         public        protected_ts_records             root     GRANT
-system         public        protected_ts_records             root     SELECT
-system         public        role_options                     admin    DELETE
-system         public        role_options                     admin    GRANT
-system         public        role_options                     admin    INSERT
-system         public        role_options                     admin    SELECT
-system         public        role_options                     admin    UPDATE
-system         public        role_options                     root     DELETE
-system         public        role_options                     root     GRANT
-system         public        role_options                     root     INSERT
-system         public        role_options                     root     SELECT
-system         public        role_options                     root     UPDATE
-system         public        statement_bundle_chunks          admin    DELETE
-system         public        statement_bundle_chunks          admin    GRANT
-system         public        statement_bundle_chunks          admin    INSERT
-system         public        statement_bundle_chunks          admin    SELECT
-system         public        statement_bundle_chunks          admin    UPDATE
-system         public        statement_bundle_chunks          root     DELETE
-system         public        statement_bundle_chunks          root     GRANT
-system         public        statement_bundle_chunks          root     INSERT
-system         public        statement_bundle_chunks          root     SELECT
-system         public        statement_bundle_chunks          root     UPDATE
-system         public        statement_diagnostics_requests   admin    DELETE
-system         public        statement_diagnostics_requests   admin    GRANT
-system         public        statement_diagnostics_requests   admin    INSERT
-system         public        statement_diagnostics_requests   admin    SELECT
-system         public        statement_diagnostics_requests   admin    UPDATE
-system         public        statement_diagnostics_requests   root     DELETE
-system         public        statement_diagnostics_requests   root     GRANT
-system         public        statement_diagnostics_requests   root     INSERT
-system         public        statement_diagnostics_requests   root     SELECT
-system         public        statement_diagnostics_requests   root     UPDATE
-system         public        statement_diagnostics            admin    DELETE
-system         public        statement_diagnostics            admin    GRANT
-system         public        statement_diagnostics            admin    INSERT
-system         public        statement_diagnostics            admin    SELECT
-system         public        statement_diagnostics            admin    UPDATE
-system         public        statement_diagnostics            root     DELETE
-system         public        statement_diagnostics            root     GRANT
-system         public        statement_diagnostics            root     INSERT
-system         public        statement_diagnostics            root     SELECT
-system         public        statement_diagnostics            root     UPDATE
-system         public        scheduled_jobs                   admin    DELETE
-system         public        scheduled_jobs                   admin    GRANT
-system         public        scheduled_jobs                   admin    INSERT
-system         public        scheduled_jobs                   admin    SELECT
-system         public        scheduled_jobs                   admin    UPDATE
-system         public        scheduled_jobs                   root     DELETE
-system         public        scheduled_jobs                   root     GRANT
-system         public        scheduled_jobs                   root     INSERT
-system         public        scheduled_jobs                   root     SELECT
-system         public        scheduled_jobs                   root     UPDATE
-system         public        sqlliveness                      admin    DELETE
-system         public        sqlliveness                      admin    GRANT
-system         public        sqlliveness                      admin    INSERT
-system         public        sqlliveness                      admin    SELECT
-system         public        sqlliveness                      admin    UPDATE
-system         public        sqlliveness                      root     DELETE
-system         public        sqlliveness                      root     GRANT
-system         public        sqlliveness                      root     INSERT
-system         public        sqlliveness                      root     SELECT
-system         public        sqlliveness                      root     UPDATE
-system         public        migrations                       admin    DELETE
-system         public        migrations                       admin    GRANT
-system         public        migrations                       admin    INSERT
-system         public        migrations                       admin    SELECT
-system         public        migrations                       admin    UPDATE
-system         public        migrations                       root     DELETE
-system         public        migrations                       root     GRANT
-system         public        migrations                       root     INSERT
-system         public        migrations                       root     SELECT
-system         public        migrations                       root     UPDATE
-system         public        join_tokens                      admin    DELETE
-system         public        join_tokens                      admin    GRANT
-system         public        join_tokens                      admin    INSERT
-system         public        join_tokens                      admin    SELECT
-system         public        join_tokens                      admin    UPDATE
-system         public        join_tokens                      root     DELETE
-system         public        join_tokens                      root     GRANT
-system         public        join_tokens                      root     INSERT
-system         public        join_tokens                      root     SELECT
-system         public        join_tokens                      root     UPDATE
-system         public        statement_statistics             admin    GRANT
-system         public        statement_statistics             admin    SELECT
-system         public        statement_statistics             root     GRANT
-system         public        statement_statistics             root     SELECT
-system         public        transaction_statistics           admin    GRANT
-system         public        transaction_statistics           admin    SELECT
-system         public        transaction_statistics           root     GRANT
-system         public        transaction_statistics           root     SELECT
-system         public        database_role_settings           admin    DELETE
-system         public        database_role_settings           admin    GRANT
-system         public        database_role_settings           admin    INSERT
-system         public        database_role_settings           admin    SELECT
-system         public        database_role_settings           admin    UPDATE
-system         public        database_role_settings           root     DELETE
-system         public        database_role_settings           root     GRANT
-system         public        database_role_settings           root     INSERT
-system         public        database_role_settings           root     SELECT
-system         public        database_role_settings           root     UPDATE
-system         public        tenant_usage                     admin    DELETE
-system         public        tenant_usage                     admin    GRANT
-system         public        tenant_usage                     admin    INSERT
-system         public        tenant_usage                     admin    SELECT
-system         public        tenant_usage                     admin    UPDATE
-system         public        tenant_usage                     root     DELETE
-system         public        tenant_usage                     root     GRANT
-system         public        tenant_usage                     root     INSERT
-system         public        tenant_usage                     root     SELECT
-system         public        tenant_usage                     root     UPDATE
-system         public        sql_instances                    admin    DELETE
-system         public        sql_instances                    admin    GRANT
-system         public        sql_instances                    admin    INSERT
-system         public        sql_instances                    admin    SELECT
-system         public        sql_instances                    admin    UPDATE
-system         public        sql_instances                    root     DELETE
-system         public        sql_instances                    root     GRANT
-system         public        sql_instances                    root     INSERT
-system         public        sql_instances                    root     SELECT
-system         public        sql_instances                    root     UPDATE
-system         public        span_configurations              admin    DELETE
-system         public        span_configurations              admin    GRANT
-system         public        span_configurations              admin    INSERT
-system         public        span_configurations              admin    SELECT
-system         public        span_configurations              admin    UPDATE
-system         public        span_configurations              root     DELETE
-system         public        span_configurations              root     GRANT
-system         public        span_configurations              root     INSERT
-system         public        span_configurations              root     SELECT
-system         public        span_configurations              root     UPDATE
-system         public        tenant_settings                  admin    DELETE
-system         public        tenant_settings                  admin    GRANT
-system         public        tenant_settings                  admin    INSERT
-system         public        tenant_settings                  admin    SELECT
-system         public        tenant_settings                  admin    UPDATE
-system         public        tenant_settings                  root     DELETE
-system         public        tenant_settings                  root     GRANT
-system         public        tenant_settings                  root     INSERT
-system         public        tenant_settings                  root     SELECT
-system         public        tenant_settings                  root     UPDATE
-a              pg_extension  NULL                             public   USAGE
-a              public        NULL                             admin    ALL
-a              public        NULL                             public   CREATE
-a              public        NULL                             public   USAGE
-a              public        NULL                             root     ALL
-defaultdb      pg_extension  NULL                             public   USAGE
-defaultdb      public        NULL                             admin    ALL
-defaultdb      public        NULL                             public   CREATE
-defaultdb      public        NULL                             public   USAGE
-defaultdb      public        NULL                             root     ALL
-postgres       pg_extension  NULL                             public   USAGE
-postgres       public        NULL                             admin    ALL
-postgres       public        NULL                             public   CREATE
-postgres       public        NULL                             public   USAGE
-postgres       public        NULL                             root     ALL
-system         pg_extension  NULL                             public   USAGE
-system         public        NULL                             admin    ALL
-system         public        NULL                             public   CREATE
-system         public        NULL                             public   USAGE
-system         public        NULL                             root     ALL
-test           pg_extension  NULL                             public   USAGE
-test           public        NULL                             admin    ALL
-test           public        NULL                             public   CREATE
-test           public        NULL                             public   USAGE
-test           public        NULL                             root     ALL
+database_name  schema_name   relation_name                    grantee  privilege_type  is_grantable
+system         pg_extension  geography_columns                public   SELECT          false
+system         pg_extension  geometry_columns                 public   SELECT          false
+system         pg_extension  spatial_ref_sys                  public   SELECT          false
+defaultdb      pg_extension  geography_columns                public   SELECT          false
+defaultdb      pg_extension  geometry_columns                 public   SELECT          false
+defaultdb      pg_extension  spatial_ref_sys                  public   SELECT          false
+postgres       pg_extension  geography_columns                public   SELECT          false
+postgres       pg_extension  geometry_columns                 public   SELECT          false
+postgres       pg_extension  spatial_ref_sys                  public   SELECT          false
+test           pg_extension  geography_columns                public   SELECT          false
+test           pg_extension  geometry_columns                 public   SELECT          false
+test           pg_extension  spatial_ref_sys                  public   SELECT          false
+a              pg_extension  geography_columns                public   SELECT          false
+a              pg_extension  geometry_columns                 public   SELECT          false
+a              pg_extension  spatial_ref_sys                  public   SELECT          false
+system         public        descriptor                       admin    GRANT           true
+system         public        descriptor                       admin    SELECT          true
+system         public        descriptor                       root     GRANT           true
+system         public        descriptor                       root     SELECT          true
+system         public        users                            admin    DELETE          true
+system         public        users                            admin    GRANT           true
+system         public        users                            admin    INSERT          true
+system         public        users                            admin    SELECT          true
+system         public        users                            admin    UPDATE          true
+system         public        users                            root     DELETE          true
+system         public        users                            root     GRANT           true
+system         public        users                            root     INSERT          true
+system         public        users                            root     SELECT          true
+system         public        users                            root     UPDATE          true
+system         public        zones                            admin    DELETE          true
+system         public        zones                            admin    GRANT           true
+system         public        zones                            admin    INSERT          true
+system         public        zones                            admin    SELECT          true
+system         public        zones                            admin    UPDATE          true
+system         public        zones                            root     DELETE          true
+system         public        zones                            root     GRANT           true
+system         public        zones                            root     INSERT          true
+system         public        zones                            root     SELECT          true
+system         public        zones                            root     UPDATE          true
+system         public        settings                         admin    DELETE          true
+system         public        settings                         admin    GRANT           true
+system         public        settings                         admin    INSERT          true
+system         public        settings                         admin    SELECT          true
+system         public        settings                         admin    UPDATE          true
+system         public        settings                         root     DELETE          true
+system         public        settings                         root     GRANT           true
+system         public        settings                         root     INSERT          true
+system         public        settings                         root     SELECT          true
+system         public        settings                         root     UPDATE          true
+system         public        tenants                          admin    GRANT           true
+system         public        tenants                          admin    SELECT          true
+system         public        tenants                          root     GRANT           true
+system         public        tenants                          root     SELECT          true
+system         public        lease                            admin    DELETE          true
+system         public        lease                            admin    GRANT           true
+system         public        lease                            admin    INSERT          true
+system         public        lease                            admin    SELECT          true
+system         public        lease                            admin    UPDATE          true
+system         public        lease                            root     DELETE          true
+system         public        lease                            root     GRANT           true
+system         public        lease                            root     INSERT          true
+system         public        lease                            root     SELECT          true
+system         public        lease                            root     UPDATE          true
+system         public        eventlog                         admin    DELETE          true
+system         public        eventlog                         admin    GRANT           true
+system         public        eventlog                         admin    INSERT          true
+system         public        eventlog                         admin    SELECT          true
+system         public        eventlog                         admin    UPDATE          true
+system         public        eventlog                         root     DELETE          true
+system         public        eventlog                         root     GRANT           true
+system         public        eventlog                         root     INSERT          true
+system         public        eventlog                         root     SELECT          true
+system         public        eventlog                         root     UPDATE          true
+system         public        rangelog                         admin    DELETE          true
+system         public        rangelog                         admin    GRANT           true
+system         public        rangelog                         admin    INSERT          true
+system         public        rangelog                         admin    SELECT          true
+system         public        rangelog                         admin    UPDATE          true
+system         public        rangelog                         root     DELETE          true
+system         public        rangelog                         root     GRANT           true
+system         public        rangelog                         root     INSERT          true
+system         public        rangelog                         root     SELECT          true
+system         public        rangelog                         root     UPDATE          true
+system         public        ui                               admin    DELETE          true
+system         public        ui                               admin    GRANT           true
+system         public        ui                               admin    INSERT          true
+system         public        ui                               admin    SELECT          true
+system         public        ui                               admin    UPDATE          true
+system         public        ui                               root     DELETE          true
+system         public        ui                               root     GRANT           true
+system         public        ui                               root     INSERT          true
+system         public        ui                               root     SELECT          true
+system         public        ui                               root     UPDATE          true
+system         public        jobs                             admin    DELETE          true
+system         public        jobs                             admin    GRANT           true
+system         public        jobs                             admin    INSERT          true
+system         public        jobs                             admin    SELECT          true
+system         public        jobs                             admin    UPDATE          true
+system         public        jobs                             root     DELETE          true
+system         public        jobs                             root     GRANT           true
+system         public        jobs                             root     INSERT          true
+system         public        jobs                             root     SELECT          true
+system         public        jobs                             root     UPDATE          true
+system         public        web_sessions                     admin    DELETE          true
+system         public        web_sessions                     admin    GRANT           true
+system         public        web_sessions                     admin    INSERT          true
+system         public        web_sessions                     admin    SELECT          true
+system         public        web_sessions                     admin    UPDATE          true
+system         public        web_sessions                     root     DELETE          true
+system         public        web_sessions                     root     GRANT           true
+system         public        web_sessions                     root     INSERT          true
+system         public        web_sessions                     root     SELECT          true
+system         public        web_sessions                     root     UPDATE          true
+system         public        table_statistics                 admin    DELETE          true
+system         public        table_statistics                 admin    GRANT           true
+system         public        table_statistics                 admin    INSERT          true
+system         public        table_statistics                 admin    SELECT          true
+system         public        table_statistics                 admin    UPDATE          true
+system         public        table_statistics                 root     DELETE          true
+system         public        table_statistics                 root     GRANT           true
+system         public        table_statistics                 root     INSERT          true
+system         public        table_statistics                 root     SELECT          true
+system         public        table_statistics                 root     UPDATE          true
+system         public        locations                        admin    DELETE          true
+system         public        locations                        admin    GRANT           true
+system         public        locations                        admin    INSERT          true
+system         public        locations                        admin    SELECT          true
+system         public        locations                        admin    UPDATE          true
+system         public        locations                        root     DELETE          true
+system         public        locations                        root     GRANT           true
+system         public        locations                        root     INSERT          true
+system         public        locations                        root     SELECT          true
+system         public        locations                        root     UPDATE          true
+system         public        role_members                     admin    DELETE          true
+system         public        role_members                     admin    GRANT           true
+system         public        role_members                     admin    INSERT          true
+system         public        role_members                     admin    SELECT          true
+system         public        role_members                     admin    UPDATE          true
+system         public        role_members                     root     DELETE          true
+system         public        role_members                     root     GRANT           true
+system         public        role_members                     root     INSERT          true
+system         public        role_members                     root     SELECT          true
+system         public        role_members                     root     UPDATE          true
+system         public        comments                         admin    DELETE          true
+system         public        comments                         admin    GRANT           true
+system         public        comments                         admin    INSERT          true
+system         public        comments                         admin    SELECT          true
+system         public        comments                         admin    UPDATE          true
+system         public        comments                         public   SELECT          false
+system         public        comments                         root     DELETE          true
+system         public        comments                         root     GRANT           true
+system         public        comments                         root     INSERT          true
+system         public        comments                         root     SELECT          true
+system         public        comments                         root     UPDATE          true
+system         public        replication_constraint_stats     admin    DELETE          true
+system         public        replication_constraint_stats     admin    GRANT           true
+system         public        replication_constraint_stats     admin    INSERT          true
+system         public        replication_constraint_stats     admin    SELECT          true
+system         public        replication_constraint_stats     admin    UPDATE          true
+system         public        replication_constraint_stats     root     DELETE          true
+system         public        replication_constraint_stats     root     GRANT           true
+system         public        replication_constraint_stats     root     INSERT          true
+system         public        replication_constraint_stats     root     SELECT          true
+system         public        replication_constraint_stats     root     UPDATE          true
+system         public        replication_critical_localities  admin    DELETE          true
+system         public        replication_critical_localities  admin    GRANT           true
+system         public        replication_critical_localities  admin    INSERT          true
+system         public        replication_critical_localities  admin    SELECT          true
+system         public        replication_critical_localities  admin    UPDATE          true
+system         public        replication_critical_localities  root     DELETE          true
+system         public        replication_critical_localities  root     GRANT           true
+system         public        replication_critical_localities  root     INSERT          true
+system         public        replication_critical_localities  root     SELECT          true
+system         public        replication_critical_localities  root     UPDATE          true
+system         public        replication_stats                admin    DELETE          true
+system         public        replication_stats                admin    GRANT           true
+system         public        replication_stats                admin    INSERT          true
+system         public        replication_stats                admin    SELECT          true
+system         public        replication_stats                admin    UPDATE          true
+system         public        replication_stats                root     DELETE          true
+system         public        replication_stats                root     GRANT           true
+system         public        replication_stats                root     INSERT          true
+system         public        replication_stats                root     SELECT          true
+system         public        replication_stats                root     UPDATE          true
+system         public        reports_meta                     admin    DELETE          true
+system         public        reports_meta                     admin    GRANT           true
+system         public        reports_meta                     admin    INSERT          true
+system         public        reports_meta                     admin    SELECT          true
+system         public        reports_meta                     admin    UPDATE          true
+system         public        reports_meta                     root     DELETE          true
+system         public        reports_meta                     root     GRANT           true
+system         public        reports_meta                     root     INSERT          true
+system         public        reports_meta                     root     SELECT          true
+system         public        reports_meta                     root     UPDATE          true
+system         public        namespace                        admin    GRANT           true
+system         public        namespace                        admin    SELECT          true
+system         public        namespace                        root     GRANT           true
+system         public        namespace                        root     SELECT          true
+system         public        protected_ts_meta                admin    GRANT           true
+system         public        protected_ts_meta                admin    SELECT          true
+system         public        protected_ts_meta                root     GRANT           true
+system         public        protected_ts_meta                root     SELECT          true
+system         public        protected_ts_records             admin    GRANT           true
+system         public        protected_ts_records             admin    SELECT          true
+system         public        protected_ts_records             root     GRANT           true
+system         public        protected_ts_records             root     SELECT          true
+system         public        role_options                     admin    DELETE          true
+system         public        role_options                     admin    GRANT           true
+system         public        role_options                     admin    INSERT          true
+system         public        role_options                     admin    SELECT          true
+system         public        role_options                     admin    UPDATE          true
+system         public        role_options                     root     DELETE          true
+system         public        role_options                     root     GRANT           true
+system         public        role_options                     root     INSERT          true
+system         public        role_options                     root     SELECT          true
+system         public        role_options                     root     UPDATE          true
+system         public        statement_bundle_chunks          admin    DELETE          true
+system         public        statement_bundle_chunks          admin    GRANT           true
+system         public        statement_bundle_chunks          admin    INSERT          true
+system         public        statement_bundle_chunks          admin    SELECT          true
+system         public        statement_bundle_chunks          admin    UPDATE          true
+system         public        statement_bundle_chunks          root     DELETE          true
+system         public        statement_bundle_chunks          root     GRANT           true
+system         public        statement_bundle_chunks          root     INSERT          true
+system         public        statement_bundle_chunks          root     SELECT          true
+system         public        statement_bundle_chunks          root     UPDATE          true
+system         public        statement_diagnostics_requests   admin    DELETE          true
+system         public        statement_diagnostics_requests   admin    GRANT           true
+system         public        statement_diagnostics_requests   admin    INSERT          true
+system         public        statement_diagnostics_requests   admin    SELECT          true
+system         public        statement_diagnostics_requests   admin    UPDATE          true
+system         public        statement_diagnostics_requests   root     DELETE          true
+system         public        statement_diagnostics_requests   root     GRANT           true
+system         public        statement_diagnostics_requests   root     INSERT          true
+system         public        statement_diagnostics_requests   root     SELECT          true
+system         public        statement_diagnostics_requests   root     UPDATE          true
+system         public        statement_diagnostics            admin    DELETE          true
+system         public        statement_diagnostics            admin    GRANT           true
+system         public        statement_diagnostics            admin    INSERT          true
+system         public        statement_diagnostics            admin    SELECT          true
+system         public        statement_diagnostics            admin    UPDATE          true
+system         public        statement_diagnostics            root     DELETE          true
+system         public        statement_diagnostics            root     GRANT           true
+system         public        statement_diagnostics            root     INSERT          true
+system         public        statement_diagnostics            root     SELECT          true
+system         public        statement_diagnostics            root     UPDATE          true
+system         public        scheduled_jobs                   admin    DELETE          true
+system         public        scheduled_jobs                   admin    GRANT           true
+system         public        scheduled_jobs                   admin    INSERT          true
+system         public        scheduled_jobs                   admin    SELECT          true
+system         public        scheduled_jobs                   admin    UPDATE          true
+system         public        scheduled_jobs                   root     DELETE          true
+system         public        scheduled_jobs                   root     GRANT           true
+system         public        scheduled_jobs                   root     INSERT          true
+system         public        scheduled_jobs                   root     SELECT          true
+system         public        scheduled_jobs                   root     UPDATE          true
+system         public        sqlliveness                      admin    DELETE          true
+system         public        sqlliveness                      admin    GRANT           true
+system         public        sqlliveness                      admin    INSERT          true
+system         public        sqlliveness                      admin    SELECT          true
+system         public        sqlliveness                      admin    UPDATE          true
+system         public        sqlliveness                      root     DELETE          true
+system         public        sqlliveness                      root     GRANT           true
+system         public        sqlliveness                      root     INSERT          true
+system         public        sqlliveness                      root     SELECT          true
+system         public        sqlliveness                      root     UPDATE          true
+system         public        migrations                       admin    DELETE          true
+system         public        migrations                       admin    GRANT           true
+system         public        migrations                       admin    INSERT          true
+system         public        migrations                       admin    SELECT          true
+system         public        migrations                       admin    UPDATE          true
+system         public        migrations                       root     DELETE          true
+system         public        migrations                       root     GRANT           true
+system         public        migrations                       root     INSERT          true
+system         public        migrations                       root     SELECT          true
+system         public        migrations                       root     UPDATE          true
+system         public        join_tokens                      admin    DELETE          true
+system         public        join_tokens                      admin    GRANT           true
+system         public        join_tokens                      admin    INSERT          true
+system         public        join_tokens                      admin    SELECT          true
+system         public        join_tokens                      admin    UPDATE          true
+system         public        join_tokens                      root     DELETE          true
+system         public        join_tokens                      root     GRANT           true
+system         public        join_tokens                      root     INSERT          true
+system         public        join_tokens                      root     SELECT          true
+system         public        join_tokens                      root     UPDATE          true
+system         public        statement_statistics             admin    GRANT           true
+system         public        statement_statistics             admin    SELECT          true
+system         public        statement_statistics             root     GRANT           true
+system         public        statement_statistics             root     SELECT          true
+system         public        transaction_statistics           admin    GRANT           true
+system         public        transaction_statistics           admin    SELECT          true
+system         public        transaction_statistics           root     GRANT           true
+system         public        transaction_statistics           root     SELECT          true
+system         public        database_role_settings           admin    DELETE          true
+system         public        database_role_settings           admin    GRANT           true
+system         public        database_role_settings           admin    INSERT          true
+system         public        database_role_settings           admin    SELECT          true
+system         public        database_role_settings           admin    UPDATE          true
+system         public        database_role_settings           root     DELETE          true
+system         public        database_role_settings           root     GRANT           true
+system         public        database_role_settings           root     INSERT          true
+system         public        database_role_settings           root     SELECT          true
+system         public        database_role_settings           root     UPDATE          true
+system         public        tenant_usage                     admin    DELETE          true
+system         public        tenant_usage                     admin    GRANT           true
+system         public        tenant_usage                     admin    INSERT          true
+system         public        tenant_usage                     admin    SELECT          true
+system         public        tenant_usage                     admin    UPDATE          true
+system         public        tenant_usage                     root     DELETE          true
+system         public        tenant_usage                     root     GRANT           true
+system         public        tenant_usage                     root     INSERT          true
+system         public        tenant_usage                     root     SELECT          true
+system         public        tenant_usage                     root     UPDATE          true
+system         public        sql_instances                    admin    DELETE          true
+system         public        sql_instances                    admin    GRANT           true
+system         public        sql_instances                    admin    INSERT          true
+system         public        sql_instances                    admin    SELECT          true
+system         public        sql_instances                    admin    UPDATE          true
+system         public        sql_instances                    root     DELETE          true
+system         public        sql_instances                    root     GRANT           true
+system         public        sql_instances                    root     INSERT          true
+system         public        sql_instances                    root     SELECT          true
+system         public        sql_instances                    root     UPDATE          true
+system         public        span_configurations              admin    DELETE          true
+system         public        span_configurations              admin    GRANT           true
+system         public        span_configurations              admin    INSERT          true
+system         public        span_configurations              admin    SELECT          true
+system         public        span_configurations              admin    UPDATE          true
+system         public        span_configurations              root     DELETE          true
+system         public        span_configurations              root     GRANT           true
+system         public        span_configurations              root     INSERT          true
+system         public        span_configurations              root     SELECT          true
+system         public        span_configurations              root     UPDATE          true
+system         public        tenant_settings                  admin    DELETE          true
+system         public        tenant_settings                  admin    GRANT           true
+system         public        tenant_settings                  admin    INSERT          true
+system         public        tenant_settings                  admin    SELECT          true
+system         public        tenant_settings                  admin    UPDATE          true
+system         public        tenant_settings                  root     DELETE          true
+system         public        tenant_settings                  root     GRANT           true
+system         public        tenant_settings                  root     INSERT          true
+system         public        tenant_settings                  root     SELECT          true
+system         public        tenant_settings                  root     UPDATE          true
+a              pg_extension  NULL                             public   USAGE           false
+a              public        NULL                             admin    ALL             true
+a              public        NULL                             public   CREATE          false
+a              public        NULL                             public   USAGE           false
+a              public        NULL                             root     ALL             true
+defaultdb      pg_extension  NULL                             public   USAGE           false
+defaultdb      public        NULL                             admin    ALL             true
+defaultdb      public        NULL                             public   CREATE          false
+defaultdb      public        NULL                             public   USAGE           false
+defaultdb      public        NULL                             root     ALL             true
+postgres       pg_extension  NULL                             public   USAGE           false
+postgres       public        NULL                             admin    ALL             true
+postgres       public        NULL                             public   CREATE          false
+postgres       public        NULL                             public   USAGE           false
+postgres       public        NULL                             root     ALL             true
+system         pg_extension  NULL                             public   USAGE           false
+system         public        NULL                             admin    ALL             true
+system         public        NULL                             public   CREATE          false
+system         public        NULL                             public   USAGE           false
+system         public        NULL                             root     ALL             true
+test           pg_extension  NULL                             public   USAGE           false
+test           public        NULL                             admin    ALL             true
+test           public        NULL                             public   CREATE          false
+test           public        NULL                             public   USAGE           false
+test           public        NULL                             root     ALL             true
 
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR root
 ----
-database_name  schema_name  relation_name                    grantee  privilege_type
-a              NULL         NULL                             root     ALL
-a              pg_catalog   "char"                           root     ALL
-a              pg_catalog   "char"[]                         root     ALL
-a              pg_catalog   anyelement                       root     ALL
-a              pg_catalog   anyelement[]                     root     ALL
-a              pg_catalog   bit                              root     ALL
-a              pg_catalog   bit[]                            root     ALL
-a              pg_catalog   bool                             root     ALL
-a              pg_catalog   bool[]                           root     ALL
-a              pg_catalog   box2d                            root     ALL
-a              pg_catalog   box2d[]                          root     ALL
-a              pg_catalog   bytes                            root     ALL
-a              pg_catalog   bytes[]                          root     ALL
-a              pg_catalog   char                             root     ALL
-a              pg_catalog   char[]                           root     ALL
-a              pg_catalog   date                             root     ALL
-a              pg_catalog   date[]                           root     ALL
-a              pg_catalog   decimal                          root     ALL
-a              pg_catalog   decimal[]                        root     ALL
-a              pg_catalog   float                            root     ALL
-a              pg_catalog   float4                           root     ALL
-a              pg_catalog   float4[]                         root     ALL
-a              pg_catalog   float[]                          root     ALL
-a              pg_catalog   geography                        root     ALL
-a              pg_catalog   geography[]                      root     ALL
-a              pg_catalog   geometry                         root     ALL
-a              pg_catalog   geometry[]                       root     ALL
-a              pg_catalog   inet                             root     ALL
-a              pg_catalog   inet[]                           root     ALL
-a              pg_catalog   int                              root     ALL
-a              pg_catalog   int2                             root     ALL
-a              pg_catalog   int2[]                           root     ALL
-a              pg_catalog   int2vector                       root     ALL
-a              pg_catalog   int2vector[]                     root     ALL
-a              pg_catalog   int4                             root     ALL
-a              pg_catalog   int4[]                           root     ALL
-a              pg_catalog   int[]                            root     ALL
-a              pg_catalog   interval                         root     ALL
-a              pg_catalog   interval[]                       root     ALL
-a              pg_catalog   jsonb                            root     ALL
-a              pg_catalog   jsonb[]                          root     ALL
-a              pg_catalog   name                             root     ALL
-a              pg_catalog   name[]                           root     ALL
-a              pg_catalog   oid                              root     ALL
-a              pg_catalog   oid[]                            root     ALL
-a              pg_catalog   oidvector                        root     ALL
-a              pg_catalog   oidvector[]                      root     ALL
-a              pg_catalog   record                           root     ALL
-a              pg_catalog   record[]                         root     ALL
-a              pg_catalog   regclass                         root     ALL
-a              pg_catalog   regclass[]                       root     ALL
-a              pg_catalog   regnamespace                     root     ALL
-a              pg_catalog   regnamespace[]                   root     ALL
-a              pg_catalog   regproc                          root     ALL
-a              pg_catalog   regproc[]                        root     ALL
-a              pg_catalog   regprocedure                     root     ALL
-a              pg_catalog   regprocedure[]                   root     ALL
-a              pg_catalog   regrole                          root     ALL
-a              pg_catalog   regrole[]                        root     ALL
-a              pg_catalog   regtype                          root     ALL
-a              pg_catalog   regtype[]                        root     ALL
-a              pg_catalog   string                           root     ALL
-a              pg_catalog   string[]                         root     ALL
-a              pg_catalog   time                             root     ALL
-a              pg_catalog   time[]                           root     ALL
-a              pg_catalog   timestamp                        root     ALL
-a              pg_catalog   timestamp[]                      root     ALL
-a              pg_catalog   timestamptz                      root     ALL
-a              pg_catalog   timestamptz[]                    root     ALL
-a              pg_catalog   timetz                           root     ALL
-a              pg_catalog   timetz[]                         root     ALL
-a              pg_catalog   unknown                          root     ALL
-a              pg_catalog   uuid                             root     ALL
-a              pg_catalog   uuid[]                           root     ALL
-a              pg_catalog   varbit                           root     ALL
-a              pg_catalog   varbit[]                         root     ALL
-a              pg_catalog   varchar                          root     ALL
-a              pg_catalog   varchar[]                        root     ALL
-a              pg_catalog   void                             root     ALL
-a              public       NULL                             root     ALL
-defaultdb      NULL         NULL                             root     ALL
-defaultdb      pg_catalog   "char"                           root     ALL
-defaultdb      pg_catalog   "char"[]                         root     ALL
-defaultdb      pg_catalog   anyelement                       root     ALL
-defaultdb      pg_catalog   anyelement[]                     root     ALL
-defaultdb      pg_catalog   bit                              root     ALL
-defaultdb      pg_catalog   bit[]                            root     ALL
-defaultdb      pg_catalog   bool                             root     ALL
-defaultdb      pg_catalog   bool[]                           root     ALL
-defaultdb      pg_catalog   box2d                            root     ALL
-defaultdb      pg_catalog   box2d[]                          root     ALL
-defaultdb      pg_catalog   bytes                            root     ALL
-defaultdb      pg_catalog   bytes[]                          root     ALL
-defaultdb      pg_catalog   char                             root     ALL
-defaultdb      pg_catalog   char[]                           root     ALL
-defaultdb      pg_catalog   date                             root     ALL
-defaultdb      pg_catalog   date[]                           root     ALL
-defaultdb      pg_catalog   decimal                          root     ALL
-defaultdb      pg_catalog   decimal[]                        root     ALL
-defaultdb      pg_catalog   float                            root     ALL
-defaultdb      pg_catalog   float4                           root     ALL
-defaultdb      pg_catalog   float4[]                         root     ALL
-defaultdb      pg_catalog   float[]                          root     ALL
-defaultdb      pg_catalog   geography                        root     ALL
-defaultdb      pg_catalog   geography[]                      root     ALL
-defaultdb      pg_catalog   geometry                         root     ALL
-defaultdb      pg_catalog   geometry[]                       root     ALL
-defaultdb      pg_catalog   inet                             root     ALL
-defaultdb      pg_catalog   inet[]                           root     ALL
-defaultdb      pg_catalog   int                              root     ALL
-defaultdb      pg_catalog   int2                             root     ALL
-defaultdb      pg_catalog   int2[]                           root     ALL
-defaultdb      pg_catalog   int2vector                       root     ALL
-defaultdb      pg_catalog   int2vector[]                     root     ALL
-defaultdb      pg_catalog   int4                             root     ALL
-defaultdb      pg_catalog   int4[]                           root     ALL
-defaultdb      pg_catalog   int[]                            root     ALL
-defaultdb      pg_catalog   interval                         root     ALL
-defaultdb      pg_catalog   interval[]                       root     ALL
-defaultdb      pg_catalog   jsonb                            root     ALL
-defaultdb      pg_catalog   jsonb[]                          root     ALL
-defaultdb      pg_catalog   name                             root     ALL
-defaultdb      pg_catalog   name[]                           root     ALL
-defaultdb      pg_catalog   oid                              root     ALL
-defaultdb      pg_catalog   oid[]                            root     ALL
-defaultdb      pg_catalog   oidvector                        root     ALL
-defaultdb      pg_catalog   oidvector[]                      root     ALL
-defaultdb      pg_catalog   record                           root     ALL
-defaultdb      pg_catalog   record[]                         root     ALL
-defaultdb      pg_catalog   regclass                         root     ALL
-defaultdb      pg_catalog   regclass[]                       root     ALL
-defaultdb      pg_catalog   regnamespace                     root     ALL
-defaultdb      pg_catalog   regnamespace[]                   root     ALL
-defaultdb      pg_catalog   regproc                          root     ALL
-defaultdb      pg_catalog   regproc[]                        root     ALL
-defaultdb      pg_catalog   regprocedure                     root     ALL
-defaultdb      pg_catalog   regprocedure[]                   root     ALL
-defaultdb      pg_catalog   regrole                          root     ALL
-defaultdb      pg_catalog   regrole[]                        root     ALL
-defaultdb      pg_catalog   regtype                          root     ALL
-defaultdb      pg_catalog   regtype[]                        root     ALL
-defaultdb      pg_catalog   string                           root     ALL
-defaultdb      pg_catalog   string[]                         root     ALL
-defaultdb      pg_catalog   time                             root     ALL
-defaultdb      pg_catalog   time[]                           root     ALL
-defaultdb      pg_catalog   timestamp                        root     ALL
-defaultdb      pg_catalog   timestamp[]                      root     ALL
-defaultdb      pg_catalog   timestamptz                      root     ALL
-defaultdb      pg_catalog   timestamptz[]                    root     ALL
-defaultdb      pg_catalog   timetz                           root     ALL
-defaultdb      pg_catalog   timetz[]                         root     ALL
-defaultdb      pg_catalog   unknown                          root     ALL
-defaultdb      pg_catalog   uuid                             root     ALL
-defaultdb      pg_catalog   uuid[]                           root     ALL
-defaultdb      pg_catalog   varbit                           root     ALL
-defaultdb      pg_catalog   varbit[]                         root     ALL
-defaultdb      pg_catalog   varchar                          root     ALL
-defaultdb      pg_catalog   varchar[]                        root     ALL
-defaultdb      pg_catalog   void                             root     ALL
-defaultdb      public       NULL                             root     ALL
-postgres       NULL         NULL                             root     ALL
-postgres       pg_catalog   "char"                           root     ALL
-postgres       pg_catalog   "char"[]                         root     ALL
-postgres       pg_catalog   anyelement                       root     ALL
-postgres       pg_catalog   anyelement[]                     root     ALL
-postgres       pg_catalog   bit                              root     ALL
-postgres       pg_catalog   bit[]                            root     ALL
-postgres       pg_catalog   bool                             root     ALL
-postgres       pg_catalog   bool[]                           root     ALL
-postgres       pg_catalog   box2d                            root     ALL
-postgres       pg_catalog   box2d[]                          root     ALL
-postgres       pg_catalog   bytes                            root     ALL
-postgres       pg_catalog   bytes[]                          root     ALL
-postgres       pg_catalog   char                             root     ALL
-postgres       pg_catalog   char[]                           root     ALL
-postgres       pg_catalog   date                             root     ALL
-postgres       pg_catalog   date[]                           root     ALL
-postgres       pg_catalog   decimal                          root     ALL
-postgres       pg_catalog   decimal[]                        root     ALL
-postgres       pg_catalog   float                            root     ALL
-postgres       pg_catalog   float4                           root     ALL
-postgres       pg_catalog   float4[]                         root     ALL
-postgres       pg_catalog   float[]                          root     ALL
-postgres       pg_catalog   geography                        root     ALL
-postgres       pg_catalog   geography[]                      root     ALL
-postgres       pg_catalog   geometry                         root     ALL
-postgres       pg_catalog   geometry[]                       root     ALL
-postgres       pg_catalog   inet                             root     ALL
-postgres       pg_catalog   inet[]                           root     ALL
-postgres       pg_catalog   int                              root     ALL
-postgres       pg_catalog   int2                             root     ALL
-postgres       pg_catalog   int2[]                           root     ALL
-postgres       pg_catalog   int2vector                       root     ALL
-postgres       pg_catalog   int2vector[]                     root     ALL
-postgres       pg_catalog   int4                             root     ALL
-postgres       pg_catalog   int4[]                           root     ALL
-postgres       pg_catalog   int[]                            root     ALL
-postgres       pg_catalog   interval                         root     ALL
-postgres       pg_catalog   interval[]                       root     ALL
-postgres       pg_catalog   jsonb                            root     ALL
-postgres       pg_catalog   jsonb[]                          root     ALL
-postgres       pg_catalog   name                             root     ALL
-postgres       pg_catalog   name[]                           root     ALL
-postgres       pg_catalog   oid                              root     ALL
-postgres       pg_catalog   oid[]                            root     ALL
-postgres       pg_catalog   oidvector                        root     ALL
-postgres       pg_catalog   oidvector[]                      root     ALL
-postgres       pg_catalog   record                           root     ALL
-postgres       pg_catalog   record[]                         root     ALL
-postgres       pg_catalog   regclass                         root     ALL
-postgres       pg_catalog   regclass[]                       root     ALL
-postgres       pg_catalog   regnamespace                     root     ALL
-postgres       pg_catalog   regnamespace[]                   root     ALL
-postgres       pg_catalog   regproc                          root     ALL
-postgres       pg_catalog   regproc[]                        root     ALL
-postgres       pg_catalog   regprocedure                     root     ALL
-postgres       pg_catalog   regprocedure[]                   root     ALL
-postgres       pg_catalog   regrole                          root     ALL
-postgres       pg_catalog   regrole[]                        root     ALL
-postgres       pg_catalog   regtype                          root     ALL
-postgres       pg_catalog   regtype[]                        root     ALL
-postgres       pg_catalog   string                           root     ALL
-postgres       pg_catalog   string[]                         root     ALL
-postgres       pg_catalog   time                             root     ALL
-postgres       pg_catalog   time[]                           root     ALL
-postgres       pg_catalog   timestamp                        root     ALL
-postgres       pg_catalog   timestamp[]                      root     ALL
-postgres       pg_catalog   timestamptz                      root     ALL
-postgres       pg_catalog   timestamptz[]                    root     ALL
-postgres       pg_catalog   timetz                           root     ALL
-postgres       pg_catalog   timetz[]                         root     ALL
-postgres       pg_catalog   unknown                          root     ALL
-postgres       pg_catalog   uuid                             root     ALL
-postgres       pg_catalog   uuid[]                           root     ALL
-postgres       pg_catalog   varbit                           root     ALL
-postgres       pg_catalog   varbit[]                         root     ALL
-postgres       pg_catalog   varchar                          root     ALL
-postgres       pg_catalog   varchar[]                        root     ALL
-postgres       pg_catalog   void                             root     ALL
-postgres       public       NULL                             root     ALL
-system         NULL         NULL                             root     CONNECT
-system         pg_catalog   "char"                           root     ALL
-system         pg_catalog   "char"[]                         root     ALL
-system         pg_catalog   anyelement                       root     ALL
-system         pg_catalog   anyelement[]                     root     ALL
-system         pg_catalog   bit                              root     ALL
-system         pg_catalog   bit[]                            root     ALL
-system         pg_catalog   bool                             root     ALL
-system         pg_catalog   bool[]                           root     ALL
-system         pg_catalog   box2d                            root     ALL
-system         pg_catalog   box2d[]                          root     ALL
-system         pg_catalog   bytes                            root     ALL
-system         pg_catalog   bytes[]                          root     ALL
-system         pg_catalog   char                             root     ALL
-system         pg_catalog   char[]                           root     ALL
-system         pg_catalog   date                             root     ALL
-system         pg_catalog   date[]                           root     ALL
-system         pg_catalog   decimal                          root     ALL
-system         pg_catalog   decimal[]                        root     ALL
-system         pg_catalog   float                            root     ALL
-system         pg_catalog   float4                           root     ALL
-system         pg_catalog   float4[]                         root     ALL
-system         pg_catalog   float[]                          root     ALL
-system         pg_catalog   geography                        root     ALL
-system         pg_catalog   geography[]                      root     ALL
-system         pg_catalog   geometry                         root     ALL
-system         pg_catalog   geometry[]                       root     ALL
-system         pg_catalog   inet                             root     ALL
-system         pg_catalog   inet[]                           root     ALL
-system         pg_catalog   int                              root     ALL
-system         pg_catalog   int2                             root     ALL
-system         pg_catalog   int2[]                           root     ALL
-system         pg_catalog   int2vector                       root     ALL
-system         pg_catalog   int2vector[]                     root     ALL
-system         pg_catalog   int4                             root     ALL
-system         pg_catalog   int4[]                           root     ALL
-system         pg_catalog   int[]                            root     ALL
-system         pg_catalog   interval                         root     ALL
-system         pg_catalog   interval[]                       root     ALL
-system         pg_catalog   jsonb                            root     ALL
-system         pg_catalog   jsonb[]                          root     ALL
-system         pg_catalog   name                             root     ALL
-system         pg_catalog   name[]                           root     ALL
-system         pg_catalog   oid                              root     ALL
-system         pg_catalog   oid[]                            root     ALL
-system         pg_catalog   oidvector                        root     ALL
-system         pg_catalog   oidvector[]                      root     ALL
-system         pg_catalog   record                           root     ALL
-system         pg_catalog   record[]                         root     ALL
-system         pg_catalog   regclass                         root     ALL
-system         pg_catalog   regclass[]                       root     ALL
-system         pg_catalog   regnamespace                     root     ALL
-system         pg_catalog   regnamespace[]                   root     ALL
-system         pg_catalog   regproc                          root     ALL
-system         pg_catalog   regproc[]                        root     ALL
-system         pg_catalog   regprocedure                     root     ALL
-system         pg_catalog   regprocedure[]                   root     ALL
-system         pg_catalog   regrole                          root     ALL
-system         pg_catalog   regrole[]                        root     ALL
-system         pg_catalog   regtype                          root     ALL
-system         pg_catalog   regtype[]                        root     ALL
-system         pg_catalog   string                           root     ALL
-system         pg_catalog   string[]                         root     ALL
-system         pg_catalog   time                             root     ALL
-system         pg_catalog   time[]                           root     ALL
-system         pg_catalog   timestamp                        root     ALL
-system         pg_catalog   timestamp[]                      root     ALL
-system         pg_catalog   timestamptz                      root     ALL
-system         pg_catalog   timestamptz[]                    root     ALL
-system         pg_catalog   timetz                           root     ALL
-system         pg_catalog   timetz[]                         root     ALL
-system         pg_catalog   unknown                          root     ALL
-system         pg_catalog   uuid                             root     ALL
-system         pg_catalog   uuid[]                           root     ALL
-system         pg_catalog   varbit                           root     ALL
-system         pg_catalog   varbit[]                         root     ALL
-system         pg_catalog   varchar                          root     ALL
-system         pg_catalog   varchar[]                        root     ALL
-system         pg_catalog   void                             root     ALL
-system         public       NULL                             root     ALL
-system         public       comments                         root     DELETE
-system         public       comments                         root     GRANT
-system         public       comments                         root     INSERT
-system         public       comments                         root     SELECT
-system         public       comments                         root     UPDATE
-system         public       database_role_settings           root     DELETE
-system         public       database_role_settings           root     GRANT
-system         public       database_role_settings           root     INSERT
-system         public       database_role_settings           root     SELECT
-system         public       database_role_settings           root     UPDATE
-system         public       descriptor                       root     GRANT
-system         public       descriptor                       root     SELECT
-system         public       eventlog                         root     DELETE
-system         public       eventlog                         root     GRANT
-system         public       eventlog                         root     INSERT
-system         public       eventlog                         root     SELECT
-system         public       eventlog                         root     UPDATE
-system         public       jobs                             root     DELETE
-system         public       jobs                             root     GRANT
-system         public       jobs                             root     INSERT
-system         public       jobs                             root     SELECT
-system         public       jobs                             root     UPDATE
-system         public       join_tokens                      root     DELETE
-system         public       join_tokens                      root     GRANT
-system         public       join_tokens                      root     INSERT
-system         public       join_tokens                      root     SELECT
-system         public       join_tokens                      root     UPDATE
-system         public       lease                            root     DELETE
-system         public       lease                            root     GRANT
-system         public       lease                            root     INSERT
-system         public       lease                            root     SELECT
-system         public       lease                            root     UPDATE
-system         public       locations                        root     DELETE
-system         public       locations                        root     GRANT
-system         public       locations                        root     INSERT
-system         public       locations                        root     SELECT
-system         public       locations                        root     UPDATE
-system         public       migrations                       root     DELETE
-system         public       migrations                       root     GRANT
-system         public       migrations                       root     INSERT
-system         public       migrations                       root     SELECT
-system         public       migrations                       root     UPDATE
-system         public       namespace                        root     GRANT
-system         public       namespace                        root     SELECT
-system         public       protected_ts_meta                root     GRANT
-system         public       protected_ts_meta                root     SELECT
-system         public       protected_ts_records             root     GRANT
-system         public       protected_ts_records             root     SELECT
-system         public       rangelog                         root     DELETE
-system         public       rangelog                         root     GRANT
-system         public       rangelog                         root     INSERT
-system         public       rangelog                         root     SELECT
-system         public       rangelog                         root     UPDATE
-system         public       replication_constraint_stats     root     DELETE
-system         public       replication_constraint_stats     root     GRANT
-system         public       replication_constraint_stats     root     INSERT
-system         public       replication_constraint_stats     root     SELECT
-system         public       replication_constraint_stats     root     UPDATE
-system         public       replication_critical_localities  root     DELETE
-system         public       replication_critical_localities  root     GRANT
-system         public       replication_critical_localities  root     INSERT
-system         public       replication_critical_localities  root     SELECT
-system         public       replication_critical_localities  root     UPDATE
-system         public       replication_stats                root     DELETE
-system         public       replication_stats                root     GRANT
-system         public       replication_stats                root     INSERT
-system         public       replication_stats                root     SELECT
-system         public       replication_stats                root     UPDATE
-system         public       reports_meta                     root     DELETE
-system         public       reports_meta                     root     GRANT
-system         public       reports_meta                     root     INSERT
-system         public       reports_meta                     root     SELECT
-system         public       reports_meta                     root     UPDATE
-system         public       role_members                     root     DELETE
-system         public       role_members                     root     GRANT
-system         public       role_members                     root     INSERT
-system         public       role_members                     root     SELECT
-system         public       role_members                     root     UPDATE
-system         public       role_options                     root     DELETE
-system         public       role_options                     root     GRANT
-system         public       role_options                     root     INSERT
-system         public       role_options                     root     SELECT
-system         public       role_options                     root     UPDATE
-system         public       scheduled_jobs                   root     DELETE
-system         public       scheduled_jobs                   root     GRANT
-system         public       scheduled_jobs                   root     INSERT
-system         public       scheduled_jobs                   root     SELECT
-system         public       scheduled_jobs                   root     UPDATE
-system         public       settings                         root     DELETE
-system         public       settings                         root     GRANT
-system         public       settings                         root     INSERT
-system         public       settings                         root     SELECT
-system         public       settings                         root     UPDATE
-system         public       span_configurations              root     DELETE
-system         public       span_configurations              root     GRANT
-system         public       span_configurations              root     INSERT
-system         public       span_configurations              root     SELECT
-system         public       span_configurations              root     UPDATE
-system         public       sql_instances                    root     DELETE
-system         public       sql_instances                    root     GRANT
-system         public       sql_instances                    root     INSERT
-system         public       sql_instances                    root     SELECT
-system         public       sql_instances                    root     UPDATE
-system         public       sqlliveness                      root     DELETE
-system         public       sqlliveness                      root     GRANT
-system         public       sqlliveness                      root     INSERT
-system         public       sqlliveness                      root     SELECT
-system         public       sqlliveness                      root     UPDATE
-system         public       statement_bundle_chunks          root     DELETE
-system         public       statement_bundle_chunks          root     GRANT
-system         public       statement_bundle_chunks          root     INSERT
-system         public       statement_bundle_chunks          root     SELECT
-system         public       statement_bundle_chunks          root     UPDATE
-system         public       statement_diagnostics            root     DELETE
-system         public       statement_diagnostics            root     GRANT
-system         public       statement_diagnostics            root     INSERT
-system         public       statement_diagnostics            root     SELECT
-system         public       statement_diagnostics            root     UPDATE
-system         public       statement_diagnostics_requests   root     DELETE
-system         public       statement_diagnostics_requests   root     GRANT
-system         public       statement_diagnostics_requests   root     INSERT
-system         public       statement_diagnostics_requests   root     SELECT
-system         public       statement_diagnostics_requests   root     UPDATE
-system         public       statement_statistics             root     GRANT
-system         public       statement_statistics             root     SELECT
-system         public       table_statistics                 root     DELETE
-system         public       table_statistics                 root     GRANT
-system         public       table_statistics                 root     INSERT
-system         public       table_statistics                 root     SELECT
-system         public       table_statistics                 root     UPDATE
-system         public       tenant_settings                  root     DELETE
-system         public       tenant_settings                  root     GRANT
-system         public       tenant_settings                  root     INSERT
-system         public       tenant_settings                  root     SELECT
-system         public       tenant_settings                  root     UPDATE
-system         public       tenant_usage                     root     DELETE
-system         public       tenant_usage                     root     GRANT
-system         public       tenant_usage                     root     INSERT
-system         public       tenant_usage                     root     SELECT
-system         public       tenant_usage                     root     UPDATE
-system         public       tenants                          root     GRANT
-system         public       tenants                          root     SELECT
-system         public       transaction_statistics           root     GRANT
-system         public       transaction_statistics           root     SELECT
-system         public       ui                               root     DELETE
-system         public       ui                               root     GRANT
-system         public       ui                               root     INSERT
-system         public       ui                               root     SELECT
-system         public       ui                               root     UPDATE
-system         public       users                            root     DELETE
-system         public       users                            root     GRANT
-system         public       users                            root     INSERT
-system         public       users                            root     SELECT
-system         public       users                            root     UPDATE
-system         public       web_sessions                     root     DELETE
-system         public       web_sessions                     root     GRANT
-system         public       web_sessions                     root     INSERT
-system         public       web_sessions                     root     SELECT
-system         public       web_sessions                     root     UPDATE
-system         public       zones                            root     DELETE
-system         public       zones                            root     GRANT
-system         public       zones                            root     INSERT
-system         public       zones                            root     SELECT
-system         public       zones                            root     UPDATE
-test           NULL         NULL                             root     ALL
-test           pg_catalog   "char"                           root     ALL
-test           pg_catalog   "char"[]                         root     ALL
-test           pg_catalog   anyelement                       root     ALL
-test           pg_catalog   anyelement[]                     root     ALL
-test           pg_catalog   bit                              root     ALL
-test           pg_catalog   bit[]                            root     ALL
-test           pg_catalog   bool                             root     ALL
-test           pg_catalog   bool[]                           root     ALL
-test           pg_catalog   box2d                            root     ALL
-test           pg_catalog   box2d[]                          root     ALL
-test           pg_catalog   bytes                            root     ALL
-test           pg_catalog   bytes[]                          root     ALL
-test           pg_catalog   char                             root     ALL
-test           pg_catalog   char[]                           root     ALL
-test           pg_catalog   date                             root     ALL
-test           pg_catalog   date[]                           root     ALL
-test           pg_catalog   decimal                          root     ALL
-test           pg_catalog   decimal[]                        root     ALL
-test           pg_catalog   float                            root     ALL
-test           pg_catalog   float4                           root     ALL
-test           pg_catalog   float4[]                         root     ALL
-test           pg_catalog   float[]                          root     ALL
-test           pg_catalog   geography                        root     ALL
-test           pg_catalog   geography[]                      root     ALL
-test           pg_catalog   geometry                         root     ALL
-test           pg_catalog   geometry[]                       root     ALL
-test           pg_catalog   inet                             root     ALL
-test           pg_catalog   inet[]                           root     ALL
-test           pg_catalog   int                              root     ALL
-test           pg_catalog   int2                             root     ALL
-test           pg_catalog   int2[]                           root     ALL
-test           pg_catalog   int2vector                       root     ALL
-test           pg_catalog   int2vector[]                     root     ALL
-test           pg_catalog   int4                             root     ALL
-test           pg_catalog   int4[]                           root     ALL
-test           pg_catalog   int[]                            root     ALL
-test           pg_catalog   interval                         root     ALL
-test           pg_catalog   interval[]                       root     ALL
-test           pg_catalog   jsonb                            root     ALL
-test           pg_catalog   jsonb[]                          root     ALL
-test           pg_catalog   name                             root     ALL
-test           pg_catalog   name[]                           root     ALL
-test           pg_catalog   oid                              root     ALL
-test           pg_catalog   oid[]                            root     ALL
-test           pg_catalog   oidvector                        root     ALL
-test           pg_catalog   oidvector[]                      root     ALL
-test           pg_catalog   record                           root     ALL
-test           pg_catalog   record[]                         root     ALL
-test           pg_catalog   regclass                         root     ALL
-test           pg_catalog   regclass[]                       root     ALL
-test           pg_catalog   regnamespace                     root     ALL
-test           pg_catalog   regnamespace[]                   root     ALL
-test           pg_catalog   regproc                          root     ALL
-test           pg_catalog   regproc[]                        root     ALL
-test           pg_catalog   regprocedure                     root     ALL
-test           pg_catalog   regprocedure[]                   root     ALL
-test           pg_catalog   regrole                          root     ALL
-test           pg_catalog   regrole[]                        root     ALL
-test           pg_catalog   regtype                          root     ALL
-test           pg_catalog   regtype[]                        root     ALL
-test           pg_catalog   string                           root     ALL
-test           pg_catalog   string[]                         root     ALL
-test           pg_catalog   time                             root     ALL
-test           pg_catalog   time[]                           root     ALL
-test           pg_catalog   timestamp                        root     ALL
-test           pg_catalog   timestamp[]                      root     ALL
-test           pg_catalog   timestamptz                      root     ALL
-test           pg_catalog   timestamptz[]                    root     ALL
-test           pg_catalog   timetz                           root     ALL
-test           pg_catalog   timetz[]                         root     ALL
-test           pg_catalog   unknown                          root     ALL
-test           pg_catalog   uuid                             root     ALL
-test           pg_catalog   uuid[]                           root     ALL
-test           pg_catalog   varbit                           root     ALL
-test           pg_catalog   varbit[]                         root     ALL
-test           pg_catalog   varchar                          root     ALL
-test           pg_catalog   varchar[]                        root     ALL
-test           pg_catalog   void                             root     ALL
-test           public       NULL                             root     ALL
+database_name  schema_name  relation_name                    grantee  privilege_type  is_grantable
+a              NULL         NULL                             root     ALL             true
+a              pg_catalog   "char"                           root     ALL             false
+a              pg_catalog   "char"[]                         root     ALL             false
+a              pg_catalog   anyelement                       root     ALL             false
+a              pg_catalog   anyelement[]                     root     ALL             false
+a              pg_catalog   bit                              root     ALL             false
+a              pg_catalog   bit[]                            root     ALL             false
+a              pg_catalog   bool                             root     ALL             false
+a              pg_catalog   bool[]                           root     ALL             false
+a              pg_catalog   box2d                            root     ALL             false
+a              pg_catalog   box2d[]                          root     ALL             false
+a              pg_catalog   bytes                            root     ALL             false
+a              pg_catalog   bytes[]                          root     ALL             false
+a              pg_catalog   char                             root     ALL             false
+a              pg_catalog   char[]                           root     ALL             false
+a              pg_catalog   date                             root     ALL             false
+a              pg_catalog   date[]                           root     ALL             false
+a              pg_catalog   decimal                          root     ALL             false
+a              pg_catalog   decimal[]                        root     ALL             false
+a              pg_catalog   float                            root     ALL             false
+a              pg_catalog   float4                           root     ALL             false
+a              pg_catalog   float4[]                         root     ALL             false
+a              pg_catalog   float[]                          root     ALL             false
+a              pg_catalog   geography                        root     ALL             false
+a              pg_catalog   geography[]                      root     ALL             false
+a              pg_catalog   geometry                         root     ALL             false
+a              pg_catalog   geometry[]                       root     ALL             false
+a              pg_catalog   inet                             root     ALL             false
+a              pg_catalog   inet[]                           root     ALL             false
+a              pg_catalog   int                              root     ALL             false
+a              pg_catalog   int2                             root     ALL             false
+a              pg_catalog   int2[]                           root     ALL             false
+a              pg_catalog   int2vector                       root     ALL             false
+a              pg_catalog   int2vector[]                     root     ALL             false
+a              pg_catalog   int4                             root     ALL             false
+a              pg_catalog   int4[]                           root     ALL             false
+a              pg_catalog   int[]                            root     ALL             false
+a              pg_catalog   interval                         root     ALL             false
+a              pg_catalog   interval[]                       root     ALL             false
+a              pg_catalog   jsonb                            root     ALL             false
+a              pg_catalog   jsonb[]                          root     ALL             false
+a              pg_catalog   name                             root     ALL             false
+a              pg_catalog   name[]                           root     ALL             false
+a              pg_catalog   oid                              root     ALL             false
+a              pg_catalog   oid[]                            root     ALL             false
+a              pg_catalog   oidvector                        root     ALL             false
+a              pg_catalog   oidvector[]                      root     ALL             false
+a              pg_catalog   record                           root     ALL             false
+a              pg_catalog   record[]                         root     ALL             false
+a              pg_catalog   regclass                         root     ALL             false
+a              pg_catalog   regclass[]                       root     ALL             false
+a              pg_catalog   regnamespace                     root     ALL             false
+a              pg_catalog   regnamespace[]                   root     ALL             false
+a              pg_catalog   regproc                          root     ALL             false
+a              pg_catalog   regproc[]                        root     ALL             false
+a              pg_catalog   regprocedure                     root     ALL             false
+a              pg_catalog   regprocedure[]                   root     ALL             false
+a              pg_catalog   regrole                          root     ALL             false
+a              pg_catalog   regrole[]                        root     ALL             false
+a              pg_catalog   regtype                          root     ALL             false
+a              pg_catalog   regtype[]                        root     ALL             false
+a              pg_catalog   string                           root     ALL             false
+a              pg_catalog   string[]                         root     ALL             false
+a              pg_catalog   time                             root     ALL             false
+a              pg_catalog   time[]                           root     ALL             false
+a              pg_catalog   timestamp                        root     ALL             false
+a              pg_catalog   timestamp[]                      root     ALL             false
+a              pg_catalog   timestamptz                      root     ALL             false
+a              pg_catalog   timestamptz[]                    root     ALL             false
+a              pg_catalog   timetz                           root     ALL             false
+a              pg_catalog   timetz[]                         root     ALL             false
+a              pg_catalog   unknown                          root     ALL             false
+a              pg_catalog   uuid                             root     ALL             false
+a              pg_catalog   uuid[]                           root     ALL             false
+a              pg_catalog   varbit                           root     ALL             false
+a              pg_catalog   varbit[]                         root     ALL             false
+a              pg_catalog   varchar                          root     ALL             false
+a              pg_catalog   varchar[]                        root     ALL             false
+a              pg_catalog   void                             root     ALL             false
+a              public       NULL                             root     ALL             true
+defaultdb      NULL         NULL                             root     ALL             true
+defaultdb      pg_catalog   "char"                           root     ALL             false
+defaultdb      pg_catalog   "char"[]                         root     ALL             false
+defaultdb      pg_catalog   anyelement                       root     ALL             false
+defaultdb      pg_catalog   anyelement[]                     root     ALL             false
+defaultdb      pg_catalog   bit                              root     ALL             false
+defaultdb      pg_catalog   bit[]                            root     ALL             false
+defaultdb      pg_catalog   bool                             root     ALL             false
+defaultdb      pg_catalog   bool[]                           root     ALL             false
+defaultdb      pg_catalog   box2d                            root     ALL             false
+defaultdb      pg_catalog   box2d[]                          root     ALL             false
+defaultdb      pg_catalog   bytes                            root     ALL             false
+defaultdb      pg_catalog   bytes[]                          root     ALL             false
+defaultdb      pg_catalog   char                             root     ALL             false
+defaultdb      pg_catalog   char[]                           root     ALL             false
+defaultdb      pg_catalog   date                             root     ALL             false
+defaultdb      pg_catalog   date[]                           root     ALL             false
+defaultdb      pg_catalog   decimal                          root     ALL             false
+defaultdb      pg_catalog   decimal[]                        root     ALL             false
+defaultdb      pg_catalog   float                            root     ALL             false
+defaultdb      pg_catalog   float4                           root     ALL             false
+defaultdb      pg_catalog   float4[]                         root     ALL             false
+defaultdb      pg_catalog   float[]                          root     ALL             false
+defaultdb      pg_catalog   geography                        root     ALL             false
+defaultdb      pg_catalog   geography[]                      root     ALL             false
+defaultdb      pg_catalog   geometry                         root     ALL             false
+defaultdb      pg_catalog   geometry[]                       root     ALL             false
+defaultdb      pg_catalog   inet                             root     ALL             false
+defaultdb      pg_catalog   inet[]                           root     ALL             false
+defaultdb      pg_catalog   int                              root     ALL             false
+defaultdb      pg_catalog   int2                             root     ALL             false
+defaultdb      pg_catalog   int2[]                           root     ALL             false
+defaultdb      pg_catalog   int2vector                       root     ALL             false
+defaultdb      pg_catalog   int2vector[]                     root     ALL             false
+defaultdb      pg_catalog   int4                             root     ALL             false
+defaultdb      pg_catalog   int4[]                           root     ALL             false
+defaultdb      pg_catalog   int[]                            root     ALL             false
+defaultdb      pg_catalog   interval                         root     ALL             false
+defaultdb      pg_catalog   interval[]                       root     ALL             false
+defaultdb      pg_catalog   jsonb                            root     ALL             false
+defaultdb      pg_catalog   jsonb[]                          root     ALL             false
+defaultdb      pg_catalog   name                             root     ALL             false
+defaultdb      pg_catalog   name[]                           root     ALL             false
+defaultdb      pg_catalog   oid                              root     ALL             false
+defaultdb      pg_catalog   oid[]                            root     ALL             false
+defaultdb      pg_catalog   oidvector                        root     ALL             false
+defaultdb      pg_catalog   oidvector[]                      root     ALL             false
+defaultdb      pg_catalog   record                           root     ALL             false
+defaultdb      pg_catalog   record[]                         root     ALL             false
+defaultdb      pg_catalog   regclass                         root     ALL             false
+defaultdb      pg_catalog   regclass[]                       root     ALL             false
+defaultdb      pg_catalog   regnamespace                     root     ALL             false
+defaultdb      pg_catalog   regnamespace[]                   root     ALL             false
+defaultdb      pg_catalog   regproc                          root     ALL             false
+defaultdb      pg_catalog   regproc[]                        root     ALL             false
+defaultdb      pg_catalog   regprocedure                     root     ALL             false
+defaultdb      pg_catalog   regprocedure[]                   root     ALL             false
+defaultdb      pg_catalog   regrole                          root     ALL             false
+defaultdb      pg_catalog   regrole[]                        root     ALL             false
+defaultdb      pg_catalog   regtype                          root     ALL             false
+defaultdb      pg_catalog   regtype[]                        root     ALL             false
+defaultdb      pg_catalog   string                           root     ALL             false
+defaultdb      pg_catalog   string[]                         root     ALL             false
+defaultdb      pg_catalog   time                             root     ALL             false
+defaultdb      pg_catalog   time[]                           root     ALL             false
+defaultdb      pg_catalog   timestamp                        root     ALL             false
+defaultdb      pg_catalog   timestamp[]                      root     ALL             false
+defaultdb      pg_catalog   timestamptz                      root     ALL             false
+defaultdb      pg_catalog   timestamptz[]                    root     ALL             false
+defaultdb      pg_catalog   timetz                           root     ALL             false
+defaultdb      pg_catalog   timetz[]                         root     ALL             false
+defaultdb      pg_catalog   unknown                          root     ALL             false
+defaultdb      pg_catalog   uuid                             root     ALL             false
+defaultdb      pg_catalog   uuid[]                           root     ALL             false
+defaultdb      pg_catalog   varbit                           root     ALL             false
+defaultdb      pg_catalog   varbit[]                         root     ALL             false
+defaultdb      pg_catalog   varchar                          root     ALL             false
+defaultdb      pg_catalog   varchar[]                        root     ALL             false
+defaultdb      pg_catalog   void                             root     ALL             false
+defaultdb      public       NULL                             root     ALL             true
+postgres       NULL         NULL                             root     ALL             true
+postgres       pg_catalog   "char"                           root     ALL             false
+postgres       pg_catalog   "char"[]                         root     ALL             false
+postgres       pg_catalog   anyelement                       root     ALL             false
+postgres       pg_catalog   anyelement[]                     root     ALL             false
+postgres       pg_catalog   bit                              root     ALL             false
+postgres       pg_catalog   bit[]                            root     ALL             false
+postgres       pg_catalog   bool                             root     ALL             false
+postgres       pg_catalog   bool[]                           root     ALL             false
+postgres       pg_catalog   box2d                            root     ALL             false
+postgres       pg_catalog   box2d[]                          root     ALL             false
+postgres       pg_catalog   bytes                            root     ALL             false
+postgres       pg_catalog   bytes[]                          root     ALL             false
+postgres       pg_catalog   char                             root     ALL             false
+postgres       pg_catalog   char[]                           root     ALL             false
+postgres       pg_catalog   date                             root     ALL             false
+postgres       pg_catalog   date[]                           root     ALL             false
+postgres       pg_catalog   decimal                          root     ALL             false
+postgres       pg_catalog   decimal[]                        root     ALL             false
+postgres       pg_catalog   float                            root     ALL             false
+postgres       pg_catalog   float4                           root     ALL             false
+postgres       pg_catalog   float4[]                         root     ALL             false
+postgres       pg_catalog   float[]                          root     ALL             false
+postgres       pg_catalog   geography                        root     ALL             false
+postgres       pg_catalog   geography[]                      root     ALL             false
+postgres       pg_catalog   geometry                         root     ALL             false
+postgres       pg_catalog   geometry[]                       root     ALL             false
+postgres       pg_catalog   inet                             root     ALL             false
+postgres       pg_catalog   inet[]                           root     ALL             false
+postgres       pg_catalog   int                              root     ALL             false
+postgres       pg_catalog   int2                             root     ALL             false
+postgres       pg_catalog   int2[]                           root     ALL             false
+postgres       pg_catalog   int2vector                       root     ALL             false
+postgres       pg_catalog   int2vector[]                     root     ALL             false
+postgres       pg_catalog   int4                             root     ALL             false
+postgres       pg_catalog   int4[]                           root     ALL             false
+postgres       pg_catalog   int[]                            root     ALL             false
+postgres       pg_catalog   interval                         root     ALL             false
+postgres       pg_catalog   interval[]                       root     ALL             false
+postgres       pg_catalog   jsonb                            root     ALL             false
+postgres       pg_catalog   jsonb[]                          root     ALL             false
+postgres       pg_catalog   name                             root     ALL             false
+postgres       pg_catalog   name[]                           root     ALL             false
+postgres       pg_catalog   oid                              root     ALL             false
+postgres       pg_catalog   oid[]                            root     ALL             false
+postgres       pg_catalog   oidvector                        root     ALL             false
+postgres       pg_catalog   oidvector[]                      root     ALL             false
+postgres       pg_catalog   record                           root     ALL             false
+postgres       pg_catalog   record[]                         root     ALL             false
+postgres       pg_catalog   regclass                         root     ALL             false
+postgres       pg_catalog   regclass[]                       root     ALL             false
+postgres       pg_catalog   regnamespace                     root     ALL             false
+postgres       pg_catalog   regnamespace[]                   root     ALL             false
+postgres       pg_catalog   regproc                          root     ALL             false
+postgres       pg_catalog   regproc[]                        root     ALL             false
+postgres       pg_catalog   regprocedure                     root     ALL             false
+postgres       pg_catalog   regprocedure[]                   root     ALL             false
+postgres       pg_catalog   regrole                          root     ALL             false
+postgres       pg_catalog   regrole[]                        root     ALL             false
+postgres       pg_catalog   regtype                          root     ALL             false
+postgres       pg_catalog   regtype[]                        root     ALL             false
+postgres       pg_catalog   string                           root     ALL             false
+postgres       pg_catalog   string[]                         root     ALL             false
+postgres       pg_catalog   time                             root     ALL             false
+postgres       pg_catalog   time[]                           root     ALL             false
+postgres       pg_catalog   timestamp                        root     ALL             false
+postgres       pg_catalog   timestamp[]                      root     ALL             false
+postgres       pg_catalog   timestamptz                      root     ALL             false
+postgres       pg_catalog   timestamptz[]                    root     ALL             false
+postgres       pg_catalog   timetz                           root     ALL             false
+postgres       pg_catalog   timetz[]                         root     ALL             false
+postgres       pg_catalog   unknown                          root     ALL             false
+postgres       pg_catalog   uuid                             root     ALL             false
+postgres       pg_catalog   uuid[]                           root     ALL             false
+postgres       pg_catalog   varbit                           root     ALL             false
+postgres       pg_catalog   varbit[]                         root     ALL             false
+postgres       pg_catalog   varchar                          root     ALL             false
+postgres       pg_catalog   varchar[]                        root     ALL             false
+postgres       pg_catalog   void                             root     ALL             false
+postgres       public       NULL                             root     ALL             true
+system         NULL         NULL                             root     CONNECT         true
+system         pg_catalog   "char"                           root     ALL             false
+system         pg_catalog   "char"[]                         root     ALL             false
+system         pg_catalog   anyelement                       root     ALL             false
+system         pg_catalog   anyelement[]                     root     ALL             false
+system         pg_catalog   bit                              root     ALL             false
+system         pg_catalog   bit[]                            root     ALL             false
+system         pg_catalog   bool                             root     ALL             false
+system         pg_catalog   bool[]                           root     ALL             false
+system         pg_catalog   box2d                            root     ALL             false
+system         pg_catalog   box2d[]                          root     ALL             false
+system         pg_catalog   bytes                            root     ALL             false
+system         pg_catalog   bytes[]                          root     ALL             false
+system         pg_catalog   char                             root     ALL             false
+system         pg_catalog   char[]                           root     ALL             false
+system         pg_catalog   date                             root     ALL             false
+system         pg_catalog   date[]                           root     ALL             false
+system         pg_catalog   decimal                          root     ALL             false
+system         pg_catalog   decimal[]                        root     ALL             false
+system         pg_catalog   float                            root     ALL             false
+system         pg_catalog   float4                           root     ALL             false
+system         pg_catalog   float4[]                         root     ALL             false
+system         pg_catalog   float[]                          root     ALL             false
+system         pg_catalog   geography                        root     ALL             false
+system         pg_catalog   geography[]                      root     ALL             false
+system         pg_catalog   geometry                         root     ALL             false
+system         pg_catalog   geometry[]                       root     ALL             false
+system         pg_catalog   inet                             root     ALL             false
+system         pg_catalog   inet[]                           root     ALL             false
+system         pg_catalog   int                              root     ALL             false
+system         pg_catalog   int2                             root     ALL             false
+system         pg_catalog   int2[]                           root     ALL             false
+system         pg_catalog   int2vector                       root     ALL             false
+system         pg_catalog   int2vector[]                     root     ALL             false
+system         pg_catalog   int4                             root     ALL             false
+system         pg_catalog   int4[]                           root     ALL             false
+system         pg_catalog   int[]                            root     ALL             false
+system         pg_catalog   interval                         root     ALL             false
+system         pg_catalog   interval[]                       root     ALL             false
+system         pg_catalog   jsonb                            root     ALL             false
+system         pg_catalog   jsonb[]                          root     ALL             false
+system         pg_catalog   name                             root     ALL             false
+system         pg_catalog   name[]                           root     ALL             false
+system         pg_catalog   oid                              root     ALL             false
+system         pg_catalog   oid[]                            root     ALL             false
+system         pg_catalog   oidvector                        root     ALL             false
+system         pg_catalog   oidvector[]                      root     ALL             false
+system         pg_catalog   record                           root     ALL             false
+system         pg_catalog   record[]                         root     ALL             false
+system         pg_catalog   regclass                         root     ALL             false
+system         pg_catalog   regclass[]                       root     ALL             false
+system         pg_catalog   regnamespace                     root     ALL             false
+system         pg_catalog   regnamespace[]                   root     ALL             false
+system         pg_catalog   regproc                          root     ALL             false
+system         pg_catalog   regproc[]                        root     ALL             false
+system         pg_catalog   regprocedure                     root     ALL             false
+system         pg_catalog   regprocedure[]                   root     ALL             false
+system         pg_catalog   regrole                          root     ALL             false
+system         pg_catalog   regrole[]                        root     ALL             false
+system         pg_catalog   regtype                          root     ALL             false
+system         pg_catalog   regtype[]                        root     ALL             false
+system         pg_catalog   string                           root     ALL             false
+system         pg_catalog   string[]                         root     ALL             false
+system         pg_catalog   time                             root     ALL             false
+system         pg_catalog   time[]                           root     ALL             false
+system         pg_catalog   timestamp                        root     ALL             false
+system         pg_catalog   timestamp[]                      root     ALL             false
+system         pg_catalog   timestamptz                      root     ALL             false
+system         pg_catalog   timestamptz[]                    root     ALL             false
+system         pg_catalog   timetz                           root     ALL             false
+system         pg_catalog   timetz[]                         root     ALL             false
+system         pg_catalog   unknown                          root     ALL             false
+system         pg_catalog   uuid                             root     ALL             false
+system         pg_catalog   uuid[]                           root     ALL             false
+system         pg_catalog   varbit                           root     ALL             false
+system         pg_catalog   varbit[]                         root     ALL             false
+system         pg_catalog   varchar                          root     ALL             false
+system         pg_catalog   varchar[]                        root     ALL             false
+system         pg_catalog   void                             root     ALL             false
+system         public       NULL                             root     ALL             true
+system         public       comments                         root     DELETE          true
+system         public       comments                         root     GRANT           true
+system         public       comments                         root     INSERT          true
+system         public       comments                         root     SELECT          true
+system         public       comments                         root     UPDATE          true
+system         public       database_role_settings           root     DELETE          true
+system         public       database_role_settings           root     GRANT           true
+system         public       database_role_settings           root     INSERT          true
+system         public       database_role_settings           root     SELECT          true
+system         public       database_role_settings           root     UPDATE          true
+system         public       descriptor                       root     GRANT           true
+system         public       descriptor                       root     SELECT          true
+system         public       eventlog                         root     DELETE          true
+system         public       eventlog                         root     GRANT           true
+system         public       eventlog                         root     INSERT          true
+system         public       eventlog                         root     SELECT          true
+system         public       eventlog                         root     UPDATE          true
+system         public       jobs                             root     DELETE          true
+system         public       jobs                             root     GRANT           true
+system         public       jobs                             root     INSERT          true
+system         public       jobs                             root     SELECT          true
+system         public       jobs                             root     UPDATE          true
+system         public       join_tokens                      root     DELETE          true
+system         public       join_tokens                      root     GRANT           true
+system         public       join_tokens                      root     INSERT          true
+system         public       join_tokens                      root     SELECT          true
+system         public       join_tokens                      root     UPDATE          true
+system         public       lease                            root     DELETE          true
+system         public       lease                            root     GRANT           true
+system         public       lease                            root     INSERT          true
+system         public       lease                            root     SELECT          true
+system         public       lease                            root     UPDATE          true
+system         public       locations                        root     DELETE          true
+system         public       locations                        root     GRANT           true
+system         public       locations                        root     INSERT          true
+system         public       locations                        root     SELECT          true
+system         public       locations                        root     UPDATE          true
+system         public       migrations                       root     DELETE          true
+system         public       migrations                       root     GRANT           true
+system         public       migrations                       root     INSERT          true
+system         public       migrations                       root     SELECT          true
+system         public       migrations                       root     UPDATE          true
+system         public       namespace                        root     GRANT           true
+system         public       namespace                        root     SELECT          true
+system         public       protected_ts_meta                root     GRANT           true
+system         public       protected_ts_meta                root     SELECT          true
+system         public       protected_ts_records             root     GRANT           true
+system         public       protected_ts_records             root     SELECT          true
+system         public       rangelog                         root     DELETE          true
+system         public       rangelog                         root     GRANT           true
+system         public       rangelog                         root     INSERT          true
+system         public       rangelog                         root     SELECT          true
+system         public       rangelog                         root     UPDATE          true
+system         public       replication_constraint_stats     root     DELETE          true
+system         public       replication_constraint_stats     root     GRANT           true
+system         public       replication_constraint_stats     root     INSERT          true
+system         public       replication_constraint_stats     root     SELECT          true
+system         public       replication_constraint_stats     root     UPDATE          true
+system         public       replication_critical_localities  root     DELETE          true
+system         public       replication_critical_localities  root     GRANT           true
+system         public       replication_critical_localities  root     INSERT          true
+system         public       replication_critical_localities  root     SELECT          true
+system         public       replication_critical_localities  root     UPDATE          true
+system         public       replication_stats                root     DELETE          true
+system         public       replication_stats                root     GRANT           true
+system         public       replication_stats                root     INSERT          true
+system         public       replication_stats                root     SELECT          true
+system         public       replication_stats                root     UPDATE          true
+system         public       reports_meta                     root     DELETE          true
+system         public       reports_meta                     root     GRANT           true
+system         public       reports_meta                     root     INSERT          true
+system         public       reports_meta                     root     SELECT          true
+system         public       reports_meta                     root     UPDATE          true
+system         public       role_members                     root     DELETE          true
+system         public       role_members                     root     GRANT           true
+system         public       role_members                     root     INSERT          true
+system         public       role_members                     root     SELECT          true
+system         public       role_members                     root     UPDATE          true
+system         public       role_options                     root     DELETE          true
+system         public       role_options                     root     GRANT           true
+system         public       role_options                     root     INSERT          true
+system         public       role_options                     root     SELECT          true
+system         public       role_options                     root     UPDATE          true
+system         public       scheduled_jobs                   root     DELETE          true
+system         public       scheduled_jobs                   root     GRANT           true
+system         public       scheduled_jobs                   root     INSERT          true
+system         public       scheduled_jobs                   root     SELECT          true
+system         public       scheduled_jobs                   root     UPDATE          true
+system         public       settings                         root     DELETE          true
+system         public       settings                         root     GRANT           true
+system         public       settings                         root     INSERT          true
+system         public       settings                         root     SELECT          true
+system         public       settings                         root     UPDATE          true
+system         public       span_configurations              root     DELETE          true
+system         public       span_configurations              root     GRANT           true
+system         public       span_configurations              root     INSERT          true
+system         public       span_configurations              root     SELECT          true
+system         public       span_configurations              root     UPDATE          true
+system         public       sql_instances                    root     DELETE          true
+system         public       sql_instances                    root     GRANT           true
+system         public       sql_instances                    root     INSERT          true
+system         public       sql_instances                    root     SELECT          true
+system         public       sql_instances                    root     UPDATE          true
+system         public       sqlliveness                      root     DELETE          true
+system         public       sqlliveness                      root     GRANT           true
+system         public       sqlliveness                      root     INSERT          true
+system         public       sqlliveness                      root     SELECT          true
+system         public       sqlliveness                      root     UPDATE          true
+system         public       statement_bundle_chunks          root     DELETE          true
+system         public       statement_bundle_chunks          root     GRANT           true
+system         public       statement_bundle_chunks          root     INSERT          true
+system         public       statement_bundle_chunks          root     SELECT          true
+system         public       statement_bundle_chunks          root     UPDATE          true
+system         public       statement_diagnostics            root     DELETE          true
+system         public       statement_diagnostics            root     GRANT           true
+system         public       statement_diagnostics            root     INSERT          true
+system         public       statement_diagnostics            root     SELECT          true
+system         public       statement_diagnostics            root     UPDATE          true
+system         public       statement_diagnostics_requests   root     DELETE          true
+system         public       statement_diagnostics_requests   root     GRANT           true
+system         public       statement_diagnostics_requests   root     INSERT          true
+system         public       statement_diagnostics_requests   root     SELECT          true
+system         public       statement_diagnostics_requests   root     UPDATE          true
+system         public       statement_statistics             root     GRANT           true
+system         public       statement_statistics             root     SELECT          true
+system         public       table_statistics                 root     DELETE          true
+system         public       table_statistics                 root     GRANT           true
+system         public       table_statistics                 root     INSERT          true
+system         public       table_statistics                 root     SELECT          true
+system         public       table_statistics                 root     UPDATE          true
+system         public       tenant_settings                  root     DELETE          true
+system         public       tenant_settings                  root     GRANT           true
+system         public       tenant_settings                  root     INSERT          true
+system         public       tenant_settings                  root     SELECT          true
+system         public       tenant_settings                  root     UPDATE          true
+system         public       tenant_usage                     root     DELETE          true
+system         public       tenant_usage                     root     GRANT           true
+system         public       tenant_usage                     root     INSERT          true
+system         public       tenant_usage                     root     SELECT          true
+system         public       tenant_usage                     root     UPDATE          true
+system         public       tenants                          root     GRANT           true
+system         public       tenants                          root     SELECT          true
+system         public       transaction_statistics           root     GRANT           true
+system         public       transaction_statistics           root     SELECT          true
+system         public       ui                               root     DELETE          true
+system         public       ui                               root     GRANT           true
+system         public       ui                               root     INSERT          true
+system         public       ui                               root     SELECT          true
+system         public       ui                               root     UPDATE          true
+system         public       users                            root     DELETE          true
+system         public       users                            root     GRANT           true
+system         public       users                            root     INSERT          true
+system         public       users                            root     SELECT          true
+system         public       users                            root     UPDATE          true
+system         public       web_sessions                     root     DELETE          true
+system         public       web_sessions                     root     GRANT           true
+system         public       web_sessions                     root     INSERT          true
+system         public       web_sessions                     root     SELECT          true
+system         public       web_sessions                     root     UPDATE          true
+system         public       zones                            root     DELETE          true
+system         public       zones                            root     GRANT           true
+system         public       zones                            root     INSERT          true
+system         public       zones                            root     SELECT          true
+system         public       zones                            root     UPDATE          true
+test           NULL         NULL                             root     ALL             true
+test           pg_catalog   "char"                           root     ALL             false
+test           pg_catalog   "char"[]                         root     ALL             false
+test           pg_catalog   anyelement                       root     ALL             false
+test           pg_catalog   anyelement[]                     root     ALL             false
+test           pg_catalog   bit                              root     ALL             false
+test           pg_catalog   bit[]                            root     ALL             false
+test           pg_catalog   bool                             root     ALL             false
+test           pg_catalog   bool[]                           root     ALL             false
+test           pg_catalog   box2d                            root     ALL             false
+test           pg_catalog   box2d[]                          root     ALL             false
+test           pg_catalog   bytes                            root     ALL             false
+test           pg_catalog   bytes[]                          root     ALL             false
+test           pg_catalog   char                             root     ALL             false
+test           pg_catalog   char[]                           root     ALL             false
+test           pg_catalog   date                             root     ALL             false
+test           pg_catalog   date[]                           root     ALL             false
+test           pg_catalog   decimal                          root     ALL             false
+test           pg_catalog   decimal[]                        root     ALL             false
+test           pg_catalog   float                            root     ALL             false
+test           pg_catalog   float4                           root     ALL             false
+test           pg_catalog   float4[]                         root     ALL             false
+test           pg_catalog   float[]                          root     ALL             false
+test           pg_catalog   geography                        root     ALL             false
+test           pg_catalog   geography[]                      root     ALL             false
+test           pg_catalog   geometry                         root     ALL             false
+test           pg_catalog   geometry[]                       root     ALL             false
+test           pg_catalog   inet                             root     ALL             false
+test           pg_catalog   inet[]                           root     ALL             false
+test           pg_catalog   int                              root     ALL             false
+test           pg_catalog   int2                             root     ALL             false
+test           pg_catalog   int2[]                           root     ALL             false
+test           pg_catalog   int2vector                       root     ALL             false
+test           pg_catalog   int2vector[]                     root     ALL             false
+test           pg_catalog   int4                             root     ALL             false
+test           pg_catalog   int4[]                           root     ALL             false
+test           pg_catalog   int[]                            root     ALL             false
+test           pg_catalog   interval                         root     ALL             false
+test           pg_catalog   interval[]                       root     ALL             false
+test           pg_catalog   jsonb                            root     ALL             false
+test           pg_catalog   jsonb[]                          root     ALL             false
+test           pg_catalog   name                             root     ALL             false
+test           pg_catalog   name[]                           root     ALL             false
+test           pg_catalog   oid                              root     ALL             false
+test           pg_catalog   oid[]                            root     ALL             false
+test           pg_catalog   oidvector                        root     ALL             false
+test           pg_catalog   oidvector[]                      root     ALL             false
+test           pg_catalog   record                           root     ALL             false
+test           pg_catalog   record[]                         root     ALL             false
+test           pg_catalog   regclass                         root     ALL             false
+test           pg_catalog   regclass[]                       root     ALL             false
+test           pg_catalog   regnamespace                     root     ALL             false
+test           pg_catalog   regnamespace[]                   root     ALL             false
+test           pg_catalog   regproc                          root     ALL             false
+test           pg_catalog   regproc[]                        root     ALL             false
+test           pg_catalog   regprocedure                     root     ALL             false
+test           pg_catalog   regprocedure[]                   root     ALL             false
+test           pg_catalog   regrole                          root     ALL             false
+test           pg_catalog   regrole[]                        root     ALL             false
+test           pg_catalog   regtype                          root     ALL             false
+test           pg_catalog   regtype[]                        root     ALL             false
+test           pg_catalog   string                           root     ALL             false
+test           pg_catalog   string[]                         root     ALL             false
+test           pg_catalog   time                             root     ALL             false
+test           pg_catalog   time[]                           root     ALL             false
+test           pg_catalog   timestamp                        root     ALL             false
+test           pg_catalog   timestamp[]                      root     ALL             false
+test           pg_catalog   timestamptz                      root     ALL             false
+test           pg_catalog   timestamptz[]                    root     ALL             false
+test           pg_catalog   timetz                           root     ALL             false
+test           pg_catalog   timetz[]                         root     ALL             false
+test           pg_catalog   unknown                          root     ALL             false
+test           pg_catalog   uuid                             root     ALL             false
+test           pg_catalog   uuid[]                           root     ALL             false
+test           pg_catalog   varbit                           root     ALL             false
+test           pg_catalog   varbit[]                         root     ALL             false
+test           pg_catalog   varchar                          root     ALL             false
+test           pg_catalog   varchar[]                        root     ALL             false
+test           pg_catalog   void                             root     ALL             false
+test           public       NULL                             root     ALL             true
 
 statement error pgcode 42P01 relation "a.t" does not exist
 SHOW GRANTS ON a.t
@@ -1834,21 +1834,21 @@ a  public  v  test-user  GRANT       true
 a  public  v  test-user  UPDATE      true
 a  public  v  test-user  ZONECONFIG  true
 
-query TTTTT
+query TTTTTB
 SHOW GRANTS FOR readwrite, "test-user"
 ----
-a  NULL    NULL  readwrite  ALL
-a  public  v     readwrite  CREATE
-a  public  v     readwrite  DROP
-a  public  v     readwrite  GRANT
-a  public  v     readwrite  SELECT
-a  public  v     readwrite  UPDATE
-a  public  v     readwrite  ZONECONFIG
-a  public  v     test-user  CREATE
-a  public  v     test-user  DROP
-a  public  v     test-user  GRANT
-a  public  v     test-user  UPDATE
-a  public  v     test-user  ZONECONFIG
+a  NULL    NULL  readwrite  ALL         true
+a  public  v     readwrite  CREATE      true
+a  public  v     readwrite  DROP        true
+a  public  v     readwrite  GRANT       true
+a  public  v     readwrite  SELECT      true
+a  public  v     readwrite  UPDATE      true
+a  public  v     readwrite  ZONECONFIG  true
+a  public  v     test-user  CREATE      true
+a  public  v     test-user  DROP        true
+a  public  v     test-user  GRANT       true
+a  public  v     test-user  UPDATE      true
+a  public  v     test-user  ZONECONFIG  true
 
 statement ok
 REVOKE ALL ON v FROM readwrite,"test-user"
@@ -1863,10 +1863,10 @@ query TTTTTB
 SHOW GRANTS ON v FOR readwrite, "test-user"
 ----
 
-query TTTTT
+query TTTTTB
 SHOW GRANTS FOR readwrite, "test-user"
 ----
-a  NULL  NULL  readwrite  ALL
+a  NULL  NULL  readwrite  ALL  true
 
 # Verify that the DB privileges have not changed.
 query TTTB colnames

--- a/pkg/sql/logictest/testdata/logic_test/grant_type
+++ b/pkg/sql/logictest/testdata/logic_test/grant_type
@@ -45,13 +45,13 @@ database_name  schema_name  type_name  grantee  privilege_type  is_grantable
 test           public       enum_a     user1    USAGE           false
 test           schema_a     enum_b     user1    ALL             true
 
-query TTTTT colnames
+query TTTTTB colnames
 SHOW GRANTS FOR user1
 ----
-database_name  schema_name  relation_name  grantee  privilege_type
-test           public       enum_a         user1    USAGE
-test           public       enum_a+b       user1    USAGE
-test           schema_a     enum_b         user1    ALL
+database_name  schema_name  relation_name  grantee  privilege_type  is_grantable
+test           public       enum_a         user1    USAGE           false
+test           public       enum_a+b       user1    USAGE           false
+test           schema_a     enum_b         user1    ALL             true
 
 statement error type "non_existent" does not exist
 SHOW GRANTS ON TYPE non_existent


### PR DESCRIPTION
Backport 1/1 commits from #81582.

/cc @cockroachdb/release

---

refs https://github.com/cockroachdb/cockroach/issues/73394

Release note (sql change): Add is_grantable column to
SHOW GRANTS FOR role to be consistent with other SHOW GRANTS
commands.

Release justification: Add is_grantable column to
SHOW GRANTS FOR role to be consistent with other SHOW GRANTS
commands.