### PR TITLE
workload/schemachanger: allow unknown schema errors in certain contexts

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -290,7 +290,6 @@ func adjustOpWeightsForCockroachVersion(
 // stochastic attempts and if verbosity is >= 2 the unsuccessful attempts are
 // recorded in `log` to help with debugging of the workload.
 func (og *operationGenerator) randOp(ctx context.Context, tx pgx.Tx) (stmt string, err error) {
-
 	for {
 		op := opType(og.params.ops.Int())
 		og.resetOpState()


### PR DESCRIPTION
Previously, the schema changer workload could hit intermittent
errors when descriptors were bound after being looked up using
crdb_internal table. Unfortunately, the crdb_internal tables never
lease out descriptors, so these schema could be pulled from under us.
To address this, this patch will allow unknown schema errors for
certain crdb_internal queries that are likely to observe this
condition.

Addressing issue #64673 would improve some of this behaviour,
and eliminate the need for the workaround here, since we would
automatically get a retry error.

Release note: None