### PR TITLE
kvstreamer: add more observability

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/BUILD.bazel
+++ b/pkg/kv/kvclient/kvstreamer/BUILD.bazel
@@ -23,6 +23,8 @@ go_library(
         "//pkg/util/admission",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/buildutil",
+        "//pkg/util/humanizeutil",
+        "//pkg/util/log",
         "//pkg/util/mon",
         "//pkg/util/quotapool",
         "//pkg/util/stop",

--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -30,6 +30,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -226,9 +228,7 @@ type Streamer struct {
 	maxKeysPerRow int32
 	budget        *budget
 
-	atomics struct {
-		batchRequestsIssued *int64
-	}
+	streamerStatistics
 
 	coordinator          workerCoordinator
 	coordinatorStarted   bool
@@ -274,6 +274,37 @@ type Streamer struct {
 		// coordinator must exit.
 		done bool
 	}
+}
+
+type streamerStatistics struct {
+	atomics struct {
+		batchRequestsIssued *int64
+		// resumeBatchRequests tracks the number of BatchRequests created for
+		// the ResumeSpans throughout the lifetime of the Streamer.
+		resumeBatchRequests int64
+		// resumeSingleRangeRequests tracks the number of single-range requests
+		// that were created for the ResumeSpans throughout the lifetime of the
+		// Streamer.
+		resumeSingleRangeRequests int64
+		// emptyBatchResponses tracks the number of BatchRequests that resulted
+		// in empty BatchResponses because they were issued with too low value
+		// of TargetBytes parameter.
+		emptyBatchResponses int64
+		// droppedBatchResponses tracks the number of the received
+		// BatchResponses that were dropped because the memory reservation
+		// during the budget reconciliation was denied (i.e. the original
+		// estimate was too low, and the budget has been used up by the time
+		// response came).
+		droppedBatchResponses int64
+	}
+	// enqueueCalls tracks the number of times Enqueue() has been called.
+	enqueueCalls int
+	// enqueuedRequests tracks the number of possibly-multi-range requests that
+	// have been Enqueue()'d into the Streamer.
+	enqueuedRequests int
+	// enqueuedSingleRangeRequests tracks the number of single-range
+	// sub-requests that were created during the truncation process in Enqueue()
+	enqueuedSingleRangeRequests int
 }
 
 // streamerConcurrencyLimit is an upper bound on the number of asynchronous
@@ -434,6 +465,9 @@ func (s *Streamer) Enqueue(ctx context.Context, reqs []roachpb.RequestUnion) (re
 		return err
 	}
 
+	s.enqueueCalls++
+	s.enqueuedRequests += len(reqs)
+
 	// The minimal key range encompassing all requests contained within.
 	// Local addressing has already been resolved.
 	rs, err := keys.Range(reqs)
@@ -542,6 +576,7 @@ func (s *Streamer) Enqueue(ctx context.Context, reqs []roachpb.RequestUnion) (re
 		}
 
 		requestsToServe = append(requestsToServe, r)
+		s.enqueuedSingleRangeRequests += len(singleRangeReqs)
 
 		// Determine next seek key, taking potentially sparse requests into
 		// consideration.
@@ -625,6 +660,7 @@ func (s *Streamer) GetResults(ctx context.Context) ([]Result, error) {
 // other calls on s are allowed after this.
 func (s *Streamer) Close(ctx context.Context) {
 	if s.coordinatorStarted {
+		s.coordinator.logStatistics(ctx)
 		s.coordinatorCtxCancel()
 		s.mu.Lock()
 		s.mu.done = true
@@ -740,6 +776,31 @@ func (w *workerCoordinator) mainLoop(ctx context.Context) {
 			return
 		}
 	}
+}
+
+// logStatistics logs some of the statistics about the Streamer. It should be
+// called at the end of the Streamer's lifecycle.
+// TODO(yuzefovich): at the moment, these statistics will be attached to the
+// tracing span of the Streamer's user. Some time has been spent to figure it
+// out but led to no success. This should be cleaned up.
+func (w *workerCoordinator) logStatistics(ctx context.Context) {
+	avgResponseSize, _ := w.getAvgResponseSize()
+	log.VEventf(
+		ctx, 1,
+		"enqueueCalls=%d enqueuedRequests=%d enqueuedSingleRangeRequests=%d "+
+			"batchRequestsIssued=%d resumeBatchRequests=%d resumeSingleRangeRequests=%d "+
+			"numSpilledResults=%d emptyBatchResponses=%d droppedBatchResponses=%d avgResponseSize=%s",
+		w.s.enqueueCalls,
+		w.s.enqueuedRequests,
+		w.s.enqueuedSingleRangeRequests,
+		atomic.LoadInt64(w.s.atomics.batchRequestsIssued),
+		atomic.LoadInt64(&w.s.atomics.resumeBatchRequests),
+		atomic.LoadInt64(&w.s.atomics.resumeSingleRangeRequests),
+		w.s.results.numSpilledResults(),
+		atomic.LoadInt64(&w.s.atomics.emptyBatchResponses),
+		atomic.LoadInt64(&w.s.atomics.droppedBatchResponses),
+		humanizeutil.IBytes(avgResponseSize),
+	)
 }
 
 // waitForRequests blocks until there is at least one request to be served.
@@ -1129,6 +1190,7 @@ func (w *workerCoordinator) performRequestAsync(
 				// but not enough for that large row).
 				toConsume := -overaccountedTotal
 				if err := w.s.budget.consume(ctx, toConsume, headOfLine /* allowDebt */); err != nil {
+					atomic.AddInt64(&w.s.atomics.droppedBatchResponses, 1)
 					w.s.budget.release(ctx, targetBytes)
 					if !headOfLine {
 						// Since this is not the head of the line, we'll just
@@ -1413,6 +1475,7 @@ func (w *workerCoordinator) processSingleRangeResults(
 		)
 	} else {
 		// We received an empty response.
+		atomic.AddInt64(&w.s.atomics.emptyBatchResponses, 1)
 		if req.minTargetBytes != 0 {
 			// We previously have already received an empty response for this
 			// request, and minTargetBytes wasn't sufficient. Make sure that
@@ -1444,6 +1507,8 @@ func (w *workerCoordinator) processSingleRangeResults(
 			req.reqs[i] = roachpb.RequestUnion{}
 		}
 		w.s.requestsToServe.add(resumeReq)
+		atomic.AddInt64(&w.s.atomics.resumeBatchRequests, 1)
+		atomic.AddInt64(&w.s.atomics.resumeSingleRangeRequests, int64(numIncompleteRequests))
 	}
 
 	return nil


### PR DESCRIPTION
This commit adds the following statistics about the streamer:
- number of Enqueue calls
- number of enqueued requests
- number of single-range enqueue requests
- number of issued BatchRequests (which is also exposed on EXPLAIN ANALYZE)
- number of resume BatchRequests
- number of resume single-range requests
- number of spilled results
- number of empty batch responses
- number of dropped batch responses
- the final average response size.

This information provides more visibility into how the streamer behaved.
It is only added to the verbose logs / tracing since these are pretty
low level details that would only pollute the output of EXPLAIN or
something like that.

Fixes: #82156.

Release note: None