### PR TITLE
storage: add MVCC point synthesizing iterator

### DIFF
--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "pebble_iterator.go",
         "pebble_merge.go",
         "pebble_mvcc_scanner.go",
+        "point_synthesizing_iter.go",
         "read_as_of_iterator.go",
         "replicas_storage.go",
         "resource_limiter.go",

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -69,7 +69,7 @@ import (
 // get            [t=<name>] [ts=<int>[,<int>]]                         [resolve [status=<txnstatus>]] k=<key> [inconsistent] [tombstones] [failOnMoreRecent] [localUncertaintyLimit=<int>[,<int>]] [globalUncertaintyLimit=<int>[,<int>]]
 // scan           [t=<name>] [ts=<int>[,<int>]]                         [resolve [status=<txnstatus>]] k=<key> [end=<key>] [inconsistent] [tombstones] [reverse] [failOnMoreRecent] [localUncertaintyLimit=<int>[,<int>]] [globalUncertaintyLimit=<int>[,<int>]] [max=<max>] [targetbytes=<target>] [avoidExcess] [allowEmpty]
 //
-// iter_new       [k=<key>] [end=<key>] [prefix] [kind=key|keyAndIntents] [types=pointsOnly|pointsWithRanges|pointsAndRanges|rangesOnly] [maskBelow=<int>[,<int>]]
+// iter_new       [k=<key>] [end=<key>] [prefix] [kind=key|keyAndIntents] [types=pointsOnly|pointsWithRanges|pointsAndRanges|rangesOnly] [pointSynthesis [emitOnSeekGE]] [maskBelow=<int>[,<int>]]
 // iter_seek_ge   k=<key> [ts=<int>[,<int>]]
 // iter_seek_lt   k=<key> [ts=<int>[,<int>]]
 // iter_seek_intent_ge k=<key> txn=<name>
@@ -1026,6 +1026,9 @@ func cmdIterNew(e *evalCtx) error {
 	e.iter = &iterWithCloseReader{
 		MVCCIterator: r.NewMVCCIterator(kind, opts),
 		closeReader:  closeReader,
+	}
+	if e.hasArg("pointSynthesis") {
+		e.iter = newPointSynthesizingIter(e.iter, e.hasArg("emitOnSeekGE"))
 	}
 	return nil
 }

--- a/pkg/storage/mvcc_key.go
+++ b/pkg/storage/mvcc_key.go
@@ -68,6 +68,12 @@ func (k MVCCKey) Next() MVCCKey {
 	}
 }
 
+// Clone returns a copy of the key.
+func (k MVCCKey) Clone() MVCCKey {
+	k.Key = k.Key.Clone()
+	return k
+}
+
 // Compare returns -1 if this key is less than the given key, 0 if they're
 // equal, or 1 if this is greater. Comparison is by key,timestamp, where larger
 // timestamps sort before smaller ones except empty ones which sort first (like

