### PR TITLE
roachtest: fix a minor bug with tpch_concurrency roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/tpch_concurrency.go
+++ b/pkg/cmd/roachtest/tests/tpch_concurrency.go
@@ -118,7 +118,7 @@ func registerTPCHConcurrency(r registry.Registry) {
 				// diagram of the query.
 				rows, err := conn.Query("EXPLAIN (DISTSQL) " + tpch.QueriesByNumber[queryNum])
 				if err != nil {
-					t.Fatal(err)
+					return err
 				}
 				defer rows.Close()
 				for rows.Next() {


### PR DESCRIPTION
`tpch_concurrency` pushes the cluster to its limits, so it is expected
that OOMs occur. Previously, in a recently added code path, we would
fail the test if an error occurred when running a debugging statement,
yet that error is expected and should be returned.

Fixes: #82510.

Release note: None