### PR TITLE
release-22.1.0: cluster-ui/ui: remove ability to search statements by plan

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.spec.tsx
@@ -102,8 +102,13 @@ describe("StatementsPage", () => {
     };
 
     assert.equal(filterBySearchQuery(statement, "select"), true);
-    assert.equal(filterBySearchQuery(statement, "virtual table"), true);
-    assert.equal(filterBySearchQuery(statement, "group (scalar)"), true);
+    assert.equal(filterBySearchQuery(statement, "count"), true);
+    assert.equal(filterBySearchQuery(statement, "select count"), true);
+    assert.equal(filterBySearchQuery(statement, "cluster settings"), true);
+
+    // Searching by plan should be false.
+    assert.equal(filterBySearchQuery(statement, "virtual table"), false);
+    assert.equal(filterBySearchQuery(statement, "group (scalar)"), false);
     assert.equal(filterBySearchQuery(statement, "node_build_info"), false);
     assert.equal(filterBySearchQuery(statement, "crdb_internal"), false);
   });

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -76,7 +76,6 @@ import {
 } from "../timeScaleDropdown";
 
 import { commonStyles } from "../common";
-import { flattenTreeAttributes, planNodeToString } from "../statementDetails";
 const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
 
@@ -157,14 +156,7 @@ export function filterBySearchQuery(
   statement: AggregateStatistics,
   search: string,
 ): boolean {
-  const label = statement.label;
-  const plan = planNodeToString(
-    flattenTreeAttributes(
-      statement.stats.sensitive_info &&
-        statement.stats.sensitive_info.most_recent_plan_description,
-    ),
-  );
-  const matchString = `${label} ${plan}`.toLowerCase();
+  const matchString = statement.label.toLowerCase();
   return search
     .toLowerCase()
     .split(" ")


### PR DESCRIPTION
Backport 1/1 commits from #83423.

/cc @cockroachdb/release

---

Closes  https://github.com/cockroachdb/cockroach/issues/83155

Previously, we allowed statements in the statements page to
searchable by text in the explain plan. This was before we
returned multiple plans for a statement fingerprint. This commit
removes the explain plan text as part of the searchable string, as
this feature could  now lead to confusing behaviour.

Release note (ui change): In the statements page, users can no
longer filter statements by searching for text in the EXPLAIN
plan.

Release justification: Bug fixes and low-risk updates to new functionality