### PR TITLE
util/mon: pass reserved account by reference

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -615,7 +615,7 @@ func TempStorageConfigFromEnv(
 		maxSizeBytes/10, /* noteworthy */
 		st,
 	)
-	monitor.Start(ctx, nil /* pool */, mon.MakeStandaloneBudget(maxSizeBytes))
+	monitor.Start(ctx, nil /* pool */, mon.NewStandaloneBudget(maxSizeBytes))
 	return TempStorageConfig{
 		InMemory: inMem,
 		Mon:      monitor,

--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -219,7 +219,7 @@ func DefaultTestTempStorageConfigWithSize(
 		maxSizeBytes/10, /* noteworthy */
 		st,
 	)
-	monitor.Start(context.Background(), nil /* pool */, mon.MakeStandaloneBudget(maxSizeBytes))
+	monitor.Start(context.Background(), nil /* pool */, mon.NewStandaloneBudget(maxSizeBytes))
 	return TempStorageConfig{
 		InMemory: true,
 		Mon:      monitor,

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -8027,7 +8027,7 @@ func TestReadBackupManifestMemoryMonitoring(t *testing.T) {
 	require.NoError(t, err)
 
 	m := mon.NewMonitor("test-monitor", mon.MemoryResource, nil, nil, 0, 0, st)
-	m.Start(ctx, nil, mon.MakeStandaloneBudget(128<<20))
+	m.Start(ctx, nil, mon.NewStandaloneBudget(128<<20))
 	mem := m.MakeBoundAccount()
 	encOpts := &jobspb.BackupEncryptionOptions{
 		Mode: jobspb.EncryptionMode_Passphrase,
@@ -9040,7 +9040,7 @@ func TestBackupMemMonitorSSTSinkQueueSize(t *testing.T) {
 	)
 	ctx := context.Background()
 	byteLimit := 14 << 20 // 14 MiB
-	memoryMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(int64(byteLimit)))
+	memoryMonitor.Start(ctx, nil, mon.NewStandaloneBudget(int64(byteLimit)))
 	defer memoryMonitor.Stop(ctx)
 	params := base.TestClusterArgs{}
 	knobs := base.TestingKnobs{

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -251,7 +251,7 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 	}
 	limit := changefeedbase.PerChangefeedMemLimit.Get(&ca.flowCtx.Cfg.Settings.SV)
 	kvFeedMemMon := mon.NewMonitorInheritWithLimit("kvFeed", limit, pool)
-	kvFeedMemMon.Start(ctx, pool, mon.BoundAccount{})
+	kvFeedMemMon.StartNoReserved(ctx, pool)
 	ca.kvFeedMemMon = kvFeedMemMon
 
 	// The job registry has a set of metrics used to monitor the various jobs it

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -6443,7 +6443,7 @@ func startMonitorWithBudget(budget int64) *mon.BytesMonitor {
 		nil, nil,
 		128 /* small allocation increment */, 100,
 		cluster.MakeTestingClusterSettings())
-	mm.Start(context.Background(), nil, mon.MakeStandaloneBudget(budget))
+	mm.Start(context.Background(), nil, mon.NewStandaloneBudget(budget))
 	return mm
 }
 

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
@@ -57,7 +57,7 @@ func getBoundAccountWithBudget(budget int64) (account mon.BoundAccount, cleanup 
 		nil, nil,
 		128 /* small allocation increment */, 100,
 		cluster.MakeTestingClusterSettings())
-	mm.Start(context.Background(), nil, mon.MakeStandaloneBudget(budget))
+	mm.Start(context.Background(), nil, mon.NewStandaloneBudget(budget))
 	return mm.MakeBoundAccount(), func() { mm.Stop(context.Background()) }
 }
 

--- a/pkg/kv/bulk/kv_buf_test.go
+++ b/pkg/kv/bulk/kv_buf_test.go
@@ -56,7 +56,9 @@ func TestKvBuf(t *testing.T) {
 	src, totalSize := makeTestData(50000)
 
 	ctx := context.Background()
-	none := mon.NewMonitorWithLimit("none", mon.MemoryResource, 0, nil, nil, 0, 0, nil).MakeBoundAccount()
+	noneMonitor := mon.NewMonitorWithLimit("none", mon.MemoryResource, 0, nil, nil, 0, 0, nil)
+	noneMonitor.StartNoReserved(ctx, nil /* pool */)
+	none := noneMonitor.MakeBoundAccount()
 	lots := mon.NewUnlimitedMonitor(ctx, "lots", mon.MemoryResource, nil, nil, 0, nil).MakeBoundAccount()
 
 	// Write everything to our buf.

--- a/pkg/kv/kvclient/kvstreamer/results_buffer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/results_buffer_test.go
@@ -55,7 +55,7 @@ func TestInOrderResultsBuffer(t *testing.T) {
 		math.MaxInt64, /* noteworthy */
 		st,
 	)
-	diskMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+	diskMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 	defer diskMonitor.Stop(ctx)
 
 	budget := newBudget(nil /* acc */, math.MaxInt /* limitBytes */)

--- a/pkg/kv/kvclient/kvstreamer/streamer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_test.go
@@ -166,7 +166,7 @@ func TestStreamerBudgetErrorInEnqueue(t *testing.T) {
 		math.MaxInt64, /* noteworthy */
 		cluster.MakeTestingClusterSettings(),
 	)
-	rootMemMonitor.Start(ctx, nil /* pool */, mon.MakeStandaloneBudget(rootPoolSize))
+	rootMemMonitor.Start(ctx, nil /* pool */, mon.NewStandaloneBudget(rootPoolSize))
 	defer rootMemMonitor.Stop(ctx)
 
 	acc := rootMemMonitor.MakeBoundAccount()

--- a/pkg/kv/kvclient/rangefeed/db_adapter_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/db_adapter_external_test.go
@@ -39,7 +39,7 @@ func startMonitorWithBudget(budget int64) *mon.BytesMonitor {
 		nil, nil,
 		128 /* small allocation increment */, 100,
 		cluster.MakeTestingClusterSettings())
-	mm.Start(context.Background(), nil, mon.MakeStandaloneBudget(budget))
+	mm.Start(context.Background(), nil, mon.NewStandaloneBudget(budget))
 	return mm
 }
 

--- a/pkg/kv/kvserver/rangefeed/budget.go
+++ b/pkg/kv/kvserver/rangefeed/budget.go
@@ -328,14 +328,14 @@ func NewBudgetFactory(ctx context.Context, config BudgetFactoryConfig) *BudgetFa
 		systemRangeFeedBudget, config.rootMon)
 	systemRangeMonitor.SetMetrics(metrics.SystemBytesCount, nil /* maxHist */)
 	systemRangeMonitor.Start(ctx, config.rootMon,
-		mon.MakeStandaloneBudget(systemRangeFeedBudget))
+		mon.NewStandaloneBudget(systemRangeFeedBudget))
 
 	rangeFeedPoolMonitor := mon.NewMonitorInheritWithLimit(
 		"rangefeed-monitor",
 		config.totalRangeReedBudget,
 		config.rootMon)
 	rangeFeedPoolMonitor.SetMetrics(metrics.SharedBytesCount, nil /* maxHist */)
