### PR TITLE
bazel: skip `printf` lint on third-party code

### DIFF
--- a/build/bazelutil/nogo_config.json
+++ b/build/bazelutil/nogo_config.json
@@ -111,6 +111,11 @@
             "cockroach/pkg/.*$": "first-party code"
         }
     },
+    "printf": {
+        "only_files": {
+            "cockroach/pkg/.*$": "first-party code"
+        }
+    },
     "returncheck": {
         "exclude_files": {
             "cockroach/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher_test.go": "existing failure",


### PR DESCRIPTION
Release note: None