### PR TITLE
kv: Allow leases to be transfered back to self

### DIFF
--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -861,7 +861,9 @@ func TestLeasesDontThrashWhenNodeBecomesSuspect(t *testing.T) {
 
 	for _, key := range startKeys {
 		repl := tc.GetFirstStoreFromServer(t, 1).LookupReplica(roachpb.RKey(key))
-		tc.TransferRangeLeaseOrFatal(t, *repl.Desc(), tc.Target(1))
+		if !repl.OwnsValidLease(ctx, tc.Servers[1].Clock().NowAsClockTimestamp()) {
+			tc.TransferRangeLeaseOrFatal(t, *repl.Desc(), tc.Target(1))
+		}
 		testutils.SucceedsSoon(t, func() error {
 			if !repl.OwnsValidLease(ctx, tc.Servers[1].Clock().NowAsClockTimestamp()) {
 				return errors.Errorf("Expected lease to transfer to server 1 for replica %s", repl)

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -860,10 +860,6 @@ func (r *Replica) AdminTransferLease(ctx context.Context, target roachpb.StoreID
 
 		now := r.store.Clock().NowAsClockTimestamp()
 		status := r.leaseStatusAtRLocked(ctx, now)
-		if status.Lease.OwnedBy(target) {
-			// The target is already the lease holder. Nothing to do.
-			return nil, nil, nil
-		}
 		desc := r.mu.state.Desc
 		if !status.Lease.OwnedBy(r.store.StoreID()) {
 			return nil, nil, newNotLeaseHolderError(status.Lease, r.store.StoreID(), desc,


### PR DESCRIPTION
Previously a lease could be transferred using AdminTransferLease
to a different node, but a call to transfer back to the original
node was a no-op. This is done to prepare the work for the fix
to #73292. Specifically the fix there is to self-transfer the lease
to restart the lease timestamp and get correct protection on merges.

A few unit tests needed to be modified to make this work, as they
were assuming that AdminTransferLease was idempotent, when in
fact it was only lucky that they worked.

Release note: None