### PR TITLE
logcrash: include channel in crash reports

### DIFF
--- a/pkg/util/log/logcrash/crash_reporting.go
+++ b/pkg/util/log/logcrash/crash_reporting.go
@@ -246,6 +246,8 @@ func SetupCrashReporter(ctx context.Context, cmd string) {
 			"distribution": info.Distribution,
 			"rev":          info.Revision,
 			"goversion":    info.GoVersion,
+			"buildchannel": info.Channel,
+			"envchannel":   info.EnvChannel,
 		})
 	})
 }

--- a/pkg/util/log/logcrash/crash_reporting_packet_test.go
+++ b/pkg/util/log/logcrash/crash_reporting_packet_test.go
@@ -111,7 +111,7 @@ func TestCrashReportingPacket(t *testing.T) {
 		title    string
 		message  *regexp.Regexp
 	}{
-		{regexp.MustCompile(`^$`), 7, func() string {
+		{regexp.MustCompile(`^$`), 9, func() string {
 			message := prefix
 			// gccgo stack traces are different in the presence of function literals.
 			if runtime.Compiler == "gccgo" {
@@ -124,7 +124,7 @@ func TestCrashReportingPacket(t *testing.T) {
 		}(),
 			regexp.MustCompile(`crash_reporting_packet_test.go:\d+: panic: boom`),
 		},
-		{regexp.MustCompile(`^[a-z0-9]{8}-1$`), 12, func() string {
+		{regexp.MustCompile(`^[a-z0-9]{8}-1$`), 14, func() string {
 			message := prefix
 			// gccgo stack traces are different in the presence of function literals.
 			if runtime.Compiler == "gccgo" {


### PR DESCRIPTION
Created in response to https://github.com/cockroachdb/cockroach/issues/81946

This will allow us to identify how a binary was built, and the
environment it is running in. (Currently only CockroachCloud sets
envchannel.)

Release note: None