### PR TITLE
opt: fix inverted key column type in testcat

### DIFF
--- a/pkg/sql/catalog/tabledesc/index.go
+++ b/pkg/sql/catalog/tabledesc/index.go
@@ -170,7 +170,7 @@ func (w index) InvertedColumnName() string {
 }
 
 // InvertedColumnKeyType returns the type of the data element that is encoded
-// as the inverted index key. This is currently always Bytes.
+// as the inverted index key. This is currently always EncodedKey.
 //
 // Panics if the index is not inverted.
 func (w index) InvertedColumnKeyType() *types.T {

--- a/pkg/sql/opt/memo/testdata/stats/inverted-array
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-array
@@ -72,7 +72,7 @@ index-join t
       ├── stats: [rows=1020]
       ├── key: (1)
       └── scan t@a_idx
-           ├── columns: k:1(int!null) a_inverted_key:5(int[]!null)
+           ├── columns: k:1(int!null) a_inverted_key:5(encodedkey!null)
            ├── inverted constraint: /5/1
            │    └── spans: ["", ""]
            ├── flags: force-index=a_idx
@@ -120,7 +120,7 @@ index-join t
       ├── stats: [rows=20]
       ├── key: (1)
       └── scan t@a_idx
-           ├── columns: k:1(int!null) a_inverted_key:5(int[]!null)
+           ├── columns: k:1(int!null) a_inverted_key:5(encodedkey!null)
            ├── inverted constraint: /5/1
            │    └── spans: ["\x8a", "\x8c")
            ├── stats: [rows=20, distinct(1)=19.6078, null(1)=0, avgsize(1)=4, distinct(5)=2, null(5)=0, avgsize(5)=4]
@@ -183,7 +183,7 @@ select
  │         ├── stats: [rows=20]
  │         ├── key: (1)
  │         └── scan t@a_idx
- │              ├── columns: k:1(int!null) a_inverted_key:5(int[]!null)
+ │              ├── columns: k:1(int!null) a_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
  │              │         ├── ["C", "C"]
@@ -222,7 +222,7 @@ select
  │         ├── stats: [rows=30]
  │         ├── key: (1)
  │         └── scan t@a_idx
- │              ├── columns: k:1(int!null) a_inverted_key:5(int[]!null)
+ │              ├── columns: k:1(int!null) a_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
  │              │         ├── ["C", "C"]
@@ -267,7 +267,7 @@ select
  │         ├── stats: [rows=30]
  │         ├── key: (1)
  │         └── scan t@a_idx
- │              ├── columns: k:1(int!null) a_inverted_key:5(int[]!null)
+ │              ├── columns: k:1(int!null) a_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
  │              │         ├── ["C", "C"]

--- a/pkg/sql/opt/memo/testdata/stats/inverted-geo
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-geo
@@ -181,7 +181,7 @@ project
       │    │              ├── stats: [rows=1.4e-06]
       │    │              ├── key: (3)
       │    │              └── scan t@t_g_idx
-      │    │                   ├── columns: rowid:3(int!null) g_inverted_key:6(geometry!null)
+      │    │                   ├── columns: rowid:3(int!null) g_inverted_key:6(encodedkey!null)
       │    │                   ├── inverted constraint: /6/3
       │    │                   │    └── spans: ["B\xfd\xff\xff\xff\xff\xff\xff\xff\xff", "B\xfd\xff\xff\xff\xff\xff\xff\xff\xff"]
       │    │                   ├── stats: [rows=1.4e-06, distinct(3)=4e-07, null(3)=0, avgsize(3)=4, distinct(6)=1.4e-06, null(6)=0, avgsize(6)=4]
@@ -401,7 +401,7 @@ project
       │    │              ├── stats: [rows=1.42e-06]
       │    │              ├── key: (3)
       │    │              └── scan t@t_g_idx
-      │    │                   ├── columns: rowid:3(int!null) g_inverted_key:6(geometry!null)
+      │    │                   ├── columns: rowid:3(int!null) g_inverted_key:6(encodedkey!null)
       │    │                   ├── inverted constraint: /6/3
       │    │                   │    └── spans: ["B\xfd\xff\xff\xff\xff\xff\xff\xff\xff", "B\xfd\xff\xff\xff\xff\xff\xff\xff\xff"]
       │    │                   ├── stats: [rows=1.42e-06, distinct(3)=4e-07, null(3)=0, avgsize(3)=4, distinct(6)=1.42e-06, null(6)=0, avgsize(6)=4]
@@ -480,7 +480,7 @@ select
  │         ├── stats: [rows=100]
  │         ├── key: (3)
  │         └── scan t@t_g_idx
- │              ├── columns: rowid:3(int!null) g_inverted_key:6(geometry!null)
+ │              ├── columns: rowid:3(int!null) g_inverted_key:6(encodedkey!null)
  │              ├── inverted constraint: /6/3
  │              │    └── spans
  │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
@@ -522,7 +522,7 @@ project
       │         ├── stats: [rows=100]
       │         ├── key: (3)
       │         └── scan t@t_g_idx
-      │              ├── columns: rowid:3(int!null) g_inverted_key:6(geometry!null)
+      │              ├── columns: rowid:3(int!null) g_inverted_key:6(encodedkey!null)
       │              ├── inverted constraint: /6/3
       │              │    └── spans
       │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]

