### PR TITLE
ttljob: make TTL work for multi-tenant

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -273,7 +273,6 @@ sql.ttl.default_delete_rate_limit	integer	0	default delete rate limit for all TT
 sql.ttl.default_range_concurrency	integer	1	default amount of ranges to process at once during a TTL delete
 sql.ttl.default_select_batch_size	integer	500	default amount of rows to select in a single query during a TTL job
 sql.ttl.job.enabled	boolean	true	whether the TTL job is enabled
-sql.ttl.range_batch_size	integer	100	amount of ranges to fetch at a time for a table during the TTL job
 timeseries.storage.enabled	boolean	true	if set, periodic timeseries data is stored within the cluster; disabling is not recommended unless you are storing the data elsewhere
 timeseries.storage.resolution_10s.ttl	duration	240h0m0s	the maximum age of time series data stored at the 10 second resolution. Data older than this is subject to rollup and deletion.
 timeseries.storage.resolution_30m.ttl	duration	2160h0m0s	the maximum age of time series data stored at the 30 minute resolution. Data older than this is subject to deletion.

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -204,7 +204,6 @@
 <tr><td><code>sql.ttl.default_range_concurrency</code></td><td>integer</td><td><code>1</code></td><td>default amount of ranges to process at once during a TTL delete</td></tr>
 <tr><td><code>sql.ttl.default_select_batch_size</code></td><td>integer</td><td><code>500</code></td><td>default amount of rows to select in a single query during a TTL job</td></tr>
 <tr><td><code>sql.ttl.job.enabled</code></td><td>boolean</td><td><code>true</code></td><td>whether the TTL job is enabled</td></tr>
-<tr><td><code>sql.ttl.range_batch_size</code></td><td>integer</td><td><code>100</code></td><td>amount of ranges to fetch at a time for a table during the TTL job</td></tr>
 <tr><td><code>timeseries.storage.enabled</code></td><td>boolean</td><td><code>true</code></td><td>if set, periodic timeseries data is stored within the cluster; disabling is not recommended unless you are storing the data elsewhere</td></tr>
 <tr><td><code>timeseries.storage.resolution_10s.ttl</code></td><td>duration</td><td><code>240h0m0s</code></td><td>the maximum age of time series data stored at the 10 second resolution. Data older than this is subject to rollup and deletion.</td></tr>
 <tr><td><code>timeseries.storage.resolution_30m.ttl</code></td><td>duration</td><td><code>2160h0m0s</code></td><td>the maximum age of time series data stored at the 30 minute resolution. Data older than this is subject to deletion.</td></tr>

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -127,6 +127,9 @@ var retiredSettings = map[string]struct{}{
 	"schemachanger.backfiller.buffer_increment":                        {},
 	"kv.rangefeed.separated_intent_scan.enabled":                       {},
 
+	// removed as of 22.1.2 and 22.2.
+	"sql.ttl.range_batch_size": {},
+
 	// removed as of 22.2.
 	"kv.bulk_io_write.experimental_incremental_export_enabled":  {},
 	"kv.bulk_io_write.revert_range_time_bound_iterator.enabled": {},

--- a/pkg/sql/ttl/ttljob/BUILD.bazel
+++ b/pkg/sql/ttl/ttljob/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",
+        "//pkg/kv/kvclient/kvcoord",
         "//pkg/roachpb",
         "//pkg/security/username",
         "//pkg/server/telemetry",
@@ -52,6 +53,7 @@ go_test(
     embed = [":ttljob"],
     deps = [
         "//pkg/base",
+        "//pkg/ccl/kvccl/kvtenantccl",
         "//pkg/jobs",
         "//pkg/jobs/jobstest",
         "//pkg/keys",
@@ -72,6 +74,7 @@ go_test(
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
+        "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/randutil",

--- a/pkg/sql/ttl/ttljob/main_test.go
+++ b/pkg/sql/ttl/ttljob/main_test.go
@@ -14,10 +14,13 @@ import (
 	"os"
 	"testing"
 
+	// Since we are testing multi-tenancy, we need to blank import kvtenantccl.
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvtenantccl"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 )
 
 //go:generate ../../../util/leaktest/add-leaktest.sh *_test.go
@@ -25,5 +28,6 @@ import (
 func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	os.Exit(m.Run())
 }

--- a/pkg/sql/ttl/ttljob/ttljob.go
+++ b/pkg/sql/ttl/ttljob/ttljob.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
@@ -83,13 +84,6 @@ var (
 		"sql.ttl.job.enabled",
 		"whether the TTL job is enabled",
 		true,
-	).WithPublic()
-	rangeBatchSize = settings.RegisterIntSetting(
-		settings.TenantWritable,
-		"sql.ttl.range_batch_size",
-		"amount of ranges to fetch at a time for a table during the TTL job",
-		100,
-		settings.PositiveInt,
 	).WithPublic()
 )
 
@@ -344,7 +338,6 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) err
 		ttlSettings.LabelMetrics,
 		relationName,
 	)
-	var rangeDesc roachpb.RangeDescriptor
 	var alloc tree.DatumAlloc
 	type rangeToProcess struct {
 		startPK, endPK tree.Datums
@@ -415,87 +408,56 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) err
 		})
 	}
 
