### PR TITLE
sql/sem/builtins: fix span double finish

### DIFF
--- a/pkg/sql/sem/builtins/generator_probe_ranges.go
+++ b/pkg/sql/sem/builtins/generator_probe_ranges.go
@@ -146,16 +146,14 @@ func makeProbeRangeGenerator(ctx *eval.Context, args tree.Datums) (eval.ValueGen
 			tracing.WithForceRealSpan(),
 		)
 		sp.SetRecordingType(tracingpb.RecordingVerbose)
-		defer func() {
-			sp.Finish()
-		}()
+		defer sp.Finish()
 		// Handle args passed in.
 		ranges, err = kvclient.ScanMetaKVs(ctx, txn, roachpb.Span{
 			Key:    keys.MinKey,
 			EndKey: keys.MaxKey,
 		})
 		if err != nil {
-			return nil, errors.Wrapf(err, "%s", sp.FinishAndGetConfiguredRecording().String())
+			return nil, errors.Wrapf(err, "%s", sp.GetConfiguredRecording().String())
 		}
 	}
 	timeout := time.Duration(tree.MustBeDInterval(args[0]).Duration.Nanos())

--- a/pkg/sql/sem/builtins/generator_probe_ranges.go
+++ b/pkg/sql/sem/builtins/generator_probe_ranges.go
@@ -153,7 +153,9 @@ func makeProbeRangeGenerator(ctx *eval.Context, args tree.Datums) (eval.ValueGen
 			EndKey: keys.MaxKey,
 		})
 		if err != nil {
-			return nil, errors.Wrapf(err, "%s", sp.GetConfiguredRecording().String())
+			return nil, errors.WithDetailf(
+				errors.Wrapf(err, "error scanning meta ranges"),
+				"trace:\n%s", sp.GetConfiguredRecording())
 		}
 	}
 	timeout := time.Duration(tree.MustBeDInterval(args[0]).Duration.Nanos())

--- a/pkg/sql/sem/builtins/generator_probe_ranges.go
+++ b/pkg/sql/sem/builtins/generator_probe_ranges.go
@@ -123,9 +123,9 @@ type probeRangeGenerator struct {
 	ranges []kv.KeyValue
 }
 
-func makeProbeRangeGenerator(ctx *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
+func makeProbeRangeGenerator(evalCtx *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
 	// The user must be an admin to use this builtin.
-	isAdmin, err := ctx.SessionAccessor.HasAdminRole(ctx.Context)
+	isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
 	if err != nil {
 		return nil, err
 	}
@@ -140,14 +140,13 @@ func makeProbeRangeGenerator(ctx *eval.Context, args tree.Datums) (eval.ValueGen
 	// to be available, unless meta2 is down.
 	var ranges []kv.KeyValue
 	{
-		txn := ctx.Txn
 		ctx, sp := tracing.EnsureChildSpan(
-			ctx.Context, ctx.Tracer, "meta2scan",
+			evalCtx.Context, evalCtx.Tracer, "meta2scan",
 			tracing.WithRecording(tracingpb.RecordingVerbose),
 		)
 		defer sp.Finish()
 		// Handle args passed in.
-		ranges, err = kvclient.ScanMetaKVs(ctx, txn, roachpb.Span{
+		ranges, err = kvclient.ScanMetaKVs(ctx, evalCtx.Txn, roachpb.Span{
 			Key:    keys.MinKey,
 			EndKey: keys.MaxKey,
 		})
@@ -160,10 +159,10 @@ func makeProbeRangeGenerator(ctx *eval.Context, args tree.Datums) (eval.ValueGen
 	timeout := time.Duration(tree.MustBeDInterval(args[0]).Duration.Nanos())
 	isWrite := args[1].(*tree.DEnum).LogicalRep
 	return &probeRangeGenerator{
-		rangeProber: ctx.RangeProber,
+		rangeProber: evalCtx.RangeProber,
 		timeout:     timeout,
 		isWrite:     isWrite == "write",
-		tracer:      ctx.Tracer,
+		tracer:      evalCtx.Tracer,
 		ranges:      ranges,
 	}, nil
 }

--- a/pkg/sql/sem/builtins/generator_probe_ranges.go
+++ b/pkg/sql/sem/builtins/generator_probe_ranges.go
@@ -143,9 +143,8 @@ func makeProbeRangeGenerator(ctx *eval.Context, args tree.Datums) (eval.ValueGen
 		txn := ctx.Txn
 		ctx, sp := tracing.EnsureChildSpan(
 			ctx.Context, ctx.Tracer, "meta2scan",
-			tracing.WithForceRealSpan(),
+			tracing.WithRecording(tracingpb.RecordingVerbose),
 		)
-		sp.SetRecordingType(tracingpb.RecordingVerbose)
 		defer sp.Finish()
 		// Handle args passed in.
 		ranges, err = kvclient.ScanMetaKVs(ctx, txn, roachpb.Span{
@@ -196,9 +195,8 @@ func (p *probeRangeGenerator) Next(ctx context.Context) (bool, error) {
 	}
 	ctx, sp := tracing.EnsureChildSpan(
 		ctx, p.tracer, opName,
-		tracing.WithForceRealSpan(),
+		tracing.WithRecording(tracingpb.RecordingVerbose),
 	)
-	sp.SetRecordingType(tracingpb.RecordingVerbose)
 	defer func() {
 		p.curr.verboseTrace = sp.FinishAndGetConfiguredRecording().String()
 	}()


### PR DESCRIPTION
The tracing span was finished twice on the error path, which is illegal.

Release note: None