### PR TITLE
parser: fix panic on CREATE SEQUENCE with invalid type name

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -33,6 +33,8 @@ import (
     "github.com/cockroachdb/cockroach/pkg/roachpb"
     "github.com/cockroachdb/cockroach/pkg/security/username"
     "github.com/cockroachdb/cockroach/pkg/sql/lexbase"
+    "github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+    "github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
     "github.com/cockroachdb/cockroach/pkg/sql/privilege"
     "github.com/cockroachdb/cockroach/pkg/sql/roleoption"
     "github.com/cockroachdb/cockroach/pkg/sql/scanner"
@@ -8124,6 +8126,11 @@ sequence_option_elem:
   AS typename                  {
                                   // Valid option values must be integer types (ex. int2, bigint)
                                   parsedType := $2.colType()
+                                  if parsedType == nil {
+                                      sqllex.(*lexer).lastError = pgerror.Newf(pgcode.UndefinedObject, "type %q does not exist", $2.val)
+                                      sqllex.(*lexer).populateErrorDetails()
+                                      return 1
+                                  }
                                   if parsedType.Family() != types.IntFamily {
                                       sqllex.Error(fmt.Sprintf("invalid integer type: %s", parsedType.SQLString()))
                                       return 1

--- a/pkg/sql/parser/testdata/create_sequence
+++ b/pkg/sql/parser/testdata/create_sequence
@@ -237,3 +237,11 @@ CREATE SEQUENCE IF NOT EXISTS a INCREMENT BY 5 RESTART WITH 1000
 CREATE SEQUENCE IF NOT EXISTS a INCREMENT BY 5 RESTART WITH 1000 -- fully parenthesized
 CREATE SEQUENCE IF NOT EXISTS a INCREMENT BY 0 RESTART WITH 0 -- literals removed
 CREATE SEQUENCE IF NOT EXISTS _ INCREMENT BY 5 RESTART WITH 1000 -- identifiers removed
+
+error
+CREATE SEQUENCE s1 AS abc
+----
+at or near "EOF": syntax error: type "abc" does not exist
+DETAIL: source SQL:
+CREATE SEQUENCE s1 AS abc
+                         ^


### PR DESCRIPTION
Fixes #82192

Previously, a statement such AS `CREATE SEQUENCE s1 AS abc` would
panic if `abc` is not a valid type name.

This fix adds a nil pointer check in the syntaxer when the type name
cannot be resolved, and returns an error message instead.

Release note (bug fix): This patch fixes the `CREATE SEQUENCE ... AS`
statement to return a valid error message when the specified type name
does not exist.