### PR TITLE
tests: update version check for tenant scoping

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_utils.go
+++ b/pkg/cmd/roachtest/tests/multitenant_utils.go
@@ -68,8 +68,8 @@ func createTenantNode(
 	versionStr, err := fetchCockroachVersion(ctx, t.L(), c, n[0])
 	v := version.MustParse(versionStr)
 	require.NoError(t, err)
-	// Tenant scoped certificates were introduced in version 22.1.
-	if v.AtLeast(version.MustParse("v22.1.0")) {
+	// Tenant scoped certificates were introduced in version 22.2.
+	if v.AtLeast(version.MustParse("v22.2.0")) {
 		tn.recreateClientCertsWithTenantScope(ctx, c)
 	}
 	tn.createTenantCert(ctx, t, c)


### PR DESCRIPTION
This PR fixes the version gate check to add tenant
scoping while creating client certs for tenant
roachtests. It is erroneously gated on v22.1 when it
should be v22.2.

Release note: None