### PR TITLE
multi-tenant: Fix MT testing probability

### DIFF
--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -78,7 +78,7 @@ const (
 // If both the environment variable and the test flag are set, the environment
 // variable wins out.
 func ShouldStartDefaultTestTenant(t testing.TB) bool {
-	const defaultProbabilityOfStartingTestTenant = 1.0
+	const defaultProbabilityOfStartingTestTenant = 0.5
 	var probabilityOfStartingDefaultTestTenant float64
 
 	tenantModeTestString, envSet := envutil.EnvString("COCKROACH_TEST_TENANT_MODE", 0)


### PR DESCRIPTION
The changes in 76582 introduced probabilistic testing within tenants. That PR
should have enabled testing in tenants with probability 0.5. A late change was
made in that PR which accidentally merged probability 1.0 - meaning that _all_
testing is now occurring in tenants. This PR reverts that change, and applies
the intended 0.5 probability so that half of the time we're testing outside of
tenants.

Release note: None