### PR TITLE
changefeedccl: added protected time stamp age to monitoring metrics.

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1004,17 +1004,19 @@ func (cf *changeFrontier) close() {
 }
 
 // closeMetrics de-registers from the progress registry that powers
-// `changefeed.max_behind_nanos`. This method is idempotent.
+// `changefeed.max_behind_nanos` and
+// `changefeed.protected_time_stamp_behind_nanos`. This method is idempotent.
 func (cf *changeFrontier) closeMetrics() {
-	// Delete this feed from the MaxBehindNanos metric so it's no longer
-	// considered by the gauge.
+	// Delete this feed from the MaxBehindNanos and ProtectedTimeStampBehindNanos
+	// metric, so they are no longer considered by the gauges.
 	cf.metrics.mu.Lock()
+	defer cf.metrics.mu.Unlock()
 	if cf.metricsID > 0 {
 		cf.sliMetrics.RunningCount.Dec(1)
 	}
 	delete(cf.metrics.mu.resolved, cf.metricsID)
+	delete(cf.metrics.mu.protectedTimeStamps, cf.metricsID)
 	cf.metricsID = -1
-	cf.metrics.mu.Unlock()
 }
 
 // Next is part of the RowSource interface.
@@ -1306,6 +1308,11 @@ func (cf *changeFrontier) manageProtectedTimestamps(
 		return nil
 	}
 	cf.lastProtectedTimestampUpdate = timeutil.Now()
+
+	// update the protected time stamp metric map.
+	cf.metrics.mu.Lock()
+	cf.metrics.mu.protectedTimeStamps[cf.metricsID] = cf.lastProtectedTimestampUpdate
+	cf.metrics.mu.Unlock()
 
 	pts := cf.flowCtx.Cfg.ProtectedTimestampProvider
 

--- a/pkg/ccl/changefeedccl/metrics.go
+++ b/pkg/ccl/changefeedccl/metrics.go
@@ -329,6 +329,13 @@ var (
 		Measurement: "Replans",
 		Unit:        metric.Unit_COUNT,
 	}
+
+	metaProtectedTimeStampBehindNanos = metric.Metadata{
+		Name:        "changefeed.protected_time_stamp_behind_nanos",
+		Help:        "Age of the oldest change feed. A Large number could indicate stale data.",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
 )
 
 func newAggregateMetrics(histogramWindow time.Duration) *AggMetrics {
@@ -512,10 +519,12 @@ type Metrics struct {
 
 	mu struct {
 		syncutil.Mutex
-		id       int
-		resolved map[int]hlc.Timestamp
+		id                  int
+		resolved            map[int]hlc.Timestamp
+		protectedTimeStamps map[int]time.Time
 	}
-	MaxBehindNanos *metric.Gauge
+	MaxBehindNanos                *metric.Gauge
+	ProtectedTimeStampBehindNanos *metric.Gauge
 }
 
 // MetricStruct implements the metric.Struct interface.
@@ -543,19 +552,34 @@ func MakeMetrics(histogramWindow time.Duration) metric.Struct {
 	}
 
 	m.mu.resolved = make(map[int]hlc.Timestamp)
-	m.mu.id = 1 // start the first id at 1 so we can detect initialization
+	m.mu.id = 1 // start the first id at 1, so we can detect initialization
 	m.MaxBehindNanos = metric.NewFunctionalGauge(metaChangefeedMaxBehindNanos, func() int64 {
 		now := timeutil.Now()
 		var maxBehind time.Duration
 		m.mu.Lock()
+		defer m.mu.Unlock()
 		for _, resolved := range m.mu.resolved {
 			if behind := now.Sub(resolved.GoTime()); behind > maxBehind {
 				maxBehind = behind
 			}
 		}
-		m.mu.Unlock()
 		return maxBehind.Nanoseconds()
 	})
+
+	m.mu.protectedTimeStamps = make(map[int]time.Time)
+	m.ProtectedTimeStampBehindNanos = metric.NewFunctionalGauge(metaProtectedTimeStampBehindNanos, func() int64 {
+		now := timeutil.Now()
+		maxBehind := now
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		for _, timeStamp := range m.mu.protectedTimeStamps {
+			if timeStamp.Before(maxBehind) {
+				maxBehind = timeStamp
+			}
+		}
+		return now.Sub(maxBehind).Nanoseconds()
+	})
+
 	return m
 }
 

--- a/pkg/kv/kvserver/metric_rules_test.go
+++ b/pkg/kv/kvserver/metric_rules_test.go
@@ -41,5 +41,6 @@ func TestMetricRules(t *testing.T) {
 	require.NotNil(t, ruleRegistry.GetRuleForTest(nodeCapacityAvailableRatioRuleName))
 	require.NotNil(t, ruleRegistry.GetRuleForTest(clusterCapacityAvailableRatioRuleName))
 	require.NotNil(t, ruleRegistry.GetRuleForTest(nodeCapacityLowRuleName))
-	require.Equal(t, 13, ruleRegistry.GetRuleCountForTest())
+	require.NotNil(t, ruleRegistry.GetRuleForTest(protectedTimeStampAgeRuleName))
+	require.Equal(t, 14, ruleRegistry.GetRuleCountForTest())
 }

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1341,6 +1341,12 @@ var charts = []sectionDescription{
 				},
 			},
 			{
+				Title: "Protected Timestamp Behind Nanos",
+				Metrics: []string{
+					"changefeed.protected_time_stamp_behind_nanos",
+				},
+			},
+			{
 				Title: "Currently Running",
 				Metrics: []string{
 					"changefeed.running",


### PR DESCRIPTION
Release note (ccl change):
The protected time stamp's age is now available as a monitoring metric (gauge).

Closes #82825 
Jira issue: [CRDB-16687](https://cockroachlabs.atlassian.net/browse/CRDB-16687)

CC @miretskiy 