### PR TITLE
release-22.1: ui: update cluster-ui to v22.1.3

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "22.1.1",
+  "version": "22.1.3",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Update cluster-ui to the latest published version

Release note: None
Release justification: non-production change