### PR TITLE
Convert alert include to inline

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -279,7 +279,9 @@ An event of type `set_cluster_setting` is recorded when a cluster setting is cha
 Events in this category are generated when a table has been
 marked as audited via `ALTER TABLE ... EXPERIMENTAL_AUDIT SET`.
 
-{% include {{ page.version.version }}/misc/experimental-warning.md %}
+{{site.data.alerts.callout_danger}}
+**This is an experimental feature**. The interface and output are subject to change.
+{{site.data.alerts.end}}
 
 Note: These events are not written to `system.eventlog`, even
 when the cluster setting `system.eventlog.enabled` is set. They


### PR DESCRIPTION
Addresses: DOC-1584

- Converts extant include alert to inline alert, to fix currently-broken include attempt in [live](https://www.cockroachlabs.com/docs/v21.2/eventlog#sql-access-audit-events) docs. This is due to an order of operations bug with Jekyll that we don't presently have a fix for.
- Please let me know if there is an upstream generation script (that I am unaware of) that is otherwise responsible for the content of this page, which might need to be edited instead.

Note: I edited the `release-22.1` version in #82850 and the `master` version in #82852.

Thank you!