### PR TITLE
batcheval: support MVCC range tombstones in `AddSSTable`

### DIFF
--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -37,7 +37,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var pointKV = storageutils.PointKV
+var (
+	pointKV = storageutils.PointKV
+	rangeKV = storageutils.RangeKV
+)
 
 type kvs = storageutils.KVs
 
@@ -521,8 +524,7 @@ func TestWithOnSSTable(t *testing.T) {
 		pointKV("a", ts, "1"),
 		pointKV("b", ts, "2"),
 		pointKV("c", ts, "3"),
-		pointKV("d", ts, "4"),
-		pointKV("e", ts, "5"),
+		rangeKV("d", "e", ts, ""),
 	}
 	sst, sstStart, sstEnd := storageutils.MakeSST(t, srv.ClusterSettings(), sstKVs)
 	_, _, _, pErr := db.AddSSTableAtBatchTimestamp(ctx, sstStart, sstEnd, sst,

--- a/pkg/kv/kvserver/batcheval/testutils_test.go
+++ b/pkg/kv/kvserver/batcheval/testutils_test.go
@@ -14,4 +14,9 @@ import "github.com/cockroachdb/cockroach/pkg/testutils/storageutils"
 
 type kvs = storageutils.KVs
 
-var pointKV = storageutils.PointKV
+var (
+	pointKV            = storageutils.PointKV
+	pointKVWithLocalTS = storageutils.PointKVWithLocalTS
+	rangeKV            = storageutils.RangeKV
+	rangeKVWithLocalTS = storageutils.RangeKVWithLocalTS
+)

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -1712,6 +1712,9 @@ message AdminVerifyProtectedTimestampResponse {
 // AddSSTableTombstones version gate first to make sure there are no 22.1 nodes
 // left in the cluster.
 //
+// MVCC range tombstones are supported in 22.2, but check the
+// MVCCRangeTombstones version gate before writing them.
+//
 // By default, AddSSTable will blindly write the SST contents into Pebble, with
 // fixed MVCC timestamps unaffected by pushes. This can violate many CRDB
 // guarantees, including ACID, serializability and single-key linearizability:
@@ -1783,6 +1786,8 @@ message AddSSTableRequest {
   // reader has already observed, changing the value at that timestamp and above
   // it. Use with SSTTimestampToRequestTimestamp to guarantee serializability.
   //
+  // MVCC range tombstones are not currently supported with DisallowConflicts.
+  //
   // Added in 22.1, so check the MVCCAddSSTable version gate before using.
   //
   // TODO(erikgrinaker): It might be possible to avoid this parameter if we
@@ -1794,6 +1799,8 @@ message AddSSTableRequest {
   // DisallowShadowing implies DisallowConflicts, and additionally rejects
   // writing above keys that have an existing/visible value (but will write
   // above tombstones).
+  //
+  // MVCC range tombstones are not currently supported with DisallowShadowing.
   //
   // TODO(erikgrinaker): Consider removing this in 22.1 if all callers have
   // been migrated to DisallowShadowingBelow.
@@ -1815,6 +1822,9 @@ message AddSSTableRequest {
   //
   // If this parameter is used, the value of DisallowShadowing is ignored, so
   // callers may pass both for forward and backwards compatibility.
+  //
+  // MVCC range tombstones are not currently supported with
+  // DisallowShadowingBelow.
   //
   // Added in 22.1, so check the MVCCAddSSTable version gate before using.
   util.hlc.Timestamp disallow_shadowing_below = 8 [(gogoproto.nullable) = false];

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -1151,7 +1151,10 @@ func cmdExport(e *evalCtx) error {
 	}
 	e.results.buf.Printf("\n")
 
-	iter, err := NewPebbleMemSSTIterator(sstFile.Bytes(), false /* verify */)
+	iter, err := NewPebbleMemSSTIterator(sstFile.Bytes(), false /* verify */, IterOptions{
+		KeyTypes:   IterKeyTypePointsAndRanges,
+		UpperBound: keys.MaxKey,
+	})
 	if err != nil {
 		return err
 	}
@@ -1514,7 +1517,10 @@ func cmdSSTIterNew(e *evalCtx) error {
 	for i, sst := range e.ssts {
 		ssts[len(ssts)-i-1] = sst
 	}
-	iter, err := NewPebbleMultiMemSSTIterator(ssts, sstIterVerify)
+	iter, err := NewPebbleMultiMemSSTIterator(ssts, sstIterVerify, IterOptions{
+		KeyTypes:   IterKeyTypePointsAndRanges,
+		UpperBound: keys.MaxKey,
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/sst_writer_test.go
+++ b/pkg/storage/sst_writer_test.go
@@ -157,7 +157,10 @@ func TestSSTWriterRangeKeys(t *testing.T) {
 	require.NoError(t, sst.Put(pointKey("a", 2), stringValueRaw("foo")))
 	require.NoError(t, sst.Finish())
 
-	iter, err := NewPebbleMemSSTIterator(sstFile.Bytes(), false)
+	iter, err := NewPebbleMemSSTIterator(sstFile.Bytes(), false /* verify */, IterOptions{
+		KeyTypes:   IterKeyTypePointsAndRanges,
+		UpperBound: keys.MaxKey,
+	})
 	require.NoError(t, err)
 	defer iter.Close()
 

--- a/pkg/testutils/storageutils/scan.go
+++ b/pkg/testutils/storageutils/scan.go
@@ -87,7 +87,11 @@ func ScanIter(t *testing.T, iter storage.SimpleMVCCIterator) KVs {
 func ScanSST(t *testing.T, sst []byte) KVs {
 	t.Helper()
 
-	iter, err := storage.NewPebbleMemSSTIterator(sst, true /* verify */)
+	iter, err := storage.NewPebbleMemSSTIterator(sst, true /* verify */, storage.IterOptions{
+		KeyTypes:   storage.IterKeyTypePointsAndRanges,
+		LowerBound: keys.MinKey,
+		UpperBound: keys.MaxKey,
+	})
 	require.NoError(t, err)
 	defer iter.Close()
 	return ScanIter(t, iter)

--- a/pkg/testutils/storageutils/scan.go
+++ b/pkg/testutils/storageutils/scan.go
@@ -52,6 +52,9 @@ func ScanIter(t *testing.T, iter storage.SimpleMVCCIterator) KVs {
 		if hasRange {
 			if bounds := iter.RangeBounds(); !bounds.Key.Equal(prevRangeStart) {
 				for _, rkv := range iter.RangeKeys() {
+					if len(rkv.Value) == 0 {
+						rkv.Value = nil
+					}
 					kvs = append(kvs, rkv.Clone())
 				}
 				prevRangeStart = bounds.Key.Clone()

--- a/pkg/testutils/storageutils/stats.go
+++ b/pkg/testutils/storageutils/stats.go
@@ -25,6 +25,7 @@ func EngineStats(t *testing.T, engine storage.Reader, nowNanos int64) *enginepb.
 	t.Helper()
 
 	iter := engine.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+		KeyTypes:   storage.IterKeyTypePointsAndRanges,
 		LowerBound: keys.LocalMax,
 		UpperBound: keys.MaxKey,
 	})
@@ -38,7 +39,10 @@ func EngineStats(t *testing.T, engine storage.Reader, nowNanos int64) *enginepb.
 func SSTStats(t *testing.T, sst []byte, nowNanos int64) *enginepb.MVCCStats {
 	t.Helper()
 
-	iter, err := storage.NewMemSSTIterator(sst, true)
+	iter, err := storage.NewPebbleMemSSTIterator(sst, true /* verify */, storage.IterOptions{
+		KeyTypes:   storage.IterKeyTypePointsAndRanges,
+		UpperBound: keys.MaxKey,
+	})
 	require.NoError(t, err)
 	defer iter.Close()
 	stats, err := storage.ComputeStatsForRange(iter, keys.MinKey, keys.MaxKey, nowNanos)


### PR DESCRIPTION
**storage: expose `IterOptions` for SST iterators**

This patch allows callers to pass `IterOptions` for the new SST
iterators.

Release note: None

**batcheval: support MVCC range tombstones in `AddSSTable`**

This patch adds initial support for MVCC range tombstones in
`AddSSTable`, allowing ingestion of SSTs with such tombstones. Callers
must check the `MVCCRangeTombstones` version gate before writing them.

They are not yet supported with `DisallowConflicts`,
`DisallowShadowing`, and `DisallowShadowingBelow` (including checking
for conflicts with existing range tombstones), and will error if an SST
contains any MVCC range tombstone. This is not needed for the initial
cluster replication use-case, and proper support would require MVCC
stats support for range tombstones as well -- this will be implemented
later.

Resolves #76234.

Release note: None