### PR TITLE
sql/builtins: remove dependency to sql/randgen

### DIFF
--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -133,6 +133,7 @@ go_test(
         "generator_builtins_test.go",
         "geo_builtins_test.go",
         "help_test.go",
+        "helpers_test.go",
         "main_test.go",
         "math_builtins_test.go",
         "show_create_all_tables_builtin_test.go",

--- a/pkg/sql/sem/builtins/helpers_test.go
+++ b/pkg/sql/sem/builtins/helpers_test.go
@@ -1,0 +1,19 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package builtins
+
+import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+
+func IterateGeoBuiltinOverloads(f func(builtinName string, ol []tree.Overload)) {
+	for k, builtin := range geoBuiltins {
+		f(k, builtin.overloads)
+	}
+}


### PR DESCRIPTION
Previously, a test in the `builtins` package depended on `randgen`.
This was inadequate because it will introduce a dependency cycle later
when we introduce the dependency from `tabledesc` to `builtins`, as
required to implement some sequence reference releated issues (see
pr #82172 for details).

Release note: None