### PR TITLE
kvserver/rangefeed: always use time-bound iterators for catchup scans

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -46,7 +46,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -90,19 +89,6 @@ type cdcTestArgs struct {
 func cdcClusterSettings(t test.Test, db *sqlutils.SQLRunner) {
 	// kv.rangefeed.enabled is required for changefeeds to run
 	db.Exec(t, "SET CLUSTER SETTING kv.rangefeed.enabled = true")
-	randomlyRun(t, db, "SET CLUSTER SETTING kv.rangefeed.catchup_scan_iterator_optimization.enabled = false")
-}
-
-const randomSettingPercent = 0.50
-
-var rng, _ = randutil.NewTestRand()
-
-func randomlyRun(t test.Test, db *sqlutils.SQLRunner, query string) {
-	if rng.Float64() < randomSettingPercent {
-		db.Exec(t, query)
-		t.L().Printf("setting non-default cluster setting: %s", query)
-	}
-
 }
 
 func cdcBasicTest(ctx context.Context, t test.Test, c cluster.Cluster, args cdcTestArgs) {

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
@@ -52,7 +52,7 @@ func runCatchUpBenchmark(b *testing.B, emk engineMaker, opts benchOptions) {
 				},
 				WithDiff: opts.withDiff,
 				Span:     span,
-			}, opts.useTBI, func() {})
+			}, func() {})
 			defer iter.Close()
 			counter := 0
 			err := iter.CatchUpScan(storage.MakeMVCCMetadataKey(startKey), storage.MakeMVCCMetadataKey(endKey), opts.ts, opts.withDiff, func(*roachpb.RangeFeedEvent) error {
@@ -136,22 +136,17 @@ func BenchmarkCatchUpScan(b *testing.B) {
 
 	for name, do := range dataOpts {
 		b.Run(name, func(b *testing.B) {
-			for _, useTBI := range []bool{true, false} {
-				b.Run(fmt.Sprintf("useTBI=%v", useTBI), func(b *testing.B) {
-					for _, withDiff := range []bool{true, false} {
-						b.Run(fmt.Sprintf("withDiff=%v", withDiff), func(b *testing.B) {
-							for _, tsExcludePercent := range []float64{0.0, 0.50, 0.75, 0.95, 0.99} {
-								wallTime := int64((5 * (float64(numKeys)*tsExcludePercent + 1)))
-								ts := hlc.Timestamp{WallTime: wallTime}
-								b.Run(fmt.Sprintf("perc=%2.2f", tsExcludePercent*100), func(b *testing.B) {
-									runCatchUpBenchmark(b, setupMVCCPebble, benchOptions{
-										dataOpts: do,
-										ts:       ts,
-										useTBI:   useTBI,
-										withDiff: withDiff,
-									})
-								})
-							}
+			for _, withDiff := range []bool{true, false} {
+				b.Run(fmt.Sprintf("withDiff=%v", withDiff), func(b *testing.B) {
+					for _, tsExcludePercent := range []float64{0.0, 0.50, 0.75, 0.95, 0.99} {
+						wallTime := int64((5 * (float64(numKeys)*tsExcludePercent + 1)))
+						ts := hlc.Timestamp{WallTime: wallTime}
+						b.Run(fmt.Sprintf("perc=%2.2f", tsExcludePercent*100), func(b *testing.B) {
+							runCatchUpBenchmark(b, setupMVCCPebble, benchOptions{
+								dataOpts: do,
+								ts:       ts,
+								withDiff: withDiff,
+							})
 						})
 					}
 				})
@@ -170,7 +165,6 @@ type benchDataOptions struct {
 
 type benchOptions struct {
 	ts       hlc.Timestamp
-	useTBI   bool
 	withDiff bool
 	dataOpts benchDataOptions
 }

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -126,6 +126,9 @@ var retiredSettings = map[string]struct{}{
 	"kv.bulk_ingest.buffer_increment":                                  {},
 	"schemachanger.backfiller.buffer_increment":                        {},
 	"kv.rangefeed.separated_intent_scan.enabled":                       {},
+
+	// removed as of 22.2.
+	"kv.rangefeed.catchup_scan_iterator_optimization.enabled": {},
 }
 
 var sqlDefaultSettings = map[string]struct{}{


### PR DESCRIPTION
EDIT: Oops, I completely missed that this had already been defaulted to true in https://github.com/cockroachdb/cockroach/pull/73473. Got confused by #79727, which I took to mean that it hadn't been flipped yet. This PR essentially just removed the setting then. Sorry for the confusion.

---

This patch always uses time-bound iterators for rangefeed catchup scans.
Previously, this was controlled by the default-off cluster setting
`kv.rangefeed.catchup_scan_iterator_optimization.enabled`, which has now
been removed. These have been used in production by several users, who
have seen significant performance improvements without reports of any
issues.

Resolves #79728.
Touches #82454.

Release note (performance improvement): Changefeed catchup scans now use
time-bound iterators, which improves their performance by avoiding
accessing data that is outside the catchup scan time interval.
Previously, this was controlled by the default-off cluster setting
`kv.rangefeed.catchup_scan_iterator_optimization.enabled`, which has now
been removed (it is in effect always enabled).