### PR TITLE
release-22.1: backupccl: introduce BACKUP-LOCK file

### DIFF
--- a/pkg/ccl/backupccl/backup_destination_test.go
+++ b/pkg/ccl/backupccl/backup_destination_test.go
@@ -121,7 +121,7 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 					defaultDest, localitiesDest, err := getURIsByLocalityKV(to, "")
 					require.NoError(t, err)
 
-					collectionURI, defaultURI, chosenSuffix, urisByLocalityKV, prevBackupURIs, err := resolveDest(
+					backupDestination, err := resolveDest(
 						ctx, security.RootUserName(),
 						jobspb.BackupDetails_Destination{To: to},
 						endTime,
@@ -131,12 +131,12 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 					require.NoError(t, err)
 
 					// Not an INTO backup, so no collection of suffix info.
-					require.Equal(t, "", collectionURI)
-					require.Equal(t, "", chosenSuffix)
+					require.Equal(t, "", backupDestination.collectionURI)
+					require.Equal(t, "", backupDestination.chosenSubdir)
 
-					require.Equal(t, defaultDest, defaultURI)
-					require.Equal(t, localitiesDest, urisByLocalityKV)
-					require.Equal(t, incrementalFrom, prevBackupURIs)
+					require.Equal(t, defaultDest, backupDestination.defaultURI)
+					require.Equal(t, localitiesDest, backupDestination.urisByLocalityKV)
+					require.Equal(t, incrementalFrom, backupDestination.prevBackupURIs)
 				}
 
 				// The first initial full backup: BACKUP TO full.
@@ -188,7 +188,7 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 				) {
 					endTime := hlc.Timestamp{WallTime: backupTime.UnixNano()}
 
-					collectionURI, defaultURI, chosenSuffix, urisByLocalityKV, prevBackupURIs, err := resolveDest(
+					backupDestination, err := resolveDest(
 						ctx, security.RootUserName(),
 						jobspb.BackupDetails_Destination{To: to},
 						endTime,
@@ -198,11 +198,11 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 					require.NoError(t, err)
 
 					// Not a backup collection.
-					require.Equal(t, "", collectionURI)
-					require.Equal(t, "", chosenSuffix)
-					require.Equal(t, expectedDefault, defaultURI)
-					require.Equal(t, expectedLocalities, urisByLocalityKV)
-					require.Equal(t, expectedPrevBackups, prevBackupURIs)
+					require.Equal(t, "", backupDestination.collectionURI)
+					require.Equal(t, "", backupDestination.chosenSubdir)
+					require.Equal(t, expectedDefault, backupDestination.defaultURI)
+					require.Equal(t, expectedLocalities, backupDestination.urisByLocalityKV)
+					require.Equal(t, expectedPrevBackups, backupDestination.prevBackupURIs)
 				}
 
 				// Initial full backup: BACKUP TO baseDir.
@@ -348,7 +348,7 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 					if expectedIncDir != "" {
 						fullBackupExists = true
 					}
-					collectionURI, defaultURI, chosenSuffix, urisByLocalityKV, prevBackupURIs, err := resolveDest(
+					backupDestination, err := resolveDest(
 						ctx, security.RootUserName(),
 						jobspb.BackupDetails_Destination{To: collectionTo, Subdir: subdir,
 							IncrementalStorage: incrementalTo, Exists: fullBackupExists},
@@ -368,13 +368,13 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 						localityDests[locality] = u.String()
 					}
 
-					require.Equal(t, collectionLoc, collectionURI)
-					require.Equal(t, expectedSuffix, chosenSuffix)
+					require.Equal(t, collectionLoc, backupDestination.collectionURI)
+					require.Equal(t, expectedSuffix, backupDestination.chosenSubdir)
 
-					require.Equal(t, expectedDefault, defaultURI)
-					require.Equal(t, localityDests, urisByLocalityKV)
+					require.Equal(t, expectedDefault, backupDestination.defaultURI)
+					require.Equal(t, localityDests, backupDestination.urisByLocalityKV)
 
-					require.Equal(t, expectedPrevBackups, prevBackupURIs)
+					require.Equal(t, expectedPrevBackups, backupDestination.prevBackupURIs)
 				}
 
 				// Initial: BACKUP INTO collection

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1604,6 +1604,9 @@ func TestBackupRestoreResume(t *testing.T) {
 				}
 				createAndWaitForJob(
 					t, sqlDB, []descpb.ID{backupTableDesc.GetID()},
+					// We set the URI and HasLockedLocation to prevent the job from
+					// running the logic that resolves the backup destination. Since this
+					// is a "fake" job record, that step is bound to fail.
 					jobspb.BackupDetails{
 						EndTime: tc.Servers[0].Clock().Now(),
 						URI:     "nodelocal://0/backup" + "-" + item.testName,
@@ -3495,10 +3498,10 @@ func TestBackupTenantsWithRevisionHistory(t *testing.T) {
 
 	const msg = "can not backup tenants with revision history"
 
-	_, err = sqlDB.DB.ExecContext(ctx, `BACKUP TENANT 10 TO 'nodelocal://0/' WITH revision_history`)
+	_, err = sqlDB.DB.ExecContext(ctx, `BACKUP TENANT 10 TO 'nodelocal://0/foo' WITH revision_history`)
 	require.Contains(t, fmt.Sprint(err), msg)
 
-	_, err = sqlDB.DB.ExecContext(ctx, `BACKUP TO 'nodelocal://0/' WITH revision_history`)
+	_, err = sqlDB.DB.ExecContext(ctx, `BACKUP TO 'nodelocal://0/bar' WITH revision_history`)
 	require.Contains(t, fmt.Sprint(err), msg)
 }
 
@@ -4034,28 +4037,28 @@ func TestTimestampMismatch(t *testing.T) {
 		sqlDB.ExpectErr(
 			t, "backups listed out of order",
 			`BACKUP DATABASE data TO $1 INCREMENTAL FROM $2`,
-			localFoo, incrementalT1FromFull,
+			localFoo+"/missing-initial", incrementalT1FromFull,
 		)
 
 		// Missing an intermediate incremental backup.
 		sqlDB.ExpectErr(
 			t, "backups listed out of order",
 			`BACKUP DATABASE data TO $1 INCREMENTAL FROM $2, $3`,
-			localFoo, fullBackup, incrementalT2FromT1,
+			localFoo+"/missing-inc", fullBackup, incrementalT2FromT1,
 		)
 
 		// Backups specified out of order.
 		sqlDB.ExpectErr(
 			t, "out of order",
 			`BACKUP DATABASE data TO $1 INCREMENTAL FROM $2, $3`,
-			localFoo, incrementalT1FromFull, fullBackup,
+			localFoo+"/ooo", incrementalT1FromFull, fullBackup,
 		)
 
 		// Missing data for one table in the most recent backup.
 		sqlDB.ExpectErr(
 			t, "previous backup does not contain table",
 			`BACKUP DATABASE data TO $1 INCREMENTAL FROM $2, $3`,
-			localFoo, fullBackup, incrementalT3FromT1OneTable,
+			localFoo+"/missing-table-data", fullBackup, incrementalT3FromT1OneTable,
 		)
 	})
 
@@ -5947,7 +5950,7 @@ func TestProtectedTimestampsDuringBackup(t *testing.T) {
 
 		// Kickoff an incremental backup, but pause it just after it writes its
 		// protected timestamps.
-		runner.Exec(t, `SET CLUSTER SETTING jobs.debug.pausepoints = 'backup.before_flow'`)
+		runner.Exec(t, `SET CLUSTER SETTING jobs.debug.pausepoints = 'backup.before.flow'`)
 
 		var jobID int
 		runner.QueryRow(t,
@@ -6415,7 +6418,7 @@ func TestProtectedTimestampsFailDueToLimits(t *testing.T) {
 
 	// Creating the protected timestamp record should fail because there are too
 	// many spans. Ensure that we get the appropriate error.
-	_, err := db.Exec(`BACKUP TABLE foo, bar TO 'nodelocal://0/foo'`)
+	_, err := db.Exec(`BACKUP TABLE foo, bar TO 'nodelocal://0/foo/byte-limit'`)
 	require.EqualError(t, err, "pq: protectedts: limit exceeded: 0+30 > 1 bytes")
 
 	// TODO(adityamaru): Remove in 22.2 once no records protect spans.
@@ -6434,7 +6437,7 @@ func TestProtectedTimestampsFailDueToLimits(t *testing.T) {
 
 		// Creating the protected timestamp record should fail because there are too
 		// many spans. Ensure that we get the appropriate error.
-		_, err := db.Exec(`BACKUP TABLE foo, bar TO 'nodelocal://0/foo'`)
+		_, err := db.Exec(`BACKUP TABLE foo, bar TO 'nodelocal://0/foo/spans-limit'`)
 		require.EqualError(t, err, "pq: protectedts: limit exceeded: 0+2 > 1 spans")
 	})
 }
@@ -9270,7 +9273,7 @@ func TestExportRequestBelowGCThresholdOnDataExcludedFromBackup(t *testing.T) {
 		return nil
 	})
 
-	_, err = conn.Exec(fmt.Sprintf("BACKUP TABLE foo TO $1 AS OF SYSTEM TIME '%s'", tsBefore), localFoo)
+	_, err = conn.Exec(fmt.Sprintf("BACKUP TABLE foo TO $1 AS OF SYSTEM TIME '%s'", tsBefore), localFoo+"/fail")
 	testutils.IsError(err, "must be after replica GC threshold")
 
 	_, err = conn.Exec(`ALTER TABLE foo SET (exclude_data_from_backup = true)`)
@@ -9282,7 +9285,7 @@ func TestExportRequestBelowGCThresholdOnDataExcludedFromBackup(t *testing.T) {
 		return true, nil
 	})
 
-	_, err = conn.Exec(fmt.Sprintf("BACKUP TABLE foo TO $1 AS OF SYSTEM TIME '%s'", tsBefore), localFoo)
+	_, err = conn.Exec(fmt.Sprintf("BACKUP TABLE foo TO $1 AS OF SYSTEM TIME '%s'", tsBefore), localFoo+"/succeed")
 	require.NoError(t, err)
 }
 
@@ -9356,7 +9359,7 @@ func TestExcludeDataFromBackupDoesNotHoldupGC(t *testing.T) {
 		return true, nil
 	})
 
