### PR TITLE
sql/syntheticprivilege: remove BUILD.bazel cruft

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -422,7 +422,6 @@ ALL_TESTS = [
     "//pkg/sql/stats:stats_test",
     "//pkg/sql/stmtdiagnostics:stmtdiagnostics_test",
     "//pkg/sql/syntheticprivilege:syntheticprivilege_test",
-    "//pkg/sql/syntheticprivilege:systemprivilege_test",
     "//pkg/sql/tests:tests_test",
     "//pkg/sql/ttl/ttljob:ttljob_test",
     "//pkg/sql/types:types_disallowed_imports_test",

--- a/pkg/sql/syntheticprivilege/BUILD.bazel
+++ b/pkg/sql/syntheticprivilege/BUILD.bazel
@@ -1,27 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "systemprivilege",
-    srcs = ["system_privilege.go"],
-    importpath = "github.com/cockroachdb/cockroach/pkg/sql/systemprivilege",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/sql/catalog",
-        "@com_github_cockroachdb_errors//:errors",
-    ],
-)
-
-go_test(
-    name = "systemprivilege_test",
-    srcs = ["system_privilege_test.go"],
-    embed = [":systemprivilege"],
-    deps = [
-        "//pkg/sql/catalog",
-        "@com_github_stretchr_testify//require",
-    ],
-)
-
-go_library(
     name = "syntheticprivilege",
     srcs = [
         "global_privilege.go",


### PR DESCRIPTION
This was added as part of the rename.

Release note: None