### PR TITLE
scripts: adjust bump-pebble.sh to add build/bazelutil/distdir_files.bzl

### DIFF
--- a/scripts/bump-pebble.sh
+++ b/scripts/bump-pebble.sh
@@ -88,7 +88,7 @@ popd
 # Create the branch and commit on the CockroachDB repository.
 pushd "$COCKROACH_DIR"
 ./dev generate bazel --mirror
-git add go.mod go.sum DEPS.bzl
+git add go.mod go.sum DEPS.bzl build/bazelutil/distdir_files.bzl
 git add vendor
 git branch -D "$COCKROACH_BRANCH" || true
 git checkout -b "$COCKROACH_BRANCH"


### PR DESCRIPTION
The bump-pebble.sh script should `git add build/bazelutil/distdir_files.bzl`
which requires updates whenever the Pebble version is bumped.

Release note: None