### PR TITLE
sql: fix virtual and system column validation in index creation

### DIFF
--- a/pkg/sql/catalog/descpb/index.go
+++ b/pkg/sql/catalog/descpb/index.go
@@ -40,7 +40,9 @@ func (desc *IndexDescriptor) ExplicitColumnStartIdx() int {
 	return start
 }
 
-// FillColumns sets the column names and directions in desc.
+// FillColumns sets the column names and directions in desc. Note that it does
+// no validation with regards to the existence of the listed columns. It also
+// delegates filling in any IDs until later.
 func (desc *IndexDescriptor) FillColumns(elems tree.IndexElemList) error {
 	desc.KeyColumnNames = make([]string, 0, len(elems))
 	desc.KeyColumnDirections = make([]IndexDescriptor_Direction, 0, len(elems))

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -193,6 +193,10 @@ func makeIndexDescriptor(
 		return nil, pgerror.Newf(pgcode.DuplicateRelation, "index with name %q already exists", n.Name)
 	}
 
+	if err := checkStoringColumns(tableDesc, n.Storing); err != nil {
+		return nil, err
+	}
+
 	indexDesc := descpb.IndexDescriptor{
 		Name:              string(n.Name),
 		Unique:            n.Unique,
@@ -309,6 +313,28 @@ func makeIndexDescriptor(
 	}
 
 	return &indexDesc, nil
+}
+
+func checkStoringColumns(desc catalog.TableDescriptor, names tree.NameList) error {
+	for i, colName := range names {
+		col, err := desc.FindColumnWithName(colName)
+		if err != nil {
+			return errors.Wrapf(err, "finding store column %d", i)
+		}
+		if col.IsVirtual() {
+			return pgerror.Newf(
+				pgcode.FeatureNotSupported,
+				"index cannot store virtual column %v", colName,
+			)
+		}
+		if col.IsSystemColumn() {
+			return pgerror.Newf(
+				pgcode.FeatureNotSupported,
+				"index cannot store system column %v", colName,
+			)
+		}
+	}
+	return nil
 }
 
 // populateInvertedIndexDescriptor adds information to the input index descriptor

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1790,6 +1790,9 @@ func NewTableDesc(
 			); err != nil {
 				return nil, err
 			}
+			if err := checkStoringColumns(&desc, d.Storing); err != nil {
+				return nil, err
+			}
 			idx := descpb.IndexDescriptor{
 				Name:             string(d.Name),
 				StoreColumnNames: d.Storing.ToStrings(),

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1790,7 +1790,7 @@ func NewTableDesc(
 			); err != nil {
 				return nil, err
 			}
-			if err := checkStoringColumns(&desc, d.Storing); err != nil {
+			if err := checkIndexColumns(&desc, d.Columns, d.Storing); err != nil {
 				return nil, err
 			}
 			idx := descpb.IndexDescriptor{

--- a/pkg/sql/logictest/testdata/logic_test/system_columns
+++ b/pkg/sql/logictest/testdata/logic_test/system_columns
@@ -207,10 +207,10 @@ CREATE INDEX idx ON tab3(x, tableoid)
 statement error pgcode XXUUU index "idx" contains unknown column "crdb_internal_mvcc_timestamp"
 CREATE INDEX idx ON tab3(x, crdb_internal_mvcc_timestamp)
 
-statement error pgcode XXUUU index "idx" contains stored column "tableoid" with unknown ID 4294967294
+statement error pgcode 0A000 index cannot store system column tableoid
 CREATE INDEX idx ON tab3(x) STORING (tableoid)
 
-statement error pgcode XXUUU  index "idx" contains stored column "crdb_internal_mvcc_timestamp" with unknown ID 4294967295
+statement error pgcode 0A000 index cannot store system column crdb_internal_mvcc_timestamp
 CREATE INDEX idx ON tab3(x) STORING (crdb_internal_mvcc_timestamp)
 
 statement error pgcode 42703 column "crdb_internal_mvcc_timestamp" does not exist

--- a/pkg/sql/logictest/testdata/logic_test/system_columns
+++ b/pkg/sql/logictest/testdata/logic_test/system_columns
@@ -198,3 +198,20 @@ SELECT tableoid, x FROM tab3@i WHERE x = 1
 
 statement error pq: relation "bad" \([0-9]+\): column name "tableoid" conflicts with a system column name
 CREATE TABLE bad (tableoid int)
+
+subtest use_in_indexes
+
+statement error pgcode XXUUU index "idx" contains unknown column "tableoid"
+CREATE INDEX idx ON tab3(x, tableoid)
+
+statement error pgcode XXUUU index "idx" contains unknown column "crdb_internal_mvcc_timestamp"
+CREATE INDEX idx ON tab3(x, crdb_internal_mvcc_timestamp)
+
+statement error pgcode XXUUU index "idx" contains stored column "tableoid" with unknown ID 4294967294
+CREATE INDEX idx ON tab3(x) STORING (tableoid)
+
+statement error pgcode XXUUU  index "idx" contains stored column "crdb_internal_mvcc_timestamp" with unknown ID 4294967295
+CREATE INDEX idx ON tab3(x) STORING (crdb_internal_mvcc_timestamp)
+
+statement error pgcode 42703 column "crdb_internal_mvcc_timestamp" does not exist
+CREATE INDEX idx ON tab3(x, (crdb_internal_mvcc_timestamp + 10))

--- a/pkg/sql/logictest/testdata/logic_test/system_columns
+++ b/pkg/sql/logictest/testdata/logic_test/system_columns
@@ -201,10 +201,10 @@ CREATE TABLE bad (tableoid int)
 
 subtest use_in_indexes
 
-statement error pgcode XXUUU index "idx" contains unknown column "tableoid"
+statement error pgcode 0A000 cannot index system column tableoid
 CREATE INDEX idx ON tab3(x, tableoid)
 
-statement error pgcode XXUUU index "idx" contains unknown column "crdb_internal_mvcc_timestamp"
+statement error pgcode 0A000 cannot index system column crdb_internal_mvcc_timestamp
 CREATE INDEX idx ON tab3(x, crdb_internal_mvcc_timestamp)
 
 statement error pgcode 0A000 index cannot store system column tableoid

--- a/pkg/sql/logictest/testdata/logic_test/virtual_columns
+++ b/pkg/sql/logictest/testdata/logic_test/virtual_columns
@@ -17,7 +17,7 @@ CREATE TABLE t (
   FAMILY (v)
 )
 
-statement error index "t_b_idx" cannot store virtual column "v"
+statement error pgcode 0A000 index cannot store virtual column v
 CREATE TABLE t (
   a INT PRIMARY KEY,
   b INT,

--- a/pkg/sql/randgen/mutator.go
+++ b/pkg/sql/randgen/mutator.go
@@ -971,8 +971,11 @@ func indexStoringMutator(rng *rand.Rand, stmts []tree.Statement) ([]tree.Stateme
 				// Skip PK columns and columns already in the index.
 				continue
 			}
-			if tableInfo.columnsTableDefs[colOrdinal].Computed.Virtual {
-				// Virtual columns can't be stored.
+			// Virtual columns can't be stored.
+			if tableInfo.columnsTableDefs[colOrdinal].Computed.Virtual ||
+				// Neither can TableOID. Neither can MVCCTimestamp, but the logic to
+				// read the columns filters that one out.
+				tableInfo.columnsTableDefs[colOrdinal].Name == colinfo.TableOIDColumnName {
 				continue
 			}
 			if rng.Intn(2) == 0 {


### PR DESCRIPTION
#### sql/randgen: do not put tableoid in an index STORING clause
    
#### sql: fix error code for system columns in index keys
    
Before this change, the validation was deferred to descriptor validation. That
lead to a bad error code.

#### sql: improve error reporting when validating index STORING clause
    
Before this change we'd delegate all input handling for `STORING` clauses
to the table descriptor validation logic. This made for bad error codes. We
need to validate input before building a descriptor.

#### sql/logictest: demonstrate bad error handling of system columns in indexes

Release note (sql change): Attempts to use a system column in an index as a key
column now uses error code 0A000 (feature not supported) instead of XXUUU
(internal error).
Release note (sql change): The error code reported when trying to use a system
or virtual column in the STORING clause of an INDEX has been changed from XXUUU
(internal error) to 0A000 (feature not supported).