### PR TITLE
ui: add period label to SQL Activity pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/pageConfig/pageConfig.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/pageConfig/pageConfig.module.scss
@@ -9,7 +9,7 @@
   // it's fixed during scrolling, but not when the page
   // is scrolled to the top. This combination of padding
   // and negative margins achieves that.
-  padding-bottom: 10px;
+  padding-bottom: 5px;
   padding-top: 10px;
   margin-bottom: -10px;
   margin-top: -10px;

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -16,7 +16,6 @@ import { ArrowLeft } from "@cockroachlabs/icons";
 import { Location } from "history";
 import _ from "lodash";
 import Long from "long";
-import { format as d3Format } from "d3-format";
 import { Helmet } from "react-helmet";
 import { Link, RouteComponentProps } from "react-router-dom";
 import classNames from "classnames/bind";
@@ -26,12 +25,7 @@ import { AxisUnits } from "../graphs";
 import { AlignedData, Options } from "uplot";
 
 import {
-  NumericStat,
   intersperse,
-  Bytes,
-  Duration,
-  FixLong,
-  stdDev,
   unique,
   queryByName,
   appAttr,
@@ -42,13 +36,11 @@ import { Loading } from "src/loading";
 import { Button } from "src/button";
 import { SqlBox, SqlBoxSize } from "src/sql";
 import { SortSetting } from "src/sortedtable";
-import { Tooltip } from "@cockroachlabs/ui-components";
 import { PlanDetails } from "./planDetails";
 import { SummaryCard } from "src/summaryCard";
-import { latencyBreakdown, genericBarChart } from "src/barCharts";
 import { DiagnosticsView } from "./diagnostics/diagnosticsView";
-import sortedTableStyles from "src/sortedtable/sortedtable.module.scss";
 import summaryCardStyles from "src/summaryCard/summaryCard.module.scss";
+import timeScaleStyles from "src/timeScaleDropdown/timeScale.module.scss";
 import styles from "./statementDetails.module.scss";
 import { commonStyles } from "src/common";
 import { NodeSummaryStats } from "../nodes";
@@ -58,6 +50,7 @@ import { StatementDetailsRequest } from "src/api/statementsApi";
 import {
   TimeScale,
   TimeScaleDropdown,
+  timeScaleToString,
   toRoundedDateRange,
 } from "../timeScaleDropdown";
 import SQLActivityError from "../sqlActivity/errorComponent";
@@ -91,25 +84,6 @@ export type StatementDetailsProps = StatementDetailsOwnProps &
 export interface StatementDetailsState {
   sortSetting: SortSetting;
   currentTab?: string;
-}
-
-interface NumericStatRow {
-  name: string;
-  value: NumericStat;
-  bar?: () => ReactNode;
-  summary?: boolean;
-  // You can override the table's formatter on a per-row basis with this format
-  // method.
-  format?: (v: number) => string;
-}
-
-interface NumericStatTableProps {
-  title?: string;
-  description?: string;
-  measure: string;
-  rows: NumericStatRow[];
-  count: number;
-  format?: (v: number) => string;
 }
 
 export type NodesSummary = {
@@ -170,8 +144,8 @@ export type StatementDetailsOwnProps = StatementDetailsDispatchProps &
   StatementDetailsStateProps;
 
 const cx = classNames.bind(styles);
-const sortableTableCx = classNames.bind(sortedTableStyles);
 const summaryCardStylesCx = classNames.bind(summaryCardStyles);
+const timeScaleStylesCx = classNames.bind(timeScaleStyles);
 
 function getStatementDetailsRequest(
   timeScale: TimeScale,
@@ -191,7 +165,6 @@ function AppLink(props: { app: string }) {
   if (!props.app) {
     return <Text className={cx("app-name", "app-name__unset")}>(unset)</Text>;
   }
-
   const searchParams = new URLSearchParams({ [appAttr]: props.app });
 
   return (
@@ -220,87 +193,6 @@ function renderTransactionType(implicitTxn: boolean) {
     return "Implicit";
   }
   return "Explicit";
-}
-
-class NumericStatTable extends React.Component<NumericStatTableProps> {
-  static defaultProps = {
-    format: (v: number) => `${v}`,
-  };
-
-  render() {
-    const { rows } = this.props;
-    return (
-      <table
-        className={classNames(
-          sortableTableCx("sort-table"),
-          cx("statements-table"),
-        )}
-      >
-        <thead>
-          <tr
-            className={sortableTableCx(
-              "sort-table__row",
-              "sort-table__row--header",
-            )}
-          >
-            <th
-              className={sortableTableCx(
-                "sort-table__cell",
-                "sort-table__cell--header",
-              )}
-            >
-              {this.props.title}
-            </th>
-            <th className={sortableTableCx("sort-table__cell")}>
-              Mean {this.props.measure}
-            </th>
-            <th className={sortableTableCx("sort-table__cell")}>
-              Standard Deviation
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((row: NumericStatRow, idx) => {
-            let { format } = this.props;
-            if (row.format) {
-              format = row.format;
-            }
-            const className = sortableTableCx(
-              "sort-table__row",
-              "sort-table__row--body",
-              {
-                "sort-table__row--summary": row.summary,
-              },
-            );
-            return (
-              <tr className={className} key={idx}>
-                <th
-                  className={sortableTableCx(
-                    "sort-table__cell",
-                    "sort-table__cell--header",
-                  )}
-                  style={{ textAlign: "left" }}
-                >
-                  {row.name}
-                </th>
-                <td className={sortableTableCx("sort-table__cell")}>
-                  {row.bar ? row.bar() : null}
-                </td>
-                <td
-                  className={sortableTableCx(
-                    "sort-table__cell",
-                    "sort-table__cell--active",
-                  )}
-                >
-                  {format(stdDev(row.value, this.props.count))}
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-    );
-  }
 }
 
 export class StatementDetails extends React.Component<
@@ -492,8 +384,8 @@ export class StatementDetails extends React.Component<
   renderTabs = (): React.ReactElement => {
     const { currentTab } = this.state;
     const { stats } = this.props.statementDetails.statement;
-
     const hasData = Number(stats.count) > 0;
+    const period = timeScaleToString(this.props.timeScale);
 
     return (
       <Tabs
@@ -503,10 +395,10 @@ export class StatementDetails extends React.Component<
         activeKey={currentTab}
       >
         <TabPane tab="Overview" key="overview">
-          {this.renderOverviewTabContent(hasData)}
+          {this.renderOverviewTabContent(hasData, period)}
         </TabPane>
         <TabPane tab="Explain Plans" key="explain-plan">
-          {this.renderExplainPlanTabContent(hasData)}
+          {this.renderExplainPlanTabContent(hasData, period)}
         </TabPane>
         {!this.props.isTenant && !this.props.hasViewActivityRedactedRole && (
           <TabPane
@@ -520,13 +412,6 @@ export class StatementDetails extends React.Component<
             {this.renderDiagnosticsTabContent(hasData)}
           </TabPane>
         )}
-        <TabPane
-          tab="Execution Stats"
-          key="execution-stats"
-          className={cx("fit-content-width")}
-        >
-          {this.renderExecutionStatsTabContent(hasData)}
-        </TabPane>
       </Tabs>
     );
   };
@@ -566,7 +451,10 @@ export class StatementDetails extends React.Component<
     </>
   );
 
-  renderOverviewTabContent = (hasData: boolean): React.ReactElement => {
+  renderOverviewTabContent = (
+    hasData: boolean,
+    period: string,
+  ): React.ReactElement => {
     if (!hasData) {
       return this.renderNoDataWithTimeScaleAndSqlBoxTabContent();
     }
@@ -672,6 +560,10 @@ export class StatementDetails extends React.Component<
             />
           </PageConfigItem>
         </PageConfig>
+        <p className={timeScaleStylesCx("time-label", "label-margin")}>
+          Showing aggregated stats from{" "}
+          <span className={timeScaleStylesCx("bold")}>{period}</span>
+        </p>
         <section className={cx("section")}>
           <Row gutter={24}>
             <Col className="gutter-row" span={24}>
@@ -794,7 +686,10 @@ export class StatementDetails extends React.Component<
     );
   };
 
-  renderExplainPlanTabContent = (hasData: boolean): React.ReactElement => {
+  renderExplainPlanTabContent = (
+    hasData: boolean,
+    period: string,
+  ): React.ReactElement => {
     if (!hasData) {
       return this.renderNoDataWithTimeScaleAndSqlBoxTabContent();
     }
@@ -810,6 +705,10 @@ export class StatementDetails extends React.Component<
             />
           </PageConfigItem>
         </PageConfig>
+        <p className={timeScaleStylesCx("time-label", "label-margin")}>
+          Showing explain plans from{" "}
+          <span className={timeScaleStylesCx("bold")}>{period}</span>
+        </p>
         <section className={cx("section")}>
           <Row gutter={24}>
             <Col className="gutter-row" span={24}>
@@ -842,120 +741,6 @@ export class StatementDetails extends React.Component<
         }
         onSortingChange={this.props.onSortingChange}
       />
-    );
-  };
-
-  renderExecutionStatsTabContent = (hasData: boolean): React.ReactElement => {
-    if (!hasData) {
-      return this.renderNoDataTabContent();
-    }
-    const { stats } = this.props.statementDetails.statement;
-
-    const count = FixLong(stats.count).toInt();
-    const { statement } = this.props.statementDetails;
-    const {
-      parseBarChart,
-      planBarChart,
-      runBarChart,
-      overheadBarChart,
-      overallBarChart,
-    } = latencyBreakdown(statement);
-    return (
-      <>
-        <SummaryCard>
-          <h3
-            className={classNames(
-              commonStyles("base-heading"),
-              summaryCardStylesCx("summary--card__title"),
-            )}
-          >
-            Execution Latency By Phase
-            <div className={cx("numeric-stats-table__tooltip")}>
-              <Tooltip content="The execution latency of this statement, broken down by phase.">
-                <div className={cx("numeric-stats-table__tooltip-hover-area")}>
-                  <div className={cx("numeric-stats-table__info-icon")}>i</div>
-                </div>
-              </Tooltip>
-            </div>
-          </h3>
-          <NumericStatTable
-            title="Phase"
-            measure="Latency"
-            count={count}
-            format={(v: number) => Duration(v * 1e9)}
-            rows={[
-              { name: "Parse", value: stats.parse_lat, bar: parseBarChart },
-              { name: "Plan", value: stats.plan_lat, bar: planBarChart },
-              { name: "Run", value: stats.run_lat, bar: runBarChart },
-              {
-                name: "Overhead",
-                value: stats.overhead_lat,
-                bar: overheadBarChart,
-              },
-              {
-                name: "Overall",
-                summary: true,
-                value: stats.service_lat,
-                bar: overallBarChart,
-              },
-            ]}
-          />
-        </SummaryCard>
-        <SummaryCard>
-          <h3
-            className={classNames(
-              commonStyles("base-heading"),
-              summaryCardStylesCx("summary--card__title"),
-            )}
-          >
-            Other Execution Statistics
-          </h3>
-          <NumericStatTable
-            title="Stat"
-            measure="Quantity"
-            count={count}
-            format={d3Format(".2f")}
-            rows={[
-              {
-                name: "Rows Read",
-                value: stats.rows_read,
-                bar: genericBarChart(stats.rows_read, stats.count),
-              },
-              {
-                name: "Disk Bytes Read",
-                value: stats.bytes_read,
-                bar: genericBarChart(stats.bytes_read, stats.count, Bytes),
-                format: Bytes,
-              },
-              {
-                name: "Rows Written",
-                value: stats.rows_written,
-                bar: genericBarChart(stats.rows_written, stats.count),
-              },
-              {
-                name: "Network Bytes Sent",
-                value: stats.exec_stats.network_bytes,
-                bar: genericBarChart(
-                  stats.exec_stats.network_bytes,
-                  stats.exec_stats.count,
-                  Bytes,
-                ),
-                format: Bytes,
-              },
-            ].filter(function (r) {
-              if (
-                r.name === "Network Bytes Sent" &&
-                r.value &&
-                r.value.mean === 0
-              ) {
-                // Omit if empty.
-                return false;
-              }
-              return r.value;
-            })}
-          />
-        </SummaryCard>
-      </>
     );
   };
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
@@ -1,5 +1,9 @@
 @import "src/core/index.module";
 
+cl-table-container {
+  padding-top: 10px;
+}
+
 .cl-table-statistic {
   display: flex;
   justify-content: space-between;
@@ -15,8 +19,9 @@
   padding: 0px;
   margin: 0px;
   color: $colors--neutral-6;
-  line-height: 1.57;
+  line-height: $line-height--large;
   letter-spacing: 0.1px;
+  display: flex;
   .label {
     font-family: $font-family--bold;
     color: $colors--neutral-7;

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -74,6 +74,7 @@ import {
   TimeScaleDropdown,
   TimeScale,
   toDateRange,
+  timeScaleToString,
 } from "../timeScaleDropdown";
 
 import { commonStyles } from "../common";
@@ -556,6 +557,8 @@ export class StatementsPage extends React.Component<
       isSelectedColumn(userSelectedColumnsToShow, c),
     );
 
+    const period = timeScaleToString(this.props.timeScale);
+
     return (
       <div>
         <section className={sortableTableCx("cl-table-container")}>
@@ -570,6 +573,7 @@ export class StatementsPage extends React.Component<
               totalCount={totalCount}
               arrayItemName="statements"
               activeFilters={activeFilters}
+              period={period}
               onClearFilters={this.onClearFilters}
             />
           </div>

--- a/pkg/ui/workspaces/cluster-ui/src/tableStatistics/tableStatistics.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tableStatistics/tableStatistics.tsx
@@ -13,8 +13,11 @@ import { statisticsClasses } from "../transactionsPage/transactionsPageClasses";
 import { ISortedTablePagination } from "../sortedtable";
 import { Button } from "src/button";
 import { ResultsPerPageLabel } from "src/pagination";
+import classNames from "classnames/bind";
+import timeScaleStyles from "../timeScaleDropdown/timeScale.module.scss";
 
 const { statistic, countTitle } = statisticsClasses;
+const timeScaleStylesCx = classNames.bind(timeScaleStyles);
 
 interface TableStatistics {
   pagination: ISortedTablePagination;
@@ -23,6 +26,7 @@ interface TableStatistics {
   activeFilters: number;
   search?: string;
   onClearFilters?: () => void;
+  period?: string;
 }
 
 // TableStatistics shows statistics about the results being
@@ -37,18 +41,33 @@ export const TableStatistics: React.FC<TableStatistics> = ({
   arrayItemName,
   onClearFilters,
   activeFilters,
+  period,
 }) => {
+  const periodLabel = (
+    <>
+      &nbsp;&nbsp;&nbsp;| &nbsp;
+      <p className={timeScaleStylesCx("time-label")}>
+        Showing aggregated stats from{" "}
+        <span className={timeScaleStylesCx("bold")}>{period}</span>
+      </p>
+    </>
+  );
+
   const resultsPerPageLabel = (
-    <ResultsPerPageLabel
-      pagination={{ ...pagination, total: totalCount }}
-      pageName={arrayItemName}
-      search={search}
-    />
+    <>
+      <ResultsPerPageLabel
+        pagination={{ ...pagination, total: totalCount }}
+        pageName={arrayItemName}
+        search={search}
+      />
+      {period && periodLabel}
+    </>
   );
 
   const resultsCountAndClear = (
     <>
       {totalCount} {totalCount === 1 ? "result" : "results"}
+      {period && periodLabel}
       &nbsp;&nbsp;&nbsp;| &nbsp;
       <Button onClick={() => onClearFilters()} type="flat" size="small">
         clear filter

--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScale.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScale.module.scss
@@ -24,3 +24,25 @@
     color: $body-color;
   }
 }
+
+.time-label {
+  font-family: $font-family--base;
+  font-size: $font-size--medium;
+  padding: 0px;
+  margin: 0px;
+  color: $colors--neutral-6;
+  line-height: $line-height--large;
+  letter-spacing: 0.1px;
+  .bold {
+    font-family: $font-family--bold;
+    color: $colors--neutral-7;
+  }
+}
+
+.label-margin {
+  margin-top: 5px;
+}
+
+.label-no-margin-bottom {
+  margin-bottom: -10px;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/utils.ts
@@ -10,6 +10,8 @@
 
 import moment from "moment";
 import { TimeScale, TimeScaleOption, TimeScaleOptions } from "./timeScaleTypes";
+import { dateFormat, timeFormat } from "./timeScaleDropdown";
+import React from "react";
 
 /**
  * defaultTimeScaleOptions is a preconfigured set of time scales that can be
@@ -138,4 +140,18 @@ export const findClosestTimeScale = (
   return closestWindowSizeSeconds === seconds
     ? data[0]
     : { ...data[0], key: "Custom" };
+};
+
+export const timeScaleToString = (ts: TimeScale): string => {
+  const [start, end] = toRoundedDateRange(ts);
+  const endDayIsToday = moment.utc(end).isSame(moment.utc(), "day");
+  const startEndOnSameDay = end.isSame(start, "day");
+  const omitDayFormat = endDayIsToday && startEndOnSameDay;
+  const dateStart = omitDayFormat ? "" : start.format(dateFormat);
+  const dateEnd =
+    omitDayFormat || startEndOnSameDay ? "" : end.format(dateFormat);
+  const timeStart = start.format(timeFormat);
+  const timeEnd = end.format(timeFormat);
+
+  return `${dateStart} ${timeStart} to ${dateEnd} ${timeEnd} (UTC)`;
 };

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -60,11 +60,14 @@ import { StatementsRequest } from "../api";
 import {
   TimeScale,
   TimeScaleDropdown,
+  timeScaleToString,
   toDateRange,
 } from "../timeScaleDropdown";
+import timeScaleStyles from "../timeScaleDropdown/timeScale.module.scss";
 
 const { containerClass } = tableClasses;
 const cx = classNames.bind(statementsStyles);
+const timeScaleStylesCx = classNames.bind(timeScaleStyles);
 
 type Statement =
   protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
@@ -218,6 +221,7 @@ export class TransactionDetails extends React.Component<
     const { latestTransactionText } = this.state;
     const statementsForTransaction = this.getStatementsForTransaction();
     const transactionStats = transaction?.stats_data?.stats;
+    const period = timeScaleToString(this.props.timeScale);
 
     return (
       <div>
@@ -242,6 +246,12 @@ export class TransactionDetails extends React.Component<
             />
           </PageConfigItem>
         </PageConfig>
+        <p
+          className={timeScaleStylesCx("time-label", "label-no-margin-bottom")}
+        >
+          Showing aggregated stats from{" "}
+          <span className={timeScaleStylesCx("bold")}>{period}</span>
+        </p>
         <Loading
           error={error}
           page={"transaction details"}

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -64,6 +64,7 @@ import {
   TimeScaleDropdown,
   TimeScale,
   toDateRange,
+  timeScaleToString,
 } from "../timeScaleDropdown";
 import { InlineAlert } from "@cockroachlabs/ui-components";
 import { TransactionViewType } from "./transactionsPageTypes";
@@ -473,6 +474,8 @@ export class TransactionsPage extends React.Component<
                 isSelectedColumn(userSelectedColumnsToShow, c),
               );
 
+              const period = timeScaleToString(this.props.timeScale);
+
               return (
                 <>
                   <section className={statisticsClasses.tableContainerClass}>
@@ -486,6 +489,7 @@ export class TransactionsPage extends React.Component<
                       totalCount={transactionsToDisplay.length}
                       arrayItemName="transactions"
                       activeFilters={activeFilters}
+                      period={period}
                       onClearFilters={this.onClearFilters}
                     />
                     <TransactionsTable


### PR DESCRIPTION
This commit adds the period label with information
about the period to which we're showing information from.
The label is added to Statement, Statement Details,
Transaction and Transaction Details pages.

Partially addresses #82914
Fixes #74523

Statement page no filter
<img width="851" alt="Screen Shot 2022-06-20 at 10 17 23 AM" src="https://user-images.githubusercontent.com/1017486/174626137-729a8351-a32d-46df-a884-a9aeb49a8ace.png">

Statement Page with filter
<img width="883" alt="Screen Shot 2022-06-20 at 10 17 07 AM" src="https://user-images.githubusercontent.com/1017486/174626135-e39be0d4-045c-49bc-b886-4337cb4baf21.png">

Statement Details Overview Tab
<img width="468" alt="Screen Shot 2022-06-20 at 10 18 24 AM" src="https://user-images.githubusercontent.com/1017486/174626138-2b5bae17-f64f-4ddd-a8eb-de0f92f53a3b.png">

Statement Details Explain Tab
<img width="463" alt="Screen Shot 2022-06-20 at 10 18 30 AM" src="https://user-images.githubusercontent.com/1017486/174626141-1e925490-667c-47e9-bc6e-b8227d189c1a.png">

Transaction page no filter
<img width="874" alt="Screen Shot 2022-06-20 at 10 21 24 AM" src="https://user-images.githubusercontent.com/1017486/174626144-10448c80-df40-4b85-bae5-19484fa97752.png">

Transaction page with filter
<img width="756" alt="Screen Shot 2022-06-20 at 10 21 38 AM" src="https://user-images.githubusercontent.com/1017486/174626146-16a0ad7b-7506-4447-8f5e-c29a0d9cde56.png">

Transaction Details
<img width="647" alt="Screen Shot 2022-06-20 at 10 36 51 AM" src="https://user-images.githubusercontent.com/1017486/174626147-de9619c6-b11e-42c7-90b3-57a5bed1f6f6.png">


This commit also removed the tab Exec Stats from the
Statement Details page.

Fixes #74526

Release note (ui change): Add period label to pages Statement, Statement Details, 
Transaction and Transaction Details, with information about the
period to which we're showing information from. Removal of
Exec stats tab under Statement Details page.