### PR TITLE
roachtest: check against alpha version for tenant-scope certs

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1810,32 +1810,36 @@ func (c *clusterImpl) StartE(
 	}
 
 	if settings.Secure {
-		var err error
-		c.localCertsDir, err = ioutil.TempDir("", "roachtest-certs")
-		if err != nil {
-			return err
-		}
-		// `roachprod get` behaves differently with `--local` depending on whether
-		// the target dir exists. With `--local`, it'll put the files into the
-		// existing dir. Without `--local`, it'll create a new subdir to house the
-		// certs. Bypass that distinction (which should be fixed independently, but
-		// that might cause fallout) by using a non-existing dir here.
-		c.localCertsDir = filepath.Join(c.localCertsDir, "certs")
-		// Get the certs from the first node.
-		if err := c.Get(ctx, c.l, "./certs", c.localCertsDir, c.Node(1)); err != nil {
-			return errors.Wrap(err, "cluster.StartE")
-		}
-		// Need to prevent world readable files or lib/pq will complain.
-		if err := filepath.Walk(c.localCertsDir, func(path string, info fs.FileInfo, err error) error {
-			if info.IsDir() {
-				return nil
-			}
-			return os.Chmod(path, 0600)
-		}); err != nil {
+		if err := c.RefetchCertsFromNode(ctx, 1); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (c *clusterImpl) RefetchCertsFromNode(ctx context.Context, node int) error {
+	var err error
+	c.localCertsDir, err = ioutil.TempDir("", "roachtest-certs")
+	if err != nil {
+		return err
+	}
+	// `roachprod get` behaves differently with `--local` depending on whether
+	// the target dir exists. With `--local`, it'll put the files into the
+	// existing dir. Without `--local`, it'll create a new subdir to house the
+	// certs. Bypass that distinction (which should be fixed independently, but
+	// that might cause fallout) by using a non-existing dir here.
+	c.localCertsDir = filepath.Join(c.localCertsDir, "certs")
+	// Get the certs from the first node.
+	if err := c.Get(ctx, c.l, "./certs", c.localCertsDir, c.Node(node)); err != nil {
+		return errors.Wrap(err, "cluster.StartE")
+	}
+	// Need to prevent world readable files or lib/pq will complain.
+	return filepath.Walk(c.localCertsDir, func(path string, info fs.FileInfo, err error) error {
+		if info.IsDir() {
+			return nil
+		}
+		return os.Chmod(path, 0600)
+	})
 }
 
 // Start is like StartE() except that it will fatal the test on error.

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -130,4 +130,5 @@ type Cluster interface {
 	) error
 
 	FetchTimeseriesData(ctx context.Context, t test.Test) error
+	RefetchCertsFromNode(ctx context.Context, node int) error
 }

--- a/pkg/cmd/roachtest/tests/multitenant_fairness.go
+++ b/pkg/cmd/roachtest/tests/multitenant_fairness.go
@@ -176,13 +176,17 @@ func runMultiTenantFairness(
 
 	// Create the tenants.
 	t.L().Printf("initializing %d tenants", numTenants)
+	tenantIDs := make([]int, 0, numTenants)
+	for i := 0; i < numTenants; i++ {
+		tenantIDs = append(tenantIDs, tenantBaseID+i)
+	}
 
 	tenants := make([]*tenantNode, numTenants)
 	for i := 0; i < numTenants; i++ {
 		node := i + 2
 		_, err := c.Conn(ctx, t.L(), 1).Exec(`SELECT crdb_internal.create_tenant($1)`, tenantBaseID+i)
 		require.NoError(t, err)
-		tenant := createTenantNode(ctx, t, c, c.Node(1), tenantBaseID+i, node, tenantHTTPPort(i), tenantSQLPort(i))
+		tenant := createTenantNode(ctx, t, c, c.Node(1), tenantBaseID+i, node, tenantHTTPPort(i), tenantSQLPort(i), createTenantOtherTenantIDs(tenantIDs))
 		defer tenant.stop(ctx, t, c)
 		tenant.start(ctx, t, c, "./cockroach")
 		tenants[i] = tenant

--- a/pkg/cmd/roachtest/tests/multitenant_utils.go
+++ b/pkg/cmd/roachtest/tests/multitenant_utils.go
@@ -45,14 +45,32 @@ type tenantNode struct {
 	node   int
 }
 
+type createTenantOptions struct {
+	// TODO(ssd): This is a hack to work around the currently tangled state of
+	// cluster management between roachtest and roachprod. createTenantNode
+	// recreates client certs. Only one copy of the client certs are cached
+	// locally, so if we want a client to work against multiple tenants in a
+	// single test, we need to create the certs with all tenants.
+	otherTenantIDs []int
+}
+type createTenantOpt func(*createTenantOptions)
+
+func createTenantOtherTenantIDs(ids []int) createTenantOpt {
+	return func(c *createTenantOptions) { c.otherTenantIDs = ids }
+}
+
 func createTenantNode(
 	ctx context.Context,
 	t test.Test,
 	c cluster.Cluster,
 	kvnodes option.NodeListOption,
 	tenantID, node, httpPort, sqlPort int,
+	opts ...createTenantOpt,
 ) *tenantNode {
-
+	var createOptions createTenantOptions
+	for _, o := range opts {
+		o(&createOptions)
+	}
 	// In secure mode only the internal address works, possibly because its started
 	// with --advertise-addr on internal address?
 	kvAddrs, err := c.InternalAddr(ctx, t.L(), kvnodes)
@@ -71,7 +89,8 @@ func createTenantNode(
 	// Tenant scoped certificates were introduced in version 22.2.
 	tenantScopeRequiredVersion := version.MustParse("v22.2.0-alpha.00000000-746-gc030b8b6dc")
 	if v.AtLeast(tenantScopeRequiredVersion) {
-		tn.recreateClientCertsWithTenantScope(ctx, c)
+		err := tn.recreateClientCertsWithTenantScope(ctx, c, createOptions.otherTenantIDs)
+		require.NoError(t, err)
 	}
 	tn.createTenantCert(ctx, t, c)
 	return tn
@@ -94,13 +113,21 @@ func (tn *tenantNode) createTenantCert(ctx context.Context, t test.Test, c clust
 	c.Run(ctx, c.Node(tn.node), cmd)
 }
 
-func (tn *tenantNode) recreateClientCertsWithTenantScope(ctx context.Context, c cluster.Cluster) {
+func (tn *tenantNode) recreateClientCertsWithTenantScope(
+	ctx context.Context, c cluster.Cluster, otherIDs []int,
+) error {
+	tenantArgs := fmt.Sprintf("1,%d", tn.tenantID)
+	for _, id := range otherIDs {
+		tenantArgs = fmt.Sprintf("%s,%d", tenantArgs, id)
+	}
+
 	for _, user := range []username.SQLUsername{username.RootUserName(), username.TestUserName()} {
 		cmd := fmt.Sprintf(
-			"./cockroach cert create-client %s --certs-dir=certs --ca-key=certs/ca.key --tenant-scope 1,%d --overwrite",
-			user.Normalized(), tn.tenantID)
+			"./cockroach cert create-client %s --certs-dir=certs --ca-key=certs/ca.key --tenant-scope %s --overwrite",
+			user.Normalized(), tenantArgs)
 		c.Run(ctx, c.Node(tn.node), cmd)
 	}
+	return c.RefetchCertsFromNode(ctx, tn.node)
 }
 
 func (tn *tenantNode) stop(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/multitenant_utils.go
+++ b/pkg/cmd/roachtest/tests/multitenant_utils.go
@@ -69,7 +69,8 @@ func createTenantNode(
 	v := version.MustParse(versionStr)
 	require.NoError(t, err)
 	// Tenant scoped certificates were introduced in version 22.2.
-	if v.AtLeast(version.MustParse("v22.2.0")) {
+	tenantScopeRequiredVersion := version.MustParse("v22.2.0-alpha.00000000-746-gc030b8b6dc")
+	if v.AtLeast(tenantScopeRequiredVersion) {
 		tn.recreateClientCertsWithTenantScope(ctx, c)
 	}
 	tn.createTenantCert(ctx, t, c)


### PR DESCRIPTION
In semver, v22.2.0 is greater than v22.2.0-alpha. Until the 22.2.0
release is cut, all nightly builds will have pre-release versions that
would fail the previous condition.

Here, I've used an alpha version that I believe is the first alpha
version that required tenant-scoped certs.

Note that we can only do this because we happened to already ship the
version that requires tenant-scoped certs.  Otherwise, we would need a
less exact comparison that would be wrong for some 22.2.0 alpha
versions. An alternative to this type of version comparison might be
if the cockroach binary could report its capabilities via some
standard interface.

Fixes #82929

Release note: None