### PR TITLE
roachtest,CODEOWNERS: remove primary assignments to the server team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -92,66 +92,66 @@
 /pkg/cli/                    @cockroachdb/cli-prs
 # last-rule-wins so bulk i/o takes userfile.go even though cli-prs takes pkg/cli
 /pkg/cli/userfile.go         @cockroachdb/bulk-io
-/pkg/cli/auth.go             @cockroachdb/server-prs     @cockroachdb/prodsec @cockroachdb/cli-prs
+/pkg/cli/auth.go             @cockroachdb/unowned        @cockroachdb/prodsec @cockroachdb/cli-prs
 /pkg/cli/cert*.go            @cockroachdb/cli-prs        @cockroachdb/prodsec
 /pkg/cli/demo*.go            @cockroachdb/sql-experience @cockroachdb/server-prs @cockroachdb/cli-prs
 /pkg/cli/democluster         @cockroachdb/sql-experience @cockroachdb/server-prs @cockroachdb/cli-prs
 /pkg/cli/debug*.go           @cockroachdb/kv-prs         @cockroachdb/cli-prs
 /pkg/cli/debug_job_trace*.go @cockroachdb/jobs-prs
 /pkg/cli/doctor*.go          @cockroachdb/sql-schema     @cockroachdb/cli-prs
-/pkg/cli/import_test.go      @cockroachdb/bulk-io       @cockroachdb/cli-prs
+/pkg/cli/import_test.go      @cockroachdb/bulk-io        @cockroachdb/cli-prs
 /pkg/cli/sql*.go             @cockroachdb/sql-experience @cockroachdb/cli-prs
 /pkg/cli/clisqlshell/        @cockroachdb/sql-experience @cockroachdb/cli-prs
 /pkg/cli/clisqlclient/       @cockroachdb/sql-experience @cockroachdb/cli-prs
 /pkg/cli/clisqlcfg/          @cockroachdb/sql-experience @cockroachdb/cli-prs
 /pkg/cli/clisqlexec/         @cockroachdb/sql-experience @cockroachdb/cli-prs
-/pkg/cli/start*.go           @cockroachdb/server-prs     @cockroachdb/cli-prs
+/pkg/cli/start*.go           @cockroachdb/cli-prs        @cockroachdb/server-prs
 /pkg/cli/mt_proxy.go         @cockroachdb/sqlproxy-prs   @cockroachdb/server-prs
 /pkg/cli/mt_start_sql.go     @cockroachdb/sqlproxy-prs   @cockroachdb/server-prs
 /pkg/cli/mt_test_directory.go @cockroachdb/sqlproxy-prs  @cockroachdb/server-prs
-/pkg/cli/connect*.go         @cockroachdb/server-prs     @cockroachdb/cli-prs @cockroachdb/prodsec
-/pkg/cli/init.go             @cockroachdb/server-prs     @cockroachdb/cli-prs
+/pkg/cli/connect*.go         @cockroachdb/unowned        @cockroachdb/cli-prs @cockroachdb/prodsec
+/pkg/cli/init.go             @cockroachdb/unowned        @cockroachdb/cli-prs
 /pkg/cli/log*.go             @cockroachdb/obs-inf-prs    @cockroachdb/cli-prs
 /pkg/cli/debug_logconfig.go  @cockroachdb/obs-inf-prs    @cockroachdb/cli-prs
 /pkg/cli/debug_merg_logs*.go @cockroachdb/obs-inf-prs    @cockroachdb/cli-prs
 
-/pkg/server/                             @cockroachdb/server-prs
-/pkg/server/addjoin*.go                  @cockroachdb/server-prs  @cockroachdb/prodsec
+/pkg/server/                             @cockroachdb/cli-prs
+/pkg/server/addjoin*.go                  @cockroachdb/unowned     @cockroachdb/server-prs @cockroachdb/prodsec
 /pkg/server/admin*.go                    @cockroachdb/obs-inf-prs @cockroachdb/server-prs
 /pkg/server/api_v2*.go                   @cockroachdb/obs-inf-prs @cockroachdb/server-prs
