### PR TITLE
build: allow overriding TESTS for roachtest CI job

### DIFF
--- a/build/teamcity/util/roachtest_util.sh
+++ b/build/teamcity/util/roachtest_util.sh
@@ -56,7 +56,7 @@ trap upload_stats EXIT
 # Set up the parameters for the roachtest invocation.
 PARALLELISM=16
 CPUQUOTA=1024
-TESTS=""
+TESTS="${TESTS-}"
 case "${CLOUD}" in
   gce)
     ;;


### PR DESCRIPTION
This allows us to invoke the roachtest CI jobs with an overridden TESTS
variable.

Release note: None
