### PR TITLE
sql/logictest: fix trigram_indexes flake

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/trigram_indexes
+++ b/pkg/sql/logictest/testdata/logic_test/trigram_indexes
@@ -25,7 +25,7 @@ INSERT INTO a VALUES (1, 'foozoopa'),
                      (2, 'Foo'),
                      (3, 'blah')
 
-query IT
+query IT rowsort
 SELECT * FROM a@a_t_idx WHERE t ILIKE '%Foo%'
 ----
 1  foozoopa


### PR DESCRIPTION
See failures like [this](https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_UnitTests/5393754?showRootCauses=false&expandBuildChangesSection=true&expandBuildProblemsSection=true&expandBuildTestsSection=true).

Release note: None