### PR TITLE
kvserver: fix buglet in Test_handleRaftReadyStats_SafeFormat

### DIFF
--- a/pkg/kv/kvserver/replica_raft_test.go
+++ b/pkg/kv/kvserver/replica_raft_test.go
@@ -67,8 +67,9 @@ func Test_handleRaftReadyStats_SafeFormat(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	now := timeutil.Now()
 	ts := func(s int) time.Time {
-		return timeutil.Now().Add(time.Duration(s) * time.Second)
+		return now.Add(time.Duration(s) * time.Second)
 	}
 
 	stats := handleRaftReadyStats{


### PR DESCRIPTION
We need a stable reference timestamp, or slow executions could result in
non-determinism.

Release note: None
