### PR TITLE
sql: cleanup fetchers

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -369,6 +369,7 @@ ALL_TESTS = [
     "//pkg/sql/protoreflect:protoreflect_test",
     "//pkg/sql/querycache:querycache_test",
     "//pkg/sql/randgen:randgen_test",
+    "//pkg/sql/row:row_disallowed_imports_test",
     "//pkg/sql/row:row_test",
     "//pkg/sql/rowcontainer:rowcontainer_test",
     "//pkg/sql/rowenc/keyside:keyside_test",

--- a/pkg/ccl/changefeedccl/cdcevent/event.go
+++ b/pkg/ccl/changefeedccl/cdcevent/event.go
@@ -387,7 +387,7 @@ func (d *eventDecoder) DecodeKV(
 
 	d.kvFetcher.KVs = d.kvFetcher.KVs[:0]
 	d.kvFetcher.KVs = append(d.kvFetcher.KVs, kv)
-	if err := d.fetcher.StartScanFrom(ctx, &d.kvFetcher, false /* traceKV */); err != nil {
+	if err := d.fetcher.StartScanFrom(ctx, &d.kvFetcher); err != nil {
 		return Row{}, err
 	}
 

--- a/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
@@ -239,8 +239,9 @@ func (c *rowFetcherCache) RowFetcherForColumnFamily(
 	if err := rf.Init(
 		context.TODO(),
 		row.FetcherInitArgs{
-			Alloc: &c.a,
-			Spec:  &spec,
+			WillUseCustomKVBatchFetcher: true,
+			Alloc:                       &c.a,
+			Spec:                        &spec,
 		},
 	); err != nil {
 		return nil, nil, err

--- a/pkg/ccl/cliccl/debug_backup.go
+++ b/pkg/ccl/cliccl/debug_backup.go
@@ -627,8 +627,9 @@ func makeRowFetcher(
 	if err := rf.Init(
 		ctx,
 		row.FetcherInitArgs{
-			Alloc: &tree.DatumAlloc{},
-			Spec:  &spec,
+			WillUseCustomKVBatchFetcher: true,
+			Alloc:                       &tree.DatumAlloc{},
+			Spec:                        &spec,
 		},
 	); err != nil {
 		return rf, err

--- a/pkg/ccl/cliccl/debug_backup.go
+++ b/pkg/ccl/cliccl/debug_backup.go
@@ -624,11 +624,13 @@ func makeRowFetcher(
 	}
 
 	var rf row.Fetcher
-	if err := rf.Init(ctx,
+	if err := rf.Init(
+		ctx,
 		row.FetcherInitArgs{
 			Alloc: &tree.DatumAlloc{},
 			Spec:  &spec,
-		}); err != nil {
+		},
+	); err != nil {
 		return rf, err
 	}
 	return rf, nil
@@ -667,7 +669,7 @@ func processEntryFiles(
 	}
 	kvFetcher := row.MakeBackupSSTKVFetcher(startKeyMVCC, endKeyMVCC, iter, startTime, endTime, debugBackupArgs.withRevisions)
 
-	if err := rf.StartScanFrom(ctx, &kvFetcher, false /* traceKV */); err != nil {
+	if err := rf.StartScanFrom(ctx, &kvFetcher); err != nil {
 		return errors.Wrapf(err, "row fetcher starts scan")
 	}
 

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -2586,7 +2586,7 @@ func columnBackfillInTxn(
 	rowMetrics := execCfg.GetRowMetrics(evalCtx.SessionData().Internal)
 	var backfiller backfill.ColumnBackfiller
 	if err := backfiller.InitForLocalUse(
-		ctx, evalCtx, semaCtx, tableDesc, columnBackfillerMon, rowMetrics, traceKV,
+		ctx, txn, evalCtx, semaCtx, tableDesc, columnBackfillerMon, rowMetrics, traceKV,
 	); err != nil {
 		return err
 	}
@@ -2635,8 +2635,10 @@ func indexBackfillInTxn(
 	sp := tableDesc.PrimaryIndexSpan(evalCtx.Codec)
 	for sp.Key != nil {
 		var err error
-		sp.Key, err = backfiller.RunIndexBackfillChunk(ctx,
-			txn, tableDesc, sp, indexTxnBackfillChunkSize, false /* alsoCommit */, traceKV)
+		sp.Key, err = backfiller.RunIndexBackfillChunk(
+			ctx, txn, tableDesc, sp, indexTxnBackfillChunkSize,
+			false /* alsoCommit */, traceKV,
+		)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -2586,7 +2586,7 @@ func columnBackfillInTxn(
 	rowMetrics := execCfg.GetRowMetrics(evalCtx.SessionData().Internal)
 	var backfiller backfill.ColumnBackfiller
 	if err := backfiller.InitForLocalUse(
-		ctx, evalCtx, semaCtx, tableDesc, columnBackfillerMon, rowMetrics,
+		ctx, evalCtx, semaCtx, tableDesc, columnBackfillerMon, rowMetrics, traceKV,
 	); err != nil {
 		return err
 	}
@@ -2594,9 +2594,10 @@ func columnBackfillInTxn(
 	sp := tableDesc.PrimaryIndexSpan(evalCtx.Codec)
 	for sp.Key != nil {
 		var err error
-		sp.Key, err = backfiller.RunColumnBackfillChunk(ctx,
-			txn, tableDesc, sp, rowinfra.RowLimit(columnBackfillBatchSize.Get(&evalCtx.Settings.SV)),
-			false /*alsoCommit*/, traceKV)
+		sp.Key, err = backfiller.RunColumnBackfillChunk(
+			ctx, txn, tableDesc, sp, rowinfra.RowLimit(columnBackfillBatchSize.Get(&evalCtx.Settings.SV)),
+			false /*alsoCommit*/, traceKV,
+		)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -105,7 +105,10 @@ func (cb *ColumnBackfiller) initCols(desc catalog.TableDescriptor) {
 
 // init performs initialization operations that are shared across the local
 // and distributed initialization procedures for the ColumnBackfiller.
+//
+// txn might be nil, in which case it will need to be set on the fetcher later.
 func (cb *ColumnBackfiller) init(
+	txn *kv.Txn,
 	evalCtx *eval.Context,
 	defaultExprs []tree.TypedExpr,
 	computedExprs []tree.TypedExpr,
@@ -154,6 +157,7 @@ func (cb *ColumnBackfiller) init(
 	return cb.fetcher.Init(
 		evalCtx.Context,
 		row.FetcherInitArgs{
+			Txn:        txn,
 			Alloc:      &cb.alloc,
 			MemMonitor: cb.mon,
 			Spec:       &spec,
@@ -167,6 +171,7 @@ func (cb *ColumnBackfiller) init(
 // is occurring on the gateway as part of the user's transaction.
 func (cb *ColumnBackfiller) InitForLocalUse(
 	ctx context.Context,
+	txn *kv.Txn,
 	evalCtx *eval.Context,
 	semaCtx *tree.SemaContext,
 	desc catalog.TableDescriptor,
@@ -193,7 +198,7 @@ func (cb *ColumnBackfiller) InitForLocalUse(
 	if err != nil {
 		return err
 	}
-	return cb.init(evalCtx, defaultExprs, computedExprs, desc, mon, rowMetrics, traceKV)
+	return cb.init(txn, evalCtx, defaultExprs, computedExprs, desc, mon, rowMetrics, traceKV)
 }
 
 // InitForDistributedUse initializes a ColumnBackfiller for use as part of a
@@ -250,7 +255,8 @@ func (cb *ColumnBackfiller) InitForDistributedUse(
 	flowCtx.Descriptors.ReleaseAll(ctx)
 
 	rowMetrics := flowCtx.GetRowMetrics()
-	return cb.init(evalCtx, defaultExprs, computedExprs, desc, mon, rowMetrics, flowCtx.TraceKV)
+	// The txn will be set on the fetcher in RunColumnBackfillChunk.
+	return cb.init(nil /* txn */, evalCtx, defaultExprs, computedExprs, desc, mon, rowMetrics, flowCtx.TraceKV)
 }
 
 // Close frees the resources used by the ColumnBackfiller.
@@ -302,6 +308,12 @@ func (cb *ColumnBackfiller) RunColumnBackfillChunk(
 		panic("only column data should be modified, but the rowUpdater is configured otherwise")
 	}
 
+	// Update the fetcher to use the new txn.
+	if err := cb.fetcher.SetTxn(txn); err != nil {
+		log.Errorf(ctx, "scan error during SetTxn: %s", err)
+		return roachpb.Key{}, err
+	}
+
 	// Get the next set of rows.
 	//
 	// Running the scan and applying the changes in many transactions
@@ -311,7 +323,7 @@ func (cb *ColumnBackfiller) RunColumnBackfillChunk(
 	// populated and deleted by the OLTP commands but not otherwise
 	// read or used
 	if err := cb.fetcher.StartScan(
-		ctx, txn, []roachpb.Span{sp}, nil, /* spanIDs */
+		ctx, []roachpb.Span{sp}, nil, /* spanIDs */
 		rowinfra.GetDefaultBatchBytesLimit(false /* forceProductionValue */),
 		chunkSize,
 	); err != nil {
@@ -804,6 +816,7 @@ func (ib *IndexBackfiller) BuildIndexEntriesChunk(
 	if err := fetcher.Init(
 		ib.evalCtx.Context,
 		row.FetcherInitArgs{
+			Txn:        txn,
 			Alloc:      &ib.alloc,
 			MemMonitor: ib.mon,
 			Spec:       &spec,
@@ -814,7 +827,7 @@ func (ib *IndexBackfiller) BuildIndexEntriesChunk(
 	}
 	defer fetcher.Close(ctx)
 	if err := fetcher.StartScan(
-		ctx, txn, []roachpb.Span{sp}, nil, /* spanIDs */
+		ctx, []roachpb.Span{sp}, nil, /* spanIDs */
 		rowinfra.GetDefaultBatchBytesLimit(false /* forceProductionValue */),
 		initBufferSize,
 	); err != nil {
@@ -980,8 +993,9 @@ func (ib *IndexBackfiller) RunIndexBackfillChunk(
 	alsoCommit bool,
 	traceKV bool,
 ) (roachpb.Key, error) {
-	entries, key, memUsedBuildingChunk, err := ib.BuildIndexEntriesChunk(ctx, txn, tableDesc, sp,
-		chunkSize, traceKV)
+	entries, key, memUsedBuildingChunk, err := ib.BuildIndexEntriesChunk(
+		ctx, txn, tableDesc, sp, chunkSize, traceKV,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/colfetcher/BUILD.bazel
+++ b/pkg/sql/colfetcher/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//pkg/col/typeconv",
         "//pkg/keys",
         "//pkg/kv",
-        "//pkg/kv/kvclient/kvstreamer",
         "//pkg/roachpb",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catpb",

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -185,7 +185,8 @@ type cFetcherArgs struct {
 	reverse bool
 	// traceKV indicates whether or not session tracing is enabled. It is set
 	// when initializing the fetcher.
-	traceKV bool
+	traceKV                    bool
+	forceProductionKVBatchSize bool
 }
 
 // noOutputColumn is a sentinel value to denote that a system column is not
@@ -511,7 +512,6 @@ func (cf *cFetcher) StartScan(
 	limitBatches bool,
 	batchBytesLimit rowinfra.BytesLimit,
 	limitHint rowinfra.RowLimit,
-	forceProductionKVBatchSize bool,
 ) error {
 	if len(spans) == 0 {
 		return errors.AssertionFailedf("no spans")
@@ -558,7 +558,7 @@ func (cf *cFetcher) StartScan(
 		cf.lockWaitPolicy,
 		cf.lockTimeout,
 		cf.kvFetcherMemAcc,
-		forceProductionKVBatchSize,
+		cf.forceProductionKVBatchSize,
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -98,7 +98,6 @@ func (s *ColBatchScan) Init(ctx context.Context) {
 		limitBatches,
 		s.batchBytesLimit,
 		s.limitHint,
-		s.flowCtx.EvalCtx.TestingKnobs.ForceProductionValues,
 	); err != nil {
 		colexecerror.InternalError(err)
 	}
@@ -204,6 +203,7 @@ func NewColBatchScan(
 		estimatedRowCount,
 		spec.Reverse,
 		flowCtx.TraceKV,
+		flowCtx.EvalCtx.TestingKnobs.ForceProductionValues,
 	}
 
 	if err = fetcher.Init(allocator, kvFetcherMemAcc, tableArgs); err != nil {

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -260,7 +260,6 @@ func (s *ColIndexJoin) Next() coldata.Batch {
 					false, /* limitBatches */
 					rowinfra.NoBytesLimit,
 					rowinfra.NoRowLimit,
-					s.flowCtx.EvalCtx.TestingKnobs.ForceProductionValues,
 				)
 			}
 			if err != nil {
@@ -552,6 +551,7 @@ func NewColIndexJoin(
 		0,     /* estimatedRowCount */
 		false, /* reverse */
 		flowCtx.TraceKV,
+		flowCtx.EvalCtx.TestingKnobs.ForceProductionValues,
 	}
 	if err = fetcher.Init(
 		fetcherAllocator, kvFetcherMemAcc, tableArgs,

--- a/pkg/sql/delete_preserving_index_test.go
+++ b/pkg/sql/delete_preserving_index_test.go
@@ -778,6 +778,7 @@ func fetchIndex(
 	require.NoError(t, fetcher.Init(
 		ctx,
 		row.FetcherInitArgs{
+			Txn:        txn,
 			Reverse:    reverse,
 			Alloc:      &alloc,
 			MemMonitor: mm.Monitor(),
@@ -787,7 +788,7 @@ func fetchIndex(
 	))
 
 	require.NoError(t, fetcher.StartScan(
-		ctx, txn, spans, nil /* spanIDs */, rowinfra.NoBytesLimit, 0,
+		ctx, spans, nil /* spanIDs */, rowinfra.NoBytesLimit, 0,
 	))
 	var rows []tree.Datums
 	for {

--- a/pkg/sql/delete_preserving_index_test.go
+++ b/pkg/sql/delete_preserving_index_test.go
@@ -782,11 +782,12 @@ func fetchIndex(
 			Alloc:      &alloc,
 			MemMonitor: mm.Monitor(),
 			Spec:       &spec,
+			TraceKV:    true,
 		},
 	))
 
 	require.NoError(t, fetcher.StartScan(
-		ctx, txn, spans, nil /* spanIDs */, rowinfra.NoBytesLimit, 0, true, false, /* forceProductionBatchSize */
+		ctx, txn, spans, nil /* spanIDs */, rowinfra.NoBytesLimit, 0,
 	))
 	var rows []tree.Datums
 	for {

--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -99,8 +99,9 @@ func (d *deleteRangeNode) startExec(params runParams) error {
 	if err := d.fetcher.Init(
 		params.ctx,
 		row.FetcherInitArgs{
-			Alloc: params.p.alloc,
-			Spec:  &spec,
+			WillUseCustomKVBatchFetcher: true,
+			Alloc:                       params.p.alloc,
+			Spec:                        &spec,
 		},
 	); err != nil {
 		return err

--- a/pkg/sql/indexbackfiller_test.go
+++ b/pkg/sql/indexbackfiller_test.go
@@ -409,6 +409,7 @@ INSERT INTO foo VALUES (1), (10), (100);
 		require.NoError(t, fetcher.Init(
 			ctx,
 			row.FetcherInitArgs{
+				Txn:        txn,
 				Alloc:      &alloc,
 				MemMonitor: mm.Monitor(),
 				Spec:       &spec,
@@ -417,7 +418,7 @@ INSERT INTO foo VALUES (1), (10), (100);
 		))
 
 		require.NoError(t, fetcher.StartScan(
-			ctx, txn, spans, nil /* spanIDs */, rowinfra.NoBytesLimit, 0,
+			ctx, spans, nil /* spanIDs */, rowinfra.NoBytesLimit, 0,
 		))
 		var rows []tree.Datums
 		for {

--- a/pkg/sql/indexbackfiller_test.go
+++ b/pkg/sql/indexbackfiller_test.go
@@ -412,11 +412,12 @@ INSERT INTO foo VALUES (1), (10), (100);
 				Alloc:      &alloc,
 				MemMonitor: mm.Monitor(),
 				Spec:       &spec,
+				TraceKV:    true,
 			},
 		))
 
 		require.NoError(t, fetcher.StartScan(
-			ctx, txn, spans, nil /* spanIDs */, rowinfra.NoBytesLimit, 0, true, false, /* forceProductionBatchSize */
+			ctx, txn, spans, nil /* spanIDs */, rowinfra.NoBytesLimit, 0,
 		))
 		var rows []tree.Datums
 		for {

--- a/pkg/sql/row/BUILD.bazel
+++ b/pkg/sql/row/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//pkg/testutils/buildutil:buildutil.bzl", "disallowed_imports_test")
 
 go_library(
     name = "row",
@@ -27,6 +28,7 @@ go_library(
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",
+        "//pkg/kv/kvclient/kvcoord",
         "//pkg/kv/kvclient/kvstreamer",
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/kv/kvserver/kvserverbase",
@@ -69,6 +71,7 @@ go_library(
         "//pkg/util/log/eventpb",
         "//pkg/util/mon",
         "//pkg/util/protoutil",
+        "//pkg/util/stop",
         "//pkg/util/timeutil",
         "//pkg/util/unique",
         "//pkg/util/uuid",
@@ -124,4 +127,9 @@ go_test(
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
+)
+
+disallowed_imports_test(
+    "row",
+    ["//pkg/sql/execinfra"],
 )

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -280,8 +281,9 @@ func DecodeRowInfo(
 	if err := rf.Init(
 		ctx,
 		FetcherInitArgs{
-			Alloc: &tree.DatumAlloc{},
-			Spec:  &spec,
+			WillUseCustomKVBatchFetcher: true,
+			Alloc:                       &tree.DatumAlloc{},
+			Spec:                        &spec,
 		},
 	); err != nil {
 		return nil, nil, nil, err
@@ -314,6 +316,12 @@ func DecodeRowInfo(
 		values[i] = datums[i].String()
 	}
 	return index, names, values, nil
+}
+
+func (f *singleKVFetcher) SetupNextFetch(
+	context.Context, roachpb.Spans, []int, rowinfra.BytesLimit, rowinfra.KeyLimit,
+) error {
+	return nil
 }
 
 func (f *singleKVFetcher) close(context.Context) {}

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -292,7 +292,7 @@ func DecodeRowInfo(
 	}
 	// Use the Fetcher to decode the single kv pair above by passing in
 	// this singleKVFetcher implementation, which doesn't actually hit KV.
-	if err := rf.StartScanFrom(ctx, &f, false /* traceKV */); err != nil {
+	if err := rf.StartScanFrom(ctx, &f); err != nil {
 		return nil, nil, nil, err
 	}
 	datums, err := rf.NextRowDecoded(ctx)

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -149,32 +149,12 @@ type tableInfo struct {
 //      // Process res.row
 //   }
 type Fetcher struct {
+	args  FetcherInitArgs
 	table tableInfo
-
-	// reverse denotes whether or not the spans should be read in reverse
-	// or not when StartScan is invoked.
-	reverse bool
 
 	// True if the index key must be decoded. This is only false if there are no
 	// needed columns.
 	mustDecodeIndexKey bool
-
-	// lockStrength represents the row-level locking mode to use when fetching
-	// rows.
-	lockStrength descpb.ScanLockingStrength
-
-	// lockWaitPolicy represents the policy to be used for handling conflicting
-	// locks held by other active transactions.
-	lockWaitPolicy descpb.ScanLockingWaitPolicy
-
-	// lockTimeout specifies the maximum amount of time that the fetcher will
-	// wait while attempting to acquire a lock on a key or while blocking on an
-	// existing lock in order to perform a non-locking read on a key.
-	lockTimeout time.Duration
-
-	// traceKV indicates whether or not session tracing is enabled. It is set
-	// when beginning a new scan.
-	traceKV bool
 
 	// mvccDecodeStrategy controls whether or not MVCC timestamps should
 	// be decoded from KV's fetched.
@@ -201,9 +181,6 @@ type Fetcher struct {
 	// IgnoreUnexpectedNulls allows Fetcher to return null values for non-nullable
 	// columns and is only used for decoding for error messages or debugging.
 	IgnoreUnexpectedNulls bool
-
-	// Buffered allocation of decoded datums.
-	alloc *tree.DatumAlloc
 
 	// Memory monitor and memory account for the bytes fetched by this fetcher.
 	mon             *mon.BytesMonitor
@@ -233,13 +210,26 @@ func (rf *Fetcher) Close(ctx context.Context) {
 
 // FetcherInitArgs contains arguments for Fetcher.Init.
 type FetcherInitArgs struct {
-	Reverse        bool
-	LockStrength   descpb.ScanLockingStrength
+	// Reverse denotes whether or not the spans should be read in reverse or not
+	// when StartScan* methods are invoked.
+	Reverse bool
+	// LockStrength represents the row-level locking mode to use when fetching
+	// rows.
+	LockStrength descpb.ScanLockingStrength
+	// LockWaitPolicy represents the policy to be used for handling conflicting
+	// locks held by other active transactions.
 	LockWaitPolicy descpb.ScanLockingWaitPolicy
-	LockTimeout    time.Duration
-	Alloc          *tree.DatumAlloc
-	MemMonitor     *mon.BytesMonitor
-	Spec           *descpb.IndexFetchSpec
+	// LockTimeout specifies the maximum amount of time that the fetcher will
+	// wait while attempting to acquire a lock on a key or while blocking on an
+	// existing lock in order to perform a non-locking read on a key.
+	LockTimeout time.Duration
+	// Alloc is used for buffered allocation of decoded datums.
+	Alloc      *tree.DatumAlloc
+	MemMonitor *mon.BytesMonitor
+	Spec       *descpb.IndexFetchSpec
+	// TraceKV indicates whether or not session tracing is enabled.
+	TraceKV                    bool
+	ForceProductionKVBatchSize bool
 }
 
 // Init sets up a Fetcher for a given table and index.
@@ -247,11 +237,8 @@ func (rf *Fetcher) Init(ctx context.Context, args FetcherInitArgs) error {
 	if args.Spec.Version != descpb.IndexFetchSpecVersionInitial {
 		return errors.Newf("unsupported IndexFetchSpec version %d", args.Spec.Version)
 	}
-	rf.reverse = args.Reverse
-	rf.lockStrength = args.LockStrength
-	rf.lockWaitPolicy = args.LockWaitPolicy
-	rf.lockTimeout = args.LockTimeout
-	rf.alloc = args.Alloc
+
+	rf.args = args
 
 	if args.MemMonitor != nil {
 		rf.mon = mon.NewMonitorInheritWithLimit("fetcher-mem", 0 /* limit */, args.MemMonitor)
@@ -398,8 +385,6 @@ func (rf *Fetcher) StartScan(
 	spanIDs []int,
 	batchBytesLimit rowinfra.BytesLimit,
 	rowLimitHint rowinfra.RowLimit,
-	traceKV bool,
-	forceProductionKVBatchSize bool,
 ) error {
 	if len(spans) == 0 {
 		return errors.AssertionFailedf("no spans")
@@ -411,14 +396,14 @@ func (rf *Fetcher) StartScan(
 			sendFn:                     makeKVBatchFetcherDefaultSendFunc(txn),
 			spans:                      spans,
 			spanIDs:                    spanIDs,
-			reverse:                    rf.reverse,
+			reverse:                    rf.args.Reverse,
 			batchBytesLimit:            batchBytesLimit,
 			firstBatchKeyLimit:         rf.rowLimitToKeyLimit(rowLimitHint),
-			lockStrength:               rf.lockStrength,
-			lockWaitPolicy:             rf.lockWaitPolicy,
-			lockTimeout:                rf.lockTimeout,
+			lockStrength:               rf.args.LockStrength,
+			lockWaitPolicy:             rf.args.LockWaitPolicy,
+			lockTimeout:                rf.args.LockTimeout,
 			acc:                        rf.kvFetcherMemAcc,
-			forceProductionKVBatchSize: forceProductionKVBatchSize,
+			forceProductionKVBatchSize: rf.args.ForceProductionKVBatchSize,
 			requestAdmissionHeader:     txn.AdmissionHeader(),
 			responseAdmissionQ:         txn.DB().SQLKVResponseAdmissionQ,
 		},
@@ -426,7 +411,7 @@ func (rf *Fetcher) StartScan(
 	if err != nil {
 		return err
 	}
-	return rf.StartScanFrom(ctx, &f, traceKV)
+	return rf.StartScanFrom(ctx, &f)
 }
 
 // TestingInconsistentScanSleep introduces a sleep inside the fetcher after
@@ -453,8 +438,6 @@ func (rf *Fetcher) StartInconsistentScan(
 	spans roachpb.Spans,
 	batchBytesLimit rowinfra.BytesLimit,
 	rowLimitHint rowinfra.RowLimit,
-	traceKV bool,
-	forceProductionKVBatchSize bool,
 	qualityOfService sessiondatapb.QoSLevel,
 ) error {
 	if len(spans) == 0 {
@@ -515,14 +498,14 @@ func (rf *Fetcher) StartInconsistentScan(
 			sendFn:                     sendFn,
 			spans:                      spans,
 			spanIDs:                    nil,
-			reverse:                    rf.reverse,
+			reverse:                    rf.args.Reverse,
 			batchBytesLimit:            batchBytesLimit,
 			firstBatchKeyLimit:         rf.rowLimitToKeyLimit(rowLimitHint),
-			lockStrength:               rf.lockStrength,
-			lockWaitPolicy:             rf.lockWaitPolicy,
-			lockTimeout:                rf.lockTimeout,
+			lockStrength:               rf.args.LockStrength,
+			lockWaitPolicy:             rf.args.LockWaitPolicy,
+			lockTimeout:                rf.args.LockTimeout,
 			acc:                        rf.kvFetcherMemAcc,
-			forceProductionKVBatchSize: forceProductionKVBatchSize,
+			forceProductionKVBatchSize: rf.args.ForceProductionKVBatchSize,
 			requestAdmissionHeader:     txn.AdmissionHeader(),
 			responseAdmissionQ:         txn.DB().SQLKVResponseAdmissionQ,
 		},
@@ -530,7 +513,7 @@ func (rf *Fetcher) StartInconsistentScan(
 	if err != nil {
 		return err
 	}
-	return rf.StartScanFrom(ctx, &f, traceKV)
+	return rf.StartScanFrom(ctx, &f)
 }
 
 func (rf *Fetcher) rowLimitToKeyLimit(rowLimitHint rowinfra.RowLimit) rowinfra.KeyLimit {
@@ -550,8 +533,7 @@ func (rf *Fetcher) rowLimitToKeyLimit(rowLimitHint rowinfra.RowLimit) rowinfra.K
 
 // StartScanFrom initializes and starts a scan from the given KVBatchFetcher. Can be
 // used multiple times.
-func (rf *Fetcher) StartScanFrom(ctx context.Context, f KVBatchFetcher, traceKV bool) error {
-	rf.traceKV = traceKV
+func (rf *Fetcher) StartScanFrom(ctx context.Context, f KVBatchFetcher) error {
 	rf.indexKey = nil
 	if rf.kvFetcher != nil {
 		rf.kvFetcher.Close(ctx)
@@ -668,7 +650,7 @@ func (rf *Fetcher) prettyKeyDatums(
 	var buf strings.Builder
 	for i, v := range vals {
 		buf.WriteByte('/')
-		if err := v.EnsureDecoded(cols[i].Type, rf.alloc); err != nil {
+		if err := v.EnsureDecoded(cols[i].Type, rf.args.Alloc); err != nil {
 			buf.WriteByte('?')
 		} else {
 			buf.WriteString(v.Datum.String())
@@ -692,7 +674,7 @@ func (rf *Fetcher) processKV(
 ) (prettyKey string, prettyValue string, err error) {
 	table := &rf.table
 
-	if rf.traceKV {
+	if rf.args.TraceKV {
 		prettyKey = fmt.Sprintf(
 			"/%s/%s%s",
 			table.spec.TableName,
@@ -744,7 +726,7 @@ func (rf *Fetcher) processKV(
 
 	if len(table.spec.FetchedColumns) == 0 {
 		// We don't need to decode any values.
-		if rf.traceKV {
+		if rf.args.TraceKV {
 			prettyValue = "<undecoded>"
 		}
 		return prettyKey, prettyValue, nil
@@ -832,7 +814,7 @@ func (rf *Fetcher) processKV(
 						table.row[idx] = table.extraVals[i]
 					}
 				}
-				if rf.traceKV {
+				if rf.args.TraceKV {
 					prettyValue = rf.prettyKeyDatums(extraCols, table.extraVals)
 				}
 			}
@@ -853,7 +835,7 @@ func (rf *Fetcher) processKV(
 		}
 	}
 
-	if rf.traceKV && prettyValue == "" {
+	if rf.args.TraceKV && prettyValue == "" {
 		prettyValue = "<undecoded>"
 	}
 
@@ -880,7 +862,7 @@ func (rf *Fetcher) processValueSingle(
 		return prettyKey, "", nil
 	}
 
-	if rf.traceKV {
+	if rf.args.TraceKV {
 		prettyKey = fmt.Sprintf("%s/%s", prettyKey, table.spec.FetchedColumns[idx].Name)
 	}
 	if len(kv.Value.RawBytes) == 0 {
@@ -892,11 +874,11 @@ func (rf *Fetcher) processValueSingle(
 	// although that would require changing UnmarshalColumnValue to operate
 	// on bytes, and for Encode/DecodeTableValue to operate on marshaled
 	// single values.
-	value, err := valueside.UnmarshalLegacy(rf.alloc, typ, kv.Value)
+	value, err := valueside.UnmarshalLegacy(rf.args.Alloc, typ, kv.Value)
 	if err != nil {
 		return "", "", err
 	}
-	if rf.traceKV {
+	if rf.args.TraceKV {
 		prettyValue = value.String()
 	}
 	table.row[idx] = rowenc.DatumToEncDatum(typ, value)
@@ -914,7 +896,7 @@ func (rf *Fetcher) processValueBytes(
 	prettyKeyPrefix string,
 ) (prettyKey string, prettyValue string, err error) {
 	prettyKey = prettyKeyPrefix
-	if rf.traceKV {
+	if rf.args.TraceKV {
 		if rf.prettyValueBuf == nil {
 			rf.prettyValueBuf = &bytes.Buffer{}
 		}
@@ -946,7 +928,7 @@ func (rf *Fetcher) processValueBytes(
 			continue
 		}
 
-		if rf.traceKV {
+		if rf.args.TraceKV {
 			prettyKey = fmt.Sprintf("%s/%s", prettyKey, table.spec.FetchedColumns[idx].Name)
 		}
 
@@ -956,8 +938,8 @@ func (rf *Fetcher) processValueBytes(
 		if err != nil {
 			return "", "", err
 		}
-		if rf.traceKV {
-			err := encValue.EnsureDecoded(table.spec.FetchedColumns[idx].Type, rf.alloc)
+		if rf.args.TraceKV {
+			err := encValue.EnsureDecoded(table.spec.FetchedColumns[idx].Type, rf.args.Alloc)
 			if err != nil {
 				return "", "", err
 			}
@@ -969,7 +951,7 @@ func (rf *Fetcher) processValueBytes(
 			log.Infof(ctx, "Scan %d -> %v", idx, encValue)
 		}
 	}
-	if rf.traceKV {
+	if rf.args.TraceKV {
 		prettyValue = rf.prettyValueBuf.String()
 	}
 	return prettyKey, prettyValue, nil
@@ -999,7 +981,7 @@ func (rf *Fetcher) NextRow(ctx context.Context) (row rowenc.EncDatumRow, spanID 
 		if err != nil {
 			return nil, 0, err
 		}
-		if rf.traceKV {
+		if rf.args.TraceKV {
 			log.VEventf(ctx, 2, "fetched: %s -> %s", prettyKey, prettyVal)
 		}
 
@@ -1059,7 +1041,7 @@ func (rf *Fetcher) NextRowDecoded(ctx context.Context) (datums tree.Datums, err 
 			rf.table.decodedRow[i] = tree.DNull
 			continue
 		}
-		if err := encDatum.EnsureDecoded(rf.table.spec.FetchedColumns[i].Type, rf.alloc); err != nil {
+		if err := encDatum.EnsureDecoded(rf.table.spec.FetchedColumns[i].Type, rf.args.Alloc); err != nil {
 			return nil, err
 		}
 		rf.table.decodedRow[i] = encDatum.Datum
@@ -1099,7 +1081,7 @@ func (rf *Fetcher) NextRowDecodedInto(
 			destination[ord] = tree.DNull
 			continue
 		}
-		if err := encDatum.EnsureDecoded(col.Type, rf.alloc); err != nil {
+		if err := encDatum.EnsureDecoded(col.Type, rf.args.Alloc); err != nil {
 			return false, err
 		}
 		destination[ord] = encDatum.Datum
@@ -1130,7 +1112,7 @@ func (rf *Fetcher) finalizeRow() error {
 		// TODO (rohany): Datums are immutable, so we can't store a DDecimal on the
 		//  fetcher and change its contents with each row. If that assumption gets
 		//  lifted, then we can avoid an allocation of a new decimal datum here.
-		dec := rf.alloc.NewDDecimal(tree.DDecimal{Decimal: eval.TimestampToDecimal(rf.RowLastModified())})
+		dec := rf.args.Alloc.NewDDecimal(tree.DDecimal{Decimal: eval.TimestampToDecimal(rf.RowLastModified())})
 		table.row[table.timestampOutputIdx] = rowenc.EncDatum{Datum: dec}
 	}
 	if table.oidOutputIdx != noOutputColumn {

--- a/pkg/sql/row/fetcher_mvcc_test.go
+++ b/pkg/sql/row/fetcher_mvcc_test.go
@@ -97,8 +97,9 @@ func TestRowFetcherMVCCMetadata(t *testing.T) {
 	if err := rf.Init(
 		ctx,
 		row.FetcherInitArgs{
-			Alloc: &tree.DatumAlloc{},
-			Spec:  &spec,
+			WillUseCustomKVBatchFetcher: true,
+			Alloc:                       &tree.DatumAlloc{},
+			Spec:                        &spec,
 		},
 	); err != nil {
 		t.Fatal(err)

--- a/pkg/sql/row/fetcher_mvcc_test.go
+++ b/pkg/sql/row/fetcher_mvcc_test.go
@@ -114,7 +114,7 @@ func TestRowFetcherMVCCMetadata(t *testing.T) {
 			log.Infof(ctx, "%v %v %v", kv.Key, kv.Value.Timestamp, kv.Value.PrettyPrint())
 		}
 
-		if err := rf.StartScanFrom(ctx, &row.SpanKVFetcher{KVs: kvs}, false /* traceKV */); err != nil {
+		if err := rf.StartScanFrom(ctx, &row.SpanKVFetcher{KVs: kvs}); err != nil {
 			t.Fatal(err)
 		}
 		var rows []rowWithMVCCMetadata

--- a/pkg/sql/row/fetcher_test.go
+++ b/pkg/sql/row/fetcher_test.go
@@ -156,8 +156,6 @@ func TestNextRowSingle(t *testing.T) {
 				nil, /* spanIDs */
 				rowinfra.NoBytesLimit,
 				rowinfra.NoRowLimit,
-				false, /*traceKV*/
-				false, /*forceProductionKVBatchSize*/
 			); err != nil {
 				t.Fatal(err)
 			}
@@ -260,9 +258,7 @@ func TestNextRowBatchLimiting(t *testing.T) {
 				roachpb.Spans{tableDesc.IndexSpan(keys.SystemSQLCodec, tableDesc.GetPrimaryIndexID())},
 				nil, /* spanIDs */
 				rowinfra.GetDefaultBatchBytesLimit(false /* forceProductionValue */),
-				10,    /*limitHint*/
-				false, /*traceKV*/
-				false, /*forceProductionKVBatchSize*/
+				10, /*limitHint*/
 			); err != nil {
 				t.Fatal(err)
 			}
@@ -356,8 +352,6 @@ func TestRowFetcherMemoryLimits(t *testing.T) {
 		nil, /* spanIDs */
 		rowinfra.NoBytesLimit,
 		rowinfra.NoRowLimit,
-		false, /*traceKV*/
-		false, /*forceProductionKVBatchSize*/
 	)
 	assert.Error(t, err)
 	assert.Equal(t, pgerror.GetPGCode(err), pgcode.OutOfMemory)
@@ -435,9 +429,7 @@ INDEX(c)
 		rowinfra.GetDefaultBatchBytesLimit(false /* forceProductionValue */),
 		// Set a limitHint of 1 to more quickly end the first batch, causing a
 		// batch that ends between rows.
-		1,     /*limitHint*/
-		false, /*traceKV*/
-		false, /*forceProductionKVBatchSize*/
+		1, /*limitHint*/
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -593,8 +585,6 @@ func TestNextRowSecondaryIndex(t *testing.T) {
 				nil, /* spanIDs */
 				rowinfra.NoBytesLimit,
 				rowinfra.NoRowLimit,
-				false, /*traceKV*/
-				false, /*forceProductionKVBatchSize*/
 			); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -237,11 +237,7 @@ func makeKVBatchFetcherDefaultSendFunc(txn *kv.Txn) sendFunc {
 
 type kvBatchFetcherArgs struct {
 	sendFn                     sendFunc
-	spans                      roachpb.Spans
-	spanIDs                    []int
 	reverse                    bool
-	batchBytesLimit            rowinfra.BytesLimit
-	firstBatchKeyLimit         rowinfra.KeyLimit
 	lockStrength               descpb.ScanLockingStrength
 	lockWaitPolicy             descpb.ScanLockingWaitPolicy
 	lockTimeout                time.Duration
@@ -251,10 +247,34 @@ type kvBatchFetcherArgs struct {
 	responseAdmissionQ         *admission.WorkQueue
 }
 
-// makeKVBatchFetcher initializes a KVBatchFetcher for the given spans. If
-// useBatchLimit is true, the number of result keys per batch is limited; the
-// limit grows between subsequent batches, starting at firstBatchKeyLimit (if not
-// 0) to ProductionKVBatchSize.
+// newKVBatchFetcher initializes a KVBatchFetcher.
+//
+// The passed-in memory account is owned by the fetcher throughout its lifetime
+// but is **not** closed - it is the caller's responsibility to close acc if it
+// is non-nil.
+func newKVBatchFetcher(args kvBatchFetcherArgs) *txnKVFetcher {
+	return &txnKVFetcher{
+		sendFn:                     args.sendFn,
+		reverse:                    args.reverse,
+		lockStrength:               getKeyLockingStrength(args.lockStrength),
+		lockWaitPolicy:             getWaitPolicy(args.lockWaitPolicy),
+		lockTimeout:                args.lockTimeout,
+		acc:                        args.acc,
+		forceProductionKVBatchSize: args.forceProductionKVBatchSize,
+		requestAdmissionHeader:     args.requestAdmissionHeader,
+		responseAdmissionQ:         args.responseAdmissionQ,
+	}
+}
+
+// setTxnAndSendFn updates the txnKVFetcher with the new txn and sendFn. txn and
+// sendFn are assumed to be non-nil.
+func (f *txnKVFetcher) setTxnAndSendFn(txn *kv.Txn, sendFn sendFunc) {
+	f.sendFn = sendFn
+	f.requestAdmissionHeader = txn.AdmissionHeader()
+	f.responseAdmissionQ = txn.DB().SQLKVResponseAdmissionQ
+}
+
+// SetupNextFetch sets up the Fetcher for the next set of spans.
 //
 // The fetcher takes ownership of the spans slice - it can modify the slice and
 // will perform the memory accounting accordingly (if acc is non-nil). The
@@ -270,48 +290,52 @@ type kvBatchFetcherArgs struct {
 // If spanIDs is non-nil, then it must be of the same length as spans.
 //
 // Batch limits can only be used if the spans are ordered.
-//
-// The passed-in memory account is owned by the fetcher throughout its lifetime
-// but is **not** closed - it is the caller's responsibility to close acc if it
-// is non-nil.
-func makeKVBatchFetcher(ctx context.Context, args kvBatchFetcherArgs) (txnKVFetcher, error) {
-	if args.firstBatchKeyLimit < 0 || (args.batchBytesLimit == 0 && args.firstBatchKeyLimit != 0) {
-		// Passing firstBatchKeyLimit without batchBytesLimit doesn't make sense - the
-		// only reason to not set batchBytesLimit is in order to get DistSender-level
-		// parallelism, and setting firstBatchKeyLimit inhibits that.
-		return txnKVFetcher{}, errors.Errorf("invalid batch limit %d (batchBytesLimit: %d)",
-			args.firstBatchKeyLimit, args.batchBytesLimit)
+func (f *txnKVFetcher) SetupNextFetch(
+	ctx context.Context,
+	spans roachpb.Spans,
+	spanIDs []int,
+	batchBytesLimit rowinfra.BytesLimit,
+	firstBatchKeyLimit rowinfra.KeyLimit,
+) error {
+	f.reset(ctx)
+
+	if firstBatchKeyLimit < 0 || (batchBytesLimit == 0 && firstBatchKeyLimit != 0) {
+		// Passing firstBatchKeyLimit without batchBytesLimit doesn't make sense
+		// - the only reason to not set batchBytesLimit is in order to get
+		// DistSender-level parallelism, and setting firstBatchKeyLimit inhibits
+		// that.
+		return errors.Errorf("invalid batch limit %d (batchBytesLimit: %d)", firstBatchKeyLimit, batchBytesLimit)
 	}
 
-	if args.batchBytesLimit != 0 {
+	if batchBytesLimit != 0 {
 		// Verify the spans are ordered if a batch limit is used.
-		for i := 1; i < len(args.spans); i++ {
-			prevKey := args.spans[i-1].EndKey
+		for i := 1; i < len(spans); i++ {
+			prevKey := spans[i-1].EndKey
 			if prevKey == nil {
 				// This is the case of a GetRequest.
-				prevKey = args.spans[i-1].Key
+				prevKey = spans[i-1].Key
 			}
-			if args.spans[i].Key.Compare(prevKey) < 0 {
-				return txnKVFetcher{}, errors.Errorf("unordered spans (%s %s)", args.spans[i-1], args.spans[i])
+			if spans[i].Key.Compare(prevKey) < 0 {
+				return errors.Errorf("unordered spans (%s %s)", spans[i-1], spans[i])
 			}
 		}
 	} else if util.RaceEnabled {
 		// Otherwise, just verify the spans don't contain consecutive overlapping
 		// spans.
-		for i := 1; i < len(args.spans); i++ {
-			prevEndKey := args.spans[i-1].EndKey
+		for i := 1; i < len(spans); i++ {
+			prevEndKey := spans[i-1].EndKey
 			if prevEndKey == nil {
-				prevEndKey = args.spans[i-1].Key
+				prevEndKey = spans[i-1].Key
 			}
-			curEndKey := args.spans[i].EndKey
+			curEndKey := spans[i].EndKey
 			if curEndKey == nil {
-				curEndKey = args.spans[i].Key
+				curEndKey = spans[i].Key
 			}
-			if args.spans[i].Key.Compare(prevEndKey) >= 0 {
+			if spans[i].Key.Compare(prevEndKey) >= 0 {
 				// Current span's start key is greater than or equal to the last span's
 				// end key - we're good.
 				continue
-			} else if curEndKey.Compare(args.spans[i-1].Key) <= 0 {
+			} else if curEndKey.Compare(spans[i-1].Key) <= 0 {
 				// Current span's end key is less than or equal to the last span's start
 				// key - also good.
 				continue
@@ -319,34 +343,23 @@ func makeKVBatchFetcher(ctx context.Context, args kvBatchFetcherArgs) (txnKVFetc
 			// Otherwise, the two spans overlap, which isn't allowed - it leaves us at
 			// risk of incorrect results, since the row fetcher can't distinguish
 			// between identical rows in two different batches.
-			return txnKVFetcher{}, errors.Errorf("overlapping neighbor spans (%s %s)", args.spans[i-1], args.spans[i])
+			return errors.Errorf("overlapping neighbor spans (%s %s)", spans[i-1], spans[i])
 		}
 	}
 
-	f := txnKVFetcher{
-		sendFn:                     args.sendFn,
-		reverse:                    args.reverse,
-		batchBytesLimit:            args.batchBytesLimit,
-		firstBatchKeyLimit:         args.firstBatchKeyLimit,
-		lockStrength:               getKeyLockingStrength(args.lockStrength),
-		lockWaitPolicy:             GetWaitPolicy(args.lockWaitPolicy),
-		lockTimeout:                args.lockTimeout,
-		acc:                        args.acc,
-		forceProductionKVBatchSize: args.forceProductionKVBatchSize,
-		requestAdmissionHeader:     args.requestAdmissionHeader,
-		responseAdmissionQ:         args.responseAdmissionQ,
-	}
+	f.batchBytesLimit = batchBytesLimit
+	f.firstBatchKeyLimit = firstBatchKeyLimit
 
 	// Account for the memory of the spans that we're taking the ownership of.
 	if f.acc != nil {
-		f.spansAccountedFor = args.spans.MemUsage()
+		f.spansAccountedFor = spans.MemUsage()
 		if err := f.acc.Grow(ctx, f.spansAccountedFor); err != nil {
-			return txnKVFetcher{}, err
+			return err
 		}
 	}
 
-	if args.spanIDs != nil && len(args.spans) != len(args.spanIDs) {
-		return txnKVFetcher{}, errors.AssertionFailedf("unexpectedly non-nil spanIDs slice has a different length than spans")
+	if spanIDs != nil && len(spans) != len(spanIDs) {
+		return errors.AssertionFailedf("unexpectedly non-nil spanIDs slice has a different length than spans")
 	}
 
 	// Since the fetcher takes ownership of the spans slice, we don't need to
@@ -354,10 +367,10 @@ func makeKVBatchFetcher(ctx context.Context, args kvBatchFetcherArgs) (txnKVFetc
 	// fetcher receives the resume spans), but the fetcher will always keep the
 	// memory accounting up to date.
 	f.spans = identifiableSpans{
-		Spans:   args.spans,
-		spanIDs: args.spanIDs,
+		Spans:   spans,
+		spanIDs: spanIDs,
 	}
-	if args.reverse {
+	if f.reverse {
 		// Reverse scans receive the spans in decreasing order. Note that we
 		// need to be this tricky since we're updating the spans in place.
 		i, j := 0, f.spans.Len()-1
@@ -371,7 +384,7 @@ func makeKVBatchFetcher(ctx context.Context, args kvBatchFetcherArgs) (txnKVFetc
 	// larger slices when processing the resume spans.
 	f.scratchSpans = f.spans
 
-	return f, nil
+	return nil
 }
 
 // fetch retrieves spans from the kv layer.
@@ -603,14 +616,21 @@ func (f *txnKVFetcher) nextBatch(ctx context.Context) (resp kvBatchFetcherRespon
 	return f.nextBatch(ctx)
 }
 
-// close releases the resources of this txnKVFetcher.
-func (f *txnKVFetcher) close(ctx context.Context) {
+func (f *txnKVFetcher) reset(ctx context.Context) {
+	f.alreadyFetched = false
+	f.batchIdx = 0
 	f.responses = nil
 	f.remainingBatches = nil
 	f.spans = identifiableSpans{}
 	f.scratchSpans = identifiableSpans{}
 	// Release only the allocations made by this fetcher.
 	f.acc.Shrink(ctx, f.batchResponseAccountedFor+f.spansAccountedFor)
+	f.batchResponseAccountedFor, f.spansAccountedFor = 0, 0
+}
+
+// close releases the resources of this txnKVFetcher.
+func (f *txnKVFetcher) close(ctx context.Context) {
+	f.reset(ctx)
 }
 
 // spansToRequests converts the provided spans to the corresponding requests. If

--- a/pkg/sql/row/locking.go
+++ b/pkg/sql/row/locking.go
@@ -44,9 +44,9 @@ func getKeyLockingStrength(lockStrength descpb.ScanLockingStrength) lock.Strengt
 	}
 }
 
-// GetWaitPolicy returns the configured lock wait policy to use for key-value
+// getWaitPolicy returns the configured lock wait policy to use for key-value
 // scans.
-func GetWaitPolicy(lockWaitPolicy descpb.ScanLockingWaitPolicy) lock.WaitPolicy {
+func getWaitPolicy(lockWaitPolicy descpb.ScanLockingWaitPolicy) lock.WaitPolicy {
 	switch lockWaitPolicy {
 	case descpb.ScanLockingWaitPolicy_BLOCK:
 		return lock.WaitPolicy_Block

--- a/pkg/sql/rowexec/BUILD.bazel
+++ b/pkg/sql/rowexec/BUILD.bazel
@@ -46,7 +46,6 @@ go_library(
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/kvclient/kvstreamer",
-        "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/roachpb",
         "//pkg/server/telemetry",

--- a/pkg/sql/rowexec/columnbackfiller.go
+++ b/pkg/sql/rowexec/columnbackfiller.go
@@ -78,8 +78,9 @@ func newColumnBackfiller(
 	}
 	cb.backfiller.chunks = cb
 
-	if err := cb.ColumnBackfiller.InitForDistributedUse(ctx, flowCtx, cb.desc,
-		columnBackfillerMon); err != nil {
+	if err := cb.ColumnBackfiller.InitForDistributedUse(
+		ctx, flowCtx, cb.desc, columnBackfillerMon,
+	); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -432,8 +432,9 @@ func (ib *indexBackfiller) buildIndexEntryBatch(
 
 		// TODO(knz): do KV tracing in DistSQL processors.
 		var err error
-		entries, key, memUsedBuildingBatch, err = ib.BuildIndexEntriesChunk(ctx, txn, ib.desc, sp,
-			ib.spec.ChunkSize, false /*traceKV*/)
+		entries, key, memUsedBuildingBatch, err = ib.BuildIndexEntriesChunk(
+			ctx, txn, ib.desc, sp, ib.spec.ChunkSize, false, /* traceKV */
+		)
 		return err
 	}); err != nil {
 		return nil, nil, 0, err

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -291,6 +291,7 @@ func newInvertedJoiner(
 	if err := fetcher.Init(
 		flowCtx.EvalCtx.Context,
 		row.FetcherInitArgs{
+			Txn:                        flowCtx.Txn,
 			LockStrength:               spec.LockingStrength,
 			LockWaitPolicy:             spec.LockingWaitPolicy,
 			LockTimeout:                flowCtx.EvalCtx.SessionData().LockTimeout,
@@ -496,7 +497,7 @@ func (ij *invertedJoiner) readInput() (invertedJoinerState, *execinfrapb.Produce
 
 	log.VEventf(ij.Ctx, 1, "scanning %d spans", len(ij.indexSpans))
 	if err = ij.fetcher.StartScan(
-		ij.Ctx, ij.FlowCtx.Txn, ij.indexSpans, nil, /* spanIDs */
+		ij.Ctx, ij.indexSpans, nil, /* spanIDs */
 		rowinfra.NoBytesLimit, rowinfra.NoRowLimit,
 	); err != nil {
 		ij.MoveToDraining(err)

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -291,12 +291,14 @@ func newInvertedJoiner(
 	if err := fetcher.Init(
 		flowCtx.EvalCtx.Context,
 		row.FetcherInitArgs{
-			LockStrength:   spec.LockingStrength,
-			LockWaitPolicy: spec.LockingWaitPolicy,
-			LockTimeout:    flowCtx.EvalCtx.SessionData().LockTimeout,
-			Alloc:          &ij.alloc,
-			MemMonitor:     flowCtx.EvalCtx.Mon,
-			Spec:           &spec.FetchSpec,
+			LockStrength:               spec.LockingStrength,
+			LockWaitPolicy:             spec.LockingWaitPolicy,
+			LockTimeout:                flowCtx.EvalCtx.SessionData().LockTimeout,
+			Alloc:                      &ij.alloc,
+			MemMonitor:                 flowCtx.EvalCtx.Mon,
+			Spec:                       &spec.FetchSpec,
+			TraceKV:                    flowCtx.TraceKV,
+			ForceProductionKVBatchSize: flowCtx.EvalCtx.TestingKnobs.ForceProductionValues,
 		},
 	); err != nil {
 		return nil, err
@@ -496,7 +498,6 @@ func (ij *invertedJoiner) readInput() (invertedJoinerState, *execinfrapb.Produce
 	if err = ij.fetcher.StartScan(
 		ij.Ctx, ij.FlowCtx.Txn, ij.indexSpans, nil, /* spanIDs */
 		rowinfra.NoBytesLimit, rowinfra.NoRowLimit,
-		ij.FlowCtx.TraceKV, ij.EvalCtx.TestingKnobs.ForceProductionValues,
 	); err != nil {
 		ij.MoveToDraining(err)
 		return ijStateUnknown, ij.DrainHelper()

--- a/pkg/sql/rowexec/rowfetcher.go
+++ b/pkg/sql/rowexec/rowfetcher.go
@@ -28,10 +28,10 @@ import (
 // collector wrapper can be plugged in.
 type rowFetcher interface {
 	StartScan(
-		_ context.Context, _ *kv.Txn, _ roachpb.Spans, spanIDs []int, batchBytesLimit rowinfra.BytesLimit,
-		rowLimitHint rowinfra.RowLimit, traceKV bool, forceProductionKVBatchSize bool,
+		_ context.Context, _ *kv.Txn, _ roachpb.Spans, spanIDs []int,
+		batchBytesLimit rowinfra.BytesLimit, rowLimitHint rowinfra.RowLimit,
 	) error
-	StartScanFrom(_ context.Context, _ row.KVBatchFetcher, traceKV bool) error
+	StartScanFrom(_ context.Context, _ row.KVBatchFetcher) error
 	StartInconsistentScan(
 		_ context.Context,
 		_ *kv.DB,
@@ -40,8 +40,6 @@ type rowFetcher interface {
 		spans roachpb.Spans,
 		batchBytesLimit rowinfra.BytesLimit,
 		rowLimitHint rowinfra.RowLimit,
-		traceKV bool,
-		forceProductionKVBatchSize bool,
 		qualityOfService sessiondatapb.QoSLevel,
 	) error
 

--- a/pkg/sql/rowexec/rowfetcher.go
+++ b/pkg/sql/rowexec/rowfetcher.go
@@ -28,7 +28,7 @@ import (
 // collector wrapper can be plugged in.
 type rowFetcher interface {
 	StartScan(
-		_ context.Context, _ *kv.Txn, _ roachpb.Spans, spanIDs []int,
+		_ context.Context, _ roachpb.Spans, spanIDs []int,
 		batchBytesLimit rowinfra.BytesLimit, rowLimitHint rowinfra.RowLimit,
 	) error
 	StartScanFrom(_ context.Context, _ row.KVBatchFetcher) error

--- a/pkg/sql/rowexec/stats.go
+++ b/pkg/sql/rowexec/stats.go
@@ -94,14 +94,13 @@ func newRowFetcherStatCollector(f *row.Fetcher) *rowFetcherStatCollector {
 // StartScan is part of the rowFetcher interface.
 func (c *rowFetcherStatCollector) StartScan(
 	ctx context.Context,
-	txn *kv.Txn,
 	spans roachpb.Spans,
 	spanIDs []int,
 	batchBytesLimit rowinfra.BytesLimit,
 	limitHint rowinfra.RowLimit,
 ) error {
 	start := timeutil.Now()
-	err := c.fetcher.StartScan(ctx, txn, spans, spanIDs, batchBytesLimit, limitHint)
+	err := c.fetcher.StartScan(ctx, spans, spanIDs, batchBytesLimit, limitHint)
 	c.startScanStallTime += timeutil.Since(start)
 	return err
 }
@@ -127,8 +126,7 @@ func (c *rowFetcherStatCollector) StartInconsistentScan(
 ) error {
 	start := timeutil.Now()
 	err := c.fetcher.StartInconsistentScan(
-		ctx, db, initialTimestamp, maxTimestampAge, spans, batchBytesLimit,
-		limitHint, qualityOfService,
+		ctx, db, initialTimestamp, maxTimestampAge, spans, batchBytesLimit, limitHint, qualityOfService,
 	)
 	c.startScanStallTime += timeutil.Since(start)
 	return err

--- a/pkg/sql/rowexec/stats.go
+++ b/pkg/sql/rowexec/stats.go
@@ -99,21 +99,17 @@ func (c *rowFetcherStatCollector) StartScan(
 	spanIDs []int,
 	batchBytesLimit rowinfra.BytesLimit,
 	limitHint rowinfra.RowLimit,
-	traceKV bool,
-	forceProductionKVBatchSize bool,
 ) error {
 	start := timeutil.Now()
-	err := c.fetcher.StartScan(ctx, txn, spans, spanIDs, batchBytesLimit, limitHint, traceKV, forceProductionKVBatchSize)
+	err := c.fetcher.StartScan(ctx, txn, spans, spanIDs, batchBytesLimit, limitHint)
 	c.startScanStallTime += timeutil.Since(start)
 	return err
 }
 
 // StartScanFrom is part of the rowFetcher interface.
-func (c *rowFetcherStatCollector) StartScanFrom(
-	ctx context.Context, f row.KVBatchFetcher, traceKV bool,
-) error {
+func (c *rowFetcherStatCollector) StartScanFrom(ctx context.Context, f row.KVBatchFetcher) error {
 	start := timeutil.Now()
-	err := c.fetcher.StartScanFrom(ctx, f, traceKV)
+	err := c.fetcher.StartScanFrom(ctx, f)
 	c.startScanStallTime += timeutil.Since(start)
 	return err
 }
@@ -127,14 +123,12 @@ func (c *rowFetcherStatCollector) StartInconsistentScan(
 	spans roachpb.Spans,
 	batchBytesLimit rowinfra.BytesLimit,
 	limitHint rowinfra.RowLimit,
-	traceKV bool,
-	forceProductionKVBatchSize bool,
 	qualityOfService sessiondatapb.QoSLevel,
 ) error {
 	start := timeutil.Now()
 	err := c.fetcher.StartInconsistentScan(
-		ctx, db, initialTimestamp, maxTimestampAge, spans, batchBytesLimit, limitHint, traceKV,
-		forceProductionKVBatchSize, qualityOfService,
+		ctx, db, initialTimestamp, maxTimestampAge, spans, batchBytesLimit,
+		limitHint, qualityOfService,
 	)
 	c.startScanStallTime += timeutil.Since(start)
 	return err

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -148,6 +148,7 @@ func newTableReader(
 	if err := fetcher.Init(
 		flowCtx.EvalCtx.Context,
 		row.FetcherInitArgs{
+			Txn:                        flowCtx.Txn,
 			Reverse:                    spec.Reverse,
 			LockStrength:               spec.LockingStrength,
 			LockWaitPolicy:             spec.LockingWaitPolicy,
@@ -211,7 +212,7 @@ func (tr *tableReader) startScan(ctx context.Context) error {
 	var err error
 	if tr.maxTimestampAge == 0 {
 		err = tr.fetcher.StartScan(
-			ctx, tr.FlowCtx.Txn, tr.Spans, nil /* spanIDs */, bytesLimit, tr.limitHint,
+			ctx, tr.Spans, nil /* spanIDs */, bytesLimit, tr.limitHint,
 		)
 	} else {
 		initialTS := tr.FlowCtx.Txn.ReadTimestamp()

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -457,12 +457,14 @@ func (z *zigzagJoiner) setupInfo(
 	if err := fetcher.Init(
 		flowCtx.EvalCtx.Context,
 		row.FetcherInitArgs{
-			LockStrength:   spec.LockingStrength,
-			LockWaitPolicy: spec.LockingWaitPolicy,
-			LockTimeout:    flowCtx.EvalCtx.SessionData().LockTimeout,
-			Alloc:          &info.alloc,
-			MemMonitor:     flowCtx.EvalCtx.Mon,
-			Spec:           &spec.FetchSpec,
+			LockStrength:               spec.LockingStrength,
+			LockWaitPolicy:             spec.LockingWaitPolicy,
+			LockTimeout:                flowCtx.EvalCtx.SessionData().LockTimeout,
+			Alloc:                      &info.alloc,
+			MemMonitor:                 flowCtx.EvalCtx.Mon,
+			Spec:                       &spec.FetchSpec,
+			TraceKV:                    flowCtx.TraceKV,
+			ForceProductionKVBatchSize: flowCtx.EvalCtx.TestingKnobs.ForceProductionValues,
 		},
 	); err != nil {
 		return err
@@ -650,8 +652,6 @@ func (z *zigzagJoiner) nextRow(ctx context.Context, txn *kv.Txn) (rowenc.EncDatu
 			nil, /* spanIDs */
 			rowinfra.GetDefaultBatchBytesLimit(z.EvalCtx.TestingKnobs.ForceProductionValues),
 			zigzagJoinerBatchSize,
-			z.FlowCtx.TraceKV,
-			z.EvalCtx.TestingKnobs.ForceProductionValues,
 		)
 		if err != nil {
 			return nil, err
@@ -793,8 +793,6 @@ func (z *zigzagJoiner) maybeFetchInitialRow() error {
 			nil, /* spanIDs */
 			rowinfra.GetDefaultBatchBytesLimit(z.EvalCtx.TestingKnobs.ForceProductionValues),
 			zigzagJoinerBatchSize,
-			z.FlowCtx.TraceKV,
-			z.EvalCtx.TestingKnobs.ForceProductionValues,
 		)
 		if err != nil {
 			log.Errorf(z.Ctx, "scan error: %s", err)


### PR DESCRIPTION
**sql: clean up Fetcher interfaces a bit**

This commit removes a couple of arguments (`traceKV`,
`forceProductionBatchSize`) from `StartScan*` fetcher methods in
favor of passing them on `Init`. Additionally, several fields are
removed from `row.Fetcher` in favor of accessing the args struct
directly.
    
The only meaningful change is that now we correctly propagate `traceKV`
flag in the column backfiller code path when it is set up in
a distributed case.

Release note: None

**sql: clean up the lifecycle of fetchers**

Previously, the lifecycle of different fetcher objects was a mess.
Consider the sequence of fetchers when used by the join reader with the
old non-streamer code path:
`rowexec.joinReader` -> `row.Fetcher` -> `row.KVFetcher` -> `row.txnKVFetcher`.
`row.Fetcher` was initialized once, but then on every call to
`StartScan`, we would create a new `row.txnKVFetcher` and then wrap it
with a new `row.KVFetcher` (during an internal `StartScanFrom` call). In
other words, throughout the lifetime of the join reader, its fetcher
would create a new pair of objects for each input row batch. This setup
is very unintuitive and previously led to some bugs with memory
accounting.

I believe such a setup was created organically, without giving too much
thought to it. Some considerations should be pointed out:
- in some cases, we have some state from the previous fetch that we want
to discard
- in some cases, we provide the `row.Fetcher` with a custom
`KVBatchFetcher` implementation.

This commit refactors all of this stuff to make it much more sane. In
particular, we now only create a single `row.KVFetcher` object that is
powered by a single `row.txnKVFetcher` or `row.txnKVStreamer`
implementation throughout the whole lifetime of `row.Fetcher`. In the
main code path, the callers are now expected to only use `StartScan`
method which correctly discards unnecessary state from the previous
call. This is achieved by adding a new method to `KVBatchFetcher`
interface.

This commit supports the use case with custom `KVBatchFetcher`s too by
asking the caller to explicitly specify a knob during the initialization
of the `row.Fetcher` - in such case, only `StartScanFrom` calls are
allowed. There, we still close the `KVBatchFetcher` from the previous
call (tbh I believe this is not necessary since these custom
`KVBatchFetcher`s don't have anything to clean up, but it's probably
safer to keep the old behavior here).

Furthermore, this commit pushes some arguments from `StartScan` into
`Init` - most notably the txn is now passed only once. However, there
are some use cases (like a column backfill, done in chunks) where the
txn might change throughout the lifetime of the fetcher - we allow
updating it later if needed.

This also allows us to unify the streamer and the non-streamer
code paths - to remove some of the duplicated code as well as push the
usage of the streamer lower in the stack.

Release note: None