### PR TITLE
kvcoord: don't construct roachpb.Spans needlessly in several spots

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
@@ -561,7 +561,7 @@ func (tp *txnPipeliner) chainToInFlightWrites(ba roachpb.BatchRequest) roachpb.B
 			} else {
 				// Transactional reads and writes needs to chain on to any
 				// overlapping in-flight writes.
-				s := req.Header().Span()
+				s := req.Header()
 				tp.ifWrites.ascendRange(s.Key, s.EndKey, writeIter)
 			}
 		}


### PR DESCRIPTION
This should be a minor performance improvement, but I don't know of good
benchmarks to verify that, yet the change doesn't seem controversial
either.

Release note: None