### PR TITLE
dev: delete some unnecessary code

### DIFF
--- a/pkg/cmd/dev/doctor.go
+++ b/pkg/cmd/dev/doctor.go
@@ -186,11 +186,6 @@ Please perform the following steps:
 	}
 	d.log.Println("doctor: running patch check")
 	{
-		stdouts, err := d.exec.CommandContextSilent(ctx, "which", "patch")
-		if err != nil {
-			panic(err)
-		}
-		d.log.Printf("which patch = %s", string(stdouts))
 		stdout, err := d.exec.CommandContextSilent(ctx, "patch", "-v")
 		stdoutStr := strings.TrimSpace(string(stdout))
 		if err != nil {


### PR DESCRIPTION
I didn't mean to check this in, it's an artifact from debugging.
Fortunately its presence has no effect on anything and we can just
delete it.

Release note: None