### PR TITLE
server: return non-live, live info per table

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -5206,6 +5206,9 @@ a table.
 | configure_zone_statement | [string](#cockroach.server.serverpb.TableDetailsResponse-string) |  | configure_zone_statement is the output of "SHOW ZONE CONFIGURATION FOR TABLE" for this table. It is a SQL statement that would re-configure the table's current zone if executed. | [reserved](#support-status) |
 | stats_last_created_at | [google.protobuf.Timestamp](#cockroach.server.serverpb.TableDetailsResponse-google.protobuf.Timestamp) |  | stats_last_created_at is the time at which statistics were last created. | [reserved](#support-status) |
 | has_index_recommendations | [bool](#cockroach.server.serverpb.TableDetailsResponse-bool) |  | has_index_recommendations notifies if the there are index recommendations on this table. | [reserved](#support-status) |
+| data_total_bytes | [int64](#cockroach.server.serverpb.TableDetailsResponse-int64) |  | data_total_bytes is the size in bytes of live and non-live data on the table. | [reserved](#support-status) |
+| data_live_bytes | [int64](#cockroach.server.serverpb.TableDetailsResponse-int64) |  | data_live_bytes is the size in bytes of live (non MVCC) data on the table. | [reserved](#support-status) |
+| data_live_percentage | [float](#cockroach.server.serverpb.TableDetailsResponse-float) |  | data_live_percentage is the percentage of live (non MVCC) data on the table. | [reserved](#support-status) |
 
 
 

--- a/docs/generated/swagger/spec.json
+++ b/docs/generated/swagger/spec.json
@@ -1523,6 +1523,24 @@
           "type": "string",
           "x-go-name": "CreateTableStatement"
         },
+        "data_live_bytes": {
+          "description": "data_live_bytes is the size in bytes of live (non MVCC) data on the table.",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "DataLiveBytes"
+        },
+        "data_live_percentage": {
+          "description": "data_live_percentage is the percentage of live (non MVCC) data on the table.",
+          "type": "number",
+          "format": "float",
+          "x-go-name": "DataLivePercentage"
+        },
+        "data_total_bytes": {
+          "description": "data_total_bytes is the size in bytes of live and non-live data on the table.",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "DataTotalBytes"
+        },
         "descriptor_id": {
           "description": "descriptor_id is an identifier used to uniquely identify this table.\nIt can be used to find events pertaining to this table by filtering on\nthe 'target_id' field of events.",
           "type": "integer",

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -218,6 +218,12 @@ message TableDetailsResponse {
   // has_index_recommendations notifies if the there are index recommendations
   // on this table.
   bool has_index_recommendations = 11;
+  // data_total_bytes is the size in bytes of live and non-live data on the table.
+  int64 data_total_bytes = 12;
+  // data_live_bytes is the size in bytes of live (non MVCC) data on the table.
+  int64 data_live_bytes = 13;
+  // data_live_percentage is the percentage of live (non MVCC) data on the table.
+  float data_live_percentage = 14;
 }
 
 // TableStatsRequest is a request for detailed, computationally expensive


### PR DESCRIPTION
This commit adds 3 new parameter to the table
details endpoint:
- dataTotalBytes
- dataNonLiveBytes
- dataNonLivePercentage

Partially addresses #82617

Release note (api change): Add information about total bytes,
non live (MVCC) bytes and non live (MVCC) percentage to
Table Details endpoint.