### PR TITLE
sql: add cancel checking to ordered aggregator

### DIFF
--- a/pkg/sql/colexec/colexecjoin/crossjoiner.go
+++ b/pkg/sql/colexec/colexecjoin/crossjoiner.go
@@ -89,6 +89,7 @@ func (c *crossJoiner) Init(ctx context.Context) {
 }
 
 func (c *crossJoiner) Next() coldata.Batch {
+	c.cancelChecker.CheckEveryCall()
 	if c.done {
 		return coldata.ZeroBatch
 	}
@@ -362,11 +363,13 @@ type crossJoinerBase struct {
 		// that should be "skipped" when building from the right input.
 		rightColOffset int
 	}
-	output coldata.Batch
+	output        coldata.Batch
+	cancelChecker colexecutils.CancelChecker
 }
 
 func (b *crossJoinerBase) init(ctx context.Context) {
 	b.initHelper.Init(ctx)
+	b.cancelChecker.Init(ctx)
 }
 
 func (b *crossJoinerBase) setupLeftBuilder() {


### PR DESCRIPTION
sql: add cancel checking to ordered aggregator

Previously we didn't check for cancelation in ordered aggregator which
can consume quite a bit of time, add a cancel checker.
  
Upon inspection Yahor also realized the cross joiner could also miss
cancelations so add it there too.
    
Fixes: #78175

Release note: None

Release justification: low risk, high benefit change
