### PR TITLE
sql/schemachanger/scexec/backfiller: fix race

### DIFF
--- a/pkg/sql/schemachanger/scexec/backfiller/tracker.go
+++ b/pkg/sql/schemachanger/scexec/backfiller/tracker.go
@@ -398,6 +398,8 @@ func (b *Tracker) collectProgressForCheckpointFlush() (
 	backfillProgress []scexec.BackfillProgress,
 	mergeProgress []scexec.MergeProgress,
 ) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	for _, p := range b.mu.backfillProgress {
 		if p.needsCheckpointFlush {
 			needsFlush = true


### PR DESCRIPTION
We were missing a lock call.

```
==================
WARNING: DATA RACE
Read at 0x00c00b3e4c00 by goroutine 1874:
  github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec/backfiller.(*Tracker).collectProgressForCheckpointFlush()
      /go/src/github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec/backfiller/tracker.go:402 +0x104
  github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec/backfiller.(*Tracker).FlushCheckpoint()
      /go/src/github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec/backfiller/tracker.go:232 +0x57
  github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec.BackfillerProgressFlusher.FlushCheckpoint-fm()
      /go/src/github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec/dependencies.go:322 +0x6b
  github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec/backfiller.(*periodicProgressFlusher).StartPeriodicUpdates.func1()
      /go/src/github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec/backfiller/periodic_progress_flusher.go:80 +0x26b
  github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec/backfiller.(*periodicProgressFlusher).StartPeriodicUpdates.func3()
      /go/src/github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec/backfiller/periodic_progress_flusher.go:92 +0xf1
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /go/src/github.com/cockroachdb/cockroach/vendor/golang.org/x/sync/errgroup/errgroup.go:74 +0x91

Previous write at 0x00c00b3e4c00 by goroutine 115:
  github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec/backfiller.(*Tracker).SetBackfillProgress()
      /go/src/github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec/backfiller/tracker.go:197 +0x2bb
  github.com/cockroachdb/cockroach/pkg/sql.(*IndexBackfillPlanner).BackfillIndexes.func2()
      /go/src/github.com/cockroachdb/cockroach/pkg/sql/index_backfiller.go:92 +0x21e
  github.com/cockroachdb/cockroach/pkg/sql.(*MetadataCallbackWriter).AddMeta()
      /go/src/github.com/cockroachdb/cockroach/pkg/sql/distsql_running.go:730 +0x65
  github.com/cockroachdb/cockroach/pkg/sql.(*DistSQLReceiver).pushMeta()
      /go/src/github.com/cockroachdb/cockroach/pkg/sql/distsql_running.go:955 +0xd5
  github.com/cockroachdb/cockroach/pkg/sql.(*DistSQLReceiver).Push()
      /go/src/github.com/cockroachdb/cockroach/pkg/sql/distsql_running.go:1084 +0x4cc
  github.com/cockroachdb/cockroach/pkg/sql/rowflow.(*copyingRowReceiver).Push()
      /go/src/github.com/cockroachdb/cockroach/pkg/sql/rowflow/row_based_flow.go:455 +0x2d5
  github.com/cockroachdb/cockroach/pkg/sql/rowexec.(*indexBackfiller).Run()
      /go/src/github.com/cockroachdb/cockroach/pkg/sql/rowexec/indexbackfiller.go:374 +0xad1
  github.com/cockroachdb/cockroach/pkg/sql/flowinfra.(*FlowBase).Run()
      /go/src/github.com/cockroachdb/cockroach/pkg/sql/flowinfra/flow.go:475 +0x429
  github.com/cockroachdb/cockroach/pkg/sql/rowflow.(*rowBasedFlow).Run()
      <autogenerated>:1 +0x73
  github.com/cockroachdb/cockroach/pkg/sql.(*DistSQLPlanner).Run()
      /go/src/github.com/cockroachdb/cockroach/pkg/sql/distsql_running.go:596 +0x1234
  github.com/cockroachdb/cockroach/pkg/sql.(*IndexBackfillPlanner).plan.func2()
      /go/src/github.com/cockroachdb/cockroach/pkg/sql/index_backfiller.go:204 +0x449
  github.com/cockroachdb/cockroach/pkg/sql.(*IndexBackfillPlanner).BackfillIndexes()
      /go/src/github.com/cockroachdb/cockroach/pkg/sql/index_backfiller.go:119 +0x71d
  github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec.runBackfill()
      /go/src/github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec/exec_backfill.go:381 +0x24b
  github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec.runBackfiller.func2()
      /go/src/github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec/exec_backfill.go:328 +0x22e
  github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec.forEachProgressConcurrently.func1.1()
      /go/src/github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec/exec_backfill.go:257 +0x155
  github.com/cockroachdb/cockroach/pkg/util/ctxgroup.Group.GoCtx.func1()
      /go/src/github.com/cockroachdb/cockroach/pkg/util/ctxgroup/ctxgroup.go:169 +0x4c
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /go/src/github.com/cockroachdb/cockroach/vendor/golang.org/x/sync/errgroup/errgroup.go:74 +0x91
```

Release note: None