### PR TITLE
util/admission: fix bazel file

### DIFF
--- a/pkg/util/admission/admissionpb/BUILD.bazel
+++ b/pkg/util/admission/admissionpb/BUILD.bazel
@@ -1,16 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "admissionwork",
-    srcs = [
-        "admissionwork.go",
-        "doc.go",
-    ],
-    importpath = "github.com/cockroachdb/cockroach/pkg/util/admission/admissionwork",
-    visibility = ["//visibility:public"],
-)
-
-go_library(
     name = "admissionpb",
     srcs = [
         "admissionpb.go",


### PR DESCRIPTION
... referencing non-existent go file (admissionwork.go).

Release note: None