### PR TITLE
[WIP] opt: add hint to ignore preserved-multiplicity consistency

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1127,6 +1127,7 @@ unreserved_keyword ::=
 	| 'NOWAIT'
 	| 'NULLS'
 	| 'IGNORE_FOREIGN_KEYS'
+	| 'IGNORE_PRESERVED_CONSISTENCY'
 	| 'INSENSITIVE'
 	| 'OF'
 	| 'OFF'

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -486,15 +486,16 @@ func (md *Metadata) DuplicateTable(
 	}
 
 	md.tables = append(md.tables, TableMeta{
-		MetaID:                   newTabID,
-		Table:                    tabMeta.Table,
-		Alias:                    tabMeta.Alias,
-		IgnoreForeignKeys:        tabMeta.IgnoreForeignKeys,
-		Constraints:              constraints,
-		ComputedCols:             computedCols,
-		partialIndexPredicates:   partialIndexPredicates,
-		indexPartitionLocalities: tabMeta.indexPartitionLocalities,
-		checkConstraintsStats:    checkConstraintsStats,
+		MetaID:                     newTabID,
+		Table:                      tabMeta.Table,
+		Alias:                      tabMeta.Alias,
+		IgnoreForeignKeys:          tabMeta.IgnoreForeignKeys,
+		IgnorePreservedConsistency: tabMeta.IgnorePreservedConsistency,
+		Constraints:                constraints,
+		ComputedCols:               computedCols,
+		partialIndexPredicates:     partialIndexPredicates,
+		indexPartitionLocalities:   tabMeta.indexPartitionLocalities,
+		checkConstraintsStats:      checkConstraintsStats,
 	})
 
 	return newTabID

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -933,6 +933,10 @@ func (c *CustomFuncs) JoinPreservesRightRows(join memo.RelExpr) bool {
 	return mult.JoinPreservesRightRows(join.Op())
 }
 
+func (c *CustomFuncs) IndexJoinPreservesRows(expr memo.RelExpr) bool {
+	return !memo.CheckIgnorePreservedConsistency(c.mem.Metadata(), expr)
+}
+
 // NoJoinHints returns true if no hints were specified for this join.
 func (c *CustomFuncs) NoJoinHints(p *memo.JoinPrivate) bool {
 	return p.Flags.Empty()

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -1571,3 +1571,11 @@ distinct-on
       │    └── column1
       └── first-agg
            └── "?column?"
+
+exec-ddl
+CREATE TABLE m (n INT PRIMARY KEY, o INT, p INT, INDEX (p))
+----
+
+optsteps
+SELECT * FROM m WHERE p > 5 AND p < 100 ORDER BY p LIMIT 5
+----

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -461,6 +461,9 @@ func (b *Builder) buildScan(
 		if indexFlags.IgnoreUniqueWithoutIndexKeys {
 			tabMeta.IgnoreUniqueWithoutIndexKeys = true
 		}
+		if indexFlags.IgnorePreservedConsistency {
+			tabMeta.IgnorePreservedConsistency = true
+		}
 	}
 
 	outScope = inScope.push()

--- a/pkg/sql/opt/table_meta.go
+++ b/pkg/sql/opt/table_meta.go
@@ -141,6 +141,12 @@ type TableMeta struct {
 	// depend on the consistency of unique without index constraints.
 	IgnoreUniqueWithoutIndexKeys bool
 
+	// IgnorePreservedConsistency is true if we should disable any rules that
+	// depend on preserved-multiplicity consistency of this table (i.e. rules that
+	// assume there is always a PK row for every secondary index row or a FK row
+	// for every FK reference). This is used for SKIP LOCKED queries.
+	IgnorePreservedConsistency bool
+
 	// Constraints stores a *FiltersExpr containing filters that are known to
 	// evaluate to true on the table data. This list is extracted from validated
 	// check constraints; specifically, those check constraints that we can prove
@@ -202,6 +208,7 @@ func (tm *TableMeta) copyFrom(from *TableMeta, copyScalarFn func(Expr) Expr) {
 		Alias:                        from.Alias,
 		IgnoreForeignKeys:            from.IgnoreForeignKeys,
 		IgnoreUniqueWithoutIndexKeys: from.IgnoreUniqueWithoutIndexKeys,
+		IgnorePreservedConsistency:   from.IgnorePreservedConsistency,
 		// Annotations are not copied.
 	}
 

--- a/pkg/sql/opt/xform/rules/limit.opt
+++ b/pkg/sql/opt/xform/rules/limit.opt
@@ -41,7 +41,8 @@
 # TODO(radu): we can similarly push Offset too.
 [PushLimitIntoIndexJoin, Explore]
 (Limit
-    (IndexJoin $input:* $indexJoinPrivate:*)
+    (IndexJoin $input:* $indexJoinPrivate:*) &
+        (IndexJoinPreservesRows $input)
     $limitExpr:(Const $limit:* & (IsPositiveInt $limit))
     $ordering:* &
         (OrderingCanProjectCols

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -838,7 +838,8 @@ func (u *sqlSymUnion) asTenantClause() tree.TenantID {
 %token <str> HAVING HASH HEADER HIGH HISTOGRAM HOLD HOUR
 
 %token <str> IDENTITY
-%token <str> IF IFERROR IFNULL IGNORE_FOREIGN_KEYS ILIKE IMMEDIATE IMPORT IN INCLUDE
+%token <str> IF IFERROR IFNULL IGNORE_FOREIGN_KEYS IGNORE_PRESERVED_CONSISTENCY ILIKE IMMEDIATE
+%token <str> IMPORT IN INCLUDE
 %token <str> INCLUDING INCREMENT INCREMENTAL INCREMENTAL_LOCATION
 %token <str> INET INET_CONTAINED_BY_OR_EQUALS
 %token <str> INET_CONTAINS_OR_EQUALS INDEX INDEXES INHERITS INJECT INITIALLY
@@ -10665,6 +10666,12 @@ index_flags_param:
     $$.val = &tree.IndexFlags{IgnoreForeignKeys: true}
   }
 |
+  IGNORE_PRESERVED_CONSISTENCY
+  {
+    /* SKIP DOC */
+    $$.val = &tree.IndexFlags{IgnorePreservedConsistency: true}
+  }
+|
   FORCE_ZIGZAG
   {
      $$.val = &tree.IndexFlags{ForceZigzag: true}
@@ -10741,6 +10748,7 @@ opt_index_flags:
 //   '{' NO_ZIGZAG_JOIN [, ...] '}'
 //   '{' NO_FULL_SCAN [, ...] '}'
 //   '{' IGNORE_FOREIGN_KEYS [, ...] '}'
+//   '{' IGNORE_PRESERVED_CONSISTENCY [, ...] '}'
 //   '{' FORCE_ZIGZAG = <idxname> [, ...]  '}'
 //
 // Join types:
@@ -14255,6 +14263,7 @@ unreserved_keyword:
 | NOWAIT
 | NULLS
 | IGNORE_FOREIGN_KEYS
+| IGNORE_PRESERVED_CONSISTENCY
 | INSENSITIVE
 | OF
 | OFF


### PR DESCRIPTION
For some queries (e.g. SELECT FOR UPDATE SKIP LOCKED) we need to disable
optimizations that depend on preserved-multiplicity consistency of
tables. Add an IGNORE_PRESERVED_CONSISTENCY hint that turns off these
optimizations. With this hint, we will no longer use optimizations that
assume:
- a PK row exists for every secondary index row
- a FK row exists for every referenced FK

Release note: None