### PR TITLE
roachtest: fix safe.directory requirement for git config

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1717,7 +1717,8 @@ func (c *clusterImpl) GitClone(
 ) error {
 	cmd := []string{"bash", "-e", "-c", fmt.Sprintf(`'
 		if ! test -d %[1]s; then
-			git clone -b %[2]s --depth 1 %[3]s %[1]s --add safe.directory %[1]s
+			git config --global --add safe.directory %[1]s
+			git clone -b %[2]s --depth 1 %[3]s %[1]s
   		else
 			cd %[1]s
 		git fetch origin


### PR DESCRIPTION
The previous fix (#82145) was wrong and is breaking multiple roachtests.

fixes #82198
fixes #82199
fixes #82205
fixes #82207
fixes #82215
fixes #82225
fixes #82224
fixes #82247
fixes #82258
fixes #82261
fixes #82262
fixes #82263
fixes #82264
fixes #82265
fixes #82267
fixes #82268
fixes #82269

Release note: None