### PR TITLE
sql/schemachanger/rel,scplan/rules: add support for rules, _; adopt

### DIFF
--- a/pkg/sql/schemachanger/rel/BUILD.bazel
+++ b/pkg/sql/schemachanger/rel/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "schema.go",
         "schema_attribute.go",
         "schema_mappings.go",
+        "schema_rules.go",
         "schema_value.go",
         "system_attributes.go",
         "values.go",

--- a/pkg/sql/schemachanger/rel/query_lang.go
+++ b/pkg/sql/schemachanger/rel/query_lang.go
@@ -20,11 +20,11 @@ type Clause interface {
 	clause()
 }
 
-// newTriple declares that an attribute of the entity represented by this var
+// makeTriple declares that an attribute of the entity represented by this var
 // should have the provided value. Note that this introduces the var as an
 // entity into the query if it is not already one.
-func newTriple(entity Var, a Attr, value expr) Clause {
-	return &tripleDecl{
+func makeTriple(entity Var, a Attr, value expr) Clause {
+	return tripleDecl{
 		entity:    entity,
 		attribute: a,
 		value:     value,
@@ -34,29 +34,29 @@ func newTriple(entity Var, a Attr, value expr) Clause {
 // AttrEq constrains the entity bound to v to have the provided value for
 // the specified attr.
 func (v Var) AttrEq(a Attr, value interface{}) Clause {
-	return newTriple(v, a, valueExpr{value: value})
+	return makeTriple(v, a, valueExpr{value: value})
 }
 
 // AttrIn constrains the entity bound to v to have a value for
 // the specified attr in the set of provided values.
 func (v Var) AttrIn(a Attr, values ...interface{}) Clause {
-	return newTriple(v, a, (anyExpr)(values))
+	return makeTriple(v, a, (anyExpr)(values))
 }
 
 // AttrEqVar constrains the entity bound to v to have a value for
 // the specified attr equal to the variable value.
 func (v Var) AttrEqVar(a Attr, value Var) Clause {
-	return newTriple(v, a, value)
+	return makeTriple(v, a, value)
 }
 
 // Eq returns a clause enforcing that the var is the value provided.
 func (v Var) Eq(value interface{}) Clause {
-	return &eqDecl{v, valueExpr{value: value}}
+	return eqDecl{v, valueExpr{value: value}}
 }
 
 // In returns a clause enforcing that the var is one of the value provided.
 func (v Var) In(disjuncts ...interface{}) Clause {
-	return &eqDecl{v, (anyExpr)(disjuncts)}
+	return eqDecl{v, (anyExpr)(disjuncts)}
 }
 
 // Type returns a clause enforcing that the variable has one of the types
@@ -100,7 +100,7 @@ func And(terms ...Clause) Clause {
 // over variables.
 func Filter(name string, vars ...Var) func(predicateFunc interface{}) Clause {
 	return func(predicateFunc interface{}) Clause {
-		return &filterDecl{
+		return filterDecl{
 			name:          name,
 			vars:          vars,
 			predicateFunc: predicateFunc,

--- a/pkg/sql/schemachanger/rel/query_lang_clause.go
+++ b/pkg/sql/schemachanger/rel/query_lang_clause.go
@@ -23,7 +23,7 @@ type tripleDecl struct {
 	value     expr
 }
 
-func (f *tripleDecl) clause() {}
+func (f tripleDecl) clause() {}
 
 var _ Clause = (*tripleDecl)(nil)
 
@@ -39,7 +39,7 @@ type eqDecl struct {
 	expr expr
 }
 
-func (e *eqDecl) clause() {}
+func (e eqDecl) clause() {}
 
 // and is a useful conjunctive construct which exists primarily as a tool
 // for libraries to write functions which emit clauses. At build time, the
@@ -65,3 +65,10 @@ type filterDecl struct {
 }
 
 func (f filterDecl) clause() {}
+
+type ruleInvocation struct {
+	args []Var
+	rule *RuleDef
+}
+
+func (f ruleInvocation) clause() {}

--- a/pkg/sql/schemachanger/rel/query_lang_clauses.go
+++ b/pkg/sql/schemachanger/rel/query_lang_clauses.go
@@ -10,13 +10,59 @@
 
 package rel
 
-import "gopkg.in/yaml.v3"
+import (
+	"github.com/cockroachdb/errors"
+	"gopkg.in/yaml.v3"
+)
 
 // Clauses exists to handle flattening of a slice of clauses before marshaling.
 type Clauses []Clause
 
+func expanded(c Clauses) Clauses {
+	needsExpansion := func() bool {
+		for _, cl := range c {
+			switch cl.(type) {
+			case and, ruleInvocation:
+				return true
+			}
+		}
+		return false
+	}
+
+	if !needsExpansion() {
+		return c
+	}
+	replaceVars := func(replacements, before []Var, cl Clause) Clause {
+		maybeReplace := func(in Var) (_ Var, replaced bool) {
+			for i, v := range before {
+				if in == v && replacements[i] != v {
+					return replacements[i], true
+				}
+			}
+			return in, false
+		}
+		replaced, _ := walkVars(cl, maybeReplace)
+		return replaced
+	}
+
+	var ret Clauses
+	for _, cl := range c {
+		switch cl := cl.(type) {
+		case and:
+			ret = append(ret, expanded(Clauses(cl))...)
+		case ruleInvocation:
+			for _, clause := range expanded(cl.rule.Clauses) {
+				ret = append(ret, replaceVars(cl.args, cl.rule.Params, clause))
+			}
+		default:
+			ret = append(ret, cl)
+		}
+	}
+	return ret
+}
+
 func flattened(c Clauses) Clauses {
-	hasAnd := func() bool {
+	needsFlatten := func() bool {
 		for _, cl := range c {
 			if _, isAnd := cl.(and); isAnd {
 				return true
@@ -24,15 +70,14 @@ func flattened(c Clauses) Clauses {
 		}
 		return false
 	}
-	if !hasAnd() {
+	if !needsFlatten() {
 		return c
 	}
 	var ret Clauses
 	for _, cl := range c {
-		switch cl := cl.(type) {
-		case and:
-			ret = append(ret, flattened(Clauses(cl))...)
-		default:
+		if andCl, ok := cl.(and); ok {
+			ret = append(ret, flattened(Clauses(andCl))...)
+		} else {
 			ret = append(ret, cl)
 		}
 	}
@@ -48,4 +93,66 @@ func (c Clauses) MarshalYAML() (interface{}, error) {
 	}
 	n.Style = yaml.LiteralStyle
 	return &n, nil
+}
+
+type replaceVarFunc = func(Var) (_ Var, replaced bool)
+
+func walkVars(cl Clause, f replaceVarFunc) (_ Clause, replaced bool) {
+	switch cl := cl.(type) {
+	case and:
+		for i := range cl {
+			child, ok := walkVars(cl[i], f)
+			if ok {
+				cl[i], replaced = child, true
+			}
+		}
+		if replaced {
+			return cl, true
+		}
+	case eqDecl:
+		if v, ok := f(cl.v); ok {
+			cl.v, replaced = v, true
+		}
+		if varExpr, isVar := cl.expr.(Var); isVar {
+			if v, ok := f(varExpr); ok {
+				cl.expr, replaced = v, true
+			}
+		}
+		if replaced {
+			return cl, true
+		}
+	case filterDecl:
+		for i := range cl.vars {
+			if v, ok := f(cl.vars[i]); ok {
+				cl.vars[i], replaced = v, true
+			}
+		}
+		if replaced {
+			return cl, true
+		}
+	case ruleInvocation:
+		for i := range cl.args {
+			if v, ok := f(cl.args[i]); ok {
+				cl.args[i], replaced = v, true
+			}
+		}
+		if replaced {
+			return cl, true
+		}
+	case tripleDecl:
+		if v, ok := f(cl.entity); ok {
+			cl.entity, replaced = v, true
+		}
+		if v, isVar := cl.value.(Var); isVar {
+			if newV, ok := f(v); ok {
+				cl.value, replaced = newV, true
+			}
+		}
+		if replaced {
+			return cl, true
+		}
+	default:
+		panic(errors.AssertionFailedf("unhandled clause type %T", cl))
+	}
+	return cl, false
 }

--- a/pkg/sql/schemachanger/rel/query_lang_expr.go
+++ b/pkg/sql/schemachanger/rel/query_lang_expr.go
@@ -25,6 +25,16 @@ type expr interface {
 // your variable names.
 type Var string
 
+// Blank is a special variable which, when used, means that the value should
+// be bound to something. Different occurrences of Blank in different parts
+// of the query are not related to each other. It's as though each occurrence
+// is its own variable, but that variable is not named and its binding cannot
+// be retrieved.
+//
+// At the time when this was created, blank is not allowed to be used as an
+// entity binding.
+const Blank Var = "_"
+
 // Var is an expr.
 func (Var) expr() {}
 

--- a/pkg/sql/schemachanger/rel/rel_internal_test.go
+++ b/pkg/sql/schemachanger/rel/rel_internal_test.go
@@ -27,10 +27,11 @@ func TestMarkers(t *testing.T) {
 	})
 	t.Run("clause", func(t *testing.T) {
 		for _, clause := range []Clause{
-			&and{},
-			&tripleDecl{},
-			&eqDecl{},
-			&filterDecl{},
+			and{},
+			tripleDecl{},
+			eqDecl{},
+			filterDecl{},
+			ruleInvocation{},
 		} {
 			clause.clause()
 		}

--- a/pkg/sql/schemachanger/rel/reltest/reltest.go
+++ b/pkg/sql/schemachanger/rel/reltest/reltest.go
@@ -111,6 +111,8 @@ func (s Suite) toYAML(t *testing.T) *yaml.Node {
 			s.encodeData(t),
 			scalarYAML("attributes"),
 			s.encodeAttributes(t),
+			scalarYAML("rules"),
+			s.encodeRules(t),
 			scalarYAML("queries"),
 			s.encodeQueries(t),
 			scalarYAML("comparisons"),
@@ -159,6 +161,16 @@ func (s Suite) encodeComparisons(t *testing.T) *yaml.Node {
 	for _, ct := range s.ComparisonTests {
 		n.Content = append(n.Content, ct.encode(t))
 	}
+	return &n
+}
+
+func (s Suite) encodeRules(t *testing.T) *yaml.Node {
+	n := yaml.Node{Kind: yaml.SequenceNode}
+	s.Schema.ForEachRule(func(def rel.RuleDef) {
+		var r yaml.Node
+		require.NoError(t, r.Encode(def))
+		n.Content = append(n.Content, &r)
+	})
 	return &n
 }
 

--- a/pkg/sql/schemachanger/rel/schema.go
+++ b/pkg/sql/schemachanger/rel/schema.go
@@ -29,6 +29,8 @@ type Schema struct {
 	entityTypeSchemas        map[reflect.Type]*entityTypeSchema
 	typeOrdinal, selfOrdinal ordinal
 	stringAttrs              ordinalSet
+	rules                    []*RuleDef
+	rulesByName              map[string]*RuleDef
 }
 
 type entityTypeSchemaSort Schema
@@ -115,6 +117,7 @@ func buildSchema(name string, opts ...SchemaOption) *Schema {
 			name:              name,
 			attrToOrdinal:     make(map[Attr]ordinal),
 			entityTypeSchemas: make(map[reflect.Type]*entityTypeSchema),
+			rulesByName:       make(map[string]*RuleDef),
 		},
 		m: m,
 	}

--- a/pkg/sql/schemachanger/rel/schema_rules.go
+++ b/pkg/sql/schemachanger/rel/schema_rules.go
@@ -1,0 +1,209 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rel
+
+import (
+	"reflect"
+	"sort"
+
+	"github.com/cockroachdb/errors"
+)
+
+// RuleDef describes a rule.
+type RuleDef struct {
+	Name    string
+	Params  []Var
+	Clauses Clauses
+	Func    interface{} `yaml:"-"`
+
+	sc *Schema
+}
+
+// ForEachRule iterates the schema's rules.
+func (sc *Schema) ForEachRule(f func(def RuleDef)) {
+	for _, r := range sc.rules {
+		f(*r)
+	}
+}
+
+// Rule1 is a rule with one input variable.
+type Rule1 = func(a Var) Clause
+
+// Rule2 is a rule with two input variables.
+type Rule2 = func(a, b Var) Clause
+
+// Rule3 is a rule with three input variables.
+type Rule3 = func(a, b, c Var) Clause
+
+// Rule4 is a rule with three input variables.
+type Rule4 = func(a, b, c, d Var) Clause
+
+// Def1 defines a Rule1.
+func (sc *Schema) Def1(name string, a Var, def func(a Var) Clauses) Rule1 {
+	return sc.rule(name, def, a).(Rule1)
+}
+
+// Def2 defines a Rule2.
+func (sc *Schema) Def2(name string, a, b Var, def func(a, b Var) Clauses) Rule2 {
+	return sc.rule(name, def, a, b).(Rule2)
+}
+
+// Def3 defines a Rule3.
+func (sc *Schema) Def3(name string, a, b, c Var, def func(a, b, c Var) Clauses) Rule3 {
+	return sc.rule(name, def, a, b, c).(Rule3)
+}
+
+// Def4 defines a Rule4.
+func (sc *Schema) Def4(name string, a, b, c, d Var, def func(a, b, c, d Var) Clauses) Rule4 {
+	return sc.rule(name, def, a, b, c, d).(Rule4)
+}
+
+var (
+	varType     = reflect.TypeOf(Var(""))
+	clauseType  = reflect.TypeOf((*Clause)(nil)).Elem()
+	clausesType = reflect.TypeOf((*Clauses)(nil)).Elem()
+)
+
+// rule is used to define a pattern of clauses for reuse.
+func (sc *Schema) rule(name string, inFunc interface{}, vars ...Var) interface{} {
+	if _, exists := sc.rulesByName[name]; exists {
+		panic(errors.AssertionFailedf("already registered rule with name %s", name))
+	}
+	inT, clauses := buildRuleClauses(vars, inFunc)
+	clauses = flattened(clauses)
+	validateRuleClauses(name, clauses, vars)
+	rd := &RuleDef{
+		Name:    name,
+		Params:  vars,
+		Clauses: clauses,
+		sc:      sc,
+	}
+	rd.Func = makeRuleFunc(inT, rd)
+	sc.rules = append(sc.rules, rd)
+	sc.rulesByName[name] = rd
+	return rd.Func
+}
+
+func buildRuleClauses(vars []Var, f interface{}) ([]reflect.Type, Clauses) {
+	inT, in := makeInTypesAndValues(vars)
+	fv := validateBuildRuleFunctionValue(inT, f)
+	clausesI := fv.Call(in)
+	clauses := clausesI[0].Interface().(Clauses)
+	return inT, clauses
+}
+
+func makeInTypesAndValues(vars []Var) ([]reflect.Type, []reflect.Value) {
+	inT := make([]reflect.Type, len(vars))
+	in := make([]reflect.Value, len(vars))
+	for i, v := range vars {
+		inT[i] = varType
+		if v == Blank {
+			panic(errors.AssertionFailedf("cannot use _ as a parameter"))
+		}
+		in[i] = reflect.ValueOf(v)
+	}
+	return inT, in
+}
+
+func validateBuildRuleFunctionValue(inT []reflect.Type, f interface{}) reflect.Value {
+	inFuncType := reflect.FuncOf(
+		inT, []reflect.Type{clausesType}, false, /* variadic */
+	)
+	fv := reflect.ValueOf(f)
+	if !fv.IsValid() {
+		panic(errors.AssertionFailedf("input function must not be nil"))
+	}
+	fvt := fv.Type()
+	if fvt != inFuncType {
+		panic(errors.AssertionFailedf("input function must be %v, got %v",
+			inFuncType, fvt))
+	}
+	return fv
+}
+
+func validateRuleClauses(name string, clauses Clauses, vars []Var) {
+	vs := varsUsedInClauses(clauses)
+	if missing := vs.removed(vars...); len(missing) != 0 {
+		panic(errors.Errorf(
+			"invalid rule %s: %v are not defined variables", name, missing.ordered(),
+		))
+	}
+	if unused := makeVarSet(vars...).removed(vs.ordered()...); len(unused) > 0 {
+		panic(errors.Errorf(
+			"invalid rule %s: %v input variable are not used", name, unused.ordered(),
+		))
+	}
+}
+
+func makeRuleFunc(inT []reflect.Type, rd *RuleDef) interface{} {
+	return reflect.MakeFunc(reflect.FuncOf(
+		inT, []reflect.Type{clauseType}, false, /* variadic */
+	), func(args []reflect.Value) []reflect.Value {
+		argVars := make([]Var, len(inT))
+		for i, v := range args {
+			argVars[i] = v.Interface().(Var)
+		}
+		return []reflect.Value{reflect.ValueOf(ruleInvocation{
+			args: argVars,
+			rule: rd,
+		}).Convert(clauseType)}
+	}).Interface()
+}
+
+func varsUsedInClauses(clauses Clauses) varSet {
+	vs := varSet{}
+	walkVars(and(clauses), func(v Var) (_ Var, replaced bool) {
+		if v != Blank {
+			vs.add(v)
+		}
+		return v, false
+	})
+	return vs
+}
+
+type varSet map[Var]struct{}
+
+func (vs varSet) clone() varSet {
+	clone := make(varSet, len(vs))
+	for k := range vs {
+		clone[k] = struct{}{}
+	}
+	return clone
+}
+
+func (vs varSet) removed(vars ...Var) varSet {
+	clone := vs.clone()
+	for _, v := range vars {
+		delete(clone, v)
+	}
+	return clone
+}
+
+func makeVarSet(vars ...Var) varSet {
+	vs := make(varSet, len(vars))
+	vs.add(vars...)
+	return vs
+}
+
+func (vs varSet) add(vars ...Var) {
+	for _, v := range vars {
+		vs[v] = struct{}{}
+	}
+}
+
+func (vs varSet) ordered() []Var {
+	ret := make([]Var, 0, len(vs))
+	for s := range vs {
+		ret = append(ret, s)
+	}
+	sort.Slice(ret, func(i, j int) bool { return ret[i] < ret[j] })
+	return ret
+}

--- a/pkg/sql/schemachanger/rel/testdata/comparetest
+++ b/pkg/sql/schemachanger/rel/testdata/comparetest
@@ -6,6 +6,7 @@ data:
     e4: {puint: 4, uint: 4}
 attributes:
     e1: {_uintptr: 0, i: 0, i16: 1, i32: 0, i64: 0, i8: 1, pi8: 1, str: "", ui: 0, ui16: 0, ui32: 0, ui64: 0, ui8: 0}
+rules: []
 queries: []
 comparisons:
     - entities: [e2, e3, e1]

--- a/pkg/sql/schemachanger/rel/testdata/cyclegraph
+++ b/pkg/sql/schemachanger/rel/testdata/cyclegraph
@@ -5,6 +5,7 @@ data:
     container1: {s1: message1}
     container2: {s2: message2}
 attributes: {}
+rules: []
 queries:
     - indexes:
         0:

--- a/pkg/sql/schemachanger/rel/testdata/entitynode
+++ b/pkg/sql/schemachanger/rel/testdata/entitynode
@@ -13,6 +13,19 @@ attributes:
     na: {value: a}
     nb: {left: na, value: b}
     nc: {right: nb, value: c}
+rules:
+    - nodeEntity($node, $entity):
+        - $node[value] = $entity
+    - rightLeft($root, $right, $right-left, $v):
+        - $root[Type] = '*entitynodetest.node'
+        - $root[right] = $right
+        - $right[left] = $right-left
+        - $right[Type] = '*entitynodetest.node'
+        - $right-left[value] = $v
+        - '$v = {i8: 1, pi8: 1, i16: 1}'
+        - noop(*entitynodetest.node)($na)
+    - passThrough($a, $b, $c, $d):
+        - rightLeft($a, $b, $c, $d)
 queries:
     - indexes:
         0:
@@ -109,6 +122,17 @@ queries:
                 - [nb, b]
                 - [nc, c]
             unsatisfiableIndexes: [2, 3, 4, 5, 6]
+        nodes with elements where i8=2 (rule):
+            query:
+                - $i8 = 2
+                - $value[i8] = $i8
+                - nodeEntity($n, $value)
+            entities: [$value, $n]
+            result-vars: [$n, $value]
+            results:
+                - [nb, b]
+                - [nc, c]
+            unsatisfiableIndexes: [2, 3, 4, 5, 6]
         list all the i8 values:
             query:
                 - $value[i8] = $i8
@@ -153,6 +177,14 @@ queries:
             results:
                 - [na, nb, nc, a]
             unsatisfiableIndexes: [1, 2, 3, 4, 5, 6]
+        nodes with rule:
+            query:
+                - passThrough($nc, $nb, $na, $a)
+            entities: [$nc, $nb, $na]
+            result-vars: [$nc, $nb, $na, $a]
+            results:
+                - [nc, nb, na, a]
+            unsatisfiableIndexes: [1, 2, 3, 5, 6]
         list nodes:
             query:
                 - $n[Type] = '*entitynodetest.node'
@@ -287,5 +319,23 @@ queries:
             entities: [$e]
             result-vars: [$e, $i8]
             results: []
+            unsatisfiableIndexes: [1, 2, 3, 4, 5, 6]
+        using blank, bind all:
+            query:
+                - $e[i8] = $_
+            entities: [$e]
+            result-vars: [$e]
+            results:
+                - [a]
+                - [b]
+                - [c]
+            unsatisfiableIndexes: [1, 2, 3, 4, 5, 6]
+        using blank, bind non-nil pointer:
+            query:
+                - $e[pi8] = $_
+            entities: [$e]
+            result-vars: [$e]
+            results:
+                - [a]
             unsatisfiableIndexes: [1, 2, 3, 4, 5, 6]
 comparisons: []

--- a/pkg/sql/schemachanger/scplan/internal/opgen/target.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/target.go
@@ -52,7 +52,6 @@ func makeTarget(e scpb.Element, spec targetSpec) (t target, err error) {
 	var element, target, node, targetStatus rel.Var = "element", "target", "node", "target-status"
 	q, err := rel.NewQuery(screl.Schema,
 		element.Type(e),
-		element.AttrEqVar(screl.DescID, "descID"), // this is to allow the index on elements to work
 		targetStatus.Eq(spec.to),
 		screl.JoinTargetNode(element, target, node),
 		target.AttrEqVar(screl.TargetStatus, targetStatus),

--- a/pkg/sql/schemachanger/scplan/internal/rules/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/internal/rules/BUILD.bazel
@@ -29,6 +29,8 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":rules"],
     deps = [
+        "//pkg/sql/schemachanger/rel",
+        "//pkg/sql/schemachanger/screl",
         "//pkg/testutils",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@in_gopkg_yaml_v3//:yaml_v3",

--- a/pkg/sql/schemachanger/scplan/internal/rules/dep_drop.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/dep_drop.go
@@ -36,8 +36,7 @@ func init() {
 					(*scpb.View)(nil),
 					(*scpb.Table)(nil),
 				),
-				targetStatusEq(fromTarget, toTarget, scpb.ToAbsent),
-				currentStatusEq(fromNode, toNode, scpb.Status_DROPPED),
+				toAbsentInDropped(fromTarget, fromNode, toTarget, toNode),
 				rel.Filter("ViewDependsOn", from, to)(func(
 					view *scpb.View, dep scpb.Element,
 				) bool {
@@ -54,10 +53,14 @@ func init() {
 		"alias", "alias-dep",
 		func(from, fromTarget, fromNode, to, toTarget, toNode rel.Var) rel.Clauses {
 			return rel.Clauses{
-				from.Type((*scpb.AliasType)(nil)),
-				to.Type((*scpb.AliasType)(nil), (*scpb.EnumType)(nil)),
-				targetStatusEq(fromTarget, toTarget, scpb.ToAbsent),
-				currentStatusEq(fromNode, toNode, scpb.Status_DROPPED),
+				from.Type(
+					(*scpb.AliasType)(nil),
+				),
+				to.Type(
+					(*scpb.AliasType)(nil),
+					(*scpb.EnumType)(nil),
+				),
+				toAbsentInDropped(fromTarget, fromNode, toTarget, toNode),
 				rel.Filter("aliasTypeDependsOn", from, to)(func(
 					alias *scpb.AliasType, dep scpb.Element,
 				) bool {
@@ -76,8 +79,7 @@ func init() {
 			return rel.Clauses{
 				from.Type((*scpb.AliasType)(nil)),
 				to.Type((*scpb.EnumType)(nil)),
-				targetStatusEq(fromTarget, toTarget, scpb.ToAbsent),
-				currentStatusEq(fromNode, toNode, scpb.Status_DROPPED),
+				toAbsentInDropped(fromTarget, fromNode, toTarget, toNode),
 				rel.Filter("joinArrayTypeWithEnumType", from, to)(func(
 					arrayType *scpb.AliasType, enumType *scpb.EnumType,
 				) bool {
@@ -103,7 +105,7 @@ func init() {
 			return rel.Clauses{
 				from.Type((*scpb.SchemaParent)(nil)),
 				to.Type((*scpb.Database)(nil)),
-				targetStatusEq(fromTarget, toTarget, scpb.ToAbsent),
+				toAbsent(fromTarget, toTarget),
 				currentStatus(fromNode, scpb.Status_ABSENT),
 				currentStatus(toNode, scpb.Status_DROPPED),
 				joinOn(from, screl.ReferencedDescID, to, screl.DescID, "desc-id"),
@@ -121,10 +123,10 @@ func init() {
 			return rel.Clauses{
 				from.Type((*scpb.ObjectParent)(nil)),
 				to.Type((*scpb.Schema)(nil)),
-				targetStatusEq(fromTarget, toTarget, scpb.ToAbsent),
+				toAbsent(fromTarget, toTarget),
 				currentStatus(fromNode, scpb.Status_ABSENT),
 				currentStatus(toNode, scpb.Status_DROPPED),
-				joinOn(from, screl.ReferencedDescID, to, screl.DescID, "desc-id"),
+				joinReferencedDescID(from, to, "desc-id"),
 			}
 		},
 	)
@@ -137,10 +139,10 @@ func init() {
 			return rel.Clauses{
 				from.Type((*scpb.TableLocalitySecondaryRegion)(nil)),
 				to.Type((*scpb.EnumType)(nil)),
-				targetStatusEq(fromTarget, toTarget, scpb.ToAbsent),
+				toAbsent(fromTarget, toTarget),
 				currentStatus(fromNode, scpb.Status_ABSENT),
 				currentStatus(toNode, scpb.Status_DROPPED),
-				joinOn(from, screl.ReferencedDescID, to, screl.DescID, "desc-id"),
+				joinReferencedDescID(from, to, "desc-id"),
 			}
 		},
 	)
@@ -157,7 +159,7 @@ func init() {
 					(*scpb.EnumType)(nil),
 					(*scpb.Sequence)(nil),
 				),
-				targetStatusEq(fromTarget, toTarget, scpb.ToAbsent),
+				toAbsent(fromTarget, toTarget),
 				currentStatus(fromNode, scpb.Status_ABSENT),
 				currentStatus(toNode, scpb.Status_DROPPED),
 				rel.Filter("checkConstraintDependsOn", from, to)(func(
@@ -178,10 +180,10 @@ func init() {
 			return rel.Clauses{
 				from.Type((*scpb.ForeignKeyConstraint)(nil)),
 				to.Type((*scpb.Table)(nil)),
-				targetStatusEq(fromTarget, toTarget, scpb.ToAbsent),
+				toAbsent(fromTarget, toTarget),
 				currentStatus(fromNode, scpb.Status_ABSENT),
 				currentStatus(toNode, scpb.Status_DROPPED),
-				joinOn(from, screl.ReferencedDescID, to, screl.DescID, "desc-id"),
+				joinReferencedDescID(from, to, "desc-id"),
 			}
 		},
 	)
@@ -194,7 +196,7 @@ func init() {
 			return rel.Clauses{
 				from.Type((*scpb.SecondaryIndexPartial)(nil)),
 				to.Type((*scpb.AliasType)(nil), (*scpb.EnumType)(nil)),
-				targetStatusEq(fromTarget, toTarget, scpb.ToAbsent),
+				toAbsent(fromTarget, toTarget),
 				currentStatus(fromNode, scpb.Status_ABSENT),
 				currentStatus(toNode, scpb.Status_DROPPED),
 				rel.Filter("indexPartialDependsOn", from, to)(func(
@@ -214,7 +216,7 @@ func init() {
 			return rel.Clauses{
 				from.Type((*scpb.ColumnType)(nil)),
 				to.Type((*scpb.AliasType)(nil), (*scpb.EnumType)(nil)),
-				targetStatusEq(fromTarget, toTarget, scpb.ToAbsent),
+				toAbsent(fromTarget, toTarget),
 				currentStatus(fromNode, scpb.Status_ABSENT),
 				currentStatus(toNode, scpb.Status_DROPPED),
 				rel.Filter("columnTypeDependsOn", from, to)(func(
@@ -242,7 +244,7 @@ func init() {
 					(*scpb.EnumType)(nil),
 					(*scpb.Sequence)(nil),
 				),
-				targetStatusEq(fromTarget, toTarget, scpb.ToAbsent),
+				toAbsent(fromTarget, toTarget),
 				currentStatus(fromNode, scpb.Status_ABSENT),
 				currentStatus(toNode, scpb.Status_DROPPED),
 				rel.Filter("columnDefaultDependsOn", from, to)(func(
@@ -267,7 +269,7 @@ func init() {
 					(*scpb.EnumType)(nil),
 					(*scpb.Sequence)(nil),
 				),
-				targetStatusEq(fromTarget, toTarget, scpb.ToAbsent),
+				toAbsent(fromTarget, toTarget),
 				currentStatus(fromNode, scpb.Status_ABSENT),
 				currentStatus(toNode, scpb.Status_DROPPED),
 				rel.Filter("columnOnUpdateDependsOn", from, to)(func(
@@ -288,10 +290,10 @@ func init() {
 			return rel.Clauses{
 				from.Type((*scpb.SequenceOwner)(nil)),
 				to.Type((*scpb.Sequence)(nil)),
-				targetStatusEq(fromTarget, toTarget, scpb.ToAbsent),
+				toAbsent(fromTarget, toTarget),
 				currentStatus(fromNode, scpb.Status_ABSENT),
 				currentStatus(toNode, scpb.Status_DROPPED),
-				joinOn(from, screl.ReferencedDescID, to, screl.DescID, "desc-id"),
+				joinReferencedDescID(from, to, "desc-id"),
 			}
 
 		},
@@ -305,10 +307,10 @@ func init() {
 			return rel.Clauses{
 				from.Type((*scpb.DatabaseRegionConfig)(nil)),
 				to.Type((*scpb.EnumType)(nil)),
-				targetStatusEq(fromTarget, toTarget, scpb.ToAbsent),
+				toAbsent(fromTarget, toTarget),
 				currentStatus(fromNode, scpb.Status_ABSENT),
 				currentStatus(toNode, scpb.Status_DROPPED),
-				joinOn(from, screl.ReferencedDescID, to, screl.DescID, "desc-id"),
+				joinReferencedDescID(from, to, "desc-id"),
 			}
 		},
 	)
@@ -321,10 +323,10 @@ func init() {
 			return rel.Clauses{
 				from.Type((*scpb.DatabaseRegionConfig)(nil)),
 				to.Type((*scpb.EnumType)(nil)),
-				targetStatusEq(fromTarget, toTarget, scpb.ToAbsent),
+				toAbsent(fromTarget, toTarget),
 				currentStatus(fromNode, scpb.Status_ABSENT),
 				currentStatus(toNode, scpb.Status_DROPPED),
-				joinOn(from, screl.ReferencedDescID, to, screl.DescID, "desc-id"),
+				joinReferencedDescID(from, to, "desc-id"),
 			}
 		})
 
@@ -393,10 +395,10 @@ func init() {
 					(*scpb.AliasType)(nil),
 					(*scpb.EnumType)(nil),
 				),
-				targetStatusEq(fromTarget, toTarget, scpb.ToAbsent),
+				toAbsent(fromTarget, toTarget),
 				currentStatus(fromNode, scpb.Status_ABSENT),
 				currentStatus(toNode, scpb.Status_DROPPED),
-				join(from, to, screl.DescID, "desc-id"),
+				joinOnDescID(from, to, "desc-id"),
 			}
 		})
 
@@ -416,9 +418,8 @@ func init() {
 					(*scpb.SecondaryIndex)(nil),
 					(*scpb.RowLevelTTL)(nil),
 				),
-				targetStatusEq(fromTarget, toTarget, scpb.ToAbsent),
-				currentStatusEq(fromNode, toNode, scpb.Status_ABSENT),
-				join(from, to, screl.DescID, "desc-id"),
+				toAbsentInAbsent(fromTarget, fromNode, toTarget, toNode),
+				joinOnDescID(from, to, "desc-id"),
 			}
 		},
 	)

--- a/pkg/sql/schemachanger/scplan/internal/rules/dep_index_and_column.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/dep_index_and_column.go
@@ -30,7 +30,7 @@ func init() {
 			return rel.Clauses{
 				from.Type((*scpb.PrimaryIndex)(nil)),
 				to.Type((*scpb.PrimaryIndex)(nil)),
-				join(from, to, screl.DescID, "table-id"),
+				joinOnDescID(from, to, "table-id"),
 				targetStatus(fromTarget, scpb.ToAbsent),
 				targetStatus(toTarget, scpb.ToPublic),
 				currentStatus(fromNode, scpb.Status_VALIDATED),
@@ -86,7 +86,7 @@ func init() {
 					(*scpb.IndexPartitioning)(nil),
 					(*scpb.IndexComment)(nil),
 				),
-				joinOnIndexID(from, to),
+				joinOnIndexID(from, to, "table-id", "index-id"),
 				targetStatusEq(fromTarget, toTarget, scpb.ToPublic),
 				currentStatus(fromNode, scpb.Status_BACKFILL_ONLY),
 				currentStatus(toNode, scpb.Status_PUBLIC),
@@ -101,7 +101,7 @@ func init() {
 			return rel.Clauses{
 				from.Type((*scpb.TemporaryIndex)(nil)),
 				to.Type((*scpb.IndexPartitioning)(nil)),
-				joinOnIndexID(from, to),
+				joinOnIndexID(from, to, "table-id", "index-id"),
 				targetStatus(fromTarget, scpb.Transient),
 				targetStatus(toTarget, scpb.ToPublic),
 				currentStatus(fromNode, scpb.Status_DELETE_ONLY),
@@ -117,12 +117,10 @@ func init() {
 			return rel.Clauses{
 				from.Type((*scpb.SecondaryIndex)(nil)),
 				to.Type((*scpb.SecondaryIndexPartial)(nil)),
-				joinOnIndexID(from, to),
+				joinOnIndexID(from, to, "table-id", "index-id"),
 				targetStatusEq(fromTarget, toTarget, scpb.ToPublic),
 				currentStatus(fromNode, scpb.Status_BACKFILL_ONLY),
 				currentStatus(to, scpb.Status_PUBLIC),
-				join(from, to, screl.DescID, "desc-id"),
-				join(from, to, screl.IndexID, "index-id"),
 			}
 		})
 
@@ -140,7 +138,7 @@ func init() {
 					(*scpb.PrimaryIndex)(nil),
 					(*scpb.SecondaryIndex)(nil),
 				),
-				joinOnIndexID(from, to),
+				joinOnIndexID(from, to, "table-id", "index-id"),
 				targetStatusEq(fromTarget, toTarget, scpb.ToPublic),
 				currentStatus(fromNode, scpb.Status_PUBLIC),
 				currentStatus(toNode, scpb.Status_WRITE_ONLY),
@@ -160,7 +158,7 @@ func init() {
 				),
 				targetStatusEq(fromTarget, toTarget, scpb.ToPublic),
 				currentStatusEq(fromNode, toNode, scpb.Status_PUBLIC),
-				joinOnIndexID(from, to),
+				joinOnIndexID(from, to, "table-id", "index-id"),
 			}
 		},
 	)
@@ -181,8 +179,7 @@ func init() {
 					(*scpb.PrimaryIndex)(nil),
 					(*scpb.SecondaryIndex)(nil),
 				),
-
-				joinOnIndexID(from, to),
+				joinOnIndexID(from, to, "table-id", "index-id"),
 				targetStatusEq(fromTarget, toTarget, scpb.ToAbsent),
 				currentStatus(fromNode, scpb.Status_ABSENT),
 				currentStatus(toNode, scpb.Status_VALIDATED),
@@ -206,7 +203,7 @@ func init() {
 					(*scpb.PrimaryIndex)(nil),
 					(*scpb.SecondaryIndex)(nil),
 				),
-				joinOnIndexID(from, to),
+				joinOnIndexID(from, to, "table-id", "index-id"),
 				targetStatusEq(fromTarget, toTarget, scpb.ToAbsent),
 				currentStatusEq(fromNode, toNode, scpb.Status_ABSENT),
 			}
@@ -225,7 +222,7 @@ func init() {
 			return rel.Clauses{
 				from.Type((*scpb.TemporaryIndex)(nil)),
 				to.Type((*scpb.PrimaryIndex)(nil), (*scpb.SecondaryIndex)(nil)),
-				join(from, to, screl.DescID, "desc-id"),
+				joinOnDescID(from, to, "desc-id"),
 				joinOn(from, screl.IndexID, to, screl.TemporaryIndexID, "temp-index-id"),
 				targetStatus(fromTarget, scpb.Transient),
 				targetStatus(toTarget, scpb.ToPublic),
@@ -251,7 +248,7 @@ func init() {
 				targetStatusEq(fromTarget, toTarget, scpb.ToPublic),
 				currentStatus(fromNode, scpb.Status_DELETE_ONLY),
 				currentStatus(toNode, scpb.Status_PUBLIC),
-				joinOnColumnID(from, to),
+				joinOnColumnID(from, to, "table-id", "col-id"),
 			}
 		},
 	)
@@ -268,7 +265,7 @@ func init() {
 					(*scpb.ColumnOnUpdateExpression)(nil),
 					(*scpb.ColumnComment)(nil),
 				),
-				joinOnColumnID(from, to),
+				joinOnColumnID(from, to, "table-id", "col-id"),
 				targetStatusEq(fromTarget, toTarget, scpb.ToPublic),
 				currentStatus(fromNode, scpb.Status_DELETE_ONLY),
 				currentStatus(toNode, scpb.Status_PUBLIC),
@@ -287,7 +284,7 @@ func init() {
 					(*scpb.ColumnOnUpdateExpression)(nil),
 				),
 				to.Type((*scpb.Column)(nil)),
-				joinOnColumnID(from, to),
+				joinOnColumnID(from, to, "table-id", "col-id"),
 				targetStatusEq(fromTarget, toTarget, scpb.ToPublic),
 				currentStatus(fromNode, scpb.Status_PUBLIC),
 				currentStatus(toNode, scpb.Status_WRITE_ONLY),
@@ -303,7 +300,7 @@ func init() {
 			return rel.Clauses{
 				from.Type((*scpb.ColumnName)(nil)),
 				to.Type((*scpb.ColumnType)(nil)),
-				joinOnColumnID(from, to),
+				joinOnColumnID(from, to, "table-id", "col-id"),
 				targetStatusEq(fromTarget, toTarget, scpb.ToPublic),
 				currentStatusEq(fromNode, toNode, scpb.Status_PUBLIC),
 			}
@@ -320,7 +317,7 @@ func init() {
 			return rel.Clauses{
 				from.Type((*scpb.ColumnComment)(nil)),
 				to.Type((*scpb.Column)(nil)),
-				joinOnColumnID(from, to),
+				joinOnColumnID(from, to, "table-id", "col-id"),
 				targetStatusEq(fromTarget, toTarget, scpb.ToPublic),
 				currentStatusEq(fromNode, toNode, scpb.Status_PUBLIC),
 			}
@@ -339,7 +336,7 @@ func init() {
 					(*scpb.ColumnName)(nil),
 					(*scpb.ColumnComment)(nil),
 				),
-				joinOnColumnID(from, to),
+				joinOnColumnID(from, to, "table-id", "col-id"),
 				targetStatusEq(fromTarget, toTarget, scpb.ToAbsent),
 				currentStatus(fromNode, scpb.Status_WRITE_ONLY),
 				currentStatus(toNode, scpb.Status_ABSENT),
@@ -359,7 +356,7 @@ func init() {
 					(*scpb.ColumnOnUpdateExpression)(nil),
 				),
 				to.Type((*scpb.ColumnType)(nil)),
-				joinOnColumnID(from, to),
+				joinOnColumnID(from, to, "table-id", "col-id"),
 				targetStatusEq(fromTarget, toTarget, scpb.ToAbsent),
 				currentStatusEq(fromNode, toNode, scpb.Status_ABSENT),
 			}
@@ -378,7 +375,7 @@ func init() {
 					(*scpb.ColumnComment)(nil),
 				),
 				to.Type((*scpb.Column)(nil)),
-				joinOnColumnID(from, to),
+				joinOnColumnID(from, to, "table-id", "col-id"),
 				targetStatusEq(fromTarget, toTarget, scpb.ToAbsent),
 				currentStatusEq(fromNode, toNode, scpb.Status_ABSENT),
 			}
@@ -416,7 +413,7 @@ func init() {
 			return rel.Clauses{
 				from.Type((*scpb.ColumnType)(nil)),
 				to.Type((*scpb.Column)(nil)),
-				joinOnColumnID(from, to),
+				joinOnColumnID(from, to, "table-id", "col-id"),
 				targetStatusEq(fromTarget, toTarget, scpb.ToAbsent),
 				currentStatusEq(fromNode, toNode, scpb.Status_ABSENT),
 				rel.Filter("columnTypeIsNotBeingDropped", from)(func(
@@ -436,7 +433,7 @@ func init() {
 			return rel.Clauses{
 				from.Type((*scpb.SecondaryIndexPartial)(nil)),
 				to.Type((*scpb.SecondaryIndex)(nil)),
-				joinOnIndexID(from, to),
+				joinOnIndexID(from, to, "table-id", "index-id"),
 				targetStatusEq(fromTarget, toTarget, scpb.ToAbsent),
 				currentStatusEq(fromNode, toNode, scpb.Status_ABSENT),
 				rel.Filter("secondaryIndexPartialIsNotBeingDropped", from)(func(

--- a/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
@@ -29,10 +29,6 @@ func idInIDs(objects []descpb.ID, id descpb.ID) bool {
 	return false
 }
 
-func targetNodeVars(el rel.Var) (element, target, node rel.Var) {
-	return el, el + "-target", el + "-node"
-}
-
 func currentStatus(node rel.Var, status scpb.Status) rel.Clause {
 	return node.AttrEq(screl.CurrentStatus, status)
 }
@@ -119,6 +115,16 @@ var (
 			return rel.Clauses{
 				joinOnDescID(a, b, descID),
 				colID.Entities(screl.ColumnID, a, b),
+			}
+		},
+	)
+	joinOnConstraintID = screl.Schema.Def4(
+		"joinOnConstraintID", "a", "b", "desc-id", "constraint-id", func(
+			a, b, descID, constraintID rel.Var,
+		) rel.Clauses {
+			return rel.Clauses{
+				joinOnDescID(a, b, descID),
+				constraintID.Entities(screl.ConstraintID, a, b),
 			}
 		},
 	)

--- a/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
@@ -11,6 +11,9 @@
 package rules
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/rel"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
@@ -57,16 +60,66 @@ func joinOn(a rel.Var, aAttr rel.Attr, b rel.Var, bAttr rel.Attr, eqVarName rel.
 	)
 }
 
-func joinOnIndexID(a, b rel.Var) rel.Clause {
-	return rel.And(
-		join(a, b, screl.DescID, "desc-id"),
-		join(a, b, screl.IndexID, "index-id"),
+var (
+	toAbsent = screl.Schema.Def2(
+		"toAbsent",
+		"target1", "target2",
+		func(target1 rel.Var, target2 rel.Var) rel.Clauses {
+			return rel.Clauses{
+				targetStatusEq(target1, target2, scpb.ToAbsent),
+			}
+		})
+	toAbsentIn = func(status scpb.Status) rel.Rule4 {
+		ss := status.String()
+		return screl.Schema.Def4(
+			fmt.Sprintf("toAbsentIn%s%s", ss[0:1], strings.ToLower(ss[1:])),
+			"target1", "node1", "target2", "node2",
+			func(
+				target1 rel.Var, node1 rel.Var, target2 rel.Var, node2 rel.Var,
+			) rel.Clauses {
+				return rel.Clauses{
+					toAbsent(target1, target2),
+					currentStatusEq(node1, node2, status),
+				}
+			})
+	}
+	toAbsentInDropped    = toAbsentIn(scpb.Status_DROPPED)
+	toAbsentInAbsent     = toAbsentIn(scpb.Status_ABSENT)
+	joinReferencedDescID = screl.Schema.Def3(
+		"joinReferencedDescID", "referrer", "referenced", "id", func(
+			referrer, referenced, id rel.Var,
+		) rel.Clauses {
+			return rel.Clauses{
+				referrer.AttrEqVar(screl.ReferencedDescID, id),
+				referenced.AttrEqVar(screl.DescID, id),
+			}
+		})
+	joinOnDescID = screl.Schema.Def3(
+		"joinOnDescID", "a", "b", "id", func(
+			a, b, id rel.Var,
+		) rel.Clauses {
+			return rel.Clauses{
+				id.Entities(screl.DescID, a, b),
+			}
+		})
+	joinOnIndexID = screl.Schema.Def4(
+		"joinOnIndexID", "a", "b", "desc-id", "index-id", func(
+			a, b, descID, indexID rel.Var,
+		) rel.Clauses {
+			return rel.Clauses{
+				joinOnDescID(a, b, descID),
+				indexID.Entities(screl.IndexID, a, b),
+			}
+		},
 	)
-}
-
-func joinOnColumnID(a, b rel.Var) rel.Clause {
-	return rel.And(
-		join(a, b, screl.DescID, "desc-id"),
-		join(a, b, screl.ColumnID, "column-id"),
+	joinOnColumnID = screl.Schema.Def4(
+		"joinOnColumnID", "a", "b", "desc-id", "col-id", func(
+			a, b, descID, colID rel.Var,
+		) rel.Clauses {
+			return rel.Clauses{
+				joinOnDescID(a, b, descID),
+				colID.Entities(screl.ColumnID, a, b),
+			}
+		},
 	)
-}
+)

--- a/pkg/sql/schemachanger/scplan/internal/rules/registry.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/registry.go
@@ -123,8 +123,6 @@ func registerDepRule(
 	c = append(c,
 		screl.JoinTargetNode(from, fromTarget, fromNode),
 		screl.JoinTargetNode(to, toTarget, toNode),
-		from.AttrEqVar(screl.DescID, "var-to-tell-rel-from-is-an-element"),
-		to.AttrEqVar(screl.DescID, "var-to-tell-rel-to-is-an-element"),
 	)
 	registry.depRules = append(registry.depRules, registeredDepRule{
 		name: ruleName,

--- a/pkg/sql/schemachanger/scplan/internal/rules/rules_test.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/rules_test.go
@@ -60,7 +60,7 @@ func TestRulesYAML(t *testing.T) {
 				}
 				return string(out)
 			}
-			d.Fatalf(t, "deprules and oprules are the only commands")
+			d.Fatalf(t, "deprules, oprules, and rules are the only commands, got %s", d.Cmd)
 			return ""
 		})
 	})

--- a/pkg/sql/schemachanger/scplan/internal/rules/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/testdata/deprules
@@ -1,3 +1,44 @@
+rules
+----
+joinTarget(element, target):
+    - $target[Type] = '*scpb.Target'
+    - $target[Element] = $element
+    - $element[DescID] = $_
+joinTargetNode(element, target, node):
+    - joinTarget($element, $target)
+    - $node[Type] = '*screl.Node'
+    - $node[Target] = $target
+toAbsent(target1, target2):
+    - $target1[TargetStatus] = ABSENT
+    - $target2[TargetStatus] = ABSENT
+toAbsentInDropped(target1, node1, target2, node2):
+    - toAbsent($target1, $target2)
+    - $node1[CurrentStatus] = DROPPED
+    - $node2[CurrentStatus] = DROPPED
+toAbsentInAbsent(target1, node1, target2, node2):
+    - toAbsent($target1, $target2)
+    - $node1[CurrentStatus] = ABSENT
+    - $node2[CurrentStatus] = ABSENT
+joinReferencedDescID(referrer, referenced, id):
+    - $referrer[ReferencedDescID] = $id
+    - $referenced[DescID] = $id
+joinOnDescID(a, b, id):
+    - $a[DescID] = $id
+    - $b[DescID] = $id
+joinOnIndexID(a, b, desc-id, index-id):
+    - joinOnDescID($a, $b, $desc-id)
+    - $a[IndexID] = $index-id
+    - $b[IndexID] = $index-id
+joinOnColumnID(a, b, desc-id, col-id):
+    - joinOnDescID($a, $b, $desc-id)
+    - $a[ColumnID] = $col-id
+    - $b[ColumnID] = $col-id
+joinOnConstraintID(a, b, desc-id, constraint-id):
+    - joinOnDescID($a, $b, $desc-id)
+    - $a[ConstraintID] = $constraint-id
+    - $b[ConstraintID] = $constraint-id
+
+
 deprules
 ----
 - name: view drops before the types, views and tables it depends on
@@ -236,8 +277,7 @@ deprules
   query:
     - $new-index[Type] = '*scpb.PrimaryIndex'
     - $old-index[Type] = '*scpb.PrimaryIndex'
-    - $new-index[DescID] = $table-id
-    - $old-index[DescID] = $table-id
+    - joinOnDescID($new-index, $old-index, $table-id)
     - $new-index-target[TargetStatus] = ABSENT
     - $old-index-target[TargetStatus] = PUBLIC
     - $new-index-node[CurrentStatus] = VALIDATED
@@ -323,8 +363,7 @@ deprules
     - $child[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
     - joinOnIndexID($child, $index, $table-id, $index-id)
-    - $child-target[TargetStatus] = ABSENT
-    - $index-target[TargetStatus] = ABSENT
+    - toAbsent($child-target, $index-target)
     - $child-node[CurrentStatus] = ABSENT
     - $index-node[CurrentStatus] = VALIDATED
     - joinTargetNode($child, $child-target, $child-node)
@@ -525,10 +564,8 @@ deprules
   query:
     - $index[Type] = '*scpb.PrimaryIndex'
     - $column[Type] = '*scpb.Column'
-    - $index-target[TargetStatus] = ABSENT
-    - $column-target[TargetStatus] = ABSENT
-    - $index[DescID] = $table-id
-    - $column[DescID] = $table-id
+    - toAbsent($index-target, $column-target)
+    - joinOnDescID($index, $column, $table-id)
     - columnFeaturedInIndex(*scpb.Column, *scpb.PrimaryIndex)($column, $index)
     - $status = WRITE_ONLY
     - $index-node[CurrentStatus] = $status
@@ -574,8 +611,7 @@ deprules
   query:
     - $primary-index[Type] = '*scpb.PrimaryIndex'
     - $second-index[Type] IN ['*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
-    - $primary-index[DescID] = $table-id
-    - $second-index[DescID] = $table-id
+    - joinOnDescID($primary-index, $second-index, $table-id)
     - $primary-index-target[TargetStatus] = PUBLIC
     - $second-index-target[TargetStatus] = PUBLIC
     - $primary-index-node[CurrentStatus] = VALIDATED
@@ -590,10 +626,8 @@ deprules
   query:
     - $second-index[Type] IN ['*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - $primary-index[Type] = '*scpb.PrimaryIndex'
-    - $second-index[DescID] = $table-id
-    - $primary-index[DescID] = $table-id
-    - $second-index-target[TargetStatus] = ABSENT
-    - $primary-index-target[TargetStatus] = ABSENT
+    - joinOnDescID($second-index, $primary-index, $table-id)
+    - toAbsent($second-index-target, $primary-index-target)
     - $second-index-node[CurrentStatus] = ABSENT
     - $primary-index-node[CurrentStatus] = VALIDATED
     - newColumnFeaturedInIndex(scpb.Element, *scpb.PrimaryIndex)($second-index, $primary-index)

--- a/pkg/sql/schemachanger/scplan/internal/rules/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/testdata/deprules
@@ -7,21 +7,10 @@ deprules
   query:
     - $view[Type] = '*scpb.View'
     - $dependents[Type] IN ['*scpb.AliasType', '*scpb.EnumType', '*scpb.View', '*scpb.Table']
-    - $view-target[TargetStatus] = ABSENT
-    - $dependents-target[TargetStatus] = ABSENT
-    - $view-node[CurrentStatus] = DROPPED
-    - $dependents-node[CurrentStatus] = DROPPED
+    - toAbsentInDropped($view-target, $view-node, $dependents-target, $dependents-node)
     - ViewDependsOn(*scpb.View, scpb.Element)($view, $dependents)
-    - $view-target[Type] = '*scpb.Target'
-    - $view-target[Element] = $view
-    - $view-node[Type] = '*screl.Node'
-    - $view-node[Target] = $view-target
-    - $dependents-target[Type] = '*scpb.Target'
-    - $dependents-target[Element] = $dependents
-    - $dependents-node[Type] = '*screl.Node'
-    - $dependents-node[Target] = $dependents-target
-    - $view[DescID] = $var-to-tell-rel-from-is-an-element
-    - $dependents[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($view, $view-target, $view-node)
+    - joinTargetNode($dependents, $dependents-target, $dependents-node)
 - name: alias type drops before the types it depends on
   from: alias-node
   kind: Precedence
@@ -29,21 +18,10 @@ deprules
   query:
     - $alias[Type] = '*scpb.AliasType'
     - $alias-dep[Type] IN ['*scpb.AliasType', '*scpb.EnumType']
-    - $alias-target[TargetStatus] = ABSENT
-    - $alias-dep-target[TargetStatus] = ABSENT
-    - $alias-node[CurrentStatus] = DROPPED
-    - $alias-dep-node[CurrentStatus] = DROPPED
+    - toAbsentInDropped($alias-target, $alias-node, $alias-dep-target, $alias-dep-node)
     - aliasTypeDependsOn(*scpb.AliasType, scpb.Element)($alias, $alias-dep)
-    - $alias-target[Type] = '*scpb.Target'
-    - $alias-target[Element] = $alias
-    - $alias-node[Type] = '*screl.Node'
-    - $alias-node[Target] = $alias-target
-    - $alias-dep-target[Type] = '*scpb.Target'
-    - $alias-dep-target[Element] = $alias-dep
-    - $alias-dep-node[Type] = '*screl.Node'
-    - $alias-dep-node[Target] = $alias-dep-target
-    - $alias[DescID] = $var-to-tell-rel-from-is-an-element
-    - $alias-dep[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($alias, $alias-target, $alias-node)
+    - joinTargetNode($alias-dep, $alias-dep-target, $alias-dep-node)
 - name: array type drops right before its element enum type
   from: alias-node
   kind: SameStagePrecedence
@@ -51,21 +29,10 @@ deprules
   query:
     - $alias[Type] = '*scpb.AliasType'
     - $enum[Type] = '*scpb.EnumType'
-    - $alias-target[TargetStatus] = ABSENT
-    - $enum-target[TargetStatus] = ABSENT
-    - $alias-node[CurrentStatus] = DROPPED
-    - $enum-node[CurrentStatus] = DROPPED
+    - toAbsentInDropped($alias-target, $alias-node, $enum-target, $enum-node)
     - joinArrayTypeWithEnumType(*scpb.AliasType, *scpb.EnumType)($alias, $enum)
-    - $alias-target[Type] = '*scpb.Target'
-    - $alias-target[Element] = $alias
-    - $alias-node[Type] = '*screl.Node'
-    - $alias-node[Target] = $alias-target
-    - $enum-target[Type] = '*scpb.Target'
-    - $enum-target[Element] = $enum
-    - $enum-node[Type] = '*screl.Node'
-    - $enum-node[Target] = $enum-target
-    - $alias[DescID] = $var-to-tell-rel-from-is-an-element
-    - $enum[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($alias, $alias-target, $alias-node)
+    - joinTargetNode($enum, $enum-target, $enum-node)
 - name: schema dropped before parent database
   from: schema-parent-node
   kind: Precedence
@@ -73,22 +40,13 @@ deprules
   query:
     - $schema-parent[Type] = '*scpb.SchemaParent'
     - $database[Type] = '*scpb.Database'
-    - $schema-parent-target[TargetStatus] = ABSENT
-    - $database-target[TargetStatus] = ABSENT
+    - toAbsent($schema-parent-target, $database-target)
     - $schema-parent-node[CurrentStatus] = ABSENT
     - $database-node[CurrentStatus] = DROPPED
     - $schema-parent[ReferencedDescID] = $desc-id
     - $database[DescID] = $desc-id
-    - $schema-parent-target[Type] = '*scpb.Target'
-    - $schema-parent-target[Element] = $schema-parent
-    - $schema-parent-node[Type] = '*screl.Node'
-    - $schema-parent-node[Target] = $schema-parent-target
-    - $database-target[Type] = '*scpb.Target'
-    - $database-target[Element] = $database
-    - $database-node[Type] = '*screl.Node'
-    - $database-node[Target] = $database-target
-    - $schema-parent[DescID] = $var-to-tell-rel-from-is-an-element
-    - $database[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($schema-parent, $schema-parent-target, $schema-parent-node)
+    - joinTargetNode($database, $database-target, $database-node)
 - name: object dropped before parent schema
   from: object-parent-node
   kind: Precedence
@@ -96,22 +54,12 @@ deprules
   query:
     - $object-parent[Type] = '*scpb.ObjectParent'
     - $schema[Type] = '*scpb.Schema'
-    - $object-parent-target[TargetStatus] = ABSENT
-    - $schema-target[TargetStatus] = ABSENT
+    - toAbsent($object-parent-target, $schema-target)
     - $object-parent-node[CurrentStatus] = ABSENT
     - $schema-node[CurrentStatus] = DROPPED
-    - $object-parent[ReferencedDescID] = $desc-id
-    - $schema[DescID] = $desc-id
-    - $object-parent-target[Type] = '*scpb.Target'
-    - $object-parent-target[Element] = $object-parent
-    - $object-parent-node[Type] = '*screl.Node'
-    - $object-parent-node[Target] = $object-parent-target
-    - $schema-target[Type] = '*scpb.Target'
-    - $schema-target[Element] = $schema
-    - $schema-node[Type] = '*screl.Node'
-    - $schema-node[Target] = $schema-target
-    - $object-parent[DescID] = $var-to-tell-rel-from-is-an-element
-    - $schema[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinReferencedDescID($object-parent, $schema, $desc-id)
+    - joinTargetNode($object-parent, $object-parent-target, $object-parent-node)
+    - joinTargetNode($schema, $schema-target, $schema-node)
 - name: secondary region locality removed before dropping multi-region enum type
   from: secondary-region-node
   kind: Precedence
@@ -119,22 +67,12 @@ deprules
   query:
     - $secondary-region[Type] = '*scpb.TableLocalitySecondaryRegion'
     - $enum-type[Type] = '*scpb.EnumType'
-    - $secondary-region-target[TargetStatus] = ABSENT
-    - $enum-type-target[TargetStatus] = ABSENT
+    - toAbsent($secondary-region-target, $enum-type-target)
     - $secondary-region-node[CurrentStatus] = ABSENT
     - $enum-type-node[CurrentStatus] = DROPPED
-    - $secondary-region[ReferencedDescID] = $desc-id
-    - $enum-type[DescID] = $desc-id
-    - $secondary-region-target[Type] = '*scpb.Target'
-    - $secondary-region-target[Element] = $secondary-region
-    - $secondary-region-node[Type] = '*screl.Node'
-    - $secondary-region-node[Target] = $secondary-region-target
-    - $enum-type-target[Type] = '*scpb.Target'
-    - $enum-type-target[Element] = $enum-type
-    - $enum-type-node[Type] = '*screl.Node'
-    - $enum-type-node[Target] = $enum-type-target
-    - $secondary-region[DescID] = $var-to-tell-rel-from-is-an-element
-    - $enum-type[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinReferencedDescID($secondary-region, $enum-type, $desc-id)
+    - joinTargetNode($secondary-region, $secondary-region-target, $secondary-region-node)
+    - joinTargetNode($enum-type, $enum-type-target, $enum-type-node)
 - name: check constraint removed before dropping dependent types and sequences
   from: check-constraint-node
   kind: Precedence
@@ -142,21 +80,12 @@ deprules
   query:
     - $check-constraint[Type] = '*scpb.CheckConstraint'
     - $dependent[Type] IN ['*scpb.AliasType', '*scpb.EnumType', '*scpb.Sequence']
-    - $check-constraint-target[TargetStatus] = ABSENT
-    - $dependent-target[TargetStatus] = ABSENT
+    - toAbsent($check-constraint-target, $dependent-target)
     - $check-constraint-node[CurrentStatus] = ABSENT
     - $dependent-node[CurrentStatus] = DROPPED
     - checkConstraintDependsOn(*scpb.CheckConstraint, scpb.Element)($check-constraint, $dependent)
-    - $check-constraint-target[Type] = '*scpb.Target'
-    - $check-constraint-target[Element] = $check-constraint
-    - $check-constraint-node[Type] = '*screl.Node'
-    - $check-constraint-node[Target] = $check-constraint-target
-    - $dependent-target[Type] = '*scpb.Target'
-    - $dependent-target[Element] = $dependent
-    - $dependent-node[Type] = '*screl.Node'
-    - $dependent-node[Target] = $dependent-target
-    - $check-constraint[DescID] = $var-to-tell-rel-from-is-an-element
-    - $dependent[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($check-constraint, $check-constraint-target, $check-constraint-node)
+    - joinTargetNode($dependent, $dependent-target, $dependent-node)
 - name: FK removed before dropping dependent table
   from: foreign-key-node
   kind: Precedence
@@ -164,22 +93,12 @@ deprules
   query:
     - $foreign-key[Type] = '*scpb.ForeignKeyConstraint'
     - $table[Type] = '*scpb.Table'
-    - $foreign-key-target[TargetStatus] = ABSENT
-    - $table-target[TargetStatus] = ABSENT
+    - toAbsent($foreign-key-target, $table-target)
     - $foreign-key-node[CurrentStatus] = ABSENT
     - $table-node[CurrentStatus] = DROPPED
-    - $foreign-key[ReferencedDescID] = $desc-id
-    - $table[DescID] = $desc-id
-    - $foreign-key-target[Type] = '*scpb.Target'
-    - $foreign-key-target[Element] = $foreign-key
-    - $foreign-key-node[Type] = '*screl.Node'
-    - $foreign-key-node[Target] = $foreign-key-target
-    - $table-target[Type] = '*scpb.Target'
-    - $table-target[Element] = $table
-    - $table-node[Type] = '*screl.Node'
-    - $table-node[Target] = $table-target
-    - $foreign-key[DescID] = $var-to-tell-rel-from-is-an-element
-    - $table[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinReferencedDescID($foreign-key, $table, $desc-id)
+    - joinTargetNode($foreign-key, $foreign-key-target, $foreign-key-node)
+    - joinTargetNode($table, $table-target, $table-node)
 - name: index partial predicate removed before dropping dependent types
   from: index-partial-node
   kind: Precedence
@@ -187,21 +106,12 @@ deprules
   query:
     - $index-partial[Type] = '*scpb.SecondaryIndexPartial'
     - $dependent-type[Type] IN ['*scpb.AliasType', '*scpb.EnumType']
-    - $index-partial-target[TargetStatus] = ABSENT
-    - $dependent-type-target[TargetStatus] = ABSENT
+    - toAbsent($index-partial-target, $dependent-type-target)
     - $index-partial-node[CurrentStatus] = ABSENT
     - $dependent-type-node[CurrentStatus] = DROPPED
     - indexPartialDependsOn(*scpb.SecondaryIndexPartial, scpb.Element)($index-partial, $dependent-type)
-    - $index-partial-target[Type] = '*scpb.Target'
-    - $index-partial-target[Element] = $index-partial
-    - $index-partial-node[Type] = '*screl.Node'
-    - $index-partial-node[Target] = $index-partial-target
-    - $dependent-type-target[Type] = '*scpb.Target'
-    - $dependent-type-target[Element] = $dependent-type
-    - $dependent-type-node[Type] = '*screl.Node'
-    - $dependent-type-node[Target] = $dependent-type-target
-    - $index-partial[DescID] = $var-to-tell-rel-from-is-an-element
-    - $dependent-type[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($index-partial, $index-partial-target, $index-partial-node)
+    - joinTargetNode($dependent-type, $dependent-type-target, $dependent-type-node)
 - name: column type removed before dropping dependent types
   from: column-type-node
   kind: Precedence
@@ -209,21 +119,12 @@ deprules
   query:
     - $column-type[Type] = '*scpb.ColumnType'
     - $dependent-type[Type] IN ['*scpb.AliasType', '*scpb.EnumType']
-    - $column-type-target[TargetStatus] = ABSENT
-    - $dependent-type-target[TargetStatus] = ABSENT
+    - toAbsent($column-type-target, $dependent-type-target)
     - $column-type-node[CurrentStatus] = ABSENT
     - $dependent-type-node[CurrentStatus] = DROPPED
     - columnTypeDependsOn(*scpb.ColumnType, scpb.Element)($column-type, $dependent-type)
-    - $column-type-target[Type] = '*scpb.Target'
-    - $column-type-target[Element] = $column-type
-    - $column-type-node[Type] = '*screl.Node'
-    - $column-type-node[Target] = $column-type-target
-    - $dependent-type-target[Type] = '*scpb.Target'
-    - $dependent-type-target[Element] = $dependent-type
-    - $dependent-type-node[Type] = '*screl.Node'
-    - $dependent-type-node[Target] = $dependent-type-target
-    - $column-type[DescID] = $var-to-tell-rel-from-is-an-element
-    - $dependent-type[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($column-type, $column-type-target, $column-type-node)
+    - joinTargetNode($dependent-type, $dependent-type-target, $dependent-type-node)
 - name: column DEFAULT removed before dropping dependent types and sequences
   from: default-expr-node
   kind: Precedence
@@ -231,21 +132,12 @@ deprules
   query:
     - $default-expr[Type] = '*scpb.ColumnDefaultExpression'
     - $dependent[Type] IN ['*scpb.AliasType', '*scpb.EnumType', '*scpb.Sequence']
-    - $default-expr-target[TargetStatus] = ABSENT
-    - $dependent-target[TargetStatus] = ABSENT
+    - toAbsent($default-expr-target, $dependent-target)
     - $default-expr-node[CurrentStatus] = ABSENT
     - $dependent-node[CurrentStatus] = DROPPED
     - columnDefaultDependsOn(*scpb.ColumnDefaultExpression, scpb.Element)($default-expr, $dependent)
-    - $default-expr-target[Type] = '*scpb.Target'
-    - $default-expr-target[Element] = $default-expr
-    - $default-expr-node[Type] = '*screl.Node'
-    - $default-expr-node[Target] = $default-expr-target
-    - $dependent-target[Type] = '*scpb.Target'
-    - $dependent-target[Element] = $dependent
-    - $dependent-node[Type] = '*screl.Node'
-    - $dependent-node[Target] = $dependent-target
-    - $default-expr[DescID] = $var-to-tell-rel-from-is-an-element
-    - $dependent[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($default-expr, $default-expr-target, $default-expr-node)
+    - joinTargetNode($dependent, $dependent-target, $dependent-node)
 - name: column ON UPDATE removed before dropping dependent types and sequences
   from: on-update-expr-node
   kind: Precedence
@@ -253,21 +145,12 @@ deprules
   query:
     - $on-update-expr[Type] = '*scpb.ColumnOnUpdateExpression'
     - $dependent[Type] IN ['*scpb.AliasType', '*scpb.EnumType', '*scpb.Sequence']
-    - $on-update-expr-target[TargetStatus] = ABSENT
-    - $dependent-target[TargetStatus] = ABSENT
+    - toAbsent($on-update-expr-target, $dependent-target)
     - $on-update-expr-node[CurrentStatus] = ABSENT
     - $dependent-node[CurrentStatus] = DROPPED
     - columnOnUpdateDependsOn(*scpb.ColumnOnUpdateExpression, scpb.Element)($on-update-expr, $dependent)
-    - $on-update-expr-target[Type] = '*scpb.Target'
-    - $on-update-expr-target[Element] = $on-update-expr
-    - $on-update-expr-node[Type] = '*screl.Node'
-    - $on-update-expr-node[Target] = $on-update-expr-target
-    - $dependent-target[Type] = '*scpb.Target'
-    - $dependent-target[Element] = $dependent
-    - $dependent-node[Type] = '*screl.Node'
-    - $dependent-node[Target] = $dependent-target
-    - $on-update-expr[DescID] = $var-to-tell-rel-from-is-an-element
-    - $dependent[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($on-update-expr, $on-update-expr-target, $on-update-expr-node)
+    - joinTargetNode($dependent, $dependent-target, $dependent-node)
 - name: sequence ownership removed before dropping sequence
   from: sequence-owner-node
   kind: Precedence
@@ -275,22 +158,12 @@ deprules
   query:
     - $sequence-owner[Type] = '*scpb.SequenceOwner'
     - $sequence[Type] = '*scpb.Sequence'
-    - $sequence-owner-target[TargetStatus] = ABSENT
-    - $sequence-target[TargetStatus] = ABSENT
+    - toAbsent($sequence-owner-target, $sequence-target)
     - $sequence-owner-node[CurrentStatus] = ABSENT
     - $sequence-node[CurrentStatus] = DROPPED
-    - $sequence-owner[ReferencedDescID] = $desc-id
-    - $sequence[DescID] = $desc-id
-    - $sequence-owner-target[Type] = '*scpb.Target'
-    - $sequence-owner-target[Element] = $sequence-owner
-    - $sequence-owner-node[Type] = '*screl.Node'
-    - $sequence-owner-node[Target] = $sequence-owner-target
-    - $sequence-target[Type] = '*scpb.Target'
-    - $sequence-target[Element] = $sequence
-    - $sequence-node[Type] = '*screl.Node'
-    - $sequence-node[Target] = $sequence-target
-    - $sequence-owner[DescID] = $var-to-tell-rel-from-is-an-element
-    - $sequence[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinReferencedDescID($sequence-owner, $sequence, $desc-id)
+    - joinTargetNode($sequence-owner, $sequence-owner-target, $sequence-owner-node)
+    - joinTargetNode($sequence, $sequence-target, $sequence-node)
 - name: database region config removed before dropping multi-region enum type
   from: region-config-node
   kind: Precedence
@@ -298,22 +171,12 @@ deprules
   query:
     - $region-config[Type] = '*scpb.DatabaseRegionConfig'
     - $enum-type[Type] = '*scpb.EnumType'
-    - $region-config-target[TargetStatus] = ABSENT
-    - $enum-type-target[TargetStatus] = ABSENT
+    - toAbsent($region-config-target, $enum-type-target)
     - $region-config-node[CurrentStatus] = ABSENT
     - $enum-type-node[CurrentStatus] = DROPPED
-    - $region-config[ReferencedDescID] = $desc-id
-    - $enum-type[DescID] = $desc-id
-    - $region-config-target[Type] = '*scpb.Target'
-    - $region-config-target[Element] = $region-config
-    - $region-config-node[Type] = '*screl.Node'
-    - $region-config-node[Target] = $region-config-target
-    - $enum-type-target[Type] = '*scpb.Target'
-    - $enum-type-target[Element] = $enum-type
-    - $enum-type-node[Type] = '*screl.Node'
-    - $enum-type-node[Target] = $enum-type-target
-    - $region-config[DescID] = $var-to-tell-rel-from-is-an-element
-    - $enum-type[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinReferencedDescID($region-config, $enum-type, $desc-id)
+    - joinTargetNode($region-config, $region-config-target, $region-config-node)
+    - joinTargetNode($enum-type, $enum-type-target, $enum-type-node)
 - name: database region config removed before dropping multi-region enum type
   from: region-config-node
   kind: Precedence
@@ -321,22 +184,12 @@ deprules
   query:
     - $region-config[Type] = '*scpb.DatabaseRegionConfig'
     - $enum-type[Type] = '*scpb.EnumType'
-    - $region-config-target[TargetStatus] = ABSENT
-    - $enum-type-target[TargetStatus] = ABSENT
+    - toAbsent($region-config-target, $enum-type-target)
     - $region-config-node[CurrentStatus] = ABSENT
     - $enum-type-node[CurrentStatus] = DROPPED
-    - $region-config[ReferencedDescID] = $desc-id
-    - $enum-type[DescID] = $desc-id
-    - $region-config-target[Type] = '*scpb.Target'
-    - $region-config-target[Element] = $region-config
-    - $region-config-node[Type] = '*screl.Node'
-    - $region-config-node[Target] = $region-config-target
-    - $enum-type-target[Type] = '*scpb.Target'
-    - $enum-type-target[Element] = $enum-type
-    - $enum-type-node[Type] = '*screl.Node'
-    - $enum-type-node[Target] = $enum-type-target
-    - $region-config[DescID] = $var-to-tell-rel-from-is-an-element
-    - $enum-type[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinReferencedDescID($region-config, $enum-type, $desc-id)
+    - joinTargetNode($region-config, $region-config-target, $region-config-node)
+    - joinTargetNode($enum-type, $enum-type-target, $enum-type-node)
 - name: dependent element removal before descriptor drop
   from: element-node
   kind: Precedence
@@ -344,22 +197,12 @@ deprules
   query:
     - $element[Type] IN ['*scpb.ColumnFamily', '*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnComment', '*scpb.SequenceOwner', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexComment', '*scpb.ConstraintName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseComment', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.ObjectParent']
     - $relation[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.Table', '*scpb.View', '*scpb.Sequence', '*scpb.AliasType', '*scpb.EnumType']
-    - $element-target[TargetStatus] = ABSENT
-    - $relation-target[TargetStatus] = ABSENT
+    - toAbsent($element-target, $relation-target)
     - $element-node[CurrentStatus] = ABSENT
     - $relation-node[CurrentStatus] = DROPPED
-    - $element[DescID] = $desc-id
-    - $relation[DescID] = $desc-id
-    - $element-target[Type] = '*scpb.Target'
-    - $element-target[Element] = $element
-    - $element-node[Type] = '*screl.Node'
-    - $element-node[Target] = $element-target
-    - $relation-target[Type] = '*scpb.Target'
-    - $relation-target[Element] = $relation
-    - $relation-node[Type] = '*screl.Node'
-    - $relation-node[Target] = $relation-target
-    - $element[DescID] = $var-to-tell-rel-from-is-an-element
-    - $relation[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinOnDescID($element, $relation, $desc-id)
+    - joinTargetNode($element, $element-target, $element-node)
+    - joinTargetNode($relation, $relation-target, $relation-node)
 - name: dependent element removal right after descriptor removal
   from: relation-node
   kind: SameStagePrecedence
@@ -367,22 +210,10 @@ deprules
   query:
     - $relation[Type] IN ['*scpb.Table', '*scpb.View']
     - $element[Type] IN ['*scpb.Column', '*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.RowLevelTTL']
-    - $relation-target[TargetStatus] = ABSENT
-    - $element-target[TargetStatus] = ABSENT
-    - $relation-node[CurrentStatus] = ABSENT
-    - $element-node[CurrentStatus] = ABSENT
-    - $relation[DescID] = $desc-id
-    - $element[DescID] = $desc-id
-    - $relation-target[Type] = '*scpb.Target'
-    - $relation-target[Element] = $relation
-    - $relation-node[Type] = '*screl.Node'
-    - $relation-node[Target] = $relation-target
-    - $element-target[Type] = '*scpb.Target'
-    - $element-target[Element] = $element
-    - $element-node[Type] = '*screl.Node'
-    - $element-node[Target] = $element-target
-    - $relation[DescID] = $var-to-tell-rel-from-is-an-element
-    - $element[DescID] = $var-to-tell-rel-to-is-an-element
+    - toAbsentInAbsent($relation-target, $relation-node, $element-target, $element-node)
+    - joinOnDescID($relation, $element, $desc-id)
+    - joinTargetNode($relation, $relation-target, $relation-node)
+    - joinTargetNode($element, $element-target, $element-node)
 - name: primary index swap
   from: old-index-node
   kind: SameStagePrecedence
@@ -390,23 +221,14 @@ deprules
   query:
     - $old-index[Type] = '*scpb.PrimaryIndex'
     - $new-index[Type] = '*scpb.PrimaryIndex'
-    - $old-index[DescID] = $table-id
-    - $new-index[DescID] = $table-id
+    - joinOnDescID($old-index, $new-index, $table-id)
     - $old-index-target[TargetStatus] = ABSENT
     - $new-index-target[TargetStatus] = PUBLIC
     - $old-index-node[CurrentStatus] = VALIDATED
     - $new-index-node[CurrentStatus] = PUBLIC
     - new-primary-index-depends-on-old(*scpb.PrimaryIndex, *scpb.PrimaryIndex)($new-index, $old-index)
-    - $old-index-target[Type] = '*scpb.Target'
-    - $old-index-target[Element] = $old-index
-    - $old-index-node[Type] = '*screl.Node'
-    - $old-index-node[Target] = $old-index-target
-    - $new-index-target[Type] = '*scpb.Target'
-    - $new-index-target[Element] = $new-index
-    - $new-index-node[Type] = '*screl.Node'
-    - $new-index-node[Target] = $new-index-target
-    - $old-index[DescID] = $var-to-tell-rel-from-is-an-element
-    - $new-index[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($old-index, $old-index-target, $old-index-node)
+    - joinTargetNode($new-index, $new-index-target, $new-index-node)
 - name: reverting primary index swap
   from: new-index-node
   kind: SameStagePrecedence
@@ -421,16 +243,8 @@ deprules
     - $new-index-node[CurrentStatus] = VALIDATED
     - $old-index-node[CurrentStatus] = PUBLIC
     - new-primary-index-depends-on-old(*scpb.PrimaryIndex, *scpb.PrimaryIndex)($new-index, $old-index)
-    - $new-index-target[Type] = '*scpb.Target'
-    - $new-index-target[Element] = $new-index
-    - $new-index-node[Type] = '*screl.Node'
-    - $new-index-node[Target] = $new-index-target
-    - $old-index-target[Type] = '*scpb.Target'
-    - $old-index-target[Element] = $old-index
-    - $old-index-node[Type] = '*screl.Node'
-    - $old-index-node[Target] = $old-index-target
-    - $new-index[DescID] = $var-to-tell-rel-from-is-an-element
-    - $old-index[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($new-index, $new-index-target, $new-index-node)
+    - joinTargetNode($old-index, $old-index-target, $old-index-node)
 - name: index existence precedes index dependents
   from: index-node
   kind: Precedence
@@ -438,24 +252,13 @@ deprules
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
     - $index-dependent[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexComment']
-    - $index[DescID] = $desc-id
-    - $index-dependent[DescID] = $desc-id
-    - $index[IndexID] = $index-id
-    - $index-dependent[IndexID] = $index-id
+    - joinOnIndexID($index, $index-dependent, $table-id, $index-id)
     - $index-target[TargetStatus] = PUBLIC
     - $index-dependent-target[TargetStatus] = PUBLIC
     - $index-node[CurrentStatus] = BACKFILL_ONLY
     - $index-dependent-node[CurrentStatus] = PUBLIC
-    - $index-target[Type] = '*scpb.Target'
-    - $index-target[Element] = $index
-    - $index-node[Type] = '*screl.Node'
-    - $index-node[Target] = $index-target
-    - $index-dependent-target[Type] = '*scpb.Target'
-    - $index-dependent-target[Element] = $index-dependent
-    - $index-dependent-node[Type] = '*screl.Node'
-    - $index-dependent-node[Target] = $index-dependent-target
-    - $index[DescID] = $var-to-tell-rel-from-is-an-element
-    - $index-dependent[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($index, $index-target, $index-node)
+    - joinTargetNode($index-dependent, $index-dependent-target, $index-dependent-node)
 - name: partitioning set right after temp index existence
   from: temp-index-node
   kind: SameStagePrecedence
@@ -463,24 +266,13 @@ deprules
   query:
     - $temp-index[Type] = '*scpb.TemporaryIndex'
     - $index-partitioning[Type] = '*scpb.IndexPartitioning'
-    - $temp-index[DescID] = $desc-id
-    - $index-partitioning[DescID] = $desc-id
-    - $temp-index[IndexID] = $index-id
-    - $index-partitioning[IndexID] = $index-id
+    - joinOnIndexID($temp-index, $index-partitioning, $table-id, $index-id)
     - $temp-index-target[TargetStatus] = TRANSIENT_ABSENT
     - $index-partitioning-target[TargetStatus] = PUBLIC
     - $temp-index-node[CurrentStatus] = DELETE_ONLY
     - $index-partitioning-node[CurrentStatus] = PUBLIC
-    - $temp-index-target[Type] = '*scpb.Target'
-    - $temp-index-target[Element] = $temp-index
-    - $temp-index-node[Type] = '*screl.Node'
-    - $temp-index-node[Target] = $temp-index-target
-    - $index-partitioning-target[Type] = '*scpb.Target'
-    - $index-partitioning-target[Element] = $index-partitioning
-    - $index-partitioning-node[Type] = '*screl.Node'
-    - $index-partitioning-node[Target] = $index-partitioning-target
-    - $temp-index[DescID] = $var-to-tell-rel-from-is-an-element
-    - $index-partitioning[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($temp-index, $temp-index-target, $temp-index-node)
+    - joinTargetNode($index-partitioning, $index-partitioning-target, $index-partitioning-node)
 - name: partial predicate set right after secondary index existence
   from: index-node
   kind: SameStagePrecedence
@@ -488,28 +280,13 @@ deprules
   query:
     - $index[Type] = '*scpb.SecondaryIndex'
     - $index-predicate[Type] = '*scpb.SecondaryIndexPartial'
-    - $index[DescID] = $desc-id
-    - $index-predicate[DescID] = $desc-id
-    - $index[IndexID] = $index-id
-    - $index-predicate[IndexID] = $index-id
+    - joinOnIndexID($index, $index-predicate, $table-id, $index-id)
     - $index-target[TargetStatus] = PUBLIC
     - $index-predicate-target[TargetStatus] = PUBLIC
     - $index-node[CurrentStatus] = BACKFILL_ONLY
     - $index-predicate[CurrentStatus] = PUBLIC
-    - $index[DescID] = $desc-id
-    - $index-predicate[DescID] = $desc-id
-    - $index[IndexID] = $index-id
-    - $index-predicate[IndexID] = $index-id
-    - $index-target[Type] = '*scpb.Target'
-    - $index-target[Element] = $index
-    - $index-node[Type] = '*screl.Node'
-    - $index-node[Target] = $index-target
-    - $index-predicate-target[Type] = '*scpb.Target'
-    - $index-predicate-target[Element] = $index-predicate
-    - $index-predicate-node[Type] = '*screl.Node'
-    - $index-predicate-node[Target] = $index-predicate-target
-    - $index[DescID] = $var-to-tell-rel-from-is-an-element
-    - $index-predicate[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($index, $index-target, $index-node)
+    - joinTargetNode($index-predicate, $index-predicate-target, $index-predicate-node)
 - name: dependents existence precedes writes to index
   from: child-node
   kind: Precedence
@@ -517,24 +294,13 @@ deprules
   query:
     - $child[Type] IN ['*scpb.IndexPartitioning', '*scpb.IndexComment']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
-    - $child[DescID] = $desc-id
-    - $index[DescID] = $desc-id
-    - $child[IndexID] = $index-id
-    - $index[IndexID] = $index-id
+    - joinOnIndexID($child, $index, $table-id, $index-id)
     - $child-target[TargetStatus] = PUBLIC
     - $index-target[TargetStatus] = PUBLIC
     - $child-node[CurrentStatus] = PUBLIC
     - $index-node[CurrentStatus] = WRITE_ONLY
-    - $child-target[Type] = '*scpb.Target'
-    - $child-target[Element] = $child
-    - $child-node[Type] = '*screl.Node'
-    - $child-node[Target] = $child-target
-    - $index-target[Type] = '*scpb.Target'
-    - $index-target[Element] = $index
-    - $index-node[Type] = '*screl.Node'
-    - $index-node[Target] = $index-target
-    - $child[DescID] = $var-to-tell-rel-from-is-an-element
-    - $index[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($child, $child-target, $child-node)
+    - joinTargetNode($index, $index-target, $index-node)
 - name: index named right before index becomes public
   from: index-name-node
   kind: SameStagePrecedence
@@ -546,20 +312,9 @@ deprules
     - $index-target[TargetStatus] = PUBLIC
     - $index-name-node[CurrentStatus] = PUBLIC
     - $index-node[CurrentStatus] = PUBLIC
-    - $index-name[DescID] = $desc-id
-    - $index[DescID] = $desc-id
-    - $index-name[IndexID] = $index-id
-    - $index[IndexID] = $index-id
-    - $index-name-target[Type] = '*scpb.Target'
-    - $index-name-target[Element] = $index-name
-    - $index-name-node[Type] = '*screl.Node'
-    - $index-name-node[Target] = $index-name-target
-    - $index-target[Type] = '*scpb.Target'
-    - $index-target[Element] = $index
-    - $index-node[Type] = '*screl.Node'
-    - $index-node[Target] = $index-target
-    - $index-name[DescID] = $var-to-tell-rel-from-is-an-element
-    - $index[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinOnIndexID($index-name, $index, $table-id, $index-id)
+    - joinTargetNode($index-name, $index-name-target, $index-name-node)
+    - joinTargetNode($index, $index-target, $index-node)
 - name: dependents removed after index no longer public
   from: child-node
   kind: SameStagePrecedence
@@ -567,24 +322,13 @@ deprules
   query:
     - $child[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
-    - $child[DescID] = $desc-id
-    - $index[DescID] = $desc-id
-    - $child[IndexID] = $index-id
-    - $index[IndexID] = $index-id
+    - joinOnIndexID($child, $index, $table-id, $index-id)
     - $child-target[TargetStatus] = ABSENT
     - $index-target[TargetStatus] = ABSENT
     - $child-node[CurrentStatus] = ABSENT
     - $index-node[CurrentStatus] = VALIDATED
-    - $child-target[Type] = '*scpb.Target'
-    - $child-target[Element] = $child
-    - $child-node[Type] = '*screl.Node'
-    - $child-node[Target] = $child-target
-    - $index-target[Type] = '*scpb.Target'
-    - $index-target[Element] = $index
-    - $index-node[Type] = '*screl.Node'
-    - $index-node[Target] = $index-target
-    - $child[DescID] = $var-to-tell-rel-from-is-an-element
-    - $index[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($child, $child-target, $child-node)
+    - joinTargetNode($index, $index-target, $index-node)
 - name: dependents removed before index
   from: dependent-node
   kind: Precedence
@@ -592,24 +336,13 @@ deprules
   query:
     - $dependent[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
-    - $dependent[DescID] = $desc-id
-    - $index[DescID] = $desc-id
-    - $dependent[IndexID] = $index-id
-    - $index[IndexID] = $index-id
+    - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - $dependent-target[TargetStatus] = ABSENT
     - $index-target[TargetStatus] = ABSENT
     - $dependent-node[CurrentStatus] = ABSENT
     - $index-node[CurrentStatus] = ABSENT
-    - $dependent-target[Type] = '*scpb.Target'
-    - $dependent-target[Element] = $dependent
-    - $dependent-node[Type] = '*screl.Node'
-    - $dependent-node[Target] = $dependent-target
-    - $index-target[Type] = '*scpb.Target'
-    - $index-target[Element] = $index
-    - $index-node[Type] = '*screl.Node'
-    - $index-node[Target] = $index-target
-    - $dependent[DescID] = $var-to-tell-rel-from-is-an-element
-    - $index[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($dependent, $dependent-target, $dependent-node)
+    - joinTargetNode($index, $index-target, $index-node)
 - name: temp index is WRITE_ONLY before backfill
   from: temp-node
   kind: Precedence
@@ -617,24 +350,15 @@ deprules
   query:
     - $temp[Type] = '*scpb.TemporaryIndex'
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
-    - $temp[DescID] = $desc-id
-    - $index[DescID] = $desc-id
+    - joinOnDescID($temp, $index, $desc-id)
     - $temp[IndexID] = $temp-index-id
     - $index[TemporaryIndexID] = $temp-index-id
     - $temp-target[TargetStatus] = TRANSIENT_ABSENT
     - $index-target[TargetStatus] = PUBLIC
     - $temp-node[CurrentStatus] = WRITE_ONLY
     - $index-node[CurrentStatus] = BACKFILLED
-    - $temp-target[Type] = '*scpb.Target'
-    - $temp-target[Element] = $temp
-    - $temp-node[Type] = '*screl.Node'
-    - $temp-node[Target] = $temp-target
-    - $index-target[Type] = '*scpb.Target'
-    - $index-target[Element] = $index
-    - $index-node[Type] = '*screl.Node'
-    - $index-node[Target] = $index-target
-    - $temp[DescID] = $var-to-tell-rel-from-is-an-element
-    - $index[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($temp, $temp-target, $temp-node)
+    - joinTargetNode($index, $index-target, $index-node)
 - name: column name set right after column existence
   from: column-node
   kind: SameStagePrecedence
@@ -646,20 +370,9 @@ deprules
     - $column-name-target[TargetStatus] = PUBLIC
     - $column-node[CurrentStatus] = DELETE_ONLY
     - $column-name-node[CurrentStatus] = PUBLIC
-    - $column[DescID] = $desc-id
-    - $column-name[DescID] = $desc-id
-    - $column[ColumnID] = $column-id
-    - $column-name[ColumnID] = $column-id
-    - $column-target[Type] = '*scpb.Target'
-    - $column-target[Element] = $column
-    - $column-node[Type] = '*screl.Node'
-    - $column-node[Target] = $column-target
-    - $column-name-target[Type] = '*scpb.Target'
-    - $column-name-target[Element] = $column-name
-    - $column-name-node[Type] = '*screl.Node'
-    - $column-name-node[Target] = $column-name-target
-    - $column[DescID] = $var-to-tell-rel-from-is-an-element
-    - $column-name[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinOnColumnID($column, $column-name, $table-id, $col-id)
+    - joinTargetNode($column, $column-target, $column-node)
+    - joinTargetNode($column-name, $column-name-target, $column-name-node)
 - name: column existence precedes column dependents
   from: column-node
   kind: Precedence
@@ -667,24 +380,13 @@ deprules
   query:
     - $column[Type] = '*scpb.Column'
     - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnComment']
-    - $column[DescID] = $desc-id
-    - $dependent[DescID] = $desc-id
-    - $column[ColumnID] = $column-id
-    - $dependent[ColumnID] = $column-id
+    - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - $column-target[TargetStatus] = PUBLIC
     - $dependent-target[TargetStatus] = PUBLIC
     - $column-node[CurrentStatus] = DELETE_ONLY
     - $dependent-node[CurrentStatus] = PUBLIC
-    - $column-target[Type] = '*scpb.Target'
-    - $column-target[Element] = $column
-    - $column-node[Type] = '*screl.Node'
-    - $column-node[Target] = $column-target
-    - $dependent-target[Type] = '*scpb.Target'
-    - $dependent-target[Element] = $dependent
-    - $dependent-node[Type] = '*screl.Node'
-    - $dependent-node[Target] = $dependent-target
-    - $column[DescID] = $var-to-tell-rel-from-is-an-element
-    - $dependent[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($column, $column-target, $column-node)
+    - joinTargetNode($dependent, $dependent-target, $dependent-node)
 - name: DEFAULT or ON UPDATE existence precedes writes to column
   from: expr-node
   kind: Precedence
@@ -692,24 +394,13 @@ deprules
   query:
     - $expr[Type] IN ['*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression']
     - $column[Type] = '*scpb.Column'
-    - $expr[DescID] = $desc-id
-    - $column[DescID] = $desc-id
-    - $expr[ColumnID] = $column-id
-    - $column[ColumnID] = $column-id
+    - joinOnColumnID($expr, $column, $table-id, $col-id)
     - $expr-target[TargetStatus] = PUBLIC
     - $column-target[TargetStatus] = PUBLIC
     - $expr-node[CurrentStatus] = PUBLIC
     - $column-node[CurrentStatus] = WRITE_ONLY
-    - $expr-target[Type] = '*scpb.Target'
-    - $expr-target[Element] = $expr
-    - $expr-node[Type] = '*screl.Node'
-    - $expr-node[Target] = $expr-target
-    - $column-target[Type] = '*scpb.Target'
-    - $column-target[Element] = $column
-    - $column-node[Type] = '*screl.Node'
-    - $column-node[Target] = $column-target
-    - $expr[DescID] = $var-to-tell-rel-from-is-an-element
-    - $column[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($expr, $expr-target, $expr-node)
+    - joinTargetNode($column, $column-target, $column-node)
 - name: column named right before column type becomes public
   from: column-name-node
   kind: SameStagePrecedence
@@ -717,24 +408,13 @@ deprules
   query:
     - $column-name[Type] = '*scpb.ColumnName'
     - $column-type[Type] = '*scpb.ColumnType'
-    - $column-name[DescID] = $desc-id
-    - $column-type[DescID] = $desc-id
-    - $column-name[ColumnID] = $column-id
-    - $column-type[ColumnID] = $column-id
+    - joinOnColumnID($column-name, $column-type, $table-id, $col-id)
     - $column-name-target[TargetStatus] = PUBLIC
     - $column-type-target[TargetStatus] = PUBLIC
     - $column-name-node[CurrentStatus] = PUBLIC
     - $column-type-node[CurrentStatus] = PUBLIC
-    - $column-name-target[Type] = '*scpb.Target'
-    - $column-name-target[Element] = $column-name
-    - $column-name-node[Type] = '*screl.Node'
-    - $column-name-node[Target] = $column-name-target
-    - $column-type-target[Type] = '*scpb.Target'
-    - $column-type-target[Element] = $column-type
-    - $column-type-node[Type] = '*screl.Node'
-    - $column-type-node[Target] = $column-type-target
-    - $column-name[DescID] = $var-to-tell-rel-from-is-an-element
-    - $column-type[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($column-name, $column-name-target, $column-name-node)
+    - joinTargetNode($column-type, $column-type-target, $column-type-node)
 - name: column comment exists before column becomes public
   from: column-comment-node
   kind: Precedence
@@ -742,24 +422,13 @@ deprules
   query:
     - $column-comment[Type] = '*scpb.ColumnComment'
     - $column[Type] = '*scpb.Column'
-    - $column-comment[DescID] = $desc-id
-    - $column[DescID] = $desc-id
-    - $column-comment[ColumnID] = $column-id
-    - $column[ColumnID] = $column-id
+    - joinOnColumnID($column-comment, $column, $table-id, $col-id)
     - $column-comment-target[TargetStatus] = PUBLIC
     - $column-target[TargetStatus] = PUBLIC
     - $column-comment-node[CurrentStatus] = PUBLIC
     - $column-node[CurrentStatus] = PUBLIC
-    - $column-comment-target[Type] = '*scpb.Target'
-    - $column-comment-target[Element] = $column-comment
-    - $column-comment-node[Type] = '*screl.Node'
-    - $column-comment-node[Target] = $column-comment-target
-    - $column-target[Type] = '*scpb.Target'
-    - $column-target[Element] = $column
-    - $column-node[Type] = '*screl.Node'
-    - $column-node[Target] = $column-target
-    - $column-comment[DescID] = $var-to-tell-rel-from-is-an-element
-    - $column[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($column-comment, $column-comment-target, $column-comment-node)
+    - joinTargetNode($column, $column-target, $column-node)
 - name: column dependents removed after column no longer public
   from: column-node
   kind: Precedence
@@ -767,24 +436,13 @@ deprules
   query:
     - $column[Type] = '*scpb.Column'
     - $dependent[Type] IN ['*scpb.ColumnType', '*scpb.ColumnName', '*scpb.ColumnComment']
-    - $column[DescID] = $desc-id
-    - $dependent[DescID] = $desc-id
-    - $column[ColumnID] = $column-id
-    - $dependent[ColumnID] = $column-id
+    - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - $column-target[TargetStatus] = ABSENT
     - $dependent-target[TargetStatus] = ABSENT
     - $column-node[CurrentStatus] = WRITE_ONLY
     - $dependent-node[CurrentStatus] = ABSENT
-    - $column-target[Type] = '*scpb.Target'
-    - $column-target[Element] = $column
-    - $column-node[Type] = '*screl.Node'
-    - $column-node[Target] = $column-target
-    - $dependent-target[Type] = '*scpb.Target'
-    - $dependent-target[Element] = $dependent
-    - $dependent-node[Type] = '*screl.Node'
-    - $dependent-node[Target] = $dependent-target
-    - $column[DescID] = $var-to-tell-rel-from-is-an-element
-    - $dependent[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($column, $column-target, $column-node)
+    - joinTargetNode($dependent, $dependent-target, $dependent-node)
 - name: column type dependents removed right before column type
   from: dependent-node
   kind: SameStagePrecedence
@@ -792,24 +450,13 @@ deprules
   query:
     - $dependent[Type] IN ['*scpb.SequenceOwner', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression']
     - $column-type[Type] = '*scpb.ColumnType'
-    - $dependent[DescID] = $desc-id
-    - $column-type[DescID] = $desc-id
-    - $dependent[ColumnID] = $column-id
-    - $column-type[ColumnID] = $column-id
+    - joinOnColumnID($dependent, $column-type, $table-id, $col-id)
     - $dependent-target[TargetStatus] = ABSENT
     - $column-type-target[TargetStatus] = ABSENT
     - $dependent-node[CurrentStatus] = ABSENT
     - $column-type-node[CurrentStatus] = ABSENT
-    - $dependent-target[Type] = '*scpb.Target'
-    - $dependent-target[Element] = $dependent
-    - $dependent-node[Type] = '*screl.Node'
-    - $dependent-node[Target] = $dependent-target
-    - $column-type-target[Type] = '*scpb.Target'
-    - $column-type-target[Element] = $column-type
-    - $column-type-node[Type] = '*screl.Node'
-    - $column-type-node[Target] = $column-type-target
-    - $dependent[DescID] = $var-to-tell-rel-from-is-an-element
-    - $column-type[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($dependent, $dependent-target, $dependent-node)
+    - joinTargetNode($column-type, $column-type-target, $column-type-node)
 - name: dependents removed before column
   from: dependent-node
   kind: Precedence
@@ -817,24 +464,13 @@ deprules
   query:
     - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnComment']
     - $column[Type] = '*scpb.Column'
-    - $dependent[DescID] = $desc-id
-    - $column[DescID] = $desc-id
-    - $dependent[ColumnID] = $column-id
-    - $column[ColumnID] = $column-id
+    - joinOnColumnID($dependent, $column, $table-id, $col-id)
     - $dependent-target[TargetStatus] = ABSENT
     - $column-target[TargetStatus] = ABSENT
     - $dependent-node[CurrentStatus] = ABSENT
     - $column-node[CurrentStatus] = ABSENT
-    - $dependent-target[Type] = '*scpb.Target'
-    - $dependent-target[Element] = $dependent
-    - $dependent-node[Type] = '*screl.Node'
-    - $dependent-node[Target] = $dependent-target
-    - $column-target[Type] = '*scpb.Target'
-    - $column-target[Element] = $column
-    - $column-node[Type] = '*screl.Node'
-    - $column-node[Target] = $column-target
-    - $dependent[DescID] = $var-to-tell-rel-from-is-an-element
-    - $column[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($dependent, $dependent-target, $dependent-node)
+    - joinTargetNode($column, $column-target, $column-node)
 - name: column type removed right before column when not dropping relation
   from: column-type-node
   kind: SameStagePrecedence
@@ -842,25 +478,14 @@ deprules
   query:
     - $column-type[Type] = '*scpb.ColumnType'
     - $column[Type] = '*scpb.Column'
-    - $column-type[DescID] = $desc-id
-    - $column[DescID] = $desc-id
-    - $column-type[ColumnID] = $column-id
-    - $column[ColumnID] = $column-id
+    - joinOnColumnID($column-type, $column, $table-id, $col-id)
     - $column-type-target[TargetStatus] = ABSENT
     - $column-target[TargetStatus] = ABSENT
     - $column-type-node[CurrentStatus] = ABSENT
     - $column-node[CurrentStatus] = ABSENT
     - columnTypeIsNotBeingDropped(*scpb.ColumnType)($column-type)
-    - $column-type-target[Type] = '*scpb.Target'
-    - $column-type-target[Element] = $column-type
-    - $column-type-node[Type] = '*screl.Node'
-    - $column-type-node[Target] = $column-type-target
-    - $column-target[Type] = '*scpb.Target'
-    - $column-target[Element] = $column
-    - $column-node[Type] = '*screl.Node'
-    - $column-node[Target] = $column-target
-    - $column-type[DescID] = $var-to-tell-rel-from-is-an-element
-    - $column[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($column-type, $column-type-target, $column-type-node)
+    - joinTargetNode($column, $column-target, $column-node)
 - name: partial predicate removed right before secondary index when not dropping relation
   from: partial-predicate-node
   kind: SameStagePrecedence
@@ -868,25 +493,14 @@ deprules
   query:
     - $partial-predicate[Type] = '*scpb.SecondaryIndexPartial'
     - $index[Type] = '*scpb.SecondaryIndex'
-    - $partial-predicate[DescID] = $desc-id
-    - $index[DescID] = $desc-id
-    - $partial-predicate[IndexID] = $index-id
-    - $index[IndexID] = $index-id
+    - joinOnIndexID($partial-predicate, $index, $table-id, $index-id)
     - $partial-predicate-target[TargetStatus] = ABSENT
     - $index-target[TargetStatus] = ABSENT
     - $partial-predicate-node[CurrentStatus] = ABSENT
     - $index-node[CurrentStatus] = ABSENT
     - secondaryIndexPartialIsNotBeingDropped(*scpb.SecondaryIndexPartial)($partial-predicate)
-    - $partial-predicate-target[Type] = '*scpb.Target'
-    - $partial-predicate-target[Element] = $partial-predicate
-    - $partial-predicate-node[Type] = '*screl.Node'
-    - $partial-predicate-node[Target] = $partial-predicate-target
-    - $index-target[Type] = '*scpb.Target'
-    - $index-target[Element] = $index
-    - $index-node[Type] = '*screl.Node'
-    - $index-node[Target] = $index-target
-    - $partial-predicate[DescID] = $var-to-tell-rel-from-is-an-element
-    - $index[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($partial-predicate, $partial-predicate-target, $partial-predicate-node)
+    - joinTargetNode($index, $index-target, $index-node)
 - name: column depends on primary index
   from: index-node
   kind: Precedence
@@ -902,16 +516,8 @@ deprules
     - $status IN [WRITE_ONLY, PUBLIC]
     - $index-node[CurrentStatus] = $status
     - $column-node[CurrentStatus] = $status
-    - $index-target[Type] = '*scpb.Target'
-    - $index-target[Element] = $index
-    - $index-node[Type] = '*screl.Node'
-    - $index-node[Target] = $index-target
-    - $column-target[Type] = '*scpb.Target'
-    - $column-target[Element] = $column
-    - $column-node[Type] = '*screl.Node'
-    - $column-node[Target] = $column-target
-    - $index[DescID] = $var-to-tell-rel-from-is-an-element
-    - $column[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($index, $index-target, $index-node)
+    - joinTargetNode($column, $column-target, $column-node)
 - name: primary index should be cleaned up before newly added column when reverting
   from: index-node
   kind: Precedence
@@ -927,16 +533,8 @@ deprules
     - $status = WRITE_ONLY
     - $index-node[CurrentStatus] = $status
     - $column-node[CurrentStatus] = $status
-    - $index-target[Type] = '*scpb.Target'
-    - $index-target[Element] = $index
-    - $index-node[Type] = '*screl.Node'
-    - $index-node[Target] = $index-target
-    - $column-target[Type] = '*scpb.Target'
-    - $column-target[Element] = $column
-    - $column-node[Type] = '*screl.Node'
-    - $column-node[Target] = $column-target
-    - $index[DescID] = $var-to-tell-rel-from-is-an-element
-    - $column[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($index, $index-target, $index-node)
+    - joinTargetNode($column, $column-target, $column-node)
 - name: column existence precedes index existence
   from: column-node
   kind: Precedence
@@ -951,16 +549,8 @@ deprules
     - $column[DescID] = $table-id
     - $index[DescID] = $table-id
     - columnFeaturedInIndex(*scpb.Column, scpb.Element)($column, $index)
-    - $column-target[Type] = '*scpb.Target'
-    - $column-target[Element] = $column
-    - $column-node[Type] = '*screl.Node'
-    - $column-node[Target] = $column-target
-    - $index-target[Type] = '*scpb.Target'
-    - $index-target[Element] = $index
-    - $index-node[Type] = '*screl.Node'
-    - $index-node[Target] = $index-target
-    - $column[DescID] = $var-to-tell-rel-from-is-an-element
-    - $index[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($column, $column-target, $column-node)
+    - joinTargetNode($index, $index-target, $index-node)
 - name: column existence precedes temporary index existence
   from: column-node
   kind: Precedence
@@ -975,16 +565,8 @@ deprules
     - $column-node[CurrentStatus] = DELETE_ONLY
     - $temp-index-node[CurrentStatus] = DELETE_ONLY
     - columnFeaturedInIndex(*scpb.Column, scpb.Element)($column, $temp-index)
-    - $column-target[Type] = '*scpb.Target'
-    - $column-target[Element] = $column
-    - $column-node[Type] = '*screl.Node'
-    - $column-node[Target] = $column-target
-    - $temp-index-target[Type] = '*scpb.Target'
-    - $temp-index-target[Element] = $temp-index
-    - $temp-index-node[Type] = '*screl.Node'
-    - $temp-index-node[Target] = $temp-index-target
-    - $column[DescID] = $var-to-tell-rel-from-is-an-element
-    - $temp-index[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($column, $column-target, $column-node)
+    - joinTargetNode($temp-index, $temp-index-target, $temp-index-node)
 - name: primary index with new columns should exist before secondary/temp indexes
   from: primary-index-node
   kind: Precedence
@@ -999,16 +581,8 @@ deprules
     - $primary-index-node[CurrentStatus] = VALIDATED
     - $second-index-node[CurrentStatus] = BACKFILL_ONLY
     - newColumnFeaturedInIndex(*scpb.PrimaryIndex, scpb.Element)($primary-index, $second-index)
-    - $primary-index-target[Type] = '*scpb.Target'
-    - $primary-index-target[Element] = $primary-index
-    - $primary-index-node[Type] = '*screl.Node'
-    - $primary-index-node[Target] = $primary-index-target
-    - $second-index-target[Type] = '*scpb.Target'
-    - $second-index-target[Element] = $second-index
-    - $second-index-node[Type] = '*screl.Node'
-    - $second-index-node[Target] = $second-index-target
-    - $primary-index[DescID] = $var-to-tell-rel-from-is-an-element
-    - $second-index[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($primary-index, $primary-index-target, $primary-index-node)
+    - joinTargetNode($second-index, $second-index-target, $second-index-node)
 - name: secondary indexes should be cleaned up before any primary index with columns when reverting
   from: second-index-node
   kind: Precedence
@@ -1023,16 +597,8 @@ deprules
     - $second-index-node[CurrentStatus] = ABSENT
     - $primary-index-node[CurrentStatus] = VALIDATED
     - newColumnFeaturedInIndex(scpb.Element, *scpb.PrimaryIndex)($second-index, $primary-index)
-    - $second-index-target[Type] = '*scpb.Target'
-    - $second-index-target[Element] = $second-index
-    - $second-index-node[Type] = '*screl.Node'
-    - $second-index-node[Target] = $second-index-target
-    - $primary-index-target[Type] = '*scpb.Target'
-    - $primary-index-target[Element] = $primary-index
-    - $primary-index-node[Type] = '*screl.Node'
-    - $primary-index-node[Target] = $primary-index-target
-    - $second-index[DescID] = $var-to-tell-rel-from-is-an-element
-    - $primary-index[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($second-index, $second-index-target, $second-index-node)
+    - joinTargetNode($primary-index, $primary-index-target, $primary-index-node)
 - name: ensure columns are in increasing order
   from: later-column-node
   kind: SameStagePrecedence
@@ -1048,13 +614,5 @@ deprules
     - $later-column-node[CurrentStatus] = $status
     - $earlier-column-node[CurrentStatus] = $status
     - columnHasSmallerID(*scpb.Column, *scpb.Column)($later-column, $earlier-column)
-    - $later-column-target[Type] = '*scpb.Target'
-    - $later-column-target[Element] = $later-column
-    - $later-column-node[Type] = '*screl.Node'
-    - $later-column-node[Target] = $later-column-target
-    - $earlier-column-target[Type] = '*scpb.Target'
-    - $earlier-column-target[Element] = $earlier-column
-    - $earlier-column-node[Type] = '*screl.Node'
-    - $earlier-column-node[Target] = $earlier-column-target
-    - $later-column[DescID] = $var-to-tell-rel-from-is-an-element
-    - $earlier-column[DescID] = $var-to-tell-rel-to-is-an-element
+    - joinTargetNode($later-column, $later-column-target, $later-column-node)
+    - joinTargetNode($earlier-column, $earlier-column-target, $earlier-column-node)

--- a/pkg/sql/schemachanger/scplan/internal/rules/testdata/oprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/testdata/oprules
@@ -1,3 +1,43 @@
+rules
+----
+joinTarget(element, target):
+    - $target[Type] = '*scpb.Target'
+    - $target[Element] = $element
+    - $element[DescID] = $_
+joinTargetNode(element, target, node):
+    - joinTarget($element, $target)
+    - $node[Type] = '*screl.Node'
+    - $node[Target] = $target
+toAbsent(target1, target2):
+    - $target1[TargetStatus] = ABSENT
+    - $target2[TargetStatus] = ABSENT
+toAbsentInDropped(target1, node1, target2, node2):
+    - toAbsent($target1, $target2)
+    - $node1[CurrentStatus] = DROPPED
+    - $node2[CurrentStatus] = DROPPED
+toAbsentInAbsent(target1, node1, target2, node2):
+    - toAbsent($target1, $target2)
+    - $node1[CurrentStatus] = ABSENT
+    - $node2[CurrentStatus] = ABSENT
+joinReferencedDescID(referrer, referenced, id):
+    - $referrer[ReferencedDescID] = $id
+    - $referenced[DescID] = $id
+joinOnDescID(a, b, id):
+    - $a[DescID] = $id
+    - $b[DescID] = $id
+joinOnIndexID(a, b, desc-id, index-id):
+    - joinOnDescID($a, $b, $desc-id)
+    - $a[IndexID] = $index-id
+    - $b[IndexID] = $index-id
+joinOnColumnID(a, b, desc-id, col-id):
+    - joinOnDescID($a, $b, $desc-id)
+    - $a[ColumnID] = $col-id
+    - $b[ColumnID] = $col-id
+joinOnConstraintID(a, b, desc-id, constraint-id):
+    - joinOnDescID($a, $b, $desc-id)
+    - $a[ConstraintID] = $constraint-id
+    - $b[ConstraintID] = $constraint-id
+
 oprules
 ----
 - name: skip column removal ops on relation drop
@@ -5,12 +45,10 @@ oprules
   query:
     - $relation[Type] IN ['*scpb.Table', '*scpb.View']
     - $column[Type] = '*scpb.Column'
-    - $relation[DescID] = $relation-id
-    - $column[DescID] = $relation-id
+    - joinOnDescID($relation, $column, $relation-id)
     - joinTarget($relation, $relation-target)
-    - $relation-target[TargetStatus] = ABSENT
+    - toAbsent($relation-target, $column-target)
     - joinTargetNode($column, $column-target, $column-node)
-    - $column-target[TargetStatus] = ABSENT
     - $column-node[CurrentStatus] IN [PUBLIC, WRITE_ONLY]
 - name: skip column dependents removal ops on relation drop
   from: column-dep-node
@@ -18,15 +56,11 @@ oprules
     - $relation[Type] IN ['*scpb.Table', '*scpb.View']
     - $column[Type] = '*scpb.Column'
     - $column-dep[Type] = '*scpb.ColumnName'
-    - $relation[DescID] = $relation-id
-    - $column[DescID] = $relation-id
-    - $column-dep[DescID] = $relation-id
-    - $column[ColumnID] = $column-id
-    - $column-dep[ColumnID] = $column-id
+    - joinOnDescID($relation, $column, $relation-id)
+    - joinOnColumnID($column, $column-dep, $relation-id, $column-id)
     - joinTarget($relation, $relation-target)
-    - $relation-target[TargetStatus] = ABSENT
+    - toAbsent($relation-target, $column-target)
     - joinTarget($column, $column-target)
-    - $column-target[TargetStatus] = ABSENT
     - joinTargetNode($column-dep, $column-dep-target, $column-dep-node)
     - $column-dep-target[TargetStatus] = ABSENT
 - name: skip index removal ops on relation drop
@@ -34,27 +68,21 @@ oprules
   query:
     - $relation[Type] IN ['*scpb.Table', '*scpb.View']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
-    - $relation[DescID] = $relation-id
-    - $index[DescID] = $relation-id
+    - joinOnDescID($relation, $index, $relation-id)
     - joinTarget($relation, $relation-target)
-    - $relation-target[TargetStatus] = ABSENT
     - joinTargetNode($index, $index-target, $index-node)
-    - $index-target[TargetStatus] = ABSENT
+    - toAbsent($relation-target, $index-target)
 - name: skip index dependents removal ops on relation drop
   from: index-dep-node
   query:
     - $relation[Type] IN ['*scpb.Table', '*scpb.View']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
     - $index-dep[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning']
-    - $relation[DescID] = $relation-id
-    - $index[DescID] = $relation-id
-    - $index-dep[DescID] = $relation-id
-    - $index[IndexID] = $index-id
-    - $index-dep[IndexID] = $index-id
+    - joinOnDescID($relation, $index, $relation-id)
+    - joinOnIndexID($index, $index-dep, $relation-id, $index-id)
     - joinTarget($relation, $relation-target)
-    - $relation-target[TargetStatus] = ABSENT
+    - toAbsent($relation-target, $index-target)
     - joinTarget($index, $index-target)
-    - $index-target[TargetStatus] = ABSENT
     - joinTargetNode($index-dep, $index-dep-target, $index-dep-node)
     - $index-dep-target[TargetStatus] = ABSENT
 - name: skip constraint removal ops on relation drop
@@ -62,27 +90,21 @@ oprules
   query:
     - $relation[Type] IN ['*scpb.Table', '*scpb.View']
     - $constraint[Type] = '*scpb.UniqueWithoutIndexConstraint'
-    - $relation[DescID] = $relation-id
-    - $constraint[DescID] = $relation-id
+    - joinOnDescID($relation, $constraint, $relation-id)
     - joinTarget($relation, $relation-target)
-    - $relation-target[TargetStatus] = ABSENT
+    - toAbsent($relation-target, $constraint-target)
     - joinTargetNode($constraint, $constraint-target, $constraint-node)
-    - $constraint-target[TargetStatus] = ABSENT
 - name: skip constraint dependents removal ops on relation drop
   from: constraint-dep-node
   query:
     - $relation[Type] IN ['*scpb.Table', '*scpb.View']
     - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
     - $constraint-dep[Type] = '*scpb.ConstraintName'
-    - $relation[DescID] = $relation-id
-    - $constraint[DescID] = $relation-id
-    - $constraint-dep[DescID] = $relation-id
-    - $constraint[ConstraintID] = $constraint-id
-    - $constraint-dep[ConstraintID] = $constraint-id
+    - joinOnDescID($relation, $constraint, $relation-id)
+    - joinOnConstraintID($constraint, $constraint-dep, $relation-id, $constraint-id)
     - joinTarget($relation, $relation-target)
-    - $relation-target[TargetStatus] = ABSENT
     - joinTarget($constraint, $constraint-target)
-    - $constraint-target[TargetStatus] = ABSENT
+    - toAbsent($relation-target, $constraint-target)
     - joinTargetNode($constraint-dep, $constraint-dep-target, $constraint-dep-node)
     - $constraint-dep-target[TargetStatus] = ABSENT
 - name: skip element removal ops on descriptor drop
@@ -90,20 +112,16 @@ oprules
   query:
     - $desc[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.Table', '*scpb.View', '*scpb.Sequence', '*scpb.AliasType', '*scpb.EnumType']
     - $dep[Type] IN ['*scpb.ColumnFamily', '*scpb.Owner', '*scpb.UserPrivileges']
-    - $desc[DescID] = $desc-id
-    - $dep[DescID] = $desc-id
+    - joinOnDescID($desc, $dep, $desc-id)
     - joinTarget($desc, $desc-target)
-    - $desc-target[TargetStatus] = ABSENT
+    - toAbsent($desc-target, $dep-target)
     - joinTargetNode($dep, $dep-target, $dep-node)
-    - $dep-target[TargetStatus] = ABSENT
 - name: skip table comment removal ops on descriptor drop
   from: dep-node
   query:
     - $desc[Type] IN ['*scpb.Table', '*scpb.View', '*scpb.Sequence']
     - $dep[Type] IN ['*scpb.ColumnComment', '*scpb.IndexComment', '*scpb.ConstraintComment', '*scpb.TableComment']
-    - $desc[DescID] = $desc-id
-    - $dep[DescID] = $desc-id
+    - joinOnDescID($desc, $dep, $desc-id)
     - joinTarget($desc, $desc-target)
-    - $desc-target[TargetStatus] = ABSENT
+    - toAbsent($desc-target, $dep-target)
     - joinTargetNode($dep, $dep-target, $dep-node)
-    - $dep-target[TargetStatus] = ABSENT

--- a/pkg/sql/schemachanger/scplan/internal/rules/testdata/oprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/testdata/oprules
@@ -7,13 +7,9 @@ oprules
     - $column[Type] = '*scpb.Column'
     - $relation[DescID] = $relation-id
     - $column[DescID] = $relation-id
-    - $relation-target[Type] = '*scpb.Target'
-    - $relation-target[Element] = $relation
+    - joinTarget($relation, $relation-target)
     - $relation-target[TargetStatus] = ABSENT
-    - $column-target[Type] = '*scpb.Target'
-    - $column-target[Element] = $column
-    - $column-node[Type] = '*screl.Node'
-    - $column-node[Target] = $column-target
+    - joinTargetNode($column, $column-target, $column-node)
     - $column-target[TargetStatus] = ABSENT
     - $column-node[CurrentStatus] IN [PUBLIC, WRITE_ONLY]
 - name: skip column dependents removal ops on relation drop
@@ -27,16 +23,11 @@ oprules
     - $column-dep[DescID] = $relation-id
     - $column[ColumnID] = $column-id
     - $column-dep[ColumnID] = $column-id
-    - $relation-target[Type] = '*scpb.Target'
-    - $relation-target[Element] = $relation
+    - joinTarget($relation, $relation-target)
     - $relation-target[TargetStatus] = ABSENT
-    - $column-target[Type] = '*scpb.Target'
-    - $column-target[Element] = $column
+    - joinTarget($column, $column-target)
     - $column-target[TargetStatus] = ABSENT
-    - $column-dep-target[Type] = '*scpb.Target'
-    - $column-dep-target[Element] = $column-dep
-    - $column-dep-node[Type] = '*screl.Node'
-    - $column-dep-node[Target] = $column-dep-target
+    - joinTargetNode($column-dep, $column-dep-target, $column-dep-node)
     - $column-dep-target[TargetStatus] = ABSENT
 - name: skip index removal ops on relation drop
   from: index-node
@@ -45,13 +36,9 @@ oprules
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
     - $relation[DescID] = $relation-id
     - $index[DescID] = $relation-id
-    - $relation-target[Type] = '*scpb.Target'
-    - $relation-target[Element] = $relation
+    - joinTarget($relation, $relation-target)
     - $relation-target[TargetStatus] = ABSENT
-    - $index-target[Type] = '*scpb.Target'
-    - $index-target[Element] = $index
-    - $index-node[Type] = '*screl.Node'
-    - $index-node[Target] = $index-target
+    - joinTargetNode($index, $index-target, $index-node)
     - $index-target[TargetStatus] = ABSENT
 - name: skip index dependents removal ops on relation drop
   from: index-dep-node
@@ -64,16 +51,11 @@ oprules
     - $index-dep[DescID] = $relation-id
     - $index[IndexID] = $index-id
     - $index-dep[IndexID] = $index-id
-    - $relation-target[Type] = '*scpb.Target'
-    - $relation-target[Element] = $relation
+    - joinTarget($relation, $relation-target)
     - $relation-target[TargetStatus] = ABSENT
-    - $index-target[Type] = '*scpb.Target'
-    - $index-target[Element] = $index
+    - joinTarget($index, $index-target)
     - $index-target[TargetStatus] = ABSENT
-    - $index-dep-target[Type] = '*scpb.Target'
-    - $index-dep-target[Element] = $index-dep
-    - $index-dep-node[Type] = '*screl.Node'
-    - $index-dep-node[Target] = $index-dep-target
+    - joinTargetNode($index-dep, $index-dep-target, $index-dep-node)
     - $index-dep-target[TargetStatus] = ABSENT
 - name: skip constraint removal ops on relation drop
   from: constraint-node
@@ -82,13 +64,9 @@ oprules
     - $constraint[Type] = '*scpb.UniqueWithoutIndexConstraint'
     - $relation[DescID] = $relation-id
     - $constraint[DescID] = $relation-id
-    - $relation-target[Type] = '*scpb.Target'
-    - $relation-target[Element] = $relation
+    - joinTarget($relation, $relation-target)
     - $relation-target[TargetStatus] = ABSENT
-    - $constraint-target[Type] = '*scpb.Target'
-    - $constraint-target[Element] = $constraint
-    - $constraint-node[Type] = '*screl.Node'
-    - $constraint-node[Target] = $constraint-target
+    - joinTargetNode($constraint, $constraint-target, $constraint-node)
     - $constraint-target[TargetStatus] = ABSENT
 - name: skip constraint dependents removal ops on relation drop
   from: constraint-dep-node
@@ -101,16 +79,11 @@ oprules
     - $constraint-dep[DescID] = $relation-id
     - $constraint[ConstraintID] = $constraint-id
     - $constraint-dep[ConstraintID] = $constraint-id
-    - $relation-target[Type] = '*scpb.Target'
-    - $relation-target[Element] = $relation
+    - joinTarget($relation, $relation-target)
     - $relation-target[TargetStatus] = ABSENT
-    - $constraint-target[Type] = '*scpb.Target'
-    - $constraint-target[Element] = $constraint
+    - joinTarget($constraint, $constraint-target)
     - $constraint-target[TargetStatus] = ABSENT
-    - $constraint-dep-target[Type] = '*scpb.Target'
-    - $constraint-dep-target[Element] = $constraint-dep
-    - $constraint-dep-node[Type] = '*screl.Node'
-    - $constraint-dep-node[Target] = $constraint-dep-target
+    - joinTargetNode($constraint-dep, $constraint-dep-target, $constraint-dep-node)
     - $constraint-dep-target[TargetStatus] = ABSENT
 - name: skip element removal ops on descriptor drop
   from: dep-node
@@ -119,13 +92,9 @@ oprules
     - $dep[Type] IN ['*scpb.ColumnFamily', '*scpb.Owner', '*scpb.UserPrivileges']
     - $desc[DescID] = $desc-id
     - $dep[DescID] = $desc-id
-    - $desc-target[Type] = '*scpb.Target'
-    - $desc-target[Element] = $desc
+    - joinTarget($desc, $desc-target)
     - $desc-target[TargetStatus] = ABSENT
-    - $dep-target[Type] = '*scpb.Target'
-    - $dep-target[Element] = $dep
-    - $dep-node[Type] = '*screl.Node'
-    - $dep-node[Target] = $dep-target
+    - joinTargetNode($dep, $dep-target, $dep-node)
     - $dep-target[TargetStatus] = ABSENT
 - name: skip table comment removal ops on descriptor drop
   from: dep-node
@@ -134,11 +103,7 @@ oprules
     - $dep[Type] IN ['*scpb.ColumnComment', '*scpb.IndexComment', '*scpb.ConstraintComment', '*scpb.TableComment']
     - $desc[DescID] = $desc-id
     - $dep[DescID] = $desc-id
-    - $desc-target[Type] = '*scpb.Target'
-    - $desc-target[Element] = $desc
+    - joinTarget($desc, $desc-target)
     - $desc-target[TargetStatus] = ABSENT
-    - $dep-target[Type] = '*scpb.Target'
-    - $dep-target[Element] = $dep
-    - $dep-node[Type] = '*screl.Node'
-    - $dep-node[Target] = $dep-target
+    - joinTargetNode($dep, $dep-target, $dep-node)
     - $dep-target[TargetStatus] = ABSENT

--- a/pkg/sql/schemachanger/screl/attr.go
+++ b/pkg/sql/schemachanger/screl/attr.go
@@ -291,21 +291,30 @@ var Schema = rel.MustSchema("screl", append(
 	),
 )...)
 
-// JoinTarget generates a clause that joins the target
-// to the corresponding element.
-func JoinTarget(element, target rel.Var) rel.Clause {
-	return rel.And(
-		target.Type((*scpb.Target)(nil)),
-		target.AttrEqVar(Element, element),
-	)
-}
+var (
+	// JoinTarget generates a clause that joins the target
+	// to the corresponding element.
+	JoinTarget = Schema.Def2(
+		"joinTarget", "element", "target", func(
+			element, target rel.Var,
+		) rel.Clauses {
+			return rel.Clauses{
+				target.Type((*scpb.Target)(nil)),
+				target.AttrEqVar(Element, element),
+				element.AttrEqVar(DescID, rel.Blank),
+			}
+		})
 
-// JoinTargetNode generates a clause that joins the target and node vars
-// to the corresponding element.
-func JoinTargetNode(element, target, node rel.Var) rel.Clause {
-	return rel.And(
-		JoinTarget(element, target),
-		node.Type((*Node)(nil)),
-		node.AttrEqVar(Target, target),
-	)
-}
+	// JoinTargetNode generates a clause that joins the target and node vars
+	// to the corresponding element.
+	JoinTargetNode = Schema.Def3(
+		"joinTargetNode", "element", "target", "node", func(
+			element, target, node rel.Var,
+		) rel.Clauses {
+			return rel.Clauses{
+				JoinTarget(element, target),
+				node.Type((*Node)(nil)),
+				node.AttrEqVar(Target, target),
+			}
+		})
+)


### PR DESCRIPTION
The first commit extends the `rel` language with support for rules and `_` and adopts it for the dep rules. The second commit contains further cleanup and adopts in op rules. 

Release note: None