### PR TITLE
planner: fix print valid sql in `show create view`

### DIFF
--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -297,8 +297,7 @@ type TableDescriptor interface {
 	// Sequences count as physical tables because their values are stored in
 	// the KV layer.
 	IsPhysicalTable() bool
-	// MaterializedView returns whether or not this TableDescriptor is a
-	// MaterializedView.
+	// MaterializedView returns whether this TableDescriptor is a MaterializedView.
 	MaterializedView() bool
 	// IsAs returns true if the TableDescriptor describes a Table that was created
 	// with a CREATE TABLE AS command.

--- a/pkg/sql/logictest/testdata/logic_test/sequences_regclass
+++ b/pkg/sql/logictest/testdata/logic_test/sequences_regclass
@@ -476,7 +476,7 @@ CREATE MATERIALIZED VIEW v5 AS SELECT currval('view_seq'), i FROM t3
 query TT
 SHOW CREATE VIEW v5
 ----
-v5  CREATE VIEW public.v5 (
+v5  CREATE MATERIALIZED VIEW public.v5 (
     currval,
     i,
     rowid

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -1245,3 +1245,18 @@ SELECT "reportingID",
  LIMIT 1;
 ----
 1  {"CascadeDroppedViews": ["db2.public.v1nest", "db2.public.v2nest", "db2.public.v3nest"], "EventType": "drop_table", "Statement": "DROP TABLE db2.public.t1nest CASCADE", "TableName": "db2.public.t1nest", "Tag": "DROP TABLE", "User": "root"}
+
+
+statement ok
+CREATE TABLE test_t1(a int);
+
+statement ok
+CREATE MATERIALIZED VIEW li AS (SELECT 1 AS test_t1);
+
+query TT
+SHOW CREATE VIEW li
+----
+li                          CREATE MATERIALIZED VIEW public.li (
+                                                    test_t1,
+                                                    rowid
+                        ) AS (SELECT 1 AS test_t1)

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -106,6 +106,9 @@ func ShowCreateView(
 	if desc.IsTemporary() {
 		f.WriteString("TEMP ")
 	}
+	if desc.MaterializedView() {
+		f.WriteString("MATERIALIZED ")
+	}
 	f.WriteString("VIEW ")
 	f.FormatNode(tn)
 	f.WriteString(" (")


### PR DESCRIPTION
When we `create materialized view ..` then use `show create table`  in the past, it will not print keyword of `materialized`. So when entering `show_create_clauses` to use `desc.MaterializedView()` to judge whether is `materialized view` and print valid sql.

Fixes https://github.com/cockroachdb/cockroach/issues/80829

Release note (bug fix): The output of SHOW CREATE VIEW now properly includes the keyword MATERIALIZED for materialized views.
