### PR TITLE
build: fix dev ui watch

### DIFF
--- a/pkg/cmd/dev/testdata/datadriven/ui
+++ b/pkg/cmd/dev/testdata/datadriven/ui
@@ -1,7 +1,16 @@
 exec
 dev ui watch
 ----
-bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl
+bazel fetch //pkg/ui/workspaces/db-console:db-console-ccl
+bazel build //pkg/ui/workspaces/cluster-ui:cluster-ui //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl
+bazel info bazel-bin --color=no
+bazel info workspace --color=no
+cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.js
+cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.js
+cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.d.ts
+cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts
+rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
+cp -r sandbox/pkg/ui/workspaces/cluster-ui/dist crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 bazel info workspace --color=no
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/cluster-ui build:watch
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.app.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://localhost:8080 --port 3000
@@ -9,7 +18,14 @@ bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/db-cons
 exec
 dev ui watch --oss
 ----
-bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client
+bazel fetch //pkg/ui/workspaces/db-console:db-console-ccl
+bazel build //pkg/ui/workspaces/cluster-ui:cluster-ui
+bazel info bazel-bin --color=no
+bazel info workspace --color=no
+cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.js
+cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.d.ts
+rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
+cp -r sandbox/pkg/ui/workspaces/cluster-ui/dist crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 bazel info workspace --color=no
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/cluster-ui build:watch
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.app.js --mode development --env.WEBPACK_SERVE --env.dist=oss --env.target=http://localhost:8080 --port 3000
@@ -17,7 +33,16 @@ bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/db-cons
 exec
 dev ui watch --secure
 ----
-bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl
+bazel fetch //pkg/ui/workspaces/db-console:db-console-ccl
+bazel build //pkg/ui/workspaces/cluster-ui:cluster-ui //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl
+bazel info bazel-bin --color=no
+bazel info workspace --color=no
+cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.js
+cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.js
+cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.d.ts
+cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts
+rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
+cp -r sandbox/pkg/ui/workspaces/cluster-ui/dist crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 bazel info workspace --color=no
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/cluster-ui build:watch
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.app.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://localhost:8080 --port 3000 --https
@@ -25,7 +50,16 @@ bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/db-cons
 exec
 dev ui watch --db http://example.crdb.io:4848
 ----
-bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl
+bazel fetch //pkg/ui/workspaces/db-console:db-console-ccl
+bazel build //pkg/ui/workspaces/cluster-ui:cluster-ui //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl
+bazel info bazel-bin --color=no
+bazel info workspace --color=no
+cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.js
+cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.js
+cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.d.ts
+cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts
+rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
+cp -r sandbox/pkg/ui/workspaces/cluster-ui/dist crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 bazel info workspace --color=no
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/cluster-ui build:watch
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.app.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://example.crdb.io:4848 --port 3000
@@ -33,7 +67,16 @@ bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/db-cons
 exec
 dev ui watch --port 12345
 ----
-bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl
+bazel fetch //pkg/ui/workspaces/db-console:db-console-ccl
+bazel build //pkg/ui/workspaces/cluster-ui:cluster-ui //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl
+bazel info bazel-bin --color=no
+bazel info workspace --color=no
+cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.js
+cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.js
+cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.d.ts
+cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts
+rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
+cp -r sandbox/pkg/ui/workspaces/cluster-ui/dist crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 bazel info workspace --color=no
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/cluster-ui build:watch
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.app.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://localhost:8080 --port 12345
@@ -61,7 +104,7 @@ bazel test //pkg/ui/workspaces/db-console:karma //pkg/ui/workspaces/cluster-ui:j
 exec
 dev ui test test --watch
 ----
-bazel build //pkg/ui/workspaces/cluster-ui:cluster-ui
+bazel build //pkg/ui/workspaces/cluster-ui:cluster-ui //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl
 bazel info bazel-bin --color=no
 bazel info workspace --color=no
 cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.js

--- a/pkg/cmd/dev/ui.go
+++ b/pkg/cmd/dev/ui.go
@@ -97,10 +97,21 @@ Replaces 'make ui-watch'.`,
 				return err
 			}
 
-			// Build prerequisites for db-console and cluster-ui.
+			// Fetch all node dependencies (through Bazel) to ensure things are up-to-date
+			err = d.exec.CommandContextInheritingStdStreams(
+				ctx,
+				"bazel",
+				"fetch",
+				"//pkg/ui/workspaces/db-console:db-console-ccl",
+			)
+			if err != nil {
+				log.Fatalf("failed to fetch node dependencies: %v", err)
+			}
+
+			// Build prerequisites for db-console
 			args := []string{
 				"build",
-				"//pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client",
+				"//pkg/ui/workspaces/cluster-ui:cluster-ui",
 			}
 			if !isOss {
 				args = append(args, "//pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl")
@@ -110,6 +121,11 @@ Replaces 'make ui-watch'.`,
 
 			if err != nil {
 				log.Fatalf("failed to build UI watch prerequisites: %v", err)
+				return err
+			}
+
+			if err := arrangeFilesForWatchers(d /* ossOnly */, isOss); err != nil {
+				log.Fatalf("failed to arrange files for watchers: %v", err)
 				return err
 			}
 
@@ -302,7 +318,7 @@ func makeUICleanCmd(d *dev) *cobra.Command {
 	return cleanCmd
 }
 
