### PR TITLE
colfetcher: increase input batch size limit when using the Streamer

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/budget.go
+++ b/pkg/kv/kvclient/kvstreamer/budget.go
@@ -90,10 +90,10 @@ func (b *budget) consume(ctx context.Context, bytes int64, allowDebt bool) error
 func (b *budget) consumeLocked(ctx context.Context, bytes int64, allowDebt bool) error {
 	b.mu.AssertHeld()
 	// If we're asked to not exceed the limit (and the limit is greater than
-	// five bytes - limits of five bytes or less are treated as a special case
+	// eight bytes - limits of eight bytes or less are treated as a special case
 	// for "forced disk spilling" scenarios like in logic tests), we have to
 	// check whether we'll stay within the budget.
-	if !allowDebt && b.limitBytes > 5 {
+	if !allowDebt && b.limitBytes > 8 {
 		if b.mu.acc.Used()+bytes > b.limitBytes {
 			return errors.Wrap(
 				mon.MemoryResource.NewBudgetExceededError(bytes, b.mu.acc.Used(), b.limitBytes),


### PR DESCRIPTION
This commit bumps up the input batch size limit in the vectorized index
join from 4MiB to 8MiB when the streamer API is used. The old number was
copy-pasted from the row-by-row join reader, and the new number is
derived based on running TPCH queries 4, 5, 6, 10, 12, 14, 15, 16 using
`tpchvec/bench`. I did a quick run of the same queries with the
row-by-row engine used by default, and it seemed like the default of
4MiB there is reasonable, so I didn't change that one.

With the non-streamer code path we didn't want to go higher than 4MiB
since it showed diminishing returns while exposing the cluster to higher
instability (since the non-streamer code path doesn't use the memory
limits in the KV layer). The streamer does use memory limits for
BatchRequests, so it should be safe to increase this limit.

Additionally, this commit makes it so that 1/8th (rather than 1/4th) of
the workmem limit is reserved for the output batch of the cFetcher. With
the default value of 64MiB this would translate to 8MiB which is large
enough.

Addresses: #82159.

Release note: None