### PR TITLE
bazel: set `no-remote-cache` for `GoPath`, propagate tags

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,6 +25,7 @@ build --define gotags=bazel,gss
 build --experimental_proto_descriptor_sets_include_source_info
 build --incompatible_strict_action_env --incompatible_enable_cc_toolchain_resolution
 build --symlink_prefix=_bazel/
+common --experimental_allow_tags_propagation
 test --config=test --experimental_ui_max_stdouterr_bytes=10485760
 build --ui_event_filters=-DEBUG
 query --ui_event_filters=-DEBUG

--- a/docs/generated/swagger/BUILD.bazel
+++ b/docs/generated/swagger/BUILD.bazel
@@ -21,6 +21,7 @@ genrule(
 
 go_path(
     name = "swagger_go_path",
+    tags = ["no-remote-cache"],
     deps = [
         "//pkg/server",
     ],


### PR DESCRIPTION
On my machine, building the `GoPath` takes a lot of time but it's almost
all in caching apparently. I turn off caching with the `no-remote-cache`
tag, but this has no effect unless we also set
`--experimental_allow_tags_propagation`. See the
[issue upstream](https://github.com/bazelbuild/bazel/issues/8830).
I suspect that `--experimental_allow_tags_propagation` will be useful in
other places as well for our fine-tuning.

Release note: None