### PR TITLE
rpc: minor cleanup

### DIFF
--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -121,7 +121,7 @@ func TestHeartbeatCB(t *testing.T) {
 		// don't talk to servers from unrelated tests by accident).
 		clusterID := uuid.MakeV4()
 
-		clock := hlc.NewClock(hlc.NewManualClock(20), time.Nanosecond /* maxOffset */)
+		clock := hlc.NewClock(hlc.NewManualClock(20), 0 /* maxOffset */)
 		serverCtx := newTestContext(clusterID, clock, stopper)
 		serverCtx.rpcCompression = compression
 		const serverNodeID = 1
@@ -311,8 +311,7 @@ func TestInternalServerAddress(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 
-	// Can't be zero because that'd be an empty offset.
-	clock := hlc.NewClock(hlc.NewManualClock(1), time.Nanosecond /* maxOffset */)
+	clock := hlc.NewClock(hlc.NewManualClock(1), 0 /* maxOffset */)
 
 	serverCtx := newTestContext(uuid.MakeV4(), clock, stopper)
 	serverCtx.Config.Addr = "127.0.0.1:9999"
@@ -337,8 +336,7 @@ func TestInternalClientAdapterRunsInterceptors(t *testing.T) {
 	defer stopper.Stop(context.Background())
 	stopper.SetTracer(tracing.NewTracer())
 
-	// Can't be zero because that'd be an empty offset.
-	clock := hlc.NewClock(timeutil.NewManualTime(timeutil.Unix(0, 1)), time.Nanosecond)
+	clock := hlc.NewClock(timeutil.NewManualTime(timeutil.Unix(0, 1)), 0 /* maxOffset */)
 
 	serverCtx := newTestContext(uuid.MakeV4(), clock, stopper)
 	serverCtx.Config.Addr = "127.0.0.1:9999"
@@ -435,8 +433,7 @@ func TestInternalClientAdapterWithClientStreamInterceptors(t *testing.T) {
 	defer stopper.Stop(context.Background())
 	stopper.SetTracer(tracing.NewTracer())
 
-	// Can't be zero because that'd be an empty offset.
-	clock := hlc.NewClock(timeutil.NewManualTime(timeutil.Unix(0, 1)), time.Nanosecond)
+	clock := hlc.NewClock(timeutil.NewManualTime(timeutil.Unix(0, 1)), 0 /* maxOffset */)
 
 	serverCtx := newTestContext(uuid.MakeV4(), clock, stopper)
 	serverCtx.Config.Addr = "127.0.0.1:9999"
@@ -487,8 +484,7 @@ func TestInternalClientAdapterWithServerStreamInterceptors(t *testing.T) {
 	defer stopper.Stop(context.Background())
 	stopper.SetTracer(tracing.NewTracer())
 
-	// Can't be zero because that'd be an empty offset.  !!!
-	clock := hlc.NewClock(timeutil.NewManualTime(timeutil.Unix(0, 1)), time.Nanosecond)
+	clock := hlc.NewClock(timeutil.NewManualTime(timeutil.Unix(0, 1)), 0 /* maxOffset */)
 
 	serverCtx := newTestContext(uuid.MakeV4(), clock, stopper)
 	serverCtx.Config.Addr = "127.0.0.1:9999"
@@ -616,8 +612,7 @@ func BenchmarkInternalClientAdapter(b *testing.B) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 
-	// Can't be zero because that'd be an empty offset.
-	clock := hlc.NewClock(timeutil.NewManualTime(timeutil.Unix(0, 1)), time.Nanosecond)
+	clock := hlc.NewClock(timeutil.NewManualTime(timeutil.Unix(0, 1)), 0 /* maxOffset */)
 
 	serverCtx := newTestContext(uuid.MakeV4(), clock, stopper)
 	serverCtx.Config.Addr = "127.0.0.1:9999"
@@ -650,8 +645,7 @@ func TestHeartbeatHealth(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 
-	// Can't be zero because that'd be an empty offset.
-	clock := hlc.NewClock(hlc.NewManualClock(1), time.Nanosecond /* maxOffset */)
+	clock := hlc.NewClock(hlc.NewManualClock(1), 0 /* maxOffset */)
 
 	// Shared cluster ID by all RPC peers (this ensures that the peers
 	// don't talk to servers from unrelated tests by accident).
@@ -916,7 +910,7 @@ func TestHeartbeatHealthTransport(t *testing.T) {
 	clusterID := uuid.MakeV4()
 
 	// Can't be zero because that'd be an empty offset.
-	clock := hlc.NewClock(hlc.NewManualClock(1), time.Nanosecond /* maxOffset */)
+	clock := hlc.NewClock(hlc.NewManualClock(1), 0 /* maxOffset */)
 
 	serverCtx := newTestContext(clusterID, clock, stopper)
 	const serverNodeID = 1
@@ -1102,7 +1096,7 @@ func TestOffsetMeasurement(t *testing.T) {
 	// don't talk to servers from unrelated tests by accident).
 	clusterID := uuid.MakeV4()
 
-	serverClock := hlc.NewClock(hlc.NewManualClock(20), time.Nanosecond /* maxOffset */)
+	serverClock := hlc.NewClock(hlc.NewManualClock(20), 0 /* maxOffset */)
 	serverCtx := newTestContext(clusterID, serverClock, stopper)
 	const serverNodeID = 1
 	serverCtx.NodeID.Set(context.Background(), serverNodeID)
@@ -1123,7 +1117,7 @@ func TestOffsetMeasurement(t *testing.T) {
 
 	// Create a client clock that is behind the server clock.
 	clientAdvancing := &AdvancingClock{time: timeutil.Unix(0, 10)}
-	clientClock := hlc.NewClock(clientAdvancing, time.Nanosecond /* maxOffset */)
+	clientClock := hlc.NewClock(clientAdvancing, 0 /* maxOffset */)
 	clientCtx := newTestContext(clusterID, clientClock, stopper)
 	// Make the interval shorter to speed up the test.
 	clientCtx.Config.RPCHeartbeatInterval = 1 * time.Millisecond
@@ -1171,8 +1165,7 @@ func TestFailedOffsetMeasurement(t *testing.T) {
 	// don't talk to servers from unrelated tests by accident).
 	clusterID := uuid.MakeV4()
 
-	// Can't be zero because that'd be an empty offset.
-	clock := hlc.NewClock(hlc.NewManualClock(1), time.Nanosecond /* maxOffset */)
+	clock := hlc.NewClock(hlc.NewManualClock(1), 0 /* maxOffset */)
 
 	serverCtx := newTestContext(clusterID, clock, stopper)
 	const serverNodeID = 1
@@ -1464,7 +1457,7 @@ func grpcRunKeepaliveTestCase(testCtx context.Context, c grpcKeepaliveTestCase) 
 
 	// Construct server with server-side keepalive.
 	log.Infof(ctx, "constructing server")
-	clock := hlc.NewClock(hlc.NewManualClock(20), time.Nanosecond /* maxOffset */)
+	clock := hlc.NewClock(hlc.NewManualClock(20), 0 /* maxOffset */)
 	serverCtx := newTestContext(clusterID, clock, stopper)
 	const serverNodeID = 1
 	serverCtx.NodeID.Set(context.Background(), serverNodeID)
@@ -1690,7 +1683,7 @@ func TestGRPCDeadlinePropagation(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 	clusterID := uuid.MakeV4()
-	clock := hlc.NewClock(hlc.NewManualClock(20), time.Nanosecond /* maxOffset */)
+	clock := hlc.NewClock(hlc.NewManualClock(20), 0 /* maxOffset */)
 
 	// Construct the server context.
 	const serverNodeID = 1
@@ -1756,7 +1749,7 @@ func TestClusterIDMismatch(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 
-	clock := hlc.NewClock(hlc.NewManualClock(20), time.Nanosecond /* maxOffset */)
+	clock := hlc.NewClock(hlc.NewManualClock(20), 0 /* maxOffset */)
 	serverCtx := newTestContext(uuid.MakeV4(), clock, stopper)
 	const serverNodeID = 1
 	serverCtx.NodeID.Set(context.Background(), serverNodeID)
@@ -1797,7 +1790,7 @@ func TestClusterIDMismatch(t *testing.T) {
 func TestClusterNameMismatch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	clock := hlc.NewClock(hlc.NewManualClock(20), time.Nanosecond /* maxOffset */)
+	clock := hlc.NewClock(hlc.NewManualClock(20), 0 /* maxOffset */)
 
 	testData := []struct {
 		serverName             string
@@ -1880,7 +1873,7 @@ func TestNodeIDMismatch(t *testing.T) {
 	// don't talk to servers from unrelated tests by accident).
 	clusterID := uuid.MakeV4()
 
-	clock := hlc.NewClock(hlc.NewManualClock(20), time.Nanosecond /* maxOffset */)
+	clock := hlc.NewClock(hlc.NewManualClock(20), 0 /* maxOffset */)
 	serverCtx := newTestContext(clusterID, clock, stopper)
 	serverCtx.NodeID.Set(context.Background(), 1)
 	s := newTestServer(t, serverCtx)
@@ -1949,7 +1942,7 @@ func TestVersionCheckBidirectional(t *testing.T) {
 			stopper := stop.NewStopper()
 			defer stopper.Stop(context.Background())
 
-			clock := hlc.NewClock(hlc.NewManualClock(20), time.Nanosecond /* maxOffset */)
+			clock := hlc.NewClock(hlc.NewManualClock(20), 0 /* maxOffset */)
 			serverCtx := newTestContext(clusterID, clock, stopper)
 			const serverNodeID = 1
 			serverCtx.NodeID.Set(context.Background(), serverNodeID)
@@ -1998,7 +1991,7 @@ func TestGRPCDialClass(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 
-	clock := hlc.NewClock(hlc.NewManualClock(20), time.Nanosecond /* maxOffset */)
+	clock := hlc.NewClock(hlc.NewManualClock(20), 0 /* maxOffset */)
 	serverCtx := newTestContext(uuid.MakeV4(), clock, stopper)
 	const serverNodeID = 1
 	serverCtx.NodeID.Set(context.Background(), serverNodeID)
@@ -2046,7 +2039,7 @@ func TestTestingKnobs(t *testing.T) {
 	defer stopper.Stop(context.Background())
 	clusterID := uuid.MakeV4()
 
-	clock := hlc.NewClock(hlc.NewManualClock(20), time.Nanosecond /* maxOffset */)
+	clock := hlc.NewClock(hlc.NewManualClock(20), 0 /* maxOffset */)
 	serverCtx := newTestContext(clusterID, clock, stopper)
 	const serverNodeID = 1
 	serverCtx.NodeID.Set(context.Background(), serverNodeID)
@@ -2154,7 +2147,7 @@ func TestRunHeartbeatSetsHeartbeatStateWhenExitingBeforeFirstHeartbeat(t *testin
 	defer stopper.Stop(ctx)
 	clusterID := uuid.MakeV4()
 
-	clock := hlc.NewClock(hlc.NewManualClock(20), time.Nanosecond /* maxOffset */)
+	clock := hlc.NewClock(hlc.NewManualClock(20), 0 /* maxOffset */)
 
 	// This test reaches into low-level implementation details to recreate
 	// the hazardous scenario seen in #41521. In that isse we saw a runHeartbeat()


### PR DESCRIPTION
Cleanup some tests to disable the maxOffset check in the RPC Context.
The tests don't care about that, and they had copy-pasted the setting
from the one test that does care about it, including a comment
suggesting that the setting is important.

Release note: None