### PR TITLE
ui: proper handle of unset app name

### DIFF
--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -428,6 +428,9 @@ func getStatementDetailsQueryClausesAndArgs(
 		if !(len(req.AppNames) == 1 && req.AppNames[0] == "") {
 			buffer.WriteString(" AND (")
 			for i, app := range req.AppNames {
+				if app == "(unset)" {
+					app = ""
+				}
 				if i != 0 {
 					args = append(args, app)
 					buffer.WriteString(fmt.Sprintf(" OR app_name = $%d", len(args)))

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
@@ -60,7 +60,7 @@ import sessionPageStyles from "./sessionPage.module.scss";
 import ColumnsSelector, {
   SelectOption,
 } from "../columnsSelector/columnsSelector";
-import { TimestampToMoment } from "src/util";
+import { TimestampToMoment, unset } from "src/util";
 import moment from "moment";
 import {
   getLabel,
@@ -109,9 +109,7 @@ function getSessionAppFilterOptions(sessions: SessionInfo[]): string[] {
       if (s.session.application_name.startsWith("$ internal")) {
         return "$ internal";
       }
-      return s.session.application_name
-        ? s.session.application_name
-        : "(unset)";
+      return s.session.application_name ? s.session.application_name : unset;
     }),
   );
 
@@ -300,7 +298,7 @@ export class SessionsPage extends React.Component<
           if (apps.includes(internalAppNamePrefix)) {
             showInternal = true;
           }
-          if (apps.includes("(unset)")) {
+          if (apps.includes(unset)) {
             apps.push("");
           }
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -20,6 +20,7 @@ import {
   statementKey,
   StatementStatistics,
   TimestampToMoment,
+  unset,
 } from "src/util";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { RouteComponentProps } from "react-router-dom";
@@ -82,9 +83,7 @@ export const selectApps = createSelector(sqlStatsSelector, sqlStatsState => {
       }
     },
   );
-  return []
-    .concat(sawBlank ? ["(unset)"] : [])
-    .concat(Object.keys(apps).sort());
+  return [].concat(sawBlank ? [unset] : []).concat(Object.keys(apps).sort());
 });
 
 // selectDatabases returns the array of all databases with statement statistics present
@@ -99,7 +98,7 @@ export const selectDatabases = createSelector(
     return Array.from(
       new Set(
         sqlStatsState.data.statements.map(s =>
-          s.key.key_data.database ? s.key.key_data.database : "(unset)",
+          s.key.key_data.database ? s.key.key_data.database : unset,
         ),
       ),
     )
@@ -155,7 +154,7 @@ export const selectStatements = createSelector(
       if (criteria.includes(state.data.internal_app_name_prefix)) {
         showInternal = true;
       }
-      if (criteria.includes("(unset)")) {
+      if (criteria.includes(unset)) {
         criteria.push("");
       }
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -38,6 +38,7 @@ import {
   unique,
   containAny,
   syncHistory,
+  unset,
 } from "src/util";
 import {
   AggregateStatistics,
@@ -434,7 +435,7 @@ export class StatementsPage extends React.Component<
         : [];
     const databases =
       filters.database.length > 0 ? filters.database.split(",") : [];
-    if (databases.includes("(unset)")) {
+    if (databases.includes(unset)) {
       databases.push("");
     }
     const regions =

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
@@ -23,12 +23,12 @@ import {
   FixLong,
   longToInt,
   TimestampToNumber,
-  TimestampToString,
   addStatementStats,
   flattenStatementStats,
   DurationToNumber,
   computeOrUseStmtSummary,
   transactionScopedStatementKey,
+  unset,
 } from "../util";
 
 type Statement =
@@ -44,7 +44,7 @@ export const getTrxAppFilterOptions = (
   const uniqueAppNames = new Set(
     transactions
       .filter(t => !t.stats_data.app.startsWith(prefix))
-      .map(t => (t.stats_data.app ? t.stats_data.app : "(unset)")),
+      .map(t => (t.stats_data.app ? t.stats_data.app : unset)),
   );
 
   return Array.from(uniqueAppNames).sort();
@@ -170,7 +170,7 @@ export const filterTransactions = (
         if (apps.includes(internalAppNamePrefix)) {
           showInternal = true;
         }
-        if (apps.includes("(unset)")) {
+        if (apps.includes(unset)) {
           apps.push("");
         }
 

--- a/pkg/ui/workspaces/cluster-ui/src/util/constants.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/constants.ts
@@ -29,6 +29,7 @@ export const schemaNameAttr = "schemaName";
 export const tableNameAttr = "table_name";
 export const indexNameAttr = "index_name";
 export const txnFingerprintIdAttr = "txn_fingerprint_id";
+export const unset = "(unset)";
 export const viewAttr = "view";
 
 export const REMOTE_DEBUGGING_ERROR_TEXT =

--- a/pkg/ui/workspaces/db-console/src/util/constants.ts
+++ b/pkg/ui/workspaces/db-console/src/util/constants.ts
@@ -32,6 +32,7 @@ export const {
   tabAttr,
   tableNameAttr,
   txnFingerprintIdAttr,
+  unset,
   viewAttr,
   REMOTE_DEBUGGING_ERROR_TEXT,
 } = util;

--- a/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
@@ -17,7 +17,12 @@ import { merge } from "lodash";
 
 import "src/protobufInit";
 import * as protos from "src/js/protos";
-import { appAttr, appNamesAttr, statementAttr } from "src/util/constants";
+import {
+  appAttr,
+  appNamesAttr,
+  statementAttr,
+  unset,
+} from "src/util/constants";
 import {
   selectStatements,
   selectApps,
@@ -171,7 +176,7 @@ describe("selectStatements", () => {
       ],
       timeScale,
     );
-    const props = makeRoutePropsWithApp("(unset)");
+    const props = makeRoutePropsWithApp(unset);
 
     const result = selectStatements(state, props);
 
@@ -215,7 +220,7 @@ describe("selectApps", () => {
 
     const result = selectApps(state);
 
-    assert.deepEqual(result, ["(unset)", "cockroach sql", "foobar"]);
+    assert.deepEqual(result, [unset, "cockroach sql", "foobar"]);
   });
 });
 
@@ -391,10 +396,7 @@ describe("selectStatement", () => {
       detailsC,
     ]);
     const stmtAFingerprintID = stmtA.id.toString();
-    const props = makeRoutePropsWithStatementAndApp(
-      stmtAFingerprintID,
-      "(unset)",
-    );
+    const props = makeRoutePropsWithStatementAndApp(stmtAFingerprintID, unset);
 
     const { statementDetails } = selectStatementDetails(state, props);
     const result = statementDetails.statement;

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -21,7 +21,7 @@ import {
 import { CachedDataReducerState } from "src/redux/cachedDataReducer";
 import { AdminUIState, AppDispatch } from "src/redux/state";
 import { StatementsResponseMessage } from "src/util/api";
-import { appAttr } from "src/util/constants";
+import { appAttr, unset } from "src/util/constants";
 import { PrintTime } from "src/views/reports/containers/range/print";
 import { selectDiagnosticsReportsPerStatement } from "src/redux/statements/statementsSelectors";
 import {
@@ -115,7 +115,7 @@ export const selectStatements = createSelector(
       if (criteria.includes(state.data.internal_app_name_prefix)) {
         showInternal = true;
       }
-      if (criteria.includes("(unset)")) {
+      if (criteria.includes(unset)) {
         criteria.push("");
       }
 
@@ -201,7 +201,7 @@ export const selectApps = createSelector(
       },
     );
     return []
-      .concat(sawBlank ? ["(unset)"] : [])
+      .concat(sawBlank ? [unset] : [])
       .concat(Object.keys(apps))
       .sort();
   },
@@ -218,7 +218,7 @@ export const selectDatabases = createSelector(
     return Array.from(
       new Set(
         state.data.statements.map(s =>
-          s.key.key_data.database ? s.key.key_data.database : "(unset)",
+          s.key.key_data.database ? s.key.key_data.database : unset,
         ),
       ),
     )


### PR DESCRIPTION
Previously, if a filter for `unset` app name
was selected on Statement page, the Statement Details
page was not finding the correct values.
Now if no filter is selected, no search params is
passed to the Details page. If there is an empty value
for the appNames on request, is looking for unset.

This commit also creates a constant for the unset value
and replaces all places to use the constant instead.

Fixes #83002

https://www.loom.com/share/2bcb83ef35714fc4b90be8d513017eab

Release note (bug fix): Statement Details now find the stats
when the `unset` app filter is selected.