### PR TITLE
ui/cluster-ui: fix transaction details stmts table pagination

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -207,16 +207,26 @@ export class TransactionDetails extends React.Component<
     const statementFingerprintIds =
       transaction?.stats_data?.statement_fingerprint_ids;
 
-    return (
-      (statementFingerprintIds &&
-        getStatementsByFingerprintId(statementFingerprintIds, statements)) ||
-      []
+    if (!statementFingerprintIds) {
+      return [];
+    }
+
+    // Get all the stmts matching the transaction's fingerprint ID. Then we filter
+    // by those statements actually associated with the current transaction.
+    const stmts = getStatementsByFingerprintId(
+      statementFingerprintIds,
+      statements,
+    ).filter(
+      s =>
+        s.key.key_data.transaction_fingerprint_id.toString() ===
+        this.props.transactionFingerprintId,
     );
+
+    return stmts;
   };
 
   render(): React.ReactElement {
-    const { error, nodeRegions, transaction, transactionFingerprintId } =
-      this.props;
+    const { error, nodeRegions, transaction } = this.props;
     const { latestTransactionText } = this.state;
     const statementsForTransaction = this.getStatementsForTransaction();
     const transactionStats = transaction?.stats_data?.stats;
@@ -275,12 +285,10 @@ export class TransactionDetails extends React.Component<
 
             const { isTenant, hasViewActivityRedactedRole } = this.props;
             const { sortSetting, pagination } = this.state;
-            const txnScopedStmts = statementsForTransaction.filter(
-              s =>
-                s.key.key_data.transaction_fingerprint_id.toString() ===
-                transactionFingerprintId,
+
+            const aggregatedStatements = aggregateStatements(
+              statementsForTransaction,
             );
-            const aggregatedStatements = aggregateStatements(txnScopedStmts);
             populateRegionNodeForStatements(
               aggregatedStatements,
               nodeRegions,
@@ -424,7 +432,7 @@ export class TransactionDetails extends React.Component<
                   </Row>
                   <TableStatistics
                     pagination={pagination}
-                    totalCount={statementsForTransaction.length}
+                    totalCount={aggregatedStatements.length}
                     arrayItemName={
                       "statement fingerprints for this transaction"
                     }
@@ -451,7 +459,7 @@ export class TransactionDetails extends React.Component<
                 <Pagination
                   pageSize={pagination.pageSize}
                   current={pagination.current}
-                  total={statementsForTransaction.length}
+                  total={aggregatedStatements.length}
                   onChange={this.onChangePage}
                 />
               </React.Fragment>

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
@@ -57,8 +57,9 @@ export const getStatementsByFingerprintId = (
   statementFingerprintIds: Long[],
   statements: Statement[],
 ): Statement[] => {
-  return statements?.filter(s =>
-    statementFingerprintIds.some(id => id.eq(s.id)),
+  return (
+    statements?.filter(s => statementFingerprintIds.some(id => id.eq(s.id))) ||
+    []
   );
 };
 


### PR DESCRIPTION
Previously, the pagination used by the stmts table in the
transaction details page used the length associated with
the unaggregated list of statements retrieved for a
transaction. This lead to the table reporting more
stmts for a transaction than available.

Release note (bug fix): The statements table for a txn
in the txn details page now shows the correct number of
stmts for a transaction.

Before: There are clearly 5 statements in the txn text and stmts table, but the stmts table pagination shows 9.
<img width="1162" alt="image" src="https://user-images.githubusercontent.com/20136951/175074289-3592ae74-74f5-4373-be2e-7de0082ad369.png">

After: correct number of stmts reported
<img width="1170" alt="image" src="https://user-images.githubusercontent.com/20136951/175074722-f61b306e-f87b-45af-a354-3ee8d81dfea0.png">

