### PR TITLE
kvserver: emit MVCC range tombstones over rangefeeds

### DIFF
--- a/pkg/ccl/streamingccl/streamproducer/event_stream.go
+++ b/pkg/ccl/streamingccl/streamproducer/event_stream.go
@@ -472,6 +472,7 @@ func (s *eventStream) streamLoop(ctx context.Context, frontier *span.Frontier) e
 					return err
 				}
 			default:
+				// TODO(erikgrinaker): Handle DeleteRange events (MVCC range tombstones).
 				return errors.AssertionFailedf("unexpected event")
 			}
 		}

--- a/pkg/kv/kvclient/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvclient/rangefeed/BUILD.bazel
@@ -73,6 +73,7 @@ go_test(
         "//pkg/spanconfig",
         "//pkg/spanconfig/spanconfigptsreader",
         "//pkg/sql/catalog/desctestutils",
+        "//pkg/storage",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",

--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -357,6 +357,12 @@ func (f *RangeFeed) processEvents(
 						"received unexpected rangefeed SST event with no OnSSTable handler")
 				}
 				f.onSSTable(ctx, ev.SST)
+			case ev.DeleteRange != nil:
+				if f.onDeleteRange == nil {
+					return errors.AssertionFailedf(
+						"received unexpected rangefeed DeleteRange event with no OnDeleteRange handler: %s", ev)
+				}
+				f.onDeleteRange(ctx, ev.DeleteRange)
 			case ev.Error != nil:
 				// Intentionally do nothing, we'll get an error returned from the
 				// call to RangeFeed.

--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigptsreader"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sstutil"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
@@ -613,6 +614,162 @@ func TestWithOnSSTableCatchesUpIfNotSet(t *testing.T) {
 		}
 	}
 	require.Equal(t, expectKVs, seenKVs)
