### PR TITLE
[release-22.1] storage,kvserver: Improve SST collision checking for wide SSTs 

### DIFF
--- a/pkg/kv/kvserver/batcheval/eval_context.go
+++ b/pkg/kv/kvserver/batcheval/eval_context.go
@@ -141,6 +141,10 @@ type EvalContext interface {
 	// GetEngineCapacity returns the store's underlying engine capacity; other
 	// StoreCapacity fields not related to engine capacity are not populated.
 	GetEngineCapacity() (roachpb.StoreCapacity, error)
+
+	// GetApproximateDiskBytes returns an approximate measure of bytes in the store
+	// in the specified key range.
+	GetApproximateDiskBytes(from, to roachpb.Key) (uint64, error)
 }
 
 // MockEvalCtx is a dummy implementation of EvalContext for testing purposes.
@@ -161,6 +165,7 @@ type MockEvalCtx struct {
 	ClosedTimestamp    hlc.Timestamp
 	RevokedLeaseSeq    roachpb.LeaseSequence
 	MaxBytes           int64
+	ApproxDiskBytes    uint64
 }
 
 // EvalContext returns the MockEvalCtx as an EvalContext. It will reflect future
@@ -286,4 +291,7 @@ func (m *mockEvalCtxImpl) GetMaxBytes() int64 {
 }
 func (m *mockEvalCtxImpl) GetEngineCapacity() (roachpb.StoreCapacity, error) {
 	return roachpb.StoreCapacity{Available: 1, Capacity: 1}, nil
+}
+func (m *mockEvalCtxImpl) GetApproximateDiskBytes(from, to roachpb.Key) (uint64, error) {
+	return m.ApproxDiskBytes, nil
 }

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -2034,6 +2034,12 @@ func (r *Replica) GetEngineCapacity() (roachpb.StoreCapacity, error) {
 	return r.store.Engine().Capacity()
 }
 
+// GetApproximateDiskBytes returns an approximate measure of bytes in the store
+// in the specified key range.
+func (r *Replica) GetApproximateDiskBytes(from, to roachpb.Key) (uint64, error) {
+	return r.store.Engine().ApproximateDiskBytes(from, to)
+}
+
 func init() {
 	tracing.RegisterTagRemapping("r", "range")
 }

