### PR TITLE
cmd/reduce: reduce costfuzz logs

### DIFF
--- a/pkg/cmd/reduce/BUILD.bazel
+++ b/pkg/cmd/reduce/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/cmd/reduce/reduce",
         "//pkg/cmd/reduce/reduce/reducesql",
+        "//pkg/util/envutil",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )


### PR DESCRIPTION
Add a `-costfuzz` mode to `reduce`, with special handling for logs
produced by the costfuzz roachtest. This mode is similar to `-tlp`.

The logs produced by costfuzz consist of various CREATE TABLE, INSERT,
UPDATE, and DELETE statements followed by three special statements:
1. A SELECT statement, called "control".
2. A SET testing_optimizer_random_cost_seed statement.
3. The same SELECT as (1), this time called "perturbed".

When the results of (1) and (3) do not match, we have a costfuzz
failure.

The `-costfuzz` mode removes these three special statements from the end
of the log, reduces the rest of the log, and then appends the statements
to the reduced log to check if the current reduction is interesting. As
long as the results of (1) and (3) continue to not match, the reduction
is interesting.

Also, make `reduce` run `cockroach demo` with an enterprise license. Now
that we use enterprise features in randgen we sometimes need this.

Informs: #81717

Release note: None