### PR TITLE
release-21.2: xform: Fix nil pointer panic in splitScanIntoUnionScans

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -518,3 +518,50 @@ vectorized: true
 └── • virtual table
       table: pg_type@pg_type_oid_idx
       spans: [/1 - /1000]
+
+
+statement ok
+CREATE TABLE t76741 (x FLOAT NOT NULL, y INT NOT NULL, PRIMARY KEY (x, y),
+                     CONSTRAINT ck CHECK (x IN (1, 3, 5) OR x BETWEEN 7 and 10))
+
+# Regression test for #76741. This test previously caused a panic.
+query T
+EXPLAIN SELECT * FROM t76741 ORDER BY y LIMIT 5
+----
+distribution: local
+vectorized: true
+·
+• limit
+│ count: 5
+│
+└── • union all
+    │
+    ├── • union all
+    │   │
+    │   ├── • union all
+    │   │   │
+    │   │   ├── • scan
+    │   │   │     missing stats
+    │   │   │     table: t76741@primary
+    │   │   │     spans: [/1.0 - /1.0]
+    │   │   │     limit: 5
+    │   │   │
+    │   │   └── • scan
+    │   │         missing stats
+    │   │         table: t76741@primary
+    │   │         spans: [/3.0 - /3.0]
+    │   │         limit: 5
+    │   │
+    │   └── • scan
+    │         missing stats
+    │         table: t76741@primary
+    │         spans: [/5.0 - /5.0]
+    │         limit: 5
+    │
+    └── • sort
+        │ order: +y
+        │
+        └── • scan
+              missing stats
+              table: t76741@primary
+              spans: [/7.0 - /10.0]

--- a/pkg/sql/opt/xform/general_funcs.go
+++ b/pkg/sql/opt/xform/general_funcs.go
@@ -627,7 +627,7 @@ func (c *CustomFuncs) splitScanIntoUnionScans(
 	// construct an unlimited Scan and add it to the UnionAll tree.
 	newScanPrivate := c.DuplicateScanPrivate(sp)
 	newScanPrivate.SetConstraint(c.e.evalCtx, &constraint.Constraint{
-		Columns: sp.Constraint.Columns.RemapColumns(sp.Table, newScanPrivate.Table),
+		Columns: cons.Columns.RemapColumns(sp.Table, newScanPrivate.Table),
 		Spans:   noLimitSpans,
 	})
 	newScan := c.e.f.ConstructScan(newScanPrivate)


### PR DESCRIPTION
Fixes #76741
Fixes [#1606](https://github.com/cockroachlabs/support/issues/1606)

This commit fixes a panic that occurs when the optimizer tries to split
a table scan into a UNION ALL of separate scans to avoid a sort. The
preconditions for the problem are:
  1. The scan is from a composite index.
  2. The first column of the composite index uses a continuous data
     type, such as FLOAT, and is NOT NULL.
  3. There is a CHECK constraint defined on the first index column where
     at least one span covers more than one first column value.
  4. The query sorts the rows on the second index column and has a LIMIT
     clause.
  5. There is no WHERE clause predicate in the query which could be used
     to constrain the scan on the index.

In this case, function `getKnownScanConstraint` uses the CHECK
constraint to build a query constraint instead of locating it in
`ScanPrivate.Constraint` (which is nil in this case). Due to
precondition 3 above, there is at least one span where `singleKeySpans`
can't be found. Those spans are added to `noLimitSpans` causing an
unlimited Scan to be built. The code building this assumes the
constraint to use is in `ScanPrivate`, and tries to access it, but it's
nil, so a panic occurs.

To fix this, reference the constraint built by `getKnownScanConstraint`
and passed in by the `cons` parameter when building the unlimited Scan
instead of assuming `ScanPrivate.Constraint` always holds the proper
constraint.

Release justification: This fixes a rare panic in the optimizer.

Release note (bug fix): This patch fixes queries from a table with a
CHECK constraint, which may error out when the query has ORDER BY and
LIMIT clauses.