### PR TITLE
server/systemconfigwatcher/systemconfigwatchertest: fix race

### DIFF
--- a/pkg/server/systemconfigwatcher/systemconfigwatchertest/BUILD.bazel
+++ b/pkg/server/systemconfigwatcher/systemconfigwatchertest/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/testutils/sqlutils",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_kr_pretty//:pretty",
         "@com_github_stretchr_testify//assert",

--- a/pkg/server/systemconfigwatcher/systemconfigwatchertest/test_system_config_watcher.go
+++ b/pkg/server/systemconfigwatcher/systemconfigwatchertest/test_system_config_watcher.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/assert"
@@ -102,14 +103,15 @@ func runTest(
 		if rs == nil {
 			return errors.New("nil config")
 		}
+		entries := protoutil.Clone(&rs.SystemConfigEntries).(*config.SystemConfigEntries)
 		sc := getSystemDescriptorAndZonesSpans(ctx, t, execCfg.Codec, kvDB)
 		if extraRows != nil {
 			sc = append(sc, extraRows(t)...)
 			sort.Sort(roachpb.KeyValueByKey(sc))
 		}
-		sort.Sort(roachpb.KeyValueByKey(rs.Values))
-		if !assert.Equal(noopT{}, sc, rs.Values) {
-			return errors.Errorf("mismatch: %v", pretty.Diff(sc, rs.Values))
+		sort.Sort(roachpb.KeyValueByKey(entries.Values))
+		if !assert.Equal(noopT{}, sc, entries.Values) {
+			return errors.Errorf("mismatch: %v", pretty.Diff(sc, entries.Values))
 		}
 		return nil
 	}


### PR DESCRIPTION
Fixes #83258

```
==================
WARNING: DATA RACE
Write at 0x00c001b75c00 by goroutine 264:
  github.com/cockroachdb/cockroach/pkg/roachpb.KeyValueByKey.Swap()
      github.com/cockroachdb/cockroach/pkg/roachpb/pkg/roachpb/data.go:2400 +0x190
  github.com/cockroachdb/cockroach/pkg/roachpb.(*KeyValueByKey).Swap()
      <autogenerated>:1 +0xb3
  sort.medianOfThree()
      GOROOT/src/sort/sort.go:90 +0x72
  sort.doPivot()
      GOROOT/src/sort/sort.go:114 +0x9e
  sort.quickSort()
      GOROOT/src/sort/sort.go:203 +0xac
  sort.Sort()
      GOROOT/src/sort/sort.go:231 +0x64
  github.com/cockroachdb/cockroach/pkg/server/systemconfigwatcher/systemconfigwatchertest.runTest.func2()
      github.com/cockroachdb/cockroach/pkg/server/systemconfigwatcher/systemconfigwatchertest/test_system_config_watcher.go:110 +0x4d1
  github.com/cockroachdb/cockroach/pkg/server/systemconfigwatcher/systemconfigwatchertest.runTest.func3.1()
      github.com/cockroachdb/cockroach/pkg/server/systemconfigwatcher/systemconfigwatchertest/test_system_config_watcher.go:118 +0x4e
  github.com/cockroachdb/cockroach/pkg/testutils.SucceedsWithinError.func1()
      github.com/cockroachdb/cockroach/pkg/testutils/soon.go:69 +0x7a
  github.com/cockroachdb/cockroach/pkg/util/retry.ForDuration()
      github.com/cockroachdb/cockroach/pkg/util/retry/retry.go:207 +0x191
  github.com/cockroachdb/cockroach/pkg/testutils.SucceedsWithinError()
      github.com/cockroachdb/cockroach/pkg/testutils/soon.go:75 +0x1d1
  github.com/cockroachdb/cockroach/pkg/testutils.SucceedsWithin()
      github.com/cockroachdb/cockroach/pkg/testutils/soon.go:57 +0x96
  github.com/cockroachdb/cockroach/pkg/testutils.SucceedsSoon()
      github.com/cockroachdb/cockroach/pkg/testutils/soon.go:40 +0x8d
  github.com/cockroachdb/cockroach/pkg/server/systemconfigwatcher/systemconfigwatchertest.runTest.func3()
      github.com/cockroachdb/cockroach/pkg/server/systemconfigwatcher/systemconfigwatchertest/test_system_config_watcher.go:117 +0x164
  github.com/cockroachdb/cockroach/pkg/server/systemconfigwatcher/systemconfigwatchertest.runTest()
      github.com/cockroachdb/cockroach/pkg/server/systemconfigwatcher/systemconfigwatchertest/test_system_config_watcher.go:121 +0x5cf
  github.com/cockroachdb/cockroach/pkg/server/systemconfigwatcher/systemconfigwatchertest.TestSystemConfigWatcher.func1()
      github.com/cockroachdb/cockroach/pkg/server/systemconfigwatcher/systemconfigwatchertest/test_system_config_watcher.go:62 +0xdc
  testing.tRunner()
      GOROOT/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      GOROOT/src/testing/testing.go:1306 +0x47

Previous read at 0x00c001b75c00 by goroutine 502:
  runtime.slicecopy()
      GOROOT/src/runtime/slice.go:284 +0x0
  github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed/rangefeedbuffer.MergeKVs()
      github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed/rangefeedbuffer/kvs.go:47 +0x354
  github.com/cockroachdb/cockroach/pkg/server/systemconfigwatcher.(*Cache).handleUpdate()
      github.com/cockroachdb/cockroach/pkg/server/systemconfigwatcher/cache.go:253 +0x431
  github.com/cockroachdb/cockroach/pkg/server/systemconfigwatcher.(*Cache).handleUpdate-fm()
      github.com/cockroachdb/cockroach/pkg/server/systemconfigwatcher/cache.go:232 +0x11e
  github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed/rangefeedcache.(*Watcher).handleUpdate()
      github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed/rangefeedcache/watcher.go:346 +0x277
  github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed/rangefeedcache.(*Watcher).Run()
      github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed/rangefeedcache/watcher.go:327 +0x1b04
  github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed/rangefeedcache.Start.func1()
      github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed/rangefeedcache/watcher.go:189 +0x3d1
  github.com/cockroachdb/cockroach/pkg/util/stop.(*Stopper).RunAsyncTaskEx.func2()
      github.com/cockroachdb/cockroach/pkg/util/stop/stopper.go:494 +0x551
```

Clone the values to make sure we don't have a race.

Release note: None