### PR TITLE
ui: add key vizualizer cell info redux and tooltip

### DIFF
--- a/pkg/ui/workspaces/db-console/src/components/icon/filter.tsx
+++ b/pkg/ui/workspaces/db-console/src/components/icon/filter.tsx
@@ -1,0 +1,38 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import * as React from "react";
+
+interface IconProps {
+  fill?: string;
+  size?: number;
+  className?: string;
+}
+
+export const FilterIcon = ({ fill, size, className, ...props }: IconProps) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox={`0 0 ${size} ${size}`}
+    fill={fill}
+    className={className}
+    {...props}
+  >
+    <path
+      d="M8.67698 14C8.53676 14 8.39891 13.9452 8.29612 13.8422L6.1423 11.6884C6.04126 11.5875 5.98454 11.4506 5.98454 11.3076V6.46147C5.98454 6.30822 5.86986 6.0314 5.76156 5.92297L0.757693 0.919106C0.603696 0.765109 0.557622 0.533624 0.641007 0.332405C0.724517 0.131209 0.920581 0 1.13832 0H14.0614C14.2793 0 14.4757 0.131212 14.5589 0.332405C14.6424 0.533602 14.5962 0.765099 14.4422 0.919106L9.43833 5.92297C9.33003 6.0314 9.21535 6.30823 9.21535 6.46147V13.4615C9.21535 13.6793 9.08427 13.8758 8.88294 13.9589C8.81646 13.9867 8.74635 14 8.67711 14L8.67698 14ZM7.0614 11.0848L8.13839 12.1618V6.46143C8.13839 6.02021 8.36488 5.47374 8.67663 5.16159L12.7616 1.07664H2.43847L6.5231 5.16159C6.8351 5.47359 7.06159 6.02021 7.06159 6.46143L7.0614 11.0848Z"
+      fill={fill}
+    />
+  </svg>
+);
+
+FilterIcon.defaultProps = {
+  fill: "#475872",
+  size: 14,
+};

--- a/pkg/ui/workspaces/db-console/src/redux/keyVizualizer/keyVizualizerReducer.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/keyVizualizer/keyVizualizerReducer.ts
@@ -1,0 +1,91 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+/**
+ * This module maintains the state of CockroachDB time series queries needed by
+ * the web application. Cached query data is maintained separately for
+ * individual components (e.g. different graphs); components are distinguished
+ * in the reducer by a unique ID.
+ */
+
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+export type KeyVizualizerState = {
+  mainData: {
+    data: any[];
+    error: Error;
+    loading: boolean;
+  };
+  cellInfoData: {
+    data: { [hash: string]: CellInfoDetails };
+    error: Error;
+    loading: boolean;
+  };
+};
+
+// Remove when CellInfoResponse is defined.
+export type CellInfoDetails = {
+  schema: {
+    database: string;
+    table: string;
+  };
+  rangeId: number;
+  qps: number;
+  startKey: string;
+  endKey: string;
+  nodes: number[];
+  store: number;
+  locality: string;
+  keyBytes: number;
+  leaseholder: number;
+  index: string;
+};
+
+const initialState: KeyVizualizerState = {
+  mainData: {
+    data: [],
+    error: null,
+    loading: false,
+  },
+  cellInfoData: {
+    data: {},
+    error: null,
+    loading: false,
+  },
+};
+
+const keyVizualizerSlice = createSlice({
+  name: "keyVizualizer",
+  initialState,
+  reducers: {
+    requestCellInfo: (state, _) => {
+      state.cellInfoData.loading = true;
+      state.cellInfoData.error = null;
+    },
+    receivedCellInfo: (state, action) => {
+      state.cellInfoData.data[
+        action.payload.input?.startKey +
+          action.payload.input?.endKey +
+          action.payload.input?.sampleTime?.toString()
+      ] = action.payload.result;
+      state.cellInfoData.loading = false;
+      state.cellInfoData.error = null;
+    },
+    failedCellInfo: (state, action: PayloadAction<Error>) => {
+      state.cellInfoData.loading = false;
+      state.cellInfoData.error = action.payload;
+    },
+    clearCellInfo: state => {
+      state.cellInfoData.data = {};
+    },
+  },
+});
+
+export const { reducer, actions } = keyVizualizerSlice;

