### PR TITLE
sql: added inet function to support conversion to inet type

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2708,6 +2708,8 @@ The output can be used to recreate a database.’</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="get_byte"></a><code>get_byte(byte_string: <a href="bytes.html">bytes</a>, index: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Extracts a byte at the given index in the byte array.</p>
 </span></td><td>Immutable</td></tr>
+<tr><td><a name="inet"></a><code>inet(val: <a href="string.html">string</a>) &rarr; <a href="inet.html">inet</a></code></td><td><span class="funcdesc"><p>If possible, converts input to that of type inet.</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="initcap"></a><code>initcap(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Capitalizes the first letter of <code>val</code>.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="left"></a><code>left(input: <a href="bytes.html">bytes</a>, return_set: <a href="int.html">int</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Returns the first <code>return_set</code> bytes from <code>input</code>.</p>

--- a/pkg/sql/logictest/testdata/logic_test/inet
+++ b/pkg/sql/logictest/testdata/logic_test/inet
@@ -888,3 +888,23 @@ SELECT '127.001.002.003'::INET, '127.001.002.003/016'::INET, '010.001.002.003'::
 127.1.2.3 127.1.2.3/16 10.1.2.3
 
 subtest end
+
+# Test inet
+
+query error pq: inet\(\): could not parse "some_invalid_value" as inet. invalid IP
+SELECT inet('some_invalid_value')
+
+query T
+SELECT inet('::111')
+----
+::111
+
+query T
+SELECT inet('192.168.0.2')
+----
+192.168.0.2
+
+query T
+SELECT inet('::ffff:192.168.0.1/24')
+----
+::ffff:192.168.0.1/24

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1041,6 +1041,22 @@ var regularBuiltins = map[string]builtinDefinition{
 		},
 	),
 
+	"inet": makeBuiltin(defProps(),
+		tree.Overload{
+			Types:      tree.ArgTypes{{"val", types.String}},
+			ReturnType: tree.FixedReturnType(types.INet),
+			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				inet, err := eval.PerformCast(ctx, args[0], types.INet)
+				if err != nil {
+					return nil, pgerror.WithCandidateCode(err, pgcode.InvalidTextRepresentation)
+				}
+				return inet, nil
+			},
+			Info:       "If possible, converts input to that of type inet.",
+			Volatility: volatility.Immutable,
+		},
+	),
+
 	"from_ip": makeBuiltin(defProps(),
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.Bytes}},


### PR DESCRIPTION
Release note (sql change):
The inet function has been added to support the conversion of a supplied type to that of the inet
type family. If the conversion fails a SQL error will be output.

Closes #82052.