### PR TITLE
gc: take range tombstones into account in mvcc gc

### DIFF
--- a/pkg/kv/kvserver/gc/BUILD.bazel
+++ b/pkg/kv/kvserver/gc/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/settings",
         "//pkg/storage",
         "//pkg/storage/enginepb",
+        "//pkg/util",
         "//pkg/util/bufalloc",
         "//pkg/util/contextutil",
         "//pkg/util/hlc",

--- a/pkg/kv/kvserver/gc/data_distribution_test.go
+++ b/pkg/kv/kvserver/gc/data_distribution_test.go
@@ -32,10 +32,16 @@ import (
 )
 
 // dataDistribution is an abstraction for testing that represents a stream of
-// MVCCKeyValues. The stream may indicate that a value is an intent by returning
+// MVCCKeyValues and MVCCRangeKeyValues. Each call would return either point
+// value or range tombstone, but not both.
+// The stream may indicate that a point value is an intent by returning
 // a non-nil transaction. If an intent is returned it must have a higher
 // timestamp than any other version written for the key.
-type dataDistribution func() (storage.MVCCKeyValue, *roachpb.Transaction, bool)
+// Range key values could only be tombstones and can't have transaction or
+// intent placed on them.
+type dataDistribution func() (
+	storage.MVCCKeyValue, storage.MVCCRangeKeyValue, *roachpb.Transaction, bool,
+)
 
 // setupTest writes the data from this distribution into eng. All data should
 // be a part of the range represented by desc.
