### PR TITLE
sqlsmith: skip three builtins

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -504,6 +504,7 @@ var functions = func() map[tree.FunctionClass]map[oid.Oid][]function {
 			"crdb_internal.start_replication_stream",
 			"crdb_internal.replication_stream_progress",
 			"crdb_internal.complete_replication_stream",
+			"crdb_internal.revalidate_unique_constraint",
 		} {
 			skip = skip || strings.Contains(def.Name, substr)
 		}


### PR DESCRIPTION
This commit skips using three builtins with
`crdb_internal.revalidate_unique_constraint` prefix.

Fixes: #82655.

Release note: None