### PR TITLE
storage: always use TBIs in `MVCCIncrementalIterator`

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -44,12 +44,6 @@ import (
 var backupOutputTypes = []*types.T{}
 
 var (
-	useTBI = settings.RegisterBoolSetting(
-		settings.TenantWritable,
-		"kv.bulk_io_write.experimental_incremental_export_enabled",
-		"use experimental time-bound file filter when exporting in BACKUP",
-		true,
-	)
 	priorityAfter = settings.RegisterDurationSetting(
 		settings.TenantWritable,
 		"bulkio.backup.read_with_priority_after",
@@ -337,7 +331,7 @@ func runBackupProcessor(
 						RequestHeader:                       roachpb.RequestHeaderFromSpan(span.span),
 						ResumeKeyTS:                         span.firstKeyTS,
 						StartTime:                           span.start,
-						EnableTimeBoundIteratorOptimization: useTBI.Get(&clusterSettings.SV),
+						EnableTimeBoundIteratorOptimization: true, // NB: Must set for 22.1 compatibility.
 						MVCCFilter:                          spec.MVCCFilter,
 						TargetFileSize:                      batcheval.ExportRequestTargetFileSize.Get(&clusterSettings.SV),
 						ReturnSST:                           true,

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -244,7 +244,7 @@ func revertToCutoverTimestamp(
 					EndKey: span.EndKey,
 				},
 				TargetTime:                          sp.StreamIngest.CutoverTime,
-				EnableTimeBoundIteratorOptimization: true,
+				EnableTimeBoundIteratorOptimization: true, // NB: Must set for 22.1 compatibility.
 			})
 		}
 		b.Header.MaxSpanRequestKeys = sql.RevertTableDefaultBatchSize

--- a/pkg/kv/kvserver/batcheval/cmd_export.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export.go
@@ -173,8 +173,6 @@ func evalExport(
 		maxIntents = uint64(m)
 	}
 
-	// Time-bound iterators only make sense to use if the start time is set.
-	useTBI := args.EnableTimeBoundIteratorOptimization && !args.StartTime.IsEmpty()
 	// Only use resume timestamp if splitting mid key is enabled.
 	resumeKeyTS := hlc.Timestamp{}
 	if args.SplitMidKey {
@@ -194,7 +192,6 @@ func evalExport(
 			MaxSize:            maxSize,
 			MaxIntents:         maxIntents,
 			StopMidKey:         args.SplitMidKey,
-			UseTBI:             useTBI,
 			ResourceLimiter:    storage.NewResourceLimiter(storage.ResourceLimiterOptions{MaxRunTime: maxRunTime}, timeutil.DefaultTimeSource{}),
 		}, destFile)
 		if err != nil {

--- a/pkg/kv/kvserver/batcheval/cmd_revert_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_revert_range.go
@@ -99,8 +99,7 @@ func RevertRange(
 
 	resume, err := storage.MVCCClearTimeRange(ctx, readWriter, cArgs.Stats, args.Key, args.EndKey,
 		args.TargetTime, cArgs.Header.Timestamp, cArgs.Header.MaxSpanRequestKeys,
-		maxRevertRangeBatchBytes,
-		args.EnableTimeBoundIteratorOptimization)
+		maxRevertRangeBatchBytes)
 	if err != nil {
 		return result.Result{}, err
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
@@ -153,9 +153,8 @@ func TestCmdRevertRange(t *testing.T) {
 					defer batch.Close()
 
 					req := roachpb.RevertRangeRequest{
-						RequestHeader:                       roachpb.RequestHeader{Key: startKey, EndKey: endKey},
-						TargetTime:                          tc.ts,
-						EnableTimeBoundIteratorOptimization: true,
+						RequestHeader: roachpb.RequestHeader{Key: startKey, EndKey: endKey},
+						TargetTime:    tc.ts,
 					}
 					cArgs.Stats = &enginepb.MVCCStats{}
 					cArgs.Args = &req
@@ -233,9 +232,8 @@ func TestCmdRevertRange(t *testing.T) {
 					defer batch.Close()
 					cArgs.Stats = &enginepb.MVCCStats{}
 					req := roachpb.RevertRangeRequest{
-						RequestHeader:                       roachpb.RequestHeader{Key: startKey, EndKey: endKey},
-						TargetTime:                          tc.ts,
-						EnableTimeBoundIteratorOptimization: true,
+						RequestHeader: roachpb.RequestHeader{Key: startKey, EndKey: endKey},
+						TargetTime:    tc.ts,
 					}
 					cArgs.Args = &req
 					var resumes int

--- a/pkg/kv/kvserver/rangefeed/catchup_scan.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan.go
@@ -65,10 +65,9 @@ func NewCatchUpIterator(
 	return &CatchUpIterator{
 		simpleCatchupIter: storage.NewMVCCIncrementalIterator(reader,
 			storage.MVCCIncrementalIterOptions{
-				EnableTimeBoundIteratorOptimization: true,
-				EndKey:                              span.EndKey,
-				StartTime:                           startTime,
-				EndTime:                             hlc.MaxTimestamp,
+				EndKey:    span.EndKey,
+				StartTime: startTime,
+				EndTime:   hlc.MaxTimestamp,
 				// We want to emit intents rather than error
 				// (the default behavior) so that we can skip
 				// over the provisional values during

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -403,6 +403,11 @@ message RevertRangeRequest {
   // for that time are still there — or the request will fail.
   util.hlc.Timestamp target_time = 2 [(gogoproto.nullable) = false];
 
+  // This parameter has no effect on 22.2, as TBI is always enabled. For
+  // compatibility with 22.1 nodes, callers must continue to set this as
+  // appropriate until 22.2.
+  //
+  // TODO(erikgrinaker): Remove this in 22.2.
   bool enable_time_bound_iterator_optimization = 3;
 
   // IgnoreGcThreshold can be set by a caller to ignore the target-time when
@@ -1511,18 +1516,11 @@ message ExportRequest {
   // Return the exported SST data in the response.
   bool return_sst = 5 [(gogoproto.customname) = "ReturnSST"];
 
-  // EnableTimeBoundIteratorOptimization, if true, enables a performance
-  // optimization that allows us to entirely skip over sstables in RocksDB that
-  // don't have data relevant to the time bounds in this request.
+  // This parameter has no effect on 22.2, as TBI is always enabled. For
+  // compatibility with 22.1 nodes, callers must continue to set this as
+  // appropriate until 22.2.
   //
-  // This can have a dramatic impact on performance, but we've seen a number of
-  // extremely subtle and hard to detect correctness issues with this (see
-  // #28358 #34819). As a result, we've decided to skip the optimization
-  // everywhere that it isn't absolutely necessary for the feature to work
-  // (leaving one place: poller-based changefeeds, which are being phased out
-  // anyway). This will both give increased confidence in correctness as well as
-  // eliminate any need to investigate time-bound iterators when/if someone hits
-  // a correctness bug.
+  // TODO(erikgrinaker): Remove this in 22.2.
   bool enable_time_bound_iterator_optimization = 7;
   // StorageByLocalityKV is a map of locality KVs to storage configurations. If
   // set, files will be written to the store that matches the most specific

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -128,9 +128,12 @@ var retiredSettings = map[string]struct{}{
 	"kv.rangefeed.separated_intent_scan.enabled":                       {},
 
 	// removed as of 22.2.
-	"kv.rangefeed.catchup_scan_iterator_optimization.enabled": {},
-	"sql.defaults.datestyle.enabled":                          {},
-	"sql.defaults.intervalstyle.enabled":                      {},
+	"kv.bulk_io_write.experimental_incremental_export_enabled":  {},
+	"kv.bulk_io_write.revert_range_time_bound_iterator.enabled": {},
+	"kv.rangefeed.catchup_scan_iterator_optimization.enabled":   {},
+	"kv.refresh_range.time_bound_iterators.enabled":             {},
+	"sql.defaults.datestyle.enabled":                            {},
+	"sql.defaults.intervalstyle.enabled":                        {},
 }
 
 var sqlDefaultSettings = map[string]struct{}{

--- a/pkg/sql/revert.go
+++ b/pkg/sql/revert.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -28,15 +27,6 @@ import (
 // reply size to worry about.
 // TODO(dt): tune this via experimentation.
 const RevertTableDefaultBatchSize = 500000
-
-// useTBIForRevertRange is a cluster setting that controls if the time-bound
-// iterator optimization is used when processing a revert range request.
-var useTBIForRevertRange = settings.RegisterBoolSetting(
-	settings.TenantWritable,
-	"kv.bulk_io_write.revert_range_time_bound_iterator.enabled",
-	"use the time-bound iterator optimization when processing a revert range request",
-	true,
-)
 
 // RevertTables reverts the passed table to the target time, which much be above
 // the GC threshold for every range (unless the flag ignoreGCThreshold is passed
@@ -88,7 +78,7 @@ func RevertTables(
 				},
 				TargetTime:                          targetTime,
 				IgnoreGcThreshold:                   ignoreGCThreshold,
-				EnableTimeBoundIteratorOptimization: useTBIForRevertRange.Get(&execCfg.Settings.SV),
+				EnableTimeBoundIteratorOptimization: true, // NB: Must set for 22.1 compatibility.
 			})
 		}
 		b.Header.MaxSpanRequestKeys = batchSize

--- a/pkg/sql/revert_test.go
+++ b/pkg/sql/revert_test.go
@@ -99,9 +99,8 @@ func TestRevertGCThreshold(t *testing.T) {
 	kvDB := tc.Server(0).DB()
 
 	req := &roachpb.RevertRangeRequest{
-		RequestHeader:                       roachpb.RequestHeader{Key: bootstrap.TestingUserTableDataMin(), EndKey: keys.MaxKey},
-		TargetTime:                          hlc.Timestamp{WallTime: -1},
-		EnableTimeBoundIteratorOptimization: true,
+		RequestHeader: roachpb.RequestHeader{Key: bootstrap.TestingUserTableDataMin(), EndKey: keys.MaxKey},
+		TargetTime:    hlc.Timestamp{WallTime: -1},
 	}
 	_, pErr := kv.SendWrapped(ctx, kvDB.NonTransactionalSender(), req)
 	if !testutils.IsPError(pErr, "must be after replica GC threshold") {

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -112,7 +112,6 @@ func BenchmarkExportToSst(b *testing.B) {
 	numKeys := []int{64, 512, 1024, 8192, 65536}
 	numRevisions := []int{1, 10, 100}
 	exportAllRevisions := []bool{false, true}
-	useTBI := []bool{false, true}
 	engineMakers := []struct {
 		name   string
 		create engineMaker
@@ -128,12 +127,7 @@ func BenchmarkExportToSst(b *testing.B) {
 						b.Run(fmt.Sprintf("numRevisions=%d", numRevision), func(b *testing.B) {
 							for _, exportAllRevisionsVal := range exportAllRevisions {
 								b.Run(fmt.Sprintf("exportAllRevisions=%t", exportAllRevisionsVal), func(b *testing.B) {
-									for _, useTBIVal := range useTBI {
-										b.Run(fmt.Sprintf("useTBI=%t", useTBIVal), func(b *testing.B) {
-											runExportToSst(b, engineImpl.create, numKey, numRevision,
-												exportAllRevisionsVal, useTBIVal)
-										})
-									}
+									runExportToSst(b, engineImpl.create, numKey, numRevision, exportAllRevisionsVal)
 								})
 							}
 						})
@@ -1504,12 +1498,7 @@ func runBatchApplyBatchRepr(
 }
 
 func runExportToSst(
-	b *testing.B,
-	emk engineMaker,
-	numKeys int,
-	numRevisions int,
-	exportAllRevisions bool,
-	useTBI bool,
+	b *testing.B, emk engineMaker, numKeys int, numRevisions int, exportAllRevisions bool,
 ) {
 	dir, cleanup := testutils.TempDir(b)
 	defer cleanup()
@@ -1552,7 +1541,6 @@ func runExportToSst(
 			TargetSize:         0,
 			MaxSize:            0,
 			StopMidKey:         false,
-			UseTBI:             useTBI,
 		}, noopWriter{})
 		if err != nil {
 			b.Fatal(err)

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -511,11 +511,6 @@ type ExportOptions struct {
 	// resources. Export queries limiter in its iteration loop to break out once
 	// resources are exhausted.
 	ResourceLimiter ResourceLimiter
-	// If UseTBI is true, the backing MVCCIncrementalIterator will initialize a
-	// time-bound iterator along with its regular iterator. The TBI will be used
-	// as an optimization to skip over swaths of uninteresting keys i.e. keys
-	// outside our time bounds, while locating the KVs to export.
-	UseTBI bool
 }
 
 // Reader is the read interface to an engine's data. Certain implementations

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -314,7 +314,7 @@ func (m mvccClearTimeRangeOp) run(ctx context.Context) string {
 		return "no-op due to no non-conflicting key range"
 	}
 	span, err := storage.MVCCClearTimeRange(ctx, m.m.engine, &enginepb.MVCCStats{}, m.key, m.endKey,
-		m.startTime, m.endTime, math.MaxInt64, math.MaxInt64, true /* useTBI */)
+		m.startTime, m.endTime, math.MaxInt64, math.MaxInt64)
 	if err != nil {
 		return fmt.Sprintf("error: %s", err)
 	}

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -2042,7 +2042,6 @@ func MVCCClearTimeRange(
 	key, endKey roachpb.Key,
 	startTime, endTime hlc.Timestamp,
 	maxBatchSize, maxBatchByteSize int64,
-	useTBI bool,
 ) (*roachpb.Span, error) {
 	var batchSize int64
 	var batchByteSize int64
@@ -2148,10 +2147,9 @@ func MVCCClearTimeRange(
 	// _expect_ to hit this since the RevertRange is only intended for non-live
 	// key spans, but there could be an intent leftover.
 	iter := NewMVCCIncrementalIterator(rw, MVCCIncrementalIterOptions{
-		EnableTimeBoundIteratorOptimization: useTBI,
-		EndKey:                              endKey,
-		StartTime:                           startTime,
-		EndTime:                             endTime,
+		EndKey:    endKey,
+		StartTime: startTime,
+		EndTime:   endTime,
 	})
 	defer iter.Close()
 

--- a/pkg/storage/mvcc_incremental_iterator.go
+++ b/pkg/storage/mvcc_incremental_iterator.go
@@ -13,10 +13,15 @@ package storage
 import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 )
+
+// mvccIncrementalIteratorMetamorphicTBI will randomly enable TBIs.
+var mvccIncrementalIteratorMetamorphicTBI = util.ConstantWithMetamorphicTestBool(
+	"mvcc-incremental-iter-tbi", true)
 
 // MVCCIncrementalIterator iterates over the diff of the key range
 // [startKey,endKey) and time range (startTime,endTime]. If a key was added or
@@ -123,10 +128,11 @@ const (
 
 // MVCCIncrementalIterOptions bundles options for NewMVCCIncrementalIterator.
 type MVCCIncrementalIterOptions struct {
-	EnableTimeBoundIteratorOptimization bool
-	EndKey                              roachpb.Key
-	// Keys visible by the MVCCIncrementalIterator must be within (StartTime,
-	// EndTime].
+	EndKey roachpb.Key
+
+	// Only keys within (StartTime,EndTime] will be emitted. EndTime defaults to
+	// hlc.MaxTimestamp. The time-bound iterator optimization will only be used if
+	// StartTime is set, since we assume EndTime will be near the current time.
 	StartTime hlc.Timestamp
 	EndTime   hlc.Timestamp
 
@@ -139,9 +145,22 @@ type MVCCIncrementalIterOptions struct {
 func NewMVCCIncrementalIterator(
 	reader Reader, opts MVCCIncrementalIterOptions,
 ) *MVCCIncrementalIterator {
+	// Default to MaxTimestamp for EndTime, since the code assumes it is set.
+	if opts.EndTime.IsEmpty() {
+		opts.EndTime = hlc.MaxTimestamp
+	}
+
+	// We assume EndTime is near the current time, so there is little to gain from
+	// using a TBI unless StartTime is set. However, we always vary it in
+	// metamorphic test builds, for better test coverage of both paths.
+	useTBI := opts.StartTime.IsSet()
+	if util.IsMetamorphicBuild() { // NB: always randomize when metamorphic
+		useTBI = mvccIncrementalIteratorMetamorphicTBI
+	}
+
 	var iter MVCCIterator
 	var timeBoundIter MVCCIterator
-	if opts.EnableTimeBoundIteratorOptimization {
+	if useTBI {
 		// An iterator without the timestamp hints is created to ensure that the
 		// iterator visits every required version of every key that has changed.
 		iter = reader.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -2018,197 +2018,177 @@ func TestMVCCClearTimeRange(t *testing.T) {
 				ts, endTs hlc.Timestamp,
 				sz int64,
 				byteLimit int64,
-				useTBI bool,
 			) int {
-				resume, err := MVCCClearTimeRange(ctx, rw, ms, key, endKey, ts, endTs, sz, byteLimit, useTBI)
+				resume, err := MVCCClearTimeRange(ctx, rw, ms, key, endKey, ts, endTs, sz, byteLimit)
 				require.NoError(t, err)
 				attempts := 1
 				for resume != nil {
-					resume, err = MVCCClearTimeRange(ctx, rw, ms, resume.Key, resume.EndKey, ts, endTs, sz, byteLimit, useTBI)
+					resume, err = MVCCClearTimeRange(ctx, rw, ms, resume.Key, resume.EndKey, ts, endTs, sz, byteLimit)
 					require.NoError(t, err)
 					attempts++
 				}
 				return attempts
 			}
-			for _, useTBI := range []bool{true, false} {
-				t.Run(fmt.Sprintf("useTBI-%t", useTBI), func(t *testing.T) {
-					t.Run("clear > ts0", func(t *testing.T) {
-						e := setupKVs(t)
-						defer e.Close()
-						_, err := MVCCClearTimeRange(ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts0, ts5, 10, 1<<10,
-							useTBI)
-						require.NoError(t, err)
-						assertKVs(t, e, ts0, ts0Content)
-						assertKVs(t, e, ts1, ts0Content)
-						assertKVs(t, e, ts5, ts0Content)
-					})
+			t.Run("clear > ts0", func(t *testing.T) {
+				e := setupKVs(t)
+				defer e.Close()
+				_, err := MVCCClearTimeRange(ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts0, ts5, 10, 1<<10)
+				require.NoError(t, err)
+				assertKVs(t, e, ts0, ts0Content)
+				assertKVs(t, e, ts1, ts0Content)
+				assertKVs(t, e, ts5, ts0Content)
+			})
 
-					t.Run("clear > ts1 ", func(t *testing.T) {
-						e := setupKVs(t)
-						defer e.Close()
-						attempts := resumingClear(t, ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts1, ts5, 10, kb, useTBI)
-						require.Equal(t, 1, attempts)
-						assertKVs(t, e, ts1, ts1Content)
-						assertKVs(t, e, ts2, ts1Content)
-						assertKVs(t, e, ts5, ts1Content)
-					})
-					t.Run("clear > ts1 count-size batch", func(t *testing.T) {
-						e := setupKVs(t)
-						defer e.Close()
-						attempts := resumingClear(t, ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts1, ts5, 1, kb,
-							useTBI)
-						require.Equal(t, 2, attempts)
-						assertKVs(t, e, ts1, ts1Content)
-						assertKVs(t, e, ts2, ts1Content)
-						assertKVs(t, e, ts5, ts1Content)
-					})
+			t.Run("clear > ts1 ", func(t *testing.T) {
+				e := setupKVs(t)
+				defer e.Close()
+				attempts := resumingClear(t, ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts1, ts5, 10, kb)
+				require.Equal(t, 1, attempts)
+				assertKVs(t, e, ts1, ts1Content)
+				assertKVs(t, e, ts2, ts1Content)
+				assertKVs(t, e, ts5, ts1Content)
+			})
+			t.Run("clear > ts1 count-size batch", func(t *testing.T) {
+				e := setupKVs(t)
+				defer e.Close()
+				attempts := resumingClear(t, ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts1, ts5, 1, kb)
+				require.Equal(t, 2, attempts)
+				assertKVs(t, e, ts1, ts1Content)
+				assertKVs(t, e, ts2, ts1Content)
+				assertKVs(t, e, ts5, ts1Content)
+			})
 
-					t.Run("clear > ts1 byte-size batch", func(t *testing.T) {
-						e := setupKVs(t)
-						defer e.Close()
-						attempts := resumingClear(t, ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts1, ts5, 10, 1,
-							useTBI)
-						require.Equal(t, 2, attempts)
-						assertKVs(t, e, ts1, ts1Content)
-						assertKVs(t, e, ts2, ts1Content)
-						assertKVs(t, e, ts5, ts1Content)
-					})
+			t.Run("clear > ts1 byte-size batch", func(t *testing.T) {
+				e := setupKVs(t)
+				defer e.Close()
+				attempts := resumingClear(t, ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts1, ts5, 10, 1)
+				require.Equal(t, 2, attempts)
+				assertKVs(t, e, ts1, ts1Content)
+				assertKVs(t, e, ts2, ts1Content)
+				assertKVs(t, e, ts5, ts1Content)
+			})
 
-					t.Run("clear > ts2", func(t *testing.T) {
-						e := setupKVs(t)
-						defer e.Close()
-						attempts := resumingClear(t, ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts2, ts5, 10, kb,
-							useTBI)
-						require.Equal(t, 1, attempts)
-						assertKVs(t, e, ts2, ts2Content)
-						assertKVs(t, e, ts5, ts2Content)
-					})
+			t.Run("clear > ts2", func(t *testing.T) {
+				e := setupKVs(t)
+				defer e.Close()
+				attempts := resumingClear(t, ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts2, ts5, 10, kb)
+				require.Equal(t, 1, attempts)
+				assertKVs(t, e, ts2, ts2Content)
+				assertKVs(t, e, ts5, ts2Content)
+			})
 
-					t.Run("clear > ts3", func(t *testing.T) {
-						e := setupKVs(t)
-						defer e.Close()
-						resumingClear(t, ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts3, ts5, 10, kb,
-							useTBI)
-						assertKVs(t, e, ts3, ts3Content)
-						assertKVs(t, e, ts5, ts3Content)
-					})
+			t.Run("clear > ts3", func(t *testing.T) {
+				e := setupKVs(t)
+				defer e.Close()
+				resumingClear(t, ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts3, ts5, 10, kb)
+				assertKVs(t, e, ts3, ts3Content)
+				assertKVs(t, e, ts5, ts3Content)
+			})
 
-					t.Run("clear > ts4 (nothing) ", func(t *testing.T) {
-						e := setupKVs(t)
-						defer e.Close()
-						_, err := MVCCClearTimeRange(ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts4, ts5, 10, kb,
-							useTBI)
-						require.NoError(t, err)
-						assertKVs(t, e, ts4, ts4Content)
-						assertKVs(t, e, ts5, ts4Content)
-					})
+			t.Run("clear > ts4 (nothing) ", func(t *testing.T) {
+				e := setupKVs(t)
+				defer e.Close()
+				_, err := MVCCClearTimeRange(ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts4, ts5, 10, kb)
+				require.NoError(t, err)
+				assertKVs(t, e, ts4, ts4Content)
+				assertKVs(t, e, ts5, ts4Content)
+			})
 
-					t.Run("clear > ts5 (nothing)", func(t *testing.T) {
-						e := setupKVs(t)
-						defer e.Close()
-						_, err := MVCCClearTimeRange(ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts5, ts5, 10, kb,
-							useTBI)
-						require.NoError(t, err)
-						assertKVs(t, e, ts4, ts4Content)
-						assertKVs(t, e, ts5, ts4Content)
-					})
+			t.Run("clear > ts5 (nothing)", func(t *testing.T) {
+				e := setupKVs(t)
+				defer e.Close()
+				_, err := MVCCClearTimeRange(ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts5, ts5, 10, kb)
+				require.NoError(t, err)
+				assertKVs(t, e, ts4, ts4Content)
+				assertKVs(t, e, ts5, ts4Content)
+			})
 
-					t.Run("clear up to k5 to ts0", func(t *testing.T) {
-						e := setupKVs(t)
-						defer e.Close()
-						resumingClear(t, ctx, e, &enginepb.MVCCStats{}, testKey1, testKey5, ts0, ts5, 10, kb,
-							useTBI)
-						assertKVs(t, e, ts2, []roachpb.KeyValue{{Key: testKey5, Value: v2}})
-						assertKVs(t, e, ts5, []roachpb.KeyValue{{Key: testKey5, Value: v4}})
-					})
+			t.Run("clear up to k5 to ts0", func(t *testing.T) {
+				e := setupKVs(t)
+				defer e.Close()
+				resumingClear(t, ctx, e, &enginepb.MVCCStats{}, testKey1, testKey5, ts0, ts5, 10, kb)
+				assertKVs(t, e, ts2, []roachpb.KeyValue{{Key: testKey5, Value: v2}})
+				assertKVs(t, e, ts5, []roachpb.KeyValue{{Key: testKey5, Value: v4}})
+			})
 
-					t.Run("clear > ts0 in empty span (nothing)", func(t *testing.T) {
-						e := setupKVs(t)
-						defer e.Close()
-						_, err := MVCCClearTimeRange(ctx, e, &enginepb.MVCCStats{}, testKey3, testKey5, ts0, ts5, 10, kb,
-							useTBI)
-						require.NoError(t, err)
-						assertKVs(t, e, ts2, ts2Content)
-						assertKVs(t, e, ts5, ts4Content)
-					})
+			t.Run("clear > ts0 in empty span (nothing)", func(t *testing.T) {
+				e := setupKVs(t)
+				defer e.Close()
+				_, err := MVCCClearTimeRange(ctx, e, &enginepb.MVCCStats{}, testKey3, testKey5, ts0, ts5, 10, kb)
+				require.NoError(t, err)
+				assertKVs(t, e, ts2, ts2Content)
+				assertKVs(t, e, ts5, ts4Content)
+			})
 
-					t.Run("clear > ts0 in empty span [k3,k5) (nothing)", func(t *testing.T) {
-						e := setupKVs(t)
-						defer e.Close()
-						_, err := MVCCClearTimeRange(ctx, e, &enginepb.MVCCStats{}, testKey3, testKey5, ts0, ts5, 10, 1<<10,
-							useTBI)
-						require.NoError(t, err)
-						assertKVs(t, e, ts2, ts2Content)
-						assertKVs(t, e, ts5, ts4Content)
-					})
+			t.Run("clear > ts0 in empty span [k3,k5) (nothing)", func(t *testing.T) {
+				e := setupKVs(t)
+				defer e.Close()
+				_, err := MVCCClearTimeRange(ctx, e, &enginepb.MVCCStats{}, testKey3, testKey5, ts0, ts5, 10, 1<<10)
+				require.NoError(t, err)
+				assertKVs(t, e, ts2, ts2Content)
+				assertKVs(t, e, ts5, ts4Content)
+			})
 
-					t.Run("clear k3 and up in ts0 > x >= ts1 (nothing)", func(t *testing.T) {
-						e := setupKVs(t)
-						defer e.Close()
-						_, err := MVCCClearTimeRange(ctx, e, &enginepb.MVCCStats{}, testKey3, keyMax, ts0, ts1, 10, 1<<10,
-							useTBI)
-						require.NoError(t, err)
-						assertKVs(t, e, ts2, ts2Content)
-						assertKVs(t, e, ts5, ts4Content)
-					})
+			t.Run("clear k3 and up in ts0 > x >= ts1 (nothing)", func(t *testing.T) {
+				e := setupKVs(t)
+				defer e.Close()
+				_, err := MVCCClearTimeRange(ctx, e, &enginepb.MVCCStats{}, testKey3, keyMax, ts0, ts1, 10, 1<<10)
+				require.NoError(t, err)
+				assertKVs(t, e, ts2, ts2Content)
+				assertKVs(t, e, ts5, ts4Content)
+			})
 
-					// Add an intent at k3@ts3.
-					txn := roachpb.MakeTransaction("test", nil, roachpb.NormalUserPriority, ts3, 1, 1)
-					setupKVsWithIntent := func(t *testing.T) Engine {
-						e := setupKVs(t)
-						require.NoError(t, MVCCPut(ctx, e, &enginepb.MVCCStats{}, testKey3, ts3, hlc.ClockTimestamp{}, value3, &txn))
-						return e
-					}
-					t.Run("clear everything hitting intent fails", func(t *testing.T) {
-						e := setupKVsWithIntent(t)
-						defer e.Close()
-						_, err := MVCCClearTimeRange(ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts0, ts5, 10, 1<<10,
-							useTBI)
-						require.EqualError(t, err, "conflicting intents on \"/db3\"")
-					})
-
-					t.Run("clear exactly hitting intent fails", func(t *testing.T) {
-						e := setupKVsWithIntent(t)
-						defer e.Close()
-						_, err := MVCCClearTimeRange(ctx, e, &enginepb.MVCCStats{}, testKey3, testKey4, ts2, ts3, 10, 1<<10,
-							useTBI)
-						require.EqualError(t, err, "conflicting intents on \"/db3\"")
-					})
-
-					t.Run("clear everything above intent", func(t *testing.T) {
-						e := setupKVsWithIntent(t)
-						defer e.Close()
-						resumingClear(t, ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts3, ts5, 10, kb,
-							useTBI)
-						assertKVs(t, e, ts2, ts2Content)
-
-						// Scan (< k3 to avoid intent) to confirm that k2 was indeed reverted to
-						// value as of ts3 (i.e. v4 was cleared to expose v2).
-						res, err := MVCCScan(ctx, e, localMax, testKey3, ts5, MVCCScanOptions{})
-						require.NoError(t, err)
-						require.Equal(t, ts3Content[:2], res.KVs)
-
-						// Verify the intent was left alone.
-						_, err = MVCCScan(ctx, e, testKey3, testKey4, ts5, MVCCScanOptions{})
-						require.Error(t, err)
-
-						// Scan (> k3 to avoid intent) to confirm that k5 was indeed reverted to
-						// value as of ts3 (i.e. v4 was cleared to expose v2).
-						res, err = MVCCScan(ctx, e, testKey4, keyMax, ts5, MVCCScanOptions{})
-						require.NoError(t, err)
-						require.Equal(t, ts3Content[2:], res.KVs)
-					})
-
-					t.Run("clear below intent", func(t *testing.T) {
-						e := setupKVsWithIntent(t)
-						defer e.Close()
-						assertKVs(t, e, ts2, ts2Content)
-						resumingClear(t, ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts1, ts2, 10, kb,
-							useTBI)
-						assertKVs(t, e, ts2, ts1Content)
-					})
-				})
+			// Add an intent at k3@ts3.
+			txn := roachpb.MakeTransaction("test", nil, roachpb.NormalUserPriority, ts3, 1, 1)
+			setupKVsWithIntent := func(t *testing.T) Engine {
+				e := setupKVs(t)
+				require.NoError(t, MVCCPut(ctx, e, &enginepb.MVCCStats{}, testKey3, ts3, hlc.ClockTimestamp{}, value3, &txn))
+				return e
 			}
+			t.Run("clear everything hitting intent fails", func(t *testing.T) {
+				e := setupKVsWithIntent(t)
+				defer e.Close()
+				_, err := MVCCClearTimeRange(ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts0, ts5, 10, 1<<10)
+				require.EqualError(t, err, "conflicting intents on \"/db3\"")
+			})
+
+			t.Run("clear exactly hitting intent fails", func(t *testing.T) {
+				e := setupKVsWithIntent(t)
+				defer e.Close()
+				_, err := MVCCClearTimeRange(ctx, e, &enginepb.MVCCStats{}, testKey3, testKey4, ts2, ts3, 10, 1<<10)
+				require.EqualError(t, err, "conflicting intents on \"/db3\"")
+			})
+
+			t.Run("clear everything above intent", func(t *testing.T) {
+				e := setupKVsWithIntent(t)
+				defer e.Close()
+				resumingClear(t, ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts3, ts5, 10, kb)
+				assertKVs(t, e, ts2, ts2Content)
+
+				// Scan (< k3 to avoid intent) to confirm that k2 was indeed reverted to
+				// value as of ts3 (i.e. v4 was cleared to expose v2).
+				res, err := MVCCScan(ctx, e, localMax, testKey3, ts5, MVCCScanOptions{})
+				require.NoError(t, err)
+				require.Equal(t, ts3Content[:2], res.KVs)
+
+				// Verify the intent was left alone.
+				_, err = MVCCScan(ctx, e, testKey3, testKey4, ts5, MVCCScanOptions{})
+				require.Error(t, err)
+
+				// Scan (> k3 to avoid intent) to confirm that k5 was indeed reverted to
+				// value as of ts3 (i.e. v4 was cleared to expose v2).
+				res, err = MVCCScan(ctx, e, testKey4, keyMax, ts5, MVCCScanOptions{})
+				require.NoError(t, err)
+				require.Equal(t, ts3Content[2:], res.KVs)
+			})
+
+			t.Run("clear below intent", func(t *testing.T) {
+				e := setupKVsWithIntent(t)
+				defer e.Close()
+				assertKVs(t, e, ts2, ts2Content)
+				resumingClear(t, ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts1, ts2, 10, kb)
+				assertKVs(t, e, ts2, ts1Content)
+			})
 		})
 	}
 }
@@ -2312,34 +2292,32 @@ func TestMVCCClearTimeRangeOnRandomData(t *testing.T) {
 			maxAttempts := (numKVs * keyLen) / byteLimit
 			var attempts int64
 			for i := len(reverts) - 1; i >= 0; i-- {
-				for _, useTBI := range []bool{false, true} {
-					t.Run(fmt.Sprintf("useTBI-%t revert-%d", useTBI, i), func(t *testing.T) {
-						revertTo := hlc.Timestamp{WallTime: int64(reverts[i])}
-						// MVCC-Scan at the revert time.
-						resBefore, err := MVCCScan(ctx, e, localMax, keyMax, revertTo, MVCCScanOptions{MaxKeys: numKVs})
-						require.NoError(t, err)
+				t.Run(fmt.Sprintf("revert-%d", i), func(t *testing.T) {
+					revertTo := hlc.Timestamp{WallTime: int64(reverts[i])}
+					// MVCC-Scan at the revert time.
+					resBefore, err := MVCCScan(ctx, e, localMax, keyMax, revertTo, MVCCScanOptions{MaxKeys: numKVs})
+					require.NoError(t, err)
 
-						// Revert to the revert time.
-						startKey := localMax
-						for {
-							attempts++
-							resume, err := MVCCClearTimeRange(ctx, e, &ms, startKey, keyMax, revertTo, now,
-								keyLimit, byteLimit, useTBI)
-							require.NoError(t, err)
-							if resume == nil {
-								break
-							}
-							startKey = resume.Key
+					// Revert to the revert time.
+					startKey := localMax
+					for {
+						attempts++
+						resume, err := MVCCClearTimeRange(ctx, e, &ms, startKey, keyMax, revertTo, now,
+							keyLimit, byteLimit)
+						require.NoError(t, err)
+						if resume == nil {
+							break
 						}
+						startKey = resume.Key
+					}
 
-						require.Equal(t, computeStats(t, e, localMax, keyMax, 2000), ms)
-						// Scanning at "now" post-revert should yield the same result as scanning
-						// at revert-time pre-revert.
-						resAfter, err := MVCCScan(ctx, e, localMax, keyMax, now, MVCCScanOptions{MaxKeys: numKVs})
-						require.NoError(t, err)
-						require.Equal(t, resBefore.KVs, resAfter.KVs)
-					})
-				}
+					require.Equal(t, computeStats(t, e, localMax, keyMax, 2000), ms)
+					// Scanning at "now" post-revert should yield the same result as scanning
+					// at revert-time pre-revert.
+					resAfter, err := MVCCScan(ctx, e, localMax, keyMax, now, MVCCScanOptions{MaxKeys: numKVs})
+					require.NoError(t, err)
+					require.Equal(t, resBefore.KVs, resAfter.KVs)
+				})
 			}
 			require.LessOrEqual(t, attempts, maxAttempts)
 		})

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -2429,11 +2429,10 @@ func pebbleExportToSst(
 	iter := NewMVCCIncrementalIterator(
 		reader,
 		MVCCIncrementalIterOptions{
-			EndKey:                              options.EndKey,
-			EnableTimeBoundIteratorOptimization: options.UseTBI,
-			StartTime:                           options.StartTS,
-			EndTime:                             options.EndTS,
-			IntentPolicy:                        MVCCIncrementalIterIntentPolicyAggregate,
+			EndKey:       options.EndKey,
+			StartTime:    options.StartTS,
+			EndTime:      options.EndTS,
+			IntentPolicy: MVCCIncrementalIterIntentPolicyAggregate,
 		})
 	defer iter.Close()
 	var curKey roachpb.Key // only used if exportAllRevisions

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -584,7 +584,6 @@ func TestSstExportFailureIntentBatching(t *testing.T) {
 				MaxSize:            0,
 				MaxIntents:         uint64(MaxIntentsPerWriteIntentError.Default()),
 				StopMidKey:         false,
-				UseTBI:             true,
 			}, destination)
 			if len(expectedIntentIndices) == 0 {
 				require.NoError(t, err)
@@ -638,29 +637,21 @@ func TestExportSplitMidKey(t *testing.T) {
 
 	for _, test := range []struct {
 		exportAll    bool
-		useTBI       bool
 		stopMidKey   bool
 		useMaxSize   bool
 		resumeCount  int
 		resumeWithTs int
 	}{
-		{false, true, false, false, 3, 0},
-		{true, true, false, false, 3, 0},
-		{false, true, true, false, 3, 0},
+		{false, false, false, 3, 0},
+		{true, false, false, 3, 0},
+		{false, true, false, 3, 0},
 		// No resume timestamps since we fall under max size criteria
-		{true, true, true, false, 3, 0},
-		{true, true, true, true, 4, 1},
-		{false, false, false, false, 3, 0},
-		{true, false, false, false, 3, 0},
-		{false, false, true, false, 3, 0},
-		// No resume timestamps since we fall under max size criteria
-		{true, false, true, false, 3, 0},
-		{true, false, true, true, 4, 1},
+		{true, true, false, 3, 0},
+		{true, true, true, 4, 1},
 	} {
 		t.Run(
-			fmt.Sprintf(
-				"exportAll=%t,useTBI=%t,stopMidKey=%t,useMaxSize=%t",
-				test.exportAll, test.useTBI, test.stopMidKey, test.useMaxSize),
+			fmt.Sprintf("exportAll=%t,stopMidKey=%t,useMaxSize=%t",
+				test.exportAll, test.stopMidKey, test.useMaxSize),
 			func(t *testing.T) {
 				firstKeyTS := hlc.Timestamp{}
 				resumeKey := key(1)
@@ -682,7 +673,6 @@ func TestExportSplitMidKey(t *testing.T) {
 							TargetSize:         1,
 							MaxSize:            maxSize,
 							StopMidKey:         test.stopMidKey,
-							UseTBI:             test.useTBI,
 						}, dest)
 					if !firstKeyTS.IsEmpty() {
 						resumeWithTs++
@@ -917,7 +907,6 @@ func exportAllData(t *testing.T, engine Engine, limits queryLimits) []MVCCKey {
 		StartTS:            limits.minTimestamp,
 		EndTS:              limits.maxTimestamp,
 		ExportAllRevisions: !limits.latest,
-		UseTBI:             true,
 	}, sstFile)
 	require.NoError(t, err, "Failed to export expected data")
 	return sstToKeys(t, sstFile.Data())
@@ -962,7 +951,6 @@ func assertDataEqual(
 			StartTS:            query.minTimestamp,
 			EndTS:              query.maxTimestamp,
 			ExportAllRevisions: !query.latest,
-			UseTBI:             true,
 			StopMidKey:         true,
 			ResourceLimiter:    &limiter,
 		}, sstFile)


### PR DESCRIPTION
This patch removes the `EnableTimeBoundIteratorOptimization` field from
`MVCCIncrementalIterOptions`. All existing caller have defaulted to
enabling these in 22.1. Time-bound iterators are now enabled if the
caller provides `StartTime`, since we otherwise assume that we're
iterating over the entire dataset. TBIs are always randomly enabled in
metamorphic test builds.

This also removes the following cluster settings which defaulted to
`true` (none of which were considered public):

* `kv.bulk_io_write.experimental_incremental_export_enabled`
* `kv.bulk_io_write.revert_range_time_bound_iterator.enabled`
* `kv.refresh_range.time_bound_iterators.enabled`

The following RPC request fields have been retained and set to `true` as
appropriate for compatibility with 22.1 nodes, but they have no effect
on 22.2 nodes:

* `ExportRequest.EnableTimeBoundIteratorOptimization`
* `RevertRequest.EnableTimeBoundIteratorOptimization`

The following `Export` callers did not enable TBIs, but will now have
them enabled by default:

* `kvclient.GetAllRevisions()`
* `lease.getDescriptorsFromStoreForInterval()`
* `schemafeed.fetchDescriptorsWithPriorityOverride()`

Resolves #82454.

Release note: None