### PR TITLE
cdc: use a more efficient underlying data structure for Targets

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -84,6 +84,7 @@ go_library(
         "//pkg/sql/rowexec",
         "//pkg/sql/sem/asof",
         "//pkg/sql/sem/builtins",
+        "//pkg/sql/sem/catid",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondatapb",

--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -343,18 +343,19 @@ func generateNewTargets(
 		return nil, nil, hlc.Timestamp{}, nil, err
 	}
 
-	for _, targetSpec := range AllTargets(prevDetails) {
+	prevTargets := AllTargets(prevDetails)
+	err = prevTargets.EachTarget(func(targetSpec changefeedbase.Target) error {
 		k := targetKey{TableID: targetSpec.TableID, FamilyName: tree.Name(targetSpec.FamilyName)}
 		desc := descResolver.DescByID[targetSpec.TableID].(catalog.TableDescriptor)
 
 		tbName, err := getQualifiedTableNameObj(ctx, p.ExecCfg(), p.Txn(), desc)
 		if err != nil {
-			return nil, nil, hlc.Timestamp{}, nil, err
+			return err
 		}
 
 		tablePattern, err := tbName.NormalizeTablePattern()
 		if err != nil {
-			return nil, nil, hlc.Timestamp{}, nil, err
+			return err
 		}
 
 		newTarget := tree.ChangefeedTarget{
@@ -370,6 +371,11 @@ func generateNewTargets(
 			FamilyName:        targetSpec.FamilyName,
 			StatementTimeName: string(targetSpec.StatementTimeName),
 		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, nil, hlc.Timestamp{}, nil, err
 	}
 
 	for _, cmd := range alterCmds {

--- a/pkg/ccl/changefeedccl/cdceval/expr_eval_test.go
+++ b/pkg/ccl/changefeedccl/cdceval/expr_eval_test.go
@@ -408,13 +408,12 @@ CREATE TABLE foo (
 				targetType = jobspb.ChangefeedTargetSpecification_COLUMN_FAMILY
 			}
 
-			targets := changefeedbase.Targets{
-				{
-					Type:       targetType,
-					TableID:    desc.GetID(),
-					FamilyName: tc.familyName,
-				},
-			}
+			targets := changefeedbase.Targets{}
+			targets.Add(changefeedbase.Target{
+				Type:       targetType,
+				TableID:    desc.GetID(),
+				FamilyName: tc.familyName,
+			})
 
 			serverCfg := s.DistSQLServer().(*distsql.ServerImpl).ServerConfig
 			ctx := context.Background()

--- a/pkg/ccl/changefeedccl/cdcevent/event_test.go
+++ b/pkg/ccl/changefeedccl/cdcevent/event_test.go
@@ -290,13 +290,12 @@ CREATE TABLE foo (
 				sqlDB.Exec(t, action)
 			}
 
-			targets := changefeedbase.Targets{
-				{
-					Type:       targetType,
-					TableID:    tableDesc.GetID(),
-					FamilyName: tc.familyName,
-				},
-			}
+			targets := changefeedbase.Targets{}
+			targets.Add(changefeedbase.Target{
+				Type:       targetType,
+				TableID:    tableDesc.GetID(),
+				FamilyName: tc.familyName,
+			})
 			serverCfg := s.DistSQLServer().(*distsql.ServerImpl).ServerConfig
 			ctx := context.Background()
 			decoder, err := NewEventDecoder(ctx, &serverCfg, targets, tc.includeVirtual)

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1195,7 +1195,8 @@ func getCommonChangefeedEventDetails(
 	changefeedEventDetails := eventpb.CommonChangefeedEventDetails{
 		Description: description,
 		SinkType:    sinkType,
-		NumTables:   int32(len(AllTargets(details))),
+		// TODO: Rename this field to NumTargets.
+		NumTables:   int32(AllTargets(details).Size),
 		Resolved:    resolved,
 		Format:      opts[changefeedbase.OptFormat],
 		InitialScan: initialScan,

--- a/pkg/ccl/changefeedccl/changefeedbase/target.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/target.go
@@ -25,8 +25,102 @@ type Target struct {
 // the changefeed, possibly modified by WITH options.
 type StatementTimeName string
 
-// WatchedTables tracks the StatementTimeName for each table id.
-type WatchedTables map[descpb.ID]StatementTimeName
+type targetsByTable struct {
+	wholeTable   *Target
+	byFamilyName map[string]Target
+}
+
+func (tbt targetsByTable) add(t Target) targetsByTable {
+	if t.FamilyName == "" {
+		tbt.wholeTable = &t
+	} else {
+		if tbt.byFamilyName == nil {
+			tbt.byFamilyName = make(map[string]Target)
+		}
+		tbt.byFamilyName[t.FamilyName] = t
+	}
+	return tbt
+}
+
+func (tbt targetsByTable) each(f func(t Target) error) error {
+	if tbt.wholeTable != nil {
+		if err := f(*tbt.wholeTable); err != nil {
+			return err
+		}
+	}
+	for _, t := range tbt.byFamilyName {
+		if err := f(t); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
 // Targets is the complete list of target specifications for a changefeed.
-type Targets []Target
+// This is stored as a map of TableID -> Family Name -> Target in order
+// to support all current ways we need to iterate over it.
+type Targets struct {
+	Size uint
+	m    map[descpb.ID]targetsByTable
+}
+
+// Add adds a target to the list.
+func (ts *Targets) Add(t Target) {
+	if ts.m == nil {
+		ts.m = make(map[descpb.ID]targetsByTable)
+	}
+	ts.m[t.TableID] = ts.m[t.TableID].add(t)
+	ts.Size++
+}
+
+// EachTarget iterates over Targets.
+func (ts *Targets) EachTarget(f func(Target) error) error {
+	for _, l := range ts.m {
+		if err := l.each(f); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// EachTableID iterates over unique TableIDs referenced in Targets.
+func (ts *Targets) EachTableID(f func(descpb.ID) error) error {
+	for id := range ts.m {
+		if err := f(id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// EachHavingTableID iterates over each Target with the given id, returning
+// false if there were none.
+func (ts *Targets) EachHavingTableID(id descpb.ID, f func(Target) error) (bool, error) {
+	targets, ok := ts.m[id]
+	return ok, targets.each(f)
+}
+
+// NumUniqueTables gives the number of unique TableIDs referenced in Targets.
+func (ts *Targets) NumUniqueTables() int {
+	return len(ts.m)
+}
+
+// FindByTableIDAndFamilyName returns a target matching the given table id and family name,
+// or false if none were found. If no target matches the family name but a target covers
+// the whole table, that target will be returned.
+func (ts *Targets) FindByTableIDAndFamilyName(id descpb.ID, family string) (Target, bool) {
+	tbt, ok := ts.m[id]
+	if !ok {
+		return Target{}, false
+	}
+	if tbt.byFamilyName != nil {
+		t, ok := tbt.byFamilyName[family]
+		if ok {
+			return t, true
+		}
+	}
+	if tbt.wholeTable != nil {
+		return *tbt.wholeTable, true
+	}
+	return Target{}, false
+}

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -210,13 +210,12 @@ func TestEncoders(t *testing.T) {
 				t.Fatalf(`unknown format: %s`, o.Format)
 			}
 
-			target := changefeedbase.Target{
+			targets := changefeedbase.Targets{}
+			targets.Add(changefeedbase.Target{
 				Type:              jobspb.ChangefeedTargetSpecification_PRIMARY_FAMILY_ONLY,
 				TableID:           tableDesc.GetID(),
 				StatementTimeName: changefeedbase.StatementTimeName(tableDesc.GetName()),
-			}
-			targets := changefeedbase.Targets{target}
-
+			})
 			if len(expected.err) > 0 {
 				require.EqualError(t, o.Validate(), expected.err)
 				return
@@ -355,12 +354,12 @@ func TestAvroEncoderWithTLS(t *testing.T) {
 			return string(avroToJSON(t, reg, r))
 		}
 
-		target := changefeedbase.Target{
+		targets := changefeedbase.Targets{}
+		targets.Add(changefeedbase.Target{
 			Type:              jobspb.ChangefeedTargetSpecification_PRIMARY_FAMILY_ONLY,
 			TableID:           tableDesc.GetID(),
 			StatementTimeName: changefeedbase.StatementTimeName(tableDesc.GetName()),
-		}
-		targets := changefeedbase.Targets{target}
+		})
 
 		e, err := getEncoder(opts, targets)
 		require.NoError(t, err)

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -104,15 +104,14 @@ func (c *kvEventToRowConsumer) topicForEvent(eventMeta cdcevent.Metadata) (Topic
 			return topic, nil
 		}
 	}
-	for _, s := range c.details.Targets {
-		if s.TableID == eventMeta.TableID && (s.FamilyName == "" || s.FamilyName == eventMeta.FamilyName) {
-			topic, err := makeTopicDescriptorFromSpec(s, eventMeta)
-			if err != nil {
-				return noTopic{}, err
-			}
-			c.topicDescriptorCache[topic.GetTopicIdentifier()] = topic
-			return topic, nil
+	t, found := c.details.Targets.FindByTableIDAndFamilyName(eventMeta.TableID, eventMeta.FamilyName)
+	if found {
+		topic, err := makeTopicDescriptorFromSpec(t, eventMeta)
+		if err != nil {
+			return noTopic{}, err
 		}
+		c.topicDescriptorCache[topic.GetTopicIdentifier()] = topic
+		return topic, nil
 	}
 	return noTopic{}, errors.AssertionFailedf("no TargetSpecification for row %s", eventMeta)
 }

--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -352,7 +352,7 @@ func makeCloudStorageSink(
 	// Using + rather than . here because some consumers may be relying on there being exactly
 	// one '.' in the filepath, and '+' shares with '-' the useful property of being
 	// lexicographically earlier than '.'.
-	tn, err := MakeTopicNamer([]changefeedbase.Target{}, WithJoinByte('+'))
+	tn, err := MakeTopicNamer(changefeedbase.Targets{}, WithJoinByte('+'))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -215,12 +215,12 @@ func makeTestKafkaSink(
 }
 
 func makeChangefeedTargets(targetNames ...string) changefeedbase.Targets {
-	targets := make(changefeedbase.Targets, len(targetNames))
+	targets := changefeedbase.Targets{}
 	for i, name := range targetNames {
-		targets[i] = changefeedbase.Target{
+		targets.Add(changefeedbase.Target{
 			TableID:           descpb.ID(i),
 			StatementTimeName: changefeedbase.StatementTimeName(name),
-		}
+		})
 	}
 	return targets
 }
@@ -427,10 +427,10 @@ func TestSQLSink(t *testing.T) {
 
 	fooTopic := overrideTopic(`foo`)
 	barTopic := overrideTopic(`bar`)
-	targets := changefeedbase.Targets{
-		fooTopic.GetTargetSpecification(),
-		barTopic.GetTargetSpecification(),
-	}
+	targets := changefeedbase.Targets{}
+	targets.Add(fooTopic.GetTargetSpecification())
+	targets.Add(barTopic.GetTargetSpecification())
+
 	const testTableName = `sink`
 	sink, err := makeSQLSink(sinkURL{URL: &pgURL}, testTableName, targets, nilMetricsRecorderBuilder)
 	require.NoError(t, err)


### PR DESCRIPTION
We had a lot of places where we'd iterate over all targets looking for the
one that matches the event currently being processed. This PR fixes that
by converting changefeedbase.Targets from a []Target to a type that
supports O(1) lookups. This also makes the code a bit more readable, I
think.

This doesn't touch cdc expressions code, which is fine for now but
should be fixed when or before we support multiple targets there.

Release note: None