### PR TITLE
lint: minor cleanup

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -257,15 +257,6 @@ func TestLint(t *testing.T) {
 					t.Errorf("did not find expected BSL license header in %s", filename)
 				}
 			}
-			if isCCL {
-				if cclHeader.Find(data) == nil {
-					t.Errorf("did not find expected license header (ccl=%t) in %s", isCCL, filename)
-				}
-			} else {
-				if bslHeader.Find(data) == nil && apacheHeader.Find(data) == nil {
-					t.Errorf("did not find expected license header (ccl=%t) in %s", isCCL, filename)
-				}
-			}
 		}); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
I had screwed up in a previous patch and left the logic for checking the
license headers in a duplicate state. Deleting some lines redundant with
what's right above them.

Release note: None