### PR TITLE
publish-artifacts: Add GCS support

### DIFF
--- a/build/bazelutil/check.sh
+++ b/build/bazelutil/check.sh
@@ -50,7 +50,6 @@ pkg/acceptance/BUILD.bazel
 pkg/cmd/cockroach-oss/BUILD.bazel
 pkg/cmd/github-post/BUILD.bazel
 pkg/cmd/prereqs/BUILD.bazel
-pkg/cmd/publish-artifacts/BUILD.bazel
 pkg/cmd/roachtest/BUILD.bazel
 pkg/cmd/teamcity-trigger/BUILD.bazel
 "

--- a/pkg/cmd/publish-artifacts/BUILD.bazel
+++ b/pkg/cmd/publish-artifacts/BUILD.bazel
@@ -7,9 +7,6 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/release",
-        "@com_github_aws_aws_sdk_go//aws",
-        "@com_github_aws_aws_sdk_go//aws/session",
-        "@com_github_aws_aws_sdk_go//service/s3",
         "@com_github_kr_pretty//:pretty",
     ],
 )
@@ -29,8 +26,6 @@ go_test(
         "//pkg/release",
         "//pkg/testutils",
         "@com_github_alessio_shellescape//:shellescape",
-        "@com_github_aws_aws_sdk_go//service/s3",
-        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/cmd/publish-artifacts/main.go
+++ b/pkg/cmd/publish-artifacts/main.go
@@ -18,9 +18,6 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/cockroachdb/cockroach/pkg/release"
 	"github.com/kr/pretty"
 )
@@ -31,24 +28,8 @@ const (
 	teamcityBuildBranchKey = "TC_BUILD_BRANCH"
 )
 
