### PR TITLE
sql: soften AOST check to be a pgerror

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/as_of
+++ b/pkg/ccl/logictestccl/testdata/logic_test/as_of
@@ -29,6 +29,9 @@ BEGIN AS OF SYSTEM TIME follower_read_timestamp(); SELECT * FROM t
 statement ok
 ROLLBACK
 
+statement error pgcode 0A000 cannot specify AS OF SYSTEM TIME with different timestamps
+SELECT * from t AS OF SYSTEM TIME '-1μs'; SELECT * from t AS OF SYSTEM TIME '-2μs'
+
 statement ok
 SET DEFAULT_TRANSACTION_USE_FOLLOWER_READS TO TRUE
 

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -776,9 +776,11 @@ func (ex *connExecutor) handleAOST(ctx context.Context, stmt tree.Statement) err
 			}
 			return errors.AssertionFailedf("expected bounded_staleness set with a max_timestamp_bound")
 		}
-		return errors.AssertionFailedf(
+		return pgerror.Newf(
+			pgcode.FeatureNotSupported,
 			"cannot specify AS OF SYSTEM TIME with different timestamps. expected: %s, got: %s",
-			p.extendedEvalCtx.AsOfSystemTime.Timestamp, asOf.Timestamp,
+			p.extendedEvalCtx.AsOfSystemTime.Timestamp,
+			asOf.Timestamp,
 		)
 	}
 	// If we're in an explicit txn, we allow AOST but only if it matches with

--- a/pkg/sql/pgwire/testdata/pgtest/as_of_system_time
+++ b/pkg/sql/pgwire/testdata/pgtest/as_of_system_time
@@ -63,6 +63,29 @@ ReadyForQuery
 {"Type":"CommandComplete","CommandTag":"SELECT 0"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
+# Make sure two AOSTs in the same txn errors as appropriate.
+send
+Parse {"Name": "parse1", "Query": "SELECT * FROM tab AS OF SYSTEM TIME '-1us'"}
+Bind {"DestinationPortal": "aostportal1", "PreparedStatement": "parse1"}
+Execute {"Portal": "aostportal1"}
+Parse {"Name": "parse2", "Query": "SELECT * FROM tab AS OF SYSTEM TIME '-4us'"}
+Bind {"DestinationPortal": "aostportal2", "PreparedStatement": "parse2"}
+Execute {"Portal": "aostportal2"}
+Sync
+----
+
+until
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"1"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ErrorResponse","Code":"0A000"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+
 # Make sure AOST is handled consistently during Bind/Execute. This also should
 # not be able to see the data in the table, since this is a historical read.
 send


### PR DESCRIPTION
Resolves #82179

Release note (bug fix): Previously, using AS OF SYSTEM TIME of two
different statements in the same line would result in an assertion
error. This is now a PG error with code 0A000.