--- a/pkg/sql/opt/memo/testdata/stats/inverted-geo-multi-column
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-geo-multi-column
@@ -99,7 +99,7 @@ project
       │         ├── stats: [rows=60.78475]
       │         ├── key: (1)
       │         └── scan t@m
-      │              ├── columns: k:1(int!null) g_inverted_key:7(geometry!null)
+      │              ├── columns: k:1(int!null) g_inverted_key:7(encodedkey!null)
       │              ├── constraint: /3: [/'banana' - /'banana']
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -151,7 +151,7 @@ project
       │         ├── stats: [rows=60.78475]
       │         ├── key: (1)
       │         └── scan t@p,partial
-      │              ├── columns: k:1(int!null) g_inverted_key:8(geometry!null)
+      │              ├── columns: k:1(int!null) g_inverted_key:8(encodedkey!null)
       │              ├── inverted constraint: /8/1
       │              │    └── spans
       │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
@@ -214,7 +214,7 @@ project
       │         ├── stats: [rows=121.5695]
       │         ├── key: (1)
       │         └── scan t@m
-      │              ├── columns: k:1(int!null) g_inverted_key:7(geometry!null)
+      │              ├── columns: k:1(int!null) g_inverted_key:7(encodedkey!null)
       │              ├── constraint: /3
       │              │    ├── [/'apple' - /'apple']
       │              │    ├── [/'banana' - /'banana']
@@ -269,7 +269,7 @@ project
       │         ├── stats: [rows=121.5695]
       │         ├── key: (1)
       │         └── scan t@p,partial
-      │              ├── columns: k:1(int!null) g_inverted_key:9(geometry!null)
+      │              ├── columns: k:1(int!null) g_inverted_key:9(encodedkey!null)
       │              ├── inverted constraint: /9/1
       │              │    └── spans
       │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
@@ -332,7 +332,7 @@ project
       │         ├── stats: [rows=5.512417]
       │         ├── key: (1)
       │         └── scan t@mp,partial
-      │              ├── columns: k:1(int!null) g_inverted_key:10(geometry!null)
+      │              ├── columns: k:1(int!null) g_inverted_key:10(encodedkey!null)
       │              ├── constraint: /4: [/400 - /400]
       │              ├── inverted constraint: /10/1
       │              │    └── spans
@@ -388,7 +388,7 @@ project
       │         ├── stats: [rows=14.82863]
       │         ├── key: (1)
       │         └── scan t@mp,partial
-      │              ├── columns: k:1(int!null) g_inverted_key:10(geometry!null)
+      │              ├── columns: k:1(int!null) g_inverted_key:10(encodedkey!null)
       │              ├── constraint: /4
       │              │    ├── [/200 - /200]
       │              │    ├── [/300 - /300]

--- a/pkg/sql/opt/memo/testdata/stats/inverted-json
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-json
@@ -100,7 +100,7 @@ index-join t
       ├── stats: [rows=1110]
       ├── key: (1)
       └── scan t@j_idx
-           ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
+           ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
            ├── inverted constraint: /5/1
            │    └── spans
            │         ├── ["7\x00\x019", "7\x00\x019"]
@@ -172,7 +172,7 @@ index-join t
       ├── stats: [rows=110]
       ├── key: (1)
       └── scan t@j_idx
-           ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
+           ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
            ├── inverted constraint: /5/1
            │    └── spans
            │         ├── ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
@@ -203,7 +203,7 @@ index-join t
       ├── stats: [rows=1110]
       ├── key: (1)
       └── scan t@j_idx
