### PR TITLE
sql/schemachanger: enable parallel testing for schemachanger tests

### DIFF
--- a/pkg/ccl/schemachangerccl/schemachanger_ccl_test.go
+++ b/pkg/ccl/schemachangerccl/schemachanger_ccl_test.go
@@ -59,9 +59,11 @@ func TestBackupRestore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	t.Run("ccl", func(t *testing.T) {
+		t.Parallel()
 		sctest.Backup(t, endToEndPath(t), newCluster)
 	})
 	t.Run("non-ccl", func(t *testing.T) {
+		t.Parallel()
 		sctest.Backup(t, sharedTestdata(t), sctest.SingleNodeCluster)
 	})
 }

--- a/pkg/sql/schemachanger/sctest/decomp.go
+++ b/pkg/sql/schemachanger/sctest/decomp.go
@@ -39,6 +39,7 @@ func DecomposeToElements(t *testing.T, dir string, newCluster NewClusterFunc) {
 	skip.UnderStress(t)
 	ctx := context.Background()
 	datadriven.Walk(t, dir, func(t *testing.T, path string) {
+		t.Parallel()
 		// Create a test cluster.
 		db, cleanup := newCluster(t, nil /* knobs */)
 		tdb := sqlutils.MakeSQLRunner(db)

--- a/pkg/sql/schemachanger/sctest/end_to_end.go
+++ b/pkg/sql/schemachanger/sctest/end_to_end.go
@@ -70,6 +70,7 @@ func SingleNodeCluster(t *testing.T, knobs *scexec.TestingKnobs) (*gosql.DB, fun
 func EndToEndSideEffects(t *testing.T, dir string, newCluster NewClusterFunc) {
 	ctx := context.Background()
 	datadriven.Walk(t, dir, func(t *testing.T, path string) {
+		t.Parallel()
 		// Create a test cluster.
 		db, cleanup := newCluster(t, nil /* knobs */)
 		tdb := sqlutils.MakeSQLRunner(db)


### PR DESCRIPTION
Previously, the data driven tests used for validating the declarative
schemachanger, did not support parallel execution. This led to longer
execution times for these tests. To address this, this patch enables
parallel execution for all of these data driven tests.

Release note: None