### PR TITLE
ui: use custom build of aria-query@5.0.0 (#95)

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -161,6 +161,7 @@
     "serialize-javascript": "~3.1.0",
     "yargs-parser": "~13.1.2",
     "protobufjs": "6.8.6",
-    "**/jest-environment-jsdom": "^27.5.1"
+    "**/jest-environment-jsdom": "^27.5.1",
+    "aria-query": "file:../../yarn-vendor/aria-query-5.0.0-no-spaced-files.tgz"
   }
 }

--- a/pkg/ui/workspaces/cluster-ui/yarn.lock
+++ b/pkg/ui/workspaces/cluster-ui/yarn.lock
@@ -3931,10 +3931,9 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-aria-query@^5.0.0:
+aria-query@^5.0.0, "aria-query@file:../../yarn-vendor/aria-query-5.0.0-no-spaced-files.tgz":
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.0.tgz#210c21aaf469613ee8c9a62c7f86525e058db52c"
-  integrity sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==
+  resolved "file:../../yarn-vendor/aria-query-5.0.0-no-spaced-files.tgz#4f643d272248b0c3df08fee7317e761fe83e9498"
 
 arr-diff@^4.0.0:
   version "4.0.0"

--- a/pkg/ui/workspaces/db-console/package.json
+++ b/pkg/ui/workspaces/db-console/package.json
@@ -193,6 +193,7 @@
     "**/redux": "^4.1.0",
     "**/ua-parser-js": "0.7.24",
     "**/url-parse": "^1.4.3",
+    "aria-query": "file:../../yarn-vendor/aria-query-5.0.0-no-spaced-files.tgz",
     "core-js": "^2.6.12",
     "elliptic": "~6.5.3",
     "http-proxy": "~1.18.1",

--- a/pkg/ui/workspaces/db-console/yarn.lock
+++ b/pkg/ui/workspaces/db-console/yarn.lock
@@ -1076,14 +1076,6 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
-"@babel/runtime-corejs3@^7.10.2":
-  version "7.14.7"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.14.7.tgz#0ef292bbce40ca00f874c9724ef175a12476465c"
-  integrity sha512-Wvzcw4mBYbTagyBVZpAJWI06auSIj033T/yNE0Zn1xcup83MieCddZA7ls3kme17L4NOGBrQ09Q+nKB41RLWBA==
-  dependencies:
-    core-js-pure "^3.15.0"
-    regenerator-runtime "^0.13.4"
-
 "@babel/runtime@7.14.6", "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.14.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
@@ -3372,18 +3364,9 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-aria-query@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
-  integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
-  dependencies:
-    "@babel/runtime" "^7.10.2"
-    "@babel/runtime-corejs3" "^7.10.2"
-
-aria-query@^5.0.0:
+aria-query@^4.2.2, aria-query@^5.0.0, "aria-query@file:../../yarn-vendor/aria-query-5.0.0-no-spaced-files.tgz":
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.0.tgz#210c21aaf469613ee8c9a62c7f86525e058db52c"
-  integrity sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==
+  resolved "file:../../yarn-vendor/aria-query-5.0.0-no-spaced-files.tgz#4f643d272248b0c3df08fee7317e761fe83e9498"
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -4929,11 +4912,6 @@ core-js-compat@^3.14.0, core-js-compat@^3.15.0, core-js-compat@^3.8.1:
   dependencies:
     browserslist "^4.16.6"
     semver "7.0.0"
-
-core-js-pure@^3.15.0:
-  version "3.15.2"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.15.2.tgz#c8e0874822705f3385d3197af9348f7c9ae2e3ce"
-  integrity sha512-D42L7RYh1J2grW8ttxoY1+17Y4wXZeKe7uyplAI3FkNQyI5OgBIAjUfFiTPfL1rs0qLpxaabITNbjKl1Sp82tA==
 
 core-js-pure@^3.8.2:
   version "3.15.1"


### PR DESCRIPTION
Version 5.0.0 of the aria-query package currently includes files with
spaces in their names [1], but those files aren't used at build- or
run-time. Unfortunately, Bazel doesn't support referencing *any* file
with a space in its name -- including transitively. The yarn-vendored
submodule recently received [2]a copy of aria-query without those extra
files [3], but using it requires a custom yarn resolution for all
packages that transitively depend on aria-query. Replace the corrupt
aria-query build with a custom build that doesn't include extra files.

[1] https://github.com/A11yance/aria-query/issues/367
[2] https://github.com/cockroachdb/yarn-vendored/pull/95
[3] https://github.com/cockroachdb/aria-query/releases/tag/v5.0.0-no-extra-files

Release note: None