### PR TITLE
colexec: derive a tracing span in materializer when collecting stats

### DIFF
--- a/pkg/sql/colexec/materializer.go
+++ b/pkg/sql/colexec/materializer.go
@@ -265,7 +265,19 @@ func (m *Materializer) OutputTypes() []*types.T {
 
 // Start is part of the execinfra.RowSource interface.
 func (m *Materializer) Start(ctx context.Context) {
-	ctx = m.StartInternalNoSpan(ctx)
+	if len(m.drainHelper.statsCollectors) > 0 {
+		// Since we're collecting stats, we'll derive a separate tracing span
+		// for them. If we don't do this, then the stats would be attached to
+		// the span of the materializer's user, and if that user itself has a
+		// lot of payloads to attach (e.g. a joinReader attaching the KV keys it
+		// looked up), then the stats might be dropped based on the maximum size
+		// of structured payload per tracing span of 10KiB (see
+		// tracing.maxStructuredBytesPerSpan). Deriving a separate span
+		// guarantees that the stats won't be dropped.
+		ctx = m.StartInternal(ctx, "materializer" /* name */)
+	} else {
+		ctx = m.StartInternalNoSpan(ctx)
+	}
 	// We can encounter an expected error during Init (e.g. an operator
 	// attempts to allocate a batch, but the memory budget limit has been
 	// reached), so we need to wrap it with a catcher.
@@ -335,17 +347,22 @@ func (m *Materializer) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata
 }
 
 func (m *Materializer) close() {
-	if m.InternalClose() {
-		if m.Ctx == nil {
-			// In some edge cases (like when Init of an operator above this
-			// materializer encounters a panic), the materializer might never be
-			// started, yet it still will attempt to close its Closers. This
-			// context is only used for logging purposes, so it is ok to grab
-			// the background context in order to prevent a NPE below.
-			m.Ctx = context.Background()
-		}
-		m.closers.CloseAndLogOnErr(m.Ctx, "materializer")
+	if m.Closed {
+		return
 	}
+	if m.Ctx == nil {
+		// In some edge cases (like when Init of an operator above this
+		// materializer encounters a panic), the materializer might never be
+		// started, yet it still will attempt to close its Closers. This
+		// context is only used for logging purposes, so it is ok to grab
+		// the background context in order to prevent a NPE below.
+		m.Ctx = context.Background()
+	}
+	// Make sure to call InternalClose() only after closing the closers - this
+	// allows the closers to utilize the unfinished tracing span (if tracing is
+	// enabled).
+	m.closers.CloseAndLogOnErr(m.Ctx, "materializer")
+	m.InternalClose()
 }
 
 // ConsumerClosed is part of the execinfra.RowSource interface.

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1485,6 +1485,10 @@ type ExecutorTestingKnobs struct {
 	// to use a transaction, and, in doing so, more deterministically allocate
 	// descriptor IDs at the cost of decreased parallelism.
 	UseTransactionalDescIDGenerator bool
+
+	// NoStatsCollectionWithVerboseTracing is used to disable the execution
+	// statistics collection in presence of the verbose tracing.
+	NoStatsCollectionWithVerboseTracing bool
 }
 
 // PGWireTestingKnobs contains knobs for the pgwire module.

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -244,7 +244,7 @@ func (ih *instrumentationHelper) Setup(
 		statsCollector.ShouldSaveLogicalPlanDesc(fingerprint, implicitTxn, p.SessionData().Database)
 
 	if sp := tracing.SpanFromContext(ctx); sp != nil {
-		if sp.IsVerbose() {
+		if sp.IsVerbose() && !cfg.TestingKnobs.NoStatsCollectionWithVerboseTracing {
 			// If verbose tracing was enabled at a higher level, stats
 			// collection is enabled so that stats are shown in the traces, but
 			// no extra work is needed by the instrumentationHelper.

--- a/pkg/upgrade/upgrademanager/BUILD.bazel
+++ b/pkg/upgrade/upgrademanager/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/settings/cluster",
+        "//pkg/sql",
         "//pkg/sql/sqlutil",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",


### PR DESCRIPTION
If we don't do this, then the stats would be attached to the span of
the materializer's user, and if that user itself has a lot of
payloads to attach (e.g. a joinReader attaching the KV keys it looked
up), then the stats might be dropped based on the maximum size of
structured payload per tracing span of 10KiB (see
`tracing.maxStructuredBytesPerSpan`). Deriving a separate span
guarantees that the stats won't be dropped.

This required some changes to make a test - that makes too many
assumptions about tracing infra - work.

Release note: None