### PR TITLE
log: embed error hints in unstructured entries

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -181,7 +181,8 @@ func initTraceDir(ctx context.Context, dir string) {
 		// to the current directory (.). If running the process
 		// from a directory which is not writable, we won't
 		// be able to create a sub-directory here.
-		log.Warningf(ctx, "cannot create trace dir; traces will not be dumped: %+v", err)
+		err = errors.WithHint(err, "Try changing the CWD of the cockroach process to a writable directory.")
+		log.Warningf(ctx, "cannot create trace dir; traces will not be dumped: %v", err)
 		return
 	}
 }


### PR DESCRIPTION
Fixes #80875.
cc @dhartunian 

With this commit, if a `log.Infof` (or warning, error, fatal etc) call
is passed an `error` object as argument, and that error object
contains hints, the hints are copied into the resulting log entry and
emitted to the sink.

At this time, we only have hints in very few places. This change is
thus merely infrastructure that will promote the implementation of
hints over time.

Example, before:
```
W220614 15:55:33.935575 1 cli/start.go:184  [n?] 5  cannot create trace dir; traces will not be dumped: mkdir inflight_trace_dump: permission denied
```

Example, after:
```
W220614 15:57:58.669410 1 cli/start.go:185  [n?] 5  cannot create trace dir; traces will not be dumped: mkdir inflight_trace_dump: permission denied
W220614 15:57:58.669410 1 cli/start.go:185  [n?] 5 +HINT: Try changing the CWD of the cockroach process to a writable directory.
```

Release note (cli change): In some cases, CockroachDB will now include
recommended remediation actions alongside log messages. We expect more
suggestions to be added in later versions.