### PR TITLE
[CRDB-16103] ui: update wording on mixed version banner alert

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/alerts.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/alerts.ts
@@ -148,13 +148,14 @@ export const staggeredVersionWarningSelector = createSelector(
       return undefined;
     }
     const versionsText = Array.from(versionsMap)
-      .map(([k, v]) => `${v} nodes are running on ${k}`)
-      .join(" and ")
+      .map(([k, v]) => (v === 1 ? `1 node on ${k}` : `${v} nodes on ${k}`))
+      .join(", ")
       .concat(". ");
     return {
       level: AlertLevel.WARNING,
       title: "Multiple versions of CockroachDB are running on this cluster.",
       text:
+        "Listed versions: " +
         versionsText +
         `You can see a list of all nodes and their versions below.
         This may be part of a normal rolling upgrade process, but should be investigated


### PR DESCRIPTION
This patch updates the wording on the mixed version
banner alert. When 1 node is on a version the wording
is now displayed as "1 node on..." and
the previous wording stays the same when more than
1 node is on a version. The different node counts
on a particular version are now a comma separated
list.

Resolves #81877

Release note (ui change): fix grammer on mixed version
banner alert

![Screen Shot 2022-06-21 at 3 53 30 PM](https://user-images.githubusercontent.com/17861665/174886981-e16eff01-9e1e-49f3-a7b9-54e7821dec5d.png)