### PR TITLE
release-22.1: parser: fix panic on CREATE SEQUENCE with invalid type name

### DIFF
--- a/pkg/sql/parser/testdata/create_sequence
+++ b/pkg/sql/parser/testdata/create_sequence
@@ -205,3 +205,11 @@ CREATE SEQUENCE a AS INT2 -- normalized!
 CREATE SEQUENCE a AS INT2 -- fully parenthesized
 CREATE SEQUENCE a AS INT2 -- literals removed
 CREATE SEQUENCE _ AS INT2 -- identifiers removed
+
+error
+CREATE SEQUENCE s1 AS abc
+----
+at or near "EOF": syntax error: type "abc" does not exist
+DETAIL: source SQL:
+CREATE SEQUENCE s1 AS abc
+                         ^


### PR DESCRIPTION
Backport 1/1 commits from #82276.

/cc @cockroachdb/release

---

Fixes #82192

Previously, a statement such AS `CREATE SEQUENCE s1 AS abc` would
panic if `abc` is not a valid type name.

This fix adds a nil pointer check in the syntaxer when the type name
cannot be resolved, and returns an error message instead.

Release justification: Low risk fix for DDL which panics instead of
returning an error.

Release note (bug fix): This patch fixes the `CREATE SEQUENCE ... AS`
statement to return a valid error message when the specified type name
does not exist.
