### PR TITLE
colexecspan: optimize some allocations

### DIFF
--- a/pkg/sql/colexec/colexecspan/span_assembler.go
+++ b/pkg/sql/colexec/colexecspan/span_assembler.go
@@ -37,7 +37,15 @@ func NewColSpanAssembler(
 	inputTypes []*types.T,
 ) ColSpanAssembler {
 	sa := spanAssemblerPool.Get().(*spanAssembler)
-	sa.colFamStartKeys, sa.colFamEndKeys = getColFamilyEncodings(splitFamilyIDs)
+	if len(splitFamilyIDs) > 0 {
+		sa.colFamStartKeys, sa.colFamEndKeys = getColFamilyEncodings(splitFamilyIDs)
+		for i := range sa.colFamStartKeys {
+			sa.colFamStartKeysTotalLength += len(sa.colFamStartKeys[i])
+		}
+		for i := range sa.colFamEndKeys {
+			sa.colFamEndKeysTotalLength += len(sa.colFamEndKeys[i])
+		}
+	}
 	keyPrefix := rowenc.MakeIndexKeyPrefix(codec, fetchSpec.TableID, fetchSpec.IndexID)
 	sa.scratchKey = append(sa.scratchKey[:0], keyPrefix...)
 	sa.prefixLength = len(keyPrefix)
@@ -142,6 +150,10 @@ type spanAssembler struct {
 	// possible to break a span into family scans (in which case these slices are
 	// empty).
 	colFamStartKeys, colFamEndKeys []roachpb.Key
+	// colFamStartKeysTotalLength and colFamEndKeysTotalLength contains the
+	// combined length of all keys in colFamStartKeys and colFamEndKeys,
+	// respectively.
+	colFamStartKeysTotalLength, colFamEndKeysTotalLength int
 }
 
 var _ ColSpanAssembler = (*spanAssembler)(nil)
@@ -170,12 +182,14 @@ func (sa *spanAssembler) ConsumeBatch(batch coldata.Batch, startIdx, endIdx int)
 				sa.scratchKey = append(sa.scratchKey, sa.spanCols[j].Get(i)...)
 			}
 			var span roachpb.Span
-			span.Key = make(roachpb.Key, 0, len(sa.scratchKey))
-			span.Key = append(span.Key, sa.scratchKey...)
+			span.Key = make(roachpb.Key, len(sa.scratchKey))
+			copy(span.Key, sa.scratchKey)
 			sa.keyBytes += len(span.Key)
-			span.EndKey = make(roachpb.Key, 0, len(sa.scratchKey)+1)
-			span.EndKey = append(span.EndKey, sa.scratchKey...)
-			span.EndKey = span.EndKey.PrefixEnd()
+			// span.Key cannot be empty (because it will at least contain the
+			// table ID and the index ID, so PrefixEnd() will definitely
+			// allocate a new slice; therefore, we don't have to preallocate any
+			// memory for span.EndKey.
+			span.EndKey = span.Key.PrefixEnd()
 			sa.keyBytes += len(span.EndKey)
 			sa.spans = append(sa.spans, span)
 		}
@@ -191,18 +205,24 @@ func (sa *spanAssembler) ConsumeBatch(batch coldata.Batch, startIdx, endIdx int)
 				// calculated and stored in an input column.
 				sa.scratchKey = append(sa.scratchKey, sa.spanCols[j].Get(i)...)
 			}
+			// Calculate how much space all start and end keys will take for
+			// this row.
+			keyAllocCap := len(sa.scratchKey)*(len(sa.colFamStartKeys)+len(sa.colFamEndKeys)) +
+				sa.colFamStartKeysTotalLength + sa.colFamEndKeysTotalLength
+			keyAlloc := make([]byte, keyAllocCap)
+			sa.keyBytes += keyAllocCap
 			for j := range sa.colFamStartKeys {
 				var span roachpb.Span
-				span.Key = make(roachpb.Key, 0, len(sa.scratchKey)+len(sa.colFamStartKeys[j]))
+				span.Key = keyAlloc[: 0 : len(sa.scratchKey)+len(sa.colFamStartKeys[j])]
+				keyAlloc = keyAlloc[len(sa.scratchKey)+len(sa.colFamStartKeys[j]):]
 				span.Key = append(span.Key, sa.scratchKey...)
 				span.Key = append(span.Key, sa.colFamStartKeys[j]...)
-				sa.keyBytes += len(span.Key)
 				// The end key may be nil, in which case the span is a point lookup.
 				if len(sa.colFamEndKeys[j]) > 0 {
-					span.EndKey = make(roachpb.Key, 0, len(sa.scratchKey)+len(sa.colFamEndKeys[j]))
+					span.EndKey = keyAlloc[: 0 : len(sa.scratchKey)+len(sa.colFamEndKeys[j])]
+					keyAlloc = keyAlloc[len(sa.scratchKey)+len(sa.colFamEndKeys[j]):]
 					span.EndKey = append(span.EndKey, sa.scratchKey...)
 					span.EndKey = append(span.EndKey, sa.colFamEndKeys[j]...)
-					sa.keyBytes += len(span.EndKey)
 				}
 				sa.spans = append(sa.spans, span)
 			}
@@ -277,12 +297,7 @@ func (sa *spanAssembler) Release() {
 // getColFamilyEncodings returns two lists of keys of the same length. Each pair
 // of keys at the same index corresponds to the suffixes of the start and end
 // keys of a span over a specific column family (or adjacent column families).
-// If the returned lists are empty, the spans cannot be split into separate
-// family spans.
 func getColFamilyEncodings(splitFamilyIDs []descpb.FamilyID) (startKeys, endKeys []roachpb.Key) {
-	if len(splitFamilyIDs) == 0 {
-		return nil, nil
-	}
 	for i, familyID := range splitFamilyIDs {
 		var key roachpb.Key
 		key = keys.MakeFamilyKey(key, uint32(familyID))


### PR DESCRIPTION
**bench: add benchmark of index joins on a table with two column families**

Release note: None

**colexecspan: optimize some allocations**

This commit pre-allocates a large byte slice for all column-family
specific spans for a single row, reducing the number of allocations. It
also removes an unnecessary allocation in a single-column family case
for `EndKey` - `PrefixEnd` itself already allocates memory.
```
name                                           old time/op    new time/op    delta
IndexJoinColumnFamilies/Cockroach-24             8.98ms ± 4%    8.96ms ± 3%    ~     (p=0.631 n=10+10)
IndexJoinColumnFamilies/MultinodeCockroach-24    12.3ms ± 4%    12.4ms ± 5%    ~     (p=0.971 n=10+10)

name                                           old alloc/op   new alloc/op   delta
IndexJoinColumnFamilies/Cockroach-24             1.72MB ± 1%    1.71MB ± 1%  -0.59%  (p=0.000 n=10+10)
IndexJoinColumnFamilies/MultinodeCockroach-24    2.58MB ± 1%    2.56MB ± 3%    ~     (p=0.218 n=10+10)

name                                           old allocs/op  new allocs/op  delta
IndexJoinColumnFamilies/Cockroach-24              13.9k ± 1%     12.9k ± 0%  -7.41%  (p=0.000 n=10+10)
IndexJoinColumnFamilies/MultinodeCockroach-24     19.6k ± 1%     18.6k ± 1%  -5.21%  (p=0.000 n=10+9)
```

Release note: None