### PR TITLE
release-22.1: sql: unredact fields for captured index usage stats logs

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2364,13 +2364,13 @@ An event of type `captured_index_usage_stats`
 | Field | Description | Sensitive |
 |--|--|--|
 | `TotalReadCount` | TotalReadCount is the number of times this index has been read from. | no |
-| `LastRead` | LastRead is the timestamp that this index was last being read from. | yes |
+| `LastRead` | LastRead is the timestamp that this index was last being read from. | no |
 | `TableID` | TableID is the ID of the table this index is created on. This is same as descpb.TableID and is unique within the cluster. | no |
 | `IndexID` | IndexID is the ID of the index within the scope of the given table. | no |
-| `DatabaseName` |  | yes |
-| `TableName` |  | yes |
-| `IndexName` |  | yes |
-| `IndexType` |  | yes |
+| `DatabaseName` |  | no |
+| `TableName` |  | no |
+| `IndexName` |  | no |
+| `IndexType` |  | no |
 | `IsUnique` |  | no |
 | `IsInverted` |  | no |
 

--- a/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
@@ -292,16 +292,16 @@ func checkNumTotalEntriesAndNumIndexEntries(
 	)
 
 	for _, e := range entries {
-		if strings.Contains(e.Message, `"IndexName":"‹test_table_pkey›"`) {
+		if strings.Contains(e.Message, `"IndexName":"test_table_pkey"`) {
 			numEntriesForTestTablePrimaryKeyIndex++
 		}
-		if strings.Contains(e.Message, `"IndexName":"‹test_table_letter_idx›"`) {
+		if strings.Contains(e.Message, `"IndexName":"test_table_letter_idx"`) {
 			numEntriesForTestTableLetterIndex++
 		}
-		if strings.Contains(e.Message, `"TableName":"‹test2_table_pkey›"`) {
+		if strings.Contains(e.Message, `"IndexName":"test2_table_pkey"`) {
 			numEntriesForTest2TablePrimaryKeyIndex++
 		}
-		if strings.Contains(e.Message, `"TableName":"‹test2_table_letter_idx›"`) {
+		if strings.Contains(e.Message, `"IndexName":"test2_table_letter_idx"`) {
 			numEntriesForTest2TableLetterIndex++
 		}
 		// Check that the entry has a tag for a node ID of 1.

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -584,9 +584,7 @@ func (m *CapturedIndexUsageStats) AppendJSONFields(printComma bool, b redact.Red
 		}
 		printComma = true
 		b = append(b, "\"LastRead\":\""...)
-		b = append(b, redact.StartMarker()...)
-		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.LastRead)))))
-		b = append(b, redact.EndMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.LastRead)))
 		b = append(b, '"')
 	}
 
@@ -614,9 +612,7 @@ func (m *CapturedIndexUsageStats) AppendJSONFields(printComma bool, b redact.Red
 		}
 		printComma = true
 		b = append(b, "\"DatabaseName\":\""...)
-		b = append(b, redact.StartMarker()...)
-		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.DatabaseName)))))
-		b = append(b, redact.EndMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.DatabaseName)))
 		b = append(b, '"')
 	}
 
@@ -626,9 +622,7 @@ func (m *CapturedIndexUsageStats) AppendJSONFields(printComma bool, b redact.Red
 		}
 		printComma = true
 		b = append(b, "\"TableName\":\""...)
-		b = append(b, redact.StartMarker()...)
-		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TableName)))))
-		b = append(b, redact.EndMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.TableName)))
 		b = append(b, '"')
 	}
 
@@ -638,9 +632,7 @@ func (m *CapturedIndexUsageStats) AppendJSONFields(printComma bool, b redact.Red
 		}
 		printComma = true
 		b = append(b, "\"IndexName\":\""...)
-		b = append(b, redact.StartMarker()...)
-		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.IndexName)))))
-		b = append(b, redact.EndMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.IndexName)))
 		b = append(b, '"')
 	}
 
@@ -650,9 +642,7 @@ func (m *CapturedIndexUsageStats) AppendJSONFields(printComma bool, b redact.Red
 		}
 		printComma = true
 		b = append(b, "\"IndexType\":\""...)
-		b = append(b, redact.StartMarker()...)
-		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.IndexType)))))
-		b = append(b, redact.EndMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.IndexType)))
 		b = append(b, '"')
 	}
 

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -55,7 +55,7 @@ message CapturedIndexUsageStats {
   uint64 total_read_count = 2;
 
   // LastRead is the timestamp that this index was last being read from.
-  string last_read = 3 [(gogoproto.jsontag) = ",omitempty"];
+  string last_read = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 
   // TableID is the ID of the table this index is created on. This is same as
   // descpb.TableID and is unique within the cluster.
@@ -64,10 +64,10 @@ message CapturedIndexUsageStats {
   // IndexID is the ID of the index within the scope of the given table.
   uint32 index_id = 5 [(gogoproto.customname) = "IndexID"];
 
-  string database_name = 6 [(gogoproto.jsontag) = ",omitempty"];
-  string table_name = 7 [(gogoproto.jsontag) = ",omitempty"];
-  string index_name = 8 [(gogoproto.jsontag) = ",omitempty"];
-  string index_type = 9 [(gogoproto.jsontag) = ",omitempty"];
+  string database_name = 6 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+  string table_name = 7 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+  string index_name = 8 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+  string index_type = 9 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
   bool is_unique = 10 [(gogoproto.jsontag) = ",omitempty"];
   bool is_inverted = 11 [(gogoproto.jsontag) = ",omitempty"];
 }


### PR DESCRIPTION
Backport 1/1 commits from #83136.

/cc @cockroachdb/release

---
Resolves: #81463

Previously, the log fields for the capture index usage stats logs were
identified as sensitive information and redacted. This change marks the
captured index usage stats log fields as not sensitive, giving us more
information to work with in our telemetry data.

Release note (sql change): Unredact fields for captured index usage
stats telemetry logs.

Release justification: Category 4: Low risk, high benefit changes to existing functionality