### PR TITLE
release-21.1: sql: materialized view creation rollback leaves behind references

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/faketreeeval"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
@@ -836,6 +837,98 @@ func (sc *SchemaChanger) initJobRunningStatus(ctx context.Context) error {
 	})
 }
 
+// dropViewDeps cleans up any dependencies that are related to a given view,
+// including anything that exists because of forward or back references.
+func (sc *SchemaChanger) dropViewDeps(
+	ctx context.Context,
+	descsCol *descs.Collection,
+	txn *kv.Txn,
+	b *kv.Batch,
+	viewDesc *tabledesc.Mutable,
+) error {
+	// Remove back-references from the tables/views this view depends on.
+	dependedOn := append([]descpb.ID(nil), viewDesc.DependsOn...)
+	for _, depID := range dependedOn {
+		dependencyDesc, err := descsCol.GetMutableTableVersionByID(ctx, depID, txn)
+		if err != nil {
+			log.Warningf(ctx, "error resolving dependency relation ID %d", depID)
+			continue
+		}
+		// The dependency is also being deleted, so we don't have to remove the
+		// references.
+		if dependencyDesc.Dropped() {
+			continue
+		}
+		dependencyDesc.DependedOnBy = removeMatchingReferences(dependencyDesc.DependedOnBy, viewDesc.ID)
+		if err := descsCol.WriteDescToBatch(ctx, false /* kvTrace*/, dependencyDesc, b); err != nil {
+			log.Warningf(ctx, "error removing dependency from releation ID %d", depID)
+			return err
+		}
+	}
+	viewDesc.DependsOn = nil
+	// If anything depends on this table clean up references from that object as well.
+	DependedOnBy := append([]descpb.TableDescriptor_Reference(nil), viewDesc.DependedOnBy...)
+	for _, depRef := range DependedOnBy {
+		dependencyDesc, err := descsCol.GetMutableTableVersionByID(ctx, depRef.ID, txn)
+		if err != nil {
+			log.Warningf(ctx, "error resolving dependency relation ID %d", depRef.ID)
+			continue
+		}
+		if dependencyDesc.Dropped() {
+			continue
+		}
+		// Entire dependent view needs to be cleaned up.
+		if err := sc.dropViewDeps(ctx, descsCol, txn, b, dependencyDesc); err != nil {
+			return err
+		}
+	}
+	// Clean up sequence and type references from the view.
+	for _, col := range viewDesc.DeletableColumns() {
+		for id := range typedesc.GetTypeDescriptorClosure(col.GetType()) {
+			typeDesc, err := descsCol.GetMutableTypeByID(ctx,
+				txn,
+				id,
+				tree.ObjectLookupFlags{
+					CommonLookupFlags: tree.CommonLookupFlags{
+						AvoidCached: true,
+					},
+				})
+			if err != nil {
+				log.Warningf(ctx, "error resolving type dependency %d", id)
+				continue
+			}
+			typeDesc.RemoveReferencingDescriptorID(viewDesc.GetID())
+			if err := descsCol.WriteDescToBatch(ctx, false /* kvTrace*/, typeDesc, b); err != nil {
+				log.Warningf(ctx, "error removing dependency from type ID %d", id)
+				return err
+			}
+		}
+		for i := 0; i < col.NumUsesSequences(); i++ {
+			id := col.GetUsesSequenceID(i)
+			seqDesc, err := descsCol.GetMutableTableVersionByID(ctx, id, txn)
+			if err != nil {
+				log.Warningf(ctx, "error resolving sequence dependency %d", id)
+				continue
+			}
+			if seqDesc.Dropped() {
+				continue
+			}
+			DependedOnBy := seqDesc.DependedOnBy
+			seqDesc.DependedOnBy = seqDesc.DependedOnBy[:0]
+			for _, dep := range DependedOnBy {
+				if dep.ID != viewDesc.ID {
+					seqDesc.DependedOnBy = append(seqDesc.DependedOnBy, dep)
+				}
+			}
+			if err := descsCol.WriteDescToBatch(ctx, false /* kvTrace*/, seqDesc, b); err != nil {
+				log.Warningf(ctx, "error removing dependency from sequence ID %d", id)
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func (sc *SchemaChanger) rollbackSchemaChange(ctx context.Context, err error) error {
 	log.Warningf(ctx, "reversing schema change %d due to irrecoverable error: %s", sc.job.ID(), err)
 	if errReverse := sc.maybeReverseMutations(ctx, err); errReverse != nil {
@@ -868,6 +961,12 @@ func (sc *SchemaChanger) rollbackSchemaChange(ctx context.Context, err error) er
 		}
 
 		b := txn.NewBatch()
+		// For views, we need to clean up and references that exist to tables.
+		if scTable.IsView() {
+			if err := sc.dropViewDeps(ctx, descsCol, txn, b, scTable); err != nil {
+				return err
+			}
+		}
 		scTable.SetDropped()
 		if err := descsCol.WriteDescToBatch(ctx, false /* kvTrace */, scTable, b); err != nil {
 			return err


### PR DESCRIPTION
Backport 1/1 commits from #82087.

/cc @cockroachdb/release

---

Fixes: #82079

Previously, if materialized view creation failed during the back
fill stage, we would properly clean up the view but not any of the
back references. This was inadequate because it would leave to
objects that are not droppable potentially, because of references
to a non-existent object. To address this, this patch will
add code to clean up the back / forward references for materialized
views.

Release note (bug fix): Rollback of materialized view creation
left references inside dependent objects.

Release justification: low risk fix addressing a rollback issue when dropping materialized views