### PR TITLE
kvstreamer: ask for a separate LeafTxn

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -292,7 +292,7 @@ func max(a, b int64) int64 {
 
 // NewStreamer creates a new Streamer.
 //
-// txn must be a LeafTxn.
+// txn must be a LeafTxn that is not used by anything other than this Streamer.
 //
 // limitBytes determines the maximum amount of memory this Streamer is allowed
 // to use (i.e. it'll be used lazily, as needed). The more memory it has, the

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -278,7 +278,7 @@ func (ds *ServerImpl) setupFlow(
 	)
 	monitor.Start(ctx, parentMonitor, mon.BoundAccount{})
 
-	makeLeaf := func(req *execinfrapb.SetupFlowRequest) (*kv.Txn, error) {
+	makeLeaf := func() (*kv.Txn, error) {
 		tis := req.LeafTxnInputState
 		if tis == nil {
 			// This must be a flow running for some bulk-io operation that doesn't use
@@ -311,7 +311,7 @@ func (ds *ServerImpl) setupFlow(
 		evalCtx.Mon = monitor
 		if localState.HasConcurrency {
 			var err error
-			leafTxn, err = makeLeaf(req)
+			leafTxn, err = makeLeaf()
 			if err != nil {
 				return nil, nil, nil, err
 			}
@@ -333,7 +333,7 @@ func (ds *ServerImpl) setupFlow(
 		// It's important to populate evalCtx.Txn early. We'll write it again in the
 		// f.SetTxn() call below, but by then it will already have been captured by
 		// processors.
-		leafTxn, err = makeLeaf(req)
+		leafTxn, err = makeLeaf()
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -369,7 +369,7 @@ func (ds *ServerImpl) setupFlow(
 
 	// Create the FlowCtx for the flow.
 	flowCtx := ds.newFlowContext(
-		ctx, req.Flow.FlowID, evalCtx, req.TraceKV, req.CollectStats, localState, req.Flow.Gateway == ds.NodeID.SQLInstanceID(),
+		ctx, req.Flow.FlowID, evalCtx, makeLeaf, req.TraceKV, req.CollectStats, localState, req.Flow.Gateway == ds.NodeID.SQLInstanceID(),
 	)
 
 	// req always contains the desired vectorize mode, regardless of whether we
@@ -417,7 +417,7 @@ func (ds *ServerImpl) setupFlow(
 	} else {
 		// If I haven't created the leaf already, do it now.
 		if leafTxn == nil {
-			leafTxn, err = makeLeaf(req)
+			leafTxn, err = makeLeaf()
 			if err != nil {
 				return nil, nil, nil, err
 			}
@@ -442,6 +442,7 @@ func (ds *ServerImpl) newFlowContext(
 	ctx context.Context,
 	id execinfrapb.FlowID,
 	evalCtx *eval.Context,
+	makeLeafTxn func() (*kv.Txn, error),
 	traceKV bool,
 	collectStats bool,
 	localState LocalState,
@@ -454,6 +455,7 @@ func (ds *ServerImpl) newFlowContext(
 		ID:             id,
 		EvalCtx:        evalCtx,
 		Txn:            evalCtx.Txn,
+		MakeLeafTxn:    makeLeafTxn,
 		NodeID:         ds.ServerConfig.NodeID,
 		TraceKV:        traceKV,
 		CollectStats:   collectStats,

--- a/pkg/sql/execinfra/flow_context.go
+++ b/pkg/sql/execinfra/flow_context.go
@@ -54,6 +54,9 @@ type FlowCtx struct {
 	// higher-level txn (like backfills).
 	Txn *kv.Txn
 
+	// MakeLeafTxn returns a new LeafTxn, different from Txn.
+	MakeLeafTxn func() (*kv.Txn, error)
+
 	// Descriptors is used to look up leased table descriptors and to construct
 	// transaction bound TypeResolvers to resolve type references during flow
 	// setup. It is not safe for concurrent use and is intended to be used only


### PR DESCRIPTION
This commit fixes the streamer so that it uses a LeafTxn that is not
shared with any other components. Such a setup is needed in order to
avoid spurious "context canceled" errors returned when multiple
streamers are part of the same flow.

Consider the following setup. We have a remote flow consisting of two
trees of operators rooted in the outboxes:
```
  └ Node 2
    ├ *colrpc.Outbox
    │ └ *rowexec.joinReader
...
    └ *colrpc.Outbox
      └ *rowexec.joinReader
```
Both of the join readers use the streamer API and run in separate
goroutines (because outboxes run in separate goroutines). Then let's
imagine that one of the outboxes is moved to draining while the
corresponding streamer is still evaluating requests. The join reader
will call `Streamer.Close` which cancels the context of the requests'
evaluation. This cancellation "poisons" the txn used by that streamer
with `ERROR: txn already encountered an error`.

Now let's imagine that the second tree of operators is not done yet and
needs to produce more data. Whenever the streamer in that tree tries to
evaluate some requests, it would run into the "poisoned" txn error.

This commit goes around this problem by giving a separate LeafTxn to
each streamer so that a streamer from one tree could not poison the txn
of the streamer from another tree. The non-streamer code path doesn't
run into a similar problem because it doesn't eagerly cancel the
outstanding requests.

I think a similar change (to give the streamer a separate leaf txn) will
also be needed to support the transparent refresh mechanism in some
cases, so this commit is beneficial from that point of view too.

I spent some time attempting to write a regression test, but it is quite
difficult to come up with something reliable here, and I decided to not
spend more time on it.

Fixes: #82336.

Release note: None