### PR TITLE
sql: move NullableArgs function property to overload level

### DIFF
--- a/pkg/sql/colexec/builtin_funcs.go
+++ b/pkg/sql/colexec/builtin_funcs.go
@@ -70,7 +70,7 @@ func (b *defaultBuiltinFuncOperator) Next() coldata.Batch {
 					err error
 				)
 				// Some functions cannot handle null arguments.
-				if hasNulls && !b.funcExpr.CanHandleNulls() {
+				if hasNulls && !b.funcExpr.ResolvedOverload().NullableArgs {
 					res = tree.DNull
 				} else {
 					res, err = b.funcExpr.ResolvedOverload().

--- a/pkg/sql/execinfra/execagg/base.go
+++ b/pkg/sql/execinfra/execagg/base.go
@@ -38,7 +38,7 @@ func GetAggregateInfo(
 		return builtins.NewAnyNotNullAggregate, inputTypes[0], nil
 	}
 
-	props, builtins := builtins.GetBuiltinProperties(strings.ToLower(fn.String()))
+	_, builtins := builtins.GetBuiltinProperties(strings.ToLower(fn.String()))
 	for _, b := range builtins {
 		typs := b.Types.Types()
 		if len(typs) != len(inputTypes) {
@@ -47,7 +47,7 @@ func GetAggregateInfo(
 		match := true
 		for i, t := range typs {
 			if !inputTypes[i].Equivalent(t) {
-				if props.NullableArgs && inputTypes[i].IsAmbiguous() {
+				if b.NullableArgs && inputTypes[i].IsAmbiguous() {
 					continue
 				}
 				match = false
@@ -131,7 +131,7 @@ func GetWindowFunctionInfo(
 			"function is neither an aggregate nor a window function",
 		)
 	}
-	props, builtins := builtins.GetBuiltinProperties(strings.ToLower(funcStr))
+	_, builtins := builtins.GetBuiltinProperties(strings.ToLower(funcStr))
 	for _, b := range builtins {
 		typs := b.Types.Types()
 		if len(typs) != len(inputTypes) {
@@ -140,7 +140,7 @@ func GetWindowFunctionInfo(
 		match := true
 		for i, t := range typs {
 			if !inputTypes[i].Equivalent(t) {
-				if props.NullableArgs && inputTypes[i].IsAmbiguous() {
+				if b.NullableArgs && inputTypes[i].IsAmbiguous() {
 					continue
 				}
 				match = false

--- a/pkg/sql/opt/memo/constraint_builder.go
+++ b/pkg/sql/opt/memo/constraint_builder.go
@@ -434,7 +434,7 @@ func (cb *constraintsBuilder) buildConstraintForTupleInequality(
 func (cb *constraintsBuilder) buildFunctionConstraints(
 	f *FunctionExpr,
 ) (_ *constraint.Set, tight bool) {
-	if f.Properties.NullableArgs {
+	if f.FunctionPrivate.Overload.NullableArgs {
 		return unconstrained, false
 	}
 

--- a/pkg/sql/opt/norm/fold_constants_funcs.go
+++ b/pkg/sql/opt/norm/fold_constants_funcs.go
@@ -562,7 +562,7 @@ func (c *CustomFuncs) FoldColumnAccess(
 //
 // See FoldFunctionWithNullArg for more details.
 func (c *CustomFuncs) CanFoldFunctionWithNullArg(private *memo.FunctionPrivate) bool {
-	return !private.Properties.NullableArgs &&
+	return !private.Overload.NullableArgs &&
 		private.Properties.Class == tree.NormalClass
 }
 

--- a/pkg/sql/opt/optbuilder/sql_fn.go
+++ b/pkg/sql/opt/optbuilder/sql_fn.go
@@ -63,7 +63,7 @@ func (b *Builder) buildSQLFn(
 			))
 		}
 		exprs[i] = memo.ExtractConstDatum(info.args[i])
-		if exprs[i] == tree.DNull && !info.def.Properties.NullableArgs {
+		if exprs[i] == tree.DNull && !info.def.Overload.NullableArgs {
 			return b.factory.ConstructNull(info.ResolvedType())
 		}
 	}

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -1425,9 +1425,6 @@ func (g *jsonEachGenerator) Values() (tree.Datums, error) {
 var jsonPopulateProps = tree.FunctionProperties{
 	Class:    tree.GeneratorClass,
 	Category: builtinconstants.CategoryGenerator,
-	// The typical way to call json_populate_record is to send NULL::atype as the
-	// first argument, so we have to accept nullable args.
-	NullableArgs: true,
 }
 
 func makeJSONPopulateImpl(gen eval.GeneratorWithExprsOverload, info string) tree.Overload {
@@ -1452,6 +1449,9 @@ func makeJSONPopulateImpl(gen eval.GeneratorWithExprsOverload, info string) tree
 		GeneratorWithExprs: gen,
 		Info:               info,
 		Volatility:         volatility.Stable,
+		// The typical way to call json_populate_record is to send NULL::atype as the
+		// first argument, so we have to accept nullable args.
+		NullableArgs: true,
 	}
 }
 

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -1187,7 +1187,7 @@ SELECT ST_S2Covering(geography, 's2_max_level=15,s2_level_mod=3').
 		},
 	),
 	"st_box2dfromgeohash": makeBuiltin(
-		tree.FunctionProperties{NullableArgs: true},
+		defProps(),
 		tree.Overload{
 			Types: tree.ArgTypes{
 				{"geohash", types.String},
@@ -1217,7 +1217,8 @@ SELECT ST_S2Covering(geography, 's2_max_level=15,s2_level_mod=3').
 			Info: infoBuilder{
 				info: "Return a Box2D from a GeoHash string with supplied precision.",
 			}.String(),
-			Volatility: volatility.Immutable,
+			Volatility:   volatility.Immutable,
+			NullableArgs: true,
 		},
 		tree.Overload{
 			Types: tree.ArgTypes{
@@ -1239,7 +1240,8 @@ SELECT ST_S2Covering(geography, 's2_max_level=15,s2_level_mod=3').
 			Info: infoBuilder{
 				info: "Return a Box2D from a GeoHash string with max precision.",
 			}.String(),
-			Volatility: volatility.Immutable,
+			Volatility:   volatility.Immutable,
+			NullableArgs: true,
 		},
 	),
 
@@ -6076,7 +6078,7 @@ See http://developers.google.com/maps/documentation/utilities/polylinealgorithm`
 		),
 	),
 	"st_combinebbox": makeBuiltin(
-		tree.FunctionProperties{NullableArgs: true},
+		defProps(),
 		tree.Overload{
 			Types:      tree.ArgTypes{{"box2d", types.Box2D}, {"geometry", types.Geometry}},
 			ReturnType: tree.FixedReturnType(types.Box2D),
@@ -6102,7 +6104,8 @@ See http://developers.google.com/maps/documentation/utilities/polylinealgorithm`
 			Info: infoBuilder{
 				info: "Combines the current bounding box with the bounding box of the Geometry.",
 			}.String(),
-			Volatility: volatility.Immutable,
+			Volatility:   volatility.Immutable,
+			NullableArgs: true,
 		},
 	),
 	"st_expand": makeBuiltin(

--- a/pkg/sql/sem/builtins/overlaps_builtins.go
+++ b/pkg/sql/sem/builtins/overlaps_builtins.go
@@ -58,8 +58,7 @@ func initOverlapsBuiltins() {
 var overlapsBuiltins = map[string]builtinDefinition{
 	"overlaps": makeBuiltin(
 		tree.FunctionProperties{
-			Category:     builtinconstants.CategoryDateAndTime,
-			NullableArgs: false,
+			Category: builtinconstants.CategoryDateAndTime,
 		},
 		makeOverlapsOverloads()...,
 	),

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -829,15 +829,16 @@ var pgBuiltins = map[string]builtinDefinition{
 	),
 
 	// TODO(bram): Make sure the reported type is correct for tuples. See #25523.
-	"pg_typeof": makeBuiltin(tree.FunctionProperties{NullableArgs: true},
+	"pg_typeof": makeBuiltin(defProps(),
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.Any}},
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.NewDString(args[0].ResolvedType().SQLStandardName()), nil
 			},
-			Info:       notUsableInfo,
-			Volatility: volatility.Stable,
+			Info:         notUsableInfo,
+			Volatility:   volatility.Stable,
+			NullableArgs: true,
 		},
 	),
 
@@ -924,7 +925,7 @@ var pgBuiltins = map[string]builtinDefinition{
 		},
 	),
 
-	"format_type": makeBuiltin(tree.FunctionProperties{NullableArgs: true, DistsqlBlocklist: true},
+	"format_type": makeBuiltin(tree.FunctionProperties{DistsqlBlocklist: true},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"type_oid", types.Oid}, {"typemod", types.Int}},
 			ReturnType: tree.FixedReturnType(types.String),
@@ -966,7 +967,8 @@ var pgBuiltins = map[string]builtinDefinition{
 			Info: "Returns the SQL name of a data type that is " +
 				"identified by its type OID and possibly a type modifier. " +
 				"Currently, the type modifier is ignored.",
-			Volatility: volatility.Stable,
+			Volatility:   volatility.Stable,
+			NullableArgs: true,
 		},
 	),
 

--- a/pkg/sql/sem/eval/expr.go
+++ b/pkg/sql/sem/eval/expr.go
@@ -477,7 +477,7 @@ func (e *evaluator) evalFuncArgs(
 		if err != nil {
 			return false, nil, err
 		}
-		if arg == tree.DNull && !expr.CanHandleNulls() {
+		if arg == tree.DNull && !expr.ResolvedOverload().NullableArgs {
 			return true, nil, nil
 		}
 		args[i] = arg

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1273,12 +1273,6 @@ func (node *FuncExpr) IsDistSQLBlocklist() bool {
 	return (node.fn != nil && node.fn.DistsqlBlocklist) || (node.fnProps != nil && node.fnProps.DistsqlBlocklist)
 }
 
-// CanHandleNulls returns whether or not the function can handle null
-// arguments.
-func (node *FuncExpr) CanHandleNulls() bool {
-	return node.fnProps != nil && node.fnProps.NullableArgs
-}
-
 type funcType int
 
 // FuncExpr.Type

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -48,22 +48,6 @@ type FunctionProperties struct {
 	// considered undocumented.
 	Private bool
 
-	// NullableArgs is set to true when a function's definition can handle NULL
-	// arguments. When set to true, the function will be given the chance to see NULL
-	// arguments.
-	//
-	// When set to false, the function will directly result in NULL in the
-	// presence of any NULL arguments without evaluating the function's
-	// implementation defined in Overload.Fn. Therefore, if the function is
-	// expected to produce side-effects with a NULL argument, NullableArgs must
-	// be true. Note that if this behavior changes so that NullableArgs=false
-	// functions can produce side-effects, the FoldFunctionWithNullArg optimizer
-	// rule must be changed to avoid folding those functions.
-	//
-	// NOTE: when set, a function should be prepared for any of its arguments to
-	// be NULL and should act accordingly.
-	NullableArgs bool
-
 	// DistsqlBlocklist is set to true when a function depends on
 	// members of the EvalContext that are not marshaled by DistSQL
 	// (e.g. planner). Currently used for DistSQL to determine if

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -153,6 +153,22 @@ type Overload struct {
 	// DistSQL. One example is when the type information for function arguments
 	// cannot be recovered.
 	DistsqlBlocklist bool
+
+	// NullableArgs is set to true when a function's definition can handle NULL
+	// arguments. When set to true, the function will be given the chance to see NULL
+	// arguments.
+	//
+	// When set to false, the function will directly result in NULL in the
+	// presence of any NULL arguments without evaluating the function's
+	// implementation defined in Overload.Fn. Therefore, if the function is
+	// expected to produce side-effects with a NULL argument, NullableArgs must
+	// be true. Note that if this behavior changes so that NullableArgs=false
+	// functions can produce side-effects, the FoldFunctionWithNullArg optimizer
+	// rule must be changed to avoid folding those functions.
+	//
+	// NOTE: when set, a function should be prepared for any of its arguments to
+	// be NULL and should act accordingly.
+	NullableArgs bool
 }
 
 // params implements the overloadImpl interface.


### PR DESCRIPTION
Currently we only have builtins, and that all overloads of a
same function name share function properties. However, we're
going to support user defined functions whose properties can
vary as how users define them. So we need to move any property
that's relevant to UDF to overload level. Currently, `NullableArgs`
is the only one matters.

Release note: None.