### PR TITLE
builtins: avoid exposing MAC address in UUID generation

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -880,7 +880,7 @@ available replica will error.</p>
 </span></td></tr>
 <tr><td><a name="unordered_unique_rowid"></a><code>unordered_unique_rowid() &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns a unique ID. The value is a combination of the insert timestamp and the ID of the node executing the statement, which guarantees this combination is globally unique. The way it is generated there is no ordering</p>
 </span></td></tr>
-<tr><td><a name="uuid_generate_v1"></a><code>uuid_generate_v1() &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Generates a version 1 UUID, and returns it as a value of UUID type. This uses the real MAC address of the server and a timestamp.</p>
+<tr><td><a name="uuid_generate_v1"></a><code>uuid_generate_v1() &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Generates a version 1 UUID, and returns it as a value of UUID type. To avoid exposing the server’s real MAC address, this uses a random MAC address and a timestamp. Essentially, this is an alias for uuid_generate_v1mc.</p>
 </span></td></tr>
 <tr><td><a name="uuid_generate_v1mc"></a><code>uuid_generate_v1mc() &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Generates a version 1 UUID, and returns it as a value of UUID type. This uses a random MAC address and a timestamp.</p>
 </span></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/uuid
+++ b/pkg/sql/logictest/testdata/logic_test/uuid
@@ -152,6 +152,18 @@ SELECT uuid_generate_v1mc() = uuid_generate_v1mc()
 ----
 false
 
+# Verify that uuid_generate_v1 does not return deterministic output for the MAC
+# address bits.
+query B
+SELECT substr(uuid_generate_v1()::TEXT, 24) = substr(uuid_generate_v1()::TEXT, 24)
+----
+false
+
+query B
+SELECT substr(uuid_generate_v1mc()::TEXT, 24) = substr(uuid_generate_v1mc()::TEXT, 24)
+----
+false
+
 query T
 SELECT uuid_generate_v3(uuid_ns_x500(), 'cat')
 ----

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -709,14 +709,17 @@ var builtins = map[string]builtinDefinition{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Uuid),
 			Fn: func(_ *eval.Context, _ tree.Datums) (tree.Datum, error) {
-				uv, err := uuid.NewV1()
+				gen := uuid.NewGenWithHWAF(uuid.RandomHardwareAddrFunc)
+				uv, err := gen.NewV1()
 				if err != nil {
 					return nil, err
 				}
 				return tree.NewDUuid(tree.DUuid{UUID: uv}), nil
 			},
 			Info: "Generates a version 1 UUID, and returns it as a value of UUID type. " +
-				"This uses the real MAC address of the server and a timestamp.",
+				"To avoid exposing the server's real MAC address, " +
+				"this uses a random MAC address and a timestamp. " +
+				"Essentially, this is an alias for uuid_generate_v1mc.",
 			Volatility: volatility.Volatile,
 		},
 	),


### PR DESCRIPTION
refs https://github.com/cockroachdb/cockroach/issues/80118

The MAC address may be considered sensitive information. The UUID spec
allows type 1 UUIDs to use random data if exposing the MAC address is
not desired, so this makes uuid_generate_v1 an alias for
uuid_generate_v1mc.

No release note since the original uuid_generate_v1 implementation was
never released.

Release note: None