### PR TITLE
roachprod: fix data race when reporting session error

### DIFF
--- a/pkg/roachprod/install/session.go
+++ b/pkg/roachprod/install/session.go
@@ -115,12 +115,10 @@ func (s *remoteSession) CombinedOutput(ctx context.Context, cmd string) ([]byte,
 	select {
 	case <-ctx.Done():
 		s.Close()
-		err = ctx.Err()
-		break
+		return nil, ctx.Err()
 	case <-commandFinished:
-		break
+		return b, err
 	}
-	return b, err
 }
 
 func (s *remoteSession) Run(ctx context.Context, cmd string) error {
@@ -143,12 +141,10 @@ func (s *remoteSession) Run(ctx context.Context, cmd string) error {
 	select {
 	case <-ctx.Done():
 		s.Close()
-		err = ctx.Err()
-		break
+		return ctx.Err()
 	case <-commandFinished:
-		break
+		return err
 	}
-	return err
 }
 
 func (s *remoteSession) Start(cmd string) error {
@@ -244,13 +240,10 @@ func (s *localSession) CombinedOutput(ctx context.Context, cmd string) ([]byte, 
 	select {
 	case <-ctx.Done():
 		s.Close()
-		err = ctx.Err()
-		break
+		return nil, ctx.Err()
 	case <-commandFinished:
-		break
+		return b, err
 	}
-
-	return b, err
 }
 
 func (s *localSession) Run(ctx context.Context, cmd string) error {
@@ -273,12 +266,10 @@ func (s *localSession) Run(ctx context.Context, cmd string) error {
 	select {
 	case <-ctx.Done():
 		s.Close()
-		err = ctx.Err()
-		break
+		return ctx.Err()
 	case <-commandFinished:
-		break
+		return err
 	}
-	return err
 }
 
 func (s *localSession) Start(cmd string) error {


### PR DESCRIPTION
In all of the cases changed in this commit, an error variable declared
in the main routine is updated in a Go routine spawned to run a
command. The main routine then waits for either the command to be
finished, or for the function's context to indicate termination.

The data race happens because the outer `error` variable is updated
when an error is returned from the context. This assignment races with
the assignment within the Go routine.

As a consequence of this data race, errors may be swallowed or
incorrectly reported.

This issue was found using the following semgrep rule:

```yaml
rules:
- id: concurrent-error-overwrite
  patterns:
   - pattern-either:
      - pattern: |
         func $F(...) {
           ...
           go func(...) {
               ...
               ($E : error) = ...
               ...
           }(...)
           ...
           $E = ...
           ...
           return $E
         }
  message: |
    data race in error variable `$E`
  languages: [go]
  severity: WARNING
```

The pattern above finds other matches in the codebase as well, but
those are not unsafe.

Inspired by Uber's report in [1].

[1] A Study of Real-World Data Races in Golang
https://arxiv.org/pdf/2204.00764.pdf

Release note: None.