### PR TITLE
streamingccl: fix producer job and ingestion job to correctly treat stream timeout

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
@@ -298,7 +298,9 @@ func (sf *streamIngestionFrontier) Next() (
 			// If heartbeatSender has error, it means remote has error, we want to
 			// stop the processor.
 		case <-sf.heartbeatSender.stoppedChan:
-			sf.MoveToDraining(sf.heartbeatSender.err())
+			err := sf.heartbeatSender.err()
+			log.Warningf(sf.Ctx, "heartbeat sender has stopped with error: %s", err)
+			sf.MoveToDraining(err)
 			return nil, sf.DrainHelper()
 		}
 	}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -154,6 +154,8 @@ func (s *streamIngestionResumer) Resume(resumeCtx context.Context, execCtx inter
 
 	// Start ingesting KVs from the replication stream.
 	streamAddress := streamingccl.StreamAddress(details.StreamAddress)
+	// TODO(casper): retry stream ingestion with exponential
+	// backoff and finally pause on error.
 	return ingest(resumeCtx, p, streamAddress, details.TenantID, details.NewTenantID,
 		streaming.StreamID(details.StreamID), details.StartTime, s.job.Progress(), s.job.ID())
 }

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
@@ -203,11 +203,10 @@ func ingestionPlanHook(
 		}
 
 		jr := jobs.Record{
-			Description:   jobDescription,
-			Username:      p.User(),
-			Progress:      jobspb.StreamIngestionProgress{},
-			Details:       streamIngestionDetails,
-			NonCancelable: true,
+			Description: jobDescription,
+			Username:    p.User(),
+			Progress:    jobspb.StreamIngestionProgress{},
+			Details:     streamIngestionDetails,
 		}
 
 		jobID := p.ExecCfg().JobRegistry.MakeJobID()

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_test.go
@@ -179,10 +179,6 @@ func TestStreamIngestionJobWithRandomClient(t *testing.T) {
 		return nil
 	})
 
-	// Canceling the job should fail as an ingestion job is non-cancelable.
-	_, err = conn.Exec(`CANCEL JOB $1`, jobID)
-	testutils.IsError(err, "not cancelable")
-
 	// Cutting over the job should shutdown the ingestion processors via a context
 	// cancellation, and subsequently rollback data above our frontier timestamp.
 	//

--- a/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"testing"
 	"time"
 
