### PR TITLE
cli/sql: support for client-side `\o`

### DIFF
--- a/pkg/cli/auth.go
+++ b/pkg/cli/auth.go
@@ -182,7 +182,7 @@ func runLogout(cmd *cobra.Command, args []string) (resErr error) {
 		username)
 	return sqlExecCtx.RunQueryAndFormatResults(
 		context.Background(),
-		sqlConn, os.Stdout, stderr, logoutQuery)
+		sqlConn, os.Stdout, os.Stdout, stderr, logoutQuery)
 }
 
 var authListCmd = &cobra.Command{
@@ -214,7 +214,7 @@ SELECT username,
   FROM system.web_sessions`)
 	return sqlExecCtx.RunQueryAndFormatResults(
 		context.Background(),
-		sqlConn, os.Stdout, stderr, logoutQuery)
+		sqlConn, os.Stdout, os.Stdout, stderr, logoutQuery)
 }
 
 var authCmds = []*cobra.Command{

--- a/pkg/cli/clisqlexec/run_query.go
+++ b/pkg/cli/clisqlexec/run_query.go
@@ -39,9 +39,10 @@ func (sqlExecCtx *Context) RunQuery(
 
 // RunQueryAndFormatResults takes a 'query' with optional 'parameters'.
 // It runs the sql query and writes output to 'w'.
+// Timings is enabled are written to 'tw'.
 // Errors and warnings, if any, are printed to 'ew'.
 func (sqlExecCtx *Context) RunQueryAndFormatResults(
-	ctx context.Context, conn clisqlclient.Conn, w, ew io.Writer, fn clisqlclient.QueryFn,
+	ctx context.Context, conn clisqlclient.Conn, w, tw, ew io.Writer, fn clisqlclient.QueryFn,
 ) (err error) {
 	startTime := timeutil.Now()
 	rows, isMultiStatementQuery, err := fn(ctx, conn)
@@ -113,7 +114,7 @@ func (sqlExecCtx *Context) RunQueryAndFormatResults(
 		} else if !more {
 			// We must call maybeShowTimes after rows has been closed, which is after
 			// NextResultSet returns false.
-			sqlExecCtx.maybeShowTimes(ctx, conn, w, ew, isMultiStatementQuery, startTime, queryCompleteTime)
+			sqlExecCtx.maybeShowTimes(ctx, conn, tw, ew, isMultiStatementQuery, startTime, queryCompleteTime)
 			return nil
 		}
 	}

--- a/pkg/cli/clisqlexec/run_query_test.go
+++ b/pkg/cli/clisqlexec/run_query_test.go
@@ -41,7 +41,7 @@ func runQueryAndFormatResults(
 ) (err error) {
 	return testExecCtx.RunQueryAndFormatResults(
 		context.Background(),
-		conn, w, ioutil.Discard, fn)
+		conn, w, ioutil.Discard, ioutil.Discard, fn)
 }
 
 func TestRunQuery(t *testing.T) {

--- a/pkg/cli/clisqlshell/context.go
+++ b/pkg/cli/clisqlshell/context.go
@@ -11,7 +11,9 @@
 package clisqlshell
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"os"
 	"time"
 
@@ -53,6 +55,14 @@ type internalContext struct {
 	// stdout and stderr are where messages and errors/warnings go.
 	stdout *os.File
 	stderr *os.File
+
+	// queryOutputFile is the output file configured via \o.
+	// This can be the same as stdout (\o without argument).
+	// Note: we use .queryOutput for query execution, which
+	// is buffered (via queryOutputBuf).
+	queryOutputFile *os.File
+	queryOutputBuf  *bufio.Writer
+	queryOutput     io.Writer
 
 	// quitAfterExecStmts tells the shell whether to quit
 	// after processing the execStmts.

--- a/pkg/cli/interactive_tests/test_local_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_local_cmds.tcl
@@ -266,6 +266,36 @@ eexpect Description
 eexpect root@
 end_test
 
+start_test "Check that the output of queries can be redirected to a file."
+send "\\o logs/query-output.txt\r"
+eexpect root@
+send "select 'hello world';\r"
+eexpect root@
+# Check the output is flushed immediately.
+system "grep -q world logs/query-output.txt"
+send "\\qecho universe\r"
+eexpect root@
+# Check qecho works.
+system "grep -q universe logs/query-output.txt"
+# Check the previous output was not erased by subsequent command.
+system "grep -q world logs/query-output.txt"
+end_test
+
+start_test "Check that errors are not redirected."
+send "select planet;\r"
+# Check the output is not redirected.
+eexpect "column \"planet\" does not exist"
+system "grep -vq planet logs/query-output.txt"
+end_test
+
+start_test "Check that the query output can be reset to stdout."
+send "\\o\r"
+eexpect root@
+send "select 'hel'||'lo';\r"
+eexpect "hello"
+eexpect root@
+end_test
+
 # Finally terminate with Ctrl+D.
 send_eof
 eexpect eof

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -13,6 +13,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -356,7 +357,7 @@ func (zc *debugZipContext) dumpTableDataForZip(
 			}
 			// Pump the SQL rows directly into the zip writer, to avoid
 			// in-RAM buffering.
-			return sqlExecCtx.RunQueryAndFormatResults(ctx, conn, w, stderr, clisqlclient.MakeQuery(query))
+			return sqlExecCtx.RunQueryAndFormatResults(ctx, conn, w, ioutil.Discard, stderr, clisqlclient.MakeQuery(query))
 		}()
 		if sqlErr != nil {
 			if cErr := zc.z.createError(s, name, sqlErr); cErr != nil {


### PR DESCRIPTION
Release note (cli change): `cockroach sql` (and thus `cockroach demo`
too) now support the client-side commands `\o` and `\qecho` like
`psql`. The command `\o` can redirect the output of SQL queries to a
file. `\qecho` adds an arbitrary text to the current query output file.