@@ -46,11 +52,19 @@ func (ds dataDistribution) setupTest(
 	var maxTs hlc.Timestamp
 	var ms enginepb.MVCCStats
 	for {
-		kv, txn, ok := ds()
+		kv, rangeKV, txn, ok := ds()
 		if !ok {
 			break
 		}
-		if txn == nil {
+		if rangeKey := rangeKV.RangeKey; len(rangeKey.StartKey) > 0 {
+			require.Nil(t, txn, "invalid test data, range can't use transaction")
+			require.Zero(t, len(kv.Key.Key),
+				"invalid test data, range can't be used together with value: key=%s, rangeKey=%s",
+				kv.Key.String(), rangeKey.String())
+			err := storage.MVCCDeleteRangeUsingTombstone(ctx, eng, &ms, rangeKey.StartKey,
+				rangeKey.EndKey, rangeKey.Timestamp, hlc.ClockTimestamp{}, nil, nil, 1)
+			require.NoError(t, err, "failed to put delete range")
+		} else if txn == nil {
 			if kv.Key.Timestamp.IsEmpty() {
 				require.NoError(t, eng.PutUnversioned(kv.Key.Key, kv.Value))
 			} else {
@@ -73,6 +87,9 @@ func (ds dataDistribution) setupTest(
 		if !kv.Key.Timestamp.Less(maxTs) {
 			maxTs = kv.Key.Timestamp
 		}
+		if ts := rangeKV.RangeKey.Timestamp; !ts.Less(maxTs) {
+			maxTs = ts
+		}
 	}
 	require.NoError(t, eng.Flush())
 	snap := eng.NewSnapshot()
@@ -80,6 +97,100 @@ func (ds dataDistribution) setupTest(
 	ms, err := rditer.ComputeStatsForRange(&desc, snap, maxTs.WallTime)
 	require.NoError(t, err)
 	return ms
+}
+
+type dataFeedItem struct {
+	kv  storage.MVCCKeyValue
+	rkv storage.MVCCRangeKeyValue
+	txn *roachpb.Transaction
+}
+
+func (i *dataFeedItem) String() string {
+	if i.txn != nil {
+		return fmt.Sprintf("%s ! %s", i.kv.Key.String(), i.txn.ID.String())
+	}
+	if len(i.kv.Key.Key) > 0 {
+		return i.kv.Key.String()
+	}
+	return i.rkv.RangeKey.String()
+}
+
+// sortedDistribution consume provided distribution fully and produce a
+// distribution with data ordered by timestamp. This distribution is helpful
+// for range key tombstones as they must be placed on top of multiple existing
+// point keys.
+func sortedDistribution(dist dataDistribution) dataDistribution {
+	var allData []dataFeedItem
+	for {
+		kv, rkv, txn, ok := dist()
+		if !ok {
+			break
+		}
+		allData = append(allData, dataFeedItem{kv: kv, rkv: rkv, txn: txn})
+	}
+	isPoint := func(d dataFeedItem) bool {
+		return len(d.kv.Key.Key) > 0
+	}
+	meta := func(i int) (roachpb.Key, hlc.Timestamp, bool) {
+		if !isPoint(allData[i]) {
+			return allData[i].rkv.RangeKey.StartKey, allData[i].rkv.RangeKey.Timestamp, false
+		}
+		return allData[i].kv.Key.Key, allData[i].kv.Key.Timestamp, true
+	}
+	sort.Slice(allData, func(i, j int) bool {
+		ki, ti, pi := meta(i)
+		kj, tj, _ := meta(j)
+		switch ti.Compare(tj) {
+		case -1:
+			return true
+		case 1:
+			return false
+		}
+		switch ki.Compare(kj) {
+		case -1:
+			return true
+		case 1:
+			return false
+		}
+		return pi
+	})
+
+	var lastTs hlc.Timestamp
+	var lastIsPoint = true
+	for i, v := range allData {
+		switch {
+		case isPoint(v) && !lastIsPoint && v.kv.Key.Timestamp.LessEq(lastTs):
+			lastTs.WallTime++
+			allData[i].kv.Key.Timestamp = lastTs
+			lastIsPoint = true
+		case isPoint(v) && lastIsPoint && v.kv.Key.Timestamp.Less(lastTs):
+			allData[i].kv.Key.Timestamp = lastTs
+		case !isPoint(v) && !lastIsPoint && v.rkv.RangeKey.Timestamp.LessEq(lastTs):
+			lastTs.WallTime++
+			allData[i].rkv.RangeKey.Timestamp = lastTs
+		case !isPoint(v) && lastIsPoint && v.rkv.RangeKey.Timestamp.LessEq(lastTs):
+			lastTs.WallTime++
+			allData[i].rkv.RangeKey.Timestamp = lastTs
+			lastIsPoint = false
+		default:
+			lastIsPoint = isPoint(v)
+			if lastIsPoint {
+				lastTs = v.kv.Key.Timestamp
+			} else {
+				lastTs = v.rkv.RangeKey.Timestamp
+			}
+		}
+	}
+
+	return func() (storage.MVCCKeyValue, storage.MVCCRangeKeyValue, *roachpb.Transaction, bool) {
+		if len(allData) == 0 {
+			return storage.MVCCKeyValue{}, storage.MVCCRangeKeyValue{}, nil, false
+		}
+		defer func() {
+			allData = allData[1:]
+		}()
+		return allData[0].kv, allData[0].rkv, allData[0].txn, true
+	}
 }
 
 // maxRetriesAllowed is limiting how many times we could retry when generating
@@ -101,17 +212,16 @@ func newDataDistribution(
 	versionsPerKey func() int,
 	intentFrac float64,
 	oldIntentFrac float64, // within intents(!)
+	rangeKeyFrac float64,
 	totalKeys int,
 	rng *rand.Rand,
 ) dataDistribution {
-	// TODO(ajwerner): provide a mechanism to control the rate of expired intents
-	// or the intent age. Such a knob would likely require decoupling intents from
-	// other keys.
+	rangeKeyDist := rangeKeyDistribution(keyDist)
 	var (
 		// Remaining values (all versions of all keys together with intents).
 		remaining = totalKeys
 		// Key for the objects currently emitted (if versions are not empty).
-		key roachpb.Key
+		key, endKey roachpb.Key
 		// Set of key.String() to avoid generating data for the same key multiple
 		// times.
 		seen = map[string]struct{}{}
@@ -121,7 +231,7 @@ func newDataDistribution(
 		hasIntent bool
 	)
 
-	generatePointKey := func() (nextKey roachpb.Key, keyTimestamps []hlc.Timestamp, hasIntent bool) {
+	generatePointKey := func() (nextKey, unusedEndKey roachpb.Key, keyTimestamps []hlc.Timestamp, hasIntent bool) {
 		hasIntent = rng.Float64() < intentFrac
 		oldIntent := hasIntent && rng.Float64() < oldIntentFrac
 		for retries := 0; len(keyTimestamps) == 0; retries++ {
@@ -186,14 +296,27 @@ func newDataDistribution(
 			}
 			retries = 0
 		}
-		return nextKey, keyTimestamps, hasIntent
+		return nextKey, nil, keyTimestamps, hasIntent
 	}
 
-	return func() (storage.MVCCKeyValue, *roachpb.Transaction, bool) {
+	generateRangeKey := func() (startKey, endKey roachpb.Key, timestamps []hlc.Timestamp, hasIntent bool) {
+		var ts hlc.Timestamp
+		for {
+			ts = tsDist()
+			if ts.Less(minIntentTs) {
+				break
+			}
+		}
+		timestamps = []hlc.Timestamp{ts}
+		startKey, endKey = rangeKeyDist()
+		return startKey, endKey, timestamps, false
+	}
+
+	return func() (storage.MVCCKeyValue, storage.MVCCRangeKeyValue, *roachpb.Transaction, bool) {
 		if remaining == 0 {
 			// Throw away temp key data, because we reached the end of sequence.
 			seen = nil
-			return storage.MVCCKeyValue{}, nil, false
+			return storage.MVCCKeyValue{}, storage.MVCCRangeKeyValue{}, nil, false
 		}
 		defer func() { remaining-- }()
 
@@ -201,12 +324,28 @@ func newDataDistribution(
 			// Loop because we can have duplicate keys or unacceptable values, in that
 			// case we retry key from scratch.
 			for len(timestamps) == 0 {
-				key, timestamps, hasIntent = generatePointKey()
+				if rng.Float64() < rangeKeyFrac {
+					key, endKey, timestamps, hasIntent = generateRangeKey()
+				} else {
+					key, endKey, timestamps, hasIntent = generatePointKey()
+				}
 			}
 			seen[string(key)] = struct{}{}
 		}
 		ts := timestamps[0]
 		timestamps = timestamps[1:]
+
+		if len(endKey) > 0 {
+			return storage.MVCCKeyValue{},
+				storage.MVCCRangeKeyValue{
+					RangeKey: storage.MVCCRangeKey{
+						StartKey:  key,
+						EndKey:    endKey,
+						Timestamp: ts,
+					},
+				}, nil, true
+		}
+
 		var txn *roachpb.Transaction
 		// On the last version, we generate a transaction as needed.
 		if len(timestamps) == 0 && hasIntent {
@@ -222,7 +361,7 @@ func newDataDistribution(
 		return storage.MVCCKeyValue{
 			Key:   storage.MVCCKey{Key: key, Timestamp: ts},
 			Value: valueDist().RawBytes,
-		}, txn, true
+		}, storage.MVCCRangeKeyValue{}, txn, true
 	}
 }
 
@@ -243,19 +382,30 @@ type uniformDistSpec struct {
 	deleteFrac                       float64
 	keysPerValueMin, keysPerValueMax int
 	intentFrac, oldIntentFrac        float64
+	rangeKeyFrac                     float64
 }
 
 var _ distSpec = uniformDistSpec{}
 
 func (ds uniformDistSpec) dist(maxRows int, rng *rand.Rand) dataDistribution {
+	if ds.tsSecMinIntent <= ds.tsSecFrom && ds.rangeKeyFrac > 0 {
+		panic("min intent ts should be set if range key generation is needed")
+	}
+	if ds.tsSecOldIntentTo <= ds.tsSecMinIntent && ds.oldIntentFrac > 0 {
+		panic("old intent ts must be lower than min intent ts if old intents are enabled")
+	}
 	return newDataDistribution(
-		uniformTimestampDistribution(ds.tsSecFrom*time.Second.Nanoseconds(), ds.tsSecTo*time.Second.Nanoseconds(), rng),
+		uniformTimestampDistribution(ds.tsSecFrom*time.Second.Nanoseconds(),
+			ds.tsSecTo*time.Second.Nanoseconds(), rng),
 		hlc.Timestamp{WallTime: ds.tsSecMinIntent * time.Second.Nanoseconds()},
 		hlc.Timestamp{WallTime: ds.tsSecOldIntentTo * time.Second.Nanoseconds()},
-		uniformTableStringKeyDistribution(ds.desc().StartKey.AsRawKey(), ds.keySuffixMin, ds.keySuffixMax, rng),
+		uniformTableStringKeyDistribution(ds.desc().StartKey.AsRawKey(), ds.keySuffixMin,
+			ds.keySuffixMax, rng),
 		uniformValueStringDistribution(ds.valueLenMin, ds.valueLenMax, ds.deleteFrac, rng),
 		uniformValuesPerKey(ds.keysPerValueMin, ds.keysPerValueMax, rng),
-		ds.intentFrac, ds.oldIntentFrac,
+		ds.intentFrac,
+		ds.oldIntentFrac,
+		ds.rangeKeyFrac,
 		maxRows,
 		rng,
 	)
@@ -275,12 +425,12 @@ func (ds uniformDistSpec) String() string {
 			"keySuffix=[%d,%d],"+
 			"valueLen=[%d,%d],"+
 			"keysPerValue=[%d,%d],"+
-			"deleteFrac=%f,intentFrac=%f",
+			"deleteFrac=%f,intentFrac=%f,oldIntentFrac=%f,rangeFrac=%f",
 		ds.tsSecFrom, ds.tsSecTo,
 		ds.keySuffixMin, ds.keySuffixMax,
 		ds.valueLenMin, ds.valueLenMax,
 		ds.keysPerValueMin, ds.keysPerValueMax,
-		ds.deleteFrac, ds.intentFrac)
+		ds.deleteFrac, ds.intentFrac, ds.oldIntentFrac, ds.rangeKeyFrac)
 }
 
 // uniformTimestamp returns an hlc timestamp distribution with a wall time
@@ -372,5 +522,18 @@ func uniformTableStringKeyDistribution(
 		lenSuffix := suffixMin + rng.Intn(n)
 		key := randutil.RandString(rng, lenSuffix, randutil.PrintableKeyAlphabet)
 		return encoding.EncodeBytesAscending(prefix[0:len(prefix):len(prefix)], []byte(key))
+	}
+}
+
+func rangeKeyDistribution(keyDist func() roachpb.Key) func() (roachpb.Key, roachpb.Key) {
+	return func() (roachpb.Key, roachpb.Key) {
+		k1 := keyDist()
+		k2 := keyDist()
+		for ; k1.Equal(k2); k2 = keyDist() {
+		}
+		if k1.Compare(k2) > 0 {
+			return k2, k1
+		}
+		return k1, k2
 	}
 }

--- a/pkg/kv/kvserver/gc/gc_iterator.go
+++ b/pkg/kv/kvserver/gc/gc_iterator.go
@@ -11,29 +11,46 @@
 package gc
 
 import (
+	"sort"
+	"strings"
+
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
 // gcIterator wraps an rditer.ReplicaMVCCDataIterator which it reverse iterates for
 // the purpose of discovering gc-able replicated data.
 type gcIterator struct {
-	it   *rditer.ReplicaMVCCDataIterator
-	done bool
-	err  error
-	buf  gcIteratorRingBuf
+	it        *rditer.ReplicaMVCCDataIterator
+	threshold hlc.Timestamp
+	done      bool
+	err       error
+	buf       gcIteratorRingBuf
+
+	// Range tombstone timestamp caching to avoid recomputing timestamp for every
+	// object covered by current range key.
+	cachedRangeTombstoneTS  hlc.Timestamp
+	cachedRangeTombstoneKey roachpb.Key
 }
 
-func makeGCIterator(desc *roachpb.RangeDescriptor, snap storage.Reader) gcIterator {
+func makeGCIterator(
+	desc *roachpb.RangeDescriptor, snap storage.Reader, threshold hlc.Timestamp,
+) gcIterator {
 	return gcIterator{
-		it: rditer.NewReplicaMVCCDataIterator(desc, snap, true /* seekEnd */),
+		it:        rditer.NewReplicaMVCCDataIterator(desc, snap, true /* seekEnd */),
+		threshold: threshold,
 	}
 }
 
 type gcIteratorState struct {
+	// Sequential elements in iteration order (oldest to newest).
 	cur, next, afterNext *storage.MVCCKeyValue
+	// Optional timestamp of the first available range tombstone at or below the
+	// GC threshold for the cur key.
+	firstRangeTombstoneTsAtOrBelowGC hlc.Timestamp
 }
 
 // curIsNewest returns true if the current MVCCKeyValue in the gcIteratorState
@@ -57,8 +74,42 @@ func (s *gcIteratorState) curIsIntent() bool {
 	return s.next != nil && !s.next.Key.IsValue()
 }
 
+func kVString(v *storage.MVCCKeyValue) string {
+	b := strings.Builder{}
+	if v != nil {
+		b.WriteString(v.Key.String())
+		if len(v.Value) == 0 {
+			b.WriteString(" del")
+		}
+	} else {
+		b.WriteString("<nil>")
+	}
+	return b.String()
+}
+
+// String implements Stringer for debugging purposes.
+func (s *gcIteratorState) String() string {
+	b := strings.Builder{}
+	add := func(v *storage.MVCCKeyValue, last bool) {
+		b.WriteString(kVString(v))
+		if !last {
+			b.WriteString(", ")
+		}
+	}
+	add(s.cur, false)
+	add(s.next, false)
+	add(s.afterNext, true)
+	if ts := s.firstRangeTombstoneTsAtOrBelowGC; !ts.IsEmpty() {
+		b.WriteString(" rts@")
+		b.WriteString(ts.String())
+	}
+	return b.String()
+}
+
 // state returns the current state of the iterator. The state contains the
-// current and the two following versions of the current key if they exist.
+// current and the two following versions of the current key if they exist
+// as well as an optional timestamp of the first range tombstone covering
+// current key at or below GC threshold.
 //
 // If ok is false, further iteration is unsafe; either the end of iteration has
 // been reached or an error has occurred. Callers should check it.err to
@@ -70,11 +121,11 @@ func (it *gcIterator) state() (s gcIteratorState, ok bool) {
 	// The current key is the newest if the key which comes next is different or
 	// the key which comes after the current key is an intent or this is the first
 	// key in the range.
-	s.cur, ok = it.peekAt(0)
+	s.cur, s.firstRangeTombstoneTsAtOrBelowGC, ok = it.peekAt(0)
 	if !ok {
 		return gcIteratorState{}, false
 	}
-	next, ok := it.peekAt(1)
+	next, _, ok := it.peekAt(1)
 	if !ok && it.err != nil { // cur is the first key in the range
 		return gcIteratorState{}, false
 	}
@@ -82,7 +133,7 @@ func (it *gcIterator) state() (s gcIteratorState, ok bool) {
 		return s, true
 	}
 	s.next = next
-	afterNext, ok := it.peekAt(2)
+	afterNext, _, ok := it.peekAt(2)
 	if !ok && it.err != nil { // cur is the first key in the range
 		return gcIteratorState{}, false
 	}
@@ -97,13 +148,16 @@ func (it *gcIterator) step() {
 	it.buf.removeFront()
 }
 
-func (it *gcIterator) peekAt(i int) (*storage.MVCCKeyValue, bool) {
+// peekAt returns key value and a ts of first range tombstone less or equal
+// to gc threshold.
+func (it *gcIterator) peekAt(i int) (*storage.MVCCKeyValue, hlc.Timestamp, bool) {
 	if it.buf.len <= i {
 		if !it.fillTo(i + 1) {
-			return nil, false
+			return nil, hlc.Timestamp{}, false
 		}
 	}
-	return it.buf.at(i), true
+	kv, rangeTs := it.buf.at(i)
+	return kv, rangeTs, true
 }
 
 func (it *gcIterator) fillTo(targetLen int) (ok bool) {
@@ -112,10 +166,39 @@ func (it *gcIterator) fillTo(targetLen int) (ok bool) {
 			it.err, it.done = err, err == nil
 			return false
 		}
-		it.buf.pushBack(it.it)
+		if hasPoint, hasRange := it.it.HasPointAndRange(); hasPoint {
+			ts := hlc.Timestamp{}
+			if hasRange {
+				ts = it.currentRangeTS()
+			}
+			it.buf.pushBack(it.it.UnsafeKey(), it.it.UnsafeValue(), ts)
+		}
 		it.it.Prev()
 	}
 	return true
+}
+
+// currentRangeTS returns timestamp of the first range tombstone at or below
+// gc threshold for current key. it also updates cached value to avoid
+// recomputation for every key and version by checking current range bounds
+// start key.
+// Note: should only be called if HasPointAndRange() indicated that we have
+// a range key.
+func (it *gcIterator) currentRangeTS() hlc.Timestamp {
+	rangeTombstoneStartKey := it.it.RangeBounds().Key
+	if rangeTombstoneStartKey.Equal(it.cachedRangeTombstoneKey) {
+		return it.cachedRangeTombstoneTS
+	}
+
+	it.cachedRangeTombstoneTS = hlc.Timestamp{}
+	rangeKeys := it.it.RangeKeys()
+	if idx := sort.Search(len(rangeKeys), func(i int) bool {
+		return rangeKeys[i].RangeKey.Timestamp.LessEq(it.threshold)
+	}); idx < len(rangeKeys) {
+		it.cachedRangeTombstoneTS = rangeKeys[idx].RangeKey.Timestamp
+	}
+	it.cachedRangeTombstoneKey = append(it.cachedRangeTombstoneKey[:0], rangeTombstoneStartKey...)
+	return it.cachedRangeTombstoneTS
 }
 
 func (it *gcIterator) close() {
@@ -130,15 +213,37 @@ const gcIteratorRingBufSize = 3
 type gcIteratorRingBuf struct {
 	allocs [gcIteratorRingBufSize]bufalloc.ByteAllocator
 	buf    [gcIteratorRingBufSize]storage.MVCCKeyValue
-	len    int
-	head   int
+	// If there are any range tombstones available for the key, this buffer will
+	// contain ts of first range at or below gc threshold. Otherwise, it'll be an
+	// empty timestamp.
+	firstRangeTombstoneAtOrBelowGCTss [gcIteratorRingBufSize]hlc.Timestamp
+	len                               int
+	head                              int
 }
 
-func (b *gcIteratorRingBuf) at(i int) *storage.MVCCKeyValue {
+func (b *gcIteratorRingBuf) String() string {
+	sb := strings.Builder{}
+	ptr := b.head
+	for i := 0; i < b.len; i++ {
+		sb.WriteString(kVString(&b.buf[ptr]))
+		if ts := b.firstRangeTombstoneAtOrBelowGCTss[ptr]; !ts.IsEmpty() {
+			sb.WriteString(" trs@")
+			sb.WriteString(b.firstRangeTombstoneAtOrBelowGCTss[ptr].String())
+		}
+		if i < b.len-1 {
+			sb.WriteString(", ")
+		}
+		ptr = (ptr + 1) % gcIteratorRingBufSize
+	}
+	return sb.String()
+}
+
+func (b *gcIteratorRingBuf) at(i int) (*storage.MVCCKeyValue, hlc.Timestamp) {
 	if i >= b.len {
 		panic("index out of range")
 	}
-	return &b.buf[(b.head+i)%gcIteratorRingBufSize]
+	idx := (b.head + i) % gcIteratorRingBufSize
+	return &b.buf[idx], b.firstRangeTombstoneAtOrBelowGCTss[idx]
 }
 
 func (b *gcIteratorRingBuf) removeFront() {
@@ -146,28 +251,23 @@ func (b *gcIteratorRingBuf) removeFront() {
 		panic("cannot remove from empty gcIteratorRingBuf")
 	}
 	b.buf[b.head] = storage.MVCCKeyValue{}
+	b.firstRangeTombstoneAtOrBelowGCTss[b.head] = hlc.Timestamp{}
 	b.head = (b.head + 1) % gcIteratorRingBufSize
 	b.len--
 }
 
-type iterator interface {
-	UnsafeKey() storage.MVCCKey
-	UnsafeValue() []byte
-}
-
-func (b *gcIteratorRingBuf) pushBack(it iterator) {
+func (b *gcIteratorRingBuf) pushBack(k storage.MVCCKey, v []byte, rangeTS hlc.Timestamp) {
 	if b.len == gcIteratorRingBufSize {
 		panic("cannot add to full gcIteratorRingBuf")
 	}
 	i := (b.head + b.len) % gcIteratorRingBufSize
 	b.allocs[i] = b.allocs[i].Truncate()
-	k := it.UnsafeKey()
-	v := it.UnsafeValue()
 	b.allocs[i], k.Key = b.allocs[i].Copy(k.Key, len(v))
 	b.allocs[i], v = b.allocs[i].Copy(v, 0)
 	b.buf[i] = storage.MVCCKeyValue{
 		Key:   k,
 		Value: v,
 	}
+	b.firstRangeTombstoneAtOrBelowGCTss[i] = rangeTS
 	b.len++
 }

--- a/pkg/kv/kvserver/gc/gc_iterator_test.go
+++ b/pkg/kv/kvserver/gc/gc_iterator_test.go
@@ -11,7 +11,6 @@
 package gc
 
 import (
-	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -32,32 +31,47 @@ func TestGCIterator(t *testing.T) {
 	// dataItem represents a version in the storage engine and optionally a
 	// corresponding transaction which will make the MVCCKeyValue an intent.
 	type dataItem struct {
-		storage.MVCCKeyValue
+		kv  storage.MVCCKeyValue
 		txn *roachpb.Transaction
+		rkv storage.MVCCRangeKeyValue
+	}
+	makeTS := func(ts int64) hlc.Timestamp {
+		return hlc.Timestamp{WallTime: ts * time.Nanosecond.Nanoseconds()}
 	}
 	// makeDataItem is a shorthand to construct dataItems.
 	makeDataItem := func(k roachpb.Key, val roachpb.Value, ts int64, txn *roachpb.Transaction) dataItem {
 		return dataItem{
-			MVCCKeyValue: storage.MVCCKeyValue{
+			kv: storage.MVCCKeyValue{
 				Key: storage.MVCCKey{
 					Key:       k,
-					Timestamp: hlc.Timestamp{WallTime: ts * time.Nanosecond.Nanoseconds()},
+					Timestamp: makeTS(ts),
 				},
 				Value: val.RawBytes,
 			},
 			txn: txn,
 		}
 	}
+	makeRangeTombstone := func(start, end roachpb.Key, ts int64) dataItem {
+		return dataItem{
+			rkv: storage.MVCCRangeKeyValue{
+				RangeKey: storage.MVCCRangeKey{
+					StartKey:  start,
+					EndKey:    end,
+					Timestamp: makeTS(ts),
+				},
+			},
+		}
+	}
 	// makeLiteralDistribution adapts dataItems for use with the data distribution
 	// infrastructure.
 	makeLiteralDataDistribution := func(items ...dataItem) dataDistribution {
-		return func() (storage.MVCCKeyValue, *roachpb.Transaction, bool) {
+		return func() (storage.MVCCKeyValue, storage.MVCCRangeKeyValue, *roachpb.Transaction, bool) {
 			if len(items) == 0 {
-				return storage.MVCCKeyValue{}, nil, false
+				return storage.MVCCKeyValue{}, storage.MVCCRangeKeyValue{}, nil, false
 			}
 			item := items[0]
 			defer func() { items = items[1:] }()
-			return item.MVCCKeyValue, item.txn, true
+			return item.kv, item.rkv, item.txn, true
 		}
 	}
 	// stateExpectations are expectations about the state of the iterator.
@@ -66,6 +80,7 @@ func TestGCIterator(t *testing.T) {
 		isNewest             bool
 		isIntent             bool
 		isNotValue           bool
+		rangeTombstoneTS     hlc.Timestamp
 	}
 	// notation to mark that an iterator state element as either nil or metadata.
 	const (
@@ -73,17 +88,23 @@ func TestGCIterator(t *testing.T) {
 		isMD  = -2
 	)
 	// exp is a shorthand to construct state expectations.
-	exp := func(cur, next, afterNext int, isNewest, isIntent, isNotValue bool) stateExpectations {
+	exp := func(cur, next, afterNext int, isNewest, isIntent, isNotValue bool,
+		tombstoneTS hlc.Timestamp,
+	) stateExpectations {
 		return stateExpectations{
 			cur: cur, next: next, afterNext: afterNext,
-			isNewest:   isNewest,
-			isIntent:   isIntent,
-			isNotValue: isNotValue,
+			isNewest:         isNewest,
+			isIntent:         isIntent,
+			isNotValue:       isNotValue,
+			rangeTombstoneTS: tombstoneTS,
 		}
 	}
 	vals := uniformValueDistribution(3, 5, 0, rand.New(rand.NewSource(1)))
 	tablePrefix := keys.SystemSQLCodec.TablePrefix(42)
-	desc := roachpb.RangeDescriptor{StartKey: roachpb.RKey(tablePrefix), EndKey: roachpb.RKey(tablePrefix.PrefixEnd())}
+	desc := roachpb.RangeDescriptor{
+		StartKey: roachpb.RKey(tablePrefix),
+		EndKey:   roachpb.RKey(tablePrefix.PrefixEnd()),
+	}
 	keyA := append(tablePrefix[0:len(tablePrefix):len(tablePrefix)], 'a')
 	keyB := append(tablePrefix[0:len(tablePrefix):len(tablePrefix)], 'b')
 	keyC := append(tablePrefix[0:len(tablePrefix):len(tablePrefix)], 'c')
@@ -99,27 +120,29 @@ func TestGCIterator(t *testing.T) {
 		name         string
 		data         []dataItem
 		expectations []stateExpectations
+		gcThreshold  hlc.Timestamp
 	}
 	// checkExpectations tests whether the state of the iterator matches the
 	// expectation.
 	checkExpectations := func(
-		t *testing.T, data []dataItem, ex stateExpectations, s gcIteratorState,
+		t *testing.T, step int, data []dataItem, ex stateExpectations, s gcIteratorState,
 	) {
-		check := func(ex int, kv *storage.MVCCKeyValue) {
+		check := func(ex int, role string, kv *storage.MVCCKeyValue) {
 			switch {
 			case ex >= 0:
-				require.EqualValues(t, &data[ex].MVCCKeyValue, kv)
+				require.EqualValues(t, &data[ex].kv, kv, "step %d: unexpected data for %s at index %d", step, role, ex)
 			case ex == isNil:
-				require.Nil(t, kv)
+				require.Nil(t, kv, "step %d", step)
 			case ex == isMD:
-				require.False(t, kv.Key.IsValue())
+				require.False(t, kv.Key.IsValue(), "step %d: expected metadata, found value", step)
 			}
 		}
-		check(ex.cur, s.cur)
-		check(ex.next, s.next)
-		check(ex.afterNext, s.afterNext)
-		require.Equal(t, ex.isNewest, s.curIsNewest())
-		require.Equal(t, ex.isIntent, s.curIsIntent())
+		check(ex.cur, "cur", s.cur)
+		check(ex.next, "next", s.next)
+		check(ex.afterNext, "after", s.afterNext)
+		require.Equal(t, ex.rangeTombstoneTS, s.firstRangeTombstoneTsAtOrBelowGC, "step %d: unexpected last tombstone timestamp", step)
+		require.Equal(t, ex.isNewest, s.curIsNewest(), "step %d: is newest", step)
+		require.Equal(t, ex.isIntent, s.curIsIntent(), "step %d: is intent", step)
 	}
 	makeTest := func(tc testCase) func(t *testing.T) {
 		return func(t *testing.T) {
@@ -129,20 +152,21 @@ func TestGCIterator(t *testing.T) {
 			ds.setupTest(t, eng, desc)
 			snap := eng.NewSnapshot()
 			defer snap.Close()
-			it := makeGCIterator(&desc, snap)
+			it := makeGCIterator(&desc, snap, tc.gcThreshold)
 			defer it.close()
 			expectations := tc.expectations
 			for i, ex := range expectations {
-				t.Run(fmt.Sprint(i), func(t *testing.T) {
-					s, ok := it.state()
-					require.True(t, ok)
-					checkExpectations(t, tc.data, ex, s)
-				})
+				s, ok := it.state()
+				require.True(t, ok, "failed to get next state on step %d", i)
+				checkExpectations(t, i, tc.data, ex, s)
 				it.step()
 			}
 		}
 	}
-	di := makeDataItem // shorthand for convenient notation
+	// Shorthands for convenient notation.
+	noTS := hlc.Timestamp{}
+	di := makeDataItem
+	rts := makeRangeTombstone
 	for _, tc := range []testCase{
 		{
 			name: "basic",
@@ -154,13 +178,75 @@ func TestGCIterator(t *testing.T) {
 				di(keyC, vals(), 7, makeTxn()),
 			},
 			expectations: []stateExpectations{
-				exp(4, isMD, isNil, false, true, false),
-				exp(isMD, isNil, isNil, false, false, true),
-				exp(3, isNil, isNil, true, false, false),
-				exp(0, 1, 2, false, false, false),
-				exp(1, 2, isNil, false, false, false),
-				exp(2, isNil, isNil, true, false, false),
+				exp(4, isMD, isNil, false, true, false, noTS),
+				exp(isMD, isNil, isNil, false, false, true, noTS),
+				exp(3, isNil, isNil, true, false, false, noTS),
+				exp(0, 1, 2, false, false, false, noTS),
+				exp(1, 2, isNil, false, false, false, noTS),
+				exp(2, isNil, isNil, true, false, false, noTS),
 			},
+		},
+		{
+			name: "range tombstones range ts in future",
+			data: []dataItem{
+				di(keyA, vals(), 2, nil),       // 0
+				di(keyB, vals(), 3, nil),       // 1
+				di(keyC, vals(), 7, makeTxn()), // 2
+				rts(keyA, keyB, 10),            // -
+				di(keyA, vals(), 11, nil),      // 4
+				di(keyA, vals(), 14, nil),      // 5
+			},
+			expectations: []stateExpectations{
+				exp(2, isMD, isNil, false, true, false, noTS),
+				exp(isMD, isNil, isNil, false, false, true, noTS),
+				exp(1, isNil, isNil, true, false, false, noTS),
+				exp(0, 4, 5, false, false, false, noTS),
+				exp(4, 5, isNil, false, false, false, noTS),
+				exp(5, isNil, isNil, true, false, false, noTS),
+			},
+			gcThreshold: makeTS(7),
+		},
+		{
+			name: "range tombstones with ts",
+			data: []dataItem{
+				di(keyA, vals(), 2, nil),       // 0
+				di(keyB, vals(), 3, nil),       // 1
+				di(keyC, vals(), 7, makeTxn()), // 2
+				rts(keyA, keyB, 10),            // -
+				di(keyA, vals(), 11, nil),      // 4
+				di(keyA, vals(), 14, nil),      // 5
+			},
+			expectations: []stateExpectations{
+				exp(2, isMD, isNil, false, true, false, noTS),
+				exp(isMD, isNil, isNil, false, false, true, noTS),
+				exp(1, isNil, isNil, true, false, false, noTS),
+				exp(0, 4, 5, false, false, false, makeTS(10)),
+				exp(4, 5, isNil, false, false, false, makeTS(10)),
+				exp(5, isNil, isNil, true, false, false, makeTS(10)),
+			},
+			gcThreshold: makeTS(10),
+		},
+		{
+			name: "multiple range tombstones",
+			data: []dataItem{
+				rts(keyA, keyB, 1),             // -
+				di(keyA, vals(), 2, nil),       // 1
+				di(keyB, vals(), 3, nil),       // 2
+				rts(keyA, keyB, 7),             // -
+				di(keyC, vals(), 7, makeTxn()), // 4
+				rts(keyA, keyC, 10),            // -
+				di(keyA, vals(), 11, nil),      // 6
+				di(keyA, vals(), 14, nil),      // 7
+			},
+			expectations: []stateExpectations{
+				exp(4, isMD, isNil, false, true, false, noTS),
+				exp(isMD, isNil, isNil, false, false, true, noTS),
+				exp(2, isNil, isNil, true, false, false, noTS),
+				exp(1, 6, 7, false, false, false, makeTS(7)),
+				exp(6, 7, isNil, false, false, false, makeTS(7)),
+				exp(7, isNil, isNil, true, false, false, makeTS(7)),
+			},
+			gcThreshold: makeTS(9),
 		},
 	} {
 		t.Run(tc.name, makeTest(tc))

--- a/pkg/kv/kvserver/gc/gc_old_test.go
+++ b/pkg/kv/kvserver/gc/gc_old_test.go
@@ -147,7 +147,7 @@ func runGCOld(
 						if batchGCKeysBytes >= KeyVersionChunkBytes {
 							batchGCKeys = append(batchGCKeys, roachpb.GCRequest_GCKey{Key: expBaseKey, Timestamp: keys[i].Timestamp})
 
-							err := gcer.GC(ctx, batchGCKeys)
+							err := gcer.GC(ctx, batchGCKeys, nil)
 
 							batchGCKeys = nil
 							batchGCKeysBytes = 0
@@ -206,7 +206,7 @@ func runGCOld(
 	// Handle last collected set of keys/vals.
 	processKeysAndValues()
 	if len(batchGCKeys) > 0 {
-		if err := gcer.GC(ctx, batchGCKeys); err != nil {
+		if err := gcer.GC(ctx, batchGCKeys, nil); err != nil {
 			return Info{}, err
 		}
 	}
@@ -326,7 +326,6 @@ var (
 
 // TestGarbageCollectorFilter verifies the filter policies for
 // different sorts of MVCC keys.
-// TODO(oleg): Remove once we don't need old GC.
 func TestGarbageCollectorFilter(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	gcA := makeGarbageCollector(hlc.Timestamp{WallTime: 0, Logical: 0}, time.Second)

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -55,7 +55,9 @@ type collectingGCer struct {
 	keys [][]roachpb.GCRequest_GCKey
 }
 
-func (c *collectingGCer) GC(_ context.Context, keys []roachpb.GCRequest_GCKey) error {
+func (c *collectingGCer) GC(
+	_ context.Context, keys []roachpb.GCRequest_GCKey, rangeKeys []roachpb.GCRequest_GCRangeKey,
+) error {
 	c.keys = append(c.keys, keys)
 	return nil
 }
@@ -564,20 +566,97 @@ var intentsAfterDelete = `
  1 |
 `
 
+var deleteRangeData = `
+   | a b c d e f g h i j
+---+----------------------
+ 9 | 
+ 8 |
+ 7 |
+ 6 |     *-
+>5 |   *-
+ 4 | *-
+ 3 |
+ 2 | a b C
+ 1 |
+`
+
+var deleteRangeDataWithNewerValues = `
+   | a b c d e f g h i j
+---+----------------------
+ 9 |
+ 8 | A C E *---
+ 7 |
+ 6 |     *-G
+>5 |   *-
+ 4 | *-      I
+ 3 |
+ 2 | b d F H i
+ 1 |
+`
+
+var deleteRangeMultipleValues = `
+   | a b c d e f g h i j
+---+----------------------
+ 9 | 
+ 8 |
+ 7 |
+ 6 |   *---
+>5 |   
+ 4 | *-
+ 3 |
+ 2 | a B C
+ 1 |
+`
+
+var deleteRangeDataWithIntents = `
+   | a  b  c  d e f g h i j
+---+----------------------
+ 9 | 
+ 8 | !A !C !E
+ 7 |
+ 6 |       *--
+>5 |    *--
+ 4 | *--
+ 3 |
+ 2 | b  d  F
+ 1 |
+`
+
+// This case verifies that if range tombstone stack caching is working correctly
+// when different keys have different removal thresholds.
+var differentRangeStacksPerPoint = `
+   | a  bb ccc  d
+---+---------------
+ 9 |
+>8 |    B3
+ 7 | *----------
+ 6 |    b2
+ 5 | *----------
+ 4 | a2 b1
+ 3 | *----------
+ 2 | a1
+ 1 |
+`
+
 func TestGC(t *testing.T) {
 	for _, d := range []struct {
 		name string
 		data string
 	}{
-		{"single", singleValueData},
-		{"multiple_newer", multipleValuesNewerData},
-		{"multiple_older", multipleValuesOlderData},
-		{"delete", deleteData},
-		{"delete_with_newer", deleteWithNewerData},
-		{"multiple_values", multipleValuesData},
-		{"intents", intents},
-		{"intents_after_data", intentsAfterData},
-		{"intents_after_delete", intentsAfterDelete},
+		{name: "single", data: singleValueData},
+		{name: "multiple_newer", data: multipleValuesNewerData},
+		{name: "multiple_older", data: multipleValuesOlderData},
+		{name: "delete", data: deleteData},
+		{name: "delete_with_newer", data: deleteWithNewerData},
+		{name: "multiple_values", data: multipleValuesData},
+		{name: "intents", data: intents},
+		{name: "intents_after_data", data: intentsAfterData},
+		{name: "intents_after_delete", data: intentsAfterDelete},
+		{name: "delete_range_data", data: deleteRangeData},
+		{name: "delete_range_data_newer", data: deleteRangeDataWithNewerValues},
+		{name: "delete_range_multiple_points", data: deleteRangeMultipleValues},
+		{name: "delete_range_with_intents", data: deleteRangeDataWithIntents},
+		{name: "delete_with_different_range_stacks", data: differentRangeStacksPerPoint},
 	} {
 		t.Run(d.name, func(t *testing.T) {
 			runTest(t, d.data)
@@ -628,6 +707,10 @@ func runTest(t *testing.T, data string) {
 	}
 
 	requireEqualReaders(t, ctrlEng, eng, desc)
+
+	// Age stats to the same TS before comparing.
+	expectedStats.AgeTo(now.WallTime)
+	stats.AgeTo(now.WallTime)
 	require.Equal(t, expectedStats, stats, "mvcc stats don't match the data")
 }
 
@@ -676,9 +759,17 @@ func requireEqualReaders(
 // dataItem is element read from test table containing mvcc key value along with
 // metadata needed for filtering.
 type dataItem struct {
-	value storage.MVCCKeyValue
-	txn   *roachpb.Transaction
-	live  bool
+	value         storage.MVCCKeyValue
+	txn           *roachpb.Transaction
+	rangeKeyValue storage.MVCCRangeKeyValue
+	live          bool
+}
+
+func (d dataItem) timestamp() hlc.Timestamp {
+	if !d.value.Key.Timestamp.IsEmpty() {
+		return d.value.Key.Timestamp
+	}
+	return d.rangeKeyValue.RangeKey.Timestamp
 }
 
 type tableData []dataItem
@@ -719,14 +810,9 @@ func readTableData(
 	parsePoint := func(val string, i int, ts hlc.Timestamp) int {
 		val = strings.TrimSpace(val)
 		if len(val) > 0 {
-			value := []byte(val)
-			// Special meaning for deletions.
-			if val == "*" || val == "." {
-				value = nil
-			}
 			var txn *roachpb.Transaction
 			if val[0] == '!' {
-				value = value[1:]
+				val = val[1:]
 				txn = &roachpb.Transaction{
 					Status:                 roachpb.PENDING,
 					ReadTimestamp:          ts,
@@ -737,8 +823,9 @@ func readTableData(
 				txn.Key = txn.ID.GetBytes()
 			}
 			var v roachpb.Value
-			if value != nil {
-				v.SetBytes(value)
+			// Special meaning for deletions.
+			if val != "*" && val != "." {
+				v.SetString(val)
 			}
 			kv := storage.MVCCKeyValue{
 				Key: storage.MVCCKey{
@@ -751,6 +838,36 @@ func readTableData(
 			items = append(items, dataItem{value: kv, txn: txn, live: live})
 		}
 		return i + 1
+	}
+
+	parseRange := func(val, l string, i int, ts hlc.Timestamp) int {
+		startKey := columnKeys[i]
+		// Handle range key. We are modifying outer loop index here.
+		p := columnPositions[i+1] - 1
+		// Find where range definition ends.
+		for ; p < columnPositions[len(columnPositions)-1] && l[p] == '-'; p++ {
+		}
+		// Find key following the end of range.
+		for i++; i < len(columnKeys) && columnPositions[i] < p; i++ {
+		}
+		// Extract value from the first element.
+		value := val[0]
+		if value != '*' && value != '.' {
+			panic("test data only supports range deletions")
+		}
+		live := value == '*'
+		// Add range to data.
+		endKey := columnKeys[i]
+		items = append(items, dataItem{
+			rangeKeyValue: storage.MVCCRangeKeyValue{
+				RangeKey: storage.MVCCRangeKey{
+					StartKey:  startKey,
+					EndKey:    endKey,
+					Timestamp: ts,
+				},
+			}, live: live,
+		})
+		return i
 	}
 
 	var gcTS hlc.Timestamp
@@ -769,7 +886,7 @@ func readTableData(
 		require.NoError(t, err, "Failed to parse timestamp from %s", l)
 		require.Less(t, tsInt, lastTs, "Timestamps should be decreasing")
 		lastTs = tsInt
-		return hlc.Timestamp{WallTime: tsInt}
+		return hlc.Timestamp{WallTime: tsInt * time.Second.Nanoseconds()}
 	}
 
 	for _, l := range lines {
@@ -793,7 +910,11 @@ func readTableData(
 		ts := parseTS(l)
 		for i := 0; i < len(columnKeys); {
 			val := l[columnPositions[i]:columnPositions[i+1]]
-			i = parsePoint(val, i, ts)
+			if val[len(val)-1] == '-' {
+				i = parseRange(val, l, i, ts)
+			} else {
+				i = parsePoint(val, i, ts)
+			}
 		}
 	}
 
@@ -802,19 +923,19 @@ func readTableData(
 		items[i], items[j] = items[j], items[i]
 	}
 
-	return items, gcTS, items[len(items)-1].value.Key.Timestamp.Add(1, 0)
+	return items, gcTS, items[len(items)-1].timestamp().Add(1, 0)
 }
 
 // fullDistribution creates a data distribution that contains all data read from
 // table.
 func (d tableData) fullDistribution() dataDistribution {
 	items := d
-	return func() (storage.MVCCKeyValue, *roachpb.Transaction, bool) {
+	return func() (storage.MVCCKeyValue, storage.MVCCRangeKeyValue, *roachpb.Transaction, bool) {
 		if len(items) == 0 {
-			return storage.MVCCKeyValue{}, nil, false
+			return storage.MVCCKeyValue{}, storage.MVCCRangeKeyValue{}, nil, false
 		}
 		defer func() { items = items[1:] }()
-		return items[0].value, items[0].txn, true
+		return items[0].value, items[0].rangeKeyValue, items[0].txn, true
 	}
 }
 
@@ -822,10 +943,10 @@ func (d tableData) fullDistribution() dataDistribution {
 // marked as live (see table data format above).
 func (d tableData) liveDistribution() dataDistribution {
 	items := d
-	return func() (storage.MVCCKeyValue, *roachpb.Transaction, bool) {
+	return func() (storage.MVCCKeyValue, storage.MVCCRangeKeyValue, *roachpb.Transaction, bool) {
 		for {
 			if len(items) == 0 {
-				return storage.MVCCKeyValue{}, nil, false
+				return storage.MVCCKeyValue{}, storage.MVCCRangeKeyValue{}, nil, false
 			}
 			if items[0].live {
 				break
@@ -833,12 +954,89 @@ func (d tableData) liveDistribution() dataDistribution {
 			items = items[1:]
 		}
 		defer func() { items = items[1:] }()
-		return items[0].value, items[0].txn, true
+		return items[0].value, items[0].rangeKeyValue, items[0].txn, true
 	}
 }
 
+// engineData reads all engine data as tableCells in no particular order.
 func engineData(t *testing.T, r storage.Reader, desc roachpb.RangeDescriptor) []tableCell {
 	var result []tableCell
+
+	rangeIt := r.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
+		LowerBound:           desc.StartKey.AsRawKey(),
+		UpperBound:           desc.EndKey.AsRawKey(),
+		KeyTypes:             storage.IterKeyTypeRangesOnly,
+		RangeKeyMaskingBelow: hlc.Timestamp{},
+	})
+	defer rangeIt.Close()
+	rangeIt.SeekGE(storage.MVCCKey{Key: desc.StartKey.AsRawKey()})
+	makeRangeCells := func(rks []storage.MVCCRangeKey) (tc []tableCell) {
+		for _, rk := range rks {
+			tc = append(tc, tableCell{
+				key: storage.MVCCKey{
+					Key:       rk.StartKey,
+					Timestamp: rk.Timestamp,
+				},
+				endKey: rk.EndKey,
+				value:  ".",
+			})
+		}
+		return tc
+	}
+	var partialRangeKeys []storage.MVCCRangeKey
+	var lastEnd roachpb.Key
+	for {
+		ok, err := rangeIt.Valid()
+		require.NoError(t, err, "failed to iterate range keys")
+		if !ok {
+			break
+		}
+		_, r := rangeIt.HasPointAndRange()
+		if r {
+			span := rangeIt.RangeBounds()
+			newKeys := rangeIt.RangeKeys()
+			if lastEnd.Equal(span.Key) {
+				// Try merging keys by timestamp.
+				var newPartial []storage.MVCCRangeKey
+				i, j := 0, 0
+				for i < len(newKeys) && j < len(partialRangeKeys) {
+					switch newKeys[i].RangeKey.Timestamp.Compare(partialRangeKeys[j].Timestamp) {
+					case 1:
+						newPartial = append(newPartial, newKeys[i].RangeKey.Clone())
+						i++
+					case 0:
+						newPartial = append(newPartial, storage.MVCCRangeKey{
+							StartKey:  partialRangeKeys[j].StartKey,
+							EndKey:    newKeys[i].RangeKey.EndKey.Clone(),
+							Timestamp: partialRangeKeys[j].Timestamp,
+						})
+						i++
+						j++
+					case -1:
+						newPartial = append(newPartial, partialRangeKeys[j].Clone())
+						j++
+					}
+				}
+				for ; i < len(newKeys); i++ {
+					newPartial = append(newPartial, newKeys[i].RangeKey.Clone())
+				}
+				for ; j < len(partialRangeKeys); j++ {
+					newPartial = append(newPartial, partialRangeKeys[j].Clone())
+				}
+				partialRangeKeys = newPartial
+			} else {
+				result = append(result, makeRangeCells(partialRangeKeys)...)
+				partialRangeKeys = make([]storage.MVCCRangeKey, len(newKeys))
+				for i, rk := range newKeys {
+					partialRangeKeys[i] = rk.RangeKey.Clone()
+				}
+			}
+			lastEnd = span.EndKey.Clone()
+		}
+		rangeIt.NextKey()
+	}
+	result = append(result, makeRangeCells(partialRangeKeys)...)
+
 	it := r.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
 		LowerBound:           desc.StartKey.AsRawKey(),
 		UpperBound:           desc.EndKey.AsRawKey(),
@@ -878,13 +1076,23 @@ func engineData(t *testing.T, r storage.Reader, desc roachpb.RangeDescriptor) []
 }
 
 type tableCell struct {
-	key   storage.MVCCKey
+	key storage.MVCCKey
+	// Optional endKey for range keys.
+	endKey roachpb.Key
+	// Formatted key value (could be value, deletion or intent).
 	value string
 }
 
 type columnInfo struct {
 	key            string
 	maxValueLength int
+	position       int
+	formatStr      string
+}
+
+type cellValue struct {
+	value  string
+	endKey string
 }
 
 // formatTable renders table with data. expecting data to be sorted naturally:
@@ -892,64 +1100,123 @@ type columnInfo struct {
 // prefix if provided defines start of the key, that would be stripped from the
 // keys to avoid clutter.
 func formatTable(data []tableCell, prefix roachpb.Key) []string {
-	prefixStr := ""
+	// Table with no data is a special case.
+	if len(data) == 0 {
+		return nil
+	}
+
+	keyPrefixStr := ""
 	if prefix != nil {
-		prefixStr = prefix.String()
+		keyPrefixStr = prefix.String()
 	}
 	keyRe := regexp.MustCompile(`^/"(.*)"$`)
-	var foundKeys []columnInfo
-	var lastKey roachpb.Key
-	rowData := make(map[int64][]string)
+	columnName := func(key roachpb.Key) string {
+		keyStr := key.String()
+		if strings.Index(keyStr, keyPrefixStr) == 0 {
+			keyStr = keyStr[len(keyPrefixStr):]
+			if keyRe.FindSubmatch([]byte(keyStr)) != nil {
+				keyStr = keyStr[2 : len(keyStr)-1]
+			}
+		}
+		return keyStr
+	}
+
+	// Table data indexed by ts, key.
+	keyData := make(map[string]columnInfo)
+
+	addKeyColumn := func(key roachpb.Key, columnLen int) {
+		keyStr := key.String()
+		if column, ok := keyData[keyStr]; !ok {
+			title := columnName(key)
+			if titleLen := len(title); columnLen < len(title) {
+				columnLen = titleLen
+			}
+			keyData[keyStr] = columnInfo{
+				key:            title,
+				maxValueLength: columnLen,
+			}
+		} else {
+			if columnLen > column.maxValueLength {
+				column.maxValueLength = columnLen
+				keyData[keyStr] = column
+			}
+		}
+	}
+
+	sparseTable := make(map[int64]map[string]cellValue)
 	for _, c := range data {
 		ts := c.key.Timestamp.WallTime
 		key := c.key.Key.String()
-		if strings.Index(key, prefixStr) == 0 {
-			key = key[len(prefixStr):]
-			if keyRe.FindSubmatch([]byte(key)) != nil {
-				key = key[2 : len(key)-1]
-			}
+		addKeyColumn(c.key.Key, len(c.value))
+		if _, ok := sparseTable[ts]; !ok {
+			sparseTable[ts] = make(map[string]cellValue)
 		}
-		if !c.key.Key.Equal(lastKey) {
-			foundKeys = append(foundKeys, columnInfo{
-				key:            key,
-				maxValueLength: len(key),
-			})
-			lastKey = c.key.Key
+		endKey := ""
+		if len(c.endKey) > 0 {
+			endKey = c.endKey.String()
 		}
-		row := rowData[ts]
-		for len(row) < len(foundKeys)-1 {
-			row = append(row, "")
-		}
-		rowData[ts] = append(row, c.value)
-		valueLen := len(c.value)
-		if i := len(foundKeys) - 1; valueLen > foundKeys[i].maxValueLength {
-			foundKeys[i].maxValueLength = valueLen
+		sparseTable[ts][key] = cellValue{c.value, endKey}
+		if len(c.endKey) > 0 {
+			addKeyColumn(c.endKey, 0)
 		}
 	}
-	var tss []int64
-	for ts := range rowData {
-		tss = append(tss, ts)
-	}
-	sort.Slice(tss, func(i, j int) bool {
-		return tss[i] > tss[j]
-	})
 
-	lsLen := len(fmt.Sprintf("%d", tss[0]))
-	rowPrefixFmt := fmt.Sprintf(" %%%dd | ", lsLen)
+	// Build table key positions for ease of iterations.
+	var keySeq []string
+	for k := range keyData {
+		keySeq = append(keySeq, k)
+	}
+	sort.Strings(keySeq)
+	base := 0
+	for _, k := range keySeq {
+		kd := keyData[k]
+		kd.position = base
+		kd.formatStr = fmt.Sprintf("%%-%ds", kd.maxValueLength)
+		base += kd.maxValueLength + 1
+		keyData[k] = kd
+	}
+	// Build key sequence.
+	var tsSeq []int64
+	for ts := range sparseTable {
+		tsSeq = append(tsSeq, ts)
+	}
+	sort.Slice(tsSeq, func(i, j int) bool {
+		return tsSeq[i] > tsSeq[j]
+	})
 
 	var result []string
 
+	lsLen := len(fmt.Sprintf("%d", tsSeq[0]/time.Second.Nanoseconds()))
+	rowPrefixFmt := fmt.Sprintf(" %%%dd | ", lsLen)
 	firstRow := fmt.Sprintf(" %s | ", strings.Repeat(" ", lsLen))
-	for _, colInfo := range foundKeys {
-		firstRow += fmt.Sprintf(fmt.Sprintf("%%%ds ", colInfo.maxValueLength), colInfo.key)
+	for _, key := range keySeq {
+		colInfo := keyData[key]
+		firstRow += fmt.Sprintf(colInfo.formatStr, colInfo.key)
+		firstRow += " "
 	}
 	result = append(result, firstRow)
 	result = append(result, strings.Repeat("-", len(firstRow)))
-	for _, ts := range tss {
-		row := rowData[ts]
-		rowStr := fmt.Sprintf(rowPrefixFmt, ts)
-		for i, v := range row {
-			rowStr += fmt.Sprintf(fmt.Sprintf("%%%ds ", foundKeys[i].maxValueLength), v)
+
+	for _, ts := range tsSeq {
+		row := sparseTable[ts]
+		rowStr := fmt.Sprintf(rowPrefixFmt, ts/time.Second.Nanoseconds())
+		curLen := 0
+		for _, key := range keySeq {
+			if v, ok := row[key]; ok {
+				colInfo := keyData[key]
+				pos := colInfo.position
+				gap := pos - curLen
+				valStr := strings.Repeat(" ", gap)
+				if len(v.endKey) > 0 {
+					rangeEnd := keyData[v.endKey].position
+					rangeLen := rangeEnd - pos - len(v.value)
+					valStr += v.value + strings.Repeat("-", rangeLen)
+				} else {
+					valStr += fmt.Sprintf(colInfo.formatStr, v.value)
+				}
+				rowStr += valStr
+				curLen += len(valStr)
+			}
 		}
 		result = append(result, rowStr)
 	}

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -482,7 +482,9 @@ func (r *replicaGCer) SetGCThreshold(ctx context.Context, thresh gc.Threshold) e
 	return r.send(ctx, req)
 }
 
-func (r *replicaGCer) GC(ctx context.Context, keys []roachpb.GCRequest_GCKey) error {
+func (r *replicaGCer) GC(
+	ctx context.Context, keys []roachpb.GCRequest_GCKey, rangeKeys []roachpb.GCRequest_GCRangeKey,
+) error {
 	if len(keys) == 0 {
 		return nil
 	}

--- a/pkg/kv/kvserver/rditer/replica_data_iter.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter.go
@@ -253,6 +253,7 @@ func (ri *ReplicaMVCCDataIterator) tryCloseAndCreateIter() {
 			storage.IterOptions{
 				LowerBound: ri.ranges[ri.curIndex].Start,
 				UpperBound: ri.ranges[ri.curIndex].End,
+				KeyTypes:   storage.IterKeyTypePointsAndRanges,
 			})
 		if ri.reverse {
 			ri.it.SeekLT(storage.MakeMVCCMetadataKey(ri.ranges[ri.curIndex].End))
@@ -340,10 +341,29 @@ func (ri *ReplicaMVCCDataIterator) UnsafeKey() storage.MVCCKey {
 	return ri.it.UnsafeKey()
 }
 
+// RangeBounds returns the range bounds for the current range key, or an
+// empty span if there are none. The returned keys are only valid until the
+// next iterator call.
+func (ri *ReplicaMVCCDataIterator) RangeBounds() roachpb.Span {
+	return ri.it.RangeBounds()
+}
+
 // UnsafeValue returns the same value as Value, but the memory is invalidated on
 // the next call to {Next,Prev,Close}.
 func (ri *ReplicaMVCCDataIterator) UnsafeValue() []byte {
 	return ri.it.UnsafeValue()
+}
+
+// RangeKeys exposes RangeKeys from underlying iterator. See
+// storage.SimpleMVCCIterator for details.
+func (ri *ReplicaMVCCDataIterator) RangeKeys() []storage.MVCCRangeKeyValue {
+	return ri.it.RangeKeys()
+}
+
+// HasPointAndRange exposes HasPointAndRange from underlying iterator. See
+// storage.SimpleMVCCIterator for details.
+func (ri *ReplicaMVCCDataIterator) HasPointAndRange() (bool, bool) {
+	return ri.it.HasPointAndRange()
 }
 
 // NewReplicaEngineDataIterator creates a ReplicaEngineDataIterator for the

--- a/pkg/kv/kvserver/rditer/replica_data_iter_test.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter_test.go
@@ -122,7 +122,11 @@ func createRangeData(
 }
 
 func verifyRDReplicatedOnlyMVCCIter(
-	t *testing.T, desc *roachpb.RangeDescriptor, eng storage.Engine, expectedKeys []storage.MVCCKey,
+	t *testing.T,
+	desc *roachpb.RangeDescriptor,
+	eng storage.Engine,
+	expectedKeys []storage.MVCCKey,
+	expectedRangeKeys []storage.MVCCRangeKey,
 ) {
 	t.Helper()
 	verify := func(t *testing.T, useSpanSet, reverse bool) {
@@ -146,22 +150,47 @@ func verifyRDReplicatedOnlyMVCCIter(
 		}
 		iter := NewReplicaMVCCDataIterator(desc, readWriter, reverse /* seekEnd */)
 		defer iter.Close()
+		next := iter.Next
+		if reverse {
+			next = iter.Prev
+		}
+		var rangeStart roachpb.Key
 		actualKeys := []storage.MVCCKey{}
+		actualRanges := []storage.MVCCRangeKey{}
 		for {
 			ok, err := iter.Valid()
 			require.NoError(t, err)
 			if !ok {
 				break
 			}
-			if !reverse {
-				actualKeys = append(actualKeys, iter.Key())
-				iter.Next()
-			} else {
-				actualKeys = append([]storage.MVCCKey{iter.Key()}, actualKeys...)
-				iter.Prev()
+			p, r := iter.HasPointAndRange()
+			if p {
+				if !reverse {
+					actualKeys = append(actualKeys, iter.Key())
+				} else {
+					actualKeys = append([]storage.MVCCKey{iter.Key()}, actualKeys...)
+				}
 			}
+			if r {
+				rks := iter.RangeKeys()
+				if !rks[0].RangeKey.StartKey.Equal(rangeStart) {
+					if !reverse {
+						for _, rk := range rks {
+							actualRanges = append(actualRanges, rk.RangeKey.Clone())
+						}
+					} else {
+						for i := len(rks) - 1; i >= 0; i-- {
+							actualRanges = append([]storage.MVCCRangeKey{rks[i].RangeKey.Clone()},
+								actualRanges...)
+						}
+					}
+					rangeStart = rks[0].RangeKey.StartKey.Clone()
+				}
+			}
+			next()
 		}
 		require.Equal(t, expectedKeys, actualKeys)
+		require.Equal(t, expectedRangeKeys, actualRanges)
 	}
 	testutils.RunTrueAndFalse(t, "reverse", func(t *testing.T, reverse bool) {
 		testutils.RunTrueAndFalse(t, "spanset", func(t *testing.T, useSpanSet bool) {
@@ -230,7 +259,7 @@ func TestReplicaDataIteratorEmptyRange(t *testing.T) {
 		EndKey:   roachpb.RKey("z"),
 	}
 
-	verifyRDReplicatedOnlyMVCCIter(t, desc, eng, []storage.MVCCKey{})
+	verifyRDReplicatedOnlyMVCCIter(t, desc, eng, []storage.MVCCKey{}, []storage.MVCCRangeKey{})
 	verifyRDEngineIter(t, desc, eng, false, []interface{}{})
 	verifyRDEngineIter(t, desc, eng, true, []interface{}{})
 }
@@ -282,16 +311,19 @@ func TestReplicaDataIterator(t *testing.T) {
 			verifyRDEngineIter(t, &tc.desc, eng, true, tc.replicatedKeys)
 
 			// Verify the replicated MVCC contents.
-			//
-			// TODO(erikgrinaker): This currently only supports MVCC point keys, so we
-			// ignore MVCC range keys for now.
 			var pointKeys []storage.MVCCKey
+			var rangeKeys []storage.MVCCRangeKey
 			for _, key := range tc.replicatedKeys {
 				if pointKey, ok := key.(storage.MVCCKey); ok {
 					pointKeys = append(pointKeys, pointKey)
+				} else if rangeKey, ok := key.(storage.MVCCRangeKey); ok {
+					// TODO(oleg): This is very naive and only works if keys don't overlap.
+					// Needs some thinking on how could we use this if ranges become
+					// fragmented.
+					rangeKeys = append(rangeKeys, rangeKey)
 				}
 			}
-			verifyRDReplicatedOnlyMVCCIter(t, &tc.desc, eng, pointKeys)
+			verifyRDReplicatedOnlyMVCCIter(t, &tc.desc, eng, pointKeys, rangeKeys)
 		})
 	}
 }

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -936,11 +936,19 @@ message HeartbeatTxnResponse {
 message GCRequest {
   RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 
+  // Point keys
   message GCKey {
     bytes key = 1 [(gogoproto.casttype) = "Key"];
     util.hlc.Timestamp timestamp = 2 [(gogoproto.nullable) = false];
   }
   repeated GCKey keys = 3 [(gogoproto.nullable) = false];
+  // Range keys
+  message GCRangeKey {
+    bytes startKey = 1 [(gogoproto.casttype) = "Key"];
+    bytes endKey = 2 [(gogoproto.casttype) = "Key"];
+    util.hlc.Timestamp timestamp = 3 [(gogoproto.nullable) = false];
+  }
+  repeated GCRangeKey rangeKeys = 6 [(gogoproto.nullable) = false];
   // Threshold is the expiration timestamp.
   util.hlc.Timestamp threshold = 4 [(gogoproto.nullable) = false];
 

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -990,7 +990,7 @@ func mvccGetMetadata(
 		if !hasPoint || !unsafeKey.Key.Equal(metaKey.Key) {
 			meta.Deleted = true
 			meta.Timestamp = rkTimestamp.ToLegacyTimestamp()
-			return true, int64(EncodedMVCCKeyPrefixLength(metaKey.Key)), 0, hlc.Timestamp{}, nil
+			return true, 0, 0, hlc.Timestamp{}, nil
 		}
 	}
 
@@ -4085,8 +4085,6 @@ func MVCCResolveWriteIntentRange(
 // not a mix of the two. This is to accommodate the implementation below
 // that creates an iterator with bounds that span from the first to last
 // key (in sorted order).
-//
-// TODO(erikgrinaker): This must handle MVCC range tombstones.
 func MVCCGarbageCollect(
 	ctx context.Context,
 	rw ReadWriter,
@@ -4119,32 +4117,78 @@ func MVCCGarbageCollect(
 	iter := rw.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
 		LowerBound: keys[0].Key,
 		UpperBound: keys[len(keys)-1].Key.Next(),
+		KeyTypes:   IterKeyTypePointsAndRanges,
 	})
 	defer iter.Close()
 	supportsPrev := iter.SupportsPrev()
+
+	// To update mvcc stats, we need to go through range tombstones to determine
+	// GCBytesAge. That requires copying current stack of range keys covering
+	// point since returned range key values are unsafe. We try to cache those
+	// copies by checking start of range.
+	var lastRangeTombstoneStart roachpb.Key
+	var rangeTombstoneTss []hlc.Timestamp
 
 	// Iterate through specified GC keys.
 	meta := &enginepb.MVCCMetadata{}
 	for _, gcKey := range keys {
 		encKey := MakeMVCCMetadataKey(gcKey.Key)
-		ok, metaKeySize, metaValSize, _, err := mvccGetMetadata(iter, encKey, meta)
+		// TODO(oleg): Results of this call are not obvious and logic to handle
+		// stats updates for different real and synthesized metadata becomes
+		// unnecessary complicated. Revisit this to make it cleaner.
+		ok, metaKeySize, metaValSize, realKeyChanged, err := mvccGetMetadata(iter, encKey, meta)
 		if err != nil {
 			return err
 		}
 		if !ok {
 			continue
 		}
+
+		// If mvccGetMetadata landed on a bare range tombstone for the key it will
+		// synthesize deletion meta. We need to filter this case out to avoid
+		// updating key stats as the key doesn't exist.
+		// Empty realKeyChanged is an indication that there are no values for the
+		// key present, but it may contain an inlined metadata which we filter out
+		// by checking that it is not inlined.
+		// In that case, we can skip to the next gc key as there's nothing to GC.
+		// As a side effect of this change, we should be positioned on the point
+		// key or inlined meta at this point and can do further checks for GC
+		// eligibility.
 		inlinedValue := meta.IsInline()
-		implicitMeta := iter.UnsafeKey().IsValue()
-		// First, check whether all values of the key are being deleted.
+		if realKeyChanged.IsEmpty() && !inlinedValue {
+			continue
+		}
+
+		// We are guaranteed now to be positioned at the meta or version key that
+		// belongs to gcKey history.
+
+		unsafeKey := iter.UnsafeKey()
+		implicitMeta := unsafeKey.IsValue()
+		// First check for the case of range tombstone covering keys when no
+		// metadata is available.
 		//
 		// Note that we naively can't terminate GC'ing keys loop early if we
-		// enter this branch, as it will update the stats under the provision
-		// that the (implicit or explicit) meta key (and thus all versions) are
-		// being removed. We had this faulty functionality at some point; it
-		// should no longer be necessary since the higher levels already make
-		// sure each individual GCRequest does bounded work.
-		if meta.Timestamp.ToTimestamp().LessEq(gcKey.Timestamp) {
+		// enter any of branches below, as it will update the stats under the
+		// provision that the (implicit or explicit) meta key (and thus all
+		// versions) are being removed. We had this faulty functionality at some
+		// point; it should no longer be necessary since the higher levels already
+		// make sure each individual GCRequest does bounded work.
+		if implicitMeta && meta.Deleted && !unsafeKey.Timestamp.Equal(realKeyChanged) {
+			// If we have implicit deletion meta, and realKeyChanged is not the first
+			// key in history, that means it is covered by a range tombstone (which
+			// was used to synthesize meta).
+			if unsafeKey.Timestamp.LessEq(gcKey.Timestamp) {
+				// If first object in history is at or below gcKey timestamp then we
+				// have no explicit meta and all objects are subject to deletion.
+				if ms != nil {
+					ms.Add(updateStatsOnGC(gcKey.Key, metaKeySize, metaValSize, meta,
+						realKeyChanged.WallTime))
+				}
+			}
+		} else if meta.Timestamp.ToTimestamp().LessEq(gcKey.Timestamp) {
+			// Then, check whether all values of the key are being deleted in the
+			// rest of the cases.
+			//
 			// For version keys, don't allow GC'ing the meta key if it's
 			// not marked deleted. However, for inline values we allow it;
 			// they are internal and GCing them directly saves the extra
@@ -4185,11 +4229,15 @@ func MVCCGarbageCollect(
 		// first garbage version.
 		prevNanos := timestamp.WallTime
 		{
-
+			// If true - forward iteration positioned iterator on first garbage
+			// (key.ts <= gc.ts).
 			var foundPrevNanos bool
 			{
 				// If reverse iteration is supported (supportsPrev), we'll step the
 				// iterator a few time before attempting to seek.
+
+				// True if we found next key while iterating. That means there's no
+				// garbage for the key.
 				var foundNextKey bool
 
 				// If there are a large number of versions which are not garbage,
@@ -4210,6 +4258,10 @@ func MVCCGarbageCollect(
 					if ok, err := iter.Valid(); err != nil {
 						return err
 					} else if !ok {
+						foundNextKey = true
+						break
+					}
+					if hasPoint, _ := iter.HasPointAndRange(); !hasPoint {
 						foundNextKey = true
 						break
 					}
@@ -4254,6 +4306,31 @@ func MVCCGarbageCollect(
 			}
 		}
 
+		// At this point iterator is positioned on first garbage version and forward
+		// iteration will give us all versions to delete up to the next key.
+
+		if ms != nil {
+			// We need to iterate ranges only to compute GCBytesAge if we are updating
+			// stats.
+			if _, hasRange := iter.HasPointAndRange(); hasRange && !lastRangeTombstoneStart.Equal(iter.RangeBounds().Key) {
+				rangeKeys := iter.RangeKeys()
+				newLen := len(rangeKeys)
+				if cap(rangeTombstoneTss) < newLen {
+					rangeTombstoneTss = make([]hlc.Timestamp, newLen)
+				} else {
+					rangeTombstoneTss = rangeTombstoneTss[:newLen]
+				}
+				for i, rkv := range rangeKeys {
+					rangeTombstoneTss[i] = rkv.RangeKey.Timestamp
+				}
+				lastRangeTombstoneStart = append(lastRangeTombstoneStart[:0], rangeKeys[0].RangeKey.StartKey...)
+			} else if !hasRange {
+				lastRangeTombstoneStart = lastRangeTombstoneStart[:0]
+				rangeTombstoneTss = rangeTombstoneTss[:0]
+			}
+		}
+		rangeIdx := 0
+
 		// Iterate through the garbage versions, accumulating their stats and
 		// issuing clear operations.
 		for ; ; iter.Next() {
@@ -4287,6 +4364,19 @@ func MVCCGarbageCollect(
 				fromNS := prevNanos
 				if unsafeVal.IsTombstone() {
 					fromNS = unsafeIterKey.Timestamp.WallTime
+				} else {
+					// For non deletions, we need to find if we had a range tombstone
+					// between this and next value (prevNanos) to use its timestamp for
+					// computing GCBytesAge.
+					for ; rangeIdx < len(rangeTombstoneTss); rangeIdx++ {
+						rangeTS := rangeTombstoneTss[rangeIdx]
+						if rangeTombstoneTss[rangeIdx].Less(unsafeIterKey.Timestamp) {
+							break
+						}
+						if rangeTS.WallTime < fromNS {
+							fromNS = rangeTS.WallTime
+						}
+					}
 				}
 
 				ms.Add(updateStatsOnGC(gcKey.Key, keySize, valSize, nil, fromNS))

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -4772,14 +4772,16 @@ func TestMVCCGarbageCollect(t *testing.T) {
 
 			ms := &enginepb.MVCCStats{}
 
-			bytes := []byte("value")
+			val := []byte("value")
 			ts1 := hlc.Timestamp{WallTime: 1e9}
 			ts2 := hlc.Timestamp{WallTime: 2e9}
 			ts3 := hlc.Timestamp{WallTime: 3e9}
-			val1 := roachpb.MakeValueFromBytesAndTimestamp(bytes, ts1)
-			val2 := roachpb.MakeValueFromBytesAndTimestamp(bytes, ts2)
-			val3 := roachpb.MakeValueFromBytesAndTimestamp(bytes, ts3)
-			valInline := roachpb.MakeValueFromBytesAndTimestamp(bytes, hlc.Timestamp{})
+			ts4 := hlc.Timestamp{WallTime: 4e9}
+			ts5 := hlc.Timestamp{WallTime: 4e9}
+			val1 := roachpb.MakeValueFromBytesAndTimestamp(val, ts1)
+			val2 := roachpb.MakeValueFromBytesAndTimestamp(val, ts2)
+			val3 := roachpb.MakeValueFromBytesAndTimestamp(val, ts3)
+			valInline := roachpb.MakeValueFromBytesAndTimestamp(val, hlc.Timestamp{})
 
 			testData := []struct {
 				key       roachpb.Key
@@ -4791,6 +4793,10 @@ func TestMVCCGarbageCollect(t *testing.T) {
 				{roachpb.Key("b"), []roachpb.Value{val1, val2, val3}, false},
 				{roachpb.Key("b-del"), []roachpb.Value{val1, val2, val3}, true},
 				{roachpb.Key("inline"), []roachpb.Value{valInline}, false},
+				{roachpb.Key("r-2"), []roachpb.Value{val1}, false},
+				{roachpb.Key("r-3"), []roachpb.Value{val1}, false},
+				{roachpb.Key("r-4"), []roachpb.Value{val1}, false},
+				{roachpb.Key("t"), []roachpb.Value{val1}, false},
 			}
 
 			for i := 0; i < 3; i++ {
@@ -4800,30 +4806,46 @@ func TestMVCCGarbageCollect(t *testing.T) {
 					}
 					for _, val := range test.vals[i : i+1] {
 						if i == len(test.vals)-1 && test.isDeleted {
-							if err := MVCCDelete(ctx, engine, ms, test.key, val.Timestamp, hlc.ClockTimestamp{}, nil); err != nil {
+							if err := MVCCDelete(ctx, engine, ms, test.key, val.Timestamp, hlc.ClockTimestamp{},
+								nil); err != nil {
 								t.Fatal(err)
 							}
 							continue
 						}
 						valCpy := *protoutil.Clone(&val).(*roachpb.Value)
 						valCpy.Timestamp = hlc.Timestamp{}
-						if err := MVCCPut(ctx, engine, ms, test.key, val.Timestamp, hlc.ClockTimestamp{}, valCpy, nil); err != nil {
+						if err := MVCCPut(ctx, engine, ms, test.key, val.Timestamp, hlc.ClockTimestamp{},
+							valCpy, nil); err != nil {
 							t.Fatal(err)
 						}
 					}
 				}
+			}
+			if err := MVCCDeleteRangeUsingTombstone(ctx, engine, ms, roachpb.Key("r"),
+				roachpb.Key("r-del").Next(), ts3, hlc.ClockTimestamp{}, nil, nil, 0); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCDeleteRangeUsingTombstone(ctx, engine, ms, roachpb.Key("t"),
+				roachpb.Key("u").Next(), ts2, hlc.ClockTimestamp{}, nil, nil, 0); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCDeleteRangeUsingTombstone(ctx, engine, ms, roachpb.Key("t"),
+				roachpb.Key("u").Next(), ts3, hlc.ClockTimestamp{}, nil, nil, 0); err != nil {
+				t.Fatal(err)
 			}
 			if log.V(1) {
 				kvsn, err := Scan(engine, localMax, keyMax, 0)
 				if err != nil {
 					t.Fatal(err)
 				}
+				log.Info(context.Background(), "before")
 				for i, kv := range kvsn {
 					log.Infof(context.Background(), "%d: %s", i, kv.Key)
 				}
 			}
 
-			keys := []roachpb.GCRequest_GCKey{
+			gcTime := ts5
+			gcKeys := []roachpb.GCRequest_GCKey{
 				{Key: roachpb.Key("a"), Timestamp: ts1},
 				{Key: roachpb.Key("a-del"), Timestamp: ts2},
 				{Key: roachpb.Key("b"), Timestamp: ts1},
@@ -4832,11 +4854,39 @@ func TestMVCCGarbageCollect(t *testing.T) {
 				// Keys that don't exist, which should result in a no-op.
 				{Key: roachpb.Key("a-bad"), Timestamp: ts2},
 				{Key: roachpb.Key("inline-bad"), Timestamp: hlc.Timestamp{}},
+				// Keys that are hidden by range key.
+				// Non-existing keys that needs to skip gracefully without
+				// distorting stats. (Checking that following keys doesn't affect it)
+				{Key: roachpb.Key("r-0"), Timestamp: ts1},
+				{Key: roachpb.Key("r-1"), Timestamp: ts4},
+				// Request has a timestamp below range key, it will be handled by
+				// logic processing range tombstones specifically.
+				{Key: roachpb.Key("r-2"), Timestamp: ts1},
+				// Requests has a timestamp at or above range key, it will be handled by
+				// logic processing synthesized metadata.
+				{Key: roachpb.Key("r-3"), Timestamp: ts3},
+				{Key: roachpb.Key("r-4"), Timestamp: ts4},
+				// This is a non-existing key that needs to skip gracefully without
+				// distorting stats. Checking that absence of next key is handled.
+				{Key: roachpb.Key("r-5"), Timestamp: ts4},
+
+				{Key: roachpb.Key("t"), Timestamp: ts4},
 			}
 			if err := MVCCGarbageCollect(
-				context.Background(), engine, ms, keys, ts3,
+				context.Background(), engine, ms, gcKeys, gcTime,
 			); err != nil {
 				t.Fatal(err)
+			}
+
+			if log.V(1) {
+				kvsn, err := Scan(engine, localMax, keyMax, 0)
+				if err != nil {
+					t.Fatal(err)
+				}
+				log.Info(context.Background(), "after")
+				for i, kv := range kvsn {
+					log.Infof(context.Background(), "%d: %s", i, kv.Key)
+				}
 			}
 
 			expEncKeys := []MVCCKey{
@@ -4859,11 +4909,12 @@ func TestMVCCGarbageCollect(t *testing.T) {
 			}
 
 			// Verify aggregated stats match computed stats after GC.
-			iter := engine.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: roachpb.KeyMax})
+			iter := engine.NewMVCCIterator(MVCCKeyAndIntentsIterKind,
+				IterOptions{UpperBound: roachpb.KeyMax, KeyTypes: IterKeyTypePointsAndRanges})
 			defer iter.Close()
 			for _, mvccStatsTest := range mvccStatsTests {
 				t.Run(mvccStatsTest.name, func(t *testing.T) {
-					expMS, err := mvccStatsTest.fn(iter, localMax, roachpb.KeyMax, ts3.WallTime)
+					expMS, err := mvccStatsTest.fn(iter, localMax, roachpb.KeyMax, gcTime.WallTime)
 					if err != nil {
 						t.Fatal(err)
 					}


### PR DESCRIPTION

Previously GC didn't take range tombstones into account
when removing old point data. This patch adds support for
removal of data hidden by range tombstones.

Release note: None