### PR TITLE
release-21.2: release-22.1: cloud/amazon: retry errors during s3 bucket region lookup

### DIFF
--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net/url"
+	"os"
 	"reflect"
 	"sort"
 	"strconv"
@@ -39,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -664,4 +666,21 @@ func forceTableGC(
 	if err := tsi.ForceTableGC(context.Background(), database, table, tsi.Clock().Now()); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func checkS3Credentials(t *testing.T) (bucket string, accessKey string, secretKey string) {
+	accessKey = os.Getenv("AWS_ACCESS_KEY_ID")
+	if accessKey == "" {
+		skip.IgnoreLint(t, "AWS_ACCESS_KEY_ID env var must be set")
+	}
+	secretKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
+	if secretKey == "" {
+		skip.IgnoreLint(t, "AWS_SECRET_ACCESS_KEY env var must be set")
+	}
+	bucket = os.Getenv("AWS_S3_BUCKET")
+	if bucket == "" {
+		skip.IgnoreLint(t, "AWS_S3_BUCKET env var must be set")
+	}
+
+	return bucket, accessKey, secretKey
 }

--- a/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
+++ b/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
@@ -10,6 +10,7 @@ package changefeedccl
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs"
@@ -61,6 +62,8 @@ func waitForJobStatus(
 func TestShowChangefeedJobs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	bucket, accessKey, secretKey := checkS3Credentials(t)
 
 	params, _ := tests.CreateTestServerParams()
 	s, rawSQLDB, _ := serverutils.StartServer(t, params)
@@ -116,8 +119,8 @@ func TestShowChangefeedJobs(t *testing.T) {
 	sqlDB.QueryRow(t, query).Scan(&singleChangefeedID)
 
 	// Cannot use kafka for tests right now because of leaked goroutine issue
-	query = `CREATE CHANGEFEED FOR TABLE foo, bar INTO 
-		'experimental-s3://fake-bucket-name/fake/path?AWS_ACCESS_KEY_ID=123&AWS_SECRET_ACCESS_KEY=456'`
+	query = fmt.Sprintf(`CREATE CHANGEFEED FOR TABLE foo, bar INTO
+		'experimental-s3://%s/fake/path?AWS_ACCESS_KEY_ID=%s&AWS_SECRET_ACCESS_KEY=%s'`, bucket, accessKey, secretKey)
 	sqlDB.QueryRow(t, query).Scan(&multiChangefeedID)
 
 	var out row
@@ -125,8 +128,9 @@ func TestShowChangefeedJobs(t *testing.T) {
 	query = `SELECT job_id, sink_uri, full_table_names, format FROM [SHOW CHANGEFEED JOB $1]`
 	sqlDB.QueryRow(t, query, multiChangefeedID).Scan(&out.id, &out.SinkURI, &out.FullTableNames, &out.format)
 
+	expectedURI := fmt.Sprintf("experimental-s3://%s/fake/path?AWS_ACCESS_KEY_ID=%s&AWS_SECRET_ACCESS_KEY=redacted", bucket, accessKey)
 	require.Equal(t, multiChangefeedID, out.id, "Expected id:%d but found id:%d", multiChangefeedID, out.id)
-	require.Equal(t, "experimental-s3://fake-bucket-name/fake/path?AWS_ACCESS_KEY_ID=123&AWS_SECRET_ACCESS_KEY=redacted", out.SinkURI, "Expected sinkUri:%s but found sinkUri:%s", "experimental-s3://fake-bucket-name/fake/path?AWS_ACCESS_KEY_ID=123&AWS_SECRET_ACCESS_KEY=redacted", out.SinkURI)
+	require.Equal(t, expectedURI, out.SinkURI, "Expected sinkUri:%s but found sinkUri:%s", expectedURI, out.SinkURI)
 	require.Equal(t, "{defaultdb.public.foo,defaultdb.public.bar}", string(out.FullTableNames), "Expected fullTableNames:%s but found fullTableNames:%s", "{defaultdb.public.foo,defaultdb.public.bar}", string(out.FullTableNames))
 	require.Equal(t, "json", out.format, "Expected format:%s but found format:%s", "json", out.format)
 
@@ -147,7 +151,7 @@ func TestShowChangefeedJobs(t *testing.T) {
 	}
 
 	require.Equal(t, multiChangefeedID, out.id, "Expected id:%d but found id:%d", multiChangefeedID, out.id)
-	require.Equal(t, "experimental-s3://fake-bucket-name/fake/path?AWS_ACCESS_KEY_ID=123&AWS_SECRET_ACCESS_KEY=redacted", out.SinkURI, "Expected sinkUri:%s but found sinkUri:%s", "experimental-s3://fake-bucket-name/fake/path?AWS_ACCESS_KEY_ID=123&AWS_SECRET_ACCESS_KEY=redacted", out.SinkURI)
+	require.Equal(t, expectedURI, out.SinkURI, "Expected sinkUri:%s but found sinkUri:%s", expectedURI, out.SinkURI)
 	require.Equal(t, "{defaultdb.public.foo,defaultdb.public.bar}", string(out.FullTableNames), "Expected fullTableNames:%s but found fullTableNames:%s", "{defaultdb.public.foo,defaultdb.public.bar}", string(out.FullTableNames))
 	require.Equal(t, "json", out.format, "Expected format:%s but found format:%s", "json", out.format)
 

--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -342,7 +342,7 @@ func newClient(
 	if region == "" {
 		if err := cloud.DelayedRetry(ctx, "s3manager.GetBucketRegion", s3ErrDelay, func() error {
 			region, err = s3manager.GetBucketRegion(ctx, sess, conf.bucket, "us-east-1")
-			return nil
+			return err
 		}); err != nil {
 			return s3Client{}, "", errors.Wrap(err, "could not find s3 bucket's region")
 		}

--- a/pkg/cloud/amazon/s3_storage_test.go
+++ b/pkg/cloud/amazon/s3_storage_test.go
@@ -323,3 +323,21 @@ func TestAntagonisticS3Read(t *testing.T) {
 
 	cloudtestutils.CheckAntagonisticRead(t, conf, testSettings)
 }
+
+func TestNewClientErrorsOnBucketRegion(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	_, err := session.NewSession()
+	if err != nil {
+		skip.IgnoreLint(t, "No AWS credentials")
+	}
+
+	testSettings := cluster.MakeTestingClusterSettings()
+	ctx := context.Background()
+	cfg := s3ClientConfig{
+		bucket: "bucket-does-not-exist-v1i3m",
+		auth:   cloud.AuthParamImplicit,
+	}
+	_, _, err = newClient(ctx, cfg, testSettings)
+	require.Regexp(t, "could not find s3 bucket's region", err)
+}

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -449,6 +449,7 @@ func TestLint(t *testing.T) {
 					":!ccl/backupccl/backup_cloud_test.go",
 					// KMS requires AWS credentials from environment variables.
 					":!ccl/backupccl/backup_test.go",
+					":!ccl/changefeedccl/helpers_test.go",
 					":!cloud",
 					":!ccl/workloadccl/fixture_test.go",
 					":!internal/reporoot/reporoot.go",


### PR DESCRIPTION
Backport 1/1 commits from #80242.

/cc @cockroachdb/release

---

Backport 1/1 commits from #79974 on behalf of @rhu713.

/cc @cockroachdb/release

----

Currently errors encountered during s3 bucket region lookup is swallowed. If
there is an error during this step then a client is created with an empty
region, which will then issue invalid requests with an empty region. This
patch fixes the bug.

Fixes #79435

Release note: None

----

Release justification: Fix bug for s3 storage not exposing region lookup errors.
