### PR TITLE
idxusage: no index recommendations for system table and primary indexes

### DIFF
--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -2657,8 +2657,9 @@ func TestDatabaseAndTableIndexRecommendations(t *testing.T) {
 	db := sqlutils.MakeSQLRunner(sqlDB)
 	db.Exec(t, "CREATE DATABASE test")
 	db.Exec(t, "USE test")
-	// Create a table, the statistics on its primary index will be fetched.
+	// Create a table and secondary index.
 	db.Exec(t, "CREATE TABLE test.test_table (num INT PRIMARY KEY, letter char)")
+	db.Exec(t, "CREATE INDEX test_idx ON test.test_table (letter)")
 
 	// Test when last read does not exist and there is no creation time. Expect
 	// an index recommendation (index never used).
@@ -2674,6 +2675,7 @@ func TestDatabaseAndTableIndexRecommendations(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
+	// Expect 1 index recommendation (no index recommendation on primary index).
 	require.Equal(t, int32(1), dbDetails.Stats.NumIndexRecommendations)
 
 	// Test table details endpoint.

--- a/pkg/server/index_usage_stats.go
+++ b/pkg/server/index_usage_stats.go
@@ -314,7 +314,7 @@ func getTableIndexUsageStats(
 			Row:              idxStatsRow,
 			UnusedIndexKnobs: execConfig.UnusedIndexRecommendationsKnobs,
 		}
-		recommendations := statsRow.GetRecommendationsFromIndexStats(st)
+		recommendations := statsRow.GetRecommendationsFromIndexStats(req.Database, st)
 		idxRecommendations = append(idxRecommendations, recommendations...)
 		idxUsageStats = append(idxUsageStats, idxStatsRow)
 	}

--- a/pkg/sql/idxusage/index_usage_stats_rec.go
+++ b/pkg/sql/idxusage/index_usage_stats_rec.go
@@ -61,9 +61,12 @@ func (*UnusedIndexRecommendationTestingKnobs) ModuleTestingKnobs() {}
 // GetRecommendationsFromIndexStats gets index recommendations from the given index
 // if applicable.
 func (i IndexStatsRow) GetRecommendationsFromIndexStats(
-	st *cluster.Settings,
+	dbName string, st *cluster.Settings,
 ) []*serverpb.IndexRecommendation {
-	var recommendations []*serverpb.IndexRecommendation
+	var recommendations = []*serverpb.IndexRecommendation{}
+	if dbName == "system" || i.Row.IndexType == "primary" {
+		return recommendations
+	}
 	rec := i.maybeAddUnusedIndexRecommendation(DropUnusedIndexDuration.Get(&st.SV))
 	if rec != nil {
 		recommendations = append(recommendations, rec)


### PR DESCRIPTION
Resolves: #79979
Previously, index recommendations were being provided to the system
table and to primary indexes. This change prevents this from occuring.

Release note: None