### PR TITLE
kvserver: make MVCC GC less disruptive to foreground traffic

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_recompute_stats.go
+++ b/pkg/kv/kvserver/batcheval/cmd_recompute_stats.go
@@ -53,6 +53,8 @@ func declareKeysRecomputeStats(
 	rdKey := keys.RangeDescriptorKey(rs.GetStartKey())
 	latchSpans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{Key: rdKey})
 	latchSpans.AddNonMVCC(spanset.SpanReadWrite, roachpb.Span{Key: keys.TransactionKey(rdKey, uuid.Nil)})
+	// Disable the assertions which check that all reads were previously declared.
+	latchSpans.DisableUndeclaredAccessAssertions()
 }
 
 // RecomputeStats recomputes the MVCCStats stored for this range and adjust them accordingly,
@@ -68,10 +70,6 @@ func RecomputeStats(
 	dryRun := args.DryRun
 
 	args = nil // avoid accidental use below
-
-	// Disable the assertions which check that all reads were previously declared.
-	// See the comment in `declareKeysRecomputeStats` for details on this.
-	reader = spanset.DisableReaderAssertions(reader)
 
 	actualMS, err := rditer.ComputeStatsForRange(desc, reader, cArgs.Header.Timestamp.WallTime)
 	if err != nil {

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -1721,6 +1721,14 @@ func gcKey(key roachpb.Key, timestamp hlc.Timestamp) roachpb.GCRequest_GCKey {
 	}
 }
 
+func recomputeStatsArgs(key roachpb.Key) roachpb.RecomputeStatsRequest {
+	return roachpb.RecomputeStatsRequest{
+		RequestHeader: roachpb.RequestHeader{
+			Key: key,
+		},
+	}
+}
+
 func gcArgs(startKey []byte, endKey []byte, keys ...roachpb.GCRequest_GCKey) roachpb.GCRequest {
 	return roachpb.GCRequest{
 		RequestHeader: roachpb.RequestHeader{
@@ -8392,56 +8400,6 @@ func TestReplicaReproposalWithNewLeaseIndexError(t *testing.T) {
 	}
 }
 
-// TestGCWithoutThreshold validates that GCRequest only declares the threshold
-// key if it is subject to change, and that it does not access this key if it
-// does not declare them.
-func TestGCWithoutThreshold(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	ctx := context.Background()
-	tc := &testContext{}
-	stopper := stop.NewStopper()
-	defer stopper.Stop(ctx)
-	tc.Start(ctx, t, stopper)
-
-	for _, keyThresh := range []hlc.Timestamp{{}, {Logical: 1}} {
-		t.Run(fmt.Sprintf("thresh=%s", keyThresh), func(t *testing.T) {
-			var gc roachpb.GCRequest
-			var spans spanset.SpanSet
-
-			gc.Threshold = keyThresh
-			cmd, _ := batcheval.LookupCommand(roachpb.GC)
-			cmd.DeclareKeys(tc.repl.Desc(), &roachpb.Header{RangeID: tc.repl.RangeID}, &gc, &spans, nil, 0)
-
-			expSpans := 1
-			if !keyThresh.IsEmpty() {
-				expSpans++
-			}
-			if numSpans := spans.Len(); numSpans != expSpans {
-				t.Fatalf("expected %d declared keys, found %d", expSpans, numSpans)
-			}
-
-			eng := storage.NewDefaultInMemForTesting()
-			defer eng.Close()
-
-			batch := eng.NewBatch()
-			defer batch.Close()
-			rw := spanset.NewBatch(batch, &spans)
-
-			var resp roachpb.GCResponse
-			if _, err := batcheval.GC(ctx, rw, batcheval.CommandArgs{
-				Args: &gc,
-				EvalCtx: NewReplicaEvalContext(
-					ctx, tc.repl, &spans, false, /* requiresClosedTSOlderThanStorageSnap */
-				),
-			}, &resp); err != nil {
-				t.Fatal(err)
-			}
-		})
-	}
-}
-
 // Test that, if the Raft command resulting from EndTxn request fails to be
 // processed/apply, then the LocalResult associated with that command is
 // cleared.
@@ -8510,6 +8468,78 @@ func TestFailureToProcessCommandClearsLocalResult(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// TestMVCCStatsGCCommutesWithWrites tests that the MVCCStats updates
+// corresponding to writes and GCs are commutative.
+//
+// This test does so by:
+// 1. Initially writing N versions of a key.
+// 2. Concurrently GC-ing the N-1 versions written in step 1 while writing N-1
+// new versions of the key.
+// 3. Concurrently recomputing MVCC stats (via RecomputeStatsRequests) in the
+// background and ensuring that the stats are always consistent at all times.
+func TestMVCCStatsGCCommutesWithWrites(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tc := serverutils.StartNewTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+	key := tc.ScratchRange(t)
+	store, err := tc.Server(0).GetStores().(*Stores).GetStore(tc.Server(0).GetFirstStoreID())
+	require.NoError(t, err)
+
+	write := func() hlc.Timestamp {
+		var ba roachpb.BatchRequest
+		put := putArgs(key, []byte("0"))
+		ba.Add(&put)
+		resp, pErr := store.TestSender().Send(ctx, ba)
+		require.Nil(t, pErr)
+		return resp.Timestamp
+	}
+
+	// Write `numIterations` versions for a key.
+	const numIterations = 100
+	writeTimestamps := make([]hlc.Timestamp, 0, numIterations)
+	for i := 0; i < numIterations; i++ {
+		writeTimestamps = append(writeTimestamps, write())
+	}
+
+	// Now, we GC the first `numIterations-1` versions we wrote above while
+	// concurrently writing `numIterations-1` new versions.
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		for _, ts := range writeTimestamps[:numIterations-1] {
+			gcReq := gcArgs(key, key.Next(), gcKey(key, ts))
+			_, pErr := kv.SendWrapped(ctx, store.TestSender(), &gcReq)
+			require.Nil(t, pErr)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numIterations-1; i++ {
+			write()
+		}
+	}()
+	// Also concurrently recompute stats and ensure that they're consistent at all
+	// times.
+	go func() {
+		defer wg.Done()
+		expDelta := enginepb.MVCCStats{}
+		for i := 0; i < numIterations; i++ {
+			recomputeReq := recomputeStatsArgs(key)
+			resp, pErr := kv.SendWrapped(ctx, store.TestSender(), &recomputeReq)
+			require.Nil(t, pErr)
+			delta := enginepb.MVCCStats(resp.(*roachpb.RecomputeStatsResponse).AddedDelta)
+			delta.AgeTo(expDelta.LastUpdateNanos)
+			require.Equal(t, expDelta, delta)
+		}
+	}()
+
+	wg.Wait()
 }
 
 // TestBatchTimestampBelowGCThreshold verifies that commands below the replica
@@ -8777,6 +8807,18 @@ func TestGCThresholdRacesWithRead(t *testing.T) {
 			b, err := resp.(*roachpb.GetResponse).Value.GetBytes()
 			require.Nil(t, err)
 			require.Equal(t, va, b)
+
+			// Since the GC request does not acquire latches on the keys being GC'ed,
+			// they're not guaranteed to wait for these above Puts to get applied on
+			// the leaseholder. See AckCommittedEntriesBeforeApplication() and the the
+			// comment above it for more details. So we separately ensure both these
+			// Puts have been applied by just trying to read the latest value @ ts2.
+			// These Get requests do indeed declare latches on the keys being read, so
+			// by the time they return, subsequent GC requests are guaranteed to see
+			// the latest keys.
+			gArgs = getArgs(key)
+			_, pErr = kv.SendWrappedWith(ctx, reader, h2, &gArgs)
+			require.Nil(t, pErr)
 
 			// Perform two actions concurrently:
 			//  1. GC up to ts2. This should remove the k@ts1 version.

--- a/pkg/kv/kvserver/spanset/spanset.go
+++ b/pkg/kv/kvserver/spanset/spanset.go
@@ -82,7 +82,8 @@ type Span struct {
 // The Span slice for a particular access and scope contains non-overlapping
 // spans in increasing key order after calls to SortAndDedup.
 type SpanSet struct {
-	spans [NumSpanAccess][NumSpanScope][]Span
+	spans           [NumSpanAccess][NumSpanScope][]Span
+	allowUndeclared bool
 }
 
 var spanSetPool = sync.Pool{
@@ -111,6 +112,7 @@ func (s *SpanSet) Release() {
 			s.spans[sa][ss] = recycle
 		}
 	}
+	s.allowUndeclared = false
 	spanSetPool.Put(s)
 }
 
@@ -152,6 +154,7 @@ func (s *SpanSet) Copy() *SpanSet {
 			n.spans[sa][ss] = append(n.spans[sa][ss], s.spans[sa][ss]...)
 		}
 	}
+	n.allowUndeclared = s.allowUndeclared
 	return n
 }
 
@@ -204,6 +207,7 @@ func (s *SpanSet) Merge(s2 *SpanSet) {
 			s.spans[sa][ss] = append(s.spans[sa][ss], s2.spans[sa][ss]...)
 		}
 	}
+	s.allowUndeclared = s2.allowUndeclared
 	s.SortAndDedup()
 }
 
@@ -335,6 +339,12 @@ func (s *SpanSet) CheckAllowedAt(
 func (s *SpanSet) checkAllowed(
 	access SpanAccess, span roachpb.Span, check func(SpanAccess, Span) bool,
 ) error {
+	if s.allowUndeclared {
+		// If the request has specified that undeclared spans are allowed, do
+		// nothing.
+		return nil
+	}
+
 	scope := SpanGlobal
 	if (span.Key != nil && keys.IsLocal(span.Key)) ||
 		(span.EndKey != nil && keys.IsLocal(span.EndKey)) {
@@ -386,4 +396,11 @@ func (s *SpanSet) Validate() error {
 	}
 
 	return nil
+}
+
+// DisableUndeclaredAccessAssertions disables the assertions that prevent
+// undeclared access to spans. This is generally set by requests that rely on
+// other forms of synchronization for correctness (e.g. GCRequest).
+func (s *SpanSet) DisableUndeclaredAccessAssertions() {
+	s.allowUndeclared = true
 }


### PR DESCRIPTION
This commit changes GC requests to no longer declare exclusive latches
at their BatchRequest's timestamp. This was already incorrect as
explained in https://github.com/cockroachdb/cockroach/issues/55293.

>The first use is broken because we acquire write latches at the batch
header's timestamp, which is set to time.Now(), so we're only
serializing with reads in the future and all other writes [1]. So we're
disruptive to everyone except who we want to serialize with – reads in
the past!

This commit makes GC requests only declare a non-mvcc exclusive latch
over the `RangeGCThresholdKey`. This is correct because:
```

// 1. We define "correctness" to be the property that a reader reading at /
// around the GC threshold will either see the correct results or receive an
// error.
// 2. Readers perform their command evaluation over a stable snapshot of the
// storage engine. This means that the reader will not see the effects of a
// subsequent GC run as long as it created a Pebble iterator before the GC
// request.
// 3. A reader checks the in-memory GC threshold of a Replica after it has
// created this snapshot (i.e. after a Pebble iterator has been created).
// 4. If the in-memory GC threshold is above the timestamp of the read, the
// reader receives an error. Otherwise, the reader is guaranteed to see a
// state of the storage engine that hasn't been affected by the GC request [5].
// 5. GC requests bump the in-memory GC threshold of a Replica as a pre-apply
// side effect. This means that if a reader checks the in-memory GC threshold
// after it has created a Pebble iterator, it is impossible for the iterator
// to point to a storage engine state that has been affected by the GC
// request.

```

As a result, GC requests should now be much less disruptive to
foreground traffic since they're no longer redundantly declaring
exclusive latches over global keys.

Resolves https://github.com/cockroachdb/cockroach/issues/55293

Release note(performance improvement): MVCC garbage collection should
now be much less disruptive to foreground traffic than before.