--- a/pkg/kv/kvserver/replica_eval_context_span.go
+++ b/pkg/kv/kvserver/replica_eval_context_span.go
@@ -267,3 +267,10 @@ func (rec *SpanSetReplicaEvalContext) GetMaxBytes() int64 {
 func (rec *SpanSetReplicaEvalContext) GetEngineCapacity() (roachpb.StoreCapacity, error) {
 	return rec.i.GetEngineCapacity()
 }
+
+// GetApproximateDiskBytes implements the batcheval.EvalContext interface.
+func (rec *SpanSetReplicaEvalContext) GetApproximateDiskBytes(
+	from, to roachpb.Key,
+) (uint64, error) {
+	return rec.i.GetApproximateDiskBytes(from, to)
+}

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -244,6 +244,7 @@ go_library(
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_pebble//:pebble",
+        "@com_github_cockroachdb_pebble//bloom",
         "@com_github_cockroachdb_pebble//vfs",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_getsentry_sentry_go//:sentry-go",

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/redact"
 )
@@ -627,7 +628,17 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 			pebbleConfig.Opts.MaxOpenFiles = int(openFileLimitPerStore)
 			// If the spec contains Pebble options, set those too.
 			if len(spec.PebbleOptions) > 0 {
-				err := pebbleConfig.Opts.Parse(spec.PebbleOptions, &pebble.ParseHooks{})
+				err := pebbleConfig.Opts.Parse(spec.PebbleOptions, &pebble.ParseHooks{
+					NewFilterPolicy: func(name string) (pebble.FilterPolicy, error) {
+						switch name {
+						case "none":
+							return nil, nil
+						case "rocksdb.BuiltinBloomFilter":
+							return bloom.FilterPolicy(10), nil
+						}
+						return nil, nil
+					},
+				})
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/storage/bench_pebble_test.go
+++ b/pkg/storage/bench_pebble_test.go
@@ -400,13 +400,13 @@ func BenchmarkBatchBuilderPut(b *testing.B) {
 func BenchmarkCheckSSTConflicts(b *testing.B) {
 	for _, numKeys := range []int{1000, 10000, 100000} {
 		b.Run(fmt.Sprintf("keys=%d", numKeys), func(b *testing.B) {
-			for _, numVersions := range []int{8, 64} {
-				b.Run(fmt.Sprintf("versions=%d", numVersions), func(b *testing.B) {
-					for _, numSstKeys := range []int{1000, 10000} {
-						b.Run(fmt.Sprintf("sstKeys=%d", numSstKeys), func(b *testing.B) {
-							for _, overlap := range []bool{false, true} {
-								b.Run(fmt.Sprintf("overlap=%t", overlap), func(b *testing.B) {
-									runCheckSSTConflicts(b, numKeys, numVersions, numSstKeys, overlap)
+			for _, numSstKeys := range []int{10, 100, 1000, 10000, 100000} {
+				b.Run(fmt.Sprintf("sstKeys=%d", numSstKeys), func(b *testing.B) {
+					for _, overlap := range []bool{false, true} {
+						b.Run(fmt.Sprintf("overlap=%t", overlap), func(b *testing.B) {
+							for _, usePrefixSeek := range []bool{false, true} {
+								b.Run(fmt.Sprintf("prefixSeek=%t", usePrefixSeek), func(b *testing.B) {
+									runCheckSSTConflicts(b, numKeys, 1 /* numVersions */, numSstKeys, overlap, usePrefixSeek)
 								})
 							}
 						})

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -309,6 +309,14 @@ type IterOptions struct {
 	// use such an iterator is to use it in concert with an iterator without
 	// timestamp hints, as done by MVCCIncrementalIterator.
 	MinTimestampHint, MaxTimestampHint hlc.Timestamp
+	// useL6Filters allows the caller to opt into reading filter blocks for
+	// L6 sstables. Only for use with Prefix = true. Helpful if a lot of prefix
+	// Seeks are expected in quick succession, that are also likely to not
+	// yield a single key. Filter blocks in L6 can be relatively large, often
+	// larger than data blocks, so the benefit of loading them in the cache
+	// is minimized if the probability of the key existing is not low or if
+	// this is a one-time Seek (where loading the data block directly is better).
+	useL6Filters bool
 }
 
 // MVCCIterKind is used to inform Reader about the kind of iteration desired

--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -323,6 +323,12 @@ func (i *intentInterleavingIter) SeekGE(key MVCCKey) {
 		// so don't expect to ever see the intent. NB: intentSeekKey is nil.
 		i.intentKey = nil
 	}
+	if !i.iterValid && i.prefix {
+		// The prefix seek below will also certainly fail, as we didn't find an
+		// MVCC value here.
+		intentSeekKey = nil
+		i.intentKey = nil
+	}
 	if intentSeekKey != nil {
 		var limitKey roachpb.Key
 		if i.iterValid && !i.prefix {

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -121,9 +121,10 @@ func (p *pebbleIterator) init(
 		panic("iterator must set prefix or upper bound or lower bound")
 	}
 
-	p.options.OnlyReadGuaranteedDurable = false
-	if durability == GuaranteedDurability {
-		p.options.OnlyReadGuaranteedDurable = true
+	// Generate new Pebble iterator options.
+	p.options = pebble.IterOptions{
+		OnlyReadGuaranteedDurable: durability == GuaranteedDurability,
+		UseL6Filters:              opts.useL6Filters,
 	}
 	if opts.LowerBound != nil {
 		// This is the same as

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -52,60 +52,57 @@ func CheckSSTConflicts(
 	disallowShadowing bool,
 	disallowShadowingBelow hlc.Timestamp,
 	maxIntents int64,
+	usePrefixSeek bool,
 ) (enginepb.MVCCStats, error) {
 	var statsDiff enginepb.MVCCStats
 	var intents []roachpb.Intent
 
-	extIter := reader.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: end.Key})
+	if usePrefixSeek {
+		// If we're going to be using a prefix iterator, check for the fast path
+		// first, where there are no keys in the reader between the sstable's start
+		// and end keys. We use a non-prefix iterator for this search, and reopen a
+		// prefix one if there are engine keys in the span.
+		nonPrefixIter := reader.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: end.Key})
+		nonPrefixIter.SeekGE(start)
+		valid, err := nonPrefixIter.Valid()
+		nonPrefixIter.Close()
+		if !valid {
+			return statsDiff, err
+		}
+	}
+
+	extIter := reader.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+		UpperBound:   end.Key,
+		Prefix:       usePrefixSeek,
+		useL6Filters: true,
+	})
 	defer extIter.Close()
-	extIter.SeekGE(start)
 
 	sstIter, err := NewMemSSTIterator(sst, false)
 	if err != nil {
 		return enginepb.MVCCStats{}, err
 	}
 	defer sstIter.Close()
-	sstIter.SeekGE(start)
 
-	extOK, extErr := extIter.Valid()
-	sstOK, sstErr := sstIter.Valid()
-	for extErr == nil && sstErr == nil && extOK && sstOK {
-		if err := ctx.Err(); err != nil {
-			return enginepb.MVCCStats{}, err
-		}
-
-		extKey, extValue := extIter.UnsafeKey(), extIter.UnsafeValue()
-		sstKey, sstValue := sstIter.UnsafeKey(), sstIter.UnsafeValue()
-
-		// Keep seeking the iterators until both keys are equal.
-		if cmp := bytes.Compare(extKey.Key, sstKey.Key); cmp < 0 {
-			extIter.SeekGE(MVCCKey{Key: sstKey.Key})
-			extOK, extErr = extIter.Valid()
-			continue
-		} else if cmp > 0 {
-			sstIter.SeekGE(MVCCKey{Key: extKey.Key})
-			sstOK, sstErr = sstIter.Valid()
-			continue
-		}
-
+	compareForCollision := func(sstKey, extKey MVCCKey, sstValueRaw, extValueRaw []byte) error {
 		// Make sure both keys are proper committed MVCC keys. Note that this is
 		// only checked when the key exists both in the SST and existing data, it is
 		// not an exhaustive check of the SST.
 		if !sstKey.IsValue() {
-			return enginepb.MVCCStats{}, errors.New("SST keys must have timestamps")
+			return errors.New("SST keys must have timestamps")
 		}
-		if len(sstValue) == 0 {
-			return enginepb.MVCCStats{}, errors.New("SST values cannot be tombstones")
+		if len(sstValueRaw) == 0 {
+			return errors.New("SST values cannot be tombstones")
 		}
 		if !extKey.IsValue() {
 			var mvccMeta enginepb.MVCCMetadata
 			if err = extIter.ValueProto(&mvccMeta); err != nil {
-				return enginepb.MVCCStats{}, err
+				return err
 			}
 			if len(mvccMeta.RawBytes) > 0 {
-				return enginepb.MVCCStats{}, errors.New("inline values are unsupported")
+				return errors.New("inline values are unsupported")
 			} else if mvccMeta.Txn == nil {
-				return enginepb.MVCCStats{}, errors.New("found intent without transaction")
+				return errors.New("found intent without transaction")
 			} else {
 				// If we encounter a write intent, keep looking for additional intents
 				// in order to return a large batch for intent resolution. The caller
@@ -114,18 +111,11 @@ func CheckSSTConflicts(
 				// of scans.
 				intents = append(intents, roachpb.MakeIntent(mvccMeta.Txn, extIter.Key().Key))
 				if int64(len(intents)) >= maxIntents {
-					return enginepb.MVCCStats{}, &roachpb.WriteIntentError{Intents: intents}
+					return &roachpb.WriteIntentError{Intents: intents}
 				}
-				sstIter.NextKey()
-				sstOK, sstErr = sstIter.Valid()
-				if sstOK {
-					extIter.SeekGE(MVCCKey{Key: sstIter.UnsafeKey().Key})
-				}
-				extOK, extErr = extIter.Valid()
-				continue
+				return nil
 			}
 		}
-
 		// Allow certain idempotent writes where key/timestamp/value all match:
 		//
 		// * disallowShadowing: any matching key.
@@ -133,7 +123,7 @@ func CheckSSTConflicts(
 		allowIdempotent := (!disallowShadowingBelow.IsEmpty() && disallowShadowingBelow.LessEq(extKey.Timestamp)) ||
 			(disallowShadowingBelow.IsEmpty() && disallowShadowing)
 		if allowIdempotent && sstKey.Timestamp.Equal(extKey.Timestamp) &&
-			bytes.Equal(extValue, sstValue) {
+			bytes.Equal(extValueRaw, sstValueRaw) {
 			// This SST entry will effectively be a noop, but its stats have already
 			// been accounted for resulting in double-counting. To address this we
 			// send back a stats diff for these existing KVs so that we can subtract
@@ -151,19 +141,13 @@ func CheckSSTConflicts(
 			statsDiff.KeyCount--
 
 			// Update the stats to account for the skipped versioned key/value.
-			totalBytes = int64(len(sstValue)) + MVCCVersionTimestampSize
+			totalBytes = int64(len(sstValueRaw)) + MVCCVersionTimestampSize
 			statsDiff.LiveBytes -= totalBytes
 			statsDiff.KeyBytes -= MVCCVersionTimestampSize
-			statsDiff.ValBytes -= int64(len(sstValue))
+			statsDiff.ValBytes -= int64(len(sstValueRaw))
 			statsDiff.ValCount--
 
-			sstIter.NextKey()
-			sstOK, sstErr = sstIter.Valid()
-			if sstOK {
-				extIter.SeekGE(MVCCKey{Key: sstIter.UnsafeKey().Key})
-			}
-			extOK, extErr = extIter.Valid()
-			continue
+			return nil
 		}
 
 		// If requested, check that we're not shadowing a live key. Note that
@@ -171,11 +155,11 @@ func CheckSSTConflicts(
 		// a WriteTooOldError -- that error implies that the client should
 		// retry at a higher timestamp, but we already know that such a retry
 		// would fail (because it will shadow an existing key).
-		if len(extValue) > 0 && (!disallowShadowingBelow.IsEmpty() || disallowShadowing) {
+		if len(extValueRaw) > 0 && (!disallowShadowingBelow.IsEmpty() || disallowShadowing) {
 			allowShadow := !disallowShadowingBelow.IsEmpty() &&
-				disallowShadowingBelow.LessEq(extKey.Timestamp) && bytes.Equal(extValue, sstValue)
+				disallowShadowingBelow.LessEq(extKey.Timestamp) && bytes.Equal(extValueRaw, sstValueRaw)
 			if !allowShadow {
-				return enginepb.MVCCStats{}, errors.Errorf(
+				return errors.Errorf(
 					"ingested key collides with an existing one: %s", sstKey.Key)
 			}
 		}
@@ -186,7 +170,7 @@ func CheckSSTConflicts(
 		// do if AddSSTable had SSTTimestampToRequestTimestamp set, but AddSSTable
 		// cannot be used in transactions so we don't need to check.
 		if sstKey.Timestamp.LessEq(extKey.Timestamp) {
-			return enginepb.MVCCStats{}, roachpb.NewWriteTooOldError(
+			return roachpb.NewWriteTooOldError(
 				sstKey.Timestamp, extKey.Timestamp.Next(), sstKey.Key)
 		}
 
@@ -194,10 +178,89 @@ func CheckSSTConflicts(
 		// to take into account the existing KV pair.
 		statsDiff.KeyCount--
 		statsDiff.KeyBytes -= int64(len(extKey.Key) + 1)
-		if len(extValue) > 0 {
+		if len(extValueRaw) > 0 {
 			statsDiff.LiveCount--
 			statsDiff.LiveBytes -= int64(len(extKey.Key) + 1)
-			statsDiff.LiveBytes -= int64(len(extValue)) + MVCCVersionTimestampSize
+			statsDiff.LiveBytes -= int64(len(extValueRaw)) + MVCCVersionTimestampSize
+		}
+		return nil
+	}
+
+	sstIter.SeekGE(start)
+	sstOK, sstErr := sstIter.Valid()
+	var extOK bool
+	var extErr error
+
+	if usePrefixSeek {
+		// In the case of prefix seeks, do not look at engine iter exhaustion. This
+		// is because the engine prefix iterator could be exhausted when it has
+		// iterated past its prefix, even if there are other keys after the prefix
+		// that should be checked.
+		for sstErr == nil && sstOK {
+			if err := ctx.Err(); err != nil {
+				return enginepb.MVCCStats{}, err
+			}
+			// extIter is a prefix iterator; it is expected to skip keys that belong
+			// to different prefixes. Only iterate along the sst iterator, and re-seek
+			// extIter each time.
+			extIter.SeekGE(MVCCKey{Key: sstIter.UnsafeKey().Key})
+			extOK, extErr = extIter.Valid()
+			if extErr != nil {
+				break
+			}
+			if !extOK {
+				// There is no key in extIter matching this prefix. Check the next key in
+				// sstIter. Note that we can't just use an exhausted extIter as a sign that
+				// we are done with the loop; extIter is a prefix iterator and could
+				// have keys after the current prefix that it will not return unless
+				// re-seeked.
+				sstIter.NextKey()
+				sstOK, sstErr = sstIter.Valid()
+				continue
+			}
+
+			extKey, extValueRaw := extIter.UnsafeKey(), extIter.UnsafeValue()
+			sstKey, sstValueRaw := sstIter.UnsafeKey(), sstIter.UnsafeValue()
+
+			// We just seeked the engine iter. If it has a mismatching prefix, the
+			// iterator is not obeying its contract.
+			if !bytes.Equal(extKey.Key, sstKey.Key) {
+				return enginepb.MVCCStats{}, errors.Errorf("prefix iterator returned mismatching prefix: %s != %s", extKey.Key, sstKey.Key)
+			}
+
+			if err := compareForCollision(sstKey, extKey, sstValueRaw, extValueRaw); err != nil {
+				return enginepb.MVCCStats{}, err
+			}
+
+			sstIter.NextKey()
+			sstOK, sstErr = sstIter.Valid()
+		}
+	} else {
+		extIter.SeekGE(start)
+		extOK, extErr = extIter.Valid()
+	}
+
+	for !usePrefixSeek && sstErr == nil && sstOK && extOK && extErr == nil {
+		if err := ctx.Err(); err != nil {
+			return enginepb.MVCCStats{}, err
+		}
+		extKey, extValueRaw := extIter.UnsafeKey(), extIter.UnsafeValue()
+		sstKey, sstValueRaw := sstIter.UnsafeKey(), sstIter.UnsafeValue()
+
+		// Keep seeking the iterators until both keys are equal.
+		if cmp := bytes.Compare(extKey.Key, sstKey.Key); cmp < 0 {
+			// sstIter is further ahead. Seek extIter.
+			extIter.SeekGE(MVCCKey{Key: sstKey.Key})
+			extOK, extErr = extIter.Valid()
+			continue
+		} else if cmp > 0 {
+			sstIter.SeekGE(MVCCKey{Key: extKey.Key})
+			sstOK, sstErr = sstIter.Valid()
+			continue
+		}
+
+		if err := compareForCollision(sstKey, extKey, sstValueRaw, extValueRaw); err != nil {
+			return enginepb.MVCCStats{}, err
 		}
 
 		sstIter.NextKey()


### PR DESCRIPTION
22.1 backport of the first part of #81062. Also bumps Pebble to pick up the relevant backported commit there.

---

This change includes 4 changes to significantly improve
the performance of CheckSSTCollisions (and by extension,
AddSSTable) for cases where we add very wide sstables
relative to the engine:

1) Check if we're adding an sstable that has a small number of
keys, or has a 100x greater overlap with the engine relative
to its own size. In that case, switch to doing prefix seeks
inside CheckSSTCollisions, similar to what we did in https://github.com/cockroachdb/cockroach/pull/73514
and then reverted later).
2) Thread a new IterOption to only optionally read L6
filter blocks in prefix iteration, defaulting to not reading
them. This iterator option hooks into the one added in
Pebble in https://github.com/cockroachdb/pebble/pull/1685 ).
3) Add a ParseHook to allow command-line pebble options to
allow configuring the writing of bloom filters. This allows
L6 filter block writing to be turned on through a command
line argument.
4) Update intentInterleavingIter to not prefix-seek the
intent/lock table iterator if we are in prefix seek mode and
the MVCC iterator returned nothing.

Fixes https://github.com/cockroachdb/cockroach/issues/80980.

Release note (performance improvement): Significantly improve
performance of IMPORTs when the source is producing data
not sorted by the destination table's primary key, especially
if the destination table has a very large primary key with
lots of columns.