### PR TITLE
release-21.2: util/mon: add monitor address to logging messages

### DIFF
--- a/pkg/acceptance/compose/gss/docker-compose-python.yml
+++ b/pkg/acceptance/compose/gss/docker-compose-python.yml
@@ -18,6 +18,7 @@ services:
       - ../../../../cockroach-linux-2.6.32-gnu-amd64:/cockroach/cockroach
   python:
     build: ./python
+    user: "${UID}:${GID}"
     depends_on:
       - cockroach
     environment:

--- a/pkg/acceptance/compose/gss/docker-compose.yml
+++ b/pkg/acceptance/compose/gss/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - ../../../../cockroach-linux-2.6.32-gnu-amd64:/cockroach/cockroach
   psql:
     build: ./psql
+    user: "${UID}:${GID}"
     depends_on:
       - cockroach
     environment:

--- a/pkg/acceptance/compose/gss/psql/Dockerfile
+++ b/pkg/acceptance/compose/gss/psql/Dockerfile
@@ -11,8 +11,15 @@ FROM postgres:11
 
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+  ca-certificates \
+  curl \
   krb5-user
 
 COPY --from=builder /workspace/gss.test .
 
-ENTRYPOINT ["/start.sh"]
+RUN curl -fsSL "https://github.com/benesch/autouseradd/releases/download/1.3.0/autouseradd-1.3.0-amd64.tar.gz" -o autouseradd.tar.gz \
+  && echo "442dae58b727a79f81368127fac141d7f95501ffa05f8c48943d27c4e807deb7 autouseradd.tar.gz" | sha256sum -c - \
+  && tar xzf autouseradd.tar.gz --strip-components 1 \
+  && rm autouseradd.tar.gz
+
+ENTRYPOINT ["autouseradd", "--user", "roach", "--no-create-home", "/start.sh"]

--- a/pkg/acceptance/compose/gss/psql/start.sh
+++ b/pkg/acceptance/compose/gss/psql/start.sh
@@ -15,7 +15,7 @@ echo "Preparing SQL user ahead of test"
 env \
     PGSSLKEY=/certs/client.root.key \
     PGSSLCERT=/certs/client.root.crt \
-    psql -c "ALTER USER root WITH PASSWORD rootpw"
+    psql -U root -c "ALTER USER root WITH PASSWORD rootpw"
 
 echo "Running test"
 ./gss.test

--- a/pkg/acceptance/compose/gss/python/Dockerfile
+++ b/pkg/acceptance/compose/gss/python/Dockerfile
@@ -3,8 +3,14 @@ ENV PYTHONUNBUFFERED 1
 
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+  curl \
   krb5-user \
   postgresql-client
+
+RUN curl -fsSL "https://github.com/benesch/autouseradd/releases/download/1.3.0/autouseradd-1.3.0-amd64.tar.gz" -o autouseradd.tar.gz \
+  && echo "442dae58b727a79f81368127fac141d7f95501ffa05f8c48943d27c4e807deb7 autouseradd.tar.gz" | sha256sum -c - \
+  && tar xzf autouseradd.tar.gz --strip-components 1 \
+  && rm autouseradd.tar.gz
 
 RUN mkdir /code
 WORKDIR /code
@@ -12,4 +18,4 @@ COPY requirements.txt /code/
 RUN pip install -r requirements.txt
 COPY . /code/
 
-ENTRYPOINT ["/start.sh"]
+ENTRYPOINT ["autouseradd", "--user", "roach", "--no-create-home", "/start.sh"]

--- a/pkg/acceptance/compose_test.go
+++ b/pkg/acceptance/compose_test.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"testing"
 )
 
