### PR TITLE
[WIP] admission: add support for disk bandwidth as a bottleneck resource

### DIFF
--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -489,6 +489,12 @@ var (
 		Measurement: "Events",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaRdbWriteStallNanos = metric.Metadata{
+		Name:        "storage.write-stall-nanos",
+		Help:        "Total write stall duration in nanos",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
 
 	// Disk health metrics.
 	metaDiskSlow = metric.Metadata{
@@ -1535,6 +1541,7 @@ type StoreMetrics struct {
 	RdbL0NumFiles               *metric.Gauge
 	RdbBytesIngested            [7]*metric.Gauge // idx = level
 	RdbWriteStalls              *metric.Gauge
+	RdbWriteStallNanos          *metric.Gauge
 
 	// Disk health metrics.
 	DiskSlow    *metric.Gauge
@@ -1999,6 +2006,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		RdbL0NumFiles:               metric.NewGauge(metaRdbL0NumFiles),
 		RdbBytesIngested:            rdbBytesIngested,
 		RdbWriteStalls:              metric.NewGauge(metaRdbWriteStalls),
+		RdbWriteStallNanos:          metric.NewGauge(metaRdbWriteStallNanos),
 
 		// Disk health metrics.
 		DiskSlow:    metric.NewGauge(metaDiskSlow),
@@ -2252,6 +2260,7 @@ func (sm *StoreMetrics) updateEngineMetrics(m storage.Metrics) {
 	sm.RdbMarkedForCompactionFiles.Update(int64(m.Compact.MarkedFiles))
 	sm.RdbNumSSTables.Update(m.NumSSTables())
 	sm.RdbWriteStalls.Update(m.WriteStallCount)
+	sm.RdbWriteStallNanos.Update(m.WriteStallDuration.Nanoseconds())
 	sm.DiskSlow.Update(m.DiskSlowCount)
 	sm.DiskStalled.Update(m.DiskStallCount)
 

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3772,7 +3772,10 @@ func (n KVAdmissionControllerImpl) AdmitKVWork(
 		}
 		admissionEnabled := true
 		if ah.storeAdmissionQ != nil {
-			// TODO(sumeer): Plumb WriteBytes for ingest requests.
+			// TODO(sumeer): Plumb WriteBytes for ingest requests, and for all
+			// AddSSTableRequests, even if they are using IngestAsWrites. For the
+			// rest we don't know the size since have not evaluated yet. It will be
+			// known when AdmittedWorkDone is called, and so we can compensate then.
 			ah.storeWorkHandle, err = ah.storeAdmissionQ.Admit(
 				ctx, admission.StoreWriteWorkInfo{WorkInfo: admissionInfo})
 			if err != nil {
@@ -3803,8 +3806,10 @@ func (n KVAdmissionControllerImpl) AdmittedKVWorkDone(handle interface{}) {
 		n.kvAdmissionQ.AdmittedWorkDone(ah.tenantID)
 	}
 	if ah.storeAdmissionQ != nil {
-		// TODO(sumeer): Plumb ingestedIntoL0Bytes and handle error return value.
-		_ = ah.storeAdmissionQ.AdmittedWorkDone(ah.storeWorkHandle, 0)
+		// TODO(sumeer): Plumb bytes to populate StoreWorkDoneInfo and handle
+		// error return value.
+		_ = ah.storeAdmissionQ.AdmittedWorkDone(ah.storeWorkHandle,
+			admission.StoreWorkDoneInfo{ActualBytes: 0, ActualBytesIntoL0: 0})
 	}
 }
 

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -265,6 +265,7 @@ go_library(
         "@com_github_gorilla_mux//:mux",
         "@com_github_grpc_ecosystem_grpc_gateway//runtime:go_default_library",
         "@com_github_grpc_ecosystem_grpc_gateway//utilities:go_default_library",
+        "@com_github_lufia_iostat//:iostat",
         "@com_github_marusama_semaphore//:semaphore",
         "@in_gopkg_yaml_v2//:yaml_v2",
         "@io_etcd_go_etcd_raft_v3//:raft",

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -772,8 +772,12 @@ func (n *Node) GetPebbleMetrics() []admission.StoreMetrics {
 	var metrics []admission.StoreMetrics
 	_ = n.stores.VisitStores(func(store *kvserver.Store) error {
 		m := store.Engine().GetMetrics()
-		metrics = append(
-			metrics, admission.StoreMetrics{StoreID: int32(store.StoreID()), Metrics: m.Metrics})
+		im := store.Engine().GetInternalIntervalMetrics()
+		metrics = append(metrics, admission.StoreMetrics{
+			StoreID:                 int32(store.StoreID()),
+			Metrics:                 m.Metrics,
+			WriteStallCount:         m.WriteStallCount,
+			InternalIntervalMetrics: im})
 		return nil
 	})
 	return metrics

--- a/pkg/server/status/disk_counters.go
+++ b/pkg/server/status/disk_counters.go
@@ -45,3 +45,19 @@ func getDiskCounters(ctx context.Context) ([]diskStats, error) {
 
 	return output, nil
 }
+
+func GetDriveStatsForAC(ctx context.Context) ([]DriveStats, error) {
+	driveStats, err := disk.IOCountersWithContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var stats []DriveStats
+	for _, counters := range driveStats {
+		stats = append(stats, DriveStats{
+			Name:         counters.Name,
+			BytesRead:    int64(counters.ReadBytes),
+			BytesWritten: int64(counters.WriteBytes),
+		})
+	}
+	return stats, nil
+}

--- a/pkg/server/status/disk_counters_darwin.go
+++ b/pkg/server/status/disk_counters_darwin.go
@@ -42,3 +42,19 @@ func getDiskCounters(context.Context) ([]diskStats, error) {
 
 	return output, nil
 }
+
+func GetDriveStatsForAC(context.Context) ([]DriveStats, error) {
+	driveStats, err := iostat.ReadDriveStats()
+	if err != nil {
+		return nil, err
+	}
+	var stats []DriveStats
+	for i := range driveStats {
+		stats = append(stats, DriveStats{
+			Name:         driveStats[i].Name,
+			BytesRead:    driveStats[i].BytesRead,
+			BytesWritten: driveStats[i].BytesWritten,
+		})
+	}
+	return stats, nil
+}

--- a/pkg/server/status/runtime.go
+++ b/pkg/server/status/runtime.go
@@ -708,3 +708,9 @@ func GetCPUTime(ctx context.Context) (userTimeMillis, sysTimeMillis int64, err e
 	}
 	return int64(cpuTime.User), int64(cpuTime.Sys), nil
 }
+
+type DriveStats struct {
+	Name         string
+	BytesRead    int64
+	BytesWritten int64
+}

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -978,6 +978,12 @@ type Engine interface {
 	// MinVersionIsAtLeastTargetVersion returns whether the engine's recorded
 	// storage min version is at least the target version.
 	MinVersionIsAtLeastTargetVersion(target roachpb.Version) (bool, error)
+
+	// GetInternalIntervalMetrics returns low-level metrics from Pebble, that
+	// are reset at every interval, where an interval is defined over successive
+	// calls to this method. Hence, this should be used with care, with only one
+	// caller, which is currently the admission control subsystem.
+	GetInternalIntervalMetrics() *pebble.InternalIntervalMetrics
 }
 
 // Batch is the interface for batch specific operations.
@@ -1016,7 +1022,8 @@ type Metrics struct {
 	//
 	// We do not split this metric across these two reasons, but they can be
 	// distinguished in the pebble logs.
-	WriteStallCount int64
+	WriteStallCount    int64
+	WriteStallDuration time.Duration
 	// DiskSlowCount counts the number of times Pebble records disk slowness.
 	DiskSlowCount int64
 	// DiskStallCount counts the number of times Pebble observes slow writes

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
@@ -723,9 +724,11 @@ type Pebble struct {
 
 	// Stats updated by pebble.EventListener invocations, and returned in
 	// GetMetrics. Updated and retrieved atomically.
-	writeStallCount int64
-	diskSlowCount   int64
-	diskStallCount  int64
+	writeStallCount      int64
+	writeStallDuration   time.Duration
+	writeStallStartNanos int64
+	diskSlowCount        int64
+	diskStallCount       int64
 
 	// Relevant options copied over from pebble.Options.
 	fs            vfs.FS
@@ -996,6 +999,22 @@ func (p *Pebble) makeMetricEtcEventListener(ctx context.Context) pebble.EventLis
 	return pebble.EventListener{
 		WriteStallBegin: func(info pebble.WriteStallBeginInfo) {
 			atomic.AddInt64(&p.writeStallCount, 1)
+			startNanos := timeutil.Now().UnixNano()
+			atomic.StoreInt64(&p.writeStallStartNanos, startNanos)
+		},
+		WriteStallEnd: func() {
+			startNanos := atomic.SwapInt64(&p.writeStallStartNanos, 0)
+			if startNanos == 0 {
+				// Should not happen since these callbacks are registered when Pebble
+				// is opened, but just in case we miss the WriteStallBegin, lets not
+				// corrupt the metric.
+				return
+			}
+			stallDuration := timeutil.Now().UnixNano() - startNanos
+			if stallDuration < 0 {
+				return
+			}
+			atomic.AddInt64((*int64)(&p.writeStallDuration), stallDuration)
 		},
 		DiskSlow: func(info pebble.DiskSlowInfo) {
 			maxSyncDuration := maxSyncDurationDefault
@@ -1571,11 +1590,17 @@ func (p *Pebble) Flush() error {
 func (p *Pebble) GetMetrics() Metrics {
 	m := p.db.Metrics()
 	return Metrics{
-		Metrics:         m,
-		WriteStallCount: atomic.LoadInt64(&p.writeStallCount),
-		DiskSlowCount:   atomic.LoadInt64(&p.diskSlowCount),
-		DiskStallCount:  atomic.LoadInt64(&p.diskStallCount),
+		Metrics:            m,
+		WriteStallCount:    atomic.LoadInt64(&p.writeStallCount),
+		WriteStallDuration: time.Duration(atomic.LoadInt64((*int64)(&p.writeStallDuration))),
+		DiskSlowCount:      atomic.LoadInt64(&p.diskSlowCount),
+		DiskStallCount:     atomic.LoadInt64(&p.diskStallCount),
 	}
+}
+
+// GetInternalIntervalMetrics implements the Engine interface.
+func (p *Pebble) GetInternalIntervalMetrics() *pebble.InternalIntervalMetrics {
+	return p.db.InternalIntervalMetrics()
 }
 
 // GetEncryptionRegistries implements the Engine interface.

--- a/pkg/util/admission/BUILD.bazel
+++ b/pkg/util/admission/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "admission",
     srcs = [
+        "disk_bandwidth.go",
         "doc.go",
         "granter.go",
         "work_queue.go",
@@ -24,6 +25,7 @@ go_library(
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_cockroachdb_redact//:redact",
+        "@com_github_hdrhistogram_hdrhistogram_go//:hdrhistogram-go",
     ],
 )
 

--- a/pkg/util/admission/disk_bandwidth.go
+++ b/pkg/util/admission/disk_bandwidth.go
@@ -1,0 +1,298 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package admission
+
+import (
+	"math"
+
+	"github.com/HdrHistogram/hdrhistogram-go"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// The functionality in this file is geared towards preventing chronic overload
+// of disk bandwidth which typically results in severely high latency for all work.
+
+// For now, we assume that:
+// - There is a provisioned limit on the sum of read and write bandwidth. This
+//   limit is allowed to change. This is true for block devices of major cloud
+//   providers.
+// - Admission control can only shape the rate of admission of writes. Writes
+//   also cause reads, since compactions do reads and writes.
+//
+// There are multiple challenges:
+// - We are unable to precisely track the causes of disk read bandwidth, since
+//   we do not have observability into what reads missed the OS page cache.
+//   That is we don't know how much of the reads were due to incoming reads
+//   (that we don't shape) and how much due to compaction read bandwidth.
+//
+// - We don't shape incoming reads.
+//
+// - There can be a huge lag between the shaping of incoming writes, and when
+//   it affects actual writes in the system, since compaction backlog can
+//   build up in various levels of the LSM store.
+//
+// - Signals of overload are coarse, since we cannot view all the internal
+//   queues that can build up due to resource overload. For instance,
+//   different examples of bandwidth saturation exhibit wildly different
+//   latency effects, presumably because the queue buildup is different. So it
+//   is non-trivial to approach full utilization without risking high latency.
+//
+// Due to these challenges, and previous design attempts that were quite
+// complicated (and incomplete), we adopt a goal of simplicity of design, and strong
+// abstraction boundaries.
+//
+// - The disk load is abstracted using an enum. The diskLoadWatcher can be
+//   evolved independently.
+//
+// - The approach uses easy to understand additive increase and multiplicative
+//   decrease, (unlike what we do for flush and compaction tokens, where we
+//   try to more precisely calculate the sustainable rates).
+//
+// Since we are using a simple approach that is somewhat coarse in its behavior,
+// we start by limiting its application to two kinds of writes:
+//
+// - Incoming writes that are deemed "elastic": This can be done by
+//   introducing a work-class (in addition to admissionpb.WorkPriority), or by
+//   implying a work-class from the priority (e.g. priorities < NormalPri are
+//   deemed elastic).
+//
+// - Optional compactions: We assume that the LSM store is configured with a
+//   ceiling on number of regular concurrent compactions, and if it needs more
+//   it can request resources for additional (optional) compactions. These
+//   latter compactions can be limited by this approach. See
+//   https://github.com/cockroachdb/pebble/issues/1329 for motivation.
+//
+// Extending this to all incoming writes is future work.
+
+type diskLoadLevel int8
+
+const (
+	// diskLoadLow implies no need to shape anything.
+	diskLoadLow diskLoadLevel = iota
+	// diskLoadModerate implies shaping and additive increase.
+	diskLoadModerate
+	// diskLoadHigh implies shaping and hold steady.
+	diskLoadHigh
+	// diskLoadOverload implies shaping and multiplicative decrease.
+	diskLoadOverload
+)
+
+type diskLoadWatcher struct {
+	lastInterval IntervalDiskLoadInfo
+	loadLevel    diskLoadLevel
+}
+
+// IntervalDiskLoadInfo provides disk stats over an adjustmentInterval.
+type IntervalDiskLoadInfo struct {
+	// Bytes/s
+	ReadBandwidth        int64
+	WriteBandwidth       int64
+	ProvisionedBandwidth int64
+	SyncLatencyMicros    *hdrhistogram.Histogram
+}
+
+// setIntervalInfo is called at the same time as ioLoadListener.pebbleMetricsTick.
+func (d *diskLoadWatcher) setIntervalInfo(load IntervalDiskLoadInfo) {
+	d.lastInterval = load
+	util := float64(load.ReadBandwidth+load.WriteBandwidth) / float64(load.ProvisionedBandwidth)
+	// These constants are arbitrary and subject to tuning based on experiments.
+	if util < 0.5 {
+		if d.loadLevel <= diskLoadModerate {
+			// Two consecutive intervals with load <= diskLoadModerate
+			d.loadLevel = diskLoadLow
+		} else {
+			d.loadLevel = diskLoadModerate
+		}
+	} else if util < 0.8 {
+		if d.loadLevel <= diskLoadHigh {
+			d.loadLevel = diskLoadModerate
+		} else {
+			d.loadLevel = diskLoadHigh
+		}
+	} else if util < 0.95 {
+		d.loadLevel = diskLoadHigh
+	} else {
+		d.loadLevel = diskLoadOverload
+	}
+	// TODO(sumeer): Use history of syncLatencyMicros and that in the current
+	// interval to bump up the load level computed earlier based on bandwidth.
+	// Don't rely fully on syncLatencyMicros since (a) sync latency could arise
+	// due to an external unrelated outage, (b) some customers may set sync to a
+	// noop. We could also consider looking at fluctuations of peak-rate that
+	// the WAL writer can sustain.
+}
+
+func (d *diskLoadWatcher) getDiskLoad() diskLoadLevel {
+	return d.loadLevel
+}
+
+// IntervalCompactionInfo provides stats over an adjustmentInterval.
+type IntervalCompactionInfo struct {
+	// Both these stats must include ongoing compactions, since we desire
+	// accuracy despite the occasional long-running compaction.
+
+	// The time weighted number of concurrent running compactions.
+	WeightedNumConcurrentCompactions float64
+	// The bytes written by these compactions.
+	CompactionWriteBytes int64
+}
+
+type compactionLimiter struct {
+	lastInterval                        IntervalCompactionInfo
+	smoothedNumConcurrentCompactions    float64
+	smoothedWriteBytesPerCompactionSlot float64
+	mu                                  struct {
+		syncutil.Mutex
+		compactionSlots int
+		usedSlots       int
+	}
+}
+
+func (c *compactionLimiter) setIntervalInfo(intervalInfo IntervalCompactionInfo) {
+	c.lastInterval = intervalInfo
+	const alpha = 0.5
+	c.smoothedNumConcurrentCompactions = alpha*intervalInfo.WeightedNumConcurrentCompactions +
+		(1-alpha)*c.smoothedNumConcurrentCompactions
+	if intervalInfo.WeightedNumConcurrentCompactions > 0 {
+		bytesPerCompactionSlot :=
+			float64(intervalInfo.CompactionWriteBytes) / intervalInfo.WeightedNumConcurrentCompactions
+		c.smoothedWriteBytesPerCompactionSlot = alpha*bytesPerCompactionSlot +
+			(1-alpha)*c.smoothedWriteBytesPerCompactionSlot
+	}
+}
+
+func (c *compactionLimiter) getCompactionSlot(force bool) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if force || c.mu.usedSlots < c.mu.compactionSlots {
+		c.mu.usedSlots++
+		return true
+	}
+	return false
+}
+
+func (c *compactionLimiter) returnCompactionSlot() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.mu.usedSlots--
+}
+
+func (c *compactionLimiter) tryIncreaseSlots() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.lastInterval.WeightedNumConcurrentCompactions > float64(c.mu.compactionSlots)-1 {
+		c.mu.compactionSlots++
+		return true
+	}
+	return false
+}
+
+func (c *compactionLimiter) decreaseSlots() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.lastInterval.WeightedNumConcurrentCompactions > float64(c.mu.compactionSlots) {
+		// Previous decrease has not taken effect yet. No point decreasing in a
+		// multiplicative manner.
+		if c.mu.compactionSlots > 0 {
+			c.mu.compactionSlots--
+		}
+		return
+	}
+	c.mu.compactionSlots /= 2
+}
+
+func (c *compactionLimiter) setUnlimitedSlots() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.mu.compactionSlots = math.MaxInt
+}
+
+type intervalLSMInfo struct {
+	// Flushed bytes + Ingested bytes seen by the LSM. Ingested bytes also incur
+	// the cost of writing a sstable, even though that is done outside Pebble.
+	// Ingested bytes don't cause WAL writes, but we ignore that difference for
+	// simplicity.
+	incomingBytes int64
+	// regularTokensUsed and elasticTokensUsed are a combination of estimated
+	// and accounted bytes for regular and elastic traffic respectively. Each of
+	// these includes both writes that will get flushed and ingested bytes. But
+	// regularTokensUsed+elasticTokensUsed does not need to sum up to
+	// incomingBytes since they may be produced using a different method.
+	regularTokensUsed int64
+	elasticTokensUsed int64
+}
+
+type diskBandwidthLimiter struct {
+	diskLoadWatcher   diskLoadWatcher
+	compactionLimiter compactionLimiter
+
+	lastInterval            intervalLSMInfo
+	smoothedIncomingBytes   float64
+	smoothedElasticFraction float64
+	elasticTokens           int64
+}
+
+// Called every adjustmentInterval.
+func (d *diskBandwidthLimiter) adjust(
+	id IntervalDiskLoadInfo, ic IntervalCompactionInfo, il intervalLSMInfo,
+) (elasticTokens int64) {
+	d.diskLoadWatcher.setIntervalInfo(id)
+	d.compactionLimiter.setIntervalInfo(ic)
+
+	d.lastInterval = il
+	const alpha = 0.5
+	d.smoothedIncomingBytes = alpha*float64(il.incomingBytes) + (1-alpha)*d.smoothedIncomingBytes
+	var intElasticFraction float64
+	if il.regularTokensUsed+il.elasticTokensUsed > 0 {
+		intElasticFraction =
+			float64(il.elasticTokensUsed) / float64(il.regularTokensUsed+il.elasticTokensUsed)
+		d.smoothedElasticFraction = alpha*intElasticFraction + (1-alpha)*d.smoothedElasticFraction
+	}
+	intElasticBytes := int64(float64(il.incomingBytes) * intElasticFraction)
+
+	ll := d.diskLoadWatcher.getDiskLoad()
+	switch ll {
+	case diskLoadLow:
+		d.elasticTokens = math.MaxInt64
+		d.compactionLimiter.setUnlimitedSlots()
+	case diskLoadModerate:
+		// First try to increase compactions in case compactions are falling
+		// behind.
+		increased := d.compactionLimiter.tryIncreaseSlots()
+		if !increased && il.elasticTokensUsed >= d.elasticTokens {
+			// Smoothed elastic bytes.
+			elasticBytes := d.smoothedElasticFraction * d.smoothedIncomingBytes
+			// Increase smoothedIncomingBytes by 10% and all of that goes to elastic
+			// work.
+			elasticBytes += 0.1 * d.smoothedIncomingBytes
+			d.elasticTokens = int64(elasticBytes)
+			if d.elasticTokens == 0 {
+				// Don't get stuck in a situation where smoothedIncomingBytes are 0.
+				d.elasticTokens = math.MaxInt64
+			}
+		}
+	case diskLoadHigh:
+		if float64(intElasticBytes) >= d.compactionLimiter.smoothedWriteBytesPerCompactionSlot {
+			// Try to decrease elastic tokens and increase compactions. This is a
+			// very rough heuristic since compactions also incur reads, which are
+			// not being accounted for here, but some compensation is better than
+			// nothing.
+			if d.compactionLimiter.tryIncreaseSlots() {
+				d.elasticTokens = intElasticBytes -
+					int64(d.compactionLimiter.smoothedNumConcurrentCompactions)
+			}
+		}
+	case diskLoadOverload:
+		d.compactionLimiter.decreaseSlots()
+		d.elasticTokens = intElasticBytes / 2
+	}
+	return d.elasticTokens
+}

--- a/pkg/util/admission/disk_bandwidth.go
+++ b/pkg/util/admission/disk_bandwidth.go
@@ -11,9 +11,12 @@
 package admission
 
 import (
+	"context"
 	"math"
 
 	"github.com/HdrHistogram/hdrhistogram-go"
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
@@ -87,6 +90,7 @@ const (
 
 type diskLoadWatcher struct {
 	lastInterval IntervalDiskLoadInfo
+	lastUtil     float64
 	loadLevel    diskLoadLevel
 }
 
@@ -103,25 +107,40 @@ type IntervalDiskLoadInfo struct {
 func (d *diskLoadWatcher) setIntervalInfo(load IntervalDiskLoadInfo) {
 	d.lastInterval = load
 	util := float64(load.ReadBandwidth+load.WriteBandwidth) / float64(load.ProvisionedBandwidth)
+	log.Infof(context.Background(), "diskLoadWatcher: rb: %s, wb: %s, pb: %s, util: %.2f",
+		humanizeutil.IBytes(load.ReadBandwidth), humanizeutil.IBytes(load.WriteBandwidth),
+		humanizeutil.IBytes(load.ProvisionedBandwidth), util)
 	// These constants are arbitrary and subject to tuning based on experiments.
-	if util < 0.5 {
-		if d.loadLevel <= diskLoadModerate {
-			// Two consecutive intervals with load <= diskLoadModerate
+	if util < 0.3 {
+		// Were at moderate or lower and have not increased significantly and the
+		// lastUtil was also low, then we can afford to go unlimited. We are
+		// trying to be really careful to narrow this case since going unlimited
+		// can blow up bandwidth.
+		if d.loadLevel <= diskLoadModerate && util < d.lastUtil+0.05 && d.lastUtil < 0.3 {
 			d.loadLevel = diskLoadLow
 		} else {
+			// util is increasing, or we just dropped from something higher than
+			// moderate. Give it more time at moderate.
 			d.loadLevel = diskLoadModerate
 		}
-	} else if util < 0.8 {
-		if d.loadLevel <= diskLoadHigh {
-			d.loadLevel = diskLoadModerate
-		} else {
-			d.loadLevel = diskLoadHigh
-		}
-	} else if util < 0.95 {
+	} else if util < 0.7 {
+		// Wide band from [0.3,0.7) where we can gradually increase. Also 0.7 is
+		// deliberately a lowish fraction since effect on compaction can be laggy
+		// and kick in later. We are ok with accepting a low utilization for
+		// elastic traffic to make progress.
+		d.loadLevel = diskLoadModerate
+	} else if util < 0.95 || (util < 2 && util < d.lastUtil-0.05) {
+		// Wide band from [0.7,0.95) where we will hold. Don't want to overreact
+		// and decrease too early since compaction bw usage can be lumpy. Also, if
+		// we are trending downward, want to hold. Note that util < 2 will always
+		// be true in real situations where one cannot actually exceed provisioned
+		// bw -- but we do also run experiments where we artifically constrain the
+		// provisioned bw, where this is useful.
 		d.loadLevel = diskLoadHigh
 	} else {
 		d.loadLevel = diskLoadOverload
 	}
+	d.lastUtil = util
 	// TODO(sumeer): Use history of syncLatencyMicros and that in the current
 	// interval to bump up the load level computed earlier based on bandwidth.
 	// Don't rely fully on syncLatencyMicros since (a) sync latency could arise
@@ -130,8 +149,9 @@ func (d *diskLoadWatcher) setIntervalInfo(load IntervalDiskLoadInfo) {
 	// the WAL writer can sustain.
 }
 
-func (d *diskLoadWatcher) getDiskLoad() diskLoadLevel {
-	return d.loadLevel
+func (d *diskLoadWatcher) getDiskLoad() (level diskLoadLevel, unusedBandwidth int64) {
+	return d.loadLevel,
+		d.lastInterval.ProvisionedBandwidth - d.lastInterval.ReadBandwidth - d.lastInterval.WriteBandwidth
 }
 
 // IntervalCompactionInfo provides stats over an adjustmentInterval.
@@ -146,7 +166,10 @@ type IntervalCompactionInfo struct {
 }
 
 type compactionLimiter struct {
-	lastInterval                        IntervalCompactionInfo
+	lastInterval IntervalCompactionInfo
+	// TODO: currently IntervalCompactionInfo is always 0, so the following will
+	// also be 0. The initial experimental evaluation does not care about
+	// dynamically adjusting number of compactions.
 	smoothedNumConcurrentCompactions    float64
 	smoothedWriteBytesPerCompactionSlot float64
 	mu                                  struct {
@@ -190,6 +213,7 @@ func (c *compactionLimiter) tryIncreaseSlots() bool {
 	defer c.mu.Unlock()
 	if c.lastInterval.WeightedNumConcurrentCompactions > float64(c.mu.compactionSlots)-1 {
 		c.mu.compactionSlots++
+		log.Infof(context.Background(), "compactionLimiter slots: %d", c.mu.compactionSlots)
 		return true
 	}
 	return false
@@ -203,6 +227,7 @@ func (c *compactionLimiter) decreaseSlots() {
 		// multiplicative manner.
 		if c.mu.compactionSlots > 0 {
 			c.mu.compactionSlots--
+			log.Infof(context.Background(), "compactionLimiter slots: %d", c.mu.compactionSlots)
 		}
 		return
 	}
@@ -212,6 +237,9 @@ func (c *compactionLimiter) decreaseSlots() {
 func (c *compactionLimiter) setUnlimitedSlots() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.mu.compactionSlots != math.MaxInt {
+		log.Infof(context.Background(), "compactionLimiter slots: unlimited")
+	}
 	c.mu.compactionSlots = math.MaxInt
 }
 
@@ -258,26 +286,63 @@ func (d *diskBandwidthLimiter) adjust(
 	}
 	intElasticBytes := int64(float64(il.incomingBytes) * intElasticFraction)
 
-	ll := d.diskLoadWatcher.getDiskLoad()
+	ll, unusedBW := d.diskLoadWatcher.getDiskLoad()
+	// Compaction bw suddenly drops close to 0, from a very high value. We have
+	// reduced elastic tokens close to 0. Now we need to ramp up. The problem here
+	// is that by halving under overload (which we can slip into), we don't manage
+	// to reduce to High due to the lag effect. So we decrease too much. So now
+	// we need to increase fast.
+	// Should we look at the contribution of compaction writes on overall bw and
+	// be forecasting the future based on compaction backlog? This is getting
+	// too complicated. In practice, we will have a mix of elastic and regular
+	// traffic, though maybe regular traffic will be quite low.
 	switch ll {
 	case diskLoadLow:
 		d.elasticTokens = math.MaxInt64
 		d.compactionLimiter.setUnlimitedSlots()
+		log.Infof(context.Background(), "diskBandwidthLimiter: low")
 	case diskLoadModerate:
 		// First try to increase compactions in case compactions are falling
 		// behind.
 		increased := d.compactionLimiter.tryIncreaseSlots()
-		if !increased && il.elasticTokensUsed >= d.elasticTokens {
-			// Smoothed elastic bytes.
-			elasticBytes := d.smoothedElasticFraction * d.smoothedIncomingBytes
-			// Increase smoothedIncomingBytes by 10% and all of that goes to elastic
-			// work.
-			elasticBytes += 0.1 * d.smoothedIncomingBytes
+		tokensFullyUtilized := func() bool {
+			return il.elasticTokensUsed+1<<10 >= d.elasticTokens || d.elasticTokens == math.MaxInt64 ||
+				(d.elasticTokens > 0 && float64(il.elasticTokensUsed)/float64(d.elasticTokens) >= 0.8)
+		}
+		if !increased && tokensFullyUtilized() {
+			// Smoothed elastic bytes plus 10% of smoothedIncomingBytes is given to
+			// elastic work.
+			elasticBytes := (d.smoothedElasticFraction + 0.1) * d.smoothedIncomingBytes
+
+			// Sometimes we see the tokens not increasing even though we are staying
+			// for multiple intervals at moderate. This is because the smoothing can
+			// have a lagging effect. We do want to increase tokens since we know
+			// there is spare capacity, so we try many ways (that don't look at
+			// smoothed numbers only). Also, we sometimes come here due to an
+			// overload=>moderate transition because compaction bw usage can be
+			// lumpy (high when there is a backlog and then dropping severely) -- in
+			// that case we want to start increasing immediately, since we've likely
+			// decreased too much.
+			intBasedElasticTokens := (d.smoothedElasticFraction + 0.1) * float64(il.incomingBytes)
+			if elasticBytes < intBasedElasticTokens {
+				elasticBytes = intBasedElasticTokens
+			}
+			if elasticBytes < 1.1*float64(il.elasticTokensUsed) {
+				elasticBytes = 1.1 * float64(il.elasticTokensUsed)
+			}
 			d.elasticTokens = int64(elasticBytes)
 			if d.elasticTokens == 0 {
 				// Don't get stuck in a situation where smoothedIncomingBytes are 0.
 				d.elasticTokens = math.MaxInt64
 			}
+			log.Infof(context.Background(),
+				"diskBandwidthLimiter: moderate fr: %.2f, smoothed-incoming: %s, unusedBW: %s, elasticBytes/Tokens: %s",
+				d.smoothedElasticFraction, humanizeutil.IBytes(int64(d.smoothedIncomingBytes)),
+				humanizeutil.IBytes(unusedBW),
+				humanizeutil.IBytes(int64(elasticBytes)))
+		} else {
+			log.Infof(context.Background(), "diskBandwidthLimiter: moderate elasticTokens (limit, used): %d, %d",
+				d.elasticTokens, il.elasticTokensUsed)
 		}
 	case diskLoadHigh:
 		if float64(intElasticBytes) >= d.compactionLimiter.smoothedWriteBytesPerCompactionSlot {
@@ -286,13 +351,38 @@ func (d *diskBandwidthLimiter) adjust(
 			// not being accounted for here, but some compensation is better than
 			// nothing.
 			if d.compactionLimiter.tryIncreaseSlots() {
+				// TODO: this will never happen in our experiments.
 				d.elasticTokens = intElasticBytes -
-					int64(d.compactionLimiter.smoothedNumConcurrentCompactions)
+					int64(d.compactionLimiter.smoothedWriteBytesPerCompactionSlot)
 			}
 		}
+		log.Infof(context.Background(), "diskBandwidthLimiter: high elastic fr: %.2f, smoothed-incoming: %d, elasticTokens: %d",
+			d.smoothedElasticFraction, int64(d.smoothedIncomingBytes), d.elasticTokens)
 	case diskLoadOverload:
 		d.compactionLimiter.decreaseSlots()
+		// Sometimes we come here after a low => overload transition. The
+		// intElasticBytes will be very high because tokens were unlimited. We
+		// don't want to use that as the starting point of the decrease if the
+		// smoothed value is lower. Hence, the min logic below, to try to dampen
+		// the increase quickly.
 		d.elasticTokens = intElasticBytes / 2
+		elasticBytes := int64(d.smoothedElasticFraction * d.smoothedIncomingBytes)
+		if elasticBytes/2 < d.elasticTokens {
+			d.elasticTokens = elasticBytes / 2
+		}
+		log.Infof(context.Background(), "diskBandwidthLimiter: overload %s",
+			humanizeutil.IBytes(d.elasticTokens))
 	}
+	// We can end up with 0 elastic tokens here -- e.g. if intElasticBytes was 0
+	// but we were still overloaded because of compactions. The trouble with 0
+	// elastic tokens is that if we don't admit anything, we cannot correct on
+	// occasional poor estimate of the per-request bytes. So we decide to give
+	// out at least 1 token. A single elastic request should not be too big for
+	// this to matter.
+	// 60 is a hack here since we know we give out tokens every 250ms for 15s.
+	// We want to give out one token in each tick since if we get unlucky and
+	// give out 1 in the first tick and that does not get used the subsequent
+	// ticks will reduce the tokens to 0.
+	d.elasticTokens = max(60, d.elasticTokens)
 	return d.elasticTokens
 }

--- a/pkg/util/admission/doc.go
+++ b/pkg/util/admission/doc.go
@@ -124,4 +124,6 @@
 // for writes. See kvStoreTokenGranter and how its tokens are dynamically
 // adjusted based on Pebble metrics.
 
+// TODO(sumeer): update with new stuff and changes to existing.
+
 package admission

--- a/pkg/util/admission/granter.go
+++ b/pkg/util/admission/granter.go
@@ -56,6 +56,15 @@ var L0SubLevelCountOverloadThreshold = settings.RegisterIntSetting(
 	"when the L0 sub-level count exceeds this threshold, the store is considered overloaded",
 	l0SubLevelCountOverloadThreshold, settings.PositiveInt)
 
+// MinFlushUtilizationPercentage is a lower-bound on the dynamically adjusted
+// flush utilization target that attempts to reduce write stalls. Set it to a
+// high percentage, like 1000, to effectively disable flush based tokens.
+var MinFlushUtilizationPercentage = settings.RegisterIntSetting(
+	settings.SystemOnly,
+	"admission.min_flush_util_percent",
+	"when computing flush tokens, this percentage is used as a lower bound on the dynamic"+
+		"multiplier of the peak flush rate", 50, settings.PositiveInt)
+
 // grantChainID is the ID for a grant chain. See continueGrantChain for
 // details.
 type grantChainID uint64
@@ -493,7 +502,11 @@ type kvStoreTokenGranter struct {
 	requester requester
 	// There is no rate limiting in granting these tokens. That is, they are all
 	// burst tokens.
-	availableIOTokens               int64
+	availableIOTokens int64
+	// startingIOTokens is the number of tokens set by
+	// setAvailableIOTokensLocked. It is used to compute the tokens used, by
+	// computing startingIOTokens-availableIOTokens.
+	startingIOTokens                int64
 	ioTokensExhaustedDurationMetric *metric.Counter
 	exhaustedStart                  time.Time
 }
@@ -560,7 +573,8 @@ func (sg *kvStoreTokenGranter) continueGrantChain(grantChainID grantChainID) {
 	sg.coord.continueGrantChain(KVWork, grantChainID)
 }
 
-func (sg *kvStoreTokenGranter) setAvailableIOTokensLocked(tokens int64) {
+func (sg *kvStoreTokenGranter) setAvailableIOTokensLocked(tokens int64) (tokensUsed int64) {
+	tokensUsed = sg.startingIOTokens - sg.availableIOTokens
 	// It is possible for availableIOTokens to be negative because of
 	// tookWithoutPermission or because tryGet will satisfy requests until
 	// availableIOTokens become <= 0. We want to remember this previous
@@ -570,6 +584,8 @@ func (sg *kvStoreTokenGranter) setAvailableIOTokensLocked(tokens int64) {
 		// Clamp to tokens.
 		sg.availableIOTokens = tokens
 	}
+	sg.startingIOTokens = tokens
+	return tokensUsed
 }
 
 // GrantCoordinator is the top-level object that coordinates grants across
@@ -904,7 +920,7 @@ func appendMetricStructsForQueues(ms []metric.Struct, coord *GrantCoordinator) [
 // pebbleMetricsTick is called every adjustmentInterval seconds and passes
 // through to the ioLoadListener, so that it can adjust the plan for future IO
 // token allocations.
-func (coord *GrantCoordinator) pebbleMetricsTick(ctx context.Context, m *pebble.Metrics) {
+func (coord *GrantCoordinator) pebbleMetricsTick(ctx context.Context, m StoreMetrics) {
 	coord.ioLoadListener.pebbleMetricsTick(ctx, m)
 }
 
@@ -916,10 +932,8 @@ func (coord *GrantCoordinator) allocateIOTokensTick() {
 	if !coord.grantChainActive {
 		coord.tryGrant()
 	}
-	// Else, let the grant chain finish. We could terminate it, but token
-	// replenishment occurs at 1s granularity which is coarse enough to not
-	// bother. Also, in production we turn off grant chains on the
-	// GrantCoordinators used for IO, so we will always call tryGrant.
+	// Else, let the grant chain finish. NB: we turn off grant chains on the
+	// GrantCoordinators used for IO, so the if-condition is always true.
 }
 
 // testingTryGrant is only for unit tests, since they sometimes cut out
@@ -1280,7 +1294,7 @@ func (sgc *StoreGrantCoordinators) SetPebbleMetricsProvider(
 		if !loaded {
 			sgc.numStores++
 		}
-		gc.pebbleMetricsTick(startupCtx, m.Metrics)
+		gc.pebbleMetricsTick(startupCtx, m)
 		gc.allocateIOTokensTick()
 	}
 	if sgc.disableTickerForTesting {
@@ -1291,13 +1305,13 @@ func (sgc *StoreGrantCoordinators) SetPebbleMetricsProvider(
 
 	go func() {
 		var ticks int64
-		ticker := time.NewTicker(time.Second)
+		ticker := time.NewTicker(ioTokenTickDuration)
 		done := false
 		for !done {
 			select {
 			case <-ticker.C:
 				ticks++
-				if ticks%adjustmentInterval == 0 {
+				if ticks%ticksInAdjustmentInterval == 0 {
 					metrics := sgc.pebbleMetricsProvider.GetPebbleMetrics()
 					if len(metrics) != sgc.numStores {
 						log.Warningf(ctx,
@@ -1306,7 +1320,7 @@ func (sgc *StoreGrantCoordinators) SetPebbleMetricsProvider(
 					for _, m := range metrics {
 						if unsafeGc, ok := sgc.gcMap.Load(int64(m.StoreID)); ok {
 							gc := (*GrantCoordinator)(unsafeGc)
-							gc.pebbleMetricsTick(ctx, m.Metrics)
+							gc.pebbleMetricsTick(ctx, m)
 						} else {
 							log.Warningf(ctx,
 								"seeing metrics for unknown storeID %d", m.StoreID)
@@ -1526,6 +1540,8 @@ type PebbleMetricsProvider interface {
 type StoreMetrics struct {
 	StoreID int32
 	*pebble.Metrics
+	WriteStallCount int64
+	*pebble.InternalIntervalMetrics
 }
 
 // granterWithIOTokens is used to abstract kvStoreTokenGranter for testing.
@@ -1535,8 +1551,11 @@ type granterWithIOTokens interface {
 	// tight bound when the callee has negative available tokens, due to the use
 	// of granter.tookWithoutPermission, since in that the case the callee
 	// increments that negative value with the value provided by tokens. This
-	// method needs to be called periodically.
-	setAvailableIOTokensLocked(tokens int64)
+	// method needs to be called periodically. The return value is the number of
+	// used tokens in the interval since the prior call to this method. Note
+	// that tokensUsed can be negative, though that will be rare, since it is
+	// possible for tokens to be returned.
+	setAvailableIOTokensLocked(tokens int64) (tokensUsed int64)
 }
 
 // storeAdmissionStats are stats maintained by a storeRequester. The non-test
@@ -1600,6 +1619,8 @@ type ioLoadListenerState struct {
 	cumL0AddedBytes uint64
 	// Gauge.
 	curL0Bytes int64
+	// Cumulative.
+	cumWriteStallCount int64
 
 	// Exponentially smoothed per interval values.
 
@@ -1610,13 +1631,24 @@ type ioLoadListenerState struct {
 	// is determined when the work is done, as then the L0 fraction is known
 	// precisely.
 	smoothedIntIngestedAccountedL0BytesFraction float64 // '1.0' means: all ingested bytes went to L0
-	smoothedTotalNumByteTokens                  float64 // smoothed history of token bucket sizes
+	// Smoothed history of byte tokens calculated based on compactions out of L0.
+	smoothedCompactionByteTokens float64
+
+	// Number of flush tokens, before multiplying by target fraction.
+	smoothedNumFlushTokens float64
+	// The target fraction to be used for the effective flush tokens. It is in
+	// the interval
+	// [MinFlushUtilizationPercentage/100,maxFlushUtilTargetFraction].
+	flushUtilTargetFraction float64
 
 	// totalNumByteTokens represents the tokens to give out until the next call to
 	// adjustTokens. They are parceled out in small intervals. tokensAllocated
 	// represents what has been given out.
 	totalNumByteTokens int64
 	tokensAllocated    int64
+	// Used tokens can be negative if some tokens taken in one interval were
+	// returned in another, but that will be extremely rare.
+	tokensUsed int64
 }
 
 // ioLoadListener adjusts tokens in kvStoreTokenGranter for IO, specifically due to
@@ -1644,12 +1676,12 @@ const unlimitedTokens = math.MaxInt64
 
 // Token changes are made at a coarse time granularity of 15s since
 // compactions can take ~10s to complete. The totalNumByteTokens to give out over
-// the 15s interval are given out in a smoothed manner, at 1s intervals.
+// the 15s interval are given out in a smoothed manner, at 250ms intervals.
 // This has similarities with the following kinds of token buckets:
 // - Zero replenishment rate and a burst value that is changed every 15s. We
 //   explicitly don't want a huge burst every 15s.
-// - A replenishment rate equal to totalNumByteTokens/15, with a burst capped at
-//   totalNumByteTokens/15. The only difference with the code here is that if
+// - A replenishment rate equal to totalNumByteTokens/60, with a burst capped at
+//   totalNumByteTokens/60. The only difference with the code here is that if
 //   totalNumByteTokens is small, the integer rounding effects are compensated for.
 //
 // In an experiment with extreme overload using KV0 with block size 64KB,
@@ -1679,17 +1711,34 @@ const unlimitedTokens = math.MaxInt64
 // reasonable to simply use metrics that are updated when compactions
 // complete (as opposed to also tracking progress in bytes of on-going
 // compactions).
+//
+// The 250ms interval to hand out the computed tokens is due to the needs of
+// flush tokens. For compaction tokens, a 1s interval is fine-grained enough.
+//
+// If flushing a memtable take 100ms, then 10 memtables can be sustainably
+// flushed in 1s. If we dole out flush tokens in 1s intervals, then there are
+// enough tokens to create 10 memtables at the very start of a 1s interval,
+// which will cause a write stall. Intuitively, the faster it is to flush a
+// memtable, the smaller the interval for doling out these tokens. We have
+// observed flushes taking ~0.5s, so we picked a 250ms interval for doling out
+// these tokens. We could use a value smaller than 250ms, but we've observed
+// CPU utilization issues at lower intervals (see the discussion in
+// runnable.go).
 const adjustmentInterval = 15
+const ticksInAdjustmentInterval = 60
+const ioTokenTickDuration = 250 * time.Millisecond
 
 // pebbleMetricsTicks is called every adjustmentInterval seconds, and decides
 // the token allocations until the next call.
-func (io *ioLoadListener) pebbleMetricsTick(ctx context.Context, m *pebble.Metrics) {
+func (io *ioLoadListener) pebbleMetricsTick(ctx context.Context, metrics StoreMetrics) {
+	m := metrics.Metrics
 	if !io.statsInitialized {
 		io.statsInitialized = true
 		io.ioLoadListenerState = ioLoadListenerState{
-			cumAdmissionStats: io.kvRequester.getStoreAdmissionStats(),
-			cumL0AddedBytes:   m.Levels[0].BytesFlushed + m.Levels[0].BytesIngested,
-			curL0Bytes:        m.Levels[0].Size,
+			cumAdmissionStats:  io.kvRequester.getStoreAdmissionStats(),
+			cumL0AddedBytes:    m.Levels[0].BytesFlushed + m.Levels[0].BytesIngested,
+			curL0Bytes:         m.Levels[0].Size,
+			cumWriteStallCount: metrics.WriteStallCount,
 			// Reasonable starting fraction until we see some ingests.
 			smoothedIntIngestedAccountedL0BytesFraction: 0.5,
 			// No initial limit, i.e, the first interval is unlimited.
@@ -1697,21 +1746,21 @@ func (io *ioLoadListener) pebbleMetricsTick(ctx context.Context, m *pebble.Metri
 		}
 		return
 	}
-	io.adjustTokens(ctx, m)
+	io.adjustTokens(ctx, metrics)
 }
 
-// allocateTokensTick gives out 1/adjustmentInterval of the totalNumByteTokens every
-// 1s.
+// allocateTokensTick gives out 1/ticksInAdjustmentInterval of the
+// totalNumByteTokens every 250ms.
 func (io *ioLoadListener) allocateTokensTick() {
 	var toAllocate int64
 	// unlimitedTokens==MaxInt64, so avoid overflow in the rounding up
 	// calculation.
-	if io.totalNumByteTokens >= unlimitedTokens-(adjustmentInterval-1) {
-		toAllocate = io.totalNumByteTokens / adjustmentInterval
+	if io.totalNumByteTokens >= unlimitedTokens-(ticksInAdjustmentInterval-1) {
+		toAllocate = io.totalNumByteTokens / ticksInAdjustmentInterval
 	} else {
 		// Round up so that we don't accumulate tokens to give in a burst on the
 		// last tick.
-		toAllocate = (io.totalNumByteTokens + adjustmentInterval - 1) / adjustmentInterval
+		toAllocate = (io.totalNumByteTokens + ticksInAdjustmentInterval - 1) / ticksInAdjustmentInterval
 		if toAllocate < 0 {
 			panic(errors.AssertionFailedf("toAllocate is negative %d", toAllocate))
 		}
@@ -1726,17 +1775,24 @@ func (io *ioLoadListener) allocateTokensTick() {
 	if io.tokensAllocated < 0 {
 		panic(errors.AssertionFailedf("tokens allocated is negative %d", io.tokensAllocated))
 	}
-	io.mu.kvGranter.setAvailableIOTokensLocked(toAllocate)
+	io.tokensUsed += io.mu.kvGranter.setAvailableIOTokensLocked(toAllocate)
 }
 
 // adjustTokens computes a new value of totalNumByteTokens (and resets
 // tokensAllocated). The new value, when overloaded, is based on comparing how
 // many bytes are being moved out of L0 via compactions with the average
 // number of bytes being added to L0 per KV work. We want the former to be
-// (significantly) larger so that L0 returns to a healthy state.
-func (io *ioLoadListener) adjustTokens(ctx context.Context, m *pebble.Metrics) {
-	res := io.adjustTokensInner(ctx, io.ioLoadListenerState, io.kvRequester.getStoreAdmissionStats(), m.Levels[0],
-		L0FileCountOverloadThreshold.Get(&io.settings.SV), L0SubLevelCountOverloadThreshold.Get(&io.settings.SV),
+// (significantly) larger so that L0 returns to a healthy state. The byte
+// token computation also takes into account the flush throughput, since an
+// inability to flush fast enough can result in write stalls due to high
+// memtable counts, which we want to avoid as it can cause latency hiccups of
+// 100+ms for all write traffic.
+func (io *ioLoadListener) adjustTokens(ctx context.Context, metrics StoreMetrics) {
+	res := io.adjustTokensInner(ctx, io.ioLoadListenerState, io.kvRequester.getStoreAdmissionStats(),
+		metrics.Levels[0], metrics.WriteStallCount, metrics.InternalIntervalMetrics,
+		L0FileCountOverloadThreshold.Get(&io.settings.SV),
+		L0SubLevelCountOverloadThreshold.Get(&io.settings.SV),
+		MinFlushUtilizationPercentage.Get(&io.settings.SV),
 	)
 	io.adjustTokensResult = res
 	io.kvRequester.setStoreRequestEstimates(res.requestEstimates)
@@ -1761,6 +1817,10 @@ type adjustTokensAuxComputations struct {
 
 	intPerWorkUnaccountedL0Bytes float64
 	l0BytesIngestFraction        float64
+
+	intFlushTokens      float64
+	intFlushUtilization float64
+	intWriteStalls      int64
 }
 
 func (*ioLoadListener) adjustTokensInner(
@@ -1768,7 +1828,10 @@ func (*ioLoadListener) adjustTokensInner(
 	prev ioLoadListenerState,
 	cumAdmissionStats storeAdmissionStats,
 	l0Metrics pebble.LevelMetrics,
+	cumWriteStallCount int64,
+	im *pebble.InternalIntervalMetrics,
 	threshNumFiles, threshNumSublevels int64,
+	minFlushUtilizationPercentage int64,
 ) adjustTokensResult {
 	curL0Bytes := l0Metrics.Size
 	cumL0AddedBytes := l0Metrics.BytesFlushed + l0Metrics.BytesIngested
@@ -1878,9 +1941,186 @@ func (*ioLoadListener) adjustTokensInner(
 		smoothedIntIngestedAccountedL0BytesFraction = prev.smoothedIntIngestedAccountedL0BytesFraction
 	}
 
-	// We constrain admission if the store is over the threshold.
+	// Flush tokens:
+	//
+	// Write stalls happen when flushing of memtables is a bottleneck.
+	//
+	// Computing Flush Tokens:
+	// Flush can go from not being the bottleneck in one 15s interval
+	// (adjustmentInterval) to being the bottleneck in the next 15s interval
+	// (e.g. when L0 falls below the unhealthy threshold and compaction tokens
+	// become unlimited). So the flush token limit has to react quickly (cannot
+	// afford to wait for multiple 15s intervals). We've observed that if we
+	// normalize the flush rate based on flush loop utilization (the PeakRate
+	// computation below), and use that to compute flush tokens, the token
+	// counts are quite stable. Here are two examples, showing this steady token
+	// count computed using PeakRate of the flush ThroughputMetric, despite
+	// changes in flush loop utilization (the util number below).
+	//
+	// Example 1: Case where IO bandwidth was not a bottleneck
+	// flush: tokens: 2312382401, util: 0.90
+	// flush: tokens: 2345477107, util: 0.31
+	// flush: tokens: 2317829891, util: 0.29
+	// flush: tokens: 2428387843, util: 0.17
+	//
+	// Example 2: Case where IO bandwidth became a bottleneck (and mean fsync
+	// latency was fluctuating between 1ms and 4ms in the low util to high util
+	// cases).
+	//
+	// flush: tokens: 1406132615, util: 1.00
+	// flush: tokens: 1356476227, util: 0.64
+	// flush: tokens: 1374880806, util: 0.24
+	// flush: tokens: 1328578534, util: 0.96
+	//
+	// Hence, using PeakRate as a basis for computing flush tokens seems sound.
+	// The other important question is what fraction of PeakRate avoids write
+	// stalls. It is likely less than 100% since while a flush is ongoing,
+	// memtables can accumulate and cause a stall. For example, we have observed
+	// write stalls at 80% of PeakRate. The fraction depends on configuration
+	// parameters like MemTableStopWritesThreshold (defaults to 4 in
+	// CockroachDB), and environmental and workload factors like how long a
+	// flush takes to flush a single 64MB memtable. Instead of trying to measure
+	// and adjust for these, we use a simple multiplier,
+	// flushUtilTargetFraction. By default, flushUtilTargetFraction ranges
+	// between 0.5 and 1.5. The lower bound is configurable via
+	// admission.min_flush_util_percent and if configured above the upper bound,
+	// the upper bound will be ignored and the target fraction will not be
+	// dynamically adjusted. The dynamic adjustment logic uses an additive step
+	// size of flushUtilTargetFractionIncrement (0.025), with the following
+	// logic:
+	// - Reduce the fraction if there is a write-stall. The reduction may use a
+	//   small multiple of flushUtilTargetFractionIncrement. This is so that
+	//   this probing spends more time below the threshold where write stalls
+	//   occur.
+	// - Increase fraction if no write-stall and flush tokens were almost all
+	//   used.
+	//
+	// This probing unfortunately cannot eliminate write stalls altogether.
+	// Future improvements could use more history to settle on a good
+	// flushUtilTargetFraction for longer, or use some measure of how close we
+	// are to a write-stall to stop the increase.
+	//
+	// Ingestion and flush tokens:
+	//
+	// Ingested sstables do not utilize any flush capacity. Consider 2 cases:
+	// - sstable ingested into L0: there was either data overlap with L0, or
+	//   file boundary overlap with L0-L6. To be conservative, lets assume there
+	//   was data overlap, and that this data overlap extended into the memtable
+	//   at the time of ingestion. Memtable(s) would have been force flushed to
+	//   handle such overlap. The cost of flushing a memtable is based on how
+	//   much of the allocated memtable capacity is used, so an early flush
+	//   seems harmless. However, write stalls are based on allocated memtable
+	//   capacity, so there is a potential negative interaction of these forced
+	//   flushes since they cause additional memtable capacity allocation.
+	// - sstable ingested into L1-L6: there was no data overlap with L0, which
+	//   implies that there was no reason to flush memtables.
+	//
+	// Since there is some interaction noted in bullet 1, and because it
+	// simplifies the admission control token behavior, we use flush tokens in
+	// an identical manner as compaction tokens -- to be consumed by all data
+	// flowing into L0. Some of this conservative choice will be compensated for
+	// by flushUtilTargetFraction (when the mix of ingestion and actual flushes
+	// are stable). Another thing to note is that compactions out of L0 are
+	// typically the more persistent bottleneck than flushes for the following
+	// reason:
+	// There is a dedicated flush thread. In comparison, with a write amp of W
+	// and maximum compaction concurrency of C, only approximately C/W threads
+	// are working on reading from L0 to compact out of L0. Since W can be 20+
+	// and C defaults to 3 (we plan to dynamically adjust C but one can expect C
+	// to be <= 10), C/W < 1. So the main reason we are considering flush tokens
+	// is transient flush bottlenecks, and workloads where W is small.
+
+	// Compute flush utilization for this interval. A very low flush utilization
+	// will cause flush tokens to be unlimited.
+	intFlushUtilization := float64(0)
+	if im.Flush.WriteThroughput.WorkDuration > 0 {
+		intFlushUtilization = float64(im.Flush.WriteThroughput.WorkDuration) /
+			float64(im.Flush.WriteThroughput.WorkDuration+im.Flush.WriteThroughput.IdleDuration)
+	}
+	// Compute flush tokens for this interval that would cause 100% utilization.
+	intFlushTokens := float64(im.Flush.WriteThroughput.PeakRate()) * adjustmentInterval
+	intWriteStalls := cumWriteStallCount - prev.cumWriteStallCount
+
+	// Ensure flushUtilTargetFraction is in the configured bounds. This also
+	// does lazy initialization.
+	const maxFlushUtilTargetFraction = 1.5
+	flushUtilTargetFraction := prev.flushUtilTargetFraction
+	minFlushUtilTargetFraction := float64(minFlushUtilizationPercentage) / 100
+	if flushUtilTargetFraction == 0 {
+		// Initialization: use the maximum configured fraction.
+		flushUtilTargetFraction = minFlushUtilTargetFraction
+		if flushUtilTargetFraction < maxFlushUtilTargetFraction {
+			flushUtilTargetFraction = maxFlushUtilTargetFraction
+		}
+	} else if flushUtilTargetFraction < minFlushUtilTargetFraction {
+		// The min can be changed in a running system, so we bump up to conform to
+		// the min.
+		flushUtilTargetFraction = minFlushUtilTargetFraction
+	}
+	numFlushTokens := int64(unlimitedTokens)
+	// doLogFlush becomes true if something interesting is done here.
+	doLogFlush := false
+	smoothedNumFlushTokens := prev.smoothedNumFlushTokens
+	const flushUtilIgnoreThreshold = 0.05
+	if intFlushUtilization > flushUtilIgnoreThreshold {
+		if smoothedNumFlushTokens == 0 {
+			// Initialization.
+			smoothedNumFlushTokens = intFlushTokens
+		} else {
+			smoothedNumFlushTokens = alpha*intFlushTokens + (1-alpha)*prev.smoothedNumFlushTokens
+		}
+		const flushUtilTargetFractionIncrement = 0.025
+		// Have we used >= 90% of the tokens.
+		highTokenUsage :=
+			float64(prev.tokensUsed) >= 0.9*smoothedNumFlushTokens*flushUtilTargetFraction
+		if intWriteStalls > 0 {
+			// Try decrease since there were write-stalls.
+			numDecreaseSteps := 1
+			// These constants of 5, 3, 2, 2 were found to work reasonably well,
+			// without causing large decreases. We need better benchmarking to tune
+			// such constants.
+			if intWriteStalls >= 5 {
+				numDecreaseSteps = 3
+			} else if intWriteStalls >= 2 {
+				numDecreaseSteps = 2
+			}
+			for i := 0; i < numDecreaseSteps; i++ {
+				if flushUtilTargetFraction >= minFlushUtilTargetFraction+flushUtilTargetFractionIncrement {
+					flushUtilTargetFraction -= flushUtilTargetFractionIncrement
+					doLogFlush = true
+				} else {
+					break
+				}
+			}
+		} else if flushUtilTargetFraction < maxFlushUtilTargetFraction-flushUtilTargetFractionIncrement &&
+			intWriteStalls == 0 && highTokenUsage {
+			// No write-stalls, and token usage was high, so give out more tokens.
+			flushUtilTargetFraction += flushUtilTargetFractionIncrement
+			doLogFlush = true
+		}
+		if highTokenUsage {
+			doLogFlush = true
+		}
+		flushTokensFloat := flushUtilTargetFraction * smoothedNumFlushTokens
+		if flushTokensFloat < float64(math.MaxInt64) {
+			numFlushTokens = int64(flushTokensFloat)
+		}
+		// Else avoid overflow by using the previously set unlimitedTokens. This
+		// should not really happen.
+	}
+	// Else intFlushUtilization is too low. We don't want to make token
+	// determination based on a very low utilization. Note that flush
+	// utilization has been observed to fluctuate from 0.16 to 0.9 in a single
+	// interval, when compaction tokens are not limited, hence we have set
+	// flushUtilIgnoreThreshold to a very low value. If we've erred towards it
+	// being too low, we run the risk of computing incorrect tokens. If we've
+	// erred towards being too high, we run the risk of giving out
+	// unlimitedTokens and causing write stalls.
+
+	// We constrain admission based on compactions, if the store is over the L0
+	// threshold.
 	var totalNumByteTokens int64
-	var smoothedTotalNumByteTokens float64
+	var smoothedCompactionByteTokens float64
 	curL0NumFiles := l0Metrics.NumFiles
 	curL0NumSublevels := int64(l0Metrics.Sublevels)
 	if curL0NumFiles > threshNumFiles || curL0NumSublevels > threshNumSublevels {
@@ -1893,12 +2133,12 @@ func (*ioLoadListener) adjustTokensInner(
 		// Smooth it. This may seem peculiar since we are already using
 		// smoothedIntL0CompactedBytes, but the else clause below uses a different
 		// computation so we also want the history of smoothedTotalNumByteTokens.
-		smoothedTotalNumByteTokens = alpha*fTotalNumByteTokens + (1-alpha)*prev.smoothedTotalNumByteTokens
-		if float64(math.MaxInt64) < smoothedTotalNumByteTokens {
+		smoothedCompactionByteTokens = alpha*fTotalNumByteTokens + (1-alpha)*prev.smoothedCompactionByteTokens
+		if float64(math.MaxInt64) < smoothedCompactionByteTokens {
 			// Avoid overflow. This should not really happen.
 			totalNumByteTokens = math.MaxInt64
 		} else {
-			totalNumByteTokens = int64(smoothedTotalNumByteTokens)
+			totalNumByteTokens = int64(smoothedCompactionByteTokens)
 		}
 	} else {
 		// Under the threshold. Maintain a smoothedTotalNumByteTokens based on what was
@@ -1907,9 +2147,15 @@ func (*ioLoadListener) adjustTokensInner(
 		// we've seen extreme situations with alternating 15s intervals of above
 		// and below the threshold.
 		numTokens := intL0CompactedBytes
-		smoothedTotalNumByteTokens = alpha*float64(numTokens) + (1-alpha)*prev.smoothedTotalNumByteTokens
+		smoothedCompactionByteTokens = alpha*float64(numTokens) + (1-alpha)*prev.smoothedCompactionByteTokens
 		totalNumByteTokens = unlimitedTokens
 		doLog = false
+	}
+	doLog = doLog || doLogFlush
+	// Use the minimum of the token count calculated using compactions and
+	// flushes.
+	if totalNumByteTokens > numFlushTokens {
+		totalNumByteTokens = numFlushTokens
 	}
 	// Install the latest cumulative stats.
 	return adjustTokensResult{
@@ -1917,12 +2163,16 @@ func (*ioLoadListener) adjustTokensInner(
 			cumAdmissionStats:                           cumAdmissionStats,
 			cumL0AddedBytes:                             cumL0AddedBytes,
 			curL0Bytes:                                  curL0Bytes,
+			cumWriteStallCount:                          cumWriteStallCount,
 			smoothedIntL0CompactedBytes:                 smoothedIntL0CompactedBytes,
 			smoothedIntPerWorkUnaccountedL0Bytes:        smoothedIntPerWorkUnaccountedL0Bytes,
 			smoothedIntIngestedAccountedL0BytesFraction: smoothedIntIngestedAccountedL0BytesFraction,
-			smoothedTotalNumByteTokens:                  smoothedTotalNumByteTokens,
+			smoothedCompactionByteTokens:                smoothedCompactionByteTokens,
+			smoothedNumFlushTokens:                      smoothedNumFlushTokens,
+			flushUtilTargetFraction:                     flushUtilTargetFraction,
 			totalNumByteTokens:                          totalNumByteTokens,
 			tokensAllocated:                             0,
+			tokensUsed:                                  0,
 		},
 		requestEstimates: storeRequestEstimates{
 			workByteAddition:       max(1, int64(smoothedIntPerWorkUnaccountedL0Bytes)),
@@ -1942,6 +2192,9 @@ func (*ioLoadListener) adjustTokensInner(
 			intUnaccountedL0Bytes:        intUnaccountedL0Bytes,
 			intPerWorkUnaccountedL0Bytes: intPerWorkUnaccountedL0Bytes,
 			l0BytesIngestFraction:        intIngestedAccountedL0BytesFraction,
+			intFlushTokens:               intFlushTokens,
+			intFlushUtilization:          intFlushUtilization,
+			intWriteStalls:               intWriteStalls,
 		},
 	}
 }
@@ -1976,12 +2229,14 @@ func (res adjustTokensResult) SafeFormat(p redact.SafePrinter, _ rune) {
 	p.Printf("%s unacc [≈%s/req, n=%d], ",
 		ib(res.aux.intUnaccountedL0Bytes), ib(int64(res.smoothedIntPerWorkUnaccountedL0Bytes)), res.aux.intAdmittedCount)
 	// How much got compacted out of L0 recently.
-	p.Printf("compacted %s [≈%s]; ", ib(res.aux.intL0CompactedBytes), ib(res.smoothedIntL0CompactedBytes))
-
+	p.Printf("compacted %s [≈%s], ", ib(res.aux.intL0CompactedBytes), ib(res.smoothedIntL0CompactedBytes))
+	p.Printf("flush tokens %s with multiplier %.3f [≈%s]; ", ib(int64(res.aux.intFlushTokens)),
+		res.flushUtilTargetFraction, ib(int64(res.smoothedNumFlushTokens*res.flushUtilTargetFraction)))
 	p.Printf("admitting ")
 	if n := res.ioLoadListenerState.totalNumByteTokens; n < unlimitedTokens {
 		p.Printf("%s", ib(n))
-		if n := res.ioLoadListenerState.tokensAllocated; 0 < n && n < unlimitedTokens/adjustmentInterval {
+		if n := res.ioLoadListenerState.tokensAllocated; 0 < n &&
+			n < unlimitedTokens/ticksInAdjustmentInterval {
 			p.Printf("(used %s)", ib(n))
 		}
 		p.Printf(" with L0 penalty: +%s/req, *%.2f/ingest",

--- a/pkg/util/admission/granter_test.go
+++ b/pkg/util/admission/granter_test.go
@@ -399,15 +399,20 @@ func (r *testRequesterForIOLL) setStoreRequestEstimates(estimates storeRequestEs
 }
 
 type testGranterWithIOTokens struct {
-	buf strings.Builder
+	buf           strings.Builder
+	allTokensUsed bool
 }
 
-func (g *testGranterWithIOTokens) setAvailableIOTokensLocked(tokens int64) {
-	fmt.Fprintf(&g.buf, "setAvailableIOTokens: %s", tokensFor1sToString(tokens))
+func (g *testGranterWithIOTokens) setAvailableIOTokensLocked(tokens int64) (tokensUsed int64) {
+	fmt.Fprintf(&g.buf, "setAvailableIOTokens: %s", tokensForTokenTickDurationToString(tokens))
+	if g.allTokensUsed {
+		return tokens * 2
+	}
+	return 0
 }
 
-func tokensFor1sToString(tokens int64) string {
-	if tokens >= unlimitedTokens/adjustmentInterval {
+func tokensForTokenTickDurationToString(tokens int64) string {
+	if tokens >= unlimitedTokens/ticksInAdjustmentInterval {
 		return "unlimited"
 	}
 	return fmt.Sprintf("%d", tokens)
@@ -418,7 +423,7 @@ type rawTokenResult adjustTokensResult
 // TestIOLoadListener is a datadriven test with the following command that
 // sets the state for token calculation and then ticks adjustmentInterval
 // times to cause tokens to be set in the testGranterWithIOTokens:
-// set-state admitted=<int> l0-bytes=<int> l0-added=<int> l0-files=<int> l0-sublevels=<int>
+// set-state admitted=<int> l0-bytes=<int> l0-added=<int> l0-files=<int> l0-sublevels=<int> ...
 func TestIOLoadListener(t *testing.T) {
 	req := &testRequesterForIOLL{}
 	kvGranter := &testGranterWithIOTokens{}
@@ -461,6 +466,12 @@ func TestIOLoadListener(t *testing.T) {
 				}
 				return fmt.Sprintf("%+v", req.stats)
 
+			case "set-min-flush-util":
+				var percent int
+				d.ScanArgs(t, "percent", &percent)
+				MinFlushUtilizationPercentage.Override(ctx, &st.SV, int64(percent))
+				return ""
+
 			case "set-state":
 				// Setup state used as input for token adjustment.
 				var metrics pebble.Metrics
@@ -477,7 +488,37 @@ func TestIOLoadListener(t *testing.T) {
 				var l0SubLevels int
 				d.ScanArgs(t, "l0-sublevels", &l0SubLevels)
 				metrics.Levels[0].Sublevels = int32(l0SubLevels)
-				ioll.pebbleMetricsTick(ctx, &metrics)
+				var flushBytes, flushWorkSec, flushIdleSec int
+				if d.HasArg("flush-bytes") {
+					d.ScanArgs(t, "flush-bytes", &flushBytes)
+					d.ScanArgs(t, "flush-work-sec", &flushWorkSec)
+					d.ScanArgs(t, "flush-idle-sec", &flushIdleSec)
+				}
+				flushMetric := pebble.ThroughputMetric{
+					Bytes:        int64(flushBytes),
+					WorkDuration: time.Duration(flushWorkSec) * time.Second,
+					IdleDuration: time.Duration(flushIdleSec) * time.Second,
+				}
+				im := &pebble.InternalIntervalMetrics{}
+				im.Flush.WriteThroughput = flushMetric
+				var writeStallCount int
+				if d.HasArg("write-stall-count") {
+					d.ScanArgs(t, "write-stall-count", &writeStallCount)
+				}
+				var allTokensUsed bool
+				if d.HasArg("all-tokens-used") {
+					d.ScanArgs(t, "all-tokens-used", &allTokensUsed)
+				}
+				kvGranter.allTokensUsed = allTokensUsed
+				var printOnlyFirstTick bool
+				if d.HasArg("print-only-first-tick") {
+					d.ScanArgs(t, "print-only-first-tick", &printOnlyFirstTick)
+				}
+				ioll.pebbleMetricsTick(ctx, StoreMetrics{
+					Metrics:                 &metrics,
+					WriteStallCount:         int64(writeStallCount),
+					InternalIntervalMetrics: im,
+				})
 				// Do the ticks until just before next adjustment.
 				var buf strings.Builder
 				fmt.Fprintln(&buf, redact.StringWithoutMarkers(&ioll.adjustTokensResult))
@@ -486,9 +527,11 @@ func TestIOLoadListener(t *testing.T) {
 					fmt.Fprintf(&buf, "%s\n", req.buf.String())
 					req.buf.Reset()
 				}
-				for i := 0; i < adjustmentInterval; i++ {
+				for i := 0; i < ticksInAdjustmentInterval; i++ {
 					ioll.allocateTokensTick()
-					fmt.Fprintf(&buf, "tick: %d, %s\n", i, kvGranter.buf.String())
+					if i == 0 || !printOnlyFirstTick {
+						fmt.Fprintf(&buf, "tick: %d, %s\n", i, kvGranter.buf.String())
+					}
 					kvGranter.buf.Reset()
 				}
 				return buf.String()
@@ -515,7 +558,7 @@ func TestIOLoadListenerOverflow(t *testing.T) {
 		// Override the totalNumByteTokens manually to trigger the overflow bug.
 		ioll.totalNumByteTokens = math.MaxInt64 - i
 		ioll.tokensAllocated = 0
-		for j := 0; j < adjustmentInterval; j++ {
+		for j := 0; j < ticksInAdjustmentInterval; j++ {
 			ioll.allocateTokensTick()
 		}
 	}
@@ -525,8 +568,10 @@ func TestIOLoadListenerOverflow(t *testing.T) {
 		Sublevels: 100,
 		NumFiles:  10000,
 	}
-	ioll.pebbleMetricsTick(ctx, &m)
-	ioll.pebbleMetricsTick(ctx, &m)
+	ioll.pebbleMetricsTick(ctx,
+		StoreMetrics{Metrics: &m, InternalIntervalMetrics: &pebble.InternalIntervalMetrics{}})
+	ioll.pebbleMetricsTick(ctx,
+		StoreMetrics{Metrics: &m, InternalIntervalMetrics: &pebble.InternalIntervalMetrics{}})
 	ioll.allocateTokensTick()
 }
 
@@ -534,8 +579,9 @@ type testGranterNonNegativeTokens struct {
 	t *testing.T
 }
 
-func (g *testGranterNonNegativeTokens) setAvailableIOTokensLocked(tokens int64) {
+func (g *testGranterNonNegativeTokens) setAvailableIOTokensLocked(tokens int64) (tokensUsed int64) {
 	require.LessOrEqual(g.t, int64(0), tokens)
+	return 0
 }
 
 func TestAdjustTokensInnerAndLogging(t *testing.T) {
@@ -571,7 +617,7 @@ func TestAdjustTokensInnerAndLogging(t *testing.T) {
 				smoothedIntL0CompactedBytes:                 47 * mb,
 				smoothedIntPerWorkUnaccountedL0Bytes:        2204, // 2kb
 				smoothedIntIngestedAccountedL0BytesFraction: 0.3,
-				smoothedTotalNumByteTokens:                  201 * mb,
+				smoothedCompactionByteTokens:                201 * mb,
 				totalNumByteTokens:                          int64(201 * mb),
 			},
 			admissionStats: admStats,
@@ -589,7 +635,8 @@ func TestAdjustTokensInnerAndLogging(t *testing.T) {
 	for _, tt := range tests {
 		buf.Printf("%s:\n", tt.name)
 		res := (*ioLoadListener)(nil).adjustTokensInner(
-			ctx, tt.prev, tt.admissionStats, tt.l0Metrics, 100, 10)
+			ctx, tt.prev, tt.admissionStats, tt.l0Metrics, 0,
+			&pebble.InternalIntervalMetrics{}, 100, 10, 50)
 		buf.Printf("%s\n", res)
 	}
 	echotest.Require(t, string(redact.Sprint(buf)), filepath.Join(testutils.TestDataPath(t, "format_adjust_tokens_stats.txt")))
@@ -629,13 +676,16 @@ func TestBadIOLoadListenerStats(t *testing.T) {
 	ioll.mu.kvGranter = kvGranter
 	for i := 0; i < 100; i++ {
 		randomValues()
-		ioll.pebbleMetricsTick(ctx, &m)
-		for j := 0; j < adjustmentInterval; j++ {
+		ioll.pebbleMetricsTick(ctx, StoreMetrics{
+			Metrics:                 &m,
+			InternalIntervalMetrics: &pebble.InternalIntervalMetrics{},
+		})
+		for j := 0; j < ticksInAdjustmentInterval; j++ {
 			ioll.allocateTokensTick()
 			require.LessOrEqual(t, int64(0), ioll.smoothedIntL0CompactedBytes)
 			require.LessOrEqual(t, float64(0), ioll.smoothedIntPerWorkUnaccountedL0Bytes)
 			require.LessOrEqual(t, float64(0), ioll.smoothedIntIngestedAccountedL0BytesFraction)
-			require.LessOrEqual(t, float64(0), ioll.smoothedTotalNumByteTokens)
+			require.LessOrEqual(t, float64(0), ioll.smoothedCompactionByteTokens)
 			require.LessOrEqual(t, int64(0), ioll.totalNumByteTokens)
 			require.LessOrEqual(t, int64(0), ioll.tokensAllocated)
 		}

--- a/pkg/util/admission/testdata/format_adjust_tokens_stats.txt
+++ b/pkg/util/admission/testdata/format_adjust_tokens_stats.txt
@@ -1,6 +1,6 @@
 echo
 ----
 zero:
-0 ssts, 0 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈0 B]; admitting all
+0 ssts, 0 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈0 B], flush tokens 0 B with multiplier 1.500 [≈0 B]; admitting all
 real-numbers:
-195 ssts, 27 sub-levels, L0 growth 577 MiB: 178 MiB acc-write + 73 MiB acc-ingest + 326 MiB unacc [≈270 KiB/req, n=621], compacted 77 MiB [≈62 MiB]; admitting 116 MiB with L0 penalty: +270 KiB/req, *0.34/ingest
+195 ssts, 27 sub-levels, L0 growth 577 MiB: 178 MiB acc-write + 73 MiB acc-ingest + 326 MiB unacc [≈270 KiB/req, n=621], compacted 77 MiB [≈62 MiB], flush tokens 0 B with multiplier 1.500 [≈0 B]; admitting 116 MiB with L0 penalty: +270 KiB/req, *0.34/ingest

--- a/pkg/util/admission/testdata/granter
+++ b/pkg/util/admission/testdata/granter
@@ -378,14 +378,14 @@ sql-sql-response: avail: -1 sql-leaf-start: used: 0, total: 2 sql-root-start: us
 init-store-grant-coordinator
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 5) io-avail: 614891469123651720
+(chain: id: 0 active: false index: 5) io-avail: 153722867280912930
 
 # Initial tokens are effectively unlimited.
 try-get work=kv v=10000
 ----
 kv: tryGet(10000) returned true
 GrantCoordinator:
-(chain: id: 0 active: false index: 5) io-avail: 614891469123641720
+(chain: id: 0 active: false index: 5) io-avail: 153722867280902930
 
 # Set the io tokens to a smaller value.
 set-io-tokens tokens=500

--- a/pkg/util/admission/testdata/io_load_listener
+++ b/pkg/util/admission/testdata/io_load_listener
@@ -11,8 +11,8 @@ prep-admission-stats admitted=0
 # Even though above the threshold, the first 15 ticks don't limit the tokens.
 set-state l0-bytes=10000 l0-added=1000 l0-files=21 l0-sublevels=21
 ----
-0 ssts, 0 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=0], compacted 0 B [≈0 B]; admitting all
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:1000 curL0Bytes:10000 smoothedIntL0CompactedBytes:0 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedTotalNumByteTokens:0 totalNumByteTokens:9223372036854775807 tokensAllocated:0} requestEstimates:{fractionOfIngestIntoL0:0 workByteAddition:0} aux:{shouldLog:false curL0NumFiles:0 curL0NumSublevels:0 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:0 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0}}
+0 ssts, 0 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=0], compacted 0 B [≈0 B], flush tokens 0 B with multiplier 0.000 [≈0 B]; admitting all
+{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:1000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:0 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:0 smoothedNumFlushTokens:0 flushUtilTargetFraction:0 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0 workByteAddition:0} aux:{shouldLog:false curL0NumFiles:0 curL0NumSublevels:0 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:0 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
 tick: 0, setAvailableIOTokens: unlimited
 tick: 1, setAvailableIOTokens: unlimited
 tick: 2, setAvailableIOTokens: unlimited
@@ -28,6 +28,51 @@ tick: 11, setAvailableIOTokens: unlimited
 tick: 12, setAvailableIOTokens: unlimited
 tick: 13, setAvailableIOTokens: unlimited
 tick: 14, setAvailableIOTokens: unlimited
+tick: 15, setAvailableIOTokens: unlimited
+tick: 16, setAvailableIOTokens: unlimited
+tick: 17, setAvailableIOTokens: unlimited
+tick: 18, setAvailableIOTokens: unlimited
+tick: 19, setAvailableIOTokens: unlimited
+tick: 20, setAvailableIOTokens: unlimited
+tick: 21, setAvailableIOTokens: unlimited
+tick: 22, setAvailableIOTokens: unlimited
+tick: 23, setAvailableIOTokens: unlimited
+tick: 24, setAvailableIOTokens: unlimited
+tick: 25, setAvailableIOTokens: unlimited
+tick: 26, setAvailableIOTokens: unlimited
+tick: 27, setAvailableIOTokens: unlimited
+tick: 28, setAvailableIOTokens: unlimited
+tick: 29, setAvailableIOTokens: unlimited
+tick: 30, setAvailableIOTokens: unlimited
+tick: 31, setAvailableIOTokens: unlimited
+tick: 32, setAvailableIOTokens: unlimited
+tick: 33, setAvailableIOTokens: unlimited
+tick: 34, setAvailableIOTokens: unlimited
+tick: 35, setAvailableIOTokens: unlimited
+tick: 36, setAvailableIOTokens: unlimited
+tick: 37, setAvailableIOTokens: unlimited
+tick: 38, setAvailableIOTokens: unlimited
+tick: 39, setAvailableIOTokens: unlimited
+tick: 40, setAvailableIOTokens: unlimited
+tick: 41, setAvailableIOTokens: unlimited
+tick: 42, setAvailableIOTokens: unlimited
+tick: 43, setAvailableIOTokens: unlimited
+tick: 44, setAvailableIOTokens: unlimited
+tick: 45, setAvailableIOTokens: unlimited
+tick: 46, setAvailableIOTokens: unlimited
+tick: 47, setAvailableIOTokens: unlimited
+tick: 48, setAvailableIOTokens: unlimited
+tick: 49, setAvailableIOTokens: unlimited
+tick: 50, setAvailableIOTokens: unlimited
+tick: 51, setAvailableIOTokens: unlimited
+tick: 52, setAvailableIOTokens: unlimited
+tick: 53, setAvailableIOTokens: unlimited
+tick: 54, setAvailableIOTokens: unlimited
+tick: 55, setAvailableIOTokens: unlimited
+tick: 56, setAvailableIOTokens: unlimited
+tick: 57, setAvailableIOTokens: unlimited
+tick: 58, setAvailableIOTokens: unlimited
+tick: 59, setAvailableIOTokens: unlimited
 
 prep-admission-stats admitted=10000
 ----
@@ -39,24 +84,69 @@ prep-admission-stats admitted=10000
 # removed), but smoothing it drops the tokens to 12,500.
 set-state l0-bytes=10000 l0-added=101000 l0-files=21 l0-sublevels=21
 ----
-21 ssts, 21 sub-levels, L0 growth 98 KiB: 0 B acc-write + 0 B acc-ingest + 98 KiB unacc [≈10 B/req, n=10000], compacted 98 KiB [≈49 KiB]; admitting 12 KiB with L0 penalty: +10 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:10000 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:101000 curL0Bytes:10000 smoothedIntL0CompactedBytes:50000 smoothedIntPerWorkUnaccountedL0Bytes:10 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedTotalNumByteTokens:12500 totalNumByteTokens:12500 tokensAllocated:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:10} aux:{shouldLog:true curL0NumFiles:21 curL0NumSublevels:21 intL0AddedBytes:100000 intL0CompactedBytes:100000 intAdmittedCount:10000 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:100000 intPerWorkUnaccountedL0Bytes:10 l0BytesIngestFraction:0}}
+21 ssts, 21 sub-levels, L0 growth 98 KiB: 0 B acc-write + 0 B acc-ingest + 98 KiB unacc [≈10 B/req, n=10000], compacted 98 KiB [≈49 KiB], flush tokens 0 B with multiplier 1.500 [≈0 B]; admitting 12 KiB with L0 penalty: +10 B/req, *0.50/ingest
+{ioLoadListenerState:{cumAdmissionStats:{admittedCount:10000 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:101000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:50000 smoothedIntPerWorkUnaccountedL0Bytes:10 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:12500 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:12500 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:10} aux:{shouldLog:true curL0NumFiles:21 curL0NumSublevels:21 intL0AddedBytes:100000 intL0CompactedBytes:100000 intAdmittedCount:10000 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:100000 intPerWorkUnaccountedL0Bytes:10 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
 store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 10
-tick: 0, setAvailableIOTokens: 834
-tick: 1, setAvailableIOTokens: 834
-tick: 2, setAvailableIOTokens: 834
-tick: 3, setAvailableIOTokens: 834
-tick: 4, setAvailableIOTokens: 834
-tick: 5, setAvailableIOTokens: 834
-tick: 6, setAvailableIOTokens: 834
-tick: 7, setAvailableIOTokens: 834
-tick: 8, setAvailableIOTokens: 834
-tick: 9, setAvailableIOTokens: 834
-tick: 10, setAvailableIOTokens: 834
-tick: 11, setAvailableIOTokens: 834
-tick: 12, setAvailableIOTokens: 834
-tick: 13, setAvailableIOTokens: 834
-tick: 14, setAvailableIOTokens: 824
+tick: 0, setAvailableIOTokens: 209
+tick: 1, setAvailableIOTokens: 209
+tick: 2, setAvailableIOTokens: 209
+tick: 3, setAvailableIOTokens: 209
+tick: 4, setAvailableIOTokens: 209
+tick: 5, setAvailableIOTokens: 209
+tick: 6, setAvailableIOTokens: 209
+tick: 7, setAvailableIOTokens: 209
+tick: 8, setAvailableIOTokens: 209
+tick: 9, setAvailableIOTokens: 209
+tick: 10, setAvailableIOTokens: 209
+tick: 11, setAvailableIOTokens: 209
+tick: 12, setAvailableIOTokens: 209
+tick: 13, setAvailableIOTokens: 209
+tick: 14, setAvailableIOTokens: 209
+tick: 15, setAvailableIOTokens: 209
+tick: 16, setAvailableIOTokens: 209
+tick: 17, setAvailableIOTokens: 209
+tick: 18, setAvailableIOTokens: 209
+tick: 19, setAvailableIOTokens: 209
+tick: 20, setAvailableIOTokens: 209
+tick: 21, setAvailableIOTokens: 209
+tick: 22, setAvailableIOTokens: 209
+tick: 23, setAvailableIOTokens: 209
+tick: 24, setAvailableIOTokens: 209
+tick: 25, setAvailableIOTokens: 209
+tick: 26, setAvailableIOTokens: 209
+tick: 27, setAvailableIOTokens: 209
+tick: 28, setAvailableIOTokens: 209
+tick: 29, setAvailableIOTokens: 209
+tick: 30, setAvailableIOTokens: 209
+tick: 31, setAvailableIOTokens: 209
+tick: 32, setAvailableIOTokens: 209
+tick: 33, setAvailableIOTokens: 209
+tick: 34, setAvailableIOTokens: 209
+tick: 35, setAvailableIOTokens: 209
+tick: 36, setAvailableIOTokens: 209
+tick: 37, setAvailableIOTokens: 209
+tick: 38, setAvailableIOTokens: 209
+tick: 39, setAvailableIOTokens: 209
+tick: 40, setAvailableIOTokens: 209
+tick: 41, setAvailableIOTokens: 209
+tick: 42, setAvailableIOTokens: 209
+tick: 43, setAvailableIOTokens: 209
+tick: 44, setAvailableIOTokens: 209
+tick: 45, setAvailableIOTokens: 209
+tick: 46, setAvailableIOTokens: 209
+tick: 47, setAvailableIOTokens: 209
+tick: 48, setAvailableIOTokens: 209
+tick: 49, setAvailableIOTokens: 209
+tick: 50, setAvailableIOTokens: 209
+tick: 51, setAvailableIOTokens: 209
+tick: 52, setAvailableIOTokens: 209
+tick: 53, setAvailableIOTokens: 209
+tick: 54, setAvailableIOTokens: 209
+tick: 55, setAvailableIOTokens: 209
+tick: 56, setAvailableIOTokens: 209
+tick: 57, setAvailableIOTokens: 209
+tick: 58, setAvailableIOTokens: 209
+tick: 59, setAvailableIOTokens: 169
 
 prep-admission-stats admitted=20000
 ----
@@ -65,46 +155,77 @@ prep-admission-stats admitted=20000
 # Same delta as previous but smoothing bumps up the tokens to 25,000.
 set-state l0-bytes=10000 l0-added=201000 l0-files=21 l0-sublevels=21
 ----
-21 ssts, 21 sub-levels, L0 growth 98 KiB: 0 B acc-write + 0 B acc-ingest + 98 KiB unacc [≈10 B/req, n=10000], compacted 98 KiB [≈73 KiB]; admitting 24 KiB with L0 penalty: +10 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:20000 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:201000 curL0Bytes:10000 smoothedIntL0CompactedBytes:75000 smoothedIntPerWorkUnaccountedL0Bytes:10 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedTotalNumByteTokens:25000 totalNumByteTokens:25000 tokensAllocated:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:10} aux:{shouldLog:true curL0NumFiles:21 curL0NumSublevels:21 intL0AddedBytes:100000 intL0CompactedBytes:100000 intAdmittedCount:10000 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:100000 intPerWorkUnaccountedL0Bytes:10 l0BytesIngestFraction:0}}
+21 ssts, 21 sub-levels, L0 growth 98 KiB: 0 B acc-write + 0 B acc-ingest + 98 KiB unacc [≈10 B/req, n=10000], compacted 98 KiB [≈73 KiB], flush tokens 0 B with multiplier 1.500 [≈0 B]; admitting 24 KiB with L0 penalty: +10 B/req, *0.50/ingest
+{ioLoadListenerState:{cumAdmissionStats:{admittedCount:20000 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:201000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:75000 smoothedIntPerWorkUnaccountedL0Bytes:10 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:25000 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:25000 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:10} aux:{shouldLog:true curL0NumFiles:21 curL0NumSublevels:21 intL0AddedBytes:100000 intL0CompactedBytes:100000 intAdmittedCount:10000 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:100000 intPerWorkUnaccountedL0Bytes:10 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
 store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 10
-tick: 0, setAvailableIOTokens: 1667
-tick: 1, setAvailableIOTokens: 1667
-tick: 2, setAvailableIOTokens: 1667
-tick: 3, setAvailableIOTokens: 1667
-tick: 4, setAvailableIOTokens: 1667
-tick: 5, setAvailableIOTokens: 1667
-tick: 6, setAvailableIOTokens: 1667
-tick: 7, setAvailableIOTokens: 1667
-tick: 8, setAvailableIOTokens: 1667
-tick: 9, setAvailableIOTokens: 1667
-tick: 10, setAvailableIOTokens: 1667
-tick: 11, setAvailableIOTokens: 1667
-tick: 12, setAvailableIOTokens: 1667
-tick: 13, setAvailableIOTokens: 1667
-tick: 14, setAvailableIOTokens: 1662
+tick: 0, setAvailableIOTokens: 417
+tick: 1, setAvailableIOTokens: 417
+tick: 2, setAvailableIOTokens: 417
+tick: 3, setAvailableIOTokens: 417
+tick: 4, setAvailableIOTokens: 417
+tick: 5, setAvailableIOTokens: 417
+tick: 6, setAvailableIOTokens: 417
+tick: 7, setAvailableIOTokens: 417
+tick: 8, setAvailableIOTokens: 417
+tick: 9, setAvailableIOTokens: 417
+tick: 10, setAvailableIOTokens: 417
+tick: 11, setAvailableIOTokens: 417
+tick: 12, setAvailableIOTokens: 417
+tick: 13, setAvailableIOTokens: 417
+tick: 14, setAvailableIOTokens: 417
+tick: 15, setAvailableIOTokens: 417
+tick: 16, setAvailableIOTokens: 417
+tick: 17, setAvailableIOTokens: 417
+tick: 18, setAvailableIOTokens: 417
+tick: 19, setAvailableIOTokens: 417
+tick: 20, setAvailableIOTokens: 417
+tick: 21, setAvailableIOTokens: 417
+tick: 22, setAvailableIOTokens: 417
+tick: 23, setAvailableIOTokens: 417
+tick: 24, setAvailableIOTokens: 417
+tick: 25, setAvailableIOTokens: 417
+tick: 26, setAvailableIOTokens: 417
+tick: 27, setAvailableIOTokens: 417
+tick: 28, setAvailableIOTokens: 417
+tick: 29, setAvailableIOTokens: 417
+tick: 30, setAvailableIOTokens: 417
+tick: 31, setAvailableIOTokens: 417
+tick: 32, setAvailableIOTokens: 417
+tick: 33, setAvailableIOTokens: 417
+tick: 34, setAvailableIOTokens: 417
+tick: 35, setAvailableIOTokens: 417
+tick: 36, setAvailableIOTokens: 417
+tick: 37, setAvailableIOTokens: 417
+tick: 38, setAvailableIOTokens: 417
+tick: 39, setAvailableIOTokens: 417
+tick: 40, setAvailableIOTokens: 417
+tick: 41, setAvailableIOTokens: 417
+tick: 42, setAvailableIOTokens: 417
+tick: 43, setAvailableIOTokens: 417
+tick: 44, setAvailableIOTokens: 417
+tick: 45, setAvailableIOTokens: 417
+tick: 46, setAvailableIOTokens: 417
+tick: 47, setAvailableIOTokens: 417
+tick: 48, setAvailableIOTokens: 417
+tick: 49, setAvailableIOTokens: 417
+tick: 50, setAvailableIOTokens: 417
+tick: 51, setAvailableIOTokens: 417
+tick: 52, setAvailableIOTokens: 417
+tick: 53, setAvailableIOTokens: 417
+tick: 54, setAvailableIOTokens: 417
+tick: 55, setAvailableIOTokens: 417
+tick: 56, setAvailableIOTokens: 417
+tick: 57, setAvailableIOTokens: 417
+tick: 58, setAvailableIOTokens: 417
+tick: 59, setAvailableIOTokens: 397
 
 # No delta. This used to trigger an overflow bug.
-set-state l0-bytes=10000 l0-added=201000 l0-files=21 l0-sublevels=21
+set-state l0-bytes=10000 l0-added=201000 l0-files=21 l0-sublevels=21 print-only-first-tick=true
 ----
-21 ssts, 21 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈10 B/req, n=1], compacted 0 B [≈37 KiB]; admitting 21 KiB with L0 penalty: +10 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:20000 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:201000 curL0Bytes:10000 smoothedIntL0CompactedBytes:37500 smoothedIntPerWorkUnaccountedL0Bytes:10 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedTotalNumByteTokens:21875 totalNumByteTokens:21875 tokensAllocated:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:10} aux:{shouldLog:false curL0NumFiles:21 curL0NumSublevels:21 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0}}
+21 ssts, 21 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈10 B/req, n=1], compacted 0 B [≈37 KiB], flush tokens 0 B with multiplier 1.500 [≈0 B]; admitting 21 KiB with L0 penalty: +10 B/req, *0.50/ingest
+{ioLoadListenerState:{cumAdmissionStats:{admittedCount:20000 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:201000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:37500 smoothedIntPerWorkUnaccountedL0Bytes:10 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:21875 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:21875 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:10} aux:{shouldLog:false curL0NumFiles:21 curL0NumSublevels:21 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
 store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 10
-tick: 0, setAvailableIOTokens: 1459
-tick: 1, setAvailableIOTokens: 1459
-tick: 2, setAvailableIOTokens: 1459
-tick: 3, setAvailableIOTokens: 1459
-tick: 4, setAvailableIOTokens: 1459
-tick: 5, setAvailableIOTokens: 1459
-tick: 6, setAvailableIOTokens: 1459
-tick: 7, setAvailableIOTokens: 1459
-tick: 8, setAvailableIOTokens: 1459
-tick: 9, setAvailableIOTokens: 1459
-tick: 10, setAvailableIOTokens: 1459
-tick: 11, setAvailableIOTokens: 1459
-tick: 12, setAvailableIOTokens: 1459
-tick: 13, setAvailableIOTokens: 1459
-tick: 14, setAvailableIOTokens: 1449
+tick: 0, setAvailableIOTokens: 365
 
 prep-admission-stats admitted=30000
 ----
@@ -112,26 +233,12 @@ prep-admission-stats admitted=30000
 
 # l0-sublevels drops below threshold. We calculate the smoothed values, but
 # don't limit the tokens.
-set-state l0-bytes=10000 l0-added=501000 l0-files=21 l0-sublevels=20
+set-state l0-bytes=10000 l0-added=501000 l0-files=21 l0-sublevels=20 print-only-first-tick=true
 ----
-21 ssts, 20 sub-levels, L0 growth 293 KiB: 0 B acc-write + 0 B acc-ingest + 293 KiB unacc [≈20 B/req, n=10000], compacted 293 KiB [≈165 KiB]; admitting all
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:30000 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:501000 curL0Bytes:10000 smoothedIntL0CompactedBytes:168750 smoothedIntPerWorkUnaccountedL0Bytes:20 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedTotalNumByteTokens:160937.5 totalNumByteTokens:9223372036854775807 tokensAllocated:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:20} aux:{shouldLog:false curL0NumFiles:21 curL0NumSublevels:20 intL0AddedBytes:300000 intL0CompactedBytes:300000 intAdmittedCount:10000 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:300000 intPerWorkUnaccountedL0Bytes:30 l0BytesIngestFraction:0}}
+21 ssts, 20 sub-levels, L0 growth 293 KiB: 0 B acc-write + 0 B acc-ingest + 293 KiB unacc [≈20 B/req, n=10000], compacted 293 KiB [≈165 KiB], flush tokens 0 B with multiplier 1.500 [≈0 B]; admitting all
+{ioLoadListenerState:{cumAdmissionStats:{admittedCount:30000 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:501000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:168750 smoothedIntPerWorkUnaccountedL0Bytes:20 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:160937.5 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:20} aux:{shouldLog:false curL0NumFiles:21 curL0NumSublevels:20 intL0AddedBytes:300000 intL0CompactedBytes:300000 intAdmittedCount:10000 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:300000 intPerWorkUnaccountedL0Bytes:30 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
 store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 20
 tick: 0, setAvailableIOTokens: unlimited
-tick: 1, setAvailableIOTokens: unlimited
-tick: 2, setAvailableIOTokens: unlimited
-tick: 3, setAvailableIOTokens: unlimited
-tick: 4, setAvailableIOTokens: unlimited
-tick: 5, setAvailableIOTokens: unlimited
-tick: 6, setAvailableIOTokens: unlimited
-tick: 7, setAvailableIOTokens: unlimited
-tick: 8, setAvailableIOTokens: unlimited
-tick: 9, setAvailableIOTokens: unlimited
-tick: 10, setAvailableIOTokens: unlimited
-tick: 11, setAvailableIOTokens: unlimited
-tick: 12, setAvailableIOTokens: unlimited
-tick: 13, setAvailableIOTokens: unlimited
-tick: 14, setAvailableIOTokens: unlimited
 
 # Test cases with more information in storeAdmissionStats.
 init
@@ -141,25 +248,11 @@ prep-admission-stats admitted=0
 ----
 {admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0}
 
-set-state l0-bytes=1000 l0-added=1000 l0-files=21 l0-sublevels=21
+set-state l0-bytes=1000 l0-added=1000 l0-files=21 l0-sublevels=21 print-only-first-tick=true
 ----
-0 ssts, 0 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=0], compacted 0 B [≈0 B]; admitting all
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:1000 curL0Bytes:1000 smoothedIntL0CompactedBytes:0 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedTotalNumByteTokens:0 totalNumByteTokens:9223372036854775807 tokensAllocated:0} requestEstimates:{fractionOfIngestIntoL0:0 workByteAddition:0} aux:{shouldLog:false curL0NumFiles:0 curL0NumSublevels:0 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:0 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0}}
+0 ssts, 0 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=0], compacted 0 B [≈0 B], flush tokens 0 B with multiplier 0.000 [≈0 B]; admitting all
+{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:1000 curL0Bytes:1000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:0 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:0 smoothedNumFlushTokens:0 flushUtilTargetFraction:0 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0 workByteAddition:0} aux:{shouldLog:false curL0NumFiles:0 curL0NumSublevels:0 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:0 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
 tick: 0, setAvailableIOTokens: unlimited
-tick: 1, setAvailableIOTokens: unlimited
-tick: 2, setAvailableIOTokens: unlimited
-tick: 3, setAvailableIOTokens: unlimited
-tick: 4, setAvailableIOTokens: unlimited
-tick: 5, setAvailableIOTokens: unlimited
-tick: 6, setAvailableIOTokens: unlimited
-tick: 7, setAvailableIOTokens: unlimited
-tick: 8, setAvailableIOTokens: unlimited
-tick: 9, setAvailableIOTokens: unlimited
-tick: 10, setAvailableIOTokens: unlimited
-tick: 11, setAvailableIOTokens: unlimited
-tick: 12, setAvailableIOTokens: unlimited
-tick: 13, setAvailableIOTokens: unlimited
-tick: 14, setAvailableIOTokens: unlimited
 
 # L0 will see an addition of 200,000 bytes. 180,000 bytes were mentioned by
 # the admitted requests, but 30,000 went into levels below L0. So 150,000 are
@@ -168,52 +261,24 @@ prep-admission-stats admitted=10 admitted-bytes=180000 ingested-bytes=50000 inge
 ----
 {admittedCount:10 admittedWithBytesCount:0 admittedAccountedBytes:180000 ingestedAccountedBytes:50000 ingestedAccountedL0Bytes:20000}
 
-set-state l0-bytes=1000 l0-added=201000 l0-files=21 l0-sublevels=21
+set-state l0-bytes=1000 l0-added=201000 l0-files=21 l0-sublevels=21 print-only-first-tick=true
 ----
-21 ssts, 21 sub-levels, L0 growth 195 KiB: 127 KiB acc-write + 20 KiB acc-ingest + 49 KiB unacc [≈4.9 KiB/req, n=10], compacted 195 KiB [≈98 KiB]; admitting 24 KiB with L0 penalty: +4.9 KiB/req, *0.45/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:10 admittedWithBytesCount:0 admittedAccountedBytes:180000 ingestedAccountedBytes:50000 ingestedAccountedL0Bytes:20000} cumL0AddedBytes:201000 curL0Bytes:1000 smoothedIntL0CompactedBytes:100000 smoothedIntPerWorkUnaccountedL0Bytes:5000 smoothedIntIngestedAccountedL0BytesFraction:0.45 smoothedTotalNumByteTokens:25000 totalNumByteTokens:25000 tokensAllocated:0} requestEstimates:{fractionOfIngestIntoL0:0.45 workByteAddition:5000} aux:{shouldLog:true curL0NumFiles:21 curL0NumSublevels:21 intL0AddedBytes:200000 intL0CompactedBytes:200000 intAdmittedCount:10 intAdmittedBytes:180000 intIngestedBytes:50000 intIngestedAccountedL0Bytes:20000 intAccountedL0Bytes:150000 intUnaccountedL0Bytes:50000 intPerWorkUnaccountedL0Bytes:5000 l0BytesIngestFraction:0.4}}
+21 ssts, 21 sub-levels, L0 growth 195 KiB: 127 KiB acc-write + 20 KiB acc-ingest + 49 KiB unacc [≈4.9 KiB/req, n=10], compacted 195 KiB [≈98 KiB], flush tokens 0 B with multiplier 1.500 [≈0 B]; admitting 24 KiB with L0 penalty: +4.9 KiB/req, *0.45/ingest
+{ioLoadListenerState:{cumAdmissionStats:{admittedCount:10 admittedWithBytesCount:0 admittedAccountedBytes:180000 ingestedAccountedBytes:50000 ingestedAccountedL0Bytes:20000} cumL0AddedBytes:201000 curL0Bytes:1000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:100000 smoothedIntPerWorkUnaccountedL0Bytes:5000 smoothedIntIngestedAccountedL0BytesFraction:0.45 smoothedCompactionByteTokens:25000 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:25000 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.45 workByteAddition:5000} aux:{shouldLog:true curL0NumFiles:21 curL0NumSublevels:21 intL0AddedBytes:200000 intL0CompactedBytes:200000 intAdmittedCount:10 intAdmittedBytes:180000 intIngestedBytes:50000 intIngestedAccountedL0Bytes:20000 intAccountedL0Bytes:150000 intUnaccountedL0Bytes:50000 intPerWorkUnaccountedL0Bytes:5000 l0BytesIngestFraction:0.4 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
 store-request-estimates: fractionOfIngestIntoL0: 0.45, workByteAddition: 5000
-tick: 0, setAvailableIOTokens: 1667
-tick: 1, setAvailableIOTokens: 1667
-tick: 2, setAvailableIOTokens: 1667
-tick: 3, setAvailableIOTokens: 1667
-tick: 4, setAvailableIOTokens: 1667
-tick: 5, setAvailableIOTokens: 1667
-tick: 6, setAvailableIOTokens: 1667
-tick: 7, setAvailableIOTokens: 1667
-tick: 8, setAvailableIOTokens: 1667
-tick: 9, setAvailableIOTokens: 1667
-tick: 10, setAvailableIOTokens: 1667
-tick: 11, setAvailableIOTokens: 1667
-tick: 12, setAvailableIOTokens: 1667
-tick: 13, setAvailableIOTokens: 1667
-tick: 14, setAvailableIOTokens: 1662
+tick: 0, setAvailableIOTokens: 417
 
 # L0 will see an addition of 20,000 bytes, all of which are accounted for.
 prep-admission-stats admitted=20 admitted-bytes=200000 ingested-bytes=50000 ingested-into-l0=20000
 ----
 {admittedCount:20 admittedWithBytesCount:0 admittedAccountedBytes:200000 ingestedAccountedBytes:50000 ingestedAccountedL0Bytes:20000}
 
-set-state l0-bytes=1000 l0-added=221000 l0-files=21 l0-sublevels=21
+set-state l0-bytes=1000 l0-added=221000 l0-files=21 l0-sublevels=21 print-only-first-tick=true
 ----
-21 ssts, 21 sub-levels, L0 growth 20 KiB: 20 KiB acc-write + 0 B acc-ingest + 0 B unacc [≈2.4 KiB/req, n=10], compacted 20 KiB [≈59 KiB]; admitting 27 KiB with L0 penalty: +2.4 KiB/req, *0.45/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:20 admittedWithBytesCount:0 admittedAccountedBytes:200000 ingestedAccountedBytes:50000 ingestedAccountedL0Bytes:20000} cumL0AddedBytes:221000 curL0Bytes:1000 smoothedIntL0CompactedBytes:60000 smoothedIntPerWorkUnaccountedL0Bytes:2500 smoothedIntIngestedAccountedL0BytesFraction:0.45 smoothedTotalNumByteTokens:27500 totalNumByteTokens:27500 tokensAllocated:0} requestEstimates:{fractionOfIngestIntoL0:0.45 workByteAddition:2500} aux:{shouldLog:true curL0NumFiles:21 curL0NumSublevels:21 intL0AddedBytes:20000 intL0CompactedBytes:20000 intAdmittedCount:10 intAdmittedBytes:20000 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:20000 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0}}
+21 ssts, 21 sub-levels, L0 growth 20 KiB: 20 KiB acc-write + 0 B acc-ingest + 0 B unacc [≈2.4 KiB/req, n=10], compacted 20 KiB [≈59 KiB], flush tokens 0 B with multiplier 1.500 [≈0 B]; admitting 27 KiB with L0 penalty: +2.4 KiB/req, *0.45/ingest
+{ioLoadListenerState:{cumAdmissionStats:{admittedCount:20 admittedWithBytesCount:0 admittedAccountedBytes:200000 ingestedAccountedBytes:50000 ingestedAccountedL0Bytes:20000} cumL0AddedBytes:221000 curL0Bytes:1000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:60000 smoothedIntPerWorkUnaccountedL0Bytes:2500 smoothedIntIngestedAccountedL0BytesFraction:0.45 smoothedCompactionByteTokens:27500 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:27500 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.45 workByteAddition:2500} aux:{shouldLog:true curL0NumFiles:21 curL0NumSublevels:21 intL0AddedBytes:20000 intL0CompactedBytes:20000 intAdmittedCount:10 intAdmittedBytes:20000 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:20000 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
 store-request-estimates: fractionOfIngestIntoL0: 0.45, workByteAddition: 2500
-tick: 0, setAvailableIOTokens: 1834
-tick: 1, setAvailableIOTokens: 1834
-tick: 2, setAvailableIOTokens: 1834
-tick: 3, setAvailableIOTokens: 1834
-tick: 4, setAvailableIOTokens: 1834
-tick: 5, setAvailableIOTokens: 1834
-tick: 6, setAvailableIOTokens: 1834
-tick: 7, setAvailableIOTokens: 1834
-tick: 8, setAvailableIOTokens: 1834
-tick: 9, setAvailableIOTokens: 1834
-tick: 10, setAvailableIOTokens: 1834
-tick: 11, setAvailableIOTokens: 1834
-tick: 12, setAvailableIOTokens: 1834
-tick: 13, setAvailableIOTokens: 1834
-tick: 14, setAvailableIOTokens: 1824
+tick: 0, setAvailableIOTokens: 459
 
 # L0 will see an addition of 20,000 bytes, but we think we have added 100,000
 # bytes to L0. We don't let unaccounted bytes become negative.
@@ -221,23 +286,138 @@ prep-admission-stats admitted=30 admitted-bytes=300000 ingested-bytes=50000 inge
 ----
 {admittedCount:30 admittedWithBytesCount:0 admittedAccountedBytes:300000 ingestedAccountedBytes:50000 ingestedAccountedL0Bytes:20000}
 
-set-state l0-bytes=1000 l0-added=241000 l0-files=21 l0-sublevels=21
+set-state l0-bytes=1000 l0-added=241000 l0-files=21 l0-sublevels=21 print-only-first-tick=true
 ----
-21 ssts, 21 sub-levels, L0 growth 20 KiB: 98 KiB acc-write + 0 B acc-ingest + 0 B unacc [≈1.2 KiB/req, n=10], compacted 20 KiB [≈39 KiB]; admitting 23 KiB with L0 penalty: +1.2 KiB/req, *0.45/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:30 admittedWithBytesCount:0 admittedAccountedBytes:300000 ingestedAccountedBytes:50000 ingestedAccountedL0Bytes:20000} cumL0AddedBytes:241000 curL0Bytes:1000 smoothedIntL0CompactedBytes:40000 smoothedIntPerWorkUnaccountedL0Bytes:1250 smoothedIntIngestedAccountedL0BytesFraction:0.45 smoothedTotalNumByteTokens:23750 totalNumByteTokens:23750 tokensAllocated:0} requestEstimates:{fractionOfIngestIntoL0:0.45 workByteAddition:1250} aux:{shouldLog:true curL0NumFiles:21 curL0NumSublevels:21 intL0AddedBytes:20000 intL0CompactedBytes:20000 intAdmittedCount:10 intAdmittedBytes:100000 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:100000 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0}}
+21 ssts, 21 sub-levels, L0 growth 20 KiB: 98 KiB acc-write + 0 B acc-ingest + 0 B unacc [≈1.2 KiB/req, n=10], compacted 20 KiB [≈39 KiB], flush tokens 0 B with multiplier 1.500 [≈0 B]; admitting 23 KiB with L0 penalty: +1.2 KiB/req, *0.45/ingest
+{ioLoadListenerState:{cumAdmissionStats:{admittedCount:30 admittedWithBytesCount:0 admittedAccountedBytes:300000 ingestedAccountedBytes:50000 ingestedAccountedL0Bytes:20000} cumL0AddedBytes:241000 curL0Bytes:1000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:40000 smoothedIntPerWorkUnaccountedL0Bytes:1250 smoothedIntIngestedAccountedL0BytesFraction:0.45 smoothedCompactionByteTokens:23750 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:23750 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.45 workByteAddition:1250} aux:{shouldLog:true curL0NumFiles:21 curL0NumSublevels:21 intL0AddedBytes:20000 intL0CompactedBytes:20000 intAdmittedCount:10 intAdmittedBytes:100000 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:100000 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
 store-request-estimates: fractionOfIngestIntoL0: 0.45, workByteAddition: 1250
-tick: 0, setAvailableIOTokens: 1584
-tick: 1, setAvailableIOTokens: 1584
-tick: 2, setAvailableIOTokens: 1584
-tick: 3, setAvailableIOTokens: 1584
-tick: 4, setAvailableIOTokens: 1584
-tick: 5, setAvailableIOTokens: 1584
-tick: 6, setAvailableIOTokens: 1584
-tick: 7, setAvailableIOTokens: 1584
-tick: 8, setAvailableIOTokens: 1584
-tick: 9, setAvailableIOTokens: 1584
-tick: 10, setAvailableIOTokens: 1584
-tick: 11, setAvailableIOTokens: 1584
-tick: 12, setAvailableIOTokens: 1584
-tick: 13, setAvailableIOTokens: 1584
-tick: 14, setAvailableIOTokens: 1574
+tick: 0, setAvailableIOTokens: 396
+
+# Test case with flush tokens.
+init
+----
+
+prep-admission-stats admitted=0
+----
+{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0}
+
+set-state l0-bytes=10000 l0-added=1000 l0-files=1 l0-sublevels=1 print-only-first-tick=true
+----
+0 ssts, 0 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=0], compacted 0 B [≈0 B], flush tokens 0 B with multiplier 0.000 [≈0 B]; admitting all
+{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:1000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:0 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:0 smoothedNumFlushTokens:0 flushUtilTargetFraction:0 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0 workByteAddition:0} aux:{shouldLog:false curL0NumFiles:0 curL0NumSublevels:0 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:0 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
+tick: 0, setAvailableIOTokens: unlimited
+
+# Flush loop utilization is too low for the interval flush tokens to
+# contribute to the smoothed value, or for tokens to become limited.
+set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=1000 flush-work-sec=2 flush-idle-sec=100 print-only-first-tick=true
+----
+1 ssts, 1 sub-levels, L0 growth 9.8 KiB: 0 B acc-write + 0 B acc-ingest + 9.8 KiB unacc [≈0 B/req, n=1], compacted 9.8 KiB [≈4.9 KiB], flush tokens 7.3 KiB with multiplier 1.500 [≈0 B]; admitting all
+{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:5000 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:5000 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:false curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:10000 intL0CompactedBytes:10000 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:10000 intPerWorkUnaccountedL0Bytes:10000 l0BytesIngestFraction:0 intFlushTokens:7500 intFlushUtilization:0.0196078431372549 intWriteStalls:0}}
+store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
+tick: 0, setAvailableIOTokens: unlimited
+
+# Flush loop utilization is high enough.
+set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=1000 flush-work-sec=2 flush-idle-sec=10 print-only-first-tick=true
+----
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈2.4 KiB], flush tokens 7.3 KiB with multiplier 1.500 [≈11 KiB]; admitting 11 KiB with L0 penalty: +1 B/req, *0.50/ingest
+{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:2500 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:2500 smoothedNumFlushTokens:7500 flushUtilTargetFraction:1.5 totalNumByteTokens:11250 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:false curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:7500 intFlushUtilization:0.16666666666666666 intWriteStalls:0}}
+store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
+tick: 0, setAvailableIOTokens: 188
+
+set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=1 print-only-first-tick=true
+----
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈1.2 KiB], flush tokens 73 KiB with multiplier 1.475 [≈59 KiB]; admitting 59 KiB with L0 penalty: +1 B/req, *0.50/ingest
+{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:1 smoothedIntL0CompactedBytes:1250 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:1250 smoothedNumFlushTokens:41250 flushUtilTargetFraction:1.475 totalNumByteTokens:60843 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:true curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1}}
+store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
+tick: 0, setAvailableIOTokens: 1015
+
+set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=3 print-only-first-tick=true
+----
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈625 B], flush tokens 73 KiB with multiplier 1.425 [≈81 KiB]; admitting 81 KiB with L0 penalty: +1 B/req, *0.50/ingest
+{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:3 smoothedIntL0CompactedBytes:625 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:625 smoothedNumFlushTokens:58125 flushUtilTargetFraction:1.4250000000000003 totalNumByteTokens:82828 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:true curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:2}}
+store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
+tick: 0, setAvailableIOTokens: 1381
+
+set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=8 print-only-first-tick=true
+----
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈312 B], flush tokens 73 KiB with multiplier 1.350 [≈88 KiB]; admitting 88 KiB with L0 penalty: +1 B/req, *0.50/ingest
+{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:8 smoothedIntL0CompactedBytes:312 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:312.5 smoothedNumFlushTokens:66562.5 flushUtilTargetFraction:1.3500000000000005 totalNumByteTokens:89859 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:true curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:5}}
+store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
+tick: 0, setAvailableIOTokens: 1498
+
+set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=9 print-only-first-tick=true
+----
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈156 B], flush tokens 73 KiB with multiplier 1.325 [≈92 KiB]; admitting 92 KiB with L0 penalty: +1 B/req, *0.50/ingest
+{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:9 smoothedIntL0CompactedBytes:156 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:156.25 smoothedNumFlushTokens:70781.25 flushUtilTargetFraction:1.3250000000000006 totalNumByteTokens:93785 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:true curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1}}
+store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
+tick: 0, setAvailableIOTokens: 1564
+
+
+set-min-flush-util percent=130
+----
+
+set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=10 print-only-first-tick=true
+----
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈78 B], flush tokens 73 KiB with multiplier 1.300 [≈92 KiB]; admitting 92 KiB with L0 penalty: +1 B/req, *0.50/ingest
+{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:10 smoothedIntL0CompactedBytes:78 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:78.125 smoothedNumFlushTokens:72890.625 flushUtilTargetFraction:1.3000000000000007 totalNumByteTokens:94757 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:true curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1}}
+store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
+tick: 0, setAvailableIOTokens: 1580
+
+set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=11 print-only-first-tick=true
+----
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈39 B], flush tokens 73 KiB with multiplier 1.300 [≈94 KiB]; admitting 94 KiB with L0 penalty: +1 B/req, *0.50/ingest
+{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:11 smoothedIntL0CompactedBytes:39 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:39.0625 smoothedNumFlushTokens:73945.3125 flushUtilTargetFraction:1.3000000000000007 totalNumByteTokens:96128 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:false curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1}}
+store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
+tick: 0, setAvailableIOTokens: 1603
+
+set-min-flush-util percent=135
+----
+
+set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=12 print-only-first-tick=true
+----
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈19 B], flush tokens 73 KiB with multiplier 1.350 [≈98 KiB]; admitting 98 KiB with L0 penalty: +1 B/req, *0.50/ingest
+{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:12 smoothedIntL0CompactedBytes:19 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:19.53125 smoothedNumFlushTokens:74472.65625 flushUtilTargetFraction:1.35 totalNumByteTokens:100538 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:false curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1}}
+store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
+tick: 0, setAvailableIOTokens: 1676
+
+set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=100 write-stall-count=13 print-only-first-tick=true
+----
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈9 B], flush tokens 73 KiB with multiplier 1.350 [≈98 KiB]; admitting all
+{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 smoothedIntL0CompactedBytes:9 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:9.765625 smoothedNumFlushTokens:74472.65625 flushUtilTargetFraction:1.35 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:false curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.0196078431372549 intWriteStalls:1}}
+store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
+tick: 0, setAvailableIOTokens: unlimited
+
+set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=13 print-only-first-tick=true
+----
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈4 B], flush tokens 73 KiB with multiplier 1.350 [≈98 KiB]; admitting 98 KiB with L0 penalty: +1 B/req, *0.50/ingest
+{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 smoothedIntL0CompactedBytes:4 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:4.8828125 smoothedNumFlushTokens:74736.328125 flushUtilTargetFraction:1.35 totalNumByteTokens:100894 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:false curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:0}}
+store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
+tick: 0, setAvailableIOTokens: 1682
+
+set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=13 all-tokens-used=true print-only-first-tick=true
+----
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈2 B], flush tokens 73 KiB with multiplier 1.350 [≈99 KiB]; admitting 99 KiB with L0 penalty: +1 B/req, *0.50/ingest
+{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 smoothedIntL0CompactedBytes:2 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:2.44140625 smoothedNumFlushTokens:74868.1640625 flushUtilTargetFraction:1.35 totalNumByteTokens:101072 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:false curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:0}}
+store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
+tick: 0, setAvailableIOTokens: 1685
+
+set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=13 all-tokens-used=true print-only-first-tick=true
+----
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈1 B], flush tokens 73 KiB with multiplier 1.375 [≈101 KiB]; admitting 101 KiB with L0 penalty: +1 B/req, *0.50/ingest
+{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 smoothedIntL0CompactedBytes:1 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:1.220703125 smoothedNumFlushTokens:74934.08203125 flushUtilTargetFraction:1.375 totalNumByteTokens:103034 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:true curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:0}}
+store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
+tick: 0, setAvailableIOTokens: 1718
+
+set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=13 all-tokens-used=true print-only-first-tick=true
+----
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈0 B], flush tokens 73 KiB with multiplier 1.400 [≈102 KiB]; admitting 102 KiB with L0 penalty: +1 B/req, *0.50/ingest
+{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 smoothedIntL0CompactedBytes:0 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:0.6103515625 smoothedNumFlushTokens:74967.041015625 flushUtilTargetFraction:1.4 totalNumByteTokens:104953 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:true curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:0}}
+store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
+tick: 0, setAvailableIOTokens: 1750
+
+set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=14 all-tokens-used=true print-only-first-tick=true
+----
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈0 B], flush tokens 73 KiB with multiplier 1.375 [≈101 KiB]; admitting 101 KiB with L0 penalty: +1 B/req, *0.50/ingest
+{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:14 smoothedIntL0CompactedBytes:0 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:0.30517578125 smoothedNumFlushTokens:74983.5205078125 flushUtilTargetFraction:1.375 totalNumByteTokens:103102 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:true curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1}}
+store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
+tick: 0, setAvailableIOTokens: 1719

--- a/pkg/util/admission/testdata/io_load_listener
+++ b/pkg/util/admission/testdata/io_load_listener
@@ -6,77 +6,77 @@ init
 
 prep-admission-stats admitted=0
 ----
-{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0}
+{admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}
 
-# Even though above the threshold, the first 15 ticks don't limit the tokens.
+# Even though above the threshold, the first 60 ticks don't limit the tokens.
 set-state l0-bytes=10000 l0-added=1000 l0-files=21 l0-sublevels=21
 ----
-0 ssts, 0 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=0], compacted 0 B [≈0 B], flush tokens 0 B with multiplier 0.000 [≈0 B]; admitting all
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:1000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:0 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:0 smoothedNumFlushTokens:0 flushUtilTargetFraction:0 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0 workByteAddition:0} aux:{shouldLog:false curL0NumFiles:0 curL0NumSublevels:0 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:0 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
-tick: 0, setAvailableIOTokens: unlimited
-tick: 1, setAvailableIOTokens: unlimited
-tick: 2, setAvailableIOTokens: unlimited
-tick: 3, setAvailableIOTokens: unlimited
-tick: 4, setAvailableIOTokens: unlimited
-tick: 5, setAvailableIOTokens: unlimited
-tick: 6, setAvailableIOTokens: unlimited
-tick: 7, setAvailableIOTokens: unlimited
-tick: 8, setAvailableIOTokens: unlimited
-tick: 9, setAvailableIOTokens: unlimited
-tick: 10, setAvailableIOTokens: unlimited
-tick: 11, setAvailableIOTokens: unlimited
-tick: 12, setAvailableIOTokens: unlimited
-tick: 13, setAvailableIOTokens: unlimited
-tick: 14, setAvailableIOTokens: unlimited
-tick: 15, setAvailableIOTokens: unlimited
-tick: 16, setAvailableIOTokens: unlimited
-tick: 17, setAvailableIOTokens: unlimited
-tick: 18, setAvailableIOTokens: unlimited
-tick: 19, setAvailableIOTokens: unlimited
-tick: 20, setAvailableIOTokens: unlimited
-tick: 21, setAvailableIOTokens: unlimited
-tick: 22, setAvailableIOTokens: unlimited
-tick: 23, setAvailableIOTokens: unlimited
-tick: 24, setAvailableIOTokens: unlimited
-tick: 25, setAvailableIOTokens: unlimited
-tick: 26, setAvailableIOTokens: unlimited
-tick: 27, setAvailableIOTokens: unlimited
-tick: 28, setAvailableIOTokens: unlimited
-tick: 29, setAvailableIOTokens: unlimited
-tick: 30, setAvailableIOTokens: unlimited
-tick: 31, setAvailableIOTokens: unlimited
-tick: 32, setAvailableIOTokens: unlimited
-tick: 33, setAvailableIOTokens: unlimited
-tick: 34, setAvailableIOTokens: unlimited
-tick: 35, setAvailableIOTokens: unlimited
-tick: 36, setAvailableIOTokens: unlimited
-tick: 37, setAvailableIOTokens: unlimited
-tick: 38, setAvailableIOTokens: unlimited
-tick: 39, setAvailableIOTokens: unlimited
-tick: 40, setAvailableIOTokens: unlimited
-tick: 41, setAvailableIOTokens: unlimited
-tick: 42, setAvailableIOTokens: unlimited
-tick: 43, setAvailableIOTokens: unlimited
-tick: 44, setAvailableIOTokens: unlimited
-tick: 45, setAvailableIOTokens: unlimited
-tick: 46, setAvailableIOTokens: unlimited
-tick: 47, setAvailableIOTokens: unlimited
-tick: 48, setAvailableIOTokens: unlimited
-tick: 49, setAvailableIOTokens: unlimited
-tick: 50, setAvailableIOTokens: unlimited
-tick: 51, setAvailableIOTokens: unlimited
-tick: 52, setAvailableIOTokens: unlimited
-tick: 53, setAvailableIOTokens: unlimited
-tick: 54, setAvailableIOTokens: unlimited
-tick: 55, setAvailableIOTokens: unlimited
-tick: 56, setAvailableIOTokens: unlimited
-tick: 57, setAvailableIOTokens: unlimited
-tick: 58, setAvailableIOTokens: unlimited
-tick: 59, setAvailableIOTokens: unlimited
+0 ssts, 0 sub-levels, L0 growth 0 B: 0 B acc + 0 B unacc [≈0 B/req, n=0], compacted 0 B [≈0 B], flush tokens 0 B with multiplier 0.000 [≈0 B]; admitting all LSM growth 0 B:  0 B acc + 0 B unacc [≈0 B/req, admit≈0 B/req] 
+{ioLoadListenerState:{cumAdmissionStats:[{admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}] cumL0AddedBytes:1000 curL0Bytes:10000 cumWriteStallCount:0 cumIncomingBytes:1000 diskStats:{BytesRead:0 BytesWritten:0 ProvisionedBandwidth:1073741824} smoothedIntL0CompactedBytes:0 smoothedCompactionByteTokens:0 smoothedIntPerWorkAtAdmitUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedL0Bytes:0 smoothedNumFlushTokens:0 flushUtilTargetFraction:0 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0 elasticDiskTokens:9223372036854775807 elasticDiskTokensAllocated:0} requestEstimates:{atAdmitWorkByteAddition:0} aux:{shouldLog:false curL0NumFiles:0 curL0NumSublevels:0 intIncomingBytes:0 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:0 intAtAdmitAccountedBytes:0 intAtAdmittedDoneAccountedBytes:0 intAtAdmittedDoneAccountedL0Bytes:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
+tick: 0, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 1, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 2, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 3, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 4, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 5, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 6, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 7, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 8, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 9, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 10, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 11, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 12, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 13, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 14, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 15, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 16, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 17, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 18, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 19, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 20, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 21, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 22, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 23, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 24, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 25, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 26, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 27, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 28, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 29, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 30, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 31, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 32, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 33, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 34, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 35, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 36, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 37, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 38, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 39, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 40, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 41, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 42, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 43, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 44, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 45, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 46, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 47, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 48, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 49, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 50, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 51, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 52, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 53, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 54, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 55, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 56, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 57, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 58, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
+tick: 59, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
 
 prep-admission-stats admitted=10000
 ----
-{admittedCount:10000 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0}
+{admittedCount:10000 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}
 
 # Delta added is 100,000. The l0-bytes are the same, so compactions removed
 # 100,000 bytes. Smoothed removed by compactions is 50,000. Each admitted is
@@ -84,161 +84,161 @@ prep-admission-stats admitted=10000
 # removed), but smoothing it drops the tokens to 12,500.
 set-state l0-bytes=10000 l0-added=101000 l0-files=21 l0-sublevels=21
 ----
-21 ssts, 21 sub-levels, L0 growth 98 KiB: 0 B acc-write + 0 B acc-ingest + 98 KiB unacc [≈10 B/req, n=10000], compacted 98 KiB [≈49 KiB], flush tokens 0 B with multiplier 1.500 [≈0 B]; admitting 12 KiB with L0 penalty: +10 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:10000 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:101000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:50000 smoothedIntPerWorkUnaccountedL0Bytes:10 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:12500 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:12500 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:10} aux:{shouldLog:true curL0NumFiles:21 curL0NumSublevels:21 intL0AddedBytes:100000 intL0CompactedBytes:100000 intAdmittedCount:10000 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:100000 intPerWorkUnaccountedL0Bytes:10 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 10
-tick: 0, setAvailableIOTokens: 209
-tick: 1, setAvailableIOTokens: 209
-tick: 2, setAvailableIOTokens: 209
-tick: 3, setAvailableIOTokens: 209
-tick: 4, setAvailableIOTokens: 209
-tick: 5, setAvailableIOTokens: 209
-tick: 6, setAvailableIOTokens: 209
-tick: 7, setAvailableIOTokens: 209
-tick: 8, setAvailableIOTokens: 209
-tick: 9, setAvailableIOTokens: 209
-tick: 10, setAvailableIOTokens: 209
-tick: 11, setAvailableIOTokens: 209
-tick: 12, setAvailableIOTokens: 209
-tick: 13, setAvailableIOTokens: 209
-tick: 14, setAvailableIOTokens: 209
-tick: 15, setAvailableIOTokens: 209
-tick: 16, setAvailableIOTokens: 209
-tick: 17, setAvailableIOTokens: 209
-tick: 18, setAvailableIOTokens: 209
-tick: 19, setAvailableIOTokens: 209
-tick: 20, setAvailableIOTokens: 209
-tick: 21, setAvailableIOTokens: 209
-tick: 22, setAvailableIOTokens: 209
-tick: 23, setAvailableIOTokens: 209
-tick: 24, setAvailableIOTokens: 209
-tick: 25, setAvailableIOTokens: 209
-tick: 26, setAvailableIOTokens: 209
-tick: 27, setAvailableIOTokens: 209
-tick: 28, setAvailableIOTokens: 209
-tick: 29, setAvailableIOTokens: 209
-tick: 30, setAvailableIOTokens: 209
-tick: 31, setAvailableIOTokens: 209
-tick: 32, setAvailableIOTokens: 209
-tick: 33, setAvailableIOTokens: 209
-tick: 34, setAvailableIOTokens: 209
-tick: 35, setAvailableIOTokens: 209
-tick: 36, setAvailableIOTokens: 209
-tick: 37, setAvailableIOTokens: 209
-tick: 38, setAvailableIOTokens: 209
-tick: 39, setAvailableIOTokens: 209
-tick: 40, setAvailableIOTokens: 209
-tick: 41, setAvailableIOTokens: 209
-tick: 42, setAvailableIOTokens: 209
-tick: 43, setAvailableIOTokens: 209
-tick: 44, setAvailableIOTokens: 209
-tick: 45, setAvailableIOTokens: 209
-tick: 46, setAvailableIOTokens: 209
-tick: 47, setAvailableIOTokens: 209
-tick: 48, setAvailableIOTokens: 209
-tick: 49, setAvailableIOTokens: 209
-tick: 50, setAvailableIOTokens: 209
-tick: 51, setAvailableIOTokens: 209
-tick: 52, setAvailableIOTokens: 209
-tick: 53, setAvailableIOTokens: 209
-tick: 54, setAvailableIOTokens: 209
-tick: 55, setAvailableIOTokens: 209
-tick: 56, setAvailableIOTokens: 209
-tick: 57, setAvailableIOTokens: 209
-tick: 58, setAvailableIOTokens: 209
-tick: 59, setAvailableIOTokens: 169
+21 ssts, 21 sub-levels, L0 growth 98 KiB: 0 B acc + 98 KiB unacc [≈10 B/req, n=10000], compacted 98 KiB [≈49 KiB], flush tokens 0 B with multiplier 1.500 [≈0 B]; admitting 12 KiB with L0 penalty: +10 B/req LSM growth 98 KiB:  0 B acc + 98 KiB unacc [≈10 B/req, admit≈10 B/req] 
+{ioLoadListenerState:{cumAdmissionStats:[{admittedCount:10000 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}] cumL0AddedBytes:101000 curL0Bytes:10000 cumWriteStallCount:0 cumIncomingBytes:101000 diskStats:{BytesRead:0 BytesWritten:0 ProvisionedBandwidth:1073741824} smoothedIntL0CompactedBytes:50000 smoothedCompactionByteTokens:12500 smoothedIntPerWorkAtAdmitUnaccountedBytes:10 smoothedIntPerWorkAtAdmittedDoneUnaccountedBytes:10 smoothedIntPerWorkAtAdmittedDoneUnaccountedL0Bytes:10 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:12500 tokensAllocated:0 tokensUsed:0 elasticDiskTokens:9223372036854775807 elasticDiskTokensAllocated:0} requestEstimates:{atAdmitWorkByteAddition:10} aux:{shouldLog:true curL0NumFiles:21 curL0NumSublevels:21 intIncomingBytes:100000 intL0AddedBytes:100000 intL0CompactedBytes:100000 intAdmittedCount:10000 intAtAdmitAccountedBytes:0 intAtAdmittedDoneAccountedBytes:0 intAtAdmittedDoneAccountedL0Bytes:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
+store-request-estimates: atAdmitWorkByteAddition: 10
+tick: 0, setAdmittedDoneByteAddition(bytes: 10, l0Bytes 10)setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 1, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 2, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 3, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 4, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 5, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 6, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 7, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 8, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 9, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 10, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 11, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 12, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 13, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 14, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 15, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 16, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 17, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 18, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 19, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 20, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 21, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 22, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 23, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 24, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 25, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 26, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 27, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 28, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 29, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 30, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 31, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 32, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 33, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 34, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 35, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 36, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 37, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 38, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 39, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 40, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 41, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 42, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 43, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 44, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 45, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 46, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 47, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 48, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 49, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 50, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 51, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 52, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 53, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 54, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 55, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 56, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 57, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 58, setAvailableIOTokens: 209 setAvailableElasticDiskTokens: unlimited
+tick: 59, setAvailableIOTokens: 169 setAvailableElasticDiskTokens: unlimited
 
 prep-admission-stats admitted=20000
 ----
-{admittedCount:20000 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0}
+{admittedCount:20000 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}
 
 # Same delta as previous but smoothing bumps up the tokens to 25,000.
 set-state l0-bytes=10000 l0-added=201000 l0-files=21 l0-sublevels=21
 ----
-21 ssts, 21 sub-levels, L0 growth 98 KiB: 0 B acc-write + 0 B acc-ingest + 98 KiB unacc [≈10 B/req, n=10000], compacted 98 KiB [≈73 KiB], flush tokens 0 B with multiplier 1.500 [≈0 B]; admitting 24 KiB with L0 penalty: +10 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:20000 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:201000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:75000 smoothedIntPerWorkUnaccountedL0Bytes:10 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:25000 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:25000 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:10} aux:{shouldLog:true curL0NumFiles:21 curL0NumSublevels:21 intL0AddedBytes:100000 intL0CompactedBytes:100000 intAdmittedCount:10000 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:100000 intPerWorkUnaccountedL0Bytes:10 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 10
-tick: 0, setAvailableIOTokens: 417
-tick: 1, setAvailableIOTokens: 417
-tick: 2, setAvailableIOTokens: 417
-tick: 3, setAvailableIOTokens: 417
-tick: 4, setAvailableIOTokens: 417
-tick: 5, setAvailableIOTokens: 417
-tick: 6, setAvailableIOTokens: 417
-tick: 7, setAvailableIOTokens: 417
-tick: 8, setAvailableIOTokens: 417
-tick: 9, setAvailableIOTokens: 417
-tick: 10, setAvailableIOTokens: 417
-tick: 11, setAvailableIOTokens: 417
-tick: 12, setAvailableIOTokens: 417
-tick: 13, setAvailableIOTokens: 417
-tick: 14, setAvailableIOTokens: 417
-tick: 15, setAvailableIOTokens: 417
-tick: 16, setAvailableIOTokens: 417
-tick: 17, setAvailableIOTokens: 417
-tick: 18, setAvailableIOTokens: 417
-tick: 19, setAvailableIOTokens: 417
-tick: 20, setAvailableIOTokens: 417
-tick: 21, setAvailableIOTokens: 417
-tick: 22, setAvailableIOTokens: 417
-tick: 23, setAvailableIOTokens: 417
-tick: 24, setAvailableIOTokens: 417
-tick: 25, setAvailableIOTokens: 417
-tick: 26, setAvailableIOTokens: 417
-tick: 27, setAvailableIOTokens: 417
-tick: 28, setAvailableIOTokens: 417
-tick: 29, setAvailableIOTokens: 417
-tick: 30, setAvailableIOTokens: 417
-tick: 31, setAvailableIOTokens: 417
-tick: 32, setAvailableIOTokens: 417
-tick: 33, setAvailableIOTokens: 417
-tick: 34, setAvailableIOTokens: 417
-tick: 35, setAvailableIOTokens: 417
-tick: 36, setAvailableIOTokens: 417
-tick: 37, setAvailableIOTokens: 417
-tick: 38, setAvailableIOTokens: 417
-tick: 39, setAvailableIOTokens: 417
-tick: 40, setAvailableIOTokens: 417
-tick: 41, setAvailableIOTokens: 417
-tick: 42, setAvailableIOTokens: 417
-tick: 43, setAvailableIOTokens: 417
-tick: 44, setAvailableIOTokens: 417
-tick: 45, setAvailableIOTokens: 417
-tick: 46, setAvailableIOTokens: 417
-tick: 47, setAvailableIOTokens: 417
-tick: 48, setAvailableIOTokens: 417
-tick: 49, setAvailableIOTokens: 417
-tick: 50, setAvailableIOTokens: 417
-tick: 51, setAvailableIOTokens: 417
-tick: 52, setAvailableIOTokens: 417
-tick: 53, setAvailableIOTokens: 417
-tick: 54, setAvailableIOTokens: 417
-tick: 55, setAvailableIOTokens: 417
-tick: 56, setAvailableIOTokens: 417
-tick: 57, setAvailableIOTokens: 417
-tick: 58, setAvailableIOTokens: 417
-tick: 59, setAvailableIOTokens: 397
+21 ssts, 21 sub-levels, L0 growth 98 KiB: 0 B acc + 98 KiB unacc [≈10 B/req, n=10000], compacted 98 KiB [≈73 KiB], flush tokens 0 B with multiplier 1.500 [≈0 B]; admitting 24 KiB with L0 penalty: +10 B/req LSM growth 98 KiB:  0 B acc + 98 KiB unacc [≈10 B/req, admit≈10 B/req] 
+{ioLoadListenerState:{cumAdmissionStats:[{admittedCount:20000 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}] cumL0AddedBytes:201000 curL0Bytes:10000 cumWriteStallCount:0 cumIncomingBytes:201000 diskStats:{BytesRead:0 BytesWritten:0 ProvisionedBandwidth:1073741824} smoothedIntL0CompactedBytes:75000 smoothedCompactionByteTokens:25000 smoothedIntPerWorkAtAdmitUnaccountedBytes:10 smoothedIntPerWorkAtAdmittedDoneUnaccountedBytes:10 smoothedIntPerWorkAtAdmittedDoneUnaccountedL0Bytes:10 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:25000 tokensAllocated:0 tokensUsed:0 elasticDiskTokens:9223372036854775807 elasticDiskTokensAllocated:0} requestEstimates:{atAdmitWorkByteAddition:10} aux:{shouldLog:true curL0NumFiles:21 curL0NumSublevels:21 intIncomingBytes:100000 intL0AddedBytes:100000 intL0CompactedBytes:100000 intAdmittedCount:10000 intAtAdmitAccountedBytes:0 intAtAdmittedDoneAccountedBytes:0 intAtAdmittedDoneAccountedL0Bytes:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
+store-request-estimates: atAdmitWorkByteAddition: 10
+tick: 0, setAdmittedDoneByteAddition(bytes: 10, l0Bytes 10)setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 1, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 2, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 3, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 4, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 5, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 6, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 7, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 8, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 9, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 10, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 11, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 12, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 13, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 14, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 15, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 16, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 17, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 18, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 19, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 20, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 21, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 22, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 23, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 24, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 25, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 26, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 27, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 28, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 29, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 30, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 31, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 32, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 33, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 34, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 35, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 36, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 37, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 38, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 39, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 40, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 41, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 42, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 43, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 44, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 45, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 46, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 47, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 48, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 49, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 50, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 51, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 52, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 53, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 54, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 55, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 56, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 57, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 58, setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
+tick: 59, setAvailableIOTokens: 397 setAvailableElasticDiskTokens: unlimited
 
 # No delta. This used to trigger an overflow bug.
 set-state l0-bytes=10000 l0-added=201000 l0-files=21 l0-sublevels=21 print-only-first-tick=true
 ----
-21 ssts, 21 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈10 B/req, n=1], compacted 0 B [≈37 KiB], flush tokens 0 B with multiplier 1.500 [≈0 B]; admitting 21 KiB with L0 penalty: +10 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:20000 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:201000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:37500 smoothedIntPerWorkUnaccountedL0Bytes:10 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:21875 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:21875 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:10} aux:{shouldLog:false curL0NumFiles:21 curL0NumSublevels:21 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 10
-tick: 0, setAvailableIOTokens: 365
+21 ssts, 21 sub-levels, L0 growth 0 B: 0 B acc + 0 B unacc [≈10 B/req, n=1], compacted 0 B [≈37 KiB], flush tokens 0 B with multiplier 1.500 [≈0 B]; admitting 21 KiB with L0 penalty: +10 B/req LSM growth 0 B:  0 B acc + 0 B unacc [≈10 B/req, admit≈10 B/req] 
+{ioLoadListenerState:{cumAdmissionStats:[{admittedCount:20000 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}] cumL0AddedBytes:201000 curL0Bytes:10000 cumWriteStallCount:0 cumIncomingBytes:201000 diskStats:{BytesRead:0 BytesWritten:0 ProvisionedBandwidth:1073741824} smoothedIntL0CompactedBytes:37500 smoothedCompactionByteTokens:21875 smoothedIntPerWorkAtAdmitUnaccountedBytes:10 smoothedIntPerWorkAtAdmittedDoneUnaccountedBytes:10 smoothedIntPerWorkAtAdmittedDoneUnaccountedL0Bytes:10 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:21875 tokensAllocated:0 tokensUsed:0 elasticDiskTokens:9223372036854775807 elasticDiskTokensAllocated:0} requestEstimates:{atAdmitWorkByteAddition:10} aux:{shouldLog:false curL0NumFiles:21 curL0NumSublevels:21 intIncomingBytes:0 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAtAdmitAccountedBytes:0 intAtAdmittedDoneAccountedBytes:0 intAtAdmittedDoneAccountedL0Bytes:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
+store-request-estimates: atAdmitWorkByteAddition: 10
+tick: 0, setAdmittedDoneByteAddition(bytes: 10, l0Bytes 10)setAvailableIOTokens: 365 setAvailableElasticDiskTokens: unlimited
 
 prep-admission-stats admitted=30000
 ----
-{admittedCount:30000 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0}
+{admittedCount:30000 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}
 
 # l0-sublevels drops below threshold. We calculate the smoothed values, but
 # don't limit the tokens.
 set-state l0-bytes=10000 l0-added=501000 l0-files=21 l0-sublevels=20 print-only-first-tick=true
 ----
-21 ssts, 20 sub-levels, L0 growth 293 KiB: 0 B acc-write + 0 B acc-ingest + 293 KiB unacc [≈20 B/req, n=10000], compacted 293 KiB [≈165 KiB], flush tokens 0 B with multiplier 1.500 [≈0 B]; admitting all
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:30000 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:501000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:168750 smoothedIntPerWorkUnaccountedL0Bytes:20 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:160937.5 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:20} aux:{shouldLog:false curL0NumFiles:21 curL0NumSublevels:20 intL0AddedBytes:300000 intL0CompactedBytes:300000 intAdmittedCount:10000 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:300000 intPerWorkUnaccountedL0Bytes:30 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 20
-tick: 0, setAvailableIOTokens: unlimited
+21 ssts, 20 sub-levels, L0 growth 293 KiB: 0 B acc + 293 KiB unacc [≈20 B/req, n=10000], compacted 293 KiB [≈165 KiB], flush tokens 0 B with multiplier 1.500 [≈0 B]; admitting all LSM growth 293 KiB:  0 B acc + 293 KiB unacc [≈20 B/req, admit≈20 B/req] 
+{ioLoadListenerState:{cumAdmissionStats:[{admittedCount:30000 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}] cumL0AddedBytes:501000 curL0Bytes:10000 cumWriteStallCount:0 cumIncomingBytes:501000 diskStats:{BytesRead:0 BytesWritten:0 ProvisionedBandwidth:1073741824} smoothedIntL0CompactedBytes:168750 smoothedCompactionByteTokens:160937.5 smoothedIntPerWorkAtAdmitUnaccountedBytes:20 smoothedIntPerWorkAtAdmittedDoneUnaccountedBytes:20 smoothedIntPerWorkAtAdmittedDoneUnaccountedL0Bytes:20 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0 elasticDiskTokens:9223372036854775807 elasticDiskTokensAllocated:0} requestEstimates:{atAdmitWorkByteAddition:20} aux:{shouldLog:false curL0NumFiles:21 curL0NumSublevels:20 intIncomingBytes:300000 intL0AddedBytes:300000 intL0CompactedBytes:300000 intAdmittedCount:10000 intAtAdmitAccountedBytes:0 intAtAdmittedDoneAccountedBytes:0 intAtAdmittedDoneAccountedL0Bytes:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
+store-request-estimates: atAdmitWorkByteAddition: 20
+tick: 0, setAdmittedDoneByteAddition(bytes: 20, l0Bytes 20)setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
 
 # Test cases with more information in storeAdmissionStats.
 init
@@ -246,52 +246,52 @@ init
 
 prep-admission-stats admitted=0
 ----
-{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0}
+{admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}
 
 set-state l0-bytes=1000 l0-added=1000 l0-files=21 l0-sublevels=21 print-only-first-tick=true
 ----
-0 ssts, 0 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=0], compacted 0 B [≈0 B], flush tokens 0 B with multiplier 0.000 [≈0 B]; admitting all
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:1000 curL0Bytes:1000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:0 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:0 smoothedNumFlushTokens:0 flushUtilTargetFraction:0 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0 workByteAddition:0} aux:{shouldLog:false curL0NumFiles:0 curL0NumSublevels:0 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:0 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
-tick: 0, setAvailableIOTokens: unlimited
+0 ssts, 0 sub-levels, L0 growth 0 B: 0 B acc + 0 B unacc [≈0 B/req, n=0], compacted 0 B [≈0 B], flush tokens 0 B with multiplier 0.000 [≈0 B]; admitting all LSM growth 0 B:  0 B acc + 0 B unacc [≈0 B/req, admit≈0 B/req] 
+{ioLoadListenerState:{cumAdmissionStats:[{admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}] cumL0AddedBytes:1000 curL0Bytes:1000 cumWriteStallCount:0 cumIncomingBytes:1000 diskStats:{BytesRead:0 BytesWritten:0 ProvisionedBandwidth:1073741824} smoothedIntL0CompactedBytes:0 smoothedCompactionByteTokens:0 smoothedIntPerWorkAtAdmitUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedL0Bytes:0 smoothedNumFlushTokens:0 flushUtilTargetFraction:0 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0 elasticDiskTokens:9223372036854775807 elasticDiskTokensAllocated:0} requestEstimates:{atAdmitWorkByteAddition:0} aux:{shouldLog:false curL0NumFiles:0 curL0NumSublevels:0 intIncomingBytes:0 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:0 intAtAdmitAccountedBytes:0 intAtAdmittedDoneAccountedBytes:0 intAtAdmittedDoneAccountedL0Bytes:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
+tick: 0, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
 
 # L0 will see an addition of 200,000 bytes. 180,000 bytes were mentioned by
 # the admitted requests, but 30,000 went into levels below L0. So 150,000 are
 # accounted for.
 prep-admission-stats admitted=10 admitted-bytes=180000 ingested-bytes=50000 ingested-into-l0=20000
 ----
-{admittedCount:10 admittedWithBytesCount:0 admittedAccountedBytes:180000 ingestedAccountedBytes:50000 ingestedAccountedL0Bytes:20000}
+{admittedCount:10 atAdmitAccountedBytes:180000 atAdmittedDoneAccountedBytes:180000 atAdmittedDoneAccountedL0Bytes:150000}
 
 set-state l0-bytes=1000 l0-added=201000 l0-files=21 l0-sublevels=21 print-only-first-tick=true
 ----
-21 ssts, 21 sub-levels, L0 growth 195 KiB: 127 KiB acc-write + 20 KiB acc-ingest + 49 KiB unacc [≈4.9 KiB/req, n=10], compacted 195 KiB [≈98 KiB], flush tokens 0 B with multiplier 1.500 [≈0 B]; admitting 24 KiB with L0 penalty: +4.9 KiB/req, *0.45/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:10 admittedWithBytesCount:0 admittedAccountedBytes:180000 ingestedAccountedBytes:50000 ingestedAccountedL0Bytes:20000} cumL0AddedBytes:201000 curL0Bytes:1000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:100000 smoothedIntPerWorkUnaccountedL0Bytes:5000 smoothedIntIngestedAccountedL0BytesFraction:0.45 smoothedCompactionByteTokens:25000 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:25000 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.45 workByteAddition:5000} aux:{shouldLog:true curL0NumFiles:21 curL0NumSublevels:21 intL0AddedBytes:200000 intL0CompactedBytes:200000 intAdmittedCount:10 intAdmittedBytes:180000 intIngestedBytes:50000 intIngestedAccountedL0Bytes:20000 intAccountedL0Bytes:150000 intUnaccountedL0Bytes:50000 intPerWorkUnaccountedL0Bytes:5000 l0BytesIngestFraction:0.4 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
-store-request-estimates: fractionOfIngestIntoL0: 0.45, workByteAddition: 5000
-tick: 0, setAvailableIOTokens: 417
+21 ssts, 21 sub-levels, L0 growth 195 KiB: 146 KiB acc + 49 KiB unacc [≈4.9 KiB/req, n=10], compacted 195 KiB [≈98 KiB], flush tokens 0 B with multiplier 1.500 [≈0 B]; admitting 24 KiB with L0 penalty: +2.0 KiB/req LSM growth 195 KiB:  176 KiB acc + 20 KiB unacc [≈2.0 KiB/req, admit≈2.0 KiB/req] 
+{ioLoadListenerState:{cumAdmissionStats:[{admittedCount:10 atAdmitAccountedBytes:180000 atAdmittedDoneAccountedBytes:180000 atAdmittedDoneAccountedL0Bytes:150000} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}] cumL0AddedBytes:201000 curL0Bytes:1000 cumWriteStallCount:0 cumIncomingBytes:201000 diskStats:{BytesRead:0 BytesWritten:0 ProvisionedBandwidth:1073741824} smoothedIntL0CompactedBytes:100000 smoothedCompactionByteTokens:25000 smoothedIntPerWorkAtAdmitUnaccountedBytes:2000 smoothedIntPerWorkAtAdmittedDoneUnaccountedBytes:2000 smoothedIntPerWorkAtAdmittedDoneUnaccountedL0Bytes:5000 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:25000 tokensAllocated:0 tokensUsed:0 elasticDiskTokens:9223372036854775807 elasticDiskTokensAllocated:0} requestEstimates:{atAdmitWorkByteAddition:2000} aux:{shouldLog:true curL0NumFiles:21 curL0NumSublevels:21 intIncomingBytes:200000 intL0AddedBytes:200000 intL0CompactedBytes:200000 intAdmittedCount:10 intAtAdmitAccountedBytes:180000 intAtAdmittedDoneAccountedBytes:180000 intAtAdmittedDoneAccountedL0Bytes:150000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
+store-request-estimates: atAdmitWorkByteAddition: 2000
+tick: 0, setAdmittedDoneByteAddition(bytes: 2000, l0Bytes 5000)setAvailableIOTokens: 417 setAvailableElasticDiskTokens: unlimited
 
 # L0 will see an addition of 20,000 bytes, all of which are accounted for.
 prep-admission-stats admitted=20 admitted-bytes=200000 ingested-bytes=50000 ingested-into-l0=20000
 ----
-{admittedCount:20 admittedWithBytesCount:0 admittedAccountedBytes:200000 ingestedAccountedBytes:50000 ingestedAccountedL0Bytes:20000}
+{admittedCount:20 atAdmitAccountedBytes:200000 atAdmittedDoneAccountedBytes:200000 atAdmittedDoneAccountedL0Bytes:170000}
 
 set-state l0-bytes=1000 l0-added=221000 l0-files=21 l0-sublevels=21 print-only-first-tick=true
 ----
-21 ssts, 21 sub-levels, L0 growth 20 KiB: 20 KiB acc-write + 0 B acc-ingest + 0 B unacc [≈2.4 KiB/req, n=10], compacted 20 KiB [≈59 KiB], flush tokens 0 B with multiplier 1.500 [≈0 B]; admitting 27 KiB with L0 penalty: +2.4 KiB/req, *0.45/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:20 admittedWithBytesCount:0 admittedAccountedBytes:200000 ingestedAccountedBytes:50000 ingestedAccountedL0Bytes:20000} cumL0AddedBytes:221000 curL0Bytes:1000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:60000 smoothedIntPerWorkUnaccountedL0Bytes:2500 smoothedIntIngestedAccountedL0BytesFraction:0.45 smoothedCompactionByteTokens:27500 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:27500 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.45 workByteAddition:2500} aux:{shouldLog:true curL0NumFiles:21 curL0NumSublevels:21 intL0AddedBytes:20000 intL0CompactedBytes:20000 intAdmittedCount:10 intAdmittedBytes:20000 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:20000 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
-store-request-estimates: fractionOfIngestIntoL0: 0.45, workByteAddition: 2500
-tick: 0, setAvailableIOTokens: 459
+21 ssts, 21 sub-levels, L0 growth 20 KiB: 20 KiB acc + 0 B unacc [≈2.4 KiB/req, n=10], compacted 20 KiB [≈59 KiB], flush tokens 0 B with multiplier 1.500 [≈0 B]; admitting 27 KiB with L0 penalty: +1000 B/req LSM growth 20 KiB:  20 KiB acc + 0 B unacc [≈1000 B/req, admit≈1000 B/req] 
+{ioLoadListenerState:{cumAdmissionStats:[{admittedCount:20 atAdmitAccountedBytes:200000 atAdmittedDoneAccountedBytes:200000 atAdmittedDoneAccountedL0Bytes:170000} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}] cumL0AddedBytes:221000 curL0Bytes:1000 cumWriteStallCount:0 cumIncomingBytes:221000 diskStats:{BytesRead:0 BytesWritten:0 ProvisionedBandwidth:1073741824} smoothedIntL0CompactedBytes:60000 smoothedCompactionByteTokens:27500 smoothedIntPerWorkAtAdmitUnaccountedBytes:1000 smoothedIntPerWorkAtAdmittedDoneUnaccountedBytes:1000 smoothedIntPerWorkAtAdmittedDoneUnaccountedL0Bytes:2500 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:27500 tokensAllocated:0 tokensUsed:0 elasticDiskTokens:9223372036854775807 elasticDiskTokensAllocated:0} requestEstimates:{atAdmitWorkByteAddition:1000} aux:{shouldLog:true curL0NumFiles:21 curL0NumSublevels:21 intIncomingBytes:20000 intL0AddedBytes:20000 intL0CompactedBytes:20000 intAdmittedCount:10 intAtAdmitAccountedBytes:20000 intAtAdmittedDoneAccountedBytes:20000 intAtAdmittedDoneAccountedL0Bytes:20000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
+store-request-estimates: atAdmitWorkByteAddition: 1000
+tick: 0, setAdmittedDoneByteAddition(bytes: 1000, l0Bytes 2500)setAvailableIOTokens: 459 setAvailableElasticDiskTokens: unlimited
 
 # L0 will see an addition of 20,000 bytes, but we think we have added 100,000
 # bytes to L0. We don't let unaccounted bytes become negative.
 prep-admission-stats admitted=30 admitted-bytes=300000 ingested-bytes=50000 ingested-into-l0=20000
 ----
-{admittedCount:30 admittedWithBytesCount:0 admittedAccountedBytes:300000 ingestedAccountedBytes:50000 ingestedAccountedL0Bytes:20000}
+{admittedCount:30 atAdmitAccountedBytes:300000 atAdmittedDoneAccountedBytes:300000 atAdmittedDoneAccountedL0Bytes:270000}
 
 set-state l0-bytes=1000 l0-added=241000 l0-files=21 l0-sublevels=21 print-only-first-tick=true
 ----
-21 ssts, 21 sub-levels, L0 growth 20 KiB: 98 KiB acc-write + 0 B acc-ingest + 0 B unacc [≈1.2 KiB/req, n=10], compacted 20 KiB [≈39 KiB], flush tokens 0 B with multiplier 1.500 [≈0 B]; admitting 23 KiB with L0 penalty: +1.2 KiB/req, *0.45/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:30 admittedWithBytesCount:0 admittedAccountedBytes:300000 ingestedAccountedBytes:50000 ingestedAccountedL0Bytes:20000} cumL0AddedBytes:241000 curL0Bytes:1000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:40000 smoothedIntPerWorkUnaccountedL0Bytes:1250 smoothedIntIngestedAccountedL0BytesFraction:0.45 smoothedCompactionByteTokens:23750 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:23750 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.45 workByteAddition:1250} aux:{shouldLog:true curL0NumFiles:21 curL0NumSublevels:21 intL0AddedBytes:20000 intL0CompactedBytes:20000 intAdmittedCount:10 intAdmittedBytes:100000 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:100000 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
-store-request-estimates: fractionOfIngestIntoL0: 0.45, workByteAddition: 1250
-tick: 0, setAvailableIOTokens: 396
+21 ssts, 21 sub-levels, L0 growth 20 KiB: 98 KiB acc + -78 KiB unacc [≈1.2 KiB/req, n=10], compacted 20 KiB [≈39 KiB], flush tokens 0 B with multiplier 1.500 [≈0 B]; admitting 23 KiB with L0 penalty: +500 B/req LSM growth 20 KiB:  98 KiB acc + -78 KiB unacc [≈500 B/req, admit≈500 B/req] 
+{ioLoadListenerState:{cumAdmissionStats:[{admittedCount:30 atAdmitAccountedBytes:300000 atAdmittedDoneAccountedBytes:300000 atAdmittedDoneAccountedL0Bytes:270000} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}] cumL0AddedBytes:241000 curL0Bytes:1000 cumWriteStallCount:0 cumIncomingBytes:241000 diskStats:{BytesRead:0 BytesWritten:0 ProvisionedBandwidth:1073741824} smoothedIntL0CompactedBytes:40000 smoothedCompactionByteTokens:23750 smoothedIntPerWorkAtAdmitUnaccountedBytes:500 smoothedIntPerWorkAtAdmittedDoneUnaccountedBytes:500 smoothedIntPerWorkAtAdmittedDoneUnaccountedL0Bytes:1250 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:23750 tokensAllocated:0 tokensUsed:0 elasticDiskTokens:9223372036854775807 elasticDiskTokensAllocated:0} requestEstimates:{atAdmitWorkByteAddition:500} aux:{shouldLog:true curL0NumFiles:21 curL0NumSublevels:21 intIncomingBytes:20000 intL0AddedBytes:20000 intL0CompactedBytes:20000 intAdmittedCount:10 intAtAdmitAccountedBytes:100000 intAtAdmittedDoneAccountedBytes:100000 intAtAdmittedDoneAccountedL0Bytes:100000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
+store-request-estimates: atAdmitWorkByteAddition: 500
+tick: 0, setAdmittedDoneByteAddition(bytes: 500, l0Bytes 1250)setAvailableIOTokens: 396 setAvailableElasticDiskTokens: unlimited
 
 # Test case with flush tokens.
 init
@@ -299,58 +299,58 @@ init
 
 prep-admission-stats admitted=0
 ----
-{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0}
+{admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}
 
 set-state l0-bytes=10000 l0-added=1000 l0-files=1 l0-sublevels=1 print-only-first-tick=true
 ----
-0 ssts, 0 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=0], compacted 0 B [≈0 B], flush tokens 0 B with multiplier 0.000 [≈0 B]; admitting all
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:1000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:0 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:0 smoothedNumFlushTokens:0 flushUtilTargetFraction:0 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0 workByteAddition:0} aux:{shouldLog:false curL0NumFiles:0 curL0NumSublevels:0 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:0 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
-tick: 0, setAvailableIOTokens: unlimited
+0 ssts, 0 sub-levels, L0 growth 0 B: 0 B acc + 0 B unacc [≈0 B/req, n=0], compacted 0 B [≈0 B], flush tokens 0 B with multiplier 0.000 [≈0 B]; admitting all LSM growth 0 B:  0 B acc + 0 B unacc [≈0 B/req, admit≈0 B/req] 
+{ioLoadListenerState:{cumAdmissionStats:[{admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}] cumL0AddedBytes:1000 curL0Bytes:10000 cumWriteStallCount:0 cumIncomingBytes:1000 diskStats:{BytesRead:0 BytesWritten:0 ProvisionedBandwidth:1073741824} smoothedIntL0CompactedBytes:0 smoothedCompactionByteTokens:0 smoothedIntPerWorkAtAdmitUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedL0Bytes:0 smoothedNumFlushTokens:0 flushUtilTargetFraction:0 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0 elasticDiskTokens:9223372036854775807 elasticDiskTokensAllocated:0} requestEstimates:{atAdmitWorkByteAddition:0} aux:{shouldLog:false curL0NumFiles:0 curL0NumSublevels:0 intIncomingBytes:0 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:0 intAtAdmitAccountedBytes:0 intAtAdmittedDoneAccountedBytes:0 intAtAdmittedDoneAccountedL0Bytes:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0}}
+tick: 0, setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
 
 # Flush loop utilization is too low for the interval flush tokens to
 # contribute to the smoothed value, or for tokens to become limited.
 set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=1000 flush-work-sec=2 flush-idle-sec=100 print-only-first-tick=true
 ----
-1 ssts, 1 sub-levels, L0 growth 9.8 KiB: 0 B acc-write + 0 B acc-ingest + 9.8 KiB unacc [≈0 B/req, n=1], compacted 9.8 KiB [≈4.9 KiB], flush tokens 7.3 KiB with multiplier 1.500 [≈0 B]; admitting all
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:5000 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:5000 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:false curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:10000 intL0CompactedBytes:10000 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:10000 intPerWorkUnaccountedL0Bytes:10000 l0BytesIngestFraction:0 intFlushTokens:7500 intFlushUtilization:0.0196078431372549 intWriteStalls:0}}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: unlimited
+1 ssts, 1 sub-levels, L0 growth 9.8 KiB: 0 B acc + 9.8 KiB unacc [≈0 B/req, n=1], compacted 9.8 KiB [≈4.9 KiB], flush tokens 7.3 KiB with multiplier 1.500 [≈0 B]; admitting all LSM growth 9.8 KiB:  0 B acc + 9.8 KiB unacc [≈0 B/req, admit≈0 B/req] 
+{ioLoadListenerState:{cumAdmissionStats:[{admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}] cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:0 cumIncomingBytes:11000 diskStats:{BytesRead:0 BytesWritten:0 ProvisionedBandwidth:1073741824} smoothedIntL0CompactedBytes:5000 smoothedCompactionByteTokens:5000 smoothedIntPerWorkAtAdmitUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedL0Bytes:0 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0 elasticDiskTokens:9223372036854775807 elasticDiskTokensAllocated:0} requestEstimates:{atAdmitWorkByteAddition:1} aux:{shouldLog:false curL0NumFiles:1 curL0NumSublevels:1 intIncomingBytes:10000 intL0AddedBytes:10000 intL0CompactedBytes:10000 intAdmittedCount:1 intAtAdmitAccountedBytes:0 intAtAdmittedDoneAccountedBytes:0 intAtAdmittedDoneAccountedL0Bytes:0 intFlushTokens:7500 intFlushUtilization:0.0196078431372549 intWriteStalls:0}}
+store-request-estimates: atAdmitWorkByteAddition: 1
+tick: 0, setAdmittedDoneByteAddition(bytes: 1, l0Bytes 1)setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
 
 # Flush loop utilization is high enough.
 set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=1000 flush-work-sec=2 flush-idle-sec=10 print-only-first-tick=true
 ----
-1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈2.4 KiB], flush tokens 7.3 KiB with multiplier 1.500 [≈11 KiB]; admitting 11 KiB with L0 penalty: +1 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:2500 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:2500 smoothedNumFlushTokens:7500 flushUtilTargetFraction:1.5 totalNumByteTokens:11250 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:false curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:7500 intFlushUtilization:0.16666666666666666 intWriteStalls:0}}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: 188
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈2.4 KiB], flush tokens 7.3 KiB with multiplier 1.500 [≈11 KiB]; admitting 11 KiB with L0 penalty: +1 B/req LSM growth 0 B:  0 B acc + 0 B unacc [≈0 B/req, admit≈0 B/req] 
+{ioLoadListenerState:{cumAdmissionStats:[{admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}] cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:0 cumIncomingBytes:11000 diskStats:{BytesRead:0 BytesWritten:0 ProvisionedBandwidth:1073741824} smoothedIntL0CompactedBytes:2500 smoothedCompactionByteTokens:2500 smoothedIntPerWorkAtAdmitUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedL0Bytes:0 smoothedNumFlushTokens:7500 flushUtilTargetFraction:1.5 totalNumByteTokens:11250 tokensAllocated:0 tokensUsed:0 elasticDiskTokens:9223372036854775807 elasticDiskTokensAllocated:0} requestEstimates:{atAdmitWorkByteAddition:1} aux:{shouldLog:false curL0NumFiles:1 curL0NumSublevels:1 intIncomingBytes:0 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAtAdmitAccountedBytes:0 intAtAdmittedDoneAccountedBytes:0 intAtAdmittedDoneAccountedL0Bytes:0 intFlushTokens:7500 intFlushUtilization:0.16666666666666666 intWriteStalls:0}}
+store-request-estimates: atAdmitWorkByteAddition: 1
+tick: 0, setAdmittedDoneByteAddition(bytes: 1, l0Bytes 1)setAvailableIOTokens: 188 setAvailableElasticDiskTokens: unlimited
 
 set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=1 print-only-first-tick=true
 ----
-1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈1.2 KiB], flush tokens 73 KiB with multiplier 1.475 [≈59 KiB]; admitting 59 KiB with L0 penalty: +1 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:1 smoothedIntL0CompactedBytes:1250 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:1250 smoothedNumFlushTokens:41250 flushUtilTargetFraction:1.475 totalNumByteTokens:60843 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:true curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1}}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: 1015
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈1.2 KiB], flush tokens 73 KiB with multiplier 1.475 [≈59 KiB]; admitting 59 KiB with L0 penalty: +1 B/req LSM growth 0 B:  0 B acc + 0 B unacc [≈0 B/req, admit≈0 B/req] 
+{ioLoadListenerState:{cumAdmissionStats:[{admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}] cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:1 cumIncomingBytes:11000 diskStats:{BytesRead:0 BytesWritten:0 ProvisionedBandwidth:1073741824} smoothedIntL0CompactedBytes:1250 smoothedCompactionByteTokens:1250 smoothedIntPerWorkAtAdmitUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedL0Bytes:0 smoothedNumFlushTokens:41250 flushUtilTargetFraction:1.475 totalNumByteTokens:60843 tokensAllocated:0 tokensUsed:0 elasticDiskTokens:9223372036854775807 elasticDiskTokensAllocated:0} requestEstimates:{atAdmitWorkByteAddition:1} aux:{shouldLog:true curL0NumFiles:1 curL0NumSublevels:1 intIncomingBytes:0 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAtAdmitAccountedBytes:0 intAtAdmittedDoneAccountedBytes:0 intAtAdmittedDoneAccountedL0Bytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1}}
+store-request-estimates: atAdmitWorkByteAddition: 1
+tick: 0, setAdmittedDoneByteAddition(bytes: 1, l0Bytes 1)setAvailableIOTokens: 1015 setAvailableElasticDiskTokens: unlimited
 
 set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=3 print-only-first-tick=true
 ----
-1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈625 B], flush tokens 73 KiB with multiplier 1.425 [≈81 KiB]; admitting 81 KiB with L0 penalty: +1 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:3 smoothedIntL0CompactedBytes:625 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:625 smoothedNumFlushTokens:58125 flushUtilTargetFraction:1.4250000000000003 totalNumByteTokens:82828 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:true curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:2}}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: 1381
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈625 B], flush tokens 73 KiB with multiplier 1.425 [≈81 KiB]; admitting 81 KiB with L0 penalty: +1 B/req LSM growth 0 B:  0 B acc + 0 B unacc [≈0 B/req, admit≈0 B/req] 
+{ioLoadListenerState:{cumAdmissionStats:[{admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}] cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:3 cumIncomingBytes:11000 diskStats:{BytesRead:0 BytesWritten:0 ProvisionedBandwidth:1073741824} smoothedIntL0CompactedBytes:625 smoothedCompactionByteTokens:625 smoothedIntPerWorkAtAdmitUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedL0Bytes:0 smoothedNumFlushTokens:58125 flushUtilTargetFraction:1.4250000000000003 totalNumByteTokens:82828 tokensAllocated:0 tokensUsed:0 elasticDiskTokens:9223372036854775807 elasticDiskTokensAllocated:0} requestEstimates:{atAdmitWorkByteAddition:1} aux:{shouldLog:true curL0NumFiles:1 curL0NumSublevels:1 intIncomingBytes:0 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAtAdmitAccountedBytes:0 intAtAdmittedDoneAccountedBytes:0 intAtAdmittedDoneAccountedL0Bytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:2}}
+store-request-estimates: atAdmitWorkByteAddition: 1
+tick: 0, setAdmittedDoneByteAddition(bytes: 1, l0Bytes 1)setAvailableIOTokens: 1381 setAvailableElasticDiskTokens: unlimited
 
 set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=8 print-only-first-tick=true
 ----
-1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈312 B], flush tokens 73 KiB with multiplier 1.350 [≈88 KiB]; admitting 88 KiB with L0 penalty: +1 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:8 smoothedIntL0CompactedBytes:312 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:312.5 smoothedNumFlushTokens:66562.5 flushUtilTargetFraction:1.3500000000000005 totalNumByteTokens:89859 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:true curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:5}}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: 1498
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈312 B], flush tokens 73 KiB with multiplier 1.350 [≈88 KiB]; admitting 88 KiB with L0 penalty: +1 B/req LSM growth 0 B:  0 B acc + 0 B unacc [≈0 B/req, admit≈0 B/req] 
+{ioLoadListenerState:{cumAdmissionStats:[{admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}] cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:8 cumIncomingBytes:11000 diskStats:{BytesRead:0 BytesWritten:0 ProvisionedBandwidth:1073741824} smoothedIntL0CompactedBytes:312 smoothedCompactionByteTokens:312.5 smoothedIntPerWorkAtAdmitUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedL0Bytes:0 smoothedNumFlushTokens:66562.5 flushUtilTargetFraction:1.3500000000000005 totalNumByteTokens:89859 tokensAllocated:0 tokensUsed:0 elasticDiskTokens:9223372036854775807 elasticDiskTokensAllocated:0} requestEstimates:{atAdmitWorkByteAddition:1} aux:{shouldLog:true curL0NumFiles:1 curL0NumSublevels:1 intIncomingBytes:0 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAtAdmitAccountedBytes:0 intAtAdmittedDoneAccountedBytes:0 intAtAdmittedDoneAccountedL0Bytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:5}}
+store-request-estimates: atAdmitWorkByteAddition: 1
+tick: 0, setAdmittedDoneByteAddition(bytes: 1, l0Bytes 1)setAvailableIOTokens: 1498 setAvailableElasticDiskTokens: unlimited
 
 set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=9 print-only-first-tick=true
 ----
-1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈156 B], flush tokens 73 KiB with multiplier 1.325 [≈92 KiB]; admitting 92 KiB with L0 penalty: +1 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:9 smoothedIntL0CompactedBytes:156 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:156.25 smoothedNumFlushTokens:70781.25 flushUtilTargetFraction:1.3250000000000006 totalNumByteTokens:93785 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:true curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1}}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: 1564
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈156 B], flush tokens 73 KiB with multiplier 1.325 [≈92 KiB]; admitting 92 KiB with L0 penalty: +1 B/req LSM growth 0 B:  0 B acc + 0 B unacc [≈0 B/req, admit≈0 B/req] 
+{ioLoadListenerState:{cumAdmissionStats:[{admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}] cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:9 cumIncomingBytes:11000 diskStats:{BytesRead:0 BytesWritten:0 ProvisionedBandwidth:1073741824} smoothedIntL0CompactedBytes:156 smoothedCompactionByteTokens:156.25 smoothedIntPerWorkAtAdmitUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedL0Bytes:0 smoothedNumFlushTokens:70781.25 flushUtilTargetFraction:1.3250000000000006 totalNumByteTokens:93785 tokensAllocated:0 tokensUsed:0 elasticDiskTokens:9223372036854775807 elasticDiskTokensAllocated:0} requestEstimates:{atAdmitWorkByteAddition:1} aux:{shouldLog:true curL0NumFiles:1 curL0NumSublevels:1 intIncomingBytes:0 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAtAdmitAccountedBytes:0 intAtAdmittedDoneAccountedBytes:0 intAtAdmittedDoneAccountedL0Bytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1}}
+store-request-estimates: atAdmitWorkByteAddition: 1
+tick: 0, setAdmittedDoneByteAddition(bytes: 1, l0Bytes 1)setAvailableIOTokens: 1564 setAvailableElasticDiskTokens: unlimited
 
 
 set-min-flush-util percent=130
@@ -358,66 +358,66 @@ set-min-flush-util percent=130
 
 set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=10 print-only-first-tick=true
 ----
-1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈78 B], flush tokens 73 KiB with multiplier 1.300 [≈92 KiB]; admitting 92 KiB with L0 penalty: +1 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:10 smoothedIntL0CompactedBytes:78 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:78.125 smoothedNumFlushTokens:72890.625 flushUtilTargetFraction:1.3000000000000007 totalNumByteTokens:94757 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:true curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1}}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: 1580
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈78 B], flush tokens 73 KiB with multiplier 1.300 [≈92 KiB]; admitting 92 KiB with L0 penalty: +1 B/req LSM growth 0 B:  0 B acc + 0 B unacc [≈0 B/req, admit≈0 B/req] 
+{ioLoadListenerState:{cumAdmissionStats:[{admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}] cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:10 cumIncomingBytes:11000 diskStats:{BytesRead:0 BytesWritten:0 ProvisionedBandwidth:1073741824} smoothedIntL0CompactedBytes:78 smoothedCompactionByteTokens:78.125 smoothedIntPerWorkAtAdmitUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedL0Bytes:0 smoothedNumFlushTokens:72890.625 flushUtilTargetFraction:1.3000000000000007 totalNumByteTokens:94757 tokensAllocated:0 tokensUsed:0 elasticDiskTokens:9223372036854775807 elasticDiskTokensAllocated:0} requestEstimates:{atAdmitWorkByteAddition:1} aux:{shouldLog:true curL0NumFiles:1 curL0NumSublevels:1 intIncomingBytes:0 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAtAdmitAccountedBytes:0 intAtAdmittedDoneAccountedBytes:0 intAtAdmittedDoneAccountedL0Bytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1}}
+store-request-estimates: atAdmitWorkByteAddition: 1
+tick: 0, setAdmittedDoneByteAddition(bytes: 1, l0Bytes 1)setAvailableIOTokens: 1580 setAvailableElasticDiskTokens: unlimited
 
 set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=11 print-only-first-tick=true
 ----
-1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈39 B], flush tokens 73 KiB with multiplier 1.300 [≈94 KiB]; admitting 94 KiB with L0 penalty: +1 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:11 smoothedIntL0CompactedBytes:39 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:39.0625 smoothedNumFlushTokens:73945.3125 flushUtilTargetFraction:1.3000000000000007 totalNumByteTokens:96128 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:false curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1}}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: 1603
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈39 B], flush tokens 73 KiB with multiplier 1.300 [≈94 KiB]; admitting 94 KiB with L0 penalty: +1 B/req LSM growth 0 B:  0 B acc + 0 B unacc [≈0 B/req, admit≈0 B/req] 
+{ioLoadListenerState:{cumAdmissionStats:[{admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}] cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:11 cumIncomingBytes:11000 diskStats:{BytesRead:0 BytesWritten:0 ProvisionedBandwidth:1073741824} smoothedIntL0CompactedBytes:39 smoothedCompactionByteTokens:39.0625 smoothedIntPerWorkAtAdmitUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedL0Bytes:0 smoothedNumFlushTokens:73945.3125 flushUtilTargetFraction:1.3000000000000007 totalNumByteTokens:96128 tokensAllocated:0 tokensUsed:0 elasticDiskTokens:9223372036854775807 elasticDiskTokensAllocated:0} requestEstimates:{atAdmitWorkByteAddition:1} aux:{shouldLog:false curL0NumFiles:1 curL0NumSublevels:1 intIncomingBytes:0 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAtAdmitAccountedBytes:0 intAtAdmittedDoneAccountedBytes:0 intAtAdmittedDoneAccountedL0Bytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1}}
+store-request-estimates: atAdmitWorkByteAddition: 1
+tick: 0, setAdmittedDoneByteAddition(bytes: 1, l0Bytes 1)setAvailableIOTokens: 1603 setAvailableElasticDiskTokens: unlimited
 
 set-min-flush-util percent=135
 ----
 
 set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=12 print-only-first-tick=true
 ----
-1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈19 B], flush tokens 73 KiB with multiplier 1.350 [≈98 KiB]; admitting 98 KiB with L0 penalty: +1 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:12 smoothedIntL0CompactedBytes:19 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:19.53125 smoothedNumFlushTokens:74472.65625 flushUtilTargetFraction:1.35 totalNumByteTokens:100538 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:false curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1}}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: 1676
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈19 B], flush tokens 73 KiB with multiplier 1.350 [≈98 KiB]; admitting 98 KiB with L0 penalty: +1 B/req LSM growth 0 B:  0 B acc + 0 B unacc [≈0 B/req, admit≈0 B/req] 
+{ioLoadListenerState:{cumAdmissionStats:[{admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}] cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:12 cumIncomingBytes:11000 diskStats:{BytesRead:0 BytesWritten:0 ProvisionedBandwidth:1073741824} smoothedIntL0CompactedBytes:19 smoothedCompactionByteTokens:19.53125 smoothedIntPerWorkAtAdmitUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedL0Bytes:0 smoothedNumFlushTokens:74472.65625 flushUtilTargetFraction:1.35 totalNumByteTokens:100538 tokensAllocated:0 tokensUsed:0 elasticDiskTokens:9223372036854775807 elasticDiskTokensAllocated:0} requestEstimates:{atAdmitWorkByteAddition:1} aux:{shouldLog:false curL0NumFiles:1 curL0NumSublevels:1 intIncomingBytes:0 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAtAdmitAccountedBytes:0 intAtAdmittedDoneAccountedBytes:0 intAtAdmittedDoneAccountedL0Bytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1}}
+store-request-estimates: atAdmitWorkByteAddition: 1
+tick: 0, setAdmittedDoneByteAddition(bytes: 1, l0Bytes 1)setAvailableIOTokens: 1676 setAvailableElasticDiskTokens: unlimited
 
 set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=100 write-stall-count=13 print-only-first-tick=true
 ----
