### PR TITLE
sql: add logictest config thats disables locality optimized search

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
+++ b/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
@@ -1,4 +1,4 @@
-# LogicTest: multiregion-9node-3region-3azs
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-no-los
 
 statement ok
 CREATE DATABASE alter_locality_test primary region "ca-central-1" regions "ap-southeast-2", "us-east-1"

--- a/pkg/ccl/logictestccl/testdata/logic_test/global_placement_restricted
+++ b/pkg/ccl/logictestccl/testdata/logic_test/global_placement_restricted
@@ -1,4 +1,4 @@
-# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-no-los
 
 statement ok
 SET enable_multiregion_placement_policy = true;

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -1,5 +1,5 @@
 # tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
-# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 query TTTT colnames
 SHOW REGIONS

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_backup
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_backup
@@ -1,4 +1,4 @@
-# LogicTest: multiregion-9node-3region-3azs
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-no-los
 
 # Tests in this file assume no multi-region tenant setup as tenants have no
 # access to nodelocal.

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_default_primary_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_default_primary_region
@@ -1,5 +1,5 @@
 # tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
-# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 statement ok
 SET CLUSTER SETTING sql.defaults.primary_region = "invalid-region-name";

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_drop_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_drop_region
@@ -1,5 +1,5 @@
 # tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
-# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 query TTTT
 SHOW REGIONS

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_import_export
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_import_export
@@ -1,4 +1,4 @@
-# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-no-los
 
 # Tests in this file assume no multi-region tenant setup as tenants have no
 # access to nodelocal.

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_privileges
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_privileges
@@ -1,5 +1,5 @@
 # tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
-# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 user root
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
@@ -1,4 +1,4 @@
-# LogicTest: multiregion-9node-3region-3azs
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-no-los
 # TODO(#75864): enable multiregion-9node-3region-3azs-tenant.
 
 # Set the closed timestamp interval to be short to shorten the amount of time
@@ -256,6 +256,7 @@ ALTER TABLE history INJECT STATISTICS '[
 
 # Regression test for #63735. Ensure that we choose locality optimized anti
 # joins for the foreign key checks.
+skipif config multiregion-9node-3region-3azs-no-los
 query T retry
 EXPLAIN INSERT
 INTO
