### PR TITLE
opt: index accelerate `<tuple> = ANY(ARRAY[<tuple>, ...])`

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -1032,6 +1032,29 @@ select
                      ├── const: 1 [type=int]
                      └── const: 2 [type=int]
 
+# Regression test for #77364. Constraints should be built when an IN expression
+# is normalized from = ANY.
+opt
+SELECT * FROM a WHERE (x, y) = ANY(ARRAY[(1, 10), (2, 20)])
+----
+select
+ ├── columns: x:1(int!null) y:2(int!null)
+ ├── scan a
+ │    ├── columns: x:1(int) y:2(int)
+ │    └── prune: (1,2)
+ └── filters
+      └── in [type=bool, outer=(1,2), constraints=(/1/2: [/1/10 - /1/10] [/2/20 - /2/20]; /2: [/10 - /10] [/20 - /20]; tight)]
+           ├── tuple [type=tuple{int, int}]
+           │    ├── variable: x:1 [type=int]
+           │    └── variable: y:2 [type=int]
+           └── tuple [type=tuple{tuple{int, int}, tuple{int, int}}]
+                ├── tuple [type=tuple{int, int}]
+                │    ├── const: 1 [type=int]
+                │    └── const: 10 [type=int]
+                └── tuple [type=tuple{int, int}]
+                     ├── const: 2 [type=int]
+                     └── const: 20 [type=int]
+
 # Tests for string operators (LIKE, SIMILAR TO).
 opt
 SELECT * FROM kuv WHERE v LIKE 'ABC%'
@@ -1405,7 +1428,7 @@ select
 # A union constraint set is tight if the right is a contradiction and the left
 # is tight.
 opt
-SELECT * FROM a WHERE (x = 10 AND y = 20) OR (x = 1 AND x = 3) 
+SELECT * FROM a WHERE (x = 10 AND y = 20) OR (x = 1 AND x = 3)
 ----
 select
  ├── columns: x:1(int!null) y:2(int!null)

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -1477,6 +1477,28 @@ select
  └── filters
       └── k:1 > ANY () [outer=(1)]
 
+# DTuples should be converted to TupleExprs. This allows constraints to be built
+# for the resulting IN expression because the constraint builder requires
+# TupleExprs on the RHS of IN expressions.
+norm expect=SimplifyAnyScalarArray
+SELECT k FROM a WHERE (k, s) = ANY(ARRAY[(1, 'foo'), (2, 'bar')])
+----
+project
+ ├── columns: k:1!null
+ ├── cardinality: [0 - 2]
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null s:4!null
+      ├── cardinality: [0 - 2]
+      ├── key: (1)
+      ├── fd: (1)-->(4)
+      ├── scan a
+      │    ├── columns: k:1!null s:4
+      │    ├── key: (1)
+      │    └── fd: (1)-->(4)
+      └── filters
+           └── (k:1, s:4) IN ((1, 'foo'), (2, 'bar')) [outer=(1,4), constraints=(/1/4: [/1/'foo' - /1/'foo'] [/2/'bar' - /2/'bar']; /4: [/'bar' - /'bar'] [/'foo' - /'foo']; tight)]
+
 # --------------------------------------------------
 # SimplifyEqualsAnyTuple + SimplifyAnyScalarArray
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -2140,6 +2140,23 @@ project
       ├── key: (1)
       └── fd: ()-->(2)
 
+# Regression test for #77364. Queries with filter in the form
+# <tuple> = ANY(ARRAY[<tuple>, ...]) should be index accelerated.
+opt expect=GenerateConstrainedScans
+SELECT * FROM e WHERE (u, w) = ANY(ARRAY[(1, 10), (2, 20), (3, 30)])
+----
+index-join e
+ ├── columns: k:1!null u:2!null v:3 w:4!null
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ └── scan e@uw
+      ├── columns: k:1!null u:2!null w:4!null
+      ├── constraint: /2/4/1
+      │    ├── [/1/10 - /1/10]
+      │    ├── [/2/20 - /2/20]
+      │    └── [/3/30 - /3/30]
+      ├── key: (1)
+      └── fd: (1)-->(2,4)
 
 # --------------------------------------------------
 # GenerateInvertedIndexScans


### PR DESCRIPTION
Previously, queries with filters of the form
`<tuple> = ANY(ARRAY[<tuple>, ...])` with constant tuples on the
right-hand side were not index accelerated. The normalization rules
`SimplifyAnyScalarArray` and `SimplifyEqualsAnyTuple` transform this
type of expression to an expression in the form
`<tuple> IN (<tuple>, ...)`, with the tuples on the right-hand side
represented as `ConstExpr`s. Because the constraint builder requires
tuples on the RHS of `IN` expressions to be `TupleExpr`s, not
`ConstExpr`s, no constraints could be generated for the normalized form
of the expression. Without constraints, exploration rules could not
generate constrained scans.

The normalization rules that perform the conversion to an `IN`
expression now convert `DTuple`s to `TupleExpr`s, allowing constraints
to be built for the `IN` expression, and enabling index acceleration.

I considered updating the constraint builder so that it can build
constraints when there are `DTuple`s on the RHS of `IN` expressions, but
it would be a more involved change. The changes here seem more likely to
be backported to a previous version. I've left a TODO as a reminder that
the best fix might be to improve the constraint builder.

Fixes #77364

Release note (performance improvement): Queries with filters containing
tuples in `= ANY` expressions, such as
`(a, b) = ANY(ARRAY[(1, 10), (2, 20)])`, are now index accelerated.