-1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈9 B], flush tokens 73 KiB with multiplier 1.350 [≈98 KiB]; admitting all
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 smoothedIntL0CompactedBytes:9 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:9.765625 smoothedNumFlushTokens:74472.65625 flushUtilTargetFraction:1.35 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:false curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.0196078431372549 intWriteStalls:1}}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: unlimited
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈9 B], flush tokens 73 KiB with multiplier 1.350 [≈98 KiB]; admitting all LSM growth 0 B:  0 B acc + 0 B unacc [≈0 B/req, admit≈0 B/req] 
+{ioLoadListenerState:{cumAdmissionStats:[{admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}] cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 cumIncomingBytes:11000 diskStats:{BytesRead:0 BytesWritten:0 ProvisionedBandwidth:1073741824} smoothedIntL0CompactedBytes:9 smoothedCompactionByteTokens:9.765625 smoothedIntPerWorkAtAdmitUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedL0Bytes:0 smoothedNumFlushTokens:74472.65625 flushUtilTargetFraction:1.35 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0 elasticDiskTokens:9223372036854775807 elasticDiskTokensAllocated:0} requestEstimates:{atAdmitWorkByteAddition:1} aux:{shouldLog:false curL0NumFiles:1 curL0NumSublevels:1 intIncomingBytes:0 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAtAdmitAccountedBytes:0 intAtAdmittedDoneAccountedBytes:0 intAtAdmittedDoneAccountedL0Bytes:0 intFlushTokens:75000 intFlushUtilization:0.0196078431372549 intWriteStalls:1}}
+store-request-estimates: atAdmitWorkByteAddition: 1
+tick: 0, setAdmittedDoneByteAddition(bytes: 1, l0Bytes 1)setAvailableIOTokens: unlimited setAvailableElasticDiskTokens: unlimited
 
 set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=13 print-only-first-tick=true
 ----
