### PR TITLE
release-22.1: cloud/gcp: support temporary token credentials for GCP storage and KMS

### DIFF
--- a/pkg/cloud/gcp/BUILD.bazel
+++ b/pkg/cloud/gcp/BUILD.bazel
@@ -26,7 +26,7 @@ go_library(
         "@org_golang_google_api//option",
         "@org_golang_google_genproto//googleapis/cloud/kms/v1:kms",
         "@org_golang_google_protobuf//types/known/wrapperspb",
-        "@org_golang_x_oauth2//google",
+        "@org_golang_x_oauth2//:oauth2",
     ],
 )
 
@@ -49,6 +49,8 @@ go_test(
         "//pkg/util/leaktest",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
+        "@com_google_cloud_go_kms//apiv1",
+        "@com_google_cloud_go_storage//:storage",
         "@org_golang_x_oauth2//google",
     ],
 )

--- a/pkg/cloud/gcp/gcs_storage.go
+++ b/pkg/cloud/gcp/gcs_storage.go
@@ -31,7 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/gogo/protobuf/types"
-	"golang.org/x/oauth2/google"
+	"golang.org/x/oauth2"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
@@ -43,6 +43,12 @@ const (
 	// CredentialsParam is the query parameter for the base64-encoded contents of
 	// the Google Application Credentials JSON file.
 	CredentialsParam = "CREDENTIALS"
+	// BearerTokenParam is the query parameter for a temporary bearer token. There
+	// is no refresh mechanism associated with this token, so it is up to the user
+	// to ensure that its TTL is longer than the duration of the job or query that
+	// is using the token. The job or query may irrecoverably fail if one of its
+	// tokens expire before completion.
+	BearerTokenParam = "BEARER_TOKEN"
 )
 
 // gcsChunkingEnabled is used to enable and disable chunking of file upload to
@@ -63,6 +69,7 @@ func parseGSURL(_ cloud.ExternalStorageURIContext, uri *url.URL) (roachpb.Extern
 		Auth:           uri.Query().Get(cloud.AuthParam),
 		BillingProject: uri.Query().Get(GoogleBillingProjectParam),
 		Credentials:    uri.Query().Get(CredentialsParam),
+		BearerToken:    uri.Query().Get(BearerTokenParam),
 	}
 	conf.GoogleCloudConfig.Prefix = strings.TrimLeft(conf.GoogleCloudConfig.Prefix, "/")
 	return conf, nil
@@ -114,29 +121,35 @@ func makeGCSStorage(
 			"implicit credentials disallowed for gs due to --external-io-disable-implicit-credentials flag")
 	}
 