-type s3putter interface {
-	PutObject(*s3.PutObjectInput) (*s3.PutObjectOutput, error)
-}
-
-// Overridden in testing.
-var testableS3 = func() (s3putter, error) {
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-east-1"),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return s3.New(sess), nil
-}
-
-var destBucket = flag.String("bucket", "", "override default bucket")
-
 func main() {
+	var destBucket = flag.String("bucket", "", "override default bucket")
 	flag.Parse()
 
 	if _, ok := os.LookupEnv(awsAccessKeyIDKey); !ok {
@@ -81,7 +62,7 @@ func main() {
 	}
 	versionStr := string(bytes.TrimSpace(out))
 
-	svc, err := testableS3()
+	s3, err := release.NewS3("us-east-1")
 	if err != nil {
 		log.Fatalf("Creating AWS S3 session: %s", err)
 	}
@@ -94,7 +75,7 @@ func main() {
 	}
 	log.Printf("Using S3 bucket: %s", bucketName)
 
-	run(svc, runFlags{
+	run([]release.ObjectPutGetter{s3}, runFlags{
 		pkgDir:     pkg,
 		branch:     branch,
 		sha:        versionStr,
@@ -103,16 +84,17 @@ func main() {
 }
 
 type runFlags struct {
-	branch, sha string
-	pkgDir      string
-	bucketName  string
+	branch     string
+	sha        string
+	pkgDir     string
+	bucketName string
 }
 
-func run(svc s3putter, flags runFlags, execFn release.ExecFn) {
+func run(providers []release.ObjectPutGetter, flags runFlags, execFn release.ExecFn) {
 	for _, platform := range []release.Platform{release.PlatformLinux, release.PlatformLinuxArm, release.PlatformMacOS, release.PlatformWindows} {
 		var o opts
 		o.Platform = platform
-		o.ReleaseVersionStrs = []string{flags.sha}
+		o.ReleaseVersions = []string{flags.sha}
 		o.PkgDir = flags.pkgDir
 		o.Branch = flags.branch
 		o.VersionStr = flags.sha
@@ -121,8 +103,7 @@ func run(svc s3putter, flags runFlags, execFn release.ExecFn) {
 		o.CockroachSQLAbsolutePath = filepath.Join(flags.pkgDir, "cockroach-sql"+release.SuffixFromPlatform(platform))
 
 		log.Printf("building %s", pretty.Sprint(o))
-
-		buildOneCockroach(svc, o, execFn)
+		buildOneCockroach(providers, o, execFn)
 	}
 	// We build workload only for Linux.
 	var o opts
@@ -131,47 +112,58 @@ func run(svc s3putter, flags runFlags, execFn release.ExecFn) {
 	o.BucketName = flags.bucketName
 	o.Branch = flags.branch
 	o.VersionStr = flags.sha
-	buildOneWorkload(svc, o, execFn)
+	buildAndPublishWorkload(providers, o, execFn)
 }
 
-func buildOneCockroach(svc s3putter, o opts, execFn release.ExecFn) {
+func buildOneCockroach(providers []release.ObjectPutGetter, o opts, execFn release.ExecFn) {
 	log.Printf("building cockroach %s", pretty.Sprint(o))
-	defer func() {
-		log.Printf("done building cockroach: %s", pretty.Sprint(o))
-	}()
-
 	if err := release.MakeRelease(o.Platform, release.BuildOptions{ExecFn: execFn}, o.PkgDir); err != nil {
 		log.Fatal(err)
 	}
-
-	putNonRelease(svc, o, release.MakeCRDBLibraryNonReleaseFiles(o.PkgDir, o.Platform, o.VersionStr)...)
+	for _, provider := range providers {
+		release.PutNonRelease(
+			provider,
+			release.PutNonReleaseOptions{
+				Branch:     o.Branch,
+				BucketName: o.BucketName,
+				Files: append(
+					[]release.NonReleaseFile{
+						release.MakeCRDBBinaryNonReleaseFile(o.AbsolutePath, o.VersionStr),
+						release.MakeCRDBBinaryNonReleaseFile(o.CockroachSQLAbsolutePath, o.VersionStr),
+					},
+					release.MakeCRDBLibraryNonReleaseFiles(o.PkgDir, o.Platform, o.VersionStr)...,
+				),
+			},
+		)
+	}
+	log.Printf("done building cockroach: %s", pretty.Sprint(o))
 }
 
-func buildOneWorkload(svc s3putter, o opts, execFn release.ExecFn) {
-	defer func() {
-		log.Printf("done building workload: %s", pretty.Sprint(o))
-	}()
-
+func buildAndPublishWorkload(providers []release.ObjectPutGetter, o opts, execFn release.ExecFn) {
+	log.Printf("building workload %s", pretty.Sprint(o))
 	if err := release.MakeWorkload(release.BuildOptions{ExecFn: execFn}, o.PkgDir); err != nil {
 		log.Fatal(err)
 	}
 	o.AbsolutePath = filepath.Join(o.PkgDir, "bin", "workload")
-	release.PutNonRelease(
-		svc,
-		release.PutNonReleaseOptions{
-			Branch:     o.Branch,
-			BucketName: o.BucketName,
-			Files: []release.NonReleaseFile{
-				release.MakeCRDBBinaryNonReleaseFile(o.AbsolutePath, o.VersionStr),
+	for _, provider := range providers {
+		release.PutNonRelease(
+			provider,
+			release.PutNonReleaseOptions{
+				Branch:     o.Branch,
+				BucketName: o.BucketName,
+				Files: []release.NonReleaseFile{
+					release.MakeCRDBBinaryNonReleaseFile(o.AbsolutePath, o.VersionStr),
+				},
 			},
-		},
-	)
+		)
+	}
+	log.Printf("done building workload: %s", pretty.Sprint(o))
 }
 
 type opts struct {
-	VersionStr         string
-	Branch             string
-	ReleaseVersionStrs []string
+	VersionStr      string
+	Branch          string
+	ReleaseVersions []string
 
 	Platform release.Platform
 
@@ -179,21 +171,4 @@ type opts struct {
 	AbsolutePath             string
 	CockroachSQLAbsolutePath string
 	PkgDir                   string
-}
-
-func putNonRelease(svc s3putter, o opts, additionalNonReleaseFiles ...release.NonReleaseFile) {
-	release.PutNonRelease(
-		svc,
-		release.PutNonReleaseOptions{
-			Branch:     o.Branch,
-			BucketName: o.BucketName,
-			Files: append(
-				[]release.NonReleaseFile{
-					release.MakeCRDBBinaryNonReleaseFile(o.AbsolutePath, o.VersionStr),
-					release.MakeCRDBBinaryNonReleaseFile(o.CockroachSQLAbsolutePath, o.VersionStr),
-				},
-				additionalNonReleaseFiles...,
-			),
-		},
-	)
 }

--- a/pkg/cmd/publish-artifacts/main_test.go
+++ b/pkg/cmd/publish-artifacts/main_test.go
@@ -26,18 +26,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type mockS3 struct {
+type mockStorage struct {
 	puts []string
 }
 
-var _ release.ObjectPutGetter = (*mockS3)(nil)
+var _ release.ObjectPutGetter = (*mockStorage)(nil)
 
-func (s *mockS3) GetObject(*release.GetObjectInput) (*release.GetObjectOutput, error) {
+func (s *mockStorage) Bucket() string {
+	return "cockroach"
+}
+
+func (s mockStorage) URL(key string) string {
+	return "storage://bucket/" + key
+}
+
+func (s *mockStorage) GetObject(*release.GetObjectInput) (*release.GetObjectOutput, error) {
 	return &release.GetObjectOutput{}, nil
 }
 
-func (s *mockS3) PutObject(i *release.PutObjectInput) error {
-	url := fmt.Sprintf(`s3://%s/%s`, *i.Bucket, *i.Key)
+func (s *mockStorage) PutObject(i *release.PutObjectInput) error {
+	url := fmt.Sprintf(`s3://%s/%s`, s.Bucket(), *i.Key)
 	if i.CacheControl != nil {
 		url += `/` + *i.CacheControl
 	}
@@ -140,9 +148,8 @@ func TestPublish(t *testing.T) {
 		{
 			name: `release`,
 			flags: runFlags{
-				branch:     "master",
-				sha:        "1234567890abcdef",
-				bucketName: "cockroach",
+				branch: "master",
+				sha:    "1234567890abcdef",
 			},
 			expectedCmds: []string{
 				"env=[] args=bazel build //pkg/cmd/cockroach //c-deps:libgeos //pkg/cmd/cockroach-sql " +
@@ -253,7 +260,8 @@ func TestPublish(t *testing.T) {
 			dir, cleanup := testutils.TempDir(t)
 			defer cleanup()
 
-			var s3 mockS3
+			var s3 mockStorage
+			var gcs mockStorage
 			var runner mockExecRunner
 			fakeBazelBin, cleanup := testutils.TempDir(t)
 			defer cleanup()
@@ -261,9 +269,10 @@ func TestPublish(t *testing.T) {
 			flags := test.flags
 			flags.pkgDir = dir
 			execFn := release.ExecFn{MockExecFn: runner.run}
-			run([]release.ObjectPutGetter{&s3}, flags, execFn)
+			run([]release.ObjectPutGetter{&s3, &gcs}, flags, execFn)
 			require.Equal(t, test.expectedCmds, runner.cmds)
 			require.Equal(t, test.expectedPuts, s3.puts)
+			require.Equal(t, test.expectedPuts, gcs.puts)
 		})
 	}
 }

--- a/pkg/cmd/publish-provisional-artifacts/BUILD.bazel
+++ b/pkg/cmd/publish-provisional-artifacts/BUILD.bazel
@@ -8,9 +8,6 @@ go_library(
     deps = [
         "//pkg/release",
         "//pkg/util/version",
-        "@com_github_aws_aws_sdk_go//aws",
-        "@com_github_aws_aws_sdk_go//aws/session",
-        "@com_github_aws_aws_sdk_go//service/s3",
         "@com_github_kr_pretty//:pretty",
     ],
 )
@@ -30,8 +27,6 @@ go_test(
         "//pkg/release",
         "//pkg/testutils",
         "@com_github_alessio_shellescape//:shellescape",
-        "@com_github_aws_aws_sdk_go//service/s3",
-        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/cmd/publish-provisional-artifacts/main_test.go
+++ b/pkg/cmd/publish-provisional-artifacts/main_test.go
@@ -27,15 +27,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type mockS3 struct {
-	gets []string
-	puts []string
+type mockStorage struct {
+	bucket string
+	gets   []string
+	puts   []string
 }
 
-var _ release.ObjectPutGetter = (*mockS3)(nil)
+var _ release.ObjectPutGetter = (*mockStorage)(nil)
 
-func (s *mockS3) GetObject(i *release.GetObjectInput) (*release.GetObjectOutput, error) {
-	url := fmt.Sprintf(`s3://%s/%s`, *i.Bucket, *i.Key)
+func (s *mockStorage) Bucket() string {
+	return s.bucket
+}
+
+func (s mockStorage) URL(key string) string {
+	return "storage://bucket/" + key
+}
+
+func (s *mockStorage) GetObject(i *release.GetObjectInput) (*release.GetObjectOutput, error) {
+	url := fmt.Sprintf(`s3://%s/%s`, s.Bucket(), *i.Key)
 	s.gets = append(s.gets, url)
 	o := &release.GetObjectOutput{
 		Body: ioutil.NopCloser(bytes.NewBufferString(url)),
@@ -43,8 +52,8 @@ func (s *mockS3) GetObject(i *release.GetObjectInput) (*release.GetObjectOutput,
 	return o, nil
 }
 
-func (s *mockS3) PutObject(i *release.PutObjectInput) error {
-	url := fmt.Sprintf(`s3://%s/%s`, *i.Bucket, *i.Key)
+func (s *mockStorage) PutObject(i *release.PutObjectInput) error {
+	url := fmt.Sprintf(`s3://%s/%s`, s.Bucket(), *i.Key)
 	if i.CacheControl != nil {
 		url += `/` + *i.CacheControl
 	}
@@ -283,7 +292,16 @@ func TestProvisional(t *testing.T) {
 			dir, cleanup := testutils.TempDir(t)
 			defer cleanup()
 
-			var s3 mockS3
+			var s3 mockStorage
+			s3.bucket = "cockroach"
+			if test.flags.isRelease {
+				s3.bucket = "binaries.cockroachdb.com"
+			}
+			var gcs mockStorage
+			gcs.bucket = "cockroach"
+			if test.flags.isRelease {
+				gcs.bucket = "binaries.cockroachdb.com"
+			}
 			var runner mockExecRunner
 			fakeBazelBin, cleanup := testutils.TempDir(t)
 			defer cleanup()
@@ -291,10 +309,12 @@ func TestProvisional(t *testing.T) {
 			flags := test.flags
 			flags.pkgDir = dir
 			execFn := release.ExecFn{MockExecFn: runner.run}
-			run([]release.ObjectPutGetter{&s3}, flags, execFn)
+			run([]release.ObjectPutGetter{&s3, &gcs}, flags, execFn)
 			require.Equal(t, test.expectedCmds, runner.cmds)
 			require.Equal(t, test.expectedGets, s3.gets)
 			require.Equal(t, test.expectedPuts, s3.puts)
+			require.Equal(t, test.expectedGets, gcs.gets)
+			require.Equal(t, test.expectedPuts, gcs.puts)
 		})
 	}
 }
@@ -343,7 +363,8 @@ func TestBless(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			var s3 mockS3
+			var s3 mockStorage
+			s3.bucket = "binaries.cockroachdb.com"
 			var execFn release.ExecFn // bless shouldn't exec anything
 			run([]release.ObjectPutGetter{&s3}, test.flags, execFn)
 			require.Equal(t, test.expectedGets, s3.gets)

--- a/pkg/release/BUILD.bazel
+++ b/pkg/release/BUILD.bazel
@@ -2,11 +2,18 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "release",
-    srcs = ["release.go"],
+    srcs = [
+        "build.go",
+        "release.go",
+        "s3.go",
+        "upload.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/release",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/build/util",
+        "@com_github_aws_aws_sdk_go//aws",
+        "@com_github_aws_aws_sdk_go//aws/session",
         "@com_github_aws_aws_sdk_go//service/s3",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/release/BUILD.bazel
+++ b/pkg/release/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "release",
     srcs = [
         "build.go",
+        "gcs.go",
         "release.go",
         "s3.go",
         "upload.go",
@@ -16,5 +17,6 @@ go_library(
         "@com_github_aws_aws_sdk_go//aws/session",
         "@com_github_aws_aws_sdk_go//service/s3",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_google_cloud_go_storage//:storage",
     ],
 )

--- a/pkg/release/build.go
+++ b/pkg/release/build.go
@@ -1,0 +1,321 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package release
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/build/util"
+	"github.com/cockroachdb/errors"
+)
+
+// BuildOptions is a set of options that may be applied to a build.
+type BuildOptions struct {
+	// True iff this is a release build.
+	Release bool
+	// BuildTag must be set if Release is set, and vice-versea.
+	BuildTag string
+
+	// ExecFn.Run() is called to execute commands for this build.
+	// The zero value is appropriate in "real" scenarios but for
+	// tests you can update ExecFn.MockExecFn.
+	ExecFn ExecFn
+}
+
+// SuffixFromPlatform returns the suffix that will be appended to the
+// `cockroach` binary when built with the given platform. The binary
+// itself can be found in pkgDir/cockroach$SUFFIX after the build.
+func SuffixFromPlatform(platform Platform) string {
+	switch platform {
+	case PlatformLinux:
+		return ".linux-2.6.32-gnu-amd64"
+	case PlatformLinuxArm:
+		return ".linux-3.7.10-gnu-aarch64"
+	case PlatformMacOS:
+		// TODO(#release): The architecture is at least 10.10 until v20.2 and 10.15 for
+		// v21.1 and after. Check whether this can be changed.
+		return ".darwin-10.9-amd64"
+	case PlatformWindows:
+		return ".windows-6.2-amd64.exe"
+	default:
+		panic(errors.Newf("unknown platform %d", platform))
+	}
+}
+
+// CrossConfigFromPlatform returns the cross*base config corresponding
+// to the given platform. (See .bazelrc for more details.)
+func CrossConfigFromPlatform(platform Platform) string {
+	switch platform {
+	case PlatformLinux:
+		return "crosslinuxbase"
+	case PlatformLinuxArm:
+		return "crosslinuxarmbase"
+	case PlatformMacOS:
+		return "crossmacosbase"
+	case PlatformWindows:
+		return "crosswindowsbase"
+	default:
+		panic(errors.Newf("unknown platform %d", platform))
+	}
+}
+
+// TargetTripleFromPlatform returns the target triple that will be baked
+// into the cockroach binary for the given platform.
+func TargetTripleFromPlatform(platform Platform) string {
+	switch platform {
+	case PlatformLinux:
+		return "x86_64-pc-linux-gnu"
+	case PlatformLinuxArm:
+		return "aarch64-unknown-linux-gnu"
+	case PlatformMacOS:
+		return "x86_64-apple-darwin19"
+	case PlatformWindows:
+		return "x86_64-w64-mingw32"
+	default:
+		panic(errors.Newf("unknown platform %d", platform))
+	}
+}
+
+// SharedLibraryExtensionFromPlatform returns the shared library extensions for a given Platform.
+func SharedLibraryExtensionFromPlatform(platform Platform) string {
+	switch platform {
+	case PlatformLinux, PlatformLinuxArm:
+		return ".so"
+	case PlatformWindows:
+		return ".dll"
+	case PlatformMacOS:
+		return ".dylib"
+	default:
+		panic(errors.Newf("unknown platform %d", platform))
+	}
+}
+
+// MakeWorkload makes the bin/workload binary. It is only ever built in the
+// crosslinux configuration.
+func MakeWorkload(opts BuildOptions, pkgDir string) error {
+	if opts.Release {
+		return errors.Newf("cannot build workload in Release mode")
+	}
+	// NB: workload doesn't need anything stamped so we can use `crosslinux`
+	// rather than `crosslinuxbase`.
+	cmd := exec.Command("bazel", "build", "//pkg/cmd/workload", "-c", "opt", "--config=crosslinux", "--config=ci")
+	cmd.Dir = pkgDir
+	cmd.Stderr = os.Stderr
+	log.Printf("%s", cmd.Args)
+	stdoutBytes, err := opts.ExecFn.Run(cmd)
+	if err != nil {
+		return errors.Wrapf(err, "failed to run %s: %s", cmd.Args, string(stdoutBytes))
+	}
+
+	bazelBin, err := getPathToBazelBin(opts.ExecFn, pkgDir, []string{"-c", "opt", "--config=crosslinux", "--config=ci"})
+	if err != nil {
+		return err
+	}
+	return stageBinary("//pkg/cmd/workload", PlatformLinux, bazelBin, filepath.Join(pkgDir, "bin"), false)
+}
+
+// MakeRelease makes the release binary and associated files.
+func MakeRelease(platform Platform, opts BuildOptions, pkgDir string) error {
+	buildArgs := []string{"build", "//pkg/cmd/cockroach", "//c-deps:libgeos", "//pkg/cmd/cockroach-sql"}
+	targetTriple := TargetTripleFromPlatform(platform)
+	if opts.Release {
+		if opts.BuildTag == "" {
+			return errors.Newf("must set BuildTag if Release is set")
+		}
+		buildArgs = append(buildArgs, fmt.Sprintf("--workspace_status_command=./build/bazelutil/stamp.sh %s official-binary %s release", targetTriple, opts.BuildTag))
+	} else {
+		if opts.BuildTag != "" {
+			return errors.Newf("cannot set BuildTag if Release is not set")
+		}
+		buildArgs = append(buildArgs, fmt.Sprintf("--workspace_status_command=./build/bazelutil/stamp.sh %s official-binary", targetTriple))
+	}
+	configs := []string{"-c", "opt", "--config=ci", "--config=force_build_cdeps", "--config=with_ui", fmt.Sprintf("--config=%s", CrossConfigFromPlatform(platform))}
+	buildArgs = append(buildArgs, configs...)
+	cmd := exec.Command("bazel", buildArgs...)
+	cmd.Dir = pkgDir
+	cmd.Stderr = os.Stderr
+	log.Printf("%s", cmd.Args)
+	stdoutBytes, err := opts.ExecFn.Run(cmd)
+	if err != nil {
+		return errors.Wrapf(err, "failed to run %s: %s", cmd.Args, string(stdoutBytes))
+	}
+
+	// Stage binaries from bazel-bin.
+	bazelBin, err := getPathToBazelBin(opts.ExecFn, pkgDir, configs)
+	if err != nil {
+		return err
+	}
+	if err := stageBinary("//pkg/cmd/cockroach", platform, bazelBin, pkgDir, true); err != nil {
+		return err
+	}
+	// TODO: strip the bianry
+	if err := stageBinary("//pkg/cmd/cockroach-sql", platform, bazelBin, pkgDir, true); err != nil {
+		return err
+	}
+	if err := stageLibraries(platform, bazelBin, filepath.Join(pkgDir, "lib")); err != nil {
+		return err
+	}
+
+	if platform == PlatformLinux {
+		suffix := SuffixFromPlatform(platform)
+		binaryName := "./cockroach" + suffix
+
+		cmd := exec.Command(binaryName, "version")
+		cmd.Dir = pkgDir
+		cmd.Env = append(cmd.Env, "MALLOC_CONF=prof:true")
+		cmd.Stderr = os.Stderr
+		log.Printf("%s %s", cmd.Env, cmd.Args)
+		stdoutBytes, err := opts.ExecFn.Run(cmd)
+		if err != nil {
+			return errors.Wrapf(err, "%s %s: %s", cmd.Env, cmd.Args, string(stdoutBytes))
+		}
+
+		cmd = exec.Command("ldd", binaryName)
+		cmd.Dir = pkgDir
+		cmd.Stderr = os.Stderr
+		log.Printf("%s %s", cmd.Env, cmd.Args)
+		stdoutBytes, err = opts.ExecFn.Run(cmd)
+		if err != nil {
+			log.Fatalf("%s %s: out=%s err=%v", cmd.Env, cmd.Args, string(stdoutBytes), err)
+		}
+		scanner := bufio.NewScanner(bytes.NewReader(stdoutBytes))
+		for scanner.Scan() {
+			if line := scanner.Text(); !linuxStaticLibsRe.MatchString(line) {
+				return errors.Newf("%s is not properly statically linked:\n%s", binaryName, line)
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+var (
+	// linuxStaticLibsRe returns the regexp of all static libraries.
+	linuxStaticLibsRe = func() *regexp.Regexp {
+		libs := strings.Join([]string{
+			regexp.QuoteMeta("linux-vdso.so."),
+			regexp.QuoteMeta("librt.so."),
+			regexp.QuoteMeta("libpthread.so."),
+			regexp.QuoteMeta("libdl.so."),
+			regexp.QuoteMeta("libm.so."),
+			regexp.QuoteMeta("libc.so."),
+			regexp.QuoteMeta("libresolv.so."),
+			strings.Replace(regexp.QuoteMeta("ld-linux-ARCH.so."), "ARCH", ".*", -1),
+		}, "|")
+		return regexp.MustCompile(libs)
+	}()
+	osVersionRe = regexp.MustCompile(`\d+(\.\d+)*-`)
+)
+
+// Platform is an enumeration of the supported platforms for release.
+type Platform int
+
+const (
+	// PlatformLinux is the Linux x86_64 target.
+	PlatformLinux Platform = iota
+	// PlatformLinuxArm is the Linux aarch64 target.
+	PlatformLinuxArm
+	// PlatformMacOS is the Darwin x86_64 target.
+	PlatformMacOS
+	// PlatformWindows is the Windows (mingw) x86_64 target.
+	PlatformWindows
+)
+
+func getPathToBazelBin(execFn ExecFn, pkgDir string, configArgs []string) (string, error) {
+	args := []string{"info", "bazel-bin"}
+	args = append(args, configArgs...)
+	cmd := exec.Command("bazel", args...)
+	cmd.Dir = pkgDir
+	cmd.Stderr = os.Stderr
+	stdoutBytes, err := execFn.Run(cmd)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to run %s: %s", cmd.Args, string(stdoutBytes))
+	}
+	return strings.TrimSpace(string(stdoutBytes)), nil
+}
+
+func stageBinary(
+	target string, platform Platform, bazelBin string, dir string, includePlatformSuffix bool,
+) error {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	rel := util.OutputOfBinaryRule(target, platform == PlatformWindows)
+	src := filepath.Join(bazelBin, rel)
+	dstBase, _ := TrimDotExe(filepath.Base(rel))
+	suffix := ""
+	if includePlatformSuffix {
+		suffix = SuffixFromPlatform(platform)
+	}
+	dstBase = dstBase + suffix
+	dst := filepath.Join(dir, dstBase)
+	srcF, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer closeFileOrPanic(srcF)
+	dstF, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE, 0755)
+	if err != nil {
+		return err
+	}
+	defer closeFileOrPanic(dstF)
+	_, err = io.Copy(dstF, srcF)
+	return err
+}
+
+func stageLibraries(platform Platform, bazelBin string, dir string) error {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	ext := SharedLibraryExtensionFromPlatform(platform)
+	for _, lib := range CRDBSharedLibraries {
+		libDir := "lib"
+		if platform == PlatformWindows {
+			// NB: On Windows these libs end up in the `bin` subdir.
+			libDir = "bin"
+		}
+		src := filepath.Join(bazelBin, "c-deps", "libgeos_foreign", libDir, lib+ext)
+		srcF, err := os.Open(src)
+		if err != nil {
+			return err
+		}
+		defer closeFileOrPanic(srcF)
+		dst := filepath.Join(dir, filepath.Base(src))
+		dstF, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			return err
+		}
+		defer closeFileOrPanic(dstF)
+		_, err = io.Copy(dstF, srcF)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func closeFileOrPanic(f io.Closer) {
+	err := f.Close()
+	if err != nil {
+		panic(errors.Wrapf(err, "could not close file"))
+	}
+}

--- a/pkg/release/gcs.go
+++ b/pkg/release/gcs.go
@@ -1,0 +1,108 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package release
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"cloud.google.com/go/storage"
+)
+
+// GCSProvider is an implementation of the ObjectPutGetter interface for GCS
+type GCSProvider struct {
+	client *storage.Client
+	bucket string
+}
+
+// NewGCS creates a new instance of GCSProvider
+func NewGCS(bucket string) (*GCSProvider, error) {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return &GCSProvider{}, err
+	}
+	provider := &GCSProvider{
+		client: client,
+		bucket: bucket,
+	}
+	return provider, nil
+}
+
+// GetObject implements object retrieval for S3
+func (p *GCSProvider) GetObject(input *GetObjectInput) (*GetObjectOutput, error) {
+	obj := p.client.Bucket(p.bucket).Object(*input.Key)
+	ctx := context.Background()
+	reader, err := obj.NewReader(ctx)
+	if err != nil {
+		return &GetObjectOutput{}, err
+	}
+	return &GetObjectOutput{
+		Body: reader,
+	}, nil
+}
+
+// Bucket returns bucket name
+func (p *GCSProvider) Bucket() string {
+	return p.bucket
+}
+
+// PutObject implements object upload for S3
+func (p *GCSProvider) PutObject(input *PutObjectInput) error {
+	obj := p.client.Bucket(p.bucket).Object(*input.Key)
+	ctx := context.Background()
+	var body []byte
+	if input.WebsiteRedirectLocation != nil {
+		// Seems like Google storage doesn't support this. Copy the original object.
+		// copy content
+		r, err := p.client.Bucket(p.bucket).Object(*input.WebsiteRedirectLocation).NewReader(ctx)
+		if err != nil {
+			return fmt.Errorf("cannot read %s: %w", *input.WebsiteRedirectLocation, err)
+		}
+		body, err = ioutil.ReadAll(r)
+		if err != nil {
+			return fmt.Errorf("cannot download %s: %w", *input.WebsiteRedirectLocation, err)
+		}
+	} else {
+		var err error
+		body, err = ioutil.ReadAll(input.Body)
+		if err != nil {
+			return fmt.Errorf("cannot download %s: %w", *input.WebsiteRedirectLocation, err)
+		}
+	}
+	w := obj.NewWriter(ctx)
+	if _, err := w.Write(body); err != nil {
+		return fmt.Errorf("error in GCS upload %s: %w", *input.Key, err)
+	}
+	attrs := storage.ObjectAttrsToUpdate{}
+	updateAttrs := false
+	if input.ContentDisposition != nil {
+		updateAttrs = true
+		attrs.ContentDisposition = *input.ContentDisposition
+	}
+	if input.CacheControl != nil {
+		updateAttrs = true
+		attrs.CacheControl = *input.CacheControl
+	}
+	if updateAttrs {
+		if _, err := obj.Update(ctx, attrs); err != nil {
+			return fmt.Errorf("error updating attributes for %s: %w", *input.Key, err)
+		}
+	}
+	return nil
+}
+
+// URL returns key's representation that can be used by gcsutil
+func (p GCSProvider) URL(key string) string {
+	return "gcs://" + p.bucket + "/" + strings.TrimPrefix(key, "/")
+}

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -62,14 +62,14 @@ func TrimDotExe(name string) (string, bool) {
 
 // NonReleaseFile is a file to upload when publishing a non-release.
 type NonReleaseFile struct {
-	// S3FileName is the name of the file stored in S3.
-	S3FileName string
-	// S3FilePath is the path the file should be stored within the  Cockroach bucket.
-	S3FilePath string
-	// S3RedirectPathPrefix is the prefix of the path that redirects  to the S3FilePath.
+	// FileName is the name of the file stored in the cloud.
+	FileName string
+	// FilePath is the path the file should be stored within the  Cockroach bucket.
+	FilePath string
+	// RedirectPathPrefix is the prefix of the path that redirects  to the FilePath.
 	// It is suffixed with .VersionStr or .LATEST, depending on whether  the branch is
 	// the master branch.
-	S3RedirectPathPrefix string
+	RedirectPathPrefix string
 
 	// LocalAbsolutePath is the location of the file to upload in the local OS.
 	LocalAbsolutePath string
@@ -91,10 +91,10 @@ func MakeCRDBBinaryNonReleaseFile(localAbsolutePath string, versionStr string) N
 	}
 
 	return NonReleaseFile{
-		S3FileName:           fileName,
-		S3FilePath:           fileName,
-		S3RedirectPathPrefix: remoteName,
-		LocalAbsolutePath:    localAbsolutePath,
+		FileName:           fileName,
+		FilePath:           fileName,
+		RedirectPathPrefix: remoteName,
+		LocalAbsolutePath:  localAbsolutePath,
 	}
 }
 
@@ -116,10 +116,10 @@ func MakeCRDBLibraryNonReleaseFiles(
 		files = append(
 			files,
 			NonReleaseFile{
-				S3FileName:           fmt.Sprintf("%s%s", remoteFileName, ext),
-				S3FilePath:           fmt.Sprintf("lib/%s%s", remoteFileName, ext),
-				S3RedirectPathPrefix: fmt.Sprintf("lib/%s%s", remoteFileNameBase, ext),
-				LocalAbsolutePath:    filepath.Join(localAbsoluteBasePath, "lib", localFileName+ext),
+				FileName:           fmt.Sprintf("%s%s", remoteFileName, ext),
+				FilePath:           fmt.Sprintf("lib/%s%s", remoteFileName, ext),
+				RedirectPathPrefix: fmt.Sprintf("lib/%s%s", remoteFileNameBase, ext),
+				LocalAbsolutePath:  filepath.Join(localAbsoluteBasePath, "lib", localFileName+ext),
 			},
 		)
 	}

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -13,62 +13,20 @@
 package release
 
 import (
-	"archive/tar"
-	"archive/zip"
-	"bufio"
 	"bytes"
-	"compress/gzip"
-	"crypto/sha256"
 	"fmt"
 	"io"
-	"log"
-	"mime"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/service/s3"
-	bazelutil "github.com/cockroachdb/cockroach/pkg/build/util"
 	"github.com/cockroachdb/errors"
-)
-
-var (
-	// linuxStaticLibsRe returns the regexp of all static libraries.
-	linuxStaticLibsRe = func() *regexp.Regexp {
-		libs := strings.Join([]string{
-			regexp.QuoteMeta("linux-vdso.so."),
-			regexp.QuoteMeta("librt.so."),
-			regexp.QuoteMeta("libpthread.so."),
-			regexp.QuoteMeta("libdl.so."),
-			regexp.QuoteMeta("libm.so."),
-			regexp.QuoteMeta("libc.so."),
-			regexp.QuoteMeta("libresolv.so."),
-			strings.Replace(regexp.QuoteMeta("ld-linux-ARCH.so."), "ARCH", ".*", -1),
-		}, "|")
-		return regexp.MustCompile(libs)
-	}()
-	osVersionRe = regexp.MustCompile(`\d+(\.\d+)*-`)
 )
 
 var (
 	// NoCache is a string constant to send no-cache to AWS.
 	NoCache = "no-cache"
-)
-
-// Platform is an enumeration of the supported platforms for release.
-type Platform int
-
-const (
-	// PlatformLinux is the Linux x86_64 target.
-	PlatformLinux Platform = iota
-	// PlatformLinuxArm is the Linux aarch64 target.
-	PlatformLinuxArm
-	// PlatformMacOS is the Darwin x86_64 target.
-	PlatformMacOS
-	// PlatformWindows is the Windows (mingw) x86_64 target.
-	PlatformWindows
 )
 
 // ChecksumSuffix is a suffix of release tarball checksums
@@ -95,218 +53,11 @@ func (e ExecFn) Run(cmd *exec.Cmd) ([]byte, error) {
 	return e.MockExecFn(cmd)
 }
 
-// BuildOptions is a set of options that may be applied to a build.
-type BuildOptions struct {
-	// True iff this is a release build.
-	Release bool
-	// BuildTag must be set if Release is set, and vice-versea.
-	BuildTag string
-
-	// ExecFn.Run() is called to execute commands for this build.
-	// The zero value is appropriate in "real" scenarios but for
-	// tests you can update ExecFn.MockExecFn.
-	ExecFn ExecFn
-}
-
-// SuffixFromPlatform returns the suffix that will be appended to the
-// `cockroach` binary when built with the given platform. The binary
-// itself can be found in pkgDir/cockroach$SUFFIX after the build.
-func SuffixFromPlatform(platform Platform) string {
-	switch platform {
-	case PlatformLinux:
-		return ".linux-2.6.32-gnu-amd64"
-	case PlatformLinuxArm:
-		return ".linux-3.7.10-gnu-aarch64"
-	case PlatformMacOS:
-		// TODO(#release): The architecture is at least 10.10 until v20.2 and 10.15 for
-		// v21.1 and after. Check whether this can be changed.
-		return ".darwin-10.9-amd64"
-	case PlatformWindows:
-		return ".windows-6.2-amd64.exe"
-	default:
-		panic(errors.Newf("unknown platform %d", platform))
-	}
-}
-
-// CrossConfigFromPlatform returns the cross*base config corresponding
-// to the given platform. (See .bazelrc for more details.)
-func CrossConfigFromPlatform(platform Platform) string {
-	switch platform {
-	case PlatformLinux:
-		return "crosslinuxbase"
-	case PlatformLinuxArm:
-		return "crosslinuxarmbase"
-	case PlatformMacOS:
-		return "crossmacosbase"
-	case PlatformWindows:
-		return "crosswindowsbase"
-	default:
-		panic(errors.Newf("unknown platform %d", platform))
-	}
-}
-
-// TargetTripleFromPlatform returns the target triple that will be baked
-// into the cockroach binary for the given platform.
-func TargetTripleFromPlatform(platform Platform) string {
-	switch platform {
-	case PlatformLinux:
-		return "x86_64-pc-linux-gnu"
-	case PlatformLinuxArm:
-		return "aarch64-unknown-linux-gnu"
-	case PlatformMacOS:
-		return "x86_64-apple-darwin19"
-	case PlatformWindows:
-		return "x86_64-w64-mingw32"
-	default:
-		panic(errors.Newf("unknown platform %d", platform))
-	}
-}
-
-// SharedLibraryExtensionFromPlatform returns the shared library extensions for a given Platform.
-func SharedLibraryExtensionFromPlatform(platform Platform) string {
-	switch platform {
-	case PlatformLinux, PlatformLinuxArm:
-		return ".so"
-	case PlatformWindows:
-		return ".dll"
-	case PlatformMacOS:
-		return ".dylib"
-	default:
-		panic(errors.Newf("unknown platform %d", platform))
-	}
-}
-
-// MakeWorkload makes the bin/workload binary. It is only ever built in the
-// crosslinux configuration.
-func MakeWorkload(opts BuildOptions, pkgDir string) error {
-	if opts.Release {
-		return errors.Newf("cannot build workload in Release mode")
-	}
-	// NB: workload doesn't need anything stamped so we can use `crosslinux`
-	// rather than `crosslinuxbase`.
-	cmd := exec.Command("bazel", "build", "//pkg/cmd/workload", "-c", "opt", "--config=crosslinux", "--config=ci")
-	cmd.Dir = pkgDir
-	cmd.Stderr = os.Stderr
-	log.Printf("%s", cmd.Args)
-	stdoutBytes, err := opts.ExecFn.Run(cmd)
-	if err != nil {
-		return errors.Wrapf(err, "failed to run %s: %s", cmd.Args, string(stdoutBytes))
-	}
-
-	bazelBin, err := getPathToBazelBin(opts.ExecFn, pkgDir, []string{"-c", "opt", "--config=crosslinux", "--config=ci"})
-	if err != nil {
-		return err
-	}
-	return stageBinary("//pkg/cmd/workload", PlatformLinux, bazelBin, filepath.Join(pkgDir, "bin"), false)
-}
-
-// MakeRelease makes the release binary and associated files.
-func MakeRelease(platform Platform, opts BuildOptions, pkgDir string) error {
-	buildArgs := []string{"build", "//pkg/cmd/cockroach", "//c-deps:libgeos", "//pkg/cmd/cockroach-sql"}
-	targetTriple := TargetTripleFromPlatform(platform)
-	if opts.Release {
-		if opts.BuildTag == "" {
-			return errors.Newf("must set BuildTag if Release is set")
-		}
-		buildArgs = append(buildArgs, fmt.Sprintf("--workspace_status_command=./build/bazelutil/stamp.sh %s official-binary %s release", targetTriple, opts.BuildTag))
-	} else {
-		if opts.BuildTag != "" {
-			return errors.Newf("cannot set BuildTag if Release is not set")
-		}
-		buildArgs = append(buildArgs, fmt.Sprintf("--workspace_status_command=./build/bazelutil/stamp.sh %s official-binary", targetTriple))
-	}
-	configs := []string{"-c", "opt", "--config=ci", "--config=force_build_cdeps", "--config=with_ui", fmt.Sprintf("--config=%s", CrossConfigFromPlatform(platform))}
-	buildArgs = append(buildArgs, configs...)
-	cmd := exec.Command("bazel", buildArgs...)
-	cmd.Dir = pkgDir
-	cmd.Stderr = os.Stderr
-	log.Printf("%s", cmd.Args)
-	stdoutBytes, err := opts.ExecFn.Run(cmd)
-	if err != nil {
-		return errors.Wrapf(err, "failed to run %s: %s", cmd.Args, string(stdoutBytes))
-	}
-
-	// Stage binaries from bazel-bin.
-	bazelBin, err := getPathToBazelBin(opts.ExecFn, pkgDir, configs)
-	if err != nil {
-		return err
-	}
-	if err := stageBinary("//pkg/cmd/cockroach", platform, bazelBin, pkgDir, true); err != nil {
-		return err
-	}
-	// TODO: strip the bianry
-	if err := stageBinary("//pkg/cmd/cockroach-sql", platform, bazelBin, pkgDir, true); err != nil {
-		return err
-	}
-	if err := stageLibraries(platform, bazelBin, filepath.Join(pkgDir, "lib")); err != nil {
-		return err
-	}
-
-	if platform == PlatformLinux {
-		suffix := SuffixFromPlatform(platform)
-		binaryName := "./cockroach" + suffix
-
-		cmd := exec.Command(binaryName, "version")
-		cmd.Dir = pkgDir
-		cmd.Env = append(cmd.Env, "MALLOC_CONF=prof:true")
-		cmd.Stderr = os.Stderr
-		log.Printf("%s %s", cmd.Env, cmd.Args)
-		stdoutBytes, err := opts.ExecFn.Run(cmd)
-		if err != nil {
-			return errors.Wrapf(err, "%s %s: %s", cmd.Env, cmd.Args, string(stdoutBytes))
-		}
-
-		cmd = exec.Command("ldd", binaryName)
-		cmd.Dir = pkgDir
-		cmd.Stderr = os.Stderr
-		log.Printf("%s %s", cmd.Env, cmd.Args)
-		stdoutBytes, err = opts.ExecFn.Run(cmd)
-		if err != nil {
-			log.Fatalf("%s %s: out=%s err=%v", cmd.Env, cmd.Args, string(stdoutBytes), err)
-		}
-		scanner := bufio.NewScanner(bytes.NewReader(stdoutBytes))
-		for scanner.Scan() {
-			if line := scanner.Text(); !linuxStaticLibsRe.MatchString(line) {
-				return errors.Newf("%s is not properly statically linked:\n%s", binaryName, line)
-			}
-		}
-		if err := scanner.Err(); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // TrimDotExe trims '.exe. from `name` and returns the result (and whether any
 // trimming has occurred).
 func TrimDotExe(name string) (string, bool) {
 	const dotExe = ".exe"
 	return strings.TrimSuffix(name, dotExe), strings.HasSuffix(name, dotExe)
-}
-
-// S3Putter is an interface allowing uploads to S3.
-type S3Putter interface {
-	PutObject(*s3.PutObjectInput) (*s3.PutObjectOutput, error)
-}
-
-// S3KeyRelease extracts the target archive base and archive
-// name for the given parameters.
-func S3KeyRelease(platform Platform, versionStr string, binaryPrefix string) (string, string) {
-	suffix := SuffixFromPlatform(platform)
-	targetSuffix, hasExe := TrimDotExe(suffix)
-	// TODO(tamird): remove this weirdness. Requires updating
-	// "users" e.g. docs, cockroachdb/cockroach-go, maybe others.
-	if platform == PlatformLinux {
-		targetSuffix = strings.Replace(targetSuffix, "gnu-", "", -1)
-		targetSuffix = osVersionRe.ReplaceAllLiteralString(targetSuffix, "")
-	}
-
-	archiveBase := fmt.Sprintf("%s-%s", binaryPrefix, versionStr)
-	targetArchiveBase := archiveBase + targetSuffix
-	if hasExe {
-		return targetArchiveBase, targetArchiveBase + ".zip"
-	}
-	return targetArchiveBase, targetArchiveBase + ".tgz"
 }
 
 // NonReleaseFile is a file to upload when publishing a non-release.
@@ -355,7 +106,7 @@ var CRDBSharedLibraries = []string{"libgeos", "libgeos_c"}
 func MakeCRDBLibraryNonReleaseFiles(
 	localAbsoluteBasePath string, platform Platform, versionStr string,
 ) []NonReleaseFile {
-	files := []NonReleaseFile{}
+	var files []NonReleaseFile
 	suffix := SuffixFromPlatform(platform)
 	ext := SharedLibraryExtensionFromPlatform(platform)
 	for _, localFileName := range CRDBSharedLibraries {
@@ -375,66 +126,7 @@ func MakeCRDBLibraryNonReleaseFiles(
 	return files
 }
 
-// PutNonReleaseOptions are options to pass into PutNonRelease.
-type PutNonReleaseOptions struct {
-	// Branch is the branch from which the release is being uploaded from.
-	Branch string
-	// BucketName is the bucket to upload the files to.
-	BucketName string
-
-	// Files are all the files to be uploaded into S3.
-	Files []NonReleaseFile
-}
-
-// PutNonRelease uploads non-release related files to S3.
-// Files are uploaded to /cockroach/<S3FilePath> for each non release file.
-// A latest key is then put at cockroach/<S3RedirectPrefix>.<BranchName> that redirects
-// to the above file.
-func PutNonRelease(svc S3Putter, o PutNonReleaseOptions) {
-	const repoName = "cockroach"
-	for _, f := range o.Files {
-		disposition := mime.FormatMediaType("attachment", map[string]string{
-			"filename": f.S3FileName,
-		})
-
-		fileToUpload, err := os.Open(f.LocalAbsolutePath)
-		if err != nil {
-			log.Fatalf("failed to open %s: %s", f.LocalAbsolutePath, err)
-		}
-		defer func() {
-			_ = fileToUpload.Close()
-		}()
-
-		// NB: The leading slash is required to make redirects work
-		// correctly since we reuse this key as the redirect location.
-		versionKey := fmt.Sprintf("/%s/%s", repoName, f.S3FilePath)
-		log.Printf("Uploading to s3://%s%s", o.BucketName, versionKey)
-		if _, err := svc.PutObject(&s3.PutObjectInput{
-			Bucket:             &o.BucketName,
-			ContentDisposition: &disposition,
-			Key:                &versionKey,
-			Body:               fileToUpload,
-		}); err != nil {
-			log.Fatalf("s3 upload %s: %s", versionKey, err)
-		}
-
-		latestSuffix := o.Branch
-		if latestSuffix == "master" {
-			latestSuffix = "LATEST"
-		}
-		latestKey := fmt.Sprintf("%s/%s.%s", repoName, f.S3RedirectPathPrefix, latestSuffix)
-		if _, err := svc.PutObject(&s3.PutObjectInput{
-			Bucket:                  &o.BucketName,
-			CacheControl:            &NoCache,
-			Key:                     &latestKey,
-			WebsiteRedirectLocation: &versionKey,
-		}); err != nil {
-			log.Fatalf("s3 redirect to %s: %s", versionKey, err)
-		}
-	}
-}
-
-// ArchiveFile is a file to store in the a archive for a release.
+// ArchiveFile is a file to store in the archive for a release.
 type ArchiveFile struct {
 	// LocalAbsolutePath is the location of the file to upload include in the archive on the local OS.
 	LocalAbsolutePath string
@@ -457,7 +149,7 @@ func MakeCRDBBinaryArchiveFile(localAbsolutePath string, path string) ArchiveFil
 
 // MakeCRDBLibraryArchiveFiles generates the ArchiveFile object for relevant CRDB helper libraries.
 func MakeCRDBLibraryArchiveFiles(pkgDir string, platform Platform) []ArchiveFile {
-	files := []ArchiveFile{}
+	var files []ArchiveFile
 	ext := SharedLibraryExtensionFromPlatform(platform)
 	for _, lib := range CRDBSharedLibraries {
 		localFileName := lib + ext
@@ -470,230 +162,4 @@ func MakeCRDBLibraryArchiveFiles(pkgDir string, platform Platform) []ArchiveFile
 		)
 	}
 	return files
-}
-
-// PutReleaseOptions are options to for the PutRelease function.
-type PutReleaseOptions struct {
-	// BucketName is the bucket to upload the files to.
-	BucketName string
-	// NoCache is true if we should set the NoCache option to S3.
-	NoCache bool
-	// Platform is the platform of the release.
-	Platform Platform
-	// VersionStr is the version (SHA/branch name) of the release.
-	VersionStr string
-
-	// Files are all the files to be included in the archive.
-	Files      []ArchiveFile
-	ExtraFiles []ArchiveFile
-}
-
-// PutRelease uploads a compressed archive containing the release
-// files and a checksum file of the archive to S3.
-func PutRelease(svc S3Putter, o PutReleaseOptions) {
-	targetArchiveBase, targetArchive := S3KeyRelease(o.Platform, o.VersionStr, "cockroach")
-	var body bytes.Buffer
-
-	if strings.HasSuffix(targetArchive, ".zip") {
-		zw := zip.NewWriter(&body)
-
-		for _, f := range o.Files {
-			file, err := os.Open(f.LocalAbsolutePath)
-			if err != nil {
-				log.Fatalf("failed to open file: %s", f.LocalAbsolutePath)
-			}
-			defer func() { _ = file.Close() }()
-
-			stat, err := file.Stat()
-			if err != nil {
-				log.Fatalf("failed to stat: %s", f.LocalAbsolutePath)
-			}
-
-			zipHeader, err := zip.FileInfoHeader(stat)
-			if err != nil {
-				log.Fatal(err)
-			}
-			zipHeader.Name = filepath.Join(targetArchiveBase, f.ArchiveFilePath)
-			zipHeader.Method = zip.Deflate
-
-			zfw, err := zw.CreateHeader(zipHeader)
-			if err != nil {
-				log.Fatal(err)
-			}
-			if _, err := io.Copy(zfw, file); err != nil {
-				log.Fatal(err)
-			}
-		}
-		if err := zw.Close(); err != nil {
-			log.Fatal(err)
-		}
-	} else {
-		gzw := gzip.NewWriter(&body)
-		tw := tar.NewWriter(gzw)
-		for _, f := range o.Files {
-
-			file, err := os.Open(f.LocalAbsolutePath)
-			if err != nil {
-				log.Fatalf("failed to open file: %s", f.LocalAbsolutePath)
-			}
-			defer func() { _ = file.Close() }()
-
-			stat, err := file.Stat()
-			if err != nil {
-				log.Fatalf("failed to stat: %s", f.LocalAbsolutePath)
-			}
-
-			// Set the tar header from the file info. Overwrite name.
-			tarHeader, err := tar.FileInfoHeader(stat, "")
-			if err != nil {
-				log.Fatal(err)
-			}
-			tarHeader.Name = filepath.Join(targetArchiveBase, f.ArchiveFilePath)
-			if err := tw.WriteHeader(tarHeader); err != nil {
-				log.Fatal(err)
-			}
-
-			if _, err := io.Copy(tw, file); err != nil {
-				log.Fatal(err)
-			}
-		}
-		if err := tw.Close(); err != nil {
-			log.Fatal(err)
-		}
-		if err := gzw.Close(); err != nil {
-			log.Fatal(err)
-		}
-	}
-
-	log.Printf("Uploading to s3://%s/%s", o.BucketName, targetArchive)
-	putObjectInput := s3.PutObjectInput{
-		Bucket: &o.BucketName,
-		Key:    &targetArchive,
-		Body:   bytes.NewReader(body.Bytes()),
-	}
-	if o.NoCache {
-		putObjectInput.CacheControl = &NoCache
-	}
-	if _, err := svc.PutObject(&putObjectInput); err != nil {
-		log.Fatalf("s3 upload %s: %s", targetArchive, err)
-	}
-	// Generate a SHA256 checksum file with a single entry.
-	checksumContents := fmt.Sprintf("%x %s\n", sha256.Sum256(body.Bytes()),
-		filepath.Base(targetArchive))
-	targetChecksum := targetArchive + ChecksumSuffix
-	log.Printf("Uploading to s3://%s/%s", o.BucketName, targetChecksum)
-	putObjectInputChecksum := s3.PutObjectInput{
-		Bucket: &o.BucketName,
-		Key:    &targetChecksum,
-		Body:   strings.NewReader(checksumContents),
-	}
-	if o.NoCache {
-		putObjectInputChecksum.CacheControl = &NoCache
-	}
-	if _, err := svc.PutObject(&putObjectInputChecksum); err != nil {
-		log.Fatalf("s3 upload %s: %s", targetChecksum, err)
-	}
-	for _, f := range o.ExtraFiles {
-		keyBase, hasExe := TrimDotExe(f.ArchiveFilePath)
-		targetKey, _ := S3KeyRelease(o.Platform, o.VersionStr, keyBase)
-		if hasExe {
-			targetKey += ".exe"
-		}
-		log.Printf("Uploading to s3://%s/%s", o.BucketName, targetKey)
-		handle, err := os.Open(f.LocalAbsolutePath)
-		if err != nil {
-			log.Fatalf("failed to open %s: %s", f.LocalAbsolutePath, err)
-		}
-		putObjectInput := s3.PutObjectInput{
-			Bucket: &o.BucketName,
-			Key:    &targetKey,
-			Body:   handle,
-		}
-		if o.NoCache {
-			putObjectInput.CacheControl = &NoCache
-		}
-		if _, err := svc.PutObject(&putObjectInput); err != nil {
-			log.Fatalf("s3 upload %s: %s", targetKey, err)
-		}
-	}
-}
-
-func getPathToBazelBin(execFn ExecFn, pkgDir string, configArgs []string) (string, error) {
-	args := []string{"info", "bazel-bin"}
-	args = append(args, configArgs...)
-	cmd := exec.Command("bazel", args...)
-	cmd.Dir = pkgDir
-	cmd.Stderr = os.Stderr
-	stdoutBytes, err := execFn.Run(cmd)
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to run %s: %s", cmd.Args, string(stdoutBytes))
-	}
-	return strings.TrimSpace(string(stdoutBytes)), nil
-}
-
-func stageBinary(
-	target string, platform Platform, bazelBin string, dir string, includePlatformSuffix bool,
-) error {
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return err
-	}
-	rel := bazelutil.OutputOfBinaryRule(target, platform == PlatformWindows)
-	src := filepath.Join(bazelBin, rel)
-	dstBase, _ := TrimDotExe(filepath.Base(rel))
-	suffix := ""
-	if includePlatformSuffix {
-		suffix = SuffixFromPlatform(platform)
-	}
-	dstBase = dstBase + suffix
-	dst := filepath.Join(dir, dstBase)
-	srcF, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer closeFileOrPanic(srcF)
-	dstF, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE, 0755)
-	if err != nil {
-		return err
-	}
-	defer closeFileOrPanic(dstF)
-	_, err = io.Copy(dstF, srcF)
-	return err
-}
-
-func stageLibraries(platform Platform, bazelBin string, dir string) error {
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return err
-	}
-	ext := SharedLibraryExtensionFromPlatform(platform)
-	for _, lib := range CRDBSharedLibraries {
-		libDir := "lib"
-		if platform == PlatformWindows {
-			// NB: On Windows these libs end up in the `bin` subdir.
-			libDir = "bin"
-		}
-		src := filepath.Join(bazelBin, "c-deps", "libgeos_foreign", libDir, lib+ext)
-		srcF, err := os.Open(src)
-		if err != nil {
-			return err
-		}
-		defer closeFileOrPanic(srcF)
-		dst := filepath.Join(dir, filepath.Base(src))
-		dstF, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			return err
-		}
-		defer closeFileOrPanic(dstF)
-		_, err = io.Copy(dstF, srcF)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func closeFileOrPanic(f io.Closer) {
-	err := f.Close()
-	if err != nil {
-		panic(errors.Wrapf(err, "could not close file"))
-	}
 }

--- a/pkg/release/s3.go
+++ b/pkg/release/s3.go
@@ -1,0 +1,67 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package release
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+// S3Provider is an implementation of the ObjectPutGetter interface for S3
+type S3Provider struct {
+	service *s3.S3
+}
+
+// NewS3 creates a new instance of S3Provider
+func NewS3(region string) (*S3Provider, error) {
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(region),
+	})
+	if err != nil {
+		return &S3Provider{}, err
+	}
+	return &S3Provider{
+		service: s3.New(sess),
+	}, nil
+}
+
+// GetObject implements object retrieval for S3
+func (p *S3Provider) GetObject(input *GetObjectInput) (*GetObjectOutput, error) {
+	obj, err := p.service.GetObject(&s3.GetObjectInput{
+		Bucket: input.Bucket,
+		Key:    input.Key,
+	})
+	if err != nil {
+		return &GetObjectOutput{}, err
+	}
+	return &GetObjectOutput{
+		Body: obj.Body,
+	}, nil
+}
+
+// PutObject implements object upload for S3
+func (p *S3Provider) PutObject(input *PutObjectInput) error {
+	putObjectInput := s3.PutObjectInput{
+		Bucket:                  input.Bucket,
+		Key:                     input.Key,
+		Body:                    input.Body,
+		CacheControl:            input.CacheControl,
+		ContentDisposition:      input.ContentDisposition,
+		WebsiteRedirectLocation: input.WebsiteRedirectLocation,
+	}
+	if _, err := p.service.PutObject(&putObjectInput); err != nil {
+		return fmt.Errorf("s3 upload %s: %w", *input.Key, err)
+	}
+	return nil
+}

--- a/pkg/release/upload.go
+++ b/pkg/release/upload.go
@@ -1,0 +1,326 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package release
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"log"
+	"mime"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// PutReleaseOptions are options to for the PutRelease function.
+type PutReleaseOptions struct {
+	// BucketName is the bucket to upload the files to.
+	BucketName string
+	// NoCache is true if we should set the NoCache option to S3.
+	NoCache bool
+	// Platform is the platform of the release.
+	Platform Platform
+	// VersionStr is the version (SHA/branch name) of the release.
+	VersionStr string
+
+	// Files are all the files to be included in the archive.
+	Files      []ArchiveFile
+	ExtraFiles []ArchiveFile
+}
+
+// PutNonReleaseOptions are options to pass into PutNonRelease.
+type PutNonReleaseOptions struct {
+	// Branch is the branch from which the release is being uploaded from.
+	Branch string
+	// BucketName is the bucket to upload the files to.
+	BucketName string
+
+	// Files are all the files to be uploaded into S3.
+	Files []NonReleaseFile
+}
+
+// PutRelease uploads a compressed archive containing the release
+// files and a checksum file of the archive to S3.
+func PutRelease(svc ObjectPutGetter, o PutReleaseOptions) {
+	keys := makeArchiveKeys(o.Platform, o.VersionStr, "cockroach")
+	var body bytes.Buffer
+
+	if strings.HasSuffix(keys.archive, ".zip") {
+		if err := createZip(o.Files, &body, keys.base); err != nil {
+			log.Fatalf("cannot create zip %s: %s", keys.archive, err)
+		}
+	} else {
+		if err := createTarball(o.Files, &body, keys.base); err != nil {
+			log.Fatalf("cannot create tarball %s: %s", keys.archive, err)
+		}
+	}
+
+	log.Printf("Uploading to s3://%s/%s", o.BucketName, keys.archive)
+	putObjectInput := PutObjectInput{
+		Bucket: &o.BucketName,
+		Key:    &keys.archive,
+		Body:   bytes.NewReader(body.Bytes()),
+	}
+	if o.NoCache {
+		putObjectInput.CacheControl = &NoCache
+	}
+	if err := svc.PutObject(&putObjectInput); err != nil {
+		log.Fatalf("s3 upload %s: %s", keys.archive, err)
+	}
+	// Generate a SHA256 checksum file with a single entry.
+	checksumContents := fmt.Sprintf("%x %s\n", sha256.Sum256(body.Bytes()),
+		filepath.Base(keys.archive))
+	targetChecksum := keys.archive + ChecksumSuffix
+	log.Printf("Uploading to s3://%s/%s", o.BucketName, targetChecksum)
+	putObjectInputChecksum := PutObjectInput{
+		Bucket: &o.BucketName,
+		Key:    &targetChecksum,
+		Body:   strings.NewReader(checksumContents),
+	}
+	if o.NoCache {
+		putObjectInputChecksum.CacheControl = &NoCache
+	}
+	if err := svc.PutObject(&putObjectInputChecksum); err != nil {
+		log.Fatalf("s3 upload %s: %s", targetChecksum, err)
+	}
+	for _, f := range o.ExtraFiles {
+		keyBase, hasExe := TrimDotExe(f.ArchiveFilePath)
+		targetKeys := makeArchiveKeys(o.Platform, o.VersionStr, keyBase)
+		targetKey := targetKeys.base
+		if hasExe {
+			targetKey += ".exe"
+		}
+		log.Printf("Uploading to s3://%s/%s", o.BucketName, targetKey)
+		handle, err := os.Open(f.LocalAbsolutePath)
+		if err != nil {
+			log.Fatalf("failed to open %s: %s", f.LocalAbsolutePath, err)
+		}
+		putObjectInput := PutObjectInput{
+			Bucket: &o.BucketName,
+			Key:    &targetKey,
+			Body:   handle,
+		}
+		if o.NoCache {
+			putObjectInput.CacheControl = &NoCache
+		}
+		if err := svc.PutObject(&putObjectInput); err != nil {
+			log.Fatalf("s3 upload %s: %s", targetKey, err)
+		}
+	}
+}
+
+func createZip(files []ArchiveFile, body *bytes.Buffer, prefix string) error {
+	zw := zip.NewWriter(body)
+	for _, f := range files {
+		file, err := os.Open(f.LocalAbsolutePath)
+		if err != nil {
+			return fmt.Errorf("failed to open file: %s", f.LocalAbsolutePath)
+		}
+		defer func() { _ = file.Close() }()
+
+		stat, err := file.Stat()
+		if err != nil {
+			return fmt.Errorf("failed to stat: %s", f.LocalAbsolutePath)
+		}
+
+		zipHeader, err := zip.FileInfoHeader(stat)
+		if err != nil {
+			return err
+		}
+		zipHeader.Name = filepath.Join(prefix, f.ArchiveFilePath)
+		zipHeader.Method = zip.Deflate
+
+		zfw, err := zw.CreateHeader(zipHeader)
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(zfw, file); err != nil {
+			return err
+		}
+	}
+	if err := zw.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func createTarball(files []ArchiveFile, body *bytes.Buffer, prefix string) error {
+	gzw := gzip.NewWriter(body)
+	tw := tar.NewWriter(gzw)
+	for _, f := range files {
+		file, err := os.Open(f.LocalAbsolutePath)
+		if err != nil {
+			return fmt.Errorf("failed to open file: %s", f.LocalAbsolutePath)
+		}
+		defer func() { _ = file.Close() }()
+
+		stat, err := file.Stat()
+		if err != nil {
+			return fmt.Errorf("failed to stat: %s", f.LocalAbsolutePath)
+		}
+
+		// Set the tar header from the file info. Overwrite name.
+		tarHeader, err := tar.FileInfoHeader(stat, "")
+		if err != nil {
+			return err
+		}
+		tarHeader.Name = filepath.Join(prefix, f.ArchiveFilePath)
+		if err := tw.WriteHeader(tarHeader); err != nil {
+			return err
+		}
+
+		if _, err := io.Copy(tw, file); err != nil {
+			return err
+		}
+	}
+	if err := tw.Close(); err != nil {
+		return err
+	}
+	if err := gzw.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// PutNonRelease uploads non-release related files to S3.
+// Files are uploaded to /cockroach/<S3FilePath> for each non release file.
+// A `latest` key is then put at cockroach/<S3RedirectPrefix>.<BranchName> that redirects
+// to the above file.
+func PutNonRelease(svc ObjectPutGetter, o PutNonReleaseOptions) {
+	const repoName = "cockroach"
+	for _, f := range o.Files {
+		disposition := mime.FormatMediaType("attachment", map[string]string{
+			"filename": f.S3FileName,
+		})
+
+		fileToUpload, err := os.Open(f.LocalAbsolutePath)
+		if err != nil {
+			log.Fatalf("failed to open %s: %s", f.LocalAbsolutePath, err)
+		}
+		defer func() {
+			_ = fileToUpload.Close()
+		}()
+
+		// NB: The leading slash is required to make redirects work
+		// correctly since we reuse this key as the redirect location.
+		versionKey := fmt.Sprintf("/%s/%s", repoName, f.S3FilePath)
+		log.Printf("Uploading to s3://%s%s", o.BucketName, versionKey)
+		if err := svc.PutObject(&PutObjectInput{
+			Bucket:             &o.BucketName,
+			ContentDisposition: &disposition,
+			Key:                &versionKey,
+			Body:               fileToUpload,
+		}); err != nil {
+			log.Fatalf("s3 upload %s: %s", versionKey, err)
+		}
+
+		latestSuffix := o.Branch
+		if latestSuffix == "master" {
+			latestSuffix = "LATEST"
+		}
+		latestKey := fmt.Sprintf("%s/%s.%s", repoName, f.S3RedirectPathPrefix, latestSuffix)
+		if err := svc.PutObject(&PutObjectInput{
+			Bucket:                  &o.BucketName,
+			CacheControl:            &NoCache,
+			Key:                     &latestKey,
+			WebsiteRedirectLocation: &versionKey,
+		}); err != nil {
+			log.Fatalf("s3 redirect to %s: %s", versionKey, err)
+		}
+	}
+}
+
+type archiveKeys struct {
+	base    string
+	archive string
+}
+
+// makeArchiveKeys extracts the target archive base and archive
+// name for the given parameters.
+func makeArchiveKeys(platform Platform, versionStr string, binaryPrefix string) archiveKeys {
+	suffix := SuffixFromPlatform(platform)
+	targetSuffix, hasExe := TrimDotExe(suffix)
+	if platform == PlatformLinux {
+		targetSuffix = strings.Replace(targetSuffix, "gnu-", "", -1)
+		targetSuffix = osVersionRe.ReplaceAllLiteralString(targetSuffix, "")
+	}
+	archiveBase := fmt.Sprintf("%s-%s", binaryPrefix, versionStr)
+	targetArchiveBase := archiveBase + targetSuffix
+	keys := archiveKeys{
+		base: targetArchiveBase,
+	}
+	if hasExe {
+		keys.archive = targetArchiveBase + ".zip"
+	} else {
+		keys.archive = targetArchiveBase + ".tgz"
+	}
+	return keys
+}
+
+const latestStr = "latest"
+
+// LatestOpts are parameters passed to MarkLatestReleaseWithSuffix
+type LatestOpts struct {
+	Platform   Platform
+	VersionStr string
+	BucketName string
+}
+
+// MarkLatestReleaseWithSuffix adds redirects to release files using "latest" instead of the version
+func MarkLatestReleaseWithSuffix(svc ObjectPutGetter, o LatestOpts, suffix string) {
+	keys := makeArchiveKeys(o.Platform, o.VersionStr, "cockroach")
+	versionedKey := keys.archive + suffix
+	oLatest := o
+	oLatest.VersionStr = latestStr
+	latestKeys := makeArchiveKeys(oLatest.Platform, oLatest.VersionStr, "cockroach")
+	latestKey := latestKeys.archive + suffix
+	log.Printf("Adding redirect to s3://%s/%s", o.BucketName, latestKey)
+	if err := svc.PutObject(&PutObjectInput{
+		Bucket:                  &o.BucketName,
+		CacheControl:            &NoCache,
+		Key:                     &latestKey,
+		WebsiteRedirectLocation: &versionedKey,
+	}); err != nil {
+		log.Fatalf("s3 redirect to %s: %s", versionedKey, err)
+	}
+}
+
+// GetObjectInput specifies input parameters for GetOject
+type GetObjectInput struct {
+	Bucket *string
+	Key    *string
+}
+
+// GetObjectOutput specifies output parameters for GetOject
+type GetObjectOutput struct {
+	Body io.ReadCloser
+}
+
+// PutObjectInput specifies input parameters for PutOject
+type PutObjectInput struct {
+	Bucket                  *string
+	Key                     *string
+	Body                    io.ReadSeeker
+	CacheControl            *string
+	ContentDisposition      *string
+	WebsiteRedirectLocation *string
+}
+
+// ObjectPutGetter specifies a minimal interface for cloud storage providers
+type ObjectPutGetter interface {
+	GetObject(*GetObjectInput) (*GetObjectOutput, error)
+	PutObject(*PutObjectInput) error
+}


### PR DESCRIPTION
Previously, the only supported storage provider was S3.

This PR adds support for GCS.
* Make the bucket name be provider specific.
* The GCS bucket is optional for now.
* Move logic to separate files.
* No direct s3 imports from publish-artifacts and publish-provisional-artifacts.
* Create an extra abstraction interface to hide the s3-specific structs and calls.
* The "latest" URLs in publish-provisional-artifacts use S3's website redirect instead of copying the whole binary. This unifies it with publish-artifacts.

Release note: None