### PR TITLE
storage: clean up `pebbleIterator` construction/initialization

### DIFF
--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -257,8 +257,8 @@ func newIntentInterleavingIterator(reader Reader, opts IterOptions) MVCCIterator
 	if reader.ConsistentIterators() {
 		iter = reader.NewMVCCIterator(MVCCKeyIterKind, opts)
 	} else {
-		iter = newPebbleIterator(
-			nil, intentIter.GetRawIter(), opts, StandardDurability, reader.SupportsRangeKeys())
+		iter = newPebbleIteratorByCloning(
+			intentIter.GetRawIter(), opts, StandardDurability, reader.SupportsRangeKeys())
 	}
 
 	*iiIter = intentInterleavingIter{

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -3613,8 +3613,8 @@ func MVCCResolveWriteIntentRange(
 		mvccIter = rw.NewMVCCIterator(MVCCKeyIterKind, iterOpts)
 	} else {
 		// For correctness, we need mvccIter to be consistent with engineIter.
-		mvccIter = newPebbleIterator(
-			nil, engineIter.GetRawIter(), iterOpts, StandardDurability, rw.SupportsRangeKeys())
+		mvccIter = newPebbleIteratorByCloning(
+			engineIter.GetRawIter(), iterOpts, StandardDurability, rw.SupportsRangeKeys())
 	}
 	iterAndBuf := GetBufUsingIter(mvccIter)
 	defer func() {

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1002,10 +1002,7 @@ func (p *Pebble) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions) MVCCIt
 		return iter
 	}
 
-	iter := newPebbleIterator(p.db, nil, opts, StandardDurability, p.SupportsRangeKeys())
-	if iter == nil {
-		panic("couldn't create a new iterator")
-	}
+	iter := newPebbleIterator(p.db, opts, StandardDurability, p.SupportsRangeKeys())
 	if util.RaceEnabled {
 		return wrapInUnsafeIter(iter)
 	}
@@ -1017,11 +1014,7 @@ func (p *Pebble) NewEngineIterator(opts IterOptions) EngineIterator {
 	if opts.KeyTypes != IterKeyTypePointsOnly {
 		panic("EngineIterator does not support range keys")
 	}
-	iter := newPebbleIterator(p.db, nil, opts, StandardDurability, p.SupportsRangeKeys())
-	if iter == nil {
-		panic("couldn't create a new iterator")
-	}
-	return iter
+	return newPebbleIterator(p.db, opts, StandardDurability, p.SupportsRangeKeys())
 }
 
 // ConsistentIterators implements the Engine interface.
