### PR TITLE
sql: support ttl_expiration_expression for row-level TTL

### DIFF
--- a/pkg/sql/catalog/catpb/catalog.go
+++ b/pkg/sql/catalog/catpb/catalog.go
@@ -98,3 +98,13 @@ func (as *AutoStatsSettings) NoAutoStatsSettingsOverrides() bool {
 	}
 	return true
 }
+
+// HasDurationExpr is a utility method to determine if ttl_expires_after was set
+func (rowLevelTTL *RowLevelTTL) HasDurationExpr() bool {
+	return rowLevelTTL.DurationExpr != ""
+}
+
+// HasExpirationExpr is a utility method to determine if ttl_expiration_expression was set
+func (rowLevelTTL *RowLevelTTL) HasExpirationExpr() bool {
+	return rowLevelTTL.ExpirationExpr != ""
+}

--- a/pkg/sql/catalog/catpb/catalog.proto
+++ b/pkg/sql/catalog/catpb/catalog.proto
@@ -216,6 +216,8 @@ message RowLevelTTL {
   // LabelMetrics is true if metrics for the TTL job should add a label containing
   // the relation name.
   optional bool label_metrics = 10 [(gogoproto.nullable) = false];
+  // ExpirationExpr is the custom assigned expression for calculating when the TTL should apply to a row.
+  optional string expiration_expr = 11 [(gogoproto.nullable)=false, (gogoproto.casttype)="Expression"];
 }
 
 // AutoStatsSettings represents settings related to automatic statistics

--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//pkg/sql/catalog/multiregion",
         "//pkg/sql/catalog/schemaexpr",
         "//pkg/sql/catalog/typedesc",
+        "//pkg/sql/lexbase",
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",

