### PR TITLE
fuzzystrmatch: fix crash and compatibility

### DIFF
--- a/pkg/util/fuzzystrmatch/soundex.go
+++ b/pkg/util/fuzzystrmatch/soundex.go
@@ -21,6 +21,11 @@ const soundexLen = 4
 //                    ABCDEFGHIJKLMNOPQRSTUVWXYZ
 const soundexTable = "01230120022455012623010202"
 
+func isAlpha(r rune) bool {
+	return (r >= 'a' && r <= 'z') ||
+		(r >= 'A' && r <= 'Z')
+}
+
 func soundexCode(r rune) byte {
 	letter := byte(unicode.ToUpper(r))
 	if letter >= 'A' && letter <= 'Z' {
@@ -32,10 +37,7 @@ func soundexCode(r rune) byte {
 func soundex(source string) string {
 	// Skip leading non-alphabetic characters
 	source = strings.TrimLeftFunc(source, func(r rune) bool {
-		if r <= unicode.MaxASCII {
-			return !(unicode.IsUpper(r) || unicode.IsLower(r))
-		}
-		return false
+		return !isAlpha(r)
 	})
 	code := make([]byte, soundexLen)
 	// No string left
@@ -48,20 +50,16 @@ func soundex(source string) string {
 		code[0] = byte(unicode.ToUpper(runes[0]))
 	}
 	j := 1
-	for i := 1; i < len(runes); i++ {
-		if runes[i] > unicode.MaxASCII {
-			j++
+	for i := 1; i < len(runes) && j < soundexLen; i++ {
+		if !isAlpha(runes[i]) {
+			continue
 		}
-		if (unicode.IsUpper(runes[i]) || unicode.IsLower(runes[i])) &&
-			soundexCode(runes[i]) != soundexCode(runes[i-1]) {
+		if soundexCode(runes[i]) != soundexCode(runes[i-1]) {
 			c := soundexCode(runes[i])
 			if c != '0' {
 				code[j] = c
 				j++
 			}
-		}
-		if j == soundexLen {
-			break
 		}
 	}
 	// Fill with 0's at the end

--- a/pkg/util/fuzzystrmatch/soundex_test.go
+++ b/pkg/util/fuzzystrmatch/soundex_test.go
@@ -10,7 +10,10 @@
 
 package fuzzystrmatch
 
-import "testing"
+import (
+	"math/rand"
+	"testing"
+)
 
 func TestSoundex(t *testing.T) {
 	tt := []struct {
@@ -39,11 +42,24 @@ func TestSoundex(t *testing.T) {
 		},
 		{
 			Source:   "🌞",
-			Expected: "000",
+			Expected: "",
 		},
 		{
 			Source:   "😄 🐃 🐯 🕣 💲 🏜 👞 🔠 🌟 📌",
 			Expected: "",
+		},
+		{
+			Source:   "zażółćx",
+			Expected: "Z200",
+		},
+		{
+			Source:   "K😋",
+			Expected: "K000",
+		},
+		// Regression test for #82640, just ensure we don't panic.
+		{
+			Source:   "l�qă�_��",
+			Expected: "L200",
 		},
 	}
 
@@ -53,6 +69,16 @@ func TestSoundex(t *testing.T) {
 			t.Fatalf("error convert string to its Soundex code with source=%q"+
 				" expected %s got %s", tc.Source, tc.Expected, got)
 		}
+	}
+
+	// Run some random test cases to make sure we don't panic.
+
+	for i := 0; i < 1000; i++ {
+		l := rand.Int31n(10)
+		b := make([]byte, l)
+		rand.Read(b)
+
+		soundex(string(b))
 	}
 }
 


### PR DESCRIPTION
Closes #82640

Release note (bug fix): fix behavior of soundex function when passed
certain unicode inputs. Previously, certain unicode inputs could result
in crashes, errors or incorrect outputs.