### PR TITLE
roachtest: don't count cluster reuse failure as clusterCreateErr

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -536,10 +536,9 @@ func (r *testRunner) runWorker(
 				return nil
 			}()
 			if err != nil {
-				// N.B. handle any error during reuse attempt as clusterCreateErr.
 				shout(ctx, l, stdout, "Unable to reuse cluster: %s due to: %s. Will attempt to create a fresh one",
 					c.Name(), err)
-				atomic.AddInt32(&r.numClusterErrs, 1)
+				// N.B. we do not count reuse attempt error toward clusterCreateErr.
 				// Let's attempt to create a fresh one.
 				testToRun.canReuseCluster = false
 			}


### PR DESCRIPTION
Roachtest tracks each cluster creation error by posting to github. It also maintains a counter of all
seen cluster creation errors, namely 'clusterCreateErr'. Previously, a failed attempt to _reuse_ an existing
cluster would increment 'clusterCreateErr'. This inconsistency makes it difficult to correlate the number of posted
github issues with the final value of 'clusterCreateErr' in the (roachtest) log.
This fix removes the increment upon handling any cluster reuse error.

Release note: None