### PR TITLE
util/stop: fix span use when recovering from a panic

### DIFF
--- a/pkg/util/netutil/net.go
+++ b/pkg/util/netutil/net.go
@@ -154,7 +154,6 @@ func (s *Server) ServeWith(
 		}
 		tempDelay = 0
 		err := stopper.RunAsyncTask(ctx, "pgwire-serve", func(ctx context.Context) {
-			defer stopper.Recover(ctx)
 			// NB: ConnState is used to manage the list of active connections that
 			// need draining; see MakeServer().
 			s.Server.ConnState(rw, http.StateNew) // before Serve can return

--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -154,10 +154,10 @@ func (f CloserFn) Close() {
 // - all the other things mentioned in:
 //     https://github.com/cockroachdb/cockroach/issues/58164
 type Stopper struct {
-	quiescer chan struct{}     // Closed when quiescing
-	stopped  chan struct{}     // Closed when stopped completely
-	onPanic  func(interface{}) // called with recover() on panic on any goroutine
-	tracer   *tracing.Tracer   // tracer used to create spans for tasks
+	quiescer chan struct{}                      // Closed when quiescing
+	stopped  chan struct{}                      // Closed when stopped completely
+	onPanic  func(context.Context, interface{}) // called with recover() on panic on any goroutine
+	tracer   *tracing.Tracer                    // tracer used to create spans for tasks
 
 	mu struct {
 		syncutil.RWMutex
@@ -185,7 +185,7 @@ type Option interface {
 	apply(*Stopper)
 }
 
-type optionPanicHandler func(interface{})
+type optionPanicHandler func(context.Context, interface{})
 
 var _ Option = optionPanicHandler(nil)
 
@@ -198,7 +198,7 @@ func (oph optionPanicHandler) apply(stopper *Stopper) {
 //
 // When Stop() is invoked during stack unwinding, OnPanic is also invoked, but
 // Stop() may not have carried out its duties.
-func OnPanic(handler func(interface{})) Option {
+func OnPanic(handler func(context.Context, interface{})) Option {
 	return optionPanicHandler(handler)
 }
 
@@ -244,7 +244,7 @@ func NewStopper(options ...Option) *Stopper {
 func (s *Stopper) Recover(ctx context.Context) {
 	if r := recover(); r != nil {
 		if s.onPanic != nil {
-			s.onPanic(r)
+			s.onPanic(ctx, r)
 			return
 		}
 		logcrash.ReportPanicWithGlobalSettings(ctx, r, 1)
@@ -481,16 +481,14 @@ func (s *Stopper) RunAsyncTaskEx(ctx context.Context, opt TaskOpts, f func(conte
 	// Call f on another goroutine.
 	taskStarted = true // Another goroutine now takes ownership of the alloc, if any.
 	go func() {
-		defer s.Recover(ctx)
+		defer sp.Finish()
 		defer s.runPostlude()
-		if sp != nil {
-			defer sp.Finish()
-			sp.UpdateGoroutineIDToCurrent()
-		}
+		defer s.Recover(ctx)
 		if alloc != nil {
 			defer alloc.Release()
 		}
 
+		sp.UpdateGoroutineIDToCurrent()
 		f(ctx)
 	}()
 	return nil


### PR DESCRIPTION
When recovering from a panic, the stopper was first finishing the
tracing span and then using it to log the panic. This was a
use-after-finish. It was not caught by the unit test because the test
was short-circuiting the logging part; I've improved the test so that it
would have caught it.

Release note: None