### PR TITLE
release-21.2: sqlsmith: add hint for ping failures and stop marking failures as release blockers

### DIFF
--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -266,11 +266,12 @@ func registerSQLSmith(r registry.Registry) {
 
 	register := func(setup, setting string) {
 		r.Add(registry.TestSpec{
-			Name: fmt.Sprintf("sqlsmith/setup=%s/setting=%s", setup, setting),
-			// NB: sqlsmith failures should never block a release.
+			Name:    fmt.Sprintf("sqlsmith/setup=%s/setting=%s", setup, setting),
 			Owner:   registry.OwnerSQLQueries,
 			Cluster: r.MakeClusterSpec(numNodes),
 			Timeout: time.Minute * 20,
+			// NB: sqlsmith failures should never block a release.
+			NonReleaseBlocker: true,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runSQLSmith(ctx, t, c, setup, setting)
 			},

--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -239,7 +239,26 @@ func registerSQLSmith(r registry.Registry) {
 			for idx, c := range allConns {
 				if err := c.PingContext(ctx); err != nil {
 					logStmt(stmt)
-					t.Fatalf("ping node %d: %v\nprevious sql:\n%s;", idx+1, err, stmt)
+					nodeID := idx + 1
+					errStr := fmt.Sprintf("ping node %d: %v\n", nodeID, err)
+					hintStr := fmt.Sprintf(
+						"HINT: node likely crashed, check logs in artifacts > logs/%d.unredacted\n",
+						nodeID,
+					)
+
+					var sb strings.Builder
+					// Print the error message and a hint.
+					sb.WriteString(errStr)
+					sb.WriteString(hintStr)
+					// Print the previous SQL.
+					sb.WriteString(fmt.Sprintf("previous sql:\n%s;", stmt))
+					// Print the error message and hint again because
+					// github-post prunes the top of the error message away when
+					// the SQL is too long.
+					sb.WriteString(errStr)
+					sb.WriteString(hintStr)
+
+					t.Fatalf(sb.String())
 				}
 			}
 		}


### PR DESCRIPTION
Backport 2/2 commits from #83297.

/cc @cockroachdb/release

Release justification: Test-only change.

---

#### sqlsmith: add hint for ping failures

Release note: None

#### sqlsmith: failures are no longer release blockers

Release note: None

