### PR TITLE
obsservice: ui handler serves db console assets 

### DIFF
--- a/pkg/ccl/oidcccl/authentication_oidc.go
+++ b/pkg/ccl/oidcccl/authentication_oidc.go
@@ -137,10 +137,9 @@ type oidcAuthenticationConf struct {
 	autoLogin       bool
 }
 
-// GetUIConf is used to extract certain parts of the OIDC
-// configuration at run-time for embedding into the
-// Admin UI HTML in order to manage the login experience
-// the UI provides.
+// GetOIDCConf is used to extract certain parts of the OIDC
+// configuration at run-time for embedding into the DB Console in order
+// to manage the login experience the UI provides.
 func (s *oidcAuthenticationServer) GetOIDCConf() ui.OIDCUIConf {
 	return ui.OIDCUIConf{
 		ButtonText: s.conf.buttonText,

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -89,6 +89,7 @@ var buildTargetMapping = map[string]string{
 	"label-merged-pr":  "//pkg/cmd/label-merged-pr:label-merged-pr",
 	"geos":             geosTarget,
 	"libgeos":          geosTarget,
+	"obsservice":       "//pkg/obsservice/cmd/obsservice",
 	"optgen":           "//pkg/sql/opt/optgen/cmd/optgen:optgen",
 	"optfmt":           "//pkg/sql/opt/optgen/cmd/optfmt:optfmt",
 	"oss":              "//pkg/cmd/cockroach-oss:cockroach-oss",
@@ -412,7 +413,9 @@ func (d *dev) getBasicBuildArgs(
 
 	// Add --config=with_ui iff we're building a target that needs it.
 	for _, target := range buildTargets {
-		if target.fullName == buildTargetMapping["cockroach"] || target.fullName == buildTargetMapping["cockroach-oss"] {
+		if target.fullName == buildTargetMapping["cockroach"] ||
+			target.fullName == buildTargetMapping["cockroach-oss"] ||
+			target.fullName == buildTargetMapping["obsservice"] {
 			args = append(args, "--config=with_ui")
 			break
 		}

--- a/pkg/obsservice/cmd/obsservice/BUILD.bazel
+++ b/pkg/obsservice/cmd/obsservice/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/cli/exit",
         "//pkg/obsservice/obslib/httpproxy",
         "//pkg/obsservice/obslib/migrations",
+        "//pkg/ui/distoss",
         "@com_github_spf13_cobra//:cobra",
     ],
 )

--- a/pkg/obsservice/cmd/obsservice/main.go
+++ b/pkg/obsservice/cmd/obsservice/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	"github.com/cockroachdb/cockroach/pkg/obsservice/obslib/httpproxy"
 	"github.com/cockroachdb/cockroach/pkg/obsservice/obslib/migrations"
+	_ "github.com/cockroachdb/cockroach/pkg/ui/distoss" // web UI init hooks
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/obsservice/obslib/httpproxy/BUILD.bazel
+++ b/pkg/obsservice/obslib/httpproxy/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/cli/exit",
+        "//pkg/ui",
         "//pkg/util/log",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_cmux//:cmux",

--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -62,6 +62,8 @@ const (
 
 type noOIDCConfigured struct{}
 
+var _ ui.OIDCUI = &noOIDCConfigured{}
+
 func (c *noOIDCConfigured) GetOIDCConf() ui.OIDCUIConf {
 	return ui.OIDCUIConf{
 		Enabled: false,

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -138,10 +138,12 @@ func Handler(cfg Config) http.Handler {
 			LoggedInUser:         cfg.GetUser(r.Context()),
 			Tag:                  buildInfo.Tag,
 			Version:              build.BinaryVersionPrefix(),
-			NodeID:               cfg.NodeID.String(),
 			OIDCAutoLogin:        oidcConf.AutoLogin,
 			OIDCLoginEnabled:     oidcConf.Enabled,
 			OIDCButtonText:       oidcConf.ButtonText,
+		}
+		if cfg.NodeID != nil {
+			args.NodeID = cfg.NodeID.String()
 		}
 		if uiConfigPath.MatchString(r.URL.Path) {
 			argBytes, err := json.Marshal(args)


### PR DESCRIPTION
This change enables the Observabilty Service to serve the DB Console UI
itself. Endpoints that CRDB can handle are proxied (`/_admin/`,
`/_status/`, `/ts/`) but the base URL will return a blank HTML page with
JS assets that load the DB Console.

In order to build with the ui code, the `--config=with_ui` flag must be
passed to bazel.

This commit also adds a shortcut to the `dev` command to build
`obsservice` which includes the `--config=with_ui` flag just as we do by
default in `cockroach` builds.

Release note: None