### PR TITLE
sql: fix CREATE TABLE LIKE with implicit pk

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -296,7 +296,7 @@ like_no_pk_rowid_hidden  CREATE TABLE public.like_no_pk_rowid_hidden (
                          a INT8 NULL,
                          b INT8 NULL,
                          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                         CONSTRAINT like_no_pk_table_pkey PRIMARY KEY (rowid ASC)
+                         CONSTRAINT like_no_pk_rowid_hidden_pkey PRIMARY KEY (rowid ASC)
 )
 
 statement error duplicate column name
@@ -323,9 +323,8 @@ like_more_specifiers  CREATE TABLE public.like_more_specifiers (
                       t TIMESTAMPTZ NULL,
                       z DECIMAL NULL,
                       blah INT8 NULL,
-                      rowid INT8 NOT VISIBLE NOT NULL,
-                      rowid_1 INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                      CONSTRAINT like_more_specifiers_pkey PRIMARY KEY (rowid_1 ASC),
+                      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                      CONSTRAINT like_more_specifiers_pkey PRIMARY KEY (rowid ASC),
                       INDEX like_more_specifiers_a_blah_z_idx (a ASC, blah ASC, z ASC)
 )
 
@@ -340,9 +339,9 @@ SHOW CREATE TABLE like_hash
 ----
 like_hash  CREATE TABLE public.like_hash (
            a INT8 NULL,
-           crdb_internal_a_shard_4 INT8 NOT VISIBLE NOT NULL,
+           crdb_internal_a_shard_4 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 4:::INT8)) VIRTUAL,
            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-           CONSTRAINT like_hash_base_pkey PRIMARY KEY (rowid ASC),
+           CONSTRAINT like_hash_pkey PRIMARY KEY (rowid ASC),
            INDEX like_hash_base_a_idx (a ASC) USING HASH WITH (bucket_count=4)
 )
 
@@ -359,7 +358,7 @@ like_hash  CREATE TABLE public.like_hash (
            a INT8 NULL,
            crdb_internal_a_shard_4 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 4:::INT8)) VIRTUAL,
            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-           CONSTRAINT like_hash_base_pkey PRIMARY KEY (rowid ASC),
+           CONSTRAINT like_hash_pkey PRIMARY KEY (rowid ASC),
            INDEX like_hash_base_a_idx (a ASC) USING HASH WITH (bucket_count=4)
 )
 

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index_multi_column
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index_multi_column
@@ -103,7 +103,7 @@ CREATE TABLE public.dst (
    b INT8 NULL,
    j JSONB NULL,
    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT src_pkey PRIMARY KEY (rowid ASC),
+   CONSTRAINT dst_pkey PRIMARY KEY (rowid ASC),
    INVERTED INDEX src_a_j_idx (a ASC, j ASC),
    INVERTED INDEX src_a_b_j_idx (a ASC, b ASC, j ASC)
 )

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -217,7 +217,7 @@ t10  CREATE TABLE public.t10 (
      a INT8 NULL,
      b INT8 NULL,
      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-     CONSTRAINT t9_pkey PRIMARY KEY (rowid ASC),
+     CONSTRAINT t10_pkey PRIMARY KEY (rowid ASC),
      INDEX t9_a_idx (a ASC) WHERE b > 1:::INT8
 )
 

--- a/pkg/sql/logictest/testdata/logic_test/virtual_columns
+++ b/pkg/sql/logictest/testdata/logic_test/virtual_columns
@@ -1176,7 +1176,7 @@ CREATE TABLE public.t63167_b (
    a INT8 NULL,
    v INT8 NULL AS (a + 1:::INT8) VIRTUAL,
    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT t63167_a_pkey PRIMARY KEY (rowid ASC)
+   CONSTRAINT t63167_b_pkey PRIMARY KEY (rowid ASC)
 )
 
 # Test that columns backfills to tables with virtual columns work.


### PR DESCRIPTION
Previously, `CREATE TABLE LIKE` copied implicitly created columns (e.g.
for the rowid default primary key and hash sharded index). Defaults for
some of these columns were not properly copied over in some cases,
causing unexpected constraint violations to surface.

This commit fixes this by skipping copying such columns; instead, they
will be freshly created. Followup work is needed for REGIONAL BY ROW.

Fixes #82401

Release note: None