### PR TITLE
sql: add logic for `GRANT ... ON seq_names`

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/grant_sequence
+++ b/pkg/sql/logictest/testdata/logic_test/grant_sequence
@@ -221,3 +221,44 @@ DROP SEQUENCE to_drop_seq
 
 statement ok
 SET ROLE root
+
+subtest grant_on_mix_table_and_sequence
+
+statement ok
+CREATE SEQUENCE mix_seq
+
+statement ok
+CREATE TABLE mix_tab (x int)
+
+statement ok
+CREATE ROLE mix_u
+
+statement ok
+GRANT USAGE ON mix_seq TO mix_u WITH GRANT OPTION
+
+query TTTTTTTT
+SELECT * FROM information_schema.table_privileges WHERE grantee = 'mix_u';
+----
+NULL  mix_u  test  public  mix_seq  USAGE  YES  NO
+
+statement ok
+GRANT SELECT, UPDATE ON mix_seq, mix_tab TO mix_u WITH GRANT OPTION
+
+statement error pq: invalid privilege type USAGE for table
+GRANT USAGE ON mix_seq, mix_tab TO mix_u WITH GRANT OPTION
+
+query TTTTTTTT
+SELECT * FROM information_schema.table_privileges WHERE grantee = 'mix_u';
+----
+NULL  mix_u  test  public  mix_seq  SELECT  YES  YES
+NULL  mix_u  test  public  mix_seq  UPDATE  YES  NO
+NULL  mix_u  test  public  mix_seq  USAGE   YES  NO
+NULL  mix_u  test  public  mix_tab  SELECT  YES  YES
+NULL  mix_u  test  public  mix_tab  UPDATE  YES  NO
+
+query BBB
+SELECT has_sequence_privilege('mix_u', 'mix_seq', 'USAGE WITH GRANT OPTION'),
+       has_sequence_privilege('mix_u', 'mix_seq', 'SELECT WITH GRANT OPTION'),
+       has_sequence_privilege('mix_u', 'mix_seq', 'UPDATE WITH GRANT OPTION')
+----
+true  true  true

--- a/pkg/sql/logictest/testdata/logic_test/grant_sequence
+++ b/pkg/sql/logictest/testdata/logic_test/grant_sequence
@@ -241,6 +241,11 @@ SELECT * FROM information_schema.table_privileges WHERE grantee = 'mix_u';
 ----
 NULL  mix_u  test  public  mix_seq  USAGE  YES  NO
 
+query B
+SELECT has_sequence_privilege('mix_u', 'mix_seq', 'USAGE WITH GRANT OPTION')
+----
+true
+
 statement ok
 GRANT SELECT, UPDATE ON mix_seq, mix_tab TO mix_u WITH GRANT OPTION
 

--- a/pkg/sql/logictest/testdata/logic_test/privilege_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/privilege_builtins
@@ -776,10 +776,7 @@ false  false  false
 
 user root
 
-# incorrectly unable to grant USAGE on sequence
-# should be statement ok
-# see https://github.com/cockroachdb/cockroach/issues/82414
-statement error pgcode 0LP01 invalid privilege type USAGE for table
+statement ok
 GRANT USAGE, SELECT, UPDATE ON seq TO testuser WITH GRANT OPTION
 
 # should be "true  true  true"
@@ -788,7 +785,7 @@ SELECT has_sequence_privilege('testuser', 'seq', 'USAGE WITH GRANT OPTION'),
        has_sequence_privilege('testuser', 'seq', 'SELECT WITH GRANT OPTION'),
        has_sequence_privilege('testuser', 'seq', 'UPDATE WITH GRANT OPTION')
 ----
-false  false  false
+true  true  true
 
 # incorrectly grants USAGE (should only have SELECT AND UPDATE)
 # see https://github.com/cockroachdb/cockroach/issues/82414
@@ -811,7 +808,7 @@ SELECT has_sequence_privilege('bar', 'seq', 'USAGE'),
        has_sequence_privilege('bar', 'seq', 'SELECT'),
        has_sequence_privilege('bar', 'seq', 'UPDATE')
 ----
-true  true  false
+false  true  false
 
 query BBB
 SELECT has_sequence_privilege('bar', 'seq', 'USAGE WITH GRANT OPTION'),

--- a/pkg/sql/logictest/testdata/logic_test/privilege_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/privilege_builtins
@@ -765,7 +765,7 @@ SELECT has_sequence_privilege('seq', 'USAGE'),
        has_sequence_privilege('seq', 'SELECT'),
        has_sequence_privilege('seq', 'UPDATE')
 ----
