### PR TITLE
upgradessccl: fix breakage in BUILD.bazel

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -57,7 +57,6 @@ ALL_TESTS = [
     "//pkg/ccl/telemetryccl:telemetryccl_test",
     "//pkg/ccl/testccl/sqlccl:sqlccl_test",
     "//pkg/ccl/testccl/workload/schemachange:schemachange_test",
-    "//pkg/ccl/upgradeccl/upgradessccl:upgradesccl_test",
     "//pkg/ccl/upgradeccl/upgradessccl:upgradessccl_test",
     "//pkg/ccl/utilccl/sampledataccl:sampledataccl_test",
     "//pkg/ccl/utilccl:utilccl_test",

--- a/pkg/ccl/upgradeccl/upgradessccl/BUILD.bazel
+++ b/pkg/ccl/upgradeccl/upgradessccl/BUILD.bazel
@@ -1,35 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
-    name = "upgradesccl_test",
-    srcs = [
-        "main_test.go",
-        "seed_span_counts_external_test.go",
-        "seed_tenant_span_configs_external_test.go",
-    ],
-    deps = [
-        "//pkg/base",
-        "//pkg/ccl/kvccl/kvtenantccl",
-        "//pkg/clusterversion",
-        "//pkg/keys",
-        "//pkg/roachpb",
-        "//pkg/security",
-        "//pkg/security/securitytest",
-        "//pkg/security/username",
-        "//pkg/server",
-        "//pkg/settings/cluster",
-        "//pkg/spanconfig",
-        "//pkg/testutils",
-        "//pkg/testutils/serverutils",
-        "//pkg/testutils/sqlutils",
-        "//pkg/testutils/testcluster",
-        "//pkg/util/leaktest",
-        "//pkg/util/log",
-        "@com_github_stretchr_testify//require",
-    ],
-)
-
-go_test(
     name = "upgradessccl_test",
     srcs = [
         "main_test.go",


### PR DESCRIPTION
The duplicated directive was making `dev generate bazel` unable to
keep the list of deps in sync.

Release note: None