### PR TITLE
roachtest: measure estimated decommission time in benchmark

### DIFF
--- a/pkg/workload/histogram/histogram.go
+++ b/pkg/workload/histogram/histogram.go
@@ -92,6 +92,16 @@ func (w *NamedHistogram) Record(elapsed time.Duration) {
 	}
 }
 
+// RecordValue saves a new integer datapoint into the histogram.
+func (w *NamedHistogram) RecordValue(value int64) {
+	w.prometheusHistogram.Observe(float64(value))
+
+	w.mu.Lock()
+	// This value may be outside the range, in which case it will be dropped.
+	_ = w.mu.current.RecordValue(value)
+	w.mu.Unlock()
+}
+
 // tick resets the current histogram to a new "period". The old one's data
 // should be saved via the closure argument.
 func (w *NamedHistogram) tick(


### PR DESCRIPTION
This change adds metrics to the `decommissionBench` Roachtest so that
during a run we can measure the estimated ideal time the decommission
could take compared to the actual duration of the decommission.
Additionally we also record the number of bytes used on the target node
over time, so that it is possible to visualize data movement during the
decommission runs.

Looking at initial runs, we see the following estimates (compared with
actual run times):
```
decommissionBench/nodes=4/cpu=16/warehouses=1000:

actual:         16m14s
theoretical min: 2m36s  (bytes used / candidate stores) / snapshot rate
estimated:       9m54s  (ceil(ranges to move / candidate stores) * (avg replica bytes / snapshot rate))
```

Depends on #81874

Release note: None