-1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈4 B], flush tokens 73 KiB with multiplier 1.350 [≈98 KiB]; admitting 98 KiB with L0 penalty: +1 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 smoothedIntL0CompactedBytes:4 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:4.8828125 smoothedNumFlushTokens:74736.328125 flushUtilTargetFraction:1.35 totalNumByteTokens:100894 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:false curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:0}}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: 1682
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈4 B], flush tokens 73 KiB with multiplier 1.350 [≈98 KiB]; admitting 98 KiB with L0 penalty: +1 B/req LSM growth 0 B:  0 B acc + 0 B unacc [≈0 B/req, admit≈0 B/req] 
+{ioLoadListenerState:{cumAdmissionStats:[{admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}] cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 cumIncomingBytes:11000 diskStats:{BytesRead:0 BytesWritten:0 ProvisionedBandwidth:1073741824} smoothedIntL0CompactedBytes:4 smoothedCompactionByteTokens:4.8828125 smoothedIntPerWorkAtAdmitUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedL0Bytes:0 smoothedNumFlushTokens:74736.328125 flushUtilTargetFraction:1.35 totalNumByteTokens:100894 tokensAllocated:0 tokensUsed:0 elasticDiskTokens:9223372036854775807 elasticDiskTokensAllocated:0} requestEstimates:{atAdmitWorkByteAddition:1} aux:{shouldLog:false curL0NumFiles:1 curL0NumSublevels:1 intIncomingBytes:0 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAtAdmitAccountedBytes:0 intAtAdmittedDoneAccountedBytes:0 intAtAdmittedDoneAccountedL0Bytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:0}}
+store-request-estimates: atAdmitWorkByteAddition: 1
+tick: 0, setAdmittedDoneByteAddition(bytes: 1, l0Bytes 1)setAvailableIOTokens: 1682 setAvailableElasticDiskTokens: unlimited
 
 set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=13 all-tokens-used=true print-only-first-tick=true
 ----
