### PR TITLE
sql: fix panic in plan gist decoding

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
@@ -25,6 +25,7 @@ SELECT crdb_internal.decode_external_plan_gist('$gist')
 ----
 • scan
   table: ?@?
+  spans: FULL SCAN
 
 # Test that EXPLAIN (GIST) still works if automatic gists are disabled.
 statement ok
@@ -58,6 +59,7 @@ SELECT crdb_internal.decode_external_plan_gist('$gist')
 │
 └── • scan
       table: ?@?
+      spans: FULL SCAN
 
 statement error pq: unknown signature: crdb_internal\.decode_plan_gist\(int\)
 SELECT * FROM crdb_internal.decode_plan_gist(10)
@@ -104,3 +106,54 @@ SELECT crdb_internal.decode_external_plan_gist('$gist')
 ----
 • scan
   table: ?@?
+  spans: FULL SCAN
+
+# Regression test for #83537. Plan gist decoding should not panic when tables
+# or indexes no longer exist.
+statement ok
+CREATE TABLE t83537 (k INT PRIMARY KEY, a INT, INDEX idx (a))
+
+statement ok
+CREATE TABLE s83537 (k INT PRIMARY KEY, a INT)
+
+let $index_gist
+EXPLAIN (GIST) SELECT * FROM t83537@idx WHERE a = 1
+
+statement ok
+DROP INDEX idx
+
+query T
+SELECT crdb_internal.decode_plan_gist('$index_gist')
+----
+• scan
+  table: t83537@?
+  spans: 1 span
+
+let $insert_gist
+EXPLAIN (GIST) INSERT INTO t83537 VALUES (1, 10)
+
+let $lookup_join_gist
+EXPLAIN (GIST) SELECT * FROM s83537 s INNER LOOKUP JOIN t83537 t ON s.k = t.k
+
+statement ok
+DROP TABLE t
+
+query T
+SELECT crdb_internal.decode_plan_gist('$insert_gist')
+----
+• insert fast path
+  into: t83537()
+  auto commit
+  size: 0 columns, 1 row
+
+query T
+SELECT crdb_internal.decode_plan_gist('$lookup_join_gist')
+----
+• lookup join
+│ table: t83537@t83537_pkey
+│ equality: (k) = (k)
+│ equality cols are key
+│
+└── • scan
+      table: s83537@s83537_pkey
+      spans: FULL SCAN

