### PR TITLE
roachtest: run workload from the tenant node

### DIFF
--- a/pkg/cmd/roachtest/tests/smoketest_secure.go
+++ b/pkg/cmd/roachtest/tests/smoketest_secure.go
@@ -80,7 +80,7 @@ func multitenantSmokeTest(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 	// init kv and check new database was done right
 	cmd := fmt.Sprintf("./cockroach workload init kv '%s'", ten.secureURL())
-	err = c.RunE(ctx, c.Node(1), cmd)
+	err = c.RunE(ctx, c.Node(2), cmd)
 	require.NoError(t, err)
 
 	sqlutils.MakeSQLRunner(db).CheckQueryResultsRetry(t, fmt.Sprintf(`


### PR DESCRIPTION
The secure URL refers to paths on disk on the clusters in the
node. Since we only create the tenant-scoped certs on the tenant node,
we need to run workload from that node.

Fixes #82266
Depends on #83703

Release note: None