### PR TITLE
release-22.1: sqlsmith: skip three builtins

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -502,6 +502,7 @@ var functions = func() map[tree.FunctionClass]map[oid.Oid][]function {
 			"crdb_internal.reset_index_usage_stats",
 			"crdb_internal.start_replication_stream",
 			"crdb_internal.replication_stream_progress",
+			"crdb_internal.revalidate_unique_constraint",
 		} {
 			skip = skip || strings.Contains(def.Name, substr)
 		}


### PR DESCRIPTION
Backport 1/1 commits from #82666.

/cc @cockroachdb/release

---

This commit skips using three builtins with
`crdb_internal.revalidate_unique_constraint` prefix.

Fixes: #82655.

Release note: None

Release justification: test fix.