### PR TITLE
sql/schemachanger/scstage: remove job references eagerly

### DIFF
--- a/pkg/sql/catalog/descriptor_id_set.go
+++ b/pkg/sql/catalog/descriptor_id_set.go
@@ -72,3 +72,13 @@ func (d DescriptorIDSet) Ordered() []descpb.ID {
 func (d *DescriptorIDSet) Remove(id descpb.ID) {
 	d.set.Remove(int(id))
 }
+
+// Difference returns the elements of d that are not in o as a new set.
+func (d DescriptorIDSet) Difference(o DescriptorIDSet) DescriptorIDSet {
+	return DescriptorIDSet{set: d.set.Difference(o.set)}
+}
+
+// Union returns the union of d and o as a new set.
+func (d *DescriptorIDSet) Union(o DescriptorIDSet) DescriptorIDSet {
+	return DescriptorIDSet{set: d.set.Union(o.set)}
+}

--- a/pkg/sql/schemachanger/scdeps/BUILD.bazel
+++ b/pkg/sql/schemachanger/scdeps/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//pkg/sql/schemachanger/scexec/backfiller",
         "//pkg/sql/schemachanger/scexec/scmutationexec",
         "//pkg/sql/schemachanger/scrun",
+        "//pkg/sql/sem/catid",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",

--- a/pkg/sql/schemachanger/scexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/dependencies.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec/scmutationexec"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
@@ -147,6 +148,7 @@ type JobUpdateCallback = func(
 	md jobs.JobMetadata,
 	updateProgress func(*jobspb.Progress),
 	setNonCancelable func(),
+	removeDescriptorIDs func([]catid.DescID) error,
 ) error
 
 // Backfiller is an abstract index backfiller that performs index backfills

--- a/pkg/sql/schemachanger/scexec/scmutationexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/dependencies.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 )
 
@@ -96,7 +97,12 @@ type MutationVisitorStateUpdater interface {
 
 	// UpdateSchemaChangerJob will update the progress and payload of the
 	// schema changer job.
-	UpdateSchemaChangerJob(jobID jobspb.JobID, isNonCancelable bool, runningStatus string) error
+	UpdateSchemaChangerJob(
+		jobID jobspb.JobID,
+		isNonCancelable bool,
+		runningStatus string,
+		descriptorIDsToRemove []catid.DescID,
+	) error
 
 	// EnqueueEvent will enqueue an event to be written to the event log.
 	EnqueueEvent(

--- a/pkg/sql/schemachanger/scexec/scmutationexec/schema_change_job.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/schema_change_job.go
@@ -30,7 +30,9 @@ func (m *visitor) CreateSchemaChangerJob(
 func (m *visitor) UpdateSchemaChangerJob(
 	ctx context.Context, op scop.UpdateSchemaChangerJob,
 ) error {
-	return m.s.UpdateSchemaChangerJob(op.JobID, op.IsNonCancelable, op.RunningStatus)
+	return m.s.UpdateSchemaChangerJob(
+		op.JobID, op.IsNonCancelable, op.RunningStatus, op.DescriptorIDsToRemove,
+	)
 }
 
 func (m *visitor) SetJobStateOnDescriptor(

--- a/pkg/sql/schemachanger/scop/mutation.go
+++ b/pkg/sql/schemachanger/scop/mutation.go
@@ -413,6 +413,10 @@ type UpdateSchemaChangerJob struct {
 	IsNonCancelable bool
 	JobID           jobspb.JobID
 	RunningStatus   string
+
+	// DescriptorIDsToRemove are references to descriptor IDs which should
+	// be removed from the job itself.
+	DescriptorIDsToRemove []descpb.ID
 }
 
 // CreateSchemaChangerJob constructs the job for the

--- a/pkg/sql/schemachanger/scplan/internal/scstage/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/internal/scstage/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/sql/schemachanger/scpb",
         "//pkg/sql/schemachanger/scplan/internal/scgraph",
         "//pkg/sql/schemachanger/screl",
+        "//pkg/sql/sem/catid",
         "//pkg/util/iterutil",
         "@com_github_cockroachdb_errors//:errors",
     ],


### PR DESCRIPTION
When a descriptor is removed, it's a problem if the job still references it.
To deal with this problem, we remove the references to the job from the
descriptor and job more eagerly. Note that it's an error if we were to
attempt to remove any references before a NonRevertiblePostCommitPhase.

Release note: None