--- a/pkg/ui/workspaces/db-console/src/redux/keyVizualizer/keyVizualizerSagas.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/keyVizualizer/keyVizualizerSagas.ts
@@ -1,0 +1,67 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { all, call, put, delay, takeLatest } from "redux-saga/effects";
+import { actions } from "./keyVizualizerReducer";
+import * as api from "src/util/api";
+import { SagaIterator } from "@redux-saga/types";
+import { PayloadAction } from "src/interfaces/action";
+import { useSelector } from "react-redux";
+import { selectTimeScaleCurrentWindow } from "./keyVizualizerSelectors";
+
+export type KeyVizualizerCellInfoRequest = {
+  startKey: number;
+  endKey: number;
+  sampleTime: number;
+};
+
+export function* requestKeyVizualizerCellInfo(
+  action: PayloadAction<KeyVizualizerCellInfoRequest>,
+): SagaIterator {
+  try {
+    //const { start, end } = useSelector(selectTimeScaleCurrentWindow);
+    //const request = new KeyVizualizerCellInfoRequest(...action.payload, start, end);
+    //const result = yield call(api.getKeyVizualizerCellInfo, request);
+    const result = mockResponse;
+    yield put(
+      actions.receivedCellInfo({
+        result: {
+          ...result,
+        },
+        input: { ...action.payload },
+      }),
+    );
+  } catch (e) {
+    yield put(actions.failedCellInfo(e));
+  }
+}
+
+export function* keyVizualizerSaga() {
+  yield all([
+    takeLatest(actions.requestCellInfo, requestKeyVizualizerCellInfo),
+  ]);
+}
+
+export const mockResponse = {
+  schema: {
+    database: "system",
+    table: "lease",
+  },
+  rangeId: 1,
+  qps: 2230.483939,
+  startKey: "Table/100/1/1",
+  endKey: "Table/200/5/5",
+  nodes: [32],
+  store: 32,
+  locality: "locality",
+  keyBytes: 5184,
+  leaseholder: 117,
+  index: "idx1_lease",
+};

--- a/pkg/ui/workspaces/db-console/src/redux/keyVizualizer/keyVizualizerSelectors.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/keyVizualizer/keyVizualizerSelectors.ts
@@ -1,0 +1,28 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { createSelector } from "reselect";
+import { AdminUIState } from "src/redux/state";
+
+export const selectCellInfoSlice = (state: AdminUIState) =>
+  state.keyVizualizer?.cellInfoData;
+
+export const selectTimeScaleCurrentWindow = (state: AdminUIState) =>
+  state.timeScale.metricsTime?.currentWindow;
+
+export const selectCellInfoByKey = (
+  startKey: string,
+  endKey: string,
+  sampleTime: number,
+) =>
+  createSelector(selectCellInfoSlice, cellInfoState => {
+    const hash = startKey + endKey + sampleTime.toString();
+    return cellInfoState.data[hash];
+  });

--- a/pkg/ui/workspaces/db-console/src/redux/sagas.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/sagas.ts
@@ -18,6 +18,7 @@ import { analyticsSaga } from "./analyticsSagas";
 import { sessionsSaga } from "./sessions";
 import { sqlStatsSaga } from "./sqlStats";
 import { indexUsageStatsSaga } from "./indexUsageStats";
