### PR TITLE
backupccl: make checkpoint interval configurable

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -799,6 +799,10 @@ func writeBackupManifestCheckpoint(
 	execCfg *sql.ExecutorConfig,
 	user username.SQLUsername,
 ) error {
+	var span *tracing.Span
+	ctx, span = tracing.ChildSpan(ctx, "write-backup-manifest-checkpoint")
+	defer span.Finish()
+
 	defaultStore, err := execCfg.DistSQLSrv.ExternalStorageFromURI(ctx, storageURI, user)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR makes the interval between checkpoints configurable and also
excludes the processing time of the checkpoint itself from that
interval.

The goal of this change is to potentially address issues we've seen in
large clusters that we currently believe can be attributed to the
backup process slowing down substantially once it takes a minute or
longer to marshall, compress, and write the progress checkpoint.

Release note (ops change): A new setting
`bulkio.backup.checkpoint_interval` controls the minimum interval
between writes of progress checkpoints to external storage.