### PR TITLE
roachtest: stop setting retired settings

### DIFF
--- a/pkg/cli/interactive_tests/test_style_enabled.tcl
+++ b/pkg/cli/interactive_tests/test_style_enabled.tcl
@@ -4,19 +4,6 @@ source [file join [file dirname $argv0] common.tcl]
 
 start_server $argv
 
-# Setup.
-spawn $argv sql
-eexpect root@
-send "SET CLUSTER SETTING sql.defaults.intervalstyle.enabled = true;\r"
-eexpect "SET CLUSTER SETTING"
-eexpect root@
-send "SET CLUSTER SETTING sql.defaults.datestyle.enabled = true;\r"
-eexpect "SET CLUSTER SETTING"
-eexpect root@
-send_eof
-eexpect eof
-
-
 # Try connect and check the session variables match.
 
 spawn $argv sql --url "postgresql://root@localhost:26257?options=-cintervalstyle%3Diso_8601"

--- a/pkg/cmd/roachtest/tests/orm_helpers.go
+++ b/pkg/cmd/roachtest/tests/orm_helpers.go
@@ -54,8 +54,6 @@ func alterZoneConfigAndClusterSettings(
 
 		// Enable experimental features.
 		`SET CLUSTER SETTING sql.defaults.experimental_temporary_tables.enabled = 'true';`,
-		`SET CLUSTER SETTING sql.defaults.datestyle.enabled = true`,
-		`SET CLUSTER SETTING sql.defaults.intervalstyle.enabled = true;`,
 	} {
 		if _, err := db.ExecContext(ctx, cmd); err != nil {
 			return err


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/82610
fixes https://github.com/cockroachdb/cockroach/issues/82609
fixes https://github.com/cockroachdb/cockroach/issues/82608
fixes https://github.com/cockroachdb/cockroach/issues/82605
fixes https://github.com/cockroachdb/cockroach/issues/82606
fixes https://github.com/cockroachdb/cockroach/issues/82604
fixes https://github.com/cockroachdb/cockroach/issues/82602
fixes https://github.com/cockroachdb/cockroach/issues/82601
fixes https://github.com/cockroachdb/cockroach/issues/82600
fixes https://github.com/cockroachdb/cockroach/issues/82599
fixes https://github.com/cockroachdb/cockroach/issues/82598
fixes https://github.com/cockroachdb/cockroach/issues/82597
fixes https://github.com/cockroachdb/cockroach/issues/82595
fixes https://github.com/cockroachdb/cockroach/issues/82594
fixes https://github.com/cockroachdb/cockroach/issues/82593
fixes https://github.com/cockroachdb/cockroach/issues/82592
fixes https://github.com/cockroachdb/cockroach/issues/82590
fixes https://github.com/cockroachdb/cockroach/issues/82587
fixes https://github.com/cockroachdb/cockroach/issues/82584


The datestyle and intervalstyle cluster settings have been retired.

Release note: None