-1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈2 B], flush tokens 73 KiB with multiplier 1.350 [≈99 KiB]; admitting 99 KiB with L0 penalty: +1 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 smoothedIntL0CompactedBytes:2 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:2.44140625 smoothedNumFlushTokens:74868.1640625 flushUtilTargetFraction:1.35 totalNumByteTokens:101072 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:false curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:0}}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: 1685
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈2 B], flush tokens 73 KiB with multiplier 1.350 [≈99 KiB]; admitting 99 KiB with L0 penalty: +1 B/req LSM growth 0 B:  0 B acc + 0 B unacc [≈0 B/req, admit≈0 B/req] 
+{ioLoadListenerState:{cumAdmissionStats:[{admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}] cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 cumIncomingBytes:11000 diskStats:{BytesRead:0 BytesWritten:0 ProvisionedBandwidth:1073741824} smoothedIntL0CompactedBytes:2 smoothedCompactionByteTokens:2.44140625 smoothedIntPerWorkAtAdmitUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedL0Bytes:0 smoothedNumFlushTokens:74868.1640625 flushUtilTargetFraction:1.35 totalNumByteTokens:101072 tokensAllocated:0 tokensUsed:0 elasticDiskTokens:9223372036854775807 elasticDiskTokensAllocated:0} requestEstimates:{atAdmitWorkByteAddition:1} aux:{shouldLog:false curL0NumFiles:1 curL0NumSublevels:1 intIncomingBytes:0 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAtAdmitAccountedBytes:0 intAtAdmittedDoneAccountedBytes:0 intAtAdmittedDoneAccountedL0Bytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:0}}
+store-request-estimates: atAdmitWorkByteAddition: 1
+tick: 0, setAdmittedDoneByteAddition(bytes: 1, l0Bytes 1)setAvailableIOTokens: 1685 setAvailableElasticDiskTokens: unlimited
 
 set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=13 all-tokens-used=true print-only-first-tick=true
 ----
