### PR TITLE
build: remove crdb-protobuf-client node_modules with ui-maintainer-clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1453,7 +1453,7 @@ ui-clean: ## Remove build artifacts.
 ui-maintainer-clean: ## Like clean, but also remove installed dependencies
 ui-maintainer-clean: ui-clean
 	$(info $(yellow)NOTE: consider using `./dev ui clean --all` instead of `make ui-maintainer-clean`$(term-reset))
-	rm -rf pkg/ui/node_modules pkg/ui/workspaces/db-console/node_modules pkg/ui/yarn.installed pkg/ui/workspaces/cluster-ui/node_modules
+	rm -rf pkg/ui/node_modules pkg/ui/workspaces/db-console/node_modules pkg/ui/yarn.installed pkg/ui/workspaces/cluster-ui/node_modules pkg/ui/workspaces/db-console/src/js/node_modules
 
 pkg/roachprod/vm/aws/embedded.go: bin/.bootstrap pkg/roachprod/vm/aws/config.json pkg/roachprod/vm/aws/old.json bin/terraformgen
 	(cd pkg/roachprod/vm/aws && $(GO) generate)


### PR DESCRIPTION
Since version 33 [1], dev ui clean --all removes the
pkg/ui/workspaces/db-console/src/js/node_modules tree. Remove that tree
with make ui-maintainer-clean to keep parity between the two build
systems.

[1] 2e9e7a5589 (dev: bump to version 33, 2022-05-27)

Release note: None