### PR TITLE
acceptance: add extra `dep` on `securityassets` in `acceptance`

### DIFF
--- a/pkg/acceptance/BUILD.bazel
+++ b/pkg/acceptance/BUILD.bazel
@@ -14,7 +14,8 @@ go_library(
         "//pkg/acceptance/cluster",
         "//pkg/base",
         "//pkg/build/bazel",
-        "//pkg/security/securitytest",  #keep
+        "//pkg/security/securityassets",  # keep
+        "//pkg/security/securitytest",  # keep
         "//pkg/security/username",
         "//pkg/server",  # keep
         "//pkg/testutils",


### PR DESCRIPTION
`2bb800eda4ef5635050950c879806e48d45e7a84` broke this, but due to a bug
in `bazci` (see https://github.com/cockroachdb/cockroach/issues/82120) the failure was not evident.

Release note: None