### PR TITLE
kvserver: log the reason for the split in range log

### DIFF
--- a/pkg/kv/kvserver/log.go
+++ b/pkg/kv/kvserver/log.go
@@ -94,11 +94,8 @@ func (s *Store) insertRangeLogEvent(
 // logSplit logs a range split event into the event table. The affected range is
 // the range which previously existed and is being split in half; the "other"
 // range is the new range which is being created.
-//
-// TODO(mrtracy): There are several different reasons that a range split
-// could occur, and that information should be logged.
 func (s *Store) logSplit(
-	ctx context.Context, txn *kv.Txn, updatedDesc, newDesc roachpb.RangeDescriptor,
+	ctx context.Context, txn *kv.Txn, updatedDesc, newDesc roachpb.RangeDescriptor, reason string,
 ) error {
 	if !s.cfg.LogRangeEvents {
 		return nil
@@ -112,6 +109,7 @@ func (s *Store) logSplit(
 		Info: &kvserverpb.RangeLogEvent_Info{
 			UpdatedDesc: &updatedDesc,
 			NewDesc:     &newDesc,
+			Details:     reason,
 		},
 	})
 }

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -184,6 +184,7 @@ func splitTxnAttempt(
 	splitKey roachpb.RKey,
 	expiration hlc.Timestamp,
 	oldDesc *roachpb.RangeDescriptor,
+	reason string,
 ) error {
 	txn.SetDebugName(splitTxnName)
 
@@ -222,7 +223,7 @@ func splitTxnAttempt(
 	}
 
 	// Log the split into the range event log.
-	if err := store.logSplit(ctx, txn, *leftDesc, *rightDesc); err != nil {
+	if err := store.logSplit(ctx, txn, *leftDesc, *rightDesc, reason); err != nil {
 		return err
 	}
 
@@ -424,7 +425,7 @@ func (r *Replica) adminSplitWithDescriptor(
 		splitKey.StringWithDirs(nil /* valDirs */, 50 /* maxLen */), rightRangeID, reason, extra)
 
 	if err := r.store.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		return splitTxnAttempt(ctx, r.store, txn, rightRangeID, splitKey, args.ExpirationTime, desc)
+		return splitTxnAttempt(ctx, r.store, txn, rightRangeID, splitKey, args.ExpirationTime, desc, reason)
 	}); err != nil {
 		// The ConditionFailedError can occur because the descriptors acting
 		// as expected values in the CPuts used to update the left or right


### PR DESCRIPTION
A split operation is recorded in the range log, but the reason for the
split is not. There are multiple reasons a range could split a manual user
action, load based splitting, size based splitting or bulk io operations.
The reason is important to capture to help troubleshoot issues with
splits and understand the reasoning.

Release note: None