### PR TITLE
sql: use uint32 for DOid

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -3326,7 +3326,7 @@ func (s *adminServer) queryTableID(
 	if row == nil {
 		return descpb.InvalidID, errors.Newf("failed to resolve %q as a table name", tableName)
 	}
-	return descpb.ID(tree.MustBeDOid(row[0]).DInt), nil
+	return descpb.ID(tree.MustBeDOid(row[0]).Oid), nil
 }
 
 // Note that the function returns plain errors, and it is the caller's

--- a/pkg/sql/catalog/schemaexpr/column.go
+++ b/pkg/sql/catalog/schemaexpr/column.go
@@ -379,7 +379,7 @@ func GetSeqIDFromExpr(expr tree.Expr) (int64, bool) {
 		}
 		return id, true
 	case *tree.DOid:
-		return int64(n.DInt), true
+		return int64(n.Oid), true
 	default:
 		return 0, false
 	}

--- a/pkg/sql/catalog/seqexpr/sequence.go
+++ b/pkg/sql/catalog/seqexpr/sequence.go
@@ -97,7 +97,7 @@ func getSequenceIdentifier(expr tree.Expr) *SeqIdentifier {
 			SeqName: seqName,
 		}
 	case *tree.DOid:
-		id := int64(a.DInt)
+		id := int64(a.Oid)
 		return &SeqIdentifier{
 			SeqID: id,
 		}

--- a/pkg/sql/evalcatalog/pg_updatable.go
+++ b/pkg/sql/evalcatalog/pg_updatable.go
@@ -34,9 +34,11 @@ var (
 )
 
 // PGRelationIsUpdatable is part of the eval.CatalogBuiltins interface.
