### PR TITLE
cloud/gcp: fix expectation in TestEncryptDecryptGCS

### DIFF
--- a/pkg/cloud/gcp/gcs_kms_test.go
+++ b/pkg/cloud/gcp/gcs_kms_test.go
@@ -53,10 +53,11 @@ func TestEncryptDecryptGCS(t *testing.T) {
 
 		_, err := cloud.KMSFromURI(ctx, uri, &cloud.TestKMSEnv{ExternalIOConfig: &base.ExternalIODirConfig{}})
 		require.EqualError(t, err, fmt.Sprintf(
-			`%s is set to '%s', but %s is not set`,
+			"%s or %s must be set if %q is %q",
+			CredentialsParam,
+			BearerTokenParam,
 			cloud.AuthParam,
 			cloud.AuthParamSpecified,
-			CredentialsParam,
 		))
 	})
 


### PR DESCRIPTION
The expected error message in TestEncryptDecryptGCS is incorrect after the
introduction of bearer tokens, this patch fixes the expectation.

Fixes https://github.com/cockroachdb/cockroach/issues/83251

Release note: None