### PR TITLE
changefeedccl: do not error out on checkpoint during pause-requested

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1241,8 +1241,11 @@ func (cf *changeFrontier) checkpointJobProgress(
 	return cf.js.job.Update(cf.Ctx, nil, func(
 		txn *kv.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
 	) error {
+		// If we're unable to update the job due to the job state, such as during
+		// pause-requested, simply skip the checkpoint
 		if err := md.CheckRunningOrReverting(); err != nil {
-			return err
+			log.Warningf(cf.Ctx, "skipping changefeed checkpoint: %s", err.Error())
+			return nil
 		}
 
 		// Advance resolved timestamp.


### PR DESCRIPTION
Resolves #83253

Previously there was a race condition where we could attempt to
checkpoint while the job was in a pause-requested state and would
error out.  Since the changefeed should still be running normally 
during *-requested states this should not error.

Release note (bug fix): Changefeeds no longer error out when attempting
to checkpoint during intermediate pause-requested or cancel-requested
states.