### PR TITLE
ui: new charts to statement details page

### DIFF
--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -563,6 +563,7 @@ func getStatementDetailsPerAggregatedTs(
 		GROUP BY
 				aggregated_ts,
 				aggregation_interval
+		ORDER BY aggregated_ts ASC
 		LIMIT $%d`, whereClause, len(args)+1)
 
 	args = append(args, limit)

--- a/pkg/ui/workspaces/cluster-ui/BUILD.bazel
+++ b/pkg/ui/workspaces/cluster-ui/BUILD.bazel
@@ -83,6 +83,7 @@ DEPENDENCIES = [
     "@npm_cluster_ui//highlight.js",
     "@npm_cluster_ui//http-proxy-middleware",
     "@npm_cluster_ui//identity-obj-proxy",
+    "@npm_cluster_ui//jest-canvas-mock",
     "@npm_cluster_ui//jest-environment-enzyme",
     "@npm_cluster_ui//jest-enzyme",
     "@npm_cluster_ui//jest-fetch-mock",

--- a/pkg/ui/workspaces/cluster-ui/jest.config.js
+++ b/pkg/ui/workspaces/cluster-ui/jest.config.js
@@ -43,7 +43,7 @@ module.exports = {
   ],
   roots: ["<rootDir>/src"],
   testEnvironment: "enzyme",
-  setupFilesAfterEnv: ["./enzyme.setup.js", "jest-enzyme"],
+  setupFilesAfterEnv: ["./enzyme.setup.js", "./src/test-utils/matchMedia.mock.js", "jest-enzyme", "jest-canvas-mock"],
   transform: {
     "^.+\\.tsx?$": "ts-jest",
     "^.+\\.jsx?$": ['babel-jest', { configFile: path.resolve(__dirname, 'babel.config.js') }],

--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -104,6 +104,7 @@
     "http-proxy-middleware": "^1.0.5",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^27.5.1",
+    "jest-canvas-mock": "^2.4.0",
     "jest-cli": "^27.5.1",
     "jest-environment-enzyme": "^7.1.2",
     "jest-enzyme": "^7.1.2",

--- a/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/bars.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/bars.ts
@@ -14,8 +14,8 @@ import { AxisUnits, AxisDomain } from "../utils/domain";
 import { barTooltipPlugin } from "./plugins";
 
 const seriesPalette = [
-  "#475872",
-  "#FFCD02",
+  "#003EBD",
+  "#2AAF44",
   "#F16969",
   "#4E9FD1",
   "#49D990",
@@ -24,7 +24,7 @@ const seriesPalette = [
   "#A3415B",
   "#B59153",
   "#C9DB6D",
-  "#203D9B",
+  "#475872",
   "#748BF2",
   "#91C8F2",
   "#FF9696",
@@ -157,6 +157,9 @@ export const getBarChartOpts = (
     scales: {
       x: {
         range: () => [xAxisDomain.extent[0], xAxisDomain.extent[1]],
+      },
+      yAxis: {
+        range: () => [yAxisDomain.extent[0], yAxisDomain.extent[1]],
       },
     },
     axes: [

--- a/pkg/ui/workspaces/cluster-ui/src/pageConfig/pageConfig.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/pageConfig/pageConfig.module.scss
@@ -14,7 +14,7 @@
   margin-bottom: -10px;
   margin-top: -10px;
 
-  z-index: 1;
+  z-index: 2;
   background-color: $colors--background;
 
   &__list {

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -8,19 +8,22 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { Col, Row, Tabs } from "antd";
-import { Text, Heading, InlineAlert } from "@cockroachlabs/ui-components";
-import { PageConfig, PageConfigItem } from "src/pageConfig";
-import _ from "lodash";
 import React, { ReactNode } from "react";
+import { Col, Row, Tabs } from "antd";
+import { cockroach, google } from "@cockroachlabs/crdb-protobuf-client";
+import { Text, InlineAlert } from "@cockroachlabs/ui-components";
+import { ArrowLeft } from "@cockroachlabs/icons";
+import { Location } from "history";
+import _ from "lodash";
+import Long from "long";
+import { format as d3Format } from "d3-format";
 import { Helmet } from "react-helmet";
 import { Link, RouteComponentProps } from "react-router-dom";
 import classNames from "classnames/bind";
-import { format as d3Format } from "d3-format";
-import { ArrowLeft } from "@cockroachlabs/icons";
-import { cockroach, google } from "@cockroachlabs/crdb-protobuf-client";
-import Long from "long";
-import { Location } from "history";
+import { PageConfig, PageConfigItem } from "src/pageConfig";
+import { BarGraphTimeSeries } from "../graphs/bargraph";
+import { AxisUnits } from "../graphs";
+import { AlignedData, Options } from "uplot";
 
 import {
   NumericStat,
@@ -28,9 +31,7 @@ import {
   Bytes,
   Duration,
   FixLong,
-  longToInt,
   stdDev,
-  formatNumberForDisplay,
   unique,
   queryByName,
   appAttr,
@@ -44,11 +45,7 @@ import { SortSetting } from "src/sortedtable";
 import { Tooltip } from "@cockroachlabs/ui-components";
 import { PlanDetails } from "./planDetails";
 import { SummaryCard } from "src/summaryCard";
-import {
-  latencyBreakdown,
-  genericBarChart,
-  formatTwoPlaces,
-} from "src/barCharts";
+import { latencyBreakdown, genericBarChart } from "src/barCharts";
 import { DiagnosticsView } from "./diagnostics/diagnosticsView";
 import sortedTableStyles from "src/sortedtable/sortedtable.module.scss";
 import summaryCardStyles from "src/summaryCard/summaryCard.module.scss";
@@ -68,6 +65,13 @@ import {
   ActivateDiagnosticsModalRef,
   ActivateStatementDiagnosticsModal,
 } from "../statementsDiagnostics";
+import {
+  generateExecCountTimeseries,
+  generateExecRetriesTimeseries,
+  generateExecuteAndPlanningTimeseries,
+  generateRowsProcessedTimeseries,
+  generateContentionTimeseries,
+} from "./timeseriesUtils";
 type IDuration = google.protobuf.IDuration;
 type StatementDetailsResponse =
   cockroach.server.serverpb.StatementDetailsResponse;
@@ -330,15 +334,6 @@ export class StatementDetails extends React.Component<
   hasDiagnosticReports = (): boolean =>
     this.props.diagnosticsReports.length > 0;
 
-  changeSortSetting = (ss: SortSetting): void => {
-    this.setState({
-      sortSetting: ss,
-    });
-    if (this.props.onSortingChange) {
-      this.props.onSortingChange("Stats By Node", ss.columnTitle, ss.ascending);
-    }
-  };
-
   refreshStatementDetails = (
     timeScale: TimeScale,
     statementFingerprintID: string,
@@ -468,13 +463,13 @@ export class StatementDetails extends React.Component<
             Statements
           </Button>
           <h3 className={commonStyles("base-heading", "no-margin-bottom")}>
-            Statement Details
+            Statement Fingerprint
           </h3>
         </div>
         <section className={cx("section", "section--container")}>
           <Loading
             loading={this.props.isLoading}
-            page={"statement details"}
+            page={"statement fingerprint"}
             error={this.props.statementsError}
             render={this.renderTabs}
             renderError={() =>
@@ -580,22 +575,14 @@ export class StatementDetails extends React.Component<
     const {
       app_names,
       databases,
-      dist_sql_count,
       failed_count,
       full_scan_count,
       vec_count,
       total_count,
       implicit_txn,
     } = this.props.statementDetails.statement.metadata;
-
-    const { statement } = this.props.statementDetails;
-
-    const totalCountBarChart = longToInt(statement.stats.count);
-    const firstAttemptsBarChart = longToInt(
-      statement.stats.first_attempt_count,
-    );
-    const retriesBarChart = totalCountBarChart - firstAttemptsBarChart;
-    const maxRetriesBarChart = longToInt(statement.stats.max_retries);
+    const { statement_statistics_per_aggregated_ts } =
+      this.props.statementDetails;
 
     const nodes: string[] = unique(
       (stats.nodes || []).map(node => node.toString()),
@@ -604,7 +591,6 @@ export class StatementDetails extends React.Component<
       (stats.nodes || []).map(node => nodeRegions[node.toString()]),
     ).sort();
 
-    const duration = (v: number) => Duration(v * 1e9);
     const lastExec =
       stats.last_exec_timestamp &&
       moment(stats.last_exec_timestamp.seconds.low * 1e3).format(
@@ -612,18 +598,10 @@ export class StatementDetails extends React.Component<
       );
     const statementSampled = stats.exec_stats.count > Long.fromNumber(0);
     const unavailableTooltip = !statementSampled && (
-      <Tooltip
-        placement="bottom"
-        style="default"
-        content={
-          <p>
-            This metric is part of the statement execution and therefore will
-            not be available until the statement is sampled via tracing.
-          </p>
-        }
-      >
-        <span className={cx("tooltip-info")}>unavailable</span>
-      </Tooltip>
+      <div>
+        This metric is part of the statement execution and therefore will not be
+        available until the statement is sampled.
+      </div>
     );
 
     const db = databases ? (
@@ -631,6 +609,59 @@ export class StatementDetails extends React.Component<
     ) : (
       <Text className={cx("app-name", "app-name__unset")}>(unset)</Text>
     );
+
+    const statsPerAggregatedTs = statement_statistics_per_aggregated_ts.sort(
+      (a, b) =>
+        a.aggregated_ts.seconds < b.aggregated_ts.seconds
+          ? -1
+          : a.aggregated_ts.seconds > b.aggregated_ts.seconds
+          ? 1
+          : 0,
+    );
+
+    const executionAndPlanningTimeseries: AlignedData =
+      generateExecuteAndPlanningTimeseries(statsPerAggregatedTs);
+    const executionAndPlanningOps: Partial<Options> = {
+      axes: [{}, { label: "Time Spent" }],
+      series: [{}, { label: "Execution" }, { label: "Planning" }],
+      width: 735,
+    };
+
+    const rowsProcessedTimeseries: AlignedData =
+      generateRowsProcessedTimeseries(statsPerAggregatedTs);
+    const rowsProcessedOps: Partial<Options> = {
+      axes: [{}, { label: "Rows" }],
+      series: [{}, { label: "Rows Read" }, { label: "Rows Written" }],
+      width: 735,
+    };
+
+    const execRetriesTimeseries: AlignedData =
+      generateExecRetriesTimeseries(statsPerAggregatedTs);
+    const execRetriesOps: Partial<Options> = {
+      axes: [{}, { label: "Retries" }],
+      series: [{}, { label: "Retries" }],
+      legend: { show: false },
+      width: 735,
+    };
+
+    const execCountTimeseries: AlignedData =
+      generateExecCountTimeseries(statsPerAggregatedTs);
+    const execCountOps: Partial<Options> = {
+      axes: [{}, { label: "Execution Counts" }],
+      series: [{}, { label: "Execution Counts" }],
+      legend: { show: false },
+      width: 735,
+    };
+
+    const contentionTimeseries: AlignedData =
+      generateContentionTimeseries(statsPerAggregatedTs);
+    const contentionOps: Partial<Options> = {
+      axes: [{}, { label: "Contention" }],
+      series: [{}, { label: "Contention" }],
+      legend: { show: false },
+      width: 735,
+    };
+
     return (
       <>
         <PageConfig>
@@ -653,110 +684,6 @@ export class StatementDetails extends React.Component<
           <Row gutter={24}>
             <Col className="gutter-row" span={12}>
               <SummaryCard className={cx("summary-card")}>
-                <Row>
-                  <Col>
-                    <div className={summaryCardStylesCx("summary--card__item")}>
-                      <Heading type="h5">Mean statement time</Heading>
-                      <Text type="body-strong">
-                        {formatNumberForDisplay(
-                          stats.service_lat.mean,
-                          duration,
-                        )}
-                      </Text>
-                    </div>
-                    <div className={summaryCardStylesCx("summary--card__item")}>
-                      <Text>Planning time</Text>
-                      <Text>
-                        {formatNumberForDisplay(stats.plan_lat.mean, duration)}
-                      </Text>
-                    </div>
-                    <p
-                      className={summaryCardStylesCx("summary--card__divider")}
-                    />
-                    <div className={summaryCardStylesCx("summary--card__item")}>
-                      <Text>Execution time</Text>
-                      <Text>
-                        {formatNumberForDisplay(stats.run_lat.mean, duration)}
-                      </Text>
-                    </div>
-                    <p
-                      className={summaryCardStylesCx("summary--card__divider")}
-                    />
-                  </Col>
-                </Row>
-              </SummaryCard>
-              <SummaryCard className={cx("summary-card")}>
-                <Row>
-                  <Col>
-                    <div className={summaryCardStylesCx("summary--card__item")}>
-                      <Heading type="h5">Resource usage</Heading>
-                    </div>
-                    <div className={summaryCardStylesCx("summary--card__item")}>
-                      <Text>Mean rows/bytes read</Text>
-                      {statementSampled && (
-                        <Text>
-                          {formatNumberForDisplay(
-                            stats.rows_read.mean,
-                            formatTwoPlaces,
-                          )}
-                          {" / "}
-                          {formatNumberForDisplay(stats.bytes_read.mean, Bytes)}
-                        </Text>
-                      )}
-                      {unavailableTooltip}
-                    </div>
-                    <div className={summaryCardStylesCx("summary--card__item")}>
-                      <Text>Mean rows written</Text>
-                      <Text>
-                        {formatNumberForDisplay(
-                          stats.rows_written?.mean,
-                          formatTwoPlaces,
-                        )}
-                      </Text>
-                    </div>
-                    <div className={summaryCardStylesCx("summary--card__item")}>
-                      <Text>Max memory usage</Text>
-                      {statementSampled && (
-                        <Text>
-                          {formatNumberForDisplay(
-                            stats.exec_stats.max_mem_usage.mean,
-                            Bytes,
-                          )}
-                        </Text>
-                      )}
-                      {unavailableTooltip}
-                    </div>
-                    <div className={summaryCardStylesCx("summary--card__item")}>
-                      <Text>Network usage</Text>
-                      {statementSampled && (
-                        <Text>
-                          {formatNumberForDisplay(
-                            stats.exec_stats.network_bytes.mean,
-                            Bytes,
-                          )}
-                        </Text>
-                      )}
-                      {unavailableTooltip}
-                    </div>
-                    <div className={summaryCardStylesCx("summary--card__item")}>
-                      <Text>Max scratch disk usage</Text>
-                      {statementSampled && (
-                        <Text>
-                          {formatNumberForDisplay(
-                            stats.exec_stats.max_disk_usage.mean,
-                            Bytes,
-                          )}
-                        </Text>
-                      )}
-                      {unavailableTooltip}
-                    </div>
-                  </Col>
-                </Row>
-              </SummaryCard>
-            </Col>
-            <Col className="gutter-row" span={12}>
-              <SummaryCard className={cx("summary-card")}>
-                <Heading type="h5">Statement details</Heading>
                 {!isTenant && (
                   <div>
                     <div className={summaryCardStylesCx("summary--card__item")}>
@@ -774,16 +701,10 @@ export class StatementDetails extends React.Component<
                     </div>
                   </div>
                 )}
-
                 <div className={summaryCardStylesCx("summary--card__item")}>
                   <Text>Database</Text>
                   {db}
                 </div>
-                <p
-                  className={summaryCardStylesCx(
-                    "summary--card__divider--large",
-                  )}
-                />
                 <div className={summaryCardStylesCx("summary--card__item")}>
                   <Text>App</Text>
                   <Text>
@@ -793,16 +714,16 @@ export class StatementDetails extends React.Component<
                     )}
                   </Text>
                 </div>
+              </SummaryCard>
+            </Col>
+            <Col className="gutter-row" span={12}>
+              <SummaryCard className={cx("summary-card")}>
                 <div className={summaryCardStylesCx("summary--card__item")}>
                   <Text>Failed?</Text>
                   <Text>{RenderCount(failed_count, total_count)}</Text>
                 </div>
                 <div className={summaryCardStylesCx("summary--card__item")}>
-                  <Text>Distributed execution?</Text>
-                  <Text>{RenderCount(dist_sql_count, total_count)}</Text>
-                </div>
-                <div className={summaryCardStylesCx("summary--card__item")}>
-                  <Text>Full Scan?</Text>
+                  <Text>Full scan?</Text>
                   <Text>{RenderCount(full_scan_count, total_count)}</Text>
                 </div>
                 <div className={summaryCardStylesCx("summary--card__item")}>
@@ -817,48 +738,55 @@ export class StatementDetails extends React.Component<
                   <Text>Last execution time</Text>
                   <Text>{lastExec}</Text>
                 </div>
-                <p
-                  className={summaryCardStylesCx(
-                    "summary--card__divider--large",
-                  )}
-                />
-                <Heading type="h5">Execution counts</Heading>
-                <div className={summaryCardStylesCx("summary--card__item")}>
-                  <Text>First attempts</Text>
-                  <Text>{firstAttemptsBarChart}</Text>
-                </div>
-                <div className={summaryCardStylesCx("summary--card__item")}>
-                  <Text>Total executions</Text>
-                  <Text>{totalCountBarChart}</Text>
-                </div>
-                <div className={summaryCardStylesCx("summary--card__item")}>
-                  <Text>Retries</Text>
-                  <Text
-                    className={summaryCardStylesCx(
-                      "summary--card__item--value",
-                      {
-                        "summary--card__item--value-red": retriesBarChart > 0,
-                      },
-                    )}
-                  >
-                    {retriesBarChart}
-                  </Text>
-                </div>
-                <div className={summaryCardStylesCx("summary--card__item")}>
-                  <Text>Max retries</Text>
-                  <Text
-                    className={summaryCardStylesCx(
-                      "summary--card__item--value",
-                      {
-                        "summary--card__item--value-red":
-                          maxRetriesBarChart > 0,
-                      },
-                    )}
-                  >
-                    {maxRetriesBarChart}
-                  </Text>
-                </div>
               </SummaryCard>
+            </Col>
+          </Row>
+          <p className={summaryCardStylesCx("summary--card__divider--large")} />
+          <Row gutter={24}>
+            <Col className="gutter-row" span={12}>
+              <BarGraphTimeSeries
+                title="Statement Execution and Planning Time"
+                alignedData={executionAndPlanningTimeseries}
+                uPlotOptions={executionAndPlanningOps}
+                yAxisUnits={AxisUnits.Duration}
+              />
+            </Col>
+            <Col className="gutter-row" span={12}>
+              <BarGraphTimeSeries
+                title="Rows Processed"
+                alignedData={rowsProcessedTimeseries}
+                uPlotOptions={rowsProcessedOps}
+                yAxisUnits={AxisUnits.Count}
+              />
+            </Col>
+          </Row>
+          <Row gutter={24}>
+            <Col className="gutter-row" span={12}>
+              <BarGraphTimeSeries
+                title="Execution Retries"
+                alignedData={execRetriesTimeseries}
+                uPlotOptions={execRetriesOps}
+                yAxisUnits={AxisUnits.Count}
+              />
+            </Col>
+            <Col className="gutter-row" span={12}>
+              <BarGraphTimeSeries
+                title="Execution Count"
+                alignedData={execCountTimeseries}
+                uPlotOptions={execCountOps}
+                yAxisUnits={AxisUnits.Count}
+              />
+            </Col>
+          </Row>
+          <Row gutter={24}>
+            <Col className="gutter-row" span={12}>
+              <BarGraphTimeSeries
+                title="Contention"
+                alignedData={contentionTimeseries}
+                uPlotOptions={contentionOps}
+                tooltip={unavailableTooltip}
+                yAxisUnits={AxisUnits.Duration}
+              />
             </Col>
           </Row>
         </section>

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
@@ -1,0 +1,93 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import { AlignedData } from "uplot";
+import { longToInt, TimestampToNumber } from "../util";
+
+type statementStatisticsPerAggregatedTs =
+  cockroach.server.serverpb.StatementDetailsResponse.ICollectedStatementGroupedByAggregatedTs;
+
+export function generateExecuteAndPlanningTimeseries(
+  stats: statementStatisticsPerAggregatedTs[],
+): AlignedData {
+  const ts: Array<number> = [];
+  const execution: Array<number> = [];
+  const planning: Array<number> = [];
+
+  stats.forEach(function (stat: statementStatisticsPerAggregatedTs) {
+    ts.push(TimestampToNumber(stat.aggregated_ts) * 1e3);
+    execution.push(stat.stats.run_lat.mean * 1e9);
+    planning.push(stat.stats.plan_lat.mean * 1e9);
+  });
+
+  return [ts, execution, planning];
+}
+
+export function generateRowsProcessedTimeseries(
+  stats: statementStatisticsPerAggregatedTs[],
+): AlignedData {
+  const ts: Array<number> = [];
+  const read: Array<number> = [];
+  const written: Array<number> = [];
+
+  stats.forEach(function (stat: statementStatisticsPerAggregatedTs) {
+    ts.push(TimestampToNumber(stat.aggregated_ts) * 1e3);
+    read.push(stat.stats.rows_read?.mean);
+    written.push(stat.stats.rows_written?.mean);
+  });
+
+  return [ts, read, written];
+}
+
+export function generateExecRetriesTimeseries(
+  stats: statementStatisticsPerAggregatedTs[],
+): AlignedData {
+  const ts: Array<number> = [];
+  const retries: Array<number> = [];
+
+  stats.forEach(function (stat: statementStatisticsPerAggregatedTs) {
+    ts.push(TimestampToNumber(stat.aggregated_ts) * 1e3);
+
+    const totalCountBarChart = longToInt(stat.stats.count);
+    const firstAttemptsBarChart = longToInt(stat.stats.first_attempt_count);
+    retries.push(totalCountBarChart - firstAttemptsBarChart);
+  });
+
+  return [ts, retries];
+}
+
+export function generateExecCountTimeseries(
+  stats: statementStatisticsPerAggregatedTs[],
+): AlignedData {
+  const ts: Array<number> = [];
+  const count: Array<number> = [];
+
+  stats.forEach(function (stat: statementStatisticsPerAggregatedTs) {
+    ts.push(TimestampToNumber(stat.aggregated_ts) * 1e3);
+    count.push(longToInt(stat.stats.count));
+  });
+
+  return [ts, count];
+}
+
+export function generateContentionTimeseries(
+  stats: statementStatisticsPerAggregatedTs[],
+): AlignedData {
+  const ts: Array<number> = [];
+  const count: Array<number> = [];
+
+  stats.forEach(function (stat: statementStatisticsPerAggregatedTs) {
+    ts.push(TimestampToNumber(stat.aggregated_ts) * 1e3);
+    count.push(stat.stats.exec_stats.contention_time.mean);
+  });
+
+  return [ts, count];
+}

--- a/pkg/ui/workspaces/cluster-ui/src/test-utils/matchMedia.mock.js
+++ b/pkg/ui/workspaces/cluster-ui/src/test-utils/matchMedia.mock.js
@@ -1,0 +1,29 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Jest uses jsdom to simulate a browser, which doesn’t include window.matchMedia.
+// This property was created and added to `setupFilesAfterEnv` on jest.config.js to
+// handle test cases where window.matchMedia and its functions (e.g. addEventListener)
+// are used.
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
+
+export {};

--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/utils.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/utils.spec.tsx
@@ -28,7 +28,7 @@ describe("timescale utils", (): void => {
       };
       const [start, end] = toRoundedDateRange(ts);
       assert.equal(start.format("YYYY.MM.DD HH:mm:ss"), "2022.01.05 13:00:00");
-      assert.equal(end.format("YYYY.MM.DD HH:mm:ss"), "2022.01.10 14:00:00");
+      assert.equal(end.format("YYYY.MM.DD HH:mm:ss"), "2022.01.10 13:59:59");
     });
 
     it("already rounded values", () => {
@@ -40,7 +40,7 @@ describe("timescale utils", (): void => {
       };
       const [start, end] = toRoundedDateRange(ts);
       assert.equal(start.format("YYYY.MM.DD HH:mm:ss"), "2022.01.05 13:00:00");
-      assert.equal(end.format("YYYY.MM.DD HH:mm:ss"), "2022.01.10 14:00:00");
+      assert.equal(end.format("YYYY.MM.DD HH:mm:ss"), "2022.01.10 13:59:59");
     });
   });
 

--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/utils.ts
@@ -88,10 +88,10 @@ export const toDateRange = (ts: TimeScale): [moment.Moment, moment.Moment] => {
 };
 
 // toRoundedDateRange round the TimeScale selected, with the start
-// rounded down and end rounded up one hour.
+// rounded down and end rounded up to the limit before the next hour.
 // e.g.
 // start: 17:45:23  ->  17:00:00
-// end:   20:14:32  ->  21:00:00
+// end:   20:14:32  ->  20:59:59
 export const toRoundedDateRange = (
   ts: TimeScale,
 ): [moment.Moment, moment.Moment] => {
@@ -99,7 +99,8 @@ export const toRoundedDateRange = (
   const startRounded = start.set({ minute: 0, second: 0, millisecond: 0 });
   const endRounded = end
     .set({ minute: 0, second: 0, millisecond: 0 })
-    .add(1, "hours");
+    .add(59, "minutes")
+    .add(59, "seconds");
 
   return [startRounded, endRounded];
 };

--- a/pkg/ui/workspaces/cluster-ui/yarn.lock
+++ b/pkg/ui/workspaces/cluster-ui/yarn.lock
@@ -5186,7 +5186,7 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@~1.1.4:
+color-name@^1.1.4, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
@@ -5614,6 +5614,11 @@ cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+
+cssfontparser@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/cssfontparser/-/cssfontparser-1.2.1.tgz#f4022fc8f9700c68029d542084afbaf425a3f3e3"
+  integrity sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==
 
 cssom@^0.4.4:
   version "0.4.4"
@@ -8516,6 +8521,14 @@ iterate-value@^1.0.2:
     es-get-iterator "^1.0.2"
     iterate-iterator "^1.0.1"
 
+jest-canvas-mock@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/jest-canvas-mock/-/jest-canvas-mock-2.4.0.tgz#947b71442d7719f8e055decaecdb334809465341"
+  integrity sha512-mmMpZzpmLzn5vepIaHk5HoH3Ka4WykbSoLuG/EKoJd0x0ID/t+INo1l8ByfcUJuDM+RIsL4QDg/gDnBbrj2/IQ==
+  dependencies:
+    cssfontparser "^1.2.1"
+    moo-color "^1.0.2"
+
 jest-changed-files@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-27.5.1.tgz#a348aed00ec9bf671cc58a66fcbe7c3dfd6a68f5"
@@ -9798,6 +9811,13 @@ moment@2.x, moment@^2.24.0:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
+moo-color@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/moo-color/-/moo-color-1.0.3.tgz#d56435f8359c8284d83ac58016df7427febece74"
+  integrity sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==
+  dependencies:
+    color-name "^1.1.4"
 
 moo@^0.5.0:
   version "0.5.1"

--- a/pkg/ui/workspaces/db-console/styl/base/layout-vars.styl
+++ b/pkg/ui/workspaces/db-console/styl/base/layout-vars.styl
@@ -20,4 +20,4 @@ $max-window-width = 1350px
 $z-index-tooltip     = 4
 $z-index-banner      = 3
 $z-index-navigation  = 2
-$z-index-page-config = 1
+$z-index-page-config = 2


### PR DESCRIPTION
The overview for a statement details page now
shows charts instead of just the mean value for:

- Execution and Planning Time
- Rows Processed
- Execution Retries
- Execution Count
- Contention

https://www.loom.com/share/2b6d0311e61a433d81ad37b8b62fba7d

<img width="1566" alt="Screen Shot 2022-06-06 at 6 14 41 PM" src="https://user-images.githubusercontent.com/1017486/172258188-d0367377-140e-4863-8ecf-f06f14a0e277.png">
<img width="1576" alt="Screen Shot 2022-06-03 at 4 53 49 PM" src="https://user-images.githubusercontent.com/1017486/171951030-0535484d-f4f2-4af4-aa50-f53247951f8c.png">
<img width="1575" alt="Screen Shot 2022-06-03 at 4 54 02 PM" src="https://user-images.githubusercontent.com/1017486/171951037-af6bf17d-0128-49dc-861a-250adaa0f383.png">


Fixes https://github.com/cockroachdb/cockroach/issues/74517

Release note (ui change): Statement Details page now shows charts
for: Execution and Planning Time, Rows Processed, Execution Retries,
Execution Count and Contention.