@@ -24,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -61,6 +62,25 @@ func (c *tenantStreamingClusters) compareResult(query string) {
 	sourceData := c.srcTenantSQL.QueryStr(c.t, query)
 	destData := c.destTenantSQL.QueryStr(c.t, query)
 	require.Equal(c.t, sourceData, destData)
+}
+
+// Waits for the ingestion job high watermark to reach the given high watermark.
+func (c *tenantStreamingClusters) waitUntilHighWatermark(
+	highWatermark time.Time, ingestionJobID jobspb.JobID,
+) {
+	testutils.SucceedsSoon(c.t, func() error {
+		progress := jobutils.GetJobProgress(c.t, c.destSysSQL, ingestionJobID)
+		if progress.GetHighWater() == nil {
+			return errors.Newf("stream ingestion has not recorded any progress yet, waiting to advance pos %s",
+				highWatermark.String())
+		}
+		highwater := *progress.GetHighWater()
+		if highwater.GoTime().Before(highWatermark) {
+			return errors.Newf("waiting for stream ingestion job progress %s to advance beyond %s",
+				highwater.String(), highWatermark.String())
+		}
+		return nil
+	})
 }
 
 func (c *tenantStreamingClusters) cutover(
@@ -123,6 +143,8 @@ func createTenantStreamingClusters(
 
 	args.srcInitFunc(t, sourceSysSQL, sourceTenantSQL)
 	args.destInitFunc(t, destSysSQL, destTenantSQL)
+	// Enable stream replication on dest by default.
+	destSysSQL.Exec(t, `SET enable_experimental_stream_replication = true;`)
 	return &tenantStreamingClusters{
 			t:             t,
 			args:          args,
@@ -141,24 +163,34 @@ func (c *tenantStreamingClusters) srcExec(exec execFunc) {
 	exec(c.t, c.srcSysSQL, c.srcTenantSQL)
 }
 
-var srcClusterSetting = `
-	SET CLUSTER SETTING kv.rangefeed.enabled = true;
-	SET CLUSTER SETTING kv.closed_timestamp.target_duration = '1s';
-	SET CLUSTER SETTING changefeed.experimental_poll_interval = '10ms';
-  SET CLUSTER SETTING stream_replication.job_liveness_timeout = '20s';
-  SET CLUSTER SETTING stream_replication.stream_liveness_track_frequency = '2s';
-  SET CLUSTER SETTING stream_replication.min_checkpoint_frequency = '1s';
-  SET CLUSTER SETTING kv.bulk_io_write.small_write_size = '1';
-`
+var srcClusterSetting = map[string]string{
+	`kv.rangefeed.enabled`:                `true`,
+	`kv.closed_timestamp.target_duration`: `'1s'`,
+	// Large timeout makes test to not fail with unexpected timeout failures.
+	`stream_replication.job_liveness_timeout`:            `'20s'`,
+	`stream_replication.stream_liveness_track_frequency`: `'2s'`,
+	`stream_replication.min_checkpoint_frequency`:        `'1s'`,
+	// Make all AddSSTable operation to trigger AddSSTable events.
+	`kv.bulk_io_write.small_write_size`: `'1'`,
+	`jobs.registry.interval.adopt`:      `'1s'`,
+}
 
-var destClusterSetting = `
-	SET enable_experimental_stream_replication = true;
-	SET CLUSTER SETTING stream_replication.consumer_heartbeat_frequency = '100ms';
-	SET CLUSTER SETTING bulkio.stream_ingestion.minimum_flush_interval = '10ms';
-	SET CLUSTER SETTING bulkio.stream_ingestion.cutover_signal_poll_interval = '100ms';
-`
+var destClusterSetting = map[string]string{
+	`stream_replication.consumer_heartbeat_frequency`:      `'1s'`,
+	`bulkio.stream_ingestion.minimum_flush_interval`:       `'10ms'`,
+	`bulkio.stream_ingestion.cutover_signal_poll_interval`: `'100ms'`,
+	`jobs.registry.interval.adopt`:                         `'1s'`,
+}
 
-func TestPartitionedTenantStreamingEndToEnd(t *testing.T) {
+func configureClusterSettings(setting map[string]string) []string {
+	res := make([]string, len(setting))
+	for key, val := range setting {
+		res = append(res, fmt.Sprintf("SET CLUSTER SETTING %s = %s;", key, val))
+	}
+	return res
+}
+
+func TestTenantStreamingSuccessfulIngestion(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -181,7 +213,7 @@ func TestPartitionedTenantStreamingEndToEnd(t *testing.T) {
 		c, cleanup := createTenantStreamingClusters(ctx, t, tenantStreamingClustersArgs{
 			srcTenantID: roachpb.MakeTenantID(10),
 			srcInitFunc: func(t *testing.T, sysSQL *sqlutils.SQLRunner, tenantSQL *sqlutils.SQLRunner) {
-				sysSQL.ExecMultiple(t, strings.Split(srcClusterSetting, ";")...)
+				sysSQL.ExecMultiple(t, configureClusterSettings(srcClusterSetting)...)
 				if !withInitialScan {
 					sysSQL.QueryRow(t, "SELECT cluster_logical_timestamp()").Scan(&startTime)
 				}
@@ -200,7 +232,7 @@ func TestPartitionedTenantStreamingEndToEnd(t *testing.T) {
 			srcNumNodes:  1,
 			destTenantID: roachpb.MakeTenantID(20),
 			destInitFunc: func(t *testing.T, sysSQL *sqlutils.SQLRunner, tenantSQL *sqlutils.SQLRunner) {
-				sysSQL.ExecMultiple(t, strings.Split(destClusterSetting, ";")...)
+				sysSQL.ExecMultiple(t, configureClusterSettings(destClusterSetting)...)
 			},
 			destNumNodes: 1,
 		})
@@ -225,6 +257,8 @@ func TestPartitionedTenantStreamingEndToEnd(t *testing.T) {
 		c.srcExec(func(t *testing.T, sysSQL *sqlutils.SQLRunner, tenantSQL *sqlutils.SQLRunner) {
 			tenantSQL.Exec(t, `INSERT INTO d.t2 VALUES (3);`)
 		})
+		// Check the dst cluster didn't receive the change after a while.
+		<-time.NewTimer(3 * time.Second).C
 		require.Equal(t, [][]string{{"2"}}, c.destTenantSQL.QueryStr(t, "SELECT * FROM d.t2"))
 	}
 
@@ -235,4 +269,65 @@ func TestPartitionedTenantStreamingEndToEnd(t *testing.T) {
 	t.Run("no-initial-scan", func(t *testing.T) {
 		testTenantStreaming(t, false /* withInitialScan */)
 	})
+}
+
+func TestTenantStreamingProducerJobTimedOut(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	srcClusterSetting[`stream_replication.job_liveness_timeout`] = `'3m'`
+	c, cleanup := createTenantStreamingClusters(ctx, t, tenantStreamingClustersArgs{
+		srcTenantID: roachpb.MakeTenantID(10),
+		srcInitFunc: func(t *testing.T, sysSQL *sqlutils.SQLRunner, tenantSQL *sqlutils.SQLRunner) {
+			sysSQL.ExecMultiple(t, configureClusterSettings(srcClusterSetting)...)
+			tenantSQL.Exec(t, `
+	CREATE DATABASE d;
+	CREATE TABLE d.t1(i int primary key, a string, b string);
+	CREATE TABLE d.t2(i int primary key);
+	INSERT INTO d.t1 (i) VALUES (42);
+	INSERT INTO d.t2 VALUES (2);
+	UPDATE d.t1 SET b = 'world' WHERE i = 42;
+	`)
+		},
+		srcNumNodes:  1,
+		destTenantID: roachpb.MakeTenantID(20),
+		destInitFunc: func(t *testing.T, sysSQL *sqlutils.SQLRunner, tenantSQL *sqlutils.SQLRunner) {
+			sysSQL.ExecMultiple(t, configureClusterSettings(destClusterSetting)...)
+		},
+		destNumNodes: 1,
+	})
+	defer cleanup()
+
+	// initial scan
+	producerJobID, ingestionJobID := c.startStreamReplication("" /* startTime */)
+
+	jobutils.WaitForJobToRun(c.t, c.srcSysSQL, jobspb.JobID(producerJobID))
+	jobutils.WaitForJobToRun(c.t, c.destSysSQL, jobspb.JobID(ingestionJobID))
+
+	var srcTime time.Time
+	c.srcSysSQL.QueryRow(t, "SELECT clock_timestamp()").Scan(&srcTime)
+	c.waitUntilHighWatermark(srcTime, jobspb.JobID(ingestionJobID))
+
+	c.compareResult("SELECT * FROM d.t1")
+	c.compareResult("SELECT * FROM d.t2")
+
+	// Make producer job easily times out
+	c.srcSysSQL.ExecMultiple(t, configureClusterSettings(map[string]string{
+		`stream_replication.job_liveness_timeout`: `'100ms'`,
+	})...)
+
+	jobutils.WaitForJobToFail(c.t, c.srcSysSQL, jobspb.JobID(producerJobID))
+	jobutils.WaitForJobToFail(c.t, c.destSysSQL, jobspb.JobID(ingestionJobID))
+
+	// Make dest cluster to ingest KV events faster.
+	c.srcSysSQL.ExecMultiple(t, configureClusterSettings(map[string]string{
+		`stream_replication.min_checkpoint_frequency`: `'100ms'`,
+	})...)
+	c.srcTenantSQL.Exec(t, "INSERT INTO d.t2 VALUES (3);")
+
+	// Check the dst cluster didn't receive the change after a while.
+	<-time.NewTimer(3 * time.Second).C
+	require.Equal(t, [][]string{{"0"}},
+		c.destTenantSQL.QueryStr(t, "SELECT count(*) FROM d.t2 WHERE i = 3"))
 }

--- a/pkg/ccl/streamingccl/streamproducer/stream_lifetime.go
+++ b/pkg/ccl/streamingccl/streamproducer/stream_lifetime.go
@@ -118,11 +118,9 @@ func updateReplicationStreamProgress(
 				}
 				status.ProtectedTimestamp = &ts
 			}
-
-			if p := md.Progress; expiration.After(p.GetStreamReplication().Expiration) {
-				p.GetStreamReplication().Expiration = expiration
-				ju.UpdateProgress(p)
-			}
+			// Allow expiration time to go backwards as user may set a smaller timeout.
+			md.Progress.GetStreamReplication().Expiration = expiration
+			ju.UpdateProgress(md.Progress)
 			return nil
 		})
 
@@ -139,7 +137,6 @@ func updateReplicationStreamProgress(
 func heartbeatReplicationStream(
 	evalCtx *eval.Context, streamID streaming.StreamID, frontier hlc.Timestamp, txn *kv.Txn,
 ) (streampb.StreamReplicationStatus, error) {
-
 	execConfig := evalCtx.Planner.ExecutorConfig().(*sql.ExecutorConfig)
 	timeout := streamingccl.StreamReplicationJobLivenessTimeout.Get(&evalCtx.Settings.SV)
 	expirationTime := timeutil.Now().Add(timeout)


### PR DESCRIPTION
    Previously, the producer job used a stale value of the job's
    expiration. This led to the producer job failing with a timed
    out state even when the ingestion job had correctly recently
    heartbeat the job. Further, the producer job did not respond to changes
    to the stream_replication.stream_liveness_track_frequency setting.
    After ingestion job fails, the registry problematically keeps
    retrying the ingestion job forever as it is Noncancelable.

    This PR makes producer job to correctly treat timeout setting
    and make the ingestion job cancelable and not retry forever on
    the producer timeout error.

    Release note: None