### PR TITLE
logictest: skip flaky fakedist-metadata/distsql_event_log test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_event_log
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_event_log
@@ -16,11 +16,13 @@ CREATE TABLE a (id INT PRIMARY KEY, x INT, y INT, INDEX x_idx (x, y))
 statement ok
 CREATE STATISTICS s1 ON id FROM a
 
+skipif config fakedist-metadata
 statement ok retry
 CREATE STATISTICS __auto__ FROM a
 
 # Check explicitly for table id 106. System tables could trigger autostats
 # collections at any time.
+skipif config fakedist-metadata
 query IIT
 SELECT "targetID", "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID'
 FROM system.eventlog


### PR DESCRIPTION
This commit skips a test in distsql_event_log which flakes in the
fakedist-metadata config, even with retries.

Release note: none