### PR TITLE
ci: skip Docker test in CI

### DIFF
--- a/build/teamcity/cockroach/ci/tests/docker_image.sh
+++ b/build/teamcity/cockroach/ci/tests/docker_image.sh
@@ -9,9 +9,10 @@ tc_prepare
 
 tc_start_block "Run docker image tests"
 
-bazel run \
-  //pkg/testutils/docker:docker_test \
-  --config=crosslinux --config=test \
-  --test_timeout=3000
+# Skip for now: #82747
+#bazel run \
+#  //pkg/testutils/docker:docker_test \
+#  --config=crosslinux --config=test \
+#  --test_timeout=3000
 
 tc_end_block "Run docker image tests"


### PR DESCRIPTION
This has been flaky for a while, skipping until we have more information
about what's going on here.

Release note: None