### PR TITLE
cli/sql: avoid taking a lease on the target db upon connect

### DIFF
--- a/pkg/cli/clisqlcfg/context.go
+++ b/pkg/cli/clisqlcfg/context.go
@@ -201,6 +201,13 @@ func (c *Context) Run(conn clisqlclient.Conn) error {
 		return err
 	}
 
+	if c.ConnCtx.DebugMode {
+		fmt.Fprintln(c.CmdOut,
+			"#\n# NOTE: if you intend to troubleshoot CockroachDB, you might want to set the current database\n"+
+				"# to the empty string (SET database = \"\"), for otherwise simple queries against crdb_internal\n"+
+				"# and other vtables will attempt to take a database lease and incur write traffic.\n#")
+	}
+
 	shell := clisqlshell.NewShell(c.CliCtx, c.ConnCtx, c.ExecCtx, &c.ShellCtx, conn)
 	return shell.RunInteractive(c.cmdIn, c.CmdOut, c.CmdErr)
 }

--- a/pkg/cli/clisqlclient/conn.go
+++ b/pkg/cli/clisqlclient/conn.go
@@ -245,7 +245,9 @@ func (c *sqlConn) GetServerMetadata(
 	ctx context.Context,
 ) (nodeID int32, version, clusterID string, err error) {
 	// Retrieve the node ID and server build info.
-	rows, err := c.Query(ctx, "SELECT * FROM crdb_internal.node_build_info")
+	// Be careful to query against the empty database string, which avoids taking
+	// a lease against the current database (in case it's currently unavailable).
+	rows, err := c.Query(ctx, `SELECT * FROM "".crdb_internal.node_build_info`)
 	if errors.Is(err, driver.ErrBadConn) {
 		return 0, "", "", err
 	}

--- a/pkg/cli/interactive_tests/test_client_side_checking.tcl
+++ b/pkg/cli/interactive_tests/test_client_side_checking.tcl
@@ -80,6 +80,13 @@ end_test
 start_test "Check that --debug-sql-cli sets suitable simplified client-side options."
 send "$argv sql --debug-sql-cli\r"
 eexpect "Welcome"
+
+# Check empty db name for build info query.
+eexpect "\"\".crdb_internal.node_build_info"
+# Check invitation to reset db name.
+eexpect "you might want to set the current database"
+eexpect "to the empty string"
+
 eexpect "root@"
 send "\\set display_format csv\r\\set\r"
 eexpect "check_syntax,false"


### PR DESCRIPTION
Informs #81673.   cc @joshimhoff @1lann 

This makes `--debug-sql-cli` slightly more useful if something is
wrong with the database in the URL string or if there's something
wrong in the leasing subsystem.

Release note: None