### PR TITLE
sql: don't clear the memory account of the prepared stmt

### DIFF
--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -153,9 +153,6 @@ func (ex *connExecutor) prepare(
 		createdAt: timeutil.Now(),
 		origin:    origin,
 	}
-	// NB: if we start caching the plan, we'll want to keep around the memory
-	// account used for the plan, rather than clearing it.
-	defer prepared.memAcc.Clear(ctx)
 
 	if stmt.AST == nil {
 		return prepared, nil


### PR DESCRIPTION
Previously, we had a bug of clearing the memory account of the prepared
statements right after that prepared statement is created although we do
keep the struct around. I believe this bug was introduced long time ago,
and it could result in some memory not being accounted for. This is now
fixed.

Partially addresses: #72581.

Release note: None