### PR TITLE
util/mon: augment "budget exceeded" errors from root monitor with a hint

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -353,7 +353,9 @@ func newRootSQLMemoryMonitor(opts monitorAndMetricsOptions) monitorAndMetrics {
 	// this monitor will be setting their own noteworthy limits.
 	rootSQLMemoryMonitor := mon.NewMonitor(
 		"root",
-		mon.MemoryResource,
+		mon.NewMemoryResourceWithErrorHint(
+			"Consider increasing --max-sql-memory startup parameter.", /* hint */
+		),
 		rootSQLMetrics.CurBytesCount,
 		rootSQLMetrics.MaxBytesHist,
 		-1,            /* increment: use default increment */


### PR DESCRIPTION
This commit adjusts the root SQL memory monitor to return "budget
exceeded" errors with a hint about considering increasing the
`--max-sql-memory` startup argument. This should hopefully help the
users to be a bit more self-sufficient.

Here is an example error from SQL shell:
```
ERROR: scan with start key /Table/105/2/0: root: memory budget exceeded: 4198400 bytes requested, 4689920 currently allocated, 8388608 bytes in budget
SQLSTATE: 53200
HINT: Consider increasing --max-sql-memory startup parameter.
```

Release note: None