### PR TITLE
release-22.1: ui: update tool tip to clearly call out the definition of session statuses

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
@@ -140,7 +140,7 @@ export const statisticsTableTitles: StatisticTableTitleType = {
         style="tableTitle"
         placement="bottom"
         content={
-          "A session is active if it has an open transaction (including implicit transactions, which are individual SQL statements), and idle if it has no open transaction."
+          "A session is Active if it has an open explicit or implicit transaction (individual SQL statement) with a statement that is actively running or waiting to acquire a lock. A session is Idle if it is not executing a statement."
         }
       >
         {getLabel("status")}


### PR DESCRIPTION
Backport 1/1 commits from #80726 on behalf of @gtr.

/cc @cockroachdb/release

----

Closes #80657

Previously, the tool tip for a session status read "a session is active if it
has an open transaction (including implicit transactions, which are individual
SQL statements), and idle if it has no open transaction." This change
updates that tool tip to the more accurate definition: "A session is
Active if it has an open explicit or implicit transaction (individual
SQL statement) with a statement that is actively running or waiting to
acquire a lock. A session is Idle if it is not executing a statement."

Release note (ui change): the tool tip for a sessions status has been
updated with a more explicit definition.

----

Release justification: low risk change