### PR TITLE
kvstreamer: clean up Result struct

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/requests_provider.go
+++ b/pkg/kv/kvclient/kvstreamer/requests_provider.go
@@ -71,7 +71,7 @@ type singleRangeBatch struct {
 	//
 	// subRequestIdx is only allocated in InOrder mode when
 	// Hints.SingleRowLookup is false and some Scan requests were enqueued.
-	subRequestIdx []int
+	subRequestIdx []int32
 	// reqsReservedBytes tracks the memory reservation against the budget for
 	// the memory usage of reqs.
 	reqsReservedBytes int64
@@ -114,7 +114,7 @@ func (r singleRangeBatch) priority() int {
 // compared when two batches have the same priority value.
 //
 // It is invalid to call this method on a batch with no requests.
-func (r singleRangeBatch) subPriority() int {
+func (r singleRangeBatch) subPriority() int32 {
 	if r.subRequestIdx == nil {
 		return 0
 	}

--- a/pkg/kv/kvclient/kvstreamer/results_buffer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/results_buffer_test.go
@@ -85,10 +85,10 @@ func TestInOrderResultsBuffer(t *testing.T) {
 				}
 				for j := 0; j < numRanges; j++ {
 					scan := makeResultWithScanResp(rng)
-					scan.ScanResp.Complete = j+1 == numRanges
+					scan.scanComplete = j+1 == numRanges
 					scan.memoryTok.toRelease = rng.Int63n(100)
 					scan.Position = i
-					scan.subRequestIdx = j
+					scan.subRequestIdx = int32(j)
 					scan.subRequestDone = true
 					results = append(results, scan)
 				}
@@ -160,13 +160,6 @@ func TestInOrderResultsBuffer(t *testing.T) {
 	}
 }
 
-func fillEnqueueKeys(r *Result, rng *rand.Rand) {
-	r.EnqueueKeysSatisfied = make([]int, rng.Intn(20)+1)
-	for i := range r.EnqueueKeysSatisfied {
-		r.EnqueueKeysSatisfied[i] = rng.Int()
-	}
-}
-
 func makeResultWithGetResp(rng *rand.Rand, empty bool) Result {
 	var r Result
 	r.GetResp = &roachpb.GetResponse{}
@@ -182,7 +175,6 @@ func makeResultWithGetResp(rng *rand.Rand, empty bool) Result {
 			},
 		}
 	}
-	fillEnqueueKeys(&r, rng)
 	return r
 }
 
@@ -195,9 +187,8 @@ func makeResultWithScanResp(rng *rand.Rand) Result {
 		rng.Read(batchResponse)
 		batchResponses[i] = batchResponse
 	}
-	r.ScanResp.ScanResponse = &roachpb.ScanResponse{
+	r.ScanResp = &roachpb.ScanResponse{
 		BatchResponses: batchResponses,
 	}
-	fillEnqueueKeys(&r, rng)
 	return r
 }

--- a/pkg/sql/rowcontainer/kvstreamer_result_disk_buffer.go
+++ b/pkg/sql/rowcontainer/kvstreamer_result_disk_buffer.go
@@ -146,8 +146,8 @@ func (b *kvStreamerResultDiskBuffer) Close(ctx context.Context) {
 // inOrderResultsBufferSpillTypeSchema is the type schema of a single
 // kvstreamer.Result that is spilled to disk.
 //
-// It contains all the information except for 'ScanResp.Complete', 'memoryTok',
-// 'Position', 'subRequestIdx', and 'subRequestDone' fields which are kept
+// It contains all the information except for 'Position', 'memoryTok',
+// 'subRequestIdx', 'subRequestDone', and 'scanComplete' fields which are kept
 // in-memory (because they are allocated in
 // kvstreamer.inOrderBufferedResult.Result anyway).
 var inOrderResultsBufferSpillTypeSchema = []*types.T{
@@ -162,7 +162,6 @@ var inOrderResultsBufferSpillTypeSchema = []*types.T{
 	// ScanResp:
 	//  BatchResponses [][]byte
 	types.BytesArray,
-	types.IntArray, // EnqueueKeysSatisfied []int
 }
 
 type resultSerializationIndex int
@@ -174,7 +173,6 @@ const (
 	getTSLogicalIdx
 	getTSSyntheticIdx
 	scanBatchResponsesIdx
-	enqueueKeysSatisfiedIdx
 )
 
 // serialize writes the serialized representation of the kvstreamer.Result into
@@ -209,14 +207,6 @@ func serialize(r *kvstreamer.Result, row rowenc.EncDatumRow, alloc *tree.DatumAl
 			row[scanBatchResponsesIdx] = rowenc.EncDatum{Datum: batchResponses}
 		}
 	}
-	enqueueKeysSatisfied := tree.NewDArray(types.Int)
-	enqueueKeysSatisfied.Array = make(tree.Datums, 0, len(r.EnqueueKeysSatisfied))
-	for _, k := range r.EnqueueKeysSatisfied {
-		if err := enqueueKeysSatisfied.Append(alloc.NewDInt(tree.DInt(k))); err != nil {
-			return err
-		}
-	}
-	row[enqueueKeysSatisfiedIdx] = rowenc.EncDatum{Datum: enqueueKeysSatisfied}
 	return nil
 }
 
@@ -224,8 +214,8 @@ func serialize(r *kvstreamer.Result, row rowenc.EncDatumRow, alloc *tree.DatumAl
 // state of the kvstreamer.Result according to
 // inOrderResultsBufferSpillTypeSchema.
 //
-// 'ScanResp.Complete', 'memoryTok', and 'position' fields are left unchanged
-// since those aren't serialized.
+// 'Position', 'memoryTok', 'subRequestIdx', 'subRequestDone', and
+// 'scanComplete' fields are left unchanged since those aren't serialized.
 func deserialize(r *kvstreamer.Result, row rowenc.EncDatumRow, alloc *tree.DatumAlloc) error {
 	for i := range row {
 		if err := row[i].EnsureDecoded(inOrderResultsBufferSpillTypeSchema[i], alloc); err != nil {
@@ -245,17 +235,12 @@ func deserialize(r *kvstreamer.Result, row rowenc.EncDatumRow, alloc *tree.Datum
 			}
 		}
 	} else {
-		r.ScanResp.ScanResponse = &roachpb.ScanResponse{}
+		r.ScanResp = &roachpb.ScanResponse{}
 		batchResponses := tree.MustBeDArray(row[scanBatchResponsesIdx].Datum)
-		r.ScanResp.ScanResponse.BatchResponses = make([][]byte, batchResponses.Len())
+		r.ScanResp.BatchResponses = make([][]byte, batchResponses.Len())
 		for i := range batchResponses.Array {
-			r.ScanResp.ScanResponse.BatchResponses[i] = []byte(tree.MustBeDBytes(batchResponses.Array[i]))
+			r.ScanResp.BatchResponses[i] = []byte(tree.MustBeDBytes(batchResponses.Array[i]))
 		}
-	}
-	enqueueKeysSatisfied := tree.MustBeDArray(row[enqueueKeysSatisfiedIdx].Datum)
-	r.EnqueueKeysSatisfied = make([]int, enqueueKeysSatisfied.Len())
-	for i := range enqueueKeysSatisfied.Array {
-		r.EnqueueKeysSatisfied[i] = int(tree.MustBeDInt(enqueueKeysSatisfied.Array[i]))
 	}
 	return nil
 }

--- a/pkg/sql/rowcontainer/kvstreamer_result_disk_buffer_test.go
+++ b/pkg/sql/rowcontainer/kvstreamer_result_disk_buffer_test.go
@@ -27,8 +27,8 @@ import (
 
 // TestRoundTripResult verifies that we can serialize and deserialize a Result
 // without any corruption. Note that fields that are kept in-memory
-// ('ScanResp.Complete', 'memoryTok', and 'position') aren't set on the test
-// Results.
+// ('Position', 'memoryTok', 'subRequestIdx', 'subRequestDone', and
+// 'scanComplete') aren't set on the test Results.
 func TestRoundTripResult(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -60,13 +60,6 @@ func TestRoundTripResult(t *testing.T) {
 	})
 }
 
-func fillEnqueueKeys(r *kvstreamer.Result, rng *rand.Rand) {
-	r.EnqueueKeysSatisfied = make([]int, rng.Intn(20)+1)
-	for i := range r.EnqueueKeysSatisfied {
-		r.EnqueueKeysSatisfied[i] = rng.Int()
-	}
-}
-
 func makeResultWithGetResp(rng *rand.Rand, empty bool) kvstreamer.Result {
 	var r kvstreamer.Result
 	r.GetResp = &roachpb.GetResponse{}
@@ -82,7 +75,6 @@ func makeResultWithGetResp(rng *rand.Rand, empty bool) kvstreamer.Result {
 			},
 		}
 	}
-	fillEnqueueKeys(&r, rng)
 	return r
 }
 
