### PR TITLE
ui: Sinon refactor jest mocks

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.spec.tsx
@@ -12,7 +12,6 @@ import React from "react";
 import _ from "lodash";
 import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
-import * as sinon from "sinon";
 import classNames from "classnames/bind";
 import {
   SortedTable,
@@ -25,7 +24,7 @@ import styles from "src/sortabletable/sortabletable.module.scss";
 const cx = classNames.bind(styles);
 
 class TestRow {
-  constructor(public name: string, public value: number) {}
+  constructor(public name: string, public value: number) { }
 }
 
 const columns: ColumnDescriptor<TestRow>[] = [
@@ -44,7 +43,7 @@ const columns: ColumnDescriptor<TestRow>[] = [
   },
 ];
 
-class TestSortedTable extends SortedTable<TestRow> {}
+class TestSortedTable extends SortedTable<TestRow> { }
 
 function makeTable(
   data: TestRow[],
@@ -99,17 +98,17 @@ describe("<SortedTable>", function () {
   });
 
   it("correctly uses onChangeSortSetting", function () {
-    const spy = sinon.spy();
+    const spy = jest.fn();
     const wrapper = makeTable([new TestRow("test", 1)], undefined, spy);
     wrapper
       .find(`th.${cx("head-wrapper__cell")}`)
       .first()
       .simulate("click");
-    assert.isTrue(spy.calledOnce);
-    assert.deepEqual(spy.getCall(0).args[0], {
+    expect(spy).toHaveBeenCalled()
+    expect(spy).toHaveBeenCalledWith({
       ascending: false,
       columnTitle: "first",
-    } as SortSetting);
+    })
   });
 
   it("correctly sorts data based on sortSetting", function () {

--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.spec.tsx
@@ -24,7 +24,7 @@ import styles from "src/sortabletable/sortabletable.module.scss";
 const cx = classNames.bind(styles);
 
 class TestRow {
-  constructor(public name: string, public value: number) { }
+  constructor(public name: string, public value: number) {}
 }
 
 const columns: ColumnDescriptor<TestRow>[] = [
@@ -43,7 +43,7 @@ const columns: ColumnDescriptor<TestRow>[] = [
   },
 ];
 
-class TestSortedTable extends SortedTable<TestRow> { }
+class TestSortedTable extends SortedTable<TestRow> {}
 
 function makeTable(
   data: TestRow[],
@@ -104,11 +104,11 @@ describe("<SortedTable>", function () {
       .find(`th.${cx("head-wrapper__cell")}`)
       .first()
       .simulate("click");
-    expect(spy).toHaveBeenCalled()
+    expect(spy).toHaveBeenCalled();
     expect(spy).toHaveBeenCalledWith({
       ascending: false,
       columnTitle: "first",
-    })
+    });
   });
 
   it("correctly sorts data based on sortSetting", function () {

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.spec.tsx
@@ -11,7 +11,6 @@
 import React from "react";
 import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
-import sinon from "sinon";
 import Long from "long";
 import { MemoryRouter } from "react-router-dom";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
@@ -23,8 +22,6 @@ import { TestStoreProvider } from "src/test-utils";
 
 type IStatementDiagnosticsReport =
   cockroach.server.serverpb.IStatementDiagnosticsReport;
-
-const sandbox = sinon.createSandbox();
 
 const activateDiagnosticsRef = { current: { showModalFor: jest.fn() } };
 
@@ -46,10 +43,6 @@ function generateDiagnosticsRequest(
 describe("DiagnosticsView", () => {
   let wrapper: ReactWrapper;
   const statementFingerprint = "some-id";
-
-  beforeEach(() => {
-    sandbox.reset();
-  });
 
   describe("With Empty state", () => {
     beforeEach(() => {

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.spec.tsx
@@ -59,7 +59,7 @@ describe("StatementDetails page", () => {
   });
 
   it("calls onTabChanged prop when selected tab is changed", () => {
-    const onTabChangeSpy = sandbox.spy();
+    const onTabChangeSpy = jest.fn();
     const wrapper = mount(
       <Router>
         <StatementDetails
@@ -75,7 +75,7 @@ describe("StatementDetails page", () => {
       .last()
       .simulate("click");
 
-    onTabChangeSpy.calledWith("execution-stats");
+    expect(onTabChangeSpy).toHaveBeenCalledWith("execution-stats");
   });
 
   describe("Diagnostics tab", () => {
@@ -87,6 +87,7 @@ describe("StatementDetails page", () => {
 
     it("calls createStatementDiagnosticsReport callback on Activate button click", () => {
       const onDiagnosticsActivateClickSpy = sandbox.spy();
+
       const wrapper = mount(
         <Router>
           <StatementDetails

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.spec.tsx
@@ -75,7 +75,7 @@ describe("StatementDetails page", () => {
       .last()
       .simulate("click");
 
-    expect(onTabChangeSpy).toHaveBeenCalledWith("execution-stats");
+    expect(onTabChangeSpy).toHaveBeenCalledWith("diagnostics");
   });
 
   describe("Diagnostics tab", () => {

--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScaleDropdown.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScaleDropdown.spec.tsx
@@ -25,7 +25,6 @@ import TimeFrameControls from "./timeFrameControls";
 import RangeSelect from "./rangeSelect";
 import { timeFormat as customMenuTimeFormat } from "../dateRangeMenu";
 import { assert } from "chai";
-import sinon from "sinon";
 import { TimeWindow, ArrowDirection, TimeScale } from "./timeScaleTypes";
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -56,7 +55,7 @@ function TimeScaleDropdownWrapper({
 }
 
 describe("<TimeScaleDropdown> component", function () {
-  let clock: sinon.SinonFakeTimers;
+  jest.useFakeTimers("modern");
 
   // Returns a new moment every time, so that we don't accidentally mutate it.
   const getNow = () => {
@@ -87,11 +86,7 @@ describe("<TimeScaleDropdown> component", function () {
   };
 
   beforeEach(() => {
-    clock = sinon.useFakeTimers(getNow().toDate());
-  });
-
-  afterEach(() => {
-    clock.restore();
+    jest.setSystemTime(getNow().toDate());
   });
 
   it("updates as different preset options are selected", () => {
@@ -249,8 +244,8 @@ const initialEntries = [
 ];
 
 describe("TimeScaleDropdown functions", function () {
+  jest.useFakeTimers("modern");
   let state: Omit<TimeScaleDropdownProps, "setTimeScale">;
-  let clock: sinon.SinonFakeTimers;
   let currentWindow: TimeWindow;
 
   const setCurrentWindowFromTimeScale = (timeScale: TimeScale): void => {
@@ -273,17 +268,13 @@ describe("TimeScaleDropdown functions", function () {
   };
 
   beforeEach(() => {
-    clock = sinon.useFakeTimers(new Date(2020, 5, 1, 9, 28, 30));
+    jest.setSystemTime(new Date(2020, 5, 1, 9, 28, 30));
     const timeScaleState = new timescale.TimeScaleState();
     setCurrentWindowFromTimeScale(timeScaleState.scale);
     state = {
       currentScale: timeScaleState.scale,
       // setTimeScale: () => {},
     };
-  });
-
-  afterEach(() => {
-    clock.restore();
   });
 
   it("valid path should not redirect to 404", () => {

--- a/pkg/ui/workspaces/db-console/src/redux/customAnalytics/customAnalyticsSagas.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/customAnalytics/customAnalyticsSagas.spec.ts
@@ -9,22 +9,15 @@
 // licenses/APL.txt.
 
 import { expectSaga } from "redux-saga-test-plan";
-import sinon from "sinon";
 import Analytics from "analytics-node";
 
 import { signUpEmailSubscription } from "./customAnalyticsSagas";
 import { signUpForEmailSubscription } from "./customAnanlyticsActions";
 
-const sandbox = sinon.createSandbox();
-
 describe("customAnalyticsSagas", () => {
   describe("signUpEmailSubscription generator", () => {
-    afterEach(() => {
-      sandbox.reset();
-    });
-
     it("calls analytics#identify with user email in args ", () => {
-      const analyticsIdentifyFn = sandbox.stub(Analytics.prototype, "identify");
+      const analyticsIdentifyFn = jest.spyOn(Analytics.prototype, "identify");
       const clusterId = "cluster-1";
       const email = "foo@bar.com";
       const action = signUpForEmailSubscription(clusterId, email);
@@ -33,13 +26,14 @@ describe("customAnalyticsSagas", () => {
         .dispatch(action)
         .run()
         .then(() => {
-          const expectedAnalyticsMessage = {
-            userId: clusterId,
-            traits: {
-              email,
-            },
-          };
-          analyticsIdentifyFn.calledOnceWith(expectedAnalyticsMessage);
+          expect(analyticsIdentifyFn).toHaveBeenCalledWith(
+            expect.objectContaining({
+              userId: clusterId,
+              traits: expect.objectContaining({
+                email,
+              }),
+            }),
+          );
         });
     });
   });

--- a/pkg/ui/workspaces/db-console/src/util/analytics/trackActivateDiagnostics.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/analytics/trackActivateDiagnostics.spec.ts
@@ -9,29 +9,22 @@
 // licenses/APL.txt.
 
 import { get, isString } from "lodash";
-import { createSandbox } from "sinon";
 import { track } from "./trackActivateDiagnostics";
 
-const sandbox = createSandbox();
-
 describe("trackActivateDiagnostics", () => {
-  afterEach(() => {
-    sandbox.reset();
-  });
-
   it("should only call track once", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     track(spy)("some statement");
-    expect(spy.calledOnce).toBe(true);
+    expect(spy).toHaveBeenCalled();
   });
 
   it("should send the right event", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     const expected = "Diagnostics Activation";
 
     track(spy)("whatever");
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const event = get(sent, "event");
 
     expect(isString(event)).toBe(true);
@@ -39,12 +32,12 @@ describe("trackActivateDiagnostics", () => {
   });
 
   it("should send the correct payload", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     const statement = "SELECT blah from blah-blah";
 
     track(spy)(statement);
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const fingerprint = get(sent, "properties.fingerprint");
 
     expect(isString(fingerprint)).toBe(true);

--- a/pkg/ui/workspaces/db-console/src/util/analytics/trackCancelDiagnosticsBundle.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/analytics/trackCancelDiagnosticsBundle.spec.ts
@@ -9,29 +9,22 @@
 // licenses/APL.txt.
 
 import { get, isString } from "lodash";
-import { createSandbox } from "sinon";
 import { track } from "./trackCancelDiagnosticsBundle";
 
-const sandbox = createSandbox();
-
 describe("trackCancelDiagnosticsBundle", () => {
-  afterEach(() => {
-    sandbox.reset();
-  });
-
   it("should only call track once", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     track(spy)("some statement");
-    expect(spy.calledOnce).toBe(true);
+    expect(spy).toHaveBeenCalled();
   });
 
   it("should send the right event", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     const expected = "Diagnostics Bundle Cancellation";
 
     track(spy)("whatever");
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const event = get(sent, "event");
 
     expect(isString(event)).toBe(true);
@@ -39,12 +32,12 @@ describe("trackCancelDiagnosticsBundle", () => {
   });
 
   it("should send the correct payload", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     const statement = "SELECT blah from blah-blah";
 
     track(spy)(statement);
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const fingerprint = get(sent, "properties.fingerprint");
 
     expect(isString(fingerprint)).toBe(true);

--- a/pkg/ui/workspaces/db-console/src/util/analytics/trackCollapseNodes.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/analytics/trackCollapseNodes.spec.ts
@@ -9,42 +9,35 @@
 // licenses/APL.txt.
 
 import { get } from "lodash";
-import { createSandbox } from "sinon";
 import { track } from "./trackCollapseNodes";
-
-const sandbox = createSandbox();
 
 describe("trackCollapseNodes", () => {
   const testCollapsed = true;
 
-  afterEach(() => {
-    sandbox.reset();
-  });
-
   it("should only call track once", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     track(spy)(testCollapsed);
-    expect(spy.calledOnce).toBe(true);
+    expect(spy).toHaveBeenCalled();
   });
 
   it("should send the right event", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     const expected = "Collapse Nodes";
 
     track(spy)(testCollapsed);
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const event = get(sent, "event");
 
     expect(event === expected).toBe(true);
   });
 
   it("should send the correct payload", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
 
     track(spy)(testCollapsed);
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const collapsed = get(sent, "properties.collapsed");
 
     expect(collapsed === testCollapsed).toBe(true);

--- a/pkg/ui/workspaces/db-console/src/util/analytics/trackDiagnosticsModalOpen.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/analytics/trackDiagnosticsModalOpen.spec.ts
@@ -9,29 +9,22 @@
 // licenses/APL.txt.
 
 import { get, isString } from "lodash";
-import { createSandbox } from "sinon";
 import { track } from "./trackDiagnosticsModalOpen";
 
-const sandbox = createSandbox();
-
 describe("trackDiagnosticsModalOpen", () => {
-  afterEach(() => {
-    sandbox.reset();
-  });
-
   it("should only call track once", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     track(spy)("some statement");
-    expect(spy.calledOnce).toBe(true);
+    expect(spy).toHaveBeenCalled();
   });
 
   it("should send a track call with the correct event", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     const expected = "Diagnostics Modal Open";
 
     track(spy)("some statement");
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const event = get(sent, "event");
 
     expect(isString(event)).toBe(true);
@@ -39,12 +32,12 @@ describe("trackDiagnosticsModalOpen", () => {
   });
 
   it("send the correct payload", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     const statement = "SELECT blah from blah-blah";
 
     track(spy)(statement);
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const fingerprint = get(sent, "properties.fingerprint");
 
     expect(isString(fingerprint)).toBe(true);

--- a/pkg/ui/workspaces/db-console/src/util/analytics/trackDocsLink.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/analytics/trackDocsLink.spec.ts
@@ -9,42 +9,35 @@
 // licenses/APL.txt.
 
 import { get } from "lodash";
-import { createSandbox } from "sinon";
 import { track } from "./trackDocsLink";
-
-const sandbox = createSandbox();
 
 describe("trackDocsLink", () => {
   const targetText = "Test target";
 
-  afterEach(() => {
-    sandbox.reset();
-  });
-
   it("should only call track once", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     track(spy)(targetText);
-    expect(spy.calledOnce).toBe(true);
+    expect(spy).toHaveBeenCalled();
   });
 
   it("should send the right event", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     const expected = "Link to Docs";
 
     track(spy)(targetText);
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const event = get(sent, "event");
 
     expect(event === expected).toBe(true);
   });
 
   it("should send the correct payload", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
 
     track(spy)(targetText);
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const linkText = get(sent, "properties.linkText");
 
     expect(linkText === targetText).toBe(true);

--- a/pkg/ui/workspaces/db-console/src/util/analytics/trackDownloadDiagnosticsBundle.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/analytics/trackDownloadDiagnosticsBundle.spec.ts
@@ -9,29 +9,22 @@
 // licenses/APL.txt.
 
 import { get, isString } from "lodash";
-import { createSandbox } from "sinon";
 import { track } from "./trackDownloadDiagnosticsBundle";
 
-const sandbox = createSandbox();
-
 describe("trackDownloadDiagnosticsBundle", () => {
-  afterEach(() => {
-    sandbox.reset();
-  });
-
   it("should only call track once", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     track(spy)("some statement");
-    expect(spy.calledOnce).toBe(true);
+    expect(spy).toHaveBeenCalled();
   });
 
   it("should send the right event", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     const expected = "Diagnostics Bundle Download";
 
     track(spy)("whatever");
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const event = get(sent, "event");
 
     expect(isString(event)).toBe(true);
@@ -39,12 +32,12 @@ describe("trackDownloadDiagnosticsBundle", () => {
   });
 
   it("should send the correct payload", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     const statement = "SELECT blah from blah-blah";
 
     track(spy)(statement);
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const fingerprint = get(sent, "properties.fingerprint");
 
     expect(isString(fingerprint)).toBe(true);

--- a/pkg/ui/workspaces/db-console/src/util/analytics/trackFilter.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/analytics/trackFilter.spec.ts
@@ -9,43 +9,36 @@
 // licenses/APL.txt.
 
 import { get } from "lodash";
-import { createSandbox } from "sinon";
 import { track } from "./trackFilter";
-
-const sandbox = createSandbox();
 
 describe("trackFilter", () => {
   const filter = "Test";
   const filterValue = "test-value";
 
-  afterEach(() => {
-    sandbox.reset();
-  });
-
   it("should only call track once", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     track(spy)(filter, filterValue);
-    expect(spy.calledOnce).toBe(true);
+    expect(spy).toHaveBeenCalled();
   });
 
   it("should send a track call with the correct event", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     const expected = "Test Filter";
 
     track(spy)(filter, filterValue);
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const event = get(sent, "event");
 
     expect(event === expected).toBe(true);
   });
 
   it("send the correct payload", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
 
     track(spy)(filter, filterValue);
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const selectedFilter = get(sent, "properties.selectedFilter");
 
     expect(selectedFilter === filterValue).toBe(true);

--- a/pkg/ui/workspaces/db-console/src/util/analytics/trackNetworkSort.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/analytics/trackNetworkSort.spec.ts
@@ -9,42 +9,35 @@
 // licenses/APL.txt.
 
 import { get } from "lodash";
-import { createSandbox } from "sinon";
 import { track } from "./trackNetworkSort";
-
-const sandbox = createSandbox();
 
 describe("trackNetworkSort", () => {
   const sortBy = "Test";
 
-  afterEach(() => {
-    sandbox.reset();
-  });
-
   it("should only call track once", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     track(spy)(sortBy);
-    expect(spy.calledOnce).toBe(true);
+    expect(spy).toHaveBeenCalled();
   });
 
   it("should send the right event", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     const expected = "Sort Network Diagnostics";
 
     track(spy)(sortBy);
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const event = get(sent, "event");
 
     expect(event === expected).toBe(true);
   });
 
   it("should send the correct payload", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
 
     track(spy)(sortBy);
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const sortedBy = get(sent, "properties.sortBy");
 
     expect(sortedBy === sortBy).toBe(true);

--- a/pkg/ui/workspaces/db-console/src/util/analytics/trackPaginate.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/analytics/trackPaginate.spec.ts
@@ -9,31 +9,23 @@
 // licenses/APL.txt.
 
 import { get, isString, isNumber } from "lodash";
-import { createSandbox } from "sinon";
 import { track } from "./trackPaginate";
-
-const sandbox = createSandbox();
 
 describe("trackPaginate", () => {
   const testPage = 5;
-
-  afterEach(() => {
-    sandbox.reset();
-  });
-
   it("should only call track once", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     track(spy)(testPage);
-    expect(spy.calledOnce).toBe(true);
+    expect(spy).toHaveBeenCalled();
   });
 
   it("should send the right event", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     const expected = "Paginate";
 
     track(spy)(testPage);
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const event = get(sent, "event");
 
     expect(isString(event)).toBe(true);
@@ -41,11 +33,11 @@ describe("trackPaginate", () => {
   });
 
   it("should send the correct payload", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
 
     track(spy)(testPage);
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const selectedPage = get(sent, "properties.selectedPage");
 
     expect(isNumber(selectedPage)).toBe(true);

--- a/pkg/ui/workspaces/db-console/src/util/analytics/trackSearch.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/analytics/trackSearch.spec.ts
@@ -9,31 +9,24 @@
 // licenses/APL.txt.
 
 import { get, isString, isNumber } from "lodash";
-import { createSandbox } from "sinon";
 import { track } from "./trackSearch";
-
-const sandbox = createSandbox();
 
 describe("trackSearch", () => {
   const testSearchResults = 3;
 
-  afterEach(() => {
-    sandbox.reset();
-  });
-
   it("should only call track once", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     track(spy)(testSearchResults);
-    expect(spy.calledOnce).toBe(true);
+    expect(spy).toHaveBeenCalled();
   });
 
   it("should send the right event", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     const expected = "Search";
 
     track(spy)(testSearchResults);
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const event = get(sent, "event");
 
     expect(isString(event)).toBe(true);
@@ -41,11 +34,11 @@ describe("trackSearch", () => {
   });
 
   it("should send the correct payload", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
 
     track(spy)(testSearchResults);
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const numberOfResults = get(sent, "properties.numberOfResults");
 
     expect(isNumber(numberOfResults)).toBe(true);

--- a/pkg/ui/workspaces/db-console/src/util/analytics/trackStatementDetailsSubnavSelection.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/analytics/trackStatementDetailsSubnavSelection.spec.ts
@@ -9,42 +9,35 @@
 // licenses/APL.txt.
 
 import { get } from "lodash";
-import { createSandbox } from "sinon";
 import { track } from "./trackStatementDetailsSubnavSelection";
-
-const sandbox = createSandbox();
 
 describe("trackSubnavSelection", () => {
   const subNavKey = "subnav-test";
 
-  afterEach(() => {
-    sandbox.reset();
-  });
-
   it("should only call track once", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     track(spy)(subNavKey);
-    expect(spy.calledOnce).toBe(true);
+    expect(spy).toHaveBeenCalled();
   });
 
   it("should send a track call with the correct event", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     const expected = "SubNavigation Selection";
 
     track(spy)(subNavKey);
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const event = get(sent, "event");
 
     expect(event === expected).toBe(true);
   });
 
   it("send the correct payload", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
 
     track(spy)(subNavKey);
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const selection = get(sent, "properties.selection");
 
     expect(selection === subNavKey).toBe(true);

--- a/pkg/ui/workspaces/db-console/src/util/analytics/trackTableSort.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/analytics/trackTableSort.spec.ts
@@ -8,30 +8,23 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { get, isString } from "lodash";
-import { createSandbox } from "sinon";
+import _, { get, isString } from "lodash";
 import { track } from "./trackTableSort";
 
-const sandbox = createSandbox();
-
 describe("trackTableSort", () => {
-  afterEach(() => {
-    sandbox.reset();
-  });
-
   it("should only call track once", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     track(spy)();
-    expect(spy.calledOnce).toBe(true);
+    expect(spy).toHaveBeenCalled();
   });
 
   it("should send the right event", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     const expected = "Table Sort";
 
     track(spy)();
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const event = get(sent, "event");
 
     expect(isString(event)).toBe(true);
@@ -39,13 +32,13 @@ describe("trackTableSort", () => {
   });
 
   it("should send the correct payload", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     const tableName = "Test table";
     const title = "test";
 
     track(spy)(tableName, title, "asc");
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const table = get(sent, "properties.tableName");
     const columnName = get(sent, "properties.columnName");
     const direction = get(sent, "properties.sortDirection");

--- a/pkg/ui/workspaces/db-console/src/util/analytics/trackTimeFrameChange.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/analytics/trackTimeFrameChange.spec.ts
@@ -9,42 +9,35 @@
 // licenses/APL.txt.
 
 import { get } from "lodash";
-import { createSandbox } from "sinon";
 import { track } from "./trackTimeFrameChange";
-
-const sandbox = createSandbox();
 
 describe("trackPaginate", () => {
   const direction = "test";
 
-  afterEach(() => {
-    sandbox.reset();
-  });
-
   it("should only call track once", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     track(spy)(direction);
-    expect(spy.calledOnce).toBe(true);
+    expect(spy).toHaveBeenCalled();
   });
 
   it("should send the right event", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     const expected = "Time Frame Change";
 
     track(spy)(direction);
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const event = get(sent, "event");
 
     expect(event === expected).toBe(true);
   });
 
   it("should send the correct payload", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
 
     track(spy)(direction);
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const changeDirection = get(sent, "properties.direction");
 
     expect(changeDirection === direction).toBe(true);

--- a/pkg/ui/workspaces/db-console/src/util/analytics/trackTimeScaleOption.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/analytics/trackTimeScaleOption.spec.ts
@@ -9,42 +9,35 @@
 // licenses/APL.txt.
 
 import { get } from "lodash";
-import { createSandbox } from "sinon";
 import { track } from "./trackTimeScaleSelected";
-
-const sandbox = createSandbox();
 
 describe("trackTimeScaleSelected", () => {
   const scale = "Last 2 weeks";
 
-  afterEach(() => {
-    sandbox.reset();
-  });
-
   it("should only call track once", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     track(spy)(scale);
-    expect(spy.calledOnce).toBe(true);
+    expect(spy).toHaveBeenCalled();
   });
 
   it("should send the right event", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
     const expected = "Time Scale Selected";
 
     track(spy)(scale);
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const event = get(sent, "event");
 
     expect(event === expected).toBe(true);
   });
 
   it("should send the correct payload", () => {
-    const spy = sandbox.spy();
+    const spy = jest.fn();
 
     track(spy)(scale);
 
-    const sent = spy.getCall(0).args[0];
+    const sent = spy.mock.calls[0][0];
     const timeScale = get(sent, "properties.timeScale");
 
     expect(timeScale === scale).toBe(true);

--- a/pkg/ui/workspaces/db-console/src/views/app/containers/metricsTimeManager/metricsTimeManager.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/containers/metricsTimeManager/metricsTimeManager.spec.tsx
@@ -10,7 +10,6 @@
 
 import React from "react";
 import { shallow } from "enzyme";
-import * as sinon from "sinon";
 import moment from "moment";
 import _ from "lodash";
 
@@ -18,13 +17,16 @@ import { MetricsTimeManagerUnconnected as MetricsTimeManager } from "./";
 import * as timewindow from "src/redux/timeScale";
 
 describe("<MetricsTimeManager>", function () {
-  let spy: sinon.SinonSpy;
+  const spy = jest.fn();
   let state: timewindow.TimeScaleState;
   const now = () => moment("11-12-1955 10:04PM -0800", "MM-DD-YYYY hh:mma Z");
 
   beforeEach(function () {
-    spy = sinon.spy();
     state = new timewindow.TimeScaleState();
+  });
+
+  afterEach(() => {
+    spy.mockReset();
   });
 
   const getManager = () =>
@@ -38,8 +40,8 @@ describe("<MetricsTimeManager>", function () {
 
   it("resets time window immediately it is empty", function () {
     getManager();
-    expect(spy.calledOnce).toBe(true);
-    expect(spy.firstCall.args[0]).toEqual({
+    expect(spy).toHaveBeenCalled();
+    expect(spy.mock.calls[0][0]).toEqual({
       start: now().subtract(state.scale.windowSize),
       end: now(),
     });
@@ -52,8 +54,8 @@ describe("<MetricsTimeManager>", function () {
     };
 
     getManager();
-    expect(spy.calledOnce).toBe(true);
-    expect(spy.firstCall.args[0]).toEqual({
+    expect(spy).toHaveBeenCalled();
+    expect(spy.mock.calls[0][0]).toEqual({
       start: now().subtract(state.scale.windowSize),
       end: now(),
     });
@@ -68,8 +70,8 @@ describe("<MetricsTimeManager>", function () {
     state.metricsTime.shouldUpdateMetricsWindowFromScale = true;
 
     getManager();
-    expect(spy.calledOnce).toBe(true);
-    expect(spy.firstCall.args[0]).toEqual({
+    expect(spy).toHaveBeenCalled();
+    expect(spy.mock.calls[0][0]).toEqual({
       start: now().subtract(state.scale.windowSize),
       end: now(),
     });
@@ -83,13 +85,13 @@ describe("<MetricsTimeManager>", function () {
     };
 
     getManager();
-    expect(spy.notCalled).toBe(true);
+    expect(spy).not.toHaveBeenCalled();
 
     // Wait 11 milliseconds, then verify that window was updated.
     return new Promise<void>((resolve, _reject) => {
       setTimeout(() => {
-        expect(spy.calledOnce).toBe(true);
-        expect(spy.firstCall.args[0]).toEqual({
+        expect(spy).toHaveBeenCalled();
+        expect(spy.mock.calls[0][0]).toEqual({
           start: now().subtract(state.scale.windowSize),
           end: now(),
         });
@@ -108,7 +110,7 @@ describe("<MetricsTimeManager>", function () {
     };
 
     const manager = getManager();
-    expect(spy.notCalled).toBe(true);
+    expect(spy).not.toHaveBeenCalled();
 
     // Set new props on currentWindow. The previous timeout should be abandoned.
     state.metricsTime.currentWindow = {
@@ -119,13 +121,13 @@ describe("<MetricsTimeManager>", function () {
     manager.setProps({
       timeWindow: state,
     });
-    expect(spy.notCalled).toBe(true);
+    expect(spy).not.toHaveBeenCalled();
 
     // Wait 11 milliseconds, then verify that window was updated a single time.
     return new Promise<void>((resolve, _reject) => {
       setTimeout(() => {
-        expect(spy.calledOnce).toBe(true);
-        expect(spy.firstCall.args[0]).toEqual({
+        expect(spy).toHaveBeenCalled();
+        expect(spy.mock.calls[0][0]).toEqual({
           start: now().subtract(state.scale.windowSize),
           end: now(),
         });

--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/linegraph.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/linegraph.spec.tsx
@@ -10,7 +10,6 @@
 
 import { shallow } from "enzyme";
 import React from "react";
-import * as sinon from "sinon";
 import uPlot from "uplot";
 import _ from "lodash";
 
@@ -41,7 +40,7 @@ describe("<LineGraph>", function () {
       subtitle: "Test Subtitle",
       legend: false,
       xAxis: true,
-      data: { results: [], toJSON: sinon.spy },
+      data: { results: [], toJSON: jest.fn() },
       timeInfo: {
         start: new Long(12345),
         end: new Long(2346),
@@ -55,7 +54,7 @@ describe("<LineGraph>", function () {
         location: {
           pathname: "",
           search: "",
-          state: sinon.spy,
+          state: jest.fn(),
           hash: "",
         },
         push: () => {},
@@ -63,8 +62,8 @@ describe("<LineGraph>", function () {
         go: () => {},
         goBack: () => {},
         goForward: () => {},
-        block: sinon.spy,
-        listen: sinon.spy,
+        block: jest.fn(),
+        listen: jest.fn(),
         createHref: () => {
           return "";
         },
@@ -107,10 +106,10 @@ describe("<LineGraph>", function () {
     // test setup
     const wrapper = linegraph({
       ...mockProps,
-      data: { results: [{}], toJSON: sinon.spy },
+      data: { results: [{}], toJSON: jest.fn() },
     });
     const instance = wrapper.instance() as unknown as LineGraph;
-    const mockFn = sinon.spy();
+    const mockFn = jest.fn();
     const mockMetrics = [
       {
         key: ".0",
@@ -145,7 +144,7 @@ describe("<LineGraph>", function () {
         ),
     );
     instance.u = new uPlot(mockOptions);
-    const setDataSpy = sinon.spy(instance.u, "setData");
+    const setDataSpy = jest.spyOn(instance.u, "setData");
     // run test
     wrapper.setProps({
       data: {
@@ -165,7 +164,7 @@ describe("<LineGraph>", function () {
         ],
       },
     });
-    expect(setDataSpy.called).toBe(true);
+    expect(setDataSpy).toHaveBeenCalled();
   });
 });
 

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/events/events.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/events/events.spec.tsx
@@ -12,7 +12,6 @@ import React from "react";
 import { mount, shallow } from "enzyme";
 import _ from "lodash";
 import Long from "long";
-import * as sinon from "sinon";
 
 import * as protos from "src/js/protos";
 import {
@@ -44,16 +43,12 @@ function makeEvent(event: Event) {
 }
 
 describe("<EventBox>", function () {
-  let spy: sinon.SinonSpy;
-
-  beforeEach(function () {
-    spy = sinon.spy();
-  });
+  const spy = jest.fn();
 
   describe("refresh", function () {
     it("refreshes events when mounted.", function () {
       makeEventBox([], spy);
-      expect(spy.called).toBe(true);
+      expect(spy).toHaveBeenCalled();
     });
   });
 

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/emailSubscriptionForm/emailSubscriptionForm.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/emailSubscriptionForm/emailSubscriptionForm.spec.tsx
@@ -10,19 +10,15 @@
 
 import React from "react";
 import { mount, ReactWrapper } from "enzyme";
-import sinon, { SinonSpy } from "sinon";
 
 import { EmailSubscriptionForm } from "./index";
 
-const sandbox = sinon.createSandbox();
-
 describe("EmailSubscriptionForm", () => {
   let wrapper: ReactWrapper;
-  let onSubmitHandler: SinonSpy;
+  const onSubmitHandler = jest.fn();
 
   beforeEach(() => {
-    sandbox.reset();
-    onSubmitHandler = sandbox.spy();
+    onSubmitHandler.mockReset();
     wrapper = mount(<EmailSubscriptionForm onSubmit={onSubmitHandler} />);
   });
 
@@ -34,7 +30,7 @@ describe("EmailSubscriptionForm", () => {
       const buttonComponent = wrapper.find(`button`).first();
       buttonComponent.simulate("click");
 
-      onSubmitHandler.calledOnceWith(emailAddress);
+      expect(onSubmitHandler).toHaveBeenCalledWith(emailAddress);
     });
   });
 
@@ -49,7 +45,7 @@ describe("EmailSubscriptionForm", () => {
     it("doesn't call onSubmit callback", () => {
       const buttonComponent = wrapper.find(`button`).first();
       buttonComponent.simulate("click");
-      expect(onSubmitHandler.notCalled).toBe(true);
+      expect(onSubmitHandler).not.toHaveBeenCalled();
     });
 
     it("submit button is disabled", () => {

--- a/pkg/ui/workspaces/db-console/src/views/shared/containers/metricDataProvider/metricDataProvider.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/containers/metricDataProvider/metricDataProvider.spec.tsx
@@ -12,7 +12,6 @@ import { shallow } from "enzyme";
 import _ from "lodash";
 import Long from "long";
 import React, { Fragment } from "react";
-import * as sinon from "sinon";
 import * as protos from "src/js/protos";
 import { MetricsQuery, requestMetrics } from "src/redux/metrics";
 import {
@@ -124,7 +123,7 @@ function makeMetricsQuery(
 }
 
 describe("<MetricsDataProvider>", function () {
-  let spy: sinon.SinonSpy;
+  const spy = jest.fn();
   const timespan1: QueryTimeInfo = {
     start: Long.fromNumber(0),
     end: Long.fromNumber(100),
@@ -138,14 +137,14 @@ describe("<MetricsDataProvider>", function () {
   const graphid = "testgraph";
 
   beforeEach(function () {
-    spy = sinon.spy();
+    spy.mockReset();
   });
 
   describe("refresh", function () {
     it("refreshes query data when mounted", function () {
       makeDataProvider(graphid, null, timespan1, spy);
-      expect(spy.called).toBe(true);
-      expect(spy.calledWith(graphid, makeMetricsRequest(timespan1))).toBe(true);
+      expect(spy).toHaveBeenCalled();
+      expect(spy).toHaveBeenCalledWith(graphid, makeMetricsRequest(timespan1));
     });
 
     it("does nothing when mounted if current request fulfilled", function () {
@@ -155,7 +154,7 @@ describe("<MetricsDataProvider>", function () {
         timespan1,
         spy,
       );
-      expect(spy.notCalled).toBe(true);
+      expect(spy).not.toHaveBeenCalled();
     });
 
     it("does nothing when mounted if current request is in flight", function () {
@@ -163,7 +162,7 @@ describe("<MetricsDataProvider>", function () {
       query.request = null;
       query.data = null;
       makeDataProvider(graphid, query, timespan1, spy);
-      expect(spy.notCalled).toBe(true);
+      expect(spy).not.toHaveBeenCalled();
     });
 
     it("refreshes query data when receiving props", function () {
@@ -173,12 +172,12 @@ describe("<MetricsDataProvider>", function () {
         timespan1,
         spy,
       );
-      expect(spy.notCalled).toBe(true);
+      expect(spy).not.toHaveBeenCalled();
       provider.setProps({
         metrics: undefined,
       });
-      expect(spy.called).toBe(true);
-      expect(spy.calledWith(graphid, makeMetricsRequest(timespan1))).toBe(true);
+      expect(spy).toHaveBeenCalled();
+      expect(spy).toHaveBeenCalledWith(graphid, makeMetricsRequest(timespan1));
     });
 
     it("refreshes if timespan changes", function () {
@@ -188,12 +187,12 @@ describe("<MetricsDataProvider>", function () {
         timespan1,
         spy,
       );
-      expect(spy.notCalled).toBe(true);
+      expect(spy).not.toHaveBeenCalled();
       provider.setProps({
         timeInfo: timespan2,
       });
-      expect(spy.called).toBe(true);
-      expect(spy.calledWith(graphid, makeMetricsRequest(timespan2))).toBe(true);
+      expect(spy).toHaveBeenCalled();
+      expect(spy).toHaveBeenCalledWith(graphid, makeMetricsRequest(timespan2));
     });
 
     it("refreshes if query changes", function () {
@@ -203,13 +202,13 @@ describe("<MetricsDataProvider>", function () {
         timespan1,
         spy,
       );
-      expect(spy.notCalled).toBe(true);
+      expect(spy).not.toHaveBeenCalled();
       // Modify "sources" parameter.
       provider.setProps({
         metrics: makeMetricsQuery(graphid, timespan1, ["1"]),
       });
-      expect(spy.called).toBe(true);
-      expect(spy.calledWith(graphid, makeMetricsRequest(timespan1))).toBe(true);
+      expect(spy).toHaveBeenCalled();
+      expect(spy).toHaveBeenCalledWith(graphid, makeMetricsRequest(timespan1));
     });
   });
 


### PR DESCRIPTION
Refactoring Sinon spies to use Jest mock functions instead. 

Refactored most of the uses of Sinon spies in Cluster UI. There is one
case in `StatementDetails.spec.tsx` where replacing the Sinon spy breaks the
test, so I ended up leaving it for the moment.

There is also a usage of Sinon in `timeScaleDropdown.spec` where
`SinonFakeTimers` are used. Since we are on Jest 27 there is no
replacement for this in Jest. In Jest 28, Jest timers are based on
Sinon fake timers, so when we upgrade we may be able to replace them
then. Or we could keep using Sinon for fake timers.