### PR TITLE
outliers: latency quantile detector

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -51,6 +51,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessionphase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/outliers"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/sslocal"
 	"github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics"
@@ -337,6 +338,9 @@ type ServerMetrics struct {
 	// ContentionSubsystemMetrics contains metrics related to contention
 	// subsystem.
 	ContentionSubsystemMetrics txnidcache.Metrics
+
+	// OutliersMetrics contains metrics related to outlier detection.
+	OutliersMetrics outliers.Metrics
 }
 
 // NewServer creates a new Server. Start() needs to be called before the Server
@@ -350,6 +354,7 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 		sqlstats.MaxMemReportedSQLStatsTxnFingerprints,
 		serverMetrics.StatsMetrics.ReportedSQLStatsMemoryCurBytesCount,
 		serverMetrics.StatsMetrics.ReportedSQLStatsMemoryMaxBytesHist,
+		serverMetrics.OutliersMetrics,
 		pool,
 		nil, /* reportedProvider */
 		cfg.SQLStatsTestingKnobs,
@@ -362,6 +367,7 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 		sqlstats.MaxMemSQLStatsTxnFingerprints,
 		serverMetrics.StatsMetrics.SQLStatsMemoryCurBytesCount,
 		serverMetrics.StatsMetrics.SQLStatsMemoryMaxBytesHist,
+		serverMetrics.OutliersMetrics,
 		pool,
 		reportedSQLStats,
 		cfg.SQLStatsTestingKnobs,
@@ -475,6 +481,7 @@ func makeServerMetrics(cfg *ExecutorConfig) ServerMetrics {
 			),
 		},
 		ContentionSubsystemMetrics: txnidcache.NewMetrics(),
+		OutliersMetrics:            outliers.NewMetrics(),
 	}
 }
 

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -433,6 +433,7 @@ func (s *Server) Metrics() (res []interface{}) {
 		&s.SQLServer.InternalMetrics.GuardrailMetrics,
 		&s.SQLServer.ServerMetrics.StatsMetrics,
 		&s.SQLServer.ServerMetrics.ContentionSubsystemMetrics,
+		&s.SQLServer.ServerMetrics.OutliersMetrics,
 	}
 }
 

--- a/pkg/sql/sqlstats/outliers/BUILD.bazel
+++ b/pkg/sql/sqlstats/outliers/BUILD.bazel
@@ -17,9 +17,12 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/sql/clusterunique",
         "//pkg/util/cache",
+        "//pkg/util/metric",
+        "//pkg/util/quantile",
         "//pkg/util/syncutil",
         "//pkg/util/uint128",
         "//pkg/util/uuid",
+        "@com_github_prometheus_client_model//go",
     ],
 )
 

--- a/pkg/sql/sqlstats/outliers/outliers.go
+++ b/pkg/sql/sqlstats/outliers/outliers.go
@@ -12,15 +12,18 @@ package outliers
 
 import (
 	"context"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
 	"github.com/cockroachdb/cockroach/pkg/util/cache"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	prometheus "github.com/prometheus/client_model/go"
 )
 
 // LatencyThreshold configures the execution time beyond which a statement is
@@ -34,6 +37,89 @@ var LatencyThreshold = settings.RegisterDurationSetting(
 	"amount of time after which an executing statement is considered an outlier. Use 0 to disable.",
 	0,
 )
