### PR TITLE
concurrency: export histogram for latch wait times

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -125,6 +125,7 @@ type Config struct {
 	// Metrics.
 	TxnWaitMetrics *txnwait.Metrics
 	SlowLatchGauge *metric.Gauge
+	LatchWaitTime  *metric.Histogram
 	// Configs + Knobs.
 	MaxLockTableSize  int64
 	DisableTxnPushing bool
@@ -151,6 +152,7 @@ func NewManager(cfg Config) Manager {
 			m: spanlatch.Make(
 				cfg.Stopper,
 				cfg.SlowLatchGauge,
+				cfg.LatchWaitTime,
 			),
 		},
 		lt: lt,

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -1248,6 +1248,13 @@ A nonzero value indicates range or replica unavailability, and should be investi
 		Unit:        metric.Unit_COUNT,
 	}
 
+	metaLatchWaitLatency = metric.Metadata{
+		Name:        "requests.latch.wait_time",
+		Help:        "Latency histogram of time spent waiting for latch acquisitions",
+		Measurement: "Latch wait time",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
+
 	// Backpressure metrics.
 	metaBackpressuredOnSplitRequests = metric.Metadata{
 		Name: "requests.backpressure.split",
@@ -1617,6 +1624,9 @@ type StoreMetrics struct {
 	SlowLatchRequests *metric.Gauge
 	SlowLeaseRequests *metric.Gauge
 	SlowRaftRequests  *metric.Gauge
+
+	// Latch wait time.
+	LatchWaitTime *metric.Histogram
 
 	// Backpressure counts.
 	BackpressuredOnSplitRequests *metric.Gauge
@@ -2089,6 +2099,8 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		SlowLatchRequests: metric.NewGauge(metaLatchRequests),
 		SlowLeaseRequests: metric.NewGauge(metaSlowLeaseRequests),
 		SlowRaftRequests:  metric.NewGauge(metaSlowRaftRequests),
+
+		LatchWaitTime: metric.NewLatency(metaLatchWaitLatency, histogramWindow),
 
 		// Backpressure counters.
 		BackpressuredOnSplitRequests: metric.NewGauge(metaBackpressuredOnSplitRequests),

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -87,6 +87,7 @@ func newUnloadedReplica(
 			IntentResolver:    store.intentResolver,
 			TxnWaitMetrics:    store.txnWaitMetrics,
 			SlowLatchGauge:    store.metrics.SlowLatchRequests,
+			LatchWaitTime:     store.metrics.LatchWaitTime,
 			DisableTxnPushing: store.TestingKnobs().DontPushOnWriteIntentError,
 			TxnWaitKnobs:      store.TestingKnobs().TxnWaitKnobs,
 		}),

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1005,6 +1005,11 @@ var charts = []sectionDescription{
 				Rate:        DescribeDerivative_NON_NEGATIVE_DERIVATIVE,
 				Metrics:     []string{"kv.replica_circuit_breaker.num_tripped_events"},
 			},
+			{
+				Title:     "Latency histogram of time spent waiting for latch acquisitions",
+				Metrics:   []string{"requests.latch.wait_time"},
+				AxisLabel: "Latch Wait Time",
+			},
 		},
 	},
 	{


### PR DESCRIPTION
Instrumentation to help with #75066.

Release note: None