### PR TITLE
[POC] storage: make `cockroach debug keys` dump keys from L0 & above, to aid in understanding cause of LSM inversion

### DIFF
--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -278,6 +278,7 @@ type IterOptions struct {
 	// use such an iterator is to use it in concert with an iterator without
 	// timestamp hints, as done by MVCCIncrementalIterator.
 	MinTimestampHint, MaxTimestampHint hlc.Timestamp
+	NothingBelowL0                     bool
 	// useL6Filters allows the caller to opt into reading filter blocks for
 	// L6 sstables. Only for use with Prefix = true. Helpful if a lot of prefix
 	// Seeks are expected in quick succession, that are also likely to not

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -142,6 +142,7 @@ func (p *pebbleIterator) setOptions(opts IterOptions, durability DurabilityRequi
 	p.options = pebble.IterOptions{
 		OnlyReadGuaranteedDurable: durability == GuaranteedDurability,
 		UseL6Filters:              opts.useL6Filters,
+		NothingBelowL0:            opts.NothingBelowL0,
 	}
 	p.prefix = opts.Prefix
 


### PR DESCRIPTION
Discussion at https://github.com/cockroachdb/cockroach/issues/79101#issuecomment-1139875769. Code extremely POC-y. Just wanted to get something working locally.

Not sure a nice way to share a branch with changes to both CRDB & pebble, but here is the pebble diff:

```
~/g/s/g/c/cockroach [viz_l0] $ git diff --submodule=diff --patch
Submodule vendor contains modified content
diff --git a/vendor/github.com/cockroachdb/pebble/db.go b/vendor/github.com/cockroachdb/pebble/db.go
index d2f758dd21..0dbf4c1e67 100644
--- a/vendor/github.com/cockroachdb/pebble/db.go
+++ b/vendor/github.com/cockroachdb/pebble/db.go
@@ -942,14 +942,14 @@ func (d *DB) newIterInternal(batch *Batch, s *Snapshot, o *IterOptions) *Iterato
        if batch != nil {
                dbi.batchSeqNum = dbi.batch.nextSeqNum()
        }
-       return finishInitializingIter(buf)
+       return finishInitializingIter(buf, o)
 }
 
 // finishInitializingIter is a helper for doing the non-trivial initialization
 // of an Iterator. It's invoked to perform the initial initialization of an
 // Iterator during NewIter or Clone, and to perform reinitialization due to a
 // change in IterOptions by a call to Iterator.SetOptions.
-func finishInitializingIter(buf *iterAlloc) *Iterator {
+func finishInitializingIter(buf *iterAlloc, o *IterOptions) *Iterator {
        // Short-hand.
        dbi := &buf.dbi
        memtables := dbi.readState.memtables
@@ -971,7 +971,7 @@ func finishInitializingIter(buf *iterAlloc) *Iterator {
        // during a SetOptions call and this Iterator has already initialized
        // dbi.merging, constructPointIter returns the existing, unmodified point
        // iterator which is stored in dbi.pointIter.
-       dbi.iter = constructPointIter(dbi, dbi.batch, memtables, buf)
+       dbi.iter = constructPointIter(dbi, dbi.batch, memtables, buf, o)
 
        // If range keys are enabled, construct the range key iterator stack too.
        if dbi.opts.rangeKeys() {
@@ -999,7 +999,7 @@ func finishInitializingIter(buf *iterAlloc) *Iterator {
 }
 
 func constructPointIter(
-       dbi *Iterator, batch *Batch, memtables flushableList, buf *iterAlloc,
+       dbi *Iterator, batch *Batch, memtables flushableList, buf *iterAlloc, o *IterOptions,
 ) internalIteratorWithStats {
        if !dbi.opts.pointKeys() {
                return emptyIter
@@ -1025,12 +1025,14 @@ func constructPointIter(
        current := dbi.readState.current
        numMergingLevels += len(current.L0SublevelFiles)
        numLevelIters += len(current.L0SublevelFiles)
-       for level := 1; level < len(current.Levels); level++ {
-               if current.Levels[level].Empty() {
-                       continue
+       if !o.NothingBelowL0 {
+               for level := 1; level < len(current.Levels); level++ {
+                       if current.Levels[level].Empty() {
+                               continue
+                       }
+                       numMergingLevels++
+                       numLevelIters++
                }
-               numMergingLevels++
-               numLevelIters++
        }
 
        if numMergingLevels > cap(mlevels) {
@@ -1096,11 +1098,13 @@ func constructPointIter(
        }
 
        // Add level iterators for the non-empty non-L0 levels.
-       for level := 1; level < len(current.Levels); level++ {
-               if current.Levels[level].Empty() {
-                       continue
+       if !o.NothingBelowL0 {
+               for level := 1; level < len(current.Levels); level++ {
+                       if current.Levels[level].Empty() {
+                               continue
+                       }
+                       addLevelIterForFiles(current.Levels[level].Iter(), manifest.Level(level))
                }
-               addLevelIterForFiles(current.Levels[level].Iter(), manifest.Level(level))
        }
        buf.merging.init(&dbi.opts, dbi.cmp, dbi.split, mlevels...)
        buf.merging.snapshot = dbi.seqNum
@@ -1595,6 +1599,7 @@ func (d *DB) SSTables(opts ...SSTablesOption) ([][]SSTableInfo, error) {
                destLevels[i] = destTables[:j]
                destTables = destTables[j:]
        }
+       
        return destLevels, nil
 }
 
diff --git a/vendor/github.com/cockroachdb/pebble/iterator.go b/vendor/github.com/cockroachdb/pebble/iterator.go
index bfd6f438c9..470275fac1 100644
--- a/vendor/github.com/cockroachdb/pebble/iterator.go
+++ b/vendor/github.com/cockroachdb/pebble/iterator.go
@@ -1977,7 +1977,7 @@ func (i *Iterator) SetOptions(o *IterOptions) {
        // Even though this is not a positioning operation, the invalidation of the
        // iterator stack means we cannot optimize Seeks by using Next.
        i.invalidate()
-       finishInitializingIter(i.alloc)
+       finishInitializingIter(i.alloc, o)
 }
 
 func (i *Iterator) invalidate() {
@@ -2065,7 +2065,7 @@ func (i *Iterator) Clone() (*Iterator, error) {
                db:                  i.db,
        }
        dbi.saveBounds(i.opts.LowerBound, i.opts.UpperBound)
-       return finishInitializingIter(buf), nil
+       return finishInitializingIter(buf, &i.opts), nil
 }
 
 func (stats *IteratorStats) String() string {
diff --git a/vendor/github.com/cockroachdb/pebble/options.go b/vendor/github.com/cockroachdb/pebble/options.go
index f6b3891632..6a4fa118cc 100644
--- a/vendor/github.com/cockroachdb/pebble/options.go
+++ b/vendor/github.com/cockroachdb/pebble/options.go
@@ -163,6 +163,7 @@ type IterOptions struct {
        // existing is not low or if we just expect a one-time Seek (where loading the
        // data block directly is better).
        UseL6Filters bool
+       NothingBelowL0 bool
        // Internal options.
        logger Logger
        // Level corresponding to this file. Only passed in if constructed by a
diff --git a/vendor/github.com/cockroachdb/pebble/tool/db.go b/vendor/github.com/cockroachdb/pebble/tool/db.go
index 8295979f45..958b187b46 100644
--- a/vendor/github.com/cockroachdb/pebble/tool/db.go
+++ b/vendor/github.com/cockroachdb/pebble/tool/db.go
@@ -358,7 +358,7 @@ func (d *dbT) runLSM(cmd *cobra.Command, args []string) {
                return
        }
        defer d.closeDB(db)
-
+       
        fmt.Fprintf(stdout, "%s", db.Metrics())
 }
```