### PR TITLE
cli: skip TestRemoveDeadReplicas

### DIFF
--- a/pkg/cli/debug_test.go
+++ b/pkg/cli/debug_test.go
@@ -101,6 +101,7 @@ func TestOpenReadOnlyStore(t *testing.T) {
 
 func TestRemoveDeadReplicas(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 75133, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	// This test is pretty slow under race (200+ cpu-seconds) because it


### PR DESCRIPTION
Refs: #75133

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None