### PR TITLE
tests: fix bad version check in multitenant fairness tests

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_utils.go
+++ b/pkg/cmd/roachtest/tests/multitenant_utils.go
@@ -69,7 +69,7 @@ func createTenantNode(
 	v := version.MustParse(versionStr)
 	require.NoError(t, err)
 	// Tenant scoped certificates were introduced in version 22.1.
-	if v.AtLeast(version.MustParse("22.1.0")) {
+	if v.AtLeast(version.MustParse("v22.1.0")) {
 		tn.recreateClientCertsWithTenantScope(ctx, c)
 	}
 	tn.createTenantCert(ctx, t, c)


### PR DESCRIPTION
Fixes #82257

This commit fixes a malformed cockroach version string that doesn't
start with a `v`.

Release note: none