--- a/pkg/sql/catalog/tabledesc/ttl.go
+++ b/pkg/sql/catalog/tabledesc/ttl.go
@@ -24,10 +24,10 @@ func ValidateRowLevelTTL(ttl *catpb.RowLevelTTL) error {
 	if ttl == nil {
 		return nil
 	}
-	if ttl.DurationExpr == "" {
+	if !ttl.HasDurationExpr() && !ttl.HasExpirationExpr() {
 		return pgerror.Newf(
 			pgcode.InvalidParameterValue,
-			`"ttl_expire_after" must be set`,
+			`"ttl_expire_after" and/or "ttl_expiration_expression" must be set`,
 		)
 	}
 	if ttl.DeleteBatchSize != 0 {

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -190,30 +190,40 @@ func (desc *wrapper) ValidateCrossReferences(
 
 	// For row-level TTL, only ascending PKs are permitted.
 	if desc.HasRowLevelTTL() {
-		pk := desc.GetPrimaryIndex()
-		if col, err := desc.FindColumnWithName(colinfo.TTLDefaultExpirationColumnName); err != nil {
-			vea.Report(errors.Wrapf(err, "expected column %s", colinfo.TTLDefaultExpirationColumnName))
-		} else {
-			intervalExpr := desc.GetRowLevelTTL().DurationExpr
-			expectedStr := `current_timestamp():::TIMESTAMPTZ + ` + string(intervalExpr)
-			if col.GetDefaultExpr() != expectedStr {
-				vea.Report(pgerror.Newf(
-					pgcode.InvalidTableDefinition,
-					"expected DEFAULT expression of %s to be %s",
-					colinfo.TTLDefaultExpirationColumnName,
-					expectedStr,
-				))
-			}
-			if col.GetOnUpdateExpr() != expectedStr {
-				vea.Report(pgerror.Newf(
-					pgcode.InvalidTableDefinition,
-					"expected ON UPDATE expression of %s to be %s",
-					colinfo.TTLDefaultExpirationColumnName,
-					expectedStr,
-				))
+		rowLevelTTL := desc.RowLevelTTL
+		if rowLevelTTL.HasDurationExpr() {
+			if col, err := desc.FindColumnWithName(colinfo.TTLDefaultExpirationColumnName); err != nil {
+				vea.Report(errors.Wrapf(err, "expected column %s", colinfo.TTLDefaultExpirationColumnName))
+			} else {
+				intervalExpr := desc.GetRowLevelTTL().DurationExpr
+				expectedStr := `current_timestamp():::TIMESTAMPTZ + ` + string(intervalExpr)
+				if col.GetDefaultExpr() != expectedStr {
+					vea.Report(pgerror.Newf(
+						pgcode.InvalidTableDefinition,
+						"expected DEFAULT expression of %s to be %s",
+						colinfo.TTLDefaultExpirationColumnName,
+						expectedStr,
+					))
+				}
+				if col.GetOnUpdateExpr() != expectedStr {
+					vea.Report(pgerror.Newf(
+						pgcode.InvalidTableDefinition,
+						"expected ON UPDATE expression of %s to be %s",
+						colinfo.TTLDefaultExpirationColumnName,
+						expectedStr,
+					))
+				}
 			}
 		}
 
+		if rowLevelTTL.HasExpirationExpr() {
+			_, err := parser.ParseExpr(string(rowLevelTTL.ExpirationExpr))
+			if err != nil {
+				vea.Report(errors.Wrapf(err, "value of 'ttl_expiration_expression' must be a valid expression"))
+			}
+		}
+
+		pk := desc.GetPrimaryIndex()
 		for i := 0; i < pk.NumKeyColumns(); i++ {
 			dir := pk.GetKeyColumnDirection(i)
 			if dir != catpb.IndexColumn_ASC {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1472,8 +1472,8 @@ func NewTableDesc(
 		}
 	}
 
-	// Create the TTL column if one does not already exist.
-	if ttl := desc.GetRowLevelTTL(); ttl != nil {
+	// Create the TTL automatic column (crdb_internal_expiration) if one does not already exist.
+	if ttl := desc.GetRowLevelTTL(); ttl != nil && ttl.HasDurationExpr() {
 		if err := checkTTLEnabledForCluster(ctx, st); err != nil {
 			return nil, err
 		}

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -1,10 +1,18 @@
+subtest todo_add_subtests
+
 statement error value of "ttl_expire_after" must be an interval
 CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (ttl_expire_after = ' xx invalid interval xx')
 
 statement error value of "ttl_expire_after" must be at least zero
 CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (ttl_expire_after = '-10 minutes')
 
-statement error "ttl_expire_after" must be set
+statement error parameter "ttl_expiration_expression" requires a string value
+CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (ttl_expiration_expression = 0)
+
+statement error value of "ttl_expiration_expression" must be a valid expression: at or near "EOF": syntax error
+CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (ttl_expiration_expression = '; DROP DATABASE defaultdb')
+
+statement error "ttl_expire_after" and/or "ttl_expiration_expression" must be set
 CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (ttl = 'on')
 
 statement error "ttl_expire_after" must be set if "ttl_automatic_column" is set
@@ -53,7 +61,7 @@ SELECT crdb_internal.repair_ttl_table_scheduled_job('tbl'::regclass::oid)
 statement ok
 SELECT crdb_internal.validate_ttl_scheduled_jobs()
 
-statement error resetting "ttl_expire_after" is not permitted\nHINT: use `RESET \(ttl\)` to remove TTL from the table
+statement error "ttl_expire_after" and/or "ttl_expiration_expression" must be set
 ALTER TABLE tbl RESET (ttl_expire_after)
 
 statement error expected DEFAULT expression of crdb_internal_expiration to be current_timestamp\(\):::TIMESTAMPTZ \+ '00:10:00':::INTERVAL
@@ -358,19 +366,19 @@ CREATE TABLE no_ttl_table ();
 statement error unsetting TTL automatic column not yet implemented
 ALTER TABLE no_ttl_table SET (ttl_automatic_column = 'off')
 
-statement error "ttl_expire_after" must be set
+statement error "ttl_expire_after" and/or "ttl_expiration_expression" must be set
 ALTER TABLE no_ttl_table SET (ttl_select_batch_size = 50)
 
-statement error "ttl_expire_after" must be set
+statement error "ttl_expire_after" and/or "ttl_expiration_expression" must be set
 ALTER TABLE no_ttl_table SET (ttl_delete_batch_size = 50)
 
-statement error "ttl_expire_after" must be set
+statement error "ttl_expire_after" and/or "ttl_expiration_expression" must be set
 ALTER TABLE no_ttl_table SET (ttl_job_cron = '@weekly')
 
-statement error "ttl_expire_after" must be set
+statement error "ttl_expire_after" and/or "ttl_expiration_expression" must be set
 ALTER TABLE no_ttl_table SET (ttl_pause = true)
 
-statement error "ttl_expire_after" must be set
+statement error "ttl_expire_after" and/or "ttl_expiration_expression" must be set
 ALTER TABLE no_ttl_table SET (ttl_label_metrics = true)
 
 statement ok
@@ -441,6 +449,255 @@ CREATE TABLE public.tbl (
                                                                                                                                                 CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
                                                                                                                                                 FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
 ) WITH (ttl = 'on', ttl_automatic_column = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly', ttl_label_metrics = true)
+
+subtest end
+
+subtest create_table_ttl_expiration_expression
+
+statement ok
+CREATE TABLE tbl_create_table_ttl_expiration_expression (
+  id INT PRIMARY KEY,
+  expire_at TIMESTAMP,
+  FAMILY (id, expire_at)
+) WITH (ttl_expiration_expression = 'expire_at')
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_create_table_ttl_expiration_expression]
+----
+CREATE TABLE public.tbl_create_table_ttl_expiration_expression (
+                                                                                        id INT8 NOT NULL,
+                                                                                        expire_at TIMESTAMP NULL,
+                                                                                        CONSTRAINT tbl_create_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
+                                                                                        FAMILY fam_0_id_expire_at (id, expire_at)
+) WITH (ttl = 'on', ttl_expiration_expression = 'expire_at', ttl_job_cron = '@hourly')
+
+statement ok
+ALTER TABLE tbl_create_table_ttl_expiration_expression RESET (ttl)
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_create_table_ttl_expiration_expression]
+----
+CREATE TABLE public.tbl_create_table_ttl_expiration_expression (
+   id INT8 NOT NULL,
+   expire_at TIMESTAMP NULL,
+   CONSTRAINT tbl_create_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
+   FAMILY fam_0_id_expire_at (id, expire_at)
+)
+
+subtest end
+
+subtest create_table_ttl_expiration_expression_escape_sql
+
+statement ok
+CREATE TABLE tbl_create_table_ttl_expiration_expression_escape_sql (
+  id INT PRIMARY KEY,
+  expire_at TIMESTAMP,
+  FAMILY (id, expire_at)
+) WITH (ttl_expiration_expression = 'IF(expire_at > ''2020-01-01 00:00:00'':::TIMESTAMP, expire_at, NULL)')
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_create_table_ttl_expiration_expression_escape_sql]
+----
+CREATE TABLE public.tbl_create_table_ttl_expiration_expression_escape_sql (
+                                                                                                                                                   id INT8 NOT NULL,
+                                                                                                                                                   expire_at TIMESTAMP NULL,
+                                                                                                                                                   CONSTRAINT tbl_create_table_ttl_expiration_expression_escape_sql_pkey PRIMARY KEY (id ASC),
+                                                                                                                                                   FAMILY fam_0_id_expire_at (id, expire_at)
+) WITH (ttl = 'on', ttl_expiration_expression = e'IF(expire_at > \'2020-01-01 00:00:00\':::TIMESTAMP, expire_at, NULL)', ttl_job_cron = '@hourly')
+
+
+subtest end
+
+subtest alter_table_ttl_expiration_expression
+
+statement ok
+CREATE TABLE tbl_alter_table_ttl_expiration_expression (
+  id INT PRIMARY KEY,
+  expire_at TIMESTAMP,
+  FAMILY (id, expire_at)
+)
+
+statement ok
+ALTER TABLE tbl_alter_table_ttl_expiration_expression SET (ttl_expiration_expression = 'expire_at')
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_alter_table_ttl_expiration_expression]
+----
+CREATE TABLE public.tbl_alter_table_ttl_expiration_expression (
+                                                                                        id INT8 NOT NULL,
+                                                                                        expire_at TIMESTAMP NULL,
+                                                                                        CONSTRAINT tbl_alter_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
+                                                                                        FAMILY fam_0_id_expire_at (id, expire_at)
+) WITH (ttl = 'on', ttl_expiration_expression = 'expire_at', ttl_job_cron = '@hourly')
+
+# try setting it again
+statement ok
+ALTER TABLE tbl_alter_table_ttl_expiration_expression SET (ttl_expiration_expression = 'expire_at + ''5 minutes'':::INTERVAL')
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_alter_table_ttl_expiration_expression]
+----
+CREATE TABLE public.tbl_alter_table_ttl_expiration_expression (
+                                                                                                                    id INT8 NOT NULL,
+                                                                                                                    expire_at TIMESTAMP NULL,
+                                                                                                                    CONSTRAINT tbl_alter_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
+                                                                                                                    FAMILY fam_0_id_expire_at (id, expire_at)
+) WITH (ttl = 'on', ttl_expiration_expression = e'expire_at + \'5 minutes\':::INTERVAL', ttl_job_cron = '@hourly')
+
+statement ok
+ALTER TABLE tbl_alter_table_ttl_expiration_expression RESET (ttl)
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_alter_table_ttl_expiration_expression]
+----
+CREATE TABLE public.tbl_alter_table_ttl_expiration_expression (
+   id INT8 NOT NULL,
+   expire_at TIMESTAMP NULL,
+   CONSTRAINT tbl_alter_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
+   FAMILY fam_0_id_expire_at (id, expire_at)
+)
+
+subtest end
+
+subtest add_ttl_expiration_expression_to_ttl_expire_after
+
+statement ok
+CREATE TABLE tbl_add_ttl_expiration_expression_to_ttl_expire_after (
+  id INT PRIMARY KEY,
+  expire_at TIMESTAMP,
+  FAMILY (id, expire_at)
+) WITH (ttl_expire_after = '10 minutes')
+
+statement ok
+ALTER TABLE tbl_add_ttl_expiration_expression_to_ttl_expire_after SET (ttl_expiration_expression = 'crdb_internal_expiration')
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_add_ttl_expiration_expression_to_ttl_expire_after]
+----
+CREATE TABLE public.tbl_add_ttl_expiration_expression_to_ttl_expire_after (
+                                                                                                                                                                              id INT8 NOT NULL,
+                                                                                                                                                                              expire_at TIMESTAMP NULL,
+                                                                                                                                                                              crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+                                                                                                                                                                              CONSTRAINT tbl_add_ttl_expiration_expression_to_ttl_expire_after_pkey PRIMARY KEY (id ASC),
+                                                                                                                                                                              FAMILY fam_0_id_expire_at_crdb_internal_expiration (id, expire_at, crdb_internal_expiration)
+) WITH (ttl = 'on', ttl_automatic_column = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_expiration_expression = 'crdb_internal_expiration', ttl_job_cron = '@hourly')
+
+statement ok
+ALTER TABLE tbl_add_ttl_expiration_expression_to_ttl_expire_after RESET (ttl_expiration_expression)
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_add_ttl_expiration_expression_to_ttl_expire_after]
+----
+CREATE TABLE public.tbl_add_ttl_expiration_expression_to_ttl_expire_after (
+                                                                                                                      id INT8 NOT NULL,
+                                                                                                                      expire_at TIMESTAMP NULL,
+                                                                                                                      crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+                                                                                                                      CONSTRAINT tbl_add_ttl_expiration_expression_to_ttl_expire_after_pkey PRIMARY KEY (id ASC),
+                                                                                                                      FAMILY fam_0_id_expire_at_crdb_internal_expiration (id, expire_at, crdb_internal_expiration)
+) WITH (ttl = 'on', ttl_automatic_column = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly')
+
+subtest end
+
+subtest add_ttl_expire_after_to_ttl_expiration_expression
+
+statement ok
+CREATE TABLE tbl_add_ttl_expire_after_to_ttl_expiration_expression (
+  id INT PRIMARY KEY,
+  expire_at TIMESTAMP,
+  FAMILY (id, expire_at)
+) WITH (ttl_expiration_expression = 'expire_at')
+
+statement ok
+ALTER TABLE tbl_add_ttl_expire_after_to_ttl_expiration_expression SET (ttl_expire_after = '10 minutes')
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_add_ttl_expire_after_to_ttl_expiration_expression]
+----
+CREATE TABLE public.tbl_add_ttl_expire_after_to_ttl_expiration_expression (
+                                                                                                                                                               id INT8 NOT NULL,
+                                                                                                                                                               expire_at TIMESTAMP NULL,
+                                                                                                                                                               crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+                                                                                                                                                               CONSTRAINT tbl_add_ttl_expire_after_to_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
+                                                                                                                                                               FAMILY fam_0_id_expire_at (id, expire_at, crdb_internal_expiration)
+) WITH (ttl = 'on', ttl_automatic_column = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_expiration_expression = 'expire_at', ttl_job_cron = '@hourly')
+
+statement ok
+ALTER TABLE tbl_add_ttl_expire_after_to_ttl_expiration_expression RESET (ttl_expire_after)
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_add_ttl_expire_after_to_ttl_expiration_expression]
+----
+CREATE TABLE public.tbl_add_ttl_expire_after_to_ttl_expiration_expression (
+   id INT8 NOT NULL,
+   expire_at TIMESTAMP NULL,
+   CONSTRAINT tbl_add_ttl_expire_after_to_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
+   FAMILY fam_0_id_expire_at (id, expire_at)
+)
+
+subtest end
+
+subtest create_table_ttl_expire_after_and_ttl_expiration_expression
+
+statement ok
+CREATE TABLE create_table_ttl_expire_after_and_ttl_expiration_expression (
+  id INT PRIMARY KEY
+) WITH (ttl_expire_after = '10 minutes', ttl_expiration_expression = 'crdb_internal_expiration')
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE create_table_ttl_expire_after_and_ttl_expiration_expression]
+----
+CREATE TABLE public.create_table_ttl_expire_after_and_ttl_expiration_expression (
+                                                                                                                                                                              id INT8 NOT NULL,
+                                                                                                                                                                              crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+                                                                                                                                                                              CONSTRAINT create_table_ttl_expire_after_and_ttl_expiration_expression_pkey PRIMARY KEY (id ASC)
+) WITH (ttl = 'on', ttl_automatic_column = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_expiration_expression = 'crdb_internal_expiration', ttl_job_cron = '@hourly')
+
+statement ok
+ALTER TABLE create_table_ttl_expire_after_and_ttl_expiration_expression RESET (ttl)
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE create_table_ttl_expire_after_and_ttl_expiration_expression]
+----
+CREATE TABLE public.create_table_ttl_expire_after_and_ttl_expiration_expression (
+   id INT8 NOT NULL,
+   CONSTRAINT create_table_ttl_expire_after_and_ttl_expiration_expression_pkey PRIMARY KEY (id ASC)
+)
+
+subtest end
+
+subtest alter_table_ttl_expire_after_and_ttl_expiration_expression
+
+statement ok
+CREATE TABLE tbl_alter_table_ttl_expire_after_and_ttl_expiration_expression (
+  id INT PRIMARY KEY
+)
+
+statement ok
+ALTER TABLE tbl_alter_table_ttl_expire_after_and_ttl_expiration_expression SET (ttl_expire_after = '10 minutes', ttl_expiration_expression = 'crdb_internal_expiration')
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_alter_table_ttl_expire_after_and_ttl_expiration_expression]
+----
+CREATE TABLE public.tbl_alter_table_ttl_expire_after_and_ttl_expiration_expression (
+                                                                                                                                                                              id INT8 NOT NULL,
+                                                                                                                                                                              crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+                                                                                                                                                                              CONSTRAINT tbl_alter_table_ttl_expire_after_and_ttl_expiration_expression_pkey PRIMARY KEY (id ASC)
+) WITH (ttl = 'on', ttl_automatic_column = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_expiration_expression = 'crdb_internal_expiration', ttl_job_cron = '@hourly')
+
+statement ok
+ALTER TABLE tbl_alter_table_ttl_expire_after_and_ttl_expiration_expression RESET (ttl)
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_alter_table_ttl_expire_after_and_ttl_expiration_expression]
+----
+CREATE TABLE public.tbl_alter_table_ttl_expire_after_and_ttl_expiration_expression (
+   id INT8 NOT NULL,
+   CONSTRAINT tbl_alter_table_ttl_expire_after_and_ttl_expiration_expression_pkey PRIMARY KEY (id ASC)
+)
+
+subtest end
+
+subtest todo_add_subtests2
 
 # Test adding to TTL table with crdb_internal_expiration already defined.
 statement ok
