### PR TITLE
roachtest: add no-streamer config to tpch_concurrency

### DIFF
--- a/pkg/cmd/roachtest/tests/tpch_concurrency.go
+++ b/pkg/cmd/roachtest/tests/tpch_concurrency.go
@@ -33,6 +33,7 @@ func registerTPCHConcurrency(r registry.Registry) {
 		t test.Test,
 		c cluster.Cluster,
 		lowerRefreshSpansBytes bool,
+		disableStreamer bool,
 	) {
 		c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, numNodes-1))
 		c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(numNodes))
@@ -53,7 +54,13 @@ func registerTPCHConcurrency(r registry.Registry) {
 			// that the new value of 4MiB is, indeed, the root cause of the
 			// regression in the highest concurrency.
 			// TODO(yuzefovich): remove this.
-			if _, err := conn.Exec("SET CLUSTER SETTING kv.transaction.max_refresh_spans_bytes = 256000"); err != nil {
+			if _, err := conn.Exec("SET CLUSTER SETTING kv.transaction.max_refresh_spans_bytes = 256000;"); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		if disableStreamer {
+			if _, err := conn.Exec("SET CLUSTER SETTING sql.distsql.use_streamer.enabled = false;"); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -179,8 +186,9 @@ func registerTPCHConcurrency(r registry.Registry) {
 		t test.Test,
 		c cluster.Cluster,
 		lowerRefreshSpansBytes bool,
+		disableStreamer bool,
 	) {
-		setupCluster(ctx, t, c, lowerRefreshSpansBytes)
+		setupCluster(ctx, t, c, lowerRefreshSpansBytes, disableStreamer)
 		// TODO(yuzefovich): once we have a good grasp on the expected value for
 		// max supported concurrency, we should use search.Searcher instead of
 		// the binary search here. Additionally, we should introduce an
@@ -221,7 +229,7 @@ func registerTPCHConcurrency(r registry.Registry) {
 		Owner:   registry.OwnerSQLQueries,
 		Cluster: r.MakeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			runTPCHConcurrency(ctx, t, c, true /* lowerRefreshSpansBytes */)
+			runTPCHConcurrency(ctx, t, c, true /* lowerRefreshSpansBytes */, false /* disableStreamer */)
 		},
 		// By default, the timeout is 10 hours which might not be sufficient
 		// given that a single iteration of checkConcurrency might take on the
@@ -237,7 +245,23 @@ func registerTPCHConcurrency(r registry.Registry) {
 		Owner:   registry.OwnerSQLQueries,
 		Cluster: r.MakeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			runTPCHConcurrency(ctx, t, c, false /* lowerRefreshSpansBytes */)
+			runTPCHConcurrency(ctx, t, c, false /* lowerRefreshSpansBytes */, false /* disableStreamer */)
+		},
+		// By default, the timeout is 10 hours which might not be sufficient
+		// given that a single iteration of checkConcurrency might take on the
+		// order of an hour and a half, so in order to let each test run to
+		// complete, we'll give it 12 hours. Successful runs typically take
+		// less, around 8 hours.
+		Timeout: 12 * time.Hour,
+	})
+
+	// TODO(yuzefovich): remove this once the streamer is stabilized.
+	r.Add(registry.TestSpec{
+		Name:    "tpch_concurrency/no_streamer",
+		Owner:   registry.OwnerSQLQueries,
+		Cluster: r.MakeClusterSpec(numNodes),
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runTPCHConcurrency(ctx, t, c, true /* lowerRefreshSpansBytes */, true /* disableStreamer */)
 		},
 		// By default, the timeout is 10 hours which might not be sufficient
 		// given that a single iteration of checkConcurrency might take on the


### PR DESCRIPTION
This commit adds another configuration to `tpch_concurrency` roachtest
which disables the streamer. My goal is to compare the concurrency
numbers with the streamer on and off while I'm working on stabilizing
the streamer.

Informs: #82160.

Release note: None