### PR TITLE
dev: bump to version 33

### DIFF
--- a/dev
+++ b/dev
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=32
+DEV_VERSION=33
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions


### PR DESCRIPTION
A recent commit [1] changed the bazel targets used by the ./dev command, but didn't upgrade the version of dev to force a recompile on all users' machines. Bump dev version to 33 to ensure everyone gets a clean copy.

[1] 5b6c271b1c (bazel: upgrade to rules_nodejs 5.4.2, 2022-05-17)

Release note: None