+
+// LatencyQuantileDetectorEnabled turns on a per-fingerprint heuristic-based
+// algorithm for marking statements as outliers, attempting to capture elevated
+// p99 latency while generally excluding uninteresting executions less than
+// 100ms.
+var LatencyQuantileDetectorEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
+	"sql.stats.outliers.experimental.latency_quantile_detection.enabled",
+	"enable per-fingerprint latency recording and outlier detection",
+	false,
+)
+
+// LatencyQuantileDetectorInterestingThreshold sets the bar above which
+// statements are considered "interesting" from an outliers perspective. A
+// statement's latency must first cross this threshold before we begin tracking
+// further execution latencies for its fingerprint (this is a memory
+// optimization), and any potential outlier execution must also cross this
+// threshold to be reported (this is a UX optimization, removing noise).
+var LatencyQuantileDetectorInterestingThreshold = settings.RegisterDurationSetting(
+	settings.TenantWritable,
+	"sql.stats.outliers.experimental.latency_quantile_detection.interesting_threshold",
+	"statements must surpass this threshold to trigger outlier detection and identification",
+	100*time.Millisecond,
+	settings.NonNegativeDuration,
+)
+
+// LatencyQuantileDetectorMemoryCap restricts the overall memory available for
+// tracking per-statement execution latencies. When changing this setting, keep
+// an eye on the metrics for memory usage and evictions to avoid introducing
+// churn.
+var LatencyQuantileDetectorMemoryCap = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
+	"sql.stats.outliers.experimental.latency_quantile_detection.memory_limit",
+	"the maximum amount of memory allowed for tracking statement latencies",
+	1024*1024,
+	settings.NonNegativeInt,
+)
+
+// Metrics holds running measurements of various outliers-related runtime stats.
+type Metrics struct {
+	// Fingerprints measures the number of statement fingerprints being monitored for
+	// outlier detection.
+	Fingerprints *metric.Gauge
+
+	// Memory measures the memory used in support of outlier detection.
+	Memory *metric.Gauge
+
+	// Evictions counts fingerprint latency summaries discarded due to memory
+	// pressure.
+	Evictions *metric.Counter
+}
+
+// MetricStruct marks Metrics for automatic member metric registration.
+func (Metrics) MetricStruct() {}
+
+var _ metric.Struct = Metrics{}
+
+// NewMetrics builds a new instance of our Metrics struct.
+func NewMetrics() Metrics {
+	return Metrics{
+		Fingerprints: metric.NewGauge(metric.Metadata{
+			Name:        "sql.stats.outliers.latency_quantile_detector.fingerprints",
+			Help:        "Current number of statement fingerprints being monitored for outlier detection",
+			Measurement: "Fingerprints",
+			Unit:        metric.Unit_COUNT,
+			MetricType:  prometheus.MetricType_GAUGE,
+		}),
+		Memory: metric.NewGauge(metric.Metadata{
+			Name:        "sql.stats.outliers.latency_quantile_detector.memory",
+			Help:        "Current memory used to support outlier detection",
+			Measurement: "Memory",
+			Unit:        metric.Unit_BYTES,
+			MetricType:  prometheus.MetricType_GAUGE,
+		}),
+		Evictions: metric.NewCounter(metric.Metadata{
+			Name:        "sql.stats.outliers.latency_quantile_detector.evictions",
+			Help:        "Evictions of fingerprint latency summaries due to memory pressure",
+			Measurement: "Evictions",
+			Unit:        metric.Unit_COUNT,
+			MetricType:  prometheus.MetricType_COUNTER,
+		}),
+	}
+}
 
 // maxCacheSize is the number of detected outliers we will retain in memory.
 // We choose a small value for the time being to allow us to iterate without
@@ -59,14 +145,18 @@ type Registry struct {
 }
 
 // New builds a new Registry.
