### PR TITLE
sql/schemachanger/scexec: remove debug log line

### DIFF
--- a/pkg/sql/schemachanger/scexec/scmutationexec/BUILD.bazel
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/BUILD.bazel
@@ -38,7 +38,6 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
         "//pkg/util/iterutil",
-        "//pkg/util/log",
         "//pkg/util/log/eventpb",
         "//pkg/util/protoutil",
         "//pkg/util/timeutil",

--- a/pkg/sql/schemachanger/scexec/scmutationexec/index.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/index.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -382,7 +381,6 @@ func (m *visitor) RemoveColumnFromIndex(ctx context.Context, op scop.RemoveColum
 	// As a special case, avoid removing any columns from dropped indexes.
 	// The index is going to be removed, so it doesn't matter if it references
 	// dropped columns.
-	log.Infof(ctx, "yo sup, %d %d %v %v %v", op.IndexID, op.ColumnID, index.Dropped(), index.DeleteOnly(), index.Public())
 	if index.Dropped() {
 		return nil
 	}


### PR DESCRIPTION
This just merged by mistake.

Release note: None