@@ -338,6 +339,7 @@ INSERT INTO promos VALUES ('7fe2dce4-ecac-4d12-87b6-e1c1f837d835', 50, '{"some":
 INSERT INTO orders
   VALUES ('94e4b847-8f2f-4ac5-83f1-641d6e3df727', 100, '7fe2dce4-ecac-4d12-87b6-e1c1f837d835', '{"some": "info"}')
 
+skipif config multiregion-9node-3region-3azs-no-los
 query T nodeidx=3
 USE multi_region_test_db; EXPLAIN (DISTSQL) SELECT
     order_id, promo_id, price AS price_without_promo, price * discount AS price_with_promo
@@ -371,6 +373,7 @@ vectorized: true
 ·
 Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJysk9tO20wQx--_pxjNDQdtlPgACZaQjPhSGpQGmlC1UjeKjHcCW5Jdd3etpkK56rP1vSp7SUNQgwTthb2n-e_M72_PPdqvM0yw--myf9IbwO7_vdHV6H1_D0bdfvf0CrQRZCZSMCiMnuuHmcwJTkZ-Mvkm3a0u3aQOWJ3ug5A216Vym4E-Ct4ML975uy2cX_QG_nYLH0a9wRnsrnLtwce33WH3dxVwDDtHMcXXnbjd6EzDaSPO8oNGJ5oGjcM4EIcUiWk7bO8gQ6UFDbI5WUw-Y4xjhoXROVmrTbV1Xwf0xAKTFkOpitJV22OGuTaEyT066WaECV5l1zMaUibINFvIUJDL5Ky-1hOkfpgUd_QdGZ7qWTlXNtnwTua0thAZjoqsCmlyTDk2OXK-OIo5X1D1uu6ccb7oTJvnP39wvpgGgvNFINRxtWjvcGy2IFMCAtDulgyOlwx16dYI1mU3hEmwZK_DDP49ZgXUehXqVrxwK96aypKR2QxKVVdJYgNsvPyDDwPd0EUz3HSgL-fSQbC1lNZLnD7XUj0YHW2m8V2Q-mFldF_ru7KAL1oq0CqBNHrs_rotVw2HDIekBJkE0oBBGjFIw-rZTw-2AkQvARiSLbSy9MTMbdaMGZK4If9hrC5NTpdG53Uav7yodfWGIOv8aegXPVUf1f_yY3HwN-LwWXG0IW49FUfPiuMn4vHyv18BAAD__47ayRw=
 
+skipif config multiregion-9node-3region-3azs-no-los
 query T nodeidx=3
 USE multi_region_test_db; EXPLAIN (DISTSQL) SELECT
     order_id, promos.promo_id, price AS price_without_promo, price * discount AS price_with_promo

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_show
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_show
@@ -1,5 +1,5 @@
 # tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
-# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 statement ok
 CREATE DATABASE test_local_db

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -1,5 +1,5 @@
 # tenant-cluster-setting-override-opt: allow-zone-configs-for-secondary-tenants allow-multi-region-abstractions-for-secondary-tenants
-# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 query TTTT
 SHOW REGIONS

--- a/pkg/ccl/logictestccl/testdata/logic_test/placement
+++ b/pkg/ccl/logictestccl/testdata/logic_test/placement
@@ -1,4 +1,4 @@
-# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-no-los
 
 statement error PLACEMENT requires that the session setting enable_multiregion_placement_policy is enabled
 CREATE DATABASE no_cluster_setting PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1" PLACEMENT RESTRICTED

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -1,5 +1,5 @@
 # tenant-cluster-setting-override-opt: allow-zone-configs-for-secondary-tenants allow-multi-region-abstractions-for-secondary-tenants
-# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-tenant
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 statement ok
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_auto_rehoming
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_auto_rehoming
@@ -1,5 +1,5 @@
 # tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
-# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 statement ok
 SET experimental_enable_auto_rehoming = true;

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index
@@ -1,4 +1,4 @@
-# LogicTest: multiregion-9node-3region-3azs
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-no-los
 
 statement ok
 CREATE DATABASE multi_region_test_db PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1" SURVIVE REGION FAILURE

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_placement_restricted
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_placement_restricted
@@ -1,5 +1,5 @@
 # tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
-# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-tenant
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 statement ok
 SET enable_multiregion_placement_policy = true;

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_rename_column
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_rename_column
@@ -1,5 +1,5 @@
 # tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
-# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-tenant
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 # This test seems to flake (#60717).
 # It seems to hit the codepath:

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_table_placement_restricted
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_table_placement_restricted
@@ -1,5 +1,5 @@
 # tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
-# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-tenant
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 statement ok
 SET enable_multiregion_placement_policy = true;

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -568,6 +568,9 @@ type testClusterConfig struct {
 	// disableDeclarativeSchemaChanger will disable the declarative schema changer
 	// for logictest.
 	disableDeclarativeSchemaChanger bool
+	// disableLocalityOptimizedSearch disables the cluster setting
+	// locality_optimized_partitioned_index_scan, which is enabled by default.
+	disableLocalityOptimizedSearch bool
 }
 
 const queryRewritePlaceholderPrefix = "__async_query_rewrite_placeholder"
@@ -898,6 +901,12 @@ var logicTestConfigs = []testClusterConfig{
 		numNodes:          9,
 		localities:        multiregion9node3region3azsLocalities,
 		overrideVectorize: "off",
+	},
+	{
+		name:                           "multiregion-9node-3region-3azs-no-los",
+		numNodes:                       9,
+		localities:                     multiregion9node3region3azsLocalities,
+		disableLocalityOptimizedSearch: true,
 	},
 	{
 		name:       "multiregion-15node-5region-3azs",
@@ -1922,6 +1931,14 @@ func (t *logicTest) newCluster(
 		if cfg.disableDeclarativeSchemaChanger {
 			if _, err := conn.Exec(
 				"SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer='off'"); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		if cfg.disableLocalityOptimizedSearch {
+			if _, err := conn.Exec(
+				"SET CLUSTER SETTING sql.defaults.locality_optimized_partitioned_index_scan.enabled = false",
+			); err != nil {
 				t.Fatal(err)
 			}
 		}


### PR DESCRIPTION
This PR increases test coverage by disabling locality optimized search
for some tests. Locality optimized search is enabled by default.

Fixes: #73633

Release note: None