### PR TITLE
ccl/sqlproxyccl: ignore watch events with UNKNOWN pod states

### DIFF
--- a/pkg/ccl/sqlproxyccl/tenant/directory.proto
+++ b/pkg/ccl/sqlproxyccl/tenant/directory.proto
@@ -19,9 +19,9 @@ import "google/protobuf/timestamp.proto";
 enum PodState {
   option (gogoproto.goproto_enum_prefix) = false;
 
-  // UNKNOWN indicates that the pod values being reported are from a potentially
-  // out of date source. UNKNOWN may be used to notify updates to pod values
-  // when the pod's state may be out of date by the time the update is processed.
+  // UNKNOWN indicates that the pod's state is not known. This is used as the
+  // default value for PodState. All pods returned by the tenant directory
+  // should have a proper state.
   UNKNOWN = 0;
   // RUNNING indicates the pod may have active SQL connections and is ready to
   // accept new SQL connections.
@@ -32,8 +32,8 @@ enum PodState {
   // DRAINING indicates that the pod may still have active SQL connections to
   // it, but is in the process of shedding those connections so that it can be
   // terminated. No new connections should be routed to the pod. In addition,
-  // the proxy will begin terminating existing, less-active connections to the
-  // pod.
+  // the proxy will begin migrating existing connections to other RUNNING pods
+  // if they exist.
   DRAINING = 2;
   // DELETING indicates that the pod is being terminated. This state is only
   // used by WatchPods.
@@ -52,6 +52,8 @@ message Pod {
   PodState state = 3;
   // Load is a number in the range [0, 1] indicating the current amount of load
   // experienced by this tenant pod.
+  //
+  // TODO(jaylim-crl): Remove the Load field since it is now unused.
   float Load = 4;
   // StateTimestamp represents the timestamp that the state was last updated.
   google.protobuf.Timestamp stateTimestamp = 5 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];

--- a/pkg/ccl/sqlproxyccl/tenant/directory_cache.go
+++ b/pkg/ccl/sqlproxyccl/tenant/directory_cache.go
@@ -438,8 +438,10 @@ func (d *directoryCache) watchPods(ctx context.Context, stopper *stop.Stopper) e
 // watcher events. When a pod is created, destroyed, or modified, it updates the
 // tenant's entry to reflect that change.
 func (d *directoryCache) updateTenantEntry(ctx context.Context, pod *Pod) {
-	if pod.Addr == "" {
+	if pod.Addr == "" || pod.TenantID == 0 {
 		// Nothing needs to be done if there is no IP address specified.
+		// We also check on TenantID here because roachpb.MakeTenantID will
+		// panic with TenantID = 0.
 		return
 	}
 
@@ -462,16 +464,14 @@ func (d *directoryCache) updateTenantEntry(ctx context.Context, pod *Pod) {
 		} else {
 			log.Infof(ctx, "updated IP address %s with load %.3f for tenant %d", pod.Addr, pod.Load, pod.TenantID)
 		}
-	// Update entries of UNKNOWN pods only if they are already present.
-	case UNKNOWN:
-		if entry.UpdatePod(pod) {
-			log.Infof(ctx, "updated IP address %s with load %.3f for tenant %d", pod.Addr, pod.Load, pod.TenantID)
-		}
-	default:
+	case DELETING:
 		// Remove addresses of DELETING pods.
 		if entry.RemovePodByAddr(pod.Addr) {
 			log.Infof(ctx, "deleted IP address %s for tenant %d", pod.Addr, pod.TenantID)
 		}
+	default:
+		// Pods with UNKNOWN state.
+		log.Infof(ctx, "invalid pod entry with IP address %s for tenant %d", pod.Addr, pod.TenantID)
 	}
 }
 

--- a/pkg/ccl/sqlproxyccl/tenant/entry.go
+++ b/pkg/ccl/sqlproxyccl/tenant/entry.go
@@ -130,28 +130,6 @@ func (e *tenantEntry) AddPod(pod *Pod) bool {
 	return true
 }
 
-// UpdatePod updates the given pod in the tenant's list of pods. If an entry
-// with a match Addr is not present, UpdatePod returns false.
-func (e *tenantEntry) UpdatePod(pod *Pod) bool {
-	e.pods.Lock()
-	defer e.pods.Unlock()
-
-	for i, existing := range e.pods.pods {
-		if existing.Addr == pod.Addr {
-			// e.pods.pods is copy on write. Whenever modifications are made,
-			// we must make a copy to avoid accidentally mutating the slice
-			// retrieved by GetPods.
-			pods := e.pods.pods
-			e.pods.pods = make([]*Pod, len(pods))
-			copy(e.pods.pods, pods)
-			e.pods.pods[i] = pod
-			return true
-		}
-	}
-
-	return false
-}
-
 // RemovePodByAddr removes the pod with the given IP address from the tenant's
 // list of pod addresses. If it was not present, RemovePodByAddr returns false.
 func (e *tenantEntry) RemovePodByAddr(addr string) bool {

--- a/pkg/ccl/sqlproxyccl/tenantdirsvr/test_directory_svr.go
+++ b/pkg/ccl/sqlproxyccl/tenantdirsvr/test_directory_svr.go
@@ -163,32 +163,6 @@ func (s *TestDirectoryServer) StartTenant(ctx context.Context, id roachpb.Tenant
 	return nil
 }
 
-// SetFakeLoad artificially sets the load reported by a specific tenant pod. If
-// the id or addr is not found, a load update event is still generated.
-func (s *TestDirectoryServer) SetFakeLoad(id roachpb.TenantID, addr net.Addr, fakeLoad float32) {
-	s.proc.RLock()
-	defer s.proc.RUnlock()
-
-	// Only set FakeLoad if an entry exists.
-	if processes, ok := s.proc.processByAddrByTenantID[id.ToUint64()]; ok {
-		if process, ok := processes[addr]; ok {
-			process.FakeLoad = fakeLoad
-		}
-	}
-
-	s.listen.RLock()
-	defer s.listen.RUnlock()
-	s.notifyEventListenersLocked(&tenant.WatchPodsResponse{
-		Pod: &tenant.Pod{
-			Addr:           addr.String(),
-			TenantID:       id.ToUint64(),
-			Load:           fakeLoad,
-			State:          tenant.UNKNOWN,
-			StateTimestamp: timeutil.Now(),
-		},
-	})
-}
-
 // GetTenant returns tenant metadata for a given ID. Hard coded to return every
 // tenant's cluster name as "tenant-cluster"
 func (s *TestDirectoryServer) GetTenant(


### PR DESCRIPTION
Previously, we were using the tenant.UNKNOWN pod state to propagate load
changes events from the tenant directory. Now that we are no longer using the
Load field in tenant.Pod for routing decisions, the tenant.UNKNOWN state
should no longer be used. This commit ignores watch events with UNKNOWN pod
states. Not having this commit would result in a bug where pods would
transition from the RUNNING/DRAINING states to the UNKNOWN state, causing
the balancer to not be able to choose a pod for the incoming connection since
it filters for RUNNING pods.

Release note: None