### PR TITLE
tree: DROP ROLE should not implement CCLOnlyStatement

### DIFF
--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -842,8 +842,6 @@ func (*DropRole) StatementType() StatementType { return TypeDDL }
 // StatementTag returns a short string identifying the type of statement.
 func (*DropRole) StatementTag() string { return "DROP ROLE" }
 
-func (*DropRole) cclOnlyStatement() {}
-
 func (*DropRole) hiddenFromShowQueries() {}
 
 // StatementReturnType implements the Statement interface.


### PR DESCRIPTION
This was moved out of CCL licensing a few releases ago.

Release note: None