-true  true  false
+false  true  false
 
 query BBB
 SELECT has_sequence_privilege('seq', 'USAGE WITH GRANT OPTION'),

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -6801,11 +6801,11 @@ opt_on_targets_roles:
 targets:
   IDENT
   {
-    $$.val = tree.TargetList{Tables: tree.TableAttrs{IsSequence: false, TablePatterns: tree.TablePatterns{&tree.UnresolvedName{NumParts:1, Parts: tree.NameParts{$1}}}}}
+    $$.val = tree.TargetList{Tables: tree.TableAttrs{SequenceOnly: false, TablePatterns: tree.TablePatterns{&tree.UnresolvedName{NumParts:1, Parts: tree.NameParts{$1}}}}}
   }
 | col_name_keyword
   {
-    $$.val = tree.TargetList{Tables: tree.TableAttrs{IsSequence: false, TablePatterns: tree.TablePatterns{&tree.UnresolvedName{NumParts:1, Parts: tree.NameParts{$1}}}}}
+    $$.val = tree.TargetList{Tables: tree.TableAttrs{SequenceOnly: false, TablePatterns: tree.TablePatterns{&tree.UnresolvedName{NumParts:1, Parts: tree.NameParts{$1}}}}}
   }
 | unreserved_keyword
   {
@@ -6842,26 +6842,26 @@ targets:
     // of increasing (or attempting to modify) the grey magic occurring
     // here.
     $$.val = tree.TargetList{
-      Tables: tree.TableAttrs{IsSequence: false, TablePatterns:tree.TablePatterns{&tree.UnresolvedName{NumParts:1, Parts: tree.NameParts{$1}}}},
+      Tables: tree.TableAttrs{SequenceOnly: false, TablePatterns:tree.TablePatterns{&tree.UnresolvedName{NumParts:1, Parts: tree.NameParts{$1}}}},
       ForRoles: $1 == "role", // backdoor for "SHOW GRANTS ON ROLE" (no name list)
     }
   }
 | complex_table_pattern
   {
-    $$.val = tree.TargetList{Tables: tree.TableAttrs{IsSequence: false, TablePatterns: tree.TablePatterns{$1.unresolvedName()}}}
+    $$.val = tree.TargetList{Tables: tree.TableAttrs{SequenceOnly: false, TablePatterns: tree.TablePatterns{$1.unresolvedName()}}}
   }
 | SEQUENCE table_pattern_list
   {
-    $$.val = tree.TargetList{Tables: tree.TableAttrs{IsSequence: true, TablePatterns: $2.tablePatterns()}}
+    $$.val = tree.TargetList{Tables: tree.TableAttrs{SequenceOnly: true, TablePatterns: $2.tablePatterns()}}
   }
 | table_pattern ',' table_pattern_list
   {
     remainderPats := $3.tablePatterns()
-    $$.val = tree.TargetList{Tables: tree.TableAttrs{IsSequence: false, TablePatterns: append(tree.TablePatterns{$1.unresolvedName()}, remainderPats...)}}
+    $$.val = tree.TargetList{Tables: tree.TableAttrs{SequenceOnly: false, TablePatterns: append(tree.TablePatterns{$1.unresolvedName()}, remainderPats...)}}
   }
 | TABLE table_pattern_list
   {
-    $$.val = tree.TargetList{Tables: tree.TableAttrs{IsSequence: false, TablePatterns: $2.tablePatterns()}}
+    $$.val = tree.TargetList{Tables: tree.TableAttrs{SequenceOnly: false, TablePatterns: $2.tablePatterns()}}
   }
 // TODO(knz): This should learn how to parse more complex expressions
 // and placeholders.

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -383,10 +383,19 @@ func (p *planner) ObjectLookupFlags(required, requireMutable bool) tree.ObjectLo
 	return tree.ObjectLookupFlags{CommonLookupFlags: flags}
 }
 