@@ -1787,7 +1780,7 @@ type pebbleReadOnly struct {
 	prefixEngineIter pebbleIterator
 	normalEngineIter pebbleIterator
 
-	iter       cloneableIter
+	iter       *pebble.Iterator
 	iterUnused bool
 	durability DurabilityRequirement
 	closed     bool
@@ -1929,13 +1922,14 @@ func (p *pebbleReadOnly) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions
 		iter = &p.prefixIter
 	}
 	if iter.inuse {
-		return newPebbleIterator(p.parent.db, p.iter, opts, p.durability, p.SupportsRangeKeys())
+		return newPebbleIteratorByCloning(p.iter, opts, p.durability, p.SupportsRangeKeys())
 	}
 
 	if iter.iter != nil {
 		iter.setOptions(opts, p.durability)
 	} else {
-		iter.init(p.parent.db, p.iter, p.iterUnused, opts, p.durability, p.SupportsRangeKeys())
+		iter.initReuseOrCreate(
+			p.parent.db, p.iter, !p.iterUnused, opts, p.durability, p.SupportsRangeKeys())
 		if p.iter == nil {
 			// For future cloning.
 			p.iter = iter.iter
@@ -1966,13 +1960,14 @@ func (p *pebbleReadOnly) NewEngineIterator(opts IterOptions) EngineIterator {
 		iter = &p.prefixEngineIter
 	}
 	if iter.inuse {
-		return newPebbleIterator(p.parent.db, p.iter, opts, p.durability, p.SupportsRangeKeys())
+		return newPebbleIteratorByCloning(p.iter, opts, p.durability, p.SupportsRangeKeys())
 	}
 
 	if iter.iter != nil {
 		iter.setOptions(opts, p.durability)
 	} else {
-		iter.init(p.parent.db, p.iter, p.iterUnused, opts, p.durability, p.SupportsRangeKeys())
+		iter.initReuseOrCreate(
+			p.parent.db, p.iter, !p.iterUnused, opts, p.durability, p.SupportsRangeKeys())
 		if p.iter == nil {
 			// For future cloning.
 			p.iter = iter.iter
@@ -2188,7 +2183,7 @@ func (p *pebbleSnapshot) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions
 	}
 
 	iter := MVCCIterator(newPebbleIterator(
-		p.snapshot, nil, opts, StandardDurability, p.SupportsRangeKeys()))
+		p.snapshot, opts, StandardDurability, p.SupportsRangeKeys()))
 	if util.RaceEnabled {
 		iter = wrapInUnsafeIter(iter)
 	}
@@ -2200,7 +2195,7 @@ func (p pebbleSnapshot) NewEngineIterator(opts IterOptions) EngineIterator {
 	if opts.KeyTypes != IterKeyTypePointsOnly {
 		panic("EngineIterator does not support range keys")
 	}
-	return newPebbleIterator(p.snapshot, nil, opts, StandardDurability, p.SupportsRangeKeys())
+	return newPebbleIterator(p.snapshot, opts, StandardDurability, p.SupportsRangeKeys())
 }
 
 // ConsistentIterators implements the Reader interface.

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -49,8 +49,8 @@ type pebbleBatch struct {
 	normalEngineIter pebbleIterator
 
 	iter              *pebble.Iterator
+	iterUsed          bool // avoids cloning after PinEngineStateForIterators()
 	writeOnly         bool
-	iterUnused        bool
 	containsRangeKeys bool
 	closed            bool
 
@@ -114,7 +114,7 @@ func (p *pebbleBatch) Close() {
 	}
 	p.closed = true
 
-	if p.iterUnused {
+	if p.iter != nil && !p.iterUsed {
 		if err := p.iter.Close(); err != nil {
 			panic(err)
 		}
@@ -228,12 +228,12 @@ func (p *pebbleBatch) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions) M
 		iter.setOptions(opts, StandardDurability)
 	} else {
 		iter.initReuseOrCreate(
-			handle, p.iter, !p.iterUnused, opts, StandardDurability, p.SupportsRangeKeys())
+			handle, p.iter, p.iterUsed, opts, StandardDurability, p.SupportsRangeKeys())
 		if p.iter == nil {
 			// For future cloning.
 			p.iter = iter.iter
 		}
-		p.iterUnused = false
+		p.iterUsed = true
 	}
 
 	iter.inuse = true
@@ -269,12 +269,12 @@ func (p *pebbleBatch) NewEngineIterator(opts IterOptions) EngineIterator {
 		iter.setOptions(opts, StandardDurability)
 	} else {
 		iter.initReuseOrCreate(
-			handle, p.iter, !p.iterUnused, opts, StandardDurability, p.SupportsRangeKeys())
+			handle, p.iter, p.iterUsed, opts, StandardDurability, p.SupportsRangeKeys())
 		if p.iter == nil {
 			// For future cloning.
 			p.iter = iter.iter
 		}
-		p.iterUnused = false
+		p.iterUsed = true
 	}
 
 	iter.inuse = true
@@ -299,10 +299,8 @@ func (p *pebbleBatch) PinEngineStateForIterators() error {
 		} else {
 			p.iter = p.db.NewIter(nil)
 		}
-		// Since the iterator is being created just to pin the state of the engine
-		// for future iterators, we'll avoid cloning it the next time we want an
-		// iterator and instead just re-use what we created here.
-		p.iterUnused = true
+		// NB: p.iterUsed == false avoids cloning this in NewMVCCIterator(). We've
+		// just created it, so cloning it would just be overhead.
 	}
 	return nil
 }


### PR DESCRIPTION
`pebbleIterator` construction and initialization has grown a bit bloated
and convoluted over time. This patch makes some minor changes to better
express the purpose of the various options:

* `init()` now simply initializes the `pebbleIterator` by resetting the
  struct and creating the iterator options, using and reconfiguring a
  raw Pebble iterator if given.

* `newPebbleIterator()` creates a new iterator from a given Pebble
  reader.

* `newPebbleIteratorByCloning()` creates a new iterator by cloning a
  given raw Pebble iterator and reconfiguring it.

* `initReuseOrCreate()` is a convenience method specialized for batch
  iterator reuse. It (re-)initializes an existing `pebbleIterator` by
  either:

  1. Cloning and reconfiguring a given raw Pebble iterator.
  2. Using and reconfiguring a given raw Pebble iterator.
  3. Creating a new raw Pebble iterator.

Additionally, the `clonableIter` interface has been removed, in favor of
passing `pebble.Iterator` directly.

Release note: None