@@ -588,3 +845,5 @@ ALTER TABLE test.public."Table-Name" WITH (ttl = 'on', ...)
 
 statement ok
 DROP TABLE "Table-Name"
+
+subtest end

--- a/pkg/sql/storageparam/tablestorageparam/BUILD.bazel
+++ b/pkg/sql/storageparam/tablestorageparam/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/paramparse",
+        "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/pgwire/pgnotice",

--- a/pkg/sql/ttl/ttljob/ttljob.go
+++ b/pkg/sql/ttl/ttljob/ttljob.go
@@ -356,6 +356,11 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) err
 		deleteRateLimit,
 	)
 
+	ttlExpression := colinfo.TTLDefaultExpirationColumnName
+	if ttlSettings.HasExpirationExpr() {
+		ttlExpression = "(" + string(ttlSettings.ExpirationExpr) + ")"
+	}
+
 	statsCloseCh := make(chan struct{})
 	ch := make(chan rangeToProcess, rangeConcurrency)
 	rowCount := int64(0)
@@ -379,6 +384,7 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) err
 					deleteBatchSize,
 					deleteRateLimiter,
 					*aost,
+					ttlExpression,
 				)
 				// add before returning err in case of partial success
 				atomic.AddInt64(&rowCount, rangeRowCount)
