### PR TITLE
sql: fix recent issue with a builtin

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -1136,3 +1136,10 @@ SELECT * FROM t69684 WHERE crdb_internal.increment_feature_counter(a)
 # The output is non-deterministic.
 statement ok
 SELECT crdb_internal.probe_ranges(INTERVAL '1000ms', 'write')
+
+# Regression test for not handling NULL values correctly by an internal builtin
+# (#82056).
+query I
+SELECT crdb_internal.num_inverted_index_entries(NULL::STRING, 0)
+----
+0

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -5668,6 +5668,9 @@ value if you rely on the HLC for accuracy.`,
 				// TODO(jordan): need to re-evaluate when we support more than just
 				// trigram inverted indexes.
 				// The version argument is currently ignored for string inverted indexes.
+				if args[0] == tree.DNull {
+					return tree.DZero, nil
+				}
 				s := string(tree.MustBeDString(args[0]))
 				return tree.NewDInt(tree.DInt(len(trigram.MakeTrigrams(s, true /* pad */)))), nil
 			},


### PR DESCRIPTION
In #81418 we forgot to check the argument of
`num_inverted_index_entries` builtin for NULL-ity.

Fixes: #82056.

Release note: None