### PR TITLE
sql: better instruction for creating HSI in mixed version cluster

### DIFF
--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -615,8 +615,9 @@ func setupShardedIndex(
 	if err != nil {
 		return nil, nil, err
 	}
-	shardCol, err := maybeCreateAndAddShardCol(int(buckets), tableDesc,
-		colNames, isNewTable)
+	shardCol, err := maybeCreateAndAddShardCol(
+		int(buckets), tableDesc, colNames, isNewTable, evalCtx.Settings.Version.ActiveVersion(ctx),
+	)
 
 	if err != nil {
 		return nil, nil, err
@@ -639,7 +640,11 @@ func setupShardedIndex(
 // `desc`, if one doesn't already exist for the given index column set and number of shard
 // buckets.
 func maybeCreateAndAddShardCol(
-	shardBuckets int, desc *tabledesc.Mutable, colNames []string, isNewTable bool,
+	shardBuckets int,
+	desc *tabledesc.Mutable,
+	colNames []string,
+	isNewTable bool,
+	cv clusterversion.ClusterVersion,
 ) (col catalog.Column, err error) {
 	shardColDesc, err := makeShardColumnDesc(colNames, shardBuckets)
 	if err != nil {
@@ -661,6 +666,15 @@ func maybeCreateAndAddShardCol(
 	columnIsUndefined := sqlerrors.IsUndefinedColumnError(err)
 	if err != nil && !columnIsUndefined {
 		return nil, err
+	}
+
+	if !cv.IsActive(clusterversion.Start22_1) {
+		return nil, pgerror.Newf(
+			pgcode.FeatureNotSupported,
+			"cannot create hash sharded index on a node running binary newer than 21.2 in a mixed version cluster "+
+				"during a cluster upgrade from pre-22.1. Please run the schema change on a node still running pre-22.1 binary "+
+				"or wait until the cluster upgrade finalized to 22.1. Hash sharded indexes have been improved in 22.1 to use "+
+				"a virtual column and can be added more efficiently")
 	}
 	if columnIsUndefined || existingShardCol.Dropped() {
 		if isNewTable {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1572,8 +1572,8 @@ func NewTableDesc(
 				if err != nil {
 					return nil, err
 				}
-				shardCol, err := maybeCreateAndAddShardCol(int(buckets), &desc,
-					[]string{string(d.Name)}, true, /* isNewTable */
+				shardCol, err := maybeCreateAndAddShardCol(
+					int(buckets), &desc, []string{string(d.Name)}, true /* isNewTable */, st.Version.ActiveVersion(ctx),
 				)
 				if err != nil {
 					return nil, err

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -8309,6 +8309,47 @@ func TestVirtualColumnNotAllowedInPkeyBefore22_1(t *testing.T) {
 	require.Equal(t, "pq: cannot use virtual column \"b\" in primary key", err.Error())
 }
 
+// TODO (Chengxiong): remove this test in 22.2
+func TestHashShardedIndexNotSupportedInMixedVersion(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	params, _ := tests.CreateTestServerParams()
+	params.Knobs.Server = &server.TestingKnobs{
+		DisableAutomaticVersionUpgrade: make(chan struct{}),
+		BinaryVersionOverride:          clusterversion.ByKey(clusterversion.V21_2),
+	}
+
+	s, sqlDB, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	expectedErrMsg := "pq: cannot create hash sharded index on a node running binary newer than 21.2 in a mixed version cluster " +
+		"during a cluster upgrade from pre-22.1. Please run the schema change on a node still running pre-22.1 binary " +
+		"or wait until the cluster upgrade finalized to 22.1. Hash sharded indexes have been improved in 22.1 to use " +
+		"a virtual column and can be added more efficiently"
+
+	_, err := sqlDB.Exec(`CREATE TABLE t (a INT PRIMARY kEY USING HASH)`)
+	require.Error(t, err)
+	require.Equal(t, expectedErrMsg, err.Error())
+
+	_, err = sqlDB.Exec(`CREATE TABLE t (a INT PRIMARY KEY, b INT, INDEX (b) USING HASH)`)
+	require.Error(t, err)
+	require.Equal(t, expectedErrMsg, err.Error())
+
+	_, err = sqlDB.Exec(`CREATE TABLE t (a INT PRIMARY KEY, b INT NOT NULL)`)
+	require.NoError(t, err)
+
+	_, err = sqlDB.Exec(`ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (b) USING HASH`)
+	require.Error(t, err)
+	require.Equal(t, expectedErrMsg, err.Error())
+
+	_, err = sqlDB.Exec(`CREATE INDEX idx_t_hash ON t(b) USING HASH`)
+	require.Error(t, err)
+	require.Equal(t, expectedErrMsg, err.Error())
+}
+
 // TestColumnBackfillProcessingDoesNotHoldLockOnJobsTable is a
 // regression test to ensure that when the column backfill progresses
 // to the next backfill chunk and it needs to update its progress, it


### PR DESCRIPTION
Previously, we threw out an error indicating virtual columns not allowed in
primary key when creating hash sharded index in mixed version cluster with
upgrading from pre-22.1. With this commit, we will return better instructions
with options of what to do insteading confusing them with validation errors.
We still keep the validation as the last line of guard.

Note that, we won't prevent user from doing the work around in which a stored
shard column is created manually.

Release note (sql change): Previously, we simply threw a descriptor validation
error when a user tries to create hash sharded index in a mixed version cluster
upgrading from pre-22.1, which is confusing to user. Now, we return a message
instructing users to run the statement from a pre-22.1 node before the upgrade
is finalized or just wait until the upgrade is finalied.