### PR TITLE
release-22.1: sql: fix panic caused by inject_retry_errors_enabled

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1149,7 +1149,9 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 		// numTxnRetryErrors is the number of times an error will be injected if
 		// the transaction is retried using SAVEPOINTs.
 		const numTxnRetryErrors = 3
-		if ex.sessionData().InjectRetryErrorsEnabled && stmt.AST.StatementTag() != "SET" {
+		isSetOrShow := stmt.AST.StatementTag() == "SET" || stmt.AST.StatementTag() == "SHOW"
+		if ex.sessionData().InjectRetryErrorsEnabled && !isSetOrShow &&
+			planner.Txn().Sender().TxnStatus() == roachpb.PENDING {
 			if planner.Txn().Epoch() < ex.state.lastEpoch+numTxnRetryErrors {
 				retryErr := planner.Txn().GenerateForcedRetryableError(
 					ctx, "injected by `inject_retry_errors_enabled` session variable")

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -1447,6 +1447,12 @@ func TestInjectRetryErrors(t *testing.T) {
 			tx, err := db.BeginTx(ctx, nil)
 			require.NoError(t, err)
 
+			// Verify that SHOW is exempt from error injection.
+			var s string
+			err = tx.QueryRow("SHOW inject_retry_errors_enabled").Scan(&s)
+			require.NoError(t, err)
+			require.Equal(t, "on", s)
+
 			if attemptCount == 5 {
 				_, err = tx.Exec("SET LOCAL inject_retry_errors_enabled = 'false'")
 				require.NoError(t, err)
@@ -1463,6 +1469,21 @@ func TestInjectRetryErrors(t *testing.T) {
 			require.NoError(t, tx.Rollback())
 		}
 		require.Equal(t, 5, txRes)
+	})
+
+	t.Run("insert_outside_of_txn", func(t *testing.T) {
+		// Add a special test for INSERTs in an implicit txn, since the 1PC
+		// optimization leads to different transaction commit semantics.
+		_, err := db.ExecContext(ctx, "CREATE TABLE t (a INT)")
+		require.NoError(t, err)
+		_, err = db.ExecContext(ctx, "INSERT INTO t VALUES(1::INT)")
+		require.NoError(t, err)
+		var res int
+		err = db.QueryRow("SELECT a FROM t LIMIT 1").Scan(&res)
+		require.NoError(t, err)
+		require.Equal(t, 1, res)
+		_, err = db.ExecContext(ctx, "DROP TABLE t")
+		require.NoError(t, err)
 	})
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #83043.

/cc @cockroachdb/release

Release justification: fix a panic

---

fixes https://github.com/cockroachdb/cockroach/issues/83011

In addition to fixing the panic, this also improves the CLI error
reporting a little, which made this easier to debug.

Release note (bug fix): Fixed a panic that could happen if the
inject_retry_errors_enabled setting is true and an INSERT
is executed outside of an explicit transaction.