+}
+
+// TestWithOnDeleteRange tests that the rangefeed emits MVCC range tombstones.
+//
+// TODO(erikgrinaker): These kinds of tests should really use a data-driven test
+// harness, for more exhaustive testing. But it'll do for now.
+func TestWithOnDeleteRange(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+	srv := tc.Server(0)
+	db := srv.DB()
+
+	_, _, err := tc.SplitRange(roachpb.Key("a"))
+	require.NoError(t, err)
+	require.NoError(t, tc.WaitForFullReplication())
+
+	_, err = tc.ServerConn(0).Exec("SET CLUSTER SETTING kv.rangefeed.enabled = true")
+	require.NoError(t, err)
+	f, err := rangefeed.NewFactory(srv.Stopper(), db, srv.ClusterSettings(), nil)
+	require.NoError(t, err)
+
+	// We lay down a few MVCC range tombstones and points. The first range
+	// tombstone should not be visible, because initial scans do not emit
+	// tombstones, nor should the points covered by it. The second range tombstone
+	// should be visible, because catchup scans do emit tombstones. The range
+	// tombstone should be ordered after the initial point, but before the foo
+	// catchup point, and the previous values should respect the range tombstones.
+	require.NoError(t, db.Put(ctx, "covered", "covered"))
+	require.NoError(t, db.Put(ctx, "foo", "covered"))
+	require.NoError(t, db.ExperimentalDelRangeUsingTombstone(ctx, "a", "z"))
+	require.NoError(t, db.Put(ctx, "foo", "initial"))
+	rangeFeedTS := db.Clock().Now()
+	require.NoError(t, db.Put(ctx, "covered", "catchup"))
+	require.NoError(t, db.ExperimentalDelRangeUsingTombstone(ctx, "a", "z"))
+	require.NoError(t, db.Put(ctx, "foo", "catchup"))
+
+	// We start the rangefeed over a narrower span than the DeleteRanges (c-g),
+	// to ensure the DeleteRange event is truncated to the registration span.
+	var checkpointOnce sync.Once
+	checkpointC := make(chan struct{})
+	deleteRangeC := make(chan *roachpb.RangeFeedDeleteRange)
+	rowC := make(chan *roachpb.RangeFeedValue)
+
+	spans := []roachpb.Span{{Key: roachpb.Key("c"), EndKey: roachpb.Key("g")}}
+	r, err := f.RangeFeed(ctx, "test", spans, rangeFeedTS,
+		func(ctx context.Context, e *roachpb.RangeFeedValue) {
+			select {
+			case rowC <- e:
+			case <-ctx.Done():
+			}
+		},
+		rangefeed.WithDiff(true),
+		rangefeed.WithInitialScan(nil),
+		rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *roachpb.RangeFeedCheckpoint) {
+			checkpointOnce.Do(func() {
+				close(checkpointC)
+			})
+		}),
+		rangefeed.WithOnDeleteRange(func(ctx context.Context, e *roachpb.RangeFeedDeleteRange) {
+			select {
+			case deleteRangeC <- e:
+			case <-ctx.Done():
+			}
+		}),
+	)
+	require.NoError(t, err)
+	defer r.Close()
+
+	// Wait for initial scan. We should see the foo=initial point, but not the
+	// range tombstone nor the covered points.
+	select {
+	case e := <-rowC:
+		require.Equal(t, roachpb.Key("foo"), e.Key)
+		value, err := e.Value.GetBytes()
+		require.NoError(t, err)
+		require.Equal(t, "initial", string(value))
+		prevValue, err := e.PrevValue.GetBytes()
+		require.NoError(t, err)
+		require.Equal(t, "initial", string(prevValue)) // initial scans supply current as prev
+	case <-time.After(3 * time.Second):
+		require.Fail(t, "timed out waiting for initial scan event")
+	}
+
+	// Wait for catchup scan. We should see the second range tombstone, truncated
+	// to the rangefeed bounds (c-g), and it should be ordered before the points
+	// covered=catchup and foo=catchup. both points should have a tombstone as the
+	// previous value.
+	select {
+	case e := <-deleteRangeC:
+		require.Equal(t, roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("g")}, e.Span)
+		require.NotEmpty(t, e.Timestamp)
+	case <-time.After(3 * time.Second):
+		require.Fail(t, "timed out waiting for DeleteRange event")
+	}
+
+	select {
+	case e := <-rowC:
+		require.Equal(t, roachpb.Key("covered"), e.Key)
+		value, err := e.Value.GetBytes()
+		require.NoError(t, err)
+		require.Equal(t, "catchup", string(value))
+		prevValue, err := storage.DecodeMVCCValue(e.PrevValue.RawBytes)
+		require.NoError(t, err)
+		require.True(t, prevValue.IsTombstone())
+	case <-time.After(3 * time.Second):
+		require.Fail(t, "timed out waiting for foo=catchup event")
+	}
+
+	select {
+	case e := <-rowC:
+		require.Equal(t, roachpb.Key("foo"), e.Key)
+		value, err := e.Value.GetBytes()
+		require.NoError(t, err)
+		require.Equal(t, "catchup", string(value))
+		prevValue, err := storage.DecodeMVCCValue(e.PrevValue.RawBytes)
+		require.NoError(t, err)
+		require.True(t, prevValue.IsTombstone())
+	case <-time.After(3 * time.Second):
+		require.Fail(t, "timed out waiting for foo=catchup event")
+	}
+
+	// Wait for checkpoint after catchup scan.
+	select {
+	case <-checkpointC:
+	case <-time.After(3 * time.Second):
+		require.Fail(t, "timed out waiting for checkpoint")
+	}
+
+	// Send another DeleteRange, and wait for the rangefeed event. This should
+	// be truncated to the rangefeed bounds (c-g).
+	require.NoError(t, db.ExperimentalDelRangeUsingTombstone(ctx, "a", "z"))
+	select {
+	case e := <-deleteRangeC:
+		require.Equal(t, roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("g")}, e.Span)
+		require.NotEmpty(t, e.Timestamp)
+	case <-time.After(3 * time.Second):
+		require.Fail(t, "timed out waiting for DeleteRange event")
+	}
+
+	// A final point write should be emitted with a tombstone as the previous value.
+	require.NoError(t, db.Put(ctx, "foo", "final"))
+	select {
+	case e := <-rowC:
+		require.Equal(t, roachpb.Key("foo"), e.Key)
+		value, err := e.Value.GetBytes()
+		require.NoError(t, err)
+		require.Equal(t, "final", string(value))
+		prevValue, err := storage.DecodeMVCCValue(e.PrevValue.RawBytes)
+		require.NoError(t, err)
+		require.True(t, prevValue.IsTombstone())
+	case <-time.After(3 * time.Second):
+		require.Fail(t, "timed out waiting for foo=final event")
+	}
 }
 
 // TestUnrecoverableErrors verifies that unrecoverable internal errors are surfaced

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
@@ -175,7 +175,7 @@ func setupMVCCPebble(b testing.TB, dir string, lBaseMaxBytes int64, readOnly boo
 	opts.FS = vfs.Default
 	opts.LBaseMaxBytes = lBaseMaxBytes
 	opts.ReadOnly = readOnly
-	opts.FormatMajorVersion = pebble.FormatBlockPropertyCollector
+	opts.FormatMajorVersion = pebble.FormatRangeKeys
 	peb, err := storage.NewPebble(
 		context.Background(),
 		storage.PebbleConfig{

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_test.go
@@ -26,6 +26,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TODO(erikgrinaker): This should be migrated to a data-driven test harness for
+// end-to-end rangefeed testing, with more exhaustive test cases. See:
+// https://github.com/cockroachdb/cockroach/issues/82715
+//
+// For now, see rangefeed_external_test.go for rudimentary range key tests.
 func TestCatchupScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/kv/kvserver/rangefeed/resolved_timestamp.go
+++ b/pkg/kv/kvserver/rangefeed/resolved_timestamp.go
@@ -142,6 +142,10 @@ func (rts *resolvedTimestamp) consumeLogicalOp(op enginepb.MVCCLogicalOp) bool {
 		rts.assertOpAboveRTS(op, t.Timestamp)
 		return false
 
+	case *enginepb.MVCCDeleteRangeOp:
+		rts.assertOpAboveRTS(op, t.Timestamp)
+		return false
+
 	case *enginepb.MVCCWriteIntentOp:
 		rts.assertOpAboveRTS(op, t.Timestamp)
 		return rts.intentQ.IncRef(t.TxnID, t.TxnKey, t.TxnMinTimestamp, t.Timestamp)

--- a/pkg/kv/kvserver/rangefeed/task_test.go
+++ b/pkg/kv/kvserver/rangefeed/task_test.go
@@ -196,17 +196,18 @@ func (s *testIterator) curKV() storage.MVCCKeyValue {
 
 // HasPointAndRange implements SimpleMVCCIterator.
 func (s *testIterator) HasPointAndRange() (bool, bool) {
-	panic("not implemented")
+	ok, err := s.Valid()
+	return ok && err == nil, false
 }
 
 // RangeBounds implements SimpleMVCCIterator.
 func (s *testIterator) RangeBounds() roachpb.Span {
-	panic("not implemented")
+	return roachpb.Span{}
 }
 
 // RangeTombstones implements SimpleMVCCIterator.
 func (s *testIterator) RangeKeys() []storage.MVCCRangeKeyValue {
-	panic("not implemented")
+	return []storage.MVCCRangeKeyValue{}
 }
 
 func TestInitResolvedTSScan(t *testing.T) {

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -513,7 +513,8 @@ func (r *Replica) populatePrevValsInLogicalOpLogRaftMuLocked(
 		case *enginepb.MVCCWriteIntentOp,
 			*enginepb.MVCCUpdateIntentOp,
 			*enginepb.MVCCAbortIntentOp,
-			*enginepb.MVCCAbortTxnOp:
+			*enginepb.MVCCAbortTxnOp,
+			*enginepb.MVCCDeleteRangeOp:
 			// Nothing to do.
 			continue
 		default:
@@ -587,7 +588,8 @@ func (r *Replica) handleLogicalOpLogRaftMuLocked(
 		case *enginepb.MVCCWriteIntentOp,
 			*enginepb.MVCCUpdateIntentOp,
 			*enginepb.MVCCAbortIntentOp,
-			*enginepb.MVCCAbortTxnOp:
+			*enginepb.MVCCAbortTxnOp,
+			*enginepb.MVCCDeleteRangeOp:
 			// Nothing to do.
 			continue
 		default:

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1519,6 +1519,9 @@ func (e *RangeFeedEvent) ShallowCopy() *RangeFeedEvent {
 	case *RangeFeedSSTable:
 		cpySST := *t
 		cpy.MustSetValue(&cpySST)
+	case *RangeFeedDeleteRange:
+		cpyDelRange := *t
+		cpy.MustSetValue(&cpyDelRange)
 	case *RangeFeedError:
 		cpyErr := *t
 		cpy.MustSetValue(&cpyErr)

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -2783,15 +2783,24 @@ message RangeFeedSSTable {
   util.hlc.Timestamp write_ts = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "WriteTS"];
 }
 
+// RangeFeedDeleteRange is a variant of RangeFeedEvent that represents a
+// deletion of the specified key range at the given timestamp using an MVCC
+// range tombstone.
+message RangeFeedDeleteRange {
+  Span               span        = 1 [(gogoproto.nullable) = false];
+  util.hlc.Timestamp timestamp   = 2 [(gogoproto.nullable) = false];
+}
+
 // RangeFeedEvent is a union of all event types that may be returned on a
 // RangeFeed response stream.
 message RangeFeedEvent {
   option (gogoproto.onlyone) = true;
 
-  RangeFeedValue      val        = 1;
-  RangeFeedCheckpoint checkpoint = 2;
-  RangeFeedError      error      = 3;
-  RangeFeedSSTable    sst        = 4 [(gogoproto.customname) = "SST"];
+  RangeFeedValue       val          = 1;
+  RangeFeedCheckpoint  checkpoint   = 2;
+  RangeFeedError       error        = 3;
+  RangeFeedSSTable     sst          = 4 [(gogoproto.customname) = "SST"];
+  RangeFeedDeleteRange delete_range = 5;
 }
 
 

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -2088,6 +2088,11 @@ func (ls LockStateInfo) String() string {
 	return redact.StringWithoutMarkers(ls)
 }
 
+// Clone returns a copy of the span.
+func (s Span) Clone() Span {
+	return Span{Key: s.Key.Clone(), EndKey: s.EndKey.Clone()}
+}
+
 // EqualValue is Equal.
 //
 // TODO(tbg): remove this passthrough.

--- a/pkg/storage/enginepb/mvcc3.proto
+++ b/pkg/storage/enginepb/mvcc3.proto
@@ -343,6 +343,15 @@ message MVCCAbortTxnOp {
     (gogoproto.nullable) = false];
 }
 
+// MVCCDeleteRangeOp corresponds to a range deletion using an MVCC range
+// tombstone.
+message MVCCDeleteRangeOp {
+  bytes              start_key = 1;
+  bytes              end_key   = 2;
+  util.hlc.Timestamp timestamp = 3 [(gogoproto.nullable) = false];
+}
+
+
 // MVCCLogicalOp is a union of all logical MVCC operation types.
 message MVCCLogicalOp {
   option (gogoproto.onlyone) = true;
@@ -353,4 +362,5 @@ message MVCCLogicalOp {
   MVCCCommitIntentOp commit_intent = 4;
   MVCCAbortIntentOp  abort_intent  = 5;
   MVCCAbortTxnOp     abort_txn     = 6;
+  MVCCDeleteRangeOp  delete_range  = 7;
 }


### PR DESCRIPTION
This patch adds MVCC range tombstone support in rangefeeds. Whenever an
MVCC range tombstone is written, a new `MVCCDeleteRangeOp` logical op
is recorded and emitted across the rangefeed as a `RangeFeedDeleteRange`
event. MVCC range tombstones will only be written when the
`MVCCRangeTombstones` version gate has been enabled.

Changefeeds will emit an error for these events. We do not expect to see
these in online spans with changefeeds, since they are initially only
planned for use with schema GC and import rollbacks.

The rangefeed client library has been extended with support for these
events, but no existing callers handle them for the same reason as
changefeeds. Initial scans do not emit regular tombstones, and thus not
range tombstones either, but catchup scans will emit them if
encountered.

This patch has rudimentary testing of MVCC range tombstones in
rangefeeds. A later patch will add a data-driven test harness for
rangefeeds with more exhaustive tests.

Resolves #82449.
Touches #70433.

Release note: None