### PR TITLE
release-22.1: kvserver: implied GCThreshold should be computed from readAt

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -337,6 +337,7 @@ go_test(
         "//pkg/kv/kvserver/kvserverpb",
         "//pkg/kv/kvserver/liveness",
         "//pkg/kv/kvserver/liveness/livenesspb",
+        "//pkg/kv/kvserver/protectedts",
         "//pkg/kv/kvserver/protectedts/ptpb",
         "//pkg/kv/kvserver/protectedts/ptstorage",
         "//pkg/kv/kvserver/protectedts/ptutil",

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -476,14 +476,21 @@ func (r *Replica) MaybeUnquiesceAndWakeLeader() bool {
 	return r.maybeUnquiesceAndWakeLeaderLocked()
 }
 
-func (r *Replica) ReadProtectedTimestamps(ctx context.Context) error {
+func (r *Replica) ReadProtectedTimestamps(
+	ctx context.Context,
+) (readAt, earliestProtectionTimestamp hlc.Timestamp, err error) {
 	var ts cachedProtectedTimestampState
 	defer r.maybeUpdateCachedProtectedTS(&ts)
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	var err error
 	ts, err = r.readProtectedTimestampsRLocked(ctx)
-	return err
+	return ts.readAt, ts.earliestProtectionTimestamp, err
+}
+
+func (r *Replica) ReadCachedProtectedTS() (readAt, earliestProtectionTimestamp hlc.Timestamp) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.mu.cachedProtectedTS.readAt, r.mu.cachedProtectedTS.earliestProtectionTimestamp
 }
 
 // ClosedTimestampPolicy returns the closed timestamp policy of the range, which


### PR DESCRIPTION
`checkGCThresholdAndLeaseRLocked` checks a batch request against
a replicas' lease and GCThreshold. When computing the implied
GCThreshold we were incorrectly using the clock timestamp at which the
lease for the request was evaluated, instead of the timestamp at
which the cached protected timestamp state was last updated.

The cached pts state is updated everytime the replica observes
a fresher protected timestamp state when being considered for GC.
In order to uphold the invariants provided by the protected timestamp
subsystem, GC decisions must be made based on the timestamp at which
the PTS state  was last `readAt`. This is akin to how
the GC queue picks its implied GCTimestamp in `checkProtectedTimestampsForGC`.

Concretely, this bug manifested as an ExportRequest failing with a
`BatchTimestampBeforeGCError` even though a protected timestamp record
had been written and reconciled. This was a consequence of the implied
GCThreshold not taking into account the PTS state.

Informs: https://github.com/cockroachlabs/support/issues/1638

Release note: None

Release justification: high impact bug fix to existing functionality