### PR TITLE
streamingccl: create new tenant automatically for replication stream

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingest/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/catalog/colinfo",
+        "//pkg/sql/catalog/descpb",
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",
         "//pkg/sql/pgwire/pgcode",


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/76952

Originally tenants had to be created manually prior to replication
stream creation.  This change instead creates a new tenant upon calling
the RESTORE INTO command using the tenant ID that was provided.  The
tenant is considered inactive until the cutover point, at which the
tenant is activated.

Release note: None