### PR TITLE
changefeedccl: correctly handle old-style protobufs in rowfetcher_cache

### DIFF
--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -252,8 +252,11 @@ func createBenchmarkChangefeed(
 		return nil, nil, err
 	}
 	serverCfg := s.DistSQLServer().(*distsql.ServerImpl).ServerConfig
-	eventConsumer := newKVEventToRowConsumer(ctx, &serverCfg, sf, initialHighWater,
+	eventConsumer, err := newKVEventToRowConsumer(ctx, &serverCfg, sf, initialHighWater,
 		sink, encoder, details, TestingKnobs{}, nil)
+	if err != nil {
+		return nil, nil, err
+	}
 	tickFn := func(ctx context.Context) (*jobspb.ResolvedSpan, error) {
 		event, err := buf.Get(ctx)
 		if err != nil {

--- a/pkg/ccl/changefeedccl/cdcevent/event_test.go
+++ b/pkg/ccl/changefeedccl/cdcevent/event_test.go
@@ -305,7 +305,8 @@ CREATE TABLE foo (
 
 			serverCfg := s.DistSQLServer().(*distsql.ServerImpl).ServerConfig
 			ctx := context.Background()
-			decoder := NewEventDecoder(ctx, &serverCfg, details)
+			decoder, err := NewEventDecoder(ctx, &serverCfg, details)
+			require.NoError(t, err)
 			expectedEvents := len(tc.expectMainFamily) + len(tc.expectOnlyCFamily)
 			for i := 0; i < expectedEvents; i++ {
 				v := popRow(t)
@@ -319,6 +320,131 @@ CREATE TABLE foo (
 				} else {
 					expect, tc.expectOnlyCFamily = tc.expectOnlyCFamily[0], tc.expectOnlyCFamily[1:]
 				}
+				updatedRow, err := decoder.DecodeKV(
+					ctx, roachpb.KeyValue{Key: v.Key, Value: v.Value}, v.Timestamp())
+
+				if expect.expectUnwatchedErr {
+					require.ErrorIs(t, err, ErrUnwatchedFamily)
+					continue
+				}
+
+				require.NoError(t, err)
+				require.True(t, updatedRow.IsInitialized())
+				if expect.deleted {
+					require.True(t, updatedRow.IsDeleted())
+				} else {
+					require.Equal(t, expect.keyValues, slurpDatums(t, updatedRow.ForEachKeyColumn()))
+					require.Equal(t, expect.allValues, slurpDatums(t, updatedRow.ForEachColumn()))
+				}
+
+				prevRow, err := decoder.DecodeKV(
+					ctx, roachpb.KeyValue{Key: v.Key, Value: v.PrevValue}, v.Timestamp())
+				require.NoError(t, err)
+
+				// prevRow always has key columns initialized.
+				require.Equal(t, expect.keyValues, slurpDatums(t, prevRow.ForEachKeyColumn()))
+
+				if expect.prevDeleted {
+					require.True(t, prevRow.IsDeleted())
+				} else {
+					require.Equal(t, expect.prevAllValues, slurpDatums(t, prevRow.ForEachColumn()))
+				}
+			}
+		})
+	}
+
+}
+
+func TestOldProtos(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
+
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, `
+CREATE TABLE foo (
+  a INT, 
+  b STRING, 
+  PRIMARY KEY (b, a)
+)`)
+
+	tableDesc := cdctest.GetHydratedTableDescriptor(t, s.ExecutorConfig(), kvDB, "foo")
+	popRow, cleanup := cdctest.MakeRangeFeedValueReader(t, s.ExecutorConfig(), tableDesc)
+	defer cleanup()
+
+	type decodeExpectation struct {
+		expectUnwatchedErr bool
+
+		// current value expectations.
+		deleted   bool
+		keyValues []string
+		allValues []string
+
+		// previous value expectations.
+		prevDeleted   bool
+		prevAllValues []string
+	}
+
+	for _, tc := range []struct {
+		testName      string
+		virtualColumn changefeedbase.VirtualColumnVisibility
+		actions       []string
+		expect        []decodeExpectation
+	}{
+		{
+			testName: "main/primary_cols",
+			actions:  []string{"INSERT INTO foo (a, b) VALUES (1, 'first test')"},
+			expect: []decodeExpectation{
+				{
+					keyValues:   []string{"first test", "1"},
+					allValues:   []string{"1", "first test"},
+					prevDeleted: true,
+				},
+			},
+		},
+		{
+			testName: "main/delete",
+			actions: []string{
+				"INSERT INTO foo (a, b) VALUES (1, '7th test')",
+				"DELETE FROM foo WHERE a = 1 and b = '7th test'",
+			},
+			expect: []decodeExpectation{
+				{
+					keyValues:   []string{"7th test", "1"},
+					allValues:   []string{"1", "7th test"},
+					prevDeleted: true,
+				},
+			}},
+	} {
+		t.Run(tc.testName, func(t *testing.T) {
+			details := jobspb.ChangefeedDetails{
+				Opts: map[string]string{
+					changefeedbase.OptVirtualColumns: string(tc.virtualColumn),
+				},
+				Tables: jobspb.ChangefeedTargets{
+					tableDesc.GetID(): jobspb.ChangefeedTargetTable{StatementTimeName: tableDesc.GetName()},
+				},
+			}
+
+			for _, action := range tc.actions {
+				sqlDB.Exec(t, action)
+			}
+
+			serverCfg := s.DistSQLServer().(*distsql.ServerImpl).ServerConfig
+			ctx := context.Background()
+			decoder, err := NewEventDecoder(ctx, &serverCfg, details)
+			require.NoError(t, err)
+			expectedEvents := len(tc.expect)
+			for i := 0; i < expectedEvents; i++ {
+				v := popRow(t)
+
+				_, _, err := decoder.(*eventDecoder).rfCache.tableDescForKey(ctx, v.Key, v.Timestamp())
+				require.NoError(t, err)
+
+				var expect decodeExpectation
+				expect, tc.expect = tc.expect[0], tc.expect[1:]
 				updatedRow, err := decoder.DecodeKV(
 					ctx, roachpb.KeyValue{Key: v.Key, Value: v.Value}, v.Timestamp())
 

--- a/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
@@ -80,7 +80,10 @@ func newRowFetcherCache(
 	cf *descs.CollectionFactory,
 	db *kv.DB,
 	specs []jobspb.ChangefeedTargetSpecification,
-) *rowFetcherCache {
+) (*rowFetcherCache, error) {
+	if len(specs) == 0 {
+		return nil, errors.AssertionFailedf("Expected at least one spec, found 0")
+	}
 	watchedFamilies := make(map[watchedFamily]struct{}, len(specs))
 	for _, s := range specs {
 		watchedFamilies[watchedFamily{tableID: s.TableID, familyName: s.FamilyName}] = struct{}{}
@@ -92,7 +95,7 @@ func newRowFetcherCache(
 		db:              db,
 		fetchers:        cache.NewUnorderedCache(defaultCacheConfig),
 		watchedFamilies: watchedFamilies,
-	}
+	}, nil
 }
 
 func refreshUDT(

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1203,26 +1203,8 @@ func getChangefeedTargetName(
 // AllTargets gets all the targets listed in a ChangefeedDetails,
 // from the statement time name map in old protos
 // or the TargetSpecifications in new ones.
-func AllTargets(cd jobspb.ChangefeedDetails) (targets []jobspb.ChangefeedTargetSpecification) {
-	// TODO: Use a version gate for this once we have CDC version gates
-	if len(cd.TargetSpecifications) > 0 {
-		for _, ts := range cd.TargetSpecifications {
-			if ts.TableID > 0 {
-				ts.StatementTimeName = cd.Tables[ts.TableID].StatementTimeName
-				targets = append(targets, ts)
-			}
-		}
-	} else {
-		for id, t := range cd.Tables {
-			ct := jobspb.ChangefeedTargetSpecification{
-				Type:              jobspb.ChangefeedTargetSpecification_PRIMARY_FAMILY_ONLY,
-				TableID:           id,
-				StatementTimeName: t.StatementTimeName,
-			}
-			targets = append(targets, ct)
-		}
-	}
-	return
+func AllTargets(cd jobspb.ChangefeedDetails) []jobspb.ChangefeedTargetSpecification {
+	return changefeedbase.AllTargets(cd)
 }
 
 func logChangefeedCreateTelemetry(ctx context.Context, jr *jobs.Record) {

--- a/pkg/ccl/changefeedccl/changefeedbase/validate.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/validate.go
@@ -111,3 +111,28 @@ func WarningsForTable(
 	}
 	return warnings
 }
+
+// AllTargets gets all the targets listed in a ChangefeedDetails,
+// from the statement time name map in old protos
+// or the TargetSpecifications in new ones.
+func AllTargets(cd jobspb.ChangefeedDetails) (targets []jobspb.ChangefeedTargetSpecification) {
+	// TODO: Use a version gate for this once we have CDC version gates
+	if len(cd.TargetSpecifications) > 0 {
+		for _, ts := range cd.TargetSpecifications {
+			if ts.TableID > 0 {
+				ts.StatementTimeName = cd.Tables[ts.TableID].StatementTimeName
+				targets = append(targets, ts)
+			}
+		}
+	} else {
+		for id, t := range cd.Tables {
+			ct := jobspb.ChangefeedTargetSpecification{
+				Type:              jobspb.ChangefeedTargetSpecification_PRIMARY_FAMILY_ONLY,
+				TableID:           id,
+				StatementTimeName: t.StatementTimeName,
+			}
+			targets = append(targets, ct)
+		}
+	}
+	return
+}


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/82309.

Release note (bug fix): Fixed a bug where changefeeds created before upgrading to 22.1 would silently fail to emit any data other than resolved timestamps.