-/pkg/server/api_v2_auth*.go              @cockroachdb/server-prs  @cockroachdb/prodsec
-/pkg/server/authentication*.go           @cockroachdb/server-prs  @cockroachdb/prodsec
-/pkg/server/auto_tls_init*go             @cockroachdb/server-prs  @cockroachdb/prodsec
-/pkg/server/clock_monotonicity.go        @cockroachdb/server-prs  @cockroachdb/kv-prs
+/pkg/server/api_v2_auth*.go              @cockroachdb/unowned     @cockroachdb/obs-inf-prs @cockroachdb/server-prs @cockroachdb/prodsec
+/pkg/server/authentication*.go           @cockroachdb/unowned     @cockroachdb/server-prs  @cockroachdb/prodsec
+/pkg/server/auto_tls_init*go             @cockroachdb/unowned     @cockroachdb/server-prs  @cockroachdb/prodsec
+/pkg/server/clock_monotonicity.go        @cockroachdb/kv-prs
 /pkg/server/combined_statement_stats*.go @cockroachdb/sql-observability @cockroachdb/obs-inf-prs
-/pkg/server/decommission*.go             @cockroachdb/server-prs  @cockroachdb/kv-prs
-/pkg/server/drain*.go                    @cockroachdb/server-prs  @cockroachdb/kv-prs
+/pkg/server/decommission*.go             @cockroachdb/kv-prs      @cockroachdb/server-prs
+/pkg/server/drain*.go                    @cockroachdb/kv-prs      @cockroachdb/server-prs
 /pkg/server/dumpstore/                   @cockroachdb/obs-inf-prs @cockroachdb/server-prs
 /pkg/server/goroutinedumper/             @cockroachdb/obs-inf-prs @cockroachdb/server-prs
 /pkg/server/heapprofiler/                @cockroachdb/obs-inf-prs @cockroachdb/server-prs
 /pkg/server/import_ts*.go                @cockroachdb/obs-inf-prs @cockroachdb/server-prs  @cockroachdb/kv-prs
-/pkg/server/init*.go                     @cockroachdb/server-prs  @cockroachdb/kv-prs
-/pkg/server/init_handshake.go            @cockroachdb/server-prs  @cockroachdb/prodsec
-/pkg/server/loss_of_quorum*.go           @cockroachdb/server-prs  @cockroachdb/kv-prs
+/pkg/server/init*.go                     @cockroachdb/kv-prs      @cockroachdb/server-prs
+/pkg/server/init_handshake.go            @cockroachdb/unowned     @cockroachdb/server-prs  @cockroachdb/prodsec
+/pkg/server/loss_of_quorum*.go           @cockroachdb/kv-prs
 /pkg/server/node_http*.go                @cockroachdb/obs-inf-prs @cockroachdb/server-prs
 /pkg/server/node_tenant*go               @cockroachdb/obs-inf-prs @cockroachdb/multi-tenant @cockroachdb/server-prs
-/pkg/server/node_tombstone*.go           @cockroachdb/server-prs  @cockroachdb/kv-prs
-/pkg/server/pgurl/                       @cockroachdb/server-prs  @cockroachdb/sql-experience
+/pkg/server/node_tombstone*.go           @cockroachdb/kv-prs      @cockroachdb/server-prs
+/pkg/server/pgurl/                       @cockroachdb/sql-experience @cockroachdb/cli-prs
 /pkg/server/server_http*.go              @cockroachdb/obs-inf-prs @cockroachdb/server-prs
-/pkg/server/server_import_ts*.go         @cockroachdb/server-prs  @cockroachdb/kv-prs
+/pkg/server/server_import_ts*.go         @cockroachdb/obs-inf-prs @cockroachdb/kv-prs
 /pkg/server/serverpb/                    @cockroachdb/obs-inf-prs @cockroachdb/server-prs
-/pkg/server/serverpb/authentication*     @cockroachdb/obs-inf-prs @cockroachdb/prodsec @cockroachdb/server-prs
+/pkg/server/serverpb/authentication*     @cockroachdb/unowned     @cockroachdb/obs-inf-prs @cockroachdb/prodsec @cockroachdb/server-prs
 /pkg/server/serverpb/index_reco*         @cockroachdb/sql-observability @cockroachdb/obs-inf-prs
 /pkg/server/serverrules/                 @cockroachdb/obs-inf-prs @cockroachdb/server-prs
-/pkg/server/settingswatcher/             @cockroachdb/server-prs  @cockroachdb/multi-tenant
+/pkg/server/settingswatcher/             @cockroachdb/multi-tenant @cockroachdb/server-prs
 /pkg/server/statements*.go               @cockroachdb/sql-observability @cockroachdb/obs-inf-prs
 /pkg/server/status*go                    @cockroachdb/obs-inf-prs @cockroachdb/server-prs
 /pkg/server/status*go                    @cockroachdb/obs-inf-prs @cockroachdb/server-prs
 /pkg/server/status/                      @cockroachdb/obs-inf-prs @cockroachdb/server-prs
