### PR TITLE
sql/pgwire: fix a leak of accounted for memory

### DIFF
--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -849,6 +849,7 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn, socketType Socket
 	var sArgs sql.SessionArgs
 	if sArgs, err = parseClientProvidedSessionParameters(ctx, &s.execCfg.Settings.SV, &buf,
 		conn.RemoteAddr(), s.trustClientProvidedRemoteAddr.Get()); err != nil {
+		reserved.Close(ctx)
 		return s.sendErr(ctx, conn, err)
 	}
 


### PR DESCRIPTION
@rafiss, can I get a suggestion on where to add an automated test?

Fixes https://github.com/cockroachdb/cockroach/issues/83034.

**sql/pgwire: fix a leak of accounted for memory**

This commit fixes a bug where in case client-provided session params failed
to parse, CRDB leaked accounted for memory.

Release note (bug fix): In case client-provided session params fail to parse,
CRDB no longer leaks accounted for memory.