### PR TITLE
backupccl: create tree.SystemUsers, a new DescriptorCoverage enum

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1509,7 +1509,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		if err := r.cleanupTempSystemTables(ctx, nil /* txn */); err != nil {
 			return err
 		}
-	} else if details.RestoreSystemUsers {
+	} else if isSystemUserRestore(details) {
 		if err := r.restoreSystemUsers(ctx, p.ExecCfg().DB, mainData.systemTables); err != nil {
 			return err
 		}
@@ -1558,6 +1558,16 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		}
 	}
 	return nil
+}
+
+// isSystemUserRestore checks if the user called RESTORE SYSTEM USERS and guards
+// against any mixed version issues. In 22.2, details.DescriptorCoverage
+// identifies a system user restore, while in 22.1, details.RestoreSystemUsers
+// identified this flavour of restore.
+//
+// TODO(msbutler): delete in 23.1
+func isSystemUserRestore(details jobspb.RestoreDetails) bool {
+	return details.DescriptorCoverage == tree.SystemUsers || details.RestoreSystemUsers
 }
 
 func revalidateIndexes(
@@ -1676,7 +1686,7 @@ func (r *restoreResumer) notifyStatsRefresherOfNewTables() {
 // This is the last of the IDs pre-allocated by the restore planner.
 // TODO(postamar): Store it directly in the details instead? This is brittle.
 func tempSystemDatabaseID(details jobspb.RestoreDetails) descpb.ID {
-	if details.DescriptorCoverage != tree.AllDescriptors && !details.RestoreSystemUsers {
+	if details.DescriptorCoverage != tree.AllDescriptors && !isSystemUserRestore(details) {
 		return descpb.InvalidID
 	}
 	var maxPreAllocatedID descpb.ID

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -175,7 +175,6 @@ func allocateDescriptorRewrites(
 	opts tree.RestoreOptions,
 	intoDB string,
 	newDBName string,
-	restoreSystemUsers bool,
 ) (jobspb.DescRewriteMap, error) {
 	descriptorRewrites := make(jobspb.DescRewriteMap)
 
@@ -292,7 +291,7 @@ func allocateDescriptorRewrites(
 	// in the backup and current max desc ID in the restoring cluster. This generator
 	// keeps produced the next descriptor ID.
 	var tempSysDBID descpb.ID
-	if descriptorCoverage == tree.AllDescriptors || restoreSystemUsers {
+	if descriptorCoverage == tree.AllDescriptors || descriptorCoverage == tree.SystemUsers {
 		var err error
 		if descriptorCoverage == tree.AllDescriptors {
 			// Restore the key which generates descriptor IDs.
@@ -323,7 +322,7 @@ func allocateDescriptorRewrites(
 			if err != nil {
 				return nil, err
 			}
-		} else if restoreSystemUsers {
+		} else if descriptorCoverage == tree.SystemUsers {
 			tempSysDBID, err = descidgen.GenerateUniqueDescID(ctx, p.ExecCfg().DB, p.ExecCfg().Codec)
 			if err != nil {
 				return nil, err
@@ -706,7 +705,7 @@ func allocateDescriptorRewrites(
 	// backup should have the same ID as they do in the backup.
 	descriptorsToRemap := make([]catalog.Descriptor, 0, len(tablesByID))
 	for _, table := range tablesByID {
-		if descriptorCoverage == tree.AllDescriptors || restoreSystemUsers {
+		if descriptorCoverage == tree.AllDescriptors || descriptorCoverage == tree.SystemUsers {
 			if table.ParentID == systemschema.SystemDB.GetID() {
 				// This is a system table that should be marked for descriptor creation.
 				descriptorsToRemap = append(descriptorsToRemap, table)
@@ -988,7 +987,6 @@ func restoreJobDescription(
 	kmsURIs []string,
 ) (string, error) {
 	r := &tree.Restore{
-		SystemUsers:        restore.SystemUsers,
 		DescriptorCoverage: restore.DescriptorCoverage,
 		AsOf:               restore.AsOf,
 		Targets:            restore.Targets,
@@ -1065,7 +1063,7 @@ func restorePlanHook(
 
 	var intoDBFn func() (string, error)
 	if restoreStmt.Options.IntoDB != nil {
-		if restoreStmt.SystemUsers {
+		if restoreStmt.DescriptorCoverage == tree.SystemUsers {
 			return nil, nil, nil, false, errors.New("cannot set into_db option when only restoring system users")
 		}
 		intoDBFn, err = p.TypeAsString(ctx, restoreStmt.Options.IntoDB, "RESTORE")
@@ -1105,12 +1103,13 @@ func restorePlanHook(
 
 	var newDBNameFn func() (string, error)
 	if restoreStmt.Options.NewDBName != nil {
-		if restoreStmt.DescriptorCoverage == tree.AllDescriptors || len(restoreStmt.Targets.Databases) != 1 {
+		if restoreStmt.DescriptorCoverage == tree.AllDescriptors ||
+			len(restoreStmt.Targets.Databases) != 1 {
 			err = errors.New("new_db_name can only be used for RESTORE DATABASE with a single target" +
 				" database")
 			return nil, nil, nil, false, err
 		}
-		if restoreStmt.SystemUsers {
+		if restoreStmt.DescriptorCoverage == tree.SystemUsers {
 			return nil, nil, nil, false, errors.New("cannot set new_db_name option when only restoring system users")
 		}
 		newDBNameFn, err = p.TypeAsString(ctx, restoreStmt.Options.NewDBName, "RESTORE")
@@ -1580,7 +1579,7 @@ func doRestorePlan(
 	}
 
 	sqlDescs, restoreDBs, tenants, err := selectTargets(
-		ctx, p, mainBackupManifests, restoreStmt.Targets, restoreStmt.DescriptorCoverage, endTime, restoreStmt.SystemUsers,
+		ctx, p, mainBackupManifests, restoreStmt.Targets, restoreStmt.DescriptorCoverage, endTime,
 	)
 	if err != nil {
 		return errors.Wrap(err,
@@ -1733,8 +1732,7 @@ func doRestorePlan(
 		restoreStmt.DescriptorCoverage,
 		restoreStmt.Options,
 		intoDB,
-		newDBName,
-		restoreStmt.SystemUsers)
+		newDBName)
 	if err != nil {
 		return err
 	}
@@ -1834,7 +1832,14 @@ func doRestorePlan(
 			RevalidateIndexes:  revalidateIndexes,
 			DatabaseModifiers:  databaseModifiers,
 			DebugPauseOn:       debugPauseOn,
-			RestoreSystemUsers: restoreStmt.SystemUsers,
+
+			// A RESTORE SYSTEM USERS planned on a 22.1 node will use the
+			// RestoreSystemUsers field in the job details to identify this flavour of
+			// RESTORE. We must continue to check this field for mixed-version
+			// compatability.
+			//
+			// TODO(msbutler): Delete in 23.1
+			RestoreSystemUsers: restoreStmt.DescriptorCoverage == tree.SystemUsers,
 			PreRewriteTenantId: oldTenantID,
 			Validation:         jobspb.RestoreValidation_DefaultRestore,
 		},

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -338,7 +338,6 @@ func selectTargets(
 	targets tree.TargetList,
 	descriptorCoverage tree.DescriptorCoverage,
 	asOf hlc.Timestamp,
-	restoreSystemUsers bool,
 ) ([]catalog.Descriptor, []catalog.DatabaseDescriptor, []descpb.TenantInfoWithUsage, error) {
 	allDescs, lastBackupManifest := loadSQLDescsFromBackupsAtTime(backupManifests, asOf)
 
@@ -346,7 +345,7 @@ func selectTargets(
 		return fullClusterTargetsRestore(allDescs, lastBackupManifest)
 	}
 
-	if restoreSystemUsers {
+	if descriptorCoverage == tree.SystemUsers {
 		systemTables := make([]catalog.Descriptor, 0)
 		var users catalog.Descriptor
 		for _, desc := range allDescs {

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -329,6 +329,9 @@ message RestoreDetails {
 
   // DebugPauseOn describes the events that the job should pause itself on for debugging purposes.
   string debug_pause_on = 20;
+
+  // RestoreSystemUsers is set to true if user runs RESTORE SYSTEM USERS.
+  // TODO(msbutler): delete in 23.1
   bool restore_system_users = 22;
 
   // PreRewrittenTenantID is the ID of tenants[0] in the backup, aka its old ID;

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3165,7 +3165,7 @@ restore_stmt:
 | RESTORE SYSTEM USERS FROM list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_restore_options
   {
     $$.val = &tree.Restore{
-      SystemUsers: true,
+      DescriptorCoverage: tree.SystemUsers,
       From: $5.listOfStringOrPlaceholderOptList(),
       AsOf: $6.asOfClause(),
       Options: *($7.restoreOptions()),
@@ -3174,7 +3174,7 @@ restore_stmt:
 | RESTORE SYSTEM USERS FROM string_or_placeholder IN list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_restore_options
   {
     $$.val = &tree.Restore{
-      SystemUsers: true,
+      DescriptorCoverage: tree.SystemUsers,
       Subdir: $5.expr(),
       From: $7.listOfStringOrPlaceholderOptList(),
       AsOf: $8.asOfClause(),

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -15,9 +15,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-// DescriptorCoverage specifies whether or not a subset of descriptors were
-// requested or if all the descriptors were requested, so all the descriptors
-// are covered in a given backup.
+// DescriptorCoverage specifies the subset of descriptors that are requested during a backup
+// or a restore.
 type DescriptorCoverage int32
 
 const (
@@ -28,10 +27,15 @@ const (
 	// backup is not said to have complete table coverage unless it was created
 	// by a `BACKUP TO` command.
 	RequestedDescriptors DescriptorCoverage = iota
+
 	// AllDescriptors table coverage means that backup is guaranteed to have all the
 	// relevant data in the cluster. These can only be created by running a
 	// full cluster backup with `BACKUP TO`.
 	AllDescriptors
+
+	// SystemUsers coverage indicates that only the system.users
+	// table will be restored from the backup.
+	SystemUsers
 )
 
 // BackupOptions describes options for the BACKUP execution.
@@ -139,9 +143,7 @@ var _ NodeFormatter = &RestoreOptions{}
 
 // Restore represents a RESTORE statement.
 type Restore struct {
-	Targets TargetList
-	// Whether this is the RESTORE SYSTEM USERS variant of RESTORE statement.
-	SystemUsers        bool
+	Targets            TargetList
 	DescriptorCoverage DescriptorCoverage
 
 	// From contains the URIs for the backup(s) we seek to restore.


### PR DESCRIPTION
Previously during planning and execution RESTORE SYSTEM USERS was identified by
a `jobDetails` field. This refactor now identifies this flavor of
restore with a new  DescriptorCoverage enum value, `tree.SystemUsers.

This refactor eases the logic around exposing extra processing steps for
flavors of backup/restore that target different sets of descriptors.

Release note: None