### PR TITLE
pkg/util/log: enable buffering by default for fluent/http sinks

### DIFF
--- a/pkg/cli/log_flags_test.go
+++ b/pkg/cli/log_flags_test.go
@@ -42,7 +42,9 @@ func TestSetupLogging(t *testing.T) {
 		`format: json-fluent-compact, ` +
 		`redactable: true, ` +
 		`exit-on-error: false, ` +
-		`buffering: NONE}`
+		`buffering: {max-staleness: 5s, ` +
+		`flush-trigger-size: 1.0MiB, ` +
+		`max-buffer-size: 50MiB}}`
 	const defaultHTTPConfig = `http-defaults: {` +
 		`method: POST, ` +
 		`unsafe-tls: false, ` +
@@ -52,7 +54,9 @@ func TestSetupLogging(t *testing.T) {
 		`format: json-compact, ` +
 		`redactable: true, ` +
 		`exit-on-error: false, ` +
-		`buffering: NONE}`
+		`buffering: {max-staleness: 5s, ` +
+		`flush-trigger-size: 1.0MiB, ` +
+		`max-buffer-size: 50MiB}}`
 	stdFileDefaultsRe := regexp.MustCompile(
 		`file-defaults: \{` +
 			`dir: (?P<path>[^,]+), ` +

--- a/pkg/util/log/fluent_client_test.go
+++ b/pkg/util/log/fluent_client_test.go
@@ -44,10 +44,24 @@ func TestFluentClient(t *testing.T) {
 	// Set up a logging configuration with the server we've just set up
 	// as target for the OPS channel.
 	cfg := logconfig.DefaultConfig()
+	zeroBytes := logconfig.ByteSize(0)
+	zeroDuration := time.Duration(0)
 	cfg.Sinks.FluentServers = map[string]*logconfig.FluentSinkConfig{
 		"ops": {
 			Address:  serverAddr,
-			Channels: logconfig.SelectChannels(channel.OPS)},
+			Channels: logconfig.SelectChannels(channel.OPS),
+			FluentDefaults: logconfig.FluentDefaults{
+				CommonSinkConfig: logconfig.CommonSinkConfig{
+					Buffering: logconfig.CommonBufferSinkConfigWrapper{
+						CommonBufferSinkConfig: logconfig.CommonBufferSinkConfig{
+							MaxStaleness:     &zeroDuration,
+							FlushTriggerSize: &zeroBytes,
+							MaxBufferSize:    &zeroBytes,
+						},
+					},
+				},
+			},
+		},
 	}
 	// Derive a full config using the same directory as the
 	// TestLogScope.
@@ -80,7 +94,7 @@ func TestFluentClient(t *testing.T) {
 	msg, err := json.Marshal(info)
 	require.NoError(t, err)
 
-	const expected = `{"c":1,"f":"util/log/fluent_client_test.go","g":222,"l":63,"message":"hello world","n":1,"r":1,"s":1,"sev":"I","t":"XXX","tag":"logtest.ops","v":"v999.0.0"}`
+	const expected = `{"c":1,"f":"util/log/fluent_client_test.go","g":222,"l":77,"message":"hello world","n":1,"r":1,"s":1,"sev":"I","t":"XXX","tag":"logtest.ops","v":"v999.0.0"}`
 	require.Equal(t, expected, string(msg))
 }
 

--- a/pkg/util/log/http_sink_test.go
+++ b/pkg/util/log/http_sink_test.go
@@ -29,6 +29,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	zeroBytes            = logconfig.ByteSize(0)
+	zeroDuration         = time.Duration(0)
+	disabledBufferingCfg = logconfig.CommonBufferSinkConfigWrapper{
+		CommonBufferSinkConfig: logconfig.CommonBufferSinkConfig{
+			MaxStaleness:     &zeroDuration,
+			FlushTriggerSize: &zeroBytes,
+			MaxBufferSize:    &zeroBytes,
+		},
+	}
+)
+
 // testBase sets the provided HTTPDefaults, logs "hello World", captures the
 // resulting request to the server, and validates the body with the provided
 // requestTestFunc.
@@ -173,6 +185,9 @@ func TestMessageReceived(t *testing.T) {
 		// We need to disable keepalives otherwise the HTTP server in the
 		// test will let an async goroutine run waiting for more requests.
 		DisableKeepAlives: &tb,
+		CommonSinkConfig: logconfig.CommonSinkConfig{
+			Buffering: disabledBufferingCfg,
+		},
 	}
 
 	testFn := func(_ http.Header, body string) error {
@@ -201,6 +216,9 @@ func TestHTTPSinkTimeout(t *testing.T) {
 		// We need to disable keepalives otherwise the HTTP server in the
 		// test will let an async goroutine run waiting for more requests.
 		DisableKeepAlives: &tb,
+		CommonSinkConfig: logconfig.CommonSinkConfig{
+			Buffering: disabledBufferingCfg,
+		},
 	}
 
 	testBase(t, defaults, nil /* testFn */, true /* hangServer */, 500*time.Millisecond)
@@ -224,7 +242,8 @@ func TestHTTPSinkContentTypeJSON(t *testing.T) {
 		// test will let an async goroutine run waiting for more requests.
 		DisableKeepAlives: &tb,
 		CommonSinkConfig: logconfig.CommonSinkConfig{
-			Format: &format,
+			Format:    &format,
+			Buffering: disabledBufferingCfg,
 		},
 	}
 
@@ -258,7 +277,8 @@ func TestHTTPSinkContentTypePlainText(t *testing.T) {
 		// test will let an async goroutine run waiting for more requests.
 		DisableKeepAlives: &tb,
 		CommonSinkConfig: logconfig.CommonSinkConfig{
-			Format: &format,
+			Format:    &format,
+			Buffering: disabledBufferingCfg,
 		},
 	}
 

--- a/pkg/util/log/logconfig/config.go
+++ b/pkg/util/log/logconfig/config.go
@@ -60,6 +60,19 @@ fluent-defaults:
     format: ` + DefaultFluentFormat + `
     redactable: true
     exit-on-error: false
+    buffering:
+      max-staleness: 5s
+      flush-trigger-size: 1mib
+      max-buffer-size: 50mib
+http-defaults:
+    filter: INFO
+    format: ` + DefaultHTTPFormat + `
+    redactable: true
+    exit-on-error: false
+    buffering:
+      max-staleness: 5s	
+      flush-trigger-size: 1mib
+      max-buffer-size: 50mib
 sinks:
   stderr:
     filter: NONE

--- a/pkg/util/log/logconfig/testdata/validate
+++ b/pkg/util/log/logconfig/testdata/validate
@@ -99,7 +99,10 @@ sinks:
       redact: false
       redactable: true
       exit-on-error: false
-      buffering: NONE
+      buffering:
+        max-staleness: 5s
+        flush-trigger-size: 1.0MiB
+        max-buffer-size: 50MiB
   stderr:
     filter: NONE
 capture-stray-errors:
@@ -171,7 +174,10 @@ sinks:
       redact: false
       redactable: true
       exit-on-error: true
-      buffering: NONE
+      buffering:
+        max-staleness: 5s
+        flush-trigger-size: 1.0MiB
+        max-buffer-size: 50MiB
   stderr:
     filter: NONE
 capture-stray-errors:

--- a/pkg/util/log/logconfig/validate.go
+++ b/pkg/util/log/logconfig/validate.go
@@ -39,6 +39,9 @@ func (c *Config) Validate(defaultLogDir *string) (resErr error) {
 	bt, bf := true, false
 	zeroDuration := time.Duration(0)
 	zeroByteSize := ByteSize(0)
+	defaultBufferedStaleness := 5 * time.Second
+	defaultFlushTriggerSize := ByteSize(1024 * 1024)   // 1mib
+	defaultMaxBufferSize := ByteSize(50 * 1024 * 1024) // 50mib
 
 	baseCommonSinkConfig := CommonSinkConfig{
 		Filter:      logpb.Severity_INFO,
@@ -48,10 +51,6 @@ func (c *Config) Validate(defaultLogDir *string) (resErr error) {
 		Criticality: &bf,
 		// Buffering is configured to "NONE". This is different from a zero value
 		// which buffers infinitely.
-		//
-		// TODO(andrei,alexb): Enable buffering by default for some sinks once the
-		// shutdown of the bufferedSink is improved. Note that baseFileDefaults
-		// below does not inherit the buffering settings from here.
 		Buffering: CommonBufferSinkConfigWrapper{
 			CommonBufferSinkConfig: CommonBufferSinkConfig{
 				MaxStaleness:     &zeroDuration,
@@ -84,11 +83,25 @@ func (c *Config) Validate(defaultLogDir *string) (resErr error) {
 	baseFluentDefaults := FluentDefaults{
 		CommonSinkConfig: CommonSinkConfig{
 			Format: func() *string { s := DefaultFluentFormat; return &s }(),
+			Buffering: CommonBufferSinkConfigWrapper{
+				CommonBufferSinkConfig: CommonBufferSinkConfig{
+					MaxStaleness:     &defaultBufferedStaleness,
+					FlushTriggerSize: &defaultFlushTriggerSize,
+					MaxBufferSize:    &defaultMaxBufferSize,
+				},
+			},
 		},
 	}
 	baseHTTPDefaults := HTTPDefaults{
 		CommonSinkConfig: CommonSinkConfig{
 			Format: func() *string { s := DefaultHTTPFormat; return &s }(),
+			Buffering: CommonBufferSinkConfigWrapper{
+				CommonBufferSinkConfig: CommonBufferSinkConfig{
+					MaxStaleness:     &defaultBufferedStaleness,
+					FlushTriggerSize: &defaultFlushTriggerSize,
+					MaxBufferSize:    &defaultMaxBufferSize,
+				},
+			},
 		},
 		UnsafeTLS:         &bf,
 		DisableKeepAlives: &bf,

--- a/pkg/util/log/testdata/config
+++ b/pkg/util/log/testdata/config
@@ -79,6 +79,55 @@ sinks:
       redact: false
       redactable: true
       exit-on-error: false
+      buffering:
+        max-staleness: 5s
+        flush-trigger-size: 1.0MiB
+        max-buffer-size: 50MiB
+  stderr:
+    format: crdb-v2-tty
+    redact: false
+    redactable: true
+    exit-on-error: true
+capture-stray-errors:
+  enable: true
+  dir: TMPDIR
+  max-group-size: 100MiB
+
+# Test the default config with an http server.
+yaml
+sinks:
+ http-servers: {local: {channels: SESSIONS, address: localhost:5170}}
+----
+sinks:
+  file-groups:
+    default:
+      channels: {INFO: all}
+      dir: TMPDIR
+      max-file-size: 10MiB
+      max-group-size: 100MiB
+      buffered-writes: true
+      format: crdb-v2
+      redact: false
+      redactable: true
+      exit-on-error: true
+  http-servers:
+    s1:
+      channels: {INFO: [SESSIONS]}
+      address: localhost:5170
+      method: POST
+      unsafe-tls: false
+      timeout: 0s
+      disable-keep-alives: false
+      filter: INFO
+      format: json-compact
+      redact: false
+      redactable: true
+      exit-on-error: false
+      auditable: false
+      buffering:
+        max-staleness: 5s
+        flush-trigger-size: 1.0MiB
+        max-buffer-size: 50MiB
   stderr:
     format: crdb-v2-tty
     redact: false


### PR DESCRIPTION
This patch updates the default `httpSink` and `fluentSink` configuration
to enable buffering with a `max-staleness` of 5 seconds, `trigger-size` of
1MiB, and `max-buffer-size` of 50MiB.

It's been identified that unavailable fluentd/http addresses, when
part of an un-buffered `fluentSink` or `httpSink`, can lead to
nodes becoming unavailable due to hanging synchronous requests to
write logs to the sink target. With a newly improved `bufferedSink`
wrapper, we should now enable buffering by default for these network
sinks to avoid this possibility.

Network sinks can still disable buffering via the `buffering: NONE`
option being set on the sink in the log config YAML.

Note that this will also affect the output of `debug check-log-config`.

Finally, the `DescribeAppliedConfig()` function previously did not
include any information about configured `httpSink`'s in its output.
This is incorrect behavior and a fix was required to verify the default
buffering config was being applied to http sinks successfully. Therefore,
this patch also updates `DescribeAppliedConfig()` to include descriptions
of http sinks.

Release note (ops change): `httpSink`'s and `fluentSinks`'s will now,
by default, have buffered writes enabled. This means that writes to these
sinks will be asynchronous. This is enabled via a new default `buffering`
configuration for both the `httpSink` and `fluentSink`, where the default
values are as follows:

```
buffering:
    // The maximum amount of time between flushes to the underlying
    // http or fluent sink.
    max-staleness: 5s
    // `flush-trigger-size` is the size in bytes of accumulated messages
    //  in the buffer which will trigger a flush. 0 disables this trigger.
    flush-trigger-size: 1MiB
    // `max-buffer-size` limits the size of the buffer. When a new message
    // is causing the buffer to overflow beyond this limit, old messages
    // are dropped
    max-buffer-size: 50MiB
```
This will show in `debug check-log-config` as well as impact the default
behavior of these two types of network sinks.
