### PR TITLE
stats: fix flaky test TestDefaultColumns

### DIFF
--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -681,7 +681,8 @@ func TestDefaultColumns(t *testing.T) {
 	sqlRun := sqlutils.MakeSQLRunner(sqlDB)
 	sqlRun.Exec(t,
 		`CREATE DATABASE t;
-		CREATE TABLE t.a (c0 INT PRIMARY KEY);`)
+		CREATE TABLE t.a (c0 INT PRIMARY KEY)
+		WITH (sql_stats_automatic_collection_enabled = false);`)
 
 	for i := 1; i < 110; i++ {
 		// Add more columns than we will collect stats on.
@@ -690,17 +691,6 @@ func TestDefaultColumns(t *testing.T) {
 	}
 
 	sqlRun.Exec(t, `CREATE STATISTICS s FROM t.a`)
-
-	// TODO(rytaft): this extra logging was added to help debug issue #81513.
-	// Remove it once that issue is resolved.
-	// === BEGINNING OF EXTRA LOGGING ===
-	res := sqlRun.QueryStr(t, `SHOW CREATE TABLE t.a`)
-	t.Log(sqlutils.MatrixToStr(res))
-	res = sqlRun.QueryStr(t, `EXPLAIN (DISTSQL) CREATE STATISTICS s FROM t.a`)
-	t.Log(sqlutils.MatrixToStr(res))
-	res = sqlRun.QueryStr(t, `SHOW STATISTICS FOR TABLE t.a`)
-	t.Log(sqlutils.MatrixToStr(res))
-	// === END OF EXTRA LOGGING ===
 
 	// There should be 101 stats. One for the primary index, plus 100 other
 	// columns.


### PR DESCRIPTION
TestDefaultColumns creates statistics on a table with 110 columns
using the command `CREATE STATISTICS s FROM t.a`. It then checks
that there are exactly 101 column statistics on table t.a with
statistics_name = 's' (one stat for the primary index, plus 100
other column stats). However, this test may be flaky if automatic
statistics are running, since each new automatic stat will cause
other stats to be deleted.

Although the test disables automatic stats at the beginning, it seems
that some sort of race condition may cause it to be reenabled. This
commit fixes the problem by disabling automatic stats using the new table
level settings, ensuring that the 101 column stats are not deleted after
they have been created.

Fixes #81513

Release note: None