### PR TITLE
backupccl: wrap error in create schedule

### DIFF
--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -526,7 +526,7 @@ func checkForExistingBackupsInCollection(
 			collectionURI)
 	}
 	if !errors.Is(err, cloud.ErrFileDoesNotExist) {
-		return errors.Newf("unexpected error occurred when checking for existing backups in %s",
+		return errors.Wrapf(err, "unexpected error occurred when checking for existing backups in %s",
 			collectionURI)
 	}
 


### PR DESCRIPTION
Wrap the error returned when resolving previous backups
in the collection with the actual error returned by the
ExternalStorage sink.

Release note: None