### PR TITLE
release-21.2: sqlsmith: skip three builtins

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -496,7 +496,8 @@ var functions = func() map[tree.FunctionClass]map[oid.Oid][]function {
 		if strings.Contains(def.Name, "crdb_internal.force_") ||
 			strings.Contains(def.Name, "crdb_internal.unsafe_") ||
 			strings.Contains(def.Name, "crdb_internal.create_join_token") ||
-			strings.Contains(def.Name, "crdb_internal.reset_multi_region_zone_configs_for_database") {
+			strings.Contains(def.Name, "crdb_internal.reset_multi_region_zone_configs_for_database") ||
+			strings.Contains(def.Name, "crdb_internal.revalidate_unique_constraint") {
 			continue
 		}
 		if _, ok := m[def.Class]; !ok {


### PR DESCRIPTION
Backport 1/1 commits from #82666.

/cc @cockroachdb/release

---

This commit skips using three builtins with
`crdb_internal.revalidate_unique_constraint` prefix.

Fixes: #82655.

Release note: None

Release justification: test fix.