### PR TITLE
server: include system and meta ranges in hot ranges report 

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2411,27 +2411,36 @@ func (s *statusServer) HotRangesV2(
 						dbName, tableName, indexName, schemaName string
 						replicaNodeIDs                           []roachpb.NodeID
 					)
-					_, tableID, err := s.sqlServer.execCfg.Codec.DecodeTablePrefix(r.Desc.StartKey.AsRawKey())
-					if err != nil {
-						log.Warningf(ctx, "cannot decode tableID for range descriptor: %s. %s", r.Desc.String(), err.Error())
-						continue
-					}
-					parent := rangeReportMetas[tableID].parentID
-					if parent != 0 {
-						tableName = rangeReportMetas[tableID].tableName
-						dbName = rangeReportMetas[parent].dbName
-					} else {
-						dbName = rangeReportMetas[tableID].dbName
-					}
-					schemaParent := rangeReportMetas[tableID].schemaParentID
-					schemaName = rangeReportMetas[schemaParent].schemaName
-					_, _, idxID, err := s.sqlServer.execCfg.Codec.DecodeIndexPrefix(r.Desc.StartKey.AsRawKey())
-					if err == nil {
-						indexName = rangeReportMetas[tableID].indexNames[idxID]
-					}
 					for _, repl := range r.Desc.Replicas().Descriptors() {
 						replicaNodeIDs = append(replicaNodeIDs, repl.NodeID)
 					}
+					if r.Desc.StartKey.Equal(roachpb.RKeyMin) ||
+						bytes.HasPrefix(r.Desc.StartKey, keys.Meta1Prefix) ||
+						bytes.HasPrefix(r.Desc.StartKey, keys.Meta2Prefix) ||
+						bytes.HasPrefix(r.Desc.StartKey, keys.SystemPrefix) {
+						dbName = "system"
+						tableName = r.Desc.StartKey.String()
+					} else {
+						_, tableID, err := s.sqlServer.execCfg.Codec.DecodeTablePrefix(r.Desc.StartKey.AsRawKey())
+						if err != nil {
+							log.Warningf(ctx, "cannot decode tableID for range descriptor: %s. %s", r.Desc.String(), err.Error())
+							continue
+						}
+						parent := rangeReportMetas[tableID].parentID
+						if parent != 0 {
+							tableName = rangeReportMetas[tableID].tableName
+							dbName = rangeReportMetas[parent].dbName
+						} else {
+							dbName = rangeReportMetas[tableID].dbName
+						}
+						schemaParent := rangeReportMetas[tableID].schemaParentID
+						schemaName = rangeReportMetas[schemaParent].schemaName
+						_, _, idxID, err := s.sqlServer.execCfg.Codec.DecodeIndexPrefix(r.Desc.StartKey.AsRawKey())
+						if err == nil {
+							indexName = rangeReportMetas[tableID].indexNames[idxID]
+						}
+					}
+
 					ranges = append(ranges, &serverpb.HotRangesResponseV2_HotRange{
 						RangeID:           r.Desc.RangeID,
 						NodeID:            nodeID,


### PR DESCRIPTION
 `status.HotRangesV2` endpoint iterates over ranges that have the highest
 QPS, and it might include meta- or system ranges that don't have
 table descriptors. Before, it didn't include such ranges that 
 didn't provide users full information on what ranges are hot even
 if it's a system range.

 The current patch includes system and meta ranges in the Hot Ranges list
 with limited information (that doesn't include table-specific data).

Release note: None

Resolves #83117