### PR TITLE
streamingccl: add tracing spans to ingestion process

### DIFF
--- a/pkg/ccl/streamingccl/streamclient/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamclient/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//pkg/util/randutil",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -237,6 +237,8 @@ func (s *streamIngestionResumer) OnFailOrCancel(_ context.Context, _ interface{}
 	return nil
 }
 
+func (s *streamIngestionResumer) ForceRealSpan() bool { return true }
+
 var _ jobs.Resumer = &streamIngestionResumer{}
 
 func init() {


### PR DESCRIPTION
This enables real spans for the stream ingestion job and adds tracing
spans to the partition client and stream ingestion processor.

Starting the job with real spans means that our trace will include
anything recorded with RecordStructured. For example, here is a
snippet of trace from a running job with this enabled:

```
   444.495ms      0.036ms                === operation:stream-ingestion-processor _unfinished:1 node:1 job:773465692775677953 stream-ingest-distsql:
   444.582ms      0.087ms                    === operation:Subscription.Subscribe _unfinished:1 node:1 job:773465692775677953 stream-ingest-distsql:
 20706.491ms  20261.994ms                structured:{"@type":"type.googleapis.com/cockroach.roachpb.ScanStats","numInterfaceSeeks":"2","numInternalSeeks":"2","numInterfaceSteps...
 20707.645ms      1.154ms                structured:{"@type":"type.googleapis.com/google.protobuf.StringValue","value":"ingesting SST (22 keys/2174 bytes) via regular write batch"}
 30447.051ms   9739.591ms                structured:{"@type":"type.googleapis.com/cockroach.roachpb.ScanStats","numInterfaceSeeks":"6","numInternalSeeks":"5","numInterfaceSteps":"...
 40932.980ms  10485.744ms                structured:{"@type":"type.googleapis.com/google.protobuf.StringValue","value":"ingesting SST (2 keys/1213 bytes) via regular write batch"}
 46027.808ms   5094.828ms                structured:{"@type":"type.googleapis.com/google.protobuf.StringValue","value":"ingesting SST (1 keys/1185 bytes) via regular write batch"}
```

I've added spans for the few functions on the ingestion side that I
imagined might be interesting, but we should add more as needed.

Informs #83318

Release note: None