-           ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
+           ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
            ├── inverted constraint: /5/1
            │    └── spans
            │         ├── ["7\x00\x018", "7\x00\x018"]
@@ -255,7 +255,7 @@ index-join t
       ├── stats: [rows=110]
       ├── key: (1)
       └── scan t@j_idx
-           ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
+           ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
            ├── inverted constraint: /5/1
            │    └── spans
            │         ├── ["7\x00\x03\x00\x01*\x04\x00", "7\x00\x03\x00\x01*\x04\x00"]
@@ -346,7 +346,7 @@ select
  │         ├── stats: [rows=110]
  │         ├── key: (1)
  │         └── scan t@j_idx
- │              ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
+ │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
  │              │         ├── ["7\x00\x019", "7\x00\x019"]
@@ -386,7 +386,7 @@ select
  │         ├── stats: [rows=120]
  │         ├── key: (1)
  │         └── scan t@j_idx
- │              ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
+ │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
  │              │         ├── ["7\x00\x019", "7\x00\x019"]
@@ -431,7 +431,7 @@ select
  │         ├── stats: [rows=120]
  │         ├── key: (1)
  │         └── scan t@j_idx
- │              ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
+ │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
  │              │         ├── ["7\x00\x019", "7\x00\x019"]
@@ -473,7 +473,7 @@ select
  │         ├── stats: [rows=110]
  │         ├── key: (1)
  │         └── scan t@j_idx
- │              ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
+ │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
  │              │         ├── ["7\x00\x01*\x04\x00", "7\x00\x01*\x04\x00"]
@@ -516,7 +516,7 @@ select
  │         ├── stats: [rows=120]
  │         ├── key: (1)
  │         └── scan t@j_idx
- │              ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
+ │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
  │              │         ├── ["7\x00\x01*\x04\x00", "7\x00\x01*\x04\x00"]
@@ -567,7 +567,7 @@ select
  │         ├── stats: [rows=120]
  │         ├── key: (1)
  │         └── scan t@j_idx
- │              ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
+ │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
  │              │         ├── ["7\x00\x01*\x04\x00", "7\x00\x01*\x04\x00"]
@@ -659,7 +659,7 @@ index-join t
       ├── stats: [rows=100]
       ├── key: (1)
       └── scan t@j_idx
-           ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
+           ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
            ├── inverted constraint: /5/1
            │    └── spans
            │         ├── ["7\x00\x019", "7\x00\x019"]
@@ -691,7 +691,7 @@ index-join t
       ├── stats: [rows=100]
       ├── key: (1)
       └── scan t@j_idx
-           ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
+           ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
            ├── inverted constraint: /5/1
            │    └── spans
            │         ├── ["7\x00\x018", "7\x00\x018"]
@@ -786,7 +786,7 @@ select
  │         ├── stats: [rows=4e-07]
  │         ├── key: (1)
  │         └── scan t@j_idx
- │              ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
+ │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
  │              │         ├── ["7a\x00\x02b\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x01\x12c\x00\x01"]
@@ -843,7 +843,7 @@ select
  │         ├── stats: [rows=4e-07]
  │         ├── key: (1)
  │         └── scan t@j_idx
- │              ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
+ │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
  │              │         ├── ["7a\x00\x02\x00\x03\x00\x01\x12b\x00\x01", "7a\x00\x02\x00\x03\x00\x01\x12b\x00\x01"]
@@ -896,7 +896,7 @@ select
  │         ├── stats: [rows=4e-07]
  │         ├── key: (1)
  │         └── scan t@j_idx
- │              ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
+ │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
  │              │         ├── ["7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12c\x00\x01"]
@@ -935,7 +935,7 @@ select
  │         ├── stats: [rows=4e-07]
  │         ├── key: (1)
  │         └── scan t@j_idx
- │              ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
+ │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
  │              │         ├── ["7a\x00\x018", "7a\x00\x018"]
@@ -973,7 +973,7 @@ select
  │         ├── stats: [rows=4e-07]
  │         ├── key: (1)
  │         └── scan t@j_idx
- │              ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
+ │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
  │              │         ├── ["7a\x00\x019", "7a\x00\x019"]
@@ -1005,7 +1005,7 @@ index-join t
       ├── stats: [rows=4e-07]
       ├── key: (1)
       └── scan t@j_idx
-           ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
+           ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
            ├── inverted constraint: /5/1
            │    └── spans
            │         ├── ["7a\x00\x01*\x02\x00", "7a\x00\x01*\x02\x00"]
