### PR TITLE
release-22.1: kvstreamer: ask for a separate LeafTxn

### DIFF
--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -277,7 +277,7 @@ func (ds *ServerImpl) setupFlow(
 	)
 	monitor.Start(ctx, parentMonitor, mon.BoundAccount{})
 
-	makeLeaf := func(req *execinfrapb.SetupFlowRequest) (*kv.Txn, error) {
+	makeLeaf := func() (*kv.Txn, error) {
 		tis := req.LeafTxnInputState
 		if tis == nil {
 			// This must be a flow running for some bulk-io operation that doesn't use
@@ -310,7 +310,7 @@ func (ds *ServerImpl) setupFlow(
 		evalCtx.Mon = monitor
 		if localState.HasConcurrency {
 			var err error
-			leafTxn, err = makeLeaf(req)
+			leafTxn, err = makeLeaf()
 			if err != nil {
 				return nil, nil, nil, err
 			}
@@ -332,7 +332,7 @@ func (ds *ServerImpl) setupFlow(
 		// It's important to populate evalCtx.Txn early. We'll write it again in the
 		// f.SetTxn() call below, but by then it will already have been captured by
 		// processors.
-		leafTxn, err = makeLeaf(req)
+		leafTxn, err = makeLeaf()
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -368,7 +368,7 @@ func (ds *ServerImpl) setupFlow(
 
 	// Create the FlowCtx for the flow.
 	flowCtx := ds.newFlowContext(
-		ctx, req.Flow.FlowID, evalCtx, req.TraceKV, req.CollectStats, localState, req.Flow.Gateway == ds.NodeID.SQLInstanceID(),
+		ctx, req.Flow.FlowID, evalCtx, makeLeaf, req.TraceKV, req.CollectStats, localState, req.Flow.Gateway == ds.NodeID.SQLInstanceID(),
 	)
 
 	// req always contains the desired vectorize mode, regardless of whether we
@@ -429,7 +429,7 @@ func (ds *ServerImpl) setupFlow(
 	} else {
 		// If I haven't created the leaf already, do it now.
 		if leafTxn == nil {
-			leafTxn, err = makeLeaf(req)
+			leafTxn, err = makeLeaf()
 			if err != nil {
 				return nil, nil, nil, err
 			}
@@ -454,6 +454,7 @@ func (ds *ServerImpl) newFlowContext(
 	ctx context.Context,
 	id execinfrapb.FlowID,
 	evalCtx *tree.EvalContext,
+	makeLeafTxn func() (*kv.Txn, error),
 	traceKV bool,
 	collectStats bool,
 	localState LocalState,
@@ -466,6 +467,7 @@ func (ds *ServerImpl) newFlowContext(
 		ID:             id,
 		EvalCtx:        evalCtx,
 		Txn:            evalCtx.Txn,
+		MakeLeafTxn:    makeLeafTxn,
 		NodeID:         ds.ServerConfig.NodeID,
 		TraceKV:        traceKV,
 		CollectStats:   collectStats,

--- a/pkg/sql/execinfra/flow_context.go
+++ b/pkg/sql/execinfra/flow_context.go
@@ -52,6 +52,9 @@ type FlowCtx struct {
 	// higher-level txn (like backfills).
 	Txn *kv.Txn
 
+	// MakeLeafTxn returns a new LeafTxn, different from Txn.
+	MakeLeafTxn func() (*kv.Txn, error)
+
 	// Descriptors is used to look up leased table descriptors and to construct
 	// transaction bound TypeResolvers to resolve type references during flow
 	// setup. It is not safe for concurrent use and is intended to be used only

--- a/pkg/sql/kvstreamer/streamer.go
+++ b/pkg/sql/kvstreamer/streamer.go
@@ -275,7 +275,7 @@ func max(a, b int64) int64 {
 
 // NewStreamer creates a new Streamer.
 //
-// txn must be a LeafTxn.
+// txn must be a LeafTxn that is not used by anything other than this Streamer.
 //
 // limitBytes determines the maximum amount of memory this Streamer is allowed
 // to use (i.e. it'll be used lazily, as needed). The more memory it has, the

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -121,8 +121,11 @@ type joinReader struct {
 	keyLocking     descpb.ScanLockingStrength
 	lockWaitPolicy lock.WaitPolicy
 
+	// txn is the transaction used by the join reader.
+	txn *kv.Txn
+
 	// usesStreamer indicates whether the joinReader performs the lookups using
-	// the kvcoord.Streamer API.
+	// the kvstreamer.Streamer API.
 	usesStreamer bool
 	streamerInfo struct {
 		*kvstreamer.Streamer
@@ -303,7 +306,7 @@ func newJoinReader(
 	if flowCtx.EvalCtx.SessionData().ParallelizeMultiKeyLookupJoinsEnabled {
 		shouldLimitBatches = false
 	}
-	useStreamer := flowCtx.Txn != nil && flowCtx.Txn.Type() == kv.LeafTxn &&
+	useStreamer := flowCtx.Txn != nil && flowCtx.Txn.Type() == kv.LeafTxn && flowCtx.MakeLeafTxn != nil &&
 		readerType == indexJoinReaderType &&
 		row.CanUseStreamer(flowCtx.EvalCtx.Ctx(), flowCtx.EvalCtx.Settings)
 
@@ -326,9 +329,19 @@ func newJoinReader(
 		jr.groupingState = &inputBatchGroupingState{doGrouping: spec.LeftJoinWithPairedJoiner}
 	}
 
+	if useStreamer {
+		var err error
+		jr.txn, err = flowCtx.MakeLeafTxn()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		jr.txn = flowCtx.Txn
+	}
+
 	// Make sure the key column types are hydrated. The fetched column types will
 	// be hydrated in ProcessorBase.Init (via joinerBase.init).
-	resolver := flowCtx.NewTypeResolver(flowCtx.Txn)
+	resolver := flowCtx.NewTypeResolver(jr.txn)
 	for i := range spec.FetchSpec.KeyAndSuffixColumns {
 		if err := typedesc.EnsureTypeIsHydrated(
 			flowCtx.EvalCtx.Ctx(), spec.FetchSpec.KeyAndSuffixColumns[i].Type, &resolver,
@@ -410,7 +423,7 @@ func newJoinReader(
 		lookupExprTypes = append(lookupExprTypes, leftTypes...)
 		lookupExprTypes = append(lookupExprTypes, rightTypes...)
 
-		semaCtx := flowCtx.NewSemaContext(flowCtx.EvalCtx.Txn)
+		semaCtx := flowCtx.NewSemaContext(jr.txn)
 		if err := jr.lookupExpr.Init(spec.LookupExpr, lookupExprTypes, semaCtx, jr.EvalCtx); err != nil {
 			return nil, err
 		}
@@ -879,7 +892,7 @@ func (jr *joinReader) readInput() (
 			}
 		}
 		err = jr.fetcher.StartScan(
-			jr.Ctx, jr.FlowCtx.Txn, spans, bytesLimit, rowinfra.NoRowLimit,
+			jr.Ctx, jr.txn, spans, bytesLimit, rowinfra.NoRowLimit,
 			jr.FlowCtx.TraceKV, jr.EvalCtx.TestingKnobs.ForceProductionBatchSizes,
 		)
 	}
@@ -955,7 +968,7 @@ func (jr *joinReader) performLookup() (joinReaderState, *execinfrapb.ProducerMet
 				bytesLimit = rowinfra.NoBytesLimit
 			}
 			if err := jr.fetcher.StartScan(
-				jr.Ctx, jr.FlowCtx.Txn, spans, bytesLimit, rowinfra.NoRowLimit,
+				jr.Ctx, jr.txn, spans, bytesLimit, rowinfra.NoRowLimit,
 				jr.FlowCtx.TraceKV, jr.EvalCtx.TestingKnobs.ForceProductionBatchSizes,
 			); err != nil {
 				jr.MoveToDraining(err)
@@ -1002,7 +1015,7 @@ func (jr *joinReader) Start(ctx context.Context) {
 		jr.streamerInfo.Streamer = kvstreamer.NewStreamer(
 			jr.FlowCtx.Cfg.DistSender,
 			jr.FlowCtx.Stopper(),
-			jr.FlowCtx.Txn,
+			jr.txn,
 			jr.FlowCtx.EvalCtx.Settings,
 			jr.lockWaitPolicy,
 			jr.streamerInfo.budgetLimit,
@@ -1108,7 +1121,7 @@ func (jr *joinReader) generateMeta() []execinfrapb.ProducerMetadata {
 	meta.Metrics = execinfrapb.GetMetricsMeta()
 	meta.Metrics.RowsRead = jr.rowsRead
 	meta.Metrics.BytesRead = jr.fetcher.GetBytesRead()
-	if tfs := execinfra.GetLeafTxnFinalState(jr.Ctx, jr.FlowCtx.Txn); tfs != nil {
+	if tfs := execinfra.GetLeafTxnFinalState(jr.Ctx, jr.txn); tfs != nil {
 		trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{LeafTxnFinalState: tfs})
 	}
 	return trailingMeta


### PR DESCRIPTION
Backport 1/1 commits from #82639.

/cc @cockroachdb/release

---

This commit fixes the streamer so that it uses a LeafTxn that is not
shared with any other components. Such a setup is needed in order to
avoid spurious "context canceled" errors returned when multiple
streamers are part of the same flow.

Consider the following setup. We have a remote flow consisting of two
trees of operators rooted in the outboxes:
```
  └ Node 2
    ├ *colrpc.Outbox
    │ └ *rowexec.joinReader
...
    └ *colrpc.Outbox
      └ *rowexec.joinReader
```
Both of the join readers use the streamer API and run in separate
goroutines (because outboxes run in separate goroutines). Then let's
imagine that one of the outboxes is moved to draining while the
corresponding streamer is still evaluating requests. The join reader
will call `Streamer.Close` which cancels the context of the requests'
evaluation. This cancellation "poisons" the txn used by that streamer
with `ERROR: txn already encountered an error`.

Now let's imagine that the second tree of operators is not done yet and
needs to produce more data. Whenever the streamer in that tree tries to
evaluate some requests, it would run into the "poisoned" txn error.

This commit goes around this problem by giving a separate LeafTxn to
each streamer so that a streamer from one tree could not poison the txn
of the streamer from another tree. The non-streamer code path doesn't
run into a similar problem because it doesn't eagerly cancel the
outstanding requests.

I think a similar change (to give the streamer a separate leaf txn) will
also be needed to support the transparent refresh mechanism in some
cases, so this commit is beneficial from that point of view too.

I spent some time attempting to write a regression test, but it is quite
difficult to come up with something reliable here, and I decided to not
spend more time on it.

Fixes: #82336.

Release note: None

Release justification: bug fix for non-default behavior.