### PR TITLE
kvserver/rangefeed: fix off-by-one in `NewCatchUpIterator()`

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -33,10 +33,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeeddist"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
-	// Imported to allow multi-tenant tests
-	_ "github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvtenantccl"
-	// Imported to allow locality-related table mutations
-	_ "github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl"
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvtenantccl" // multi-tenant tests
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl"    // locality-related table mutations
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/partitionccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	_ "github.com/cockroachdb/cockroach/pkg/cloud/impl" // registers cloud storage providers
@@ -1292,16 +1290,16 @@ func TestChangefeedLaggingSpanCheckpointing(t *testing.T) {
 		setErr := func(stp kvcoord.SpanTimePair, expectedTS hlc.Timestamp) {
 			incorrectCheckpointErr = errors.Newf(
 				"rangefeed for span %s expected to start @%s, started @%s instead",
-				stp.Span, expectedTS, stp.TS)
+				stp.Span, expectedTS, stp.StartAfter)
 		}
 
 		for _, sp := range spans {
 			if laggingSpans.Encloses(sp.Span) {
-				if !sp.TS.Equal(cursor) {
+				if !sp.StartAfter.Equal(cursor) {
 					setErr(sp, cursor)
 				}
 			} else {
-				if !sp.TS.Equal(checkpointTS) {
+				if !sp.StartAfter.Equal(checkpointTS) {
 					setErr(sp, checkpointTS)
 				}
 			}

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -432,7 +432,7 @@ func (f *kvFeed) runUntilTableEvent(
 
 	var stps []kvcoord.SpanTimePair
 	resumeFrontier.Entries(func(s roachpb.Span, ts hlc.Timestamp) (done span.OpResult) {
-		stps = append(stps, kvcoord.SpanTimePair{Span: s, TS: ts})
+		stps = append(stps, kvcoord.SpanTimePair{Span: s, StartAfter: ts})
 		return span.ContinueMatch
 	})
 

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
@@ -393,10 +393,10 @@ func (f rawEventFeed) run(
 	withDiff bool,
 	eventC chan<- *roachpb.RangeFeedEvent,
 ) error {
-	var startFrom hlc.Timestamp
+	var startAfter hlc.Timestamp
 	for _, s := range spans {
-		if startFrom.IsEmpty() || s.TS.Less(startFrom) {
-			startFrom = s.TS
+		if startAfter.IsEmpty() || s.StartAfter.Less(startAfter) {
+			startAfter = s.StartAfter
 		}
 	}
 
@@ -405,8 +405,8 @@ func (f rawEventFeed) run(
 	var i int
 	for i = range f {
 		ev := f[i]
-		if ev.Val != nil && startFrom.LessEq(ev.Val.Value.Timestamp) ||
-			ev.Checkpoint != nil && startFrom.LessEq(ev.Checkpoint.ResolvedTS) {
+		if ev.Val != nil && startAfter.LessEq(ev.Val.Value.Timestamp) ||
+			ev.Checkpoint != nil && startAfter.LessEq(ev.Checkpoint.ResolvedTS) {
 			break
 		}
 

--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -114,6 +114,11 @@ func newFactory(stopper *stop.Stopper, client DB, knobs *TestingKnobs) *Factory 
 //
 // The only error which can be returned will indicate that the server is being
 // shut down.
+//
+// NB: for the rangefeed itself, initialTimestamp is exclusive, i.e. the first
+// possible event emitted by the server (including the catchup scan) is at
+// initialTimestamp.Next(). This follows from the gRPC API semantics. However,
+// the initial scan (if any) is run at initialTimestamp.
 func (f *Factory) RangeFeed(
 	ctx context.Context,
 	name string,

--- a/pkg/kv/kvserver/rangefeed/catchup_scan.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan.go
@@ -61,10 +61,8 @@ func NewCatchUpIterator(
 			storage.MVCCIncrementalIterOptions{
 				EnableTimeBoundIteratorOptimization: true,
 				EndKey:                              args.Span.EndKey,
-				// StartTime is exclusive but args.Timestamp
-				// is inclusive.
-				StartTime: args.Timestamp.Prev(),
-				EndTime:   hlc.MaxTimestamp,
+				StartTime:                           args.Timestamp,
+				EndTime:                             hlc.MaxTimestamp,
 				// We want to emit intents rather than error
 				// (the default behavior) so that we can skip
 				// over the provisional values during

--- a/pkg/kv/kvserver/rangefeed/catchup_scan.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan.go
@@ -53,6 +53,9 @@ func (i simpleCatchupIterAdapter) NextIgnoringTime() {
 var _ simpleCatchupIter = simpleCatchupIterAdapter{}
 
 // NewCatchUpIterator returns a CatchUpIterator for the given Reader.
+//
+// NB: The start timestamp given in args.Header.Timestamp is exclusive, i.e. the
+// first possible event will be emitted at Timestamp.Next().
 func NewCatchUpIterator(
 	reader storage.Reader, args *roachpb.RangeFeedRequest, closer func(),
 ) *CatchUpIterator {

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_test.go
@@ -94,8 +94,7 @@ func TestCatchupScan(t *testing.T) {
 	testutils.RunTrueAndFalse(t, "withDiff", func(t *testing.T, withDiff bool) {
 		iter := NewCatchUpIterator(eng, &roachpb.RangeFeedRequest{
 			Header: roachpb.Header{
-				// Inclusive, so want everything >= ts2
-				Timestamp: ts2,
+				Timestamp: ts1, // exclusive
 			},
 			Span: roachpb.Span{
 				EndKey: roachpb.KeyMax,

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -436,7 +436,7 @@ func (p *Processor) sendStop(pErr *roachpb.Error) {
 // provided an error when the registration closes.
 //
 // The optionally provided "catch-up" iterator is used to read changes from the
-// engine which occurred after the provided start timestamp.
+// engine which occurred after the provided start timestamp (exclusive).
 //
 // If the method returns false, the processor will have been stopped, so calling
 // Stop is not necessary. If the method returns true, it will also return an
@@ -444,6 +444,8 @@ func (p *Processor) sendStop(pErr *roachpb.Error) {
 // registration.
 //
 // NOT safe to call on nil Processor.
+//
+// NB: startTS is exclusive; the first possible event will be at startTS.Next().
 func (p *Processor) Register(
 	span roachpb.RSpan,
 	startTS hlc.Timestamp,

--- a/pkg/kv/kvserver/rangefeed/registry.go
+++ b/pkg/kv/kvserver/rangefeed/registry.go
@@ -76,7 +76,7 @@ func putPooledSharedEvent(e *sharedEvent) {
 type registration struct {
 	// Input.
 	span             roachpb.Span
-	catchUpTimestamp hlc.Timestamp
+	catchUpTimestamp hlc.Timestamp // exclusive
 	withDiff         bool
 	metrics          *Metrics
 

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -323,7 +323,7 @@ func logSlowRangefeedRegistration(ctx context.Context) func() {
 func (r *Replica) registerWithRangefeedRaftMuLocked(
 	ctx context.Context,
 	span roachpb.RSpan,
-	startTS hlc.Timestamp,
+	startTS hlc.Timestamp, // exclusive
 	catchUpIter rangefeed.CatchUpIteratorConstructor,
 	withDiff bool,
 	stream rangefeed.Stream,

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -2681,7 +2681,11 @@ message RangeLookupResponse {
 }
 
 // RangeFeedRequest is a request that expresses the intention to establish a
-// RangeFeed stream over the provided span, starting at the specified timestamp.
+// RangeFeed stream over the provided span, starting at the specified timestamp
+// (exclusive).
+//
+// NB: The start timestamp is exclusive, i.e. the first possible event emitted
+// will be at Header.Timestamp.Next(). This includes catchup scans.
 message RangeFeedRequest {
   Header header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   Span   span   = 2 [(gogoproto.nullable) = false];

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -5502,6 +5502,7 @@ GROUP BY
 
 var crdbInternalActiveRangeFeedsTable = virtualSchemaTable{
 	comment: `node-level table listing all currently running range feeds`,
+	// NB: startTS is exclusive; consider renaming to startAfter.
 	schema: `
 CREATE TABLE crdb_internal.active_range_feeds (
   id INT,
@@ -5529,7 +5530,7 @@ CREATE TABLE crdb_internal.active_range_feeds (
 				return addRow(
 					tree.NewDInt(tree.DInt(rfCtx.ID)),
 					tree.NewDString(rfCtx.CtxTags),
-					tree.NewDString(rf.StartTS.AsOfSystemTime()),
+					tree.NewDString(rf.StartAfter.AsOfSystemTime()),
 					tree.MakeDBool(tree.DBool(rfCtx.WithDiff)),
 					tree.NewDInt(tree.DInt(rf.NodeID)),
 					tree.NewDInt(tree.DInt(rf.RangeID)),


### PR DESCRIPTION
**kvserver/rangefeed: fix off-by-one in NewCatchUpIterator()**

`NewCatchUpIterator` created the `MVCCIncrementalIterator` with
`RangeFeedRequest.Header.Timestamp.Prev()`, because it assumed the given
timestamp was inclusive. However, the rest of the rangefeed code treats
this timestamp as exclusive.

This patch uses the correct, exclusive timestamp when creating the
`MVCCIncrementalIterator`. This change has no externally visible effect:
even though the previous code would cause `MVCCIncrementalIterator` to emit
keys at `Timestamp`, the `CatchUpScan()` method would discard those
events if they were at or below `Timestamp`.

An integration test is also added to verify that the start timestamp of
a rangefeed catchup scan is exclusive. The test passes both with the new
and the old code, as expected.

Release note: None

**rangefeed: emphasize that start time is exclusive**

This patch adds comments for rangefeed-related APIs and components
emphasizing that the start timestamp of rangefeeds is exclusive. In
other words, the first possible emitted event (including catchup scans)
will be at `RangeFeedRequest.Header.Timestamp.Next()`. Several
parameters are also renamed to emphasize this.

There are no functional or semantic changes.

Touches #82488.

Release note: None