### PR TITLE
release-21.1: kvserver: allow gc of data at timestamp < lease start

### DIFF
--- a/pkg/kv/kvserver/replica_protected_timestamp.go
+++ b/pkg/kv/kvserver/replica_protected_timestamp.go
@@ -276,6 +276,20 @@ func (r *Replica) checkProtectedTimestampsForGC(
 	// read.earliestRecord is the record with the earliest timestamp which is
 	// greater than the existing gcThreshold.
 	read = r.readProtectedTimestampsRLocked(ctx, nil)
+	if read.readAt.IsEmpty() {
+		// We don't want to allow GC to proceed if no protected timestamp
+		// information is available.
+		log.VEventf(ctx, 1,
+			"not gc'ing replica %v because protected timestamp information is unavailable", r)
+		return false, hlc.Timestamp{}, hlc.Timestamp{}, hlc.Timestamp{}, hlc.Timestamp{}
+	}
+
+	if read.readAt.Less(lease.Start.ToTimestamp()) {
+		log.VEventf(ctx, 1, "not gc'ing replica %v because current lease %v started after record was read %v",
+			r, lease, read.readAt)
+		return false, hlc.Timestamp{}, hlc.Timestamp{}, hlc.Timestamp{}, hlc.Timestamp{}
+	}
+
 	gcTimestamp = read.readAt
 	if read.earliestRecord != nil {
 		// NB: we want to allow GC up to the timestamp preceding the earliest valid
@@ -284,12 +298,6 @@ func (r *Replica) checkProtectedTimestampsForGC(
 		if impliedGCTimestamp.Less(gcTimestamp) {
 			gcTimestamp = impliedGCTimestamp
 		}
-	}
-
-	if gcTimestamp.Less(lease.Start.ToTimestamp()) {
-		log.VEventf(ctx, 1, "not gc'ing replica %v due to new lease %v started after %v",
-			r, lease, gcTimestamp)
-		return false, hlc.Timestamp{}, hlc.Timestamp{}, hlc.Timestamp{}, hlc.Timestamp{}
 	}
 
 	newThreshold = gc.CalculateThreshold(gcTimestamp, policy)


### PR DESCRIPTION
Backport 1/1 commits from #82956.

/cc @cockroachdb/release

---

Fixes #82954.

Release note (bug): Fix a bug where it was possible to accrue MVCC
garbage for much longer than needed.

Release justification: Bug fix.
