### PR TITLE
democluster: ensure `sslrootcert` is populated

### DIFF
--- a/pkg/cli/democluster/BUILD.bazel
+++ b/pkg/cli/democluster/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/rpc",
         "//pkg/security",
+        "//pkg/security/certnames",
         "//pkg/security/username",
         "//pkg/server",
         "//pkg/server/pgurl",

--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/certnames"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/pgurl"
@@ -1164,9 +1165,17 @@ func (c *transientCluster) getNetworkURLForServer(
 	if c.demoCtx.Insecure {
 		u.WithInsecure()
 	} else {
+		caCert := certnames.CACertFilename()
+		if isTenant {
+			caCert = certnames.TenantClientCACertFilename()
+		}
+
 		u.
 			WithAuthn(pgurl.AuthnPassword(true, c.adminPassword)).
-			WithTransport(pgurl.TransportTLS(pgurl.TLSRequire, ""))
+			WithTransport(pgurl.TransportTLS(
+				pgurl.TLSRequire,
+				filepath.Join(c.demoDir, caCert),
+			))
 	}
 	return u, nil
 }

--- a/pkg/cli/interactive_tests/test_demo.tcl
+++ b/pkg/cli/interactive_tests/test_demo.tcl
@@ -115,6 +115,7 @@ eexpect "(sql)"
 eexpect "demo:"
 eexpect ":26258"
 eexpect "sslmode=require"
+eexpect "sslrootcert="
 eexpect "(sql/unix)"
 eexpect "demo:"
 eexpect "=26258"
@@ -123,6 +124,7 @@ eexpect "(sql)"
 eexpect "demo:"
 eexpect ":26257"
 eexpect "sslmode=require"
+eexpect "sslrootcert="
 eexpect "defaultdb>"
 
 send_eof
@@ -142,6 +144,7 @@ eexpect "http://"
 eexpect "(sql)"
 eexpect "demo:"
 eexpect "sslmode=require"
+eexpect "sslrootcert="
 eexpect "(sql/unix)"
 eexpect "demo:"
 eexpect "defaultdb>"
@@ -190,6 +193,7 @@ spawn $argv demo --insecure=false --no-example-database
 # Expect that security related tags are part of the connection URL.
 eexpect "(sql)"
 eexpect "sslmode=require"
+eexpect "sslrootcert="
 eexpect "defaultdb>"
 
 send_eof


### PR DESCRIPTION
The `pgx` driver defaults the root CA cert to ~/.postgresql/root.crt
if not provided in the connection URL. For demo clusters, that can
never work.

This commit changes the generated demo URLs to include `sslrootcert`
explicitly and point it to the demo-generate root CA cert.

Release note: None