### PR TITLE
sqlproxyccl/tenant: improve a test

### DIFF
--- a/pkg/ccl/sqlproxyccl/tenant/directory_cache_test.go
+++ b/pkg/ccl/sqlproxyccl/tenant/directory_cache_test.go
@@ -172,8 +172,6 @@ func TestWatchPods(t *testing.T) {
 	pods, err = dir.TryLookupTenantPods(ctx, tenantID)
 	require.NoError(t, err)
 	require.Empty(t, pods)
-	stopper.Stop(ctx)
-	stopper.Stop(ctx)
 }
 
 func TestCancelLookups(t *testing.T) {


### PR DESCRIPTION
This test was triple-closing its Stopper. I don't think there was a
reason for this.

Release note: None