### PR TITLE
sql: deflake TestPrimaryKeyDropIndexNotCancelable

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -3303,18 +3303,18 @@ func TestPrimaryKeyDropIndexNotCancelable(t *testing.T) {
 
 	ctx := context.Background()
 	var db *gosql.DB
-	shouldAttemptCancel := true
+	var shouldAttemptCancel syncutil.AtomicBool
+	shouldAttemptCancel.Set(true)
 	hasAttemptedCancel := make(chan struct{})
 	params, _ := tests.CreateTestServerParams()
 	params.Knobs = base.TestingKnobs{
 		GCJob: &sql.GCJobTestingKnobs{
 			RunBeforeResume: func(jobID jobspb.JobID) error {
-				if !shouldAttemptCancel {
+				if !shouldAttemptCancel.Swap(false) {
 					return nil
 				}
 				_, err := db.Exec(`CANCEL JOB ($1)`, jobID)
-				require.Regexp(t, "not cancelable", err)
-				shouldAttemptCancel = false
+				assert.Regexp(t, "not cancelable", err)
 				close(hasAttemptedCancel)
 				return nil
 			},


### PR DESCRIPTION
The problem was that we weren't atomically setting the boolean, at least, I
think. I repro'd another flake of it pretty quickly.

Release note: None