-func New(st *cluster.Settings) *Registry {
+func New(st *cluster.Settings, metrics Metrics) *Registry {
 	config := cache.Config{
 		Policy: cache.CacheFIFO,
 		ShouldEvict: func(size int, key, value interface{}) bool {
 			return size > maxCacheSize
 		},
 	}
-	r := &Registry{detector: anyDetector{detectors: []detector{latencyThresholdDetector{st: st}}}}
+	r := &Registry{
+		detector: anyDetector{detectors: []detector{
+			latencyThresholdDetector{st: st},
+			newLatencyQuantileDetector(st, metrics),
+		}}}
 	r.mu.statements = make(map[clusterunique.ID][]*Outlier_Statement)
 	r.mu.outliers = cache.NewUnorderedCache(config)
 	return r
@@ -119,6 +209,11 @@ func (r *Registry) ObserveTransaction(sessionID clusterunique.ID, txnID uuid.UUI
 	}
 }
 
+// TODO(todd):
+//   Once we can handle sufficient throughput to live on the hot
+//   execution path in #81021, we can probably get rid of this external
+//   concept of "enabled" and let the detectors just decide for themselves
+//   internally.
 func (r *Registry) enabled() bool {
 	return r.detector.enabled()
 }

--- a/pkg/sql/sqlstats/outliers/outliers_test.go
+++ b/pkg/sql/sqlstats/outliers/outliers_test.go
@@ -36,7 +36,7 @@ func TestOutliers(t *testing.T) {
 	t.Run("detection", func(t *testing.T) {
 		st := cluster.MakeTestingClusterSettings()
 		outliers.LatencyThreshold.Override(ctx, &st.SV, 1*time.Second)
-		registry := outliers.New(st)
+		registry := outliers.New(st, outliers.NewMetrics())
 		registry.ObserveStatement(sessionID, stmtID, stmtFptID, 2)
 		registry.ObserveTransaction(sessionID, txnID)
 
@@ -68,7 +68,7 @@ func TestOutliers(t *testing.T) {
 	t.Run("disabled", func(t *testing.T) {
 		st := cluster.MakeTestingClusterSettings()
 		outliers.LatencyThreshold.Override(ctx, &st.SV, 0)
-		registry := outliers.New(st)
+		registry := outliers.New(st, outliers.NewMetrics())
 		registry.ObserveStatement(sessionID, stmtID, stmtFptID, 2)
 		registry.ObserveTransaction(sessionID, txnID)
 
@@ -85,7 +85,7 @@ func TestOutliers(t *testing.T) {
 	t.Run("too fast", func(t *testing.T) {
 		st := cluster.MakeTestingClusterSettings()
 		outliers.LatencyThreshold.Override(ctx, &st.SV, 1*time.Second)
-		registry := outliers.New(st)
+		registry := outliers.New(st, outliers.NewMetrics())
 		registry.ObserveStatement(sessionID, stmtID, stmtFptID, 0.5)
 		registry.ObserveTransaction(sessionID, txnID)
 
@@ -107,7 +107,7 @@ func TestOutliers(t *testing.T) {
 
 		st := cluster.MakeTestingClusterSettings()
 		outliers.LatencyThreshold.Override(ctx, &st.SV, 1*time.Second)
-		registry := outliers.New(st)
+		registry := outliers.New(st, outliers.NewMetrics())
 		registry.ObserveStatement(sessionID, stmtID, stmtFptID, 2)
 		registry.ObserveStatement(otherSessionID, otherStmtID, otherStmtFptID, 3)
 		registry.ObserveTransaction(sessionID, txnID)

--- a/pkg/sql/sqlstats/sslocal/BUILD.bazel
+++ b/pkg/sql/sqlstats/sslocal/BUILD.bazel
@@ -57,6 +57,7 @@ go_test(
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessionphase",
         "//pkg/sql/sqlstats",
+        "//pkg/sql/sqlstats/outliers",
         "//pkg/sql/sqlstats/persistedsqlstats",
         "//pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil",
         "//pkg/sql/tests",

--- a/pkg/sql/sqlstats/sslocal/sql_stats.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats.go
@@ -76,6 +76,7 @@ func newSQLStats(
 	uniqueTxnFingerprintLimit *settings.IntSetting,
 	curMemBytesCount *metric.Gauge,
 	maxMemBytesHist *metric.Histogram,
+	outliersMetrics outliers.Metrics,
 	parentMon *mon.BytesMonitor,
 	flushTarget Sink,
 	knobs *sqlstats.TestingKnobs,
@@ -95,7 +96,7 @@ func newSQLStats(
 		uniqueTxnFingerprintLimit:  uniqueTxnFingerprintLimit,
 		flushTarget:                flushTarget,
 		knobs:                      knobs,
-		outliers:                   outliers.New(st),
+		outliers:                   outliers.New(st, outliersMetrics),
 	}
 	s.mu.apps = make(map[string]*ssmemstorage.Container)
 	s.mu.mon = monitor

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessionphase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/outliers"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/sslocal"
@@ -440,6 +441,7 @@ func TestExplicitTxnFingerprintAccounting(t *testing.T) {
 		sqlstats.MaxMemSQLStatsTxnFingerprints,
 		nil, /* curMemoryBytesCount */
 		nil, /* maxMemoryBytesHist */
+		outliers.NewMetrics(),
 		monitor,
 		nil, /* reportingSink */
 		nil, /* knobs */
@@ -553,6 +555,7 @@ func TestAssociatingStmtStatsWithTxnFingerprint(t *testing.T) {
 			sqlstats.MaxMemSQLStatsTxnFingerprints,
 			nil,
 			nil,
+			outliers.NewMetrics(),
 			monitor,
 			nil,
 			nil,

--- a/pkg/sql/sqlstats/sslocal/sslocal_provider.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_provider.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/outliers"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/ssmemstorage"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -37,12 +38,13 @@ func New(
 	maxTxnFingerprints *settings.IntSetting,
 	curMemoryBytesCount *metric.Gauge,
 	maxMemoryBytesHist *metric.Histogram,
+	outliersMetrics outliers.Metrics,
 	pool *mon.BytesMonitor,
 	reportingSink Sink,
 	knobs *sqlstats.TestingKnobs,
 ) *SQLStats {
 	return newSQLStats(settings, maxStmtFingerprints, maxTxnFingerprints,
-		curMemoryBytesCount, maxMemoryBytesHist, pool,
+		curMemoryBytesCount, maxMemoryBytesHist, outliersMetrics, pool,
 		reportingSink, knobs)
 }
 

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -2155,6 +2155,22 @@ var charts = []sectionDescription{
 				Metrics: []string{"sql.stats.txn_stats_collection.duration"},
 			},
 		},
+	}, {
+		Organization: [][]string{{SQLLayer, "SQL Stats", "Outliers"}},
+		Charts: []chartDescription{
+			{
+				Title:   "Number of statement fingerprints being monitored for outlier detection",
+				Metrics: []string{"sql.stats.outliers.latency_quantile_detector.fingerprints"},
+			},
+			{
+				Title:   "Current memory used to support outlier detection",
+				Metrics: []string{"sql.stats.outliers.latency_quantile_detector.memory"},
+			},
+			{
+				Title:   "Evictions of fingerprint latency summaries due to memory pressure",
+				Metrics: []string{"sql.stats.outliers.latency_quantile_detector.evictions"},
+			},
+		},
 	},
 	{
 		Organization: [][]string{{SQLLayer, "Contention"}},

--- a/pkg/util/quantile/stream.go
+++ b/pkg/util/quantile/stream.go
@@ -33,6 +33,7 @@ package quantile
 import (
 	"math"
 	"sort"
+	"unsafe"
 )
 
 // Sample holds an observed value and meta information for compression. JSON
@@ -213,6 +214,14 @@ func (s *Stream) Samples() Samples {
 // since initialization.
 func (s *Stream) Count() int {
 	return len(s.b) + s.stream.count()
+}
+
+// ByteSize returns the total amount of memory used by the stream.
+func (s *Stream) ByteSize() int64 {
+	const s1 = int64(unsafe.Sizeof(Stream{}))
+	const s2 = int64(unsafe.Sizeof(stream{}))
+	const s3 = int64(unsafe.Sizeof(Sample{}))
+	return s1 + s2 + s3*int64(len(s.b)+len(s.l))
 }
 
 func (s *Stream) flush() {

--- a/pkg/util/quantile/stream_test.go
+++ b/pkg/util/quantile/stream_test.go
@@ -229,3 +229,27 @@ func TestDefaults(t *testing.T) {
 		t.Errorf("want 0, got %f", g)
 	}
 }
+
+func TestByteSize(t *testing.T) {
+	// Empty size is nonzero.
+	q := NewTargeted(Targets)
+	s0 := q.ByteSize()
+	if s0 <= 0 {
+		t.Errorf("want > 0, got %d", s0)
+	}
+
+	// Uncompressed size is greater than empty size.
+	for i := cap(q.b); i > 1; i-- {
+		q.Insert(float64(i))
+	}
+	s1 := q.ByteSize()
+	if s1 <= s0 {
+		t.Errorf("want > %d, got %d", s0, s1)
+	}
+
+	// Compressed size is less than uncompressed size.
+	q.Insert(float64(42))
+	if s := q.ByteSize(); s <= s0 || s1 <= s {
+		t.Errorf("want between (%d, %d), got %d", s0, s1, s)
+	}
+}


### PR DESCRIPTION
Closes #79451.

Note that this detector comes disabled by default. To enable, use the
`sql.stats.outliers.experimental.latency_quantile_detection.enabled`
cluster setting.

This new detection "algorithm" is a simple, perhaps naïve, heuristic,
though it may be good enough to be useful: we consider a statement an
outlier if its execution latency is > p99 latency for its fingerprint,
so long as it's also greater than twice the median latency and greater
than an arbitrary user-defined threshold.[^1]

We expect the operation of this detector to be memory constrained. To
avoid OOM errors, we offer a cluster setting[^2] to cap the overall
memory used, along with metrics reporting the number of fingerprints
being tracked, memory usage, and "evictions," or fingerprint histories
being dropped due to memory pressure. If a high rate of evictions is
observed, it will be necessary to raise either one or both of the memory
limit and the "interesting" threshold settings to regain a steady state.

Note also that this detector is not designed to be used concurrently by
multiple goroutines. Correctness currently relies on the global lock in
`outliers.Registry`, to be addressed next in #81021.

[^1]: This threshold is defined by a cluster setting,
`sql.stats.outliers.experimental.latency_quantile_detection.interesting_threshold`.
Without such a threshold, we would otherwise flag a statement that, say,
normally executes in 3ms taking 7ms; but 7ms is probably still fast
enough that there's nothing to be done.

[^2]: `sql.stats.outliers.experimental.latency_quantile_detection.memory_limit`

Release note: None