### PR TITLE
kv: only scan intents span for QueryIntent request

### DIFF
--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -104,6 +104,7 @@ go_test(
         "cmd_export_test.go",
         "cmd_get_test.go",
         "cmd_lease_test.go",
+        "cmd_query_intent_test.go",
         "cmd_query_resolved_timestamp_test.go",
         "cmd_recover_txn_test.go",
         "cmd_refresh_range_bench_test.go",

--- a/pkg/kv/kvserver/batcheval/cmd_query_intent_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_intent_test.go
@@ -1,0 +1,141 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package batcheval
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryIntent(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	db := storage.NewDefaultInMemForTesting()
+	defer db.Close()
+
+	makeTS := func(ts int64) hlc.Timestamp {
+		return hlc.Timestamp{WallTime: ts}
+	}
+
+	writeIntent := func(k roachpb.Key, ts int64) roachpb.Transaction {
+		txn := roachpb.MakeTransaction("test", k, 0, makeTS(ts), 0, 1)
+		require.NoError(t, storage.MVCCDelete(ctx, db, nil, k, makeTS(ts), hlc.ClockTimestamp{}, &txn))
+		return txn
+	}
+
+	// Write three keys in three separate transactions.
+	keyA := roachpb.Key("a")
+	keyAA := roachpb.Key("aa")
+	keyB := roachpb.Key("b")
+	keyC := roachpb.Key("c")
+
+	txA := writeIntent(keyA, 5)
+	txAA := writeIntent(keyAA, 6)
+	txB := writeIntent(keyB, 7)
+
+	st := cluster.MakeTestingClusterSettings()
+	clock := hlc.NewClock(hlc.NewManualClock(10), time.Nanosecond)
+	evalCtx := &MockEvalCtx{ClusterSettings: st, Clock: clock}
+
+	// Since we can't move the intents clock after they are written, created
+	// cloned transactions with the clock shifted instead.
+	txABack := *txA.Clone()
+	txAForward := *txA.Clone()
+	txABack.WriteTimestamp = txABack.WriteTimestamp.Add(-2, 0)
+	txAForward.WriteTimestamp = txAForward.WriteTimestamp.Add(20, 0)
+
+	type Success struct{}
+	type NotFound struct{}
+	success := Success{}
+	notFound := NotFound{}
+
+	tests := []struct {
+		name           string
+		hTransaction   roachpb.Transaction
+		argTransaction roachpb.Transaction
+		key            roachpb.Key
+		errorFlag      bool
+		response       interface{}
+	}{
+		// Perform standard reading of all three keys.
+		{"readA", txA, txA, keyA, true, success},
+		{"readAA", txAA, txAA, keyAA, true, success},
+		{"readB", txB, txB, keyB, true, success},
+
+		{"readC", txA, txA, keyC, true, &roachpb.IntentMissingError{}},
+
+		// This tries reading a different key than this tx was written with. The
+		// returned error depends on the error flag setting.
+		{"wrongTxE", txA, txA, keyB, true, &roachpb.IntentMissingError{}},
+		{"wrongTx", txA, txA, keyB, false, notFound},
+
+		// This sets a mismatch for transactions in the header and the body. An
+		// error is returned regardless of the errorFlag.
+		{"mismatchTxE", txA, txB, keyA, true, errors.AssertionFailedf("")},
+		{"mismatchTx", txA, txB, keyA, false, errors.AssertionFailedf("")},
+
+		// This simulates pushed intents by moving the tx clock backwards in time.
+		// An error is only returned if the error flag is set.
+		{"clockBackE", txABack, txABack, keyA, true, &roachpb.TransactionRetryError{}},
+		{"clockBack", txABack, txABack, keyA, false, notFound},
+
+		// This simulates pushed transactions by moving the tx clock forward in time.
+		{"clockFwd", txAForward, txAForward, keyA, true, success},
+
+		// This simulates a mismatch in the header and arg write timestamps. This is
+		// always an error regardless of flag.
+		{"mismatchTxClockE", txA, txAForward, keyA, true, errors.AssertionFailedf("")},
+		{"mismatchTxClock", txA, txAForward, keyA, false, errors.AssertionFailedf("")},
+
+		// It is OK if the time on the arg transaction is moved backwards, its
+		// unclear if this happens in practice.
+		{"mismatchTxClock", txA, txABack, keyA, true, success},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cArgs := CommandArgs{
+				Header: roachpb.Header{Timestamp: clock.Now(), Txn: &test.hTransaction},
+				Args: &roachpb.QueryIntentRequest{
+					RequestHeader:  roachpb.RequestHeader{Key: test.key},
+					Txn:            test.argTransaction.TxnMeta,
+					ErrorIfMissing: test.errorFlag,
+				},
+			}
+			cArgs.EvalCtx = evalCtx.EvalContext()
+			var resp roachpb.QueryIntentResponse
+			_, err := QueryIntent(ctx, db, cArgs, &resp)
+			switch test.response {
+			case success:
+				require.NoError(t, err)
+				require.True(t, resp.FoundIntent)
+			case notFound:
+				require.NoError(t, err)
+				require.False(t, resp.FoundIntent)
+			default:
+				require.IsType(t, test.response, err, "received %v", err)
+				require.False(t, resp.FoundIntent)
+			}
+		})
+	}
+}

--- a/pkg/kv/kvserver/concurrency/lock/locking.proto
+++ b/pkg/kv/kvserver/concurrency/lock/locking.proto
@@ -101,7 +101,7 @@ enum Strength {
   //
   // To avoid this potential deadlock problem, an Upgrade lock can be used in
   // place of a Shared lock. Upgrade locks are not compatible with any other
-  // form of locking. As with Shared locks, the lock holder of a Shared lock
+  // form of locking. As with Shared locks, the lock holder of an Upgrade lock
   // on a key is only allowed to read from the key while the lock is held.
   // This resolves the deadlock scenario presented above because only one of
   // the transactions would have been able to acquire an Upgrade lock at a

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -40,7 +40,7 @@ const (
 	_ waitKind = iota
 
 	// waitFor indicates that the request is waiting on another transaction to
-	// to release its locks or complete its own request. waitingStates with this
+	// release its locks or complete its own request. waitingStates with this
 	// waitKind will provide information on who the request is waiting on. The
 	// request will likely want to eventually push the conflicting transaction.
 	waitFor


### PR DESCRIPTION
Change QueryIntent to only read from the lock table. Previously the request required merging the read from the MVC iterator with the lock table. This should improve performance.

Also, add unit testing for QueryIntent

Fixes #69716

Release note: None