### PR TITLE
release-22.1: ui: Add time picker to Transaction Details and Statement Details Overview pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.tsx
@@ -223,7 +223,7 @@ export class DiagnosticsView extends React.Component<
       activateDiagnosticsRef,
     } = this.props;
 
-    const canRequestDiagnostics = diagnosticsReports.every(
+    const readyToRequestDiagnostics = diagnosticsReports.every(
       diagnostic => diagnostic.completed,
     );
 
@@ -244,14 +244,14 @@ export class DiagnosticsView extends React.Component<
       <SummaryCard>
         <div className={cx("crl-statements-diagnostics-view__title")}>
           <Text textType={TextTypes.Heading3}>Statement diagnostics</Text>
-          {canRequestDiagnostics && (
+          {readyToRequestDiagnostics && (
             <Button
               onClick={() =>
                 activateDiagnosticsRef?.current?.showModalFor(
                   statementFingerprint,
                 )
               }
-              disabled={!canRequestDiagnostics}
+              disabled={!readyToRequestDiagnostics}
               intent="secondary"
             >
               Activate diagnostics

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
@@ -13,51 +13,561 @@ import Long from "long";
 import { createMemoryHistory } from "history";
 import { noop } from "lodash";
 import { StatementDetailsProps } from "./statementDetails";
+import { StatementDetailsResponse } from "../api";
 
 const history = createMemoryHistory({ initialEntries: ["/statements"] });
 
-export const getStatementDetailsPropsFixture = (): StatementDetailsProps => ({
-  history,
-  location: {
-    pathname: "/statement/true/4705782015019656142",
-    search: "",
-    hash: "",
-    state: null,
+const statementDetailsNoData: StatementDetailsResponse = {
+  statement: {
+    metadata: {
+      query: "",
+      formatted_query: "",
+      query_summary: "",
+      stmt_type: "",
+      implicit_txn: false,
+      dist_sql_count: new Long(0),
+      failed_count: new Long(0),
+      full_scan_count: new Long(0),
+      vec_count: new Long(0),
+      total_count: new Long(0),
+    },
+    stats: {
+      count: new Long(0),
+      first_attempt_count: new Long(0),
+      max_retries: new Long(0),
+      legacy_last_err: "",
+      num_rows: { mean: 0, squared_diffs: 0 },
+      parse_lat: { mean: 0, squared_diffs: 0 },
+      plan_lat: { mean: 0, squared_diffs: 0 },
+      run_lat: { mean: 0, squared_diffs: 0 },
+      service_lat: { mean: 0, squared_diffs: 0 },
+      overhead_lat: { mean: 0, squared_diffs: 0 },
+      legacy_last_err_redacted: "",
+      sensitive_info: {
+        last_err: "",
+        most_recent_plan_description: { name: "" },
+        most_recent_plan_timestamp: { seconds: new Long(-62135596800) },
+      },
+      bytes_read: { mean: 0, squared_diffs: 0 },
+      rows_read: { mean: 0, squared_diffs: 0 },
+      exec_stats: {
+        count: new Long(0),
+        network_bytes: { mean: 0, squared_diffs: 0 },
+        max_mem_usage: { mean: 0, squared_diffs: 0 },
+        contention_time: { mean: 0, squared_diffs: 0 },
+        network_messages: { mean: 0, squared_diffs: 0 },
+        max_disk_usage: { mean: 0, squared_diffs: 0 },
+      },
+      sql_type: "",
+      last_exec_timestamp: { seconds: new Long(-62135596800) },
+      rows_written: { mean: 0, squared_diffs: 0 },
+    },
+    aggregation_interval: {},
   },
-  match: {
-    path: "/statement/:implicitTxn/:statement",
-    url: "/statement/true/4705782015019656142",
-    isExact: true,
-    params: {
-      implicitTxn: "true",
-      statement: "4705782015019656142",
+  internal_app_name_prefix: "$ internal",
+  statement_statistics_per_aggregated_ts: [],
+  statement_statistics_per_plan_hash: [],
+  toJSON: () => ({}),
+};
+
+const statementDetailsData: StatementDetailsResponse = {
+  statement: {
+    metadata: {
+      query: "SELECT * FROM crdb_internal.node_build_info",
+      app_names: ["$ cockroach sql", "newname"],
+      dist_sql_count: new Long(2),
+      failed_count: new Long(2),
+      implicit_txn: true,
+      vec_count: new Long(2),
+      full_scan_count: new Long(2),
+      databases: ["defaultdb"],
+      query_summary: "SELECT * FROM crdb_internal.node_build_info",
+      formatted_query: "SELECT * FROM crdb_internal.node_build_info\n",
+      stmt_type: "DDL",
+      total_count: new Long(3),
+    },
+    stats: {
+      count: new Long(5),
+      first_attempt_count: new Long(5),
+      max_retries: new Long(0),
+      legacy_last_err: "",
+      legacy_last_err_redacted: "",
+      num_rows: {
+        mean: 6,
+        squared_diffs: 0,
+      },
+      parse_lat: {
+        mean: 0.0000876,
+        squared_diffs: 2.35792e-8,
+      },
+      plan_lat: {
+        mean: 0.008131,
+        squared_diffs: 0.00127640837,
+      },
+      run_lat: {
+        mean: 0.0002796,
+        squared_diffs: 2.401919999999999e-8,
+      },
+      service_lat: {
+        mean: 0.008522,
+        squared_diffs: 0.001298238058,
+      },
+      overhead_lat: {
+        mean: 0.000023799999999999972,
+        squared_diffs: 5.492799999999973e-9,
+      },
+      sensitive_info: {
+        last_err: "",
+        most_recent_plan_description: {
+          name: "virtual table",
+          attrs: [
+            {
+              key: "Table",
+              value: "node_build_info@primary",
+            },
+          ],
+          children: [],
+        },
+        most_recent_plan_timestamp: {
+          seconds: new Long(1614851546),
+          nanos: 956814000,
+        },
+      },
+      bytes_read: {
+        mean: 0,
+        squared_diffs: 0,
+      },
+      rows_read: {
+        mean: 0,
+        squared_diffs: 0,
+      },
+      rows_written: {
+        mean: 0,
+        squared_diffs: 0,
+      },
+      exec_stats: {
+        count: new Long(5),
+        network_bytes: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        max_mem_usage: {
+          mean: 10240,
+          squared_diffs: 0,
+        },
+        contention_time: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        network_messages: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        max_disk_usage: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+      },
+      sql_type: "TypeDML",
+      last_exec_timestamp: {
+        seconds: Long.fromInt(1599670290),
+        nanos: 111613000,
+      },
+      nodes: [new Long(1)],
+      plan_gists: ["AgH6////nxkAAA4AAAAGBg=="],
     },
   },
-  timeScale: {
-    windowSize: moment.duration(5, "day"),
-    sampleSize: moment.duration(5, "minutes"),
-    fixedWindowEnd: moment.utc("2021.12.12"),
-    key: "Custom",
-  },
-  statementDetails: {
-    statement: {
-      metadata: {
-        query: "SELECT * FROM crdb_internal.node_build_info",
-        app_names: ["$ cockroach sql", "newname"],
-        dist_sql_count: new Long(2),
-        failed_count: new Long(2),
-        implicit_txn: true,
-        vec_count: new Long(2),
-        full_scan_count: new Long(2),
-        databases: ["defaultdb"],
-        query_summary: "SELECT * FROM crdb_internal.node_build_info",
-        formatted_query: "SELECT * FROM crdb_internal.node_build_info\n",
-        stmt_type: "DDL",
-        total_count: new Long(3),
-      },
+  statement_statistics_per_aggregated_ts: [
+    {
       stats: {
-        count: new Long(5),
-        first_attempt_count: new Long(5),
+        count: new Long(1),
+        first_attempt_count: new Long(1),
+        max_retries: new Long(0),
+        legacy_last_err: "",
+        legacy_last_err_redacted: "",
+        num_rows: {
+          mean: 6,
+          squared_diffs: 0,
+        },
+        parse_lat: {
+          mean: 0.00004,
+          squared_diffs: 0,
+        },
+        plan_lat: {
+          mean: 0.000105,
+          squared_diffs: 0,
+        },
+        run_lat: {
+          mean: 0.000285,
+          squared_diffs: 0,
+        },
+        service_lat: {
+          mean: 0.000436,
+          squared_diffs: 0,
+        },
+        overhead_lat: {
+          mean: 0.000006000000000000037,
+          squared_diffs: 0,
+        },
+        sensitive_info: {
+          last_err: "",
+          most_recent_plan_description: {
+            name: "virtual table",
+            attrs: [
+              {
+                key: "Table",
+                value: "node_build_info@primary",
+              },
+            ],
+            children: [],
+          },
+          most_recent_plan_timestamp: {
+            seconds: new Long(1614851546),
+            nanos: 956814000,
+          },
+        },
+        bytes_read: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        rows_read: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        rows_written: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        exec_stats: {
+          count: new Long(1),
+          network_bytes: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          max_mem_usage: {
+            mean: 10240,
+            squared_diffs: 0,
+          },
+          contention_time: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          network_messages: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          max_disk_usage: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+        },
+        sql_type: "TypeDML",
+        last_exec_timestamp: {
+          seconds: Long.fromInt(1599670292),
+          nanos: 111613000,
+        },
+        nodes: [new Long(1)],
+        plan_gists: ["AgH6////nxkAAA4AAAAGBg=="],
+      },
+      aggregated_ts: {
+        seconds: Long.fromInt(1599670292),
+        nanos: 111613000,
+      },
+    },
+    {
+      stats: {
+        count: new Long(2),
+        first_attempt_count: new Long(2),
+        max_retries: new Long(0),
+        legacy_last_err: "",
+        legacy_last_err_redacted: "",
+        num_rows: {
+          mean: 6,
+          squared_diffs: 0,
+        },
+        parse_lat: {
+          mean: 0.000071,
+          squared_diffs: 4.050000000000001e-9,
+        },
+        plan_lat: {
+          mean: 0.0001525,
+          squared_diffs: 3.960499999999999e-9,
+        },
+        run_lat: {
+          mean: 0.0002255,
+          squared_diffs: 1.08045e-8,
+        },
+        service_lat: {
+          mean: 0.0004555,
+          squared_diffs: 1.0224500000000002e-8,
+        },
+        overhead_lat: {
+          mean: 0.000006499999999999995,
+          squared_diffs: 4.499999999999893e-12,
+        },
+        sensitive_info: {
+          last_err: "",
+          most_recent_plan_description: {
+            name: "virtual table",
+            attrs: [
+              {
+                key: "Table",
+                value: "node_build_info@primary",
+              },
+            ],
+            children: [],
+          },
+          most_recent_plan_timestamp: {
+            seconds: new Long(1614851546),
+            nanos: 956814000,
+          },
+        },
+        bytes_read: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        rows_read: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        rows_written: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        exec_stats: {
+          count: new Long(2),
+          network_bytes: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          max_mem_usage: {
+            mean: 10240,
+            squared_diffs: 0,
+          },
+          contention_time: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          network_messages: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          max_disk_usage: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+        },
+        sql_type: "TypeDML",
+        last_exec_timestamp: {
+          seconds: Long.fromInt(1599670292),
+          nanos: 111613000,
+        },
+        nodes: [new Long(1)],
+        plan_gists: ["AgH6////nxkAAA4AAAAGBg=="],
+      },
+      aggregated_ts: {
+        seconds: Long.fromInt(1599670292),
+        nanos: 111613000,
+      },
+    },
+    {
+      stats: {
+        count: new Long(1),
+        first_attempt_count: new Long(1),
+        max_retries: new Long(0),
+        legacy_last_err: "",
+        legacy_last_err_redacted: "",
+        num_rows: {
+          mean: 6,
+          squared_diffs: 0,
+        },
+        parse_lat: {
+          mean: 0.000046,
+          squared_diffs: 0,
+        },
+        plan_lat: {
+          mean: 0.000159,
+          squared_diffs: 0,
+        },
+        run_lat: {
+          mean: 0.000299,
+          squared_diffs: 0,
+        },
+        service_lat: {
+          mean: 0.000514,
+          squared_diffs: 0,
+        },
+        overhead_lat: {
+          mean: 0.000010000000000000026,
+          squared_diffs: 0,
+        },
+        sensitive_info: {
+          last_err: "",
+          most_recent_plan_description: {
+            name: "virtual table",
+            attrs: [
+              {
+                key: "Table",
+                value: "node_build_info@primary",
+              },
+            ],
+            children: [],
+          },
+          most_recent_plan_timestamp: {
+            seconds: new Long(1614851546),
+            nanos: 956814000,
+          },
+        },
+        bytes_read: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        rows_read: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        rows_written: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        exec_stats: {
+          count: new Long(1),
+          network_bytes: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          max_mem_usage: {
+            mean: 10240,
+            squared_diffs: 0,
+          },
+          contention_time: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          network_messages: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          max_disk_usage: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+        },
+        sql_type: "TypeDML",
+        last_exec_timestamp: {
+          seconds: Long.fromInt(1599670292),
+          nanos: 111613000,
+        },
+        nodes: [new Long(1)],
+        plan_gists: ["AgH6////nxkAAA4AAAAGBg=="],
+      },
+      aggregated_ts: {
+        seconds: Long.fromInt(1599671292),
+        nanos: 111613000,
+      },
+    },
+    {
+      stats: {
+        count: new Long(1),
+        first_attempt_count: new Long(1),
+        max_retries: new Long(0),
+        legacy_last_err: "",
+        legacy_last_err_redacted: "",
+        num_rows: {
+          mean: 6,
+          squared_diffs: 0,
+        },
+        parse_lat: {
+          mean: 0.00021,
+          squared_diffs: 0,
+        },
+        plan_lat: {
+          mean: 0.040086,
+          squared_diffs: 0,
+        },
+        run_lat: {
+          mean: 0.000363,
+          squared_diffs: 0,
+        },
+        service_lat: {
+          mean: 0.040749,
+          squared_diffs: 0,
+        },
+        overhead_lat: {
+          mean: 0.0000899999999999998,
+          squared_diffs: 0,
+        },
+        sensitive_info: {
+          last_err: "",
+          most_recent_plan_description: {
+            name: "virtual table",
+            attrs: [
+              {
+                key: "Table",
+                value: "node_build_info@primary",
+              },
+            ],
+            children: [],
+          },
+          most_recent_plan_timestamp: {
+            seconds: new Long(1614851546),
+            nanos: 956814000,
+          },
+        },
+        bytes_read: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        rows_read: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        rows_written: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        exec_stats: {
+          count: new Long(1),
+          network_bytes: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          max_mem_usage: {
+            mean: 10240,
+            squared_diffs: 0,
+          },
+          contention_time: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          network_messages: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          max_disk_usage: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+        },
+        sql_type: "TypeDML",
+        last_exec_timestamp: {
+          seconds: Long.fromInt(1599670292),
+          nanos: 111613000,
+        },
+        nodes: [new Long(1)],
+        plan_gists: ["AgH6////nxkAAA4AAAAGBg=="],
+      },
+      aggregated_ts: {
+        seconds: Long.fromInt(1599680292),
+        nanos: 111613000,
+      },
+    },
+  ],
+  statement_statistics_per_plan_hash: [
+    {
+      stats: {
+        count: new Long(3),
+        first_attempt_count: new Long(3),
         max_retries: new Long(0),
         legacy_last_err: "",
         legacy_last_err_redacted: "",
@@ -139,592 +649,144 @@ export const getStatementDetailsPropsFixture = (): StatementDetailsProps => ({
         },
         sql_type: "TypeDML",
         last_exec_timestamp: {
-          seconds: Long.fromInt(1599670290),
+          seconds: Long.fromInt(1599670292),
           nanos: 111613000,
         },
         nodes: [new Long(1)],
         plan_gists: ["AgH6////nxkAAA4AAAAGBg=="],
       },
+      explain_plan: "• virtual table\n  table: @primary",
+      plan_hash: new Long(14192395335876201826),
     },
-    statement_statistics_per_aggregated_ts: [
-      {
-        stats: {
-          count: new Long(1),
-          first_attempt_count: new Long(1),
-          max_retries: new Long(0),
-          legacy_last_err: "",
-          legacy_last_err_redacted: "",
-          num_rows: {
-            mean: 6,
-            squared_diffs: 0,
-          },
-          parse_lat: {
-            mean: 0.00004,
-            squared_diffs: 0,
-          },
-          plan_lat: {
-            mean: 0.000105,
-            squared_diffs: 0,
-          },
-          run_lat: {
-            mean: 0.000285,
-            squared_diffs: 0,
-          },
-          service_lat: {
-            mean: 0.000436,
-            squared_diffs: 0,
-          },
-          overhead_lat: {
-            mean: 0.000006000000000000037,
-            squared_diffs: 0,
-          },
-          sensitive_info: {
-            last_err: "",
-            most_recent_plan_description: {
-              name: "virtual table",
-              attrs: [
-                {
-                  key: "Table",
-                  value: "node_build_info@primary",
-                },
-              ],
-              children: [],
-            },
-            most_recent_plan_timestamp: {
-              seconds: new Long(1614851546),
-              nanos: 956814000,
-            },
-          },
-          bytes_read: {
-            mean: 0,
-            squared_diffs: 0,
-          },
-          rows_read: {
-            mean: 0,
-            squared_diffs: 0,
-          },
-          rows_written: {
-            mean: 0,
-            squared_diffs: 0,
-          },
-          exec_stats: {
-            count: new Long(1),
-            network_bytes: {
-              mean: 0,
-              squared_diffs: 0,
-            },
-            max_mem_usage: {
-              mean: 10240,
-              squared_diffs: 0,
-            },
-            contention_time: {
-              mean: 0,
-              squared_diffs: 0,
-            },
-            network_messages: {
-              mean: 0,
-              squared_diffs: 0,
-            },
-            max_disk_usage: {
-              mean: 0,
-              squared_diffs: 0,
-            },
-          },
-          sql_type: "TypeDML",
-          last_exec_timestamp: {
-            seconds: Long.fromInt(1599670292),
-            nanos: 111613000,
-          },
-          nodes: [new Long(1)],
-          plan_gists: ["AgH6////nxkAAA4AAAAGBg=="],
+    {
+      stats: {
+        count: new Long(2),
+        first_attempt_count: new Long(2),
+        max_retries: new Long(0),
+        legacy_last_err: "",
+        legacy_last_err_redacted: "",
+        num_rows: {
+          mean: 6,
+          squared_diffs: 0,
         },
-        aggregated_ts: {
+        parse_lat: {
+          mean: 0.0000876,
+          squared_diffs: 2.35792e-8,
+        },
+        plan_lat: {
+          mean: 0.008131,
+          squared_diffs: 0.00127640837,
+        },
+        run_lat: {
+          mean: 0.0002796,
+          squared_diffs: 2.401919999999999e-8,
+        },
+        service_lat: {
+          mean: 0.008522,
+          squared_diffs: 0.001298238058,
+        },
+        overhead_lat: {
+          mean: 0.000023799999999999972,
+          squared_diffs: 5.492799999999973e-9,
+        },
+        sensitive_info: {
+          last_err: "",
+          most_recent_plan_description: {
+            name: "virtual table",
+            attrs: [
+              {
+                key: "Table",
+                value: "node_build_info@primary",
+              },
+            ],
+            children: [],
+          },
+          most_recent_plan_timestamp: {
+            seconds: new Long(1614851546),
+            nanos: 956814000,
+          },
+        },
+        bytes_read: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        rows_read: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        rows_written: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        exec_stats: {
+          count: new Long(5),
+          network_bytes: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          max_mem_usage: {
+            mean: 10240,
+            squared_diffs: 0,
+          },
+          contention_time: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          network_messages: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          max_disk_usage: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+        },
+        sql_type: "TypeDML",
+        last_exec_timestamp: {
           seconds: Long.fromInt(1599670292),
           nanos: 111613000,
         },
+        nodes: [new Long(1)],
+        plan_gists: ["Ah0GAg=="],
       },
-      {
-        stats: {
-          count: new Long(2),
-          first_attempt_count: new Long(2),
-          max_retries: new Long(0),
-          legacy_last_err: "",
-          legacy_last_err_redacted: "",
-          num_rows: {
-            mean: 6,
-            squared_diffs: 0,
-          },
-          parse_lat: {
-            mean: 0.000071,
-            squared_diffs: 4.050000000000001e-9,
-          },
-          plan_lat: {
-            mean: 0.0001525,
-            squared_diffs: 3.960499999999999e-9,
-          },
-          run_lat: {
-            mean: 0.0002255,
-            squared_diffs: 1.08045e-8,
-          },
-          service_lat: {
-            mean: 0.0004555,
-            squared_diffs: 1.0224500000000002e-8,
-          },
-          overhead_lat: {
-            mean: 0.000006499999999999995,
-            squared_diffs: 4.499999999999893e-12,
-          },
-          sensitive_info: {
-            last_err: "",
-            most_recent_plan_description: {
-              name: "virtual table",
-              attrs: [
-                {
-                  key: "Table",
-                  value: "node_build_info@primary",
-                },
-              ],
-              children: [],
-            },
-            most_recent_plan_timestamp: {
-              seconds: new Long(1614851546),
-              nanos: 956814000,
-            },
-          },
-          bytes_read: {
-            mean: 0,
-            squared_diffs: 0,
-          },
-          rows_read: {
-            mean: 0,
-            squared_diffs: 0,
-          },
-          rows_written: {
-            mean: 0,
-            squared_diffs: 0,
-          },
-          exec_stats: {
-            count: new Long(2),
-            network_bytes: {
-              mean: 0,
-              squared_diffs: 0,
-            },
-            max_mem_usage: {
-              mean: 10240,
-              squared_diffs: 0,
-            },
-            contention_time: {
-              mean: 0,
-              squared_diffs: 0,
-            },
-            network_messages: {
-              mean: 0,
-              squared_diffs: 0,
-            },
-            max_disk_usage: {
-              mean: 0,
-              squared_diffs: 0,
-            },
-          },
-          sql_type: "TypeDML",
-          last_exec_timestamp: {
-            seconds: Long.fromInt(1599670292),
-            nanos: 111613000,
-          },
-          nodes: [new Long(1)],
-          plan_gists: ["AgH6////nxkAAA4AAAAGBg=="],
-        },
-        aggregated_ts: {
-          seconds: Long.fromInt(1599670292),
-          nanos: 111613000,
-        },
-      },
-      {
-        stats: {
-          count: new Long(1),
-          first_attempt_count: new Long(1),
-          max_retries: new Long(0),
-          legacy_last_err: "",
-          legacy_last_err_redacted: "",
-          num_rows: {
-            mean: 6,
-            squared_diffs: 0,
-          },
-          parse_lat: {
-            mean: 0.000046,
-            squared_diffs: 0,
-          },
-          plan_lat: {
-            mean: 0.000159,
-            squared_diffs: 0,
-          },
-          run_lat: {
-            mean: 0.000299,
-            squared_diffs: 0,
-          },
-          service_lat: {
-            mean: 0.000514,
-            squared_diffs: 0,
-          },
-          overhead_lat: {
-            mean: 0.000010000000000000026,
-            squared_diffs: 0,
-          },
-          sensitive_info: {
-            last_err: "",
-            most_recent_plan_description: {
-              name: "virtual table",
-              attrs: [
-                {
-                  key: "Table",
-                  value: "node_build_info@primary",
-                },
-              ],
-              children: [],
-            },
-            most_recent_plan_timestamp: {
-              seconds: new Long(1614851546),
-              nanos: 956814000,
-            },
-          },
-          bytes_read: {
-            mean: 0,
-            squared_diffs: 0,
-          },
-          rows_read: {
-            mean: 0,
-            squared_diffs: 0,
-          },
-          rows_written: {
-            mean: 0,
-            squared_diffs: 0,
-          },
-          exec_stats: {
-            count: new Long(1),
-            network_bytes: {
-              mean: 0,
-              squared_diffs: 0,
-            },
-            max_mem_usage: {
-              mean: 10240,
-              squared_diffs: 0,
-            },
-            contention_time: {
-              mean: 0,
-              squared_diffs: 0,
-            },
-            network_messages: {
-              mean: 0,
-              squared_diffs: 0,
-            },
-            max_disk_usage: {
-              mean: 0,
-              squared_diffs: 0,
-            },
-          },
-          sql_type: "TypeDML",
-          last_exec_timestamp: {
-            seconds: Long.fromInt(1599670292),
-            nanos: 111613000,
-          },
-          nodes: [new Long(1)],
-          plan_gists: ["AgH6////nxkAAA4AAAAGBg=="],
-        },
-        aggregated_ts: {
-          seconds: Long.fromInt(1599671292),
-          nanos: 111613000,
-        },
-      },
-      {
-        stats: {
-          count: new Long(1),
-          first_attempt_count: new Long(1),
-          max_retries: new Long(0),
-          legacy_last_err: "",
-          legacy_last_err_redacted: "",
-          num_rows: {
-            mean: 6,
-            squared_diffs: 0,
-          },
-          parse_lat: {
-            mean: 0.00021,
-            squared_diffs: 0,
-          },
-          plan_lat: {
-            mean: 0.040086,
-            squared_diffs: 0,
-          },
-          run_lat: {
-            mean: 0.000363,
-            squared_diffs: 0,
-          },
-          service_lat: {
-            mean: 0.040749,
-            squared_diffs: 0,
-          },
-          overhead_lat: {
-            mean: 0.0000899999999999998,
-            squared_diffs: 0,
-          },
-          sensitive_info: {
-            last_err: "",
-            most_recent_plan_description: {
-              name: "virtual table",
-              attrs: [
-                {
-                  key: "Table",
-                  value: "node_build_info@primary",
-                },
-              ],
-              children: [],
-            },
-            most_recent_plan_timestamp: {
-              seconds: new Long(1614851546),
-              nanos: 956814000,
-            },
-          },
-          bytes_read: {
-            mean: 0,
-            squared_diffs: 0,
-          },
-          rows_read: {
-            mean: 0,
-            squared_diffs: 0,
-          },
-          rows_written: {
-            mean: 0,
-            squared_diffs: 0,
-          },
-          exec_stats: {
-            count: new Long(1),
-            network_bytes: {
-              mean: 0,
-              squared_diffs: 0,
-            },
-            max_mem_usage: {
-              mean: 10240,
-              squared_diffs: 0,
-            },
-            contention_time: {
-              mean: 0,
-              squared_diffs: 0,
-            },
-            network_messages: {
-              mean: 0,
-              squared_diffs: 0,
-            },
-            max_disk_usage: {
-              mean: 0,
-              squared_diffs: 0,
-            },
-          },
-          sql_type: "TypeDML",
-          last_exec_timestamp: {
-            seconds: Long.fromInt(1599670292),
-            nanos: 111613000,
-          },
-          nodes: [new Long(1)],
-          plan_gists: ["AgH6////nxkAAA4AAAAGBg=="],
-        },
-        aggregated_ts: {
-          seconds: Long.fromInt(1599680292),
-          nanos: 111613000,
-        },
-      },
-    ],
-    statement_statistics_per_plan_hash: [
-      {
-        stats: {
-          count: new Long(3),
-          first_attempt_count: new Long(3),
-          max_retries: new Long(0),
-          legacy_last_err: "",
-          legacy_last_err_redacted: "",
-          num_rows: {
-            mean: 6,
-            squared_diffs: 0,
-          },
-          parse_lat: {
-            mean: 0.0000876,
-            squared_diffs: 2.35792e-8,
-          },
-          plan_lat: {
-            mean: 0.008131,
-            squared_diffs: 0.00127640837,
-          },
-          run_lat: {
-            mean: 0.0002796,
-            squared_diffs: 2.401919999999999e-8,
-          },
-          service_lat: {
-            mean: 0.008522,
-            squared_diffs: 0.001298238058,
-          },
-          overhead_lat: {
-            mean: 0.000023799999999999972,
-            squared_diffs: 5.492799999999973e-9,
-          },
-          sensitive_info: {
-            last_err: "",
-            most_recent_plan_description: {
-              name: "virtual table",
-              attrs: [
-                {
-                  key: "Table",
-                  value: "node_build_info@primary",
-                },
-              ],
-              children: [],
-            },
-            most_recent_plan_timestamp: {
-              seconds: new Long(1614851546),
-              nanos: 956814000,
-            },
-          },
-          bytes_read: {
-            mean: 0,
-            squared_diffs: 0,
-          },
-          rows_read: {
-            mean: 0,
-            squared_diffs: 0,
-          },
-          rows_written: {
-            mean: 0,
-            squared_diffs: 0,
-          },
-          exec_stats: {
-            count: new Long(5),
-            network_bytes: {
-              mean: 0,
-              squared_diffs: 0,
-            },
-            max_mem_usage: {
-              mean: 10240,
-              squared_diffs: 0,
-            },
-            contention_time: {
-              mean: 0,
-              squared_diffs: 0,
-            },
-            network_messages: {
-              mean: 0,
-              squared_diffs: 0,
-            },
-            max_disk_usage: {
-              mean: 0,
-              squared_diffs: 0,
-            },
-          },
-          sql_type: "TypeDML",
-          last_exec_timestamp: {
-            seconds: Long.fromInt(1599670292),
-            nanos: 111613000,
-          },
-          nodes: [new Long(1)],
-          plan_gists: ["AgH6////nxkAAA4AAAAGBg=="],
-        },
-        explain_plan: "• virtual table\n  table: @primary",
-        plan_hash: new Long(14192395335876201826),
-      },
-      {
-        stats: {
-          count: new Long(2),
-          first_attempt_count: new Long(2),
-          max_retries: new Long(0),
-          legacy_last_err: "",
-          legacy_last_err_redacted: "",
-          num_rows: {
-            mean: 6,
-            squared_diffs: 0,
-          },
-          parse_lat: {
-            mean: 0.0000876,
-            squared_diffs: 2.35792e-8,
-          },
-          plan_lat: {
-            mean: 0.008131,
-            squared_diffs: 0.00127640837,
-          },
-          run_lat: {
-            mean: 0.0002796,
-            squared_diffs: 2.401919999999999e-8,
-          },
-          service_lat: {
-            mean: 0.008522,
-            squared_diffs: 0.001298238058,
-          },
-          overhead_lat: {
-            mean: 0.000023799999999999972,
-            squared_diffs: 5.492799999999973e-9,
-          },
-          sensitive_info: {
-            last_err: "",
-            most_recent_plan_description: {
-              name: "virtual table",
-              attrs: [
-                {
-                  key: "Table",
-                  value: "node_build_info@primary",
-                },
-              ],
-              children: [],
-            },
-            most_recent_plan_timestamp: {
-              seconds: new Long(1614851546),
-              nanos: 956814000,
-            },
-          },
-          bytes_read: {
-            mean: 0,
-            squared_diffs: 0,
-          },
-          rows_read: {
-            mean: 0,
-            squared_diffs: 0,
-          },
-          rows_written: {
-            mean: 0,
-            squared_diffs: 0,
-          },
-          exec_stats: {
-            count: new Long(5),
-            network_bytes: {
-              mean: 0,
-              squared_diffs: 0,
-            },
-            max_mem_usage: {
-              mean: 10240,
-              squared_diffs: 0,
-            },
-            contention_time: {
-              mean: 0,
-              squared_diffs: 0,
-            },
-            network_messages: {
-              mean: 0,
-              squared_diffs: 0,
-            },
-            max_disk_usage: {
-              mean: 0,
-              squared_diffs: 0,
-            },
-          },
-          sql_type: "TypeDML",
-          last_exec_timestamp: {
-            seconds: Long.fromInt(1599670292),
-            nanos: 111613000,
-          },
-          nodes: [new Long(1)],
-          plan_gists: ["Ah0GAg=="],
-        },
-        explain_plan: "• virtual table\n  table: @primary\nFULL SCAN",
-        plan_hash: new Long(14192395335876212345),
-      },
-    ],
-    internal_app_name_prefix: "$ internal",
-    toJSON: () => ({}),
+      explain_plan: "• virtual table\n  table: @primary\nFULL SCAN",
+      plan_hash: new Long(14192395335876212345),
+    },
+  ],
+  internal_app_name_prefix: "$ internal",
+  toJSON: () => ({}),
+};
+
+export const getStatementDetailsPropsFixture = (
+  withData = true,
+): StatementDetailsProps => ({
+  history,
+  location: {
+    pathname: "/statement/true/4705782015019656142",
+    search: "",
+    hash: "",
+    state: null,
   },
+  match: {
+    path: "/statement/:implicitTxn/:statement",
+    url: "/statement/true/4705782015019656142",
+    isExact: true,
+    params: {
+      implicitTxn: "true",
+      statement: "4705782015019656142",
+    },
+  },
+  isLoading: false,
+  timeScale: {
+    windowSize: moment.duration(5, "day"),
+    sampleSize: moment.duration(5, "minutes"),
+    fixedWindowEnd: moment.utc("2021.12.12"),
+    key: "Custom",
+  },
+  statementFingerprintID: "4705782015019656142",
+  latestQuery: "SELECT * FROM crdb_internal.node_build_info",
+  latestFormattedQuery: "SELECT * FROM crdb_internal.node_build_info\n",
+  statementDetails: withData ? statementDetailsData : statementDetailsNoData,
   statementsError: null,
   nodeNames: {
     "1": "127.0.0.1:55529 (n1)",
@@ -745,7 +807,10 @@ export const getStatementDetailsPropsFixture = (): StatementDetailsProps => ({
   refreshUserSQLRoles: noop,
   diagnosticsReports: [],
   dismissStatementDiagnosticsAlertMessage: noop,
+  onTimeScaleChange: noop,
   createStatementDiagnosticsReport: noop,
+  onStatementDetailsQueryChange: noop,
+  onStatementDetailsFormattedQueryChange: noop,
   uiConfig: {
     showStatementDiagnosticsLink: true,
   },

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.selectors.ts
@@ -30,13 +30,16 @@ export const selectStatementDetails = createSelector(
   (_state: AppState, props: RouteComponentProps): string =>
     queryByName(props.location, appNamesAttr),
   (state: AppState): TimeScale => selectTimeScale(state),
-  (state: AppState) => state.adminUI.sqlDetailsStats,
+  (state: AppState) => state.adminUI.sqlDetailsStats.cachedData,
   (
     fingerprintID,
     appNames,
     timeScale,
-    statementDetailsStats,
-  ): StatementDetailsResponseMessage => {
+    statementDetailsStatsData,
+  ): {
+    statementDetails: StatementDetailsResponseMessage;
+    isLoading: boolean;
+  } => {
     // Since the aggregation interval is 1h, we want to round the selected timeScale to include
     // the full hour. If a timeScale is between 14:32 - 15:17 we want to search for values
     // between 14:00 - 16:00. We don't encourage the aggregation interval to be modified, but
@@ -49,10 +52,13 @@ export const selectStatementDetails = createSelector(
       Long.fromNumber(start.unix()),
       Long.fromNumber(end.unix()),
     );
-    if (Object.keys(statementDetailsStats).includes(key)) {
-      return statementDetailsStats[key].data;
+    if (Object.keys(statementDetailsStatsData).includes(key)) {
+      return {
+        statementDetails: statementDetailsStatsData[key].data,
+        isLoading: statementDetailsStatsData[key].inFlight,
+      };
     }
-    return null;
+    return { statementDetails: null, isLoading: true };
   },
 );
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.spec.tsx
@@ -29,6 +29,7 @@ describe("StatementDetails page", () => {
   });
 
   it("shows loading indicator when data is not ready yet", () => {
+    statementDetailsProps.isLoading = true;
     statementDetailsProps.statementDetails = null;
     statementDetailsProps.statementsError = null;
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.stories.tsx
@@ -86,4 +86,23 @@ storiesOf("StatementDetails", module)
       ["tab", "execution-stats"],
     ]).toString();
     return <StatementDetails {...props} />;
+  })
+  .add("Loading", () => {
+    const props = getStatementDetailsPropsFixture();
+    props.statementDetails = null;
+    props.isLoading = true;
+    return <StatementDetails {...props} />;
+  })
+  .add(
+    "No data for this time frame; has statement cached from previous time frame",
+    () => {
+      const props = getStatementDetailsPropsFixture(false);
+      return <StatementDetails {...props} />;
+    },
+  )
+  .add("No data for this time frame; no cached statement", () => {
+    const props = getStatementDetailsPropsFixture(false);
+    props.latestQuery = "";
+    props.latestFormattedQuery = "";
+    return <StatementDetails {...props} />;
   });

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -9,7 +9,8 @@
 // licenses/APL.txt.
 
 import { Col, Row, Tabs } from "antd";
-import { Text, Heading } from "@cockroachlabs/ui-components";
+import { Text, Heading, InlineAlert } from "@cockroachlabs/ui-components";
+import { PageConfig, PageConfigItem } from "src/pageConfig";
 import _ from "lodash";
 import React, { ReactNode } from "react";
 import { Helmet } from "react-helmet";
@@ -19,6 +20,7 @@ import { format as d3Format } from "d3-format";
 import { ArrowLeft } from "@cockroachlabs/icons";
 import { cockroach, google } from "@cockroachlabs/crdb-protobuf-client";
 import Long from "long";
+import { Location } from "history";
 
 import {
   NumericStat,
@@ -31,10 +33,8 @@ import {
   formatNumberForDisplay,
   unique,
   queryByName,
-  getMatchParamByName,
   appAttr,
   appNamesAttr,
-  statementAttr,
   RenderCount,
 } from "src/util";
 import { Loading } from "src/loading";
@@ -57,8 +57,12 @@ import { commonStyles } from "src/common";
 import { NodeSummaryStats } from "../nodes";
 import { UIConfigState } from "../store";
 import moment from "moment";
-import { TimeScale, toRoundedDateRange } from "../timeScaleDropdown";
 import { StatementDetailsRequest } from "src/api/statementsApi";
+import {
+  TimeScale,
+  TimeScaleDropdown,
+  toRoundedDateRange,
+} from "../timeScaleDropdown";
 import SQLActivityError from "../sqlActivity/errorComponent";
 import {
   ActivateDiagnosticsModalRef,
@@ -76,7 +80,7 @@ export interface Fraction {
 }
 
 export type StatementDetailsProps = StatementDetailsOwnProps &
-  RouteComponentProps;
+  RouteComponentProps<{ implicitTxn: string; statement: string }>;
 
 export interface StatementDetailsState {
   sortSetting: SortSetting;
@@ -130,6 +134,7 @@ export interface StatementDetailsDispatchProps {
   ) => void;
   dismissStatementDiagnosticsAlertMessage?: () => void;
   onTabChanged?: (tabName: string) => void;
+  onTimeScaleChange: (ts: TimeScale) => void;
   onDiagnosticsModalOpen?: (statementFingerprint: string) => void;
   onDiagnosticBundleDownload?: (statementFingerprint?: string) => void;
   onDiagnosticCancelRequest?: (report: IStatementDiagnosticsReport) => void;
@@ -139,10 +144,16 @@ export interface StatementDetailsDispatchProps {
     ascending: boolean,
   ) => void;
   onBackToStatementsClick?: () => void;
+  onStatementDetailsQueryChange: (query: string) => void;
+  onStatementDetailsFormattedQueryChange: (formattedQuery: string) => void;
 }
 
 export interface StatementDetailsStateProps {
+  statementFingerprintID: string;
   statementDetails: StatementDetailsResponse;
+  isLoading: boolean;
+  latestQuery: string;
+  latestFormattedQuery: string;
   statementsError: Error | null;
   timeScale: TimeScale;
   nodeNames: { [nodeId: string]: string };
@@ -160,18 +171,15 @@ const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortedTableStyles);
 const summaryCardStylesCx = classNames.bind(summaryCardStyles);
 
-function statementDetailsRequestFromProps(
-  props: StatementDetailsProps,
+function getStatementDetailsRequest(
+  timeScale: TimeScale,
+  statementFingerprintID: string,
+  location: Location,
 ): cockroach.server.serverpb.StatementDetailsRequest {
-  const [start, end] = toRoundedDateRange(props.timeScale);
-  const statementFingerprintID = getMatchParamByName(
-    props.match,
-    statementAttr,
-  );
-
+  const [start, end] = toRoundedDateRange(timeScale);
   return new cockroach.server.serverpb.StatementDetailsRequest({
     fingerprint_id: statementFingerprintID,
-    app_names: queryByName(props.location, appNamesAttr)?.split(","),
+    app_names: queryByName(location, appNamesAttr)?.split(","),
     start: Long.fromNumber(start.unix()),
     end: Long.fromNumber(end.unix()),
   });
@@ -321,6 +329,9 @@ export class StatementDetails extends React.Component<
     hasViewActivityRedactedRole: false,
   };
 
+  hasDiagnosticReports = (): boolean =>
+    this.props.diagnosticsReports.length > 0;
+
   changeSortSetting = (ss: SortSetting): void => {
     this.setState({
       sortSetting: ss,
@@ -330,13 +341,25 @@ export class StatementDetails extends React.Component<
     }
   };
 
-  refreshStatementDetails = (): void => {
-    const req = statementDetailsRequestFromProps(this.props);
+  refreshStatementDetails = (
+    timeScale: TimeScale,
+    statementFingerprintID: string,
+    location: Location,
+  ): void => {
+    const req = getStatementDetailsRequest(
+      timeScale,
+      statementFingerprintID,
+      location,
+    );
     this.props.refreshStatementDetails(req);
   };
 
   componentDidMount(): void {
-    this.refreshStatementDetails();
+    this.refreshStatementDetails(
+      this.props.timeScale,
+      this.props.statementFingerprintID,
+      this.props.location,
+    );
     this.props.refreshUserSQLRoles();
     if (!this.props.isTenant) {
       this.props.refreshNodes();
@@ -347,14 +370,60 @@ export class StatementDetails extends React.Component<
     }
   }
 
-  componentDidUpdate(): void {
-    this.refreshStatementDetails();
+  componentDidUpdate(prevProps: StatementDetailsProps): void {
+    if (
+      prevProps.timeScale != this.props.timeScale ||
+      prevProps.statementFingerprintID != this.props.statementFingerprintID ||
+      prevProps.location != this.props.location
+    ) {
+      this.refreshStatementDetails(
+        this.props.timeScale,
+        this.props.statementFingerprintID,
+        this.props.location,
+      );
+    }
+
     if (!this.props.isTenant) {
       this.props.refreshNodes();
       this.props.refreshNodesLiveness();
       if (!this.props.hasViewActivityRedactedRole) {
         this.props.refreshStatementDiagnosticsRequests();
       }
+    }
+
+    // If new, non-empty-string query text is available (derived from the statement details response),
+    // cache the query text.
+    if (
+      this.props.statementDetails &&
+      this.props.statementDetails.statement.metadata.query != "" &&
+      this.props.latestQuery !=
+        this.props.statementDetails.statement.metadata.query
+    ) {
+      this.props.onStatementDetailsQueryChange(
+        this.props.statementDetails.statement.metadata.query,
+      );
+    }
+
+    // If a new, non-empty-string formatted query text is available (derived from the statement details response),
+    // cache the query text.
+    if (
+      this.props.statementDetails &&
+      this.props.statementDetails.statement.metadata.formatted_query != "" &&
+      this.props.latestFormattedQuery !=
+        this.props.statementDetails.statement.metadata.formatted_query
+    ) {
+      this.props.onStatementDetailsFormattedQueryChange(
+        this.props.statementDetails.statement.metadata.formatted_query,
+      );
+    }
+
+    // If the statementFingerprintID (derived from the URL) changes, invalidate the cached query texts.
+    // This is necessary for when the new statementFingerprintID does not have data for the given time frame.
+    // The new query text and the formatted query text would be an empty string, and we need to invalidate the old
+    // query text and formatted query text.
+    if (this.props.statementFingerprintID != prevProps.statementFingerprintID) {
+      this.props.onStatementDetailsQueryChange("");
+      this.props.onStatementDetailsFormattedQueryChange("");
     }
   }
 
@@ -406,10 +475,10 @@ export class StatementDetails extends React.Component<
         </div>
         <section className={cx("section", "section--container")}>
           <Loading
-            loading={_.isNil(this.props.statementDetails)}
+            loading={this.props.isLoading}
             page={"statement details"}
             error={this.props.statementsError}
-            render={this.renderContent}
+            render={this.renderTabs}
             renderError={() =>
               SQLActivityError({
                 statsType: "statements",
@@ -427,23 +496,91 @@ export class StatementDetails extends React.Component<
     );
   }
 
-  renderContent = (): React.ReactElement => {
-    const {
-      diagnosticsReports,
-      dismissStatementDiagnosticsAlertMessage,
-      onDiagnosticBundleDownload,
-      onDiagnosticCancelRequest,
-      nodeRegions,
-      isTenant,
-      hasViewActivityRedactedRole,
-    } = this.props;
+  renderTabs = (): React.ReactElement => {
     const { currentTab } = this.state;
-    const { statement_statistics_per_plan_hash } = this.props.statementDetails;
+    const { stats } = this.props.statementDetails.statement;
+
+    const hasData = Number(stats.count) > 0;
+
+    return (
+      <Tabs
+        defaultActiveKey="1"
+        className={commonStyles("cockroach--tabs")}
+        onChange={this.onTabChange}
+        activeKey={currentTab}
+      >
+        <TabPane tab="Overview" key="overview">
+          {this.renderOverviewTabContent(hasData)}
+        </TabPane>
+        <TabPane tab="Explain Plans" key="explain-plan">
+          {this.renderExplainPlanTabContent(hasData)}
+        </TabPane>
+        {!this.props.isTenant && !this.props.hasViewActivityRedactedRole && (
+          <TabPane
+            tab={`Diagnostics${
+              this.hasDiagnosticReports()
+                ? ` (${this.props.diagnosticsReports.length})`
+                : ""
+            }`}
+            key="diagnostics"
+          >
+            {this.renderDiagnosticsTabContent(hasData)}
+          </TabPane>
+        )}
+        <TabPane
+          tab="Execution Stats"
+          key="execution-stats"
+          className={cx("fit-content-width")}
+        >
+          {this.renderExecutionStatsTabContent(hasData)}
+        </TabPane>
+      </Tabs>
+    );
+  };
+
+  renderNoDataTabContent = (): React.ReactElement => (
+    <section className={cx("section")}>
+      <InlineAlert intent="info" title="No data available." />
+    </section>
+  );
+
+  renderNoDataWithTimeScaleAndSqlBoxTabContent = (): React.ReactElement => (
+    <>
+      <PageConfig>
+        <PageConfigItem>
+          <TimeScaleDropdown
+            currentScale={this.props.timeScale}
+            setTimeScale={this.props.onTimeScaleChange}
+          />
+        </PageConfigItem>
+      </PageConfig>
+      <section className={cx("section")}>
+        {this.props.latestFormattedQuery && (
+          <Row gutter={24}>
+            <Col className="gutter-row" span={24}>
+              <SqlBox
+                value={this.props.latestFormattedQuery}
+                size={SqlBoxSize.small}
+              />
+            </Col>
+          </Row>
+        )}
+        <InlineAlert
+          intent="info"
+          title="Data not available for this time frame. Select a different time frame."
+        />
+      </section>
+    </>
+  );
+
+  renderOverviewTabContent = (hasData: boolean): React.ReactElement => {
+    if (!hasData) {
+      return this.renderNoDataWithTimeScaleAndSqlBoxTabContent();
+    }
+    const { nodeRegions, isTenant } = this.props;
     const { stats } = this.props.statementDetails.statement;
     const {
       app_names,
-      formatted_query,
-      query,
       databases,
       dist_sql_count,
       failed_count,
@@ -453,34 +590,7 @@ export class StatementDetails extends React.Component<
       implicit_txn,
     } = this.props.statementDetails.statement.metadata;
 
-    if (Number(stats.count) == 0) {
-      const sourceApp = queryByName(this.props.location, appAttr);
-      const listUrl =
-        "/sql-activity?tab=Statements" +
-        (sourceApp ? "&" + appAttr + "=" + sourceApp : "");
-
-      return (
-        <React.Fragment>
-          <section className={cx("section")}>
-            <h3>Unable to find statement</h3>
-            There are no execution statistics for this statement.{" "}
-            <Link className={cx("back-link")} to={listUrl}>
-              Back to Statements
-            </Link>
-          </section>
-        </React.Fragment>
-      );
-    }
-
-    const count = FixLong(stats.count).toInt();
     const { statement } = this.props.statementDetails;
-    const {
-      parseBarChart,
-      planBarChart,
-      runBarChart,
-      overheadBarChart,
-      overallBarChart,
-    } = latencyBreakdown(statement);
 
     const totalCountBarChart = longToInt(statement.stats.count);
     const firstAttemptsBarChart = longToInt(
@@ -497,7 +607,6 @@ export class StatementDetails extends React.Component<
     ).sort();
 
     const duration = (v: number) => Duration(v * 1e9);
-    const hasDiagnosticReports = diagnosticsReports.length > 0;
     const lastExec =
       stats.last_exec_timestamp &&
       moment(stats.last_exec_timestamp.seconds.low * 1e3).format(
@@ -524,18 +633,23 @@ export class StatementDetails extends React.Component<
     ) : (
       <Text className={cx("app-name", "app-name__unset")}>(unset)</Text>
     );
-
     return (
-      <Tabs
-        defaultActiveKey="1"
-        className={commonStyles("cockroach--tabs")}
-        onChange={this.onTabChange}
-        activeKey={currentTab}
-      >
-        <TabPane tab="Overview" key="overview">
+      <>
+        <PageConfig>
+          <PageConfigItem>
+            <TimeScaleDropdown
+              currentScale={this.props.timeScale}
+              setTimeScale={this.props.onTimeScaleChange}
+            />
+          </PageConfigItem>
+        </PageConfig>
+        <section className={cx("section")}>
           <Row gutter={24}>
             <Col className="gutter-row" span={24}>
-              <SqlBox value={formatted_query} size={SqlBoxSize.small} />
+              <SqlBox
+                value={this.props.latestFormattedQuery}
+                size={SqlBoxSize.small}
+              />
             </Col>
           </Row>
           <Row gutter={24}>
@@ -749,8 +863,28 @@ export class StatementDetails extends React.Component<
               </SummaryCard>
             </Col>
           </Row>
-        </TabPane>
-        <TabPane tab="Explain Plans" key="explain-plan">
+        </section>
+      </>
+    );
+  };
+
+  renderExplainPlanTabContent = (hasData: boolean): React.ReactElement => {
+    if (!hasData) {
+      return this.renderNoDataWithTimeScaleAndSqlBoxTabContent();
+    }
+    const { statement_statistics_per_plan_hash } = this.props.statementDetails;
+    const { formatted_query } = this.props.statementDetails.statement.metadata;
+    return (
+      <>
+        <PageConfig>
+          <PageConfigItem>
+            <TimeScaleDropdown
+              currentScale={this.props.timeScale}
+              setTimeScale={this.props.onTimeScaleChange}
+            />
+          </PageConfigItem>
+        </PageConfig>
+        <section className={cx("section")}>
           <Row gutter={24}>
             <Col className="gutter-row" span={24}>
               <SqlBox value={formatted_query} size={SqlBoxSize.small} />
@@ -758,133 +892,144 @@ export class StatementDetails extends React.Component<
           </Row>
           <p className={summaryCardStylesCx("summary--card__divider")} />
           <PlanDetails plans={statement_statistics_per_plan_hash} />
-        </TabPane>
-        {!isTenant && !hasViewActivityRedactedRole && (
-          <TabPane
-            tab={`Diagnostics ${
-              hasDiagnosticReports ? `(${diagnosticsReports.length})` : ""
-            }`}
-            key="diagnostics"
+        </section>
+      </>
+    );
+  };
+
+  renderDiagnosticsTabContent = (hasData: boolean): React.ReactElement => {
+    if (!hasData && !this.props.latestQuery) {
+      return this.renderNoDataTabContent();
+    }
+
+    return (
+      <DiagnosticsView
+        activateDiagnosticsRef={this.activateDiagnosticsRef}
+        diagnosticsReports={this.props.diagnosticsReports}
+        dismissAlertMessage={this.props.dismissStatementDiagnosticsAlertMessage}
+        hasData={this.hasDiagnosticReports()}
+        statementFingerprint={this.props.latestQuery}
+        onDownloadDiagnosticBundleClick={this.props.onDiagnosticBundleDownload}
+        onDiagnosticCancelRequestClick={this.props.onDiagnosticCancelRequest}
+        showDiagnosticsViewLink={
+          this.props.uiConfig.showStatementDiagnosticsLink
+        }
+        onSortingChange={this.props.onSortingChange}
+      />
+    );
+  };
+
+  renderExecutionStatsTabContent = (hasData: boolean): React.ReactElement => {
+    if (!hasData) {
+      return this.renderNoDataTabContent();
+    }
+    const { stats } = this.props.statementDetails.statement;
+
+    const count = FixLong(stats.count).toInt();
+    const { statement } = this.props.statementDetails;
+    const {
+      parseBarChart,
+      planBarChart,
+      runBarChart,
+      overheadBarChart,
+      overallBarChart,
+    } = latencyBreakdown(statement);
+    return (
+      <>
+        <SummaryCard>
+          <h3
+            className={classNames(
+              commonStyles("base-heading"),
+              summaryCardStylesCx("summary--card__title"),
+            )}
           >
-            <DiagnosticsView
-              activateDiagnosticsRef={this.activateDiagnosticsRef}
-              diagnosticsReports={diagnosticsReports}
-              dismissAlertMessage={dismissStatementDiagnosticsAlertMessage}
-              hasData={hasDiagnosticReports}
-              statementFingerprint={query}
-              onDownloadDiagnosticBundleClick={onDiagnosticBundleDownload}
-              onDiagnosticCancelRequestClick={onDiagnosticCancelRequest}
-              showDiagnosticsViewLink={
-                this.props.uiConfig.showStatementDiagnosticsLink
+            Execution Latency By Phase
+            <div className={cx("numeric-stats-table__tooltip")}>
+              <Tooltip content="The execution latency of this statement, broken down by phase.">
+                <div className={cx("numeric-stats-table__tooltip-hover-area")}>
+                  <div className={cx("numeric-stats-table__info-icon")}>i</div>
+                </div>
+              </Tooltip>
+            </div>
+          </h3>
+          <NumericStatTable
+            title="Phase"
+            measure="Latency"
+            count={count}
+            format={(v: number) => Duration(v * 1e9)}
+            rows={[
+              { name: "Parse", value: stats.parse_lat, bar: parseBarChart },
+              { name: "Plan", value: stats.plan_lat, bar: planBarChart },
+              { name: "Run", value: stats.run_lat, bar: runBarChart },
+              {
+                name: "Overhead",
+                value: stats.overhead_lat,
+                bar: overheadBarChart,
+              },
+              {
+                name: "Overall",
+                summary: true,
+                value: stats.service_lat,
+                bar: overallBarChart,
+              },
+            ]}
+          />
+        </SummaryCard>
+        <SummaryCard>
+          <h3
+            className={classNames(
+              commonStyles("base-heading"),
+              summaryCardStylesCx("summary--card__title"),
+            )}
+          >
+            Other Execution Statistics
+          </h3>
+          <NumericStatTable
+            title="Stat"
+            measure="Quantity"
+            count={count}
+            format={d3Format(".2f")}
+            rows={[
+              {
+                name: "Rows Read",
+                value: stats.rows_read,
+                bar: genericBarChart(stats.rows_read, stats.count),
+              },
+              {
+                name: "Disk Bytes Read",
+                value: stats.bytes_read,
+                bar: genericBarChart(stats.bytes_read, stats.count, Bytes),
+                format: Bytes,
+              },
+              {
+                name: "Rows Written",
+                value: stats.rows_written,
+                bar: genericBarChart(stats.rows_written, stats.count),
+              },
+              {
+                name: "Network Bytes Sent",
+                value: stats.exec_stats.network_bytes,
+                bar: genericBarChart(
+                  stats.exec_stats.network_bytes,
+                  stats.exec_stats.count,
+                  Bytes,
+                ),
+                format: Bytes,
+              },
+            ].filter(function(r) {
+              if (
+                r.name === "Network Bytes Sent" &&
+                r.value &&
+                r.value.mean === 0
+              ) {
+                // Omit if empty.
+                return false;
               }
-              onSortingChange={this.props.onSortingChange}
-            />
-          </TabPane>
-        )}
-        <TabPane
-          tab="Execution Stats"
-          key="execution-stats"
-          className={cx("fit-content-width")}
-        >
-          <SummaryCard>
-            <h3
-              className={classNames(
-                commonStyles("base-heading"),
-                summaryCardStylesCx("summary--card__title"),
-              )}
-            >
-              Execution Latency By Phase
-              <div className={cx("numeric-stats-table__tooltip")}>
-                <Tooltip content="The execution latency of this statement, broken down by phase.">
-                  <div
-                    className={cx("numeric-stats-table__tooltip-hover-area")}
-                  >
-                    <div className={cx("numeric-stats-table__info-icon")}>
-                      i
-                    </div>
-                  </div>
-                </Tooltip>
-              </div>
-            </h3>
-            <NumericStatTable
-              title="Phase"
-              measure="Latency"
-              count={count}
-              format={(v: number) => Duration(v * 1e9)}
-              rows={[
-                { name: "Parse", value: stats.parse_lat, bar: parseBarChart },
-                { name: "Plan", value: stats.plan_lat, bar: planBarChart },
-                { name: "Run", value: stats.run_lat, bar: runBarChart },
-                {
-                  name: "Overhead",
-                  value: stats.overhead_lat,
-                  bar: overheadBarChart,
-                },
-                {
-                  name: "Overall",
-                  summary: true,
-                  value: stats.service_lat,
-                  bar: overallBarChart,
-                },
-              ]}
-            />
-          </SummaryCard>
-          <SummaryCard>
-            <h3
-              className={classNames(
-                commonStyles("base-heading"),
-                summaryCardStylesCx("summary--card__title"),
-              )}
-            >
-              Other Execution Statistics
-            </h3>
-            <NumericStatTable
-              title="Stat"
-              measure="Quantity"
-              count={count}
-              format={d3Format(".2f")}
-              rows={[
-                {
-                  name: "Rows Read",
-                  value: stats.rows_read,
-                  bar: genericBarChart(stats.rows_read, stats.count),
-                },
-                {
-                  name: "Disk Bytes Read",
-                  value: stats.bytes_read,
-                  bar: genericBarChart(stats.bytes_read, stats.count, Bytes),
-                  format: Bytes,
-                },
-                {
-                  name: "Rows Written",
-                  value: stats.rows_written,
-                  bar: genericBarChart(stats.rows_written, stats.count),
-                },
-                {
-                  name: "Network Bytes Sent",
-                  value: stats.exec_stats.network_bytes,
-                  bar: genericBarChart(
-                    stats.exec_stats.network_bytes,
-                    stats.exec_stats.count,
-                    Bytes,
-                  ),
-                  format: Bytes,
-                },
-              ].filter(function(r) {
-                if (
-                  r.name === "Network Bytes Sent" &&
-                  r.value &&
-                  r.value.mean === 0
-                ) {
-                  // Omit if empty.
-                  return false;
-                }
-                return r.value;
-              })}
-            />
-          </SummaryCard>
-        </TabPane>
-      </Tabs>
+              return r.value;
+            })}
+          />
+        </SummaryCard>
+      </>
     );
   };
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
@@ -30,6 +30,7 @@ import {
   nodeRegionsByIDSelector,
 } from "../store/nodes";
 import { actions as sqlDetailsStatsActions } from "src/store/statementDetails";
+import { actions as sqlStatsActions } from "src/store/sqlStats";
 import {
   actions as statementDiagnosticsActions,
   selectDiagnosticsReportsByStatementFingerprint,
@@ -41,6 +42,8 @@ import { actions as nodeLivenessActions } from "../store/liveness";
 import { selectTimeScale } from "../statementsPage/statementsPage.selectors";
 import { cockroach, google } from "@cockroachlabs/crdb-protobuf-client";
 import { StatementDetailsRequest } from "../api";
+import { TimeScale } from "../timeScaleDropdown";
+import { getMatchParamByName, statementAttr } from "../util";
 type IDuration = google.protobuf.IDuration;
 type IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosticsReport;
 
@@ -53,10 +56,13 @@ const CancelStatementDiagnosticsReportRequest =
 // For tenant cases, we don't show information about node, regions and
 // diagnostics.
 const mapStateToProps = (state: AppState, props: RouteComponentProps) => {
-  const statementDetails = selectStatementDetails(state, props);
-  const statementFingerprint = statementDetails?.statement.metadata.query;
+  const { statementDetails, isLoading } = selectStatementDetails(state, props);
   return {
+    statementFingerprintID: getMatchParamByName(props.match, statementAttr),
     statementDetails,
+    isLoading: isLoading,
+    latestQuery: state.adminUI.sqlDetailsStats.latestQuery,
+    latestFormattedQuery: state.adminUI.sqlDetailsStats.latestFormattedQuery,
     statementsError: state.adminUI.sqlStats.lastError,
     timeScale: selectTimeScale(state),
     nodeNames: selectIsTenant(state) ? {} : nodeDisplayNameByIDSelector(state),
@@ -66,7 +72,7 @@ const mapStateToProps = (state: AppState, props: RouteComponentProps) => {
         ? []
         : selectDiagnosticsReportsByStatementFingerprint(
             state,
-            statementFingerprint,
+            state.adminUI.sqlDetailsStats.latestQuery,
           ),
     uiConfig: selectStatementDetailsUiConfig(state),
     isTenant: selectIsTenant(state),
@@ -84,6 +90,13 @@ const mapDispatchToProps = (
   refreshNodes: () => dispatch(nodesActions.refresh()),
   refreshNodesLiveness: () => dispatch(nodeLivenessActions.refresh()),
   refreshUserSQLRoles: () => dispatch(uiConfigActions.refreshUserSQLRoles()),
+  onTimeScaleChange: (ts: TimeScale) => {
+    dispatch(
+      sqlStatsActions.updateTimeScale({
+        ts: ts,
+      }),
+    );
+  },
   dismissStatementDiagnosticsAlertMessage: () =>
     dispatch(
       localStorageActions.update({
@@ -143,6 +156,14 @@ const mapDispatchToProps = (
         page: "Statement Details",
         action: "Cancelled",
       }),
+    );
+  },
+  onStatementDetailsQueryChange: (latestQuery: string) => {
+    dispatch(sqlDetailsStatsActions.setLatestQuery(latestQuery));
+  },
+  onStatementDetailsFormattedQueryChange: (latestFormattedQuery: string) => {
+    dispatch(
+      sqlDetailsStatsActions.setLatestFormattedQuery(latestFormattedQuery),
     );
   },
   onSortingChange: (tableName, columnName) =>

--- a/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.reducer.ts
@@ -14,7 +14,7 @@ import { DOMAIN_NAME } from "../utils";
 import { StatementsRequest } from "src/api/statementsApi";
 import { TimeScale } from "../../timeScaleDropdown";
 
-type StatementsResponse = cockroach.server.serverpb.StatementsResponse;
+export type StatementsResponse = cockroach.server.serverpb.StatementsResponse;
 
 export type SQLStatsState = {
   data: StatementsResponse;

--- a/pkg/ui/workspaces/cluster-ui/src/store/statementDetails/statementDetails.sagas.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/statementDetails/statementDetails.sagas.spec.ts
@@ -26,7 +26,7 @@ import {
 import {
   actions,
   reducer,
-  SQLDetailsStatsState,
+  SQLDetailsStatsReducerState,
 } from "./statementDetails.reducer";
 export type StatementDetailsRequest = cockroach.server.serverpb.StatementDetailsRequest;
 
@@ -657,12 +657,17 @@ describe("SQLDetailsStats sagas", () => {
           }),
         )
         .withReducer(reducer)
-        .hasFinalState<Record<string, SQLDetailsStatsState>>({
-          "SELECT * FROM crdb_internal.node_build_info/$ cockroach sql,newname/0/0": {
-            data: SQLDetailsStatsResponse,
-            lastError: null,
-            valid: true,
+        .hasFinalState<SQLDetailsStatsReducerState>({
+          cachedData: {
+            "SELECT * FROM crdb_internal.node_build_info/$ cockroach sql,newname/0/0": {
+              data: SQLDetailsStatsResponse,
+              lastError: null,
+              valid: true,
+              inFlight: false,
+            },
           },
+          latestQuery: "",
+          latestFormattedQuery: "",
         })
         .run();
     });
@@ -678,12 +683,17 @@ describe("SQLDetailsStats sagas", () => {
           }),
         )
         .withReducer(reducer)
-        .hasFinalState<Record<string, SQLDetailsStatsState>>({
-          "SELECT * FROM crdb_internal.node_build_info/$ cockroach sql,newname/0/0": {
-            data: null,
-            lastError: error,
-            valid: false,
+        .hasFinalState<SQLDetailsStatsReducerState>({
+          cachedData: {
+            "SELECT * FROM crdb_internal.node_build_info/$ cockroach sql,newname/0/0": {
+              data: null,
+              lastError: error,
+              valid: false,
+              inFlight: false,
+            },
           },
+          latestQuery: "",
+          latestFormattedQuery: "",
         })
         .run();
     });

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.fixture.ts
@@ -14,615 +14,524 @@ import { createMemoryHistory } from "history";
 import Long from "long";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
 import { TimeScale } from "../timeScaleDropdown";
+import { StatementsResponse } from "src/store/sqlStats/sqlStats.reducer";
 
 const history = createMemoryHistory({ initialEntries: ["/transactions"] });
 const timestamp = new protos.google.protobuf.Timestamp({
   seconds: new Long(Date.parse("Nov 26 2021 01:00:00 GMT") * 1e-3),
 });
-const timestampString = TimestampToString(timestamp);
+export const transactionFingerprintId = new Long(3632089240731979669);
 
 export const routeProps = {
   history,
   location: {
-    pathname: `/transaction/${timestampString}/3632089240731979669`,
+    pathname: `/transaction/${transactionFingerprintId}`,
     search: "",
     hash: "",
     state: {},
   },
   match: {
-    path: "/transaction/:aggregated_ts/:txn_fingerprint_id",
-    url: `/transaction/${timestampString}/3632089240731979669`,
+    path: "/transaction/:txn_fingerprint_id",
+    url: `/transaction/${transactionFingerprintId}`,
     isExact: true,
     params: {
-      aggregated_ts: timestampString,
-      txn_fingerprint_id: "3632089240731979669",
+      txn_fingerprint_id: transactionFingerprintId,
+    },
+  },
+};
+export const nodeRegions = {
+  "1": "gcp-us-east1",
+  "2": "gcp-us-east1",
+  "3": "gcp-us-west1",
+  "4": "gcp-europe-west1",
+};
+
+export const error = new RequestError(
+  "Forbidden",
+  403,
+  "this operation requires admin privilege",
+);
+
+export const transaction = {
+  stats_data: {
+    statement_fingerprint_ids: [
+      new Long(4176684928840388768),
+      new Long(18377382163116490400),
+    ],
+    app: "$ cockroach sql",
+    stats: {
+      count: new Long(1),
+      max_retries: new Long(0),
+      num_rows: {
+        mean: 6,
+        squared_diffs: 0,
+      },
+      service_lat: {
+        mean: 0.001121754,
+        squared_diffs: 0,
+      },
+      retry_lat: {
+        mean: 0,
+        squared_diffs: 0,
+      },
+      commit_lat: {
+        mean: 0.000021931,
+        squared_diffs: 0,
+      },
+      bytes_read: {
+        mean: 0,
+        squared_diffs: 0,
+      },
+      rows_read: {
+        mean: 0,
+        squared_diffs: 0,
+      },
+      exec_stats: {
+        count: new Long(1),
+        network_bytes: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        max_mem_usage: {
+          mean: 10240,
+          squared_diffs: 0,
+        },
+        contention_time: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        network_messages: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        max_disk_usage: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+      },
+      rows_written: {
+        mean: 0,
+        squared_diffs: 0,
+      },
+    },
+    aggregated_ts: timestamp,
+    transaction_fingerprint_id: transactionFingerprintId,
+    aggregation_interval: {
+      seconds: new Long(3600),
     },
   },
 };
 
-export const transactionDetails = {
-  data: {
-    statements: [
-      {
-        label:
-          "WITH deleted_sessions AS (DELETE FROM sqlliveness WHERE expiration < $1 RETURNING session_id) SELECT count(*) FROM deleted_sessions",
-        key: {
-          key_data: {
-            id: "673bf9d0055bbae332ad497072db9bbf",
-            query:
-              "WITH deleted_sessions AS (DELETE FROM sqlliveness WHERE expiration < $1 RETURNING session_id) SELECT count(*) FROM deleted_sessions",
-            app: "$ internal-delete-sessions",
-            distSQL: false,
-            failed: false,
-            opt: true,
-            implicit_txn: true,
-            vec: false,
-          },
-          node_id: 1,
+export const transactionDetailsData: StatementsResponse = {
+  toJSON: () => ({}),
+  statements: [
+    {
+      key: {
+        key_data: {
+          query: "SELECT * FROM crdb_internal.node_build_info",
+          app: "$ cockroach sql",
+          distSQL: false,
+          failed: false,
+          implicit_txn: true,
+          vec: true,
+          full_scan: false,
+          database: "movr",
+          plan_hash: new Long(0),
+          transaction_fingerprint_id: transactionFingerprintId,
+          query_summary: "SELECT * FROM crdb_internal.node_build_info",
         },
-        stats: {
-          count: "164",
-          first_attempt_count: "164",
-          max_retries: "0",
-          legacy_last_err: "",
-          num_rows: { mean: 0, squared_diffs: 0 },
-          parse_lat: { mean: 0, squared_diffs: 0 },
-          plan_lat: {
-            mean: 0.0017302560975609757,
-            squared_diffs: 0.027190766097243916,
-          },
-          run_lat: {
-            mean: 0.0010671524390243902,
-            squared_diffs: 0.0024573014511890235,
-          },
-          service_lat: {
-            mean: 0.011479207317073171,
-            squared_diffs: 1.822788002048951,
-          },
-          overhead_lat: {
-            mean: 0.0086817987804878,
-            squared_diffs: 1.38481972086236,
-          },
-          legacy_last_err_redacted: "",
-          sensitive_info: {
-            last_err: "",
-            most_recent_plan_description: {
-              name: "root",
-              children: [
-                {
-                  name: "group (scalar)",
-                  children: [
-                    {
-                      name: "scan buffer",
-                      attrs: [
-                        { key: "label", value: "buffer 1 (deleted_sessions)" },
-                      ],
-                    },
-                  ],
-                },
-                {
-                  name: "subquery",
-                  attrs: [
-                    { key: "id", value: "@S1" },
-                    {
-                      key: "original sql",
-                      value:
-                        "DELETE FROM sqlliveness WHERE expiration < $1 RETURNING session_id",
-                    },
-                    { key: "exec mode", value: "all rows" },
-                  ],
-                  children: [
-                    {
-                      name: "buffer",
-                      attrs: [
-                        { key: "label", value: "buffer 1 (deleted_sessions)" },
-                      ],
-                      children: [
-                        {
-                          name: "delete",
-                          attrs: [{ key: "from", value: "sqlliveness" }],
-                          children: [
-                            {
-                              name: "filter",
-                              attrs: [
-                                { key: "filter", value: "expiration < _" },
-                              ],
-                              children: [
-                                {
-                                  name: "scan",
-                                  attrs: [
-                                    { key: "missing stats", value: "" },
-                                    {
-                                      key: "table",
-                                      value: "sqlliveness@primary",
-                                    },
-                                    { key: "spans", value: "FULL SCAN" },
-                                  ],
-                                },
-                              ],
-                            },
-                          ],
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-            most_recent_plan_timestamp: {
-              seconds: "1598943488",
-              nanos: 956814000,
-            },
-          },
-          bytes_read: { mean: 0, squared_diffs: 0 },
-          rows_read: { mean: 0, squared_diffs: 0 },
-          rows_written: { mean: 1, squared_diffs: 0.99 },
+        aggregated_ts: timestamp,
+        aggregation_interval: {
+          seconds: new Long(3600),
         },
       },
-      {
-        label: 'SELECT "generated" FROM system.reports_meta WHERE id = $1',
-        key: {
-          key_data: {
-            id: "60d2c10043884cb136674a449007bc52",
-            query: 'SELECT "generated" FROM system.reports_meta WHERE id = $1',
-            app: "$ internal-get-previous-timestamp",
-            distSQL: false,
-            failed: false,
-            opt: true,
-            implicit_txn: false,
-            vec: false,
-          },
-          node_id: 1,
+      stats: {
+        count: new Long(1),
+        first_attempt_count: new Long(1),
+        max_retries: new Long(0),
+        legacy_last_err: "",
+        num_rows: {
+          mean: 6,
+          squared_diffs: 0,
         },
-        stats: {
-          count: "165",
-          first_attempt_count: "165",
-          max_retries: "0",
-          legacy_last_err: "",
-          num_rows: { mean: 0, squared_diffs: 0 },
-          parse_lat: { mean: 0, squared_diffs: 0 },
-          plan_lat: {
-            mean: 0.0010962727272727276,
-            squared_diffs: 0.0002159174727272727,
+        parse_lat: {
+          mean: 0.00017026,
+          squared_diffs: 0,
+        },
+        plan_lat: {
+          mean: 0.000188651,
+          squared_diffs: 0,
+        },
+        run_lat: {
+          mean: 0.000255685,
+          squared_diffs: 0,
+        },
+        service_lat: {
+          mean: 0.000629367,
+          squared_diffs: 0,
+        },
+        overhead_lat: {
+          mean: 0.000014771000000000012,
+          squared_diffs: 0,
+        },
+        legacy_last_err_redacted: "",
+        sensitive_info: {
+          last_err: "",
+          most_recent_plan_description: {
+            name: "virtual table",
+            attrs: [
+              {
+                key: "Table",
+                value: "node_build_info@primary",
+              },
+            ],
           },
-          run_lat: {
-            mean: 0.00037714545454545445,
-            squared_diffs: 0.00006664950650909095,
+          most_recent_plan_timestamp: {
+            seconds: new Long(-2135596800),
+          },
+        },
+        bytes_read: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        rows_read: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        exec_stats: {
+          count: new Long(1),
+          network_bytes: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          max_mem_usage: {
+            mean: 10240,
+            squared_diffs: 0,
+          },
+          contention_time: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          network_messages: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          max_disk_usage: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+        },
+        sql_type: "TypeDML",
+        last_exec_timestamp: {
+          seconds: new Long(1650591005),
+          nanos: 677408609,
+        },
+        nodes: [new Long(2)],
+        rows_written: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        plan_gists: ["AgH6////nxoAAA4AAAAGBg=="],
+      },
+      id: new Long(4176684928840388768),
+    },
+    {
+      key: {
+        key_data: {
+          query: "SET sql_safe_updates = _",
+          app: "$ cockroach sql",
+          distSQL: false,
+          failed: false,
+          implicit_txn: true,
+          vec: true,
+          full_scan: false,
+          database: "movr",
+          plan_hash: new Long(0),
+          transaction_fingerprint_id: new Long(5794495518355343743),
+          query_summary: "SET sql_safe_updates = _",
+        },
+        aggregated_ts: timestamp,
+        aggregation_interval: {
+          seconds: new Long(3600),
+        },
+      },
+      stats: {
+        count: new Long(1),
+        first_attempt_count: new Long(1),
+        max_retries: new Long(0),
+        legacy_last_err: "",
+        num_rows: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        parse_lat: {
+          mean: 0.000045175,
+          squared_diffs: 0,
+        },
+        plan_lat: {
+          mean: 0.000065382,
+          squared_diffs: 0,
+        },
+        run_lat: {
+          mean: 0.000131952,
+          squared_diffs: 0,
+        },
+        service_lat: {
+          mean: 0.000250045,
+          squared_diffs: 0,
+        },
+        overhead_lat: {
+          mean: 0.00000753599999999999,
+          squared_diffs: 0,
+        },
+        legacy_last_err_redacted: "",
+        sensitive_info: {
+          last_err: "",
+          most_recent_plan_description: {
+            name: "set",
+          },
+          most_recent_plan_timestamp: {
+            seconds: new Long(-2135596800),
+          },
+        },
+        bytes_read: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        rows_read: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        exec_stats: {
+          count: new Long(1),
+          network_bytes: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          max_mem_usage: {
+            mean: 10240,
+            squared_diffs: 0,
+          },
+          contention_time: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          network_messages: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          max_disk_usage: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+        },
+        sql_type: "TypeDCL",
+        last_exec_timestamp: {
+          seconds: new Long(1650591005),
+          nanos: 801046328,
+        },
+        nodes: [new Long(2)],
+        rows_written: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        plan_gists: ["Ais="],
+      },
+      id: new Long(18377382163116490400),
+    },
+    {
+      key: {
+        key_data: {
+          query: "SELECT * FROM users",
+          app: "$ cockroach sql",
+          distSQL: false,
+          failed: false,
+          implicit_txn: true,
+          vec: true,
+          full_scan: true,
+          database: "movr",
+          plan_hash: new Long(0),
+          transaction_fingerprint_id: new Long(13388351560861020642),
+          query_summary: "SELECT * FROM users",
+        },
+        aggregated_ts: timestamp,
+        aggregation_interval: {
+          seconds: new Long(3600),
+        },
+      },
+      stats: {
+        count: new Long(2),
+        first_attempt_count: new Long(2),
+        max_retries: new Long(0),
+        legacy_last_err: "",
+        num_rows: {
+          mean: 8,
+          squared_diffs: 0,
+        },
+        parse_lat: {
+          mean: 0.000066329,
+          squared_diffs: 6.509404999999994e-11,
+        },
+        plan_lat: {
+          mean: 0.0004147245,
+          squared_diffs: 7.797132564500002e-9,
+        },
+        run_lat: {
+          mean: 0.0036602285,
+          squared_diffs: 0.000005232790426512499,
+        },
+        service_lat: {
+          mean: 0.0041592605,
+          squared_diffs: 0.0000056896068047405,
+        },
+        overhead_lat: {
+          mean: 0.00001797850000000048,
+          squared_diffs: 1.9345445000014194e-12,
+        },
+        legacy_last_err_redacted: "",
+        sensitive_info: {
+          last_err: "",
+          most_recent_plan_description: {
+            name: "scan",
+            attrs: [
+              {
+                key: "Estimated Row Count",
+                value: "8 (100% of the table; stats collected 20 days ago)",
+              },
+              {
+                key: "Spans",
+                value: "FULL SCAN",
+              },
+              {
+                key: "Table",
+                value: "users@users_pkey",
+              },
+            ],
+          },
+          most_recent_plan_timestamp: {
+            seconds: new Long(-2135596800),
+          },
+        },
+        bytes_read: {
+          mean: 918,
+          squared_diffs: 0,
+        },
+        rows_read: {
+          mean: 8,
+          squared_diffs: 0,
+        },
+        exec_stats: {
+          count: new Long(2),
+          network_bytes: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          max_mem_usage: {
+            mean: 20480,
+            squared_diffs: 0,
+          },
+          contention_time: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          network_messages: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          max_disk_usage: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+        },
+        sql_type: "TypeDML",
+        last_exec_timestamp: {
+          seconds: new Long(1650591014),
+          nanos: 178832951,
+        },
+        nodes: [new Long(2)],
+        rows_written: {
+          mean: 0,
+          squared_diffs: 0,
+        },
+        plan_gists: ["AgHUAQIAHwAAAAYK"],
+      },
+      id: new Long(1634603821603440189),
+    },
+  ],
+  last_reset: {
+    seconds: new Long(1651000310),
+    nanos: 419008978,
+  },
+  internal_app_name_prefix: "$ internal",
+  transactions: [
+    transaction,
+    {
+      stats_data: {
+        statement_fingerprint_ids: [new Long(1634603821603440189)],
+        app: "$ cockroach sql",
+        stats: {
+          count: new Long(2),
+          max_retries: new Long(0),
+          num_rows: {
+            mean: 8,
+            squared_diffs: 0,
           },
           service_lat: {
-            mean: 0.00308030303030303,
-            squared_diffs: 0.0004142852428484848,
+            mean: 0.0047974385,
+            squared_diffs: 0.0000059061373681005006,
           },
-          overhead_lat: {
-            mean: 0.0016068848484848484,
-            squared_diffs: 0.00004782026481212121,
+          retry_lat: {
+            mean: 0,
+            squared_diffs: 0,
           },
-          legacy_last_err_redacted: "",
-          sensitive_info: {
-            last_err: "",
-            most_recent_plan_description: {
-              name: "scan",
-              attrs: [
-                { key: "missing stats", value: "" },
-                { key: "table", value: "reports_meta@primary" },
-                { key: "spans", value: "1 span" },
-              ],
-            },
-            most_recent_plan_timestamp: {
-              seconds: "1598943469",
-              nanos: 391020000,
-            },
+          commit_lat: {
+            mean: 0.000031955499999999996,
+            squared_diffs: 1.4620500000000385e-14,
           },
           bytes_read: {
-            mean: 37.87272727272729,
-            squared_diffs: 18.32727272727264,
+            mean: 918,
+            squared_diffs: 0,
           },
-          rows_read: { mean: 1, squared_diffs: 0 },
-          rows_written: { mean: 1, squared_diffs: 0.99 },
-        },
-      },
-      {
-        label:
-          'SELECT id, "parentID", "parentSchemaID", name FROM system.namespace',
-        key: {
-          key_data: {
-            id: "d469b9ad35098627c7bc28a0eca86f0a",
-            query:
-              'SELECT id, "parentID", "parentSchemaID", name FROM system.namespace',
-            app: "$ internal-get-all-names",
-            distSQL: false,
-            failed: false,
-            opt: true,
-            implicit_txn: false,
-            vec: false,
+          rows_read: {
+            mean: 8,
+            squared_diffs: 0,
           },
-          node_id: 1,
-        },
-        stats: {
-          count: "29",
-          first_attempt_count: "29",
-          max_retries: "0",
-          legacy_last_err: "",
-          num_rows: { mean: 0, squared_diffs: 0 },
-          parse_lat: {
-            mean: 0.0011247241379310346,
-            squared_diffs: 0.0002293455597931035,
-          },
-          plan_lat: {
-            mean: 0.0036076896551724123,
-            squared_diffs: 0.001673707710206896,
-          },
-          run_lat: {
-            mean: 0.0005267241379310345,
-            squared_diffs: 0.000006591083793103449,
-          },
-          service_lat: {
-            mean: 0.005386103448275863,
-            squared_diffs: 0.0018046449686896554,
-          },
-          overhead_lat: {
-            mean: 0.00012696551724137938,
-            squared_diffs: 5.500029655172411e-7,
-          },
-          legacy_last_err_redacted: "",
-          sensitive_info: {
-            last_err: "",
-            most_recent_plan_description: {
-              name: "scan",
-              attrs: [
-                { key: "missing stats", value: "" },
-                { key: "table", value: "namespace2@primary" },
-                { key: "spans", value: "FULL SCAN" },
-              ],
+          exec_stats: {
+            count: new Long(2),
+            network_bytes: {
+              mean: 0,
+              squared_diffs: 0,
             },
-            most_recent_plan_timestamp: {
-              seconds: "1598943058",
-              nanos: 815110000,
+            max_mem_usage: {
+              mean: 20480,
+              squared_diffs: 0,
+            },
+            contention_time: {
+              mean: 0,
+              squared_diffs: 0,
+            },
+            network_messages: {
+              mean: 0,
+              squared_diffs: 0,
+            },
+            max_disk_usage: {
+              mean: 0,
+              squared_diffs: 0,
             },
           },
-          bytes_read: { mean: 1570, squared_diffs: 0 },
-          rows_read: { mean: 35, squared_diffs: 0 },
-          rows_written: { mean: 1, squared_diffs: 0.99 },
+          rows_written: {
+            mean: 0,
+            squared_diffs: 0,
+          },
         },
-      },
-      {
-        label:
-          "SELECT (SELECT count(*) FROM system.jobs AS j WHERE ((j.created_by_type = _) AND (j.created_by_id = s.schedule_id)) AND (j.status NOT IN (_, _, __more1__))) AS num_running, s.* FROM system.scheduled_jobs AS s WHERE next_run < current_timestamp() ORDER BY random() LIMIT _",
-        key: {
-          key_data: {
-            query:
-              "SELECT (SELECT count(*) FROM system.jobs AS j WHERE ((j.created_by_type = _) AND (j.created_by_id = s.schedule_id)) AND (j.status NOT IN (_, _, __more1__))) AS num_running, s.* FROM system.scheduled_jobs AS s WHERE next_run < current_timestamp() ORDER BY random() LIMIT _",
-            app: "$ internal-find-scheduled-jobs",
-            distSQL: false,
-            failed: false,
-            opt: true,
-            implicit_txn: false,
-            vec: false,
-          },
-          node_id: 1,
-        },
-        stats: {
-          count: "55",
-          first_attempt_count: "55",
-          max_retries: "0",
-          legacy_last_err: "",
-          num_rows: { mean: 0, squared_diffs: 0 },
-          parse_lat: { mean: 0.0002004, squared_diffs: 8.563692e-7 },
-          plan_lat: {
-            mean: 0.0033483454545454546,
-            squared_diffs: 0.00012831949443636365,
-          },
-          run_lat: {
-            mean: 0.001046581818181818,
-            squared_diffs: 0.00015142185738181813,
-          },
-          service_lat: {
-            mean: 0.004701018181818182,
-            squared_diffs: 0.00028161206498181825,
-          },
-          overhead_lat: {
-            mean: 0.0001056909090909091,
-            squared_diffs: 1.1588574545454597e-7,
-          },
-          legacy_last_err_redacted: "",
-          sensitive_info: {
-            last_err: "",
-            most_recent_plan_description: {
-              name: "limit",
-              attrs: [{ key: "count", value: "_" }],
-              children: [
-                {
-                  name: "sort",
-                  attrs: [{ key: "order", value: "+column26" }],
-                  children: [
-                    {
-                      name: "render",
-                      children: [
-                        {
-                          name: "group",
-                          attrs: [
-                            { key: "group by", value: "schedule_id" },
-                            { key: "ordered", value: "+schedule_id" },
-                          ],
-                          children: [
-                            {
-                              name: "merge join (left outer)",
-                              attrs: [
-                                {
-                                  key: "equality",
-                                  value: "(schedule_id) = (created_by_id)",
-                                },
-                                { key: "left cols are key", value: "" },
-                              ],
-                              children: [
-                                {
-                                  name: "filter",
-                                  attrs: [
-                                    { key: "filter", value: "next_run < _" },
-                                  ],
-                                  children: [
-                                    {
-                                      name: "scan",
-                                      attrs: [
-                                        { key: "missing stats", value: "" },
-                                        {
-                                          key: "table",
-                                          value: "scheduled_jobs@primary",
-                                        },
-                                        { key: "spans", value: "FULL SCAN" },
-                                      ],
-                                    },
-                                  ],
-                                },
-                                {
-                                  name: "filter",
-                                  attrs: [
-                                    { key: "filter", value: "status NOT IN _" },
-                                  ],
-                                  children: [
-                                    {
-                                      name: "scan",
-                                      attrs: [
-                                        { key: "missing stats", value: "" },
-                                        {
-                                          key: "table",
-                                          value:
-                                            "jobs@jobs_created_by_type_created_by_id_idx",
-                                        },
-                                        { key: "spans", value: "1 span" },
-                                      ],
-                                    },
-                                  ],
-                                },
-                              ],
-                            },
-                          ],
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-            most_recent_plan_timestamp: {
-              seconds: "1598943460",
-              nanos: 53285000,
-            },
-          },
-          bytes_read: { mean: 0, squared_diffs: 0 },
-          rows_read: { mean: 0, squared_diffs: 0 },
-          rows_written: { mean: 1, squared_diffs: 0.99 },
-        },
-      },
-      {
-        label: "SELECT id, config FROM system.zones",
-        key: {
-          key_data: {
-            id: "ba29a6d105491afdc2671ca4bd28ee5W",
-            query: "SELECT id, config FROM system.zones",
-            app: "$ internal-read-zone-configs",
-            distSQL: false,
-            failed: false,
-            opt: true,
-            implicit_txn: true,
-            vec: false,
-          },
-          node_id: 1,
-        },
-        stats: {
-          count: "1",
-          first_attempt_count: "1",
-          max_retries: "0",
-          legacy_last_err: "",
-          num_rows: { mean: 0, squared_diffs: 0 },
-          parse_lat: { mean: 0.000056, squared_diffs: 0 },
-          plan_lat: { mean: 0.000677, squared_diffs: 0 },
-          run_lat: { mean: 0.000161, squared_diffs: 0 },
-          service_lat: { mean: 0.001023, squared_diffs: 0 },
-          overhead_lat: { mean: 0.0001290000000000001, squared_diffs: 0 },
-          legacy_last_err_redacted: "",
-          sensitive_info: {
-            last_err: "",
-            most_recent_plan_description: {
-              name: "scan",
-              attrs: [
-                { key: "missing stats", value: "" },
-                { key: "table", value: "zones@primary" },
-                { key: "spans", value: "FULL SCAN" },
-              ],
-            },
-            most_recent_plan_timestamp: {
-              seconds: "1598938499",
-              nanos: 112061000,
-            },
-          },
-          bytes_read: { mean: 327, squared_diffs: 0 },
-          rows_read: { mean: 7, squared_diffs: 0 },
-          rows_written: { mean: 1, squared_diffs: 0.99 },
-        },
-      },
-      {
-        label: "SHOW GRANTS ON TABLE system.role_options",
-        key: {
-          key_data: {
-            query: "SHOW GRANTS ON TABLE system.role_options",
-            app: "$ internal-admin-show-grants",
-            distSQL: false,
-            failed: false,
-            opt: true,
-            implicit_txn: true,
-            vec: false,
-          },
-          node_id: 1,
-        },
-        stats: {
-          count: "1",
-          first_attempt_count: "1",
-          max_retries: "0",
-          legacy_last_err: "",
-          num_rows: { mean: 0, squared_diffs: 0 },
-          parse_lat: { mean: 0.000243, squared_diffs: 0 },
-          plan_lat: { mean: 0.004487, squared_diffs: 0 },
-          run_lat: { mean: 0.094834, squared_diffs: 0 },
-          service_lat: { mean: 0.100139, squared_diffs: 0 },
-          overhead_lat: { mean: 0.0005750000000000061, squared_diffs: 0 },
-          legacy_last_err_redacted: "",
-          sensitive_info: {
-            last_err: "",
-            most_recent_plan_description: {
-              name: "sort",
-              attrs: [{ key: "order", value: "+grantee,+privilege_type" }],
-              children: [
-                {
-                  name: "filter",
-                  attrs: [
-                    {
-                      key: "filter",
-                      value: "(table_catalog, table_schema, table_name) IN _",
-                    },
-                  ],
-                  children: [
-                    {
-                      name: "virtual table",
-                      attrs: [
-                        { key: "table", value: "table_privileges@primary" },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-            most_recent_plan_timestamp: {
-              seconds: "1598943060",
-              nanos: 614455000,
-            },
-          },
-          bytes_read: { mean: 0, squared_diffs: 0 },
-          rows_read: { mean: 0, squared_diffs: 0 },
-          rows_written: { mean: 1, squared_diffs: 0.99 },
-        },
-      },
-      {
-        label: "SHOW GRANTS ON TABLE system.statement_bundle_chunks",
-        key: {
-          key_data: {
-            query: "SHOW GRANTS ON TABLE system.statement_bundle_chunks",
-            app: "$ internal-admin-show-grants",
-            distSQL: false,
-            failed: false,
-            opt: true,
-            implicit_txn: true,
-            vec: false,
-          },
-          node_id: 1,
-        },
-        stats: {
-          count: "1",
-          first_attempt_count: "1",
-          max_retries: "0",
-          legacy_last_err: "",
-          num_rows: { mean: 0, squared_diffs: 0 },
-          parse_lat: { mean: 0.000029, squared_diffs: 0 },
-          plan_lat: { mean: 0.004052, squared_diffs: 0 },
-          run_lat: { mean: 0.019415, squared_diffs: 0 },
-          service_lat: { mean: 0.023886, squared_diffs: 0 },
-          overhead_lat: { mean: 0.000389999999999998, squared_diffs: 0 },
-          legacy_last_err_redacted: "",
-          sensitive_info: {
-            last_err: "",
-            most_recent_plan_description: {
-              name: "sort",
-              attrs: [{ key: "order", value: "+grantee,+privilege_type" }],
-              children: [
-                {
-                  name: "filter",
-                  attrs: [
-                    {
-                      key: "filter",
-                      value: "(table_catalog, table_schema, table_name) IN _",
-                    },
-                  ],
-                  children: [
-                    {
-                      name: "virtual table",
-                      attrs: [
-                        { key: "table", value: "table_privileges@primary" },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-            most_recent_plan_timestamp: {
-              seconds: "1598943060",
-              nanos: 702937000,
-            },
-          },
-          bytes_read: { mean: 0, squared_diffs: 0 },
-          rows_read: { mean: 0, squared_diffs: 0 },
-          rows_written: { mean: 1, squared_diffs: 0.99 },
-        },
-      },
-    ],
-    aggregatedTs: timestampString,
-    transactionFingerprintId: "3632089240731979669",
-    transaction: {
-      stats_data: {
-        statement_fingerprint_ids: [
-          Long.fromString("673bf9d0055bbae332ad497072db9bbf"),
-        ],
-        app: "$ internal-select-running/get-claimed-jobs",
         aggregated_ts: timestamp,
-        stats: {
-          count: Long.fromInt(93),
-          max_retries: Long.fromInt(0),
-          num_rows: { mean: 0, squared_diffs: 0 },
-          service_lat: {
-            mean: 0.05745331182795698,
-            squared_diffs: 14.213222686585958,
-          },
-          retry_lat: { mean: 0, squared_diffs: 0 },
-          commit_lat: {
-            mean: 0.000010258064516129034,
-            squared_diffs: 3.1277806451612896e-8,
-          },
+        transaction_fingerprint_id: new Long(13388351560861020642),
+        aggregation_interval: {
+          seconds: new Long(3600),
         },
       },
-      node_id: 5,
-      regionNodes: ["gcp-us-east1"],
     },
-  },
-  error: new RequestError(
-    "Forbidden",
-    403,
-    "this operation requires admin privilege",
-  ),
-  nodeRegions: {
-    "1": "gcp-us-east1",
-    "2": "gcp-us-east1",
-    "3": "gcp-us-west1",
-    "4": "gcp-europe-west1",
-  },
+  ],
 };
 
 export const timeScale: TimeScale = {

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.stories.tsx
@@ -13,14 +13,16 @@ import { storiesOf } from "@storybook/react";
 import { MemoryRouter } from "react-router-dom";
 import { noop } from "lodash";
 import {
-  transactionDetails,
+  transactionDetailsData,
   routeProps,
+  nodeRegions,
+  error,
   timeScale,
+  transaction,
+  transactionFingerprintId,
 } from "./transactionDetails.fixture";
 
 import { TransactionDetails } from ".";
-
-const { data, nodeRegions, error } = transactionDetails;
 
 storiesOf("Transactions Details", module)
   .addDecorator(storyFn => <MemoryRouter>{storyFn()}</MemoryRouter>)
@@ -30,43 +32,67 @@ storiesOf("Transactions Details", module)
   .add("with data", () => (
     <TransactionDetails
       {...routeProps}
-      aggregatedTs={data.aggregatedTs}
       timeScale={timeScale}
-      transactionFingerprintId={data.transactionFingerprintId}
-      transaction={data.transaction}
-      statements={data.statements as any}
+      transactionFingerprintId={transactionFingerprintId.toString()}
+      transaction={transaction}
+      isLoading={false}
+      statements={transactionDetailsData.statements}
       nodeRegions={nodeRegions}
       isTenant={false}
       hasViewActivityRedactedRole={false}
       refreshData={noop}
+      refreshUserSQLRoles={noop}
+      onTimeScaleChange={noop}
     />
   ))
   .add("with loading indicator", () => (
     <TransactionDetails
       {...routeProps}
-      aggregatedTs={data.aggregatedTs}
       timeScale={timeScale}
-      transactionFingerprintId={data.transactionFingerprintId}
-      transaction={data.transaction}
+      transactionFingerprintId={transactionFingerprintId.toString()}
+      transaction={null}
+      isLoading={true}
       statements={undefined}
       nodeRegions={nodeRegions}
       isTenant={false}
       hasViewActivityRedactedRole={false}
       refreshData={noop}
+      refreshUserSQLRoles={noop}
+      onTimeScaleChange={noop}
     />
   ))
   .add("with error alert", () => (
     <TransactionDetails
       {...routeProps}
-      aggregatedTs={undefined}
-      timeScale={undefined}
+      timeScale={timeScale}
       transactionFingerprintId={undefined}
       transaction={undefined}
+      isLoading={false}
       statements={undefined}
       nodeRegions={nodeRegions}
       error={error}
       isTenant={false}
       hasViewActivityRedactedRole={false}
       refreshData={noop}
+      refreshUserSQLRoles={noop}
+      onTimeScaleChange={noop}
     />
-  ));
+  ))
+  .add("No data for this time frame; no cached transaction text", () => {
+    return (
+      <TransactionDetails
+        {...routeProps}
+        timeScale={timeScale}
+        transactionFingerprintId={transactionFingerprintId.toString()}
+        transaction={undefined}
+        isLoading={false}
+        statements={transactionDetailsData.statements}
+        nodeRegions={nodeRegions}
+        isTenant={false}
+        hasViewActivityRedactedRole={false}
+        refreshData={noop}
+        refreshUserSQLRoles={noop}
+        onTimeScaleChange={noop}
+      />
+    );
+  });

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -20,7 +20,8 @@ import {
   ISortedTablePagination,
   SortSetting,
 } from "../sortedtable";
-import { Tooltip } from "@cockroachlabs/ui-components";
+import { PageConfig, PageConfigItem } from "src/pageConfig";
+import { InlineAlert, Tooltip } from "@cockroachlabs/ui-components";
 import { Pagination } from "../pagination";
 import { TableStatistics } from "../tableStatistics";
 import { baseHeadingClasses } from "../transactionsPage/transactionsPageClasses";
@@ -29,7 +30,7 @@ import { tableClasses } from "../transactionsTable/transactionsTableClasses";
 import { SqlBox } from "../sql";
 import {
   aggregateStatements,
-  getStatementsByFingerprintIdAndTime,
+  getStatementsByFingerprintId,
   statementFingerprintIdsToText,
 } from "../transactionsPage/utils";
 import { Loading } from "../loading";
@@ -53,10 +54,14 @@ import {
   populateRegionNodeForStatements,
   makeStatementsColumns,
 } from "src/statementsTable/statementsTable";
-import { TransactionInfo } from "src/transactionsTable";
+import { Transaction } from "src/transactionsTable";
 import Long from "long";
 import { StatementsRequest } from "../api";
-import { TimeScale, toDateRange } from "../timeScaleDropdown";
+import {
+  TimeScale,
+  TimeScaleDropdown,
+  toDateRange,
+} from "../timeScaleDropdown";
 
 const { containerClass } = tableClasses;
 const cx = classNames.bind(statementsStyles);
@@ -67,20 +72,21 @@ const summaryCardStylesCx = classNames.bind(summaryCardStyles);
 const transactionDetailsStylesCx = classNames.bind(transactionDetailsStyles);
 
 export interface TransactionDetailsStateProps {
-  aggregatedTs: string | null;
   timeScale: TimeScale;
   error?: Error | null;
   isTenant: UIConfigState["isTenant"];
   hasViewActivityRedactedRole?: UIConfigState["hasViewActivityRedactedRole"];
   nodeRegions: { [nodeId: string]: string };
   statements?: Statement[];
-  transaction: TransactionInfo;
+  transaction: Transaction;
   transactionFingerprintId: string;
+  isLoading: boolean;
 }
 
 export interface TransactionDetailsDispatchProps {
   refreshData: (req?: StatementsRequest) => void;
   refreshUserSQLRoles: () => void;
+  onTimeScaleChange: (ts: TimeScale) => void;
 }
 
 export type TransactionDetailsProps = TransactionDetailsStateProps &
@@ -90,8 +96,7 @@ export type TransactionDetailsProps = TransactionDetailsStateProps &
 interface TState {
   sortSetting: SortSetting;
   pagination: ISortedTablePagination;
-  statementsForTransaction: Statement[];
-  transactionText: string;
+  latestTransactionText: string;
 }
 
 function statementsRequestFromProps(
@@ -121,8 +126,7 @@ export class TransactionDetails extends React.Component<
         pageSize: 10,
         current: 1,
       },
-      statementsForTransaction: [],
-      transactionText: "",
+      latestTransactionText: "",
     };
   }
 
@@ -131,53 +135,52 @@ export class TransactionDetails extends React.Component<
     hasViewActivityRedactedRole: false,
   };
 
-  getTransactionStateInfo = (): void => {
-    const { transaction, aggregatedTs, statements } = this.props;
+  getTransactionStateInfo = (prevTransactionFingerprintId: string): void => {
+    const { transaction, transactionFingerprintId } = this.props;
+
     const statementFingerprintIds =
       transaction?.stats_data?.statement_fingerprint_ids;
-
-    const statementsForTransaction =
-      (statementFingerprintIds &&
-        getStatementsByFingerprintIdAndTime(
-          statementFingerprintIds,
-          aggregatedTs,
-          statements,
-        )) ||
-      [];
 
     const transactionText =
       (statementFingerprintIds &&
         statementFingerprintIdsToText(
           statementFingerprintIds,
-          statementsForTransaction,
+          this.getStatementsForTransaction(),
         )) ||
       "";
 
+    // If a new, non-empty-string transaction text is available (derived from the time-frame-specific endpoint
+    // response), cache the text.
     if (
-      statementsForTransaction?.toString() !=
-        this.state.statementsForTransaction?.toString() ||
-      transactionText != this.state.transactionText
+      transactionText &&
+      transactionText != this.state.latestTransactionText
     ) {
       this.setState({
-        statementsForTransaction,
-        transactionText,
+        latestTransactionText: transactionText,
+      });
+    }
+
+    // If the transactionFingerprintId (derived from the URL) changes, invalidate the cached transaction text
+    if (prevTransactionFingerprintId != transactionFingerprintId) {
+      this.setState({
+        latestTransactionText: "",
       });
     }
   };
 
-  refreshData = (): void => {
+  refreshData = (prevTransactionFingerprintId: string): void => {
     const req = statementsRequestFromProps(this.props);
     this.props.refreshData(req);
-    this.getTransactionStateInfo();
+    this.getTransactionStateInfo(prevTransactionFingerprintId);
   };
 
   componentDidMount(): void {
-    this.refreshData();
+    this.refreshData("");
     this.props.refreshUserSQLRoles();
   }
 
-  componentDidUpdate(): void {
-    this.getTransactionStateInfo();
+  componentDidUpdate(prevProps: TransactionDetailsProps): void {
+    this.getTransactionStateInfo(prevProps.transactionFingerprintId);
   }
 
   onChangeSortSetting = (ss: SortSetting): void => {
@@ -195,6 +198,19 @@ export class TransactionDetails extends React.Component<
     this.props.history.push("/sql-activity?tab=Transactions");
   };
 
+  getStatementsForTransaction = (): Statement[] => {
+    const { transaction, statements } = this.props;
+
+    const statementFingerprintIds =
+      transaction?.stats_data?.statement_fingerprint_ids;
+
+    return (
+      (statementFingerprintIds &&
+        getStatementsByFingerprintId(statementFingerprintIds, statements)) ||
+      []
+    );
+  };
+
   render(): React.ReactElement {
     const {
       error,
@@ -202,7 +218,8 @@ export class TransactionDetails extends React.Component<
       transaction,
       transactionFingerprintId,
     } = this.props;
-    const { transactionText, statementsForTransaction } = this.state;
+    const { latestTransactionText } = this.state;
+    const statementsForTransaction = this.getStatementsForTransaction();
     const transactionStats = transaction?.stats_data?.stats;
 
     return (
@@ -220,13 +237,43 @@ export class TransactionDetails extends React.Component<
           </Button>
           <h3 className={baseHeadingClasses.tableName}>Transaction Details</h3>
         </section>
+        <PageConfig>
+          <PageConfigItem>
+            <TimeScaleDropdown
+              currentScale={this.props.timeScale}
+              setTimeScale={this.props.onTimeScaleChange}
+            />
+          </PageConfigItem>
+        </PageConfig>
         <Loading
           error={error}
           page={"transaction details"}
-          loading={
-            statementsForTransaction.length == 0 || transactionText.length == 0
-          }
+          loading={this.props.isLoading}
           render={() => {
+            if (!transaction) {
+              return (
+                <section className={containerClass}>
+                  {latestTransactionText && (
+                    <Row
+                      gutter={16}
+                      className={transactionDetailsStylesCx("summary-columns")}
+                    >
+                      <Col span={16}>
+                        <SqlBox
+                          value={latestTransactionText}
+                          className={transactionDetailsStylesCx("summary-card")}
+                        />
+                      </Col>
+                    </Row>
+                  )}
+                  <InlineAlert
+                    intent="info"
+                    title="Data not available for this time frame. Select a different time frame."
+                  />
+                </section>
+              );
+            }
+
             const { isTenant, hasViewActivityRedactedRole } = this.props;
             const { sortSetting, pagination } = this.state;
             const txnScopedStmts = statementsForTransaction.filter(
@@ -269,7 +316,7 @@ export class TransactionDetails extends React.Component<
                   >
                     <Col span={16}>
                       <SqlBox
-                        value={transactionText}
+                        value={latestTransactionText}
                         className={transactionDetailsStylesCx("summary-card")}
                       />
                     </Col>

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.spec.ts
@@ -11,27 +11,22 @@
 import { assert } from "chai";
 import {
   filterTransactions,
-  getStatementsByFingerprintIdAndTime,
+  getStatementsByFingerprintId,
   statementFingerprintIdsToText,
 } from "./utils";
-import { TimestampToString } from "../util";
 import { Filters } from "../queryFilter";
-import { data, nodeRegions, timestamp } from "./transactions.fixture";
+import { data, nodeRegions } from "./transactions.fixture";
 import Long from "long";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
 
 type Transaction = protos.cockroach.server.serverpb.StatementsResponse.IExtendedCollectedTransactionStatistics;
 
-describe("getStatementsByFingerprintIdAndTime", () => {
-  it("filters statements by fingerprint id and time", () => {
-    const selectedStatements = getStatementsByFingerprintIdAndTime(
+describe("getStatementsByFingerprintId", () => {
+  it("filters statements by fingerprint id", () => {
+    const selectedStatements = getStatementsByFingerprintId(
       [Long.fromInt(4104049045071304794), Long.fromInt(3334049045071304794)],
-      TimestampToString(timestamp),
       [
-        {
-          id: Long.fromInt(4104049045071304794),
-          key: { aggregated_ts: timestamp },
-        },
+        { id: Long.fromInt(4104049045071304794) },
         { id: Long.fromInt(5554049045071304794) },
       ],
     );

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
@@ -51,17 +51,12 @@ export const getTrxAppFilterOptions = (
 export const collectStatementsText = (statements: Statement[]): string =>
   statements.map(s => s.key.key_data.query).join("\n");
 
-export const getStatementsByFingerprintIdAndTime = (
+export const getStatementsByFingerprintId = (
   statementFingerprintIds: Long[],
-  timestamp: string | null,
   statements: Statement[],
 ): Statement[] => {
-  return statements?.filter(
-    s =>
-      (timestamp == null ||
-        (s.key?.aggregated_ts != null &&
-          timestamp == TimestampToString(s.key.aggregated_ts))) &&
-      statementFingerprintIds.some(id => id.eq(s.id)),
+  return statements?.filter(s =>
+    statementFingerprintIds.some(id => id.eq(s.id)),
   );
 };
 
@@ -125,9 +120,8 @@ export const searchTransactionsData = (
     search
       ? search.split(" ").every(val =>
           collectStatementsText(
-            getStatementsByFingerprintIdAndTime(
+            getStatementsByFingerprintId(
               t.stats_data.statement_fingerprint_ids,
-              TimestampToString(t.stats_data.aggregated_ts),
               statements,
             ),
           )
@@ -201,9 +195,8 @@ export const filterTransactions = (
       let foundRegion: boolean = regions.length == 0;
       let foundNode: boolean = nodes.length == 0;
 
-      getStatementsByFingerprintIdAndTime(
+      getStatementsByFingerprintId(
         t.stats_data.statement_fingerprint_ids,
-        TimestampToString(t.stats_data.aggregated_ts),
         statements,
       ).some(stmt => {
         stmt.stats.nodes &&
@@ -246,9 +239,8 @@ export const generateRegionNode = (
   // nodes and regions of all the statements to a single list of `region: nodes`
   // for the transaction.
   // E.g. {"gcp-us-east1" : [1,3,4]}
-  getStatementsByFingerprintIdAndTime(
+  getStatementsByFingerprintId(
     transaction.stats_data.statement_fingerprint_ids,
-    TimestampToString(transaction.stats_data.aggregated_ts),
     statements,
   ).forEach(stmt => {
     stmt.stats.nodes &&

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
@@ -33,7 +33,7 @@ import { transactionLink } from "./transactionsCells";
 import { FixLong, longToInt, TimestampToString } from "src/util";
 import { SortSetting } from "../sortedtable";
 import {
-  getStatementsByFingerprintIdAndTime,
+  getStatementsByFingerprintId,
   collectStatementsText,
   statementFingerprintIdsToText,
   statementFingerprintIdsToSummarizedText,
@@ -41,7 +41,7 @@ import {
 import classNames from "classnames/bind";
 import statsTablePageStyles from "src/statementsTable/statementsTableContent.module.scss";
 
-type Transaction = protos.cockroach.server.serverpb.StatementsResponse.IExtendedCollectedTransactionStatistics;
+export type Transaction = protos.cockroach.server.serverpb.StatementsResponse.IExtendedCollectedTransactionStatistics;
 type Statement = protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 
 interface TransactionsTable {
@@ -71,7 +71,7 @@ interface TransactionLinkTargetProps {
 export const TransactionLinkTarget = (
   props: TransactionLinkTargetProps,
 ): string => {
-  return `/transaction/${props.aggregatedTs}/${props.transactionFingerprintId}`;
+  return `/transaction/${props.transactionFingerprintId}`;
 };
 
 export function makeTransactionsColumns(
@@ -145,9 +145,8 @@ export function makeTransactionsColumns(
         }),
       sort: (item: TransactionInfo) =>
         collectStatementsText(
-          getStatementsByFingerprintIdAndTime(
+          getStatementsByFingerprintId(
             item.stats_data.statement_fingerprint_ids,
-            TimestampToString(item.stats_data.aggregated_ts),
             statements,
           ),
         ),

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -264,8 +264,13 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                 />
                 <Route
                   exact
-                  path={`/transaction/:${aggregatedTsAttr}/:${txnFingerprintIdAttr}`}
+                  path={`/transaction/:${txnFingerprintIdAttr}`}
                   component={TransactionDetails}
+                />
+                <Redirect
+                  exact
+                  from={`/transaction/:${aggregatedTsAttr}/:${txnFingerprintIdAttr}`}
+                  to={`/transaction/:${txnFingerprintIdAttr}`}
                 />
 
                 {/* debug pages */}

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -326,18 +326,19 @@ export const statementDetailsRequestToID = (
     req.end,
   );
 
-const queryReducerObj = new KeyedCachedDataReducer(
+export const statementDetailsActionNamespace = "statementDetails";
+export const statementDetailsReducerObj = new KeyedCachedDataReducer(
   api.getStatementDetails,
-  "statementDetails",
+  statementDetailsActionNamespace,
   statementDetailsRequestToID,
   moment.duration(5, "m"),
 );
 
 export const invalidateStatementDetails =
-  queryReducerObj.cachedDataReducer.invalidateData;
+  statementDetailsReducerObj.cachedDataReducer.invalidateData;
 export const invalidateAllStatementDetails =
-  queryReducerObj.cachedDataReducer.invalidateAllData;
-export const refreshStatementDetails = queryReducerObj.refresh;
+  statementDetailsReducerObj.cachedDataReducer.invalidateAllData;
+export const refreshStatementDetails = statementDetailsReducerObj.refresh;
 
 const userSQLRolesReducerObj = new CachedDataReducer(
   api.getUserSQLRoles,
@@ -445,7 +446,8 @@ export const apiReducersReducer = combineReducers<APIReducersState>({
   [sessionsReducerObj.actionNamespace]: sessionsReducerObj.reducer,
   [storesReducerObj.actionNamespace]: storesReducerObj.reducer,
   [queriesReducerObj.actionNamespace]: queriesReducerObj.reducer,
-  [queryReducerObj.actionNamespace]: queryReducerObj.reducer,
+  [statementDetailsReducerObj.actionNamespace]:
+    statementDetailsReducerObj.reducer,
   [dataDistributionReducerObj.actionNamespace]:
     dataDistributionReducerObj.reducer,
   [metricMetadataReducerObj.actionNamespace]: metricMetadataReducerObj.reducer,

--- a/pkg/ui/workspaces/db-console/src/redux/sqlActivity.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/sqlActivity.ts
@@ -1,0 +1,78 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import { Action } from "redux";
+import _ from "lodash";
+import { PayloadAction } from "oss/src/interfaces/action";
+
+/**
+ * SqlActivityState maintains a MetricQuerySet collection, along with some
+ * metadata relevant to server queries.
+ */
+export class SqlActivityState {
+  /**
+   * Caches the latest query text associated with the statement fingerprint in the URL, to preserve this data even if
+   * the time frame changes such that there is no longer data for this statement fingerprint in the selected time frame.
+   */
+  statementDetailsLatestQuery: string;
+  /**
+   * Caches the latest formatted query associated with the statement fingerprint in the URL, to preserve this data even if
+   * the time frame changes such that there is no longer data for this statement fingerprint in the selected time frame.
+   */
+  statementDetailsLatestFormattedQuery: string;
+}
+
+const SET_STATEMENT_DETAILS_LATEST_QUERY =
+  "cockroachui/sqlActivity/SET_STATEMENT_DETAILS_LATEST_QUERY";
+const SET_STATEMENT_DETAILS_LATEST_FORMATTED_QUERY =
+  "cockroachui/sqlActivity/SET_STATEMENT_DETAILS_LATEST_FORMATTED_QUERY";
+
+export function statementDetailsLatestQueryAction(
+  query: string,
+): PayloadAction<string> {
+  return {
+    type: SET_STATEMENT_DETAILS_LATEST_QUERY,
+    payload: query,
+  };
+}
+export function statementDetailsLatestFormattedQueryAction(
+  formattedQuery: string,
+): PayloadAction<string> {
+  return {
+    type: SET_STATEMENT_DETAILS_LATEST_FORMATTED_QUERY,
+    payload: formattedQuery,
+  };
+}
+
+/**
+ * The metrics reducer accepts events for individual MetricQuery objects,
+ * dispatching them based on ID. It also accepts actions which indicate the
+ * state of the connection to the server.
+ */
+export function sqlActivityReducer(
+  state: SqlActivityState = new SqlActivityState(),
+  action: Action,
+): SqlActivityState {
+  switch (action.type) {
+    case SET_STATEMENT_DETAILS_LATEST_QUERY: {
+      const { payload: query } = action as PayloadAction<string>;
+      state = _.clone(state);
+      state.statementDetailsLatestQuery = query;
+      return state;
+    }
+    case SET_STATEMENT_DETAILS_LATEST_FORMATTED_QUERY: {
+      const { payload: formattedQuery } = action as PayloadAction<string>;
+      state = _.clone(state);
+      state.statementDetailsLatestFormattedQuery = formattedQuery;
+      return state;
+    }
+    default:
+      return state;
+  }
+}

--- a/pkg/ui/workspaces/db-console/src/redux/state.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/state.ts
@@ -30,6 +30,7 @@ import { apiReducersReducer, APIReducersState } from "./apiReducers";
 import { hoverReducer, HoverState } from "./hover";
 import { localSettingsReducer, LocalSettingsState } from "./localsettings";
 import { metricsReducer, MetricsState } from "./metrics";
+import { sqlActivityReducer, SqlActivityState } from "src/redux/sqlActivity";
 import { queryManagerReducer, QueryManagerState } from "./queryManager/reducer";
 import { timeScaleReducer, TimeScaleState } from "./timeScale";
 import { uiDataReducer, UIDataState } from "./uiData";
@@ -41,6 +42,8 @@ export interface AdminUIState {
   hover: HoverState;
   localSettings: LocalSettingsState;
   metrics: MetricsState;
+  sqlActivity: SqlActivityState;
+
   queryManager: QueryManagerState;
   router: RouterState;
   timeScale: TimeScaleState;
@@ -63,6 +66,8 @@ export function createAdminUIStore(historyInst: History<any>) {
       hover: hoverReducer,
       localSettings: localSettingsReducer,
       metrics: metricsReducer,
+      sqlActivity: sqlActivityReducer,
+
       queryManager: queryManagerReducer,
       router: routerReducer,
       timeScale: timeScaleReducer,

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
@@ -37,6 +37,7 @@ import {
 import {
   cancelStatementDiagnosticsReportAction,
   createStatementDiagnosticsReportAction,
+  setCombinedStatementsTimeScaleAction,
 } from "src/redux/statements";
 import { createStatementDiagnosticsAlertLocalSetting } from "src/redux/alerts";
 import { statementsTimeScaleLocalSetting } from "src/redux/statementsTimeScale";
@@ -51,6 +52,10 @@ import { StatementDetailsResponseMessage } from "src/util/api";
 import { getMatchParamByName, queryByName } from "src/util/query";
 
 import { appNamesAttr, statementAttr } from "src/util/constants";
+import {
+  statementDetailsLatestQueryAction,
+  statementDetailsLatestFormattedQueryAction,
+} from "src/redux/sqlActivity";
 type IStatementDiagnosticsReport = protos.cockroach.server.serverpb.IStatementDiagnosticsReport;
 
 const { generateStmtDetailsToID } = util;
@@ -68,7 +73,10 @@ export const selectStatementDetails = createSelector(
     appNames,
     timeScale,
     statementDetailsStats,
-  ): StatementDetailsResponseMessage => {
+  ): {
+    statementDetails: StatementDetailsResponseMessage;
+    isLoading: boolean;
+  } => {
     // Since the aggregation interval is 1h, we want to round the selected timeScale to include
     // the full hour. If a timeScale is between 14:32 - 15:17 we want to search for values
     // between 14:00 - 16:00. We don't encourage the aggregation interval to be modified, but
@@ -82,9 +90,12 @@ export const selectStatementDetails = createSelector(
       Long.fromNumber(end.unix()),
     );
     if (Object.keys(statementDetailsStats).includes(key)) {
-      return statementDetailsStats[key].data;
+      return {
+        statementDetails: statementDetailsStats[key].data,
+        isLoading: statementDetailsStats[key].inFlight,
+      };
     }
-    return null;
+    return { statementDetails: null, isLoading: true };
   },
 );
 
@@ -92,17 +103,21 @@ const mapStateToProps = (
   state: AdminUIState,
   props: RouteComponentProps,
 ): StatementDetailsStateProps => {
-  const statementDetails = selectStatementDetails(state, props);
-  const statementFingerprint = statementDetails?.statement.metadata.query;
+  const { statementDetails, isLoading } = selectStatementDetails(state, props);
   return {
+    statementFingerprintID: getMatchParamByName(props.match, statementAttr),
     statementDetails,
+    isLoading: isLoading,
+    latestQuery: state.sqlActivity.statementDetailsLatestQuery,
+    latestFormattedQuery:
+      state.sqlActivity.statementDetailsLatestFormattedQuery,
     statementsError: state.cachedData.statements.lastError,
     timeScale: statementsTimeScaleLocalSetting.selector(state),
     nodeNames: nodeDisplayNameByIDSelector(state),
     nodeRegions: nodeRegionsByIDSelector(state),
     diagnosticsReports: selectDiagnosticsReportsByStatementFingerprint(
       state,
-      statementFingerprint,
+      state.sqlActivity.statementDetailsLatestQuery,
     ),
     hasViewActivityRedactedRole: selectHasViewActivityRedactedRole(state),
   };
@@ -115,6 +130,7 @@ const mapDispatchToProps: StatementDetailsDispatchProps = {
     createStatementDiagnosticsAlertLocalSetting.set({ show: false }),
   createStatementDiagnosticsReport: createStatementDiagnosticsReportAction,
   onTabChanged: trackStatementDetailsSubnavSelectionAction,
+  onTimeScaleChange: setCombinedStatementsTimeScaleAction,
   onDiagnosticBundleDownload: trackDownloadDiagnosticsBundleAction,
   onDiagnosticCancelRequest: (report: IStatementDiagnosticsReport) => {
     return (dispatch: AppDispatch) => {
@@ -124,6 +140,8 @@ const mapDispatchToProps: StatementDetailsDispatchProps = {
       );
     };
   },
+  onStatementDetailsQueryChange: statementDetailsLatestQueryAction,
+  onStatementDetailsFormattedQueryChange: statementDetailsLatestFormattedQueryAction,
   refreshNodes: refreshNodes,
   refreshNodesLiveness: refreshLiveness,
   refreshUserSQLRoles: refreshUserSQLRoles,

--- a/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
@@ -308,7 +308,8 @@ describe("selectStatement", () => {
   it("returns null if the statements data is invalid", () => {
     const state = makeInvalidState();
     const props = makeEmptyRouteProps();
-    const result = selectStatementDetails(state, props);
+    const { statementDetails } = selectStatementDetails(state, props);
+    const result = statementDetails;
 
     assert.isNull(result);
   });
@@ -328,7 +329,8 @@ describe("selectStatement", () => {
 
     const stmtAFingerprintID = stmtA.id.toString();
     const props = makeRoutePropsWithStatement(stmtAFingerprintID);
-    const result = selectStatementDetails(state, props).statement;
+    const { statementDetails } = selectStatementDetails(state, props);
+    const result = statementDetails.statement;
 
     assert.equal(result.metadata.query, stmtA.key.key_data.query);
     assert.equal(result.stats.count.toNumber(), stmtA.stats.count.toNumber());
@@ -361,7 +363,8 @@ describe("selectStatement", () => {
       appFilter,
     );
 
-    const result = selectStatementDetails(state, props).statement;
+    const { statementDetails } = selectStatementDetails(state, props);
+    const result = statementDetails.statement;
 
     assert.equal(result.metadata.query, stmtA.key.key_data.query);
     assert.equal(result.stats.count.toNumber(), stmtA.stats.count.toNumber());
@@ -392,7 +395,8 @@ describe("selectStatement", () => {
       "(unset)",
     );
 
-    const result = selectStatementDetails(state, props).statement;
+    const { statementDetails } = selectStatementDetails(state, props);
+    const result = statementDetails.statement;
 
     assert.equal(result.metadata.query, stmtA.key.key_data.query);
     assert.equal(result.stats.count.toNumber(), stmtA.stats.count.toNumber());
@@ -424,7 +428,8 @@ describe("selectStatement", () => {
       appFilter,
     );
 
-    const result = selectStatementDetails(state, props)?.statement;
+    const { statementDetails } = selectStatementDetails(state, props);
+    const result = statementDetails?.statement;
 
     assert.equal(result.metadata.query, stmtA.key.key_data.query);
     assert.equal(result.stats.count.toNumber(), stmtA.stats.count.toNumber());

--- a/pkg/ui/workspaces/db-console/src/views/transactions/transactionDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/transactionDetails.tsx
@@ -13,7 +13,7 @@ import { createSelector } from "reselect";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { refreshStatements, refreshUserSQLRoles } from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
-import { aggregatedTsAttr, txnFingerprintIdAttr } from "src/util/constants";
+import { txnFingerprintIdAttr } from "src/util/constants";
 import { getMatchParamByName } from "src/util/query";
 import { nodeRegionsByIDSelector } from "src/redux/nodes";
 import {
@@ -26,8 +26,8 @@ import {
   TransactionDetailsDispatchProps,
   TransactionDetailsProps,
   TransactionDetails,
-  util,
 } from "@cockroachlabs/cluster-ui";
+import { setCombinedStatementsTimeScaleAction } from "src/redux/statements";
 
 export const selectTransaction = createSelector(
   (state: AdminUIState) => state.cachedData.statements,
@@ -35,24 +35,25 @@ export const selectTransaction = createSelector(
   (transactionState, props) => {
     const transactions = transactionState.data?.transactions;
     if (!transactions) {
-      return null;
+      return {
+        isLoading: true,
+        transaction: null,
+      };
     }
-    const aggregatedTs = getMatchParamByName(props.match, aggregatedTsAttr);
     const txnFingerprintId = getMatchParamByName(
       props.match,
       txnFingerprintIdAttr,
     );
 
-    return transactions
-      .filter(
-        txn =>
-          txn.stats_data.transaction_fingerprint_id.toString() ==
-          txnFingerprintId,
-      )
-      .filter(
-        txn =>
-          util.TimestampToString(txn.stats_data.aggregated_ts) == aggregatedTs,
-      )[0];
+    const transaction = transactions.filter(
+      txn =>
+        txn.stats_data.transaction_fingerprint_id.toString() ==
+        txnFingerprintId,
+    )[0];
+    return {
+      isLoading: false,
+      transaction: transaction,
+    };
   },
 );
 
@@ -62,9 +63,8 @@ export default withRouter(
       state: AdminUIState,
       props: TransactionDetailsProps,
     ): TransactionDetailsStateProps => {
-      const transaction = selectTransaction(state, props);
+      const { isLoading, transaction } = selectTransaction(state, props);
       return {
-        aggregatedTs: getMatchParamByName(props.match, aggregatedTsAttr),
         timeScale: statementsTimeScaleLocalSetting.selector(state),
         error: selectLastError(state),
         isTenant: false,
@@ -75,8 +75,13 @@ export default withRouter(
           props.match,
           txnFingerprintIdAttr,
         ),
+        isLoading: isLoading,
       };
     },
-    { refreshData: refreshStatements, refreshUserSQLRoles },
+    {
+      refreshData: refreshStatements,
+      refreshUserSQLRoles,
+      onTimeScaleChange: setCombinedStatementsTimeScaleAction,
+    },
   )(TransactionDetails),
 );


### PR DESCRIPTION
Backport 1/1 commits from #76687.

/cc @cockroachdb/release 

---

Addresses #74512

This commit adds the time selection component to the Statement Details
(Overview and Explain Plan tabs) and Transaction Details pages.

If staying on the same Statement/Transaction details page and switching to a
time that there is no data for, the Overview and Explain Plan tabs on the
Statement Details page, and the Transaction details page will continue to show
the statement/transaction text. The Diagnostics tab on the Statement Details
page will also continue to work as usual. However, these features are not
available if landing directly on a Statement/Transactions Details page for a
time frame with no data, without having previously switched from a time frame
that did have data for the same statement/transaction.

This commit also removes the aggregatedTs match param from the Transaction
Details page URL, since this is insufficient to specify a time frame and to bring
it in line with the Statement Details page.

This commit also fixes Transaction Details page stories that were previously out
of date and broken. The Statement Details Explain Plan tab story was already
previously broken and is not fixed here.

Release note (ui): The time selection component previously on the Statements and
Transactions Pages has been added to the Statement Details Overview and Explain
Plan tabs, and the Transaction Details page.

---
Release justification: small change, high benefit change