### PR TITLE
kv: remove dead code in `Replica.raftTruncatedStateLocked`

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_truncate_log.go
+++ b/pkg/kv/kvserver/batcheval/cmd_truncate_log.go
@@ -58,10 +58,6 @@ func TruncateLog(
 		return result.Result{}, nil
 	}
 
-	firstIndex, err := cArgs.EvalCtx.GetFirstIndex()
-	if err != nil {
-		return result.Result{}, errors.Wrap(err, "getting first index")
-	}
 	// Have we already truncated this log? If so, just return without an error.
 	// Note that there may in principle be followers whose Raft log is longer
 	// than this node's, but to issue a truncation we also need the *term* for
@@ -70,6 +66,7 @@ func TruncateLog(
 	//
 	// TODO(tbg): think about synthesizing a valid term. Can we use the next
 	// existing entry's term?
+	firstIndex := cArgs.EvalCtx.GetFirstIndex()
 	if firstIndex >= args.Index {
 		if log.V(3) {
 			log.Infof(ctx, "attempting to truncate previously truncated raft log. FirstIndex:%d, TruncateFrom:%d",

--- a/pkg/kv/kvserver/batcheval/eval_context.go
+++ b/pkg/kv/kvserver/batcheval/eval_context.go
@@ -64,7 +64,7 @@ type EvalContext interface {
 	GetNodeLocality() roachpb.Locality
 
 	IsFirstRange() bool
-	GetFirstIndex() (uint64, error)
+	GetFirstIndex() uint64
 	GetTerm(uint64) (uint64, error)
 	GetLeaseAppliedIndex() uint64
 
@@ -228,8 +228,8 @@ func (m *mockEvalCtxImpl) GetRangeID() roachpb.RangeID {
 func (m *mockEvalCtxImpl) IsFirstRange() bool {
 	panic("unimplemented")
 }
-func (m *mockEvalCtxImpl) GetFirstIndex() (uint64, error) {
-	return m.FirstIndex, nil
+func (m *mockEvalCtxImpl) GetFirstIndex() uint64 {
+	return m.FirstIndex
 }
 func (m *mockEvalCtxImpl) GetTerm(uint64) (uint64, error) {
 	return m.Term, nil

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -726,8 +726,7 @@ func mergeCheckingTimestampCaches(
 			}
 			minLastIndex := uint64(math.MaxUint64)
 			for _, r := range lhsRepls {
-				lastIndex, err := r.GetLastIndex()
-				require.NoError(t, err)
+				lastIndex := r.GetLastIndex()
 				minLastIndex = min(minLastIndex, lastIndex)
 			}
 			// Truncate the log at index+1 (log entries < N are removed).
@@ -745,8 +744,7 @@ func mergeCheckingTimestampCaches(
 					// Loosely-coupled truncation requires an engine flush to advance
 					// guaranteed durability.
 					require.NoError(t, r.Engine().Flush())
-					firstIndex, err := r.GetFirstIndex()
-					require.NoError(t, err)
+					firstIndex := r.GetFirstIndex()
 					if firstIndex < truncIndex {
 						return errors.Errorf("truncate not applied, %d < %d", firstIndex, truncIndex)
 					}
@@ -3974,10 +3972,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 	// Truncate the logs of the LHS.
 	index := func() uint64 {
 		repl := store0.LookupReplica(roachpb.RKey(keyA))
-		index, err := repl.GetLastIndex()
-		if err != nil {
-			t.Fatal(err)
-		}
+		index := repl.GetLastIndex()
 		truncArgs := &roachpb.TruncateLogRequest{
 			RequestHeader: roachpb.RequestHeader{Key: keyA},
 			Index:         index,

--- a/pkg/kv/kvserver/client_raft_log_queue_test.go
+++ b/pkg/kv/kvserver/client_raft_log_queue_test.go
@@ -75,10 +75,7 @@ func TestRaftLogQueue(t *testing.T) {
 	// Get the raft leader (and ensure one exists).
 	raftLeaderRepl := tc.GetRaftLeader(t, roachpb.RKey(key))
 	require.NotNil(t, raftLeaderRepl)
-	originalIndex, err := raftLeaderRepl.GetFirstIndex()
-	if err != nil {
-		t.Fatal(err)
-	}
+	originalIndex := raftLeaderRepl.GetFirstIndex()
 
 	// Write a collection of values to increase the raft log.
 	value := bytes.Repeat(key, 1000) // 1KB
@@ -100,10 +97,7 @@ func TestRaftLogQueue(t *testing.T) {
 		require.NoError(t, raftLeaderRepl.Engine().Flush())
 		// Ensure that firstIndex has increased indicating that the log
 		// truncation has occurred.
-		afterTruncationIndex, err = raftLeaderRepl.GetFirstIndex()
-		if err != nil {
-			return err
-		}
+		afterTruncationIndex = raftLeaderRepl.GetFirstIndex()
 		if afterTruncationIndex <= originalIndex {
 			return errors.Errorf("raft log has not been truncated yet, afterTruncationIndex:%d originalIndex:%d",
 				afterTruncationIndex, originalIndex)
@@ -122,10 +116,7 @@ func TestRaftLogQueue(t *testing.T) {
 		tc.GetFirstStoreFromServer(t, i).MustForceRaftLogScanAndProcess()
 	}
 
-	after2ndTruncationIndex, err := raftLeaderRepl.GetFirstIndex()
-	if err != nil {
-		t.Fatal(err)
-	}
+	after2ndTruncationIndex := raftLeaderRepl.GetFirstIndex()
 	if afterTruncationIndex > after2ndTruncationIndex {
 		t.Fatalf("second truncation destroyed state: afterTruncationIndex:%d after2ndTruncationIndex:%d",
 			afterTruncationIndex, after2ndTruncationIndex)

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -519,10 +519,7 @@ func TestReplicateAfterTruncation(t *testing.T) {
 
 	repl := store.LookupReplica(key)
 	// Get that command's log index.
-	index, err := repl.GetLastIndex()
-	if err != nil {
-		t.Fatal(err)
-	}
+	index := repl.GetLastIndex()
 
 	// Truncate the log at index+1 (log entries < N are removed, so this includes
 	// the increment).
@@ -604,10 +601,7 @@ func TestRaftLogSizeAfterTruncation(t *testing.T) {
 
 	repl := store.LookupReplica(key)
 	require.NotNil(t, repl)
-	index, err := repl.GetLastIndex()
-	if err != nil {
-		t.Fatal(err)
-	}
+	index := repl.GetLastIndex()
 
 	// Verifies the recomputed log size against what we track in `r.mu.raftLogSize`.
 	assertCorrectRaftLogSize := func() error {
@@ -722,10 +716,7 @@ func TestSnapshotAfterTruncation(t *testing.T) {
 			tc.WaitForValues(t, key, []int64{incAB, incA, incAB})
 
 			repl0 := store.LookupReplica(key)
-			index, err := repl0.GetLastIndex()
-			if err != nil {
-				t.Fatal(err)
-			}
+			index := repl0.GetLastIndex()
 
 			// Truncate the log at index+1 (log entries < N are removed, so this
 			// includes the increment).
@@ -806,13 +797,13 @@ func TestSnapshotAfterTruncation(t *testing.T) {
 				// persistently unavailable range.
 				repl0 = tc.GetFirstStoreFromServer(t, otherStore1).LookupReplica(key)
 				require.NotNil(t, repl0)
-				expectedLastIndex, _ := repl0.GetLastIndex()
+				expectedLastIndex := repl0.GetLastIndex()
 				expectedLastTerm := repl0.GetCachedLastTerm()
 
 				verifyIndexAndTerm := func(i int) error {
 					repl1 := tc.GetFirstStoreFromServer(t, i).LookupReplica(key)
 					require.NotNil(t, repl1)
-					if lastIndex, _ := repl1.GetLastIndex(); expectedLastIndex != lastIndex {
+					if lastIndex := repl1.GetLastIndex(); expectedLastIndex != lastIndex {
 						return fmt.Errorf("%d: expected last index %d, but found %d", i, expectedLastIndex, lastIndex)
 					}
 					if lastTerm := repl1.GetCachedLastTerm(); expectedLastTerm != lastTerm {
@@ -837,8 +828,7 @@ func waitForTruncationForTesting(t *testing.T, r *kvserver.Replica, newFirstInde
 		// Flush the engine to advance durability, which triggers truncation.
 		require.NoError(t, r.Engine().Flush())
 		// FirstIndex has changed.
-		firstIndex, err := r.GetFirstIndex()
-		require.NoError(t, err)
+		firstIndex := r.GetFirstIndex()
 		if firstIndex != newFirstIndex {
 			return errors.Errorf("expected firstIndex == %d, got %d", newFirstIndex, firstIndex)
 		}
@@ -1004,10 +994,7 @@ func TestSnapshotAfterTruncationWithUncommittedTail(t *testing.T) {
 	tc.WaitForValues(t, key, []int64{incA, incAB, incAB})
 	log.Infof(ctx, "test: waiting for values... done")
 
-	index, err := newLeaderRepl.GetLastIndex()
-	if err != nil {
-		t.Fatal(err)
-	}
+	index := newLeaderRepl.GetLastIndex()
 
 	// Truncate the log at index+1 (log entries < N are removed, so this
 	// includes the increment).
@@ -1233,8 +1220,7 @@ func TestRequestsOnLaggingReplica(t *testing.T) {
 	}
 
 	tc.WaitForValues(t, key, []int64{1, 2, 2})
-	index, err := otherRepl.GetLastIndex()
-	require.NoError(t, err)
+	index := otherRepl.GetLastIndex()
 
 	// Truncate the log at index+1 (log entries < N are removed, so this includes
 	// the increment). This means that the partitioned replica will need a
@@ -1432,10 +1418,7 @@ func TestConcurrentRaftSnapshots(t *testing.T) {
 
 	tc.WaitForValues(t, key, []int64{incAB, incA, incA, incAB, incAB})
 
-	index, err := repl.GetLastIndex()
-	if err != nil {
-		t.Fatal(err)
-	}
+	index := repl.GetLastIndex()
 
 	// Truncate the log at index+1 (log entries < N are removed, so this
 	// includes the increment).
@@ -2005,10 +1988,7 @@ func runReplicateRestartAfterTruncation(t *testing.T, removeBeforeTruncateAndReA
 	{
 		// Get the last increment's log index.
 		repl := store.LookupReplica(roachpb.RKey(key))
-		index, err := repl.GetLastIndex()
-		if err != nil {
-			t.Fatal(err)
-		}
+		index := repl.GetLastIndex()
 		// Truncate the log at index+1 (log entries < N are removed, so this includes
 		// the increment).
 		truncArgs := truncateLogArgs(index+1, repl.RangeID)

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -2680,10 +2680,7 @@ func TestLeaseTransferInSnapshotUpdatesTimestampCache(t *testing.T) {
 		// Truncate the log at index+1 (log entries < N are removed, so this
 		// includes the increment). This necessitates a snapshot when the
 		// partitioned replica rejoins the rest of the range.
-		index, err := repl0.GetLastIndex()
-		if err != nil {
-			t.Fatal(err)
-		}
+		index := repl0.GetLastIndex()
 		truncArgs := truncateLogArgs(index+1, repl0.GetRangeID())
 		truncArgs.Key = keyA
 		if _, err := kv.SendWrapped(ctx, store0.TestSender(), truncArgs); err != nil {

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -246,14 +246,6 @@ func (r *Replica) RaftUnlock() {
 	r.raftMu.Unlock()
 }
 
-// GetLastIndex is the same function as LastIndex but it does not require
-// that the replica lock is held.
-func (r *Replica) GetLastIndex() (uint64, error) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.raftLastIndexRLocked()
-}
-
 // LastAssignedLeaseIndexRLocked returns the last assigned lease index.
 func (r *Replica) LastAssignedLeaseIndex() uint64 {
 	r.mu.RLock()

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -249,9 +249,9 @@ func (r *Replica) RaftUnlock() {
 // GetLastIndex is the same function as LastIndex but it does not require
 // that the replica lock is held.
 func (r *Replica) GetLastIndex() (uint64, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return r.raftLastIndexLocked()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.raftLastIndexRLocked()
 }
 
 // LastAssignedLeaseIndexRLocked returns the last assigned lease index.

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -270,11 +270,8 @@ func newTruncateDecision(ctx context.Context, r *Replica) (truncateDecision, err
 	// will become false and we will recompute the size -- so this cannot cause
 	// an indefinite delay in recomputation.
 	logSizeTrusted := r.mu.raftLogSizeTrusted
-	firstIndex, err := r.raftFirstIndexRLocked()
+	firstIndex := r.raftFirstIndexRLocked()
 	r.mu.RUnlock()
-	if err != nil {
-		return truncateDecision{}, errors.Wrapf(err, "error retrieving first index for r%d", rangeID)
-	}
 	firstIndex = r.pendingLogTruncations.computePostTruncFirstIndex(firstIndex)
 
 	if raftStatus == nil {

--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -603,10 +603,7 @@ func TestProactiveRaftLogTruncate(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			oldFirstIndex, err := r.GetFirstIndex()
-			if err != nil {
-				t.Fatal(err)
-			}
+			oldFirstIndex := r.GetFirstIndex()
 
 			for i := 0; i < c.count; i++ {
 				key := roachpb.Key(fmt.Sprintf("key%02d", i))
@@ -624,10 +621,7 @@ func TestProactiveRaftLogTruncate(t *testing.T) {
 					// Flush the engine to advance durability, which triggers truncation.
 					require.NoError(t, store.engine.Flush())
 				}
-				newFirstIndex, err := r.GetFirstIndex()
-				if err != nil {
-					t.Fatal(err)
-				}
+				newFirstIndex := r.GetFirstIndex()
 				if newFirstIndex <= oldFirstIndex {
 					return errors.Errorf("log was not correctly truncated, old first index:%d, current first index:%d",
 						oldFirstIndex, newFirstIndex)
@@ -722,10 +716,7 @@ func TestTruncateLog(t *testing.T) {
 			if _, pErr := tc.SendWrapped(args); pErr != nil {
 				t.Fatal(pErr)
 			}
-			idx, err := tc.repl.GetLastIndex()
-			if err != nil {
-				t.Fatal(err)
-			}
+			idx := tc.repl.GetLastIndex()
 			indexes = append(indexes, idx)
 		}
 
@@ -921,8 +912,7 @@ func waitForTruncationForTesting(
 			require.NoError(t, r.Engine().Flush())
 		}
 		// FirstIndex should have changed.
-		firstIndex, err := r.GetFirstIndex()
-		require.NoError(t, err)
+		firstIndex := r.GetFirstIndex()
 		if firstIndex != newFirstIndex {
 			return errors.Errorf("expected firstIndex == %d, got %d", newFirstIndex, firstIndex)
 		}

--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -669,7 +669,7 @@ func TestSnapshotLogTruncationConstraints(t *testing.T) {
 	assertMin := func(exp uint64, now time.Time) {
 		t.Helper()
 		const anyRecipientStore roachpb.StoreID = 0
-		if maxIndex := r.getSnapshotLogTruncationConstraintsLocked(anyRecipientStore); maxIndex != exp {
+		if maxIndex := r.getSnapshotLogTruncationConstraintsRLocked(anyRecipientStore); maxIndex != exp {
 			t.Fatalf("unexpected max index %d, wanted %d", maxIndex, exp)
 		}
 	}
@@ -760,7 +760,7 @@ func TestTruncateLog(t *testing.T) {
 
 		// The term of the last truncated entry is still available.
 		tc.repl.mu.Lock()
-		term, err := tc.repl.raftTermRLocked(indexes[4])
+		term, err := tc.repl.raftTermLocked(indexes[4])
 		tc.repl.mu.Unlock()
 		if err != nil {
 			t.Fatal(err)
@@ -771,7 +771,7 @@ func TestTruncateLog(t *testing.T) {
 
 		// The terms of older entries are gone.
 		tc.repl.mu.Lock()
-		_, err = tc.repl.raftTermRLocked(indexes[3])
+		_, err = tc.repl.raftTermLocked(indexes[3])
 		tc.repl.mu.Unlock()
 		if !errors.Is(err, raft.ErrCompacted) {
 			t.Errorf("expected ErrCompacted, got %s", err)
@@ -793,7 +793,7 @@ func TestTruncateLog(t *testing.T) {
 
 		tc.repl.mu.Lock()
 		// The term of the last truncated entry is still available.
-		term, err = tc.repl.raftTermRLocked(indexes[4])
+		term, err = tc.repl.raftTermLocked(indexes[4])
 		tc.repl.mu.Unlock()
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -903,13 +903,6 @@ func (r *Replica) GetConcurrencyManager() concurrency.Manager {
 	return r.concMgr
 }
 
-// GetTerm returns the term of the given index in the raft log.
-func (r *Replica) GetTerm(i uint64) (uint64, error) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.raftTermRLocked(i)
-}
-
 // GetRangeID returns the Range ID.
 func (r *Replica) GetRangeID() roachpb.RangeID {
 	return r.RangeID

--- a/pkg/kv/kvserver/replica_eval_context_span.go
+++ b/pkg/kv/kvserver/replica_eval_context_span.go
@@ -86,7 +86,7 @@ func (rec *SpanSetReplicaEvalContext) GetNodeLocality() roachpb.Locality {
 }
 
 // GetFirstIndex returns the first index.
-func (rec *SpanSetReplicaEvalContext) GetFirstIndex() (uint64, error) {
+func (rec *SpanSetReplicaEvalContext) GetFirstIndex() uint64 {
 	return rec.i.GetFirstIndex()
 }
 

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1662,12 +1662,12 @@ func (r *Replica) completeSnapshotLogTruncationConstraint(snapUUID uuid.UUID) {
 func (r *Replica) getSnapshotLogTruncationConstraints(
 	recipientStore roachpb.StoreID,
 ) (minSnapIndex uint64) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return r.getSnapshotLogTruncationConstraintsLocked(recipientStore)
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.getSnapshotLogTruncationConstraintsRLocked(recipientStore)
 }
 
-func (r *Replica) getSnapshotLogTruncationConstraintsLocked(
+func (r *Replica) getSnapshotLogTruncationConstraintsRLocked(
 	recipientStore roachpb.StoreID,
 ) (minSnapIndex uint64) {
 	for _, item := range r.mu.snapshotLogTruncationConstraints {

--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -193,7 +193,7 @@ type quiescer interface {
 	descRLocked() *roachpb.RangeDescriptor
 	raftStatusRLocked() *raft.Status
 	raftBasicStatusRLocked() raft.BasicStatus
-	raftLastIndexRLocked() (uint64, error)
+	raftLastIndexRLocked() uint64
 	hasRaftReadyRLocked() bool
 	hasPendingProposalsRLocked() bool
 	hasPendingProposalQuotaRLocked() bool
@@ -345,13 +345,7 @@ func shouldReplicaQuiesce(
 		}
 		return nil, nil, false
 	}
-	lastIndex, err := q.raftLastIndexRLocked()
-	if err != nil {
-		if log.V(4) {
-			log.Infof(ctx, "not quiescing: %v", err)
-		}
-		return nil, nil, false
-	}
+	lastIndex := q.raftLastIndexRLocked()
 	if status.Commit != lastIndex {
 		if log.V(4) {
 			log.Infof(ctx, "not quiescing: commit (%d) != lastIndex (%d)",

--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -193,7 +193,7 @@ type quiescer interface {
 	descRLocked() *roachpb.RangeDescriptor
 	raftStatusRLocked() *raft.Status
 	raftBasicStatusRLocked() raft.BasicStatus
-	raftLastIndexLocked() (uint64, error)
+	raftLastIndexRLocked() (uint64, error)
 	hasRaftReadyRLocked() bool
 	hasPendingProposalsRLocked() bool
 	hasPendingProposalQuotaRLocked() bool
@@ -345,7 +345,7 @@ func shouldReplicaQuiesce(
 		}
 		return nil, nil, false
 	}
-	lastIndex, err := q.raftLastIndexLocked()
+	lastIndex, err := q.raftLastIndexRLocked()
 	if err != nil {
 		if log.V(4) {
 			log.Infof(ctx, "not quiescing: %v", err)

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -334,32 +334,38 @@ func term(
 	return ents[0].Term, nil
 }
 
+// raftLastIndexRLocked requires that r.mu is held for reading.
+func (r *Replica) raftLastIndexRLocked() uint64 {
+	return r.mu.lastIndex
+}
+
 // LastIndex implements the raft.Storage interface.
 // LastIndex requires that r.mu is held for reading.
 func (r *replicaRaftStorage) LastIndex() (uint64, error) {
-	return r.mu.lastIndex, nil
+	return (*Replica)(r).raftLastIndexRLocked(), nil
 }
 
-// raftLastIndexRLocked requires that r.mu is held for reading.
-func (r *Replica) raftLastIndexRLocked() (uint64, error) {
-	return (*replicaRaftStorage)(r).LastIndex()
+// GetLastIndex returns the index of the last entry in the replica's Raft log.
+func (r *Replica) GetLastIndex() uint64 {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.raftLastIndexRLocked()
+}
+
+// raftFirstIndexRLocked requires that r.mu is held for reading.
+func (r *Replica) raftFirstIndexRLocked() uint64 {
+	// TruncatedState is guaranteed to be non-nil.
+	return r.mu.state.TruncatedState.Index + 1
 }
 
 // FirstIndex implements the raft.Storage interface.
 // FirstIndex requires that r.mu is held for reading.
 func (r *replicaRaftStorage) FirstIndex() (uint64, error) {
-	// TruncatedState is guaranteed to be non-nil.
-	return r.mu.state.TruncatedState.Index + 1, nil
+	return (*Replica)(r).raftFirstIndexRLocked(), nil
 }
 
-// raftFirstIndexRLocked requires that r.mu is held for reading.
-func (r *Replica) raftFirstIndexRLocked() (uint64, error) {
-	return (*replicaRaftStorage)(r).FirstIndex()
-}
-
-// GetFirstIndex is the same function as raftFirstIndexLocked but it requires
-// that r.mu is not held.
-func (r *Replica) GetFirstIndex() (uint64, error) {
+// GetFirstIndex returns the index of the first entry in the replica's Raft log.
+func (r *Replica) GetFirstIndex() uint64 {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.raftFirstIndexRLocked()

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -846,10 +846,7 @@ func TestReplicaRangefeedRetryErrors(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		index, err := repl.GetLastIndex()
-		if err != nil {
-			t.Fatal(err)
-		}
+		index := repl.GetLastIndex()
 
 		// Truncate the log at index+1 (log entries < N are removed, so this
 		// includes the put). This necessitates a snapshot when the partitioned

--- a/pkg/kv/kvserver/replica_sideload_test.go
+++ b/pkg/kv/kvserver/replica_sideload_test.go
@@ -806,10 +806,7 @@ func TestRaftSSTableSideloadingTruncation(t *testing.T) {
 
 		var indexes []uint64
 		addLastIndex := func() {
-			lastIndex, err := tc.repl.GetLastIndex()
-			if err != nil {
-				t.Fatal(err)
-			}
+			lastIndex := tc.repl.GetLastIndex()
 			indexes = append(indexes, lastIndex)
 		}
 		for i := 0; i < count; i++ {

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -7226,10 +7226,7 @@ func TestEntries(t *testing.T) {
 				if _, pErr := tc.SendWrapped(args); pErr != nil {
 					t.Fatal(pErr)
 				}
-				idx, err := repl.GetLastIndex()
-				if err != nil {
-					t.Fatal(err)
-				}
+				idx := repl.GetLastIndex()
 				newIndexes = append(newIndexes, idx)
 			}
 			return newIndexes
@@ -7385,10 +7382,7 @@ func TestTerm(t *testing.T) {
 			if _, pErr := tc.SendWrapped(args); pErr != nil {
 				t.Fatal(pErr)
 			}
-			idx, err := tc.repl.GetLastIndex()
-			if err != nil {
-				t.Fatal(err)
-			}
+			idx := tc.repl.GetLastIndex()
 			indexes = append(indexes, idx)
 		}
 
@@ -7402,10 +7396,7 @@ func TestTerm(t *testing.T) {
 		repl.mu.Lock()
 		defer repl.mu.Unlock()
 
-		firstIndex, err := repl.raftFirstIndexRLocked()
-		if err != nil {
-			t.Fatal(err)
-		}
+		firstIndex := repl.raftFirstIndexRLocked()
 		if firstIndex != indexes[5] {
 			t.Fatalf("expected firstIndex %d to be %d", firstIndex, indexes[4])
 		}
@@ -7432,10 +7423,7 @@ func TestTerm(t *testing.T) {
 			t.Errorf("expected firstIndex-1's term:%d to equal that of firstIndex:%d", term, firstIndexTerm)
 		}
 
-		lastIndex, err := repl.raftLastIndexRLocked()
-		if err != nil {
-			t.Fatal(err)
-		}
+		lastIndex := repl.raftLastIndexRLocked()
 
 		// Last index should return correctly.
 		if _, err := tc.repl.raftTermLocked(lastIndex); err != nil {
@@ -9968,8 +9956,8 @@ func (q *testQuiescer) raftBasicStatusRLocked() raft.BasicStatus {
 	return q.status.BasicStatus
 }
 
-func (q *testQuiescer) raftLastIndexRLocked() (uint64, error) {
-	return q.lastIndex, nil
+func (q *testQuiescer) raftLastIndexRLocked() uint64 {
+	return q.lastIndex
 }
 
 func (q *testQuiescer) hasRaftReadyRLocked() bool {

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -7402,7 +7402,7 @@ func TestTerm(t *testing.T) {
 		repl.mu.Lock()
 		defer repl.mu.Unlock()
 
-		firstIndex, err := repl.raftFirstIndexLocked()
+		firstIndex, err := repl.raftFirstIndexRLocked()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -7411,20 +7411,20 @@ func TestTerm(t *testing.T) {
 		}
 
 		// Truncated logs should return an ErrCompacted error.
-		if _, err := tc.repl.raftTermRLocked(indexes[1]); !errors.Is(err, raft.ErrCompacted) {
+		if _, err := tc.repl.raftTermLocked(indexes[1]); !errors.Is(err, raft.ErrCompacted) {
 			t.Errorf("expected ErrCompacted, got %s", err)
 		}
-		if _, err := tc.repl.raftTermRLocked(indexes[3]); !errors.Is(err, raft.ErrCompacted) {
+		if _, err := tc.repl.raftTermLocked(indexes[3]); !errors.Is(err, raft.ErrCompacted) {
 			t.Errorf("expected ErrCompacted, got %s", err)
 		}
 
 		// FirstIndex-1 should return the term of firstIndex.
-		firstIndexTerm, err := tc.repl.raftTermRLocked(firstIndex)
+		firstIndexTerm, err := tc.repl.raftTermLocked(firstIndex)
 		if err != nil {
 			t.Errorf("expect no error, got %s", err)
 		}
 
-		term, err := tc.repl.raftTermRLocked(indexes[4])
+		term, err := tc.repl.raftTermLocked(indexes[4])
 		if err != nil {
 			t.Errorf("expect no error, got %s", err)
 		}
@@ -7432,21 +7432,21 @@ func TestTerm(t *testing.T) {
 			t.Errorf("expected firstIndex-1's term:%d to equal that of firstIndex:%d", term, firstIndexTerm)
 		}
 
-		lastIndex, err := repl.raftLastIndexLocked()
+		lastIndex, err := repl.raftLastIndexRLocked()
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		// Last index should return correctly.
-		if _, err := tc.repl.raftTermRLocked(lastIndex); err != nil {
+		if _, err := tc.repl.raftTermLocked(lastIndex); err != nil {
 			t.Errorf("expected no error, got %s", err)
 		}
 
 		// Terms for after the last index should return ErrUnavailable.
-		if _, err := tc.repl.raftTermRLocked(lastIndex + 1); !errors.Is(err, raft.ErrUnavailable) {
+		if _, err := tc.repl.raftTermLocked(lastIndex + 1); !errors.Is(err, raft.ErrUnavailable) {
 			t.Errorf("expected ErrUnavailable, got %s", err)
 		}
-		if _, err := tc.repl.raftTermRLocked(indexes[9] + 1000); !errors.Is(err, raft.ErrUnavailable) {
+		if _, err := tc.repl.raftTermLocked(indexes[9] + 1000); !errors.Is(err, raft.ErrUnavailable) {
 			t.Errorf("expected ErrUnavailable, got %s", err)
 		}
 	})
@@ -9968,7 +9968,7 @@ func (q *testQuiescer) raftBasicStatusRLocked() raft.BasicStatus {
 	return q.status.BasicStatus
 }
 
-func (q *testQuiescer) raftLastIndexLocked() (uint64, error) {
+func (q *testQuiescer) raftLastIndexRLocked() (uint64, error) {
 	return q.lastIndex, nil
 }
 


### PR DESCRIPTION
`r.mu.state.TruncatedState` is never nil (this is already assumed in `raftTruncatorReplica.getTruncatedState`), so the logic in `Replica.raftTruncatedStateLocked` that fell back to reading from the engine and lazily populating `r.mu.state.TruncatedState` was dead code.