### PR TITLE
sql: support FOR {UPDATE,SHARE} SKIP LOCKED

### DIFF
--- a/pkg/sql/catalog/descpb/locking.proto
+++ b/pkg/sql/catalog/descpb/locking.proto
@@ -124,9 +124,6 @@ enum ScanLockingWaitPolicy {
   BLOCK = 0;
 
   // SKIP_LOCKED represents SKIP LOCKED - skip rows that can't be locked.
-  //
-  // NOTE: SKIP_LOCKED is not currently implemented and does not make it out of
-  // the SQL optimizer without throwing an error.
   SKIP_LOCKED = 1;
 
   // ERROR represents NOWAIT - raise an error if a row cannot be locked.

--- a/pkg/sql/logictest/testdata/logic_test/select_for_update
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update
@@ -53,30 +53,37 @@ SELECT 1 FOR UPDATE OF public.a
 query error pgcode 42601 FOR UPDATE must specify unqualified relation names
 SELECT 1 FOR UPDATE OF db.public.a
 
-# We don't currently support SKIP LOCKED, since it returns an inconsistent view
-# and generally has strange semantics with respect to serializable isolation.
-# Support may be added in the future.
-
-query error unimplemented: SKIP LOCKED lock wait policy is not supported
+query I
 SELECT 1 FOR UPDATE SKIP LOCKED
+----
+1
 
-query error unimplemented: SKIP LOCKED lock wait policy is not supported
+query I
 SELECT 1 FOR NO KEY UPDATE SKIP LOCKED
+----
+1
 
-query error unimplemented: SKIP LOCKED lock wait policy is not supported
+query I
 SELECT 1 FOR SHARE SKIP LOCKED
+----
+1
 
-query error unimplemented: SKIP LOCKED lock wait policy is not supported
+query I
 SELECT 1 FOR KEY SHARE SKIP LOCKED
+----
+1
 
-query error unimplemented: SKIP LOCKED lock wait policy is not supported
+query error pgcode 42P01 relation "a" in FOR UPDATE clause not found in FROM clause
 SELECT 1 FOR UPDATE OF a SKIP LOCKED
 
-query error unimplemented: SKIP LOCKED lock wait policy is not supported
+query error pgcode 42P01 relation "a" in FOR UPDATE clause not found in FROM clause
 SELECT 1 FOR UPDATE OF a SKIP LOCKED FOR NO KEY UPDATE OF b SKIP LOCKED
 
-query error unimplemented: SKIP LOCKED lock wait policy is not supported
+query error pgcode 42P01 relation "a" in FOR UPDATE clause not found in FROM clause
 SELECT 1 FOR UPDATE OF a SKIP LOCKED FOR NO KEY UPDATE OF b NOWAIT
+
+query error pgcode 42P01 relation "a" in FOR UPDATE clause not found in FROM clause
+SELECT 1 FOR UPDATE OF a SKIP LOCKED FOR SHARE OF b, c SKIP LOCKED FOR NO KEY UPDATE OF d SKIP LOCKED FOR KEY SHARE OF e, f SKIP LOCKED
 
 query I
 SELECT 1 FOR UPDATE NOWAIT
@@ -105,18 +112,24 @@ query error pgcode 42P01 relation "a" in FOR UPDATE clause not found in FROM cla
 SELECT 1 FOR UPDATE OF a NOWAIT FOR NO KEY UPDATE OF b NOWAIT
 
 query error pgcode 42P01 relation "a" in FOR UPDATE clause not found in FROM clause
-SELECT 1 FOR UPDATE OF a NOWAIT FOR SHARE OF b, c NOWAIT FOR NO KEY UPDATE OF d NOWAIT  FOR KEY SHARE OF e, f NOWAIT 
+SELECT 1 FOR UPDATE OF a NOWAIT FOR SHARE OF b, c NOWAIT FOR NO KEY UPDATE OF d NOWAIT FOR KEY SHARE OF e, f NOWAIT
 
 # Locking clauses both inside and outside of parenthesis are handled correctly.
 
-query error unimplemented: SKIP LOCKED lock wait policy is not supported
+query I
 ((SELECT 1)) FOR UPDATE SKIP LOCKED
+----
+1
 
-query error unimplemented: SKIP LOCKED lock wait policy is not supported
+query I
 ((SELECT 1) FOR UPDATE SKIP LOCKED)
+----
+1
 
-query error unimplemented: SKIP LOCKED lock wait policy is not supported
+query I
 ((SELECT 1 FOR UPDATE SKIP LOCKED))
+----
+1
 
 # FOR READ ONLY is ignored, like in Postgres.
 query I
@@ -295,7 +308,7 @@ SELECT * FROM t FOR KEY SHARE
 statement ok
 ROLLBACK
 
-# The NOWAIT wait policy returns error when conflicting lock is encountered.
+# The NOWAIT wait policy returns error when a conflicting lock is encountered.
 
 statement ok
 INSERT INTO t VALUES (1, 1)
@@ -372,3 +385,50 @@ user root
 
 statement ok
 ROLLBACK
+
+# The SKIP LOCKED wait policy skip rows when a conflicting lock is encountered.
+
+statement ok
+INSERT INTO t VALUES (2, 2), (3, 3), (4, 4)
+
+statement ok
+BEGIN; UPDATE t SET v = 3 WHERE k = 2
+
+user testuser
+
+statement ok
+BEGIN
+
+query II
+SELECT * FROM t FOR UPDATE SKIP LOCKED
+----
+1  1
+3  3
+4  4
+
+statement ok
+UPDATE t SET v = 4 WHERE k = 3
+
+query II
+SELECT * FROM t FOR UPDATE SKIP LOCKED
+----
+1  1
+3  4
+4  4
+
+user root
+
+query II
+SELECT * FROM t FOR UPDATE SKIP LOCKED
+----
+2  3
+
+statement ok
+ROLLBACK
+
+user testuser
+
+statement ok
+ROLLBACK
+
+user root

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
@@ -2255,3 +2255,275 @@ vectorized: true
       spans: /1/0
       locking strength: for update
       locking wait policy: nowait
+
+# ------------------------------------------------------------------------------
+# Tests with the SKIP LOCKED lock wait policy.
+# ------------------------------------------------------------------------------
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1,000 (missing stats)
+  table: t@t_pkey
+  spans: FULL SCAN
+  locking strength: for update
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t FOR NO KEY UPDATE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1,000 (missing stats)
+  table: t@t_pkey
+  spans: FULL SCAN
+  locking strength: for no key update
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t FOR SHARE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1,000 (missing stats)
+  table: t@t_pkey
+  spans: FULL SCAN
+  locking strength: for share
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1,000 (missing stats)
+  table: t@t_pkey
+  spans: FULL SCAN
+  locking strength: for key share
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1,000 (missing stats)
+  table: t@t_pkey
+  spans: FULL SCAN
+  locking strength: for share
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED FOR NO KEY UPDATE
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1,000 (missing stats)
+  table: t@t_pkey
+  spans: FULL SCAN
+  locking strength: for no key update
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED FOR NO KEY UPDATE FOR UPDATE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1,000 (missing stats)
+  table: t@t_pkey
+  spans: FULL SCAN
+  locking strength: for update
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE OF t SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1,000 (missing stats)
+  table: t@t_pkey
+  spans: FULL SCAN
+  locking strength: for update
+  locking wait policy: skip locked
+
+query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
+EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE OF t2 SKIP LOCKED
+
+query T
+EXPLAIN (VERBOSE) SELECT 1 FROM t FOR UPDATE OF t SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• render
+│ columns: ("?column?")
+│ estimated row count: 1,000 (missing stats)
+│ render ?column?: 1
+│
+└── • scan
+      columns: ()
+      estimated row count: 1,000 (missing stats)
+      table: t@t_pkey
+      spans: FULL SCAN
+      locking strength: for update
+      locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@t_pkey
+  spans: /1/0
+  locking strength: for update
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR NO KEY UPDATE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@t_pkey
+  spans: /1/0
+  locking strength: for no key update
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR SHARE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@t_pkey
+  spans: /1/0
+  locking strength: for share
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@t_pkey
+  spans: /1/0
+  locking strength: for key share
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@t_pkey
+  spans: /1/0
+  locking strength: for share
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@t_pkey
+  spans: /1/0
+  locking strength: for no key update
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@t_pkey
+  spans: /1/0
+  locking strength: for update
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE OF t SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@t_pkey
+  spans: /1/0
+  locking strength: for update
+  locking wait policy: skip locked
+
+query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE OF t2 SKIP LOCKED
+
+query T
+EXPLAIN (VERBOSE) SELECT 1 FROM t WHERE a = 1 FOR UPDATE OF t SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• render
+│ columns: ("?column?")
+│ estimated row count: 1 (missing stats)
+│ render ?column?: 1
+│
+└── • scan
+      columns: (a)
+      estimated row count: 1 (missing stats)
+      table: t@t_pkey
+      spans: /1/0
+      locking strength: for update
+      locking wait policy: skip locked

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -1307,8 +1307,7 @@ func (b *Builder) validateLockingInFrom(
 		case tree.LockWaitBlock:
 			// Default. Block on conflicting locks.
 		case tree.LockWaitSkipLocked:
-			panic(unimplementedWithIssueDetailf(40476, "",
-				"SKIP LOCKED lock wait policy is not supported"))
+			// Skip rows that can't be locked.
 		case tree.LockWaitError:
 			// Raise an error on conflicting locks.
 		default:

--- a/pkg/sql/opt/optbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/optbuilder/testdata/select_for_update
@@ -1305,3 +1305,95 @@ project
  │    └── locking: for-update,nowait
  └── projections
       └── 1 [as="?column?":5]
+
+# ------------------------------------------------------------------------------
+# Tests with the SKIP LOCKED lock wait policy.
+# ------------------------------------------------------------------------------
+
+build
+SELECT * FROM t FOR UPDATE SKIP LOCKED
+----
+project
+ ├── columns: a:1!null b:2
+ └── scan t
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      └── locking: for-update,skip-locked
+
+build
+SELECT * FROM t FOR NO KEY UPDATE SKIP LOCKED
+----
+project
+ ├── columns: a:1!null b:2
+ └── scan t
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      └── locking: for-no-key-update,skip-locked
+
+build
+SELECT * FROM t FOR SHARE SKIP LOCKED
+----
+project
+ ├── columns: a:1!null b:2
+ └── scan t
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      └── locking: for-share,skip-locked
+
+build
+SELECT * FROM t FOR KEY SHARE SKIP LOCKED
+----
+project
+ ├── columns: a:1!null b:2
+ └── scan t
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      └── locking: for-key-share,skip-locked
+
+build
+SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED
+----
+project
+ ├── columns: a:1!null b:2
+ └── scan t
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      └── locking: for-share,skip-locked
+
+build
+SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED FOR NO KEY UPDATE
+----
+project
+ ├── columns: a:1!null b:2
+ └── scan t
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      └── locking: for-no-key-update,skip-locked
+
+build
+SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED FOR NO KEY UPDATE FOR UPDATE SKIP LOCKED
+----
+project
+ ├── columns: a:1!null b:2
+ └── scan t
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      └── locking: for-update,skip-locked
+
+build
+SELECT * FROM t FOR UPDATE OF t SKIP LOCKED
+----
+project
+ ├── columns: a:1!null b:2
+ └── scan t
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      └── locking: for-update,skip-locked
+
+build
+SELECT * FROM t FOR UPDATE OF t2 SKIP LOCKED
+----
+error (42P01): relation "t2" in FOR UPDATE clause not found in FROM clause
+
+build
+SELECT 1 FROM t FOR UPDATE OF t SKIP LOCKED
+----
+project
+ ├── columns: "?column?":5!null
+ ├── scan t
+ │    ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+ │    └── locking: for-update,skip-locked
+ └── projections
+      └── 1 [as="?column?":5]

--- a/pkg/sql/row/locking.go
+++ b/pkg/sql/row/locking.go
@@ -52,8 +52,7 @@ func getWaitPolicy(lockWaitPolicy descpb.ScanLockingWaitPolicy) lock.WaitPolicy 
 		return lock.WaitPolicy_Block
 
 	case descpb.ScanLockingWaitPolicy_SKIP_LOCKED:
-		// Should not get here. Query should be rejected during planning.
-		panic(errors.AssertionFailedf("unsupported wait policy %s", lockWaitPolicy))
+		return lock.WaitPolicy_SkipLocked
 
 	case descpb.ScanLockingWaitPolicy_ERROR:
 		return lock.WaitPolicy_Error


### PR DESCRIPTION
**NOTE: this includes a draft of the final commit from https://github.com/cockroachdb/cockroach/pull/79134, which hooks KV support up for SKIP LOCKED to the corresponding SQL. Pulling that commit out allows us to land the KV portion of the PR.**

----

Fixes #40476.
Assists #62734.
Assists #72407.
Assists #78564.

```sql
CREATE TABLE kv (k INT PRIMARY KEY, v INT)
INSERT INTO kv VALUES (1, 1), (2, 2), (3, 3)


-- in session 1
BEGIN; UPDATE kv SET v = 0 WHERE k = 1 RETURNING *

  k | v
----+----
  1 | 0


-- in session 2
BEGIN; SELECT * FROM kv ORDER BY k LIMIT 1 FOR UPDATE SKIP LOCKED

  k | v
----+----
  2 | 2


-- in session 3
BEGIN; SELECT * FROM kv FOR UPDATE SKIP LOCKED

  k | v
----+----
  3 | 3
```

These semantics closely match those of FOR {UPDATE,SHARE} SKIP LOCKED in PostgreSQL. With SKIP LOCKED, any selected rows that cannot be immediately locked are skipped. Skipping locked rows provides an inconsistent view of the data, so this is not suitable for general purpose work, but can be used to avoid lock contention with multiple consumers accessing a queue-like table.

[Here](https://www.pgcasts.com/episodes/the-skip-locked-feature-in-postgres-9-5) is a short video that explains why users might want to use SKIP LOCKED in Postgres. The same motivation applies to CockroachDB. However, SKIP LOCKED is not a complete solution to queues, as MVCC garbage will still become a major problem with sufficiently high consumer throughput. Even with a very low gc.ttl, CockroachDB does not garbage collect MVCC garbage fast enough to avoid slowing down consumers that scan from the head of a queue over MVCC tombstones of previously consumed queue entries.

----

### Implementation

Skip locked has a number of touchpoints in Storage and KV. To understand these, we first need to understand the isolation model of skip-locked. When a request is using a SkipLocked wait policy, it behaves as if run at a weaker isolation level for any keys that it skips over. If the read request does not return a key, it does not make a claim about whether that key does or does not exist or what the key's value was at the read's MVCC timestamp. Instead, it only makes a claim about the set of keys that are returned. For those keys which were not skipped and were returned (and often locked, if combined with a locking strength, though this is not required), serializable isolation is enforced.

When the `pebbleMVCCScanner` is configured with the skipLocked option, it does not include locked keys in the result set. To support this, the MVCC layer needs to be provided access to the in-memory lock table, so that it can determine whether keys are locked with unreplicated lock. Replicated locks are represented as intents, which will be skipped over in getAndAdvance.

Requests using the SkipLocked wait policy acquire the same latches as before and wait on all latches ahead of them in line. However, if a request is using a SkipLocked wait policy, we always perform optimistic evaluation. In Replica.collectSpansRead, SkipLocked reads are able to constrain their read spans down to point reads on just those keys that were returned and were not already locked. This means that there is a good chance that some or all of the write latches that the SkipLocked read would have blocked on won't overlap with the keys that the request ends up returning, so they won't conflict when checking for optimistic conflicts.

Skip locked requests do not scan the lock table when initially sequencing. Instead, they capture a snapshot of the in-memory lock table while sequencing and scan the lock table as they perform their MVCC scan using the btree snapshot stored in the concurrency guard. MVCC was taught about skip locked in the previous commit.

Skip locked requests add point reads for each of the keys returned to the timestamp cache, instead of adding a single ranged read. This satisfies the weaker isolation level of skip locked. Because the issuing transaction is not intending to enforce serializable isolation across keys that were skipped by its request, it does not need to prevent writes below its read timestamp to keys that were skipped.

Similarly, Skip locked requests only records refresh spans for the individual keys returned, instead of recording a refresh span across the entire read span. Because the issuing transaction is not intending to enforce serializable isolation across keys that were skipped by its request, it does not need to validate that they have not changed if the transaction ever needs to refresh.

----

### Benchmarking

I haven't done any serious benchmarking with this SKIP LOCKED yet, though I'd like to. At some point, I would like to build a simple queue-like workload into the `workload` tool and experiment with various consumer access patterns (non-locking reads, locking reads, skip-locked reads), indexing schemes, concurrency levels (for producers and consumers), and batch sizes.

----

Release note (sql change): SELECT ... FOR {UPDATE,SHARE} SKIP LOCKED is now supported. The option can be used to skip rows that cannot be immediately locked instead of blocking on contended row-level lock acquisition.