### PR TITLE
release-22.1: generate-distdir: include go_repository artifacts from `WORKSPACE`

### DIFF
--- a/build/bazelutil/distdir_files.bzl
+++ b/build/bazelutil/distdir_files.bzl
@@ -961,6 +961,8 @@ DISTDIR_FILES = {
     "https://storage.googleapis.com/public-bazel-artifacts/go/go1.17.6.windows-386.zip": "3809c4e40482ff047200c8b1e22a43a2c9c79b53ef540668d2b00f7228f093aa",
     "https://storage.googleapis.com/public-bazel-artifacts/go/go1.17.6.windows-amd64.zip": "5bf8f87aec7edfc08e6bc845f1c30dba6de32b863f89ae46553ff4bbcc1d4954",
     "https://storage.googleapis.com/public-bazel-artifacts/go/go1.17.6.windows-arm64.zip": "c794af7c7fe32207df2c30a39cad1cca2e382c82a4e9493499fc2feab5967ca0",
+    "https://storage.googleapis.com/public-bazel-artifacts/gomod/github.com/bazelbuild/buildtools/v0.0.0-20200718160251-b1667ff58f71/buildtools-v0.0.0-20200718160251-b1667ff58f71.tar.gz": "a9ef5103739dfb5ed2a5b47ab1654842a89695812e4af09e57d7015a5caf97e0",
+    "https://storage.googleapis.com/public-bazel-artifacts/gomod/github.com/bmatcuk/doublestar/v1.2.2/doublestar-1.2.2.tar.gz": "50b02a6a30e186ba189c037901719248667b595b3131a4f6b29aebe3c874e83b",
     "https://storage.googleapis.com/public-bazel-artifacts/java/railroad/rr-1.63-java8.zip": "d2791cd7a44ea5be862f33f5a9b3d40aaad9858455828ebade7007ad7113fb41",
     "https://storage.googleapis.com/public-bazel-artifacts/js/node/v16.13.0/node-v16.13.0-darwin-arm64.tar.gz": "46d83fc0bd971db5050ef1b15afc44a6665dee40bd6c1cbaec23e1b40fa49e6d",
     "https://storage.googleapis.com/public-bazel-artifacts/js/node/v16.13.0/node-v16.13.0-darwin-x64.tar.gz": "37e09a8cf2352f340d1204c6154058d81362fef4ec488b0197b2ce36b3f0367a",

--- a/pkg/build/starlarkutil/starlarkutil.go
+++ b/pkg/build/starlarkutil/starlarkutil.go
@@ -105,7 +105,20 @@ func downloadableArtifactsFromGoDeps(def *syntax.DefStmt) (map[string]Downloadab
 	return ret, nil
 }
 
-// maybeGetDownloadableArtifact returns the artifact pointed to by the given
+// GetArtifactFromGoRepository returns the DownloadableArtifact pointed to by the given
+// go_repository.
+func GetArtifactFromGoRepository(call *syntax.CallExpr) (DownloadableArtifact, error) {
+	name, art, err := maybeGetDownloadableArtifact(call)
+	if err != nil {
+		return art, err
+	}
+	if name == "" {
+		return DownloadableArtifact{}, fmt.Errorf("could not parse downloadable artifact from given go_repository call")
+	}
+	return art, err
+}
+
+// maybeGetDownloadableArtifact returns the DownloadableArtifact pointed to by the given
 // go_repository or http_repository expression, returning the name of the repo
 // and the location of the mirror if one can be found, or the empty string/an
 // empty existingMirror if not. Returns an error iff an unrecoverable problem

--- a/pkg/cmd/generate-distdir/main.go
+++ b/pkg/cmd/generate-distdir/main.go
@@ -208,6 +208,13 @@ func getShasFromWorkspace(workspace string, shas map[string]string) error {
 					}
 					shas[artifact.URL] = artifact.Sha256
 				}
+				if fun == "go_repository" {
+					artifact, err := starlarkutil.GetArtifactFromGoRepository(x)
+					if err != nil {
+						return err
+					}
+					shas[artifact.URL] = artifact.Sha256
+				}
 				if fun == "go_download_sdk" {
 					if err := getShasFromGoDownloadSdkCall(x, shas); err != nil {
 						return err


### PR DESCRIPTION
Backport 1/2 commits from #82469.

---

generate-distdir: include go_repository artifacts from `WORKSPACE`

Otherwise this stuff doesn't get included in the `distdir`.

Release note: None

---

Release note: None
Release justification: Build-only code change
