### PR TITLE
sql: add testing knob for split and scatter in secondary tenants

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1522,6 +1522,10 @@ type TenantTestingKnobs struct {
 	// OverrideTokenBucketProvider allows a test-only TokenBucketProvider (which
 	// can optionally forward requests to the real provider).
 	OverrideTokenBucketProvider func(origProvider kvtenant.TokenBucketProvider) kvtenant.TokenBucketProvider
+
+	// AllowSplitAndScatter, if set, allows secondary tenants to execute ALTER
+	// TABLE ... SPLIT AT and SCATTER SQL commands.
+	AllowSplitAndScatter bool
 }
 
 var _ base.ModuleTestingKnobs = &TenantTestingKnobs{}

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1899,7 +1899,8 @@ func (ef *execFactory) ConstructAlterTableSplit(
 		return nil, err
 	}
 
-	if !ef.planner.ExecCfg().Codec.ForSystemTenant() {
+	knobs := ef.planner.ExecCfg().TenantTestingKnobs
+	if !(knobs != nil && knobs.AllowSplitAndScatter) && !ef.planner.ExecCfg().Codec.ForSystemTenant() {
 		return nil, errorutil.UnsupportedWithMultiTenancy(54254)
 	}
 

--- a/pkg/sql/scatter.go
+++ b/pkg/sql/scatter.go
@@ -34,7 +34,8 @@ type scatterNode struct {
 // (`ALTER TABLE/INDEX ... SCATTER ...` statement)
 // Privileges: INSERT on table.
 func (p *planner) Scatter(ctx context.Context, n *tree.Scatter) (planNode, error) {
-	if !p.ExecCfg().Codec.ForSystemTenant() {
+	knobs := p.ExecCfg().TenantTestingKnobs
+	if !(knobs != nil && knobs.AllowSplitAndScatter) && !p.ExecCfg().Codec.ForSystemTenant() {
 		return nil, errorutil.UnsupportedWithMultiTenancy(54255)
 	}
 


### PR DESCRIPTION
This PR adds a testing knob to TenantTestingKnobs that enables secondary
tenants to execute `ALTER TABLE ... SPLIT AT` and `ALTER TABLE ...
SCATTER` commands. This will be useful for testing both DistSQL and Bulk
of distributed multi-tenant features.

Once either `SPLIT` and `SCATTER` are supported and enabled in secondary
tenants by default or the system tenant can execute `ALTER TABLE`
commands on secondary tenant tables, this testing knob can be
deprecated.

Release note: None