### PR TITLE
ui: format rows processed

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "22.2.0-prerelease-2",
+  "version": "22.2.0-prerelease-3",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -16,6 +16,7 @@ import {
   longToInt,
   StatementSummary,
   StatementStatistics,
+  Count,
 } from "src/util";
 import {
   countBarChart,
@@ -106,7 +107,7 @@ function makeCommonColumns(
       title: statisticsTableTitles.rowsProcessed(statType),
       className: cx("statements-table__col-rows-read"),
       cell: (stmt: AggregateStatistics) =>
-        `${FixLong(Number(stmt.stats.rows_read.mean))} Reads / ${FixLong(
+        `${Count(Number(stmt.stats.rows_read.mean))} Reads / ${Count(
           Number(stmt.stats.rows_written?.mean),
         )} Writes`,
       sort: (stmt: AggregateStatistics) =>

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
@@ -28,7 +28,7 @@ import {
 import { statisticsTableTitles } from "../statsTableUtil/statsTableUtil";
 import { tableClasses } from "./transactionsTableClasses";
 import { transactionLink } from "./transactionsCells";
-import { FixLong, longToInt, TimestampToString } from "src/util";
+import { Count, FixLong, longToInt, TimestampToString } from "src/util";
 import { SortSetting } from "../sortedtable";
 import {
   getStatementsByFingerprintId,
@@ -156,9 +156,7 @@ export function makeTransactionsColumns(
       name: "rowsProcessed",
       title: statisticsTableTitles.rowsProcessed(statType),
       cell: (item: TransactionInfo) =>
-        `${FixLong(
-          Number(item.stats_data.stats.rows_read.mean),
-        )} Reads / ${FixLong(
+        `${Count(Number(item.stats_data.stats.rows_read.mean))} Reads / ${Count(
           Number(item.stats_data.stats.rows_written?.mean),
         )} Writes`,
       className: cx("statements-table__col-rows-read"),


### PR DESCRIPTION
Previously, the rows processed could show a really
long number. This commit adds formatting to it, so
it can have the proper unit.

Before
<img width="600" alt="Screen Shot 2022-06-30 at 9 18 26 AM" src="https://user-images.githubusercontent.com/1017486/176693739-3063c940-8d16-436d-84f5-2dbff37a419f.png">

After
<img width="210" alt="Screen Shot 2022-06-30 at 9 44 16 AM" src="https://user-images.githubusercontent.com/1017486/176693816-e78c3ee5-f963-400f-a2de-ee07a78bb4f3.png">



Release note: None