### PR TITLE
sql/multiregion: move telemetry names to break catpb->tree dep

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -2049,11 +2049,11 @@ opt_in_schemas ::=
 	| 
 
 abbreviated_grant_stmt ::=
-	'GRANT' privileges 'ON' alter_default_privileges_target_object 'TO' role_spec_list opt_with_grant_option
+	'GRANT' privileges 'ON' target_object_type 'TO' role_spec_list opt_with_grant_option
 
 abbreviated_revoke_stmt ::=
-	'REVOKE' privileges 'ON' alter_default_privileges_target_object 'FROM' role_spec_list opt_drop_behavior
-	| 'REVOKE' 'GRANT' 'OPTION' 'FOR' privileges 'ON' alter_default_privileges_target_object 'FROM' role_spec_list opt_drop_behavior
+	'REVOKE' privileges 'ON' target_object_type 'FROM' role_spec_list opt_drop_behavior
+	| 'REVOKE' 'GRANT' 'OPTION' 'FOR' privileges 'ON' target_object_type 'FROM' role_spec_list opt_drop_behavior
 
 alter_changefeed_cmds ::=
 	( alter_changefeed_cmd ) ( ( alter_changefeed_cmd ) )*
@@ -2570,7 +2570,7 @@ relocate_subject_nonlease ::=
 	| 
 	| 'NONVOTERS'
 