-// arrangeFilesForTestWatchers moves files from Bazel's build output directory
+// arrangeFilesForWatchers moves files from Bazel's build output directory
 // into the locations they'd be found during a non-Bazel build, so that test
 // watchers can successfully operate outside of the Bazel sandbox.
 //
@@ -311,12 +327,13 @@ func makeUICleanCmd(d *dev) *cobra.Command {
 // running between changes, since Jest won't find changes. But having ibazel
 // kill Jest when a file changes defeat the purpose of Jest's watch mode, and
 // makes devs pay the cost of node + jest startup times after every file change.
-// As a workaround, arrangeFilesForTestWatchers copies files out of the Bazel
-// sandbox and allows Jest (in watch mode) to be executed from directly within
-// a pkg/ui/workspaces/... directory.
+// Similar issues apply to webpack's watch-mode, as compiled output doesn't
+// exist outside of the Bazel sandbox. As a workaround, arrangeFilesForWatchers
+// copies files out of the Bazel sandbox and allows Jest or webpack (in watch
+// mode) to be executed from directly within a pkg/ui/workspaces/... directory.
 //
 // See https://github.com/bazelbuild/rules_nodejs/issues/2028
-func arrangeFilesForTestWatchers(d *dev) error {
+func arrangeFilesForWatchers(d *dev, ossOnly bool) error {
 	bazelBin, err := d.getBazelBin(d.cli.Context())
 	if err != nil {
 		return err
@@ -340,10 +357,15 @@ func arrangeFilesForTestWatchers(d *dev) error {
 	// Recreate protobuf client files that were previously copied out of the sandbox
 	for _, relPath := range protoFiles {
 		ossDst := filepath.Join(ossProtobufDst, relPath)
-		cclDst := filepath.Join(cclProtobufDst, relPath)
 		if err := d.os.CopyFile(filepath.Join(ossProtobufSrc, relPath), ossDst); err != nil {
 			return err
 		}
+
+		if ossOnly {
+			continue
+		}
+
+		cclDst := filepath.Join(cclProtobufDst, relPath)
 		if err := d.os.CopyFile(filepath.Join(cclProtobufSrc, relPath), cclDst); err != nil {
 			return err
 		}
@@ -401,6 +423,7 @@ Replaces 'make ui-test' and 'make ui-test-watch'.`,
 				args := []string{
 					"build",
 					"//pkg/ui/workspaces/cluster-ui:cluster-ui",
+					"//pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl",
 				}
 				logCommand("bazel", args...)
 				err := d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)
@@ -410,7 +433,7 @@ Replaces 'make ui-test' and 'make ui-test-watch'.`,
 					return err
 				}
 
-				err = arrangeFilesForTestWatchers(d)
+				err = arrangeFilesForWatchers(d /* ossOnly */, false)
 				if err != nil {
 					// nolint:errwrap
 					return fmt.Errorf("unable to arrange files properly for watch-mode testing: %+v", err)

--- a/pkg/ui/workspaces/db-console/webpack.app.js
+++ b/pkg/ui/workspaces/db-console/webpack.app.js
@@ -17,19 +17,6 @@ const CopyWebpackPlugin = require("copy-webpack-plugin");
 const StringReplacePlugin = require("string-replace-webpack-plugin");
 const WebpackBar = require("webpackbar");
 
-// Remove a broken dependency that Yarn insists upon installing before every
-// Webpack compile. We also do this when installing dependencies via Make, but
-// it"s common to run e.g. `yarn add` manually without re-running Make, which
-// will reinstall the broken dependency. The error this dependency causes is
-// horribly cryptic, so it"s important to remove it aggressively.
-//
-// See: https://github.com/yarnpkg/yarn/issues/2987
-class RemoveBrokenDependenciesPlugin {
-  apply(compiler) {
-    compiler.plugin("compile", () => rimraf.sync("./node_modules/@types/node"));
-  }
-}
-
 const proxyPrefixes = ["/_admin", "/_status", "/ts", "/login", "/logout"];
 function shouldProxy(reqPath) {
   if (reqPath === "/") {
@@ -50,7 +37,6 @@ module.exports = (env, argv) => {
   }
 
   let plugins = [
-    new RemoveBrokenDependenciesPlugin(),
     new CopyWebpackPlugin([
       { from: path.resolve(__dirname, "favicon.ico"), to: "favicon.ico" },
     ]),


### PR DESCRIPTION
Since https://github.com/cockroachdb/cockroach/commit/5b6c271b1cd78323ac11cde677834d4918c183f4 (bazel: upgrade to rules_nodejs 5.4.2, 2022-05-17),
building //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client no
longer installs the NPM dependencies for cluster-ui nor db-console.
Install those dependencies manually with a `bazel fetch` invocation, and
copy the compiled protobuf clients back into the workspace root so that
non-bazel builds can access them.

While I'm in the neighborhood, this PR also removes the manual "delete
`node_modules/@types/node/`" behavior we currently have.

The presence of @types/node doesn't appear to cause issues at build-time
anymore (and it's arguably necessary to type-check some test
infrastructure that depends on Node.js types). In fact, deleting it
introduces issues when a Bazel build attempts to copy that package into
a build sandbox. Stop deleting @types/node when compiling db-console.

fixes https://github.com/cockroachdb/cockroach/issues/82549