### PR TITLE
gssapiccl: document resolv_wrapper ubuntu package

### DIFF
--- a/pkg/ccl/gssapiccl/BUILD.bazel
+++ b/pkg/ccl/gssapiccl/BUILD.bazel
@@ -13,7 +13,8 @@ go_library(
     }),
     cgo = True,
     clinkopts = select({
-        # NB: On Ubuntu, res_nsearch is found in resolv_wrapper library.
+        # NB: On Ubuntu, res_nsearch is found in the resolv_wrapper library,
+        # found in the libresolv-wrapper package.
         "//build/toolchains:is_dev_linux": ["-ldl -lresolv -lresolv_wrapper"],
         "@io_bazel_rules_go//go/platform:linux": ["-ldl -lresolv"],
         "//conditions:default": [],


### PR DESCRIPTION
When building Cockroach on Linux (Ubuntu), the build will fail if the
`libresolv-wrapper` package is not installed.

Update the comment to include the package to install.

Release note: None.