### PR TITLE
sql: fix the propagation of some scan stats in some cases

### DIFF
--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -161,12 +161,12 @@ func (s *ColBatchScan) GetRowsRead() int64 {
 
 // GetCumulativeContentionTime is part of the colexecop.KVReader interface.
 func (s *ColBatchScan) GetCumulativeContentionTime() time.Duration {
-	return execstats.GetCumulativeContentionTime(s.Ctx)
+	return execstats.GetCumulativeContentionTime(s.Ctx, nil /* recording */)
 }
 
 // GetScanStats is part of the colexecop.KVReader interface.
 func (s *ColBatchScan) GetScanStats() execstats.ScanStats {
-	return execstats.GetScanStats(s.Ctx)
+	return execstats.GetScanStats(s.Ctx, nil /* recording */)
 }
 
 var colBatchScanPool = sync.Pool{

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -437,7 +437,7 @@ func (s *ColIndexJoin) GetRowsRead() int64 {
 
 // GetCumulativeContentionTime is part of the colexecop.KVReader interface.
 func (s *ColIndexJoin) GetCumulativeContentionTime() time.Duration {
-	return execstats.GetCumulativeContentionTime(s.Ctx)
+	return execstats.GetCumulativeContentionTime(s.Ctx, nil /* recording */)
 }
 
 // inputBatchSizeLimit is a batch size limit for the number of input rows that
@@ -625,7 +625,7 @@ func adjustMemEstimate(estimate int64) int64 {
 
 // GetScanStats is part of the colexecop.KVReader interface.
 func (s *ColIndexJoin) GetScanStats() execstats.ScanStats {
-	return execstats.GetScanStats(s.Ctx)
+	return execstats.GetScanStats(s.Ctx, nil /* recording */)
 }
 
 // Release implements the execinfra.Releasable interface.

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -359,6 +359,14 @@ type ProcessorBaseNoHelper struct {
 	//
 	// Can return nil.
 	ExecStatsForTrace func() *execinfrapb.ComponentStats
+	// storeExecStatsTrace indicates whether ExecStatsTrace should be populated
+	// in InternalClose.
+	storeExecStatsTrace bool
+	// ExecStatsTrace stores the recording in case HijackExecStatsForTrace has
+	// been called. This is needed in order to provide the access to the
+	// recording after the span has been finished in InternalClose. Only set if
+	// storeExecStatsTrace is true.
+	ExecStatsTrace tracing.Recording
 	// trailingMetaCallback, if set, will be called by moveToTrailingMeta(). The
 	// callback is expected to close all inputs, do other cleanup on the processor
 	// (including calling InternalClose()) and generate the trailing meta that
@@ -607,9 +615,18 @@ var _ ExecStatsForTraceHijacker = &ProcessorBase{}
 
 // HijackExecStatsForTrace is a part of the ExecStatsForTraceHijacker interface.
 func (pb *ProcessorBase) HijackExecStatsForTrace() func() *execinfrapb.ComponentStats {
+	if pb.ExecStatsForTrace == nil {
+		return nil
+	}
 	execStatsForTrace := pb.ExecStatsForTrace
 	pb.ExecStatsForTrace = nil
-	return execStatsForTrace
+	pb.storeExecStatsTrace = true
+	return func() *execinfrapb.ComponentStats {
+		cs := execStatsForTrace()
+		// Make sure to unset the trace since we don't need it anymore.
+		pb.ExecStatsTrace = nil
+		return cs
+	}
 }
 
 // moveToTrailingMeta switches the processor to the "trailing meta" state: only
@@ -643,6 +660,9 @@ func (pb *ProcessorBaseNoHelper) moveToTrailingMeta() {
 		}
 		if trace := pb.span.GetConfiguredRecording(); trace != nil {
 			pb.trailingMeta = append(pb.trailingMeta, execinfrapb.ProducerMetadata{TraceData: trace})
+			if pb.storeExecStatsTrace {
+				pb.ExecStatsTrace = trace
+			}
 		}
 	}
 

--- a/pkg/sql/execstats/stats.go
+++ b/pkg/sql/execstats/stats.go
@@ -30,13 +30,13 @@ func ShouldCollectStats(ctx context.Context, collectStats bool) bool {
 }
 
 // GetCumulativeContentionTime is a helper function to calculate the cumulative
-// contention time from the tracing span from the context. All contention events
-// found in the trace are included.
-func GetCumulativeContentionTime(ctx context.Context) time.Duration {
+// contention time from the given recording or, if the recording is nil, from
+// the tracing span from the context. All contention events found in the trace
+// are included.
+func GetCumulativeContentionTime(ctx context.Context, recording tracing.Recording) time.Duration {
 	var cumulativeContentionTime time.Duration
-	recording := tracing.SpanFromContext(ctx).GetConfiguredRecording()
 	if recording == nil {
-		return cumulativeContentionTime
+		recording = tracing.SpanFromContext(ctx).GetConfiguredRecording()
 	}
 	var ev roachpb.ContentionEvent
 	for i := range recording {
@@ -81,12 +81,12 @@ func PopulateKVMVCCStats(kvStats *execinfrapb.KVStats, ss *ScanStats) {
 	kvStats.NumInternalSeeks = optional.MakeUint(ss.NumInternalSeeks)
 }
 
-// GetScanStats is a helper function to calculate scan stats from the tracing
-// span from the context.
-func GetScanStats(ctx context.Context) (ss ScanStats) {
-	recording := tracing.SpanFromContext(ctx).GetConfiguredRecording()
+// GetScanStats is a helper function to calculate scan stats from the given
+// recording or, if the recording is nil, from the tracing span from the
+// context.
+func GetScanStats(ctx context.Context, recording tracing.Recording) (ss ScanStats) {
 	if recording == nil {
-		return ScanStats{}
+		recording = tracing.SpanFromContext(ctx).GetConfiguredRecording()
 	}
 	var ev roachpb.ScanStats
 	for i := range recording {

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -760,14 +760,14 @@ func (ij *invertedJoiner) execStatsForTrace() *execinfrapb.ComponentStats {
 	if !ok {
 		return nil
 	}
-	ij.scanStats = execstats.GetScanStats(ij.Ctx)
+	ij.scanStats = execstats.GetScanStats(ij.Ctx, ij.ExecStatsTrace)
 	ret := execinfrapb.ComponentStats{
 		Inputs: []execinfrapb.InputStats{is},
 		KV: execinfrapb.KVStats{
 			BytesRead:      optional.MakeUint(uint64(ij.fetcher.GetBytesRead())),
 			TuplesRead:     fis.NumTuples,
 			KVTime:         fis.WaitTime,
-			ContentionTime: optional.MakeTimeValue(execstats.GetCumulativeContentionTime(ij.Ctx)),
+			ContentionTime: optional.MakeTimeValue(execstats.GetCumulativeContentionTime(ij.Ctx, ij.ExecStatsTrace)),
 		},
 		Exec: execinfrapb.ExecStats{
 			MaxAllocatedMem:  optional.MakeUint(uint64(ij.MemMonitor.MaximumBytes())),

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -1131,14 +1131,14 @@ func (jr *joinReader) execStatsForTrace() *execinfrapb.ComponentStats {
 		return nil
 	}
 
-	jr.scanStats = execstats.GetScanStats(jr.Ctx)
+	jr.scanStats = execstats.GetScanStats(jr.Ctx, jr.ExecStatsTrace)
 	ret := &execinfrapb.ComponentStats{
 		Inputs: []execinfrapb.InputStats{is},
 		KV: execinfrapb.KVStats{
 			BytesRead:      optional.MakeUint(uint64(jr.fetcher.GetBytesRead())),
 			TuplesRead:     fis.NumTuples,
 			KVTime:         fis.WaitTime,
-			ContentionTime: optional.MakeTimeValue(execstats.GetCumulativeContentionTime(jr.Ctx)),
+			ContentionTime: optional.MakeTimeValue(execstats.GetCumulativeContentionTime(jr.Ctx, jr.ExecStatsTrace)),
 		},
 		Output: jr.OutputHelper.Stats(),
 	}

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -307,13 +307,13 @@ func (tr *tableReader) execStatsForTrace() *execinfrapb.ComponentStats {
 	if !ok {
 		return nil
 	}
-	tr.scanStats = execstats.GetScanStats(tr.Ctx)
+	tr.scanStats = execstats.GetScanStats(tr.Ctx, tr.ExecStatsTrace)
 	ret := &execinfrapb.ComponentStats{
 		KV: execinfrapb.KVStats{
 			BytesRead:      optional.MakeUint(uint64(tr.fetcher.GetBytesRead())),
 			TuplesRead:     is.NumTuples,
 			KVTime:         is.WaitTime,
-			ContentionTime: optional.MakeTimeValue(execstats.GetCumulativeContentionTime(tr.Ctx)),
+			ContentionTime: optional.MakeTimeValue(execstats.GetCumulativeContentionTime(tr.Ctx, tr.ExecStatsTrace)),
 		},
 		Output: tr.OutputHelper.Stats(),
 	}

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -843,11 +843,11 @@ func (z *zigzagJoiner) ConsumerClosed() {
 
 // execStatsForTrace implements ProcessorBase.ExecStatsForTrace.
 func (z *zigzagJoiner) execStatsForTrace() *execinfrapb.ComponentStats {
-	z.scanStats = execstats.GetScanStats(z.Ctx)
+	z.scanStats = execstats.GetScanStats(z.Ctx, z.ExecStatsTrace)
 
 	kvStats := execinfrapb.KVStats{
 		BytesRead:      optional.MakeUint(uint64(z.getBytesRead())),
-		ContentionTime: optional.MakeTimeValue(execstats.GetCumulativeContentionTime(z.Ctx)),
+		ContentionTime: optional.MakeTimeValue(execstats.GetCumulativeContentionTime(z.Ctx, z.ExecStatsTrace)),
 	}
 	execstats.PopulateKVMVCCStats(&kvStats, &z.scanStats)
 	for i := range z.infos {


### PR DESCRIPTION
Previously, whenever a KV-reading row-by-row processor was wrapped
into a vectorized flow, during the execution stats collection we would
not get any scan stats (number of steps and seeks) nor the contention
time for that processor. This was due to a mismatch in how we collect
stats in the row-by-row and vectorized engines. Namely, the following
sequence would occur:
- `InternalClose` is called on the processor, which happens
automatically when the processor has been exhausted
- in that function, the tracing span would be finished
- later, we would call the hijacked `ExecStatsForTrace` function
- the implementations of that function would try to get a trace from the
context and would get nothing.

This issue is now fixed by storing the trace in `InternalClose` until
`ExecStatsForTrace` is called and using the stored trace in the
implementations rather than searching through the context.

Informs: #82156.

Release note: None