--- a/pkg/storage/point_synthesizing_iter.go
+++ b/pkg/storage/point_synthesizing_iter.go
@@ -1,0 +1,696 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package storage
+
+import (
+	"sort"
+	"sync"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/errors"
+)
+
+// pointSynthesizingIterPool reuses pointSynthesizingIters to avoid allocations.
+var pointSynthesizingIterPool = sync.Pool{
+	New: func() interface{} {
+		return &pointSynthesizingIter{}
+	},
+}
+
+// pointSynthesizingIter wraps an MVCCIterator, and synthesizes MVCC point keys
+// for MVCC range keys above/below existing point keys, and at the start of
+// range keys (truncated to iterator bounds). If emitOnSeekGE is set, it will
+// also unconditionally synthesize point keys around a SeekGE seek key if it
+// overlaps an MVCC range key.
+//
+// It does not emit MVCC range keys at all, since these would appear to conflict
+// with the synthesized point keys.
+//
+// During iteration, any range keys overlapping the current iterator position
+// are kept in rangeKeys. When atPoint is true, the iterator is positioned on a
+// real point key in the underlying iterator. Otherwise, it is positioned on a
+// synthetic point key given by rangeKeysPos and rangeKeys[rangeKeysIdx].
+//
+// The relative positioning of pointSynthesizingIter and the underlying iterator
+// is as follows in the forward direction:
+//
+// - atPoint=true: rangeKeysIdx points to a range key following the point key,
+//   or beyond the slice bounds when there are no further range keys at this
+//   key position.
+//
+// - atPoint=false: the underlying iterator is on a following key or exhausted.
+//   This can either be a different version of the current key or a different
+//   point/range key.
+//
+// This positioning is mirrored in the reverse direction. For example, when
+// atPoint=true and rangeKeys are exhausted, rangeKeysIdx will be len(rangeKeys)
+// in the forward direction and -1 in the reverse direction. Similarly, the
+// underlying iterator is always >= rangeKeysPos in the forward direction and <=
+// in reverse.
+//
+// See also assertInvariants() which asserts positioning invariants.
+type pointSynthesizingIter struct {
+	iter MVCCIterator
+
+	// rangeKeys contains any range keys that overlap the current key position,
+	// for which points will be synthesized.
+	rangeKeys []MVCCRangeKeyValue
+
+	// rangeKeysPos is the current key (along the rangeKeys span) that points will
+	// be synthesized for. It is only set if rangeKeys is non-empty, and may
+	// differ from the underlying iterator position.
+	rangeKeysPos roachpb.Key
+
+	// rangeKeysIdx is the rangeKeys index of the current/pending range key
+	// to synthesize a point for. See struct comment for details.
+	rangeKeysIdx int
+
+	// rangeKeysStart contains the start key of the current rangeKeys stack. It is
+	// only used to memoize rangeKeys for adjacent keys.
+	rangeKeysStart roachpb.Key
+
+	// atPoint is true if the synthesizing iterator is positioned on a real point
+	// key in the underlying iterator. See struct comment for details.
+	atPoint bool
+
+	// reverse is true when the current iterator direction is in reverse, i.e.
+	// following a SeekLT or Prev call.
+	reverse bool
+
+	// emitOnSeekGE will synthesize point keys for the SeekGE seek key if it
+	// overlaps with a range key even if no point key exists. The primary use-case
+	// is to synthesize point keys for e.g. an MVCCGet that does not match a point
+	// key but overlaps a range key, which is necessary for conflict checks.
+	//
+	// This is optional, because e.g. pebbleMVCCScanner often uses seeks as an
+	// optimization to skip over old versions of a key, and we don't want to keep
+	// synthesizing point keys every time it skips ahead.
+	//
+	// TODO(erikgrinaker): This could instead check for prefix iterators, or a
+	// separate SeekPrefixGE() method, but we don't currently have APIs for it.
+	emitOnSeekGE bool
+}
+
+var _ MVCCIterator = new(pointSynthesizingIter)
+
+// newPointSynthesizingIter creates a new pointSynthesizingIter, or gets one
+// from the pool.
+func newPointSynthesizingIter(parent MVCCIterator, emitOnSeekGE bool) *pointSynthesizingIter {
+	iter := pointSynthesizingIterPool.Get().(*pointSynthesizingIter)
+	*iter = pointSynthesizingIter{
+		iter:         parent,
+		emitOnSeekGE: emitOnSeekGE,
+		// Reuse pooled byte slices.
+		rangeKeysPos:   iter.rangeKeysPos,
+		rangeKeysStart: iter.rangeKeysStart,
+	}
+	return iter
+}
+
+// Close implements MVCCIterator.
+//
+// Close will also close the underlying iterator. Use release() to release it
+// back to the pool without closing the parent iterator.
+func (i *pointSynthesizingIter) Close() {
+	i.iter.Close()
+	i.release()
+}
+
+// release releases the iterator back into the pool.
+func (i *pointSynthesizingIter) release() {
+	*i = pointSynthesizingIter{
+		// Reuse byte slices.
+		rangeKeysPos:   i.rangeKeysPos[:0],
+		rangeKeysStart: i.rangeKeysStart[:0],
+	}
+	pointSynthesizingIterPool.Put(i)
+}
+
+// updateRangeKeys updates i.rangeKeys and related fields with range keys from
+// the underlying iterator. rangeKeysIdx is reset to the first/last range key.
+func (i *pointSynthesizingIter) updateRangeKeys() {
+	if _, hasRange := i.iter.HasPointAndRange(); hasRange {
+		i.rangeKeysPos = append(i.rangeKeysPos[:0], i.iter.UnsafeKey().Key...)
+		if rangeStart := i.iter.RangeBounds().Key; !rangeStart.Equal(i.rangeKeysStart) {
+			i.rangeKeysStart = append(i.rangeKeysStart[:0], rangeStart...)
+			i.rangeKeys = i.rangeKeys[:0]
+			for _, rk := range i.iter.RangeKeys() {
+				// TODO(erikgrinaker): We should optimize the clone cost.
+				i.rangeKeys = append(i.rangeKeys, rk.Clone())
+			}
+		}
+	} else if len(i.rangeKeys) != 0 {
+		i.rangeKeys = i.rangeKeys[:0]
+		i.rangeKeysPos = i.rangeKeysPos[:0]
+		i.rangeKeysStart = i.rangeKeysStart[:0]
+	}
+	if !i.reverse {
+		i.rangeKeysIdx = 0
+	} else {
+		i.rangeKeysIdx = len(i.rangeKeys) - 1 // NB: -1 is correct with no range keys
+	}
+}
+
+// clearRangeKeys resets the iterator by clearing out all range key state.
+// gcassert:inline
+func (i *pointSynthesizingIter) clearRangeKeys() {
+	if len(i.rangeKeys) != 0 {
+		i.rangeKeys = i.rangeKeys[:0]
+		i.rangeKeysPos = i.rangeKeysPos[:0]
+		i.rangeKeysStart = i.rangeKeysStart[:0]
+	}
+	if !i.reverse {
+		i.rangeKeysIdx = 0
+	} else {
+		i.rangeKeysIdx = -1
+	}
+}
+
+// updateAtPoint updates i.atPoint according to whether the synthesizing
+// iterator is positioned on the real point key in the underlying iterator.
+// Requires i.rangeKeys to have been positioned first.
+func (i *pointSynthesizingIter) updateAtPoint() {
+	if hasPoint, _ := i.iter.HasPointAndRange(); !hasPoint {
+		i.atPoint = false
+	} else if len(i.rangeKeys) == 0 {
+		i.atPoint = true
+	} else if point := i.iter.UnsafeKey(); !point.Key.Equal(i.rangeKeysPos) {
+		i.atPoint = false
+	} else if !i.reverse {
+		i.atPoint = i.rangeKeysIdx >= len(i.rangeKeys) ||
+			!point.Timestamp.IsSet() ||
+			i.rangeKeys[i.rangeKeysIdx].RangeKey.Timestamp.LessEq(point.Timestamp)
+	} else {
+		i.atPoint = i.rangeKeysIdx < 0 || (point.Timestamp.IsSet() &&
+			point.Timestamp.LessEq(i.rangeKeys[i.rangeKeysIdx].RangeKey.Timestamp))
+	}
+}
+
+// updatePosition updates the synthesizing iterator with the position of the
+// underlying iterator. This may step the underlying iterator to position it
+// correctly relative to bare range keys.
+func (i *pointSynthesizingIter) updatePosition() {
+	if hasPoint, hasRange := i.iter.HasPointAndRange(); !hasRange {
+		// Fast path: no range keys, so just clear range keys and bail out.
+		i.atPoint = hasPoint
+		i.clearRangeKeys()
+
+	} else if !i.reverse {
+		// If we're on a bare range key in the forward direction, we populate the
+		// range keys but then step iter ahead before updating the point position.
+		// The next position may be a point key with the same key as the current
+		// range key, which must be interleaved with the synthetic points.
+		i.updateRangeKeys()
+		if hasRange && !hasPoint {
+			i.iter.Next()
+		}
+		i.updateAtPoint()
+
+	} else {
+		// If we're on a bare range key in the reverse direction, and we've already
+		// emitted synthetic points for this key (as evidenced by rangeKeysPos),
+		// then we skip over the bare range key to avoid duplicates.
+		if hasRange && !hasPoint && i.iter.UnsafeKey().Key.Equal(i.rangeKeysPos) {
+			i.iter.Prev()
+		}
+		i.updateRangeKeys()
+		i.updateAtPoint()
+	}
+}
+
+// SeekGE implements MVCCIterator.
+func (i *pointSynthesizingIter) SeekGE(seekKey MVCCKey) {
+	i.reverse = false
+	i.iter.SeekGE(seekKey)
+
+	// Fast path: no range key, so just reset the iterator and bail out.
+	hasPoint, hasRange := i.iter.HasPointAndRange()
+	if !hasRange {
+		i.atPoint = hasPoint
+		i.clearRangeKeys()
+		return
+	}
+
+	// If we land in the middle of a bare range key and emitOnSeekGE is disabled,
+	// then skip over it to the next point/range key -- we're only supposed to
+	// synthesize at the range key start bound and at existing points.
+	//
+	// However, if we're seeking to a specific version and don't find an older
+	// point key at the seek key, then we also need to peek backwards for an
+	// existing point key above us, which would mandate that we synthesize point
+	// keys here after all.
+	//
+	// TODO(erikgrinaker): It might be faster to first do an unversioned seek to
+	// look for previous points and then a versioned seek. We can also omit this
+	// if there are no range keys below the seek timestamp.
+	//
+	// TODO(erikgrinaker): We could avoid this in the SeekGE case if we only
+	// synthesize points above existing points, except in the emitOnSeeGE case
+	// where no existing point exists. That could also result in fewer synthetic
+	// points overall. Do we need to synthesize older points?
+	var positioned bool
+	if !i.emitOnSeekGE && hasRange && !hasPoint &&
+		!i.iter.RangeBounds().Key.Equal(i.iter.UnsafeKey().Key) {
+		i.iter.Next()
+
+		if seekKey.Timestamp.IsSet() {
+			ok, err := i.iter.Valid()
+			if err == nil && (!ok || !seekKey.Key.Equal(i.iter.UnsafeKey().Key)) {
+				i.iter.Prev()
+				if hasP, _ := i.iter.HasPointAndRange(); hasP && seekKey.Key.Equal(i.iter.UnsafeKey().Key) {
+					i.updateRangeKeys()
+					positioned = true
+				}
+				i.iter.Next()
+			}
+		}
+		hasPoint, hasRange = i.iter.HasPointAndRange()
+	}
+
+	if !positioned {
+		i.updateRangeKeys()
+
+		// If we're now at a bare range key, we must either be at the start of it,
+		// or in the middle with emitOnSeekGE enabled. In either case, we want to
+		// move the iterator ahead to look for a point key with the same key as the
+		// start/seek key in order to interleave it.
+		if hasRange && !hasPoint {
+			i.iter.Next()
+		}
+	}
+
+	// If we're seeking to a specific version, skip newer range keys.
+	if len(i.rangeKeys) > 0 && seekKey.Timestamp.IsSet() && seekKey.Key.Equal(i.rangeKeysPos) {
+		i.rangeKeysIdx = sort.Search(len(i.rangeKeys), func(idx int) bool {
+			return i.rangeKeys[idx].RangeKey.Timestamp.LessEq(seekKey.Timestamp)
+		})
+	}
+
+	i.updateAtPoint()
+
+	// It's possible that we seeked past all of the range key versions. In this
+	// case, we have to reposition on the next key (current iter key).
+	if !i.atPoint && i.rangeKeysIdx >= len(i.rangeKeys) {
+		i.updatePosition()
+	}
+}
+
+// SeekIntentGE implements MVCCIterator.
+func (i *pointSynthesizingIter) SeekIntentGE(seekKey roachpb.Key, txnUUID uuid.UUID) {
+	i.reverse = false
+	i.iter.SeekIntentGE(seekKey, txnUUID)
+
+	// Fast path: no range key, so just reset the iterator and bail out.
+	hasPoint, hasRange := i.iter.HasPointAndRange()
+	if !hasRange {
+		i.atPoint = hasPoint
+		i.clearRangeKeys()
+		return
+	}
+
+	// If we land in the middle of a bare range key and emitOnSeekGE is disabled,
+	// then skip over it to the next point/range key.
+	if !i.emitOnSeekGE && hasRange && !hasPoint &&
+		!i.iter.RangeBounds().Key.Equal(i.iter.UnsafeKey().Key) {
+		i.iter.Next()
+	}
+
+	i.updatePosition()
+}
+
+// Next implements MVCCIterator.
+func (i *pointSynthesizingIter) Next() {
+	// When changing direction, flip the relative positioning with iter.
+	if i.reverse {
+		i.reverse = false
+		if !i.atPoint && len(i.rangeKeys) == 0 { // iterator was exhausted
+			i.iter.Next()
+			i.updatePosition()
+			return
+		} else if i.atPoint {
+			i.rangeKeysIdx++
+		} else {
+			i.iter.Next()
+		}
+	}
+
+	// Step off the current point, either real or synthetic.
+	if i.atPoint {
+		i.iter.Next()
+	} else {
+		i.rangeKeysIdx++
+	}
+	i.updateAtPoint()
+
+	// If we've exhausted the current range keys, update with the underlying
+	// iterator position (which must now be at a later key).
+	if !i.atPoint && i.rangeKeysIdx >= len(i.rangeKeys) {
+		i.updatePosition()
+	}
+}
+
+// NextKey implements MVCCIterator.
+func (i *pointSynthesizingIter) NextKey() {
+	// When changing direction, flip the relative positioning with iter.
+	//
+	// NB: This isn't really supported by the MVCCIterator interface, but we have
+	// best-effort handling in e.g. `pebbleIterator` and it's simple enough to
+	// implement, so we may as well.
+	if i.reverse {
+		i.reverse = false
+		if !i.atPoint {
+			i.iter.Next()
+		}
+	}
+	// Don't call NextKey() if the underlying iterator is already on the next key.
+	if i.atPoint || i.rangeKeysPos.Equal(i.iter.UnsafeKey().Key) {
+		i.iter.NextKey()
+	}
+	i.updatePosition()
+}
+
+// SeekLT implements MVCCIterator.
+func (i *pointSynthesizingIter) SeekLT(seekKey MVCCKey) {
+	i.reverse = true
+	i.iter.SeekLT(seekKey)
+
+	// Fast path: no range key, so just reset the iterator and bail out.
+	hasPoint, hasRange := i.iter.HasPointAndRange()
+	if !hasRange {
+		i.atPoint = hasPoint
+		i.clearRangeKeys()
+		return
+	}
+
+	// If we did a versioned seek and find a range key that overlaps the seek key,
+	// we may have skipped over existing point key versions of the seek key. These
+	// would mandate that we synthesize point keys for the seek key after all, so
+	// we peek ahead to check for them.
+	//
+	// TODO(erikgrinaker): It might be faster to do an unversioned seek from the
+	// next key first to look for points.
+	var positioned bool
+	if seekKey.Timestamp.IsSet() && hasRange &&
+		(!hasPoint || !i.iter.UnsafeKey().Key.Equal(seekKey.Key)) &&
+		seekKey.Key.Compare(i.iter.RangeBounds().EndKey) < 0 {
+		i.iter.Next()
+		if hasP, _ := i.iter.HasPointAndRange(); hasP && i.iter.UnsafeKey().Key.Equal(seekKey.Key) {
+			i.updateRangeKeys()
+			positioned = true
+		}
+		i.iter.Prev()
+	}
+
+	if !positioned {
+		i.updateRangeKeys()
+	}
+
+	// If we're seeking to a specific version, skip over older range keys.
+	if seekKey.Timestamp.IsSet() && seekKey.Key.Equal(i.rangeKeysPos) {
+		i.rangeKeysIdx = sort.Search(len(i.rangeKeys), func(idx int) bool {
+			return i.rangeKeys[idx].RangeKey.Timestamp.LessEq(seekKey.Timestamp)
+		}) - 1
+	}
+
+	i.updateAtPoint()
+
+	// It's possible that we seeked past all of the range key versions. In this
+	// case, we have to reposition on the previous key (current iter key).
+	if !i.atPoint && i.rangeKeysIdx < 0 {
+		i.updatePosition()
+	}
+}
+
+// Prev implements MVCCIterator.
+func (i *pointSynthesizingIter) Prev() {
+	// When changing direction, flip the relative positioning with iter.
+	if !i.reverse {
+		i.reverse = true
+		if !i.atPoint && len(i.rangeKeys) == 0 { // iterator was exhausted
+			i.iter.Prev()
+			i.updatePosition()
+			return
+		} else if i.atPoint {
+			i.rangeKeysIdx--
+		} else {
+			i.iter.Prev()
+		}
+	}
+
+	// Step off the current point key (real or synthetic).
+	if i.atPoint {
+		i.iter.Prev()
+	} else {
+		i.rangeKeysIdx--
+	}
+	i.updateAtPoint()
+
+	// If we've exhausted the current range keys, and we're not positioned on a
+	// point key at the current range key position, then update with the
+	// underlying iter position (which must be before the current key).
+	if i.rangeKeysIdx < 0 && (!i.atPoint || !i.rangeKeysPos.Equal(i.iter.UnsafeKey().Key)) {
+		i.updatePosition()
+	}
+}
+
+// Valid implements MVCCIterator.
+func (i *pointSynthesizingIter) Valid() (bool, error) {
+	if util.RaceEnabled {
+		if err := i.assertInvariants(); err != nil {
+			panic(err)
+		}
+	}
+	if !i.atPoint && i.rangeKeysIdx >= 0 && i.rangeKeysIdx < len(i.rangeKeys) {
+		return true, nil // on synthetic point key
+	}
+	return i.iter.Valid()
+}
+
+// Key implements MVCCIterator.
+func (i *pointSynthesizingIter) Key() MVCCKey {
+	return i.UnsafeKey().Clone()
+}
+
+// UnsafeKey implements MVCCIterator.
+func (i *pointSynthesizingIter) UnsafeKey() MVCCKey {
+	if i.atPoint {
+		return i.iter.UnsafeKey()
+	}
+	if i.rangeKeysIdx >= len(i.rangeKeys) || i.rangeKeysIdx < 0 {
+		return MVCCKey{}
+	}
+	return MVCCKey{
+		Key:       i.rangeKeysPos,
+		Timestamp: i.rangeKeys[i.rangeKeysIdx].RangeKey.Timestamp,
+	}
+}
+
+// UnsafeRawKey implements MVCCIterator.
+func (i *pointSynthesizingIter) UnsafeRawKey() []byte {
+	if i.atPoint {
+		return i.iter.UnsafeRawKey()
+	}
+	return EncodeMVCCKeyPrefix(i.rangeKeysPos)
+}
+
+// UnsafeRawMVCCKey implements MVCCIterator.
+func (i *pointSynthesizingIter) UnsafeRawMVCCKey() []byte {
+	if i.atPoint {
+		return i.iter.UnsafeRawMVCCKey()
+	}
+	return EncodeMVCCKey(i.UnsafeKey())
+}
+
+// Value implements MVCCIterator.
+func (i *pointSynthesizingIter) Value() []byte {
+	if v := i.UnsafeValue(); v != nil {
+		return append([]byte{}, v...)
+	}
+	return nil
+}
+
+// UnsafeValue implements MVCCIterator.
+func (i *pointSynthesizingIter) UnsafeValue() []byte {
+	if i.atPoint {
+		return i.iter.UnsafeValue()
+	}
+	if i.rangeKeysIdx >= len(i.rangeKeys) || i.rangeKeysIdx < 0 {
+		return nil
+	}
+	return i.rangeKeys[i.rangeKeysIdx].Value
+}
+
+// ValueProto implements MVCCIterator.
+func (i *pointSynthesizingIter) ValueProto(msg protoutil.Message) error {
+	return protoutil.Unmarshal(i.UnsafeValue(), msg)
+}
+
+// HasPointAndRange implements MVCCIterator.
+func (i *pointSynthesizingIter) HasPointAndRange() (bool, bool) {
+	ok, err := i.Valid()
+	return ok && err == nil, false
+}
+
+// RangeBounds implements MVCCIterator.
+func (i *pointSynthesizingIter) RangeBounds() roachpb.Span {
+	return roachpb.Span{}
+}
+
+// RangeKeys implements MVCCIterator.
+func (i *pointSynthesizingIter) RangeKeys() []MVCCRangeKeyValue {
+	return []MVCCRangeKeyValue{}
+}
+
+// ComputeStats implements MVCCIterator.
+func (i *pointSynthesizingIter) ComputeStats(
+	start, end roachpb.Key, nowNanos int64,
+) (enginepb.MVCCStats, error) {
+	return i.iter.ComputeStats(start, end, nowNanos)
+}
+
+// FindSplitKey implements MVCCIterator.
+func (i *pointSynthesizingIter) FindSplitKey(
+	start, end, minSplitKey roachpb.Key, targetSize int64,
+) (MVCCKey, error) {
+	return i.iter.FindSplitKey(start, end, minSplitKey, targetSize)
+}
+
+// Stats implements MVCCIterator.
+func (i *pointSynthesizingIter) Stats() IteratorStats {
+	return i.iter.Stats()
+}
+
+// SupportsPrev implements MVCCIterator.
+func (i *pointSynthesizingIter) SupportsPrev() bool {
+	return i.iter.SupportsPrev()
+}
+
+// assertInvariants asserts iterator invariants.
+func (i *pointSynthesizingIter) assertInvariants() error {
+	// If the underlying iterator has errored, make sure we're not positioned on a
+	// synthetic point such that Valid() will surface the error.
+	if _, err := i.iter.Valid(); err != nil {
+		if !i.atPoint && i.rangeKeysIdx >= 0 && i.rangeKeysIdx < len(i.rangeKeys) {
+			return errors.NewAssertionErrorWithWrappedErrf(err, "iterator error with synthetic point %s",
+				i.rangeKeysPos)
+		}
+		return nil
+	}
+
+	// When atPoint is true, the underlying iterator must be valid and on a point.
+	if i.atPoint {
+		if ok, _ := i.iter.Valid(); !ok {
+			return errors.AssertionFailedf("atPoint with invalid iter")
+		}
+		if hasPoint, _ := i.iter.HasPointAndRange(); !hasPoint {
+			return errors.AssertionFailedf("atPoint at non-point position %s", i.iter.UnsafeKey())
+		}
+	}
+
+	// rangeKeysIdx is never more than 1 outside of the slice bounds, and the
+	// excess depends on the direction: len(rangeKeys) in the forward direction,
+	// -1 in the reverse.
+	if i.rangeKeysIdx < 0 || i.rangeKeysIdx >= len(i.rangeKeys) {
+		if (!i.reverse && i.rangeKeysIdx != len(i.rangeKeys)) || (i.reverse && i.rangeKeysIdx != -1) {
+			return errors.AssertionFailedf("invalid rangeKeysIdx %d with length %d and reverse=%t",
+				i.rangeKeysIdx, len(i.rangeKeys), i.reverse)
+		}
+	}
+
+	// If rangeKeys is empty, atPoint is true unless exhausted and other state is
+	// cleared. In this case, there's nothing more to check.
+	if len(i.rangeKeys) == 0 {
+		if ok, _ := i.iter.Valid(); ok && !i.atPoint {
+			return errors.AssertionFailedf("no rangeKeys nor atPoint")
+		}
+		if len(i.rangeKeysPos) > 0 {
+			return errors.AssertionFailedf("no rangeKeys but rangeKeysPos %s", i.rangeKeysPos)
+		}
+		if len(i.rangeKeysStart) > 0 {
+			return errors.AssertionFailedf("no rangeKeys but rangeKeysStart %s", i.rangeKeysStart)
+		}
+		return nil
+	}
+
+	// rangeKeysStart must be set, and rangeKeysPos must be at or after it. This
+	// implies that rangeKeysPos must also be set.
+	if len(i.rangeKeysStart) == 0 {
+		return errors.AssertionFailedf("no rangeKeysStart at %s", i.iter.UnsafeKey())
+	}
+	if i.rangeKeysPos.Compare(i.rangeKeysStart) < 0 {
+		return errors.AssertionFailedf("rangeKeysPos %s not after rangeKeysStart %s",
+			i.rangeKeysPos, i.rangeKeysStart)
+	}
+
+	// rangeKeysIdx must be valid if we're not on a point.
+	if !i.atPoint && (i.rangeKeysIdx < 0 || i.rangeKeysIdx >= len(i.rangeKeys)) {
+		return errors.AssertionFailedf("not atPoint with invalid rangeKeysIdx %d at %s",
+			i.rangeKeysIdx, i.rangeKeysPos)
+	}
+
+	// If the underlying iterator is exhausted, then there's nothing more to
+	// check. We must either be on a synthetic point key or exhausted iterator.
+	if ok, _ := i.iter.Valid(); !ok {
+		return nil
+	}
+
+	// We now have range keys and a non-exhausted iterator. Check their relative
+	// positioning as minimum and maximum iter keys (in MVCC order). We can assume
+	// that overlapping range keys and point keys don't have the same timestamp,
+	// since this is enforced by MVCC mutations.
+	var minKey, maxKey MVCCKey
+
+	// The iterator should never lag behind the range key position.
+	if !i.reverse {
+		minKey = MVCCKey{Key: i.rangeKeysPos}
+	} else {
+		maxKey = MVCCKey{Key: i.rangeKeysPos, Timestamp: hlc.MinTimestamp}
+	}
+
+	// If we're not at a real point, then the iterator must be ahead of the
+	// current synthesized point. If we are on a point, then it must lie between
+	// the surrounding range keys (if they exist).
+	minIdx, maxIdx := -1, -1
+	if !i.atPoint {
+		if !i.reverse {
+			minIdx = i.rangeKeysIdx
+		} else {
+			maxIdx = i.rangeKeysIdx
+		}
+	} else if !i.reverse {
+		minIdx = i.rangeKeysIdx - 1
+		maxIdx = i.rangeKeysIdx
+	} else {
+		minIdx = i.rangeKeysIdx
+		maxIdx = i.rangeKeysIdx + 1
+	}
+	if minIdx >= 0 && minIdx < len(i.rangeKeys) {
+		minKey = MVCCKey{Key: i.rangeKeysPos, Timestamp: i.rangeKeys[minIdx].RangeKey.Timestamp}
+	}
+	if maxIdx >= 0 && maxIdx < len(i.rangeKeys) {
+		maxKey = MVCCKey{Key: i.rangeKeysPos, Timestamp: i.rangeKeys[maxIdx].RangeKey.Timestamp}
+	}
+
+	iterKey := i.iter.Key()
+	if minKey.Key != nil && iterKey.Compare(minKey) < 0 {
+		return errors.AssertionFailedf("iter %s below minimum key %s", iterKey, minKey)
+	}
+	if maxKey.Key != nil && iterKey.Compare(maxKey) > 0 {
+		return errors.AssertionFailedf("iter %s above maximum key %s", iterKey, maxKey)
+	}
+
+	return nil
+}

