### PR TITLE
tracing: add ChildrenMetadata to String and JSON traces

### DIFF
--- a/pkg/server/node_tenant.go
+++ b/pkg/server/node_tenant.go
@@ -43,27 +43,6 @@ func redactRecordingForTenant(tenID roachpb.TenantID, rec tracingpb.Recording) e
 					"recording has non-redactable span with the Message field set: %s", sp)
 			}
 			record.Message = record.Message.Redact()
-
-			// For compatibility with old versions, also redact DeprecatedFields.
-			for k := range record.DeprecatedFields {
-				field := &record.DeprecatedFields[k]
-				if field.Key != tracingpb.LogMessageField {
-					// We don't have any of these fields, but let's not take any
-					// chances (our dependencies might slip them in).
-					field.Value = TraceRedactedMarker
-					continue
-				}
-				if !sp.RedactableLogs {
-					// If we're handling a span that originated from an (early patch
-					// release) 22.1 node, all the containing information will be
-					// stripped. Note that this is not the common path here, as most
-					// information in the trace will be from the local node, which
-					// always creates redactable logs.
-					field.Value = TraceRedactedMarker
-					continue
-				}
-				field.Value = field.Value.Redact()
-			}
 		}
 	}
 	return nil

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -678,10 +678,6 @@ func (s *crdbSpan) record(msg redact.RedactableString) {
 	logRecord := &tracingpb.LogRecord{
 		Time:    now,
 		Message: msg,
-		// Compatibility with 21.2.
-		DeprecatedFields: []tracingpb.LogRecord_Field{
-			{Key: tracingpb.LogMessageField, Value: msg},
-		},
 	}
 
 	s.recordInternal(logRecord, &s.mu.recording.logs)

--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -105,6 +105,8 @@ func TestRecordingString(t *testing.T) {
 
 	require.NoError(t, CheckRecording(rec, `
 		=== operation:root _verbose:1
+		[remote child]
+		[local child]
 		event:root 1
 			=== operation:remote child _verbose:1
 			event:remote child 1
@@ -124,7 +126,7 @@ func TestRecordingString(t *testing.T) {
 		timeSincePrev:       "0.000ms",
 		text:                "=== operation:root _verbose:1",
 	}, l)
-	l, err = parseLine(lines[1])
+	l, err = parseLine(lines[3])
 	require.Equal(t, traceLine{
 		timeSinceTraceStart: "1.000ms",
 		timeSincePrev:       "1.000ms",
@@ -183,6 +185,7 @@ func TestRecordingInRecording(t *testing.T) {
 
 	require.NoError(t, CheckRecording(childRec, `
 		=== operation:child _verbose:1
+		[grandchild]
 			=== operation:grandchild _verbose:1
 		`))
 }
@@ -208,6 +211,7 @@ func TestImportRemoteRecording(t *testing.T) {
 			if verbose {
 				require.NoError(t, CheckRecording(sp.FinishAndGetRecording(tracingpb.RecordingVerbose), `
 				=== operation:root _verbose:1
+				[child]
 					=== operation:child _verbose:1
 					event:&Int32Value{Value:4,XXX_unrecognized:[],}
 					event:foo
@@ -216,6 +220,7 @@ func TestImportRemoteRecording(t *testing.T) {
 			} else {
 				require.NoError(t, CheckRecording(sp.FinishAndGetRecording(tracingpb.RecordingStructured), `
 				=== operation:root
+				[child]
 				structured:{"@type":"type.googleapis.com/google.protobuf.Int32Value","value":4}
 	`))
 			}
@@ -844,6 +849,7 @@ func TestOpenChildIncludedRecording(t *testing.T) {
 	rec := parent.FinishAndGetRecording(tracingpb.RecordingVerbose)
 	require.NoError(t, CheckRecording(rec, `
 		=== operation:parent _verbose:1
+		[child]
 			=== operation:child _unfinished:1 _verbose:1
 	`))
 	child.Finish()

--- a/pkg/util/tracing/tracingpb/BUILD.bazel
+++ b/pkg/util/tracing/tracingpb/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util/humanizeutil",
         "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/util/tracing/tracingpb/recorded_span.go
+++ b/pkg/util/tracing/tracingpb/recorded_span.go
@@ -82,17 +82,6 @@ func (l LogRecord) Msg() redact.RedactableString {
 	if l.Message != "" {
 		return l.Message
 	}
-
-	// Compatibility with 21.2: look at l.DeprecatedFields.
-	for _, f := range l.DeprecatedFields {
-		key := f.Key
-		if key == LogMessageField {
-			return f.Value
-		}
-		if key == "error" {
-			return redact.Sprintf("error: %s", f.Value)
-		}
-	}
 	return ""
 }
 

--- a/pkg/util/tracing/tracingpb/recorded_span.go
+++ b/pkg/util/tracing/tracingpb/recorded_span.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/redact"
 	types "github.com/gogo/protobuf/types"
 )
@@ -116,4 +117,19 @@ func (m OperationMetadata) Combine(other OperationMetadata) OperationMetadata {
 	m.ContainsUnfinished = m.ContainsUnfinished || other.ContainsUnfinished
 	m.Duration += other.Duration
 	return m
+}
+
+var _ redact.SafeFormatter = OperationMetadata{}
+
+func (m OperationMetadata) String() string {
+	return redact.StringWithoutMarkers(m)
+}
+
+// SafeFormat implements redact.SafeFormatter.
+func (m OperationMetadata) SafeFormat(s redact.SafePrinter, _ rune) {
+	s.Printf("{count: %d, duration %s", m.Count, humanizeutil.Duration(m.Duration))
+	if m.ContainsUnfinished {
+		s.Printf(", unfinished")
+	}
+	s.Print("}")
 }

--- a/pkg/util/tracing/tracingpb/recorded_span.proto
+++ b/pkg/util/tracing/tracingpb/recorded_span.proto
@@ -27,12 +27,10 @@ message LogRecord {
     string key = 1;
     string value = 2 [(gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/cockroachdb/redact.RedactableString"];
   }
-  // Fields with values converted to strings. In 22.1, the `message` field
-  // contains the log message, and this field is only used for compatibility
-  // with 21.2 nodes.
-  repeated Field deprecated_fields = 2 [(gogoproto.nullable) = false];
   // The log message.
   string message = 3 [(gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/cockroachdb/redact.RedactableString"];
+
+  reserved 2;
 }
 
 // StructuredRecord is a structured message recorded in a traced span.

--- a/pkg/util/tracing/tracingpb/recorded_span.proto
+++ b/pkg/util/tracing/tracingpb/recorded_span.proto
@@ -44,6 +44,8 @@ message StructuredRecord {
 // OperationMetadata captures information corresponding to the operation that
 // a span is started with.
 message OperationMetadata {
+  option (gogoproto.goproto_stringer) = false;
+
   // Duration represents the total time spent by spans tracing the operation.
   int64 duration = 1 [(gogoproto.casttype) = "time.Duration"];
   // Count represents the number of spans tracing the operation.
@@ -177,5 +179,6 @@ message NormalizedSpan {
                                         (gogoproto.stdduration) = true];
   repeated LogRecord logs = 5 [(gogoproto.nullable) = false];
   repeated StructuredRecord structured_records = 7 [(gogoproto.nullable) = false];
+  map<string, OperationMetadata> children_metadata = 9 [(gogoproto.nullable) = false];
   repeated NormalizedSpan children = 6 [(gogoproto.nullable) = false];
 }

--- a/pkg/util/tracing/utils.go
+++ b/pkg/util/tracing/utils.go
@@ -40,6 +40,7 @@ func normalizeSpan(s tracingpb.RecordedSpan, trace tracingpb.Recording) tracingp
 	n.TagGroups = s.TagGroups
 	n.Logs = s.Logs
 	n.StructuredRecords = s.StructuredRecords
+	n.ChildrenMetadata = s.ChildrenMetadata
 
 	for _, ss := range trace {
 		if ss.ParentSpanID != s.SpanID {


### PR DESCRIPTION
This change teaches the Recording stringer about the
ChildrenMetadata map, that contains per operation metadata
about the spans' children.

This change also adds ChildrenMetadata to the JSON view of
a recording so that it shows up in the `trace.json` file that
is included in a statement bundle.

Informs: https://github.com/cockroachdb/cockroach/issues/80391

Release note: a trace recording will now output an additional field
per tracing span that corresponds to metadata bucketed by operation
name of the spans' children.