### PR TITLE
sql: fix prepared statement query summary

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -454,6 +454,7 @@ func (ex *connExecutor) execStmtInOpenState(
 		stmt.Prepared = ps
 		stmt.ExpectedTypes = ps.Columns
 		stmt.StmtNoConstants = ps.StatementNoConstants
+		stmt.StmtSummary = ps.StatementSummary
 		res.ResetStmtType(ps.AST)
 
 		if e.DiscardRows {

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -509,6 +509,43 @@ func TestAppNameStatisticsInitialization(t *testing.T) {
 	}
 }
 
+func TestPrepareStatisticsMetadata(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: true})
+	defer s.Stopper().Stop(context.Background())
+	defer sqlDB.Close()
+
+	// PREPARE a prepared statement.
+	stmt, err := sqlDB.Prepare("SELECT $1::int")
+	require.NoError(t, err)
+
+	// EXECUTE the prepared statement
+	_, err = stmt.Exec(3)
+	require.NoError(t, err)
+
+	// Verify that query and querySummary are equal in crdb_internal.statement_statistics.metadata.
+	rows, err := sqlDB.Query(`SELECT metadata->>'query', metadata->>'querySummary' FROM crdb_internal.statement_statistics WHERE metadata->>'query' LIKE 'SELECT $1::INT8'`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	var query, summary string
+	for rows.Next() {
+		if err := rows.Scan(&query, &summary); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(query) < 1 {
+		t.Fatal("unable to retrieve query metadata")
+	}
+	if query != summary {
+		t.Fatalf("query is not consistent with querySummary")
+	}
+}
+
 func TestQueryProgress(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -67,8 +67,7 @@ type PreparedStatement struct {
 	createdAt time.Time
 	// origin is the protocol in which this prepare statement was created.
 	// Used for reporting on `pg_prepared_statements`.
-	origin           PreparedStatementOrigin
-	StatementSummary string
+	origin PreparedStatementOrigin
 }
 
 // MemoryEstimate returns a rough estimate of the PreparedStatement's memory

--- a/pkg/sql/querycache/prepared_statement.go
+++ b/pkg/sql/querycache/prepared_statement.go
@@ -30,6 +30,9 @@ type PrepareMetadata struct {
 	// suitable for recording in statement statistics.
 	StatementNoConstants string
 
+	// StatementSummary is a summarized version of the query.
+	StatementSummary string
+
 	// Provides TypeHints and Types fields which contain placeholder typing
 	// information.
 	tree.PlaceholderTypesInfo


### PR DESCRIPTION
This commit sets the StmtSummary metadata field for prepared
statements to the StatementSummary value in the prepared statement
metadata for prepared statements at execution.

Fixes #79152.

Release note (bug fix): Previously, the querySummary metadata field in
the crdb_internal.statement_statistics table was inconsistent with the
query metadata field for executed prepared statements. These fields
are now consistent for prepared statements.