### PR TITLE
storage: add range key support for `MVCCIncrementalIterator`

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_refresh_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_refresh_range.go
@@ -89,7 +89,7 @@ func refreshRange(
 			break
 		}
 
-		key := iter.Key()
+		key := iter.UnsafeKey().Clone()
 		if !key.IsValue() {
 			// Found an intent. Check whether it is owned by this transaction.
 			// If so, proceed with iteration. Otherwise, return an error.

--- a/pkg/storage/mvcc_incremental_iterator.go
+++ b/pkg/storage/mvcc_incremental_iterator.go
@@ -11,6 +11,8 @@
 package storage
 
 import (
+	"sort"
+
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -89,6 +91,25 @@ type MVCCIncrementalIterator struct {
 	// regardless if they are metakeys.
 	meta enginepb.MVCCMetadata
 
+	// hasPoint and hasRange control whether the iterator should surface a point
+	// or range key from the underlying iterator. If true, this implies that the
+	// underlying iterator returns true as well. This can be used to hide point or
+	// range keys where one key kind satisfies the time predicate but the other
+	// one doesn't.
+	hasPoint, hasRange bool
+
+	// rangeKeysStart contains the last seen range key start bound. It is used
+	// to detect changes to range keys.
+	//
+	// TODO(erikgrinaker): This pattern keeps coming up, and involves one
+	// comparison for every covered point key. Consider exposing this from Pebble,
+	// who has presumably already done these comparisons, so we can avoid them.
+	rangeKeysStart roachpb.Key
+
+	// ignoringTime is true if the iterator is currently ignoring time bounds,
+	// i.e. following a call to NextIgnoringTime().
+	ignoringTime bool
+
 	// Configuration passed in MVCCIncrementalIterOptions.
 	intentPolicy MVCCIncrementalIterIntentPolicy
 
@@ -128,13 +149,22 @@ const (
 
 // MVCCIncrementalIterOptions bundles options for NewMVCCIncrementalIterator.
 type MVCCIncrementalIterOptions struct {
-	EndKey roachpb.Key
+	KeyTypes IterKeyType
+	StartKey roachpb.Key
+	EndKey   roachpb.Key
 
 	// Only keys within (StartTime,EndTime] will be emitted. EndTime defaults to
 	// hlc.MaxTimestamp. The time-bound iterator optimization will only be used if
 	// StartTime is set, since we assume EndTime will be near the current time.
 	StartTime hlc.Timestamp
 	EndTime   hlc.Timestamp
+
+	// RangeKeyMaskingBelow will mask points keys covered by MVCC range tombstones
+	// below the given timestamp. For more details, see IterOptions.
+	//
+	// NB: This masking also affects NextIgnoringTime(), which cannot see points
+	// below MVCC range tombstones either.
+	RangeKeyMaskingBelow hlc.Timestamp
 
 	IntentPolicy MVCCIncrementalIterIntentPolicy
 }
@@ -164,20 +194,36 @@ func NewMVCCIncrementalIterator(
 		// An iterator without the timestamp hints is created to ensure that the
 		// iterator visits every required version of every key that has changed.
 		iter = reader.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
-			UpperBound: opts.EndKey,
+			KeyTypes:             opts.KeyTypes,
+			LowerBound:           opts.StartKey,
+			UpperBound:           opts.EndKey,
+			RangeKeyMaskingBelow: opts.RangeKeyMaskingBelow,
 		})
 		// The timeBoundIter is only required to see versioned keys, since the
-		// intents will be found by iter.
+		// intents will be found by iter. It can also always enable range key
+		// masking at the start time, since we never care about point keys below it
+		// (the same isn't true for the main iterator, since it would break
+		// NextIgnoringTime).
+		tbiRangeKeyMasking := opts.RangeKeyMaskingBelow
+		if tbiRangeKeyMasking.LessEq(opts.StartTime) && opts.KeyTypes == IterKeyTypePointsAndRanges {
+			tbiRangeKeyMasking = opts.StartTime.Next()
+		}
 		timeBoundIter = reader.NewMVCCIterator(MVCCKeyIterKind, IterOptions{
+			KeyTypes:   opts.KeyTypes,
+			LowerBound: opts.StartKey,
 			UpperBound: opts.EndKey,
 			// The call to startTime.Next() converts our exclusive start bound into
 			// the inclusive start bound that MinTimestampHint expects.
-			MinTimestampHint: opts.StartTime.Next(),
-			MaxTimestampHint: opts.EndTime,
+			MinTimestampHint:     opts.StartTime.Next(),
+			MaxTimestampHint:     opts.EndTime,
+			RangeKeyMaskingBelow: tbiRangeKeyMasking,
 		})
 	} else {
 		iter = reader.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
-			UpperBound: opts.EndKey,
+			KeyTypes:             opts.KeyTypes,
+			LowerBound:           opts.StartKey,
+			UpperBound:           opts.EndKey,
+			RangeKeyMaskingBelow: opts.RangeKeyMaskingBelow,
 		})
 	}
 
@@ -208,11 +254,7 @@ func (i *MVCCIncrementalIterator) SeekGE(startKey MVCCKey) {
 		}
 	}
 	i.iter.SeekGE(startKey)
-	if !i.updateValid() {
-		return
-	}
-	i.err = nil
-	i.valid = true
+	i.rangeKeysStart = nil
 	i.advance()
 }
 