-1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈1 B], flush tokens 73 KiB with multiplier 1.375 [≈101 KiB]; admitting 101 KiB with L0 penalty: +1 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 smoothedIntL0CompactedBytes:1 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:1.220703125 smoothedNumFlushTokens:74934.08203125 flushUtilTargetFraction:1.375 totalNumByteTokens:103034 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:true curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:0}}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: 1718
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈1 B], flush tokens 73 KiB with multiplier 1.375 [≈101 KiB]; admitting 101 KiB with L0 penalty: +1 B/req LSM growth 0 B:  0 B acc + 0 B unacc [≈0 B/req, admit≈0 B/req] 
+{ioLoadListenerState:{cumAdmissionStats:[{admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}] cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 cumIncomingBytes:11000 diskStats:{BytesRead:0 BytesWritten:0 ProvisionedBandwidth:1073741824} smoothedIntL0CompactedBytes:1 smoothedCompactionByteTokens:1.220703125 smoothedIntPerWorkAtAdmitUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedL0Bytes:0 smoothedNumFlushTokens:74934.08203125 flushUtilTargetFraction:1.375 totalNumByteTokens:103034 tokensAllocated:0 tokensUsed:0 elasticDiskTokens:9223372036854775807 elasticDiskTokensAllocated:0} requestEstimates:{atAdmitWorkByteAddition:1} aux:{shouldLog:true curL0NumFiles:1 curL0NumSublevels:1 intIncomingBytes:0 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAtAdmitAccountedBytes:0 intAtAdmittedDoneAccountedBytes:0 intAtAdmittedDoneAccountedL0Bytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:0}}
+store-request-estimates: atAdmitWorkByteAddition: 1
+tick: 0, setAdmittedDoneByteAddition(bytes: 1, l0Bytes 1)setAvailableIOTokens: 1718 setAvailableElasticDiskTokens: unlimited
 
 set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=13 all-tokens-used=true print-only-first-tick=true
 ----
