### PR TITLE
sql/backfill: Make all columns accessible when checking for uniqueness

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -1798,3 +1798,12 @@ SELECT pk, a, b, crdb_region_col, crdb_region_col1 FROM regional_by_row_table_as
 1  NULL  NULL  ca-central-1  ca-central-1
 2  NULL  NULL  us-east-1     ca-central-1
 3  NULL  NULL  us-east-1     ca-central-1
+
+# Regression for https://github.com/cockroachdb/cockroach/issues/83076
+# It tests that we should be able to create a unique, expression index
+# on a REGIONAL BY ROW table.
+statement ok
+CREATE TABLE regional_by_row_table_with_unique_expression_index(s STRING) LOCALITY REGIONAL BY ROW
+
+statement ok
+CREATE UNIQUE INDEX idx ON regional_by_row_table_with_unique_expression_index(lower(s))

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1868,7 +1868,24 @@ func countIndexRowsAndMaybeCheckUniqueness(
 		if err != nil {
 			return 0, err
 		}
-		desc = fakeDesc
+		// Mark all the columns accessible if they are not.
+		// This is to fix a bug when attempting to create a unique, expression
+		// index on a REGIONAL BY table -- the accompanying expression column
+		// is inaccessible, but later we check for uniqueness on this column
+		// via a SQL `SELECT` query, which then errors out.
+		// Such a fix is safe since this copy ('fakeDesc') is only used
+		// internally for validation.
+		// See https://github.com/cockroachdb/cockroach/issues/83076 for details.
+		mut, ok := fakeDesc.(*tabledesc.Mutable)
+		if !ok {
+			mut = tabledesc.NewBuilder(fakeDesc.TableDesc()).BuildCreatedMutableTable()
+		}
+		for i := range mut.Columns {
+			if col := &mut.Columns[i]; col.Inaccessible {
+				col.Inaccessible = false
+			}
+		}
+		desc = mut.ImmutableCopy().(catalog.TableDescriptor)
 	}
 
 	// Retrieve the row count in the index.


### PR DESCRIPTION
We ran into a issue when attempting to create a unique expression index
on a REGIONAL BY table. The root cause is that when doing uniqueness
check for this index, we use `SELECT` on the accompanying expression
column, which is inaccessible.

This PR fixes this by making all the columns accessible on the existing
temporary table descriptor, a copy of the original one, but with all
mutations made public. Such a temporary descriptor is only used
internally for validation purpose so it's safe to do so.

Release note (bug fix): fixes the issue when creating a unique,
expression index on a REGIONAL BY table. 

Fix: #83076 