### PR TITLE
roachtest: skip artifact upload for pebble nightly race runs

### DIFF
--- a/pkg/cmd/roachtest/tests/pebble_ycsb.go
+++ b/pkg/cmd/roachtest/tests/pebble_ycsb.go
@@ -57,7 +57,7 @@ func registerPebbleYCSB(r registry.Registry) {
 				Cluster: r.MakeClusterSpec(5, spec.CPU(16)),
 				Tags:    []string{tag},
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-					runPebbleYCSB(ctx, t, c, size, pebble, d, nil)
+					runPebbleYCSB(ctx, t, c, size, pebble, d, nil, true /* artifacts */)
 				},
 			})
 		}
@@ -71,7 +71,7 @@ func registerPebbleYCSB(r registry.Registry) {
 		Cluster: r.MakeClusterSpec(5, spec.CPU(16)),
 		Tags:    []string{"pebble_nightly_ycsb_race"},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			runPebbleYCSB(ctx, t, c, 64, pebble, 30, []string{"A"})
+			runPebbleYCSB(ctx, t, c, 64, pebble, 30, []string{"A"}, false /* artifacts */)
 		},
 	})
 }
@@ -85,6 +85,7 @@ func runPebbleYCSB(
 	bin string,
 	dur int64,
 	workloads []string,
+	collectArtifacts bool,
 ) {
 	c.Put(ctx, bin, "./pebble")
 	if workloads == nil {
@@ -133,6 +134,10 @@ func runPebbleYCSB(
 				" --cache=%d"+
 				" --duration=%s > ycsb.log 2>&1",
 			benchDir, dataTar, benchDir, workload, size, keys, initialKeys, cache, duration))
+
+		if !collectArtifacts {
+			return
+		}
 
 		runPebbleCmd(ctx, t, c, fmt.Sprintf("tar cvPf profiles_%s.tar *.prof", workload))
 


### PR DESCRIPTION
Currently, the Pebble nightly race detector test job runs the
`ycsb/A/values=64` variant and uploads its artifacts to S3. As this job
typically finishes before the main YCSB roachtest, the artifacts will be
present when the `mkbench` tool is run to calculate the results, skewing
the results (the resulting average is much lower for the A benchmark).

As the race variant is only used to detect races and not for the
benchmark data itself, avoid uploading the artifacts from the race
detector run.

Release note: None.