### PR TITLE
rowexec: improve join reader memory usage when ordering is maintained

### DIFF
--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -597,11 +597,15 @@ func (jr *joinReader) initJoinReaderStrategy(
 		}
 	}
 
+	defer func() {
+		generator.setResizeMemoryAccountFunc(jr.strategy.resizeMemoryAccount)
+	}()
+
 	if readerType == indexJoinReaderType {
 		jr.strategy = &joinReaderIndexJoinStrategy{
 			joinerBase:              &jr.joinerBase,
 			joinReaderSpanGenerator: generator,
-			memAcc:                  &strategyMemAcc,
+			strategyMemAcc:          &strategyMemAcc,
 		}
 		return nil
 	}
@@ -612,7 +616,7 @@ func (jr *joinReader) initJoinReaderStrategy(
 			joinReaderSpanGenerator: generator,
 			isPartialJoin:           jr.joinType == descpb.LeftSemiJoin || jr.joinType == descpb.LeftAntiJoin,
 			groupingState:           jr.groupingState,
-			memAcc:                  &strategyMemAcc,
+			strategyMemAcc:          &strategyMemAcc,
 		}
 		return nil
 	}
@@ -623,6 +627,10 @@ func (jr *joinReader) initJoinReaderStrategy(
 	limit := execinfra.GetWorkMemLimit(flowCtx)
 	// Initialize memory monitors and row container for looked up rows.
 	jr.limitedMemMonitor = execinfra.NewLimitedMonitor(ctx, jr.MemMonitor, flowCtx, "joinreader-limited")
+	// We want to make sure that if the disk-backed container is spilled to
+	// disk, it releases all of the memory reservations, so we make the
+	// corresponding memory monitor not hold on to any bytes.
+	jr.limitedMemMonitor.RelinquishAllOnReleaseBytes()
 	jr.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, "joinreader-disk")
 	drc := rowcontainer.NewDiskBackedNumberedRowContainer(
 		false, /* deDup */
@@ -644,7 +652,7 @@ func (jr *joinReader) initJoinReaderStrategy(
 		lookedUpRows:                      drc,
 		groupingState:                     jr.groupingState,
 		outputGroupContinuationForLeftRow: jr.outputGroupContinuationForLeftRow,
-		memAcc:                            &strategyMemAcc,
+		strategyMemAcc:                    &strategyMemAcc,
 	}
 	return nil
 }