@@ -32,6 +33,16 @@ func TestComposeFlyway(t *testing.T) {
 }
 
 func testCompose(t *testing.T, path string, exitCodeFrom string) {
+	uid := os.Getuid()
+	err := os.Setenv("UID", strconv.Itoa(uid))
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	gid := os.Getgid()
+	err = os.Setenv("GID", strconv.Itoa(gid))
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
 	cmd := exec.Command(
 		"docker-compose",
 		"--no-ansi",

--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -121,6 +121,10 @@ func TestReadEnvironmentVariables(t *testing.T) {
 
 	resetEnvVar()
 	cfg.readEnvironmentVariables()
+
+	// Temp storage disk monitors will have slightly different names, so we
+	// override them to point to the same one.
+	cfgExpected.TempStorageConfig.Mon = cfg.TempStorageConfig.Mon
 	require.Equal(t, cfgExpected, cfg)
 
 	// Set all the environment variables to valid values and ensure they are set

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -198,6 +198,10 @@ type BytesMonitor struct {
 
 	// name identifies this monitor in logging messages.
 	name redact.RedactableString
+	// nameWithPointer contains name with the address of the monitor attached to
+	// it. This can be used in logging messages to uniquely identify all
+	// messages for a single monitor.
+	nameWithPointer redact.RedactableString
 
 	// resource specifies what kind of resource the monitor is tracking
 	// allocations for. Specific behavior is delegated to this resource (e.g.
@@ -301,6 +305,7 @@ func NewMonitorWithLimit(
 		poolAllocationSize:   increment,
 		settings:             settings,
 	}
+	m.nameWithPointer = redact.Sprintf("%s (%p)", name, redact.Safe(m))
 	m.mu.curBytesCount = curCount
 	m.mu.maxBytesHist = maxHist
 	return m
@@ -346,10 +351,10 @@ func (mm *BytesMonitor) Start(ctx context.Context, pool *BytesMonitor, reserved 
 	if log.V(2) {
 		poolname := redact.RedactableString("(none)")
 		if pool != nil {
-			poolname = pool.name
+			poolname = pool.nameWithPointer
 		}
 		log.InfofDepth(ctx, 1, "%s: starting monitor, reserved %s, pool %s",
-			mm.name,
+			mm.nameWithPointer,
 			humanizeutil.IBytes(mm.reserved.used),
 			poolname)
 	}
@@ -379,6 +384,7 @@ func NewUnlimitedMonitor(
 		reserved:             MakeStandaloneBudget(math.MaxInt64),
 		settings:             settings,
 	}
+	m.nameWithPointer = redact.Sprintf("%s (%p)", name, redact.Safe(m))
 	m.mu.curBytesCount = curCount
 	m.mu.maxBytesHist = maxHist
 	return m
@@ -407,7 +413,7 @@ func (mm *BytesMonitor) doStop(ctx context.Context, check bool) {
 	// monitor is not shared any more.
 	if log.V(1) && mm.mu.maxAllocated >= bytesMaxUsageLoggingThreshold {
 		log.InfofDepth(ctx, 1, "%s, bytes usage max %s",
-			mm.name,
+			mm.nameWithPointer,
 			humanizeutil.IBytes(mm.mu.maxAllocated))
 	}
 
@@ -686,7 +692,7 @@ func (mm *BytesMonitor) reserveBytes(ctx context.Context, x int64) error {
 			// many small allocations.
 			if bits.Len64(uint64(mm.mu.curAllocated)) != bits.Len64(uint64(mm.mu.curAllocated-x)) {
 				log.Infof(ctx, "%s: bytes usage increases to %s (+%d)",
-					mm.name,
+					mm.nameWithPointer,
 					humanizeutil.IBytes(mm.mu.curAllocated), x)
 			}
 		}
@@ -696,7 +702,7 @@ func (mm *BytesMonitor) reserveBytes(ctx context.Context, x int64) error {
 		// We avoid VEventf here because we want to avoid computing the
 		// trace string if there is nothing to log.
 		log.Infof(ctx, "%s: now at %d bytes (+%d) - %s",
-			mm.name, mm.mu.curAllocated, x, util.GetSmallTrace(3))
+			mm.nameWithPointer, mm.mu.curAllocated, x, util.GetSmallTrace(3))
 	}
 	return nil
 }
@@ -722,7 +728,7 @@ func (mm *BytesMonitor) releaseBytes(ctx context.Context, sz int64) {
 		// We avoid VEventf here because we want to avoid computing the
 		// trace string if there is nothing to log.
 		log.Infof(ctx, "%s: now at %d bytes (-%d) - %s",
-			mm.name, mm.mu.curAllocated, sz, util.GetSmallTrace(5))
+			mm.nameWithPointer, mm.mu.curAllocated, sz, util.GetSmallTrace(5))
 	}
 }
 
@@ -738,7 +744,7 @@ func (mm *BytesMonitor) increaseBudget(ctx context.Context, minExtra int64) erro
 		)
 	}
 	if log.V(2) {
-		log.Infof(ctx, "%s: requesting %d bytes from the pool", mm.name, minExtra)
+		log.Infof(ctx, "%s: requesting %d bytes from the pool", mm.nameWithPointer, minExtra)
 	}
 
 	return mm.mu.curBudget.Grow(ctx, minExtra)
@@ -762,7 +768,7 @@ func (mm *BytesMonitor) roundSize(sz int64) int64 {
 func (mm *BytesMonitor) releaseBudget(ctx context.Context) {
 	// NB: mm.mu need not be locked here, as this is only called from StopMonitor().
 	if log.V(2) {
-		log.Infof(ctx, "%s: releasing %d bytes to the pool", mm.name, mm.mu.curBudget.allocated())
+		log.Infof(ctx, "%s: releasing %d bytes to the pool", mm.nameWithPointer, mm.mu.curBudget.allocated())
 	}
 	mm.mu.curBudget.Clear(ctx)
 }

--- a/pkg/util/smalltrace.go
+++ b/pkg/util/smalltrace.go
@@ -42,7 +42,7 @@ func GetSmallTrace(skip int) redact.RedactableString {
 		if index := strings.LastIndexByte(file, '/'); index >= 0 {
 			file = file[index+1:]
 		}
-		callers.Printf("%s%s:%d:%s", callerPrefix, file, f.Line, function)
+		callers.Printf("%s%s:%d:%s", callerPrefix, redact.SafeString(file), f.Line, redact.SafeString(function))
 		callerPrefix = ","
 		if !more {
 			break

--- a/pkg/util/smalltrace_test.go
+++ b/pkg/util/smalltrace_test.go
@@ -23,7 +23,7 @@ import (
 
 func testSmallTrace2(t *testing.T) {
 	s := GetSmallTrace(2)
-	if !strings.Contains(string(s), "‹smalltrace_test.go›:‹1002›:‹util.testSmallTrace2›,‹smalltrace_test.go›:‹1009›:‹util.testSmallTrace›,‹smalltrace_test.go›:‹1013›:‹util.TestGenerateSmallTrace›") {
+	if !strings.Contains(string(s), "smalltrace_test.go:‹1002›:util.testSmallTrace2,smalltrace_test.go:‹1009›:util.testSmallTrace,smalltrace_test.go:‹1013›:util.TestGenerateSmallTrace") {
 		t.Fatalf("trace not generated properly: %q", s)
 	}
 }


### PR DESCRIPTION
This will allow us to uniquely identify all messages coming from
a single monitor. Additionally, this commit fixes the redactability of
the file name and function name when getting a stack trace.

Release note: None

Release justification: low-risk debugging improvement.