@@ -398,7 +404,7 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) err
 	if ttlSettings.RowStatsPollInterval != 0 {
 		g.GoCtx(func(ctx context.Context) error {
 			// Do once initially to ensure we have some base statistics.
-			fetchStatistics(ctx, p.ExecCfg(), knobs, relationName, details, metrics, aostDuration)
+			fetchStatistics(ctx, p.ExecCfg(), knobs, relationName, details, metrics, aostDuration, ttlExpression)
 			// Wait until poll interval is reached, or early exit when we are done
 			// with the TTL job.
 			for {
@@ -406,7 +412,7 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) err
 				case <-statsCloseCh:
 					return nil
 				case <-time.After(ttlSettings.RowStatsPollInterval):
-					fetchStatistics(ctx, p.ExecCfg(), knobs, relationName, details, metrics, aostDuration)
+					fetchStatistics(ctx, p.ExecCfg(), knobs, relationName, details, metrics, aostDuration, ttlExpression)
 				}
 			}
 		})
@@ -521,12 +527,14 @@ func fetchStatistics(
 	details jobspb.RowLevelTTLDetails,
 	metrics rowLevelTTLMetrics,
 	aostDuration time.Duration,
+	ttlExpression string,
 ) {
 	if err := func() error {
 		aost, err := tree.MakeDTimestampTZ(timeutil.Now().Add(aostDuration), time.Microsecond)
 		if err != nil {
 			return err
 		}
+
 		for _, c := range []struct {
 			opName string
 			query  string
@@ -540,7 +548,7 @@ func fetchStatistics(
 			},
 			{
 				opName: fmt.Sprintf("ttl num expired rows stats %s", relationName),
-				query:  `SELECT count(1) FROM [%d AS t] AS OF SYSTEM TIME %s WHERE ` + colinfo.TTLDefaultExpirationColumnName + ` < $1`,
+				query:  `SELECT count(1) FROM [%d AS t] AS OF SYSTEM TIME %s WHERE ` + ttlExpression + ` < $1`,
 				args:   []interface{}{details.Cutoff},
 				gauge:  metrics.TotalExpiredRows,
 			},
@@ -590,6 +598,7 @@ func runTTLOnRange(
 	selectBatchSize, deleteBatchSize int,
 	deleteRateLimiter *quotapool.RateLimiter,
 	aost tree.DTimestampTZ,
+	ttlExpression string,
 ) (rangeRowCount int64, err error) {
 	metrics.NumActiveRanges.Inc(1)
 	defer metrics.NumActiveRanges.Dec(1)
@@ -609,6 +618,7 @@ func runTTLOnRange(
 		endPK,
 		aost,
 		selectBatchSize,
+		ttlExpression,
 	)
 	deleteBuilder := makeDeleteQueryBuilder(
 		details.TableID,
@@ -616,6 +626,7 @@ func runTTLOnRange(
 		pkColumns,
 		relationName,
 		deleteBatchSize,
+		ttlExpression,
 	)
 
 	for {

--- a/pkg/sql/ttl/ttljob/ttljob_query_builder_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_query_builder_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -49,6 +50,7 @@ func TestSelectQueryBuilder(t *testing.T) {
 				tree.Datums{tree.NewDInt(200), tree.NewDInt(15)},
 				*mockTimestampTZ,
 				2,
+				colinfo.TTLDefaultExpirationColumnName,
 			),
 			iterations: []iteration{
 				{
@@ -109,6 +111,7 @@ LIMIT 2`,
 				nil,
 				*mockTimestampTZ,
 				2,
+				colinfo.TTLDefaultExpirationColumnName,
 			),
 			iterations: []iteration{
 				{
@@ -165,6 +168,7 @@ LIMIT 2`,
 				tree.Datums{tree.NewDInt(181)},
 				*mockTimestampTZ,
 				2,
+				colinfo.TTLDefaultExpirationColumnName,
 			),
 			iterations: []iteration{
 				{
@@ -225,6 +229,7 @@ LIMIT 2`,
 				tree.Datums{tree.NewDInt(200), tree.NewDInt(15)},
 				*mockTimestampTZ,
 				2,
+				colinfo.TTLDefaultExpirationColumnName,
 			),
 			iterations: []iteration{
 				{
@@ -284,6 +289,7 @@ LIMIT 2`,
 				nil,
 				*mockTimestampTZ,
 				2,
+				colinfo.TTLDefaultExpirationColumnName,
 			),
 			iterations: []iteration{
 				{
@@ -366,7 +372,7 @@ func TestDeleteQueryBuilder(t *testing.T) {
 	}{
 		{
 			desc: "single delete less than batch size",
-			b:    makeDeleteQueryBuilder(1, mockTime, []string{"col1", "col2"}, "table_name", 3),
+			b:    makeDeleteQueryBuilder(1, mockTime, []string{"col1", "col2"}, "table_name", 3, colinfo.TTLDefaultExpirationColumnName),
 			iterations: []iteration{
 				{
 					rows: []tree.Datums{
@@ -384,7 +390,7 @@ func TestDeleteQueryBuilder(t *testing.T) {
 		},
 		{
 			desc: "multiple deletes",
-			b:    makeDeleteQueryBuilder(1, mockTime, []string{"col1", "col2"}, "table_name", 3),
+			b:    makeDeleteQueryBuilder(1, mockTime, []string{"col1", "col2"}, "table_name", 3, colinfo.TTLDefaultExpirationColumnName),
 			iterations: []iteration{
 				{
 					rows: []tree.Datums{


### PR DESCRIPTION
refs https://github.com/cockroachdb/cockroach/issues/76916

Release note (sql change): Allow `CREATE TABLE ... WITH (ttl_expiration_expression='...')`.
Allow `ALTER TABLE ... SET (ttl_expiration_expression='...')` and
`ALTER TABLE ... RESET (ttl_expiration_expression)`. ttl_expiration_expression accepts
an expression that returns a timestamp to support custom TTL calculation.