### PR TITLE
kvserver: instrument snapshot flow with tracing and timing

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -210,6 +210,7 @@ go_library(
         "@io_etcd_go_etcd_raft_v3//:raft",
         "@io_etcd_go_etcd_raft_v3//raftpb",
         "@io_etcd_go_etcd_raft_v3//tracker",
+        "@io_opentelemetry_go_otel//attribute",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_x_time//rate",
     ],

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -2456,6 +2456,7 @@ func TestStoreReplicaGCAfterMerge(t *testing.T) {
 	transport := kvserver.NewRaftTransport(
 		tc.Servers[0].AmbientCtx(),
 		cluster.MakeTestingClusterSettings(),
+		tc.Servers[0].AmbientCtx().Tracer,
 		nodedialer.New(tc.Servers[0].RPCContext(), gossip.AddressResolver(tc.Servers[0].Gossip())),
 		nil, /* grpcServer */
 		tc.Servers[0].Stopper(),

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -3043,6 +3043,7 @@ func TestReplicaGCRace(t *testing.T) {
 	fromTransport := kvserver.NewRaftTransport(
 		ambient,
 		cluster.MakeTestingClusterSettings(),
+		ambient.Tracer,
 		nodedialer.New(tc.Servers[0].RPCContext(), gossip.AddressResolver(fromStore.Gossip())),
 		nil, /* grpcServer */
 		tc.Servers[0].Stopper(),
@@ -3540,6 +3541,7 @@ func TestReplicateRemovedNodeDisruptiveElection(t *testing.T) {
 	transport0 := kvserver.NewRaftTransport(
 		tc.Servers[0].AmbientCtx(),
 		cluster.MakeTestingClusterSettings(),
+		tc.Servers[0].AmbientCtx().Tracer,
 		nodedialer.New(tc.Servers[0].RPCContext(),
 			gossip.AddressResolver(tc.GetFirstStoreFromServer(t, 0).Gossip())),
 		nil, /* grpcServer */

--- a/pkg/kv/kvserver/raft_transport_test.go
+++ b/pkg/kv/kvserver/raft_transport_test.go
@@ -169,9 +169,11 @@ func (rttc *raftTransportTestContext) AddNodeWithoutGossip(
 	nodeID roachpb.NodeID, addr net.Addr, stopper *stop.Stopper,
 ) (*kvserver.RaftTransport, net.Addr) {
 	grpcServer := rpc.NewServer(rttc.nodeRPCContext)
+	ctwWithTracer := log.MakeTestingAmbientCtxWithNewTracer()
 	transport := kvserver.NewRaftTransport(
-		log.MakeTestingAmbientCtxWithNewTracer(),
+		ctwWithTracer,
 		cluster.MakeTestingClusterSettings(),
+		ctwWithTracer.Tracer,
 		nodedialer.New(rttc.nodeRPCContext, gossip.AddressResolver(rttc.gossip)),
 		grpcServer,
 		rttc.stopper,

--- a/pkg/kv/kvserver/raft_transport_unit_test.go
+++ b/pkg/kv/kvserver/raft_transport_unit_test.go
@@ -67,9 +67,11 @@ func TestRaftTransportStartNewQueue(t *testing.T) {
 		return addr, nil
 	}
 
+	ctxWithTracer := log.MakeTestingAmbientCtxWithNewTracer()
 	tp := NewRaftTransport(
-		log.MakeTestingAmbientCtxWithNewTracer(),
+		ctxWithTracer,
 		cluster.MakeTestingClusterSettings(),
+		ctxWithTracer.Tracer,
 		nodedialer.New(rpcC, resolver),
 		grpcServer,
 		stopper,

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -42,6 +42,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
@@ -2653,6 +2655,15 @@ var followerSnapshotsEnabled = func() *settings.BoolSetting {
 	return s
 }()
 
+// traceSnapshotThreshold is used to enable or disable snapshot tracing.
+var traceSnapshotThreshold = settings.RegisterDurationSetting(
+	settings.SystemOnly,
+	"kv.trace.snapshot.enable_threshold",
+	"enables tracing and gathers timing information on all snapshots;"+
+		"snapshots with a duration longer than this threshold will have their "+
+		"trace logged (set to 0 to disable);", 0,
+)
+
 // followerSendSnapshot receives a delegate snapshot request and generates the
 // snapshot from this replica. The entire process of generating and transmitting
 // the snapshot is handled, and errors are propagated back to the leaseholder.
@@ -2663,6 +2674,23 @@ func (r *Replica) followerSendSnapshot(
 	stream DelegateSnapshotResponseStream,
 ) (retErr error) {
 	ctx = r.AnnotateCtx(ctx)
+	sendThreshold := traceSnapshotThreshold.Get(&r.ClusterSettings().SV)
+	if sendThreshold > 0 {
+		var sp *tracing.Span
+		ctx, sp = tracing.EnsureChildSpan(ctx, r.store.cfg.Tracer(),
+			"follower snapshot send", tracing.WithRecording(tracingpb.RecordingVerbose))
+		sendStart := timeutil.Now()
+		defer func() {
+			sendDur := timeutil.Since(sendStart)
+			if sendThreshold > 0 && sendDur > sendThreshold {
+				// Note that log lines larger than 65k are truncated in the debug zip (see
+				// #50166).
+				log.Infof(ctx, "%s took %s, exceeding threshold of %s:\n%s",
+					"snapshot", sendDur, sendThreshold, sp.GetConfiguredRecording())
+			}
+			sp.Finish()
+		}()
+	}
 
 	// TODO(amy): when delegating to different senders, check raft applied state
 	// to determine if this follower replica is fit to send.

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1160,6 +1160,11 @@ func (sc *StoreConfig) LeaseExpiration() int64 {
 	return 2 * (sc.RangeLeaseActiveDuration() + maxOffset).Nanoseconds()
 }
 
+// Tracer returns the tracer embedded within StoreConfig
+func (sc *StoreConfig) Tracer() *tracing.Tracer {
+	return sc.AmbientCtx.Tracer
+}
+
 // NewStore returns a new instance of a store.
 func NewStore(
 	ctx context.Context, cfg StoreConfig, eng storage.Engine, nodeDesc *roachpb.NodeDescriptor,

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -58,6 +58,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/kr/pretty"
@@ -2881,6 +2882,7 @@ func TestSendSnapshotThrottling(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
+	tr := tracing.NewTracer()
 
 	header := kvserverpb.SnapshotRequest_Header{
 		State: kvserverpb.ReplicaState{
@@ -2895,7 +2897,7 @@ func TestSendSnapshotThrottling(t *testing.T) {
 		expectedErr := errors.New("")
 		c := fakeSnapshotStream{nil, expectedErr}
 		err := sendSnapshot(
-			ctx, st, c, sp, header, nil /* snap */, newBatch, nil /* sent */, nil, /* recordBytesSent */
+			ctx, st, tr, c, sp, header, nil /* snap */, newBatch, nil /* sent */, nil, /* recordBytesSent */
 		)
 		if sp.failedThrottles != 1 {
 			t.Fatalf("expected 1 failed throttle, but found %d", sp.failedThrottles)
@@ -2913,7 +2915,7 @@ func TestSendSnapshotThrottling(t *testing.T) {
 		}
 		c := fakeSnapshotStream{resp, nil}
 		err := sendSnapshot(
-			ctx, st, c, sp, header, nil /* snap */, newBatch, nil /* sent */, nil, /* recordBytesSent */
+			ctx, st, tr, c, sp, header, nil /* snap */, newBatch, nil /* sent */, nil, /* recordBytesSent */
 		)
 		if sp.failedThrottles != 1 {
 			t.Fatalf("expected 1 failed throttle, but found %d", sp.failedThrottles)

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1344,6 +1344,7 @@ func (n *Node) ResetQuorum(
 	if err := kvserver.SendEmptySnapshot(
 		ctx,
 		n.storeCfg.Settings,
+		n.storeCfg.Tracer(),
 		conn,
 		n.storeCfg.Clock.Now(),
 		desc,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -464,7 +464,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	)
 
 	raftTransport := kvserver.NewRaftTransport(
-		cfg.AmbientCtx, st, nodeDialer, grpcServer.Server, stopper,
+		cfg.AmbientCtx, st, cfg.AmbientCtx.Tracer, nodeDialer, grpcServer.Server, stopper,
 	)
 
 	ctSender := sidetransport.NewSender(stopper, st, clock, nodeDialer)


### PR DESCRIPTION
This commit adds additional tracing to both the sender and receiver sides
of the snapshot flow. On the sender side, existing tracing was extended and
new spans are added for sender-side snapshot reservation and the act of
streaming the snapshot to a recipient. On the receiver side, new tracing was
added to follow the reception of the snapshot bytes. Spans were added to
show receiver-side snapshot reservation and the act of reading the snapshot
of the gRPC stream. This tracing can be enabled using the new cluster
setting `kv.trace.snapshot.enable_threshold`, and snapshots that take longer
than the threshold have their traces written to the log.
<img width="1330" alt="Screen Shot 2022-06-16 at 2 01 31 PM" src="https://user-images.githubusercontent.com/20501291/174136239-4d1c3cd8-abe7-4d0f-814e-44b75e6d4f47.png">


Additionally, timing was added to the snapshot Send() and Receive()
functions. This change allows users to see what percentage of sending and
receiving is spent on disk IO, network IO, and rate-limiting.
<img width="906" alt="Screen Shot 2022-06-16 at 2 02 53 PM" src="https://user-images.githubusercontent.com/20501291/174136477-005dc9aa-0cb3-40ba-9597-1f1d0b1dd2dd.png">
<img width="903" alt="Screen Shot 2022-06-16 at 2 03 08 PM" src="https://user-images.githubusercontent.com/20501291/174136482-e3ac27ae-f172-40a6-a9f6-774910129dc6.png">

These changes give better insight into where time is bring spent during
rebalance and recovery operations, allowing for future works to better
optimize these processes.

Resolves: #82753

Release note: None