@@ -773,8 +781,8 @@ func (jr *joinReader) readInput() (
 		// We've just discarded the old rows, so we have to update the memory
 		// accounting accordingly.
 		newSz := jr.accountedFor.scratchInputRows + jr.accountedFor.groupingState
-		if err := jr.memAcc.ResizeTo(jr.Ctx, newSz); err != nil {
-			jr.MoveToDraining(addWorkmemHint(err))
+		if err := jr.strategy.resizeMemoryAccount(&jr.memAcc, jr.memAcc.Used(), newSz); err != nil {
+			jr.MoveToDraining(err)
 			return jrStateUnknown, nil, jr.DrainHelper()
 		}
 		jr.scratchInputRows = jr.scratchInputRows[:0]
@@ -837,8 +845,8 @@ func (jr *joinReader) readInput() (
 		//
 		// We need to subtract the EncDatumRowOverhead because that is already
 		// tracked in jr.accountedFor.scratchInputRows.
-		if err := jr.memAcc.Grow(jr.Ctx, rowSize-int64(rowenc.EncDatumRowOverhead)); err != nil {
-			jr.MoveToDraining(addWorkmemHint(err))
+		if err := jr.strategy.growMemoryAccount(&jr.memAcc, rowSize-int64(rowenc.EncDatumRowOverhead)); err != nil {
+			jr.MoveToDraining(err)
 			return jrStateUnknown, nil, jr.DrainHelper()
 		}
 		jr.scratchInputRows = append(jr.scratchInputRows, jr.rowAlloc.CopyRow(encDatumRow))
@@ -1055,7 +1063,7 @@ func (jr *joinReader) performMemoryAccounting() error {
 	jr.accountedFor.scratchInputRows = int64(cap(jr.scratchInputRows)) * int64(rowenc.EncDatumRowOverhead)
 	jr.accountedFor.groupingState = jr.groupingState.memUsage()
 	newSz := jr.accountedFor.scratchInputRows + jr.accountedFor.groupingState
-	return addWorkmemHint(jr.memAcc.Resize(jr.Ctx, oldSz, newSz))
+	return jr.strategy.resizeMemoryAccount(&jr.memAcc, oldSz, newSz)
 }
 
 // Start is part of the RowSource interface.

--- a/pkg/sql/rowexec/joinreader_strategies.go
+++ b/pkg/sql/rowexec/joinreader_strategies.go
@@ -82,6 +82,13 @@ type joinReaderStrategy interface {
 	nextRowToEmit(ctx context.Context) (rowenc.EncDatumRow, joinReaderState, error)
 	// spilled returns whether the strategy spilled to disk.
 	spilled() bool
+	// growMemoryAccount and resizeMemoryAccount should be used instead of
+	// memAcc.Grow and memAcc.Resize, respectively. The goal of these functions
+	// is to provide strategies a way to try to handle "memory budget exceeded"
+	// errors. These methods also wrap all errors with a workmem hint so that
+	// the caller doesn't have to.
+	growMemoryAccount(memAcc *mon.BoundAccount, delta int64) error
+	resizeMemoryAccount(memAcc *mon.BoundAccount, oldSz, newSz int64) error
 	// close releases any resources associated with the joinReaderStrategy.
 	close(ctx context.Context)
 }
@@ -140,10 +147,10 @@ type joinReaderNoOrderingStrategy struct {
 
 	groupingState *inputBatchGroupingState
 
-	// memAcc is owned by this strategy and is closed when the strategy is
-	// closed. inputRows are owned by the joinReader, so they aren't accounted
-	// for with this memory account.
-	memAcc *mon.BoundAccount
+	// strategyMemAcc is owned by this strategy and is closed when the strategy
+	// is closed. inputRows are owned by the joinReader, so they aren't
+	// accounted for with this memory account.
+	strategyMemAcc *mon.BoundAccount
 }
 
 // getLookupRowsBatchSizeHint returns the batch size for the join reader no
@@ -194,8 +201,8 @@ func (s *joinReaderNoOrderingStrategy) processLookedUpRow(
 		matchingInputRowIndices = s.scratchMatchingInputRowIndices
 
 		// Perform memory accounting.
-		if err := s.memAcc.ResizeTo(s.Ctx, s.memUsage()); err != nil {
-			return jrStateUnknown, addWorkmemHint(err)
+		if err := s.resizeMemoryAccount(s.strategyMemAcc, s.strategyMemAcc.Used(), s.memUsage()); err != nil {
+			return jrStateUnknown, err
 		}
 	}
 	s.emitState.processingLookupRow = true
@@ -230,8 +237,8 @@ func (s *joinReaderNoOrderingStrategy) nextRowToEmit(
 			s.emitState.unmatchedInputRowIndicesCursor = 0
 
 			// Perform memory accounting.
-			if err := s.memAcc.ResizeTo(s.Ctx, s.memUsage()); err != nil {
-				return nil, jrStateUnknown, addWorkmemHint(err)
+			if err := s.resizeMemoryAccount(s.strategyMemAcc, s.strategyMemAcc.Used(), s.memUsage()); err != nil {
+				return nil, jrStateUnknown, err
 			}
 		}
 
@@ -291,8 +298,20 @@ func (s *joinReaderNoOrderingStrategy) nextRowToEmit(
 
 func (s *joinReaderNoOrderingStrategy) spilled() bool { return false }
 
+func (s *joinReaderNoOrderingStrategy) growMemoryAccount(
+	memAcc *mon.BoundAccount, delta int64,
+) error {
+	return addWorkmemHint(memAcc.Grow(s.Ctx, delta))
+}
+
+func (s *joinReaderNoOrderingStrategy) resizeMemoryAccount(
+	memAcc *mon.BoundAccount, oldSz, newSz int64,
+) error {
+	return addWorkmemHint(memAcc.Resize(s.Ctx, oldSz, newSz))
+}
+
 func (s *joinReaderNoOrderingStrategy) close(ctx context.Context) {
-	s.memAcc.Close(ctx)
+	s.strategyMemAcc.Close(ctx)
 	s.joinReaderSpanGenerator.close(ctx)
 	*s = joinReaderNoOrderingStrategy{}
 }
@@ -340,13 +359,13 @@ type joinReaderIndexJoinStrategy struct {
 		lookedUpRow         rowenc.EncDatumRow
 	}
 
-	// memAcc is owned by this strategy and is closed when the strategy is
-	// closed. inputRows are owned by the joinReader, so they aren't accounted
-	// for with this memory account.
+	// strategyMemAcc is owned by this strategy and is closed when the strategy
+	// is closed. inputRows are owned by the joinReader, so they aren't
+	// accounted for with this memory account.
 	//
-	// Note that joinReaderIndexJoinStrategy doesn't actually need a
-	// memory account, and it's only responsible for closing it.
-	memAcc *mon.BoundAccount
+	// Note that joinReaderIndexJoinStrategy doesn't actually need a memory
+	// account, and it's only responsible for closing it.
+	strategyMemAcc *mon.BoundAccount
 }
 
 // getLookupRowsBatchSizeHint returns the batch size for the join reader index
@@ -397,8 +416,20 @@ func (s *joinReaderIndexJoinStrategy) spilled() bool {
 	return false
 }
 
+func (s *joinReaderIndexJoinStrategy) growMemoryAccount(
+	memAcc *mon.BoundAccount, delta int64,
+) error {
+	return addWorkmemHint(memAcc.Grow(s.Ctx, delta))
+}
+
+func (s *joinReaderIndexJoinStrategy) resizeMemoryAccount(
+	memAcc *mon.BoundAccount, oldSz, newSz int64,
+) error {
+	return addWorkmemHint(memAcc.Resize(s.Ctx, oldSz, newSz))
+}
+
 func (s *joinReaderIndexJoinStrategy) close(ctx context.Context) {
-	s.memAcc.Close(ctx)
+	s.strategyMemAcc.Close(ctx)
 	s.joinReaderSpanGenerator.close(ctx)
 	*s = joinReaderIndexJoinStrategy{}
 }
@@ -483,11 +514,11 @@ type joinReaderOrderingStrategy struct {
 	// the second join in paired-joins).
 	outputGroupContinuationForLeftRow bool
 
-	// memAcc is owned by this strategy and is closed when the strategy is
-	// closed. inputRows are owned by the joinReader, so they aren't accounted
-	// for with this memory account.
-	memAcc       *mon.BoundAccount
-	accountedFor struct {
+	// strategyMemAcc is owned by this strategy and is closed when the strategy
+	// is closed. inputRows are owned by the joinReader, so they aren't
+	// accounted for with this memory account.
+	strategyMemAcc *mon.BoundAccount
+	accountedFor   struct {
 		// sliceOverhead contains the memory usage of
 		// inputRowIdxToLookedUpRowIndices and
 		// accountedFor.inputRowIdxToLookedUpRowIndices that is currently
@@ -576,7 +607,7 @@ func (s *joinReaderOrderingStrategy) processLookupRows(
 	// Account for the new allocations, if any.
 	sliceOverhead := memsize.IntSliceOverhead*int64(cap(s.inputRowIdxToLookedUpRowIndices)) +
 		memsize.Int64*int64(cap(s.accountedFor.inputRowIdxToLookedUpRowIndices))
-	if err := s.growMemoryAccount(sliceOverhead - s.accountedFor.sliceOverhead); err != nil {
+	if err := s.growMemoryAccount(s.strategyMemAcc, sliceOverhead-s.accountedFor.sliceOverhead); err != nil {
 		return nil, nil, err
 	}
 	s.accountedFor.sliceOverhead = sliceOverhead
@@ -640,7 +671,7 @@ func (s *joinReaderOrderingStrategy) processLookedUpRow(
 		delta += newSize - s.accountedFor.inputRowIdxToLookedUpRowIndices[idx]
 		s.accountedFor.inputRowIdxToLookedUpRowIndices[idx] = newSize
 	}
-	if err := s.growMemoryAccount(delta); err != nil {
+	if err := s.growMemoryAccount(s.strategyMemAcc, delta); err != nil {
 		return jrStateUnknown, err
 	}
 
@@ -741,7 +772,7 @@ func (s *joinReaderOrderingStrategy) spilled() bool {
 }
 
 func (s *joinReaderOrderingStrategy) close(ctx context.Context) {
-	s.memAcc.Close(ctx)
+	s.strategyMemAcc.Close(ctx)
 	s.joinReaderSpanGenerator.close(ctx)
 	if s.lookedUpRows != nil {
 		s.lookedUpRows.Close(ctx)
@@ -755,8 +786,10 @@ func (s *joinReaderOrderingStrategy) close(ctx context.Context) {
 // reservation is denied initially, then it'll attempt to spill lookedUpRows row
 // container to disk, so the error is only returned when that wasn't
 // successful.
-func (s *joinReaderOrderingStrategy) growMemoryAccount(delta int64) error {
-	if err := s.memAcc.Grow(s.Ctx, delta); err != nil {
+func (s *joinReaderOrderingStrategy) growMemoryAccount(
+	memAcc *mon.BoundAccount, delta int64,
+) error {
+	if err := memAcc.Grow(s.Ctx, delta); err != nil {
 		// We don't have enough budget to account for the new size. Check
 		// whether we can spill the looked up rows to disk to free up the
 		// budget.
@@ -765,7 +798,28 @@ func (s *joinReaderOrderingStrategy) growMemoryAccount(delta int64) error {
 			return addWorkmemHint(errors.CombineErrors(err, spillErr))
 		}
 		// We freed up some budget, so try to perform the accounting again.
-		return addWorkmemHint(s.memAcc.Grow(s.Ctx, delta))
+		return addWorkmemHint(memAcc.Grow(s.Ctx, delta))
+	}
+	return nil
+}
+
+// resizeMemoryAccount resizes the memory account according to oldSz and newSz.
+// If the reservation is denied initially, then it'll attempt to spill
+// lookedUpRows row container to disk, so the error is only returned when that
+// wasn't successful.
+func (s *joinReaderOrderingStrategy) resizeMemoryAccount(
+	memAcc *mon.BoundAccount, oldSz, newSz int64,
+) error {
+	if err := memAcc.Resize(s.Ctx, oldSz, newSz); err != nil {
+		// We don't have enough budget to account for the new size. Check
+		// whether we can spill the looked up rows to disk to free up the
+		// budget.
+		spilled, spillErr := s.lookedUpRows.SpillToDisk(s.Ctx)
+		if !spilled || spillErr != nil {
+			return addWorkmemHint(errors.CombineErrors(err, spillErr))
+		}
+		// We freed up some budget, so try to perform the accounting again.
+		return addWorkmemHint(memAcc.Resize(s.Ctx, oldSz, newSz))
 	}
 	return nil
 }

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -226,6 +226,10 @@ type BytesMonitor struct {
 	// pool.
 	poolAllocationSize int64
 
+	// relinquishAllOnReleaseBytes, if true, indicates that the monitor should
+	// relinquish all bytes on releaseBytes() call.
+	relinquishAllOnReleaseBytes bool
+
 	// noteworthyUsageBytes is the size beyond which total allocations start to
 	// become reported in the logs.
 	noteworthyUsageBytes int64
@@ -841,13 +845,22 @@ func (mm *BytesMonitor) releaseBudget(ctx context.Context) {
 	mm.mu.curBudget.Clear(ctx)
 }
 
+// RelinquishAllOnReleaseBytes makes it so that the monitor doesn't keep any
+// margin bytes when the bytes are released from it.
+func (mm *BytesMonitor) RelinquishAllOnReleaseBytes() {
+	mm.relinquishAllOnReleaseBytes = true
+}
+
 // adjustBudget ensures that the monitor does not keep many more bytes reserved
 // from the pool than it currently has allocated. Bytes are relinquished when
 // there are at least maxAllocatedButUnusedBlocks*poolAllocationSize bytes
-// reserved but unallocated.
+// reserved but unallocated (if relinquishAllOnReleaseBytes is false).
 func (mm *BytesMonitor) adjustBudget(ctx context.Context) {
 	// NB: mm.mu Already locked by releaseBytes().
-	margin := mm.poolAllocationSize * int64(maxAllocatedButUnusedBlocks)
+	var margin int64
+	if !mm.relinquishAllOnReleaseBytes {
+		margin = mm.poolAllocationSize * int64(maxAllocatedButUnusedBlocks)
+	}
 
 	neededBytes := mm.mu.curAllocated
 	if neededBytes <= mm.reserved.used {


### PR DESCRIPTION
This commit improves the join reader behavior when used by lookup joins
when ordering is maintained. In that case, we have a disk-backed row
container that we can spill to disk in order to free up some memory.
Previously, we would do so only in the case when the memory error occurs
inside of the strategy but would make the query error out if the memory
reservation is denied in the span generator or in the join reader
itself. This commit makes it so that in all places where the memory
accounting is performed, we try to ask the strategy to handle the memory
reservations. This allows the join reader ordering strategy attempt
spilling looked up rows to disk in all scenarios first, before erroring
out the query.

Additionally, this commit makes it so that the memory monitor used by
that disk-backed row container doesn't hold on to any memory when the
corresponding memory account is cleared. By default, our memory monitor
can keep a margin of 100KiB in reserve, but this behavior doesn't make
sense when we're forcing the disk-backed container to use disk.

Release note: None