### PR TITLE
builtins: remove certain overloads for to_timestamp

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -655,13 +655,7 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><a name="to_char"></a><code>to_char(timestamp: <a href="timestamp.html">timestamp</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Convert an timestamp to a string assuming the ISO, MDY DateStyle.</p>
 </span></td></tr>
-<tr><td><a name="to_timestamp"></a><code>to_timestamp(timestamp: <a href="decimal.html">decimal</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Convert Unix epoch (seconds since 1970-01-01 00:00:00+00) to timestamp with time zone.</p>
-</span></td></tr>
 <tr><td><a name="to_timestamp"></a><code>to_timestamp(timestamp: <a href="float.html">float</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Convert Unix epoch (seconds since 1970-01-01 00:00:00+00) to timestamp with time zone.</p>
-</span></td></tr>
-<tr><td><a name="to_timestamp"></a><code>to_timestamp(timestamp: <a href="int.html">int</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Convert Unix epoch (seconds since 1970-01-01 00:00:00+00) to timestamp with time zone.</p>
-</span></td></tr>
-<tr><td><a name="to_timestamp"></a><code>to_timestamp(timestamp: <a href="string.html">string</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Convert Unix epoch (seconds since 1970-01-01 00:00:00+00) to timestamp with time zone.</p>
 </span></td></tr>
 <tr><td><a name="transaction_timestamp"></a><code>transaction_timestamp() &rarr; <a href="date.html">date</a></code></td><td><span class="funcdesc"><p>Returns the time of the current transaction.</p>
 <p>The value is based on a timestamp picked when the transaction starts

--- a/pkg/sql/logictest/testdata/logic_test/timestamp
+++ b/pkg/sql/logictest/testdata/logic_test/timestamp
@@ -523,79 +523,19 @@ statement ok
 SET TIME ZONE 'UTC'
 
 ## Test for to_timestamp without implicit type conversion
-query T
-SELECT to_timestamp(1646906263.123456)
+query TTT
+SELECT to_timestamp(1646906263.123456), to_timestamp(1646906263), to_timestamp('1646906263.123456')
 ----
-2022-03-10 09:57:43.123456 +0000 UTC
-
-query T
-SELECT to_timestamp('1646906263.123456')
-----
-2022-03-10 09:57:43.123456 +0000 UTC
-
-## Test for to_timestamp with implicit type conversion to int
-query T
-SELECT to_timestamp(1646906263.123456::INT)
-----
-2022-03-10 09:57:43 +0000 UTC
-
-query T
-SELECT to_timestamp(32767::INT2)
-----
-1970-01-01 09:06:07 +0000 UTC
-
-query T
-SELECT to_timestamp(1646906263.123456::INT4)
-----
-2022-03-10 09:57:43 +0000 UTC
-
-query T
-SELECT to_timestamp(1646906263.123456::INT8)
-----
-2022-03-10 09:57:43 +0000 UTC
-
-## Test for to_timestamp with implicit type conversion to float
-query T
-SELECT to_timestamp(1646906263.123456::FLOAT)
-----
-2022-03-10 09:57:43.123456 +0000 UTC
-
-query T
-SELECT to_timestamp(1646906263.123456::REAL)
-----
-2022-03-10 09:57:43.123456 +0000 UTC
-
-query T
-SELECT to_timestamp(1646906263.123456::DOUBLE PRECISION)
-----
-2022-03-10 09:57:43.123456 +0000 UTC
-
-## Test for to_timestamp with implicit type conversion to decimal
-query T
-SELECT to_timestamp(1646906263.123456::DECIMAL)
-----
-2022-03-10 09:57:43.123456 +0000 UTC
+2022-03-10 09:57:43.123456 +0000 UTC  2022-03-10 09:57:43 +0000 UTC  2022-03-10 09:57:43.123456 +0000 UTC
 
 ## Test for to_timestamp with positive and negative infinities
-query T
-SELECT to_timestamp('infinity'::DECIMAL)
+query TT
+SELECT to_timestamp('infinity'), to_timestamp('-infinity')
 ----
-294276-12-31 23:59:59.999999 +0000 UTC
-
-query T
-SELECT to_timestamp('-infinity'::DECIMAL)
-----
--4713-11-24 00:00:00 +0000 UTC
+294276-12-31 23:59:59.999999 +0000 UTC  -4713-11-24 00:00:00 +0000 UTC
 
 ## Test for to_timestamp with NULL
 query T
 SELECT to_timestamp(NULL)
 ----
 NULL
-
-## Test for invalid inputs
-statement error to_timestamp\(\): invalid input for type text
-SELECT to_timestamp('invalid')
-
-statement error unknown signature: to_timestamp\(\)
-SELECT to_timestamp()

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2654,48 +2654,20 @@ var builtins = map[string]builtinDefinition{
 	"to_timestamp": makeBuiltin(
 		tree.FunctionProperties{Category: categoryDateAndTime},
 		tree.Overload{
-			Types:      tree.ArgTypes{{"timestamp", types.String}},
-			ReturnType: tree.FixedReturnType(types.TimestampTZ),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				ts, err := strconv.ParseFloat(string(tree.MustBeDString(args[0])), 64)
-				if err != nil {
-					return nil, pgerror.New(pgcode.AmbiguousFunction, "invalid input for type text")
-				}
-				return floatToTimestampTZ(ts)
-			},
-			Info:       "Convert Unix epoch (seconds since 1970-01-01 00:00:00+00) to timestamp with time zone.",
-			Volatility: volatility.Immutable,
-		},
-		tree.Overload{
-			Types:      tree.ArgTypes{{"timestamp", types.Int}},
-			ReturnType: tree.FixedReturnType(types.TimestampTZ),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				ts := float64(tree.MustBeDInt(args[0]))
-				return floatToTimestampTZ(ts)
-			},
-			Info:       "Convert Unix epoch (seconds since 1970-01-01 00:00:00+00) to timestamp with time zone.",
-			Volatility: volatility.Immutable,
-		},
-		tree.Overload{
 			Types:      tree.ArgTypes{{"timestamp", types.Float}},
 			ReturnType: tree.FixedReturnType(types.TimestampTZ),
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				ts := float64(tree.MustBeDFloat(args[0]))
-				return floatToTimestampTZ(ts)
-			},
-			Info:       "Convert Unix epoch (seconds since 1970-01-01 00:00:00+00) to timestamp with time zone.",
-			Volatility: volatility.Immutable,
-		},
-		tree.Overload{
-			Types:      tree.ArgTypes{{"timestamp", types.Decimal}},
-			ReturnType: tree.FixedReturnType(types.TimestampTZ),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				decimal := tree.MustBeDDecimal(args[0]).Decimal
-				ts, err := decimal.Float64()
-				if err != nil {
-					return nil, err
+				if math.IsNaN(ts) {
+					return nil, pgerror.New(pgcode.DatetimeFieldOverflow, "timestamp cannot be NaN")
 				}
-				return floatToTimestampTZ(ts)
+				if ts == math.Inf(1) {
+					return tree.MakeDTimestampTZ(pgdate.TimeInfinity, time.Microsecond)
+				}
+				if ts == math.Inf(-1) {
+					return tree.MakeDTimestampTZ(pgdate.TimeNegativeInfinity, time.Microsecond)
+				}
+				return tree.MakeDTimestampTZ(timeutil.Unix(0, int64(ts*float64(time.Second))), time.Microsecond)
 			},
 			Info:       "Convert Unix epoch (seconds since 1970-01-01 00:00:00+00) to timestamp with time zone.",
 			Volatility: volatility.Immutable,
@@ -9644,17 +9616,4 @@ func prettyStatement(p tree.PrettyCfg, stmt string) (string, error) {
 		formattedStmt.WriteString("\n")
 	}
 	return formattedStmt.String(), nil
-}
-
-func floatToTimestampTZ(ts float64) (tree.Datum, error) {
-	if math.IsNaN(ts) {
-		return nil, pgerror.New(pgcode.DatetimeFieldOverflow, "timestamp cannot be NaN")
-	}
-	if ts == math.Inf(1) {
-		return tree.MakeDTimestampTZ(pgdate.TimeInfinity, time.Microsecond)
-	}
-	if ts == math.Inf(-1) {
-		return tree.MakeDTimestampTZ(pgdate.TimeNegativeInfinity, time.Microsecond)
-	}
-	return tree.MakeDTimestampTZ(timeutil.Unix(0, int64(ts*float64(time.Second))), time.Microsecond)
 }


### PR DESCRIPTION
Paving the way for this to be backported - remove some overloads that
were added to remove ambiguity for the purpose of better backwards
compat.

Release note: None