### PR TITLE
sql: fix panic caused by inject_retry_errors_enabled

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1156,7 +1156,9 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 		// numTxnRetryErrors is the number of times an error will be injected if
 		// the transaction is retried using SAVEPOINTs.
 		const numTxnRetryErrors = 3
-		if ex.sessionData().InjectRetryErrorsEnabled && stmt.AST.StatementTag() != "SET" {
+		isSetOrShow := stmt.AST.StatementTag() == "SET" || stmt.AST.StatementTag() == "SHOW"
+		if ex.sessionData().InjectRetryErrorsEnabled && !isSetOrShow &&
+			planner.Txn().Sender().TxnStatus() == roachpb.PENDING {
 			if planner.Txn().Epoch() < ex.state.lastEpoch+numTxnRetryErrors {
 				retryErr := planner.Txn().GenerateForcedRetryableError(
 					ctx, "injected by `inject_retry_errors_enabled` session variable")


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/83011

In addition to fixing the panic, this also improves the CLI error
reporting a little, which made this easier to debug.

Release note (bug fix): Fixed a panic that could happen if the
inject_retry_errors_enabled setting is true and an INSERT
is executed outside of an explicit transaction.