### PR TITLE
sql: add an example distsql tenant logic test with split ranges

### DIFF
--- a/pkg/ccl/logictestccl/logic_test.go
+++ b/pkg/ccl/logictestccl/logic_test.go
@@ -28,9 +28,10 @@ func TestCCLLogic(t *testing.T) {
 }
 
 // TestTenantLogic runs all non-CCL logic test files under the 3node-tenant
-// configuration, which constructs a secondary tenant and runs the test within
+// configurations, which constructs a secondary tenant and runs the test within
 // that secondary tenant's sandbox. Test files that blocklist the 3node-tenant
-// configuration (i.e. "# LogicTest: !3node-tenant") are not run.
+// configuration (e.g., "# LogicTest: !3node-tenant-default-configs") are not
+// run.
 func TestTenantLogic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -43,11 +44,15 @@ func TestTenantLogic(t *testing.T) {
 		testdataDir = runfile
 	}
 
+	// Run 3node-tenant as a default config and any tests that require
+	// 3node-tenant-multiregion.
 	logictest.RunLogicTestWithDefaultConfig(
-		t, logictest.TestServerArgs{}, "3node-tenant", true, /* runCCLConfigs */
+		t, logictest.TestServerArgs{}, "3node-tenant", "3node-tenant-multiregion",
+		true, /* runCCLConfigs */
 		filepath.Join(testdataDir, logictestGlob))
 	logictest.RunLogicTestWithDefaultConfig(
-		t, logictest.TestServerArgs{}, "3node-tenant", true, /* runCCLConfigs */
+		t, logictest.TestServerArgs{}, "3node-tenant", "3node-tenant-multiregion",
+		true, /* runCCLConfigs */
 		testutils.TestDataPath(t, logictestGlob))
 }
 
@@ -73,6 +78,7 @@ func TestTenantExecBuild(t *testing.T) {
 	}
 
 	logictest.RunLogicTestWithDefaultConfig(
-		t, logictest.TestServerArgs{DisableWorkmemRandomization: true}, "3node-tenant", true, /* runCCLConfigs */
+		t, logictest.TestServerArgs{DisableWorkmemRandomization: true},
+		"3node-tenant", "3node-tenant-multiregion", true, /* runCCLConfigs */
 		filepath.Join(testdataDir, "[^.]*"))
 }

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -534,6 +534,8 @@ type testClusterConfig struct {
 	useFakeSpanResolver bool
 	// if non-empty, overrides the default distsql mode.
 	overrideDistSQLMode string
+	// allowSplitAndScatter enables the AllowSplitAndScatter tenant testing knob.
+	allowSplitAndScatter bool
 	// if non-empty, overrides the default vectorize mode.
 	overrideVectorize string
 	// if non-empty, overrides the default experimental DistSQL planning mode.
@@ -841,12 +843,43 @@ var logicTestConfigs = []testClusterConfig{
 		// can only be run with a CCL binary, so is a noop if run through the normal
 		// logictest command.
 		// To run a logic test with this config as a directive, run:
-		// make test PKG=./pkg/ccl/logictestccl TESTS=TestTenantLogic//<test_name>
+		// make test PKG=./pkg/ccl/logictestccl TESTS=TestTenantLogic/^3node-tenant$$/<test_name>
 		name:                threeNodeTenantConfigName,
 		numNodes:            3,
 		useTenant:           true,
 		isCCLConfig:         true,
 		overrideDistSQLMode: "on",
+	},
+	{
+		// 3node-tenant-multiregion is a config that runs the test as a SQL tenant
+		// with SQL instances and KV nodes in multiple regions. This config can only
+		// be run with a CCL binary, so is a noop if run through the normal
+		// logictest command.
+		// To run a logic test with this config as a directive, run:
+		// make test PKG=./pkg/ccl/logictestccl TESTS=TestTenantLogic/3node-tenant-multiregion/<test_name>
+		name:                 "3node-tenant-multiregion",
+		numNodes:             3,
+		useTenant:            true,
+		isCCLConfig:          true,
+		overrideDistSQLMode:  "on",
+		allowSplitAndScatter: true,
+		localities: map[int]roachpb.Locality{
+			1: {
+				Tiers: []roachpb.Tier{
+					{Key: "region", Value: "test"},
+				},
+			},
+			2: {
+				Tiers: []roachpb.Tier{
+					{Key: "region", Value: "test1"},
+				},
+			},
+			3: {
+				Tiers: []roachpb.Tier{
+					{Key: "region", Value: "test2"},
+				},
+			},
+		},
 	},
 	// Regions and zones below are named deliberately, and contain "-"'s to be reflective
 	// of the naming convention in public clouds.  "-"'s are handled differently in SQL
@@ -999,8 +1032,16 @@ var (
 		"5node-disk",
 		"5node-spec-planning",
 	}
-	defaultConfig         = parseTestConfig(defaultConfigNames)
-	fiveNodeDefaultConfig = parseTestConfig(fiveNodeDefaultConfigNames)
+	// threeNodeTenantDefaultConfigName is a special alias for all 3-node tenant
+	// configs.
+	threeNodeTenantDefaultConfigName  = "3node-tenant-default-configs"
+	threeNodeTenantDefaultConfigNames = []string{
+		"3node-tenant",
+		"3node-tenant-multiregion",
+	}
+	defaultConfig                = parseTestConfig(defaultConfigNames)
+	fiveNodeDefaultConfig        = parseTestConfig(fiveNodeDefaultConfigNames)
+	threeNodeTenantDefaultConfig = parseTestConfig(threeNodeTenantDefaultConfigNames)
 )
 
 func findLogicTestConfig(name string) (logicTestConfigIdx, bool) {
@@ -1726,6 +1767,11 @@ func (t *logicTest) newCluster(
 	}
 
 	cfg := t.cfg
+	if cfg.useTenant {
+		// In the tenant case we need to enable replication in order to split and
+		// relocate ranges correctly.
+		params.ReplicationMode = base.ReplicationAuto
+	}
 	distSQLKnobs := &execinfra.TestingKnobs{
 		MetadataTestLevel: execinfra.Off,
 	}
@@ -1828,6 +1874,9 @@ func (t *logicTest) newCluster(
 					},
 					SQLStatsKnobs: &sqlstats.TestingKnobs{
 						AOSTClause: "AS OF SYSTEM TIME '-1us'",
+					},
+					TenantTestingKnobs: &sql.TenantTestingKnobs{
+						AllowSplitAndScatter: cfg.allowSplitAndScatter,
 					},
 				},
 				MemoryPoolSize:    params.ServerArgs.SQLMemoryPoolSize,
