### PR TITLE
sql: update crdb_internal.cluster_contended_keys join

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2163,6 +2163,8 @@ CREATE VIEW crdb_internal.cluster_contended_keys (
     crdb_internal.cluster_contention_events.index_id
     = crdb_internal.table_indexes.index_id
     AND crdb_internal.cluster_contention_events.table_id
+      = crdb_internal.table_indexes.descriptor_id
+    AND crdb_internal.cluster_contention_events.table_id
       = crdb_internal.tables.table_id
   GROUP BY
     database_name, schema_name, name, index_name, key

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -138,7 +138,11 @@ CREATE VIEW crdb_internal.cluster_contended_keys (
   FROM
     crdb_internal.cluster_contention_events, crdb_internal.tables, crdb_internal.table_indexes
   WHERE
-    crdb_internal.cluster_contention_events.index_id = crdb_internal.table_indexes.index_id
+    (
+      crdb_internal.cluster_contention_events.index_id = crdb_internal.table_indexes.index_id
+      AND crdb_internal.cluster_contention_events.table_id
+        = crdb_internal.table_indexes.descriptor_id
+    )
     AND crdb_internal.cluster_contention_events.table_id = crdb_internal.tables.table_id
   GROUP BY
     database_name, schema_name, name, index_name, key  CREATE VIEW crdb_internal.cluster_contended_keys (
@@ -153,7 +157,11 @@ CREATE VIEW crdb_internal.cluster_contended_keys (
   FROM
     crdb_internal.cluster_contention_events, crdb_internal.tables, crdb_internal.table_indexes
   WHERE
-    crdb_internal.cluster_contention_events.index_id = crdb_internal.table_indexes.index_id
+    (
+      crdb_internal.cluster_contention_events.index_id = crdb_internal.table_indexes.index_id
+      AND crdb_internal.cluster_contention_events.table_id
+        = crdb_internal.table_indexes.descriptor_id
+    )
     AND crdb_internal.cluster_contention_events.table_id = crdb_internal.tables.table_id
   GROUP BY
     database_name, schema_name, name, index_name, key  {}  {}


### PR DESCRIPTION
This PR adds an additional join condition on the `crdb_internal.cluster_contention_events` and `crdb_internal.table_indexes` table join in the `crdb_internal.cluster_contended_keys` CREATE statement.

Fixes https://github.com/cockroachdb/cockroach/issues/80643.

Release note (bug fix): Previously, the CREATE statement for the `crdb_internal.cluster_contended_keys` view was missing the `crdb_internal.table_indexes.descriptor_id = crdb_internal.cluster_contention_events.table_id` JOIN condition, resulting in the view having more rows than expected. Now, the view properly joins the `crdb_internal.cluster_contention_events` and `crdb_internal.table_indexes` tables with all necessary JOIN conditions.