### PR TITLE
changefeedccl: Test demonstrating changefeed inhibiting node shutdown. 

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -329,6 +329,9 @@ func (ca *changeAggregator) startKVFeed(
 	// but only the first one is ever used.
 	ca.errCh = make(chan error, 2)
 	ca.kvFeedDoneCh = make(chan struct{})
+	if ca.knobs.BeforeKVFeed != nil {
+		ca.knobs.BeforeKVFeed(ctx)
+	}
 	if err := ca.flowCtx.Stopper().RunAsyncTask(ctx, "changefeed-poller", func(ctx context.Context) {
 		defer close(ca.kvFeedDoneCh)
 		// Trying to call MoveToDraining here is racy (`MoveToDraining called in

--- a/pkg/ccl/changefeedccl/changefeedbase/errors.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/errors.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/joberror"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/errors"
 )
@@ -117,7 +118,9 @@ func IsRetryableError(err error) bool {
 		return true
 	}
 
-	return (joberror.IsDistSQLRetryableError(err) || flowinfra.IsNoInboundStreamConnectionError(err))
+	return (joberror.IsDistSQLRetryableError(err) ||
+		flowinfra.IsNoInboundStreamConnectionError(err) ||
+		errors.HasType(err, (*roachpb.NodeUnavailableError)(nil)))
 }
 
 // MaybeStripRetryableErrorMarker performs some minimal attempt to clean the

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -325,6 +325,7 @@ SET CLUSTER SETTING kv.rangefeed.enabled = true;
 SET CLUSTER SETTING kv.closed_timestamp.target_duration = '1s';
 SET CLUSTER SETTING changefeed.experimental_poll_interval = '10ms';
 SET CLUSTER SETTING sql.defaults.vectorize=on;
+SET CLUSTER SETTING server.shutdown.query_wait='50ms';
 CREATE DATABASE d;
 `
 

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -33,6 +33,8 @@ type TestingKnobs struct {
 	// ShouldSkipResolved is a filter returning true if the resolved span event should
 	// be skipped.
 	ShouldSkipResolved func(resolved *jobspb.ResolvedSpan) bool
+	// BeforeKVFeed invoked before kvfeed created
+	BeforeKVFeed func(ctx context.Context)
 	// FeedKnobs are kvfeed testing knobs.
 	FeedKnobs     kvfeed.TestingKnobs
 	DistflowKnobs changefeeddist.TestingKnobs


### PR DESCRIPTION
Full fix tracked in https://github.com/cockroachdb/cockroach/issues/82765

This test demonstrates that running changfeeds inhibit node shutdown.
The issue is on the dist flow side.  This is a temporary fix.
The test itself takes more than 1 minute to run.  This is the reason
why it's being pushed as a proof of concept PR.
However, it does demonstrate the issue; and that the context
cancellation upon node shutdown added in change aggregator fixes the
issue.

Once we determine the cause of this test taking so much time, then
it can also be added.

Release Notes: None