### PR TITLE
kv: don't allow lease transfers to replicas in need of snapshot

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -349,6 +349,7 @@ go_test(
         "//pkg/kv/kvserver/protectedts/ptstorage",
         "//pkg/kv/kvserver/protectedts/ptutil",
         "//pkg/kv/kvserver/raftentry",
+        "//pkg/kv/kvserver/raftutil",
         "//pkg/kv/kvserver/rditer",
         "//pkg/kv/kvserver/readsummary/rspb",
         "//pkg/kv/kvserver/replicastats",

--- a/pkg/kv/kvserver/client_relocate_range_test.go
+++ b/pkg/kv/kvserver/client_relocate_range_test.go
@@ -43,6 +43,7 @@ func relocateAndCheck(
 	voterTargets []roachpb.ReplicationTarget,
 	nonVoterTargets []roachpb.ReplicationTarget,
 ) (retries int) {
+	t.Helper()
 	every := log.Every(1 * time.Second)
 	testutils.SucceedsSoon(t, func() error {
 		err := tc.Servers[0].DB().

--- a/pkg/kv/kvserver/markers.go
+++ b/pkg/kv/kvserver/markers.go
@@ -82,8 +82,21 @@ func IsIllegalReplicationChangeError(err error) bool {
 var errMarkReplicationChangeInProgress = errors.New("replication change in progress")
 
 // IsReplicationChangeInProgressError detects whether an error (assumed to have
-// been emitted a replication change) indicates that the replication change
+// been emitted by a replication change) indicates that the replication change
 // failed because another replication change was in progress on the range.
 func IsReplicationChangeInProgressError(err error) bool {
 	return errors.Is(err, errMarkReplicationChangeInProgress)
+}
+
+var errMarkLeaseTransferRejectedBecauseTargetMayNeedSnapshot = errors.New(
+	"lease transfer rejected because the target may need a snapshot")
+
+// IsLeaseTransferRejectedBecauseTargetMayNeedSnapshotError detects whether an
+// error (assumed to have been emitted by a lease transfer request) indicates
+// that the lease transfer failed because the current leaseholder could not
+// prove that the lease transfer target did not need a Raft snapshot. In order
+// to prove this, the current leaseholder must also be the Raft leader, which is
+// periodically requested in maybeTransferRaftLeadershipToLeaseholderLocked.
+func IsLeaseTransferRejectedBecauseTargetMayNeedSnapshotError(err error) bool {
+	return errors.Is(err, errMarkLeaseTransferRejectedBecauseTargetMayNeedSnapshot)
 }

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -104,6 +104,7 @@ func newUnloadedReplica(
 	r.mu.checksums = map[uuid.UUID]replicaChecksum{}
 	r.mu.proposalBuf.Init((*replicaProposer)(r), tracker.NewLockfreeTracker(), r.Clock(), r.ClusterSettings())
 	r.mu.proposalBuf.testing.allowLeaseProposalWhenNotLeader = store.cfg.TestingKnobs.AllowLeaseRequestProposalsWhenNotLeader
+	r.mu.proposalBuf.testing.allowLeaseTransfersWhenTargetMayNeedSnapshot = store.cfg.TestingKnobs.AllowLeaseTransfersWhenTargetMayNeedSnapshot
 	r.mu.proposalBuf.testing.dontCloseTimestamps = store.cfg.TestingKnobs.DontCloseTimestamps
 	r.mu.proposalBuf.testing.submitProposalFilter = store.cfg.TestingKnobs.TestingProposalSubmitFilter
 

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -389,20 +389,8 @@ func (b *propBuf) FlushLockedWithRaftGroup(
 	buf := b.arr.asSlice()[:used]
 	ents := make([]raftpb.Entry, 0, used)
 
-	// Figure out leadership info. We'll use it to conditionally drop some
-	// requests.
-	var leaderInfo rangeLeaderInfo
-	if raftGroup != nil {
-		leaderInfo = b.p.leaderStatusRLocked(raftGroup)
-		// Sanity check.
-		if leaderInfo.leaderKnown && leaderInfo.leader == b.p.getReplicaID() &&
-			!leaderInfo.iAmTheLeader {
-			log.Fatalf(ctx,
-				"inconsistent Raft state: state %s while the current replica is also the lead: %d",
-				raftGroup.BasicStatus().RaftState, leaderInfo.leader)
-		}
-	}
-
+	// Compute the closed timestamp target, which will be used to assign a closed
+	// timestamp to all proposals in this batch.
 	closedTSTarget := b.p.closedTimestampTarget()
 
 	// Remember the first error that we see when proposing the batch. We don't
@@ -418,58 +406,10 @@ func (b *propBuf) FlushLockedWithRaftGroup(
 		buf[i] = nil // clear buffer
 		reproposal := !p.tok.stillTracked()
 
-		// Handle an edge case about lease acquisitions: we don't want to forward
-		// lease acquisitions to another node (which is what happens when we're not
-		// the leader) because:
-		// a) if there is a different leader, that leader should acquire the lease
-		// itself and thus avoid a change of leadership caused by the leaseholder
-		// and leader being different (Raft leadership follows the lease), and
-		// b) being a follower, it's possible that this replica is behind in
-		// applying the log. Thus, there might be another lease in place that this
-		// follower doesn't know about, in which case the lease we're proposing here
-		// would be rejected. Not only would proposing such a lease be wasted work,
-		// but we're trying to protect against pathological cases where it takes a
-		// long time for this follower to catch up (for example because it's waiting
-		// for a snapshot, and the snapshot is queued behind many other snapshots).
-		// In such a case, we don't want all requests arriving at this node to be
-		// blocked on this lease acquisition (which is very likely to eventually
-		// fail anyway).
-		//
-		// Thus, we do one of two things:
-		// - if the leader is known, we reject this proposal and make sure the
-		// request that needed the lease is redirected to the leaseholder;
-		// - if the leader is not known, we don't do anything special here to
-		// terminate the proposal, but we know that Raft will reject it with a
-		// ErrProposalDropped. We'll eventually re-propose it once a leader is
-		// known, at which point it will either go through or be rejected based on
-		// whether or not it is this replica that became the leader.
-		//
-		// A special case is when the leader is known, but is ineligible to get the
-		// lease. In that case, we have no choice but to continue with the proposal.
-		//
-		// Lease extensions for a currently held lease always go through, to
-		// keep the lease alive until the normal lease transfer mechanism can
-		// colocate it with the leader.
-		if !leaderInfo.iAmTheLeader && p.Request.IsSingleRequestLeaseRequest() {
-			leaderKnownAndEligible := leaderInfo.leaderKnown && leaderInfo.leaderEligibleForLease
-			ownsCurrentLease := b.p.ownsValidLeaseRLocked(ctx, b.clock.NowAsClockTimestamp())
-			if leaderKnownAndEligible && !ownsCurrentLease && !b.testing.allowLeaseProposalWhenNotLeader {
-				log.VEventf(ctx, 2, "not proposing lease acquisition because we're not the leader; replica %d is",
-					leaderInfo.leader)
-				b.p.rejectProposalWithRedirectLocked(ctx, p, leaderInfo.leader)
-				p.tok.doneIfNotMovedLocked(ctx)
-				continue
-			}
-			// If the leader is not known, or if it is known but it's ineligible
-			// for the lease, continue with the proposal as explained above. We
-			// also send lease extensions for an existing leaseholder.
-			if ownsCurrentLease {
-				log.VEventf(ctx, 2, "proposing lease extension even though we're not the leader; we hold the current lease")
-			} else if !leaderInfo.leaderKnown {
-				log.VEventf(ctx, 2, "proposing lease acquisition even though we're not the leader; the leader is unknown")
-			} else {
-				log.VEventf(ctx, 2, "proposing lease acquisition even though we're not the leader; the leader is ineligible")
-			}
+		// Conditionally reject the proposal based on the state of the raft group.
+		if b.maybeRejectUnsafeProposalLocked(ctx, raftGroup, p) {
+			p.tok.doneIfNotMovedLocked(ctx)
+			continue
 		}
 
 		// Raft processing bookkeeping.
@@ -583,6 +523,105 @@ func (b *propBuf) FlushLockedWithRaftGroup(
 		return 0, firstErr
 	}
 	return used, proposeBatch(raftGroup, b.p.getReplicaID(), ents)
+}
+
+// maybeRejectUnsafeProposalLocked conditionally rejects proposals that are
+// deemed unsafe, given the current state of the raft group. Requests that may
+// be deemed unsafe and rejected at this level are those whose safety has some
+// dependency on raft leadership, follower progress, leadership term, commit
+// index, or other properties of raft. By rejecting these requests on the
+// "flushing" side of the proposal buffer (i.e. while holding the raftMu), we
+// can perform the safety checks without risk of the state of the raft group
+// changing before the proposal is passed to etcd/raft.
+//
+// Currently, the request types which may be rejected by this function are:
+// - RequestLease when the proposer is not the raft leader (with caveats).
+//
+// The function returns true if the proposal was rejected, and false if not.
+// If the proposal was rejected and true is returned, it will have been cleaned
+// up (passed to Replica.cleanupFailedProposalLocked) and finished
+// (ProposalData.finishApplication called).
+func (b *propBuf) maybeRejectUnsafeProposalLocked(
+	ctx context.Context, raftGroup proposerRaft, p *ProposalData,
+) (rejected bool) {
+	switch {
+	case p.Request.IsSingleRequestLeaseRequest():
+		// Handle an edge case about lease acquisitions: we don't want to forward
+		// lease acquisitions to another node (which is what happens when we're not
+		// the leader) because:
+		// a) if there is a different leader, that leader should acquire the lease
+		// itself and thus avoid a change of leadership caused by the leaseholder
+		// and leader being different (Raft leadership follows the lease), and
+		// b) being a follower, it's possible that this replica is behind in
+		// applying the log. Thus, there might be another lease in place that this
+		// follower doesn't know about, in which case the lease we're proposing here
+		// would be rejected. Not only would proposing such a lease be wasted work,
+		// but we're trying to protect against pathological cases where it takes a
+		// long time for this follower to catch up (for example because it's waiting
+		// for a snapshot, and the snapshot is queued behind many other snapshots).
+		// In such a case, we don't want all requests arriving at this node to be
+		// blocked on this lease acquisition (which is very likely to eventually
+		// fail anyway).
+		//
+		// Thus, we do one of two things:
+		// - if the leader is known, we reject this proposal and make sure the
+		// request that needed the lease is redirected to the leaseholder;
+		// - if the leader is not known, we don't do anything special here to
+		// terminate the proposal, but we know that Raft will reject it with a
+		// ErrProposalDropped. We'll eventually re-propose it once a leader is
+		// known, at which point it will either go through or be rejected based on
+		// whether or not it is this replica that became the leader.
+		//
+		// A special case is when the leader is known, but is ineligible to get the
+		// lease. In that case, we have no choice but to continue with the proposal.
+		//
+		// Lease extensions for a currently held lease always go through, to
+		// keep the lease alive until the normal lease transfer mechanism can
+		// colocate it with the leader.
+		li := b.leaderStatusRLocked(ctx, raftGroup)
+		if li.iAmTheLeader {
+			return false
+		}
+		leaderKnownAndEligible := li.leaderKnown && li.leaderEligibleForLease
+		ownsCurrentLease := b.p.ownsValidLeaseRLocked(ctx, b.clock.NowAsClockTimestamp())
+		if leaderKnownAndEligible && !ownsCurrentLease && !b.testing.allowLeaseProposalWhenNotLeader {
+			log.VEventf(ctx, 2, "not proposing lease acquisition because we're not the leader; replica %d is",
+				li.leader)
+			b.p.rejectProposalWithRedirectLocked(ctx, p, li.leader)
+			return true
+		}
+		// If the leader is not known, or if it is known but it's ineligible
+		// for the lease, continue with the proposal as explained above. We
+		// also send lease extensions for an existing leaseholder.
+		if ownsCurrentLease {
+			log.VEventf(ctx, 2, "proposing lease extension even though we're not the leader; we hold the current lease")
+		} else if !li.leaderKnown {
+			log.VEventf(ctx, 2, "proposing lease acquisition even though we're not the leader; the leader is unknown")
+		} else {
+			log.VEventf(ctx, 2, "proposing lease acquisition even though we're not the leader; the leader is ineligible")
+		}
+		return false
+
+	default:
+		return false
+	}
+}
+
+// leaderStatusRLocked returns the rangeLeaderInfo for the provided raft group,
+// or an empty rangeLeaderInfo if the raftGroup is nil.
+func (b *propBuf) leaderStatusRLocked(ctx context.Context, raftGroup proposerRaft) rangeLeaderInfo {
+	if raftGroup == nil {
+		return rangeLeaderInfo{}
+	}
+	leaderInfo := b.p.leaderStatusRLocked(raftGroup)
+	// Sanity check.
+	if leaderInfo.leaderKnown && leaderInfo.leader == b.p.getReplicaID() &&
+		!leaderInfo.iAmTheLeader {
+		log.Fatalf(ctx,
+			"inconsistent Raft state: state %s while the current replica is also the lead: %d",
+			raftGroup.BasicStatus().RaftState, leaderInfo.leader)
+	}
+	return leaderInfo
 }
 
 // allocateLAIAndClosedTimestampLocked computes a LAI and closed timestamp to be

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -616,6 +616,9 @@ func TestBehaviorDuringLeaseTransfer(t *testing.T) {
 		tsc := TestStoreConfig(clock)
 		var leaseAcquisitionTrap atomic.Value
 		tsc.TestingKnobs.DisableAutomaticLeaseRenewal = true
+		// We're transferring the lease to a bogus replica, so disable protection
+		// which would otherwise notice this and reject the lease transfer.
+		tsc.TestingKnobs.AllowLeaseTransfersWhenTargetMayNeedSnapshot = true
 		tsc.TestingKnobs.LeaseRequestEvent = func(ts hlc.Timestamp, _ roachpb.StoreID, _ roachpb.RangeID) *roachpb.Error {
 			val := leaseAcquisitionTrap.Load()
 			if val == nil {

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -340,6 +340,15 @@ type StoreTestingKnobs struct {
 	// heartbeats and then expect other replicas to take the lease without
 	// worrying about Raft).
 	AllowLeaseRequestProposalsWhenNotLeader bool
+	// AllowLeaseTransfersWhenTargetMayNeedSnapshot, if set, makes the Replica
+	// and proposal buffer allow lease request proposals even when the proposer
+	// cannot prove that the lease transfer target does not need a Raft snapshot.
+	AllowLeaseTransfersWhenTargetMayNeedSnapshot bool
+	// LeaseTransferRejectedRetryLoopCount, if set, configures the maximum number
+	// of retries for the retry loop used during lease transfers. This retry loop
+	// retries after transfer attempts are rejected because the transfer is deemed
+	// to be unsafe.
+	LeaseTransferRejectedRetryLoopCount int
 	// DontCloseTimestamps inhibits the propBuf's closing of timestamps. All Raft
 	// commands will carry an empty closed timestamp.
 	DontCloseTimestamps bool

--- a/pkg/testutils/serverutils/test_cluster_shim.go
+++ b/pkg/testutils/serverutils/test_cluster_shim.go
@@ -114,7 +114,7 @@ type TestClusterInterface interface {
 	// RebalanceVoterOrFatal rebalances a voting replica from src to dest but wil
 	// fatal if it fails.
 	RebalanceVoterOrFatal(
-		ctx context.Context, t *testing.T, startKey roachpb.Key, src, dest roachpb.ReplicationTarget,
+		ctx context.Context, t testing.TB, startKey roachpb.Key, src, dest roachpb.ReplicationTarget,
 	) *roachpb.RangeDescriptor
 
 	// SwapVoterWithNonVoter atomically "swaps" the voting replica located on
@@ -129,7 +129,7 @@ type TestClusterInterface interface {
 	// SwapVoterWithNonVoterOrFatal is the same as SwapVoterWithNonVoter but will
 	// fatal if it fails.
 	SwapVoterWithNonVoterOrFatal(
-		t *testing.T, startKey roachpb.Key, voterTarget, nonVoterTarget roachpb.ReplicationTarget,
+		t testing.TB, startKey roachpb.Key, voterTarget, nonVoterTarget roachpb.ReplicationTarget,
 	) *roachpb.RangeDescriptor
 
 	// FindRangeLeaseHolder returns the current lease holder for the given range.
@@ -157,6 +157,12 @@ type TestClusterInterface interface {
 	TransferRangeLease(
 		rangeDesc roachpb.RangeDescriptor, dest roachpb.ReplicationTarget,
 	) error
+
+	// TransferRangeLeaseOrFatal is the same as TransferRangeLease but will fatal
+	// if it fails.
+	TransferRangeLeaseOrFatal(
+		t testing.TB, rangeDesc roachpb.RangeDescriptor, dest roachpb.ReplicationTarget,
+	)
 
 	// MoveRangeLeaseNonCooperatively performs a non-cooperative transfer of the
 	// lease for a range from whoever has it to a particular store. That store

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -975,7 +975,7 @@ func (tc *TestCluster) SwapVoterWithNonVoter(
 
 // SwapVoterWithNonVoterOrFatal is part of TestClusterInterface.
 func (tc *TestCluster) SwapVoterWithNonVoterOrFatal(
-	t *testing.T, startKey roachpb.Key, voterTarget, nonVoterTarget roachpb.ReplicationTarget,
+	t testing.TB, startKey roachpb.Key, voterTarget, nonVoterTarget roachpb.ReplicationTarget,
 ) *roachpb.RangeDescriptor {
 	afterDesc, err := tc.SwapVoterWithNonVoter(startKey, voterTarget, nonVoterTarget)
 
@@ -1011,7 +1011,7 @@ func (tc *TestCluster) RebalanceVoter(
 
 // RebalanceVoterOrFatal is part of TestClusterInterface.
 func (tc *TestCluster) RebalanceVoterOrFatal(
-	ctx context.Context, t *testing.T, startKey roachpb.Key, src, dest roachpb.ReplicationTarget,
+	ctx context.Context, t testing.TB, startKey roachpb.Key, src, dest roachpb.ReplicationTarget,
 ) *roachpb.RangeDescriptor {
 	afterDesc, err := tc.RebalanceVoter(ctx, startKey, src, dest)
 	if err != nil {


### PR DESCRIPTION
Fixes #81763.
Fixes #79385.
Part of #81561.

### Background

When performing a lease transfer, the outgoing leaseholder revokes its lease before proposing the lease transfer request, meaning that it promises to stop using the previous lease to serve reads or writes. The lease transfer request is then proposed and committed to the Raft log, at which point the new lease officially becomes active. However, this new lease is not usable until the incoming leaseholder applies the Raft entry that contains the lease transfer and notices that it is now the leaseholder for the range.

The effect of this handoff is that there exists a "power vacuum" time period when the outgoing leaseholder has revoked its previous lease but the incoming leaseholder has not yet applied its new lease. During this time period, a range is effectively unavailable for strong reads and writes, because no replica will act as the leaseholder. Instead, requests that require the lease will be redirected back and forth between the outgoing leaseholder and the incoming leaseholder (the client backs off). To minimize the disruption caused by lease transfers, we need to minimize this time period.

We assume that if a lease transfer target is sufficiently caught up on its log such that it will be able to apply the lease transfer through log entry application then this unavailability window will be acceptable. This may be a faulty assumption in cases with severe replication lag, but we must balance any heuristics here that attempts to determine "too much lag" with the possibility of starvation of lease transfers under sustained write load and a resulting sustained replication lag. See #38065 and #42379, which removed such a heuristic. For now, we don't try to make such a determination.

### Patch Details

However, with this change, we now draw a distinction between lease transfer targets that will be able to apply the lease transfer through log entry application and those that will require a Raft snapshot to catch up and apply the lease transfer. Raft snapshots are more expensive than Raft entry replication. They are also significantly more likely to be delayed due to queueing behind other snapshot traffic in the system. This potential for delay makes transferring a lease to a replica that needs a snapshot very risky, as doing so has the effect of inducing range unavailability until the snapshot completes, which could take seconds, minutes, or hours.

In the future, we will likely get better at prioritizing snapshots to improve the responsiveness of snapshots that are needed to recover availability. However, even in this world, it is not worth inducing unavailability that can only be recovered through a Raft snapshot. It is better to catch the desired lease target up on the log first and then initiate the lease transfer once its log is connected to the leader's. For this reason, unless we can guarantee that the lease transfer target does not need a Raft snapshot, we don't let it through. 

This commit adds protection against such risky lease transfers at two levels. First, it includes hardened protection in the Replica proposal buffer, immediately before handing the lease transfer proposal off to etcd/raft. Second, it includes best-effort protection before a Replica begins to initiate a lease transfer in `AdminTransferLease`, which all lease transfer operations flow through.

The change includes protection at two levels because rejecting a lease transfer in the proposal buffer after we have revoked our current lease is more disruptive than doing so earlier, before we have revoked our current lease. Best-effort protection is also able to respond more gracefully to invalid targets (e.g. they pick the next best target).

However, the check in the Replica proposal buffer is the only place where the protection is airtight against race conditions because the check is performed:
1. by the current Raft leader, else the proposal will fail
2. while holding latches that prevent interleaving log truncation

### Remaining Work

With this change, there is a single known race which can lead to an incoming leaseholder needing a snapshot. This is the case when a leader/leaseholder transfers the lease and then quickly loses Raft leadership to a peer that has a shorter log. Even if the older leader could have caught the incoming leaseholder up on its log, the new leader may not be able to because its log may not go back as far. Such a scenario has been possible since we stopped ensuring that all replicas have logs that start at the same index. For more details, see the discussion about #35701 in #81561.

This race is theoretical — we have not seen it in practice. It's not clear whether we will try to address it or rely on a mitigation like the one described in #81764 to limit its blast radius.

----

Release note (bug fix): Range lease transfers are no longer permitted to follower replicas that may require a Raft snapshot. This ensures that lease transfers are never delayed behind snapshots, which could previously create range unavailability until the snapshot completed. Lease transfers now err on the side of caution and are only allowed when the outgoing leaseholder can guarantee that the incoming leaseholder does not need a snapshot.