### PR TITLE
ui: don't add highlight for * and ^

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/highlightedText/highlightedText.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/highlightedText/highlightedText.spec.ts
@@ -1,0 +1,78 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import ReactDomServer from "react-dom/server";
+import { getHighlightedText } from "./highlightedText";
+
+function elementToString(value: string | JSX.Element): string {
+  if (typeof value == "string") {
+    return value;
+  }
+  return ReactDomServer.renderToString(value);
+}
+
+describe("Highlighted Text", () => {
+  it("text with no highlight", () => {
+    const highlightedText = getHighlightedText(
+      "full text",
+      "no matches",
+      false,
+      true,
+    );
+    expect(highlightedText).toEqual(["full text"]);
+  });
+
+  it("text with everything highlighted", () => {
+    const highlightedText = getHighlightedText(
+      "everything matches",
+      "everything matches",
+      false,
+      true,
+    );
+
+    expect(highlightedText.length).toEqual(5);
+    expect(elementToString(highlightedText[1])).toEqual(
+      '<span class="_text-bold" data-reactroot="">everything</span>',
+    );
+    expect(elementToString(highlightedText[3])).toEqual(
+      '<span class="_text-bold" data-reactroot="">matches</span>',
+    );
+  });
+
+  it("text with partial highlight", () => {
+    const highlightedText = getHighlightedText(
+      "regular text highlighted match",
+      "highlighted match",
+      false,
+      true,
+    );
+    expect(highlightedText.length).toEqual(5);
+    expect(highlightedText[0].toString()).toEqual("regular text ");
+    expect(elementToString(highlightedText[1])).toEqual(
+      '<span class="_text-bold" data-reactroot="">highlighted</span>',
+    );
+    expect(elementToString(highlightedText[3])).toEqual(
+      '<span class="_text-bold" data-reactroot="">match</span>',
+    );
+  });
+
+  it("special characters (used on regex) don't get highlighted", () => {
+    const highlightedText = getHighlightedText(
+      "text * ? + \\ - ^ () {} matches",
+      "* ? + \\ - ^ { } ( )",
+      false,
+      true,
+    );
+    expect(highlightedText.length).toEqual(1);
+    expect(highlightedText[0].toString()).toEqual(
+      "text * ? + \\ - ^ () {} matches",
+    );
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/highlightedText/highlightedText.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/highlightedText/highlightedText.tsx
@@ -79,19 +79,14 @@ export function getHighlightedText(
   if (!highlight || highlight.length === 0) {
     return text;
   }
+
   highlight = highlight.replace(
-    /[°§%()\[\]{}\\?´`'#|;:+-]+/g,
+    /[°§%()\[\]{}\\?´`'#|;:+^*-]+/g,
     "highlightNotDefined",
   );
   const search = highlight
     .split(" ")
     .map(val => {
-      // When it's only a character we want to make sure to use the literal value (by adding []),
-      // this is added to handle cases where the highlighted term is a character used normally
-      // in regex, such as '*', '+', '?'
-      if (val.length == 1) {
-        return `[${val.toLowerCase()}]`;
-      }
       if (val.length > 0) {
         return val.toLowerCase();
       }


### PR DESCRIPTION
We don't highlight special characters that are normally
used on regex, but the characters `*` and `^` were not on
the list.
This commit adds them on the list to be ignored to highlight.
This commit also adds tests for the higlight function.

Fixes #81695

Release note (bug fix): properly handle special characters to
not being highlighted.