### PR TITLE
batcheval: fix key ordering in `TestRandomKeyAndTimestampExport`

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_export_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export_test.go
@@ -17,6 +17,7 @@ import (
 	"math"
 	"math/rand"
 	"sort"
+	"strconv"
 	"testing"
 	"time"
 
@@ -706,20 +707,18 @@ func TestRandomKeyAndTimestampExport(t *testing.T) {
 		var keys []roachpb.Key
 		var timestamps []hlc.Timestamp
 
-		var curWallTime = 0
-		var curLogical = 0
-
+		numDigits := len(strconv.Itoa(numKeys))
 		batch := e.NewBatch()
 		for i := 0; i < numKeys; i++ {
 			// Ensure walltime and logical are monotonically increasing.
-			curWallTime = randutil.RandIntInRange(rnd, 0, math.MaxInt64-1)
-			curLogical = randutil.RandIntInRange(rnd, 0, math.MaxInt32-1)
+			curWallTime := randutil.RandIntInRange(rnd, 0, math.MaxInt64-1)
+			curLogical := randutil.RandIntInRange(rnd, 0, math.MaxInt32-1)
 			ts := hlc.Timestamp{WallTime: int64(curWallTime), Logical: int32(curLogical)}
 			timestamps = append(timestamps, ts)
 
 			// Make keys unique and ensure they are monotonically increasing.
 			key := roachpb.Key(randutil.RandBytes(rnd, keySize))
-			key = append([]byte(fmt.Sprintf("#%d", i)), key...)
+			key = append([]byte(fmt.Sprintf("#%0"+strconv.Itoa(numDigits)+"d", i)), key...)
 			keys = append(keys, key)
 
 			averageValueSize := bytesPerValue - keySize


### PR DESCRIPTION
`TestRandomKeyAndTimestampExport` was supposed to generate a set of
ordered random keys by prefixing the random byte string with a
text-formatted sequence number. However, the sequence number was not
padded, so e.g. `#314` could precede `#1000`. This led it to generate
bogus iterator bounds, where the lower bound was ordered after the upper
bound, triggering iterator assertion failures.

This patch correctly left-pads the number with `0` to maintain correct
lexicographic ordering.

Resolves #83370.

Release note: None