### PR TITLE
kvserver: add regression test for mvcc gc queue bug

### DIFF
--- a/pkg/kv/kvserver/replica_protected_timestamp.go
+++ b/pkg/kv/kvserver/replica_protected_timestamp.go
@@ -89,7 +89,7 @@ func (r *Replica) readProtectedTimestampsRLocked(
 		}
 
 		log.VEventf(ctx, 2, "span: %s has a protection policy protecting: %s",
-			sp.String(), protectionTimestamp.String())
+			sp, protectionTimestamp)
 
 		if earliestTS.IsEmpty() || protectionTimestamp.Less(earliestTS) {
 			earliestTS = protectionTimestamp


### PR DESCRIPTION
We author a test with the following scenario :
```
     gc threshold < pts record timestamp < lease start < pts record read at
AND  pts record timestamp + gcttl < lease start
```
We're simulating a protection record being read within the current lease
interval, with a protection timestamp before the current lease start
time but larger than the replica's gc threshold (i.e. the pts record
applies to the replica). Finally, we want to make sure that the newly
computed gc threshold is still less than the current lease start time --
all of this serving as a regression test for #82954. In this scenario,
we should still be able to GC data.

Release note: None