### PR TITLE
kvstreamer: remove some redundant function calls

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/streamer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_test.go
@@ -47,6 +47,7 @@ func getStreamer(
 		limitBytes,
 		acc,
 		nil, /* batchRequestsIssued */
+		lock.None,
 	)
 }
 
@@ -98,6 +99,7 @@ func TestStreamerLimitations(t *testing.T) {
 				math.MaxInt64, /* limitBytes */
 				nil,           /* acc */
 				nil,           /* batchRequestsIssued */
+				lock.None,
 			)
 		})
 	})

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -149,6 +149,7 @@ func NewStreamingKVFetcher(
 		streamerBudgetLimit,
 		streamerBudgetAcc,
 		&batchRequestsIssued,
+		getKeyLockingStrength(lockStrength),
 	)
 	mode := kvstreamer.OutOfOrder
 	if maintainOrdering {


### PR DESCRIPTION
This commit refactors the logic of processing the BatchResponse in order
to avoid getting the "inner" request for each response - it is
sufficient for us to do a type switch on the response itself.

I did run the microbenchmarks, and they showed no difference, but
I believe this change should be beneficial.

Release note: None