### PR TITLE
bazel: bump size of `schemachangerccl`, `pkg/sql/catalog/lease` tests

### DIFF
--- a/pkg/ccl/schemachangerccl/BUILD.bazel
+++ b/pkg/ccl/schemachangerccl/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_test(
     name = "schemachangerccl_test",
-    size = "large",
+    size = "enormous",
     srcs = [
         "main_test.go",
         "schemachanger_ccl_test.go",

--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -56,7 +56,7 @@ go_library(
 
 go_test(
     name = "lease_test",
-    size = "medium",
+    size = "large",
     srcs = [
         "helpers_test.go",
         "lease_internal_test.go",


### PR DESCRIPTION
Release note: None