### PR TITLE
roachtest,roachprod: detect tenant-scope certs via help, unskip tests

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_fairness.go
+++ b/pkg/cmd/roachtest/tests/multitenant_fairness.go
@@ -64,9 +64,7 @@ func registerMultiTenantFairness(r registry.Registry) {
 			s.maxLoadOps = 100_000
 
 			r.Add(registry.TestSpec{
-				Name: fmt.Sprintf("multitenant/fairness/kv/%s/%s", s.name, acStr[s.acEnabled]),
-				// TODO(cucaroach): remove this once #82926 is resolved.
-				Skip:              "#82926",
+				Name:              fmt.Sprintf("multitenant/fairness/kv/%s/%s", s.name, acStr[s.acEnabled]),
 				Cluster:           r.MakeClusterSpec(5),
 				Owner:             registry.OwnerSQLQueries,
 				NonReleaseBlocker: false,
@@ -95,9 +93,7 @@ func registerMultiTenantFairness(r registry.Registry) {
 			s.maxLoadOps = 1000
 
 			r.Add(registry.TestSpec{
-				Name: fmt.Sprintf("multitenant/fairness/store/%s/%s", s.name, acStr[s.acEnabled]),
-				// TODO(cucaroach): remove this once #82926 is resolved.
-				Skip:              "#82926",
+				Name:              fmt.Sprintf("multitenant/fairness/store/%s/%s", s.name, acStr[s.acEnabled]),
 				Cluster:           r.MakeClusterSpec(5),
 				Owner:             registry.OwnerSQLQueries,
 				NonReleaseBlocker: false,
@@ -162,7 +158,7 @@ func runMultiTenantFairness(
 	const (
 		tenantBaseID       = 11
 		tenantBaseHTTPPort = 8081
-		tenantBaseSQLPort  = 26257
+		tenantBaseSQLPort  = 26259
 	)
 
 	tenantHTTPPort := func(offset int) int {

--- a/pkg/roachprod/install/BUILD.bazel
+++ b/pkg/roachprod/install/BUILD.bazel
@@ -36,7 +36,6 @@ go_library(
         "//pkg/util/retry",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
-        "//pkg/util/version",
         "@com_github_alessio_shellescape//:shellescape",
         "@com_github_cockroachdb_errors//:errors",
         "@org_golang_x_sync//errgroup",


### PR DESCRIPTION
The version comparison code to detect tenant scoped certificates was
still incorrect because the "alpha" portion of semver versions is
compare lexicographically. Since our alpha versions contain a count of
commits, this broke when we hit commit 1000 since the last tag.

Here, we search the help on the command to see if it supports the
tenant-scoped certs flag.  If it does, we assume we will need them.

There is duplication between the multitenant tests and roachprod still
that we should clean up.

Fixes #82926

Release note: None