### PR TITLE
rowexec: fix recent bug of using nil context

### DIFF
--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -478,7 +478,7 @@ func newJoinReader(
 		var diskBuffer kvstreamer.ResultDiskBuffer
 		if jr.maintainOrdering {
 			jr.streamerInfo.diskMonitor = execinfra.NewMonitor(
-				jr.Ctx, jr.FlowCtx.DiskMonitor, "streamer-disk", /* name */
+				flowCtx.EvalCtx.Ctx(), jr.FlowCtx.DiskMonitor, "streamer-disk", /* name */
 			)
 			diskBuffer = rowcontainer.NewKVStreamerResultDiskBuffer(
 				jr.FlowCtx.Cfg.TempStorage, jr.streamerInfo.diskMonitor,


### PR DESCRIPTION
In e7e724ead15aa037f9f0188fe18f8179bf3945f0 we moved the creation of
a monitor for the streamer's disk usage into the constructor of the join
reader but forgot to update the context used during that operation. The
thing is that the context on the processors is only set in `Start`
meaning it is `nil` in the construct of the processor. This commit fixes
the issue.

Fixes: #83367

Release note: None