### PR TITLE
cdc: updated the initial scan syntax for ALTER changefeeds

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -310,12 +310,20 @@ func generateNewTargets(
 	// name of the target was modified.
 	originalSpecs := make(map[tree.ChangefeedTarget]jobspb.ChangefeedTargetSpecification)
 
+	// We want to store the value of whether or not the original changefeed had
+	// initial_scan set to only so that we only do an initial scan on an alter
+	// changefeed with initial_scan = 'only' if the original one also had
+	// initial_scan = 'only'.
+	_, originalInitialScanOnlyOption := opts[changefeedbase.OptInitialScanOnly]
+
 	// When we add new targets with or without initial scans, indicating
 	// initial_scan or no_initial_scan in the job description would lose its
 	// meaning. Hence, we will omit these details from the changefeed
 	// description. However, to ensure that we do perform the initial scan on
 	// newly added targets, we will introduce the initial_scan opt after the
 	// job record is created.
+
+	delete(opts, changefeedbase.OptInitialScanOnly)
 	delete(opts, changefeedbase.OptNoInitialScan)
 	delete(opts, changefeedbase.OptInitialScan)
 
@@ -384,12 +392,48 @@ func generateNewTargets(
 				return nil, nil, hlc.Timestamp{}, nil, err
 			}
 
-			_, withInitialScan := targetOpts[changefeedbase.OptInitialScan]
-			_, noInitialScan := targetOpts[changefeedbase.OptNoInitialScan]
-			if withInitialScan && noInitialScan {
+			var withInitialScan bool
+			initialScanType, initialScanSet := targetOpts[changefeedbase.OptInitialScan]
+			_, noInitialScanSet := targetOpts[changefeedbase.OptNoInitialScan]
+			_, initialScanOnlySet := targetOpts[changefeedbase.OptInitialScanOnly]
+
+			if initialScanSet {
+				if initialScanType == `no` || (initialScanType == `only` && !originalInitialScanOnlyOption) {
+					withInitialScan = false
+				} else {
+					withInitialScan = true
+				}
+			} else {
+				withInitialScan = false
+			}
+
+			if initialScanType != `` && initialScanType != `yes` && initialScanType != `no` && initialScanType != `only` {
+				return nil, nil, hlc.Timestamp{}, nil, pgerror.Newf(
+					pgcode.InvalidParameterValue,
+					`cannot set initial_scan to %q. possible values for initial_scan are "yes", "no", "only", or no value`, changefeedbase.OptInitialScan,
+				)
+			}
+
+			if initialScanSet && noInitialScanSet {
 				return nil, nil, hlc.Timestamp{}, nil, pgerror.Newf(
 					pgcode.InvalidParameterValue,
 					`cannot specify both %q and %q`, changefeedbase.OptInitialScan,
+					changefeedbase.OptNoInitialScan,
+				)
+			}
+
+			if initialScanSet && initialScanOnlySet {
+				return nil, nil, hlc.Timestamp{}, nil, pgerror.Newf(
+					pgcode.InvalidParameterValue,
+					`cannot specify both %q and %q`, changefeedbase.OptInitialScan,
+					changefeedbase.OptInitialScanOnly,
+				)
+			}
+
+			if noInitialScanSet && initialScanOnlySet {
+				return nil, nil, hlc.Timestamp{}, nil, pgerror.Newf(
+					pgcode.InvalidParameterValue,
+					`cannot specify both %q and %q`, changefeedbase.OptInitialScanOnly,
 					changefeedbase.OptNoInitialScan,
 				)
 			}

--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -894,91 +894,6 @@ func TestAlterChangefeedAlterTableName(t *testing.T) {
 	cdcTest(t, testFn, feedTestEnterpriseSinks)
 }
 
-func TestAlterChangefeedInitialScan(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
-		sqlDB := sqlutils.MakeSQLRunner(s.DB)
-		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
-		sqlDB.Exec(t, `INSERT INTO foo VALUES (1), (2), (3)`)
-		sqlDB.Exec(t, `CREATE TABLE bar (a INT PRIMARY KEY)`)
-		sqlDB.Exec(t, `INSERT INTO bar VALUES (1), (2), (3)`)
-
-		testFeed := feed(t, f, `CREATE CHANGEFEED FOR foo WITH resolved = '1s', no_initial_scan`)
-		defer closeFeed(t, testFeed)
-
-		expectResolvedTimestamp(t, testFeed)
-
-		feed, ok := testFeed.(cdctest.EnterpriseTestFeed)
-		require.True(t, ok)
-
-		sqlDB.Exec(t, `PAUSE JOB $1`, feed.JobID())
-		waitForJobStatus(sqlDB, t, feed.JobID(), `paused`)
-
-		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d ADD bar WITH initial_scan`, feed.JobID()))
-
-		sqlDB.Exec(t, fmt.Sprintf(`RESUME JOB %d`, feed.JobID()))
-		waitForJobStatus(sqlDB, t, feed.JobID(), `running`)
-
-		assertPayloads(t, testFeed, []string{
-			`bar: [1]->{"after": {"a": 1}}`,
-			`bar: [2]->{"after": {"a": 2}}`,
-			`bar: [3]->{"after": {"a": 3}}`,
-		})
-
-		sqlDB.Exec(t, `INSERT INTO bar VALUES (4)`)
-		assertPayloads(t, testFeed, []string{
-			`bar: [4]->{"after": {"a": 4}}`,
-		})
-	}
-
-	cdcTest(t, testFn, feedTestEnterpriseSinks)
-}
-
-func TestAlterChangefeedNoInitialScan(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
-		sqlDB := sqlutils.MakeSQLRunner(s.DB)
-		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
-		sqlDB.Exec(t, `INSERT INTO foo VALUES (1), (2), (3)`)
-		sqlDB.Exec(t, `CREATE TABLE bar (a INT PRIMARY KEY)`)
-		sqlDB.Exec(t, `INSERT INTO bar VALUES (1), (2), (3)`)
-
-		testFeed := feed(t, f, `CREATE CHANGEFEED FOR foo WITH resolved = '1s'`)
-		defer closeFeed(t, testFeed)
-
-		assertPayloads(t, testFeed, []string{
-			`foo: [1]->{"after": {"a": 1}}`,
-			`foo: [2]->{"after": {"a": 2}}`,
-			`foo: [3]->{"after": {"a": 3}}`,
-		})
-		expectResolvedTimestamp(t, testFeed)
-
-		feed, ok := testFeed.(cdctest.EnterpriseTestFeed)
-		require.True(t, ok)
-
-		sqlDB.Exec(t, `PAUSE JOB $1`, feed.JobID())
-		waitForJobStatus(sqlDB, t, feed.JobID(), `paused`)
-
-		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d ADD bar WITH no_initial_scan`, feed.JobID()))
-
-		sqlDB.Exec(t, fmt.Sprintf(`RESUME JOB %d`, feed.JobID()))
-		waitForJobStatus(sqlDB, t, feed.JobID(), `running`)
-
-		expectResolvedTimestamp(t, testFeed)
-
-		sqlDB.Exec(t, `INSERT INTO bar VALUES (4)`)
-		assertPayloads(t, testFeed, []string{
-			`bar: [4]->{"after": {"a": 4}}`,
-		})
-	}
-
-	cdcTest(t, testFn, feedTestEnterpriseSinks)
-}
-
 func TestAlterChangefeedAddTargetsDuringSchemaChangeError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1353,4 +1268,57 @@ func TestAlterChangefeedUpdateFilter(t *testing.T) {
 	}
 
 	cdcTest(t, testFn, feedTestEnterpriseSinks)