-/pkg/server/systemconfigwatcher/         @cockroachdb/server-prs  @cockroachdb/multi-tenant
+/pkg/server/systemconfigwatcher/         @cockroachdb/kv-prs      @cockroachdb/multi-tenant
 /pkg/server/tenant*.go                   @cockroachdb/obs-inf-prs @cockroachdb/multi-tenant @cockroachdb/server-prs
-/pkg/server/tenantsettingswatcher/       @cockroachdb/server-prs  @cockroachdb/multi-tenant
-/pkg/server/testserver*.go               @cockroachdb/server-prs  @cockroachdb/test-eng
+/pkg/server/tenantsettingswatcher/       @cockroachdb/unowned     @cockroachdb/multi-tenant
+/pkg/server/testserver*.go               @cockroachdb/test-eng    @cockroachdb/server-prs
 /pkg/server/tracedumper/                 @cockroachdb/obs-inf-prs @cockroachdb/server-prs
 /pkg/server/user*.go                     @cockroachdb/obs-inf-prs @cockroachdb/server-prs @cockroachdb/prodsec
 
@@ -191,7 +191,7 @@
 /pkg/gen/                    @cockroachdb/dev-inf
 
 /pkg/acceptance/             @cockroachdb/sql-experience
-/pkg/base/                   @cockroachdb/server-prs
+/pkg/base/                   @cockroachdb/unowned @cockroachdb/kv-prs @cockroachdb/server-prs
 /pkg/bench/                  @cockroachdb/sql-queries-noreview
 /pkg/bench/rttanalysis       @cockroachdb/sql-schema
 /pkg/blobs/                  @cockroachdb/bulk-io
@@ -201,22 +201,24 @@
 /pkg/ccl/cliccl/             @cockroachdb/cli-prs
 /pkg/ccl/cmdccl/enc_utils/   @cockroachdb/storage
 /pkg/ccl/cmdccl/stub-schema-registry/ @cockroachdb/cdc-prs
-/pkg/ccl/gssapiccl/          @cockroachdb/server-prs
+/pkg/ccl/gssapiccl/          @cockroachdb/unowned
 /pkg/ccl/kvccl/              @cockroachdb/kv-noreview
 /pkg/ccl/kvccl/kvtenantccl/  @cockroachdb/multi-tenant
 /pkg/ccl/upgradeccl/         @cockroachdb/unowned
 /pkg/ccl/logictestccl/       @cockroachdb/sql-queries-noreview
 /pkg/ccl/multiregionccl/     @cockroachdb/multiregion
 /pkg/ccl/multitenantccl/     @cockroachdb/multi-tenant
-/pkg/ccl/oidcccl/            @cockroachdb/server-prs
+/pkg/ccl/oidcccl/            @cockroachdb/unowned
 /pkg/ccl/partitionccl/       @cockroachdb/sql-schema @cockroachdb/multiregion
-/pkg/ccl/serverccl/          @cockroachdb/server-prs
-/pkg/ccl/serverccl/statusccl @cockroachdb/sql-observability
+/pkg/ccl/serverccl/          @cockroachdb/unowned @cockroachdb/server-prs
+/pkg/ccl/serverccl/server_sql* @cockroachdb/multi-tenant @cockroachdb/server-prs
+/pkg/ccl/serverccl/tenant_*  @cockroachdb/multi-tenant @cockroachdb/server-prs
+/pkg/ccl/serverccl/statusccl @cockroachdb/sql-observability @cockroachdb/multi-tenant
 /pkg/ccl/telemetryccl/       @cockroachdb/obs-inf-prs
 /pkg/ccl/testccl/sqlccl/     @cockroachdb/sql-queries
 /pkg/ccl/testccl/workload/schemachange/ @cockroachdb/sql-schema
 /pkg/ccl/testutilsccl/       @cockroachdb/test-eng-noreview
-/pkg/ccl/utilccl/            @cockroachdb/server-prs
+/pkg/ccl/utilccl/            @cockroachdb/unowned @cockroachdb/server-prs
 /pkg/ccl/workloadccl/        @cockroachdb/sql-experience-noreview
 /pkg/ccl/benchccl/rttanalysisccl/     @cockroachdb/sql-experience
 /pkg/clusterversion/         @cockroachdb/kv-prs-noreview