+import { keyVizualizerSaga } from "./keyVizualizer/keyVizualizerSagas";
 
 export default function* rootSaga() {
   yield all([
@@ -29,5 +30,6 @@ export default function* rootSaga() {
     fork(sessionsSaga),
     fork(sqlStatsSaga),
     fork(indexUsageStatsSaga),
+    fork(keyVizualizerSaga),
   ]);
 }

--- a/pkg/ui/workspaces/db-console/src/redux/state.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/state.ts
@@ -35,6 +35,10 @@ import { queryManagerReducer, QueryManagerState } from "./queryManager/reducer";
 import { timeScaleReducer, TimeScaleState } from "./timeScale";
 import { uiDataReducer, UIDataState } from "./uiData";
 import { loginReducer, LoginAPIState } from "./login";
+import {
+  reducer as keyVizualizerReducer,
+  KeyVizualizerState,
+} from "./keyVizualizer/keyVizualizerReducer";
 import rootSaga from "./sagas";
 
 export interface AdminUIState {
@@ -49,6 +53,7 @@ export interface AdminUIState {
   timeScale: TimeScaleState;
   uiData: UIDataState;
   login: LoginAPIState;
+  keyVizualizer: KeyVizualizerState;
 }
 
 const history = createHashHistory();
@@ -73,6 +78,7 @@ export function createAdminUIStore(historyInst: History<any>) {
       timeScale: timeScaleReducer,
       uiData: uiDataReducer,
       login: loginReducer,
+      keyVizualizer: keyVizualizerReducer,
     }),
     compose(
       applyMiddleware(thunk, sagaMiddleware, routerMiddleware(historyInst)),

--- a/pkg/ui/workspaces/db-console/src/util/api.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.ts
@@ -966,3 +966,20 @@ export function setTraceRecordingType(
     timeout,
   );
 }
+
+// TODO @santamaura: update with correct names when rpc is implemented
+export function getKeyVizualizerCellInfo(
+  req: any,
+  timeout?: moment.Duration,
+): Promise<any> {
+  // return timeoutFetch(
+  //   serverpb.KeyVizualizerCellInfoResponse,
+  //   `${API_PREFIX}/keyvizualizer_cellinfo`,
+  //   req as any,
+  //   timeout,
+  // );
+  if (req || timeout) {
+    return null;
+  }
+  return null;
+}

--- a/pkg/ui/workspaces/db-console/src/util/format.ts
+++ b/pkg/ui/workspaces/db-console/src/util/format.ts
@@ -21,6 +21,7 @@ export const byteUnits: string[] = [
   "YiB",
 ];
 export const durationUnits: string[] = ["ns", "µs", "ms", "s"];
+export const normalizedScale: string[] = ["", "K", "M", "B", "T"];
 
 interface UnitValue {
   value: number;
@@ -149,6 +150,18 @@ export const DurationFitScale = (scale: string) => (nanoseconds: number) => {
   }
   const n = durationUnits.indexOf(scale);
   return `${(nanoseconds / Math.pow(1000, n)).toFixed(2)} ${scale}`;
+};
+/**
+ * RawToNormalizedValue receives a raw value and returns a UnitValue object
+ * such that it is scaled down according to the normalized scale.
+ * e.g. 100000 -> { value: 100, units: K }
+ */
+export const RawToNormalizedValue = (value: number) => {
+  const scale = ComputePrefixExponent(value, 1000, normalizedScale);
+  return {
+    value: value / Math.pow(1000, scale),
+    units: normalizedScale[scale],
+  };
 };
 
 export const DATE_FORMAT = "MMM DD, YYYY [at] H:mm";

--- a/pkg/ui/workspaces/db-console/src/views/keyVizualizer/keyVizualizer.module.styl
+++ b/pkg/ui/workspaces/db-console/src/views/keyVizualizer/keyVizualizer.module.styl
@@ -1,0 +1,27 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+@require "~src/components/core/index"
+
+.span-tooltip
+    position absolute
+    left var(--x)
+    top var(--y)
+    background #FFFFFF
+    padding 20px
+    border-radius 5px
+    font-family SourceSansPro-Regular
+    color: $colors--neutral-8
+    z-index 3
+    min-width 200px
+
+.filter-icon
+    cursor pointer
+    margin-bottom -2px

--- a/pkg/ui/workspaces/db-console/src/views/keyVizualizer/tooltip.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/keyVizualizer/tooltip.tsx
@@ -1,0 +1,159 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React, { CSSProperties } from "react";
+import { Link } from "react-router-dom";
+import { Loading } from "@cockroachlabs/cluster-ui";
+import classNames from "classnames/bind";
+import styles from "./keyVizualizer.module.styl";
+import ErrorBoundary from "../app/components/errorMessage/errorBoundary";
+import { CellInfoDetails } from "src/redux/keyVizualizer/keyVizualizerReducer";
+import { FilterIcon } from "src/components/icon/filter";
+import { BytesToUnitValue, RawToNormalizedValue } from "src/util/format";
+import { round } from "lodash";
+
+const cx = classNames.bind(styles);
+
+export interface KeyVizualizerTooltipProps {
+  x: number;
+  y: number;
+  applyFilter: (filterType: string, id: string | number) => void;
+  cellDetails: CellInfoDetails;
+  error: Error;
+  loading: boolean;
+}
+export const KeyVizualizerTooltip = (props: KeyVizualizerTooltipProps) => {
+  const { x, y, applyFilter, cellDetails, error, loading } = props;
+  const style = { "--x": `${x + 60}px`, "--y": `${y + 30}px` } as CSSProperties;
+
+  const formatMetric = (
+    value: number,
+    isBytes: boolean,
+    roundAmount: number,
+  ): string => {
+    const result = isBytes
+      ? BytesToUnitValue(value)
+      : RawToNormalizedValue(value);
+    return round(result.value, roundAmount).toString() + result.units;
+  };
+
+  return (
+    <div className={cx("span-tooltip")} style={style}>
+      <ErrorBoundary>
+        <Loading
+          loading={loading}
+          error={error}
+          page={undefined}
+          render={() => (
+            <div>
+              <p>
+                Range:{" "}
+                <Link to={`/reports/range/${cellDetails?.rangeId}`}>
+                  {cellDetails?.rangeId}
+                </Link>
+              </p>
+              <p>QPS: {formatMetric(cellDetails?.qps, false, 2)}</p>
+              <p>Bytes: {formatMetric(cellDetails?.keyBytes, true, 1)}</p>
+              <p>Leaseholder: {cellDetails?.leaseholder}</p>
+              <p>
+                Nodes:{" "}
+                {cellDetails?.nodes.map(
+                  (nodeId: number, idx: number, arr: string | any[]) => (
+                    <Link to={`/node/${nodeId}`}>
+                      {nodeId}
+                      {idx < arr.length - 1 && ", "}
+                    </Link>
+                  ),
+                )}{" "}
+                | {/* which node do we apply filter here for? */}
+                {
+                  <span
+                    onClick={() => applyFilter("node", cellDetails?.nodes[0])}
+                  >
+                    <FilterIcon
+                      fill={"#1890FF"}
+                      className={cx("filter-icon")}
+                    />
+                  </span>
+                }
+              </p>
+              <p>
+                Store: {cellDetails?.store} |{" "}
+                {
+                  <span
+                    onClick={() => applyFilter("store", cellDetails?.store)}
+                  >
+                    <FilterIcon
+                      fill={"#1890FF"}
+                      className={cx("filter-icon")}
+                    />
+                  </span>
+                }
+              </p>
+              <p>
+                Database:{" "}
+                <Link to={`/database/${cellDetails?.schema?.database}`}>
+                  {cellDetails?.schema?.database}
+                </Link>{" "}
+                |{" "}
+                {
+                  <span
+                    onClick={() =>
+                      applyFilter("database", cellDetails?.schema?.database)
+                    }
+                  >
+                    <FilterIcon
+                      fill={"#1890FF"}
+                      className={cx("filter-icon")}
+                    />
+                  </span>
+                }
+              </p>
+              <p>
+                Table:{" "}
+                <Link
+                  to={`/database/${cellDetails?.schema?.database}/table/${cellDetails?.schema?.table}`}
+                >
+                  {cellDetails?.schema?.table}
+                </Link>{" "}
+                |{" "}
+                {
+                  <span
+                    onClick={() =>
+                      applyFilter("table", cellDetails?.schema?.table)
+                    }
+                  >
+                    <FilterIcon
+                      fill={"#1890FF"}
+                      className={cx("filter-icon")}
+                    />
+                  </span>
+                }
+              </p>
+              <p>
+                Index: {cellDetails?.index} |{" "}
+                {
+                  <span
+                    onClick={() => applyFilter("index", cellDetails?.index)}
+                  >
+                    <FilterIcon
+                      fill={"#1890FF"}
+                      className={cx("filter-icon")}
+                    />
+                  </span>
+                }
+              </p>
+            </div>
+          )}
+        />
+      </ErrorBoundary>
+    </div>
+  );
+};


### PR DESCRIPTION
This patch adds the redux layer to manage cell info requests
and responses (wip until gRPC is created). The tooltip for
cell info is also introduced.

Release note (ui change): add cell info redux and tooltip
as part of the key vizualizer feature.

![Screen Shot 2022-05-26 at 4 27 24 PM](https://user-images.githubusercontent.com/17861665/171428026-112e13aa-1dbc-4c1b-bd1c-75fe7a1f4ca4.png)
