### PR TITLE
timeutil: improve Timer API

### DIFF
--- a/pkg/util/timeutil/timer.go
+++ b/pkg/util/timeutil/timer.go
@@ -79,8 +79,14 @@ func (t *Timer) Reset(d time.Duration) {
 		t.C = t.timer.C
 		return
 	}
-	if !t.timer.Stop() && !t.Read {
-		<-t.C
+	// Stop the timer and, if the timer had fired already, attempt to drain its
+	// channel in case the user had not already received from the channel before
+	// calling Reset().
+	if !t.timer.Stop() {
+		select {
+		case <-t.C:
+		default:
+		}
 	}
 	t.timer.Reset(d)
 	t.Read = false


### PR DESCRIPTION
The stdlib time.Timer is a very confusing beast, because the
implementation that we're stuck with does not work as originally
intended. We have our own timeutil.Timer which wraps time.Timer, while
adjusting the interface to alleviate
https://github.com/golang/go/issues/14038 and
https://github.com/golang/go/issues/11513. In contast to stdlib, our
timeutil.Timer has a Reset() method that drains that timer's channel if
the user has not drained it already. For this, however, timeutil.Timer
asks the user to cooperate and indicate every time they've read from the
channel by setting Timer.Read = true. Forgetting to set Read results in
the next Reset() deadlocking.

This patch removes the need to set Timer.Read, by making Reset()
*attempt* to drain the channel. If the channel has already been drained,
then Reset() moves on. Doing this in the stdlib was suggested by rsc in
[1], but ultimately not done because the it would have been a visible
change in behavior. But we are in a position to make the change to our
timeutil.Timer; given our current implementation, this patch does not
change any behavior.

[1] https://github.com/golang/go/issues/14038#issuecomment-219909704

Release note: None