+	// Iterate over every range to feed work for the goroutine processors.
 	if err := func() (retErr error) {
 		defer func() {
 			close(ch)
 			close(statsCloseCh)
 			retErr = errors.CombineErrors(retErr, g.Wait())
 		}()
+
+		ri := kvcoord.MakeRangeIterator(p.ExecCfg().DistSender)
 		done := false
-
-		batchSize := rangeBatchSize.Get(p.ExecCfg().SV())
-		for !done {
-			var ranges []kv.KeyValue
-
-			// Scan ranges up to rangeBatchSize.
-			if err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-				metaStart := keys.RangeMetaKey(keys.MustAddr(rangeSpan.Key).Next())
-				metaEnd := keys.RangeMetaKey(keys.MustAddr(rangeSpan.EndKey))
-
-				kvs, err := txn.Scan(ctx, metaStart, metaEnd, batchSize)
+		ri.Seek(ctx, roachpb.RKey(entirePKSpan.Key), kvcoord.Ascending)
+		for ; ri.Valid() && !done; ri.Next(ctx) {
+			// Send range info to each goroutine worker.
+			rangeDesc := ri.Desc()
+			var nextRange rangeToProcess
+			// A single range can contain multiple tables or indexes.
+			// If this is the case, the rangeDesc.StartKey would be less than entirePKSpan.Key
+			// or the rangeDesc.EndKey would be greater than the entirePKSpan.EndKey, meaning
+			// the range contains the start or the end of the range respectively.
+			// Trying to decode keys outside the PK range will lead to a decoding error.
+			// As such, only populate nextRange.startPK and nextRange.endPK if this is the case
+			// (by default, a 0 element startPK or endPK means the beginning or end).
+			if rangeDesc.StartKey.AsRawKey().Compare(entirePKSpan.Key) > 0 {
+				nextRange.startPK, err = keyToDatums(rangeDesc.StartKey, p.ExecCfg().Codec, pkTypes, &alloc)
 				if err != nil {
-					return err
+					return errors.Wrapf(
+						err,
+						"error decoding starting PRIMARY KEY for range ID %d (start key %x, table start key %x)",
+						rangeDesc.RangeID,
+						rangeDesc.StartKey.AsRawKey(),
+						entirePKSpan.Key,
+					)
 				}
-				if len(kvs) < int(batchSize) {
-					done = true
-					if len(kvs) == 0 || !kvs[len(kvs)-1].Key.Equal(metaEnd.AsRawKey()) {
-						// Normally we need to scan one more KV because the ranges are addressed by
-						// the end key.
-						extraKV, err := txn.Scan(ctx, metaEnd, keys.Meta2Prefix.PrefixEnd(), 1 /* one result */)
-						if err != nil {
-							return err
-						}
-						kvs = append(kvs, extraKV[0])
-					}
-				}
-				ranges = kvs
-				return nil
-			}); err != nil {
-				return err
 			}
-
-			// Send these to each goroutine worker.
-			for _, r := range ranges {
-				if err := r.ValueProto(&rangeDesc); err != nil {
-					return err
+			if rangeDesc.EndKey.AsRawKey().Compare(entirePKSpan.EndKey) < 0 {
+				rangeSpan.Key = rangeDesc.EndKey.AsRawKey()
+				nextRange.endPK, err = keyToDatums(rangeDesc.EndKey, p.ExecCfg().Codec, pkTypes, &alloc)
+				if err != nil {
+					return errors.Wrapf(
+						err,
+						"error decoding ending PRIMARY KEY for range ID %d (end key %x, table end key %x)",
+						rangeDesc.RangeID,
+						rangeDesc.EndKey.AsRawKey(),
+						entirePKSpan.EndKey,
+					)
 				}
-				var nextRange rangeToProcess
-				// A single range can contain multiple tables or indexes.
-				// If this is the case, the rangeDesc.StartKey would be less than entirePKSpan.Key
-				// or the rangeDesc.EndKey would be greater than the entirePKSpan.EndKey, meaning
-				// the range contains the start or the end of the range respectively.
-				// Trying to decode keys outside the PK range will lead to a decoding error.
-				// As such, only populate nextRange.startPK and nextRange.endPK if this is the case
-				// (by default, a 0 element startPK or endPK means the beginning or end).
-				if rangeDesc.StartKey.AsRawKey().Compare(entirePKSpan.Key) > 0 {
-					nextRange.startPK, err = keyToDatums(rangeDesc.StartKey, p.ExecCfg().Codec, pkTypes, &alloc)
-					if err != nil {
-						return errors.Wrapf(
-							err,
-							"error decoding starting PRIMARY KEY for range ID %d (start key %x, table start key %x)",
-							rangeDesc.RangeID,
-							rangeDesc.StartKey.AsRawKey(),
-							entirePKSpan.Key,
-						)
-					}
-				}
-				if rangeDesc.EndKey.AsRawKey().Compare(entirePKSpan.EndKey) < 0 {
-					rangeSpan.Key = rangeDesc.EndKey.AsRawKey()
-					nextRange.endPK, err = keyToDatums(rangeDesc.EndKey, p.ExecCfg().Codec, pkTypes, &alloc)
-					if err != nil {
-						return errors.Wrapf(
-							err,
-							"error decoding ending PRIMARY KEY for range ID %d (end key %x, table end key %x)",
-							rangeDesc.RangeID,
-							rangeDesc.EndKey.AsRawKey(),
-							entirePKSpan.EndKey,
-						)
-					}
-				} else {
-					done = true
-				}
-				ch <- nextRange
+			} else {
+				done = true
 			}
+			ch <- nextRange
 		}
 		return nil
 	}(); err != nil {

--- a/pkg/sql/ttl/ttljob/ttljob_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_test.go
@@ -45,8 +45,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type ttlServer interface {
+	JobRegistry() interface{}
+}
+
 type rowLevelTTLTestJobTestHelper struct {
-	server           serverutils.TestServerInterface
+	server           ttlServer
 	env              *jobstest.JobSchedulerTestEnv
 	cfg              *scheduledjobs.JobExecutionConfig
 	sqlDB            *sqlutils.SQLRunner
@@ -55,7 +59,7 @@ type rowLevelTTLTestJobTestHelper struct {
 }
 
 func newRowLevelTTLTestJobTestHelper(
-	t *testing.T, testingKnobs *sql.TTLTestingKnobs,
+	t *testing.T, testingKnobs *sql.TTLTestingKnobs, testMultiTenant bool,
 ) (*rowLevelTTLTestJobTestHelper, func()) {
 	th := &rowLevelTTLTestJobTestHelper{
 		env: jobstest.NewJobSchedulerTestEnv(
@@ -65,33 +69,52 @@ func newRowLevelTTLTestJobTestHelper(
 		),
 	}
 
-	knobs := &jobs.TestingKnobs{
-		JobSchedulerEnv: th.env,
-		TakeOverJobsScheduling: func(fn func(ctx context.Context, maxSchedules int64) error) {
-			th.executeSchedules = func() error {
-				defer th.server.JobRegistry().(*jobs.Registry).TestingNudgeAdoptionQueue()
-				return fn(context.Background(), 0 /* allSchedules */)
-			}
+	baseTestingKnobs := base.TestingKnobs{
+		JobsTestingKnobs: &jobs.TestingKnobs{
+			JobSchedulerEnv: th.env,
+			TakeOverJobsScheduling: func(fn func(ctx context.Context, maxSchedules int64) error) {
+				th.executeSchedules = func() error {
+					defer th.server.JobRegistry().(*jobs.Registry).TestingNudgeAdoptionQueue()
+					return fn(context.Background(), 0 /* allSchedules */)
+				}
+			},
+			CaptureJobExecutionConfig: func(config *scheduledjobs.JobExecutionConfig) {
+				th.cfg = config
+			},
 		},
-
-		CaptureJobExecutionConfig: func(config *scheduledjobs.JobExecutionConfig) {
-			th.cfg = config
-		},
+		TTL: testingKnobs,
 	}
 
-	args := base.TestServerArgs{
-		Knobs: base.TestingKnobs{
-			JobsTestingKnobs: knobs,
-			TTL:              testingKnobs,
-		},
+	// As `ALTER TABLE ... SPLIT AT ...` is not supported in multi-tenancy, we
+	// do not run those tests.
+	if testMultiTenant {
+		tc := serverutils.StartNewTestCluster(t, 1, base.TestClusterArgs{
+			ServerArgs: base.TestServerArgs{
+				DisableWebSessionAuthentication: true,
+			},
+		})
+		ts := tc.Server(0)
+		tenantServer, db := serverutils.StartTenant(
+			t, ts, base.TestTenantArgs{
+				TenantID:     serverutils.TestTenantID(),
+				TestingKnobs: baseTestingKnobs,
+			},
+		)
+		require.NotNil(t, th.cfg)
+		th.sqlDB = sqlutils.MakeSQLRunner(db)
+		th.kvDB = ts.DB()
+		th.server = tenantServer
+
+		return th, func() {
+			tc.Stopper().Stop(context.Background())
+		}
 	}
 
-	s, db, kvDB := serverutils.StartServer(t, args)
+	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{Knobs: baseTestingKnobs})
 	require.NotNil(t, th.cfg)
 	th.kvDB = kvDB
 	th.sqlDB = sqlutils.MakeSQLRunner(db)
 	th.server = s
-
 	return th, func() {
 		s.Stopper().Stop(context.Background())
 	}
@@ -143,7 +166,7 @@ func TestRowLevelTTLNoTestingKnobs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	th, cleanupFunc := newRowLevelTTLTestJobTestHelper(t, nil /* SQLTestingKnobs */)
+	th, cleanupFunc := newRowLevelTTLTestJobTestHelper(t, nil /* SQLTestingKnobs */, true /* testMultiTenant */)
 	defer cleanupFunc()
 
 	th.sqlDB.Exec(t, `CREATE TABLE t (id INT PRIMARY KEY) WITH (ttl_expire_after = '1 minute')`)
@@ -213,7 +236,7 @@ INSERT INTO t (id, crdb_internal_expiration) VALUES (1, now() - '1 month'), (2, 
 				AOSTDuration:                      &tc.aostDuration,
 				MockDescriptorVersionDuringDelete: tc.mockDescriptorVersionDuringDelete,
 				OnDeleteLoopStart:                 onDeleteLoopStart,
-			})
+			}, false /* testMultiTenant */)
 			defer cleanupFunc()
 			sqlDB = th.sqlDB
 			sqlDB.Exec(t, createTable)
@@ -239,7 +262,6 @@ func TestRowLevelTTLJobDisabled(t *testing.T) {
 		return fmt.Sprintf(`CREATE TABLE t (
 	id INT PRIMARY KEY
 ) WITH (ttl_expire_after = '10 minutes', ttl_range_concurrency = 2%s);
-ALTER TABLE t SPLIT AT VALUES (1), (2);
 INSERT INTO t (id, crdb_internal_expiration) VALUES (1, now() - '1 month'), (2, now() - '1 month');`, pauseStr)
 	}
 
@@ -265,7 +287,7 @@ INSERT INTO t (id, crdb_internal_expiration) VALUES (1, now() - '1 month'), (2, 
 			var zeroDuration time.Duration
 			th, cleanupFunc := newRowLevelTTLTestJobTestHelper(t, &sql.TTLTestingKnobs{
 				AOSTDuration: &zeroDuration,
-			})
+			}, true /* testMultiTenant */)
 			defer cleanupFunc()
 
 			th.sqlDB.ExecMultiple(t, strings.Split(tc.setup, ";")...)
@@ -299,13 +321,14 @@ func TestRowLevelTTLJobRandomEntries(t *testing.T) {
 	}
 
 	type testCase struct {
-		desc              string
-		createTable       string
-		preSetup          []string
-		postSetup         []string
-		numExpiredRows    int
-		numNonExpiredRows int
-		numSplits         int
+		desc                string
+		createTable         string
+		preSetup            []string
+		postSetup           []string
+		numExpiredRows      int
+		numNonExpiredRows   int
+		numSplits           int
+		forceNonMultiTenant bool
 	}
 	// Add some basic one and three column row-level TTL tests.
 	testCases := []testCase{
@@ -332,8 +355,9 @@ func TestRowLevelTTLJobRandomEntries(t *testing.T) {
 				`CREATE TABLE tbl2 (id INT PRIMARY KEY)`,
 				`ALTER TABLE tbl2 SPLIT AT VALUES (1)`,
 			},
-			numExpiredRows:    1001,
-			numNonExpiredRows: 5,
+			numExpiredRows:      1001,
+			numNonExpiredRows:   5,
+			forceNonMultiTenant: true,
 		},
 		{
 			desc: "one column pk with statistics",
@@ -451,16 +475,17 @@ func TestRowLevelTTLJobRandomEntries(t *testing.T) {
 			t.Logf("test case: %#v", tc)
 
 			var zeroDuration time.Duration
-			th, cleanupFunc := newRowLevelTTLTestJobTestHelper(t, &sql.TTLTestingKnobs{
-				AOSTDuration: &zeroDuration,
-				OnStatisticsError: func(err error) {
-					require.NoError(t, err, "error gathering statistics")
+			th, cleanupFunc := newRowLevelTTLTestJobTestHelper(
+				t,
+				&sql.TTLTestingKnobs{
+					AOSTDuration: &zeroDuration,
+					OnStatisticsError: func(err error) {
+						require.NoError(t, err, "error gathering statistics")
+					},
 				},
-			})
+				tc.numSplits == 0 && !tc.forceNonMultiTenant, // SPLIT AT does not work with multi-tenant
+			)
 			defer cleanupFunc()
-
-			rangeBatchSize := 1 + rng.Intn(3)
-			t.Logf("range batch size: %d", rangeBatchSize)
 
 			for _, stmt := range tc.preSetup {
 				t.Logf("running pre statement: %s", stmt)
@@ -468,7 +493,6 @@ func TestRowLevelTTLJobRandomEntries(t *testing.T) {
 			}
 
 			th.sqlDB.Exec(t, tc.createTable)
-			th.sqlDB.Exec(t, `SET CLUSTER SETTING sql.ttl.range_batch_size = $1`, rangeBatchSize)
 
 			// Extract the columns from CREATE TABLE.
 			stmt, err := parser.ParseOne(tc.createTable)
@@ -510,16 +534,16 @@ func TestRowLevelTTLJobRandomEntries(t *testing.T) {
 				)
 			}
 
-			tbDesc := desctestutils.TestingGetPublicTableDescriptor(
-				th.kvDB,
-				keys.SystemSQLCodec,
-				"defaultdb",
-				createTableStmt.Table.Table(),
-			)
-			require.NotNil(t, tbDesc)
-
 			// Split the ranges by a random PK value.
 			if tc.numSplits > 0 {
+				tbDesc := desctestutils.TestingGetPublicTableDescriptor(
+					th.kvDB,
+					keys.SystemSQLCodec,
+					"defaultdb",
+					createTableStmt.Table.Table(),
+				)
+				require.NotNil(t, tbDesc)
+
 				for i := 0; i < tc.numSplits; i++ {
 					var values []interface{}
 					var placeholders []string


### PR DESCRIPTION
Use the appropriate KV abstraction to make ttl work for serverless
clusters.

We can't use `SPLIT AT` with multi-tenant tests, so we are skipping
those for now.

Release note (sql change): The cluster setting
`sql.ttl.range_batch_size` is deprecated.

Resolves #82386

Release note (sql change): Row-level TTL now works for multi-tenant
clusters.