--- a/pkg/storage/testdata/mvcc_histories/range_key_point_synthesis
+++ b/pkg/storage/testdata/mvcc_histories/range_key_point_synthesis
@@ -1,0 +1,1042 @@
+# Tests pointSynthesizingIter.
+#
+# Sets up following dataset, where x is tombstone, o-o is range tombstone, [] is intent.
+#
+#  T
+#  7             [d7]                    [j7]
+#  6                      f6
+#  5          o---------------o               k5  o-----------o
+#  4  x   x       d4      f4  g4
+#  3      o-------o   e3  o-------oh3                     o---o
+#  2  a2                  f2  g2
+#  1  o-------------------o       o-----------o
+#     a   b   c   d   e   f   g   h   i   j   k   l   m   n   o   p
+#
+run ok
+put_rangekey k=a end=f ts=1
+put_rangekey k=h end=k ts=1
+put_rangekey k=b end=d ts=3
+put_rangekey k=n end=o ts=3
+put_rangekey k=l end=o ts=5
+put k=a ts=2 v=a2
+del k=a ts=4
+del k=b ts=4
+put k=d ts=4 v=d4
+put k=e ts=3 v=e3
+put k=f ts=2 v=f2
+put k=g ts=2 v=g2
+put_rangekey k=f end=h ts=3 localTs=4
+put k=f ts=4 v=f4
+put k=f ts=6 v=f6
+put k=g ts=4 v=g4
+put_rangekey k=c end=g ts=5
+put k=h ts=3 v=h3
+put k=k ts=5 v=k5
+with t=A
+  txn_begin ts=7
+  put k=d v=d7
+  put k=j v=j7
+----
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=vheader{ localTs=4.000000000,0 } /<empty>]
+rangekey: {g-h}/[3.000000000,0=vheader{ localTs=4.000000000,0 } /<empty>]
+rangekey: {h-k}/[1.000000000,0=/<empty>]
+rangekey: {l-n}/[5.000000000,0=/<empty>]
+rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+meta: "d"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "d"/7.000000000,0 -> /BYTES/d7
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /BYTES/g4
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/3.000000000,0 -> /BYTES/h3
+meta: "j"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "j"/7.000000000,0 -> /BYTES/j7
+data: "k"/5.000000000,0 -> /BYTES/k5
+
+# Iterate across the entire span, forward and reverse.
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/4.000000000,0=/<empty>
+iter_scan: "a"/4.000000000,0=/<empty>
+iter_scan: "a"/2.000000000,0=/BYTES/a2
+iter_scan: "a"/1.000000000,0=/<empty>
+iter_scan: "b"/4.000000000,0=/<empty>
+iter_scan: "b"/3.000000000,0=/<empty>
+iter_scan: "b"/1.000000000,0=/<empty>
+iter_scan: "c"/5.000000000,0=/<empty>
+iter_scan: "c"/3.000000000,0=/<empty>
+iter_scan: "c"/1.000000000,0=/<empty>
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "d"/7.000000000,0=/BYTES/d7
+iter_scan: "d"/5.000000000,0=/<empty>
+iter_scan: "d"/4.000000000,0=/BYTES/d4
+iter_scan: "d"/1.000000000,0=/<empty>
+iter_scan: "e"/5.000000000,0=/<empty>
+iter_scan: "e"/3.000000000,0=/BYTES/e3
+iter_scan: "e"/1.000000000,0=/<empty>
+iter_scan: "f"/6.000000000,0=/BYTES/f6
+iter_scan: "f"/5.000000000,0=/<empty>
+iter_scan: "f"/4.000000000,0=/BYTES/f4
+iter_scan: "f"/3.000000000,0=vheader{ localTs=4.000000000,0 } /<empty>
+iter_scan: "f"/2.000000000,0=/BYTES/f2
+iter_scan: "g"/4.000000000,0=/BYTES/g4
+iter_scan: "g"/3.000000000,0=vheader{ localTs=4.000000000,0 } /<empty>
+iter_scan: "g"/2.000000000,0=/BYTES/g2
+iter_scan: "h"/3.000000000,0=/BYTES/h3
+iter_scan: "h"/1.000000000,0=/<empty>
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "j"/7.000000000,0=/BYTES/j7
+iter_scan: "j"/1.000000000,0=/<empty>
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "l"/5.000000000,0=/<empty>
+iter_scan: "n"/5.000000000,0=/<empty>
+iter_scan: "n"/3.000000000,0=/<empty>
+iter_scan: .
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=z
+iter_scan reverse
+----
+iter_seek_lt: "n"/3.000000000,0=/<empty>
+iter_scan: "n"/3.000000000,0=/<empty>
+iter_scan: "n"/5.000000000,0=/<empty>
+iter_scan: "l"/5.000000000,0=/<empty>
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "j"/1.000000000,0=/<empty>
+iter_scan: "j"/7.000000000,0=/BYTES/j7
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "h"/1.000000000,0=/<empty>
+iter_scan: "h"/3.000000000,0=/BYTES/h3
+iter_scan: "g"/2.000000000,0=/BYTES/g2
+iter_scan: "g"/3.000000000,0=vheader{ localTs=4.000000000,0 } /<empty>
+iter_scan: "g"/4.000000000,0=/BYTES/g4
+iter_scan: "f"/2.000000000,0=/BYTES/f2
+iter_scan: "f"/3.000000000,0=vheader{ localTs=4.000000000,0 } /<empty>
+iter_scan: "f"/4.000000000,0=/BYTES/f4
+iter_scan: "f"/5.000000000,0=/<empty>
+iter_scan: "f"/6.000000000,0=/BYTES/f6
+iter_scan: "e"/1.000000000,0=/<empty>
+iter_scan: "e"/3.000000000,0=/BYTES/e3
+iter_scan: "e"/5.000000000,0=/<empty>
+iter_scan: "d"/1.000000000,0=/<empty>
+iter_scan: "d"/4.000000000,0=/BYTES/d4
+iter_scan: "d"/5.000000000,0=/<empty>
+iter_scan: "d"/7.000000000,0=/BYTES/d7
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "c"/1.000000000,0=/<empty>
+iter_scan: "c"/3.000000000,0=/<empty>
+iter_scan: "c"/5.000000000,0=/<empty>
+iter_scan: "b"/1.000000000,0=/<empty>
+iter_scan: "b"/3.000000000,0=/<empty>
+iter_scan: "b"/4.000000000,0=/<empty>
+iter_scan: "a"/1.000000000,0=/<empty>
+iter_scan: "a"/2.000000000,0=/BYTES/a2
+iter_scan: "a"/4.000000000,0=/<empty>
+iter_scan: .
+
+# Iterate across the entire span using NextKey().
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=a
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+----
+iter_seek_ge: "a"/4.000000000,0=/<empty>
+iter_next_key: "b"/4.000000000,0=/<empty>
+iter_next_key: "c"/5.000000000,0=/<empty>
+iter_next_key: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next_key: "e"/5.000000000,0=/<empty>
+iter_next_key: "f"/6.000000000,0=/BYTES/f6
+iter_next_key: "g"/4.000000000,0=/BYTES/g4
+iter_next_key: "h"/3.000000000,0=/BYTES/h3
+iter_next_key: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next_key: "k"/5.000000000,0=/BYTES/k5
+iter_next_key: "l"/5.000000000,0=/<empty>
+iter_next_key: "n"/5.000000000,0=/<empty>
+iter_next_key: .
+
+# Unversioned seeks.
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=a
+iter_seek_ge k=b
+iter_seek_ge k=c
+iter_seek_ge k=d
+iter_seek_ge k=e
+iter_seek_ge k=f
+iter_seek_ge k=g
+iter_seek_ge k=h
+iter_seek_ge k=i
+iter_seek_ge k=j
+iter_seek_ge k=k
+iter_seek_ge k=l
+iter_seek_ge k=m
+iter_seek_ge k=n
+iter_seek_ge k=o
+----
+iter_seek_ge: "a"/4.000000000,0=/<empty>
+iter_seek_ge: "b"/4.000000000,0=/<empty>
+iter_seek_ge: "c"/5.000000000,0=/<empty>
+iter_seek_ge: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_ge: "e"/5.000000000,0=/<empty>
+iter_seek_ge: "f"/6.000000000,0=/BYTES/f6
+iter_seek_ge: "g"/4.000000000,0=/BYTES/g4
+iter_seek_ge: "h"/3.000000000,0=/BYTES/h3
+iter_seek_ge: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_ge: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_ge: "k"/5.000000000,0=/BYTES/k5
+iter_seek_ge: "l"/5.000000000,0=/<empty>
+iter_seek_ge: "n"/5.000000000,0=/<empty>
+iter_seek_ge: "n"/5.000000000,0=/<empty>
+iter_seek_ge: .
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis emitOnSeekGE
+iter_seek_ge k=a
+iter_seek_ge k=b
+iter_seek_ge k=c
+iter_seek_ge k=d
+iter_seek_ge k=e
+iter_seek_ge k=f
+iter_seek_ge k=g
+iter_seek_ge k=h
+iter_seek_ge k=i
+iter_seek_ge k=j
+iter_seek_ge k=k
+iter_seek_ge k=l
+iter_seek_ge k=m
+iter_seek_ge k=n
+iter_seek_ge k=o
+----
+iter_seek_ge: "a"/4.000000000,0=/<empty>
+iter_seek_ge: "b"/4.000000000,0=/<empty>
+iter_seek_ge: "c"/5.000000000,0=/<empty>
+iter_seek_ge: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_ge: "e"/5.000000000,0=/<empty>
+iter_seek_ge: "f"/6.000000000,0=/BYTES/f6
+iter_seek_ge: "g"/4.000000000,0=/BYTES/g4
+iter_seek_ge: "h"/3.000000000,0=/BYTES/h3
+iter_seek_ge: "i"/1.000000000,0=/<empty>
+iter_seek_ge: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_ge: "k"/5.000000000,0=/BYTES/k5
+iter_seek_ge: "l"/5.000000000,0=/<empty>
+iter_seek_ge: "m"/5.000000000,0=/<empty>
+iter_seek_ge: "n"/5.000000000,0=/<empty>
+iter_seek_ge: .
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=o
+iter_seek_lt k=n
+iter_seek_lt k=m
+iter_seek_lt k=l
+iter_seek_lt k=k
+iter_seek_lt k=j
+iter_seek_lt k=i
+iter_seek_lt k=h
+iter_seek_lt k=g
+iter_seek_lt k=f
+iter_seek_lt k=e
+iter_seek_lt k=d
+iter_seek_lt k=c
+iter_seek_lt k=b
+iter_seek_lt k=a
+----
+iter_seek_lt: "n"/3.000000000,0=/<empty>
+iter_seek_lt: "l"/5.000000000,0=/<empty>
+iter_seek_lt: "l"/5.000000000,0=/<empty>
+iter_seek_lt: "k"/5.000000000,0=/BYTES/k5
+iter_seek_lt: "j"/1.000000000,0=/<empty>
+iter_seek_lt: "h"/1.000000000,0=/<empty>
+iter_seek_lt: "h"/1.000000000,0=/<empty>
+iter_seek_lt: "g"/2.000000000,0=/BYTES/g2
+iter_seek_lt: "f"/2.000000000,0=/BYTES/f2
+iter_seek_lt: "e"/1.000000000,0=/<empty>
+iter_seek_lt: "d"/1.000000000,0=/<empty>
+iter_seek_lt: "c"/1.000000000,0=/<empty>
+iter_seek_lt: "b"/1.000000000,0=/<empty>
+iter_seek_lt: "a"/1.000000000,0=/<empty>
+iter_seek_lt: .
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_intent_ge k=a txn=A
+iter_seek_intent_ge k=b txn=A
+iter_seek_intent_ge k=c txn=A
+iter_seek_intent_ge k=d txn=A
+iter_seek_intent_ge k=e txn=A
+iter_seek_intent_ge k=f txn=A
+iter_seek_intent_ge k=g txn=A
+iter_seek_intent_ge k=h txn=A
+iter_seek_intent_ge k=i txn=A
+iter_seek_intent_ge k=j txn=A
+iter_seek_intent_ge k=k txn=A
+iter_seek_intent_ge k=l txn=A
+iter_seek_intent_ge k=m txn=A
+iter_seek_intent_ge k=n txn=A
+iter_seek_intent_ge k=o txn=A
+----
+iter_seek_intent_ge: "a"/4.000000000,0=/<empty>
+iter_seek_intent_ge: "b"/4.000000000,0=/<empty>
+iter_seek_intent_ge: "c"/5.000000000,0=/<empty>
+iter_seek_intent_ge: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_intent_ge: "e"/5.000000000,0=/<empty>
+iter_seek_intent_ge: "f"/6.000000000,0=/BYTES/f6
+iter_seek_intent_ge: "g"/4.000000000,0=/BYTES/g4
+iter_seek_intent_ge: "h"/3.000000000,0=/BYTES/h3
+iter_seek_intent_ge: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_intent_ge: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_intent_ge: "k"/5.000000000,0=/BYTES/k5
+iter_seek_intent_ge: "l"/5.000000000,0=/<empty>
+iter_seek_intent_ge: "n"/5.000000000,0=/<empty>
+iter_seek_intent_ge: "n"/5.000000000,0=/<empty>
+iter_seek_intent_ge: .
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis emitOnSeekGE
+iter_seek_intent_ge k=a txn=A
+iter_seek_intent_ge k=b txn=A
+iter_seek_intent_ge k=c txn=A
+iter_seek_intent_ge k=d txn=A
+iter_seek_intent_ge k=e txn=A
+iter_seek_intent_ge k=f txn=A
+iter_seek_intent_ge k=g txn=A
+iter_seek_intent_ge k=h txn=A
+iter_seek_intent_ge k=i txn=A
+iter_seek_intent_ge k=j txn=A
+iter_seek_intent_ge k=k txn=A
+iter_seek_intent_ge k=l txn=A
+iter_seek_intent_ge k=m txn=A
+iter_seek_intent_ge k=n txn=A
+iter_seek_intent_ge k=o txn=A
+----
+iter_seek_intent_ge: "a"/4.000000000,0=/<empty>
+iter_seek_intent_ge: "b"/4.000000000,0=/<empty>
+iter_seek_intent_ge: "c"/5.000000000,0=/<empty>
+iter_seek_intent_ge: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_intent_ge: "e"/5.000000000,0=/<empty>
+iter_seek_intent_ge: "f"/6.000000000,0=/BYTES/f6
+iter_seek_intent_ge: "g"/4.000000000,0=/BYTES/g4
+iter_seek_intent_ge: "h"/3.000000000,0=/BYTES/h3
+iter_seek_intent_ge: "i"/1.000000000,0=/<empty>
+iter_seek_intent_ge: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_intent_ge: "k"/5.000000000,0=/BYTES/k5
+iter_seek_intent_ge: "l"/5.000000000,0=/<empty>
+iter_seek_intent_ge: "m"/5.000000000,0=/<empty>
+iter_seek_intent_ge: "n"/5.000000000,0=/<empty>
+iter_seek_intent_ge: .
+
+# Versioned seeks.
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=a ts=5
+iter_seek_ge k=a ts=4
+iter_seek_ge k=a ts=3
+iter_seek_ge k=a ts=2
+iter_seek_ge k=a ts=1
+----
+iter_seek_ge: "a"/4.000000000,0=/<empty>
+iter_seek_ge: "a"/4.000000000,0=/<empty>
+iter_seek_ge: "a"/2.000000000,0=/BYTES/a2
+iter_seek_ge: "a"/2.000000000,0=/BYTES/a2
+iter_seek_ge: "a"/1.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=b ts=5
+iter_seek_ge k=b ts=4
+iter_seek_ge k=b ts=3
+iter_seek_ge k=b ts=2
+iter_seek_ge k=b ts=1
+----
+iter_seek_ge: "b"/4.000000000,0=/<empty>
+iter_seek_ge: "b"/4.000000000,0=/<empty>
+iter_seek_ge: "b"/3.000000000,0=/<empty>
+iter_seek_ge: "b"/1.000000000,0=/<empty>
+iter_seek_ge: "b"/1.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=c ts=6
+iter_seek_ge k=c ts=5
+iter_seek_ge k=c ts=4
+iter_seek_ge k=c ts=3
+iter_seek_ge k=c ts=2
+iter_seek_ge k=c ts=1
+----
+iter_seek_ge: "c"/5.000000000,0=/<empty>
+iter_seek_ge: "c"/5.000000000,0=/<empty>
+iter_seek_ge: "c"/3.000000000,0=/<empty>
+iter_seek_ge: "c"/3.000000000,0=/<empty>
+iter_seek_ge: "c"/1.000000000,0=/<empty>
+iter_seek_ge: "c"/1.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=d ts=0
+iter_seek_ge k=d ts=8
+iter_seek_ge k=d ts=7
+iter_seek_ge k=d ts=6
+iter_seek_ge k=d ts=5
+iter_seek_ge k=d ts=4
+iter_seek_ge k=d ts=3
+iter_seek_ge k=d ts=2
+iter_seek_ge k=d ts=1
+----
+iter_seek_ge: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_ge: "d"/7.000000000,0=/BYTES/d7
+iter_seek_ge: "d"/7.000000000,0=/BYTES/d7
+iter_seek_ge: "d"/5.000000000,0=/<empty>
+iter_seek_ge: "d"/5.000000000,0=/<empty>
+iter_seek_ge: "d"/4.000000000,0=/BYTES/d4
+iter_seek_ge: "d"/1.000000000,0=/<empty>
+iter_seek_ge: "d"/1.000000000,0=/<empty>
+iter_seek_ge: "d"/1.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=e ts=6
+iter_seek_ge k=e ts=5
+iter_seek_ge k=e ts=4
+iter_seek_ge k=e ts=3
+iter_seek_ge k=e ts=2
+iter_seek_ge k=e ts=1
+----
+iter_seek_ge: "e"/5.000000000,0=/<empty>
+iter_seek_ge: "e"/5.000000000,0=/<empty>
+iter_seek_ge: "e"/3.000000000,0=/BYTES/e3
+iter_seek_ge: "e"/3.000000000,0=/BYTES/e3
+iter_seek_ge: "e"/1.000000000,0=/<empty>
+iter_seek_ge: "e"/1.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=f ts=7
+iter_seek_ge k=f ts=6
+iter_seek_ge k=f ts=5
+iter_seek_ge k=f ts=4
+iter_seek_ge k=f ts=3
+iter_seek_ge k=f ts=2
+iter_seek_ge k=f ts=1
+----
+iter_seek_ge: "f"/6.000000000,0=/BYTES/f6
+iter_seek_ge: "f"/6.000000000,0=/BYTES/f6
+iter_seek_ge: "f"/5.000000000,0=/<empty>
+iter_seek_ge: "f"/4.000000000,0=/BYTES/f4
+iter_seek_ge: "f"/3.000000000,0=vheader{ localTs=4.000000000,0 } /<empty>
+iter_seek_ge: "f"/2.000000000,0=/BYTES/f2
+iter_seek_ge: "g"/4.000000000,0=/BYTES/g4
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=g ts=6
+iter_seek_ge k=g ts=5
+iter_seek_ge k=g ts=4
+iter_seek_ge k=g ts=3
+iter_seek_ge k=g ts=2
+iter_seek_ge k=g ts=1
+----
+iter_seek_ge: "g"/4.000000000,0=/BYTES/g4
+iter_seek_ge: "g"/4.000000000,0=/BYTES/g4
+iter_seek_ge: "g"/4.000000000,0=/BYTES/g4
+iter_seek_ge: "g"/3.000000000,0=vheader{ localTs=4.000000000,0 } /<empty>
+iter_seek_ge: "g"/2.000000000,0=/BYTES/g2
+iter_seek_ge: "h"/3.000000000,0=/BYTES/h3
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=h ts=4
+iter_seek_ge k=h ts=3
+iter_seek_ge k=h ts=2
+iter_seek_ge k=h ts=1
+----
+iter_seek_ge: "h"/3.000000000,0=/BYTES/h3
+iter_seek_ge: "h"/3.000000000,0=/BYTES/h3
+iter_seek_ge: "h"/1.000000000,0=/<empty>
+iter_seek_ge: "h"/1.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=i ts=2
+iter_seek_ge k=i ts=1
+----
+iter_seek_ge: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_ge: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=j ts=8
+iter_seek_ge k=j ts=7
+iter_seek_ge k=j ts=6
+iter_seek_ge k=j ts=1
+----
+iter_seek_ge: "j"/7.000000000,0=/BYTES/j7
+iter_seek_ge: "j"/7.000000000,0=/BYTES/j7
+iter_seek_ge: "j"/1.000000000,0=/<empty>
+iter_seek_ge: "j"/1.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=k ts=6
+iter_seek_ge k=k ts=5
+iter_seek_ge k=k ts=4
+----
+iter_seek_ge: "k"/5.000000000,0=/BYTES/k5
+iter_seek_ge: "k"/5.000000000,0=/BYTES/k5
+iter_seek_ge: "l"/5.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=l ts=6
+iter_seek_ge k=l ts=5
+iter_seek_ge k=l ts=4
+----
+iter_seek_ge: "l"/5.000000000,0=/<empty>
+iter_seek_ge: "l"/5.000000000,0=/<empty>
+iter_seek_ge: "n"/5.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=m ts=6
+iter_seek_ge k=m ts=5
+iter_seek_ge k=m ts=4
+----
+iter_seek_ge: "n"/5.000000000,0=/<empty>
+iter_seek_ge: "n"/5.000000000,0=/<empty>
+iter_seek_ge: "n"/5.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=n ts=6
+iter_seek_ge k=n ts=5
+iter_seek_ge k=n ts=4
+iter_seek_ge k=n ts=3
+iter_seek_ge k=n ts=2
+----
+iter_seek_ge: "n"/5.000000000,0=/<empty>
+iter_seek_ge: "n"/5.000000000,0=/<empty>
+iter_seek_ge: "n"/3.000000000,0=/<empty>
+iter_seek_ge: "n"/3.000000000,0=/<empty>
+iter_seek_ge: .
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=o ts=6
+iter_seek_ge k=o ts=5
+iter_seek_ge k=o ts=4
+iter_seek_ge k=o ts=3
+----
+iter_seek_ge: .
+iter_seek_ge: .
+iter_seek_ge: .
+iter_seek_ge: .
+
+# Versioned seeks with emitOnSeekGE.
+run ok
+iter_new types=pointsAndRanges pointSynthesis emitOnSeekGE
+iter_seek_ge k=l ts=6
+iter_seek_ge k=l ts=5
+iter_seek_ge k=l ts=4
+----
+iter_seek_ge: "l"/5.000000000,0=/<empty>
+iter_seek_ge: "l"/5.000000000,0=/<empty>
+iter_seek_ge: "n"/5.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis emitOnSeekGE
+iter_seek_ge k=m ts=6
+iter_seek_ge k=m ts=5
+iter_seek_ge k=m ts=4
+----
+iter_seek_ge: "m"/5.000000000,0=/<empty>
+iter_seek_ge: "m"/5.000000000,0=/<empty>
+iter_seek_ge: "n"/5.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis emitOnSeekGE
+iter_seek_ge k=n ts=6
+iter_seek_ge k=n ts=5
+iter_seek_ge k=n ts=4
+iter_seek_ge k=n ts=3
+----
+iter_seek_ge: "n"/5.000000000,0=/<empty>
+iter_seek_ge: "n"/5.000000000,0=/<empty>
+iter_seek_ge: "n"/3.000000000,0=/<empty>
+iter_seek_ge: "n"/3.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis emitOnSeekGE
+iter_seek_ge k=o ts=6
+iter_seek_ge k=o ts=5
+iter_seek_ge k=o ts=4
+----
+iter_seek_ge: .
+iter_seek_ge: .
+iter_seek_ge: .
+
+# Versioned reverse seeks.
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=a ts=1
+iter_seek_lt k=a ts=2
+iter_seek_lt k=a ts=3
+iter_seek_lt k=a ts=4
+iter_seek_lt k=a ts=5
+----
+iter_seek_lt: "a"/2.000000000,0=/BYTES/a2
+iter_seek_lt: "a"/4.000000000,0=/<empty>
+iter_seek_lt: "a"/4.000000000,0=/<empty>
+iter_seek_lt: .
+iter_seek_lt: .
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=b ts=1
+iter_seek_lt k=b ts=2
+iter_seek_lt k=b ts=3
+iter_seek_lt k=b ts=4
+iter_seek_lt k=b ts=5
+----
+iter_seek_lt: "b"/3.000000000,0=/<empty>
+iter_seek_lt: "b"/3.000000000,0=/<empty>
+iter_seek_lt: "b"/4.000000000,0=/<empty>
+iter_seek_lt: "a"/1.000000000,0=/<empty>
+iter_seek_lt: "a"/1.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=c ts=1
+iter_seek_lt k=c ts=2
+iter_seek_lt k=c ts=3
+iter_seek_lt k=c ts=4
+iter_seek_lt k=c ts=5
+iter_seek_lt k=c ts=6
+----
+iter_seek_lt: "c"/3.000000000,0=/<empty>
+iter_seek_lt: "c"/3.000000000,0=/<empty>
+iter_seek_lt: "c"/5.000000000,0=/<empty>
+iter_seek_lt: "c"/5.000000000,0=/<empty>
+iter_seek_lt: "b"/1.000000000,0=/<empty>
+iter_seek_lt: "b"/1.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=d ts=1
+iter_seek_lt k=d ts=2
+iter_seek_lt k=d ts=3
+iter_seek_lt k=d ts=4
+iter_seek_lt k=d ts=5
+iter_seek_lt k=d ts=6
+iter_seek_lt k=d ts=7
+iter_seek_lt k=d ts=8
+----
+iter_seek_lt: "d"/4.000000000,0=/BYTES/d4
+iter_seek_lt: "d"/4.000000000,0=/BYTES/d4
+iter_seek_lt: "d"/4.000000000,0=/BYTES/d4
+iter_seek_lt: "d"/5.000000000,0=/<empty>
+iter_seek_lt: "d"/7.000000000,0=/BYTES/d7
+iter_seek_lt: "d"/7.000000000,0=/BYTES/d7
+iter_seek_lt: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_lt: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=e ts=1
+iter_seek_lt k=e ts=2
+iter_seek_lt k=e ts=3
+iter_seek_lt k=e ts=4
+iter_seek_lt k=e ts=5
+iter_seek_lt k=e ts=6
+----
+iter_seek_lt: "e"/3.000000000,0=/BYTES/e3
+iter_seek_lt: "e"/3.000000000,0=/BYTES/e3
+iter_seek_lt: "e"/5.000000000,0=/<empty>
+iter_seek_lt: "e"/5.000000000,0=/<empty>
+iter_seek_lt: "d"/1.000000000,0=/<empty>
+iter_seek_lt: "d"/1.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=f ts=1
+iter_seek_lt k=f ts=2
+iter_seek_lt k=f ts=3
+iter_seek_lt k=f ts=4
+iter_seek_lt k=f ts=5
+iter_seek_lt k=f ts=6
+iter_seek_lt k=f ts=7
+----
+iter_seek_lt: "f"/2.000000000,0=/BYTES/f2
+iter_seek_lt: "f"/3.000000000,0=vheader{ localTs=4.000000000,0 } /<empty>
+iter_seek_lt: "f"/4.000000000,0=/BYTES/f4
+iter_seek_lt: "f"/5.000000000,0=/<empty>
+iter_seek_lt: "f"/6.000000000,0=/BYTES/f6
+iter_seek_lt: "e"/1.000000000,0=/<empty>
+iter_seek_lt: "e"/1.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=g ts=1
+iter_seek_lt k=g ts=2
+iter_seek_lt k=g ts=3
+iter_seek_lt k=g ts=4
+iter_seek_lt k=g ts=5
+iter_seek_lt k=g ts=6
+----
+iter_seek_lt: "g"/2.000000000,0=/BYTES/g2
+iter_seek_lt: "g"/3.000000000,0=vheader{ localTs=4.000000000,0 } /<empty>
+iter_seek_lt: "g"/4.000000000,0=/BYTES/g4
+iter_seek_lt: "f"/2.000000000,0=/BYTES/f2
+iter_seek_lt: "f"/2.000000000,0=/BYTES/f2
+iter_seek_lt: "f"/2.000000000,0=/BYTES/f2
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=h ts=1
+iter_seek_lt k=h ts=2
+iter_seek_lt k=h ts=3
+iter_seek_lt k=h ts=4
+----
+iter_seek_lt: "h"/3.000000000,0=/BYTES/h3
+iter_seek_lt: "h"/3.000000000,0=/BYTES/h3
+iter_seek_lt: "g"/2.000000000,0=/BYTES/g2
+iter_seek_lt: "g"/2.000000000,0=/BYTES/g2
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=i ts=1
+iter_seek_lt k=i ts=2
+----
+iter_seek_lt: "h"/1.000000000,0=/<empty>
+iter_seek_lt: "h"/1.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=j ts=1
+iter_seek_lt k=j ts=6
+iter_seek_lt k=j ts=7
+iter_seek_lt k=j ts=8
+----
+iter_seek_lt: "j"/7.000000000,0=/BYTES/j7
+iter_seek_lt: "j"/7.000000000,0=/BYTES/j7
+iter_seek_lt: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_lt: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=k ts=1
+iter_seek_lt k=k ts=4
+iter_seek_lt k=k ts=5
+iter_seek_lt k=k ts=6
+----
+iter_seek_lt: "k"/5.000000000,0=/BYTES/k5
+iter_seek_lt: "k"/5.000000000,0=/BYTES/k5
+iter_seek_lt: "j"/1.000000000,0=/<empty>
+iter_seek_lt: "j"/1.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=l ts=4
+iter_seek_lt k=l ts=5
+iter_seek_lt k=l ts=6
+----
+iter_seek_lt: "l"/5.000000000,0=/<empty>
+iter_seek_lt: "k"/5.000000000,0=/BYTES/k5
+iter_seek_lt: "k"/5.000000000,0=/BYTES/k5
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=l ts=4
+iter_seek_lt k=l ts=5
+iter_seek_lt k=l ts=6
+----
+iter_seek_lt: "l"/5.000000000,0=/<empty>
+iter_seek_lt: "k"/5.000000000,0=/BYTES/k5
+iter_seek_lt: "k"/5.000000000,0=/BYTES/k5
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=m ts=4
+iter_seek_lt k=m ts=5
+iter_seek_lt k=m ts=6
+----
+iter_seek_lt: "l"/5.000000000,0=/<empty>
+iter_seek_lt: "l"/5.000000000,0=/<empty>
+iter_seek_lt: "l"/5.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=n ts=2
+iter_seek_lt k=n ts=3
+iter_seek_lt k=n ts=4
+iter_seek_lt k=n ts=5
+iter_seek_lt k=n ts=6
+----
+iter_seek_lt: "n"/3.000000000,0=/<empty>
+iter_seek_lt: "n"/5.000000000,0=/<empty>
+iter_seek_lt: "n"/5.000000000,0=/<empty>
+iter_seek_lt: "l"/5.000000000,0=/<empty>
+iter_seek_lt: "l"/5.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=o ts=1
+----
+iter_seek_lt: "n"/3.000000000,0=/<empty>
+
+# Seeks with opposite scans.
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=d
+iter_scan reverse
+----
+iter_seek_ge: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "c"/1.000000000,0=/<empty>
+iter_scan: "c"/3.000000000,0=/<empty>
+iter_scan: "c"/5.000000000,0=/<empty>
+iter_scan: "b"/1.000000000,0=/<empty>
+iter_scan: "b"/3.000000000,0=/<empty>
+iter_scan: "b"/4.000000000,0=/<empty>
+iter_scan: "a"/1.000000000,0=/<empty>
+iter_scan: "a"/2.000000000,0=/BYTES/a2
+iter_scan: "a"/4.000000000,0=/<empty>
+iter_scan: .
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=d ts=5
+iter_scan reverse
+----
+iter_seek_ge: "d"/5.000000000,0=/<empty>
+iter_scan: "d"/5.000000000,0=/<empty>
+iter_scan: "d"/7.000000000,0=/BYTES/d7
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "c"/1.000000000,0=/<empty>
+iter_scan: "c"/3.000000000,0=/<empty>
+iter_scan: "c"/5.000000000,0=/<empty>
+iter_scan: "b"/1.000000000,0=/<empty>
+iter_scan: "b"/3.000000000,0=/<empty>
+iter_scan: "b"/4.000000000,0=/<empty>
+iter_scan: "a"/1.000000000,0=/<empty>
+iter_scan: "a"/2.000000000,0=/BYTES/a2
+iter_scan: "a"/4.000000000,0=/<empty>
+iter_scan: .
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=g
+iter_scan
+----
+iter_seek_lt: "f"/2.000000000,0=/BYTES/f2
+iter_scan: "f"/2.000000000,0=/BYTES/f2
+iter_scan: "g"/4.000000000,0=/BYTES/g4
+iter_scan: "g"/3.000000000,0=vheader{ localTs=4.000000000,0 } /<empty>
+iter_scan: "g"/2.000000000,0=/BYTES/g2
+iter_scan: "h"/3.000000000,0=/BYTES/h3
+iter_scan: "h"/1.000000000,0=/<empty>
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "j"/7.000000000,0=/BYTES/j7
+iter_scan: "j"/1.000000000,0=/<empty>
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "l"/5.000000000,0=/<empty>
+iter_scan: "n"/5.000000000,0=/<empty>
+iter_scan: "n"/3.000000000,0=/<empty>
+iter_scan: .
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=g ts=2
+iter_scan
+----
+iter_seek_lt: "g"/3.000000000,0=vheader{ localTs=4.000000000,0 } /<empty>
+iter_scan: "g"/3.000000000,0=vheader{ localTs=4.000000000,0 } /<empty>
+iter_scan: "g"/2.000000000,0=/BYTES/g2
+iter_scan: "h"/3.000000000,0=/BYTES/h3
+iter_scan: "h"/1.000000000,0=/<empty>
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "j"/7.000000000,0=/BYTES/j7
+iter_scan: "j"/1.000000000,0=/<empty>
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "l"/5.000000000,0=/<empty>
+iter_scan: "n"/5.000000000,0=/<empty>
+iter_scan: "n"/3.000000000,0=/<empty>
+iter_scan: .
+
+# Try some direction changes.
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=e ts=4
+iter_prev
+iter_next
+iter_next
+iter_prev
+----
+iter_seek_ge: "e"/3.000000000,0=/BYTES/e3
+iter_prev: "e"/5.000000000,0=/<empty>
+iter_next: "e"/3.000000000,0=/BYTES/e3
+iter_next: "e"/1.000000000,0=/<empty>
+iter_prev: "e"/3.000000000,0=/BYTES/e3
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=e ts=4
+iter_next
+iter_prev
+iter_prev
+iter_next
+----
+iter_seek_lt: "e"/5.000000000,0=/<empty>
+iter_next: "e"/3.000000000,0=/BYTES/e3
+iter_prev: "e"/5.000000000,0=/<empty>
+iter_prev: "d"/1.000000000,0=/<empty>
+iter_next: "e"/5.000000000,0=/<empty>
+
+run ok
+iter_new kind=keys types=pointsAndRanges pointSynthesis
+iter_seek_ge k=e ts=4
+iter_prev
+iter_prev
+iter_next_key
+iter_next
+iter_next_key
+iter_prev
+iter_prev
+iter_next_key
+iter_next
+----
+iter_seek_ge: "e"/3.000000000,0=/BYTES/e3
+iter_prev: "e"/5.000000000,0=/<empty>
+iter_prev: "d"/1.000000000,0=/<empty>
+iter_next_key: "e"/5.000000000,0=/<empty>
+iter_next: "e"/3.000000000,0=/BYTES/e3
+iter_next_key: "f"/6.000000000,0=/BYTES/f6
+iter_prev: "e"/1.000000000,0=/<empty>
+iter_prev: "e"/3.000000000,0=/BYTES/e3
+iter_next_key: "f"/6.000000000,0=/BYTES/f6
+iter_next: "f"/5.000000000,0=/<empty>
+
+run ok
+iter_new kind=keys types=pointsAndRanges pointSynthesis
+iter_seek_ge k=k ts=4
+iter_next_key
+iter_prev
+iter_next_key
+iter_next
+iter_prev
+----
+iter_seek_ge: "l"/5.000000000,0=/<empty>
+iter_next_key: "n"/5.000000000,0=/<empty>
+iter_prev: "l"/5.000000000,0=/<empty>
+iter_next_key: "n"/5.000000000,0=/<empty>
+iter_next: "n"/3.000000000,0=/<empty>
+iter_prev: "n"/5.000000000,0=/<empty>
+
+run ok
+iter_new kind=keys types=pointsAndRanges pointSynthesis
+iter_seek_ge k=e ts=3
+iter_prev
+iter_next_key
+----
+iter_seek_ge: "e"/3.000000000,0=/BYTES/e3
+iter_prev: "e"/5.000000000,0=/<empty>
+iter_next_key: "f"/6.000000000,0=/BYTES/f6
+
+# Exhausting the iterator then reversing should work in both directions,
+# both after a seek and after a step.
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=a
+iter_next
+----
+iter_seek_lt: .
+iter_next: "a"/4.000000000,0=/<empty>
+
+run ok
+iter_new kind=keys types=pointsAndRanges pointSynthesis
+iter_seek_lt k=a
+iter_next_key
+----
+iter_seek_lt: .
+iter_next_key: "a"/4.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=z
+iter_prev
+----
+iter_seek_ge: .
+iter_prev: "n"/3.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=z
+iter_next
+iter_next
+iter_prev
+----
+iter_seek_lt: "n"/3.000000000,0=/<empty>
+iter_next: .
+iter_next: .
+iter_prev: "n"/3.000000000,0=/<empty>
+
+run ok
+iter_new kind=keys types=pointsAndRanges pointSynthesis
+iter_seek_lt k=z
+iter_next_key
+iter_next_key
+iter_prev
+----
+iter_seek_lt: "n"/3.000000000,0=/<empty>
+iter_next_key: .
+iter_next_key: .
+iter_prev: "n"/3.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=a
+iter_prev
+iter_prev
+iter_next
+----
+iter_seek_ge: "a"/4.000000000,0=/<empty>
+iter_prev: .
+iter_prev: .
+iter_next: "a"/4.000000000,0=/<empty>
+
+run ok
+iter_new kind=keys types=pointsAndRanges pointSynthesis
+iter_seek_ge k=a
+iter_prev
+iter_prev
+iter_next_key
+----
+iter_seek_ge: "a"/4.000000000,0=/<empty>
+iter_prev: .
+iter_prev: .
+iter_next_key: "a"/4.000000000,0=/<empty>


### PR DESCRIPTION
This patch adds `pointSynthesizingIter`, an MVCC iterator which wraps an
arbitrary MVCC iterator and synthesizes point keys for range keys at
their start key and where they overlap point keys. It can optionally
synthesize around the SeekGE seek key too, which is useful for point
operations like `MVCCGet` where we may want to return a synthetic
tombstone for an MVCC range tombstone if there is no existing point key.

This will primarily be used to handle MVCC range tombstones in MVCC
scans and gets, as well as during MVCC conflict checks, which allows
much of this logic to remain unchanged and simplified (in particular,
`pebbleMVCCScanner` will not need any changes).

However, this patch does not make use of the iterator yet, since both it
and Pebble will need further performance optimizations for use in hot
paths. For now, correctness is sufficient, and only basic attempts at
performance optimization have been made.

Touches #70412.

Release note: None