### PR TITLE
sql, pgwire: Add `SEVERITY_NONLOCALIZED` error field

### DIFF
--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -1474,6 +1474,9 @@ func writeErrFields(
 	msgBuilder.putErrFieldMsg(pgwirebase.ServerErrFieldSeverity)
 	msgBuilder.writeTerminatedString(pgErr.Severity)
 
+	msgBuilder.putErrFieldMsg(pgwirebase.ServerErrFieldSeverityNonLocalized)
+	msgBuilder.writeTerminatedString(pgErr.Severity)
+
 	msgBuilder.putErrFieldMsg(pgwirebase.ServerErrFieldSQLState)
 	msgBuilder.writeTerminatedString(pgErr.Code)
 

--- a/pkg/sql/pgwire/pgwirebase/msg.go
+++ b/pkg/sql/pgwire/pgwirebase/msg.go
@@ -61,15 +61,16 @@ type ServerErrFieldType byte
 
 // http://www.postgresql.org/docs/current/static/protocol-error-fields.html
 const (
-	ServerErrFieldSeverity       ServerErrFieldType = 'S'
-	ServerErrFieldSQLState       ServerErrFieldType = 'C'
-	ServerErrFieldMsgPrimary     ServerErrFieldType = 'M'
-	ServerErrFieldDetail         ServerErrFieldType = 'D'
-	ServerErrFieldHint           ServerErrFieldType = 'H'
-	ServerErrFieldSrcFile        ServerErrFieldType = 'F'
-	ServerErrFieldSrcLine        ServerErrFieldType = 'L'
-	ServerErrFieldSrcFunction    ServerErrFieldType = 'R'
-	ServerErrFieldConstraintName ServerErrFieldType = 'n'
+	ServerErrFieldSeverity             ServerErrFieldType = 'S'
+	ServerErrFieldSeverityNonLocalized ServerErrFieldType = 'V'
+	ServerErrFieldSQLState             ServerErrFieldType = 'C'
+	ServerErrFieldMsgPrimary           ServerErrFieldType = 'M'
+	ServerErrFieldDetail               ServerErrFieldType = 'D'
+	ServerErrFieldHint                 ServerErrFieldType = 'H'
+	ServerErrFieldSrcFile              ServerErrFieldType = 'F'
+	ServerErrFieldSrcLine              ServerErrFieldType = 'L'
+	ServerErrFieldSrcFunction          ServerErrFieldType = 'R'
+	ServerErrFieldConstraintName       ServerErrFieldType = 'n'
 )
 
 // PrepareType represents a subtype for prepare messages.

--- a/pkg/sql/pgwire/pgwirebase/servererrfieldtype_string.go
+++ b/pkg/sql/pgwire/pgwirebase/servererrfieldtype_string.go
@@ -9,6 +9,7 @@ func _() {
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
 	_ = x[ServerErrFieldSeverity-83]
+	_ = x[ServerErrFieldSeverityNonLocalized-86]
 	_ = x[ServerErrFieldSQLState-67]
 	_ = x[ServerErrFieldMsgPrimary-77]
 	_ = x[ServerErrFieldDetail-68]
@@ -25,7 +26,8 @@ const (
 	_ServerErrFieldType_name_2 = "ServerErrFieldHint"
 	_ServerErrFieldType_name_3 = "ServerErrFieldSrcLineServerErrFieldMsgPrimary"
 	_ServerErrFieldType_name_4 = "ServerErrFieldSrcFunctionServerErrFieldSeverity"
-	_ServerErrFieldType_name_5 = "ServerErrFieldConstraintName"
+	_ServerErrFieldType_name_5 = "ServerErrFieldSeverityNonLocalized"
+	_ServerErrFieldType_name_6 = "ServerErrFieldConstraintName"
 )
 
 var (
@@ -49,8 +51,10 @@ func (i ServerErrFieldType) String() string {
 	case 82 <= i && i <= 83:
 		i -= 82
 		return _ServerErrFieldType_name_4[_ServerErrFieldType_index_4[i]:_ServerErrFieldType_index_4[i+1]]
-	case i == 110:
+	case i == 86:
 		return _ServerErrFieldType_name_5
+	case i == 110:
+		return _ServerErrFieldType_name_6
 	default:
 		return "ServerErrFieldType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -55,7 +55,7 @@ Query {"String": "DROP INDEX t_x_idx"}
 until crdb_only
 CommandComplete
 ----
-{"Severity":"NOTICE","SeverityUnlocalized":"","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":572,"Routine":"dropIndexByName","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":572,"Routine":"dropIndexByName","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 
 until noncrdb_only


### PR DESCRIPTION
Resolves #81794

Release note (sql change): We now send the Severity_Nonlocalized field
in the pgwire Notice Response.