### PR TITLE
ui: fix contention chart on Statement Details page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.module.scss
@@ -102,7 +102,7 @@
 }
 
 .cl-table-container {
-  padding: 18px 24px 18px 0px;
+  padding: 20px 24px 18px 0px;
 }
 .cl-table-wrapper {
   padding: 9.55px 20px 17px;

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -603,6 +603,7 @@ export class StatementDetails extends React.Component<
         available until the statement is sampled.
       </div>
     );
+    const noSamples = statementSampled ? "" : " (no samples)";
 
     const db = databases ? (
       <Text>{databases}</Text>
@@ -781,7 +782,7 @@ export class StatementDetails extends React.Component<
           <Row gutter={24}>
             <Col className="gutter-row" span={12}>
               <BarGraphTimeSeries
-                title="Contention"
+                title={`Contention${noSamples}`}
                 alignedData={contentionTimeseries}
                 uPlotOptions={contentionOps}
                 tooltip={unavailableTooltip}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
@@ -86,7 +86,7 @@ export function generateContentionTimeseries(
 
   stats.forEach(function (stat: statementStatisticsPerAggregatedTs) {
     ts.push(TimestampToNumber(stat.aggregated_ts) * 1e3);
-    count.push(stat.stats.exec_stats.contention_time.mean);
+    count.push(stat.stats.exec_stats.contention_time.mean * 1e9);
   });
 
   return [ts, count];

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
@@ -49,7 +49,7 @@
 .table-area {
   position: relative;
   overflow-x: scroll;
-  min-height: 480px;
+  min-height: 590px;
 }
 
 .reset-btn-area {


### PR DESCRIPTION
This commit adds the proper multiplication factor to
contention value and change title when there are no samples.
<img width="782" alt="Screen Shot 2022-06-14 at 5 18 24 PM" src="https://user-images.githubusercontent.com/1017486/173690768-cdb1eac5-3147-47b3-8692-010825f8aac6.png">

<img width="800" alt="Screen Shot 2022-06-14 at 4 39 08 PM" src="https://user-images.githubusercontent.com/1017486/173690515-59d2201c-89ae-4bab-9a0c-b3428bc32442.png">

It also fixes two small spacing issues.
Before
<img width="258" alt="Screen Shot 2022-06-14 at 4 48 28 PM" src="https://user-images.githubusercontent.com/1017486/173690578-26668aaf-74e1-4a3c-a4fb-0c5bfa86c55c.png">

After
<img width="242" alt="Screen Shot 2022-06-14 at 4 48 18 PM" src="https://user-images.githubusercontent.com/1017486/173690596-60fcc5af-96b0-46b9-a1bc-5f031a4e8e50.png">


Release note (bug fix): Use proper multiplying factor to
contention value on Statement Details page.