### PR TITLE
server, ui: handle null plan gist in getStatementDetailsPerPlanHash

### DIFF
--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -729,8 +729,11 @@ func getStatementDetailsPerPlanHash(
 		if planHash, err = sqlstatsutil.DatumToUint64(row[0]); err != nil {
 			return nil, serverError(ctx, err)
 		}
-		planGist := string(tree.MustBeDString(row[1]))
-		explainPlan := getExplainPlanFromGist(ctx, ie, planGist)
+		planGist := string(tree.MustBeDStringOrDNull(row[1]))
+		var explainPlan string
+		if planGist != "" {
+			explainPlan = getExplainPlanFromGist(ctx, ie, planGist)
+		}
 
 		var metadata roachpb.CollectedStatementStatistics
 		var aggregatedMetadata roachpb.AggregatedStatementMetadata

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1220,6 +1220,16 @@ func MustBeDString(e Expr) DString {
 	return i
 }
 
+// MustBeDStringOrDNull attempts to retrieve a DString or DNull from an Expr, panicking if the
+// assertion fails.
+func MustBeDStringOrDNull(e Expr) DString {
+	i, ok := AsDString(e)
+	if !ok && e != DNull {
+		panic(errors.AssertionFailedf("expected *DString or DNull, found %T", e))
+	}
+	return i
+}
+
 // ResolvedType implements the TypedExpr interface.
 func (*DString) ResolvedType() *types.T {
 	return types.String

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
@@ -57,6 +57,8 @@ function renderExplainPlan(
   plan: PlanHashStats,
   backToPlanTable: () => void,
 ): React.ReactElement {
+  const explainPlan =
+    plan.explain_plan === "" ? "unavailable" : plan.explain_plan;
   return (
     <div>
       <Helmet title="Plan Details" />
@@ -70,7 +72,7 @@ function renderExplainPlan(
       >
         All Plans
       </Button>
-      <SqlBox value={plan.explain_plan} size={SqlBoxSize.large} />
+      <SqlBox value={explainPlan} size={SqlBoxSize.large} />
     </div>
   );
 }


### PR DESCRIPTION
This PR adds a new function that handles null plan gists in `getStatementDetailsPerPlanHash`. The PR also adds some logic to hide null plan gists in the SqlBox of the Statement Details page.

Here's a screenshot of the Statement Details page when the plan gist is null:

<img width="1024" alt="Screen Shot 2022-06-03 at 7 18 59 PM" src="https://user-images.githubusercontent.com/27286675/171966978-6a444297-70d4-4ef3-8afa-5068e3f35d9e.png">


Fixes #82095.

We probably want to figure out why there are null values in [`planner.instrumentation.planGist`](https://github.com/cockroachdb/cockroach/blob/master/pkg/sql/executor_statement_metrics.go#L212) in the first place. `getStatementDetailsPerPlanHash` is pulling from the system table populated with the plan gist from `planner.instrumentation.planGist`. CC @cucaroach

Release note: None