@@ -1041,7 +1041,7 @@ select
  │         ├── stats: [rows=100]
  │         ├── key: (1)
  │         └── scan t@j_idx
- │              ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
+ │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
  │              │         ├── ["7\x00\x019", "7\x00\x019"]
@@ -1074,7 +1074,7 @@ index-join t
       ├── stats: [rows=4e-07]
       ├── key: (1)
       └── scan t@j_idx
-           ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
+           ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
            ├── inverted constraint: /5/1
            │    └── spans
            │         ├── ["7a\x00\x02b\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x01\x12c\x00\x01"]
@@ -1111,7 +1111,7 @@ select
  │         ├── stats: [rows=100]
  │         ├── key: (1)
  │         └── scan t@j_idx
- │              ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
+ │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
  │              │         ├── ["7\x00\x019", "7\x00\x019"]
@@ -1171,7 +1171,7 @@ select
  │         ├── stats: [rows=100]
  │         ├── key: (1)
  │         └── scan t@j_idx
- │              ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
+ │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
  │              │         ├── ["7\x00\x019", "7\x00\x019"]
@@ -1216,7 +1216,7 @@ select
  │         ├── stats: [rows=4e-07]
  │         ├── key: (1)
  │         └── scan t@j_idx
- │              ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
+ │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
  │              │         ├── ["7a\x00\x02\x00\x03\x00\x01*\x02\x00", "7a\x00\x02\x00\x03\x00\x01*\x02\x00"]
@@ -1258,7 +1258,7 @@ select
  │         ├── stats: [rows=100]
  │         ├── key: (1)
  │         └── scan t@j_idx
- │              ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
+ │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
  │              │         ├── ["7\x00\x019", "7\x00\x019"]
@@ -1296,7 +1296,7 @@ index-join t
       ├── stats: [rows=4e-07]
       ├── key: (1)
       └── scan t@j_idx
-           ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
+           ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
            ├── inverted constraint: /5/1
            │    └── spans
            │         ├── ["7a\x00\x02b\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x01\x12c\x00\x01"]
@@ -1337,7 +1337,7 @@ select
  │         ├── stats: [rows=100]
  │         ├── key: (1)
  │         └── scan t@j_idx
- │              ├── columns: k:1(int!null) j_inverted_key:5(jsonb!null)
+ │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
  │              │         ├── ["7\x00\x019", "7\x00\x019"]

--- a/pkg/sql/opt/memo/testdata/stats/partial-index-scan
+++ b/pkg/sql/opt/memo/testdata/stats/partial-index-scan
@@ -1245,7 +1245,7 @@ project
       │         ├── stats: [rows=16.66667]
       │         ├── key: (1)
       │         └── scan spatial@p,partial
-      │              ├── columns: k:1(int!null) g_inverted_key:7(geometry!null)
+      │              ├── columns: k:1(int!null) g_inverted_key:7(encodedkey!null)
       │              ├── inverted constraint: /7/1
       │              │    └── spans
       │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
@@ -1291,7 +1291,7 @@ project
       │         ├── stats: [rows=16.66667]
       │         ├── key: (1)
       │         └── scan spatial@p,partial
-      │              ├── columns: k:1(int!null) g_inverted_key:7(geometry!null)
+      │              ├── columns: k:1(int!null) g_inverted_key:7(encodedkey!null)
       │              ├── inverted constraint: /7/1
       │              │    └── spans
       │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
@@ -1358,7 +1358,7 @@ project
       │         ├── stats: [rows=8.547009]
       │         ├── key: (1)
       │         └── scan spatial@p,partial
-      │              ├── columns: k:1(int!null) g_inverted_key:7(geometry!null)
+      │              ├── columns: k:1(int!null) g_inverted_key:7(encodedkey!null)
       │              ├── inverted constraint: /7/1
       │              │    └── spans
       │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
@@ -1402,7 +1402,7 @@ project
       │         ├── stats: [rows=8.547009]
       │         ├── key: (1)
       │         └── scan spatial@p,partial
-      │              ├── columns: k:1(int!null) g_inverted_key:7(geometry!null)
+      │              ├── columns: k:1(int!null) g_inverted_key:7(encodedkey!null)
       │              ├── inverted constraint: /7/1
       │              │    └── spans
       │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
@@ -1492,7 +1492,7 @@ project
       │         ├── stats: [rows=118.7568]
       │         ├── key: (1)
       │         └── scan spatial@p,partial
