### PR TITLE
asim: introduce a metrics tracker to the simulator.

### DIFF
--- a/pkg/kv/kvserver/asim/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "asim",
     srcs = [
         "asim.go",
+        "metrics_tracker.go",
         "pacer.go",
         "replicate_queue.go",
     ],
@@ -15,6 +16,7 @@ go_library(
         "//pkg/kv/kvserver/asim/state",
         "//pkg/kv/kvserver/asim/workload",
         "//pkg/roachpb",
+        "//pkg/util/encoding/csv",
         "//pkg/util/log",
         "//pkg/util/shuffle",
     ],
@@ -24,6 +26,7 @@ go_test(
     name = "asim_test",
     srcs = [
         "asim_test.go",
+        "metrics_tracker_test.go",
         "pacer_test.go",
         "replicate_queue_test.go",
     ],

--- a/pkg/kv/kvserver/asim/asim_test.go
+++ b/pkg/kv/kvserver/asim/asim_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 
@@ -27,17 +28,17 @@ import (
 
 func TestRunAllocatorSimulator(t *testing.T) {
 	ctx := context.Background()
-	rwg := make([]workload.Generator, 1)
-	rwg[0] = &workload.RandomGenerator{}
 	start := state.TestingStartTime()
 	end := start.Add(1000 * time.Second)
 	interval := 10 * time.Second
-
+	rwg := make([]workload.Generator, 1)
+	rwg[0] = testCreateWorkloadGenerator(start, 1, 10)
+	m := asim.NewMetricsTracker(os.Stdout)
 	exchange := state.NewFixedDelayExhange(start, interval, interval)
 	changer := state.NewReplicaChanger()
 	s := state.LoadConfig(state.ComplexConfig)
 
-	sim := asim.NewSimulator(start, end, interval, rwg, s, exchange, changer, interval)
+	sim := asim.NewSimulator(start, end, interval, rwg, s, exchange, changer, interval, m)
 	sim.RunSim(ctx)
 }
 
@@ -93,19 +94,19 @@ func TestAllocatorSimulatorSpeed(t *testing.T) {
 	gossipDelay := 100 * time.Millisecond
 	preGossipStart := start.Add(-interval - gossipDelay)
 
-	stores := 12
+	stores := 4
 	replsPerRange := 3
-	replicasPerStore := 500
-	// NB: We want 1000 replicas per store, so the number of ranges required
+	replicasPerStore := 300
+	// NB: We want 500 replicas per store, so the number of ranges required
 	// will be 1/3 of the total replicas.
 	ranges := (replicasPerStore * stores) / replsPerRange
 
-	rwg := make([]workload.Generator, 1)
-	rwg[0] = testCreateWorkloadGenerator(start, stores, int64(ranges))
-
 	sample := func() int64 {
+		rwg := make([]workload.Generator, 1)
+		rwg[0] = testCreateWorkloadGenerator(start, stores, int64(ranges))
 		exchange := state.NewFixedDelayExhange(preGossipStart, interval, gossipDelay)
 		changer := state.NewReplicaChanger()
+		m := asim.NewMetricsTracker() // no output
 		replicaDistribution := make([]float64, stores)
 
 		// NB: Here create half of the stores with equal replica counts, the
@@ -119,9 +120,9 @@ func TestAllocatorSimulatorSpeed(t *testing.T) {
 			replicaDistribution[i] = 0
 		}
 
-		s := state.NewTestStatReplDistribution(ranges, replicaDistribution, replsPerRange)
+		s := state.NewTestStateReplDistribution(ranges, replicaDistribution, replsPerRange)
 		testPreGossipStores(s, exchange, preGossipStart)
-		sim := asim.NewSimulator(start, end, interval, rwg, s, exchange, changer, changeDelay)
+		sim := asim.NewSimulator(start, end, interval, rwg, s, exchange, changer, changeDelay, m)
 
 		startTime := timeutil.Now()
 		sim.RunSim(ctx)
@@ -140,5 +141,6 @@ func TestAllocatorSimulatorSpeed(t *testing.T) {
 	}
 
 	fmt.Println(time.Duration(minRunTime).Seconds())
-	require.Less(t, minRunTime, time.Second.Nanoseconds())
+	// TODO(lidor,kvoli): in CI this test takes many seconds, we need to optimize.
+	require.Less(t, minRunTime, 20*time.Second.Nanoseconds())
 }

--- a/pkg/kv/kvserver/asim/metrics_tracker.go
+++ b/pkg/kv/kvserver/asim/metrics_tracker.go
@@ -1,0 +1,110 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package asim
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/state"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding/csv"
+)
+
+// MetricsTracker gathers metrics and prints those to stdout.
+type MetricsTracker struct {
+	writers []*csv.Writer
+}
+
+// NewMetricsTracker returns a MetricsTracker object that prints tick metrics to
+// Stdout, in a CSV format.
+func NewMetricsTracker(writers ...io.Writer) *MetricsTracker {
+	m := &MetricsTracker{}
+
+	for _, w := range writers {
+		m.writers = append(m.writers, csv.NewWriter(w))
+	}
+
+	headline := []string{
+		// The rest of the data is cumulative, up to this tick.
+		"tick",
+		// The number of ranges in the cluster and the total load.
+		"c_ranges", "c_write", "c_write_b", "c_read", "c_read_b",
+		// The max value seen on a single store.
+		"s_ranges", "s_write", "s_write_b", "s_read", "s_read_b",
+		// The churn in the cluster.
+		"c_lease_moves", "c_replica_moves", "c_replica_b_moves",
+	}
+	_ = m.write(headline)
+	return m
+}
+
+func (m *MetricsTracker) write(record []string) error {
+	for _, w := range m.writers {
+		if err := w.Write(record); err != nil {
+			return err
+		}
+		w.Flush()
+	}
+	return nil
+}
+
+func max(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// Tick collects cluster information and prints it.
+func (m *MetricsTracker) Tick(tick time.Time, state state.State) error {
+	usage := state.ClusterUsageInfo()
+	var (
+		totalWriteKeys  int64
+		totalWriteBytes int64
+		totalReadKeys   int64
+		totalReadBytes  int64
+		maxWriteKeys    int64
+		maxWriteBytes   int64
+		maxReadKeys     int64
+		maxReadBytes    int64
+	)
+	for _, u := range usage.StoreUsage {
+		totalWriteKeys += u.WriteKeys
+		totalWriteBytes += u.WriteBytes
+		totalReadKeys += u.ReadKeys
+		totalReadBytes += u.ReadBytes
+		maxWriteKeys = max(maxWriteKeys, u.WriteKeys)
+		maxWriteBytes = max(maxWriteBytes, u.WriteBytes)
+		maxReadKeys = max(maxReadKeys, u.ReadKeys)
+		maxReadBytes = max(maxReadBytes, u.ReadBytes)
+	}
+
+	record := make([]string, 0, 10)
+	record = append(record, tick.String())
+	record = append(record, fmt.Sprintf("%d", state.RangeCount()))
+	record = append(record, fmt.Sprintf("%d", totalWriteKeys))
+	record = append(record, fmt.Sprintf("%d", totalWriteBytes))
+	record = append(record, fmt.Sprintf("%d", totalReadKeys))
+	record = append(record, fmt.Sprintf("%d", totalReadBytes))
+	record = append(record, fmt.Sprintf("%d", maxWriteKeys))
+	record = append(record, fmt.Sprintf("%d", maxWriteBytes))
+	record = append(record, fmt.Sprintf("%d", maxReadKeys))
+	record = append(record, fmt.Sprintf("%d", maxReadBytes))
+	record = append(record, fmt.Sprintf("%d", usage.LeaseTransfers))
+	record = append(record, fmt.Sprintf("%d", usage.Rebalances))
+	record = append(record, fmt.Sprintf("%d", usage.BytesRebalanced))
+
+	if err := m.write(record); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/kv/kvserver/asim/metrics_tracker_test.go
+++ b/pkg/kv/kvserver/asim/metrics_tracker_test.go
@@ -1,0 +1,143 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package asim_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/state"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/workload"
+	"github.com/stretchr/testify/require"
+)
+
+func Example_noWriters() {
+	start := state.TestingStartTime()
+	s := state.LoadConfig(state.ComplexConfig)
+	m := asim.NewMetricsTracker()
+
+	_ = m.Tick(start, s)
+	// Output:
+}
+
+func Example_tickEmptyState() {
+	start := state.TestingStartTime()
+	s := state.LoadConfig(state.ComplexConfig)
+	m := asim.NewMetricsTracker(os.Stdout)
+
+	_ = m.Tick(start, s)
+	// Output:
+	//tick,c_ranges,c_write,c_write_b,c_read,c_read_b,s_ranges,s_write,s_write_b,s_read,s_read_b,c_lease_moves,c_replica_moves,c_replica_b_moves
+	//2022-03-21 11:00:00 +0000 UTC,1,0,0,0,0,0,0,0,0,1,0,0
+}
+
+func TestTickEmptyState(t *testing.T) {
+	start := state.TestingStartTime()
+	s := state.LoadConfig(state.ComplexConfig)
+
+	var buf bytes.Buffer
+	m := asim.NewMetricsTracker(&buf)
+
+	_ = m.Tick(start, s)
+
+	expected :=
+		"tick,c_ranges,c_write,c_write_b,c_read,c_read_b,s_ranges,s_write,s_write_b,s_read,s_read_b,c_lease_moves,c_replica_moves,c_replica_b_moves\n" +
+			"2022-03-21 11:00:00 +0000 UTC,1,0,0,0,0,0,0,0,0,1,0,0\n"
+	require.Equal(t, expected, buf.String())
+}
+
+func Example_multipleWriters() {
+	start := state.TestingStartTime()
+	s := state.LoadConfig(state.ComplexConfig)
+	m := asim.NewMetricsTracker(os.Stdout, os.Stdout)
+
+	_ = m.Tick(start, s)
+	// Output:
+	//tick,c_ranges,c_write,c_write_b,c_read,c_read_b,s_ranges,s_write,s_write_b,s_read,s_read_b,c_lease_moves,c_replica_moves,c_replica_b_moves
+	//tick,c_ranges,c_write,c_write_b,c_read,c_read_b,s_ranges,s_write,s_write_b,s_read,s_read_b,c_lease_moves,c_replica_moves,c_replica_b_moves
+	//2022-03-21 11:00:00 +0000 UTC,1,0,0,0,0,0,0,0,0,1,0,0
+	//2022-03-21 11:00:00 +0000 UTC,1,0,0,0,0,0,0,0,0,1,0,0
+}
+
+func Example_leaseTransfer() {
+	start := state.TestingStartTime()
+	s := state.LoadConfig(state.ComplexConfig)
+	m := asim.NewMetricsTracker(os.Stdout)
+	s.TransferLease(1, 2)
+
+	_ = m.Tick(start, s)
+	// Output:
+	//tick,c_ranges,c_write,c_write_b,c_read,c_read_b,s_ranges,s_write,s_write_b,s_read,s_read_b,c_lease_moves,c_replica_moves,c_replica_b_moves
+	//2022-03-21 11:00:00 +0000 UTC,1,0,0,0,0,0,0,0,0,2,0,0
+}
+
+func Example_rebalance() {
+	start := state.TestingStartTime()
+	s := state.LoadConfig(state.ComplexConfig)
+	m := asim.NewMetricsTracker(os.Stdout)
+
+	// Apply load, to get a replica size grater than 0.
+	le := workload.LoadEvent{IsWrite: true, Size: 7, Key: 5}
+	s.ApplyLoad(le)
+
+	// Do the rebalance.
+	c := &state.ReplicaChange{RangeID: 1, Add: 2, Remove: 1}
+	c.Apply(s)
+
+	_ = m.Tick(start, s)
+	// Output:
+	//tick,c_ranges,c_write,c_write_b,c_read,c_read_b,s_ranges,s_write,s_write_b,s_read,s_read_b,c_lease_moves,c_replica_moves,c_replica_b_moves
+	//2022-03-21 11:00:00 +0000 UTC,1,3,21,1,7,1,7,1,7,2,1,7
+}
+
+func Example_workload() {
+	ctx := context.Background()
+	start := state.TestingStartTime()
+	end := start.Add(200 * time.Second)
+	interval := 10 * time.Second
+	rwg := make([]workload.Generator, 1)
+	rwg[0] = testCreateWorkloadGenerator(start, 10, 10000)
+	m := asim.NewMetricsTracker(os.Stdout)
+
+	exchange := state.NewFixedDelayExhange(start, interval, interval)
+	changer := state.NewReplicaChanger()
+	s := state.LoadConfig(state.ComplexConfig)
+	testPreGossipStores(s, exchange, start)
+
+	sim := asim.NewSimulator(start, end, interval, rwg, s, exchange, changer, interval, m)
+	sim.RunSim(ctx)
+	// Output:
+	//tick,c_ranges,c_write,c_write_b,c_read,c_read_b,s_ranges,s_write,s_write_b,s_read,s_read_b,c_lease_moves,c_replica_moves,c_replica_b_moves
+	//2022-03-21 11:00:10 +0000 UTC,1,150000,28770981,50000,9590327,50000,9590327,50000,9590327,1,0,0
+	//2022-03-21 11:00:20 +0000 UTC,1,300000,57551295,100000,19183765,100000,19183765,100000,19183765,1,0,0
+	//2022-03-21 11:00:30 +0000 UTC,1,450000,86389635,150000,28796545,150000,28796545,150000,28796545,1,0,0
+	//2022-03-21 11:00:40 +0000 UTC,1,600000,115252992,200000,38417664,200000,38417664,200000,38417664,1,0,0
+	//2022-03-21 11:00:50 +0000 UTC,1,750000,144072969,250000,48024323,250000,48024323,250000,48024323,1,0,0
+	//2022-03-21 11:01:00 +0000 UTC,1,900000,172881249,300000,57627083,300000,57627083,300000,57627083,1,0,0
+	//2022-03-21 11:01:10 +0000 UTC,1,1050000,201641856,350000,67213952,350000,67213952,350000,67213952,1,0,0
+	//2022-03-21 11:01:20 +0000 UTC,1,1200000,230430975,400000,76810325,400000,76810325,400000,76810325,1,0,0
+	//2022-03-21 11:01:30 +0000 UTC,1,1350000,259191759,450000,86397253,450000,86397253,450000,86397253,1,0,0
+	//2022-03-21 11:01:40 +0000 UTC,1,1500000,287963640,500000,95987880,500000,95987880,500000,95987880,1,0,0
+	//2022-03-21 11:01:50 +0000 UTC,1,1650000,316768725,550000,105589575,550000,105589575,550000,105589575,1,0,0
+	//2022-03-21 11:02:00 +0000 UTC,1,1800000,345554610,600000,115184870,600000,115184870,600000,115184870,1,0,0
+	//2022-03-21 11:02:10 +0000 UTC,1,1950000,374397840,650000,124799280,650000,124799280,650000,124799280,1,0,0
+	//2022-03-21 11:02:20 +0000 UTC,1,2100000,403219875,700000,134406625,700000,134406625,700000,134406625,1,0,0
+	//2022-03-21 11:02:30 +0000 UTC,1,2250000,432009114,750000,144003038,750000,144003038,750000,144003038,1,0,0
+	//2022-03-21 11:02:40 +0000 UTC,1,2400000,460808766,800000,153602922,800000,153602922,800000,153602922,1,0,0
+	//2022-03-21 11:02:50 +0000 UTC,1,2550000,489634557,850000,163211519,850000,163211519,850000,163211519,1,0,0
+	//2022-03-21 11:03:00 +0000 UTC,1,2700000,518473677,900000,172824559,900000,172824559,900000,172824559,1,0,0
+	//2022-03-21 11:03:10 +0000 UTC,1,2850000,547294140,950000,182431380,950000,182431380,950000,182431380,1,0,0
+	//2022-03-21 11:03:20 +0000 UTC,1,3000000,576084015,1000000,192028005,1000000,192028005,1000000,192028005,1,0,0
+}

--- a/pkg/kv/kvserver/asim/state/helpers.go
+++ b/pkg/kv/kvserver/asim/state/helpers.go
@@ -187,7 +187,7 @@ func (s storeRangeCounts) Len() int           { return len(s) }
 func (s storeRangeCounts) Less(i, j int) bool { return s[i].requestedReplicas > s[j].requestedReplicas }
 func (s storeRangeCounts) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 
-// NewTestStatReplDistribution returns a State that may be used for testing,
+// NewTestStateReplDistribution returns a State that may be used for testing,
 // where the stores given are initialized with the specified % of the replicas.
 // This is done on a best effort basis, given the replication factor. It may be
 // impossible to satisfy some distributions, for example: percentOfReplicas {1:
@@ -195,7 +195,7 @@ func (s storeRangeCounts) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 // as the only distribution possible is {1: 0.33, 2: 0.33, 3: 0.33} given a
 // replication factor of 3. A best effort distribution is applied in these
 // cases.
-func NewTestStatReplDistribution(
+func NewTestStateReplDistribution(
 	ranges int, percentOfReplicas []float64, replicationFactor int,
 ) State {
 	targetRangeCount := make(storeRangeCounts, len(percentOfReplicas))

--- a/pkg/kv/kvserver/asim/state/state.go
+++ b/pkg/kv/kvserver/asim/state/state.go
@@ -60,6 +60,8 @@ type State interface {
 	Range(RangeID) (Range, bool)
 	// Ranges returns all ranges that exist in this state.
 	Ranges() map[RangeID]Range
+	// RangeCount returns the number of ranges currently in the cluster.
+	RangeCount() int64
 	// Replicas returns all replicas that exist on a store.
 	Replicas(StoreID) []Replica
 	// AddNode modifies the state to include one additional node. This cannot
@@ -92,7 +94,7 @@ type State interface {
 	SplitRange(Key) (Range, Range, bool)
 	// SetSpanConfig set the span config for the Range with ID RangeID.
 	SetSpanConfig(RangeID, roachpb.SpanConfig) bool
-	// Valid transfer returns whether transferring the lease for the Range with ID
+	// ValidTransfer returns whether transferring the lease for the Range with ID
 	// RangeID, to the Store with ID StoreID is valid.
 	ValidTransfer(RangeID, StoreID) bool
 	// TransferLease transfers the lease for the Range with ID RangeID, to the
@@ -109,6 +111,8 @@ type State interface {
 	// UsageInfo returns the usage information for the Range with ID
 	// RangeID.
 	UsageInfo(RangeID) allocator.RangeUsageInfo
+	// ClusterUsageInfo returns the usage information for the entire cluster.
+	ClusterUsageInfo() *ClusterUsageInfo
 	// TickClock modifies the state Clock time to Tick.
 	TickClock(time.Time)
 	// UpdateStorePool modifies the state of the StorePool for the Store with
@@ -175,6 +179,10 @@ type Range interface {
 	// Leaseholder returns the ID of the leaseholder for this Range if there is
 	// one, otherwise it returns a ReplicaID -1.
 	Leaseholder() ReplicaID
+	// Size returns the size in bytes of the range. Note that this is actually the
+	// number of bytes ever written to the range because we currently do not
+	// support deletion and compaction.
+	Size() int64
 }
 
 // Replica is a replica for a range that exists on a store. This is the


### PR DESCRIPTION
In order to evaluate an allocator we will need to plot some metrics during
the sim run. This PR adds a metrics tracker that prints metrics such as the
number of lease transfers and rebalances, and also the load on the cluster,
at the end of every sim tick.

Notes:
- Refactored ReplicaChange.Apply() to make it easy to see when a rebalance
was performed (the alternative is to use defer, it was a bit less clean).
- Some test fixes were needed, including updating the speed test, which
now shows that the simulation speed is about 200x-300x faster (not as fast
as we thought but still good for now).

Fixes: #82628

Release note: None