### PR TITLE
dev: add `doctor` check for `patch` version

### DIFF
--- a/dev
+++ b/dev
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=33
+DEV_VERSION=34
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/doctor.go
+++ b/pkg/cmd/dev/doctor.go
@@ -32,7 +32,7 @@ const (
 	// doctorStatusVersion is the current "version" of the status checks performed
 	// by `dev doctor``. Increasing it will force doctor to be re-run before other
 	// dev commands can be run.
-	doctorStatusVersion = 3
+	doctorStatusVersion = 4
 
 	noCacheFlag = "no-cache"
 )
@@ -181,6 +181,41 @@ Please perform the following steps:
 					}
 					failures = append(failures, msg)
 				}
+			}
+		}
+	}
+	d.log.Println("doctor: running patch check")
+	{
+		stdouts, err := d.exec.CommandContextSilent(ctx, "which", "patch")
+		if err != nil {
+			panic(err)
+		}
+		d.log.Printf("which patch = %s", string(stdouts))
+		stdout, err := d.exec.CommandContextSilent(ctx, "patch", "-v")
+		stdoutStr := strings.TrimSpace(string(stdout))
+		if err != nil {
+			log.Println("Failed to run `patch`. `patch` v2.7+ is required.")
+			printStdoutAndErr(stdoutStr, err)
+			failureStr := "Please install GNU `patch`."
+			if runtime.GOOS == "darwin" {
+				failureStr += "\nYou can install GNU patch with: `brew install gpatch`"
+			}
+			failures = append(failures, failureStr)
+		} else {
+			firstLine := strings.Split(stdoutStr, "\n")[0]
+			fields := strings.Fields(firstLine)
+			ver := fields[len(fields)-1]
+			d.log.Printf("got version %s", ver)
+			if ver < "2.7" {
+				failureStr := fmt.Sprintf("The installed version of `patch` is too old: %s", ver)
+				if runtime.GOOS == "darwin" {
+					failureStr += `
+You can install a more recent version of ` + "`patch` with: `brew install gpatch`" + `
+If you have already installed the package with brew but this check is still
+failing, you may have to update your $PATH so that ` + "`which path`" + ` returns
+the homebrew-installed path rather than /usr/bin/patch.`
+				}
+				failures = append(failures, failureStr)
 			}
 		}
 	}


### PR DESCRIPTION
The UI build has been broken on most Macs since
`5b6c271b1cd78323ac11cde677834d4918c183f4`, as parsing the patch files
introduced in that commit requires a later version of GNU patch than
gets installed on macOS by default. Add a `doctor` check to make sure
that the `patch` at the head of the `PATH` is v2.7+.

Release note: None