--- a/pkg/sql/opt/exec/explain/BUILD.bazel
+++ b/pkg/sql/opt/exec/explain/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     visibility = ["//visibility:public"],
     # Pin the dependencies used in auto-generated code.
     deps = [
+        "//pkg/geo/geoindex",
         "//pkg/roachpb",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
@@ -25,6 +26,9 @@ go_library(
         "//pkg/sql/opt/constraint",
         "//pkg/sql/opt/exec",
         "//pkg/sql/opt/invertedexpr",  # keep
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
+        "//pkg/sql/sem/catid",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
         "//pkg/util",

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -891,10 +891,6 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 }
 
 func (e *emitter) emitTableAndIndex(field string, table cat.Table, index cat.Index) {
-	if table == nil || index == nil {
-		e.ob.Attr(field, "?@?")
-		return
-	}
 	partial := ""
 	if _, isPartial := index.Predicate(); isPartial {
 		partial = " (partial index)"

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -16,13 +16,19 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 
+	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/inverted"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/errors"
@@ -278,29 +284,28 @@ func (f *PlanGistFactory) decodeID() cat.StableID {
 }
 
 func (f *PlanGistFactory) decodeTable() cat.Table {
-	id := f.decodeID()
-	if f.catalog != nil {
-		if ds, _, err := f.catalog.ResolveDataSourceByID(context.TODO(), cat.Flags{}, id); err == nil {
-			return ds.(cat.Table)
-		}
+	if f.catalog == nil {
+		return &unknownTable{}
 	}
-	return nil
+	id := f.decodeID()
+	ds, _, err := f.catalog.ResolveDataSourceByID(context.TODO(), cat.Flags{}, id)
+	if err == nil {
+		return ds.(cat.Table)
+	}
+	if pgerror.GetPGCode(err) == pgcode.UndefinedTable {
+		return &unknownTable{}
+	}
+	panic(err)
 }
 
 func (f *PlanGistFactory) decodeIndex(tbl cat.Table) cat.Index {
 	id := f.decodeID()
-	// If tbl is null just return nil after consuming the id, plan will display
-	// "unknown table".
-	if tbl == nil {
-		return nil
-	}
 	for i, n := 0, tbl.IndexCount(); i < n; i++ {
 		if tbl.Index(i).ID() == id {
 			return tbl.Index(i)
 		}
 	}
-
-	return nil
+	return &unknownIndex{}
 }
 
 // TODO: implement this and figure out how to test...
@@ -429,3 +434,235 @@ func (f *PlanGistFactory) decodeRows() [][]tree.TypedExpr {
 	numRows := f.decodeInt()
 	return make([][]tree.TypedExpr, numRows)
 }
+
+// unknownTable implements the cat.Table interface and is used to represent
+// tables that cannot be decoded. This can happen when tables in plan gists are
+// dropped and are no longer in the catalog.
+type unknownTable struct{}
+
+func (u *unknownTable) ID() cat.StableID {
+	panic(errors.AssertionFailedf("not implemented"))
+}
+
+func (u *unknownTable) PostgresDescriptorID() catid.DescID {
+	panic(errors.AssertionFailedf("not implemented"))
+}
+
+func (u *unknownTable) Equals(other cat.Object) bool {
+	panic(errors.AssertionFailedf("not implemented"))
+}
+
+func (u *unknownTable) Name() tree.Name {
+	return "?"
+}
+
+func (u *unknownTable) CollectTypes(ord int) (descpb.IDs, error) {
+	return nil, errors.AssertionFailedf("not implemented")
+}
+
+func (u *unknownTable) IsVirtualTable() bool {
+	return false
+}
+
+func (u *unknownTable) IsSystemTable() bool {
+	return false
+}
+
+func (u *unknownTable) IsMaterializedView() bool {
+	return false
+}
+
+func (u *unknownTable) ColumnCount() int {
+	return 0
+}
+
+func (u *unknownTable) Column(i int) *cat.Column {
+	panic(errors.AssertionFailedf("not implemented"))
+}
+
+func (u *unknownTable) IndexCount() int {
+	return 0
+}
+
+func (u *unknownTable) WritableIndexCount() int {
+	return 0
+}
+
+func (u *unknownTable) DeletableIndexCount() int {
+	return 0
+}
+
+func (u *unknownTable) Index(i cat.IndexOrdinal) cat.Index {
+	panic(errors.AssertionFailedf("not implemented"))
+}
+
+func (u *unknownTable) StatisticCount() int {
+	return 0
+}
+
+func (u *unknownTable) Statistic(i int) cat.TableStatistic {
+	panic(errors.AssertionFailedf("not implemented"))
+}
+
+func (u *unknownTable) CheckCount() int {
+	return 0
+}
+
+func (u *unknownTable) Check(i int) cat.CheckConstraint {
+	panic(errors.AssertionFailedf("not implemented"))
+}
+
+func (u *unknownTable) FamilyCount() int {
+	return 0
+}
+
+func (u *unknownTable) Family(i int) cat.Family {
+	panic(errors.AssertionFailedf("not implemented"))
+}
+
+func (u *unknownTable) OutboundForeignKeyCount() int {
+	return 0
+}
+
+func (u *unknownTable) OutboundForeignKey(i int) cat.ForeignKeyConstraint {
+	panic(errors.AssertionFailedf("not implemented"))
+}
+
+func (u *unknownTable) InboundForeignKeyCount() int {
+	return 0
+}
+
+func (u *unknownTable) InboundForeignKey(i int) cat.ForeignKeyConstraint {
+	panic(errors.AssertionFailedf("not implemented"))
+}
+
+func (u *unknownTable) UniqueCount() int {
+	return 0
+}
+
+func (u *unknownTable) Unique(i cat.UniqueOrdinal) cat.UniqueConstraint {
+	panic(errors.AssertionFailedf("not implemented"))
+}
+
+func (u *unknownTable) Zone() cat.Zone {
+	return cat.EmptyZone()
+}
+
+func (u *unknownTable) IsPartitionAllBy() bool {
+	return false
+}
+
+var _ cat.Table = &unknownTable{}
+
+// unknownTable implements the cat.Index interface and is used to represent
+// indexes that cannot be decoded. This can happen when indexes in plan gists
+// are dropped and are no longer in the catalog.
+type unknownIndex struct{}
+
+func (u *unknownIndex) ID() cat.StableID {
+	panic(errors.AssertionFailedf("not implemented"))
+}
+
+func (u *unknownIndex) Name() tree.Name {
+	return "?"
+}
+
+func (u *unknownIndex) Table() cat.Table {
+	panic(errors.AssertionFailedf("not implemented"))
+}
+
+func (u *unknownIndex) Ordinal() int {
+	return 0
+}
+
+func (u *unknownIndex) IsUnique() bool {
+	return false
+}
+
+func (u *unknownIndex) IsInverted() bool {
+	return false
+}
+
+func (u *unknownIndex) ColumnCount() int {
+	return 0
+}
+
+func (u *unknownIndex) ExplicitColumnCount() int {
+	return 0
+}
+
+func (u *unknownIndex) KeyColumnCount() int {
+	return 0
+}
+
+func (u *unknownIndex) LaxKeyColumnCount() int {
+	return 0
+}
+
+func (u *unknownIndex) NonInvertedPrefixColumnCount() int {
+	return 0
+}
+
+func (u *unknownIndex) Column(i int) cat.IndexColumn {
+	var col cat.Column
+	col.Init(
+		i,
+		cat.StableID(0),
+		"?",
+		cat.Ordinary,
+		types.Int,
+		true, /* nullable */
+		cat.Visible,
+		nil, /* defaultExpr */
+		nil, /* computedExpr */
+		nil, /* onUpdateExpr */
+		cat.NotGeneratedAsIdentity,
+		nil, /* generatedAsIdentitySequenceOption */
+	)
+	return cat.IndexColumn{
+		Column:     &col,
+		Descending: false,
+	}
+}
+
+func (u *unknownIndex) InvertedColumn() cat.IndexColumn {
+	panic(errors.AssertionFailedf("not implemented"))
+}
+
+func (u *unknownIndex) Predicate() (string, bool) {
+	return "", false
+}
+
+func (u *unknownIndex) Zone() cat.Zone {
+	return cat.EmptyZone()
+}
+
+func (u *unknownIndex) Span() roachpb.Span {
+	panic(errors.AssertionFailedf("not implemented"))
+}
+
+func (u *unknownIndex) ImplicitColumnCount() int {
+	return 0
+}
+
+func (u *unknownIndex) ImplicitPartitioningColumnCount() int {
+	return 0
+}
+
+func (u *unknownIndex) GeoConfig() geoindex.Config {
+	return geoindex.Config{}
+}
+
+func (u *unknownIndex) Version() descpb.IndexDescriptorVersion {
+	return descpb.LatestIndexDescriptorVersion
+}
+
+func (u *unknownIndex) PartitionCount() int {
+	return 0
+}
+
+func (u *unknownIndex) Partition(i int) cat.Partition {
+	panic(errors.AssertionFailedf("not implemented"))
+}
+
+var _ cat.Index = &unknownIndex{}

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -149,7 +149,23 @@ func (f *PlanGistFactory) PlanGist() PlanGist {
 }
 
 // DecodePlanGistToRows converts a gist to a logical plan and returns the rows.
-func DecodePlanGistToRows(gist string, catalog cat.Catalog) ([]string, error) {
+func DecodePlanGistToRows(gist string, catalog cat.Catalog) (_ []string, retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			// This code allows us to propagate internal errors without having
+			// to add error checks everywhere throughout the code. This is only
+			// possible because the code does not update shared state and does
+			// not manipulate locks.
+			if ok, e := errorutil.ShouldCatch(r); ok {
+				retErr = e
+			} else {
+				// Other panic objects can't be considered "safe" and thus are
+				// propagated as crashes that terminate the session.
+				panic(r)
+			}
+		}
+	}()
+
 	flags := Flags{HideValues: true, Redact: RedactAll}
 	ob := NewOutputBuilder(flags)
 	explainPlan, err := DecodePlanGistToPlan(gist, catalog)
@@ -177,22 +193,6 @@ func DecodePlanGistToPlan(s string, cat cat.Catalog) (plan *Plan, retErr error) 
 	f.buffer.Reset()
 	f.buffer.Write(bytes)
 	plan = &Plan{}
-
-	defer func() {
-		if r := recover(); r != nil {
-			// This code allows us to propagate internal errors without having to add
-			// error checks everywhere throughout the code. This is only possible
-			// because the code does not update shared state and does not manipulate
-			// locks.
-			if ok, e := errorutil.ShouldCatch(r); ok {
-				retErr = e
-			} else {
-				// Other panic objects can't be considered "safe" and thus are
-				// propagated as crashes that terminate the session.
-				panic(r)
-			}
-		}
-	}()
 
 	ver := f.decodeInt()
 	if ver != gistVersion {


### PR DESCRIPTION
#### sql: fix panic in plan gist decoding

Previously, the plan gist decoder would set tables and indexes to nil in
`exec.Node`s when they could not be decoded, which can happen when
tables or indexes are dropped. This could cause node-crashing panics
because `explain.Emit` assumes that `exec.Node`s never have nil tables
or indexes.

This commit fixes the issue assigning two new structs to `exec.Node`
fields instead of `nil`: `unknownTable` which implements `cat.Table` and
`unknownIndex` which implements `cat.Index`. This avoids nil pointer
exceptions when `explain.Emit` tries to access these fields.

Fixes #83537

Release note (bug fix): A bug has been fixed which could crash nodes
when visiting the console statements page. This bug was present since
version 21.2.0.

#### sql: move panic catcher in plan gist decoder

This commit moves the panic catcher in `DecodePlanGistToPlan` to its
calling function `DecodePlanGistToRows`. This allows panics originating
in `Emit` to be caught without crashing nodes.

Release note: None