@@ -95,9 +87,8 @@ func makeResultWithScanResp(rng *rand.Rand) kvstreamer.Result {
 		rng.Read(batchResponse)
 		batchResponses[i] = batchResponse
 	}
-	r.ScanResp.ScanResponse = &roachpb.ScanResponse{
+	r.ScanResp = &roachpb.ScanResponse{
 		BatchResponses: batchResponses,
 	}
-	fillEnqueueKeys(&r, rng)
 	return r
 }


### PR DESCRIPTION
This commit cleans up the `Result` struct in order to reduce its memory
size, bringing it down into 48 byte size class.
```
name                             old time/op    new time/op    delta
IndexJoin/Cockroach-24             6.29ms ± 1%    6.22ms ± 2%   -1.06%  (p=0.024 n=9+9)
IndexJoin/MultinodeCockroach-24    7.99ms ± 1%    7.93ms ± 2%     ~     (p=0.165 n=10+10)

name                             old alloc/op   new alloc/op   delta
IndexJoin/Cockroach-24             1.64MB ± 1%    1.48MB ± 0%   -9.25%  (p=0.000 n=9+10)
IndexJoin/MultinodeCockroach-24    2.37MB ± 1%    2.20MB ± 1%   -7.06%  (p=0.000 n=10+10)

name                             old allocs/op  new allocs/op  delta
IndexJoin/Cockroach-24              8.15k ± 1%     7.15k ± 1%  -12.28%  (p=0.000 n=8+10)
IndexJoin/MultinodeCockroach-24     12.7k ± 1%     11.7k ± 1%   -8.18%  (p=0.000 n=10+10)
```

The main change of this commit is the removal of the concept of "enqueue
keys" from the Streamer API in favor of relying on `Result.Position`.
When requests are unique, then a single `Result` can only satisfy
a single enqueue key; however, for non-unique requests a single `Result`
can satisfy multiple requests and, thus, can have multiple enqueue keys.
At the moment, only unique requests are supported though. Once
non-unique requests are supported too, we'll need to figure out how to
handle those (maybe we'll be returning a `Result` `N` number of times if
it satisfies `N` original requests with different values for
`Position`).

Also, initially multiple "enqueue keys" support was envisioned for the
case of `multiSpanGenerator` in the lookup joins (i.e. multi-equality
lookup joins); however, I believe we should push that complexity out of
the streamer (into `TxnKVStreamer`) which is what this commit does.

Other changes done in this commit:
- unexport `ScanResp.Complete` field since this is currently only
used within the `kvstreamer` package
- reorder all existing fields so that the footprint of the struct is
minimized (in particular, `scanComplete` field is moved to the bottom
and `ScanResp` anonymous struct is removed)
- make `subRequestIdx` `int32` rather than `int`. This value is bound
by the number of ranges in the cluster, so max int32 is more than
sufficient.

Addresses: #82159.
Addresses: #82160.

Release note: None