### PR TITLE
roachtest: tracked cpu allocation leak in newCluster can result in deadlock

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -832,6 +832,9 @@ func (f *clusterFactory) newCluster(
 	// that each create attempt gets a unique cluster name.
 	createVMOpts, providerOpts, err := cfg.spec.RoachprodOpts("", cfg.useIOBarrier)
 	if err != nil {
+		// We must release the allocation because cluster creation is not possible at this point.
+		cfg.alloc.Release()
+
 		return nil, err
 	}
 	if cfg.spec.Cloud != spec.Local {


### PR DESCRIPTION
Roachtest 'cpu-quota' limits the total number of allocated cloud CPUs at any given time.
In conjunction with 'parallelism', these CLI options limit the total number of
concurrently executing roachtests.
Internally, 'cpu-quota' is essentially tracked via an atomic counter,
initialized to its maximum value; its current value denotes available CPUs.
A test worker selects a roachtest whose required CPUs do not exceed the available.
Normally, when a roachtest creates a cluster, it saves the CPU allocations into `destroyState`;
when a cluster is destroyed, the corresponding CPUs are released; i.e.,
the available CPUs counter is incremented.
However, it was previously possible to leak CPU allocations in `newCluster` by
passing invalid roachprod CLI options to `RoachprodOpts`.
In that case, cluster creation is never attempted, and hence the corresponding
CPU allocations are never released.
Consequently, all test workers will eventually block due to being unable to
select the remaining roachtest(s), since
their required CPUs exceed the available. This results in a deadlock.

This bug fix releases the cpu allocations if cluster creation is never attempted.

Release note: None
Resolves: https://github.com/cockroachdb/cockroach/issues/83088