### PR TITLE
roachtest: fix `safe.directory` requirement for git clone

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1717,7 +1717,7 @@ func (c *clusterImpl) GitClone(
 ) error {
 	cmd := []string{"bash", "-e", "-c", fmt.Sprintf(`'
 		if ! test -d %[1]s; then
-			git clone -b %[2]s --depth 1 %[3]s %[1]s
+			git clone -b %[2]s --depth 1 %[3]s %[1]s --add safe.directory %[1]s
   		else
 			cd %[1]s
 		git fetch origin


### PR DESCRIPTION
Some roachtests are failing recently for git requires setting the safe 
destination directory explicitly. It is related to
https://github.blog/2022-04-12-git-security-vulnerability-announced/.

fixes #81722

Release note: None