### PR TITLE
kv: fix conflict resolution for high-priority, non-txn'al requests

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_push_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_push_txn.go
@@ -255,7 +255,7 @@ func PushTxn(
 		// If just attempting to cleanup old or already-committed txns,
 		// pusher always fails.
 		pusherWins = false
-	case CanPushWithPriority(&args.PusherTxn, &reply.PusheeTxn):
+	case txnwait.CanPushWithPriority(args.PusherTxn.Priority, reply.PusheeTxn.Priority):
 		reason = "pusher has priority"
 		pusherWins = true
 	case args.Force:

--- a/pkg/kv/kvserver/batcheval/transaction.go
+++ b/pkg/kv/kvserver/batcheval/transaction.go
@@ -118,13 +118,6 @@ func UpdateAbortSpan(
 	return rec.AbortSpan().Put(ctx, readWriter, ms, txn.ID, &curEntry)
 }
 
-// CanPushWithPriority returns true if the given pusher can push the pushee
-// based on its priority.
-func CanPushWithPriority(pusher, pushee *roachpb.Transaction) bool {
-	return (pusher.Priority > enginepb.MinTxnPriority && pushee.Priority == enginepb.MinTxnPriority) ||
-		(pusher.Priority == enginepb.MaxTxnPriority && pushee.Priority < pusher.Priority)
-}
-
 // CanCreateTxnRecord determines whether a transaction record can be created for
 // the provided transaction. If not, the function will return an error. If so,
 // the function may modify the provided transaction.

--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -380,7 +380,7 @@ type Request struct {
 	Timestamp hlc.Timestamp
 
 	// The priority of the request. Only set if Txn is nil.
-	Priority roachpb.UserPriority
+	NonTxnPriority roachpb.UserPriority
 
 	// The consistency level of the request. Only set if Txn is nil.
 	ReadConsistency roachpb.ReadConsistencyType

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -55,7 +55,7 @@ import (
 //
 // The input files use the following DSL:
 //
-// new-txn      name=<txn-name> ts=<int>[,<int>] epoch=<int> [uncertainty-limit=<int>[,<int>]]
+// new-txn      name=<txn-name> ts=<int>[,<int>] [epoch=<int>] [priority] [uncertainty-limit=<int>[,<int>]]
 // new-request  name=<req-name> txn=<txn-name>|none ts=<int>[,<int>] [priority] [inconsistent] [wait-policy=<policy>] [lock-timeout] [max-lock-wait-queue-length=<int>] [poison-policy=[err|wait]]
 //   <proto-name> [<field-name>=<field-value>...] (hint: see scanSingleRequest)
 // sequence     req=<req-name> [eval-kind=<pess|opt|pess-after-opt]
@@ -104,8 +104,12 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				d.ScanArgs(t, "name", &txnName)
 				ts := scanTimestamp(t, d)
 
-				var epoch int
-				d.ScanArgs(t, "epoch", &epoch)
+				epoch := 0
+				if d.HasArg("epoch") {
+					d.ScanArgs(t, "epoch", &epoch)
+				}
+
+				priority := scanTxnPriority(t, d)
 
 				uncertaintyLimit := ts
 				if d.HasArg("uncertainty-limit") {
@@ -125,7 +129,7 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 						Epoch:          enginepb.TxnEpoch(epoch),
 						WriteTimestamp: ts,
 						MinTimestamp:   ts,
-						Priority:       1, // not min or max
+						Priority:       priority,
 					},
 					ReadTimestamp:          ts,
 					GlobalUncertaintyLimit: uncertaintyLimit,
@@ -159,6 +163,7 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 					readConsistency = roachpb.INCONSISTENT
 				}
 
+				priority := scanUserPriority(t, d)
 				waitPolicy := scanWaitPolicy(t, d, false /* required */)
 
 				var lockTimeout time.Duration
@@ -182,9 +187,9 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				latchSpans, lockSpans := c.collectSpans(t, txn, ts, reqs)
 
 				c.requestsByName[reqName] = concurrency.Request{
-					Txn:       txn,
-					Timestamp: ts,
-					// TODO(nvanbenschoten): test Priority
+					Txn:                    txn,
+					Timestamp:              ts,
+					NonTxnPriority:         priority,
 					ReadConsistency:        readConsistency,
 					WaitPolicy:             waitPolicy,
 					LockTimeout:            lockTimeout,
@@ -693,19 +698,47 @@ func (c *cluster) PushTransaction(
 		}
 		defer c.unregisterPush(push)
 	}
+	var pusherPriority enginepb.TxnPriority
+	if h.Txn != nil {
+		pusherPriority = h.Txn.Priority
+	} else {
+		pusherPriority = roachpb.MakePriority(h.UserPriority)
+	}
+	pushTo := h.Timestamp.Next()
 	for {
 		// Is the pushee pushed?
 		pusheeTxn, pusheeRecordSig := pusheeRecord.asTxn()
-		var pushed bool
-		switch pushType {
-		case roachpb.PUSH_TIMESTAMP:
-			pushed = h.Timestamp.Less(pusheeTxn.WriteTimestamp) || pusheeTxn.Status.IsFinalized()
-		case roachpb.PUSH_ABORT, roachpb.PUSH_TOUCH:
-			pushed = pusheeTxn.Status.IsFinalized()
+		// NOTE: this logic is adapted from cmd_push_txn.go.
+		var pusherWins bool
+		switch {
+		case pusheeTxn.Status.IsFinalized():
+			// Already finalized.
+			return pusheeTxn, nil
+		case pushType == roachpb.PUSH_TIMESTAMP && pushTo.LessEq(pusheeTxn.WriteTimestamp):
+			// Already pushed.
+			return pusheeTxn, nil
+		case pushType == roachpb.PUSH_TOUCH:
+			pusherWins = false
+		case txnwait.CanPushWithPriority(pusherPriority, pusheeTxn.Priority):
+			pusherWins = true
 		default:
-			return nil, roachpb.NewErrorf("unexpected push type: %s", pushType)
+			pusherWins = false
 		}
-		if pushed {
+		if pusherWins {
+			switch pushType {
+			case roachpb.PUSH_ABORT:
+				log.Eventf(ctx, "pusher aborted pushee")
+				err = c.updateTxnRecord(pusheeTxn.ID, roachpb.ABORTED, pusheeTxn.WriteTimestamp)
+			case roachpb.PUSH_TIMESTAMP:
+				log.Eventf(ctx, "pusher pushed pushee to %s", pushTo)
+				err = c.updateTxnRecord(pusheeTxn.ID, pusheeTxn.Status, pushTo)
+			default:
+				err = errors.Errorf("unexpected push type: %s", pushType)
+			}
+			if err != nil {
+				return nil, roachpb.NewError(err)
+			}
+			pusheeTxn, _ = pusheeRecord.asTxn()
 			return pusheeTxn, nil
 		}
 		// If PUSH_TOUCH, return error instead of waiting.

--- a/pkg/kv/kvserver/concurrency/datadriven_util_test.go
+++ b/pkg/kv/kvserver/concurrency/datadriven_util_test.go
@@ -44,6 +44,41 @@ func scanTimestampWithName(t *testing.T, d *datadriven.TestData, name string) hl
 	return ts
 }
 
+func scanTxnPriority(t *testing.T, d *datadriven.TestData) enginepb.TxnPriority {
+	priority := scanUserPriority(t, d)
+	// NB: don't use roachpb.MakePriority to avoid randomness.
+	switch priority {
+	case roachpb.MinUserPriority:
+		return enginepb.MinTxnPriority
+	case roachpb.NormalUserPriority:
+		return 1 // not min nor max
+	case roachpb.MaxUserPriority:
+		return enginepb.MaxTxnPriority
+	default:
+		d.Fatalf(t, "unknown priority: %s", priority)
+		return 0
+	}
+}
+
+func scanUserPriority(t *testing.T, d *datadriven.TestData) roachpb.UserPriority {
+	const key = "priority"
+	priS := "normal"
+	if d.HasArg(key) {
+		d.ScanArgs(t, key, &priS)
+	}
+	switch priS {
+	case "low":
+		return roachpb.MinUserPriority
+	case "normal":
+		return roachpb.NormalUserPriority
+	case "high":
+		return roachpb.MaxUserPriority
+	default:
+		d.Fatalf(t, "unknown priority: %s", priS)
+		return 0
+	}
+}
+
 func scanLockStrength(t *testing.T, d *datadriven.TestData) lock.Strength {
 	var strS string
 	d.ScanArgs(t, "strength", &strS)

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/intentresolver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/txnwait"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -221,9 +222,14 @@ func (w *lockTableWaiterImpl) WaitOn(
 				// still active.
 				timeoutPush := req.LockTimeout != 0
 
+				// If the pushee has the minimum priority or if the pusher has the
+				// maximum priority, push immediately to proceed without queueing.
+				// The push should succeed without entering the txn wait-queue.
+				priorityPush := canPushWithPriority(req, state)
+
 				// If the request doesn't want to perform a delayed push for any
 				// reason, continue waiting without a timer.
-				if !livenessPush && !deadlockPush && !timeoutPush {
+				if !(livenessPush || deadlockPush || timeoutPush || priorityPush) {
 					continue
 				}
 
@@ -250,12 +256,7 @@ func (w *lockTableWaiterImpl) WaitOn(
 					}
 					delay = minDuration(delay, w.timeUntilDeadline(lockDeadline))
 				}
-
-				// However, if the pushee has the minimum priority or if the
-				// pusher has the maximum priority, push immediately.
-				// TODO(nvanbenschoten): flesh these interactions out more and
-				// add some testing.
-				if hasMinPriority(state.txn) || hasMaxPriority(req.Txn) {
+				if priorityPush {
 					delay = 0
 				}
 
@@ -754,7 +755,7 @@ func (w *lockTableWaiterImpl) pushRequestTxn(
 func (w *lockTableWaiterImpl) pushHeader(req Request) roachpb.Header {
 	h := roachpb.Header{
 		Timestamp:    req.Timestamp,
-		UserPriority: req.Priority,
+		UserPriority: req.NonTxnPriority,
 	}
 	if req.Txn != nil {
 		// We are going to hand the header (and thus the transaction proto) to
@@ -1224,12 +1225,19 @@ func newWriteIntentErr(
 	return err
 }
 
-func hasMinPriority(txn *enginepb.TxnMeta) bool {
-	return txn != nil && txn.Priority == enginepb.MinTxnPriority
-}
-
-func hasMaxPriority(txn *roachpb.Transaction) bool {
-	return txn != nil && txn.Priority == enginepb.MaxTxnPriority
+func canPushWithPriority(req Request, s waitingState) bool {
+	var pusher, pushee enginepb.TxnPriority
+	if req.Txn != nil {
+		pusher = req.Txn.Priority
+	} else {
+		pusher = roachpb.MakePriority(req.NonTxnPriority)
+	}
+	if s.txn == nil {
+		// Can't push a non-transactional request.
+		return false
+	}
+	pushee = s.txn.Priority
+	return txnwait.CanPushWithPriority(pusher, pushee)
 }
 
 func minDuration(a, b time.Duration) time.Duration {

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -230,6 +230,7 @@ func (w *lockTableWaiterImpl) WaitOn(
 				// If the request doesn't want to perform a delayed push for any
 				// reason, continue waiting without a timer.
 				if !(livenessPush || deadlockPush || timeoutPush || priorityPush) {
+					log.Eventf(ctx, "not pushing")
 					continue
 				}
 
@@ -259,6 +260,11 @@ func (w *lockTableWaiterImpl) WaitOn(
 				if priorityPush {
 					delay = 0
 				}
+
+				log.Eventf(ctx, "pushing after %s for: "+
+					"liveness detection = %t, deadlock detection = %t, "+
+					"timeout enforcement = %t, priority enforcement = %t",
+					delay, livenessPush, deadlockPush, timeoutPush, priorityPush)
 
 				if delay > 0 {
 					if timer == nil {

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
@@ -241,8 +241,8 @@ func TestLockTableWaiterWithNonTxn(t *testing.T) {
 	reqHeaderTS := hlc.Timestamp{WallTime: 10}
 	makeReq := func() Request {
 		return Request{
-			Timestamp: reqHeaderTS,
-			Priority:  roachpb.NormalUserPriority,
+			Timestamp:      reqHeaderTS,
+			NonTxnPriority: roachpb.NormalUserPriority,
 		}
 	}
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
@@ -117,6 +117,7 @@ sequence req=req3
 [2] sequence req3: scanning lock table for conflicting locks
 [2] sequence req3: waiting in lock wait-queues
 [2] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
+[2] sequence req3: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [2] sequence req3: pushing timestamp of txn 00000002 above 14.000000000,1
 [2] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -204,6 +205,7 @@ sequence req=req5
 [2] sequence req5: scanning lock table for conflicting locks
 [2] sequence req5: waiting in lock wait-queues
 [2] sequence req5: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
+[2] sequence req5: pushing after 0s for: liveness detection = true, deadlock detection = false, timeout enforcement = false, priority enforcement = false
 [2] sequence req5: pushing timestamp of txn 00000002 above 14.000000000,1
 [2] sequence req5: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -218,6 +220,7 @@ sequence req=req6
 [3] sequence req6: scanning lock table for conflicting locks
 [3] sequence req6: waiting in lock wait-queues
 [3] sequence req6: lock wait-queue event: wait for txn 00000002 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 2)
+[3] sequence req6: not pushing
 [3] sequence req6: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 debug-advance-clock ts=123
@@ -261,6 +264,7 @@ finish req=req6
 [4] sequence req7: scanning lock table for conflicting locks
 [4] sequence req7: waiting in lock wait-queues
 [4] sequence req7: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[4] sequence req7: pushing after 0s for: liveness detection = true, deadlock detection = false, timeout enforcement = false, priority enforcement = false
 [4] sequence req7: pushing txn 00000002 to abort
 [4] sequence req7: blocked on select in concurrency_test.(*cluster).PushTransaction
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
@@ -65,6 +65,7 @@ sequence req=req1
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
 [3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "a" (queuedWriters: 0, queuedReaders: 1)
+[3] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -178,6 +179,7 @@ sequence req=req1
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
 [3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "a" (queuedWriters: 1, queuedReaders: 0)
+[3] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req1: pushing txn 00000002 to abort
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -354,6 +356,7 @@ sequence req=req1
 [4] sequence req1: scanning lock table for conflicting locks
 [4] sequence req1: waiting in lock wait-queues
 [4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "a" (queuedWriters: 0, queuedReaders: 1)
+[4] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -471,6 +474,7 @@ sequence req=req1
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
 [3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "c" (queuedWriters: 1, queuedReaders: 0)
+[3] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req1: pushing txn 00000003 to abort
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -564,6 +568,7 @@ sequence req=req2
 [6] sequence req2: scanning lock table for conflicting locks
 [6] sequence req2: waiting in lock wait-queues
 [6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "a" (queuedWriters: 0, queuedReaders: 1)
+[6] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [6] sequence req2: pushing timestamp of txn 00000003 above 11.000000000,1
 [6] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -603,11 +608,13 @@ on-txn-updated txn=txn3 status=aborted
 [3] sequence req1: resolving intent "c" for txn 00000003 with ABORTED status
 [3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000005 holding lock @ key "e" (queuedWriters: 1, queuedReaders: 0)
 [3] sequence req1: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 123.000s
+[3] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req1: pushing txn 00000005 to abort
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 [6] sequence req2: resolving intent "a" for txn 00000003 with ABORTED status
 [6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000004 holding lock @ key "b" (queuedWriters: 0, queuedReaders: 1)
 [6] sequence req2: conflicted with 00000003-0000-0000-0000-000000000000 on "a" for 123.000s
+[6] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [6] sequence req2: pushing timestamp of txn 00000004 above 11.000000000,1
 [6] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
@@ -44,6 +44,7 @@ sequence req=req1
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
 [3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "a" (queuedWriters: 0, queuedReaders: 1)
+[3] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
@@ -113,6 +113,7 @@ sequence req=req1r
 [4] sequence req1r: scanning lock table for conflicting locks
 [4] sequence req1r: waiting in lock wait-queues
 [4] sequence req1r: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "b" (queuedWriters: 0, queuedReaders: 1)
+[4] sequence req1r: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req1r: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1r: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -123,6 +124,7 @@ sequence req=req2r
 [5] sequence req2r: scanning lock table for conflicting locks
 [5] sequence req2r: waiting in lock wait-queues
 [5] sequence req2r: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "c" (queuedWriters: 0, queuedReaders: 1)
+[5] sequence req2r: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [5] sequence req2r: pushing timestamp of txn 00000003 above 10.000000000,1
 [5] sequence req2r: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -135,6 +137,7 @@ sequence req=req3r
 [6] sequence req3r: scanning lock table for conflicting locks
 [6] sequence req3r: waiting in lock wait-queues
 [6] sequence req3r: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "a" (queuedWriters: 0, queuedReaders: 1)
+[6] sequence req3r: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [6] sequence req3r: pushing timestamp of txn 00000001 above 10.000000000,1
 [6] sequence req3r: blocked on select in concurrency_test.(*cluster).PushTransaction
 [6] sequence req3r: dependency cycle detected 00000003->00000001->00000002->00000003
@@ -326,6 +329,7 @@ sequence req=req4w
 [4] sequence req4w: scanning lock table for conflicting locks
 [4] sequence req4w: waiting in lock wait-queues
 [4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "a" (queuedWriters: 1, queuedReaders: 0)
+[4] sequence req4w: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req4w: pushing txn 00000001 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -336,6 +340,7 @@ sequence req=req1w2
 [5] sequence req1w2: scanning lock table for conflicting locks
 [5] sequence req1w2: waiting in lock wait-queues
 [5] sequence req1w2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "b" (queuedWriters: 1, queuedReaders: 0)
+[5] sequence req1w2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [5] sequence req1w2: pushing txn 00000002 to abort
 [5] sequence req1w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -346,6 +351,7 @@ sequence req=req2w2
 [6] sequence req2w2: scanning lock table for conflicting locks
 [6] sequence req2w2: waiting in lock wait-queues
 [6] sequence req2w2: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "c" (queuedWriters: 1, queuedReaders: 0)
+[6] sequence req2w2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [6] sequence req2w2: pushing txn 00000003 to abort
 [6] sequence req2w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -358,6 +364,7 @@ sequence req=req3w2
 [7] sequence req3w2: scanning lock table for conflicting locks
 [7] sequence req3w2: waiting in lock wait-queues
 [7] sequence req3w2: lock wait-queue event: wait for txn 00000001 holding lock @ key "a" (queuedWriters: 2, queuedReaders: 0)
+[7] sequence req3w2: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [7] sequence req3w2: pushing txn 00000001 to abort
 [7] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 [7] sequence req3w2: dependency cycle detected 00000003->00000001->00000002->00000003
@@ -399,6 +406,7 @@ on-txn-updated txn=txn1 status=aborted
 [7] sequence req3w2: resolving intent "a" for txn 00000001 with ABORTED status
 [7] sequence req3w2: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key "a" (queuedWriters: 1, queuedReaders: 0)
 [7] sequence req3w2: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 0.000s
+[7] sequence req3w2: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [7] sequence req3w2: pushing txn 00000004 to detect request deadlock
 [7] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -552,6 +560,7 @@ sequence req=req4w
 [4] sequence req4w: scanning lock table for conflicting locks
 [4] sequence req4w: waiting in lock wait-queues
 [4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "b" (queuedWriters: 1, queuedReaders: 0)
+[4] sequence req4w: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req4w: pushing txn 00000002 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -561,6 +570,7 @@ on-txn-updated txn=txn2 status=committed
 [4] sequence req4w: resolving intent "b" for txn 00000002 with COMMITTED status
 [4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "c" (queuedWriters: 1, queuedReaders: 0)
 [4] sequence req4w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 0.000s
+[4] sequence req4w: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req4w: pushing txn 00000003 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -597,6 +607,7 @@ sequence req=req1w2
 [5] sequence req1w2: scanning lock table for conflicting locks
 [5] sequence req1w2: waiting in lock wait-queues
 [5] sequence req1w2: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key "b" (queuedWriters: 1, queuedReaders: 0)
+[5] sequence req1w2: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [5] sequence req1w2: pushing txn 00000004 to detect request deadlock
 [5] sequence req1w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -609,6 +620,7 @@ sequence req=req3w2
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: waiting in lock wait-queues
 [6] sequence req3w2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "a" (queuedWriters: 1, queuedReaders: 0)
+[6] sequence req3w2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [6] sequence req3w2: pushing txn 00000001 to abort
 [6] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 [6] sequence req3w2: dependency cycle detected 00000003->00000001->00000004->00000003
@@ -786,6 +798,7 @@ sequence req=req4w
 [4] sequence req4w: scanning lock table for conflicting locks
 [4] sequence req4w: waiting in lock wait-queues
 [4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "b" (queuedWriters: 1, queuedReaders: 0)
+[4] sequence req4w: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req4w: pushing txn 00000002 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -795,6 +808,7 @@ on-txn-updated txn=txn2 status=committed
 [4] sequence req4w: resolving intent "b" for txn 00000002 with COMMITTED status
 [4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "c" (queuedWriters: 1, queuedReaders: 0)
 [4] sequence req4w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 0.000s
+[4] sequence req4w: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req4w: pushing txn 00000003 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -831,6 +845,7 @@ sequence req=req1w2
 [5] sequence req1w2: scanning lock table for conflicting locks
 [5] sequence req1w2: waiting in lock wait-queues
 [5] sequence req1w2: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key "b" (queuedWriters: 1, queuedReaders: 0)
+[5] sequence req1w2: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [5] sequence req1w2: pushing txn 00000004 to detect request deadlock
 [5] sequence req1w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -843,6 +858,7 @@ sequence req=req3w2
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: waiting in lock wait-queues
 [6] sequence req3w2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "a" (queuedWriters: 1, queuedReaders: 0)
+[6] sequence req3w2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [6] sequence req3w2: pushing txn 00000001 to abort
 [6] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 [6] sequence req3w2: dependency cycle detected 00000003->00000001->00000004->00000003
@@ -1032,6 +1048,7 @@ sequence req=req5w
 [4] sequence req5w: scanning lock table for conflicting locks
 [4] sequence req5w: waiting in lock wait-queues
 [4] sequence req5w: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "b" (queuedWriters: 1, queuedReaders: 0)
+[4] sequence req5w: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req5w: pushing txn 00000002 to abort
 [4] sequence req5w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -1042,6 +1059,7 @@ sequence req=req4w
 [5] sequence req4w: scanning lock table for conflicting locks
 [5] sequence req4w: waiting in lock wait-queues
 [5] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "a" (queuedWriters: 1, queuedReaders: 0)
+[5] sequence req4w: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [5] sequence req4w: pushing txn 00000001 to abort
 [5] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -1051,6 +1069,7 @@ on-txn-updated txn=txn1 status=committed
 [5] sequence req4w: resolving intent "a" for txn 00000001 with COMMITTED status
 [5] sequence req4w: lock wait-queue event: wait for txn 00000002 holding lock @ key "b" (queuedWriters: 2, queuedReaders: 0)
 [5] sequence req4w: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 0.000s
+[5] sequence req4w: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [5] sequence req4w: pushing txn 00000002 to abort
 [5] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -1060,11 +1079,13 @@ on-txn-updated txn=txn2 status=committed
 [4] sequence req5w: resolving intent "b" for txn 00000002 with COMMITTED status
 [4] sequence req5w: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "c" (queuedWriters: 1, queuedReaders: 0)
 [4] sequence req5w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 0.000s
+[4] sequence req5w: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req5w: pushing txn 00000003 to abort
 [4] sequence req5w: blocked on select in concurrency_test.(*cluster).PushTransaction
 [5] sequence req4w: resolving intent "b" for txn 00000002 with COMMITTED status
 [5] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000005 running request @ key "b" (queuedWriters: 1, queuedReaders: 0)
 [5] sequence req4w: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 0.000s
+[5] sequence req4w: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [5] sequence req4w: pushing txn 00000005 to detect request deadlock
 [5] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -1102,6 +1123,7 @@ sequence req=req3w2
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: waiting in lock wait-queues
 [6] sequence req3w2: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key "a" (queuedWriters: 1, queuedReaders: 0)
+[6] sequence req3w2: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [6] sequence req3w2: pushing txn 00000004 to detect request deadlock
 [6] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
 [6] sequence req3w2: dependency cycle detected 00000003->00000004->00000005->00000003

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
@@ -150,6 +150,7 @@ sequence req=req4
 [5] sequence req4: scanning lock table for conflicting locks
 [5] sequence req4: waiting in lock wait-queues
 [5] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
+[5] sequence req4: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [5] sequence req4: pushing timestamp of txn 00000003 above 10.000000000,0
 [5] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -176,6 +177,7 @@ sequence req=req2
 [7] sequence req2: scanning lock table for conflicting locks
 [7] sequence req2: waiting in lock wait-queues
 [7] sequence req2: lock wait-queue event: wait for txn 00000003 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 2)
+[7] sequence req2: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [7] sequence req2: pushing timestamp of txn 00000003 above 10.000000000,0
 [7] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
@@ -39,6 +39,7 @@ sequence req=req1
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
 [3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
+[3] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req1: pushing timestamp of txn 00000001 above 12.000000000,1
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout
@@ -71,6 +71,7 @@ sequence req=req3
 [3] sequence req3: scanning lock table for conflicting locks
 [3] sequence req3: waiting in lock wait-queues
 [3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k2" (queuedWriters: 1, queuedReaders: 0)
+[3] sequence req3: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req3: pushing txn 00000001 to abort
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -104,6 +105,7 @@ sequence req=reqTimeout1
 [4] sequence reqTimeout1: scanning lock table for conflicting locks
 [4] sequence reqTimeout1: waiting in lock wait-queues
 [4] sequence reqTimeout1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
+[4] sequence reqTimeout1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = true, priority enforcement = false
 [4] sequence reqTimeout1: pushing txn 00000001 to check if abandoned
 [4] sequence reqTimeout1: pushee not abandoned
 [4] sequence reqTimeout1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
@@ -120,6 +122,7 @@ on-txn-updated txn=txn1 status=committed
 [3] sequence req3: resolving intent "k2" for txn 00000001 with COMMITTED status
 [3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k3" (queuedWriters: 1, queuedReaders: 0)
 [3] sequence req3: conflicted with 00000001-0000-0000-0000-000000000000 on "k2" for 0.000s
+[3] sequence req3: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req3: pushing txn 00000002 to abort
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -163,6 +166,7 @@ sequence req=reqTimeout2
 [6] sequence reqTimeout2: scanning lock table for conflicting locks
 [6] sequence reqTimeout2: waiting in lock wait-queues
 [6] sequence reqTimeout2: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key "k2" (queuedWriters: 1, queuedReaders: 0)
+[6] sequence reqTimeout2: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = true, priority enforcement = false
 [6] sequence reqTimeout2: conflicted with 00000003-0000-0000-0000-000000000000 on "k2" for 0.000s
 [6] sequence reqTimeout2: sequencing complete, returned error: conflicting intents on "k2" [reason=lock_timeout]
 
@@ -194,6 +198,7 @@ sequence req=reqTimeout3
 [9] sequence reqTimeout3: scanning lock table for conflicting locks
 [9] sequence reqTimeout3: waiting in lock wait-queues
 [9] sequence reqTimeout3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k4" (queuedWriters: 0, queuedReaders: 1)
+[9] sequence reqTimeout3: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = true, priority enforcement = false
 [9] sequence reqTimeout3: pushing txn 00000002 to check if abandoned
 [9] sequence reqTimeout3: pushee not abandoned
 [9] sequence reqTimeout3: conflicted with 00000002-0000-0000-0000-000000000000 on "k4" for 0.000s

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/optimistic
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/optimistic
@@ -93,6 +93,7 @@ sequence req=req3 eval-kind=pess-after-opt
 [4] sequence req3: scanning lock table for conflicting locks
 [4] sequence req3: waiting in lock wait-queues
 [4] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "d" (queuedWriters: 0, queuedReaders: 1)
+[4] sequence req3: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req3: pushing timestamp of txn 00000001 above 12.000000000,1
 [4] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/priority
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/priority
@@ -1,0 +1,575 @@
+new-txn name=txnLowPushee ts=10,1 priority=low
+----
+
+new-txn name=txnNormalPushee ts=10,1 priority=normal
+----
+
+new-txn name=txnHighPushee ts=10,1 priority=high
+----
+
+new-txn name=txnLowPusher1 ts=10,1 priority=low
+----
+
+new-txn name=txnLowPusher2 ts=10,1 priority=low
+----
+
+new-txn name=txnLowPusher3 ts=10,1 priority=low
+----
+
+new-txn name=txnNormalPusher1 ts=10,1 priority=normal
+----
+
+new-txn name=txnNormalPusher2 ts=10,1 priority=normal
+----
+
+new-txn name=txnHighPusher ts=10,1 priority=high
+----
+
+# -------------------------------------------------------------
+# Prep: "Pushee" txns acquire 2 locks each.
+# -------------------------------------------------------------
+
+new-request name=req1 txn=txnLowPushee ts=10,1
+  put key=kLow1  value=v
+  put key=kLow2  value=v
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+on-lock-acquired req=req1 key=kLow1
+----
+[-] acquire lock: txn 00000001 @ kLow1
+
+on-lock-acquired req=req1 key=kLow2
+----
+[-] acquire lock: txn 00000001 @ kLow2
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+new-request name=req2 txn=txnNormalPushee ts=10,1
+  put key=kNormal1  value=v
+  put key=kNormal2  value=v
+----
+
+sequence req=req2
+----
+[2] sequence req2: sequencing request
+[2] sequence req2: acquiring latches
+[2] sequence req2: scanning lock table for conflicting locks
+[2] sequence req2: sequencing complete, returned guard
+
+on-lock-acquired req=req2 key=kNormal1
+----
+[-] acquire lock: txn 00000002 @ kNormal1
+
+on-lock-acquired req=req2 key=kNormal2
+----
+[-] acquire lock: txn 00000002 @ kNormal2
+
+finish req=req2
+----
+[-] finish req2: finishing request
+
+new-request name=req3 txn=txnHighPushee ts=10,1
+  put key=kHigh1  value=v
+  put key=kHigh2  value=v
+----
+
+sequence req=req3
+----
+[3] sequence req3: sequencing request
+[3] sequence req3: acquiring latches
+[3] sequence req3: scanning lock table for conflicting locks
+[3] sequence req3: sequencing complete, returned guard
+
+on-lock-acquired req=req3 key=kHigh1
+----
+[-] acquire lock: txn 00000003 @ kHigh1
+
+on-lock-acquired req=req3 key=kHigh2
+----
+[-] acquire lock: txn 00000003 @ kHigh2
+
+finish req=req3
+----
+[-] finish req3: finishing request
+
+debug-lock-table
+----
+global: num=6
+ lock: "kHigh1"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kHigh2"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kLow1"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kLow2"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kNormal1"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kNormal2"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+local: num=0
+
+# -------------------------------------------------------------
+# Push (timestamp) the low priority txn using:
+# - a low priority transactional request
+# - a normal priority transactional request
+# -------------------------------------------------------------
+
+new-request name=req4 txn=txnLowPusher1 ts=10,1
+  get key=kLow1
+----
+
+new-request name=req5 txn=txnNormalPusher1 ts=10,1
+  get key=kLow1
+----
+
+sequence req=req4
+----
+[4] sequence req4: sequencing request
+[4] sequence req4: acquiring latches
+[4] sequence req4: scanning lock table for conflicting locks
+[4] sequence req4: waiting in lock wait-queues
+[4] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "kLow1" (queuedWriters: 0, queuedReaders: 1)
+[4] sequence req4: pushing timestamp of txn 00000001 above 10.000000000,1
+[4] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+sequence req=req5
+----
+[4] sequence req4: resolving intent "kLow1" for txn 00000001 with PENDING status and clock observation {1 123.000000000,1}
+[4] sequence req4: lock wait-queue event: done waiting
+[4] sequence req4: conflicted with 00000001-0000-0000-0000-000000000000 on "kLow1" for 0.000s
+[4] sequence req4: acquiring latches
+[4] sequence req4: scanning lock table for conflicting locks
+[4] sequence req4: sequencing complete, returned guard
+[5] sequence req5: sequencing request
+[5] sequence req5: acquiring latches
+[5] sequence req5: scanning lock table for conflicting locks
+[5] sequence req5: waiting in lock wait-queues
+[5] sequence req5: lock wait-queue event: wait for txn 00000001 holding lock @ key "kLow1" (queuedWriters: 0, queuedReaders: 2)
+[5] sequence req5: pushing timestamp of txn 00000001 above 10.000000000,1
+[5] sequence req5: pusher pushed pushee to 10.000000000,2
+[5] sequence req5: resolving intent "kLow1" for txn 00000001 with PENDING status and clock observation {1 123.000000000,3}
+[5] sequence req5: lock wait-queue event: done waiting
+[5] sequence req5: conflicted with 00000001-0000-0000-0000-000000000000 on "kLow1" for 0.000s
+[5] sequence req5: acquiring latches
+[5] sequence req5: scanning lock table for conflicting locks
+[5] sequence req5: sequencing complete, returned guard
+
+finish req=req4
+----
+[-] finish req4: finishing request
+
+finish req=req5
+----
+[-] finish req5: finishing request
+
+debug-lock-table
+----
+global: num=6
+ lock: "kHigh1"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kHigh2"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kLow1"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kLow2"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kNormal1"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kNormal2"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+local: num=0
+
+# -------------------------------------------------------------
+# Push (abort) the low priority txn using:
+# - a low priority transactional request
+# - a normal priority non-transactional request
+# -------------------------------------------------------------
+
+new-request name=req6 txn=txnLowPusher1 ts=10,1
+  put key=kLow2  value=v
+----
+
+new-request name=req7 txn=none ts=10,1 priority=normal
+  put key=kLow2  value=v
+----
+
+sequence req=req6
+----
+[6] sequence req6: sequencing request
+[6] sequence req6: acquiring latches
+[6] sequence req6: scanning lock table for conflicting locks
+[6] sequence req6: waiting in lock wait-queues
+[6] sequence req6: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "kLow2" (queuedWriters: 1, queuedReaders: 0)
+[6] sequence req6: pushing txn 00000001 to abort
+[6] sequence req6: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+sequence req=req7
+----
+[6] sequence req6: resolving intent "kLow2" for txn 00000001 with ABORTED status
+[6] sequence req6: lock wait-queue event: done waiting
+[6] sequence req6: conflicted with 00000001-0000-0000-0000-000000000000 on "kLow2" for 0.000s
+[6] sequence req6: acquiring latches
+[6] sequence req6: scanning lock table for conflicting locks
+[6] sequence req6: sequencing complete, returned guard
+[7] sequence req7: sequencing request
+[7] sequence req7: acquiring latches
+[7] sequence req7: scanning lock table for conflicting locks
+[7] sequence req7: waiting in lock wait-queues
+[7] sequence req7: lock wait-queue event: wait for txn 00000001 holding lock @ key "kLow2" (queuedWriters: 2, queuedReaders: 0)
+[7] sequence req7: pushing txn 00000001 to abort
+[7] sequence req7: pusher aborted pushee
+[7] sequence req7: resolving intent "kLow2" for txn 00000001 with ABORTED status
+[7] sequence req7: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key "kLow2" (queuedWriters: 1, queuedReaders: 0)
+[7] sequence req7: conflicted with 00000001-0000-0000-0000-000000000000 on "kLow2" for 0.000s
+[7] sequence req7: pushing txn 00000004 to detect request deadlock
+[7] sequence req7: pusher aborted pushee
+[7] sequence req7: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
+
+finish req=req6
+----
+[-] finish req6: finishing request
+[7] sequence req7: lock wait-queue event: done waiting
+[7] sequence req7: conflicted with 00000004-0000-0000-0000-000000000000 on "kLow2" for 0.000s
+[7] sequence req7: acquiring latches
+[7] sequence req7: scanning lock table for conflicting locks
+[7] sequence req7: sequencing complete, returned guard
+
+finish req=req7
+----
+[-] finish req7: finishing request
+
+debug-lock-table
+----
+global: num=5
+ lock: "kHigh1"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kHigh2"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kLow1"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl [holder finalized: aborted] epoch: 0, seqs: [0]
+ lock: "kNormal1"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kNormal2"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+local: num=0
+
+# -------------------------------------------------------------
+# Push (timestamp) the normal priority txn using:
+# - a normal priority transactional request
+# - a high priority transactional request
+# -------------------------------------------------------------
+
+new-request name=req8 txn=txnNormalPusher1 ts=10,1
+  get key=kNormal1
+----
+
+new-request name=req9 txn=txnHighPusher ts=10,1
+  get key=kNormal1
+----
+
+sequence req=req8
+----
+[8] sequence req8: sequencing request
+[8] sequence req8: acquiring latches
+[8] sequence req8: scanning lock table for conflicting locks
+[8] sequence req8: waiting in lock wait-queues
+[8] sequence req8: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "kNormal1" (queuedWriters: 0, queuedReaders: 1)
+[8] sequence req8: pushing timestamp of txn 00000002 above 10.000000000,1
+[8] sequence req8: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+sequence req=req9
+----
+[8] sequence req8: resolving intent "kNormal1" for txn 00000002 with PENDING status and clock observation {1 123.000000000,6}
+[8] sequence req8: lock wait-queue event: done waiting
+[8] sequence req8: conflicted with 00000002-0000-0000-0000-000000000000 on "kNormal1" for 0.000s
+[8] sequence req8: acquiring latches
+[8] sequence req8: scanning lock table for conflicting locks
+[8] sequence req8: sequencing complete, returned guard
+[9] sequence req9: sequencing request
+[9] sequence req9: acquiring latches
+[9] sequence req9: scanning lock table for conflicting locks
+[9] sequence req9: waiting in lock wait-queues
+[9] sequence req9: lock wait-queue event: wait for txn 00000002 holding lock @ key "kNormal1" (queuedWriters: 0, queuedReaders: 2)
+[9] sequence req9: pushing timestamp of txn 00000002 above 10.000000000,1
+[9] sequence req9: pusher pushed pushee to 10.000000000,2
+[9] sequence req9: resolving intent "kNormal1" for txn 00000002 with PENDING status and clock observation {1 123.000000000,8}
+[9] sequence req9: lock wait-queue event: done waiting
+[9] sequence req9: conflicted with 00000002-0000-0000-0000-000000000000 on "kNormal1" for 0.000s
+[9] sequence req9: acquiring latches
+[9] sequence req9: scanning lock table for conflicting locks
+[9] sequence req9: sequencing complete, returned guard
+
+finish req=req8
+----
+[-] finish req8: finishing request
+
+finish req=req9
+----
+[-] finish req9: finishing request
+
+debug-lock-table
+----
+global: num=5
+ lock: "kHigh1"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kHigh2"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kLow1"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl [holder finalized: aborted] epoch: 0, seqs: [0]
+ lock: "kNormal1"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kNormal2"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+local: num=0
+
+# -------------------------------------------------------------
+# Push (abort) the normal priority txn using:
+# - a normal priority transactional request
+# - a high priority non-transactional request
+# -------------------------------------------------------------
+
+new-request name=req10 txn=txnNormalPusher1 ts=10,1
+  put key=kNormal2  value=v
+----
+
+new-request name=req11 txn=none ts=10,1 priority=high
+  put key=kNormal2  value=v
+----
+
+sequence req=req10
+----
+[10] sequence req10: sequencing request
+[10] sequence req10: acquiring latches
+[10] sequence req10: scanning lock table for conflicting locks
+[10] sequence req10: waiting in lock wait-queues
+[10] sequence req10: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "kNormal2" (queuedWriters: 1, queuedReaders: 0)
+[10] sequence req10: pushing txn 00000002 to abort
+[10] sequence req10: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+sequence req=req11
+----
+[10] sequence req10: resolving intent "kNormal2" for txn 00000002 with ABORTED status
+[10] sequence req10: lock wait-queue event: done waiting
+[10] sequence req10: conflicted with 00000002-0000-0000-0000-000000000000 on "kNormal2" for 0.000s
+[10] sequence req10: acquiring latches
+[10] sequence req10: scanning lock table for conflicting locks
+[10] sequence req10: sequencing complete, returned guard
+[11] sequence req11: sequencing request
+[11] sequence req11: acquiring latches
+[11] sequence req11: scanning lock table for conflicting locks
+[11] sequence req11: waiting in lock wait-queues
+[11] sequence req11: lock wait-queue event: wait for txn 00000002 holding lock @ key "kNormal2" (queuedWriters: 2, queuedReaders: 0)
+[11] sequence req11: pushing txn 00000002 to abort
+[11] sequence req11: pusher aborted pushee
+[11] sequence req11: resolving intent "kNormal2" for txn 00000002 with ABORTED status
+[11] sequence req11: lock wait-queue event: wait for (distinguished) txn 00000007 running request @ key "kNormal2" (queuedWriters: 1, queuedReaders: 0)
+[11] sequence req11: conflicted with 00000002-0000-0000-0000-000000000000 on "kNormal2" for 0.000s
+[11] sequence req11: pushing txn 00000007 to detect request deadlock
+[11] sequence req11: pusher aborted pushee
+[11] sequence req11: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
+
+finish req=req10
+----
+[-] finish req10: finishing request
+[11] sequence req11: lock wait-queue event: done waiting
+[11] sequence req11: conflicted with 00000007-0000-0000-0000-000000000000 on "kNormal2" for 0.000s
+[11] sequence req11: acquiring latches
+[11] sequence req11: scanning lock table for conflicting locks
+[11] sequence req11: sequencing complete, returned guard
+
+finish req=req11
+----
+[-] finish req11: finishing request
+
+debug-lock-table
+----
+global: num=4
+ lock: "kHigh1"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kHigh2"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kLow1"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl [holder finalized: aborted] epoch: 0, seqs: [0]
+ lock: "kNormal1"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl [holder finalized: aborted] epoch: 0, seqs: [0]
+local: num=0
+
+# -------------------------------------------------------------
+# Push (timestamp) the high priority txn using:
+# - a normal priority transactional request
+# - a high priority transactional request
+# -------------------------------------------------------------
+
+new-request name=req12 txn=txnNormalPusher2 ts=10,1
+  get key=kHigh1
+----
+
+new-request name=req13 txn=txnHighPusher ts=10,1
+  get key=kHigh1
+----
+
+sequence req=req12
+----
+[12] sequence req12: sequencing request
+[12] sequence req12: acquiring latches
+[12] sequence req12: scanning lock table for conflicting locks
+[12] sequence req12: waiting in lock wait-queues
+[12] sequence req12: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "kHigh1" (queuedWriters: 0, queuedReaders: 1)
+[12] sequence req12: pushing timestamp of txn 00000003 above 10.000000000,1
+[12] sequence req12: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+sequence req=req13
+----
+[13] sequence req13: sequencing request
+[13] sequence req13: acquiring latches
+[13] sequence req13: scanning lock table for conflicting locks
+[13] sequence req13: waiting in lock wait-queues
+[13] sequence req13: lock wait-queue event: wait for txn 00000003 holding lock @ key "kHigh1" (queuedWriters: 0, queuedReaders: 2)
+[13] sequence req13: pushing timestamp of txn 00000003 above 10.000000000,1
+[13] sequence req13: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+on-txn-updated txn=txnHighPushee status=pending ts=10,2
+----
+[-] update txn: increasing timestamp of txnHighPushee
+[12] sequence req12: resolving intent "kHigh1" for txn 00000003 with PENDING status and clock observation {1 123.000000000,11}
+[12] sequence req12: lock wait-queue event: done waiting
+[12] sequence req12: conflicted with 00000003-0000-0000-0000-000000000000 on "kHigh1" for 0.000s
+[12] sequence req12: acquiring latches
+[12] sequence req12: scanning lock table for conflicting locks
+[12] sequence req12: sequencing complete, returned guard
+[13] sequence req13: resolving intent "kHigh1" for txn 00000003 with PENDING status and clock observation {1 123.000000000,13}
+[13] sequence req13: lock wait-queue event: done waiting
+[13] sequence req13: conflicted with 00000003-0000-0000-0000-000000000000 on "kHigh1" for 0.000s
+[13] sequence req13: acquiring latches
+[13] sequence req13: scanning lock table for conflicting locks
+[13] sequence req13: sequencing complete, returned guard
+
+finish req=req12
+----
+[-] finish req12: finishing request
+
+finish req=req13
+----
+[-] finish req13: finishing request
+
+debug-lock-table
+----
+global: num=4
+ lock: "kHigh1"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "kHigh2"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "kLow1"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl [holder finalized: aborted] epoch: 0, seqs: [0]
+ lock: "kNormal1"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl [holder finalized: aborted] epoch: 0, seqs: [0]
+local: num=0
+
+# -------------------------------------------------------------
+# Push (abort) the high priority txn using:
+# - a normal priority transactional request
+# - a high priority non-transactional request
+# -------------------------------------------------------------
+
+new-request name=req14 txn=txnNormalPusher2 ts=10,1
+  put key=kHigh2  value=v
+----
+
+new-request name=req15 txn=none ts=10,1 priority=high
+  put key=kHigh2  value=v
+----
+
+sequence req=req14
+----
+[14] sequence req14: sequencing request
+[14] sequence req14: acquiring latches
+[14] sequence req14: scanning lock table for conflicting locks
+[14] sequence req14: waiting in lock wait-queues
+[14] sequence req14: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "kHigh2" (queuedWriters: 1, queuedReaders: 0)
+[14] sequence req14: pushing txn 00000003 to abort
+[14] sequence req14: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+sequence req=req15
+----
+[15] sequence req15: sequencing request
+[15] sequence req15: acquiring latches
+[15] sequence req15: scanning lock table for conflicting locks
+[15] sequence req15: waiting in lock wait-queues
+[15] sequence req15: lock wait-queue event: wait for txn 00000003 holding lock @ key "kHigh2" (queuedWriters: 2, queuedReaders: 0)
+[15] sequence req15: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
+
+on-txn-updated txn=txnHighPushee status=committed
+----
+[-] update txn: committing txnHighPushee
+[14] sequence req14: resolving intent "kHigh2" for txn 00000003 with COMMITTED status
+[14] sequence req14: lock wait-queue event: done waiting
+[14] sequence req14: conflicted with 00000003-0000-0000-0000-000000000000 on "kHigh2" for 0.000s
+[14] sequence req14: acquiring latches
+[14] sequence req14: scanning lock table for conflicting locks
+[14] sequence req14: sequencing complete, returned guard
+[15] sequence req15: lock wait-queue event: wait for (distinguished) txn 00000008 running request @ key "kHigh2" (queuedWriters: 1, queuedReaders: 0)
+[15] sequence req15: conflicted with 00000003-0000-0000-0000-000000000000 on "kHigh2" for 0.000s
+[15] sequence req15: pushing txn 00000008 to detect request deadlock
+[15] sequence req15: pusher aborted pushee
+[15] sequence req15: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
+
+finish req=req14
+----
+[-] finish req14: finishing request
+[15] sequence req15: lock wait-queue event: done waiting
+[15] sequence req15: conflicted with 00000008-0000-0000-0000-000000000000 on "kHigh2" for 0.000s
+[15] sequence req15: acquiring latches
+[15] sequence req15: scanning lock table for conflicting locks
+[15] sequence req15: sequencing complete, returned guard
+
+finish req=req15
+----
+[-] finish req15: finishing request
+
+debug-lock-table
+----
+global: num=3
+ lock: "kHigh1"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl [holder finalized: committed] epoch: 0, seqs: [0]
+ lock: "kLow1"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl [holder finalized: aborted] epoch: 0, seqs: [0]
+ lock: "kNormal1"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,2, info: unrepl [holder finalized: aborted] epoch: 0, seqs: [0]
+local: num=0
+
+# -------------------------------------------------------------
+# Scan across keyspace to clear out all aborted locks.
+# -------------------------------------------------------------
+
+new-request name=req16 txn=none ts=11,1
+  scan key=a endkey=z
+----
+
+sequence req=req16
+----
+[16] sequence req16: sequencing request
+[16] sequence req16: acquiring latches
+[16] sequence req16: scanning lock table for conflicting locks
+[16] sequence req16: sequencing complete, returned guard
+
+finish req=req16
+----
+[-] finish req16: finishing request
+
+debug-lock-table
+----
+global: num=0
+local: num=0
+
+reset
+----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/priority
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/priority
@@ -139,6 +139,7 @@ sequence req=req4
 [4] sequence req4: scanning lock table for conflicting locks
 [4] sequence req4: waiting in lock wait-queues
 [4] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "kLow1" (queuedWriters: 0, queuedReaders: 1)
+[4] sequence req4: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req4: pushing timestamp of txn 00000001 above 10.000000000,1
 [4] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -155,6 +156,7 @@ sequence req=req5
 [5] sequence req5: scanning lock table for conflicting locks
 [5] sequence req5: waiting in lock wait-queues
 [5] sequence req5: lock wait-queue event: wait for txn 00000001 holding lock @ key "kLow1" (queuedWriters: 0, queuedReaders: 2)
+[5] sequence req5: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = true
 [5] sequence req5: pushing timestamp of txn 00000001 above 10.000000000,1
 [5] sequence req5: pusher pushed pushee to 10.000000000,2
 [5] sequence req5: resolving intent "kLow1" for txn 00000001 with PENDING status and clock observation {1 123.000000000,3}
@@ -210,6 +212,7 @@ sequence req=req6
 [6] sequence req6: scanning lock table for conflicting locks
 [6] sequence req6: waiting in lock wait-queues
 [6] sequence req6: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "kLow2" (queuedWriters: 1, queuedReaders: 0)
+[6] sequence req6: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [6] sequence req6: pushing txn 00000001 to abort
 [6] sequence req6: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -226,11 +229,13 @@ sequence req=req7
 [7] sequence req7: scanning lock table for conflicting locks
 [7] sequence req7: waiting in lock wait-queues
 [7] sequence req7: lock wait-queue event: wait for txn 00000001 holding lock @ key "kLow2" (queuedWriters: 2, queuedReaders: 0)
+[7] sequence req7: pushing after 0s for: liveness detection = false, deadlock detection = false, timeout enforcement = false, priority enforcement = true
 [7] sequence req7: pushing txn 00000001 to abort
 [7] sequence req7: pusher aborted pushee
 [7] sequence req7: resolving intent "kLow2" for txn 00000001 with ABORTED status
 [7] sequence req7: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key "kLow2" (queuedWriters: 1, queuedReaders: 0)
 [7] sequence req7: conflicted with 00000001-0000-0000-0000-000000000000 on "kLow2" for 0.000s
+[7] sequence req7: pushing after 0s for: liveness detection = false, deadlock detection = false, timeout enforcement = false, priority enforcement = true
 [7] sequence req7: pushing txn 00000004 to detect request deadlock
 [7] sequence req7: pusher aborted pushee
 [7] sequence req7: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
@@ -284,6 +289,7 @@ sequence req=req8
 [8] sequence req8: scanning lock table for conflicting locks
 [8] sequence req8: waiting in lock wait-queues
 [8] sequence req8: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "kNormal1" (queuedWriters: 0, queuedReaders: 1)
+[8] sequence req8: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [8] sequence req8: pushing timestamp of txn 00000002 above 10.000000000,1
 [8] sequence req8: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -300,6 +306,7 @@ sequence req=req9
 [9] sequence req9: scanning lock table for conflicting locks
 [9] sequence req9: waiting in lock wait-queues
 [9] sequence req9: lock wait-queue event: wait for txn 00000002 holding lock @ key "kNormal1" (queuedWriters: 0, queuedReaders: 2)
+[9] sequence req9: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = true
 [9] sequence req9: pushing timestamp of txn 00000002 above 10.000000000,1
 [9] sequence req9: pusher pushed pushee to 10.000000000,2
 [9] sequence req9: resolving intent "kNormal1" for txn 00000002 with PENDING status and clock observation {1 123.000000000,8}
@@ -353,6 +360,7 @@ sequence req=req10
 [10] sequence req10: scanning lock table for conflicting locks
 [10] sequence req10: waiting in lock wait-queues
 [10] sequence req10: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "kNormal2" (queuedWriters: 1, queuedReaders: 0)
+[10] sequence req10: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [10] sequence req10: pushing txn 00000002 to abort
 [10] sequence req10: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -369,11 +377,13 @@ sequence req=req11
 [11] sequence req11: scanning lock table for conflicting locks
 [11] sequence req11: waiting in lock wait-queues
 [11] sequence req11: lock wait-queue event: wait for txn 00000002 holding lock @ key "kNormal2" (queuedWriters: 2, queuedReaders: 0)
+[11] sequence req11: pushing after 0s for: liveness detection = false, deadlock detection = false, timeout enforcement = false, priority enforcement = true
 [11] sequence req11: pushing txn 00000002 to abort
 [11] sequence req11: pusher aborted pushee
 [11] sequence req11: resolving intent "kNormal2" for txn 00000002 with ABORTED status
 [11] sequence req11: lock wait-queue event: wait for (distinguished) txn 00000007 running request @ key "kNormal2" (queuedWriters: 1, queuedReaders: 0)
 [11] sequence req11: conflicted with 00000002-0000-0000-0000-000000000000 on "kNormal2" for 0.000s
+[11] sequence req11: pushing after 0s for: liveness detection = false, deadlock detection = false, timeout enforcement = false, priority enforcement = true
 [11] sequence req11: pushing txn 00000007 to detect request deadlock
 [11] sequence req11: pusher aborted pushee
 [11] sequence req11: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
@@ -425,6 +435,7 @@ sequence req=req12
 [12] sequence req12: scanning lock table for conflicting locks
 [12] sequence req12: waiting in lock wait-queues
 [12] sequence req12: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "kHigh1" (queuedWriters: 0, queuedReaders: 1)
+[12] sequence req12: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [12] sequence req12: pushing timestamp of txn 00000003 above 10.000000000,1
 [12] sequence req12: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -435,6 +446,7 @@ sequence req=req13
 [13] sequence req13: scanning lock table for conflicting locks
 [13] sequence req13: waiting in lock wait-queues
 [13] sequence req13: lock wait-queue event: wait for txn 00000003 holding lock @ key "kHigh1" (queuedWriters: 0, queuedReaders: 2)
+[13] sequence req13: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [13] sequence req13: pushing timestamp of txn 00000003 above 10.000000000,1
 [13] sequence req13: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -496,6 +508,7 @@ sequence req=req14
 [14] sequence req14: scanning lock table for conflicting locks
 [14] sequence req14: waiting in lock wait-queues
 [14] sequence req14: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "kHigh2" (queuedWriters: 1, queuedReaders: 0)
+[14] sequence req14: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [14] sequence req14: pushing txn 00000003 to abort
 [14] sequence req14: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -506,6 +519,7 @@ sequence req=req15
 [15] sequence req15: scanning lock table for conflicting locks
 [15] sequence req15: waiting in lock wait-queues
 [15] sequence req15: lock wait-queue event: wait for txn 00000003 holding lock @ key "kHigh2" (queuedWriters: 2, queuedReaders: 0)
+[15] sequence req15: not pushing
 [15] sequence req15: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 on-txn-updated txn=txnHighPushee status=committed
@@ -519,6 +533,7 @@ on-txn-updated txn=txnHighPushee status=committed
 [14] sequence req14: sequencing complete, returned guard
 [15] sequence req15: lock wait-queue event: wait for (distinguished) txn 00000008 running request @ key "kHigh2" (queuedWriters: 1, queuedReaders: 0)
 [15] sequence req15: conflicted with 00000003-0000-0000-0000-000000000000 on "kHigh2" for 0.000s
+[15] sequence req15: pushing after 0s for: liveness detection = false, deadlock detection = false, timeout enforcement = false, priority enforcement = true
 [15] sequence req15: pushing txn 00000008 to detect request deadlock
 [15] sequence req15: pusher aborted pushee
 [15] sequence req15: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/queue_length_exceeded
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/queue_length_exceeded
@@ -51,6 +51,7 @@ sequence req=req2
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
 [2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[2] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [2] sequence req2: pushing txn 00000001 to abort
 [2] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -65,6 +66,7 @@ sequence req=req3
 [3] sequence req3: scanning lock table for conflicting locks
 [3] sequence req3: waiting in lock wait-queues
 [3] sequence req3: lock wait-queue event: wait for txn 00000001 holding lock @ key "k" (queuedWriters: 2, queuedReaders: 0)
+[3] sequence req3: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req3: pushing txn 00000001 to abort
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -79,6 +81,7 @@ sequence req=req4
 [4] sequence req4: scanning lock table for conflicting locks
 [4] sequence req4: waiting in lock wait-queues
 [4] sequence req4: lock wait-queue event: wait for txn 00000001 holding lock @ key "k" (queuedWriters: 3, queuedReaders: 0)
+[4] sequence req4: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req4: pushing txn 00000001 to abort
 [4] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -111,6 +114,7 @@ sequence req=req5r
 [5] sequence req5r: scanning lock table for conflicting locks
 [5] sequence req5r: waiting in lock wait-queues
 [5] sequence req5r: lock wait-queue event: wait for txn 00000001 holding lock @ key "k" (queuedWriters: 3, queuedReaders: 1)
+[5] sequence req5r: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [5] sequence req5r: pushing timestamp of txn 00000001 above 10.000000000,1
 [5] sequence req5r: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -126,11 +130,13 @@ on-txn-updated txn=txn1 status=committed
 [3] sequence req3: resolving intent "k" for txn 00000001 with COMMITTED status
 [3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 running request @ key "k" (queuedWriters: 2, queuedReaders: 0)
 [3] sequence req3: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
+[3] sequence req3: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req3: pushing txn 00000002 to detect request deadlock
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
 [4] sequence req4: resolving intent "k" for txn 00000001 with COMMITTED status
 [4] sequence req4: lock wait-queue event: wait for txn 00000002 running request @ key "k" (queuedWriters: 2, queuedReaders: 0)
 [4] sequence req4: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 0.000s
+[4] sequence req4: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req4: pushing txn 00000002 to detect request deadlock
 [4] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
 [5] sequence req5r: resolving intent "k" for txn 00000001 with COMMITTED status
@@ -148,9 +154,11 @@ on-lock-acquired req=req2 key=k
 ----
 [-] acquire lock: txn 00000002 @ k
 [3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k" (queuedWriters: 2, queuedReaders: 0)
+[3] sequence req3: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req3: pushing txn 00000002 to abort
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
 [4] sequence req4: lock wait-queue event: wait for txn 00000002 holding lock @ key "k" (queuedWriters: 2, queuedReaders: 0)
+[4] sequence req4: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req4: pushing txn 00000002 to abort
 [4] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -203,6 +211,7 @@ on-txn-updated txn=txn2 status=aborted
 [4] sequence req4: resolving intent "k" for txn 00000002 with ABORTED status
 [4] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key "k" (queuedWriters: 1, queuedReaders: 0)
 [4] sequence req4: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 0.000s
+[4] sequence req4: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req4: pushing txn 00000003 to detect request deadlock
 [4] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
@@ -95,6 +95,7 @@ sequence req=req2
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
 [2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[2] sequence req2: pushing after 1h0m0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [2] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 debug-lock-table
@@ -179,6 +180,7 @@ sequence req=req2
 [7] sequence req2: scanning lock table for conflicting locks
 [7] sequence req2: waiting in lock wait-queues
 [7] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[7] sequence req2: pushing after 1h0m0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [7] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 new-request name=reqRes1 txn=none ts=10,1
@@ -297,6 +299,7 @@ sequence req=req3
 [13] sequence req3: scanning lock table for conflicting locks
 [13] sequence req3: waiting in lock wait-queues
 [13] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[13] sequence req3: pushing after 1h0m0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [13] sequence req3: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 new-request name=reqRes2 txn=none ts=10,1
@@ -411,6 +414,7 @@ sequence req=req2
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
 [2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[2] sequence req2: pushing after 1h0m0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [2] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 debug-lock-table
@@ -458,6 +462,7 @@ sequence req=req2
 [4] sequence req2: scanning lock table for conflicting locks
 [4] sequence req2: waiting in lock wait-queues
 [4] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[4] sequence req2: pushing after 1h0m0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 new-request name=reqRes1 txn=none ts=10,1
@@ -586,6 +591,7 @@ sequence req=req2
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
 [2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[2] sequence req2: pushing after 1h0m0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [2] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 sequence req=req3
@@ -682,6 +688,7 @@ sequence req=req2
 [8] sequence req2: scanning lock table for conflicting locks
 [8] sequence req2: waiting in lock wait-queues
 [8] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[8] sequence req2: pushing after 1h0m0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [8] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 new-request name=reqRes1 txn=none ts=10,1
@@ -796,6 +803,7 @@ sequence req=req2
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
 [2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[2] sequence req2: pushing after 1h0m0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [2] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 debug-lock-table
@@ -843,6 +851,7 @@ sequence req=req2
 [4] sequence req2: scanning lock table for conflicting locks
 [4] sequence req2: waiting in lock wait-queues
 [4] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[4] sequence req2: pushing after 1h0m0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 new-request name=reqRes1 txn=none ts=10,1

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
@@ -41,6 +41,7 @@ sequence req=req1
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
 [3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
+[3] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req1: pushing timestamp of txn 00000001 above 15.000000000,1
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -107,6 +108,7 @@ sequence req=req1
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
 [3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
+[3] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req1: pushing timestamp of txn 00000001 above 135.000000000,0
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -176,6 +178,7 @@ sequence req=req1
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
 [3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
+[3] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req1: pushing timestamp of txn 00000001 above 150.000000000,1?
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -251,6 +254,7 @@ sequence req=req1
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
 [3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
+[3] sequence req1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req1: pushing timestamp of txn 00000001 above 15.000000000,1
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -289,6 +293,7 @@ sequence req=req2-retry
 [5] sequence req2-retry: scanning lock table for conflicting locks
 [5] sequence req2-retry: waiting in lock wait-queues
 [5] sequence req2-retry: lock wait-queue event: wait for txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 2)
+[5] sequence req2-retry: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [5] sequence req2-retry: pushing timestamp of txn 00000001 above 15.000000000,1
 [5] sequence req2-retry: blocked on select in concurrency_test.(*cluster).PushTransaction
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/update
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/update
@@ -50,6 +50,7 @@ sequence req=req2
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
 [2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
+[2] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [2] sequence req2: pushing timestamp of txn 00000001 above 12.000000000,1
 [2] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -171,6 +172,7 @@ sequence req=req2
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
 [2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
+[2] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [2] sequence req2: pushing timestamp of txn 00000001 above 12.000000000,1
 [2] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -301,6 +303,7 @@ sequence req=req2
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
 [2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 0, queuedReaders: 1)
+[2] sequence req2: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [2] sequence req2: pushing timestamp of txn 00000001 above 12.000000000,1
 [2] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -359,6 +362,7 @@ sequence req=req4
 [3] sequence req4: scanning lock table for conflicting locks
 [3] sequence req4: waiting in lock wait-queues
 [3] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[3] sequence req4: pushing after 0s for: liveness detection = true, deadlock detection = false, timeout enforcement = false, priority enforcement = false
 [3] sequence req4: pushing txn 00000001 to abort
 [3] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_elsewhere
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_elsewhere
@@ -63,6 +63,7 @@ sequence req=reqWaiter
 [4] sequence reqWaiter: scanning lock table for conflicting locks
 [4] sequence reqWaiter: waiting in lock wait-queues
 [4] sequence reqWaiter: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[4] sequence reqWaiter: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence reqWaiter: pushing txn 00000001 to abort
 [4] sequence reqWaiter: blocked on select in concurrency_test.(*cluster).PushTransaction
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
@@ -71,6 +71,7 @@ sequence req=req3
 [3] sequence req3: scanning lock table for conflicting locks
 [3] sequence req3: waiting in lock wait-queues
 [3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k2" (queuedWriters: 1, queuedReaders: 0)
+[3] sequence req3: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req3: pushing txn 00000001 to abort
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -123,6 +124,7 @@ on-txn-updated txn=txn1 status=committed
 [3] sequence req3: resolving intent "k2" for txn 00000001 with COMMITTED status
 [3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k3" (queuedWriters: 1, queuedReaders: 0)
 [3] sequence req3: conflicted with 00000001-0000-0000-0000-000000000000 on "k2" for 123.000s
+[3] sequence req3: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence req3: pushing txn 00000002 to abort
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_self
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_self
@@ -48,6 +48,7 @@ sequence req=reqTxn1
 [2] sequence reqTxn1: scanning lock table for conflicting locks
 [2] sequence reqTxn1: waiting in lock wait-queues
 [2] sequence reqTxn1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[2] sequence reqTxn1: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [2] sequence reqTxn1: pushing txn 00000002 to abort
 [2] sequence reqTxn1: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -58,6 +59,7 @@ sequence req=reqTxnMiddle
 [3] sequence reqTxnMiddle: scanning lock table for conflicting locks
 [3] sequence reqTxnMiddle: waiting in lock wait-queues
 [3] sequence reqTxnMiddle: lock wait-queue event: wait for txn 00000002 holding lock @ key "k" (queuedWriters: 2, queuedReaders: 0)
+[3] sequence reqTxnMiddle: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence reqTxnMiddle: pushing txn 00000002 to abort
 [3] sequence reqTxnMiddle: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -68,6 +70,7 @@ sequence req=reqTxn2
 [4] sequence reqTxn2: scanning lock table for conflicting locks
 [4] sequence reqTxn2: waiting in lock wait-queues
 [4] sequence reqTxn2: lock wait-queue event: wait for txn 00000002 holding lock @ key "k" (queuedWriters: 3, queuedReaders: 0)
+[4] sequence reqTxn2: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence reqTxn2: pushing txn 00000002 to abort
 [4] sequence reqTxn2: blocked on select in concurrency_test.(*cluster).PushTransaction
 
@@ -86,6 +89,7 @@ on-txn-updated txn=txnOld status=committed
 [3] sequence reqTxnMiddle: resolving intent "k" for txn 00000002 with COMMITTED status
 [3] sequence reqTxnMiddle: lock wait-queue event: wait for (distinguished) txn 00000001 running request @ key "k" (queuedWriters: 2, queuedReaders: 0)
 [3] sequence reqTxnMiddle: conflicted with 00000002-0000-0000-0000-000000000000 on "k" for 123.000s
+[3] sequence reqTxnMiddle: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [3] sequence reqTxnMiddle: pushing txn 00000001 to detect request deadlock
 [3] sequence reqTxnMiddle: blocked on select in concurrency_test.(*cluster).PushTransaction
 [4] sequence reqTxn2: resolving intent "k" for txn 00000002 with COMMITTED status
@@ -120,6 +124,7 @@ finish req=reqTxn1
 [3] sequence reqTxnMiddle: sequencing complete, returned guard
 [4] sequence reqTxn2: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key "k" (queuedWriters: 1, queuedReaders: 0)
 [4] sequence reqTxn2: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 123.000s
+[4] sequence reqTxn2: pushing after 0s for: liveness detection = false, deadlock detection = true, timeout enforcement = false, priority enforcement = false
 [4] sequence reqTxn2: pushing txn 00000003 to detect request deadlock
 [4] sequence reqTxn2: blocked on select in concurrency_test.(*cluster).PushTransaction
 

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -445,7 +445,7 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 		g, resp, pErr = r.concMgr.SequenceReq(ctx, g, concurrency.Request{
 			Txn:             ba.Txn,
 			Timestamp:       ba.Timestamp,
-			Priority:        ba.UserPriority,
+			NonTxnPriority:  ba.UserPriority,
 			ReadConsistency: ba.ReadConsistency,
 			WaitPolicy:      ba.WaitPolicy,
 			LockTimeout:     ba.LockTimeout,


### PR DESCRIPTION
Fixes #83342.

This commit reworks the behavior of non-transactional requests in lock
wait-queues when the lock holder or the lock queue waiter has an extreme
priority (min or max priority). In such cases, we allow the lock queue
waiter to immediately push the lock holder out of its way, either by
moving its timestamp to resolve a read-write conflict or aborting it to
resolve a write-write conflict.

This handling was broken in two ways for non-transactional requests.
1. these requests' priorities were not consulted when deciding whether
   to immediately push instead of temporarily delaying while waiting in the
   lock wait-queue. This meant that a high-priority, non-txn request might
   still wait for 50ms (kv.lock_table.coordinator_liveness_push_delay)
   before pushing a lower priority lock holder out of its way.
2. worse, it was possible that if these requests were not in the front
   of a lock wait-queue, they might never push. This was because we had
   logic that disabled a push if it was not needed for the purposes of
   checking liveness, detecting deadlocks, or enforcing timeouts.

This commit resolves both of these issues. It also improves the testing
of transaction priorities in the `kv/kvserver/concurrency` package.
Finally, it consolidates the determination of when a pusher should be
able to push/abort a pushee into a single location.

Release note (bug fix): a bug in transaction conflict resolution which
could allow backups to wait on long-running transactions has been
resolved.