### PR TITLE
prometheus: improve UX, add grafana, node_exporter, custom dashboards

### DIFF
--- a/pkg/cmd/roachtest/tests/canary.go
+++ b/pkg/cmd/roachtest/tests/canary.go
@@ -109,6 +109,17 @@ var canaryRetryOptions = retry.Options{
 	MaxRetries:     10,
 }
 
+type repeatRunner struct {
+	T test.Test
+	C cluster.Cluster
+}
+
+func (rr repeatRunner) repeatRunE(
+	ctx context.Context, node option.NodeListOption, operation string, args ...string,
+) error {
+	return repeatRunE(ctx, rr.T, rr.C, node, operation, args...)
+}
+
 // repeatRunE is the same function as c.RunE but with an automatic retry loop.
 func repeatRunE(
 	ctx context.Context,


### PR DESCRIPTION
We already had the ability to deploy a prometheus instance to a node in
the cluster. However, to run experiments / long investigations[^1] we
often need a Grafana instance with the dashboards du jour. This commit
dramatically cuts down on the manual steps needed to get this set up.

All it takes is adding setup like this to the roachtest:

```
clusNodes := c.Range(1, c.Spec().NodeCount-1)
workloadNode := c.Node(c.Spec().NodeCount)
promNode := workloadNode
cfg := (&prometheus.Config{}).
        WithPrometheusNode(promNode).
        WithCluster(clusNodes).
        WithGrafanaDashboard("https://gist.githubusercontent.com/tbg/f238d578269143187e71a1046562225f/raw").
        WithNodeExporter(clusNodes).
        WithWorkload(workloadNode, 2112).
        WithWorkload(workloadNode, 2113)

p, saveSnap, err := prometheus.Init(
        ctx,
        *cfg,
        c,
        t.L(),
        repeatRunner{C: c, T: t}.repeatRunE,
)
require.NoError(t, err)
defer saveSnap(ctx, t.ArtifactsDir())
```

There has been talk[^2] of adding some of this tooling to `roachprod`.
Probably a good idea, but we can pour infinite amount of work into this,
and for now I think this is a good stepping stone and satisfies my
immediate needs.

[^1]: https://github.com/cockroachdb/cockroach/issues/82109
[^2]: [internal slack](https://cockroachlabs.slack.com/archives/CAC6K3SLU/p1654267035695569?thread_ts=1654153265.215669&cid=CAC6K3SLU)

Release note: None
