### PR TITLE
sql: audit json.AsText for nil return value

### DIFF
--- a/pkg/sql/sem/eval/json.go
+++ b/pkg/sql/sem/eval/json.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
+	"github.com/cockroachdb/errors"
 )
 
 // PopulateDatumWithJSON is used for the json to record function family, like
@@ -59,6 +60,9 @@ func PopulateDatumWithJSON(ctx *Context, j json.JSON, desiredType *types.T) (tre
 		t, err := j.AsText()
 		if err != nil {
 			return nil, err
+		}
+		if t == nil {
+			return nil, errors.AssertionFailedf("JSON NULL value was checked above")
 		}
 		s = *t
 	default:

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_decoding.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_decoding.go
@@ -72,7 +72,11 @@ func JSONToExplainTreePlanNode(jsonVal json.JSON) (*roachpb.ExplainTreePlanNode,
 		if err != nil {
 			return nil, err
 		}
-		node.Name = *str
+		if str == nil {
+			node.Name = "<null>"
+		} else {
+			node.Name = *str
+		}
 	}
 
 	iter, err := jsonVal.ObjectIter()
@@ -112,9 +116,13 @@ func JSONToExplainTreePlanNode(jsonVal json.JSON) (*roachpb.ExplainTreePlanNode,
 			if err != nil {
 				return nil, err
 			}
+			value := "<null>"
+			if str != nil {
+				value = *str
+			}
 			node.Attrs = append(node.Attrs, &roachpb.ExplainTreePlanNode_Attr{
 				Key:   key,
-				Value: *str,
+				Value: value,
 			})
 		}
 	}

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
@@ -414,7 +414,11 @@ func (s *jsonString) decodeJSON(js json.JSON) error {
 	if err != nil {
 		return err
 	}
-	*s = (jsonString)(*text)
+	if text != nil {
+		*s = (jsonString)(*text)
+	} else {
+		*s = "<null>"
+	}
 	return nil
 }
 

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -2060,6 +2060,9 @@ func (j jsonArray) RemoveString(s string) (JSON, bool, error) {
 			if err != nil {
 				return nil, false, err
 			}
+			if t == nil {
+				return nil, false, errors.AssertionFailedf("StringJSONType should not be nil here")
+			}
 			if *t != s {
 				b.Add(el)
 			} else {


### PR DESCRIPTION
This commit audits all calls of `json.AsText` to make sure that we
always do nil-pointer check. I think all of the callsites where this
commit adds the check are impossible to hit the nil-pointer panic, but
it's still good to have the checks explicitly.

Informs: #81097.

Release note: None