### PR TITLE
release-22.1: changefeedccl: Do not inhibit node shutdown

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -213,16 +213,13 @@ func (ca *changeAggregator) MustBeStreaming() bool {
 
 // Start is part of the RowSource interface.
 func (ca *changeAggregator) Start(ctx context.Context) {
+	// Derive a separate context so that we can shutdown the poller.
+	ctx, ca.cancel = ca.flowCtx.Stopper().WithCancelOnQuiesce(ctx)
+
 	if ca.spec.JobID != 0 {
 		ctx = logtags.AddTag(ctx, "job", ca.spec.JobID)
 	}
 	ctx = ca.StartInternal(ctx, changeAggregatorProcName)
-
-	// Derive a separate context so that we can shutdown the poller. Note that
-	// we need to update both ctx (used throughout this function) and
-	// ProcessorBase.Ctx (used in all other methods) to the new context.
-	ctx, ca.cancel = context.WithCancel(ctx)
-	ca.Ctx = ctx
 
 	initialHighWater, needsInitialScan := getKVFeedInitialParameters(ca.spec)
 

--- a/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/clusterversion",
         "//pkg/jobs/joberror",
         "//pkg/jobs/jobspb",
+        "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/sql",
         "//pkg/sql/catalog",

--- a/pkg/ccl/changefeedccl/changefeedbase/errors.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/errors.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/joberror"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/errors"
 )
@@ -117,7 +118,9 @@ func IsRetryableError(err error) bool {
 		return true
 	}
 
-	return (joberror.IsDistSQLRetryableError(err) || flowinfra.IsNoInboundStreamConnectionError(err))
+	return (joberror.IsDistSQLRetryableError(err) ||
+		flowinfra.IsNoInboundStreamConnectionError(err) ||
+		errors.HasType(err, (*roachpb.NodeUnavailableError)(nil)))
 }
 
 // MaybeStripRetryableErrorMarker performs some minimal attempt to clean the


### PR DESCRIPTION
Backport 2/2 commits from #82768.

/cc @cockroachdb/release

---

See individual commits for details:
  * Ensure running changefeed do not inhibit node shutdown (Informs #82765)
  * Treat node unavailable error as retryable.

Test not being merged as part of this PR -- see https://github.com/cockroachdb/cockroach/pull/82767

Release Notes (bug fix): Ensure running changefeeds do
not inhibit node shutdown.
Release Notes (bug fix): Treat node unavailable error as a retryable changefeed error.

Release Justification: Bug fix