### PR TITLE
kv: don't try to reject lease transfer when flushing proposal buffer

### DIFF
--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -567,6 +567,13 @@ func (b *propBuf) FlushLockedWithRaftGroup(
 func (b *propBuf) maybeRejectUnsafeProposalLocked(
 	ctx context.Context, raftGroup proposerRaft, p *ProposalData,
 ) (rejected bool) {
+	if raftGroup == nil {
+		// If we do not have a raft group, we won't try to propose this proposal.
+		// Instead, we will register the proposal so that it can be reproposed later
+		// with a raft group. Wait until that point to determine whether to reject
+		// the proposal or not.
+		return false
+	}
 	switch {
 	case p.Request.IsSingleRequestLeaseRequest():
 		// Handle an edge case about lease acquisitions: we don't want to forward
@@ -706,9 +713,6 @@ func (b *propBuf) maybeRejectUnsafeProposalLocked(
 // leaderStatusRLocked returns the rangeLeaderInfo for the provided raft group,
 // or an empty rangeLeaderInfo if the raftGroup is nil.
 func (b *propBuf) leaderStatusRLocked(ctx context.Context, raftGroup proposerRaft) rangeLeaderInfo {
-	if raftGroup == nil {
-		return rangeLeaderInfo{}
-	}
 	leaderInfo := b.p.leaderStatusRLocked(raftGroup)
 	// Sanity check.
 	if leaderInfo.leaderKnown && leaderInfo.leader == b.p.getReplicaID() &&


### PR DESCRIPTION
Fixes #83498.
Fixes #83402.
Fixes #83308.

This was fallout from #82758.

This commit adds logic to `propBuf.maybeRejectUnsafeProposalLocked` to avoid
trying to reject proposals based on the state of the raft group when the group
is not provided (e.g. when flushing the buffer). We already had this logic for
`RequestLease` (indirectly), but did not for `TransferLease`.