### PR TITLE
colbuilder: vectorizing rendering on top of wrapped processors

### DIFF
--- a/pkg/sql/execinfrapb/flow_diagram.go
+++ b/pkg/sql/execinfrapb/flow_diagram.go
@@ -460,23 +460,15 @@ func (post *PostProcessSpec) summary() []string {
 	var res []string
 	if post.Projection {
 		outputColumns := "None"
-		outputCols := post.OutputColumns
-		if post.OriginalOutputColumns != nil {
-			outputCols = post.OriginalOutputColumns
-		}
-		if len(outputCols) > 0 {
-			outputColumns = colListStr(outputCols)
+		if len(post.OutputColumns) > 0 {
+			outputColumns = colListStr(post.OutputColumns)
 		}
 		res = append(res, fmt.Sprintf("Out: %s", outputColumns))
 	}
-	renderExprs := post.RenderExprs
-	if post.OriginalRenderExprs != nil {
-		renderExprs = post.OriginalRenderExprs
-	}
-	if len(renderExprs) > 0 {
+	if len(post.RenderExprs) > 0 {
 		var buf bytes.Buffer
 		buf.WriteString("Render: ")
-		for i, expr := range renderExprs {
+		for i, expr := range post.RenderExprs {
 			if i > 0 {
 				buf.WriteString(", ")
 			}

--- a/pkg/sql/execinfrapb/processors_base.proto
+++ b/pkg/sql/execinfrapb/processors_base.proto
@@ -38,22 +38,12 @@ message PostProcessSpec {
   // Can only be set if projection is true. Cannot be set at the same time with
   // render expressions.
   repeated uint32 output_columns = 3 [packed = true];
-  // OriginalOutputColumns will be set if OutputColumns are destructively
-  // modified during the vectorized flow setup. This field is only used for
-  // population of the DistSQL diagrams, and if set, it takes precedence over
-  // OutputColumns.
-  repeated uint32 original_output_columns = 7 [packed = true];
 
   // If set, the output is the result of rendering these expressions. The
   // expressions reference the internal columns of the processor.
   //
   // Cannot be set at the same time with output columns.
   repeated Expression render_exprs = 4 [(gogoproto.nullable) = false];
-  // OriginalRenderExprs will be set if RenderExprs are destructively
-  // modified during the vectorized flow setup. This field is only used for
-  // population of the DistSQL diagrams, and if set, it takes precedence over
-  // RenderExprs.
-  repeated Expression original_render_exprs = 8 [(gogoproto.nullable) = false];
 
   // If nonzero, the first <offset> rows will be suppressed.
   optional uint64 offset = 5 [(gogoproto.nullable) = false];
@@ -62,7 +52,7 @@ message PostProcessSpec {
   // suppressed by <offset>, if any, do not count towards this limit.
   optional uint64 limit = 6 [(gogoproto.nullable) = false];
 
-  reserved 1;
+  reserved 1, 7, 8;
 }
 
 message Columns {

--- a/pkg/sql/opt/exec/execbuilder/testdata/tpch_vec
+++ b/pkg/sql/opt/exec/execbuilder/testdata/tpch_vec
@@ -20579,12 +20579,14 @@ EXPLAIN (VEC) SELECT l_orderkey, sum(l_extendedprice * (1 - l_discount)) AS reve
 └ Node 1
   └ *colexec.topKSorter
     └ *colexec.hashAggregator
-      └ *rowexec.joinReader
-        └ *colexecjoin.hashJoiner
-          ├ *colexecsel.selLTInt64Int64ConstOp
-          │ └ *colfetcher.ColBatchScan
-          └ *colexecsel.selEQBytesBytesConstOp
-            └ *colfetcher.ColBatchScan
+      └ *colexecproj.projMultFloat64Float64Op
+        └ *colexecprojconst.projMinusFloat64ConstFloat64Op
+          └ *rowexec.joinReader
+            └ *colexecjoin.hashJoiner
+              ├ *colexecsel.selLTInt64Int64ConstOp
+              │ └ *colfetcher.ColBatchScan
+              └ *colexecsel.selEQBytesBytesConstOp
+                └ *colfetcher.ColBatchScan
 
 # Query 4
 query T
@@ -20759,11 +20761,13 @@ EXPLAIN (VEC) SELECT ps_partkey, sum(ps_supplycost * ps_availqty::float) AS valu
       └ *colexecbase.castOpNullAny
         └ *colexecbase.constNullOp
           └ *colexec.hashAggregator
-            └ *rowexec.joinReader
-              └ *rowexec.joinReader
+            └ *colexecproj.projMultFloat64Float64Op
+              └ *colexecbase.castIntFloatOp
                 └ *rowexec.joinReader
-                  └ *colexecsel.selEQBytesBytesConstOp
-                    └ *colfetcher.ColBatchScan
+                  └ *rowexec.joinReader
+                    └ *rowexec.joinReader
+                      └ *colexecsel.selEQBytesBytesConstOp
+                        └ *colfetcher.ColBatchScan
 
 # Query 12
 query T
@@ -20773,12 +20777,30 @@ EXPLAIN (VEC) SELECT l_shipmode, sum(CASE WHEN o_orderpriority = '1-URGENT' or o
 └ Node 1
   └ *colexec.sortOp
     └ *colexec.hashAggregator
-      └ *rowexec.joinReader
-        └ *colexecsel.selLTInt64Int64Op
-          └ *colexecsel.selLTInt64Int64Op
-            └ *colexec.selectInOpBytes
-              └ *colfetcher.ColIndexJoin
-                └ *colfetcher.ColBatchScan
+      └ *colexec.caseOp
+        ├ *colexec.bufferOp
+        │ └ *colexec.caseOp
+        │   ├ *colexec.bufferOp
+        │   │ └ *rowexec.joinReader
+        │   │   └ *colexecsel.selLTInt64Int64Op
+        │   │     └ *colexecsel.selLTInt64Int64Op
+        │   │       └ *colexec.selectInOpBytes
+        │   │         └ *colfetcher.ColIndexJoin
+        │   │           └ *colfetcher.ColBatchScan
+        │   ├ *colexecbase.constInt64Op
+        │   │ └ *colexec.orProjOp
+        │   │   ├ *colexec.bufferOp
+        │   │   ├ *colexecprojconst.projEQBytesBytesConstOp
+        │   │   └ *colexecprojconst.projEQBytesBytesConstOp
+        │   └ *colexecbase.constInt64Op
+        │     └ *colexec.bufferOp
+        ├ *colexecbase.constInt64Op
+        │ └ *colexec.andProjOp
+        │   ├ *colexec.bufferOp
+        │   ├ *colexecprojconst.projNEBytesBytesConstOp
+        │   └ *colexecprojconst.projNEBytesBytesConstOp
+        └ *colexecbase.constInt64Op
+          └ *colexec.bufferOp
 
 # Query 13
 query T
@@ -20993,12 +21015,15 @@ EXPLAIN (VEC) SELECT cntrycode, count(*) AS numcust, sum(c_acctbal) AS totacctba
 └ Node 1
   └ *colexec.sortOp
     └ *colexec.hashAggregator
-      └ *rowexec.joinReader
-        └ *colexecsel.selGTFloat64Float64Op
-          └ *colexecbase.castOpNullAny
-            └ *colexecbase.constNullOp
-              └ *colexec.selectInOpBytes
-                └ *colexec.substringInt64Int64Operator
-                  └ *colexecbase.constInt64Op
-                    └ *colexecbase.constInt64Op
-                      └ *colfetcher.ColBatchScan
+      └ *colexec.substringInt64Int64Operator
+        └ *colexecbase.constInt64Op
+          └ *colexecbase.constInt64Op
+            └ *rowexec.joinReader
+              └ *colexecsel.selGTFloat64Float64Op
+                └ *colexecbase.castOpNullAny
+                  └ *colexecbase.constNullOp
+                    └ *colexec.selectInOpBytes
+                      └ *colexec.substringInt64Int64Operator
+                        └ *colexecbase.constInt64Op
+                          └ *colexecbase.constInt64Op
+                            └ *colfetcher.ColBatchScan

--- a/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
@@ -447,9 +447,13 @@ EXPLAIN (VEC)
 ----
 │
 └ Node 1
-  └ *sql.planNodeToRowSource
-    └ *colfetcher.ColIndexJoin
-      └ *colfetcher.ColBatchScan
+  └ *colexec.caseOp
+    ├ *colexec.bufferOp
+    │ └ *sql.planNodeToRowSource
+    │   └ *colfetcher.ColIndexJoin
+    │     └ *colfetcher.ColBatchScan
+    ├ *colexec.bufferOp
+    └ *colexec.bufferOp
 
 # Regression test for releasing operators before closing them with EXPLAIN (VEC)
 # (#70438).


### PR DESCRIPTION
**sql: remove no longer used fields from PostProcessSpec**

This commit removes no longer used `OriginalOutputColumns` and
`OriginalRenderExprs` fields from the `PostProcessSpec` - they
are no longer needed because we now propagate the set of needed
columns in the `IndexFetchSpec`.

Release note: None

**colbuilder: check native support via processor core rather than the spec**

This commit is just a mechanical change.

Release note: None

**colbuilder: vectorizing rendering on top of wrapped processors**

Previously, whenever we needed to wrap a row-by-row processor into the
vectorized flow, we would pass in the whole `PostProcessSpec` to that
processor. When this was originally implemented several years ago, this
was needed so that processors could determine the set of "needed
columns" (which should be decoded from KV responses). However, recently
we refactored that, and now the set of needed columns is passed via the
`IndexFetchSpec`. This means that we no longer need to pass the whole
`PostProcessSpec` when wrapping, and this commit takes advantage of that
observation in order to vectorize the evaluation of render expressions.
In particular, vectorizing of render expressions allows us to plan more
efficient vectorized builtins. We still pass all other parts of the
`PostProcessSpec` (meaning that the wrapped processor is still
responsible for projections, limits, and offsets) since those operations
will limit the number of datums that need to be converted to the
columnar in-memory format as well as provide limit hints to the wrapped
processors.

Release note: None