-1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈0 B], flush tokens 73 KiB with multiplier 1.400 [≈102 KiB]; admitting 102 KiB with L0 penalty: +1 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 smoothedIntL0CompactedBytes:0 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:0.6103515625 smoothedNumFlushTokens:74967.041015625 flushUtilTargetFraction:1.4 totalNumByteTokens:104953 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:true curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:0}}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: 1750
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈0 B], flush tokens 73 KiB with multiplier 1.400 [≈102 KiB]; admitting 102 KiB with L0 penalty: +1 B/req LSM growth 0 B:  0 B acc + 0 B unacc [≈0 B/req, admit≈0 B/req] 
+{ioLoadListenerState:{cumAdmissionStats:[{admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}] cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 cumIncomingBytes:11000 diskStats:{BytesRead:0 BytesWritten:0 ProvisionedBandwidth:1073741824} smoothedIntL0CompactedBytes:0 smoothedCompactionByteTokens:0.6103515625 smoothedIntPerWorkAtAdmitUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedL0Bytes:0 smoothedNumFlushTokens:74967.041015625 flushUtilTargetFraction:1.4 totalNumByteTokens:104953 tokensAllocated:0 tokensUsed:0 elasticDiskTokens:9223372036854775807 elasticDiskTokensAllocated:0} requestEstimates:{atAdmitWorkByteAddition:1} aux:{shouldLog:true curL0NumFiles:1 curL0NumSublevels:1 intIncomingBytes:0 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAtAdmitAccountedBytes:0 intAtAdmittedDoneAccountedBytes:0 intAtAdmittedDoneAccountedL0Bytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:0}}
+store-request-estimates: atAdmitWorkByteAddition: 1
+tick: 0, setAdmittedDoneByteAddition(bytes: 1, l0Bytes 1)setAvailableIOTokens: 1750 setAvailableElasticDiskTokens: unlimited
 
 set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=14 all-tokens-used=true print-only-first-tick=true
 ----