-// getDescriptorsFromTargetListForPrivilegeChange fetches the descriptors for the targets.
-func getDescriptorsFromTargetListForPrivilegeChange(
-	ctx context.Context, p *planner, targets tree.TargetList,
-) ([]catalog.Descriptor, error) {
+// DescriptorWithObjectType wraps a descriptor with the corresponding
+// privilege object type.
+type DescriptorWithObjectType struct {
+	descriptor catalog.Descriptor
+	objectType privilege.ObjectType
+}
+
+// getDescriptorsFromTargetListForPrivilegeChange fetches the descriptors
+// for the targets. Each descriptor is marked along with the corresponding
+// object type.
+func (p *planner) getDescriptorsFromTargetListForPrivilegeChange(
+	ctx context.Context, targets tree.TargetList,
+) ([]DescriptorWithObjectType, error) {
 	const required = true
 	flags := tree.CommonLookupFlags{
 		Required:       required,
@@ -397,14 +406,17 @@ func getDescriptorsFromTargetListForPrivilegeChange(
 		if len(targets.Databases) == 0 {
 			return nil, errNoDatabase
 		}
-		descs := make([]catalog.Descriptor, 0, len(targets.Databases))
+		descs := make([]DescriptorWithObjectType, 0, len(targets.Databases))
 		for _, database := range targets.Databases {
 			descriptor, err := p.Descriptors().
 				GetMutableDatabaseByName(ctx, p.txn, string(database), flags)
 			if err != nil {
 				return nil, err
 			}
-			descs = append(descs, descriptor)
+			descs = append(descs, DescriptorWithObjectType{
+				descriptor: descriptor,
+				objectType: privilege.Database,
+			})
 		}
 		if len(descs) == 0 {
 			return nil, errNoMatch
@@ -416,14 +428,17 @@ func getDescriptorsFromTargetListForPrivilegeChange(
 		if len(targets.Types) == 0 {
 			return nil, errNoType
 		}
-		descs := make([]catalog.Descriptor, 0, len(targets.Types))
+		descs := make([]DescriptorWithObjectType, 0, len(targets.Types))
 		for _, typ := range targets.Types {
 			_, descriptor, err := p.ResolveMutableTypeDescriptor(ctx, typ, required)
 			if err != nil {
 				return nil, err
 			}
 
-			descs = append(descs, descriptor)
+			descs = append(descs, DescriptorWithObjectType{
+				descriptor: descriptor,
+				objectType: privilege.Type,
+			})
 		}
 
 		if len(descs) == 0 {
@@ -438,7 +453,7 @@ func getDescriptorsFromTargetListForPrivilegeChange(
 		}
 		if targets.AllTablesInSchema || targets.AllSequencesInSchema {
 			// Get all the descriptors for the tables in the specified schemas.
-			var descs []catalog.Descriptor
+			var descs []DescriptorWithObjectType
 			for _, sc := range targets.Schemas {
 				dbName := p.CurrentDatabase()
 				if sc.ExplicitCatalog {
@@ -462,7 +477,12 @@ func getDescriptorsFromTargetListForPrivilegeChange(
 					if targets.AllTablesInSchema {
 						if mut != nil {
 							if mut.DescriptorType() == catalog.Table {
-								descs = append(descs, mut)
+								descs = append(
+									descs,
+									DescriptorWithObjectType{
+										descriptor: mut,
+										objectType: privilege.Table,
+									})
 							}
 						}
 					} else if targets.AllSequencesInSchema {
@@ -472,7 +492,13 @@ func getDescriptorsFromTargetListForPrivilegeChange(
 								return nil, err
 							}
 							if tableDesc.IsSequence() {
-								descs = append(descs, mut)
+								descs = append(
+									descs,
+									DescriptorWithObjectType{
+										descriptor: mut,
+										objectType: privilege.Sequence,
+									},
+								)
 							}
 						}
 					}
@@ -482,7 +508,7 @@ func getDescriptorsFromTargetListForPrivilegeChange(
 			return descs, nil
 		}
 
-		descs := make([]catalog.Descriptor, 0, len(targets.Schemas))
+		descs := make([]DescriptorWithObjectType, 0, len(targets.Schemas))
 
 		// Resolve the databases being changed
 		type schemaWithDBDesc struct {
@@ -499,7 +525,10 @@ func getDescriptorsFromTargetListForPrivilegeChange(
 			if err != nil {
 				return nil, err
 			}
-			targetSchemas = append(targetSchemas, schemaWithDBDesc{schema: sc.Schema(), dbDesc: db})
+			targetSchemas = append(
+				targetSchemas,
+				schemaWithDBDesc{schema: sc.Schema(), dbDesc: db},
+			)
 		}
 
 		for _, sc := range targetSchemas {
@@ -510,7 +539,12 @@ func getDescriptorsFromTargetListForPrivilegeChange(
 			}
 			switch resSchema.SchemaKind() {
 			case catalog.SchemaUserDefined:
-				descs = append(descs, resSchema)
+				descs = append(
+					descs,
+					DescriptorWithObjectType{
+						descriptor: resSchema,
+						objectType: privilege.Schema,
+					})
 			default:
 				return nil, pgerror.Newf(pgcode.InvalidSchemaName,
 					"cannot change privileges on schema %q", resSchema.GetName())
@@ -522,7 +556,7 @@ func getDescriptorsFromTargetListForPrivilegeChange(
 	if len(targets.Tables.TablePatterns) == 0 {
 		return nil, errNoTable
 	}
-	descs := make([]catalog.Descriptor, 0, len(targets.Tables.TablePatterns))
+	descs := make([]DescriptorWithObjectType, 0, len(targets.Tables.TablePatterns))
 	for _, tableTarget := range targets.Tables.TablePatterns {
 		tableGlob, err := tableTarget.NormalizeTablePattern()
 		if err != nil {
@@ -538,16 +572,26 @@ func getDescriptorsFromTargetListForPrivilegeChange(
 		}
 		for _, mut := range muts {
 			if mut != nil && mut.DescriptorType() == catalog.Table {
-				if targets.Tables.IsSequence {
-					tableDesc, err := catalog.AsTableDescriptor(mut)
-					if err != nil {
-						return nil, err
-					}
-					if tableDesc.IsSequence() {
-						descs = append(descs, mut)
-					}
+				tableDesc, err := catalog.AsTableDescriptor(mut)
+				if err != nil {
+					return nil, err
+				}
+				if tableDesc.IsSequence() {
+					descs = append(
+						descs,
+						DescriptorWithObjectType{
+							descriptor: mut,
+							objectType: privilege.Sequence,
+						},
+					)
 				} else {
-					descs = append(descs, mut)
+					descs = append(
+						descs,
+						DescriptorWithObjectType{
+							descriptor: mut,
+							objectType: privilege.Table,
+						},
+					)
 				}
 			}
 		}

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -1533,8 +1533,8 @@ SELECT description
 			privs, err := parsePrivilegeStr(args[1], privMap{
 				// Sequences and other table objects cannot be given a USAGE privilege,
 				// so we check for SELECT here instead. See privilege.TablePrivileges.
-				"USAGE":                    {Kind: privilege.SELECT},
-				"USAGE WITH GRANT OPTION":  {Kind: privilege.SELECT, GrantOption: true},
+				"USAGE":                    {Kind: privilege.USAGE},
+				"USAGE WITH GRANT OPTION":  {Kind: privilege.USAGE, GrantOption: true},
 				"SELECT":                   {Kind: privilege.SELECT},
 				"SELECT WITH GRANT OPTION": {Kind: privilege.SELECT, GrantOption: true},
 				"UPDATE":                   {Kind: privilege.UPDATE},

--- a/pkg/sql/sem/tree/grant.go
+++ b/pkg/sql/sem/tree/grant.go
@@ -77,7 +77,7 @@ func (tl *TargetList) Format(ctx *FmtCtx) {
 			ctx.FormatNode(typ)
 		}
 	} else {
-		if tl.Tables.IsSequence {
+		if tl.Tables.SequenceOnly {
 			ctx.WriteString("SEQUENCE ")
 		} else {
 			ctx.WriteString("TABLE ")

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -2145,7 +2145,7 @@ func (node *TargetList) docRow(p *PrettyCfg) pretty.TableRow {
 	if node.TenantID.Specified {
 		return p.row("TENANT", p.Doc(&node.TenantID))
 	}
-	if node.Tables.IsSequence {
+	if node.Tables.SequenceOnly {
 		return p.row("SEQUENCE", p.Doc(&node.Tables.TablePatterns))
 	}
 	return p.row("TABLE", p.Doc(&node.Tables.TablePatterns))

--- a/pkg/sql/sem/tree/table_pattern.go
+++ b/pkg/sql/sem/tree/table_pattern.go
@@ -72,10 +72,10 @@ func (at *AllTablesSelector) NormalizeTablePattern() (TablePattern, error) { ret
 // Used by e.g. the GRANT statement.
 type TablePatterns []TablePattern
 
-// TableAttrs saves the table petterns and a bool field IsSequence that shows
+// TableAttrs saves the table petterns and a bool field SequenceOnly that shows
 // if all tables are sequences.
 type TableAttrs struct {
-	IsSequence    bool
+	SequenceOnly  bool
 	TablePatterns TablePatterns
 }
 


### PR DESCRIPTION
Currently, the `GRANT ... ON names` syntax by default take all the target
as table, while in Postgres 14, the `names` field accepts names for both
table and sequence. This commit is to add similar sementics.

Given that a table's privilege list is the subset of a sequence's, if the
targets list contains any table, the allowed privilege should be the table
privilege. Only when all targets are of the type sequence, the allowed list
is the sequence privilege.

Since the target list may contain both tables and sequences, when validating,
we need to sepcify the privilege type for each target descriptor.

fixes #82414
fixes #82465

Release note (sql): add logic for GRANT ... ON seq_names