### PR TITLE
changefeedccl: correctly handle old-style protobufs in rowfetcher_cache

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -137,6 +137,7 @@ go_test(
         "bench_test.go",
         "changefeed_test.go",
         "encoder_test.go",
+        "event_processing_test.go",
         "helpers_tenant_shim_test.go",
         "helpers_test.go",
         "main_test.go",

--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -252,8 +252,11 @@ func createBenchmarkChangefeed(
 		return nil, nil, err
 	}
 	serverCfg := s.DistSQLServer().(*distsql.ServerImpl).ServerConfig
-	eventConsumer := newKVEventToRowConsumer(ctx, &serverCfg, sf, initialHighWater,
+	eventConsumer, err := newKVEventToRowConsumer(ctx, &serverCfg, sf, initialHighWater,
 		sink, encoder, details, TestingKnobs{}, nil)
+	if err != nil {
+		return nil, nil, err
+	}
 	tickFn := func(ctx context.Context) (*jobspb.ResolvedSpan, error) {
 		event, err := buf.Get(ctx)
 		if err != nil {

--- a/pkg/ccl/changefeedccl/cdcevent/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/cdcevent/BUILD.bazel
@@ -46,7 +46,6 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/ccl/changefeedccl/cdctest",
-        "//pkg/ccl/changefeedccl/changefeedbase",
         "//pkg/ccl/utilccl",
         "//pkg/jobs/jobspb",
         "//pkg/roachpb",

--- a/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
@@ -80,7 +80,10 @@ func newRowFetcherCache(
 	cf *descs.CollectionFactory,
 	db *kv.DB,
 	specs []jobspb.ChangefeedTargetSpecification,
-) *rowFetcherCache {
+) (*rowFetcherCache, error) {
+	if len(specs) == 0 {
+		return nil, errors.AssertionFailedf("Expected at least one spec, found 0")
+	}
 	watchedFamilies := make(map[watchedFamily]struct{}, len(specs))
 	for _, s := range specs {
 		watchedFamilies[watchedFamily{tableID: s.TableID, familyName: s.FamilyName}] = struct{}{}
@@ -92,7 +95,7 @@ func newRowFetcherCache(
 		db:              db,
 		fetchers:        cache.NewUnorderedCache(defaultCacheConfig),
 		watchedFamilies: watchedFamilies,
-	}
+	}, nil
 }
 
 func refreshUDT(

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1208,7 +1208,9 @@ func AllTargets(cd jobspb.ChangefeedDetails) (targets []jobspb.ChangefeedTargetS
 	if len(cd.TargetSpecifications) > 0 {
 		for _, ts := range cd.TargetSpecifications {
 			if ts.TableID > 0 {
-				ts.StatementTimeName = cd.Tables[ts.TableID].StatementTimeName
+				if ts.StatementTimeName == "" {
+					ts.StatementTimeName = cd.Tables[ts.TableID].StatementTimeName
+				}
 				targets = append(targets, ts)
 			}
 		}

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -55,18 +55,23 @@ func newKVEventToRowConsumer(
 	details jobspb.ChangefeedDetails,
 	knobs TestingKnobs,
 	topicNamer *TopicNamer,
-) *kvEventToRowConsumer {
+) (*kvEventToRowConsumer, error) {
+	includeVirtual := details.Opts[changefeedbase.OptVirtualColumns] == string(changefeedbase.OptVirtualColumnsNull)
+	decoder, err := cdcevent.NewEventDecoder(ctx, cfg, AllTargets(details), includeVirtual)
+	if err != nil {
+		return nil, err
+	}
 	return &kvEventToRowConsumer{
 		frontier:             frontier,
 		encoder:              encoder,
-		decoder:              cdcevent.NewEventDecoder(ctx, cfg, details),
+		decoder:              decoder,
 		sink:                 sink,
 		cursor:               cursor,
 		details:              details,
 		knobs:                knobs,
 		topicDescriptorCache: make(map[TopicIdentifier]TopicDescriptor),
 		topicNamer:           topicNamer,
-	}
+	}, nil
 }
 
 func (c *kvEventToRowConsumer) topicForEvent(eventMeta cdcevent.Metadata) (TopicDescriptor, error) {
@@ -75,7 +80,7 @@ func (c *kvEventToRowConsumer) topicForEvent(eventMeta cdcevent.Metadata) (Topic
 			return topic, nil
 		}
 	}
-	for _, s := range c.details.TargetSpecifications {
+	for _, s := range AllTargets(c.details) {
 		if s.TableID == eventMeta.TableID && (s.FamilyName == "" || s.FamilyName == eventMeta.FamilyName) {
 			topic, err := makeTopicDescriptorFromSpec(s, eventMeta)
 			if err != nil {

--- a/pkg/ccl/changefeedccl/event_processing_test.go
+++ b/pkg/ccl/changefeedccl/event_processing_test.go
@@ -1,0 +1,168 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcevent"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTopicForEvent(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Test verifies that topic naming works for various combinations of table/families.
+	// Versions prior to 22.1 did not initialize TargetSpecifications, and used Tables instead.
+	// Both flavors are tested -- with "old proto" tests testing topic naming with "Tables" field.
+	for _, tc := range []struct {
+		name      string
+		details   jobspb.ChangefeedDetails
+		event     cdcevent.Metadata
+		expectErr string
+		topicName string
+	}{
+		{
+			name: "old proto",
+			details: jobspb.ChangefeedDetails{
+				Tables: jobspb.ChangefeedTargets{1: jobspb.ChangefeedTargetTable{StatementTimeName: "t1"}},
+			},
+			event:     cdcevent.Metadata{TableID: 1, TableName: "t1"},
+			topicName: "t1",
+		},
+		{
+			name: "old proto no such topic",
+			details: jobspb.ChangefeedDetails{
+				Tables: jobspb.ChangefeedTargets{
+					1: jobspb.ChangefeedTargetTable{StatementTimeName: "t1"},
+					2: jobspb.ChangefeedTargetTable{StatementTimeName: "t2"},
+				},
+			},
+			event:     cdcevent.Metadata{TableID: 3},
+			expectErr: "no TargetSpecification for row",
+		},
+		{
+			name: "old proto table renamed",
+			details: jobspb.ChangefeedDetails{
+				Tables: jobspb.ChangefeedTargets{1: jobspb.ChangefeedTargetTable{StatementTimeName: "old_name"}},
+			},
+			event:     cdcevent.Metadata{TableID: 1, TableName: "new_name"},
+			topicName: "old_name",
+		},
+		{
+			name: "old proto family ignored",
+			details: jobspb.ChangefeedDetails{
+				Tables: jobspb.ChangefeedTargets{1: jobspb.ChangefeedTargetTable{StatementTimeName: "t1"}},
+			},
+			event:     cdcevent.Metadata{TableID: 1, TableName: "t1", FamilyID: 2, FamilyName: "fam"},
+			topicName: "t1",
+		},
+		{
+			name: "full table",
+			details: jobspb.ChangefeedDetails{
+				TargetSpecifications: []jobspb.ChangefeedTargetSpecification{
+					{
+						TableID:           1,
+						StatementTimeName: "t1",
+					},
+				},
+			},
+			event:     cdcevent.Metadata{TableID: 1, TableName: "t1"},
+			topicName: "t1",
+		},
+		{
+			name: "full table renamed",
+			details: jobspb.ChangefeedDetails{
+				TargetSpecifications: []jobspb.ChangefeedTargetSpecification{
+					{
+						TableID:           1,
+						StatementTimeName: "old_name",
+					},
+				},
+			},
+			event:     cdcevent.Metadata{TableID: 1, TableName: "new_name"},
+			topicName: "old_name",
+		},
+		{
+			name: "single family",
+			details: jobspb.ChangefeedDetails{
+				TargetSpecifications: []jobspb.ChangefeedTargetSpecification{
+					{
+						Type:              jobspb.ChangefeedTargetSpecification_COLUMN_FAMILY,
+						TableID:           1,
+						FamilyName:        "fam",
+						StatementTimeName: "t1",
+					},
+				},
+			},
+			event:     cdcevent.Metadata{TableID: 1, TableName: "new_name", FamilyName: "fam", FamilyID: 1},
+			topicName: "t1.fam",
+		},
+		{
+			name: "each family",
+			details: jobspb.ChangefeedDetails{
+				TargetSpecifications: []jobspb.ChangefeedTargetSpecification{
+					{
+						Type:              jobspb.ChangefeedTargetSpecification_EACH_FAMILY,
+						TableID:           1,
+						FamilyName:        "fam",
+						StatementTimeName: "old_name",
+					},
+					{
+						Type:              jobspb.ChangefeedTargetSpecification_EACH_FAMILY,
+						TableID:           1,
+						FamilyName:        "fam2",
+						StatementTimeName: "old_name",
+					},
+				},
+			},
+			event:     cdcevent.Metadata{TableID: 1, TableName: "new_name", FamilyName: "fam2", FamilyID: 2},
+			topicName: "old_name.fam2",
+		},
+		{
+			name: "wrong family",
+			details: jobspb.ChangefeedDetails{
+				TargetSpecifications: []jobspb.ChangefeedTargetSpecification{
+					{
+						Type:              jobspb.ChangefeedTargetSpecification_COLUMN_FAMILY,
+						TableID:           1,
+						FamilyName:        "fam",
+						StatementTimeName: "t1",
+					},
+				},
+			},
+			event:     cdcevent.Metadata{TableID: 1, TableName: "new_name", FamilyName: "wrong", FamilyID: 0},
+			expectErr: "no TargetSpecification for row",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := kvEventToRowConsumer{
+				details:              tc.details,
+				topicDescriptorCache: make(map[TopicIdentifier]TopicDescriptor),
+			}
+			tn, err := MakeTopicNamer(AllTargets(tc.details))
+			require.NoError(t, err)
+
+			td, err := c.topicForEvent(tc.event)
+			if tc.expectErr == "" {
+				require.NoError(t, err)
+				topicName, err := tn.Name(td)
+				require.NoError(t, err)
+				require.Equal(t, tc.topicName, topicName)
+			} else {
+				require.Regexp(t, tc.expectErr, err)
+				require.Equal(t, noTopic{}, td)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/82309.

Release note (bug fix): Fixed a bug where changefeeds created before
upgrading to 22.1 would silently fail to emit any data other than
resolved timestamps.