### PR TITLE
changefeedccl: infer WITH diff from changefeed expression

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -692,7 +692,7 @@ func (e EncodingOptions) Validate() error {
 			OptEnvelope, OptEnvelopeRow, OptFormat, OptFormatAvro,
 		)
 	}
-	if e.Envelope != OptEnvelopeWrapped {
+	if e.Envelope != OptEnvelopeWrapped && e.Format != OptFormatJSON {
 		requiresWrap := []struct {
 			k string
 			b bool
@@ -702,12 +702,6 @@ func (e EncodingOptions) Validate() error {
 			{OptUpdatedTimestamps, e.UpdatedTimestamps},
 			{OptMVCCTimestamps, e.MVCCTimestamps},
 			{OptDiff, e.Diff},
-		}
-		if e.Format == OptFormatJSON {
-			requiresWrap = []struct {
-				k string
-				b bool
-			}{{OptDiff, e.Diff}}
 		}
 		for _, v := range requiresWrap {
 			if v.b {
@@ -841,6 +835,20 @@ func (s StatementOptions) ForceTopicInValue() error {
 	s.cache.EncodingOptions = EncodingOptions{}
 	_, err := s.GetEncodingOptions()
 	return err
+}
+
+// ForceDiff sets diff to true regardess of its previous value.
+func (s StatementOptions) ForceDiff() {
+	s.m[OptDiff] = ``
+	s.cache.EncodingOptions = EncodingOptions{}
+}
+
+// SetDefaultEnvelope sets the envelope if not already set.
+func (s StatementOptions) SetDefaultEnvelope(t EnvelopeType) {
+	if _, ok := s.m[OptEnvelope]; !ok {
+		s.m[OptEnvelope] = string(t)
+		s.cache.EncodingOptions = EncodingOptions{}
+	}
 }
 
 // GetOnError validates and returns the desired behavior when a non-retriable error is encountered.

--- a/pkg/ccl/changefeedccl/encoder_json.go
+++ b/pkg/ccl/changefeedccl/encoder_json.go
@@ -48,10 +48,6 @@ func makeJSONEncoder(
 	e.updatedField = opts.UpdatedTimestamps
 	e.mvccTimestampField = opts.MVCCTimestamps
 	e.beforeField = opts.Diff
-	if e.beforeField && !e.wrapped {
-		return nil, errors.Errorf(`%s is only usable with %s=%s`,
-			changefeedbase.OptDiff, changefeedbase.OptEnvelope, changefeedbase.OptEnvelopeWrapped)
-	}
 	e.keyInValue = opts.KeyInValue
 	if e.keyInValue && !e.wrapped {
 		return nil, errors.Errorf(`%s is only usable with %s=%s`,

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -76,10 +76,14 @@ func TestEncoders(t *testing.T) {
 			resolved: `{"__crdb__":{"resolved":"1.0000000002"}}`,
 		},
 		`format=json,envelope=key_only,diff`: {
-			err: `diff is only usable with envelope=wrapped`,
+			insert:   `[1]->`,
+			delete:   `[1]->`,
+			resolved: `{"__crdb__":{"resolved":"1.0000000002"}}`,
 		},
 		`format=json,envelope=key_only,updated,diff`: {
-			err: `diff is only usable with envelope=wrapped`,
+			insert:   `[1]->`,
+			delete:   `[1]->`,
+			resolved: `{"__crdb__":{"resolved":"1.0000000002"}}`,
 		},
 		`format=json,envelope=row`: {
 			insert:   `[1]->{"a": 1, "b": "bar"}`,
@@ -92,10 +96,14 @@ func TestEncoders(t *testing.T) {
 			resolved: `{"__crdb__":{"resolved":"1.0000000002"}}`,
 		},
 		`format=json,envelope=row,diff`: {
-			err: `diff is only usable with envelope=wrapped`,
+			insert:   `[1]->{"a": 1, "b": "bar"}`,
+			delete:   `[1]->`,
+			resolved: `{"__crdb__":{"resolved":"1.0000000002"}}`,
 		},
 		`format=json,envelope=row,updated,diff`: {
-			err: `diff is only usable with envelope=wrapped`,
+			insert:   `[1]->{"__crdb__": {"updated": "1.0000000002"}, "a": 1, "b": "bar"}`,
+			delete:   `[1]->`,
+			resolved: `{"__crdb__":{"resolved":"1.0000000002"}}`,
 		},
 		`format=json,envelope=wrapped`: {
 			insert:   `[1]->{"after": {"a": 1, "b": "bar"}}`,
@@ -216,6 +224,7 @@ func TestEncoders(t *testing.T) {
 				TableID:           tableDesc.GetID(),
 				StatementTimeName: changefeedbase.StatementTimeName(tableDesc.GetName()),
 			})
+
 			if len(expected.err) > 0 {
 				require.EqualError(t, o.Validate(), expected.err)
 				return


### PR DESCRIPTION
Informs #83322. Specifically this does the "infer whether
or not to set diff" part of it.

This went through a more ambitious phase
(https://github.com/cockroachdb/cockroach/compare/master...HonoreDB:cockroach:cdc_expressions_infer_diff?expand=1)
where it also handled user defined types, but I ended up
agreeing with wiser heads that this was adding too much complexity
for no known use case.

I also came really close to setting envelope=row as the
default, but envelope=row is not supported in all sinks
so again, it felt too messy to do without a little further
conversation.

Release note (sql change): CREATE CHANGEFEED AS statements no longer need to include WITH DIFF when using cdc_prev().