### PR TITLE
sql/schemachanger: fix multiple add column statements in a transaction

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -1850,4 +1850,42 @@ statement ok
 DROP DATABASE test CASCADE
 
 statement ok
-CREATE DATABASE test
+CREATE DATABASE test;
+USE test
+
+subtest add_multiple_columns_in_transaction
+
+statement ok
+CREATE TABLE t (i INT PRIMARY KEY);
+INSERT INTO t VALUES (1), (2), (3)
+
+statement ok
+SET use_declarative_schema_changer = 'unsafe_always';
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE t ADD COLUMN k INT AS (i + 3) STORED NOT NULL UNIQUE;
+ALTER TABLE t ADD COLUMN j INT DEFAULT 42;
+
+statement ok
+COMMIT
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t]
+----
+CREATE TABLE public.t (
+   i INT8 NOT NULL,
+   k INT8 NOT NULL AS (i + 3:::INT8) STORED,
+   j INT8 NULL DEFAULT 42:::INT8,
+   CONSTRAINT t_pkey PRIMARY KEY (i ASC),
+   UNIQUE INDEX t_expr_key (k ASC)
+)
+
+query III rowsort
+SELECT * FROM t
+----
+1  4  42
+2  5  42
+3  6  42

--- a/pkg/sql/schemachanger/scplan/internal/rules/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/testdata/deprules
@@ -158,20 +158,6 @@ deprules
     - $index-dependent-node[CurrentStatus] = PUBLIC
     - joinTargetNode($index, $index-target, $index-node)
     - joinTargetNode($index-dependent, $index-dependent-target, $index-dependent-node)
-- name: index exists right before columns, partitioning, and partial
-  from: index-node
-  kind: SameStagePrecedence
-  to: index-column-node
-  query:
-    - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
-    - $index-column[Type] IN ['*scpb.IndexColumn', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial']
-    - joinOnIndexID($index, $index-column, $table-id, $index-id)
-    - $index-target[TargetStatus] = PUBLIC
-    - $index-column-target[TargetStatus] = PUBLIC
-    - $index-node[CurrentStatus] = BACKFILL_ONLY
-    - $index-column-node[CurrentStatus] = PUBLIC
-    - joinTargetNode($index, $index-target, $index-node)
-    - joinTargetNode($index-column, $index-column-target, $index-column-node)
 - name: temp index exists right before columns, partitioning, and partial
   from: temp-index-node
   kind: SameStagePrecedence
@@ -513,7 +499,7 @@ deprules
     - joinTargetNode($column-name, $column-name-target, $column-name-node)
 - name: index-column added to index after index exists
   from: index-node
-  kind: SameStagePrecedence
+  kind: Precedence
   to: index-column-node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
@@ -525,9 +511,23 @@ deprules
     - $index-column-node[CurrentStatus] = PUBLIC
     - joinTargetNode($index, $index-target, $index-node)
     - joinTargetNode($index-column, $index-column-target, $index-column-node)
+- name: index-column added to index before index is backfilled
+  from: index-column-node
+  kind: Precedence
+  to: index-node
+  query:
+    - $index-column[Type] = '*scpb.IndexColumn'
+    - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
+    - joinOnIndexID($index-column, $index, $table-id, $index-id)
+    - $index-column-target[TargetStatus] = PUBLIC
+    - $index-target[TargetStatus] = PUBLIC
+    - $index-column-node[CurrentStatus] = PUBLIC
+    - $index-node[CurrentStatus] = BACKFILLED
+    - joinTargetNode($index-column, $index-column-target, $index-column-node)
+    - joinTargetNode($index, $index-target, $index-node)
 - name: index-column added to index after temp index exists
   from: index-node
-  kind: SameStagePrecedence
+  kind: Precedence
   to: index-column-node
   query:
     - $index[Type] = '*scpb.TemporaryIndex'
@@ -539,6 +539,20 @@ deprules
     - $index-column-node[CurrentStatus] = PUBLIC
     - joinTargetNode($index, $index-target, $index-node)
     - joinTargetNode($index-column, $index-column-target, $index-column-node)
+- name: index-column added to index before temp index receives writes
+  from: index-column-node
+  kind: Precedence
+  to: index-node
+  query:
+    - $index-column[Type] = '*scpb.IndexColumn'
+    - $index[Type] = '*scpb.TemporaryIndex'
+    - joinOnIndexID($index-column, $index, $table-id, $index-id)
+    - $index-column-target[TargetStatus] = PUBLIC
+    - $index-target[TargetStatus] = TRANSIENT_ABSENT
+    - $index-column-node[CurrentStatus] = PUBLIC
+    - $index-node[CurrentStatus] = WRITE_ONLY
+    - joinTargetNode($index-column, $index-column-target, $index-column-node)
+    - joinTargetNode($index, $index-target, $index-node)
 - name: ensure columns are in increasing order
   from: later-column-node
   kind: SameStagePrecedence

--- a/pkg/sql/schemachanger/scplan/testdata/create_index
+++ b/pkg/sql/schemachanger/scplan/testdata/create_index
@@ -180,21 +180,45 @@ PostCommitNonRevertiblePhase stage 2 of 2 with 4 MutationType ops
 deps
 CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money)
 ----
+- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILLED]
+  kind: Precedence
+  rule: index-column added to index before index is backfilled
+- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, WRITE_ONLY]
+  kind: Precedence
+  rule: index-column added to index before temp index receives writes
+- from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILLED]
+  kind: Precedence
+  rule: index-column added to index before index is backfilled
+- from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, PUBLIC]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, WRITE_ONLY]
+  kind: Precedence
+  rule: index-column added to index before temp index receives writes
+- from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, PUBLIC]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILLED]
+  kind: Precedence
+  rule: index-column added to index before index is backfilled
+- from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, PUBLIC]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, WRITE_ONLY]
+  kind: Precedence
+  rule: index-column added to index before temp index receives writes
 - from: [IndexName:{DescID: 104, Name: id1, IndexID: 2}, PUBLIC]
   to:   [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC]
   kind: SameStagePrecedence
   rule: index named right before index becomes public
 - from: [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILL_ONLY]
   to:   [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC]
-  kind: SameStagePrecedence
+  kind: Precedence
   rule: index-column added to index after index exists
 - from: [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILL_ONLY]
   to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC]
-  kind: SameStagePrecedence
+  kind: Precedence
   rule: index-column added to index after index exists
 - from: [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILL_ONLY]
   to:   [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, PUBLIC]
-  kind: SameStagePrecedence
+  kind: Precedence
   rule: index-column added to index after index exists
 - from: [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILL_ONLY]
   to:   [IndexName:{DescID: 104, Name: id1, IndexID: 2}, PUBLIC]
@@ -202,15 +226,15 @@ CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money)
   rule: index existence precedes index name and comment
 - from: [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, DELETE_ONLY]
   to:   [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC]
-  kind: SameStagePrecedence
+  kind: Precedence
   rule: index-column added to index after temp index exists
 - from: [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, DELETE_ONLY]
   to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, PUBLIC]
-  kind: SameStagePrecedence
+  kind: Precedence
   rule: index-column added to index after temp index exists
 - from: [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, DELETE_ONLY]
   to:   [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, PUBLIC]
-  kind: SameStagePrecedence
+  kind: Precedence
   rule: index-column added to index after temp index exists
 - from: [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, WRITE_ONLY]
   to:   [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILLED]
@@ -400,21 +424,45 @@ PostCommitNonRevertiblePhase stage 2 of 2 with 4 MutationType ops
 deps
 CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money)
 ----
+- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILLED]
+  kind: Precedence
+  rule: index-column added to index before index is backfilled
+- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, WRITE_ONLY]
+  kind: Precedence
+  rule: index-column added to index before temp index receives writes
+- from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILLED]
+  kind: Precedence
+  rule: index-column added to index before index is backfilled
+- from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, PUBLIC]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, WRITE_ONLY]
+  kind: Precedence
+  rule: index-column added to index before temp index receives writes
+- from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, PUBLIC]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILLED]
+  kind: Precedence
+  rule: index-column added to index before index is backfilled
+- from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, PUBLIC]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, WRITE_ONLY]
+  kind: Precedence
+  rule: index-column added to index before temp index receives writes
 - from: [IndexName:{DescID: 104, Name: id1, IndexID: 2}, PUBLIC]
   to:   [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC]
   kind: SameStagePrecedence
   rule: index named right before index becomes public
 - from: [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILL_ONLY]
   to:   [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC]
-  kind: SameStagePrecedence
+  kind: Precedence
   rule: index-column added to index after index exists
 - from: [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILL_ONLY]
   to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC]
-  kind: SameStagePrecedence
+  kind: Precedence
   rule: index-column added to index after index exists
 - from: [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILL_ONLY]
   to:   [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, PUBLIC]
-  kind: SameStagePrecedence
+  kind: Precedence
   rule: index-column added to index after index exists
 - from: [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILL_ONLY]
   to:   [IndexName:{DescID: 104, Name: id1, IndexID: 2}, PUBLIC]
@@ -422,15 +470,15 @@ CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money)
   rule: index existence precedes index name and comment
 - from: [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, DELETE_ONLY]
   to:   [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC]
-  kind: SameStagePrecedence
+  kind: Precedence
   rule: index-column added to index after temp index exists
 - from: [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, DELETE_ONLY]
   to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, PUBLIC]
-  kind: SameStagePrecedence
+  kind: Precedence
   rule: index-column added to index after temp index exists
 - from: [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, DELETE_ONLY]
   to:   [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, PUBLIC]
-  kind: SameStagePrecedence
+  kind: Precedence
   rule: index-column added to index after temp index exists
 - from: [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, WRITE_ONLY]
   to:   [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILLED]


### PR DESCRIPTION
Recent changes combined to prevent multiple add column statements in a
transaction from working properly. The result was that we had a rule
which disallowed adding a second column because it would violate a
SameStagePrecedence rule. We fix this by instead making the old rule
less string (Precedence) and adding a pair of new rules to make sure
we don't add columns to the index too late.

Release note: None