### PR TITLE
prometheus: add roachprod "node" label to scraped time series

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -1439,13 +1439,9 @@ func setupPrometheusForTPCC(
 		cfg = &prometheus.Config{
 			PrometheusNode: workloadNode,
 			// Scrape each CockroachDB node and the workload node.
-			ScrapeConfigs: []prometheus.ScrapeConfig{
-				prometheus.MakeInsecureCockroachScrapeConfig(
-					"cockroach",
-					c.Range(1, c.Spec().NodeCount-1),
-				),
+			ScrapeConfigs: append(prometheus.MakeInsecureCockroachScrapeConfig(c.Range(1, c.Spec().NodeCount-1)),
 				prometheus.MakeWorkloadScrapeConfig("workload", makeWorkloadScrapeNodes(workloadNode, workloadInstances)),
-			},
+			),
 		}
 	}
 	if opts.DisablePrometheus {


### PR DESCRIPTION
Prior to this change, some time series would use "instance" as the main
identifier (an IP address), and CRDB timeseries would use "store". This
required constant translation between the two, which is cumbersome.

Make sure the roachprod int identifying the node is present both on the
CRDB nodes as well as node_exporter. We intentionally don't add it to
workload since it isn't as important where the workload runs, though
this is easy to patch up for the tests in which it might matter more;
these tests would likely want to add something bespoke (like the region
in multi-region tests) anyway though.

Release note: None
