### PR TITLE
workload/schemachanger: address intermittent failures linked to inserts

### DIFF
--- a/pkg/workload/schemachange/error_code_set.go
+++ b/pkg/workload/schemachange/error_code_set.go
@@ -62,6 +62,15 @@ type codesWithConditions []struct {
 	condition bool
 }
 
+func (c codesWithConditions) append(code pgcode.Code) codesWithConditions {
+	return append(c, codesWithConditions{
+		{
+			code:      code,
+			condition: true,
+		},
+	}...)
+}
+
 func (c codesWithConditions) add(s errorCodeSet) {
 	for _, cc := range c {
 		if cc.condition {

--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -589,7 +589,7 @@ func (og *operationGenerator) validateGeneratedExpressionsForInsert(
 					// We intentionally use NULL in case any division operations are encountered.
 					// This reduces odds of extra overflows, but these will be evaluated as
 					// potential errors not expected ones.
-					nonNullValue = fmt.Sprintf("1:::%s", colInfos[colIdx].typ.SQLString())
+					nonNullValue = fmt.Sprintf("1::%s", colInfos[colIdx].typ.SQLString())
 				}
 			}
 			query.WriteString(value)

--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -1230,13 +1230,17 @@ func (og *operationGenerator) violatesFkConstraintsHelper(
 					return false, err
 				}
 			}
+			// Skip over NULL values.
+			if parentValueInSameInsert == "NULL" {
+				continue
+			}
 			parentAndChildSameQueryColumns = append(parentAndChildSameQueryColumns,
 				fmt.Sprintf("%s = %s", parentValueInSameInsert, childValue))
 		}
 	}
 	checkSharedParentChildRows := ""
 	if len(parentAndChildSameQueryColumns) > 0 {
-		checkSharedParentChildRows = fmt.Sprintf("false = ANY (ARRAY [%s]) OR",
+		checkSharedParentChildRows = fmt.Sprintf("false = ANY (ARRAY [%s]) AND",
 			strings.Join(parentAndChildSameQueryColumns, ","))
 	}
 	return og.scanBool(ctx, tx, fmt.Sprintf(`

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -2316,6 +2316,10 @@ func (og *operationGenerator) insertRow(ctx context.Context, tx pgx.Tx) (sq stri
 				d = tree.NewDOid(randgen.RandColumnType(og.params.rng).Oid())
 			}
 			str := tree.AsStringWithFlags(d, tree.FmtParsable)
+			// For strings use the actual type, so that comparisons for NULL values are sane.
+			if col.typ.Family() == types.StringFamily {
+				str = strings.Replace(str, ":::STRING", fmt.Sprintf("::%s", col.typ.SQLString()), -1)
+			}
 			row = append(row, str)
 		}
 

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -2324,10 +2324,12 @@ func (og *operationGenerator) insertRow(ctx context.Context, tx pgx.Tx) (sq stri
 	// Verify that none of the generated expressions will blow up on this insert.
 	anyInvalidInserts := false
 	for _, row := range rows {
-		invalidInsert, generatedErrors, err := og.validateGeneratedExpressionsForInsert(ctx, tx, tableName, colNames, allColumns, row)
+		invalidInsert, generatedErrors, potentialErrors, err := og.validateGeneratedExpressionsForInsert(ctx, tx, tableName, colNames, allColumns, row)
 		if err != nil {
 			return "", err
 		}
+		// We may have errors that are possible, but not guaranteed.
+		potentialErrors.add(og.potentialExecErrors)
 		if invalidInsert {
 			generatedErrors.add(og.expectedExecErrors)
 			// We will be pessimistic and assume that other column related errors can


### PR DESCRIPTION
These failures were caused by the following test issues:

1. FK duplicate detection for self-references (within a transaction) had incorrect logic, leading to false positives.
2. Unique value detection was broken due to the casting text types as STRING, which would cause certain comparisons to fail. These same comparisons would be correct for indexes.
3. Generated column errors were not correctly detected for NULL numeric columns, since the order of operations during an INSERT could differ. Based on which variables are bound.