### PR TITLE
sql: Use one BytesMonitor for all IE created by IEFactory 

### DIFF
--- a/pkg/ccl/serverccl/role_authentication_test.go
+++ b/pkg/ccl/serverccl/role_authentication_test.go
@@ -44,11 +44,10 @@ func TestVerifyPassword(t *testing.T) {
 	)
 	defer s.Stopper().Stop(ctx)
 
+	mon := sql.MakeInternalExecutorMemMonitor(sql.MemoryMetrics{}, s.ClusterSettings())
+	mon.StartNoReserved(ctx, s.(*server.TestServer).Server.PGServer().SQLServer.GetBytesMonitor())
 	ie := sql.MakeInternalExecutor(
-		context.Background(),
-		s.(*server.TestServer).Server.PGServer().SQLServer,
-		sql.MemoryMetrics{},
-		s.ExecutorConfig().(sql.ExecutorConfig).Settings,
+		s.(*server.TestServer).Server.PGServer().SQLServer, sql.MemoryMetrics{}, mon,
 	)
 
 	ts := s.(*server.TestServer)

--- a/pkg/ccl/sqlproxyccl/backend_dialer_test.go
+++ b/pkg/ccl/sqlproxyccl/backend_dialer_test.go
@@ -44,6 +44,10 @@ func TestBackendDialTLS(t *testing.T) {
 		defer sql.Stopper().Stop(ctx)
 
 		conn, err := BackendDial(startupMsg, sql.ServingSQLAddr(), tlsConfig)
+		defer func() {
+			_ = conn.Close()
+		}()
+
 		require.NoError(t, err)
 		require.NotNil(t, conn)
 	})

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -353,6 +353,7 @@ go_test(
         "servemode_test.go",
         "server_http_test.go",
         "server_import_ts_test.go",
+        "server_internal_executor_factory_test.go",
         "server_systemlog_gc_test.go",
         "server_test.go",
         "settings_cache_test.go",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1012,7 +1012,10 @@ func (s *Server) PreStart(ctx context.Context) error {
 	// Initialize the external storage builders configuration params now that the
 	// engines have been created. The object can be used to create ExternalStorage
 	// objects hereafter.
-	fileTableInternalExecutor := sql.MakeInternalExecutor(ctx, s.PGServer().SQLServer, sql.MemoryMetrics{}, s.st)
+	ieMon := sql.MakeInternalExecutorMemMonitor(sql.MemoryMetrics{}, s.ClusterSettings())
+	ieMon.StartNoReserved(ctx, s.PGServer().SQLServer.GetBytesMonitor())
+	s.stopper.AddCloser(stop.CloserFn(func() { ieMon.Stop(ctx) }))
+	fileTableInternalExecutor := sql.MakeInternalExecutor(s.PGServer().SQLServer, sql.MemoryMetrics{}, ieMon)
 	s.externalStorageBuilder.init(
 		ctx,
 		s.cfg.ExternalIODirConfig,

--- a/pkg/server/server_internal_executor_factory_test.go
+++ b/pkg/server/server_internal_executor_factory_test.go
@@ -1,0 +1,45 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInternalExecutorClearsMonitorMemory(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	mon := s.(*TestServer).sqlServer.internalExecutorFactoryMemMonitor
+	ief := s.ExecutorConfig().(sql.ExecutorConfig).InternalExecutorFactory
+	sessionData := sql.NewFakeSessionData(&s.ClusterSettings().SV)
+	ie := ief(ctx, sessionData)
+	rows, err := ie.QueryIteratorEx(ctx, "test", nil, sessiondata.NodeUserSessionDataOverride, `SELECT 1`)
+	require.NoError(t, err)
+	require.Greater(t, mon.AllocBytes(), int64(0))
+	err = rows.Close()
+	require.NoError(t, err)
+	s.Stopper().Stop(ctx)
+	require.Equal(t, mon.AllocBytes(), int64(0))
+}

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -176,6 +176,12 @@ type SQLServer struct {
 	// connection management tools learning this status from health checks.
 	// This is set to true when the server has started accepting client conns.
 	isReady syncutil.AtomicBool
+
+	// internalExecutorFactoryMemMonitor is the memory monitor corresponding to the
+	// InternalExecutorFactory singleton. It only gets closed when
+	// Server is closed. Every InternalExecutor created via the factory
+	// uses this memory monitor.
+	internalExecutorFactoryMemMonitor *mon.BytesMonitor
 }
 
 // sqlServerOptionalKVArgs are the arguments supplied to newSQLServer which are
@@ -909,6 +915,19 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	distSQLServer.ServerConfig.SQLStatsController = pgServer.SQLServer.GetSQLStatsController()
 	distSQLServer.ServerConfig.IndexUsageStatsController = pgServer.SQLServer.GetIndexUsageStatsController()
 
+	// We use one BytesMonitor for all InternalExecutor's created by the
+	// ieFactory, this BytesMonitor is never closed.
+	ieFactoryMonitor := mon.NewMonitor(
+		"internal executor factory",
+		mon.MemoryResource,
+		internalMemMetrics.CurBytesCount,
+		internalMemMetrics.MaxBytesHist,
+		-1,            /* use default increment */
+		math.MaxInt64, /* noteworthy */
+		cfg.Settings,
+	)
+	ieFactoryMonitor.StartNoReserved(ctx, pgServer.SQLServer.GetBytesMonitor())
+	cfg.stopper.AddCloser(stop.CloserFn(func() { ieFactoryMonitor.Stop(ctx) }))
 	// Now that we have a pgwire.Server (which has a sql.Server), we can close a
 	// circular dependency between the rowexec.Server and sql.Server and set
 	// SessionBoundInternalExecutorFactory. The same applies for setting a
@@ -916,12 +935,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	ieFactory := func(
 		ctx context.Context, sessionData *sessiondata.SessionData,
 	) sqlutil.InternalExecutor {
-		ie := sql.MakeInternalExecutor(
-			ctx,
-			pgServer.SQLServer,
-			internalMemMetrics,
-			cfg.Settings,
-		)
+		ie := sql.MakeInternalExecutor(pgServer.SQLServer, internalMemMetrics, ieFactoryMonitor)
 		ie.SetSessionData(sessionData)
 		return &ie
 	}
@@ -946,9 +960,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	for _, m := range pgServer.Metrics() {
 		cfg.registry.AddMetricStruct(m)
 	}
-	*cfg.circularInternalExecutor = sql.MakeInternalExecutor(
-		ctx, pgServer.SQLServer, internalMemMetrics, cfg.Settings,
-	)
+	*cfg.circularInternalExecutor = sql.MakeInternalExecutor(pgServer.SQLServer, internalMemMetrics, ieFactoryMonitor)
 	execCfg.InternalExecutor = cfg.circularInternalExecutor
 	stmtDiagnosticsRegistry := stmtdiagnostics.NewRegistry(
 		cfg.circularInternalExecutor,
@@ -1083,36 +1095,37 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	}
 
 	return &SQLServer{
-		ambientCtx:                     cfg.BaseConfig.AmbientCtx,
-		stopper:                        cfg.stopper,
-		sqlIDContainer:                 cfg.nodeIDContainer,
-		pgServer:                       pgServer,
-		distSQLServer:                  distSQLServer,
-		execCfg:                        execCfg,
-		internalExecutor:               cfg.circularInternalExecutor,
-		leaseMgr:                       leaseMgr,
-		blobService:                    blobService,
-		tracingService:                 tracingService,
-		tenantConnect:                  cfg.tenantConnect,
-		sessionRegistry:                cfg.sessionRegistry,
-		closedSessionCache:             cfg.closedSessionCache,
-		jobRegistry:                    jobRegistry,
-		statsRefresher:                 statsRefresher,
-		temporaryObjectCleaner:         temporaryObjectCleaner,
-		internalMemMetrics:             internalMemMetrics,
-		sqlMemMetrics:                  sqlMemMetrics,
-		stmtDiagnosticsRegistry:        stmtDiagnosticsRegistry,
-		sqlLivenessProvider:            cfg.sqlLivenessProvider,
-		sqlInstanceProvider:            cfg.sqlInstanceProvider,
-		metricsRegistry:                cfg.registry,
-		diagnosticsReporter:            reporter,
-		spanconfigMgr:                  spanConfig.manager,
-		spanconfigSQLTranslatorFactory: spanConfig.sqlTranslatorFactory,
-		spanconfigSQLWatcher:           spanConfig.sqlWatcher,
-		settingsWatcher:                settingsWatcher,
-		systemConfigWatcher:            cfg.systemConfigWatcher,
-		isMeta1Leaseholder:             cfg.isMeta1Leaseholder,
-		cfg:                            cfg.BaseConfig,
+		ambientCtx:                        cfg.BaseConfig.AmbientCtx,
+		stopper:                           cfg.stopper,
+		sqlIDContainer:                    cfg.nodeIDContainer,
+		pgServer:                          pgServer,
+		distSQLServer:                     distSQLServer,
+		execCfg:                           execCfg,
+		internalExecutor:                  cfg.circularInternalExecutor,
+		leaseMgr:                          leaseMgr,
+		blobService:                       blobService,
+		tracingService:                    tracingService,
+		tenantConnect:                     cfg.tenantConnect,
+		sessionRegistry:                   cfg.sessionRegistry,
+		closedSessionCache:                cfg.closedSessionCache,
+		jobRegistry:                       jobRegistry,
+		statsRefresher:                    statsRefresher,
+		temporaryObjectCleaner:            temporaryObjectCleaner,
+		internalMemMetrics:                internalMemMetrics,
+		sqlMemMetrics:                     sqlMemMetrics,
+		stmtDiagnosticsRegistry:           stmtDiagnosticsRegistry,
+		sqlLivenessProvider:               cfg.sqlLivenessProvider,
+		sqlInstanceProvider:               cfg.sqlInstanceProvider,
+		metricsRegistry:                   cfg.registry,
+		diagnosticsReporter:               reporter,
+		spanconfigMgr:                     spanConfig.manager,
+		spanconfigSQLTranslatorFactory:    spanConfig.sqlTranslatorFactory,
+		spanconfigSQLWatcher:              spanConfig.sqlWatcher,
+		settingsWatcher:                   settingsWatcher,
+		systemConfigWatcher:               cfg.systemConfigWatcher,
+		isMeta1Leaseholder:                cfg.isMeta1Leaseholder,
+		cfg:                               cfg.BaseConfig,
+		internalExecutorFactoryMemMonitor: ieFactoryMonitor,
 	}, nil
 }
 
@@ -1225,8 +1238,10 @@ func (s *SQLServer) preStart(
 	s.leaseMgr.RefreshLeases(ctx, stopper, s.execCfg.DB)
 	s.leaseMgr.PeriodicallyRefreshSomeLeases(ctx)
 
-	migrationsExecutor := sql.MakeInternalExecutor(
-		ctx, s.pgServer.SQLServer, s.internalMemMetrics, s.execCfg.Settings)
+	ieMon := sql.MakeInternalExecutorMemMonitor(sql.MemoryMetrics{}, s.execCfg.Settings)
+	ieMon.StartNoReserved(ctx, s.pgServer.SQLServer.GetBytesMonitor())
+	s.stopper.AddCloser(stop.CloserFn(func() { ieMon.Stop(ctx) }))
+	migrationsExecutor := sql.MakeInternalExecutor(s.pgServer.SQLServer, s.internalMemMetrics, ieMon)
 	migrationsExecutor.SetSessionData(
 		&sessiondata.SessionData{
 			LocalOnlySessionData: sessiondatapb.LocalOnlySessionData{

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -395,17 +395,20 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 	telemetryLoggingMetrics.Knobs = cfg.TelemetryLoggingTestingKnobs
 	s.TelemetryLoggingMetrics = telemetryLoggingMetrics
 
-	sqlStatsInternalExecutor := MakeInternalExecutor(context.Background(), s, MemoryMetrics{}, cfg.Settings)
+	sqlStatsInternalExecutorMonitor := MakeInternalExecutorMemMonitor(MemoryMetrics{}, s.GetExecutorConfig().Settings)
+	sqlStatsInternalExecutorMonitor.StartNoReserved(context.Background(), s.GetBytesMonitor())
+	sqlStatsInternalExecutor := MakeInternalExecutor(s, MemoryMetrics{}, sqlStatsInternalExecutorMonitor)
 	persistedSQLStats := persistedsqlstats.New(&persistedsqlstats.Config{
-		Settings:         s.cfg.Settings,
-		InternalExecutor: &sqlStatsInternalExecutor,
-		KvDB:             cfg.DB,
-		SQLIDContainer:   cfg.NodeID,
-		JobRegistry:      s.cfg.JobRegistry,
-		Knobs:            cfg.SQLStatsTestingKnobs,
-		FlushCounter:     serverMetrics.StatsMetrics.SQLStatsFlushStarted,
-		FailureCounter:   serverMetrics.StatsMetrics.SQLStatsFlushFailure,
-		FlushDuration:    serverMetrics.StatsMetrics.SQLStatsFlushDuration,
+		Settings:                s.cfg.Settings,
+		InternalExecutor:        &sqlStatsInternalExecutor,
+		InternalExecutorMonitor: sqlStatsInternalExecutorMonitor,
+		KvDB:                    cfg.DB,
+		SQLIDContainer:          cfg.NodeID,
+		JobRegistry:             s.cfg.JobRegistry,
+		Knobs:                   cfg.SQLStatsTestingKnobs,
+		FlushCounter:            serverMetrics.StatsMetrics.SQLStatsFlushStarted,
+		FailureCounter:          serverMetrics.StatsMetrics.SQLStatsFlushFailure,
+		FlushDuration:           serverMetrics.StatsMetrics.SQLStatsFlushDuration,
 	}, memSQLStats)
 
 	s.sqlStats = persistedSQLStats
@@ -642,6 +645,11 @@ func (s *Server) GetStmtStatsLastReset() time.Time {
 // GetExecutorConfig returns this server's executor config.
 func (s *Server) GetExecutorConfig() *ExecutorConfig {
 	return s.cfg
+}
+
+// GetBytesMonitor returns this server's BytesMonitor.
+func (s *Server) GetBytesMonitor() *mon.BytesMonitor {
+	return s.pool
 }
 
 // SetupConn creates a connExecutor for the client connection.
@@ -1117,7 +1125,10 @@ func (ex *connExecutor) close(ctx context.Context, closeType closeType) {
 	}
 
 	if ex.hasCreatedTemporarySchema && !ex.server.cfg.TestingKnobs.DisableTempObjectsCleanupOnSessionExit {
-		ie := MakeInternalExecutor(ctx, ex.server, MemoryMetrics{}, ex.server.cfg.Settings)
+		ieMon := MakeInternalExecutorMemMonitor(MemoryMetrics{}, ex.server.cfg.Settings)
+		ieMon.StartNoReserved(ctx, ex.server.GetBytesMonitor())
+		defer ieMon.Stop(ctx)
+		ie := MakeInternalExecutor(ex.server, MemoryMetrics{}, ieMon)
 		err := cleanupSessionTempObjects(
 			ctx,
 			ex.server.cfg.Settings,

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -404,7 +404,7 @@ func (ep *DummyEvalPlanner) QueryRowEx(
 func (ep *DummyEvalPlanner) QueryIteratorEx(
 	ctx context.Context,
 	opName string,
-	session sessiondata.InternalExecutorOverride,
+	override sessiondata.InternalExecutorOverride,
 	stmt string,
 	qargs ...interface{},
 ) (eval.InternalRows, error) {

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -97,9 +97,21 @@ func (ie *InternalExecutor) WithSyntheticDescriptors(
 
 // MakeInternalExecutor creates an InternalExecutor.
 func MakeInternalExecutor(
-	ctx context.Context, s *Server, memMetrics MemoryMetrics, settings *cluster.Settings,
+	s *Server, memMetrics MemoryMetrics, monitor *mon.BytesMonitor,
 ) InternalExecutor {
-	monitor := mon.NewMonitor(
+	return InternalExecutor{
+		s:          s,
+		mon:        monitor,
+		memMetrics: memMetrics,
+	}
+}
+
+// MakeInternalExecutorMemMonitor creates and starts memory monitor for an
+// InternalExecutor.
+func MakeInternalExecutorMemMonitor(
+	memMetrics MemoryMetrics, settings *cluster.Settings,
+) *mon.BytesMonitor {
+	return mon.NewMonitor(
 		"internal SQL executor",
 		mon.MemoryResource,
 		memMetrics.CurBytesCount,
@@ -108,12 +120,6 @@ func MakeInternalExecutor(
 		math.MaxInt64, /* noteworthy */
 		settings,
 	)
-	monitor.StartNoReserved(ctx, s.pool)
-	return InternalExecutor{
-		s:          s,
-		mon:        monitor,
-		memMetrics: memMetrics,
-	}
 }
 
 // SetSessionData binds the session variables that will be used by queries

--- a/pkg/sql/internal_test.go
+++ b/pkg/sql/internal_test.go
@@ -149,11 +149,10 @@ func TestInternalFullTableScan(t *testing.T) {
 		"pq: query `SELECT * FROM t` contains a full table/index scan which is explicitly disallowed",
 		err.Error())
 
+	mon := sql.MakeInternalExecutorMemMonitor(sql.MemoryMetrics{}, s.ClusterSettings())
+	mon.StartNoReserved(ctx, s.(*server.TestServer).Server.PGServer().SQLServer.GetBytesMonitor())
 	ie := sql.MakeInternalExecutor(
-		ctx,
-		s.(*server.TestServer).Server.PGServer().SQLServer,
-		sql.MemoryMetrics{},
-		s.ExecutorConfig().(sql.ExecutorConfig).Settings,
+		s.(*server.TestServer).Server.PGServer().SQLServer, sql.MemoryMetrics{}, mon,
 	)
 	ie.SetSessionData(
 		&sessiondata.SessionData{
@@ -189,13 +188,11 @@ func TestInternalStmtFingerprintLimit(t *testing.T) {
 	_, err = db.Exec("SET CLUSTER SETTING sql.metrics.max_mem_stmt_fingerprints = 0;")
 	require.NoError(t, err)
 
+	mon := sql.MakeInternalExecutorMemMonitor(sql.MemoryMetrics{}, s.ClusterSettings())
+	mon.StartNoReserved(ctx, s.(*server.TestServer).Server.PGServer().SQLServer.GetBytesMonitor())
 	ie := sql.MakeInternalExecutor(
-		ctx,
-		s.(*server.TestServer).Server.PGServer().SQLServer,
-		sql.MemoryMetrics{},
-		s.ExecutorConfig().(sql.ExecutorConfig).Settings,
+		s.(*server.TestServer).Server.PGServer().SQLServer, sql.MemoryMetrics{}, mon,
 	)
-
 	_, err = ie.Exec(ctx, "stmt-exceeds-fingerprint-limit", nil, "SELECT 1")
 	require.NoError(t, err)
 }
@@ -322,11 +319,10 @@ func TestSessionBoundInternalExecutor(t *testing.T) {
 	}
 
 	expDB := "foo"
+	mon := sql.MakeInternalExecutorMemMonitor(sql.MemoryMetrics{}, s.ClusterSettings())
+	mon.StartNoReserved(ctx, s.(*server.TestServer).Server.PGServer().SQLServer.GetBytesMonitor())
 	ie := sql.MakeInternalExecutor(
-		ctx,
-		s.(*server.TestServer).Server.PGServer().SQLServer,
-		sql.MemoryMetrics{},
-		s.ExecutorConfig().(sql.ExecutorConfig).Settings,
+		s.(*server.TestServer).Server.PGServer().SQLServer, sql.MemoryMetrics{}, mon,
 	)
 	ie.SetSessionData(
 		&sessiondata.SessionData{
@@ -390,11 +386,10 @@ func TestInternalExecAppNameInitialization(t *testing.T) {
 		s, _, _ := serverutils.StartServer(t, params)
 		defer s.Stopper().Stop(context.Background())
 
+		mon := sql.MakeInternalExecutorMemMonitor(sql.MemoryMetrics{}, s.ClusterSettings())
+		mon.StartNoReserved(context.Background(), s.(*server.TestServer).Server.PGServer().SQLServer.GetBytesMonitor())
 		ie := sql.MakeInternalExecutor(
-			context.Background(),
-			s.(*server.TestServer).Server.PGServer().SQLServer,
-			sql.MemoryMetrics{},
-			s.ExecutorConfig().(sql.ExecutorConfig).Settings,
+			s.(*server.TestServer).Server.PGServer().SQLServer, sql.MemoryMetrics{}, mon,
 		)
 		ie.SetSessionData(
 			&sessiondata.SessionData{

--- a/pkg/sql/sem/builtins/show_create_all_schemas_builtin.go
+++ b/pkg/sql/sem/builtins/show_create_all_schemas_builtin.go
@@ -20,13 +20,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/errors"
 )
 
 // getSchemaIDs returns the set of schema ids from
 // crdb_internal.show_create_all_schemas for a specified database.
 func getSchemaIDs(
 	ctx context.Context, evalPlanner eval.Planner, txn *kv.Txn, dbName string, acc *mon.BoundAccount,
-) ([]int64, error) {
+) (schemaIDs []int64, retErr error) {
 	query := fmt.Sprintf(`
 		SELECT descriptor_id
 		FROM %s.crdb_internal.create_schema_statements
@@ -42,8 +43,9 @@ func getSchemaIDs(
 	if err != nil {
 		return nil, err
 	}
-
-	var schemaIDs []int64
+	defer func() {
+		retErr = errors.CombineErrors(retErr, it.Close())
+	}()
 
 	var ok bool
 	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {

--- a/pkg/sql/sem/builtins/show_create_all_tables_builtin.go
+++ b/pkg/sql/sem/builtins/show_create_all_tables_builtin.go
@@ -100,6 +100,9 @@ func getTopologicallySortedTableIDs(
 		}
 
 		dependsOnIDs[tid] = refs
+		if err := it.Close(); err != nil {
+			return nil, err
+		}
 	}
 
 	// First sort by ids to guarantee stable output.
@@ -149,7 +152,7 @@ func getTopologicallySortedTableIDs(
 // crdb_internal.show_create_all_tables for a specified database.
 func getTableIDs(
 	ctx context.Context, evalPlanner eval.Planner, txn *kv.Txn, dbName string, acc *mon.BoundAccount,
-) ([]int64, error) {
+) (tableIDs []int64, retErr error) {
 	query := fmt.Sprintf(`
 		SELECT descriptor_id
 		FROM %s.crdb_internal.create_statements
@@ -167,8 +170,9 @@ func getTableIDs(
 	if err != nil {
 		return nil, err
 	}
-
-	var tableIDs []int64
+	defer func() {
+		retErr = errors.CombineErrors(retErr, it.Close())
+	}()
 
 	var ok bool
 	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -323,13 +323,7 @@ type Planner interface {
 	//
 	// The fields set in session that are set override the respective fields if they
 	// have previously been set through SetSessionData().
-	QueryIteratorEx(
-		ctx context.Context,
-		opName string,
-		override sessiondata.InternalExecutorOverride,
-		stmt string,
-		qargs ...interface{},
-	) (InternalRows, error)
+	QueryIteratorEx(ctx context.Context, opName string, override sessiondata.InternalExecutorOverride, stmt string, qargs ...interface{}) (InternalRows, error)
 }
 
 // InternalRows is an iterator interface that's exposed by the internal

--- a/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//pkg/sql/sqlutil",
         "//pkg/util/log",
         "//pkg/util/metric",
+        "//pkg/util/mon",
         "//pkg/util/stop",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",


### PR DESCRIPTION
Previously InternalExecutor's created via IEFactory would
create a monitor that would never be closed.

Now we have one monitor for all IEs that is closed with server
is closed.

Release note: None