### PR TITLE
sql: better error for exprs in ALTER PRIMARY KEY

### DIFF
--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -121,6 +121,16 @@ func (p *planner) AlterPrimaryKey(
 	}
 
 	for _, elem := range alterPKNode.Columns {
+		if elem.Column == "" && elem.Expr != nil {
+			return errors.WithHint(
+				pgerror.Newf(
+					pgcode.InvalidColumnDefinition,
+					"expressions such as %q are not allowed in primary index definition",
+					elem.Expr.String(),
+				),
+				"use columns instead",
+			)
+		}
 		col, err := tableDesc.FindColumnWithName(elem.Column)
 		if err != nil {
 			return err

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -77,6 +77,10 @@ SELECT y, z, v FROM t@i2
 12 13 15
 17 18 20
 
+# Regression test for issue #81522.
+statement error pgcode 42611 expressions such as \"gen_random_uuid\(\)\" are not allowed in primary index definition
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (gen_random_uuid());
+
 # Test that composite values are encoded correctly in covering indexes.
 statement ok
 CREATE TABLE t_composite (x INT PRIMARY KEY, y DECIMAL NOT NULL);


### PR DESCRIPTION
Previously, a statement such as

  ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (gen_random_uuid())

would correctly fail because we don't allow expression-based primary
indexes, but the error message was rather obscure:

  ERROR: column "" does not exist

This patch provides a more useful error message.

Fixes #81522.

Release note: None