### PR TITLE
storage: use new `pebble.CloneOptions` when cloning iterators

### DIFF
--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -89,12 +89,16 @@ func newPebbleIteratorByCloning(
 	iter *pebble.Iterator, opts IterOptions, durability DurabilityRequirement, supportsRangeKeys bool,
 ) *pebbleIterator {
 	var err error
-	if iter, err = iter.Clone(pebble.CloneOptions{}); err != nil {
-		panic(err)
-	}
 	p := pebbleIterPool.Get().(*pebbleIterator)
 	p.reusable = false // defensive
-	p.init(iter, opts, durability, supportsRangeKeys)
+	p.init(nil, opts, durability, supportsRangeKeys)
+	p.iter, err = iter.Clone(pebble.CloneOptions{
+		IterOptions:      &p.options,
+		RefreshBatchView: true,
+	})
+	if err != nil {
+		panic(err)
+	}
 	return p
 }
 
@@ -145,15 +149,23 @@ func (p *pebbleIterator) initReuseOrCreate(
 	durability DurabilityRequirement,
 	supportsRangeKeys bool, // TODO(erikgrinaker): remove after 22.2
 ) {
-	if clone && iter != nil {
-		var err error
-		if iter, err = iter.Clone(pebble.CloneOptions{}); err != nil {
-			panic(err)
-		}
+	if iter != nil && !clone {
+		p.init(iter, opts, durability, supportsRangeKeys)
+		return
 	}
-	p.init(iter, opts, durability, supportsRangeKeys)
+
+	p.init(nil, opts, durability, supportsRangeKeys)
 	if iter == nil {
 		p.iter = handle.NewIter(&p.options)
+	} else if clone {
+		var err error
+		p.iter, err = iter.Clone(pebble.CloneOptions{
+			IterOptions:      &p.options,
+			RefreshBatchView: true,
+		})
+		if err != nil {
+			panic(err)
+		}
 	}
 }
 


### PR DESCRIPTION
This patch avoids first cloning and then reconfiguring the cloned
iterator, by constructing the clone with the correct settings in the
first place.

This shows a slight improvement on `MVCCGet` benchmarks that were
modified to always use cloned iterators. This would also happen
normally in many cases (e.g. when using an intent interleaving iterator
with a raw `Engine`, or when constructing a time-bound iterator which
requires two iterators from the underlying reader).

```
MVCCGet_Pebble/batch=false/versions=1/valueSize=8-24      4.87µs ± 3%    4.82µs ± 2%    ~     (p=0.101 n=10+10)
MVCCGet_Pebble/batch=false/versions=10/valueSize=8-24     5.88µs ± 1%    5.83µs ± 0%  -0.94%  (p=0.004 n=10+9)
MVCCGet_Pebble/batch=false/versions=100/valueSize=8-24    13.7µs ± 6%    13.7µs ± 4%    ~     (p=0.971 n=10+10)
MVCCGet_Pebble/batch=true/versions=1/valueSize=8-24       2.76µs ± 1%    2.76µs ± 1%    ~     (p=0.871 n=10+10)
MVCCGet_Pebble/batch=true/versions=10/valueSize=8-24      3.89µs ± 1%    3.86µs ± 2%  -0.76%  (p=0.011 n=10+10)
MVCCGet_Pebble/batch=true/versions=100/valueSize=8-24     10.2µs ± 3%    10.2µs ± 4%    ~     (p=0.912 n=10+10)
```

Release note: None