@@ -250,7 +252,7 @@
 /pkg/cmd/internal/issues/    @cockroachdb/test-eng
 /pkg/cmd/mirror/             @cockroachdb/dev-inf
 /pkg/cmd/prereqs/            @cockroachdb/dev-inf
-/pkg/cmd/protoc-gen-gogoroach/ @cockroachdb/server-prs
+/pkg/cmd/protoc-gen-gogoroach/ @cockroachdb/dev-inf
 /pkg/cmd/publish-artifacts/  @cockroachdb/dev-inf
 /pkg/cmd/publish-provisional-artifacts/ @cockroachdb/dev-inf
 /pkg/cmd/reduce/             @cockroachdb/sql-queries
@@ -283,10 +285,10 @@
 /pkg/cmd/zerosum/            @cockroachdb/kv-noreview
 /pkg/col/                    @cockroachdb/sql-queries
 /pkg/compose/                @cockroachdb/sql-experience
-/pkg/config/                 @cockroachdb/server-prs
+/pkg/config/                 @cockroachdb/kv-prs @cockroachdb/server-prs
 /pkg/docs/                   @cockroachdb/docs
 /pkg/featureflag/            @cockroachdb/cli-prs-noreview
-/pkg/gossip/                 @cockroachdb/server-prs @cockroachdb/kv-prs
+/pkg/gossip/                 @cockroachdb/kv-prs
 /pkg/internal/client/requestbatcher/ @cockroachdb/kv-prs
 /pkg/internal/codeowners/    @cockroachdb/test-eng
 /pkg/internal/reporoot       @cockroachdb/dev-inf
@@ -328,14 +330,14 @@
 /pkg/roachpb/testdata/repl*  @cockroachdb/kv-prs
 /pkg/roachpb/version*        @cockroachdb/unowned
 /pkg/roachprod/              @cockroachdb/test-eng
-/pkg/rpc/                    @cockroachdb/server-prs @cockroachdb/kv-prs
-/pkg/rpc/auth.go             @cockroachdb/server-prs @cockroachdb/kv-prs @cockroachdb/prodsec
+/pkg/rpc/                    @cockroachdb/kv-prs
+/pkg/rpc/auth.go             @cockroachdb/unowned @cockroachdb/server-prs @cockroachdb/kv-prs @cockroachdb/prodsec
 /pkg/scheduledjobs/          @cockroachdb/jobs-prs
-/pkg/security/               @cockroachdb/server-prs @cockroachdb/prodsec
-/pkg/security/clientsecopts/ @cockroachdb/server-prs @cockroachdb/sql-experience @cockroachdb/prodsec
-/pkg/settings/               @cockroachdb/server-prs
+/pkg/security/               @cockroachdb/unowned @cockroachdb/server-prs @cockroachdb/prodsec
+/pkg/security/clientsecopts/ @cockroachdb/unowned @cockroachdb/server-prs @cockroachdb/sql-experience @cockroachdb/prodsec
+/pkg/settings/               @cockroachdb/unowned
 /pkg/spanconfig/             @cockroachdb/kv-prs
-/pkg/startupmigrations/      @cockroachdb/server-prs @cockroachdb/sql-schema
+/pkg/startupmigrations/      @cockroachdb/unowned @cockroachdb/sql-schema
 /pkg/streaming/              @cockroachdb/bulk-io
 /pkg/testutils/              @cockroachdb/test-eng-noreview
 /pkg/testutils/reduce/       @cockroachdb/sql-queries
@@ -345,9 +347,9 @@
 /pkg/ts/catalog/             @cockroachdb/obs-inf-prs
 /pkg/util/                   @cockroachdb/unowned
 /pkg/util/log/               @cockroachdb/obs-inf-prs
-/pkg/util/addr/              @cockroachdb/server-prs @cockroachdb/obs-inf-prs
+/pkg/util/addr/              @cockroachdb/cli-prs @cockroachdb/obs-inf-prs
 /pkg/util/metric/            @cockroachdb/obs-inf-prs
-/pkg/util/stop/              @cockroachdb/server-prs
+/pkg/util/stop/              @cockroachdb/kv-prs
 /pkg/util/tracing            @cockroachdb/obs-inf-prs
 /pkg/workload/               @cockroachdb/sql-experience-noreview
 /pkg/obsservice/             @cockroachdb/obs-inf-prs

