### PR TITLE
release-22.1: don't add highlight to * and ^

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/highlightedText/highlightedText.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/highlightedText/highlightedText.spec.ts
@@ -1,0 +1,78 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import ReactDomServer from "react-dom/server";
+import { getHighlightedText } from "./highlightedText";
+
+function elementToString(value: string | JSX.Element): string {
+  if (typeof value == "string") {
+    return value;
+  }
+  return ReactDomServer.renderToString(value);
+}
+
+describe("Highlighted Text", () => {
+  it("text with no highlight", () => {
+    const highlightedText = getHighlightedText(
+      "full text",
+      "no matches",
+      false,
+      true,
+    );
+    expect(highlightedText).toEqual(["full text"]);
+  });
+
+  it("text with everything highlighted", () => {
+    const highlightedText = getHighlightedText(
+      "everything matches",
+      "everything matches",
+      false,
+      true,
+    );
+
+    expect(highlightedText.length).toEqual(5);
+    expect(elementToString(highlightedText[1])).toEqual(
+      '<span class="_text-bold" data-reactroot="">everything</span>',
+    );
+    expect(elementToString(highlightedText[3])).toEqual(
+      '<span class="_text-bold" data-reactroot="">matches</span>',
+    );
+  });
+
+  it("text with partial highlight", () => {
+    const highlightedText = getHighlightedText(
+      "regular text highlighted match",
+      "highlighted match",
+      false,
+      true,
+    );
+    expect(highlightedText.length).toEqual(5);
+    expect(highlightedText[0].toString()).toEqual("regular text ");
+    expect(elementToString(highlightedText[1])).toEqual(
+      '<span class="_text-bold" data-reactroot="">highlighted</span>',
+    );
+    expect(elementToString(highlightedText[3])).toEqual(
+      '<span class="_text-bold" data-reactroot="">match</span>',
+    );
+  });
+
+  it("special characters (used on regex) don't get highlighted", () => {
+    const highlightedText = getHighlightedText(
+      "text * ? + \\ - ^ () {} matches",
+      "* ? + \\ - ^ { } ( )",
+      false,
+      true,
+    );
+    expect(highlightedText.length).toEqual(1);
+    expect(highlightedText[0].toString()).toEqual(
+      "text * ? + \\ - ^ () {} matches",
+    );
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/highlightedText/highlightedText.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/highlightedText/highlightedText.tsx
@@ -15,7 +15,10 @@ import styles from "./highlightedText.module.scss";
 
 const cx = classNames.bind(styles);
 
-export function isStringIncludesArrayElement(arr: string[], text: string) {
+export function isStringIncludesArrayElement(
+  arr: string[],
+  text: string,
+): boolean {
   let includes = false;
   arr.forEach(val => {
     if (text.toLowerCase().includes(val.toLowerCase())) {
@@ -25,12 +28,12 @@ export function isStringIncludesArrayElement(arr: string[], text: string) {
   return includes;
 }
 
-export function getWordAt(word: string, text: string) {
+export function getWordAt(word: string, text: string): number {
   const regex = new RegExp("\\b" + word.toLowerCase() + "\\b");
   return text.toLowerCase().search(regex);
 }
 
-function rebaseText(text: string, highlight: string) {
+function rebaseText(text: string, highlight: string): string {
   const search = highlight.split(" ");
   const maxLength = 425;
   const defaultCropLength = 150;
@@ -83,6 +86,12 @@ export function getHighlightedText(
   const search = highlight
     .split(" ")
     .map(val => {
+      // When it's only a character we want to make sure to use the literal value (by adding []),
+      // this is added to handle cases where the highlighted term is a character used normally
+      // in regex, such as '*', '+', '?'
+      if (val.length == 1) {
+        return `[${val.toLowerCase()}]`;
+      }
       if (val.length > 0) {
         return val.toLowerCase();
       }

--- a/pkg/ui/workspaces/cluster-ui/src/highlightedText/highlightedText.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/highlightedText/highlightedText.tsx
@@ -79,19 +79,14 @@ export function getHighlightedText(
   if (!highlight || highlight.length === 0) {
     return text;
   }
+
   highlight = highlight.replace(
-    /[°§%()\[\]{}\\?´`'#|;:+-]+/g,
+    /[°§%()\[\]{}\\?´`'#|;:+^*-]+/g,
     "highlightNotDefined",
   );
   const search = highlight
     .split(" ")
     .map(val => {
-      // When it's only a character we want to make sure to use the literal value (by adding []),
-      // this is added to handle cases where the highlighted term is a character used normally
-      // in regex, such as '*', '+', '?'
-      if (val.length == 1) {
-        return `[${val.toLowerCase()}]`;
-      }
       if (val.length > 0) {
         return val.toLowerCase();
       }


### PR DESCRIPTION
Backport 1/1 commits from #81988 on behalf of @maryliag.
Backport 1/1 commits from #82081 on behalf of @maryliag.

/cc @cockroachdb/release

----

Previously, when searching for * on statement
and transaction pages, the pages would crash.
This commit fixes this issue by using the literal
value * during the regex for highlighting the text.

Fixes #81695

Release note (bug fix): Statement and Transaction pages no longer
crash when search term includes '*'.

----

We don't highlight special characters that are normally
used on regex, but the characters * and ^ were not on
the list.
This commit adds them on the list to be ignored to highlight.
This commit also adds tests for the highlight function.

Fixes https://github.com/cockroachdb/cockroach/issues/81695

Release note (bug fix): properly handle special characters to
not being highlighted.

----

Release justification: bug fix