### PR TITLE
sql: fix SPLIT AT and EXPERIMENTAL_RELOCATE for multi-column geo-spatial indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_filter_geospatial_dist
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_filter_geospatial_dist
@@ -1,21 +1,22 @@
 # LogicTest: 5node
 
 statement ok
-CREATE TABLE geo_table(
-  k int primary key,
-  geom geometry,
-  INVERTED INDEX geom_index(geom)
+CREATE TABLE geo_table (
+  k INT PRIMARY KEY,
+  s STRING,
+  geom GEOMETRY,
+  INVERTED INDEX geom_index (geom)
 )
 
 statement ok
 INSERT INTO geo_table VALUES
-  (1, 'POINT(1 1)'),
-  (2, 'LINESTRING(1 1, 2 2)'),
-  (3, 'POINT(3 3)'),
-  (4, 'LINESTRING(4 4, 5 5)'),
-  (5, 'LINESTRING(40 40, 41 41)'),
-  (6, 'POLYGON((1 1, 5 1, 5 5, 1 5, 1 1))'),
-  (7, 'LINESTRING(1 1, 3 3)')
+  (1, 'foo', 'POINT(1 1)'),
+  (2, 'foo', 'LINESTRING(1 1, 2 2)'),
+  (3, 'foo', 'POINT(3 3)'),
+  (4, 'bar', 'LINESTRING(4 4, 5 5)'),
+  (5, 'bar', 'LINESTRING(40 40, 41 41)'),
+  (6, 'bar', 'POLYGON((1 1, 5 1, 5 5, 1 5, 1 1))'),
+  (7, 'foo', 'LINESTRING(1 1, 3 3)')
 
 # Not distributed.
 query I
@@ -101,7 +102,65 @@ SELECT k FROM geo_table@geom_index WHERE ST_Intersects('MULTIPOINT((2.2 2.2), (3
 
 # Filtering is placed at node 2.
 query I
-SELECT k FROM geo_table WHERE ST_CoveredBy('MULTIPOINT((2.2 2.2), (3.0 3.0))'::geometry, geom) ORDER BY k
+SELECT k FROM geo_table@geom_index WHERE ST_CoveredBy('MULTIPOINT((2.2 2.2), (3.0 3.0))'::geometry, geom) ORDER BY k
 ----
 6
+7
+
+statement ok
+DROP INDEX geom_index;
+
+# Test for multi-column geo-spatial indexes.
+statement ok
+CREATE INVERTED INDEX geom_index2 ON geo_table(s, geom)
+
+query TI colnames,rowsort
+SELECT replicas, lease_holder FROM [SHOW RANGES FROM INDEX geo_table@geom_index2]
+----
+replicas  lease_holder
+{2}       2
+
+# Not distributed.
+query I
+SELECT k FROM geo_table@geom_index2 WHERE s = 'foo' AND ST_Intersects('MULTIPOINT((2.2 2.2), (3.0 3.0))'::geometry, geom) ORDER BY k
+----
+3
+7
+
+query I
+SELECT k FROM geo_table@geom_index2 WHERE s = 'foo' AND ST_CoveredBy('MULTIPOINT((2.2 2.2), (3.0 3.0))'::geometry, geom) ORDER BY k
+----
+7
+
+statement ok
+ALTER INDEX geo_table@geom_index2 SPLIT AT VALUES ('foo', 1152921574000000000)
+
+query TI colnames,rowsort
+SELECT replicas, lease_holder FROM [SHOW RANGES FROM INDEX geo_table@geom_index2]
+----
+replicas  lease_holder
+{2}       2
+{2}       2
+
+statement ok
+ALTER INDEX geo_table@geom_index2 EXPERIMENTAL_RELOCATE VALUES (ARRAY[1], 'foo', 1152921574000000000)
+
+query TTTI colnames,rowsort
+SELECT start_key, end_key, replicas, lease_holder FROM [SHOW RANGES FROM INDEX geo_table@geom_index2]
+----
+start_key                   end_key                     replicas  lease_holder
+NULL                        /"foo"/1152921574000000000  {2}       2
+/"foo"/1152921574000000000  NULL                        {1}       1
+
+# Distributed.
+query I
+SELECT k FROM geo_table@geom_index2 WHERE s = 'foo' AND ST_Intersects('MULTIPOINT((2.2 2.2), (3.0 3.0))'::geometry, geom) ORDER BY k
+----
+3
+7
+
+# Data is distributed, but the filterer can't be distributed since it is not a union.
+query I
+SELECT k FROM geo_table@geom_index2 WHERE s = 'foo' AND ST_CoveredBy('MULTIPOINT((2.2 2.2), (3.0 3.0))'::geometry, geom) ORDER BY k
+----
 7

--- a/pkg/sql/logictest/testdata/logic_test/inverted_filter_geospatial_dist
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_filter_geospatial_dist
@@ -19,14 +19,14 @@ INSERT INTO geo_table VALUES
 
 # Not distributed.
 query I
-SELECT k FROM geo_table WHERE ST_Intersects('MULTIPOINT((2.2 2.2), (3.0 3.0))'::geometry, geom) ORDER BY k
+SELECT k FROM geo_table@geom_index WHERE ST_Intersects('MULTIPOINT((2.2 2.2), (3.0 3.0))'::geometry, geom) ORDER BY k
 ----
 3
 6
 7
 
 query I
-SELECT k FROM geo_table WHERE ST_CoveredBy('MULTIPOINT((2.2 2.2), (3.0 3.0))'::geometry, geom) ORDER BY k
+SELECT k FROM geo_table@geom_index WHERE ST_CoveredBy('MULTIPOINT((2.2 2.2), (3.0 3.0))'::geometry, geom) ORDER BY k
 ----
 6
 7
@@ -66,7 +66,7 @@ NULL                  /1152921574000000000  {1}       1
 
 # Distributed.
 query I
-SELECT k FROM geo_table WHERE ST_Intersects('MULTIPOINT((2.2 2.2), (3.0 3.0))'::geometry, geom) ORDER BY k
+SELECT k FROM geo_table@geom_index WHERE ST_Intersects('MULTIPOINT((2.2 2.2), (3.0 3.0))'::geometry, geom) ORDER BY k
 ----
 3
 6
@@ -74,7 +74,7 @@ SELECT k FROM geo_table WHERE ST_Intersects('MULTIPOINT((2.2 2.2), (3.0 3.0))'::
 
 # Data is distributed, but the filterer can't be distributed since it is not a union.
 query I
-SELECT k FROM geo_table WHERE ST_CoveredBy('MULTIPOINT((2.2 2.2), (3.0 3.0))'::geometry, geom) ORDER BY k
+SELECT k FROM geo_table@geom_index WHERE ST_CoveredBy('MULTIPOINT((2.2 2.2), (3.0 3.0))'::geometry, geom) ORDER BY k
 ----
 6
 7
@@ -93,7 +93,7 @@ NULL                  /1152921574000000000  {2}       2
 /1152921574000000000  NULL                  {2}       2
 
 query I
-SELECT k FROM geo_table WHERE ST_Intersects('MULTIPOINT((2.2 2.2), (3.0 3.0))'::geometry, geom) ORDER BY k
+SELECT k FROM geo_table@geom_index WHERE ST_Intersects('MULTIPOINT((2.2 2.2), (3.0 3.0))'::geometry, geom) ORDER BY k
 ----
 3
 6

--- a/pkg/sql/opt/optbuilder/alter_table.go
+++ b/pkg/sql/opt/optbuilder/alter_table.go
@@ -206,9 +206,9 @@ func getIndexColumnNamesAndTypes(index cat.Index) (colNames []string, colTypes [
 		// TODO(sumeer): special case Array too. JSON is harder since the split
 		// needs to be a Datum and the JSON inverted column is not.
 		//
-		// Geospatial inverted index. The first column is the inverted column and
-		// is an int.
-		colTypes[0] = types.Int
+		// Geospatial inverted index. The last explicit column is the inverted
+		// column and is an int.
+		colTypes[index.ExplicitColumnCount()-1] = types.Int
 	}
 	return colNames, colTypes
 }


### PR DESCRIPTION
#### sql: add index hints for inverted_filter_geospatial_dist

This commit adds index hints to queries in
`invert_filter_geospatial_dist` logic tests. This ensures that the tests
are testing inverted filterer logic, which is their intent.

Release note: None

#### sql: fix SPLIT AT and EXPERIMENTAL_RELOCATE for multi-column geo-spatial indexes

This commit fixes a bug that prevented `ALTER INDEX ... SPLIT AT` and
`ALTER TABLE ... EXPERIMENTAL_RELOCATE` from working on multi-column
geo-spatial indexes.

Release note: None
