### PR TITLE
kv: Track the min valid observed timestamp

### DIFF
--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -862,6 +862,186 @@ func TestTxnReadWithinUncertaintyIntervalAfterLeaseTransfer(t *testing.T) {
 	require.IsType(t, &roachpb.ReadWithinUncertaintyIntervalError{}, pErr.GetDetail())
 }
 
+// TestTxnReadWithinUncertaintyIntervalAfterRangeMerge verifies that on a merge of two
+// ranges, the limiting of the uncertainty timestamp from the RHS is preserved.
+// The following series demonstrates the problem.
+//
+// +-----------+            +-----------+        +-----------+       +----------+
+// | S1* (A-B) |            | S2 (A-B)  |        | S3* (C-D) |       | S4 (C-D) |
+// +-----------+            +-----------+        +-----------+       +----------+
+// | - Time 0               | - Time 0           | - Time 100        | - Time 0
+// |                        |                    |                   |
+// |                        |                    | - Put(C)          |
+// | - Get(A, TX1)          |                    |                   |
+// |  Observed TS (1)       |                    |                   |
+// |                        |                    |                   |
+// |<-----------------------|--------------------|-- Transfer(C-D) --X
+// |                        X -- Transfer(A-B) ->|
+// |                                             |
+// |<----------------------- Merge (A-D) --------X - no longer leaseholder
+// | - Time bumped to 100
+// |
+// | - Get(C, TX1)
+// | - BUG - Not found!
+//
+// This is a bug because from a causality perspective, the put of C
+// happened before the later get of C. It is not found because the transaction
+// uncertainty window is incorrectly (0). Note that leaseholder protection would
+// not help here as there are no lease changes or transfers.
+//
+// The underlying issue is that the observed timestamp on S0 becomes "invalid"
+// after the merge. This is one scenario where this can occur, but not the only one.
+// Fundamentally the guarantee the observed timestamp is intended to provide,
+// that no writes for any names were written before the time T0 is broken.
+// The underlying cause for this is an implicit, but incorrect mapping between
+// leaseholders and leases which is stored by the client.
+//
+// The situation for the test is 4 nodes total, 2 holding the "LHS" and 2
+// holding the RHS of the range that is going to merge. The nodes are merged so
+// that the leaseholders are unaligned at the time of the merge, and the RHS
+// leaseholder clock is ahead of the LHS.
+func TestTxnReadWithinUncertaintyIntervalAfterRangeMerge(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	run := func(t *testing.T, alignLeaseholders bool, alsoSplit bool) {
+
+		// The stores 0 and 1 are the "LHS", and the stores 2 and 3 are the RHS.
+		// The stores 0 and 2 are leaseholders, and the clocks on the replicas are fast
+		// Before the merge operation, need to align replicas, so 3 => 0 and 1 => 2 to
+		// avoid moving leases and triggering leaseholder protection.
+		// After the merge, the only leaseholder is store 0. Store 2 is the replica of
+		// that store.
+		const numServers = 4
+		// First set up all the four stores with manual clocks
+		var manuals [numServers]*hlc.HybridManualClock
+		for i := 0; i < numServers; i++ {
+			manuals[i] = hlc.NewHybridManualClock()
+		}
+		serverArgs := make(map[int]base.TestServerArgs)
+		for i := 0; i < numServers; i++ {
+			serverArgs[i] = base.TestServerArgs{
+				Knobs: base.TestingKnobs{
+					Server: &server.TestingKnobs{
+						WallClock: manuals[i],
+					},
+				},
+			}
+		}
+		ctx := context.Background()
+		tc := testcluster.StartTestCluster(t, numServers,
+			base.TestClusterArgs{
+				ReplicationMode:   base.ReplicationManual,
+				ServerArgsPerNode: serverArgs,
+			})
+		defer tc.Stopper().Stop(ctx)
+
+		// Now, generate two scratch ranges that will later be merged together.
+		keyA, keyC := roachpb.Key("A"), roachpb.Key("C")
+		tc.SplitRangeOrFatal(t, keyA)
+		// Split the range in half to create the ranges that will later be merged.
+		_, keyCDesc := tc.SplitRangeOrFatal(t, keyC)
+		// Next, we place key A's replicas on nodes 0 and 1 and key C's replicas on
+		// nodes 2 and 3.
+		tc.AddVotersOrFatal(t, keyA, tc.Target(1))
+		tc.AddVotersOrFatal(t, keyC, tc.Target(2))
+		tc.AddVotersOrFatal(t, keyC, tc.Target(3))
+		// Finally, transfer the lease for the RHS to node 2.
+		tc.TransferRangeLeaseOrFatal(t, keyCDesc, tc.Target(2))
+		// Make sure the lease transfer completes before we read the clock times.
+		testutils.SucceedsSoon(t, func() error {
+			repl := tc.GetFirstStoreFromServer(t, 2).LookupReplica(keyCDesc.StartKey)
+			lease, _ := repl.GetLease()
+			if lease.Replica.NodeID != repl.NodeID() {
+				return errors.Errorf("expected lease transfer to node 2: %s", lease)
+			}
+			return nil
+		})
+
+		tc.RemoveVotersOrFatal(t, keyC, tc.Target(0))
+		// At this point all the ranges are in the right places.
+
+		// Pause the servers' clocks going forward.
+		var maxNanos int64
+		for _, m := range manuals {
+			m.Pause()
+			if cur := m.UnixNano(); cur > maxNanos {
+				maxNanos = cur
+			}
+		}
+		// After doing so, perfectly synchronize them.
+		for _, m := range manuals {
+			m.Increment(maxNanos - m.UnixNano())
+		}
+
+		// Grab the clock times before we increment the other clock. Otherwise, there
+		// is a chance that server 0 will see server 2's clock and update itself prior
+		// to reading these values.
+		now := tc.Servers[0].Clock().Now()
+		maxOffset := tc.Servers[0].Clock().MaxOffset().Nanoseconds()
+		instanceId := int32(tc.Servers[0].SQLInstanceID())
+
+		// Move the RHS leaseholders clocks forward past the observed timestamp before
+		// writing.
+		manuals[2].Increment(2000)
+
+		// Write the data from a different transaction to establish the time for the
+		// key as 10 ns in the future.
+		_, pErr := kv.SendWrapped(ctx, tc.Servers[2].DistSender(), putArgs(keyC, []byte("value")))
+		require.Nil(t, pErr)
+
+		// Create two identical transactions. The first one will perform a read to a
+		// store before the merge, the second will only read after the merge.
+		txn := roachpb.MakeTransaction("txn1", keyA, 1, now, maxOffset, instanceId)
+		txn2 := roachpb.MakeTransaction("txn2", keyA, 1, now, maxOffset, instanceId)
+
+		// Simulate a read which will cause the observed time to be set to now
+		resp, pErr := kv.SendWrappedWith(ctx, tc.Servers[1].DistSender(), roachpb.Header{Txn: &txn}, getArgs(keyA))
+		require.Nil(t, pErr)
+		// The client needs to update its transaction to the returned transaction which has observed timestamps in it
+		txn = *resp.Header().Txn
+
+		// Now move the ranges, being careful not to move either leaseholder
+		// C: 3 (RHS - replica) => 0 (LHS leaseholder)
+		tc.AddVotersOrFatal(t, keyC, tc.Target(0))
+		tc.RemoveVotersOrFatal(t, keyC, tc.Target(3))
+		// A: 1 (LHS - replica) => 2 (RHS leaseholder)
+		tc.AddVotersOrFatal(t, keyA, tc.Target(2))
+		tc.RemoveVotersOrFatal(t, keyA, tc.Target(1))
+
+		if alignLeaseholders {
+			tc.TransferRangeLeaseOrFatal(t, keyCDesc, tc.Target(0))
+		}
+
+		// Finally, perform the actual merge operation on server 0
+		require.NoError(t, tc.Server(0).DB().AdminMerge(ctx, keyA))
+
+		if alsoSplit {
+			require.NoError(t, tc.Server(0).DB().AdminSplit(ctx, keyC, hlc.MaxTimestamp))
+		}
+
+		// Try and read the transaction from the context of a new transaction. This
+		// will fail as expected as the observed timestamp will not be set.
+		_, pErr = kv.SendWrappedWith(ctx, tc.Servers[0].DistSender(), roachpb.Header{Txn: &txn2}, getArgs(keyC))
+		require.IsType(t, &roachpb.ReadWithinUncertaintyIntervalError{}, pErr.GetDetail())
+
+		// Try and read the key from the existing transaction. This should fail the
+		// same way.
+		// There are four possible outcomes:
+		// - Uncertainty (Good) - Expected since the read and write timestamps cross.
+		// - Other error (Bad) - We expect an uncertainty error so the client can choose a new timestamp and retry.
+		// - Not found (Bad) - Error because the data was written before us.
+		// - Found (Bad) - The write HLC timestamp is after our timestamp.
+		_, pErr = kv.SendWrappedWith(ctx, tc.Servers[0].DistSender(), roachpb.Header{Txn: &txn}, getArgs(keyC))
+		require.IsType(t, &roachpb.ReadWithinUncertaintyIntervalError{}, pErr.GetDetail())
+	}
+
+	testutils.RunTrueAndFalse(t, "alignLeaseholders", func(t *testing.T, alignLeaseholders bool) {
+		testutils.RunTrueAndFalse(t, "alsoSplit", func(t *testing.T, alsoSplit bool) {
+			run(t, alignLeaseholders, alsoSplit)
+		})
+	})
+}
+
 // TestNonTxnReadWithinUncertaintyIntervalAfterLeaseTransfer tests a case where
 // a non-transactional request defers its timestamp allocation to a replica that
 // does not hold the lease at the time of receiving the request, but does by the
