### PR TITLE
changefeedccl: Replan changefeed when topology changes

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/jobs/jobspb",
         "//pkg/roachpb",
         "//pkg/settings",
+        "//pkg/sql",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/flowinfra",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/ccl/changefeedccl/changefeedbase/errors.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/errors.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/joberror"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/errors"
 )
@@ -120,7 +121,8 @@ func IsRetryableError(err error) bool {
 
 	return (joberror.IsDistSQLRetryableError(err) ||
 		flowinfra.IsNoInboundStreamConnectionError(err) ||
-		errors.HasType(err, (*roachpb.NodeUnavailableError)(nil)))
+		errors.HasType(err, (*roachpb.NodeUnavailableError)(nil)) ||
+		errors.Is(err, sql.ErrPlanChanged))
 }
 
 // MaybeStripRetryableErrorMarker performs some minimal attempt to clean the

--- a/pkg/ccl/changefeedccl/metrics.go
+++ b/pkg/ccl/changefeedccl/metrics.go
@@ -322,6 +322,13 @@ var (
 		Measurement: "Updates",
 		Unit:        metric.Unit_COUNT,
 	}
+
+	metaChangefeedReplanCount = metric.Metadata{
+		Name:        "changefeed.replan_count",
+		Help:        "Number of replans triggered across all feeds",
+		Measurement: "Replans",
+		Unit:        metric.Unit_COUNT,
+	}
 )
 
 func newAggregateMetrics(histogramWindow time.Duration) *AggMetrics {
@@ -501,6 +508,7 @@ type Metrics struct {
 	CheckpointHistNanos *metric.Histogram
 	FrontierUpdates     *metric.Counter
 	ThrottleMetrics     cdcutils.Metrics
+	ReplanCount         *metric.Counter
 
 	mu struct {
 		syncutil.Mutex
@@ -531,6 +539,7 @@ func MakeMetrics(histogramWindow time.Duration) metric.Struct {
 			changefeedCheckpointHistMaxLatency.Nanoseconds(), 2),
 		FrontierUpdates: metric.NewCounter(metaChangefeedFrontierUpdates),
 		ThrottleMetrics: cdcutils.MakeMetrics(histogramWindow),
+		ReplanCount:     metric.NewCounter(metaChangefeedReplanCount),
 	}
 
 	m.mu.resolved = make(map[int]hlc.Timestamp)

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvfeed"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 )
@@ -42,6 +43,8 @@ type TestingKnobs struct {
 	NullSinkIsExternalIOAccounted bool
 	// OnDistflowSpec is called when specs for distflow planning have been created
 	OnDistflowSpec func(aggregatorSpecs []*execinfrapb.ChangeAggregatorSpec, frontierSpec *execinfrapb.ChangeFrontierSpec)
+	// ShouldReplan is used to see if a replan for a changefeed should be triggered
+	ShouldReplan func(ctx context.Context, oldPlan, newPlan *sql.PhysicalPlan) bool
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1367,6 +1367,12 @@ var charts = []sectionDescription{
 				},
 			},
 			{
+				Title: "Replan Count",
+				Metrics: []string{
+					"changefeed.replan_count",
+				},
+			},
+			{
 				Title: "Flushed Bytes",
 				Metrics: []string{
 					"changefeed.flushed_bytes",


### PR DESCRIPTION
cdc: created replanning functionality for changefeeds when topology changes
and added a metric to count number of replans. additionally, added a test
to test replanning functionality and metric counter.

See also: https://github.com/cockroachdb/cockroach/issues/82025

Release note (enterprise change): added replanning functionality for
changefeeds when topology changes with a replanning counter metric. this
functionality only works properly for serverless currently.