### PR TITLE
ui: fix when search contains *

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/highlightedText/highlightedText.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/highlightedText/highlightedText.tsx
@@ -15,7 +15,10 @@ import styles from "./highlightedText.module.scss";
 
 const cx = classNames.bind(styles);
 
-export function isStringIncludesArrayElement(arr: string[], text: string) {
+export function isStringIncludesArrayElement(
+  arr: string[],
+  text: string,
+): boolean {
   let includes = false;
   arr.forEach(val => {
     if (text.toLowerCase().includes(val.toLowerCase())) {
@@ -25,12 +28,12 @@ export function isStringIncludesArrayElement(arr: string[], text: string) {
   return includes;
 }
 
-export function getWordAt(word: string, text: string) {
+export function getWordAt(word: string, text: string): number {
   const regex = new RegExp("\\b" + word.toLowerCase() + "\\b");
   return text.toLowerCase().search(regex);
 }
 
-function rebaseText(text: string, highlight: string) {
+function rebaseText(text: string, highlight: string): string {
   const search = highlight.split(" ");
   const maxLength = 425;
   const defaultCropLength = 150;
@@ -83,6 +86,12 @@ export function getHighlightedText(
   const search = highlight
     .split(" ")
     .map(val => {
+      // When it's only a character we want to make sure to use the literal value (by adding []),
+      // this is added to handle cases where the highlighted term is a character used normally
+      // in regex, such as '*', '+', '?'
+      if (val.length == 1) {
+        return `[${val.toLowerCase()}]`;
+      }
       if (val.length > 0) {
         return val.toLowerCase();
       }


### PR DESCRIPTION
Previously, when searching for * on statement
and transaction pages, the pages would crash.
This commit fixes this issue by using the literal
value * during the regex for highlighting the text.

Fixes #81695

Release note (bug fix): Statement and Transaction pages no longer
crash when search term includes '*'.