### PR TITLE
cli: remove stray uses of ExpandEnv

### DIFF
--- a/pkg/cli/client_url.go
+++ b/pkg/cli/client_url.go
@@ -12,7 +12,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
@@ -238,7 +237,6 @@ func (u urlParser) setInternal(v string, warn bool) error {
 				// If --certs-dir was not specified, we'll pick up
 				// the first directory encountered below.
 				candidateCertsDir = cliCtx.SSLCertsDir
-				candidateCertsDir = os.ExpandEnv(candidateCertsDir)
 				candidateCertsDir, err = filepath.Abs(candidateCertsDir)
 				if err != nil {
 					return err

--- a/pkg/cli/connect.go
+++ b/pkg/cli/connect.go
@@ -124,7 +124,7 @@ func runConnectInit(cmd *cobra.Command, args []string) (retErr error) {
 	defer func() {
 		if retErr == nil {
 			fmt.Println("server certificate generation complete.\n\n" +
-				"cert files generated in: " + os.ExpandEnv(baseCfg.SSLCertsDir) + "\n\n" +
+				"cert files generated in: " + baseCfg.SSLCertsDir + "\n\n" +
 				"Do not forget to generate a client certificate for the 'root' user!\n" +
 				"This must be done manually, preferably from a different unix user account\n" +
 				"than the one running the server. Example command:\n\n" +


### PR DESCRIPTION
This is leftover work from #81298.

Release note: None