### PR TITLE
logictest: fix test flake in distsql_event_log

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_event_log
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_event_log
@@ -16,7 +16,7 @@ CREATE TABLE a (id INT PRIMARY KEY, x INT, y INT, INDEX x_idx (x, y))
 statement ok
 CREATE STATISTICS s1 ON id FROM a
 
-statement ok
+statement ok retry
 CREATE STATISTICS __auto__ FROM a
 
 # Check explicitly for table id 106. System tables could trigger autostats


### PR DESCRIPTION
Fixes #82108

This commit fixes a test flake caused by conflicting stats jobs.

Release note: none