### PR TITLE
dev: disable remote cache when building bazel-remote

### DIFF
--- a/dev
+++ b/dev
@@ -16,7 +16,7 @@ fi
 if [[ ! -f "$BINARY_PATH" ]]; then
     echo "$BINARY_PATH not found, building..."
     mkdir -p $BINARY_DIR
-    bazel build //pkg/cmd/dev --//build/toolchains:nogo_disable_flag
+    bazel build //pkg/cmd/dev --//build/toolchains:nogo_disable_flag --remote_cache=
     cp $(bazel info bazel-bin --//build/toolchains:nogo_disable_flag)/pkg/cmd/dev/dev_/dev $BINARY_PATH
     # The Bazel-built binary won't have write permissions.
     chmod a+w $BINARY_PATH

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -31,6 +31,7 @@ const (
 	crossFlag       = "cross"
 	nogoDisableFlag = "--//build/toolchains:nogo_disable_flag"
 	geosTarget      = "//c-deps:libgeos"
+	devTarget       = "//pkg/cmd/dev:dev"
 )
 
 type buildTarget struct {
@@ -79,7 +80,7 @@ var buildTargetMapping = map[string]string{
 	"cockroach-oss":    "//pkg/cmd/cockroach-oss:cockroach-oss",
 	"cockroach-short":  "//pkg/cmd/cockroach-short:cockroach-short",
 	"crlfmt":           "@com_github_cockroachdb_crlfmt//:crlfmt",
-	"dev":              "//pkg/cmd/dev:dev",
+	"dev":              devTarget,
 	"docgen":           "//pkg/cmd/docgen:docgen",
 	"docs-issue-gen":   "//pkg/cmd/docs-issue-generation:docs-issue-generation",
 	"execgen":          "//pkg/sql/colexec/execgen/cmd/execgen:execgen",
@@ -404,7 +405,7 @@ func (d *dev) getBasicBuildArgs(
 		} else {
 			buildTargets = append(buildTargets, buildTarget{fullName: aliased, kind: "go_binary"})
 		}
-		if strings.HasPrefix(aliased, "//") {
+		if strings.HasPrefix(aliased, "//") && aliased != devTarget {
 			canDisableNogo = false
 		}
 	}

--- a/pkg/cmd/dev/cache.go
+++ b/pkg/cmd/dev/cache.go
@@ -25,10 +25,11 @@ import (
 )
 
 const (
-	bazelRemoteTarget = "@com_github_buchgr_bazel_remote//:bazel-remote"
-	cacheCleanFlag    = "clean"
-	cacheDownFlag     = "down"
-	cacheResetFlag    = "reset"
+	remoteCacheDisableFlag = "--remote_cache="
+	bazelRemoteTarget      = "@com_github_buchgr_bazel_remote//:bazel-remote"
+	cacheCleanFlag         = "clean"
+	cacheDownFlag          = "down"
+	cacheResetFlag         = "reset"
 
 	cachePidFilename = ".dev-cache.pid"
 	configFilename   = "config.yml"
@@ -136,11 +137,11 @@ func (d *dev) setUpCache(ctx context.Context) (string, error) {
 
 	log.Printf("Configuring cache...\n")
 
-	err := d.exec.CommandContextInheritingStdStreams(ctx, "bazel", "build", bazelRemoteTarget, nogoDisableFlag)
+	err := d.exec.CommandContextInheritingStdStreams(ctx, "bazel", "build", bazelRemoteTarget, nogoDisableFlag, remoteCacheDisableFlag)
 	if err != nil {
 		return "", err
 	}
-	bazelRemoteLoc, err := d.exec.CommandContextSilent(ctx, "bazel", "run", bazelRemoteTarget, nogoDisableFlag, "--run_under=//build/bazelutil/whereis")
+	bazelRemoteLoc, err := d.exec.CommandContextSilent(ctx, "bazel", "run", bazelRemoteTarget, nogoDisableFlag, "--run_under=//build/bazelutil/whereis", remoteCacheDisableFlag)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Typically you're building this binary because your cache is not up, but
if your cache is not up you can encounter a lot of these
`Connection refused` errors. Disable the remote cache when building in
this case.

Also disable `nogo` when building `dev`, similarly to save time, and
disable remote caching when building from the top-level `dev` script.

Release note: None