### PR TITLE
ui: fix last execution timestamp

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
@@ -18,6 +18,7 @@ import {
   longToInt,
   TimestampToMoment,
   RenderCount,
+  DATE_FORMAT_24_UTC,
 } from "../../util";
 
 export type PlanHashStats =
@@ -151,7 +152,7 @@ export function makeExplainPlanColumns(
       title: planDetailsTableTitles.lastExecTime(),
       cell: (item: PlanHashStats) =>
         TimestampToMoment(item.stats.last_exec_timestamp).format(
-          "MMM DD, YYYY HH:MM",
+          DATE_FORMAT_24_UTC,
         ),
       sort: (item: PlanHashStats) =>
         TimestampToMoment(item.stats.last_exec_timestamp).unix(),

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -37,6 +37,8 @@ import {
   appAttr,
   appNamesAttr,
   RenderCount,
+  TimestampToMoment,
+  DATE_FORMAT_24_UTC,
 } from "src/util";
 import { Loading } from "src/loading";
 import { Button } from "src/button";
@@ -53,7 +55,6 @@ import styles from "./statementDetails.module.scss";
 import { commonStyles } from "src/common";
 import { NodeSummaryStats } from "../nodes";
 import { UIConfigState } from "../store";
-import moment from "moment";
 import { StatementDetailsRequest } from "src/api/statementsApi";
 import {
   TimeScale,
@@ -593,9 +594,8 @@ export class StatementDetails extends React.Component<
 
     const lastExec =
       stats.last_exec_timestamp &&
-      moment(stats.last_exec_timestamp.seconds.low * 1e3).format(
-        "MMM DD, YYYY HH:MM",
-      );
+      TimestampToMoment(stats.last_exec_timestamp).format(DATE_FORMAT_24_UTC);
+
     const statementSampled = stats.exec_stats.count > Long.fromNumber(0);
     const unavailableTooltip = !statementSampled && (
       <div>

--- a/pkg/ui/workspaces/cluster-ui/src/util/format.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/format.ts
@@ -170,6 +170,7 @@ export const DurationFitScale =
   };
 
 export const DATE_FORMAT = "MMM DD, YYYY [at] H:mm";
+export const DATE_FORMAT_24_UTC = "MMM DD, YYYY [at] HH:mm UTC";
 
 export function RenderCount(yesCount: Long, totalCount: Long): string {
   if (longToInt(yesCount) == 0) {


### PR DESCRIPTION
Previously, the last execution time format was using
`MM` for the minutes, which means month, instead of the
correct `mm` to indicate minutes.
This commit uses the correct format for the date.

Fixes #81682

Release note (bug fix): Last Execution time now
shows the correct value on Statement Details page (Overview
and Explain Plans).