### PR TITLE
roachtest: allow --cluster to create cluster

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -687,7 +687,8 @@ func (c *clusterImpl) closeLogger() {
 }
 
 type clusterConfig struct {
-	spec spec.ClusterSpec
+	nameOverride string
+	spec         spec.ClusterSpec
 	// artifactsDir is the path where log file will be stored.
 	artifactsDir string
 	// username is the username passed via the --username argument
@@ -746,6 +747,9 @@ func (f *clusterFactory) releaseSem() {
 func (f *clusterFactory) genName(cfg clusterConfig) string {
 	if cfg.localCluster {
 		return "local" // The roachprod tool understands this magic name.
+	}
+	if cfg.nameOverride != "" {
+		return cfg.nameOverride
 	}
 	count := atomic.AddUint64(&f.counter, 1)
 	return makeClusterName(
@@ -841,7 +845,13 @@ func (f *clusterFactory) newCluster(
 
 	// Attempt to create a cluster several times to be able to move past
 	// temporary flakiness in the cloud providers.
-	const maxAttempts = 3
+	maxAttempts := 3
+	if cfg.nameOverride != "" {
+		// Usually when retrying we pick a new name (to avoid repeat failures due to
+		// partially created resources), but we were were asked to use a specific
+		// name. To keep things simple, disable retries in that case.
+		maxAttempts = 1
+	}
 	// loop assumes maxAttempts is atleast (1).
 	for i := 1; ; i++ {
 		c := &clusterImpl{
@@ -940,14 +950,14 @@ func attachToExistingCluster(
 		r: r,
 	}
 
-	if err := r.registerCluster(c); err != nil {
-		return nil, err
-	}
-
 	if !opt.skipValidation {
 		if err := c.validate(ctx, spec, l); err != nil {
 			return nil, err
 		}
+	}
+
+	if err := r.registerCluster(c); err != nil {
+		return nil, err
 	}
 
 	if !opt.skipStop {
@@ -1017,6 +1027,8 @@ func (c *clusterImpl) Save(ctx context.Context, msg string, l *logger.Logger) {
 	c.destroyState.mu.Unlock()
 }
 
+var errClusterNotFound = errors.New("cluster not found")
+
 // validateCluster takes a cluster and checks that the reality corresponds to
 // the cluster's spec. It's intended to be used with clusters created by
 // attachToExistingCluster(); otherwise, clusters create with newCluster() are
@@ -1033,7 +1045,7 @@ func (c *clusterImpl) validate(
 	}
 	cDetails, ok := cloudClusters.Clusters[c.name]
 	if !ok {
-		return fmt.Errorf("cluster %q not found", c.name)
+		return errors.Wrapf(errClusterNotFound, "%q", c.name)
 	}
 	if len(cDetails.VMs) < c.spec.NodeCount {
 		return fmt.Errorf("cluster has %d nodes, test requires at least %d", len(cDetails.VMs), c.spec.NodeCount)

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -121,7 +121,8 @@ func main() {
 		&clusterName, "cluster", "c", "",
 		"Comma-separated list of names existing cluster to use for running tests. "+
 			"If fewer than --parallelism names are specified, then the parallelism "+
-			"is capped to the number of clusters specified.")
+			"is capped to the number of clusters specified. When a cluster does not exist "+
+			"yet, it is created according to the spec.")
 	rootCmd.PersistentFlags().BoolVarP(
 		&local, "local", "l", local, "run tests locally")
 	rootCmd.PersistentFlags().StringVarP(

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -362,11 +362,24 @@ func defaultClusterAllocator(
 				skipWipe:       r.config.skipClusterWipeOnAttach,
 			}
 			lopt.l.PrintfCtx(ctx, "Attaching to existing cluster %s for test %s", existingClusterName, t.Name)
-			return attachToExistingCluster(ctx, existingClusterName, clusterL, t.Cluster, opt, r.cr)
+			c, err := attachToExistingCluster(ctx, existingClusterName, clusterL, t.Cluster, opt, r.cr)
+			if err == nil {
+				return c, nil
+			}
+			if err != nil && !errors.Is(err, errClusterNotFound) {
+				return nil, err
+			}
+			// Fall through to create new cluster with name override.
+			lopt.l.PrintfCtx(
+				ctx, "Creating new cluster with custom name %q for test %s: %s",
+				clustersOpt.clusterName, t.Name, t.Cluster,
+			)
+		} else {
+			lopt.l.PrintfCtx(ctx, "Creating new cluster for test %s: %s", t.Name, t.Cluster)
 		}
-		lopt.l.PrintfCtx(ctx, "Creating new cluster for test %s: %s", t.Name, t.Cluster)
 
 		cfg := clusterConfig{
+			nameOverride: clustersOpt.clusterName, // only set if we hit errClusterFound above
 			spec:         t.Cluster,
 			artifactsDir: artifactsDir,
 			username:     clustersOpt.user,


### PR DESCRIPTION
For #81516 I am concurrently running multiple clusters on both AWS and
GCE.  Maintaing the mental mapping of automatically generated cluster
name to flavor of test, cloud, etc, is an unnecessary complication.

This commit extends the semantics of the `--cluster` flag to allow
specifying a cluster name to use for a test, so we can now freely
choose the cluster name like so:

`roachtest run mytest/foo --cloud aws --cluster $USER-mytest-foo-aws`

Release note: None
