### PR TITLE
Fix sql stats compaction job scheduling

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/scheduled_job_monitor.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/scheduled_job_monitor.go
@@ -71,7 +71,10 @@ func (j *jobMonitor) start(ctx context.Context, stopper *stop.Stopper) {
 	j.registerClusterSettingHook()
 
 	_ = stopper.RunAsyncTask(ctx, "sql-stats-scheduled-compaction-job-monitor", func(ctx context.Context) {
-		for timer := timeutil.NewTimer(); ; timer.Reset(j.jitterFn(j.scanInterval)) {
+		timer := timeutil.NewTimer()
+		defer timer.Stop()
+		for {
+			timer.Reset(j.jitterFn(j.scanInterval))
 			select {
 			case <-timer.C:
 				timer.Read = true


### PR DESCRIPTION
Fixes #80561

This commit fixes the scheduling of the sql stats compaction job, so that it now
wakes up and ensures the schedule after the first time.

This was manually tested by adding a print statement in ensureSchedule, reducing
defaultScanInterval to 6 seconds, and seeing that ensureSchedule was now being
called.

Release note (bug fix): Fixed a bug introduced in v21.2 where the
`sql-stats-compaction` job had a chance of not being scheduled during a 21.1 to
21.2 upgrade, causing persisted Statement and Transaction statistics to be
enabled without memory accounting.