### PR TITLE
kvstreamer: optimize the results buffers a bit

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/requests_provider_test.go
+++ b/pkg/kv/kvclient/kvstreamer/requests_provider_test.go
@@ -44,10 +44,10 @@ func TestInOrderRequestsProvider(t *testing.T) {
 	for len(priorities) > 0 {
 		// Simulate issuing a request.
 		p.Lock()
-		first := p.firstLocked()
-		p.removeFirstLocked()
+		next := p.nextLocked()
+		p.removeNextLocked()
 		p.Unlock()
-		require.Equal(t, priorities[0], first.priority())
+		require.Equal(t, priorities[0], next.priority())
 		priorities = priorities[1:]
 		// With 50% probability simulate that a resume request with random
 		// priority is added.
@@ -55,9 +55,9 @@ func TestInOrderRequestsProvider(t *testing.T) {
 			// Note that in reality the position of the resume request cannot
 			// have lower value than of the original request, but it's ok for
 			// the test.
-			first.positions[0] = rng.Intn(maxNumRequests)
-			p.add(first)
-			priorities = append(priorities, first.priority())
+			next.positions[0] = rng.Intn(maxNumRequests)
+			p.add(next)
+			priorities = append(priorities, next.priority())
 			sort.Ints(priorities)
 		}
 	}

--- a/pkg/kv/kvclient/kvstreamer/results_buffer.go
+++ b/pkg/kv/kvclient/kvstreamer/results_buffer.go
@@ -11,7 +11,6 @@
 package kvstreamer
 
 import (
-	"container/heap"
 	"context"
 	"fmt"
 
@@ -338,6 +337,10 @@ var TestResultDiskBufferConstructor func(diskmap.Factory, *mon.BytesMonitor) Res
 // considered "unreleased" - we think of them as "buffered". This matters so
 // that the Streamer could issue the head-of-the-line request with
 // headOfLine=true even if there are some buffered results.
+//
+// Note that the heap methods were copied (with minor adjustments) from the
+// standard library as we chose not to make the struct implement the
+// heap.Interface interface in order to avoid allocations.
 type inOrderResultsBuffer struct {
 	*resultsBufferBase
 	// headOfLinePosition is the Position value of the next Result to be
@@ -369,7 +372,6 @@ type inOrderResultsBuffer struct {
 }
 
 var _ resultsBuffer = &inOrderResultsBuffer{}
-var _ heap.Interface = &inOrderResultsBuffer{}
 
 func newInOrderResultsBuffer(
 	budget *budget, diskBuffer ResultDiskBuffer, singleRowLookup bool,
@@ -384,11 +386,7 @@ func newInOrderResultsBuffer(
 	}
 }
 
-func (b *inOrderResultsBuffer) Len() int {
-	return len(b.buffered)
-}
-
-func (b *inOrderResultsBuffer) Less(i, j int) bool {
+func (b *inOrderResultsBuffer) less(i, j int) bool {
 	posI, posJ := b.buffered[i].Position, b.buffered[j].Position
 	subI, subJ := b.buffered[i].subRequestIdx, b.buffered[j].subRequestIdx
 	epochI, epochJ := b.buffered[i].addEpoch, b.buffered[j].addEpoch
@@ -397,18 +395,52 @@ func (b *inOrderResultsBuffer) Less(i, j int) bool {
 		(posI == posJ && subI == subJ && epochI < epochJ) // results for the same Scan request, for the same range
 }
 
-func (b *inOrderResultsBuffer) Swap(i, j int) {
+func (b *inOrderResultsBuffer) swap(i, j int) {
 	b.buffered[i], b.buffered[j] = b.buffered[j], b.buffered[i]
 }
 
-func (b *inOrderResultsBuffer) Push(x interface{}) {
-	b.buffered = append(b.buffered, x.(inOrderBufferedResult))
+// heapPush pushes r onto the heap of the results.
+func (b *inOrderResultsBuffer) heapPush(r inOrderBufferedResult) {
+	b.buffered = append(b.buffered, r)
+	b.heapUp(len(b.buffered) - 1)
 }
 
-func (b *inOrderResultsBuffer) Pop() interface{} {
-	x := b.buffered[len(b.buffered)-1]
-	b.buffered = b.buffered[:len(b.buffered)-1]
-	return x
+// heapRemoveFirst removes the 0th result from the heap. It assumes that the
+// heap is not empty.
+func (b *inOrderResultsBuffer) heapRemoveFirst() {
+	n := len(b.buffered) - 1
+	b.swap(0, n)
+	b.heapDown(0, n)
+	b.buffered = b.buffered[:n]
+}
+
+func (b *inOrderResultsBuffer) heapUp(j int) {
+	for {
+		i := (j - 1) / 2 // parent
+		if i == j || !b.less(j, i) {
+			break
+		}
+		b.swap(i, j)
+		j = i
+	}
+}
+
+func (b *inOrderResultsBuffer) heapDown(i, n int) {
+	for {
+		j1 := 2*i + 1
+		if j1 >= n {
+			return
+		}
+		j := j1 // left child
+		if j2 := j1 + 1; j2 < n && b.less(j2, j1) {
+			j = j2 // = 2*i + 2  // right child
+		}
+		if !b.less(j, i) {
+			return
+		}
+		b.swap(i, j)
+		i = j
+	}
 }
 
 func (b *inOrderResultsBuffer) init(ctx context.Context, numExpectedResponses int) error {
@@ -442,7 +474,7 @@ func (b *inOrderResultsBuffer) addLocked(r Result) {
 	}
 	// All the Results have already been registered with the budget, so we're
 	// keeping them in-memory.
-	heap.Push(b, inOrderBufferedResult{Result: r, onDisk: false, addEpoch: b.addCounter})
+	b.heapPush(inOrderBufferedResult{Result: r, onDisk: false, addEpoch: b.addCounter})
 	b.addCounter++
 }
 
@@ -497,7 +529,7 @@ func (b *inOrderResultsBuffer) get(ctx context.Context) ([]Result, bool, error) 
 			}
 		}
 		res = append(res, result)
-		heap.Remove(b, 0)
+		b.heapRemoveFirst()
 		if result.subRequestDone {
 			// Only advance the sub-request index if we're done with all parts
 			// of the sub-request.

--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -743,11 +743,11 @@ func (w *workerCoordinator) mainLoop(ctx context.Context) {
 		if !w.s.requestsToServe.emptyLocked() {
 			// If we already have minTargetBytes set on the first request to be
 			// issued, then use that.
-			atLeastBytes = w.s.requestsToServe.firstLocked().minTargetBytes
+			atLeastBytes = w.s.requestsToServe.nextLocked().minTargetBytes
 			// The first request has the highest urgency among all current
 			// requests to serve, so we use its priority to spill everything
 			// with less urgency when necessary to free up the budget.
-			spillingPriority = w.s.requestsToServe.firstLocked().priority()
+			spillingPriority = w.s.requestsToServe.nextLocked().priority()
 		}
 		w.s.requestsToServe.Unlock()
 
@@ -943,7 +943,7 @@ func (w *workerCoordinator) issueRequestsForAsyncProcessing(
 	headOfLine := w.s.getNumRequestsInProgress() == 0
 	var budgetIsExhausted bool
 	for !w.s.requestsToServe.emptyLocked() && maxNumRequestsToIssue > 0 && !budgetIsExhausted {
-		singleRangeReqs := w.s.requestsToServe.firstLocked()
+		singleRangeReqs := w.s.requestsToServe.nextLocked()
 		availableBudget := w.s.budget.limitBytes - w.s.budget.mu.acc.Used()
 		// minAcceptableBudget is the minimum TargetBytes limit with which it
 		// makes sense to issue this request (if we issue the request with
@@ -1035,7 +1035,7 @@ func (w *workerCoordinator) issueRequestsForAsyncProcessing(
 			)
 		}
 		w.performRequestAsync(ctx, singleRangeReqs, targetBytes, headOfLine)
-		w.s.requestsToServe.removeFirstLocked()
+		w.s.requestsToServe.removeNextLocked()
 		maxNumRequestsToIssue--
 		headOfLine = false
 	}

--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -89,11 +89,6 @@ type Result struct {
 	ScanResp *roachpb.ScanResponse
 	// Position tracks the ordinal among all originally enqueued requests that
 	// this result satisfies. See singleRangeBatch.positions for more details.
-	//
-	// If Streamer.Enqueue() was called with nil enqueueKeys argument, then
-	// EnqueueKeysSatisfied will exactly contain Position; if non-nil
-	// enqueueKeys argument was passed, then Position is used as an ordinal to
-	// lookup into enqueueKeys to populate EnqueueKeysSatisfied.
 	// TODO(yuzefovich): this might need to be []int when non-unique requests
 	// are supported.
 	Position int
@@ -622,9 +617,11 @@ func (s *Streamer) Enqueue(ctx context.Context, reqs []roachpb.RequestUnion) (re
 
 // GetResults blocks until at least one result is available. If the operation
 // mode is OutOfOrder, any result will do, and the caller is expected to examine
-// Result.EnqueueKeysSatisfied to understand which request the result
-// corresponds to. For InOrder, only head-of-line results will do. Zero-length
-// result slice is returned once all enqueued requests have been responded to.
+// Result.Position to understand which request the result corresponds to. For
+// InOrder, only head-of-line results will do. Zero-length result slice is
+// returned once all enqueued requests have been responded to.
+//
+// Calling GetResults() invalidates the results returned on the previous call.
 func (s *Streamer) GetResults(ctx context.Context) ([]Result, error) {
 	for {
 		results, allComplete, err := s.results.get(ctx)


### PR DESCRIPTION
**kvstreamer: make InOrder-mode structs implement heap logic on their own**

This commit refactors the `inOrderRequestsProvider` as well as the
`inOrderResultsBuffer` to make them maintain the min heap over the
requests and results, respectively, on their own. This allows us to
avoid allocations for `interface{}` objects that occur when using
`heap.Interface`. The code was copied, with minor adjustments, from the
standard library.
```
name                                                  old time/op    new time/op    delta
LookupJoinEqColsAreKeyOrdering/Cockroach-24             8.83ms ± 3%    8.58ms ± 3%   -2.82%  (p=0.002 n=10+10)
LookupJoinEqColsAreKeyOrdering/MultinodeCockroach-24    10.3ms ± 1%    10.1ms ± 2%   -1.86%  (p=0.009 n=10+10)
LookupJoinOrdering/Cockroach-24                         10.7ms ± 5%    10.5ms ± 3%     ~     (p=0.123 n=10+10)
LookupJoinOrdering/MultinodeCockroach-24                14.0ms ± 5%    13.6ms ± 5%   -3.16%  (p=0.043 n=10+10)

name                                                  old alloc/op   new alloc/op   delta
LookupJoinEqColsAreKeyOrdering/Cockroach-24             1.77MB ± 2%    1.59MB ± 1%   -9.94%  (p=0.000 n=10+10)
LookupJoinEqColsAreKeyOrdering/MultinodeCockroach-24    2.57MB ± 3%    2.38MB ± 1%   -7.57%  (p=0.000 n=10+10)
LookupJoinOrdering/Cockroach-24                         1.67MB ± 0%    1.50MB ± 1%  -10.08%  (p=0.000 n=9+9)
LookupJoinOrdering/MultinodeCockroach-24                2.53MB ± 2%    2.34MB ± 2%   -7.78%  (p=0.000 n=10+9)

name                                                  old allocs/op  new allocs/op  delta
LookupJoinEqColsAreKeyOrdering/Cockroach-24              12.5k ± 1%     10.4k ± 1%  -16.54%  (p=0.000 n=9+10)
LookupJoinEqColsAreKeyOrdering/MultinodeCockroach-24     17.6k ± 0%     15.5k ± 0%  -11.64%  (p=0.000 n=8+10)
LookupJoinOrdering/Cockroach-24                          14.4k ± 1%     12.4k ± 1%  -14.17%  (p=0.000 n=9+9)
LookupJoinOrdering/MultinodeCockroach-24                 20.6k ± 1%     18.5k ± 1%  -10.19%  (p=0.000 n=10+9)
```

Addresses: #82159.

Release note: None

**kvstreamer: refactor the OutOfOrder requests provider a bit**

This commit refactors the `requestsProvider` interface renaming a couple
of methods - `s/firstLocked/nextLocked/` and
`s/removeFirstLocked/removeNextLocked/`. The idea is that for the
InOrder mode "first" == "next", but for the OutOfOrder mode we can pick
an arbitrary request that is not necessarily "first". This commit then
makes the OutOfOrder requests provider pick its last request in the
queue - which should reduce the memory usage in case resume requests are
added later.

Previously, we would slice "next" requests off the front and append to
the end, and it could trigger reallocation of the underlying slice. Now,
we'll be updating only the "tail" of the queue, and since a single
request can result in at most one resume request, the initial slice
provided in `enqueue` will definitely have enough capacity.

Release note: None

**kvstreamer: reduce allocations in the InOrder results buffer**

This commit improves the InOrder results buffer by reusing the same
scratch space for returning the results on `get()` calls as well as by
reducing the size of `inOrderBufferedResult` struct from the 80 bytes
size class to the 64 bytes size class.

It also cleans up a couple of comments and clarifies `GetResults` method
a bit.
```
name                                                  old time/op    new time/op    delta
LookupJoinEqColsAreKeyOrdering/Cockroach-24             8.47ms ± 3%    8.54ms ± 2%    ~     (p=0.182 n=9+10)
LookupJoinEqColsAreKeyOrdering/MultinodeCockroach-24    10.2ms ± 2%    10.1ms ± 2%    ~     (p=0.280 n=10+10)
LookupJoinOrdering/Cockroach-24                         10.4ms ± 3%    10.3ms ± 4%    ~     (p=0.393 n=10+10)
LookupJoinOrdering/MultinodeCockroach-24                13.8ms ± 5%    13.7ms ± 5%    ~     (p=0.739 n=10+10)

name                                                  old alloc/op   new alloc/op   delta
LookupJoinEqColsAreKeyOrdering/Cockroach-24             1.59MB ± 2%    1.49MB ± 1%  -6.20%  (p=0.000 n=10+9)
LookupJoinEqColsAreKeyOrdering/MultinodeCockroach-24    2.36MB ± 2%    2.27MB ± 2%  -3.49%  (p=0.000 n=10+10)
LookupJoinOrdering/Cockroach-24                         1.51MB ± 1%    1.42MB ± 1%  -6.27%  (p=0.000 n=9+10)
LookupJoinOrdering/MultinodeCockroach-24                2.37MB ± 6%    2.26MB ± 2%  -4.77%  (p=0.000 n=10+9)

name                                                  old allocs/op  new allocs/op  delta
LookupJoinEqColsAreKeyOrdering/Cockroach-24              10.4k ± 1%     10.3k ± 1%    ~     (p=0.055 n=8+9)
LookupJoinEqColsAreKeyOrdering/MultinodeCockroach-24     15.5k ± 0%     15.5k ± 1%  -0.34%  (p=0.037 n=10+10)
LookupJoinOrdering/Cockroach-24                          12.4k ± 1%     12.3k ± 1%  -0.98%  (p=0.000 n=9+10)
LookupJoinOrdering/MultinodeCockroach-24                 18.5k ± 1%     18.5k ± 2%    ~     (p=0.743 n=8+9)
```

Addresses: #82160.

Release note: None