-1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈0 B], flush tokens 73 KiB with multiplier 1.375 [≈101 KiB]; admitting 101 KiB with L0 penalty: +1 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:14 smoothedIntL0CompactedBytes:0 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:0.30517578125 smoothedNumFlushTokens:74983.5205078125 flushUtilTargetFraction:1.375 totalNumByteTokens:103102 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{shouldLog:true curL0NumFiles:1 curL0NumSublevels:1 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1}}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: 1719
+1 ssts, 1 sub-levels, L0 growth 0 B: 0 B acc + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈0 B], flush tokens 73 KiB with multiplier 1.375 [≈101 KiB]; admitting 101 KiB with L0 penalty: +1 B/req LSM growth 0 B:  0 B acc + 0 B unacc [≈0 B/req, admit≈0 B/req] 
+{ioLoadListenerState:{cumAdmissionStats:[{admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}] cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:14 cumIncomingBytes:11000 diskStats:{BytesRead:0 BytesWritten:0 ProvisionedBandwidth:1073741824} smoothedIntL0CompactedBytes:0 smoothedCompactionByteTokens:0.30517578125 smoothedIntPerWorkAtAdmitUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedBytes:0 smoothedIntPerWorkAtAdmittedDoneUnaccountedL0Bytes:0 smoothedNumFlushTokens:74983.5205078125 flushUtilTargetFraction:1.375 totalNumByteTokens:103102 tokensAllocated:0 tokensUsed:0 elasticDiskTokens:9223372036854775807 elasticDiskTokensAllocated:0} requestEstimates:{atAdmitWorkByteAddition:1} aux:{shouldLog:true curL0NumFiles:1 curL0NumSublevels:1 intIncomingBytes:0 intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAtAdmitAccountedBytes:0 intAtAdmittedDoneAccountedBytes:0 intAtAdmittedDoneAccountedL0Bytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1}}
+store-request-estimates: atAdmitWorkByteAddition: 1
+tick: 0, setAdmittedDoneByteAddition(bytes: 1, l0Bytes 1)setAvailableIOTokens: 1719 setAvailableElasticDiskTokens: unlimited

