### PR TITLE
storage: support reading and writing raw engine range keys

### DIFF
--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -625,6 +625,18 @@ func (s spanSetWriter) ExperimentalPutMVCCRangeKey(
 	return s.w.ExperimentalPutMVCCRangeKey(rangeKey, value)
 }
 
+func (s spanSetWriter) ExperimentalPutEngineRangeKey(
+	start, end roachpb.Key, suffix, value []byte,
+) error {
+	if !s.spansOnly {
+		panic("cannot do timestamp checking for ExperimentalPutEngineRangeKey")
+	}
+	if err := s.checkAllowedRange(start, end); err != nil {
+		return err
+	}
+	return s.w.ExperimentalPutEngineRangeKey(start, end, suffix, value)
+}
+
 func (s spanSetWriter) ExperimentalClearMVCCRangeKey(rangeKey storage.MVCCRangeKey) error {
 	if err := s.checkAllowedRange(rangeKey.StartKey, rangeKey.EndKey); err != nil {
 		return err
@@ -633,6 +645,9 @@ func (s spanSetWriter) ExperimentalClearMVCCRangeKey(rangeKey storage.MVCCRangeK
 }
 
 func (s spanSetWriter) ExperimentalClearAllRangeKeys(start, end roachpb.Key) error {
+	if !s.spansOnly {
+		panic("cannot do timestamp checking for ExperimentalClearAllRangeKeys")
+	}
 	if err := s.checkAllowedRange(start, end); err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -358,6 +358,21 @@ func (i *EngineIterator) checkKeyAllowed() (valid bool, err error) {
 	return true, nil
 }
 
+// HasEnginePointAndRange is part of the storage.EngineIterator interface.
+func (i *EngineIterator) HasEnginePointAndRange() (bool, bool) {
+	return i.i.HasEnginePointAndRange()
+}
+
+// EngineRangeBounds is part of the storage.EngineIterator interface.
+func (i *EngineIterator) EngineRangeBounds() (roachpb.Span, error) {
+	return i.i.EngineRangeBounds()
+}
+
+// EngineRangeKeys is part of the storage.EngineIterator interface.
+func (i *EngineIterator) EngineRangeKeys() []storage.EngineRangeKeyValue {
+	return i.i.EngineRangeKeys()
+}
+
 // UnsafeEngineKey is part of the storage.EngineIterator interface.
 func (i *EngineIterator) UnsafeEngineKey() (storage.EngineKey, error) {
 	return i.i.UnsafeEngineKey()

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -617,11 +617,11 @@ func (s spanSetWriter) ExperimentalClearMVCCRangeKey(rangeKey storage.MVCCRangeK
 	return s.w.ExperimentalClearMVCCRangeKey(rangeKey)
 }
 
-func (s spanSetWriter) ExperimentalClearAllMVCCRangeKeys(start, end roachpb.Key) error {
+func (s spanSetWriter) ExperimentalClearAllRangeKeys(start, end roachpb.Key) error {
 	if err := s.checkAllowedRange(start, end); err != nil {
 		return err
 	}
-	return s.w.ExperimentalClearAllMVCCRangeKeys(start, end)
+	return s.w.ExperimentalClearAllRangeKeys(start, end)
 }
 
 func (s spanSetWriter) Merge(key storage.MVCCKey, value []byte) error {

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -706,6 +706,13 @@ type Writer interface {
 	// only being stored in memory.
 	ExperimentalPutMVCCRangeKey(MVCCRangeKey, MVCCValue) error
 
+	// ExperimentalPutEngineRangeKey sets the given range key to the values
+	// provided. This is a general-purpose and low-level method that should be
+	// used sparingly, only when the other Put* methods are not applicable.
+	//
+	// It is safe to modify the contents of the arguments after it returns.
+	ExperimentalPutEngineRangeKey(start, end roachpb.Key, suffix, value []byte) error
+
 	// Merge is a high-performance write operation used for values which are
 	// accumulated over several writes. Multiple values can be merged
 	// sequentially into a single key; a subsequent read will return a "merged"

--- a/pkg/storage/engine_key.go
+++ b/pkg/storage/engine_key.go
@@ -289,3 +289,11 @@ func (lk LockTableKey) ToEngineKey(buf []byte) (EngineKey, []byte) {
 	copy(k.Version[1:], lk.TxnUUID)
 	return k, buf
 }
+
+// EngineRangeKeyValue is a raw value for a general range key as stored in the
+// engine. It consists of a version (suffix) and corresponding value. The range
+// key bounds are not included, but are surfaced via EngineRangeBounds().
+type EngineRangeKeyValue struct {
+	Version []byte
+	Value   []byte
+}

--- a/pkg/storage/engine_key_test.go
+++ b/pkg/storage/engine_key_test.go
@@ -186,3 +186,10 @@ func TestEngineKeyValidate(t *testing.T) {
 		})
 	}
 }
+
+func engineKey(key string, ts int) EngineKey {
+	return EngineKey{
+		Key:     roachpb.Key(key),
+		Version: encodeMVCCTimestamp(wallTS(ts)),
+	}
+}

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1097,7 +1097,7 @@ func (p *Pebble) ClearRawRange(start, end roachpb.Key) error {
 	if err := p.db.DeleteRange(startKey, endKey, pebble.Sync); err != nil {
 		return err
 	}
-	return p.ExperimentalClearAllMVCCRangeKeys(start, end)
+	return p.ExperimentalClearAllRangeKeys(start, end)
 }
 
 // ClearMVCCRange implements the Engine interface.
@@ -1139,8 +1139,8 @@ func (p *Pebble) ExperimentalClearMVCCRangeKey(rangeKey MVCCRangeKey) error {
 		pebble.Sync)
 }
 
-// ExperimentalClearAllMVCCRangeKeys implements the Engine interface.
-func (p *Pebble) ExperimentalClearAllMVCCRangeKeys(start, end roachpb.Key) error {
+// ExperimentalClearAllRangeKeys implements the Engine interface.
+func (p *Pebble) ExperimentalClearAllRangeKeys(start, end roachpb.Key) error {
 	if !p.SupportsRangeKeys() {
 		return nil // noop
 	}
@@ -2056,7 +2056,7 @@ func (p *pebbleReadOnly) ExperimentalClearMVCCRangeKey(MVCCRangeKey) error {
 	panic("not implemented")
 }
 
-func (p *pebbleReadOnly) ExperimentalClearAllMVCCRangeKeys(roachpb.Key, roachpb.Key) error {
+func (p *pebbleReadOnly) ExperimentalClearAllRangeKeys(roachpb.Key, roachpb.Key) error {
 	panic("not implemented")
 }
 

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1009,9 +1009,6 @@ func (p *Pebble) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions) MVCCIt
 
 // NewEngineIterator implements the Engine interface.
 func (p *Pebble) NewEngineIterator(opts IterOptions) EngineIterator {
-	if opts.KeyTypes != IterKeyTypePointsOnly {
-		panic("EngineIterator does not support range keys")
-	}
 	return newPebbleIterator(p.db, opts, StandardDurability, p.SupportsRangeKeys())
 }
 
@@ -1949,9 +1946,6 @@ func (p *pebbleReadOnly) NewEngineIterator(opts IterOptions) EngineIterator {
 	if p.closed {
 		panic("using a closed pebbleReadOnly")
 	}
-	if opts.KeyTypes != IterKeyTypePointsOnly {
-		panic("EngineIterator does not support range keys")
-	}
 
 	iter := &p.normalEngineIter
 	if opts.Prefix {
@@ -2188,9 +2182,6 @@ func (p *pebbleSnapshot) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions
 
 // NewEngineIterator implements the Reader interface.
 func (p pebbleSnapshot) NewEngineIterator(opts IterOptions) EngineIterator {
-	if opts.KeyTypes != IterKeyTypePointsOnly {
-		panic("EngineIterator does not support range keys")
-	}
 	return newPebbleIterator(p.snapshot, opts, StandardDurability, p.SupportsRangeKeys())
 }
 

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -371,7 +371,7 @@ func (p *pebbleBatch) ClearRawRange(start, end roachpb.Key) error {
 	if err := p.batch.DeleteRange(p.buf, EncodeMVCCKey(MVCCKey{Key: end}), nil); err != nil {
 		return err
 	}
-	return p.ExperimentalClearAllMVCCRangeKeys(start, end)
+	return p.ExperimentalClearAllRangeKeys(start, end)
 }
 
 // ClearMVCCRange implements the Batch interface.
@@ -408,7 +408,7 @@ func (p *pebbleBatch) ClearMVCCIteratorRange(start, end roachpb.Key) error {
 			return err
 		}
 	}
-	return p.ExperimentalClearAllMVCCRangeKeys(start, end)
+	return p.ExperimentalClearAllRangeKeys(start, end)
 }
 
 // ExperimentalClearMVCCRangeKey implements the Engine interface.
@@ -426,8 +426,8 @@ func (p *pebbleBatch) ExperimentalClearMVCCRangeKey(rangeKey MVCCRangeKey) error
 		nil)
 }
 
-// ExperimentalClearAllMVCCRangeKeys implements the Engine interface.
-func (p *pebbleBatch) ExperimentalClearAllMVCCRangeKeys(start, end roachpb.Key) error {
+// ExperimentalClearAllRangeKeys implements the Engine interface.
+func (p *pebbleBatch) ExperimentalClearAllRangeKeys(start, end roachpb.Key) error {
 	if !p.SupportsRangeKeys() {
 		return nil // noop
 	}
@@ -487,7 +487,7 @@ func (p *pebbleBatch) ExperimentalPutMVCCRangeKey(rangeKey MVCCRangeKey, value M
 		return err
 	}
 	// Mark the batch as containing range keys. See
-	// ExperimentalClearAllMVCCRangeKeys for why.
+	// ExperimentalClearAllRangeKeys for why.
 	p.containsRangeKeys = true
 	return nil
 }

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -249,9 +249,6 @@ func (p *pebbleBatch) NewEngineIterator(opts IterOptions) EngineIterator {
 	if p.writeOnly {
 		panic("write-only batch")
 	}
-	if opts.KeyTypes != IterKeyTypePointsOnly {
-		panic("EngineIterator does not support range keys")
-	}
 
 	iter := &p.normalEngineIter
 	if opts.Prefix {

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -154,10 +154,10 @@ func (fw *SSTWriter) ExperimentalClearMVCCRangeKey(MVCCRangeKey) error {
 	panic("not implemented")
 }
 
-// ExperimentalClearAllMVCCRangeKeys implements the Writer interface.
+// ExperimentalClearAllRangeKeys implements the Writer interface.
 //
 // TODO(erikgrinaker): This must clear range keys when SSTs support them.
-func (fw *SSTWriter) ExperimentalClearAllMVCCRangeKeys(roachpb.Key, roachpb.Key) error {
+func (fw *SSTWriter) ExperimentalClearAllRangeKeys(roachpb.Key, roachpb.Key) error {
 	return nil
 }
 

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -161,6 +161,13 @@ func (fw *SSTWriter) ExperimentalClearAllRangeKeys(roachpb.Key, roachpb.Key) err
 	return nil
 }
 
+// ExperimentalPutEngineRangeKey implements the Writer interface.
+func (fw *SSTWriter) ExperimentalPutEngineRangeKey(
+	start, end roachpb.Key, suffix, value []byte,
+) error {
+	panic("not implemented")
+}
+
 func (fw *SSTWriter) clearRange(start, end MVCCKey) error {
 	if fw.fw == nil {
 		return errors.New("cannot call ClearRange on a closed writer")


### PR DESCRIPTION
**storage: rename `ClearAllMVCCRangeKeys` to `ClearAllRangeKeys`**

Since `Engine.ExperimentalClearAllMVCCRangeKeys` takes only
`roachpb.Key` bounds, it can be used to clear both MVCC range keys and
more general engine range keys. This patch therefore renames the method
to `ExperimentalClearAllRangeKeys` to make it agnostic to the range key
type.

Release note: None
  
**storage: support range keys in `EngineIterator`**

This patch adds range key support to `EngineIterator`. This is needed
e.g. to process range keys in the Raft machinery, which operates on
arbitrary range data.

No tests are included, as there is no existing test framework for
`EngineIterator`. The logic is a simple wrapper around Pebble, so this
was considered less problematic than it would normally be.

Resolves #82935.

Release note: None
  
**storage: add `Engine.ExperimentalPutEngineRangeKey`**

This patch adds `Engine.ExperimentalPutEngineRangeKey` to write raw
engine range keys. This will be used e.g. when ingesting Raft snapshots,
which is agnostic to the kind of range key and doesn't care about
decoding or encoding them.

Release note: None