### PR TITLE
roachtest: remove superfluous nil check to make nogo happy

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -366,7 +366,7 @@ func defaultClusterAllocator(
 			if err == nil {
 				return c, nil
 			}
-			if err != nil && !errors.Is(err, errClusterNotFound) {
+			if !errors.Is(err, errClusterNotFound) {
 				return nil, err
 			}
 			// Fall through to create new cluster with name override.


### PR DESCRIPTION
A recent change to roachtest was causing nogo to complain:

```
compilepkg: nogo: errors found by nogo during build-time code analysis:
pkg/cmd/roachtest/test_runner.go:369:11: tautological condition: non-nil != nil (nilness)
```

Release note: None