-alter_default_privileges_target_object ::=
+target_object_type ::=
 	'TABLES'
 	| 'SEQUENCES'
 	| 'TYPES'

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -229,6 +229,7 @@ ALL_TESTS = [
     "//pkg/sql/backfill:backfill_test",
     "//pkg/sql/catalog/catalogkeys:catalogkeys_test",
     "//pkg/sql/catalog/catformat:catformat_test",
+    "//pkg/sql/catalog/catpb:catpb_disallowed_imports_test",
     "//pkg/sql/catalog/catpb:catpb_test",
     "//pkg/sql/catalog/catprivilege:catprivilege_test",
     "//pkg/sql/catalog/colinfo:colinfo_test",

--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -402,7 +402,7 @@ var specs = []stmtSpec{
 	},
 	{
 		name:    "alter_default_privileges_stmt",
-		inline:  []string{"opt_for_roles", "role_or_group_or_user", "name_list", "opt_in_schemas", "schema_name_list", "abbreviated_grant_stmt", "opt_with_grant_option", "alter_default_privileges_target_object", "abbreviated_revoke_stmt", "opt_drop_behavior"},
+		inline:  []string{"opt_for_roles", "role_or_group_or_user", "name_list", "opt_in_schemas", "schema_name_list", "abbreviated_grant_stmt", "opt_with_grant_option", "target_object_type", "abbreviated_revoke_stmt", "opt_drop_behavior"},
 		nosplit: true,
 	},
 	{

--- a/pkg/sql/alter_default_privileges.go
+++ b/pkg/sql/alter_default_privileges.go
@@ -29,11 +29,11 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-var targetObjectToPrivilegeObject = map[tree.AlterDefaultPrivilegesTargetObject]privilege.ObjectType{
-	tree.Tables:    privilege.Table,
-	tree.Sequences: privilege.Table,
-	tree.Types:     privilege.Type,
-	tree.Schemas:   privilege.Schema,
+var targetObjectToPrivilegeObject = map[privilege.TargetObjectType]privilege.ObjectType{
+	privilege.Tables:    privilege.Table,
+	privilege.Sequences: privilege.Table,
+	privilege.Types:     privilege.Type,
+	privilege.Schemas:   privilege.Schema,
 }
 
 type alterDefaultPrivilegesNode struct {
@@ -67,7 +67,7 @@ func (p *planner) alterDefaultPrivileges(
 		objectType = n.Revoke.Target
 	}
 
-	if len(n.Schemas) > 0 && objectType == tree.Schemas {
+	if len(n.Schemas) > 0 && objectType == privilege.Schemas {
 		return nil, pgerror.WithCandidateCode(errors.New(
 			"cannot use IN SCHEMA clause when using GRANT/REVOKE ON SCHEMAS"),
 			pgcode.InvalidGrantOperation,
@@ -176,7 +176,7 @@ func (n *alterDefaultPrivilegesNode) startExec(params runParams) error {
 func (n *alterDefaultPrivilegesNode) alterDefaultPrivilegesForSchemas(
 	params runParams,
 	targetRoles []username.SQLUsername,
-	objectType tree.AlterDefaultPrivilegesTargetObject,
+	objectType privilege.TargetObjectType,
 	grantees tree.RoleSpecList,
 	privileges privilege.List,
 	grantOption bool,
@@ -281,7 +281,7 @@ func (n *alterDefaultPrivilegesNode) alterDefaultPrivilegesForSchemas(
 func (n *alterDefaultPrivilegesNode) alterDefaultPrivilegesForDatabase(
 	params runParams,
 	targetRoles []username.SQLUsername,
-	objectType tree.AlterDefaultPrivilegesTargetObject,
+	objectType privilege.TargetObjectType,
 	grantees tree.RoleSpecList,
 	privileges privilege.List,
 	grantOption bool,

--- a/pkg/sql/alter_table_locality.go
+++ b/pkg/sql/alter_table_locality.go
@@ -462,14 +462,14 @@ func (n *alterTableSetLocalityNode) startExec(params runParams) error {
 	newLocality := n.n.Locality
 	existingLocality := n.tableDesc.LocalityConfig
 
-	existingLocalityTelemetryName, err := existingLocality.TelemetryName()
+	existingLocalityTelemetryName, err := multiregion.TelemetryNameForLocalityConfig(existingLocality)
 	if err != nil {
 		return err
 	}
 	telemetry.Inc(
 		sqltelemetry.AlterTableLocalityCounter(
 			existingLocalityTelemetryName,
-			newLocality.TelemetryName(),
+			multiregion.TelemetryNameForLocality(newLocality),
 		),
 	)
 

--- a/pkg/sql/catalog/catpb/BUILD.bazel
+++ b/pkg/sql/catalog/catpb/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("//pkg/testutils/buildutil:buildutil.bzl", "disallowed_imports_test")
 load("//build:STRINGER.bzl", "stringer")
 
 proto_library(
@@ -49,7 +50,6 @@ go_library(
         "//pkg/sql/privilege",
         "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/catid",
-        "//pkg/sql/sem/tree",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
     ],
@@ -74,4 +74,11 @@ stringer(
     name = "gen-privilegedescversion-stringer",
     src = "privilege.go",
     typ = "PrivilegeDescVersion",
+)
+
+disallowed_imports_test(
+    src = "catpb",
+    disallowed_list = [
+        "//pkg/sql/sem/tree",
+    ],
 )

--- a/pkg/sql/catalog/catpb/default_privilege.go
+++ b/pkg/sql/catalog/catpb/default_privilege.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/errors"
 )
 
@@ -112,7 +111,7 @@ func InitDefaultPrivilegesForRole(
 		}
 		return DefaultPrivilegesForRole{
 			Role:                       defaultPrivilegesRole,
-			DefaultPrivilegesPerObject: map[tree.AlterDefaultPrivilegesTargetObject]PrivilegeDescriptor{},
+			DefaultPrivilegesPerObject: map[privilege.TargetObjectType]PrivilegeDescriptor{},
 		}
 	}
 
@@ -138,7 +137,7 @@ func InitDefaultPrivilegesForRole(
 	}
 	return DefaultPrivilegesForRole{
 		Role:                       defaultPrivilegesRole,
-		DefaultPrivilegesPerObject: map[tree.AlterDefaultPrivilegesTargetObject]PrivilegeDescriptor{},
+		DefaultPrivilegesPerObject: map[privilege.TargetObjectType]PrivilegeDescriptor{},
 	}
 }
 
@@ -169,7 +168,7 @@ func (p *DefaultPrivilegeDescriptor) Validate() error {
 			return errors.AssertionFailedf("default privilege list is not sorted")
 		}
 		for objectType, defaultPrivileges := range defaultPrivilegesForRole.DefaultPrivilegesPerObject {
-			privilegeObjectType := objectType.ToPrivilegeObjectType()
+			privilegeObjectType := objectType.ToObjectType()
 			valid, u, remaining := defaultPrivileges.IsValidPrivilegesForObjectType(privilegeObjectType)
 			if !valid {
 				return errors.AssertionFailedf("user %s must not have %s privileges on %s",

--- a/pkg/sql/catalog/catpb/multiregion.go
+++ b/pkg/sql/catalog/catpb/multiregion.go
@@ -10,11 +10,6 @@
 
 package catpb
 
-import (
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/errors"
-)
-
 // RegionName is an alias for a region stored on the database.
 type RegionName string
 
@@ -33,26 +28,4 @@ func (regions RegionNames) ToStrings() []string {
 		ret[i] = string(region)
 	}
 	return ret
-}
-
-// TelemetryName returns the name to use for the given locality.
-func (cfg *LocalityConfig) TelemetryName() (string, error) {
-	switch l := cfg.Locality.(type) {
-	case *LocalityConfig_Global_:
-		return tree.TelemetryNameGlobal, nil
-	case *LocalityConfig_RegionalByTable_:
-		if l.RegionalByTable.Region != nil {
-			return tree.TelemetryNameRegionalByTableIn, nil
-		}
-		return tree.TelemetryNameRegionalByTable, nil
-	case *LocalityConfig_RegionalByRow_:
-		if l.RegionalByRow.As != nil {
-			return tree.TelemetryNameRegionalByRowAs, nil
-		}
-		return tree.TelemetryNameRegionalByRow, nil
-	}
-	return "", errors.AssertionFailedf(
-		"unknown locality config TelemetryName: type %T",
-		cfg.Locality,
-	)
 }

--- a/pkg/sql/catalog/catpb/privilege.proto
+++ b/pkg/sql/catalog/catpb/privilege.proto
@@ -39,7 +39,7 @@ message PrivilegeDescriptor {
 // DefaultPrivileges are the set of privileges that an object created by a user
 // should have at creation time.
 // DefaultPrivilegesForRole is further broken down depending on the object type.
-// The object types (AlterDefaultPrivilegesTargetObject) are:
+// The object types (TargetObjectType) are:
 //   1: Tables
 //   2: Sequences
 //   3: Types
@@ -81,7 +81,7 @@ message DefaultPrivilegesForRole {
     ForAllRolesPseudoRole for_all_roles = 13;
   }
   map<uint32, PrivilegeDescriptor> default_privileges_per_object = 14 [(gogoproto.nullable) = false,
-    (gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/sql/sem/tree.AlterDefaultPrivilegesTargetObject"];
+    (gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/sql/privilege.TargetObjectType"];
 }
 
 // DefaultPrivilegeDescriptor describes the set of default privileges for a

--- a/pkg/sql/catalog/catprivilege/BUILD.bazel
+++ b/pkg/sql/catalog/catprivilege/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/privilege",
         "//pkg/sql/sem/catconstants",
-        "//pkg/sql/sem/tree",
     ],
 )
 
@@ -36,7 +35,6 @@ go_test(
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/privilege",
-        "//pkg/sql/sem/tree",
         "//pkg/util/leaktest",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/sql/catalog/catprivilege/default_privilege_test.go
+++ b/pkg/sql/catalog/catprivilege/default_privilege_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/stretchr/testify/require"
 )
@@ -37,70 +36,70 @@ func TestGrantDefaultPrivileges(t *testing.T) {
 		defaultPrivilegesRole catpb.DefaultPrivilegesRole
 		privileges            privilege.List
 		grantees              []username.SQLUsername
-		targetObject          tree.AlterDefaultPrivilegesTargetObject
+		targetObject          privilege.TargetObjectType
 		objectCreator         username.SQLUsername
 	}{
 		{
 			defaultPrivilegesRole: catpb.DefaultPrivilegesRole{Role: creatorUser},
 			privileges:            privilege.List{privilege.ALL},
 			grantees:              []username.SQLUsername{fooUser},
-			targetObject:          tree.Tables,
+			targetObject:          privilege.Tables,
 			objectCreator:         creatorUser,
 		},
 		{
 			defaultPrivilegesRole: catpb.DefaultPrivilegesRole{Role: creatorUser},
 			privileges:            privilege.List{privilege.ALL},
 			grantees:              []username.SQLUsername{fooUser, barUser, bazUser},
-			targetObject:          tree.Tables,
+			targetObject:          privilege.Tables,
 			objectCreator:         creatorUser,
 		},
 		{
 			defaultPrivilegesRole: catpb.DefaultPrivilegesRole{Role: creatorUser},
 			privileges:            privilege.List{privilege.ALL},
 			grantees:              []username.SQLUsername{fooUser, barUser, bazUser},
-			targetObject:          tree.Sequences,
+			targetObject:          privilege.Sequences,
 			objectCreator:         creatorUser,
 		},
 		{
 			defaultPrivilegesRole: catpb.DefaultPrivilegesRole{Role: creatorUser},
 			privileges:            privilege.List{privilege.ALL},
 			grantees:              []username.SQLUsername{fooUser, barUser, bazUser},
-			targetObject:          tree.Types,
+			targetObject:          privilege.Types,
 			objectCreator:         creatorUser,
 		},
 		{
 			defaultPrivilegesRole: catpb.DefaultPrivilegesRole{Role: creatorUser},
 			privileges:            privilege.List{privilege.ALL},
 			grantees:              []username.SQLUsername{fooUser, barUser, bazUser},
-			targetObject:          tree.Schemas,
+			targetObject:          privilege.Schemas,
 			objectCreator:         creatorUser,
 		},
 		{
 			defaultPrivilegesRole: catpb.DefaultPrivilegesRole{Role: creatorUser},
 			privileges:            privilege.List{privilege.SELECT, privilege.DELETE},
 			grantees:              []username.SQLUsername{fooUser, barUser, bazUser},
-			targetObject:          tree.Tables,
+			targetObject:          privilege.Tables,
 			objectCreator:         creatorUser,
 		},
 		{
 			defaultPrivilegesRole: catpb.DefaultPrivilegesRole{Role: creatorUser},
 			privileges:            privilege.List{privilege.SELECT, privilege.DELETE},
 			grantees:              []username.SQLUsername{fooUser, barUser, bazUser},
-			targetObject:          tree.Sequences,
+			targetObject:          privilege.Sequences,
 			objectCreator:         creatorUser,
 		},
 		{
 			defaultPrivilegesRole: catpb.DefaultPrivilegesRole{Role: creatorUser},
 			privileges:            privilege.List{privilege.USAGE},
 			grantees:              []username.SQLUsername{fooUser, barUser, bazUser},
-			targetObject:          tree.Types,
+			targetObject:          privilege.Types,
 			objectCreator:         creatorUser,
 		},
 		{
 			defaultPrivilegesRole: catpb.DefaultPrivilegesRole{Role: creatorUser},
 			privileges:            privilege.List{privilege.USAGE},
 			grantees:              []username.SQLUsername{fooUser, barUser, bazUser},
-			targetObject:          tree.Schemas,
+			targetObject:          privilege.Schemas,
 			objectCreator:         creatorUser,
 		},
 		/* Test cases for ForAllRoles */
@@ -108,56 +107,56 @@ func TestGrantDefaultPrivileges(t *testing.T) {
 			defaultPrivilegesRole: catpb.DefaultPrivilegesRole{ForAllRoles: true},
 			privileges:            privilege.List{privilege.ALL},
 			grantees:              []username.SQLUsername{fooUser, barUser, bazUser},
-			targetObject:          tree.Tables,
+			targetObject:          privilege.Tables,
 			objectCreator:         creatorUser,
 		},
 		{
 			defaultPrivilegesRole: catpb.DefaultPrivilegesRole{ForAllRoles: true},
 			privileges:            privilege.List{privilege.ALL},
 			grantees:              []username.SQLUsername{fooUser, barUser, bazUser},
-			targetObject:          tree.Sequences,
+			targetObject:          privilege.Sequences,
 			objectCreator:         creatorUser,
 		},
 		{
 			defaultPrivilegesRole: catpb.DefaultPrivilegesRole{ForAllRoles: true},
 			privileges:            privilege.List{privilege.ALL},
 			grantees:              []username.SQLUsername{fooUser, barUser, bazUser},
-			targetObject:          tree.Types,
+			targetObject:          privilege.Types,
 			objectCreator:         creatorUser,
 		},
 		{
 			defaultPrivilegesRole: catpb.DefaultPrivilegesRole{ForAllRoles: true},
 			privileges:            privilege.List{privilege.ALL},
 			grantees:              []username.SQLUsername{fooUser, barUser, bazUser},
-			targetObject:          tree.Schemas,
+			targetObject:          privilege.Schemas,
 			objectCreator:         creatorUser,
 		},
 		{
 			defaultPrivilegesRole: catpb.DefaultPrivilegesRole{ForAllRoles: true},
 			privileges:            privilege.List{privilege.SELECT, privilege.DELETE},
 			grantees:              []username.SQLUsername{fooUser, barUser, bazUser},
-			targetObject:          tree.Tables,
+			targetObject:          privilege.Tables,
 			objectCreator:         creatorUser,
 		},
 		{
 			defaultPrivilegesRole: catpb.DefaultPrivilegesRole{ForAllRoles: true},
 			privileges:            privilege.List{privilege.SELECT, privilege.DELETE},
 			grantees:              []username.SQLUsername{fooUser, barUser, bazUser},
-			targetObject:          tree.Sequences,
+			targetObject:          privilege.Sequences,
 			objectCreator:         creatorUser,
 		},
 		{
 			defaultPrivilegesRole: catpb.DefaultPrivilegesRole{ForAllRoles: true},
 			privileges:            privilege.List{privilege.USAGE},
 			grantees:              []username.SQLUsername{fooUser, barUser, bazUser},
-			targetObject:          tree.Types,
+			targetObject:          privilege.Types,
 			objectCreator:         creatorUser,
 		},
 		{
 			defaultPrivilegesRole: catpb.DefaultPrivilegesRole{ForAllRoles: true},
 			privileges:            privilege.List{privilege.USAGE},
 			grantees:              []username.SQLUsername{fooUser, barUser, bazUser},
-			targetObject:          tree.Schemas,
+			targetObject:          privilege.Schemas,
 			objectCreator:         creatorUser,
 		},
 	}
@@ -195,7 +194,7 @@ func TestRevokeDefaultPrivileges(t *testing.T) {
 		defaultPrivilegesRole                                 catpb.DefaultPrivilegesRole
 		grantPrivileges, revokePrivileges, expectedPrivileges privilege.List
 		grantees                                              []username.SQLUsername
-		targetObject                                          tree.AlterDefaultPrivilegesTargetObject
+		targetObject                                          privilege.TargetObjectType
 		objectCreator                                         username.SQLUsername
 	}{
 		{
@@ -207,7 +206,7 @@ func TestRevokeDefaultPrivileges(t *testing.T) {
 				privilege.DELETE, privilege.UPDATE, privilege.ZONECONFIG,
 			},
 			grantees:      []username.SQLUsername{fooUser, barUser, bazUser},
-			targetObject:  tree.Tables,
+			targetObject:  privilege.Tables,
 			objectCreator: creatorUser,
 		},
 		{
@@ -219,7 +218,7 @@ func TestRevokeDefaultPrivileges(t *testing.T) {
 				privilege.DELETE, privilege.UPDATE, privilege.ZONECONFIG,
 			},
 			grantees:      []username.SQLUsername{fooUser, barUser, bazUser},
-			targetObject:  tree.Sequences,
+			targetObject:  privilege.Sequences,
 			objectCreator: creatorUser,
 		},
 		{
@@ -230,7 +229,7 @@ func TestRevokeDefaultPrivileges(t *testing.T) {
 				privilege.GRANT,
 			},
 			grantees:      []username.SQLUsername{fooUser, barUser, bazUser},
-			targetObject:  tree.Types,
+			targetObject:  privilege.Types,
 			objectCreator: creatorUser,
 		},
 		{
@@ -241,7 +240,7 @@ func TestRevokeDefaultPrivileges(t *testing.T) {
 				privilege.CREATE, privilege.GRANT,
 			},
 			grantees:      []username.SQLUsername{fooUser, barUser, bazUser},
-			targetObject:  tree.Schemas,
+			targetObject:  privilege.Schemas,
 			objectCreator: creatorUser,
 		},
 		/* Test cases for ForAllRoles */
@@ -254,7 +253,7 @@ func TestRevokeDefaultPrivileges(t *testing.T) {
 				privilege.DELETE, privilege.UPDATE, privilege.ZONECONFIG,
 			},
 			grantees:      []username.SQLUsername{fooUser, barUser, bazUser},
-			targetObject:  tree.Sequences,
+			targetObject:  privilege.Sequences,
 			objectCreator: creatorUser,
 		},
 		{
@@ -265,7 +264,7 @@ func TestRevokeDefaultPrivileges(t *testing.T) {
 				privilege.GRANT,
 			},
 			grantees:      []username.SQLUsername{fooUser, barUser, bazUser},
-			targetObject:  tree.Types,
+			targetObject:  privilege.Types,
 			objectCreator: creatorUser,
 		},
 		{
@@ -276,7 +275,7 @@ func TestRevokeDefaultPrivileges(t *testing.T) {
 				privilege.CREATE, privilege.GRANT,
 			},
 			grantees:      []username.SQLUsername{fooUser, barUser, bazUser},
-			targetObject:  tree.Schemas,
+			targetObject:  privilege.Schemas,
 			objectCreator: creatorUser,
 		},
 	}
@@ -312,11 +311,11 @@ func TestRevokeDefaultPrivilegesFromEmptyList(t *testing.T) {
 	fooUser := username.MakeSQLUsernameFromPreNormalizedString("foo")
 	defaultPrivileges.RevokeDefaultPrivileges(catpb.DefaultPrivilegesRole{
 		Role: creatorUser,
-	}, privilege.List{privilege.ALL}, []username.SQLUsername{fooUser}, tree.Tables, false /* grantOptionFor */, false /*deprecateGrant*/)
+	}, privilege.List{privilege.ALL}, []username.SQLUsername{fooUser}, privilege.Tables, false /* grantOptionFor */, false /*deprecateGrant*/)
 
 	newPrivileges := CreatePrivilegesFromDefaultPrivileges(
 		defaultPrivileges, nil, /* schemaDefaultPrivilegeDescriptor */
-		nonSystemDatabaseID, creatorUser, tree.Tables, &catpb.PrivilegeDescriptor{},
+		nonSystemDatabaseID, creatorUser, privilege.Tables, &catpb.PrivilegeDescriptor{},
 	)
 
 	if newPrivileges.AnyPrivilege(fooUser) {
@@ -332,7 +331,7 @@ func TestCreatePrivilegesFromDefaultPrivilegesForSystemDatabase(t *testing.T) {
 	creatorUser := username.MakeSQLUsernameFromPreNormalizedString("creator")
 	newPrivileges := CreatePrivilegesFromDefaultPrivileges(
 		defaultPrivileges, nil, /* schemaDefaultPrivilegeDescriptor */
-		keys.SystemDatabaseID, creatorUser, tree.Tables, &catpb.PrivilegeDescriptor{},
+		keys.SystemDatabaseID, creatorUser, privilege.Tables, &catpb.PrivilegeDescriptor{},
 	)
 
 	if !newPrivileges.Owner().IsNodeUser() {
@@ -347,7 +346,7 @@ func TestPresetDefaultPrivileges(t *testing.T) {
 	defaultPrivileges := NewMutableDefaultPrivileges(defaultPrivilegeDescriptor)
 	creatorUser := username.MakeSQLUsernameFromPreNormalizedString("creator")
 
-	targetObjectTypes := tree.GetAlterDefaultPrivilegesTargetObjects()
+	targetObjectTypes := privilege.GetTargetObjectTypes()
 	for _, targetObject := range targetObjectTypes {
 		newPrivileges := CreatePrivilegesFromDefaultPrivileges(
 			defaultPrivileges, nil, /* schemaDefaultPrivilegeDescriptor */
@@ -358,7 +357,7 @@ func TestPresetDefaultPrivileges(t *testing.T) {
 			t.Errorf("expected creator to have ALL privileges on %s", targetObject)
 		}
 
-		if targetObject == tree.Types {
+		if targetObject == privilege.Types {
 			if !newPrivileges.CheckPrivilege(username.PublicRoleName(), privilege.USAGE) {
 				t.Errorf("expected %s to have %s on types", username.PublicRoleName(), privilege.USAGE)
 			}
@@ -373,7 +372,7 @@ func TestPresetDefaultPrivilegesInSchema(t *testing.T) {
 	defaultPrivileges := NewMutableDefaultPrivileges(defaultPrivilegeDescriptor)
 	creatorUser := username.MakeSQLUsernameFromPreNormalizedString("creator")
 
-	targetObjectTypes := tree.GetAlterDefaultPrivilegesTargetObjects()
+	targetObjectTypes := privilege.GetTargetObjectTypes()
 	for _, targetObject := range targetObjectTypes {
 		newPrivileges := CreatePrivilegesFromDefaultPrivileges(
 			defaultPrivileges, nil, /* schemaDefaultPrivilegeDescriptor */
@@ -386,7 +385,7 @@ func TestPresetDefaultPrivilegesInSchema(t *testing.T) {
 			t.Errorf("creator should not have ALL privileges on %s", targetObject)
 		}
 
-		if targetObject == tree.Types {
+		if targetObject == privilege.Types {
 			if newPrivileges.CheckPrivilege(username.PublicRoleName(), privilege.USAGE) {
 				t.Errorf("%s should not have %s on types", username.PublicRoleName(), privilege.USAGE)
 			}
@@ -408,7 +407,7 @@ func TestDefaultPrivileges(t *testing.T) {
 		objectCreator          username.SQLUsername
 		defaultPrivilegesRole  username.SQLUsername
 		dbID                   descpb.ID
-		targetObject           tree.AlterDefaultPrivilegesTargetObject
+		targetObject           privilege.TargetObjectType
 		userAndGrants          []userAndGrants
 		userAndGrantsInSchema  []userAndGrants
 		expectedGrantsOnObject []userAndGrants
@@ -423,7 +422,7 @@ func TestDefaultPrivileges(t *testing.T) {
 			// admin.
 			objectCreator:         username.MakeSQLUsernameFromPreNormalizedString("creator"),
 			defaultPrivilegesRole: username.MakeSQLUsernameFromPreNormalizedString("creator"),
-			targetObject:          tree.Tables,
+			targetObject:          privilege.Tables,
 			dbID:                  keys.SystemDatabaseID,
 			userAndGrants: []userAndGrants{
 				{
@@ -445,7 +444,7 @@ func TestDefaultPrivileges(t *testing.T) {
 		{
 			objectCreator:         username.MakeSQLUsernameFromPreNormalizedString("creator"),
 			defaultPrivilegesRole: username.MakeSQLUsernameFromPreNormalizedString("creator"),
-			targetObject:          tree.Tables,
+			targetObject:          privilege.Tables,
 			dbID:                  defaultDatabaseID,
 			userAndGrants: []userAndGrants{
 				{
@@ -463,7 +462,7 @@ func TestDefaultPrivileges(t *testing.T) {
 		{
 			objectCreator:         username.MakeSQLUsernameFromPreNormalizedString("creator"),
 			defaultPrivilegesRole: username.MakeSQLUsernameFromPreNormalizedString("creator"),
-			targetObject:          tree.Tables,
+			targetObject:          privilege.Tables,
 			dbID:                  defaultDatabaseID,
 			userAndGrants: []userAndGrants{
 				{
@@ -481,7 +480,7 @@ func TestDefaultPrivileges(t *testing.T) {
 		{
 			objectCreator:         username.MakeSQLUsernameFromPreNormalizedString("creator"),
 			defaultPrivilegesRole: username.MakeSQLUsernameFromPreNormalizedString("creator"),
-			targetObject:          tree.Tables,
+			targetObject:          privilege.Tables,
 			dbID:                  defaultDatabaseID,
 			userAndGrants: []userAndGrants{
 				{
@@ -499,7 +498,7 @@ func TestDefaultPrivileges(t *testing.T) {
 		{
 			objectCreator:         username.MakeSQLUsernameFromPreNormalizedString("creator"),
 			defaultPrivilegesRole: username.MakeSQLUsernameFromPreNormalizedString("creator"),
-			targetObject:          tree.Tables,
+			targetObject:          privilege.Tables,
 			dbID:                  defaultDatabaseID,
 			userAndGrants: []userAndGrants{
 				{
@@ -517,7 +516,7 @@ func TestDefaultPrivileges(t *testing.T) {
 		{
 			objectCreator:         username.MakeSQLUsernameFromPreNormalizedString("creator"),
 			defaultPrivilegesRole: username.MakeSQLUsernameFromPreNormalizedString("creator"),
-			targetObject:          tree.Tables,
+			targetObject:          privilege.Tables,
 			dbID:                  defaultDatabaseID,
 			userAndGrants: []userAndGrants{
 				{
@@ -546,7 +545,7 @@ func TestDefaultPrivileges(t *testing.T) {
 			// we don't expect any privileges on the object.
 			objectCreator:         username.MakeSQLUsernameFromPreNormalizedString("foo"),
 			defaultPrivilegesRole: username.MakeSQLUsernameFromPreNormalizedString("bar"),
-			targetObject:          tree.Tables,
+			targetObject:          privilege.Tables,
 			dbID:                  defaultDatabaseID,
 			userAndGrants: []userAndGrants{
 				{
@@ -564,7 +563,7 @@ func TestDefaultPrivileges(t *testing.T) {
 		{
 			objectCreator:         username.MakeSQLUsernameFromPreNormalizedString("creator"),
 			defaultPrivilegesRole: username.MakeSQLUsernameFromPreNormalizedString("creator"),
-			targetObject:          tree.Tables,
+			targetObject:          privilege.Tables,
 			dbID:                  defaultDatabaseID,
 			userAndGrants: []userAndGrants{
 				{
@@ -597,7 +596,7 @@ func TestDefaultPrivileges(t *testing.T) {
 		{
 			objectCreator:         username.MakeSQLUsernameFromPreNormalizedString("creator"),
 			defaultPrivilegesRole: username.MakeSQLUsernameFromPreNormalizedString("creator"),
-			targetObject:          tree.Tables,
+			targetObject:          privilege.Tables,
 			dbID:                  defaultDatabaseID,
 			userAndGrants: []userAndGrants{
 				{
@@ -630,7 +629,7 @@ func TestDefaultPrivileges(t *testing.T) {
 		{
 			objectCreator:         username.MakeSQLUsernameFromPreNormalizedString("creator"),
 			defaultPrivilegesRole: username.MakeSQLUsernameFromPreNormalizedString("creator"),
-			targetObject:          tree.Tables,
+			targetObject:          privilege.Tables,
 			dbID:                  defaultDatabaseID,
 			userAndGrants: []userAndGrants{
 				{
@@ -712,23 +711,23 @@ func TestModifyDefaultDefaultPrivileges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	testCases := []struct {
-		targetObject             tree.AlterDefaultPrivilegesTargetObject
+		targetObject             privilege.TargetObjectType
 		revokeAndGrantPrivileges privilege.List
 	}{
 		{
-			targetObject:             tree.Tables,
+			targetObject:             privilege.Tables,
 			revokeAndGrantPrivileges: privilege.List{privilege.SELECT},
 		},
 		{
-			targetObject:             tree.Sequences,
+			targetObject:             privilege.Sequences,
 			revokeAndGrantPrivileges: privilege.List{privilege.SELECT},
 		},
 		{
-			targetObject:             tree.Types,
+			targetObject:             privilege.Types,
 			revokeAndGrantPrivileges: privilege.List{privilege.USAGE},
 		},
 		{
-			targetObject:             tree.Schemas,
+			targetObject:             privilege.Schemas,
 			revokeAndGrantPrivileges: privilege.List{privilege.USAGE},
 		},
 	}
@@ -782,7 +781,7 @@ func TestModifyDefaultDefaultPrivilegesForPublic(t *testing.T) {
 		catpb.DefaultPrivilegesRole{Role: creatorUser},
 		privilege.List{privilege.USAGE},
 		[]username.SQLUsername{username.PublicRoleName()},
-		tree.Types, false, /* grantOptionFor */
+		privilege.Types, false, /* grantOptionFor */
 		false, /*deprecateGrant*/
 	)
 	if GetPublicHasUsageOnTypes(defaultPrivilegesForCreator) {
@@ -792,7 +791,7 @@ func TestModifyDefaultDefaultPrivilegesForPublic(t *testing.T) {
 		catpb.DefaultPrivilegesRole{Role: creatorUser},
 		privilege.List{privilege.USAGE},
 		[]username.SQLUsername{username.PublicRoleName()},
-		tree.Types, false, /* withGrantOption */
+		privilege.Types, false, /* withGrantOption */
 		false, /*deprecateGrant*/
 	)
 	if !GetPublicHasUsageOnTypes(defaultPrivilegesForCreator) {
@@ -804,11 +803,11 @@ func TestModifyDefaultDefaultPrivilegesForPublic(t *testing.T) {
 		catpb.DefaultPrivilegesRole{Role: creatorUser},
 		privilege.List{privilege.USAGE},
 		[]username.SQLUsername{username.PublicRoleName()},
-		tree.Types, true, /* withGrantOption */
+		privilege.Types, true, /* withGrantOption */
 		false, /*deprecateGrant*/
 	)
 
-	privDesc := defaultPrivilegesForCreator.DefaultPrivilegesPerObject[tree.Types]
+	privDesc := defaultPrivilegesForCreator.DefaultPrivilegesPerObject[privilege.Types]
 	user, found := privDesc.FindUser(username.PublicRoleName())
 	if !found {
 		t.Errorf("public not found on privilege descriptor when expected")
@@ -827,11 +826,11 @@ func TestModifyDefaultDefaultPrivilegesForPublic(t *testing.T) {
 		catpb.DefaultPrivilegesRole{Role: creatorUser},
 		privilege.List{privilege.USAGE},
 		[]username.SQLUsername{username.PublicRoleName()},
-		tree.Types, true, /* grantOptionFor */
+		privilege.Types, true, /* grantOptionFor */
 		false, /*deprecateGrant*/
 	)
 
-	privDesc = defaultPrivilegesForCreator.DefaultPrivilegesPerObject[tree.Types]
+	privDesc = defaultPrivilegesForCreator.DefaultPrivilegesPerObject[privilege.Types]
 	_, found = privDesc.FindUser(username.PublicRoleName())
 	if found {
 		t.Errorf("public found on privilege descriptor when it was supposed to be removed")
@@ -846,7 +845,7 @@ func TestModifyDefaultDefaultPrivilegesForPublic(t *testing.T) {
 		catpb.DefaultPrivilegesRole{Role: creatorUser},
 		privilege.List{privilege.USAGE},
 		[]username.SQLUsername{username.PublicRoleName()},
-		tree.Types, false, /* grantOptionFor */
+		privilege.Types, false, /* grantOptionFor */
 		false, /*deprecateGrant*/
 	)
 	if GetPublicHasUsageOnTypes(defaultPrivilegesForCreator) {

--- a/pkg/sql/catalog/dbdesc/database_desc_builder.go
+++ b/pkg/sql/catalog/dbdesc/database_desc_builder.go
@@ -141,12 +141,12 @@ func maybeConvertIncompatibleDBPrivilegesToDefaultPrivileges(
 
 		// Convert the incompatible privileges to default privileges.
 		role := defaultPrivileges.FindOrCreateUser(catpb.DefaultPrivilegesRole{ForAllRoles: true})
-		tableDefaultPrivilegesForAllRoles := role.DefaultPrivilegesPerObject[tree.Tables]
+		tableDefaultPrivilegesForAllRoles := role.DefaultPrivilegesPerObject[privilege.Tables]
 
 		defaultPrivilegesForUser := tableDefaultPrivilegesForAllRoles.FindOrCreateUser(user.User())
 		defaultPrivilegesForUser.Privileges |= incompatiblePrivileges
 
-		role.DefaultPrivilegesPerObject[tree.Tables] = tableDefaultPrivilegesForAllRoles
+		role.DefaultPrivilegesPerObject[privilege.Tables] = tableDefaultPrivilegesForAllRoles
 	}
 
 	return hasChanged

--- a/pkg/sql/catalog/dbdesc/database_test.go
+++ b/pkg/sql/catalog/dbdesc/database_test.go
@@ -404,21 +404,21 @@ func TestMaybeConvertIncompatibleDBPrivilegesToDefaultPrivileges(t *testing.T) {
 		require.Equal(t, shouldChange, test.shouldChange)
 
 		for _, testUser := range test.users {
-			for _, privilege := range test.incompatiblePrivileges {
+			for _, priv := range test.incompatiblePrivileges {
 				// Check that the incompatible privileges are removed from the
 				// PrivilegeDescriptor.
-				if test.privilegeDesc.CheckPrivilege(testUser, privilege) {
-					t.Errorf("found incompatible privilege %s", privilege.String())
+				if test.privilegeDesc.CheckPrivilege(testUser, priv) {
+					t.Errorf("found incompatible privilege %s", priv.String())
 				}
 
 				forAllRoles := test.defaultPrivilegeDesc.
 					FindOrCreateUser(catpb.DefaultPrivilegesRole{ForAllRoles: true})
 				// Check that the incompatible privileges have been converted to the
 				// equivalent default privileges.
-				if !forAllRoles.DefaultPrivilegesPerObject[tree.Tables].CheckPrivilege(testUser, privilege) {
+				if !forAllRoles.DefaultPrivilegesPerObject[privilege.Tables].CheckPrivilege(testUser, priv) {
 					t.Errorf(
 						"expected incompatible privilege %s to be converted to a default privilege",
-						privilege.String(),
+						priv.String(),
 					)
 				}
 			}

--- a/pkg/sql/catalog/ingesting/privileges.go
+++ b/pkg/sql/catalog/ingesting/privileges.go
@@ -118,10 +118,10 @@ func getIngestingPrivilegesForTableOrSchema(
 		dbDefaultPrivileges := parentDB.GetDefaultPrivilegeDescriptor()
 
 		var schemaDefaultPrivileges catalog.DefaultPrivilegeDescriptor
-		targetObject := tree.Schemas
+		targetObject := privilege.Schemas
 		switch privilegeType {
 		case privilege.Table:
-			targetObject = tree.Tables
+			targetObject = privilege.Tables
 			schemaID := desc.GetParentSchemaID()
 
 			// TODO(adityamaru): Remove in 22.2 once we are sure not to see synthentic public schema descriptors

--- a/pkg/sql/catalog/multiregion/BUILD.bazel
+++ b/pkg/sql/catalog/multiregion/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "multiregion",
     srcs = [
         "region_config.go",
+        "telemetry.go",
         "validate_table.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/multiregion",

--- a/pkg/sql/catalog/multiregion/telemetry.go
+++ b/pkg/sql/catalog/multiregion/telemetry.go
@@ -1,0 +1,71 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package multiregion
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
+)
+
+// Constants to use for telemetry for multi-region table localities.
+const (
+	TelemetryNameGlobal            = "global"
+	TelemetryNameRegionalByTable   = "regional_by_table"
+	TelemetryNameRegionalByTableIn = "regional_by_table_in"
+	TelemetryNameRegionalByRow     = "regional_by_row"
+	TelemetryNameRegionalByRowAs   = "regional_by_row_as"
+)
+
+// TelemetryNameForLocality returns the telemetry name for a given locality level.
+func TelemetryNameForLocality(node *tree.Locality) string {
+	switch node.LocalityLevel {
+	case tree.LocalityLevelGlobal:
+		return TelemetryNameGlobal
+	case tree.LocalityLevelTable:
+		if node.TableRegion != tree.RegionalByRowRegionNotSpecifiedName {
+			return TelemetryNameRegionalByTableIn
+		}
+		return TelemetryNameRegionalByTable
+	case tree.LocalityLevelRow:
+		if node.RegionalByRowColumn != tree.PrimaryRegionNotSpecifiedName {
+			return TelemetryNameRegionalByRowAs
+		}
+		return TelemetryNameRegionalByRow
+	default:
+		panic(fmt.Sprintf("unknown locality: %#v", node.LocalityLevel))
+	}
+}
+
+// TelemetryNameForLocalityConfig returns the name to use for the given
+// locality config.
+func TelemetryNameForLocalityConfig(cfg *catpb.LocalityConfig) (string, error) {
+	switch l := cfg.Locality.(type) {
+	case *catpb.LocalityConfig_Global_:
+		return TelemetryNameGlobal, nil
+	case *catpb.LocalityConfig_RegionalByTable_:
+		if l.RegionalByTable.Region != nil {
+			return TelemetryNameRegionalByTableIn, nil
+		}
+		return TelemetryNameRegionalByTable, nil
+	case *catpb.LocalityConfig_RegionalByRow_:
+		if l.RegionalByRow.As != nil {
+			return TelemetryNameRegionalByRowAs, nil
+		}
+		return TelemetryNameRegionalByRow, nil
+	}
+	return "", errors.AssertionFailedf(
+		"unknown locality config TelemetryNameForLocality: type %T",
+		cfg.Locality,
+	)
+}

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -5204,7 +5204,7 @@ CREATE TABLE crdb_internal.default_privileges (
 					}
 
 					if schema == tree.DNull {
-						for _, objectType := range tree.GetAlterDefaultPrivilegesTargetObjects() {
+						for _, objectType := range privilege.GetTargetObjectTypes() {
 							if catprivilege.GetRoleHasAllPrivilegesOnTargetObject(&defaultPrivilegesForRole, objectType) {
 								if err := addRow(
 									tree.NewDString(descriptor.GetName()), // database_name
@@ -5225,7 +5225,7 @@ CREATE TABLE crdb_internal.default_privileges (
 								tree.DNull,                            // schema_name
 								role,                                  // role
 								forAllRoles,                           // for_all_roles
-								tree.NewDString(tree.Types.String()),  // object_type
+								tree.NewDString(privilege.Types.String()),               // object_type
 								tree.NewDString(username.PublicRoleName().Normalized()), // grantee
 								tree.NewDString(privilege.USAGE.String()),               // privilege_type
 							); err != nil {

--- a/pkg/sql/create_schema.go
+++ b/pkg/sql/create_schema.go
@@ -153,7 +153,7 @@ func CreateSchemaDescriptorWithPrivileges(
 		nil, /* schemaDefaultPrivilegeDescriptor */
 		db.GetID(),
 		user,
-		tree.Schemas,
+		privilege.Schemas,
 		db.GetPrivileges(),
 	)
 

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -115,7 +115,7 @@ func doCreateSequence(
 		scDesc.GetDefaultPrivilegeDescriptor(),
 		dbDesc.GetID(),
 		sessionData.User(),
-		tree.Sequences,
+		privilege.Sequences,
 		dbDesc.GetPrivileges(),
 	)
 

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -2253,7 +2253,7 @@ func NewTableDesc(
 	if regionConfig != nil || n.Locality != nil {
 		localityTelemetryName := "unspecified"
 		if n.Locality != nil {
-			localityTelemetryName = n.Locality.TelemetryName()
+			localityTelemetryName = multiregion.TelemetryNameForLocality(n.Locality)
 		}
 		telemetry.Inc(sqltelemetry.CreateTableLocalityCounter(localityTelemetryName))
 		if n.Locality == nil {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
@@ -367,7 +368,7 @@ func (n *createTableNode) startExec(params runParams) error {
 		schema.GetDefaultPrivilegeDescriptor(),
 		n.dbDesc.GetID(),
 		params.SessionData().User(),
-		tree.Tables,
+		privilege.Tables,
 		n.dbDesc.GetPrivileges(),
 	)
 	if n.n.As() {

--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -347,7 +347,7 @@ func CreateEnumTypeDesc(
 		schema.GetDefaultPrivilegeDescriptor(),
 		dbDesc.GetID(),
 		params.SessionData().User(),
-		tree.Types,
+		privilege.Types,
 		dbDesc.GetPrivileges(),
 	)
 

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -175,7 +175,7 @@ func (n *createViewNode) startExec(params runParams) error {
 		schema.GetDefaultPrivilegeDescriptor(),
 		n.dbDesc.GetID(),
 		params.SessionData().User(),
-		tree.Tables,
+		privilege.Tables,
 		n.dbDesc.GetPrivileges(),
 	)
 

--- a/pkg/sql/drop_role.go
+++ b/pkg/sql/drop_role.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/decodeusername"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/roleoption"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessioninit"
@@ -464,7 +465,7 @@ func accumulateDependentDefaultPrivileges(
 }
 
 func addDependentPrivileges(
-	object tree.AlterDefaultPrivilegesTargetObject,
+	object privilege.TargetObjectType,
 	defaultPrivs catpb.PrivilegeDescriptor,
 	role catpb.DefaultPrivilegesRole,
 	userNames map[username.SQLUsername][]objectAndType,
@@ -473,13 +474,13 @@ func addDependentPrivileges(
 ) {
 	var objectType string
 	switch object {
-	case tree.Tables:
+	case privilege.Tables:
 		objectType = "relations"
-	case tree.Sequences:
+	case privilege.Sequences:
 		objectType = "sequences"
-	case tree.Types:
+	case privilege.Types:
 		objectType = "types"
-	case tree.Schemas:
+	case privilege.Schemas:
 		objectType = "schemas"
 	}
 

--- a/pkg/sql/privilege/BUILD.bazel
+++ b/pkg/sql/privilege/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "privilege",
     srcs = [
         "privilege.go",
+        "target_object_type.go",
         ":gen-kind-stringer",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/privilege",

--- a/pkg/sql/privilege/target_object_type.go
+++ b/pkg/sql/privilege/target_object_type.go
@@ -1,0 +1,67 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package privilege
+
+import "github.com/cockroachdb/errors"
+
+// TargetObjectType represents the type of object that is
+// having its default privileges altered.
+type TargetObjectType uint32
+
+var targetObjectToPrivilegeObject = map[TargetObjectType]ObjectType{
+	Tables:    Table,
+	Sequences: Sequence,
+	Schemas:   Schema,
+	Types:     Type,
+}
+
+// ToObjectType returns the privilege.ObjectType corresponding to
+// the TargetObjectType.
+func (t TargetObjectType) ToObjectType() ObjectType {
+	return targetObjectToPrivilegeObject[t]
+}
+
+// The numbers are explicitly assigned since the DefaultPrivilegesPerObject
+// map defined in the DefaultPrivilegesPerRole proto requires the key value
+// for the object type to remain unchanged.
+const (
+	Tables    TargetObjectType = 1
+	Sequences TargetObjectType = 2
+	Types     TargetObjectType = 3
+	Schemas   TargetObjectType = 4
+)
+
+// GetTargetObjectTypes returns a slice of all the
+// AlterDefaultPrivilegesTargetObjects.
+func GetTargetObjectTypes() []TargetObjectType {
+	return []TargetObjectType{
+		Tables,
+		Sequences,
+		Types,
+		Schemas,
+	}
+}
+
+// String makes TargetObjectType a fmt.Stringer.
+func (t TargetObjectType) String() string {
+	switch t {
+	case Tables:
+		return "tables"
+	case Sequences:
+		return "sequences"
+	case Types:
+		return "types"
+	case Schemas:
+		return "schemas"
+	default:
+		panic(errors.AssertionFailedf("unknown TargetObjectType value: %d", t))
+	}
+}

--- a/pkg/sql/sem/tree/alter_default_privileges.go
+++ b/pkg/sql/sem/tree/alter_default_privileges.go
@@ -10,10 +10,7 @@
 
 package tree
 
-import (
-	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
-	"github.com/cockroachdb/errors"
-)
+import "github.com/cockroachdb/cockroach/pkg/sql/privilege"
 
 // AlterDefaultPrivileges represents an ALTER DEFAULT PRIVILEGES statement.
 type AlterDefaultPrivileges struct {
@@ -63,63 +60,11 @@ func (n *AlterDefaultPrivileges) Format(ctx *FmtCtx) {
 	}
 }
 
-// AlterDefaultPrivilegesTargetObject represents the type of object that is
-// having it's default privileges altered.
-type AlterDefaultPrivilegesTargetObject uint32
-
-// ToPrivilegeObjectType returns the privilege.ObjectType corresponding to
-// the AlterDefaultPrivilegesTargetObject.
-func (t AlterDefaultPrivilegesTargetObject) ToPrivilegeObjectType() privilege.ObjectType {
-	targetObjectToPrivilegeObject := map[AlterDefaultPrivilegesTargetObject]privilege.ObjectType{
-		Tables:    privilege.Table,
-		Sequences: privilege.Sequence,
-		Schemas:   privilege.Schema,
-		Types:     privilege.Type,
-	}
-	return targetObjectToPrivilegeObject[t]
-}
-
-// The numbers are explicitly assigned since the DefaultPrivilegesPerObject
-// map defined in the DefaultPrivilegesPerRole proto requires the key value
-// for the object type to remain unchanged.
-const (
-	Tables    AlterDefaultPrivilegesTargetObject = 1
-	Sequences AlterDefaultPrivilegesTargetObject = 2
-	Types     AlterDefaultPrivilegesTargetObject = 3
-	Schemas   AlterDefaultPrivilegesTargetObject = 4
-)
-
-// GetAlterDefaultPrivilegesTargetObjects returns a slice of all the
-// AlterDefaultPrivilegesTargetObjects.
-func GetAlterDefaultPrivilegesTargetObjects() []AlterDefaultPrivilegesTargetObject {
-	return []AlterDefaultPrivilegesTargetObject{
-		Tables,
-		Sequences,
-		Types,
-		Schemas,
-	}
-}
-
-func (t AlterDefaultPrivilegesTargetObject) String() string {
-	switch t {
-	case Tables:
-		return "tables"
-	case Sequences:
-		return "sequences"
-	case Types:
-		return "types"
-	case Schemas:
-		return "schemas"
-	default:
-		panic(errors.AssertionFailedf("unknown AlterDefaultPrivilegesTargetObject value: %d", t))
-	}
-}
-
 // AbbreviatedGrant represents the GRANT part of an
 // ALTER DEFAULT PRIVILEGES statement.
 type AbbreviatedGrant struct {
 	Privileges      privilege.List
-	Target          AlterDefaultPrivilegesTargetObject
+	Target          privilege.TargetObjectType
 	Grantees        RoleSpecList
 	WithGrantOption bool
 }
@@ -130,13 +75,13 @@ func (n *AbbreviatedGrant) Format(ctx *FmtCtx) {
 	n.Privileges.Format(&ctx.Buffer)
 	ctx.WriteString(" ON ")
 	switch n.Target {
-	case Tables:
+	case privilege.Tables:
 		ctx.WriteString("TABLES ")
-	case Sequences:
+	case privilege.Sequences:
 		ctx.WriteString("SEQUENCES ")
-	case Types:
+	case privilege.Types:
 		ctx.WriteString("TYPES ")
-	case Schemas:
+	case privilege.Schemas:
 		ctx.WriteString("SCHEMAS ")
 	}
 	ctx.WriteString("TO ")
@@ -150,7 +95,7 @@ func (n *AbbreviatedGrant) Format(ctx *FmtCtx) {
 // ALTER DEFAULT PRIVILEGES statement.
 type AbbreviatedRevoke struct {
 	Privileges     privilege.List
-	Target         AlterDefaultPrivilegesTargetObject
+	Target         privilege.TargetObjectType
 	Grantees       RoleSpecList
 	GrantOptionFor bool
 }
@@ -164,13 +109,13 @@ func (n *AbbreviatedRevoke) Format(ctx *FmtCtx) {
 	n.Privileges.Format(&ctx.Buffer)
 	ctx.WriteString(" ON ")
 	switch n.Target {
-	case Tables:
+	case privilege.Tables:
 		ctx.WriteString("TABLES ")
-	case Sequences:
+	case privilege.Sequences:
 		ctx.WriteString("SEQUENCES ")
-	case Types:
+	case privilege.Types:
 		ctx.WriteString("TYPES ")
-	case Schemas:
+	case privilege.Schemas:
 		ctx.WriteString("SCHEMAS ")
 	}
 	ctx.WriteString(" FROM ")

--- a/pkg/sql/sem/tree/region.go
+++ b/pkg/sql/sem/tree/region.go
@@ -56,35 +56,6 @@ type Locality struct {
 	RegionalByRowColumn Name
 }
 
-// Constants to use for telemetry for multi-region table localities.
-const (
-	TelemetryNameGlobal            = "global"
-	TelemetryNameRegionalByTable   = "regional_by_table"
-	TelemetryNameRegionalByTableIn = "regional_by_table_in"
-	TelemetryNameRegionalByRow     = "regional_by_row"
-	TelemetryNameRegionalByRowAs   = "regional_by_row_as"
-)
-
-// TelemetryName returns the telemetry name for a given locality level.
-func (node *Locality) TelemetryName() string {
-	switch node.LocalityLevel {
-	case LocalityLevelGlobal:
-		return TelemetryNameGlobal
-	case LocalityLevelTable:
-		if node.TableRegion != RegionalByRowRegionNotSpecifiedName {
-			return TelemetryNameRegionalByTableIn
-		}
-		return TelemetryNameRegionalByTable
-	case LocalityLevelRow:
-		if node.RegionalByRowColumn != PrimaryRegionNotSpecifiedName {
-			return TelemetryNameRegionalByRowAs
-		}
-		return TelemetryNameRegionalByRow
-	default:
-		panic(fmt.Sprintf("unknown locality: %#v", node.LocalityLevel))
-	}
-}
-
 // Format implements the NodeFormatter interface.
 func (node *Locality) Format(ctx *FmtCtx) {
 	ctx.WriteString("LOCALITY ")


### PR DESCRIPTION
It was a bottleneck in the build graph. See individual commits.

Release note: None