+	var credentialsOpt []option.ClientOption
 	switch conf.Auth {
 	case cloud.AuthParamImplicit:
 		// Do nothing; use implicit params:
 		// https://godoc.org/golang.org/x/oauth2/google#FindDefaultCredentials
 	default:
-		if conf.Credentials == "" {
+		if conf.Credentials != "" {
+			authOption, err := createAuthOptionFromServiceAccountKey(conf.Credentials)
+			if err != nil {
+				return nil, errors.Wrapf(err, "error getting credentials from %s", CredentialsParam)
+			}
+			credentialsOpt = append(credentialsOpt, authOption)
+		} else if conf.BearerToken != "" {
+			credentialsOpt = append(credentialsOpt, createAuthOptionFromBearerToken(conf.BearerToken))
+		} else {
 			return nil, errors.Errorf(
-				"%s must be set unless %q is %q",
+				"%s or %s must be set if %q is %q",
 				CredentialsParam,
+				BearerTokenParam,
 				cloud.AuthParam,
 				cloud.AuthParamImplicit,
 			)
 		}
-		decodedKey, err := base64.StdEncoding.DecodeString(conf.Credentials)
-		if err != nil {
-			return nil, errors.Wrapf(err, "decoding value of %s", CredentialsParam)
-		}
-		source, err := google.JWTConfigFromJSON(decodedKey, scope)
-		if err != nil {
-			return nil, errors.Wrap(err, "creating GCS oauth token source from specified credentials")
-		}
-		opts = append(opts, option.WithTokenSource(source.TokenSource(ctx)))
 	}
+
+	// Once credentials have been obtained via implicit or specified params, we
+	// then check if we should use the credentials directly or whether they should
+	// be used to assume another role.
+	opts = append(opts, credentialsOpt...)
 	g, err := gcs.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create google cloud client")
@@ -153,6 +166,25 @@ func makeGCSStorage(
 		prefix:   conf.Prefix,
 		settings: args.Settings,
 	}, nil
+}
+
+// createAuthOptionFromServiceAccountKey creates an option.ClientOption for
+// authentication with the given Service Account key.
+func createAuthOptionFromServiceAccountKey(encodedKey string) (option.ClientOption, error) {
+	// Service Account keys are passed in base64 encoded, so decode it first.
+	credentialsJSON, err := base64.StdEncoding.DecodeString(encodedKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return option.WithCredentialsJSON(credentialsJSON), nil
+}
+
+// createAuthOptionFromBearerToken creates an option.ClientOption for
+// authentication with the given bearer token.
+func createAuthOptionFromBearerToken(bearerToken string) option.ClientOption {
+	token := &oauth2.Token{AccessToken: bearerToken}
+	return option.WithTokenSource(oauth2.StaticTokenSource(token))
 }
 
 func (g *gcsStorage) Writer(ctx context.Context, basename string) (io.WriteCloser, error) {
@@ -267,5 +299,5 @@ func (g *gcsStorage) Close() error {
 
 func init() {
 	cloud.RegisterExternalStorageProvider(roachpb.ExternalStorageProvider_gs,
-		parseGSURL, makeGCSStorage, cloud.RedactedParams(CredentialsParam), "gs")
+		parseGSURL, makeGCSStorage, cloud.RedactedParams(CredentialsParam, BearerTokenParam), "gs")
 }

--- a/pkg/cloud/gcp/gcs_storage_test.go
+++ b/pkg/cloud/gcp/gcs_storage_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"testing"
 
+	gcs "cloud.google.com/go/storage"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/cloud/cloudtestutils"
@@ -87,6 +88,42 @@ func TestPutGoogleCloud(t *testing.T) {
 				"listing-test",
 				cloud.AuthParam,
 				cloud.AuthParamImplicit,
+			),
+			security.RootUserName(), nil, nil, testSettings,
+		)
+	})
+
+	t.Run("auth-specified-bearer-token", func(t *testing.T) {
+		credentials := os.Getenv("GOOGLE_CREDENTIALS_JSON")
+		if credentials == "" {
+			skip.IgnoreLint(t, "GOOGLE_CREDENTIALS_JSON env var must be set")
+		}
+
+		ctx := context.Background()
+		source, err := google.JWTConfigFromJSON([]byte(credentials), gcs.ScopeReadWrite)
+		require.NoError(t, err, "creating GCS oauth token source from specified credentials")
+		ts := source.TokenSource(ctx)
+
+		token, err := ts.Token()
+		require.NoError(t, err, "getting token")
+
+		uri := fmt.Sprintf("gs://%s/%s?%s=%s",
+			bucket,
+			"backup-test-specified",
+			BearerTokenParam,
+			token.AccessToken,
+		)
+		uri += fmt.Sprintf("&%s=%s", cloud.AuthParam, cloud.AuthParamSpecified)
+		cloudtestutils.CheckExportStore(t, uri, false, user, nil, nil, testSettings)
+		cloudtestutils.CheckListFiles(t,
+			fmt.Sprintf("gs://%s/%s/%s?%s=%s&%s=%s",
+				bucket,
+				"backup-test-specified",
+				"listing-test",
+				cloud.AuthParam,
+				cloud.AuthParamSpecified,
+				BearerTokenParam,
+				token.AccessToken,
 			),
 			security.RootUserName(), nil, nil, testSettings,
 		)

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -1397,6 +1397,12 @@ message ExternalStorage {
     string billing_project = 4;
 
     string credentials = 5;
+
+    // BearerToken is a temporary bearer token that could be used to access the
+    // storage. This token is only used for "specified" auth mode and if
+    // Credentials is not supplied. Currently only OAuth 2.0 tokens are
+    // supported.
+    string bearer_token = 7;
   }
   message Azure {
     string container = 1;
@@ -1719,7 +1725,7 @@ message AddSSTableRequest {
   // could pick an MVCC timestamp that's guaranteed to not collide with
   // existing keys, see: https://github.com/cockroachdb/cockroach/issues/73047.
   // However, this would always lead to inaccurate MVCC stats.
-  bool disallow_conflicts = 7; 
+  bool disallow_conflicts = 7;
 
   // DisallowShadowing implies DisallowConflicts, and additionally rejects
   // writing above keys that have an existing/visible value (but will write


### PR DESCRIPTION
Backport 1/1 commits from #82861.

/cc @cockroachdb/release

---

Previously, the "specified" authentication method for GCP only allowed the
usage of the credentials JSON, which was a form of long-lived credentials,
with no short-lived alternative. This patch adds the ability to provide
short-lived OAuth 2.0 tokens as credentials through the new ACCESS_TOKEN
parameter.

Release note (enterprise change): Adds the ability to provide short-lived
OAuth 2.0 tokens as a form of short-lived credentials to Google Cloud Storage
and KMS. The token can be passed to the GCS or KMS URI via the new
ACCESS_TOKEN parameter for "specified" authentication mode.

Example GCS URI: gs://<bucket>/<key>?AUTH=specified&ACCESS_TOKEN=<token>
Example KMS URI: gs:///<key_resource>?AUTH=specified&ACCESS_TOKEN=<token>

There is no refresh mechanism associated with this token, so it is up to the
user to ensure that its TTL is longer than the duration of the job or query
that is using the token. The job or query may irrecoverably fail if one of its
access tokens expire before completion.

Release justification: necessary change for CMEK implementation. The newly introduced parameter in GCS and KMS URIs is additive and doesn't interfere with existing URIs.