### PR TITLE
storage: add range key support for SST iterators and writers

### DIFF
--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "store_properties.go",
         "temp_engine.go",
         "testing_knobs.go",
+        "verifying_iterator.go",
         ":gen-resourcelimitreached-stringer",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/storage",

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -2353,7 +2353,7 @@ func scanIntentKeys(t *testing.T, r Reader) []roachpb.Key {
 
 // scanIter scans all point/range keys from the iterator, and returns a combined
 // slice of MVCCRangeKeyValue and MVCCKeyValue in order.
-func scanIter(t *testing.T, iter MVCCIterator) []interface{} {
+func scanIter(t *testing.T, iter SimpleMVCCIterator) []interface{} {
 	t.Helper()
 
 	iter.SeekGE(MVCCKey{Key: keys.LocalMax})
@@ -2377,8 +2377,8 @@ func scanIter(t *testing.T, iter MVCCIterator) []interface{} {
 		}
 		if hasPoint {
 			keys = append(keys, MVCCKeyValue{
-				Key:   iter.Key(),
-				Value: iter.Value(),
+				Key:   iter.UnsafeKey().Clone(),
+				Value: append([]byte{}, iter.UnsafeValue()...),
 			})
 		}
 		iter.Next()

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/uncertainty"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
@@ -39,8 +40,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/redact"
 )
+
+var sstIterVerify = util.ConstantWithMetamorphicTestBool("mvcc-histories-sst-iter-verify", false)
 
 // TestMVCCHistories verifies that sequences of MVCC reads and writes
 // perform properly.
@@ -89,6 +94,13 @@ import (
 // clear				  k=<key> [ts=<int>[,<int>]]
 // clear_range    k=<key> end=<key>
 // clear_rangekey k=<key> end=<key> ts=<int>[,<int>]
+//
+// sst_put            [ts=<int>[,<int>]] [localTs=<int>[,<int>]] k=<key> [v=<string>]
+// sst_put_rangekey   ts=<int>[,<int>] [localTS=<int>[,<int>]] k=<key> end=<key>
+// sst_clear_range    k=<key> end=<key>
+// sst_clear_rangekey k=<key> end=<key> ts=<int>[,<int>]
+// sst_finish
+// sst_iter_new
 //
 // Where `<key>` can be a simple string, or a string
 // prefixed by the following characters:
@@ -198,6 +210,104 @@ func TestMVCCHistories(t *testing.T) {
 			return err
 		}
 
+		// reportSSTEntries outputs entries from a raw SSTable. It uses a raw
+		// SST iterator in order to accurately represent the raw SST data.
+		reportSSTEntries := func(buf *redact.StringBuilder, name string, sst []byte) error {
+			r, err := sstable.NewMemReader(sst, sstable.ReaderOptions{
+				Comparer: EngineComparer,
+			})
+			if err != nil {
+				return err
+			}
+			buf.Printf(">> %s:\n", name)
+
+			// Dump point keys.
+			iter, err := r.NewIter(nil, nil)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = iter.Close() }()
+			for k, v := iter.SeekGE(nil, false); k != nil; k, v = iter.Next() {
+				if err := iter.Error(); err != nil {
+					return err
+				}
+				key, err := DecodeMVCCKey(k.UserKey)
+				if err != nil {
+					return err
+				}
+				value, err := DecodeMVCCValue(v)
+				if err != nil {
+					return err
+				}
+				buf.Printf("%s: %s -> %s\n", strings.ToLower(k.Kind().String()), key, value)
+			}
+
+			// Dump rangedels.
+			if rdIter, err := r.NewRawRangeDelIter(); err != nil {
+				return err
+			} else if rdIter != nil {
+				defer func() { _ = rdIter.Close() }()
+				for s := rdIter.SeekGE(nil); s != nil; s = rdIter.Next() {
+					if err := rdIter.Error(); err != nil {
+						return err
+					}
+					start, err := DecodeMVCCKey(s.Start)
+					if err != nil {
+						return err
+					}
+					end, err := DecodeMVCCKey(s.End)
+					if err != nil {
+						return err
+					}
+					for _, k := range s.Keys {
+						buf.Printf("%s: %s\n", strings.ToLower(k.Kind().String()),
+							roachpb.Span{Key: start.Key, EndKey: end.Key})
+					}
+				}
+			}
+
+			// Dump range keys.
+			if rkIter, err := r.NewRawRangeKeyIter(); err != nil {
+				return err
+			} else if rkIter != nil {
+				defer func() { _ = rkIter.Close() }()
+				for s := rkIter.SeekGE(nil); s != nil; s = rkIter.Next() {
+					if err := rkIter.Error(); err != nil {
+						return err
+					}
+					start, err := DecodeMVCCKey(s.Start)
+					if err != nil {
+						return err
+					}
+					end, err := DecodeMVCCKey(s.End)
+					if err != nil {
+						return err
+					}
+					for _, k := range s.Keys {
+						buf.Printf("%s: %s", strings.ToLower(k.Kind().String()),
+							roachpb.Span{Key: start.Key, EndKey: end.Key})
+						if k.Suffix != nil {
+							ts, err := decodeMVCCTimestampSuffix(k.Suffix)
+							if err != nil {
+								return err
+							}
+							buf.Printf("/%s", ts)
+						}
+						if k.Kind() == pebble.InternalKeyKindRangeKeySet {
+							value, err := DecodeMVCCValue(k.Value)
+							if err != nil {
+								return err
+							}
+							buf.Printf(" -> %s", value)
+						}
+						buf.Printf("\n")
+					}
+				}
+			}
+
+			return nil
+		}
+
 		e := newEvalCtx(ctx, engine)
 		defer e.close()
 
@@ -277,6 +387,17 @@ func TestMVCCHistories(t *testing.T) {
 								foundErr = err
 							} else {
 								buf.Printf("error reading data: (%T:) %v\n", err, err)
+							}
+						}
+						for i, sst := range e.ssts {
+							err = reportSSTEntries(&buf, fmt.Sprintf("sst-%d", i), sst)
+							if err != nil {
+								if foundErr == nil {
+									// Handle the error below.
+									foundErr = err
+								} else {
+									buf.Printf("error reading SST data: (%T:) %v\n", err, err)
+								}
 							}
 						}
 					}
