### PR TITLE
changefeedccl: handle old-style protobufs in rowfetcher_cache

### DIFF
--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -243,8 +243,11 @@ func createBenchmarkChangefeed(
 		return nil, nil, err
 	}
 	serverCfg := s.DistSQLServer().(*distsql.ServerImpl).ServerConfig
-	eventConsumer := newKVEventToRowConsumer(ctx, &serverCfg, sf, initialHighWater,
+	eventConsumer, err := newKVEventToRowConsumer(ctx, &serverCfg, sf, initialHighWater,
 		sink, encoder, details, TestingKnobs{}, nil)
+	if err != nil {
+		return nil, nil, err
+	}
 	tickFn := func(ctx context.Context) (*jobspb.ResolvedSpan, error) {
 		event, err := buf.Get(ctx)
 		if err != nil {


### PR DESCRIPTION
Manual backport of https://github.com/cockroachdb/cockroach/pull/82311

Addresses https://github.com/cockroachdb/cockroach/issues/82309

Release note (bug fix): Fixed a bug where changefeeds created before upgrading to 22.1 would silently fail to emit any data other than resolved timestamps.