### PR TITLE
geos: add pgcode for initialization failures

### DIFF
--- a/pkg/geo/geos/geos.go
+++ b/pkg/geo/geos/geos.go
@@ -227,10 +227,13 @@ func wrapGEOSInitError(err error) error {
 	case "windows":
 		page = "windows"
 	}
-	return errors.WithHintf(
-		err,
-		"Ensure you have the spatial libraries installed as per the instructions in %s",
-		docs.URL("install-cockroachdb-"+page),
+	return pgerror.WithCandidateCode(
+		errors.WithHintf(
+			err,
+			"Ensure you have the spatial libraries installed as per the instructions in %s",
+			docs.URL("install-cockroachdb-"+page),
+		),
+		pgcode.ConfigFile,
 	)
 }
 


### PR DESCRIPTION
This should reduce incoming sentry entries regarding invalid GEOS
setups, which is not something we can action.

Release note: None