### PR TITLE
rangefeed: remove support for inline values

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -76,6 +76,10 @@ func maxConcurrentCatchupScans(sv *settings.Values) int {
 // Note that the timestamps in RangeFeedCheckpoint events that are streamed back
 // may be lower than the timestamp given here.
 //
+// Rangefeeds do not support inline (unversioned) values, and may omit them or
+// error on them. Similarly, rangefeeds will error if MVCC history is mutated
+// via e.g. ClearRange. Do not use rangefeeds across such key spans.
+//
 // NB: the given startAfter timestamp is exclusive, i.e. the first possible
 // emitted event (including catchup scans) will be at startAfter.Next().
 func (ds *DistSender) RangeFeed(

--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -110,10 +110,12 @@ func newFactory(stopper *stop.Stopper, client DB, knobs *TestingKnobs) *Factory 
 // RangeFeed constructs a new rangefeed and runs it in an async task.
 //
 // The rangefeed can be stopped via Close(); otherwise, it will stop when the
-// server shuts down.
+// server shuts down. The only error which can be returned will indicate that
+// the server is being shut down.
 //
-// The only error which can be returned will indicate that the server is being
-// shut down.
+// Rangefeeds do not support inline (unversioned) values, and may omit them or
+// error on them. Similarly, rangefeeds will error if MVCC history is mutated
+// via e.g. ClearRange. Do not use rangefeeds across such key spans.
 //
 // NB: for the rangefeed itself, initialTimestamp is exclusive, i.e. the first
 // possible event emitted by the server (including the catchup scan) is at

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -760,12 +760,8 @@ func TestEvalAddSSTable(t *testing.T) {
 						}
 
 						// Scan resulting data from engine.
-						iter := storage.NewMVCCIncrementalIterator(engine, storage.MVCCIncrementalIterOptions{
-							EndKey:       keys.MaxKey,
-							StartTime:    hlc.MinTimestamp,
-							EndTime:      hlc.MaxTimestamp,
-							IntentPolicy: storage.MVCCIncrementalIterIntentPolicyEmit,
-							InlinePolicy: storage.MVCCIncrementalIterInlinePolicyEmit,
+						iter := engine.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+							UpperBound: keys.MaxKey,
 						})
 						defer iter.Close()
 						iter.SeekGE(storage.MVCCKey{Key: keys.SystemPrefix})

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -671,7 +671,6 @@ func TestProcessorInitializeResolvedTimestamp(t *testing.T) {
 	txn1, txn2 := uuid.MakeV4(), uuid.MakeV4()
 	rtsIter := newTestIterator([]storage.MVCCKeyValue{
 		makeKV("a", "val1", 10),
-		makeInline("b", "val2"),
 		makeIntent("c", txn1, "txnKey1", 15),
 		makeProvisionalKV("c", "txnKey1", 15),
 		makeKV("c", "val3", 11),
@@ -680,7 +679,6 @@ func TestProcessorInitializeResolvedTimestamp(t *testing.T) {
 		makeProvisionalKV("d", "txnKey2", 21),
 		makeKV("d", "val5", 20),
 		makeKV("d", "val6", 19),
-		makeInline("g", "val7"),
 		makeKV("m", "val8", 1),
 		makeIntent("n", txn1, "txnKey1", 12),
 		makeProvisionalKV("n", "txnKey1", 12),
@@ -689,7 +687,6 @@ func TestProcessorInitializeResolvedTimestamp(t *testing.T) {
 		makeKV("r", "val9", 4),
 		makeIntent("w", txn1, "txnKey1", 3),
 		makeProvisionalKV("w", "txnKey1", 3),
-		makeInline("x", "val10"),
 		makeIntent("z", txn2, "txnKey2", 21),
 		makeProvisionalKV("z", "txnKey2", 21),
 		makeKV("z", "val11", 4),

--- a/pkg/kv/kvserver/rangefeed/registry_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_test.go
@@ -169,7 +169,6 @@ func TestRegistrationBasic(t *testing.T) {
 	catchupReg := newTestRegistration(spBC, hlc.Timestamp{WallTime: 1},
 		newTestIterator([]storage.MVCCKeyValue{
 			makeKV("b", "val1", 10),
-			makeInline("ba", "val2"),
 			makeKV("bc", "val3", 11),
 			makeKV("bd", "val4", 9),
 		}, nil), false)
@@ -179,8 +178,8 @@ func TestRegistrationBasic(t *testing.T) {
 	go catchupReg.runOutputLoop(context.Background(), 0)
 	require.NoError(t, catchupReg.waitForCaughtUp())
 	events := catchupReg.stream.Events()
-	require.Equal(t, 6, len(events))
-	require.Equal(t, []*roachpb.RangeFeedEvent{ev1, ev2}, events[4:])
+	require.Equal(t, 5, len(events))
+	require.Equal(t, []*roachpb.RangeFeedEvent{ev1, ev2}, events[3:])
 	catchupReg.disconnect(nil)
 	<-catchupReg.errC
 
@@ -243,7 +242,6 @@ func TestRegistrationCatchUpScan(t *testing.T) {
 	txn1, txn2 := uuid.MakeV4(), uuid.MakeV4()
 	iter := newTestIterator([]storage.MVCCKeyValue{
 		makeKV("a", "valA1", 10),
-		makeInline("b", "valB1"),
 		makeIntent("c", txn1, "txnKeyC", 15),
 		makeProvisionalKV("c", "txnKeyC", 15),
 		makeKV("c", "valC2", 11),
@@ -261,7 +259,6 @@ func TestRegistrationCatchUpScan(t *testing.T) {
 		makeKV("f", "valF3", 7),
 		makeKV("f", "valF2", 6),
 		makeKV("f", "valF1", 5),
-		makeInline("g", "valG1"),
 		makeKV("h", "valH1", 15),
 		makeKV("m", "valM1", 1),
 		makeIntent("n", txn1, "txnKeyN", 12),
@@ -271,7 +268,6 @@ func TestRegistrationCatchUpScan(t *testing.T) {
 		makeKV("r", "valR1", 4),
 		makeIntent("w", txn1, "txnKeyW", 3),
 		makeProvisionalKV("w", "txnKeyW", 3),
-		makeInline("x", "valX1"),
 		makeIntent("z", txn2, "txnKeyZ", 21),
 		makeProvisionalKV("z", "txnKeyZ", 21),
 		makeKV("z", "valZ1", 4),
@@ -326,10 +322,6 @@ func TestRegistrationCatchUpScan(t *testing.T) {
 			roachpb.Key("f"),
 			makeValWithTs("valF3", 7),
 			makeVal("valF2"),
-		),
-		rangeFeedValue(
-			roachpb.Key("g"),
-			makeVal("valG1"),
 		),
 		rangeFeedValue(
 			roachpb.Key("h"),

--- a/pkg/kv/kvserver/rangefeed/task_test.go
+++ b/pkg/kv/kvserver/rangefeed/task_test.go
@@ -64,12 +64,6 @@ func makeMetaKV(key string, meta enginepb.MVCCMetadata) storage.MVCCKeyValue {
 	}
 }
 
-func makeInline(key, val string) storage.MVCCKeyValue {
-	return makeMetaKV(key, enginepb.MVCCMetadata{
-		RawBytes: makeVal(val).RawBytes,
-	})
-}
-
 func makeIntent(key string, txnID uuid.UUID, txnKey string, txnTS int64) storage.MVCCKeyValue {
 	return makeMetaKV(key, enginepb.MVCCMetadata{
 		Txn: &enginepb.TxnMeta{
@@ -254,7 +248,6 @@ func TestInitResolvedTSScan(t *testing.T) {
 		engine := storage.NewDefaultInMemForTesting()
 		testData := []op{
 			{kv: makeKV("a", "val1", 10)},
-			{kv: makeInline("b", "val2")},
 			{kv: makeKV("c", "val4", 9)},
 			{kv: makeKV("c", "val3", 11)},
 			{
@@ -267,7 +260,6 @@ func TestInitResolvedTSScan(t *testing.T) {
 				txn: &txn2,
 				kv:  makeProvisionalKV("d", "txnKey2", 21),
 			},
-			{kv: makeInline("g", "val7")},
 			{kv: makeKV("m", "val8", 1)},
 			{
 				txn: &txn1,
@@ -282,7 +274,6 @@ func TestInitResolvedTSScan(t *testing.T) {
 				txn: &txn1,
 				kv:  makeProvisionalKV("w", "txnKey1", 15),
 			},
-			{kv: makeInline("x", "val10")},
 			{kv: makeKV("z", "val11", 4)},
 			{
 				txn: &txn2,

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -2684,6 +2684,10 @@ message RangeLookupResponse {
 // RangeFeed stream over the provided span, starting at the specified timestamp
 // (exclusive).
 //
+// Rangefeeds do not support inline (unversioned) values, and may omit them or
+// error on them. Similarly, rangefeeds will error if MVCC history is mutated
+// via e.g. ClearRange. Do not use rangefeeds across such key spans.
+//
 // NB: The start timestamp is exclusive, i.e. the first possible event emitted
 // will be at Header.Timestamp.Next(). This includes catchup scans.
 message RangeFeedRequest {

--- a/pkg/storage/enginepb/mvcc3.proto
+++ b/pkg/storage/enginepb/mvcc3.proto
@@ -268,7 +268,7 @@ message RangeAppliedState {
 }
 
 // MVCCWriteValueOp corresponds to a value being written outside of a
-// transaction.
+// transaction. Inline values (without timestamp) are not logged.
 message MVCCWriteValueOp {
   bytes key = 1;
   util.hlc.Timestamp timestamp = 2 [(gogoproto.nullable) = false];

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -1354,12 +1354,6 @@ func mvccPutInternal(
 		if ms != nil {
 			updateStatsForInline(ms, key, origMetaKeySize, origMetaValSize, metaKeySize, metaValSize)
 		}
-		if err == nil {
-			writer.LogLogicalOp(MVCCWriteValueOpType, MVCCLogicalOpDetails{
-				Key:  key,
-				Safe: true,
-			})
-		}
 		return err
 	}
 

--- a/pkg/storage/mvcc_incremental_iterator.go
+++ b/pkg/storage/mvcc_incremental_iterator.go
@@ -24,9 +24,8 @@ import (
 // most recent version (before or at endTime) of that key. If the key was most
 // recently deleted, this is signaled with an empty value.
 //
-// Inline values (non-user data) are handled according to the
-// MVCCIncrementalIterInlinePolicy. By default, an error will be
-// returned.
+// Inline (unversioned) values are not supported, and may return an error or be
+// omitted entirely. The iterator should not be used across such keys.
 //
 // Intents outside the time bounds are ignored. Intents inside the
 // time bounds are handled according to the provided
@@ -87,7 +86,6 @@ type MVCCIncrementalIterator struct {
 
 	// Configuration passed in MVCCIncrementalIterOptions.
 	intentPolicy MVCCIncrementalIterIntentPolicy
-	inlinePolicy MVCCIncrementalIterInlinePolicy
 
 	// Optional collection of intents created on demand when first intent encountered.
 	intents []roachpb.Intent
@@ -123,20 +121,6 @@ const (
 	MVCCIncrementalIterIntentPolicyEmit
 )
 
-// MVCCIncrementalIterInlinePolicy controls how the
-// MVCCIncrementalIterator will handle inline values that it
-// encounters when iterating.
-type MVCCIncrementalIterInlinePolicy int
-
-const (
-	// MVCCIncrementalIterInlinePolicyError will immediately
-	// return an error for any inline value found.
-	MVCCIncrementalIterInlinePolicyError MVCCIncrementalIterInlinePolicy = iota
-	// MVCCIncrementalIterInlinePolicyEmit will return inline
-	// values to the caller.
-	MVCCIncrementalIterInlinePolicyEmit
-)
-
 // MVCCIncrementalIterOptions bundles options for NewMVCCIncrementalIterator.
 type MVCCIncrementalIterOptions struct {
 	EnableTimeBoundIteratorOptimization bool
@@ -147,7 +131,6 @@ type MVCCIncrementalIterOptions struct {
 	EndTime   hlc.Timestamp
 
 	IntentPolicy MVCCIncrementalIterIntentPolicy
-	InlinePolicy MVCCIncrementalIterInlinePolicy
 }
 
 // NewMVCCIncrementalIterator creates an MVCCIncrementalIterator with the
@@ -185,7 +168,6 @@ func NewMVCCIncrementalIterator(
 		endTime:       opts.EndTime,
 		timeBoundIter: timeBoundIter,
 		intentPolicy:  opts.IntentPolicy,
-		inlinePolicy:  opts.InlinePolicy,
 	}
 }
 
@@ -349,16 +331,9 @@ func (i *MVCCIncrementalIterator) initMetaAndCheckForIntentOrInlineError() error
 	}
 
 	if i.meta.IsInline() {
-		switch i.inlinePolicy {
-		case MVCCIncrementalIterInlinePolicyError:
-			i.valid = false
-			i.err = errors.Errorf("unexpected inline value found: %s", unsafeKey.Key)
-			return i.err
-		case MVCCIncrementalIterInlinePolicyEmit:
-			return nil
-		default:
-			return errors.AssertionFailedf("unknown inline policy: %d", i.inlinePolicy)
-		}
+		i.valid = false
+		i.err = errors.Errorf("unexpected inline value found: %s", unsafeKey.Key)
+		return i.err
 	}
 
 	if i.meta.Txn == nil {
@@ -396,13 +371,9 @@ func (i *MVCCIncrementalIterator) initMetaAndCheckForIntentOrInlineError() error
 // advance advances the main iterator until it is referencing a key within
 // (start_time, end_time].
 //
-// It populates i.err with an error if either of the following was encountered:
-//
-// a) an inline value when the inline policy is
-//    MVCCIncrementalIterInlinePolicyError; or
-//
-// b) an intent with a timestamp within the incremental iterator's bounds when
-//    the intent policy is MVCCIncrementalIterIntentPolicyError.
+// It populates i.err with an error if it encountered an inline value or an
+// intent with a timestamp within the incremental iterator's bounds when the
+// intent policy is MVCCIncrementalIterIntentPolicyError.
 func (i *MVCCIncrementalIterator) advance() {
 	for {
 		i.maybeSkipKeys()
@@ -411,14 +382,6 @@ func (i *MVCCIncrementalIterator) advance() {
 		}
 
 		if err := i.initMetaAndCheckForIntentOrInlineError(); err != nil {
-			return
-		}
-
-		// If we have an inline value and the policy was to error, we
-		// would have errored in the call above. If our policy is to
-		// emit inline values, we don't want to advance past it. Inline
-		// values don't have timestamps that we can filter on.
-		if i.meta.IsInline() && i.inlinePolicy == MVCCIncrementalIterInlinePolicyEmit {
 			return
 		}
 
@@ -511,8 +474,8 @@ func (i *MVCCIncrementalIterator) UnsafeValue() []byte {
 
 // NextIgnoringTime returns the next key/value that would be encountered in a
 // non-incremental iteration by moving the underlying non-TBI iterator forward.
-// Intents in the time range (startTime,EndTime] and inline values are handled
-// according to the iterator policy.
+// Intents in the time range (startTime,EndTime] are handled according to the
+// iterator policy.
 func (i *MVCCIncrementalIterator) NextIgnoringTime() {
 	for {
 		i.iter.Next()
@@ -531,15 +494,15 @@ func (i *MVCCIncrementalIterator) NextIgnoringTime() {
 			continue
 		}
 
-		// We have a valid KV or an intent or an inline value to emit.
+		// We have a valid KV or an intent to emit.
 		return
 	}
 }
 
 // NextKeyIgnoringTime returns the next distinct key that would be encountered
 // in a non-incremental iteration by moving the underlying non-TBI iterator
-// forward. Intents in the time range (startTime,EndTime] and inline values are
-// handled according to the iterator policy.
+// forward. Intents in the time range (startTime,EndTime] are handled according
+// to the iterator policy.
 //
 // TODO(sumeer): consider removing this method since it is never used, and it
 // isn't clear what purpose it can serve in the future. We have two current
@@ -568,7 +531,7 @@ func (i *MVCCIncrementalIterator) NextKeyIgnoringTime() {
 			continue
 		}
 
-		// We have a valid KV or an intent or an inline value to emit.
+		// We have a valid KV or an intent to emit.
 		return
 	}
 }

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -801,49 +801,23 @@ func TestMVCCIncrementalIteratorInlinePolicy(t *testing.T) {
 			}
 		}
 		t.Run(engineImpl.name, func(t *testing.T) {
-			t.Run("PolicyError returns error if inline value is found", func(t *testing.T) {
+			t.Run("returns error if inline value is found", func(t *testing.T) {
 				iter := NewMVCCIncrementalIterator(e, MVCCIncrementalIterOptions{
-					EndKey:       keyMax,
-					StartTime:    tsMin,
-					EndTime:      tsMax,
-					InlinePolicy: MVCCIncrementalIterInlinePolicyError,
+					EndKey:    keyMax,
+					StartTime: tsMin,
+					EndTime:   tsMax,
 				})
 				defer iter.Close()
 				iter.SeekGE(MakeMVCCMetadataKey(testKey1))
 				_, err := iter.Valid()
 				assert.EqualError(t, err, "unexpected inline value found: \"/db1\"")
 			})
-			t.Run("PolicyEmit returns inline values to caller", func(t *testing.T) {
-				iter := NewMVCCIncrementalIterator(e, MVCCIncrementalIterOptions{
-					EndKey:       keyMax,
-					StartTime:    tsMin,
-					EndTime:      tsMax,
-					InlinePolicy: MVCCIncrementalIterInlinePolicyEmit,
-				})
-				defer iter.Close()
-				iter.SeekGE(MakeMVCCMetadataKey(testKey1))
-				expectInlineKeyValue(t, iter, inline1_1_1)
-				iter.Next()
-				expectKeyValue(t, iter, kv2_2_2)
-				iter.Next()
-				expectKeyValue(t, iter, kv2_1_1)
-				iter.Next()
-				expectInlineKeyValue(t, iter, inline3_2_1)
-
-				iter.SeekGE(MakeMVCCMetadataKey(testKey2))
-				expectKeyValue(t, iter, kv2_2_2)
-				iter.NextIgnoringTime()
-				expectKeyValue(t, iter, kv2_1_1)
-				iter.NextIgnoringTime()
-				expectInlineKeyValue(t, iter, inline3_2_1)
-			})
-			t.Run("PolicyError returns error on NextIgnoringTime if inline value is found",
+			t.Run("returns error on NextIgnoringTime if inline value is found",
 				func(t *testing.T) {
 					iter := NewMVCCIncrementalIterator(e, MVCCIncrementalIterOptions{
-						EndKey:       keyMax,
-						StartTime:    tsMin,
-						EndTime:      tsMax,
-						InlinePolicy: MVCCIncrementalIterInlinePolicyError,
+						EndKey:    keyMax,
+						StartTime: tsMin,
+						EndTime:   tsMax,
 					})
 					defer iter.Close()
 					iter.SeekGE(MakeMVCCMetadataKey(testKey2))
@@ -1000,24 +974,6 @@ func expectKeyValue(t *testing.T, iter SimpleMVCCIterator, kv MVCCKeyValue) {
 	assert.Equal(t, kv.Key.Timestamp, unsafeKey.Timestamp)
 	assert.Equal(t, kv.Value, unsafeVal)
 
-}
-
-func expectInlineKeyValue(t *testing.T, iter SimpleMVCCIterator, kv MVCCKeyValue) {
-	valid, err := iter.Valid()
-	assert.True(t, valid)
-	assert.NoError(t, err)
-
-	unsafeKey := iter.UnsafeKey()
-	unsafeVal := iter.UnsafeValue()
-
-	var meta enginepb.MVCCMetadata
-	err = protoutil.Unmarshal(unsafeVal, &meta)
-	require.NoError(t, err)
-
-	assert.True(t, meta.IsInline())
-	assert.False(t, unsafeKey.IsValue())
-	assert.True(t, unsafeKey.Key.Equal(kv.Key.Key))
-	assert.Equal(t, kv.Value, meta.RawBytes)
 }
 
 func expectIntent(t *testing.T, iter SimpleMVCCIterator, intent roachpb.Intent) {

--- a/pkg/storage/mvcc_logical_ops_test.go
+++ b/pkg/storage/mvcc_logical_ops_test.go
@@ -110,6 +110,11 @@ func TestMVCCOpLogWriter(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			// Write an inline value. This should be ignored by the log.
+			if err := MVCCPut(ctx, ol, nil, testKey6, hlc.Timestamp{}, hlc.ClockTimestamp{}, value6, nil); err != nil {
+				t.Fatal(err)
+			}
+
 			// Verify that the recorded logical ops match expectations.
 			makeOp := func(val interface{}) enginepb.MVCCLogicalOp {
 				var op enginepb.MVCCLogicalOp


### PR DESCRIPTION
**storage: omit inline values from MVCC logical op log**

Inline values were recorded in the MVCC logical op log, which is used
for emitting rangefeed events. However, they were de facto unsupported
by rangefeeds, since they would trigger an assertion panic due to their
(zero-valued) timestamp being below the the rangefeed's resolved
timestamp.

It isn't clear that inline values make sense in rangefeeds. They can't
be ordered, nor checkpointed, and the catchup scan may omit them
entirely due to their use of time-bound iterators.

This patch therefore omits inline values from MVCC logical op logging,
with an assertion to prevent one from being added. The alternative would
have been to include these in the log and then omit them (or error) in
rangefeeds, but this doesn't seem worth the cost or complexity.

Resolves #69357.

Release note: None

**rangefeed: error on inline values in catchup scans**

Inline values have de facto been unsupported in rangefeeds, as they
would trigger an assertion because their zero-valued timestamp was below
the rangefeed's resolved timestamp. Because of this, they were recently
removed from the MVCC logical op log too, which omits them from
rangefeeds entirely.

This patch causes rangefeed catchup scans to error on them -- that is,
unless the time-bound iterator skips them completely. It also documents
this in the rangefeed API documentation.

Resolves #69357.

Release note: None

**storage: remove inline value support from `MVCCIncrementalIterator`**

`MVCCIncrementalIterator` supported emitting inline values via the
option `MVCCIncrementalIterInlinePolicyEmit`. However, time-bound
iterators may entirely omit such values, and there are no remaining
callers making use of this.

This patch therefore removes the support for emitting inline values,
instead always erroring on them (unless TBIs skip them entirely).

Resolves #82507.

Release note: None