### PR TITLE
rpc: break testing dependency on spanconfig

### DIFF
--- a/pkg/rpc/BUILD.bazel
+++ b/pkg/rpc/BUILD.bazel
@@ -82,6 +82,7 @@ go_test(
         "codec_test.go",
         "context_test.go",
         "heartbeat_test.go",
+        "helpers_test.go",
         "main_test.go",
         "tls_test.go",
     ],

--- a/pkg/rpc/helpers_test.go
+++ b/pkg/rpc/helpers_test.go
@@ -1,0 +1,49 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rpc
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"google.golang.org/grpc"
+)
+
+// WrappedServerStream is exported for testing.
+type WrappedServerStream = wrappedServerStream
+
+// TestingNewWrappedServerStream constructs a WrappedServerStream for testing.
+// This function returns the more generic interface to defeat the linter
+// which complains about returning an unexported type. Callers can type
+// assert the return value into the above-exported *WrappedServerStream.
+func TestingNewWrappedServerStream(
+	ctx context.Context, ss grpc.ServerStream, recvFunc func(interface{}) error,
+) grpc.ServerStream {
+	return &WrappedServerStream{
+		ServerStream: ss,
+		ctx:          ctx,
+		recv:         recvFunc,
+	}
+}
+
+// TestingAuthenticateTenant performs authentication of a tenant from a context
+// for testing.
+func TestingAuthenticateTenant(ctx context.Context) (roachpb.TenantID, error) {
+	return kvAuth{tenant: tenantAuthorizer{tenantID: roachpb.SystemTenantID}}.authenticate(ctx)
+}
+
+// TestingAuthorizeTenantRequest performs authorization of a tenant request
+// for testing.
+func TestingAuthorizeTenantRequest(
+	tenID roachpb.TenantID, method string, request interface{},
+) error {
+	return tenantAuthorizer{}.authorize(tenID, method, request)
+}


### PR DESCRIPTION
It's weird to have rpc depend on the much higher-level spanconfig package.

Release note: None