### PR TITLE
builtins: implement to_timestamp for Unix epoch

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -655,6 +655,14 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><a name="to_char"></a><code>to_char(timestamp: <a href="timestamp.html">timestamp</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Convert an timestamp to a string assuming the ISO, MDY DateStyle.</p>
 </span></td></tr>
+<tr><td><a name="to_timestamp"></a><code>to_timestamp(timestamp: <a href="decimal.html">decimal</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Convert Unix epoch (seconds since 1970-01-01 00:00:00+00) to timestamp with time zone.</p>
+</span></td></tr>
+<tr><td><a name="to_timestamp"></a><code>to_timestamp(timestamp: <a href="float.html">float</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Convert Unix epoch (seconds since 1970-01-01 00:00:00+00) to timestamp with time zone.</p>
+</span></td></tr>
+<tr><td><a name="to_timestamp"></a><code>to_timestamp(timestamp: <a href="int.html">int</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Convert Unix epoch (seconds since 1970-01-01 00:00:00+00) to timestamp with time zone.</p>
+</span></td></tr>
+<tr><td><a name="to_timestamp"></a><code>to_timestamp(timestamp: <a href="string.html">string</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Convert Unix epoch (seconds since 1970-01-01 00:00:00+00) to timestamp with time zone.</p>
+</span></td></tr>
 <tr><td><a name="transaction_timestamp"></a><code>transaction_timestamp() &rarr; <a href="date.html">date</a></code></td><td><span class="funcdesc"><p>Returns the time of the current transaction.</p>
 <p>The value is based on a timestamp picked when the transaction starts
 and which stays constant throughout the transaction. This timestamp

--- a/pkg/sql/logictest/testdata/logic_test/timestamp
+++ b/pkg/sql/logictest/testdata/logic_test/timestamp
@@ -516,3 +516,86 @@ SELECT date_trunc('day', t), date_trunc('hour', t) FROM (VALUES
 ----
 2020-10-25 00:00:00 +0300 EEST  2020-10-25 03:00:00 +0300 EEST
 2020-10-25 00:00:00 +0300 EEST  2020-10-25 03:00:00 +0200 EET
+
+
+# Test for to_timestamp
+statement ok
+SET TIME ZONE 'UTC'
+
+## Test for to_timestamp without implicit type conversion
+query T
+SELECT to_timestamp(1646906263.123456)
+----
+2022-03-10 09:57:43.123456 +0000 UTC
+
+query T
+SELECT to_timestamp('1646906263.123456')
+----
+2022-03-10 09:57:43.123456 +0000 UTC
+
+## Test for to_timestamp with implicit type conversion to int
+query T
+SELECT to_timestamp(1646906263.123456::INT)
+----
+2022-03-10 09:57:43 +0000 UTC
+
+query T
+SELECT to_timestamp(32767::INT2)
+----
+1970-01-01 09:06:07 +0000 UTC
+
+query T
+SELECT to_timestamp(1646906263.123456::INT4)
+----
+2022-03-10 09:57:43 +0000 UTC
+
+query T
+SELECT to_timestamp(1646906263.123456::INT8)
+----
+2022-03-10 09:57:43 +0000 UTC
+
+## Test for to_timestamp with implicit type conversion to float
+query T
+SELECT to_timestamp(1646906263.123456::FLOAT)
+----
+2022-03-10 09:57:43.123456 +0000 UTC
+
+query T
+SELECT to_timestamp(1646906263.123456::REAL)
+----
+2022-03-10 09:57:43.123456 +0000 UTC
+
+query T
+SELECT to_timestamp(1646906263.123456::DOUBLE PRECISION)
+----
+2022-03-10 09:57:43.123456 +0000 UTC
+
+## Test for to_timestamp with implicit type conversion to decimal
+query T
+SELECT to_timestamp(1646906263.123456::DECIMAL)
+----
+2022-03-10 09:57:43.123456 +0000 UTC
+
+## Test for to_timestamp with positive and negative infinities
+query T
+SELECT to_timestamp('infinity'::DECIMAL)
+----
+294276-12-31 23:59:59.999999 +0000 UTC
+
+query T
+SELECT to_timestamp('-infinity'::DECIMAL)
+----
+-4713-11-24 00:00:00 +0000 UTC
+
+## Test for to_timestamp with NULL
+query T
+SELECT to_timestamp(NULL)
+----
+NULL
+
+## Test for invalid inputs
+statement error to_timestamp\(\): invalid input for type text
+SELECT to_timestamp('invalid')
+
+statement error unknown signature: to_timestamp\(\)
+SELECT to_timestamp()


### PR DESCRIPTION
fixes #77591

Previously, CockroachDB did not support to_timestamp(double precision)
In PostgreSQL, the function also handles INT, DECIMAL and text by casting,
so the commit also implements those for compatibility.

Release note (sql change): Add new function to_timestamp which
converts Unix epoch of FLOAT, INT, DECIMAL and text to Timestamp with time zone.