### PR TITLE
pkg/util/tracing: Add hidden tag group, make server responsible for sorting.

### DIFF
--- a/pkg/kv/test_utils.go
+++ b/pkg/kv/test_utils.go
@@ -27,7 +27,7 @@ func OnlyFollowerReads(rec tracingpb.Recording) bool {
 		if sp.Operation != "/cockroach.roachpb.Internal/Batch" {
 			continue
 		}
-		anonTagGroup := sp.FindTagGroup("")
+		anonTagGroup := sp.FindTagGroup(tracingpb.AnonymousTagGroupName)
 		if anonTagGroup == nil {
 			continue
 		}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2627,7 +2627,7 @@ func getMessagesForSubtrace(
 
 	for _, tg := range span.TagGroups {
 		var prefix string
-		if tg.Name != "" {
+		if tg.Name != tracingpb.AnonymousTagGroupName {
 			prefix = fmt.Sprintf("%s-", tg.Name)
 		}
 		for _, tag := range tg.Tags {

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -638,7 +638,7 @@ func TestTraceDistSQL(t *testing.T) {
 	require.True(t, ok, "table reader span not found")
 	require.Empty(t, rec.OrphanSpans())
 	// Check that the table reader indeed came from a remote note.
-	anonTagGroup := sp.FindTagGroup("")
+	anonTagGroup := sp.FindTagGroup(tracingpb.AnonymousTagGroupName)
 	require.NotNil(t, anonTagGroup)
 	val, ok := anonTagGroup.FindTag("node")
 	require.True(t, ok)

--- a/pkg/ui/workspaces/db-console/src/views/tracez/tracez.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/tracez/tracez.tsx
@@ -157,12 +157,12 @@ const TagBadge = ({
   let badgeStatus: BadgeStatus;
   if (status) {
     badgeStatus = status;
+  } else if (t.hidden) {
+    badgeStatus = "default";
   } else if (isExpandable) {
     badgeStatus = "warning";
-  } else if (!t.hidden) {
-    badgeStatus = "info";
   } else {
-    badgeStatus = "default";
+    badgeStatus = "info";
   }
   return (
     <Button
@@ -216,7 +216,6 @@ const TagCell = (props: {
 }) => {
   const [expandedTagIndex, setExpandedTagIndex] = useState<number>(-1);
   const processedTags = props.sr.span.processed_tags;
-  const orderedTags = _.sortBy(processedTags, t => t.hidden);
 
   // Pad 8px on top and bottom.
   //
@@ -230,7 +229,7 @@ const TagCell = (props: {
   return (
     <div className={"outer-row"}>
       <div className={"inner-row"}>
-        {orderedTags.map((t, i) => (
+        {processedTags.map((t, i) => (
           <TagBadge
             t={t}
             setSearch={props.setSearch}
@@ -248,11 +247,13 @@ const TagCell = (props: {
       </div>
       {expandedTagIndex != -1 && (
         <div className={"inner-row"}>
-          {orderedTags[expandedTagIndex].children.map((t, i) => (
+          {processedTags[expandedTagIndex].children.map((t, i) => (
             <TagBadge
               t={t}
               key={i}
-              status="warning"
+              status={
+                processedTags[expandedTagIndex].hidden ? "default" : "warning"
+              }
               setSearch={props.setSearch}
               isExpanded={false}
             />
@@ -454,7 +455,6 @@ export const Tracez = () => {
       });
     });
   };
-
   return (
     <div>
       {showTrace && currentTrace ? (

--- a/pkg/util/tracing/grpcinterceptor/grpc_interceptor_test.go
+++ b/pkg/util/tracing/grpcinterceptor/grpc_interceptor_test.go
@@ -266,12 +266,12 @@ func TestGRPCInterceptors(t *testing.T) {
 				// it's not worth having to have a separate expectation for each.
 				// Note that we check that we're not leaking spans at the end of
 				// the test.
-				anonymousTagGroup := rec.FindTagGroup("")
+				anonymousTagGroup := rec.FindTagGroup(tracingpb.AnonymousTagGroupName)
 				if anonymousTagGroup == nil {
 					continue
 				}
 
-				filteredAnonymousTags := make([]tracingpb.Tag, 0)
+				filteredAnonymousTagGroup := make([]tracingpb.Tag, 0)
 				for _, tag := range anonymousTagGroup.Tags {
 					if tag.Key == "_unfinished" {
 						continue
@@ -279,9 +279,9 @@ func TestGRPCInterceptors(t *testing.T) {
 					if tag.Key == "_verbose" {
 						continue
 					}
-					filteredAnonymousTags = append(filteredAnonymousTags, tag)
+					filteredAnonymousTagGroup = append(filteredAnonymousTagGroup, tag)
 				}
-				anonymousTagGroup.Tags = filteredAnonymousTags
+				anonymousTagGroup.Tags = filteredAnonymousTagGroup
 			}
 			require.Equal(t, 1, n)
 

--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -301,7 +301,7 @@ func TestSpanRecordStructuredLimit(t *testing.T) {
 	rec := sp.GetRecording(tracingpb.RecordingVerbose)
 	require.Len(t, rec, 1)
 	require.Len(t, rec[0].StructuredRecords, numStructuredRecordings)
-	val, ok := rec[0].FindTagGroup("").FindTag("_dropped")
+	val, ok := rec[0].FindTagGroup(tracingpb.AnonymousTagGroupName).FindTag("_dropped")
 	require.True(t, ok)
 	require.Equal(t, "1", val)
 
@@ -352,7 +352,7 @@ func TestSpanRecordLimit(t *testing.T) {
 	rec := sp.GetRecording(tracingpb.RecordingVerbose)
 	require.Len(t, rec, 1)
 	require.Len(t, rec[0].Logs, numLogs)
-	val, ok := rec[0].FindTagGroup("").FindTag("_dropped")
+	val, ok := rec[0].FindTagGroup(tracingpb.AnonymousTagGroupName).FindTag("_dropped")
 	require.True(t, ok)
 	require.Equal(t, val, "1")
 
@@ -612,7 +612,7 @@ func TestSpanTags(t *testing.T) {
 
 	rec := sp.GetRecording(tracingpb.RecordingVerbose)
 
-	anonTagGroup := rec[0].FindTagGroup("")
+	anonTagGroup := rec[0].FindTagGroup(tracingpb.AnonymousTagGroupName)
 	_, ok = anonTagGroup.FindTag("tag")
 	require.True(t, ok)
 
@@ -657,8 +657,8 @@ func TestSpanTagsInRecordings(t *testing.T) {
 	require.Len(t, rec, 1)
 
 	require.Len(t, rec[0].TagGroups, 1)
-	anonTagGroup := rec[0].FindTagGroup("")
-	require.Len(t, anonTagGroup.Tags, 5) // _unfinished:1 _verbose:1 foo:tagbar foo1:1 foor2:bar2
+	anonTagGroup := rec[0].FindTagGroup(tracingpb.AnonymousTagGroupName)
+	require.Len(t, anonTagGroup.Tags, 5) // foo:tagbar foo1:1 foor2:bar2 _unfinished:1 _verbose:1
 
 	_, ok := anonTagGroup.FindTag("foo")
 	require.True(t, ok)
@@ -674,7 +674,7 @@ func TestSpanTagsInRecordings(t *testing.T) {
 	require.Len(t, rec, 1)
 
 	require.Len(t, rec[0].TagGroups, 1)
-	anonTagGroup = rec[0].FindTagGroup("")
+	anonTagGroup = rec[0].FindTagGroup(tracingpb.AnonymousTagGroupName)
 	require.Len(t, anonTagGroup.Tags, 6)
 
 	_, ok = anonTagGroup.FindTag("foo3")
@@ -692,10 +692,10 @@ func TestVerboseTag(t *testing.T) {
 
 	sp.SetRecordingType(tracingpb.RecordingStructured)
 	rec := sp.GetRecording(tracingpb.RecordingVerbose)
-	anonymousTagGroup := rec[0].FindTagGroup("")
-	ok := anonymousTagGroup != nil
+	anonTagGroup := rec[0].FindTagGroup(tracingpb.AnonymousTagGroupName)
+	ok := anonTagGroup != nil
 	if ok {
-		_, ok = anonymousTagGroup.FindTag("_verbose")
+		_, ok = anonTagGroup.FindTag("_verbose")
 	}
 	require.False(t, ok)
 
@@ -703,16 +703,16 @@ func TestVerboseTag(t *testing.T) {
 	sp.SetRecordingType(tracingpb.RecordingVerbose)
 	rec = sp.GetRecording(tracingpb.RecordingVerbose)
 
-	_, ok = rec[0].FindTagGroup("").FindTag("_verbose")
+	_, ok = rec[0].FindTagGroup(tracingpb.AnonymousTagGroupName).FindTag("_verbose")
 	require.True(t, ok)
 
 	// After we stop recording, the tag goes away.
 	sp.SetRecordingType(tracingpb.RecordingStructured)
 	rec = sp.GetRecording(tracingpb.RecordingVerbose)
-	anonymousTagGroup = rec[0].FindTagGroup("")
-	ok = anonymousTagGroup != nil
+	anonTagGroup = rec[0].FindTagGroup(tracingpb.AnonymousTagGroupName)
+	ok = anonTagGroup != nil
 	if ok {
-		_, ok = anonymousTagGroup.FindTag("_verbose")
+		_, ok = anonTagGroup.FindTag("_verbose")
 	}
 	require.False(t, ok)
 }

--- a/pkg/util/tracing/tracingpb/recorded_span.go
+++ b/pkg/util/tracing/tracingpb/recorded_span.go
@@ -20,6 +20,11 @@ import (
 	types "github.com/gogo/protobuf/types"
 )
 
+const (
+	// AnonymousTagGroupName is the name of the anonymous tag group.
+	AnonymousTagGroupName = ""
+)
+
 // TraceID is a probabilistically-unique id, shared by all spans in a trace.
 type TraceID uint64
 

--- a/pkg/util/tracing/tracingpb/recording.go
+++ b/pkg/util/tracing/tracingpb/recording.go
@@ -262,7 +262,7 @@ func (r Recording) visitSpan(sp RecordedSpan, depth int) []traceLogData {
 
 	for _, tg := range sp.TagGroups {
 		var prefix string
-		if tg.Name != "" {
+		if tg.Name != AnonymousTagGroupName {
 			prefix = fmt.Sprintf("%s-", tg.Name)
 		}
 		for _, tag := range tg.Tags {
@@ -457,7 +457,7 @@ func (r Recording) ToJaegerJSON(stmt, comment, nodeStr string) (string, error) {
 		for _, tagGroup := range sp.TagGroups {
 			for _, tag := range tagGroup.Tags {
 				var prefix string
-				if tagGroup.Name != "" {
+				if tagGroup.Name != AnonymousTagGroupName {
 					prefix = fmt.Sprintf("%s-", tagGroup.Name)
 				}
 				s.Tags = append(s.Tags, jaegerjson.KeyValue{


### PR DESCRIPTION
Release note: none

This moves all tags marked as "hidden" into a single tag group at the UI layer. This declutters the trace page a little bit and makes it easier to pick out more important information.

<img width="1620" alt="Screen Shot 2022-07-01 at 12 37 07 PM" src="https://user-images.githubusercontent.com/261508/176937757-bf8ac920-9e28-4908-8de4-1fbc077fd2c7.png">
