### PR TITLE
cloud/gcp: support temporary token credentials for GCP storage and KMS

### DIFF
--- a/pkg/cloud/gcp/BUILD.bazel
+++ b/pkg/cloud/gcp/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "@org_golang_google_api//option",
         "@org_golang_google_genproto//googleapis/cloud/kms/v1:kms",
         "@org_golang_google_protobuf//types/known/wrapperspb",
+        "@org_golang_x_oauth2//:oauth2",
     ],
 )
 
@@ -49,6 +50,8 @@ go_test(
         "//pkg/util/leaktest",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
+        "@com_google_cloud_go_kms//apiv1",
+        "@com_google_cloud_go_storage//:storage",
         "@org_golang_google_api//impersonate",
         "@org_golang_x_oauth2//google",
     ],

--- a/pkg/cloud/gcp/gcs_kms.go
+++ b/pkg/cloud/gcp/gcs_kms.go
@@ -12,7 +12,6 @@ package gcp
 
 import (
 	"context"
-	"encoding/base64"
 	"hash/crc32"
 	"net/url"
 	"strings"
@@ -42,6 +41,7 @@ type kmsURIParams struct {
 	credentials string
 	auth        string
 	assumeRole  string
+	bearerToken string
 }
 
 func resolveKMSURIParams(kmsURI url.URL) kmsURIParams {
@@ -49,6 +49,7 @@ func resolveKMSURIParams(kmsURI url.URL) kmsURIParams {
 		credentials: kmsURI.Query().Get(CredentialsParam),
 		auth:        kmsURI.Query().Get(cloud.AuthParam),
 		assumeRole:  kmsURI.Query().Get(AssumeRoleParam),
+		bearerToken: kmsURI.Query().Get(BearerTokenParam),
 	}
 
 	return params
@@ -74,22 +75,23 @@ func MakeGCSKMS(ctx context.Context, uri string, env cloud.KMSEnv) (cloud.KMS, e
 
 	switch kmsURIParams.auth {
 	case "", cloud.AuthParamSpecified:
-		if kmsURIParams.credentials == "" {
+		if kmsURIParams.credentials != "" {
+			authOption, err := createAuthOptionFromServiceAccountKey(kmsURIParams.credentials)
+			if err != nil {
+				return nil, errors.Wrapf(err, "error getting credentials from %s", CredentialsParam)
+			}
+			credentialsOpt = append(credentialsOpt, authOption)
+		} else if kmsURIParams.bearerToken != "" {
+			credentialsOpt = append(credentialsOpt, createAuthOptionFromBearerToken(kmsURIParams.bearerToken))
+		} else {
 			return nil, errors.Errorf(
-				"%s is set to '%s', but %s is not set",
+				"%s or %s must be set if %q is %q",
+				CredentialsParam,
+				BearerTokenParam,
 				cloud.AuthParam,
 				cloud.AuthParamSpecified,
-				CredentialsParam,
 			)
 		}
-
-		// Credentials are passed in base64 encoded, so decode the credentials first.
-		credentialsJSON, err := base64.StdEncoding.DecodeString(kmsURIParams.credentials)
-		if err != nil {
-			return nil, err
-		}
-
-		credentialsOpt = append(credentialsOpt, option.WithCredentialsJSON(credentialsJSON))
 	case cloud.AuthParamImplicit:
 		if env.KMSConfig().DisableImplicitCredentials {
 			return nil, errors.New(

--- a/pkg/cloud/gcp/gcs_kms_test.go
+++ b/pkg/cloud/gcp/gcs_kms_test.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"testing"
 
+	kms "cloud.google.com/go/kms/apiv1"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -24,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2/google"
 	_ "google.golang.org/api/impersonate"
 )
 
@@ -69,7 +71,7 @@ func TestEncryptDecryptGCS(t *testing.T) {
 
 		uri := fmt.Sprintf("gs:///%s?%s", keyID, params.Encode())
 		cloud.KMSEncryptDecrypt(t, uri, &cloud.TestKMSEnv{
-			Settings:         cluster.NoSettings,
+			Settings:         cluster.MakeTestingClusterSettings(),
 			ExternalIOConfig: &base.ExternalIODirConfig{},
 		})
 	})
@@ -88,7 +90,33 @@ func TestEncryptDecryptGCS(t *testing.T) {
 
 		uri := fmt.Sprintf("gs:///%s?%s", keyID, q.Encode())
 		cloud.KMSEncryptDecrypt(t, uri, &cloud.TestKMSEnv{
-			Settings:         cluster.NoSettings,
+			Settings:         cluster.MakeTestingClusterSettings(),
+			ExternalIOConfig: &base.ExternalIODirConfig{},
+		})
+	})
+
+	t.Run("auth-specified-bearer-token", func(t *testing.T) {
+		// Fetch the base64 encoded JSON credentials.
+		credentials := os.Getenv("GOOGLE_CREDENTIALS_JSON")
+		if credentials == "" {
+			skip.IgnoreLint(t, "GOOGLE_CREDENTIALS_JSON env var must be set")
+		}
+
+		ctx := context.Background()
+		source, err := google.JWTConfigFromJSON([]byte(credentials), kms.DefaultAuthScopes()...)
+		require.NoError(t, err, "creating GCS oauth token source from specified credentials")
+		ts := source.TokenSource(ctx)
+
+		token, err := ts.Token()
+		require.NoError(t, err, "getting token")
+		q.Set(BearerTokenParam, token.AccessToken)
+
+		// Set AUTH to specified.
+		q.Set(cloud.AuthParam, cloud.AuthParamSpecified)
+
+		uri := fmt.Sprintf("gs:///%s?%s", keyID, q.Encode())
+		cloud.KMSEncryptDecrypt(t, uri, &cloud.TestKMSEnv{
+			Settings:         cluster.MakeTestingClusterSettings(),
 			ExternalIOConfig: &base.ExternalIODirConfig{},
 		})
 	})
@@ -156,7 +184,7 @@ func TestGCSKMSDisallowImplicitCredentials(t *testing.T) {
 
 	uri := fmt.Sprintf("gs:///%s?%s", keyID, q.Encode())
 	_, err := cloud.KMSFromURI(ctx, uri, &cloud.TestKMSEnv{
-		Settings:         cluster.NoSettings,
+		Settings:         cluster.MakeTestingClusterSettings(),
 		ExternalIOConfig: &base.ExternalIODirConfig{DisableImplicitCredentials: true}})
 	require.True(t, testutils.IsError(err,
 		"implicit credentials disallowed for gcs due to --external-io-implicit-credentials flag"),

--- a/pkg/cloud/gcp/gcs_storage_test.go
+++ b/pkg/cloud/gcp/gcs_storage_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"testing"
 
+	gcs "cloud.google.com/go/storage"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/cloud/cloudtestutils"
@@ -86,6 +87,42 @@ func TestPutGoogleCloud(t *testing.T) {
 				"listing-test",
 				cloud.AuthParam,
 				cloud.AuthParamImplicit,
+			),
+			username.RootUserName(), nil, nil, testSettings,
+		)
+	})
+
+	t.Run("auth-specified-bearer-token", func(t *testing.T) {
+		credentials := os.Getenv("GOOGLE_CREDENTIALS_JSON")
+		if credentials == "" {
+			skip.IgnoreLint(t, "GOOGLE_CREDENTIALS_JSON env var must be set")
+		}
+
+		ctx := context.Background()
+		source, err := google.JWTConfigFromJSON([]byte(credentials), gcs.ScopeReadWrite)
+		require.NoError(t, err, "creating GCS oauth token source from specified credentials")
+		ts := source.TokenSource(ctx)
+
+		token, err := ts.Token()
+		require.NoError(t, err, "getting token")
+
+		uri := fmt.Sprintf("gs://%s/%s?%s=%s",
+			bucket,
+			"backup-test-specified",
+			BearerTokenParam,
+			token.AccessToken,
+		)
+		uri += fmt.Sprintf("&%s=%s", cloud.AuthParam, cloud.AuthParamSpecified)
+		cloudtestutils.CheckExportStore(t, uri, false, user, nil, nil, testSettings)
+		cloudtestutils.CheckListFiles(t,
+			fmt.Sprintf("gs://%s/%s/%s?%s=%s&%s=%s",
+				bucket,
+				"backup-test-specified",
+				"listing-test",
+				cloud.AuthParam,
+				cloud.AuthParamSpecified,
+				BearerTokenParam,
+				token.AccessToken,
 			),
 			username.RootUserName(), nil, nil, testSettings,
 		)

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -1445,6 +1445,12 @@ message ExternalStorage {
     // AssumeRole if non-empty, is the email of the service account that should
     // be assumed in order to access this storage.
     string assume_role = 6;
+
+    // BearerToken is a temporary bearer token that could be used to access the
+    // storage. This token is only used for "specified" auth mode and if
+    // Credentials is not supplied. Currently only OAuth 2.0 tokens are
+    // supported.
+    string bearer_token = 7;
   }
   message Azure {
     string container = 1;


### PR DESCRIPTION
Previously, the "specified" authentication method for GCP only allowed the
usage of the credentials JSON, which was a form of long-lived credentials,
with no short-lived alternative. This patch adds the ability to provide
short-lived OAuth 2.0 tokens as credentials through the new ACCESS_TOKEN
parameter.

Release note (enterprise change): Adds the ability to provide short-lived
OAuth 2.0 tokens as a form of short-lived credentials to Google Cloud Storage
and KMS. The token can be passed to the GCS or KMS URI via the new
ACCESS_TOKEN parameter for "specified" authentication mode.

Example GCS URI: gs://<bucket>/<key>?AUTH=specified&ACCESS_TOKEN=<token>
Example KMS URI: gs:///<key_resource>?AUTH=specified&ACCESS_TOKEN=<token>

There is no refresh mechanism associated with this token, so it is up to the
user to ensure that its TTL is longer than the duration of the job or query
that is using the token. The job or query may irrecoverably fail if one of its
access tokens expire before completion.