### PR TITLE
release-22.1.0: ui/cluster-ui: fix transaction details stmts table pagination

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -137,13 +137,12 @@ export class TransactionDetails extends React.Component<
       transaction?.stats_data?.statement_fingerprint_ids;
 
     const statementsForTransaction =
-      (statementFingerprintIds &&
-        getStatementsByFingerprintIdAndTime(
-          statementFingerprintIds,
-          aggregatedTs,
-          statements,
-        )) ||
-      [];
+      statementFingerprintIds &&
+      getStatementsByFingerprintIdAndTime(
+        statementFingerprintIds,
+        aggregatedTs,
+        statements,
+      );
 
     const transactionText =
       (statementFingerprintIds &&
@@ -378,7 +377,7 @@ export class TransactionDetails extends React.Component<
                   </Row>
                   <TableStatistics
                     pagination={pagination}
-                    totalCount={statementsForTransaction.length}
+                    totalCount={aggregatedStatements.length}
                     arrayItemName={
                       "statement fingerprints for this transaction"
                     }
@@ -405,7 +404,7 @@ export class TransactionDetails extends React.Component<
                 <Pagination
                   pageSize={pagination.pageSize}
                   current={pagination.current}
-                  total={statementsForTransaction.length}
+                  total={aggregatedStatements.length}
                   onChange={this.onChangePage}
                 />
               </React.Fragment>

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
@@ -56,12 +56,14 @@ export const getStatementsByFingerprintIdAndTime = (
   timestamp: string | null,
   statements: Statement[],
 ): Statement[] => {
-  return statements?.filter(
-    s =>
-      (timestamp == null ||
-        (s.key?.aggregated_ts != null &&
-          timestamp == TimestampToString(s.key.aggregated_ts))) &&
-      statementFingerprintIds.some(id => id.eq(s.id)),
+  return (
+    statements?.filter(
+      (s) =>
+        (timestamp == null ||
+          (s.key?.aggregated_ts != null &&
+            timestamp == TimestampToString(s.key.aggregated_ts))) &&
+        statementFingerprintIds.some((id) => id.eq(s.id)),
+    ) || []
   );
 };
 


### PR DESCRIPTION
Backport 1/1 commits from #83191.

/cc @cockroachdb/release

---

Previously, the pagination used by the stmts table in the
transaction details page used the length associated with
the unaggregated list of statements retrieved for a
transaction. This lead to the table reporting more
stmts for a transaction than available.

Release note (bug fix): The statements table for a txn
in the txn details page now shows the correct number of
stmts for a transaction.

Before: There are clearly 5 statements in the txn text and stmts table, but the stmts table pagination shows 9.
<img width="1162" alt="image" src="https://user-images.githubusercontent.com/20136951/175074289-3592ae74-74f5-4373-be2e-7de0082ad369.png">

After: correct number of stmts reported
<img width="1170" alt="image" src="https://user-images.githubusercontent.com/20136951/175074722-f61b306e-f87b-45af-a354-3ee8d81dfea0.png">

Release justification: Bug fixes and low-risk updates to new functionality
