### PR TITLE
pgwire: permit DESCRIBE of DECLARED cursor

### DIFF
--- a/pkg/sql/pgwire/testdata/pgtest/portals
+++ b/pkg/sql/pgwire/testdata/pgtest/portals
@@ -1305,3 +1305,54 @@ ReadyForQuery
 {"Type":"ParseComplete"}
 {"Type":"ErrorResponse","Code":"42P03"}
 {"Type":"ReadyForQuery","TxStatus":"E"}
+
+send
+Parse {"Query": "ROLLBACK"}
+Bind
+Execute
+Parse {"Query": "BEGIN"}
+Bind
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"ROLLBACK"}
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"BEGIN"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+# Check interop of SQL DECLARE and wire DESCRIBE
+
+send
+Parse {"Query": "DECLARE foo CURSOR FOR SELECT g::INT8 FROM generate_series(1, 10) g(g)"}
+Bind
+Describe {"ObjectType": "P", "Name": ""}
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"NoData"}
+{"Type":"CommandComplete","CommandTag":"DECLARE CURSOR"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+send
+Describe {"ObjectType": "P", "Name": "foo"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"RowDescription","Fields":[{"Name":"g","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0}]}
+{"Type":"ReadyForQuery","TxStatus":"T"}


### PR DESCRIPTION
Closes #82563

This commit adds support for pgwire-level DESCRIBE to describe a cursor
created with SQL-level DECLARE by asking for information about a portal.

This improves compatibility with Postgres. Note that after this commit
it's still not possible to execute/fetch from a SQL-level cursor using a
pgwire-level EXECUTE with limit.

Release note (sql change): permit use of the pgwire DESCRIBE command
against a cursor created with the DECLARE command in SQL. This improves
compatibility with Postgres and is needed for compatibility with
psycopg3 server-side cursors.