### PR TITLE
release-22.1: ui: Fix accidental commit of `it.only`

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScaleDropdown.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScaleDropdown.spec.tsx
@@ -158,10 +158,10 @@ describe("<TimeScaleDropdown> component", function() {
     getByText("Past 10 Minutes");
   });
 
-  it.only("allows selection of a custom time frame", () => {
+  it("initializes the custom selection to the current time frame", () => {
     const mockSetTimeScale = jest.fn();
     // Default state
-    const { getByText, getByDisplayValue, container } = render(
+    const { getByText, getByDisplayValue } = render(
       <MemoryRouter>
         <TimeScaleDropdownWrapper
           currentScale={new timescale.TimeScaleState().scale}


### PR DESCRIPTION
Backport 1/1 commits from https://github.com/cockroachdb/cockroach/pull/80743.

/cc @cockroachdb/release 

---

This commit fixes an accidental commit of `it.only` to frontend tests.
It also adds a comment explaining why the test does not go further.

Release note: None

--- 
Release justification: non-production changes