--- a/pkg/cmd/github-post/main_test.go
+++ b/pkg/cmd/github-post/main_test.go
@@ -47,7 +47,7 @@ func TestListFailures(t *testing.T) {
 				testName:   "TestStopperWithCancelConcurrent",
 				title:      "util/stop: TestStopperWithCancelConcurrent failed",
 				message:    "this is just a testing issue",
-				mention:    []string{"@cockroachdb/server"},
+				mention:    []string{"@cockroachdb/kv"},
 				hasProject: true,
 			}},
 			formatter: defaultFormatter,

--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -22,7 +22,7 @@ const (
 	OwnerKV            Owner = `kv`
 	OwnerMultiRegion   Owner = `multiregion`
 	OwnerObsInf        Owner = `obs-inf-prs`
-	OwnerServer        Owner = `server`
+	OwnerServer        Owner = `server` // not currently staffed
 	OwnerSQLQueries    Owner = `sql-queries`
 	OwnerSQLSchema     Owner = `sql-schema`
 	OwnerStorage       Owner = `storage`

--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -59,6 +59,9 @@ func registerAcceptance(r registry.Registry) {
 				minVersion: "v19.2.0",
 				timeout:    30 * time.Minute,
 			},
+			{name: "cli/node-status", fn: runCLINodeStatus},
+			{name: "cluster-init", fn: runClusterInit},
+			{name: "rapid-restart", fn: runRapidRestart},
 		},
 		registry.OwnerMultiTenant: {
 			{
@@ -67,13 +70,12 @@ func registerAcceptance(r registry.Registry) {
 				fn:   runAcceptanceMultitenant,
 			},
 		},
-		registry.OwnerServer: {
+		registry.OwnerObsInf: {
+			{name: "status-server", fn: runStatusServer},
+		},
+		registry.OwnerDevInf: {
 			{name: "build-info", fn: RunBuildInfo},
 			{name: "build-analyze", fn: RunBuildAnalyze},
-			{name: "cli/node-status", fn: runCLINodeStatus},
-			{name: "cluster-init", fn: runClusterInit},
-			{name: "rapid-restart", fn: runRapidRestart},
-			{name: "status-server", fn: runStatusServer},
 		},
 	}
 	tags := []string{"default", "quick"}

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -71,7 +71,7 @@ func registerDecommission(r registry.Registry) {
 		numNodes := 4
 		r.Add(registry.TestSpec{
 			Name:    "decommission/drains",
-			Owner:   registry.OwnerServer,
+			Owner:   registry.OwnerKV,
 			Cluster: r.MakeClusterSpec(numNodes),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runDecommissionDrains(ctx, t, c)
@@ -105,7 +105,7 @@ func registerDecommission(r registry.Registry) {
 		numNodes := 6
 		r.Add(registry.TestSpec{
 			Name:    "decommission/slow",
-			Owner:   registry.OwnerServer,
+			Owner:   registry.OwnerKV,
 			Cluster: r.MakeClusterSpec(numNodes),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runDecommissionSlow(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/network.go
+++ b/pkg/cmd/roachtest/tests/network.go
@@ -293,7 +293,7 @@ func registerNetwork(r registry.Registry) {
 	const numNodes = 4
 	r.Add(registry.TestSpec{
 		Name:    fmt.Sprintf("network/authentication/nodes=%d", numNodes),
-		Owner:   registry.OwnerServer,
+		Owner:   registry.OwnerKV, // Should be moved to new security team once one exists.
 		Cluster: r.MakeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runNetworkAuthentication(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/slow_drain.go
+++ b/pkg/cmd/roachtest/tests/slow_drain.go
@@ -30,7 +30,7 @@ func registerSlowDrain(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:    fmt.Sprintf("slow-drain/duration=%s", duration),
-		Owner:   registry.OwnerServer,
+		Owner:   registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runSlowDrain(ctx, t, c, duration)


### PR DESCRIPTION
As discussed with @lunevalex and @jtsiros .

As the server team is currently unstaffed, we don't want issues to
be automatically assigned to it. This commit redirects the
issues to either the appropriate team, or to the virtual "noowner"
team.

The `cockroach/server-prs` notification target remains in CODEOWNERS
so that folk can use it to register to changes to particular code areas.

Release note: None