### PR TITLE
pgwire: fix for specific cases of unnamed portal execution

### DIFF
--- a/pkg/sql/pgwire/testdata/pgtest/portals
+++ b/pkg/sql/pgwire/testdata/pgtest/portals
@@ -1394,3 +1394,81 @@ ReadyForQuery
 {"Type":"DataRow","Values":[{"text":"2"}]}
 {"Type":"CommandComplete","CommandTag":"FETCH 2"}
 {"Type":"ReadyForQuery","TxStatus":"T"}
+
+# Test for executing/re-preparing unnamed portal. PG docs say:
+# "An unnamed portal is destroyed at the end of the transaction, or as soon as
+# the next Bind statement specifying the unnamed portal as destination is
+# issued. (Note that a simple Query message also destroys the unnamed portal.)"
+
+send
+Parse {"Query": "SELECT * FROM generate_series(1, 4)"}
+Bind
+Execute {"MaxRows": 1}
+Parse {"Name": "s17", "Query": "SELECT * FROM generate_series(10, 14)"}
+Bind {"PreparedStatement": "s17"}
+Execute {"MaxRows": 1}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"1"}]}
+{"Type":"PortalSuspended"}
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"10"}]}
+{"Type":"PortalSuspended"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# A Describe between Parse and Bind is also allowed.
+
+send
+Parse {"Query": "SELECT * FROM generate_series(1, 4)"}
+Bind
+Execute {"MaxRows": 1}
+Parse {"Query": "SELECT n::INT4 FROM generate_series(10, 14) n"}
+Describe  {"ObjectType": "S"}
+Bind
+Execute {"MaxRows": 1}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"1"}]}
+{"Type":"PortalSuspended"}
+{"Type":"ParseComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":null}
+{"Type":"RowDescription","Fields":[{"Name":"n","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":23,"DataTypeSize":4,"TypeModifier":-1,"Format":0}]}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"10"}]}
+{"Type":"PortalSuspended"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Parse {"Query": "SELECT * FROM generate_series(1, 4)"}
+Bind
+Execute {"MaxRows": 1}
+Query {"String": "SELECT n::INT4 FROM generate_series(10, 12) n"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"1"}]}
+{"Type":"PortalSuspended"}
+{"Type":"RowDescription","Fields":[{"Name":"n","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":23,"DataTypeSize":4,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"10"}]}
+{"Type":"DataRow","Values":[{"text":"11"}]}
+{"Type":"DataRow","Values":[{"text":"12"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 3"}
+{"Type":"ReadyForQuery","TxStatus":"I"}


### PR DESCRIPTION
refs https://github.com/MagicStack/asyncpg/issues/580#issuecomment-1159097540

The Postgres docs say that an unnamed portal is automatically closed
when a Bind command for another unnamed portal or a simple query is
sent. We already implemented that for "normal" portals, but not for
portals that were partially executed.

This does not address the general case, but it does handle the common
case that we see from tools like asyncpg.

Release note (bug fix): Previously, executing an unnamed portal with a
row count limit could encounter errors if another unnamed portal was
opened. Now, CockroachDB correctly handles the common case of preparing
and binding an unnamed portal by closing the existing unnamed portal.
This matches the Postgres wire protocol.