### PR TITLE
workload/schemachanger: version gate FK support in workload

### DIFF
--- a/pkg/workload/schemachange/BUILD.bazel
+++ b/pkg/workload/schemachange/BUILD.bazel
@@ -15,6 +15,8 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/workload/schemachange",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
+        "//pkg/roachpb",
         "//pkg/security/username",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/colinfo",

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -163,6 +163,10 @@ func (s *schemaChange) Ops(
 		return workload.QueryLoad{}, err
 	}
 
+	err = adjustOpWeightsForCockroachVersion(ctx, pool, opWeights)
+	if err != nil {
+		return workload.QueryLoad{}, err
+	}
 	ops := newDeck(rand.New(rand.NewSource(timeutil.Now().UnixNano())), opWeights...)
 	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
 


### PR DESCRIPTION
Fixes: #82796

Previously, when the foreign key support was added in the schema
changer workload we added a new builtin into master to help support
this functionality. Unfortunately, previous versions don't have
crdb_internal.is_constraint_active to identify if FK constraints
are active. To address this, this patch will disable foreign key
constraint testing in mixed version environments for this test.

Release note: None