--- a/pkg/util/admission/testdata/store_work_queue
+++ b/pkg/util/admission/testdata/store_work_queue
@@ -4,8 +4,8 @@ init
 print
 ----
 closed epoch: 0 tenantHeap len: 0
-stats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0}
-estimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1}
+stats:[{admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}]
+estimates:{atAdmitWorkByteAddition:1}
 
 set-try-get-return-value v=true
 ----
@@ -13,35 +13,36 @@ set-try-get-return-value v=true
 admit id=1 tenant=53 priority=0 create-time-millis=1 bypass=false
 ----
 tryGet: returning true
-id 1: admit succeeded with handle {tenantID:{InternalValue:53} writeBytes:0 writeTokens:1 workByteAdditionTokens:1 ingestRequest:false admissionEnabled:true}
+id 1: admit succeeded with handle {tenantID:{InternalValue:53} writeBytes:0 writeTokens:1 ingestRequest:false admissionEnabled:true workClass:0}
 
 work-done id=1
 ----
+storeWriteDone: tokens: 1 ac: 0 ac-L0: 0
 
-set-store-request-estimates percent-ingested-into-l0=20 work-bytes-addition=100
+set-store-request-estimates work-bytes-addition=100
 ----
 closed epoch: 0 tenantHeap len: 0
  tenant-id: 53 used: 1, w: 1, fifo: -128
-stats:{admittedCount:1 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0}
-estimates:{fractionOfIngestIntoL0:0.2 workByteAddition:100}
+stats:[{admittedCount:1 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}]
+estimates:{atAdmitWorkByteAddition:100}
 
 admit id=2 tenant=55 priority=0 create-time-millis=1 bypass=false
 ----
 tryGet: returning true
-id 2: admit succeeded with handle {tenantID:{InternalValue:55} writeBytes:0 writeTokens:100 workByteAdditionTokens:100 ingestRequest:false admissionEnabled:true}
+id 2: admit succeeded with handle {tenantID:{InternalValue:55} writeBytes:0 writeTokens:100 ingestRequest:false admissionEnabled:true workClass:0}
 
 admit id=3 tenant=53 priority=0 create-time-millis=1 bypass=false write-bytes=1000000 ingest-request=true
 ----
 tryGet: returning true
-id 3: admit succeeded with handle {tenantID:{InternalValue:53} writeBytes:1000000 writeTokens:200100 workByteAdditionTokens:100 ingestRequest:true admissionEnabled:true}
+id 3: admit succeeded with handle {tenantID:{InternalValue:53} writeBytes:1000000 writeTokens:1000100 ingestRequest:true admissionEnabled:true workClass:0}
 
 print
 ----
 closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 200101, w: 1, fifo: -128
+ tenant-id: 53 used: 1000101, w: 1, fifo: -128
  tenant-id: 55 used: 100, w: 1, fifo: -128
-stats:{admittedCount:1 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0}
-estimates:{fractionOfIngestIntoL0:0.2 workByteAddition:100}
+stats:[{admittedCount:1 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}]
+estimates:{atAdmitWorkByteAddition:100}
 
 set-try-get-return-value v=false
 ----
@@ -52,52 +53,54 @@ tryGet: returning false
 
 work-done id=2
 ----
+storeWriteDone: tokens: 100 ac: 0 ac-L0: 0
 
 print
 ----
 closed epoch: 0 tenantHeap len: 1 top tenant: 57
- tenant-id: 53 used: 200101, w: 1, fifo: -128
+ tenant-id: 53 used: 1000101, w: 1, fifo: -128
  tenant-id: 55 used: 100, w: 1, fifo: -128
  tenant-id: 57 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 0]
-stats:{admittedCount:2 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0}
-estimates:{fractionOfIngestIntoL0:0.2 workByteAddition:100}
+stats:[{admittedCount:2 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}]
+estimates:{atAdmitWorkByteAddition:100}
 
 granted
 ----
 continueGrantChain 0
-id 4: admit succeeded with handle {tenantID:{InternalValue:57} writeBytes:2000 writeTokens:2100 workByteAdditionTokens:100 ingestRequest:false admissionEnabled:true}
+id 4: admit succeeded with handle {tenantID:{InternalValue:57} writeBytes:2000 writeTokens:2100 ingestRequest:false admissionEnabled:true workClass:0}
 granted: returned 2100
 
 work-done id=3 ingested-into-l0=20000
 ----
-returnGrant 180000
+storeWriteDone: tokens: 1000100 ac: 1000000 ac-L0: 20000
 
 print
 ----
 closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 20101, w: 1, fifo: -128
+ tenant-id: 53 used: 1000101, w: 1, fifo: -128
  tenant-id: 55 used: 100, w: 1, fifo: -128
  tenant-id: 57 used: 2100, w: 1, fifo: -128
-stats:{admittedCount:3 admittedWithBytesCount:1 admittedAccountedBytes:1000000 ingestedAccountedBytes:1000000 ingestedAccountedL0Bytes:20000}
-estimates:{fractionOfIngestIntoL0:0.2 workByteAddition:100}
+stats:[{admittedCount:3 atAdmitAccountedBytes:1000000 atAdmittedDoneAccountedBytes:1000000 atAdmittedDoneAccountedL0Bytes:20000} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}]
+estimates:{atAdmitWorkByteAddition:100}
 
-set-store-request-estimates percent-ingested-into-l0=10 work-bytes-addition=10000
+set-store-request-estimates work-bytes-addition=10000
 ----
 closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 20101, w: 1, fifo: -128
+ tenant-id: 53 used: 1000101, w: 1, fifo: -128
  tenant-id: 55 used: 100, w: 1, fifo: -128
  tenant-id: 57 used: 2100, w: 1, fifo: -128
-stats:{admittedCount:3 admittedWithBytesCount:1 admittedAccountedBytes:1000000 ingestedAccountedBytes:1000000 ingestedAccountedL0Bytes:20000}
-estimates:{fractionOfIngestIntoL0:0.1 workByteAddition:10000}
+stats:[{admittedCount:3 atAdmitAccountedBytes:1000000 atAdmittedDoneAccountedBytes:1000000 atAdmittedDoneAccountedL0Bytes:20000} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}]
+estimates:{atAdmitWorkByteAddition:10000}
 
 work-done id=4
 ----
+storeWriteDone: tokens: 2100 ac: 2000 ac-L0: 2000
 
 print
 ----
 closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 20101, w: 1, fifo: -128
+ tenant-id: 53 used: 1000101, w: 1, fifo: -128
  tenant-id: 55 used: 100, w: 1, fifo: -128
  tenant-id: 57 used: 2100, w: 1, fifo: -128
-stats:{admittedCount:4 admittedWithBytesCount:2 admittedAccountedBytes:1002000 ingestedAccountedBytes:1000000 ingestedAccountedL0Bytes:20000}
-estimates:{fractionOfIngestIntoL0:0.1 workByteAddition:10000}
+stats:[{admittedCount:4 atAdmitAccountedBytes:1002000 atAdmittedDoneAccountedBytes:1002000 atAdmittedDoneAccountedL0Bytes:22000} {admittedCount:0 atAdmitAccountedBytes:0 atAdmittedDoneAccountedBytes:0 atAdmittedDoneAccountedL0Bytes:0}]
+estimates:{atAdmitWorkByteAddition:10000}

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -1605,15 +1605,15 @@ func (q *StoreWorkQueue) Admit(
 		return StoreWorkHandle{}, errors.Errorf("IngestRequest must specify WriteBytes")
 	}
 	// For now, we compute a workClass based on priority.
-	workClass := regularWorkClass
+	wc := regularWorkClass
 	if info.Priority < admissionpb.NormalPri {
-		workClass = elasticWorkClass
+		wc = elasticWorkClass
 	}
 	h := StoreWorkHandle{
 		tenantID:      info.TenantID,
 		writeBytes:    info.WriteBytes,
 		ingestRequest: info.IngestRequest,
-		workClass:     workClass,
+		workClass:     wc,
 	}
 	q.mu.RLock()
 	estimates := q.mu.estimates
@@ -1621,7 +1621,7 @@ func (q *StoreWorkQueue) Admit(
 	h.writeTokens = h.writeBytes
 	h.writeTokens += estimates.atAdmitWorkByteAddition
 	info.WorkInfo.requestedCount = h.writeTokens
-	enabled, err := q.queues[workClass].Admit(ctx, info.WorkInfo)
+	enabled, err := q.queues[wc].Admit(ctx, info.WorkInfo)
 	if err != nil {
 		return StoreWorkHandle{}, err
 	}

--- a/pkg/util/admission/work_queue_test.go
+++ b/pkg/util/admission/work_queue_test.go
@@ -468,7 +468,7 @@ func TestStoreWorkQueueBasic(t *testing.T) {
 	printQueue := func() string {
 		q.mu.Lock()
 		defer q.mu.Unlock()
-		return fmt.Sprintf("%s\nstats:%+v\nestimates:%+v", q.q.String(), q.mu.stats,
+		return fmt.Sprintf("%s\nstats:%+v\nestimates:%+v", q.regularQ.String(), q.mu.stats,
 			q.mu.estimates)
 	}
 


### PR DESCRIPTION
The first commit is from 82440

We assume that:
- There is a provisioned known limit on the sum of read and write
  bandwidth. This limit is allowed to change.
- Admission control can only shape the rate of admission of writes. Writes
  also cause reads, since compactions do reads and writes.

There are multiple challenges:
- We are unable to precisely track the causes of disk read bandwidth, since
  we do not have observability into what reads missed the OS page cache.
  That is, we don't know how much of the reads were due to incoming reads
  (that we don't shape) and how much due to compaction read bandwidth.
- We don't shape incoming reads.
- There can be a large time lag between the shaping of incoming writes, and when
  it affects actual writes in the system, since compaction backlog can
  build up in various levels of the LSM store.
- Signals of overload are coarse, since we cannot view all the internal
  queues that can build up due to resource overload. For instance,
  different examples of bandwidth saturation exhibit wildly different
  latency effects, presumably because the queue buildup is different. So it
  is non-trivial to approach full utilization without risking high latency.

Due to these challenges, and previous design attempts that were quite
complicated (and incomplete), we adopt a goal of simplicity of design, and strong
abstraction boundaries.
- The disk load is abstracted using an enum. The diskLoadWatcher can be
  evolved independently.
- The approach uses easy to understand additive increase and multiplicative
  decrease, (unlike what we do for flush and compaction tokens, where we
  try to more precisely calculate the sustainable rates).

Since we are using a simple approach that is somewhat coarse in its behavior,
we start by limiting its application to two kinds of writes:
- Incoming writes that are deemed "elastic": This can be done by
  introducing a work-class (in addition to admissionpb.WorkPriority), or by
  implying a work-class from the priority (e.g. priorities < NormalPri are
  deemed elastic). This prototype does the latter.
- Optional compactions: We assume that the LSM store is configured with a
  ceiling on number of regular concurrent compactions, and if it needs more
  it can request resources for additional (optional) compactions. These
  latter compactions can be limited by this approach. See
  https://github.com/cockroachdb/pebble/issues/1329 for motivation.

The reader should start with disk_bandwidth.go, consisting of
- diskLoadWatcher: which computes load levels.
- compactionLimiter: which tracks all compaction slots and limits
  optional compactions.
- diskBandwidthLimiter: It composes the previous two objects and
  uses load information to limit write tokens for elastic writes
  and limit compactions.

There is significant refactoring and changes in granter.go and
work_queue.go. This is driven by the fact that:
- Previously the tokens were for L0 and now we need to support tokens for
  bytes into L0 and tokens for bytes into the LSM (the former being a subset
  of the latter).
- Elastic work is in a different WorkQueue than regular work, but they
  are competing for the same tokens.

The latter is handled by allowing kvSlotGranter to multiplex across
multiple requesters, via multiple child granters. A number of interfaces
are adjusted to make this viable. In general, the GrantCoordinator
is now slightly dumber and some of that logic is moved into the granters.

For the former (two kinds of tokens), I considered adding multiple
resource dimensions to the granter-requester interaction but found it
too complicated. Instead we rely on the observation that we can request
tokens based on the total incoming bytes of the request (not just L0),
and when the request is completed, can tell the granter how many bytes
went into L0. The latter allows us to return tokens to L0. There was
also the (unrelated) realization that we can use the information
of the size of the batch in the call to AdmittedWorkDone and fix
estimation that we had to make pre-evaluation. This resulted in a
bunch of changes to how we do estimation to adjust the tokens consumed:
we now estimate how much we need to compensate what is being asked
for at (a) admission time, (b) work done time, for the bytes added
to the LSM, (c) work done time, for the bytes added to L0. Since we
are askinf for tokens at admission time based on the full incoming
bytes, the estimation for what fraction of an ingest goes into L0 is
eliminated. This had the consequence of simplifying some of the
estimation logic that was distinguishing writes from ingests.

There are no tests (and breaks existing tests) so this code is probably littered with bugs.

Next steps:
- Unit tests
- Pebble changes for IntervalCompactionInfo
- CockroachDB changes for IntervalDiskLoadInfo
- Experimental evaluation and tuning
- Separate into multiple PRs for review
- KV and storage package plumbing for properly populating
  StoreWriteWorkInfo.{WriteBytes,IngestRequest} for ingestions and
  StoreWorkDoneInfo.{ActualBytes,ActualBytesIntoL0} for writes and
  ingestions.

Some experimental results with artificially set provisioned bandwidth limit of 95MiB and a kv0 workload with 4KB writes that are all considered elastic traffic. There were 4 runs: the first one has no provisioned bw limit and the subsequent ones are iterations over heuristics. The last one is the latest code: it is tuned to not increase load if we have reached 70% of provisioned bandwidth.
<img width="1464" alt="Screen Shot 2022-07-12 at 2 48 35 PM" src="https://user-images.githubusercontent.com/54990988/178571608-41d2a920-c9ee-47a4-83b0-1fb6f90676e0.png">

The challenge in doing better is the sharp transitions from < 0.7 fraction bandwidth utilization to > 0.95, due to the lag in compactions. For example:
```
I220712 18:17:34.770083 541 util/admission/disk_bandwidth.go:110 ⋮ [-] 543  diskLoadWatcher: rb: 0 B, wb: 3.0 MiB, pb: 95 MiB, util: 0.03
I220712 18:17:49.770806 541 util/admission/disk_bandwidth.go:110 ⋮ [-] 555  diskLoadWatcher: rb: 0 B, wb: 54 MiB, pb: 95 MiB, util: 0.57
I220712 18:18:04.770748 541 util/admission/disk_bandwidth.go:110 ⋮ [-] 566  diskLoadWatcher: rb: 0 B, wb: 53 MiB, pb: 95 MiB, util: 0.56
I220712 18:18:19.770290 541 util/admission/disk_bandwidth.go:110 ⋮ [-] 578  diskLoadWatcher: rb: 0 B, wb: 67 MiB, pb: 95 MiB, util: 0.70
I220712 18:18:34.770280 541 util/admission/disk_bandwidth.go:110 ⋮ [-] 589  diskLoadWatcher: rb: 0 B, wb: 104 MiB, pb: 95 MiB, util: 1.10
I220712 18:18:49.769979 541 util/admission/disk_bandwidth.go:110 ⋮ [-] 600  diskLoadWatcher: rb: 0 B, wb: 53 MiB, pb: 95 MiB, util: 0.56
I220712 18:19:04.770342 541 util/admission/disk_bandwidth.go:110 ⋮ [-] 612  diskLoadWatcher: rb: 0 B, wb: 17 MiB, pb: 95 MiB, util: 0.18
I220712 18:19:19.771061 541 util/admission/disk_bandwidth.go:110 ⋮ [-] 623  diskLoadWatcher: rb: 0 B, wb: 66 MiB, pb: 95 MiB, util: 0.69
I220712 18:19:34.770318 541 util/admission/disk_bandwidth.go:110 ⋮ [-] 636  diskLoadWatcher: rb: 0 B, wb: 96 MiB, pb: 95 MiB, util: 1.01
```
Release note: None