### PR TITLE
ui: display the lowest version of node in mixed version cluster state

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/nodes.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/nodes.ts
@@ -513,6 +513,25 @@ export const singleVersionSelector = createSelector(
   },
 );
 
+// clusterVersionSelector returns build version of the cluster, or returns the lowest version
+// if cluster's version is staggered.
+export const clusterVersionLabelSelector = createSelector(
+  versionsSelector,
+  builds => {
+    if (!builds) {
+      return undefined;
+    }
+    if (builds.length > 1) {
+      const lowestVersion = _.chain(builds)
+        .sortBy(b => b)
+        .first()
+        .value();
+      return `${lowestVersion} - Mixed Versions`;
+    }
+    return builds[0];
+  },
+);
+
 /**
  * partitionedStatuses divides the list of node statuses into "live" and "dead".
  */

--- a/pkg/ui/workspaces/db-console/src/views/app/containers/layout/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/containers/layout/index.tsx
@@ -21,7 +21,7 @@ import RequireLogin from "src/views/login/requireLogin";
 import {
   clusterIdSelector,
   clusterNameSelector,
-  singleVersionSelector,
+  clusterVersionLabelSelector,
 } from "src/redux/nodes";
 import { AdminUIState } from "src/redux/state";
 import LoginIndicator from "src/views/app/components/loginIndicator";
@@ -112,7 +112,7 @@ class Layout extends React.Component<LayoutProps & RouteComponentProps> {
 const mapStateToProps = (state: AdminUIState) => {
   return {
     clusterName: clusterNameSelector(state),
-    clusterVersion: singleVersionSelector(state),
+    clusterVersion: clusterVersionLabelSelector(state),
     clusterId: clusterIdSelector(state),
   };
 };


### PR DESCRIPTION
Resolves: #80729

Previously, when cluster had nodes with different versions, it didn't
display cluster version on Cluster overview page (near cluster ID label).

Now, the lowest node version is displayed with additional label
"Mixed Versions" to bring users' attention to that cluster runs in
mixed version state.

Release note (ui change): display the old version of cluster
(cluster_version - Mixed Versions) when cluster runs nodes with
different versions.

Screen:
<img width="1414" alt="Screen Shot 2022-05-31 at 13 51 38" src="https://user-images.githubusercontent.com/3106437/171158622-1931fcde-3de1-4545-9019-14340c41b1d7.png">
