### PR TITLE
opt: use expr and input fds to remap index join columns

### DIFF
--- a/pkg/sql/opt/ordering/lookup_join.go
+++ b/pkg/sql/opt/ordering/lookup_join.go
@@ -82,7 +82,13 @@ func indexJoinBuildProvided(expr memo.RelExpr, required *props.OrderingChoice) o
 	// using column equivalencies.
 	indexJoin := expr.(*memo.IndexJoinExpr)
 	rel := indexJoin.Relational()
-	return remapProvided(indexJoin.Input.ProvidedPhysical().Ordering, &rel.FuncDeps, rel.OutputCols)
+	input := indexJoin.Input
+	// The index join's FDs may not include all the necessary columns for
+	// remapping, so we add the input's FDs as well. See `buildIndexJoinProps`.
+	var fds props.FuncDepSet
+	fds.CopyFrom(&input.Relational().FuncDeps)
+	fds.AddFrom(&rel.FuncDeps)
+	return remapProvided(input.ProvidedPhysical().Ordering, &fds, rel.OutputCols)
 }
 
 func lookupJoinBuildProvided(expr memo.RelExpr, required *props.OrderingChoice) opt.Ordering {

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -12378,3 +12378,37 @@ project
       │    └── columns: col0:8
       └── filters
            └── col3:4 = col0:8 [outer=(4,8), constraints=(/4: (/NULL - ]; /8: (/NULL - ]), fd=(4)==(8), (8)==(4)]
+
+# Regression for #81649
+exec-ddl
+CREATE TABLE t81649 (
+  col0 STRING NULL,
+  col1 DECIMAL NOT NULL,
+  col2 STRING NULL AS (lower(col0)) STORED,
+  col3 DECIMAL NOT NULL AS (col1 + 0:::DECIMAL) VIRTUAL,
+  PRIMARY KEY (col3, col1),
+  UNIQUE (col3 ASC, col1 DESC) STORING (col0));
+----
+
+opt
+SELECT col2 FROM t81649@t81649_col3_col1_key ORDER BY col0 ASC, col3 ASC LIMIT 2;
+----
+index-join t81649
+ ├── columns: col2:3  [hidden: col0:1 col3:4!null]
+ ├── cardinality: [0 - 2]
+ ├── key: (4)
+ ├── fd: (1)-->(3), (4)-->(1,3)
+ ├── ordering: +1,+4
+ └── top-k
+      ├── columns: col0:1 col1:2!null col3:4!null
+      ├── internal-ordering: +1,+(2|4)
+      ├── k: 2
+      ├── cardinality: [0 - 2]
+      ├── key: (4)
+      ├── fd: (2,4)-->(1), (2)==(4), (4)==(2)
+      ├── ordering: +1,+(2|4) [actual: +1,+2]
+      └── scan t81649@t81649_col3_col1_key
+           ├── columns: col0:1 col1:2!null col3:4!null
+           ├── flags: force-index=t81649_col3_col1_key
+           ├── key: (4)
+           └── fd: (2,4)-->(1), (2)==(4), (4)==(2)


### PR DESCRIPTION
Before this change index joins would use their own FDs to remap input to
output columns if there was a required ordering. This could miss some
cases where the index joins' FDs were generated from another expression
in the memo group and did not include FDs from its own input, such as
equivalent columns only found the index joins' input. This change
modifies the FDs used for remapping columns to include both the index
join and input FDs.

Fixes: #81649

Release note (bug fix): Index joins now consider functional dependencies
from their input when determining equivalent columns instead of
returning an internal error.

