### PR TITLE
storage: remove dependency to sql/catalog/bootstrap

### DIFF
--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -104,6 +104,7 @@ go_test(
         "disk_map_test.go",
         "engine_key_test.go",
         "engine_test.go",
+        "external_helpers_test.go",
         "intent_interleaving_iter_test.go",
         "intent_reader_writer_test.go",
         "main_test.go",

--- a/pkg/storage/external_helpers_test.go
+++ b/pkg/storage/external_helpers_test.go
@@ -1,0 +1,21 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package storage_test
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+)
+
+func init() {
+	storage.TestingUserDescID = bootstrap.TestingUserDescID
+	storage.TestingUserTableDataMin = bootstrap.TestingUserTableDataMin
+}


### PR DESCRIPTION
Previously, tests in `pkg/storage` depended on `sql/catalog/bootstrap`.
This was inadequate/weird because `storage` is a much lower layer in the
architectural stack. It will also help prevent dependency cycles in
other PRs when we introduce depencies (see #82172 if interested).

Release note: None