### PR TITLE
bazci: correct `errors.As()` call

### DIFF
--- a/pkg/cmd/bazci/bazci.go
+++ b/pkg/cmd/bazci/bazci.go
@@ -165,7 +165,7 @@ func runBazelReturningStdout(subcmd string, arg ...string) (string, error) {
 		if len(buf) > 0 {
 			fmt.Printf("COMMAND STDOUT:\n%s\n", string(buf))
 		}
-		var cmderr exec.ExitError
+		var cmderr *exec.ExitError
 		if errors.As(err, &cmderr) && len(cmderr.Stderr) > 0 {
 			fmt.Printf("COMMAND STDERR:\n%s\n", string(cmderr.Stderr))
 		}


### PR DESCRIPTION
The second argument should be a pointer to a type that implements
`error`, so just make this type a pointer.

Closes #82120.

Release note: None