### PR TITLE
cli,sql: fix reported result columns for EXPLAIN ANALYZE

### DIFF
--- a/pkg/cli/interactive_tests/test_explain_analyze.tcl
+++ b/pkg/cli/interactive_tests/test_explain_analyze.tcl
@@ -1,0 +1,26 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_server $argv
+
+start_test "Ensure that EXPLAIN ANALYZE works as expected in the sql shell"
+
+# Spawn a sql shell.
+spawn $argv sql
+set client_spawn_id $spawn_id
+eexpect root@
+
+# Check for a regression where the CLI would get confused when the statement
+# had a different number of result columns.
+send "EXPLAIN ANALYZE SELECT 1,2;\r"
+eexpect "info"
+eexpect "planning time"
+eexpect "actual row count"
+
+send_eof
+eexpect eof
+
+end_test
+
+stop_server $argv

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3004,7 +3004,10 @@ func (ex *connExecutor) initStatementResult(
 			return err
 		}
 	}
-	if ast.StatementReturnType() == tree.Rows {
+	// If the output mode has been modified by instrumentation (e.g. EXPLAIN
+	// ANALYZE), then the columns will be set later.
+	if ex.planner.instrumentation.outputMode == unmodifiedOutput &&
+		ast.StatementReturnType() == tree.Rows {
 		// Note that this call is necessary even if cols is nil.
 		res.SetColumns(ctx, cols)
 	}


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/82502

This fixes an issue where EXPLAIN ANALYZE would report a RowDescription
for both the EXPLAIN and for the statement being explained. If the
statement had a different number of result columns, this would confuse
the CLI.

No release note, since this bug was not released.

Release note: None