### PR TITLE
ccl/sqlproxyccl: ensure that EnsureTenantPod always resumes a pod

### DIFF
--- a/pkg/ccl/sqlproxyccl/tenant/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/tenant/BUILD.bazel
@@ -49,10 +49,11 @@ go_test(
     size = "large",
     srcs = [
         "directory_cache_test.go",
+        "entry_test.go",
         "main_test.go",
     ],
+    embed = [":tenant"],
     deps = [
-        ":tenant",
         "//pkg/base",
         "//pkg/ccl",
         "//pkg/ccl/kvccl/kvtenantccl",

--- a/pkg/ccl/sqlproxyccl/tenant/directory_cache.go
+++ b/pkg/ccl/sqlproxyccl/tenant/directory_cache.go
@@ -194,14 +194,7 @@ func (d *directoryCache) LookupTenantPods(
 	tenantPods := entry.GetPods()
 
 	// Trigger resumption if there are no RUNNING pods.
-	hasRunningPod := false
-	for _, pod := range tenantPods {
-		if pod.State == RUNNING {
-			hasRunningPod = true
-			break
-		}
-	}
-	if !hasRunningPod {
+	if !hasRunningPod(tenantPods) {
 		// There are no known pod IP addresses, so fetch pod information from
 		// the directory server. Resume the tenant if it is suspended; that
 		// will always result in at least one pod IP address (or an error).

--- a/pkg/ccl/sqlproxyccl/tenant/directory_cache_test.go
+++ b/pkg/ccl/sqlproxyccl/tenant/directory_cache_test.go
@@ -147,6 +147,11 @@ func TestWatchPods(t *testing.T) {
 		}
 		return nil
 	})
+
+	// Trigger a deletion event, which will be missed by the pod watcher.
+	require.True(t, tds.RemovePod(tenantID, runningPod.Addr))
+
+	// Start the directory server again.
 	require.NoError(t, tds.Start(ctx))
 	testutils.SucceedsSoon(t, func() error {
 		if tds.WatchListenersCount() == 0 {
@@ -154,6 +159,20 @@ func TestWatchPods(t *testing.T) {
 		}
 		return nil
 	})
+
+	// Directory cache should still have the DRAINING pod.
+	pods, err = dir.TryLookupTenantPods(ctx, tenantID)
+	require.NoError(t, err)
+	require.Len(t, pods, 1)
+	require.Equal(t, pod, pods[0])
+
+	// Now attempt to perform a resumption. We get an error here, which shows
+	// that we attempted to call EnsurePod in the test directory server because
+	// the cache has no running pods. In the actual directory server, this
+	// should put the draining pod back to running.
+	pods, err = dir.LookupTenantPods(ctx, tenantID, "my-tenant")
+	require.Regexp(t, "tenant has no pods", err)
+	require.Empty(t, pods)
 
 	// Put the same pod back to running.
 	require.True(t, tds.AddPod(tenantID, runningPod))

--- a/pkg/ccl/sqlproxyccl/tenant/entry_test.go
+++ b/pkg/ccl/sqlproxyccl/tenant/entry_test.go
@@ -1,0 +1,56 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package tenant
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasRunningPod(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	for _, tc := range []struct {
+		name     string
+		pods     []*Pod
+		expected bool
+	}{
+		{
+			name:     "no pods",
+			pods:     nil,
+			expected: false,
+		},
+		{
+			name:     "single running pod",
+			pods:     []*Pod{{State: RUNNING}},
+			expected: true,
+		},
+		{
+			name:     "single draining pod",
+			pods:     []*Pod{{State: DRAINING}},
+			expected: false,
+		},
+		{
+			name: "multiple pods",
+			pods: []*Pod{
+				{State: DRAINING},
+				{State: DRAINING},
+				{State: RUNNING},
+				{State: RUNNING},
+			},
+			expected: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, hasRunningPod(tc.pods))
+		})
+	}
+}


### PR DESCRIPTION
This was a regression from the new load balancing work. Previously, the pods
list in entry.go only stores a list of running pods. That has been modified to
also store draining pods, and this breaks some of the existing logic. In
particular, there could be an issue where EnsureTenantPod returned right away
when there are only DRAINING pods left because we relied on the length of pods
rather than checking through all their states. This commit fixes that buglet
by ensuring that EnsureTenantPods will attempt to resume tenants whenever only
DRAINING pods are left.

This bug was prominent when the pod watcher restarted at the moment the
DRAINING pod was deleted, causing the deletion event to be missed. When that
happens, the cache is stuck with a DRAINING pod that will never get refreshed
because (1) EnsureTenantPod does not attempt to resume that tenant, and
(2) we don't call ReportFailure when we fail to obtain an address. The second
behavior is expected because we relied on the fact that (1) should resume the
tenant.

Release note: None