### PR TITLE
spanconfigkvsubscriber: add `spanconfig.kvsubscriber.update_behind_nanos`

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -583,6 +583,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 				fallbackConf,
 				cfg.Settings,
 				spanConfigKnobs,
+				registry,
 			)
 		}
 

--- a/pkg/spanconfig/spanconfigkvsubscriber/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigkvsubscriber/BUILD.bazel
@@ -26,9 +26,11 @@ go_library(
         "//pkg/sql/types",
         "//pkg/util/hlc",
         "//pkg/util/log",
+        "//pkg/util/metric",
         "//pkg/util/protoutil",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/spanconfig/spanconfigkvsubscriber/datadriven_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/datadriven_test.go
@@ -167,6 +167,7 @@ func TestDataDriven(t *testing.T) {
 					ErrorInjectionCh: injectedErrCh,
 				},
 			},
+			nil, /* registry */
 		)
 
 		kvSubscriber.Subscribe(func(ctx context.Context, span roachpb.Span) {

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_test.go
@@ -83,6 +83,7 @@ func TestGetProtectionTimestamps(t *testing.T) {
 		roachpb.SpanConfig{},
 		cluster.MakeTestingClusterSettings(),
 		nil,
+		nil,
 	)
 	m := &manualStore{
 		spanAndConfigs: []spanAndSpanConfig{sp42Cfg, sp43Cfg},

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -228,6 +228,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 		cfg.DefaultSpanConfig,
 		cfg.Settings,
 		nil,
+		nil,
 	)
 	cfg.SystemConfigProvider = systemconfigwatcher.New(
 		keys.SystemSQLCodec,

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -735,6 +735,17 @@ var charts = []sectionDescription{
 		},
 	},
 	{
+		Organization: [][]string{
+			{Process, "Span Configs"},
+		},
+		Charts: []chartDescription{
+			{
+				Title:   "KVSubscriber",
+				Metrics: []string{"spanconfig.kvsubscriber.update_behind_nanos"},
+			},
+		},
+	},
+	{
 		Organization: [][]string{{KVTransactionLayer, "Clocks"}}, Charts: []chartDescription{
 			{
 				Title:   "Roundtrip Latency",


### PR DESCRIPTION
This change introduces a `spanconfig.kvsubscriber.update_behind_nanos`
metric that is updated every time the KVSubscriber handles an update
request. This metric tracks the latency between realtime and the last update
handled by the KVSubscriber from the underlying rangefeed. This metric
can be interpreted as a measure of the kvsubscribers' staleness, where a
flatline would indicate that the subscriber is receiving no events.

Release note (sql change): `spanconfig.kvsubscriber.update_behind_nanos`
metric has been added to track the latency between realtime and the last
update handled by the KVSubscriber. This metric can be used to
monitor the staleness of a nodes' view of reconciled spanconfig state.