### PR TITLE
compose: remove extra dependency on `cockroach`, `compare_test`

### DIFF
--- a/pkg/compose/BUILD.bazel
+++ b/pkg/compose/BUILD.bazel
@@ -11,9 +11,7 @@ go_test(
     name = "compose_test",
     srcs = ["compose_test.go"],
     data = [
-        "//pkg/cmd/cockroach",
         "//pkg/compose:compare/docker-compose.yml",
-        "//pkg/compose/compare/compare:compare_test",
     ],
     embed = [":compose"],
     gotags = ["compose"],


### PR DESCRIPTION
As of `afbc568788c` we build `cockroach` and `compare_test` separately
and then "inject" them into the `compose_test`, but I forgot to remove
the extra dependency on `cockroach` from the `BUILD.bazel` file. In CI
this has resulted in build failures, and on non-CI machines where it may
not necessarily fail the build this at least requires building way more
than is actually necessary.

Release note: None