### PR TITLE
Colocate auth logging with auth metric for consistency

### DIFF
--- a/pkg/sql/pgwire/auth.go
+++ b/pkg/sql/pgwire/auth.go
@@ -205,7 +205,6 @@ func (c *conn) handleAuthentication(
 		}
 	}
 
-	ac.LogAuthOK(ctx)
 	return connClose, nil
 }
 


### PR DESCRIPTION
refs https://github.com/cockroachdb/cockroach/issues/83224

Release note (bug fix): Move connection OK log and metric to same location
after auth completes for consistency. This resolves an inconsistency 
(see linked isssue) in the DB console where the log and metric did not match.
