### PR TITLE
streamingccl: update a couple test skips

### DIFF
--- a/pkg/ccl/streamingccl/streamclient/partitioned_stream_client_test.go
+++ b/pkg/ccl/streamingccl/streamclient/partitioned_stream_client_test.go
@@ -58,7 +58,7 @@ func (f *subscriptionFeedSource) Close(ctx context.Context) {}
 
 func TestPartitionedStreamReplicationClient(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.UnderRaceWithIssue(t, 77916, "flaky test")
+	skip.UnderRaceWithIssue(t, 83694)
 	defer log.Scope(t).Close(t)
 
 	h, cleanup := streamingtest.NewReplicationHelper(t,

--- a/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
@@ -210,8 +210,7 @@ func TestTenantStreamingSuccessfulIngestion(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderRace(t, "slow under race")
-	skip.UnderStress(t, "slow under stress")
+	skip.UnderStressRace(t, "slow under stressrace")
 
 	dataSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "GET" {


### PR DESCRIPTION
- TestPartitionedStreamReplicationClient now references the first
  issue I hit when running this under the race detector.

- TestTenantStreamingSuccessfulIngestion is now only skipped under
  StressRace. I've run it locally and while this test is slow under
  stress and race, I think it is probably worth it to run our main e2e
  test under race for a bit.

Release note: None