### PR TITLE
Re-introduce alert inline

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -359,6 +359,10 @@ is changed, either for another tenant or for all tenants.
 Events in this category are generated when a table has been
 marked as audited via `ALTER TABLE ... EXPERIMENTAL_AUDIT SET`.
 
+{{site.data.alerts.callout_danger}}
+**This is an experimental feature**. The interface and output are subject to change.
+{{site.data.alerts.end}}
+
 Note: These events are not written to `system.eventlog`, even
 when the cluster setting `system.eventlog.enabled` is set. They
 are only emitted via external logging.


### PR DESCRIPTION
Addresses: DOC-1584

- Re-introduces alert as inline text. My understanding is that the alert was removed initially in [this commit](https://github.com/cockroachdb/cockroach/commit/5ab7683da6f2397e7fdec2a8e03def0fa287e91b) to fix a rendering error (seen [here](https://www.cockroachlabs.com/docs/v22.1/eventlog#sql-access-audit-events) in live docs),  not necessarily because the guidance was inappropriate. Please let me know if I am making the wrong call and I will instead discard this PR.
- Please let me know if there is an upstream generation script (that I am unaware of) that is otherwise responsible for the content of this page, which might need to be edited instead.

Note: I edited the `release-22.1` version in #82850, and the `release-21.2` version in #82851 to fix the broken rendering. This edit to `master` simply re-introduces the alert in same fashion.

Thank you!