### PR TITLE
gceworker: add status subcommand

### DIFF
--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -177,8 +177,11 @@ case "${cmd}" in
     HOST=$(gcloud compute ssh --dry-run ${NAME} | awk '{print $NF}')
     code --wait --remote ssh-remote+$HOST "$@"
     ;;
+    status)
+    gcloud compute instances describe ${NAME} --format="table(name,status,lastStartTimestamp,lastStopTimestamp)"
+    ;;
     *)
-    echo "$0: unknown command: ${cmd}, use one of create, start, stop, delete, ssh, or sync"
+    echo "$0: unknown command: ${cmd}, use one of create, start, stop, delete, status, ssh, or sync"
     exit 1
     ;;
 esac


### PR DESCRIPTION
There was previously no way to tell if scripts/gceworker.sh ssh failed because of network issues or because the gceworker instance was simply down. Add 'scripts/gceworker.sh status' subcommand to report the current state of a user's gceworker, e.g.:

```
$ scripts/gceworker.sh status
NAME             STATUS   LAST_START_TIMESTAMP           LAST_STOP_TIMESTAMP
gceworker-barag  RUNNING  2022-05-25T10:40:44.041-07:00  2022-05-25T10:36:03.703-07:00
```

Release note: None