@@ -227,9 +269,6 @@ func (i *MVCCIncrementalIterator) Close() {
 // Next implements SimpleMVCCIterator.
 func (i *MVCCIncrementalIterator) Next() {
 	i.iter.Next()
-	if !i.updateValid() {
-		return
-	}
 	i.advance()
 }
 
@@ -237,20 +276,13 @@ func (i *MVCCIncrementalIterator) Next() {
 // returns true if valid.
 // gcassert:inline
 func (i *MVCCIncrementalIterator) updateValid() bool {
-	if ok, err := i.iter.Valid(); !ok {
-		i.err = err
-		i.valid = false
-		return false
-	}
-	return true
+	i.valid, i.err = i.iter.Valid()
+	return i.valid
 }
 
 // NextKey implements SimpleMVCCIterator.
 func (i *MVCCIncrementalIterator) NextKey() {
 	i.iter.NextKey()
-	if !i.updateValid() {
-		return
-	}
 	i.advance()
 }
 
@@ -259,6 +291,11 @@ func (i *MVCCIncrementalIterator) NextKey() {
 // to the earliest version of the next candidate key.
 // It is expected (but not required) that TBI is at a key <= main iterator key
 // when calling maybeSkipKeys().
+//
+// TODO(erikgrinaker): Make sure this works properly when TBIs handle range
+// keys. In particular, we need to make sure a SeekGE doesn't get stuck
+// prematurely on a bare range key that we've already emitted, but moves onto
+// the next TBI point key (which can be much further ahead).
 func (i *MVCCIncrementalIterator) maybeSkipKeys() {
 	if i.timeBoundIter == nil {
 		// If there is no time bound iterator, we cannot skip any keys.
@@ -387,12 +424,62 @@ func (i *MVCCIncrementalIterator) updateMeta() error {
 // intent with a timestamp within the incremental iterator's bounds when the
 // intent policy is MVCCIncrementalIterIntentPolicyError.
 func (i *MVCCIncrementalIterator) advance() {
+	i.ignoringTime = false
 	for {
+		if !i.updateValid() {
+			return
+		}
 		i.maybeSkipKeys()
 		if !i.valid {
 			return
 		}
 
+		// NB: Don't update i.hasRange directly -- we only change it when
+		// i.rangeKeysStart changes, to avoid unnecessary checks.
+		hasPoint, hasRange := i.iter.HasPointAndRange()
+		i.hasPoint = hasPoint
+
+		// Process range keys.
+		//
+		// TODO(erikgrinaker): This needs to be optimized. For example, range keys
+		// only change on unversioned keys (except after a SeekGE), which can save a
+		// bunch of comparisons here. HasPointAndRange() has also been seen to have
+		// a non-negligible cost even without any range keys.
+		var newRangeKey bool
+		if hasRange {
+			if rangeStart := i.iter.RangeBounds().Key; !rangeStart.Equal(i.rangeKeysStart) {
+				i.rangeKeysStart = append(i.rangeKeysStart[:0], rangeStart...)
+				// Find the first range key at or below EndTime. If that's also above
+				// StartTime then we have visible range keys. We use a linear search
+				// rather than a binary search because we expect EndTime to be near the
+				// current time, so the first range key will typically be sufficient.
+				hasRange = false
+				for _, rkv := range i.iter.RangeKeys() {
+					if ts := rkv.RangeKey.Timestamp; ts.LessEq(i.endTime) {
+						hasRange = i.startTime.Less(ts)
+						break
+					}
+				}
+				i.hasRange = hasRange
+				newRangeKey = hasRange
+			}
+			// else keep i.hasRange from last i.rangeKeysStart change.
+		} else {
+			i.hasRange = false
+		}
+
+		// If we're on a visible, bare range key then we're done. If the range key
+		// isn't visible either, then we keep going.
+		if !i.hasPoint {
+			if !i.hasRange {
+				i.iter.Next()
+				continue
+			}
+			i.meta.Reset()
+			return
+		}
+
+		// Process point keys.
 		if err := i.updateMeta(); err != nil {
 			return
 		}
@@ -406,14 +493,15 @@ func (i *MVCCIncrementalIterator) advance() {
 				// intent. If it is outside our time bounds, it
 				// will be filtered below.
 			case MVCCIncrementalIterIntentPolicyError, MVCCIncrementalIterIntentPolicyAggregate:
-				// We have encountered an intent but it must lie
-				// outside the timestamp span (startTime,
-				// endTime] or we have aggregated it. In either
-				// case, we want to advance past it.
-				i.iter.Next()
-				if !i.updateValid() {
+				// We have encountered an intent but it must lie outside the timestamp
+				// span (startTime, endTime] or we have aggregated it. In either case,
+				// we want to advance past it, unless we're also on a new range key that
+				// must be emitted.
+				if newRangeKey {
+					i.hasPoint = false
 					return
 				}
+				i.iter.Next()
 				continue
 			}
 		}
@@ -421,8 +509,15 @@ func (i *MVCCIncrementalIterator) advance() {
 		// Note that MVCC keys are sorted by key, then by _descending_ timestamp
 		// order with the exception of the metakey (timestamp 0) being sorted
 		// first.
+		//
+		// If we encountered a new range key on this position, then we must emit it
+		// even if the the point key should be skipped. This typically happens on a
+		// filtered intent or when seeking directly to a filtered point version.
 		metaTimestamp := i.meta.Timestamp.ToTimestamp()
-		if i.endTime.Less(metaTimestamp) {
+		if newRangeKey {
+			i.hasPoint = i.startTime.Less(metaTimestamp) && metaTimestamp.LessEq(i.endTime)
+			return
+		} else if i.endTime.Less(metaTimestamp) {
 			i.iter.Next()
 		} else if metaTimestamp.LessEq(i.startTime) {
 			i.iter.NextKey()
@@ -430,9 +525,6 @@ func (i *MVCCIncrementalIterator) advance() {
 			// The current key is a valid user key and within the time bounds. We are
 			// done.
 			break
-		}
-		if !i.updateValid() {
-			return
 		}
 	}
 }
@@ -449,21 +541,61 @@ func (i *MVCCIncrementalIterator) UnsafeKey() MVCCKey {
 
 // HasPointAndRange implements SimpleMVCCIterator.
 func (i *MVCCIncrementalIterator) HasPointAndRange() (bool, bool) {
-	panic("not implemented")
+	return i.hasPoint && i.valid, i.hasRange && i.valid
 }
 
 // RangeBounds implements SimpleMVCCIterator.
 func (i *MVCCIncrementalIterator) RangeBounds() roachpb.Span {
-	panic("not implemented")
+	if !i.hasRange || !i.valid {
+		return roachpb.Span{}
+	}
+	return i.iter.RangeBounds()
 }
 
 // RangeKeys implements SimpleMVCCIterator.
 func (i *MVCCIncrementalIterator) RangeKeys() []MVCCRangeKeyValue {
-	panic("not implemented")
+	if !i.hasRange || !i.valid {
+		return []MVCCRangeKeyValue{}
+	}
+
+	// TODO(erikgrinaker): It may be worthwhile to clone and memoize this result
+	// for the same range key. However, callers may avoid calling RangeKeys()
+	// unnecessarily, and we may optimize parent iterators, so let's measure.
+	rangeKeys := i.iter.RangeKeys()
+
+	if i.ignoringTime {
+		return rangeKeys
+	}
+
+	// Find the first range key at or below endTime, and truncate rangeKeys. We do
+	// a linear search rather than a binary search, because we expect endTime to
+	// be near the current time, so the first element will typically match.
+	first := len(rangeKeys) - 1
+	for idx, rkv := range rangeKeys {
+		if rkv.RangeKey.Timestamp.LessEq(i.endTime) {
+			first = idx
+			break
+		}
+	}
+	rangeKeys = rangeKeys[first:]
+
+	// Find the first range key at or below startTime, and truncate rangeKeys.
+	if i.startTime.IsSet() {
+		if idx := sort.Search(len(rangeKeys), func(idx int) bool {
+			return rangeKeys[idx].RangeKey.Timestamp.LessEq(i.startTime)
+		}); idx >= 0 {
+			rangeKeys = rangeKeys[:idx]
+		}
+	}
+
+	return rangeKeys
 }
 
 // UnsafeValue implements SimpleMVCCIterator.
 func (i *MVCCIncrementalIterator) UnsafeValue() []byte {
+	if !i.hasPoint {
+		return nil
+	}
 	return i.iter.UnsafeValue()
 }
 
@@ -472,9 +604,23 @@ func (i *MVCCIncrementalIterator) UnsafeValue() []byte {
 // Intents in the time range (startTime,EndTime] are handled according to the
 // iterator policy.
 func (i *MVCCIncrementalIterator) NextIgnoringTime() {
+	i.ignoringTime = true
 	for {
 		i.iter.Next()
 		if !i.updateValid() {
+			return
+		}
+
+		i.hasPoint, i.hasRange = i.iter.HasPointAndRange()
+		if i.hasRange {
+			// Make sure we update rangeKeysStart appropriately so that switching back
+			// to regular iteration won't emit bare range keys twice.
+			if rangeStart := i.iter.RangeBounds().Key; !rangeStart.Equal(i.rangeKeysStart) {
+				i.rangeKeysStart = append(i.rangeKeysStart[:0], rangeStart...)
+			}
+		}
+
+		if !i.hasPoint {
 			return
 		}
 

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -38,6 +38,9 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// See also tests in testdata/mvcc_histories/range_key_iter_incremental which
+// cover iteration with range keys.
+
 const all, latest = true, false
 
 func makeKVT(key roachpb.Key, value roachpb.Value, ts hlc.Timestamp) MVCCKeyValue {

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -284,30 +284,6 @@ func nextIgnoreTimeExpectErr(
 	}
 }
 
-func nextKeyIgnoreTimeExpectErr(
-	t *testing.T,
-	e Engine,
-	startKey, endKey roachpb.Key,
-	startTime, endTime hlc.Timestamp,
-	errString string,
-) {
-	iter := NewMVCCIncrementalIterator(e, MVCCIncrementalIterOptions{
-		EndKey:    endKey,
-		StartTime: startTime,
-		EndTime:   endTime,
-	})
-	defer iter.Close()
-	for iter.SeekGE(MakeMVCCMetadataKey(startKey)); ; iter.NextKeyIgnoringTime() {
-		if ok, _ := iter.Valid(); !ok || iter.UnsafeKey().Key.Compare(endKey) >= 0 {
-			break
-		}
-		// pass
-	}
-	if _, err := iter.Valid(); !testutils.IsError(err, errString) {
-		t.Fatalf("expected error %q but got %v", errString, err)
-	}
-}
-
 func assertNextIgnoreTimeIteratedKVs(
 	t *testing.T,
 	e Engine,
@@ -328,43 +304,8 @@ func assertNextIgnoreTimeIteratedKVs(
 		} else if !ok || iter.UnsafeKey().Key.Compare(endKey) >= 0 {
 			break
 		}
-		kvs = append(kvs, MVCCKeyValue{Key: iter.Key(), Value: iter.Value()})
-	}
-
-	if len(kvs) != len(expected) {
-		t.Fatalf("got %d kvs but expected %d: %v", len(kvs), len(expected), kvs)
-	}
-	for i := range kvs {
-		if !kvs[i].Key.Equal(expected[i].Key) {
-			t.Fatalf("%d key: got %v but expected %v", i, kvs[i].Key, expected[i].Key)
-		}
-		if !bytes.Equal(kvs[i].Value, expected[i].Value) {
-			t.Fatalf("%d value: got %x but expected %x", i, kvs[i].Value, expected[i].Value)
-		}
-	}
-}
-
-func assertNextKeyIgnoreTimeIteratedKVs(
-	t *testing.T,
-	e Engine,
-	startKey, endKey roachpb.Key,
-	startTime, endTime hlc.Timestamp,
-	expected []MVCCKeyValue,
-) {
-	iter := NewMVCCIncrementalIterator(e, MVCCIncrementalIterOptions{
-		EndKey:    endKey,
-		StartTime: startTime,
-		EndTime:   endTime,
-	})
-	defer iter.Close()
-	var kvs []MVCCKeyValue
-	for iter.SeekGE(MakeMVCCMetadataKey(startKey)); ; iter.NextKeyIgnoringTime() {
-		if ok, err := iter.Valid(); err != nil {
-			t.Fatalf("unexpected error: %+v", err)
-		} else if !ok || iter.UnsafeKey().Key.Compare(endKey) >= 0 {
-			break
-		}
-		kvs = append(kvs, MVCCKeyValue{Key: iter.Key(), Value: iter.Value()})
+		kvs = append(kvs, MVCCKeyValue{
+			Key: iter.UnsafeKey().Clone(), Value: append([]byte{}, iter.UnsafeValue()...)})
 	}
 
 	if len(kvs) != len(expected) {
@@ -411,7 +352,8 @@ func assertIteratedKVs(
 		if iter.NumCollectedIntents() > 0 {
 			t.Fatal("got unexpected intent error")
 		}
-		kvs = append(kvs, MVCCKeyValue{Key: iter.Key(), Value: iter.Value()})
+		kvs = append(kvs, MVCCKeyValue{
+			Key: iter.UnsafeKey().Clone(), Value: append([]byte{}, iter.UnsafeValue()...)})
 	}
 
 	if len(kvs) != len(expected) {
@@ -579,140 +521,6 @@ func TestMVCCIncrementalIteratorNextIgnoringTime(t *testing.T) {
 			})
 			t.Run("intents", func(t *testing.T) {
 				assertNextIgnoreTimeIteratedKVs(t, e, localMax, keyMax, ts4.Next(), tsMax, kvs())
-			})
-		})
-	}
-}
-
-// TestMVCCIncrementalIteratorNextKeyIgnoringTime tests the iteration semantics
-// of the method NextKeyIgnoreTime(). This method is supposed to return all new
-// keys that would be encountered in a non-incremental iteration.
-func TestMVCCIncrementalIteratorNextKeyIgnoringTime(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-	DisableMetamorphicSimpleValueEncoding(t)
-	ctx := context.Background()
-
-	var (
-		keyMax   = roachpb.KeyMax
-		testKey1 = roachpb.Key("/db1")
-		testKey2 = roachpb.Key("/db2")
-
-		testValue1 = roachpb.MakeValueFromString("val1")
-		testValue2 = roachpb.MakeValueFromString("val2")
-		testValue3 = roachpb.MakeValueFromString("val3")
-		testValue4 = roachpb.MakeValueFromString("val4")
-
-		// Use a non-zero min, since we use IsEmpty to decide if a ts should be used
-		// as upper/lower-bound during iterator initialization.
-		tsMin = hlc.Timestamp{WallTime: 0, Logical: 1}
-		ts1   = hlc.Timestamp{WallTime: 1, Logical: 0}
-		ts2   = hlc.Timestamp{WallTime: 2, Logical: 0}
-		ts3   = hlc.Timestamp{WallTime: 3, Logical: 0}
-		ts4   = hlc.Timestamp{WallTime: 4, Logical: 0}
-		tsMax = hlc.Timestamp{WallTime: math.MaxInt64, Logical: 0}
-	)
-
-	kv1_1_1 := makeKVT(testKey1, testValue1, ts1)
-	kv1_2_2 := makeKVT(testKey1, testValue2, ts2)
-	kv2_2_2 := makeKVT(testKey2, testValue3, ts2)
-	kv1_3Deleted := makeKVT(testKey1, roachpb.Value{}, ts3)
-
-	for _, engineImpl := range mvccEngineImpls {
-		t.Run(engineImpl.name, func(t *testing.T) {
-			e := engineImpl.create()
-			defer e.Close()
-
-			t.Run("empty", func(t *testing.T) {
-				assertNextKeyIgnoreTimeIteratedKVs(t, e, localMax, keyMax, tsMin, ts3, nil)
-			})
-
-			for _, kv := range kvs(kv1_1_1, kv1_2_2, kv2_2_2) {
-				v := roachpb.Value{RawBytes: kv.Value}
-				if err := MVCCPut(ctx, e, nil, kv.Key.Key, kv.Key.Timestamp, hlc.ClockTimestamp{}, v, nil); err != nil {
-					t.Fatal(err)
-				}
-			}
-
-			// Exercise time ranges.
-			t.Run("ts (0-0]", func(t *testing.T) {
-				assertNextKeyIgnoreTimeIteratedKVs(t, e, localMax, keyMax, tsMin, tsMin, nil)
-			})
-			// Returns the kv_2_2_2 even though it is outside (startTime, endTime].
-			t.Run("ts (0-1]", func(t *testing.T) {
-				assertNextKeyIgnoreTimeIteratedKVs(t, e, localMax, keyMax, tsMin, ts1, kvs(kv1_1_1, kv2_2_2))
-			})
-			t.Run("ts (0-∞]", func(t *testing.T) {
-				assertNextKeyIgnoreTimeIteratedKVs(t, e, localMax, keyMax, tsMin, tsMax, kvs(kv1_2_2, kv2_2_2))
-			})
-			t.Run("ts (1-1]", func(t *testing.T) {
-				assertNextKeyIgnoreTimeIteratedKVs(t, e, localMax, keyMax, ts1, ts1, nil)
-			})
-			t.Run("ts (1-2]", func(t *testing.T) {
-				assertNextKeyIgnoreTimeIteratedKVs(t, e, localMax, keyMax, ts1, ts2, kvs(kv1_2_2, kv2_2_2))
-			})
-			t.Run("ts (2-2]", func(t *testing.T) {
-				assertNextKeyIgnoreTimeIteratedKVs(t, e, localMax, keyMax, ts2, ts2, nil)
-			})
-
-			// Exercise key ranges.
-			t.Run("kv [1-1)", func(t *testing.T) {
-				assertNextKeyIgnoreTimeIteratedKVs(t, e, testKey1, testKey1, tsMin, tsMax, nil)
-			})
-			t.Run("kv [1-2)", func(t *testing.T) {
-				assertNextKeyIgnoreTimeIteratedKVs(t, e, testKey1, testKey2, tsMin, tsMax, kvs(kv1_2_2))
-			})
-
-			// Exercise deletion.
-			if err := MVCCDelete(ctx, e, nil, testKey1, ts3, hlc.ClockTimestamp{}, nil); err != nil {
-				t.Fatal(err)
-			}
-			// Returns the kv_1_1_1 even though it is outside (startTime, endTime].
-			t.Run("del", func(t *testing.T) {
-				assertNextKeyIgnoreTimeIteratedKVs(t, e, localMax, keyMax, ts1, tsMax, kvs(kv1_3Deleted,
-					kv2_2_2))
-			})
-
-			// Insert an intent of testKey2.
-			txn1ID := uuid.MakeV4()
-			txn1 := roachpb.Transaction{
-				TxnMeta: enginepb.TxnMeta{
-					Key:            testKey2,
-					ID:             txn1ID,
-					Epoch:          1,
-					WriteTimestamp: ts4,
-				},
-				ReadTimestamp: ts4,
-			}
-			if err := MVCCPut(ctx, e, nil, txn1.TxnMeta.Key, txn1.ReadTimestamp, hlc.ClockTimestamp{}, testValue4, &txn1); err != nil {
-				t.Fatal(err)
-			}
-
-			// We have to be careful that we are testing the intent handling logic of
-			// NextIgnoreTime() rather than the first SeekGE(). We do this by
-			// ensuring that the SeekGE() doesn't encounter an intent.
-			t.Run("intents", func(t *testing.T) {
-				nextKeyIgnoreTimeExpectErr(t, e, testKey1, testKey2.PrefixEnd(), tsMin, tsMax, "conflicting intents")
-			})
-			t.Run("intents", func(t *testing.T) {
-				nextKeyIgnoreTimeExpectErr(t, e, localMax, keyMax, tsMin, ts4, "conflicting intents")
-			})
-			// Intents above the upper time bound or beneath the lower time bound must
-			// be ignored. Note that the lower time bound is exclusive while the upper
-			// time bound is inclusive.
-			//
-			// The intent at ts=4 for kv2 lies outside the timespan
-			// (startTime, endTime] so we do not raise an error and just move on to
-			// its versioned KV.
-			t.Run("intents", func(t *testing.T) {
-				assertNextKeyIgnoreTimeIteratedKVs(t, e, localMax, keyMax, tsMin, ts3, kvs(kv1_3Deleted,
-					kv2_2_2))
-			})
-			t.Run("intents", func(t *testing.T) {
-				assertNextKeyIgnoreTimeIteratedKVs(t, e, localMax, keyMax, ts4, tsMax, kvs())
-			})
-			t.Run("intents", func(t *testing.T) {
-				assertNextKeyIgnoreTimeIteratedKVs(t, e, localMax, keyMax, ts4.Next(), tsMax, kvs())
 			})
 		})
 	}
@@ -1138,7 +946,8 @@ func slurpKVsInTimeRange(
 		} else if !ok || iter.UnsafeKey().Key.Compare(endKey) >= 0 {
 			break
 		}
-		kvs = append(kvs, MVCCKeyValue{Key: iter.Key(), Value: iter.Value()})
+		kvs = append(kvs, MVCCKeyValue{
+			Key: iter.UnsafeKey().Clone(), Value: append([]byte{}, iter.UnsafeValue()...)})
 	}
 	return kvs, nil
 }

--- a/pkg/storage/testdata/mvcc_histories/range_key_iter_incremental
+++ b/pkg/storage/testdata/mvcc_histories/range_key_iter_incremental
@@ -1,0 +1,1517 @@
+# Tests range key handling in MVCCIncrementalIterator. It does not support
+# reverse iteration, as it does not implement MVCCIterator.
+#
+# Sets up the following dataset, where x is tombstone, o-o is range tombstone, [] is intent.
+#
+#  8             [d8]                                [m8]
+#  7 [a7]                                [j7]    [l7]       [o7]
+#  6                      f6
+#  5          o---------------o               k5
+#  4  x   x       d4      f4  g4  x
+#  3      o-------o   e3  o-------oh3                 o---o
+#  2  a2                  f2  g2
+#  1  o---------------------------------------o
+#     a   b   c   d   e   f   g   h   i   j   k   l   m   n   o
+#
+run ok
+put_rangekey k=a end=k ts=1
+put k=a ts=2 v=a2
+del k=a ts=4
+put_rangekey k=b end=d ts=3
+del k=b ts=4
+put k=d ts=4 v=d4
+put k=e ts=3 v=e3
+put k=f ts=2 v=f2
+put k=g ts=2 v=g2
+put_rangekey k=f end=h ts=3
+put k=f ts=4 v=f4
+put_rangekey k=c end=g ts=5
+put k=f ts=6 v=f6
+put k=g ts=4 v=g4
+put k=h ts=3 v=h3
+del k=h ts=4
+put k=k ts=5 v=k5
+put_rangekey k=m end=n ts=3 localTs=2
+with t=A
+  txn_begin ts=7
+  put k=a v=a7
+  put k=j v=j7
+  put k=l v=l7
+  put k=o v=o7
+with t=B
+  txn_begin ts=8
+  put k=d v=d8
+  put k=m v=m8
+----
+>> at end:
+txn: "B" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=8.000000000,0 wto=false gul=0,0
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/7.000000000,0 -> /BYTES/a7
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+meta: "d"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "d"/8.000000000,0 -> /BYTES/d8
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /BYTES/g4
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/4.000000000,0 -> /<empty>
+data: "h"/3.000000000,0 -> /BYTES/h3
+meta: "j"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "j"/7.000000000,0 -> /BYTES/j7
+data: "k"/5.000000000,0 -> /BYTES/k5
+meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "l"/7.000000000,0 -> /BYTES/l7
+meta: "m"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "m"/8.000000000,0 -> /BYTES/m8
+meta: "o"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "o"/7.000000000,0 -> /BYTES/o7
+
+# Iterate across the entire span for all key types.
+run ok
+iter_new_incremental types=pointsOnly intents=emit
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "a"/7.000000000,0=/BYTES/a7
+iter_scan: "a"/4.000000000,0=/<empty>
+iter_scan: "a"/2.000000000,0=/BYTES/a2
+iter_scan: "b"/4.000000000,0=/<empty>
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "d"/8.000000000,0=/BYTES/d8
+iter_scan: "d"/4.000000000,0=/BYTES/d4
+iter_scan: "e"/3.000000000,0=/BYTES/e3
+iter_scan: "f"/6.000000000,0=/BYTES/f6
+iter_scan: "f"/4.000000000,0=/BYTES/f4
+iter_scan: "f"/2.000000000,0=/BYTES/f2
+iter_scan: "g"/4.000000000,0=/BYTES/g4
+iter_scan: "g"/2.000000000,0=/BYTES/g2
+iter_scan: "h"/4.000000000,0=/<empty>
+iter_scan: "h"/3.000000000,0=/BYTES/h3
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "j"/7.000000000,0=/BYTES/j7
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "m"/8.000000000,0=/BYTES/m8
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/7.000000000,0=/BYTES/o7
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/7.000000000,0=/BYTES/o7
+iter_scan: .
+
+run ok
+iter_new_incremental types=rangesOnly intents=emit
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: .
+
+# Iterate across the span while moving StartTime upwards.
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit startTs=1
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "a"/7.000000000,0=/BYTES/a7
+iter_scan: "a"/4.000000000,0=/<empty>
+iter_scan: "a"/2.000000000,0=/BYTES/a2
+iter_scan: {b-c}/[3.000000000,0=/<empty>]
+iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty>]
+iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty>]
+iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty>]
+iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty>]
+iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty>]
+iter_scan: "h"/4.000000000,0=/<empty>
+iter_scan: "h"/3.000000000,0=/BYTES/h3
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "j"/7.000000000,0=/BYTES/j7
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/7.000000000,0=/BYTES/o7
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit startTs=2
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "a"/7.000000000,0=/BYTES/a7
+iter_scan: "a"/4.000000000,0=/<empty>
+iter_scan: {b-c}/[3.000000000,0=/<empty>]
+iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty>]
+iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty>]
+iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty>]
+iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty>]
+iter_scan: "h"/4.000000000,0=/<empty>
+iter_scan: "h"/3.000000000,0=/BYTES/h3
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "j"/7.000000000,0=/BYTES/j7
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/7.000000000,0=/BYTES/o7
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit startTs=3
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "a"/7.000000000,0=/BYTES/a7
+iter_scan: "a"/4.000000000,0=/<empty>
+iter_scan: "b"/4.000000000,0=/<empty>
+iter_scan: {c-d}/[5.000000000,0=/<empty>]
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty>]
+iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty>]
+iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty>]
+iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty>]
+iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty>]
+iter_scan: "g"/4.000000000,0=/BYTES/g4
+iter_scan: "h"/4.000000000,0=/<empty>
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "j"/7.000000000,0=/BYTES/j7
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "m"/8.000000000,0=/BYTES/m8
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/7.000000000,0=/BYTES/o7
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit startTs=4
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "a"/7.000000000,0=/BYTES/a7
+iter_scan: {c-d}/[5.000000000,0=/<empty>]
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty>]
+iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty>]
+iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty>]
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "j"/7.000000000,0=/BYTES/j7
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "m"/8.000000000,0=/BYTES/m8
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/7.000000000,0=/BYTES/o7
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit startTs=5
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "a"/7.000000000,0=/BYTES/a7
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "d"/8.000000000,0=/BYTES/d8
+iter_scan: "f"/6.000000000,0=/BYTES/f6
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "j"/7.000000000,0=/BYTES/j7
+iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "m"/8.000000000,0=/BYTES/m8
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/7.000000000,0=/BYTES/o7
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit startTs=6
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "a"/7.000000000,0=/BYTES/a7
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "d"/8.000000000,0=/BYTES/d8
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "j"/7.000000000,0=/BYTES/j7
+iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "m"/8.000000000,0=/BYTES/m8
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/7.000000000,0=/BYTES/o7
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit startTs=7
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "d"/8.000000000,0=/BYTES/d8
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "m"/8.000000000,0=/BYTES/m8
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit startTs=8
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: .
+iter_scan: .
+
+# Iterate across the span while moving EndTime downwards.
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit endTs=8
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/7.000000000,0=/BYTES/o7
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit endTs=7
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/7.000000000,0=/BYTES/o7
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit endTs=6
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit endTs=5
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit endTs=4
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {d-f}/[1.000000000,0=/<empty>]
+iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[1.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[1.000000000,0=/<empty>]
+iter_scan: {f-g}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit endTs=3
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {d-f}/[1.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[1.000000000,0=/<empty>]
+iter_scan: {f-g}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit endTs=2
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[1.000000000,0=/<empty>]
+iter_scan: {c-d}/[1.000000000,0=/<empty>]
+iter_scan: {d-f}/[1.000000000,0=/<empty>]
+iter_scan: {f-g}/[1.000000000,0=/<empty>]
+iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[1.000000000,0=/<empty>]
+iter_scan: {g-h}/[1.000000000,0=/<empty>]
+iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit endTs=1
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[1.000000000,0=/<empty>]
+iter_scan: {c-d}/[1.000000000,0=/<empty>]
+iter_scan: {d-f}/[1.000000000,0=/<empty>]
+iter_scan: {f-g}/[1.000000000,0=/<empty>]
+iter_scan: {g-h}/[1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: .
+
+# Run a scan of a single timestamp going upwards.
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit startTs=0 endTs=1
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[1.000000000,0=/<empty>]
+iter_scan: {c-d}/[1.000000000,0=/<empty>]
+iter_scan: {d-f}/[1.000000000,0=/<empty>]
+iter_scan: {f-g}/[1.000000000,0=/<empty>]
+iter_scan: {g-h}/[1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit startTs=1 endTs=2
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/2.000000000,0=/BYTES/a2
+iter_scan: "a"/2.000000000,0=/BYTES/a2
+iter_scan: "f"/2.000000000,0=/BYTES/f2
+iter_scan: "g"/2.000000000,0=/BYTES/g2
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit startTs=2 endTs=3
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {b-c}/[3.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty>]
+iter_scan: {c-d}/[3.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3
+iter_scan: {f-g}/[3.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty>]
+iter_scan: "h"/3.000000000,0=/BYTES/h3
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit startTs=3 endTs=4
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/4.000000000,0=/<empty>
+iter_scan: "a"/4.000000000,0=/<empty>
+iter_scan: "b"/4.000000000,0=/<empty>
+iter_scan: "d"/4.000000000,0=/BYTES/d4
+iter_scan: "f"/4.000000000,0=/BYTES/f4
+iter_scan: "g"/4.000000000,0=/BYTES/g4
+iter_scan: "h"/4.000000000,0=/<empty>
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit startTs=4 endTs=5
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {c-d}/[5.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty>]
+iter_scan: {d-f}/[5.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty>]
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit startTs=5 endTs=6
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "f"/6.000000000,0=/BYTES/f6
+iter_scan: "f"/6.000000000,0=/BYTES/f6
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit startTs=6 endTs=7
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "a"/7.000000000,0=/BYTES/a7
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "j"/7.000000000,0=/BYTES/j7
+iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/7.000000000,0=/BYTES/o7
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit startTs=7 endTs=8
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "d"/8.000000000,0=/BYTES/d8
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "m"/8.000000000,0=/BYTES/m8
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit startTs=8 endTs=9
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: .
+iter_scan: .
+
+# Bounded scan.
+run ok
+iter_new_incremental types=pointsAndRanges k=ccc end=fff intents=emit startTs=1 endTs=5
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {ccc-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: {ccc-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: {d-f}/[5.000000000,0=/<empty>]
+iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty>]
+iter_scan: f{-ff}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: "f"/4.000000000,0=/BYTES/f4 f{-ff}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: "f"/2.000000000,0=/BYTES/f2 f{-ff}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: .
+
+# NextKey across span, unbounded and bounded.
+run ok
+iter_new_incremental types=pointsAndRanges intents=emit
+iter_seek_ge k=a
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+----
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_next_key: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key: {h-k}/[1.000000000,0=/<empty>]
+iter_next_key: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+iter_next_key: "k"/5.000000000,0=/BYTES/k5
+iter_next_key: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next_key: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_next_key: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next_key: .
+
+run ok
+iter_new_incremental types=pointsAndRanges k=ccc end=fff intents=emit startTs=1 endTs=5
+iter_seek_ge k=a
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+----
+iter_seek_ge: {ccc-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_next_key: {d-f}/[5.000000000,0=/<empty>]
+iter_next_key: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty>]
+iter_next_key: f{-ff}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_next_key: .
+
+# Seek to every point location.
+run ok
+iter_new_incremental types=pointsAndRanges k=a end=z startTs=1 endTs=4 intents=emit
+iter_seek_ge k=a
+iter_seek_ge k=b
+iter_seek_ge k=c
+iter_seek_ge k=d
+iter_seek_ge k=e
+iter_seek_ge k=f
+iter_seek_ge k=g
+iter_seek_ge k=h
+iter_seek_ge k=i
+iter_seek_ge k=j
+iter_seek_ge k=k
+iter_seek_ge k=l
+iter_seek_ge k=m
+iter_seek_ge k=n
+----
+iter_seek_ge: "a"/4.000000000,0=/<empty>
+iter_seek_ge: {b-c}/[3.000000000,0=/<empty>]
+iter_seek_ge: {c-d}/[3.000000000,0=/<empty>]
+iter_seek_ge: "d"/4.000000000,0=/BYTES/d4
+iter_seek_ge: "e"/3.000000000,0=/BYTES/e3
+iter_seek_ge: {f-g}/[3.000000000,0=/<empty>]
+iter_seek_ge: {g-h}/[3.000000000,0=/<empty>]
+iter_seek_ge: "h"/4.000000000,0=/<empty>
+iter_seek_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_seek_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_seek_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_seek_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_seek_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_seek_ge: .
+
+# Seek to every point location above and below the filtered time span.
+run ok
+iter_new_incremental types=pointsAndRanges k=a end=z startTs=1 endTs=4 intents=emit
+iter_seek_ge k=a ts=5
+iter_seek_ge k=b ts=5
+iter_seek_ge k=c ts=5
+iter_seek_ge k=d ts=5
+iter_seek_ge k=e ts=5
+iter_seek_ge k=f ts=5
+iter_seek_ge k=g ts=5
+iter_seek_ge k=h ts=5
+iter_seek_ge k=i ts=5
+iter_seek_ge k=j ts=5
+iter_seek_ge k=k ts=5
+iter_seek_ge k=l ts=5
+iter_seek_ge k=m ts=5
+iter_seek_ge k=n ts=5
+----
+iter_seek_ge: "a"/4.000000000,0=/<empty>
+iter_seek_ge: {b-c}/[3.000000000,0=/<empty>]
+iter_seek_ge: {c-d}/[3.000000000,0=/<empty>]
+iter_seek_ge: "d"/4.000000000,0=/BYTES/d4
+iter_seek_ge: "e"/3.000000000,0=/BYTES/e3
+iter_seek_ge: {f-g}/[3.000000000,0=/<empty>]
+iter_seek_ge: {g-h}/[3.000000000,0=/<empty>]
+iter_seek_ge: "h"/4.000000000,0=/<empty>
+iter_seek_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_seek_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_seek_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_seek_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_seek_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_seek_ge: .
+
+run ok
+iter_new_incremental types=pointsAndRanges k=a end=z startTs=3 endTs=6 intents=emit
+iter_seek_ge k=a ts=3
+iter_seek_ge k=b ts=3
+iter_seek_ge k=c ts=3
+iter_seek_ge k=d ts=3
+iter_seek_ge k=e ts=3
+iter_seek_ge k=f ts=3
+iter_seek_ge k=g ts=3
+iter_seek_ge k=h ts=3
+iter_seek_ge k=i ts=3
+iter_seek_ge k=j ts=3
+iter_seek_ge k=k ts=3
+iter_seek_ge k=l ts=3
+iter_seek_ge k=m ts=3
+iter_seek_ge k=n ts=3
+----
+iter_seek_ge: "b"/4.000000000,0=/<empty>
+iter_seek_ge: {c-d}/[5.000000000,0=/<empty>]
+iter_seek_ge: {c-d}/[5.000000000,0=/<empty>]
+iter_seek_ge: {d-f}/[5.000000000,0=/<empty>]
+iter_seek_ge: {d-f}/[5.000000000,0=/<empty>]
+iter_seek_ge: {f-g}/[5.000000000,0=/<empty>]
+iter_seek_ge: "h"/4.000000000,0=/<empty>
+iter_seek_ge: "k"/5.000000000,0=/BYTES/k5
+iter_seek_ge: "k"/5.000000000,0=/BYTES/k5
+iter_seek_ge: "k"/5.000000000,0=/BYTES/k5
+iter_seek_ge: .
+iter_seek_ge: .
+iter_seek_ge: .
+iter_seek_ge: .
+
+# Seek directly to a hidden point, and then iterate forward. In particular, this
+# tests that the bare range key is emitted first.
+run ok
+iter_new_incremental types=pointsAndRanges k=a end=z startTs=2 endTs=4 intents=emit
+iter_seek_ge k=f ts=6
+iter_next
+----
+iter_seek_ge: {f-g}/[3.000000000,0=/<empty>]
+iter_next: "f"/4.000000000,0=/BYTES/f4 {f-g}/[3.000000000,0=/<empty>]
+
+# Seeking twice to within the same range key must emit the bare range key both
+# times.
+run ok
+iter_new_incremental types=pointsAndRanges k=a end=z startTs=1 endTs=4 intents=emit
+iter_seek_ge k=d
+iter_seek_ge k=d ts=2
+iter_seek_ge k=e
+----
+iter_seek_ge: "d"/4.000000000,0=/BYTES/d4
+iter_seek_ge: "e"/3.000000000,0=/BYTES/e3
+iter_seek_ge: "e"/3.000000000,0=/BYTES/e3
+
+# Test intent error handling.
+run error
+iter_new_incremental types=pointsAndRanges k=a end=z intents=error
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: err=conflicting intents on "a"
+iter_scan: err=conflicting intents on "a"
+error: (*roachpb.WriteIntentError:) conflicting intents on "a"
+
+run error
+iter_new_incremental types=pointsAndRanges k=a end=z intents=aggregate
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "o"/7.000000000,0=/BYTES/o7
+iter_scan: .
+error: (*roachpb.WriteIntentError:) conflicting intents on "a", "d", "j", "l", "m", "o"
+
+run error
+iter_new_incremental types=pointsAndRanges k=a end=z endTs=7 intents=aggregate
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "o"/7.000000000,0=/BYTES/o7
+iter_scan: .
+error: (*roachpb.WriteIntentError:) conflicting intents on "a", "j", "l", "o"
+
+run ok
+iter_new_incremental types=pointsAndRanges k=a end=z endTs=6 intents=aggregate
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges k=e end=j intents=aggregate
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {e-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {e-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3 {e-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {h-j}/[1.000000000,0=/<empty>]
+iter_scan: "h"/4.000000000,0=/<empty> {h-j}/[1.000000000,0=/<empty>]
+iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-j}/[1.000000000,0=/<empty>]
+iter_scan: .
+
+# Test that intents outside of time bounds won't error, and will be skipped
+# instead. Within time bounds will error.
+run ok
+iter_new_incremental types=pointsAndRanges k=a end=z startTs=2 endTs=4 intents=error
+iter_seek_ge k=c
+iter_next_ignoring_time
+----
+iter_seek_ge: {c-d}/[3.000000000,0=/<empty>]
+iter_next_ignoring_time: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+
+run error
+iter_new_incremental types=pointsAndRanges k=a end=z startTs=2 endTs=10 intents=error
+iter_seek_ge k=c
+iter_next_ignoring_time
+----
+iter_seek_ge: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_next_ignoring_time: err=conflicting intents on "d"
+error: (*roachpb.WriteIntentError:) conflicting intents on "d"
+
+# rangesOnly doesn't care about intents.
+run ok
+iter_new_incremental types=rangesOnly k=a end=z intents=error
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: .
+
+# Test NextIgnoringTime().
+run ok
+iter_new_incremental types=pointsAndRanges k=a end=z startTs=2 endTs=4 intents=emit
+iter_seek_ge k=a
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+----
+iter_seek_ge: "a"/4.000000000,0=/<empty>
+iter_next_ignoring_time: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
+iter_next_ignoring_time: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: {h-k}/[1.000000000,0=/<empty>]
+iter_next_ignoring_time: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
+iter_next_ignoring_time: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_next_ignoring_time: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+iter_next_ignoring_time: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
+iter_next_ignoring_time: "k"/5.000000000,0=/BYTES/k5
+iter_next_ignoring_time: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next_ignoring_time: "l"/7.000000000,0=/BYTES/l7
+iter_next_ignoring_time: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_next_ignoring_time: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_next_ignoring_time: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next_ignoring_time: "o"/7.000000000,0=/BYTES/o7
+
+# Switch from ignoring to respecting time at point key.
+run ok
+iter_new_incremental types=pointsAndRanges k=a end=z startTs=2 endTs=4 intents=emit
+iter_seek_ge k=a
+iter_next_ignoring_time
+iter_next
+----
+iter_seek_ge: "a"/4.000000000,0=/<empty>
+iter_next_ignoring_time: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
+iter_next: {b-c}/[3.000000000,0=/<empty>]
+
+# Switch from ignoring to respecting time at range key.
+run ok
+iter_new_incremental types=pointsAndRanges k=a end=z startTs=2 endTs=4 intents=emit
+iter_seek_ge k=a
+iter_next
+iter_next
+iter_next_ignoring_time
+iter_next
+----
+iter_seek_ge: "a"/4.000000000,0=/<empty>
+iter_next: {b-c}/[3.000000000,0=/<empty>]
+iter_next: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty>]
+iter_next_ignoring_time: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: "d"/4.000000000,0=/BYTES/d4
+
+# NextIgnoringTime with only range keys.
+run ok
+iter_new_incremental types=rangesOnly k=a end=z startTs=4 endTs=5 intents=emit
+iter_seek_ge k=f
+iter_next_ignoring_time
+----
+iter_seek_ge: {f-g}/[5.000000000,0=/<empty>]
+iter_next_ignoring_time: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+
+# Try some scans, bounded and unbounded, with only point keys.
+run ok
+iter_new_incremental types=pointsOnly k=a end=z endTs=8 intents=emit
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "a"/7.000000000,0=/BYTES/a7
+iter_scan: "a"/4.000000000,0=/<empty>
+iter_scan: "a"/2.000000000,0=/BYTES/a2
+iter_scan: "b"/4.000000000,0=/<empty>
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "d"/8.000000000,0=/BYTES/d8
+iter_scan: "d"/4.000000000,0=/BYTES/d4
+iter_scan: "e"/3.000000000,0=/BYTES/e3
+iter_scan: "f"/6.000000000,0=/BYTES/f6
+iter_scan: "f"/4.000000000,0=/BYTES/f4
+iter_scan: "f"/2.000000000,0=/BYTES/f2
+iter_scan: "g"/4.000000000,0=/BYTES/g4
+iter_scan: "g"/2.000000000,0=/BYTES/g2
+iter_scan: "h"/4.000000000,0=/<empty>
+iter_scan: "h"/3.000000000,0=/BYTES/h3
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "j"/7.000000000,0=/BYTES/j7
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "m"/8.000000000,0=/BYTES/m8
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/7.000000000,0=/BYTES/o7
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsOnly k=bbb end=fff startTs=2 endTs=5 intents=emit
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "d"/4.000000000,0=/BYTES/d4
+iter_scan: "d"/4.000000000,0=/BYTES/d4
+iter_scan: "e"/3.000000000,0=/BYTES/e3
+iter_scan: "f"/4.000000000,0=/BYTES/f4
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsOnly k=a end=z endTs=8 intents=emit
+iter_seek_ge k=a
+iter_seek_ge k=b
+iter_seek_ge k=c
+iter_seek_ge k=d
+iter_seek_ge k=e
+iter_seek_ge k=f
+iter_seek_ge k=g
+iter_seek_ge k=h
+iter_seek_ge k=i
+iter_seek_ge k=j
+iter_seek_ge k=k
+----
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_ge: "b"/4.000000000,0=/<empty>
+iter_seek_ge: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_ge: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_ge: "e"/3.000000000,0=/BYTES/e3
+iter_seek_ge: "f"/6.000000000,0=/BYTES/f6
+iter_seek_ge: "g"/4.000000000,0=/BYTES/g4
+iter_seek_ge: "h"/4.000000000,0=/<empty>
+iter_seek_ge: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_ge: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_ge: "k"/5.000000000,0=/BYTES/k5
+
+run ok
+iter_new_incremental types=pointsOnly k=a end=z endTs=8 intents=emit
+iter_seek_ge k=f ts=7
+iter_seek_ge k=f ts=6
+iter_seek_ge k=f ts=5
+iter_seek_ge k=f ts=4
+iter_seek_ge k=f ts=3
+iter_seek_ge k=f ts=2
+iter_seek_ge k=f ts=1
+----
+iter_seek_ge: "f"/6.000000000,0=/BYTES/f6
+iter_seek_ge: "f"/6.000000000,0=/BYTES/f6
+iter_seek_ge: "f"/4.000000000,0=/BYTES/f4
+iter_seek_ge: "f"/4.000000000,0=/BYTES/f4
+iter_seek_ge: "f"/2.000000000,0=/BYTES/f2
+iter_seek_ge: "f"/2.000000000,0=/BYTES/f2
+iter_seek_ge: "g"/4.000000000,0=/BYTES/g4
+
+# Try some scans, bounded and unbounded, with only range keys.
+run ok
+iter_new_incremental types=rangesOnly k=a end=z endTs=8 intents=emit
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: .
+
+run ok
+iter_new_incremental types=rangesOnly k=bbb end=fff startTs=2 endTs=5 intents=emit
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {bbb-c}/[3.000000000,0=/<empty>]
+iter_scan: {bbb-c}/[3.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: {d-f}/[5.000000000,0=/<empty>]
+iter_scan: f{-ff}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: .
+
+run ok
+iter_new_incremental types=rangesOnly k=a end=z endTs=8 intents=emit
+iter_seek_ge k=a
+iter_seek_ge k=b
+iter_seek_ge k=c
+iter_seek_ge k=d
+iter_seek_ge k=e
+iter_seek_ge k=f
+iter_seek_ge k=g
+iter_seek_ge k=h
+iter_seek_ge k=i
+iter_seek_ge k=j
+iter_seek_ge k=k
+----
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
+iter_seek_ge: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: {h-k}/[1.000000000,0=/<empty>]
+iter_seek_ge: {h-k}/[1.000000000,0=/<empty>]
+iter_seek_ge: {h-k}/[1.000000000,0=/<empty>]
+iter_seek_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+
+run ok
+iter_new_incremental types=rangesOnly k=a end=z endTs=8 intents=emit
+iter_seek_ge k=f ts=7
+iter_seek_ge k=f ts=6
+iter_seek_ge k=f ts=5
+iter_seek_ge k=f ts=4
+iter_seek_ge k=f ts=3
+iter_seek_ge k=f ts=2
+iter_seek_ge k=f ts=1
+----
+iter_seek_ge: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+
+# Range key masking at increasing timestamps.
+run ok
+iter_new_incremental types=pointsAndRanges k=a end=z intents=emit maskBelow=1
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/7.000000000,0=/BYTES/o7
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges k=a end=z intents=emit maskBelow=2
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/7.000000000,0=/BYTES/o7
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges k=a end=z intents=emit maskBelow=3
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/7.000000000,0=/BYTES/o7
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges k=a end=z intents=emit maskBelow=4
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/7.000000000,0=/BYTES/o7
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges k=a end=z intents=emit maskBelow=5
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/7.000000000,0=/BYTES/o7
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsAndRanges k=a end=z intents=emit maskBelow=6
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/7.000000000,0=/BYTES/o7
+iter_scan: .
+
+# Range key masking also affects NextIgnoringTime.
+run ok
+iter_new_incremental types=pointsAndRanges k=a end=z intents=emit startTs=3 maskBelow=5
+iter_seek_ge k=f
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+iter_next_ignoring_time
+----
+iter_seek_ge: {f-g}/[5.000000000,0=/<empty>]
+iter_next_ignoring_time: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: {h-k}/[1.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_key_iter_intent_without_provisional_norace
+++ b/pkg/storage/testdata/mvcc_histories/range_key_iter_intent_without_provisional_norace
@@ -48,42 +48,46 @@ error: (*withstack.withStack:) intentIter should not be after iter
 
 # Seeking to intent at c will error, due to best-effort checks for provisional
 # value.
-run ok
+run error
 iter_new types=pointsAndRanges
 iter_seek_ge k=c
 ----
 iter_seek_ge: err=iter not on provisional value for intent "c"
+error: (*withstack.withStack:) iter not on provisional value for intent "c"
 
 # Seeking to e intent will not error immediately, because the best-effort checks
 # only look for a point key covered by a range key (which it finds at f@1). This
 # is fine, as long as we expose the correct range key. The next step will error.
-run ok
+run error
 iter_new types=pointsAndRanges
 iter_seek_ge k=e
 iter_next
 ----
 iter_seek_ge: "e"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {e-g}/[5.000000000,0=/<empty>]
 iter_next: err=intentIter at intent, but iter not at provisional value
+error: (*withstack.withStack:) intentIter at intent, but iter not at provisional value
 
 # With prefix iterators, both seeks immediately error.
-run ok
+run error
 iter_new prefix types=pointsAndRanges
 iter_seek_ge k=c
 iter_seek_ge k=e
 ----
 iter_seek_ge: err=iter not on provisional value for intent "c"
 iter_seek_ge: err=iter not on provisional value for intent "e"
+error: (*withstack.withStack:) iter not on provisional value for intent "e"
 
 # Reverse seek at f will land on intent at e, even though there was no
 # provisional value. This is fine, as long as we emit the correct range keys.
 # It eventually errors because 
-run ok
+run error
 iter_new types=pointsAndRanges
 iter_seek_lt k=f
 iter_prev
 ----
 iter_seek_lt: "e"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {e-g}/[5.000000000,0=/<empty>]
 iter_prev: err=intentIter should not be after iter
+error: (*withstack.withStack:) intentIter should not be after iter
 
 # Reverse seek at d ends up succeeding. This is also fine, as long as the
 # emitted range keys and values are correct.
@@ -99,13 +103,14 @@ iter_prev: .
 
 # Switching directions on these positions should also error if appropriate, and
 # never expose the wrong range key for an intent.
-run ok
+run error
 iter_new types=pointsAndRanges
 iter_seek_ge k=e
 iter_prev
 ----
 iter_seek_ge: "e"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {e-g}/[5.000000000,0=/<empty>]
 iter_prev: err=iter not at provisional value, cmp: -1
+error: (*withstack.withStack:) iter not at provisional value, cmp: -1
 
 run ok
 iter_new types=pointsAndRanges


### PR DESCRIPTION
**storage: minor `MVCCIncrementalIterator` cleanup**

This patch makes some minor, mechanical cleanups of
`MVCCIncrementalIterator`:

* `checkValidAndSaveErr` was renamed `updateValid`.

* `initMetaAndCheckForIntentOrInlineError` was renamed `updateMeta`.

* `NextKeyIgnoringTime` was removed, as it was never used.

* `Key()` and `Value()` were removed, as they are not part of the
  `SimpleMVCCIterator` interface.

* Method comments that were copies of interface method comments were
  replaced with "implements SimpleMVCCIterator" variants.

Release note: None

**storage: add range key support for `MVCCIncrementalIterator`**

This patch adds range key support for `MVCCIncrementalIterator`,
filtering them by the time bounds and exposing them via the usual
`SimpleMVCCIterator` interface.

This comes with a moderate performance penalty in the no-range-key case,
mostly due to additional `HasPointAndRange()` checks. This, and the
range key paths, will be optimized later. For now, correctness is
sufficient, in order to unblock higher-level work.

```
name                                                 old time/op  new time/op  delta
MVCCIncrementalIterator/ts=5-24                      11.7ms ± 9%  12.1ms ± 3%    ~     (p=0.065 n=9+10)
MVCCIncrementalIterator/ts=480-24                     442µs ± 1%   444µs ± 1%    ~     (p=0.094 n=9+9)
MVCCIncrementalIteratorForOldData/valueSize=100-24   1.41ms ± 1%  1.49ms ± 1%  +5.59%  (p=0.000 n=10+10)
MVCCIncrementalIteratorForOldData/valueSize=500-24   1.89ms ± 2%  1.98ms ± 2%  +4.61%  (p=0.000 n=10+10)
MVCCIncrementalIteratorForOldData/valueSize=1000-24  2.59ms ± 2%  2.68ms ± 1%  +3.33%  (p=0.000 n=10+10)
MVCCIncrementalIteratorForOldData/valueSize=2000-24  4.15ms ± 2%  4.12ms ± 3%    ~     (p=0.481 n=10+10)
```

Release note: None