### PR TITLE
release-22.1: backupccl: replace bulk-prs with bulk-io in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -70,12 +70,12 @@
 
 /pkg/cli/                    @cockroachdb/cli-prs
 # last-rule-wins so bulk i/o takes userfile.go even though cli-prs takes pkg/cli
-/pkg/cli/userfile.go         @cockroachdb/bulk-prs
+/pkg/cli/userfile.go         @cockroachdb/bulk-io
 /pkg/cli/demo*.go            @cockroachdb/cli-prs @cockroachdb/sql-experience @cockroachdb/server-prs
 /pkg/cli/debug*.go           @cockroachdb/cli-prs @cockroachdb/kv-prs
-/pkg/cli/debug_job_trace*.go @cockroachdb/bulk-prs
+/pkg/cli/debug_job_trace*.go @cockroachdb/bulk-io
 /pkg/cli/doctor*.go          @cockroachdb/cli-prs @cockroachdb/sql-schema
-/pkg/cli/import_test.go      @cockroachdb/cli-prs @cockroachdb/bulk-prs
+/pkg/cli/import_test.go      @cockroachdb/cli-prs @cockroachdb/bulk-io
 /pkg/cli/sql*.go             @cockroachdb/cli-prs @cockroachdb/sql-experience
 /pkg/cli/start*.go           @cockroachdb/cli-prs @cockroachdb/server-prs
 /pkg/cli/mt_proxy.go         @cockroachdb/sqlproxy-prs @cockroachdb/server-prs
@@ -91,16 +91,16 @@
 /pkg/ccl/jobsccl/            @cockroachdb/cdc-prs
 /pkg/ccl/changefeedccl/      @cockroachdb/cdc-prs
 /pkg/ccl/streamingccl/       @cockroachdb/cdc-prs
-# last-rule-wins so *after* CDC takes most of streamingccl bulk-prs takes ingest pkg.
-/pkg/ccl/streamingccl/streamingest @cockroachdb/bulk-prs
+# last-rule-wins so *after* CDC takes most of streamingccl bulk-io takes ingest pkg.
+/pkg/ccl/streamingccl/streamingest @cockroachdb/bulk-io
 
-/pkg/ccl/backupccl/          @cockroachdb/bulk-prs
-/pkg/sql/importer/           @cockroachdb/bulk-prs
-/pkg/ccl/importerccl/        @cockroachdb/bulk-prs
+/pkg/ccl/backupccl/          @cockroachdb/bulk-io
+/pkg/sql/importer/           @cockroachdb/bulk-io
+/pkg/ccl/importerccl/        @cockroachdb/bulk-io
 /pkg/ccl/spanconfigccl/      @cockroachdb/kv-prs
-/pkg/ccl/storageccl/         @cockroachdb/bulk-prs
-/pkg/cloud/                  @cockroachdb/bulk-prs
-/pkg/sql/distsql_plan_csv.go @cockroachdb/bulk-prs
+/pkg/ccl/storageccl/         @cockroachdb/bulk-io
+/pkg/cloud/                  @cockroachdb/bulk-io
+/pkg/sql/distsql_plan_csv.go @cockroachdb/bulk-io
 
 /pkg/geo/                    @cockroachdb/geospatial
 
@@ -124,7 +124,7 @@
 /pkg/base/                   @cockroachdb/server-prs
 /pkg/bench/                  @cockroachdb/sql-queries-noreview
 /pkg/bench/rttanalysis       @cockroachdb/sql-schema
-/pkg/blobs/                  @cockroachdb/bulk-prs
+/pkg/blobs/                  @cockroachdb/bulk-io
 /pkg/build/                  @cockroachdb/dev-inf
 /pkg/ccl/baseccl/            @cockroachdb/cli-prs
 /pkg/ccl/buildccl/           @cockroachdb/dev-inf
@@ -256,12 +256,12 @@
 /pkg/roachpb/version*        @cockroachdb/unowned
 /pkg/roachprod/              @cockroachdb/dev-inf
 /pkg/rpc/                    @cockroachdb/server-prs
-/pkg/scheduledjobs/          @cockroachdb/bulk-prs
+/pkg/scheduledjobs/          @cockroachdb/bulk-io
 /pkg/security/               @cockroachdb/server-prs @cockroachdb/prodsec
 /pkg/settings/               @cockroachdb/server-prs
 /pkg/spanconfig/             @cockroachdb/kv-prs
 /pkg/startupmigrations/      @cockroachdb/server-prs @cockroachdb/sql-schema
-/pkg/streaming/              @cockroachdb/bulk-prs
+/pkg/streaming/              @cockroachdb/bulk-io
 /pkg/testutils/              @cockroachdb/test-eng-noreview
 /pkg/testutils/reduce/       @cockroachdb/sql-queries
 /pkg/testutils/sqlutils/     @cockroachdb/sql-queries
@@ -280,7 +280,7 @@
 /pkg/cli/auth.go                       @cockroachdb/prodsec
 /pkg/rpc/auth.go                       @cockroachdb/prodsec
 /pkg/sql/pgwire/auth.go                @cockroachdb/prodsec
-               
+
 
 # Own all bazel files to dev-inf, but don't request reviews for them
 # as they are mostly - but not only - generated code that changes with


### PR DESCRIPTION
Backport 1/1 commits from #83162.

/cc @cockroachdb/release

---

Informs #83160

Release note: None

Release justification: non prod change