### PR TITLE
roachprod: avoid invoking `cockroach version`

### DIFF
--- a/pkg/roachprod/install/BUILD.bazel
+++ b/pkg/roachprod/install/BUILD.bazel
@@ -35,7 +35,6 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
-        "//pkg/util/version",
         "@com_github_alessio_shellescape//:shellescape",
         "@com_github_cockroachdb_errors//:errors",
         "@org_golang_x_sync//errgroup",


### PR DESCRIPTION
This was only being used for compatibility with v20.2 nodes
expecting different logging arguments. That version is no longer
officially supported, and in CI/elsewhere, we build roachprod using the
SHA from the specific release. Avoiding the version here lets me use
roachprod with crdb binaries that don't stamp in the version:
https://github.com/cockroachdb/cockroach/pull/79360 (avoiding stamping
can shave off a few precious seconds in builds).

Release note: None