@@ -2224,7 +2273,16 @@ func processConfigs(
 		if *printBlocklistIssues && issueNo != 0 {
 			t.Logf("will skip %s config in test %s due to issue: %s", blockedConfig, path, build.MakeIssueURL(issueNo))
 		}
-		blocklist[blockedConfig] = issueNo
+		// Enumerate all the blocked configs if the blocked config is a default
+		// config list.
+		names := getDefaultConfigListNames(blockedConfig)
+		if len(names) == 0 {
+			blocklist[blockedConfig] = issueNo
+		} else {
+			for _, name := range names {
+				blocklist[name] = issueNo
+			}
+		}
 	}
 
 	if _, ok := blocklist["metamorphic"]; ok && util.IsMetamorphicBuild() {
@@ -2251,6 +2309,8 @@ func processConfigs(
 				configs = append(configs, applyBlocklistToConfigs(defaults, blocklist)...)
 			case fiveNodeDefaultConfigName:
 				configs = append(configs, applyBlocklistToConfigs(fiveNodeDefaultConfig, blocklist)...)
+			case threeNodeTenantDefaultConfigName:
+				configs = append(configs, applyBlocklistToConfigs(threeNodeTenantDefaultConfig, blocklist)...)
 			default:
 				t.Fatalf("%s: unknown config name %s", path, configName)
 			}
@@ -3319,7 +3379,7 @@ func (t *logicTest) processSubtest(
 					return errors.New("skipif config CONFIG [ISSUE] command requires configuration parameter")
 				}
 				configName := fields[2]
-				if t.cfg.name == configName {
+				if t.cfg.name == configName || configIsInDefaultList(t.cfg.name, configName) {
 					issue := "no issue given"
 					if len(fields) > 3 {
 						issue = fields[3]
@@ -3347,7 +3407,7 @@ func (t *logicTest) processSubtest(
 					return errors.New("onlyif config CONFIG [ISSUE] command requires configuration parameter")
 				}
 				configName := fields[2]
-				if t.cfg.name != configName {
+				if t.cfg.name != configName && !configIsInDefaultList(t.cfg.name, configName) {
 					issue := "no issue given"
 					if len(fields) > 3 {
 						issue = fields[3]
@@ -4276,19 +4336,22 @@ type TestServerArgs struct {
 // RunLogicTest is the main entry point for the logic test. The globs parameter
 // specifies the default sets of files to run.
 func RunLogicTest(t *testing.T, serverArgs TestServerArgs, globs ...string) {
-	RunLogicTestWithDefaultConfig(t, serverArgs, *overrideConfig, false /* runCCLConfigs */, globs...)
+	RunLogicTestWithDefaultConfig(t, serverArgs, *overrideConfig, "", false /* runCCLConfigs */, globs...)
 }
 
-// RunLogicTestWithDefaultConfig is the main entry point for the logic test.
-// The globs parameter specifies the default sets of files to run. The config
+// RunLogicTestWithDefaultConfig is the main entry point for the logic test. The
+// globs parameter specifies the default sets of files to run. The config
 // override parameter, if not empty, specifies the set of configurations to run
-// those files in. If empty, the default set of configurations is used.
-// runCCLConfigs specifies whether the test runner should skip configs that can
-// only be run with a CCL binary.
+// those files in. If empty, the default set of configurations is used. The
+// config filter override specifies a set of configurations to run the files in
+// if there are explicit directives for those configurations. runCCLConfigs
+// specifies whether the test runner should skip configs that can only be run
+// with a CCL binary.
 func RunLogicTestWithDefaultConfig(
 	t *testing.T,
 	serverArgs TestServerArgs,
 	configOverride string,
+	configFilterOverride string,
 	runCCLConfigs bool,
 	globs ...string,
 ) {
@@ -4351,6 +4414,15 @@ func RunLogicTestWithDefaultConfig(
 		names := strings.Split(configOverride, ",")
 		configDefaults = parseTestConfig(names)
 		configFilter = make(map[string]struct{})
+		for _, name := range names {
+			configFilter[name] = struct{}{}
+		}
+	}
+	if configFilterOverride != "" {
+		// If a config filter override is provided, add them to the filter to
+		// also run tests with them as a config directive. This is in addition to
+		// any configs added via the config override.
+		names := strings.Split(configFilterOverride, ",")
 		for _, name := range names {
 			configFilter[name] = struct{}{}
 		}
@@ -4564,7 +4636,7 @@ func runSQLLiteLogicTest(t *testing.T, configOverride string, globs ...string) {
 	serverArgs := TestServerArgs{
 		maxSQLMemoryLimit: 512 << 20, // 512 MiB
 	}
-	RunLogicTestWithDefaultConfig(t, serverArgs, configOverride, true /* runCCLConfigs */, prefixedGlobs...)
+	RunLogicTestWithDefaultConfig(t, serverArgs, configOverride, "", true /* runCCLConfigs */, prefixedGlobs...)
 }
 
 type errorSummaryEntry struct {
@@ -4757,4 +4829,27 @@ func roundFloatsInString(s string) string {
 		}
 		return []byte(fmt.Sprintf("%.6g", f))
 	}))
+}
+
+// configIsInDefaultList returns true if defaultName is one of the default
+// config lists and configName is a config included in that list.
+func configIsInDefaultList(configName, defaultName string) bool {
+	for _, name := range getDefaultConfigListNames(defaultName) {
+		if name == configName {
+			return true
+		}
+	}
+	return false
+}
+
+func getDefaultConfigListNames(name string) []string {
+	switch name {
+	case defaultConfigName:
+		return defaultConfigNames
+	case fiveNodeDefaultConfigName:
+		return fiveNodeDefaultConfigNames
+	case threeNodeTenantDefaultConfigName:
+		return threeNodeTenantDefaultConfigNames
+	}
+	return []string{}
 }

--- a/pkg/sql/logictest/testdata/logic_test/as_of
+++ b/pkg/sql/logictest/testdata/logic_test/as_of
@@ -37,7 +37,7 @@ SELECT pg_sleep(5) -- we need to sleep so that the 4.8s elapses and the SELECT *
 
 # Notices print twice -- once during planning and once during execution.
 # There's no nice way of reducing this to once without some hacks -- so left as is.
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query T noticetrace
 SELECT * FROM t AS OF SYSTEM TIME follower_read_timestamp()
 ----
@@ -79,33 +79,33 @@ SELECT * FROM t AS OF SYSTEM TIME '0'
 statement ok
 EXPLAIN SELECT * FROM t AS OF SYSTEM TIME '-1us'
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 # Regression test for out of bounds error during the type-checking of AOST with
 # a placeholder (#56488).
 statement error pq: no value provided for placeholder: \$1
 SELECT * FROM t AS OF SYSTEM TIME $1
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 statement error pgcode XXC01 with_min_timestamp can only be used with a CCL distribution
 SELECT with_min_timestamp('2020-01-15 15:16:17')
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 statement error pgcode XXC01 with_min_timestamp can only be used with a CCL distribution
 SELECT with_min_timestamp(statement_timestamp())
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 statement error pgcode XXC01 with_max_staleness can only be used with a CCL distribution
 SELECT with_max_staleness('1s')
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 statement error pgcode XXC01 with_min_timestamp can only be used with a CCL distribution
 SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp('2020-01-15 15:16:17')
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 statement error pgcode XXC01 with_min_timestamp can only be used with a CCL distribution
 SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp(statement_timestamp())
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 statement error pgcode XXC01 with_max_staleness can only be used with a CCL distribution
 SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1s'::interval)
 

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -3104,7 +3104,7 @@ statement ok
 CREATE USER parentuser;
 GRANT parentuser TO testuser
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 statement error session revival tokens are not supported on this cluster
 select crdb_internal.create_session_revival_token()
 

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function_notenant
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function_notenant
@@ -1,4 +1,4 @@
-# LogicTest: !3node-tenant !fakedist-spec-planning
+# LogicTest: !3node-tenant-default-configs !fakedist-spec-planning
 
 subtest check_consistency
 

--- a/pkg/sql/logictest/testdata/logic_test/ccl
+++ b/pkg/sql/logictest/testdata/logic_test/ccl
@@ -1,6 +1,6 @@
 # 3node-tenant is blocked from running this file because the config runs with
 # a CCL binary, so the expected failures from using a non-CCL binary don't occur.
-# LogicTest: !3node-tenant
+# LogicTest: !3node-tenant-default-configs
 
 # CCL-only statements error out trying to handle the parsed statements.
 

--- a/pkg/sql/logictest/testdata/logic_test/cluster_settings
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_settings
@@ -148,41 +148,41 @@ SHOW CLUSTER SETTING sql.defaults.stub_catalog_tables.enabled
 ----
 true
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 statement ok
 SET CLUSTER SETTING kv.snapshot_rebalance.max_rate = '10Mib'
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query T
 SHOW CLUSTER SETTING kv.snapshot_rebalance.max_rate
 ----
 10 MiB
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query T
 SELECT crdb_internal.cluster_setting_encoded_default('kv.snapshot_rebalance.max_rate')
 ----
 33554432
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query T
 SELECT crdb_internal.decode_cluster_setting('kv.snapshot_rebalance.max_rate', '33554432')
 ----
 32 MiB
 
-onlyif config 3node-tenant
+onlyif config 3node-tenant-default-configs
 query error unknown cluster setting
 SELECT crdb_internal.cluster_setting_encoded_default('kv.snapshot_rebalance.max_rate')
 
-onlyif config 3node-tenant
+onlyif config 3node-tenant-default-configs
 query error unknown cluster setting
 SELECT crdb_internal.decode_cluster_setting('kv.snapshot_rebalance.max_rate', '33554432')
 
-onlyif config 3node-tenant
+onlyif config 3node-tenant-default-configs
 statement error unknown cluster setting
 SET CLUSTER SETTING kv.snapshot_rebalance.max_rate = '10Mib'
 
-onlyif config 3node-tenant
+onlyif config 3node-tenant-default-configs
 statement error unknown setting
 SHOW CLUSTER SETTING kv.snapshot_rebalance.max_rate
 
@@ -191,85 +191,85 @@ subtest tenant-cluster-settings
 
 # Skip this test when inside a tenant, as this setting won't be visible in
 # there.
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 statement error admission.kv.enabled is a system-only setting and must be set in the admin tenant using SET CLUSTER SETTING
 ALTER TENANT 10 SET CLUSTER SETTING admission.kv.enabled=true
 
-onlyif config 3node-tenant
+onlyif config 3node-tenant-default-configs
 statement error ALTER TENANT can only be called by system operators
 ALTER TENANT 10 SET CLUSTER SETTING server.mem_profile.total_dump_size_limit='10M'
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 statement error cannot use this statement to access cluster settings in system tenant
 ALTER TENANT 1 SET CLUSTER SETTING server.mem_profile.total_dump_size_limit='10M'
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 statement ok
 SELECT crdb_internal.create_tenant(10)
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 statement ok
 ALTER TENANT 10 SET CLUSTER SETTING server.mem_profile.total_dump_size_limit='10M'
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 statement ok
 ALTER TENANT ALL SET CLUSTER SETTING server.mem_profile.total_dump_size_limit='10M'
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 statement ok
 ALTER TENANT 10 RESET CLUSTER SETTING server.mem_profile.total_dump_size_limit
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 statement ok
 ALTER TENANT ALL RESET CLUSTER SETTING server.mem_profile.total_dump_size_limit
 
-onlyif config 3node-tenant
+onlyif config 3node-tenant-default-configs
 statement error SHOW CLUSTER SETTING FOR TENANT can only be called by system operators
 SHOW CLUSTER SETTING server.mem_profile.total_dump_size_limit FOR TENANT 10
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query error tenant ID must be non-zero
 SHOW CLUSTER SETTING server.mem_profile.total_dump_size_limit FOR TENANT 0
 
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query error use SHOW CLUSTER SETTING to display a setting for the system tenant
 SHOW CLUSTER SETTING server.mem_profile.total_dump_size_limit FOR TENANT 1
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query error no tenant found with ID 1111
 SHOW CLUSTER SETTING server.mem_profile.total_dump_size_limit FOR TENANT 1111
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query T
 SHOW CLUSTER SETTING server.mem_profile.total_dump_size_limit FOR TENANT 10
 ----
 NULL
 
-onlyif config 3node-tenant
+onlyif config 3snode-tenant-default-config
 query error SHOW CLUSTER SETTINGS FOR TENANT can only be called by system operators
 SHOW CLUSTER SETTINGS FOR TENANT 10
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query error tenant ID must be non-zero
 SHOW CLUSTER SETTINGS FOR TENANT 0
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query error use SHOW CLUSTER SETTINGS to display settings for the system tenant
 SHOW CLUSTER SETTINGS FOR TENANT 1
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query error no tenant found with ID 1111
 SHOW CLUSTER SETTINGS FOR TENANT 1111
 
 # The IN clause should contain one public and one hidden cluster setting.
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query TTT
 SELECT variable, type, origin FROM [SHOW CLUSTER SETTINGS FOR TENANT 10] WHERE variable IN ('jobs.scheduler.enabled', 'jobs.retention_time') ORDER BY 1
 ----
 jobs.retention_time  d  no-override
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query TTBT
 SELECT variable, type, public, origin FROM [SHOW ALL CLUSTER SETTINGS FOR TENANT 10] WHERE variable IN ('jobs.scheduler.enabled', 'jobs.retention_time') ORDER BY 1
 ----

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -1,6 +1,6 @@
 # 3node-tenant is blocked from running this file due to heavy reliance on
 # unavailable node IDs in this test.
-# LogicTest: !3node-tenant
+# LogicTest: !3node-tenant-default-configs
 
 query error database "crdb_internal" does not exist
 ALTER DATABASE crdb_internal RENAME TO not_crdb_internal

--- a/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
@@ -75,7 +75,7 @@ UPDATE data SET d = 12 WHERE d = 10
 # For some reason, 3node-tenant occasionally splits the UPDATE into 4 pieces,
 # with each one affecting at most 88 rows. Since 88 < 205, the refresh is not
 # guaranteed, making this test flaky.
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query TTIII colnames,rowsort,retry
 SELECT DISTINCT ON (column_names) statistics_name, column_names, row_count, distinct_count, null_count
 FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names ASC, created DESC

--- a/pkg/sql/logictest/testdata/logic_test/distsql_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_tenant
@@ -1,4 +1,4 @@
-# LogicTest: 3node-tenant
+# LogicTest: 3node-tenant-default-configs
 
 statement ok
 CREATE TABLE t (k INT PRIMARY KEY, v INT, w INT, x INT,

--- a/pkg/sql/logictest/testdata/logic_test/distsql_tenant_locality
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_tenant_locality
@@ -1,0 +1,34 @@
+# LogicTest: 3node-tenant-multiregion
+
+# Create a table on the secondary tenant.
+statement ok
+CREATE TABLE t (k INT PRIMARY KEY, v INT)
+
+# Split the ranges in the table.
+statement ok
+ALTER TABLE t SPLIT AT VALUES (1), (2), (3)
+
+# Relocate ranges in the admin tenant based on node locality.
+user host-cluster-root
+
+statement ok
+ALTER RANGE RELOCATE LEASE TO 1 FOR SELECT range_id FROM crdb_internal.ranges WHERE start_pretty LIKE '%Tenant%1'
+
+statement ok
+ALTER RANGE RELOCATE LEASE TO 2 FOR SELECT range_id FROM crdb_internal.ranges WHERE start_pretty LIKE '%Tenant%2'
+
+statement ok
+ALTER RANGE RELOCATE LEASE TO 3 FOR SELECT range_id FROM crdb_internal.ranges WHERE start_pretty LIKE '%Tenant%3'
+
+# Check range lease holders in the admin tenant.
+query TI
+SELECT start_pretty, lease_holder FROM crdb_internal.ranges WHERE start_pretty LIKE '%Tenant%'
+----
+/Tenant/10                1
+/Tenant/10/Table/106/1/1  1
+/Tenant/10/Table/106/1/2  2
+/Tenant/10/Table/106/1/3  3
+
+# TODO(harding): Once locality-aware distribution is implemented, run queries in
+# the secondary tenant.
+#user root

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1669,14 +1669,14 @@ FROM
 # Regression test for incorrectly serializing NULL expression type annotation in
 # a enum tuple.
 # Skipped on tenants because of SPLIT AT and SCATTER usage.
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 statement ok
 CREATE TYPE greeting58889 AS ENUM ('hello', 'howdy', 'hi', 'good day', 'morning');
 CREATE TABLE t58889 AS SELECT enum_range('hello'::greeting58889)[g] as _enum FROM generate_series(1, 5) as g;
 ALTER TABLE t58889 SPLIT AT SELECT i FROM generate_series(1, 5) as g(i);
 ALTER TABLE t58889 SCATTER;
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query T
 SELECT _enum FROM t58889 WHERE _enum::greeting58889 IN (NULL, 'hi':::greeting58889);
 ----

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -485,7 +485,7 @@ ORDER BY "timestamp", info
 0  1  {"EventType": "set_cluster_setting", "SettingName": "kv.allocator.load_based_lease_rebalancing.enabled", "Statement": "SET CLUSTER SETTING \"kv.allocator.load_based_lease_rebalancing.enabled\" = DEFAULT", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "DEFAULT"}
 0  1  {"EventType": "set_cluster_setting", "PlaceholderValues": ["'some string'"], "SettingName": "cluster.organization", "Statement": "SET CLUSTER SETTING \"cluster.organization\" = $1", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "'some string'"}
 
-onlyif config 3node-tenant
+onlyif config 3node-tenant-default-configs
 query IIT
 SELECT "targetID", "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID'
 FROM system.eventlog
@@ -508,17 +508,17 @@ ORDER BY "timestamp", info
 statement ok
 CREATE TABLE a (id INT PRIMARY KEY)
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 statement ok
 ALTER TABLE a CONFIGURE ZONE USING range_max_bytes = 67108865, range_min_bytes = 16777216
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 statement ok
 ALTER TABLE a CONFIGURE ZONE DISCARD
 
 # verify zone config changes are logged
 ##################
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query IT
 SELECT "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID'
 FROM system.eventlog
@@ -527,7 +527,7 @@ ORDER BY "timestamp", info
 ----
 1  {"EventType": "set_zone_config", "Options": ["range_max_bytes = 67108865", "range_min_bytes = 16777216"], "Statement": "ALTER TABLE \"\".\"\".a CONFIGURE ZONE USING range_max_bytes = 67108865, range_min_bytes = 16777216", "Tag": "CONFIGURE ZONE", "Target": "TABLE test.public.a", "User": "root"}
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query IT
 SELECT "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID'
 FROM system.eventlog

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -809,7 +809,7 @@ CREATE TABLE t_hash_pre_split (
   b INT
 );
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query TITTT retry
 SELECT t.name, r.table_id, r.index_name, r.start_pretty, r.end_pretty
 FROM crdb_internal.tables t
@@ -822,7 +822,7 @@ AND r.split_enforced_until IS NOT NULL;
 statement ok
 CREATE INDEX t_hash_pre_split_idx_b ON t_hash_pre_split (b) USING HASH WITH (bucket_count=8);
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query TITTT colnames,retry
 SELECT t.name, r.table_id, r.index_name, r.start_pretty, r.end_pretty
 FROM crdb_internal.tables t

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -2,7 +2,7 @@
 # the tenant table for tenants. Legacy schema changer is also skipped, because
 # some of the queries relating internal state will be impacted in terms of
 # descriptor versions, etc..
-# LogicTest: !3node-tenant !local-legacy-schema-changer
+# LogicTest: !3node-tenant-default-configs !local-legacy-schema-changer
 
 # Verify information_schema database handles mutation statements correctly.
 

--- a/pkg/sql/logictest/testdata/logic_test/kv_builtin_functions
+++ b/pkg/sql/logictest/testdata/logic_test/kv_builtin_functions
@@ -1,4 +1,4 @@
-# LogicTest: !3node-tenant
+# LogicTest: !3node-tenant-default-configs
 
 # Test crdb_internal.kv_set_queue_active commands that target all stores on the
 # gateway node.

--- a/pkg/sql/logictest/testdata/logic_test/locality
+++ b/pkg/sql/logictest/testdata/logic_test/locality
@@ -1,4 +1,4 @@
-# LogicTest: !3node-tenant
+# LogicTest: !3node-tenant-default-configs
 
 query T
 SELECT crdb_internal.locality_value('region')

--- a/pkg/sql/logictest/testdata/logic_test/partitioning
+++ b/pkg/sql/logictest/testdata/logic_test/partitioning
@@ -1,6 +1,6 @@
 # 3node-tenant is blocked from running this file because the config runs with
 # a CCL binary, so the expected failures from using a non-CCL binary don't occur.
-# LogicTest: !3node-tenant
+# LogicTest: !3node-tenant-default-configs
 
 statement error pgcode XXC01 creating or manipulating partitions requires a CCL binary
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1075,7 +1075,7 @@ t6_pkey            6       NULL                                      NULL
 statement ok
 SET DATABASE = system
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query OOIBBBBBBBBBBTTTTTTI colnames
 SELECT *
 FROM pg_catalog.pg_index
@@ -1134,7 +1134,7 @@ indexrelid  indrelid  indnatts  indisunique  indisprimary  indisexclusion  indim
 4225994721  13        2         true         true          false           true          false           true        false         false       true       false           1 7            0 0                        0 0          2 2          NULL      NULL                                                                                                                          2
 
 # From #26504
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query OOI colnames
 SELECT indexrelid,
        (information_schema._pg_expandarray(indclass)).x AS operator_argument_type_oid,
@@ -4097,7 +4097,7 @@ SET DATABASE = test
 
 # We filter here because 'optimizer' will be different depending on which
 # configuration this logic test is running in, and session ID will vary.
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query TTTTTT colnames
 SELECT
   name, setting, category, short_desc, extra_desc, vartype
@@ -4218,7 +4218,7 @@ use_declarative_schema_changer                        on                  NULL  
 vectorize                                             on                  NULL      NULL        NULL        string
 xmloption                                             content             NULL      NULL        NULL        string
 
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query TTTTTTT colnames
 SELECT
   name, setting, unit, context, enumvals, boot_val, reset_val

--- a/pkg/sql/logictest/testdata/logic_test/show_transfer_state
+++ b/pkg/sql/logictest/testdata/logic_test/show_transfer_state
@@ -1,4 +1,4 @@
-# LogicTest: !3node-tenant
+# LogicTest: !3node-tenant-default-configs
 
 # Statement does not work on system tenant.
 query TTT colnames

--- a/pkg/sql/logictest/testdata/logic_test/split_at
+++ b/pkg/sql/logictest/testdata/logic_test/split_at
@@ -1,4 +1,4 @@
-# LogicTest: !3node-tenant
+# LogicTest: !3node-tenant-default-configs
 
 # Test formatting of keys in output of SPLIT AT
 

--- a/pkg/sql/logictest/testdata/logic_test/sqlsmith
+++ b/pkg/sql/logictest/testdata/logic_test/sqlsmith
@@ -2,7 +2,7 @@
 
 
 # Regression: #28836 (nulls in string_agg)
-skipif config 3node-tenant #72565
+skipif config 3node-tenant-default-configs #72565
 statement ok
 SELECT subq_0.c3 AS c0, subq_0.c6 AS c1, subq_0.c4 AS c2, CASE WHEN (SELECT start_key FROM crdb_internal.ranges LIMIT 1 OFFSET 6) < CAST(NULLIF(pg_catalog.string_agg(CAST((SELECT start_key FROM crdb_internal.ranges LIMIT 1 OFFSET 7) AS BYTES), CAST((SELECT pg_catalog.xor_agg(tgargs) FROM pg_catalog.pg_trigger) AS BYTES)) OVER (PARTITION BY subq_0.c0 ORDER BY subq_0.c0, subq_0.c5, subq_0.c2), CAST(NULL AS BYTES)) AS BYTES) THEN subq_0.c6 ELSE subq_0.c6 END AS c3, subq_0.c2 AS c4, subq_0.c7 AS c5, CAST(COALESCE(subq_0.c7, subq_0.c7) AS INT8) AS c6 FROM (SELECT ref_0.table_name AS c0, ref_0.table_catalog AS c1, ref_0.table_type AS c2, (SELECT rolcreatedb FROM pg_catalog.pg_roles LIMIT 1 OFFSET 79) AS c3, ref_0.table_name AS c4, ref_0.version AS c5, ref_0.version AS c6, ref_0.version AS c7 FROM information_schema.tables AS ref_0 WHERE (ref_0.version IS NOT NULL) OR (pg_catalog.set_masklen(CAST(CAST(NULL AS INET) AS INET), CAST(ref_0.version AS INT8)) != (SELECT pg_catalog.max(client_addr) FROM pg_catalog.pg_stat_activity)) LIMIT 101) AS subq_0 WHERE subq_0.c7 IS NOT NULL
 

--- a/pkg/sql/logictest/testdata/logic_test/statement_statistics
+++ b/pkg/sql/logictest/testdata/logic_test/statement_statistics
@@ -123,7 +123,7 @@ SHOW CLUSTER SETTING debug.panic_on_failed_assertions
 statement ok
 SET application_name = ''; RESET distsql
 
-skipif config 3node-tenant #52763
+skipif config 3node-tenant-default-configs #52763
 query TT colnames
 SELECT key,flags
   FROM test.crdb_internal.node_statement_statistics

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -8,7 +8,7 @@ test       root  NULL  {}  NULL
 
 # The test expectations are different on tenants because of
 # descriptor_id_sq, tenant, tenant_usage, and span_configurations.
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query TTTTT
 SELECT schema_name, table_name, type, owner, locality FROM [SHOW TABLES FROM system] ORDER BY 2
 ----
@@ -50,7 +50,7 @@ public  users                            table  NULL  NULL
 public  web_sessions                     table  NULL  NULL
 public  zones                            table  NULL  NULL
 
-onlyif config 3node-tenant
+onlyif config 3node-tenant-default-configs
 query TTTTT
 SELECT schema_name, table_name, type, owner, locality FROM [SHOW TABLES FROM system] ORDER BY 2
 ----
@@ -93,7 +93,7 @@ public  zones                            table     NULL  NULL
 
 # The test expectations are different on tenants because of
 # descriptor_id_sq, tenant, tenant_usage, and span_configurations.
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query I rowsort
 SELECT id FROM system.descriptor
 ----
@@ -142,7 +142,7 @@ SELECT id FROM system.descriptor
 104
 105
 
-onlyif config 3node-tenant
+onlyif config 3node-tenant-default-configs
 query I rowsort
 SELECT id FROM system.descriptor
 ----
@@ -302,7 +302,7 @@ system  root   CONNECT  true
 
 # The test expectations are different on tenants because of
 # descriptor_id_sq, tenant, tenant_usage, and span_configurations.
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query TTTTTB
 SHOW GRANTS ON system.*
 ----
@@ -562,7 +562,7 @@ system  public  zones                            root    INSERT  true
 system  public  zones                            root    SELECT  true
 system  public  zones                            root    UPDATE  true
 
-onlyif config 3node-tenant
+onlyif config 3node-tenant-default-configs
 query TTTTTB
 SHOW GRANTS ON system.*
 ----
@@ -942,7 +942,7 @@ diagnostics.reporting.enabled
 sql.crdb_internal.table_row_statistics.as_of_time
 version
 
-onlyif config 3node-tenant
+onlyif config 3node-tenant-default-configs
 query T
 SELECT name
 FROM system.settings
@@ -976,7 +976,7 @@ diagnostics.reporting.enabled                      true
 somesetting                                        somevalue
 sql.crdb_internal.table_row_statistics.as_of_time  -1µs
 
-onlyif config 3node-tenant
+onlyif config 3node-tenant-default-configs
 query TT
 SELECT name, value
 FROM system.settings
@@ -1022,7 +1022,7 @@ query error relation ".system.users" does not exist
 SELECT username FROM "".system.users WHERE username = 'root'
 
 # Verify that tenant_usage has a reduced TTL.
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query T
 SELECT raw_config_sql FROM [ SHOW ZONE CONFIGURATION FOR TABLE system.tenant_usage ]
 ----

--- a/pkg/sql/logictest/testdata/logic_test/system_namespace
+++ b/pkg/sql/logictest/testdata/logic_test/system_namespace
@@ -1,4 +1,4 @@
-skipif config 3node-tenant
+skipif config 3node-tenant-default-configs
 query IITI rowsort
 SELECT * FROM system.namespace
 ----

--- a/pkg/sql/logictest/testdata/logic_test/tenant
+++ b/pkg/sql/logictest/testdata/logic_test/tenant
@@ -1,4 +1,4 @@
-# LogicTest: !3node-tenant
+# LogicTest: !3node-tenant-default-configs
 query IBT colnames
 SELECT * FROM system.tenants ORDER BY id
 ----

--- a/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
@@ -1,4 +1,4 @@
-# LogicTest: !3node-tenant
+# LogicTest: !3node-tenant-default-configs
 # Zone config logic tests that are only meant to work for the system tenant.
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/geospatial
@@ -1,7 +1,7 @@
 # This logic test fails in the 3node-tenant configuration because the keys are
 # prefixed with the tenant ID if run by a tenant:
 # https://github.com/cockroachdb/cockroach/issues/49582
-# LogicTest: !3node-tenant
+# LogicTest: !3node-tenant-default-configs
 
 statement ok
 CREATE TABLE b(


### PR DESCRIPTION
This PR adds an example distsql logic test, `distsql_tenant_locality`,
that splits ranges and assigns them to spcific leaseholders, for future
use in testing locality-aware distsql changes.

This PR also introduces the following logic test improvements:
* A new logic test config for multi-tenant multi-region testing,
    `3node-tenant-multiregion`.
* Blocklists in logic tests can now include default config lists.
* Skip directives in logic tests can now include default config lists.
* A default config list for multi-tenant configurations that include
    `3node-tenant` and `3node-tenant-multi-region`.
* `TestTenantLogic` and `TestTenantExecBuild` now run the 3 node
      tenant configuration by default and any logic/exec builder tests
      that have the 3 node tenant multiregion directive.

Release note: None
