### PR TITLE
sql: allow user to see pg_catalog data for current database

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/drop_view
+++ b/pkg/sql/logictest/testdata/logic_test/drop_view
@@ -99,6 +99,9 @@ DROP VIEW testuser3
 query TTTTIT
 SHOW TABLES FROM test
 ----
+public  d          view  root  0  NULL
+public  testuser1  view  root  0  NULL
+public  testuser2  view  root  0  NULL
 
 statement error cannot drop relation "testuser1" because view "testuser2" depends on it
 DROP VIEW testuser1
@@ -112,6 +115,7 @@ DROP VIEW testuser1 CASCADE
 query TTTTIT
 SHOW TABLES FROM test
 ----
+public  d  view  root  0  NULL
 
 statement error pgcode 42P01 relation "testuser2" does not exist
 DROP VIEW testuser2

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -432,6 +432,30 @@ oid         nspname             nspowner    nspacl
 1098122499  pg_extension        NULL        NULL
 4101115737  public              2310524507  NULL
 
+# Verify that we can still see the schemas even if we don't have any privilege
+# on the current database.
+
+statement ok
+REVOKE ALL ON DATABASE test FROM public;
+REVOKE ALL ON DATABASE test FROM testuser
+
+user testuser
+
+query OTOT colnames
+SELECT * FROM pg_catalog.pg_namespace
+----
+oid         nspname             nspowner    nspacl
+1445254017  crdb_internal       NULL        NULL
+155990598   information_schema  NULL        NULL
+2154378761  pg_catalog          NULL        NULL
+1098122499  pg_extension        NULL        NULL
+4101115737  public              2310524507  NULL
+
+user root
+
+statement ok
+GRANT CONNECT ON DATABASE test TO public
+
 ## pg_catalog.pg_database
 
 query OTOITTBB colnames


### PR DESCRIPTION
Release note (bug fix): Previously a user could be connected to a
database, but be unable to see the metadata for that database in
pg_catalog if the user did not have privileges (e.g. CONNECT) for the
database. Now, a user can always see the pg_catalog metadata for
the current database they are connected to.

This is needed because CockroachDB currently does not require the
CONNECT privilege to connect to a database (see
https://github.com/cockroachdb/cockroach/issues/59875).