### PR TITLE
kvserver: allow voter demoting to get a lease, in case there's an incoming voter

### DIFF
--- a/pkg/kv/kvclient/kvcoord/replica_slice.go
+++ b/pkg/kv/kvclient/kvcoord/replica_slice.go
@@ -81,7 +81,7 @@ func NewReplicaSlice(
 		}
 	}
 	canReceiveLease := func(rDesc roachpb.ReplicaDescriptor) bool {
-		if err := roachpb.CheckCanReceiveLease(rDesc, desc.Replicas()); err != nil {
+		if err := roachpb.CheckCanReceiveLease(rDesc, desc.Replicas(), true /* leaseHolderRemovalAllowed */); err != nil {
 			return false
 		}
 		return true

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -1479,8 +1479,9 @@ func (a *Allocator) ValidLeaseTargets(
 ) []roachpb.ReplicaDescriptor {
 	candidates := make([]roachpb.ReplicaDescriptor, 0, len(existing))
 	replDescs := roachpb.MakeReplicaSet(existing)
+	lhRemovalAllowed := a.StorePool.St.Version.IsActive(ctx, clusterversion.EnableLeaseHolderRemoval)
 	for i := range existing {
-		if err := roachpb.CheckCanReceiveLease(existing[i], replDescs); err != nil {
+		if err := roachpb.CheckCanReceiveLease(existing[i], replDescs, lhRemovalAllowed); err != nil {
 			continue
 		}
 		// If we're not allowed to include the current replica, remove it from

--- a/pkg/kv/kvserver/batcheval/cmd_lease_request.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_request.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/readsummary/rspb"
@@ -67,9 +68,13 @@ func RequestLease(
 		Requested: args.Lease,
 	}
 
+	lhRemovalAllowed :=
+		cArgs.EvalCtx.ClusterSettings().Version.IsActive(ctx, clusterversion.EnableLeaseHolderRemoval)
 	// If this check is removed at some point, the filtering of learners on the
 	// sending side would have to be removed as well.
-	if err := roachpb.CheckCanReceiveLease(args.Lease.Replica, cArgs.EvalCtx.Desc().Replicas()); err != nil {
+	if err := roachpb.CheckCanReceiveLease(args.Lease.Replica, cArgs.EvalCtx.Desc().Replicas(),
+		lhRemovalAllowed,
+	); err != nil {
 		rErr.Message = err.Error()
 		return newFailedLeaseTrigger(false /* isTransfer */), rErr
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_lease_transfer.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_transfer.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/readsummary/rspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
@@ -76,9 +77,13 @@ func TransferLease(
 	newLease := args.Lease
 	args.Lease = roachpb.Lease{} // prevent accidental use below
 
+	lhRemovalAllowed := cArgs.EvalCtx.ClusterSettings().Version.IsActive(ctx,
+		clusterversion.EnableLeaseHolderRemoval)
 	// If this check is removed at some point, the filtering of learners on the
 	// sending side would have to be removed as well.
-	if err := roachpb.CheckCanReceiveLease(newLease.Replica, cArgs.EvalCtx.Desc().Replicas()); err != nil {
+	if err := roachpb.CheckCanReceiveLease(
+		newLease.Replica, cArgs.EvalCtx.Desc().Replicas(), lhRemovalAllowed,
+	); err != nil {
 		return newFailedLeaseTrigger(true /* isTransfer */), err
 	}
 

--- a/pkg/kv/kvserver/replica_proposal_buf_test.go
+++ b/pkg/kv/kvserver/replica_proposal_buf_test.go
@@ -177,7 +177,9 @@ func (t *testProposer) ownsValidLeaseRLocked(ctx context.Context, now hlc.ClockT
 	return t.ownsValidLease
 }
 
-func (t *testProposer) leaderStatusRLocked(raftGroup proposerRaft) rangeLeaderInfo {
+func (t *testProposer) leaderStatusRLocked(
+	ctx context.Context, raftGroup proposerRaft,
+) rangeLeaderInfo {
 	lead := raftGroup.Status().Lead
 	leaderKnown := lead != raft.None
 	var leaderRep roachpb.ReplicaID
@@ -196,7 +198,7 @@ func (t *testProposer) leaderStatusRLocked(raftGroup proposerRaft) rangeLeaderIn
 			rngDesc := roachpb.RangeDescriptor{
 				InternalReplicas: []roachpb.ReplicaDescriptor{repDesc},
 			}
-			err := roachpb.CheckCanReceiveLease(repDesc, rngDesc.Replicas())
+			err := roachpb.CheckCanReceiveLease(repDesc, rngDesc.Replicas(), true)
 			leaderEligibleForLease = err == nil
 		} else {
 			// This matches replicaProposed.leaderStatusRLocked().

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -363,26 +363,38 @@ func (r *Replica) propose(
 		// replicas to 4, and if region1 goes down, we loose a quorum. Instead,
 		// we move to a joint config where v1 (VOTER_DEMOTING_LEARNER) transfer the
 		// lease to v4 (VOTER_INCOMING) directly.
+		//
+		// Our implementation assumes that the intention of the caller is for the
+		// VOTER_INCOMING node to be the replacement replica, and hence get the
+		// lease. We therefore don't dynamically select a lease target during the
+		// joint config, and hand it to the VOTER_INCOMING node. This means,
+		// however, that we only allow a VOTER_DEMOTING to have the lease in a
+		// joint configuration, when there's also a VOTER_INCOMING node (that
+		// will be used as a target for the lease transfer). Otherwise, the caller
+		// is expected to shed the lease before entering a joint configuration.
 		// See also https://github.com/cockroachdb/cockroach/issues/67740.
-		replID := r.ReplicaID()
-		rDesc, ok := p.command.ReplicatedEvalResult.State.Desc.GetReplicaDescriptorByID(replID)
-		hasVoterIncoming := p.command.ReplicatedEvalResult.State.Desc.ContainsVoterIncoming()
-		lhRemovalAllowed := hasVoterIncoming && r.store.cfg.Settings.Version.IsActive(ctx,
-			clusterversion.EnableLeaseHolderRemoval)
-		// Previously, we were not allowed to enter a joint config where the
-		// leaseholder is being removed (i.e., not a full voter). In the new version
-		// we're allowed to enter such a joint config (if it has a VOTER_INCOMING),
-		// but not to exit it in this state, i.e., the leaseholder must be some
-		// kind of voter in the next new config (potentially VOTER_DEMOTING).
-		if !ok ||
-			(lhRemovalAllowed && !rDesc.IsAnyVoter()) ||
-			(!lhRemovalAllowed && !rDesc.IsVoterNewConfig()) {
-			err := errors.Mark(errors.Newf("received invalid ChangeReplicasTrigger %s to remove "+
-				"self (leaseholder); hasVoterIncoming: %v, lhRemovalAllowed: %v; proposed descriptor: %v",
-				crt, hasVoterIncoming, lhRemovalAllowed, p.command.ReplicatedEvalResult.State.Desc),
-				errMarkInvalidReplicationChange)
-			log.Errorf(p.ctx, "%v", err)
+		lhRemovalAllowed := r.store.cfg.Settings.Version.IsActive(
+			ctx, clusterversion.EnableLeaseHolderRemoval)
+		lhDescriptor, err := r.GetReplicaDescriptor()
+		if err != nil {
 			return roachpb.NewError(err)
+		}
+		proposedDesc := p.command.ReplicatedEvalResult.State.Desc
+		// This is a reconfiguration command, we make sure the proposed
+		// config is legal w.r.t. the current leaseholder: we now allow the
+		// leaseholder to be a VOTER_DEMOTING as long as there is a VOTER_INCOMING.
+		// Otherwise, the leaseholder must be a full voter in the target config.
+		// This check won't allow exiting the joint config before the lease is
+		// transferred away. The previous leaseholder is a LEARNER in the target config,
+		// and therefore shouldn't continue holding the lease.
+		if err := roachpb.CheckCanReceiveLease(
+			lhDescriptor, proposedDesc.Replicas(), lhRemovalAllowed,
+		); err != nil {
+			e := errors.Mark(errors.Wrapf(err, "received invalid ChangeReplicasTrigger %s to "+
+				"remove self (leaseholder); lhRemovalAllowed: %v; proposed descriptor: %v", crt,
+				lhRemovalAllowed, proposedDesc), errMarkInvalidReplicationChange)
+			log.Errorf(p.ctx, "%v", e)
+			return roachpb.NewError(e)
 		}
 	} else if p.command.ReplicatedEvalResult.AddSSTable != nil {
 		log.VEvent(p.ctx, 4, "sideloadable proposal detected")

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -322,16 +322,6 @@ func (r *RangeDescriptor) GetReplicaDescriptorByID(replicaID ReplicaID) (Replica
 	return r.Replicas().GetReplicaDescriptorByID(replicaID)
 }
 
-// ContainsVoterIncoming returns true if the descriptor contains a VOTER_INCOMING replica.
-func (r *RangeDescriptor) ContainsVoterIncoming() bool {
-	for _, repDesc := range r.Replicas().Descriptors() {
-		if repDesc.GetType() == VOTER_INCOMING {
-			return true
-		}
-	}
-	return false
-}
-
 // IsInitialized returns false if this descriptor represents an
 // uninitialized range.
 // TODO(bdarnell): unify this with Validate().


### PR DESCRIPTION
Fixes #83687.

It is possible that we've entered a joint config where the leaseholder is being
replaced with an incoming voter. We try to transfer the lease away, but this fails.
In this case, we need the demoted voter to re-aquire the lease, as it might be an epoch
based lease, that doesn't expire. Otherwise we might be stuck without anyone else getting
the lease (the original leaseholder will be in the PROSCRIBED state, repeatedly trying to 
re-aquire the lease, but will fail since its a VOTER_DEMOTING_LEARNER).

Release note (bug fix): Fixes a critical bug (#83687) introduced in 22.1.0 where
failure to transfer a lease in the joint config may result in range unavailability. The fix
allows the original leaseholder to re-aquire the lease so that lease transfer can be retried.