### PR TITLE
release-22.1: sql: omit dropped columns from SHOW STATISTICS output

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -1542,3 +1542,91 @@ SELECT jsonb_pretty(COALESCE(json_agg(stat), '[]'))
         "row_count": 1
     }
 ]
+
+# Regression test for #76573
+statement ok
+CREATE TABLE t1 (a INT, b INT, c INT)
+
+statement ok
+ANALYZE t1
+
+statement ok
+CREATE STATISTICS t1_ab ON a,b FROM t1
+
+statement ok
+CREATE STATISTICS t1_ac ON a,c FROM t1
+
+statement ok
+CREATE STATISTICS t1_bc ON b,c FROM t1
+
+statement ok
+ALTER TABLE t1 drop column c
+
+statement ok
+show statistics for table t1
+
+query TTIII colnames
+SELECT
+  statistics_name,
+  column_names,
+  row_count,
+  distinct_count,
+  null_count
+FROM
+  [SHOW STATISTICS FOR TABLE t1]
+ORDER BY statistics_name, column_names::STRING
+----
+statistics_name  column_names  row_count  distinct_count  null_count
+NULL             {a}           0          0               0
+NULL             {b}           0          0               0
+NULL             {rowid}       0          0               0
+t1_ab            {a,b}         0          0               0
+
+query T
+SELECT jsonb_pretty(COALESCE(json_agg(stat), '[]'))
+  FROM (
+SELECT json_array_elements(statistics) - 'created_at' - 'histo_col_type' - 'histo_version' AS stat
+FROM [SHOW STATISTICS USING JSON FOR TABLE t1]
+)
+----
+[
+    {
+        "avg_size": 0,
+        "columns": [
+            "rowid"
+        ],
+        "distinct_count": 0,
+        "null_count": 0,
+        "row_count": 0
+    },
+    {
+        "avg_size": 0,
+        "columns": [
+            "a"
+        ],
+        "distinct_count": 0,
+        "null_count": 0,
+        "row_count": 0
+    },
+    {
+        "avg_size": 0,
+        "columns": [
+            "b"
+        ],
+        "distinct_count": 0,
+        "null_count": 0,
+        "row_count": 0
+    },
+    {
+        "avg_size": 0,
+        "columns": [
+            "a",
+            "b"
+        ],
+        "distinct_count": 0,
+        "name": "t1_ab",
+        "null_count": 0,
+        "row_count": 0
+    }
+]
+


### PR DESCRIPTION
Backport 1/1 commits from #82190.

/cc @cockroachdb/release

---

Fixes #76573

Previously, statistics on dropped columns were displayed in `SHOW
STATISTICS [USING JSON]` output.

This was inadequate because statement bundle scripts with
`ALTER TABLE ... INJECT STATISTICS` statements, generated via
`SHOW STATISTICS USING JSON` output, required manual editing
in order to run successfully if the table in question had a dropped
column.

To address this, this patch omits printing of statistics involving
dropped columns in `SHOW STATISTICS` output, including multicolumn
statistics.

Release justification: Simplify support by removing requirement to
manually edit statement bundle scripts.

Release note (bug fix): This fixes SHOW STATISTICS output so statistics
involving dropped columns are not displayed.
