### PR TITLE
clisqlshell: fix a bug where `\copy` would fail

### DIFF
--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -1235,13 +1235,16 @@ func (c *cliState) doHandleCliCmd(loopState, nextState cliStateEnum) cliStateEnu
 
 	case `\copy`:
 		c.exitErr = c.runWithInterruptableCtx(func(ctx context.Context) error {
-			return c.beginCopyFrom(ctx, c.concatLines)
+			// Strip out the starting \ in \copy.
+			return c.beginCopyFrom(ctx, line[1:])
 		})
-		if !c.singleStatement {
-			clierror.OutputError(c.iCtx.stderr, c.exitErr, true /*showSeverity*/, false /*verbose*/)
-		}
-		if c.exitErr != nil && c.iCtx.errExit {
-			return cliStop
+		if c.exitErr != nil {
+			if !c.singleStatement {
+				clierror.OutputError(c.iCtx.stderr, c.exitErr, true /*showSeverity*/, false /*verbose*/)
+			}
+			if c.iCtx.errExit {
+				return cliStop
+			}
 		}
 		return cliStartLine
 

--- a/pkg/cli/interactive_tests/test_copy.tcl
+++ b/pkg/cli/interactive_tests/test_copy.tcl
@@ -60,7 +60,11 @@ eexpect "COPY 3"
 eexpect root@
 
 # Try \copy as well.
-send "\copy t FROM STDIN CSV;\r"
+send "\\copy t FROM STDIN CSV INVALID;\r"
+eexpect "syntax error"
+eexpect root@
+
+send "\\copy t FROM STDIN CSV;\r"
 eexpect ">>"
 send "4,epa! epa!\r"
 send_eof


### PR DESCRIPTION
Resolves #82097

Release note (bug fix): Fix a bug where `\copy` in CLI would panic.