### PR TITLE
serverpb: remove stray Protobuf import

### DIFF
--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -24,7 +24,6 @@ import "ts/catalog/chart_catalog.proto";
 import "util/metric/metric.proto";
 import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
-import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
 // ZoneConfigurationLevel indicates, for objects with a Zone Configuration,


### PR DESCRIPTION
This removes a stray Protobuf import, which caused warnings during code
generation:

```
server/serverpb/admin.proto:27:1: warning: Import google/protobuf/duration.proto but not used.
```

Release note: None