### PR TITLE
storage: add batch and multi-version `BenchmarkMVCCPut` variants

### DIFF
--- a/pkg/storage/bench_pebble_test.go
+++ b/pkg/storage/bench_pebble_test.go
@@ -190,10 +190,14 @@ func BenchmarkMVCCFindSplitKey_Pebble(b *testing.B) {
 
 func BenchmarkMVCCPut_Pebble(b *testing.B) {
 	ctx := context.Background()
-	for _, valueSize := range []int{10, 100, 1000, 10000} {
-		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
-			runMVCCPut(ctx, b, setupMVCCInMemPebble, valueSize)
-		})
+	for _, batch := range []bool{false, true} {
+		for _, valueSize := range []int{10, 100, 1000, 10000} {
+			for _, versions := range []int{1, 10} {
+				b.Run(fmt.Sprintf("batch=%t,valueSize=%d,versions=%d", batch, valueSize, versions), func(b *testing.B) {
+					runMVCCPut(ctx, b, setupMVCCInMemPebble, valueSize, versions, batch)
+				})
+			}
+		}
 	}
 }
 

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -942,7 +942,9 @@ func runMVCCGet(ctx context.Context, b *testing.B, emk engineMaker, opts benchDa
 	b.StopTimer()
 }
 
-func runMVCCPut(ctx context.Context, b *testing.B, emk engineMaker, valueSize int) {
+func runMVCCPut(
+	ctx context.Context, b *testing.B, emk engineMaker, valueSize, versions int, useBatch bool,
+) {
 	rng, _ := randutil.NewTestRand()
 	value := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, valueSize))
 	keyBuf := append(make([]byte, 0, 64), []byte("key-")...)
@@ -950,14 +952,23 @@ func runMVCCPut(ctx context.Context, b *testing.B, emk engineMaker, valueSize in
 	eng := emk(b, fmt.Sprintf("put_%d", valueSize))
 	defer eng.Close()
 
+	rw := ReadWriter(eng)
+	if useBatch {
+		batch := eng.NewBatch()
+		defer batch.Close()
+		rw = batch
+	}
+
 	b.SetBytes(int64(valueSize))
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		key := roachpb.Key(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(i)))
-		ts := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
-		if err := MVCCPut(ctx, eng, nil, key, ts, hlc.ClockTimestamp{}, value, nil); err != nil {
-			b.Fatalf("failed put: %+v", err)
+		for j := 0; j < versions; j++ {
+			key := roachpb.Key(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(i)))
+			ts := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
+			if err := MVCCPut(ctx, rw, nil, key, ts, hlc.ClockTimestamp{}, value, nil); err != nil {
+				b.Fatalf("failed put: %+v", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Release note: None