### PR TITLE
WIP backupccl: experiment with alternate sst stitching strategy

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -405,6 +405,26 @@ func TestBackupRestorePartitioned(t *testing.T) {
 	})
 }
 
+// TestBackupManifestFileCount tests that we don't get more than 1 file per node
+// in a case where we know that the entire dataset should fit inside the
+// file_sst_sink reorder buffer.
+func TestBackupManifestFileCount(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const numAccounts = 1000
+	_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, multiNode, numAccounts, InitManualReplication)
+	defer cleanupFn()
+	sqlDB.Exec(t, "SELECT crdb_internal.set_vmodule('file_sst_sink=3')")
+	sqlDB.Exec(t, "BACKUP INTO 'userfile:///backup'")
+	rows := sqlDB.QueryRow(t, "SELECT count(distinct(path)) FROM [SHOW BACKUP FILES FROM LATEST IN 'userfile:///backup']")
+	var count int
+	rows.Scan(&count)
+	require.True(t, multiNode <= count)
+	files := sqlDB.QueryStr(t, "SHOW BACKUP FILES FROM LATEST IN 'userfile:///backup'")
+	t.Logf("FILES: %v", files)
+}
+
 func TestBackupRestoreAppend(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	skip.WithIssue(t, 54599, "flaky test")


### PR DESCRIPTION
This introduces 3 new options:

* bulkio.backup.immediately_process_resume_spans

Currently, we place resume spans from an export request back on the
queue. I think this is possibly the wrong choice for a few reasons:

1) The resume span is contiguous with the span we just processed and
   thus it would be nice to put it in the same SST so that we can cut
   down on manifest entries.  Currently, we are very unlikely to put the
   resume span in the same SST. Processing it immediately makes it
   more likely to end up in the same SST, especially when combined
   with the next option.

2) We've just issued an export request and the resume span is often
   data that lives in the same range, and may be already residing in
   pebble and operating system caches. Reading it immediately may
   allow us to take advantage of this. I have no evidence of this yet.

* bulkio.backup.sst_per_export_worker

Currently, we maintain one sst_file_writer for all export workers and
depend on a sort buffer to get reasonably sized SSTs. Since our todo
spans is coming to us in likely sorted order, giving each export
worker its own sst_writer allows us to fill up SSTs to the desired
size with no reorder buffer. Further, when combined with the above
option, we also cut down on manifest entries since more contigous
spans end up in the same SST.

*  bulkio.backup.allow_file_underfill

Right now we prefer overfilling an SST. This can lead us to put a
non-contiguous span in an SST (and thus generate a manifest entry)
that was already rather full. This is a small heuristic to start a new
SST to avoid this. So far, I'm not sure this one is really worth it.

Release note: None