-      │              ├── columns: k:1(int!null) g_inverted_key:7(geometry!null)
+      │              ├── columns: k:1(int!null) g_inverted_key:7(encodedkey!null)
       │              ├── inverted constraint: /7/1
       │              │    └── spans
       │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
@@ -1544,7 +1544,7 @@ project
       │         ├── stats: [rows=118.7568]
       │         ├── key: (1)
       │         └── scan spatial@p,partial
-      │              ├── columns: k:1(int!null) g_inverted_key:7(geometry!null)
+      │              ├── columns: k:1(int!null) g_inverted_key:7(encodedkey!null)
       │              ├── inverted constraint: /7/1
       │              │    └── spans
       │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
@@ -1632,7 +1632,7 @@ project
       │         ├── stats: [rows=121.5695]
       │         ├── key: (1)
       │         └── scan spatial@p,partial
-      │              ├── columns: k:1(int!null) g_inverted_key:7(geometry!null)
+      │              ├── columns: k:1(int!null) g_inverted_key:7(encodedkey!null)
       │              ├── inverted constraint: /7/1
       │              │    └── spans
       │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
@@ -1682,7 +1682,7 @@ project
       │         ├── stats: [rows=121.5695]
       │         ├── key: (1)
       │         └── scan spatial@p,partial
-      │              ├── columns: k:1(int!null) g_inverted_key:7(geometry!null)
+      │              ├── columns: k:1(int!null) g_inverted_key:7(encodedkey!null)
       │              ├── inverted constraint: /7/1
       │              │    └── spans
       │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -2235,7 +2235,7 @@ select
  │         ├── stats: [rows=1]
  │         ├── key: (2)
  │         └── scan tab@tab_geom_idx
- │              ├── columns: rowid:2(int!null) geom_inverted_key:5(geometry!null)
+ │              ├── columns: rowid:2(int!null) geom_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/2
  │              │    └── spans
  │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]

--- a/pkg/sql/opt/optbuilder/testdata/inverted-indexes
+++ b/pkg/sql/opt/optbuilder/testdata/inverted-indexes
@@ -26,11 +26,11 @@ TABLE kj
  ├── j jsonb
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- ├── j_inverted_key jsonb not null [inverted]
+ ├── j_inverted_key encodedkey not null [inverted]
  ├── PRIMARY INDEX kj_pkey
  │    └── k int not null
  └── INVERTED INDEX kj_j_idx
-      ├── j_inverted_key jsonb not null [inverted]
+      ├── j_inverted_key encodedkey not null [inverted]
       └── k int not null
 
 build

--- a/pkg/sql/opt/testutils/testcat/testdata/index
+++ b/pkg/sql/opt/testutils/testcat/testdata/index
@@ -83,18 +83,18 @@ TABLE g
  ├── geog geography
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- ├── geog_inverted_key geography not null [inverted]
- ├── geog_inverted_key geography not null [inverted]
+ ├── geog_inverted_key encodedkey not null [inverted]
+ ├── geog_inverted_key encodedkey not null [inverted]
  ├── PRIMARY INDEX g_pkey
  │    └── k int not null
  ├── INVERTED INDEX g_a_geog_idx
  │    ├── a int
- │    ├── geog_inverted_key geography not null [inverted]
+ │    ├── geog_inverted_key encodedkey not null [inverted]
  │    └── k int not null
  └── INVERTED INDEX g_a_b_geog_idx
       ├── a int
       ├── b int
-      ├── geog_inverted_key geography not null [inverted]
+      ├── geog_inverted_key encodedkey not null [inverted]
       └── k int not null
 
 # Test for expression index columns.
@@ -133,10 +133,10 @@ TABLE xyz
  ├── crdb_internal_idx_expr string as (lower(z)) virtual [inaccessible]
  ├── crdb_internal_idx_expr_1 int as (y + 1) virtual [inaccessible]
  ├── crdb_internal_idx_expr_2 jsonb as (j->'a') virtual [inaccessible]
- ├── crdb_internal_idx_expr_2_inverted_key jsonb not null [inverted]
- ├── crdb_internal_idx_expr_2_inverted_key jsonb not null [inverted]
+ ├── crdb_internal_idx_expr_2_inverted_key encodedkey not null [inverted]
+ ├── crdb_internal_idx_expr_2_inverted_key encodedkey not null [inverted]
  ├── crdb_internal_idx_expr_3 int as (x + y) virtual [inaccessible]
