### PR TITLE
spanconfig: reset job run_stats to avoid job system backoff

### DIFF
--- a/pkg/spanconfig/spanconfigjob/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigjob/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
+        "//pkg/kv",
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/spanconfig",

--- a/pkg/spanconfig/spanconfigjob/job.go
+++ b/pkg/spanconfig/spanconfigjob/job.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
@@ -74,6 +75,21 @@ func (r *resumer) Resume(ctx context.Context, execCtxI interface{}) (jobErr erro
 	// safe to wind the SQL pod down whenever it's running -- something we
 	// indicate through the job's idle status.
 	r.job.MarkIdle(true)
+
+	// If the Job's NumRuns is greater than 1, reset it to 0 so that future
+	// resumptions are not delayed by the job system.
+	//
+	// Note that we are doing this before the possible error return below. If
+	// there is a problem starting the reconciler this job will aggressively
+	// restart at the job system level with no backoff.
+	if err := r.job.Update(ctx, nil, func(_ *kv.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+		if md.RunStats != nil && md.RunStats.NumRuns > 1 {
+			ju.UpdateRunStats(1, md.RunStats.LastRun)
+		}
+		return nil
+	}); err != nil {
+		log.Warningf(ctx, "failed to reset reconciliation job run stats: %v", err)
+	}
 
 	// Start the protected timestamp reconciler. This will periodically poll the
 	// protected timestamp table to cleanup stale records. We take advantage of


### PR DESCRIPTION
If the coordinator of the span configuration job dies, another node
will adopt the job. However, when doing so it will bump the num_runs
run stat. As this number increases, the job system will delay future
resumptions of this job.

We solve this here by resetting the job's run_stats at the beginning
of the job.

We've yet again handled this in the job directly rather than adjusting
the behavior of the job system. In this case, my justification is that
this solution is fit for backporting.

Fixes #82689

Release note (bug fix): Fix a bug where the startup of an internal
component after a server restart could result in the delayed
application of zone configuration.