-func (b *Builtins) PGRelationIsUpdatable(ctx context.Context, oid *tree.DOid) (*tree.DInt, error) {
+func (b *Builtins) PGRelationIsUpdatable(
+	ctx context.Context, oidArg *tree.DOid,
+) (*tree.DInt, error) {
 	tableDesc, err := b.dc.GetImmutableTableByID(
-		ctx, b.txn, descpb.ID(oid.DInt), tree.ObjectLookupFlagsWithRequired(),
+		ctx, b.txn, descpb.ID(oidArg.Oid), tree.ObjectLookupFlagsWithRequired(),
 	)
 	if err != nil {
 		// For postgres compatibility, it is expected that rather returning
@@ -62,13 +64,12 @@ func (b *Builtins) PGRelationIsUpdatable(ctx context.Context, oid *tree.DOid) (*
 func (b *Builtins) PGColumnIsUpdatable(
 	ctx context.Context, oidArg *tree.DOid, attNumArg tree.DInt,
 ) (*tree.DBool, error) {
-	oid := descpb.ID(oidArg.DInt)
 	if attNumArg < 0 {
 		// System columns are not updatable.
 		return tree.DBoolFalse, nil
 	}
 	attNum := descpb.PGAttributeNum(attNumArg)
-	tableDesc, err := b.dc.GetImmutableTableByID(ctx, b.txn, oid, tree.ObjectLookupFlagsWithRequired())
+	tableDesc, err := b.dc.GetImmutableTableByID(ctx, b.txn, descpb.ID(oidArg.Oid), tree.ObjectLookupFlagsWithRequired())
 	if err != nil {
 		if sqlerrors.IsUndefinedRelationError(err) {
 			// For postgres compatibility, it is expected that rather returning

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2368,7 +2368,7 @@ SELECT pg_catalog.length('hello')
 query OOO
 SELECT oid(3), oid(0), oid(12023948723)
 ----
-3  0  12023948723
+3  0  3434014131
 
 query T
 SELECT to_english(i) FROM (VALUES (1), (13), (617), (-2), (-9223372036854775808)) AS a(i)

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2365,10 +2365,20 @@ SELECT pg_catalog.length('hello')
 ----
 5
 
-query OOO
-SELECT oid(3), oid(0), oid(12023948723)
+# -2147483648 is MinInt32.
+# 4294967295 is MaxUint32.
+query OOOOO
+SELECT oid(3), oid(0), (-1)::oid, (-2147483648)::oid, (4294967295)::oid
 ----
-3  0  3434014131
+3  0  4294967295  2147483648  4294967295
+
+# -2147483649 is (MinInt32 - 1).
+query error OID out of range: -2147483649
+SELECT oid(-2147483649)
+
+# 4294967296 is (MaxUint32 + 1).
+query error OID out of range: 4294967296
+SELECT oid(4294967296)
 
 query T
 SELECT to_english(i) FROM (VALUES (1), (13), (617), (-2), (-9223372036854775808)) AS a(i)

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -420,7 +420,7 @@ SELECT proargtypes::REGTYPE[] FROM pg_proc WHERE proname = 'obj_description'
 query I
 SELECT 'trigger'::REGTYPE::INT
 ----
--1
+0
 
 # Regression test for #41708.
 

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -525,3 +525,40 @@ regression_62205
 # Check we error as appropriate if the OID type is not legit.
 statement error pgcode 22P02 invalid input syntax for type oid: "regression_69907"
 SELECT 'regression_69907'::oid
+
+# 4294967295 is MaxUint32.
+# -2147483648 is MinInt32.
+query OIBB
+SELECT o, i, o > i, i > o FROM (VALUES
+  (1::oid, 4294967295::int8),
+  (1::oid, -2147483648::int8),
+  ((-1)::oid, 4294967295::int8),
+  ((-1)::oid, -2147483648::int8),
+  ((-2147483648)::oid, 4294967295::int8),
+  ((-2147483648)::oid, -2147483648::int8),
+  (4294967295::oid, 4294967295::int8),
+  (4294967295::oid, -2147483648::int8)
+) tbl(o, i)
+----
+1           4294967295   false  true
+1           -2147483648  false  true
+4294967295  4294967295   false  false
+4294967295  -2147483648  true   false
+2147483648  4294967295   false  true
+2147483648  -2147483648  false  false
+4294967295  4294967295   false  false
+4294967295  -2147483648  true   false
+
+# 4294967296 is (MaxUint32 + 1).
+query error OID out of range: 4294967296
+SELECT 1:::OID >= 4294967296:::INT8
+
+query error OID out of range: 4294967296
+SELECT 4294967296:::INT8 >= 1:::OID
+
+# -2147483649 is (MinInt32 - 1).
+query error OID out of range: -2147483649
+SELECT 1:::OID >= -2147483649:::INT8
+
+query error OID out of range: -2147483649
+SELECT -2147483649:::INT8 >= 1:::OID

--- a/pkg/sql/opt/constraint/span_test.go
+++ b/pkg/sql/opt/constraint/span_test.go
@@ -700,7 +700,7 @@ func TestSpan_KeyCount(t *testing.T) {
 			// Multiple key span with DOid datum type.
 			keyCtx:   kcAscAsc,
 			length:   1,
-			span:     ParseSpan(&evalCtx, "[/-5 - /5]", types.OidFamily),
+			span:     ParseSpan(&evalCtx, "[/0 - /10]", types.OidFamily),
 			expected: "11",
 		},
 		{ // 3

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1096,7 +1096,7 @@ func makeAllRelationsVirtualTableWithDescriptorIDIndex(
 					var id descpb.ID
 					switch t := unwrappedConstraint.(type) {
 					case *tree.DOid:
-						id = descpb.ID(t.DInt)
+						id = descpb.ID(t.Oid)
 					case *tree.DInt:
 						id = descpb.ID(*t)
 					default:
@@ -3021,7 +3021,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-type.html`,
 				h := makeOidHasher()
 				nspOid := h.NamespaceOid(db.GetID(), pgCatalogName)
 				coid := tree.MustBeDOid(unwrappedConstraint)
-				ooid := oid.Oid(int(coid.DInt))
+				ooid := coid.Oid
 
 				// Check if it is a predefined type.
 				typ, ok := types.OidToType[ooid]
@@ -4167,7 +4167,7 @@ https://www.postgresql.org/docs/9.6/catalog-pg-aggregate.html`,
 								}
 							}
 						}
-						regprocForZeroOid := tree.NewDOidWithName(tree.DInt(0), types.RegProc, "-")
+						regprocForZeroOid := tree.NewDOidWithName(0, types.RegProc, "-")
 						err := addRow(
 							h.BuiltinOid(name, &overload).AsRegProc(name), // aggfnoid
 							aggregateKind,     // aggkind
@@ -4213,7 +4213,7 @@ func init() {
 		for _, o := range def.Definition {
 			if overload, ok := o.(*tree.Overload); ok {
 				builtinOid := h.BuiltinOid(name, overload)
-				id := oid.Oid(builtinOid.DInt)
+				id := builtinOid.Oid
 				tree.OidToBuiltinName[id] = name
 				overload.Oid = id
 			}
@@ -4283,7 +4283,7 @@ func (h oidHasher) writeUInt64(i uint64) {
 }
 
 func (h oidHasher) writeOID(oid *tree.DOid) {
-	h.writeUInt64(uint64(oid.DInt))
+	h.writeUInt64(uint64(oid.Oid))
 }
 
 type oidTypeTag uint8

--- a/pkg/sql/pg_oid_test.go
+++ b/pkg/sql/pg_oid_test.go
@@ -39,8 +39,8 @@ func TestDefaultOid(t *testing.T) {
 
 	for _, tc := range testCases {
 		oid := tableOid(tc.id)
-		if tc.oid.DInt != oid.DInt {
-			t.Fatalf("expected oid %d(%32b), got %d(%32b)", tc.oid.DInt, tc.oid.DInt, oid.DInt, oid.DInt)
+		if tc.oid.Oid != oid.Oid {
+			t.Fatalf("expected oid %d(%32b), got %d(%32b)", tc.oid.Oid, tc.oid.Oid, oid.Oid, oid.Oid)
 		}
 	}
 }

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -744,7 +744,7 @@ func writeBinaryDatumNotNull(
 
 	case *tree.DOid:
 		b.putInt32(4)
-		b.putInt32(int32(v.DInt))
+		b.putInt32(int32(v.Oid))
 	default:
 		b.setError(errors.AssertionFailedf("unsupported type %T", d))
 	}

--- a/pkg/sql/resolve_oid.go
+++ b/pkg/sql/resolve_oid.go
@@ -88,7 +88,7 @@ func resolveOID(
 			"%s %s does not exist", info.objName, toResolve)
 	}
 	return tree.NewDOidWithName(
-		results[0].(*tree.DOid).DInt,
+		tree.DInt(results[0].(*tree.DOid).Oid),
 		resultType,
 		tree.AsStringWithFlags(results[1], tree.FmtBareStrings),
 	), nil

--- a/pkg/sql/row/expr_walker.go
+++ b/pkg/sql/row/expr_walker.go
@@ -498,7 +498,7 @@ func importNextVal(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) 
 func importNextValByID(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 	c := getCellInfoAnnotation(evalCtx.Annotations)
 	oid := tree.MustBeDOid(args[0])
-	seqMetadata, ok := c.seqIDToMetadata[descpb.ID(oid.DInt)]
+	seqMetadata, ok := c.seqIDToMetadata[descpb.ID(oid.Oid)]
 	if !ok {
 		return nil, errors.Newf("sequence with ID %v not found in annotation", oid)
 	}

--- a/pkg/sql/rowenc/keyside/encode.go
+++ b/pkg/sql/rowenc/keyside/encode.go
@@ -163,9 +163,9 @@ func Encode(b []byte, val tree.Datum, dir encoding.Direction) ([]byte, error) {
 		return encoding.EncodeBitArrayDescending(b, t.BitArray), nil
 	case *tree.DOid:
 		if dir == encoding.Ascending {
-			return encoding.EncodeVarintAscending(b, int64(t.DInt)), nil
+			return encoding.EncodeVarintAscending(b, int64(t.Oid)), nil
 		}
-		return encoding.EncodeVarintDescending(b, int64(t.DInt)), nil
+		return encoding.EncodeVarintDescending(b, int64(t.Oid)), nil
 	case *tree.DEnum:
 		if dir == encoding.Ascending {
 			return encoding.EncodeBytesAscending(b, t.PhysicalRep), nil

--- a/pkg/sql/rowenc/valueside/array.go
+++ b/pkg/sql/rowenc/valueside/array.go
@@ -300,7 +300,7 @@ func encodeArrayElement(b []byte, d tree.Datum) ([]byte, error) {
 	case *tree.DIPAddr:
 		return encoding.EncodeUntaggedIPAddrValue(b, t.IPAddr), nil
 	case *tree.DOid:
-		return encoding.EncodeUntaggedIntValue(b, int64(t.DInt)), nil
+		return encoding.EncodeUntaggedIntValue(b, int64(t.Oid)), nil
 	case *tree.DCollatedString:
 		return encoding.EncodeUntaggedBytesValue(b, []byte(t.Contents)), nil
 	case *tree.DOidWrapper:

--- a/pkg/sql/rowenc/valueside/encode.go
+++ b/pkg/sql/rowenc/valueside/encode.go
@@ -92,7 +92,7 @@ func Encode(appendTo []byte, colID ColumnIDDelta, val tree.Datum, scratch []byte
 	case *tree.DCollatedString:
 		return encoding.EncodeBytesValue(appendTo, uint32(colID), []byte(t.Contents)), nil
 	case *tree.DOid:
-		return encoding.EncodeIntValue(appendTo, uint32(colID), int64(t.DInt)), nil
+		return encoding.EncodeIntValue(appendTo, uint32(colID), int64(t.Oid)), nil
 	case *tree.DEnum:
 		return encoding.EncodeBytesValue(appendTo, uint32(colID), t.PhysicalRep), nil
 	case *tree.DVoid:

--- a/pkg/sql/rowenc/valueside/legacy.go
+++ b/pkg/sql/rowenc/valueside/legacy.go
@@ -169,7 +169,7 @@ func MarshalLegacy(colType *types.T, val tree.Datum) (roachpb.Value, error) {
 		}
 	case types.OidFamily:
 		if v, ok := val.(*tree.DOid); ok {
-			r.SetInt(int64(v.DInt))
+			r.SetInt(int64(v.Oid))
 			return r, nil
 		}
 	case types.EnumFamily:

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2207,7 +2207,7 @@ var builtins = map[string]builtinDefinition{
 				if err != nil {
 					return nil, err
 				}
-				res, err := evalCtx.Sequence.IncrementSequenceByID(evalCtx.Ctx(), int64(dOid.DInt))
+				res, err := evalCtx.Sequence.IncrementSequenceByID(evalCtx.Ctx(), int64(dOid.Oid))
 				if err != nil {
 					return nil, err
 				}
@@ -2221,7 +2221,7 @@ var builtins = map[string]builtinDefinition{
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				oid := tree.MustBeDOid(args[0])
-				res, err := evalCtx.Sequence.IncrementSequenceByID(evalCtx.Ctx(), int64(oid.DInt))
+				res, err := evalCtx.Sequence.IncrementSequenceByID(evalCtx.Ctx(), int64(oid.Oid))
 				if err != nil {
 					return nil, err
 				}
@@ -2247,7 +2247,7 @@ var builtins = map[string]builtinDefinition{
 				if err != nil {
 					return nil, err
 				}
-				res, err := evalCtx.Sequence.GetLatestValueInSessionForSequenceByID(evalCtx.Ctx(), int64(dOid.DInt))
+				res, err := evalCtx.Sequence.GetLatestValueInSessionForSequenceByID(evalCtx.Ctx(), int64(dOid.Oid))
 				if err != nil {
 					return nil, err
 				}
@@ -2261,7 +2261,7 @@ var builtins = map[string]builtinDefinition{
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				oid := tree.MustBeDOid(args[0])
-				res, err := evalCtx.Sequence.GetLatestValueInSessionForSequenceByID(evalCtx.Ctx(), int64(oid.DInt))
+				res, err := evalCtx.Sequence.GetLatestValueInSessionForSequenceByID(evalCtx.Ctx(), int64(oid.Oid))
 				if err != nil {
 					return nil, err
 				}
@@ -2311,7 +2311,7 @@ var builtins = map[string]builtinDefinition{
 
 				newVal := tree.MustBeDInt(args[1])
 				if err := evalCtx.Sequence.SetSequenceValueByID(
-					evalCtx.Ctx(), uint32(dOid.DInt), int64(newVal), true /* isCalled */); err != nil {
+					evalCtx.Ctx(), uint32(dOid.Oid), int64(newVal), true /* isCalled */); err != nil {
 					return nil, err
 				}
 				return args[1], nil
@@ -2327,7 +2327,7 @@ var builtins = map[string]builtinDefinition{
 				oid := tree.MustBeDOid(args[0])
 				newVal := tree.MustBeDInt(args[1])
 				if err := evalCtx.Sequence.SetSequenceValueByID(
-					evalCtx.Ctx(), uint32(oid.DInt), int64(newVal), true /* isCalled */); err != nil {
+					evalCtx.Ctx(), uint32(oid.Oid), int64(newVal), true /* isCalled */); err != nil {
 					return nil, err
 				}
 				return args[1], nil
@@ -2351,7 +2351,7 @@ var builtins = map[string]builtinDefinition{
 
 				newVal := tree.MustBeDInt(args[1])
 				if err := evalCtx.Sequence.SetSequenceValueByID(
-					evalCtx.Ctx(), uint32(dOid.DInt), int64(newVal), isCalled); err != nil {
+					evalCtx.Ctx(), uint32(dOid.Oid), int64(newVal), isCalled); err != nil {
 					return nil, err
 				}
 				return args[1], nil
@@ -2371,7 +2371,7 @@ var builtins = map[string]builtinDefinition{
 
 				newVal := tree.MustBeDInt(args[1])
 				if err := evalCtx.Sequence.SetSequenceValueByID(
-					evalCtx.Ctx(), uint32(oid.DInt), int64(newVal), isCalled); err != nil {
+					evalCtx.Ctx(), uint32(oid.Oid), int64(newVal), isCalled); err != nil {
 					return nil, err
 				}
 				return args[1], nil
@@ -6498,7 +6498,7 @@ table's zone configuration this will return NULL.`,
 			ReturnType: tree.FixedReturnType(types.Void),
 			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				oid := tree.MustBeDOid(args[0])
-				if err := evalCtx.Planner.RepairTTLScheduledJobForTable(evalCtx.Ctx(), int64(oid.DInt)); err != nil {
+				if err := evalCtx.Planner.RepairTTLScheduledJobForTable(evalCtx.Ctx(), int64(oid.Oid)); err != nil {
 					return nil, err
 				}
 				return tree.DVoidDatum, nil
@@ -6587,7 +6587,7 @@ in the current database. Returns an error if validation fails.`,
 				if err != nil {
 					return nil, err
 				}
-				if err := evalCtx.Planner.RevalidateUniqueConstraintsInTable(evalCtx.Ctx(), int(dOid.DInt)); err != nil {
+				if err := evalCtx.Planner.RevalidateUniqueConstraintsInTable(evalCtx.Ctx(), int(dOid.Oid)); err != nil {
 					return nil, err
 				}
 				return tree.DVoidDatum, nil
@@ -6613,7 +6613,7 @@ table. Returns an error if validation fails.`,
 					return nil, err
 				}
 				if err = evalCtx.Planner.RevalidateUniqueConstraint(
-					evalCtx.Ctx(), int(dOid.DInt), string(constraintName),
+					evalCtx.Ctx(), int(dOid.Oid), string(constraintName),
 				); err != nil {
 					return nil, err
 				}

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -1032,8 +1032,8 @@ WHERE c.type=$1::int AND c.object_id=$2::int AND c.sub_id=$3::int LIMIT 1
 		tree.Overload{
 			Types:      tree.ArgTypes{{"int", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Oid),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return tree.NewDOid(*args[0].(*tree.DInt)), nil
+			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return eval.PerformCast(evalCtx, args[0], types.Oid)
 			},
 			Info:       "Converts an integer to an OID.",
 			Volatility: volatility.Immutable,

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -654,7 +654,7 @@ var pgBuiltins = map[string]builtinDefinition{
 				t, err := ctx.Planner.QueryRowEx(
 					ctx.Ctx(), "pg_get_function_result",
 					sessiondata.NoSessionDataOverride,
-					`SELECT prorettype::REGTYPE::TEXT FROM pg_proc WHERE oid=$1`, int(funcOid.DInt))
+					`SELECT prorettype::REGTYPE::TEXT FROM pg_proc WHERE oid=$1`, funcOid.Oid)
 				if err != nil {
 					return nil, err
 				}
@@ -681,7 +681,7 @@ var pgBuiltins = map[string]builtinDefinition{
 				t, err := ctx.Planner.QueryRowEx(
 					ctx.Ctx(), "pg_get_function_identity_arguments",
 					sessiondata.NoSessionDataOverride,
-					`SELECT array_agg(unnest(proargtypes)::REGTYPE::TEXT) FROM pg_proc WHERE oid=$1`, int(funcOid.DInt))
+					`SELECT array_agg(unnest(proargtypes)::REGTYPE::TEXT) FROM pg_proc WHERE oid=$1`, funcOid.Oid)
 				if err != nil {
 					return nil, err
 				}
@@ -930,7 +930,7 @@ var pgBuiltins = map[string]builtinDefinition{
 					return tree.DNull, nil
 				}
 				maybeTypmod := args[1]
-				oid := oid.Oid(oidArg.(*tree.DOid).DInt)
+				oid := oidArg.(*tree.DOid).Oid
 				typ, ok := types.OidToType[oid]
 				if !ok {
 					// If the type wasn't statically known, try looking it up as a user
@@ -1009,7 +1009,7 @@ WHERE c.type=$1::int AND c.object_id=$2::int AND c.sub_id=$3::int LIMIT 1
 			Types:      tree.ArgTypes{{"object_oid", types.Oid}},
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return getPgObjDesc(ctx, "", int(args[0].(*tree.DOid).DInt))
+				return getPgObjDesc(ctx, "", args[0].(*tree.DOid).Oid)
 			},
 			Info:       notUsableInfo,
 			Volatility: volatility.Stable,
@@ -1020,7 +1020,7 @@ WHERE c.type=$1::int AND c.object_id=$2::int AND c.sub_id=$3::int LIMIT 1
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return getPgObjDesc(ctx,
 					string(tree.MustBeDString(args[1])),
-					int(args[0].(*tree.DOid).DInt),
+					args[0].(*tree.DOid).Oid,
 				)
 			},
 			Info:       notUsableInfo,
@@ -1046,7 +1046,7 @@ WHERE c.type=$1::int AND c.object_id=$2::int AND c.sub_id=$3::int LIMIT 1
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				catalogName := string(tree.MustBeDString(args[1]))
-				objOid := int(args[0].(*tree.DOid).DInt)
+				objOid := args[0].(*tree.DOid).Oid
 
 				classOid, ok := getCatalogOidForComments(catalogName)
 				if !ok {
@@ -1131,7 +1131,7 @@ SELECT description
 				t, err := ctx.Planner.QueryRowEx(
 					ctx.Ctx(), "pg_function_is_visible",
 					sessiondata.NoSessionDataOverride,
-					"SELECT * from pg_proc WHERE oid=$1 LIMIT 1", int(oid.DInt))
+					"SELECT * from pg_proc WHERE oid=$1 LIMIT 1", oid.Oid)
 				if err != nil {
 					return nil, err
 				}
@@ -1154,7 +1154,7 @@ SELECT description
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				oidArg := tree.MustBeDOid(args[0])
 				isVisible, exists, err := ctx.Planner.IsTableVisible(
-					ctx.Context, ctx.SessionData().Database, ctx.SessionData().SearchPath, oid.Oid(oidArg.DInt),
+					ctx.Context, ctx.SessionData().Database, ctx.SessionData().SearchPath, oidArg.Oid,
 				)
 				if err != nil {
 					return nil, err
@@ -1182,7 +1182,7 @@ SELECT description
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				oidArg := tree.MustBeDOid(args[0])
 				isVisible, exists, err := ctx.Planner.IsTypeVisible(
-					ctx.Context, ctx.SessionData().Database, ctx.SessionData().SearchPath, oid.Oid(oidArg.DInt),
+					ctx.Context, ctx.SessionData().Database, ctx.SessionData().SearchPath, oidArg.Oid,
 				)
 				if err != nil {
 					return nil, err
@@ -1940,7 +1940,7 @@ SELECT description
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				typid := oid.Oid(args[0].(*tree.DOid).DInt)
+				typid := args[0].(*tree.DOid).Oid
 				typmod := *args[1].(*tree.DInt)
 				if typmod == -1 {
 					return tree.DNull, nil
@@ -2010,7 +2010,7 @@ SELECT description
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				typid := oid.Oid(tree.MustBeDOid(args[0]).DInt)
+				typid := tree.MustBeDOid(args[0]).Oid
 				typmod := tree.MustBeDInt(args[1])
 				switch typid {
 				case oid.T_int2:
@@ -2047,7 +2047,7 @@ SELECT description
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				typid := oid.Oid(tree.MustBeDOid(args[0]).DInt)
+				typid := tree.MustBeDOid(args[0]).Oid
 				if typid == oid.T_int2 || typid == oid.T_int4 || typid == oid.T_int8 || typid == oid.T_float4 || typid == oid.T_float8 {
 					return tree.NewDInt(2), nil
 				} else if typid == oid.T_numeric {
@@ -2069,7 +2069,7 @@ SELECT description
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				typid := oid.Oid(tree.MustBeDOid(args[0]).DInt)
+				typid := tree.MustBeDOid(args[0]).Oid
 				typmod := tree.MustBeDInt(args[1])
 				if typid == oid.T_int2 || typid == oid.T_int4 || typid == oid.T_int8 {
 					return tree.NewDInt(0), nil
@@ -2136,7 +2136,7 @@ func getCatalogOidForComments(catalogName string) (id int, ok bool) {
 // getPgObjDesc queries pg_description for object comments. catalog_name, if not
 // empty, provides a constraint on which "system catalog" the comment is in.
 // System catalogs are things like pg_class, pg_type, pg_database, and so on.
-func getPgObjDesc(ctx *eval.Context, catalogName string, oid int) (tree.Datum, error) {
+func getPgObjDesc(ctx *eval.Context, catalogName string, oidVal oid.Oid) (tree.Datum, error) {
 	classOidFilter := ""
 	if catalogName != "" {
 		classOid, ok := getCatalogOidForComments(catalogName)
@@ -2156,7 +2156,7 @@ SELECT description
    AND objsubid = 0
    %[2]s
  LIMIT 1`,
-			oid,
+			oidVal,
 			classOidFilter,
 		))
 	if err != nil {
@@ -2175,8 +2175,8 @@ func databaseHasPrivilegeSpecifier(databaseArg tree.Datum) (eval.HasPrivilegeSpe
 		s := string(*t)
 		specifier.DatabaseName = &s
 	case *tree.DOid:
-		oid := oid.Oid(t.DInt)
-		specifier.DatabaseOID = &oid
+		oidVal := t.Oid
+		specifier.DatabaseOID = &oidVal
 	default:
 		return specifier, errors.AssertionFailedf("unknown privilege specifier: %#v", databaseArg)
 	}
@@ -2196,8 +2196,8 @@ func tableHasPrivilegeSpecifier(
 		s := string(*t)
 		specifier.TableName = &s
 	case *tree.DOid:
-		oid := oid.Oid(t.DInt)
-		specifier.TableOID = &oid
+		oidVal := t.Oid
+		specifier.TableOID = &oidVal
 	default:
 		return specifier, errors.AssertionFailedf("unknown privilege specifier: %#v", tableArg)
 	}

--- a/pkg/sql/sem/eval/binary_op.go
+++ b/pkg/sql/sem/eval/binary_op.go
@@ -140,7 +140,10 @@ func (e *evaluator) EvalCompareScalarOp(
 			return tree.DNull, nil
 		}
 	}
-	cmp := left.Compare(e.ctx(), right)
+	cmp, err := left.CompareError(e.ctx(), right)
+	if err != nil {
+		return nil, err
+	}
 	return boolFromCmp(cmp, op.ComparisonOperator), nil
 }
 

--- a/pkg/sql/sem/eval/cast.go
+++ b/pkg/sql/sem/eval/cast.go
@@ -911,6 +911,9 @@ func performIntToOidCast(
 	// OIDs are always unsigned 32-bit integers. Some languages, like Java,
 	// store OIDs as signed 32-bit integers, so we implement the cast
 	// by converting to a uint32 first. This matches Postgres behavior.
+	if v > math.MaxUint32 || v < math.MinInt32 {
+		return nil, pgerror.Newf(pgcode.NumericValueOutOfRange, "OID out of range: %d", v)
+	}
 	o := oid.Oid(v)
 	switch t.Oid() {
 	case oid.T_oid:

--- a/pkg/sql/sem/eval/cast.go
+++ b/pkg/sql/sem/eval/cast.go
@@ -231,7 +231,7 @@ func performCastWithoutPrecisionTruncation(
 			}
 			res = tree.NewDInt(tree.DInt(iv))
 		case *tree.DOid:
-			res = &v.DInt
+			res = tree.NewDInt(tree.DInt(v.Oid))
 		case *tree.DJSON:
 			dec, ok := v.AsDecimal()
 			if !ok {
@@ -856,13 +856,9 @@ func performCastWithoutPrecisionTruncation(
 	case types.OidFamily:
 		switch v := d.(type) {
 		case *tree.DOid:
-			return performIntToOidCast(ctx.Ctx(), ctx.Planner, t, v.DInt)
+			return performIntToOidCast(ctx.Ctx(), ctx.Planner, t, tree.DInt(v.Oid))
 		case *tree.DInt:
-			// OIDs are always unsigned 32-bit integers. Some languages, like Java,
-			// store OIDs as signed 32-bit integers, so we implement the cast
-			// by converting to a uint32 first. This matches Postgres behavior.
-			i := tree.DInt(uint32(*v))
-			return performIntToOidCast(ctx.Ctx(), ctx.Planner, t, i)
+			return performIntToOidCast(ctx.Ctx(), ctx.Planner, t, *v)
 		case *tree.DString:
 			if t.Oid() != oid.T_oid && string(*v) == tree.ZeroOidValue {
 				return tree.WrapAsZeroOid(t), nil
@@ -912,16 +908,20 @@ func performCastWithoutPrecisionTruncation(
 func performIntToOidCast(
 	ctx context.Context, res TypeResolver, t *types.T, v tree.DInt,
 ) (tree.Datum, error) {
+	// OIDs are always unsigned 32-bit integers. Some languages, like Java,
+	// store OIDs as signed 32-bit integers, so we implement the cast
+	// by converting to a uint32 first. This matches Postgres behavior.
+	o := oid.Oid(v)
 	switch t.Oid() {
 	case oid.T_oid:
 		return tree.NewDOidWithType(v, t), nil
 	case oid.T_regtype:
 		// Mapping an dOid to a regtype is easy: we have a hardcoded map.
 		var name string
-		if typ, ok := types.OidToType[oid.Oid(v)]; ok {
+		if typ, ok := types.OidToType[o]; ok {
 			name = typ.PGName()
-		} else if types.IsOIDUserDefinedType(oid.Oid(v)) {
-			typ, err := res.ResolveTypeByOID(ctx, oid.Oid(v))
+		} else if types.IsOIDUserDefinedType(o) {
+			typ, err := res.ResolveTypeByOID(ctx, o)
 			if err != nil {
 				return nil, err
 			}
@@ -933,7 +933,7 @@ func performIntToOidCast(
 
 	case oid.T_regproc, oid.T_regprocedure:
 		// Mapping an dOid to a regproc is easy: we have a hardcoded map.
-		name, ok := tree.OidToBuiltinName[oid.Oid(v)]
+		name, ok := tree.OidToBuiltinName[o]
 		if !ok {
 			if v == 0 {
 				return tree.WrapAsZeroOid(t), nil

--- a/pkg/sql/sem/eval/parse_doid.go
+++ b/pkg/sql/sem/eval/parse_doid.go
@@ -117,9 +117,9 @@ func ParseDOid(ctx *Context, s string, t *types.T) (*tree.DOid, error) {
 		default:
 			return nil, missingTypeErr
 		}
-		// Types we don't support get OID -1, so they won't match anything
+		// Types we don't support get OID 0, so they won't match anything
 		// in catalogs.
-		return tree.NewDOidWithTypeAndName(-1, t, s), nil
+		return tree.NewDOidWithTypeAndName(0, t, s), nil
 
 	case oid.T_regclass:
 		tn, err := castStringToRegClassTableName(s)

--- a/pkg/sql/sem/eval/testdata/eval/cast
+++ b/pkg/sql/sem/eval/testdata/eval/cast
@@ -1376,3 +1376,32 @@ eval
 '2'::BIT
 ----
 could not parse string as bit array: "2" is not a valid binary digit
+
+eval
+(-1)::oid
+----
+4294967295
+
+# -2147483648 is MinInt32.
+eval
+(-2147483648)::oid
+----
+2147483648
+
+# -2147483649 is (MinInt32 - 1).
+eval
+(-2147483649)::oid
+----
+OID out of range: -2147483649
+
+# 4294967295 is MaxUint32.
+eval
+(4294967295)::oid
+----
+4294967295
+
+# 4294967296 is (MaxUint32 + 1).
+eval
+(4294967296)::oid
+----
+OID out of range: 4294967296

--- a/pkg/sql/sem/eval/testdata/eval/oid
+++ b/pkg/sql/sem/eval/testdata/eval/oid
@@ -82,3 +82,47 @@ eval
 1:::OID <= -3:::INT
 ----
 true
+
+# 4294967295 is MaxUint32.
+eval
+1:::OID >= 4294967295:::INT8
+----
+false
+
+eval
+4294967295:::INT8 >= 1:::OID
+----
+true
+
+# 4294967296 is (MaxUint32 + 1).
+eval
+1:::OID >= 4294967296:::INT8
+----
+OID out of range: 4294967296
+
+eval
+4294967296:::INT8 >= 1:::OID
+----
+OID out of range: 4294967296
+
+# -2147483648 is MinInt32.
+eval
+1:::OID >= -2147483648:::INT8
+----
+false
+
+eval
+-2147483648:::INT8 >= 1:::OID
+----
+true
+
+# -2147483649 is (MinInt32 - 1).
+eval
+1:::OID >= -2147483649:::INT8
+----
+OID out of range: -2147483649
+
+eval
+-2147483649:::INT8 >= 1:::OID
+----
+OID out of range: -2147483649

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -759,6 +759,9 @@ func (d *DInt) CompareError(ctx CompareContext, other Datum) (int, error) {
 		// OIDs are always unsigned 32-bit integers. Some languages, like Java,
 		// compare OIDs to signed 32-bit integers, so we implement the comparison
 		// by converting to a uint32 first. This matches Postgres behavior.
+		if thisInt > math.MaxUint32 || thisInt < math.MinInt32 {
+			return 0, pgerror.Newf(pgcode.NumericValueOutOfRange, "OID out of range: %d", thisInt)
+		}
 		thisInt = DInt(uint32(thisInt))
 		v = DInt(t.Oid)
 	default:
@@ -4963,6 +4966,9 @@ func (d *DOid) CompareError(ctx CompareContext, other Datum) (int, error) {
 		// OIDs are always unsigned 32-bit integers. Some languages, like Java,
 		// compare OIDs to signed 32-bit integers, so we implement the comparison
 		// by converting to a uint32 first. This matches Postgres behavior.
+		if *t > math.MaxUint32 || *t < math.MinInt32 {
+			return 0, pgerror.Newf(pgcode.NumericValueOutOfRange, "OID out of range: %d", *t)
+		}
 		v = oid.Oid(*t)
 	default:
 		return 0, makeUnsupportedComparisonMessage(d, other)

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -378,7 +378,7 @@ WHERE
 	var ok bool
 	for ok, err = defaultSettingsIt.Next(ctx); ok; ok, err = defaultSettingsIt.Next(ctx) {
 		row := defaultSettingsIt.Cur()
-		fetechedDatabaseID := descpb.ID(tree.MustBeDOid(row[0]).DInt)
+		fetechedDatabaseID := descpb.ID(tree.MustBeDOid(row[0]).Oid)
 		fetchedUsername := username.MakeSQLUsernameFromPreNormalizedString(string(tree.MustBeDString(row[1])))
 		settingsDatum := tree.MustBeDArray(row[2])
 		fetchedSettings := make([]string, settingsDatum.Len())

--- a/pkg/workload/rand/rand.go
+++ b/pkg/workload/rand/rand.go
@@ -334,7 +334,7 @@ func DatumToGoSQL(d tree.Datum) (interface{}, error) {
 	case *tree.DInt:
 		return int64(*d), nil
 	case *tree.DOid:
-		return int(d.DInt), nil
+		return uint32(d.Oid), nil
 	case *tree.DFloat:
 		return float64(*d), nil
 	case *tree.DDecimal:


### PR DESCRIPTION
refs https://github.com/cockroachdb/cockroach/issues/41904

This resolves a piece of tech debt that has caused us a few surprises
and bugs in the past. This doesn't change anything about the on-disk
representation -- it just makes it so that OIDs handled in memory are
more reliably unsigned 32 bit integers.

Release note: None