-	rangeFeedPoolMonitor.Start(ctx, config.rootMon, mon.BoundAccount{})
+	rangeFeedPoolMonitor.StartNoReserved(ctx, config.rootMon)
 
 	return &BudgetFactory{
 		limit:              config.provisionalFeedLimit,

--- a/pkg/kv/kvserver/rangefeed/budget_test.go
+++ b/pkg/kv/kvserver/rangefeed/budget_test.go
@@ -28,7 +28,7 @@ func TestFeedBudget(t *testing.T) {
 		*FeedBudget, *mon.BytesMonitor, *mon.BoundAccount,
 	) {
 		m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
-		m.Start(context.Background(), nil, mon.MakeStandaloneBudget(poolSize))
+		m.Start(context.Background(), nil, mon.NewStandaloneBudget(poolSize))
 		b := m.MakeBoundAccount()
 
 		s := cluster.MakeTestingClusterSettings()
@@ -190,7 +190,7 @@ func TestBudgetFactory(t *testing.T) {
 	s := cluster.MakeTestingClusterSettings()
 
 	rootMon := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, s)
-	rootMon.Start(context.Background(), nil, mon.MakeStandaloneBudget(10000000))
+	rootMon.Start(context.Background(), nil, mon.NewStandaloneBudget(10000000))
 	bf := NewBudgetFactory(context.Background(),
 		CreateBudgetFactoryConfig(rootMon, 10000, time.Second*5, budgetLowThresholdFn(10000), &s.SV))
 
@@ -214,7 +214,7 @@ func TestDisableBudget(t *testing.T) {
 	s := cluster.MakeTestingClusterSettings()
 
 	rootMon := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, s)
-	rootMon.Start(context.Background(), nil, mon.MakeStandaloneBudget(10000000))
+	rootMon.Start(context.Background(), nil, mon.NewStandaloneBudget(10000000))
 	bf := NewBudgetFactory(context.Background(),
 		CreateBudgetFactoryConfig(rootMon, 10000, time.Second*5, func(_ int64) int64 {
 			return 0
@@ -228,7 +228,7 @@ func TestDisableBudgetOnTheFly(t *testing.T) {
 	s := cluster.MakeTestingClusterSettings()
 
 	m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
-	m.Start(context.Background(), nil, mon.MakeStandaloneBudget(100000))
+	m.Start(context.Background(), nil, mon.NewStandaloneBudget(100000))
 	bf := NewBudgetFactory(context.Background(),
 		CreateBudgetFactoryConfig(
 			m,
@@ -265,7 +265,7 @@ func TestDisableBudgetOnTheFly(t *testing.T) {
 func TestConfigFactory(t *testing.T) {
 	s := cluster.MakeTestingClusterSettings()
 	rootMon := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
-	rootMon.Start(context.Background(), nil, mon.MakeStandaloneBudget(10000000))
+	rootMon.Start(context.Background(), nil, mon.NewStandaloneBudget(10000000))
 
 	// Check provisionalFeedLimit is computed.
 	config := CreateBudgetFactoryConfig(rootMon, 100000, time.Second*5, budgetLowThresholdFn(10000),
@@ -285,7 +285,7 @@ func TestConfigFactory(t *testing.T) {
 func TestBudgetLimits(t *testing.T) {
 	s := cluster.MakeTestingClusterSettings()
 	rootMon := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
-	rootMon.Start(context.Background(), nil, mon.MakeStandaloneBudget(10000000))
+	rootMon.Start(context.Background(), nil, mon.NewStandaloneBudget(10000000))
 
 	provisionalSize := int64(10000)
 	adjustedSize := int64(1000)

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -1080,7 +1080,7 @@ func TestBudgetReleaseOnProcessorStop(t *testing.T) {
 
 	s := cluster.MakeTestingClusterSettings()
 	m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
-	m.Start(context.Background(), nil, mon.MakeStandaloneBudget(math.MaxInt64))
+	m.Start(context.Background(), nil, mon.NewStandaloneBudget(math.MaxInt64))
 	//budgetEnabled := int32(1)
 	b := m.MakeBoundAccount()
 	fb := NewFeedBudget(&b, 0, &s.SV)
@@ -1228,7 +1228,7 @@ func TestBudgetReleaseOnLastStreamError(t *testing.T) {
 func newTestBudget(limit int64) *FeedBudget {
 	s := cluster.MakeTestingClusterSettings()
 	m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
-	m.Start(context.Background(), nil, mon.MakeStandaloneBudget(limit))
+	m.Start(context.Background(), nil, mon.NewStandaloneBudget(limit))
 	b := m.MakeBoundAccount()
 	fb := NewFeedBudget(&b, 0, &s.SV)
 	return fb

--- a/pkg/kv/kvserver/ts_maintenance_queue_test.go
+++ b/pkg/kv/kvserver/ts_maintenance_queue_test.go
@@ -292,7 +292,7 @@ func TestTimeSeriesMaintenanceQueueServer(t *testing.T) {
 		math.MaxInt64, /* noteworthy */
 		cluster.MakeTestingClusterSettings(),
 	)
-	memMon.Start(context.Background(), nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
+	memMon.Start(context.Background(), nil /* pool */, mon.NewStandaloneBudget(math.MaxInt64))
 	defer memMon.Stop(context.Background())
 	memContext := ts.MakeQueryMemoryContext(
 		memMon,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -503,7 +503,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	})
 	kvMemoryMonitor := mon.NewMonitorInheritWithLimit(
 		"kv-mem", 0 /* limit */, sqlMonitorAndMetrics.rootSQLMemoryMonitor)
-	kvMemoryMonitor.Start(ctx, sqlMonitorAndMetrics.rootSQLMemoryMonitor, mon.BoundAccount{})
+	kvMemoryMonitor.StartNoReserved(ctx, sqlMonitorAndMetrics.rootSQLMemoryMonitor)
 	rangeReedBudgetFactory := serverrangefeed.NewBudgetFactory(
 		ctx,
 		serverrangefeed.CreateBudgetFactoryConfig(

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -368,7 +368,7 @@ func newRootSQLMemoryMonitor(opts monitorAndMetricsOptions) monitorAndMetrics {
 	// serves as a parent for a memory monitor that accounts for memory used in
 	// the KV layer at the same node.
 	rootSQLMemoryMonitor.Start(
-		context.Background(), nil, mon.MakeStandaloneBudget(opts.memoryPoolSize))
+		context.Background(), nil, mon.NewStandaloneBudget(opts.memoryPoolSize))
 	return monitorAndMetrics{
 		rootSQLMemoryMonitor: rootSQLMemoryMonitor,
 		rootSQLMetrics:       rootSQLMetrics,
@@ -496,7 +496,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	bulkMetrics := bulk.MakeBulkMetrics(cfg.HistogramWindowInterval())
 	cfg.registry.AddMetricStruct(bulkMetrics)
 	bulkMemoryMonitor.SetMetrics(bulkMetrics.CurBytesCount, bulkMetrics.MaxBytesHist)
-	bulkMemoryMonitor.Start(context.Background(), rootSQLMemoryMonitor, mon.BoundAccount{})
+	bulkMemoryMonitor.StartNoReserved(context.Background(), rootSQLMemoryMonitor)
 
 	backfillMemoryMonitor := execinfra.NewMonitor(ctx, bulkMemoryMonitor, "backfill-mon")
 	backupMemoryMonitor := execinfra.NewMonitor(ctx, bulkMemoryMonitor, "backup-mon")
@@ -504,7 +504,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	serverCacheMemoryMonitor := mon.NewMonitorInheritWithLimit(
 		"server-cache-mon", 0 /* limit */, rootSQLMemoryMonitor,
 	)
-	serverCacheMemoryMonitor.Start(context.Background(), rootSQLMemoryMonitor, mon.BoundAccount{})
+	serverCacheMemoryMonitor.StartNoReserved(context.Background(), rootSQLMemoryMonitor)
 
 	// Set up the DistSQL temp engine.
 

--- a/pkg/sql/catalog/descs/collection_test.go
+++ b/pkg/sql/catalog/descs/collection_test.go
@@ -632,7 +632,7 @@ func TestKVDescriptorsProperlyUsesMemoryMonitoring(t *testing.T) {
 		nil, nil, -1, 0, cluster.MakeTestingClusterSettings())
 
 	// Start the monitor with unlimited budget.
-	monitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+	monitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 
 	// Create a `Collection` with monitor hooked up.
 	col := tc.Server(0).ExecutorConfig().(sql.ExecutorConfig).CollectionFactory.
@@ -650,7 +650,7 @@ func TestKVDescriptorsProperlyUsesMemoryMonitoring(t *testing.T) {
 
 	// Restart the monitor to a smaller budget (in fact, let's be bold by setting it to be only one byte below
 	// what has been allocated in the previous round).
-	monitor.Start(ctx, nil, mon.MakeStandaloneBudget(allocatedMemoryInBytes-1))
+	monitor.Start(ctx, nil, mon.NewStandaloneBudget(allocatedMemoryInBytes-1))
 	require.Equal(t, int64(0), monitor.AllocBytes())
 
 	// Repeat the process again and assert this time memory allocation will err out.

--- a/pkg/sql/closed_session_cache.go
+++ b/pkg/sql/closed_session_cache.go
@@ -81,7 +81,7 @@ func NewClosedSessionCache(
 
 	c.mu.acc = monitor.MakeBoundAccount()
 	c.mon = monitor
-	c.mon.Start(context.Background(), parentMon, mon.BoundAccount{})
+	c.mon.StartNoReserved(context.Background(), parentMon)
 	return c
 }
 

--- a/pkg/sql/colexec/colexecargs/monitor_registry.go
+++ b/pkg/sql/colexec/colexecargs/monitor_registry.go
@@ -89,7 +89,7 @@ func (r *MonitorRegistry) CreateMemAccountForSpillStrategyWithLimit(
 	}
 	monitorName := r.getMemMonitorName(opName, processorID, "limited" /* suffix */)
 	bufferingOpMemMonitor := mon.NewMonitorInheritWithLimit(monitorName, limit, flowCtx.EvalCtx.Mon)
-	bufferingOpMemMonitor.Start(ctx, flowCtx.EvalCtx.Mon, mon.BoundAccount{})
+	bufferingOpMemMonitor.StartNoReserved(ctx, flowCtx.EvalCtx.Mon)
 	r.monitors = append(r.monitors, bufferingOpMemMonitor)
 	bufferingMemAccount := bufferingOpMemMonitor.MakeBoundAccount()
 	r.accounts = append(r.accounts, &bufferingMemAccount)

--- a/pkg/sql/colflow/draining_test.go
+++ b/pkg/sql/colflow/draining_test.go
@@ -47,7 +47,7 @@ func TestDrainingAfterRemoteError(t *testing.T) {
 		math.MaxInt64,
 		cluster.MakeTestingClusterSettings(),
 	)
-	diskMonitor.Start(ctx, nil /* pool */, mon.MakeStandaloneBudget(1))
+	diskMonitor.Start(ctx, nil /* pool */, mon.NewStandaloneBudget(1))
 
 	// Set up a two node cluster.
 	tempStorageConfig := base.TempStorageConfig{InMemory: true, Mon: diskMonitor}

--- a/pkg/sql/colflow/explain_vec.go
+++ b/pkg/sql/colflow/explain_vec.go
@@ -74,7 +74,7 @@ func convertToVecTree(
 		math.MaxInt64, /* noteworthy */
 		flowCtx.Cfg.Settings,
 	)
-	memoryMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+	memoryMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 	defer memoryMonitor.Stop(ctx)
 	defer creator.cleanup(ctx)
 	opChains, _, err = creator.setupFlow(ctx, flowCtx, flow.Processors, localProcessors, fuseOpt)

--- a/pkg/sql/colflow/vectorized_flow_space_test.go
+++ b/pkg/sql/colflow/vectorized_flow_space_test.go
@@ -79,9 +79,9 @@ func TestVectorizeInternalMemorySpaceError(t *testing.T) {
 				}
 				memMon := mon.NewMonitor("MemoryMonitor", mon.MemoryResource, nil, nil, 0, math.MaxInt64, st)
 				if success {
-					memMon.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+					memMon.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 				} else {
-					memMon.Start(ctx, nil, mon.MakeStandaloneBudget(1))
+					memMon.Start(ctx, nil, mon.NewStandaloneBudget(1))
 				}
 				defer memMon.Stop(ctx)
 				acc := memMon.MakeBoundAccount()
@@ -204,7 +204,7 @@ func TestVectorizeAllocatorSpaceError(t *testing.T) {
 				memMon := mon.NewMonitor("MemoryMonitor", mon.MemoryResource, nil, nil, 0, math.MaxInt64, st)
 				flowCtx.Cfg.TestingKnobs = execinfra.TestingKnobs{}
 				if expectNoMemoryError {
-					memMon.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+					memMon.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 					if !success {
 						// These are the cases that we expect in-memory operators to hit a
 						// memory error. To enable testing this case, force disk spills. We
@@ -213,7 +213,7 @@ func TestVectorizeAllocatorSpaceError(t *testing.T) {
 						flowCtx.Cfg.TestingKnobs.ForceDiskSpill = true
 					}
 				} else {
-					memMon.Start(ctx, nil, mon.MakeStandaloneBudget(1))
+					memMon.Start(ctx, nil, mon.NewStandaloneBudget(1))
 					flowCtx.Cfg.TestingKnobs.ForceDiskSpill = true
 				}
 				defer memMon.Stop(ctx)

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -358,7 +358,7 @@ func startConnExecutor(
 	// routine, we're going to push commands into the StmtBuf and, from time to
 	// time, collect and check their results.
 	go func() {
-		finished <- s.ServeConn(ctx, conn, mon.BoundAccount{}, nil /* cancel */)
+		finished <- s.ServeConn(ctx, conn, &mon.BoundAccount{}, nil /* cancel */)
 	}()
 	return buf, syncResults, finished, stopper, resultChannel, nil
 }
@@ -402,7 +402,7 @@ CREATE TEMPORARY TABLE foo();
 
 	done := make(chan error)
 	go func() {
-		done <- srv.ServeConn(ctx, connHandler, mon.BoundAccount{}, nil /* cancel */)
+		done <- srv.ServeConn(ctx, connHandler, &mon.BoundAccount{}, nil /* cancel */)
 	}()
 	results := <-flushed
 	require.Len(t, results, 6) // We expect results for 5 statements + sync.

--- a/pkg/sql/delete_preserving_index_test.go
+++ b/pkg/sql/delete_preserving_index_test.go
@@ -741,7 +741,7 @@ func fetchIndex(
 	var fetcher row.Fetcher
 	var alloc tree.DatumAlloc
 
-	mm := mon.MakeStandaloneBudget(1 << 30)
+	mm := mon.NewStandaloneBudget(1 << 30)
 	idx, err := table.FindIndexWithName(indexName)
 	require.NoError(t, err)
 	colIdxMap := catalog.ColumnIDToOrdinalMap(table.PublicColumns())

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -89,7 +89,7 @@ func NewServer(
 			cfg.Settings,
 		),
 	}
-	ds.memMonitor.Start(ctx, cfg.ParentMemoryMonitor, mon.BoundAccount{})
+	ds.memMonitor.StartNoReserved(ctx, cfg.ParentMemoryMonitor)
 	// We have to initialize the flow scheduler at the same time we're creating
 	// the DistSQLServer because the latter will be registered as a gRPC service
 	// right away, so the RPCs might start coming in pretty much right after the
@@ -277,7 +277,7 @@ func (ds *ServerImpl) setupFlow(
 		noteworthyMemoryUsageBytes,
 		ds.Settings,
 	)
-	monitor.Start(ctx, parentMonitor, mon.BoundAccount{})
+	monitor.StartNoReserved(ctx, parentMonitor)
 
 	makeLeaf := func() (*kv.Txn, error) {
 		tis := req.LeafTxnInputState

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1269,7 +1269,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 		noteworthyMemoryUsageBytes,
 		dsp.distSQLSrv.Settings,
 	)
-	subqueryMonitor.Start(ctx, evalCtx.Mon, mon.BoundAccount{})
+	subqueryMonitor.StartNoReserved(ctx, evalCtx.Mon)
 	defer subqueryMonitor.Stop(ctx)
 
 	subqueryMemAccount := subqueryMonitor.MakeBoundAccount()
@@ -1622,7 +1622,7 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 		noteworthyMemoryUsageBytes,
 		dsp.distSQLSrv.Settings,
 	)
-	postqueryMonitor.Start(ctx, evalCtx.Mon, mon.BoundAccount{})
+	postqueryMonitor.StartNoReserved(ctx, evalCtx.Mon)
 	defer postqueryMonitor.Stop(ctx)
 
 	postqueryMemAccount := postqueryMonitor.MakeBoundAccount()

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -947,7 +947,7 @@ func NewMonitor(
 	ctx context.Context, parent *mon.BytesMonitor, name redact.RedactableString,
 ) *mon.BytesMonitor {
 	monitor := mon.NewMonitorInheritWithLimit(name, 0 /* limit */, parent)
-	monitor.Start(ctx, parent, mon.BoundAccount{})
+	monitor.StartNoReserved(ctx, parent)
 	return monitor
 }
 
@@ -961,7 +961,7 @@ func NewLimitedMonitor(
 	ctx context.Context, parent *mon.BytesMonitor, flowCtx *FlowCtx, name redact.RedactableString,
 ) *mon.BytesMonitor {
 	limitedMon := mon.NewMonitorInheritWithLimit(name, GetWorkMemLimit(flowCtx), parent)
-	limitedMon.Start(ctx, parent, mon.BoundAccount{})
+	limitedMon.StartNoReserved(ctx, parent)
 	return limitedMon
 }
 

--- a/pkg/sql/execinfra/testutils.go
+++ b/pkg/sql/execinfra/testutils.go
@@ -95,7 +95,7 @@ func NewTestMemMonitor(ctx context.Context, st *cluster.Settings) *mon.BytesMoni
 		math.MaxInt64, /* noteworthy */
 		st,
 	)
-	memMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+	memMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 	return memMonitor
 }
 
@@ -111,7 +111,7 @@ func NewTestDiskMonitor(ctx context.Context, st *cluster.Settings) *mon.BytesMon
 		math.MaxInt64,
 		st,
 	)
-	diskMonitor.Start(ctx, nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
+	diskMonitor.Start(ctx, nil /* pool */, mon.NewStandaloneBudget(math.MaxInt64))
 	return diskMonitor
 }
 

--- a/pkg/sql/indexbackfiller_test.go
+++ b/pkg/sql/indexbackfiller_test.go
@@ -375,7 +375,7 @@ INSERT INTO foo VALUES (1), (10), (100);
 	) []tree.Datums {
 		t.Helper()
 
-		mm := mon.MakeStandaloneBudget(1 << 30)
+		mm := mon.NewStandaloneBudget(1 << 30)
 		idx, err := table.FindIndexWithID(indexID)
 		colIDsNeeded := idx.CollectKeyColumnIDs()
 		if idx.Primary() {

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -108,7 +108,7 @@ func MakeInternalExecutor(
 		math.MaxInt64, /* noteworthy */
 		settings,
 	)
-	monitor.Start(ctx, s.pool, mon.BoundAccount{})
+	monitor.StartNoReserved(ctx, s.pool)
 	return InternalExecutor{
 		s:          s,
 		mon:        monitor,
@@ -203,7 +203,7 @@ func (ie *InternalExecutor) initConnEx(
 
 	wg.Add(1)
 	go func() {
-		if err := ex.run(ctx, ie.mon, mon.BoundAccount{} /*reserved*/, nil /* cancel */); err != nil {
+		if err := ex.run(ctx, ie.mon, &mon.BoundAccount{} /*reserved*/, nil /* cancel */); err != nil {
 			sqltelemetry.RecordError(ctx, err, &ex.server.cfg.Settings.SV)
 			errCallback(err)
 		}

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -155,7 +155,7 @@ func (s *Server) serveConn(
 	ctx context.Context,
 	netConn net.Conn,
 	sArgs sql.SessionArgs,
-	reserved mon.BoundAccount,
+	reserved *mon.BoundAccount,
 	connStart time.Time,
 	authOpt authOptions,
 ) {
@@ -276,7 +276,7 @@ func (c *conn) serveImpl(
 	ctx context.Context,
 	draining func() bool,
 	sqlServer *sql.Server,
-	reserved mon.BoundAccount,
+	reserved *mon.BoundAccount,
 	authOpt authOptions,
 ) {
 	defer func() { _ = c.conn.Close() }()
@@ -632,7 +632,7 @@ func (c *conn) processCommandsAsync(
 	authOpt authOptions,
 	ac AuthConn,
 	sqlServer *sql.Server,
-	reserved mon.BoundAccount,
+	reserved *mon.BoundAccount,
 	cancelConn func(),
 	onDefaultIntSizeChange func(newSize int32),
 ) <-chan error {

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -116,7 +116,7 @@ func TestConn(t *testing.T) {
 			func() bool { return false }, /* draining */
 			// sqlServer - nil means don't create a command processor and a write side of the conn
 			nil,
-			mon.BoundAccount{}, /* reserved */
+			&mon.BoundAccount{}, /* reserved */
 			authOptions{testingSkipAuth: true, connType: hba.ConnHostAny},
 		)
 		return nil
@@ -1082,7 +1082,7 @@ func TestMaliciousInputs(t *testing.T) {
 				ctx,
 				func() bool { return false }, /* draining */
 				nil,                          /* sqlServer */
-				mon.BoundAccount{},           /* reserved */
+				&mon.BoundAccount{},          /* reserved */
 				authOptions{testingSkipAuth: true, connType: hba.ConnHostAny},
 			)
 			if err := <-errChan; err != nil {

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -344,7 +344,7 @@ func MakeServer(
 		nil, /* curCount */
 		nil, /* maxHist */
 		0, noteworthySQLMemoryUsageBytes, st)
-	server.sqlMemoryPool.Start(context.Background(), parentMemoryMonitor, mon.BoundAccount{})
+	server.sqlMemoryPool.StartNoReserved(context.Background(), parentMemoryMonitor)
 	server.SQLServer = sql.NewServer(executorConfig, server.sqlMemoryPool)
 
 	// TODO(knz,ben): Use a cluster setting for this.
@@ -355,7 +355,7 @@ func MakeServer(
 		server.metrics.ConnMemMetrics.CurBytesCount,
 		server.metrics.ConnMemMetrics.MaxBytesHist,
 		int64(connReservationBatchSize)*baseSQLMemoryBudget, noteworthyConnMemoryUsageBytes, st)
-	server.connMonitor.Start(context.Background(), server.sqlMemoryPool, mon.BoundAccount{})
+	server.connMonitor.StartNoReserved(context.Background(), server.sqlMemoryPool)
 
 	server.mu.Lock()
 	server.mu.connCancelMap = make(cancelChanMap)
@@ -872,7 +872,7 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn, socketType Socket
 	// This includes authentication.
 	s.serveConn(
 		ctx, conn, sArgs,
-		reserved,
+		&reserved,
 		connStart,
 		authOptions{
 			connType:        connType,

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -360,7 +360,7 @@ func newInternalPlanner(
 		memMetrics.CurBytesCount, memMetrics.MaxBytesHist,
 		-1, /* increment */
 		noteworthyInternalMemoryUsageBytes, execCfg.Settings)
-	plannerMon.Start(ctx, execCfg.RootMemoryMonitor, mon.BoundAccount{})
+	plannerMon.StartNoReserved(ctx, execCfg.RootMemoryMonitor)
 
 	smi := &sessionDataMutatorIterator{
 		sds: sds,

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -262,7 +262,7 @@ func (rf *Fetcher) Init(ctx context.Context, args FetcherInitArgs) error {
 
 	if args.MemMonitor != nil {
 		rf.mon = mon.NewMonitorInheritWithLimit("fetcher-mem", 0 /* limit */, args.MemMonitor)
-		rf.mon.Start(ctx, args.MemMonitor, mon.BoundAccount{})
+		rf.mon.StartNoReserved(ctx, args.MemMonitor)
 		memAcc := rf.mon.MakeBoundAccount()
 		rf.kvFetcherMemAcc = &memAcc
 	}

--- a/pkg/sql/row/fetcher_test.go
+++ b/pkg/sql/row/fetcher_test.go
@@ -342,7 +342,7 @@ func TestRowFetcherMemoryLimits(t *testing.T) {
 	// we can test whether scans of wide tables are prevented if
 	// we have insufficient memory to do them.
 	memMon := mon.NewMonitor("test", mon.MemoryResource, nil, nil, -1, 1000, settings)
-	memMon.Start(ctx, nil, mon.MakeStandaloneBudget(1<<20))
+	memMon.Start(ctx, nil, mon.NewStandaloneBudget(1<<20))
 	defer memMon.Stop(ctx)
 	txn := kv.NewTxn(ctx, kvDB, 0)
 	rf := initFetcher(t, txn, args, false /*reverseScan*/, alloc, memMon)

--- a/pkg/sql/rowcontainer/disk_row_container_test.go
+++ b/pkg/sql/rowcontainer/disk_row_container_test.go
@@ -117,7 +117,7 @@ func TestDiskRowContainer(t *testing.T) {
 		math.MaxInt64,
 		st,
 	)
-	diskMonitor.Start(ctx, nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
+	diskMonitor.Start(ctx, nil /* pool */, mon.NewStandaloneBudget(math.MaxInt64))
 	defer diskMonitor.Stop(ctx)
 	t.Run("EncodeDecode", func(t *testing.T) {
 		for i := 0; i < 100; i++ {
@@ -387,7 +387,7 @@ func TestDiskRowContainerDiskFull(t *testing.T) {
 		math.MaxInt64,
 		st,
 	)
-	monitor.Start(ctx, nil, mon.MakeStandaloneBudget(0 /* capacity */))
+	monitor.Start(ctx, nil, mon.NewStandaloneBudget(0 /* capacity */))
 
 	d := MakeDiskRowContainer(
 		monitor,
@@ -426,7 +426,7 @@ func TestDiskRowContainerFinalIterator(t *testing.T) {
 		math.MaxInt64,
 		st,
 	)
-	diskMonitor.Start(ctx, nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
+	diskMonitor.Start(ctx, nil /* pool */, mon.NewStandaloneBudget(math.MaxInt64))
 	defer diskMonitor.Stop(ctx)
 
 	d := MakeDiskRowContainer(diskMonitor, types.OneIntCol, nil /* ordering */, tempEngine)
@@ -554,7 +554,7 @@ func TestDiskRowContainerUnsafeReset(t *testing.T) {
 		math.MaxInt64,
 		st,
 	)
-	monitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+	monitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 
 	d := MakeDiskRowContainer(monitor, types.OneIntCol, nil /* ordering */, tempEngine)
 	defer d.Close(ctx)

--- a/pkg/sql/rowcontainer/hash_row_container_test.go
+++ b/pkg/sql/rowcontainer/hash_row_container_test.go
@@ -89,9 +89,9 @@ func TestHashDiskBackedRowContainer(t *testing.T) {
 	// disk halfway through, keeps on adding rows, and then verifies that all
 	// rows were properly added to the hashDiskBackedRowContainer.
 	t.Run("NormalRun", func(t *testing.T) {
-		memoryMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+		memoryMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 		defer memoryMonitor.Stop(ctx)
-		diskMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+		diskMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 		defer diskMonitor.Stop(ctx)
 		rc := getRowContainer()
 		defer rc.Close(ctx)
@@ -134,9 +134,9 @@ func TestHashDiskBackedRowContainer(t *testing.T) {
 	})
 
 	t.Run("AddRowOutOfMem", func(t *testing.T) {
-		memoryMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(1))
+		memoryMonitor.Start(ctx, nil, mon.NewStandaloneBudget(1))
 		defer memoryMonitor.Stop(ctx)
-		diskMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+		diskMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 		defer diskMonitor.Stop(ctx)
 		rc := getRowContainer()
 		defer rc.Close(ctx)
@@ -156,9 +156,9 @@ func TestHashDiskBackedRowContainer(t *testing.T) {
 	})
 
 	t.Run("AddRowOutOfDisk", func(t *testing.T) {
-		memoryMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(1))
+		memoryMonitor.Start(ctx, nil, mon.NewStandaloneBudget(1))
 		defer memoryMonitor.Stop(ctx)
-		diskMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(1))
+		diskMonitor.Start(ctx, nil, mon.NewStandaloneBudget(1))
 		rc := getRowContainer()
 		defer rc.Close(ctx)
 
@@ -184,9 +184,9 @@ func TestHashDiskBackedRowContainer(t *testing.T) {
 	// container to disk, and verifies that the iterator was recreated and points
 	// to the appropriate row.
 	t.Run("VerifyIteratorRecreation", func(t *testing.T) {
-		memoryMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+		memoryMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 		defer memoryMonitor.Stop(ctx)
-		diskMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+		diskMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 		defer diskMonitor.Stop(ctx)
 		rc := getRowContainer()
 		defer rc.Close(ctx)
@@ -259,9 +259,9 @@ func TestHashDiskBackedRowContainer(t *testing.T) {
 	// spills the container to disk, and verifies that the iterator was recreated
 	// and is not valid.
 	t.Run("VerifyIteratorRecreationAfterExhaustion", func(t *testing.T) {
-		memoryMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+		memoryMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 		defer memoryMonitor.Stop(ctx)
-		diskMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+		diskMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 		defer diskMonitor.Stop(ctx)
 		rc := getRowContainer()
 		defer rc.Close(ctx)
@@ -376,9 +376,9 @@ func TestHashDiskBackedRowContainerPreservesMatchesAndMarks(t *testing.T) {
 	// from the same buckets, and then verifies that all rows were properly added
 	// to the hashDiskBackedRowContainer.
 	t.Run("PreservingMatches", func(t *testing.T) {
-		memoryMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+		memoryMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 		defer memoryMonitor.Stop(ctx)
-		diskMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+		diskMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 		defer diskMonitor.Stop(ctx)
 		rc := getRowContainer()
 		defer rc.Close(ctx)
@@ -425,9 +425,9 @@ func TestHashDiskBackedRowContainerPreservesMatchesAndMarks(t *testing.T) {
 	// hashDiskBackedRowContainer, marks all rows belonging to the first bucket,
 	// spills to disk, and checks that marks are preserved correctly.
 	t.Run("PreservingMarks", func(t *testing.T) {
-		memoryMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+		memoryMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 		defer memoryMonitor.Stop(ctx)
-		diskMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+		diskMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 		defer diskMonitor.Stop(ctx)
 		rc := getRowContainer()
 		defer rc.Close(ctx)

--- a/pkg/sql/rowcontainer/numbered_row_container_test.go
+++ b/pkg/sql/rowcontainer/numbered_row_container_test.go
@@ -44,7 +44,7 @@ func newTestDiskMonitor(ctx context.Context, st *cluster.Settings) *mon.BytesMon
 		math.MaxInt64, /* noteworthy */
 		st,
 	)
-	diskMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+	diskMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 	return diskMonitor
 }
 
@@ -83,7 +83,7 @@ func TestNumberedRowContainerDeDuping(t *testing.T) {
 		fmt.Printf("using smallMemoryBudget to spill to disk\n")
 		memoryBudget = smallMemoryBudget
 	}
-	memoryMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(int64(memoryBudget)))
+	memoryMonitor.Start(ctx, nil, mon.NewStandaloneBudget(int64(memoryBudget)))
 	defer memoryMonitor.Stop(ctx)
 
 	// Use random types and random rows.
@@ -169,7 +169,7 @@ func TestNumberedRowContainerIteratorCaching(t *testing.T) {
 	// This memory budget allows for some caching, but typically cannot
 	// cache all the rows.
 	const memoryBudget = 12000
-	memoryMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(memoryBudget))
+	memoryMonitor.Start(ctx, nil, mon.NewStandaloneBudget(memoryBudget))
 	defer memoryMonitor.Stop(ctx)
 
 	// Use random types and random rows.
@@ -463,7 +463,7 @@ func makeMemMonitorAndStart(
 		math.MaxInt64, /* noteworthy */
 		st,
 	)
-	memoryMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(budget))
+	memoryMonitor.Start(ctx, nil, mon.NewStandaloneBudget(budget))
 	return memoryMonitor
 }
 

--- a/pkg/sql/rowcontainer/row_container_test.go
+++ b/pkg/sql/rowcontainer/row_container_test.go
@@ -237,9 +237,9 @@ func TestDiskBackedRowContainer(t *testing.T) {
 	// halfway through, keeps on adding rows, and then verifies that all rows
 	// were properly added to the DiskBackedRowContainer.
 	t.Run("NormalRun", func(t *testing.T) {
-		memoryMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+		memoryMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 		defer memoryMonitor.Stop(ctx)
-		diskMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+		diskMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 		defer diskMonitor.Stop(ctx)
 
 		defer func() {
@@ -285,9 +285,9 @@ func TestDiskBackedRowContainer(t *testing.T) {
 	})
 
 	t.Run("AddRowOutOfMem", func(t *testing.T) {
-		memoryMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(1))
+		memoryMonitor.Start(ctx, nil, mon.NewStandaloneBudget(1))
 		defer memoryMonitor.Stop(ctx)
-		diskMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+		diskMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 		defer diskMonitor.Stop(ctx)
 
 		defer func() {
@@ -311,9 +311,9 @@ func TestDiskBackedRowContainer(t *testing.T) {
 	})
 
 	t.Run("AddRowOutOfDisk", func(t *testing.T) {
-		memoryMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(1))
+		memoryMonitor.Start(ctx, nil, mon.NewStandaloneBudget(1))
 		defer memoryMonitor.Stop(ctx)
-		diskMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(1))
+		diskMonitor.Start(ctx, nil, mon.NewStandaloneBudget(1))
 		defer diskMonitor.Stop(ctx)
 
 		defer func() {
@@ -363,7 +363,7 @@ func TestDiskBackedRowContainerDeDuping(t *testing.T) {
 	)
 	diskMonitor := newTestDiskMonitor(ctx, st)
 
-	memoryMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+	memoryMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 	defer memoryMonitor.Stop(ctx)
 	defer diskMonitor.Stop(ctx)
 
@@ -497,9 +497,9 @@ func TestDiskBackedIndexedRowContainer(t *testing.T) {
 	newOrdering := colinfo.ColumnOrdering{{ColIdx: 1, Direction: encoding.Ascending}}
 
 	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
-	memoryMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+	memoryMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 	defer memoryMonitor.Stop(ctx)
-	diskMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+	diskMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 	defer diskMonitor.Stop(ctx)
 
 	// SpillingHalfway adds half of all rows into DiskBackedIndexedRowContainer,
@@ -662,9 +662,9 @@ func TestDiskBackedIndexedRowContainer(t *testing.T) {
 				sortedRows.rows = append(sortedRows.rows, IndexedRow{Idx: len(sortedRows.rows), Row: row})
 			}
 
-			memoryMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(budget))
+			memoryMonitor.Start(ctx, nil, mon.NewStandaloneBudget(budget))
 			defer memoryMonitor.Stop(ctx)
-			diskMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+			diskMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 			defer diskMonitor.Stop(ctx)
 
 			sorter := rowsSorter{evalCtx: &evalCtx, rows: sortedRows, ordering: ordering}
@@ -933,9 +933,9 @@ func BenchmarkDiskBackedIndexedRowContainer(b *testing.B) {
 		st,
 	)
 	rows := randgen.MakeIntRows(numRows, numCols)
-	memoryMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+	memoryMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 	defer memoryMonitor.Stop(ctx)
-	diskMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+	diskMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 	defer diskMonitor.Stop(ctx)
 
 	accessPattern := generateAccessPattern(numRows)

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -423,7 +423,7 @@ func newJoinReader(
 	jr.MemMonitor = mon.NewMonitorInheritWithLimit(
 		"joinreader-mem" /* name */, memoryLimit, flowCtx.EvalCtx.Mon,
 	)
-	jr.MemMonitor.Start(flowCtx.EvalCtx.Ctx(), flowCtx.EvalCtx.Mon, mon.BoundAccount{})
+	jr.MemMonitor.StartNoReserved(flowCtx.EvalCtx.Ctx(), flowCtx.EvalCtx.Mon)
 	jr.memAcc = jr.MemMonitor.MakeBoundAccount()
 
 	if err := jr.initJoinReaderStrategy(flowCtx, rightTypes, readerType); err != nil {
@@ -471,7 +471,7 @@ func newJoinReader(
 		jr.streamerInfo.unlimitedMemMonitor = mon.NewMonitorInheritWithLimit(
 			"joinreader-streamer-unlimited" /* name */, math.MaxInt64, flowCtx.EvalCtx.Mon,
 		)
-		jr.streamerInfo.unlimitedMemMonitor.Start(flowCtx.EvalCtx.Ctx(), flowCtx.EvalCtx.Mon, mon.BoundAccount{})
+		jr.streamerInfo.unlimitedMemMonitor.StartNoReserved(flowCtx.EvalCtx.Ctx(), flowCtx.EvalCtx.Mon)
 		jr.streamerInfo.budgetAcc = jr.streamerInfo.unlimitedMemMonitor.MakeBoundAccount()
 		jr.streamerInfo.txnKVStreamerMemAcc = jr.streamerInfo.unlimitedMemMonitor.MakeBoundAccount()
 

--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -1068,7 +1068,7 @@ func TestJoinReader(t *testing.T) {
 		math.MaxInt64,
 		st,
 	)
-	diskMonitor.Start(ctx, nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
+	diskMonitor.Start(ctx, nil /* pool */, mon.NewStandaloneBudget(math.MaxInt64))
 	defer diskMonitor.Stop(ctx)
 	for i, td := range []catalog.TableDescriptor{tdSecondary, tdFamily} {
 		for _, c := range testCases {
@@ -1271,7 +1271,7 @@ CREATE TABLE test.t (a INT, s STRING, INDEX (a, s))`); err != nil {
 		math.MaxInt64,
 		st,
 	)
-	diskMonitor.Start(ctx, nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
+	diskMonitor.Start(ctx, nil /* pool */, mon.NewStandaloneBudget(math.MaxInt64))
 	defer diskMonitor.Stop(ctx)
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -157,7 +157,7 @@ func newWindower(
 		limit = memRequiredByWindower
 	}
 	limitedMon := mon.NewMonitorInheritWithLimit("windower-limited", limit, evalCtx.Mon)
-	limitedMon.Start(ctx, evalCtx.Mon, mon.BoundAccount{})
+	limitedMon.StartNoReserved(ctx, evalCtx.Mon)
 
 	if err := w.InitWithEvalCtx(
 		w,

--- a/pkg/sql/sem/builtins/show_create_all_tables_builtin_test.go
+++ b/pkg/sql/sem/builtins/show_create_all_tables_builtin_test.go
@@ -35,7 +35,7 @@ func TestTopologicalSort(t *testing.T) {
 		math.MaxInt64, /* noteworthy */
 		cluster.MakeTestingClusterSettings(),
 	)
-	monitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+	monitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 	acc := monitor.MakeBoundAccount()
 
 	testCases := []struct {

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -279,7 +279,7 @@ func MakeTestingEvalContextWithMon(st *cluster.Settings, monitor *mon.BytesMonit
 		Settings:         st,
 		NodeID:           base.TestingIDContainer,
 	}
-	monitor.Start(context.Background(), nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
+	monitor.Start(context.Background(), nil /* pool */, mon.NewStandaloneBudget(math.MaxInt64))
 	ctx.Mon = monitor
 	ctx.Context = context.TODO()
 	now := timeutil.Now()

--- a/pkg/sql/sqlstats/sslocal/sql_stats.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats.go
@@ -99,7 +99,7 @@ func newSQLStats(
 	}
 	s.mu.apps = make(map[string]*ssmemstorage.Container)
 	s.mu.mon = monitor
-	s.mu.mon.Start(context.Background(), parentMon, mon.BoundAccount{})
+	s.mu.mon.StartNoReserved(context.Background(), parentMon)
 	return s
 }
 

--- a/pkg/sql/stats/row_sampling_test.go
+++ b/pkg/sql/stats/row_sampling_test.go
@@ -118,7 +118,7 @@ func TestSampleReservoir(t *testing.T) {
 						math.MaxInt64,
 						st,
 					)
-					monitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+					monitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 					memAcc := monitor.MakeBoundAccount()
 					expectedK := k
 					if mem == 1<<8 && n > 1 && k > 1 {

--- a/pkg/sql/txn_fingerprint_id_cache.go
+++ b/pkg/sql/txn_fingerprint_id_cache.go
@@ -69,7 +69,7 @@ func NewTxnFingerprintIDCache(
 
 	monitor := mon.NewMonitorInheritWithLimit("txn-fingerprint-id-cache", 0 /* limit */, parentMon)
 	b.mon = monitor
-	b.mon.Start(context.Background(), parentMon, mon.BoundAccount{})
+	b.mon.StartNoReserved(context.Background(), parentMon)
 
 	return b
 }

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -208,7 +208,7 @@ func (ts *txnState) resetForNewSQLTxn(
 	}
 
 	ts.Ctx, ts.cancel = contextutil.WithCancel(txnCtx)
-	ts.mon.Start(ts.Ctx, tranCtx.connMon, mon.BoundAccount{} /* reserved */)
+	ts.mon.StartNoReserved(ts.Ctx, tranCtx.connMon)
 	txnID = func() (txnID uuid.UUID) {
 		ts.mu.Lock()
 		defer ts.mu.Unlock()

--- a/pkg/sql/txn_state_test.go
+++ b/pkg/sql/txn_state_test.go
@@ -92,7 +92,7 @@ func (tc *testContext) createOpenState(typ txnType) (fsm.State, *txnState) {
 		1000, /* noteworthy */
 		cluster.MakeTestingClusterSettings(),
 	)
-	txnStateMon.Start(tc.ctx, tc.mon, mon.BoundAccount{})
+	txnStateMon.StartNoReserved(tc.ctx, tc.mon)
 
 	ts := txnState{
 		Ctx:           ctx,

--- a/pkg/storage/pebble_mvcc_scanner_test.go
+++ b/pkg/storage/pebble_mvcc_scanner_test.go
@@ -174,7 +174,7 @@ func scannerWithAccount(
 	ctx context.Context, st *cluster.Settings, scanner *pebbleMVCCScanner, limitBytes int64,
 ) (cleanup func()) {
 	m := mon.NewMonitor("test", mon.MemoryResource, nil, nil, 1, math.MaxInt64, st)
-	m.Start(ctx, nil, mon.MakeStandaloneBudget(limitBytes))
+	m.Start(ctx, nil, mon.NewStandaloneBudget(limitBytes))
 	ba := m.MakeBoundAccount()
 	scanner.memAccount = &ba
 	return func() {

--- a/pkg/ts/query_test.go
+++ b/pkg/ts/query_test.go
@@ -403,7 +403,7 @@ func TestQueryWorkerMemoryConstraint(t *testing.T) {
 				math.MaxInt64,
 				cluster.MakeTestingClusterSettings(),
 			)
-			adjustedMon.Start(context.Background(), tm.workerMemMonitor, mon.BoundAccount{})
+			adjustedMon.StartNoReserved(context.Background(), tm.workerMemMonitor)
 			defer adjustedMon.Stop(context.Background())
 
 			query := tm.makeQuery("test.metric", resolution1ns, 11, 109)
@@ -419,7 +419,7 @@ func TestQueryWorkerMemoryConstraint(t *testing.T) {
 			} {
 				// Limit memory in use by model. Reset memory monitor to get new maximum.
 				adjustedMon.Stop(context.Background())
-				adjustedMon.Start(context.Background(), tm.workerMemMonitor, mon.BoundAccount{})
+				adjustedMon.StartNoReserved(context.Background(), tm.workerMemMonitor)
 				if adjustedMon.MaximumBytes() != 0 {
 					t.Fatalf("maximum bytes was %d, wanted zero", adjustedMon.MaximumBytes())
 				}
@@ -481,7 +481,7 @@ func TestQueryWorkerMemoryMonitor(t *testing.T) {
 			100,
 			cluster.MakeTestingClusterSettings(),
 		)
-		limitedMon.Start(context.Background(), tm.workerMemMonitor, mon.BoundAccount{})
+		limitedMon.StartNoReserved(context.Background(), tm.workerMemMonitor)
 		defer limitedMon.Stop(context.Background())
 
 		// Assert correctness with no memory pressure.
@@ -503,7 +503,7 @@ func TestQueryWorkerMemoryMonitor(t *testing.T) {
 
 		// Start/Stop limited monitor to reset maximum allocation.
 		limitedMon.Stop(context.Background())
-		limitedMon.Start(context.Background(), tm.workerMemMonitor, mon.BoundAccount{})
+		limitedMon.StartNoReserved(context.Background(), tm.workerMemMonitor)
 
 		var (
 			memStatsBefore runtime.MemStats

--- a/pkg/ts/rollup_test.go
+++ b/pkg/ts/rollup_test.go
@@ -273,7 +273,7 @@ func TestRollupMemoryConstraint(t *testing.T) {
 		math.MaxInt64,
 		cluster.MakeTestingClusterSettings(),
 	)
-	adjustedMon.Start(context.Background(), tm.workerMemMonitor, mon.BoundAccount{})
+	adjustedMon.StartNoReserved(context.Background(), tm.workerMemMonitor)
 	defer adjustedMon.Stop(context.Background())
 
 	// Roll up time series with the new monitor to measure high-water mark
@@ -319,7 +319,7 @@ func TestRollupMemoryConstraint(t *testing.T) {
 
 		// Restart monitor to clear query memory options.
 		adjustedMon.Stop(context.Background())
-		adjustedMon.Start(context.Background(), tm.workerMemMonitor, mon.BoundAccount{})
+		adjustedMon.StartNoReserved(context.Background(), tm.workerMemMonitor)
 
 		qmc := MakeQueryMemoryContext(adjustedMon, adjustedMon, QueryMemoryOptions{
 			// Large budget, but not maximum to avoid overflows.

--- a/pkg/ts/server.go
+++ b/pkg/ts/server.go
@@ -141,12 +141,12 @@ func MakeServer(
 		workerSem:      workerSem,
 	}
 
-	s.workerMemMonitor.Start(ctx, memoryMonitor, mon.BoundAccount{})
+	s.workerMemMonitor.StartNoReserved(ctx, memoryMonitor)
 	stopper.AddCloser(stop.CloserFn(func() {
 		s.workerMemMonitor.Stop(ctx)
 	}))
 
-	s.resultMemMonitor.Start(ambient.AnnotateCtx(context.Background()), memoryMonitor, mon.BoundAccount{})
+	s.resultMemMonitor.StartNoReserved(ambient.AnnotateCtx(context.Background()), memoryMonitor)
 	stopper.AddCloser(stop.CloserFn(func() {
 		s.resultMemMonitor.Stop(ctx)
 	}))


### PR DESCRIPTION
**util/mon: pass reserved account by reference**

This commit makes it so that we now pass the `reserved` memory account
when starting up memory monitors by reference. Previously, due to
passing by value, when the monitor is stopped, the copy of the value
would get used so that the actual "reserved" memory account would get
out of sync with its user. This is now fixed. However, this bug doesn't
really have any production impact since we use this "reserved" feature
in a handful of places and these "reserved" memory accounts are not
reused between different usages.

Additionally, this commit renames `MakeStandaloneBudget` to
`NewStandaloneBudget` (since it now returns a reference) and adds
a separate "start" method when the caller doesn't want to pre-reserve
anything when starting up a monitor.

Release note: None

**sql: make sure to close the reserved account for each session**

This commit makes it more clear that the "reserved" memory account
created for each connection is closed when that connection is closed.
Previously, the account was already cleared (when "session root" monitor
is stopped which happens when the connExecutor stops), so there was no
leak in the accounting system because of it, yet it wasn't obvious - this
commit makes it more obvious.

Release note: None