### PR TITLE
changefeedccl: fix changefeed telemetry resolved

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1186,7 +1186,7 @@ func getCommonChangefeedEventDetails(
 	resolvedValue, resolvedSet := opts[changefeedbase.OptResolvedTimestamps]
 	if !resolvedSet {
 		resolved = "no"
-	} else if resolved == `` {
+	} else if resolvedValue == `` {
 		resolved = "yes"
 	} else {
 		resolved = resolvedValue

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -6663,14 +6663,14 @@ func TestChangefeedCreateTelemetryLogs(t *testing.T) {
 	t.Run(`gcpubsub_sink_type with options`, func(t *testing.T) {
 		pubsubFeedFactory := makePubsubFeedFactory(s.Server, s.DB)
 		beforeCreatePubsub := timeutil.Now()
-		pubsubFeed := feed(t, pubsubFeedFactory, `CREATE CHANGEFEED FOR foo, bar WITH resolved, no_initial_scan`)
+		pubsubFeed := feed(t, pubsubFeedFactory, `CREATE CHANGEFEED FOR foo, bar WITH resolved="10s", no_initial_scan`)
 		defer closeFeed(t, pubsubFeed)
 
 		createLogs := checkCreateChangefeedLogs(t, beforeCreatePubsub.UnixNano())
 		require.Equal(t, 1, len(createLogs))
 		require.Equal(t, createLogs[0].SinkType, `gcpubsub`)
 		require.Equal(t, createLogs[0].NumTables, int32(2))
-		require.Equal(t, createLogs[0].Resolved, `yes`)
+		require.Equal(t, createLogs[0].Resolved, `10s`)
 		require.Equal(t, createLogs[0].InitialScan, `no`)
 	})
 }


### PR DESCRIPTION
Resolves #81599

Our internal-use changefeed create / failed telemetry events would
incorrectly record "yes" for any non-no value of resolved, rather than
using the value that was passed in.  This change resolves that, emitting
yes for "resolved" and the value itself for "resolved=<value>".

Release note: None