- ├── crdb_internal_idx_expr_2_inverted_key jsonb not null [inverted]
+ ├── crdb_internal_idx_expr_2_inverted_key encodedkey not null [inverted]
  ├── PRIMARY INDEX xyz_pkey
  │    └── x int not null
  ├── INDEX idx1
@@ -151,12 +151,12 @@ TABLE xyz
  │    ├── crdb_internal_idx_expr string as (lower(z)) virtual [inaccessible]
  │    └── x int not null
  ├── INVERTED INDEX idx4
- │    ├── crdb_internal_idx_expr_2_inverted_key jsonb not null [inverted]
+ │    ├── crdb_internal_idx_expr_2_inverted_key encodedkey not null [inverted]
  │    └── x int not null
  ├── INVERTED INDEX idx5
  │    ├── y int
  │    ├── z string
- │    ├── crdb_internal_idx_expr_2_inverted_key jsonb not null [inverted]
+ │    ├── crdb_internal_idx_expr_2_inverted_key encodedkey not null [inverted]
  │    └── x int not null
  ├── INDEX idx6
  │    ├── crdb_internal_idx_expr_3 int as (x + y) virtual [inaccessible]
@@ -166,6 +166,6 @@ TABLE xyz
  │    └── WHERE v > 1
  └── INVERTED INDEX idx7
       ├── crdb_internal_idx_expr_3 int as (x + y) virtual [inaccessible]
-      ├── crdb_internal_idx_expr_2_inverted_key jsonb not null [inverted]
+      ├── crdb_internal_idx_expr_2_inverted_key encodedkey not null [inverted]
       ├── x int not null
       └── WHERE v > 1

--- a/pkg/sql/opt/testutils/testcat/testdata/table
+++ b/pkg/sql/opt/testutils/testcat/testdata/table
@@ -204,15 +204,15 @@ TABLE inv
  ├── g geometry
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- ├── j_inverted_key jsonb not null [inverted]
- ├── g_inverted_key geometry not null [inverted]
+ ├── j_inverted_key encodedkey not null [inverted]
+ ├── g_inverted_key encodedkey not null [inverted]
  ├── PRIMARY INDEX inv_pkey
  │    └── k int not null
  ├── INVERTED INDEX inv_j_idx
- │    ├── j_inverted_key jsonb not null [inverted]
+ │    ├── j_inverted_key encodedkey not null [inverted]
  │    └── k int not null
  └── INVERTED INDEX inv_g_idx
-      ├── g_inverted_key geometry not null [inverted]
+      ├── g_inverted_key encodedkey not null [inverted]
       └── k int not null
 
 # Table with inverted indexes and implicit primary index.
@@ -236,15 +236,15 @@ TABLE inv2
  ├── rowid int not null default (unique_rowid()) [hidden]
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- ├── j_inverted_key jsonb not null [inverted]
- ├── g_inverted_key geometry not null [inverted]
+ ├── j_inverted_key encodedkey not null [inverted]
+ ├── g_inverted_key encodedkey not null [inverted]
  ├── PRIMARY INDEX inv2_pkey
  │    └── rowid int not null default (unique_rowid()) [hidden]
  ├── INVERTED INDEX inv2_j_idx
- │    ├── j_inverted_key jsonb not null [inverted]
+ │    ├── j_inverted_key encodedkey not null [inverted]
  │    └── rowid int not null default (unique_rowid()) [hidden]
  └── INVERTED INDEX inv2_g_idx
-      ├── g_inverted_key geometry not null [inverted]
+      ├── g_inverted_key encodedkey not null [inverted]
       └── rowid int not null default (unique_rowid()) [hidden]
 
 # Table with unique constraints.

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -892,10 +892,8 @@ func newOptTable(
 
 			invertedSourceColOrdinal, _ := ot.lookupColumnOrdinal(invertedColumnID)
 
-			// Add a inverted column that refers to the inverted index key.
+			// Add an inverted column that refers to the inverted index key.
 			invertedCol, invertedColOrd := newColumn()
-
-			// All inverted columns have type bytes.
 			invertedCol.InitInverted(
 				invertedColOrd,
 				tree.Name(invertedColumnName+"_inverted_key"),


### PR DESCRIPTION
Previously, inverted key columns in the test catalog were incorrectly
given the type of their source column. Now they have the correct type,
`types.EncodedKey`.

Release note: None