### PR TITLE
release-22.1: ui: fix transaction details page title

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -13,6 +13,7 @@ import * as protos from "@cockroachlabs/crdb-protobuf-client";
 import classNames from "classnames/bind";
 import _ from "lodash";
 import { RouteComponentProps } from "react-router-dom";
+import { Helmet } from "react-helmet";
 
 import statementsStyles from "../statementsPage/statementsPage.module.scss";
 import {
@@ -224,6 +225,7 @@ export class TransactionDetails extends React.Component<
 
     return (
       <div>
+        <Helmet title={"Details | Transactions"} />
         <section className={baseHeadingClasses.wrapper}>
           <Button
             onClick={this.backToTransactionsClick}


### PR DESCRIPTION
Backport 1/1 commits from #83425 

/cc @cockroachdb/release 

---
Previously, the Transaction Details page was showing
undefined on the Browser Tab title.
This commit adds the proper title to it.

Fixes #80646

Release note: None

--- 
Release justification: bug fix