### PR TITLE
release-21.2: cli: stop ignoring user arg in insecure mode

### DIFF
--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -973,7 +973,8 @@ func (c *transientCluster) getNetworkURLForServer(
 	host, port, _ := addr.SplitHostPort(c.servers[serverIdx].ServingSQLAddr(), "")
 	u.
 		WithNet(pgurl.NetTCP(host, port)).
-		WithDatabase(c.defaultDB)
+		WithDatabase(c.defaultDB).
+		WithUsername(c.adminUser.Normalized())
 
 	// For a demo cluster we don't use client TLS certs and instead use
 	// password-based authentication with the password pre-filled in the
@@ -982,7 +983,6 @@ func (c *transientCluster) getNetworkURLForServer(
 		u.WithInsecure()
 	} else {
 		u.
-			WithUsername(c.adminUser.Normalized()).
 			WithAuthn(pgurl.AuthnPassword(true, c.adminPassword)).
 			WithTransport(pgurl.TransportTLS(pgurl.TLSRequire, ""))
 	}

--- a/pkg/cli/interactive_tests/test_style_enabled.tcl
+++ b/pkg/cli/interactive_tests/test_style_enabled.tcl
@@ -19,7 +19,7 @@ eexpect eof
 
 # Try connect and check the session variables match.
 
-spawn $argv sql --url "postgresql://test@localhost:26257?options=-cintervalstyle%3Diso_8601"
+spawn $argv sql --url "postgresql://root@localhost:26257?options=-cintervalstyle%3Diso_8601"
 eexpect root@
 send "SHOW intervalstyle;\r"
 eexpect "iso_8601"
@@ -28,7 +28,7 @@ interrupt
 eexpect eof
 
 # TODO(#72065): uncomment
-#spawn $argv sql --url "postgresql://test@localhost:26257?options=-cdatestyle%3Dymd"
+#spawn $argv sql --url "postgresql://root@localhost:26257?options=-cdatestyle%3Dymd"
 #eexpect root@
 #send "SHOW datestyle;\r"
 #eexpect "ISO, YMD"

--- a/pkg/cli/interactive_tests/test_url_db_override.tcl
+++ b/pkg/cli/interactive_tests/test_url_db_override.tcl
@@ -23,6 +23,11 @@ spawn $argv sql --url "postgresql://test@localhost:26257" --insecure -e "select 
 eexpect "1 row"
 eexpect eof
 
+# Make sure --insecure does not override --user
+spawn $argv sql --user=test --insecure -e "select 'user=' || current_user()"
+eexpect "user=test"
+eexpect eof
+
 set ::env(COCKROACH_INSECURE) "true"
 end_test
 

--- a/pkg/server/pgurl/pgurl.go
+++ b/pkg/server/pgurl/pgurl.go
@@ -138,7 +138,6 @@ func (u *URL) GetExtraOptions() url.Values {
 // all security controls disabled.
 func (u *URL) WithInsecure() *URL {
 	return u.
-		WithUsername("root").
 		WithAuthn(AuthnNone()).
 		WithTransport(TransportNone())
 }

--- a/pkg/server/pgurl/testdata/url
+++ b/pkg/server/pgurl/testdata/url
@@ -90,13 +90,13 @@ JDBC:   jdbc:postgresql://somehost:26257/somedb?application_name=myapp&password=
 
 insecure
 ----
-pq URL: postgresql://root@/?sslmode=disable
-DSN:    user=root sslmode=disable
-JDBC:   jdbc:postgresql:///?sslmode=disable&user=root
+pq URL: postgresql:///?sslmode=disable
+DSN:    sslmode=disable
+JDBC:   jdbc:postgresql:///?sslmode=disable
 --defaults filled--
-pq URL: postgresql://root@defaulthost:26257/defaultdb?sslmode=disable
-DSN:    database=defaultdb user=root host=defaulthost port=26257 sslmode=disable
-JDBC:   jdbc:postgresql://defaulthost:26257/defaultdb?sslmode=disable&user=root
+pq URL: postgresql://defaultuser@defaulthost:26257/defaultdb?sslmode=disable
+DSN:    database=defaultdb user=defaultuser host=defaulthost port=26257 sslmode=disable
+JDBC:   jdbc:postgresql://defaulthost:26257/defaultdb?sslmode=disable&user=defaultuser
 
 subtest redundant
 


### PR DESCRIPTION
Backport 1/1 commits from #75194.

/cc @cockroachdb/release

fixes https://github.com/cockroachdb/cockroach/issues/82287

Release justification: high value bug fix
---

fixes https://github.com/cockroachdb/cockroach/issues/74704

Release note (bug fix): The --user argument is no longer ignored when
using `cockroach sql` in --insecure mode.
