### PR TITLE
kv: don't skip "may need snapshot" protection for VOTER_INCOMING replicas

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -2261,12 +2261,6 @@ func ReplicaIsBehind(raftStatus *raft.Status, replicaID roachpb.ReplicaID) bool 
 // replica that is not the raft leader), we pessimistically assume that
 // `replicaID` may need a snapshot.
 func replicaMayNeedSnapshot(raftStatus *raft.Status, replica roachpb.ReplicaDescriptor) bool {
-	// When adding replicas, we only move them from LEARNER to VOTER_INCOMING after
-	// they applied the snapshot (see initializeRaftLearners and its use in
-	// changeReplicasImpl).
-	if replica.GetType() == roachpb.VOTER_INCOMING {
-		return false
-	}
 	if raftStatus == nil || len(raftStatus.Progress) == 0 {
 		return true
 	}


### PR DESCRIPTION
This was added in 208e2b4. I'd like to understand whether it's actually needed, and if so, why. If we just sent a snapshot to the VOTER_INCOMING replica, why don't we see it in StateReplicate? Are we not the Raft leader? Did we not update our raft group's progress in reportSnapshotStatus.

cc. @shralex 