### PR TITLE
kvserver: skip `TestCheckConsistencyInconsistent` under race

### DIFF
--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -229,6 +230,8 @@ func TestCheckConsistencyReplay(t *testing.T) {
 func TestCheckConsistencyInconsistent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderRaceWithIssue(t, 81819, "slow test, and TestingSetRedactable triggers race detector")
 
 	// This test prints a consistency checker diff, so it's
 	// good to make sure we're overly redacting said diff.


### PR DESCRIPTION
The test is rather slow and also timing-dependent, which can result in
false positives. Furthermore, the call to `TestingSetRedactable`
triggers the race detector. This patch therefore disables the test under
the race detector.

Touches #81819.

Release note: None