@@ -403,6 +524,13 @@ func TestMVCCHistories(t *testing.T) {
 					foundErr = e.iterErr()
 				}
 
+				// Flush any unfinished SSTs.
+				if foundErr == nil {
+					foundErr = e.finishSST()
+				} else {
+					e.closeSST()
+				}
+
 				if !trace {
 					// If we were not tracing, no results were printed yet. Do it now.
 					if txnChange || dataChange {
@@ -514,6 +642,14 @@ var commands = map[string]cmd{
 	"iter_next_key":           {typReadOnly, cmdIterNextKey},
 	"iter_prev":               {typReadOnly, cmdIterPrev},
 	"iter_scan":               {typReadOnly, cmdIterScan},
+
+	"sst_put":            {typDataUpdate, cmdSSTPut},
+	"sst_put_rangekey":   {typDataUpdate, cmdSSTPutRangeKey},
+	"sst_clear_range":    {typDataUpdate, cmdSSTClearRange},
+	"sst_clear_rangekey": {typDataUpdate, cmdSSTClearRangeKey},
+	"sst_finish":         {typDataUpdate, cmdSSTFinish},
+	"sst_reset":          {typDataUpdate, cmdSSTReset},
+	"sst_iter_new":       {typReadOnly, cmdSSTIterNew},
 }
 
 func cmdTxnAdvance(e *evalCtx) error {
@@ -1185,6 +1321,69 @@ func cmdIterScan(e *evalCtx) error {
 	}
 }
 
+func cmdSSTPut(e *evalCtx) error {
+	key := e.getKey()
+	ts := e.getTs(nil)
+	var val roachpb.Value
+	if e.hasArg("v") {
+		val = e.getVal()
+	}
+	return e.sst().PutMVCC(MVCCKey{Key: key, Timestamp: ts}, MVCCValue{Value: val})
+}
+
+func cmdSSTPutRangeKey(e *evalCtx) error {
+	var rangeKey MVCCRangeKey
+	rangeKey.StartKey, rangeKey.EndKey = e.getKeyRange()
+	rangeKey.Timestamp = e.getTs(nil)
+	var value MVCCValue
+	value.MVCCValueHeader.LocalTimestamp = hlc.ClockTimestamp(e.getTsWithName("localTs"))
+
+	return e.sst().ExperimentalPutMVCCRangeKey(rangeKey, value)
+}
+
+func cmdSSTClearRange(e *evalCtx) error {
+	start, end := e.getKeyRange()
+	return e.sst().ClearRawRange(start, end)
+}
+
+func cmdSSTClearRangeKey(e *evalCtx) error {
+	var rangeKey MVCCRangeKey
+	rangeKey.StartKey, rangeKey.EndKey = e.getKeyRange()
+	rangeKey.Timestamp = e.getTs(nil)
+
+	return e.sst().ExperimentalClearMVCCRangeKey(rangeKey)
+}
+
+func cmdSSTFinish(e *evalCtx) error {
+	return e.finishSST()
+}
+
+func cmdSSTReset(e *evalCtx) error {
+	if err := e.finishSST(); err != nil {
+		return err
+	}
+	e.ssts = nil
+	return nil
+}
+
+func cmdSSTIterNew(e *evalCtx) error {
+	if e.iter != nil {
+		e.iter.Close()
+	}
+	// Reverse the order of the SSTs, since earliers SSTs take precedence over
+	// later SSTs, and we want last-write-wins.
+	ssts := make([][]byte, len(e.ssts))
+	for i, sst := range e.ssts {
+		ssts[len(ssts)-i-1] = sst
+	}
+	iter, err := NewPebbleMultiMemSSTIterator(ssts, sstIterVerify)
+	if err != nil {
+		return err
+	}
+	e.iter = iter
+	return nil
+}
+
 func printIter(e *evalCtx) {
 	e.results.buf.Printf("%s:", e.td.Cmd)
 	defer e.results.buf.Printf("\n")
@@ -1294,6 +1493,7 @@ type evalCtx struct {
 		traceIntentWrites bool
 	}
 	ctx        context.Context
+	st         *cluster.Settings
 	engine     Engine
 	iter       SimpleMVCCIterator
 	t          *testing.T
@@ -1301,11 +1501,15 @@ type evalCtx struct {
 	txns       map[string]*roachpb.Transaction
 	txnCounter uint128.Uint128
 	ms         *enginepb.MVCCStats
+	sstWriter  *SSTWriter
+	sstFile    *MemFile
+	ssts       [][]byte
 }
 
 func newEvalCtx(ctx context.Context, engine Engine) *evalCtx {
 	return &evalCtx{
 		ctx:        ctx,
+		st:         cluster.MakeTestingClusterSettings(),
 		engine:     engine,
 		txns:       make(map[string]*roachpb.Transaction),
 		txnCounter: uint128.FromInts(0, 1),
@@ -1498,6 +1702,37 @@ func (e *evalCtx) newTxn(
 	e.txnCounter = e.txnCounter.Add(1)
 	e.txns[txnName] = txn
 	return txn, nil
+}
+
+func (e *evalCtx) sst() *SSTWriter {
+	if e.sstWriter == nil {
+		e.sstFile = &MemFile{}
+		w := MakeIngestionSSTWriter(e.ctx, e.st, e.sstFile)
+		e.sstWriter = &w
+	}
+	return e.sstWriter
+}
+
+func (e *evalCtx) finishSST() error {
+	if e.sstWriter == nil {
+		return nil
+	}
+	err := e.sstWriter.Finish()
+	if err == nil && e.sstWriter.DataSize > 0 {
+		e.ssts = append(e.ssts, e.sstFile.Bytes())
+	}
+	e.sstFile = nil
+	e.sstWriter = nil
+	return err
+}
+
+func (e *evalCtx) closeSST() {
+	if e.sstWriter == nil {
+		return
+	}
+	e.sstWriter.Close()
+	e.sstFile = nil
+	e.sstWriter = nil
 }
 
 func (e *evalCtx) lookupTxn(txnName string) (*roachpb.Transaction, error) {

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -98,6 +98,20 @@ func newPebbleIteratorByCloning(
 	return p
 }
 
+// newPebbleSSTIterator creates a new Pebble iterator for the given SSTs.
+func newPebbleSSTIterator(files []sstable.ReadableFile, opts IterOptions) (*pebbleIterator, error) {
+	p := pebbleIterPool.Get().(*pebbleIterator)
+	p.reusable = false // defensive
+	p.init(nil, opts, StandardDurability, true /* supportsRangeKeys */)
+
+	var err error
+	if p.iter, err = pebble.NewExternalIter(DefaultPebbleOptions(), &p.options, files); err != nil {
+		p.destroy()
+		return nil, err
+	}
+	return p, nil
+}
+
 // init resets this pebbleIterator for use with the specified arguments,
 // reconfiguring the given iter. It is valid to pass a nil iter and then create
 // p.iter using p.options, to avoid redundant reconfiguration via SetOptions().

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/sstable"
@@ -30,6 +31,8 @@ type SSTWriter struct {
 	// DataSize tracks the total key and value bytes added so far.
 	DataSize int64
 	scratch  []byte
+
+	supportsRangeKeys bool // TODO(erikgrinaker): remove after 22.2
 }
 
 var _ Writer = &SSTWriter{}
@@ -98,8 +101,11 @@ func MakeBackupSSTWriter(ctx context.Context, cs *cluster.Settings, f io.Writer)
 	opts.BlockSize = 128 << 10
 
 	opts.MergerName = "nullptr"
-	sst := sstable.NewWriter(noopSyncCloser{f}, opts)
-	return SSTWriter{fw: sst, f: f}
+	return SSTWriter{
+		fw:                sstable.NewWriter(noopSyncCloser{f}, opts),
+		f:                 f,
+		supportsRangeKeys: opts.TableFormat >= sstable.TableFormatPebblev2,
+	}
 }
 
 // MakeIngestionSSTWriter creates a new SSTWriter tailored for ingestion SSTs.
@@ -108,9 +114,11 @@ func MakeBackupSSTWriter(ctx context.Context, cs *cluster.Settings, f io.Writer)
 func MakeIngestionSSTWriter(
 	ctx context.Context, cs *cluster.Settings, f writeCloseSyncer,
 ) SSTWriter {
+	opts := MakeIngestionWriterOptions(ctx, cs)
 	return SSTWriter{
-		fw: sstable.NewWriter(f, MakeIngestionWriterOptions(ctx, cs)),
-		f:  f,
+		fw:                sstable.NewWriter(f, opts),
+		f:                 f,
+		supportsRangeKeys: opts.TableFormat >= sstable.TableFormatPebblev2,
 	}
 }
 
@@ -128,10 +136,11 @@ func (fw *SSTWriter) Finish() error {
 }
 
 // ClearRawRange implements the Writer interface.
-//
-// TODO(erikgrinaker): This must clear range keys when SSTs support them.
 func (fw *SSTWriter) ClearRawRange(start, end roachpb.Key) error {
-	return fw.clearRange(MVCCKey{Key: start}, MVCCKey{Key: end})
+	if err := fw.clearRange(MVCCKey{Key: start}, MVCCKey{Key: end}); err != nil {
+		return err
+	}
+	return fw.ExperimentalClearAllRangeKeys(start, end)
 }
 
 // ClearMVCCRange implements the Writer interface.
@@ -145,20 +154,59 @@ func (fw *SSTWriter) ClearMVCCVersions(start, end MVCCKey) error {
 }
 
 // ExperimentalPutMVCCRangeKey implements the Writer interface.
-func (fw *SSTWriter) ExperimentalPutMVCCRangeKey(MVCCRangeKey, MVCCValue) error {
-	panic("not implemented")
+func (fw *SSTWriter) ExperimentalPutMVCCRangeKey(rangeKey MVCCRangeKey, value MVCCValue) error {
+	if !fw.supportsRangeKeys {
+		return errors.New("range keys not supported by SST writer")
+	}
+	if err := rangeKey.Validate(); err != nil {
+		return err
+	}
+	// NB: all MVCC APIs currently assume all range keys are range tombstones.
+	if !value.IsTombstone() {
+		return errors.New("range keys can only be MVCC range tombstones")
+	}
+	valueRaw, err := EncodeMVCCValue(value)
+	if err != nil {
+		return errors.Wrapf(err, "failed to encode MVCC value for range key %s", rangeKey)
+	}
+	fw.DataSize += int64(len(rangeKey.StartKey)) + int64(len(rangeKey.EndKey)) + int64(len(valueRaw))
+	return fw.fw.RangeKeySet(
+		EncodeMVCCKeyPrefix(rangeKey.StartKey),
+		EncodeMVCCKeyPrefix(rangeKey.EndKey),
+		EncodeMVCCTimestampSuffix(rangeKey.Timestamp),
+		valueRaw)
 }
 
 // ExperimentalClearMVCCRangeKey implements the Writer interface.
-func (fw *SSTWriter) ExperimentalClearMVCCRangeKey(MVCCRangeKey) error {
-	panic("not implemented")
+func (fw *SSTWriter) ExperimentalClearMVCCRangeKey(rangeKey MVCCRangeKey) error {
+	if !fw.supportsRangeKeys {
+		return nil // noop
+	}
+	if err := rangeKey.Validate(); err != nil {
+		return err
+	}
+	fw.DataSize += int64(len(rangeKey.StartKey)) + int64(len(rangeKey.EndKey))
+	return fw.fw.RangeKeyUnset(
+		EncodeMVCCKeyPrefix(rangeKey.StartKey),
+		EncodeMVCCKeyPrefix(rangeKey.EndKey),
+		EncodeMVCCTimestampSuffix(rangeKey.Timestamp))
 }
 
 // ExperimentalClearAllRangeKeys implements the Writer interface.
-//
-// TODO(erikgrinaker): This must clear range keys when SSTs support them.
-func (fw *SSTWriter) ExperimentalClearAllRangeKeys(roachpb.Key, roachpb.Key) error {
-	return nil
+func (fw *SSTWriter) ExperimentalClearAllRangeKeys(start roachpb.Key, end roachpb.Key) error {
+	if !fw.supportsRangeKeys {
+		return nil // noop
+	}
+	rangeKey := MVCCRangeKey{StartKey: start, EndKey: end, Timestamp: hlc.MinTimestamp}
+	if err := rangeKey.Validate(); err != nil {
+		return err
+	}
+	fw.DataSize += int64(len(start)) + int64(len(end))
+	// TODO(erikgrinaker): Consider omitting this if there are no range key in the
+	// SST, to avoid dropping unnecessary range tombstones. However, this may not
+	// be safe, because the caller may want to ingest the SST including the range
+	// tombstone into an engine that does have range keys that should be cleared.
+	return fw.fw.RangeKeyDelete(EncodeMVCCKeyPrefix(start), EncodeMVCCKeyPrefix(end))
 }
 
 // ExperimentalPutEngineRangeKey implements the Writer interface.
@@ -168,6 +216,10 @@ func (fw *SSTWriter) ExperimentalPutEngineRangeKey(
 	panic("not implemented")
 }
 
+// clearRange clears all point keys in the given range by dropping a Pebble
+// range tombstone.
+//
+// NB: Does not clear range keys.
 func (fw *SSTWriter) clearRange(start, end MVCCKey) error {
 	if fw.fw == nil {
 		return errors.New("cannot call ClearRange on a closed writer")

--- a/pkg/storage/testdata/mvcc_histories/sst_iter
+++ b/pkg/storage/testdata/mvcc_histories/sst_iter
@@ -1,0 +1,155 @@
+# Write a dataset, and iterate across it. Tests are not exhaustive, since
+# we assume that we're calling through to pebbleIterator, which is tested
+# separately.
+run ok
+sst_put k=a ts=3 v=a3
+sst_put k=a ts=1 v=a1
+sst_put_rangekey k=b end=f ts=4
+sst_put k=b ts=3
+sst_put k=b ts=1 v=b1
+sst_put_rangekey k=d end=g ts=3
+sst_put k=c ts=2
+sst_put_rangekey k=g end=h ts=3
+sst_put k=e ts=5 v=e5
+----
+>> at end:
+<no data>
+>> sst-0:
+set: "a"/3.000000000,0 -> /BYTES/a3
+set: "a"/1.000000000,0 -> /BYTES/a1
+set: "b"/3.000000000,0 -> /<empty>
+set: "b"/1.000000000,0 -> /BYTES/b1
+set: "c"/2.000000000,0 -> /<empty>
+set: "e"/5.000000000,0 -> /BYTES/e5
+rangekeyset: {b-d}/4.000000000,0 -> /<empty>
+rangekeyset: {d-f}/4.000000000,0 -> /<empty>
+rangekeyset: {d-f}/3.000000000,0 -> /<empty>
+rangekeyset: {f-g}/3.000000000,0 -> /<empty>
+rangekeyset: {g-h}/3.000000000,0 -> /<empty>
+
+# Iterate across the span.
+run ok
+sst_iter_new
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/3.000000000,0=/BYTES/a3
+iter_scan: "a"/3.000000000,0=/BYTES/a3
+iter_scan: "a"/1.000000000,0=/BYTES/a1
+iter_scan: {b-d}/[4.000000000,0=/<empty>]
+iter_scan: "b"/3.000000000,0=/<empty> {b-d}/[4.000000000,0=/<empty>]
+iter_scan: "b"/1.000000000,0=/BYTES/b1 {b-d}/[4.000000000,0=/<empty>]
+iter_scan: "c"/2.000000000,0=/<empty> {b-d}/[4.000000000,0=/<empty>]
+iter_scan: {d-f}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: "e"/5.000000000,0=/BYTES/e5 {d-f}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: {f-h}/[3.000000000,0=/<empty>]
+iter_scan: .
+
+# Iterate across the span in reverse.
+run ok
+sst_iter_new
+iter_seek_lt k=z
+iter_scan reverse
+----
+iter_seek_lt: {f-h}/[3.000000000,0=/<empty>]
+iter_scan: {f-h}/[3.000000000,0=/<empty>]
+iter_scan: "e"/5.000000000,0=/BYTES/e5 {d-f}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: {d-f}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: "c"/2.000000000,0=/<empty> {b-d}/[4.000000000,0=/<empty>]
+iter_scan: "b"/1.000000000,0=/BYTES/b1 {b-d}/[4.000000000,0=/<empty>]
+iter_scan: "b"/3.000000000,0=/<empty> {b-d}/[4.000000000,0=/<empty>]
+iter_scan: {b-d}/[4.000000000,0=/<empty>]
+iter_scan: "a"/1.000000000,0=/BYTES/a1
+iter_scan: "a"/3.000000000,0=/BYTES/a3
+iter_scan: .
+
+# Iterate using NextKey.
+run ok
+sst_iter_new
+iter_seek_ge k=a
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+----
+iter_seek_ge: "a"/3.000000000,0=/BYTES/a3
+iter_next_key: {b-d}/[4.000000000,0=/<empty>]
+iter_next_key: "c"/2.000000000,0=/<empty> {b-d}/[4.000000000,0=/<empty>]
+iter_next_key: {d-f}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_next_key: "e"/5.000000000,0=/BYTES/e5 {d-f}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_next_key: {f-h}/[3.000000000,0=/<empty>]
+iter_next_key: .
+
+# Seek directly to all keys, forward and reverse.
+run ok
+sst_iter_new
+iter_seek_ge k=a
+iter_seek_ge k=b
+iter_seek_ge k=c
+iter_seek_ge k=d
+iter_seek_ge k=e
+iter_seek_ge k=f
+iter_seek_ge k=g
+iter_seek_ge k=h
+----
+iter_seek_ge: "a"/3.000000000,0=/BYTES/a3
+iter_seek_ge: {b-d}/[4.000000000,0=/<empty>]
+iter_seek_ge: {b-d}/[4.000000000,0=/<empty>]
+iter_seek_ge: {d-f}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_seek_ge: {d-f}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_seek_ge: {f-h}/[3.000000000,0=/<empty>]
+iter_seek_ge: {f-h}/[3.000000000,0=/<empty>]
+iter_seek_ge: .
+
+run ok
+sst_iter_new
+iter_seek_lt k=a
+iter_seek_lt k=b
+iter_seek_lt k=c
+iter_seek_lt k=d
+iter_seek_lt k=e
+iter_seek_lt k=f
+iter_seek_lt k=g
+iter_seek_lt k=h
+----
+iter_seek_lt: .
+iter_seek_lt: "a"/1.000000000,0=/BYTES/a1
+iter_seek_lt: "b"/1.000000000,0=/BYTES/b1 {b-d}/[4.000000000,0=/<empty>]
+iter_seek_lt: "c"/2.000000000,0=/<empty> {b-d}/[4.000000000,0=/<empty>]
+iter_seek_lt: {d-f}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_seek_lt: "e"/5.000000000,0=/BYTES/e5 {d-f}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_seek_lt: {f-h}/[3.000000000,0=/<empty>]
+iter_seek_lt: {f-h}/[3.000000000,0=/<empty>]
+
+# Seek to specific versions, outside and inside range keys.
+run ok
+sst_iter_new
+iter_seek_ge k=a ts=4
+iter_seek_ge k=a ts=3
+iter_seek_ge k=a ts=2
+iter_seek_ge k=a ts=1
+iter_seek_ge k=a ts=0
+----
+iter_seek_ge: "a"/3.000000000,0=/BYTES/a3
+iter_seek_ge: "a"/3.000000000,0=/BYTES/a3
+iter_seek_ge: "a"/1.000000000,0=/BYTES/a1
+iter_seek_ge: "a"/1.000000000,0=/BYTES/a1
+iter_seek_ge: "a"/3.000000000,0=/BYTES/a3
+
+run ok
+sst_iter_new
+iter_seek_ge k=b ts=5
+iter_seek_ge k=b ts=4
+iter_seek_ge k=b ts=3
+iter_seek_ge k=b ts=2
+iter_seek_ge k=b ts=1
+iter_seek_ge k=b ts=0
+----
+iter_seek_ge: {b-d}/[4.000000000,0=/<empty>]
+iter_seek_ge: {b-d}/[4.000000000,0=/<empty>]
+iter_seek_ge: "b"/3.000000000,0=/<empty> {b-d}/[4.000000000,0=/<empty>]
+iter_seek_ge: {b-d}/[4.000000000,0=/<empty>]
+iter_seek_ge: "b"/1.000000000,0=/BYTES/b1 {b-d}/[4.000000000,0=/<empty>]
+iter_seek_ge: {b-d}/[4.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/sst_iter_multi
+++ b/pkg/storage/testdata/mvcc_histories/sst_iter_multi
@@ -1,0 +1,269 @@
+# Writes a dataset across multiple SSTs, and iterate across it. The
+# final dataset will be:
+#
+# 5                 e5
+# 4     o---------------o
+# 3 a3  x       o---------------o       o---o
+# 2         x
+# 1 a1  b1                                  k1
+#   a   b   c   d   e   f   g   h   i   j   k
+
+# First SST: add some initial point keys.
+run ok
+sst_put k=a ts=3 v=initial
+sst_put k=a ts=1 v=a1
+sst_put k=b ts=3
+sst_put k=b ts=1 v=initial
+sst_put k=c ts=2
+sst_put k=h ts=2 v=h2
+sst_put k=h ts=1 v=h1
+sst_put k=i ts=1 v=i1
+sst_put k=k ts=1 v=k1
+----
+>> at end:
+<no data>
+>> sst-0:
+set: "a"/3.000000000,0 -> /BYTES/initial
+set: "a"/1.000000000,0 -> /BYTES/a1
+set: "b"/3.000000000,0 -> /<empty>
+set: "b"/1.000000000,0 -> /BYTES/initial
+set: "c"/2.000000000,0 -> /<empty>
+set: "h"/2.000000000,0 -> /BYTES/h2
+set: "h"/1.000000000,0 -> /BYTES/h1
+set: "i"/1.000000000,0 -> /BYTES/i1
+set: "k"/1.000000000,0 -> /BYTES/k1
+
+# Second SST: replace a@3 and b@1 with new values, and write [b-f)@4 and [g-k)@3.
+run ok
+sst_put_rangekey k=b end=f ts=4
+sst_put_rangekey k=g end=k ts=3
+sst_put k=a ts=3 v=a3
+sst_put k=b ts=1 v=b1
+----
+>> at end:
+<no data>
+>> sst-0:
+set: "a"/3.000000000,0 -> /BYTES/initial
+set: "a"/1.000000000,0 -> /BYTES/a1
+set: "b"/3.000000000,0 -> /<empty>
+set: "b"/1.000000000,0 -> /BYTES/initial
+set: "c"/2.000000000,0 -> /<empty>
+set: "h"/2.000000000,0 -> /BYTES/h2
+set: "h"/1.000000000,0 -> /BYTES/h1
+set: "i"/1.000000000,0 -> /BYTES/i1
+set: "k"/1.000000000,0 -> /BYTES/k1
+>> sst-1:
+set: "a"/3.000000000,0 -> /BYTES/a3
+set: "b"/1.000000000,0 -> /BYTES/b1
+rangekeyset: {b-f}/4.000000000,0 -> /<empty>
+rangekeyset: {g-k}/3.000000000,0 -> /<empty>
+
+# Third SST: write range keys [d-g)@3 which fragments [b-f)@4, and [i-k)@3 which
+# partially replaces [g-k)@3 with a new localTs. Also write e@5.
+run ok
+sst_put_rangekey k=d end=g ts=3
+sst_put_rangekey k=i end=k ts=3 localTs=2
+sst_put k=e ts=5 v=e5
+----
+>> at end:
+<no data>
+>> sst-0:
+set: "a"/3.000000000,0 -> /BYTES/initial
+set: "a"/1.000000000,0 -> /BYTES/a1
+set: "b"/3.000000000,0 -> /<empty>
+set: "b"/1.000000000,0 -> /BYTES/initial
+set: "c"/2.000000000,0 -> /<empty>
+set: "h"/2.000000000,0 -> /BYTES/h2
+set: "h"/1.000000000,0 -> /BYTES/h1
+set: "i"/1.000000000,0 -> /BYTES/i1
+set: "k"/1.000000000,0 -> /BYTES/k1
+>> sst-1:
+set: "a"/3.000000000,0 -> /BYTES/a3
+set: "b"/1.000000000,0 -> /BYTES/b1
+rangekeyset: {b-f}/4.000000000,0 -> /<empty>
+rangekeyset: {g-k}/3.000000000,0 -> /<empty>
+>> sst-2:
+set: "e"/5.000000000,0 -> /BYTES/e5
+rangekeyset: {d-g}/3.000000000,0 -> /<empty>
+rangekeyset: {i-k}/3.000000000,0 -> {localTs=2.000000000,0}/<empty>
+
+# Fourth SST: clear the [h-j) span.
+run ok
+sst_clear_range k=h end=j
+sst_finish
+----
+>> at end:
+<no data>
+>> sst-0:
+set: "a"/3.000000000,0 -> /BYTES/initial
+set: "a"/1.000000000,0 -> /BYTES/a1
+set: "b"/3.000000000,0 -> /<empty>
+set: "b"/1.000000000,0 -> /BYTES/initial
+set: "c"/2.000000000,0 -> /<empty>
+set: "h"/2.000000000,0 -> /BYTES/h2
+set: "h"/1.000000000,0 -> /BYTES/h1
+set: "i"/1.000000000,0 -> /BYTES/i1
+set: "k"/1.000000000,0 -> /BYTES/k1
+>> sst-1:
+set: "a"/3.000000000,0 -> /BYTES/a3
+set: "b"/1.000000000,0 -> /BYTES/b1
+rangekeyset: {b-f}/4.000000000,0 -> /<empty>
+rangekeyset: {g-k}/3.000000000,0 -> /<empty>
+>> sst-2:
+set: "e"/5.000000000,0 -> /BYTES/e5
+rangekeyset: {d-g}/3.000000000,0 -> /<empty>
+rangekeyset: {i-k}/3.000000000,0 -> {localTs=2.000000000,0}/<empty>
+>> sst-3:
+rangedel: {h-j}
+rangekeydel: {h-j}
+
+# Iterate across the span.
+run ok
+sst_iter_new
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/3.000000000,0=/BYTES/a3
+iter_scan: "a"/3.000000000,0=/BYTES/a3
+iter_scan: "a"/1.000000000,0=/BYTES/a1
+iter_scan: {b-d}/[4.000000000,0=/<empty>]
+iter_scan: "b"/3.000000000,0=/<empty> {b-d}/[4.000000000,0=/<empty>]
+iter_scan: "b"/1.000000000,0=/BYTES/b1 {b-d}/[4.000000000,0=/<empty>]
+iter_scan: "c"/2.000000000,0=/<empty> {b-d}/[4.000000000,0=/<empty>]
+iter_scan: {d-f}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: "e"/5.000000000,0=/BYTES/e5 {d-f}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: {f-h}/[3.000000000,0=/<empty>]
+iter_scan: {j-k}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "k"/1.000000000,0=/BYTES/k1
+iter_scan: .
+
+# Iterate across the span in reverse.
+run ok
+sst_iter_new
+iter_seek_lt k=z
+iter_scan reverse
+----
+iter_seek_lt: "k"/1.000000000,0=/BYTES/k1
+iter_scan: "k"/1.000000000,0=/BYTES/k1
+iter_scan: {j-k}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: {f-h}/[3.000000000,0=/<empty>]
+iter_scan: "e"/5.000000000,0=/BYTES/e5 {d-f}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: {d-f}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: "c"/2.000000000,0=/<empty> {b-d}/[4.000000000,0=/<empty>]
+iter_scan: "b"/1.000000000,0=/BYTES/b1 {b-d}/[4.000000000,0=/<empty>]
+iter_scan: "b"/3.000000000,0=/<empty> {b-d}/[4.000000000,0=/<empty>]
+iter_scan: {b-d}/[4.000000000,0=/<empty>]
+iter_scan: "a"/1.000000000,0=/BYTES/a1
+iter_scan: "a"/3.000000000,0=/BYTES/a3
+iter_scan: .
+
+# Iterate using NextKey.
+run ok
+sst_iter_new
+iter_seek_ge k=a
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+----
+iter_seek_ge: "a"/3.000000000,0=/BYTES/a3
+iter_next_key: {b-d}/[4.000000000,0=/<empty>]
+iter_next_key: "c"/2.000000000,0=/<empty> {b-d}/[4.000000000,0=/<empty>]
+iter_next_key: {d-f}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_next_key: "e"/5.000000000,0=/BYTES/e5 {d-f}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_next_key: {f-h}/[3.000000000,0=/<empty>]
+iter_next_key: {j-k}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_next_key: "k"/1.000000000,0=/BYTES/k1
+iter_next_key: .
+
+# Seek directly to all keys, forward and reverse.
+run ok
+sst_iter_new
+iter_seek_ge k=a
+iter_seek_ge k=b
+iter_seek_ge k=c
+iter_seek_ge k=d
+iter_seek_ge k=e
+iter_seek_ge k=f
+iter_seek_ge k=g
+iter_seek_ge k=h
+iter_seek_ge k=i
+iter_seek_ge k=j
+iter_seek_ge k=k
+iter_seek_ge k=l
+----
+iter_seek_ge: "a"/3.000000000,0=/BYTES/a3
+iter_seek_ge: {b-d}/[4.000000000,0=/<empty>]
+iter_seek_ge: {b-d}/[4.000000000,0=/<empty>]
+iter_seek_ge: {d-f}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_seek_ge: {d-f}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_seek_ge: {f-h}/[3.000000000,0=/<empty>]
+iter_seek_ge: {f-h}/[3.000000000,0=/<empty>]
+iter_seek_ge: {j-k}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_seek_ge: {j-k}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_seek_ge: {j-k}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_seek_ge: "k"/1.000000000,0=/BYTES/k1
+iter_seek_ge: .
+
+run ok
+sst_iter_new
+iter_seek_lt k=a
+iter_seek_lt k=b
+iter_seek_lt k=c
+iter_seek_lt k=d
+iter_seek_lt k=e
+iter_seek_lt k=f
+iter_seek_lt k=g
+iter_seek_lt k=h
+iter_seek_lt k=i
+iter_seek_lt k=j
+iter_seek_lt k=k
+iter_seek_lt k=l
+----
+iter_seek_lt: .
+iter_seek_lt: "a"/1.000000000,0=/BYTES/a1
+iter_seek_lt: "b"/1.000000000,0=/BYTES/b1 {b-d}/[4.000000000,0=/<empty>]
+iter_seek_lt: "c"/2.000000000,0=/<empty> {b-d}/[4.000000000,0=/<empty>]
+iter_seek_lt: {d-f}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_seek_lt: "e"/5.000000000,0=/BYTES/e5 {d-f}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_seek_lt: {f-h}/[3.000000000,0=/<empty>]
+iter_seek_lt: {f-h}/[3.000000000,0=/<empty>]
+iter_seek_lt: {f-h}/[3.000000000,0=/<empty>]
+iter_seek_lt: {f-h}/[3.000000000,0=/<empty>]
+iter_seek_lt: {j-k}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_seek_lt: "k"/1.000000000,0=/BYTES/k1
+
+# Seek to specific versions, outside and inside range keys.
+run ok
+sst_iter_new
+iter_seek_ge k=a ts=4
+iter_seek_ge k=a ts=3
+iter_seek_ge k=a ts=2
+iter_seek_ge k=a ts=1
+iter_seek_ge k=a ts=0
+----
+iter_seek_ge: "a"/3.000000000,0=/BYTES/a3
+iter_seek_ge: "a"/3.000000000,0=/BYTES/a3
+iter_seek_ge: "a"/1.000000000,0=/BYTES/a1
+iter_seek_ge: "a"/1.000000000,0=/BYTES/a1
+iter_seek_ge: "a"/3.000000000,0=/BYTES/a3
+
+run ok
+sst_iter_new
+iter_seek_ge k=b ts=5
+iter_seek_ge k=b ts=4
+iter_seek_ge k=b ts=3
+iter_seek_ge k=b ts=2
+iter_seek_ge k=b ts=1
+iter_seek_ge k=b ts=0
+----
+iter_seek_ge: {b-d}/[4.000000000,0=/<empty>]
+iter_seek_ge: {b-d}/[4.000000000,0=/<empty>]
+iter_seek_ge: "b"/3.000000000,0=/<empty> {b-d}/[4.000000000,0=/<empty>]
+iter_seek_ge: {b-d}/[4.000000000,0=/<empty>]
+iter_seek_ge: "b"/1.000000000,0=/BYTES/b1 {b-d}/[4.000000000,0=/<empty>]
+iter_seek_ge: {b-d}/[4.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/sst_writer
+++ b/pkg/storage/testdata/mvcc_histories/sst_writer
@@ -1,0 +1,161 @@
+# Writing keys out of order fails, except for overlapping range keys by
+# timestamp which succeeds.
+run error
+sst_put k=b ts=1 v=b1
+sst_put k=a ts=1 v=a1
+----
+>> at end:
+<no data>
+error: (*withstack.withStack:) pebble: keys must be added in order: "b"/1.000000000,0#0,SET, "a"/1.000000000,0#0,SET
+
+run error
+sst_put k=a ts=1 v=a1
+sst_put k=a ts=2 v=a2
+----
+>> at end:
+<no data>
+error: (*withstack.withStack:) pebble: keys must be added in order: "a"/1.000000000,0#0,SET, "a"/2.000000000,0#0,SET
+
+run error
+sst_put_rangekey k=d end=f ts=1
+sst_put_rangekey k=a end=c ts=1
+----
+>> at end:
+<no data>
+error: (*withstack.withStack:) pebble: spans must be added in order: "d"/0,0 > "a"/0,0
+
+run ok
+sst_put_rangekey k=a end=c ts=1
+sst_put_rangekey k=a end=c ts=2
+----
+>> at end:
+<no data>
+>> sst-0:
+rangekeyset: {a-c}/2.000000000,0 -> /<empty>
+rangekeyset: {a-c}/1.000000000,0 -> /<empty>
+
+# Writing invalid range keys fails.
+run error
+sst_reset
+sst_put_rangekey k=f end=c ts=1
+----
+>> at end:
+<no data>
+error: (*withstack.withStack:) invalid range key {f-c}/1.000000000,0: start key "f" is at or after end key "c"
+
+# Writing the same key multiple times. Iteration sees the first written key.
+run ok
+sst_put k=a ts=1 v=a1
+sst_put k=a ts=1 v=again
+sst_put_rangekey k=a end=c ts=3 localTs=2
+sst_put_rangekey k=a end=c ts=3 localTs=1
+----
+>> at end:
+<no data>
+>> sst-0:
+set: "a"/1.000000000,0 -> /BYTES/a1
+set: "a"/1.000000000,0 -> /BYTES/again
+rangekeyset: {a-c}/3.000000000,0 -> {localTs=2.000000000,0}/<empty>
+
+run ok
+sst_iter_new
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {a-c}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: {a-c}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "a"/1.000000000,0=/BYTES/a1 {a-c}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: .
+
+# Writing abutting range keys. Iteration defragments them, unless the value
+# is different.
+run ok
+sst_reset
+sst_put_rangekey k=f end=g ts=3
+sst_put_rangekey k=g end=h ts=3
+sst_put_rangekey k=h end=j ts=3 localTs=2
+sst_finish
+sst_iter_new
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {f-h}/[3.000000000,0=/<empty>]
+iter_scan: {f-h}/[3.000000000,0=/<empty>]
+iter_scan: {h-j}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: .
+>> at end:
+<no data>
+>> sst-0:
+rangekeyset: {f-g}/3.000000000,0 -> /<empty>
+rangekeyset: {g-h}/3.000000000,0 -> /<empty>
+rangekeyset: {h-j}/3.000000000,0 -> {localTs=2.000000000,0}/<empty>
+
+# Clearing a span. Iteration still sees cleared keys when clear is in the same
+# SST, because the clear needs to be at a higher seqnum than the keys that it
+# clears, and the SST is built at a single seqnum. A later clear in a different
+# SST properly clears them.
+run ok
+sst_reset
+sst_put k=b ts=1 v=b1
+sst_put k=c ts=2 v=c2
+sst_put k=d ts=1 v=d1
+sst_put k=e ts=1 v=e1
+sst_put_rangekey k=a end=f ts=3
+sst_clear_range k=c end=e
+----
+>> at end:
+<no data>
+>> sst-0:
+set: "b"/1.000000000,0 -> /BYTES/b1
+set: "c"/2.000000000,0 -> /BYTES/c2
+set: "d"/1.000000000,0 -> /BYTES/d1
+set: "e"/1.000000000,0 -> /BYTES/e1
+rangedel: {c-e}
+rangekeyset: {a-c}/3.000000000,0 -> /<empty>
+rangekeyset: {c-e}/3.000000000,0 -> /<empty>
+rangekeydel: {c-e}
+rangekeyset: {e-f}/3.000000000,0 -> /<empty>
+
+run ok
+sst_iter_new
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {a-f}/[3.000000000,0=/<empty>]
+iter_scan: {a-f}/[3.000000000,0=/<empty>]
+iter_scan: "b"/1.000000000,0=/BYTES/b1 {a-f}/[3.000000000,0=/<empty>]
+iter_scan: "c"/2.000000000,0=/BYTES/c2 {a-f}/[3.000000000,0=/<empty>]
+iter_scan: "d"/1.000000000,0=/BYTES/d1 {a-f}/[3.000000000,0=/<empty>]
+iter_scan: "e"/1.000000000,0=/BYTES/e1 {a-f}/[3.000000000,0=/<empty>]
+iter_scan: .
+
+run ok
+sst_clear_range k=c end=e
+----
+>> at end:
+<no data>
+>> sst-0:
+set: "b"/1.000000000,0 -> /BYTES/b1
+set: "c"/2.000000000,0 -> /BYTES/c2
+set: "d"/1.000000000,0 -> /BYTES/d1
+set: "e"/1.000000000,0 -> /BYTES/e1
+rangedel: {c-e}
+rangekeyset: {a-c}/3.000000000,0 -> /<empty>
+rangekeyset: {c-e}/3.000000000,0 -> /<empty>
+rangekeydel: {c-e}
+rangekeyset: {e-f}/3.000000000,0 -> /<empty>
+>> sst-1:
+rangedel: {c-e}
+rangekeydel: {c-e}
+
+run ok
+sst_iter_new
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {a-c}/[3.000000000,0=/<empty>]
+iter_scan: {a-c}/[3.000000000,0=/<empty>]
+iter_scan: "b"/1.000000000,0=/BYTES/b1 {a-c}/[3.000000000,0=/<empty>]
+iter_scan: {e-f}/[3.000000000,0=/<empty>]
+iter_scan: "e"/1.000000000,0=/BYTES/e1 {e-f}/[3.000000000,0=/<empty>]
+iter_scan: .

--- a/pkg/storage/verifying_iterator.go
+++ b/pkg/storage/verifying_iterator.go
@@ -1,0 +1,117 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package storage
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+)
+
+// VerifyingMVCCIterator is an MVCC iterator that wraps an arbitrary MVCC
+// iterator and verifies roachpb.Value checksums for encountered values.
+type VerifyingMVCCIterator struct {
+	MVCCIterator
+
+	valid bool
+	err   error
+	key   MVCCKey
+	value []byte
+}
+
+// NewVerifyingMVCCIterator creates a new VerifyingMVCCIterator.
+func NewVerifyingMVCCIterator(iter MVCCIterator) MVCCIterator {
+	return &VerifyingMVCCIterator{MVCCIterator: iter}
+}
+
+// saveAndVerify fetches the current key and value, saves them in the iterator,
+// and verifies the value.
+func (i *VerifyingMVCCIterator) saveAndVerify() {
+	if i.valid, i.err = i.MVCCIterator.Valid(); !i.valid || i.err != nil {
+		return
+	}
+	i.key = i.MVCCIterator.UnsafeKey()
+	if hasPoint, _ := i.MVCCIterator.HasPointAndRange(); hasPoint {
+		i.value = i.MVCCIterator.UnsafeValue()
+		if i.key.IsValue() {
+			mvccValue, ok, err := tryDecodeSimpleMVCCValue(i.value)
+			if !ok && err == nil {
+				mvccValue, err = decodeExtendedMVCCValue(i.value)
+			}
+			if err == nil {
+				err = mvccValue.Value.Verify(i.key.Key)
+			}
+			if err != nil {
+				i.err = err
+				i.valid = false
+				return
+			}
+		}
+	}
+}
+
+// Next implements MVCCIterator.
+func (i *VerifyingMVCCIterator) Next() {
+	i.MVCCIterator.Next()
+	i.saveAndVerify()
+}
+
+// NextKey implements MVCCIterator.
+func (i *VerifyingMVCCIterator) NextKey() {
+	i.MVCCIterator.NextKey()
+	i.saveAndVerify()
+}
+
+// Prev implements MVCCIterator.
+func (i *VerifyingMVCCIterator) Prev() {
+	i.MVCCIterator.Prev()
+	i.saveAndVerify()
+}
+
+// SeekGE implements MVCCIterator.
+func (i *VerifyingMVCCIterator) SeekGE(key MVCCKey) {
+	i.MVCCIterator.SeekGE(key)
+	i.saveAndVerify()
+}
+
+// SeekIntentGE implements MVCCIterator.
+func (i *VerifyingMVCCIterator) SeekIntentGE(key roachpb.Key, txnUUID uuid.UUID) {
+	i.MVCCIterator.SeekIntentGE(key, txnUUID)
+	i.saveAndVerify()
+}
+
+// SeekLT implements MVCCIterator.
+func (i *VerifyingMVCCIterator) SeekLT(key MVCCKey) {
+	i.MVCCIterator.SeekLT(key)
+	i.saveAndVerify()
+}
+
+// UnsafeKey implements MVCCIterator.
+func (i *VerifyingMVCCIterator) UnsafeKey() MVCCKey {
+	return i.key
+}
+
+// UnsafeValue implements MVCCIterator.
+func (i *VerifyingMVCCIterator) UnsafeValue() []byte {
+	return i.value
+}
+
+// Valid implements MVCCIterator.
+func (i *VerifyingMVCCIterator) Valid() (bool, error) {
+	return i.valid, i.err
+}
+
+// HasPointAndRange implements MVCCIterator.
+func (i *VerifyingMVCCIterator) HasPointAndRange() (bool, bool) {
+	if !i.valid {
+		return false, false
+	}
+	return i.MVCCIterator.HasPointAndRange()
+}


### PR DESCRIPTION
This patch adds `NewPebbleSSTIterator()`, which constructs an MVCC
iterator for SSTs. Unlike the existing `sstIterator`, it supports range
keys and merged iteration across multiple SSTs. It is based on a new
`pebble.NewExternalIter()` API for SST iteration, and reuses
`pebbleIterator` for the CRDB logic. Value verification has been split
out to a separate, general `VerifyingMVCCIterator`.

This iterator currently has significantly worse performance than the
existing SST iterator (as much as 100%), so it is not used yet outside
of tests. This will be optimized later.

The patch also adds support for writing range keys in `SSTWriter`. This
is only enabled when the SST format is `TableFormatPebblev2` or newer,
which is only the case once the cluster version reaches
`EnablePebbleFormatVersionRangeKeys`.

Resolves #82586.

Release note: None