### PR TITLE
storage: add nextKeyIgnoringTime() to MVCCIncrementalIterator

### DIFF
--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -89,6 +89,7 @@ var sstIterVerify = util.ConstantWithMetamorphicTestBool("mvcc-histories-sst-ite
 // iter_seek_intent_ge k=<key> txn=<name>
 // iter_next
 // iter_next_ignoring_time
+// iter_next_key_ignoring_time
 // iter_next_key
 // iter_prev
 // iter_scan      [reverse]
@@ -667,16 +668,17 @@ var commands = map[string]cmd{
 	"put_rangekey":   {typDataUpdate, cmdPutRangeKey},
 	"scan":           {typReadOnly, cmdScan},
 
-	"iter_new":                {typReadOnly, cmdIterNew},
-	"iter_new_incremental":    {typReadOnly, cmdIterNewIncremental}, // MVCCIncrementalIterator
-	"iter_seek_ge":            {typReadOnly, cmdIterSeekGE},
-	"iter_seek_lt":            {typReadOnly, cmdIterSeekLT},
-	"iter_seek_intent_ge":     {typReadOnly, cmdIterSeekIntentGE},
-	"iter_next":               {typReadOnly, cmdIterNext},
-	"iter_next_ignoring_time": {typReadOnly, cmdIterNextIgnoringTime}, // MVCCIncrementalIterator
-	"iter_next_key":           {typReadOnly, cmdIterNextKey},
-	"iter_prev":               {typReadOnly, cmdIterPrev},
-	"iter_scan":               {typReadOnly, cmdIterScan},
+	"iter_new":                    {typReadOnly, cmdIterNew},
+	"iter_new_incremental":        {typReadOnly, cmdIterNewIncremental}, // MVCCIncrementalIterator
+	"iter_seek_ge":                {typReadOnly, cmdIterSeekGE},
+	"iter_seek_lt":                {typReadOnly, cmdIterSeekLT},
+	"iter_seek_intent_ge":         {typReadOnly, cmdIterSeekIntentGE},
+	"iter_next":                   {typReadOnly, cmdIterNext},
+	"iter_next_ignoring_time":     {typReadOnly, cmdIterNextIgnoringTime},    // MVCCIncrementalIterator
+	"iter_next_key_ignoring_time": {typReadOnly, cmdIterNextKeyIgnoringTime}, // MVCCIncrementalIterator
+	"iter_next_key":               {typReadOnly, cmdIterNextKey},
+	"iter_prev":                   {typReadOnly, cmdIterPrev},
+	"iter_scan":                   {typReadOnly, cmdIterScan},
 
 	"sst_put":            {typDataUpdate, cmdSSTPut},
 	"sst_put_rangekey":   {typDataUpdate, cmdSSTPutRangeKey},
@@ -1428,6 +1430,12 @@ func cmdIterNext(e *evalCtx) error {
 
 func cmdIterNextIgnoringTime(e *evalCtx) error {
 	e.mvccIncrementalIter().NextIgnoringTime()
+	printIter(e)
+	return nil
+}
+
+func cmdIterNextKeyIgnoringTime(e *evalCtx) error {
+	e.mvccIncrementalIter().NextKeyIgnoringTime()
 	printIter(e)
 	return nil
 }

--- a/pkg/storage/testdata/mvcc_histories/range_key_iter_incremental
+++ b/pkg/storage/testdata/mvcc_histories/range_key_iter_incremental
@@ -1011,6 +1011,23 @@ iter_seek_ge: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 iter_next_ignoring_time: err=conflicting intents on "d"
 error: (*roachpb.WriteIntentError:) conflicting intents on "d"
 
+run ok
+iter_new_incremental types=pointsAndRanges k=a end=z startTs=2 endTs=4 intents=error
+iter_seek_ge k=c
+iter_next_key_ignoring_time
+----
+iter_seek_ge: {c-d}/[3.000000000,0=/<empty>]
+iter_next_key_ignoring_time: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+
+run error
+iter_new_incremental types=pointsAndRanges k=a end=z startTs=2 endTs=10 intents=error
+iter_seek_ge k=c
+iter_next_key_ignoring_time
+----
+iter_seek_ge: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_next_key_ignoring_time: err=conflicting intents on "d"
+error: (*roachpb.WriteIntentError:) conflicting intents on "d"
+
 # rangesOnly doesn't care about intents.
 run ok
 iter_new_incremental types=rangesOnly k=a end=z intents=error
@@ -1123,6 +1140,46 @@ iter_next_ignoring_time
 ----
 iter_seek_ge: {f-g}/[5.000000000,0=/<empty>]
 iter_next_ignoring_time: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+
+# Test NextKeyIgnoringTime().
+run ok
+iter_new_incremental types=pointsAndRanges k=a end=z startTs=2 endTs=4 intents=emit
+iter_seek_ge k=a
+iter_next_key_ignoring_time
+iter_next_key_ignoring_time
+iter_next_key_ignoring_time
+iter_next_key_ignoring_time
+iter_next_key_ignoring_time
+iter_next_key_ignoring_time
+iter_next_key_ignoring_time
+iter_next_key_ignoring_time
+iter_next_key_ignoring_time
+iter_next_key_ignoring_time
+iter_next_key_ignoring_time
+iter_next_key_ignoring_time
+----
+iter_seek_ge: "a"/4.000000000,0=/<empty>
+iter_next_key_ignoring_time: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key_ignoring_time: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key_ignoring_time: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key_ignoring_time: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key_ignoring_time: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key_ignoring_time: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key_ignoring_time: {h-k}/[1.000000000,0=/<empty>]
+iter_next_key_ignoring_time: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+iter_next_key_ignoring_time: "k"/5.000000000,0=/BYTES/k5
+iter_next_key_ignoring_time: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next_key_ignoring_time: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_next_key_ignoring_time: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+# NextKeyIgnoringTime with only range keys.
+run ok
+iter_new_incremental types=rangesOnly k=a end=z startTs=4 endTs=5 intents=emit
+iter_seek_ge k=f
+iter_next_key_ignoring_time
+----
+iter_seek_ge: {f-g}/[5.000000000,0=/<empty>]
+iter_next_key_ignoring_time: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 
 # Try some scans, bounded and unbounded, with only point keys.
 run ok


### PR DESCRIPTION
The MVCCInvermentalIterator's NextKeyIgnoringTime() function was previously
deleted in https://github.com/cockroachdb/cockroach/pull/82691, as there wasn't any use for it at the time. Now, the new
Delete Range with predicate filtering will need it (https://github.com/cockroachdb/cockroach/pull/83676).

This PR also cleans up duplicate code used to test NextIgnoringTime and
NextKeyIgnoringTime.

Release note: None