### PR TITLE
trigram: fix to similarity with length=0; tests

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -518,6 +518,7 @@ ALL_TESTS = [
     "//pkg/util/tracing/service:service_test",
     "//pkg/util/tracing:tracing_test",
     "//pkg/util/treeprinter:treeprinter_test",
+    "//pkg/util/trigram:trigram_test",
     "//pkg/util/uint128:uint128_test",
     "//pkg/util/ulid:ulid_test",
     "//pkg/util/unique:unique_test",

--- a/pkg/sql/logictest/testdata/logic_test/trigram_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/trigram_builtins
@@ -42,12 +42,24 @@ SELECT show_trgm('a b,c|d_e3 bl  ')
 # Test the similarity builtin.
 query F
 SELECT similarity(a, b) FROM (VALUES
+    ('', ''),
+    ('foo', ''),
+    ('', 'foo'),
+    ('foo', NULL),
+    (NULL, 'foo'),
+    (NULL, NULL),
     ('foo', 'bar'),
     ('foo', 'far'),
     ('foo', 'for'),
     ('foo', 'foo')
   ) tbl(a, b)
 ----
+0
+0
+0
+NULL
+NULL
+NULL
 0
 0.142857142857143
 0.333333333333333

--- a/pkg/util/trigram/BUILD.bazel
+++ b/pkg/util/trigram/BUILD.bazel
@@ -1,8 +1,15 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "trigram",
     srcs = ["trigram.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/trigram",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "trigram_test",
+    srcs = ["trigram_test.go"],
+    embed = [":trigram"],
+    deps = ["@com_github_stretchr_testify//assert"],
 )

--- a/pkg/util/trigram/trigram.go
+++ b/pkg/util/trigram/trigram.go
@@ -19,7 +19,7 @@ import (
 
 // Trigrams are calculated per word. Words are made up of alphanumeric
 // characters. Note that this doesn't include _, so we can't just use \w.
-var alphaNumRe = regexp.MustCompile("[a-zA-Z0-9]+")
+var alphaNumRe = regexp.MustCompile("[a-z0-9]+")
 
 // MakeTrigrams returns the downcased, sorted and de-duplicated trigrams for an
 // input string. Non-alphanumeric characters are treated as word boundaries.
@@ -53,7 +53,7 @@ func MakeTrigrams(s string, pad bool) []string {
 	}
 
 	if len(output) == 0 {
-		return output
+		return nil
 	}
 
 	// Sort the array and deduplicate.
@@ -79,6 +79,10 @@ func MakeTrigrams(s string, pad bool) []string {
 // means the trigrams are identical, 0.0 means no trigrams were shared.
 func Similarity(l string, r string) float64 {
 	lTrigrams, rTrigrams := MakeTrigrams(l, true /* pad */), MakeTrigrams(r, true /* pad */)
+
+	if len(lTrigrams) == 0 || len(rTrigrams) == 0 {
+		return 0
+	}
 
 	// To calculate the similarity, we count the number of shared trigrams
 	// in the strings, and divide by the number of non-shared trigrams.

--- a/pkg/util/trigram/trigram_test.go
+++ b/pkg/util/trigram/trigram_test.go
@@ -1,0 +1,83 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package trigram
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeTrigrams(t *testing.T) {
+	for _, tc := range []struct {
+		s            string
+		wantPadded   []string
+		wantUnpadded []string
+	}{
+		// Test short strings.
+		{"", nil, nil},
+		{"a", []string{"  a", " a "}, nil},
+		{"1", []string{"  1", " 1 "}, nil},
+		{"ab", []string{"  a", " ab", "ab "}, nil},
+		{"ab ", []string{"  a", " ab", "ab "}, nil},
+		{"%ab", []string{"  a", " ab", "ab "}, nil},
+		// Test non-alphanum removal.
+		{".,!@#$%^&*()[]{}-_ ", nil, nil},
+		// Test de-duping and sorting of trigrams.
+		{"abaaba",
+			[]string{"  a", " ab", "aab", "aba", "ba ", "baa"},
+			[]string{"aab", "aba", "baa"}},
+		{"bcaabc",
+			[]string{"  b", " bc", "aab", "abc", "bc ", "bca", "caa"},
+			[]string{"aab", "abc", "bca", "caa"}},
+	} {
+		padded := MakeTrigrams(tc.s, true)
+		unpadded := MakeTrigrams(tc.s, false)
+		assert.Equal(t, tc.wantPadded, padded)
+		assert.Equal(t, tc.wantUnpadded, unpadded)
+	}
+}
+
+func TestSimilarity(t *testing.T) {
+	for _, tc := range []struct {
+		l    string
+		r    string
+		want float64
+	}{
+		// Empty cases.
+		{"", "", 0},
+		{"a", "", 0},
+		{"blahblah blah", "", 0},
+		{"", "a", 0},
+		{"", "blahblah blah", 0},
+
+		// Non-alpha.
+		{"_-%#@($", "_-%#@($", 0},
+		{"_-%#@($a", "a_-%#@($", 1},
+		{"_-%#@($a", "a_-%#@($a", 1},
+
+		{"a", "a", 1},
+		{"ab", "ab", 1},
+		{"ab", "ba", 0},
+		{"baba", "abab", 0.25},
+		{"trigram", "triglam", 0.4545},
+		{"trigram", "trigam", 0.5},
+		{"trigram", "trigarm", 0.3333},
+		{"tritritritri", "tritritritri", 1},
+		{"tritritritri", "tritritritrn", 0.625},
+		{"tritritri", "tritritrn", 0.625},
+		{"tritritri", "tritrntri", 0.6666},
+		{"tritri", "tritrn", 0.625},
+		{"tritri", "trntri", 0.4444},
+	} {
+		assert.InDelta(t, tc.want, Similarity(tc.l, tc.r), 0.0001, "for %s %% %s", tc.l, tc.r)
+	}
+}


### PR DESCRIPTION
Closes #82755

The trigram similarity function returned NaN when it should have
returned 0 when passed two empty inputs.

This is now corrected. Also, add a unit test suite just for the trigram
package.

Release note: None