+}
+
+func TestAlterChangefeedInitialScan(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(initialScanOption string) cdcTestFn {
+		return func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+			sqlDB := sqlutils.MakeSQLRunner(s.DB)
+			sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+			sqlDB.Exec(t, `INSERT INTO foo VALUES (1), (2), (3)`)
+			sqlDB.Exec(t, `CREATE TABLE bar (a INT PRIMARY KEY)`)
+			sqlDB.Exec(t, `INSERT INTO bar VALUES (1), (2), (3)`)
+
+			testFeed := feed(t, f, `CREATE CHANGEFEED FOR foo WITH resolved = '1s', no_initial_scan`)
+			defer closeFeed(t, testFeed)
+
+			expectResolvedTimestamp(t, testFeed)
+
+			feed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+			require.True(t, ok)
+
+			sqlDB.Exec(t, `PAUSE JOB $1`, feed.JobID())
+			waitForJobStatus(sqlDB, t, feed.JobID(), `paused`)
+
+			sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d ADD bar WITH %s`, feed.JobID(), initialScanOption))
+
+			sqlDB.Exec(t, fmt.Sprintf(`RESUME JOB %d`, feed.JobID()))
+			waitForJobStatus(sqlDB, t, feed.JobID(), `running`)
+
+			expectPayloads := (initialScanOption == "initial_scan = 'yes'" || initialScanOption == "initial_scan")
+			if expectPayloads {
+				assertPayloads(t, testFeed, []string{
+					`bar: [1]->{"after": {"a": 1}}`,
+					`bar: [2]->{"after": {"a": 2}}`,
+					`bar: [3]->{"after": {"a": 3}}`,
+				})
+			}
+
+			sqlDB.Exec(t, `INSERT INTO bar VALUES (4)`)
+			assertPayloads(t, testFeed, []string{
+				`bar: [4]->{"after": {"a": 4}}`,
+			})
+		}
+	}
+
+	for _, initialScanOpt := range []string{
+		"initial_scan = 'yes'",
+		"initial_scan = 'no'",
+		"initial_scan",
+		"no_initial_scan"} {
+		cdcTest(t, testFn(initialScanOpt), feedTestForceSink("kafka"))
+	}
 }

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -386,7 +386,7 @@ var AlterChangefeedOptionExpectValues = func() map[string]OptionPermittedValues 
 // AlterChangefeedTargetOptions is used to parse target specific alter
 // changefeed options using PlanHookState.TypeAsStringOpts().
 var AlterChangefeedTargetOptions = map[string]OptionPermittedValues{
-	OptInitialScan:   flagOption,
+	OptInitialScan:   enum("yes", "no", "only").orEmptyMeans("yes"),
 	OptNoInitialScan: flagOption,
 }
 


### PR DESCRIPTION
updated the initial scan syntax for ALTER changefeeds to handle initial_scan, no_initial_scan, initial_scan = 'yes|no|only' options and added tests for this

Release note: None