### PR TITLE
storage: take timestamps in `MVCCValue` local timestamp helpers

### DIFF
--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -1615,7 +1615,8 @@ func mvccPutInternal(
 	versionValue := MVCCValue{}
 	versionValue.Value = value
 	versionValue.LocalTimestamp = localTimestamp
-	if !versionValue.LocalTimestampNeeded(versionKey) || !writer.ShouldWriteLocalTimestamps(ctx) {
+	if !versionValue.LocalTimestampNeeded(versionKey.Timestamp) ||
+		!writer.ShouldWriteLocalTimestamps(ctx) {
 		versionValue.LocalTimestamp = hlc.ClockTimestamp{}
 	}
 
@@ -3128,9 +3129,9 @@ func mvccResolveWriteIntent(
 			// while the transaction was still pending, in which case it can be advanced
 			// to the observed timestamp.
 			newValue := oldValue
-			newValue.LocalTimestamp = oldValue.GetLocalTimestamp(oldKey)
+			newValue.LocalTimestamp = oldValue.GetLocalTimestamp(oldKey.Timestamp)
 			newValue.LocalTimestamp.Forward(intent.ClockWhilePending.Timestamp)
-			if !newValue.LocalTimestampNeeded(newKey) || !rw.ShouldWriteLocalTimestamps(ctx) {
+			if !newValue.LocalTimestampNeeded(newKey.Timestamp) || !rw.ShouldWriteLocalTimestamps(ctx) {
 				newValue.LocalTimestamp = hlc.ClockTimestamp{}
 			}
 

--- a/pkg/storage/mvcc_value.go
+++ b/pkg/storage/mvcc_value.go
@@ -86,7 +86,10 @@ func (v MVCCValue) IsTombstone() bool {
 // LocalTimestampNeeded returns whether the MVCCValue's local timestamp is
 // needed, or whether it can be implied by (i.e. set to the same value as)
 // its key's version timestamp.
-func (v MVCCValue) LocalTimestampNeeded(k MVCCKey) bool {
+//
+// TODO(erikgrinaker): Consider making this and GetLocalTimestamp() generic over
+// MVCCKey and MVCCRangeKey once generics have matured a bit.
+func (v MVCCValue) LocalTimestampNeeded(keyTS hlc.Timestamp) bool {
 	// If the local timestamp is empty, it is assumed to be equal to the key's
 	// version timestamp and so the local timestamp is not needed.
 	return !v.LocalTimestamp.IsEmpty() &&
@@ -96,15 +99,15 @@ func (v MVCCValue) LocalTimestampNeeded(k MVCCKey) bool {
 		// However, it is not safe for the local clock timestamp to be rounded up,
 		// as this could lead to stale reads. As a result, in such cases, the local
 		// timestamp is needed and cannot be implied by the version timestamp.
-		v.LocalTimestamp.ToTimestamp().Less(k.Timestamp)
+		v.LocalTimestamp.ToTimestamp().Less(keyTS)
 }
 
 // GetLocalTimestamp returns the MVCCValue's local timestamp. If the local
 // timestamp is not set explicitly, its implicit value is taken from the
-// provided MVCCKey and returned.
-func (v MVCCValue) GetLocalTimestamp(k MVCCKey) hlc.ClockTimestamp {
+// provided key version timestamp and returned.
+func (v MVCCValue) GetLocalTimestamp(keyTS hlc.Timestamp) hlc.ClockTimestamp {
 	if v.LocalTimestamp.IsEmpty() {
-		if k.Timestamp.Synthetic {
+		if keyTS.Synthetic {
 			// A synthetic version timestamp means that the version timestamp is
 			// disconnected from real time and did not come from an HLC clock on the
 			// leaseholder that wrote the value or from somewhere else in the system.
@@ -115,7 +118,7 @@ func (v MVCCValue) GetLocalTimestamp(k MVCCKey) hlc.ClockTimestamp {
 			// timestamp.
 			return hlc.MinClockTimestamp
 		}
-		return hlc.ClockTimestamp(k.Timestamp)
+		return hlc.ClockTimestamp(keyTS)
 	}
 	return v.LocalTimestamp
 }

--- a/pkg/storage/mvcc_value_test.go
+++ b/pkg/storage/mvcc_value_test.go
@@ -41,11 +41,10 @@ func TestMVCCValueLocalTimestampNeeded(t *testing.T) {
 	}
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			mvccKey := MVCCKey{Timestamp: tc.versionTs}
 			mvccVal := MVCCValue{}
 			mvccVal.LocalTimestamp = hlc.ClockTimestamp(tc.localTs)
 
-			require.Equal(t, tc.expect, mvccVal.LocalTimestampNeeded(mvccKey))
+			require.Equal(t, tc.expect, mvccVal.LocalTimestampNeeded(tc.versionTs))
 		})
 	}
 }
@@ -71,11 +70,10 @@ func TestMVCCValueGetLocalTimestamp(t *testing.T) {
 	}
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			mvccKey := MVCCKey{Timestamp: tc.versionTs}
 			mvccVal := MVCCValue{}
 			mvccVal.LocalTimestamp = hlc.ClockTimestamp(tc.localTs)
 
-			require.Equal(t, hlc.ClockTimestamp(tc.expect), mvccVal.GetLocalTimestamp(mvccKey))
+			require.Equal(t, hlc.ClockTimestamp(tc.expect), mvccVal.GetLocalTimestamp(tc.versionTs))
 		})
 	}
 }

--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -604,7 +604,7 @@ func (p *pebbleMVCCScanner) getAndAdvance(ctx context.Context) bool {
 			// 5. Our txn's read timestamp is less than the max timestamp
 			// seen by the txn. We need to check for clock uncertainty
 			// errors.
-			localTS := p.curUnsafeValue.GetLocalTimestamp(p.curUnsafeKey)
+			localTS := p.curUnsafeValue.GetLocalTimestamp(p.curUnsafeKey.Timestamp)
 			if p.uncertainty.IsUncertain(p.curUnsafeKey.Timestamp, localTS) {
 				return p.uncertaintyError(p.curUnsafeKey.Timestamp)
 			}
@@ -1025,7 +1025,7 @@ func (p *pebbleMVCCScanner) seekVersion(
 			// are only uncertain if their timestamps are synthetic. Meanwhile,
 			// any value with a time in the range (ts, uncertainty.LocalLimit]
 			// is uncertain.
-			localTS := p.curUnsafeValue.GetLocalTimestamp(p.curUnsafeKey)
+			localTS := p.curUnsafeValue.GetLocalTimestamp(p.curUnsafeKey.Timestamp)
 			if p.uncertainty.IsUncertain(p.curUnsafeKey.Timestamp, localTS) {
 				return p.uncertaintyError(p.curUnsafeKey.Timestamp)
 			}
@@ -1053,7 +1053,7 @@ func (p *pebbleMVCCScanner) seekVersion(
 		// Iterate through uncertainty interval. See the comment above about why
 		// a value in this interval is not necessarily cause for an uncertainty
 		// error.
-		localTS := p.curUnsafeValue.GetLocalTimestamp(p.curUnsafeKey)
+		localTS := p.curUnsafeValue.GetLocalTimestamp(p.curUnsafeKey.Timestamp)
 		if p.uncertainty.IsUncertain(p.curUnsafeKey.Timestamp, localTS) {
 			return p.uncertaintyError(p.curUnsafeKey.Timestamp)
 		}


### PR DESCRIPTION
`MVCCValue.LocalTimestampNeeded()` and `GetLocalTimestamp()` took a
`MVCCKey` as a parameter, even though they only needed to know the key's
timestamp -- likely to gain some degree of type safety.

However, MVCC range keys will also need local timestamps when they are
added, and these do not use `MVCCKey`. This patch therefore changes
these methods to take the key's version timestamp, so they can be used
both for point keys and range keys.

Release note: None