### PR TITLE
logictest: comment out non-retryable test in distsql_event_log

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_event_log
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_event_log
@@ -16,13 +16,13 @@ CREATE TABLE a (id INT PRIMARY KEY, x INT, y INT, INDEX x_idx (x, y))
 statement ok
 CREATE STATISTICS s1 ON id FROM a
 
-skipif config fakedist-metadata
-statement ok retry
-CREATE STATISTICS __auto__ FROM a
+# TODO(msirek): Re-enable this test once autostats collection is made
+#               consistently retryable.
+# statement ok retry
+# CREATE STATISTICS __auto__ FROM a
 
 # Check explicitly for table id 106. System tables could trigger autostats
 # collections at any time.
-skipif config fakedist-metadata
 query IIT
 SELECT "targetID", "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID'
 FROM system.eventlog
@@ -30,7 +30,6 @@ WHERE "eventType" = 'create_statistics' AND "targetID" = 106
 ORDER BY "timestamp", info
 ----
 106  1  {"EventType": "create_statistics", "Statement": "CREATE STATISTICS s1 ON id FROM test.public.a", "TableName": "test.public.a", "Tag": "CREATE STATISTICS", "User": "root"}
-106  1  {"EventType": "create_statistics", "Statement": "CREATE STATISTICS __auto__ FROM test.public.a", "TableName": "test.public.a", "Tag": "CREATE STATISTICS", "User": "root"}
 
 statement ok
 DROP TABLE a


### PR DESCRIPTION
This commit comments out a test that flakes even with retries on
multiple logictest configurations.

Release note: none