-	runner.Exec(t, `SET CLUSTER SETTING jobs.debug.pausepoints = 'backup.before_flow'`)
+	runner.Exec(t, `SET CLUSTER SETTING jobs.debug.pausepoints = 'backup.before.flow'`)
 	if _, err := conn.Exec(`BACKUP DATABASE test INTO $1`, localFoo); !testutils.IsError(err, "pause") {
 		t.Fatal(err)
 	}
@@ -9802,7 +9805,7 @@ func TestBackupTimestampedCheckpointsAreLexicographical(t *testing.T) {
 	numCheckpoints := 5
 
 	for i := 0; i < numCheckpoints; i++ {
-		checkpoints = append(checkpoints, newTimestampedCheckpointFileName())
+		checkpoints = append(checkpoints, newTimestampedFilename(backupManifestCheckpointName))
 		// Occasionally, we call newTimestampedCheckpointFileName() in succession
 		// too fast and the timestamp is the same. So wait for a moment to
 		// avoid that.

--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -263,6 +263,9 @@ func (d *datadrivenTestState) getSQLDB(t *testing.T, server string, user string)
 //
 //   Supported arguments:
 //
+//   + expect-error-regex=<regex>: expects the query to return an error with a string
+//   matching the provided regex
+//
 //   + expect-error-ignore: expects the query to return an error, but we will
 //   ignore it.
 //
@@ -277,8 +280,14 @@ func (d *datadrivenTestState) getSQLDB(t *testing.T, server string, user string)
 //
 //   Supported arguments:
 //
+//   + resume=<tag>: resumes the job referenced by the tag, use in conjunction
+//   with wait-for-state.
+//
 //   + cancel=<tag>: cancels the job referenced by the tag and waits for it to
 //   reach a CANCELED state.
+//
+//   + wait-for-state=<succeeded|paused|failed|cancelled> tag=<tag>: wait for
+//   the job referenced by the tag to reach the specified state.
 //
 // - "save-cluster-ts" tag=<tag>
 //   Saves the `SELECT cluster_logical_timestamp()` with the tag. Can be used
@@ -431,6 +440,17 @@ func TestDataDriven(t *testing.T) {
 				if d.HasArg("expect-error-ignore") {
 					require.NotNilf(t, err, "expected error")
 					ret = append(ret, "ignoring expected error")
+					return strings.Join(ret, "\n")
+				}
+
+				// Check if we are expecting an error, and want to match it against a
+				// regex.
+				if d.HasArg("expect-error-regex") {
+					require.NotNilf(t, err, "expected error")
+					var expectErrorRegex string
+					d.ScanArgs(t, "expect-error-regex", &expectErrorRegex)
+					testutils.IsError(err, expectErrorRegex)
+					ret = append(ret, "regex matches error")
 					return strings.Join(ret, "\n")
 				}
 
@@ -610,6 +630,39 @@ func TestDataDriven(t *testing.T) {
 					runner := sqlutils.MakeSQLRunner(ds.getSQLDB(t, server, user))
 					runner.Exec(t, `CANCEL JOB $1`, jobID)
 					jobutils.WaitForJobToCancel(t, runner, jobID)
+				} else if d.HasArg("resume") {
+					var resumeJobTag string
+					d.ScanArgs(t, "resume", &resumeJobTag)
+					var jobID jobspb.JobID
+					var ok bool
+					if jobID, ok = ds.jobTags[resumeJobTag]; !ok {
+						t.Fatalf("could not find job with tag %s", resumeJobTag)
+					}
+					runner := sqlutils.MakeSQLRunner(ds.getSQLDB(t, server, user))
+					runner.Exec(t, `RESUME JOB $1`, jobID)
+				} else if d.HasArg("wait-for-state") {
+					var tag string
+					d.ScanArgs(t, "tag", &tag)
+					var jobID jobspb.JobID
+					var ok bool
+					if jobID, ok = ds.jobTags[tag]; !ok {
+						t.Fatalf("could not find job with tag %s", tag)
+					}
+					runner := sqlutils.MakeSQLRunner(ds.getSQLDB(t, server, user))
+					var state string
+					d.ScanArgs(t, "wait-for-state", &state)
+					switch state {
+					case "succeeded":
+						jobutils.WaitForJobToSucceed(t, runner, jobID)
+					case "cancelled":
+						jobutils.WaitForJobToCancel(t, runner, jobID)
+					case "paused":
+						jobutils.WaitForJobToPause(t, runner, jobID)
+					case "failed":
+						jobutils.WaitForJobToFail(t, runner, jobID)
+					default:
+						t.Fatalf("unknown state %s", state)
+					}
 				}
 				return ""
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/lock-concurrent-backups
+++ b/pkg/ccl/backupccl/testdata/backup-restore/lock-concurrent-backups
@@ -1,0 +1,137 @@
+new-server name=s1
+----
+
+# Test that a backup job does not read its own lock file on resumption,
+# effectively locking itself out. We pause the job after it has written its
+# BACKUP-LOCK file and then resume it to ensure we don't read our own write.
+subtest backup-does-not-read-its-own-lock
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'backup.after.write_lock';
+----
+
+backup expect-pausepoint tag=a
+BACKUP INTO 'userfile://defaultdb.public.foo/foo';
+----
+job paused at pausepoint
+
+# The job should have written a `BACKUP-LOCK` file suffixed with a job ID and a
+# timestamp.
+query-sql
+SELECT regexp_replace(filename, '.*BACKUP-LOCK-[0-9]+$', 'BACKUP-LOCK') FROM defaultdb.public.foo_upload_files;
+----
+BACKUP-LOCK
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+# Resume the job and expect it to succeed.
+job resume=a
+----
+
+job tag=a wait-for-state=succeeded
+----
+
+subtest end
+
+
+# Test that a backup job on resume will not rewrite the `BACKUP-LOCK` file if it
+# already sees one, thus maintaining write-once semantics.
+subtest backup-lock-is-write-once
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'backup.before.write_first_checkpoint';
+----
+
+backup expect-pausepoint tag=b
+BACKUP INTO 'userfile://defaultdb.public.bar/bar';
+----
+job paused at pausepoint
+
+# The job should have written a `BACKUP-LOCK` file suffixed with a job ID and a
+# timestamp.
+query-sql
+SELECT regexp_replace(filename, '.*BACKUP-LOCK-[0-9]+$', 'BACKUP-LOCK') FROM defaultdb.public.bar_upload_files;
+----
+BACKUP-LOCK
+
+# Resume the job and expect it to pause again after writing `BACKUP-LOCK` again.
+job resume=b
+----
+
+job tag=b wait-for-state=paused
+----
+
+# We expect to see only one lock file since the resumed job would see the
+# previously written one.
+query-sql
+SELECT regexp_replace(filename, '.*BACKUP-LOCK-[0-9]+$', 'BACKUP-LOCK') FROM defaultdb.public.bar_upload_files;
+----
+BACKUP-LOCK
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+# Resume the job and expect it to succeed.
+job resume=b
+----
+
+job tag=b wait-for-state=succeeded
+----
+
+subtest end
+
+# Note, `BACKUP TO` is going away, and `BACKUP INTO` picks a timestamped
+# directory making it *impossible* for two backups to write to the same
+# directory in the future.
+#
+# Backup should fail if it sees a BACKUP_LOCK in the bucket.
+subtest backup-lock-file-prevents-concurrent-backups
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'backup.before.flow';
+----
+
+backup expect-pausepoint
+BACKUP TO 'userfile://defaultdb.public.baz/baz';
+----
+job paused at pausepoint
+
+exec-sql expect-error-regex='userfile://defaultdb.public.baz/baz already contains a `BACKUP-LOCK`'
+BACKUP TO 'userfile://defaultdb.public.baz/baz';
+----
+regex matches error
+
+subtest end
+
+# For mixed version compatability the backup job also checks for a
+# `BACKUP-CHECKPOINT` file when ensuring that there are no concurrent backups
+# writing to the same bucket.
+#
+# This test ensures that a backup job does not check for a `BACKUP-CHECKPOINT`
+# lock file after writing its own `BACKUP-CHECKPOINT`.
+subtest backup-does-not-read-its-own-checkpoint
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'backup.after.write_first_checkpoint';
+----
+
+backup expect-pausepoint tag=d
+BACKUP TO 'userfile://defaultdb.public.bat/bat';
+----
+job paused at pausepoint
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+# Resume the job and expect it to succeed.
+job resume=d
+----
+
+job tag=d wait-for-state=succeeded
+----
+
+subtest end

--- a/pkg/testutils/jobutils/jobs_verification.go
+++ b/pkg/testutils/jobutils/jobs_verification.go
@@ -50,6 +50,12 @@ func WaitForJobToCancel(t testing.TB, db *sqlutils.SQLRunner, jobID jobspb.JobID
 	waitForJobToHaveStatus(t, db, jobID, jobs.StatusCanceled)
 }
 
+// WaitForJobToFail waits for the specified job ID to be in a failed state.
+func WaitForJobToFail(t testing.TB, db *sqlutils.SQLRunner, jobID jobspb.JobID) {
+	t.Helper()
+	waitForJobToHaveStatus(t, db, jobID, jobs.StatusFailed)
+}
+
 func waitForJobToHaveStatus(
 	t testing.TB, db *sqlutils.SQLRunner, jobID jobspb.JobID, expectedStatus jobs.Status,
 ) {


### PR DESCRIPTION
Only one backup job is allowed to write to a backup location.
Prior to this change, the backup job would rely on the presence of
a BACKUP-CHECKPOINT file to know of the presence of a concurrent backup
job writing to the same location. This was problematic in subtle ways.

In 22.1, we moved backup destination resolution, and the writing of the
checkpoint file to the backup resumer. Before writing the checkpoint file we
would check if anyone else had laid claim to the loxation. Now, all operations
in a job resumer need to be idempotent because a job can be resumed an
arbittrary number of times, either due to transient errors or user intervention.
One can imagine (and we have seen more than once in recent roachtests)
a situation where a job:

1. Checks for other BACKUP-CHECKPOINT files in the location, but finds none.
2. Writes its own BACKUP-CHECKPOINT file.
3. Gets resumed before it gets to update BackupDetails to indicate it has
completed 1) and 2).

So, when the job repeats 1), it will now see its own BACKUP-CHECKPOINT
file and claim another backup is writing to the location, foolishly locking
itself out.

A similar situation can happen in a mixed version state where the node performs
1) and 2) during planning, and the planner txn retries.

Before we discuss the solution it is important to highlight the mixed
version states to consider:

1) Backups planned/executed by 21.2.x and 22.1.0 nodes will continue
to check BACKUP-CHECKPOINT files before laying claim to a location.

2) Backups planned/executed by 21.2.x and 22.1.0 nodes will continue
to write BACKUP-CHECKPOINT files as their way of claiming a location.

This change introduces a `BACKUP-LOCK` file that going forward will be
used to check and lay claim on a location. The `BACKUP-LOCK` file will
be suffixed with the jobID of the backup job. With this change a backup job will
check for the existence of `BACKUP-LOCK` files suffixed with a job ID other
than their own, before laying claim to a location. We continue to read
the BACKUP-CHECKPOINT file so as to respect the claim laid by backups
started on older binary nodes. Naturally, the job also continues to write
a BACKUP-CHECKPOINT file which prevents older nodes from starting concurrent
backups.

Fixes: https://github.com/cockroachdb/cockroach/issues/81808

Release note: None

Release justification: high impact change that prevents a backup from locking itself out of its own location