### PR TITLE
roachtest: disable implicit txns in tpch_concurrency

### DIFF
--- a/pkg/cmd/roachtest/tests/tpch_concurrency.go
+++ b/pkg/cmd/roachtest/tests/tpch_concurrency.go
@@ -160,9 +160,14 @@ func registerTPCHConcurrency(r registry.Registry) {
 				maxOps := concurrency / 10
 				// Use very short duration for --display-every parameter so that
 				// all query runs are logged.
+				//
+				// We also disable the implicit txn for multi-statement batches
+				// since Q15 consists of three statements (two of which are
+				// schema changes which would contend with each other causing
+				// many retries).
 				cmd := fmt.Sprintf(
 					"./workload run tpch {pgurl:1-%d} --display-every=1ns --tolerate-errors "+
-						"--count-errors --queries=%d --concurrency=%d --max-ops=%d",
+						"--disable-implicit-txn --count-errors --queries=%d --concurrency=%d --max-ops=%d",
 					numNodes-1, queryNum, concurrency, maxOps,
 				)
 				if err := c.RunE(ctx, c.Node(numNodes), cmd); err != nil {


### PR DESCRIPTION
This commit adds a knob to `tpch` workload to set
`enable_implicit_transaction_for_batch_statements` session variable to
`false` on the connections and uses that knob in the tpch_concurrency
roachtest. This is needed in order to reduce the number of retries that
occur when running Q15 with high concurrency. (That query creates and
drops a view in addition to the actual SELECT query, and running all
three statements inside of a single implicit txn leads to increase in
the "contention footprint" (time-wise).)

Fixes: #79870.

Release note: None