### PR TITLE
opt: calculate filter cost more accurately when spatial functions involved

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats/inverted-geo
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-geo
@@ -307,7 +307,7 @@ memo (optimized, ~5KB, required=[presentation: i:1,g:2])
  ├── G1: (select G2 G3)
  │    └── [presentation: i:1,g:2]
  │         ├── best: (select G2 G3)
- │         └── cost: 2144.55
+ │         └── cost: 4144.55
  ├── G2: (scan t,cols=(1,2))
  │    └── []
  │         ├── best: (scan t,cols=(1,2))

--- a/pkg/sql/opt/xform/testdata/coster/spatial-filters
+++ b/pkg/sql/opt/xform/testdata/coster/spatial-filters
@@ -1,0 +1,297 @@
+exec-ddl
+CREATE TABLE g (
+  id INT PRIMARY KEY,
+  a FLOAT,
+  b BOOL,
+  geog GEOGRAPHY
+);
+----
+
+exec-ddl
+ALTER TABLE g INJECT STATISTICS '[
+  {
+    "columns": [
+      "id"
+    ],
+    "created_at": "2021-01-01 00:00:00",
+    "distinct_count": 500000,
+    "name": "__auto__",
+    "row_count": 500000
+  }
+]';
+----
+
+opt
+SELECT id FROM g
+WHERE st_dwithin(geog, st_makepoint(1.0, 1.0)::geography, 200) = b;
+----
+project
+ ├── columns: id:1!null
+ ├── immutable
+ ├── stats: [rows=165000]
+ ├── cost: 1041674.77
+ ├── key: (1)
+ └── select
+      ├── columns: id:1!null b:3!null geog:4
+      ├── immutable
+      ├── stats: [rows=165000, distinct(3)=3, null(3)=0, avgsize(3)=4]
+      ├── cost: 1040024.75
+      ├── key: (1)
+      ├── fd: (1)-->(3,4), (4)-->(3)
+      ├── scan g
+      │    ├── columns: id:1!null b:3 geog:4
+      │    ├── stats: [rows=500000, distinct(1)=500000, null(1)=0, avgsize(1)=4, distinct(3)=3, null(3)=5000, avgsize(3)=4]
+      │    ├── cost: 535024.72
+      │    ├── key: (1)
+      │    └── fd: (1)-->(3,4)
+      └── filters
+           └── b:3 = st_dwithin(geog:4, '0101000020E6100000000000000000F03F000000000000F03F', 200.0) [outer=(3,4), immutable, constraints=(/3: (/NULL - ]), fd=(4)-->(3)]
+
+opt
+SELECT id FROM g
+WHERE b = st_dwithin(geog, st_makepoint(1.0, 1.0)::geography, 200);
+----
+project
+ ├── columns: id:1!null
+ ├── immutable
+ ├── stats: [rows=165000]
+ ├── cost: 1041674.77
+ ├── key: (1)
+ └── select
+      ├── columns: id:1!null b:3!null geog:4
+      ├── immutable
+      ├── stats: [rows=165000, distinct(3)=3, null(3)=0, avgsize(3)=4]
+      ├── cost: 1040024.75
+      ├── key: (1)
+      ├── fd: (1)-->(3,4), (4)-->(3)
+      ├── scan g
+      │    ├── columns: id:1!null b:3 geog:4
+      │    ├── stats: [rows=500000, distinct(1)=500000, null(1)=0, avgsize(1)=4, distinct(3)=3, null(3)=5000, avgsize(3)=4]
+      │    ├── cost: 535024.72
+      │    ├── key: (1)
+      │    └── fd: (1)-->(3,4)
+      └── filters
+           └── b:3 = st_dwithin(geog:4, '0101000020E6100000000000000000F03F000000000000F03F', 200.0) [outer=(3,4), immutable, constraints=(/3: (/NULL - ]), fd=(4)-->(3)]
+
+opt
+SELECT id FROM g
+WHERE st_dwithin(geog, st_makepoint(1.0, 1.0)::geography, 200);
+----
+project
+ ├── columns: id:1!null
+ ├── immutable
+ ├── stats: [rows=55000]
+ ├── cost: 1035574.67
+ ├── key: (1)
+ └── select
+      ├── columns: id:1!null geog:4!null
+      ├── immutable
+      ├── stats: [rows=55000, distinct(4)=50000, null(4)=0, avgsize(4)=4]
+      ├── cost: 1035024.65
+      ├── key: (1)
+      ├── fd: (1)-->(4)
+      ├── scan g
+      │    ├── columns: id:1!null geog:4
+      │    ├── stats: [rows=500000, distinct(1)=500000, null(1)=0, avgsize(1)=4, distinct(4)=50000, null(4)=5000, avgsize(4)=4]
+      │    ├── cost: 530024.62
+      │    ├── key: (1)
+      │    └── fd: (1)-->(4)
+      └── filters
+           └── st_dwithin(geog:4, '0101000020E6100000000000000000F03F000000000000F03F', 200.0) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+
+opt
+SELECT id FROM g
+WHERE b = st_dwithin(geog, st_makepoint(a, 1.0)::geography, 200);
+----
+project
+ ├── columns: id:1!null
+ ├── immutable
+ ├── stats: [rows=165000]
+ ├── cost: 1546674.87
+ ├── key: (1)
+ └── select
+      ├── columns: id:1!null a:2 b:3!null geog:4
+      ├── immutable
+      ├── stats: [rows=165000, distinct(3)=3, null(3)=0, avgsize(3)=4]
+      ├── cost: 1545024.85
+      ├── key: (1)
+      ├── fd: (1)-->(2-4)
+      ├── scan g
+      │    ├── columns: id:1!null a:2 b:3 geog:4
+      │    ├── stats: [rows=500000, distinct(1)=500000, null(1)=0, avgsize(1)=4, distinct(3)=3, null(3)=5000, avgsize(3)=4]
+      │    ├── cost: 540024.82
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2-4)
+      └── filters
+           └── b:3 = st_dwithin(geog:4, st_makepoint(a:2, 1.0)::GEOGRAPHY, 200.0) [outer=(2-4), immutable, constraints=(/3: (/NULL - ])]
+
+opt
+SELECT id FROM g
+WHERE st_distance(geog, st_makepoint(1.0, 1.0)::geography) < 200;
+----
+project
+ ├── columns: id:1!null
+ ├── immutable
+ ├── stats: [rows=55000]
+ ├── cost: 535574.67
+ ├── key: (1)
+ └── select
+      ├── columns: id:1!null geog:4!null
+      ├── immutable
+      ├── stats: [rows=55000, distinct(4)=50000, null(4)=0, avgsize(4)=4]
+      ├── cost: 535024.65
+      ├── key: (1)
+      ├── fd: (1)-->(4)
+      ├── scan g
+      │    ├── columns: id:1!null geog:4
+      │    ├── stats: [rows=500000, distinct(1)=500000, null(1)=0, avgsize(1)=4, distinct(4)=50000, null(4)=5000, avgsize(4)=4]
+      │    ├── cost: 530024.62
+      │    ├── key: (1)
+      │    └── fd: (1)-->(4)
+      └── filters
+           └── st_dwithinexclusive(geog:4, '0101000020E6100000000000000000F03F000000000000F03F', 200.0) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+
+opt
+SELECT id FROM g
+WHERE st_distance(geog, st_makepoint(a, 1.0)::geography) < 200;
+----
+project
+ ├── columns: id:1!null
+ ├── immutable
+ ├── stats: [rows=55000]
+ ├── cost: 1040574.77
+ ├── key: (1)
+ └── select
+      ├── columns: id:1!null a:2 geog:4!null
+      ├── immutable
+      ├── stats: [rows=55000, distinct(4)=50000, null(4)=0, avgsize(4)=4]
+      ├── cost: 1040024.75
+      ├── key: (1)
+      ├── fd: (1)-->(2,4)
+      ├── scan g
+      │    ├── columns: id:1!null a:2 geog:4
+      │    ├── stats: [rows=500000, distinct(1)=500000, null(1)=0, avgsize(1)=4, distinct(4)=50000, null(4)=5000, avgsize(4)=4]
+      │    ├── cost: 535024.72
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2,4)
+      └── filters
+           └── st_dwithinexclusive(geog:4, st_makepoint(a:2, 1.0)::GEOGRAPHY, 200.0) [outer=(2,4), immutable, constraints=(/4: (/NULL - ])]
+
+opt
+SELECT id FROM g
+WHERE st_intersects(st_makepoint(a, 1.0)::geometry, st_geomfromtext('SRID=4326;POLYGON((-87.906471 43.038902, -95.992775 36.153980, -75.704722 36.076944, -87.906471 43.038902))'));
+----
+project
+ ├── columns: id:1!null
+ ├── immutable
+ ├── stats: [rows=166666.7]
+ ├── cost: 1536691.34
+ ├── key: (1)
+ └── select
+      ├── columns: id:1!null a:2
+      ├── immutable
+      ├── stats: [rows=166666.7]
+      ├── cost: 1535024.65
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      ├── scan g
+      │    ├── columns: id:1!null a:2
+      │    ├── stats: [rows=500000, distinct(1)=500000, null(1)=0, avgsize(1)=4]
+      │    ├── cost: 530024.62
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── filters
+           └── st_intersects(st_makepoint(a:2, 1.0), '0103000020E610000001000000040000006FF1F09E03FA55C0DFDFA0BDFA844540545227A089FF57C0791EDC9DB513424064B14D2A1AED52C0CCCF0D4DD90942406FF1F09E03FA55C0DFDFA0BDFA844540') [outer=(2), immutable]
+
+opt
+SELECT * FROM g WHERE st_area(geog) < a;
+----
+select
+ ├── columns: id:1!null a:2!null b:3 geog:4
+ ├── immutable
+ ├── stats: [rows=165000, distinct(2)=50000, null(2)=0, avgsize(2)=4]
+ ├── cost: 1045024.85
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── scan g
+ │    ├── columns: id:1!null a:2 b:3 geog:4
+ │    ├── stats: [rows=500000, distinct(1)=500000, null(1)=0, avgsize(1)=4, distinct(2)=50000, null(2)=5000, avgsize(2)=4]
+ │    ├── cost: 540024.82
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-4)
+ └── filters
+      └── a:2 > st_area(geog:4) [outer=(2,4), immutable, constraints=(/2: (/NULL - ])]
+
+opt
+SELECT * FROM g WHERE st_area(geog) > a AND st_area(geog) < 2*a;
+----
+select
+ ├── columns: id:1!null a:2!null b:3 geog:4
+ ├── immutable
+ ├── stats: [rows=55000, distinct(2)=50000, null(2)=0, avgsize(2)=4]
+ ├── cost: 1545024.86
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── scan g
+ │    ├── columns: id:1!null a:2 b:3 geog:4
+ │    ├── stats: [rows=500000, distinct(1)=500000, null(1)=0, avgsize(1)=4, distinct(2)=50000, null(2)=5000, avgsize(2)=4]
+ │    ├── cost: 540024.82
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-4)
+ └── filters
+      ├── a:2 < st_area(geog:4) [outer=(2,4), immutable, constraints=(/2: (/NULL - ])]
+      └── st_area(geog:4) < (a:2 * 2.0) [outer=(2,4), immutable]
+
+exec-ddl
+CREATE TABLE x (
+  id INT PRIMARY KEY,
+  a FLOAT,
+  b BOOL,
+  geog GEOGRAPHY
+);
+----
+
+exec-ddl
+ALTER TABLE x INJECT STATISTICS '[
+  {
+    "columns": [
+      "id"
+    ],
+    "created_at": "2021-01-01 00:00:00",
+    "distinct_count": 500000,
+    "name": "__auto__",
+    "row_count": 500000
+  }
+]';
+----
+
+opt
+SELECT * FROM g JOIN x
+ON g.id = x.id
+WHERE st_area(g.geog) > st_area(x.geog);
+----
+inner-join (merge)
+ ├── columns: id:1!null a:2 b:3 geog:4 id:7!null a:8 b:9 geog:10
+ ├── left ordering: +1
+ ├── right ordering: +7
+ ├── immutable
+ ├── stats: [rows=166666.7, distinct(1)=166667, null(1)=0, avgsize(1)=4, distinct(7)=166667, null(7)=0, avgsize(7)=4]
+ ├── cost: 2095049.67
+ ├── key: (7)
+ ├── fd: (1)-->(2-4), (7)-->(8-10), (1)==(7), (7)==(1)
+ ├── scan g
+ │    ├── columns: g.id:1!null g.a:2 g.b:3 g.geog:4
+ │    ├── stats: [rows=500000, distinct(1)=500000, null(1)=0, avgsize(1)=4]
+ │    ├── cost: 540024.82
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    └── ordering: +1
+ ├── scan x
+ │    ├── columns: x.id:7!null x.a:8 x.b:9 x.geog:10
+ │    ├── stats: [rows=500000, distinct(7)=500000, null(7)=0, avgsize(7)=4]
+ │    ├── cost: 540024.82
+ │    ├── key: (7)
+ │    ├── fd: (7)-->(8-10)
+ │    └── ordering: +7
+ └── filters
+      └── st_area(g.geog:4) > st_area(x.geog:10) [outer=(4,10), immutable]

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -4149,7 +4149,7 @@ project
            ├── st_covers('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
            └── st_overlaps('0102000000020000000000000000000000000000000000000000000000000000000000000000000040', geom:3) [outer=(3), immutable, constraints=(/3: (/NULL - ])]
 
-# Cannot use either index in this case.
+# We can use both indexes because of the SplitDisjunction rule.
 opt
 SELECT k FROM g
 WHERE ST_Covers('SRID=4326;POINT(-43.23456 72.4567772)'::geography, geog)
@@ -4159,17 +4159,78 @@ project
  ├── columns: k:1!null
  ├── immutable
  ├── key: (1)
- └── select
+ └── distinct-on
       ├── columns: k:1!null geom:3 geog:4
+      ├── grouping columns: k:1!null
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(3,4)
-      ├── scan g
+      ├── union-all
       │    ├── columns: k:1!null geom:3 geog:4
-      │    ├── key: (1)
-      │    └── fd: (1)-->(3,4)
-      └── filters
-           └── st_covers('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4) OR st_touches('0102000000020000000000000000000000000000000000000000000000000000000000000000000040', geom:3) [outer=(3,4), immutable]
+      │    ├── left columns: k:9 geom:11 geog:12
+      │    ├── right columns: k:17 geom:19 geog:20
+      │    ├── immutable
+      │    ├── select
+      │    │    ├── columns: k:9!null geom:11 geog:12!null
+      │    │    ├── immutable
+      │    │    ├── key: (9)
+      │    │    ├── fd: (9)-->(11,12)
+      │    │    ├── index-join g
+      │    │    │    ├── columns: k:9!null geom:11 geog:12
+      │    │    │    ├── key: (9)
+      │    │    │    ├── fd: (9)-->(11,12)
+      │    │    │    └── inverted-filter
+      │    │    │         ├── columns: k:9!null
+      │    │    │         ├── inverted expression: /16
+      │    │    │         │    ├── tight: false, unique: false
+      │    │    │         │    └── union spans
+      │    │    │         │         ├── ["B\xfdL\x00\x00\x00\x00\x00\x00\x00", "B\xfdL\x00\x00\x00\x00\x00\x00\x00"]
+      │    │    │         │         ├── ["B\xfdN\x00\x00\x00\x00\x00\x00\x01", "B\xfdP\x00\x00\x00\x00\x00\x00\x00")
+      │    │    │         │         └── ["B\xfdP\x00\x00\x00\x00\x00\x00\x00", "B\xfdP\x00\x00\x00\x00\x00\x00\x00"]
+      │    │    │         ├── pre-filterer expression
+      │    │    │         │    └── st_covers('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:12)
+      │    │    │         ├── key: (9)
+      │    │    │         └── scan g@geog_idx
+      │    │    │              ├── columns: k:9!null geog_inverted_key:16!null
+      │    │    │              ├── inverted constraint: /16/9
+      │    │    │              │    └── spans
+      │    │    │              │         ├── ["B\xfdL\x00\x00\x00\x00\x00\x00\x00", "B\xfdL\x00\x00\x00\x00\x00\x00\x00"]
+      │    │    │              │         ├── ["B\xfdN\x00\x00\x00\x00\x00\x00\x01", "B\xfdP\x00\x00\x00\x00\x00\x00\x00")
+      │    │    │              │         └── ["B\xfdP\x00\x00\x00\x00\x00\x00\x00", "B\xfdP\x00\x00\x00\x00\x00\x00\x00"]
+      │    │    │              ├── key: (9)
+      │    │    │              └── fd: (9)-->(16)
+      │    │    └── filters
+      │    │         └── st_covers('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:12) [outer=(12), immutable, constraints=(/12: (/NULL - ])]
+      │    └── select
+      │         ├── columns: k:17!null geom:19!null geog:20
+      │         ├── immutable
+      │         ├── key: (17)
+      │         ├── fd: (17)-->(19,20)
+      │         ├── index-join g
+      │         │    ├── columns: k:17!null geom:19 geog:20
+      │         │    ├── key: (17)
+      │         │    ├── fd: (17)-->(19,20)
+      │         │    └── inverted-filter
+      │         │         ├── columns: k:17!null
+      │         │         ├── inverted expression: /23
+      │         │         │    ├── tight: false, unique: false
+      │         │         │    └── union spans: ["B\x89", "B\xfd \x00\x00\x00\x00\x00\x00\x00")
+      │         │         ├── pre-filterer expression
+      │         │         │    └── st_touches('0102000000020000000000000000000000000000000000000000000000000000000000000000000040', geom:19)
+      │         │         ├── key: (17)
+      │         │         └── scan g@geom_idx
+      │         │              ├── columns: k:17!null geom_inverted_key:23!null
+      │         │              ├── inverted constraint: /23/17
+      │         │              │    └── spans: ["B\x89", "B\xfd \x00\x00\x00\x00\x00\x00\x00")
+      │         │              ├── key: (17)
+      │         │              └── fd: (17)-->(23)
+      │         └── filters
+      │              └── st_touches('0102000000020000000000000000000000000000000000000000000000000000000000000000000040', geom:19) [outer=(19), immutable, constraints=(/19: (/NULL - ])]
+      └── aggregations
+           ├── const-agg [as=geom:3, outer=(3)]
+           │    └── geom:3
+           └── const-agg [as=geog:4, outer=(4)]
+                └── geog:4
 
 opt expect=GenerateInvertedIndexScans
 SELECT k FROM g


### PR DESCRIPTION
Fixes #59718

Release note (performance improvement): the optimizer's cost model is now more
aware of the cost of executing expensive functions (such as spatial functions)
in filter conditions. This may lead to improved query plans.