### PR TITLE
sql: disallow adding column as primary key

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -188,6 +188,10 @@ func (n *alterTableNode) startExec(params runParams) error {
 						"UNIQUE WITHOUT INDEX constraint on the column",
 				)
 			}
+			if t.ColumnDef.PrimaryKey.IsPrimaryKey {
+				return pgerror.Newf(pgcode.InvalidColumnDefinition,
+					"multiple primary keys for table %q are not allowed", tn.Object())
+			}
 			var err error
 			params.p.runWithOptions(resolveFlags{contextDatabaseID: n.tableDesc.ParentID}, func() {
 				err = params.p.addColumnImpl(params, n, tn, n.tableDesc, t)

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -2593,3 +2593,14 @@ CREATE INDEX idx_j ON t_add_column_not_null (j);
 
 statement ok
 DROP TABLE t_add_column_not_null
+
+subtest regression_81448
+
+statement ok
+CREATE TABLE t81448 (a INT PRIMARY KEY)
+
+statement error pq: multiple primary keys for table "t81448" are not allowed
+ALTER TABLE t81448 ADD COLUMN b INT PRIMARY KEY
+
+statement ok
+DROP TABLE t81448


### PR DESCRIPTION
Previously, the behavior of ALTER TABLE ... ADD COLUMN ... PRIMARY KEY
was undefined. With the legacy schema changer, this statement would
appear to succeed, but it would break the new schema changer. This
commit changes this by returning an explicit error.

In the future, we should support this statement if the table's primary
key was originally the default rowid primary key (see #82735).

Fixes #82489

Release note: None