### PR TITLE
sql: Allow internal QoS level for privileged users

### DIFF
--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1941,15 +1941,7 @@ var varGen = map[string]sessionVar{
 	},
 	`default_transaction_quality_of_service`: {
 		GetStringVal: makePostgresBoolGetStringValFn(`default_transaction_quality_of_service`),
-		Set: func(_ context.Context, m sessionDataMutator, s string) error {
-			qosLevel, ok := sessiondatapb.ParseQoSLevelFromString(s)
-			if !ok {
-				return newVarValueError(`default_transaction_quality_of_service`, s,
-					sessiondatapb.NormalName, sessiondatapb.UserHighName, sessiondatapb.UserLowName)
-			}
-			m.SetQualityOfService(qosLevel)
-			return nil
-		},
+		Set:          defaultTransactionQualityOfServiceVarSet,
 		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
 			return evalCtx.QualityOfService().String(), nil
 		},

--- a/pkg/util/admission/admissionpb/admissionpb.go
+++ b/pkg/util/admission/admissionpb/admissionpb.go
@@ -31,6 +31,13 @@ const (
 	NormalPri WorkPriority = 0
 	// UserHighPri is high priority work from user submissions (SQL).
 	UserHighPri WorkPriority = 50
+	// InternalNormalPri is normal priority work that originates from verified
+	// internal sources. The work maybe from a user submission (SQL) but the
+	// user will be an non-standard SQL user with a specific need to have
+	// elevated priority. For example, a CC created user that exists for the
+	// sole purpose of sending SQL probe queries that validate the availability
+	// of the cluster could create work with this priority level.
+	InternalNormalPri WorkPriority = 75
 	// LockingPri is for transactions that are acquiring locks.
 	LockingPri WorkPriority = 100
 	// HighPri is high priority work.
@@ -45,5 +52,6 @@ var _ = TTLLowPri
 var _ = UserLowPri
 var _ = NormalPri
 var _ = UserHighPri
+var _ = InternalNormalPri
 var _ = LockingPri
 var _ = HighPri


### PR DESCRIPTION
  This commit allows a privileged user or users (defined by an
  environment variable) to set a new internal QoS level
  "internal_regular". This QoS level has a higher priority than the User
  priorities (eg. UserHigh, UserLow) but a lower priority than the
  Locking priority. By setting the session variable
  `default_transaction_quality_of_service` to `internal_regular`,
  privileged users can issue queries at a priority level higher than
  normal users. This functionality can be used in CC to allow certain
  internal tools, like a prober, to always bypass customer queries when
  throttled by admission control. An ability to bypass customer queries
  will lead to higher signal to noise ratios in alerts built off of the
  prober's results.

  Related to #81415.