### PR TITLE
dev: provide a way to easily build and stage `libgeos` libraries

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -167,6 +167,7 @@ func findBinaryOrLibrary(binOrLib string, name string) (string, error) {
 		}
 		dirs := []string{
 			filepath.Join(gopath, "/src/github.com/cockroachdb/cockroach/"),
+			filepath.Join(gopath, "/src/github.com/cockroachdb/cockroach/artifacts/"),
 			filepath.Join(gopath, "/src/github.com/cockroachdb/cockroach", binOrLib+suffix),
 			filepath.Join(os.ExpandEnv("$PWD"), binOrLib+suffix),
 			filepath.Join(gopath, "/src/github.com/cockroachdb/cockroach", binOrLib),


### PR DESCRIPTION
Provide special logic to `dev build geos` which builds the libraries and
stages them in `lib/`. Also give the same power to
`dev build geos --cross`, and allow `roachtest` to find the libraries
in `artifacts/`.

Closes https://github.com/cockroachdb/cockroach/issues/80282.

Release note: None