### PR TITLE
sql: adjust multitenant_fairness tests to avoid kvserver falling over

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_fairness.go
+++ b/pkg/cmd/roachtest/tests/multitenant_fairness.go
@@ -51,7 +51,8 @@ func registerMultiTenantFairness(r registry.Registry) {
 			},
 			{
 				name:        "concurrency-skew",
-				concurrency: func(i int) int { return i * 250 },
+				// Factor of 100 gives same overall concurrency as "same" (i.e. 1000)
+				concurrency: func(i int) int { return i * 100 },
 			},
 		}
 		for i := range kvSpecs {
@@ -80,7 +81,8 @@ func registerMultiTenantFairness(r registry.Registry) {
 			},
 			{
 				name:        "concurrency-skew",
-				concurrency: func(i int) int { return i * 50 },
+				// Factor of 20 gives same overall concurrency as "same" (i.e. 200)
+				concurrency: func(i int) int { return i * 20 },
 			},
 		}
 		for i := range storeSpecs {


### PR DESCRIPTION
Fixes: #82033

In further validation of admission control the kvserver was falling
over with super high concurrency of the concurrency-skew workload. Dial
it back to be inline with "same" workload, ie 1000 for kv and 200
for store.

Release note: None
