### PR TITLE
kvcoord: optimize Truncate

### DIFF
--- a/pkg/kv/kvclient/kvcoord/truncate_test.go
+++ b/pkg/kv/kvclient/kvcoord/truncate_test.go
@@ -12,6 +12,7 @@ package kvcoord
 
 import (
 	"bytes"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -21,7 +22,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTruncate(t *testing.T) {
@@ -187,6 +190,53 @@ func TestTruncate(t *testing.T) {
 		if !reflect.DeepEqual(original, goldenOriginal) {
 			t.Errorf("%d: truncation mutated original:\nexpected: %s\nactual: %s",
 				i, goldenOriginal, original)
+		}
+	}
+}
+
+func BenchmarkTruncate(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+	defer log.Scope(b).Close(b)
+
+	rng, _ := randutil.NewTestRand()
+	// For simplicity, we'll work with single-byte keys, so we divide up the
+	// single-byte key space into three parts, and we'll be truncating the
+	// requests according to the middle part.
+	rs := roachpb.RSpan{Key: roachpb.RKey([]byte{85}), EndKey: roachpb.RKey([]byte{170})}
+	randomKeyByte := func() byte {
+		// Plus two is needed to skip local key space.
+		return byte(2 + rng.Intn(253))
+	}
+	for _, numRequests := range []int{1 << 5, 1 << 10, 1 << 15} {
+		for _, requestType := range []string{"get", "scan"} {
+			b.Run(fmt.Sprintf("reqs=%d/type=%s", numRequests, requestType), func(b *testing.B) {
+				reqs := make([]roachpb.RequestUnion, numRequests)
+				switch requestType {
+				case "get":
+					for i := 0; i < numRequests; i++ {
+						var get roachpb.GetRequest
+						get.Key = []byte{randomKeyByte()}
+						reqs[i].MustSetInner(&get)
+					}
+				case "scan":
+					for i := 0; i < numRequests; i++ {
+						var scan roachpb.ScanRequest
+						startKey := randomKeyByte()
+						endKey := randomKeyByte()
+						if endKey < startKey {
+							startKey, endKey = endKey, startKey
+						}
+						scan.Key = []byte{startKey}
+						scan.EndKey = []byte{endKey}
+						reqs[i].MustSetInner(&scan)
+					}
+				}
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					_, _, err := Truncate(reqs, rs)
+					require.NoError(b, err)
+				}
+			})
 		}
 	}
 }


### PR DESCRIPTION
**kvcoord: introduce benchmark for Truncate function**

Release note: None

**kvcoord: optimize Truncate**

This commit optimizes the `Truncate` function by accessing the header of
the request directly (instead of having to construct `roachpb.Span`) as
well as keeping track of whether the request has been changed (instead
of performing key comparison later).
```
name                              old time/op    new time/op    delta
Truncate/reqs=32/type=get-24        3.81µs ± 4%    3.42µs ± 1%  -10.32%  (p=0.000 n=9+9)
Truncate/reqs=32/type=scan-24       6.35µs ±11%    5.81µs ±11%   -8.56%  (p=0.019 n=10+10)
Truncate/reqs=1024/type=get-24      98.9µs ± 2%    85.8µs ± 1%  -13.24%  (p=0.000 n=10+10)
Truncate/reqs=1024/type=scan-24      176µs ± 2%     155µs ± 2%  -12.17%  (p=0.000 n=10+10)
Truncate/reqs=32768/type=get-24     3.23ms ± 1%    2.78ms ± 0%  -13.86%  (p=0.000 n=10+9)
Truncate/reqs=32768/type=scan-24    5.64ms ± 1%    5.02ms ± 0%  -11.01%  (p=0.000 n=10+9)

name                              old alloc/op   new alloc/op   delta
Truncate/reqs=32/type=get-24          744B ± 0%      744B ± 0%     ~     (all equal)
Truncate/reqs=32/type=scan-24       2.08kB ±37%    2.05kB ±36%     ~     (p=0.897 n=10+10)
Truncate/reqs=1024/type=get-24      24.6kB ± 0%    24.6kB ± 0%     ~     (all equal)
Truncate/reqs=1024/type=scan-24     73.2kB ± 2%    73.7kB ± 2%     ~     (p=0.167 n=9+9)
Truncate/reqs=32768/type=get-24     1.21MB ± 0%    1.21MB ± 0%     ~     (p=0.370 n=10+10)
Truncate/reqs=32768/type=scan-24    2.82MB ± 0%    2.84MB ± 0%   +0.48%  (p=0.000 n=10+10)

name                              old allocs/op  new allocs/op  delta
Truncate/reqs=32/type=get-24          10.0 ± 0%      10.0 ± 0%     ~     (all equal)
Truncate/reqs=32/type=scan-24         33.6 ±25%      34.8 ±26%     ~     (p=0.646 n=10+10)
Truncate/reqs=1024/type=get-24        20.0 ± 0%      20.0 ± 0%     ~     (all equal)
Truncate/reqs=1024/type=scan-24        692 ± 5%       705 ± 6%     ~     (p=0.167 n=9+9)
Truncate/reqs=32768/type=get-24       40.0 ± 0%      40.0 ± 0%     ~     (all equal)
Truncate/reqs=32768/type=scan-24     21.6k ± 2%     22.0k ± 1%   +1.73%  (p=0.000 n=10+10)
```

Addresses: #68536.

Release note: None