### PR TITLE
release-22.1: sql: better instruction for creating HSI in mixed version cluster

### DIFF
--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/docs"
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
@@ -538,8 +539,9 @@ func setupShardedIndex(
 	if err != nil {
 		return nil, nil, err
 	}
-	shardCol, err := maybeCreateAndAddShardCol(int(buckets), tableDesc,
-		colNames, isNewTable)
+	shardCol, err := maybeCreateAndAddShardCol(
+		int(buckets), tableDesc, colNames, isNewTable, evalCtx.Settings.Version.ActiveVersion(ctx),
+	)
 
 	if err != nil {
 		return nil, nil, err
@@ -562,7 +564,11 @@ func setupShardedIndex(
 // `desc`, if one doesn't already exist for the given index column set and number of shard
 // buckets.
 func maybeCreateAndAddShardCol(
-	shardBuckets int, desc *tabledesc.Mutable, colNames []string, isNewTable bool,
+	shardBuckets int,
+	desc *tabledesc.Mutable,
+	colNames []string,
+	isNewTable bool,
+	cv clusterversion.ClusterVersion,
 ) (col catalog.Column, err error) {
 	shardColDesc, err := makeShardColumnDesc(colNames, shardBuckets)
 	if err != nil {
@@ -584,6 +590,20 @@ func maybeCreateAndAddShardCol(
 	columnIsUndefined := sqlerrors.IsUndefinedColumnError(err)
 	if err != nil && !columnIsUndefined {
 		return nil, err
+	}
+
+	if !cv.IsActive(clusterversion.Start22_1) {
+		return nil, errors.WithHint(
+			pgerror.Newf(
+				pgcode.FeatureNotSupported,
+				"cannot create hash sharded index on a node running binary newer than 21.2 in a mixed version cluster "+
+					"during a cluster upgrade from pre-22.1.",
+			),
+			"Please run the schema change on a node still running pre-22.1 binary "+
+				"or wait until the cluster upgrade finalized to 22.1. Hash sharded indexes have been improved in 22.1 to use "+
+				"a virtual column and can be added more efficiently",
+		)
+
 	}
 	if columnIsUndefined || existingShardCol.Dropped() {
 		if isNewTable {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1553,8 +1553,8 @@ func NewTableDesc(
 				if err != nil {
 					return nil, err
 				}
-				shardCol, err := maybeCreateAndAddShardCol(int(buckets), &desc,
-					[]string{string(d.Name)}, true, /* isNewTable */
+				shardCol, err := maybeCreateAndAddShardCol(
+					int(buckets), &desc, []string{string(d.Name)}, true /* isNewTable */, st.Version.ActiveVersion(ctx),
 				)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
Backport 1/1 commits from #83521.
Fixes #83447

/cc @cockroachdb/release

---

Previously, we threw out an error indicating virtual columns not allowed in
primary key when creating hash sharded index in mixed version cluster with
upgrading from pre-22.1. With this commit, we will return better instructions
with options of what to do insteading confusing them with validation errors.
We still keep the validation as the last line of guard.

Note that, we won't prevent user from doing the work around in which a stored
shard column is created manually.

Release justification: There was a support issue where user got confused by
the insufficient validation error message. This commit adds more helpful
instructions to better educate users what is happening.

Release note (sql change): Previously, we simply threw a descriptor validation
error when a user tries to create hash sharded index in a mixed version cluster
upgrading from pre-22.1, which is confusing to user. Now, we return a message
instructing users to run the statement from a pre-22.1 node before the upgrade
is finalized or just wait until the upgrade is finalied.