@@ -2661,8 +2841,8 @@ func TestLeaseTransferInSnapshotUpdatesTimestampCache(t *testing.T) {
 
 		// Partition node 2 from the rest of its range. Once partitioned, perform
 		// another write and truncate the Raft log on the two connected nodes. This
-		// ensures that that when node 2 comes back up it will require a snapshot
-		// from Raft.
+		// ensures that when node 2 comes back up it will require a snapshot from
+		// Raft.
 		funcs := noopRaftHandlerFuncs()
 		funcs.dropReq = func(*kvserverpb.RaftMessageRequest) bool {
 			return true
@@ -3187,7 +3367,7 @@ func TestReplicaTombstone(t *testing.T) {
 		// to a newer replica ID (in this case a heartbeat) removes an initialized
 		// Replica.
 		//
-		// Don't use tc.AddVoter; this would retry internally as we're faking a
+		// Don't use tc.AddVoter; this would retry internally as we're faking
 		// a snapshot error here (and these are all considered retriable).
 		_, err = tc.Servers[0].DB().AdminChangeReplicas(
 			ctx, key, tc.LookupRangeOrFatal(t, key), roachpb.MakeReplicationChanges(roachpb.ADD_VOTER, tc.Target(2)),
@@ -3235,12 +3415,10 @@ func TestReplicaTombstone(t *testing.T) {
 			ServerArgs: base.TestServerArgs{
 				Knobs: base.TestingKnobs{Store: &kvserver.StoreTestingKnobs{
 					DisableReplicaGCQueue: true,
-					TestingProposalFilter: kvserverbase.ReplicaProposalFilter(
-						func(args kvserverbase.ProposalFilterArgs) *roachpb.Error {
-							return proposalFilter.
-								Load().(func(kvserverbase.ProposalFilterArgs) *roachpb.Error)(args)
-						},
-					),
+					TestingProposalFilter: func(args kvserverbase.ProposalFilterArgs) *roachpb.Error {
+						return proposalFilter.
+							Load().(func(kvserverbase.ProposalFilterArgs) *roachpb.Error)(args)
+					},
 				}},
 			},
 			ReplicationMode: base.ReplicationManual,
@@ -3434,7 +3612,7 @@ func TestAdminRelocateRangeSafety(t *testing.T) {
 // TestChangeReplicasLeaveAtomicRacesWithMerge exercises a hazardous case which
 // arises during concurrent AdminChangeReplicas requests. The code reads the
 // descriptor from range id local, checks to make sure that the read
-// descriptor matches the expectation and then uses the bytes of the read read
+// descriptor matches the expectation and then uses the bytes of the read
 // bytes in a CPut with the update. The code contains an optimization to
 // transition out of joint consensus even if the read descriptor does not match
 // the expectation. That optimization did not verify anything about the read
@@ -3467,8 +3645,8 @@ func TestChangeReplicasLeaveAtomicRacesWithMerge(t *testing.T) {
 			if req, isGet := ba.GetArg(roachpb.Get); !isGet ||
 				ba.RangeID != rangeToBlockRangeDescriptorRead.Load().(roachpb.RangeID) ||
 				!ba.IsSingleRequest() ||
-				!bytes.HasSuffix([]byte(req.(*roachpb.GetRequest).Key),
-					[]byte(keys.LocalRangeDescriptorSuffix)) {
+				!bytes.HasSuffix(req.(*roachpb.GetRequest).Key,
+					keys.LocalRangeDescriptorSuffix) {
 				return nil
 			}
 			select {
@@ -3636,20 +3814,18 @@ func TestTransferLeaseBlocksWrites(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{Store: &kvserver.StoreTestingKnobs{
-				TestingProposalFilter: kvserverbase.ReplicaProposalFilter(
-					func(args kvserverbase.ProposalFilterArgs) *roachpb.Error {
-						if args.Req.RangeID != scratchRangeID.Load().(roachpb.RangeID) {
-							return nil
-						}
-						// Block increment requests on blockInc.
-						if _, isInc := args.Req.GetArg(roachpb.Increment); isInc {
-							unblock := make(chan struct{})
-							blockInc <- unblock
-							<-unblock
-						}
+				TestingProposalFilter: func(args kvserverbase.ProposalFilterArgs) *roachpb.Error {
+					if args.Req.RangeID != scratchRangeID.Load().(roachpb.RangeID) {
 						return nil
-					},
-				),
+					}
+					// Block increment requests on blockInc.
+					if _, isInc := args.Req.GetArg(roachpb.Increment); isInc {
+						unblock := make(chan struct{})
+						blockInc <- unblock
+						<-unblock
+					}
+					return nil
+				},
 			}},
 		},
 		ReplicationMode: base.ReplicationManual,
@@ -4379,7 +4555,7 @@ func TestTenantID(t *testing.T) {
 				Store: &kvserver.StoreTestingKnobs{
 					BeforeSnapshotSSTIngestion: func(
 						snapshot kvserver.IncomingSnapshot,
-						request_type kvserverpb.SnapshotRequest_Type,
+						requestType kvserverpb.SnapshotRequest_Type,
 						strings []string,
 					) error {
 						if snapshot.Desc.RangeID == repl.RangeID {

--- a/pkg/kv/kvserver/kvserverpb/lease_status.proto
+++ b/pkg/kv/kvserver/kvserverpb/lease_status.proto
@@ -94,4 +94,7 @@ message LeaseStatus {
   string err_info = 6;
   // Liveness if this is an epoch-based lease.
   kv.kvserver.liveness.livenesspb.Liveness liveness = 4 [(gogoproto.nullable) = false];
+  // The minimum observed timestamp on a transaction that is respected by this lease.
+  util.hlc.Timestamp min_valid_observed_timestamp = 7 [(gogoproto.nullable) = false,
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/util/hlc.ClockTimestamp"];
 }

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -648,6 +648,7 @@ func (r *Replica) leaseStatus(
 	lease roachpb.Lease,
 	now hlc.ClockTimestamp,
 	minProposedTS hlc.ClockTimestamp,
+	minValidObservedTS hlc.ClockTimestamp,
 	reqTS hlc.Timestamp,
 ) kvserverpb.LeaseStatus {
 	status := kvserverpb.LeaseStatus{
@@ -659,8 +660,9 @@ func (r *Replica) leaseStatus(
 		// present time. We need the current time to distinguish between an
 		// EXPIRED lease and an UNUSABLE lease. Only an EXPIRED lease can change
 		// hands through a lease acquisition.
-		Now:         now,
-		RequestTime: reqTS,
+		Now:                       now,
+		RequestTime:               reqTS,
+		MinValidObservedTimestamp: minValidObservedTS,
 	}
 	var expiration hlc.Timestamp
 	if lease.Type() == roachpb.LeaseExpiration {
@@ -747,7 +749,8 @@ func (r *Replica) leaseStatusForRequestRLocked(
 		// would be given to a request with a timestamp of now.
 		reqTS = now.ToTimestamp()
 	}
-	return r.leaseStatus(ctx, *r.mu.state.Lease, now, r.mu.minLeaseProposedTS, reqTS)
+	return r.leaseStatus(ctx, *r.mu.state.Lease, now, r.mu.minLeaseProposedTS,
+		r.mu.minValidObservedTimestamp, reqTS)
 }
 
 // OwnsValidLease returns whether this replica is the current valid

--- a/pkg/kv/kvserver/store_merge.go
+++ b/pkg/kv/kvserver/store_merge.go
@@ -161,10 +161,15 @@ func (s *Store) MergeRange(
 	// queued transactions to the left-hand replica, if necessary.
 	rightRepl.concMgr.OnRangeMerge()
 
+	// Track Whether the leaseholders were aligned for later updating the
+	// minValidObservedTimestamp.
 	leftLease, _ := leftRepl.GetLease()
 	rightLease, _ := rightRepl.GetLease()
-	if leftLease.OwnedBy(s.Ident.StoreID) {
-		if !rightLease.OwnedBy(s.Ident.StoreID) {
+
+	leftLeaseholder := leftLease.OwnedBy(s.Ident.StoreID)
+	rightLeaseholder := rightLease.OwnedBy(s.Ident.StoreID)
+	if leftLeaseholder {
+		if !rightLeaseholder {
 			// We hold the lease for the LHS, but do not hold the lease for the RHS.
 			// That means we don't have up-to-date timestamp cache entries for the
 			// keyspace previously owned by the RHS. Update the timestamp cache for
@@ -217,6 +222,19 @@ func (s *Store) MergeRange(
 	// leftRepl.Desc().
 	leftRepl.mu.Lock()
 	defer leftRepl.mu.Unlock()
+
+	// As a result of the merge, update the minimum valid observed timestamp so
+	// that times before the merge freeze time are no longer respected. If the
+	// leaseholders were previously aligned, then we simply keep the larger
+	// timestamp. Otherwise, use the more pessimistic RHS freeze timestamp.
+	if leftLeaseholder {
+		if rightLeaseholder {
+			leftRepl.mu.minValidObservedTimestamp.Forward(rightRepl.mu.minValidObservedTimestamp)
+		} else {
+			leftRepl.mu.minValidObservedTimestamp.Forward(freezeStart)
+		}
+	}
+
 	leftRepl.setDescLockedRaftMuLocked(ctx, &newLeftDesc)
 	return nil
 }

--- a/pkg/kv/kvserver/uncertainty/compute_test.go
+++ b/pkg/kv/kvserver/uncertainty/compute_test.go
@@ -82,7 +82,7 @@ func TestComputeInterval(t *testing.T) {
 			tsFromServerClock: &now,
 			lease: func() kvserverpb.LeaseStatus {
 				leaseClone := lease
-				leaseClone.Lease.Start = hlc.ClockTimestamp{WallTime: 18}
+				leaseClone.MinValidObservedTimestamp = hlc.ClockTimestamp{WallTime: 18}
 				return leaseClone
 			}(),
 			exp: Interval{
@@ -96,7 +96,7 @@ func TestComputeInterval(t *testing.T) {
 			tsFromServerClock: &now,
 			lease: func() kvserverpb.LeaseStatus {
 				leaseClone := lease
-				leaseClone.Lease.Start = hlc.ClockTimestamp{WallTime: 32}
+				leaseClone.MinValidObservedTimestamp = hlc.ClockTimestamp{WallTime: 32}
 				return leaseClone
 			}(),
 			exp: Interval{
@@ -138,7 +138,7 @@ func TestComputeInterval(t *testing.T) {
 			txn:  txn,
 			lease: func() kvserverpb.LeaseStatus {
 				leaseClone := lease
-				leaseClone.Lease.Start = hlc.ClockTimestamp{WallTime: 18}
+				leaseClone.MinValidObservedTimestamp = hlc.ClockTimestamp{WallTime: 18}
 				return leaseClone
 			}(),
 			exp: Interval{
@@ -151,7 +151,7 @@ func TestComputeInterval(t *testing.T) {
 			txn:  txn,
 			lease: func() kvserverpb.LeaseStatus {
 				leaseClone := lease
-				leaseClone.Lease.Start = hlc.ClockTimestamp{WallTime: 22}
+				leaseClone.MinValidObservedTimestamp = hlc.ClockTimestamp{WallTime: 22}
 				return leaseClone
 			}(),
 			exp: Interval{


### PR DESCRIPTION
Previously it was possible during a merge for a stale read to
occur due to the handling of observed timestamps. Specifically if
a read occurred on a TX on the LHS of a merge and the following
four conditions held:
- A transaction read from the LHS before the merge.
- The RHS clock was ahead of the LHS clock.
- A write was performed on the RHS "ahead of" the LHS clock.
- The transaction attempted to read the write.

In this case, the read would return not found rather than either
returning the data or an uncertainty error. This results
in a stale read.

The fix is to introduce a new in-memory field to a LeaseStatus
which is when it most recently acquired data that a different
store. Any uncertainty observed timestamps before this time is
ignored.

Release note (bug fix): Prevent a rare case where a stale read
could be returned.