### PR TITLE
dev: various improvements to `dev generate cgo` and friends

### DIFF
--- a/build/bazelutil/BUILD.bazel
+++ b/build/bazelutil/BUILD.bazel
@@ -22,6 +22,16 @@ analysis_test(
     ),
 )
 
+# The output file will be empty unless we're using the force_build_cdeps config.
+genrule(
+    name = "test_force_build_cdeps",
+    outs = ["test_force_build_cdeps.txt"],
+    cmd = select({
+        "//build/toolchains:force_build_cdeps": "echo 1 > $@",
+        "//conditions:default": "touch $@",
+    }),
+)
+
 lint_binary(
     name = "lint",
     test = "//pkg/testutils/lint:lint_test",

--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -463,7 +463,10 @@ config_setting(
     flag_values = {
         ":force_build_cdeps_flag": "true",
     },
-    visibility = ["//c-deps:__pkg__"],
+    visibility = [
+        "//build/bazelutil:__pkg__",
+        "//c-deps:__pkg__",
+    ],
 )
 
 bool_flag(

--- a/pkg/cmd/dev/generate.go
+++ b/pkg/cmd/dev/generate.go
@@ -37,7 +37,8 @@ func makeGenerateCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.
         dev generate bazel     # DEPS.bzl and BUILD.bazel files
         dev generate cgo       # files that help non-Bazel systems (IDEs, go) link to our C dependencies
         dev generate docs      # generates documentation
-        dev generate go        # generates go code (execgen, stringer, protobufs, etc.)
+        dev generate go        # generates go code (execgen, stringer, protobufs, etc.), plus everything 'cgo' generates
+        dev generate go_nocgo  # generates go code (execgen, stringer, protobufs, etc.)
         dev generate protobuf  # *.pb.go files (subset of 'dev generate go')
 `,
 		Args: cobra.MinimumNArgs(0),
@@ -64,48 +65,45 @@ var archivedCdepConfigurations = []configuration{
 	{"windows", "amd64"},
 }
 
-// archivedCdepConfig returns eturn the cross config string associated with the
-// current machine configuration (e.g. "macosarm").
-func archivedCdepConfig() string {
-	for _, config := range archivedCdepConfigurations {
-		if config.Os == runtime.GOOS && config.Arch == runtime.GOARCH {
-			ret := config.Os
-			if ret == "darwin" {
-				ret = "macos"
-			}
-			if config.Arch == "arm64" {
-				ret += "arm"
-			}
-			return ret
-		}
-	}
-	return ""
-}
-
 func (d *dev) generate(cmd *cobra.Command, targets []string) error {
 	var generatorTargetMapping = map[string]func(cmd *cobra.Command) error{
 		"bazel":    d.generateBazel,
 		"cgo":      d.generateCgo,
 		"docs":     d.generateDocs,
 		"go":       d.generateGo,
+		"go_nocgo": d.generateGoNoCgo,
 		"protobuf": d.generateProtobuf,
 	}
 
 	if len(targets) == 0 {
-		targets = append(targets, "bazel", "go", "docs", "cgo")
+		targets = append(targets, "bazel", "go_nocgo", "docs", "cgo")
 	}
 
 	targetsMap := make(map[string]struct{})
 	for _, target := range targets {
 		targetsMap[target] = struct{}{}
 	}
-	_, includesGo := targetsMap["go"]
-	_, includesDocs := targetsMap["docs"]
-	if includesGo && includesDocs {
-		delete(targetsMap, "go")
-		delete(targetsMap, "docs")
-		if err := d.generateGoAndDocs(cmd); err != nil {
-			return err
+	{
+		// In this case, generating both go and cgo would duplicate work.
+		// Generate go_nocgo instead.
+		_, includesGo := targetsMap["go"]
+		_, includesCgo := targetsMap["cgo"]
+		if includesGo && includesCgo {
+			delete(targetsMap, "go")
+			targetsMap["go_nocgo"] = struct{}{}
+		}
+	}
+	{
+		// generateGoAndDocs is a faster way to generate both (non-cgo)
+		// go code as well as the docs
+		_, includesGonocgo := targetsMap["go_nocgo"]
+		_, includesDocs := targetsMap["docs"]
+		if includesGonocgo && includesDocs {
+			delete(targetsMap, "go_nocgo")
+			delete(targetsMap, "docs")
+			if err := d.generateGoAndDocs(cmd); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -162,6 +160,13 @@ func (d *dev) generateGoAndDocs(cmd *cobra.Command) error {
 }
 
 func (d *dev) generateGo(cmd *cobra.Command) error {
+	if err := d.generateGoNoCgo(cmd); err != nil {
+		return err
+	}
+	return d.generateCgo(cmd)
+}
+
+func (d *dev) generateGoNoCgo(cmd *cobra.Command) error {
 	return d.generateTarget(cmd.Context(), "//pkg/gen:code")
 }
 
@@ -199,7 +204,7 @@ func (d *dev) generateRedactSafe(ctx context.Context) error {
 
 func (d *dev) generateCgo(cmd *cobra.Command) error {
 	ctx := cmd.Context()
-	args := []string{"build", "//c-deps:libjemalloc", "//c-deps:libproj"}
+	args := []string{"build", "//build/bazelutil:test_force_build_cdeps", "//c-deps:libjemalloc", "//c-deps:libproj"}
 	if runtime.GOOS == "linux" {
 		args = append(args, "//c-deps:libkrb5")
 	}
@@ -211,6 +216,11 @@ func (d *dev) generateCgo(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
+	bazelBin, err := d.getBazelBin(ctx)
+	if err != nil {
+		return err
+	}
+
 	const cgoTmpl = `// GENERATED FILE DO NOT EDIT
 
 package {{ .Package }}
@@ -221,8 +231,30 @@ import "C"
 `
 
 	tpl := template.Must(template.New("source").Parse(cgoTmpl))
+	var archived string
+	// If force_build_cdeps is set then the prebuilt libraries won't be in
+	// the archived location anyway.
+	forceBuildCdeps, err := d.os.ReadFile(filepath.Join(bazelBin, "build", "bazelutil", "test_force_build_cdeps.txt"))
+	if err != nil {
+		return err
+	}
+	// force_build_cdeps is activated if the length of this file is not 0.
+	if len(forceBuildCdeps) == 0 {
+		for _, config := range archivedCdepConfigurations {
+			if config.Os == runtime.GOOS && config.Arch == runtime.GOARCH {
+				archived = config.Os
+				if archived == "darwin" {
+					archived = "macos"
+				}
+				if config.Arch == "arm64" {
+					archived += "arm"
+				}
+			}
+		}
+	}
+
+	// Figure out where to find the c-deps libraries.
 	var jemallocDir, projDir, krbDir string
-	archived := archivedCdepConfig()
 	if archived != "" {
 		execRoot, err := d.getExecutionRoot(ctx)
 		if err != nil {
@@ -234,10 +266,6 @@ import "C"
 			krbDir = filepath.Join(execRoot, "external", fmt.Sprintf("archived_cdep_libkrb5_%s", archived))
 		}
 	} else {
-		bazelBin, err := d.getBazelBin(ctx)
-		if err != nil {
-			return err
-		}
 		jemallocDir = filepath.Join(bazelBin, "c-deps/libjemalloc_foreign")
 		projDir = filepath.Join(bazelBin, "c-deps/libproj_foreign")
 		if runtime.GOOS == "linux" {

--- a/pkg/cmd/dev/testdata/datadriven/generate
+++ b/pkg/cmd/dev/testdata/datadriven/generate
@@ -18,7 +18,7 @@ export COCKROACH_BAZEL_FORCE_GENERATE=1
 crdb-checkout/build/bazelutil/bazel-generate.sh
 
 exec
-dev generate go
+dev generate go_nocgo
 ----
 bazel run //pkg/gen:code
 
@@ -31,7 +31,7 @@ crdb-checkout/build/bazelutil/generate_redact_safe.sh
 echo "" > crdb-checkout/docs/generated/redact_safe.md
 
 exec
-dev gen go docs
+dev gen go_nocgo docs
 ----
 bazel run //pkg/gen
 bazel info workspace --color=no

--- a/pkg/gen/genbzl/targets.go
+++ b/pkg/gen/genbzl/targets.go
@@ -66,6 +66,7 @@ let all = kind("generated file", {{ .All }})
 in ($all ^ labels("out", kind("_gomock_prog_gen rule",  {{ .All }})))
   + filter(".*:.*(-gen|gen-).*", $all)
   + //pkg/testutils/lint/passes/errcheck:errcheck_excludes.txt
+  + //build/bazelutil:test_force_build_cdeps.txt
   + //build/bazelutil:test_stamping.txt
   + labels("outs", //docs/generated/sql/bnf:svg)
 `,


### PR DESCRIPTION
1. Up until this point, `dev generate go` has not included the
   `zcgo_flags.go` sources, which has been a point of confusion for
   people who expect `dev generate go` to generate all the .go files.
   Now `dev generate go` includes `cgo` as well, and there is a new
   target `dev generate go_nocgo` that does what `dev generate go` used
   to do.
2. Now `dev generate cgo` is conscious of where `force_build_cdeps` is
   set. If it is, then we make sure not to check in one of the
   pre-archived locations. To this end we add a `test_force_build_cdeps`
   target that `dev generate cgo` builds.

Release note: None