### PR TITLE
cli: fix statement-bundle recreate

### DIFF
--- a/pkg/cli/statement_bundle.go
+++ b/pkg/cli/statement_bundle.go
@@ -96,9 +96,15 @@ func loadStatementBundle(zipdir string) (*statementBundle, error) {
 	if err != nil {
 		return ret, err
 	}
-	ret.statement, err = ioutil.ReadFile(filepath.Join(zipdir, "statement.txt"))
+	ret.statement, err = ioutil.ReadFile(filepath.Join(zipdir, "statement.sql"))
 	if err != nil {
-		return ret, err
+		// In 21.2 and prior releases, the statement file had 'txt' extension,
+		// let's try that.
+		var newErr error
+		ret.statement, newErr = ioutil.ReadFile(filepath.Join(zipdir, "statement.txt"))
+		if newErr != nil {
+			return ret, errors.CombineErrors(err, newErr)
+		}
 	}
 
 	return ret, filepath.WalkDir(zipdir, func(path string, d fs.DirEntry, _ error) error {


### PR DESCRIPTION
In 22.1 time frame, the statement file in the bundle changed its
extension from `txt` to `sql`, so currently `statement-bundle recreate`
with 22.1 CRDB binary fails if the bundle was collected on 22.1. This
commit fixes the issue by attempting to use `sql` extension first, and
if that fails, trying `txt` extension (so that older bundles can be
recreated with a newer binary).

Release note: None